### PR TITLE
Added flag for mergebot to rebase to viable/strict branch

### DIFF
--- a/torchci/lib/bot/cliParser.ts
+++ b/torchci/lib/bot/cliParser.ts
@@ -43,7 +43,7 @@ const cliOptions: { [key: string]: any } = {
         key: "stable",
         alternatives: ["s", "stable", "viableStrict"],
         type: "flag",
-      }
+      },
     ],
   },
 };

--- a/torchci/lib/bot/cliParser.ts
+++ b/torchci/lib/bot/cliParser.ts
@@ -38,7 +38,13 @@ const cliOptions: { [key: string]: any } = {
     ],
   },
   rebase: {
-    options: [],
+    options: [
+      {
+        key: "stable",
+        alternatives: ["s", "stable", "viableStrict"],
+        type: "flag",
+      }
+    ],
   },
 };
 

--- a/torchci/lib/bot/mergeBot.ts
+++ b/torchci/lib/bot/mergeBot.ts
@@ -76,7 +76,7 @@ function mergeBot(app: Probot): void {
       await reactOnComment(ctx, "+1");
     }
 
-    async function handleRebase() {
+    async function handleRebase(stable: boolean) {
       async function comment_author_in_pytorch_org() {
         try {
           return (await ctx.octokit.rest.orgs.getMembershipForUser({
@@ -89,7 +89,7 @@ function mergeBot(app: Probot): void {
       }
 
       if (ctx.payload.comment.user.login == ctx.payload.issue.user.login || await comment_author_in_pytorch_org()) {
-        await dispatchEvent("try-rebase");
+        await dispatchEvent("try-rebase", stable);
         await reactOnComment(ctx, "+1");
       } else {
         await addComment(
@@ -152,7 +152,7 @@ function mergeBot(app: Probot): void {
         await handleConfused();
         return;
       }
-      await handleRebase();
+      await handleRebase(false);
       return;
     }
 
@@ -193,7 +193,7 @@ function mergeBot(app: Probot): void {
       } else if (cmd === "merge") {
         await handleMerge(option["force"], option["green"], option['allGreen']);
       } else if (cmd === "rebase") {
-        await handleRebase();
+        await handleRebase(option["stable"]);
       } else if (cmd === "help") {
         await handleHelp();
       } else {

--- a/torchci/lib/bot/mergeBot.ts
+++ b/torchci/lib/bot/mergeBot.ts
@@ -33,7 +33,8 @@ function mergeBot(app: Probot): void {
       force: boolean = false,
       onGreen: boolean = false,
       allGreen: boolean = false,
-      reason: string = ""
+      reason: string = "",
+      stable: boolean = false
     ) {
       let payload: any = {
         pr_num: prNum,
@@ -46,6 +47,8 @@ function mergeBot(app: Probot): void {
         payload.all_green = true;
       } else if (onGreen) {
         payload.on_green = true;
+      } else if (stable) {
+        payload.stable = true
       }
 
       if (reason.length > 0) {
@@ -89,7 +92,7 @@ function mergeBot(app: Probot): void {
       }
 
       if (ctx.payload.comment.user.login == ctx.payload.issue.user.login || await comment_author_in_pytorch_org()) {
-        await dispatchEvent("try-rebase", stable);
+        await dispatchEvent("try-rebase", false, false, false, "", stable);
         await reactOnComment(ctx, "+1");
       } else {
         await addComment(

--- a/torchci/test/mergeBot.test.ts
+++ b/torchci/test/mergeBot.test.ts
@@ -288,6 +288,46 @@ describe("merge-bot", () => {
     scope.done();
   });
 
+  test("rebase to viable/strict", async () => {
+    const event = require("./fixtures/pull_request_comment.json");
+
+    event.payload.comment.body = "@pytorchbot rebase -s";
+    event.payload.comment.user.login = "random1";
+    event.payload.issue.user.login = "random2";
+
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    const pr_number = event.payload.issue.number;
+    const comment_number = event.payload.comment.id;
+    
+    const scope = nock("https://api.github.com")
+      .get(`/orgs/pytorch/memberships/${event.payload.comment.user.login}`)
+      .reply(200, {
+        state: "active"
+      })
+      .post(
+        `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
+        (body) => {
+          expect(JSON.stringify(body)).toContain(`{"content":"+1"}`);
+          return true;
+        }
+      )
+      .reply(200, {})
+      .post(`/repos/${owner}/${repo}/dispatches`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          `{"event_type":"try-rebase","client_payload":{"pr_num":${pr_number},"comment_id":${comment_number},"stable":true}}`
+        );
+        return true;
+      })
+      .reply(200, {});
+
+    await probot.receive(event);
+    if (!scope.isDone()) {
+      console.error("pending mocks: %j", scope.pendingMocks());
+    }
+    scope.done();
+  });
+
   test("rebase does not have permissions", async () => {
     const event = require("./fixtures/pull_request_comment.json");
 


### PR DESCRIPTION
Test plan: Added test case that calls rebase with stable flag, which signals to mergebot to rebase to the viable/strict branch. This case registers the flag as true and all other mergebot tests pass.
![Screen Shot 2022-05-24 at 4 23 10 PM](https://user-images.githubusercontent.com/24441980/170125551-cf954c13-409f-41ea-b698-026c5a18cc26.png)