### PR TITLE
[hud] handle ansi colors properly in log viewer

### DIFF
--- a/torchci/components/LogViewer.tsx
+++ b/torchci/components/LogViewer.tsx
@@ -1,11 +1,100 @@
 import { basicSetup } from "@codemirror/basic-setup";
 import { EditorSelection, EditorState } from "@codemirror/state";
-import { EditorView } from "@codemirror/view";
+import {
+  EditorView,
+  ViewUpdate,
+  ViewPlugin,
+  DecorationSet,
+  Decoration,
+  Range,
+} from "@codemirror/view";
+import { RangeSet } from "@codemirror/rangeset";
+import { parse } from "ansicolor";
+
 import { JobData } from "lib/types";
 import { useEffect, useRef, useState } from "react";
 import useSWRImmutable from "swr";
 import { oneDark } from "@codemirror/theme-one-dark";
 import _ from "lodash";
+
+// Based on the current editor view, produce a series of decorations that
+// correctly colorize the ANSI escape codes found in the view.
+function computeDecorations(view: EditorView) {
+  let builder: Range<Decoration>[] = [];
+
+  for (const { from, to } of view.visibleRanges) {
+    for (let pos = from; pos <= to; ) {
+      const line = view.state.doc.lineAt(pos);
+      const lineText = line.text;
+      // If we detect an escape code in this line
+      if (lineText.includes("\x1b[")) {
+        // Build highlight colors for this line.
+        const parsed = parse(lineText);
+
+        // Cursor for tracking our position while processing the line.
+        let cursor = 0;
+
+        // @ts-expect-error
+        // Iterate through each segment of the line that has a color.
+        for (const segment of parsed) {
+          // Find the start position of this segment within the line, starting
+          // at the cursor.
+          const startWithinLine = lineText.indexOf(segment.text, cursor);
+
+          // Translate that position to an absolute position within the document.
+          const decoFrom = pos + startWithinLine;
+          const decoTo = decoFrom + segment.text.length;
+
+          // Add a decoration based on the computed style.
+          builder.push(
+            Decoration.mark({ attributes: { style: segment.css } }).range(
+              decoFrom,
+              decoTo
+            )
+          );
+
+          // Update our cursor within the line.
+          cursor = startWithinLine + segment.text.length;
+        }
+
+        // Also hide all the weird escape characters.
+        for (const match of lineText.matchAll(/\x1b\[[0-9;]*m/g)) {
+          const startWithinLine = match.index;
+          const decoFrom = pos + startWithinLine!;
+          const decoTo = decoFrom + match[0].length;
+
+          builder.push(
+            Decoration.replace({ inclusiveStart: true }).range(decoFrom, decoTo)
+          );
+        }
+      }
+
+      // Update our position within the viewport.
+      pos = line.to + 1;
+    }
+  }
+  return RangeSet.of(builder, /*sort=*/ true);
+}
+
+// View plugin for displaying ANSI colors in the log vewer correctly.
+// The real logic is in in computeDecorations()
+const ansiColors = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = computeDecorations(view);
+    }
+
+    update(update: ViewUpdate) {
+      if (update.docChanged || update.viewportChanged)
+        this.decorations = computeDecorations(update.view);
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+  }
+);
 
 const fetcher = (url: string) => fetch(url).then((res) => res.text());
 function Log({ url, line }: { url: string; line: number }) {
@@ -21,6 +110,7 @@ function Log({ url, line }: { url: string; line: number }) {
         EditorView.theme({ "&": { height: "90vh" } }), // set height
         EditorView.theme({ ".cm-activeLine": { backgroundColor: "indigo" } }), // set height
         oneDark, // set theme
+        ansiColors,
       ],
     });
 

--- a/torchci/components/LogViewer.tsx
+++ b/torchci/components/LogViewer.tsx
@@ -76,8 +76,8 @@ function computeDecorations(view: EditorView) {
   return RangeSet.of(builder, /*sort=*/ true);
 }
 
-// View plugin for displaying ANSI colors in the log vewer correctly.
-// The real logic is in in computeDecorations()
+// View plugin for displaying ANSI colors in the log viewer correctly.
+// The real logic is in computeDecorations()
 const ansiColors = ViewPlugin.fromClass(
   class {
     decorations: DecorationSet;

--- a/torchci/package.json
+++ b/torchci/package.json
@@ -24,6 +24,7 @@
     "@mui/x-date-pickers": "^5.0.0-alpha.0",
     "@octokit/webhooks": "^9.22.0",
     "@rockset/client": "^0.8.9",
+    "ansicolor": "^1.1.100",
     "axios": "^0.26.0",
     "dayjs": "^1.10.8",
     "dayjs-plugin-utc": "^0.1.2",

--- a/torchci/tsconfig.json
+++ b/torchci/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": "./",
-    "target": "es5",
+    "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/torchci/yarn.lock
+++ b/torchci/yarn.lock
@@ -3000,6 +3000,11 @@ ansi-styles@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
+ansicolor@^1.1.100:
+  version "1.1.100"
+  resolved "https://registry.yarnpkg.com/ansicolor/-/ansicolor-1.1.100.tgz#811f1afbf726edca3aafb942a14df8351996304a"
+  integrity sha512-Jl0pxRfa9WaQVUX57AB8/V2my6FJxrOR1Pp2qqFbig20QB4HzUoQ48THTKAgHlUCJeQm/s2WoOPcoIDhyCL/kw==
+
 any-promise@^1.0.0, any-promise@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"


### PR DESCRIPTION
Quality of life improvement. Before we just displayed the escape
characters raw, now actually colorize (and make them bold, etc.)
properly!

Before: 
<img width="403" alt="image" src="https://user-images.githubusercontent.com/1617424/164292115-35659e6b-64d7-4212-a9ce-170bf680f1d5.png">

After:
<img width="414" alt="Screen Shot 2022-04-20 at 10 48 53 AM" src="https://user-images.githubusercontent.com/1617424/164292132-59edced1-87ca-4d83-8576-52507a8dc4a7.png">

