### PR TITLE
Fix hud reloading when you set name filter

### DIFF
--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -73,12 +73,30 @@ export function packHudParams(input: any) {
   };
 }
 
-export function formatHudURL(urlPrefix: string, params: HudParams): string {
+export function formatHudUrlForFetch(
+  urlPrefix: string,
+  params: HudParams
+): string {
+  return formatHudURL(urlPrefix, params, /*keepFilter=*/ false);
+}
+
+export function formatHudUrlForRoute(
+  urlPrefix: string,
+  params: HudParams
+): string {
+  return formatHudURL(urlPrefix, params, /*keepFilter=*/ true);
+}
+
+function formatHudURL(
+  urlPrefix: string,
+  params: HudParams,
+  keepFilter: boolean
+): string {
   let base = `/${urlPrefix}/${params.repoOwner}/${
     params.repoName
   }/${encodeURIComponent(params.branch)}/${params.page}`;
 
-  if (params.nameFilter != null) {
+  if (params.nameFilter != null && keepFilter) {
     base += `?name_filter=${encodeURIComponent(params.nameFilter)}`;
   }
   return base;

--- a/torchci/lib/useHudData.ts
+++ b/torchci/lib/useHudData.ts
@@ -1,10 +1,16 @@
 import useSWR from "swr";
-import { formatHudURL, HudData, HudParams, JobData, RowData } from "./types";
+import {
+  formatHudUrlForFetch,
+  HudData,
+  HudParams,
+  JobData,
+  RowData,
+} from "./types";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
 export default function useHudData(params: HudParams): HudData | undefined {
-  const { data } = useSWR(formatHudURL("api/hud", params), fetcher, {
+  const { data } = useSWR(formatHudUrlForFetch("api/hud", params), fetcher, {
     refreshInterval: 60 * 1000, // refresh every minute
     // Refresh even when the user isn't looking, so that switching to the tab
     // will always have fresh info.
@@ -12,7 +18,7 @@ export default function useHudData(params: HudParams): HudData | undefined {
   });
 
   const { data: originalPRData } = useSWR(
-    formatHudURL("api/original_pr_hud", params),
+    formatHudUrlForFetch("api/original_pr_hud", params),
     fetcher,
     {
       refreshInterval: 60 * 1000,

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[page].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[page].tsx
@@ -1,6 +1,5 @@
 import { useRouter } from "next/router";
 import _ from "lodash";
-import { SWRConfig } from "swr";
 
 import React, {
   useState,
@@ -9,18 +8,16 @@ import React, {
   useEffect,
   useCallback,
 } from "react";
-import { GetStaticPaths, GetStaticProps } from "next";
 import Link from "next/link";
 
 import styles from "components/hud.module.css";
 import {
-  formatHudURL,
+  formatHudUrlForRoute,
   HudParams,
   JobData,
   packHudParams,
   RowData,
 } from "lib/types";
-import fetchHud from "lib/fetchHud";
 import { LocalTimeHuman } from "components/TimeUtils";
 import TooltipTarget from "components/TooltipTarget";
 import JobConclusion from "components/JobConclusion";
@@ -169,10 +166,15 @@ function FilterableHudTable({
   const handleInput = useCallback((f) => setJobFilter(f), []);
   const handleSubmit = useCallback(() => {
     if (jobFilter === "") {
-      router.push(formatHudURL("hud", params), undefined, { shallow: true });
+      router.push(formatHudUrlForRoute("hud", params), undefined, {
+        shallow: true,
+      });
     } else {
       router.push(
-        formatHudURL("hud", { ...params, nameFilter: jobFilter ?? undefined }),
+        formatHudUrlForRoute("hud", {
+          ...params,
+          nameFilter: jobFilter ?? undefined,
+        }),
         undefined,
         {
           shallow: true,
@@ -230,14 +232,19 @@ function PageSelector({ params }: { params: HudParams }) {
       {params.page !== 0 ? (
         <span>
           <Link
-            href={formatHudURL("hud", { ...params, page: params.page - 1 })}
+            href={formatHudUrlForRoute("hud", {
+              ...params,
+              page: params.page - 1,
+            })}
           >
             Prev
           </Link>{" "}
           |{" "}
         </span>
       ) : null}
-      <Link href={formatHudURL("hud", { ...params, page: params.page + 1 })}>
+      <Link
+        href={formatHudUrlForRoute("hud", { ...params, page: params.page + 1 })}
+      >
         Next
       </Link>
     </div>
@@ -250,7 +257,7 @@ function HudHeader({ params }: { params: HudParams }) {
     e.preventDefault();
     // @ts-ignore
     const branch = e.target[0].value;
-    window.location.href = formatHudURL("hud", { ...params, branch });
+    window.location.href = formatHudUrlForRoute("hud", { ...params, branch });
   }
 
   return (

--- a/torchci/pages/minihud.tsx
+++ b/torchci/pages/minihud.tsx
@@ -11,7 +11,7 @@ import {
 import { useRouter } from "next/router";
 
 import fetchHud from "lib/fetchHud";
-import { formatHudURL, HudParams, JobData, RowData } from "lib/types";
+import { formatHudUrlForRoute, HudParams, JobData, RowData } from "lib/types";
 import styles from "components/minihud.module.css";
 import JobLinks from "components/JobLinks";
 import { LocalTimeHuman } from "components/TimeUtils";
@@ -358,7 +358,7 @@ export const getStaticProps: GetStaticProps = async () => {
   return {
     props: {
       fallback: {
-        [formatHudURL("api/hud", params)]: await fetchHud(params),
+        [formatHudUrlForRoute("api/hud", params)]: await fetchHud(params),
       },
     },
     revalidate: 60,


### PR DESCRIPTION
Adding name filter to the route naively was triggering a refetch of the data, because the memoization key for requests had changed. This is unnecessary because the data fetched is the same regardless of name filter. Fix this by splitting our utils for formatting URLs into two kinds, URLs for routes (which need the name filter applied), and URLs for fetch (which don't care about name filter)
