### PR TITLE
Updated Rockset query for Dr. CI comment

### DIFF
--- a/torchci/lib/fetchRecentWorkflows.ts
+++ b/torchci/lib/fetchRecentWorkflows.ts
@@ -4,7 +4,7 @@ import rocksetVersions from "rockset/prodVersions.json";
 import { RecentWorkflowsData } from "./types";
 
 export default async function fetchRecentWorkflows(
-  numMinutes: string = "60"
+  numMinutes: string = "15"
 ): Promise<RecentWorkflowsData[]> {
   const rocksetClient = getRocksetClient();
   const recentWorkflowsQuery = await rocksetClient.queryLambdas.executeQueryLambda(

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -90,14 +90,13 @@ export interface FlakyTestData {
 }
 
 export interface RecentWorkflowsData {
-  name: string;
+  job_name: string;
   conclusion: string;
   completed_at: string;
   html_url: string;
   head_sha: string;
-  number: number;
-  ref: string;
-  login: string;
+  pr_number: number;
+  owner_login: string;
 }
 
 export function packHudParams(input: any) {

--- a/torchci/rockset/commons/__sql/recent_pr_workflows_query.sql
+++ b/torchci/rockset/commons/__sql/recent_pr_workflows_query.sql
@@ -1,22 +1,30 @@
 select
-    w.name,
+	w.name as job_name,
     w.conclusion,
     w.completed_at,
     w.html_url,
     w.head_sha,
-    p.number,
-    p.head.ref,
-    p.user.login
+    p.number as pr_number,
+    p.user.login as owner_login,
 from
-    commons.workflow_job w inner join commons.pull_request p on w.head_sha = p.head.sha   
+	commons.workflow_job w inner join commons.pull_request p on w.head_sha = p.head.sha
 where
-	PARSE_TIMESTAMP_ISO8601(w.completed_at) > (CURRENT_TIMESTAMP() - MINUTES(:numMinutes))
+	w.head_sha in (
+      select
+          w.head_sha
+      from
+      	commons.workflow_job w
+      where 
+      	PARSE_TIMESTAMP_ISO8601(w.completed_at) > (CURRENT_TIMESTAMP() - MINUTES(:numMinutes))
+    )
+    and w.head_sha = p.head.sha 
+    and p.base.repo.full_name = 'pytorch/pytorch'
+    
 group by
-    name,
+	job_name,
     conclusion,
     completed_at,
     html_url,
     head_sha,
-    number,
-    ref,
-    login
+    pr_number,
+    owner_login

--- a/torchci/rockset/commons/recent_pr_workflows_query.lambda.json
+++ b/torchci/rockset/commons/recent_pr_workflows_query.lambda.json
@@ -4,8 +4,8 @@
     {
       "name": "numMinutes",
       "type": "int",
-      "value": "60"
+      "value": "15"
     }
   ],
-  "description": "retrieve the CI check results in the past N minutes"
+  "description": "retrieve the CI check results in the past N minutes, as well as the other workflows from the same PRs that were previously run/pending"
 }

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -7,7 +7,7 @@
     "test_time_per_file": "50cb3694334ed63a",
     "issue_query": "f29a1afe94563601",
     "failure_samples_query": "2961636418a148c2",
-    "recent_pr_workflows_query": "21ef45465dfd2bb0"
+    "recent_pr_workflows_query": "4e03cb13e8372050"
   },
   "pytorch_dev_infra_kpis": {
     "num_reverts": "57e5562a57427ae3",


### PR DESCRIPTION
**Overview**: modified Rockset query [here](https://console.rockset.com/lambdas/details/commons.recent_pr_workflows_query?tab=summary) to include not only the recently completed workflows from the last N minutes, but also all of the previous/pending workflow jobs that correspond to the same commit SHAs and PRs. The previous rockset query would make it difficult to compare how many jobs had already been completed or hadn't been completed. Now that all of the workflow jobs for a SHA are in the same place, this will make it easier to calculate the number of failing and pending workflow jobs for the Dr. CI comment.

**Test Plan**: example output, null for completed_at and conclusion means the workflow is still pending
![Screen Shot 2022-07-13 at 5 40 33 PM](https://user-images.githubusercontent.com/24441980/178841537-ae8e94cf-38a2-4128-97a5-0ee6da84383b.png)

