### PR TITLE
[torch ci] remove announcement

### DIFF
--- a/torchci/components/AnnouncementBanner.tsx
+++ b/torchci/components/AnnouncementBanner.tsx
@@ -2,17 +2,7 @@ import React from "react";
 import styles from "./AnnouncementBanner.module.css";
 
 function AnnouncementBanner() {
-  return (
-    <div className={styles.announcementBanner}>
-      <b>HUD Migration:</b> HUD is being migrated. If you would like to use the
-      old HUD, go here to use the{" "}
-      <a href={"https://hud2.pytorch.org/"}>old HUD</a> or{" "}
-      <a href="https://github.com/pytorch/test-infra/issues/new?assignees=&labels=&template=feature_request.yaml&title=%5Bfeature%5D%3A+">
-        file an issue
-      </a>
-      {" to let us know what's wrong."}
-    </div>
-  );
+  return null;
 }
 
 export default AnnouncementBanner;


### PR DESCRIPTION
Remove announcement for HUD deprecation. On April 4th, we will:
1. Land this change
2. Remove HUD2 from netlify / remove DNS mapping
3. Archive hud project

Check that there's no banner: 
<img width="1262" alt="image" src="https://user-images.githubusercontent.com/34172846/161295805-1da0e4cb-a027-4d49-9189-36cb0e2543c7.png">
