### PR TITLE
[mergebot] rebase and merge only viable/strict or master

### DIFF
--- a/torchci/lib/bot/cliParser.ts
+++ b/torchci/lib/bot/cliParser.ts
@@ -57,11 +57,12 @@ mergeOption.add_argument("-l", "--land-checks", {
     "reliability and decrease risk of revert. The tests added are: pull, Lint and trunk. Note " +
     "that periodic is excluded. (EXPERIMENTAL)",
 });
-mergeOption.add_argument("-r", "--rebase", {
-  help: "Rebase the PR to re run checks before merging.  It will accept a branch name and " +
-  "will default to master if not specified.",
+merge.add_argument("-r", "--rebase", {
+  help: "Rebase the PR to re run checks before merging.  Accepts viable/strict or master as branch options and " +
+  "will default to viable/strict if not specified.",
   nargs: "?",
-  const: true
+  const: "viable/strict",
+  choices: ["viable/strict", "master"],
 });
 
 // Revert

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -171,9 +171,6 @@ The explanation needs to be clear on why this is needed. Here are some good exam
         );
         rebase = false;
       }
-      if (rebase === true) {
-        rebase = "viable/strict";
-      }
       await this.logger.log("merge", extra_data);
       await this.dispatchEvent("try-merge", {
         force: forceRequested,

--- a/torchci/test/mergeCommands.test.ts
+++ b/torchci/test/mergeCommands.test.ts
@@ -966,6 +966,7 @@ some other text lol
     const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = "@pytorchbot merge -r";
+
     const owner = event.payload.repository.owner.login;
     const repo = event.payload.repository.name;
     const pr_number = event.payload.issue.number;

--- a/torchci/test/mergeCommands.test.ts
+++ b/torchci/test/mergeCommands.test.ts
@@ -928,7 +928,7 @@ some other text lol
     handleScope(scope);
   });
 
-  test("merge rebase custom branch", async () => {
+  test("merge rebase master", async () => {
     const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = "@pytorchbot merge -r master";
@@ -966,7 +966,6 @@ some other text lol
     const event = requireDeepCopy("./fixtures/pull_request_comment.json");
 
     event.payload.comment.body = "@pytorchbot merge -r";
-
     const owner = event.payload.repository.owner.login;
     const repo = event.payload.repository.name;
     const pr_number = event.payload.issue.number;
@@ -994,6 +993,27 @@ some other text lol
       .post(`/repos/${owner}/${repo}/dispatches`, (body) => {
         expect(JSON.stringify(body)).toContain(
           `{"event_type":"try-merge","client_payload":{"pr_num":${pr_number},"comment_id":${comment_number}}}`
+        );
+        return true;
+      })
+      .reply(200, {});
+
+    await probot.receive(event);
+    handleScope(scope);
+  });
+
+  test("merge rebase invalid branch", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
+
+    event.payload.comment.body = "@pytorchbot merge -r something";
+
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    const pr_number = event.payload.issue.number;
+    const scope = nock("https://api.github.com")
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          "@pytorchbot merge: error: argument -r/--rebase: invalid choice: 'something' (choose from 'viable/strict', 'master')"
         );
         return true;
       })


### PR DESCRIPTION
restrict rebase and merge to only viable/strict and master to prevent rebasing onto <other branch> and merging <other branch>'s unapproved changes

