### PR TITLE
Add better support for building clang-tidy binaries on osx

### DIFF
--- a/clang-tidy-checks/setup.sh
+++ b/clang-tidy-checks/setup.sh
@@ -2,6 +2,16 @@
 
 set -e
 
+function unreachable() {
+  echo "[fatal]: Hit unreachable code!"
+  exit 1
+}
+
+function error() {
+  echo "[error]:" "$1"
+  exit 1
+}
+
 function info() {
   echo "[info]:" "$1"
 }
@@ -12,6 +22,15 @@ function success() {
 
 function check_requirements() {
   info "checking requirements"
+
+  case $(uname) in
+    Linux|Darwin)
+      ;;
+    *)
+      error "Unsupported OS $(uname)"
+      ;;
+  esac
+
   cmake --version
   gcc --version
   python3 --version
@@ -39,22 +58,44 @@ function apply_patches() {
 }
 
 function build() {
+  local cmake_common_args=(
+    -DCMAKE_C_COMPILER=clang
+    -DCMAKE_CXX_COMPILER=clang++
+    -DCMAKE_BUILD_TYPE=Release
+    -DCLANG_ENABLE_STATIC_ANALYZER=OFF
+    -DCLANG_ENABLE_ARCMT=OFF
+    -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"
+    -DLLVM_BUILD_TOOLS=OFF
+    -DLLVM_BUILD_UTILS=OFF
+    -GNinja
+  )
+
+  local cmake_os_args
+
+  case $(uname) in
+    Linux)
+      cmake_os_args=(
+        -DLLVM_USE_LINKER=lld
+        -DLLVM_BUILD_STATIC=ON
+        -DCMAKE_CXX_FLAGS="-static"
+      )
+      ;;
+    Darwin)
+      cmake_os_args=(
+        -DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++"
+        -DCMAKE_OSX_DEPLOYMENT_TARGET="10.15"
+      )
+      ;;
+    *)
+      unreachable
+      ;;
+  esac
+
+
   mkdir build
   cd build
-  cmake -DCMAKE_C_COMPILER=clang \
-        -DCMAKE_CXX_COMPILER=clang++ \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_EXE_LINKER_FLAGS="-static" \
-        -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra" \
-        -DLLVM_ENABLE_LIBCXX=ON \
-        -DLLVM_STATIC_LINK_CXX_STDLIB=ON \
-        -DLLVM_USE_LINKER=lld \
-        -DLLVM_TARGETS_TO_BUILD="X86" \
-        -DCLANG_ENABLE_STATIC_ANALYZER=OFF \
-        -DCLANG_ENABLE_ARCMT=OFF \
-        -DLLVM_BUILD_TOOLS=OFF \
-        -DLLVM_BUILD_UTILS=OFF \
-        -GNinja ../llvm
+
+  cmake "${cmake_common_args[@] cmake_os_args[@]}" ../llvm
   cmake --build . --target clang-tidy
   success
 }
@@ -65,9 +106,27 @@ function setup() {
   build
 }
 
+function check_if_static() {
+  case $(uname) in
+    Linux)
+      ldd ./bin/clang-tidy 2>&1 | grep -q "not a dynamic executable"
+      ;;
+    Darwin)
+      # No static link check for MacOS
+      #
+      # Apple makes it a little hard to build a fully statically linked binary.
+      # It involves performing some hacks that move shared dynamic libraries to
+      # particular directories. This adds a bit of complexity to the build
+      # step. To keep things simple, we ignore this check.
+      ;;
+    *)
+      unreachable
+      ;;
+  esac
+}
+
 function verify() {
-  [[ -e ./bin/clang-tidy ]] &&
-  ldd ./bin/clang-tidy 2>&1 | grep -q "not a dynamic executable"
+  [[ -e ./bin/clang-tidy ]] && check_if_static
 }
 
 check_requirements


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58
* **#57**

This PR adds better support for compiling clang-tidy binaries on MacOS. Notably, the `-static` flag causes `clang` to fail when attempting to build on a Mac. This has been replaced with `-static-libgcc` and `-static-libstdc++`. 

Statically linking binaries on MacOS is [not straightforward](https://developer.apple.com/library/archive/qa/qa1118/_index.html) and Apple makes no guarantees on that front. Therefore, I opt into shipping a dynamically linked executable instead.
