### PR TITLE
[flaky test bot] Triage module-marked issues, but not oncall ones

### DIFF
--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -176,6 +176,9 @@ export async function getTestOwnerLabels(testFile: string): Promise<string[]> {
         if (labels.length === 0) {
           return ["module: unknown"];
         }
+        if (labels.some(x => x.startsWith("module: ") && x !== "module: unknown")) {
+          labels.push("triaged")
+        }
         return labels;
       }
     }


### PR DESCRIPTION
When the bot finds the relevant module, it should add the triaged label. 

cc. @albanD 