### PR TITLE
[Nova] Upload Linux Conda binaries to anaconda after building

### DIFF
--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -115,6 +115,7 @@ jobs:
             ${CONDA_RUN} bash "${POST_SCRIPT}"
           fi
       - name: Upload package to conda
+        if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/')) }}
         working-directory: ${{ inputs.repository }}
         env:
           CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}

--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -115,6 +115,7 @@ jobs:
             ${CONDA_RUN} bash "${POST_SCRIPT}"
           fi
       - name: Upload package to conda
+        working-directory: ${{ inputs.repository }}
         env:
           CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}
         run: |

--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -114,7 +114,15 @@ jobs:
           else
             ${CONDA_RUN} bash "${POST_SCRIPT}"
           fi
-      # TODO: Figure out upload method to s3
+      - name: Upload package to conda
+        env:
+          CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}
+        run: |
+          source "${BUILD_ENV_FILE}"
+          ${CONDA_RUN} conda install -yq anaconda-client
+          set -x
+          export ANACONDA_PATH=$(${CONDA_RUN} conda info --base)/bin
+          $ANACONDA_PATH/anaconda  -t "${CONDA_PYTORCHBOT_TOKEN}" upload dist/linux-64/*.tar.bz2 -u "pytorch-${CHANNEL}" --label main --no-progress --force
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/test_build_conda_linux.yml
+++ b/.github/workflows/test_build_conda_linux.yml
@@ -25,14 +25,14 @@ jobs:
             pre-script: packaging/pre_build_script_wheel.sh
             post-script: packaging/post_build_script_wheel.sh
             conda-package-directory: packaging/torchaudio
-          # - repository: pytorch/vision
-          #   pre-script: ""
-          #   post-script: ""
-          #   conda-package-directory: packaging/torchvision
-          # - repository: pytorch/text
-          #   pre-script: ""
-          #   post-script: ""
-          #   conda-package-directory: packaging/torchtext
+          - repository: pytorch/vision
+            pre-script: ""
+            post-script: ""
+            conda-package-directory: packaging/torchvision
+          - repository: pytorch/text
+            pre-script: ""
+            post-script: ""
+            conda-package-directory: packaging/torchtext
     name: ${{ matrix.repository }}
     uses: ./.github/workflows/build_conda_linux.yml
     with:

--- a/.github/workflows/test_build_conda_linux.yml
+++ b/.github/workflows/test_build_conda_linux.yml
@@ -25,14 +25,14 @@ jobs:
             pre-script: packaging/pre_build_script_wheel.sh
             post-script: packaging/post_build_script_wheel.sh
             conda-package-directory: packaging/torchaudio
-          - repository: pytorch/vision
-            pre-script: ""
-            post-script: ""
-            conda-package-directory: packaging/torchvision
-          - repository: pytorch/text
-            pre-script: ""
-            post-script: ""
-            conda-package-directory: packaging/torchtext
+          # - repository: pytorch/vision
+          #   pre-script: ""
+          #   post-script: ""
+          #   conda-package-directory: packaging/torchvision
+          # - repository: pytorch/text
+          #   pre-script: ""
+          #   post-script: ""
+          #   conda-package-directory: packaging/torchtext
     name: ${{ matrix.repository }}
     uses: ./.github/workflows/build_conda_linux.yml
     with:


### PR DESCRIPTION
Upload the binaries to anaconda post-build. I'll make a similar PR for uploading wheels and another for conda uploads for macos once https://github.com/pytorch/test-infra/pull/685 is merged (waiting since that PR changes the workflow name and uses for both x86 and arm mac builds).