### PR TITLE
Adding install command to matrix

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -144,7 +144,7 @@ def get_base_download_url_for_repo(repo: str, channel: str, gpu_arch_type: str, 
 
 def get_libtorch_install_command(channel: str, gpu_arch_type: str, libtorch_variant: str, devtoolset: str, desired_cuda: str) -> str:
     build_name = f"libtorch-{devtoolset}-{libtorch_variant}-latest.zip" if devtoolset ==  "cxx11-abi" else f"libtorch-{libtorch_variant}-latest.zip"
-    return f"{get_base_download_url_for_repo('libtorch', channel, gpu_arch_type, desired_cuda)}/${build_name}"
+    return f"{get_base_download_url_for_repo('libtorch', channel, gpu_arch_type, desired_cuda)}/{build_name}"
 
 def get_wheel_install_command(channel: str, gpu_arch_type: str, desired_cuda: str) -> str:
     return f"{WHL_INSTALL_BASE} --extra-index-url {get_base_download_url_for_repo('whl', channel, gpu_arch_type, desired_cuda)}"

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -143,7 +143,7 @@ def get_base_download_url_for_repo(repo: str, channel: str, gpu_arch_type: str, 
     return base_url_for_type
 
 def get_libtorch_install_command(channel: str, gpu_arch_type: str, libtorch_variant: str, devtoolset: str, desired_cuda: str) -> str:
-    build_name = "libtorch-${devtoolset}-${libtorch_variant}-latest.zip" if devtoolset ==  "cxx11-abi" else "libtorch-${libtorch_variant}-latest.zip"
+    build_name = f"libtorch-{devtoolset}-{libtorch_variant}-latest.zip" if devtoolset ==  "cxx11-abi" else f"libtorch-{libtorch_variant}-latest.zip"
     return f"{get_base_download_url_for_repo('libtorch', channel, gpu_arch_type, desired_cuda)}/${build_name}"
 
 def get_wheel_install_command(channel: str, gpu_arch_type: str, desired_cuda: str) -> str:

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -123,7 +123,7 @@ def get_conda_install_command(channel: str, gpu_arch_type: str, arch_version: st
     conda_channels = "-c pytorch" if channel == "release" else f"-c pytorch-{channel}"
 
     if gpu_arch_type == "cuda":
-        if arch_version == "10.2" or arch_version == "11.3":
+        if float(arch_version) <= 11.3:
             conda_package_type = f"cudatoolkit={arch_version}"
         else:
             conda_package_type = f"pytorch-cuda={arch_version}"

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -38,6 +38,9 @@ WIN_GPU_RUNNER="windows-2019-m60"
 WIN_CPU_RUNNER="windows-2019"
 MACOS_M1_RUNNER="macos-m1-12"
 
+CONDA_INSTALL_BASE="conda install pytorch torchvision torchaudio"
+WHL_INSTALL_BASE="pip3 install torch torchvision torchaudio"
+DOWNLOAD_URL_BASE="https://download.pytorch.org"
 
 def arch_type(arch_version: str) -> str:
     if arch_version in CUDA_ARCHES:
@@ -81,7 +84,6 @@ CONDA_CONTAINER_IMAGES = {
 }
 
 
-
 LIBTORCH_CONTAINER_IMAGES: Dict[Tuple[str, str], str] = {
     **{
         (gpu_arch, PRE_CXX11_ABI): f"pytorch/manylinux-builder:cuda{gpu_arch}"
@@ -117,6 +119,35 @@ def translate_desired_cuda(gpu_arch_type: str, gpu_arch_version: str) -> str:
 def list_without(in_list: List[str], without: List[str]) -> List[str]:
     return [item for item in in_list if item not in without]
 
+def get_conda_install_command(channel: str, gpu_arch_type: str, arch_version: str) -> str:
+    conda_channels = "-c pytorch" if channel == "release" else f"-c pytorch-{channel}"
+
+    if gpu_arch_type == "cuda":
+        if arch_version == "10.2" or arch_version == "11.3":
+            conda_package_type = f"cudatoolkit={arch_version}"
+        else:
+            conda_package_type = f"pytorch-cuda={arch_version}"
+            conda_channels = f"{conda_channels} -c nvidia"
+    else:
+        conda_package_type = "cpuonly"
+
+    return f"{CONDA_INSTALL_BASE} {conda_package_type} {conda_channels}"
+
+def get_base_download_url_for_repo(repo: str, channel: str, gpu_arch_type: str, desired_cuda: str) -> str:
+    base_url_for_type = f"{DOWNLOAD_URL_BASE}/{repo}"
+    base_url_for_type = base_url_for_type if channel == "release" else f"{base_url_for_type}/{channel}"
+
+    if gpu_arch_type != "cpu":
+        base_url_for_type= f"{base_url_for_type}/{desired_cuda}"
+
+    return base_url_for_type
+
+def get_libtorch_install_command(channel: str, gpu_arch_type: str, libtorch_variant: str, devtoolset: str, desired_cuda: str) -> str:
+    build_name = "libtorch-${devtoolset}-${libtorch_variant}-latest.zip" if devtoolset ==  "cxx11-abi" else "libtorch-${libtorch_variant}-latest.zip"
+    return f"{get_base_download_url_for_repo('libtorch', channel, gpu_arch_type, desired_cuda)}/${build_name}"
+
+def get_wheel_install_command(channel: str, gpu_arch_type: str, desired_cuda: str) -> str:
+    return f"{WHL_INSTALL_BASE} --extra-index-url {get_base_download_url_for_repo('whl', channel, gpu_arch_type, desired_cuda)}"
 
 def generate_conda_matrix(os: str, channel: str) -> List[Dict[str, str]]:
     ret: List[Dict[str, str]] = []
@@ -134,6 +165,7 @@ def generate_conda_matrix(os: str, channel: str) -> List[Dict[str, str]]:
         for arch_version in arches:
             gpu_arch_type = arch_type(arch_version)
             gpu_arch_version = "" if arch_version == "cpu" else arch_version
+
             ret.append(
                 {
                     "python_version": python_version,
@@ -149,6 +181,7 @@ def generate_conda_matrix(os: str, channel: str) -> List[Dict[str, str]]:
                     ),
                     "validation_runner": validation_runner(gpu_arch_type, os),
                     "channel": channel,
+                    "installation": get_conda_install_command(channel, gpu_arch_type, arch_version)
                 }
             )
     return ret
@@ -201,16 +234,16 @@ def generate_libtorch_matrix(
                 # ROCm builds without-deps failed even in ROCm runners; skip for now
                 if gpu_arch_type == "rocm" and "without-deps" in libtorch_variant:
                     continue
+                desired_cuda = translate_desired_cuda(gpu_arch_type, gpu_arch_version)
+                devtoolset = abi_version if os != "windows" else ""
                 ret.append(
                     {
                         "gpu_arch_type": gpu_arch_type,
                         "gpu_arch_version": gpu_arch_version,
-                        "desired_cuda": translate_desired_cuda(
-                            gpu_arch_type, gpu_arch_version
-                        ),
+                        "desired_cuda": desired_cuda,
                         "libtorch_variant": libtorch_variant,
                         "libtorch_config": abi_version if os == "windows" else "",
-                        "devtoolset": abi_version if os != "windows" else "",
+                        "devtoolset": devtoolset,
                         "container_image": LIBTORCH_CONTAINER_IMAGES[
                             (arch_version, abi_version)
                         ]
@@ -221,6 +254,7 @@ def generate_libtorch_matrix(
                             ".", "_"
                         ),
                         "validation_runner": validation_runner(gpu_arch_type, os),
+                        "installation": get_libtorch_install_command(channel, gpu_arch_type, libtorch_variant, devtoolset, desired_cuda),
                         "channel": channel
                     }
                 )
@@ -266,20 +300,20 @@ def generate_wheels_matrix(
             # Skip rocm 3.11 binaries for now as the docker image are not correct
             if python_version == "3.11" and gpu_arch_type == "rocm":
                 continue
+            desired_cuda =  translate_desired_cuda(gpu_arch_type, gpu_arch_version)
             ret.append(
                 {
                     "python_version": python_version,
                     "gpu_arch_type": gpu_arch_type,
                     "gpu_arch_version": gpu_arch_version,
-                    "desired_cuda": translate_desired_cuda(
-                        gpu_arch_type, gpu_arch_version
-                    ),
+                    "desired_cuda": desired_cuda,
                     "container_image": WHEEL_CONTAINER_IMAGES[arch_version],
                     "package_type": package_type,
                     "build_name": f"{package_type}-py{python_version}-{gpu_arch_type}{gpu_arch_version}".replace(
                         ".", "_"
                     ),
                     "validation_runner": validation_runner(gpu_arch_type, os),
+                    "installation": get_wheel_install_command(channel, gpu_arch_type, desired_cuda),
                     "channel": channel,
                 }
             )


### PR DESCRIPTION
Adding install command to matrix

conda:
```
(.venv) [atalman@devvm214.ftw0 ~/local/test-infra/tools/scripts (adding_install_command_to_matrix)]$ python3 generate_binary_build_matrix.py --package-type conda --channel nightly
{"include": [{"python_version": "3.7", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_7-cpu", "validation_runner": "ubuntu-20.04", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "10.2", "desired_cuda": "cu102", "container_image": "pytorch/conda-builder:cuda10.2", "package_type": "conda", "build_name": "conda-py3_7-cuda10_2", "validation_runner": "ubuntu-20.04-m60", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio cudatoolkit=10.2 -c pytorch-nightly"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "11.3", "desired_cuda": "cu113", "container_image": "pytorch/conda-builder:cuda11.3", "package_type": "conda", "build_name": "conda-py3_7-cuda11_3", "validation_runner": "ubuntu-20.04-m60", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio cudatoolkit=11.3 -c pytorch-nightly"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/conda-builder:cuda11.6", "package_type": "conda", "build_name": "conda-py3_7-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.6 -c pytorch-nightly -c nvidia"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/conda-builder:cuda11.7", "package_type": "conda", "build_name": "conda-py3_7-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch-nightly -c nvidia"}, {"python_version": "3.8", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_8-cpu", "validation_runner": "ubuntu-20.04", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "10.2", "desired_cuda": "cu102", "container_image": "pytorch/conda-builder:cuda10.2", "package_type": "conda", "build_name": "conda-py3_8-cuda10_2", "validation_runner": "ubuntu-20.04-m60", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio cudatoolkit=10.2 -c pytorch-nightly"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.3", "desired_cuda": "cu113", "container_image": "pytorch/conda-builder:cuda11.3", "package_type": "conda", "build_name": "conda-py3_8-cuda11_3", "validation_runner": "ubuntu-20.04-m60", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio cudatoolkit=11.3 -c pytorch-nightly"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/conda-builder:cuda11.6", "package_type": "conda", "build_name": "conda-py3_8-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.6 -c pytorch-nightly -c nvidia"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/conda-builder:cuda11.7", "package_type": "conda", "build_name": "conda-py3_8-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch-nightly -c nvidia"}, {"python_version": "3.9", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_9-cpu", "validation_runner": "ubuntu-20.04", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "10.2", "desired_cuda": "cu102", "container_image": "pytorch/conda-builder:cuda10.2", "package_type": "conda", "build_name": "conda-py3_9-cuda10_2", "validation_runner": "ubuntu-20.04-m60", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio cudatoolkit=10.2 -c pytorch-nightly"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.3", "desired_cuda": "cu113", "container_image": "pytorch/conda-builder:cuda11.3", "package_type": "conda", "build_name": "conda-py3_9-cuda11_3", "validation_runner": "ubuntu-20.04-m60", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio cudatoolkit=11.3 -c pytorch-nightly"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/conda-builder:cuda11.6", "package_type": "conda", "build_name": "conda-py3_9-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.6 -c pytorch-nightly -c nvidia"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/conda-builder:cuda11.7", "package_type": "conda", "build_name": "conda-py3_9-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch-nightly -c nvidia"}, {"python_version": "3.10", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_10-cpu", "validation_runner": "ubuntu-20.04", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "10.2", "desired_cuda": "cu102", "container_image": "pytorch/conda-builder:cuda10.2", "package_type": "conda", "build_name": "conda-py3_10-cuda10_2", "validation_runner": "ubuntu-20.04-m60", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio cudatoolkit=10.2 -c pytorch-nightly"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.3", "desired_cuda": "cu113", "container_image": "pytorch/conda-builder:cuda11.3", "package_type": "conda", "build_name": "conda-py3_10-cuda11_3", "validation_runner": "ubuntu-20.04-m60", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio cudatoolkit=11.3 -c pytorch-nightly"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/conda-builder:cuda11.6", "package_type": "conda", "build_name": "conda-py3_10-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.6 -c pytorch-nightly -c nvidia"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/conda-builder:cuda11.7", "package_type": "conda", "build_name": "conda-py3_10-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "channel": "nightly", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch-nightly -c nvidia"}]}
```

wheel:
```
 python3 generate_binary_build_matrix.py --package-type wheel --channel nightly
{"include": [{"python_version": "3.7", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_7-cpu", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly", "channel": "nightly"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "10.2", "desired_cuda": "cu102", "container_image": "pytorch/manylinux-builder:cuda10.2", "package_type": "manywheel", "build_name": "manywheel-py3_7-cuda10_2", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu102", "channel": "nightly"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "11.3", "desired_cuda": "cu113", "container_image": "pytorch/manylinux-builder:cuda11.3", "package_type": "manywheel", "build_name": "manywheel-py3_7-cuda11_3", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu113", "channel": "nightly"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_7-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu116", "channel": "nightly"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_7-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly"}, {"python_version": "3.7", "gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "container_image": "pytorch/manylinux-builder:rocm5.1.1", "package_type": "manywheel", "build_name": "manywheel-py3_7-rocm5_1_1", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.1.1", "channel": "nightly"}, {"python_version": "3.7", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_7-rocm5_2", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly"}, {"python_version": "3.8", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_8-cpu", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly", "channel": "nightly"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "10.2", "desired_cuda": "cu102", "container_image": "pytorch/manylinux-builder:cuda10.2", "package_type": "manywheel", "build_name": "manywheel-py3_8-cuda10_2", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu102", "channel": "nightly"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.3", "desired_cuda": "cu113", "container_image": "pytorch/manylinux-builder:cuda11.3", "package_type": "manywheel", "build_name": "manywheel-py3_8-cuda11_3", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu113", "channel": "nightly"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_8-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu116", "channel": "nightly"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_8-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly"}, {"python_version": "3.8", "gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "container_image": "pytorch/manylinux-builder:rocm5.1.1", "package_type": "manywheel", "build_name": "manywheel-py3_8-rocm5_1_1", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.1.1", "channel": "nightly"}, {"python_version": "3.8", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_8-rocm5_2", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly"}, {"python_version": "3.9", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_9-cpu", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly", "channel": "nightly"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "10.2", "desired_cuda": "cu102", "container_image": "pytorch/manylinux-builder:cuda10.2", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda10_2", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu102", "channel": "nightly"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.3", "desired_cuda": "cu113", "container_image": "pytorch/manylinux-builder:cuda11.3", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda11_3", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu113", "channel": "nightly"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu116", "channel": "nightly"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly"}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "container_image": "pytorch/manylinux-builder:rocm5.1.1", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm5_1_1", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.1.1", "channel": "nightly"}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm5_2", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly"}, {"python_version": "3.10", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_10-cpu", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly", "channel": "nightly"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "10.2", "desired_cuda": "cu102", "container_image": "pytorch/manylinux-builder:cuda10.2", "package_type": "manywheel", "build_name": "manywheel-py3_10-cuda10_2", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu102", "channel": "nightly"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.3", "desired_cuda": "cu113", "container_image": "pytorch/manylinux-builder:cuda11.3", "package_type": "manywheel", "build_name": "manywheel-py3_10-cuda11_3", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu113", "channel": "nightly"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_10-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu116", "channel": "nightly"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_10-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly"}, {"python_version": "3.10", "gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "container_image": "pytorch/manylinux-builder:rocm5.1.1", "package_type": "manywheel", "build_name": "manywheel-py3_10-rocm5_1_1", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.1.1", "channel": "nightly"}, {"python_version": "3.10", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_10-rocm5_2", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly"}, {"python_version": "3.11", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_11-cpu", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly", "channel": "nightly"}, {"python_version": "3.11", "gpu_arch_type": "cuda", "gpu_arch_version": "10.2", "desired_cuda": "cu102", "container_image": "pytorch/manylinux-builder:cuda10.2", "package_type": "manywheel", "build_name": "manywheel-py3_11-cuda10_2", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu102", "channel": "nightly"}, {"python_version": "3.11", "gpu_arch_type": "cuda", "gpu_arch_version": "11.3", "desired_cuda": "cu113", "container_image": "pytorch/manylinux-builder:cuda11.3", "package_type": "manywheel", "build_name": "manywheel-py3_11-cuda11_3", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu113", "channel": "nightly"}, {"python_version": "3.11", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_11-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu116", "channel": "nightly"}, {"python_version": "3.11", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_11-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly"}]}
```

libtorch:
```
python3 generate_binary_build_matrix.py --package-type libtorch --channel nightly
{"include": [{"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-shared-with-deps-pre-cxx11", "validation_runner": "ubuntu-20.04", "installation": "https://download.pytorch.org/libtorch/nightly/libtorch-shared-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-shared-without-deps-pre-cxx11", "validation_runner": "ubuntu-20.04", "installation": "https://download.pytorch.org/libtorch/nightly/libtorch-shared-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-static-with-deps-pre-cxx11", "validation_runner": "ubuntu-20.04", "installation": "https://download.pytorch.org/libtorch/nightly/libtorch-static-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-static-without-deps-pre-cxx11", "validation_runner": "ubuntu-20.04", "installation": "https://download.pytorch.org/libtorch/nightly/libtorch-static-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "10.2", "desired_cuda": "cu102", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda10.2", "package_type": "libtorch", "build_name": "libtorch-cuda10_2-shared-with-deps-pre-cxx11", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu102/libtorch-shared-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "10.2", "desired_cuda": "cu102", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda10.2", "package_type": "libtorch", "build_name": "libtorch-cuda10_2-shared-without-deps-pre-cxx11", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu102/libtorch-shared-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "10.2", "desired_cuda": "cu102", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda10.2", "package_type": "libtorch", "build_name": "libtorch-cuda10_2-static-with-deps-pre-cxx11", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu102/libtorch-static-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "10.2", "desired_cuda": "cu102", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda10.2", "package_type": "libtorch", "build_name": "libtorch-cuda10_2-static-without-deps-pre-cxx11", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu102/libtorch-static-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.3", "desired_cuda": "cu113", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.3", "package_type": "libtorch", "build_name": "libtorch-cuda11_3-shared-with-deps-pre-cxx11", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu113/libtorch-shared-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.3", "desired_cuda": "cu113", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.3", "package_type": "libtorch", "build_name": "libtorch-cuda11_3-shared-without-deps-pre-cxx11", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu113/libtorch-shared-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.3", "desired_cuda": "cu113", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.3", "package_type": "libtorch", "build_name": "libtorch-cuda11_3-static-with-deps-pre-cxx11", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu113/libtorch-static-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.3", "desired_cuda": "cu113", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.3", "package_type": "libtorch", "build_name": "libtorch-cuda11_3-static-without-deps-pre-cxx11", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu113/libtorch-static-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "libtorch", "build_name": "libtorch-cuda11_6-shared-with-deps-pre-cxx11", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu116/libtorch-shared-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "libtorch", "build_name": "libtorch-cuda11_6-shared-without-deps-pre-cxx11", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu116/libtorch-shared-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "libtorch", "build_name": "libtorch-cuda11_6-static-with-deps-pre-cxx11", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu116/libtorch-static-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "libtorch", "build_name": "libtorch-cuda11_6-static-without-deps-pre-cxx11", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu116/libtorch-static-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "libtorch", "build_name": "libtorch-cuda11_7-shared-with-deps-pre-cxx11", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu117/libtorch-shared-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "libtorch", "build_name": "libtorch-cuda11_7-shared-without-deps-pre-cxx11", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu117/libtorch-shared-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "libtorch", "build_name": "libtorch-cuda11_7-static-with-deps-pre-cxx11", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu117/libtorch-static-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "libtorch", "build_name": "libtorch-cuda11_7-static-without-deps-pre-cxx11", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu117/libtorch-static-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:rocm5.1.1", "package_type": "libtorch", "build_name": "libtorch-rocm5_1_1-shared-with-deps-pre-cxx11", "validation_runner": "ubuntu-20.04", "installation": "https://download.pytorch.org/libtorch/nightly/rocm5.1.1/libtorch-shared-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:rocm5.1.1", "package_type": "libtorch", "build_name": "libtorch-rocm5_1_1-static-with-deps-pre-cxx11", "validation_runner": "ubuntu-20.04", "installation": "https://download.pytorch.org/libtorch/nightly/rocm5.1.1/libtorch-static-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "libtorch", "build_name": "libtorch-rocm5_2-shared-with-deps-pre-cxx11", "validation_runner": "ubuntu-20.04", "installation": "https://download.pytorch.org/libtorch/nightly/rocm5.2/libtorch-shared-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "libtorch", "build_name": "libtorch-rocm5_2-static-with-deps-pre-cxx11", "validation_runner": "ubuntu-20.04", "installation": "https://download.pytorch.org/libtorch/nightly/rocm5.2/libtorch-static-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-shared-with-deps-cxx11-abi", "validation_runner": "ubuntu-20.04", "installation": "https://download.pytorch.org/libtorch/nightly/libtorch-cxx11-abi-shared-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-shared-without-deps-cxx11-abi", "validation_runner": "ubuntu-20.04", "installation": "https://download.pytorch.org/libtorch/nightly/libtorch-cxx11-abi-shared-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-static-with-deps-cxx11-abi", "validation_runner": "ubuntu-20.04", "installation": "https://download.pytorch.org/libtorch/nightly/libtorch-cxx11-abi-static-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-static-without-deps-cxx11-abi", "validation_runner": "ubuntu-20.04", "installation": "https://download.pytorch.org/libtorch/nightly/libtorch-cxx11-abi-static-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "10.2", "desired_cuda": "cu102", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda10.2", "package_type": "libtorch", "build_name": "libtorch-cuda10_2-shared-with-deps-cxx11-abi", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu102/libtorch-cxx11-abi-shared-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "10.2", "desired_cuda": "cu102", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda10.2", "package_type": "libtorch", "build_name": "libtorch-cuda10_2-shared-without-deps-cxx11-abi", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu102/libtorch-cxx11-abi-shared-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "10.2", "desired_cuda": "cu102", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda10.2", "package_type": "libtorch", "build_name": "libtorch-cuda10_2-static-with-deps-cxx11-abi", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu102/libtorch-cxx11-abi-static-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "10.2", "desired_cuda": "cu102", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda10.2", "package_type": "libtorch", "build_name": "libtorch-cuda10_2-static-without-deps-cxx11-abi", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu102/libtorch-cxx11-abi-static-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.3", "desired_cuda": "cu113", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.3", "package_type": "libtorch", "build_name": "libtorch-cuda11_3-shared-with-deps-cxx11-abi", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu113/libtorch-cxx11-abi-shared-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.3", "desired_cuda": "cu113", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.3", "package_type": "libtorch", "build_name": "libtorch-cuda11_3-shared-without-deps-cxx11-abi", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu113/libtorch-cxx11-abi-shared-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.3", "desired_cuda": "cu113", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.3", "package_type": "libtorch", "build_name": "libtorch-cuda11_3-static-with-deps-cxx11-abi", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu113/libtorch-cxx11-abi-static-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.3", "desired_cuda": "cu113", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.3", "package_type": "libtorch", "build_name": "libtorch-cuda11_3-static-without-deps-cxx11-abi", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu113/libtorch-cxx11-abi-static-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.6", "package_type": "libtorch", "build_name": "libtorch-cuda11_6-shared-with-deps-cxx11-abi", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu116/libtorch-cxx11-abi-shared-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.6", "package_type": "libtorch", "build_name": "libtorch-cuda11_6-shared-without-deps-cxx11-abi", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu116/libtorch-cxx11-abi-shared-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.6", "package_type": "libtorch", "build_name": "libtorch-cuda11_6-static-with-deps-cxx11-abi", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu116/libtorch-cxx11-abi-static-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.6", "package_type": "libtorch", "build_name": "libtorch-cuda11_6-static-without-deps-cxx11-abi", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu116/libtorch-cxx11-abi-static-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.7", "package_type": "libtorch", "build_name": "libtorch-cuda11_7-shared-with-deps-cxx11-abi", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu117/libtorch-cxx11-abi-shared-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.7", "package_type": "libtorch", "build_name": "libtorch-cuda11_7-shared-without-deps-cxx11-abi", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu117/libtorch-cxx11-abi-shared-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.7", "package_type": "libtorch", "build_name": "libtorch-cuda11_7-static-with-deps-cxx11-abi", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu117/libtorch-cxx11-abi-static-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.7", "package_type": "libtorch", "build_name": "libtorch-cuda11_7-static-without-deps-cxx11-abi", "validation_runner": "ubuntu-20.04-m60", "installation": "https://download.pytorch.org/libtorch/nightly/cu117/libtorch-cxx11-abi-static-without-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:rocm5.1.1", "package_type": "libtorch", "build_name": "libtorch-rocm5_1_1-shared-with-deps-cxx11-abi", "validation_runner": "ubuntu-20.04", "installation": "https://download.pytorch.org/libtorch/nightly/rocm5.1.1/libtorch-cxx11-abi-shared-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:rocm5.1.1", "package_type": "libtorch", "build_name": "libtorch-rocm5_1_1-static-with-deps-cxx11-abi", "validation_runner": "ubuntu-20.04", "installation": "https://download.pytorch.org/libtorch/nightly/rocm5.1.1/libtorch-cxx11-abi-static-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:rocm5.2", "package_type": "libtorch", "build_name": "libtorch-rocm5_2-shared-with-deps-cxx11-abi", "validation_runner": "ubuntu-20.04", "installation": "https://download.pytorch.org/libtorch/nightly/rocm5.2/libtorch-cxx11-abi-shared-with-deps-latest.zip", "channel": "nightly"}, {"gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:rocm5.2", "package_type": "libtorch", "build_name": "libtorch-rocm5_2-static-with-deps-cxx11-abi", "validation_runner": "ubuntu-20.04", "installation": "https://download.pytorch.org/libtorch/nightly/rocm5.2/libtorch-cxx11-abi-static-with-deps-latest.zip", "channel": "nightly"}]}
```