### PR TITLE
[Nova] Add steps for pre and post build in reusable workflow

### DIFF
--- a/.github/workflows/build_wheels_linux_reusable.yml
+++ b/.github/workflows/build_wheels_linux_reusable.yml
@@ -22,7 +22,11 @@ jobs:
       # Include domain-specific pre-build step here 
       # (where each domain lib brings its own setup script)
       # Use the domain input to call the right composite action
+    - name: Run pre-build script
+      run: ./packaging/pre_build_script.sh
     - name: Build clean
       run: python setup.py clean
     - name: Build wheels
       run: python setup.py bdist_wheel
+    - name: Run post-build script
+      run: ./packaging/post_build_script.sh

--- a/.github/workflows/build_wheels_linux_reusable.yml
+++ b/.github/workflows/build_wheels_linux_reusable.yml
@@ -52,7 +52,7 @@ jobs:
       run: python setup.py bdist_wheel
     - name: Run post-build script
       run: ./packaging/post_build_script_wheel.sh
-    - name: Upload wheel to GitHub
+    # - name: Upload wheel to GitHub
       # Commenting upload step to avoid publishing until reusable workflows are
       # finalized, and ready to replace existing workflows.
       # uses: actions/upload-artifact@v3

--- a/.github/workflows/build_wheels_linux_reusable.yml
+++ b/.github/workflows/build_wheels_linux_reusable.yml
@@ -3,7 +3,7 @@ name: Build Linux Wheels
 on:
   workflow_call:
     inputs:
-      domain:
+      repository:
         description: 'name of the domain library calling this reusable workflow.'
         required: true
         type: string
@@ -11,23 +11,30 @@ on:
         description: 'docker image container for running the reusable workflow.'
         required: true
         type: string
+      python_version:
+        description: 'python version to use for building wheels binary'
+        required: true
+        type: string
 
 jobs:
   wheels:
     runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: ${{ inputs.python_version }}
+      PACKAGE_TYPE: wheel
+      REPOSITORY: ${{ inputs.repository }}
     container:
       image: ${{ inputs.image }}
     steps:
     - uses: actions/checkout@v2
-    # - name: Set up Python 3.x
-    #   uses: actions/setup-python@v2
-    #   with:
-    #     python-version: '3.x'
-    # - name: Install dependencies
-    #   run: python -m pip install --upgrade setuptools wheel
-      # Include domain-specific pre-build step here 
-      # (where each domain lib brings its own setup script)
-      # Use the domain input to call the right composite action
+    - name: Install pytorch-pkg-helpers
+      run: |
+        python3 -m pip install pytorch-pkg-helpers==0.1.0
+    - name: Create environemnt variables from pytorch-pkg-helpers
+      run: |
+        BUILD_ENV_FILE="${RUNNER_TEMP}/build_env_${GITHUB_RUN_ID}"
+        python3 -m pytorch_pkg_helpers > "${BUILD_ENV_FILE}"
+        echo "BUILD_ENV_FILE=${BUILD_ENV_FILE}" >> "${GITHUB_ENV}"
     - name: Run pre-build script
       run: ./packaging/pre_build_script.sh
     - name: Build clean

--- a/.github/workflows/build_wheels_linux_reusable.yml
+++ b/.github/workflows/build_wheels_linux_reusable.yml
@@ -23,8 +23,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
-    - name: Install dependencies
-      run: python -m pip install --upgrade setuptools wheel
+    # - name: Install dependencies
+    #   run: python -m pip install --upgrade setuptools wheel
       # Include domain-specific pre-build step here 
       # (where each domain lib brings its own setup script)
       # Use the domain input to call the right composite action

--- a/.github/workflows/build_wheels_linux_reusable.yml
+++ b/.github/workflows/build_wheels_linux_reusable.yml
@@ -7,10 +7,16 @@ on:
         description: 'name of the domain library calling this reusable workflow.'
         required: true
         type: string
+      image:
+        description: 'docker image container for running the reusable workflow.'
+        required: true
+        type: string
 
 jobs:
   wheels:
     runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.image }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.x

--- a/.github/workflows/build_wheels_linux_reusable.yml
+++ b/.github/workflows/build_wheels_linux_reusable.yml
@@ -41,7 +41,6 @@ jobs:
       with:
         auto-update-conda: true
         python-version: ${PYTHON_VERSION}
-        activate-environment: build
     - name: Clean conda environment
       run: |
         conda clean --all --quiet --yes

--- a/.github/workflows/build_wheels_linux_reusable.yml
+++ b/.github/workflows/build_wheels_linux_reusable.yml
@@ -66,6 +66,7 @@ jobs:
     - name: Create environemnt variables from pytorch-pkg-helpers
       run: |
         # https://github.com/actions/checkout/issues/760#issuecomment-1097501613
+        # need to move this version.py get_root_dir(), and make it generic for all repositories
         git config --global --add safe.directory /__w/audio/audio
         BUILD_ENV_FILE="${RUNNER_TEMP}/build_env_${GITHUB_RUN_ID}"
         ${CONDA_RUN} python3 -m pytorch_pkg_helpers > "${BUILD_ENV_FILE}"

--- a/.github/workflows/build_wheels_linux_reusable.yml
+++ b/.github/workflows/build_wheels_linux_reusable.yml
@@ -36,6 +36,11 @@ jobs:
     - name: Set artifact name
       run: |
         echo "ARTIFACT_NAME=${REPOSITORY/\//_}_${REF}_${PYTHON_VERSION}" >> "${GITHUB_ENV}"
+    - name: Setup miniconda
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+        python-version: ${PYTHON_VERSION}
     - name: Clean conda environment
       run: |
         conda clean --all --quiet --yes

--- a/.github/workflows/build_wheels_linux_reusable.yml
+++ b/.github/workflows/build_wheels_linux_reusable.yml
@@ -36,21 +36,54 @@ jobs:
     - name: Set artifact name
       run: |
         echo "ARTIFACT_NAME=${REPOSITORY/\//_}_${REF}_${PYTHON_VERSION}" >> "${GITHUB_ENV}"
+    - name: Setup miniconda
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+        python-version: ${PYTHON_VERSION}
+        activate-environment: build
+    - name: Clean conda environment
+      run: |
+        conda clean --all --quiet --yes
+    - name: Create conda environment
+      run: |
+        CONDA_ENV="${RUNNER_TEMP}/conda_environment_${GITHUB_RUN_ID}"
+        conda create \
+          --yes \
+          --prefix "${CONDA_ENV}" \
+          "python=${PYTHON_VERSION}" \
+          cmake=3.22 \
+          ninja=1.10 \
+          numpy=1.23 \
+          pkg-config=0.29 \
+          wheel=0.37
+        echo "CONDA_ENV=${CONDA_ENV}" >> "${GITHUB_ENV}"
+        echo "CONDA_RUN=conda run -p ${CONDA_ENV}" >> "${GITHUB_ENV}"
     - name: Install pytorch-pkg-helpers
       run: |
-        python3 -m pip install pytorch-pkg-helpers==0.1.0
+        ${CONDA_RUN} python3 -m pip install pytorch-pkg-helpers==0.1.0
     - name: Create environemnt variables from pytorch-pkg-helpers
       run: |
         BUILD_ENV_FILE="${RUNNER_TEMP}/build_env_${GITHUB_RUN_ID}"
-        python3 -m pytorch_pkg_helpers > "${BUILD_ENV_FILE}"
+        ${CONDA_RUN} python3 -m pytorch_pkg_helpers > "${BUILD_ENV_FILE}"
         echo "BUILD_ENV_FILE=${BUILD_ENV_FILE}" >> "${GITHUB_ENV}"
-    - name: Run pre-build script
+    - name: Install delocate-wheel
+      run: |
+        ${CONDA_RUN} python3 -m pip install delocate
+    - name: Install torch dependency
+      run: |
+        source "${BUILD_ENV_FILE}"
+        # shellcheck disable=SC2086
+        ${CONDA_RUN} ${PIP_INSTALL_TORCH}
+    - name: Run pre-build script with steps specific to the repository
       run: ./packaging/pre_build_script_wheel.sh
     - name: Build clean
-      run: python setup.py clean
-    - name: Build wheels
-      run: python setup.py bdist_wheel
-    - name: Run post-build script
+      run: ${CONDA_RUN} python3 setup.py clean
+    - name: Build the wheel (bdist_wheel)
+      run: |
+        source "${BUILD_ENV_FILE}"
+        ${CONDA_RUN} python3 setup.py bdist_wheel
+    - name: Run post-build script with steps specific to the repository
       run: ./packaging/post_build_script_wheel.sh
     # - name: Upload wheel to GitHub
       # Commenting upload step to avoid publishing until reusable workflows are

--- a/.github/workflows/build_wheels_linux_reusable.yml
+++ b/.github/workflows/build_wheels_linux_reusable.yml
@@ -36,11 +36,6 @@ jobs:
     - name: Set artifact name
       run: |
         echo "ARTIFACT_NAME=${REPOSITORY/\//_}_${REF}_${PYTHON_VERSION}" >> "${GITHUB_ENV}"
-    - name: Setup miniconda
-      uses: conda-incubator/setup-miniconda@v2
-      with:
-        auto-update-conda: true
-        python-version: ${PYTHON_VERSION}
     - name: Clean conda environment
       run: |
         conda clean --all --quiet --yes

--- a/.github/workflows/build_wheels_linux_reusable.yml
+++ b/.github/workflows/build_wheels_linux_reusable.yml
@@ -4,15 +4,19 @@ on:
   workflow_call:
     inputs:
       repository:
-        description: 'name of the domain library calling this reusable workflow.'
+        description: 'name of the domain respository calling this reusable workflow.'
         required: true
         type: string
-      image:
+      docker_image:
         description: 'docker image container for running the reusable workflow.'
         required: true
         type: string
       python_version:
         description: 'python version to use for building wheels binary'
+        required: true
+        type: string
+      gpu_arch_version:
+        description: 'cuda version to use for building wheels binary'
         required: true
         type: string
 
@@ -23,10 +27,15 @@ jobs:
       PYTHON_VERSION: ${{ inputs.python_version }}
       PACKAGE_TYPE: wheel
       REPOSITORY: ${{ inputs.repository }}
+      GPU_ARCH_VERSION: ${{ inputs.gpu_arch_version }}
     container:
-      image: ${{ inputs.image }}
+      image: ${{ inputs.docker_image }}
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout the repository
+      uses: actions/checkout@v2
+    - name: Set artifact name
+      run: |
+        echo "ARTIFACT_NAME=${REPOSITORY/\//_}_${REF}_${PYTHON_VERSION}" >> "${GITHUB_ENV}"
     - name: Install pytorch-pkg-helpers
       run: |
         python3 -m pip install pytorch-pkg-helpers==0.1.0
@@ -36,10 +45,17 @@ jobs:
         python3 -m pytorch_pkg_helpers > "${BUILD_ENV_FILE}"
         echo "BUILD_ENV_FILE=${BUILD_ENV_FILE}" >> "${GITHUB_ENV}"
     - name: Run pre-build script
-      run: ./packaging/pre_build_script.sh
+      run: ./packaging/pre_build_script_wheel.sh
     - name: Build clean
       run: python setup.py clean
     - name: Build wheels
       run: python setup.py bdist_wheel
     - name: Run post-build script
-      run: ./packaging/post_build_script.sh
+      run: ./packaging/post_build_script_wheel.sh
+    - name: Upload wheel to GitHub
+      # Commenting upload step to avoid publishing until reusable workflows are
+      # finalized, and ready to replace existing workflows.
+      # uses: actions/upload-artifact@v3
+      # with:
+      #   name: ${{ env.ARTIFACT_NAME }}
+      #   path: dist/

--- a/.github/workflows/build_wheels_linux_reusable.yml
+++ b/.github/workflows/build_wheels_linux_reusable.yml
@@ -19,10 +19,10 @@ jobs:
       image: ${{ inputs.image }}
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.x
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
+    # - name: Set up Python 3.x
+    #   uses: actions/setup-python@v2
+    #   with:
+    #     python-version: '3.x'
     # - name: Install dependencies
     #   run: python -m pip install --upgrade setuptools wheel
       # Include domain-specific pre-build step here 

--- a/.github/workflows/build_wheels_linux_reusable.yml
+++ b/.github/workflows/build_wheels_linux_reusable.yml
@@ -75,7 +75,7 @@ jobs:
       run: |
         source "${BUILD_ENV_FILE}"
         # shellcheck disable=SC2086
-        ${CONDA_RUN} ${PIP_INSTALL_TORCH}
+        ${CONDA_RUN} pip_install --pre torch -f "https://download.pytorch.org/whl/nightly/${GPU_ARCH_VERSION}/torch_nightly.html"
     - name: Run pre-build script with steps specific to the repository
       run: ./packaging/pre_build_script_wheel.sh
     - name: Build clean

--- a/.github/workflows/build_wheels_linux_reusable.yml
+++ b/.github/workflows/build_wheels_linux_reusable.yml
@@ -39,8 +39,10 @@ jobs:
     - name: Setup miniconda
       uses: conda-incubator/setup-miniconda@v2
       with:
+        installer-url: https://github.com/conda-forge/miniforge/releases/download/4.8.3-2/Miniforge-pypy3-4.8.3-2-Linux-x86_64.sh
         auto-update-conda: true
         python-version: ${PYTHON_VERSION}
+        activate-environment: build
     - name: Clean conda environment
       run: |
         conda clean --all --quiet --yes

--- a/.github/workflows/build_wheels_linux_reusable.yml
+++ b/.github/workflows/build_wheels_linux_reusable.yml
@@ -41,7 +41,7 @@ jobs:
       with:
         installer-url: https://github.com/conda-forge/miniforge/releases/download/4.8.3-2/Miniforge-pypy3-4.8.3-2-Linux-x86_64.sh
         auto-update-conda: true
-        python-version: ${PYTHON_VERSION}
+        python-version: ${{ inputs.python_version }}
         activate-environment: build
     - name: Clean conda environment
       run: |

--- a/.github/workflows/build_wheels_linux_reusable.yml
+++ b/.github/workflows/build_wheels_linux_reusable.yml
@@ -65,6 +65,8 @@ jobs:
         ${CONDA_RUN} python3 -m pip install pytorch-pkg-helpers==0.1.0
     - name: Create environemnt variables from pytorch-pkg-helpers
       run: |
+        # https://github.com/actions/checkout/issues/760#issuecomment-1097501613
+        git config --global --add safe.directory /__w/audio/audio
         BUILD_ENV_FILE="${RUNNER_TEMP}/build_env_${GITHUB_RUN_ID}"
         ${CONDA_RUN} python3 -m pytorch_pkg_helpers > "${BUILD_ENV_FILE}"
         echo "BUILD_ENV_FILE=${BUILD_ENV_FILE}" >> "${GITHUB_ENV}"
@@ -75,7 +77,7 @@ jobs:
       run: |
         source "${BUILD_ENV_FILE}"
         # shellcheck disable=SC2086
-        ${CONDA_RUN} pip_install --pre torch -f "https://download.pytorch.org/whl/nightly/${GPU_ARCH_VERSION}/torch_nightly.html"
+        ${CONDA_RUN} ${PIP_INSTALL_TORCH}
     - name: Run pre-build script with steps specific to the repository
       run: ./packaging/pre_build_script_wheel.sh
     - name: Build clean


### PR DESCRIPTION
## Summary

Every domain library will have some custom steps in building binaries unique to it. As part of this PR, we want to add steps to run `pre_build_script` and `post_build_script` to the reusable workflow. These script files will be provided by the domain library.

Integrated with `pytorch-pkg-helpers` for the common logic in building wheels binary.

## Test plan

Using PR in audio library: https://github.com/pytorch/audio/pull/2548/ to test building wheels binary.