### PR TITLE
[metrics] add pending jobs to master commit red chart

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -146,17 +146,28 @@ function MasterCommitRedPanel({ params }: { params: RocksetParam[] }) {
           y: "red",
         },
       },
+      {
+        type: "bar",
+        stack: "all",
+        encode: {
+          x: "granularity_bucket",
+          y: "pending",
+        },
+      },
     ],
-    color: ["#3ba272", "#ee6666"],
+    color: ["#3ba272", "#ee6666", "#f2d643"],
     tooltip: {
       trigger: "axis",
       formatter: (params: any) => {
         const red = params[0].data.red;
         const green = params[0].data.green;
-        const redPct = ((red / (red + green)) * 100).toFixed(2) + "%";
-        const greenPct = ((green / (red + green)) * 100).toFixed(2) + "%";
-        const total = red + green;
-        return `Red: ${red} (${redPct})<br/>Green: ${green} (${greenPct})<br/>Total: ${total}`;
+        const pending = params[0].data.pending;
+        const total = params[0].data.total;
+
+        const redPct = ((red / total) * 100).toFixed(2) + "%";
+        const greenPct = ((green / total) * 100).toFixed(2) + "%";
+        const pendingPct = ((pending / total) * 100).toFixed(2) + "%";
+        return `Red: ${red} (${redPct})<br/>Green: ${green} (${greenPct})<br/>Pending: ${pending} (${pendingPct})<br/>Total: ${total}`;
       },
     },
   };

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -19,7 +19,7 @@
     "last_successful_jobs": "8ce513bc65c75b8c",
     "last_successful_workflow": "ff4b611647c21e4c",
     "master_commit_red_avg": "039988db87a03a94",
-    "master_commit_red": "a98acf09b50b3e5c",
+    "master_commit_red": "2aebf9e805912bab",
     "master_jobs_red_avg": "29b138b4454f2a63",
     "master_jobs_red": "bd04d300f24b4fa0",
     "queued_jobs_by_label": "0ec7d5348138b3fc",


### PR DESCRIPTION
This chart was a little confusing--the most recent day tends to have
very few commits represented, since most jobs are still pending. This
adds a third bar in the stacked chart for "pending" commits.

Also some cleanups to make the sql a little nicer.
