### PR TITLE
Added static docs builds links to Dr. CI comment

### DIFF
--- a/torchci/lib/bot/drciBot.ts
+++ b/torchci/lib/bot/drciBot.ts
@@ -34,7 +34,7 @@ export function formDrciComment(prNum: number): string {
   body += `* Preview [Python docs built from this PR](${docsBuildsUrl}${prNum}${pythonDocsUrl})\n`;
   body += `* Preview [C++ docs built from this PR](${docsBuildsUrl}${prNum}${cppDocsUrl})\n`;
   body += `* Need help or want to give feedback on the CI? Visit our [office hours](${officeHoursUrl})\n`;
-  body += `Note: Links to docs will display an error until the docs builds have been completed.`;
+  body += `\nNote: Links to docs will display an error until the docs builds have been completed.`;
   return drciCommentStart + body + drciCommentEnd;
 }
 

--- a/torchci/lib/bot/drciBot.ts
+++ b/torchci/lib/bot/drciBot.ts
@@ -2,6 +2,9 @@ import { Context, Probot } from "probot";
 
 export const drciCommentStart = "<!-- drci-comment-start -->\n";
 export const officeHoursUrl = "https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours";
+export const docsBuildsUrl = "https://docs-preview.pytorch.org/"
+export const pythonDocsUrl = "/index.html"
+export const cppDocsUrl = "/cppdocs/index.html"
 const drciCommentEnd = "\n<!-- drci-comment-end -->";
 const possibleUsers = ["swang392"]
 const hudUrl = "https://hud.pytorch.org/pr/";
@@ -28,7 +31,10 @@ async function getDrciComment(
 export function formDrciComment(prNum: number): string {
   let body = "# Helpful Links\n";
   body += `* See artifacts and rendered test results [here](${hudUrl}${prNum})\n`;
-  body += `* Need help or want to give feedback on the CI? Visit our [office hours](${officeHoursUrl})`;
+  body += `* Preview [Python docs built from this PR](${docsBuildsUrl}${prNum}${pythonDocsUrl})\n`;
+  body += `* Preview [C++ docs built from this PR](${docsBuildsUrl}${prNum}${cppDocsUrl})\n`;
+  body += `* Need help or want to give feedback on the CI? Visit our [office hours](${officeHoursUrl})\n`;
+  body += `Note: Links to docs will display an error until the docs builds have been completed.`;
   return drciCommentStart + body + drciCommentEnd;
 }
 
@@ -78,6 +84,9 @@ export default function drciBot(app: Probot): void {
         repo,
         comment_id: existingDrciID,
       });
+      context.log(
+        `Updated comment with "${drciComment}" for pull request ${context.payload.pull_request.html_url}`
+      );
     }
   });
 }

--- a/torchci/test/drciBot.test.ts
+++ b/torchci/test/drciBot.test.ts
@@ -35,6 +35,7 @@ describe("verify-drci-functionality", () => {
         expect(comment.includes("See artifacts and rendered test results")).toBeTruthy();
         expect(comment.includes("Need help or want to give feedback on the CI?")).toBeTruthy();
         expect(comment.includes(botUtils.officeHoursUrl)).toBeTruthy();
+        expect(comment.includes(botUtils.docsBuildsUrl)).toBeTruthy();
         return true;
       })
       .reply(200);


### PR DESCRIPTION
**Overview:** Added static links for docs builds. I have not yet implemented an update comment script that will only add the link to the docs builds if their respective jobs have completed. 

**Example Output:**
![Screen Shot 2022-06-28 at 5 06 32 PM](https://user-images.githubusercontent.com/24441980/176288066-7ae0e9e2-a047-47ac-9064-54402a882e7f.png)

**Test Plan:** Added an `expect` statement to check if the docs builds links are present.