### PR TITLE
[hud] Fix to PR view

### DIFF
--- a/torchci/components/CommitStatus.tsx
+++ b/torchci/components/CommitStatus.tsx
@@ -23,7 +23,13 @@ function WorkflowsContainer({ jobs }: { jobs: JobData[] }) {
   );
 }
 
-export default function CommitStatus({ commit }: { commit: CommitData }) {
+export default function CommitStatus({
+  commit,
+  jobs,
+}: {
+  commit: CommitData;
+  jobs: JobData[];
+}) {
   return (
     <>
       <VersionControlLinks sha={commit.sha} diffNum={commit.diffNum} />
@@ -34,17 +40,17 @@ export default function CommitStatus({ commit }: { commit: CommitData }) {
 
       <FilteredJobList
         filterName="Failed jobs"
-        jobs={commit.jobs}
+        jobs={jobs}
         pred={isFailedJob}
       />
 
       <FilteredJobList
         filterName="Pending jobs"
-        jobs={commit.jobs}
+        jobs={jobs}
         pred={(job) => job.conclusion === "pending"}
       />
 
-      <WorkflowsContainer jobs={commit.jobs} />
+      <WorkflowsContainer jobs={jobs} />
     </>
   );
 }

--- a/torchci/lib/fetchCommit.ts
+++ b/torchci/lib/fetchCommit.ts
@@ -1,57 +1,34 @@
 import _ from "lodash";
+import { getOctokit, commitDataFromResponse } from "./github";
 import getRocksetClient from "./rockset";
 
-import { CommitData } from "./types";
+import { CommitData, JobData } from "./types";
 
-export default async function fetchCommit(sha: string): Promise<CommitData> {
+export default async function fetchCommit(
+  owner: string,
+  repo: string,
+  sha: string
+): Promise<{ commit: CommitData; jobs: JobData[] }> {
+  // Retrieve commit data from GitHub
+  const octokit = await getOctokit(owner, repo);
+  const res = await octokit.rest.repos.getCommit({ owner, repo, ref: sha });
+  const commit = commitDataFromResponse(res.data);
+
   const rocksetClient = getRocksetClient();
-  const [commitQuery, commitJobsQuery] = await Promise.all([
-    rocksetClient.queryLambdas.executeQueryLambda(
-      "commons",
-      "commit_query",
-      "06a5040c34cdf9d9",
-      {
-        parameters: [
-          {
-            name: "sha",
-            type: "string",
-            value: sha,
-          },
-        ],
-      }
-    ),
-    await rocksetClient.queryLambdas.executeQueryLambda(
-      "commons",
-      "commit_jobs_query",
-      "cc19958f5b6953c3",
-      {
-        parameters: [
-          {
-            name: "sha",
-            type: "string",
-            value: sha,
-          },
-        ],
-      }
-    ),
-  ]);
-
-  const commit = commitQuery.results?.[0].commit;
-  const firstLine = commit.message.indexOf("\n");
-  const commitTitle: string = commit.message.slice(0, firstLine);
-  const commitMessageBody: string = commit.message.slice(firstLine + 1);
-
-  const pullRe = /Pull Request resolved: (.*)/;
-  const exportedPhabRegex = /Differential Revision: \[(.*)\]/;
-  const commitedPhabRegex = /Differential Revision: (D.*)/;
-
-  let match = commitMessageBody.match(pullRe);
-  const prUrl = match ? match[1] : null;
-
-  match = commitMessageBody.match(exportedPhabRegex);
-  if (match === null) {
-    match = commitMessageBody.match(commitedPhabRegex);
-  }
+  const commitJobsQuery = await rocksetClient.queryLambdas.executeQueryLambda(
+    "commons",
+    "commit_jobs_query",
+    "cc19958f5b6953c3",
+    {
+      parameters: [
+        {
+          name: "sha",
+          type: "string",
+          value: sha,
+        },
+      ],
+    }
+  );
 
   let jobs = commitJobsQuery.results!;
 
@@ -63,13 +40,8 @@ export default async function fetchCommit(sha: string): Promise<CommitData> {
   // Now reverse again, because we want to display earlier jobs first in the the UI.
   jobs.reverse();
 
-  const diffNum = match ? match[1] : null;
   return {
-    sha: commit.id,
-    commitTitle,
-    commitMessageBody,
-    prUrl,
-    diffNum,
+    commit,
     jobs,
   };
 }

--- a/torchci/lib/github.ts
+++ b/torchci/lib/github.ts
@@ -1,6 +1,9 @@
 import { Octokit, App } from "octokit";
 import { createAppAuth } from "@octokit/auth-app";
+import { CommitData } from "./types";
 
+// Retrieve an Octokit instance authenticated as PyTorchBot's installation on
+// the given repo.
 export async function getOctokit(
   owner: string,
   repo: string
@@ -22,9 +25,44 @@ export async function getOctokit(
     auth: {
       appId: process.env.APP_ID,
       privateKey,
-      // optional: this will make appOctokit authenticate as app (JWT)
-      //           or installation (access token), depending on the request URL
       installationId: installation.data.id,
     },
   });
+}
+
+const PR_REGEX = /Pull Request resolved: .*?(\d+)/;
+const PHAB_REGEX = /Differential Revision: (D.*)/;
+const EXPORTED_PHAB_REGEX = /Differential Revision: \[(.*)\]/;
+
+// Turns a JSON response from octokit into our CommitData type.
+export function commitDataFromResponse(data: any): CommitData {
+  const message = data.commit.message;
+  const prMatch = message.match(PR_REGEX);
+  let prNum = null;
+  if (prMatch) {
+    prNum = parseInt(prMatch[1]);
+  }
+
+  const phabMatch = message.match(PHAB_REGEX);
+  let diffNum = null;
+  if (phabMatch) {
+    diffNum = phabMatch[1];
+  }
+
+  if (diffNum === null) {
+    const exportedPhabMatch = message.match(EXPORTED_PHAB_REGEX);
+    if (exportedPhabMatch) {
+      diffNum = exportedPhabMatch[1];
+    }
+  }
+
+  return {
+    time: data.commit.committer!.date as string,
+    sha: data.sha,
+    commitUrl: data.html_url,
+    commitTitle: data.commit.message.split("\n")[0],
+    commitMessageBody: data.commit.message,
+    prNum,
+    diffNum,
+  };
 }

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -21,23 +21,15 @@ export interface JobData {
 
 export interface CommitData {
   sha: string;
-  prUrl: string | null;
+  time: string;
+  prNum: number | null;
   diffNum: string | null;
+  commitUrl: string;
   commitTitle: string;
   commitMessageBody: string;
-  jobs: JobData[];
 }
 
-export interface HudCommitData {
-  sha: string;
-  time: string;
-  commitUrl: string;
-  commitMessage: string;
-  diffNum: string | null; // like: `D123456`
-  prNum: number | null;
-}
-
-export interface RowData extends HudCommitData {
+export interface RowData extends CommitData {
   jobs: JobData[];
 }
 

--- a/torchci/pages/[repoOwner]/[repoName]/commit/[sha].tsx
+++ b/torchci/pages/[repoOwner]/[repoName]/commit/[sha].tsx
@@ -13,7 +13,7 @@ export function CommitInfo({
   repoName: string;
   sha: string;
 }) {
-  const { data: commit, error } = useSWR(
+  const { data, error } = useSWR(
     `/api/${repoOwner}/${repoName}/commit/${sha}`,
     fetcher,
     {
@@ -28,14 +28,15 @@ export function CommitInfo({
     return <div>Error occured</div>;
   }
 
-  if (commit === undefined) {
+  if (data === undefined) {
     return <div>Loading...</div>;
   }
 
+  const { commit, jobs } = data;
   return (
     <div>
       <h2>{commit.commitTitle}</h2>
-      <CommitStatus commit={commit} />
+      <CommitStatus commit={commit} jobs={jobs} />
     </div>
   );
 }

--- a/torchci/pages/[repoOwner]/[repoName]/pull/[prNumber].tsx
+++ b/torchci/pages/[repoOwner]/[repoName]/pull/[prNumber].tsx
@@ -16,7 +16,7 @@ function CommitInfo({
   repoName: string;
   sha: string;
 }) {
-  const { data: commit, error } = useSWR(
+  const { data, error } = useSWR(
     sha != null ? `/api/${repoOwner}/${repoName}/commit/${sha}` : null,
     fetcher,
     {
@@ -30,11 +30,12 @@ function CommitInfo({
     return <div>Error occured</div>;
   }
 
-  if (commit === undefined) {
+  if (data === undefined) {
     return <div>Loading...</div>;
   }
+  const { commit, jobs } = data;
 
-  return <CommitStatus commit={commit} />;
+  return <CommitStatus commit={commit} jobs={jobs} />;
 }
 
 function CommitHeader({

--- a/torchci/pages/api/[repoOwner]/[repoName]/commit/[sha].ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/commit/[sha].ts
@@ -1,10 +1,18 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import fetchCommit from "lib/fetchCommit";
-import { CommitData } from "lib/types";
+import { CommitData, JobData } from "lib/types";
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<CommitData>
+  res: NextApiResponse<{ commit: CommitData; jobs: JobData[] }>
 ) {
-  res.status(200).json(await fetchCommit(req.query.sha as string));
+  res
+    .status(200)
+    .json(
+      await fetchCommit(
+        req.query.repoOwner as string,
+        req.query.repoName as string,
+        req.query.sha as string
+      )
+    );
 }

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[page].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[page].tsx
@@ -62,7 +62,7 @@ function HudRow({ rowData }: { rowData: RowData }) {
           {/* here, we purposefully do not use Link/. The prefetch behavior
           (even with prefetch disabled) spams our backend).*/}
           <a href={`/${params.repoOwner}/${params.repoName}/commit/${sha}`}>
-            {rowData.commitMessage}
+            {rowData.commitTitle}
           </a>
         </div>
       </td>

--- a/torchci/pages/minihud.tsx
+++ b/torchci/pages/minihud.tsx
@@ -153,7 +153,7 @@ function CommitSummaryLine({
         {/* here, we purposefully do not use Link/. The prefetch behavior
           (even with prefetch disabled) spams our backend).*/}
         <a target="_blank" rel="noreferrer" href={`/pytorch/pytorch/commit/${row.sha}`}>
-          {row.commitMessage}
+          {row.commitTitle}
         </a>
       </span>
 


### PR DESCRIPTION
Similar to https://github.com/pytorch/test-infra/pull/187, we had an issue where reconstructing PR commit state from webhooks wasn't good enough. In particular, it would fail if:
- Someone force-pushed to a PR branch.
- Someone created a PR from a forked repo (since we don't receive the `push` webhook.

Fix is the same as https://github.com/pytorch/test-infra/pull/187: ask GitHub for the information.

I also took the opportunity to clean up some of the code around commit data handling, so now commit info for the HUD and for the commit/PR views goes through the same flow.
