### PR TITLE
Only disable trunk flaky tests

### DIFF
--- a/torchci/lib/fetchFlakyTests.ts
+++ b/torchci/lib/fetchFlakyTests.ts
@@ -8,7 +8,7 @@ export default async function fetchFlakyTests(num_hours: string): Promise<FlakyT
     rocksetClient.queryLambdas.executeQueryLambda(
       "commons",
       "flaky_test_query",
-      "12b03f2fbf584dc0",
+      "7e7c838ec2592c60",
       {
         parameters: [
           {
@@ -19,6 +19,5 @@ export default async function fetchFlakyTests(num_hours: string): Promise<FlakyT
         ],
       }
     );
-
    return flakyTestQuery.results ?? [];
 }

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -72,6 +72,7 @@ export interface FlakyTestData {
   num_red: number;
   workflow_ids: string[];
   workflow_names: string[];
+  branches: string[];
 }
 
 export function packHudParams(input: any) {


### PR DESCRIPTION
Following discussion in TreeHuggers, it is wisest to limit the bot's functionality for now to only disable trunk instances. Added unit tests for new functions

The stats will still contain info for all instances, though.