### PR TITLE
[torch ci] Add a new Nav Bar 

### DIFF
--- a/torchci/components/GroupJobConclusion.tsx
+++ b/torchci/components/GroupJobConclusion.tsx
@@ -6,7 +6,7 @@ import { useContext } from "react";
 import {
   JobCell,
   PinnedTooltipContext,
-} from "pages/hud/[repoOwner]/[repoName]/[branch]/[page]";
+} from "pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]]";
 
 enum JobStatus {
   Success = "success",

--- a/torchci/components/NavBar.module.css
+++ b/torchci/components/NavBar.module.css
@@ -1,0 +1,35 @@
+.menu li {
+  display: inline;
+  font: bold;
+  margin-right: 1em;
+  color: red;
+  padding-left: 1em;
+}
+
+.menu {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.linksContainer {
+  padding: 10px;
+  background: rgb(255, 227, 227);
+  background: linear-gradient(326deg, rgb(255 246 246), rgb(255 247 236));
+  box-shadow: 0 -4px 20px 0px #c2c2c2;
+  width: 100%;
+}
+
+.links {
+  display: flex;
+  flex-direction: row;
+  padding-bottom: 3px;
+}
+
+.links > ul {
+  margin-bottom: 0;
+}
+
+.homeLink {
+  font-weight: bold;
+  padding-right: 10px;
+}

--- a/torchci/components/NavBar.tsx
+++ b/torchci/components/NavBar.tsx
@@ -51,7 +51,9 @@ function NavBar() {
                   href="https://github.com/pytorch/test-infra/tree/main/torchci"
                   passHref
                 >
-                  <AiFillGithub />
+                  <a>
+                    <AiFillGithub />
+                  </a>
                 </Link>
               </span>
             </li>

--- a/torchci/components/NavBar.tsx
+++ b/torchci/components/NavBar.tsx
@@ -1,5 +1,7 @@
 import styles from "components/NavBar.module.css";
 import React from "react";
+import { AiFillGithub } from "react-icons/ai";
+
 function NavBar() {
   // TODO: Rewrite Help Link
   return (
@@ -45,8 +47,10 @@ function NavBar() {
             <li>
               <a
                 style={{ color: "black" }}
-                href="https://github.com/pytorch/pytorch-ci-hud"
-              ></a>
+                href="https://github.com/pytorch/test-infra/tree/main/torchci"
+              >
+                <AiFillGithub />
+              </a>
             </li>
           </ul>
         </div>

--- a/torchci/components/NavBar.tsx
+++ b/torchci/components/NavBar.tsx
@@ -1,0 +1,58 @@
+import styles from "components/NavBar.module.css";
+import React from "react";
+function NavBar() {
+  // TODO: Rewrite Help Link
+  return (
+    <div className={styles.linksContainer}>
+      <div className={styles.links}>
+        <div>
+          <ul className={styles.menu}>
+            <a className={styles.homeLink} href="/">
+              Pytorch CI HUD
+            </a>
+            <li>
+              <a href="/hud/pytorch/pytorch/master">Master</a>
+            </li>
+            <li>
+              <a href="/hud/pytorch/pytorch/nightly">Nightly</a>
+            </li>
+            <li>
+              <a href="/minihud">MiniHUD</a>
+            </li>
+          </ul>
+        </div>
+        <div
+          style={{
+            display: "inline",
+            marginLeft: "auto",
+            marginRight: "0px",
+          }}
+        >
+          <ul style={{ marginBottom: "0" }} className={styles.menu}>
+            <li>
+              <a href="https://github.com/pytorch/pytorch/wiki/Using-hud.pytorch.org">
+                Help
+              </a>
+            </li>
+            <li>
+              <a href="https://github.com/pytorch/test-infra/issues/new?assignees=&labels=&template=feature_request.yaml&title=%5Bfeature%5D%3A+">
+                Requests
+              </a>
+            </li>
+            <li>
+              <a href="https://metrics.pytorch.org">Metrics</a>
+            </li>
+            <li>
+              <a
+                style={{ color: "black" }}
+                href="https://github.com/pytorch/pytorch-ci-hud"
+              ></a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default NavBar;

--- a/torchci/components/NavBar.tsx
+++ b/torchci/components/NavBar.tsx
@@ -1,4 +1,5 @@
 import styles from "components/NavBar.module.css";
+import Link from "next/link";
 import React from "react";
 import { AiFillGithub } from "react-icons/ai";
 
@@ -9,17 +10,17 @@ function NavBar() {
       <div className={styles.links}>
         <div>
           <ul className={styles.menu}>
-            <a className={styles.homeLink} href="/">
-              Pytorch CI HUD
-            </a>
+            <span className={styles.homeLink}>
+              <Link href="/">Pytorch CI HUD</Link>
+            </span>
             <li>
-              <a href="/hud/pytorch/pytorch/master">Master</a>
+              <Link href="/hud/pytorch/pytorch/master">Master</Link>
             </li>
             <li>
-              <a href="/hud/pytorch/pytorch/nightly">Nightly</a>
+              <Link href="/hud/pytorch/pytorch/nightly">Nightly</Link>
             </li>
             <li>
-              <a href="/minihud">MiniHUD</a>
+              <Link href="/minihud">MiniHUD</Link>
             </li>
           </ul>
         </div>
@@ -32,25 +33,27 @@ function NavBar() {
         >
           <ul style={{ marginBottom: "0" }} className={styles.menu}>
             <li>
-              <a href="https://github.com/pytorch/pytorch/wiki/Using-hud.pytorch.org">
+              <Link href="https://github.com/pytorch/pytorch/wiki/Using-hud.pytorch.org">
                 Help
-              </a>
+              </Link>
             </li>
             <li>
-              <a href="https://github.com/pytorch/test-infra/issues/new?assignees=&labels=&template=feature_request.yaml&title=%5Bfeature%5D%3A+">
+              <Link href="https://github.com/pytorch/test-infra/issues/new?assignees=&labels=&template=feature_request.yaml&title=%5Bfeature%5D%3A+">
                 Requests
-              </a>
+              </Link>
             </li>
             <li>
-              <a href="https://metrics.pytorch.org">Metrics</a>
+              <Link href="https://metrics.pytorch.org">Metrics</Link>
             </li>
             <li>
-              <a
-                style={{ color: "black" }}
-                href="https://github.com/pytorch/test-infra/tree/main/torchci"
-              >
-                <AiFillGithub />
-              </a>
+              <span style={{ color: "black", cursor: "pointer" }}>
+                <Link
+                  href="https://github.com/pytorch/test-infra/tree/main/torchci"
+                  passHref
+                >
+                  <AiFillGithub />
+                </Link>
+              </span>
             </li>
           </ul>
         </div>

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -79,7 +79,7 @@ export function packHudParams(input: any) {
     repoOwner: input.repoOwner as string,
     repoName: input.repoName as string,
     branch: input.branch as string,
-    page: parseInt(input.page as string),
+    page: parseInt((input.page as string) ?? 0),
     nameFilter: input.name_filter as string | undefined,
   };
 }

--- a/torchci/pages/_app.tsx
+++ b/torchci/pages/_app.tsx
@@ -1,7 +1,8 @@
-import "styles/globals.css";
+import NavBar from "components/NavBar";
+import SevReport from "components/SevReport";
 import type { AppProps } from "next/app";
 import Head from "next/head";
-import SevReport from "components/SevReport";
+import "styles/globals.css";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
@@ -9,8 +10,11 @@ function MyApp({ Component, pageProps }: AppProps) {
       <Head>
         <title>PyTorch CI HUD</title>
       </Head>
+      <NavBar />
       <SevReport />
-      <Component {...pageProps} />
+      <div style={{ margin: "20px" }}>
+        <Component {...pageProps} />
+      </div>
     </>
   );
 }

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -1,6 +1,6 @@
 import {
-  GroupHudTableColumns,
-  GroupHudTableHeader,
+    GroupHudTableColumns,
+    GroupHudTableHeader
 } from "components/GroupHudTableHeaders";
 import HudGroupedCell from "components/GroupJobConclusion";
 import styles from "components/hud.module.css";
@@ -12,16 +12,17 @@ import TooltipTarget from "components/TooltipTarget";
 import { includesCaseInsensitive } from "lib/GeneralUtils";
 import { getGroupingData } from "lib/JobClassifierUtil";
 import {
-  formatHudUrlForRoute,
-  HudData,
-  HudParams,
-  JobData,
-  packHudParams,
-  RowData,
+    formatHudUrlForRoute,
+    HudData,
+    HudParams,
+    JobData,
+    packHudParams,
+    RowData
 } from "lib/types";
 import useHudData from "lib/useHudData";
 import UserSettingContext from "lib/UserSettingsContext";
 import useTableFilter from "lib/useTableFilter";
+import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import React, { createContext, useContext, useEffect, useState } from "react";
@@ -409,22 +410,29 @@ export default function Hud() {
   }, []);
 
   const params = packHudParams(router.query);
-
   return (
-    <UserSettingContext.Provider value={{ userSettings, setUserSettings }}>
-      <PinnedTooltipContext.Provider value={[pinnedTooltip, setPinnedTooltip]}>
-        {params.branch !== undefined && (
-          <div onClick={handleClick}>
-            <HudHeader params={params} />
-            <div>This page automatically updates.</div>
-            <div>
-              <PageSelector params={params} />
+    <>
+      <Head>
+        <title>
+          PyTorch CI HUD (
+          {`${params.repoOwner}/${params.repoName}: ${params.branch}`})
+        </title>
+      </Head>
+      <UserSettingContext.Provider value={{ userSettings, setUserSettings }}>
+        <PinnedTooltipContext.Provider
+          value={[pinnedTooltip, setPinnedTooltip]}
+        >
+          {params.branch !== undefined && (
+            <div onClick={handleClick}>
+              <HudHeader params={params} />
+              <div>This page automatically updates.</div>
               <HudTable params={params} />
+              <PageSelector params={params} />
             </div>
-          </div>
-        )}
-      </PinnedTooltipContext.Provider>
-    </UserSettingContext.Provider>
+          )}
+        </PinnedTooltipContext.Provider>
+      </UserSettingContext.Provider>
+    </>
   );
 }
 


### PR DESCRIPTION
This just adds a new nav bar, similar to the one found on the CI HUD. Major changes include:
- new nav bar
- going to /hud/pytorch/pytorch/master won't 404 anymore, and will default to the first page
- some css adjustments

<img width="2996" alt="image" src="https://user-images.githubusercontent.com/34172846/155577693-0218921c-8dcf-419e-ae2d-b27d70f50370.png">

Some additional features that I think we might want in the feature are:
- quick go to links for commits/prs
- logos?
- 