### PR TITLE
Properly set highlighting when you first go to a link with a hash.

### DIFF
--- a/torchci/pages/minihud.tsx
+++ b/torchci/pages/minihud.tsx
@@ -44,6 +44,7 @@ function FailedJob({ job }: { job: JobData }) {
       const hash = window.location.hash.slice(1);
       setHighlighted(hash === job.id?.toString());
     };
+    onHashChanged();
 
     window.addEventListener("hashchange", onHashChanged);
 
@@ -247,6 +248,7 @@ function CommitSummary({ row }: { row: RowData }) {
       const hash = window.location.hash.slice(1);
       setHighlighted(hash === row.sha);
     };
+    onHashChanged();
 
     window.addEventListener("hashchange", onHashChanged);
 


### PR DESCRIPTION
Before, if you gave someone a link like torch-ci.com/minihud#4899572403 it would not set the highlighted style correctly. Fixing that.
