### PR TITLE
Expand clickable area to include text

### DIFF
--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -223,15 +223,16 @@ function GroupViewCheckBox({
 }) {
   return (
     <>
-      <input
-        type="checkbox"
-        name="groupView"
-        checked={useGrouping}
-        onChange={() => {
+      <div onClick={() => {
           setUseGrouping(!useGrouping);
-        }}
-      />
-      <label htmlFor="groupView"> Use grouped view</label>
+        }}>
+        <input
+          type="checkbox"
+          name="groupView"
+          checked={useGrouping}
+        />
+        <label htmlFor="groupView"> Use grouped view</label>
+      </div>
       <br />
     </>
   );


### PR DESCRIPTION
In the HUD home screen, let the "group by" check box become checked if you hit either the check box or the text associated with it.

Previously, you had to click the checkbox itself

Video before shows before & after behavior

https://user-images.githubusercontent.com/4468967/193086401-2d12bcac-4438-4dc5-a463-22a3e70a9078.mov

