### PR TITLE
[flakytest bot] use better capture for flaky unittests

### DIFF
--- a/torchci/components/LogViewer.tsx
+++ b/torchci/components/LogViewer.tsx
@@ -204,7 +204,7 @@ export default function LogViewer({ job }: { job: JobData }) {
     });
   });
 
-  if (!isFailure(job.conclusion)) {
+  if (!job.failureLine && !isFailure(job.conclusion)) {
     return null;
   }
 

--- a/torchci/pages/api/classifier/rules.ts
+++ b/torchci/pages/api/classifier/rules.ts
@@ -195,8 +195,13 @@ export default async function handler(
         priority: 100,
       },
       {
-        name: "Python flaky unittest",
-        pattern: r`^\s*(test.*) (fail|error|succeed)?ed - num_retries_left:`,
+        name: "Python flaky unittest - failed",
+        pattern: r`^\s*(test.*) failed - num_retries_left:`,
+        priority: 100,
+      },
+      {
+        name: "Python flaky unittest - errored",
+        pattern: r`^\s*(test.*) errored - num_retries_left:`,
         priority: 100,
       },
       {

--- a/torchci/pages/api/flaky-tests/flakytest.ts
+++ b/torchci/pages/api/flaky-tests/flakytest.ts
@@ -5,8 +5,10 @@ import fetchFailureSamples from "lib/fetchFailureSamples";
 
 interface Data {}
 
+// The captures are based on the regex in the Python flaky unittest
+// classifications in torchci/pages/api/classifier/rules.ts
 export function getFlakyTestCapture(flakyTest: FlakyTestData): string {
-  return `${flakyTest.name}, ${flakyTest.suite}`;
+  return `${flakyTest.name}`;
 }
 
 export default async function handler(


### PR DESCRIPTION
This would enable flaky test view to have log viewers! 

A few steps had to happen for this to occur:
1. the actual aws lambda had to start categorizing the logs of succeeding jobs (done on 8/12 manually)
2. the capture we supposed had to match the capture that was captured as a part of the classification --> this PR does this
3. the LogViewer would reveal itself if there is a failureLine associated with a job --> this PR does this

Test plan: please checkout the preview! https://torchci-git-fork-janeyx99-use-better-capture-flaky-torchci.vercel.app/flakytest?name=test_no_cyclic_references 
![Screen Shot 2022-08-15 at 11 13 36 AM](https://user-images.githubusercontent.com/31798555/184663259-faa54d69-f3a9-49b6-9f44-4ee1b0fb668e.png)

