### PR TITLE
[mergeBot] improvements to help message

### DIFF
--- a/torchci/lib/bot/mergeBot.ts
+++ b/torchci/lib/bot/mergeBot.ts
@@ -132,6 +132,10 @@ function mergeBot(app: Probot): void {
       return;
     }
 
+    if (args.help) {
+      return await addComment(ctx, getHelp());
+    }
+
     switch (args.command) {
       case "revert":
         return await handleRevert(args.message);
@@ -143,8 +147,6 @@ function mergeBot(app: Probot): void {
         }
         return await handleRebase(args.branch);
       }
-      case "help":
-        return await addComment(ctx, getHelp());
       default:
         return await handleConfused();
     }

--- a/torchci/test/mergeBot.test.ts
+++ b/torchci/test/mergeBot.test.ts
@@ -586,7 +586,7 @@ some other text lol
   test("help using CLI", async () => {
     const event = require("./fixtures/pull_request_comment.json");
 
-    event.payload.comment.body = `@pytorchbot help`;
+    event.payload.comment.body = `@pytorchbot --help`;
     const owner = event.payload.repository.owner.login;
     const repo = event.payload.repository.name;
     const pr_number = event.payload.issue.number;


### PR DESCRIPTION
- Make it accessible with the more conventional `-h, --help`.
- Add descriptions and examples to each command.

At this point, the information presented is the same as the wiki, which
is nice.
