### PR TITLE
Do not display "null" phab link

### DIFF
--- a/torchci/components/VersionControlLinks.tsx
+++ b/torchci/components/VersionControlLinks.tsx
@@ -8,7 +8,7 @@ export default function VersionControlLinks({
   return (
     <div>
       <a href={`https://github.com/pytorch/pytorch/commit/${sha}`}>GitHub</a>
-      {diffNum !== undefined ? (
+      {typeof diffNum === "string" ? (
         <span>
           {" "}
           |{" "}


### PR DESCRIPTION
When commit does not have a differential revision


Before the change [PyTorchCommit-21a82f5)(https://hud.pytorch.org/pytorch/pytorch/commit/21a82fb5194d2a079c752215a8f87e36ddc2f6b6) contained a link to `https://www.internalfb.com/diff/null`
