### PR TITLE
[mergebot] Ignore whitespace in front of commands

### DIFF
--- a/torchci/lib/bot/cliParser.ts
+++ b/torchci/lib/bot/cliParser.ts
@@ -112,7 +112,7 @@ parser.add_argument("-h", "--help", {
   action: "store_true",
 });
 
-const botCommandPattern = new RegExp(/^@pytorch(merge|)bot.*$/m);
+const botCommandPattern = new RegExp(/^ *@pytorch(merge|)bot.*$/m);
 
 export function getInputArgs(commentBody: string): string {
   const match = commentBody.match(botCommandPattern);


### PR DESCRIPTION
TSIA. We had a person try to merge with a whitespace, but due to our regex not matching it, we didn't take that into account so this adds that. 

Test Plan:
Let tests run