### PR TITLE
Making Grafana deployment a periodic job and renewing certificates du…

### DIFF
--- a/.github/templates/metrics_pytorch_org.yml.j2
+++ b/.github/templates/metrics_pytorch_org.yml.j2
@@ -9,6 +9,8 @@ on:
     paths:
       - 'aws/websites/metrics.pytorch.org/**'
       - '.github/workflows/metrics_pytorch_org.yml'
+  schedule:
+    - cron: 0 0 * * 3
 
 concurrency:
   group: "deploy metrics.pytorch.org"
@@ -31,16 +33,11 @@ jobs:
           pip install ansible
       - name: Setup Secets
         env:
-          FULLCHAIN: ${{ secrets.METRICS_FULLCHAIN }}
-          PRIVKEY: ${{ secrets.METRICS_PRIVKEY }}
           VARS: ${{ secrets.METRICS_VARS }}
           SSH_KEY: ${{ secrets.METRICS_SSH_KEY }}
         run: |
           set -e  # NB: This needs to run without -x since GitHub will sometimes not hide secrets in the logs
           cd aws/websites/metrics.pytorch.org
-
-          echo "$FULLCHAIN" > files/fullchain.pem
-          echo "$PRIVKEY" > files/privkey.pem
           echo "$VARS" > vars.yml
           echo "$SSH_KEY" > ssh_key.pem
           chmod 600 ssh_key.pem

--- a/.github/workflows/generated-metrics-pytorch-org.yml
+++ b/.github/workflows/generated-metrics-pytorch-org.yml
@@ -11,6 +11,8 @@ on:
     paths:
       - 'aws/websites/metrics.pytorch.org/**'
       - '.github/workflows/metrics_pytorch_org.yml'
+  schedule:
+    - cron: 0 0 * * 3
 
 concurrency:
   group: "deploy metrics.pytorch.org"
@@ -59,16 +61,11 @@ jobs:
           pip install ansible
       - name: Setup Secets
         env:
-          FULLCHAIN: ${{ secrets.METRICS_FULLCHAIN }}
-          PRIVKEY: ${{ secrets.METRICS_PRIVKEY }}
           VARS: ${{ secrets.METRICS_VARS }}
           SSH_KEY: ${{ secrets.METRICS_SSH_KEY }}
         run: |
           set -e  # NB: This needs to run without -x since GitHub will sometimes not hide secrets in the logs
           cd aws/websites/metrics.pytorch.org
-
-          echo "$FULLCHAIN" > files/fullchain.pem
-          echo "$PRIVKEY" > files/privkey.pem
           echo "$VARS" > vars.yml
           echo "$SSH_KEY" > ssh_key.pem
           chmod 600 ssh_key.pem

--- a/aws/websites/metrics.pytorch.org/README.md
+++ b/aws/websites/metrics.pytorch.org/README.md
@@ -16,8 +16,6 @@ This is a Terraform script + Ansible playbook to spin up a Grafana instance poin
     terraform apply -var="key_name=<aws key name>" -var="name=metrics.pytorch.org" -var="type=t2.xlarge" -var="size=50"
     ```
 
-2. Acquire an SSL key and certificate and store them in `files/privkey.pem` and `files/fullchain.pem` respectively
-
 3. Create a file called `vars.yml` that looks like
 
     ```yaml
@@ -27,10 +25,6 @@ This is a Terraform script + Ansible playbook to spin up a Grafana instance poin
         aws:
             id: 123
             secret: 123
-
-    ssl_filenames:
-        key: privkey.pem
-        cert: fullchain.pem
     ```
 
 3. Run the Ansible playbook to provision the machine

--- a/aws/websites/metrics.pytorch.org/install.yml
+++ b/aws/websites/metrics.pytorch.org/install.yml
@@ -42,4 +42,6 @@
     - name: Run compose
       shell: |
         docker stack rm monitoring || echo done
+        certbot renew
+        cp /etc/letsencrypt/live/metrics.pytorch.org-0002/*.pem /etc/pytorch/
         docker stack deploy -c /etc/pytorch/docker-compose.yml monitoring


### PR DESCRIPTION
Fixes #231 

We apply following logic:
run the metrics github action install periodically (once a month)
regenerate new certificate during install
disable and remove overwriting of certificates from secrets

The  GHA is run weekly Wed at midnight.