### PR TITLE
[torchci] Add missing paths

### DIFF
--- a/torchci/components/AnnouncementBanner.module.css
+++ b/torchci/components/AnnouncementBanner.module.css
@@ -1,0 +1,8 @@
+.announcementBanner {
+    border: 1px solid black;
+    border-radius: 5px;
+    background-color: #daedf4;
+    padding: 10px;
+    margin-bottom: 10px;
+    margin-top: 10px;
+  }

--- a/torchci/components/AnnouncementBanner.tsx
+++ b/torchci/components/AnnouncementBanner.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import styles from "./SevReport.module.css";
+
+function AnnouncementBanner() {
+  return (
+    <div className={styles.announcementBanner}>
+      <a href="https://github.com/pytorch/pytorch/wiki/%5BWIP%5D-What-is-a-SEV">
+        HUD Migration:
+      </a>
+      HUD is being migrated. If you would like to use the old HUD, go here to
+      use the <a href={"https://hud.pytorch.org/"}>old HUD</a> or{" "}
+      <a href="https://github.com/pytorch/test-infra/issues/new?assignees=&labels=&template=feature_request.yaml&title=%5Bfeature%5D%3A+">
+        file an issue
+      </a>
+      .
+    </div>
+  );
+}
+
+export default AnnouncementBanner;

--- a/torchci/components/AnnouncementBanner.tsx
+++ b/torchci/components/AnnouncementBanner.tsx
@@ -8,7 +8,7 @@ function AnnouncementBanner() {
         HUD Migration:
       </a>
       HUD is being migrated. If you would like to use the old HUD, go here to
-      use the <a href={"https://hud.pytorch.org/"}>old HUD</a> or{" "}
+      use the <a href={"https://hud2.pytorch.org/"}>old HUD</a> or{" "}
       <a href="https://github.com/pytorch/test-infra/issues/new?assignees=&labels=&template=feature_request.yaml&title=%5Bfeature%5D%3A+">
         file an issue
       </a>

--- a/torchci/components/AnnouncementBanner.tsx
+++ b/torchci/components/AnnouncementBanner.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styles from "./SevReport.module.css";
+import styles from "./AnnouncementBanner.module.css";
 
 function AnnouncementBanner() {
   return (
@@ -12,7 +12,7 @@ function AnnouncementBanner() {
       <a href="https://github.com/pytorch/test-infra/issues/new?assignees=&labels=&template=feature_request.yaml&title=%5Bfeature%5D%3A+">
         file an issue
       </a>
-      .
+      {" to let us know what's wrong."}
     </div>
   );
 }

--- a/torchci/components/AnnouncementBanner.tsx
+++ b/torchci/components/AnnouncementBanner.tsx
@@ -4,11 +4,9 @@ import styles from "./AnnouncementBanner.module.css";
 function AnnouncementBanner() {
   return (
     <div className={styles.announcementBanner}>
-      <a href="https://github.com/pytorch/pytorch/wiki/%5BWIP%5D-What-is-a-SEV">
-        HUD Migration:
-      </a>
-      HUD is being migrated. If you would like to use the old HUD, go here to
-      use the <a href={"https://hud2.pytorch.org/"}>old HUD</a> or{" "}
+      <b>HUD Migration:</b> HUD is being migrated. If you would like to use the
+      old HUD, go here to use the{" "}
+      <a href={"https://hud2.pytorch.org/"}>old HUD</a> or{" "}
       <a href="https://github.com/pytorch/test-infra/issues/new?assignees=&labels=&template=feature_request.yaml&title=%5Bfeature%5D%3A+">
         file an issue
       </a>

--- a/torchci/components/SevReport.module.css
+++ b/torchci/components/SevReport.module.css
@@ -5,3 +5,12 @@
   padding: 10px;
   margin-bottom: 10px;
 }
+
+.announcementBanner {
+  border: 1px solid black;
+  border-radius: 5px;
+  background-color: #daedf4;
+  padding: 10px;
+  margin-bottom: 10px;
+  margin-top: 10px;
+}

--- a/torchci/components/SevReport.module.css
+++ b/torchci/components/SevReport.module.css
@@ -5,12 +5,3 @@
   padding: 10px;
   margin-bottom: 10px;
 }
-
-.announcementBanner {
-  border: 1px solid black;
-  border-radius: 5px;
-  background-color: #daedf4;
-  padding: 10px;
-  margin-bottom: 10px;
-  margin-top: 10px;
-}

--- a/torchci/lib/useTableFilter.ts
+++ b/torchci/lib/useTableFilter.ts
@@ -2,10 +2,7 @@ import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
 import { formatHudUrlForRoute, HudParams } from "./types";
 
-export default function useTableFilter(
-  params: HudParams,
-  setUserSettings: any
-) {
+export default function useTableFilter(params: HudParams) {
   const router = useRouter();
 
   const [jobFilter, setJobFilter] = useState<string | null>(null);
@@ -49,8 +46,7 @@ export default function useTableFilter(
     const filterValue = (router.query.name_filter as string) || "";
     setJobFilter(filterValue);
     handleInput(filterValue);
-    setUserSettings(filterValue != null);
-  }, [router.query.name_filter, handleInput, setUserSettings]);
+  }, [router.query.name_filter, handleInput]);
 
   return { jobFilter, handleSubmit, handleInput, normalizedJobFilter };
 }

--- a/torchci/next.config.js
+++ b/torchci/next.config.js
@@ -23,6 +23,10 @@ module.exports = {
         source: "/commit/:sha",
         destination: "/pytorch/pytorch/commit/:sha",
       },
+      {
+        source: "/ci/:repoOwner/:repoName/:branch",
+        destination: "/hud/:repoOwner/:repoName/:branch/0",
+      },
     ];
   },
 };

--- a/torchci/pages/_app.tsx
+++ b/torchci/pages/_app.tsx
@@ -1,3 +1,4 @@
+import AnnouncementBanner from "components/AnnouncementBanner";
 import NavBar from "components/NavBar";
 import SevReport from "components/SevReport";
 import type { AppProps } from "next/app";
@@ -11,6 +12,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         <title>PyTorch CI HUD</title>
       </Head>
       <NavBar />
+      <AnnouncementBanner />
       <SevReport />
       <div style={{ margin: "20px" }}>
         <Component {...pageProps} />

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -1,6 +1,6 @@
 import {
   GroupHudTableColumns,
-  GroupHudTableHeader
+  GroupHudTableHeader,
 } from "components/GroupHudTableHeaders";
 import HudGroupedCell from "components/GroupJobConclusion";
 import styles from "components/hud.module.css";
@@ -16,7 +16,7 @@ import {
   HudParams,
   JobData,
   packHudParams,
-  RowData
+  RowData,
 } from "lib/types";
 import useHudData from "lib/useHudData";
 import useTableFilter from "lib/useTableFilter";
@@ -169,7 +169,7 @@ function GroupFilterableHudTable({
   setUseGrouping: any;
 }) {
   const { jobFilter, handleSubmit, handleInput, normalizedJobFilter } =
-    useTableFilter(params, setUseGrouping);
+    useTableFilter(params);
   const headerNames = useGrouping ? groupNames : names;
   return (
     <>
@@ -392,7 +392,9 @@ function GroupedHudTable({
     data.jobNames
   );
   const [expandedGroups, setExpandedGroups] = useState(new Set<string>());
-  const [useGrouping, setUseGrouping] = useState(true);
+  const [useGrouping, setUseGrouping] = useState(
+    !(params.nameFilter != null && params.nameFilter !== "")
+  );
 
   const groupNames = Array.from(groupNameMapping.keys());
   let names = groupNames;

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -348,14 +348,14 @@ export default function Hud() {
       }
     });
   }, []);
-
+  const title =
+    params.repoOwner != null && params.repoName != null && params.branch != null
+      ? ` (${params.repoOwner}/${params.repoName}: ${params.branch})`
+      : "";
   return (
     <>
       <Head>
-        <title>
-          PyTorch CI HUD (
-          {`${params.repoOwner}/${params.repoName}: ${params.branch}`})
-        </title>
+        <title>PyTorch CI HUD {title}</title>
       </Head>
       <PinnedTooltipContext.Provider value={[pinnedTooltip, setPinnedTooltip]}>
         {params.branch !== undefined && (


### PR DESCRIPTION
This does a few fixes in preparation for launching:
1. Add announcement banner on hud2 to redirect users back  
<img width="1492" alt="image" src="https://user-images.githubusercontent.com/34172846/157108356-182f5f5a-c1e9-4b3d-8fdd-40365ca17c0f.png">

2. Add null checks for title so that it doesn't show Pytorch CI HUD (undefined/undefined: undefined) on page.tsx
3. Add a redirect for /ci/repoOwner/repoName/branch. Don't need to worry about paging cause old hud doesn't have paging 
4. Fix group view unchecked when filter is nonnull on page load
Check that view works with the given example of `/ci/pytorch/pytorch/nightly?name_filter=ci/circleci:%20binary_windows`. Only difference is some naming differences between hud and hud2 (we don't prefix it with circle_ci). 


<img width="1491" alt="image" src="https://user-images.githubusercontent.com/34172846/157109022-e06354a8-de6c-4bfd-a25e-6c6f95e910a1.png">
