### PR TITLE
Use nondeprecated instance for upload_disabled_tests

### DIFF
--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   update-disabled-tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
18.04 is getting deprecated so here's the small fix