### PR TITLE
Enabling adding custom tags for repos beyond pytorch/pytorch

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -124,10 +124,10 @@ const repoSpecificAutoLabels: {[repo: string]: [RegExp, string][]}  = {
 function getRepoSpecificLabels(owner: string, repo: string): [RegExp, string][] {
   var repoKey = owner + "/" + repo;
   if (!repoSpecificAutoLabels.hasOwnProperty(repoKey)) {
-    return []
+    return [];
   }
 
-  return repoSpecificAutoLabels[repoKey]
+  return repoSpecificAutoLabels[repoKey];
 }
 
 function myBot(app: Probot): void {
@@ -322,13 +322,13 @@ function myBot(app: Probot): void {
     }
 
     // Add a repo specific labels (if any)
-    var repoSpecificLables = getRepoSpecificLabels(owner, repo)
+    var repoSpecificLabels = getRepoSpecificLabels(owner, repo);
 
     for (const file of filesChanged) {
       // check for typical matches
-      for (const [regex, label] of repoSpecificLables) {
+      for (const [regex, label] of repoSpecificLabels) {
         if (file.match(regex)) {
-          labelsToAdd.push(label)
+          labelsToAdd.push(label);
         }
       }
     }

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -317,6 +317,37 @@ describe("auto-label-bot", () => {
     scope.done();
   });
 
+  test("custom repo labels get add when on a matching repo and file", async () => {
+
+    nock("https://api.github.com")
+      .post("/app/installations/2/access_tokens")
+      .reply(200, { token: "test" });
+
+    const payload = requireDeepCopy("./fixtures/pull_request.opened")["payload"];
+    payload["pull_request"]["title"] = "modify a pytorch/tau file";
+    payload["pull_request"]["labels"] = [];
+    payload["repository"]["owner"]["login"] = "pytorch";
+    payload["repository"]["name"] = "fake-test-repo";
+    const prFiles = requireDeepCopy("./fixtures/pull_files");
+    prFiles["items"] = [{"filename": "somefolder/a.py"}, {"filename": "otherfolder/b.py"}]
+
+    const scope = nock("https://api.github.com")
+      .get("/repos/pytorch/fake-test-repo/pulls/31/files?per_page=100")
+      .reply(200, prFiles, {
+        Link: "<https://api.github.com/repos/pytorch/fake-test-repo/pulls/31/files?per_page=100&page=1>; rel='last'",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+      })
+      .post("/repos/pytorch/fake-test-repo/issues/31/labels", (body) => {
+        expect(body).toMatchObject({ labels: ["cool-label"] });
+        return true;
+      })
+      .reply(200);
+
+    await probot.receive({ name: "pull_request", payload: payload, id: "2" });
+
+    scope.done();
+  });
+
   test("caffe2 files trigger caffe2 label", async () => {
     nock("https://api.github.com")
       .post("/app/installations/2/access_tokens")

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -329,7 +329,7 @@ describe("auto-label-bot", () => {
     payload["repository"]["owner"]["login"] = "pytorch";
     payload["repository"]["name"] = "fake-test-repo";
     const prFiles = requireDeepCopy("./fixtures/pull_files");
-    prFiles["items"] = [{"filename": "somefolder/a.py"}, {"filename": "otherfolder/b.py"}]
+    prFiles["items"] = [{"filename": "somefolder/a.py"}, {"filename": "otherfolder/b.py"}];
 
     const scope = nock("https://api.github.com")
       .get("/repos/pytorch/fake-test-repo/pulls/31/files?per_page=100")

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -324,7 +324,7 @@ describe("auto-label-bot", () => {
       .reply(200, { token: "test" });
 
     const payload = requireDeepCopy("./fixtures/pull_request.opened")["payload"];
-    payload["pull_request"]["title"] = "modify a pytorch/tau file";
+    payload["pull_request"]["title"] = "modify a pytorch/fake-test-repo file";
     payload["pull_request"]["labels"] = [];
     payload["repository"]["owner"]["login"] = "pytorch";
     payload["repository"]["name"] = "fake-test-repo";


### PR DESCRIPTION
This will enable repos such as pytorch/tau to also have their PRs autolabled.

Current support is pretty rudimentary: All labels corresponding to a file path modified in that PR will be added to the PR

We can evolve this implementation as we get requests from other repos