### PR TITLE
[alerts] Edit alert if conditions change

### DIFF
--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -313,7 +313,7 @@ def main():
         alerts_cleared = clear_alerts(alerts)
 
     # Create a new alert if no alerts active or edit the original one if there's a new update
-    no_alert_currently_active = alerts_cleared == True or len(alerts) == 0
+    no_alert_currently_active = alerts_cleared or len(alerts) == 0
     if len(jobs_to_alert_on) > 0 and (no_alert_currently_active):
         create_issue(generate_failed_job_issue(jobs_to_alert_on))
     elif len(jobs_to_alert_on) > 0 and len(alerts) == 1:

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -1,12 +1,11 @@
 import json
-import numbers
 import os
 import urllib.parse
 from collections import defaultdict
 from curses.ascii import CAN
 from difflib import SequenceMatcher
 from email.policy import default
-from typing import Any, List, Tuple, Dict
+from typing import Any, Dict, List, Tuple
 
 import requests
 


### PR DESCRIPTION
Previously, we didn't do anything if there were updates to the alert if some jobs got fixed or more jobs failed. Now, we compare the old alert to the new one and if there's any updates, we edit the comment. 

Also, we start raising for the request fetches instead of silently failing/failing later when we try to access the responses. 

Test Plan: 
ran it locally and saw that it updated https://github.com/pytorch/test-infra/issues/571 