### PR TITLE
Add specific RuntimeError for test file failures

### DIFF
--- a/torchci/pages/api/classifier/rules.ts
+++ b/torchci/pages/api/classifier/rules.ts
@@ -185,6 +185,11 @@ export default async function handler(
         priority: 100,
       },
       {
+        name: "Python Test File RuntimeError",
+        pattern: r`^RuntimeError: test.* failed`,
+        priority: 100,
+      },
+      {
         name: "Python RuntimeError",
         pattern: r`^RuntimeError: .*`,
         priority: 99,


### PR DESCRIPTION
As I was oncall, I saw https://hud.pytorch.org/minihud#e99c8ec3c267228c9ff9fefbfb0235dd41698948 had classified the logs with a line that was actually a part of a passing test, which was confusing.
![image](https://user-images.githubusercontent.com/31798555/172916620-f6225df6-d5cc-4ae4-aa0e-08173241531a.png)

This PR attempts to highlight the real failure (a SIGBUS). 
```
2022-06-09T17:32:27.6826608Z Running test_serialization ... [2022-06-09 17:32:27.682354]
2022-06-09T17:32:27.6827122Z Executing ['/opt/conda/bin/python', 'test_serialization.py', '-v', '--import-slow-tests', '--import-disabled-tests'] ... [2022-06-09 17:32:27.682438]
2022-06-09T17:32:27.7815930Z Traceback (most recent call last):
2022-06-09T17:32:27.7816192Z   File "test/run_test.py", line 1077, in <module>
2022-06-09T17:32:27.7818758Z     main()
2022-06-09T17:32:27.7819035Z   File "test/run_test.py", line 1055, in main
2022-06-09T17:32:27.7821128Z     raise RuntimeError(err_message)
2022-06-09T17:32:27.7821718Z RuntimeError: test_serialization failed! Received signal: SIGBUS
```