### PR TITLE
Fix HUD failures page

### DIFF
--- a/torchci/rockset/commons/failure_samples_query.lambda.json
+++ b/torchci/rockset/commons/failure_samples_query.lambda.json
@@ -2,9 +2,19 @@
   "sql_path": "__sql/failure_samples_query.sql",
   "default_parameters": [
     {
+      "name": "branch",
+      "type": "string",
+      "value": "%"
+    },
+    {
       "name": "captures",
       "type": "string",
-      "value": "test_random_seed, TestDataLoaderUtils"
+      "value": "timeout "
+    },
+    {
+      "name": "repo",
+      "type": "string",
+      "value": "pytorch/pytorch"
     }
   ],
   "description": ""

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -7,7 +7,7 @@
     "test_time_per_file": "50cb3694334ed63a",
     "test_time_per_file_periodic_jobs": "39c105542e297c09",
     "issue_query": "f29a1afe94563601",
-    "failure_samples_query": "7be8da412210d424",
+    "failure_samples_query": "ab2b589414b966a8",
     "recent_pr_workflows_query": "4e03cb13e8372050",
     "reverted_prs_with_reason": "f35155a95a233476",
     "unclassified": "1b31a2d8f4ab7230"


### PR DESCRIPTION
The HUD failures page is currently broken since it got synced to a bad version of the query which accidentally left out a table (it keeps loading forever while rockset returns 500s)

This PR:
1. Fixes the query to add that table back in
2. Lets the failure page to show tests that only match part of the requested error text (e.g. "timeout")