### PR TITLE
Add unidiff to clang-tidy Dockerfile

### DIFF
--- a/ci-docker-base/Dockerfile.cilint-clang-tidy
+++ b/ci-docker-base/Dockerfile.cilint-clang-tidy
@@ -27,4 +27,4 @@ RUN cd ./clang-tidy-checks && ./verify.sh
 
 # Install python deps
 RUN wget https://raw.githubusercontent.com/pytorch/pytorch/master/requirements.txt && \
-    pip3 install -r requirements.txt
+    pip3 install -r requirements.txt && pip3 install unidiff==0.6.0


### PR DESCRIPTION
See https://github.com/pytorch/pytorch/pull/60297

This one has to land and build on master before that PR can be tested + landed