### PR TITLE
Limit test insights Rockset query to only master branch

### DIFF
--- a/torchci/pages/tests.tsx
+++ b/torchci/pages/tests.tsx
@@ -183,6 +183,12 @@ export default function GatherTestsInfo() {
 
       <Grid container spacing={4}>
         <GenerateTestInsightsOverviewTable
+          workflowName={"pull"}
+          startTime={startTime}
+          stopTime={stopTime}
+        />
+
+        <GenerateTestInsightsOverviewTable
           workflowName={"trunk"}
           startTime={startTime}
           stopTime={stopTime}
@@ -190,12 +196,6 @@ export default function GatherTestsInfo() {
 
         <GenerateTestInsightsOverviewTable
           workflowName={"periodic"}
-          startTime={startTime}
-          stopTime={stopTime}
-        />
-
-        <GenerateTestInsightsOverviewTable
-          workflowName={"pull"}
           startTime={startTime}
           stopTime={stopTime}
         />

--- a/torchci/rockset/commons/__sql/test_insights_latest_runs.sql
+++ b/torchci/rockset/commons/__sql/test_insights_latest_runs.sql
@@ -19,6 +19,7 @@ WHERE
     AND workflow_job.name = :jobName
     AND test_run_summary.invoking_file = :testFile
     AND test_run_summary.classname = :testClass
+    AND workflow_run.head_branch = 'master'
 ORDER BY
     test_run_summary._event_time DESC
 LIMIT

--- a/torchci/rockset/commons/__sql/test_insights_overview.sql
+++ b/torchci/rockset/commons/__sql/test_insights_overview.sql
@@ -19,6 +19,7 @@ test_runs AS (
         AND test_run_summary._event_time < PARSE_DATETIME_ISO8601(:stopTime)
         AND test_run_summary.workflow_run_attempt = 1
         AND workflow_run.name = :workflowName
+        AND workflow_run.head_branch = 'master'
 ),
 aggregated_test_runs AS (
     SELECT

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -11,8 +11,8 @@
     "recent_pr_workflows_query": "4e03cb13e8372050",
     "reverted_prs_with_reason": "bf2b0607bddcc552",
     "unclassified": "1b31a2d8f4ab7230",
-    "test_insights_overview": "391cf927a9e5e96c",
-    "test_insights_latest_runs": "7cab5b1fbb4aa5bb"
+    "test_insights_overview": "c9be5cbdda1030af",
+    "test_insights_latest_runs": "949f5e49f76bfdd4"
   },
   "pytorch_dev_infra_kpis": {
     "num_reverts": "dd2bac0ff36ea47f",


### PR DESCRIPTION
Address the issue in https://github.com/pytorch/test-infra/pull/848.  The test insights page will only looks into jobs on master.