### PR TITLE
Add cuda install to base windows AMIs

### DIFF
--- a/aws/ami/windows/README.md
+++ b/aws/ami/windows/README.md
@@ -2,8 +2,14 @@
 
 Windows AMIs can be built using packer (in this directory) with:
 
+To just test builds:
 ```
-packer build windows.pkr.hcl
+packer build .
+```
+
+To create new AMIs:
+```
+packer build -var 'skip_create_ami=false' .
 ```
 
 They can be found under `us-east-1`  and `us-east-2` with the name prefix of **Windows 2019 GHA CI - {{timestamp}}**

--- a/aws/ami/windows/scripts/Installers/Install-CUDA-Toolkit.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-CUDA-Toolkit.ps1
@@ -1,0 +1,31 @@
+param(
+  [string] $cudaVersion = $env:CUDA_VERSION
+)
+
+$windowsS3BaseUrl = "https://ossci-windows.s3.amazonaws.com"
+
+# Switch statement for specfic CUDA versions
+Switch ($cudaVersion) {
+  "10.2" {
+    $toolkitInstaller = "cuda_10.2.89_441.22_win10.exe"
+    $cudnnZip = "cudnn-10.2-windows10-x64-v7.6.5.32.zip"
+  }
+}
+
+Switch -Wildcard ($cudaVersion) {
+  "10*" {
+    $installerArgs = "nvcc_$cudaVersion cuobjdump_$cudaVersion nvprune_$cudaVersion cupti_$cudaVersion cublas_$cudaVersion cublas_dev_$cudaVersion cudart_$cudaVersion cufft_$cudaVersion cufft_dev_$cudaVersion curand_$cudaVersion curand_dev_$cudaVersion cusolver_$cudaVersion cusolver_dev_$cudaVersion cusparse_$cudaVersion cusparse_dev_$cudaVersion nvgraph_$cudaVersion nvgraph_dev_$cudaVersion npp_$cudaVersion npp_dev_$cudaVersion nvrtc_$cudaVersion nvrtc_dev_$cudaVersion nvml_dev_$cudaVersion"
+  }
+}
+
+Write-Output "Downloading toolkit installer, $windowsS3BaseUrl/$toolkitInstaller"
+$tmpToolkitInstaller = New-TemporaryFile
+Invoke-WebRequest -Uri "$windowsS3BaseUrl/$toolkitInstaller" -OutFile "$tmpToolkitInstaller"
+$tmpExtractedInstaller = New-TemporaryFile | ForEach-Object { Remove-Item $_; New-Item -ItemType Directory -Path $_ }
+7z x "$toolkitInstaller" -o "$tmpExtractedInstaller"
+
+Start-Process -Wait "$tmpExtractedInstaller\setup.exe" -s "$installerArgs"
+
+# Write-Output "Downloading cudnn archive, $windowsS3BaseUrl/$cudnnZip"
+# $tmpCudnnZip = New-TemporaryFile
+# Invoke-WebRequest -Uri $windowsS3BaseUrl/$cudnnZip -OutFile $tmpCudnnZip

--- a/aws/ami/windows/scripts/Installers/Install-CUDA-Tools.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-CUDA-Tools.ps1
@@ -3,12 +3,21 @@ param(
 )
 
 $windowsS3BaseUrl = "https://ossci-windows.s3.amazonaws.com"
+$ProgressPreference = 'SilentlyContinue'
 
 # Switch statement for specfic CUDA versions
 Switch ($cudaVersion) {
   "10.2" {
     $toolkitInstaller = "cuda_10.2.89_441.22_win10.exe"
     $cudnnZip = "cudnn-10.2-windows10-x64-v7.6.5.32.zip"
+  }
+  "11.1" {
+    $toolkitInstaller = "cuda_11.1.0_456.43_win10.exe"
+    $cudnnZip = "cudnn-11.1-windows-x64-v8.0.5.39.zip"
+  }
+  "11.3" {
+    $toolkitInstaller = "cuda_11.3.0_465.89_win10.exe"
+    $cudnnZip = "cudnn-11.3-windows-x64-v8.2.0.53.zip"
   }
 }
 
@@ -27,37 +36,55 @@ function New-TemporaryDirectory() {
 }
 
 function Install-CudaToolkit() {
+  $expectedInstallLocation = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$cudaVersion"
+  if (Test-Path -Path "$expectedInstallLocation" -PathType Container) {
+    Write-Output "Existing cudatoolkit installation already found at '$expectedInstallLocation', continuing..."
+    return
+  }
+
   Write-Output "Downloading toolkit installer, $windowsS3BaseUrl/$toolkitInstaller"
   $tmpToolkitInstaller = New-TemporaryFile
   Invoke-WebRequest -Uri "$windowsS3BaseUrl/$toolkitInstaller" -OutFile "$tmpToolkitInstaller"
   $tmpExtractedInstaller = New-TemporaryDirectory
-  7z x "$toolkitInstaller" -o "$tmpExtractedInstaller"
+  7z x "$tmpToolkitInstaller" -o"$tmpExtractedInstaller"
   $cudaInstallLogs = New-TemporaryDirectory
 
-  Start-Process -Wait "$tmpExtractedInstaller\setup.exe" -s "$installerArgs" -loglevel:6 -log:"$cudaInstallLogs"
-  $expectedInstallLocation = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$cudaVersion"
+  Write-Output "Running installer for CUDA v$cudaVersion..."
+  $argsList = "-s $installerArgs -loglevel:6 -log:$cudaInstallLogs"
+  Write-Output "setup.exe: $tmpExtractedInstaller\setup.exe"
+  Write-Output "Args: $argsList"
+  Start-Process -FilePath "$tmpExtractedInstaller\setup.exe" -ArgumentList "$argsList" -Wait -NoNewWindow -PassThru
   if (-Not (Test-Path -Path "$expectedInstallLocation\bin\nvcc.exe" -PathType Leaf)) {
     Write-Error "CUDA installation failed for CUDA version $cudaVersion, nvcc not found at $expectedInstallLocation\bin\nvcc.exe"
+    Write-Error "==== LOG.RunDll32.exe.log ===="
     Get-Content -Path "$cudaInstallLogs\LOG.RunDll32.exe.log"
+    Write-Error "==== Log.setup.exe.log ===="
     Get-Content -Path "$cudaInstallLogs\LOG.setup.exe.log"
     exit 1
   }
 }
 
 function Install-Cudnn() {
+  $cudnnOutputLocation = "$env:ProgramFiles\NVIDIA GPU Computing Toolkit\CUDA\v$cudaVersion\"
+  if (Test-Path -Path "$cudnnOutputLocation" -PathType Container) {
+    Write-Output "Existing cudnn installation already found at '$cudnnOutputLocation', continuing..."
+    return
+  }
+
   Write-Output "Downloading cudnnArchive, $windowsS3BaseUrl/$cudnnZip"
   $tmpCudnnInstall = New-TemporaryFile
   Invoke-WebRequest -Uri "$windowsS3BaseUrl/$cudnnZip" -OutFile "$tmpCudnnInstall"
   $tmpCudnnExtracted = New-TemporaryDirectory
-  7z x "$toolkitInstaller" -o "$tmpCudnnExtracted"
-
-  Copy-Item -Force -Recurse "$tmpCudnnExtracted\*" "$env:ProgramFiles\NVIDIA GPU Computing Toolkit\CUDA\v$cudaVersion\"
+  7z x "$tmpCudnnInstall" -o"$tmpCudnnExtracted"
+  Write-Output "Copying cudnn to $cudnnOutputLocation"
+  Copy-Item -Force -Verbose -Recurse "$tmpCudnnExtracted\cuda\*" "$cudnnOutputLocation"
 }
 
 function Install-NvTools() {
   $nvToolsLocalPath = "C:\Program Files\NVIDIA Corporation\NvToolsExt"
   # Check if we actually need to do the install
-  if (Test-Path -Path "$nvToolsLocalPath\bin\x64\nvToolsExt64_1.dll" -PathType Leaf) {
+  if (Test-Path -Path "$nvToolsLocalPath" -PathType Container) {
+    Write-Output "Existing nvtools installation already found, continuing..."
     return
   }
   $nvToolsUrl = "https://ossci-windows.s3.amazonaws.com/NvToolsExt.7z"
@@ -65,16 +92,15 @@ function Install-NvTools() {
   Write-Output "Downloading NvTools, $nvToolsUrl"
   Invoke-WebRequest -Uri "$nvToolsUrl" -OutFile "$tmpToolsDl"
   $tmpExtractedNvTools = New-TemporaryDirectory
-  7z x "$tmpToolsDl" -o "$tmpExtractedNvTools"
+  7z x "$tmpToolsDl" -o"$tmpExtractedNvTools"
 
   Write-Output "Copying NvTools, '$tmpExtractedNvTools' -> '$nvToolsLocalPath'"
   New-Item -Path "$nvToolsLocalPath "-ItemType "directory" -Force
   Copy-Item -Recurse -Path "$tmpExtractedNvTools\*" -Destination "$nvToolsLocalPath"
 }
 
-# TODO:
-# - install vs integration
-
 Install-CudaToolkit
 Install-Cudnn
 Install-NvTools
+# Clear out temp files
+Remove-Item -Path "$env:TEMP\*" -Recurse -Force -ErrorAction SilentlyContinue

--- a/aws/ami/windows/scripts/Installers/Install-CUDA-Tools.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-CUDA-Tools.ps1
@@ -5,6 +5,16 @@ param(
 $windowsS3BaseUrl = "https://ossci-windows.s3.amazonaws.com"
 $ProgressPreference = 'SilentlyContinue'
 
+# installerArgs
+Switch -Wildcard ($cudaVersion) {
+  "10*" {
+    $installerArgs = "nvcc_$cudaVersion cuobjdump_$cudaVersion nvprune_$cudaVersion cupti_$cudaVersion cublas_$cudaVersion cublas_dev_$cudaVersion cudart_$cudaVersion cufft_$cudaVersion cufft_dev_$cudaVersion curand_$cudaVersion curand_dev_$cudaVersion cusolver_$cudaVersion cusolver_dev_$cudaVersion cusparse_$cudaVersion cusparse_dev_$cudaVersion nvgraph_$cudaVersion nvgraph_dev_$cudaVersion npp_$cudaVersion npp_dev_$cudaVersion nvrtc_$cudaVersion nvrtc_dev_$cudaVersion nvml_dev_$cudaVersion"
+  }
+  "11*" {
+    $installerArgs = "nvcc_$cudaVersion cuobjdump_$cudaVersion nvprune_$cudaVersion nvprof_$cudaVersion cupti_$cudaVersion cublas_$cudaVersion cublas_dev_$cudaVersion cudart_$cudaVersion cufft_$cudaVersion cufft_dev_$cudaVersion curand_$cudaVersion curand_dev_$cudaVersion cusolver_$cudaVersion cusolver_dev_$cudaVersion cusparse_$cudaVersion cusparse_dev_$cudaVersion npp_$cudaVersion npp_dev_$cudaVersion nvrtc_$cudaVersion nvrtc_dev_$cudaVersion nvml_dev_$cudaVersion"
+  }
+}
+
 # Switch statement for specfic CUDA versions
 Switch ($cudaVersion) {
   "10.2" {
@@ -18,16 +28,8 @@ Switch ($cudaVersion) {
   "11.3" {
     $toolkitInstaller = "cuda_11.3.0_465.89_win10.exe"
     $cudnnZip = "cudnn-11.3-windows-x64-v8.2.0.53.zip"
-  }
-}
-
-# installerArgs
-Switch -Wildcard ($cudaVersion) {
-  "10*" {
-    $installerArgs = "nvcc_$cudaVersion cuobjdump_$cudaVersion nvprune_$cudaVersion cupti_$cudaVersion cublas_$cudaVersion cublas_dev_$cudaVersion cudart_$cudaVersion cufft_$cudaVersion cufft_dev_$cudaVersion curand_$cudaVersion curand_dev_$cudaVersion cusolver_$cudaVersion cusolver_dev_$cudaVersion cusparse_$cudaVersion cusparse_dev_$cudaVersion nvgraph_$cudaVersion nvgraph_dev_$cudaVersion npp_$cudaVersion npp_dev_$cudaVersion nvrtc_$cudaVersion nvrtc_dev_$cudaVersion nvml_dev_$cudaVersion"
-  }
-  "11*" {
-    $installerArgs = "nvcc_$cudaVersion cuobjdump_$cudaVersion nvprune_$cudaVersion nvprof_$cudaVersion cupti_$cudaVersion cublas_$cudaVersion cublas_dev_$cudaVersion cudart_$cudaVersion cufft_$cudaVersion cufft_dev_$cudaVersion curand_$cudaVersion curand_dev_$cudaVersion cusolver_$cudaVersion cusolver_dev_$cudaVersion cusparse_$cudaVersion cusparse_dev_$cudaVersion npp_$cudaVersion npp_dev_$cudaVersion nvrtc_$cudaVersion nvrtc_dev_$cudaVersion nvml_dev_$cudaVersion"
+    # Add thrust for 11.3
+    $installerArgs = "$installerArgs thrust_$cudaVersion"
   }
 }
 

--- a/aws/ami/windows/variables.pkr.hcl
+++ b/aws/ami/windows/variables.pkr.hcl
@@ -1,0 +1,4 @@
+variable "skip_create_ami" {
+  type    = bool
+  default = true
+}

--- a/aws/ami/windows/windows.pkr.hcl
+++ b/aws/ami/windows/windows.pkr.hcl
@@ -67,11 +67,25 @@ build {
     ]
   }
 
-  # Install CUDA Toolkit 10.2
+  # Install CUDA Toolkits
   provisioner "powershell" {
     environment_vars = ["CUDA_VERSION=10.2"]
     scripts = [
-      "${path.root}/scripts/Installers/Install-CUDA-Toolkit.ps1",
+      "${path.root}/scripts/Installers/Install-CUDA-Tools.ps1",
+    ]
+  }
+
+  provisioner "powershell" {
+    environment_vars = ["CUDA_VERSION=11.1"]
+    scripts = [
+      "${path.root}/scripts/Installers/Install-CUDA-Tools.ps1",
+    ]
+  }
+
+  provisioner "powershell" {
+    environment_vars = ["CUDA_VERSION=11.3"]
+    scripts = [
+      "${path.root}/scripts/Installers/Install-CUDA-Tools.ps1",
     ]
   }
 }

--- a/aws/ami/windows/windows.pkr.hcl
+++ b/aws/ami/windows/windows.pkr.hcl
@@ -23,13 +23,14 @@ source "amazon-ebs" "windows_ebs_builder" {
     device_name           = "/dev/sda1"
     volume_size           = 64
   }
-  source_ami     = "${data.amazon-ami.windows_root_ami.id}"
-  region         = "us-east-1"
-  ami_regions    = ["us-east-1", "us-east-2"]
-  user_data_file = "user-data-scripts/bootstrap-winrm.ps1"
-  winrm_insecure = true
-  winrm_use_ssl  = true
-  winrm_username = "Administrator"
+  source_ami      = "${data.amazon-ami.windows_root_ami.id}"
+  region          = "us-east-1"
+  ami_regions     = ["us-east-1", "us-east-2"]
+  user_data_file  = "user-data-scripts/bootstrap-winrm.ps1"
+  winrm_insecure  = true
+  winrm_use_ssl   = true
+  winrm_username  = "Administrator"
+  skip_create_ami = var.skip_create_ami
   aws_polling {
     # For some reason the AMIs take a really long time to be ready so just assume it'll take a while
     max_attempts = 600
@@ -66,4 +67,11 @@ build {
     ]
   }
 
+  # Install CUDA Toolkit 10.2
+  provisioner "powershell" {
+    environment_vars = ["CUDA_VERSION=10.2"]
+    scripts = [
+      "${path.root}/scripts/Installers/Install-CUDA-Toolkit.ps1",
+    ]
+  }
 }


### PR DESCRIPTION
Basically just a rewrite of this: https://github.com/pytorch/builder/blob/master/windows/internal/cuda_install.bat in powershell

TODO:
- [x] Create script to install all of things that https://github.com/pytorch/builder/blob/master/windows/internal/cuda_install.bat currently installs
- [x] Verify that the packer build works
- [x] Land change to skip install on `pytorch/pytorch` if existing (https://github.com/pytorch/pytorch/pull/64825)
- [x] Deploy AMI to canary environment for test
- [ ] Deploy AMI to prod environment

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>