### PR TITLE
[revert tracker] fix regex 

### DIFF
--- a/.github/workflows/revert-tracker.yml
+++ b/.github/workflows/revert-tracker.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     # At 15:10 (8:10 AM PST) on Monday
     - cron: 10 15 * * 1
-  push:
+
 jobs:
   revert_printer:
     runs-on: ubuntu-20.04

--- a/.github/workflows/revert-tracker.yml
+++ b/.github/workflows/revert-tracker.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     # At 15:10 (8:10 AM PST) on Monday
     - cron: 10 15 * * 1
-
+  push:
 jobs:
   revert_printer:
     runs-on: ubuntu-20.04

--- a/torchci/rockset/commons/__sql/reverted_prs_with_reason.sql
+++ b/torchci/rockset/commons/__sql/reverted_prs_with_reason.sql
@@ -1,8 +1,8 @@
 SELECT 
     ic._event_time revert_time,
 	ic.user.login as reverter,
-    REGEXP_EXTRACT(ic.body, '-c[\s =]+"?(\w+)"?', 1) as code,
-    REGEXP_EXTRACT(ic.body, '-m[\s =]+["'']?([^"'']+)["'']?', 1) as message,
+    REGEXP_EXTRACT(ic.body, '(-c|--classification)[\s =]+"?(\w+)"?', 2) as code,
+    REGEXP_EXTRACT(ic.body, '(-m|--message)[\s =]+["'']?([^"'']+)["'']?', 2) as message,
     ic.html_url as comment_url
 FROM commons.issue_comment AS ic
 	INNER JOIN 

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -9,7 +9,7 @@
     "issue_query": "f29a1afe94563601",
     "failure_samples_query": "ab2b589414b966a8",
     "recent_pr_workflows_query": "4e03cb13e8372050",
-    "reverted_prs_with_reason": "f35155a95a233476",
+    "reverted_prs_with_reason": "bf2b0607bddcc552",
     "unclassified": "1b31a2d8f4ab7230"
   },
   "pytorch_dev_infra_kpis": {


### PR DESCRIPTION
make the regex for the revert tracker slightly broader
it was causing the workflow to fail https://github.com/pytorch/test-infra/actions/runs/3128929655/jobs/5077381984 

as a side note, im not a big fan of how we've gone back to regex for parsing 