### PR TITLE
Remove label requirement for disabled tests

### DIFF
--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Generate new disabled test list
         run: |
           # score changes every request, so we strip it out to avoid creating a commit every time we query.
-          curl 'https://api.github.com/search/issues?q=is%3Aissue+is%3Aopen+label%3A%22module%3A+flaky-tests%22+repo:pytorch/pytorch+in%3Atitle+DISABLED' \
+          curl 'https://api.github.com/search/issues?q=is%3Aissue+is%3Aopen+repo:pytorch/pytorch+in%3Atitle+DISABLED' \
           | sed 's/"score": [0-9\.]*/"score": 0.0/g' > disabled-tests.json
       - name: Push file to test-infra repository
         uses: dmnemec/copy_file_to_another_repo_action@5f40763ccee2954067adba7fb8326e4df33bcb92


### PR DESCRIPTION
There shouldn't be a label requirement for disabling tests. Currently, some tests aren't successfully disabled because they don't have `module: flaky-test` as a label, e.g., https://github.com/pytorch/pytorch/issues/61201

This will also allow us to disable other tests that aren't necessarily flaky, like for forward fixing in the future.