### PR TITLE
Add torchaudio to Windows wheels

### DIFF
--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -31,6 +31,10 @@ on:
         description: "Script to setup environment variables for the build"
         default: ""
         type: string
+      build-params:
+        description: "Additional parameters for bdist_wheel"
+        default: ""
+        type: string
       post-script:
         description: "Post script to run prior to build"
         default: ""
@@ -105,6 +109,7 @@ jobs:
         working-directory: ${{ inputs.repository }}
         env:
           ENV_SCRIPT: ${{ inputs.env-script }}
+          BUILD_PARAMS: ${{ inputs.build-params }}
         run: |
           source "${BUILD_ENV_FILE}"
           if [[ -z "${ENV_SCRIPT}" ]]; then
@@ -114,7 +119,7 @@ jobs:
               echo "::error::Specified env-script file (${ENV_SCRIPT}) not found"
               exit 1
             else
-              ${CONDA_RUN} ${ENV_SCRIPT} python setup.py bdist_wheel
+              ${CONDA_RUN} ${ENV_SCRIPT} python setup.py bdist_wheel ${BUILD_PARAMS}
             fi
           fi
       - name: Upload wheel to GitHub

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -31,7 +31,7 @@ on:
         description: "Script to setup environment variables for the build"
         default: ""
         type: string
-      build-params:
+      wheel-build-params:
         description: "Additional parameters for bdist_wheel"
         default: ""
         type: string
@@ -109,7 +109,7 @@ jobs:
         working-directory: ${{ inputs.repository }}
         env:
           ENV_SCRIPT: ${{ inputs.env-script }}
-          BUILD_PARAMS: ${{ inputs.build-params }}
+          BUILD_PARAMS: ${{ inputs.wheel-build-params }}
         run: |
           source "${BUILD_ENV_FILE}"
           if [[ -z "${ENV_SCRIPT}" ]]; then

--- a/.github/workflows/test_build_wheels_windows.yml
+++ b/.github/workflows/test_build_wheels_windows.yml
@@ -26,7 +26,7 @@ jobs:
           - repository: pytorch/audio
             pre-script: ""
             env-script: packaging/vc_env_helper.bat
-            build-params: "--plat-name win_amd64"
+            wheel-build-params: "--plat-name win_amd64"
             post-script: ""
             smoke-test-script: ""
             package-name: torchaudio
@@ -52,7 +52,7 @@ jobs:
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
       env-script: ${{ matrix.env-script }}
-      build-params: ${{ matrix.build-params }}
+      wheel-build-params: ${{ matrix.wheel-build-params }}
       post-script: ${{ matrix.post-script }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
       package-name: ${{ matrix.package-name }}

--- a/.github/workflows/test_build_wheels_windows.yml
+++ b/.github/workflows/test_build_wheels_windows.yml
@@ -23,18 +23,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - repository: pytorch/audio
-          #   pre-script: packaging/pre_build_script.sh
-          #   post-script: packaging/post_build_script.sh
+          - repository: pytorch/audio
+            pre-script: ""
+            env-script: packaging/vc_env_helper.bat
+            build-params: "--plat-name win_amd64"
+            post-script: ""
+            smoke-test-script: ""
+            package-name: torchaudio
           - repository: pytorch/vision
             pre-script: ""
-            env-script: "packaging/windows/internal/vc_env_helper.bat"
+            env-script: packaging/windows/internal/vc_env_helper.bat
             post-script: ""
             smoke-test-script: ""
             package-name: torchvision
           - repository: pytorch/text
             pre-script: ""
-            env-script: "packaging/vc_env_helper.bat"
+            env-script: packaging/vc_env_helper.bat
             post-script: ""
             smoke-test-script: ""
             package-name: torchtext
@@ -48,6 +52,7 @@ jobs:
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
       env-script: ${{ matrix.env-script }}
+      build-params: ${{ matrix.build-params }}
       post-script: ${{ matrix.post-script }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
       package-name: ${{ matrix.package-name }}


### PR DESCRIPTION
To build torchaudio on Windows, new workflow parameter is added `inputs.build-params` - to put into command line after `python setup.py bdist_wheel`.

`pre-script` is apparently not needed, because we don't build ffmpeg on Windows.

The testing is done via `test_build_wheels_windows.yml` - it executes the worfklow, which runs "Run Primitive Smoke Tests" step.