### PR TITLE
Add email notifications to metrics.pytorch.org

### DIFF
--- a/aws/websites/metrics.pytorch.org/files/docker-compose.yml
+++ b/aws/websites/metrics.pytorch.org/files/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - /etc/pytorch/grafana:/var/lib/grafana
       - /etc/pytorch/grafana-provisioning/:/etc/grafana/provisioning
+      - /etc/pytorch/email_template.html:/usr/share/grafana/public/emails/alert_notification.html
       - /etc/pytorch/grafana.ini:/etc/grafana/grafana.ini
       - /etc/pytorch/dashboards:/var/lib/grafana/dashboards
 

--- a/aws/websites/metrics.pytorch.org/files/email_template.html
+++ b/aws/websites/metrics.pytorch.org/files/email_template.html
@@ -1,0 +1,41 @@
+{% raw %}
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="viewport" content="width=device-width" />
+</head>
+
+<body>
+
+  <p>{{.Name}} [{{.State}}]</p>
+  <br>
+
+  <p>{{.Message}}</p>
+  <br>
+
+  <p>{{.Error}}</p>
+  <br>
+
+  <p>
+    Rule: {{.RuleUrl}}
+    <br>
+    Alert: {{.AlertPageUrl}}
+  </p>
+
+  <br>
+  <p>
+    Values:
+    <br>
+    {{range .EvalMatches}}
+    &nbsp;&nbsp;{{.Metric}} = {{.Value}}<br>
+    {{end}}
+      <br>
+  </p>
+
+  {{.ImageLink}}
+</body>
+
+</html>
+{% endraw %}

--- a/aws/websites/metrics.pytorch.org/files/grafana-provisioning/notifiers/email.yml
+++ b/aws/websites/metrics.pytorch.org/files/grafana-provisioning/notifiers/email.yml
@@ -1,0 +1,11 @@
+notifiers:
+  - name: default-email
+    type: email
+    org_id: 1
+    uid: notifier1
+    disable_resolve_message: false
+    send_reminder: true
+    frequency: 8h
+    is_default: true
+    settings:
+      addresses: {{ passwords.email.to_address }}

--- a/aws/websites/metrics.pytorch.org/files/grafana.ini
+++ b/aws/websites/metrics.pytorch.org/files/grafana.ini
@@ -15,6 +15,16 @@ enabled = true
 [dashboards]
 default_home_dashboard_path = /var/lib/grafana/dashboards/lambda_status.json
 
+# For email alerts
+[smtp]
+enabled = true
+host = {{ passwords.email.server }}
+user = {{ passwords.email.user }}
+password = {{ passwords.email.password }}
+skip_verify = true
+from_address = {{ passwords.email.user }}
+from_name = "metrics.pytorch.org alerts"
+
 ; TODO: This is broken, the GitHub API returns an empty response when querying teams / organizations from Grafana so it only works if anyone from GitHub can log in
 ; [auth.github]
 ; enabled = true

--- a/aws/websites/metrics.pytorch.org/install.yml
+++ b/aws/websites/metrics.pytorch.org/install.yml
@@ -17,6 +17,7 @@
         rm -rf /etc/pytorch
         mkdir -p \
           /etc/pytorch/grafana-provisioning/datasources \
+          /etc/pytorch/grafana-provisioning/notifiers \
           /etc/pytorch/grafana-provisioning/dashboards \
           /etc/pytorch/dashboards/ \
           /etc/pytorch/grafana


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #77
* #76
* **#75**

This adds the config for an SMTP server for notifications. For the actual usage it gets sent from a random gmail I made to my work email, which Butterfly sends to the chat group for [this group](https://fb.prod.workplace.com/groups/1125997287887834), so we can get notifications like we do other Butterfly alerts.