### PR TITLE
Add note about circleci requirement (or lack-thereof) for `torchci`

### DIFF
--- a/torchci/docs/architecture.md
+++ b/torchci/docs/architecture.md
@@ -83,7 +83,7 @@ To get the basic HUD working, you will need to:
 1. Install the PyTorch Bot app to the repo. This requires admin access to the
    `pytorch` org. To find someone with admin access, consult the [Build/CI POCs].
 2. Configure CircleCI to send webhooks to `torchci` (see above). This requires
-   admin access to CircleCI.
+   admin access to CircleCI. (**NOTE**: Only required if running CircleCI workflows)
 
 You won't get any of the other goodies listed in "Secondary with paths" above,
 but other than that, things should work!


### PR DESCRIPTION
circleci isn't present on some repositories so we shouldn't make it a requirement for adding a new repository to torchci