### PR TITLE
flaky tests - make debugging instructions more prominent

### DIFF
--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -153,7 +153,16 @@ This test was disabled because it is failing in CI. See [recent examples](${exam
 
 Over the past ${NUM_HOURS} hours, it has been determined flaky in ${
     test.workflowIds.length
-  } workflow(s) with ${test.numRed} red and ${test.numGreen} green.`;
+  } workflow(s) with ${test.numRed} failures and ${test.numGreen} successes.
+
+**Debugging instructions (after clicking on the recent samples link):**
+DO NOT BE ALARMED THE CI IS GREEN. We now shield flaky tests from developers so CI will thus be green but it will be harder to parse the logs.
+To find relevant log snippets:
+1. Click on the workflow logs linked above
+2. Click on the Test step of the job so that it is expanded. Otherwise, the grepping will not work.
+3. Grep for \`${test.name}\`
+4. There should be several instances run (as flaky tests are rerun in CI) from which you can study the logs.
+`;
 }
 
 export async function getTestOwnerLabels(testFile: string): Promise<string[]> {

--- a/torchci/pages/flakytest.tsx
+++ b/torchci/pages/flakytest.tsx
@@ -39,6 +39,31 @@ export default function Page() {
                 <code>{`${test.name}, ${test.suite}`}</code>
               </h1>
               from file <code>{`${test.file}`}</code>
+              <h4>Debugging instructions:</h4>
+              <p>
+                DO NOT BE ALARMED THE CI IS GREEN. We now shield flaky tests
+                from developers so CI will thus be green but it will be harder
+                to parse the logs. To find relevant log snippets:
+              </p>
+              <ol>
+                <li>
+                  Click on any of the workflow job links below, for example{" "}
+                  <a
+                    href={`https://github.com/pytorch/pytorch/runs/${test.jobIds[0]}`}
+                  >{`${test.workflowNames[0]} / ${test.jobNames[0]}`}</a>
+                </li>
+                <li>
+                  Click on the Test step of the job so that it is expanded.
+                  Otherwise, the grepping will not work.
+                </li>
+                <li>
+                  Grep for <code>{test.name}</code>
+                </li>
+                <li>
+                  There should be several instances run (as flaky tests are
+                  rerun in CI) from which you can study the logs.
+                </li>
+              </ol>
               <div>
                 <h4> Test workflow job URLs: </h4>
                 <ul>
@@ -59,30 +84,6 @@ export default function Page() {
                   <p>Example logs: </p> <LogViewer job={samples[0]} />
                 </div>
               )}
-              <h4>Debugging instructions:</h4>
-              <p>
-                As flaky tests will soon show as green, it will be harder to
-                parse the logs. To find relevant log snippets:
-              </p>
-              <ol>
-                <li>
-                  Click on any of the workflow job links above, for example{" "}
-                  <a
-                    href={`https://github.com/pytorch/pytorch/runs/${test.jobIds[0]}`}
-                  >{`${test.workflowNames[0]} / ${test.jobNames[0]}`}</a>
-                </li>
-                <li>
-                  Click on the Test step of the job so that it is expanded.
-                  Otherwise, the grepping will not work.
-                </li>
-                <li>
-                  Grep for <code>{test.name}</code>
-                </li>
-                <li>
-                  There should be several instances run (as flaky tests are
-                  rerun in CI) from which you can study the logs.
-                </li>
-              </ol>
             </div>
           );
         })


### PR DESCRIPTION
Make debugging instructions for flaky tests more prominent by
* moving the debugging instructions to the top on the hud flaky test view (first pic)
* add debugging instructions when the issue is made (second pic)
<img width="1343" alt="image" src="https://user-images.githubusercontent.com/44682903/184439197-7ccb5446-8341-4779-8f53-79415d8d6798.png">
<img width="865" alt="image" src="https://user-images.githubusercontent.com/44682903/184439521-46ff30d9-6237-4e31-8295-0642fa8af915.png">
