### PR TITLE
[mergeBot] port arg parsing logic to argparse+shlex

### DIFF
--- a/torchci/package.json
+++ b/torchci/package.json
@@ -43,11 +43,13 @@
     "react-linkify-it": "1.0.5",
     "react-use-clipboard": "^1.0.8",
     "recharts": "^2.1.8",
+    "shlex": "^2.1.0",
     "swr": "^1.3.0",
     "urllib": "^2.38.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@types/argparse": "^2.0.10",
     "@types/echarts": "^4.9.14",
     "@types/jest": "^27.4.1",
     "@types/jsdom": "^16.2.14",

--- a/torchci/yarn.lock
+++ b/torchci/yarn.lock
@@ -2331,6 +2331,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@types/argparse@^2.0.10":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@types/argparse/-/argparse-2.0.10.tgz#664e84808accd1987548d888b9d21b3e9c996a6c"
+  integrity sha512-C4wahC3gz3vQtvPazrJ5ONwmK1zSDllQboiWvpMM/iOswCYfBREFnjFbq/iWKIVOCl8+m5Pk6eva6/ZSsDuIGA==
+
 "@types/aws-lambda@^8.10.83":
   version "8.10.94"
   resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.94.tgz#04c9e20d1c254c663ec293cc84c1197873417386"
@@ -7235,6 +7240,11 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+shlex@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/shlex/-/shlex-2.1.0.tgz#4f8fbf75c4a9956283e4095fa5eac3f4969f6a6b"
+  integrity sha512-Tk8PjohJbWpGu2NtAlsEi/9AS4GU2zW2ZWLFrWRDskZpSJmyBIU3nTkBtocxD90r3w4BwRevsNtIqIP9HMuYiQ==
 
 side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
This brings a few benefits:
- shlex ensures that the command-line parsing is POSIX-compliant, which
conforms to people's expectations of what is allowed on a command line
(as an example, single-quoted strings should work).
- argparse is a more declarative way of specifying arguments, which
eliminates a lot of handwritten code for, e.g. required arguments,
choice allowlists, generating a help message, and so on.
- argparse also is more familiar to PyTorch in terms of syntax users, as
it is the conventional thing that Python programs use. (e.g. single dash
for short form, double dash for long form)
