### PR TITLE
Link clang-tidy so that it has access to missing system headers

### DIFF
--- a/ci-docker-base/Dockerfile.cilint-clang-tidy
+++ b/ci-docker-base/Dockerfile.cilint-clang-tidy
@@ -16,11 +16,11 @@ RUN apt-get update && \
 # Build clang-tidy, copy out the binary, and remove the llvm checkout
 RUN cd ./clang-tidy-checks && \
     ./setup.sh && \
-    cp llvm-project/build/bin/clang-tidy . && \
+    cp -r llvm-project/build . && \
     rm -rf llvm-project
 
 # Link clang-tidy to custom build
-RUN ln -s $(pwd)/clang-tidy-checks/clang-tidy /bin/clang-tidy
+RUN ln -s $(pwd)/clang-tidy-checks/build/bin/clang-tidy /usr/bin/clang-tidy
 
 # Verify that clang-tidy has custom checks
 RUN cd ./clang-tidy-checks && ./verify.sh

--- a/clang-tidy-checks/verify.sh
+++ b/clang-tidy-checks/verify.sh
@@ -3,7 +3,7 @@
 set -xe
 
 checks=$(ls *.diff)
-found_checks=$(/bin/clang-tidy -checks=* --list-checks)
+found_checks=$(clang-tidy -checks=* --list-checks)
 for check in $checks; do
   name=${check%-check.*}
   echo $name


### PR DESCRIPTION
This change will link the clang-tidy binary in a way that it correctly access system headers.

Relevant links:
https://clang.llvm.org/docs/LibTooling.html#builtin-includes - Where clang tooling expects the headers to be at