### PR TITLE
Rebase onto viable/strict by default

### DIFF
--- a/torchci/lib/bot/cliParser.ts
+++ b/torchci/lib/bot/cliParser.ts
@@ -89,7 +89,7 @@ revert.add_argument("-c", "--classification", {
 const rebase = commands.add_parser("rebase", {
   help: "Rebase a PR",
   description:
-    "Rebase a PR. Rebasing defaults to the default branch of pytorch (master).\n" +
+    "Rebase a PR. Rebasing defaults to the stable viable/strict branch of pytorch.\n" +
     "You, along with any member of the pytorch organization, can rebase your PR.",
   formatter_class: RawTextHelpFormatter,
   add_help: false,
@@ -98,6 +98,10 @@ const branch_selection = rebase.add_mutually_exclusive_group();
 branch_selection.add_argument("-s", "--stable", {
   action: "store_true",
   help: "Rebase to viable/strict",
+});
+branch_selection.add_argument("-m", "--master", {
+  action: "store_true",
+  help: "Rebase to master (trunk)",
 });
 branch_selection.add_argument("-b", "--branch", {
   help: "Branch you would like to rebase to",

--- a/torchci/lib/bot/cliParser.ts
+++ b/torchci/lib/bot/cliParser.ts
@@ -97,11 +97,7 @@ const rebase = commands.add_parser("rebase", {
 const branch_selection = rebase.add_mutually_exclusive_group();
 branch_selection.add_argument("-s", "--stable", {
   action: "store_true",
-  help: "Rebase to viable/strict",
-});
-branch_selection.add_argument("-m", "--master", {
-  action: "store_true",
-  help: "Rebase to master (trunk)",
+  help: "[DEPRECATED] Rebase onto viable/strict",
 });
 branch_selection.add_argument("-b", "--branch", {
   help: "Branch you would like to rebase to",

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -317,8 +317,10 @@ The explanation needs to be clear on why this is needed. Here are some good exam
           args.rebase
         );
       case "rebase": {
-        if (args.stable) {
+        if (!args.branch) {
           args.branch = "viable/strict";
+        } else if (args.master) {
+          args.branch = "master";
         }
         return await this.handleRebase(args.branch);
       }

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -319,7 +319,8 @@ The explanation needs to be clear on why this is needed. Here are some good exam
       case "rebase": {
         if (!args.branch) {
           args.branch = "viable/strict";
-        } else if (args.master) {
+        }
+        if (args.master) {
           args.branch = "master";
         }
         return await this.handleRebase(args.branch);

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -320,9 +320,6 @@ The explanation needs to be clear on why this is needed. Here are some good exam
         if (!args.branch) {
           args.branch = "viable/strict";
         }
-        if (args.master) {
-          args.branch = "master";
-        }
         return await this.handleRebase(args.branch);
       }
       case "label": {


### PR DESCRIPTION
Currently merbot rebases PRs onto the master branch by default, which is not ideal since that branch can have broken tests.

This PR changes mergebot behavior to default to the viable/strict branch instead.

It adds a new parameter to mergebot "-m" for those who really want to rebase onto the latest master branch.  The old -s parameter is sticking around for backwards compat, but it's effectively a no-op now.

# Rollout plan

Announce the change on PyTorch Dev Discussions (I'm going to wait for the current sevs to be over before submitting/announcing this change)