### PR TITLE
Add scribe proxy lambda

### DIFF
--- a/.github/workflows/deploy_lambda_checks_cron.yml
+++ b/.github/workflows/deploy_lambda_checks_cron.yml
@@ -1,12 +1,12 @@
-name: Deploy Lambda
+name: deploy_lambda_checks_cron
 
 on:
   push:
     branches:
       - master
     paths:
-      - '.github/workflows/deploy_lambda.yml'
-      - 'fbossci-aws-lambas/us-east-1/github-status-webhook-handler/**'
+      - '.github/workflows/deploy_lambda_checks_cron.yml'
+      - 'fbossci-aws-lambas/us-east-1/checks-cron/**'
 
 jobs:
   deploy:
@@ -14,11 +14,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cd fbossci-aws-lambas/us-east-1/checks-cron
+          make deployment.zip
       - name: Deploy
         uses: appleboy/lambda-action@1e05c1377056f21ebb2ce69b910bc16b943c2a66
         with:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-1
-          function_name: github-status-webhook-handler
-          source: fbossci-aws-lambas/us-east-1/github-status-webhook-handler/lambda_function.py
+          function_name: github-checks-status-updater
+          timeout: 15
+          zip_file: fbossci-aws-lambas/us-east-1/checks-cron/deployment.zip

--- a/.github/workflows/deploy_lambda_github_status_webhook_handler.yml
+++ b/.github/workflows/deploy_lambda_github_status_webhook_handler.yml
@@ -1,12 +1,12 @@
-name: Deploy Checks Updater Lambda
+name: deploy_lambda_github_status_webhook_handler
 
 on:
   push:
     branches:
       - master
     paths:
-      - '.github/workflows/deploy_lambda.yml'
-      - 'fbossci-aws-lambas/us-east-1/checks-cron/**'
+      - '.github/workflows/deploy_lambda_github_status_webhook_handler.yml'
+      - 'fbossci-aws-lambas/us-east-1/github-status-webhook-handler/**'
 
 jobs:
   deploy:
@@ -14,16 +14,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Build
-        run: |
-          cd fbossci-aws-lambas/us-east-1/checks-cron
-          make deployment.zip
       - name: Deploy
         uses: appleboy/lambda-action@1e05c1377056f21ebb2ce69b910bc16b943c2a66
         with:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-1
-          function_name: github-checks-status-updater
-          timeout: 15
-          zip_file: fbossci-aws-lambas/us-east-1/checks-cron/deployment.zip
+          function_name: github-status-webhook-handler
+          source: fbossci-aws-lambas/us-east-1/github-status-webhook-handler/lambda_function.py

--- a/.github/workflows/deploy_lambda_scribe_proxy.yml
+++ b/.github/workflows/deploy_lambda_scribe_proxy.yml
@@ -1,0 +1,24 @@
+name: deploy_lambda_scribe_proxy
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/deploy_lambda_scribe_proxy.yml'
+      - 'fbossci-aws-lambas/us-east-1/scribe-proxy/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Deploy
+        uses: appleboy/lambda-action@1e05c1377056f21ebb2ce69b910bc16b943c2a66
+        with:
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: us-east-1
+          function_name: gh-ci-scribe-proxy
+          source: fbossci-aws-lambas/us-east-1/scribe-proxy/lambda_function.py

--- a/fbossci-aws-lambas/us-east-1/scribe-proxy/lambda_function.py
+++ b/fbossci-aws-lambas/us-east-1/scribe-proxy/lambda_function.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2019-present, Facebook, Inc.
+
+import json
+import os
+from urllib.request import Request, urlopen
+
+
+# This lambda function proxy the event to scribe with access_token attached
+# Usage example from the invocation with IAM role permission:
+#
+# ```
+# import boto3
+# data = {
+#     'access_token': '', # optional field, will be overwritten by the lambda function
+#     'logs': json.dumps(
+#         [
+#             {
+#                 "category": "perfpipe_pytorch_test_times",
+#                 "message": "message",
+#                 "line_escape": False,
+#             }
+#         ]
+#     )
+# }
+# client = boto3.client('lambda')
+# res = client.invoke(FunctionName='gh-ci-scribe-proxy', Payload=json.dumps(data).encode())
+# if res['FunctionError']:
+#     raise Exception(res['Payload'].read().decode())
+# ```
+def lambda_handler(event, context):
+    req = Request('https://graph.facebook.com/scribe_logs', method='POST')
+    req.add_header('Content-Type', 'application/json')
+    event['access_token'] = os.environ.get('SCRIBE_GRAPHQL_ACCESS_TOKEN')
+    return urlopen(req, data=json.dumps(event).encode()).read()


### PR DESCRIPTION
# Context
Related to https://github.com/pytorch/pytorch/issues/61632, this pr adds a lambda function that adds the `access_token` to the scribe api


# Deployment note
- [ ] Needs to add SCRIBE_GRAPHQL_ACCESS_TOKEN on aws console for the function


