### PR TITLE
auto revert tracker helper

### DIFF
--- a/.github/workflows/revert-tracker.yml
+++ b/.github/workflows/revert-tracker.yml
@@ -2,7 +2,6 @@ name: revert printer
 
 on:
   repository_dispatch:
-  push:
   schedule:
     # At 16:39 (9:39 AM PST) on Monday
     - cron: 39 16 * * 1

--- a/.github/workflows/revert-tracker.yml
+++ b/.github/workflows/revert-tracker.yml
@@ -39,4 +39,8 @@ jobs:
           destination_branch: csl/reverttest
           user_email: "csl@fb.com"
           user_name: "Catherine Lee"
+          # if this gets merged ill use these instead of my own branch and identity
+          # destination_branch: generated-stats
+          # user_email: 'test-infra@pytorch.org'
+          # user_name: 'PyTorch Test Infra'
           commit_message: "Updating helper for reverts"

--- a/.github/workflows/revert-tracker.yml
+++ b/.github/workflows/revert-tracker.yml
@@ -21,19 +21,22 @@ jobs:
           repository: pytorch/pytorch
           path: pytorch
           fetch-depth: 0
-      - run: |
+      - id: generate-reverts-file
+        run: |
           cd test-infra
           python3 -m pip install rockset==0.8.3
-          python3 -m torchci.scripts.reverts > reverts.md
+          file=$(python3 -m torchci.scripts.reverts)
+          echo "::set-output name=revert_file::$file"
         env:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
 
       - name: Push file to this repository
+        if: steps.generate-reverts-file.outputs.revert_file != 'None'
         uses: dmnemec/copy_file_to_another_repo_action@5f40763ccee2954067adba7fb8326e4df33bcb92
         env:
           API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
         with:
-          source_file: "test-infra/reverts.md"
+          source_file: test-infra/${{ steps.generate-reverts-file.outputs.revert_file }}
           destination_repo: "pytorch/test-infra"
           destination_folder: "reverts"
           destination_branch: csl/reverttest

--- a/.github/workflows/revert-tracker.yml
+++ b/.github/workflows/revert-tracker.yml
@@ -1,0 +1,42 @@
+name: revert printer
+
+on:
+  repository_dispatch:
+  push:
+  schedule:
+    # At 16:39 (9:39 AM PST) on Monday
+    - cron: 39 16 * * 1
+
+jobs:
+  revert_printer:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          path: test-infra
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          repository: pytorch/pytorch
+          path: pytorch
+          fetch-depth: 0
+      - run: |
+          cd test-infra
+          python3 -m pip install rockset==0.8.3
+          python3 -m torchci.scripts.reverts > reverts.md
+        env:
+          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
+
+      - name: Push file to this repository
+        uses: dmnemec/copy_file_to_another_repo_action@5f40763ccee2954067adba7fb8326e4df33bcb92
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          source_file: "test-infra/reverts.md"
+          destination_repo: "pytorch/test-infra"
+          destination_folder: "reverts"
+          destination_branch: csl/reverttest
+          user_email: "csl@fb.com"
+          user_name: "Catherine Lee"
+          commit_message: "Updating helper for reverts"

--- a/.github/workflows/revert-tracker.yml
+++ b/.github/workflows/revert-tracker.yml
@@ -39,11 +39,7 @@ jobs:
           source_file: test-infra/${{ steps.generate-reverts-file.outputs.revert_file }}
           destination_repo: "pytorch/test-infra"
           destination_folder: "reverts"
-          destination_branch: csl/reverttest
-          user_email: "csl@fb.com"
-          user_name: "Catherine Lee"
-          # if this gets merged ill use these instead of my own branch and identity
-          # destination_branch: generated-stats
-          # user_email: 'test-infra@pytorch.org'
-          # user_name: 'PyTorch Test Infra'
+          destination_branch: generated-stats
+          user_email: "test-infra@pytorch.org"
+          user_name: "PyTorch Test Infra"
           commit_message: "Updating helper for reverts"

--- a/torchci/rockset/commons/__sql/reverted_prs_with_reason.sql
+++ b/torchci/rockset/commons/__sql/reverted_prs_with_reason.sql
@@ -1,0 +1,23 @@
+SELECT 
+    ic._event_time revert_time,
+	ic.user.login as reverter,
+    REGEXP_EXTRACT(ic.body, '-c[\s =]+"?(\w+)"?', 1) as code,
+    REGEXP_EXTRACT(ic.body, '-m[\s =]+["'']?([^"'']+)["'']?', 1) as message,
+    ic.html_url as comment_url
+FROM commons.issue_comment AS ic
+	INNER JOIN 
+    (
+      SELECT 
+        issue_comment.issue_url,
+        MAX(issue_comment._event_time) as event_time -- Use the max for when invalid revert commands are tried first
+      FROM commons.issue_comment
+      WHERE issue_comment.body LIKE '@pytorchbot revert%'
+          OR issue_comment.body LIKE '@pytorchmergebot revert%'
+          OR issue_comment.body LIKE '@mergebotbot revert%'
+      GROUP BY issue_comment.issue_url
+    ) AS rc ON ic.issue_url = rc.issue_url
+WHERE
+	ic._event_time = rc.event_time 
+    AND ic._event_time >= PARSE_DATETIME_ISO8601(:startTime)
+    AND ic._event_time < PARSE_DATETIME_ISO8601(:stopTime)
+ORDER BY code DESC

--- a/torchci/rockset/commons/reverted_prs_with_reason.lambda.json
+++ b/torchci/rockset/commons/reverted_prs_with_reason.lambda.json
@@ -1,0 +1,16 @@
+{
+  "sql_path": "__sql/reverted_prs_with_reason.sql",
+  "default_parameters": [
+    {
+      "name": "startTime",
+      "type": "string",
+      "value": "2022-07-25T00:06:32.839Z"
+    },
+    {
+      "name": "stopTime",
+      "type": "string",
+      "value": "2022-08-01T00:06:32.839Z"
+    }
+  ],
+  "description": "Displays the PRs that were reverted and their classifications"
+}

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -9,6 +9,7 @@
     "issue_query": "f29a1afe94563601",
     "failure_samples_query": "2961636418a148c2",
     "recent_pr_workflows_query": "4e03cb13e8372050",
+    "reverted_prs_with_reason": "f35155a95a233476",
     "unclassified": "df744380711131d9"
   },
   "pytorch_dev_infra_kpis": {

--- a/torchci/scripts/github_analyze.py
+++ b/torchci/scripts/github_analyze.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+# taken from the builder repo
+
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Iterable, Optional, Union
+from urllib.request import urlopen, Request
+from urllib.error import HTTPError
+import json
+import enum
+import os
+
+
+class IssueState(enum.Enum):
+    OPEN = "open"
+    CLOSED = "closed"
+    ALL = "all"
+
+    def __str__(self):
+        return self.value
+
+
+class GitCommit:
+    commit_hash: str
+    title: str
+    body: str
+    author: str
+    author_date: datetime
+    commit_date: Optional[datetime]
+
+    def __init__(self,
+                 commit_hash: str,
+                 author: str,
+                 author_date: datetime,
+                 title: str,
+                 body: str,
+                 commit_date: Optional[datetime] = None) -> None:
+        self.commit_hash = commit_hash
+        self.author = author
+        self.author_date = author_date
+        self.commit_date = commit_date
+        self.title = title
+        self.body = body
+
+    def __contains__(self, item: Any) -> bool:
+        return item in self.body or item in self.title
+
+
+def get_revert_revision(commit: GitCommit) -> Optional[str]:
+    import re
+    body_rc = re.search("Original Phabricator Diff: (D\\d+)", commit.body)
+
+    if commit.title.startswith("Back out \"") and body_rc is not None:
+        return body_rc.group(1)
+
+    rc = re.match("Revert (D\\d+):", commit.title)
+    if rc is None:
+        return None
+    return rc.group(1)
+
+
+def get_diff_revision(commit: GitCommit) -> Optional[str]:
+    import re
+    rc = re.search("\\s*Differential Revision: (D\\d+)", commit.body)
+    if rc is None:
+        return None
+    return rc.group(1)
+
+
+def get_ghf_revert_revision(commit: GitCommit) -> Optional[str]:
+    import re
+    rc = re.search("\\s*This reverts commit ([0-9a-f]+).", commit.body)
+    if all([
+        commit.title.startswith("Revert"),
+        commit.author == "PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>",
+        rc is not None
+    ]):
+        return rc.group(1)
+    return None
+
+
+def is_revert(commit: GitCommit) -> bool:
+    return get_revert_revision(commit) is not None or get_ghf_revert_revision(commit) is not None
+
+
+def parse_medium_format(lines: Union[str, List[str]]) -> GitCommit:
+    """
+    Expect commit message generated using `--format=medium --date=unix` format, i.e.:
+        commit <sha1>
+        Author: <author>
+        Date:   <author date>
+
+        <title line>
+
+        <full commit message>
+
+    """
+    if isinstance(lines, str):
+        lines = lines.split("\n")
+    # TODO: Handle merge commits correctly
+    if len(lines) > 1 and lines[1].startswith("Merge:"):
+        del lines[1]
+    assert len(lines) > 5
+    assert lines[0].startswith("commit")
+    assert lines[1].startswith("Author: ")
+    assert lines[2].startswith("Date: ")
+    assert len(lines[3]) == 0
+    return GitCommit(commit_hash=lines[0].split()[1].strip(),
+                     author=lines[1].split(":", 1)[1].strip(),
+                     author_date=datetime.fromtimestamp(int(lines[2].split(":", 1)[1].strip())),
+                     title=lines[4].strip(),
+                     body="\n".join(lines[5:]),
+                     )
+
+
+def parse_fuller_format(lines: Union[str, List[str]]) -> GitCommit:
+    """
+    Expect commit message generated using `--format=fuller --date=unix` format, i.e.:
+        commit <sha1>
+        Author:     <author>
+        AuthorDate: <author date>
+        Commit:     <committer>
+        CommitDate: <committer date>
+
+        <title line>
+
+        <full commit message>
+
+    """
+    if isinstance(lines, str):
+        lines = lines.split("\n")
+    # TODO: Handle merge commits correctly
+    if len(lines) > 1 and lines[1].startswith("Merge:"):
+        del lines[1]
+    assert len(lines) > 7
+    assert lines[0].startswith("commit")
+    assert lines[1].startswith("Author: ")
+    assert lines[2].startswith("AuthorDate: ")
+    assert lines[3].startswith("Commit: ")
+    assert lines[4].startswith("CommitDate: ")
+    assert len(lines[5]) == 0
+    return GitCommit(commit_hash=lines[0].split()[1].strip(),
+                     author=lines[1].split(":", 1)[1].strip(),
+                     author_date=datetime.fromtimestamp(int(lines[2].split(":", 1)[1].strip())),
+                     commit_date=datetime.fromtimestamp(int(lines[4].split(":", 1)[1].strip())),
+                     title=lines[6].strip(),
+                     body="\n".join(lines[7:]),
+                     )
+
+
+def _check_output(items: List[str], encoding='utf-8') -> str:
+    from subprocess import check_output
+    return check_output(items).decode(encoding)
+
+
+def get_git_remotes(path: str) -> Dict[str, str]:
+    keys = _check_output(["git", "-C", path, "remote"]).strip().split("\n")
+    return {key: _check_output(["git", "-C", path, "remote", "get-url", key]).strip() for key in keys}
+
+
+class GitRepo:
+    def __init__(self, path, remote='upstream'):
+        self.repo_dir = path
+        self.remote = remote
+
+    def _run_git_log(self, revision_range, additional_args=[]) -> List[GitCommit]:
+        log = _check_output(['git', '-C', self.repo_dir, 'log',
+                             '--format=fuller', '--date=unix', revision_range] + additional_args + ['--', '.'] + additional_args).split("\n")
+        rc: List[GitCommit] = []
+        cur_msg: List[str] = []
+        for line in log:
+            if line.startswith("commit"):
+                if len(cur_msg) > 0:
+                    rc.append(parse_fuller_format(cur_msg))
+                    cur_msg = []
+            cur_msg.append(line)
+        if len(cur_msg) > 0:
+            rc.append(parse_fuller_format(cur_msg))
+        return rc
+
+    def get_commit_list(self, from_ref, to_ref) -> List[GitCommit]:
+        return self._run_git_log(f"{self.remote}/{from_ref}..{self.remote}/{to_ref}")
+
+
+def build_commit_dict(commits: List[GitCommit]) -> Dict[str, GitCommit]:
+    rc = {}
+    for commit in commits:
+        assert commit.commit_hash not in rc
+        rc[commit.commit_hash] = commit
+    return rc
+
+
+def fetch_json(url: str, params: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+    headers = {'Accept': 'application/vnd.github.v3+json'}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token is not None and url.startswith('https://api.github.com/'):
+        headers['Authorization'] = f'token {token}'
+    if params is not None and len(params) > 0:
+        url += '?' + '&'.join(f"{name}={val}" for name, val in params.items())
+    try:
+        with urlopen(Request(url, headers=headers)) as data:
+            return json.load(data)
+    except HTTPError as err:
+        if err.code == 403 and all(key in err.headers for key in ['X-RateLimit-Limit', 'X-RateLimit-Used']):
+            print(f"Rate limit exceeded: {err.headers['X-RateLimit-Used']}/{err.headers['X-RateLimit-Limit']}")
+        raise
+
+
+def fetch_multipage_json(url: str, params: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+    if params is None:
+        params = {}
+    assert "page" not in params
+    page_idx, rc, prev_len, params = 1, [], -1, params.copy()
+    while len(rc) > prev_len:
+        prev_len = len(rc)
+        params["page"] = page_idx
+        page_idx += 1
+        rc += fetch_json(url, params)
+    return rc
+
+
+def gh_get_milestones(org='pytorch', project='pytorch', state: IssueState = IssueState.OPEN) -> List[Dict[str, Any]]:
+    url = f'https://api.github.com/repos/{org}/{project}/milestones'
+    return fetch_multipage_json(url, {"state": state})
+
+
+def gh_get_milestone_issues(org: str, project: str, milestone_idx: int, state: IssueState = IssueState.OPEN):
+    url = f'https://api.github.com/repos/{org}/{project}/issues'
+    return fetch_multipage_json(url, {"milestone": milestone_idx, "state": state})
+
+
+def gh_get_ref_statuses(org: str, project: str, ref: str) -> Dict[str, Any]:
+    url = f'https://api.github.com/repos/{org}/{project}/commits/{ref}/status'
+    params = {"page": 1, "per_page": 100}
+    nrc = rc = fetch_json(url, params)
+    while "statuses" in nrc and len(nrc["statuses"]) == 100:
+        params["page"] += 1
+        nrc = fetch_json(url, params)
+        if "statuses" in nrc:
+            rc["statuses"] += nrc["statuses"]
+    return rc
+
+
+def extract_statuses_map(json: Dict[str, Any]):
+    return {s["context"]: s["state"] for s in json["statuses"]}
+
+
+class PeriodStats:
+    commits: int
+    reverts: int
+    authors: int
+    date: datetime
+
+    def __init__(self, date: datetime, commits: int, reverts: int, authors: int) -> None:
+        self.date = date
+        self.commits = commits
+        self.reverts = reverts
+        self.authors = authors
+
+
+def get_monthly_stats(commits: List[GitCommit]) -> Iterable[PeriodStats]:
+    y, m, total, reverts, authors = None, None, 0, 0, set()
+    for commit in commits:
+        commit_date = commit.commit_date if commit.commit_date is not None else commit.author_date
+        if y != commit_date.year or m != commit_date.month:
+            if y is not None:
+                yield PeriodStats(datetime(y, m, 1), total, reverts, len(authors))
+            y, m, total, reverts, authors = commit_date.year, commit_date.month, 0, 0, set()
+        if is_revert(commit):
+            reverts += 1
+        total += 1
+        authors.add(commit.author)
+
+
+def print_monthly_stats(commits: List[GitCommit]) -> None:
+    stats = list(get_monthly_stats(commits))
+    for idx, stat in enumerate(stats):
+        y = stat.date.year
+        m = stat.date.month
+        total, reverts, authors = stat.commits, stat.reverts, stat.authors
+        reverts_ratio = 100.0 * reverts / total
+        if idx + 1 < len(stats):
+            commits_growth = 100.0 * (stat.commits / stats[idx + 1].commits - 1)
+        else:
+            commits_growth = float('nan')
+        print(f"{y}-{m:02d}: commits {total} ({commits_growth:+.1f}%)  reverts {reverts} ({reverts_ratio:.1f}%) authors {authors}")
+
+
+def print_reverts(commits: List[GitCommit]) -> None:
+    for commit in commits:
+        if not is_revert(commit):
+            continue
+        print(f"{commit.commit_date} {commit.title} {commit.commit_hash} {commit.body}")
+
+
+def analyze_reverts(commits: List[GitCommit]):
+    for idx, commit in enumerate(commits):
+        revert_id = get_revert_revision(commit)
+        if revert_id is None:
+            continue
+        orig_commit = None
+        for i in range(1, 100):
+            orig_commit = commits[idx + i]
+            if get_diff_revision(orig_commit) == revert_id:
+                break
+        if orig_commit is None:
+            print(f"Failed to find original commit for {commit.title}")
+            continue
+        print(f"{commit.commit_hash} is a revert of {orig_commit.commit_hash}: {orig_commit.title}")
+        revert_statuses = gh_get_ref_statuses("pytorch", "pytorch", commit.commit_hash)
+        orig_statuses = gh_get_ref_statuses("pytorch", "pytorch", orig_commit.commit_hash)
+        orig_sm = extract_statuses_map(orig_statuses)
+        revert_sm = extract_statuses_map(revert_statuses)
+        for k in revert_sm.keys():
+            if k not in orig_sm:
+                continue
+            if orig_sm[k] != revert_sm[k]:
+                print(f"{k} {orig_sm[k]}->{revert_sm[k]}")
+
+
+def print_contributor_stats(commits, delta: Optional[timedelta] = None) -> None:
+    authors: Dict[str, int] = {}
+    now = datetime.now()
+    # Default delta is one non-leap year
+    if delta is None:
+        delta = timedelta(days=365)
+    for commit in commits:
+        date, author = commit.commit_date, commit.author
+        if now - date > delta:
+            break
+        if author not in authors:
+            authors[author] = 0
+        authors[author] += 1
+
+    print(f"{len(authors)} contributors made {sum(authors.values())} commits in last {delta.days} days")
+    for count, author in sorted(((commit, author) for author, commit in authors.items()), reverse=True):
+        print(f"{author}: {count}")
+
+
+def commits_missing_in_branch(repo: GitRepo, branch: str, orig_branch: str, milestone_idx: int) -> None:
+    def get_commits_dict(x, y):
+        return build_commit_dict(repo.get_commit_list(x, y))
+    master_commits = get_commits_dict(orig_branch, 'master')
+    release_commits = get_commits_dict(orig_branch, branch)
+    print(f"len(master_commits)={len(master_commits)}")
+    print(f"len(release_commits)={len(release_commits)}")
+    print("URL;Title;Status")
+    for issue in gh_get_milestone_issues('pytorch', 'pytorch', milestone_idx, IssueState.ALL):
+        html_url, state = issue["html_url"], issue["state"]
+        # Skip closed states if they were landed before merge date
+        if state == "closed":
+            mentioned_after_cut = any(html_url in commit_message for commit_message in master_commits.values())
+            # If issue is not mentioned after cut, that it must be present in release branch
+            if not mentioned_after_cut:
+                continue
+            mentioned_in_release = any(html_url in commit_message for commit_message in release_commits.values())
+            # if Issue is mentioned is release branch, than it was picked already
+            if mentioned_in_release:
+                continue
+        print(f'{html_url};{issue["title"]};{state}')
+
+
+def parse_arguments():
+    from argparse import ArgumentParser
+    parser = ArgumentParser(description="Print GitHub repo stats")
+    parser.add_argument("--repo-path",
+                        type=str,
+                        help="Path to PyTorch git checkout",
+                        default=os.path.expanduser("~/git/pytorch/pytorch"))
+    parser.add_argument("--milestone-id", type=str)
+    parser.add_argument("--branch", type=str)
+    parser.add_argument("--remote",
+                        type=str,
+                        help="Remote to base off of",
+                        default="")
+    parser.add_argument("--analyze-reverts", action="store_true")
+    parser.add_argument("--print-reverts", action="store_true")
+    parser.add_argument("--contributor-stats", action="store_true")
+    parser.add_argument("--missing-in-branch", action="store_true")
+    return parser.parse_args()
+
+
+def main():
+    import time
+    args = parse_arguments()
+    remote = args.remote
+    if not remote:
+        remotes = get_git_remotes(args.repo_path)
+        # Pick best remote
+        remote = next(iter(remotes.keys()))
+        for key in remotes:
+            if remotes[key].endswith('github.com/pytorch/pytorch'):
+                remote = key
+
+    repo = GitRepo(args.repo_path, remote)
+
+    if args.missing_in_branch:
+        # Use milestone idx or search it along milestone titles
+        try:
+            milestone_idx = int(args.milestone_id)
+        except ValueError:
+            milestone_idx = -1
+            milestones = gh_get_milestones()
+            for milestone in milestones:
+                if milestone.get('title', '') == args.milestone_id:
+                    milestone_idx = int(milestone.get('number', '-2'))
+            if milestone_idx < 0:
+                print(f'Could not find milestone {args.milestone_id}')
+                return
+
+        commits_missing_in_branch(repo,
+                                  args.branch,
+                                  f'orig/{args.branch}',
+                                  milestone_idx)
+        return
+
+    print(f"Parsing git history with remote {remote}...", end='', flush=True)
+    start_time = time.time()
+    x = repo._run_git_log(f"{remote}/master")
+    print(f"done in {time.time()-start_time:.1f} sec")
+    if args.analyze_reverts:
+        analyze_reverts(x)
+    elif args.contributor_stats:
+        print_contributor_stats(x)
+    elif args.print_reverts:
+        print_reverts(x[:2**9])
+        print(len(x))
+    else:
+        print_monthly_stats(x)
+
+
+if __name__ == "__main__":
+    main()

--- a/torchci/scripts/github_analyze.py
+++ b/torchci/scripts/github_analyze.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# taken from the builder repo
+# taken from the builder repo https://github.com/pytorch/builder/blob/main/analytics/github_analyze.py
 
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Iterable, Optional, Union
@@ -353,7 +353,7 @@ def commits_missing_in_branch(repo: GitRepo, branch: str, orig_branch: str, mile
             if not mentioned_after_cut:
                 continue
             mentioned_in_release = any(html_url in commit_message for commit_message in release_commits.values())
-            # if Issue is mentioned is release branch, than it was picked already
+            # if Issue is mentioned in release branch, than it was picked already
             if mentioned_in_release:
                 continue
         print(f'{html_url};{issue["title"]};{state}')

--- a/torchci/scripts/reverts.py
+++ b/torchci/scripts/reverts.py
@@ -39,6 +39,7 @@ def format_string_for_markdown_short(
         s += f"- [{commit.title}](https://github.com/pytorch/pytorch/commit/{commit.commit_hash})"
     if rockset_result is not None:
         s += f' by [comment]({rockset_result["comment_url"]})'
+    s += "\n"
     return s
 
 
@@ -52,6 +53,7 @@ def format_string_for_markdown_long(
         s = f"- [{commit.title}](https://github.com/pytorch/pytorch/commit/{commit.commit_hash})"
     if rockset_result is not None:
         s += f'\n  - {rockset_result["message"]} ([comment]({rockset_result["comment_url"]}))'
+    s += "\n"
     return s
 
 
@@ -123,16 +125,19 @@ def main():
     for gitlog_revert in gitlog_reverts:
         classification_dict["manual"].append((gitlog_revert, None))
 
-    print(f"# Week of {start_time.split('T')[0]} to {end_time.split('T')[0]}")
-    for classification, reverts in classification_dict.items():
-        print(f"\n### {CLASSIFICATIONS[classification]}\n")
-        for commit, rockset_result in reverts:
-            print(format_string_for_markdown_short(commit, rockset_result))
-    print(f"# Week of {start_time.split('T')[0]} to {end_time.split('T')[0]}")
-    for classification, reverts in classification_dict.items():
-        print(f"\n### {CLASSIFICATIONS[classification]}\n")
-        for commit, rockset_result in reverts:
-            print(format_string_for_markdown_long(commit, rockset_result))
+    filename = f"{start_time.split('T')[0]}.md"
+    with open(filename, "w") as f:
+        f.write(f"# Week of {start_time.split('T')[0]} to {end_time.split('T')[0]}\n")
+        for classification, reverts in classification_dict.items():
+            f.write(f"\n### {CLASSIFICATIONS[classification]}\n\n")
+            for commit, rockset_result in reverts:
+                f.write(format_string_for_markdown_short(commit, rockset_result))
+        f.write(f"# Week of {start_time.split('T')[0]} to {end_time.split('T')[0]}\n")
+        for classification, reverts in classification_dict.items():
+            f.write(f"\n### {CLASSIFICATIONS[classification]}\n\n")
+            for commit, rockset_result in reverts:
+                f.write(format_string_for_markdown_long(commit, rockset_result))
+    print(filename)
 
 
 if __name__ == "__main__":

--- a/torchci/scripts/reverts.py
+++ b/torchci/scripts/reverts.py
@@ -1,0 +1,140 @@
+from collections import defaultdict
+import datetime
+import re
+from torchci.scripts.github_analyze import GitCommit, GitRepo
+import json
+import os
+from typing import Dict, List, Optional
+from rockset import Client, ParamDict
+import sys
+
+
+CLASSIFICATIONS = {
+    "nosignal": "No Signal",
+    "ignoredsignal": "Ignored Signal",
+    "landrace": "Landrace",
+    "weird": "Weird",
+    "ghfirst": "GHFirst",
+    "manual": "Not through pytorchbot",
+}
+
+
+def find_corresponding_gitlog_commit(
+    pr_num: str, list_of_commits: List[GitCommit]
+) -> Optional[GitCommit]:
+    for i, revert in enumerate(list_of_commits):
+        if revert.title.endswith(f'(#{pr_num})"'):
+            return list_of_commits.pop(i)
+    return None
+
+
+def format_string_for_markdown(
+    commit: GitCommit, rockset_result: Optional[Dict[str, str]] = None
+) -> str:
+    s = f"- [{commit.title}](https://github.com/pytorch/pytorch/commit/{commit.commit_hash})"
+    if rockset_result is not None:
+        s += f' by [comment]({rockset_result["comment_url"]})'
+    return s
+
+
+def format_string_for_markdown2(
+    commit: GitCommit, rockset_result: Optional[Dict[str, str]] = None
+) -> str:
+    s = f"- [{commit.title}](https://github.com/pytorch/pytorch/commit/{commit.commit_hash})"
+    if rockset_result is not None:
+        s += f'\n  - because {rockset_result["message"]} ([comment]({rockset_result["comment_url"]}))'
+    return s
+
+
+def get_start_stop_times():
+    today = datetime.date.today()
+    start_time = today + datetime.timedelta(days=-today.weekday(), weeks=-1)
+    end_time = today + datetime.timedelta(days=-today.weekday())
+    start_time = f"{start_time}T00:13:30.000Z"
+    end_time = f"{end_time}T00:13:30.000Z"
+    return start_time, end_time
+
+
+def get_rockset_reverts(start_time: str, end_time: str) -> List[Dict[str, str]]:
+    params = ParamDict(
+        {
+            "startTime": start_time,
+            "stopTime": end_time,
+        }
+    )
+    ROCKSET_API_KEY = os.environ.get("ROCKSET_API_KEY")
+    if ROCKSET_API_KEY is None:
+        raise RuntimeError("ROCKSET_API_KEY not set")
+
+    with open("torchci/rockset/prodVersions.json") as f:
+        prod_versions = json.load(f)
+
+    client = Client(
+        api_key=ROCKSET_API_KEY,
+        api_server="https://api.rs2.usw2.rockset.com",
+    )
+    qlambda = client.QueryLambda.retrieve(
+        "reverted_prs_with_reason",
+        version=prod_versions["commons"]["reverted_prs_with_reason"],
+        workspace="commons",
+    )
+
+    return qlambda.execute(parameters=params).results
+
+
+def get_gitlog_reverts(start_time: str, end_time: str):
+    repo_path = "../pytorch"
+    remote = "origin"
+    repo = GitRepo(repo_path, remote)
+    all_commits = repo._run_git_log(
+        f"{remote}/master", [f"--since={start_time}", f"--before={end_time}"]
+    )
+
+    return [
+        commit
+        for commit in all_commits
+        if commit.title.startswith("Revert") or commit.title.startswith("Back out")
+    ]
+
+
+def main():
+    start_time, end_time = get_start_stop_times()
+    rockset_reverts = get_rockset_reverts(start_time, end_time)
+    gitlog_reverts = get_gitlog_reverts(start_time, end_time)
+    classifcation_dict1 = defaultdict(lambda: [])
+    classifcation_dict2 = defaultdict(lambda: [])
+
+    for rockset_revert in rockset_reverts:
+        pr_num = re.search(r"/(\d+)\#", rockset_revert["comment_url"]).group(1)
+        commit = find_corresponding_gitlog_commit(pr_num, gitlog_reverts)
+        if commit is not None:
+            classifcation_dict1[rockset_revert["code"]].append(
+                format_string_for_markdown(commit, rockset_revert)
+            )
+            classifcation_dict2[rockset_revert["code"]].append(
+                format_string_for_markdown2(commit, rockset_revert)
+            )
+        if commit is None:
+            print(
+                f"I cant find the commit corresponding to {rockset_revert['comment_url']}",
+                file=sys.stderr,
+            )
+
+    for gitlog_revert in gitlog_reverts:
+        classifcation_dict1["manual"].append(format_string_for_markdown(gitlog_revert))
+        classifcation_dict2["manual"].append(format_string_for_markdown(gitlog_revert))
+
+    print(f"# Week of {start_time.split('T')[0]} to {end_time.split('T')[0]}")
+    for classification, reverts in classifcation_dict1.items():
+        print(f"\n### {CLASSIFICATIONS[classification]}\n")
+        for revert in reverts:
+            print(revert)
+    print(f"# Week of {start_time.split('T')[0]} to {end_time.split('T')[0]}")
+    for classification, reverts in classifcation_dict2.items():
+        print(f"\n### {CLASSIFICATIONS[classification]}\n")
+        for revert in reverts:
+            print(revert)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Make a periodic job to generate a list of reverts categorized with links to the revert reason, to be used for convenience when creating oncall shift summaries.  The hope is to make this as close to simply copy pasting it into the shift summary or just using the generated md file when presenting.

Example of the output: https://github.com/pytorch/test-infra/blob/csl/reverttest/reverts/reverts.md

"Not through pytorchbot" = starts with "Revert" or "Backout" but cannot find a @pytorchbot revert comment 

Two versions - one is short the other is long

Periodic job is set to Monday at 9:30am PT ish.  It should list all the revert commits happening from the previous Monday at 6:30am PT to the currently Monday at 6:30am PT as this is the official time the oncall shift starts.  It lists 

If this PR is approved, I'll change the it so that it is not my own branch/identity and remove the push trigger.
