### PR TITLE
ci: Add env file flag, add install/build commands, remove default numpy install

### DIFF
--- a/.github/actions/setup-miniconda/README.md
+++ b/.github/actions/setup-miniconda/README.md
@@ -9,6 +9,12 @@ Sets up miniconda in your `${RUNNER_TEMP}` environment and gives you the `${COND
 
 ## Usage
 
+This action provides the following environment variables to use with the provided conda environment:
+
+* `CONDA_RUN` to run specific commands (including python within the environment)
+* `CONDA_BUILD` to run conda-build from the created environment
+* `CONDA_INSTALL` to install extra dependencies within the provided environment
+
 ```yaml
       - name: Setup miniconda
         # You could potentially lock this down to a specific hash as well
@@ -17,5 +23,13 @@ Sets up miniconda in your `${RUNNER_TEMP}` environment and gives you the `${COND
           python_version: "3.9"
       - name: Can use ${CONDA_RUN}, outputs Python "3.9"
         run: |
+          ${CONDA_RUN} python --version
           ${CONDA_RUN} python --version | grep "3.9"
+      - name: Can use ${CONDA_INSTALL}, installs older numpy
+        run: |
+          ${CONDA_INSTALL} numpy=1.19
+      - name: Can use ${CONDA_BUILD}, outputs version
+        run: |
+          ${CONDA_BUILD} --version
+          ${CONDA_BUILD} path/to/mypackage
 ```

--- a/.github/actions/setup-miniconda/README.md
+++ b/.github/actions/setup-miniconda/README.md
@@ -27,7 +27,7 @@ This action provides the following environment variables to use with the provide
           ${CONDA_RUN} python --version | grep "3.9"
       - name: Can use ${CONDA_INSTALL}, installs older numpy
         run: |
-          ${CONDA_INSTALL} numpy=1.19
+          ${CONDA_INSTALL} numpy=1.17
       - name: Can use ${CONDA_BUILD}, outputs version
         run: |
           ${CONDA_BUILD} --version

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -48,7 +48,7 @@ runs:
           ENV_FILE_FLAG=""
           if [[ -f "${ENV_FILE}" ]]; then
             ENV_FILE_FLAG="--file ${ENV_FILE}"
-          elif [[ -n "${ENV_FILE}" ]]
+          elif [[ -n "${ENV_FILE}" ]]; then
             echo "::warning::Specified env file (${ENV_FILE}) not found, not going to include it"
           fi
           conda create \

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -30,7 +30,7 @@ runs:
               MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
               ;;
             *)
-              echo "Platform ${RUNNER_OS}-${RUNNER_ARCH} currently unsupported using this action"
+            echo "::error::Platform ${RUNNER_OS}-${RUNNER_ARCH} currently unsupported using this action"
               exit 1
               ;;
           esac
@@ -48,7 +48,7 @@ runs:
           ENV_FILE_FLAG=""
           if [[ -f "${ENV_FILE}" ]]; then
             ENV_FILE_FLAG="--file ${ENV_FILE}"
-          else
+          elif [[ -n "${ENV_FILE}" ]]
             echo "::warning::Specified env file (${ENV_FILE}) not found, not going to include it"
           fi
           conda create \
@@ -59,7 +59,6 @@ runs:
             cmake=3.22 \
             conda-build=3.21 \
             ninja=1.10 \
-            numpy=1.19 \
             pkg-config=0.29 \
             wheel=0.37
           echo "CONDA_ENV=${CONDA_ENV}" >> "${GITHUB_ENV}"

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -64,5 +64,5 @@ runs:
             wheel=0.37
           echo "CONDA_ENV=${CONDA_ENV}" >> "${GITHUB_ENV}"
           echo "CONDA_RUN=conda run -p ${CONDA_ENV}" >> "${GITHUB_ENV}"
+          echo "CONDA_BUILD=conda run -p ${CONDA_ENV} conda-build" >> "${GITHUB_ENV}"
           echo "CONDA_INSTALL=conda install -p ${CONDA_ENV}" >> "${GITHUB_ENV}"
-          echo "CONDA_BUILD=${CONDA_RUN} conda-build" >> "${GITHUB_ENV}"

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -59,7 +59,7 @@ runs:
             cmake=3.22 \
             conda-build=3.21 \
             ninja=1.10 \
-            numpy=1.23 \
+            numpy=1.19 \
             pkg-config=0.29 \
             wheel=0.37
           echo "CONDA_ENV=${CONDA_ENV}" >> "${GITHUB_ENV}"

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -8,6 +8,11 @@ inputs:
     required: false
     type: string
     default: "3.9"
+  environment-file:
+    description: Environment file to install dependencies from
+    required: false
+    type: string
+    default: ""
 
 runs:
   using: composite
@@ -37,12 +42,20 @@ runs:
         shell: bash
         env:
           PYTHON_VERSION: ${{ inputs.python-version }}
+          ENV_FILE: ${{ inputs.environment-file }}
         run: |
           CONDA_ENV="${RUNNER_TEMP}/conda_environment_${GITHUB_RUN_ID}"
+          ENV_FILE_FLAG=""
+          if [[ -f "${ENV_FILE}" ]]; then
+            ENV_FILE_FLAG="--file ${ENV_FILE}"
+          else
+            echo "::warning::Specified env file (${ENV_FILE}) not found, not going to include it"
+          fi
           conda create \
             --yes \
             --prefix "${CONDA_ENV}" \
             "python=${PYTHON_VERSION}" \
+            ${ENV_FILE_FLAG} \
             cmake=3.22 \
             conda-build=3.21 \
             ninja=1.10 \
@@ -51,3 +64,5 @@ runs:
             wheel=0.37
           echo "CONDA_ENV=${CONDA_ENV}" >> "${GITHUB_ENV}"
           echo "CONDA_RUN=conda run -p ${CONDA_ENV}" >> "${GITHUB_ENV}"
+          echo "CONDA_INSTALL=conda install -p ${CONDA_ENV}" >> "${GITHUB_ENV}"
+          echo "CONDA_BUILD=${CONDA_RUN} conda-build" >> "${GITHUB_ENV}"

--- a/.github/workflows/test-setup-minconda.yml
+++ b/.github/workflows/test-setup-minconda.yml
@@ -11,28 +11,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner_type:
+        runner-type:
           - macos-12
           - macos-m1-12
-    name: ${{ matrix.runner_type }}
-    runs-on: ${{ matrix.runner_type }}
+        # Only testing minimum and maximum versions here
+        python-version:
+          - 3.7
+          - 3.8
+          - 3.10
+        exclude:
+          - runner-type: macos-m1-12
+            python-version: 3.7
+          - runner-type: macos-12
+            python-version: 3.8
+    name: ${{ matrix.runner-type }}-py${{ matrix.python-version }}
+    runs-on: ${{ matrix.runner-type }}
     # If a build is taking longer than 60 minutes on these runners we need
     # to have a conversation
     timeout-minutes: 60
+    env:
+      PYTHON_VERSION: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
       - name: Test that setup-miniconda works
         uses: ./.github/actions/setup-miniconda
         with:
-          python-version: "3.7"
-      - name: Can use ${CONDA_RUN}, outputs Python "3.7"
+          python-version: ${{ matrix.python-version }}
+      - name: Can use ${CONDA_RUN}, outputs correct python version
         run: |
           ${CONDA_RUN} python --version
-          ${CONDA_RUN} python --version | grep "3.7"
+          ${CONDA_RUN} python --version | grep "${PYTHON_VERSION}"
       - name: Can use ${CONDA_INSTALL}, installs older numpy
         run: |
           ${CONDA_INSTALL} numpy=1.17
-      - name: Can use ${CONDA_BUILD}, outputs version
+      - name: Can use ${CONDA_BUILD}, outputs correct version
         run: |
           ${CONDA_BUILD} --version
           ${CONDA_BUILD} --version | grep "3.21"

--- a/.github/workflows/test-setup-minconda.yml
+++ b/.github/workflows/test-setup-minconda.yml
@@ -41,9 +41,9 @@ jobs:
         run: |
           ${CONDA_RUN} python --version
           ${CONDA_RUN} python --version | grep "${PYTHON_VERSION}"
-      - name: Can use ${CONDA_INSTALL}, installs older numpy
+      - name: Can use ${CONDA_INSTALL}, installs requests
         run: |
-          ${CONDA_INSTALL} numpy=1.17
+          ${CONDA_INSTALL} requests
       - name: Can use ${CONDA_BUILD}, outputs correct version
         run: |
           ${CONDA_BUILD} --version

--- a/.github/workflows/test-setup-minconda.yml
+++ b/.github/workflows/test-setup-minconda.yml
@@ -16,14 +16,14 @@ jobs:
           - macos-m1-12
         # Only testing minimum and maximum versions here
         python-version:
-          - 3.7
-          - 3.8
-          - 3.10
+          - "3.7"
+          - "3.8"
+          - "3.10"
         exclude:
           - runner-type: macos-m1-12
-            python-version: 3.7
+            python-version: "3.7"
           - runner-type: macos-12
-            python-version: 3.8
+            python-version: "3.8"
     name: ${{ matrix.runner-type }}-py${{ matrix.python-version }}
     runs-on: ${{ matrix.runner-type }}
     # If a build is taking longer than 60 minutes on these runners we need

--- a/.github/workflows/test-setup-minconda.yml
+++ b/.github/workflows/test-setup-minconda.yml
@@ -31,6 +31,13 @@ jobs:
         run: |
           ${CONDA_RUN} python --version
           ${CONDA_RUN} python --version | grep "3.9"
+      - name: Can use ${CONDA_INSTALL}, installs older numpy
+        run: |
+          ${CONDA_INSTALL} numpy=1.19
+      - name: Can use ${CONDA_BUILD}, outputs version
+        run: |
+          ${CONDA_BUILD} --version
+          ${CONDA_BUILD} --version | grep "3.21"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/test-setup-minconda.yml
+++ b/.github/workflows/test-setup-minconda.yml
@@ -14,8 +14,6 @@ jobs:
         runner_type:
           - macos-12
           - macos-m1-12
-    env:
-      PYTHON_VERSION: 3.9
     name: ${{ matrix.runner_type }}
     runs-on: ${{ matrix.runner_type }}
     # If a build is taking longer than 60 minutes on these runners we need
@@ -26,14 +24,14 @@ jobs:
       - name: Test that setup-miniconda works
         uses: ./.github/actions/setup-miniconda
         with:
-          python-version: "3.9"
-      - name: Can use ${CONDA_RUN}, outputs Python "3.9"
+          python-version: "3.7"
+      - name: Can use ${CONDA_RUN}, outputs Python "3.7"
         run: |
           ${CONDA_RUN} python --version
-          ${CONDA_RUN} python --version | grep "3.9"
+          ${CONDA_RUN} python --version | grep "3.7"
       - name: Can use ${CONDA_INSTALL}, installs older numpy
         run: |
-          ${CONDA_INSTALL} numpy=1.19
+          ${CONDA_INSTALL} numpy=1.17
       - name: Can use ${CONDA_BUILD}, outputs version
         run: |
           ${CONDA_BUILD} --version


### PR DESCRIPTION
Adds hooks to do both conda install and conda build from the provided
setup-miniconda environment

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>