### PR TITLE
[torchci] [flakytest] Change flaky test view to link to job instead of workflow

### DIFF
--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -94,7 +94,7 @@ export function getLatestTrunkJobURL(test: FlakyTestData): string {
         console.warn(`Flaky test ${test.name} has no trunk failures. Disabling anyway, but this may be unintended.`);
         index = test.jobIds.length - 1;
     }
-    return `https://github.com/pytorch/pytorch/actions/jobs/${test.jobIds[index]}`;
+    return `https://github.com/pytorch/pytorch/runs/${test.jobIds[index]}`;
 }
 
 

--- a/torchci/pages/flakytest.tsx
+++ b/torchci/pages/flakytest.tsx
@@ -1,4 +1,5 @@
 import { FlakyTestData } from "lib/types";
+import {getWorkflowJobNames} from "pages/api/flaky-tests/disable";
 import { useRouter } from "next/router";
 import useSWR from "swr";
 import styles from "components/flakytest.module.css";
@@ -27,13 +28,13 @@ export default function Page() {
     <div>
       <h1>PyTorch CI Flaky Tests</h1>
       <h2>
-        Test Name Filter: <code>{name === "%" ? "" : name}</code>
+        Test Name Filter: <code>{name === "%" ? "<any>" : name}</code>
       </h2>
       <h2>
-        Test Suite Filter: <code>{suite === "%" ? "" : suite}</code>
+        Test Suite Filter: <code>{suite === "%" ? "<any>" : suite}</code>
       </h2>
       <h2>
-        Test File Filter: <code>{file === "%" ? "" : file}</code>
+        Test File Filter: <code>{file === "%" ? "<any>" : file}</code>
       </h2>
       <em>Showing last 14 days of data.</em>
       {data === undefined ? (
@@ -45,11 +46,8 @@ export default function Page() {
               <th className={styles.table}>Test Name</th>
               <th className={styles.table}>Test Suite</th>
               <th className={styles.table}>Test File</th>
-              <th className={styles.table}># Green</th>
-              <th className={styles.table}># Red</th>
               <th className={styles.table}>Workflow Job URLs</th>
-              <th className={styles.table}>Workflow Names</th>
-              <th className={styles.table}>Job Names</th>
+              <th className={styles.table}>Workflow Job Names</th>
               <th className={styles.table}>Branches</th>
             </tr>
           </thead>
@@ -60,13 +58,10 @@ export default function Page() {
                   <td className={styles.table}>{test.name}</td>
                   <td className={styles.table}>{test.suite}</td>
                   <td className={styles.table}>{test.file}</td>
-                  <td className={styles.table}>{test.numGreen}</td>
-                  <td className={styles.table}>{test.numRed}</td>
                   <td className={styles.table}>
                     {convertJobIDtoURLs(test.jobIds).join("\n")}
                   </td>
-                  <td className={styles.table}>{test.workflowNames.join("\n")}</td>
-                  <td className={styles.table}>{test.jobNames.join("\n")}</td>
+                  <td className={styles.table}>{getWorkflowJobNames(test)}</td>
                   <td className={styles.table}>{test.branches.join("\n")}</td>
                 </tr>
               );

--- a/torchci/pages/flakytest.tsx
+++ b/torchci/pages/flakytest.tsx
@@ -5,9 +5,9 @@ import styles from "components/flakytest.module.css";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
-function convertWorkflowIDtoURLs(workflowIds: string[]): string[] {
-  return workflowIds.map((element) => {
-    return `https://github.com/pytorch/pytorch/actions/runs/${element}`;
+function convertJobIDtoURLs(jobIds: number[]): string[] {
+  return jobIds.map((element) => {
+    return `https://github.com/pytorch/pytorch/actions/jobs/${element}`;
   });
 }
 
@@ -47,8 +47,9 @@ export default function Page() {
               <th className={styles.table}>Test File</th>
               <th className={styles.table}># Green</th>
               <th className={styles.table}># Red</th>
-              <th className={styles.table}>Workflow URLs</th>
+              <th className={styles.table}>Workflow Job URLs</th>
               <th className={styles.table}>Workflow Names</th>
+              <th className={styles.table}>Job Names</th>
               <th className={styles.table}>Branches</th>
             </tr>
           </thead>
@@ -62,9 +63,10 @@ export default function Page() {
                   <td className={styles.table}>{test.numGreen}</td>
                   <td className={styles.table}>{test.numRed}</td>
                   <td className={styles.table}>
-                    {convertWorkflowIDtoURLs(test.workflowIds).join("\n")}
+                    {convertJobIDtoURLs(test.jobIds).join("\n")}
                   </td>
                   <td className={styles.table}>{test.workflowNames.join("\n")}</td>
+                  <td className={styles.table}>{test.jobNames.join("\n")}</td>
                   <td className={styles.table}>{test.branches.join("\n")}</td>
                 </tr>
               );

--- a/torchci/pages/flakytest.tsx
+++ b/torchci/pages/flakytest.tsx
@@ -27,13 +27,13 @@ export default function Page() {
     <div>
       <h1>PyTorch CI Flaky Tests</h1>
       <h2>
-        Test Name: <code>{name}</code>
+        Test Name Filter: <code>{name === "%" ? "" : name}</code>
       </h2>
       <h2>
-        Test Suite: <code>{suite}</code>
+        Test Suite Filter: <code>{suite === "%" ? "" : suite}</code>
       </h2>
       <h2>
-        Test File: <code>{file}</code>
+        Test File Filter: <code>{file === "%" ? "" : file}</code>
       </h2>
       <em>Showing last 14 days of data.</em>
       {data === undefined ? (

--- a/torchci/pages/flakytest.tsx
+++ b/torchci/pages/flakytest.tsx
@@ -54,7 +54,7 @@ export default function Page() {
                     {test.workflowNames.map((value, index) => {
                       return (
                         <li><a
-                          href={`https://github.com/pytorch/pytorch/actions/jobs/${test.jobIds[index]}`}
+                          href={`https://github.com/pytorch/pytorch/runs/${test.jobIds[index]}`}
                         >{`${value} / ${test.jobNames[index]}`}</a></li>
                       );
                     })}

--- a/torchci/pages/flakytest.tsx
+++ b/torchci/pages/flakytest.tsx
@@ -5,12 +5,6 @@ import styles from "components/flakytest.module.css";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
-function convertJobIDtoURLs(jobIds: number[]): string[] {
-  return jobIds.map((element) => {
-    return `https://github.com/pytorch/pytorch/actions/jobs/${element}`;
-  });
-}
-
 export default function Page() {
   const router = useRouter();
   const name = (router.query.name || "%") as string;
@@ -27,13 +21,13 @@ export default function Page() {
     <div>
       <h1>PyTorch CI Flaky Tests</h1>
       <h2>
-        Test Name Filter: <code>{name === "%" ? "<any>" : name}</code>
+        Test Name Filter: {name === "%" ? "<any>" : name}
       </h2>
       <h2>
-        Test Suite Filter: <code>{suite === "%" ? "<any>" : suite}</code>
+        Test Suite Filter: {suite === "%" ? "<any>" : suite}
       </h2>
       <h2>
-        Test File Filter: <code>{file === "%" ? "<any>" : file}</code>
+        Test File Filter: {file === "%" ? "<any>" : file}
       </h2>
       <em>Showing last 14 days of data.</em>
       {data === undefined ? (
@@ -45,8 +39,7 @@ export default function Page() {
               <th className={styles.table}>Test Name</th>
               <th className={styles.table}>Test Suite</th>
               <th className={styles.table}>Test File</th>
-              <th className={styles.table}>Workflow Job URLs</th>
-              <th className={styles.table}>Workflow Job Names</th>
+              <th className={styles.table}>Workflow Jobs</th>
               <th className={styles.table}>Branches</th>
             </tr>
           </thead>
@@ -58,10 +51,14 @@ export default function Page() {
                   <td className={styles.table}>{test.suite}</td>
                   <td className={styles.table}>{test.file}</td>
                   <td className={styles.table}>
-                    {convertJobIDtoURLs(test.jobIds).join("\n")}
+                    {test.workflowNames.map((value, index) => {
+                      return (
+                        <li><a
+                          href={`https://github.com/pytorch/pytorch/actions/jobs/${test.jobIds[index]}`}
+                        >{`${value} / ${test.jobNames[index]}`}</a></li>
+                      );
+                    })}
                   </td>
-                  {/* The following is the same as getWorkflowJobNames in disable.ts but I couldn't figure out how to import correctly */}
-                  <td className={styles.table}>{test.workflowNames.map((value, index) => `${value} / ${test.jobNames[index]}`)}</td>
                   <td className={styles.table}>{test.branches.join("\n")}</td>
                 </tr>
               );

--- a/torchci/pages/flakytest.tsx
+++ b/torchci/pages/flakytest.tsx
@@ -53,7 +53,7 @@ export default function Page() {
                   <td className={styles.table}>
                     {test.workflowNames.map((value, index) => {
                       return (
-                        <li><a
+                        <li key={index}><a
                           href={`https://github.com/pytorch/pytorch/runs/${test.jobIds[index]}`}
                         >{`${value} / ${test.jobNames[index]}`}</a></li>
                       );

--- a/torchci/pages/flakytest.tsx
+++ b/torchci/pages/flakytest.tsx
@@ -1,5 +1,4 @@
 import { FlakyTestData } from "lib/types";
-import {getWorkflowJobNames} from "pages/api/flaky-tests/disable";
 import { useRouter } from "next/router";
 import useSWR from "swr";
 import styles from "components/flakytest.module.css";
@@ -61,7 +60,8 @@ export default function Page() {
                   <td className={styles.table}>
                     {convertJobIDtoURLs(test.jobIds).join("\n")}
                   </td>
-                  <td className={styles.table}>{getWorkflowJobNames(test)}</td>
+                  {/* The following is the same as getWorkflowJobNames in disable.ts but I couldn't figure out how to import correctly */}
+                  <td className={styles.table}>{test.workflowNames.map((value, index) => `${value} / ${test.jobNames[index]}`)}</td>
                   <td className={styles.table}>{test.branches.join("\n")}</td>
                 </tr>
               );

--- a/torchci/rockset/commons/__sql/flaky_test_query.sql
+++ b/torchci/rockset/commons/__sql/flaky_test_query.sql
@@ -1,4 +1,4 @@
-SELECT 
+SELECT
   flaky_tests.name,
   flaky_tests.suite,
   flaky_tests.file,
@@ -6,9 +6,12 @@ SELECT
   sum(flaky_tests.num_red) AS numRed,
   ARRAY_AGG(flaky_tests.workflow_id) AS workflowIds,
   ARRAY_AGG(workflow.name) as workflowNames,
+  ARRAY_AGG(flaky_tests.job_id) AS jobIds,
+  ARRAY_AGG(job.name) as jobNames,
   ARRAY_AGG(workflow.head_branch) as branches,
 FROM commons.flaky_tests flaky_tests JOIN commons.workflow_run workflow on CAST(flaky_tests.workflow_id as int) = workflow.id
-WHERE 
+	JOIN commons.workflow_job job on CAST(flaky_tests.job_id as int) = job.id
+WHERE
 	flaky_tests._event_time > (CURRENT_TIMESTAMP() - HOURs(:num_hours)) AND
     flaky_tests.name LIKE :name AND
     flaky_tests.suite LIKE :suite AND

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -1,7 +1,7 @@
 {
   "hud_query": "86804e2dcb570a13",
   "commit_jobs_query": "8eba563cd0fb72a7",
-  "flaky_test_query": "315b58b83e5d13e8",
+  "flaky_test_query": "482db17169272025",
   "original_pr_hud_query": "a07ff9976e0363e8",
   "issue_query": "f29a1afe94563601",
   "failure_samples_query": "2961636418a148c2"

--- a/torchci/test/disableFlakyBot.test.ts
+++ b/torchci/test/disableFlakyBot.test.ts
@@ -230,12 +230,12 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
 
     test("getLatestTrunkJobURL: should return URL of last trunk job if it exists", async () => {
         expect(disableFlakyTestBot.getLatestTrunkJobURL(flakyTestE))
-            .toEqual("https://github.com/pytorch/pytorch/actions/jobs/56789876");
+            .toEqual("https://github.com/pytorch/pytorch/runs/56789876");
     });
 
     test("getLatestTrunkJobURL: should return URL of last job if no trunk instance exists", async () => {
         expect(disableFlakyTestBot.getLatestTrunkJobURL(flakyTestA))
-            .toEqual("https://github.com/pytorch/pytorch/actions/jobs/56789876");
+            .toEqual("https://github.com/pytorch/pytorch/runs/56789876");
     });
 
     test("getIssueTitle: test suite in subclass should not have __main__", async () => {


### PR DESCRIPTION
Also addresses some other stuff in https://github.com/pytorch/pytorch/issues/71005#issuecomment-1062216629
- % to `<any>`
- Delete #green and #red since those are misleading and unuseful so far
- Use workflow job names
- Use workflow job URLs

<img width="1735" alt="image" src="https://user-images.githubusercontent.com/31798555/161818862-3fe79827-90e1-42fb-92fc-79c0e130acbe.png">


Yes, it still looks meh but one small step at a time!