### PR TITLE
Add pytest pattern to log classifier

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -73,6 +73,10 @@ name = 'Python unittest failure'
 pattern = 'FAIL \[.*\]: (test.*) \((?:__main__\.)?(.*)\)'
 
 [[rule]]
+name = 'pytest failure'
+pattern = '^FAILED .*.py::.*::test_.*$'
+
+[[rule]]
 name = 'Python unittest error'
 pattern = 'ERROR \[.*\]: (test.*) \((?:__main__\.)?(.*)\)'
 


### PR DESCRIPTION
This matches against the "short test summary info". An example log snippet:

```
2022-09-29T18:25:18.2044765Z =================================== FAILURES ===================================
2022-09-29T18:25:18.2045241Z _ TestCommonCUDA.test_noncontiguous_samples_nn_functional_conv_transpose2d_cuda_float32 _
2022-09-29T18:25:18.2045634Z Traceback (most recent call last):
2022-09-29T18:25:18.2046030Z   File "/var/lib/jenkins/workspace/test/test_ops.py", line 468, in test_noncontiguous_samples
2022-09-29T18:25:18.2046415Z     self.assertEqual(actual, expected)
2022-09-29T18:25:18.2046989Z   File "/opt/conda/lib/python3.10/site-packages/torch/testing/_internal/common_utils.py", line 2455, in assertEqual
2022-09-29T18:25:18.2047371Z     assert_equal(
2022-09-29T18:25:18.2047917Z   File "/opt/conda/lib/python3.10/site-packages/torch/testing/_comparison.py", line 1093, in assert_equal
2022-09-29T18:25:18.2048306Z     raise error_metas[0].to_error(msg)
2022-09-29T18:25:18.2048689Z AssertionError: Tensor-likes are not close!
2022-09-29T18:25:18.2048897Z 
2022-09-29T18:25:18.2049031Z Mismatched elements: 1 / 392 (0.3%)
2022-09-29T18:25:18.2049479Z Greatest absolute difference: 1.52587890625e-05 at index (0, 4, 4, 4) (up to 1e-05 allowed)
2022-09-29T18:25:18.2050016Z Greatest relative difference: 4.9182343538669616e-05 at index (0, 4, 4, 4) (up to 1.3e-06 allowed)
2022-09-29T18:25:18.2050637Z - generated xml file: /var/lib/jenkins/workspace/test/test-reports/python-pytest/test_ops/test_ops-4e692d005a353671.xml -
2022-09-29T18:25:18.2051102Z =========================== short test summary info ============================
MATCHES THIS LINE >>>> 2022-09-29T18:25:18.2051540Z FAILED test_ops.py::TestCommonCUDA::test_noncontiguous_samples_nn_functional_conv_transpose2d_cuda_float32
2022-09-29T18:25:18.2051987Z !!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
```

Arguably we should match against the line that precedes the actual stack trace, but the pattern would be more general and would potentially have more false positives. I think this is good enough.