### PR TITLE
Fix TTS spike due to manual workflow retrying

### DIFF
--- a/torchci/rockset/metrics/__sql/job_duration_avg.sql
+++ b/torchci/rockset/metrics/__sql/job_duration_avg.sql
@@ -19,6 +19,7 @@ WHERE
     AND job._event_time < PARSE_DATETIME_ISO8601(:stopTime)
     AND job.conclusion = 'success'
     AND workflow.head_branch LIKE :branch
+    AND workflow.run_attempt = 1
 GROUP BY
     name
 ORDER BY

--- a/torchci/rockset/metrics/__sql/job_duration_percentile.sql
+++ b/torchci/rockset/metrics/__sql/job_duration_percentile.sql
@@ -27,6 +27,7 @@ FROM (
             AND job._event_time < PARSE_DATETIME_ISO8601(:stopTime)
             AND job.conclusion = 'success'
             AND workflow.head_branch LIKE :branch
+            AND workflow.run_attempt = 1
     ) AS duration
 ) AS p
 WHERE

--- a/torchci/rockset/metrics/__sql/tts_avg.sql
+++ b/torchci/rockset/metrics/__sql/tts_avg.sql
@@ -19,6 +19,7 @@ WHERE
     AND job._event_time < PARSE_DATETIME_ISO8601(:stopTime)
     AND job.conclusion = 'success'
     AND workflow.head_branch LIKE :branch
+    AND workflow.run_attempt = 1
 GROUP BY
     name
 ORDER BY

--- a/torchci/rockset/metrics/__sql/tts_duration_historical.sql
+++ b/torchci/rockset/metrics/__sql/tts_duration_historical.sql
@@ -24,6 +24,7 @@ WHERE
     AND job._event_time < PARSE_DATETIME_ISO8601(:stopTime)
     AND workflow.name IN ('pull', 'trunk', 'nightly', 'periodic')
 	AND workflow.head_branch LIKE 'master'
+    AND workflow.run_attempt = 1
 GROUP BY
     granularity_bucket,
     full_name

--- a/torchci/rockset/metrics/__sql/tts_duration_historical_percentile.sql
+++ b/torchci/rockset/metrics/__sql/tts_duration_historical_percentile.sql
@@ -38,6 +38,7 @@ FROM (
             AND job._event_time < PARSE_DATETIME_ISO8601(:stopTime)
             AND workflow.name IN ('pull', 'trunk', 'nightly', 'periodic')
             AND workflow.head_branch LIKE :branch
+            AND workflow.run_attempt = 1
     ) AS tts_duration
 ) AS p
 WHERE

--- a/torchci/rockset/metrics/__sql/tts_percentile.sql
+++ b/torchci/rockset/metrics/__sql/tts_percentile.sql
@@ -27,6 +27,7 @@ FROM (
             AND job._event_time < PARSE_DATETIME_ISO8601(:stopTime)
             AND job.conclusion = 'success'
             AND workflow.head_branch LIKE :branch
+            AND workflow.run_attempt = 1
     ) AS tts
 ) AS p
 WHERE

--- a/torchci/rockset/metrics/__sql/workflow_duration_avg.sql
+++ b/torchci/rockset/metrics/__sql/workflow_duration_avg.sql
@@ -14,6 +14,7 @@ WHERE
     AND name = :name
     AND workflow._event_time >= PARSE_DATETIME_ISO8601(:startTime)
     AND workflow._event_time < PARSE_DATETIME_ISO8601(:stopTime)
+    AND workflow.run_attempt = 1
 GROUP BY
     workflow.name
 ORDER BY

--- a/torchci/rockset/metrics/__sql/workflow_duration_percentile.sql
+++ b/torchci/rockset/metrics/__sql/workflow_duration_percentile.sql
@@ -20,6 +20,7 @@ FROM (
         	AND workflow.name = :name
         	AND workflow._event_time >= PARSE_DATETIME_ISO8601(:startTime)
         	AND workflow._event_time < PARSE_DATETIME_ISO8601(:stopTime)
+            AND workflow.run_attempt = 1
     ) AS tts
 ) AS p
 WHERE

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -22,8 +22,8 @@
   },
   "metrics": {
     "correlation_matrix": "4960260cbb0c5b48",
-    "job_duration_avg": "124f44f27a7d8225",
-    "job_duration_percentile": "9cc2fb692664e05f",
+    "job_duration_avg": "10a88ea2ebb80647",
+    "job_duration_percentile": "96507ed62db7a3a8",
     "last_branch_push": "3d995ac2143586dc",
     "last_successful_jobs": "fd8bc3a2afc989a2",
     "last_successful_workflow": "5d22927dd0b0956b",
@@ -36,14 +36,14 @@
     "queued_jobs_by_label": "52ab0f4570516f6b",
     "queued_jobs": "7b5ef18c1273bab2",
     "reverts": "f5bc84a10c4065a3",
-    "tts_avg": "c0049352a4c38aa5",
-    "tts_duration_historical": "593f718235d55e75",
-    "tts_duration_historical_percentile": "4ccc23b6d3da41e5",
-    "tts_percentile": "a6f994a29726df6b",
+    "tts_avg": "2dd4a04e091c58aa",
+    "tts_percentile": "cc993e55cc1804f0",
+    "tts_duration_historical": "b50886e19e057356",
+    "tts_duration_historical_percentile": "db31fc175359b91c",
     "strict_lag_sec": "f9523e8c8c3a3311",
     "queue_times_historical": "7f4d6599362e70ba",
-    "workflow_duration_avg": "34e698a78cb36669",
-    "workflow_duration_percentile": "703d4a1a2a719a34",
+    "workflow_duration_avg": "b92d60f09ac39069",
+    "workflow_duration_percentile": "a69732c03132613c",
     "workflow_load": "eff394d8e0b76436"
   }
 }


### PR DESCRIPTION
I finally understand why we are seeing TTS in term of days in our metrics, for example:

![Screen Shot 2022-09-01 at 19 20 23](https://user-images.githubusercontent.com/475357/188045479-6285c6fd-6f0f-4fb0-8ede-b9cdd90d80bf.png)

or 

![Screen Shot 2022-09-01 at 19 20 47](https://user-images.githubusercontent.com/475357/188045537-0e861fcb-c7ce-4abd-a5f4-309274d738ff.png)

Here is what happens:

* A workflow was spawned, and failed on the first try, i.e. https://github.com/pytorch/pytorch/actions/runs/2886769854
* The PR owner didn't have time to address the failure right away and left it for an undetermined amount of time, which could be days
* After a while, the PR owner retried those failed jobs manually, i.e. https://github.com/pytorch/pytorch/runs/8074502755 (may be to see if the flakiness went away).  So far so good.  The catch, however, is that GitHub will also update the `completed_at` timestamp of successful jobs and bump their `run_attempt` version.  When it happens, the `completed_at` timestamp we use to calculate TTS could be days away from the creation time of the workflow. This leads to the issue in the screenshots.

At the moment, I don't think we keep separate records for retry in `workflow_job` collection.  So I couldn't find a way to get the timestamp of the first successful jobs in a failed workflow.  Instead I opt for a quick an easy fix to record only workflows with `run_attempt` equal to 1:

* This is the main case.  People only retry failed jobs in the same workflow when they think it's due to flakiness during development.  We could safely ignore retried workflows without any impacts to the metrics
* No need to hack our brain to figure out a way to record retries to get their timestamp
* This also fits well with how we define TTS today in which we only take into account successfully jobs

### Testing

![Screen Shot 2022-09-01 at 19 19 37](https://user-images.githubusercontent.com/475357/188049113-c39fceb1-3b06-4a7e-945f-a6ac2def218a.png)

![Screen Shot 2022-09-01 at 19 23 10](https://user-images.githubusercontent.com/475357/188049154-6218b9cc-6086-42bc-8a85-495e9fce68f4.png)





