### PR TITLE
[HUD] Add folder name to `artifacts.zip`

### DIFF
--- a/torchci/lib/fetchS3Links.ts
+++ b/torchci/lib/fetchS3Links.ts
@@ -12,7 +12,8 @@ export default async function fetchS3Links(
 
   const artifacts =
     response.Contents?.map((jobs) => {
-      const name = jobs.Key?.split("/").slice(-1)[0];
+      const basename = jobs.Key?.split("/").slice(-1)[0];
+      const name = basename !== "artifacts.zip" ? basename : jobs.Key?.split("/").slice(-2).join("/");
       return {
         kind: "s3",
         name: name ?? "",


### PR DESCRIPTION
As we have a lot of `artifacts.zip` in one workflow right now

Test plan: Open https://torchci-git-malfet-add-folder-name-to-artifacts-torchci.vercel.app/pytorch/pytorch/commit/1dab71ab258df5168bb635530a820625f9d4b522
