### PR TITLE
update rockset query version for `unclassified`

### DIFF
--- a/torchci/log_classifier/backfill.py
+++ b/torchci/log_classifier/backfill.py
@@ -34,7 +34,7 @@ def do_backfill(n):
         api_server="https://api.rs2.usw2.rockset.com",
     )
     qlambda = client.QueryLambda.retrieve(
-        "unclassified", version="d39e66c0ed0aa238", workspace="commons"
+        "unclassified", version="672227495ac70f7d", workspace="commons"
     )
 
     params = ParamDict()


### PR DESCRIPTION
Previous version was old, updated the rockset query and put the new version in the python file.  

Tested by running `torchci/log_classifier/backfill.py` and checking that there were no more errors