### PR TITLE
GHA scale-config.yml - increase linux.large (c5.large) disk size to 15GiB

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -81,7 +81,7 @@ runner_types:
     disk_size: 150
     is_ephemeral: true
   linux.large:
-    disk_size: 10
+    disk_size: 15
     instance_type: c5.large
     is_ephemeral: false
     os: linux


### PR DESCRIPTION
![Screenshot 2022-10-05 at 14 55 52](https://user-images.githubusercontent.com/4520845/194065451-cea74c0d-d5bb-4eea-bcc2-4b648b36f94e.png)

linux.large GHA runners don't have a lot of disk available, what might cause a breakage in future changes, to avoid that, I am increasing it slightly.