### PR TITLE
[hud] fix logviewer copying escape characters

### DIFF
--- a/torchci/components/LogViewer.tsx
+++ b/torchci/components/LogViewer.tsx
@@ -18,6 +18,7 @@ import { oneDark } from "@codemirror/theme-one-dark";
 import _ from "lodash";
 import { isFailure } from "lib/JobClassifierUtil";
 
+const ESC_CHAR_REGEX = /\x1b\[[0-9;]*m/g;
 // Based on the current editor view, produce a series of decorations that
 // correctly colorize the ANSI escape codes found in the view.
 function computeDecorations(view: EditorView) {
@@ -63,7 +64,7 @@ function computeDecorations(view: EditorView) {
         }
 
         // Also hide all the weird escape characters.
-        for (const match of lineText.matchAll(/\x1b\[[0-9;]*m/g)) {
+        for (const match of lineText.matchAll(ESC_CHAR_REGEX)) {
           const startWithinLine = match.index;
           const decoFrom = pos + startWithinLine!;
           const decoTo = decoFrom + match[0].length;
@@ -189,6 +190,18 @@ function Log({ url, line }: { url: string; line: number | null }) {
 
 export default function LogViewer({ job }: { job: JobData }) {
   const [showLogViewer, setShowLogViewer] = useState(false);
+
+  useEffect(() => {
+    document.addEventListener("copy", (e) => {
+      const selection = document.getSelection();
+      e.clipboardData?.setData(
+        "text/plain",
+        (selection?.toString() ?? "").replaceAll(ESC_CHAR_REGEX, "")
+      );
+      e.preventDefault();
+    });
+  });
+
   if (!isFailure(job.conclusion)) {
     return null;
   }


### PR DESCRIPTION
This intercepts copy commands and replaces the selection text if it has escape characters with nothing.

Tried replacing the entire log string's escape characters but they're needed for formatting and such.

https://user-images.githubusercontent.com/34172846/172436512-6dc98e85-c35b-4288-bdb9-9c8c0bb8a0e0.mov

Addresses
https://github.com/pytorch/test-infra/issues/375
