### PR TITLE
Link jobs on HUD metrics with its historical TTS page

### DIFF
--- a/torchci/components/metrics/panels/TablePanel.tsx
+++ b/torchci/components/metrics/panels/TablePanel.tsx
@@ -45,6 +45,7 @@ export default function TablePanel({
       </Typography>
     );
   }
+
   return (
     <DataGrid
       {...dataGridProps}

--- a/torchci/next.config.js
+++ b/torchci/next.config.js
@@ -31,6 +31,10 @@ module.exports = {
         source: "/minihud",
         destination: "/minihud/pytorch/pytorch/master/1",
       },
+      {
+        source: "/tts",
+        destination: "/tts/pytorch/pytorch/master",
+      },
     ];
   },
 };

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -172,12 +172,14 @@ function TTSPanel({
   queryParams,
   metricHeaderName,
   metricName,
+  branchName
 }: {
   title: string;
   queryName: string;
   queryParams: RocksetParam[];
   metricHeaderName: string;
   metricName: string;
+  branchName: string;
 }) {
   return (
     <TablePanel
@@ -193,7 +195,27 @@ function TTSPanel({
             durationDisplay(params.value),
         },
         { field: "count", headerName: "Count", flex: 1 },
-        { field: "name", headerName: "Name", flex: 5 },
+        {
+          field: "name",
+          headerName: "Name",
+          flex: 5,
+          // valueFormatter only treat the return value as string, so we need
+          // to use renderCell here to get the JSX
+          renderCell: (params: GridRenderCellParams<string>) => {
+            const jobName = params.value;
+            if (jobName === undefined) {
+              return `Invalid job name ${jobName}`;
+            }
+
+            const encodedJobName = encodeURIComponent(jobName);
+            const encodedBranchName = encodeURIComponent(branchName);
+            return (
+              <a href={`/tts/pytorch/pytorch/${encodedBranchName}?jobName=${encodedJobName}`}>
+                {jobName}
+              </a>
+            );
+          }
+        },
       ]}
       dataGridProps={{ getRowId: (el: any) => el.name }}
     />
@@ -319,7 +341,7 @@ export function TtsPercentilePicker({
       <FormControl>
         <InputLabel id="tts-percentile-picker-select-label">Percentile</InputLabel>
         <Select
-          defaultValue={0.50}
+          defaultValue={ttsPercentile}
           label="Percentile"
           labelId="tts-percentile-picker-select-label"
           onChange={handleChange}
@@ -414,6 +436,7 @@ function JobsDuration({
         queryParams={queryParams}
         metricName={metricName}
         metricHeaderName={metricHeaderName}
+        branchName={branchName}
       />
     </Grid>
   );

--- a/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -18,6 +18,7 @@ import {
 import { useRouter } from "next/router";
 import {
   useCallback,
+  useRef,
   useState
 } from "react";
 import { RocksetParam } from "lib/rockset";
@@ -275,10 +276,8 @@ function GranularityPicker({
 
 export default function Page() {
   const router = useRouter();
-  const branch =
-    router.query.branch === undefined ? "master": router.query.branch as string;
-  const jobName =
-    router.query.jobName === undefined ? "none": router.query.jobName as string;
+  const branch: string = router.query.branch as string ?? "master";
+  const jobName: string = router.query.jobName as string ?? "none";
   const percentile: number =
     router.query.percentile === undefined ? 0.50: parseFloat(router.query.percentile as string);
 

--- a/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -15,7 +15,11 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
-import { useState } from "react";
+import { useRouter } from "next/router";
+import {
+  useCallback,
+  useState
+} from "react";
 import { RocksetParam } from "lib/rockset";
 import { fetcher } from "lib/GeneralUtils";
 import {
@@ -25,7 +29,7 @@ import {
 } from "components/metrics/panels/TimeSeriesPanel";
 import { durationDisplay } from "components/TimeUtils";
 import React from "react";
-import { TimeRangePicker, TtsPercentilePicker } from "./metrics";
+import { TimeRangePicker, TtsPercentilePicker } from "../../../../metrics";
 
 function Panel({
   series,
@@ -120,10 +124,14 @@ function Graphs({
   queryParams,
   granularity,
   ttsPercentile,
+  selectedJobName,
+  checkboxRef,
 }: {
   queryParams: RocksetParam[];
   granularity: "hour" | "day" | "week" | "month" | "year";
   ttsPercentile: number;
+  selectedJobName: string;
+  checkboxRef: any;
 }) {
   const [filter, setFilter] = useState(new Set());
   const ROW_HEIGHT = 800;
@@ -138,7 +146,6 @@ function Graphs({
     ttsFieldName = "tts_avg_sec";
     durationFieldName = "duration_avg_sec";
   }
-
 
   const timeFieldName = "granularity_bucket";
   const groupByFieldName = "full_name";
@@ -207,6 +214,7 @@ function Graphs({
   var duration_series = duration_true_series.filter((item: any) =>
     filter.has(item["name"])
   );
+
   return (
     <Grid container spacing={2}>
       <Grid item xs={9} height={ROW_HEIGHT}>
@@ -218,7 +226,7 @@ function Graphs({
         </Paper>
       </Grid>
       <Grid item xs={3} height={ROW_HEIGHT}>
-        <div style={{ overflow: "auto", height: ROW_HEIGHT, fontSize: "15px" }}>
+        <div style={{ overflow: "auto", height: ROW_HEIGHT, fontSize: "15px" }} ref={checkboxRef}>
           {tts_true_series.map((job) => (
             <div key={job["name"]}>
               <input
@@ -266,10 +274,18 @@ function GranularityPicker({
 }
 
 export default function Page() {
+  const router = useRouter();
+  const branch =
+    router.query.branch === undefined ? "master": router.query.branch as string;
+  const jobName =
+    router.query.jobName === undefined ? "none": router.query.jobName as string;
+  const percentile: number =
+    router.query.percentile === undefined ? 0.50: parseFloat(router.query.percentile as string);
+
   const [startTime, setStartTime] = useState(dayjs().subtract(1, "week"));
   const [stopTime, setStopTime] = useState(dayjs());
   const [granularity, setGranularity] = useState<Granularity>("day");
-  const [ttsPercentile, setTtsPercentile] = useState<number>(0.50);
+  const [ttsPercentile, setTtsPercentile] = useState<number>(percentile);
 
   const queryParams: RocksetParam[] = [
     {
@@ -281,8 +297,15 @@ export default function Page() {
     { name: "stopTime", type: "string", value: stopTime },
     { name: "granularity", type: "string", value: granularity },
     { name: "percentile", type: "float", value: ttsPercentile },
-    { name: "branch", type: "string", value: "master" },
+    { name: "branch", type: "string", value: branch },
   ];
+
+  const checkboxRef = useCallback(() => {
+    const selectedJob = document.getElementById(jobName);
+    if (selectedJob != undefined) {
+      selectedJob.click();
+    }
+  }, [jobName]);
 
   return (
     <div>
@@ -309,6 +332,8 @@ export default function Page() {
         queryParams={queryParams}
         granularity={granularity}
         ttsPercentile={ttsPercentile}
+        selectedJobName={jobName}
+        checkboxRef={checkboxRef}
       />
     </div>
   );


### PR DESCRIPTION
The [historical TTS page](https://hud.pytorch.org/tts) shows valuable information about the TTS of a job, but it's not linked anywhere from the more popular [HUD metrics page](https://hud.pytorch.org/metrics). This PR is to link the twos by allowing a clickable link from the jobs on [HUD metrics page](https://hud.pytorch.org/metrics) with its corresponding historical TTS page. The change to support this includes:

* Move https://hud.pytorch.org/tts to https://hud.pytorch.org/tts/[repoOwner]/[repoName]/[branchName]
  * repoOwner and repoName are both `pytorch`
  * branchName can be master or `%` for all branches
* https://hud.pytorch.org/tts will be route to `/tts/pytorch/pytorch/master`, as a landing page
* Tweak https://hud.pytorch.org/tts to set the job name via a query parameter, i.e. `?jobName=pull%20%2F%20linux-docs%20%2F%20build-docs%20%28cpp%29`

### Testing

HUD metrics,

![Screen Shot 2022-07-29 at 19 53 29](https://user-images.githubusercontent.com/475357/181867496-03015e13-6eb9-4bbd-9a7f-e9c817df9dc3.png)

Click on one of the link will go to historical TTS page,

![Screen Shot 2022-07-29 at 19 53 56](https://user-images.githubusercontent.com/475357/181867511-61c083f4-97df-4f01-b8f3-181b03191a05.png)

** Note that setting the percentile as a parameter is not yet supported, but I'm planning to add that later **