### PR TITLE
torchci: Switch metrics to hud metrics

### DIFF
--- a/torchci/components/NavBar.tsx
+++ b/torchci/components/NavBar.tsx
@@ -49,7 +49,7 @@ function NavBar() {
               </Link>
             </li>
             <li>
-              <Link href="https://metrics.pytorch.org">Metrics</Link>
+              <Link href="https://hud.pytorch.org/metrics">Metrics</Link>
             </li>
             <li>
               <span style={{ cursor: "pointer" }}>


### PR DESCRIPTION
metrics.pytorch.org will eventually be deprecated and it was a surprise
to me that the metrics link in the navbar took me to it. This just
changes the hyperlink to point to metrics in the hud instead of grafana

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>
