### PR TITLE
Remove workflow and user scopes

### DIFF
--- a/torchci/pages/api/auth/[...nextauth].js
+++ b/torchci/pages/api/auth/[...nextauth].js
@@ -7,7 +7,7 @@ export default (req, res) =>
       GithubProvider({
         clientId: process.env.GITHUB_CLIENT_ID,
         clientSecret: process.env.GITHUB_CLIENT_SECRET,
-        authorization: { params: { scope: "repo user workflow" } },
+        authorization: { params: { scope: "repo" } },
       }),
     ],
     debug: process.env.NODE_ENV === "development",


### PR DESCRIPTION
We should just need the repo scope for doing managing stuff like reverts and such on HUD. Don't need emails and such. 

