### PR TITLE
[metrics] small timezone fix

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -98,7 +98,14 @@ function MasterJobsRedPanel({ params }: { params: RocksetParam[] }) {
 
 function MasterCommitRedPanel({ params }: { params: RocksetParam[] }) {
   const url = `/api/query/metrics/master_commit_red?parameters=${encodeURIComponent(
-    JSON.stringify(params)
+    JSON.stringify([
+      ...params,
+      {
+        name: "timezone",
+        type: "string",
+        value: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      },
+    ])
   )}`;
 
   const { data } = useSWR(url, fetcher, {
@@ -121,9 +128,6 @@ function MasterCommitRedPanel({ params }: { params: RocksetParam[] }) {
       {
         type: "bar",
         stack: "all",
-        emphasis: {
-          focus: "series",
-        },
         encode: {
           x: "granularity_bucket",
           y: "green",
@@ -132,9 +136,6 @@ function MasterCommitRedPanel({ params }: { params: RocksetParam[] }) {
       {
         type: "bar",
         stack: "all",
-        emphasis: {
-          focus: "series",
-        },
         encode: {
           x: "granularity_bucket",
           y: "red",
@@ -149,7 +150,8 @@ function MasterCommitRedPanel({ params }: { params: RocksetParam[] }) {
         const green = params[0].data.green;
         const redPct = ((red / (red + green)) * 100).toFixed(2) + "%";
         const greenPct = ((green / (red + green)) * 100).toFixed(2) + "%";
-        return `Red: ${red} (${redPct})<br/>Green: ${green} (${greenPct})`;
+        const total = red + green;
+        return `Red: ${red} (${redPct})<br/>Green: ${green} (${greenPct})<br/>Total: ${total}`;
       },
     },
   };

--- a/torchci/rockset/metrics/__sql/master_commit_red.sql
+++ b/torchci/rockset/metrics/__sql/master_commit_red.sql
@@ -61,7 +61,11 @@ with any_red as (
         time DESC
 )
 SELECT
-    FORMAT_TIMESTAMP('%m-%d-%y', DATE_TRUNC(:granularity, time)) AS granularity_bucket,
+    FORMAT_TIMESTAMP(
+        '%m-%d-%y',
+        DATE_TRUNC('hour', time),
+        :timezone
+    ) AS granularity_bucket,
     SUM(any_red) as red,
     SUM(total) - SUM(any_red) as green,
     SUM(total) as total,

--- a/torchci/rockset/metrics/master_commit_red.lambda.json
+++ b/torchci/rockset/metrics/master_commit_red.lambda.json
@@ -15,6 +15,11 @@
       "name": "stopTime",
       "type": "string",
       "value": "2022-03-21T00:06:32.839Z"
+    },
+    {
+      "name": "timezone",
+      "type": "string",
+      "value": "America/Los_Angeles"
     }
   ],
   "description": ""

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -19,7 +19,7 @@
     "last_successful_jobs": "8ce513bc65c75b8c",
     "last_successful_workflow": "ff4b611647c21e4c",
     "master_commit_red_avg": "039988db87a03a94",
-    "master_commit_red": "0b6da2f679ad2970",
+    "master_commit_red": "a98acf09b50b3e5c",
     "master_jobs_red_avg": "29b138b4454f2a63",
     "master_jobs_red": "bd04d300f24b4fa0",
     "queued_jobs_by_label": "0ec7d5348138b3fc",


### PR DESCRIPTION
This always bothered me; the buckets on the "Commits red by day" chart
were always aggregated on UTC time. This is against the user
expectation, which is that times should reflect the local timezone. This
was not fixable in grafana, but can be here! Yay.
