### PR TITLE
Add squid proxy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/.terraform.lock.hcl linguist-generated=true

--- a/aws/websites/squid-proxy/.gitignore
+++ b/aws/websites/squid-proxy/.gitignore
@@ -1,0 +1,6 @@
+target/
+*.iml
+.idea/
+**/.terraform/
+**/*.tfstate*
+**/.DS_Store

--- a/aws/websites/squid-proxy/.terraform.lock.hcl
+++ b/aws/websites/squid-proxy/.terraform.lock.hcl
@@ -1,0 +1,55 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.50.0"
+  hashes = [
+    "h1:gX/faGzGvZvf9W6597S7ZcMiNI1gw9ilQwM9hkc6F2Q=",
+    "zh:11d5508e180b93ab06935dbebefb08745c78ebfe1ec41d53b4340fb7f27d32eb",
+    "zh:192ae31ddf1c5c4ed7f64a15c8cf3f1a440b1427fa15604e90eee40037973f0a",
+    "zh:2f381b6aec131b468409416ffa1a23a15e70f2e64a554bf47da13d499a30e7e2",
+    "zh:5d7457d0ef1dfe65fbfa89bdddd4132cab728384c99950e2ac2f0c27d0c3ed34",
+    "zh:6d0067f4bc0d0f16ab9c1143cc6817876e5258504e4893070504cd1559758227",
+    "zh:8398b8b872173ce9c9144e81c50ed1a3d5904afac50d6431b970a82534a1f1f4",
+    "zh:adbe50b8504cc0929cd54a945a0509ff2a72ebf790137b492c647314a2d2512a",
+    "zh:b518a91608fcba26fbbc73121373129b4ac7a4544d983ac922a8dc249702f86d",
+    "zh:d208c00f9e52b8accdc1b1f8466789e12491cf3129e849e2ba28427a1f86ba59",
+    "zh:db61d71857e44aa2d3bb3f6ad568c531cb6e2a6b830d8672b46021c5bb194ef1",
+    "zh:eac7aad200f4df951dd30ec8547b9412909c8dc450c1322b28619499e5e2bdbe",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.0"
+  hashes = [
+    "h1:xhbHC6in3nQryvTQBWKxebi3inG5OCgHgc4fRxL0ymc=",
+    "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
+    "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",
+    "zh:5f9200bf708913621d0f6514179d89700e9aa3097c77dac730e8ba6e5901d521",
+    "zh:9ebf4d9704faba06b3ec7242c773c0fbfe12d62db7d00356d4f55385fc69bfb2",
+    "zh:a6576c81adc70326e4e1c999c04ad9ca37113a6e925aefab4765e5a5198efa7e",
+    "zh:a8a42d13346347aff6c63a37cda9b2c6aa5cc384a55b2fe6d6adfa390e609c53",
+    "zh:c797744d08a5307d50210e0454f91ca4d1c7621c68740441cf4579390452321d",
+    "zh:cecb6a304046df34c11229f20a80b24b1603960b794d68361a67c5efe58e62b8",
+    "zh:e1371aa1e502000d9974cfaff5be4cfa02f47b17400005a16f14d2ef30dc2a70",
+    "zh:fc39cc1fe71234a0b0369d5c5c7f876c71b956d23d7d6f518289737a001ba69b",
+    "zh:fea4227271ebf7d9e2b61b89ce2328c7262acd9fd190e1fd6d15a591abfa848e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}

--- a/aws/websites/squid-proxy/README.md
+++ b/aws/websites/squid-proxy/README.md
@@ -1,0 +1,36 @@
+# Squid Cached Proxy
+
+Squid Cached Proxy is a transparent egress proxy we use in pytorch CI to
+cache common download requests.
+
+# Cache policy
+
+```
+refresh_pattern -i .(7z|deb|rpm|exe|zip|tar|tgz|gz|ram|rar|bin|tiff)$ 1440 80% 2880
+```
+
+It uses the standard squid refresh_pattern for cache requests. In our setup, we tried
+to cache at least (1440 minutes - 1 day) and at max (2880 minutes - 2 days), with
+last-modified factor 80%. Please refer to `squid/user-data.sh` for details.
+
+See doc here http://www.squid-cache.org/Doc/config/refresh_pattern/
+
+
+# Deployment
+
+```
+# Prepare and validation
+terraform init
+terraform fmt && terraform validate
+
+# Deployment is manual
+terraform plan -var "aws_key_name=squid-key-pair" -var "vpc_id=vpc-xxxxxxxx"
+terraform apply -var "aws_key_name=squid-key-pair" -var "vpc_id=vpc-xxxxxxxx"
+```
+
+The terraform has instance refresh built in, so whenever there's a change, `terraform apply` can
+deploy those changes, including changes in `squid/user-data.sh`.
+
+- Get the secrets from https://console.aws.amazon.com/secretsmanager/home?region=us-east-1#!/secret?name=squid-proxy-vars
+- Import key-pair by `ssh-add -K ~/.ssh/squid-key-pair.pem`
+- Run `terraform apply -var "aws_key_name=squid-key-pair" -var "vpc_id=vpc-xxxxxxxx"`

--- a/aws/websites/squid-proxy/main.tf
+++ b/aws/websites/squid-proxy/main.tf
@@ -1,0 +1,52 @@
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+}
+
+data "aws_subnet_ids" "dev" {
+  vpc_id = var.vpc_id
+}
+
+resource "aws_security_group" "sg" {
+  name   = "${var.environment_name}_sg"
+  vpc_id = var.vpc_id
+
+  # Squid proxy port
+  ingress {
+    from_port   = var.squid_port
+    to_port     = var.squid_port
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.environment_name}_sg"
+  }
+}
+
+module "squid" {
+  source                = "./squid"
+  environment_name      = var.environment_name
+  aws_key_name          = var.aws_key_name
+  aws_region            = var.aws_region
+  aws_profile           = var.aws_profile
+  aws_security_group_id = aws_security_group.sg.id
+  aws_subnet_ids        = [tolist(data.aws_subnet_ids.dev.ids)[0]]
+  aws_ami               = lookup(var.aws_amis, var.aws_region)
+  aws_public_vpc_cidr   = var.aws_public_vpc_cidr
+  squid_port            = var.squid_port
+}

--- a/aws/websites/squid-proxy/squid/outputs.tf
+++ b/aws/websites/squid-proxy/squid/outputs.tf
@@ -1,0 +1,3 @@
+output "dns_name" {
+  value = "${aws_elb.elb_1.dns_name}"
+}

--- a/aws/websites/squid-proxy/squid/squid.tf
+++ b/aws/websites/squid-proxy/squid/squid.tf
@@ -1,0 +1,127 @@
+provider "aws" {
+  region                       = "${var.aws_region}"
+  profile                      = "${var.aws_profile}"
+}
+
+locals {
+  user_data = templatefile("${path.module}/user-data.sh", {
+    aws_public_vpc_cidr        = "${var.aws_public_vpc_cidr}"
+    squid_port                 = "${var.squid_port}"
+    maximum_object_size         = "${var.maximum_object_size}"
+    disk_size                  = "${var.disk_size}"
+  })
+}
+
+resource "aws_elb" "elb_1" {
+  internal                     = false
+  cross_zone_load_balancing    = true
+  idle_timeout                 = 300
+  connection_draining          = true
+  connection_draining_timeout  = 300
+  security_groups              = ["${var.aws_security_group_id}"]
+  subnets                      = "${var.aws_subnet_ids}"
+
+  listener {
+    instance_port              = "${var.squid_port}"
+    instance_protocol          = "TCP"
+    lb_port                    = "${var.squid_port}"
+    lb_protocol                = "TCP"
+  }
+
+  health_check {
+    healthy_threshold          = 5
+    unhealthy_threshold        = 2
+    timeout                    = 5
+    target                     = "TCP:${var.squid_port}"
+    interval                   = 10
+  }
+
+  tags = {
+    Name                       = "${var.environment_name}_elb_1"
+  }
+}
+
+resource "aws_launch_configuration" "lc_1" {
+  name_prefix                  = "${var.environment_name}_squid_proxy_"
+  image_id                     = "${var.aws_ami}"
+  instance_type                = "${var.aws_instance_type}"
+  key_name                     = "${var.aws_key_name}"
+  security_groups              = ["${var.aws_security_group_id}"]
+  associate_public_ip_address  = true
+  user_data                    = local.user_data
+  ebs_optimized = true
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 160
+  }
+
+  lifecycle {
+    create_before_destroy      = true
+  }
+}
+
+resource "aws_autoscaling_group" "asg_1" {
+  name                         = "${var.environment_name}_asg_squid_proxy"
+  launch_configuration         = "${aws_launch_configuration.lc_1.name}"
+  vpc_zone_identifier          = "${var.aws_subnet_ids}"
+  load_balancers               = ["${aws_elb.elb_1.id}"]
+  health_check_grace_period    = 180
+  health_check_type            = "ELB"
+  force_delete                 = false
+  termination_policies         = ["OldestInstance"]
+  min_size                     = "${var.aws_asg_min_size}"
+  max_size                     = "${var.aws_asg_max_size}"
+
+  lifecycle {
+    create_before_destroy      = true
+  }
+
+  tag {
+    key                        = "userdata_sha"
+    value                      = sha1(local.user_data)
+    propagate_at_launch        = true
+  }
+
+  instance_refresh {
+    strategy = "Rolling"
+    preferences {
+      min_healthy_percentage = 50
+    }
+    triggers = ["tag"]
+  }
+}
+
+# auto scale up policy
+resource "aws_autoscaling_policy" "asp_1" {
+  name = "${var.environment_name}_asp_1"
+  scaling_adjustment = 1
+  adjustment_type = "ChangeInCapacity"
+  cooldown = 300
+  autoscaling_group_name = "${aws_autoscaling_group.asg_1.name}"
+}
+
+
+# auto scale down policy
+resource "aws_autoscaling_policy" "asp_2" {
+  name = "${var.environment_name}_asp_2"
+  scaling_adjustment = -1
+  adjustment_type = "ChangeInCapacity"
+  cooldown = 300
+  autoscaling_group_name = "${aws_autoscaling_group.asg_1.name}"
+}
+
+resource "aws_cloudwatch_metric_alarm" "cwa_1" {
+  alarm_name = "${var.environment_name}_cwa_1"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods = "2"
+  metric_name = "CPUUtilization"
+  namespace = "AWS/EC2"
+  period = "120"
+  statistic = "Average"
+  threshold = "80"
+  alarm_description = "Check whether EC2 instance CPU utilisation is over 80% on average"
+  alarm_actions = ["${aws_autoscaling_policy.asp_1.arn}"]
+  dimensions = {
+    AutoScalingGroupName = "${aws_autoscaling_group.asg_1.name}"
+  }
+}

--- a/aws/websites/squid-proxy/squid/user-data.sh
+++ b/aws/websites/squid-proxy/squid/user-data.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+yum update -y
+yum install -y squid
+
+cat > /etc/squid/squid.conf << EOF
+acl manager proto cache_object
+acl CONNECT method CONNECT
+acl localnet src ${aws_public_vpc_cidr}
+acl localhost src 127.0.0.1/255.255.255.255
+acl Safe_ports port 80
+acl Safe_ports port 443
+acl purge method PURGE
+
+http_access allow manager localhost
+http_access deny manager
+http_access allow purge localhost
+http_access deny purge
+http_access deny !Safe_ports
+http_access allow localhost
+http_access allow localnet
+http_access deny all
+
+icp_access allow all
+
+maximum_object_size            ${maximum_object_size} MB
+cache_dir ufs /var/spool/squid ${disk_size} 16 256
+cache_mem 12000 MB
+coredump_dir /var/spool/squid
+dns_nameservers 1.1.1.1 8.8.4.4
+http_port 3128
+
+refresh_pattern -i .(7z|deb|rpm|exe|zip|tar|tgz|gz|ram|rar|bin|tiff|bz2|run|csv|sh)$ 1440 80% 2880
+refresh_pattern . 0	20%	4320
+
+EOF
+
+service squid start
+chkconfig squid on

--- a/aws/websites/squid-proxy/squid/variables.tf
+++ b/aws/websites/squid-proxy/squid/variables.tf
@@ -1,0 +1,62 @@
+variable "environment_name" {
+  description = "The name of the environment"
+}
+
+variable "aws_region" {
+  description = "AWS region to create the VPC and services"
+}
+
+variable "aws_profile" {
+  description = "AWS profile to use other than the default"
+  default     = "default"
+}
+
+variable "aws_key_name" {
+  description = "AWS key name to use, it must exist in the specified region"
+}
+
+variable "aws_security_group_id" {
+  description = "AWS security group ID that the instances will be bound to"
+}
+
+variable "aws_subnet_ids" {
+  description = "AWS subnet IDs that the launch configuration will use"
+  type        = list
+}
+
+variable "aws_ami" {
+  description = "AWS AMI to use for the squid proxy hosts"
+}
+
+variable "aws_instance_type" {
+  description = "The EC2 instance type"
+  default     = "t3.medium"
+}
+
+variable "aws_asg_min_size" {
+  description = "Auto scale group minimum size"
+  default     = 1
+}
+
+variable "aws_asg_max_size" {
+  description = "Auto scale group maximum size"
+  default     = 3
+}
+
+variable "aws_public_vpc_cidr" {
+  description = "VPC CIDR block range for the public VPC"
+}
+
+variable "squid_port" {
+  description = "Squid proxies ELB port"
+}
+
+variable "disk_size" {
+  description = "disk size of the instances in MB, also the same as the squid cache size"
+  default = 150000
+}
+
+variable "maximum_object_size" {
+  description = "maximum_object_size cache object size in MB"
+  default = 20000
+}

--- a/aws/websites/squid-proxy/variables.tf
+++ b/aws/websites/squid-proxy/variables.tf
@@ -1,0 +1,41 @@
+variable "environment_name" {
+  description = "The name of the environment"
+  default     = "squid_dev"
+}
+
+variable "aws_region" {
+  description = "AWS region to create the VPC and services"
+  default     = "us-east-1"
+}
+
+variable "aws_profile" {
+  description = "AWS profile to use other than the default"
+  default     = "default"
+}
+
+variable "vpc_id" {
+  description = "vpc id to be used"
+}
+
+# NOTE: The key should be available via your SSH agent, use ssh-add to add this key
+variable "aws_key_name" {
+  description = "AWS key name to use, it must exist in the specified region"
+}
+
+variable "aws_public_vpc_cidr" {
+  description = "VPC CIDR block range for the public VPC"
+  default     = "10.0.0.0/20"
+}
+
+variable "squid_port" {
+  description = "Squid proxies ELB port"
+  default     = 3128
+}
+
+# Latest official amazon Linux (x64) ami with
+variable "aws_amis" {
+  type = map(any)
+  default = {
+    us-east-1 = "ami-0ff8a91507f77f867"
+  }
+}


### PR DESCRIPTION
Related to https://github.com/pytorch/pytorch/issues/61793

We are creating a simple squid cache proxy with terraform and aws resources that can help caching the common filetype of http egress traffic in pytorch CI.