### PR TITLE
Use upgraded query to allow for a view

### DIFF
--- a/torchci/lib/fetchFlakyTests.ts
+++ b/torchci/lib/fetchFlakyTests.ts
@@ -2,22 +2,38 @@ import getRocksetClient from "./rockset";
 
 import { FlakyTestData } from "./types";
 
-export default async function fetchFlakyTests(num_hours: string): Promise<FlakyTestData[]> {
+export default async function fetchFlakyTests(numHours: string = "3",
+  testName: string = "%", testSuite: string = "%", testFile: string = "%"): Promise<FlakyTestData[]> {
   const rocksetClient = getRocksetClient();
   const flakyTestQuery = await
     rocksetClient.queryLambdas.executeQueryLambda(
       "commons",
       "flaky_test_query",
-      "7e7c838ec2592c60",
+      "2bbca6ed782f660d",
       {
         parameters: [
           {
             name: "num_hours",
             type: "int",
-            value: num_hours,
+            value: numHours,
+          },
+          {
+            name: "name",
+            type: "string",
+            value: `%${testName}%`,
+          },
+          {
+            name: "suite",
+            type: "string",
+            value: `%${testSuite}%`,
+          },
+          {
+            name: "file",
+            type: "string",
+            value: `%${testFile}%`,
           },
         ],
       }
     );
-   return flakyTestQuery.results ?? [];
+  return flakyTestQuery.results ?? [];
 }


### PR DESCRIPTION
This is mostly a query change:
```
SELECT 
  flaky_tests.name,
  flaky_tests.suite,
  flaky_tests.file,
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
  flaky_tests._event_time,
<<<<<<<<<<<< DELETED
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
  sum(flaky_tests.num_green) AS "num_green",
  sum(flaky_tests.num_red) AS "num_red",
  ARRAY_AGG(flaky_tests.workflow_id) AS workflow_ids,
  ARRAY_AGG(workflow.name) as workflow_names,
  ARRAY_AGG(workflow.head_branch) as branches,
FROM commons.flaky_tests flaky_tests JOIN commons.workflow_run workflow on CAST(flaky_tests.workflow_id as int) = workflow.id
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
WHERE flaky_tests._event_time > (CURRENT_TIMESTAMP() - HOURs(:num_hours))
GROUP BY name, suite, file, _event_time
<<<<<<<<<<<< MODIFIED
WHERE 
    flaky_tests._event_time > (CURRENT_TIMESTAMP() - HOURs(:num_hours)) AND
    flaky_tests.name LIKE :name AND
    flaky_tests.suite LIKE :suite AND
    flaky_tests.file LIKE :file
GROUP BY name, suite, file
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

```