### PR TITLE
bot changes for workflow consolidation.

### DIFF
--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -141,7 +141,7 @@ async function handleLabelEvent(context: Context<"pull_request.labeled">) {
   if (isOldCIFlowLabel) {
     let body = `We have recently simplified the CIFlow labels and \`${label}\` is no longer in use.`;
     body += "You can use any of the following";
-    body += "- `ciflow/trunk` (`.github/workflowss/trunk.yml`): all jobs we run per-commit on master";
+    body += "- `ciflow/trunk` (`.github/workflows/trunk.yml`): all jobs we run per-commit on master";
     body += "- `ciflow/periodic` (`.github/workflows/periodic.yml`): all jobs we run periodically on master";
     body += "- `ciflow/all`: trunk + periodic; all jobs we run in master CI";
     body += "- `ciflow/nightly` (`.github/workflows/nightly.yml`): all jobs we run nightly";

--- a/torchci/lib/bot/index.ts
+++ b/torchci/lib/bot/index.ts
@@ -13,7 +13,7 @@ export default function bot(app: Probot) {
   autoCcBot(app);
   autoLabelBot(app);
   verifyDisableTestIssueBot(app);
-  ciflowBot(app);
+  // ciflowBot(app);
   ciflowPushTrigger(app);
   webhookToDynamo(app);
   triggerCircleCIWorkflows(app);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #257
* #258

Three changes in this PR:
1. Disable the CIFlow comment, to reduce noise. I don't think it's very useful anymore, because:
    - The labels have been drastically simplified
    - The info is static for every PR and inferrable by just looking at the relevant workflow.
    - The information has been inaccurate for weeks and no one noticed lol (it says binary builds are default-triggered when they are not)
2. Disable some of the smaller parts of CIFlow functionality: adding ciflow/default (which hasn't done anything for a while), disable automatic label adding based on the issue (functionality only used by a single person, who I will reach out to).
3. Tell people if they use an obsolete tag and give them a list of working options.