### PR TITLE
[HUD] Post correct GitHub link in commit view

### DIFF
--- a/torchci/components/CommitStatus.tsx
+++ b/torchci/components/CommitStatus.tsx
@@ -38,7 +38,7 @@ export default function CommitStatus({
 }) {
   return (
     <>
-      <VersionControlLinks sha={commit.sha} diffNum={commit.diffNum} />
+      <VersionControlLinks githubUrl={commit.commitUrl} diffNum={commit.diffNum} />
 
       <article className={styles.commitMessage}>
         {commit.commitMessageBody}

--- a/torchci/components/VersionControlLinks.tsx
+++ b/torchci/components/VersionControlLinks.tsx
@@ -1,13 +1,13 @@
 export default function VersionControlLinks({
-  sha,
+  githubUrl,
   diffNum,
 }: {
-  sha: string;
+  githubUrl: string;
   diffNum: string | null;
 }) {
   return (
     <div>
-      <a href={`https://github.com/pytorch/pytorch/commit/${sha}`}>GitHub</a>
+      <a href={`${githubUrl}`}>GitHub</a>
       {typeof diffNum === "string" ? (
         <span>
           {" "}

--- a/torchci/pages/[repoOwner]/[repoName]/commit/[sha].tsx
+++ b/torchci/pages/[repoOwner]/[repoName]/commit/[sha].tsx
@@ -43,11 +43,17 @@ export function CommitInfo({
 export default function Page() {
   const router = useRouter();
   const { sha, repoOwner, repoName } = router.query;
+  const fancyName =
+    (repoOwner === "pytorch" && repoName === "pytorch") ? "PyTorch"
+    : (repoOwner === "pytorch" && repoName === "vision") ? "TorchVision"
+    : (repoOwner === "pytorch" && repoName === "audio") ? "TorchAudio"
+    : `${repoOwner}/${repoName}`;
+
 
   return (
     <div>
       <h1 id="hud-header">
-        PyTorch Commit: <code>{sha}</code>
+        {fancyName} Commit: <code>{sha}</code>
       </h1>
       {sha !== undefined && (
         <CommitInfo


### PR DESCRIPTION
Also, render https://github.com/pytorch/vision commits as `TorchVision commit` and so on
Test Plan: Open [vision@1af20e8c](https://hud.pytorch.org/pytorch/vision/commit/1af20e8c232c7769b3875804e31e3e11cfddef39) and click on "GitHub" link
