### PR TITLE
Add flaky capture

### DIFF
--- a/torchci/log_classifier/classify_log.py
+++ b/torchci/log_classifier/classify_log.py
@@ -188,11 +188,6 @@ def classify(rules, id):
     log_obj = s3.Object(BUCKET_NAME, f"log/{id}")
     log_obj.load()
 
-    if log_obj.metadata.get("conclusion") != "failure":
-        # only classify failed jobs
-        logger.info("skipping non-failing job")
-        return
-
     log = log_obj.get()
 
     # logs are stored gzip-compressed

--- a/torchci/pages/api/classifier/rules.ts
+++ b/torchci/pages/api/classifier/rules.ts
@@ -96,7 +96,7 @@ export default async function handler(
       },
       {
         name: "Python flaky unittest",
-        pattern: r`(test.*) (fail|error|succeed)?ed - num_retries_left:`,
+        pattern: r`^\s*(test.*) (fail|error|succeed)?ed - num_retries_left:`,
         priority: 998,
       },
       {

--- a/torchci/pages/api/classifier/rules.ts
+++ b/torchci/pages/api/classifier/rules.ts
@@ -95,6 +95,11 @@ export default async function handler(
         priority: 999,
       },
       {
+        name: "Python flaky unittest",
+        pattern: r`(test.*) (fail|error|succeed)?ed - num_retries_left:`,
+        priority: 998,
+      },
+      {
         name: "Python unittest failure",
         pattern: r`FAIL \[.*\]: (test.*) \((?:__main__\.)?(.*)\)`,
         priority: 998,

--- a/torchci/pages/api/classifier/rules.ts
+++ b/torchci/pages/api/classifier/rules.ts
@@ -95,14 +95,14 @@ export default async function handler(
         priority: 999,
       },
       {
-        name: "Python flaky unittest",
-        pattern: r`^\s*(test.*) (fail|error|succeed)?ed - num_retries_left:`,
-        priority: 998,
-      },
-      {
         name: "Python unittest failure",
         pattern: r`FAIL \[.*\]: (test.*) \((?:__main__\.)?(.*)\)`,
         priority: 998,
+      },
+      {
+        name: "Python flaky unittest",
+        pattern: r`^\s*(test.*) (fail|error|succeed)?ed - num_retries_left:`,
+        priority: 997,
       },
       {
         name: "Python unittest error",


### PR DESCRIPTION
Flaky tests rerun in logs, so match against one of the rerun lines.

This looks to be helpful in getting the log view to jump to the correct lines for flaky tests, but I'm not sure I wrote the rule 100% correctly.