### PR TITLE
Fix stale Dr. CI comment after retrying jobs

### DIFF
--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -97,6 +97,7 @@ export interface RecentWorkflowsData {
   completed_at: string | null;
   html_url: string;
   head_sha?: string;
+  run_attempt: number;
   pr_number?: number;
   owner_login?: string;
 }

--- a/torchci/rockset/commons/__sql/recent_pr_workflows_query.sql
+++ b/torchci/rockset/commons/__sql/recent_pr_workflows_query.sql
@@ -1,30 +1,32 @@
-select
-	w.name as job_name,
+SELECT
+    w.name AS job_name,
     w.conclusion,
     w.completed_at,
     w.html_url,
     w.head_sha,
-    p.number as pr_number,
-    p.user.login as owner_login,
-from
-	commons.workflow_job w inner join commons.pull_request p on w.head_sha = p.head.sha
-where
-	w.head_sha in (
-      select
-          w.head_sha
-      from
-      	commons.workflow_job w
-      where 
-      	PARSE_TIMESTAMP_ISO8601(w.completed_at) > (CURRENT_TIMESTAMP() - MINUTES(:numMinutes))
+    w.run_attempt,
+    p.number AS pr_number,
+    p.user.login AS owner_login,
+FROM
+    commons.workflow_job w INNER JOIN commons.pull_request p ON w.head_sha = p.head.sha
+WHERE
+    w.head_sha IN (
+        SELECT
+            w.head_sha
+        FROM
+            commons.workflow_job w
+        WHERE
+            PARSE_TIMESTAMP_ISO8601(w.completed_at) > (CURRENT_TIMESTAMP() - MINUTES(:numMinutes))
     )
-    and w.head_sha = p.head.sha 
-    and p.base.repo.full_name = 'pytorch/pytorch'
-    
-group by
-	job_name,
+    AND w.head_sha = p.head.sha
+    AND p.base.repo.full_name = 'pytorch/pytorch'
+
+GROUP BY
+    job_name,
     conclusion,
     completed_at,
     html_url,
     head_sha,
+    run_attempt,
     pr_number,
     owner_login

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -8,7 +8,7 @@
     "test_time_per_file_periodic_jobs": "39c105542e297c09",
     "issue_query": "5d4dfeb992e2f29b",
     "failure_samples_query": "ab2b589414b966a8",
-    "recent_pr_workflows_query": "080dbc94ee42b5ef",
+    "recent_pr_workflows_query": "7486549578f7a837",
     "reverted_prs_with_reason": "bf2b0607bddcc552",
     "unclassified": "1b31a2d8f4ab7230",
     "test_insights_overview": "c9be5cbdda1030af",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -8,7 +8,7 @@
     "test_time_per_file_periodic_jobs": "39c105542e297c09",
     "issue_query": "5d4dfeb992e2f29b",
     "failure_samples_query": "ab2b589414b966a8",
-    "recent_pr_workflows_query": "4e03cb13e8372050",
+    "recent_pr_workflows_query": "080dbc94ee42b5ef",
     "reverted_prs_with_reason": "bf2b0607bddcc552",
     "unclassified": "1b31a2d8f4ab7230",
     "test_insights_overview": "c9be5cbdda1030af",


### PR DESCRIPTION
Recently, I realize that Dr. CI doesn't take the results of retrying jobs into account and this leads to a discrepancy between Dr. CI comment, HUD, and GitHub signal box. This is an example https://github.com/pytorch/pytorch/pull/85313 where Dr. CI reports a failing job while none is showed in https://hud.pytorch.org/pr/85313 or GitHub signal box.  The failed jobs was retried successfully.

Also cleaning up the `recent_pr_workflows_query` query a bit and adding `run_attempt` field.