### PR TITLE
Made HUD link more prominent on Dr. CI comment

### DIFF
--- a/torchci/lib/bot/drciBot.ts
+++ b/torchci/lib/bot/drciBot.ts
@@ -30,8 +30,8 @@ async function getDrciComment(
 }
 
 export function formDrciComment(prNum: number): string {
-  let body = "# :link: Helpful Links\n";
-  body += `* :test_tube: See artifacts and rendered test results [here](${hudUrl}${prNum})\n`;
+  let body = "## :link: Helpful Links\n";
+  body += `### :test_tube: See artifacts and rendered test results [here](${hudUrl}${prNum})\n`;
   body += `* :page_facing_up: Preview [Python docs built from this PR](${docsBuildsUrl}${prNum}${pythonDocsUrl})\n`;
   body += `* :page_facing_up: Preview [C++ docs built from this PR](${docsBuildsUrl}${prNum}${cppDocsUrl})\n`;
   body += `* :question: Need help or want to give feedback on the CI? Visit our [office hours](${officeHoursUrl})\n`;


### PR DESCRIPTION
**Overview**: I received feedback that the HUD link in the Dr. CI comment should be emphasized, since many people thought that this was the most important/used part of the Dr. CI comment. Increased the size of the text to make it more prominent.

**Example Output:**
![Screen Shot 2022-07-08 at 3 12 24 PM](https://user-images.githubusercontent.com/24441980/178055999-774324a4-e2b6-41a1-8f59-3a98833a17a2.png)

**Testing**: No changes that would affect any test cases -- the existing test cases all pass