### PR TITLE
increasing max runners to 25 for linux.g4dn.12xlarge.nvidia.gpu

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -67,7 +67,7 @@ runner_types:
     disk_size: 150
     instance_type: g4dn.12xlarge
     is_ephemeral: false
-    max_available: 10
+    max_available: 25
     os: linux
   linux.p3.8xlarge.nvidia.gpu:
     instance_type: p3.8xlarge


### PR DESCRIPTION
Yesterday jobs where throttled due to hitting the max runners allowed for `linux.g4dn.12xlarge.nvidia.gpu`. As the peak seems to be legitimate, a increase in the max number of runners is required.

![Screenshot 2022-09-20 at 17 25 07](https://user-images.githubusercontent.com/4520845/191299917-43b7f030-dcd4-40b9-bd1c-d75ab4923d2d.png)
