### PR TITLE
Upgrade to Grafana 8.2.3

### DIFF
--- a/aws/websites/metrics.pytorch.org/files/docker-compose.yml
+++ b/aws/websites/metrics.pytorch.org/files/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   grafana:
-    image: grafana/grafana:8.1.1
+    image: grafana/grafana:8.2.3
     logging:
       driver: "json-file"
       options:

--- a/aws/websites/metrics.pytorch.org/files/http.conf
+++ b/aws/websites/metrics.pytorch.org/files/http.conf
@@ -20,6 +20,11 @@ server {
 
     set $grafana_upstream_endpoint http://grafana:3000;
 
+    # Adding a workaround for nginx rule https://grafana.com/blog/2021/11/03/grafana-8.2.3-released-with-medium-severity-security-fix-cve-2021-41174-grafana-xss/
+    location ~ \{\{ {
+        deny all;
+    }
+
     location / {
         resolver 127.0.0.11 valid=30s ipv6=off;
         proxy_pass	$grafana_upstream_endpoint;


### PR DESCRIPTION
Remedy for Grafana issue https://grafana.com/blog/2021/11/03/grafana-8.2.3-released-with-medium-severity-security-fix-cve-2021-41174-grafana-xss/