### PR TITLE
[metrics] visualize red commits as a stacked bar chart

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -110,31 +110,46 @@ function MasterCommitRedPanel({ params }: { params: RocksetParam[] }) {
   }
 
   const options: EChartsOption = {
-    title: { text: "% commits red on master, by day" },
+    title: { text: "Commits red on master, by day" },
     grid: { top: 48, right: 8, bottom: 24, left: 36 },
     dataset: { source: data },
     xAxis: { type: "category" },
     yAxis: {
       type: "value",
-      axisLabel: {
-        formatter: (value: number) => {
-          return (value * 100).toString() + "%";
-        },
-      },
     },
     series: [
       {
         type: "bar",
+        stack: "all",
+        emphasis: {
+          focus: "series",
+        },
+        encode: {
+          x: "granularity_bucket",
+          y: "green",
+        },
+      },
+      {
+        type: "bar",
+        stack: "all",
+        emphasis: {
+          focus: "series",
+        },
         encode: {
           x: "granularity_bucket",
           y: "red",
         },
       },
     ],
+    color: ["#3ba272", "#ee6666"],
     tooltip: {
       trigger: "axis",
-      valueFormatter: (value: any) => {
-        return (value * 100).toFixed(2) + "%";
+      formatter: (params: any) => {
+        const red = params[0].data.red;
+        const green = params[0].data.green;
+        const redPct = ((red / (red + green)) * 100).toFixed(2) + "%";
+        const greenPct = ((green / (red + green)) * 100).toFixed(2) + "%";
+        return `Red: ${red} (${redPct})<br/>Green: ${green} (${greenPct})`;
       },
     },
   };

--- a/torchci/rockset/metrics/__sql/master_commit_red.sql
+++ b/torchci/rockset/metrics/__sql/master_commit_red.sql
@@ -12,7 +12,7 @@ with any_red as (
                 END
             ) > 0 as int
         ) as any_red,
-        COUNT(*)
+        1 as total,
     FROM
         (
             SELECT
@@ -62,7 +62,9 @@ with any_red as (
 )
 SELECT
     FORMAT_TIMESTAMP('%m-%d-%y', DATE_TRUNC(:granularity, time)) AS granularity_bucket,
-    AVG(any_red) as red,
+    SUM(any_red) as red,
+    SUM(total) - SUM(any_red) as green,
+    SUM(total) as total,
 from
     any_red
 GROUP BY

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -19,7 +19,7 @@
     "last_successful_jobs": "8ce513bc65c75b8c",
     "last_successful_workflow": "ff4b611647c21e4c",
     "master_commit_red_avg": "039988db87a03a94",
-    "master_commit_red": "c35c92c7c0231943",
+    "master_commit_red": "0b6da2f679ad2970",
     "master_jobs_red_avg": "29b138b4454f2a63",
     "master_jobs_red": "bd04d300f24b4fa0",
     "queued_jobs_by_label": "0ec7d5348138b3fc",


### PR DESCRIPTION
As previously discussed, we want to include some notion of commit volume in this chart. This introduces a stacked bar chart where the y-axis is number of commits. The tooltip shows percents.
