### PR TITLE
[accept2ship] Run/Ship when label is applied and there's an accept

### DIFF
--- a/torchci/lib/bot/acceptBot.ts
+++ b/torchci/lib/bot/acceptBot.ts
@@ -57,40 +57,6 @@ function acceptBot(app: Probot): void {
       }
     }
   });
-
-  app.on("pull_request.labeled", async (ctx) => {
-    const owner = ctx.payload.repository.owner.login;
-    const repo = ctx.payload.repository.name;
-    const issue_number = ctx.payload.pull_request.number;
-
-    if (ctx.payload.label.name === ACCEPT_2_RUN) {
-      await ctx.octokit.issues.addLabels({
-        owner,
-        repo,
-        issue_number,
-        labels: [CIFLOW_TRUNK_LABEL],
-      });
-      await ctx.octokit.issues.removeLabel({
-        owner,
-        repo,
-        issue_number,
-        name: ACCEPT_2_RUN,
-      });
-    } else if (ctx.payload.label.name === ACCEPT_2_SHIP) {
-      await ctx.octokit.issues.createComment({
-        owner,
-        repo,
-        issue_number,
-        body: ACCEPT_MESSAGE,
-      });
-      await ctx.octokit.issues.removeLabel({
-        owner,
-        repo,
-        issue_number,
-        name: ACCEPT_2_SHIP,
-      });
-    }
-  });
 }
 
 export default acceptBot;

--- a/torchci/lib/bot/acceptBot.ts
+++ b/torchci/lib/bot/acceptBot.ts
@@ -57,6 +57,40 @@ function acceptBot(app: Probot): void {
       }
     }
   });
+
+  app.on("pull_request.labeled", async (ctx) => {
+    const owner = ctx.payload.repository.owner.login;
+    const repo = ctx.payload.repository.name;
+    const issue_number = ctx.payload.pull_request.number;
+
+    if (ctx.payload.label.name === ACCEPT_2_RUN) {
+      await ctx.octokit.issues.addLabels({
+        owner,
+        repo,
+        issue_number,
+        labels: [CIFLOW_TRUNK_LABEL],
+      });
+      await ctx.octokit.issues.removeLabel({
+        owner,
+        repo,
+        issue_number,
+        name: ACCEPT_2_RUN,
+      });
+    } else if (ctx.payload.label.name === ACCEPT_2_SHIP) {
+      await ctx.octokit.issues.createComment({
+        owner,
+        repo,
+        issue_number,
+        body: ACCEPT_MESSAGE,
+      });
+      await ctx.octokit.issues.removeLabel({
+        owner,
+        repo,
+        issue_number,
+        name: ACCEPT_2_SHIP,
+      });
+    }
+  });
 }
 
 export default acceptBot;

--- a/torchci/lib/bot/acceptBot.ts
+++ b/torchci/lib/bot/acceptBot.ts
@@ -1,4 +1,5 @@
 import { Label } from "@octokit/webhooks-types";
+import { Octokit } from "octokit";
 import { Probot } from "probot";
 
 function containsLabel(labels: Label[], labelName: string) {
@@ -42,6 +43,56 @@ function acceptBot(app: Probot): void {
           name: ACCEPT_2_RUN,
         });
       } else if (hasAcceptToShip) {
+        await ctx.octokit.issues.createComment({
+          owner,
+          repo,
+          issue_number,
+          body: ACCEPT_MESSAGE,
+        });
+        await ctx.octokit.issues.removeLabel({
+          owner,
+          repo,
+          issue_number,
+          name: ACCEPT_2_SHIP,
+        });
+      }
+    }
+  });
+
+  app.on("pull_request.labeled", async (ctx) => {
+    const owner = ctx.payload.repository.owner.login;
+    const repo = ctx.payload.repository.name;
+    const issue_number = ctx.payload.pull_request.number;
+    ctx.payload.pull_request;
+
+    async function isApproved(): Promise<boolean> {
+      const reviews = await ctx.octokit.pulls.listReviews({
+        owner,
+        repo,
+        pull_number: issue_number,
+      });
+      const isApproved =
+        reviews.data.filter((review) => review.state == "approved").length > 0;
+      return isApproved;
+    }
+
+    if (ctx.payload.label.name === ACCEPT_2_RUN) {
+      if (await isApproved()) {
+        await ctx.octokit.issues.addLabels({
+          owner,
+          repo,
+          issue_number,
+          labels: [CIFLOW_TRUNK_LABEL],
+        });
+        await ctx.octokit.issues.removeLabel({
+          owner,
+          repo,
+          issue_number,
+          name: ACCEPT_2_RUN,
+        });
+      }
+    } else if (ctx.payload.label.name === ACCEPT_2_SHIP) {
+      if (await isApproved()) {
         await ctx.octokit.issues.createComment({
           owner,
           repo,

--- a/torchci/lib/bot/acceptBot.ts
+++ b/torchci/lib/bot/acceptBot.ts
@@ -1,5 +1,4 @@
 import { Label } from "@octokit/webhooks-types";
-import { Octokit } from "octokit";
 import { Probot } from "probot";
 
 function containsLabel(labels: Label[], labelName: string) {


### PR DESCRIPTION
Previously, if there was already an accept on the PR, and you added accept2run, it wouldn't do anything, which was kind of annoying. Now, if the label added is accept2run/accept2ship, we check if it's been accepted and then apply the ciflow labels if it is. 

Test Plan:
Let tests run