### PR TITLE
Remove labeling for module: flaky-tests

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -42,10 +42,6 @@ function myBot(app: Probot): void {
       case "critical":
         addLabel(labelSet, newLabels, "triage review");
         break;
-      case "module: flaky-tests":
-        addLabel(labelSet, newLabels, "high priority");
-        addLabel(labelSet, newLabels, "triage review");
-        break;
     }
 
     if (newLabels.length) {


### PR DESCRIPTION
We ignore these during triage review anyway, so don't add high priority and triage review for these