### PR TITLE
[test stats] Upload test times

### DIFF
--- a/.github/workflows/update-test-times.yml
+++ b/.github/workflows/update-test-times.yml
@@ -1,0 +1,33 @@
+name: Update test times
+
+on:
+  schedule:
+    # Every day at 3:05am UTC
+    - cron: "5 3 * * *"
+  # Have the ability to trigger this job manually
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: torchci
+jobs:
+  update-slow-stats:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: yarn install --frozen-lockfile
+      - run: yarn --silent node scripts/updateTestTimes.mjs > test-times.json
+        env:
+          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
+      - name: Push file to this repository
+        uses: dmnemec/copy_file_to_another_repo_action@5f40763ccee2954067adba7fb8326e4df33bcb92
+        env:
+           API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          source_file: 'torchci/test-times.json'
+          destination_repo: 'pytorch/test-infra'
+          destination_folder: 'stats'
+          destination_branch: generated-stats
+          user_email: 'test-infra@pytorch.org'
+          user_name: 'PyTorch Test Infra'
+          commit_message: 'Updating test time stats'

--- a/torchci/rockset/commons/__sql/test_time_per_file.sql
+++ b/torchci/rockset/commons/__sql/test_time_per_file.sql
@@ -1,0 +1,61 @@
+WITH most_recent_strict_commits AS (
+    SELECT
+        push.head_commit.id as sha,
+    FROM
+        commons.push
+    WHERE
+        push.ref = 'refs/heads/viable/strict'
+        AND push.repository.full_name = 'pytorch/pytorch'
+    ORDER BY
+        push._event_time DESC
+    LIMIT
+        3
+), workflow AS (
+    SELECT
+        id
+    FROM
+        commons.workflow_run w
+        INNER JOIN most_recent_strict_commits c on w.head_sha = c.sha
+),
+job AS (
+    SELECT
+        j.name,
+        j.id
+    FROM
+        commons.workflow_job j
+        INNER JOIN workflow w on w.id = j.run_id
+),
+file_duration_per_job AS (
+    SELECT
+        test_run.invoking_file as file,
+        job.name,
+        SUM(time) as time,
+        job.id
+    FROM
+        commons.test_run_summary test_run
+        /* `test_run` is ginormous and `job` is small, so lookup join is essential */
+        INNER JOIN job ON test_run.job_id = job.id HINT(join_strategy = lookup)
+    WHERE
+        /* cpp tests do not populate `file` for some reason. */
+        /* Exclude them as we don't include them in our slow test infra */
+        test_run.file IS NOT NULL
+    GROUP BY
+        test_run.invoking_file,
+        job.name,
+        job.id
+)
+SELECT
+    file,
+    REGEXP_EXTRACT(name, '^(.*) /', 1) as base_name,
+    REGEXP_EXTRACT(name, '/ test \((\w*),', 1) as test_config,
+    AVG(time) as time
+FROM
+    file_duration_per_job
+GROUP BY
+    file,
+    name
+ORDER BY
+    base_name,
+    test_config,
+    file
+

--- a/torchci/rockset/commons/test_time_per_file.lambda.json
+++ b/torchci/rockset/commons/test_time_per_file.lambda.json
@@ -1,0 +1,5 @@
+{
+  "sql_path": "__sql/test_time_per_file.sql",
+  "default_parameters": [],
+  "description": ""
+}

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -4,6 +4,7 @@
     "commit_jobs_query": "e05467fcb948e0ec",
     "flaky_tests": "59d7546183743626",
     "slow_tests": "ef8d035d23aa8ab6",
+    "test_time_per_file": "340cffc6a8913a19",
     "issue_query": "f29a1afe94563601",
     "failure_samples_query": "2961636418a148c2"
   },

--- a/torchci/scripts/updateTestTimes.mjs
+++ b/torchci/scripts/updateTestTimes.mjs
@@ -1,0 +1,30 @@
+import rockset from "@rockset/client";
+import { promises as fs } from "fs";
+import dotenv from "dotenv";
+import path from "path";
+import _ from "lodash"
+
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+const client = rockset.default(process.env.ROCKSET_API_KEY);
+
+async function readJSON(path) {
+    const rawData = await fs.readFile(path);
+    return JSON.parse(rawData);
+}
+
+const prodVersions = await readJSON("rockset/prodVersions.json");
+
+const response = await client.queryLambdas.executeQueryLambda(
+    "commons",
+    "test_time_per_file",
+    prodVersions.commons.test_time_per_file,
+    {}
+);
+
+let ret = {}
+for (const row of response.results) {
+    _.set(ret, `["${row.base_name}"]["${row.test_config}"]["${row.file}"]`, row.time);
+}
+
+process.stdout.write(JSON.stringify(ret, null, 2))


### PR DESCRIPTION
Right now we perform sharding on a per-job basis. The setup looks like:
- Build job downloads the most recent test reports from S3 and parses
them according to sum duration by file and build environment
- Build job packages resulting data as a json along with the rest of the
build artifacts
- Test jobs use this json to make sharding decisions.

We want to:
1. Eliminate the dependence on manual parsing and aggregation of test
stats in S3 in favor of using Rockset, to improve maintainability
2. Compute test statistics globally instead of per-build-job, to avoid
tests jumping around shards too frequently.

This PR does the first part: it downloads the test stats from rockset
and makes them available in GH, similar to what we do with slow tests.
This happens every day in the night time.

There are two differences with the existing query:
1. Only the last 3 commits on viable/strict are used instead of 10.
2. We further segment by TEST_CONFIG, which should improve the accuracy
of the stats

After this is landed, I will make a corresponding PR on the PyTorch side
to actually use this info to make sharding decisions.
