### PR TITLE
backfill script check for steps 

### DIFF
--- a/torchci/scripts/backfillJobs.mjs
+++ b/torchci/scripts/backfillJobs.mjs
@@ -143,6 +143,9 @@ ids = queuedJobs.results.map((r) => r.id);
 
 // See above for why we're awaiting in a loop.
 for (const id of ids) {
-  await backfillWorkflowJob(id, (job) => job.status === "queued");
+  await backfillWorkflowJob(
+    id,
+    (job) => job.status === "queued" && job.steps.length === 0
+  );
 }
 console.log("::endgroup::");


### PR DESCRIPTION
Sometimes github's api is broken and doesn't update some fields so we think that a job is still queued even though it has run already, so I add a check that the steps array is empty.  If the steps array is not empty, then the job has actually started and is no longer queued.