### PR TITLE
Land Check Rollout 1

### DIFF
--- a/torchci/lib/bot/rolloutUtils.ts
+++ b/torchci/lib/bot/rolloutUtils.ts
@@ -1,0 +1,21 @@
+const landCheckPilotGroup = new Set([
+  "landchecktestuser",
+  "zengk95",
+  "atalman",
+  "clee2000",
+  "huydhn",
+  "izaitsevfb",
+  "mehtanirav",
+  "weiwangmeta",
+  "ZainRizvi",
+  "janeyx99",
+  "DanilBaibak",
+  "jeanschmidt",
+  "osalpekar",
+  "malfet",
+  "kit1980",
+]);
+
+export function isInLandCheckAllowlist(username: string) {
+  return landCheckPilotGroup.has(username);
+}


### PR DESCRIPTION
We are enrolling everyone in Dev Infra into the land checks. If you need to land something immediately or don't want to wait, then use -f or if you want to get the old behavior, use -g. 

Test Plan:
Check that tests for the allowlist still works. 