### PR TITLE
[Nova] Secrets passed from caller workflow for uploading

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -39,6 +39,13 @@ on:
         description: "Type of build: development, nightly, or release"
         default: ""
         type: string
+    secrets:
+      AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID:
+        description: "AWS Access Key passed from caller workflow"
+        required: false
+      AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY:
+        description: "AWS Secret Access Ket passed from caller workflow"
+        required: false
 
 jobs:
   build:

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -35,8 +35,8 @@ on:
         description: "Name of the actual python package that is imported"
         default: ""
         type: string
-      build-type:
-        description: "Type of build: development, nightly, or release"
+      trigger-event:
+        description: "Trigger Event in caller that determines whether or not to upload"
         default: ""
         type: string
     secrets:
@@ -130,7 +130,7 @@ jobs:
           ${CONDA_RUN} pip install "${{ inputs.repository }}/dist/$WHEEL_NAME" 
           ${CONDA_RUN} python3 -c "import ${PACKAGE_NAME}; print('package version is ', ${PACKAGE_NAME}.__version__)"
       - name: Upload package to pytorch.org
-        if: ${{ inputs.build-type == 'nightly' || inputs.build-type == 'release' }}
+        if: ${{ inputs.trigger-event == 'push' }}
         shell: bash -l {0}
         working-directory: ${{ inputs.repository }}
         env:

--- a/.github/workflows/test_build_wheels_linux_with_cuda.yml
+++ b/.github/workflows/test_build_wheels_linux_with_cuda.yml
@@ -42,4 +42,4 @@ jobs:
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}
-      build-type: development
+      trigger-event: "${{ github.event_name }}"

--- a/.github/workflows/test_build_wheels_linux_without_cuda.yml
+++ b/.github/workflows/test_build_wheels_linux_without_cuda.yml
@@ -39,3 +39,4 @@ jobs:
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}
+      trigger-event: "${{ github.event_name }}"


### PR DESCRIPTION
In the current workflow, credentials cannot be found when doing `aws s3 cp`. Trying to pass the credentials from the caller workflow in audio to this reusable workflow here. 

Also simplify trigger on whether to upload or not based on the event_name.