### PR TITLE
Pin clang version to 11

### DIFF
--- a/ci-docker-base/Dockerfile.cilint-clang-tidy
+++ b/ci-docker-base/Dockerfile.cilint-clang-tidy
@@ -7,12 +7,16 @@ ENV DEBIAN_FRONTEND=noninteractive
 COPY ./clang-tidy-checks clang-tidy-checks
 
 # Install dependencies
-RUN apt-get update && apt-get upgrade -y && apt-get install -y software-properties-common
+RUN apt-get update && apt-get upgrade -y && apt-get install -y software-properties-common wget
 RUN apt-add-repository ppa:git-core/ppa
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main"
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    git python3-dev python3-pip python3-setuptools python3-wheel build-essential time wget \
-    cmake clang lld ninja-build libomp-dev
+    git python3-dev python3-pip python3-setuptools python3-wheel build-essential time \
+    cmake clang-11 lld ninja-build libomp-11-dev
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-11 1000
+RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-11 1000
 
 # Run setup script (See ./clang-tidy-checks/README.md for more details)
 # Build clang-tidy, copy out the binary, and remove the llvm checkout


### PR DESCRIPTION
This PR pins our clang-tooling to use v11. This will help prevent errors caused by version detection (which in our previous build result in the OpenMP headers not being installed in `/usr/lib/llvm-11`). This should fix the PR failure observed [here](https://github.com/pytorch/pytorch/pull/60976).

Test plan:
1. Build the docker image
```bash
docker build . -t clang-tidy-pinned -f ci-docker-base/Dockerfile.cilint-clang-tidy
```
2. Start an interactive session
```bash
docker run -it clang-tidy-pinned /bin/bash
```
3. Locate `<omp.h>` header files
```bash
find . -name omp.h
```
Expected Output: 
```bash
./usr/lib/llvm-11/lib/clang/11.1.0/include/omp.h
./usr/lib/llvm-11/include/openmp/omp.h
./usr/lib/gcc/x86_64-linux-gnu/9/include/omp.h
```
Observe that `/usr/lib/llvm-11` now exists.