### PR TITLE
[metrics] Show queue times in descending order instead of ascending

### DIFF
--- a/torchci/rockset/metrics/__sql/queued_jobs.sql
+++ b/torchci/rockset/metrics/__sql/queued_jobs.sql
@@ -12,4 +12,4 @@ WHERE
     AND job._event_time > (CURRENT_TIMESTAMP() - INTERVAL 1 DAY)
     AND job._event_time < (CURRENT_TIMESTAMP() - INTERVAL 10 MINUTE)
 ORDER BY
-    queue_s ASC
+    queue_s DESC

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -23,7 +23,7 @@
     "master_jobs_red_avg": "29b138b4454f2a63",
     "master_jobs_red": "bd04d300f24b4fa0",
     "queued_jobs_by_label": "0ec7d5348138b3fc",
-    "queued_jobs": "8d6064d1ed890fe2",
+    "queued_jobs": "054eefebcbee4ef6",
     "reverts": "4446ee821236f997",
     "tts_avg": "597897063acde94c"
   }

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -23,7 +23,7 @@
     "master_jobs_red_avg": "29b138b4454f2a63",
     "master_jobs_red": "bd04d300f24b4fa0",
     "queued_jobs_by_label": "0ec7d5348138b3fc",
-    "queued_jobs": "054eefebcbee4ef6",
+    "queued_jobs": "3724769f76ad4ecc",
     "reverts": "4446ee821236f997",
     "tts_avg": "597897063acde94c"
   }


### PR DESCRIPTION
This way we are more alarmed by our long queue times and things become more actionable
![image](https://user-images.githubusercontent.com/31798555/165634964-4b036f2e-6776-42f7-82cf-5cbee2ae76dc.png)
