### PR TITLE
Improve force merge message usability

### DIFF
--- a/torchci/lib/bot/cliParser.ts
+++ b/torchci/lib/bot/cliParser.ts
@@ -46,9 +46,8 @@ mergeOption.add_argument("-g", "--green", {
 mergeOption.add_argument("-f", "--force", {
   metavar: "MESSAGE",
   help:
-    "Merge without checking anything. This requires a reason for auditting purpose, for example:\n" +
-    "`@pytorchbot merge -f 'Minor update to fix lint. Expecting all PR tests to pass'`\n" +
-    "The reason must be longer than 2 words. ONLY USE THIS FOR CRITICAL FAILURES.",
+`Merge without checking anything. This requires a reason for auditting purpose, for example:
+@pytorchbot merge -f 'Minor update to fix lint. Expecting all PR tests to pass'`
 });
 mergeOption.add_argument("-l", "--land-checks", {
   action: "store_true",

--- a/torchci/lib/bot/cliParser.ts
+++ b/torchci/lib/bot/cliParser.ts
@@ -44,9 +44,10 @@ mergeOption.add_argument("-g", "--green", {
   help: "Merge when *all* status checks pass.",
 });
 mergeOption.add_argument("-f", "--force", {
+  metavar: "MESSAGE",
   help:
     "Merge without checking anything. This requires a reason for auditting purpose, for example:\n" +
-    "`@pytorchbot merge -f '[MINOR] Fix lint. Expecting all PR tests to pass'`\n" +
+    "`@pytorchbot merge -f 'Minor update to fix lint. Expecting all PR tests to pass'`\n" +
     "The reason must be longer than 2 words. ONLY USE THIS FOR CRITICAL FAILURES.",
 });
 mergeOption.add_argument("-l", "--land-checks", {

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -137,10 +137,10 @@ class PytorchBotHandler {
         true,
         "You need to provide a reason for using force merge, in the format `@pytorchbot merge -f 'Explanation'`. " +
           "The explanation needs to be clear on why this is needed. Here are some good examples:\n" +
-          " Bypass checks due to unrelated upstream failures from XLA\n" +
-          " This is a minor fix to clean up unused variables, which shouldn't break anything\n" +
-          " This is pre-tested in a previous CI run\n" +
-          " Bypass flaky cpp doc check"
+          " * Bypass checks due to unrelated upstream failures from XLA\n" +
+          " * This is a minor fix to clean up unused variables, which shouldn't break anything\n" +
+          " * This is pre-tested in a previous CI run\n" +
+          " * Bypass flaky cpp doc check"
       );
     }
   }

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -137,10 +137,10 @@ class PytorchBotHandler {
         true,
         "You need to provide a reason for using force merge, in the format `@pytorchbot merge -f 'Explanation'`. " +
           "The explanation needs to be clear on why this is needed. Here are some good examples:\n" +
-          " * Bypass checks due to unrelated upstream failures from XLA\n" +
-          " * This is a minor fix to clean up unused variables, which shouldn't break anything\n" +
-          " * This is pre-tested in a previous CI run\n" +
-          " * Bypass flaky cpp doc check"
+          "* Bypass checks due to unrelated upstream failures from XLA\n" +
+          "* This is a minor fix to clean up unused variables, which shouldn't break anything\n" +
+          "* This is pre-tested in a previous CI run\n" +
+          "* Bypass flaky cpp doc check"
       );
     }
   }

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -138,7 +138,7 @@ class PytorchBotHandler {
         "You need to provide a reason for using force merge, in the format `@pytorchbot merge -f 'Explanation'`. " +
           "The explanation needs to be clear on why this is needed. Here are some good examples:\n" +
           "* Bypass checks due to unrelated upstream failures from ...\n" +
-          "* This is a minor fix to clean up unused variables, which shouldn't break anything\n" +
+          "* This is a minor fix to ..., which shouldn't break anything\n" +
           "* This is pre-tested in a previous CI run\n" +
           "* Bypass flaky ... check"
       );

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -137,10 +137,10 @@ class PytorchBotHandler {
         true,
         "You need to provide a reason for using force merge, in the format `@pytorchbot merge -f 'Explanation'`. " +
           "The explanation needs to be clear on why this is needed. Here are some good examples:\n" +
-          "* Bypass checks due to unrelated upstream failures from XLA\n" +
+          "* Bypass checks due to unrelated upstream failures from ...\n" +
           "* This is a minor fix to clean up unused variables, which shouldn't break anything\n" +
           "* This is pre-tested in a previous CI run\n" +
-          "* Bypass flaky cpp doc check"
+          "* Bypass flaky ... check"
       );
     }
   }

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -135,12 +135,12 @@ class PytorchBotHandler {
     } else {
       await this.handleConfused(
         true,
-        "You need to provide a reason for using force merge, in the format `@pytorchbot merge -f 'Explanation'`. " +
-          "The explanation needs to be clear on why this is needed. Here are some good examples:\n" +
-          "* Bypass checks due to unrelated upstream failures from ...\n" +
-          "* This is a minor fix to ..., which shouldn't break anything\n" +
-          "* This is pre-tested in a previous CI run\n" +
-          "* Bypass flaky ... check"
+`You need to provide a reason for using force merge, in the format @pytorchbot merge -f 'Explanation'.
+The explanation needs to be clear on why this is needed. Here are some good examples:
+* Bypass checks due to unrelated upstream failures from ...
+* This is a minor fix to ..., which shouldn't break anything
+* This is pre-tested in a previous CI run
+* Bypass flaky ... check`
       );
     }
   }

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -135,12 +135,12 @@ class PytorchBotHandler {
     } else {
       await this.handleConfused(
         true,
-        "You need to provide a reason for using force merge, in the format `@pytorchbot merge -f '[CATEGORY] Explanation'`. " +
-          "With [CATEGORY] being one the following:\n" +
-          " EMERGENCY - an emergency fix to quickly address an issue\n" +
-          " MINOR - a minor fix such as cleaning locally unused variables, which shouldn't break anything\n" +
-          " PRE_TESTED - a previous CI run tested everything and you've only added minor changes like fixing lint\n" +
-          " OTHER - something not covered above"
+        "You need to provide a reason for using force merge, in the format `@pytorchbot merge -f 'Explanation'`. " +
+          "The explanation needs to be clear on why this is needed. Here are some good examples:\n" +
+          " Bypass checks due to unrelated upstream failures from XLA\n" +
+          " This is a minor fix to clean up unused variables, which shouldn't break anything\n" +
+          " This is pre-tested in a previous CI run\n" +
+          " Bypass flaky cpp doc check"
       );
     }
   }


### PR DESCRIPTION
After [auditing force merge usage](https://github.com/pytorch/test-infra/issues/463#issuecomment-1201757297) in the 2 weeks from July 15th to Aug 1st, I want to improve the way the message is conveyed a bit:

* Use `-f MESSAGE` instead of the default `-f FORCE` generated by argparse. By default, argparse uses the flag name to refer to the parameter in the help message from `--help`. This is pretty confusing for the `--force` flag. I have seen people trying to use `@pytorchbot merge -f FORCE` literally before realizing that they need to provide a string message as the FORCE parameter. Changing the param name to MESSAGE is also consistent with the revert `-m MESSAGE` use case.
* Simplify force merge message by removing the explicit category, which is rarely used from contributors outside PyTorch Dev Infra.