### PR TITLE
Prevent bot from auto clearing nightly alerts

### DIFF
--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -312,7 +312,7 @@ def main():
     if len(jobs_to_alert_on) == 0 :
         print("Didn't find anything to alert on.")
 
-        if master_is_green(sha_grid):
+        if trunk_is_green(sha_grid):
             clear_alerts(existing_alerts)
             existing_alerts = [] # all alerts have now been cleared
 

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -268,7 +268,7 @@ def clear_alerts(alerts: List[Any]) -> bool:
 
 # We need to clear alerts is there is a commit that's all green is before a commit that has a red
 # If there's pending things after the all green commit, that's fine, as long as it's all green/pending
-def should_clear_alerts(sha_grid: Any):
+def master_is_green(sha_grid: Any):
     categorized_shas = categorize_shas(sha_grid)
     first_green_sha_ind = find_first_sha(categorized_shas, SUCCESS)
     first_red_sha_ind = find_first_sha(categorized_shas, FAILURE)
@@ -309,16 +309,13 @@ def main():
     existing_alerts = fetch_alerts()
 
     # Alerts should also be cleared if the current status of HUD is green
-    if len(jobs_to_alert_on) == 0 and should_clear_alerts(sha_grid):
-        if clear_alerts(existing_alerts):
+    if len(jobs_to_alert_on) == 0 :
+        print("Didn't find anything to alert on.")
+
+        if master_is_green(sha_grid):
+            clear_alerts(existing_alerts)
             existing_alerts = [] # all alerts have now been cleared
 
-    if len(jobs_to_alert_on) == 0:
-        print(
-            "Didn't find anything to alert on.",
-            no_alert_currently_active,
-            jobs_to_alert_on,
-        )
         return
 
     # Find the existing alert for recurrently failing jobs (if any).
@@ -330,7 +327,6 @@ def main():
             break
 
     # Create a new alert if no alerts active or edit the original one if there's a new update
-    no_alert_currently_active = len(existing_alerts) == 0
     if existing_recurrent_job_failure_alert:
         new_issue = generate_failed_job_issue(jobs_to_alert_on)
         if existing_recurrent_job_failure_alert["body"] != new_issue["body"]:

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -268,7 +268,7 @@ def clear_alerts(alerts: List[Any]) -> bool:
 
 # We need to clear alerts is there is a commit that's all green is before a commit that has a red
 # If there's pending things after the all green commit, that's fine, as long as it's all green/pending
-def master_is_green(sha_grid: Any):
+def trunk_is_green(sha_grid: Any):
     categorized_shas = categorize_shas(sha_grid)
     first_green_sha_ind = find_first_sha(categorized_shas, SUCCESS)
     first_red_sha_ind = find_first_sha(categorized_shas, FAILURE)


### PR DESCRIPTION
## The problem
If a nightly workflow fails two nights in a row, the alert bot sees that the workflow has been consistently failing and decides to alert on it. The next iteration, since the nightly workflow hasn't been retriggered yet, the bot continues to update the alert. 
 Or it would have, but the bot also sees that the _current head_ is green, so it first clears all alerts (including the one for the nightly workflow), before it files a brand new alert, resulting in duplicate tickets being filed and the oncall getting re-paged 

Examples:
https://github.com/pytorch/test-infra/issues/726
https://github.com/pytorch/test-infra/issues/727
https://github.com/pytorch/test-infra/issues/728
https://github.com/pytorch/test-infra/issues/729
https://github.com/pytorch/test-infra/issues/730
https://github.com/pytorch/test-infra/issues/731

## The fix

Only clear the existing alerts if we know that there are no new alerts that we want to trigger. Otherwise, prioritize updating the existing alerts.

This PR also removes the hard constraint that there should never be more than one alert existing at any point in time.  Even though right now we only expect to have a single alert firing at any point, if we extend the alerter that assumption may no longer hold true and we shouldn't have alerts being auto-magically cleared.  If extra alerts ever end up being filed then the oncall can triage the problem at that point

## Testing

```
(base) zainr@zainr-mbp torchci % python scripts/check_alerts.py
Generating alerts for:  [jobName: docker-release-builds / docker-release-build]
No new updates. Not updating any alerts.
```