### PR TITLE
Scale up disable bot to detect more than 100 issues

### DIFF
--- a/.github/scripts/update_disabled_tests.py
+++ b/.github/scripts/update_disabled_tests.py
@@ -45,12 +45,7 @@ def update_issues(issues_json: Dict[Any, Any], info: str) -> None:
 def get_disable_issues() -> Dict[Any, Any]:
     prefix = "https://api.github.com/search/issues?q=is%3Aissue+is%3Aopen+repo:pytorch/pytorch+in%3Atitle+DISABLED&" \
              "&per_page=100"
-    header, info = request_for_labels(prefix + "&page=1")
-    issues_json: Dict[Any, Any] = {
-        "items": [],
-        "total_count": 0,
-    }
-    update_issues(issues_json, info)
+    header, issues_json = request_for_labels(prefix + "&page=1")
     last_page = get_last_page(header)
     assert last_page > 0, "Error reading header info to determine total number of pages of labels"
     for page_number in range(2, last_page + 1):  # skip page 1

--- a/.github/scripts/update_disabled_tests.py
+++ b/.github/scripts/update_disabled_tests.py
@@ -56,10 +56,15 @@ def get_disable_issues() -> Dict[Any, Any]:
 
 
 def validate_and_sort(issues_json: Dict[str, Any]) -> None:
-    print(issues_json)
     assert issues_json["total_count"] is len(issues_json["items"]), f"# issues {len(issues_json['items'])} does not" \
          f"equal total count {issues_json['total_count']}."
     assert not issues_json["incomplete_results"], f"Results were incomplete. There may be missing issues."
+
+    # score changes every request, so we strip it out to avoid creating a commit every time we query.
+    for issue in issues_json["items"]:
+        if "score" in issue:
+            issue["score"] = 0.0
+
     issues_json["items"].sort(key=lambda x: x["url"])
 
 

--- a/.github/scripts/update_disabled_tests.py
+++ b/.github/scripts/update_disabled_tests.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-'''
+"""
 Query for the DISABLED test issues.
 
-'''
+"""
 
 import json
 from functools import lru_cache
@@ -12,11 +12,11 @@ from urllib.request import urlopen, Request
 # Modified from https://github.com/pytorch/pytorch/blob/b00206d4737d1f1e7a442c9f8a1cadccd272a386/torch/hub.py#L129
 def _read_url(url: Any) -> Any:
     with urlopen(url) as r:
-        return r.headers, r.read().decode(r.headers.get_content_charset('utf-8'))
+        return r.headers, r.read().decode(r.headers.get_content_charset("utf-8"))
 
 
 def request_for_labels(url: str) -> Any:
-    headers = {'Accept': 'application/vnd.github.v3+json'}
+    headers = {"Accept": "application/vnd.github.v3+json"}
     return _read_url(Request(url, headers=headers))
 
 
@@ -25,7 +25,7 @@ def get_last_page(header: Any) -> int:
     # Link: <https://api.github.com/search/issues?q=is%3Aissue+is%3Aopen+repo%3Apytorch%2Fpytorch+in%3Atitle+
     # DISABLED&per_page=30&page=2>; rel="next", <https://api.github.com/search/issues?q=is%3Aissue+is%3Aopen+
     # repo%3Apytorch%2Fpytorch+in%3Atitle+DISABLED&per_page=30&page=4>; rel="last"
-    link_info = header['link']
+    link_info = header["link"]
     if link_info is None:
         print("WARNING: Link information missing, most likely because there is only one page of results.")
         return 1
@@ -36,8 +36,9 @@ def get_last_page(header: Any) -> int:
 
 def update_issues(issues_json: Dict[Any, Any], info: str) -> None:
     more_issues = json.loads(info)
-    issues_json["items"].extend(more_issues)
-    issues_json["total_count"] += len(more_issues)
+    issues_json["items"].extend(more_issues["items"])
+    issues_json["incomplete_results"] &= more_issues["incomplete_results"]
+    issues_json["total_count"] += more_issues["total_count"]
 
 
 @lru_cache()
@@ -59,16 +60,23 @@ def get_disable_issues() -> Dict[Any, Any]:
     return issues_json
 
 
-def write_issues_to_file(issues_json: Dict[Any, Any]) -> None:
-    issues_json['items'].sort(key=lambda x: x['url'])
+def validate_and_sort(issues_json: Dict[str, Any]) -> None:
+    assert issues_json["total_count"] is len(issues_json["items"]), f"# issues {len(issues_json['items'])} does not" \
+         f"equal total count {issues_json['total_count']}."
+    assert not issues_json["incomplete_results"], f"Results were incomplete. There may be missing issues."
+    issues_json["items"].sort(key=lambda x: x["url"])
 
-    with open('disabled-tests.json', mode='w') as file:
+
+def write_issues_to_file(issues_json: Dict[Any, Any]) -> None:
+    with open("disabled-tests.json", mode="w") as file:
         json.dump(issues_json, file, sort_keys=True, indent=2)
 
 
 def main() -> None:
-    write_issues_to_file(get_disable_issues())
+    disable_issues = get_disable_issues()
+    validate_and_sort(disable_issues)
+    write_issues_to_file(disable_issues)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/.github/scripts/update_disabled_tests.py
+++ b/.github/scripts/update_disabled_tests.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+'''
+Query for the DISABLED test issues.
+
+'''
+
+import json
+from functools import lru_cache
+from typing import Any, Dict
+from urllib.request import urlopen, Request
+
+# Modified from https://github.com/pytorch/pytorch/blob/b00206d4737d1f1e7a442c9f8a1cadccd272a386/torch/hub.py#L129
+def _read_url(url: Any) -> Any:
+    with urlopen(url) as r:
+        return r.headers, r.read().decode(r.headers.get_content_charset('utf-8'))
+
+
+def request_for_labels(url: str) -> Any:
+    headers = {'Accept': 'application/vnd.github.v3+json'}
+    return _read_url(Request(url, headers=headers))
+
+
+def get_last_page(header: Any) -> int:
+    # Link info looks like: <https://api.github.com/repositories/65600975/labels?per_page=100&page=2>;
+    # rel="next", <https://api.github.com/repositories/65600975/labels?per_page=100&page=3>; rel="last"
+    link_info = header['link']
+    prefix = "&page="
+    suffix = ">;"
+    return int(link_info[link_info.rindex(prefix) + len(prefix):link_info.rindex(suffix)])
+
+
+def update_issues(issues_json: Dict[Any, Any], info: str) -> None:
+    more_issues = json.loads(info)
+    issues_json["items"].extend(more_issues)
+    issues_json["total_count"] += len(more_issues)
+
+
+@lru_cache()
+def get_disable_issues() -> Dict[Any, Any]:
+    prefix = "https://api.github.com/repos/pytorch/pytorch/issues?q=is%3Aissue+repo:pytorch/pytorch" \
+             "+in%3Atitle+DISABLED&per_page=100"
+    header, info = request_for_labels(prefix + "&page=1")
+    issues_json: Dict[Any, Any] = {
+        "items": [],
+        "total_count": 0,
+    }
+    update_issues(issues_json, info)
+    print(header)
+    exit(0)
+    last_page = get_last_page(header)
+    assert last_page > 0, "Error reading header info to determine total number of pages of labels"
+    for page_number in range(2, last_page + 1):  # skip page 1
+        _, info = request_for_labels(prefix + f"&page={page_number}")
+        update_issues(issues_json, info)
+
+    return issues_json
+
+
+def write_issues_to_file(issues_json: Dict[Any, Any]) -> None:
+    issues_json['items'].sort(key=lambda x: x['url'])
+
+    with open('disabled-tests.json', mode='w') as file:
+        json.dump(issues_json, file, sort_keys=True, indent=2)
+
+
+def main() -> None:
+    write_issues_to_file(get_disable_issues())
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -1,6 +1,7 @@
 name: Update disabled tests
 
 on:
+  pull_request:
   schedule:
     # Every 15 minutes
     - cron: "*/15 * * * *"
@@ -14,6 +15,9 @@ jobs:
       - name: Generate new disabled test json
         run: |
           .github/scripts/update_disabled_tests.py
+      - name: Print file
+        run: |
+          cat disabled-tests.json
       - name: Push file to test-infra repository
         uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
         env:

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -1,7 +1,6 @@
 name: Update disabled tests
 
 on:
-  pull_request:
   schedule:
     # Every 15 minutes
     - cron: "*/15 * * * *"

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -12,6 +12,8 @@ jobs:
   update-disabled-tests:
     runs-on: ubuntu-18.04
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Generate new disabled test json
         run: |
           .github/scripts/update_disabled_tests.py

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -11,23 +11,9 @@ jobs:
   update-disabled-tests:
     runs-on: ubuntu-18.04
     steps:
-      - name: Generate new disabled test list
+      - name: Generate new disabled test json
         run: |
-          # score changes every request, so we strip it out to avoid creating a commit every time we query.
-          curl 'https://api.github.com/search/issues?q=is%3Aissue+is%3Aopen+repo:pytorch/pytorch+in%3Atitle+DISABLED&page=1&per_page=100' \
-          | sed 's/"score": [0-9\.]*/"score": 0.0/g' > disabled-tests.json
-      - name: Sort disabled-tests.json
-        shell: python
-        run: |
-          import json
-          with open('disabled-tests.json') as file:
-            disabled_tests_json = json.load(file)
-
-          # Sort disabled test issues by URL, e.g., https://api.github.com/repos/pytorch/pytorch/issues/38491
-          disabled_tests_json['items'].sort(key=lambda x: x['url'])
-
-          with open('disabled-tests.json', mode='w') as file:
-              json.dump(disabled_tests_json, file, sort_keys=True, indent=2)
+          .github/scripts/update_disabled_tests.py
       - name: Push file to test-infra repository
         uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
         env:


### PR DESCRIPTION
Before, we had a one liner legacy query that was not able to handle more than 100 issues, which is a problem for our disable bot as we're nearing 100 issues!