### PR TITLE
improvements to backfill script

### DIFF
--- a/torchci/scripts/backfillJobs.mjs
+++ b/torchci/scripts/backfillJobs.mjs
@@ -47,28 +47,7 @@ const client = rockset.default(process.env.ROCKSET_API_KEY);
 const dClient = getDynamoClient();
 const octokit = await getOctokit("pytorch", "pytorch");
 
-const q = await client.queries.query({
-  sql: {
-    query: `
-SELECT
-    j.id
-FROM
-    workflow_job j
-    INNER JOIN workflow_run w on j.run_id = w.id
-WHERE
-    j.conclusion IS NULL
-    AND PARSE_TIMESTAMP_ISO8601(j.started_at) < (CURRENT_TIMESTAMP() - INTERVAL 3 HOUR)
-    AND w.repository.name = 'pytorch'
-ORDER BY
-    j._event_time DESC
-LIMIT 10000
-`,
-  },
-});
-
-const ids = q.results.map((r) => r.id);
-
-async function handleWorkflowJob(id) {
+async function backfillWorkflowJob(id, skipBackfill) {
   console.log(`Checking job ${id}`);
   // There is the chance that job ids from different repos could collide. To
   // prevent this, prefix the object key with the repo that they come from.
@@ -81,10 +60,8 @@ async function handleWorkflowJob(id) {
   });
   job = job.data;
 
-  if (job.conclusion === null) {
-    // Some jobs just never get marked completed due to bugs in the GHA backend.
-    // Just skip them.
-    console.log(`Skipping job ${id}, conclusion still null`);
+  if (skipBackfill(job)) {
+    console.log(`Skipping backfill for job ${id}`);
     return;
   }
 
@@ -104,4 +81,69 @@ async function handleWorkflowJob(id) {
   await dClient.put(thing);
 }
 
-await Promise.all(ids.map(handleWorkflowJob));
+
+console.log("::group::Backfilling jobs without a conclusion...")
+const jobsWithNoConclusion = await client.queries.query({
+  sql: {
+    query: `
+SELECT
+    j.id
+FROM
+    workflow_job j
+    INNER JOIN workflow_run w on j.run_id = w.id
+WHERE
+    j.conclusion IS NULL
+    AND PARSE_TIMESTAMP_ISO8601(j.started_at) < (CURRENT_TIMESTAMP() - INTERVAL 3 HOUR)
+    AND PARSE_TIMESTAMP_ISO8601(j.started_at) > (CURRENT_TIMESTAMP() - INTERVAL 1 DAY)
+    AND w.repository.name = 'pytorch'
+ORDER BY
+    j._event_time DESC
+LIMIT 10000
+`,
+  },
+});
+
+let ids = jobsWithNoConclusion.results.map((r) => r.id);
+
+// Await in a loop???
+// Yes: when GitHub has outages and fails to deliver webhooks en masse, we can
+// get rate limited while trying to backfill. Since backfilling is not
+// latency-sensitive, it's fine to just processed them serially to ensure we
+// make forward progress.
+for (const id of ids) {
+  // Some jobs just never get marked completed due to bugs in the GHA backend.
+  // Just skip them.
+  await backfillWorkflowJob(id, (job) => job.conclusion === null);
+}
+console.log("::endgroup::")
+
+console.log("::group::Backfilling queued jobs...")
+// Also try to backfill queued jobs specifically, with a tighter time bound.
+// This is so our queue time stats are as accurate as possible.
+const queuedJobs = await client.queries.query({
+  sql: {
+    query: `
+SELECT
+    j.id
+FROM
+    workflow_job j
+    INNER JOIN workflow_run w on j.run_id = w.id
+WHERE
+    j.status = 'queued'
+    AND w.status != 'completed'
+    AND PARSE_TIMESTAMP_ISO8601(j.started_at) < (CURRENT_TIMESTAMP() - INTERVAL 5 MINUTE)
+    AND w.repository.name = 'pytorch'
+ORDER BY
+    j._event_time DESC
+LIMIT 10000
+`,
+  },
+});
+
+ids = queuedJobs.results.map((r) => r.id);
+
+// See above for why we're awaiting in a loop.
+for (const id of ids) {
+  await backfillWorkflowJob(id, (job) => job.status === "queued");
+}
+console.log("::endgroup::")


### PR DESCRIPTION
- Run await serially so we don't get rate limited by github when there
are many backfills to process.
- Add some nice GHA log grouping
- Refine the query a little bit so that we filter out obviously broken
GHA jobs
- Add a second, more tightly-bounded backfill for jobs in queue so we
have more accurate queue time metrics
