### PR TITLE
Add test case for Dr. CI bot to edit existing comments

### DIFF
--- a/torchci/lib/bot/drciBot.ts
+++ b/torchci/lib/bot/drciBot.ts
@@ -29,11 +29,11 @@ async function getDrciComment(
 }
 
 export function formDrciComment(prNum: number): string {
-  let body = "# Helpful Links\n";
-  body += `* See artifacts and rendered test results [here](${hudUrl}${prNum})\n`;
-  body += `* Preview [Python docs built from this PR](${docsBuildsUrl}${prNum}${pythonDocsUrl})\n`;
-  body += `* Preview [C++ docs built from this PR](${docsBuildsUrl}${prNum}${cppDocsUrl})\n`;
-  body += `* Need help or want to give feedback on the CI? Visit our [office hours](${officeHoursUrl})\n`;
+  let body = "# :link: Helpful Links\n";
+  body += `* :test_tube: See artifacts and rendered test results [here](${hudUrl}${prNum})\n`;
+  body += `* :page_facing_up: Preview [Python docs built from this PR](${docsBuildsUrl}${prNum}${pythonDocsUrl})\n`;
+  body += `* :page_facing_up: Preview [C++ docs built from this PR](${docsBuildsUrl}${prNum}${cppDocsUrl})\n`;
+  body += `* :question: Need help or want to give feedback on the CI? Visit our [office hours](${officeHoursUrl})\n`;
   body += `\nNote: Links to docs will display an error until the docs builds have been completed.`;
   return drciCommentStart + body + drciCommentEnd;
 }

--- a/torchci/test/drciBot.test.ts
+++ b/torchci/test/drciBot.test.ts
@@ -3,6 +3,9 @@ import * as utils from "./utils";
 import nock from "nock";
 import myProbotApp, * as botUtils from "../lib/bot/drciBot";
 
+const comment_id = 10;
+const comment_node_id = "abcd";
+
 describe("verify-drci-functionality", () => {
   let probot: Probot;
 
@@ -16,7 +19,7 @@ describe("verify-drci-functionality", () => {
     jest.restoreAllMocks();
   });
   
-  test("Dr. CI comment if user of PR is swang392", async () => {
+  test("Dr. CI comments if user of PR is swang392", async () => {
     nock("https://api.github.com")
       .post("/app/installations/2/access_tokens")
       .reply(200, { token: "test" });
@@ -56,6 +59,45 @@ describe("verify-drci-functionality", () => {
 
     await probot.receive({ name: "pull_request", payload: payload, id: "2" });
     expect(mock).not.toHaveBeenCalled();
+  });
+
+  test("Dr. CI edits existing comment if a comment is already present", async () => {
+    nock("https://api.github.com")
+      .post("/app/installations/2/access_tokens")
+      .reply(200, { token: "test" });
+
+    const payload = require("./fixtures/pull_request.opened")["payload"];
+    payload["pull_request"]["user"]["login"] = "swang392"
+    
+    const scope = nock("https://api.github.com")
+      .get("/repos/zhouzhuojie/gha-ci-playground/issues/31/comments", (body) => {
+        return true;
+      })
+      .reply(200, [
+        {
+          id: comment_id,
+          node_id: comment_node_id,
+          body: "<!-- drci-comment-start -->\nhello\n<!-- drci-comment-end -->\n",
+        },
+      ])
+      .patch(
+        `/repos/zhouzhuojie/gha-ci-playground/issues/comments/${comment_id}`,
+        (body) => {
+          const comment = body.body;
+          expect(comment.includes(botUtils.drciCommentStart)).toBeTruthy();
+          expect(comment.includes("See artifacts and rendered test results")).toBeTruthy();
+          expect(comment.includes("Need help or want to give feedback on the CI?")).toBeTruthy();
+          expect(comment.includes(botUtils.officeHoursUrl)).toBeTruthy();
+          expect(comment.includes(botUtils.docsBuildsUrl)).toBeTruthy();
+          return true;
+        }
+      )
+      .reply(200)
+    await probot.receive({ name: "pull_request", payload: payload, id: "2" });
+
+    if (!nock.isDone()) {
+      console.error("pending mocks: %j", scope.pendingMocks());
+    }
   });
 
 });

--- a/torchci/test/drciBot.test.ts
+++ b/torchci/test/drciBot.test.ts
@@ -99,5 +99,4 @@ describe("verify-drci-functionality", () => {
       console.error("pending mocks: %j", scope.pendingMocks());
     }
   });
-
 });


### PR DESCRIPTION
**Overview:** Added a test case to check that the Dr. CI bot edits an existing comment if one is present. And added emojis!

**Example Output:**
<img width="569" alt="Screen Shot 2022-06-29 at 5 57 03 PM" src="https://user-images.githubusercontent.com/24441980/176552827-64accab6-7437-4945-b1e1-5f89f184c29e.png">

**Test Plan:** ensure that all tests pass, `context.log` statements show that a comment was updated and not created