### PR TITLE
Fix job filter for grouped view

### DIFF
--- a/torchci/components/GroupHudTableHeaders.tsx
+++ b/torchci/components/GroupHudTableHeaders.tsx
@@ -54,7 +54,7 @@ export function GroupHudTableHeader({
           const passesFilter =
             filter === null || includesCaseInsensitive(name, filter);
           const style = passesFilter ? {} : { visibility: "collapse" as any };
-          const cursorStyle = isGroup ? {} : { cursor: "pointer" };
+          const cursorStyle = isGroup ? { cursor: "pointer" } : {};
 
           return (
             <th

--- a/torchci/components/GroupHudTableHeaders.tsx
+++ b/torchci/components/GroupHudTableHeaders.tsx
@@ -1,16 +1,40 @@
 import styles from "components/hud.module.css";
+import { group } from "console";
 import { includesCaseInsensitive } from "lib/GeneralUtils";
 import React from "react";
 import { BsFillCaretDownFill, BsFillCaretRightFill } from "react-icons/bs";
+
+function groupingIncludesJobFilter(jobNames: string[], filter: string) {
+  for (const jobName of jobNames) {
+    if (includesCaseInsensitive(jobName, filter)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function passesGroupFilter(
+  filter: string | null,
+  name: string,
+  groupNameMapping: Map<string, string[]>
+) {
+  return (
+    filter === null ||
+    includesCaseInsensitive(name, filter) ||
+    groupingIncludesJobFilter(groupNameMapping.get(name) ?? [], filter)
+  );
+}
 
 export function GroupHudTableColumns({
   names,
   filter,
   expandedGroups,
+  groupNameMapping,
 }: {
   names: string[];
   filter: string | null;
   expandedGroups: Set<string>;
+  groupNameMapping: Map<string, string[]>;
 }) {
   return (
     <colgroup>
@@ -19,9 +43,9 @@ export function GroupHudTableColumns({
       <col className={styles.colCommit} />
       <col className={styles.colPr} />
       {names.map((name: string) => {
-        const passesFilter =
-          filter === null || includesCaseInsensitive(name, filter);
-        const style = passesFilter ? {} : { visibility: "collapse" as any };
+        const style = passesGroupFilter(filter, name, groupNameMapping)
+          ? {}
+          : { visibility: "collapse" as any };
 
         return <col className={styles.colJob} key={name} style={style} />;
       })}
@@ -34,14 +58,15 @@ export function GroupHudTableHeader({
   filter,
   expandedGroups,
   setExpandedGroups,
-  groupNames,
+  groupNameMapping,
 }: {
   names: string[];
   filter: string | null;
   expandedGroups: Set<string>;
   setExpandedGroups: React.Dispatch<React.SetStateAction<Set<string>>>;
-  groupNames: Set<string>;
+  groupNameMapping: Map<string, string[]>;
 }) {
+  const groupNames = new Set(groupNameMapping.keys());
   return (
     <thead>
       <tr>
@@ -51,9 +76,9 @@ export function GroupHudTableHeader({
         <th className={styles.regularHeader}>PR</th>
         {names.map((name) => {
           const isGroup = groupNames.has(name);
-          const passesFilter =
-            filter === null || includesCaseInsensitive(name, filter);
-          const style = passesFilter ? {} : { visibility: "collapse" as any };
+          const style = passesGroupFilter(filter, name, groupNameMapping)
+            ? {}
+            : { visibility: "collapse" as any };
           const cursorStyle = isGroup ? { cursor: "pointer" } : {};
 
           return (

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[page].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[page].tsx
@@ -247,13 +247,14 @@ function GroupFilterableHudTable({
           filter={normalizedJobFilter}
           names={names}
           expandedGroups={expandedGroups}
+          groupNameMapping={groupNameMapping}
         />
         <GroupHudTableHeader
           filter={normalizedJobFilter}
           names={names}
           expandedGroups={expandedGroups}
           setExpandedGroups={setExpandedGroups}
-          groupNames={new Set(groupNameMapping.keys())}
+          groupNameMapping={groupNameMapping}
         />
         {children}
       </table>


### PR DESCRIPTION
- This fixes issue #199 with making jobs searchable when doing the grouped view. It doesn't automatically expand it but will show you the groupings that contain the jobs
- Fixes an issue with hovering on a group/workflow. Now has a pointer instead of a cursor when hovering over a group (just swapped around)

See that I searched mac and "other" and "macOS Github Action" groups show up. 

<img width="1141" alt="image" src="https://user-images.githubusercontent.com/34172846/154726245-a57e03c2-1cd9-4f92-bb06-ca3b41c9dbd8.png">
