### PR TITLE
Add duration and queue time info to commit summary

### DIFF
--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -14,6 +14,11 @@ export default function JobLinks({ job }: { job: JobData }) {
       </span>
     ) : null;
 
+  const queueTimeS =
+    job.queueTimeS != null ? (
+      <span>{` | Queued: ${durationHuman(job.queueTimeS!)}`}</span>
+    ) : null;
+
   const durationS =
     job.durationS != null ? (
       <span>{` | Duration: ${durationHuman(job.durationS!)}`}</span>
@@ -42,6 +47,7 @@ export default function JobLinks({ job }: { job: JobData }) {
     <span>
       {rawLogs}
       {failureCaptures}
+      {queueTimeS}
       {durationS}
       {eventTime}
       <DisableIssue job={job} />

--- a/torchci/components/JobSummary.tsx
+++ b/torchci/components/JobSummary.tsx
@@ -2,10 +2,22 @@ import { JobData } from "lib/types";
 import JobConclusion from "./JobConclusion";
 
 export default function JobSummary({ job }: { job: JobData }) {
+  var queueTimeInfo = null
+  if (job.queueTimeS != null) {
+    queueTimeInfo = <><i>Queued:</i> {Math.max(Math.round(job.queueTimeS / 60), 0)} mins</>
+  }
+
+  var durationInfo = null
+  if (job.durationS != null) {
+    durationInfo = <><i>Duration:</i> {Math.round((job.durationS / 60))} mins</>
+  }
+
+  var separator = (queueTimeInfo && durationInfo) ? ", ": ""
+
   return (
     <>
       <JobConclusion conclusion={job.conclusion} />
-      <a href={job.htmlUrl}> {job.jobName} </a>
+      <a href={job.htmlUrl}> {job.jobName}</a> {queueTimeInfo}{separator} {durationInfo}
     </>
   );
 }

--- a/torchci/components/JobSummary.tsx
+++ b/torchci/components/JobSummary.tsx
@@ -2,22 +2,10 @@ import { JobData } from "lib/types";
 import JobConclusion from "./JobConclusion";
 
 export default function JobSummary({ job }: { job: JobData }) {
-  var queueTimeInfo = null
-  if (job.queueTimeS != null) {
-    queueTimeInfo = <><i>Queued:</i> {Math.max(Math.round(job.queueTimeS / 60), 0)} mins</>
-  }
-
-  var durationInfo = null
-  if (job.durationS != null) {
-    durationInfo = <><i>Duration:</i> {Math.round((job.durationS / 60))} mins</>
-  }
-
-  var separator = (queueTimeInfo && durationInfo) ? ", ": ""
-
   return (
     <>
       <JobConclusion conclusion={job.conclusion} />
-      <a href={job.htmlUrl}> {job.jobName}</a> {queueTimeInfo}{separator} {durationInfo}
+      <a href={job.htmlUrl}> {job.jobName}</a><br/>
     </>
   );
 }

--- a/torchci/components/JobSummary.tsx
+++ b/torchci/components/JobSummary.tsx
@@ -5,7 +5,7 @@ export default function JobSummary({ job }: { job: JobData }) {
   return (
     <>
       <JobConclusion conclusion={job.conclusion} />
-      <a href={job.htmlUrl}> {job.jobName}</a>
+      <a href={job.htmlUrl}> {job.jobName} </a>
     </>
   );
 }

--- a/torchci/components/JobSummary.tsx
+++ b/torchci/components/JobSummary.tsx
@@ -5,7 +5,7 @@ export default function JobSummary({ job }: { job: JobData }) {
   return (
     <>
       <JobConclusion conclusion={job.conclusion} />
-      <a href={job.htmlUrl}> {job.jobName}</a><br/>
+      <a href={job.htmlUrl}> {job.jobName}</a>
     </>
   );
 }

--- a/torchci/components/WorkflowBox.tsx
+++ b/torchci/components/WorkflowBox.tsx
@@ -18,6 +18,28 @@ function sortJobsByConclusion( jobA: JobData, jobB: JobData): number {
   return ('' + jobA.jobName).localeCompare('' + jobB.jobName);  // the '' forces the type to be a string
 }
 
+function getWorkflowJobSummary(job: JobData) {
+  var queueTimeInfo = null
+  if (job.queueTimeS != null) {
+    queueTimeInfo = <><i>Queued:</i> {Math.max(Math.round(job.queueTimeS / 60), 0)} mins</>
+  }
+
+  var durationInfo = null
+  if (job.durationS != null) {
+    durationInfo = <><i>Duration:</i> {Math.round((job.durationS / 60))} mins</>
+  }
+
+  var separator = (queueTimeInfo && durationInfo) ? ", ": ""
+
+  return <>
+    <JobSummary job={job} />
+    <small>
+      &nbsp;&nbsp;&nbsp;&nbsp;
+      {queueTimeInfo}{separator}{durationInfo}
+    </small>
+  </>
+}
+
 export default function WorkflowBox({
   workflowName,
   jobs,
@@ -32,6 +54,8 @@ export default function WorkflowBox({
 
   const workflowId = jobs[0].workflowId;
   const anchorName = encodeURIComponent(workflowName.toLowerCase())
+
+
   return (
     <div id={anchorName} className={workflowClass}>
       <h3>{workflowName}</h3>
@@ -39,7 +63,7 @@ export default function WorkflowBox({
       <>
         {jobs.sort(sortJobsByConclusion).map((job) => (
           <div key={job.id}>
-            <JobSummary job={job} />
+            {getWorkflowJobSummary(job)}
             {isFailedJob(job) && (<LogViewer job={job} />)}
           </div>
         ))}

--- a/torchci/components/WorkflowBox.tsx
+++ b/torchci/components/WorkflowBox.tsx
@@ -33,6 +33,7 @@ function getWorkflowJobSummary(job: JobData) {
 
   return <>
     <JobSummary job={job} />
+    <br/>
     <small>
       &nbsp;&nbsp;&nbsp;&nbsp;
       {queueTimeInfo}{separator}{durationInfo}
@@ -54,8 +55,6 @@ export default function WorkflowBox({
 
   const workflowId = jobs[0].workflowId;
   const anchorName = encodeURIComponent(workflowName.toLowerCase())
-
-
   return (
     <div id={anchorName} className={workflowClass}>
       <h3>{workflowName}</h3>

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -14,6 +14,7 @@ export interface JobData {
   htmlUrl?: string;
   logUrl?: string;
   durationS?: number;
+  queueTimeS?: number;
   failureLine?: string;
   failureLineNumber?: number;
   failureCaptures?: string;

--- a/torchci/rockset/commons/__sql/commit_jobs_query.sql
+++ b/torchci/rockset/commons/__sql/commit_jobs_query.sql
@@ -65,8 +65,7 @@ WITH job as (
         ) as html_url,
         -- logs aren't downloaded currently, just reuse html_url
         html_url as log_url,
-        null as queue_time_s,
-        -- for circle ci, the event time comes after the end time, so its not reliable for queueing
+        null as queue_time_s, -- for circle ci, the event time comes after the end time, so its not reliable for queueing
         DATE_DIFF(
             'SECOND',
             PARSE_TIMESTAMP_ISO8601(job.job.started_at),

--- a/torchci/rockset/commons/__sql/commit_jobs_query.sql
+++ b/torchci/rockset/commons/__sql/commit_jobs_query.sql
@@ -15,6 +15,11 @@ WITH job as (
         ) as log_url,
         DATE_DIFF(
             'SECOND',
+            job._event_time,
+            PARSE_TIMESTAMP_ISO8601(job.started_at)
+        ) as queue_time_s,
+        DATE_DIFF(
+            'SECOND',
             PARSE_TIMESTAMP_ISO8601(job.started_at),
             PARSE_TIMESTAMP_ISO8601(job.completed_at)
         ) as duration_s,
@@ -60,6 +65,8 @@ WITH job as (
         ) as html_url,
         -- logs aren't downloaded currently, just reuse html_url
         html_url as log_url,
+        null as queue_time_s,
+        -- for circle ci, the event time comes after the end time, so its not reliable for queueing
         DATE_DIFF(
             'SECOND',
             PARSE_TIMESTAMP_ISO8601(job.job.started_at),
@@ -90,6 +97,7 @@ SELECT
     html_url as htmlUrl,
     log_url as logUrl,
     duration_s as durationS,
+    queue_time_s as queueTimeS,
     line as failureLine,
     line_num as failureLineNumber,
     captures as failureCaptures,

--- a/torchci/rockset/commons/commit_jobs_query.lambda.json
+++ b/torchci/rockset/commons/commit_jobs_query.lambda.json
@@ -9,7 +9,7 @@
     {
       "name": "sha",
       "type": "string",
-      "value": "0a94f108eb7cc39fc625e96081dde54b37b42fde"
+      "value": "ae93a4dc43a7103b1856b83456b247dd3395fe47"
     }
   ],
   "description": ""

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -1,7 +1,7 @@
 {
   "commons": {
     "hud_query": "f5ebefcdd53b6ff5",
-    "commit_jobs_query": "54f2f2b643a456cc",
+    "commit_jobs_query": "442a6f64bd44f351",
     "flaky_tests": "59d7546183743626",
     "slow_tests": "ef8d035d23aa8ab6",
     "test_time_per_file": "50cb3694334ed63a",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -1,7 +1,7 @@
 {
   "commons": {
     "hud_query": "f5ebefcdd53b6ff5",
-    "commit_jobs_query": "6201b6a715f84a44",
+    "commit_jobs_query": "54f2f2b643a456cc",
     "flaky_tests": "59d7546183743626",
     "slow_tests": "ef8d035d23aa8ab6",
     "test_time_per_file": "50cb3694334ed63a",


### PR DESCRIPTION
Make it easier to tell how long a job has been queued for and how long it ran for from the commit page.

This should be especially handy as we keep track of the increasing ROCm queue times.  (Optionally, we could later remove the queue time if we ever feel like it's no longer a concern)

The effect: It adds subtle stats to the pending & completed workflow jobs
<img width="701" alt="image" src="https://user-images.githubusercontent.com/4468967/193350399-3520956e-9faf-48f6-86b0-65c0496da7f7.png">



