### PR TITLE
[torchci] Add Google Analytics for Tracking

### DIFF
--- a/torchci/.env.example
+++ b/torchci/.env.example
@@ -13,3 +13,5 @@ WEBHOOK_SECRET=
 # AWS Access key for Dynamo/S3. Only needed if testing lambda stuff locally.
 OUR_AWS_ACCESS_KEY_ID=
 OUR_AWS_SECRET_ACCESS_KEY=
+
+NEXT_PUBLIC_GOOGLE_ANALYTICS=<Your_tracking_ID>

--- a/torchci/README.md
+++ b/torchci/README.md
@@ -94,3 +94,8 @@ If you ever need to modify the deployment settings like the oauth callbacks, dom
 2. [Environment Variables](https://vercel.com/torchci/torchci/settings/environment-variables)
 3. [OAuth Project](https://github.com/settings/applications/1973779) / [OAuth Project Local](https://github.com/settings/applications/1976306)
 4. [Domain Management](https://vercel.com/torchci/torchci/settings/domains)
+
+
+### Analytics
+
+If you want to get data about the website performance, go to [Google Analytics](https://analytics.google.com/analytics/web/#/p309888230/reports/intelligenthome). If you don't have access, reach out to the [Pytorch DevX Team](https://github.com/pytorch/pytorch/wiki/Contact-Pytorch-Dev-Infra-Office).

--- a/torchci/lib/googleAnalytics.js
+++ b/torchci/lib/googleAnalytics.js
@@ -1,0 +1,11 @@
+// log the pageview with their URL
+export const pageview = (url) => {
+  window.gtag("config", process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS, {
+    page_path: url,
+  });
+};
+
+// log specific events happening.
+export const event = ({ action, params }) => {
+  window.gtag("event", action, params);
+};

--- a/torchci/pages/_app.tsx
+++ b/torchci/pages/_app.tsx
@@ -3,9 +3,30 @@ import NavBar from "components/NavBar";
 import SevReport from "components/SevReport";
 import type { AppProps } from "next/app";
 import Head from "next/head";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
 import "styles/globals.css";
+import { pageview } from "../lib/googleAnalytics";
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleRouteChange = (url: string) => {
+      console.log("GOING INTO PAGE VIEW");
+      pageview(url);
+    };
+    //When the component is mounted, subscribe to router changes
+    //and log those page views
+    router.events.on("routeChangeComplete", handleRouteChange);
+
+    // If the component is unmounted, unsubscribe
+    // from the event with the `off` method
+    return () => {
+      router.events.off("routeChangeComplete", handleRouteChange);
+    };
+  }, [router.events]);
+
   return (
     <>
       <Head>

--- a/torchci/pages/_app.tsx
+++ b/torchci/pages/_app.tsx
@@ -1,19 +1,31 @@
 import AnnouncementBanner from "components/AnnouncementBanner";
 import NavBar from "components/NavBar";
 import SevReport from "components/SevReport";
-import type { AppProps } from "next/app";
+import type { AppProps, NextWebVitalsMetric } from "next/app";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 import "styles/globals.css";
-import { pageview } from "../lib/googleAnalytics";
+import { pageview, event } from "../lib/googleAnalytics";
+
+export function reportWebVitals(metric: NextWebVitalsMetric) {
+  // @ts-ignore
+  window.gtag("event", metric.name, {
+    event_category:
+      metric.label === "web-vital" ? "Web Vitals" : "Next.js custom metric",
+    value: Math.round(
+      metric.name === "CLS" ? metric.value * 1000 : metric.value
+    ), // values must be integers
+    event_label: metric.id, // id unique to current page load
+    non_interaction: true, // avoids affecting bounce rate.
+  });
+}
 
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
 
   useEffect(() => {
     const handleRouteChange = (url: string) => {
-      console.log("GOING INTO PAGE VIEW");
       pageview(url);
     };
     //When the component is mounted, subscribe to router changes

--- a/torchci/pages/_document.tsx
+++ b/torchci/pages/_document.tsx
@@ -1,0 +1,33 @@
+import Document, { Html, Head, Main, NextScript } from "next/document";
+
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <Html>
+        <Head>
+          {/* Global Site Tag (gtag.js) - Google Analytics */}
+          <script
+            async
+            src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS}`}
+          />
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS}', {
+              page_path: window.location.pathname,
+            });
+          `,
+            }}
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}


### PR DESCRIPTION
This adds some google analytics for things like page views/navigations and webvitals for things like render times, navigation times, etc. 

The navigation times are a bit hard to aggregate in here but we can potentially use a different time of logging for it in the future. 


Test Plan:
Check to see that it's working and logging to GA
![image](https://user-images.githubusercontent.com/34172846/186482531-6cc424b2-ea30-4a7d-92da-92a009da4dd5.png)
