### PR TITLE
Add lambda to write webhooks to RDS

### DIFF
--- a/.github/workflows/lambda_github_webhook_rds_sync.yml
+++ b/.github/workflows/lambda_github_webhook_rds_sync.yml
@@ -1,0 +1,34 @@
+name: Deploy github-webhook-rds-sync
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/lambda_github_log_webhook.yml'
+      - 'aws/lambda/github-logs-webhook/**'
+
+
+concurrency:
+  group: Deploy github-logs-webhook
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cd aws/lambda/github-logs-webhook
+          make deployment
+      - name: Deploy
+        uses: appleboy/lambda-action@1e05c1377056f21ebb2ce69b910bc16b943c2a66
+        with:
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: us-east-1
+          function_name: github-checks-status-updater
+          timeout: 15
+          zip_file: aws/lambda/github-logs-webhook/deployment.zip

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.env
 *.zip
 *.swp
+*.txt
 
 __pycache__
 
@@ -23,3 +24,6 @@ override.tf.json
 terraform.rc
 
 aws/websites/metrics.pytorch.org/vars.yml
+
+aws/lambda/github-webhook-rds-sync/python/*
+aws/lambda/github-webhook-rds-sync/hooks/*

--- a/aws/lambda/github-webhook-rds-sync/Makefile
+++ b/aws/lambda/github-webhook-rds-sync/Makefile
@@ -1,0 +1,10 @@
+deployment:
+	pip install --target ./python -r requirements.txt
+	cd python && zip -r ../deployment.zip .
+	zip -g deployment.zip lambda_function.py utils.py
+
+manual_update:
+	aws lambda update-function-code --function-name github-webhook-rds-sync --zip-file fileb://deployment.zip
+
+clean:
+	rm -rf deployment.zip python

--- a/aws/lambda/github-webhook-rds-sync/generate_schema.py
+++ b/aws/lambda/github-webhook-rds-sync/generate_schema.py
@@ -1,0 +1,71 @@
+"""
+This script creates and stores the schema needed to hold the data for a set of
+webhooks. The webhooks should be in JSON files in a hooks/ directory (see
+save_to_s3 in lambda_function.py for the mechanism to gather the hooks). Once
+thats done set up the DB connection with the (db_host, db_user, db_password)
+env variables and run this script to create classes in SQLAlchemy's ORM and
+insert them into the database.
+
+This is intended to be run manually on DB migrations or for testing / restoring
+the database.
+"""
+from collections import defaultdict
+import json
+import asyncio
+from pathlib import Path
+from typing import *
+
+from sqlalchemy.orm import declarative_base
+
+from utils import (
+    extract_github_objects,
+    generate_orm,
+    get_engine,
+    connection_string,
+    ACCEPTABLE_WEBHOOKS,
+)
+
+
+async def update_schema_for(payload: Dict[str, Any], webhook: str):
+    Base = declarative_base()
+
+    # Only look at allowlisted webhooks
+    if webhook not in ACCEPTABLE_WEBHOOKS:
+        return {"statusCode": 200, "body": f"not processing {webhook}"}
+
+    # Marshal JSON into SQL-able data
+    objects = extract_github_objects(payload, webhook)
+
+    # NB: This has to be before create_all since it passively registers the tables
+    [generate_orm(name, obj, Base) for name, obj in objects]
+
+    # # Set up link to DB
+    # session, engine = get_session()
+    Base.metadata.create_all(get_engine(connection_string()))
+
+
+if __name__ == "__main__":
+    samples_path = Path(__file__).resolve().parent / "hooks"
+
+    webhooks = defaultdict(dict)
+
+    # Go over and combine all webhooks of the same type
+    n = len([x for x in samples_path.glob("*.json")])
+    for i, name in enumerate(samples_path.glob("*.json")):
+        if i % 1000 == 0:
+            print(f"{i} / {n}")
+
+        webhook = name.name.replace(".json", "").split("-")[0]
+        name = samples_path / name
+        if webhook not in ACCEPTABLE_WEBHOOKS:
+            continue
+
+        with open(name) as f:
+            data = json.load(f)
+
+        for k, v in data.items():
+            webhooks[webhook][k] = v
+
+    # Write all the schemas to the DB
+    for webhook, combined_data in webhooks.items():
+        r = asyncio.run(update_schema_for(combined_data, webhook=webhook))

--- a/aws/lambda/github-webhook-rds-sync/lambda_function.py
+++ b/aws/lambda/github-webhook-rds-sync/lambda_function.py
@@ -1,0 +1,110 @@
+import json
+import datetime
+import asyncio
+import os
+import boto3
+import hmac
+import hashlib
+from typing import *
+from urllib.parse import unquote
+from sqlalchemy import insert, table, column
+from sqlalchemy.dialects.mysql import insert
+
+from utils import (
+    extract_github_objects,
+    get_engine,
+    transform_data,
+    connection_string,
+    ACCEPTABLE_WEBHOOKS,
+    WEBHOOK_SECRET,
+)
+
+
+def upsert(engine, model, insert_dict):
+    """
+    Insert or update to an engine backed by MySQL
+    """
+    inserted = insert(model).values(**insert_dict)
+    upserted = inserted.on_duplicate_key_update(
+        **{k: inserted.inserted[k] for k, v in insert_dict.items()}
+    )
+    res = engine.execute(upserted)
+    return res.lastrowid
+
+
+async def handle_webhook(payload: Dict[str, Any], type: str):
+    engine = get_engine(connection_string())
+
+    # Only look at allowlisted webhooks
+    if type not in ACCEPTABLE_WEBHOOKS:
+        return {"statusCode": 200, "body": f"not processing {type}"}
+
+    # Marshal JSON into SQL-able data
+    objects = extract_github_objects(payload, type)
+
+    print("Writing", ", ".join([n for n, o in objects]))
+
+    with engine.connect() as conn:
+        for tablename, obj in objects:
+            # Some of the data is not already in the right form (e.g. dates and
+            # lists, so fix that up here)
+            obj = transform_data(obj)
+
+            model_data = [tablename] + [column(k) for k in obj.keys()]
+            model = table(*model_data)
+            upsert(conn, model, obj)
+
+    return {"statusCode": 200, "body": "ok"}
+
+
+def check_hash(payload, expected):
+    signature = hmac.new(
+        WEBHOOK_SECRET.encode("utf-8"), payload, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(signature, expected)
+
+
+def save_to_s3(event_type, payload):
+    """
+    Save a webhook payload to S3 in gha-artifacts/pytorch/pytorch/webhooks (used
+    in generate_schema.py)
+    """
+    session = boto3.Session(
+        aws_access_key_id=os.environ["aws_key_id"],
+        aws_secret_access_key=os.environ["aws_access_key"],
+    )
+    s3 = session.resource("s3")
+
+    now = datetime.datetime.now()
+    millis = int(now.timestamp() * 1000)
+    day = now.strftime("%Y-%m-%d")
+    name = f"pytorch/pytorch/webhooks/{day}/{event_type}-{millis}.json"
+    bucket = s3.Bucket("gha-artifacts")
+    bucket.put_object(Key=name, Body=json.dumps(payload).encode("utf-8"))
+
+
+def lambda_handler(event, context):
+    expected = event["headers"].get("X-Hub-Signature-256", "").split("=")[1]
+    payload = event["body"].encode("utf-8")
+
+    # Check that the signature matches the secret on GitHub
+    if check_hash(payload, expected):
+        body = unquote(event["body"])
+        if body.startswith("payload="):
+            body = body[len("payload=") :]
+        payload = json.loads(body)
+
+        # Pull out the webhook type (e.g. pull_request, issues, check_run, etc)
+        event_type = event["headers"]["X-GitHub-Event"]
+
+        # If we want to, save webhooks to S3 for later processing (this is used
+        # to generate the DB schema with generate_schema.py
+        if os.getenv("save_to_s3", False) == "1":
+            save_to_s3(event_type, payload)
+
+        result = asyncio.run(handle_webhook(payload, event_type))
+    else:
+        result = {"statusCode": 403, "body": "Forbidden"}
+
+    print("Result:", result)
+    return result

--- a/aws/lambda/github-webhook-rds-sync/test_lambda.py
+++ b/aws/lambda/github-webhook-rds-sync/test_lambda.py
@@ -1,0 +1,49 @@
+"""
+NB: This file requires a running MySQL database. On an Ubuntu machine, this can
+be done with these steps: https://www.digitalocean.com/community/tutorials/how-to-install-mariadb-on-ubuntu-20-04
+
+Once done, set the db_host, db_password and db_user env variables accordingly.
+"""
+import os
+
+os.environ["gh_secret"] = "test"
+
+import lambda_function
+import json
+import asyncio
+import io
+import unittest
+from pathlib import Path
+import tempfile
+
+
+class TestWebhook(unittest.TestCase):
+    def test_real_webhooks(self):
+        samples_path = Path(__file__).resolve().parent / "hooks"
+        with tempfile.NamedTemporaryFile() as f:
+
+            def load_hook(name: str):
+                name = samples_path / name
+                with open(name) as f:
+                    data = json.load(f)
+
+                type_name = name.name.replace(".json", "").split("-")[0]
+                return type_name, data
+
+            glob_path = os.getenv("TEST", "*.json")
+
+            n = len([x for x in samples_path.glob(glob_path)])
+            for i, name in enumerate(samples_path.glob(glob_path)):
+                type, data = load_hook(name)
+                type = type.split("-")[0]
+                if i % 20 == 0:
+                    print(f"{i} / {n}")
+                try:
+                    r = asyncio.run(lambda_function.handle_webhook(data, type=type))
+                except Exception as e:
+                    print(f"Failed on {name.name}")
+                    raise e
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/aws/lambda/github-webhook-rds-sync/utils.py
+++ b/aws/lambda/github-webhook-rds-sync/utils.py
@@ -1,0 +1,429 @@
+import json
+import sys
+import pymysql
+import datetime
+import traceback
+import asyncio
+import os
+import hmac
+import hashlib
+import sqlalchemy
+from typing import *
+from urllib.parse import unquote
+
+
+from sqlalchemy import create_engine, schema
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Boolean,
+    DateTime,
+    Table,
+    ForeignKey,
+    JSON,
+    Text,
+)
+
+# We're just going to dump the webhook straight into mysql by flattening out the
+# JSON object and inlining arrays into JSON strings
+FlatDict = Dict[str, Union[str, int]]
+NamedDict = Tuple[str, FlatDict]
+
+
+WEBHOOK_SECRET = os.environ["gh_secret"]
+
+# This marks that a key would store an object (something with a node_id)
+OBJECT_PLACEHOLDER = object()
+
+NAME_MAP = {
+    "id": (str, lambda: Column(String(20))),
+}
+
+TYPE_MAP = {
+    "repository": {
+        "description": lambda: Column(Text),
+        "homepage": lambda: Column(String(300)),
+        "license": lambda: OBJECT_PLACEHOLDER,
+        "mirror_url": lambda: Column(String(300)),
+        "master_branch": lambda: Column(String(300)),
+        "stargazers": lambda: Column(Integer),
+        "organization": lambda: Column(String(300)),
+        "allow_squash_merge": lambda: Column(Boolean),
+        "allow_merge_commit": lambda: Column(Boolean),
+        "allow_rebase_merge": lambda: Column(Boolean),
+        "allow_auto_merge": lambda: Column(Boolean),
+        "delete_branch_on_merge": lambda: Column(Boolean),
+    },
+    "app": {
+        "description": lambda: Column(Text),
+    },
+    "issues_event": {
+        "changes_title_from": lambda: Column(String(300)),
+        "changes_body_from": lambda: Column(Text),
+        "label": lambda: OBJECT_PLACEHOLDER,
+    },
+    "push_event": {
+        "base_ref": lambda: Column(String(300)),
+        "head_commit_message": lambda: Column(Text),
+    },
+    "license": {
+        "url": lambda: Column(String(300)),
+    },
+    "issue": {
+        "assignee": lambda: OBJECT_PLACEHOLDER,
+        "milestone": lambda: OBJECT_PLACEHOLDER,
+        "closed_at": lambda: Column(DateTime),
+        "active_lock_reason": lambda: Column(String(100)),
+        "performed_via_github_app": lambda: Column(Boolean),
+    },
+    "user": {
+        "name": lambda: Column(String(100)),
+        "email": lambda: Column(String(100)),
+    },
+    "enterprise": {
+        "description": lambda: Column(Text),
+        "website_url": lambda: Column(String(300)),
+    },
+    "check_run": {
+        "name": lambda: Column(String(300)),
+        "conclusion": lambda: Column(String(100)),
+        "output_title": lambda: Column(String(100)),
+        "output_summary": lambda: Column(Text),
+        "output_text": lambda: Column(Text),
+    },
+    "workflow_job": {
+        "conclusion": lambda: Column(String(100)),
+    },
+    "create_event": {
+        "description": lambda: Column(String(100)),
+    },
+    "label": {"description": lambda: Column(Text)},
+    "check_suite": {
+        "conclusion": lambda: Column(String(100)),
+        "latest_check_runs_count": lambda: Column(Integer),
+        "before": lambda: Column(String(300)),
+        "after": lambda: Column(String(300)),
+        "head_branch": lambda: Column(String(300)),
+        "head_commit_message": lambda: Column(Text),
+        "head_commit_id": lambda: Column(String(300)),
+        "head_commit_tree_id": lambda: Column(String(300)),
+        "head_commit_timestamp": lambda: Column(DateTime),
+        "head_commit_author_name": lambda: Column(String(300)),
+        "head_commit_author_email": lambda: Column(String(300)),
+        "head_commit_committer_name": lambda: Column(String(300)),
+        "head_commit_committer_email": lambda: Column(String(300)),
+    },
+    "commit": {
+        "commit_verification_signature": lambda: Column(Text),
+        "commit_verification_payload": lambda: Column(Text),
+        "author": lambda: OBJECT_PLACEHOLDER,
+        "committer": lambda: OBJECT_PLACEHOLDER,
+    },
+    "pull_request": {
+        "body": lambda: Column(Text),
+        "milestone": lambda: OBJECT_PLACEHOLDER,
+        "head_repo_description": lambda: Column(Text),
+        "head_repo_homepage": lambda: Column(String(100)),
+        "head_repo_mirror_url": lambda: Column(String(100)),
+        "head_repo_license": lambda: Column(String(100)),
+        "base_repo_description": lambda: Column(Text),
+        "base_repo_homepage": lambda: Column(String(100)),
+        "base_repo_mirror_url": lambda: Column(String(100)),
+        "base_repo_license": lambda: Column(String(100)),
+        "auto_merge": lambda: Column(String(100)),
+        "active_lock_reason": lambda: Column(String(100)),
+        "mergeable": lambda: Column(Boolean),
+        "rebaseable": lambda: Column(Boolean),
+        "merged_by": lambda: Column(String(100)),
+        "merge_commit_sha": lambda: Column(String(100)),
+        "assignee": lambda: OBJECT_PLACEHOLDER,
+    },
+    "pull_request_event": {
+        "changes_title_from": lambda: Column(String(300)),
+        "changes_body_from": lambda: Column(Text),
+    }
+}
+
+TABLE_NAME_REMAP = {
+    "repo": "repository",
+    "committer": "user",
+    "assignee": "user",
+    "author": "user",
+    "requested_reviewer": "user",
+    "owner": "user",
+    "sender": "user",
+}
+
+
+ACCEPTABLE_WEBHOOKS = {
+    "check_suite",
+    "check_run",
+    "pull_request",
+    "issues",
+    "push",
+    "create",
+    "workflow_job",
+    "status",
+}
+
+
+def flatten_object(obj: Dict[str, Any]) -> FlatDict:
+    """
+    Take an object and inline all the fields so it doesn't have any nesting
+    """
+    result = {}
+
+    def helper(curr: Dict[str, Any], name: List[str]):
+        for key, value in curr.items():
+            full_name = "_".join(name + [key])
+            if value is None or isinstance(value, (str, int, bool, list)):
+                result[full_name] = value
+            elif isinstance(value, dict):
+                helper(value, name + [key])
+            else:
+                raise RuntimeError(f"Unknown type on {full_name}: {value}")
+
+    helper(obj, [])
+    return result
+
+
+def extract_github_objects(obj: Dict[str, Any], obj_name: str) -> List[NamedDict]:
+    """
+    GitHub's real 'objects' (i.e. things accessible in the API) all have a
+    unique "node_id" string. This descends into an object and pulls out anything
+    with a node_id and removes it from the parent. It also flattens the objects
+    from a Dict[str, Any] to a Dict[str, str] (with an exception for lists so we
+    still know later on that they're lists and not ordinary strings)
+    """
+    objects = []
+
+    def drop_key(key: str) -> bool:
+        return key.endswith("_url") or key == "_links" or key == "url" or key == "permissions"
+
+    def visit_dict(
+        curr: Dict[str, Any], full_name: List[str]
+    ) -> Tuple[bool, FlatDict]:
+        result = {}
+
+        for key, value in list(curr.items()):
+            # Objects are not always named consistently (e.g. repository vs
+            # repo, owner vs. user, so fix that up here)
+            remapped_key = TABLE_NAME_REMAP.get(key, None)
+            
+            if drop_key(key):
+                # Ignore URLs
+                continue
+
+            if isinstance(value, dict):
+                if remapped_key is not None:
+                    is_gh_object, data = visit_dict(value, full_name + [remapped_key])
+                else:
+                    is_gh_object, data = visit_dict(value, full_name + [key])
+
+                if not is_gh_object:
+                    # Not a separate object so inline all of its fields
+                    for flat_key, flat_value in flatten_object(data).items():
+                        result[f"{key}_{flat_key}"] = flat_value
+                else:
+                    # It will go into its own table so just put a link to it
+                    # here
+                    result[f"{key}_node_id"] = data["node_id"]
+            elif value is None and TYPE_MAP.get(full_name[-1], {}).get(key, lambda: None)() == OBJECT_PLACEHOLDER:
+                # We might have a null object, in which case we still need to
+                # add it as a _node_id
+                result[f"{key}_node_id"] = None
+            else:
+                result[key] = value
+
+        if "node_id" in curr:
+            # It's a github object so stash it for returning later
+            objects.append((full_name[-1], result))
+            return True, curr
+        else:
+            return False, result
+
+    _, newobj = visit_dict(obj, [obj_name])
+
+    # Add an entry for the top level object
+    objects.append((f"{obj_name}_event", flatten_object(newobj)))
+
+    # Add the time of creation for each object
+    for _, object in objects:
+        object["sync_last_update_at"] = datetime.datetime.now()
+
+    return objects
+
+
+def get_column(key: str, value: Any, type_name: str) -> Column:
+    """
+    If the key is present for the webhook type 'type_name' in the hardcoded
+    TYPE_MAP, use it. Otherwise, guess the type based on the value's runtime
+    type.
+    """
+    if isinstance(value, dict):
+        raise RuntimeError(f"Value cannot be a dict: {key}: {value}")
+
+    if key in TYPE_MAP.get(type_name, {}):
+        return TYPE_MAP[type_name][key]()
+
+    if key in NAME_MAP:
+        return NAME_MAP[key][1]()
+
+    if is_date(key, value):
+        return Column(DateTime)
+    if isinstance(value, str):
+        return Column(String(max(30, len(value) * 10)))
+    if isinstance(value, int):
+        return Column(Integer)
+    if isinstance(value, bool):
+        return Column(Boolean)
+    if isinstance(value, list):
+        return Column(JSON)
+    else:
+        # Don't error out immediately, but bubble this up so we can report all
+        # errors at once later
+        # breakpoint()
+        if key.endswith("_node_id"):
+            return get_column(key[:-len("_node_id")], value, type_name)
+        # raise RuntimeError()
+        return None
+
+
+rprint_buffer = ""
+
+
+def rprint(s):
+    global rprint_buffer
+    rprint_buffer += "\n" + str(s)
+
+
+def is_date(key: str, value: Any) -> bool:
+    return key.endswith("_at") or key.endswith("timestamp")
+
+
+def get_primary_key(name: str, obj: FlatDict) -> Tuple[str, Column]:
+    if "node_id" in obj:
+        # if name == "status_event":
+        #     return "node_id", Column(String(100), primary_key=True)
+        return "node_id", Column(String(100), primary_key=True)
+
+    return "pk_id", Column(Integer, primary_key=True)
+
+
+def transform_data(obj: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Run in-place transformations on obj to translate fields into the appropriate
+    type for storage:
+        * lists -> JSON encoded data
+        * dates -> Python datetimes
+    """
+    for key, value in obj.items():
+        if isinstance(value, list):
+            obj[key] = json.dumps(value)
+        elif is_date(key, value) and value is not None:
+            if isinstance(value, int):
+                # convert from timestamp
+                obj[key] = datetime.datetime.fromtimestamp(value)
+            elif isinstance(value, datetime.datetime):
+                obj[key] = value
+            elif isinstance(value, str):
+                formats = ["%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S%z"]
+                date = None
+
+                for format in formats:
+                    try:
+                        date = datetime.datetime.strptime(value, format)
+                    except ValueError:
+                        pass
+
+                if date is None:
+                    raise RuntimeError(value)
+                obj[key] = date
+            else:
+                raise RuntimeError(f"Unknown date type {key}: {value}")
+        elif isinstance(value, str):
+            # TODO: Use utf8mb4 on the DB instead of this which deletes all
+            # unicode chars
+            obj[key] = value.encode("ascii", "ignore").decode()
+
+    for key, item in NAME_MAP.items():
+        caster, _ = item
+        if key in obj:
+            obj[key] = caster(obj[key])
+
+    return obj
+
+
+def generate_orm(name: str, obj: FlatDict, sql_base: Any) -> Any:
+    """
+    Create an instance of a SQLAlchemy ORM class from a dictionary.
+    """
+    columns = {"__tablename__": name, "__table_args__": {"extend_existing": True}}
+    errors = []
+    for key, value in obj.items():
+        col = get_column(key, value, type_name=name)
+        if col is OBJECT_PLACEHOLDER:
+            # There is a null object (with a node_id) missing, so create it as
+            # we would if something was there but leave the value blank
+            columns[f"{key}_node_id"] = Column(String(100))
+        elif col is None:
+            # Unable to find a type for this value. An entry is missing in the
+            # TYPE_MAP for this name.key pair
+            errors.append(f"{name} -> {key}: {value}")
+        else:
+            # Got a column successfully, so set it on the table
+            columns[key] = col
+
+    if len(errors) > 0:
+        # Couldn't get a column type for some of the data, so error out
+        catted_errors = "\n    ".join([f"typeerr: {e}" for e in errors])
+        raise RuntimeError(f"Unknown types:\n{catted_errors}")
+
+    # Change data into the right types for storage
+    obj = transform_data(obj)
+
+    # Fill in any inconsistent / missing columns from the GitHub API
+    # The loop above only looks at the data actually received on the webhook.
+    # Some things may be missing (inconsistencies in GitHub's API or just
+    # doesn't exist), so fill in their types here:
+    for key, column_creator in TYPE_MAP.get(name, {}).items():
+        value = column_creator()
+        if value is OBJECT_PLACEHOLDER:
+            columns[f"{key}_node_id"] = Column(String(50))
+            if key in obj:
+                if obj[key] is not None:
+                    raise RuntimeError(f"not doing it {name}.{key}")
+                else:
+                    del obj[key]
+                    obj[f"{key}_node_id"] = None
+        else:
+            columns[key] = value
+
+    # Set the primary key (some webhooks don't have a node_id at the top level
+    # so set up an auto-incrementing int ID for them)
+    pk_name, pk_type = get_primary_key(name, obj)
+    columns[pk_name] = pk_type
+
+    # Create SQLAlchemy ORM class (which registers it to be created in sql_base)
+    the_class = type(name, (sql_base,), columns)
+    return the_class(**obj)
+
+
+def connection_string():
+    host = os.environ["db_host"]
+    password = os.environ["db_password"]
+    user = os.environ["db_user"]
+
+    return f"mysql+pymysql://{user}:{password}@{host}?charset=utf8mb4"
+
+
+engine = None
+
+
+def get_engine(connection_string: str):
+    global engine
+    if engine is None:
+        engine = create_engine(connection_string, echo=bool(os.getenv("ECHO", False)))
+
+    return engine

--- a/aws/websites/metrics.pytorch.org/files/grafana-provisioning/datasources/mysql.yml
+++ b/aws/websites/metrics.pytorch.org/files/grafana-provisioning/datasources/mysql.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: MySQL
+    type: mysql
+    url: {{ passwords.mysql.host }}
+    database: pytorch
+    user: {{ passwords.mysql.user }}
+    password: {{ passwords.mysql.password }}
+    jsonData:
+      maxOpenConns: 0
+      maxIdleConns: 2
+      connMaxLifetime: 14400


### PR DESCRIPTION
This is a webhook that can receive all GitHub webhooks for a repo and write them into a MySQL DB (the code is mostly db agnostic but uses a MySQL-specific feature to update rows in place).

The webhook handler assumes that the schema is already present in the DB, so if not then `python generate_schema.py` should be used. This reads in a bunch of hooks (the lambda has a flag to gather them to S3).
```bash
cd aws/lambda/github-webhook-rds-sync

# Get hooks from S3 (they're bucketed by day)
mkdir -p hooks
aws s3 sync hooks s3://gha-artifacts/pytorch/pytorch/webhooks/<year>-<month>-<day>

# Generate the schema and write it to a DB
export db_host=...
export db_user=...
export db_password=...
export gh_secret=abc
python generate_schema.py
```

After that the lambda has all it needs to work. The data itself is split into tables based on what GitHub tags as objects. Some items in a webhook payload have a unique `node_id`, which globally identifies something from GitHub (e.g. a user, PR, label). Anything with a `node_id` gets its own table, and anything else is written to that table (with plain objects flattened and lists as JSON fields). You can see some of the data here https://metrics.pytorch.org/d/L0r6ErGnk/github-status?orgId=1 or query the DB directly from Grafana's explore page.