### PR TITLE
Statically link clang-tidy binary

### DIFF
--- a/clang-tidy-checks/setup.sh
+++ b/clang-tidy-checks/setup.sh
@@ -44,7 +44,10 @@ function build() {
   cmake -DCMAKE_C_COMPILER=clang \
         -DCMAKE_CXX_COMPILER=clang++ \
         -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_EXE_LINKER_FLAGS="-static" \
         -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra" \
+        -DLLVM_ENABLE_LIBCXX=ON \
+        -DLLVM_STATIC_LINK_CXX_STDLIB=ON \
         -DLLVM_USE_LINKER=lld \
         -DLLVM_TARGETS_TO_BUILD="X86" \
         -DCLANG_ENABLE_STATIC_ANALYZER=OFF \

--- a/clang-tidy-checks/setup.sh
+++ b/clang-tidy-checks/setup.sh
@@ -66,7 +66,8 @@ function setup() {
 }
 
 function verify() {
-  [[ -e ./bin/clang-tidy ]]
+  [[ -e ./bin/clang-tidy ]] &&
+  ldd ./bin/clang-tidy | grep -q "not a dynamic executable"
 }
 
 check_requirements


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #49 [test][do not merge] Test publishing clang-tidy binaries to s3 bucket
* #48 Modify job to publish clang-tidy binaries on S3
* **#47 Statically link clang-tidy binary**

This PR creates a statically linked `clang-tidy` binary. This will allow us to avoid having to worry about missing shared libraries when users download it.

Test Plan:

1. Build the docker image
```bash
docker build . --tag clang-tidy-static --file ./ci-docker-base/Dockerfile.cilint-clang-tidy
```
2. Copy the binary out of the image
```bash
image_id=$(docker create clang-tidy-static)
docker cp $image_id:/clang-tidy-checks/build/bin/clang-tidy ./clang-tidy
docker rm -v $image_id
```
3. Check if its a dynamic executable
```bash
ldd ./clang-tidy
```

Expected Output:
```
not a dynamic executable
```

Binary size stats (measured on AWS GPU cluster jumphost):
- before static linking: 5.5M
- after static linking: 39M