### PR TITLE
Fix revert reason regex

### DIFF
--- a/torchci/lib/bot/mergeBot.ts
+++ b/torchci/lib/bot/mergeBot.ts
@@ -47,7 +47,7 @@ function mergeBot(app: Probot): void {
         return;
       }
       const revertWithReasonCmdPat = new RegExp(
-        "^\\s*@pytorch(merge|)bot\\s+revert\\s+this(.|\s)*(\\s+\\w+){3,}"
+        "^\\s*@pytorch(merge|)bot\\s+revert\\s+this(.|\\s)*(\\s+\\w+){3,}"
       );
       if (commentBody.match(revertWithReasonCmdPat) === null) {
         // revert reason of 3+ words not given

--- a/torchci/lib/bot/mergeBot.ts
+++ b/torchci/lib/bot/mergeBot.ts
@@ -47,14 +47,14 @@ function mergeBot(app: Probot): void {
         return;
       }
       const revertWithReasonCmdPat = new RegExp(
-        "^\\s*@pytorch(merge|)bot\\s+revert\\s+this.*(\\s+\\w+){3,}"
+        "^\\s*@pytorch(merge|)bot\\s+revert\\s+this(.|\s)*(\\s+\\w+){3,}"
       );
       if (commentBody.match(revertWithReasonCmdPat) === null) {
         // revert reason of 3+ words not given
         await addComment(
           ctx,
           "Revert unsuccessful: please retry the command explaining why the revert is necessary, " +
-            "e.g. @pytorchbot revert this as it breaks mac tests on trunk, see <url to logs>."
+            "e.g. @pytorchbot revert this as it breaks mac tests on trunk, see {url to logs}."
         );
         return;
       }

--- a/torchci/test/mergeBot.test.ts
+++ b/torchci/test/mergeBot.test.ts
@@ -178,7 +178,7 @@ describe("merge-bot", () => {
       .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
         expect(JSON.stringify(body)).toContain(
           "Revert unsuccessful: please retry the command explaining why the revert is " +
-            "necessary, e.g. @pytorchbot revert this as it breaks mac tests on trunk, see <url to logs>."
+            "necessary, e.g. @pytorchbot revert this as it breaks mac tests on trunk, see {url to logs}."
         );
         return true;
       })
@@ -195,7 +195,7 @@ describe("merge-bot", () => {
     const event = require("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body =
-      "@pytorchbot  revert this--it breaks ios tests on trunk " +
+      "@pytorchbot  revert this--\n\nit breaks ios tests on trunk " +
       "see https://hud.pytorch.org/minihud?name_filter=trunk%20/%20ios-12-5-1-x86-64-coreml%20/%20build";
 
     const owner = event.payload.repository.owner.login;


### PR DESCRIPTION
Turns out the . in regex doesn't cover line terminators! This causes undesired behavior like https://github.com/pytorch/pytorch/pull/74596#issuecomment-1113457935.