### PR TITLE
Add retries to GitHub queries

### DIFF
--- a/aws/lambda/github-status-sync/lambda_function.py
+++ b/aws/lambda/github-status-sync/lambda_function.py
@@ -360,13 +360,18 @@ class GraphQL:
             f"[rate limit] Used {used}, {remaining} / {total} remaining, reset at {reset}"
         )
 
-    async def query(self, query: str, verify: Any = None, retries: int = 5) -> Any:
+    async def query(
+        self,
+        query: str,
+        verify: Optional[Callable[[Any], None]] = None,
+        retries: int = 5,
+    ) -> Any:
         """
         Run an authenticated GraphQL query
         """
         # Remove unnecessary white space
         query = compress_query(query)
-        if retries == 0:
+        if retries <= 0:
             raise RuntimeError(f"Query {query[:100]} failed, no retries left")
 
         url = "https://api.github.com/graphql"


### PR DESCRIPTION
This adds 5 default retries since the GitHub queries are pretty heavy, GitHub often just gives up or errors out. If this isn't enough for a particular repo we will need to reduce `fetch_size` for that repo, but this will eat up more of our rate limit.
