### PR TITLE
Add metrics.pytorch.org

### DIFF
--- a/.github/workflows/metrics_pytorch_org.yml
+++ b/.github/workflows/metrics_pytorch_org.yml
@@ -1,0 +1,42 @@
+name: Deploy metrics.pytorch.org
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'aws/websites/metrics.pytorch.org/**'
+      - '.github/workflows/metrics_pytorch_org.yml'
+
+concurrency:
+  group: "deploy metrics.pytorch.org"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          set -eux
+          pip install ansible
+      - name: Deploy
+        env:
+          FULLCHAIN: ${{ secrets.METRICS_FULLCHAIN }}
+          PRIVKEY: ${{ secrets.METRICS_PRIVKEY }}
+          VARS: ${{ secrets.METRICS_VARS }}
+          SSH_KEY: ${{ secrets.METRICS_SSH_KEY }}
+        run: |
+          set -eux
+          cd aws/websites/metrics.pytorch.org
+
+          echo "$FULLCHAIN" > files/fullchain.pem
+          echo "$PRIVKEY" > files/privkey.pem
+          echo "$VARS" > vars.yml
+          echo "$SSH_KEY" > ssh_key.pem
+          chmod 600 ssh_key.pem
+
+          ansible-playbook -i ubuntu@metrics.pytorch.org, install.yml --extra-vars=@vars.yml --private-key=ssh_key.pem
+

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ override.tf.json
 *_override.tf.json
 .terraformrc
 terraform.rc
+
+aws/websites/metrics.pytorch.org/vars.yml

--- a/aws/websites/metrics.pytorch.org/README.md
+++ b/aws/websites/metrics.pytorch.org/README.md
@@ -1,0 +1,60 @@
+# metrics.pytorch.org
+
+This is a Terraform script + Ansible playbook to spin up a Grafana instance pointed to PyTorch's CloudWatch.
+
+0. Install dependencies
+
+    ```bash
+    pip install ansible
+    brew tap hashicorp/tap
+    brew install hashicorp/tap/terraform
+    ```
+
+1. Start up an instance with Terraform
+
+    ```bash
+    terraform apply -var="key_name=<aws key name>" -var="name=metrics.pytorch.org" -var="type=t2.xlarge" -var="size=50"
+    ```
+
+2. Acquire an SSL key and certificate and store them in `files/privkey.pem` and `files/fullchain.pem` respectively
+
+3. Create a file called `vars.yml` that looks like
+
+    ```yaml
+    passwords:
+        grafana_admin_username: 123
+        grafana_admin: 123
+        aws:
+            id: 123
+            secret: 123
+
+    ssl_filenames:
+        key: privkey.pem
+        cert: fullchain.pem
+    ```
+
+3. Run the Ansible playbook to provision the machine
+
+    ```bash
+    ansible-playbook -i awsmon, install.yml --extra-vars=@vars.yml --private-key=<aws private key>
+    ```
+
+## Debugging
+
+```bash
+# see why containers aren't up
+sudo docker stack ps monitoring --no-trunc
+
+# see grafana logs
+sudo docker service logs monitoring_grafana --raw
+
+# log into a container
+sudo docker ps  # get id
+sudo docker exec -it <ID> /bin/bash
+```
+
+## Adding a Dashboard
+
+Dashboards are defined via [Grafana's provisioning](https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards). Create a new dashboard in the UI, then export it to JSON and save that to a file in the repo under [`aws/websites/metrics.pytorch.org/files/dashboards`](aws/websites/metrics.pytorch.org/files/dashboards).
+
+Any `.yml` files there will automatically be picked up by Grafana when it restarts.

--- a/aws/websites/metrics.pytorch.org/files/dashboards/lambda_status.json
+++ b/aws/websites/metrics.pytorch.org/files/dashboards/lambda_status.json
@@ -1,0 +1,782 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": 1,
+    "links": [],
+    "panels": [
+      {
+        "datasource": "CloudWatch",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "bars",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single"
+          }
+        },
+        "targets": [
+          {
+            "alias": "",
+            "dimensions": {
+              "FunctionName": "pytorch-probot"
+            },
+            "expression": "",
+            "id": "",
+            "matchExact": true,
+            "metricName": "Invocations",
+            "namespace": "AWS/Lambda",
+            "period": "1h",
+            "queryType": "randomWalk",
+            "refId": "A",
+            "region": "us-east-1",
+            "statistics": [
+              "Sum"
+            ]
+          }
+        ],
+        "title": "pytorch-probot Invocations",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "CloudWatch",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "bars",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 5,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single"
+          }
+        },
+        "targets": [
+          {
+            "alias": "",
+            "dimensions": {
+              "FunctionName": "pytorch-probot"
+            },
+            "expression": "",
+            "id": "",
+            "matchExact": true,
+            "metricName": "Duration",
+            "namespace": "AWS/Lambda",
+            "period": "1h",
+            "queryType": "randomWalk",
+            "refId": "A",
+            "region": "us-east-1",
+            "statistics": [
+              "Sum"
+            ]
+          }
+        ],
+        "title": "pytorch-probot Duration",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "CloudWatch",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "bars",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 9
+        },
+        "id": 4,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single"
+          }
+        },
+        "targets": [
+          {
+            "alias": "",
+            "dimensions": {
+              "FunctionName": "github-status-webhook-handler"
+            },
+            "expression": "",
+            "id": "",
+            "matchExact": true,
+            "metricName": "Invocations",
+            "namespace": "AWS/Lambda",
+            "period": "1h",
+            "queryType": "randomWalk",
+            "refId": "A",
+            "region": "us-east-1",
+            "statistics": [
+              "Sum"
+            ]
+          }
+        ],
+        "title": "github-status-webhook-handler Invocations",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "CloudWatch",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "bars",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 9
+        },
+        "id": 7,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single"
+          }
+        },
+        "targets": [
+          {
+            "alias": "",
+            "dimensions": {
+              "FunctionName": "github-status-webhook-handler"
+            },
+            "expression": "",
+            "id": "",
+            "matchExact": true,
+            "metricName": "Duration",
+            "namespace": "AWS/Lambda",
+            "period": "1h",
+            "queryType": "randomWalk",
+            "refId": "A",
+            "region": "us-east-1",
+            "statistics": [
+              "Sum"
+            ]
+          }
+        ],
+        "title": "github-status-webhook-handler Duration",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "CloudWatch",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "bars",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 18
+        },
+        "id": 6,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single"
+          }
+        },
+        "targets": [
+          {
+            "alias": "",
+            "dimensions": {
+              "FunctionName": "gh-ci-scale-down"
+            },
+            "expression": "",
+            "id": "",
+            "matchExact": true,
+            "metricName": "Invocations",
+            "namespace": "AWS/Lambda",
+            "period": "1h",
+            "queryType": "randomWalk",
+            "refId": "A",
+            "region": "us-east-1",
+            "statistics": [
+              "Sum"
+            ]
+          }
+        ],
+        "title": "gh-ci-scale-down Invocations",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "CloudWatch",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "bars",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 18
+        },
+        "id": 3,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single"
+          }
+        },
+        "targets": [
+          {
+            "alias": "",
+            "dimensions": {
+              "FunctionName": "gh-ci-scale-down"
+            },
+            "expression": "",
+            "id": "",
+            "matchExact": true,
+            "metricName": "Duration",
+            "namespace": "AWS/Lambda",
+            "period": "1h",
+            "queryType": "randomWalk",
+            "refId": "A",
+            "region": "us-east-1",
+            "statistics": [
+              "Sum"
+            ]
+          }
+        ],
+        "title": "gh-ci-scale-down Duration",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "CloudWatch",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "bars",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 27
+        },
+        "id": 8,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single"
+          }
+        },
+        "targets": [
+          {
+            "alias": "",
+            "dimensions": {
+              "FunctionName": "gh-ci-scale-up"
+            },
+            "expression": "",
+            "id": "",
+            "matchExact": true,
+            "metricName": "Invocations",
+            "namespace": "AWS/Lambda",
+            "period": "1h",
+            "queryType": "randomWalk",
+            "refId": "A",
+            "region": "us-east-1",
+            "statistics": [
+              "Sum"
+            ]
+          }
+        ],
+        "title": "gh-ci-scale-up Invocations",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "CloudWatch",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "bars",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 27
+        },
+        "id": 9,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single"
+          }
+        },
+        "targets": [
+          {
+            "alias": "",
+            "dimensions": {
+              "FunctionName": "gh-ci-scale-down"
+            },
+            "expression": "",
+            "id": "",
+            "matchExact": true,
+            "metricName": "Duration",
+            "namespace": "AWS/Lambda",
+            "period": "1h",
+            "queryType": "randomWalk",
+            "refId": "A",
+            "region": "us-east-1",
+            "statistics": [
+              "Sum"
+            ]
+          }
+        ],
+        "title": "gh-ci-scale-up Duration",
+        "type": "timeseries"
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": 30,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-7d",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Lambda Status",
+    "uid": "LFSW__inz",
+    "version": 4
+  }

--- a/aws/websites/metrics.pytorch.org/files/docker-compose.yml
+++ b/aws/websites/metrics.pytorch.org/files/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3.7'
+
+services:
+  grafana:
+    image: grafana/grafana:8.0.6
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "10"
+    networks:
+      - monitoring
+    volumes:
+      - /etc/pytorch/grafana:/var/lib/grafana
+      - /etc/pytorch/grafana-provisioning/:/etc/grafana/provisioning
+      - /etc/pytorch/grafana.ini:/etc/grafana/grafana.ini
+      - /etc/pytorch/dashboards:/var/lib/grafana/dashboards
+
+  nginx:
+    image: nginx:1.21.0
+    ports:
+      - "80:80"
+      - "443:443"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "10"
+    networks:
+      - monitoring
+    volumes:
+      - "/etc/pytorch/http.conf:/etc/nginx/conf.d/default.conf"
+      - "/etc/pytorch/fullchain.pem:/etc/nginx/fullchain.pem"
+      - "/etc/pytorch/privkey.pem:/etc/nginx/privkey.pem"
+
+networks:
+  monitoring:
+    external: false

--- a/aws/websites/metrics.pytorch.org/files/grafana-provisioning/dashboards/dashboards.yml
+++ b/aws/websites/metrics.pytorch.org/files/grafana-provisioning/dashboards/dashboards.yml
@@ -1,0 +1,24 @@
+apiVersion: 1
+
+providers:
+  # <string> an unique provider name. Required
+  - name: 'PyTorch Dashboards'
+    # <int> Org id. Default to 1
+    orgId: 1
+    # <string> name of the dashboard folder.
+    folder: ''
+    # <string> folder UID. will be automatically generated if not specified
+    folderUid: ''
+    # <string> provider type. Default to 'file'
+    type: file
+    # <bool> disable dashboard deletion
+    disableDeletion: false
+    # <int> how often Grafana will scan for changed dashboards
+    updateIntervalSeconds: 10
+    # <bool> allow updating provisioned dashboards from the UI
+    allowUiUpdates: true
+    options:
+      # <string, required> path to dashboard files on disk. Required when using the 'file' type
+      path: /var/lib/grafana/dashboards
+      # <bool> use folder names from filesystem to create folders in Grafana
+      foldersFromFilesStructure: true

--- a/aws/websites/metrics.pytorch.org/files/grafana-provisioning/datasources/cloudwatch.yml
+++ b/aws/websites/metrics.pytorch.org/files/grafana-provisioning/datasources/cloudwatch.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+datasources:
+  - name: CloudWatch
+    type: cloudwatch
+    jsonData:
+      authType: keys
+      defaultRegion: us-east-1
+    secureJsonData:
+      accessKey: {{ passwords.aws.id }}
+      secretKey: {{ passwords.aws.secret }}

--- a/aws/websites/metrics.pytorch.org/files/grafana.ini
+++ b/aws/websites/metrics.pytorch.org/files/grafana.ini
@@ -1,0 +1,28 @@
+[server]
+domain = metrics.pytorch.org
+root_url = https://metrics.pytorch.org/
+
+[security]
+admin_user = {{ passwords.grafana_admin_username }}
+admin_password = {{ passwords.grafana_admin }}
+
+[users]
+allow_sign_up = false
+
+[auth.anonymous]
+enabled = true
+
+[dashboards]
+default_home_dashboard_path = /var/lib/grafana/dashboards/lambda_status.json
+
+; TODO: This is broken, the GitHub API returns an empty response when querying teams / organizations from Grafana so it only works if anyone from GitHub can log in
+; [auth.github]
+; enabled = true
+; allow_sign_up = true
+; client_id = {{ passwords.github_id }}
+; client_secret = {{ passwords.github_secret }} 
+; auth_url = https://github.com/login/oauth/authorize
+; token_url = https://github.com/login/oauth/access_token
+; api_url = https://api.github.com/user
+; team_ids =
+; allowed_organizations = pytorch

--- a/aws/websites/metrics.pytorch.org/files/http.conf
+++ b/aws/websites/metrics.pytorch.org/files/http.conf
@@ -1,0 +1,52 @@
+server {
+    listen [::]:80 ipv6only=off;
+    server_name /;
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+upstream grafana {
+    server grafana;
+}
+
+server {
+    listen [::]:443 ipv6only=off ssl;
+    ssl_certificate /etc/nginx/fullchain.pem;
+    ssl_certificate_key /etc/nginx/privkey.pem;
+
+    client_max_body_size 500M;
+
+    set $grafana_upstream_endpoint http://grafana:3000;
+
+    location / {
+        resolver 127.0.0.11 valid=30s ipv6=off;
+        proxy_pass	$grafana_upstream_endpoint;
+
+        proxy_set_header    Host                $host:$server_port;
+        proxy_set_header    X-Real-IP           $remote_addr;
+        proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+        proxy_set_header    X-Forwarded-Host    $host;
+        proxy_set_header    X-Forwarded-Port    $server_port;
+        proxy_set_header    X-Forwarded-Server  $host:$server_port;
+        proxy_set_header    X-Forwarded-Proto   $scheme;
+
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        Connection "upgrade";
+
+        proxy_max_temp_file_size 0;
+
+        client_max_body_size       100m;
+        client_body_buffer_size    128k;
+
+        proxy_connect_timeout      90;
+        proxy_send_timeout         90;
+        proxy_read_timeout         90;
+
+        proxy_buffer_size          4k;
+        proxy_buffers              4 32k;
+        proxy_busy_buffers_size    64k;
+        proxy_temp_file_write_size 64k;
+    }
+}

--- a/aws/websites/metrics.pytorch.org/install.yml
+++ b/aws/websites/metrics.pytorch.org/install.yml
@@ -1,0 +1,34 @@
+---
+
+- name: Setup Docker
+  hosts: all
+  become: true
+  become_user: root
+  become_method: sudo
+  gather_facts: false
+  tasks:
+    - name: Setup
+      shell: |
+        apt update
+        apt install -y docker.io
+        docker swarm init || echo done
+        docker stack rm monitoring || echo done
+
+        rm -rf /etc/pytorch
+        mkdir -p \
+          /etc/pytorch/grafana-provisioning/datasources \
+          /etc/pytorch/grafana-provisioning/dashboards \
+          /etc/pytorch/dashboards/ \
+          /etc/pytorch/grafana
+
+          find /etc/pytorch -type d | xargs chmod 777
+    - name: Copy files
+      template:
+        src: "{{ item.src }}"
+        dest: "/etc/pytorch/{{ item.path }}"
+      with_filetree: files/
+      when: item.state == 'file'
+    - name: Run compose
+      shell: |
+        docker stack rm monitoring || echo done
+        docker stack deploy -c /etc/pytorch/docker-compose.yml monitoring

--- a/aws/websites/metrics.pytorch.org/provision.tf
+++ b/aws/websites/metrics.pytorch.org/provision.tf
@@ -1,0 +1,95 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+variable "key_name" {
+  type = string
+}
+
+variable "ami" {
+  type = string
+  default = "ami-09e67e426f25ce0d7"
+}
+
+variable "type" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "size" {
+  type = number
+  default = 20
+}
+
+resource "aws_vpc" "gh_ci" {
+  # imported from AWS
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "gh-ci-vpc"
+  }
+}
+
+resource "aws_security_group" "metrics" {
+  vpc_id = aws_vpc.gh_ci.id
+  name = "${var.name}_ports"
+  egress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "metrics_ec2_instances" {
+  count = 1
+  ami = var.ami
+  instance_type = var.type
+  subnet_id = "${aws_vpc.gh_ci.subnets[0]}"
+  vpc_security_group_ids = [aws_security_group.metrics.id]
+  key_name = var.key_name
+  associate_public_ip_address = true
+
+  tags = {
+    Name = "${var.name}"
+  }
+
+  root_block_device {
+    volume_size = var.size
+  }
+}
+
+output "cluster_names" {
+  value = ["${aws_instance.metrics_ec2_instances.*.tags.Name}"]
+}
+
+output "cluster_dns" {
+  value = ["${aws_instance.metrics_ec2_instances.*.public_dns}"]
+}


### PR DESCRIPTION
This adds the provisioning steps for metrics.pytorch.org, which for now is a Docker Swarm with Nginx -> Grafana. See the README.md for details.

Tested deployment workflow in: https://github.com/pytorch/test-infra/pull/65/checks?check_run_id=3088283895 (`git push -f` deleted this check's output but it completed successfully)
