### PR TITLE
github: Install pkg-helpers from source

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -82,7 +82,7 @@ runs:
             "python=3.9"
           CONDA_ENV="${CONDA_ENV}"
           CONDA_RUN="conda run -p ${CONDA_ENV}"
-          ${CONDA_RUN} python -m pip install pytorch-pkg-helpers==0.1.5
+          ${CONDA_RUN} python -m pip install ${GITHUB_WORKSPACE}/test-infra/tools/pkg-helpers
           BUILD_ENV_FILE="${RUNNER_TEMP}/build_env_${GITHUB_RUN_ID}"
           ${CONDA_RUN} python -m pytorch_pkg_helpers > "${BUILD_ENV_FILE}"
           echo "BUILD_ENV_FILE=${BUILD_ENV_FILE}" >> "${GITHUB_ENV}"


### PR DESCRIPTION
Installing it from pip was a nice idea but not necessarily the best way to move fast

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>