### PR TITLE
Sort disabled_tests.json to reduce commits

### DIFF
--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -16,6 +16,18 @@ jobs:
           # score changes every request, so we strip it out to avoid creating a commit every time we query.
           curl 'https://api.github.com/search/issues?q=is%3Aissue+is%3Aopen+repo:pytorch/pytorch+in%3Atitle+DISABLED' \
           | sed 's/"score": [0-9\.]*/"score": 0.0/g' > disabled-tests.json
+      - name: Sort disabled-tests.json
+        shell: python
+        run: |
+          import json
+          with open('disabled_tests.json') as file:
+            disabled_tests_json = json.load(file)
+
+          # Sort the items (disabled tests) by their URL
+          disabled_tests_json['items'].sort(key=lambda x: x['url'])
+
+          with open('disabled_tests.json', mode='w') as file:
+              json.dump(disabled_tests_json, file, sort_keys=True, indent=2)
       - name: Push file to test-infra repository
         uses: dmnemec/copy_file_to_another_repo_action@5f40763ccee2954067adba7fb8326e4df33bcb92
         env:

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -23,7 +23,7 @@ jobs:
           with open('disabled_tests.json') as file:
             disabled_tests_json = json.load(file)
 
-          # Sort the items (disabled tests) by their URL
+          # Sort disabled test issues by URL, e.g., https://api.github.com/repos/pytorch/pytorch/issues/38491
           disabled_tests_json['items'].sort(key=lambda x: x['url'])
 
           with open('disabled_tests.json', mode='w') as file:


### PR DESCRIPTION
Fixes #93

Test plan:
A snippet of the current disabled_tests.json getting sorted would be:
```
{
  "incomplete_results": false,
  "items": [
    {
      "active_lock_reason": null,
      "assignee": null,
      "assignees": [],
      "author_association": "CONTRIBUTOR",
      "body": "https://app.circleci.com/pipelines/github/pytorch/pytorch/169923/workflows/d66ca278-d55c-462b-96cb-55623ce713f7/jobs/5472514/steps\r\n\r\n```\r\nMay 14 07:37:27 =================================== FAILURES ===================================\r\nMay 14 07:37:27 ______________ ParallelWorkersTest.testParallelWorkersShutdownFun ______________\r\nMay 14 07:37:27 \r\nMay 14 07:37:27 self = <caffe2.python.parallel_workers_test.ParallelWorkersTest testMethod=testParallelWorkersShutdownFun>\r\nMay 14 07:37:27 \r\nMay 14 07:37:27     def testParallelWorkersShutdownFun(self):\r\nMay 14 07:37:27         workspace.ResetWorkspace()\r\nMay 14 07:37:27     \r\nMay 14 07:37:27         queue = create_queue()\r\nMay 14 07:37:27         dummy_worker = create_worker(queue, lambda worker_id: str(worker_id))\r\nMay 14 07:37:27         workspace.FeedBlob('data', 'not shutdown')\r\nMay 14 07:37:27     \r\nMay 14 07:37:27         def shutdown_fun():\r\nMay 14 07:37:27             workspace.FeedBlob('data', 'shutdown')\r\nMay 14 07:37:27     \r\nMay 14 07:37:27         worker_coordinator = parallel_workers.init_workers(\r\nMay 14 07:37:27             dummy_worker, shutdown_fun=shutdown_fun\r\nMay 14 07:37:27         )\r\nMay 14 07:37:27         worker_coordinator.start()\r\nMay 14 07:37:27     \r\nMay 14 07:37:27 >       self.assertTrue(worker_coordinator.stop())\r\nMay 14 07:37:27 E       AssertionError: False is not true\r\nMay 14 07:37:27 \r\nMay 14 07:37:27 ../.local/lib/python3.6/site-packages/caffe2/python/parallel_workers_test.py:116: AssertionError\r\nMay 14 07:37:27 ----------------------------- Captured stdout call -----------------------------\r\n```\n\ncc @ezyang @gchanan @zou3519 @bdhirsh @jbschlosser @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @agolynski @SciPioneer @H-Huang @mrzzd @cbalioglu @houseroad @spandantiwari @lara-hdr @BowenBao @neginraoof",
      "closed_at": null,
      "comments": 0,
      "comments_url": "https://api.github.com/repos/pytorch/pytorch/issues/38491/comments",
      "created_at": "2020-05-14T17:45:34Z",
      "events_url": "https://api.github.com/repos/pytorch/pytorch/issues/38491/events",
      "html_url": "https://github.com/pytorch/pytorch/issues/38491",
      "id": 618421559,
      "labels": [
        {
          "color": "F22613",
          "default": false,
          "description": null,
          "id": 443484135,
          "name": "high priority",
          "node_id": "MDU6TGFiZWw0NDM0ODQxMzU=",
          "url": "https://api.github.com/repos/pytorch/pytorch/labels/high%20priority"
        },
        {
          "color": "cc317c",
          "default": false,
          "description": "",
          "id": 466131885,
          "name": "triage review",
          "node_id": "MDU6TGFiZWw0NjYxMzE4ODU=",
          "url": "https://api.github.com/repos/pytorch/pytorch/labels/triage%20review"
        },
        {
          "color": "f7e101",
          "default": false,
          "description": "Add this issue/PR to distributed oncall triage queue",
          "id": 679953883,
          "name": "oncall: distributed",
          "node_id": "MDU6TGFiZWw2Nzk5NTM4ODM=",
          "url": "https://api.github.com/repos/pytorch/pytorch/labels/oncall:%20distributed"
        },
        {
          "color": "006b75",
          "default": false,
          "description": "This issue has been looked at a team member, and triaged and prioritized into an appropriate module",
          "id": 1301347167,
          "name": "triaged",
          "node_id": "MDU6TGFiZWwxMzAxMzQ3MTY3",
          "url": "https://api.github.com/repos/pytorch/pytorch/labels/triaged"
        },
        {
          "color": "f7e101",
          "default": false,
          "description": "Problem is a flaky test in CI",
          "id": 1301397902,
          "name": "module: flaky-tests",
          "node_id": "MDU6TGFiZWwxMzAxMzk3OTAy",
          "url": "https://api.github.com/repos/pytorch/pytorch/labels/module:%20flaky-tests"
        }
      ],
      "labels_url": "https://api.github.com/repos/pytorch/pytorch/issues/38491/labels{/name}",
      "locked": false,
      "milestone": null,
      "node_id": "MDU6SXNzdWU2MTg0MjE1NTk=",
      "number": 38491,
      "performed_via_github_app": null,
      "repository_url": "https://api.github.com/repos/pytorch/pytorch",
      "score": 0.0,
      "state": "open",
      "title": "DISABLED ParallelWorkersTest.testParallelWorkersShutdownFun ",
      "updated_at": "2021-02-25T21:37:31Z",
      "url": "https://api.github.com/repos/pytorch/pytorch/issues/38491",
      "user": {
        "avatar_url": "https://avatars.githubusercontent.com/u/16999635?v=4",
        "events_url": "https://api.github.com/users/mrshenli/events{/privacy}",
        "followers_url": "https://api.github.com/users/mrshenli/followers",
        "following_url": "https://api.github.com/users/mrshenli/following{/other_user}",
        "gists_url": "https://api.github.com/users/mrshenli/gists{/gist_id}",
        "gravatar_id": "",
        "html_url": "https://github.com/mrshenli",
        "id": 16999635,
        "login": "mrshenli",
        "node_id": "MDQ6VXNlcjE2OTk5NjM1",
        "organizations_url": "https://api.github.com/users/mrshenli/orgs",
        "received_events_url": "https://api.github.com/users/mrshenli/received_events",
        "repos_url": "https://api.github.com/users/mrshenli/repos",
        "site_admin": false,
        "starred_url": "https://api.github.com/users/mrshenli/starred{/owner}{/repo}",
        "subscriptions_url": "https://api.github.com/users/mrshenli/subscriptions",
        "type": "User",
        "url": "https://api.github.com/users/mrshenli"
      }
    },
```