### PR TITLE
Update pep503_whl_redirect

### DIFF
--- a/aws/websites/download.pytorch.org/pep503_whl_redirect.js
+++ b/aws/websites/download.pytorch.org/pep503_whl_redirect.js
@@ -2,9 +2,16 @@ function handler(event) {
     var request = event.request;
     var uri = request.uri;
     
-    // Check whether the URI is missing a file name.
-    if (uri.startsWith('/whl') && uri.endsWith('/')) {
-        request.uri += 'index.html';
+    if (uri.startsWith('/whl')) {
+        // Check whether the URI is missing a file name.
+        if (uri.endsWith('/')) {
+            request.uri += 'index.html';
+        // Check whether the URI is folder like
+        // I.e. does not have dots in path
+        // For example /whl/cpu/torch
+        } else if (uri.indexOf('.') == -1) {
+            request.uri += '/index.html';
+        }
     } 
 
     return request;


### PR DESCRIPTION
Assume that every path that starts with 'whl/' and does not contain dots
is some folder inside S3

Fixes https://github.com/pytorch/pytorch/issues/63098
