### PR TITLE
Add ciflow/test-config into the list of valid ciflow labels

### DIFF
--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -204,9 +204,12 @@ async function handleLabelEvent(context: Context<"pull_request.labeled">) {
     return;
   }
 
+  // TODO: Convert the test config label to tag is not yet supported and could
+  // only be done once we refactor the current workflows to support smaller
+  // workflow granularity per test config. After that, we can remove this check
+  // and do the same for these ciflow test config labels as what we are currently
+  // doing with ciflow/trunk, ciflow/periodic, and others
   if (valid_test_config_labels.includes(label)) {
-    // Convert the test config label to tag is not yet supported and could
-    // only be done once we refactor the current workflows to support it
     return;
   }
 

--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -145,7 +145,28 @@ async function handleLabelEvent(context: Context<"pull_request.labeled">) {
     "ciflow/binaries_libtorch",
     "ciflow/binaries_wheel",
   ];
-  if (!valid_labels.includes(label)) {
+
+  // The following labels control the test subsets we want to run,
+  // so their names are the same as shard names
+  const valid_test_config_labels = [
+    "ciflow/backwards_compat",
+    "ciflow/crossref",
+    "ciflow/default",
+    "ciflow/deploy",
+    "ciflow/distributed",
+    "ciflow/docs_tests",
+    "ciflow/dynamo",
+    "ciflow/force_on_cpu",
+    "ciflow/functorch",
+    "ciflow/jit_legacy",
+    "ciflow/multigpu",
+    "ciflow/nogpu_AVX512",
+    "ciflow/nogpu_NO_AVX2",
+    "ciflow/slow",
+    "ciflow/xla",
+  ];
+
+  if (!valid_labels.includes(label) && !valid_test_config_labels.includes(label)) {
     let body;
     if (label === "ciflow/all") {
       body =
@@ -165,15 +186,15 @@ async function handleLabelEvent(context: Context<"pull_request.labeled">) {
     body +=
       "- `ciflow/android` (`.github/workflows/run_android_tests.yml`): android build and test\n";
     body +=
-      "- `ciflow/mps` (`.github/workflows/mac-mps.yml`): Mac M1 build and MPS test\n";
-    body +=
       "- `ciflow/nightly` (`.github/workflows/nightly.yml`): all jobs we run nightly\n";
     body += "- `ciflow/binaries`: all binary build and upload jobs\n";
     body +=
       " - `ciflow/binaries_conda`: binary build and upload job for conda\n";
     body +=
       " - `ciflow/binaries_libtorch`: binary build and upload job for libtorch\n";
-    body += " - `ciflow/binaries_wheel`: binary build and upload job for wheel";
+    body += " - `ciflow/binaries_wheel`: binary build and upload job for wheel\n";
+    body += "In addition, you can use the following labels to select the test subsets to run: ";
+    body += valid_test_config_labels.join(", ");
     await context.octokit.issues.createComment(
       context.repo({
         body,
@@ -182,6 +203,13 @@ async function handleLabelEvent(context: Context<"pull_request.labeled">) {
     );
     return;
   }
+
+  if (valid_test_config_labels.includes(label)) {
+    // Convert the test config label to tag is not yet supported and could
+    // only be done once we refactor the current workflows to support it
+    return;
+  }
+
   const prNum = context.payload.pull_request.number;
   const tag = labelToTag(context.payload.label.name, prNum);
   await syncTag(context, tag, context.payload.pull_request.head.sha);


### PR DESCRIPTION
This is to support the new set of `ciflow/test-config` labels for manual test selection in https://github.com/pytorch/pytorch/pull/83690