### PR TITLE
[Nova] Add support for CUDATOOLKIT_CHANNEL in pytorch-pkg-helpers

### DIFF
--- a/tools/pkg-helpers/pytorch_pkg_helpers/conda.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/conda.py
@@ -62,6 +62,7 @@ def get_conda_cuda_variables(platform: str, gpu_arch_version: str) -> List[str]:
         f"export CONDA_BUILD_VARIANT='{conda_build_variant}'",
         f"export CMAKE_USE_CUDA='{cmake_use_cuda}'",
         f"export CONDA_CUDATOOLKIT_CONSTRAINT='{conda_cuda_toolkit_constraint}'",
+        f"export CUDATOOLKIT_CHANNEL=nvidia",
     ]
 
 

--- a/tools/pkg-helpers/tests/test_conda.py
+++ b/tools/pkg-helpers/tests/test_conda.py
@@ -40,6 +40,7 @@ def test_get_conda_version_variables(gpu_arch_version, pytorch_version, expected
                 "export CONDA_BUILD_VARIANT='cpu'",
                 "export CMAKE_USE_CUDA='0'",
                 "export CONDA_CUDATOOLKIT_CONSTRAINT=''",
+                "export CUDATOOLKIT_CHANNEL=nvidia",
             ],
         ),
         (
@@ -48,6 +49,7 @@ def test_get_conda_version_variables(gpu_arch_version, pytorch_version, expected
                 "export CONDA_BUILD_VARIANT='cpu'",
                 "export CMAKE_USE_CUDA='0'",
                 "export CONDA_CUDATOOLKIT_CONSTRAINT=''",
+                "export CUDATOOLKIT_CHANNEL=nvidia",
             ],
         ),
         (
@@ -56,6 +58,7 @@ def test_get_conda_version_variables(gpu_arch_version, pytorch_version, expected
                 "export CONDA_BUILD_VARIANT='cuda'",
                 "export CMAKE_USE_CUDA='1'",
                 "export CONDA_CUDATOOLKIT_CONSTRAINT='- pytorch-cuda=11.6 # [not osx]'",
+                "export CUDATOOLKIT_CHANNEL=nvidia",
             ],
         ),
         (
@@ -64,6 +67,7 @@ def test_get_conda_version_variables(gpu_arch_version, pytorch_version, expected
                 "export CONDA_BUILD_VARIANT='cuda'",
                 "export CMAKE_USE_CUDA='1'",
                 "export CONDA_CUDATOOLKIT_CONSTRAINT='- cudatoolkit >=11.3,<11.4 # [not osx]'",
+                "export CUDATOOLKIT_CHANNEL=nvidia",
             ],
         ),
     ],


### PR DESCRIPTION
Most domains set CUDATOOLKIT_CHANNEL=nvidia as an additional channel during conda builds. We currently handle this in a custom fashion in the workflow, but it's more modular to do this in pkg-helpers.