### PR TITLE
Add MacOS x86_64 support when generating binary matrix

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -182,7 +182,7 @@ def generate_conda_matrix(os: str, channel: str) -> List[Dict[str, str]]:
                         ".", "_"
                     ),
                     "validation_runner": validation_runner(gpu_arch_type, os),
-                    "channel": channel if channel == "release" else f"pytorch-{channel}",
+                    "channel": "pytorch" if channel == "release" else f"pytorch-{channel}",
                     "installation": get_conda_install_command(channel, gpu_arch_type, arch_version)
                 }
             )

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -37,6 +37,7 @@ LINUX_CPU_RUNNER="ubuntu-20.04"
 WIN_GPU_RUNNER="windows-2019-m60"
 WIN_CPU_RUNNER="windows-2019"
 MACOS_M1_RUNNER="macos-m1-12"
+MACOS_XL_RUNNER="macos-12-xl"
 
 CONDA_INSTALL_BASE="conda install pytorch torchvision torchaudio"
 WHL_INSTALL_BASE="pip3 install torch torchvision torchaudio"
@@ -63,6 +64,8 @@ def validation_runner(arch_type: str, os: str) -> str:
             return WIN_CPU_RUNNER
     elif os == "macos-arm64":
         return MACOS_M1_RUNNER
+    elif os == "macos-x86_64":
+        return MACOS_XL_RUNNER
     else: # default to linux cpu runner
         return LINUX_CPU_RUNNER
 
@@ -357,10 +360,18 @@ def main() -> None:
     if options.channel == "all":
         for channel in CUDA_ACRHES_DICT:
             CUDA_ARCHES = CUDA_ACRHES_DICT[channel]
-            includes.extend(GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[options.package_type](options.operating_system, channel))
+            if options.operating_system == "macos":
+              includes.extend(GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[options.package_type]("macos-arm64", channel))
+              includes.extend(GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[options.package_type]("macos-x86_64", channel))
+            else: 
+              includes.extend(GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[options.package_type](options.operating_system, channel))
     else:
         CUDA_ARCHES = CUDA_ACRHES_DICT[options.channel]
-        includes = GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[options.package_type](options.operating_system, options.channel)
+        if options.operating_system == "macos":
+          includes.extend(GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[options.package_type]("macos-arm64", options.channel))
+          includes.extend(GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[options.package_type]("macos-x86_64", options.channel))
+        else: 
+          includes = GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[options.package_type](options.operating_system, options.channel)
 
     print(json.dumps({"include": includes}))
 

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -185,7 +185,7 @@ def generate_conda_matrix(os: str, channel: str) -> List[Dict[str, str]]:
                         ".", "_"
                     ),
                     "validation_runner": validation_runner(gpu_arch_type, os),
-                    "channel": "pytorch" if channel == "release" else f"pytorch-{channel}",
+                    "channel": channel,
                     "installation": get_conda_install_command(channel, gpu_arch_type, arch_version)
                 }
             )

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -182,7 +182,7 @@ def generate_conda_matrix(os: str, channel: str) -> List[Dict[str, str]]:
                         ".", "_"
                     ),
                     "validation_runner": validation_runner(gpu_arch_type, os),
-                    "channel": channel,
+                    "channel": channel if channel == "release" else f"pytorch-{channel}",
                     "installation": get_conda_install_command(channel, gpu_arch_type, arch_version)
                 }
             )

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -37,7 +37,7 @@ LINUX_CPU_RUNNER="ubuntu-20.04"
 WIN_GPU_RUNNER="windows-2019-m60"
 WIN_CPU_RUNNER="windows-2019"
 MACOS_M1_RUNNER="macos-m1-12"
-MACOS_XL_RUNNER="macos-12-xl"
+MACOS_X86_RUNNER="macos-12"
 
 CONDA_INSTALL_BASE="conda install pytorch torchvision torchaudio"
 WHL_INSTALL_BASE="pip3 install torch torchvision torchaudio"
@@ -65,7 +65,7 @@ def validation_runner(arch_type: str, os: str) -> str:
     elif os == "macos-arm64":
         return MACOS_M1_RUNNER
     elif os == "macos-x86_64":
-        return MACOS_XL_RUNNER
+        return MACOS_X86_RUNNER
     else: # default to linux cpu runner
         return LINUX_CPU_RUNNER
 
@@ -360,18 +360,10 @@ def main() -> None:
     if options.channel == "all":
         for channel in CUDA_ACRHES_DICT:
             CUDA_ARCHES = CUDA_ACRHES_DICT[channel]
-            if options.operating_system == "macos":
-              includes.extend(GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[options.package_type]("macos-arm64", channel))
-              includes.extend(GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[options.package_type]("macos-x86_64", channel))
-            else: 
-              includes.extend(GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[options.package_type](options.operating_system, channel))
+            includes.extend(GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[options.package_type](options.operating_system, channel))
     else:
         CUDA_ARCHES = CUDA_ACRHES_DICT[options.channel]
-        if options.operating_system == "macos":
-          includes.extend(GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[options.package_type]("macos-arm64", options.channel))
-          includes.extend(GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[options.package_type]("macos-x86_64", options.channel))
-        else: 
-          includes = GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[options.package_type](options.operating_system, options.channel)
+        includes = GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[options.package_type](options.operating_system, options.channel)
 
     print(json.dumps({"include": includes}))
 


### PR DESCRIPTION
Adding the support for MacOS x86_64 to generate wheels and conda packages configuration matrix. 
Use "macos-arm64" to target ARM-based Mac 
Use "macos-x86_64" to target X86_64 based Mac