### PR TITLE
[Nova] Every test workflow should use a consistent build script

### DIFF
--- a/.github/workflows/test_build_conda_m1.yml
+++ b/.github/workflows/test_build_conda_m1.yml
@@ -24,8 +24,8 @@ jobs:
       matrix:
         include:
           - repository: pytorch/audio
-            pre-script: packaging/pre_build_script_conda.sh
-            post-script: packaging/post_build_script_conda.sh
+            pre-script: packaging/pre_build_script_wheel.sh
+            post-script: packaging/post_build_script_wheel.sh
             conda-package-directory: packaging/torchaudio
           - repository: pytorch/vision
             pre-script: ""

--- a/.github/workflows/test_build_conda_macos.yml
+++ b/.github/workflows/test_build_conda_macos.yml
@@ -22,8 +22,8 @@ jobs:
       matrix:
         include:
           - repository: pytorch/audio
-            pre-script: packaging/pre_build_script_conda.sh
-            post-script: packaging/post_build_script_conda.sh
+            pre-script: packaging/pre_build_script_wheel.sh
+            post-script: packaging/post_build_script_wheel.sh
             conda-package-directory: packaging/torchaudio
           - repository: pytorch/vision
             pre-script: ""


### PR DESCRIPTION
If this keeps all the builds green, I'm going to merge this, make a PR in audio that renames the scripts to just `pre/post_build_script`, and make a PR here that uses those new names. The conda builds script effectively does the same thing as the wheels script apart from exporting a number of environment variables that don't propagate to this action anyways.