### PR TITLE
Add RDS proxy lambda

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 **/.terraform.lock.hcl linguist-generated=true
+.github/workflows/generated-*.yml linguist-generated=true

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import jinja2
+import os
+from typing import Dict
+
+
+DOCKER_REGISTRY = "308535385114.dkr.ecr.us-east-1.amazonaws.com"
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+GITHUB_DIR = REPO_ROOT / ".github"
+
+
+@dataclass
+class CIWorkflow:
+    name: str
+
+    def generate_workflow_file(self, workflow_template: jinja2.Template) -> None:
+        output_file_path = (
+            GITHUB_DIR / f"workflows/generated-{self.name}.yml"
+        )
+        with open(output_file_path, "w") as output_file:
+            generated = "generated"  # Note that please keep the variable generated otherwise phabricator will hide the whole file
+
+            filename = Path(workflow_template.filename).relative_to(REPO_ROOT)
+            output_file.write(f"# @{generated} DO NOT EDIT MANUALLY\n")
+            output_file.write(f"# Generated from {filename}\n")
+            output_file.write(workflow_template.render(asdict(self)))
+            output_file.write("\n")
+        print(output_file_path)
+
+
+@dataclass
+class ZipLambda(CIWorkflow):
+    timeout: int
+
+
+ZIP_LAMBDAS = [
+    ZipLambda(name="github_webhook_rds_sync", timeout=3),
+    ZipLambda(name="checks-cron", timeout=3),
+    ZipLambda(name="rds-proxy", timeout=3),
+]
+
+
+if __name__ == "__main__":
+    jinja_env = jinja2.Environment(
+        variable_start_string="!{{",
+        loader=jinja2.FileSystemLoader(str(GITHUB_DIR.joinpath("templates"))),
+    )
+    template_and_workflows = [
+        (jinja_env.get_template("deploy_lambda.yml.j2"), ZIP_LAMBDAS),
+    ]
+    # Delete the existing generated files first, this should align with .gitattributes file description.
+    existing_workflows = GITHUB_DIR.glob("workflows/generated-*")
+    for w in existing_workflows:
+        try:
+            os.remove(w)
+        except Exception as e:
+            print(f"Error occurred when deleting file {w}: {e}")
+
+    for template, workflows in template_and_workflows:
+        for workflow in workflows:
+            workflow.generate_workflow_file(workflow_template=template)
+

--- a/.github/templates/deploy_lambda.yml.j2
+++ b/.github/templates/deploy_lambda.yml.j2
@@ -1,12 +1,17 @@
-name: lambda_checks_cron
+name: Deploy !{{ name }}
 
 on:
   push:
     branches:
-      - main
+      - master
     paths:
-      - '.github/workflows/lambda_checks_cron.yml'
-      - 'aws/lambda/checks-cron/**'
+      - '.github/templates/deploy_lambda.yml.j2'
+      - 'aws/lambda/!{{ name }}/**'
+
+
+concurrency:
+  group: Deploy !{{ name }}
+  cancel-in-progress: true
 
 jobs:
   deploy:
@@ -16,14 +21,14 @@ jobs:
         uses: actions/checkout@v2
       - name: Build
         run: |
-          cd aws/lambda/checks-cron
-          make deployment.zip
+          cd aws/lambda/!{{ name }}
+          make deployment
       - name: Deploy
         uses: appleboy/lambda-action@1e05c1377056f21ebb2ce69b910bc16b943c2a66
         with:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-1
-          function_name: github-checks-status-updater
-          timeout: 15
-          zip_file: aws/lambda/checks-cron/deployment.zip
+          function_name: !{{ name }}-app
+          timeout: !{{ timeout }}
+          zip_file: aws/lambda/!{{ name }}/deployment.zip

--- a/.github/workflows/generated-checks-cron.yml
+++ b/.github/workflows/generated-checks-cron.yml
@@ -1,0 +1,36 @@
+# @generated DO NOT EDIT MANUALLY
+# Generated from .github/templates/deploy_lambda.yml.j2
+name: Deploy checks-cron
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/templates/deploy_lambda.yml.j2'
+      - 'aws/lambda/checks-cron/**'
+
+
+concurrency:
+  group: Deploy checks-cron
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cd aws/lambda/checks-cron
+          make deployment
+      - name: Deploy
+        uses: appleboy/lambda-action@1e05c1377056f21ebb2ce69b910bc16b943c2a66
+        with:
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: us-east-1
+          function_name: checks-cron-app
+          timeout: 3
+          zip_file: aws/lambda/checks-cron/deployment.zip

--- a/.github/workflows/generated-github_webhook_rds_sync.yml
+++ b/.github/workflows/generated-github_webhook_rds_sync.yml
@@ -1,16 +1,18 @@
-name: Deploy github-webhook-rds-sync
+# @generated DO NOT EDIT MANUALLY
+# Generated from .github/templates/deploy_lambda.yml.j2
+name: Deploy github_webhook_rds_sync
 
 on:
   push:
     branches:
       - master
     paths:
-      - '.github/workflows/lambda_github_log_webhook.yml'
-      - 'aws/lambda/github-logs-webhook/**'
+      - '.github/templates/deploy_lambda.yml.j2'
+      - 'aws/lambda/github_webhook_rds_sync/**'
 
 
 concurrency:
-  group: Deploy github-logs-webhook
+  group: Deploy github_webhook_rds_sync
   cancel-in-progress: true
 
 jobs:
@@ -21,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Build
         run: |
-          cd aws/lambda/github-logs-webhook
+          cd aws/lambda/github_webhook_rds_sync
           make deployment
       - name: Deploy
         uses: appleboy/lambda-action@1e05c1377056f21ebb2ce69b910bc16b943c2a66
@@ -29,6 +31,6 @@ jobs:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-1
-          function_name: github-checks-status-updater
-          timeout: 15
-          zip_file: aws/lambda/github-logs-webhook/deployment.zip
+          function_name: github_webhook_rds_sync-app
+          timeout: 3
+          zip_file: aws/lambda/github_webhook_rds_sync/deployment.zip

--- a/.github/workflows/generated-rds-proxy.yml
+++ b/.github/workflows/generated-rds-proxy.yml
@@ -1,0 +1,36 @@
+# @generated DO NOT EDIT MANUALLY
+# Generated from .github/templates/deploy_lambda.yml.j2
+name: Deploy rds-proxy
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/templates/deploy_lambda.yml.j2'
+      - 'aws/lambda/rds-proxy/**'
+
+
+concurrency:
+  group: Deploy rds-proxy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cd aws/lambda/rds-proxy
+          make deployment
+      - name: Deploy
+        uses: appleboy/lambda-action@1e05c1377056f21ebb2ce69b910bc16b943c2a66
+        with:
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: us-east-1
+          function_name: rds-proxy-app
+          timeout: 3
+          zip_file: aws/lambda/rds-proxy/deployment.zip

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ aws/websites/metrics.pytorch.org/vars.yml
 
 aws/lambda/github-webhook-rds-sync/python/*
 aws/lambda/github-webhook-rds-sync/hooks/*
+aws/lambda/rds-proxy/python/*

--- a/aws/lambda/github-webhook-rds-sync/generate_schema.py
+++ b/aws/lambda/github-webhook-rds-sync/generate_schema.py
@@ -22,16 +22,11 @@ from utils import (
     generate_orm,
     get_engine,
     connection_string,
-    ACCEPTABLE_WEBHOOKS,
 )
 
 
 async def update_schema_for(payload: Dict[str, Any], webhook: str):
     Base = declarative_base()
-
-    # Only look at allowlisted webhooks
-    if webhook not in ACCEPTABLE_WEBHOOKS:
-        return {"statusCode": 200, "body": f"not processing {webhook}"}
 
     # Marshal JSON into SQL-able data
     objects = extract_github_objects(payload, webhook)
@@ -50,15 +45,13 @@ if __name__ == "__main__":
     webhooks = defaultdict(dict)
 
     # Go over and combine all webhooks of the same type
-    n = len([x for x in samples_path.glob("*.json")])
-    for i, name in enumerate(samples_path.glob("*.json")):
+    n = len([x for x in samples_path.glob("*/*.json")])
+    for i, name in enumerate(samples_path.glob("*/*.json")):
         if i % 1000 == 0:
             print(f"{i} / {n}")
 
         webhook = name.name.replace(".json", "").split("-")[0]
         name = samples_path / name
-        if webhook not in ACCEPTABLE_WEBHOOKS:
-            continue
 
         with open(name) as f:
             data = json.load(f)

--- a/aws/lambda/rds-proxy/Makefile
+++ b/aws/lambda/rds-proxy/Makefile
@@ -4,7 +4,7 @@ deployment:
 	zip -g deployment.zip lambda_function.py utils.py
 
 manual_update:
-	aws lambda update-function-code --function-name github-webhook-rds-sync-app --zip-file fileb://deployment.zip
+	aws lambda update-function-code --function-name rds-proxy --zip-file fileb://deployment.zip
 
 clean:
 	rm -rf deployment.zip python

--- a/aws/lambda/rds-proxy/lambda_function.py
+++ b/aws/lambda/rds-proxy/lambda_function.py
@@ -1,0 +1,298 @@
+"""
+This adds a lambda to handle reading / writing to our RDS MySQL instance that we can access from the EC2 runners in CI. Similar to scribe-proxy, this means we can write on pull requests without a secret and also run queries to plan tests / etc.
+"""
+import json
+import datetime
+import os
+from typing import *
+from contextlib import closing
+import re
+
+
+import mysql.connector
+
+
+_connections = {
+    "reader": {
+        "connection": None,
+        "user": "db_user",
+        "password": "db_password",
+        "database": "pytorch",
+    },
+    "inserter": {
+        "connection": None,
+        "user": "db_user_inserter",
+        "password": "db_password_inserter",
+        "database": "metrics",
+    },
+    "creator": {
+        "connection": None,
+        "user": "db_user_creator",
+        "password": "db_password_creator",
+        "database": "metrics",
+    },
+}
+
+
+def get_connection(name: str):
+    field = _connections[name]
+
+    if field["connection"] is None:
+        field["connection"] = mysql.connector.connect(
+            host=os.environ["db_host"],
+            port=3306,
+            user=os.environ[field["user"]],
+            password=os.environ[field["password"]],
+            database=field["database"],
+        )
+
+    return field["connection"]
+
+
+SAVED_QUERIES = {"sample": "select name from workflow_run limit 10"}
+
+TYPE_MAP = {
+    "int": "INTEGER",
+    "string": "VARCHAR(300)",
+}
+
+
+NAME_REGEX = re.compile("^[a-z_]+$")
+
+
+def validate_schema_name(s: str):
+    if NAME_REGEX.match(s) is not None:
+        return s
+    else:
+        raise RuntimeError(f"Invalid name: {s}")
+
+
+def safe_join(s: Union[str, List[str]], join_str: str = ", ") -> str:
+    if isinstance(s, str):
+        s = [s]
+
+    return join_str.join([validate_schema_name(x) for x in s])
+
+
+def build_query(body):
+    # If the request is a simple query we can just build it manually rather
+    # than having to hard code it in the list above
+    params = []
+    table_name = validate_schema_name(body["table_name"])
+
+    query = f"SELECT {safe_join(body['fields'])} FROM {safe_join(table_name)}"
+
+    where = body.get("where", None)
+    if where is not None:
+        if not isinstance(where, list):
+            where = [where]
+        for item in where:
+            item["field"] = validate_schema_name(item["field"])
+        query += " WHERE"
+        items = [f"{n['field']} {'like' if n['like'] else '='} %s" for n in where]
+        query += f" {' and '.join(items)}"
+        params += [n["value"] for n in where]
+
+    group_by = body.get("group_by", None)
+    if group_by is not None:
+        query += f" GROUP BY {safe_join(group_by)}"
+
+    order_by = body.get("order_by", None)
+    if order_by is not None:
+        query += f" ORDER BY {safe_join(order_by)}"
+
+    limit = body.get("limit", None)
+    if limit is not None:
+        query += f" LIMIT %s"
+        params.append(int(limit))
+
+    return query, params
+
+
+def run_query(query: str, params: List[str], connection: Any) -> List[Dict[str, str]]:
+    print(f"Executing '{query}' with params: {params}")
+    if "--" in query:
+        raise RuntimeError("No -- allowed")
+
+    with closing(connection.cursor(dictionary=True)) as cursor:
+        cursor.execute(query, params)
+        return [row for row in cursor]
+
+
+def run_write(write):
+    # Insert a record into a table
+    name = validate_schema_name(write["table_name"])
+    fields = {
+        validate_schema_name(field): value for field, value in write["values"].items()
+    }
+    fields["updated_at"] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    names = ", ".join([k for k in fields.keys()])
+
+    # Here we can actually use parameterized queries, so don't put the actual
+    # values
+    placeholders = ", ".join(["%s" for _ in range(len(fields))])
+    query = f"INSERT INTO {name}({names}) VALUES ({placeholders})"
+    params = [v for v in fields.values()]
+
+    conn = get_connection("inserter")
+    res = run_query(query, params, conn)
+    conn.commit()
+    return res
+
+
+def run_create_table(create_table):
+    name = validate_schema_name(create_table["table_name"])
+
+    def mquery(sql):
+        return run_query(sql, [], get_connection("creator"))
+
+    # Validate all the field names since we have to insert them directly
+    fields = {
+        validate_schema_name(field): TYPE_MAP[validate_schema_name(type)]
+        for field, type in create_table["fields"].items()
+    }
+    # Add a marker of when this data was inserted
+    fields["updated_at"] = "DATETIME"
+
+    if "id" in fields:
+        raise RuntimeError(f"Cannot use name 'id': {fields}")
+
+    # SQL returns schema types a little different from how they're specified, so
+    # fix that up here
+    def clean_type(s):
+        if s == "int(11)":
+            return "integer".upper()
+        return s.upper()
+
+    try:
+        # Check if the table exists
+        schema = mquery(f"DESCRIBE {name}")
+        existing_fields = {x["Field"]: x["Type"] for x in schema}
+        existing_fields = {
+            field: clean_type(type) for field, type in existing_fields.items()
+        }
+
+        # Make sure every requested field in the DB is there and the type
+        # matches, and fix it if not
+        for field, type in fields.items():
+            if field not in existing_fields:
+                print(f"Adding new field {field}")
+                mquery(f"ALTER TABLE {name} ADD COLUMN {field} {type}")
+            elif existing_fields[field] != type:
+                print(f"Modifying {field}")
+                mquery(f"ALTER TABLE {name} MODIFY {field} {type}")
+
+    except mysql.connector.errors.ProgrammingError as e:
+        if not str(e).endswith(f"Table 'metrics.{name}' doesn't exist"):
+            raise e
+
+        # The table isn't there at all and we need to create it from scratch
+        field_queries = [f"{field} {type}" for field, type in fields.items()]
+        create_table_query = f"""
+            CREATE TABLE {name} (
+                id INTEGER AUTO_INCREMENT,
+                {', '.join(field_queries)},
+                PRIMARY KEY (id)
+            );
+        """.strip()
+        print(create_table_query)
+        mquery(create_table_query)
+
+
+def run_read(read):
+    # If the query is in the list of hardcoded queries, just use that
+    print(f"Executing read {read}")
+    saved_query_name = read.get("saved_query_name", None)
+    params = read.get("params", [])
+    saved_query = SAVED_QUERIES.get(saved_query_name, None)
+    if saved_query is not None:
+        results = run_query(saved_query, params, get_connection("reader"))
+    else:
+        # Build a SQL query ad-hoc and run it
+        query, params = build_query(read)
+        results = run_query(query, params, get_connection("reader"))
+
+    print("Fetched", results)
+    return json.dumps(results, default=str)
+
+
+def handle_event(event):
+    print("Handling event", event)
+    create_table = event.get("create_table", None)
+    if create_table is not None:
+        # Create the table if requests, gated behind a killswitch since we
+        # shouldn't need this to be on all the time
+        if os.environ.get("create_enabled", False) == "1":
+            return run_create_table(create_table)
+        else:
+            return "create is disabled"
+
+    write = event.get("write", None)
+    if write is not None:
+        return run_write(write)
+
+    read = event.get("read", None)
+    if read is not None:
+        return run_read(read)
+
+
+def lambda_handler(events, context):
+    """
+    Takes in a list of "events", which are actions for the lambda to do on MySQL
+
+    Create: make a table or alter an existing table
+        {
+            "create_table": {
+                "table_name": "my_table",
+                "fields": {
+                    "something": "int",
+                    "something_else": "string",
+                },
+            }
+        }
+
+    Write: insert a record into a metrics table
+        {
+            "create_table": {
+                "table_name": "my_table",
+                "fields": {
+                    "something": "int",
+                    "something_else": "string",
+                },
+            }
+        }
+
+    Read: query the pytorch database (everything after "fields" is optional)
+        {
+            "read": {
+                "table_name": "my_table",
+                "fields": ["something", "something_else"],
+                "where": [
+                    {
+                        "field": "something",
+                        "value": 10
+                    }
+                ],
+                "group_by": ["something"],
+                "order_by": ["something"],
+                "limit": 5,
+            }
+        }
+
+        or use a hardcoded query
+
+        {
+            "read": {
+                "saved_query_name": "sample",
+            }
+        }
+    """
+    print("Handling", events)
+
+    # Run over all the requests and collate the results
+    results = []
+    for event in events:
+        results.append(handle_event(event))
+
+    print(results)
+    return results


### PR DESCRIPTION
This adds a lambda to handle reading / writing to our RDS MySQL instance that we can access from the EC2 runners in CI. Similar to scribe-proxy, this means we can write on pull requests without a secret and also run queries to plan tests / etc.

This API has 3 functions:
1. `create`: register a new table with a particular schema. if a new `create` comes along with a different schema then the table will be updated to be the union of the two.
2. `write`: insert a record into a table
3. `read`: run a simple query that follows a regular pattern (`select X from Y limit Z`) or run a hardcoded, more complex query by name.
Sadly you can't parameterize parts of queries over schemas, so we're stuck doing raw string interpolation before running things on the DB. Risk is mitigated here by some restrictive checks (user supplied data can only be ascii + '_') and fine grained permissions for each API.

This also adds some light templating, mostly copied from pytorch/pytorch to use Jinja2 to generate our lambda deploy workflows.

Also see the corresponding PyTorch PR: https://github.com/pytorch/pytorch/pull/64303