### PR TITLE
[flaky-test] Add SQL for flaky test history

### DIFF
--- a/torchci/rockset/commons/__sql/flaky_test_history.sql
+++ b/torchci/rockset/commons/__sql/flaky_test_history.sql
@@ -1,0 +1,26 @@
+SELECT
+	test_run.name,
+	test_run.classname as suite,
+	test_run.file,
+	SUM(ELEMENT_AT(JSON_PARSE(REPLACE(test_run.skipped.message, 'True', 'true')), 'num_green')) as numGreen,
+	SUM(ELEMENT_AT(JSON_PARSE(REPLACE(test_run.skipped.message, 'True', 'true')), 'num_red')) as numRed,
+	ARRAY_AGG(job.name) as jobNames,
+	ARRAY_AGG(job.id) as jobIds,
+	ARRAY_AGG(workflow.id) as workflowIds,
+	ARRAY_AGG(workflow.name) as workflowNames,
+	ARRAY_AGG(workflow.head_branch) as branches,
+    ARRAY_AGG(test_run.workflow_run_attempt) as runAttempts
+FROM
+    commons.workflow_job job 
+    INNER JOIN commons.test_run ON test_run.job_id = job.id HINT(join_strategy=lookup)
+    INNER JOIN commons.workflow_run workflow ON job.run_id = workflow.id 
+WHERE 
+	test_run.skipped IS NOT NULL
+    AND STRPOS(test_run.skipped.message, 'num_red') > 0  
+    AND test_run.name = :name
+    AND test_run.classname LIKE :suite
+    AND test_run.file LIKE :file
+GROUP BY
+	name,
+    suite,
+    file

--- a/torchci/rockset/commons/flaky_test_history.lambda.json
+++ b/torchci/rockset/commons/flaky_test_history.lambda.json
@@ -1,0 +1,21 @@
+{
+  "sql_path": "__sql/flaky_test_history.sql",
+  "default_parameters": [
+    {
+      "name": "file",
+      "type": "string",
+      "value": "%"
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "value": "test_ddp_uneven_inputs"
+    },
+    {
+      "name": "suite",
+      "type": "string",
+      "value": "%"
+    }
+  ],
+  "description": "Get flaky test instances by test name"
+}

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -3,6 +3,7 @@
     "hud_query": "8d82c48b124ffd71",
     "commit_jobs_query": "c2a4dbce081d0144",
     "flaky_tests": "6bcb2aac00dc33bb",
+    "flaky_test_history": "9b4aedc197c46c12",
     "flaky_test_query": "482db17169272025",
     "original_pr_hud_query": "65174273ce3e602a",
     "issue_query": "f29a1afe94563601",


### PR DESCRIPTION
Originally, I had wanted one single query for querying 
1. flaky tests from the last _ hours (usually 3 or 6) for the disable bot https://github.com/pytorch/test-infra/pull/363
2. flaky test history for particular flaky tests (this PR)

The current flaky_tests_query does this and is able to query for all flaky tests in the last 30 days because it reads from a tiny collection. However, maintaining that collection has been tedious and sometimes inaccurate as it relies on individual calculations for every job run in CI. 

The new flaky_tests query has the potential of doing that IF we had a ton of machines and compute, as currently, it is incredibly slow as it queries and filters from our MASSIVE test_run data. We simply split this query into two very similar queries with different use cases. One will just ask for all flaky tests within a short time (good for our job that detects and handles flakiness in almost real time) and the other will ask for just a particular flaky test and its history (good for our flaky-test historical view + debugging purposes).

This PR is for the history query.