### PR TITLE
Fix actionlint error on reusable GHA workflow

### DIFF
--- a/.github/workflows/build_wheels_linux_reusable.yml
+++ b/.github/workflows/build_wheels_linux_reusable.yml
@@ -4,6 +4,7 @@ on:
   workflow_call:
     inputs:
       domain:
+        description: 'name of the domain library calling this reusable workflow.'
         required: true
         type: string
 

--- a/.github/workflows/lint_actions.yml
+++ b/.github/workflows/lint_actions.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install requirements
         run: |
           set -eux
-          go install github.com/rhysd/actionlint/cmd/actionlint@7040327ca40aefd92888871131adc30c7d9c1b6d
+          go install github.com/rhysd/actionlint/cmd/actionlint@97ad72abf96ba516f4a49f2da567165eaebf7e5a
       - name: Run actionlint
         run: |
           set -eux


### PR DESCRIPTION
## Summary

`actionlint` check is failing on the reusable workflow introduced in https://github.com/pytorch/test-infra/pull/460. This PR fixes the failures by.

- Upgrading `actionlint` to the [latest release binary](https://github.com/rhysd/actionlint/releases) which understands reusable workflow keywords like `workflow_call` and `inputs`.
- Add `description` field for reusable workflow inputs.

## Test Plan

```
go install github.com/rhysd/actionlint/cmd/actionlint@97ad72abf96ba516f4a49f2da567165eaebf7e5a
/Users/niravmehta/go/bin/actionlint
```