### PR TITLE
[torchci] Padding fixes to columns

### DIFF
--- a/torchci/components/GroupHudTableHeaders.tsx
+++ b/torchci/components/GroupHudTableHeaders.tsx
@@ -28,12 +28,10 @@ export function GroupHudTableColumns({
   names,
   filter,
   groupNameMapping,
-  useGrouping,
 }: {
   names: string[];
   filter: string | null;
   groupNameMapping: Map<string, string[]>;
-  useGrouping: boolean;
 }) {
   return (
     <colgroup>
@@ -58,14 +56,12 @@ export function GroupHudTableHeader({
   expandedGroups,
   setExpandedGroups,
   groupNameMapping,
-  useGrouping,
 }: {
   names: string[];
   filter: string | null;
   expandedGroups: Set<string>;
   setExpandedGroups: React.Dispatch<React.SetStateAction<Set<string>>>;
   groupNameMapping: Map<string, string[]>;
-  useGrouping: boolean;
 }) {
   const groupNames = new Set(groupNameMapping.keys());
   return (

--- a/torchci/components/hud.module.css
+++ b/torchci/components/hud.module.css
@@ -33,6 +33,7 @@
   height: 220px;
   white-space: nowrap;
   font-family: sans-serif;
+  padding-right:4px;
 }
 
 .jobHeaderName {

--- a/torchci/components/hud.module.css
+++ b/torchci/components/hud.module.css
@@ -38,7 +38,7 @@
 
 .jobHeaderName {
   transform: translate(10px, 100px) rotate(315deg);
-  width: 10px;
+  width: 12px;
   font-weight: 400;
   font-size: 0.8em;
 }
@@ -75,5 +75,5 @@
   font-size: 1em;
   border: 0px;
   padding: 0px;
-  padding-left: 5px;
+  padding-left: 4px;
 }

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -190,7 +190,6 @@ function GroupFilterableHudTable({
           filter={normalizedJobFilter}
           names={headerNames}
           groupNameMapping={groupNameMapping}
-          useGrouping={useGrouping}
         />
         <GroupHudTableHeader
           filter={normalizedJobFilter}
@@ -198,7 +197,6 @@ function GroupFilterableHudTable({
           expandedGroups={expandedGroups}
           setExpandedGroups={setExpandedGroups}
           groupNameMapping={groupNameMapping}
-          useGrouping={useGrouping}
         />
         {children}
       </table>


### PR DESCRIPTION
This just adds some additional padding in between the columns to make it more readable and also fixes some unused variables in the header.

Going forward, we should try to make any usages of px divisible by 4 to follow CSS standards from FB. 

![image](https://user-images.githubusercontent.com/34172846/158626425-dd6c789f-16f0-49c0-917e-71a93b922e8e.png)
