### PR TITLE
[Nova] Use the new single-repo format for building Linux Conda

### DIFF
--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -88,6 +88,28 @@ jobs:
         run: |
           source "${BUILD_ENV_FILE}"
           CUDATOOLKIT_CHANNEL="nvidia"
+          case "$CU_VERSION" in
+            cu117)
+              CONDA_CUDATOOLKIT_CONSTRAINT="- pytorch-cuda=11.7 # [not osx]"
+              ;;
+            cu116)
+              CONDA_CUDATOOLKIT_CONSTRAINT="- pytorch-cuda=11.6 # [not osx]"
+              ;;
+            cu113)
+              CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=11.3,<11.4 # [not osx]"
+              ;;
+            cu102)
+              CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=10.2,<10.3 # [not osx]"
+              ;;
+            cpu)
+              CONDA_CUDATOOLKIT_CONSTRAINT=""
+              CONDA_BUILD_VARIANT="cpu"
+              ;;
+            *)
+              echo "Unrecognized CU_VERSION=$CU_VERSION"
+              exit 1
+              ;;
+          esac
           ${CONDA_RUN} conda build \
             -c defaults \
             -c "$CUDATOOLKIT_CHANNEL" \

--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -85,6 +85,9 @@ jobs:
           echo "SOURCE_ROOT_DIR=${GITHUB_WORKSPACE}/${REPOSITORY}" >> "${GITHUB_ENV}"
       - name: Build the conda (conda-build)
         working-directory: ${{ inputs.repository }}
+        # TODO: We can remove the case statement for handling
+        # CONDA_CUDATOOLKIT_CONSTRAINT once we cut a release for the
+        # pytorch-pkg-helpers library
         run: |
           source "${BUILD_ENV_FILE}"
           CUDATOOLKIT_CHANNEL="nvidia"

--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -90,20 +90,20 @@ jobs:
           CUDATOOLKIT_CHANNEL="nvidia"
           case "$CU_VERSION" in
             cu117)
-              CONDA_CUDATOOLKIT_CONSTRAINT="- pytorch-cuda=11.7 # [not osx]"
+              export CONDA_CUDATOOLKIT_CONSTRAINT="- pytorch-cuda=11.7 # [not osx]"
               ;;
             cu116)
-              CONDA_CUDATOOLKIT_CONSTRAINT="- pytorch-cuda=11.6 # [not osx]"
+              export CONDA_CUDATOOLKIT_CONSTRAINT="- pytorch-cuda=11.6 # [not osx]"
               ;;
             cu113)
-              CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=11.3,<11.4 # [not osx]"
+              export CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=11.3,<11.4 # [not osx]"
               ;;
             cu102)
-              CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=10.2,<10.3 # [not osx]"
+              export CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=10.2,<10.3 # [not osx]"
               ;;
             cpu)
-              CONDA_CUDATOOLKIT_CONSTRAINT=""
-              CONDA_BUILD_VARIANT="cpu"
+              export CONDA_CUDATOOLKIT_CONSTRAINT=""
+              export CONDA_BUILD_VARIANT="cpu"
               ;;
             *)
               echo "Unrecognized CU_VERSION=$CU_VERSION"

--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -87,8 +87,10 @@ jobs:
         working-directory: ${{ inputs.repository }}
         run: |
           source "${BUILD_ENV_FILE}"
+          CUDATOOLKIT_CHANNEL="nvidia"
           ${CONDA_RUN} conda build \
             -c defaults \
+            -c "$CUDATOOLKIT_CHANNEL" \
             -c "pytorch-${CHANNEL}" \
             --no-anaconda-upload \
             --python "${PYTHON_VERSION}" \

--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -1,0 +1,118 @@
+name: Build Linux Conda
+
+on:
+  workflow_call:
+    inputs:
+      conda-package-directory:
+        description: 'Directory where your meta.yaml for your conda package lives'
+        required: true
+        type: string
+      repository:
+        description: 'Repository to checkout, defaults to ""'
+        default: ""
+        type: string
+      ref:
+        description: 'Reference to checkout, defaults to "nightly"'
+        default: "nightly"
+        type: string
+      test-infra-repository:
+        description: "Test infra repository to use"
+        default: "pytorch/test-infra"
+        type: string
+      test-infra-ref:
+        description: "Test infra reference to use"
+        default: ""
+        type: string
+      build-matrix:
+        description: "Build matrix to utilize"
+        default: ""
+        type: string
+      pre-script:
+        description: "Pre script to run prior to build"
+        default: ""
+        type: string
+      post-script:
+        description: "Post script to run prior to build"
+        default: ""
+        type: string
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(inputs.build-matrix) }}
+    env:
+      CONDA_PACKAGE_DIRECTORY: ${{ inputs.conda-package-directory }}
+      PYTHON_VERSION: ${{ matrix.python_version }}
+      PACKAGE_TYPE: conda
+      REPOSITORY: ${{ inputs.repository }}
+      REF: ${{ inputs.ref }}
+      CU_VERSION: ${{ matrix.desired_cuda }}
+    name: ${{ matrix.build_name }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.container_image }}
+    # If a build is taking longer than 60 minutes on these runners we need
+    # to have a conversation
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Support the use case where we need to checkout someone's fork
+          repository: ${{ inputs.test-infra-repository }}
+          ref: ${{ inputs.test-infra-ref }}
+          path: test-infra
+      - uses: ./test-infra/.github/actions/setup-binary-builds
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
+          setup-miniconda: false
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Run pre-script
+        working-directory: ${{ inputs.repository }}
+        env:
+          PRE_SCRIPT: ${{ inputs.pre-script }}
+        if: ${{ inputs.pre-script != '' }}
+        run: |
+          if [[ ! -f ${PRE_SCRIPT} ]]; then
+            echo "::error::Specified pre-script file (${PRE_SCRIPT}) not found, not going execute it"
+            exit 1
+          else
+            ${CONDA_RUN} bash "${PRE_SCRIPT}"
+          fi
+      - name: Setup base environment variables
+        run: |
+          echo "SOURCE_ROOT_DIR=${GITHUB_WORKSPACE}/${REPOSITORY}" >> "${GITHUB_ENV}"
+      - name: Build the conda (conda-build)
+        working-directory: ${{ inputs.repository }}
+        run: |
+          source "${BUILD_ENV_FILE}"
+          ${CONDA_RUN} conda build \
+            -c defaults \
+            -c "pytorch-${CHANNEL}" \
+            --no-anaconda-upload \
+            --python "${PYTHON_VERSION}" \
+            --output-folder dist/ \
+            "${CONDA_PACKAGE_DIRECTORY}"
+      - name: Upload artifact to GitHub
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ inputs.repository }}/dist/
+      - name: Run post-script
+        working-directory: ${{ inputs.repository }}
+        env:
+          POST_SCRIPT: ${{ inputs.post-script }}
+        if: ${{ inputs.post-script != '' }}
+        run: |
+          if [[ ! -f ${POST_SCRIPT} ]]; then
+            echo "::error::Specified post-script file (${POST_SCRIPT}) not found, not going execute it"
+            exit 1
+          else
+            ${CONDA_RUN} bash "${POST_SCRIPT}"
+          fi
+      # TODO: Figure out upload method to s3
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true

--- a/.github/workflows/test_build_conda_linux.yml
+++ b/.github/workflows/test_build_conda_linux.yml
@@ -25,14 +25,14 @@ jobs:
             pre-script: packaging/pre_build_script_wheel.sh
             post-script: packaging/post_build_script_wheel.sh
             conda-package-directory: packaging/torchaudio
-          # - repository: pytorch/vision
-          #   pre-script: ""
-          #   post-script: ""
-          #   conda-package-directory: packaging/torchvision
-          # - repository: pytorch/text
-          #   pre-script: ""
-          #   post-script: ""
-          #   conda-package-directory: packaging/torchtext
+          - repository: pytorch/vision
+            pre-script: ""
+            post-script: ""
+            conda-package-directory: packaging/torchvision
+          - repository: pytorch/text
+            pre-script: ""
+            post-script: ""
+            conda-package-directory: packaging/torchtext
     name: ${{ matrix.repository }}
     uses: ./.github/workflows/build_conda_linux.yml
     with:

--- a/.github/workflows/test_build_conda_linux.yml
+++ b/.github/workflows/test_build_conda_linux.yml
@@ -1,0 +1,46 @@
+name: Test Build Linux Conda
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/test_build_conda_linux.yml
+      - .github/workflows/build_conda_linux.yml
+      - .github/workflows/generate_binary_build_matrix.yml
+
+jobs:
+  generate-matrix:
+    uses: ./.github/workflows/generate_binary_build_matrix.yml
+    with:
+      package-type: conda
+      os: linux
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+  test:
+    needs: generate-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repository: pytorch/audio
+            pre-script: packaging/pre_build_script_wheel.sh
+            post-script: packaging/post_build_script_wheel.sh
+            conda-package-directory: packaging/torchaudio
+          - repository: pytorch/vision
+            pre-script: ""
+            post-script: ""
+            conda-package-directory: packaging/torchvision
+          - repository: pytorch/text
+            pre-script: ""
+            post-script: ""
+            conda-package-directory: packaging/torchtext
+    name: ${{ matrix.repository }}
+    uses: ./.github/workflows/build_conda_linux.yml
+    with:
+      conda-package-directory: ${{ matrix.conda-package-directory }}
+      repository: ${{ matrix.repository }}
+      ref: nightly
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      pre-script: ${{ matrix.pre-script }}
+      post-script: ${{ matrix.post-script }}

--- a/.github/workflows/test_build_conda_linux.yml
+++ b/.github/workflows/test_build_conda_linux.yml
@@ -25,14 +25,14 @@ jobs:
             pre-script: packaging/pre_build_script_wheel.sh
             post-script: packaging/post_build_script_wheel.sh
             conda-package-directory: packaging/torchaudio
-          - repository: pytorch/vision
-            pre-script: ""
-            post-script: ""
-            conda-package-directory: packaging/torchvision
-          - repository: pytorch/text
-            pre-script: ""
-            post-script: ""
-            conda-package-directory: packaging/torchtext
+          # - repository: pytorch/vision
+          #   pre-script: ""
+          #   post-script: ""
+          #   conda-package-directory: packaging/torchvision
+          # - repository: pytorch/text
+          #   pre-script: ""
+          #   post-script: ""
+          #   conda-package-directory: packaging/torchtext
     name: ${{ matrix.repository }}
     uses: ./.github/workflows/build_conda_linux.yml
     with:


### PR DESCRIPTION
This PR uses the new single-repo format for building Linux Conda binaries. Apart from migrating the workflow over, we also must explicitly handle setting `CONDA_CUDATOOLKIT_CONSTRAINT` correctly, since the current implementation in pytorch-pkg-helpers does not yield a successful build (fails to parse the conda meta.yaml file). In a follow-up PR, I plan to add more thorough handling of `CONDA_CUDATOOLKIT_CONSTRAINT` to the pytorch-pkg-helpers library, so that it's more closely aligned with the pkg_helpers bash script in the domain repos.