### PR TITLE
Simplify ciflow bot

### DIFF
--- a/torchci/lib/bot/ciflowBot.ts
+++ b/torchci/lib/bot/ciflowBot.ts
@@ -1,9 +1,9 @@
 import { Context, Probot } from "probot";
-import minimist from "minimist";
 import { CachedIssueTracker } from "./utils";
 
 const ciflowCommentStart = "<!-- ciflow-comment-start -->";
 const ciflowCommentEnd = "<!-- ciflow-comment-end -->";
+const DEFAULT_LABELS = ["ciflow/default"];
 
 interface IUserConfig {
   optOut: boolean;
@@ -40,7 +40,7 @@ export function parseCIFlowIssue(rawText: string): Map<string, IUserConfig> {
     // users with custom labels
     const login = elements[0].substring(1);
     const defaultLabels =
-      elements.length === 1 ? CIFlowBot.defaultLabels : elements.slice(1);
+      elements.length === 1 ? DEFAULT_LABELS : elements.slice(1);
     userConfigMap.set(login, {
       optOut: false,
       defaultLabels,
@@ -49,467 +49,83 @@ export function parseCIFlowIssue(rawText: string): Map<string, IUserConfig> {
   return userConfigMap;
 }
 
-// The CIFlowBot helps to dispatch labels and signal GitHub Action workflows to run.
-// For more details about the design, please refer to the RFC: https://github.com/pytorch/pytorch/issues/61888
-// Currently it supports strong validation and slow rollout, and it runs through a pipeline of dispatch strategies.
-export default class CIFlowBot {
-  // Constructor required
-  readonly ctx: Context;
-  readonly tracker: CachedIssueTracker;
-
-  // Static readonly configurations
-  static readonly command_ciflow = "ciflow";
-  static readonly command_ciflow_rerun = "rerun";
-  static readonly allowed_commands: string[] = [CIFlowBot.command_ciflow];
-
-  static readonly bot_assignee = "pytorchbot";
-  static readonly event_issue_comment = "issue_comment";
-  static readonly event_pull_request = "pull_request";
-  static readonly pr_label_prefix = "ciflow/";
-
-  static readonly strategy_add_default_labels = "strategy_add_default_labels";
-  static readonly defaultLabels = ["ciflow/default"];
-
-  // Stateful instance variables
-  command = "";
+async function getUserLabels(
+  context: Context<"pull_request.opened">,
+  tracker: CachedIssueTracker
+): Promise<string[]> {
   // @ts-ignore
-  command_args: minimist.ParsedArgs;
-  comment_id = 0;
-  comment_author = "";
-  comment_author_permission = "";
-  comment_body = "";
-  confusing_command = false;
-  dispatch_labels: string[] = [];
-  dispatch_strategies = [CIFlowBot.strategy_add_default_labels];
-  default_labels = CIFlowBot.defaultLabels;
-  event = "";
-  owner = "";
-  pr_author = "";
-  pr_labels: string[] = [];
-  pr_number = 0;
-  repo = "";
+  const userConfigMap: Map<string, IUserConfig> = await tracker.loadIssue(
+    context
+  );
 
-  constructor(ctx: Context, tracker: CachedIssueTracker) {
-    this.ctx = ctx;
-    this.tracker = tracker;
+  const prAuthor = context.payload.pull_request.user.login;
+
+  // rollout to everyone if no config is found
+  if (!userConfigMap.has(prAuthor)) {
+    return DEFAULT_LABELS;
   }
 
-  valid(): boolean {
-    if (
-      this.event !== CIFlowBot.event_pull_request &&
-      this.event !== CIFlowBot.event_issue_comment
-    ) {
-      this.ctx.log.error({ ctx: this.ctx }, "Unknown webhook event");
-      return false;
-    }
-
-    // validate the issue_comment event
-    if (this.event === CIFlowBot.event_issue_comment) {
-      if (!CIFlowBot.allowed_commands.includes(this.command)) {
-        return false;
-      }
-
-      if (
-        this.comment_author !== this.pr_author &&
-        !(
-          this.comment_author_permission === "admin" ||
-          this.comment_author_permission === "write"
-        )
-      ) {
-        return false;
-      }
-    }
-
-    // validate the pull_request event, so far we just return true
-    return true;
+  // respect opt-out users
+  // @ts-ignore
+  if (userConfigMap.get(prAuthor).optOut) {
+    return [];
   }
 
-  async getUserPermission(username: string): Promise<string> {
-    const res = await this.ctx.octokit.repos.getCollaboratorPermissionLevel(
-      this.ctx.repo({
-        username,
-      })
-    );
-    return res?.data?.permission;
-  }
-
-  async getUserLabels(): Promise<string[]> {
-    const userConfigMap: Map<string, IUserConfig> =
-      this.tracker != null
-        ? ((await this.tracker.loadIssue(this.ctx)) as Map<string, IUserConfig>)
-        : new Map<string, IUserConfig>();
-
-    // rollout to everyone if no config is found
-    if (!userConfigMap.has(this.pr_author)) {
-      return CIFlowBot.defaultLabels;
-    }
-
-    // respect opt-out users
+  return (
     // @ts-ignore
-    if (userConfigMap.get(this.pr_author).optOut) {
-      return [];
-    }
+    userConfigMap.get(prAuthor).defaultLabels || CIFlowBot.defaultLabels
+  );
+}
 
-    return (
-      // @ts-ignore
-      userConfigMap.get(this.pr_author).defaultLabels || CIFlowBot.defaultLabels
-    );
-  }
-
-  async dispatch(): Promise<void> {
-    if (this.confusing_command) {
-      await this.postReaction();
-      this.ctx.log.info(
-        {
-          event: this.event,
-          owner: this.owner,
-          command_args: this.command_args,
-        },
-        "ciflow dispatch is confused!"
-      );
-      return;
-    }
-    // Dispatch_strategies is like a pipeline of functions we can apply to
-    // change `this.dispatch_labels`. We can add other dispatch algorithms
-    // based on the ctx or user instructions.
-    // The future algorithms can manipulate the `this.dispatch_labels`, and
-    // individual workflows that can build up `if` conditions on the labels
-    // can be found in `.github/workflows` of pytorch/pytorch repo.
-    this.dispatch_strategies.map(this.dispatchStrategyFunc.bind(this));
-
-    // Signal the dispatch to GitHub
-    await this.setLabels();
-    await this.signalGithub();
-
-    // Logging of the dispatch
-    this.ctx.log.info(
-      {
-        dispatch_labels: this.dispatch_labels,
-        dispatch_strategies: this.dispatch_strategies,
-        event: this.event,
-        owner: this.owner,
-        pr_number: this.pr_number,
-        pr_labels: this.pr_labels,
-        repo: this.repo,
-      },
-      "ciflow dispatch success!"
-    );
-  }
-
-  dispatchStrategyFunc(strategyName: string): void {
-    switch (strategyName) {
-      case CIFlowBot.strategy_add_default_labels:
-        // strategy_add_default_labels: just make sure the we add `default_labels` to the existing set of pr_labels
-        if (this.dispatch_labels.length === 0) {
-          this.dispatch_labels = this.pr_labels;
-        }
-
-        // respect author's ciflow labels before PR is made
-        if (this.hasLabelsBeforePR()) {
-          break;
-        }
-
-        this.dispatch_labels = this.default_labels.concat(this.dispatch_labels);
-        break;
-      default: {
-        this.ctx.log.error({ strategyName }, "Unknown dispatch strategy");
-        break;
-      }
-    }
-  }
-
-  // triggerGHADispatch sends a signal to GitHub to trigger the dispatch
-  // The logic here is leverage some event that's rarely triggered by other users or bots,
-  // thus we pick "assign/unassign" to begin with. See details from the CIFlow RFC:
-  // https://github.com/pytorch/pytorch/issues/61888
-  async triggerGHADispatch(): Promise<void> {
-    await this.ctx.octokit.issues.addAssignees(
-      this.ctx.repo({
-        issue_number: this.pr_number,
-        assignees: [CIFlowBot.bot_assignee],
-      })
-    );
-
-    await this.ctx.octokit.issues.removeAssignees(
-      this.ctx.repo({
-        issue_number: this.pr_number,
-        assignees: [CIFlowBot.bot_assignee],
-      })
-    );
-  }
-
-  async postReaction(): Promise<void> {
-    if (this.event === CIFlowBot.event_issue_comment) {
-      await this.ctx.octokit.reactions.createForIssueComment(
-        this.ctx.repo({
-          comment_id: this.comment_id,
-          content: this.confusing_command ? "confused" : "+1",
-        })
-      );
-    }
-  }
-
-  // signalGithub triggers a dispatch (if needed) as well as reacts to the comment
-  async signalGithub(): Promise<void> {
-    if (
-      this.event === CIFlowBot.event_pull_request &&
-      this.default_labels.length === CIFlowBot.defaultLabels.length &&
-      this.default_labels.every(
-        (val, idx) => val === CIFlowBot.defaultLabels[idx]
-      )
-    ) {
-      this.ctx.log.info(
-        {
-          dispatch_labels: this.dispatch_labels,
-          default_labels: this.default_labels,
-          event: this.event,
-          owner: this.owner,
-          pr_number: this.pr_number,
-          pr_labels: this.pr_labels,
-          repo: this.repo,
-        },
-        "skipping pull request dispatch for defaultLabel"
-      );
-    } else {
-      await this.triggerGHADispatch();
-    }
-
-    await this.postReaction();
-
-    await new Ruleset(
-      this.ctx,
-      this.owner,
-      this.repo,
-      this.pr_number,
-      this.dispatch_labels
-    ).upsertRootComment();
-  }
-
-  hasLabelsBeforePR(): boolean {
-    return (
-      this.event === CIFlowBot.event_pull_request &&
-      this.pr_labels.some((l) => l.startsWith(CIFlowBot.pr_label_prefix))
-    );
-  }
-
-  isRerunCommand(): boolean {
-    return (
-      this.event === CIFlowBot.event_issue_comment &&
-      this.command_args.length > 0 &&
-      this.command_args._[0] === CIFlowBot.command_ciflow_rerun
-    );
-  }
-
-  logSkipLabels(message: string): void {
-    this.ctx.log.info(
-      {
-        dispatch_labels: this.dispatch_labels,
-        default_labels: this.default_labels,
-        event: this.event,
-        owner: this.owner,
-        pr_number: this.pr_number,
-        pr_labels: this.pr_labels,
-        repo: this.repo,
-      },
-      message
-    );
-  }
-
-  async setLabels(): Promise<void> {
-    if (this.hasLabelsBeforePR()) {
-      this.logSkipLabels("do not set labels as it'll override users choice.");
-      return;
-    }
-
-    if (this.isRerunCommand() && typeof this.command_args.l === undefined) {
-      this.logSkipLabels(
-        "Do not set labels for rerun comments without -l option."
-      );
-      return;
-    }
-
-    const labels = this.dispatch_labels.filter((label) =>
-      label.startsWith(CIFlowBot.pr_label_prefix)
-    );
-    const labelsToDelete = this.pr_labels.filter((l) => !labels.includes(l));
-    const labelsToAdd = labels.filter((l) => !this.pr_labels.includes(l));
-    for (const label of labelsToDelete) {
-      await this.ctx.octokit.issues.removeLabel(
-        this.ctx.repo({
-          issue_number: this.pr_number,
-          name: label,
-        })
-      );
-    }
-
-    // skip addLabels if there's no label to add
-    if (labelsToAdd.length > 0) {
-      await this.ctx.octokit.issues.addLabels(
-        this.ctx.repo({
-          issue_number: this.pr_number,
-          labels: labelsToAdd,
-        })
-      );
-    }
-    this.dispatch_labels = labels;
-  }
-
-  parseCommandArgs(): boolean {
-    switch (this.command) {
-      case CIFlowBot.command_ciflow: {
-        if (this.command_args._.length === 0) {
-          return false;
-        }
-        const commandArgsLength = Object.keys(this.command_args).length;
-        const subCommand = this.command_args._[0];
-        if (subCommand !== CIFlowBot.command_ciflow_rerun) {
-          return false;
-        }
-        // `rerun` command is confusing if it has any other subcommand
-        if (this.command_args._.length !== 1) {
-          this.confusing_command = true;
-        }
-        const lType = typeof this.command_args.l;
-        // `rerun` does not accept any other options but "-l"
-        // So, mark command as confusing if it has any other arguments than l
-        if (lType === "undefined") {
-          this.confusing_command =
-            this.confusing_command || commandArgsLength !== 1;
-          break;
-        }
-        this.confusing_command =
-          this.confusing_command || commandArgsLength !== 2;
-        if (lType !== "object") {
-          // Arg can be string, integer or boolean
-          this.command_args.l = [this.command_args.l];
-        }
-        for (const label of this.command_args.l) {
-          if (typeof label !== "string") {
-            this.confusing_command = true;
-            continue;
-          }
-          if (!label.startsWith(CIFlowBot.pr_label_prefix)) {
-            this.confusing_command = true;
-          }
-          this.dispatch_labels.push(label);
-        }
-        break;
-      }
-      default:
-        return false;
-    }
-
-    return true;
-  }
-
-  parseComment(): boolean {
-    // skip if the comment edit event is from the bot comment itself
-    if (
-      this.command.includes(ciflowCommentStart) ||
-      this.command.includes(ciflowCommentEnd)
-    ) {
-      return false;
-    }
-
-    // considering the `m` multi-line comment match
-    const re = new RegExp(
-      `^.*@${CIFlowBot.bot_assignee}\\s+(\\w+)\\s+(.*)$`,
-      "m"
-    );
-
-    const found = this.comment_body?.match(re);
-    if (!found) {
-      return false;
-    }
-
-    if (found.length >= 2) {
-      this.command = found[1];
-    }
-    if (found.length === 3) {
-      this.command_args = minimist(found[2].trim().split(/\s+/));
-    }
-
-    return this.parseCommandArgs();
-  }
-
-  async setContext(): Promise<boolean> {
-    this.event = this.ctx.name;
-    // @ts-expect-error (we know these are available because we only use PR and issue triggers)
-    const pr = this.ctx.payload?.pull_request || this.ctx.payload?.issue;
-    this.pr_number = pr?.number;
-    this.pr_author = pr?.user?.login;
-    this.pr_labels = pr?.labels
-      ?.filter((label: any) => label.name.startsWith(CIFlowBot.pr_label_prefix))
-      ?.map((label: any) => label.name);
-    this.owner = this.ctx.repo().owner;
-    this.repo = this.ctx.repo().repo;
-
-    if (this.event === CIFlowBot.event_issue_comment) {
-      // @ts-expect-error we check this above
-      this.comment_author = this.ctx.payload?.comment?.user?.login;
-      // @ts-expect-error we check this above
-      this.comment_body = this.ctx.payload?.comment?.body;
-      // @ts-expect-error we check this above
-      this.comment_id = this.ctx.payload?.comment?.id;
-
-      // if parseComment returns false, we don't need to do anything
-      if (!this.parseComment()) {
-        return false;
-      }
-
-      const permission = await this.getUserPermission(this.comment_author);
-      this.comment_author_permission = permission;
-    }
-
-    return this.valid();
-  }
-
-  async handler(): Promise<void> {
-    const isValid = await this.setContext();
-    this.default_labels = await this.getUserLabels();
-
-    this.ctx.log.info(
-      {
-        command: this.command,
-        command_args: this.command_args,
-        comment_author: this.comment_author,
-        comment_author_permission: this.comment_author_permission,
-        dispatch_labels: this.dispatch_labels,
-        dispatch_strategies: this.dispatch_strategies,
-        event: this.event,
-        owner: this.owner,
-        pr_author: this.pr_author,
-        pr_labels: this.pr_labels,
-        pr_number: this.pr_number,
-        repo: this.repo,
-        default_labels: this.default_labels,
-        confusing_command: this.confusing_command,
-        valid: isValid,
-      },
-      "ciflow dispatch started!"
-    );
-
-    if (!isValid || this.default_labels.length === 0) {
-      return;
-    }
-    await this.dispatch();
-  }
-
-  static main(app: Probot): void {
+export default function ciflowBot(app: Probot): void {
+  // When a pull request is open, add an initial set of labels based on the
+  // user's config, and add the ruleset comment.
+  app.on("pull_request.opened", async (context) => {
+    // Add labels based on user configuration.
     const tracker = new CachedIssueTracker(
       app,
       "ciflow_tracking_issue",
       parseCIFlowIssue
     );
-    const webhookHandler = async (ctx: Context): Promise<void> => {
-      await new CIFlowBot(ctx, tracker).handler();
-    };
-    app.on("pull_request.opened", webhookHandler);
-    app.on("pull_request.reopened", webhookHandler);
-    app.on("pull_request.synchronize", webhookHandler);
-    app.on("issue_comment.created", webhookHandler);
-    app.on("issue_comment.edited", webhookHandler);
-  }
+    const prNumber = context.payload.pull_request.number;
+    const labels = await getUserLabels(context, tracker);
+    if (labels.length !== 0) {
+      await context.octokit.issues.addLabels(
+        context.repo({
+          issue_number: prNumber,
+          labels: labels,
+        })
+      );
+    }
+
+    // Add CIFlowBot comment.
+    await new Ruleset(context, prNumber, labels).upsertRootComment();
+  });
+
+  // When a user tries to talk to ciflow, respond by telling them they don't
+  // need to do that anymore.
+  app.on("issue_comment.created", async (context) => {
+    const re = new RegExp(`^.*@pytorchbot\\s+(\\w+)\\s+(.*)$`, "m");
+    const found = context.payload.comment.body.match(re);
+    if (!found) {
+      return;
+    }
+    const command = found[1];
+    if (command !== "ciflow") {
+      return;
+    }
+
+    const prNumber = context.payload.issue.number;
+    await context.octokit.issues.createComment(
+      context.repo({
+        body:
+          "<strong>This command didn't do anything.</strong>\n" +
+          "You don't need to manually issue ciflow rerun commands anymore. " +
+          "Just adding a `ciflow/` label will trigger the workflow.",
+        issue_number: prNumber,
+      })
+    );
+  });
 }
 
 interface IRulesetJson {
@@ -528,18 +144,16 @@ export class Ruleset {
 
   constructor(
     readonly ctx: Context,
-    readonly owner: string,
-    readonly repo: string,
     readonly pr_number: number,
     readonly labels: string[]
   ) {}
 
   async fetchRulesetJson(): Promise<IRulesetJson | null> {
-    const prRes = await this.ctx.octokit.pulls.get({
-      owner: this.owner,
-      repo: this.repo,
-      pull_number: this.pr_number,
-    });
+    const prRes = await this.ctx.octokit.pulls.get(
+      this.ctx.repo({
+        pull_number: this.pr_number,
+      })
+    );
     const head = prRes?.data?.head;
     const contentRes = await this.ctx.octokit.repos.getContent({
       ref: head.sha,
@@ -559,12 +173,12 @@ export class Ruleset {
   }
 
   async fetchRootComment(perPage = 10): Promise<[number, string]> {
-    const commentsRes = await this.ctx.octokit.issues.listComments({
-      owner: this.owner,
-      repo: this.repo,
-      issue_number: this.pr_number,
-      per_page: perPage,
-    });
+    const commentsRes = await this.ctx.octokit.issues.listComments(
+      this.ctx.repo({
+        issue_number: this.pr_number,
+        per_page: perPage,
+      })
+    );
     for (const comment of commentsRes.data) {
       if (comment.body!.includes(ciflowCommentStart)) {
         return [comment.id, comment.body!];
@@ -579,6 +193,9 @@ export class Ruleset {
     body += `\nRuleset - Version: \`${ruleset.version}\``;
     body += `\nRuleset - File: ${this.ruleset_json_link}`;
     body += `\nPR ciflow labels: \`${Array.from(labels)}\``;
+
+    body +=
+      "\n<strong>Add ciflow labels to this PR to trigger more builds:</strong>";
 
     const workflowToLabelMap: any = {};
 
@@ -631,23 +248,7 @@ export class Ruleset {
       body += `\n| ${row[0]} | ${row[1].join(", ")} | ${row[2]} |`;
     }
 
-    body += `
-<br/>
-You can add a comment to the PR and tag @pytorchbot with the following commands:
-<br/>
-
-\`\`\`sh
-# ciflow rerun, "ciflow/default" will always be added automatically
-@pytorchbot ciflow rerun
-
-# ciflow rerun with additional labels "-l <ciflow/label_name>", which is equivalent to adding these labels manually and trigger the rerun
-@pytorchbot ciflow rerun -l ciflow/scheduled -l ciflow/slow
-\`\`\`
-
-<br/>
-
-For more information, please take a look at the [CI Flow Wiki](https://github.com/pytorch/pytorch/wiki/Continuous-Integration#using-ciflow).
-</details>`;
+    body += "</details>";
 
     return body;
   }
@@ -676,20 +277,20 @@ For more information, please take a look at the [CI Flow Wiki](https://github.co
     }
 
     if (commentId === 0) {
-      const res = await this.ctx.octokit.issues.createComment({
-        body,
-        owner: this.owner,
-        repo: this.repo,
-        issue_number: this.pr_number,
-      });
+      const res = await this.ctx.octokit.issues.createComment(
+        this.ctx.repo({
+          body,
+          issue_number: this.pr_number,
+        })
+      );
       commentId = res.data.id;
     } else {
-      await this.ctx.octokit.issues.updateComment({
-        body,
-        owner: this.owner,
-        repo: this.repo,
-        comment_id: commentId,
-      });
+      await this.ctx.octokit.issues.updateComment(
+        this.ctx.repo({
+          body,
+          comment_id: commentId,
+        })
+      );
     }
   }
 }

--- a/torchci/lib/bot/index.ts
+++ b/torchci/lib/bot/index.ts
@@ -1,7 +1,7 @@
 import { Probot } from "probot";
 import autoCcBot from "./autoCcBot";
 import autoLabelBot from "./autoLabelBot";
-import CIFlowBot from "./ciflowBot";
+import ciflowBot from "./ciflowBot";
 import ciflowPushTrigger from "./ciflowPushTrigger";
 import webhookToDynamo from "./webhookToDynamo";
 import verifyDisableTestIssueBot from "./verifyDisableTestIssueBot";
@@ -11,7 +11,7 @@ export default function bot(app: Probot) {
   autoCcBot(app);
   autoLabelBot(app);
   verifyDisableTestIssueBot(app);
-  CIFlowBot.main(app);
+  ciflowBot(app);
   ciflowPushTrigger(app);
   webhookToDynamo(app);
   mergeBot(app);

--- a/torchci/package.json
+++ b/torchci/package.json
@@ -18,7 +18,6 @@
     "dayjs": "^1.10.7",
     "dayjs-plugin-utc": "^0.1.2",
     "lodash": "^4.17.21",
-    "minimist": "^1.2.5",
     "next": "12.0.7",
     "probot": "^12.1.4",
     "react": "17.0.2",
@@ -30,7 +29,6 @@
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/lodash": "^4.14.178",
-    "@types/minimist": "^1.2.2",
     "@types/node": "17.0.8",
     "@types/react": "17.0.38",
     "@types/uuid": "^8.3.4",

--- a/torchci/test/ciflowBot.test.ts
+++ b/torchci/test/ciflowBot.test.ts
@@ -1,180 +1,20 @@
 import nock from "nock";
 import * as probot from "probot";
 import * as utils from "./utils";
-import CIFlowBot, { Ruleset } from "../lib/bot/ciflowBot";
+import ciflowBot, { Ruleset } from "../lib/bot/ciflowBot";
 import { nockTracker } from "./common";
 
 nock.disableNetConnect();
-jest.setTimeout(60000); // 60 seconds
-
-describe("CIFlowBot Unit Tests", () => {
-  const pr_number = 5;
-  const owner = "pytorch";
-  const repo = "pytorch";
-
-  beforeEach(() => {
-    jest
-      .spyOn(CIFlowBot.prototype, "getUserPermission")
-      .mockResolvedValue("write");
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  test("parseContext for pull_request.opened", async () => {
-    const event = require("./fixtures/pull_request.opened.json");
-    event.payload.pull_request.number = pr_number;
-    event.payload.repository.owner.login = owner;
-    event.payload.repository.name = repo;
-
-    // @ts-ignore
-    const ciflow = new CIFlowBot(new probot.Context(event, null, null));
-    const isValid = await ciflow.setContext();
-    expect(isValid).toBe(true);
-  });
-
-  test("parseContext for pull_request.reopened", async () => {
-    const event = require("./fixtures/pull_request.reopened.json");
-    event.payload.pull_request.number = pr_number;
-    event.payload.repository.owner.login = owner;
-    event.payload.repository.name = repo;
-
-    // @ts-ignore
-    const ciflow = new CIFlowBot(new probot.Context(event, null, null));
-    const isValid = await ciflow.setContext();
-    expect(isValid).toBe(true);
-  });
-
-  describe("parseContext for issue_comment.created with valid or invalid comments", () => {
-    const event = require("./fixtures/issue_comment.json");
-
-    beforeEach(() => {
-      event.payload.issue.number = pr_number;
-      event.payload.repository.owner.login = owner;
-      event.payload.repository.name = repo;
-      event.payload.comment.user.login = event.payload.issue.user.login;
-    });
-
-    const validComments = [
-      `@${CIFlowBot.bot_assignee} ciflow rerun`,
-      `@${CIFlowBot.bot_assignee} ciflow rerun `,
-      `   @${CIFlowBot.bot_assignee} ciflow rerun`,
-      `   @${CIFlowBot.bot_assignee}     ciflow rerun`,
-      `   @${CIFlowBot.bot_assignee}     ciflow   rerun`,
-      `   @${CIFlowBot.bot_assignee}     ciflow   rerun    `,
-      `Some other comments, \n@${CIFlowBot.bot_assignee} ciflow rerun`,
-      `Some other comments, \n   @${CIFlowBot.bot_assignee} ciflow rerun`,
-      `Some other comments, \n@${CIFlowBot.bot_assignee}    ciflow rerun`,
-      `Some other comments, \n@${CIFlowBot.bot_assignee} ciflow    rerun`,
-      `Some other comments, \n@${CIFlowBot.bot_assignee} ciflow rerun -l ciflow/slow`,
-      `Some other comments, \n@${CIFlowBot.bot_assignee} ciflow rerun -l ciflow/slow -l ciflow/scheduled`,
-      `Some other comments, \n@${CIFlowBot.bot_assignee} ciflow rerun -l     ciflow/slow`, // with spaces
-      `Some other comments, \n@${CIFlowBot.bot_assignee} ciflow rerun -l     ciflow/slow -l ciflow/scheduled`,
-      `Some other comments, \n@${CIFlowBot.bot_assignee} ciflow rerun\nNew comments\n`,
-    ];
-    test.each(validComments)(
-      `valid comment: %s`,
-      async (validComment: string) => {
-        event.payload.comment.body = validComment;
-        // @ts-ignore
-        const ciflow = new CIFlowBot(new probot.Context(event, null, null));
-        const isValid = await ciflow.setContext();
-        expect(isValid).toBe(true);
-        expect(ciflow.confusing_command).toBe(false);
-      }
-    );
-
-    const invalidComments = [
-      `invalid`,
-      `@${CIFlowBot.bot_assignee}`, // without commands appended after the @assignee
-      `@${CIFlowBot.bot_assignee} ciflow`, // without subcommand rerun
-    ];
-    test.each(invalidComments)(
-      "invalid comment: %s",
-      async (invalidComment: string) => {
-        event.payload.comment.body = invalidComment;
-        // @ts-ignore
-        const ciflow = new CIFlowBot(new probot.Context(event, null, null));
-        const isValid = await ciflow.setContext();
-        expect(isValid).toBe(false);
-      }
-    );
-    const confusingComments = [
-      `@${CIFlowBot.bot_assignee} ciflow rerun again`, // two subcommands
-      `@${CIFlowBot.bot_assignee} ciflow rerun -m foo`, // subcommand with invalid flag
-      `@${CIFlowBot.bot_assignee} ciflow rerun -l`, // rerun -l with no args
-      `@${CIFlowBot.bot_assignee} ciflow rerun -l 1`, // rerun -l with integer arg
-      `@${CIFlowBot.bot_assignee} ciflow rerun -l meow`, // rerun -l with integer arg
-    ];
-    test.each(confusingComments)(
-      "confusing comment: %s",
-      async (confusingComment: string) => {
-        event.payload.comment.body = confusingComment;
-        // @ts-ignore
-        const ciflow = new CIFlowBot(new probot.Context(event, null, null));
-        const isValid = await ciflow.setContext();
-        expect(isValid).toBe(true);
-        expect(ciflow.confusing_command).toBe(true);
-      }
-    );
-  });
-
-  test("parseContext for issue_comment.created with comment author that has write permission", async () => {
-    const event = require("./fixtures/issue_comment.json");
-    event.payload.issue.number = pr_number;
-    event.payload.repository.owner.login = owner;
-    event.payload.repository.name = repo;
-    event.payload.comment.body = `@${CIFlowBot.bot_assignee} ciflow rerun`;
-    event.payload.comment.user.login = "non-exist-user";
-
-    // @ts-ignore
-    const ciflow = new CIFlowBot(new probot.Context(event, null, null));
-    jest.spyOn(ciflow, "getUserPermission").mockResolvedValue("write");
-    const isValid = await ciflow.setContext();
-    expect(isValid).toBe(true);
-  });
-
-  test("parseContext for issue_comment.created with comment author that has read permission", async () => {
-    const event = require("./fixtures/issue_comment.json");
-    event.payload.issue.number = pr_number;
-    event.payload.repository.owner.login = owner;
-    event.payload.repository.name = repo;
-    event.payload.comment.body = `@${CIFlowBot.bot_assignee} ciflow rerun`;
-    event.payload.comment.user.login = "non-exist-user";
-
-    // @ts-ignore
-    const ciflow = new CIFlowBot(new probot.Context(event, null, null));
-    jest.spyOn(ciflow, "getUserPermission").mockResolvedValue("read");
-    const isValid = await ciflow.setContext();
-    expect(isValid).toBe(false);
-  });
-  /*
-  test('parseContext for issue_comment.created invalid owner/repo', async () => {
-    const event = require('./fixtures/issue_comment.json');
-    event.payload.issue.number = pr_number;
-    event.payload.repository.owner.login = 'invalid';
-    event.payload.repository.name = 'invalid';
-    event.payload.comment.body = `@${CIFlowBot.bot_assignee} ciflow rerun`;
-    event.payload.comment.user.login = event.payload.issue.user.login;
-
-    const ciflow = new CIFlowBot(new probot.Context(event, null, null));
-    const isValid = await ciflow.setContext();
-    expect(isValid).toBe(false);
-  });
- */
-});
 
 describe("CIFlowBot Integration Tests", () => {
   let p: probot.Probot;
   const pr_number = 5;
   const owner = "pytorch";
   const repo = "pytorch";
-  const comment_id = 10;
 
   beforeEach(() => {
     p = utils.testProbot();
-    p.load(CIFlowBot.main);
+    ciflowBot(p);
 
     nock("https://api.github.com")
       .post("/app/installations/2/access_tokens")
@@ -194,6 +34,7 @@ describe("CIFlowBot Integration Tests", () => {
   });
 
   afterEach(() => {
+    nock.cleanAll();
     jest.restoreAllMocks();
   });
 
@@ -256,134 +97,10 @@ describe("CIFlowBot Integration Tests", () => {
     scope.done();
   });
 
-  test("pull_request.opened event: do not override pre-existing labels", async () => {
-    const event = require("./fixtures/pull_request.opened.json");
-    event.payload.pull_request.number = pr_number;
-    event.payload.pull_request.labels = [{ name: "ciflow/eeklo" }];
-    event.payload.repository.owner.login = owner;
-    event.payload.repository.name = repo;
-
-    const scope = nock("https://api.github.com");
-    await p.receive(event);
-
-    if (!scope.isDone()) {
-      console.error("pending mocks: %j", scope.pendingMocks());
-    }
-    scope.done();
-  });
-
-  test("pull_request.opened event: add_default_labels strategy not rolled out", async () => {
-    const event = require("./fixtures/pull_request.opened.json");
-    event.payload.pull_request.user.login = "rumpelstiltskin";
-    event.payload.pull_request.number = pr_number;
-    event.payload.repository.owner.login = owner;
-    event.payload.repository.name = repo;
-
-    const scope = nock("https://api.github.com");
-    await p.receive(event);
-
-    if (!scope.isDone()) {
-      console.error("pending mocks: %j", scope.pendingMocks());
-    }
-    scope.done();
-  });
-
-  describe("issue_comment.created event: add_default_labels strategy happy path", () => {
+  describe("issue_comment.created event", () => {
     const event = require("./fixtures/issue_comment.json");
 
-    beforeEach(() => {
-      event.payload.issue.number = pr_number;
-      event.payload.repository.owner.login = owner;
-      event.payload.repository.name = repo;
-      event.payload.comment.user.login = "non-exist-user";
-      event.payload.comment.id = comment_id;
-    });
-
-    test.each([
-      [`@${CIFlowBot.bot_assignee} ciflow rerun`, ["ciflow/default"]],
-      [
-        `@${CIFlowBot.bot_assignee} ciflow rerun -l ciflow/scheduled`,
-        ["ciflow/default", "ciflow/scheduled"],
-      ],
-      [
-        `@${CIFlowBot.bot_assignee} ciflow rerun -l ciflow/scheduled -l ciflow/slow`,
-        ["ciflow/default", "ciflow/scheduled", "ciflow/slow"],
-      ],
-    ])(
-      `valid comment: %s, expected labels: %j`,
-      async (validComment: string, expectedLabels: string[]) => {
-        event.payload.comment.body = validComment;
-        for (const permission of ["write", "admin"]) {
-          const scope = nock("https://api.github.com")
-            .get(
-              `/repos/${owner}/${repo}/collaborators/${event.payload.comment.user.login}/permission`
-            )
-            .reply(200, { permission: `${permission}` })
-            .post(
-              `/repos/${owner}/${repo}/issues/${pr_number}/labels`,
-              (body) => {
-                expect(body).toMatchObject({ labels: expectedLabels });
-                return true;
-              }
-            )
-            .reply(200)
-            .post(
-              `/repos/${owner}/${repo}/issues/${pr_number}/assignees`,
-              (body) => {
-                expect(body).toMatchObject({
-                  assignees: [CIFlowBot.bot_assignee],
-                });
-                return true;
-              }
-            )
-            .reply(200)
-            .delete(
-              `/repos/${owner}/${repo}/issues/${pr_number}/assignees`,
-              (body) => {
-                expect(body).toMatchObject({
-                  assignees: [CIFlowBot.bot_assignee],
-                });
-                return true;
-              }
-            )
-            .reply(200)
-            .post(
-              `/repos/${owner}/${repo}/issues/comments/${comment_id}/reactions`,
-              (body) => {
-                expect(body).toMatchObject({ content: "+1" });
-                return true;
-              }
-            )
-            .reply(200);
-
-          await p.receive(event);
-
-          if (!scope.isDone()) {
-            console.error("pending mocks: %j", scope.pendingMocks());
-          }
-          scope.done();
-        }
-      }
-    );
-  });
-
-  describe("issue_comment.created event: add_default_labels strategy with invalid parseComments", () => {
-    const event = require("./fixtures/issue_comment.json");
-
-    beforeEach(() => {
-      event.payload.issue.number = pr_number;
-      event.payload.repository.owner.login = owner;
-      event.payload.repository.name = repo;
-      event.payload.comment.user.login = "non-exist-user";
-    });
-
-    test.each([
-      `invalid`,
-      `@${CIFlowBot.bot_assignee} invalid`,
-      `@${CIFlowBot.bot_assignee} ciflow invalid`,
-    ])(`invalid comment: %s`, async (invalidComment: string) => {
-      event.payload.comment.body = invalidComment;
-
+    test("random comment doesn't trigger response", async () => {
       // we shouldn't hit the github API, thus a catch-all scope and asserting no api calls
       const scope = nock("https://api.github.com");
 
@@ -393,29 +110,30 @@ describe("CIFlowBot Integration Tests", () => {
       }
       scope.done();
     });
-  });
 
-  test("issue_comment.created event: add_default_labels strategy not not enough permission", async () => {
-    const event = require("./fixtures/issue_comment.json");
-    event.payload.issue.number = pr_number;
-    event.payload.repository.owner.login = owner;
-    event.payload.repository.name = repo;
-    event.payload.comment.body = `@${CIFlowBot.bot_assignee} ciflow rerun`;
-    event.payload.comment.user.login = "non-exist-user";
-
-    for (const permission of ["read", "none"]) {
+    test("ciflowbot related comment elicits a response", async () => {
+      const owner = event.payload.repository.owner.login;
+      const repo = event.payload.repository.name;
+      event.payload.comment.body = "@pytorchbot ciflow do something!";
+      // we shouldn't hit the github API, thus a catch-all scope and asserting no api calls
       const scope = nock("https://api.github.com")
-        .get(
-          `/repos/${owner}/${repo}/collaborators/${event.payload.comment.user.login}/permission`
+        .post(
+          `/repos/${owner}/${repo}/issues/${pr_number}/comments`,
+          (body) => {
+            expect(JSON.stringify(body)).toContain(
+              "You don't need to manually issue ciflow"
+            );
+            return true;
+          }
         )
-        .reply(200, { permission: `${permission}` });
-      await p.receive(event);
+        .reply(200, {});
 
+      await p.receive(event);
       if (!scope.isDone()) {
         console.error("pending mocks: %j", scope.pendingMocks());
       }
       scope.done();
-    }
+    });
   });
 });
 
@@ -448,9 +166,7 @@ describe("Ruleset Integration Tests", () => {
   test("Upsert ruleset to the root comment block: create new comment when not found", async () => {
     // @ts-ignore
     const ctx = new probot.Context(event, github, null);
-    const ruleset = new Ruleset(ctx, owner, repo, pr_number, [
-      "ciflow/default",
-    ]);
+    const ruleset = new Ruleset(ctx, pr_number, ["ciflow/default"]);
 
     const scope = nock("https://api.github.com")
       .get(`/repos/${owner}/${repo}/pulls/${pr_number}`)
@@ -499,9 +215,7 @@ describe("Ruleset Integration Tests", () => {
   test("Upsert ruleset to the root comment block: update existing comment when found", async () => {
     // @ts-ignore
     const ctx = new probot.Context(event, github, null);
-    const ruleset = new Ruleset(ctx, owner, repo, pr_number, [
-      "ciflow/default",
-    ]);
+    const ruleset = new Ruleset(ctx, pr_number, ["ciflow/default"]);
 
     const scope = nock("https://api.github.com")
       .get(`/repos/${owner}/${repo}/pulls/${pr_number}`)


### PR DESCRIPTION
Now that the push trigger is rolled out, we can take the opportunity to significantly simplify the ciflow bot logic. In particular:
- We do not need the dispatch or signaling stuff anymore, as the dispatch is handled through the push trigger.
- We do not need ciflow command parsing or handling anymore, since adding a label is sufficient to trigger workflow runs.

So what is retained is:
- User configuration handling; ciflow will populate initial labels based on configuration. Honestly, we could get rid of this; the tracking issue has only a single config. But keeping it for now.
- CIFlow comment is nice because it tells you what labels you need to add, so that stays.
- Now, if you try to give ciflow a command, it'll respond telling you not to bother.
