### PR TITLE
[NOVA] Use Conda Env when pip installing awscli

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -132,6 +132,10 @@ jobs:
         run: |
           source "${BUILD_ENV_FILE}"
           ${CONDA_RUN} pip install awscli
+          set +x
+          export AWS_ACCESS_KEY_ID="${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}"
+          export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}"
+          set -x
           for pkg in dist/*; do
             ${CONDA_RUN} aws s3 cp "$pkg" "s3://pytorch/whl/${CHANNEL}/${{ matrix.desired_cuda }}" --acl public-read
           done

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -132,10 +132,6 @@ jobs:
         run: |
           source "${BUILD_ENV_FILE}"
           ${CONDA_RUN} pip install awscli
-          set +x
-          export AWS_ACCESS_KEY_ID="${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}"
-          export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}"
-          set -x
           for pkg in dist/*; do
             ${CONDA_RUN} aws s3 cp "$pkg" "s3://pytorch/whl/${CHANNEL}/${{ matrix.desired_cuda }}" --acl public-read
           done

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -131,7 +131,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}
         run: |
           source "${BUILD_ENV_FILE}"
-          ${CONDA_RUN} pip install --user awscli
+          ${CONDA_RUN} pip install awscli
           for pkg in dist/*; do
             ${CONDA_RUN} aws s3 cp "$pkg" "s3://pytorch/whl/${CHANNEL}/${{ matrix.desired_cuda }}" --acl public-read
           done

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -113,6 +113,7 @@ jobs:
             ${CONDA_RUN} bash "${POST_SCRIPT}"
           fi
       - name: Run Primitive Smoke Tests
+        shell: bash -l {0}
         env:
           PACKAGE_NAME: ${{ inputs.package-name }}
         run: |
@@ -123,6 +124,7 @@ jobs:
           ${CONDA_RUN} python3 -c "import ${PACKAGE_NAME}; print('package version is ', ${PACKAGE_NAME}.__version__)"
       - name: Upload package to pytorch.org
         if: ${{ inputs.build-type == 'nightly' || inputs.build-type == 'release' }}
+        shell: bash -l {0}
         working-directory: ${{ inputs.repository }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -128,9 +128,10 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}
         run: |
-          pip install --user awscli
+          source "${BUILD_ENV_FILE}"
+          ${CONDA_RUN} pip install --user awscli
           for pkg in dist/*; do
-            aws s3 cp "$pkg" "s3://pytorch/whl/${CHANNEL}/${{ matrix.desired_cuda }}" --acl public-read
+            ${CONDA_RUN} aws s3 cp "$pkg" "s3://pytorch/whl/${CHANNEL}/${{ matrix.desired_cuda }}" --acl public-read
           done
 
 concurrency:


### PR DESCRIPTION
If the conda env is not used, the upload step will fail with `pip not found`.