### PR TITLE
Fix query for disabled tests

### DIFF
--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Generate new disabled test list
         run: |
           # score changes every request, so we strip it out to avoid creating a commit every time we query.
-          curl 'https://api.github.com/search/issues?q=is%3Aissue+is%3Aopen+repo:pytorch/pytorch+in%3Atitle+DISABLED' \
+          curl 'https://api.github.com/search/issues?q=is%3Aissue+is%3Aopen+repo:pytorch/pytorch+in%3Atitle+DISABLED&page=1&per_page=100' \
           | sed 's/"score": [0-9\.]*/"score": 0.0/g' > disabled-tests.json
       - name: Sort disabled-tests.json
         shell: python


### PR DESCRIPTION
The default for the query is 30, but we have ~73 disabled tests. Honestly, I'm not sure how we didn't catch this sooner :/ 

I will write a more robust query for the GHA after this PR, but this is an immediate fix.