### PR TITLE
[metrics] clean up machine type grouping

### DIFF
--- a/torchci/README.md
+++ b/torchci/README.md
@@ -75,8 +75,9 @@ console.
    parameter definitions are found in `rockset/<workspace>`.
 2. You can test your query lambda using the [Rockset
    CLI](https://github.com/rockset/rockset-js/tree/master/packages/cli#execute-and-test-query-lambda-sql).
-3. Run `rockset local deploy -l <yourlambda>` to sync it to Rockset.
-4. Update `rockset/prodVersion.json` with the new version of the lambda.
+3. Run `yarn node scripts/uploadQueryLambda.mjs`. This will upload *all* of the
+   local query lambdas to Rockset and update `rockset/prodVersions.json` to
+   point to the new versions.
 
 ### Work on the query in Rockset console
 

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -515,9 +515,9 @@ export default function Page() {
                 valueFormatter: (params: GridValueFormatterParams<number>) =>
                   durationDisplay(params.value),
               },
-              { field: "labels", headerName: "Machine Type", flex: 4 },
+              { field: "machine_type", headerName: "Machine Type", flex: 4 },
             ]}
-            dataGridProps={{ getRowId: (el: any) => el.labels[0] }}
+            dataGridProps={{ getRowId: (el: any) => el.machine_type }}
           />
         </Grid>
 
@@ -534,7 +534,7 @@ export default function Page() {
                 valueFormatter: (params: GridValueFormatterParams<number>) =>
                   durationDisplay(params.value),
               },
-              { field: "labels", headerName: "Machine Type", flex: 1 },
+              { field: "machine_type", headerName: "Machine Type", flex: 1 },
               {
                 field: "name",
                 headerName: "Job Name",

--- a/torchci/rockset/metrics/__sql/queued_jobs.sql
+++ b/torchci/rockset/metrics/__sql/queued_jobs.sql
@@ -2,12 +2,16 @@ SELECT
     DATE_DIFF('second', job._event_time, CURRENT_TIMESTAMP()) as queue_s,
     CONCAT(workflow.name, ' / ', job.name) as name,
     job.html_url,
-    job.labels,
+    IF(
+        LENGTH(job.labels) > 1,
+        ELEMENT_AT(job.labels, 2),
+        ELEMENT_AT(job.labels, 1)
+    ) as machine_type,
 FROM
     commons.workflow_job job
-    JOIN commons.workflow_run workflow HINT(access_path=column_scan) on workflow.id = job.run_id
+    JOIN commons.workflow_run workflow HINT(access_path = column_scan) on workflow.id = job.run_id
 WHERE
-	workflow.repository.full_name = 'pytorch/pytorch'
+    workflow.repository.full_name = 'pytorch/pytorch'
     AND job.status = 'queued'
     AND job._event_time > (CURRENT_TIMESTAMP() - INTERVAL 1 DAY)
     AND job._event_time < (CURRENT_TIMESTAMP() - INTERVAL 10 MINUTE)

--- a/torchci/rockset/metrics/__sql/queued_jobs_by_label.sql
+++ b/torchci/rockset/metrics/__sql/queued_jobs_by_label.sql
@@ -3,7 +3,11 @@ WITH queued_jobs as (
         DATE_DIFF('second', job._event_time, CURRENT_TIMESTAMP()) as queue_s,
         CONCAT(workflow.name, ' / ', job.name) as name,
         job.html_url,
-        job.labels,
+        IF(
+            LENGTH(job.labels) > 1,
+            ELEMENT_AT(job.labels, 2),
+            ELEMENT_AT(job.labels, 1)
+        ) as machine_type,
     FROM
         commons.workflow_job job
         JOIN commons.workflow_run workflow on workflow.id = job.run_id
@@ -20,10 +24,10 @@ WITH queued_jobs as (
 SELECT
     COUNT(*) as count,
     MAX(queue_s) as avg_queue_s,
-    labels,
+    machine_type,
 FROM
     queued_jobs
 GROUP BY
-    labels
+    machine_type
 ORDER BY
     count DESC

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -8,7 +8,7 @@
     "failure_samples_query": "2961636418a148c2"
   },
   "pytorch_dev_infra_kpis": {
-    "num_reverts": "2a62d48a0b3fc309",
+    "num_reverts": "57e5562a57427ae3",
     "time_to_merge": "be1c2a28cf75fe32",
     "time_to_review": "adfbcdfc51ede11a",
     "time_to_signal": "670e34fc86adb3ad"
@@ -19,13 +19,13 @@
     "last_branch_push": "3d995ac2143586dc",
     "last_successful_jobs": "fd8bc3a2afc989a2",
     "last_successful_workflow": "5d22927dd0b0956b",
-    "master_commit_red_avg": "fbb27c782608d52d",
-    "master_commit_red": "e5003789ace2ca6a",
-    "master_jobs_red_avg": "a017cf67c6a503a5",
-    "master_jobs_red": "739a319fd5133800",
-    "queued_jobs_by_label": "6ddd544c9608d394",
-    "queued_jobs": "3724769f76ad4ecc",
-    "reverts": "235c444d865a5e48",
+    "master_commit_red_avg": "70391ac17f1c45bd",
+    "master_commit_red": "e4e5cb062864bf1f",
+    "master_jobs_red_avg": "e5cc28eb51fc9fe9",
+    "master_jobs_red": "aa08fa7af455e1b9",
+    "queued_jobs_by_label": "cbfdab021c22f823",
+    "queued_jobs": "f5cadeeb8d274b79",
+    "reverts": "f5bc84a10c4065a3",
     "tts_avg": "c0049352a4c38aa5",
     "workflow_duration_avg": "34e698a78cb36669"
   }

--- a/torchci/scripts/uploadQueryLambda.mjs
+++ b/torchci/scripts/uploadQueryLambda.mjs
@@ -1,0 +1,51 @@
+import rockset from "@rockset/client";
+import { promises as fs } from "fs";
+import dotenv from "dotenv";
+import path from "path";
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+const client = rockset.default(process.env.ROCKSET_API_KEY);
+
+async function readJSON(path) {
+    const rawData = await fs.readFile(path);
+    return JSON.parse(rawData);
+}
+const prodVersions = await readJSON("rockset/prodVersions.json");
+const prodVersionsNew = await readJSON("rockset/prodVersions.json");
+
+async function upload(workspace, queryName) {
+    const config = await readJSON(
+        `./rockset/${workspace}/${queryName}.lambda.json`
+    );
+    const query = await fs.readFile(
+        `./rockset/${workspace}/__sql/${queryName}.sql`,
+        "utf8"
+    );
+
+    const res = await client.queryLambdas.updateQueryLambda(workspace, queryName, {
+        description: config.description,
+        sql: {
+            query,
+            default_parameters: config.default_parameters,
+        },
+    })
+
+    const newVersion = res.data.version;
+    prodVersionsNew[workspace][queryName] = newVersion;
+
+    console.log(`Updated ${workspace}.${queryName} to version ${newVersion}`);
+}
+
+const tasks = [];
+Object.keys(prodVersions).forEach((workspace) => {
+    Object.entries(prodVersions[workspace]).forEach(([queryName, _]) =>
+        tasks.push(upload(workspace, queryName))
+    );
+});
+await Promise.all(tasks);
+
+await fs.writeFile(
+    "rockset/prodVersions.json",
+    JSON.stringify(prodVersionsNew, null, 2),
+    "utf8"
+);


### PR DESCRIPTION
Our CI sometimes has labels like `[x]`, and sometimes like
`[self-hosted, x]`. The `[self-hosted, x]` formulation is recommended by
GitHub:
https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow#using-self-hosted-runners-in-a-workflow

But they are equivalent from the perpsective of metrics. So clean things
up by unpacking the label so that `[x]` and `[self-hosted, x]` turn into
the same thing.

I also added a convenience script uploading your local SQL and syncing
`prodVersions.json` in one command.
