### PR TITLE
Adding static links to Dr. CI bot comment

### DIFF
--- a/torchci/lib/bot/drciBot.ts
+++ b/torchci/lib/bot/drciBot.ts
@@ -3,6 +3,7 @@ import { Context, Probot } from "probot";
 const drciCommentStart = "<!-- drci-comment-start -->";
 const drciCommentEnd = "<!-- drci-comment-end -->";
 const possibleUsers = ["swang392"]
+const officeHoursLink = "https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours";
 
 async function getDrciComment(
   context: Context,
@@ -23,8 +24,12 @@ async function getDrciComment(
   return {id: 0, body: ""};
 }
 
-export function formDrciComment(): string {
-  let body = "hello there!"
+export function formDrciComment(prNum: number): string {
+  const hudUrl = "hud.pytorch.org/pr/" + prNum;
+  let body = "<h1>Helpful Links</h1>\n";
+  body += "<body>See artifacts and rendered test results [here](" + hudUrl + ")\n";
+  body += "Need help or want to give feedback on the CI? Visit our [office hours](" + officeHoursLink + ")";
+  body += "</body>";
   return drciCommentStart + body + drciCommentEnd;
 }
 
@@ -51,7 +56,7 @@ export default function drciBot(app: Probot): void {
     const existingDrciID = existingDrciData.id
     const existingDrciComment = existingDrciData.body
 
-    const drciComment = formDrciComment();
+    const drciComment = formDrciComment(prNum);
 
     if (existingDrciComment === drciComment) {
       return;

--- a/torchci/lib/bot/drciBot.ts
+++ b/torchci/lib/bot/drciBot.ts
@@ -1,9 +1,10 @@
 import { Context, Probot } from "probot";
 
-const drciCommentStart = "<!-- drci-comment-start -->";
+export const drciCommentStart = "<!-- drci-comment-start -->";
+export const officeHoursUrl = "https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours";
 const drciCommentEnd = "<!-- drci-comment-end -->";
 const possibleUsers = ["swang392"]
-const officeHoursLink = "https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours";
+const hudUrl = "hud.pytorch.org/pr/";
 
 async function getDrciComment(
   context: Context,
@@ -25,11 +26,9 @@ async function getDrciComment(
 }
 
 export function formDrciComment(prNum: number): string {
-  const hudUrl = "hud.pytorch.org/pr/" + prNum;
-  let body = "<h1>Helpful Links</h1>\n";
-  body += "<body>See artifacts and rendered test results [here](" + hudUrl + ")\n";
-  body += "Need help or want to give feedback on the CI? Visit our [office hours](" + officeHoursLink + ")";
-  body += "</body>";
+  let body = "# Helpful Links\n";
+  body += `See artifacts and rendered test results [here](${hudUrl}${prNum})\n`;
+  body += `Need help or want to give feedback on the CI? Visit our [office hours](${officeHoursUrl})`;
   return drciCommentStart + body + drciCommentEnd;
 }
 

--- a/torchci/test/drciBot.test.ts
+++ b/torchci/test/drciBot.test.ts
@@ -31,9 +31,10 @@ describe("verify-drci-functionality", () => {
       .reply(200)
       .post("/repos/zhouzhuojie/gha-ci-playground/issues/31/comments", (body) => {
         const comment = body.body;
-        expect(comment.includes("<!-- drci-comment-start -->")).toBeTruthy();
+        expect(comment.includes(botUtils.drciCommentStart)).toBeTruthy();
         expect(comment.includes("See artifacts and rendered test results")).toBeTruthy();
         expect(comment.includes("Need help or want to give feedback on the CI?")).toBeTruthy();
+        expect(comment.includes(botUtils.officeHoursUrl)).toBeTruthy();
         return true;
       })
       .reply(200);

--- a/torchci/test/drciBot.test.ts
+++ b/torchci/test/drciBot.test.ts
@@ -30,7 +30,10 @@ describe("verify-drci-functionality", () => {
       })
       .reply(200)
       .post("/repos/zhouzhuojie/gha-ci-playground/issues/31/comments", (body) => {
-        expect(body).toMatchObject({ body: "<!-- drci-comment-start -->hello there!<!-- drci-comment-end -->" });
+        const comment = body.body;
+        expect(comment.includes("<!-- drci-comment-start -->")).toBeTruthy();
+        expect(comment.includes("See artifacts and rendered test results")).toBeTruthy();
+        expect(comment.includes("Need help or want to give feedback on the CI?")).toBeTruthy();
         return true;
       })
       .reply(200);


### PR DESCRIPTION
**Overview:** Edited `formDrciComment` function to include static helpful links -- hud and office hours link

**Test Plan:** modified test case to check that both links are there. Example output of the comment:
![Screen Shot 2022-06-24 at 3 14 55 PM](https://user-images.githubusercontent.com/24441980/175650454-fc58e21e-83c6-49c3-932f-490961b12d09.png)
 