### PR TITLE
[metrics] Add elasticsearch data source

### DIFF
--- a/aws/websites/metrics.pytorch.org/files/docker-compose.yml
+++ b/aws/websites/metrics.pytorch.org/files/docker-compose.yml
@@ -17,6 +17,18 @@ services:
       - /etc/pytorch/grafana.ini:/etc/grafana/grafana.ini
       - /etc/pytorch/dashboards:/var/lib/grafana/dashboards
 
+  kibana:
+    image: amazon/opendistro-for-elasticsearch-kibana:1.13.2
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "10"
+    networks:
+      - monitoring
+    volumes:
+      - "/etc/pytorch/kibana.yml:/usr/share/kibana/config/kibana.yml"
+
   nginx:
     image: nginx:1.21.0
     ports:

--- a/aws/websites/metrics.pytorch.org/files/grafana-provisioning/datasources/elasticsearch.yml
+++ b/aws/websites/metrics.pytorch.org/files/grafana-provisioning/datasources/elasticsearch.yml
@@ -1,0 +1,18 @@
+apiVersion: 1
+
+datasources:
+  - name: ElasticSearch
+    type: elasticsearch
+    access: proxy
+    database: "github-logs"
+    interval: null
+    url: "{{ passwords.es.host }}"
+    basicAuth: true
+    editable: true
+    basicAuthUser: "{{ passwords.es.username }}"
+    jsonData:
+      interval: Daily
+      timeField: "date"
+      esVersion: 70
+    secureJsonData:
+      basicAuthPassword: "{{ passwords.es.password }}"

--- a/aws/websites/metrics.pytorch.org/files/http.conf
+++ b/aws/websites/metrics.pytorch.org/files/http.conf
@@ -1,6 +1,6 @@
 server {
     listen [::]:80 ipv6only=off;
-    server_name /;
+    server_name _;
 
     location / {
         return 301 https://$host$request_uri;
@@ -19,6 +19,37 @@ server {
     client_max_body_size 500M;
 
     set $grafana_upstream_endpoint http://grafana:3000;
+    set $kibana_upstream_endpoint http://kibana:5601;
+
+    location /kibana/ {
+        resolver 127.0.0.11 valid=30s ipv6=off;
+        proxy_pass	$kibana_upstream_endpoint;
+
+        proxy_set_header    Host                $host:$server_port;
+        proxy_set_header    X-Real-IP           $remote_addr;
+        proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+        proxy_set_header    X-Forwarded-Host    $host;
+        proxy_set_header    X-Forwarded-Port    $server_port;
+        proxy_set_header    X-Forwarded-Server  $host:$server_port;
+        proxy_set_header    X-Forwarded-Proto   $scheme;
+
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        Connection "upgrade";
+
+        proxy_max_temp_file_size 0;
+
+        client_max_body_size       100m;
+        client_body_buffer_size    128k;
+
+        proxy_connect_timeout      90;
+        proxy_send_timeout         90;
+        proxy_read_timeout         90;
+
+        proxy_buffer_size          4k;
+        proxy_buffers              4 32k;
+        proxy_busy_buffers_size    64k;
+        proxy_temp_file_write_size 64k;
+    }
 
     location / {
         resolver 127.0.0.11 valid=30s ipv6=off;

--- a/aws/websites/metrics.pytorch.org/files/kibana.yml
+++ b/aws/websites/metrics.pytorch.org/files/kibana.yml
@@ -1,0 +1,30 @@
+server.host: '0.0.0.0'
+
+elasticsearch.hosts: ['{{ passwords.es.host }}']
+
+kibana.index: ".username"
+
+server.basePath: "/kibana"
+server.rewriteBasePath: true
+security.showInsecureClusterWarning: false
+
+elasticsearch.ssl.verificationMode: none # if not using HTTPS
+
+opendistro_security.auth.type: basicauth
+opendistro_security.auth.anonymous_auth_enabled: false
+opendistro_security.cookie.secure: false # set to true when using HTTPS
+opendistro_security.cookie.ttl: 3600000
+opendistro_security.session.ttl: 3600000
+opendistro_security.session.keepalive: false
+opendistro_security.multitenancy.enabled: false
+opendistro_security.readonly_mode.roles: ['kibana_read_only']
+opendistro_security.auth.unauthenticated_routes: []
+opendistro_security.basicauth.login.title: 'Please log in using your user name and password'
+
+elasticsearch.username: '{{ passwords.es.username }}'
+elasticsearch.password: '{{ passwords.es.password }}'
+elasticsearch.requestHeadersWhitelist: [
+  authorization,
+  securitytenant,
+  security_tenant,
+]

--- a/aws/websites/metrics.pytorch.org/install.yml
+++ b/aws/websites/metrics.pytorch.org/install.yml
@@ -22,7 +22,7 @@
           /etc/pytorch/dashboards/ \
           /etc/pytorch/grafana
 
-          find /etc/pytorch -type d | xargs chmod 777
+        find /etc/pytorch -type d | xargs chmod 777
     - name: Copy files
       template:
         src: "{{ item.src }}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #95
* **#94**

This adds our AWS ElasticSearch which is currently storing GitHub Actions logs, accessible through both Grafana and a Kibana instance to connect to AWS ElasticSearch.