### PR TITLE
Dr. CI Modifications -- collapse and sort failures

### DIFF
--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -19,6 +19,7 @@ export function formDrciHeader(prNum: number): string {
 * :page_facing_up: Preview [Python docs built from this PR](${DOCS_URL}${prNum}${PYTHON_DOCS_URL})
 * :page_facing_up: Preview [C++ docs built from this PR](${DOCS_URL}${prNum}${CPP_DOCS_URL})
 * :question: Need help or want to give feedback on the CI? Visit our [office hours](${OH_URL})
+
 Note: Links to docs will display an error until the docs builds have been completed.`;
 }
 

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -69,7 +69,7 @@ export function constructResultsComment(
             output += somePending;
         }
         output += `\nAs of commit ${sha}:`;
-        output += '\n<details><summary>The following jobs have failed:</summary><p>\n\n';
+        output += '\n<details open><summary>The following jobs have failed:</summary><p>\n\n';
         const failedJobsSorted = failedJobs.sort((a, b) => a.job_name.localeCompare(b.job_name))
         for (const job of failedJobsSorted) {
             output += `* [${job.job_name}](${job.html_url})\n`;

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -69,10 +69,11 @@ export function constructResultsComment(
             output += somePending;
         }
         output += `\nAs of commit ${sha}:`;
-        output += '\nThe following jobs have failed:\n';
+        output += '\n<details><summary>The following jobs have failed:</summary><p>\n';
         for (const job of failedJobs) {
             output += `* [${job.job_name}](${job.html_url})\n`;
         }
+        output += "</p></details>"
     }
     return output;
 }

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -69,7 +69,7 @@ export function constructResultsComment(
             output += somePending;
         }
         output += `\nAs of commit ${sha}:`;
-        output += '\n<details><summary>The following jobs have failed:</summary><p>\n';
+        output += '\n<details><summary>The following jobs have failed:</summary><p>\n\n';
         for (const job of failedJobs) {
             output += `* [${job.job_name}](${job.html_url})\n`;
         }

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -70,7 +70,8 @@ export function constructResultsComment(
         }
         output += `\nAs of commit ${sha}:`;
         output += '\n<details><summary>The following jobs have failed:</summary><p>\n\n';
-        for (const job of failedJobs) {
+        const failedJobsSorted = failedJobs.sort((a, b) => a.job_name.localeCompare(b.job_name))
+        for (const job of failedJobsSorted) {
             output += `* [${job.job_name}](${job.html_url})\n`;
         }
         output += "</p></details>"

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -26,20 +26,20 @@ const recentWorkflowB = {
 }
 
 const recentWorkflowC = {
-    job_name: 'Lint / lintrunner (pull_request)',
+    job_name: 'Lint',
     conclusion: "failure",
     completed_at: '2022-07-13T19:34:03Z',
-    html_url: "abcdefg",
+    html_url: "a",
     head_sha: "abcdefg",
     pr_number: 1001,
     owner_login: "notswang392",
 }
 
 const recentWorkflowD = {
-    job_name: 'something-docs / build-docs (cpp)',
+    job_name: 'something',
     conclusion: "failure",
     completed_at: '2022-07-13T19:34:03Z',
-    html_url: "abcdefg",
+    html_url: "a",
     head_sha: "abcdefg",
     pr_number: 1001,
     owner_login: "notswang392",
@@ -49,7 +49,7 @@ const recentWorkflowE = {
     job_name: 'z-docs / build-docs (cpp)',
     conclusion: "failure",
     completed_at: '2022-07-13T19:34:03Z',
-    html_url: "abcdefg",
+    html_url: "a",
     head_sha: "abcdefg",
     pr_number: 1001,
     owner_login: "notswang392",
@@ -90,6 +90,11 @@ describe("Update Dr. CI Bot Unit Tests", () => {
 
         expect(failureInfo.includes("3 Failures, 1 Pending")).toBeTruthy();
         expect(failureInfo.includes(failedJobName)).toBeTruthy();
+        const expectedFailureOrder = `* [Lint](a)
+* [something](a)
+* [z-docs / build-docs (cpp)](a)`;
+        expect(failureInfo.includes(expectedFailureOrder)).toBeTruthy();
+        console.log(failureInfo);
     });
 
     test("Check that reorganizeWorkflows works correctly", async () => {

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -35,6 +35,26 @@ const recentWorkflowC = {
     owner_login: "notswang392",
 }
 
+const recentWorkflowD = {
+    job_name: 'something-docs / build-docs (cpp)',
+    conclusion: "failure",
+    completed_at: '2022-07-13T19:34:03Z',
+    html_url: "abcdefg",
+    head_sha: "abcdefg",
+    pr_number: 1001,
+    owner_login: "notswang392",
+}
+
+const recentWorkflowE = {
+    job_name: 'z-docs / build-docs (cpp)',
+    conclusion: "failure",
+    completed_at: '2022-07-13T19:34:03Z',
+    html_url: "abcdefg",
+    head_sha: "abcdefg",
+    pr_number: 1001,
+    owner_login: "notswang392",
+}
+
 describe("Update Dr. CI Bot Integration Tests", () => {
     beforeEach(() => { });
 
@@ -61,14 +81,14 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     });
 
     test("Check that constructFailureAnalysis works correctly", async () => {
-        const originalWorkflows = [recentWorkflowA, recentWorkflowB, recentWorkflowC];
+        const originalWorkflows = [recentWorkflowA, recentWorkflowB, recentWorkflowD, recentWorkflowC, recentWorkflowE];
         const workflowsByPR = updateDrciBot.reorganizeWorkflows(originalWorkflows);
         const pr_1001 = workflowsByPR.get(1001)!;
         const { pending, failedJobs } = updateDrciBot.getWorkflowJobsStatuses(pr_1001);
         const failureInfo = updateDrciBot.constructResultsComment(pending, failedJobs, pr_1001.head_sha);
         const failedJobName = recentWorkflowC.job_name;
 
-        expect(failureInfo.includes("1 Failures, 1 Pending")).toBeTruthy();
+        expect(failureInfo.includes("3 Failures, 1 Pending")).toBeTruthy();
         expect(failureInfo.includes(failedJobName)).toBeTruthy();
     });
 


### PR DESCRIPTION
**Overview**:  Added modifications to Dr. CI comment following the DevX sync. Put bullet list of failures into a collapsible section (which defaults to be opened), and also added alphabetical sorting for the failure names. 

**Example Output:**
![Screen Shot 2022-07-27 at 4 03 42 PM](https://user-images.githubusercontent.com/24441980/181361957-30b4a8e4-d0e6-4b21-9074-9828ab3002f8.png)

**Test Plan**: Updated test cases to check that the order of failures are in alphabetical order. 
