### PR TITLE
[metrics] fix TimeSeriesPanel range

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -247,7 +247,7 @@ export function TimeRangePicker({
   useEffect(() => {
     const id = setInterval(updateTimeRange, 1000 * 60 * 5 /*5 minutes*/);
     return () => clearInterval(id);
-  }, [timeRange]);
+  }, [timeRange, updateTimeRange]);
 
   function handleChange(e: SelectChangeEvent<number>) {
     setTimeRange(e.target.value as number);


### PR DESCRIPTION
Fix the range to the start/end specified by the user, instead of letting
the returned data determine it. Otherwise if we don't have data for some
period we will show a chart with a different range than the one
requested by the user
