### PR TITLE
Remove `master` from sync workflow

### DIFF
--- a/.github/workflows/sync_pytorch_canary.yml
+++ b/.github/workflows/sync_pytorch_canary.yml
@@ -11,7 +11,7 @@ jobs:
   sync-pytorch:
     strategy:
       matrix:
-        ref: ["master", "viable/strict"]
+        ref: ["viable/strict"]
     runs-on: ubuntu-20.04
     env:
       PYTORCH_REF: ${{ matrix.ref }}


### PR DESCRIPTION
ShipIt is enabled for pytorch-canary now so we don't need to keep this workflow https://www.internalfb.com/intern/opensource/github/repo/1672688976258095/repo_settings/shipit/


