### PR TITLE
[torch ci][ez] resize and move minihud link

### DIFF
--- a/torchci/components/NavBar.tsx
+++ b/torchci/components/NavBar.tsx
@@ -14,13 +14,13 @@ function NavBar() {
               <Link href="/">Pytorch CI HUD</Link>
             </span>
             <li>
+              <Link href="/minihud">MiniHUD</Link>
+            </li>
+            <li>
               <Link href="/hud/pytorch/pytorch/master">Master</Link>
             </li>
             <li>
               <Link href="/hud/pytorch/pytorch/nightly">Nightly</Link>
-            </li>
-            <li>
-              <Link href="/minihud">MiniHUD</Link>
             </li>
             <li>
               <Link href="/hud/pytorch/vision/main">TorchVision</Link>

--- a/torchci/components/hud.module.css
+++ b/torchci/components/hud.module.css
@@ -23,7 +23,7 @@
   width: 1.3ch;
 }
 .colAuthor {
-  width: 16h;
+  width: 12ch;
 }
 .tooltip-target-no-click {
   cursor: default;
@@ -60,6 +60,18 @@
   height: 20px;
   min-width: 0;
   max-width: 37ch;
+  display: inline-block;
+  overflow: clip;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.jobMetadataTruncatedAuthor {
+  vertical-align: top;
+  width: auto;
+  height: 20px;
+  min-width: 0;
+  max-width: 12ch;
   display: inline-block;
   overflow: clip;
   text-overflow: ellipsis;

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -80,13 +80,11 @@ function HudRow({
           </a>
         )}
       </td>
-      {rowData.authorUrl !== null ? (
-        <td className={styles.jobMetadata}>
-          <a href={rowData.authorUrl}>{rowData.author}</a>
-        </td>
-      ) : (
-        <td>{rowData.author}</td>
-      )}
+      <td className={styles.jobMetadata}>
+        <div className={styles.jobMetadataTruncatedAuthor}>
+          <a href={rowData.authorUrl ?? ""}>{rowData.author}</a>
+        </div>
+      </td>
       <HudJobCells
         rowData={rowData}
         expandedGroups={expandedGroups}

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -82,7 +82,11 @@ function HudRow({
       </td>
       <td className={styles.jobMetadata}>
         <div className={styles.jobMetadataTruncatedAuthor}>
-          <a href={rowData.authorUrl ?? ""}>{rowData.author}</a>
+          {rowData.authorUrl !== null ? (
+            <a href={rowData.authorUrl}>{rowData.author}</a>
+          ) : (
+            rowData.author
+          )}
         </div>
       </td>
       <HudJobCells


### PR DESCRIPTION
See title. Also moving MiniHUD link to the top left so that repos/branches are all together. 
![Screen Shot 2022-04-01 at 4 33 04 PM](https://user-images.githubusercontent.com/34172846/161344169-ded0642e-abb6-4605-84f5-37b6637f416a.png)

