### PR TITLE
Add flaky_tests SQL that queries test_run stats

### DIFF
--- a/torchci/rockset/commons/__sql/flaky_tests.sql
+++ b/torchci/rockset/commons/__sql/flaky_tests.sql
@@ -15,12 +15,9 @@ FROM
     INNER JOIN commons.test_run ON test_run.job_id = job.id HINT(join_strategy=lookup)
     INNER JOIN commons.workflow_run workflow ON job.run_id = workflow.id 
 WHERE 
-	NOT test_run.skipped IS NULL
+	test_run.skipped IS NOT NULL
     AND STRPOS(test_run.skipped.message, 'num_red') > 0  
     AND test_run._event_time > (CURRENT_TIMESTAMP() - HOURs(:numHours)) 
-    AND test_run.name LIKE :name
-    AND test_run.classname LIKE :suite
-    AND test_run.file LIKE :file
 GROUP BY
 	name,
     suite,

--- a/torchci/rockset/commons/__sql/flaky_tests.sql
+++ b/torchci/rockset/commons/__sql/flaky_tests.sql
@@ -1,0 +1,27 @@
+SELECT
+	test_run.name,
+	test_run.classname as suite,
+	test_run.file,
+	SUM(ELEMENT_AT(JSON_PARSE(REPLACE(test_run.skipped.message, 'True', 'true')), 'num_green')) as numGreen,
+	SUM(ELEMENT_AT(JSON_PARSE(REPLACE(test_run.skipped.message, 'True', 'true')), 'num_red')) as numRed,
+	ARRAY_AGG(job.name) as jobNames,
+	ARRAY_AGG(job.id) as jobIds,
+	ARRAY_AGG(workflow.id) as workflowIds,
+	ARRAY_AGG(workflow.name) as workflowNames,
+	ARRAY_AGG(workflow.head_branch) as branches,
+    ARRAY_AGG(test_run.workflow_run_attempt) as runAttempts
+FROM
+    commons.workflow_job job 
+    INNER JOIN commons.test_run ON test_run.job_id = job.id HINT(join_strategy=lookup)
+    INNER JOIN commons.workflow_run workflow ON job.run_id = workflow.id 
+WHERE 
+	NOT test_run.skipped IS NULL
+    AND STRPOS(test_run.skipped.message, 'num_red') > 0  
+    AND test_run._event_time > (CURRENT_TIMESTAMP() - HOURs(:numHours)) 
+    AND test_run.name LIKE :name
+    AND test_run.classname LIKE :suite
+    AND test_run.file LIKE :file
+GROUP BY
+	name,
+    suite,
+    file

--- a/torchci/rockset/commons/flaky_tests.lambda.json
+++ b/torchci/rockset/commons/flaky_tests.lambda.json
@@ -1,0 +1,26 @@
+{
+  "sql_path": "__sql/flaky_tests.sql",
+  "default_parameters": [
+    {
+      "name": "file",
+      "type": "string",
+      "value": "%"
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "value": "%"
+    },
+    {
+      "name": "numHours",
+      "type": "int",
+      "value": "48"
+    },
+    {
+      "name": "suite",
+      "type": "string",
+      "value": "%"
+    }
+  ],
+  "description": "Using test_run statistics"
+}

--- a/torchci/rockset/commons/flaky_tests.lambda.json
+++ b/torchci/rockset/commons/flaky_tests.lambda.json
@@ -14,7 +14,7 @@
     {
       "name": "numHours",
       "type": "int",
-      "value": "48"
+      "value": "6"
     },
     {
       "name": "suite",
@@ -22,5 +22,5 @@
       "value": "%"
     }
   ],
-  "description": "Using test_run statistics"
+  "description": "Flaky tests from the last numHours hours, using test_run"
 }

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -2,6 +2,7 @@
   "commons": {
     "hud_query": "8d82c48b124ffd71",
     "commit_jobs_query": "c2a4dbce081d0144",
+    "flaky_tests": "2cfdf84f013e6d0f",
     "flaky_test_query": "482db17169272025",
     "original_pr_hud_query": "65174273ce3e602a",
     "issue_query": "f29a1afe94563601",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -2,7 +2,7 @@
   "commons": {
     "hud_query": "8d82c48b124ffd71",
     "commit_jobs_query": "c2a4dbce081d0144",
-    "flaky_tests": "2cfdf84f013e6d0f",
+    "flaky_tests": "6bcb2aac00dc33bb",
     "flaky_test_query": "482db17169272025",
     "original_pr_hud_query": "65174273ce3e602a",
     "issue_query": "f29a1afe94563601",


### PR DESCRIPTION
Disclaimer: I don't think anything is wrong with my query, but this has returned fewer results than the OG flaky_test_query for the same inputs

The results look like for the past 48 hours:

```
[
  {
    "name": "test_forward_overlap",
    "suite": "TestForwardOverlapWorldSizeOne",
    "file": "distributed/fsdp/test_fsdp_overlap.py",
    "numGreen": 4,
    "numRed": 4,
    "jobNames": [
      "linux-bionic-rocm5.1-py3.7-distributed / test (distributed, 2, 2, linux.rocm.gpu)",
      "linux-bionic-rocm5.1-py3.7-distributed / test (distributed, 2, 2, linux.rocm.gpu)"
    ],
    "jobIds": [
      6667611253,
      6667611253
    ],
    "workflowIds": [
      2413793937,
      2413793937
    ],
    "workflowNames": [
      "periodic",
      "periodic"
    ],
    "branches": [
      "master",
      "master"
    ],
    "runAttempts": [
      1,
      2
    ]
  }
]
```