### PR TITLE
Sort workflows and jobs by conclusion

### DIFF
--- a/torchci/components/CommitStatus.tsx
+++ b/torchci/components/CommitStatus.tsx
@@ -6,17 +6,27 @@ import styles from "components/commit.module.css";
 import _ from "lodash";
 import { isFailedJob } from "lib/jobUtils";
 import { linkIt, UrlComponent, urlRegex } from "react-linkify-it";
+import { getConclusionSeverityForSorting } from "../lib/JobClassifierUtil";
 
 function WorkflowsContainer({ jobs }: { jobs: JobData[] }) {
-  const byWorkflow = _.groupBy(jobs, (job) => job.workflowName);
   if (jobs.length === 0) {
     return null;
   }
+  
+  const byWorkflow = _(jobs)
+    .groupBy(job => job.workflowName)
+    .sortBy(jobs => _(jobs)
+      .map(job => getConclusionSeverityForSorting(job.conclusion))
+      .max())
+    .reverse() // List workflows with failed jobs first
+    .value()
+
   return (
     <>
       <h1>Workflows</h1>
       <div className={styles.workflowContainer}>
-        {_.map(byWorkflow, (jobs, workflowName) => {
+        {_.map(byWorkflow, jobs => {
+          let workflowName = '' + jobs[0].workflowName
           return (
             <WorkflowBox
               key={workflowName}

--- a/torchci/components/CommitStatus.tsx
+++ b/torchci/components/CommitStatus.tsx
@@ -15,10 +15,12 @@ function WorkflowsContainer({ jobs }: { jobs: JobData[] }) {
   
   const byWorkflow = _(jobs)
     .groupBy(job => job.workflowName)
-    .sortBy(jobs => _(jobs)
-      .map(job => getConclusionSeverityForSorting(job.conclusion))
-      .max())
-    .reverse() // List workflows with failed jobs first
+    .sortBy(
+      (jobs => _(jobs)
+          .map(job => getConclusionSeverityForSorting(job.conclusion))
+          .max()), // put failing workflows first
+      (jobs => jobs.length)) // put worflows of similar lenghts together to keep the display more compact
+    .reverse()
     .value()
 
   return (

--- a/torchci/components/WorkflowBox.tsx
+++ b/torchci/components/WorkflowBox.tsx
@@ -6,6 +6,17 @@ import useSWR from "swr";
 import JobArtifact from "./JobArtifact";
 import JobSummary from "./JobSummary";
 import LogViewer from "./LogViewer";
+import { getConclusionSeverityForSorting } from "../lib/JobClassifierUtil";
+
+function sortJobs( jobA: JobData, jobB: JobData): number {
+  // Show failed jobs first, then pending jobs, then successful jobs
+  if (jobA.conclusion !== jobB.conclusion) {
+    return getConclusionSeverityForSorting(jobB.conclusion) - getConclusionSeverityForSorting(jobA.conclusion);
+  }
+
+  // Jobs with the same conclusion are sorted alphabetically
+  return ('' + jobA.jobName).localeCompare('' + jobB.jobName);  // the '' forces the type to be a string
+}
 
 export default function WorkflowBox({
   workflowName,
@@ -25,7 +36,7 @@ export default function WorkflowBox({
       <h3>{workflowName}</h3>
       <h4>Job Status</h4>
       <>
-        {jobs.map((job) => (
+        {jobs.sort(sortJobs).map((job) => (
           <div key={job.id}>
             <JobSummary job={job} />
             <LogViewer job={job} />

--- a/torchci/components/WorkflowBox.tsx
+++ b/torchci/components/WorkflowBox.tsx
@@ -8,7 +8,7 @@ import JobSummary from "./JobSummary";
 import LogViewer from "./LogViewer";
 import { getConclusionSeverityForSorting } from "../lib/JobClassifierUtil";
 
-function sortJobs( jobA: JobData, jobB: JobData): number {
+function sortJobsByConclusion( jobA: JobData, jobB: JobData): number {
   // Show failed jobs first, then pending jobs, then successful jobs
   if (jobA.conclusion !== jobB.conclusion) {
     return getConclusionSeverityForSorting(jobB.conclusion) - getConclusionSeverityForSorting(jobA.conclusion);
@@ -36,7 +36,7 @@ export default function WorkflowBox({
       <h3>{workflowName}</h3>
       <h4>Job Status</h4>
       <>
-        {jobs.sort(sortJobs).map((job) => (
+        {jobs.sort(sortJobsByConclusion).map((job) => (
           <div key={job.id}>
             <JobSummary job={job} />
             <LogViewer job={job} />

--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -141,6 +141,29 @@ export function getConclusionChar(conclusion?: string): string {
   }
 }
 
+export function getConclusionSeverityForSorting(conclusion?: string): number {
+  // Returns a severity level for the conclusion. 
+  // Used to sort jobs by severity
+  switch (conclusion) {
+    case JobStatus.Success:
+      return 0;
+    case JobStatus.Skipped:
+      return 1;
+    case JobStatus.Neutral:
+      return 2;
+    case JobStatus.Cancelled:
+      return 3;
+    case JobStatus.Pending:
+      return 4;
+    case undefined:
+      return 5;
+    case JobStatus.Failure:
+      return 6;
+    default:
+      return 7;
+  }
+}
+
 export function getGroupingData(shaGrid: RowData[], jobNames: string[]) {
   // Construct Job Groupping Mapping
   const groupNameMapping = new Map<string, Array<string>>(); // group -> [jobs]


### PR DESCRIPTION
This sorts the the commit view data in two ways:
- Sort workflows so that workflows with failing jobs are listed first
- Within each workflows, put failing jobs 

Screenshots show before and after examples of the build status (using [this in progress commit](https://hud.pytorch.org/pytorch/pytorch/commit/3a9ae518f2c9424251eae13fb23db6ea571cfce1) as an example)

# Before
You had to scroll past the successful workflows to find the ones that are failing.
And then you have to search within the list to see which workflows actually failed, which are still pending, etc. 

<img width="1589" alt="image" src="https://user-images.githubusercontent.com/4468967/186507559-f9d19907-762e-4f29-b209-a9ed663d5a5c.png">

# After
First we see all failing workflows, then we see workflows that have jobs still pending

<img width="1588" alt="image" src="https://user-images.githubusercontent.com/4468967/186507623-e90a2942-09c1-4822-a714-11ea6a960ee3.png">
