### PR TITLE
Remove llvm-project after build

### DIFF
--- a/ci-docker-base/Dockerfile.cilint-clang-tidy
+++ b/ci-docker-base/Dockerfile.cilint-clang-tidy
@@ -14,9 +14,6 @@ RUN apt-get update && \
 # Run setup script (See ./clang-tidy-checks/README.md for more details)
 RUN cd ./clang-tidy-checks && ./setup.sh
 
-# Link clang-tidy to custom build
-RUN ln -s $(pwd)/clang-tidy-checks/llvm-project/build/bin/clang-tidy /bin/clang-tidy
-
 # Verify that clang-tidy has custom checks
 RUN cd ./clang-tidy-checks && ./verify.sh
 

--- a/clang-tidy-checks/setup.sh
+++ b/clang-tidy-checks/setup.sh
@@ -53,6 +53,9 @@ function build() {
         -DLLVM_BUILD_UTILS=OFF \
         -GNinja ../llvm
   cmake --build . --target clang-tidy
+  cp bin/clang-tidy /bin
+  cd ../../
+  rm -rf llvm-project
   success
 }
 
@@ -63,7 +66,7 @@ function setup() {
 }
 
 function verify() {
-  [[ -e bin/clang-tidy ]]
+  [[ -e /bin/clang-tidy ]]
 }
 
 check_requirements


### PR DESCRIPTION
Summary:
This PR removes the llvm-project folder right after building the clang-tidy binary. This reduces the size of the final docker image to about 4G, which can easily fit on a GHA runner (max 16G).