### PR TITLE
[flaky test bot] when rocm, only triage rocm

### DIFF
--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -132,6 +132,7 @@ export function getPlatformsAffected(workflowJobNames: string[]): string[] {
     workflowJobNames.forEach((workflowJobNames) => {
       if (
         workflowJobNames.includes(platform) &&
+        (platform == "rocm" || !workflowJobNames.includes("rocm")) &&
         !platformsToSkip.includes(platform)
       ) {
         platformsToSkip.push(platform);

--- a/torchci/test/disableFlakyBot.test.ts
+++ b/torchci/test/disableFlakyBot.test.ts
@@ -404,6 +404,13 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
     ]);
   });
 
+  test("getPlatformsAffected: should correctly triage rocm without linux", async () => {
+    const workflowJobs = ["pull / whatever-rocm-linux / build"];
+    expect(disableFlakyTestBot.getPlatformsAffected(workflowJobs)).toEqual([
+      "rocm"
+    ]);
+  });
+
   test("getIssueBodyForFlakyTest: should contain Platforms line", async () => {
     expect(disableFlakyTestBot.getIssueBodyForFlakyTest(flakyTestA)).toContain(
       "Platforms: "


### PR DESCRIPTION
Usually for rocm, we also mark linux as a platform for which to skip the test, but that is wrong. We should isolate rocm to only disable tests for rocm only.