### PR TITLE
Match query outputs with camelCase change

### DIFF
--- a/torchci/lib/fetchFlakyTests.ts
+++ b/torchci/lib/fetchFlakyTests.ts
@@ -9,7 +9,7 @@ export default async function fetchFlakyTests(numHours: string = "3",
     rocksetClient.queryLambdas.executeQueryLambda(
       "commons",
       "flaky_test_query",
-      "2bbca6ed782f660d",
+      "2778eac601839f5b",
       {
         parameters: [
           {


### PR DESCRIPTION
The old query outputted things in snake case, so after my change in #209, flaky test bot has not been receiving the right stats. :c 

This would fix that. 

```
SELECT 
  flaky_tests.name,
  flaky_tests.suite,
  flaky_tests.file,
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
  sum(flaky_tests.num_green) AS num_green,
  sum(flaky_tests.num_red) AS num_red,
  ARRAY_AGG(flaky_tests.workflow_id) AS workflow_ids,
  ARRAY_AGG(workflow.name) as workflow_names,
<<<<<<<<<<<<<< MODIFIED
  sum(flaky_tests.num_green) AS numGreen,
  sum(flaky_tests.num_red) AS numRed,
  ARRAY_AGG(flaky_tests.workflow_id) AS workflowIds,
  ARRAY_AGG(workflow.name) as workflowNames,
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
  ARRAY_AGG(workflow.head_branch) as branches,
FROM commons.flaky_tests flaky_tests JOIN commons.workflow_run workflow on CAST(flaky_tests.workflow_id as int) = workflow.id
WHERE 
	flaky_tests._event_time > (CURRENT_TIMESTAMP() - HOURs(:num_hours)) AND
    flaky_tests.name LIKE :name AND
    flaky_tests.suite LIKE :suite AND
    flaky_tests.file LIKE :file
GROUP BY name, suite, file
```