### PR TITLE
Exclude workflow_run-triggered workflows from HUD queries

### DIFF
--- a/torchci/rockset/commons/__sql/commit_jobs_query.sql
+++ b/torchci/rockset/commons/__sql/commit_jobs_query.sql
@@ -29,7 +29,8 @@ WITH job as (
     WHERE
         job.name != 'ciflow_should_run'
         AND job.name != 'generate-test-matrix'
-        and workflow.head_commit.id = :sha
+        AND workflow.event != 'workflow_run' -- Filter out worflow_run-triggered jobs, which have nothing to do with the SHA
+        AND workflow.head_commit.id = :sha
     UNION
         -- Handle CircleCI
         -- IMPORTANT: this needs to have the same order as the query above

--- a/torchci/rockset/commons/__sql/hud_query.sql
+++ b/torchci/rockset/commons/__sql/hud_query.sql
@@ -42,6 +42,7 @@ from
         WHERE
             job.name != 'ciflow_should_run'
             AND job.name != 'generate-test-matrix'
+            AND workflow.event != 'workflow_run' -- Filter out worflow_run-triggered jobs, which have nothing to do with the SHA
             AND ARRAY_CONTAINS(SPLIT(:shas, ','), workflow.head_commit.id)
         UNION
             -- Handle CircleCI

--- a/torchci/rockset/commons/__sql/original_pr_hud_query.sql
+++ b/torchci/rockset/commons/__sql/original_pr_hud_query.sql
@@ -71,6 +71,7 @@ from
         WHERE
             job.name != 'ciflow_should_run'
             AND job.name != 'generate-test-matrix'
+            AND workflow.event != 'workflow_run' -- Filter out worflow_run-triggered jobs, which have nothing to do with the SHA
         UNION
             -- Handle CircleCI
             -- IMPORTANT: this needs to have the same order as the query above

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -1,9 +1,9 @@
 {
   "commons": {
-    "hud_query": "86804e2dcb570a13",
-    "commit_jobs_query": "8eba563cd0fb72a7",
+    "hud_query": "a08c69a5d20cab55",
+    "commit_jobs_query": "0705e283a78dd425",
     "flaky_test_query": "482db17169272025",
-    "original_pr_hud_query": "a07ff9976e0363e8",
+    "original_pr_hud_query": "ac04505036da4c7a",
     "issue_query": "f29a1afe94563601",
     "failure_samples_query": "2961636418a148c2"
   },


### PR DESCRIPTION
If a workflow is triggered from `workflow_run`, it's `sha` is set to the current master SHA, regardless of the original workflow that triggered it. That makes it seem like that the workflow ran *on* that SHA which is misleading. Exclude such jobs from our HUD queries.

We'll need to do the same for metrics. I guess that's yet another reason to move the metrics to the HUD where it's easy to update everything at once.
