### PR TITLE
fix bad circleci job url

### DIFF
--- a/torchci/rockset/commons/__sql/hud_query.sql
+++ b/torchci/rockset/commons/__sql/hud_query.sql
@@ -59,10 +59,7 @@ from
             END as conclusion,
             -- cirleci doesn't provide a url, piece one together out of the info we have
             CONCAT(
-                'https://app.circleci.com/pipelines/github/pytorch/pytorch/',
-                CAST(job.pipeline.number as string),
-                '/workflows/',
-                job.workflow.id,
+                job.workflow.url,
                 '/jobs/',
                 CAST(job.job.number AS string)
             ) as html_url,

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -1,5 +1,5 @@
 {
-  "hud_query": "cee7578c7a095800",
+  "hud_query": "9db80569b984c37e",
   "commit_jobs_query": "999dc65120324dd8",
   "flaky_test_query": "2778eac601839f5b",
   "original_pr_hud_query": "bd10f482796f4abd",


### PR DESCRIPTION
pytorch/pytorch was hardcoded, don't do that!
