### PR TITLE
Add versioning to unclassified lambda, clean up backfill.py

### DIFF
--- a/torchci/log_classifier/README.md
+++ b/torchci/log_classifier/README.md
@@ -21,3 +21,9 @@ the rule.
 Run `backfill.py`. Note that this uses the Lambda to run the rules, so you need
 to make sure [the live site](https://www.torch-ci.com/api/classifier/rules)
 reflects your changes before you run!
+
+## Why do we classify every log (including succeeding logs) but only backfill failing ones?
+
+Before Aug 12, 2022, the AWS lambda only classified failing jobs, because many of the log classifications are only relevant for failed jobs. However, after flaky tests started to be shielded from CI, CI now shows as "passing" even when it contained flakiness. To better equip developers in debugging these instances, we want to classify flaky tests as well, so we now classify all logs (and not only failing ones).
+
+However, we DON'T want to backfill succeeding jobs, as they often do not match any classification line (and if they do, it's usually because of an expected failure). Backfilling currently attempts to classify the most recent 1000 unclassified logs. Since succeeding jobs often have no classification, backfilling will not be able to tell that those jobs have already been classified and will attempt to re-classify these jobs.

--- a/torchci/rockset/commons/__sql/unclassified.sql
+++ b/torchci/rockset/commons/__sql/unclassified.sql
@@ -1,0 +1,16 @@
+SELECT
+	job.html_url,
+    CONCAT(
+        'https://ossci-raw-job-status.s3.amazonaws.com/log/',
+        CAST(job.id as string)
+    ) as log_url,
+    job.id as id,
+FROM
+    commons.workflow_job job
+    JOIN commons.workflow_run workflow on job.run_id = workflow.id
+    LEFT JOIN "GitHub-Actions".classification on classification.job_id = job.id
+WHERE
+    classification.line IS NULL
+    AND job._event_time > (CURRENT_TIMESTAMP() - HOURS(24))
+ORDER BY
+	job._event_time ASC

--- a/torchci/rockset/commons/__sql/unclassified.sql
+++ b/torchci/rockset/commons/__sql/unclassified.sql
@@ -10,7 +10,8 @@ FROM
     JOIN commons.workflow_run workflow on job.run_id = workflow.id
     LEFT JOIN "GitHub-Actions".classification on classification.job_id = job.id
 WHERE
-    classification.line IS NULL
+    job.conclusion = 'failure'
+    AND classification.line IS NULL
     AND job._event_time > (CURRENT_TIMESTAMP() - HOURS(24))
 ORDER BY
 	job._event_time ASC

--- a/torchci/rockset/commons/unclassified.lambda.json
+++ b/torchci/rockset/commons/unclassified.lambda.json
@@ -1,5 +1,5 @@
 {
   "sql_path": "__sql/unclassified.sql",
   "default_parameters": [],
-  "description": "all unclassified job ids from the last day"
+  "description": ""
 }

--- a/torchci/rockset/commons/unclassified.lambda.json
+++ b/torchci/rockset/commons/unclassified.lambda.json
@@ -1,0 +1,5 @@
+{
+  "sql_path": "__sql/unclassified.sql",
+  "default_parameters": [],
+  "description": "all unclassified job ids from the last day"
+}

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -7,7 +7,8 @@
     "test_time_per_file": "50cb3694334ed63a",
     "issue_query": "f29a1afe94563601",
     "failure_samples_query": "2961636418a148c2",
-    "recent_pr_workflows_query": "4e03cb13e8372050"
+    "recent_pr_workflows_query": "4e03cb13e8372050",
+    "unclassified": "672227495ac70f7d"
   },
   "pytorch_dev_infra_kpis": {
     "num_reverts": "dd2bac0ff36ea47f",


### PR DESCRIPTION
Today, I synced the AWS lambda with classify_log.py so that it would start classifying succeeding jobs too. 

With this change, I am explaining why we are doing that + why we are NOT switching backfill.py to broaden its search to succeeding jobs too.

It would be ideal if CI with flaky tests could set the output of a check to be "neutral" or something other than passed so that we can still shield devs and still be able to single out these checks in our flaky test infra.