### PR TITLE
bot changes for workflow consolidation.

### DIFF
--- a/torchci/lib/bot/index.ts
+++ b/torchci/lib/bot/index.ts
@@ -13,7 +13,7 @@ export default function bot(app: Probot) {
   autoCcBot(app);
   autoLabelBot(app);
   verifyDisableTestIssueBot(app);
-  ciflowBot(app);
+  // ciflowBot(app);
   ciflowPushTrigger(app);
   webhookToDynamo(app);
   triggerCircleCIWorkflows(app);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Two changes in this PR:
First, disable the CIFlow comment, to reduce noise. I don't think it's very useful anymore, because:
- The labels have been drastically simplified
- The info is static for every PR and inferrable by just looking at the relevant workflow.
- The information has been inaccurate for weeks and no one noticed lol (it says binary builds are default-triggered when they are not)

Second, tell people if they use an obsolete tag and give them a list of working options.