### PR TITLE
Tts percentiles per job

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -577,17 +577,17 @@ export default function Page() {
         <Grid item xs={6} height={ROW_HEIGHT}>
           <TTSPanel
             title={"Job time-to-signal, all branches"}
-            queryName={"tts_avg"}
+            queryName={"tts_percentile"}
             queryParams={timeParams}
             metricName={"tts_sec"}
-            metricHeaderName={"Time-to-signal"}
+            metricHeaderName={"p50"}
           />
         </Grid>
 
         <Grid item xs={6} height={ROW_HEIGHT}>
           <TTSPanel
             title={"Job time-to-signal, master-only"}
-            queryName={"tts_avg"}
+            queryName={"tts_percentile"}
             queryParams={[
               ...timeParams,
               {
@@ -595,26 +595,31 @@ export default function Page() {
                 type: "string",
                 value: "master",
               },
+              {
+                name: "percentile",
+                type: "float",
+                value: 0.5,
+              },
             ]}
             metricName={"tts_sec"}
-            metricHeaderName={"Time-to-signal"}
+            metricHeaderName={"p50"}
           />
         </Grid>
 
         <Grid item xs={6} height={ROW_HEIGHT}>
           <TTSPanel
             title={"Job duration, all branches"}
-            queryName={"job_duration_avg"}
+            queryName={"job_duration_percentile"}
             queryParams={timeParams}
             metricName={"duration_sec"}
-            metricHeaderName={"Duration"}
+            metricHeaderName={"p50"}
           />
         </Grid>
 
         <Grid item xs={6} height={ROW_HEIGHT}>
           <TTSPanel
             title={"Job duration, master-only"}
-            queryName={"job_duration_avg"}
+            queryName={"job_duration_percentile"}
             queryParams={[
               ...timeParams,
               {
@@ -622,9 +627,14 @@ export default function Page() {
                 type: "string",
                 value: "master",
               },
+              {
+                name: "percentile",
+                type: "float",
+                value: 0.5,
+              },
             ]}
             metricName={"duration_sec"}
-            metricHeaderName={"Duration"}
+            metricHeaderName={"p50"}
           />
         </Grid>
       </Grid>

--- a/torchci/rockset/metrics/__sql/job_duration_percentile.sql
+++ b/torchci/rockset/metrics/__sql/job_duration_percentile.sql
@@ -1,0 +1,37 @@
+SELECT
+	max(duration_sec) AS duration_sec,
+    COUNT(name) AS count,
+	name
+FROM (
+    SELECT
+  		duration_sec,
+    	name,
+        PERCENT_RANK() OVER (PARTITION BY name ORDER BY duration_sec DESC) AS percentile
+    FROM (
+    	SELECT
+        	DATE_DIFF(
+        		'second',
+            	PARSE_TIMESTAMP_ISO8601(job.started_at),
+            	PARSE_TIMESTAMP_ISO8601(job.completed_at)
+            ) AS duration_sec,
+        	CONCAT(workflow.name, ' / ', job.name) as name
+    	FROM
+        	commons.workflow_job job
+        	JOIN commons.workflow_run workflow on workflow.id = job.run_id
+    	WHERE
+        	job.name != 'ciflow_should_run'
+        	AND job.name != 'generate-test-matrix'
+      		AND job.name != 'get_workflow_conclusion'
+        	AND workflow.repository.full_name = 'pytorch/pytorch'
+        	AND job._event_time >= PARSE_DATETIME_ISO8601(:startTime)
+        	AND job._event_time < PARSE_DATETIME_ISO8601(:stopTime)
+        	AND job.conclusion = 'success'
+        	AND workflow.head_branch LIKE :branch
+    ) AS duration
+) AS p
+WHERE
+	(SELECT NOT IS_NAN(p.percentile) AND p.percentile >= (1.0 - :percentile))
+GROUP BY
+	name
+ORDER BY
+	COUNT(name) * MAX(duration_sec) DESC

--- a/torchci/rockset/metrics/__sql/job_duration_percentile.sql
+++ b/torchci/rockset/metrics/__sql/job_duration_percentile.sql
@@ -35,4 +35,3 @@ GROUP BY
     name
 ORDER BY
     COUNT(name) * MAX(duration_sec) DESC
-

--- a/torchci/rockset/metrics/__sql/job_duration_percentile.sql
+++ b/torchci/rockset/metrics/__sql/job_duration_percentile.sql
@@ -1,37 +1,37 @@
 SELECT
-	max(duration_sec) AS duration_sec,
+    max(duration_sec) AS duration_sec,
     COUNT(name) AS count,
-	name
+    name
 FROM (
     SELECT
-  		duration_sec,
-    	name,
+        duration_sec,
+        name,
         PERCENT_RANK() OVER (PARTITION BY name ORDER BY duration_sec DESC) AS percentile
     FROM (
-    	SELECT
-        	DATE_DIFF(
-        		'second',
-            	PARSE_TIMESTAMP_ISO8601(job.started_at),
-            	PARSE_TIMESTAMP_ISO8601(job.completed_at)
+        SELECT
+            DATE_DIFF(
+                'second',
+                PARSE_TIMESTAMP_ISO8601(job.started_at),
+                PARSE_TIMESTAMP_ISO8601(job.completed_at)
             ) AS duration_sec,
-        	CONCAT(workflow.name, ' / ', job.name) as name
-    	FROM
-        	commons.workflow_job job
-        	JOIN commons.workflow_run workflow on workflow.id = job.run_id
-    	WHERE
-        	job.name != 'ciflow_should_run'
-        	AND job.name != 'generate-test-matrix'
-      		AND job.name != 'get_workflow_conclusion'
-        	AND workflow.repository.full_name = 'pytorch/pytorch'
-        	AND job._event_time >= PARSE_DATETIME_ISO8601(:startTime)
-        	AND job._event_time < PARSE_DATETIME_ISO8601(:stopTime)
-        	AND job.conclusion = 'success'
-        	AND workflow.head_branch LIKE :branch
+            CONCAT(workflow.name, ' / ', job.name) as name
+        FROM
+            commons.workflow_job job
+            JOIN commons.workflow_run workflow on workflow.id = job.run_id
+        WHERE
+            job.name != 'ciflow_should_run'
+            AND job.name != 'generate-test-matrix'
+            AND job.name != 'get_workflow_conclusion'
+            AND workflow.repository.full_name = 'pytorch/pytorch'
+            AND job._event_time >= PARSE_DATETIME_ISO8601(:startTime)
+            AND job._event_time < PARSE_DATETIME_ISO8601(:stopTime)
+            AND job.conclusion = 'success'
+            AND workflow.head_branch LIKE :branch
     ) AS duration
 ) AS p
 WHERE
-	(SELECT NOT IS_NAN(p.percentile) AND p.percentile >= (1.0 - :percentile))
+    (SELECT NOT IS_NAN(p.percentile) AND p.percentile >= (1.0 - :percentile))
 GROUP BY
-	name
+    name
 ORDER BY
-	COUNT(name) * MAX(duration_sec) DESC
+    COUNT(name) * MAX(duration_sec) DESC

--- a/torchci/rockset/metrics/__sql/job_duration_percentile.sql
+++ b/torchci/rockset/metrics/__sql/job_duration_percentile.sql
@@ -35,3 +35,4 @@ GROUP BY
     name
 ORDER BY
     COUNT(name) * MAX(duration_sec) DESC
+

--- a/torchci/rockset/metrics/__sql/tts_percentile.sql
+++ b/torchci/rockset/metrics/__sql/tts_percentile.sql
@@ -1,0 +1,37 @@
+SELECT
+	max(tts_sec) AS tts_sec,
+    COUNT(name) AS count,
+	name
+FROM (
+    SELECT
+  		tts_sec,
+    	name,
+        PERCENT_RANK() OVER (PARTITION BY name ORDER BY tts_sec DESC) AS percentile
+    FROM (
+    	SELECT
+        	DATE_DIFF(
+        		'second',
+            	PARSE_TIMESTAMP_ISO8601(workflow.created_at),
+            	PARSE_TIMESTAMP_ISO8601(job.completed_at)
+            ) AS tts_sec,
+        	CONCAT(workflow.name, ' / ', job.name) as name
+    	FROM
+        	commons.workflow_job job
+        	JOIN commons.workflow_run workflow on workflow.id = job.run_id
+    	WHERE
+        	job.name != 'ciflow_should_run'
+        	AND job.name != 'generate-test-matrix'
+      		AND job.name != 'get_workflow_conclusion'
+        	AND workflow.repository.full_name = 'pytorch/pytorch'
+        	AND job._event_time >= PARSE_DATETIME_ISO8601(:startTime)
+        	AND job._event_time < PARSE_DATETIME_ISO8601(:stopTime)
+        	AND job.conclusion = 'success'
+        	AND workflow.head_branch LIKE :branch
+    ) AS tts
+) AS p
+WHERE
+	(SELECT NOT IS_NAN(p.percentile) AND p.percentile >= (1.0 - :percentile))
+GROUP BY
+	name
+ORDER BY
+	COUNT(name) * MAX(tts_sec) DESC

--- a/torchci/rockset/metrics/__sql/tts_percentile.sql
+++ b/torchci/rockset/metrics/__sql/tts_percentile.sql
@@ -1,37 +1,37 @@
 SELECT
-	max(tts_sec) AS tts_sec,
+    max(tts_sec) AS tts_sec,
     COUNT(name) AS count,
-	name
+    name
 FROM (
     SELECT
-  		tts_sec,
-    	name,
+        tts_sec,
+        name,
         PERCENT_RANK() OVER (PARTITION BY name ORDER BY tts_sec DESC) AS percentile
     FROM (
-    	SELECT
-        	DATE_DIFF(
-        		'second',
-            	PARSE_TIMESTAMP_ISO8601(workflow.created_at),
-            	PARSE_TIMESTAMP_ISO8601(job.completed_at)
+        SELECT
+            DATE_DIFF(
+                'second',
+                PARSE_TIMESTAMP_ISO8601(workflow.created_at),
+                PARSE_TIMESTAMP_ISO8601(job.completed_at)
             ) AS tts_sec,
-        	CONCAT(workflow.name, ' / ', job.name) as name
-    	FROM
-        	commons.workflow_job job
-        	JOIN commons.workflow_run workflow on workflow.id = job.run_id
-    	WHERE
-        	job.name != 'ciflow_should_run'
-        	AND job.name != 'generate-test-matrix'
-      		AND job.name != 'get_workflow_conclusion'
-        	AND workflow.repository.full_name = 'pytorch/pytorch'
-        	AND job._event_time >= PARSE_DATETIME_ISO8601(:startTime)
-        	AND job._event_time < PARSE_DATETIME_ISO8601(:stopTime)
-        	AND job.conclusion = 'success'
-        	AND workflow.head_branch LIKE :branch
+            CONCAT(workflow.name, ' / ', job.name) as name
+        FROM
+            commons.workflow_job job
+            JOIN commons.workflow_run workflow on workflow.id = job.run_id
+        WHERE
+            job.name != 'ciflow_should_run'
+            AND job.name != 'generate-test-matrix'
+            AND job.name != 'get_workflow_conclusion'
+            AND workflow.repository.full_name = 'pytorch/pytorch'
+            AND job._event_time >= PARSE_DATETIME_ISO8601(:startTime)
+            AND job._event_time < PARSE_DATETIME_ISO8601(:stopTime)
+            AND job.conclusion = 'success'
+            AND workflow.head_branch LIKE :branch
     ) AS tts
 ) AS p
 WHERE
-	(SELECT NOT IS_NAN(p.percentile) AND p.percentile >= (1.0 - :percentile))
+    (SELECT NOT IS_NAN(p.percentile) AND p.percentile >= (1.0 - :percentile))
 GROUP BY
-	name
+    name
 ORDER BY
-	COUNT(name) * MAX(tts_sec) DESC
+    COUNT(name) * MAX(tts_sec) DESC

--- a/torchci/rockset/metrics/__sql/tts_percentile.sql
+++ b/torchci/rockset/metrics/__sql/tts_percentile.sql
@@ -35,3 +35,4 @@ GROUP BY
     name
 ORDER BY
     COUNT(name) * MAX(tts_sec) DESC
+

--- a/torchci/rockset/metrics/__sql/tts_percentile.sql
+++ b/torchci/rockset/metrics/__sql/tts_percentile.sql
@@ -35,4 +35,3 @@ GROUP BY
     name
 ORDER BY
     COUNT(name) * MAX(tts_sec) DESC
-

--- a/torchci/rockset/metrics/job_duration_percentile.lambda.json
+++ b/torchci/rockset/metrics/job_duration_percentile.lambda.json
@@ -1,0 +1,27 @@
+{
+  "sql_path": "__sql/job_duration_percentile.sql",
+  "default_parameters": [
+    {
+      "name": "branch",
+      "type": "string",
+      "value": "%"
+    },
+    {
+      "name": "percentile",
+      "type": "float",
+      "value": "0.90"
+    },
+    {
+      "name": "startTime",
+      "type": "string",
+      "value": "2022-07-01T00:00:00.000Z"
+    },
+    {
+      "name": "stopTime",
+      "type": "string",
+      "value": "2022-08-01T00:00:00.000Z"
+    }
+  ],
+  "description": "Query job duration at different percentiles"
+}
+

--- a/torchci/rockset/metrics/job_duration_percentile.lambda.json
+++ b/torchci/rockset/metrics/job_duration_percentile.lambda.json
@@ -9,7 +9,7 @@
     {
       "name": "percentile",
       "type": "float",
-      "value": "0.90"
+      "value": "0.9"
     },
     {
       "name": "startTime",

--- a/torchci/rockset/metrics/tts_percentile.lambda.json
+++ b/torchci/rockset/metrics/tts_percentile.lambda.json
@@ -9,7 +9,7 @@
     {
       "name": "percentile",
       "type": "float",
-      "value": "0.90"
+      "value": "0.9"
     },
     {
       "name": "startTime",

--- a/torchci/rockset/metrics/tts_percentile.lambda.json
+++ b/torchci/rockset/metrics/tts_percentile.lambda.json
@@ -1,0 +1,26 @@
+{
+  "sql_path": "__sql/tts_percentile.sql",
+  "default_parameters": [
+    {
+      "name": "branch",
+      "type": "string",
+      "value": "%"
+    },
+    {
+      "name": "percentile",
+      "type": "float",
+      "value": "0.90"
+    },
+    {
+      "name": "startTime",
+      "type": "string",
+      "value": "2022-07-01T00:00:00.000Z"
+    },
+    {
+      "name": "stopTime",
+      "type": "string",
+      "value": "2022-08-01T00:00:00.000Z"
+    }
+  ],
+  "description": "Query job TTS at different percentiles"
+}

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -18,7 +18,7 @@
   "metrics": {
     "correlation_matrix": "4960260cbb0c5b48",
     "job_duration_avg": "124f44f27a7d8225",
-    "job_duration_percentile": "943836b84f539cc0",
+    "job_duration_percentile": "c64a455ac06003ba",
     "last_branch_push": "3d995ac2143586dc",
     "last_successful_jobs": "fd8bc3a2afc989a2",
     "last_successful_workflow": "5d22927dd0b0956b",
@@ -31,7 +31,7 @@
     "reverts": "f5bc84a10c4065a3",
     "tts_avg": "c0049352a4c38aa5",
     "tts_duration_historical": "593f718235d55e75",
-    "tts_percentile": "72c215bafaa1d542",
+    "tts_percentile": "7d7dcb69f3bca3e2",
     "strict_lag_sec": "f9523e8c8c3a3311",
     "queue_times_historical": "7f4d6599362e70ba",
     "workflow_duration_avg": "34e698a78cb36669",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -18,6 +18,7 @@
   "metrics": {
     "correlation_matrix": "4960260cbb0c5b48",
     "job_duration_avg": "124f44f27a7d8225",
+    "job_duration_percentile": "943836b84f539cc0",
     "last_branch_push": "3d995ac2143586dc",
     "last_successful_jobs": "fd8bc3a2afc989a2",
     "last_successful_workflow": "5d22927dd0b0956b",
@@ -30,6 +31,7 @@
     "reverts": "f5bc84a10c4065a3",
     "tts_avg": "c0049352a4c38aa5",
     "tts_duration_historical": "593f718235d55e75",
+    "tts_percentile": "72c215bafaa1d542",
     "strict_lag_sec": "f9523e8c8c3a3311",
     "queue_times_historical": "7f4d6599362e70ba",
     "workflow_duration_avg": "34e698a78cb36669",

--- a/torchci/scripts/checkRockset.mjs
+++ b/torchci/scripts/checkRockset.mjs
@@ -37,7 +37,7 @@ async function checkQuery(client, workspace, queryName, version) {
     `./rockset/${workspace}/__sql/${queryName}.sql`,
     "utf8"
   );
-  if (remoteQuery !== localQuery) {
+  if (remoteQuery.trim() !== localQuery.trim()) {
     console.log(
       `::error::${workspace}.${queryName}:${version} SQL does not match your local checkout.
        Run 'yarn node scripts/downloadQueryLambda.mjs ${workspace} ${queryName} ${version}' to overwrite your local checkout.`


### PR DESCRIPTION
Switch the rest of the HUD metrics page to percentile including job TTS and duration. I use p50 to make it consistent with the overall metrics.

~~There is an ongoing thread on which percentile to use. However, that can be addressed on a different PR~~ I'm working on the next PR to allow people to choose the percentile (and avg for backward compatibility). This should make the metrics easier to use in all cases. I'll submit it once this one this reviewed and merged to avoid merge conflicts.

### Testing
![Screen Shot 2022-07-27 at 17 09 45](https://user-images.githubusercontent.com/475357/181393278-b8900e28-52d3-4dbe-9fd3-1fe993a56248.png)

There is no obvious changes in the top long poles when comparing with https://hud.pytorch.org/metrics. Only some changes their order slightly.
