### PR TITLE
[Nova] Update scripts names in test workflows after audio update

### DIFF
--- a/.github/workflows/test_build_conda_linux.yml
+++ b/.github/workflows/test_build_conda_linux.yml
@@ -24,8 +24,8 @@ jobs:
       matrix:
         include:
           - repository: pytorch/audio
-            pre-script: packaging/pre_build_script_wheel.sh
-            post-script: packaging/post_build_script_wheel.sh
+            pre-script: packaging/pre_build_script.sh
+            post-script: packaging/post_build_script.sh
             conda-package-directory: packaging/torchaudio
           - repository: pytorch/vision
             pre-script: ""

--- a/.github/workflows/test_build_conda_m1.yml
+++ b/.github/workflows/test_build_conda_m1.yml
@@ -24,8 +24,8 @@ jobs:
       matrix:
         include:
           - repository: pytorch/audio
-            pre-script: packaging/pre_build_script_wheel.sh
-            post-script: packaging/post_build_script_wheel.sh
+            pre-script: packaging/pre_build_script.sh
+            post-script: packaging/post_build_script.sh
             conda-package-directory: packaging/torchaudio
           - repository: pytorch/vision
             pre-script: ""

--- a/.github/workflows/test_build_conda_macos.yml
+++ b/.github/workflows/test_build_conda_macos.yml
@@ -22,8 +22,8 @@ jobs:
       matrix:
         include:
           - repository: pytorch/audio
-            pre-script: packaging/pre_build_script_wheel.sh
-            post-script: packaging/post_build_script_wheel.sh
+            pre-script: packaging/pre_build_script.sh
+            post-script: packaging/post_build_script.sh
             conda-package-directory: packaging/torchaudio
           - repository: pytorch/vision
             pre-script: ""

--- a/.github/workflows/test_build_wheels_linux.yml
+++ b/.github/workflows/test_build_wheels_linux.yml
@@ -24,8 +24,8 @@ jobs:
       matrix:
         include:
           - repository: pytorch/audio
-            pre-script: packaging/pre_build_script_wheel.sh
-            post-script: packaging/post_build_script_wheel.sh
+            pre-script: packaging/pre_build_script.sh
+            post-script: packaging/post_build_script.sh
           - repository: pytorch/vision
             pre-script: ""
             post-script: ""

--- a/.github/workflows/test_build_wheels_m1.yml
+++ b/.github/workflows/test_build_wheels_m1.yml
@@ -24,8 +24,8 @@ jobs:
       matrix:
         include:
           - repository: pytorch/audio
-            pre-script: packaging/pre_build_script_wheel.sh
-            post-script: packaging/post_build_script_wheel.sh
+            pre-script: packaging/pre_build_script.sh
+            post-script: packaging/post_build_script.sh
           - repository: pytorch/vision
             pre-script: ""
             post-script: ""

--- a/.github/workflows/test_build_wheels_macos.yml
+++ b/.github/workflows/test_build_wheels_macos.yml
@@ -24,8 +24,8 @@ jobs:
       matrix:
         include:
           - repository: pytorch/audio
-            pre-script: packaging/pre_build_script_wheel.sh
-            post-script: packaging/post_build_script_wheel.sh
+            pre-script: packaging/pre_build_script.sh
+            post-script: packaging/post_build_script.sh
           - repository: pytorch/vision
             pre-script: ""
             post-script: ""

--- a/.github/workflows/test_build_wheels_windows.yml
+++ b/.github/workflows/test_build_wheels_windows.yml
@@ -23,8 +23,8 @@ jobs:
       matrix:
         include:
           # - repository: pytorch/audio
-          #   pre-script: packaging/pre_build_script_wheel.sh
-          #   post-script: packaging/post_build_script_wheel.sh
+          #   pre-script: packaging/pre_build_script.sh
+          #   post-script: packaging/post_build_script.sh
           - repository: pytorch/vision
             pre-script: ""
             post-script: ""


### PR DESCRIPTION
This is going to break all the builds until https://github.com/pytorch/audio/pull/2695 is merged. Just putting this up so we can test afterwards.