### PR TITLE
ci: Add setup-miniconda action for use with macOS

### DIFF
--- a/.github/actions/setup-miniconda/README.md
+++ b/.github/actions/setup-miniconda/README.md
@@ -1,0 +1,21 @@
+# setup-miniconda
+
+Sets up miniconda in your ${RUNNER_TEMP} environment and gives you the ${CONDA_RUN} environment variable so you don't have to worry about polluting non-empeheral runners anymore
+
+## Supported platforms
+
+- macOS-ARM64
+- macOS-X64
+
+## Usage
+
+```yaml
+      - name: Setup miniconda
+        # You could potentially lock this down to a specific hash as well
+        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
+        with:
+          python_version: "3.9"
+      - name: Can use ${CONDA_RUN}, outputs Python "3.9"
+        run: |
+          ${CONDA_RUN} python --version | grep "3.9"
+```

--- a/.github/actions/setup-miniconda/README.md
+++ b/.github/actions/setup-miniconda/README.md
@@ -1,6 +1,6 @@
 # setup-miniconda
 
-Sets up miniconda in your ${RUNNER_TEMP} environment and gives you the ${CONDA_RUN} environment variable so you don't have to worry about polluting non-empeheral runners anymore
+Sets up miniconda in your `${RUNNER_TEMP}` environment and gives you the `${CONDA_RUN}` environment variable so you don't have to worry about polluting non-empeheral runners anymore
 
 ## Supported platforms
 

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -1,0 +1,53 @@
+name: Set up conda environment for testing
+
+description: Clean workspace and check out PyTorch
+
+inputs:
+  python_version:
+    description: If set to any value, don't use sudo to clean the workspace
+    required: false
+    type: string
+    default: "3.9"
+
+runs:
+  using: composite
+  steps:
+      - name: Install miniconda onto the machine
+        shell: bash -l {0}
+        run: |
+          MINICONDA_INSTALL_PATH_MACOS="${RUNNER_TEMP}/miniconda"
+          mkdir -p "${MINICONDA_INSTALL_PATH_MACOS}"
+          case ${RUNNER_OS}-${RUNNER_ARCH} in
+            macOS-ARM64)
+              MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh"
+              ;;
+            macOS-X86)
+              MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+              ;;
+            *)
+              echo "Platform ${RUNNER_OS}-${RUNNER_ARCH} currently unsupported using this action"
+              exit 1
+              ;;
+          esac
+          curl -fsSL "${MINICONDA_URL}" -o "${MINICONDA_INSTALL_PATH_MACOS}/miniconda.sh"
+          bash "${MINICONDA_INSTALL_PATH_MACOS}/miniconda.sh" -b -u -p "${MINICONDA_INSTALL_PATH_MACOS}"
+          rm -rf "${MINICONDA_INSTALL_PATH_MACOS}/miniconda.sh"
+          echo "${MINICONDA_INSTALL_PATH_MACOS}/bin" >> $GITHUB_PATH
+      - name: Setup conda environment
+        shell: bash
+        env:
+          PYTHON_VERSION: ${{ inputs.python-version }}
+        run: |
+          CONDA_ENV="${RUNNER_TEMP}/conda_environment_${GITHUB_RUN_ID}"
+          conda create \
+            --yes \
+            --prefix "${CONDA_ENV}" \
+            "python=${PYTHON_VERSION}" \
+            cmake=3.22 \
+            conda-build=3.21 \
+            ninja=1.10 \
+            numpy=1.23 \
+            pkg-config=0.29 \
+            wheel=0.37
+          echo "CONDA_ENV=${CONDA_ENV}" >> "${GITHUB_ENV}"
+          echo "CONDA_RUN=conda run -p ${CONDA_ENV}" >> "${GITHUB_ENV}"

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -3,7 +3,7 @@ name: Set up conda environment for testing
 description: Clean workspace and check out PyTorch
 
 inputs:
-  python_version:
+  python-version:
     description: If set to any value, don't use sudo to clean the workspace
     required: false
     type: string

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -21,7 +21,7 @@ runs:
             macOS-ARM64)
               MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh"
               ;;
-            macOS-X86)
+            macOS-X64)
               MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
               ;;
             *)

--- a/.github/workflows/test-setup-minconda.yml
+++ b/.github/workflows/test-setup-minconda.yml
@@ -25,6 +25,11 @@ jobs:
       - uses: actions/checkout@v3
       - name: Test that setup-miniconda works
         uses: ./.github/actions/setup-miniconda
+        with:
+          python-version: "3.9"
+      - name: Can use ${CONDA_RUN}, outputs Python "3.9"
+        run: |
+          ${CONDA_RUN} python --version | grep "3.9"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/test-setup-minconda.yml
+++ b/.github/workflows/test-setup-minconda.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Test that setup-miniconda works
         uses: ./.github/actions/setup-miniconda
         with:
-          python-version: "3.9"
+          python_version: "3.9"
       - name: Can use ${CONDA_RUN}, outputs Python "3.9"
         run: |
           ${CONDA_RUN} python --version | grep "3.9"

--- a/.github/workflows/test-setup-minconda.yml
+++ b/.github/workflows/test-setup-minconda.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Test that setup-miniconda works
         uses: ./.github/actions/setup-miniconda
         with:
-          python_version: "3.9"
+          python-version: "3.9"
       - name: Can use ${CONDA_RUN}, outputs Python "3.9"
         run: |
           ${CONDA_RUN} python --version

--- a/.github/workflows/test-setup-minconda.yml
+++ b/.github/workflows/test-setup-minconda.yml
@@ -1,0 +1,31 @@
+name: Test setup-miniconda
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/test-setup-miniconda.yml
+      - .github/actions/setup-miniconda/*
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner_type:
+          - macos-12
+          - macos-m1-12
+    env:
+      PYTHON_VERSION: 3.9
+    name: ${{ matrix.runner_type }}
+    runs-on: ${{ matrix.runner_type }}
+    # If a build is taking longer than 60 minutes on these runners we need
+    # to have a conversation
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
+      - name: Test that setup-miniconda works
+        uses: ./test-infra/.github/actions/setup-miniconda
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true

--- a/.github/workflows/test-setup-minconda.yml
+++ b/.github/workflows/test-setup-minconda.yml
@@ -29,6 +29,7 @@ jobs:
           python_version: "3.9"
       - name: Can use ${CONDA_RUN}, outputs Python "3.9"
         run: |
+          ${CONDA_RUN} python --version
           ${CONDA_RUN} python --version | grep "3.9"
 
 concurrency:

--- a/.github/workflows/test-setup-minconda.yml
+++ b/.github/workflows/test-setup-minconda.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Test that setup-miniconda works
-        uses: ./test-infra/.github/actions/setup-miniconda
+        uses: ./.github/actions/setup-miniconda
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/test-setup-minconda.yml
+++ b/.github/workflows/test-setup-minconda.yml
@@ -27,5 +27,5 @@ jobs:
         uses: ./.github/actions/setup-miniconda
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true


### PR DESCRIPTION
Adds a setup-miniconda action for us to use in our macOS workflows to
give us a working version of setup-miniconda that can be re-used amongst
even non-ephemeral runners in general

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>