### PR TITLE
Fixed typo

### DIFF
--- a/tools/pkg-helpers/pytorch_pkg_helpers/__main__.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/__main__.py
@@ -69,7 +69,7 @@ def parse_args() -> argparse.Namespace:
         "--arch-name",
         type=str,
         help="Architecture name of the machine (uname -m)",
-        default=default=os.getenv("ARCH_NAME", ""),
+        default=os.getenv("ARCH_NAME", ""),
     )
     options = parser.parse_args()
     return options


### PR DESCRIPTION
Fixed a typo in the parameters list for `pkg_helper`.