### PR TITLE
Update Dockerfile to use custom clang-tidy build

### DIFF
--- a/ci-docker-base/Dockerfile.cilint-clang-tidy
+++ b/ci-docker-base/Dockerfile.cilint-clang-tidy
@@ -1,12 +1,21 @@
 # ubuntu18.04-cuda10.2-py3.6-tidy11
 FROM nvidia/cuda:10.2-devel-ubuntu18.04
 
-RUN apt-get update && apt-get upgrade -y
-RUN apt install -y software-properties-common wget
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main"
-RUN apt-add-repository ppa:git-core/ppa
+# Copy diffs
+COPY ./clang-tidy-checks clang-tidy-checks
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git python3-dev python3-pip build-essential cmake clang-tidy-11 time
-RUN update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-11 1000
+# Install dependencies
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+    git python3-dev python3-pip build-essential time \
+    cmake clang lld ninja-build
+
+# Run setup script (See ./clang-tidy-checks/README.md for more details)
+RUN cd ./clang-tidy-checks && ./setup.sh
+
+# Link clang-tidy to custom build
+RUN ln -s $(pwd)/clang-tidy-checks/llvm-project/build/bin/clang-tidy /bin/clang-tidy
+
+# Install python deps
 RUN pip3 install pyyaml typing_extensions dataclasses


### PR DESCRIPTION
Summary:
This PR updates the Dockerfile to use our custom build of clang-tidy