### PR TITLE
Fix doc push job names

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -622,7 +622,7 @@ export default function Page() {
                   name: "jobNames",
                   type: "string",
                   value:
-                    "docs push / build-docs (python, 30),docs push / build-docs (cpp, 180)",
+                    "docs push / build-docs (python, 30);docs push / build-docs (cpp, 180)",
                 },
               ]}
               badThreshold={(value) => value > 3 * 24 * 60 * 60} // 3 day

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -622,7 +622,7 @@ export default function Page() {
                   name: "jobNames",
                   type: "string",
                   value:
-                    "docs push / build-docs (python),docs push / build-docs (cpp)",
+                    "docs push / build-docs (python, 30),docs push / build-docs (cpp, 180)",
                 },
               ]}
               badThreshold={(value) => value > 3 * 24 * 60 * 60} // 3 day

--- a/torchci/rockset/metrics/__sql/last_successful_jobs.sql
+++ b/torchci/rockset/metrics/__sql/last_successful_jobs.sql
@@ -14,7 +14,7 @@ with successful_jobs as (
         workflow.repository.full_name = 'pytorch/pytorch'
         AND workflow.head_branch IN ('master', 'main')
         AND job.conclusion = 'success'
-        AND ARRAY_CONTAINS(SPLIT(:jobNames, ','), job.name)
+        AND ARRAY_CONTAINS(SPLIT(:jobNames, ';'), job.name)
     order by
         job._event_time desc
 ),
@@ -33,7 +33,7 @@ select
 from
     successful_commits
 where
-    distinct_names >= LENGTH(SPLIT(:jobNames, ','))
+    distinct_names >= LENGTH(SPLIT(:jobNames, ';'))
 order by
     seconds_ago
 limit

--- a/torchci/rockset/metrics/last_successful_jobs.lambda.json
+++ b/torchci/rockset/metrics/last_successful_jobs.lambda.json
@@ -4,8 +4,8 @@
     {
       "name": "jobNames",
       "type": "string",
-      "value": "docs push / build-docs (python),docs push / build-docs (cpp)"
+      "value": "docs push / build-docs (python, 30);docs push / build-docs (cpp, 180)"
     }
   ],
-  "description": "given a comma-separated list of jobs, return the number of seconds since master built all the jobs successfully"
+  "description": "given a semicolon-separated list of jobs, return the number of seconds since master built all the jobs successfully"
 }

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -25,7 +25,7 @@
     "job_duration_avg": "10a88ea2ebb80647",
     "job_duration_percentile": "96507ed62db7a3a8",
     "last_branch_push": "3d995ac2143586dc",
-    "last_successful_jobs": "fd8bc3a2afc989a2",
+    "last_successful_jobs": "814fb497003c9625",
     "last_successful_workflow": "5d22927dd0b0956b",
     "master_commit_red_avg": "70391ac17f1c45bd",
     "master_commit_red": "e4e5cb062864bf1f",


### PR DESCRIPTION
The doc push job names now include another dimension after https://github.com/pytorch/pytorch/pull/83957, so [HUD](https://hud.pytorch.org/metrics) wrongly reports that docs haven't been updated since a 23+ days.  Also switch to a semicolon-separate list of job names because comma can be part of the GHA job name

### Testing

yarn dev

![Screen Shot 2022-09-16 at 13 35 28](https://user-images.githubusercontent.com/475357/190728814-41a0d66a-dc77-4006-ad15-b95121a9a7dc.png)



