### PR TITLE
[metrics] added ingestion of data related to PRs

### DIFF
--- a/torchci/lib/bot/webhookToDynamo.ts
+++ b/torchci/lib/bot/webhookToDynamo.ts
@@ -103,9 +103,41 @@ async function handlePush(event: WebhookEvent<"push">) {
   });
 }
 
+async function handlePullRequestReview(
+  event: WebhookEvent<"pull_request_review">
+) {
+  const key_prefix = event.payload.repository.full_name + "/";
+  const client = getDynamoClient();
+
+  await client.put({
+    TableName: "torchci-pull-request-review",
+    Item: {
+      dynamoKey: `${key_prefix}/${uuidv4()}`,
+      ...event.payload,
+    },
+  });
+}
+
+async function handlePullRequestReviewComment(
+  event: WebhookEvent<"pull_request_review_comment">
+) {
+  const key_prefix = event.payload.repository.full_name + "/";
+  const client = getDynamoClient();
+
+  await client.put({
+    TableName: "torchci-pull-request-review-comment",
+    Item: {
+      dynamoKey: `${key_prefix}/${uuidv4()}`,
+      ...event.payload,
+    },
+  });
+}
+
 export default function webhookToDynamo(app: Probot) {
   app.on(["workflow_job", "workflow_run"], handleWorkflowJob);
   app.on("issues", handleIssues);
   app.on("pull_request", handlePullRequest);
+  app.on("pull_request_review", handlePullRequestReview);
+  app.on("pull_request_review_comment", handlePullRequestReviewComment);
   app.on("push", handlePush);
 }

--- a/torchci/lib/bot/webhookToDynamo.ts
+++ b/torchci/lib/bot/webhookToDynamo.ts
@@ -106,7 +106,7 @@ async function handlePush(event: WebhookEvent<"push">) {
 async function handlePullRequestReview(
   event: WebhookEvent<"pull_request_review">
 ) {
-  const key_prefix = event.payload.repository.full_name + "/";
+  const key_prefix = event.payload.repository.full_name;
   const client = getDynamoClient();
 
   await client.put({
@@ -121,7 +121,7 @@ async function handlePullRequestReview(
 async function handlePullRequestReviewComment(
   event: WebhookEvent<"pull_request_review_comment">
 ) {
-  const key_prefix = event.payload.repository.full_name + "/";
+  const key_prefix = event.payload.repository.full_name;
   const client = getDynamoClient();
 
   await client.put({


### PR DESCRIPTION
This adds ingestion of new webhook events for PR reviews since we need this data to get some metrics like 
P0: Time for a PR to be reviewed for external contributors under 2 business days 
P0: Time for a PR to be reviewed for the org is under 2 business days 
And maybe some of the PR merge stuff although maybe not. 