### PR TITLE
Revert "[flaky-tests] Use new queries"

### DIFF
--- a/torchci/lib/fetchFlakyTests.ts
+++ b/torchci/lib/fetchFlakyTests.ts
@@ -5,12 +5,15 @@ import { FlakyTestData } from "./types";
 
 export default async function fetchFlakyTests(
   numHours: string = "3",
+  testName: string = "%",
+  testSuite: string = "%",
+  testFile: string = "%"
 ): Promise<FlakyTestData[]> {
   const rocksetClient = getRocksetClient();
   const flakyTestQuery = await rocksetClient.queryLambdas.executeQueryLambda(
     "commons",
-    "flaky_tests",
-    rocksetVersions.commons.flaky_tests,
+    "flaky_test_query",
+    rocksetVersions.commons.flaky_test_query,
     {
       parameters: [
         {
@@ -18,28 +21,10 @@ export default async function fetchFlakyTests(
           type: "int",
           value: numHours,
         },
-      ],
-    }
-  );
-  return flakyTestQuery.results ?? [];
-}
-
-export async function fetchFlakyTestHistory(
-  testName: string = "test_ddp_uneven_inputs",
-  testSuite: string = "%",
-  testFile: string = "%"
-): Promise<FlakyTestData[]> {
-  const rocksetClient = getRocksetClient();
-  const flakyTestQuery = await rocksetClient.queryLambdas.executeQueryLambda(
-    "commons",
-    "flaky_test_history",
-    rocksetVersions.commons.flaky_test_history,
-    {
-      parameters: [
         {
           name: "name",
           type: "string",
-          value: `${testName}`,
+          value: `%${testName}%`,
         },
         {
           name: "suite",

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -88,7 +88,6 @@ export interface FlakyTestData {
   jobIds: number[];
   jobNames: string[];
   branches: string[];
-  runAttempts?: number[];
 }
 
 export function packHudParams(input: any) {

--- a/torchci/pages/api/flaky-tests/flakytest.ts
+++ b/torchci/pages/api/flaky-tests/flakytest.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { fetchFlakyTestHistory } from "lib/fetchFlakyTests";
+import fetchFlakyTests from "lib/fetchFlakyTests";
 import { FlakyTestData } from "lib/types";
 
 interface Data {}
@@ -12,7 +12,10 @@ export default async function handler(
   const suite = req.query.suite;
   const file = req.query.file;
 
-  const flakyTests: FlakyTestData[] = await fetchFlakyTestHistory(
+  let numHours = 30 * 24 + "";
+
+  const flakyTests: FlakyTestData[] = await fetchFlakyTests(
+    numHours,
     name as string,
     suite as string,
     file as string

--- a/torchci/pages/flakytest.tsx
+++ b/torchci/pages/flakytest.tsx
@@ -6,7 +6,7 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
 export default function Page() {
   const router = useRouter();
-  const name = (router.query.name || "test_ddp_uneven_inputs") as string;
+  const name = (router.query.name || "%") as string;
   const suite = (router.query.suite || "%") as string;
   const file = (router.query.file || "%") as string;
 
@@ -20,11 +20,11 @@ export default function Page() {
     <div>
       <h1>PyTorch CI Flaky Tests</h1>
       <h3>
-        Test Name (Must Be Exact): <code>{name}</code> | Test
+        Test Name Filter: <code>{name === "%" ? "<any>" : name}</code> | Test
         Suite Filter: <code>{suite === "%" ? "<any>" : suite}</code> | Test File
         Filter: <code>{file === "%" ? "<any>" : file}</code>
       </h3>
-      <em>Showing all data since June 2022.</em>
+      <em>Showing last 30 days of data.</em>
       {data === undefined ? (
         <div>Loading...</div>
       ) : (

--- a/torchci/rockset/commons/flaky_tests.lambda.json
+++ b/torchci/rockset/commons/flaky_tests.lambda.json
@@ -2,9 +2,24 @@
   "sql_path": "__sql/flaky_tests.sql",
   "default_parameters": [
     {
+      "name": "file",
+      "type": "string",
+      "value": "%"
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "value": "%"
+    },
+    {
       "name": "numHours",
       "type": "int",
       "value": "6"
+    },
+    {
+      "name": "suite",
+      "type": "string",
+      "value": "%"
     }
   ],
   "description": "Flaky tests from the last numHours hours, using test_run"

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -2,7 +2,7 @@
   "commons": {
     "hud_query": "8d82c48b124ffd71",
     "commit_jobs_query": "c2a4dbce081d0144",
-    "flaky_tests": "7840f7d6383fda90",
+    "flaky_tests": "6bcb2aac00dc33bb",
     "flaky_test_history": "9b4aedc197c46c12",
     "flaky_test_query": "482db17169272025",
     "original_pr_hud_query": "65174273ce3e602a",


### PR DESCRIPTION
Reverts pytorch/test-infra#394

It turns out my query is too slow for vercel so reverting to old query until I can speed up or mitigate this one. 

The disable test bot timed out for all its past runs since Vercel employs a 5s timeout :/ See https://github.com/pytorch/test-infra/actions/runs/2460572331 and https://stackoverflow.com/questions/68771480/nextjs-vercel-504-error-function-invocation-timeout