### PR TITLE
[classification] move flaky test instance higher

### DIFF
--- a/torchci/pages/api/classifier/rules.ts
+++ b/torchci/pages/api/classifier/rules.ts
@@ -190,6 +190,11 @@ export default async function handler(
         priority: 100,
       },
       {
+        name: "Python flaky unittest",
+        pattern: r`^\s*(test.*) (fail|error|succeed)?ed - num_retries_left:`,
+        priority: 100,
+      },
+      {
         name: "Python RuntimeError",
         pattern: r`^RuntimeError: .*`,
         priority: 99,
@@ -218,11 +223,6 @@ export default async function handler(
         name: "GHA error",
         pattern: r`^##\[error\](.*)`,
         priority: 94,
-      },
-      {
-        name: "Python flaky unittest",
-        pattern: r`^\s*(test.*) (fail|error|succeed)?ed - num_retries_left:`,
-        priority: 93,
       },
     ]);
 }


### PR DESCRIPTION
When running the classification script on 6968080598: 
```
python ./log_classifier/classify_log.py 6968080598    
```
We get:
```
{
    "job_id": 6968080598,
    "rule": "Python RuntimeError",
    "line": "RuntimeError: raised from 0",
    "line_num": 19141,
    "context": "\nGenerating XML reports...\nGenerated XML report: test-reports/python-unittest/distributed.fsdp.test_fsdp_misc/TEST-TestFSDPMisc-20220620161302.xml\nRunning distributed/elastic/multiprocessing/api_test ... [2022-06-20 16:13:49.221174]\nExecuting ['/opt/conda/bin/python', 'distributed/elastic/multiprocessing/api_test.py', '-v', '--import-slow-tests', '--import-disabled-tests'] ... [2022-06-20 16:13:49.221335]\nTest results will be stored in test-reports/python-unittest/distributed.elastic.multiprocessing.api_test\n\nRunning tests...\n----------------------------------------------------------------------\n  test_get_failures (__main__.RunProcResultsTest) ... ok (0.596s)\n  test_is_failed (__main__.RunProcResultsTest) ... ok (0.001s)\n  test_args_env_len_mismatch (__main__.StartProcessesListTest) ... ok (0.002s)\n  test_binary (__main__.StartProcessesListTest) ... hello stdout from 0\nhello stderr from 0\nhello stdout from 1\nhello stderr from 1\nok (0.129s)\n  test_binary_exit (__main__.StartProcessesListTest) ... bar stdout from 1\nbar stderr from 1\nfailed (exitcode: 138) local_rank: 0 (pid: 94830) of binary: distributed/elastic/multiprocessing/bin/echo1.py\nok (0.137s)\n  test_binary_incorrect_entrypoint (__main__.StartProcessesListTest) ... ok (0.020s)\n  test_binary_raises (__main__.StartProcessesListTest) ... Traceback (most recent call last):\n  File \"distributed/elastic/multiprocessing/bin/echo2.py\", line 22, in <module>\n    raise RuntimeError(f\"raised from {rank}\")\nRuntimeError: raised from 0\nbar from 1\nfailed (exitcode: 1) local_rank: 0 (pid: 94833) of binary: distributed/elastic/multiprocessing/bin/echo2.py\nok (0.136s)\n  test_binary_redirect_and_tee (__main__.StartProcessesListTest) ... world stdout from 1\n[trainer0]:hello stdout from 0\n[trainer1]:world stderr from 1\nok (1.040s)\n  test_function (__main__.StartProcessesListTest) ... hello stdout from 1\nhello stderr from 1\nhello stdout from 0\nhello stderr from 0\nClosing process 94840 via signal SIGTERM\nok (2.973s)\n  test_function_large_ret_val (__main__.StartProcessesListTest) ... Closing process 94974 via signal SIGTERM\nClosing process 94975 via signal SIGTERM\nClosing process 94976 via signal SIGTERM\nok (3.488s)\n  test_function_raise (__main__.StartProcessesListTest)\nrun 2x copies of echo2, raise an exception on the first ... failed (exitcode: 1) local_rank: 0 (pid: 95242) of fn: echo2 (start_method: spawn)\nTraceback (most recent call last):\n  File \"/opt/conda/lib/python3.7/site-packages/torch/distributed/elastic/multiprocessing/api.py\", line 453, in _poll\n    self._pc.join(-1)\n  File \"/opt/conda/lib/python3.7/site-packages/torch/multiprocessing/spawn.py\", line 160, in join\n    raise ProcessRaisedException(msg, error_index, failed_process.pid)",
    "captures": "RuntimeError: raised from 0"
}
```

But that Runtime Error is intentional. We want the flaky classification to be above the generic Runtime Error.

Another alternative is moving the generic Runtime classification below flaky tests.