### PR TITLE
new classification rule for pytest failures

### DIFF
--- a/torchci/pages/api/classifier/rules.ts
+++ b/torchci/pages/api/classifier/rules.ts
@@ -105,6 +105,11 @@ export default async function handler(
         priority: 997,
       },
       {
+        name: "Python pytest failure",
+        pattern: r`^FAILED test_\[:\w\.\]*`,
+        priority: 997,
+      },
+      {
         name: "failed to download github artifacts",
         pattern: r`List Artifacts failed:.*`,
         priority: 997,


### PR DESCRIPTION
add new classification rule for pytest failures now that pytest is run in CI

The rule should match things of the form:
`FAILED test_ops.py::TestTagsCPU::test_tags__refs_constant_pad_nd_cpu_float32`
where `FAILED` is at the beginning of the line.

Tested via `rules.json` as stated in the README, but because json requires a few changes for the regex, testing might not have been sufficient. 