### PR TITLE
CURRENT_TIME is not the same as CURRENT_TIMESTAMP

### DIFF
--- a/torchci/lib/fetchFlakyTests.ts
+++ b/torchci/lib/fetchFlakyTests.ts
@@ -8,7 +8,7 @@ export default async function fetchFlakyTests(num_hours: string): Promise<FlakyT
     rocksetClient.queryLambdas.executeQueryLambda(
       "commons",
       "flaky_test_query",
-      "f9456c0b8c5a39a3",
+      "12b03f2fbf584dc0",
       {
         parameters: [
           {


### PR DESCRIPTION
Realized I was getting results for the query even after expanding to 24 hours and then realized this mistake.

this is another lambda update:
```
SELECT 
  flaky_tests.name,
  flaky_tests.suite,
  flaky_tests.file,
  flaky_tests._event_time,
  sum(flaky_tests.num_green) AS "num_green",
  sum(flaky_tests.num_red) AS "num_red",
  ARRAY_AGG(flaky_tests.workflow_id) AS workflow_ids,
  ARRAY_AGG(workflow.name) as workflow_names,
FROM commons.flaky_tests flaky_tests JOIN commons.workflow_run workflow on CAST(flaky_tests.workflow_id as int) = workflow.id
>>>>>>>>>>>>>>>>>>>>>>>>>>> THIS LINE CHANGED
WHERE flaky_tests._event_time > (CURRENT_TIME() - HOURs(:num_hours))
<<<<< TO THIS LINE
WHERE flaky_tests._event_time > (CURRENT_TIMESTAMP() - HOURs(:num_hours))
>>>>>>>>>>>>>>>>>>>>>>>>>>> 
GROUP BY name, suite, file, _event_time
Fixes the problem where the bot kept picking up the same instance of flaky test in different cron jobs.
```