### PR TITLE
Add percentile picker to https://hud.pytorch.org/tts

### DIFF
--- a/torchci/rockset/metrics/__sql/tts_duration_historical_percentile.sql
+++ b/torchci/rockset/metrics/__sql/tts_duration_historical_percentile.sql
@@ -1,0 +1,49 @@
+SELECT
+    granularity_bucket,
+    MAX(tts_sec) AS tts_percentile_sec,
+    MAX(duration_sec) AS duration_percentile_sec,
+    full_name
+FROM (
+    SELECT
+        granularity_bucket,
+        tts_sec,
+        PERCENT_RANK() OVER (PARTITION BY full_name ORDER BY tts_sec DESC) AS tts_percentile,
+        duration_sec,
+        PERCENT_RANK() OVER (PARTITION BY full_name ORDER BY duration_sec DESC) AS duration_percentile,
+        full_name,
+    FROM (
+        SELECT
+            FORMAT_ISO8601(
+                DATE_TRUNC(
+                    :granularity,
+                    job._event_time AT TIME ZONE :timezone
+                )
+            ) AS granularity_bucket,
+            DATE_DIFF(
+                'second',
+                PARSE_TIMESTAMP_ISO8601(workflow.created_at) AT TIME ZONE :timezone,
+                PARSE_TIMESTAMP_ISO8601(job.completed_at) AT TIME ZONE :timezone
+            ) AS tts_sec,
+            DATE_DIFF(
+                'second',
+                PARSE_TIMESTAMP_ISO8601(job.started_at) AT TIME ZONE :timezone,
+                PARSE_TIMESTAMP_ISO8601(job.completed_at) AT TIME ZONE :timezone
+            ) AS duration_sec,
+            CONCAT(workflow.name, ' / ', job.name) as full_name
+        FROM
+            commons.workflow_job job
+            JOIN commons.workflow_run workflow on workflow.id = job.run_id
+        WHERE
+            job._event_time >= PARSE_DATETIME_ISO8601(:startTime)
+            AND job._event_time < PARSE_DATETIME_ISO8601(:stopTime)
+            AND workflow.name IN ('pull', 'trunk', 'nightly', 'periodic')
+            AND workflow.head_branch LIKE :branch
+    ) AS tts_duration
+) AS p
+WHERE
+    (SELECT p.tts_percentile >= (1.0 - :percentile) OR p.duration_percentile >= (1.0 - :percentile))
+GROUP BY
+    granularity_bucket,
+    full_name
+ORDER BY
+    full_name ASC

--- a/torchci/rockset/metrics/tts_duration_historical_percentile.lambda.json
+++ b/torchci/rockset/metrics/tts_duration_historical_percentile.lambda.json
@@ -12,11 +12,6 @@
       "value": "day"
     },
     {
-      "name": "timezone",
-      "type": "string",
-      "value": "America/Los_Angeles"
-    },
-    {
       "name": "percentile",
       "type": "float",
       "value": "0.9"
@@ -30,6 +25,11 @@
       "name": "stopTime",
       "type": "string",
       "value": "2022-08-01T00:00:00.000Z"
+    },
+    {
+      "name": "timezone",
+      "type": "string",
+      "value": "America/Los_Angeles"
     }
   ],
   "description": "Query both TTS and duration percentiles and group them at different granularity"

--- a/torchci/rockset/metrics/tts_duration_historical_percentile.lambda.json
+++ b/torchci/rockset/metrics/tts_duration_historical_percentile.lambda.json
@@ -1,0 +1,36 @@
+{
+  "sql_path": "__sql/tts_duration_historical_percentile.sql",
+  "default_parameters": [
+    {
+      "name": "branch",
+      "type": "string",
+      "value": "%"
+    },
+    {
+      "name": "granularity",
+      "type": "string",
+      "value": "day"
+    },
+    {
+      "name": "timezone",
+      "type": "string",
+      "value": "America/Los_Angeles"
+    },
+    {
+      "name": "percentile",
+      "type": "float",
+      "value": "0.9"
+    },
+    {
+      "name": "startTime",
+      "type": "string",
+      "value": "2022-07-01T00:00:00.000Z"
+    },
+    {
+      "name": "stopTime",
+      "type": "string",
+      "value": "2022-08-01T00:00:00.000Z"
+    }
+  ],
+  "description": "Query both TTS and duration percentiles and group them at different granularity"
+}

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -31,6 +31,7 @@
     "reverts": "f5bc84a10c4065a3",
     "tts_avg": "c0049352a4c38aa5",
     "tts_duration_historical": "593f718235d55e75",
+    "tts_duration_historical_percentile": "433d43743c002994",
     "tts_percentile": "7d7dcb69f3bca3e2",
     "strict_lag_sec": "f9523e8c8c3a3311",
     "queue_times_historical": "7f4d6599362e70ba",


### PR DESCRIPTION
Now we can switch between avg and different percentiles on https://hud.pytorch.org/tts. 

### Testing

![Screen Shot 2022-07-29 at 12 08 39](https://user-images.githubusercontent.com/475357/181828120-b7cb0f3e-af20-4f5e-84e8-930cbb73f5fd.png)

I plan to submit another PR after this to link the jobs on [HUD metrics](https://hud.pytorch.org/metrics) with this page. So that people have more visibility of https://hud.pytorch.org/tts.


 