### PR TITLE
Add TTS metric picker on HUD

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -300,6 +300,134 @@ export function TimeRangePicker({
   );
 }
 
+/**
+ * Allows the user to pick the TTS metrics.
+ */
+export function TtsPercentilePicker({
+  ttsPercentile,
+  setTtsPercentile,
+}: {
+  ttsPercentile: number;
+  setTtsPercentile: any;
+}) {
+  function handleChange(e: SelectChangeEvent<number>) {
+    setTtsPercentile(e.target.value as number);
+  }
+
+  return (
+    <>
+      <FormControl>
+        <InputLabel id="tts-percentile-picker-select-label">Workflow Duration</InputLabel>
+        <Select
+          defaultValue={0.50}
+          label="Workflow Duration"
+          labelId="tts-percentile-picker-select-label"
+          onChange={handleChange}
+        >
+          <MenuItem value={-1.0}>avg</MenuItem>
+          <MenuItem value={0.50}>p50</MenuItem>
+          <MenuItem value={0.90}>p90</MenuItem>
+          <MenuItem value={0.95}>p95</MenuItem>
+          <MenuItem value={0.99}>p99</MenuItem>
+          <MenuItem value={1.00}>p100</MenuItem>
+        </Select>
+      </FormControl>
+    </>
+  );
+}
+
+function WorkflowDuration({
+  percentileParam,
+  timeParams,
+  workflowName,
+}: {
+  percentileParam: RocksetParam;
+  timeParams: RocksetParam[];
+  workflowName: string;
+}) {
+  const ttsPercentile = percentileParam.value;
+
+  // -1 is the specical case where we will show the avg instead
+  if (ttsPercentile !== -1) {
+    return (
+      <ScalarPanel
+        title={`p${ttsPercentile * 100} ${workflowName} workflow duration`}
+        queryName={"workflow_duration_percentile"}
+        metricName={"duration_sec"}
+        valueRenderer={(value) => durationDisplay(value)}
+        queryParams={[
+          { name: "name", type: "string", value: workflowName },
+          percentileParam,
+          ...timeParams,
+        ]}
+        badThreshold={(value) => value > 60 * 60 * 3} // 3 hours
+      />
+    );
+  }
+  else {
+    return (
+      <ScalarPanel
+        title={`avg ${workflowName} workflow duration`}
+        queryName={"workflow_duration_avg"}
+        metricName={"duration_sec"}
+        valueRenderer={(value) => durationDisplay(value)}
+        queryParams={[
+          { name: "name", type: "string", value: workflowName },
+          ...timeParams,
+        ]}
+        badThreshold={(value) => value > 60 * 60 * 3} // 3 hours
+      />
+    );
+  }
+}
+
+function JobsDuration({
+  title,
+  branchName,
+  queryName,
+  metricName,
+  percentileParam,
+  timeParams,
+}: {
+  title: string;
+  branchName: string;
+  queryName: string;
+  metricName: string;
+  percentileParam: RocksetParam;
+  timeParams: RocksetParam[];
+}) {
+  const ttsPercentile = percentileParam.value;
+
+  let metricHeaderName: string = `p${ttsPercentile * 100}`;
+  let queryParams: RocksetParam[] = [
+    {
+      name: "branch",
+      type: "string",
+      value: branchName,
+    },
+    percentileParam,
+    ...timeParams,
+  ];
+
+  // -1 is the specical case where we will show the avg instead
+  if (ttsPercentile === -1) {
+    metricHeaderName = "avg";
+    queryName = queryName.replace("percentile", "avg");
+  }
+
+  return (
+    <Grid item xs={6} height={ROW_HEIGHT}>
+      <TTSPanel
+        title={title}
+        queryName={queryName}
+        queryParams={queryParams}
+        metricName={metricName}
+        metricHeaderName={metricHeaderName}
+      />
+    </Grid>
+  );
+}
+
 const ROW_HEIGHT = 340;
 
 export default function Page() {
@@ -319,6 +447,14 @@ export default function Page() {
     },
   ];
 
+  const [ttsPercentile, setTtsPercentile] = useState<number>(0.50);
+
+  const percentileParam: RocksetParam = {
+    name: "percentile",
+    type: "float",
+    value: ttsPercentile,
+  };
+
   return (
     <div>
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
@@ -330,6 +466,10 @@ export default function Page() {
           stopTime={stopTime}
           setStartTime={setStartTime}
           setStopTime={setStopTime}
+        />
+        <TtsPercentilePicker
+          ttsPercentile={ttsPercentile}
+          setTtsPercentile={setTtsPercentile}
         />
       </Stack>
 
@@ -358,17 +498,10 @@ export default function Page() {
               queryParams={timeParams}
               badThreshold={(value) => value > 10}
             />
-            <ScalarPanel
-              title={"p50 pull workflow duration"}
-              queryName={"workflow_duration_percentile"}
-              metricName={"duration_sec"}
-              valueRenderer={(value) => durationDisplay(value)}
-              queryParams={[
-                { name: "name", type: "string", value: "pull" },
-                { name: "percentile", type: "float", value: 0.50 },
-                ...timeParams,
-              ]}
-              badThreshold={(value) => value > 60 * 60 * 3} // 3 hours
+            <WorkflowDuration
+              percentileParam={percentileParam}
+              timeParams={timeParams}
+              workflowName={"pull"}
             />
           </Stack>
         </Grid>
@@ -383,17 +516,10 @@ export default function Page() {
               queryParams={[]}
               badThreshold={(value) => value > 60 * 60 * 6} // 6 hours
             />
-            <ScalarPanel
-              title={"p50 trunk workflow duration"}
-              queryName={"workflow_duration_percentile"}
-              metricName={"duration_sec"}
-              valueRenderer={(value) => durationDisplay(value)}
-              queryParams={[
-                { name: "name", type: "string", value: "trunk" },
-                { name: "percentile", type: "float", value: 0.50 },
-                ...timeParams,
-              ]}
-              badThreshold={(value) => value > 60 * 60 * 3} // 3 hours
+            <WorkflowDuration
+              percentileParam={percentileParam}
+              timeParams={timeParams}
+              workflowName={"trunk"}
             />
           </Stack>
         </Grid>
@@ -574,69 +700,41 @@ export default function Page() {
           />
         </Grid>
 
-        <Grid item xs={6} height={ROW_HEIGHT}>
-          <TTSPanel
-            title={"Job time-to-signal, all branches"}
-            queryName={"tts_percentile"}
-            queryParams={timeParams}
-            metricName={"tts_sec"}
-            metricHeaderName={"p50"}
-          />
-        </Grid>
+        <JobsDuration
+          title={"Job time-to-signal, all branches"}
+          branchName={"%"}
+          queryName={"tts_percentile"}
+          metricName={"tts_sec"}
+          percentileParam={percentileParam}
+          timeParams={timeParams}
+        />
 
-        <Grid item xs={6} height={ROW_HEIGHT}>
-          <TTSPanel
-            title={"Job time-to-signal, master-only"}
-            queryName={"tts_percentile"}
-            queryParams={[
-              ...timeParams,
-              {
-                name: "branch",
-                type: "string",
-                value: "master",
-              },
-              {
-                name: "percentile",
-                type: "float",
-                value: 0.5,
-              },
-            ]}
-            metricName={"tts_sec"}
-            metricHeaderName={"p50"}
-          />
-        </Grid>
+        <JobsDuration
+          title={"Job time-to-signal, master-only"}
+          branchName={"master"}
+          queryName={"tts_percentile"}
+          metricName={"tts_sec"}
+          percentileParam={percentileParam}
+          timeParams={timeParams}
+        />
 
-        <Grid item xs={6} height={ROW_HEIGHT}>
-          <TTSPanel
-            title={"Job duration, all branches"}
-            queryName={"job_duration_percentile"}
-            queryParams={timeParams}
-            metricName={"duration_sec"}
-            metricHeaderName={"p50"}
-          />
-        </Grid>
+        <JobsDuration
+          title={"Job duration, all branches"}
+          branchName={"%"}
+          queryName={"job_duration_percentile"}
+          metricName={"duration_sec"}
+          percentileParam={percentileParam}
+          timeParams={timeParams}
+        />
 
-        <Grid item xs={6} height={ROW_HEIGHT}>
-          <TTSPanel
-            title={"Job duration, master-only"}
-            queryName={"job_duration_percentile"}
-            queryParams={[
-              ...timeParams,
-              {
-                name: "branch",
-                type: "string",
-                value: "master",
-              },
-              {
-                name: "percentile",
-                type: "float",
-                value: 0.5,
-              },
-            ]}
-            metricName={"duration_sec"}
-            metricHeaderName={"p50"}
-          />
-        </Grid>
+        <JobsDuration
+          title={"Job duration, master-only"}
+          branchName={"master"}
+          queryName={"job_duration_percentile"}
+          metricName={"duration_sec"}
+          percentileParam={percentileParam}
+          timeParams={timeParams}
+        />
       </Grid>
     </div>
   );

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -347,38 +347,29 @@ function WorkflowDuration({
 }) {
   const ttsPercentile = percentileParam.value;
 
+  let title: string = `p${ttsPercentile * 100} ${workflowName} workflow duration`;
+  let queryName: string = "workflow_duration_percentile";
+
   // -1 is the specical case where we will show the avg instead
-  if (ttsPercentile !== -1) {
-    return (
-      <ScalarPanel
-        title={`p${ttsPercentile * 100} ${workflowName} workflow duration`}
-        queryName={"workflow_duration_percentile"}
-        metricName={"duration_sec"}
-        valueRenderer={(value) => durationDisplay(value)}
-        queryParams={[
-          { name: "name", type: "string", value: workflowName },
-          percentileParam,
-          ...timeParams,
-        ]}
-        badThreshold={(value) => value > 60 * 60 * 3} // 3 hours
-      />
-    );
+  if (ttsPercentile === -1) {
+    title=`avg ${workflowName} workflow duration`;
+    queryName = queryName.replace("percentile", "avg");
   }
-  else {
-    return (
-      <ScalarPanel
-        title={`avg ${workflowName} workflow duration`}
-        queryName={"workflow_duration_avg"}
-        metricName={"duration_sec"}
-        valueRenderer={(value) => durationDisplay(value)}
-        queryParams={[
-          { name: "name", type: "string", value: workflowName },
-          ...timeParams,
-        ]}
-        badThreshold={(value) => value > 60 * 60 * 3} // 3 hours
-      />
-    );
-  }
+
+  return (
+    <ScalarPanel
+      title={title}
+      queryName={queryName}
+      metricName={"duration_sec"}
+      valueRenderer={(value) => durationDisplay(value)}
+      queryParams={[
+        { name: "name", type: "string", value: workflowName },
+        percentileParam,
+        ...timeParams,
+      ]}
+      badThreshold={(value) => value > 60 * 60 * 3} // 3 hours
+    />
+  );
 }
 
 function JobsDuration({

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -352,7 +352,7 @@ function WorkflowDuration({
 
   // -1 is the specical case where we will show the avg instead
   if (ttsPercentile === -1) {
-    title=`avg ${workflowName} workflow duration`;
+    title = `avg ${workflowName} workflow duration`;
     queryName = queryName.replace("percentile", "avg");
   }
 

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -317,10 +317,10 @@ export function TtsPercentilePicker({
   return (
     <>
       <FormControl>
-        <InputLabel id="tts-percentile-picker-select-label">Workflow Duration</InputLabel>
+        <InputLabel id="tts-percentile-picker-select-label">Percentile</InputLabel>
         <Select
           defaultValue={0.50}
-          label="Workflow Duration"
+          label="Percentile"
           labelId="tts-percentile-picker-select-label"
           onChange={handleChange}
         >


### PR DESCRIPTION
Allow switching between `avg` and all the common percentiles (p50, p90, p95, p99, p100).

### Testing

#### AVG
![localhost_3000_metrics_avg](https://user-images.githubusercontent.com/475357/181658701-3a27baf1-0fb4-46f0-88e7-830987572069.png)

#### P50
![localhost_3000_metrics_p50](https://user-images.githubusercontent.com/475357/181658705-7a48e434-a941-4be7-a1ac-76b992365800.png)

#### P90
![localhost_3000_metrics_p90](https://user-images.githubusercontent.com/475357/181658708-2bb0ae1f-efd3-44e7-80a1-6b70c4903121.png)

#### p95
![localhost_3000_metrics_p95](https://user-images.githubusercontent.com/475357/181658713-3b0c8e65-ae8e-4901-bfd5-aa2b5c98f8c8.png)

#### p99
![localhost_3000_metrics_p99](https://user-images.githubusercontent.com/475357/181658715-ebd92f2a-0f61-4dd2-91dd-95d90a0e2bad.png)

#### p100
![localhost_3000_metrics_p100](https://user-images.githubusercontent.com/475357/181658717-df8b628d-414b-424f-8bb7-499336647b88.png)

** p100 looks weird, it seems that there are some stuck job and the metrics reveals them **




