### PR TITLE
[hud] last set of query optimizations

### DIFF
--- a/torchci/rockset/commons/__sql/failure_samples_query.sql
+++ b/torchci/rockset/commons/__sql/failure_samples_query.sql
@@ -1,14 +1,3 @@
-with c as (
-    SELECT
-        *
-    from
-        "GitHub-Actions".classification c
-    where
-        c.captures = :captures
-        AND c._event_time > (CURRENT_TIMESTAMP() - INTERVAL 14 day)
-    ORDER BY
-        c._event_time DESC
-)
 SELECT
     job._event_time as time,
     w.name as workflowName,
@@ -30,17 +19,14 @@ SELECT
         PARSE_TIMESTAMP_ISO8601(job.started_at),
         PARSE_TIMESTAMP_ISO8601(job.completed_at)
     ) as durationS,
-    c.line as failureLine,
-    c.line_num as failureLineNumber,
-    c.context as failureContext,
-    c.captures AS failureCaptures,
+    torchci_classification.line as failureLine,
+    torchci_classification.line_num as failureLineNumber,
+    torchci_classification.captures AS failureCaptures,
 from
     workflow_run w
-    INNER JOIN (
-        workflow_job job
-        INNER JOIN c on job.id = c.job_id
-    ) ON w.id = job.run_id
+    INNER JOIN workflow_job job ON w.id = job.run_id
 where
-    c.captures = :captures
+    torchci_classification.captures = :captures
+    AND job._event_time > (CURRENT_TIMESTAMP() - INTERVAL 14 day)
 ORDER BY
-    c._event_time DESC
+    workflow_job._event_time DESC

--- a/torchci/rockset/commons/__sql/unclassified.sql
+++ b/torchci/rockset/commons/__sql/unclassified.sql
@@ -8,11 +8,10 @@ SELECT
 FROM
     commons.workflow_job job
     JOIN commons.workflow_run workflow on job.run_id = workflow.id
-    LEFT JOIN "GitHub-Actions".classification on classification.job_id = job.id
 WHERE
 	job.conclusion = 'failure'
-    AND classification.line IS NULL
     AND job._event_time > (CURRENT_TIMESTAMP() - HOURS(24))
+    AND job.torchci_classification IS NULL
 ORDER BY
 	job._event_time ASC
 LIMIT :n

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -1,16 +1,16 @@
 {
   "commons": {
-    "hud_query": "5329660e8057caf2",
-    "commit_jobs_query": "90e009e81c0f58de",
+    "hud_query": "f5ebefcdd53b6ff5",
+    "commit_jobs_query": "935a7b9f251dc4aa",
     "flaky_tests": "59d7546183743626",
     "slow_tests": "ef8d035d23aa8ab6",
     "test_time_per_file": "50cb3694334ed63a",
     "test_time_per_file_periodic_jobs": "39c105542e297c09",
     "issue_query": "f29a1afe94563601",
-    "failure_samples_query": "2961636418a148c2",
+    "failure_samples_query": "7be8da412210d424",
     "recent_pr_workflows_query": "4e03cb13e8372050",
     "reverted_prs_with_reason": "f35155a95a233476",
-    "unclassified": "df744380711131d9"
+    "unclassified": "1b31a2d8f4ab7230"
   },
   "pytorch_dev_infra_kpis": {
     "num_reverts": "dd2bac0ff36ea47f",


### PR DESCRIPTION
This makes use of the new dynamodb mutation implemented in #674 to do
the queries.

This makes the queries ridonkulously fast. `commit_jobs_query` takes
sub-50ms (down from several seconds), and `hud_query` takes ~150ms (down
from 5+ seconds).

We should be able to reduce our VM size after these changes.

The data is already backfilled and consistent, so we can merge this
whenever to get the speed boost.
