### PR TITLE
Dr. CI Feedback: display full HUD link to improve clarity

### DIFF
--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -15,7 +15,7 @@ export const HUD_URL = "https://hud.pytorch.org/pr/";
 
 export function formDrciHeader(prNum: number): string {
     return `## :link: Helpful Links
-### :test_tube: See artifacts and rendered test results [here](${HUD_URL}${prNum})
+### :test_tube: See artifacts and rendered test results [at hud.pytorch.org/pr/${prNum}](${HUD_URL}${prNum})
 * :page_facing_up: Preview [Python docs built from this PR](${DOCS_URL}${prNum}${PYTHON_DOCS_URL})
 * :page_facing_up: Preview [C++ docs built from this PR](${DOCS_URL}${prNum}${CPP_DOCS_URL})
 * :question: Need help or want to give feedback on the CI? Visit our [office hours](${OH_URL})

--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -15,7 +15,7 @@ export const HUD_URL = "https://hud.pytorch.org/pr/";
 
 export function formDrciHeader(prNum: number): string {
     return `## :link: Helpful Links
-### :test_tube: See artifacts and rendered test results [at hud.pytorch.org/pr/${prNum}](${HUD_URL}${prNum})
+### :test_tube: See artifacts and rendered test results at [hud.pytorch.org/pr/${prNum}](${HUD_URL}${prNum})
 * :page_facing_up: Preview [Python docs built from this PR](${DOCS_URL}${prNum}${PYTHON_DOCS_URL})
 * :page_facing_up: Preview [C++ docs built from this PR](${DOCS_URL}${prNum}${CPP_DOCS_URL})
 * :question: Need help or want to give feedback on the CI? Visit our [office hours](${OH_URL})


### PR DESCRIPTION
**Overview:** Modified `drciUtils.ts` header construction method to make the hud link clearer. Rather than linking the hug with 'here' the output now shoes the actual url for the HUD.

**Example Output:**
![Screen Shot 2022-08-02 at 4 15 04 PM](https://user-images.githubusercontent.com/24441980/182465119-5b42a4e1-4320-4bba-88a2-ec85944a5d1a.png)


**Test Plan:** no tests should be affected and all pass.