### PR TITLE
condensed disabled tests

### DIFF
--- a/.github/scripts/update_disabled_tests.py
+++ b/.github/scripts/update_disabled_tests.py
@@ -8,7 +8,6 @@ import json
 from functools import lru_cache
 from typing import Any, Dict
 from urllib.request import urlopen, Request
-import re
 # Modified from https://github.com/pytorch/pytorch/blob/b00206d4737d1f1e7a442c9f8a1cadccd272a386/torch/hub.py#L129
 
 

--- a/.github/scripts/update_disabled_tests.py
+++ b/.github/scripts/update_disabled_tests.py
@@ -98,7 +98,7 @@ def condense_disable_issues(disable_issues):
                         )
             disabled_test_from_issues[test_name] = (
                 issue_number,
-                item["html_url"],
+                issue_url,
                 platforms_to_skip,
             )
     with open("disabled-tests-condensed.json", mode="w") as file:

--- a/.github/scripts/update_disabled_tests.py
+++ b/.github/scripts/update_disabled_tests.py
@@ -8,8 +8,10 @@ import json
 from functools import lru_cache
 from typing import Any, Dict
 from urllib.request import urlopen, Request
-
+import re
 # Modified from https://github.com/pytorch/pytorch/blob/b00206d4737d1f1e7a442c9f8a1cadccd272a386/torch/hub.py#L129
+
+
 def _read_url(url: Any) -> Any:
     with urlopen(url) as r:
         return r.headers, r.read().decode(r.headers.get_content_charset("utf-8"))
@@ -57,7 +59,7 @@ def get_disable_issues() -> Dict[Any, Any]:
 
 def validate_and_sort(issues_json: Dict[str, Any]) -> None:
     assert issues_json["total_count"] == len(issues_json["items"]), f"# issues {len(issues_json['items'])} does not" \
-         f" equal total count {issues_json['total_count']}."
+        f" equal total count {issues_json['total_count']}."
     assert not issues_json["incomplete_results"], f"Results were incomplete. There may be missing issues."
 
     # score changes every request, so we strip it out to avoid creating a commit every time we query.
@@ -73,10 +75,41 @@ def write_issues_to_file(issues_json: Dict[Any, Any]) -> None:
         json.dump(issues_json, file, sort_keys=True, indent=2)
 
 
+def condense_disable_issues(disable_issues):
+    disabled_test_from_issues = dict()
+    for item in disable_issues["items"]:
+        title = item["title"]
+        key = "DISABLED "
+        issue_url = item["html_url"]
+        issue_number = issue_url.split("/")[-1]
+        if title.startswith(key):
+            test_name = title[len(key):].strip()
+            body = item["body"]
+            platforms_to_skip = []
+            key = "platforms:"
+            # When the issue has no body, it is assumed that all platforms should skip the test
+            if body is not None:
+                for line in body.splitlines():
+                    line = line.lower()
+                    if line.startswith(key):
+                        pattern = re.compile(r"^\s+|\s*,\s*|\s+$")
+                        platforms_to_skip.extend(
+                            [x for x in pattern.split(line[len(key):]) if x]
+                        )
+            disabled_test_from_issues[test_name] = (
+                issue_number,
+                item["html_url"],
+                platforms_to_skip,
+            )
+    with open("disabled-tests-condensed.json", mode="w") as file:
+        json.dump(disabled_test_from_issues, file, sort_keys=True, indent=2)
+
+
 def main() -> None:
     disable_issues = get_disable_issues()
     validate_and_sort(disable_issues)
     write_issues_to_file(disable_issues)
+    condense_disable_issues(disable_issues)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/update_disabled_tests.py
+++ b/.github/scripts/update_disabled_tests.py
@@ -92,9 +92,8 @@ def condense_disable_issues(disable_issues):
                 for line in body.splitlines():
                     line = line.lower()
                     if line.startswith(key):
-                        pattern = re.compile(r"^\s+|\s*,\s*|\s+$")
                         platforms_to_skip.extend(
-                            [x for x in pattern.split(line[len(key):]) if x]
+                            [x.strip() for x in line[len(key):].split(",") if x.strip()]
                         )
             disabled_test_from_issues[test_name] = (
                 issue_number,

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -43,4 +43,4 @@ jobs:
           destination_branch: generated-stats
           user_email: "test-infra@pytorch.org"
           user_name: "Pytorch Test Infra"
-          commit_message: "Updating disabled tests stats"
+          commit_message: "Updating condensed disabled tests stats"

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -6,6 +6,7 @@ on:
     - cron: "*/15 * * * *"
   # Have the ability to trigger this job manually through the API
   workflow_dispatch:
+  pull_request:
 
 jobs:
   update-disabled-tests:
@@ -19,12 +20,25 @@ jobs:
       - name: Print file
         run: |
           cat disabled-tests.json
+          cat disabled-tests-condensed.json
       - name: Push file to test-infra repository
         uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
         env:
            API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
         with:
           source_file: 'disabled-tests.json'
+          destination_repo: 'pytorch/test-infra'
+          destination_folder: 'stats'
+          destination_branch: generated-stats
+          user_email: 'test-infra@pytorch.org'
+          user_name: 'Pytorch Test Infra'
+          commit_message: 'Updating disabled tests stats'
+      - name: Push file to test-infra repository
+        uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          source_file: 'disabled-tests-condensed.json'
           destination_repo: 'pytorch/test-infra'
           destination_folder: 'stats'
           destination_branch: generated-stats

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -6,7 +6,6 @@ on:
     - cron: "*/15 * * * *"
   # Have the ability to trigger this job manually through the API
   workflow_dispatch:
-  pull_request:
 
 jobs:
   update-disabled-tests:
@@ -24,24 +23,24 @@ jobs:
       - name: Push file to test-infra repository
         uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
         env:
-           API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
         with:
-          source_file: 'disabled-tests.json'
-          destination_repo: 'pytorch/test-infra'
-          destination_folder: 'stats'
+          source_file: "disabled-tests.json"
+          destination_repo: "pytorch/test-infra"
+          destination_folder: "stats"
           destination_branch: generated-stats
-          user_email: 'test-infra@pytorch.org'
-          user_name: 'Pytorch Test Infra'
-          commit_message: 'Updating disabled tests stats'
+          user_email: "test-infra@pytorch.org"
+          user_name: "Pytorch Test Infra"
+          commit_message: "Updating disabled tests stats"
       - name: Push file to test-infra repository
         uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
         env:
           API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
         with:
-          source_file: 'disabled-tests-condensed.json'
-          destination_repo: 'pytorch/test-infra'
-          destination_folder: 'stats'
+          source_file: "disabled-tests-condensed.json"
+          destination_repo: "pytorch/test-infra"
+          destination_folder: "stats"
           destination_branch: generated-stats
-          user_email: 'test-infra@pytorch.org'
-          user_name: 'Pytorch Test Infra'
-          commit_message: 'Updating disabled tests stats'
+          user_email: "test-infra@pytorch.org"
+          user_name: "Pytorch Test Infra"
+          commit_message: "Updating disabled tests stats"


### PR DESCRIPTION
condense the disabled-tests.json because it is huge and we don't use the information from most of it

This will help us get a better sense of what is disabled and also what is actually used in CI.

I'll make a followup PR in pytorch for corresponding changes if this ends up being merged

Changes
* usually the tuple is (link, platforms) but now its (issue number, link, platforms) because the ci needs to know the pr number in order to re enable tests

Test Plan
go to  https://github.com/pytorch/test-infra/blob/generated-stats/stats/disabled-tests-condensed.json to see what it looks like