### PR TITLE
jump to stack traces for pytest failures

### DIFF
--- a/torchci/pages/api/classifier/rules.ts
+++ b/torchci/pages/api/classifier/rules.ts
@@ -106,7 +106,7 @@ export default async function handler(
       },
       {
         name: "Python pytest failure",
-        pattern: r`^FAILED test.*`,
+        pattern: r`=== FAILURES ===`,
         priority: 997,
       },
       {


### PR DESCRIPTION
Change classification for pytest so that it jumps to the `===== FAILURES ======` line which is where the stack traces are located