### PR TITLE
tools: Add check_runners_state.py

### DIFF
--- a/tools/self-hosted-runner-utils/README.md
+++ b/tools/self-hosted-runner-utils/README.md
@@ -43,3 +43,18 @@ There are also dry run options to just show which runners would be deleted
 ```bash
 python clear_offline_runners.py pytorch/pytorch --dry-run
 ```
+
+## check_runners_state.py
+
+A utility to check overall stats for self hosted runners.
+
+> NOTE: You do need adminstrator access to use this script
+
+> NOTE: GITHUB_TOKEN should be set in your environment for this script to work properly
+
+### Usage
+
+```bash
+# python check_runners_state.py <REPO>
+python check_runners_state.py pytorch/pytorch
+```

--- a/tools/self-hosted-runner-utils/clear_offline_runners.py
+++ b/tools/self-hosted-runner-utils/clear_offline_runners.py
@@ -44,7 +44,10 @@ def main() -> None:
     repo = gh.get_repo(options.repo)
     runners = repo.get_self_hosted_runners()
     include_pattern = re.compile(options.include)
+    num_removed = 0
+    num_total = 0
     for runner in runners:
+        num_total += 1
         if runner.status != "offline" or not include_pattern.match(runner.name):
             continue
         print(f"- {runner.name} ", end="")
@@ -53,6 +56,8 @@ def main() -> None:
         else:
             repo.remove_self_hosted_runner(runner)
             print("removed")
+        num_removed += 1
+    print(f"Removed {num_removed}/{num_total}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a utility script to check the status of all self hosted runners
available on Github Actions for a particular repository

Output should look like:
```
❯ python check_runners_state.py pytorch/pytorch
Repository stats for pytorch/pytorch
            129 total runners
        129/129 online runners

Number of online runners per label
       31 (24)% linux.8xlarge.nvidia.gpu
       48 (37)% linux.2xlarge
       37 (28)% windows.4xlarge
       12 ( 9)% windows.8xlarge.nvidia.gpu
        1 ( 0)% linux.16xlarge.nvidia.gpu
```

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>