### PR TITLE
Add auth.pytorch.org setup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 *.swp
 
 **/.DS_Store
+*.pem
+*.tfstate
+*.tfstate.*
+.terraform/

--- a/auth.pytorch.org/README.md
+++ b/auth.pytorch.org/README.md
@@ -1,0 +1,19 @@
+The capabilities of what we can show for PRs on GitHub is very limited. Solutions have been posed in the past with Dr. CI, first as a separate page then as a GitHub comment. I’ve also developed some Chrome extensions to fill gaps in DevX but these haven’t had wide adoption since they’re hard to discover and require installation. Similar to [prow.k8s.io](http://prow.k8s.io/), we should have our own landing page for displaying anything and everything a PR developer needs.
+
+GitHub’s API has a very low IP-based rate limit for unauthenticated requests, so we need some kind of GitHub sign in for this to work. Unfortunately GitHub does not host this themselves for you, so we need to stand up [an OAuth proxy server](https://github.com/prose/gatekeeper) to handle generating tokens while keeping our client secret a secret.
+
+To deploy the server:
+
+1. Provision an EC2 instance with Terraform
+
+    ```bash
+    terraform apply -var="key_name=<the key name>" -var="name=auth.pytorch.org"
+    ```
+
+2. Set up a file called `vars.yml` to contain a file path to: a SSL key, a SSL cert, the OAuth client ID, and the OAuth client secret.
+
+3. Run the Ansible playbook to set up the server
+
+    ```bash
+    ansible-playbook -i ubuntu@<the instance name>, install.yml --extra-vars=@vars.yml --private-key=~/<the aws private key from step 1>
+    ```

--- a/auth.pytorch.org/files/docker-compose.yml
+++ b/auth.pytorch.org/files/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.7'
+
+services:
+  gatekeeper:
+    image: gatekeeper:local
+    ports:
+      - "9999:9999"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "10"
+    networks:
+      - gatekeeper
+
+  nginx:
+    image: nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "10"
+    networks:
+      - gatekeeper
+    volumes:
+        - "/etc/pytorch/http.conf:/etc/nginx/conf.d/default.conf"
+        - "/etc/pytorch/fullchain.pem:/etc/nginx/fullchain.pem"
+        - "/etc/pytorch/privkey.pem:/etc/nginx/privkey.pem"
+
+networks:
+  gatekeeper:
+    external: true

--- a/auth.pytorch.org/files/http.conf
+++ b/auth.pytorch.org/files/http.conf
@@ -1,0 +1,44 @@
+server {
+    listen [::]:80 ipv6only=off;
+    server_name /;
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen [::]:443 ipv6only=off ssl;
+    ssl_certificate /etc/nginx/fullchain.pem;
+    ssl_certificate_key /etc/nginx/privkey.pem;
+
+    client_max_body_size 500M;
+    
+    set $upstream_gatekeeper http://gatekeeper:9999;
+
+    location / {
+        resolver 127.0.0.11 valid=30s ipv6=off;
+        proxy_pass	$upstream_gatekeeper;
+        proxy_set_header    Host                $host:$server_port;
+        proxy_set_header    X-Real-IP           $remote_addr;
+        proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+        proxy_set_header    X-Forwarded-Host    $host;
+        proxy_set_header    X-Forwarded-Port    $server_port;
+        proxy_set_header    X-Forwarded-Server  $host:$server_port;
+        proxy_set_header    X-Forwarded-Proto   $scheme;
+
+        proxy_max_temp_file_size 0;
+
+        client_max_body_size       100m;
+        client_body_buffer_size    128k;
+
+        proxy_connect_timeout      90;
+        proxy_send_timeout         90;
+        proxy_read_timeout         90;
+
+        proxy_buffer_size          4k;
+        proxy_buffers              4 32k;
+        proxy_busy_buffers_size    64k;
+        proxy_temp_file_write_size 64k;
+    }
+}

--- a/auth.pytorch.org/install.yml
+++ b/auth.pytorch.org/install.yml
@@ -1,0 +1,54 @@
+---
+
+- name: Setup Docker
+  hosts: all
+  become: true
+  become_user: root
+  become_method: sudo
+  gather_facts: false
+  tasks:
+    - name: Setup
+      shell: |
+        apt update
+        apt install -y docker.io
+        docker swarm init || echo done
+        docker stack rm gatekeeper || echo done
+        docker network create --driver overlay --attachable gatekeeper || echo done
+
+        mkdir -p /etc/pytorch/
+    - name: Copy files
+      template:
+        src: "{{ item }}"
+        dest: "/etc/pytorch/"
+      with_fileglob:
+        - files/*
+    - name: Copy files
+      template:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+      with_items:
+        - { src: "{{ ssl_filenames.key }}", dest: "/etc/pytorch/privkey.pem" }
+        - { src: "{{ ssl_filenames.cert }}", dest: "/etc/pytorch/fullchain.pem" }
+    - name: Build gatekeeper image
+      shell: |
+        git clone https://github.com/prose/gatekeeper.git
+        cd gatekeeper
+        git checkout 7703f8c2ee7df67362f6eb114a512acc06a64744
+
+        echo '
+          {
+            "oauth_client_id": "{{ oauth.client_id }}",
+            "oauth_client_secret": "{{ oauth.secret }}",
+            "oauth_host": "github.com",
+            "oauth_port": 443,
+            "oauth_path": "/login/oauth/access_token",
+            "oauth_method": "POST",
+            "port": 9999
+          }
+        ' > config.json
+
+        docker build -t gatekeeper:local .
+    - name: Run compose
+      shell: |
+        docker stack rm gatekeeper || echo done
+        docker stack deploy -c /etc/pytorch/docker-compose.yml gatekeeper

--- a/auth.pytorch.org/provision.tf
+++ b/auth.pytorch.org/provision.tf
@@ -1,0 +1,89 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+variable "key_name" {
+  type = string
+}
+
+variable "ami" {
+  type = string
+  default = "ami-09e67e426f25ce0d7"
+}
+
+variable "type" {
+  type = string
+  default = "t2.micro"
+}
+
+variable "name" {
+  type = string
+}
+
+variable "size" {
+  type = number
+  default = 20
+}
+
+variable "num" {
+  type = number
+  default = 1
+}
+
+resource "aws_security_group" "ec2_security_group" {
+  name = "${var.name}_ports"
+  egress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "ec2_instances" {
+  count = var.num
+  ami = var.ami
+  instance_type = var.type
+  vpc_security_group_ids = [aws_security_group.ec2_security_group.id]
+  key_name = var.key_name
+
+  tags = {
+    Name = "${var.name}-${count.index}"
+  }
+
+  root_block_device {
+    volume_size = var.size
+  }
+}
+
+output "cluster_names" {
+  value = ["${aws_instance.ec2_instances.*.tags.Name}"]
+}
+
+output "cluster_dns" {
+  value = ["${aws_instance.ec2_instances.*.public_dns}"]
+}


### PR DESCRIPTION
See the README for details. This adds a simple server to proxy OAuth tokens for hud.pytorch.org. The setup flow is:

1. terraform creates instance
2. ansible installs docker, builds gatekeeper image, runs it

It's already up at [auth.pytorch.org](https://auth.pytorch.org)