### PR TITLE
Fix bug with `/` in filenames for updating dashboards

### DIFF
--- a/aws/websites/metrics.pytorch.org/update_dashboards.py
+++ b/aws/websites/metrics.pytorch.org/update_dashboards.py
@@ -53,7 +53,7 @@ def diff(expected, actual):
 
 
 def file_path(name: str) -> Path:
-    name = name.replace(" ", "_").replace("-", "_")
+    name = name.replace(" ", "_").replace("-", "_").replace("/", "_")
     return DASHBOARD_DIR / f"{name}.json"
 
 


### PR DESCRIPTION
This was surfaced with the torch/benchmark dashboard, the filename just needs to be changed to something without a slash
