### PR TITLE
[metrics] report queued jobs by max, not avg

### DIFF
--- a/torchci/rockset/metrics/__sql/queued_jobs_by_label.sql
+++ b/torchci/rockset/metrics/__sql/queued_jobs_by_label.sql
@@ -19,7 +19,7 @@ WITH queued_jobs as (
 )
 SELECT
     COUNT(*) as count,
-    AVG(queue_s) as avg_queue_s,
+    MAX(queue_s) as avg_queue_s,
     labels,
 FROM
     queued_jobs

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -23,7 +23,7 @@
     "master_commit_red": "e5003789ace2ca6a",
     "master_jobs_red_avg": "a017cf67c6a503a5",
     "master_jobs_red": "739a319fd5133800",
-    "queued_jobs_by_label": "0ec7d5348138b3fc",
+    "queued_jobs_by_label": "6ddd544c9608d394",
     "queued_jobs": "3724769f76ad4ecc",
     "reverts": "235c444d865a5e48",
     "tts_avg": "597897063acde94c",


### PR DESCRIPTION
The actual length of the queue is the maximum queueing time, not the
average. So report the max
