### PR TITLE
[flaky test bot] don't incorporate file info into flaky test link

### DIFF
--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -142,7 +142,7 @@ export function getPlatformsAffected(workflowJobNames: string[]): string[] {
 }
 
 export function getIssueBodyForFlakyTest(test: FlakyTestData): string {
-  const examplesURL = `https://hud.pytorch.org/flakytest?name=${test.name}&suite=${test.suite}&file=${test.file}`;
+  const examplesURL = `https://hud.pytorch.org/flakytest?name=${test.name}&suite=${test.suite}`;
   return `Platforms: ${getPlatformsAffected(getWorkflowJobNames(test)).join(
     ", "
   )}

--- a/torchci/test/disableFlakyBot.test.ts
+++ b/torchci/test/disableFlakyBot.test.ts
@@ -412,7 +412,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
 
   test("getIssueBodyForFlakyTest: should contain correct examples URL", async () => {
     expect(disableFlakyTestBot.getIssueBodyForFlakyTest(flakyTestA)).toContain(
-      "https://hud.pytorch.org/flakytest?name=test_a&suite=suite_a&file=file_a.py"
+      "https://hud.pytorch.org/flakytest?name=test_a&suite=suite_a"
     );
   });
 });


### PR DESCRIPTION
Test file info does not work for files not in the test folder (because they contain `../`, I think, but I don't know) and we can almost always differentiate tests by suite + name anyway so we might as well just not include it.

Discovered with functorch test links not working unless you delete the file part.