### PR TITLE
use a different token for getOctokit

### DIFF
--- a/torchci/lib/github.ts
+++ b/torchci/lib/github.ts
@@ -1,5 +1,4 @@
-import { Octokit, App } from "octokit";
-import { createAppAuth } from "@octokit/auth-app";
+import { Octokit } from "octokit";
 import { CommitData } from "./types";
 
 // Retrieve an Octokit instance authenticated as PyTorchBot's installation on
@@ -8,25 +7,11 @@ export async function getOctokit(
   owner: string,
   repo: string
 ): Promise<Octokit> {
-  let privateKey = process.env.PRIVATE_KEY as string;
+  let privateKey = process.env.PYTORCH_HUD_TOKEN as string;
   privateKey = Buffer.from(privateKey, "base64").toString();
 
-  const app = new App({
-    appId: process.env.APP_ID!,
-    privateKey,
-  });
-  const installation = await app.octokit.request(
-    "GET /repos/{owner}/{repo}/installation",
-    { owner, repo }
-  );
-
   return new Octokit({
-    authStrategy: createAppAuth,
-    auth: {
-      appId: process.env.APP_ID,
-      privateKey,
-      installationId: installation.data.id,
-    },
+    auth: privateKey
   });
 }
 

--- a/torchci/scripts/backfillJobs.mjs
+++ b/torchci/scripts/backfillJobs.mjs
@@ -4,8 +4,7 @@
 
 import { DynamoDB } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
-import { Octokit, App } from "octokit";
-import { createAppAuth } from "@octokit/auth-app";
+import { Octokit } from "octokit";
 import rockset from "@rockset/client";
 
 function getDynamoClient() {
@@ -21,25 +20,11 @@ function getDynamoClient() {
 }
 
 async function getOctokit(owner, repo) {
-  let privateKey = process.env.PRIVATE_KEY;
+  let privateKey = process.env.PYTORCH_HUD_TOKEN;
   privateKey = Buffer.from(privateKey, "base64").toString();
 
-  const app = new App({
-    appId: process.env.APP_ID,
-    privateKey,
-  });
-  const installation = await app.octokit.request(
-    "GET /repos/{owner}/{repo}/installation",
-    { owner, repo }
-  );
-
   return new Octokit({
-    authStrategy: createAppAuth,
-    auth: {
-      appId: process.env.APP_ID,
-      privateKey,
-      installationId: installation.data.id,
-    },
+    auth: privateKey
   });
 }
 


### PR DESCRIPTION
created a new account called pytorch-hud

as in title, so that we dont use probot's rate when
* querying for hud (pr, commit, hud main page, flaky-tests)
* retrieving comments and commenting for dr ci
* querying when backfilling jobs


token has already been added to vercel and secrets in test-infra