### PR TITLE
fix pytest classification regex

### DIFF
--- a/torchci/pages/api/classifier/rules.ts
+++ b/torchci/pages/api/classifier/rules.ts
@@ -106,7 +106,7 @@ export default async function handler(
       },
       {
         name: "Python pytest failure",
-        pattern: r`^FAILED test_\[:\w\.\]*`,
+        pattern: r`^FAILED test.*`,
         priority: 997,
       },
       {


### PR DESCRIPTION
The regex actually needs to be broader than i thought it did

It should match things like 
`FAILED test_ops.py::TestCommonCPU::test_dtypes_H_cpu - assert 1 == 2`
`FAILED test/test_ops.py::TestOperatorsCUDA::test_vmap_autograd_grad___rmatmul___cuda_float32`
`FAILED test_ops.py::TestTagsCPU::test_tags__refs_constant_pad_nd_cpu_float32`
 