### PR TITLE
add periodic jobs to test times json

### DIFF
--- a/torchci/rockset/commons/__sql/test_time_per_file_periodic_jobs.sql
+++ b/torchci/rockset/commons/__sql/test_time_per_file_periodic_jobs.sql
@@ -1,0 +1,72 @@
+-- same as test_time_per_file query except for the first select
+WITH good_periodic_sha AS (
+    select
+        job.head_sha as sha
+    from
+        commons.workflow_job job
+        JOIN commons.workflow_run workflow on workflow.id = job.run_id
+        JOIN push on workflow.head_commit.id = push.head_commit.id
+    where
+        workflow.name = 'periodic'
+        AND workflow.head_branch LIKE 'master'
+    group by
+        job.head_sha,
+        push._event_time
+    having
+        BOOL_AND(
+            job.conclusion = 'success'
+            and job.conclusion is not null
+        )
+    order by
+        push._event_time desc
+    limit
+        3
+), workflow AS (
+    SELECT
+        id
+    FROM
+        commons.workflow_run w
+        INNER JOIN good_periodic_sha c on w.head_sha = c.sha
+        and w.name = 'periodic'
+),
+job AS (
+    SELECT
+        j.name,
+        j.id
+    FROM
+        commons.workflow_job j
+        INNER JOIN workflow w on w.id = j.run_id
+),
+file_duration_per_job AS (
+    SELECT
+        test_run.invoking_file as file,
+        job.name,
+        SUM(time) as time,
+        job.id
+    FROM
+        commons.test_run_summary test_run
+        /* `test_run` is ginormous and `job` is small, so lookup join is essential */
+        INNER JOIN job ON test_run.job_id = job.id HINT(join_strategy = lookup)
+    WHERE
+        /* cpp tests do not populate `file` for some reason. */
+        /* Exclude them as we don't include them in our slow test infra */
+        test_run.file IS NOT NULL
+    GROUP BY
+        test_run.invoking_file,
+        job.name,
+        job.id
+)
+SELECT
+    REPLACE(file, '.', '/') AS file,
+    REGEXP_EXTRACT(name, '^(.*) /', 1) as base_name,
+    REGEXP_EXTRACT(name, '/ test \((\w*),', 1) as test_config,
+    AVG(time) as time
+FROM
+    file_duration_per_job
+GROUP BY
+    file,
+    name
+ORDER BY
+    base_name,
+    test_config,
+    file

--- a/torchci/rockset/commons/test_time_per_file_periodic_jobs.lambda.json
+++ b/torchci/rockset/commons/test_time_per_file_periodic_jobs.lambda.json
@@ -1,0 +1,5 @@
+{
+  "sql_path": "__sql/test_time_per_file_periodic_jobs.sql",
+  "default_parameters": [],
+  "description": ""
+}

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -5,6 +5,7 @@
     "flaky_tests": "59d7546183743626",
     "slow_tests": "ef8d035d23aa8ab6",
     "test_time_per_file": "50cb3694334ed63a",
+    "test_time_per_file_periodic_jobs": "39c105542e297c09",
     "issue_query": "f29a1afe94563601",
     "failure_samples_query": "2961636418a148c2",
     "recent_pr_workflows_query": "4e03cb13e8372050",

--- a/torchci/scripts/updateTestTimes.mjs
+++ b/torchci/scripts/updateTestTimes.mjs
@@ -2,29 +2,47 @@ import rockset from "@rockset/client";
 import { promises as fs } from "fs";
 import dotenv from "dotenv";
 import path from "path";
-import _ from "lodash"
+import _ from "lodash";
 
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
 
 const client = rockset.default(process.env.ROCKSET_API_KEY);
 
 async function readJSON(path) {
-    const rawData = await fs.readFile(path);
-    return JSON.parse(rawData);
+  const rawData = await fs.readFile(path);
+  return JSON.parse(rawData);
 }
 
 const prodVersions = await readJSON("rockset/prodVersions.json");
 
 const response = await client.queryLambdas.executeQueryLambda(
-    "commons",
-    "test_time_per_file",
-    prodVersions.commons.test_time_per_file,
-    {}
+  "commons",
+  "test_time_per_file",
+  prodVersions.commons.test_time_per_file,
+  {}
 );
 
-let ret = {}
+const periodic = await client.queryLambdas.executeQueryLambda(
+  "commons",
+  "test_time_per_file_periodic_jobs",
+  prodVersions.commons.test_time_per_file_periodic_jobs,
+  {}
+);
+
+let ret = {};
+for (const row of periodic.results) {
+  _.set(
+    ret,
+    `["${row.base_name}"]["${row.test_config}"]["${row.file}"]`,
+    row.time
+  );
+}
 for (const row of response.results) {
-    _.set(ret, `["${row.base_name}"]["${row.test_config}"]["${row.file}"]`, row.time);
+  _.set(
+    ret,
+    `["${row.base_name}"]["${row.test_config}"]["${row.file}"]`,
+    row.time
+  );
 }
 
-process.stdout.write(JSON.stringify(ret, null, 2))
+process.stdout.write(JSON.stringify(ret, null, 2));

--- a/torchci/scripts/updateTestTimes.mjs
+++ b/torchci/scripts/updateTestTimes.mjs
@@ -30,14 +30,7 @@ const periodic = await client.queryLambdas.executeQueryLambda(
 );
 
 let ret = {};
-for (const row of periodic.results) {
-  _.set(
-    ret,
-    `["${row.base_name}"]["${row.test_config}"]["${row.file}"]`,
-    row.time
-  );
-}
-for (const row of response.results) {
+for (const row of periodic.results.concat(response.results)) {
   _.set(
     ret,
     `["${row.base_name}"]["${row.test_config}"]["${row.file}"]`,


### PR DESCRIPTION
as in title, so that periodic jobs can be sharded properly (at least, i think)

<details><summary>snippet of file </summary>

```
"linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck": {
    "default": {
      "backends/xeon/test_launch": 2.1216666666666666,
      "benchmark_utils/test_benchmark_utils": 2.9416666666666664,
      "distributions/test_distributions": 68.079,
      "lazy/test_reuse_ir": 1.6843333333333337,
      "lazy/test_ts_opinfo": 0.25566666666666665,
      "test_ao_sparsity": 8.661,
      "test_autocast": 1.6963333333333328,
      "test_autograd": 59.615000000000045,
      "test_binary_ufuncs": 197.18666666664592,
      "test_bundled_inputs": 2.556666666666666,
      "test_complex": 0.009666666666666667,
      "test_cpp_api_parity": 21.73700000000004,
      "test_cpp_extensions_aot_ninja": 0.4913333333333334,
      "test_cpp_extensions_aot_no_ninja": 0.496,
      "test_cpp_extensions_jit": 0.030000000000000013,
      "test_cpp_extensions_open_device_registration": 3.425666666666667,
      "test_cuda": 55.251,
      "test_cuda_primary_ctx": 0.004,
      "test_cuda_trace": 9.820000000000002,
      "test_custom_backend": 0.11666666666666665,
      "test_custom_ops": 0.10266666666666668,
      "test_dataloader": 50.61566666666667,
      "test_datapipe": 2.133666666666666,
      "test_decomp": 1.9166666666665524,
      "test_dispatch": 37.40266666666667,
      "test_dynamic_shapes": 7.816,
      "test_expanded_weights": 4.314666666666664,
      "test_fake_tensor": 6.0029999999999974,
      "test_foreach": 295.18766666666556,
      "test_function_schema": 2.0273333333333325,
      "test_functional_autograd_benchmark": 23.781666666666666,
      "test_functional_optim": 1.6669999999999998,
      "test_functionalization": 2.462999999999998,
      "test_futures": 2.2126666666666654,
      "test_fx": 7.512999999999995,
      "test_fx_backends": 1.6883333333333335,
      "test_fx_experimental": 18.95066666666663,
      "test_fx_passes": 0.2946666666666668,
      "test_fx_reinplace_pass": 1.6356666666666664,
      "test_import_stats": 4.686333333333334,
      "test_indexing": 1.8263333333333307,
      "test_jit": 172.62433333333328,
      "test_jit_autocast": 65.75333333333333,
      "test_jit_cuda_fuser": 128.40600000000072,
      "test_jit_disabled": 1.8616666666666666,
      "test_jit_fuser_te": 475.4343333333339,
      "test_jit_llga_fuser": 65.64633333333335,
      "test_jiterator": 9.674333333333417,
      "test_license": 1.5686666666666664,
      "test_linalg": 357.8479999999974,
      "test_logging": 3.6293333333333333,
      "test_masked": 37.75433333333315,
      "test_meta": 10.163666666666485,
      "test_mkl_verbose": 4.897666666666667,
      "test_mkldnn": 27.276999999999997,
      "test_mkldnn_fusion": 1.401,
      "test_mkldnn_verbose": 4.7,
      "test_mobile_optimizer": 4.743333333333333,
      "test_model_dump": 2.4263333333333335,
      "test_module_init": 4.17466666666665,
      "test_modules": 916.9693333333353,
      "test_monitor": 1.772333333333333,
      "test_multiprocessing": 61.94733333333332,
      "test_multiprocessing_spawn": 1.7253333333333334,
      "test_namedtensor": 1.8449999999999982,
      "test_namedtuple_return_api": 3.456,
      "test_native_functions": 1.7296666666666667,
      "test_native_mha": 0.3703333333333334,
      "test_nestedtensor": 1.4686666666666672,
      "test_nn": 2685.7176666666624,
      "test_numba_integration": 0.06233333333333333,
      "test_numpy_interop": 0.139,
      "test_openmp": 5.0600000000000005,
      "test_ops": 807.4949999999911,
      "test_ops_gradients": 10657.99766666822,
      "test_ops_jit": 2.129999999999987,
      "test_optim": 136.75,
      "test_overrides": 3.2783333333332885,
      "test_package": 4.139999999999998,
      "test_per_overload_api": 1.593333333333333,
      "test_prims": 2.3123333333333327,
      "test_profiler": 19.81533333333333,
      "test_profiler_tree": 7.297333333333332,
      "test_proxy_tensor": 4.759999999999999,
      "test_public_bindings": 3.1749999999999994,
      "test_python_dispatch": 3.1349999999999962,
      "test_pytree": 1.639666666666666,
      "test_quantization": 443.50566666666674,
      "test_reductions": 93.6663333333337,
      "test_scatter_gather_ops": 5.958666666666666,
      "test_schema_check": 587.4236666666604,
      "test_serialization": 28.583,
      "test_set_default_mobile_cpu_allocator": 1.5733333333333333,
      "test_shape_ops": 2.249333333333331,
      "test_show_pickle": 1.5903333333333334,
      "test_sort_and_select": 6.227666666666657,
      "test_sparse": 76.93200000000026,
      "test_sparse_csr": 53.33066666666722,
      "test_spectral_ops": 8.738333333333328,
      "test_stateless": 5.903666666666666,
      "test_subclass": 1.791999999999998,
      "test_tensor_creation_ops": 96.73733333333331,
      "test_tensorboard": 28.027333333333335,
      "test_tensorexpr": 78.34166666666665,
      "test_tensorexpr_pybind": 0.6363333333333334,
      "test_testing": 20.183000000000003,
      "test_torch": 107.64733333333362,
      "test_transformers": 2.5463333333333336,
      "test_type_hints": 74.278,
      "test_type_info": 1.5886666666666667,
      "test_type_promotion": 20.592333333333332,
      "test_unary_ufuncs": 266.3139999999471,
      "test_utils": 24.675333333333338,
      "test_view_ops": 26.080666666666655,
      "test_vmap": 2.9746666666666672,
      "test_vulkan": 0.005,
      "test_xnnpack_integration": 7.281333333333333
    }
  },
```
</details>