### PR TITLE
Add docker base push job

### DIFF
--- a/.github/workflows/push_ci_docker_base.yml
+++ b/.github/workflows/push_ci_docker_base.yml
@@ -1,0 +1,24 @@
+name: Push CI Docker Base
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'ci-docker-base/**'
+      - '.github/workflows/push_ci_docker_base.yml'
+
+jobs:
+  cilint-clang-tidy:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Push
+        run: |
+          set -ex
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+          cd ci-docker-base
+          docker build . --tag ghcr.io/pytorch/cilint-clang-tidy:$GITHUB_SHA -f Dockerfile.cilint-clang-tidy
+          docker push ghcr.io/pytorch/cilint-clang-tidy:$GITHUB_SHA
+

--- a/ci-docker-base/Dockerfile.cilint-clang-tidy
+++ b/ci-docker-base/Dockerfile.cilint-clang-tidy
@@ -1,0 +1,12 @@
+# ubuntu18.04-cuda10.2-py3.6-tidy11
+FROM nvidia/cuda:10.2-devel-ubuntu18.04
+
+RUN apt-get update && apt-get upgrade -y
+RUN apt install -y software-properties-common wget
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main"
+RUN apt-add-repository ppa:git-core/ppa
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git python3-dev python3-pip build-essential cmake clang-tidy-11 time
+RUN update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-11 1000
+RUN pip3 install pyyaml typing_extensions dataclasses


### PR DESCRIPTION
Add a ci-clang-tidy base docker image to speed up the CI Lint. This shortens 8mins to 4mins.

Previous docker build with PR `GITHUB_TOKEN` permission failed at the last step of pushing the image to github container registry, will verify if it works when merged into master

https://github.com/pytorch/test-infra/runs/2671207595?check_suite_focus=true

By default, the permissive action's default `GITHUB_TOKEN` should be able to write to the github container registry from `master` branch.

https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token