### PR TITLE
Increase gh-ci-scribe-proxy memory size

### DIFF
--- a/.github/workflows/lambda_scribe_proxy.yml
+++ b/.github/workflows/lambda_scribe_proxy.yml
@@ -39,3 +39,4 @@ jobs:
           function_name: gh-ci-scribe-proxy
           source: aws/lambda/scribe-proxy/lambda_function.py
           timeout: 60 # 60 seconds as the max duration of the lambda_function
+          memory_size: 256 # 256 MB


### PR DESCRIPTION
The payload sometime is huge, increasing the memory from default (128 MB) to 256 MB.

Fix rare exception events like
```
Error: Runtime exited with error: signal: killed
Runtime.ExitError
```