### PR TITLE
use requireDeepCopy

### DIFF
--- a/torchci/test/mergeBot.test.ts
+++ b/torchci/test/mergeBot.test.ts
@@ -3,6 +3,10 @@ import * as probot from "probot";
 import * as utils from "./utils";
 import mergeBot from "../lib/bot/mergeBot";
 
+function requireDeepCopy(fileName: string) {
+  return JSON.parse(JSON.stringify(require(fileName)));
+}
+
 function handleScope(scope: nock.Scope) {
   if (!scope.isDone()) {
     console.error("pending mocks: %j", scope.pendingMocks());
@@ -25,32 +29,32 @@ describe("merge-bot", () => {
   });
 
   test("random pr comment no reaction", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
     const scope = nock("https://api.github.com");
     await probot.receive(event);
     handleScope(scope);
   });
 
   test("random issue comment no event", async () => {
-    const event = require("./fixtures/issue_comment.json");
+    const event = requireDeepCopy("./fixtures/issue_comment.json");
     const scope = nock("https://api.github.com");
     await probot.receive(event);
     handleScope(scope);
   });
 
   test("random pull request review no event", async () => {
-    const event = require("./fixtures/pull_request_review.json");
+    const event = requireDeepCopy("./fixtures/pull_request_review.json");
     const scope = nock("https://api.github.com");
     await probot.receive(event);
     handleScope(scope);
   });
 
   test("quoted merge/revert command no event", async () => {
-    const merge_event = require("./fixtures/issue_comment.json");
+    const merge_event = requireDeepCopy("./fixtures/issue_comment.json");
     merge_event.payload.comment.body = "> @pytorchbot merge";
-    const revert_event = require("./fixtures/issue_comment.json");
+    const revert_event = requireDeepCopy("./fixtures/issue_comment.json");
     revert_event.payload.comment.body = "> @pytorchbot revert";
-    const rebase_event = require("./fixtures/issue_comment.json");
+    const rebase_event = requireDeepCopy("./fixtures/issue_comment.json");
     rebase_event.payload.comment.body = "> @pytorchbot rebase";
     const scope = nock("https://api.github.com");
     await probot.receive(merge_event);
@@ -59,7 +63,7 @@ describe("merge-bot", () => {
   });
 
   test("merge command on issue triggers confused reaction", async () => {
-    const event = require("./fixtures/issue_comment.json");
+    const event = requireDeepCopy("./fixtures/issue_comment.json");
     event.payload.comment.body = "@pytorchbot merge";
 
     const owner = event.payload.repository.owner.login;
@@ -80,7 +84,7 @@ describe("merge-bot", () => {
   });
 
   test("merge command on pull request triggers dispatch and like", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = "@pytorchbot merge";
 
@@ -109,7 +113,7 @@ describe("merge-bot", () => {
   });
 
   test("merge -f on pull request triggers dispatch and like", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = "@pytorchbot merge -f";
 
@@ -139,7 +143,7 @@ describe("merge-bot", () => {
   });
 
   test("merge -g command on pull request triggers dispatch and like", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = "@pytorchbot merge -g";
 
@@ -169,7 +173,7 @@ describe("merge-bot", () => {
   });
 
   test("merge this command raises an error", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = "@pytorchbot merge this";
     const owner = event.payload.repository.owner.login;
@@ -189,7 +193,7 @@ describe("merge-bot", () => {
   });
 
   test("revert command w/o explanation on pull request triggers comment only", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = "@pytorchbot revert";
     const owner = event.payload.repository.owner.login;
@@ -211,7 +215,7 @@ describe("merge-bot", () => {
   });
 
   test("revert command w/ explanation on pull request triggers dispatch and like", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
     const reason =
       "--breaks master: " +
       "https://hud.pytorch.org/minihud?name_filter=trunk%20/%20ios-12-5-1-x86-64-coreml%20/%20build";
@@ -248,7 +252,7 @@ describe("merge-bot", () => {
   });
 
   test("rebase command on pull request triggers dispatch and like", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = "@pytorchbot rebase";
     event.payload.comment.user.login = "clee2000";
@@ -285,7 +289,7 @@ describe("merge-bot", () => {
   });
 
   test("rebase to viable/strict", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = "@pytorchbot rebase -s";
     event.payload.comment.user.login = "random1";
@@ -323,7 +327,7 @@ describe("merge-bot", () => {
   });
 
   test("rebase to any branch", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = "@pytorchbot rebase -b randombranch";
     event.payload.comment.user.login = "random1";
@@ -361,7 +365,7 @@ describe("merge-bot", () => {
   });
 
   test("merge fail because mutually exclusive options", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = "@pytorchbot merge -g -f";
 
@@ -384,7 +388,7 @@ describe("merge-bot", () => {
   });
 
   test("rebase fail because -b and -s", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = "@pytorchbot rebase -b randombranch -s";
 
@@ -407,7 +411,7 @@ describe("merge-bot", () => {
   });
 
   test("rebase does not have permissions", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = "@pytorchbot rebase";
     event.payload.comment.user.login = "random1";
@@ -435,7 +439,7 @@ describe("merge-bot", () => {
   });
 
   test("merge this pull request review triggers dispatch and +1 comment", async () => {
-    const event = require("./fixtures/pull_request_review.json");
+    const event = requireDeepCopy("./fixtures/pull_request_review.json");
 
     event.payload.review.body = "@pytorchbot merge this";
 
@@ -462,7 +466,7 @@ describe("merge-bot", () => {
   });
 
   test("merge on green using CLI", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = "@pytorchmergebot merge -g";
 
@@ -492,7 +496,7 @@ describe("merge-bot", () => {
   });
 
   test("merge with land checks using CLI", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = "@pytorchmergebot merge -l";
 
@@ -523,7 +527,7 @@ describe("merge-bot", () => {
 
   test("merge with land checks using CLI", async () => {
     const event = JSON.parse(
-      JSON.stringify(require("./fixtures/pull_request_comment.json"))
+      JSON.stringify(requireDeepCopy("./fixtures/pull_request_comment.json"))
     );
     event.payload.comment.body = "@pytorchmergebot merge";
     event.payload.comment.user.login = "zengk95";
@@ -553,7 +557,7 @@ describe("merge-bot", () => {
   });
 
   test("merge on green using CLI", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = "@pytorchbot merge -g";
 
@@ -583,7 +587,7 @@ describe("merge-bot", () => {
   });
 
   test("merge using CLI + other content in comment", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = `esome text
 @pytorchbot merge
@@ -616,7 +620,7 @@ some other text lol
   });
 
   test("force merge using CLI", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = "@pytorchbot merge -f";
 
@@ -646,7 +650,7 @@ some other text lol
   });
 
   test("help using CLI", async () => {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = `@pytorchbot --help`;
     const owner = event.payload.repository.owner.login;
@@ -665,7 +669,7 @@ some other text lol
   });
 
   async function handleRevertTest(commentBody: string, reason: string) {
-    const event = require("./fixtures/pull_request_comment.json");
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
     event.payload.comment.body = commentBody;
 
     const owner = event.payload.repository.owner.login;
@@ -709,10 +713,14 @@ some other text lol
   });
 
   test("Random commands won't trigger CLI", async () => {
-    const eventCantMerge = require("./fixtures/pull_request_comment.json");
-    const eventWithQuotes = require("./fixtures/pull_request_comment.json");
-    const eventQuoted = require("./fixtures/pull_request_comment.json");
-    const testCommand = require("./fixtures/pull_request_comment.json");
+    const eventCantMerge = requireDeepCopy(
+      "./fixtures/pull_request_comment.json"
+    );
+    const eventWithQuotes = requireDeepCopy(
+      "./fixtures/pull_request_comment.json"
+    );
+    const eventQuoted = requireDeepCopy("./fixtures/pull_request_comment.json");
+    const testCommand = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     eventCantMerge.payload.comment.body = "Can't merge closed PR #77376";
     eventWithQuotes.payload.comment.body = `"@pytorchbot merge" use this command`;


### PR DESCRIPTION
Use requireDeepCopy everywhere. Require was messing things before where if we changed the object that we got from require, it might end up polluting other tests. 