### PR TITLE
[test stats] switch slow tests to use rockset

### DIFF
--- a/.github/workflows/update_slow_tests.yml
+++ b/.github/workflows/update_slow_tests.yml
@@ -7,30 +7,18 @@ on:
   # Have the ability to trigger this job manually
   workflow_dispatch:
 
+defaults:
+  run:
+    working-directory: torchci
 jobs:
   update-slow-stats:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.x
-          architecture: x64
-      - name: Checkout PyTorch
-        uses: actions/checkout@v2
-        with:
-          repository: pytorch/pytorch
-          fetch-depth: 0 # deep clone, to allow us to use git log
-      - name: Install dependencies
-        # mypy and boto3 versions copied from
-        # .circleci/docker/common/install_conda.sh
-        run: |
-          set -eux
-          pip install -r requirements.txt
-          pip install boto3==1.16.34
-      - name: Generate new slow test stats
-        run: |
-          python -m tools.stats.export_slow_tests -f slow-tests.json --ignore-small-diffs 0.1
+      - uses: actions/checkout@v3
+      - run: yarn install --frozen-lockfile
+      - run: yarn --silent node scripts/updateSlowTests.mjs > slow-tests.json
+        env:
+          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
       - name: Push file to this repository
         uses: dmnemec/copy_file_to_another_repo_action@5f40763ccee2954067adba7fb8326e4df33bcb92
         env:

--- a/torchci/rockset/commons/__sql/slow_tests.sql
+++ b/torchci/rockset/commons/__sql/slow_tests.sql
@@ -1,0 +1,74 @@
+WITH most_recent_strict_commits AS (
+    SELECT
+        push.head_commit.id as sha,
+    FROM
+        commons.push
+    WHERE
+        push.ref = 'refs/heads/viable/strict'
+        AND push.repository.full_name = 'pytorch/pytorch'
+    ORDER BY
+        push._event_time DESC
+    LIMIT
+        3
+), workflows AS (
+    SELECT
+        id
+    FROM
+        commons.workflow_run w
+        INNER JOIN most_recent_strict_commits c on w.head_sha = c.sha
+    WHERE
+        w.name != 'periodic'
+),
+job AS (
+    SELECT
+        j.id
+    FROM
+        commons.workflow_job j
+        INNER JOIN workflows w on w.id = j.run_id
+    WHERE
+        j.name NOT LIKE '%asan%'
+),
+duration_per_job AS (
+    SELECT
+        test_run.classname,
+        test_run.name,
+        job.id,
+        SUM(time) as time
+    FROM
+        commons.test_run_s3 test_run
+        /* `test_run` is ginormous and `job` is small, so lookup join is essential */
+        INNER JOIN job ON test_run.job_id = job.id HINT(join_strategy = lookup)
+    WHERE
+        /* cpp tests do not populate `file` for some reason. */
+        /* Exclude them as we don't include them in our slow test infra */
+        test_run.file IS NOT NULL
+        /* do some more filtering to cut down on the test_run size */
+        AND test_run.skipped IS NULL
+        AND test_run.failure IS NULL
+        AND test_run.error IS NULL
+    GROUP BY
+        test_run.classname,
+        test_run.name,
+        job.id
+)
+SELECT
+    CONCAT(
+        name,
+        ' (__main__.',
+        classname,
+        ')'
+    ) as test_name,
+    AVG(time) as avg_duration_sec
+FROM
+    duration_per_job
+GROUP BY
+    CONCAT(
+        name,
+        ' (__main__.',
+        classname,
+        ')'
+    )
+HAVING
+    AVG(time) > 60.0
+ORDER BY
+    test_name

--- a/torchci/rockset/commons/slow_tests.lambda.json
+++ b/torchci/rockset/commons/slow_tests.lambda.json
@@ -1,0 +1,5 @@
+{
+  "sql_path": "__sql/slow_tests.sql",
+  "default_parameters": [],
+  "description": ""
+}

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -3,6 +3,7 @@
     "hud_query": "a848c067c22e5a09",
     "commit_jobs_query": "e05467fcb948e0ec",
     "flaky_tests": "59d7546183743626",
+    "slow_tests": "ef8d035d23aa8ab6",
     "issue_query": "f29a1afe94563601",
     "failure_samples_query": "2961636418a148c2"
   },

--- a/torchci/scripts/updateSlowTests.mjs
+++ b/torchci/scripts/updateSlowTests.mjs
@@ -1,0 +1,27 @@
+import rockset from "@rockset/client";
+import { promises as fs } from "fs";
+import dotenv from "dotenv";
+import path from "path";
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+const client = rockset.default(process.env.ROCKSET_API_KEY);
+
+async function readJSON(path) {
+    const rawData = await fs.readFile(path);
+    return JSON.parse(rawData);
+}
+const prodVersions = await readJSON("rockset/prodVersions.json");
+
+const response = await client.queryLambdas.executeQueryLambda(
+    "commons",
+    "slow_tests",
+    prodVersions.commons.slow_tests,
+    {}
+);
+
+let slowTests = {}
+for (const row of response.results) {
+    slowTests[row.test_name] = row.avg_duration_sec
+}
+
+process.stdout.write(JSON.stringify(slowTests, null, 2))


### PR DESCRIPTION
This recreates the query that we do manually today in rockset, and uses
that directly to write the slow-tests.json

One difference is that we only look at the 3 most recent viable/strict
commits instead of the last 10, to cut down on query time.

Here is the diff of what's produced:
https://www.diffchecker.com/rES6z0ls. I think the differences are largely
due to partial data in the new test_run_s3 dataset, so they should converge
(I will check this).
