### PR TITLE
Fix sync-pytorch-canary by using force push

### DIFF
--- a/.github/workflows/sync_pytorch_canary.yml
+++ b/.github/workflows/sync_pytorch_canary.yml
@@ -40,4 +40,4 @@ jobs:
           #   git push --tags git@github.com:pytorch/pytorch-canary.git
           #   git branch -a --format "%(refname)" | xargs -i bash -c "git symbolic-ref HEAD {} && git push git@github.com:pytorch/pytorch-canary"
           # OR we could just settle with pushing master. So we'll do that instead.
-          git push git@github.com:pytorch/pytorch-canary master
+          git push -f git@github.com:pytorch/pytorch-canary master

--- a/.github/workflows/sync_pytorch_canary.yml
+++ b/.github/workflows/sync_pytorch_canary.yml
@@ -26,6 +26,7 @@ jobs:
           ref: 'master'
           submodules: 'recursive'
           path: 'pytorch'
+          fetch-depth: 0  # pushing master requires nonshallow checkout
       - name: Mirror push to pytorch/pytorch-canary
         run: |
           set -eu


### PR DESCRIPTION
Our workflows (https://github.com/pytorch/test-infra/runs/3603114635?check_suite_focus=true) are failing with 
```
To github.com:pytorch/pytorch-canary
 ! [rejected]        master -> master (fetch first)
error: failed to push some refs to 'github.com:pytorch/pytorch-canary'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```

Because I locally pushed those changes when testing. Are we okay with doing a force push here?