### PR TITLE
[Nova] Call pre/post scripts in same shell

### DIFF
--- a/.github/workflows/build_conda_linux_reusable.yml
+++ b/.github/workflows/build_conda_linux_reusable.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run pre-build script
-      run: ./packaging/pre_build_script_conda.sh
+      run: . packaging/pre_build_script_conda.sh
     - name: Generate Conda Recipe Path
       run: export CONDA_PATH=packaging/${{ inputs.domain }}
     - name: Build Conda Package
@@ -30,4 +30,4 @@ jobs:
               --python "$PYTHON_VERSION" \
               "$CONDA_PATH" 
     - name: Run post-build script
-      run: ./packaging/post_build_script_conda.sh
+      run: . packaging/post_build_script_conda.sh


### PR DESCRIPTION
Call pre/post scripts in same shell as the main conda build command, so the value of the env vars set is maintained across actions and jobs.