### PR TITLE
Adds a deployment workflow for runners lambda

### DIFF
--- a/.github/workflows/lambda-release-runners.yml
+++ b/.github/workflows/lambda-release-runners.yml
@@ -19,6 +19,7 @@ jobs:
         run: yarn dist
       - name: Create Release
         uses: actions/create-release@v1
+        id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/lambda-release-runners.yml
+++ b/.github/workflows/lambda-release-runners.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Build distribution
         run: yarn dist
       - name: Create Release
-        id: create-release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -28,7 +27,6 @@ jobs:
           draft: false
           prerelease: false
       - name: Upload Release Asset
-        id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lambda-release-runners.yml
+++ b/.github/workflows/lambda-release-runners.yml
@@ -1,0 +1,39 @@
+on:
+  push:
+    tags:
+      - 'v*'
+
+name: Upload Release for runners lambdas
+
+jobs:
+  build:
+    name: Upload Release for runners lambdas
+    runs-on: ubuntu-latest
+    container: node:12
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: yarn install
+      - name: Build distribution
+        run: yarn dist
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Runner lambdas ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./terraform-aws-github-runner/modules/runners/lambdas/runners/runners.zip
+          asset_name: runners.zip
+          asset_content_type: application/zip

--- a/.github/workflows/lambda-release-tag-runners.yml
+++ b/.github/workflows/lambda-release-tag-runners.yml
@@ -17,7 +17,7 @@ jobs:
           wait-interval: 30
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y%m%d-%H%M')"
+        run: echo "::set-output name=date::$(date +'%Y%m%d-%H%M%S')"
       - name: Checkout branch "master"
         uses: actions/checkout@v2
       - name: Tag snapshot

--- a/.github/workflows/lambda-release-tag-runners.yml
+++ b/.github/workflows/lambda-release-tag-runners.yml
@@ -1,0 +1,27 @@
+name: Create Release Tag
+
+jobs:
+  tag:
+    name: Create Release Tag
+    runs-on: ubuntu-latest
+    container: node:12
+    steps:
+      - name: Wait for tests to succeed
+        uses: lewagon/wait-on-check-action@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          ref: ${{ github.ref }}
+          check-name: "Run tests for runners lambda"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y%m%d-%H%M')"
+      - name: Checkout branch "master"
+        uses: actions/checkout@v2
+      - name: Tag snapshot
+        uses: tvdias/github-tagger@v0.0.1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: v${{ steps.date.outputs.date }}

--- a/.github/workflows/lambda-release-tag-runners.yml
+++ b/.github/workflows/lambda-release-tag-runners.yml
@@ -6,6 +6,15 @@ jobs:
     runs-on: ubuntu-latest
     container: node:12
     steps:
+      - name: Wait for tflint to succeed
+        uses: lewagon/wait-on-check-action@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          ref: ${{ github.ref }}
+          check-name: TFLint
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
       - name: Wait for tests to succeed
         uses: lewagon/wait-on-check-action@v1.0.0
         env:
@@ -22,6 +31,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Tag snapshot
         uses: tvdias/github-tagger@v0.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           tag: v${{ steps.date.outputs.date }}

--- a/.github/workflows/lambda-runners.yml
+++ b/.github/workflows/lambda-runners.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    name: "Run tests for runners lambda"
     runs-on: ubuntu-latest
     container: node:12
     defaults:

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   tflint:
+    name: TFLint
     runs-on: ubuntu-latest
     container: node:12
 


### PR DESCRIPTION
Adds a workflow to tag versions in the format `v$DATE-$TIME` that only completes if tests are successful;
Adds a workflow that when a tag named `v.*` is created, it uploads a new release of lambda runners to the repo