### PR TITLE
Small fix for Dr. CI script's comment updating process

### DIFF
--- a/torchci/lib/bot/drciBot.ts
+++ b/torchci/lib/bot/drciBot.ts
@@ -44,8 +44,8 @@ export default function drciBot(app: Probot): void {
       );
       const existingDrciID = existingDrciData.id;
       const existingDrciComment = existingDrciData.body;
-
-      const drciComment = drciUtils.formDrciHeader(prNum) + drciUtils.DRCI_COMMENT_END;
+      
+      const drciComment = drciUtils.formDrciComment(prNum, "");
 
       if (existingDrciComment === drciComment) {
         return;

--- a/torchci/lib/bot/drciBot.ts
+++ b/torchci/lib/bot/drciBot.ts
@@ -45,7 +45,7 @@ export default function drciBot(app: Probot): void {
       const existingDrciID = existingDrciData.id;
       const existingDrciComment = existingDrciData.body;
       
-      const drciComment = drciUtils.formDrciComment(prNum, "");
+      const drciComment = drciUtils.formDrciComment(prNum);
 
       if (existingDrciComment === drciComment) {
         return;

--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -23,7 +23,7 @@ Note: Links to docs will display an error until the docs builds have been comple
 
 export function formDrciComment(
     pr_num: number, 
-    pr_results: string,
+    pr_results?: string,
 ): string {
     const header = formDrciHeader(pr_num);
     return DRCI_COMMENT_START + header + pr_results + DRCI_COMMENT_END;

--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -13,11 +13,19 @@ export const POSSIBLE_USERS = ["swang392"];
 export const HUD_URL = "https://hud.pytorch.org/pr/";
 
 export function formDrciHeader(prNum: number): string {
-    var body = `## :link: Helpful Links
+    let body = `## :link: Helpful Links
 ### :test_tube: See artifacts and rendered test results [here](${HUD_URL}${prNum})
 * :page_facing_up: Preview [Python docs built from this PR](${DOCS_URL}${prNum}${PYTHON_DOCS_URL})
 * :page_facing_up: Preview [C++ docs built from this PR](${DOCS_URL}${prNum}${CPP_DOCS_URL})
 * :question: Need help or want to give feedback on the CI? Visit our [office hours](${OH_URL})
 Note: Links to docs will display an error until the docs builds have been completed.`;
-    return DRCI_COMMENT_START + body;
+    return body;
+}
+
+export function formDrciComment(
+    pr_num: number, 
+    pr_results: string,
+): string {
+    const header = formDrciHeader(pr_num);
+    return DRCI_COMMENT_START + header + pr_results + DRCI_COMMENT_END;
 }

--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -13,13 +13,12 @@ export const POSSIBLE_USERS = ["swang392"];
 export const HUD_URL = "https://hud.pytorch.org/pr/";
 
 export function formDrciHeader(prNum: number): string {
-    let body = `## :link: Helpful Links
+    return `## :link: Helpful Links
 ### :test_tube: See artifacts and rendered test results [here](${HUD_URL}${prNum})
 * :page_facing_up: Preview [Python docs built from this PR](${DOCS_URL}${prNum}${PYTHON_DOCS_URL})
 * :page_facing_up: Preview [C++ docs built from this PR](${DOCS_URL}${prNum}${CPP_DOCS_URL})
 * :question: Need help or want to give feedback on the CI? Visit our [office hours](${OH_URL})
 Note: Links to docs will display an error until the docs builds have been completed.`;
-    return body;
 }
 
 export function formDrciComment(

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -131,10 +131,7 @@ export async function updateCommentWithWorkflow(
         REPO
     );
 
-    if (id === 0) {
-        return;
-    }
-    if (body === comment) {
+    if (id === 0 || body === comment) {
         return;
     }
 

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -3,7 +3,7 @@ import { getOctokit } from "lib/github";
 import { Octokit } from "octokit";
 import fetchRecentWorkflows from "lib/fetchRecentWorkflows";
 import { RecentWorkflowsData } from "lib/types";
-import { NUM_MINUTES, POSSIBLE_USERS, REPO, DRCI_COMMENT_END, formDrciHeader } from "lib/drciUtils";
+import { NUM_MINUTES, POSSIBLE_USERS, REPO, DRCI_COMMENT_END, formDrciComment } from "lib/drciUtils";
 
 interface PRandJobs {
     head_sha: string;
@@ -35,9 +35,9 @@ export async function fetchWorkflows() {
         const { pending, failedJobs } = getWorkflowAnalysis(pr_info);
 
         const failureInfo = constructFailureAnalysis(pending, failedJobs, pr_info.head_sha);
-        const comment = formDrciHeader(pr_number) + failureInfo + DRCI_COMMENT_END;
+        const comment = formDrciComment(pr_number, failureInfo);
 
-        updateCommentWithWorkflow(pr_info, comment);
+        await updateCommentWithWorkflow(pr_info, comment);
     }
 }
 
@@ -140,7 +140,7 @@ export async function updateCommentWithWorkflow(
 
     const octokit = await getOctokit(owner_login, REPO);
     await octokit.rest.issues.updateComment({
-        body: body,
+        body: comment,
         owner: owner_login!,
         repo: REPO,
         comment_id: id,

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -121,7 +121,7 @@ export async function updateCommentWithWorkflow(
     comment: string,
 ): Promise<void> {
     const { pr_number, owner_login } = pr_info;
-    if (!POSSIBLE_USERS.includes(owner_login!) || pr_number != 80896) {
+    if (!POSSIBLE_USERS.includes(owner_login!) && pr_number != 80896) {
         console.log("did not make a comment");
         return;
     }

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -1,7 +1,7 @@
 import nock from "nock";
 import * as utils from "./utils";
 import * as updateDrciBot from "../pages/api/drci/drci";
-import { OH_URL, DOCS_URL, DRCI_COMMENT_START, formDrciHeader } from "lib/drciUtils";
+import { OH_URL, DOCS_URL, DRCI_COMMENT_START, formDrciComment } from "lib/drciUtils";
 
 nock.disableNetConnect();
 
@@ -94,7 +94,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     });
 
     test("Check that dr ci comment is correctly formed", async () => {
-        const comment = formDrciHeader(recentWorkflowA.pr_number);
+        const comment = formDrciComment(recentWorkflowA.pr_number, "");
         expect(comment.includes(DRCI_COMMENT_START)).toBeTruthy();
         expect(
             comment.includes("See artifacts and rendered test results")

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -94,7 +94,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     });
 
     test("Check that dr ci comment is correctly formed", async () => {
-        const comment = formDrciComment(recentWorkflowA.pr_number, "");
+        const comment = formDrciComment(recentWorkflowA.pr_number);
         expect(comment.includes(DRCI_COMMENT_START)).toBeTruthy();
         expect(
             comment.includes("See artifacts and rendered test results")


### PR DESCRIPTION
**Overview:** I forgot to change the `body` parameter from the original comment (without failure info) to the update done. I also modified the comment formation process by splitting it up into the methods `formDrciHeader` and `formDrciComment`

**Test Plan:** the current GHA correctly identifies and updates my PR, but the comment body was not the correct one with pr workflow results. 