### PR TITLE
[Nova] Do not add 3.11 to Domains build matrix

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -244,11 +244,6 @@ def generate_wheels_matrix(
         if os == "macos-arm64":
             python_versions = list_without(python_versions, ["3.7"])
 
-        if os == "linux":
-            # NOTE: We only build 3.11 wheel on linux as 3.11 is not
-            # available on conda right now
-            python_versions.append("3.11")
-
     if arches is None:
         # Define default compute archivectures
         arches = ["cpu"]


### PR DESCRIPTION
Just putting this PR up as an RFC. We can exclude 3.11 builds from the build workflows but this is a nice place to exclude from all the workflows in one place. It also makes this code a little cleaner. If we don't want this script to diverge from the corresponding script in pytorch/pytorch, we can close this PR and go with a different approach.

Synced with @atalman about this approach as well