### PR TITLE
Fix TTS to ignore failed workflows

### DIFF
--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -7,8 +7,8 @@ import { useState } from "react";
 const ROW_HEIGHT = 240;
 
 export default function Kpis() {
-    // Start looking at data from 6 weeks in to avoid outlier data from the start of the year
-    const [startTime, setStartTime] = useState(dayjs().startOf("year").add(6, 'week'));
+    // Looking at data from the past 6 months
+    const [startTime, setStartTime] = useState(dayjs().subtract(6, 'month'));
     const [stopTime, setStopTime] = useState(dayjs());
 
     const timeParams: RocksetParam[] = [

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -17,7 +17,7 @@
     "number_of_force_pushes_historical": "7f57dbe505878a81",
     "time_to_merge": "be1c2a28cf75fe32",
     "time_to_review": "adfbcdfc51ede11a",
-    "time_to_signal": "113fdb5296a099d0",
+    "time_to_signal": "ff332d025976c103",
     "strict_lag_historical": "d2a09d13caf8b76a"
   },
   "metrics": {

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -17,7 +17,7 @@
     "number_of_force_pushes_historical": "7f57dbe505878a81",
     "time_to_merge": "be1c2a28cf75fe32",
     "time_to_review": "adfbcdfc51ede11a",
-    "time_to_signal": "0628a40515be1873",
+    "time_to_signal": "3257279f746509e0",
     "strict_lag_historical": "d2a09d13caf8b76a"
   },
   "metrics": {

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -17,7 +17,7 @@
     "number_of_force_pushes_historical": "7f57dbe505878a81",
     "time_to_merge": "be1c2a28cf75fe32",
     "time_to_review": "adfbcdfc51ede11a",
-    "time_to_signal": "3257279f746509e0",
+    "time_to_signal": "113fdb5296a099d0",
     "strict_lag_historical": "d2a09d13caf8b76a"
   },
   "metrics": {

--- a/torchci/rockset/pytorch_dev_infra_kpis/__sql/time_to_signal.sql
+++ b/torchci/rockset/pytorch_dev_infra_kpis/__sql/time_to_signal.sql
@@ -1,10 +1,10 @@
 with failed_workflows as (
-	Select
-        DISTINCT(w.head_commit.id)	as sha
+	select
+        distinct(w.head_commit.id)	as sha
     from commons.workflow_run w
     where
         w.conclusion in ('failure', 'startup_failure', 'cancelled')
-        AND w.repository.full_name = 'pytorch/pytorch'
+        and w.repository.full_name = 'pytorch/pytorch'
 ),
 successful_commits as (
   select 
@@ -12,7 +12,7 @@ successful_commits as (
       count(*) as cnt,
       MIN(w.created_at) as created_at
   from 
-      commons.workflow_run w LEFT OUTER JOIN failed_workflows f on w.head_commit.id = f.sha
+      commons.workflow_run w left outer join failed_workflows f on w.head_commit.id = f.sha
   where 
       f.sha is null
       and PARSE_TIMESTAMP_ISO8601(w.created_at) > PARSE_TIMESTAMP_ISO8601(:startTime)
@@ -30,7 +30,7 @@ completed_workflows as (
         commons.workflow_run w
     where
         status = 'completed'
-        AND w.repository.full_name = 'pytorch/pytorch'
+        and w.repository.full_name = 'pytorch/pytorch'
         and PARSE_TIMESTAMP_ISO8601(w.created_at) > PARSE_TIMESTAMP_ISO8601(:startTime)
         and w.run_attempt = 1 
         and w.head_sha in (select sha from successful_commits)

--- a/torchci/rockset/pytorch_dev_infra_kpis/__sql/time_to_signal.sql
+++ b/torchci/rockset/pytorch_dev_infra_kpis/__sql/time_to_signal.sql
@@ -33,7 +33,7 @@ completed_workflows as (
         AND w.repository.full_name = 'pytorch/pytorch'
         and PARSE_TIMESTAMP_ISO8601(w.created_at) > PARSE_TIMESTAMP_ISO8601(:startTime)
         and w.run_attempt = 1 
-  		and w.head_sha in (select sha from successful_commits)
+        and w.head_sha in (select sha from successful_commits)
 ),
 tts_by_sha as (
     select

--- a/torchci/rockset/pytorch_dev_infra_kpis/__sql/time_to_signal.sql
+++ b/torchci/rockset/pytorch_dev_infra_kpis/__sql/time_to_signal.sql
@@ -1,4 +1,27 @@
-with completed_workflows as (
+with failed_workflows as (
+	Select
+        DISTINCT(w.head_commit.id)	as sha
+    from commons.workflow_run w
+    where
+        w.conclusion in ('failure', 'startup_failure', 'cancelled')
+        AND w.repository.full_name = 'pytorch/pytorch'
+),
+successful_commits as (
+  select 
+      w.head_commit.id as sha,
+      count(*) as cnt,
+      MIN(w.created_at) as created_at
+  from 
+      commons.workflow_run w LEFT OUTER JOIN failed_workflows f on w.head_commit.id = f.sha
+  where 
+      f.sha is null
+      and PARSE_TIMESTAMP_ISO8601(w.created_at) > PARSE_TIMESTAMP_ISO8601(:startTime)
+      AND w.repository.full_name = 'pytorch/pytorch'
+      and w.conclusion = 'success'
+      and w.run_attempt = 1 
+  group by sha
+),
+completed_workflows as (
     select
         w.created_at as created_at,
         w.id,
@@ -10,6 +33,7 @@ with completed_workflows as (
         AND w.repository.full_name = 'pytorch/pytorch'
         and PARSE_TIMESTAMP_ISO8601(w.created_at) > PARSE_TIMESTAMP_ISO8601(:startTime)
         and w.run_attempt = 1 
+  		and w.head_sha in (select sha from successful_commits)
 ),
 tts_by_sha as (
     select
@@ -37,8 +61,8 @@ select
 from
     tts_by_sha
 where
-    job_cnt > 15
+    job_cnt > 35
 group by
     week_bucket
 order by
-    week_bucket asc
+    week_bucket desc

--- a/torchci/rockset/pytorch_dev_infra_kpis/time_to_signal.lambda.json
+++ b/torchci/rockset/pytorch_dev_infra_kpis/time_to_signal.lambda.json
@@ -12,5 +12,5 @@
       "value": "2022-01-01T00:00:00.000Z"
     }
   ],
-  "description": "Exclude failed workflows from TTS"
+  "description": "TTS for successful workflows"
 }

--- a/torchci/rockset/pytorch_dev_infra_kpis/time_to_signal.lambda.json
+++ b/torchci/rockset/pytorch_dev_infra_kpis/time_to_signal.lambda.json
@@ -12,5 +12,5 @@
       "value": "2022-01-01T00:00:00.000Z"
     }
   ],
-  "description": ""
+  "description": "Exclude failed workflows from TTS"
 }


### PR DESCRIPTION
The old TTS metric included the TTS from failed workflows, which would introduce variable noice and incorrectly lower the TTS number.

We now only look at workflows which passed all jobs. Since we're not excluding the low-TTS failed jobs, our official TTS numbers have of course increased slightly 

This also changes the KPI chart to only look at the past 6 months of data (which is all that's relevant in each half).

The chart still isn't perfect yet. It still averages in data for workflows like nightly, periodic.  Future task is to figure out how to filter out that data from here as well

Old chart:
<img width="735" alt="image" src="https://user-images.githubusercontent.com/4468967/189001164-f5bbf0a1-cda5-42a7-98b1-458ab0567d0f.png">

New chart:
<img width="733" alt="image" src="https://user-images.githubusercontent.com/4468967/189003074-70a5f129-0724-4d20-9c89-5472dc4428e6.png">