### PR TITLE
Exclude `repository_dispatch` triggered workflows from HUD

### DIFF
--- a/torchci/rockset/commons/__sql/commit_jobs_query.sql
+++ b/torchci/rockset/commons/__sql/commit_jobs_query.sql
@@ -29,7 +29,8 @@ WITH job as (
     WHERE
         job.name != 'ciflow_should_run'
         AND job.name != 'generate-test-matrix'
-        AND workflow.event != 'workflow_run' -- Filter out worflow_run-triggered jobs, which have nothing to do with the SHA
+        AND workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
+        AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
         AND workflow.head_commit.id = :sha
     UNION
         -- Handle CircleCI

--- a/torchci/rockset/commons/__sql/hud_query.sql
+++ b/torchci/rockset/commons/__sql/hud_query.sql
@@ -42,7 +42,8 @@ from
         WHERE
             job.name != 'ciflow_should_run'
             AND job.name != 'generate-test-matrix'
-            AND workflow.event != 'workflow_run' -- Filter out worflow_run-triggered jobs, which have nothing to do with the SHA
+            AND workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
+            AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
             AND ARRAY_CONTAINS(SPLIT(:shas, ','), workflow.head_commit.id)
         UNION
             -- Handle CircleCI

--- a/torchci/rockset/commons/__sql/original_pr_hud_query.sql
+++ b/torchci/rockset/commons/__sql/original_pr_hud_query.sql
@@ -71,7 +71,8 @@ from
         WHERE
             job.name != 'ciflow_should_run'
             AND job.name != 'generate-test-matrix'
-            AND workflow.event != 'workflow_run' -- Filter out worflow_run-triggered jobs, which have nothing to do with the SHA
+            AND workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
+            AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
         UNION
             -- Handle CircleCI
             -- IMPORTANT: this needs to have the same order as the query above

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -1,9 +1,9 @@
 {
   "commons": {
-    "hud_query": "a08c69a5d20cab55",
-    "commit_jobs_query": "0705e283a78dd425",
+    "hud_query": "4badc1e12924dd4d",
+    "commit_jobs_query": "d92bfea885b0265c",
     "flaky_test_query": "482db17169272025",
-    "original_pr_hud_query": "09377767e3178ee4",
+    "original_pr_hud_query": "65174273ce3e602a",
     "issue_query": "f29a1afe94563601",
     "failure_samples_query": "2961636418a148c2"
   },


### PR DESCRIPTION
Those are usually triggered by probot and they have nothing to do with
the sha they are running on
