### PR TITLE
[mergebot] fix case where there is other content in the bot comment

### DIFF
--- a/torchci/lib/bot/mergeBot.ts
+++ b/torchci/lib/bot/mergeBot.ts
@@ -4,7 +4,7 @@ import { getHelp, getParser } from "./cliParser";
 import shlex from "shlex";
 
 function mergeBot(app: Probot): void {
-  const botCommandPattern = new RegExp("^@pytorchbot");
+  const botCommandPattern = new RegExp(/^@pytorchbot.*$/m);
 
   const mergeCmdPat = new RegExp(
     "^\\s*@pytorch(merge|)bot\\s+(force\\s+)?merge\\s+this\\s*(on\\s*green)?"
@@ -101,16 +101,19 @@ function mergeBot(app: Probot): void {
       }
     }
 
-    if (!botCommandPattern.test(commentBody)) {
+    const match = commentBody.match(botCommandPattern);
+    if (!match) {
       return;
     }
+
+    const command = match[0];
 
     if (!ctx.payload.issue.pull_request) {
       // Issue, not pull request.
       return await handleConfused();
     }
 
-    let inputArgs = commentBody.replace(botCommandPattern, "");
+    const inputArgs = command.replace(/@pytorchbot/, "");
     let args;
     const parser = getParser();
     try {

--- a/torchci/test/mergeBot.test.ts
+++ b/torchci/test/mergeBot.test.ts
@@ -235,7 +235,7 @@ describe("merge-bot", () => {
   test("revert command w/ explanation on pull request triggers dispatch and like", async () => {
     const event = require("./fixtures/pull_request_comment.json");
     const reason =
-      "--\n\nbreaks master: " +
+      "--breaks master: " +
       "https://hud.pytorch.org/minihud?name_filter=trunk%20/%20ios-12-5-1-x86-64-coreml%20/%20build";
     event.payload.comment.body = `@pytorchbot revert -m='${reason}'`;
 
@@ -439,6 +439,44 @@ describe("merge-bot", () => {
     }
     scope.done();
   });
+
+  test("merge using CLI + other content in comment", async () => {
+    const event = require("./fixtures/pull_request_comment.json");
+
+    event.payload.comment.body =
+`esome text
+@pytorchbot merge
+
+some other text lol
+`
+
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    const pr_number = event.payload.issue.number;
+    const comment_number = event.payload.comment.id;
+    const scope = nock("https://api.github.com")
+      .post(
+        `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
+        (body) => {
+          expect(JSON.stringify(body)).toContain('{"content":"+1"}');
+          return true;
+        }
+      )
+      .reply(200, {})
+      .post(`/repos/${owner}/${repo}/dispatches`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          `{"event_type":"try-merge","client_payload":{"pr_num":${pr_number},"comment_id":${comment_number}}}`
+        );
+        return true;
+      })
+      .reply(200, {});
+    await probot.receive(event);
+    if (!scope.isDone()) {
+      console.error("pending mocks: %j", scope.pendingMocks());
+    }
+    scope.done();
+  });
+
 
   test("force merge using CLI", async () => {
     const event = require("./fixtures/pull_request_comment.json");


### PR DESCRIPTION
Only look at the line that starts with @pytorchbot when parsing
commands.

This breaks one of the existing tests, which explicitly inserted
newlines. But I think it's fine to regress this behavior.
