### PR TITLE
[accept2ship] Don't Rerun on Multiple Accepts

### DIFF
--- a/torchci/lib/bot/acceptBot.ts
+++ b/torchci/lib/bot/acceptBot.ts
@@ -57,40 +57,6 @@ function acceptBot(app: Probot): void {
       }
     }
   });
-
-  app.on("pull_request.labeled", async (ctx) => {
-    const owner = ctx.payload.repository.owner.login;
-    const repo = ctx.payload.repository.name;
-    const issue_number = ctx.payload.pull_request.number;
-
-    if (ctx.payload.label.name === ACCEPT_2_RUN) {
-      await ctx.octokit.issues.addLabels({
-        owner,
-        repo,
-        issue_number,
-        labels: [CIFLOW_TRUNK_LABEL],
-      });
-      await ctx.octokit.issues.removeLabel({
-        owner,
-        repo,
-        issue_number,
-        name: ACCEPT_2_RUN,
-      });
-    } else if (ctx.payload.label.name === ACCEPT_2_SHIP) {
-      await ctx.octokit.issues.createComment({
-        owner,
-        repo,
-        issue_number,
-        body: ACCEPT_MESSAGE,
-      });
-      await ctx.octokit.issues.removeLabel({
-        owner,
-        repo,
-        issue_number,
-        name: ACCEPT_2_SHIP,
-      });
-    }
-  });
 }
 
 export default acceptBot;

--- a/torchci/lib/bot/acceptBot.ts
+++ b/torchci/lib/bot/acceptBot.ts
@@ -57,6 +57,40 @@ function acceptBot(app: Probot): void {
       }
     }
   });
+
+  app.on("pull_request.labeled", async (ctx) => {
+    const owner = ctx.payload.repository.owner.login;
+    const repo = ctx.payload.repository.name;
+    const issue_number = ctx.payload.pull_request.number;
+
+    if (ctx.payload.label.name === ACCEPT_2_RUN) {
+      await ctx.octokit.issues.addLabels({
+        owner,
+        repo,
+        issue_number,
+        labels: [CIFLOW_TRUNK_LABEL],
+      });
+      await ctx.octokit.issues.removeLabel({
+        owner,
+        repo,
+        issue_number,
+        name: ACCEPT_2_RUN,
+      });
+    } else if (ctx.payload.label.name === ACCEPT_2_SHIP) {
+      await ctx.octokit.issues.createComment({
+        owner,
+        repo,
+        issue_number,
+        body: ACCEPT_MESSAGE,
+      });
+      await ctx.octokit.issues.removeLabel({
+        owner,
+        repo,
+        issue_number,
+        name: ACCEPT_2_SHIP,
+      });
+    }
+  });
 }
 
 export default acceptBot;

--- a/torchci/lib/bot/acceptBot.ts
+++ b/torchci/lib/bot/acceptBot.ts
@@ -35,12 +35,24 @@ function acceptBot(app: Probot): void {
           issue_number,
           labels: [CIFLOW_TRUNK_LABEL],
         });
+        await ctx.octokit.issues.removeLabel({
+          owner,
+          repo,
+          issue_number,
+          name: ACCEPT_2_RUN,
+        });
       } else if (hasAcceptToShip) {
         await ctx.octokit.issues.createComment({
           owner,
           repo,
           issue_number,
           body: ACCEPT_MESSAGE,
+        });
+        await ctx.octokit.issues.removeLabel({
+          owner,
+          repo,
+          issue_number,
+          name: ACCEPT_2_SHIP,
         });
       }
     }

--- a/torchci/test/acceptBot.test.ts
+++ b/torchci/test/acceptBot.test.ts
@@ -39,10 +39,13 @@ describe("accept bot", () => {
 
     const scope = nock("https://api.github.com")
       .post(`/repos/${owner}/${repo}/issues/${pr_number}/labels`, (body) => {
-        expect(JSON.stringify(body)).toContain(`"labels":["${CIFLOW_TRUNK_LABEL}"]`);
+        expect(JSON.stringify(body)).toContain(
+          `"labels":["${CIFLOW_TRUNK_LABEL}"]`
+        );
         return true;
       })
-
+      .reply(200, {})
+      .delete(`/repos/${owner}/${repo}/issues/4/labels/${ACCEPT_2_RUN}`)
       .reply(200, {});
     await probot.receive(event);
 
@@ -66,7 +69,8 @@ describe("accept bot", () => {
         );
         return true;
       })
-
+      .reply(200, {})
+      .delete(`/repos/${owner}/${repo}/issues/4/labels/${ACCEPT_2_SHIP}`)
       .reply(200, {});
     await probot.receive(event);
 


### PR DESCRIPTION
Once someone accepts, we remove the label to prevent it from running again. Another solution is adding another label and checking if that exists before kicking off merge from here, but we'd need to worry about deleting that label as well in trymerge if it fails. 

Test Plan: 
Let tests run