### PR TITLE
Install higher git version on docker image

### DIFF
--- a/ci-docker-base/Dockerfile.cilint-clang-tidy
+++ b/ci-docker-base/Dockerfile.cilint-clang-tidy
@@ -8,7 +8,6 @@ COPY ./clang-tidy-checks clang-tidy-checks
 RUN apt-get update && apt-get upgrade -y && apt-get install -y software-properties-common
 RUN apt-add-repository ppa:git-core/ppa
 RUN apt-get update && \
-    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
     git python3-dev python3-pip build-essential time wget \
     cmake clang lld ninja-build

--- a/ci-docker-base/Dockerfile.cilint-clang-tidy
+++ b/ci-docker-base/Dockerfile.cilint-clang-tidy
@@ -5,10 +5,12 @@ FROM nvidia/cuda:10.2-devel-ubuntu18.04
 COPY ./clang-tidy-checks clang-tidy-checks
 
 # Install dependencies
+RUN apt-get update && apt-get upgrade -y && apt-get install -y software-properties-common
+RUN apt-add-repository ppa:git-core/ppa
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-    git python3-dev python3-pip build-essential time \
+    git python3-dev python3-pip build-essential time wget \
     cmake clang lld ninja-build
 
 # Run setup script (See ./clang-tidy-checks/README.md for more details)


### PR DESCRIPTION
GHA requires git version >= 2.18 to clone correctly.

This PR attempts to fix the following lint failure (https://github.com/pytorch/pytorch/runs/2822676682?check_suite_focus=true)