### PR TITLE
[metrics] introduce viable/strict lag time metric

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -375,17 +375,11 @@ export default function Page() {
         <Grid container item xs={2} justifyContent={"stretch"}>
           <Stack justifyContent={"space-between"} flexGrow={1}>
             <ScalarPanel
-              title={"Last viable/strict push"}
-              queryName={"last_branch_push"}
-              metricName={"push_seconds_ago"}
+              title={"viable/strict lag"}
+              queryName={"strict_lag_sec"}
+              metricName={"strict_lag_sec"}
               valueRenderer={(value) => durationDisplay(value)}
-              queryParams={[
-                {
-                  name: "branch",
-                  type: "string",
-                  value: "refs/heads/viable/strict",
-                },
-              ]}
+              queryParams={[]}
               badThreshold={(value) => value > 60 * 60 * 6} // 6 hours
             />
             <ScalarPanel

--- a/torchci/rockset/metrics/__sql/strict_lag_sec.sql
+++ b/torchci/rockset/metrics/__sql/strict_lag_sec.sql
@@ -1,0 +1,34 @@
+WITH master as (
+    SELECT
+        PARSE_TIMESTAMP_ISO8601(push.head_commit.timestamp) as master
+    FROM
+        push
+    WHERE
+        push.ref = 'refs/heads/master'
+        AND push.repository.owner.name = 'pytorch'
+        AND push.repository.name = 'pytorch'
+        AND push.head_commit is not null
+    ORDER BY
+        push._event_time desc
+    LIMIT
+        1
+), strict as (
+    SELECT
+        PARSE_TIMESTAMP_ISO8601(push.head_commit.timestamp) as strict
+    FROM
+        push
+    WHERE
+        push.ref = 'refs/heads/viable/strict'
+        AND push.repository.owner.name = 'pytorch'
+        AND push.repository.name = 'pytorch'
+        AND push.head_commit is not null
+    ORDER BY
+        push._event_time desc
+    LIMIT
+        1
+)
+SELECT
+    DATE_DIFF('second', strict, master) as strict_lag_sec
+FROM
+    master,
+    strict

--- a/torchci/rockset/metrics/strict_lag_sec.lambda.json
+++ b/torchci/rockset/metrics/strict_lag_sec.lambda.json
@@ -1,0 +1,5 @@
+{
+  "sql_path": "__sql/strict_lag_sec.sql",
+  "default_parameters": [],
+  "description": "How many seconds viable/strict lags behind master"
+}

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -27,6 +27,7 @@
     "queued_jobs": "7b5ef18c1273bab2",
     "reverts": "f5bc84a10c4065a3",
     "tts_avg": "c0049352a4c38aa5",
+    "strict_lag_sec": "f9523e8c8c3a3311",
     "queue_times_historical": "7f4d6599362e70ba",
     "workflow_duration_avg": "34e698a78cb36669",
     "workflow_load": "eff394d8e0b76436"


### PR DESCRIPTION
Before we were measuring the last time the viable/strict branch was
pushed. But what we actually want to measure how far behind
viable/strict is from master, which is a higher order metric that
captures how long the strict promotion process takes.
