### PR TITLE
Stub script for adding workflow information to Dr. CI comment

### DIFF
--- a/torchci/lib/bot/drciBot.ts
+++ b/torchci/lib/bot/drciBot.ts
@@ -1,16 +1,6 @@
 import { Context, Probot } from "probot";
 import * as drciUtils from "lib/drciUtils";
 
-// export const drciCommentStart = "<!-- drci-comment-start -->\n";
-// export const officeHoursUrl =
-//   "https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours";
-// export const docsBuildsUrl = "https://docs-preview.pytorch.org/";
-// export const pythonDocsUrl = "/index.html";
-// export const cppDocsUrl = "/cppdocs/index.html";
-// const drciCommentEnd = "\n<!-- drci-comment-end -->";
-// const possibleUsers = ["swang392"];
-// const hudUrl = "https://hud.pytorch.org/pr/";
-
 async function getDrciComment(
   context: Context,
   prNum: number,
@@ -29,16 +19,6 @@ async function getDrciComment(
   }
   return { id: 0, body: "" };
 }
-
-// export function formDrciComment(prNum: number): string {
-//   let body = `## :link: Helpful Links
-// ### :test_tube: See artifacts and rendered test results [here](${hudUrl}${prNum})
-// * :page_facing_up: Preview [Python docs built from this PR](${docsBuildsUrl}${prNum}${pythonDocsUrl})
-// * :page_facing_up: Preview [C++ docs built from this PR](${docsBuildsUrl}${prNum}${cppDocsUrl})
-// * :question: Need help or want to give feedback on the CI? Visit our [office hours](${officeHoursUrl})
-// Note: Links to docs will display an error until the docs builds have been completed.`;
-//   return drciCommentStart + body + drciCommentEnd;
-// }
 
 export default function drciBot(app: Probot): void {
   app.on(

--- a/torchci/lib/bot/drciBot.ts
+++ b/torchci/lib/bot/drciBot.ts
@@ -1,14 +1,15 @@
 import { Context, Probot } from "probot";
+import * as drciUtils from "lib/drciUtils";
 
-export const drciCommentStart = "<!-- drci-comment-start -->\n";
-export const officeHoursUrl =
-  "https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours";
-export const docsBuildsUrl = "https://docs-preview.pytorch.org/";
-export const pythonDocsUrl = "/index.html";
-export const cppDocsUrl = "/cppdocs/index.html";
-const drciCommentEnd = "\n<!-- drci-comment-end -->";
-const possibleUsers = ["swang392"];
-const hudUrl = "https://hud.pytorch.org/pr/";
+// export const drciCommentStart = "<!-- drci-comment-start -->\n";
+// export const officeHoursUrl =
+//   "https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours";
+// export const docsBuildsUrl = "https://docs-preview.pytorch.org/";
+// export const pythonDocsUrl = "/index.html";
+// export const cppDocsUrl = "/cppdocs/index.html";
+// const drciCommentEnd = "\n<!-- drci-comment-end -->";
+// const possibleUsers = ["swang392"];
+// const hudUrl = "https://hud.pytorch.org/pr/";
 
 async function getDrciComment(
   context: Context,
@@ -22,22 +23,22 @@ async function getDrciComment(
     issue_number: prNum,
   });
   for (const comment of commentsRes.data) {
-    if (comment.body!.includes(drciCommentStart)) {
+    if (comment.body!.includes(drciUtils.DRCI_COMMENT_START)) {
       return { id: comment.id, body: comment.body! };
     }
   }
   return { id: 0, body: "" };
 }
 
-export function formDrciComment(prNum: number): string {
-  let body = `## :link: Helpful Links
-### :test_tube: See artifacts and rendered test results [here](${hudUrl}${prNum})
-* :page_facing_up: Preview [Python docs built from this PR](${docsBuildsUrl}${prNum}${pythonDocsUrl})
-* :page_facing_up: Preview [C++ docs built from this PR](${docsBuildsUrl}${prNum}${cppDocsUrl})
-* :question: Need help or want to give feedback on the CI? Visit our [office hours](${officeHoursUrl})
-Note: Links to docs will display an error until the docs builds have been completed.`;
-  return drciCommentStart + body + drciCommentEnd;
-}
+// export function formDrciComment(prNum: number): string {
+//   let body = `## :link: Helpful Links
+// ### :test_tube: See artifacts and rendered test results [here](${hudUrl}${prNum})
+// * :page_facing_up: Preview [Python docs built from this PR](${docsBuildsUrl}${prNum}${pythonDocsUrl})
+// * :page_facing_up: Preview [C++ docs built from this PR](${docsBuildsUrl}${prNum}${cppDocsUrl})
+// * :question: Need help or want to give feedback on the CI? Visit our [office hours](${officeHoursUrl})
+// Note: Links to docs will display an error until the docs builds have been completed.`;
+//   return drciCommentStart + body + drciCommentEnd;
+// }
 
 export default function drciBot(app: Probot): void {
   app.on(
@@ -50,7 +51,7 @@ export default function drciBot(app: Probot): void {
 
       context.log(pr_owner);
 
-      if (!possibleUsers.includes(pr_owner)) {
+      if (!drciUtils.POSSIBLE_USERS.includes(pr_owner)) {
         context.log("did not make a comment");
         return;
       }
@@ -64,7 +65,7 @@ export default function drciBot(app: Probot): void {
       const existingDrciID = existingDrciData.id;
       const existingDrciComment = existingDrciData.body;
 
-      const drciComment = formDrciComment(prNum);
+      const drciComment = drciUtils.formDrciComment(prNum);
 
       if (existingDrciComment === drciComment) {
         return;

--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -1,0 +1,21 @@
+export const NUM_MINUTES = 15;
+export const REPO: string = "pytorch";
+export const DRCI_COMMENT_START = "<!-- drci-comment-start -->\n";
+export const OH_URL =
+  "https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours";
+export const DOCS_URL = "https://docs-preview.pytorch.org/";
+export const PYTHON_DOCS_URL = "/index.html";
+export const CPP_DOCS_URL = "/cppdocs/index.html";
+export const DRCI_COMMENT_END = "\n<!-- drci-comment-end -->";
+export const POSSIBLE_USERS = ["swang392"];
+export const HUD_URL = "https://hud.pytorch.org/pr/";
+
+export function formDrciComment(prNum: number): string {
+    let body = `## :link: Helpful Links
+### :test_tube: See artifacts and rendered test results [here](${HUD_URL}${prNum})
+* :page_facing_up: Preview [Python docs built from this PR](${DOCS_URL}${prNum}${PYTHON_DOCS_URL})
+* :page_facing_up: Preview [C++ docs built from this PR](${DOCS_URL}${prNum}${CPP_DOCS_URL})
+* :question: Need help or want to give feedback on the CI? Visit our [office hours](${OH_URL})
+Note: Links to docs will display an error until the docs builds have been completed.`;
+    return DRCI_COMMENT_START + body + DRCI_COMMENT_END;
+}

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -1,0 +1,92 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getOctokit } from "lib/github";
+import { Octokit } from "octokit";
+import fetchRecentWorkflows from "lib/fetchRecentWorkflows";
+import { RecentWorkflowsData } from "lib/types";
+
+const NUM_MINUTES = 15;
+const repo: string = "pytorch";
+export const drciCommentStart = "<!-- drci-comment-start -->\n";
+export const officeHoursUrl =
+  "https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours";
+export const docsBuildsUrl = "https://docs-preview.pytorch.org/";
+export const pythonDocsUrl = "/index.html";
+export const cppDocsUrl = "/cppdocs/index.html";
+const drciCommentEnd = "\n<!-- drci-comment-end -->";
+const possibleUsers = ["swang392"];
+const hudUrl = "https://hud.pytorch.org/pr/";
+
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<void>
+) {
+    let numMinutes = NUM_MINUTES + "";
+
+    const recentWorkflows: RecentWorkflowsData[] = await fetchRecentWorkflows(
+        numMinutes
+    );
+}
+
+export async function updateCommentWithWorkflow(
+    workflow: RecentWorkflowsData,
+    octokit: Octokit
+): Promise<void> {
+
+    //not sure how to get current pr owner -- for now this works since comments only exist on swang392's PRs
+    const prNum = workflow.pr_number;
+    const owner = workflow.owner_login;
+    const existingDrciData = await getDrciComment(
+        prNum,
+        owner,
+        repo
+      );
+    
+    const existingDrciID = existingDrciData.id;
+    const existingDrciComment = existingDrciData.body;
+    const drciComment = formDrciComment(prNum);
+
+    if (existingDrciID == 0) {
+        return;
+    }
+    if (existingDrciComment == drciComment) {
+        return;
+    }
+    await octokit.rest.issues.updateComment({
+        body: drciComment,
+        owner,
+        repo,
+        comment_id: existingDrciID,
+    });
+}
+
+async function getDrciComment(
+    prNum: number,
+    owner: string,
+    repo: string
+    ): Promise<{ id: number; body: string }> {
+    
+    const octokit = getOctokit(owner, repo);
+    const commentsRes = (await octokit).rest.issues.listComments({
+        owner,
+        repo,
+        issue_number: prNum,
+    });
+    for (const comment of (await commentsRes).data) {
+        if (comment.body!.includes(drciCommentStart)) {
+        return { id: comment.id, body: comment.body! };
+        }
+    }
+    return { id: 0, body: "" };
+}
+
+export function formDrciComment(prNum: number): string {
+    let body = `## :link: Helpful Links
+### :test_tube: See artifacts and rendered test results [here](${hudUrl}${prNum})
+* :page_facing_up: Preview [Python docs built from this PR](${docsBuildsUrl}${prNum}${pythonDocsUrl})
+* :page_facing_up: Preview [C++ docs built from this PR](${docsBuildsUrl}${prNum}${cppDocsUrl})
+* :question: Need help or want to give feedback on the CI? Visit our [office hours](${officeHoursUrl})
+Note: Links to docs will display an error until the docs builds have been completed.`;
+    return drciCommentStart + body + drciCommentEnd;
+  }
+

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -1,4 +1,3 @@
-import type { NextApiRequest, NextApiResponse } from "next";
 import { getOctokit } from "lib/github";
 import { Octokit } from "octokit";
 import fetchRecentWorkflows from "lib/fetchRecentWorkflows";
@@ -8,7 +7,7 @@ const NUM_MINUTES = 15;
 const repo: string = "pytorch";
 export const drciCommentStart = "<!-- drci-comment-start -->\n";
 export const officeHoursUrl =
-  "https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours";
+    "https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours";
 export const docsBuildsUrl = "https://docs-preview.pytorch.org/";
 export const pythonDocsUrl = "/index.html";
 export const cppDocsUrl = "/cppdocs/index.html";
@@ -17,12 +16,8 @@ const possibleUsers = ["swang392"];
 const hudUrl = "https://hud.pytorch.org/pr/";
 
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<void>
-) {
-    let numMinutes = NUM_MINUTES + "";
-
+export async function fetchWorkflows() {
+    const numMinutes = NUM_MINUTES + "";
     const recentWorkflows: RecentWorkflowsData[] = await fetchRecentWorkflows(
         numMinutes
     );
@@ -33,30 +28,30 @@ export async function updateCommentWithWorkflow(
     octokit: Octokit
 ): Promise<void> {
 
-    //not sure how to get current pr owner -- for now this works since comments only exist on swang392's PRs
-    const prNum = workflow.pr_number;
-    const owner = workflow.owner_login;
-    const existingDrciData = await getDrciComment(
-        prNum,
-        owner,
-        repo
-      );
-    
-    const existingDrciID = existingDrciData.id;
-    const existingDrciComment = existingDrciData.body;
-    const drciComment = formDrciComment(prNum);
-
-    if (existingDrciID == 0) {
+    const { pr_number, owner_login } = workflow;
+    if (!possibleUsers.includes(owner_login)) {
+        console.log("did not make a comment");
         return;
     }
-    if (existingDrciComment == drciComment) {
+    const { id, body } = await getDrciComment(
+        pr_number,
+        owner_login,
+        repo
+    );
+
+    const drciComment = formDrciComment(pr_number);
+
+    if (id === 0) {
+        return;
+    }
+    if (body === drciComment) {
         return;
     }
     await octokit.rest.issues.updateComment({
-        body: drciComment,
-        owner,
-        repo,
-        comment_id: existingDrciID,
+        body: body,
+        owner: owner_login,
+        repo: repo,
+        comment_id: id,
     });
 }
 
@@ -64,17 +59,17 @@ async function getDrciComment(
     prNum: number,
     owner: string,
     repo: string
-    ): Promise<{ id: number; body: string }> {
-    
-    const octokit = getOctokit(owner, repo);
-    const commentsRes = (await octokit).rest.issues.listComments({
+): Promise<{ id: number; body: string }> {
+
+    const octokit = await getOctokit(owner, repo);
+    const commentsRes = await octokit.rest.issues.listComments({
         owner,
         repo,
         issue_number: prNum,
     });
-    for (const comment of (await commentsRes).data) {
+    for (const comment of commentsRes.data) {
         if (comment.body!.includes(drciCommentStart)) {
-        return { id: comment.id, body: comment.body! };
+            return { id: comment.id, body: comment.body! };
         }
     }
     return { id: 0, body: "" };
@@ -88,5 +83,5 @@ export function formDrciComment(prNum: number): string {
 * :question: Need help or want to give feedback on the CI? Visit our [office hours](${officeHoursUrl})
 Note: Links to docs will display an error until the docs builds have been completed.`;
     return drciCommentStart + body + drciCommentEnd;
-  }
+}
 

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -4,7 +4,7 @@ import fetchRecentWorkflows from "lib/fetchRecentWorkflows";
 import { RecentWorkflowsData } from "lib/types";
 
 const NUM_MINUTES = 15;
-const repo: string = "pytorch";
+const REPO: string = "pytorch/pytorch";
 export const drciCommentStart = "<!-- drci-comment-start -->\n";
 export const officeHoursUrl =
     "https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours";
@@ -17,9 +17,8 @@ const hudUrl = "https://hud.pytorch.org/pr/";
 
 
 export async function fetchWorkflows() {
-    const numMinutes = NUM_MINUTES + "";
     const recentWorkflows: RecentWorkflowsData[] = await fetchRecentWorkflows(
-        numMinutes
+        NUM_MINUTES + ""
     );
 }
 
@@ -36,7 +35,7 @@ export async function updateCommentWithWorkflow(
     const { id, body } = await getDrciComment(
         pr_number,
         owner_login,
-        repo
+        REPO
     );
 
     const drciComment = formDrciComment(pr_number);
@@ -50,7 +49,7 @@ export async function updateCommentWithWorkflow(
     await octokit.rest.issues.updateComment({
         body: body,
         owner: owner_login,
-        repo: repo,
+        repo: REPO,
         comment_id: id,
     });
 }

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -28,11 +28,11 @@ const recentWorkflowB = {
 describe("Update Dr. CI Bot Integration Tests", () => {
     const octokit = utils.testOctokit();
 
-    beforeEach(() => {});
-  
+    beforeEach(() => { });
+
     afterEach(() => {
-      nock.cleanAll();
-      jest.restoreAllMocks();
+        nock.cleanAll();
+        jest.restoreAllMocks();
     });
 
     test("comment updated when user is swang392", async () => {
@@ -47,23 +47,23 @@ describe("Update Dr. CI Bot Integration Tests", () => {
 describe("Update Dr. CI Bot Unit Tests", () => {
     const octokit = utils.testOctokit();
 
-    beforeEach(() => {});
-  
+    beforeEach(() => { });
+
     afterEach(() => {
-      nock.cleanAll();
-      jest.restoreAllMocks();
+        nock.cleanAll();
+        jest.restoreAllMocks();
     });
 
     test("Check that dr ci comment is correctly formed", async () => {
         const comment = updateDrciBot.formDrciComment(recentWorkflowA.pr_number);
         expect(comment.includes(updateDrciBot.drciCommentStart)).toBeTruthy();
-          expect(
+        expect(
             comment.includes("See artifacts and rendered test results")
-          ).toBeTruthy();
-          expect(
+        ).toBeTruthy();
+        expect(
             comment.includes("Need help or want to give feedback on the CI?")
-          ).toBeTruthy();
-          expect(comment.includes(updateDrciBot.officeHoursUrl)).toBeTruthy();
-          expect(comment.includes(updateDrciBot.docsBuildsUrl)).toBeTruthy();
+        ).toBeTruthy();
+        expect(comment.includes(updateDrciBot.officeHoursUrl)).toBeTruthy();
+        expect(comment.includes(updateDrciBot.docsBuildsUrl)).toBeTruthy();
     });
 });

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -1,6 +1,7 @@
 import nock from "nock";
 import * as utils from "./utils";
 import * as updateDrciBot from "../pages/api/drci/drci";
+import * as drciUtils from "lib/drciUtils";
 
 nock.disableNetConnect();
 
@@ -55,15 +56,15 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     });
 
     test("Check that dr ci comment is correctly formed", async () => {
-        const comment = updateDrciBot.formDrciComment(recentWorkflowA.pr_number);
-        expect(comment.includes(updateDrciBot.drciCommentStart)).toBeTruthy();
+        const comment = drciUtils.formDrciComment(recentWorkflowA.pr_number);
+        expect(comment.includes(drciUtils.DRCI_COMMENT_START)).toBeTruthy();
         expect(
             comment.includes("See artifacts and rendered test results")
         ).toBeTruthy();
         expect(
             comment.includes("Need help or want to give feedback on the CI?")
         ).toBeTruthy();
-        expect(comment.includes(updateDrciBot.officeHoursUrl)).toBeTruthy();
-        expect(comment.includes(updateDrciBot.docsBuildsUrl)).toBeTruthy();
+        expect(comment.includes(drciUtils.OH_URL)).toBeTruthy();
+        expect(comment.includes(drciUtils.DOCS_URL)).toBeTruthy();
     });
 });

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -27,8 +27,6 @@ const recentWorkflowB = {
 
 
 describe("Update Dr. CI Bot Integration Tests", () => {
-    const octokit = utils.testOctokit();
-
     beforeEach(() => { });
 
     afterEach(() => {
@@ -46,8 +44,6 @@ describe("Update Dr. CI Bot Integration Tests", () => {
 });
 
 describe("Update Dr. CI Bot Unit Tests", () => {
-    const octokit = utils.testOctokit();
-
     beforeEach(() => { });
 
     afterEach(() => {

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -1,0 +1,69 @@
+import nock from "nock";
+import * as utils from "./utils";
+import * as updateDrciBot from "../pages/api/drci/drci";
+
+nock.disableNetConnect();
+
+const recentWorkflowA = {
+    job_name: 'linux-docs / build-docs (cpp)',
+    conclusion: "success",
+    completed_at: '2022-07-13T19:34:03Z',
+    html_url: "abcdefg",
+    head_sha: "abcdefg",
+    pr_number: 1000,
+    owner_login: "swang392",
+}
+
+const recentWorkflowB = {
+    job_name: 'linux-docs / build-docs (cpp)',
+    conclusion: "success",
+    completed_at: '2022-07-13T19:34:03Z',
+    html_url: "abcdefg",
+    head_sha: "abcdefg",
+    pr_number: 1000,
+    owner_login: "notswang392",
+}
+
+
+describe("Update Dr. CI Bot Integration Tests", () => {
+    const octokit = utils.testOctokit();
+
+    beforeEach(() => {});
+  
+    afterEach(() => {
+      nock.cleanAll();
+      jest.restoreAllMocks();
+    });
+
+    test("comment updated when user is swang392", async () => {
+
+    });
+
+    test("comment not updated when user is swang392", async () => {
+
+    });
+});
+
+describe("Update Dr. CI Bot Unit Tests", () => {
+    const octokit = utils.testOctokit();
+
+    beforeEach(() => {});
+  
+    afterEach(() => {
+      nock.cleanAll();
+      jest.restoreAllMocks();
+    });
+
+    test("Check that dr ci comment is correctly formed", async () => {
+        const comment = updateDrciBot.formDrciComment(recentWorkflowA.pr_number);
+        expect(comment.includes(updateDrciBot.drciCommentStart)).toBeTruthy();
+          expect(
+            comment.includes("See artifacts and rendered test results")
+          ).toBeTruthy();
+          expect(
+            comment.includes("Need help or want to give feedback on the CI?")
+          ).toBeTruthy();
+          expect(comment.includes(updateDrciBot.officeHoursUrl)).toBeTruthy();
+          expect(comment.includes(updateDrciBot.docsBuildsUrl)).toBeTruthy();
+    });
+});

--- a/torchci/test/drciBot.test.ts
+++ b/torchci/test/drciBot.test.ts
@@ -2,6 +2,7 @@ import { Probot } from "probot";
 import * as utils from "./utils";
 import nock from "nock";
 import myProbotApp, * as botUtils from "../lib/bot/drciBot";
+import * as drciUtils from "lib/drciUtils";
 
 const comment_id = 10;
 const comment_node_id = "abcd";
@@ -39,15 +40,15 @@ describe("verify-drci-functionality", () => {
         "/repos/zhouzhuojie/gha-ci-playground/issues/31/comments",
         (body) => {
           const comment = body.body;
-          expect(comment.includes(botUtils.drciCommentStart)).toBeTruthy();
+          expect(comment.includes(drciUtils.DRCI_COMMENT_START)).toBeTruthy();
           expect(
             comment.includes("See artifacts and rendered test results")
           ).toBeTruthy();
           expect(
             comment.includes("Need help or want to give feedback on the CI?")
           ).toBeTruthy();
-          expect(comment.includes(botUtils.officeHoursUrl)).toBeTruthy();
-          expect(comment.includes(botUtils.docsBuildsUrl)).toBeTruthy();
+          expect(comment.includes(drciUtils.OH_URL)).toBeTruthy();
+          expect(comment.includes(drciUtils.DOCS_URL)).toBeTruthy();
           return true;
         }
       )
@@ -64,7 +65,7 @@ describe("verify-drci-functionality", () => {
     const payload = require("./fixtures/pull_request.opened")["payload"];
     payload["pull_request"]["user"]["login"] = "not_swang392";
 
-    const mock = jest.spyOn(botUtils, "formDrciComment");
+    const mock = jest.spyOn(drciUtils, "formDrciComment");
     mock.mockImplementation();
 
     await probot.receive({ name: "pull_request", payload: payload, id: "2" });
@@ -97,15 +98,15 @@ describe("verify-drci-functionality", () => {
         `/repos/zhouzhuojie/gha-ci-playground/issues/comments/${comment_id}`,
         (body) => {
           const comment = body.body;
-          expect(comment.includes(botUtils.drciCommentStart)).toBeTruthy();
+          expect(comment.includes(drciUtils.DRCI_COMMENT_START)).toBeTruthy();
           expect(
             comment.includes("See artifacts and rendered test results")
           ).toBeTruthy();
           expect(
             comment.includes("Need help or want to give feedback on the CI?")
           ).toBeTruthy();
-          expect(comment.includes(botUtils.officeHoursUrl)).toBeTruthy();
-          expect(comment.includes(botUtils.docsBuildsUrl)).toBeTruthy();
+          expect(comment.includes(drciUtils.OH_URL)).toBeTruthy();
+          expect(comment.includes(drciUtils.DOCS_URL)).toBeTruthy();
           return true;
         }
       )


### PR DESCRIPTION
Overview: Made a stub script for updating the Dr. CI comment with results from the rockset query of recently completed workflows. Implemented method to update comment, but haven't yet implemented the method that will calculate the workflow check results.

Test Plan: haven't implemented it fully yet, but I've thought of some test cases. The current integration tests will only look at the pr owner, since before rolling out the Dr. CI comment I only want to update comments on my PRs.
