### PR TITLE
Don't show logviewer on green

### DIFF
--- a/torchci/components/WorkflowBox.tsx
+++ b/torchci/components/WorkflowBox.tsx
@@ -39,7 +39,7 @@ export default function WorkflowBox({
         {jobs.sort(sortJobsByConclusion).map((job) => (
           <div key={job.id}>
             <JobSummary job={job} />
-            <LogViewer job={job} />
+            {isFailedJob(job) && (<LogViewer job={job} />)}
           </div>
         ))}
       </>


### PR DESCRIPTION
Fixes https://github.com/pytorch/test-infra/issues/606

Before:
<img width="1652" alt="image" src="https://user-images.githubusercontent.com/31798555/187297624-78079792-f967-4cd1-af6b-43b8a20e8034.png">

After:
<img width="1664" alt="image" src="https://user-images.githubusercontent.com/31798555/187297685-7d36c984-6845-43d1-a03b-f26a058e4988.png">

Flaky test view still has the info
<img width="1664" alt="image" src="https://user-images.githubusercontent.com/31798555/187298928-8ab7188b-0786-4411-8de4-b8eabbd7fa19.png">

