### PR TITLE
Add link to job names in TTS page

### DIFF
--- a/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -127,12 +127,14 @@ function Graphs({
   ttsPercentile,
   selectedJobName,
   checkboxRef,
+  branchName,
 }: {
   queryParams: RocksetParam[];
   granularity: "hour" | "day" | "week" | "month" | "year";
   ttsPercentile: number;
   selectedJobName: string;
   checkboxRef: any;
+  branchName: string;
 }) {
   const [filter, setFilter] = useState(new Set());
   const ROW_HEIGHT = 800;
@@ -216,6 +218,9 @@ function Graphs({
     filter.has(item["name"])
   );
 
+  const encodedBranchName = encodeURIComponent(branchName);
+  const jobUrlPrefix = `/tts/pytorch/pytorch/${encodedBranchName}?jobName=`;
+
   return (
     <Grid container spacing={2}>
       <Grid item xs={9} height={ROW_HEIGHT}>
@@ -236,7 +241,11 @@ function Graphs({
                 onChange={toggleFilter}
                 checked={filter.has(job["name"])}
               />
-              <label htmlFor={job["name"]}> {job["name"]}</label>
+              <label htmlFor={job["name"]}>
+                <a href={jobUrlPrefix + encodeURIComponent(job["name"])}>
+                  {job["name"]}
+                </a>
+              </label>
             </div>
           ))}
         </div>
@@ -333,6 +342,7 @@ export default function Page() {
         ttsPercentile={ttsPercentile}
         selectedJobName={jobName}
         checkboxRef={checkboxRef}
+        branchName={branch}
       />
     </div>
   );


### PR DESCRIPTION
I find myself frequently looking for the link to specific jobs on TTS page so that I can share them on doc, chat, etc.  So this is an easy tweak to have the link available right away in the TTS page. We have the same link on HUD metric page, but they are kind of harder to find.

### Testing
![Screen Shot 2022-08-11 at 17 44 02](https://user-images.githubusercontent.com/475357/184265164-0ae531c0-0f1c-45aa-a5b4-2b4a6703fdcf.png)

