### PR TITLE
[Nova] Adding reusable workflow for building linux conda binaries

### DIFF
--- a/.github/workflows/build_conda_linux_reusable.yml
+++ b/.github/workflows/build_conda_linux_reusable.yml
@@ -1,0 +1,32 @@
+name: Build Linux Conda
+
+on:
+  workflow_call:
+    inputs:
+      domain:
+        description: 'name of the domain library calling this reusable workflow.'
+        required: true
+        type: string
+      image:
+        description: 'docker image container for running the reusable workflow.'
+        required: true
+        type: string
+
+jobs:
+  wheels:
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.image }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run pre-build script
+      run: ./packaging/pre_build_script_conda.sh
+      # TODO: make the conda channel generalizable based on the domain input
+    - name: Build Conda Package
+      run: conda build -c defaults \
+              -c $CUDATOOLKIT_CHANNEL ${CONDA_CHANNEL_FLAGS:-} \
+              --no-anaconda-upload \
+              --python "$PYTHON_VERSION" \
+              packaging/torchaudio
+    - name: Run post-build script
+      run: ./packaging/post_build_script_conda.sh

--- a/.github/workflows/build_conda_linux_reusable.yml
+++ b/.github/workflows/build_conda_linux_reusable.yml
@@ -21,12 +21,13 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run pre-build script
       run: ./packaging/pre_build_script_conda.sh
-      # TODO: make the conda channel generalizable based on the domain input
+    - name: Generate Conda Recipe Path
+      run: export CONDA_PATH=packaging/torch${{ inputs.domain }}
     - name: Build Conda Package
       run: conda build -c defaults \
-              -c $CUDATOOLKIT_CHANNEL ${CONDA_CHANNEL_FLAGS:-} \
+              -c "$CUDATOOLKIT_CHANNEL" "${CONDA_CHANNEL_FLAGS:-}" \
               --no-anaconda-upload \
               --python "$PYTHON_VERSION" \
-              packaging/torchaudio
+              "$CONDA_PATH" 
     - name: Run post-build script
       run: ./packaging/post_build_script_conda.sh

--- a/.github/workflows/build_conda_linux_reusable.yml
+++ b/.github/workflows/build_conda_linux_reusable.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Run pre-build script
       run: ./packaging/pre_build_script_conda.sh
     - name: Generate Conda Recipe Path
-      run: export CONDA_PATH=packaging/torch${{ inputs.domain }}
+      run: export CONDA_PATH=packaging/${{ inputs.domain }}
     - name: Build Conda Package
       run: conda build -c defaults \
               -c "$CUDATOOLKIT_CHANNEL" "${CONDA_CHANNEL_FLAGS:-}" \


### PR DESCRIPTION
Creating a reusable workflow for building conda binaries for linux. A follow-up PR in torchaudio will call this to build the conda binaries by calling this workflow.

For now, this can expect separate pre/post build scripts from the linux wheels workflow. In the future, we can try to unify them into a single thing that leverages @seemethere 's pkg-helpers python cli.