### PR TITLE
[hud] more log improvements

### DIFF
--- a/torchci/components/LogViewer.tsx
+++ b/torchci/components/LogViewer.tsx
@@ -8,6 +8,7 @@ import {
   Decoration,
 } from "@codemirror/view";
 import { RangeSet, Range } from "@codemirror/state";
+import { foldService, codeFolding, foldAll } from "@codemirror/language";
 import { parse } from "ansicolor";
 
 import { JobData } from "lib/types";
@@ -15,6 +16,7 @@ import { useEffect, useRef, useState } from "react";
 import useSWRImmutable from "swr";
 import { oneDark } from "@codemirror/theme-one-dark";
 import _ from "lodash";
+import { isFailure } from "lib/JobClassifierUtil";
 
 // Based on the current editor view, produce a series of decorations that
 // correctly colorize the ANSI escape codes found in the view.
@@ -75,6 +77,39 @@ function computeDecorations(view: EditorView) {
   return RangeSet.of(builder, /*sort=*/ true);
 }
 
+// Fold the uninteresting parts of the log.
+// - Anything in a GitHub group (e.g. gets automatically collapse in GitHub UI)
+// - All the "cleanup" stuff (e.g. anything after the actual build/test). This
+//   part is hardcoded but should be good enough for starters.
+const foldUninteresting = foldService.of(
+  (state: EditorState, lineStart: number, lineEnd: number) => {
+    const startingLine = state.doc.lineAt(lineStart);
+    if (!startingLine.text.includes("##[group]")) {
+      return null;
+    }
+
+    // If this group begins the teardown process, just fold the entire rest of
+    // the document.
+    if (
+      startingLine.text.includes(".github/actions/teardown") ||
+      startingLine.text.includes("github/actions/get-workflow-job-id")
+    ) {
+      return { from: lineStart, to: state.doc.length };
+    }
+
+    // Otherwise find the ##[endgroup] line.
+    for (let pos = lineEnd + 1; pos < state.doc.length; ) {
+      const line = state.doc.lineAt(pos);
+      if (line.text.includes("##[endgroup]")) {
+        return { from: lineStart, to: line.to };
+      }
+      pos = line.to + 1;
+    }
+
+    return null;
+  }
+);
+
 // View plugin for displaying ANSI colors in the log viewer correctly.
 // The real logic is in computeDecorations()
 const ansiColors = ViewPlugin.fromClass(
@@ -96,7 +131,7 @@ const ansiColors = ViewPlugin.fromClass(
 );
 
 const fetcher = (url: string) => fetch(url).then((res) => res.text());
-function Log({ url, line }: { url: string; line: number }) {
+function Log({ url, line }: { url: string; line: number | null }) {
   const { data } = useSWRImmutable(url, fetcher);
   const viewer = useRef<HTMLDivElement>(null!);
 
@@ -109,17 +144,35 @@ function Log({ url, line }: { url: string; line: number }) {
         EditorView.theme({ "&": { height: "90vh" } }), // set height
         EditorView.theme({ ".cm-activeLine": { backgroundColor: "indigo" } }), // set height
         oneDark, // set theme
-        ansiColors,
+        ansiColors, // properly render ansi colors in the logs
+        foldUninteresting, // Fold the uninteresting parts of the log to clean up the view.
+        codeFolding({
+          placeholderText:
+            "<probably uninteresting folded group, click to show>",
+        }),
       ],
     });
 
     const view = new EditorView({ state, parent: viewer.current });
+
+    foldAll(view);
     if (data !== undefined) {
-      const focusLine = state.doc.line(line);
-      view.dispatch({
-        selection: EditorSelection.cursor(focusLine.from),
-        effects: EditorView.scrollIntoView(focusLine.from, { y: "center" }),
-      });
+      if (line != null) {
+        // Select and center the failure line
+        const focusLine = state.doc.line(line);
+        view.dispatch({
+          selection: EditorSelection.cursor(focusLine.from),
+          effects: EditorView.scrollIntoView(focusLine.from, { y: "center" }),
+        });
+      } else {
+        // If we don't have a failure line, just scroll to the bottom.
+        view.dispatch({
+          effects: EditorView.scrollIntoView(
+            state.doc.line(state.doc.lines).from,
+            {}
+          ),
+        });
+      }
     }
     return () => {
       view.destroy();
@@ -131,7 +184,7 @@ function Log({ url, line }: { url: string; line: number }) {
 
 export default function LogViewer({ job }: { job: JobData }) {
   const [showLogViewer, setShowLogViewer] = useState(false);
-  if (job.failureLine == null) {
+  if (!isFailure(job.conclusion)) {
     return null;
   }
 
@@ -143,7 +196,7 @@ export default function LogViewer({ job }: { job: JobData }) {
     <div>
       {showLogViewer ? "▼ " : "▶ "}
       <code style={{ cursor: "pointer" }} onClick={handleClick}>
-        {job.failureLine}
+        {job.failureLine ?? "Show log"}
       </code>
       {showLogViewer && <Log url={job.logUrl!} line={job.failureLineNumber!} />}
     </div>

--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -102,8 +102,23 @@ export function getGroupConclusionChar(conclusion?: GroupedJobStatus): string {
       return "U";
   }
 }
+
+export function isFailure(conclusion?: string): boolean {
+  switch (conclusion) {
+    case JobStatus.Failure:
+    case JobStatus.Cancelled:
+    case JobStatus.Timed_out:
+      return true;
+    case JobStatus.Success:
+    case JobStatus.Neutral:
+    case JobStatus.Skipped:
+    case JobStatus.Pending:
+    case undefined:
+    default:
+      return false;
+  }
+}
 export function getConclusionChar(conclusion?: string): string {
-  let conclusionChar;
   switch (conclusion) {
     case JobStatus.Success:
       return "O";


### PR DESCRIPTION
- Always show the log viewer on failures, even if we don't have a classification.
- Use folds to hide uninteresting log content (really helps with log readability)
