### PR TITLE
Bump docker base image

### DIFF
--- a/ci-docker-base/Dockerfile.cilint-clang-tidy
+++ b/ci-docker-base/Dockerfile.cilint-clang-tidy
@@ -1,5 +1,7 @@
-# ubuntu18.04-cuda10.2-py3.6-tidy11
-FROM nvidia/cuda:10.2-devel-ubuntu18.04
+# ubuntu20.04-cuda11.2-py3.8-tidy11
+FROM nvidia/cuda:11.2.0-devel-ubuntu20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Copy diffs
 COPY ./clang-tidy-checks clang-tidy-checks


### PR DESCRIPTION
This PR bumps the base image of the clang-tidy Dockerfile to use `cuda-11.2` and `ubuntu-20.04`. The advantage is that we'll have python 3.8 by default.

This fixes #45

One consequence of the update is that `libomp-dev` doesn't install its headers at `/usr/include`. It instead does it at `/usr/lib/llvm-11/include/openmp`. We will need to update the job in clang-tidy to include this path (which can now be done easily with the [`-I` option](https://github.com/pytorch/pytorch/pull/60745))