### PR TITLE
[Nova] Fix CONDA_CUDATOOLKIT_CONSTRAINT handling in pytorch-pkg-helpers

### DIFF
--- a/tools/pkg-helpers/pytorch_pkg_helpers/conda.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/conda.py
@@ -51,7 +51,11 @@ def get_conda_cuda_variables(platform: str, gpu_arch_version: str) -> List[str]:
         conda_build_variant = "cuda"
         cmake_use_cuda = "1"
         if float(sanitized_version) >= 11.6:
-            conda_cuda_toolkit_constraint = f"cuda={sanitized_version}"
+            conda_cuda_toolkit_constraint = f"- pytorch-cuda={sanitized_version} # [not osx]"
+        elif float(sanitized_version) == 11.3:
+            conda_cuda_toolkit_constraint = "- cudatoolkit >=11.3,<11.4 # [not osx]"
+        elif float(sanitized_version) == 10.2:
+            conda_cuda_toolkit_constraint = "- cudatoolkit >=10.2,<10.3 # [not osx]"
         else:
             conda_cuda_toolkit_constraint = f"cudatoolkit={sanitized_version}"
     return [

--- a/tools/pkg-helpers/tests/test_conda.py
+++ b/tools/pkg-helpers/tests/test_conda.py
@@ -55,7 +55,7 @@ def test_get_conda_version_variables(gpu_arch_version, pytorch_version, expected
             [
                 "export CONDA_BUILD_VARIANT='cuda'",
                 "export CMAKE_USE_CUDA='1'",
-                "export CONDA_CUDATOOLKIT_CONSTRAINT='cuda=11.6'",
+                "export CONDA_CUDATOOLKIT_CONSTRAINT='- pytorch-cuda=11.6 # [not osx]'",
             ],
         ),
         (
@@ -63,7 +63,7 @@ def test_get_conda_version_variables(gpu_arch_version, pytorch_version, expected
             [
                 "export CONDA_BUILD_VARIANT='cuda'",
                 "export CMAKE_USE_CUDA='1'",
-                "export CONDA_CUDATOOLKIT_CONSTRAINT='cudatoolkit=11.3'",
+                "export CONDA_CUDATOOLKIT_CONSTRAINT='- cudatoolkit >=11.3,<11.4 # [not osx]'",
             ],
         ),
     ],


### PR DESCRIPTION
We found that the handling of `CONDA_CUDATOOLKIT_CONSTRAINT` in https://github.com/pytorch/test-infra/pull/660 resulted in conda builds on CUDA failing due to being unable to parse the meta.yaml config file. The config depends on the env var, and pytorch-pkg-helpers handling of the env var differed from the pkg-helpers.bash files (https://github.com/pytorch/audio/blob/main/packaging/pkg_helpers.bash) in the domain repos. This change makes pytorch-pkg-helpers handle `CONDA_CUDATOOLKIT_CONSTRAINT` the same way as the bash script, and also results in successful conda builds.

Will need to do a release of the pytorch-pkg-helpers library before removing this logic from the workflow.