### PR TITLE
[MergeBot] Restrict merge/revert cmd scope

### DIFF
--- a/torchci/lib/bot/mergeBot.ts
+++ b/torchci/lib/bot/mergeBot.ts
@@ -2,8 +2,8 @@ import { Probot } from "probot";
 import { reactOnComment} from './botUtils'
 
 function mergeBot(app: Probot): void {
-  const mergeCmdPat = new RegExp("@pytorch(merge|)bot\\s+(force\\s+)?merge\\s+this");
-  const revertCmdPat = new RegExp("@pytorch(merge|)bot\\s+revert\\s+this");
+  const mergeCmdPat = new RegExp("^\\s*@pytorch(merge|)bot\\s+(force\\s+)?merge\\s+this");
+  const revertCmdPat = new RegExp("^\\s*@pytorch(merge|)bot\\s+revert\\s+this");
   app.on("issue_comment.created", async (ctx) => {
     const commentBody = ctx.payload.comment.body;
     const owner = ctx.payload.repository.owner.login;

--- a/torchci/test/mergeBot.test.ts
+++ b/torchci/test/mergeBot.test.ts
@@ -48,6 +48,21 @@ describe("merge-bot", () => {
     scope.done();
   });
 
+  test("quoted merge/revert command no event", async() => {
+    const merge_event = require("./fixtures/issue_comment.json");
+    merge_event.payload.comment.body = "> @pytorchbot merge this";
+    const revert_event = require("./fixtures/issue_comment.json");
+    revert_event.payload.comment.body = "> @pytorchbot revert this";
+    const scope = nock("https://api.github.com");
+    await probot.receive(merge_event);
+    await probot.receive(revert_event);
+    if (!scope.isDone()) {
+      console.error("pending mocks: %j", scope.pendingMocks());
+    }
+    scope.done();
+  });
+
+
   test("merge this comment on issue triggers confused reaction", async() => {
     const event = require("./fixtures/issue_comment.json");
     event.payload.comment.body = "@pytorchbot merge this";


### PR DESCRIPTION
Mentioning merge/revert command in the middle of sentence (and
specifically quoting it) should not trigger bot

Fixes https://github.com/pytorch/test-infra/issues/278
