### PR TITLE
Map conda matrix channel input to real channel output that exists

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -182,7 +182,7 @@ def generate_conda_matrix(os: str, channel: str) -> List[Dict[str, str]]:
                         ".", "_"
                     ),
                     "validation_runner": validation_runner(gpu_arch_type, os),
-                    "channel": channel if channel == "release" else f"pytorch-{channel}",
+                    "channel": "pytorch" if channel == "release" else f"pytorch-{channel}",
                     "installation": get_conda_install_command(channel, gpu_arch_type, arch_version)
                 }
             )

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -182,7 +182,7 @@ def generate_conda_matrix(os: str, channel: str) -> List[Dict[str, str]]:
                         ".", "_"
                     ),
                     "validation_runner": validation_runner(gpu_arch_type, os),
-                    "channel": channel,
+                    "channel": channel if channel == "release" else f"pytorch-{channel}",
                     "installation": get_conda_install_command(channel, gpu_arch_type, arch_version)
                 }
             )


### PR DESCRIPTION
Currently the conda matrix channel out is directly piped out, but downstream tasks may need to add if else to translate to pytorch, pytorch-test, pytorch-nightly. I propose to do it in here. 