### PR TITLE
Add lambda to use GitHub API to get job statuses

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: Lint
+
+on:
+  pull_request:
+    paths:
+      - '**.py'
+  push:
+    branches:
+      - main
+    paths:
+      - '**.py'
+
+jobs:
+  mypy:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+          architecture: 'x64'
+      - name: Install dependencies
+        run: |
+          pip install mypy==0.812
+          pip install -r aws/lambda/github-status-sync/requirements.txt
+      - name: Run mypy
+        env:
+          MYPY_FORCE_COLOR: 1
+        run: |
+          mypy

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ aws/lambda/hud-query-proxy/python/*
 aws/lambda/github-webhook-rds-sync/python/*
 aws/lambda/github-webhook-rds-sync/hooks/*
 aws/lambda/rds-proxy/python/*
+aws/lambda/github-status-sync/python/*

--- a/aws/lambda/github-status-sync/Makefile
+++ b/aws/lambda/github-status-sync/Makefile
@@ -1,0 +1,10 @@
+deployment:
+	pip install --target ./python -r requirements.txt
+	cd python && zip -r ../deployment.zip .
+	zip -g deployment.zip lambda_function.py
+
+manual_update:
+	aws lambda update-function-code --function-name ossci-job-status-sync --zip-file fileb://deployment.zip
+
+clean:
+	rm -rf deployment.zip python

--- a/aws/lambda/github-status-sync/README.md
+++ b/aws/lambda/github-status-sync/README.md
@@ -1,0 +1,50 @@
+This lambda updates data in S3 that is used by hud.pytorch.org on the main status page. It lists out the top N commits for a branch along with the statuses for each.
+
+## Configuration
+
+Mandatory:
+
+- `app_id` - the GitHub App ID to authenticate with (e.g. `1234351`)
+- `private_key` - a private key generated from the GitHub App with newlines replaced with `|` characters
+- `bucket` - s3 bucket to write to (e.g. `ossci-job-status`), the Lambda should be configured to have write access to the S3 `bucket`
+
+Optional:
+
+- `branches` - comma separated list of branches to handle: `master,nightly,viable/strict,release/1.10`
+- `repo` - GitHub repository (e.g. `vision`)
+- `user` - GitHub username (e.g. `pytorch`)
+- `history_size` - number of commits to fetch in the past (e.g. `100`)
+
+These can optionally be configured via an EventBridge event (which would let you sync multiple repos at different rates from a single lambda):
+
+1. In the Lambda triggers configuration page, add a new EventBridge trigger to run on a schedule (e.g. `rate(1 minute)`).
+2. Click on the EventBridge event and got "Edit" it
+3. In "Select targets" expand "Configure input" and choose "Constant (JSON text)". Paste in something like this
+
+   ```json
+   {
+     "branches": "master,nightly,viable/strict,release/1.10",
+     "user": "pytorch",
+     "repo": "pytorch",
+     "history_size": 100
+   }
+   ```
+
+4. "Update" to save the changes, monitor the logs to ensure the Lambda is functioning correctly
+
+## Local Development
+
+Use the environment variables above along with `DEBUG=1` to run locally.
+
+```bash
+# One-time setup
+export DEBUG=1
+export app_id=1234
+export bucket=ossci-job-status
+export private_key=$(cat key.pem | tr '\n' '|')
+
+# Run and debug
+python lambda_function.py
+```
+
+**Note**: The `cryptography` package relies on binaries, so you can only deploy this from a Linux machine (doing it from MacOS will result in errors reading ELF headers at import time)

--- a/aws/lambda/github-status-sync/lambda_function.py
+++ b/aws/lambda/github-status-sync/lambda_function.py
@@ -1,0 +1,435 @@
+import asyncio
+import aiohttp  # type: ignore
+import math
+import os
+import datetime
+import re
+import boto3  # type: ignore
+import json
+import io
+import gzip
+import os
+from cryptography.hazmat.backends import default_backend
+import jwt
+import requests
+import time
+from typing import *
+
+
+BUCKET = os.environ["bucket"]
+APP_ID = int(os.environ["app_id"])
+
+# The private key needs to maintain its newlines, get it via
+# $ cat key.pem | tr '\n' '|' | pbcopy
+PRIVATE_KEY = os.environ["private_key"].replace("|", "\n")
+
+
+def app_headers() -> Dict[str, str]:
+    cert_bytes = PRIVATE_KEY.encode()
+    private_key = default_backend().load_pem_private_key(cert_bytes, None)  # type: ignore
+
+    time_since_epoch_in_seconds = int(time.time())
+
+    payload = {
+        # issued at time
+        "iat": time_since_epoch_in_seconds,
+        # JWT expiration time (10 minute maximum)
+        "exp": time_since_epoch_in_seconds + (10 * 60),
+        # GitHub App's identifier
+        "iss": APP_ID,
+    }
+
+    actual_jwt = jwt.encode(payload, private_key, algorithm="RS256")
+    headers = {
+        "Authorization": f"Bearer {actual_jwt}",
+        "Accept": "application/vnd.github.machine-man-preview+json",
+    }
+    return headers
+
+
+def jprint(obj: Any) -> None:
+    print(json.dumps(obj, indent=2))
+
+
+def installation_id(user: str) -> int:
+    r_bytes = requests.get(
+        "https://api.github.com/app/installations", headers=app_headers()
+    )
+    r = json.loads(r_bytes.content.decode())
+    for item in r:
+        if item["account"]["login"] == user:
+            return int(item["id"])
+
+    raise RuntimeError(f"User {user} not found in {r}")
+
+
+def user_token(user: str) -> str:
+    """
+    Authorize this request with the GitHub app set by the 'app_id' and
+    'private_key' environment variables.
+    1. Get the installation ID for the user that has installed the app
+    2. Request a new token for that user
+    3. Return it so it can be used in future API requests
+    """
+    id = installation_id(user)
+    url = f"https://api.github.com/app/installations/{id}/access_tokens"
+    r_bytes = requests.post(url, headers=app_headers())
+    r = json.loads(r_bytes.content.decode())
+    token = str(r["token"])
+    return token
+
+
+if "AWS_KEY_ID" in os.environ and "AWS_SECRET_KEY" in os.environ:
+    # Use keys for local development
+    session = boto3.Session(
+        aws_access_key_id=os.environ.get("AWS_KEY_ID"),
+        aws_secret_access_key=os.environ.get("AWS_SECRET_KEY"),
+    )
+else:
+    # In the Lambda, use permissions on the Lambda's role
+    session = boto3.Session()
+s3 = session.resource("s3")
+
+
+def compress_query(query: str) -> str:
+    query = query.replace("\n", "")
+    query = re.sub("\s+", " ", query)
+    return query
+
+
+def head_commit_query(user: str, repo: str, branches: List[str]) -> str:
+    """
+    Fetch the head commit for a list of branches
+    """
+
+    def branch_part(branch: str, num: int) -> str:
+        return f"""
+        r{num}: repository(name: "{repo}", owner: "{user}") {{
+            ref(qualifiedName:"refs/heads/{branch}") {{
+            name
+            target {{
+                ... on Commit {{
+                    oid
+                }}        
+            }}
+        }}
+        }}
+        """
+
+    parts = [branch_part(branch, i) for i, branch in enumerate(branches)]
+    return "{" + "\n".join(parts) + "}"
+
+
+def extract_gha(suites: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+    jobs = []
+    for suite in suites:
+        suite = suite["node"]
+        if suite["workflowRun"] is None:
+            # If no jobs were triggered this will be empty
+            continue
+        workflow = suite["workflowRun"]["workflow"]["name"]
+        for run in suite["checkRuns"]["nodes"]:
+            conclusion = run["conclusion"]
+            if conclusion is None:
+                if run["status"].lower() == "queued":
+                    conclusion = "queued"
+                elif run["status"].lower() == "in_progress":
+                    conclusion = "pending"
+                else:
+                    raise RuntimeError(f"unexpected run {run}")
+            jobs.append(
+                {
+                    "name": f"{workflow} / {run['name']}",
+                    "status": conclusion.lower(),
+                    "url": run["detailsUrl"],
+                }
+            )
+
+    return jobs
+
+
+def extract_status(contexts: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+    jobs = []
+    for context in contexts:
+        jobs.append(
+            {
+                "name": context["context"],
+                "status": context["state"].lower(),
+                "url": context["targetUrl"],
+            }
+        )
+
+    return jobs
+
+
+def extract_jobs(raw_commits: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    commits = []
+
+    for raw_commit in raw_commits:
+        if raw_commit["status"] is None:
+            # Will be none if no non-GHA jobs were triggered
+            status = []
+        else:
+            status = extract_status(raw_commit["status"]["contexts"])
+        gha = extract_gha(raw_commit["checkSuites"]["edges"])
+        jobs = status + gha
+
+        if raw_commit["author"]["user"] is None:
+            author = raw_commit["author"]["name"]
+        else:
+            author = raw_commit["author"]["user"]["login"]
+        commits.append(
+            {
+                "sha": raw_commit["oid"],
+                "headline": raw_commit["messageHeadline"],
+                "body": raw_commit["messageBody"],
+                "author": author,
+                "date": raw_commit["authoredDate"],
+                "jobs": jobs,
+            }
+        )
+    return commits
+
+
+class BranchHandler:
+    def __init__(
+        self,
+        gql: Any,
+        user: str,
+        repo: str,
+        name: str,
+        head: str,
+        history_size: int,
+        fetch_size: int = 10,
+    ):
+        self.gql = gql
+        self.user = user
+        self.repo = repo
+        self.name = name
+        self.head = head
+        self.fetch_size = fetch_size
+        self.history_size = history_size
+
+    def write_to_s3(self, data: Any) -> None:
+        content = json.dumps(data, default=str)
+        buf = io.BytesIO()
+        gzipfile = gzip.GzipFile(fileobj=buf, mode="w")
+        gzipfile.write(content.encode())
+        gzipfile.close()
+        bucket = s3.Bucket(BUCKET)
+        prefix = f"v5/{self.user}/{self.repo}/{self.name.replace('/', '_')}.json"
+        bucket.put_object(
+            Key=prefix,
+            Body=buf.getvalue(),
+            ContentType="application/json",
+            ContentEncoding="gzip",
+        )
+        print(f"Wrote {len(data)} commits from {self.name} to {prefix}")
+
+    def query(self, offset: int) -> str:
+        after = ""
+        # The cursor for fetches are formatted like after: "<sha> <offset>", but
+        # the first commit isn't included, so shift all the offsets and don't
+        # use an "after" for the first batch
+        if offset > 0:
+            after = f', after: "{self.head} {offset - 1}"'
+
+        return f"""
+        {{
+            repository(name: "{self.repo}", owner: "{self.user}") {{
+                ref(qualifiedName:"refs/heads/{self.name}") {{
+                name
+                target {{
+                    ... on Commit {{
+                    history(first:{self.fetch_size}{after}) {{
+                        nodes {{
+                        oid
+                        messageBody
+                        messageHeadline
+                        author {{
+                            name
+                            user {{
+                                login
+                            }}
+                        }}
+                        authoredDate
+                        checkSuites(first:100) {{
+                            edges {{
+                            node {{
+                                checkRuns(first:100) {{
+                                    nodes {{
+                                        name
+                                        status
+                                        conclusion
+                                        detailsUrl
+                                    }}
+                                }}
+                                workflowRun {{
+                                    workflow {{
+                                        name
+                                    }}
+                                }}
+                            }}
+                            }}
+                        }}
+                        status {{
+                            contexts {{
+                            context
+                            state
+                            targetUrl
+                            }}
+                        }}
+                        }}
+                    }}
+                    }}
+                }}
+                }}
+            }}
+        }}
+        """
+
+    async def run(self) -> None:
+        """
+        Fetch history for the branch (in batches) and merge them all together
+        """
+        # GitHub's API errors out if you try to fetch too much data at once, so
+        # split up the 100 commits into batches of 'self.fetch_size'
+        fetches = math.ceil(self.history_size / self.fetch_size)
+
+        async def fetch(i: int) -> Any:
+            try:
+                return await self.gql.query(self.query(offset=self.fetch_size * i))
+            except Exception as e:
+                print(f"Error: {e}\nFailed to fetch {self.name} on batch {i}")
+                return None
+
+        coros = [fetch(i) for i in range(fetches)]
+        result = await asyncio.gather(*coros)
+        raw_commits = []
+
+        print(f"Parsing results {self.name}")
+        # Merge all the batches
+        for r in result:
+            if r is None:
+                continue
+            try:
+                commits_batch = r["data"]["repository"]["ref"]["target"]["history"][
+                    "nodes"
+                ]
+                raw_commits += commits_batch
+            except Exception as e:
+                print(e)
+                # Errors here are expected if the branch has less than HISTORY_SIZE
+                # commits (GitHub will just time out). There's no easy way to find
+                # this number ahead of time and avoid errors, but if we had that
+                # then we could delete this try-catch.
+                pass
+
+        # Pull out the data and format it
+        commits = extract_jobs(raw_commits)
+
+        print(f"Writing results for {self.name} to S3")
+        # Store gzip'ed data to S3
+        self.write_to_s3(commits)
+
+
+class GraphQL:
+    def __init__(self, session: aiohttp.ClientSession) -> None:
+        self.session = session
+
+    def log_rate_limit(self, headers: Dict[str, Any]) -> None:
+        remaining = headers.get("X-RateLimit-Remaining")
+        used = headers.get("X-RateLimit-Used")
+        total = headers.get("X-RateLimit-Limit")
+        reset_timestamp = int(headers.get("X-RateLimit-Reset"))  # type: ignore
+        reset = datetime.datetime.fromtimestamp(reset_timestamp).strftime(
+            "%a, %d %b %Y %H:%M:%S"
+        )
+
+        print(
+            f"[rate limit] Used {used}, {remaining} / {total} remaining, reset at {reset}"
+        )
+
+    async def query(self, query: str) -> Any:
+        """
+        Run an authenticated GraphQL query
+        """
+        # Remove unnecessary white space
+        query = compress_query(query)
+
+        url = "https://api.github.com/graphql"
+        async with self.session.post(url, json={"query": query}) as resp:
+            self.log_rate_limit(resp.headers)
+            r = await resp.json()
+        if "data" not in r:
+            raise RuntimeError(r)
+        return r
+
+
+async def main(user: str, repo: str, branches: List[str], history_size: int) -> None:
+    """
+    Grab a list of all the head commits for each branch, then fetch all the jobs
+    for the last 'history_size' commits on that branch
+    """
+    async with aiohttp.ClientSession(
+        headers={
+            "Authorization": "token {}".format(user_token(user)),
+            "Accept": "application/vnd.github.machine-man-preview+json",
+        }
+    ) as aiosession:
+        gql = GraphQL(aiosession)
+        print(f"Querying branches: {branches}")
+        heads = await gql.query(head_commit_query(user, repo, branches))
+        handlers = []
+
+        for head in heads["data"].values():
+            sha = head["ref"]["target"]["oid"]
+            branch = head["ref"]["name"]
+            handlers.append(BranchHandler(gql, user, repo, branch, sha, history_size))
+
+        await asyncio.gather(*[h.run() for h in handlers])
+
+
+def lambda_handler(event: Any, context: Any) -> None:
+    """
+    'event' here is the payload configured from EventBridge (or set manually
+    via environment variables)
+    """
+    data: Dict[str, Any] = {
+        "branches": None,
+        "user": None,
+        "repo": None,
+        "history_size": None,
+    }
+
+    for key in data.keys():
+        if key in os.environ:
+            data[key] = os.environ[key]
+        else:
+            data[key] = event[key]
+
+    if any(x is None for x in data.values()):
+        raise RuntimeError(
+            "Data missing from configuration, it must be set as an environment "
+            f"variable or as the input JSON payload in the Lambda event:\n{data}"
+        )
+
+    data["history_size"] = int(data["history_size"])
+    data["branches"] = data["branches"].split(",")
+
+    # return
+    asyncio.run(main(**data))
+
+
+if os.getenv("DEBUG", "0") == "1":
+    # For local development
+    lambda_handler(
+        {
+            "branches": "master",
+            "user": "pytorch",
+            "repo": "pytorch",
+            "history_size": 100,
+        },
+        None,
+    )
+

--- a/aws/lambda/github-status-sync/requirements.txt
+++ b/aws/lambda/github-status-sync/requirements.txt
@@ -1,0 +1,5 @@
+boto3==1.16.52
+aiohttp==3.6.2
+cryptography==35.0.0
+requests==2.24.0
+PyJWT==2.1.0

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,32 @@
+# Copied from pytorch/mypy-strict.ini
+[mypy]
+python_version = 3.8
+
+strict_optional = True
+show_error_codes = True
+show_column_numbers = True
+warn_no_return = True
+disallow_any_unimported = True
+
+# Across versions of mypy, the flags toggled by --strict vary.  To ensure
+# we have reproducible type check, we instead manually specify the flags
+warn_unused_configs = True
+disallow_any_generics = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_redundant_casts = True
+warn_return_any = True
+implicit_reexport = False
+strict_equality = True
+
+# do not reenable this:
+# https://github.com/pytorch/pytorch/pull/60006#issuecomment-866130657
+warn_unused_ignores = False
+
+files =
+    aws/lambda/github-status-sync/lambda_function.py


### PR DESCRIPTION
This re-writes the status lambda to use the GitHub API rather than webhooks. This makes it much easier to debug and work on and simpler to execute (we don't have to worry about concurrency anymore). This also makes it configurable via environment variables so we can run it for any repo (e.g. `vision`) and get that from the HUD in a predictable way.

Fixes #125