### PR TITLE
Add first KPI and update TimeSeriesPanel to handle them

### DIFF
--- a/torchci/components/NavBar.tsx
+++ b/torchci/components/NavBar.tsx
@@ -66,11 +66,6 @@ function NavBar() {
               </Link>
             </li>
             <li>
-              <Link prefetch={false} href="/kpis">
-                Kpis
-              </Link>
-            </li>
-            <li>
               <span style={{ cursor: "pointer" }}>
                 <Link
                   href="https://github.com/pytorch/test-infra/tree/main/torchci"

--- a/torchci/components/NavBar.tsx
+++ b/torchci/components/NavBar.tsx
@@ -61,8 +61,13 @@ function NavBar() {
               </Link>
             </li>
             <li>
-              <Link prefetch={false} href="https://hud.pytorch.org/metrics">
+              <Link prefetch={false} href="/metrics">
                 Metrics
+              </Link>
+            </li>
+            <li>
+              <Link prefetch={false} href="/kpis">
+                Kpis
               </Link>
             </li>
             <li>

--- a/torchci/components/metrics/panels/TimeSeriesPanel.tsx
+++ b/torchci/components/metrics/panels/TimeSeriesPanel.tsx
@@ -48,15 +48,16 @@ export function seriesWithInterpolatedTimes(
     prevT = t;
     t = dayjs(times[i]);
 
-    // If the granularity isn't exactly the same, then do an extra check
+    // Normally the time difference is expected to be 1 (or less)
+    // Things like Daylight Savings Time can cause it to increase or decrease a bit.
+    // We don't want to interpolate data just because of DST though!
+    // For that, we buffer the accpetable granularity a bit
     let timeGap = t.diff(prevT, granularity);
     if (timeGap > 1.15) {
-      // We're missing a large chunk of data, so we'll add an interpolated timestamp
+      // We're missing too large a chunk of data, so we'll add an interpolated timestamp
       // at the next expected granularity point.
-      // We ignore smaller time chunks that may be missing since those can be caused by daylight savings time
-      // and other time related funkiness
       t = prevT.add(1, granularity)
-      i-- // We'll try processing at the old times[i] again next round, in case there are more gaps to interpolate
+      i-- // Try processing at the old times[i] again next round, in case there are more gaps to interpolate
     }
     interpolatedTimes.push(t.toISOString());
   }

--- a/torchci/components/metrics/panels/TimeSeriesPanel.tsx
+++ b/torchci/components/metrics/panels/TimeSeriesPanel.tsx
@@ -48,7 +48,7 @@ export function seriesWithInterpolatedTimes(
     prevT = t;
     t = dayjs(times[i]);
 
-    // Normally the time difference is expected to be 1 (or less)
+    // Normally the time difference is expected to be 1 (or less) of whatever the granularity is.
     // Things like Daylight Savings Time can cause it to increase or decrease a bit.
     // We don't want to interpolate data just because of DST though!
     // For that, we buffer the accpetable granularity a bit

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -7,7 +7,7 @@ import { useState } from "react";
 const ROW_HEIGHT = 340;
 
 export default function Kpis() {
-    const [startTime, setStartTime] = useState(dayjs().startOf("year").add(1, 'month'));
+    const [startTime, setStartTime] = useState(dayjs().startOf("year"));
     const [stopTime, setStopTime] = useState(dayjs());
         
     const timeParams: RocksetParam[] = [
@@ -27,7 +27,7 @@ export default function Kpis() {
         <Grid container spacing={2}>
             <Grid item xs={true} height={ROW_HEIGHT}>
                 <TimeSeriesPanel
-                title={"Percent Jobs Red Over Time"}
+                title={"% Jobs Red (Weekly)"}
                 queryName={"master_jobs_red"}
                 queryParams={[
                     ...timeParams,

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -1,0 +1,45 @@
+import { Grid } from "@mui/material";
+import TimeSeriesPanel from "components/metrics/panels/TimeSeriesPanel";
+import dayjs from "dayjs";
+import { RocksetParam } from "lib/rockset";
+import { useState } from "react";
+
+const ROW_HEIGHT = 340;
+
+export default function Kpis() {
+    const [startTime, setStartTime] = useState(dayjs().startOf("year").add(1, 'month'));
+    const [stopTime, setStopTime] = useState(dayjs());
+        
+    const timeParams: RocksetParam[] = [
+        {
+        name: "startTime",
+        type: "string",
+        value: startTime,
+        },
+        {
+        name: "stopTime",
+        type: "string",
+        value: stopTime,
+        },
+    ];
+    
+    return (
+        <Grid container spacing={2}>
+            <Grid item lg={true} height={ROW_HEIGHT}>
+                <TimeSeriesPanel
+                title={"Percent Jobs Red Over Time"}
+                queryName={"master_jobs_red"}
+                queryParams={[
+                    ...timeParams,
+                ]}
+                granularity={"week"}
+                timeFieldName={"granularity_bucket"}
+                yAxisFieldName={"red"}
+                yAxisRenderer={(unit) => {
+                    return `${unit * 100} %`;
+                }}
+                />
+            </Grid>
+        </Grid>
+    );
+}

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -25,7 +25,7 @@ export default function Kpis() {
     
     return (
         <Grid container spacing={2}>
-            <Grid item lg={true} height={ROW_HEIGHT}>
+            <Grid item xs={true} height={ROW_HEIGHT}>
                 <TimeSeriesPanel
                 title={"Percent Jobs Red Over Time"}
                 queryName={"master_jobs_red"}


### PR DESCRIPTION
Adds a KPI page to hud.pytorch.org/kpis. A Future PR will add more KPIs

The existing TimeSeriesPanel had a bug where it wouldn't correctly interpolate any data with a granularity greater than an hour (it tended to show all zeros for the data), especially if that data crossed a daylight savings time boundary.

This PR also fixes that bug and also hides the legend when we're not grouping the data into multiple lines.

Also updated the navbar link to the metrics page to be a relative link so that the dev server links to the dev server and not the prod metrics page

# Testing
Manually tested on local machine and validated that the /metrics page wasn't updated