### PR TITLE
Don't cache ci job status JSON

### DIFF
--- a/aws/lambda/github-status-sync/lambda_function.py
+++ b/aws/lambda/github-status-sync/lambda_function.py
@@ -16,7 +16,7 @@ import time
 from typing import *
 
 
-BUCKET = os.environ["bucket"]
+BUCKET = os.getenv("bucket", "ossci-job-status")
 APP_ID = int(os.environ["app_id"])
 
 # The private key needs to maintain its newlines, get it via
@@ -223,6 +223,7 @@ class BranchHandler:
             Body=buf.getvalue(),
             ContentType="application/json",
             ContentEncoding="gzip",
+            Expires="0",
         )
         print(f"Wrote {len(data)} commits from {self.name} to {prefix}")
 


### PR DESCRIPTION
This sets the `Expires` header on S3 JSONs with job statuses to 0. Hopefully this should prevent any time-based caching in the browser and make it rely on the `Etag` exclusively which will ensure clients always get the up-to-date JSON.

Tested locally with

```bash
export app_id=<app id>
export private_key=(cat key.pem | tr '\n' '|')
python lambda_function.py
```