### PR TITLE
Install omp in clang-tidy docker image

### DIFF
--- a/ci-docker-base/Dockerfile.cilint-clang-tidy
+++ b/ci-docker-base/Dockerfile.cilint-clang-tidy
@@ -10,7 +10,7 @@ RUN apt-add-repository ppa:git-core/ppa
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     git python3-dev python3-pip python3-setuptools python3-wheel build-essential time wget \
-    cmake clang lld ninja-build
+    cmake clang lld ninja-build libomp-11-dev
 
 # Run setup script (See ./clang-tidy-checks/README.md for more details)
 # Build clang-tidy, copy out the binary, and remove the llvm checkout


### PR DESCRIPTION
PyTorch's distributed library imports `omp.h` a bunch so we need that header around for clang-tidy. `libomp-dev` provides it, so this adds that to the `apt install` of the Docker image. Once we merge this and land https://github.com/pytorch/pytorch/pull/60225, we can update the image tag in `lint.yml` and re-enable clang-tidy on master since all the errors we saw should be addressed.

Tested by running the clang command in the Docker image, seeing a failure, installing `libomp-dev`, running again and seeing no failure.

```bash
docker run -it test /bin/bash

clang-tidy -p build -config '{"InheritParentConfig": true, "Checks": " bugprone-*, -bugprone-forward-declaration-namespace, -bugprone-macro-parentheses, -bugprone-lambda-function-name, -bugprone-reserved-identifier, cppcoreguidelines-*, -cppcoreguidelines-avoid-magic-numbers, -cppcoreguidelines-interfaces-global-init, -cppcoreguidelines-macro-usage, -cppcoreguidelines-owning-memory, -cppcoreguidelines-pro-bounds-array-to-pointer-decay, -cppcoreguidelines-pro-bounds-constant-array-index, -cppcoreguidelines-pro-bounds-pointer-arithmetic, -cppcoreguidelines-pro-type-cstyle-cast, -cppcoreguidelines-pro-type-reinterpret-cast, -cppcoreguidelines-pro-type-static-cast-downcast, -cppcoreguidelines-pro-type-union-access, -cppcoreguidelines-pro-type-vararg, -cppcoreguidelines-special-member-functions, -facebook-hte-RelativeInclude, hicpp-exception-baseclass, hicpp-avoid-goto, modernize-*, -modernize-concat-nested-namespaces, -modernize-return-braced-init-list, -modernize-use-auto, -modernize-use-default-member-init, -modernize-use-using, -modernize-use-trailing-return-type, performance-*, -performance-noexcept-move-constructor, -performance-unnecessary-value-param, ", "HeaderFilterRegex": "torch/csrc/.*", "AnalyzeTemporaryDtors": false, "CheckOptions": null}' -line-filter '[{"name": "torch/csrc/distributed/rpc/testing/faulty_process_group_agent.cpp", "lines": [["1", "1"]]}, {"name": "torch/csrc/distributed/rpc/testing/faulty_process_group_agent.h", "lines": [["39", "39"]]}, {"name": "torch/csrc/distributed/rpc/testing/init.cpp", "lines": [["1", "1"]]}]' torch/csrc/distributed/rpc/testing/faulty_process_group_agent.cpp torch/csrc/distributed/rpc/testing/init.cpp

apt install -y libomp-dev

clang-tidy -p build -config '{"InheritParentConfig": true, "Checks": " bugprone-*, -bugprone-forward-declaration-namespace, -bugprone-macro-parentheses, -bugprone-lambda-function-name, -bugprone-reserved-identifier, cppcoreguidelines-*, -cppcoreguidelines-avoid-magic-numbers, -cppcoreguidelines-interfaces-global-init, -cppcoreguidelines-macro-usage, -cppcoreguidelines-owning-memory, -cppcoreguidelines-pro-bounds-array-to-pointer-decay, -cppcoreguidelines-pro-bounds-constant-array-index, -cppcoreguidelines-pro-bounds-pointer-arithmetic, -cppcoreguidelines-pro-type-cstyle-cast, -cppcoreguidelines-pro-type-reinterpret-cast, -cppcoreguidelines-pro-type-static-cast-downcast, -cppcoreguidelines-pro-type-union-access, -cppcoreguidelines-pro-type-vararg, -cppcoreguidelines-special-member-functions, -facebook-hte-RelativeInclude, hicpp-exception-baseclass, hicpp-avoid-goto, modernize-*, -modernize-concat-nested-namespaces, -modernize-return-braced-init-list, -modernize-use-auto, -modernize-use-default-member-init, -modernize-use-using, -modernize-use-trailing-return-type, performance-*, -performance-noexcept-move-constructor, -performance-unnecessary-value-param, ", "HeaderFilterRegex": "torch/csrc/.*", "AnalyzeTemporaryDtors": false, "CheckOptions": null}' -line-filter '[{"name": "torch/csrc/distributed/rpc/testing/faulty_process_group_agent.cpp", "lines": [["1", "1"]]}, {"name": "torch/csrc/distributed/rpc/testing/faulty_process_group_agent.h", "lines": [["39", "39"]]}, {"name": "torch/csrc/distributed/rpc/testing/init.cpp", "lines": [["1", "1"]]}]' torch/csrc/distributed/rpc/testing/faulty_process_group_agent.cpp torch/csrc/distributed/rpc/testing/init.cpp
```
