### PR TITLE
Print live output to stdout/stderr when using conda run

### DIFF
--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -63,7 +63,7 @@ runs:
             pkg-config=0.29 \
             wheel=0.37
           echo "CONDA_ENV=${CONDA_ENV}" >> "${GITHUB_ENV}"
-          echo "CONDA_RUN=conda run -p ${CONDA_ENV}" >> "${GITHUB_ENV}"
+          echo "CONDA_RUN=conda run -p ${CONDA_ENV} --no-capture-output" >> "${GITHUB_ENV}"
           echo "CONDA_BUILD=conda run -p ${CONDA_ENV} conda-build" >> "${GITHUB_ENV}"
           echo "CONDA_INSTALL=conda install -p ${CONDA_ENV}" >> "${GITHUB_ENV}"
 


### PR DESCRIPTION
When using CONDA_RUN to execute MacOS test, I learn that conda will capture the subprocess output to stdout/stderr and print everything at the end. This has 2 drawbacks:

* The minor drawback is that I need to wait until the end of the command to see the test output.  This comes as a surprise to me because I expect to see the output right away. There should be no different between `conda run python test_mps.py` and `python test_mps.py`
* Another problem is that the command could hang sometimes, i.e. [4868437777](https://github.com/pytorch/pytorch/actions/runs/3025570812/jobs/4868437777).  In this example, nothing is printed out which makes debugging very tricky. This is just an example and not related to this PR.

The simple fix is to not capture stdout/stderr when using CONDA_RUN so that all the output will be printed out right away normally.  This can be done by adding `--no-capture-output` flag.