### PR TITLE
Automate dashboard updates

### DIFF
--- a/.github/workflows/update_grafana_dashboards.yml
+++ b/.github/workflows/update_grafana_dashboards.yml
@@ -1,9 +1,8 @@
 name: Update Grafana Dashboards
 
 on:
-  pull_request:
-  # schedule:
-  #   - cron: "*/15 * * * *"
+  schedule:
+    - cron: "*/15 * * * *"
 
 jobs:
   update-dashboards:
@@ -31,5 +30,4 @@ jobs:
           git config user.name 'facebook-github-bot'
           git config user.email 'facebook-github-bot@users.noreply.github.com'
           git commit -m"Automated Grafana dashboard update"
-          # Skipping git push for now...
-          # git push origin/main
+          git push origin/main

--- a/.github/workflows/update_grafana_dashboards.yml
+++ b/.github/workflows/update_grafana_dashboards.yml
@@ -1,0 +1,35 @@
+name: Update Grafana Dashboards
+
+on:
+  pull_request:
+  # schedule:
+  #   - cron: "*/15 * * * *"
+
+jobs:
+  update-dashboards:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install requirements
+        run: |
+          set -eux
+          pip install requests==2.24.0
+      - name: Update Dashboards
+        id: update
+        env:
+          GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}
+        run: |
+          set -eux
+          cd aws/websites/metrics.pytorch.org
+          python update_dashboards.py
+      - name: Push changes
+        if: ${{ steps.update.outputs.UPDATED_DASHBOARDS == 'yes' }} 
+        run: |
+          set -eux
+          git add aws/websites/metrics.pytorch.org/files/dashboards/*.json
+          git config user.name 'facebook-github-bot'
+          git config user.email 'facebook-github-bot@users.noreply.github.com'
+          git commit -m"Automated Grafana dashboard update"
+          # Skipping git push for now...
+          # git push origin/main

--- a/.github/workflows/update_grafana_dashboards.yml
+++ b/.github/workflows/update_grafana_dashboards.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Update Dashboards
         id: update
         env:
-          GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}
+          GRAFANA_USER: ${{ secrets.GRAFANA_USER }}
+          GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
         run: |
           set -eux
           cd aws/websites/metrics.pytorch.org

--- a/aws/websites/metrics.pytorch.org/update_dashboards.py
+++ b/aws/websites/metrics.pytorch.org/update_dashboards.py
@@ -1,0 +1,82 @@
+"""
+This script pulls down dashboards from Grafana, matches them by name to their
+correpsonding JSONs in files/dashboards, and sends a new commit to
+pytorch/test-infra if anything has changed
+"""
+
+import os
+import requests
+import json
+import difflib
+from pathlib import Path
+from typing import List, Dict, Any, Tuple
+
+token = os.environ["GRAFANA_TOKEN"]
+
+Dashboard = Dict[str, Any]
+
+ROOT = Path(__file__).resolve().parent
+DASHBOARD_DIR = ROOT / "files" / "dashboards"
+
+
+def grafana(url):
+    base = "https://metrics.pytorch.org/api"
+    headers = {"Authorization": f"Bearer {token}"}
+    r = requests.get(f"{base}/{url.lstrip('/')}", headers=headers)
+    return r.json()
+
+
+def get_dashboards() -> List[Dashboard]:
+    response = grafana("search?query=")
+    return [item for item in response if item.get("type") == "dash-db"]
+
+
+def files_by_uid() -> List[Dict[str, Any]]:
+    paths = DASHBOARD_DIR.glob("*.json")
+    files = {}
+    for path in paths:
+        with open(path) as f:
+            dashboard = json.load(f)
+            uid = dashboard["uid"]
+            files[uid] = {"path": path, "dashboard": dashboard}
+    return files
+
+
+def diff(expected, actual):
+    expected = expected.splitlines(1)
+    actual = actual.splitlines(1)
+    diff = difflib.unified_diff(expected, actual)
+    return "".join(diff)
+
+
+if __name__ == "__main__":
+    dashboards = get_dashboards()
+    files = files_by_uid()
+
+    updated = False
+
+    for dashboard in dashboards:
+        uid = dashboard["uid"]
+        file = files[uid]
+        dashboard_on_grafana = grafana(f"dashboards/uid/{uid}")["dashboard"]
+        dashboard_in_repo = file["dashboard"]
+
+        if dashboard_on_grafana == dashboard_in_repo:
+            # They're the same, no need to update
+            continue
+
+        updated = True
+        dashboard_on_grafana = json.dumps(dashboard_on_grafana, indent=2)
+        dashboard_in_repo = json.dumps(dashboard_in_repo, indent=2)
+
+        print(diff(dashboard_in_repo, dashboard_on_grafana))
+
+        with open(file["path"], "w") as f:
+            f.write(dashboard_on_grafana)
+    
+    if updated:
+        print('::set-output name=UPDATED_DASHBOARDS::yes')
+    else:
+        print('::set-output name=UPDATED_DASHBOARDS::no')
+    
+

--- a/aws/websites/metrics.pytorch.org/update_dashboards.py
+++ b/aws/websites/metrics.pytorch.org/update_dashboards.py
@@ -11,7 +11,8 @@ import difflib
 from pathlib import Path
 from typing import List, Dict, Any, Tuple
 
-token = os.environ["GRAFANA_TOKEN"]
+user = os.environ["GRAFANA_USER"]
+password = os.environ["GRAFANA_PASSWORD"]
 
 Dashboard = Dict[str, Any]
 
@@ -21,9 +22,11 @@ DASHBOARD_DIR = ROOT / "files" / "dashboards"
 
 def grafana(url):
     base = "https://metrics.pytorch.org/api"
-    headers = {"Authorization": f"Bearer {token}"}
-    r = requests.get(f"{base}/{url.lstrip('/')}", headers=headers)
-    return r.json()
+    r = requests.get(f"{base}/{url.lstrip('/')}", auth=(user, password))
+    value = r.json()
+    if isinstance(value, dict) and value.get("message", None) is not None:
+        raise RuntimeError(value)
+    return value
 
 
 def get_dashboards() -> List[Dashboard]:


### PR DESCRIPTION
This adds a script that will check Grafana every 15 minutes and auto-push any dashboard changes. This is only there so we can keep our running Grafana instance and what we have in the repo in sync. If something is broken in the UI, we can still roll back by finding a good JSON in the git history then setting that on Grafana.

Tested by adding `on_pull_request:` and removing the `git push` from the final step: https://github.com/pytorch/test-infra/pull/88/checks?check_run_id=3185571549