### PR TITLE
Fix update slow tests GHA workflow by using legit username/email

### DIFF
--- a/.github/workflows/update_slow_tests.yml
+++ b/.github/workflows/update_slow_tests.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  update-slow-list:
+  update-slow-stats:
     runs-on: ubuntu-18.04
     steps:
       - name: Setup Python
@@ -40,6 +40,7 @@ jobs:
           source_file: '.pytorch-slow-tests'
           destination_repo: 'pytorch/test-infra'
           destination_folder: 'stats'
+          destination_branch: master
           user_email: 'test-infra@pytorch.org'
           user_name: 'PyTorch Test Infra'
           commit_message: 'Updating slow tests stats'


### PR DESCRIPTION
Would resolve a broken run such as: https://github.com/pytorch/test-infra/actions/runs/720431754

Bigger question: is there a team email/team git user we could use?