### PR TITLE
[Nova] Use latest pytorch-pkg-helpers in Linux Conda Builds

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -83,7 +83,7 @@ runs:
             "python=3.9"
           CONDA_ENV="${CONDA_ENV}"
           CONDA_RUN="conda run -p ${CONDA_ENV}"
-          ${CONDA_RUN} python3 -m pip install pytorch-pkg-helpers==0.1.0
+          ${CONDA_RUN} python3 -m pip install pytorch-pkg-helpers==0.1.3
           BUILD_ENV_FILE="${RUNNER_TEMP}/build_env_${GITHUB_RUN_ID}"
           ${CONDA_RUN} python3 -m pytorch_pkg_helpers > "${BUILD_ENV_FILE}"
           echo "BUILD_ENV_FILE=${BUILD_ENV_FILE}" >> "${GITHUB_ENV}"

--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -85,37 +85,12 @@ jobs:
           echo "SOURCE_ROOT_DIR=${GITHUB_WORKSPACE}/${REPOSITORY}" >> "${GITHUB_ENV}"
       - name: Build the conda (conda-build)
         working-directory: ${{ inputs.repository }}
-        # TODO: We can remove the case statement for handling
-        # CONDA_CUDATOOLKIT_CONSTRAINT once we cut a release for the
-        # pytorch-pkg-helpers library
         run: |
           source "${BUILD_ENV_FILE}"
           CUDATOOLKIT_CHANNEL="nvidia"
-          case "$CU_VERSION" in
-            cu117)
-              export CONDA_CUDATOOLKIT_CONSTRAINT="- pytorch-cuda=11.7 # [not osx]"
-              ;;
-            cu116)
-              export CONDA_CUDATOOLKIT_CONSTRAINT="- pytorch-cuda=11.6 # [not osx]"
-              ;;
-            cu113)
-              export CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=11.3,<11.4 # [not osx]"
-              ;;
-            cu102)
-              export CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=10.2,<10.3 # [not osx]"
-              ;;
-            cpu)
-              export CONDA_CUDATOOLKIT_CONSTRAINT=""
-              export CONDA_BUILD_VARIANT="cpu"
-              ;;
-            *)
-              echo "Unrecognized CU_VERSION=$CU_VERSION"
-              exit 1
-              ;;
-          esac
           ${CONDA_RUN} conda build \
             -c defaults \
-            -c "$CUDATOOLKIT_CHANNEL" \
+            -c ${{ env.CUDATOOLKIT_CHANNEL }} \
             -c "pytorch-${CHANNEL}" \
             --no-anaconda-upload \
             --python "${PYTHON_VERSION}" \

--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -85,12 +85,13 @@ jobs:
           echo "SOURCE_ROOT_DIR=${GITHUB_WORKSPACE}/${REPOSITORY}" >> "${GITHUB_ENV}"
       - name: Build the conda (conda-build)
         working-directory: ${{ inputs.repository }}
+        env:
+          CUDATOOLKIT_CHANNEL: ${{ env.CUDATOOLKIT_CHANNEL }}
         run: |
           source "${BUILD_ENV_FILE}"
-          CUDATOOLKIT_CHANNEL="nvidia"
           ${CONDA_RUN} conda build \
             -c defaults \
-            -c ${{ env.CUDATOOLKIT_CHANNEL }} \
+            -c "${CUDATOOLKIT_CHANNEL}" \
             -c "pytorch-${CHANNEL}" \
             --no-anaconda-upload \
             --python "${PYTHON_VERSION}" \


### PR DESCRIPTION
This does 2 things:
1. Bumps the usage in setup-binary-builds action to the latest version (0.1.3) of the package helpers library.
2. Cleans up previous case statements and env vars that were patched before the latest version release.