### PR TITLE
Extend pkg helper for mac os

### DIFF
--- a/tools/pkg-helpers/pytorch_pkg_helpers/__main__.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/__main__.py
@@ -65,6 +65,12 @@ def parse_args() -> argparse.Namespace:
         # BUILD_VERSION for legacy scripts
         default=os.getenv("BUILD_VERSION", os.getenv("BASE_BUILD_VERSION", "")),
     )
+    parser.add_argument(
+        "--arch-name",
+        type=str,
+        help="Architecture name of the machine (uname -m)",
+        default=default=os.getenv("ARCH_NAME", ""),
+    )
     options = parser.parse_args()
     return options
 
@@ -100,8 +106,10 @@ def main():
                 channel=options.channel,
             )
         )
+
     if options.platform == "darwin":
-        variables.extend(get_macos_variables())
+        variables.extend(get_macos_variables(options.arch_name))
+
     variables.extend(
         get_cuda_variables(
             options.package_type, options.platform, options.gpu_arch_version

--- a/tools/pkg-helpers/pytorch_pkg_helpers/macos.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/macos.py
@@ -1,6 +1,11 @@
-def get_macos_variables():
-    return [
+def get_macos_variables(arch_name: str) -> list:
+    variables = [
         "export MACOSX_DEPLOYMENT_TARGET=10.9",
         "export CC=clang",
         "export CXX=clang++",
     ]
+
+    if arch_name != "arm64":
+        variables.append("export CONDA_EXTRA_BUILD_CONSTRAINT='- mkl<=2021.2.0'")
+
+    return variables

--- a/tools/pkg-helpers/tests/test_macos.py
+++ b/tools/pkg-helpers/tests/test_macos.py
@@ -1,0 +1,23 @@
+import pytest
+
+from pytorch_pkg_helpers.macos import get_macos_variables
+
+
+@pytest.mark.parametrize(
+    "arch_name,expected",
+    [
+        (("arm64"), [
+            "export MACOSX_DEPLOYMENT_TARGET=10.9",
+            "export CC=clang",
+            "export CXX=clang++",
+        ]),
+        (("x86_64"), [
+            "export MACOSX_DEPLOYMENT_TARGET=10.9",
+            "export CC=clang",
+            "export CXX=clang++",
+            "export CONDA_EXTRA_BUILD_CONSTRAINT='- mkl<=2021.2.0'",
+        ])
+    ]
+)
+def test_get_macos_variables(arch_name, expected):
+    assert get_macos_variables(arch_name) == expected


### PR DESCRIPTION
Added constant `CONDA_EXTRA_BUILD_CONSTRAINT` to pkg helper for MacOS.