### PR TITLE
Lint actions

### DIFF
--- a/.github/workflows/clang-tidy-linux.yml
+++ b/.github/workflows/clang-tidy-linux.yml
@@ -23,22 +23,22 @@ jobs:
       - name: Build docker image
         run: |
           set -ex
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker build ./tools/clang-tidy-checks --tag ghcr.io/pytorch/cilint-clang-tidy:$GITHUB_SHA -f tools/clang-tidy-checks/Dockerfile.cilint-clang-tidy
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+          docker build ./tools/clang-tidy-checks --tag ghcr.io/pytorch/cilint-clang-tidy:"$GITHUB_SHA" -f tools/clang-tidy-checks/Dockerfile.cilint-clang-tidy
       - name: Publish docker image and extract binary
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
           set -ex
-          docker push ghcr.io/pytorch/cilint-clang-tidy:$GITHUB_SHA
+          docker push ghcr.io/pytorch/cilint-clang-tidy:"$GITHUB_SHA"
 
           # Copying files directly from a docker image is not supported
           # As a workaround, we create a temporary container, copy the binary, and remove it
-          image_id=$(docker create ghcr.io/pytorch/cilint-clang-tidy:$GITHUB_SHA)
-          docker cp $image_id:/clang-tidy-checks/build/bin/clang-tidy ./clang-tidy
-          docker rm -v $image_id
+          image_id=$(docker create ghcr.io/pytorch/cilint-clang-tidy:"$GITHUB_SHA")
+          docker cp "$image_id":/clang-tidy-checks/build/bin/clang-tidy ./clang-tidy
+          docker rm -v "$image_id"
       - uses: driazati/upload-artifact-s3@50adbe4ef0b6d9221df25c18c5fc528dfcb7c3f8
         name: Publish binary
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
           name: clang-tidy
           if-no-files-found: error

--- a/.github/workflows/clang-tidy-macos.yml
+++ b/.github/workflows/clang-tidy-macos.yml
@@ -37,7 +37,7 @@ jobs:
           ./setup.sh
       - uses: driazati/upload-artifact-s3@50adbe4ef0b6d9221df25c18c5fc528dfcb7c3f8
         name: Publish binary
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
           name: clang-tidy
           if-no-files-found: error

--- a/.github/workflows/lambda_scribe_proxy.yml
+++ b/.github/workflows/lambda_scribe_proxy.yml
@@ -26,7 +26,7 @@ jobs:
           python -m unittest
   deploy:
     runs-on: ubuntu-20.04
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/lint_actions.yml
+++ b/.github/workflows/lint_actions.yml
@@ -2,6 +2,9 @@ name: Lint GitHub Actions
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   lint-actions:
@@ -12,6 +15,16 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.16.0'
+      # Lifted from https://github.com/pytorch/pytorch/blob/b39b28ced39f6400c97c1ab663046d765fc95a87/.github/workflows/lint.yml#L189-L200
+      - name: Install ShellCheck
+        run: |
+          set -x
+          scversion="v0.7.2"
+          wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv
+          mkdir -p ~/.local/bin
+          cp "shellcheck-${scversion}/shellcheck" ~/.local/bin/
+          rm -r "shellcheck-${scversion}"
+          ~/.local/bin/shellcheck --version
       - name: Install requirements
         run: |
           set -eux
@@ -19,4 +32,4 @@ jobs:
       - name: Run actionlint
         run: |
           set -eux
-          actionlint --shellcheck NONE --pyflakes NONE
+          actionlint

--- a/.github/workflows/lint_actions.yml
+++ b/.github/workflows/lint_actions.yml
@@ -1,0 +1,22 @@
+name: Lint GitHub Actions
+
+on:
+  pull_request:
+
+jobs:
+  lint-actions:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16.0'
+      - name: Install requirements
+        run: |
+          set -eux
+          go install github.com/rhysd/actionlint/cmd/actionlint@7040327ca40aefd92888871131adc30c7d9c1b6d
+      - name: Run actionlint
+        run: |
+          set -eux
+          actionlint --shellcheck NONE --pyflakes NONE

--- a/README.md
+++ b/README.md
@@ -25,6 +25,25 @@ $ git clone --recursive https://github.com/pytorch/test-infra
     └── scripts
 ```
 
+## Linting
+
+We use [`actionlint`](https://github.com/rhysd/actionlint) to verify that the GitHub Actions workflows in [`.github/workflows`](github/workflows) are correct. To run it locally:
+
+1. [Set up Go](https://golang.org/doc/install)
+2. Install actionlint
+
+    ```bash
+    go install github.com/rhysd/actionlint/cmd/actionlint@7040327ca40aefd92888871131adc30c7d9c1b6d
+    ```
+3. Run actionlint
+
+    ```bash
+    # The executable will be in ~/go/bin, so make sure that's on your PATH
+    # actionlint automatically detects and uses shellcheck, so if it's not in
+    # your PATH you will get different results than in CI
+    actionlint
+    ```
+
 ## Join the PyTorch TestInfra community
 See the [`CONTRIBUTING`](CONTRIBUTING.md) file for how to help out.
 


### PR DESCRIPTION
This integrates [https://github.com/rhysd/actionlint](https://github.com/rhysd/actionlint) which checks workflow files for syntactic validity plus some extra GitHub Action specific semantics. If it sees that ShellCheck is installed it will also pull out each `run:` block and check it, so this integrates that as well.

Example failure: https://github.com/pytorch/test-infra/runs/3186195613

We can copy-paste this pretty much verbatim into pytorch/pytorch since actionlint finds workflow files automatically.