### PR TITLE
Updated rockset query for Dr. CI

### DIFF
--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -96,6 +96,8 @@ export interface RecentWorkflowsData {
   html_url: string;
   head_sha: string;
   number: number;
+  ref: string;
+  login: string;
 }
 
 export function packHudParams(input: any) {

--- a/torchci/rockset/commons/__sql/recent_pr_workflows_query.sql
+++ b/torchci/rockset/commons/__sql/recent_pr_workflows_query.sql
@@ -5,6 +5,8 @@ select
     w.html_url,
     w.head_sha,
     p.number,
+    p.head.ref,
+    p.user.login
 from
     commons.workflow_job w inner join commons.pull_request p on w.head_sha = p.head.sha   
 where
@@ -15,4 +17,6 @@ group by
     completed_at,
     html_url,
     head_sha,
-    number
+    number,
+    ref,
+    login

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -7,7 +7,7 @@
     "test_time_per_file": "50cb3694334ed63a",
     "issue_query": "f29a1afe94563601",
     "failure_samples_query": "2961636418a148c2",
-    "recent_pr_workflows_query": "3aa65fe124a684b7"
+    "recent_pr_workflows_query": "21ef45465dfd2bb0"
   },
   "pytorch_dev_infra_kpis": {
     "num_reverts": "57e5562a57427ae3",


### PR DESCRIPTION
**Overview**: Updated the `recent_pr_workflows_query` Rockset query [here](https://console.rockset.com/lambdas/details/commons.recent_pr_workflows_query?tab=summary) to include a reference to the repo and the PR owner, which are needed in the `drci.ts` script to retrieve and update the Dr. CI comment. Updated necessary fields and sql code on test-infra. 

**Testing**: N/A, ran the code on rockset to ensure that the new values are correct