### PR TITLE
Add text to win wheels

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -106,7 +106,7 @@ jobs:
           source "${BUILD_ENV_FILE}"
           export FFMPEG_ROOT="${PWD}"/third_party/ffmpeg
           export USE_FFMPEG="1"
-          ${CONDA_RUN} python3 setup.py bdist_wheel
+          ${CONDA_RUN} python setup.py bdist_wheel
       - name: Upload wheel to GitHub
         uses: actions/upload-artifact@v3
         with:
@@ -134,14 +134,14 @@ jobs:
           source "${BUILD_ENV_FILE}"
           WHEEL_NAME=$(ls "${{ inputs.repository }}/dist/")
           echo "$WHEEL_NAME"
-          ${CONDA_RUN} pip install "${{ inputs.repository }}/dist/$WHEEL_NAME" 
+          ${CONDA_RUN} pip install "${{ inputs.repository }}/dist/$WHEEL_NAME"
           if [[ ! -f "${{ inputs.repository }}"/${SMOKE_TEST_SCRIPT} ]]; then
             echo "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT} not found"
-            ${CONDA_RUN} python3 -c "import ${PACKAGE_NAME}; print('package version is ', ${PACKAGE_NAME}.__version__)"
+            ${CONDA_RUN} python -c "import ${PACKAGE_NAME}; print('package version is ', ${PACKAGE_NAME}.__version__)"
           else
             echo "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT} found"
             export LD_LIBRARY_PATH="{LD_LIBRARY_PATH}:${{ inputs.repository }}/third_party/ffmpeg/lib"
-            ${CONDA_RUN} python3 "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT}"
+            ${CONDA_RUN} python "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT}"
           fi
       - name: Upload package to pytorch.org
         if: ${{ inputs.trigger-event == 'push' }}

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -27,8 +27,20 @@ on:
         description: "Pre script to run prior to build"
         default: ""
         type: string
+      env-script:
+        description: "Script to setup environment variables for the build"
+        default: ""
+        type: string
       post-script:
         description: "Post script to run prior to build"
+        default: ""
+        type: string
+      smoke-test-script:
+        description: "Script for Smoke Test for a specific domain"
+        default: ""
+        type: string
+      package-name:
+        description: "Name of the actual python package that is imported"
         default: ""
         type: string
       runner-type:
@@ -91,9 +103,20 @@ jobs:
           ${CONDA_RUN} python setup.py clean
       - name: Build the wheel (bdist_wheel)
         working-directory: ${{ inputs.repository }}
+        env:
+          ENV_SCRIPT: ${{ inputs.env-script }}
         run: |
           source "${BUILD_ENV_FILE}"
-          ${CONDA_RUN} python setup.py bdist_wheel
+          if [[ -z "${ENV_SCRIPT}" ]]; then
+            ${CONDA_RUN} python setup.py bdist_wheel
+          else
+            if [[ ! -f ${ENV_SCRIPT} ]]; then
+              echo "::error::Specified env-script file (${ENV_SCRIPT}) not found"
+              exit 1
+            else
+              ${CONDA_RUN} ${ENV_SCRIPT} python setup.py bdist_wheel
+            fi
+          fi
       - name: Upload wheel to GitHub
         uses: actions/upload-artifact@v3
         with:
@@ -111,6 +134,24 @@ jobs:
           else
             ${CONDA_RUN} bash "${POST_SCRIPT}"
           fi
+      - name: Run Primitive Smoke Tests
+        env:
+          PACKAGE_NAME: ${{ inputs.package-name }}
+          SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
+        run: |
+          source "${BUILD_ENV_FILE}"
+          WHEEL_NAME=$(ls "${{ inputs.repository }}/dist/")
+          echo "$WHEEL_NAME"
+          ${CONDA_RUN} pip install "${{ inputs.repository }}/dist/$WHEEL_NAME"
+          if [[ ! -f "${{ inputs.repository }}"/${SMOKE_TEST_SCRIPT} ]]; then
+            echo "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT} not found"
+            ${CONDA_RUN} python -c "import ${PACKAGE_NAME}; print('package version is ', ${PACKAGE_NAME}.__version__)"
+          else
+            echo "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT} found"
+            export LD_LIBRARY_PATH="{LD_LIBRARY_PATH}:${{ inputs.repository }}/third_party/ffmpeg/lib"
+            ${CONDA_RUN} python "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT}"
+          fi
+
       # TODO: Figure out upload method to s3
 
 concurrency:

--- a/.github/workflows/test_build_wheels_windows.yml
+++ b/.github/workflows/test_build_wheels_windows.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/test_build_wheels_windows.yml
       - .github/workflows/build_wheels_windows.yml
       - .github/workflows/generate_binary_build_matrix.yml
+  workflow_dispatch:
 
 jobs:
   generate-matrix:
@@ -27,10 +28,16 @@ jobs:
           #   post-script: packaging/post_build_script.sh
           - repository: pytorch/vision
             pre-script: ""
+            env-script: "packaging/windows/internal/vc_env_helper.bat"
             post-script: ""
-          # - repository: pytorch/text
-          #   pre-script: ""
-          #   post-script: ""
+            smoke-test-script: ""
+            package-name: torchvision
+          - repository: pytorch/text
+            pre-script: ""
+            env-script: "packaging/vc_env_helper.bat"
+            post-script: ""
+            smoke-test-script: ""
+            package-name: torchtext
     uses: ./.github/workflows/build_wheels_windows.yml
     name: ${{ matrix.repository }}
     with:
@@ -40,5 +47,8 @@ jobs:
       test-infra-ref: ${{ github.ref }}
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
+      env-script: ${{ matrix.env-script }}
       post-script: ${{ matrix.post-script }}
+      smoke-test-script: ${{ matrix.smoke-test-script }}
+      package-name: ${{ matrix.package-name }}
       runner-type: windows-2019


### PR DESCRIPTION
This PR introduces `inputs.env-script`, this is needed to specify visual c++ compiler variables. `pre-script` can not be reused for this, because the scripts don't export the variables and need to be run in the same command line as `python setup.py bdist_wheel`, not before it.
Also this PR adds smoke tests copied from Linux builds.