### PR TITLE
be: Add blame ignore revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# torchci: Format code with prettier (#329)
+25fdd96b6460cf5504f98f70e2791b2944fc17b2


### PR DESCRIPTION
Adds an ignore revs file to make blame a bit easier to user after my big
formatting PR

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>