### PR TITLE
[mergebot] remove all green option

### DIFF
--- a/torchci/lib/bot/cliParser.ts
+++ b/torchci/lib/bot/cliParser.ts
@@ -24,11 +24,7 @@ const merge = commands.add_parser("merge", {
 });
 merge.add_argument("-g", "--green", {
   action: "store_true",
-  help: "Merge when required status checks pass. Currently, we only require lint and builds to pass.",
-});
-merge.add_argument("-a", "--all-green", {
-  action: "store_true",
-  help: "Merge when all status checks pass",
+  help: "Merge when all status checks pass.",
 });
 merge.add_argument("-f", "--force", {
   action: "store_true",

--- a/torchci/lib/bot/mergeBot.ts
+++ b/torchci/lib/bot/mergeBot.ts
@@ -20,7 +20,6 @@ function mergeBot(app: Probot): void {
       event_type: string,
       force: boolean = false,
       onGreen: boolean = false,
-      allGreen: boolean = false,
       reason: string = "",
       branch: string = ""
     ) {
@@ -31,8 +30,6 @@ function mergeBot(app: Probot): void {
 
       if (force) {
         payload.force = true;
-      } else if (allGreen) {
-        payload.all_green = true;
       } else if (onGreen) {
         payload.on_green = true;
       }
@@ -62,14 +59,13 @@ function mergeBot(app: Probot): void {
     async function handleMerge(
       force: boolean,
       mergeOnGreen: boolean,
-      allGreen: boolean
     ) {
-      await dispatchEvent("try-merge", force, mergeOnGreen, allGreen);
+      await dispatchEvent("try-merge", force, mergeOnGreen);
       await reactOnComment(ctx, "+1");
     }
 
     async function handleRevert(reason: string) {
-      await dispatchEvent("try-revert", false, false, false, reason);
+      await dispatchEvent("try-revert", false, false, reason);
       await reactOnComment(ctx, "+1");
     }
 
@@ -93,7 +89,7 @@ function mergeBot(app: Probot): void {
         ctx.payload.comment.user.login == ctx.payload.issue.user.login ||
         (await comment_author_in_pytorch_org())
       ) {
-        await dispatchEvent("try-rebase", false, false, false, "", branch);
+        await dispatchEvent("try-rebase", false, false, "", branch);
         await reactOnComment(ctx, "+1");
       } else {
         await addComment(
@@ -144,7 +140,7 @@ function mergeBot(app: Probot): void {
       case "revert":
         return await handleRevert(args.message);
       case "merge":
-        return await handleMerge(args.force, args.green, args.all_green);
+        return await handleMerge(args.force, args.green);
       case "rebase": {
         if (args.stable) {
           args.branch = "viable/strict";

--- a/torchci/test/mergeBot.test.ts
+++ b/torchci/test/mergeBot.test.ts
@@ -574,39 +574,6 @@ some other text lol
     scope.done();
   });
 
-  test("merge on all green using CLI", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
-
-    event.payload.comment.body = "@pytorchbot merge --all-green";
-
-    const owner = event.payload.repository.owner.login;
-    const repo = event.payload.repository.name;
-    const pr_number = event.payload.issue.number;
-    const comment_number = event.payload.comment.id;
-    const scope = nock("https://api.github.com")
-      .post(
-        `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
-        (body) => {
-          expect(JSON.stringify(body)).toContain('{"content":"+1"}');
-          return true;
-        }
-      )
-      .reply(200, {})
-      .post(`/repos/${owner}/${repo}/dispatches`, (body) => {
-        expect(JSON.stringify(body)).toContain(
-          `{"event_type":"try-merge","client_payload":{"pr_num":${pr_number},"comment_id":${comment_number},"all_green":true}}`
-        );
-        return true;
-      })
-      .reply(200, {});
-
-    await probot.receive(event);
-    if (!scope.isDone()) {
-      console.error("pending mocks: %j", scope.pendingMocks());
-    }
-    scope.done();
-  });
-
   test("help using CLI", async () => {
     const event = require("./fixtures/pull_request_comment.json");
 


### PR DESCRIPTION
After adding https://github.com/pytorch/pytorch/pull/79209, we don't need the all green option since it's being merged in with -g. Another option is to keep the -a and just make it the same behavior, but I think it could make our CI options a bit too confusing.

Also @malfet , we added the mandatory_only option but do we really want to hook that up? It feels like it adds another option that could be confused and if we're going to make everything mandatory (at least in pull), it doesn't feel like it's worth it. 