### PR TITLE
[Nova] Change when the upload is triggered by passing from caller

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -35,6 +35,10 @@ on:
         description: "Name of the actual python package that is imported"
         default: ""
         type: string
+      build-type:
+        description: "Type of build: development, nightly, or release"
+        default: ""
+        type: string
 
 jobs:
   build:
@@ -118,7 +122,7 @@ jobs:
           ${CONDA_RUN} pip install "${{ inputs.repository }}/dist/$WHEEL_NAME" 
           ${CONDA_RUN} python3 -c "import ${PACKAGE_NAME}; print('package version is ', ${PACKAGE_NAME}.__version__)"
       - name: Upload package to pytorch.org
-        if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/')) }}
+        if: ${{ inputs.build-type == 'nightly' || inputs.build-type == 'release' }}
         working-directory: ${{ inputs.repository }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}

--- a/.github/workflows/test_build_conda_linux_without_cuda.yml
+++ b/.github/workflows/test_build_conda_linux_without_cuda.yml
@@ -39,3 +39,4 @@ jobs:
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
+      build-type: development

--- a/.github/workflows/test_build_wheels_linux_with_cuda.yml
+++ b/.github/workflows/test_build_wheels_linux_with_cuda.yml
@@ -42,3 +42,4 @@ jobs:
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}
+      build-type: development


### PR DESCRIPTION
Creates a new input for the reusable build workflow called build-type. This can take values: development, nightly, and release. Development is used from the test_build_* workflows for testing. Nightly and Release are used accordingly when build is trigged from the domain repos.