### PR TITLE
[hud] revert naming change

### DIFF
--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -7,16 +7,28 @@ const groups = [
     name: "Lint Jobs",
   },
   {
-    regex: /(\(periodic-pytorch)|(ci\/circleci: periodic_pytorch)|(^periodic-)/,
-    name: "Periodic Jobs",
+    regex: /android/,
+    name: "Android",
   },
   {
-    regex: /(Linux CI \(pytorch-linux-)|(^linux-)/,
-    name: "Linux GitHub Actions",
+    regex: /\slinux-/,
+    name: "Linux",
+  },
+  {
+    regex: /linux-binary/,
+    name: "Binary Linux",
+  },
+  {
+    regex: /windows-binary/,
+    name: "Binary Windows",
+  },
+  {
+    regex: /pytorch-xla/,
+    name: "XLA",
   },
   {
     regex:
-      /(Add annotations )|(Close stale pull requests)|(Label PRs & Issues)|(Triage )|(Update S3 HTML indices)|(codecov\/project)|(Facebook CLA Check)|(auto-label-rocm)/,
+      /(Add annotations )|(Close stale pull requests)|(Label PRs & Issues)|(Triage )|(Update S3 HTML indices)|(is-properly-labeled)|(Facebook CLA Check)|(auto-label-rocm)/,
     name: "Annotations and labeling",
   },
   {
@@ -25,8 +37,8 @@ const groups = [
     name: "Docker",
   },
   {
-    regex: /(Windows CI \(pytorch-)|(^win-)/,
-    name: "Windows GitHub Actions",
+    regex: /\swin-/,
+    name: "Windows",
   },
   {
     regex: / \/ calculate-docker-image/,
@@ -41,12 +53,12 @@ const groups = [
     name: "ci/circleci: pytorch_ios",
   },
   {
-    regex: /^ios-/,
-    name: "iOS Github Actions",
+    regex: /\sios-/,
+    name: "iOS",
   },
   {
-    regex: /^macos-/,
-    name: "macOS Github Actions",
+    regex: /\smacos-/,
+    name: "Mac",
   },
   {
     regex:
@@ -54,70 +66,16 @@ const groups = [
     name: "Parallel",
   },
   {
-    regex:
-      /(ci\/circleci: pytorch_cpp_doc_build)|(ci\/circleci: pytorch_cpp_doc_test)|(pytorch_python_doc_build)|(pytorch_doc_test)/,
+    regex: /(docs push)|(docs build)/,
     name: "Docs",
-  },
-  {
-    regex: /ci\/circleci: pytorch_linux_bionic_cuda10_2_cudnn7_py3_9_gcc7_/,
-    name: "ci/circleci: pytorch_linux_bionic_cuda10_2_cudnn7_py3_9_gcc7",
-  },
-  {
-    regex: /ci\/circleci: pytorch_linux_xenial_cuda10_2_cudnn7_py3_/,
-    name: "ci/circleci: pytorch_linux_xenial_cuda10_2_cudnn7_py3",
-  },
-  {
-    regex: /ci\/circleci: pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7_/,
-    name: "ci/circleci: pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7",
-  },
-  {
-    regex:
-      /(ci\/circleci: pytorch_linux_xenial_py3_clang5_android_ndk_r19c_)|(ci\/circleci: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-)/,
-    name: "ci/circleci: pytorch_linux_xenial_py3_clang5_android_ndk",
-  },
-  {
-    regex: /ci\/circleci: pytorch_linux_xenial_py3_6_gcc7_build/,
-    name: "ci/circleci: pytorch_linux_xenial_py3_clang5_asan_build",
-  },
-  {
-    regex: /ci\/circleci: pytorch_linux_xenial_py3_clang5_mobile_/,
-    name: "ci/circleci: pytorch_linux_xenial_py3_clang5_mobile",
-  },
-  {
-    regex: /ci\/circleci: pytorch_linux_xenial_py3_clang7_onnx_/,
-    name: "ci/circleci: pytorch_linux_xenial_py3_clang7_onnx",
-  },
-  {
-    regex: /ci\/circleci: pytorch_linux_xenial_py3_clang5_asan_/,
-    name: "ci/circleci: pytorch_linux_xenial_py3_clang5_asan",
-  },
-  {
-    regex: /ci\/circleci: pytorch_linux_xenial_py3_6_gcc7_/,
-    name: "ci/circleci: pytorch_linux_xenial_py3_6_gcc7",
-  },
-  {
-    regex: /ci\/circleci: pytorch_macos_10_13_py3_/,
-    name: "ci/circleci: pytorch_macos_10_13_py3",
-  },
-  {
-    regex: /ci\/circleci: pytorch_linux_xenial_py3_6_gcc5_4_/,
-    name: "ci/circleci: pytorch_linux_xenial_py3_6_gcc5_4",
-  },
-  {
-    regex: /ci\/circleci: binary_linux_/,
-    name: "ci/circleci: binary_linux",
-  },
-  {
-    regex: /ci\/circleci: binary_macos_/,
-    name: "ci/circleci: binary_macos",
-  },
-  {
-    regex: /ci\/circleci: binary_windows_/,
-    name: "ci/circleci: binary_windows",
   },
   {
     regex: /(pytorch-linux-bionic-rocm)|(pytorch_linux_bionic_rocm)/,
     name: "ROCm",
+  },
+  {
+    regex: /libtorch/,
+    name: "libtorch",
   },
 ];
 

--- a/torchci/rockset/commons/__sql/hud_query.sql
+++ b/torchci/rockset/commons/__sql/hud_query.sql
@@ -17,18 +17,8 @@ from
     (
         SELECT
             workflow.head_commit.id as sha,
-            IF(
-                workflow.name IN ('pull', 'nightly', 'trunk', 'periodic'),
-                SPLIT_PART(job.name, ' / ', 2),
-                -- job.name looks like 'linux-cpu / build'
-                job.name
-            ) as job_name,
-            IF(
-                workflow.name IN ('pull', 'nightly', 'trunk', 'periodic'),
-                SPLIT_PART(job.name, ' / ', 1),
-                -- job.name looks like 'linux-cpu / build'
-                workflow.name
-            ) as workflow_name,
+            job.name as job_name,
+            workflow.name as workflow_name,
             job.id,
             job.conclusion,
             job.html_url as html_url,

--- a/torchci/rockset/commons/__sql/original_pr_hud_query.sql
+++ b/torchci/rockset/commons/__sql/original_pr_hud_query.sql
@@ -45,18 +45,8 @@ from
         SELECT
             workflow.head_commit.id as pr_head_sha,
             original_pr.master_commit_sha as master_commit_sha,
-            IF(
-                workflow.name IN ('pull', 'nightly', 'trunk', 'periodic'),
-                SPLIT_PART(job.name, ' / ', 2),
-                -- job.name looks like 'linux-cpu / build'
-                job.name
-            ) as job_name,
-            IF(
-                workflow.name IN ('pull', 'nightly', 'trunk', 'periodic'),
-                SPLIT_PART(job.name, ' / ', 1),
-                -- job.name looks like 'linux-cpu / build'
-                workflow.name
-            ) as workflow_name,
+            job.name as job_name,
+            workflow.name as workflow_name,
             job.id,
             job.conclusion,
             job.html_url,

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -1,8 +1,8 @@
 {
-  "hud_query": "ae16dc0971eba910",
+  "hud_query": "86804e2dcb570a13",
   "commit_jobs_query": "8eba563cd0fb72a7",
   "flaky_test_query": "315b58b83e5d13e8",
-  "original_pr_hud_query": "d4ae464fa67a5d17",
+  "original_pr_hud_query": "a07ff9976e0363e8",
   "issue_query": "f29a1afe94563601",
   "failure_samples_query": "2961636418a148c2"
 }


### PR DESCRIPTION
During the transition to the consolidated workflow setup, we mapped, e.g. `pull / mytest` to `mytest` so that naming would be consistent across the transition. Now that we are fully migrated over, revert to reporting workflow and name normally.
