### PR TITLE
[test][do not merge] Test publishing clang-tidy binaries to s3 bucket

### DIFF
--- a/.github/workflows/push_ci_docker_base.yml
+++ b/.github/workflows/push_ci_docker_base.yml
@@ -1,6 +1,7 @@
 name: Push CI Docker Base
 
 on:
+  pull_request:
   push:
     branches:
       - master


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49 [test][do not merge] Test publishing clang-tidy binaries to s3 bucket**
* #48 Modify job to publish clang-tidy binaries on S3
* #47 Statically link clang-tidy binary

