### PR TITLE
Require a reason when force merge with -f

### DIFF
--- a/torchci/lib/bot/cliParser.ts
+++ b/torchci/lib/bot/cliParser.ts
@@ -38,19 +38,16 @@ const merge = commands.add_parser("merge", {
   formatter_class: RawTextHelpFormatter,
   add_help: false,
 });
-// It would be nicer if argparse supports necessarily inclusive group, so -m and -f
-// always go together. However, that feature is not supported at the moment AFAIK
-merge.add_argument("-m", "--message", {
-  help: "If you are using force merge, you must provide a clear reason for auditting purpose.",
-});
 const mergeOption = merge.add_mutually_exclusive_group();
 mergeOption.add_argument("-g", "--green", {
   action: "store_true",
   help: "Merge when *all* status checks pass.",
 });
 mergeOption.add_argument("-f", "--force", {
-  action: "store_true",
-  help: "Merge without checking anything. ONLY USE THIS FOR CRITICAL FAILURES.",
+  help:
+    "Merge without checking anything. This requires a reason for auditting purpose, for example:\n" +
+    "`@pytorchbot merge -f '[MINOR] Fix lint. Expecting all PR tests to pass'`\n" +
+    "The reason must be longer than 2 words. ONLY USE THIS FOR CRITICAL FAILURES.",
 });
 mergeOption.add_argument("-l", "--land-checks", {
   action: "store_true",

--- a/torchci/lib/bot/cliParser.ts
+++ b/torchci/lib/bot/cliParser.ts
@@ -38,6 +38,11 @@ const merge = commands.add_parser("merge", {
   formatter_class: RawTextHelpFormatter,
   add_help: false,
 });
+// It would be nicer if argparse supports necessarily inclusive group, so -m and -f
+// always go together. However, that feature is not supported at the moment AFAIK
+merge.add_argument("-m", "--message", {
+  help: "If you are using force merge, you must provide a clear reason for auditting purpose.",
+});
 const mergeOption = merge.add_mutually_exclusive_group();
 mergeOption.add_argument("-g", "--green", {
   action: "store_true",

--- a/torchci/lib/bot/pytorchBot.ts
+++ b/torchci/lib/bot/pytorchBot.ts
@@ -69,7 +69,11 @@ function pytorchBot(app: Probot): void {
       // However, it seems too strict to enforce a fixed set of categories right
       // away without conducting a user study for all common use cases of force
       // merge first. So the message is just a free form text for now
-      return message !== undefined && message && message?.match(forceMergeMessagePat);
+      if (message !== undefined && message && message.match(forceMergeMessagePat)) {
+        return true;
+      }
+
+      return false;
     }
 
     async function handleMerge(

--- a/torchci/lib/bot/pytorchBot.ts
+++ b/torchci/lib/bot/pytorchBot.ts
@@ -73,7 +73,7 @@ function pytorchBot(app: Probot): void {
         await reactOnComment(ctx, "confused");
         await addComment(
           ctx,
-          "You need to provide a clear reason for using force merge, i.e. @pytorchbot merge -f -m 'Minor fixes. Expecting all PR tests to pass'."
+          "You need to provide a reason for using force merge, i.e. `@pytorchbot merge -f -m 'Minor fixes. Expecting all PR tests to pass'.`"
         );
       }
     }

--- a/torchci/lib/bot/pytorchBot.ts
+++ b/torchci/lib/bot/pytorchBot.ts
@@ -70,7 +70,7 @@ function pytorchBot(app: Probot): void {
         await reactOnComment(ctx, "+1");
       }
       else {
-        await reactOnComment(ctx, "eyes");
+        await reactOnComment(ctx, "confused");
         await addComment(
           ctx,
           "You need to provide a clear reason for using force merge, i.e. @pytorchbot merge -f -m 'Minor fixes. Expecting all PR tests to pass'."

--- a/torchci/lib/bot/pytorchBot.ts
+++ b/torchci/lib/bot/pytorchBot.ts
@@ -69,11 +69,8 @@ function pytorchBot(app: Probot): void {
       // However, it seems too strict to enforce a fixed set of categories right
       // away without conducting a user study for all common use cases of force
       // merge first. So the message is just a free form text for now
-      if (message?.match(forceMergeMessagePat)) {
-        return true;
-      }
-
-      return false;
+      const matches = message?.match(forceMergeMessagePat);
+      return matches != undefined && matches.length != 0;
     }
 
     async function handleMerge(
@@ -81,7 +78,7 @@ function pytorchBot(app: Probot): void {
       mergeOnGreen: boolean,
       landChecks: boolean,
     ) {
-      const isForced = forceMessage !== undefined;
+      const isForced = forceMessage != undefined;
       const isValidMessage = isValidForceMergeMessage(forceMessage);
 
       if (!isForced || isValidMessage) {
@@ -92,7 +89,12 @@ function pytorchBot(app: Probot): void {
         await reactOnComment(ctx, "confused");
         await addComment(
           ctx,
-          "You need to provide a reason (>= 2 words) for using force merge, i.e. `@pytorchbot merge -f '[MINOR] Fix lint. Expecting all PR tests to pass'.`"
+          "You need to provide a reason for using force merge, in the format `@pytorchbot merge -f '[CATEGORY] Explanation'`. " +
+          "With [CATEGORY] being one the following:\n" +
+          " EMERGENCY - an emergency fix to quickly address an issue\n" +
+          " MINOR - a minor fix such as cleaning locally unused variables, which shouldn't break anything\n" +
+          " PRE_TESTED - a previous CI run tested everything and you've only added minor changes like fixing lint\n" +
+          " OTHER - something not covered above"
         );
       }
     }

--- a/torchci/lib/bot/pytorchBot.ts
+++ b/torchci/lib/bot/pytorchBot.ts
@@ -69,7 +69,7 @@ function pytorchBot(app: Probot): void {
       // However, it seems too strict to enforce a fixed set of categories right
       // away without conducting a user study for all common use cases of force
       // merge first. So the message is just a free form text for now
-      if (message !== undefined && message && message.match(forceMergeMessagePat)) {
+      if (message?.match(forceMergeMessagePat)) {
         return true;
       }
 

--- a/torchci/test/mergeCommands.test.ts
+++ b/torchci/test/mergeCommands.test.ts
@@ -214,7 +214,7 @@ describe("merge-bot", () => {
       .reply(200, {})
       .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
         expect(JSON.stringify(body)).toContain(
-          "You need to provide a reason (>= 2 words) for using force merge"
+          "You need to provide a reason for using force merge"
         );
         return true;
       })
@@ -244,7 +244,7 @@ describe("merge-bot", () => {
       .reply(200, {})
       .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
         expect(JSON.stringify(body)).toContain(
-          "You need to provide a reason (>= 2 words) for using force merge"
+          "You need to provide a reason for using force merge"
         );
         return true;
       })

--- a/torchci/test/mergeCommands.test.ts
+++ b/torchci/test/mergeCommands.test.ts
@@ -155,7 +155,7 @@ describe("merge-bot", () => {
       .post(
         `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
         (body) => {
-          expect(JSON.stringify(body)).toContain('{"content":"eyes"}');
+          expect(JSON.stringify(body)).toContain('{"content":"confused"}');
           return true;
         }
       )
@@ -185,7 +185,7 @@ describe("merge-bot", () => {
       .post(
         `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
         (body) => {
-          expect(JSON.stringify(body)).toContain('{"content":"eyes"}');
+          expect(JSON.stringify(body)).toContain('{"content":"confused"}');
           return true;
         }
       )

--- a/torchci/test/mergeCommands.test.ts
+++ b/torchci/test/mergeCommands.test.ts
@@ -115,7 +115,37 @@ describe("merge-bot", () => {
   test("merge -f on pull request triggers dispatch and like", async () => {
     const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
-    event.payload.comment.body = "@pytorchbot merge -f -m 'YOLO'";
+    event.payload.comment.body = "@pytorchbot merge -f '[MINOR] Fix lint'";
+
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    const pr_number = event.payload.issue.number;
+    const comment_number = event.payload.comment.id;
+    const scope = nock("https://api.github.com")
+      .post(
+        `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
+        (body) => {
+          expect(JSON.stringify(body)).toContain('{"content":"+1"}');
+          return true;
+        }
+      )
+      .reply(200, {})
+      .post(`/repos/${owner}/${repo}/dispatches`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          `{"event_type":"try-merge","client_payload":{"pr_num":${pr_number},"comment_id":${comment_number},"force":true}}`
+        );
+        return true;
+      })
+      .reply(200, {});
+
+    await probot.receive(event);
+    handleScope(scope);
+  });
+
+  test("merge -f with a minimal acceptable message (2 words)", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
+
+    event.payload.comment.body = "@pytorchbot merge -f 'Fix lint'";
 
     const owner = event.payload.repository.owner.login;
     const repo = event.payload.repository.name;
@@ -152,17 +182,9 @@ describe("merge-bot", () => {
     const pr_number = event.payload.issue.number;
     const comment_number = event.payload.comment.id;
     const scope = nock("https://api.github.com")
-      .post(
-        `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
-        (body) => {
-          expect(JSON.stringify(body)).toContain('{"content":"confused"}');
-          return true;
-        }
-      )
-      .reply(200, {})
       .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
         expect(JSON.stringify(body)).toContain(
-          "You need to provide a clear reason for using force merge"
+          "@pytorchbot merge: error: argument -f/--force: expected one argument"
         );
         return true;
       })
@@ -175,7 +197,7 @@ describe("merge-bot", () => {
   test("reject merge -f with an empty reason", async () => {
     const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
-    event.payload.comment.body = "@pytorchbot merge -f -m ''";
+    event.payload.comment.body = "@pytorchbot merge -f ''";
 
     const owner = event.payload.repository.owner.login;
     const repo = event.payload.repository.name;
@@ -192,7 +214,37 @@ describe("merge-bot", () => {
       .reply(200, {})
       .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
         expect(JSON.stringify(body)).toContain(
-          "You need to provide a clear reason for using force merge"
+          "You need to provide a reason (>= 2 words) for using force merge"
+        );
+        return true;
+      })
+      .reply(200, {});
+
+    await probot.receive(event);
+    handleScope(scope);
+  });
+
+  test("reject merge -f with a too short reason (< 2 words)", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
+
+    event.payload.comment.body = "@pytorchbot merge -f 'YOLO'";
+
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    const pr_number = event.payload.issue.number;
+    const comment_number = event.payload.comment.id;
+    const scope = nock("https://api.github.com")
+      .post(
+        `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
+        (body) => {
+          expect(JSON.stringify(body)).toContain('{"content":"confused"}');
+          return true;
+        }
+      )
+      .reply(200, {})
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          "You need to provide a reason (>= 2 words) for using force merge"
         );
         return true;
       })
@@ -427,7 +479,7 @@ describe("merge-bot", () => {
   test("merge fail because mutually exclusive options", async () => {
     const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
-    event.payload.comment.body = "@pytorchbot merge -g -f";
+    event.payload.comment.body = "@pytorchbot merge -g -f '[MINOR] Fix lint'";
 
     const owner = event.payload.repository.owner.login;
     const repo = event.payload.repository.name;
@@ -437,6 +489,29 @@ describe("merge-bot", () => {
       .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
         expect(JSON.stringify(body)).toContain(
           "@pytorchbot merge: error: argument -f/--force: not allowed with argument -g/--green"
+        );
+        return true;
+      })
+      .reply(200);
+
+    await probot.receive(event);
+
+    handleScope(scope);
+  });
+
+  test("merge fail because mutually exclusive options without force merge reason", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
+
+    event.payload.comment.body = "@pytorchbot merge -g -f";
+
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    const pr_number = event.payload.issue.number;
+
+    const scope = nock("https://api.github.com")
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          "@pytorchbot merge: error: argument -f/--force: expected one argument"
         );
         return true;
       })
@@ -682,7 +757,7 @@ some other text lol
   test("force merge using CLI", async () => {
     const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
-    event.payload.comment.body = "@pytorchbot merge -f -m 'YOLO'";
+    event.payload.comment.body = "@pytorchbot merge -f '[MINOR] Fix lint'";
 
     const owner = event.payload.repository.owner.login;
     const repo = event.payload.repository.name;


### PR DESCRIPTION
For example `@pytorchbot merge -f -m 'Flaky tests'`. Without a message, a `confused` emoji and the following message will be posted.

```
You need to provide a clear reason for using force merge, i.e. @pytorchbot merge -f -m 'Minor fixes. Expecting all PR tests to pass'
```

On the other hand, `@pytorchbot merge -f` will soon be recorded in dynamoDB/Rockset by https://github.com/pytorch/test-infra/pull/461. We will be able to easily audit the usage of merge -f querying the new `issue_comment` collection

### Testing
`npm run test -- test/mergeCommands.test.ts`

### Issue
https://github.com/pytorch/test-infra/issues/409