### PR TITLE
Add lambda to store GitHub Actions status

### DIFF
--- a/.github/workflows/deploy_checks_lambda.yml
+++ b/.github/workflows/deploy_checks_lambda.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cd fbossci-aws-lambas/us-east-1/checks-cron
+          make deployment.zip
       - name: Deploy
         uses: appleboy/lambda-action@1e05c1377056f21ebb2ce69b910bc16b943c2a66
         with:
@@ -21,4 +25,5 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-1
           function_name: checks-cron
-          source: fbossci-aws-lambas/us-east-1/checks-cron/lambda_function.py
+          timeout: 15
+          zip_file: fbossci-aws-lambas/us-east-1/checks-cron/deployment.zip

--- a/.github/workflows/deploy_checks_lambda.yml
+++ b/.github/workflows/deploy_checks_lambda.yml
@@ -1,0 +1,24 @@
+name: Deploy Checks Updater Lambda
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/deploy_lambda.yml'
+      - 'fbossci-aws-lambas/us-east-1/checks-cron/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Deploy
+        uses: appleboy/lambda-action@1e05c1377056f21ebb2ce69b910bc16b943c2a66
+        with:
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: us-east-1
+          function_name: checks-cron
+          source: fbossci-aws-lambas/us-east-1/checks-cron/lambda_function.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .vscode
+
+*.env
+*.txt
+*.zip

--- a/fbossci-aws-lambas/us-east-1/checks-cron/Makefile
+++ b/fbossci-aws-lambas/us-east-1/checks-cron/Makefile
@@ -3,7 +3,7 @@ deployment.zip:
 	cd python && zip -r ../deployment.zip .
 	zip -g deployment.zip lambda_function.py
 
-update: deployment.zip
+manual_update: deployment.zip
 	aws lambda update-function-code --function-name github-checks-status-updater --zip-file fileb://deployment.zip
 
 clean:

--- a/fbossci-aws-lambas/us-east-1/checks-cron/Makefile
+++ b/fbossci-aws-lambas/us-east-1/checks-cron/Makefile
@@ -1,0 +1,10 @@
+deployment.zip:
+	pip install --target ./python -r requirements.txt
+	cd python && zip -r ../deployment.zip .
+	zip -g deployment.zip lambda_function.py
+
+update: deployment.zip
+	aws lambda update-function-code --function-name github-checks-status-updater --zip-file fileb://deployment.zip
+
+clean:
+	rm -rf deployment.zip python

--- a/fbossci-aws-lambas/us-east-1/checks-cron/lambda_function.py
+++ b/fbossci-aws-lambas/us-east-1/checks-cron/lambda_function.py
@@ -1,0 +1,140 @@
+"""
+This pings repos/pytorch/pytorch/actions/runs and gathers the most recent jobs
+until it sees that everything is complete. It then stores the current count of
+all types of jobs ('in_progress' and 'queued' are the relevant parts).
+"""
+import aiohttp
+import asyncio
+import datetime
+import json
+import os
+import collections
+import aiobotocore
+import collections
+import json
+
+
+config = {"quiet": False, "github_oauth": os.environ["gh_pat"]}
+
+
+async def github(method, path, payload=None, note="", **kwargs):
+    if payload is None:
+        payload = {}
+    headers = {
+        "Content-Type": "application/json",
+        "Host": "api.github.com",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US,en;q=0.9",
+    }
+    if config["github_oauth"] is not None:
+        headers["Authorization"] = "token " + config["github_oauth"]
+    url = "https://api.github.com/" + path
+    print(method, url, f"({note})")
+    async with aiohttp.ClientSession() as session:
+        r = await session.get(url, headers=headers, **kwargs)
+        return await r.json()
+
+
+async def fetch_workflow_page(num):
+    return await github(
+        "get",
+        "repos/pytorch/pytorch/actions/runs",
+        params={"per_page": 100, "page": num},
+    )
+
+
+def page_in_progress(new_statuses):
+    return "queued" in new_statuses or "in_progress" in new_statuses
+
+
+async def get_page_batch(start: int, batch_size: int):
+    coros = []
+    for i in range(start, start + batch_size):
+        coros.append(
+            github(
+                "get",
+                "repos/pytorch/pytorch/actions/runs",
+                params={"per_page": 100, "page": i},
+                note=f"fetching page {i}",
+            )
+        )
+
+    return await asyncio.gather(*coros)
+
+
+def should_check_github(stats):
+    if len(stats) == 0:
+        return True
+
+    delta = datetime.datetime.now() - datetime.datetime.fromtimestamp(stats[-1]["last_updated"])
+    return delta > datetime.timedelta(minutes=5)
+
+
+
+async def get_gha_statuses(max_pages=30, batch_size=10):
+    all_statuses = collections.defaultdict(lambda: 0)
+
+    max_pages_past = 10
+    pages_past = max_pages_past
+
+    i = 1
+    should_quit = False
+    while not should_quit and i < max_pages:
+        batch = await get_page_batch(i, batch_size)
+        i += batch_size
+        for page in batch:
+            new_statuses = collections.defaultdict(lambda: 0)
+            for run in page["workflow_runs"]:
+                all_statuses[run["status"]] += 1
+                new_statuses[run["status"]] += 1
+
+            if not page_in_progress(new_statuses):
+                pages_past -= 1
+            else:
+                pages_past = max_pages_past
+
+            if pages_past == 0:
+                should_quit = True
+            print(new_statuses)
+
+    return {"last_updated": datetime.datetime.now().timestamp(), **all_statuses}
+
+
+MAX_LEN = 1000
+
+async def main():
+    bucket_name = "ossci-checks-status"
+    session = aiobotocore.get_session()
+    async with session.create_client(
+        "s3",
+        region_name="us-east-1",
+        aws_secret_access_key=os.environ["aws_secret"],
+        aws_access_key_id=os.environ["aws_key"],
+    ) as client:
+        content = await client.get_object(
+            Bucket=bucket_name, Key="status.json"
+        )
+        content = await content["Body"].read()
+        all_stats = json.loads(content.decode())
+
+        if not should_check_github(all_stats):
+            print("Ran too early, not doing anything")
+            return
+
+        if len(all_stats) >= MAX_LEN:
+            # Chop off old data
+            all_stats = all_stats[:MAX_LEN]
+
+        all_stats.insert(0, await get_gha_statuses())
+        print("writing", all_stats)
+        await client.put_object(
+            Bucket=bucket_name, Key="status.json", Body=json.dumps(all_stats)
+        )
+
+
+def lambda_handler(event, context):
+    print("handling lambda")
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())
+    return {"statusCode": 200, "body": "update processed"}

--- a/fbossci-aws-lambas/us-east-1/checks-cron/lambda_function.py
+++ b/fbossci-aws-lambas/us-east-1/checks-cron/lambda_function.py
@@ -67,7 +67,7 @@ def should_check_github(stats):
     if len(stats) == 0:
         return True
 
-    delta = datetime.datetime.now() - datetime.datetime.fromtimestamp(stats[-1]["last_updated"])
+    delta = datetime.datetime.now() - datetime.datetime.fromtimestamp(stats[0]["last_updated"])
     return delta > datetime.timedelta(minutes=5)
 
 
@@ -75,6 +75,13 @@ def should_check_github(stats):
 async def get_gha_statuses(max_pages=30, batch_size=10):
     all_statuses = collections.defaultdict(lambda: 0)
 
+    # There's no way to get all the unfinished jobs from the GitHub Actions API,
+    # here this assumes that it returns the most recent data first (and it's all
+    # paginated via the API), the heuristic here is that once the lambda has
+    # seen a certain number of completed jobs with no pending/queued/in progress
+    # jobs in between, it's probably safe to assume we've seen all the
+    # unfinished jobs. The stuff here is just making sure it checks a certain
+    # number of completed jobs before moving on (page size * max_pages_past)
     max_pages_past = 10
     pages_past = max_pages_past
 

--- a/fbossci-aws-lambas/us-east-1/checks-cron/lambda_function.py
+++ b/fbossci-aws-lambas/us-east-1/checks-cron/lambda_function.py
@@ -122,9 +122,8 @@ async def main():
             print("Ran too early, not doing anything")
             return
 
-        if len(all_stats) >= MAX_LEN:
-            # Chop off old data
-            all_stats = all_stats[:MAX_LEN]
+        # Chop off old data
+        all_stats = all_stats[:MAX_LEN]
 
         all_stats.insert(0, await get_gha_statuses())
         print("writing", all_stats)

--- a/fbossci-aws-lambas/us-east-1/checks-cron/lambda_function.py
+++ b/fbossci-aws-lambas/us-east-1/checks-cron/lambda_function.py
@@ -135,6 +135,5 @@ async def main():
 
 def lambda_handler(event, context):
     print("handling lambda")
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())
     return {"statusCode": 200, "body": "update processed"}

--- a/fbossci-aws-lambas/us-east-1/checks-cron/requirements.txt
+++ b/fbossci-aws-lambas/us-east-1/checks-cron/requirements.txt
@@ -1,0 +1,10 @@
+# To install the lambda layers:
+#
+# pip install --target ./python -r requirements.txt
+# zip -r layer.zip ./python
+#
+# Then upload the layer via aws console or aws cli
+# Update the lambda's layer reference to the newly uploaded layer
+
+aioboto3
+aiohttp


### PR DESCRIPTION
This lambda is intended to be run on a CloudWatch event that fires every few minutes or so, the lambda itself handles debouncing so it does not write data sooner than 5 minutes from the previous entry. It will append to a single `status.json` file the latest results from GitHub's workflows API. It crawls through pages of results from GitHub until it sees that all the jobs on that page are `completed` and records the counts of each into `status.json`.
