### PR TITLE
[torch ci] Add additional paths

### DIFF
--- a/torchci/pages/commit/[repoOwner]/[repoName]/[sha].tsx
+++ b/torchci/pages/commit/[repoOwner]/[repoName]/[sha].tsx
@@ -1,0 +1,3 @@
+import ShaPage from "pages/[repoOwner]/[repoName]/commit/[sha]";
+
+export default ShaPage;

--- a/torchci/pages/pr/[repoOwner]/[repoName]/[prNumber].tsx
+++ b/torchci/pages/pr/[repoOwner]/[repoName]/[prNumber].tsx
@@ -1,0 +1,3 @@
+import PRPage from "pages/[repoOwner]/[repoName]/pull/[prNumber]";
+
+export default PRPage;


### PR DESCRIPTION
Adds a few additional paths for the commits and PR pages so that it matches the old HUD since we have a few links that refer to these. Instead of modifying those links, it's easier to just match the old one. Other path should also work as well. 

Commit page works with new link:
![image](https://user-images.githubusercontent.com/34172846/155626141-5d6eed8b-3e69-4542-9f65-a1ea83a1a05c.png)

PR page works with new link:
![image](https://user-images.githubusercontent.com/34172846/155626186-407b9ddc-f7e2-4203-846c-39f2bcea3748.png)
