### PR TITLE
List when individual workflows were started

### DIFF
--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -1,4 +1,4 @@
-import { durationHuman } from "./TimeUtils";
+import { durationHuman, LocalTimeHuman } from "./TimeUtils";
 import useSWR from "swr";
 import React from "react";
 import { IssueData, JobData } from "../lib/types";
@@ -17,6 +17,11 @@ export default function JobLinks({ job }: { job: JobData }) {
   const durationS =
     job.durationS != null ? (
       <span>{` | Duration: ${durationHuman(job.durationS!)}`}</span>
+    ) : null;
+
+  const eventTime =
+    job.time != null ? (
+      <span>{` | Started: `}<LocalTimeHuman timestamp={job.time} /></span>
     ) : null;
 
   const failureCaptures =
@@ -38,6 +43,7 @@ export default function JobLinks({ job }: { job: JobData }) {
       {rawLogs}
       {failureCaptures}
       {durationS}
+      {eventTime}
       <DisableIssue job={job} />
     </span>
   );

--- a/torchci/rockset/commons/__sql/commit_jobs_query.sql
+++ b/torchci/rockset/commons/__sql/commit_jobs_query.sql
@@ -93,6 +93,7 @@ SELECT
     line as failureLine,
     line_num as failureLineNumber,
     captures as failureCaptures,
+    time,
 from
     job
 ORDER BY

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -1,7 +1,7 @@
 {
   "commons": {
     "hud_query": "f5ebefcdd53b6ff5",
-    "commit_jobs_query": "935a7b9f251dc4aa",
+    "commit_jobs_query": "6201b6a715f84a44",
     "flaky_tests": "59d7546183743626",
     "slow_tests": "ef8d035d23aa8ab6",
     "test_time_per_file": "50cb3694334ed63a",


### PR DESCRIPTION
Adding this timestamp is useful when looking at the historical failures view ([like this one](hud.pytorch.org/failure/test_compute_bucket_assignment_by_size_sparse_error_with_logger)) to know just how old the similar looking test examples are

Next to the duration, the failure results now also tell you when a given workflow was started.

```
linux-bionic-cuda11.6-py3.10-gcc7 / test (distributed, 1, 3, linux.8xlarge.nvidia.gpu)
Raw logs | more like this | Duration: 47m 6s | Started: Wed, Sep 14 | 
```

Screenshots:

Old
<img width="1084" alt="image" src="https://user-images.githubusercontent.com/4468967/190812069-a72ba75e-1f05-44bd-bff1-dcd9989c7ad4.png">

New
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/4468967/190811932-0990b301-edee-44d0-a6e5-7c9ca0612c63.png">

While this does also affect the commit view, it's added to a spot of low enough prominence to not interfere with existing flows
