### PR TITLE
Remove llvm-project dir after build is complete

### DIFF
--- a/ci-docker-base/Dockerfile.cilint-clang-tidy
+++ b/ci-docker-base/Dockerfile.cilint-clang-tidy
@@ -15,7 +15,7 @@ RUN apt-get update && \
 RUN cd ./clang-tidy-checks && ./setup.sh
 
 # Link clang-tidy to custom build
-RUN ln -s $(pwd)/clang-tidy-checks/llvm-project/build/bin/clang-tidy /bin/clang-tidy
+RUN ln -s $(pwd)/clang-tidy-checks/clang-tidy /bin/clang-tidy
 
 # Verify that clang-tidy has custom checks
 RUN cd ./clang-tidy-checks && ./verify.sh

--- a/clang-tidy-checks/setup.sh
+++ b/clang-tidy-checks/setup.sh
@@ -53,6 +53,9 @@ function build() {
         -DLLVM_BUILD_UTILS=OFF \
         -GNinja ../llvm
   cmake --build . --target clang-tidy
+  cd ../../
+  cp llvm-project/build/bin/clang-tidy .
+  rm -rf llvm-project
   success
 }
 
@@ -63,7 +66,7 @@ function setup() {
 }
 
 function verify() {
-  [[ -e bin/clang-tidy ]]
+  [[ -e ./clang-tidy ]]
 }
 
 check_requirements


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #33 Use release build
* #32 [do not merge] trigger ci on pr for testing
* **#31 Remove llvm-project dir after build is complete**

