### PR TITLE
Fix clang header conflicts

### DIFF
--- a/ci-docker-base/Dockerfile.cilint-clang-tidy
+++ b/ci-docker-base/Dockerfile.cilint-clang-tidy
@@ -25,8 +25,11 @@ RUN cd ./clang-tidy-checks && \
     cp -r llvm-project/build . && \
     rm -rf llvm-project
 
-# Link clang-tidy to custom build
-RUN ln -s $(pwd)/clang-tidy-checks/build/bin/clang-tidy /usr/bin/clang-tidy
+# Copy binary to /usr/bin
+#
+# We are copying the binary (instead of symlinking it) to avoid header file
+# conflicts between the installed version of clang and our custom build
+RUN cp /clang-tidy-checks/build/bin/clang-tidy /usr/bin/clang-tidy
 
 # Verify that clang-tidy has custom checks
 RUN cd ./clang-tidy-checks && ./verify.sh

--- a/clang-tidy-checks/setup.sh
+++ b/clang-tidy-checks/setup.sh
@@ -2,16 +2,6 @@
 
 set -e
 
-function unreachable() {
-  echo "[fatal]: Hit unreachable code!"
-  exit 1
-}
-
-function error() {
-  echo "[error]:" "$1"
-  exit 1
-}
-
 function info() {
   echo "[info]:" "$1"
 }
@@ -22,15 +12,6 @@ function success() {
 
 function check_requirements() {
   info "checking requirements"
-
-  case $(uname) in
-    Linux|Darwin)
-      ;;
-    *)
-      error "Unsupported OS $(uname)"
-      ;;
-  esac
-
   cmake --version
   gcc --version
   python3 --version
@@ -58,44 +39,22 @@ function apply_patches() {
 }
 
 function build() {
-  local cmake_common_args=(
-    -DCMAKE_C_COMPILER=clang
-    -DCMAKE_CXX_COMPILER=clang++
-    -DCMAKE_BUILD_TYPE=Release
-    -DCLANG_ENABLE_STATIC_ANALYZER=OFF
-    -DCLANG_ENABLE_ARCMT=OFF
-    -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"
-    -DLLVM_BUILD_TOOLS=OFF
-    -DLLVM_BUILD_UTILS=OFF
-    -GNinja
-  )
-
-  local cmake_os_args
-
-  case $(uname) in
-    Linux)
-      cmake_os_args=(
-        -DLLVM_USE_LINKER=lld
-        -DLLVM_BUILD_STATIC=ON
-        -DCMAKE_CXX_FLAGS="-static"
-      )
-      ;;
-    Darwin)
-      cmake_os_args=(
-        -DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++"
-        -DCMAKE_OSX_DEPLOYMENT_TARGET="10.15"
-      )
-      ;;
-    *)
-      unreachable
-      ;;
-  esac
-
-
   mkdir build
   cd build
-
-  cmake "${cmake_common_args[@] cmake_os_args[@]}" ../llvm
+  cmake -DCMAKE_C_COMPILER=clang \
+        -DCMAKE_CXX_COMPILER=clang++ \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_EXE_LINKER_FLAGS="-static" \
+        -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra" \
+        -DLLVM_ENABLE_LIBCXX=ON \
+        -DLLVM_STATIC_LINK_CXX_STDLIB=ON \
+        -DLLVM_USE_LINKER=lld \
+        -DLLVM_TARGETS_TO_BUILD="X86" \
+        -DCLANG_ENABLE_STATIC_ANALYZER=OFF \
+        -DCLANG_ENABLE_ARCMT=OFF \
+        -DLLVM_BUILD_TOOLS=OFF \
+        -DLLVM_BUILD_UTILS=OFF \
+        -GNinja ../llvm
   cmake --build . --target clang-tidy
   success
 }
@@ -106,27 +65,9 @@ function setup() {
   build
 }
 
-function check_if_static() {
-  case $(uname) in
-    Linux)
-      ldd ./bin/clang-tidy 2>&1 | grep -q "not a dynamic executable"
-      ;;
-    Darwin)
-      # No static link check for MacOS
-      #
-      # Apple makes it a little hard to build a fully statically linked binary.
-      # It involves performing some hacks that move shared dynamic libraries to
-      # particular directories. This adds a bit of complexity to the build
-      # step. To keep things simple, we ignore this check.
-      ;;
-    *)
-      unreachable
-      ;;
-  esac
-}
-
 function verify() {
-  [[ -e ./bin/clang-tidy ]] && check_if_static
+  [[ -e ./bin/clang-tidy ]] &&
+  ldd ./bin/clang-tidy 2>&1 | grep -q "not a dynamic executable"
 }
 
 check_requirements

--- a/clang-tidy-checks/setup.sh
+++ b/clang-tidy-checks/setup.sh
@@ -2,6 +2,16 @@
 
 set -e
 
+function unreachable() {
+  echo "[fatal]: Hit unreachable code!"
+  exit 1
+}
+
+function error() {
+  echo "[error]:" "$1"
+  exit 1
+}
+
 function info() {
   echo "[info]:" "$1"
 }
@@ -12,6 +22,15 @@ function success() {
 
 function check_requirements() {
   info "checking requirements"
+
+  case $(uname) in
+    Linux|Darwin)
+      ;;
+    *)
+      error "Unsupported OS $(uname)"
+      ;;
+  esac
+
   cmake --version
   gcc --version
   python3 --version
@@ -39,22 +58,44 @@ function apply_patches() {
 }
 
 function build() {
+  local cmake_common_args=(
+    -DCMAKE_C_COMPILER=clang
+    -DCMAKE_CXX_COMPILER=clang++
+    -DCMAKE_BUILD_TYPE=Release
+    -DCLANG_ENABLE_STATIC_ANALYZER=OFF
+    -DCLANG_ENABLE_ARCMT=OFF
+    -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"
+    -DLLVM_BUILD_TOOLS=OFF
+    -DLLVM_BUILD_UTILS=OFF
+    -GNinja
+  )
+
+  local cmake_os_args
+
+  case $(uname) in
+    Linux)
+      cmake_os_args=(
+        -DLLVM_USE_LINKER=lld
+        -DLLVM_BUILD_STATIC=ON
+        -DCMAKE_CXX_FLAGS="-static"
+      )
+      ;;
+    Darwin)
+      cmake_os_args=(
+        -DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++"
+        -DCMAKE_OSX_DEPLOYMENT_TARGET="10.15"
+      )
+      ;;
+    *)
+      unreachable
+      ;;
+  esac
+
+
   mkdir build
   cd build
-  cmake -DCMAKE_C_COMPILER=clang \
-        -DCMAKE_CXX_COMPILER=clang++ \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_EXE_LINKER_FLAGS="-static" \
-        -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra" \
-        -DLLVM_ENABLE_LIBCXX=ON \
-        -DLLVM_STATIC_LINK_CXX_STDLIB=ON \
-        -DLLVM_USE_LINKER=lld \
-        -DLLVM_TARGETS_TO_BUILD="X86" \
-        -DCLANG_ENABLE_STATIC_ANALYZER=OFF \
-        -DCLANG_ENABLE_ARCMT=OFF \
-        -DLLVM_BUILD_TOOLS=OFF \
-        -DLLVM_BUILD_UTILS=OFF \
-        -GNinja ../llvm
+
+  cmake "${cmake_common_args[@] cmake_os_args[@]}" ../llvm
   cmake --build . --target clang-tidy
   success
 }
@@ -65,9 +106,27 @@ function setup() {
   build
 }
 
+function check_if_static() {
+  case $(uname) in
+    Linux)
+      ldd ./bin/clang-tidy 2>&1 | grep -q "not a dynamic executable"
+      ;;
+    Darwin)
+      # No static link check for MacOS
+      #
+      # Apple makes it a little hard to build a fully statically linked binary.
+      # It involves performing some hacks that move shared dynamic libraries to
+      # particular directories. This adds a bit of complexity to the build
+      # step. To keep things simple, we ignore this check.
+      ;;
+    *)
+      unreachable
+      ;;
+  esac
+}
+
 function verify() {
-  [[ -e ./bin/clang-tidy ]] &&
-  ldd ./bin/clang-tidy 2>&1 | grep -q "not a dynamic executable"
+  [[ -e ./bin/clang-tidy ]] && check_if_static
 }
 
 check_requirements


### PR DESCRIPTION
Summary:

This PR opts in to using v11.1.0 of clang's builtin includes. It does this by copying (instead of symlinking) our custom build clang-tidy binary. As per [this document](https://clang.llvm.org/docs/FAQ.html#id3), clang looks for its builtin includes relative to the location of the binary. By copying it into `/usr/bin`, we ensure that it cannot pick up our custom built headers which are located at `/clang-tidy-checks/build/lib/include/clang/11.0.0/include`. The clang-tidy runner script ensures that it will pick up the v11.1.0 header files.

Test Plan:

1. Build a docker image, and start an interactive session
```bash
docker build . -t ct-no-header-conflicts -f ci-docker-base/Dockerfile.cilint-clang-tidy
docker run -it ct-no-header-conflicts /bin/bash
```

2. Clone pytorch and run clang-tidy on `torch/csrc/autograd/profiler_kineto.cpp`
```bash
git clone --depth 1 https://github.com/pytorch/pytorch
cd pytorch
python3 -m tools.linter.clang_tidy -p torch/csrc/autograd/profiler_kineto.cpp -v
```

You should see no clang-diagnostic-errors, thereby fixing the failed run observed in https://github.com/pytorch/pytorch/pull/61478/checks?check_run_id=3033608896
