### PR TITLE
tts on minihud

### DIFF
--- a/torchci/lib/fetchHud.ts
+++ b/torchci/lib/fetchHud.ts
@@ -14,7 +14,7 @@ export default async function fetchHud(params: HudParams): Promise<{
     owner: params.repoOwner,
     repo: params.repoName,
     sha: params.branch,
-    per_page: 50,
+    per_page: params.per_page,
     page: params.page,
   });
   const commits = branch.data.map(commitDataFromResponse);

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -101,6 +101,14 @@ export interface RecentWorkflowsData {
   login: string;
 }
 
+export interface TTSChange {
+  name: string | undefined;
+  duration: string;
+  color: string;
+  percentChangeString: string;
+  absoluteChangeString: string;
+}
+
 export function packHudParams(input: any) {
   return {
     repoOwner: input.repoOwner as string,

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -69,6 +69,7 @@ export interface HudParams {
   repoName: string;
   branch: string;
   page: number;
+  per_page: number;
   nameFilter?: string;
 }
 
@@ -106,6 +107,7 @@ export function packHudParams(input: any) {
     repoName: input.repoName as string,
     branch: input.branch as string,
     page: parseInt((input.page as string) ?? 1),
+    per_page: parseInt((input.per_page as string) ?? 50),
     nameFilter: input.name_filter as string | undefined,
   };
 }
@@ -133,8 +135,10 @@ function formatHudURL(
     params.repoName
   }/${encodeURIComponent(params.branch)}/${params.page}`;
 
+  base += `?per_page=${params.per_page}`;
+
   if (params.nameFilter != null && keepFilter) {
-    base += `?name_filter=${encodeURIComponent(params.nameFilter)}`;
+    base += `&name_filter=${encodeURIComponent(params.nameFilter)}`;
   }
   return base;
 }

--- a/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -6,11 +6,12 @@ import JobLinks from "components/JobLinks";
 import LogViewer from "components/LogViewer";
 import styles from "components/minihud.module.css";
 import PageSelector from "components/PageSelector";
-import { LocalTimeHuman } from "components/TimeUtils";
+import { durationHuman, LocalTimeHuman } from "components/TimeUtils";
 import { isFailedJob } from "lib/jobUtils";
 import { HudParams, JobData, packHudParams, RowData } from "lib/types";
 import useHudData from "lib/useHudData";
 import useScrollTo from "lib/useScrollTo";
+import _ from "lodash";
 import { useRouter } from "next/router";
 import {
   createContext,
@@ -187,10 +188,12 @@ function CommitSummaryLine({
   row,
   numPending,
   showRevert,
+  ttsAlert,
 }: {
   row: RowData;
   numPending: number;
   showRevert: boolean;
+  ttsAlert: boolean;
 }) {
   const router = useRouter();
   useScrollTo();
@@ -231,12 +234,161 @@ function CommitSummaryLine({
           </a>
         </span>
       )}
+      {ttsAlert && (
+        <span style={{ float: "right" }}>
+          <b>tts alert</b>
+        </span>
+      )}
       <CommitLinks row={row} />
     </div>
   );
 }
 
-function CommitSummary({ row }: { row: RowData }) {
+function DurationInfo({
+  jobs,
+  prevRow,
+  expandAllDurationInfo,
+}: {
+  jobs: JobData[];
+  prevRow: RowData | undefined;
+  expandAllDurationInfo: boolean;
+}) {
+  function getAggregateTestTimes(jobs: JobData[] | undefined) {
+    return _.reduce(
+      jobs,
+      (
+        prev: {
+          [key: string]: {
+            duration: number;
+            validData: boolean;
+          };
+        },
+        cur
+      ) => {
+        // filter out rocm and macos because they tend to be variable
+        if (
+          cur.name != undefined &&
+          cur.name.includes(",") &&
+          !cur.name.includes("rocm") &&
+          !cur.name.includes("macos")
+        ) {
+          let name = cur.name.substring(0, cur.name.indexOf(","));
+          if (!(name in prev)) {
+            prev[name] = { duration: 0, validData: true };
+          }
+          if (cur.conclusion != "success" || cur.durationS === undefined) {
+            prev[name].validData = false;
+          } else {
+            prev[name].duration += cur.durationS;
+          }
+        }
+        return prev;
+      },
+      {}
+    );
+  }
+
+  const prevRowJobsAggregate = _.pickBy(
+    getAggregateTestTimes(prevRow?.jobs),
+    (value) => value.validData
+  );
+
+  function getDurationInfo(name: string, duration: number, validData: boolean) {
+    const durationString = validData ? durationHuman(duration) : "invalid data";
+    var color = "black";
+    if (
+      !validData ||
+      prevRow === undefined ||
+      prevRowJobsAggregate[name] === undefined
+    ) {
+      return {
+        concerningChange: false,
+        name,
+        color,
+        duration: durationString,
+        percentChangeString: "",
+        absoluteChangeString: "",
+      };
+    }
+    const prevDuration = prevRowJobsAggregate[name].duration;
+
+    const percentChange = duration / prevDuration;
+    const percentChangeString =
+      percentChange >= 1
+        ? `+ ${((percentChange - 1) * 100).toFixed(2)}%`
+        : `- ${((1 - percentChange) * 100).toFixed(2)}%`;
+    const absoluteChange = Math.round(duration - prevDuration);
+    const absoluteChangeString =
+      absoluteChange >= 0
+        ? `+ ${durationHuman(absoluteChange)}`
+        : `- ${durationHuman(Math.abs(absoluteChange))}`;
+    const concerningChange = Math.abs(absoluteChange) > 60 * 30;
+    if (concerningChange) {
+      color = absoluteChange > 0 ? "red" : "purple";
+    }
+    return {
+      concerningChange,
+      color,
+      name,
+      duration: durationString,
+      percentChangeString,
+      absoluteChangeString,
+    };
+  }
+
+  const [concerning, notConcerning] = _.partition(
+    _.map(getAggregateTestTimes(jobs), (value, key) => {
+      return getDurationInfo(key, value.duration, value.validData);
+    }),
+    (e) => e.concerningChange
+  );
+
+  function getRow(val: {
+    concerningChange: boolean;
+    name: string | undefined;
+    duration: string;
+    color: string;
+    percentChangeString: string;
+    absoluteChangeString: string;
+  }) {
+    return (
+      <tr key={`duration-row-${val.name}`} style={{ color: val.color }}>
+        <td style={{ width: "750px" }}>{val.name}</td>
+        <td style={{ width: "100px" }}>{val.duration}</td>
+        <td style={{ width: "100px" }}>{val.percentChangeString}</td>
+        <td style={{ width: "100px" }}>{val.absoluteChangeString}</td>
+      </tr>
+    );
+  }
+  return {
+    ttsAlert: concerning.length > 0,
+    durationJsxElement: (
+      <div style={{ padding: "10px" }}>
+        <table>
+          <tbody>{concerning.map((val) => getRow(val))}</tbody>
+        </table>
+        <details open={expandAllDurationInfo}>
+          <summary>See all jobs</summary>
+          <table>
+            <tbody>{notConcerning.map((val) => getRow(val))}</tbody>
+          </table>
+        </details>
+      </div>
+    ),
+  };
+}
+
+function CommitSummary({
+  row,
+  prevRow,
+  showDurationInfo,
+  expandAllDurationInfo,
+}: {
+  row: RowData;
+  prevRow: RowData | undefined;
+  showDurationInfo: boolean;
+  expandAllDurationInfo: boolean;
+}) {
   const [jobFilter, _setJobFilter] = useContext(JobFilterContext);
   const [highlighted, setHighlighted] = useState(false);
 
@@ -266,6 +418,12 @@ function CommitSummary({ row }: { row: RowData }) {
     className += " " + styles.workflowBoxHighlight;
   }
 
+  const { ttsAlert, durationJsxElement } = DurationInfo({
+    jobs,
+    prevRow,
+    expandAllDurationInfo,
+  });
+
   useEffect(() => {
     const onHashChanged = () => {
       if (window.location.hash === "") {
@@ -289,14 +447,24 @@ function CommitSummary({ row }: { row: RowData }) {
         row={row}
         numPending={pendingJobs.length}
         showRevert={failedJobs.length !== 0}
+        ttsAlert={ttsAlert}
       />
-      <FailedJobs failedJobs={failedJobs} />
+      {!showDurationInfo && <FailedJobs failedJobs={failedJobs} />}
+      {showDurationInfo && durationJsxElement}
     </div>
   );
 }
 
 function MiniHud({ params }: { params: HudParams }) {
   const data = useHudData(params);
+
+  var paramsNextPage = { ...params };
+  paramsNextPage.page = params.page + 1;
+  const extraRow = useHudData(paramsNextPage);
+
+  const [showDurationInfo, setShowDurationInfo] = useState(false);
+  const [expandAllDurationInfo, setExpandAllDurationInfo] = useState(false);
+
   if (data === undefined) {
     return <div>Loading...</div>;
   }
@@ -305,8 +473,39 @@ function MiniHud({ params }: { params: HudParams }) {
 
   return (
     <>
-      {shaGrid.map((row: RowData) => (
-        <CommitSummary row={row} key={row.sha} />
+      <div>
+        <input
+          type="checkbox"
+          id={"showDurationInfo"}
+          onChange={() => setShowDurationInfo(!showDurationInfo)}
+        />
+        <label htmlFor={"showDurationInfo"}>show duration info</label>
+        {showDurationInfo && (
+          <>
+            <input
+              type="checkbox"
+              id={"expandAllDurationInfo"}
+              checked={expandAllDurationInfo}
+              onChange={() => setExpandAllDurationInfo(!expandAllDurationInfo)}
+            />
+            <label htmlFor={"expandAllDurationInfo"}>
+              expand all duration info
+            </label>
+          </>
+        )}
+      </div>
+      {shaGrid.map((row: RowData, index: number, array: RowData[]) => (
+        <CommitSummary
+          row={row}
+          prevRow={
+            index + 1 >= array.length
+              ? extraRow?.shaGrid[0]
+              : array.at(index + 1)
+          }
+          key={row.sha}
+          showDurationInfo={showDurationInfo}
+          expandAllDurationInfo={expandAllDurationInfo}
+        />
       ))}
     </>
   );

--- a/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -487,7 +487,8 @@ function MiniHud({ params }: { params: HudParams }) {
   const data = useHudData(params);
 
   let paramsNextPage = { ...params };
-  paramsNextPage.page = params.page + 1;
+  paramsNextPage.page = params.per_page * params.page + 1;
+  paramsNextPage.per_page = 1;
   const extraRow = useHudData(paramsNextPage);
 
   const [showDurationInfo, setShowDurationInfo] = useState(false);

--- a/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -294,7 +294,7 @@ function DurationInfo({
   );
 
   function getDurationInfo(name: string, duration: number, validData: boolean) {
-    const durationString = validData ? durationHuman(duration) : "invalid data";
+    const durationString = validData ? durationHuman(duration) : "N/A";
     var color = "black";
     if (
       !validData ||

--- a/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -506,6 +506,7 @@ function MiniHud({ params }: { params: HudParams }) {
         <input
           type="checkbox"
           id={"durationInfoCheckbox"}
+          checked={showDurationInfo}
           onChange={() => setShowDurationInfo(!showDurationInfo)}
         />
         <label htmlFor={"durationInfoCheckbox"}>Show duration info</label>

--- a/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -8,7 +8,13 @@ import styles from "components/minihud.module.css";
 import PageSelector from "components/PageSelector";
 import { durationHuman, LocalTimeHuman } from "components/TimeUtils";
 import { isFailedJob } from "lib/jobUtils";
-import { HudParams, JobData, packHudParams, RowData } from "lib/types";
+import {
+  HudParams,
+  JobData,
+  packHudParams,
+  RowData,
+  TTSChange,
+} from "lib/types";
 import useHudData from "lib/useHudData";
 import useScrollTo from "lib/useScrollTo";
 import _ from "lodash";
@@ -244,14 +250,6 @@ function CommitSummaryLine({
   );
 }
 
-interface TTSChange {
-  name: string | undefined;
-  duration: string;
-  color: string;
-  percentChangeString: string;
-  absoluteChangeString: string;
-}
-
 function getTTSChanges(jobs: JobData[], prevRow: RowData | undefined) {
   function getAggregateTestTimes(jobs: JobData[] | undefined) {
     return _.reduce(
@@ -340,17 +338,17 @@ function getTTSChanges(jobs: JobData[], prevRow: RowData | undefined) {
     };
   }
 
-  const [ttsConcerning, ttsNotConcerning] = _.partition(
+  const [concerningTTS, notConcerningTTS] = _.partition(
     _.map(getAggregateTestTimes(jobs), (value, key) => {
       return getDurationInfo(key, value.duration, value.availableData);
     }),
     (e) => e.concerningChange
   );
 
-  return { ttsConcerning, ttsNotConcerning };
+  return { concerningTTS, notConcerningTTS };
 }
 
-function DurationInfoElement({
+function DurationInfo({
   concerning,
   notConcerning,
   expandAllDurationInfo,
@@ -444,7 +442,7 @@ function CommitSummary({
     className += " " + styles.workflowBoxHighlight;
   }
 
-  const { ttsConcerning, ttsNotConcerning } = getTTSChanges(jobs, prevRow);
+  const { concerningTTS, notConcerningTTS } = getTTSChanges(jobs, prevRow);
 
   useEffect(() => {
     const onHashChanged = () => {
@@ -469,13 +467,13 @@ function CommitSummary({
         row={row}
         numPending={pendingJobs.length}
         showRevert={failedJobs.length !== 0}
-        ttsAlert={ttsConcerning.length > 0}
+        ttsAlert={concerningTTS.length > 0}
       />
       {!showDurationInfo && <FailedJobs failedJobs={failedJobs} />}
       {showDurationInfo && (
-        <DurationInfoElement
-          concerning={ttsConcerning}
-          notConcerning={ttsNotConcerning}
+        <DurationInfo
+          concerning={concerningTTS}
+          notConcerning={notConcerningTTS}
           expandAllDurationInfo={expandAllDurationInfo}
         />
       )}


### PR DESCRIPTION
Add a ui element that shows up when the test time has changed significantly, along with a basic ui that shows how much the test times have changed.  The hope is that this will help us be more aware of changes in test time/tts.

Notes:
* compares aggregate test time over shards to previous commit, if previous commit does not have available data (see next bullet point) then current commit also says N/A
* "N/A" can mean many things - pending, a shard failed, previous commit failed, previous commit is pending, previous commit doesn't have data
* colors chosen rather randomly - red = increase in test time, green = decrease in test time, I believe that any significant change in test time regardless of direction is important, so colors do not necessary indicate how "good" this change is
* threshold set to changes >= 30 minutes
* no builds because they can be variable due to sscache
* no rocm or macos tests because they are variable, I don't know why
* changed the hud api query to take a per_page parameter