### PR TITLE
[metrics] improve queue time metrics

### DIFF
--- a/torchci/rockset/metrics/__sql/queued_jobs.sql
+++ b/torchci/rockset/metrics/__sql/queued_jobs.sql
@@ -7,13 +7,21 @@ SELECT
         ELEMENT_AT(job.labels, 2),
         ELEMENT_AT(job.labels, 1)
     ) as machine_type,
+    job.steps,
+    workflow.status
 FROM
     commons.workflow_job job
-    JOIN commons.workflow_run workflow HINT(access_path = column_scan) on workflow.id = job.run_id
+    JOIN commons.workflow_run workflow on workflow.id = job.run_id
 WHERE
     workflow.repository.full_name = 'pytorch/pytorch'
     AND job.status = 'queued'
-    AND job._event_time > (CURRENT_TIMESTAMP() - INTERVAL 1 DAY)
-    AND job._event_time < (CURRENT_TIMESTAMP() - INTERVAL 10 MINUTE)
+    AND job._event_time < (CURRENT_TIMESTAMP() - INTERVAL 5 MINUTE)
+    /* These two conditions are workarounds for GitHub's broken API. Sometimes */
+    /* jobs get stuck in a permanently "queued" state but definitely ran. We can */
+    /* detect this by looking at whether any steps executed (if there were, */
+    /* obviously the job started running), and whether the workflow was marked as */
+    /* complete (somehow more reliable than the job-level API) */
+    AND LENGTH(job.steps) = 0
+    AND workflow.status != 'completed'
 ORDER BY
     queue_s DESC

--- a/torchci/rockset/metrics/__sql/queued_jobs_by_label.sql
+++ b/torchci/rockset/metrics/__sql/queued_jobs_by_label.sql
@@ -16,8 +16,14 @@ WITH queued_jobs as (
         push.repository.owner.name = 'pytorch'
         AND push.repository.name = 'pytorch'
         AND job.status = 'queued'
-        AND job._event_time > (CURRENT_TIMESTAMP() - INTERVAL 1 DAY)
-        AND job._event_time < (CURRENT_TIMESTAMP() - INTERVAL 10 MINUTE)
+        AND job._event_time < (CURRENT_TIMESTAMP() - INTERVAL 5 MINUTE)
+        /* These two conditions are workarounds for GitHub's broken API. Sometimes */
+        /* jobs get stuck in a permanently "queued" state but definitely ran. We can */
+        /* detect this by looking at whether any steps executed (if there were, */
+        /* obviously the job started running), and whether the workflow was marked as */
+        /* complete (somehow more reliable than the job-level API) */
+        AND LENGTH(job.steps) = 0
+        AND workflow.status != 'completed'
     ORDER BY
         job._event_time DESC
 )

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -23,8 +23,8 @@
     "master_commit_red": "e4e5cb062864bf1f",
     "master_jobs_red_avg": "e5cc28eb51fc9fe9",
     "master_jobs_red": "aa08fa7af455e1b9",
-    "queued_jobs_by_label": "cbfdab021c22f823",
-    "queued_jobs": "f5cadeeb8d274b79",
+    "queued_jobs_by_label": "f6cc7d2e5360c6c5",
+    "queued_jobs": "d66a6ecf3fae2ebc",
     "reverts": "f5bc84a10c4065a3",
     "tts_avg": "c0049352a4c38aa5",
     "workflow_duration_avg": "34e698a78cb36669"


### PR DESCRIPTION
We keep getting afflicted by incorrect results that GitHub's API is
returning, where some jobs are incorrectly marked as queueing forever.
I've filed a ticket for GH eng to investigate, but in the meantime this
workaround should filter out those bad jobs.
