### PR TITLE
hud kpis - add viable strict historical chart

### DIFF
--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -130,6 +130,36 @@ export default function Kpis() {
                 yAxisRenderer={(unit) => `${unit}`}
                 />
             </Grid>
+            <Grid item xs={12} lg={6} height={ROW_HEIGHT}>
+              <TimeSeriesPanel
+                title={"viable/strict Lag (Daily)"}
+                queryName={"strict_lag_historical"}
+                queryCollection={"pytorch_dev_infra_kpis"}
+                queryParams={[...timeParams]}
+                granularity={"day"}
+                timeFieldName={"push_time"}
+                yAxisFieldName={"diff_hr"}
+                yAxisLabel={"Hours"}
+                yAxisRenderer={(unit) => `${unit}`}
+                // some outliers make this graph hard to read, so set a maximum yaxis˚
+                ymax={7}
+              />
+            </Grid>
+            <Grid item xs={12} lg={6} height={ROW_HEIGHT}>
+              <TimeSeriesPanel
+                title={"viable/strict Lag (Per Commit)"}
+                queryName={"strict_lag_historical"}
+                queryCollection={"pytorch_dev_infra_kpis"}
+                queryParams={[...timeParams]}
+                granularity={"milliseconds"}
+                timeFieldName={"push_time"}
+                yAxisFieldName={"diff_hr"}
+                yAxisLabel={"Hours"}
+                yAxisRenderer={(unit) => `${unit}`}
+                // some outliers make this graph hard to read, so set a maximum yaxis˚
+                ymax={7}
+              />
+            </Grid>
         </Grid>
     );
 }

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -151,7 +151,7 @@ export default function Kpis() {
                 queryName={"strict_lag_historical"}
                 queryCollection={"pytorch_dev_infra_kpis"}
                 queryParams={[...timeParams]}
-                granularity={"milliseconds"}
+                granularity={"minute"}
                 timeFieldName={"push_time"}
                 yAxisFieldName={"diff_hr"}
                 yAxisLabel={"Hours"}

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -141,7 +141,7 @@ export default function Kpis() {
                 yAxisFieldName={"diff_hr"}
                 yAxisLabel={"Hours"}
                 yAxisRenderer={(unit) => `${unit}`}
-                // some outliers make this graph hard to read, so set a maximum yaxis˚
+                // the data is very variable, so set the y axis to be something that makes this chart a bit easier to read
                 ymax={7}
               />
             </Grid>
@@ -156,7 +156,7 @@ export default function Kpis() {
                 yAxisFieldName={"diff_hr"}
                 yAxisLabel={"Hours"}
                 yAxisRenderer={(unit) => `${unit}`}
-                // some outliers make this graph hard to read, so set a maximum yaxis˚
+                // the data is very variable, so set the y axis to be something that makes this chart a bit easier to read
                 ymax={7}
               />
             </Grid>

--- a/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -16,11 +16,7 @@ import {
   Typography,
 } from "@mui/material";
 import { useRouter } from "next/router";
-import {
-  useCallback,
-  useRef,
-  useState
-} from "react";
+import { useCallback, useRef, useState } from "react";
 import { RocksetParam } from "lib/rockset";
 import { fetcher } from "lib/GeneralUtils";
 import {
@@ -79,48 +75,6 @@ function Panel({
   );
 }
 
-function getSeries(
-  data: any,
-  startTime: dayjs.Dayjs,
-  stopTime: dayjs.Dayjs,
-  granularity: any,
-  groupByFieldName: string,
-  timeFieldName: string,
-  yAxisFieldName: string
-) {
-  if (granularity == "minute") {
-    // dont interpolate, this is kinda like equivalent of granularity commit
-    let byGroup = _.groupBy(data, (d) => d[groupByFieldName]);
-    return _.map(byGroup, (value, key) => {
-      const data = value
-        .map((t: any) => {
-          return [t[timeFieldName], t[yAxisFieldName]];
-        })
-        .sort();
-      return {
-        name: key,
-        type: "line",
-        symbol: "circle",
-        symbolSize: 4,
-        data,
-        emphasis: {
-          focus: "series",
-        },
-      };
-    });
-  } else {
-    return seriesWithInterpolatedTimes(
-      data,
-      startTime,
-      stopTime,
-      granularity,
-      groupByFieldName,
-      timeFieldName,
-      yAxisFieldName
-    );
-  }
-}
-
 function Graphs({
   queryParams,
   granularity,
@@ -130,7 +84,7 @@ function Graphs({
   branchName,
 }: {
   queryParams: RocksetParam[];
-  granularity: "milliseconds" | "hour" | "day" | "week" | "month" | "year";
+  granularity: Granularity;
   ttsPercentile: number;
   selectedJobName: string;
   checkboxRef: any;
@@ -193,23 +147,23 @@ function Graphs({
   startTime = dayjs(startTime).startOf(granularity);
   stopTime = dayjs(stopTime).endOf(granularity);
 
-  const tts_true_series = getSeries(
+  const tts_true_series = seriesWithInterpolatedTimes(
     data,
     startTime,
     stopTime,
     granularity,
     groupByFieldName,
     timeFieldName,
-    ttsFieldName,
+    ttsFieldName
   );
-  const duration_true_series = getSeries(
+  const duration_true_series = seriesWithInterpolatedTimes(
     data,
     startTime,
     stopTime,
     granularity,
     groupByFieldName,
     timeFieldName,
-    durationFieldName,
+    durationFieldName
   );
   var tts_series = tts_true_series.filter((item: any) =>
     filter.has(item["name"])
@@ -232,7 +186,10 @@ function Graphs({
         </Paper>
       </Grid>
       <Grid item xs={3} height={ROW_HEIGHT}>
-        <div style={{ overflow: "auto", height: ROW_HEIGHT, fontSize: "15px" }} ref={checkboxRef}>
+        <div
+          style={{ overflow: "auto", height: ROW_HEIGHT, fontSize: "15px" }}
+          ref={checkboxRef}
+        >
           {tts_true_series.map((job) => (
             <div key={job["name"]}>
               <input
@@ -277,7 +234,7 @@ function GranularityPicker({
         <MenuItem value={"week"}>week</MenuItem>
         <MenuItem value={"day"}>day</MenuItem>
         <MenuItem value={"hour"}>hour</MenuItem>
-        <MenuItem value={"minute"}>minute</MenuItem>
+        <MenuItem value={"minute"}>minute (no interpolation)</MenuItem>
       </Select>
     </FormControl>
   );
@@ -285,10 +242,12 @@ function GranularityPicker({
 
 export default function Page() {
   const router = useRouter();
-  const branch: string = router.query.branch as string ?? "master";
-  const jobName: string = router.query.jobName as string ?? "none";
+  const branch: string = (router.query.branch as string) ?? "master";
+  const jobName: string = (router.query.jobName as string) ?? "none";
   const percentile: number =
-    router.query.percentile === undefined ? 0.50: parseFloat(router.query.percentile as string);
+    router.query.percentile === undefined
+      ? 0.5
+      : parseFloat(router.query.percentile as string);
 
   const [startTime, setStartTime] = useState(dayjs().subtract(1, "week"));
   const [stopTime, setStopTime] = useState(dayjs());

--- a/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -130,7 +130,7 @@ function Graphs({
   branchName,
 }: {
   queryParams: RocksetParam[];
-  granularity: "hour" | "day" | "week" | "month" | "year";
+  granularity: "milliseconds" | "hour" | "day" | "week" | "month" | "year";
   ttsPercentile: number;
   selectedJobName: string;
   checkboxRef: any;

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -16,7 +16,8 @@
     "number_of_force_pushes_historical": "d335eee3527a9c3c",
     "time_to_merge": "be1c2a28cf75fe32",
     "time_to_review": "adfbcdfc51ede11a",
-    "time_to_signal": "670e34fc86adb3ad"
+    "time_to_signal": "670e34fc86adb3ad",
+    "strict_lag_historical": "d2a09d13caf8b76a"
   },
   "metrics": {
     "correlation_matrix": "4960260cbb0c5b48",

--- a/torchci/rockset/pytorch_dev_infra_kpis/__sql/strict_lag_historical.sql
+++ b/torchci/rockset/pytorch_dev_infra_kpis/__sql/strict_lag_historical.sql
@@ -1,0 +1,19 @@
+select
+    AVG(
+        DATE_DIFF(
+            'minute',
+            PARSE_Timestamp_ISO8601(push.head_commit.timestamp),
+            push._event_time
+        ) / 60.0
+    ) as diff_hr,
+    DATE_TRUNC(:granularity, push._event_time) AS push_time,
+from
+    push
+where
+    push._event_time >= PARSE_DATETIME_ISO8601(:startTime)
+    AND push._event_time < PARSE_DATETIME_ISO8601(:stopTime)
+    and push.ref like 'refs/heads/viable/strict'
+group by
+    push_time
+order by
+    push_time

--- a/torchci/rockset/pytorch_dev_infra_kpis/strict_lag_historical.lambda.json
+++ b/torchci/rockset/pytorch_dev_infra_kpis/strict_lag_historical.lambda.json
@@ -1,0 +1,21 @@
+{
+  "sql_path": "__sql/strict_lag_historical.sql",
+  "default_parameters": [
+    {
+      "name": "granularity",
+      "type": "string",
+      "value": "week"
+    },
+    {
+      "name": "startTime",
+      "type": "string",
+      "value": "2022-06-09T00:06:32.839Z"
+    },
+    {
+      "name": "stopTime",
+      "type": "string",
+      "value": "2022-06-19T00:06:32.839Z"
+    }
+  ],
+  "description": ""
+}


### PR DESCRIPTION
add a viable/strict historical chart, graphing how far behind viable/strict was before it got updated, averaged daily and per minute, which should be granular enough to be equivalent to per commit

also changed a lot of stuff in tts page to take advantage of the minute granularity not interpolating

<img width="1679" alt="image" src="https://user-images.githubusercontent.com/44682903/187764522-b1d0fc6b-b45d-415c-a14f-216b49acd4c8.png">


Notes
* max yaxis of 7 b/c some days were very large
* lag is calculated by _event_time - commit timestamp