### PR TITLE
Drop GHA jobs unless workflow name is found

### DIFF
--- a/fbossci-aws-lambas/us-east-1/github-status-webhook-handler/lambda_function.py
+++ b/fbossci-aws-lambas/us-east-1/github-status-webhook-handler/lambda_function.py
@@ -96,7 +96,7 @@ def lambda_handler(event, context):
         if workflow_name:
             job_name = f'{workflow_name} / {body["check_run"]["name"]}'
         else:
-            job_name = body["check_run"]["name"]
+            return
         status = body["check_run"]["conclusion"]
         committer = body["sender"]["login"]
         # For some reason actions aren't facebook-github-bot..


### PR DESCRIPTION
Currently, [the HUD](https://ezyang.github.io/pytorch-ci-hud/build2/pytorch-master) has a bunch of columns (whose names are those of GHA jobs without their workflow names) that are empty except for a bunch of yellow question marks:

<img width="804" alt="Screen Shot 2021-05-05 at 9 38 14 AM" src="https://user-images.githubusercontent.com/8246041/117177304-b8589200-ad85-11eb-87a1-c60b94b9d1d5.png">

It looks like this is caused because the lambda somehow fails to get the workflow name for some jobs that have not yet finished (although not for all such jobs, since there are still some question marks in the correct columns). This PR disables pushing to S3 when the workflow name can't be found, to get rid of those near-empty columns.