### PR TITLE
[alerts][ez] Remove assignment for Alerts

### DIFF
--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -166,7 +166,6 @@ def generate_failed_job_issue(failed_jobs: List[JobStatus]) -> Any:
     body += "Please review the errors and revert if needed."
     issue["body"] = body
     issue["labels"] = labels
-    issue["assignees"] = ["zengk95"]
 
     print("Generating alerts for: ", failed_jobs)
     return issue


### PR DESCRIPTION
Assigning the issue to me interferes with the butterfly/open source bots. It should assign it to the Oncall but open source bot keeps getting reassigned to me since I am the owner of the issue on Github. Hopefully this should fix it. 