### PR TITLE
[hud] query GitHub to get branch information

### DIFF
--- a/torchci/lib/fetchHud.ts
+++ b/torchci/lib/fetchHud.ts
@@ -18,13 +18,13 @@ async function getCommitData(params: HudParams): Promise<HudCommitData[]> {
   const commitData = branch.data.map((data) => {
     const message = data.commit.message;
     const prMatch = message.match(prRegex);
-    let prNum;
+    let prNum = null;
     if (prMatch) {
       prNum = parseInt(prMatch[1]);
     }
 
     const phabMatch = message.match(phabRegex);
-    let diffNum;
+    let diffNum = null;
     if (phabMatch) {
       diffNum = phabMatch[1];
     }

--- a/torchci/lib/fetchHud.ts
+++ b/torchci/lib/fetchHud.ts
@@ -1,75 +1,72 @@
 import _ from "lodash";
+import { getOctokit } from "./github";
 import getRocksetClient from "./rockset";
-import { HudParams, JobData, RowData } from "./types";
+import { HudCommitData, HudParams, JobData, RowData } from "./types";
+
+async function getCommitData(params: HudParams): Promise<HudCommitData[]> {
+  const prRegex = /Pull Request resolved: .*?(\d+)'/;
+  const phabRegex = /Differential Revision: (D.*)/;
+
+  const octokit = await getOctokit(params.repoOwner, params.repoName);
+  const branch = await octokit.rest.repos.listCommits({
+    owner: params.repoOwner,
+    repo: params.repoName,
+    sha: params.branch,
+    per_page: 50,
+    page: params.page,
+  });
+  const commitData = branch.data.map((data) => {
+    const message = data.commit.message;
+    const prMatch = message.match(prRegex);
+    let prNum;
+    if (prMatch) {
+      prNum = parseInt(prMatch[1]);
+    }
+
+    const phabMatch = message.match(phabRegex);
+    let diffNum;
+    if (phabMatch) {
+      diffNum = phabMatch[1];
+    }
+
+    return {
+      time: data.commit.committer!.date as string,
+      sha: data.sha,
+      commitUrl: data.html_url,
+      commitMessage: data.commit.message.split("\n")[0],
+      prNum,
+      diffNum,
+    };
+  });
+  return commitData;
+}
 
 export default async function fetchHud(params: HudParams): Promise<{
   shaGrid: RowData[];
   jobNames: string[];
 }> {
-  const rocksetClient = getRocksetClient();
-  const [hudQuery, commitQuery] = await Promise.all([
-    rocksetClient.queryLambdas.executeQueryLambda(
-      "commons",
-      "hud_query",
-      "e7597aba6bba4320",
-      {
-        parameters: [
-          {
-            name: "branch",
-            type: "string",
-            value: `refs/heads/${params.branch}`,
-          },
-          {
-            name: "page",
-            type: "int",
-            value: params.page.toString(),
-          },
-          {
-            name: "owner",
-            type: "string",
-            value: params.repoOwner,
-          },
-          {
-            name: "repo",
-            type: "string",
-            value: params.repoName,
-          },
-        ],
-      }
-    ),
-    rocksetClient.queryLambdas.executeQueryLambda(
-      "commons",
-      "master_commits",
-      "cf237486df000e4b",
-      {
-        parameters: [
-          {
-            name: "branch",
-            type: "string",
-            value: `refs/heads/${params.branch}`,
-          },
-          {
-            name: "page",
-            type: "int",
-            value: params.page.toString(),
-          },
-          {
-            name: "owner",
-            type: "string",
-            value: params.repoOwner,
-          },
-          {
-            name: "repo",
-            type: "string",
-            value: params.repoName,
-          },
-        ],
-      }
-    ),
-  ]);
+  const commits = await getCommitData(params);
 
-  const commitsBySha = _.keyBy(commitQuery.results, "sha");
-  let results = hudQuery.results;
+  // Retrieve job data from rockset
+  const shas = commits.map((commit) => commit.sha);
+  const rocksetClient = getRocksetClient();
+  const hudQuery = await rocksetClient.queryLambdas.executeQueryLambda(
+    "commons",
+    "hud_query",
+    "cee7578c7a095800",
+    {
+      parameters: [
+        {
+          name: "shas",
+          type: "string",
+          value: shas.join(","),
+        },
+      ],
+    }
+  );
+
+  const commitsBySha = _.keyBy(commits, "sha");
+  const results = hudQuery.results;
 
   const namesSet: Set<string> = new Set();
   // Built a list of all the distinct job names.
@@ -122,12 +119,7 @@ export default async function fetchHud(params: HudParams): Promise<{
     }
 
     const row: RowData = {
-      sha: sha,
-      time: commit.timestamp,
-      commitUrl: commit.url,
-      diffNum: commit.diffNum,
-      commitMessage: commit.message,
-      prNum: commit.prNum,
+      ...commit,
       jobs: jobs,
     };
     shaGrid.push(row);

--- a/torchci/lib/github.ts
+++ b/torchci/lib/github.ts
@@ -1,0 +1,30 @@
+import { Octokit, App } from "octokit";
+import { createAppAuth } from "@octokit/auth-app";
+
+export async function getOctokit(
+  owner: string,
+  repo: string
+): Promise<Octokit> {
+  let privateKey = process.env.PRIVATE_KEY as string;
+  privateKey = Buffer.from(privateKey, "base64").toString();
+
+  const app = new App({
+    appId: process.env.APP_ID!,
+    privateKey,
+  });
+  const installation = await app.octokit.request(
+    "GET /repos/{owner}/{repo}/installation",
+    { owner, repo }
+  );
+
+  return new Octokit({
+    authStrategy: createAppAuth,
+    auth: {
+      appId: process.env.APP_ID,
+      privateKey,
+      // optional: this will make appOctokit authenticate as app (JWT)
+      //           or installation (access token), depending on the request URL
+      installationId: installation.data.id,
+    },
+  });
+}

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -33,8 +33,8 @@ export interface HudCommitData {
   time: string;
   commitUrl: string;
   commitMessage: string;
-  diffNum?: string; // like: `D123456`
-  prNum?: number;
+  diffNum: string | null; // like: `D123456`
+  prNum: number | null;
 }
 
 export interface RowData extends HudCommitData {

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -28,13 +28,16 @@ export interface CommitData {
   jobs: JobData[];
 }
 
-export interface RowData {
+export interface HudCommitData {
   sha: string;
   time: string;
   commitUrl: string;
   commitMessage: string;
-  diffNum: string; // like: `D123456`
-  prNum: number | null;
+  diffNum?: string; // like: `D123456`
+  prNum?: number;
+}
+
+export interface RowData extends HudCommitData {
   jobs: JobData[];
 }
 

--- a/torchci/package.json
+++ b/torchci/package.json
@@ -19,6 +19,7 @@
     "dayjs-plugin-utc": "^0.1.2",
     "lodash": "^4.17.21",
     "next": "12.0.8",
+    "octokit": "^1.7.1",
     "probot": "^12.1.4",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/torchci/yarn.lock
+++ b/torchci/yarn.lock
@@ -1309,6 +1309,19 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@octokit/app@^12.0.4":
+  version "12.0.5"
+  resolved "https://registry.yarnpkg.com/@octokit/app/-/app-12.0.5.tgz#0b25446daffcb36967b26944410eab1ccbba0c06"
+  integrity sha512-lM3pIfx2h+UbvsXHFVs1ApJ9Rmp8LO4ciFSr5q/9MdHmhsH6WtwayieUn875xwB77IoR9r8czxxxASu2WCtdeA==
+  dependencies:
+    "@octokit/auth-app" "^3.3.0"
+    "@octokit/auth-unauthenticated" "^2.0.4"
+    "@octokit/core" "^3.4.0"
+    "@octokit/oauth-app" "^3.3.2"
+    "@octokit/plugin-paginate-rest" "^2.13.3"
+    "@octokit/types" "^6.27.1"
+    "@octokit/webhooks" "^9.0.1"
+
 "@octokit/auth-app@^3.3.0":
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/@octokit/auth-app/-/auth-app-3.6.1.tgz#aa5b02cc211175cbc28ce6c03c73373c1206d632"
@@ -1325,7 +1338,7 @@
     universal-github-app-jwt "^1.0.1"
     universal-user-agent "^6.0.0"
 
-"@octokit/auth-oauth-app@^4.3.0":
+"@octokit/auth-oauth-app@^4.0.0", "@octokit/auth-oauth-app@^4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-app/-/auth-oauth-app-4.3.0.tgz#de02f184360ffd7cfccef861053784fc4410e7ea"
   integrity sha512-cETmhmOQRHCz6cLP7StThlJROff3A/ln67Q961GuIr9zvyFXZ4lIJy9RE6Uw5O7D8IXWPU3jhDnG47FTSGQr8Q==
@@ -1348,7 +1361,7 @@
     "@octokit/types" "^6.10.0"
     universal-user-agent "^6.0.0"
 
-"@octokit/auth-oauth-user@^1.2.1", "@octokit/auth-oauth-user@^1.2.3":
+"@octokit/auth-oauth-user@^1.2.1", "@octokit/auth-oauth-user@^1.2.3", "@octokit/auth-oauth-user@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-user/-/auth-oauth-user-1.3.0.tgz#da4e4529145181a6aa717ae858afb76ebd6e3360"
   integrity sha512-3QC/TAdk7onnxfyZ24BnJRfZv8TRzQK7SEFUS9vLng4Vv6Hv6I64ujdk/CUkREec8lhrwU764SZ/d+yrjjqhaQ==
@@ -1367,7 +1380,7 @@
   dependencies:
     "@octokit/types" "^6.0.3"
 
-"@octokit/auth-unauthenticated@^2.0.2":
+"@octokit/auth-unauthenticated@^2.0.0", "@octokit/auth-unauthenticated@^2.0.2", "@octokit/auth-unauthenticated@^2.0.4":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@octokit/auth-unauthenticated/-/auth-unauthenticated-2.1.0.tgz#ef97de366836e09f130de4e2205be955f9cf131c"
   integrity sha512-+baofLfSL0CAv3CfGQ9rxiZZQEX8VNJMGuuS4PgrMRBUL52Ho5+hQYb63UJQshw7EXYMPDZxbXznc0y33cbPqw==
@@ -1375,7 +1388,7 @@
     "@octokit/request-error" "^2.1.0"
     "@octokit/types" "^6.0.3"
 
-"@octokit/core@^3.2.4":
+"@octokit/core@^3.2.4", "@octokit/core@^3.3.2", "@octokit/core@^3.4.0", "@octokit/core@^3.5.1":
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.5.1.tgz#8601ceeb1ec0e1b1b8217b960a413ed8e947809b"
   integrity sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==
@@ -1406,12 +1419,27 @@
     "@octokit/types" "^6.0.3"
     universal-user-agent "^6.0.0"
 
-"@octokit/oauth-authorization-url@^4.3.1":
+"@octokit/oauth-app@^3.3.2", "@octokit/oauth-app@^3.5.1":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@octokit/oauth-app/-/oauth-app-3.6.0.tgz#36f660c7eb6b5a5cd23f6207a8d95e74b6834db0"
+  integrity sha512-OxPw4ItQXaC2GuEXyZB7EmZ2rHvNFX4y3yAsqdFIRW7qg2HyoEPxacxza6c8wqbEEvu84b98AJ5BXm+IjPWrww==
+  dependencies:
+    "@octokit/auth-oauth-app" "^4.0.0"
+    "@octokit/auth-oauth-user" "^1.3.0"
+    "@octokit/auth-unauthenticated" "^2.0.0"
+    "@octokit/core" "^3.3.2"
+    "@octokit/oauth-authorization-url" "^4.2.1"
+    "@octokit/oauth-methods" "^1.2.2"
+    "@types/aws-lambda" "^8.10.83"
+    fromentries "^1.3.1"
+    universal-user-agent "^6.0.0"
+
+"@octokit/oauth-authorization-url@^4.2.1", "@octokit/oauth-authorization-url@^4.3.1":
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/@octokit/oauth-authorization-url/-/oauth-authorization-url-4.3.3.tgz#6a6ef38f243086fec882b62744f39b517528dfb9"
   integrity sha512-lhP/t0i8EwTmayHG4dqLXgU+uPVys4WD/qUNvC+HfB1S1dyqULm5Yx9uKc1x79aP66U1Cb4OZeW8QU/RA9A4XA==
 
-"@octokit/oauth-methods@^1.1.0":
+"@octokit/oauth-methods@^1.1.0", "@octokit/oauth-methods@^1.2.2":
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@octokit/oauth-methods/-/oauth-methods-1.2.6.tgz#b9ac65e374b2cc55ee9dd8dcdd16558550438ea7"
   integrity sha512-nImHQoOtKnSNn05uk2o76om1tJWiAo4lOu2xMAHYsNr0fwopP+Dv+2MlGvaMMlFjoqVd3fF3X5ZDTKCsqgmUaQ==
@@ -1435,14 +1463,14 @@
     "@octokit/request-error" "^2.1.0"
     "@octokit/types" "^6.0.3"
 
-"@octokit/plugin-paginate-rest@^2.6.2":
+"@octokit/plugin-paginate-rest@^2.13.3", "@octokit/plugin-paginate-rest@^2.16.8", "@octokit/plugin-paginate-rest@^2.6.2":
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz#32e9c7cab2a374421d3d0de239102287d791bce7"
   integrity sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==
   dependencies:
     "@octokit/types" "^6.34.0"
 
-"@octokit/plugin-rest-endpoint-methods@^5.0.1":
+"@octokit/plugin-rest-endpoint-methods@^5.0.1", "@octokit/plugin-rest-endpoint-methods@^5.12.0":
   version "5.13.0"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz#8c46109021a3412233f6f50d28786f8e552427ba"
   integrity sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==
@@ -1450,7 +1478,7 @@
     "@octokit/types" "^6.34.0"
     deprecation "^2.3.1"
 
-"@octokit/plugin-retry@^3.0.6":
+"@octokit/plugin-retry@^3.0.6", "@octokit/plugin-retry@^3.0.9":
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-retry/-/plugin-retry-3.0.9.tgz#ae625cca1e42b0253049102acd71c1d5134788fe"
   integrity sha512-r+fArdP5+TG6l1Rv/C9hVoty6tldw6cE2pRHNGmFPdyfrc696R6JjrQ3d7HdVqGwuzfyrcaLAKD7K8TX8aehUQ==
@@ -1458,7 +1486,7 @@
     "@octokit/types" "^6.0.3"
     bottleneck "^2.15.3"
 
-"@octokit/plugin-throttling@^3.3.4":
+"@octokit/plugin-throttling@^3.3.4", "@octokit/plugin-throttling@^3.5.1":
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-throttling/-/plugin-throttling-3.5.2.tgz#8b1797a5f14edbca0b8af619394056ed0ed5c9b5"
   integrity sha512-Eu7kfJxU8vmHqWGNszWpg+GVp2tnAfax3XQV5CkYPEE69C+KvInJXW9WajgSeW+cxYe0UVdouzCtcreGNuJo7A==
@@ -1487,7 +1515,7 @@
     node-fetch "^2.6.7"
     universal-user-agent "^6.0.0"
 
-"@octokit/types@^6.0.1", "@octokit/types@^6.0.3", "@octokit/types@^6.1.1", "@octokit/types@^6.10.0", "@octokit/types@^6.12.2", "@octokit/types@^6.16.1", "@octokit/types@^6.34.0":
+"@octokit/types@^6.0.1", "@octokit/types@^6.0.3", "@octokit/types@^6.1.1", "@octokit/types@^6.10.0", "@octokit/types@^6.12.2", "@octokit/types@^6.16.1", "@octokit/types@^6.26.0", "@octokit/types@^6.27.1", "@octokit/types@^6.34.0":
   version "6.34.0"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.34.0.tgz#c6021333334d1ecfb5d370a8798162ddf1ae8218"
   integrity sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==
@@ -1504,7 +1532,7 @@
   resolved "https://registry.yarnpkg.com/@octokit/webhooks-types/-/webhooks-types-5.2.0.tgz#9d1d451f37460107409c81cab04dd473108abb02"
   integrity sha512-OZhKy1w8/GF4GWtdiJc+o8sloWAHRueGB78FWFLZnueK7EHV9MzDVr4weJZMflJwMK4uuYLzcnJVnAoy3yB35g==
 
-"@octokit/webhooks@^9.22.0", "@octokit/webhooks@^9.8.4":
+"@octokit/webhooks@^9.0.1", "@octokit/webhooks@^9.22.0", "@octokit/webhooks@^9.8.4":
   version "9.22.0"
   resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-9.22.0.tgz#07a36a10358d39c1870758fae2b1ad3c24ca578d"
   integrity sha512-wUd7nGfDRHG6xkz311djmq6lIB2tQ+r94SNkyv9o0bQhOsrkwH8fQCM7uVsbpkGUU2lqCYsVoa8z/UC9HJgRaw==
@@ -1654,6 +1682,11 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
+"@types/aws-lambda@^8.10.83":
+  version "8.10.92"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.92.tgz#645f769ff88b8eba1acd35542695ac322c7757c4"
+  integrity sha512-dB14TltT1SNq73z3MaZfKyyBZ37NAgAFl8jze59bisR4fJ6pB6AYGxItHFkooZbN7UcVJX/cFudM4p8wp1W4rA==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.18"
@@ -3536,6 +3569,11 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
+fromentries@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/fromentries/-/fromentries-1.3.2.tgz#e4bca6808816bf8f93b52750f1127f5a6fd86e3a"
+  integrity sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -5203,6 +5241,20 @@ octokit-auth-probot@^1.2.2:
     "@octokit/auth-token" "^2.4.4"
     "@octokit/auth-unauthenticated" "^2.0.2"
     "@octokit/types" "^6.1.1"
+
+octokit@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/octokit/-/octokit-1.7.1.tgz#d86e51c8e0cec65cb64822ca2c9ff1b052593799"
+  integrity sha512-1b7eRgU8uWetHOWr8f9ptnVo2EKbrkOfocMeQdpgCt7tl/LK67HptFsy2Xg4fMjsJ/+onoBJW0hy/fO0In3/uA==
+  dependencies:
+    "@octokit/app" "^12.0.4"
+    "@octokit/core" "^3.5.1"
+    "@octokit/oauth-app" "^3.5.1"
+    "@octokit/plugin-paginate-rest" "^2.16.8"
+    "@octokit/plugin-rest-endpoint-methods" "^5.12.0"
+    "@octokit/plugin-retry" "^3.0.9"
+    "@octokit/plugin-throttling" "^3.5.1"
+    "@octokit/types" "^6.26.0"
 
 on-finished@~2.3.0:
   version "2.3.0"


### PR DESCRIPTION
@malfet pointed out that the release/1.1 branch was totally borked after he force pushed it. This is because our Rockset query reconstructs the branch from the history of `push` webhooks. This works for master, which is append-only, but breaks for a branch that was force-pushed to.

We could probably fix this with fancy rockset queries, but it seems simpler to just ask GitHub for the branch history directly, and query rockset just for the SHAs we care about.

We use the PyTorch Bot app to authenticate GH requests. This is nice because:
- We have the same permissions as the bot, which we use to receive webhooks to populate our job data anyway.
- We have better rate limits without requiring user login, as GitHub Apps are allotted extra rate limits per user per repo they are installed to (see [docs](https://docs.github.com/en/developers/apps/building-github-apps/rate-limits-for-github-apps#default-server-to-server-rate-limits-for-githubcom))
