### PR TITLE
Update dashboards before deploying

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -1,57 +1,60 @@
 #!/usr/bin/env python3
 
-from dataclasses import asdict, dataclass
 from pathlib import Path
 
 import jinja2
 import os
-from typing import Dict
+from typing import Any
 
 
-DOCKER_REGISTRY = "308535385114.dkr.ecr.us-east-1.amazonaws.com"
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 GITHUB_DIR = REPO_ROOT / ".github"
 
 
-@dataclass
 class CIWorkflow:
     name: str
+    template: str
+
+    def __init__(self, name: str, template: str, **kwargs: Any) -> None:
+        self.name = name
+        self.template = template
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
     def generate_workflow_file(self, workflow_template: jinja2.Template) -> None:
-        output_file_path = (
-            GITHUB_DIR / f"workflows/generated-{self.name}.yml"
-        )
+        output_file_path = GITHUB_DIR / f"workflows/generated-{self.name}.yml"
         with open(output_file_path, "w") as output_file:
-            generated = "generated"  # Note that please keep the variable generated otherwise phabricator will hide the whole file
-
             filename = Path(workflow_template.filename).relative_to(REPO_ROOT)
-            output_file.write(f"# @{generated} DO NOT EDIT MANUALLY\n")
+            output_file.write("# @generated DO NOT EDIT MANUALLY\n")
             output_file.write(f"# Generated from {filename}\n")
-            output_file.write(workflow_template.render(asdict(self)))
+            output_file.write(workflow_template.render(self.__dict__))
             output_file.write("\n")
-        print(output_file_path)
+        print("Wrote", output_file_path.relative_to(REPO_ROOT))
 
 
-@dataclass
-class ZipLambda(CIWorkflow):
-    timeout: int
-
-
-ZIP_LAMBDAS = [
-    ZipLambda(name="github_webhook_rds_sync", timeout=3),
-    ZipLambda(name="checks-cron", timeout=3),
-    ZipLambda(name="rds-proxy", timeout=3),
+WORKFLOWS = [
+    CIWorkflow(
+        template="deploy_lambda.yml.j2", name="github_webhook_rds_sync", timeout=3
+    ),
+    CIWorkflow(template="deploy_lambda.yml.j2", name="checks-cron", timeout=3),
+    CIWorkflow(template="deploy_lambda.yml.j2", name="rds-proxy", timeout=3),
+    CIWorkflow(
+        template="metrics_pytorch_org.yml.j2", name="metrics-pytorch-org", timeout=3
+    ),
+    CIWorkflow(
+        template="update_grafana_dashboards.yml.j2",
+        name="update-grafana-dashboards",
+        timeout=3,
+    ),
 ]
 
 
 if __name__ == "__main__":
     jinja_env = jinja2.Environment(
         variable_start_string="!{{",
-        loader=jinja2.FileSystemLoader(str(GITHUB_DIR.joinpath("templates"))),
+        loader=jinja2.FileSystemLoader(str(GITHUB_DIR / "templates")),
     )
-    template_and_workflows = [
-        (jinja_env.get_template("deploy_lambda.yml.j2"), ZIP_LAMBDAS),
-    ]
+
     # Delete the existing generated files first, this should align with .gitattributes file description.
     existing_workflows = GITHUB_DIR.glob("workflows/generated-*")
     for w in existing_workflows:
@@ -60,7 +63,6 @@ if __name__ == "__main__":
         except Exception as e:
             print(f"Error occurred when deleting file {w}: {e}")
 
-    for template, workflows in template_and_workflows:
-        for workflow in workflows:
-            workflow.generate_workflow_file(workflow_template=template)
-
+    for workflow in WORKFLOWS:
+        template = jinja_env.get_template(workflow.template)
+        workflow.generate_workflow_file(workflow_template=template)

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -1,0 +1,29 @@
+{%- macro update_dashboards_job() -%}
+  update-dashboards:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install requirements
+        run: |
+          set -eux
+          pip install requests==2.24.0
+      - name: Update Dashboards
+        id: update
+        env:
+          GRAFANA_USER: ${{ secrets.GRAFANA_USER }}
+          GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
+        run: |
+          set -eux
+          cd aws/websites/metrics.pytorch.org
+          python update_dashboards.py
+      - name: Push changes
+        if: ${{ steps.update.outputs.UPDATED_DASHBOARDS == 'yes' }}
+        run: |
+          set -eux
+          git add aws/websites/metrics.pytorch.org/files/dashboards/.
+          git config user.name 'facebook-github-bot'
+          git config user.email 'facebook-github-bot@users.noreply.github.com'
+          git commit -m"Automated Grafana dashboard update"
+          git push
+{%- endmacro -%}

--- a/.github/templates/metrics_pytorch_org.yml.j2
+++ b/.github/templates/metrics_pytorch_org.yml.j2
@@ -1,0 +1,52 @@
+{% import 'common.yml.j2' as common %}
+name: Deploy metrics.pytorch.org
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'aws/websites/metrics.pytorch.org/**'
+      - '.github/workflows/metrics_pytorch_org.yml'
+
+concurrency:
+  group: "deploy metrics.pytorch.org"
+  cancel-in-progress: true
+
+jobs:
+  !{{ common.update_dashboards_job() }}
+  deploy:
+    runs-on: ubuntu-20.04
+    needs:
+      - update-dashboards
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+            ref: 'main'
+      - name: Install dependencies
+        run: |
+          set -eux
+          pip install ansible
+      - name: Setup Secets
+        env:
+          FULLCHAIN: ${{ secrets.METRICS_FULLCHAIN }}
+          PRIVKEY: ${{ secrets.METRICS_PRIVKEY }}
+          VARS: ${{ secrets.METRICS_VARS }}
+          SSH_KEY: ${{ secrets.METRICS_SSH_KEY }}
+        run: |
+          set -e  # NB: This needs to run without -x since GitHub will sometimes not hide secrets in the logs
+          cd aws/websites/metrics.pytorch.org
+
+          echo "$FULLCHAIN" > files/fullchain.pem
+          echo "$PRIVKEY" > files/privkey.pem
+          echo "$VARS" > vars.yml
+          echo "$SSH_KEY" > ssh_key.pem
+          chmod 600 ssh_key.pem
+      - name: Deploy
+        run: |
+          set -eux
+          cd aws/websites/metrics.pytorch.org
+          ansible-playbook -i ubuntu@metrics.pytorch.org, install.yml --extra-vars=@vars.yml --private-key=ssh_key.pem
+

--- a/.github/templates/update_grafana_dashboards.yml.j2
+++ b/.github/templates/update_grafana_dashboards.yml.j2
@@ -1,0 +1,10 @@
+{% import 'common.yml.j2' as common %}
+
+name: Update Grafana Dashboards
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+
+jobs:
+  !{{ common.update_dashboards_job() }}

--- a/.github/workflows/generated-metrics-pytorch-org.yml
+++ b/.github/workflows/generated-metrics-pytorch-org.yml
@@ -1,3 +1,6 @@
+# @generated DO NOT EDIT MANUALLY
+# Generated from .github/templates/metrics_pytorch_org.yml.j2
+
 name: Deploy metrics.pytorch.org
 
 on:
@@ -14,11 +17,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
+  update-dashboards:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install requirements
+        run: |
+          set -eux
+          pip install requests==2.24.0
+      - name: Update Dashboards
+        id: update
+        env:
+          GRAFANA_USER: ${{ secrets.GRAFANA_USER }}
+          GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
+        run: |
+          set -eux
+          cd aws/websites/metrics.pytorch.org
+          python update_dashboards.py
+      - name: Push changes
+        if: ${{ steps.update.outputs.UPDATED_DASHBOARDS == 'yes' }}
+        run: |
+          set -eux
+          git add aws/websites/metrics.pytorch.org/files/dashboards/.
+          git config user.name 'facebook-github-bot'
+          git config user.email 'facebook-github-bot@users.noreply.github.com'
+          git commit -m"Automated Grafana dashboard update"
+          git push
+  deploy:
+    runs-on: ubuntu-20.04
+    needs:
+      - update-dashboards
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+            ref: 'main'
       - name: Install dependencies
         run: |
           set -eux

--- a/.github/workflows/generated-update-grafana-dashboards.yml
+++ b/.github/workflows/generated-update-grafana-dashboards.yml
@@ -1,3 +1,7 @@
+# @generated DO NOT EDIT MANUALLY
+# Generated from .github/templates/update_grafana_dashboards.yml.j2
+
+
 name: Update Grafana Dashboards
 
 on:
@@ -24,7 +28,7 @@ jobs:
           cd aws/websites/metrics.pytorch.org
           python update_dashboards.py
       - name: Push changes
-        if: ${{ steps.update.outputs.UPDATED_DASHBOARDS == 'yes' }} 
+        if: ${{ steps.update.outputs.UPDATED_DASHBOARDS == 'yes' }}
         run: |
           set -eux
           git add aws/websites/metrics.pytorch.org/files/dashboards/.


### PR DESCRIPTION
Without this step we have the risk of re-deploying dashboards before they get updated to the repo if they were updated in the last 15 minutes and a deploy is triggered. This also consolidates these down to templates
