### PR TITLE
Filter paths on pull_request for clang-tidy

### DIFF
--- a/.github/workflows/clang-tidy-linux.yml
+++ b/.github/workflows/clang-tidy-linux.yml
@@ -2,6 +2,10 @@ name: Custom clang-tidy build (linux)
 
 on:
   pull_request:
+    paths:
+      - 'tools/clang-tidy-checks/**'
+      - '!tools/clang-tidy-checks/README.md'
+      - '.github/workflows/clang-tidy-linux.yml'
   push:
     branches:
       - master

--- a/.github/workflows/clang-tidy-macos.yml
+++ b/.github/workflows/clang-tidy-macos.yml
@@ -2,6 +2,11 @@ name: Custom clang-tidy build (macos)
 
 on:
   pull_request:
+    paths:
+      - 'tools/clang-tidy-checks/**'
+      - '!tools/clang-tidy-checks/Dockerfile.cilint-clang-tidy'
+      - '!tools/clang-tidy-checks/README.md'
+      - '.github/workflows/clang-tidy-macos.yml'
   push:
     branches:
       - master


### PR DESCRIPTION
Right now it builds on every PR even if the relevant files haven't changed
