### PR TITLE
[hud] add link to github pr on pr page

### DIFF
--- a/torchci/pages/[repoOwner]/[repoName]/pull/[prNumber].tsx
+++ b/torchci/pages/[repoOwner]/[repoName]/pull/[prNumber].tsx
@@ -103,7 +103,7 @@ function Page() {
   return (
     <div>
       <h1>
-        {prData.title} <code>{router.query.pr}</code>
+        {prData.title} <code><a href={`https://github.com/${repoOwner}/${repoName}/pull/${prNumber}`}>#{prNumber}</a></code>
       </h1>
       <CommitHeader
         repoOwner={repoOwner as string}


### PR DESCRIPTION
Add link to the github pr on the pr page

Before:
<img width="1214" alt="image" src="https://user-images.githubusercontent.com/44682903/161165542-b6baeb1f-1aba-44f7-93c6-215e65587c59.png">


After:
<img width="1213" alt="image" src="https://user-images.githubusercontent.com/44682903/161165566-0702c94c-b73d-4d7c-bbd8-0f714ee63c0d.png">
