### PR TITLE
Reland "[hud] Add Failure Classification to HUD" (#861)"

### DIFF
--- a/torchci/components/CommitStatus.tsx
+++ b/torchci/components/CommitStatus.tsx
@@ -16,21 +16,23 @@ function WorkflowsContainer({ jobs }: { jobs: JobData[] }) {
     return null;
   }
   const byWorkflow = _(jobs)
-    .groupBy(job => job.workflowName)
+    .groupBy((job) => job.workflowName)
     .sortBy(
-      (jobs => _(jobs)
-          .map(job => getConclusionSeverityForSorting(job.conclusion))
-          .max()), // put failing workflows first
-      (jobs => jobs.length)) // put worflows of similar lenghts together to keep the display more compact
+      (jobs) =>
+        _(jobs)
+          .map((job) => getConclusionSeverityForSorting(job.conclusion))
+          .max(), // put failing workflows first
+      (jobs) => jobs.length // put worflows of similar lenghts together to keep the display more compact
+    )
     .reverse()
-    .value()
+    .value();
 
   return (
     <>
       <h1>Workflows</h1>
       <div className={styles.workflowContainer}>
-        {_.map(byWorkflow, jobs => {
-          let workflowName = '' + jobs[0].workflowName
+        {_.map(byWorkflow, (jobs) => {
+          let workflowName = "" + jobs[0].workflowName;
           return (
             <WorkflowBox
               key={workflowName}
@@ -71,6 +73,7 @@ export default function CommitStatus({
         filterName="Failed jobs"
         jobs={jobs}
         pred={isFailedJob}
+        showClassification
       />
       <FilteredJobList
         filterName="Pending jobs"

--- a/torchci/components/FilteredJobList.tsx
+++ b/torchci/components/FilteredJobList.tsx
@@ -1,4 +1,8 @@
+import { fetcher } from "lib/GeneralUtils";
 import { JobData } from "lib/types";
+import { useRouter } from "next/router";
+import useSWR from "swr";
+import JobAnnotationToggle, { JobAnnotation } from "./JobAnnotationToggle";
 import JobLinks from "./JobLinks";
 import JobSummary from "./JobSummary";
 import LogViewer from "./LogViewer";
@@ -7,12 +11,29 @@ export default function FilteredJobList({
   filterName,
   jobs,
   pred,
+  showClassification = false,
 }: {
   filterName: string;
   jobs: JobData[];
   pred: (job: JobData) => boolean;
+  showClassification?: boolean;
 }) {
   const filteredJobs = jobs.filter(pred);
+
+  const router = useRouter();
+  const { repoOwner, repoName } = router.query;
+  const { data } = useSWR(
+    showClassification
+      ? `/api/job_annotation/${repoOwner}/${repoName}/annotations/${encodeURIComponent(
+          JSON.stringify(filteredJobs.map((failedJob) => failedJob.id))
+        )}`
+      : null,
+    fetcher
+  );
+  if (showClassification && data == null) {
+    return null;
+  }
+
   if (filteredJobs.length === 0) {
     return null;
   }
@@ -27,6 +48,15 @@ export default function FilteredJobList({
               <JobLinks job={job} />
             </div>
             <LogViewer job={job} />
+            {showClassification && (
+              <JobAnnotationToggle
+                job={job}
+                annotation={
+                  (data[job?.id ?? ""] && data[job?.id ?? ""]["annotation"]) ?? JobAnnotation.NULL
+                }
+                repo={`${repoOwner}/${repoName}`}
+              />
+            )}
           </li>
         ))}
       </ul>

--- a/torchci/components/GroupJobConclusion.tsx
+++ b/torchci/components/GroupJobConclusion.tsx
@@ -23,16 +23,19 @@ export enum GroupedJobStatus {
   Pending = "pending",
   AllNull = "all_null",
   Success = "success",
+  Classified = "classified",
 }
 
 export default function HudGroupedCell({
   sha,
   groupData,
   isExpanded,
+  isClassified,
 }: {
   sha: string;
   groupData: GroupData;
   isExpanded: boolean;
+  isClassified: boolean;
 }) {
   const erroredJobs = [];
   const pendingJobs = [];
@@ -79,7 +82,11 @@ export default function HudGroupedCell({
         >
           <span className={styles.conclusion}>
             <span
-              className={styles[conclusion ?? "none"]}
+              className={
+                isClassified
+                  ? styles["classified"]
+                  : styles[conclusion ?? "none"]
+              }
               style={{ border: "1px solid gainsboro" }}
             >
               {getGroupConclusionChar(conclusion)}
@@ -90,7 +97,14 @@ export default function HudGroupedCell({
       {isExpanded ? (
         <>
           {groupData.jobs.map((job, ind) => {
-            return <JobCell key={ind} sha={sha} job={job} />;
+            return (
+              <JobCell
+                key={ind}
+                sha={sha}
+                job={job}
+                isClassified={isClassified}
+              />
+            );
           })}
         </>
       ) : null}

--- a/torchci/components/JobAnnotationToggle.tsx
+++ b/torchci/components/JobAnnotationToggle.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { JobData } from "../lib/types";
+import { ToggleButtonGroup, ToggleButton } from "@mui/material";
+import { useSession } from "next-auth/react";
+
+export enum JobAnnotation {
+  NULL = "None",
+  INFRA_FLAKE = "Infra Flake",
+  TIME_OUT = "Time Out",
+  SEV = "Sev",
+  BROKEN_TRUNK = "Broken Trunk",
+  TEST_FLAKE = "Test Flake",
+  TEST_FAILURE = "Test Failure",
+}
+
+export default function JobAnnotationToggle({
+  job,
+  annotation,
+  repo = null,
+}: {
+  job: JobData;
+  annotation: JobAnnotation;
+  repo?: string | null;
+}) {
+  const [state, setState] = React.useState<JobAnnotation>(
+    (annotation ?? "null") as JobAnnotation
+  );
+  const session = useSession();
+  async function handleChange(
+    _: React.MouseEvent<HTMLElement>,
+    newState: JobAnnotation
+  ) {
+    setState(newState);
+    await fetch(
+      `/api/job_annotation/${repo ?? job.repo}/${job.id}/${newState}`,
+      {
+        method: "POST",
+      }
+    );
+  }
+
+  return (
+    <>
+      Classify failure:{" "}
+      <ToggleButtonGroup
+        value={state}
+        exclusive
+        onChange={handleChange}
+        disabled={session.status !== "authenticated"}
+      >
+        {Object.keys(JobAnnotation).map((annotation, ind) => {
+          return (
+            <ToggleButton
+              key={ind}
+              value={annotation}
+              style={{ height: "12pt", textTransform: "none" }}
+            >
+              {
+                //@ts-ignore
+                JobAnnotation[annotation]
+              }
+            </ToggleButton>
+          );
+        })}
+      </ToggleButtonGroup>
+    </>
+  );
+}

--- a/torchci/components/JobConclusion.module.css
+++ b/torchci/components/JobConclusion.module.css
@@ -4,6 +4,10 @@
   font-weight: bold;
 }
 
+.classified {
+  color: lightcoral;
+}
+
 .success {
   color: green;
 }

--- a/torchci/components/JobConclusion.tsx
+++ b/torchci/components/JobConclusion.tsx
@@ -1,10 +1,20 @@
 import { getConclusionChar } from "lib/JobClassifierUtil";
 import styles from "./JobConclusion.module.css";
 
-export default function JobConclusion({ conclusion }: { conclusion?: string }) {
+export default function JobConclusion({
+  conclusion,
+  classified = false,
+}: {
+  conclusion?: string;
+  classified?: boolean;
+}) {
   return (
     <span className={styles.conclusion}>
-      <span className={styles[conclusion ?? "none"]}>
+      <span
+        className={
+          classified ? styles["classified"] : styles[conclusion ?? "none"]
+        }
+      >
         {getConclusionChar(conclusion)}
       </span>
     </span>

--- a/torchci/components/minihud.module.css
+++ b/torchci/components/minihud.module.css
@@ -26,6 +26,13 @@
   background-color: lightgreen;
 }
 
+.workflowBoxClassified {
+  border: 1px solid gray;
+  padding: 10px;
+  border-radius: 5px;
+  background-color: linen;
+}
+
 .workflowBoxHighlight {
   border: 15px solid #5eced4;
   padding: 10px;

--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -98,6 +98,8 @@ export function getGroupConclusionChar(conclusion?: GroupedJobStatus): string {
       return "?";
     case GroupedJobStatus.AllNull:
       return "O";
+    case GroupedJobStatus.Classified:
+      return "X";
     default:
       return "U";
   }
@@ -142,7 +144,7 @@ export function getConclusionChar(conclusion?: string): string {
 }
 
 export function getConclusionSeverityForSorting(conclusion?: string): number {
-  // Returns a severity level for the conclusion. 
+  // Returns a severity level for the conclusion.
   // Used to sort jobs by severity
   switch (conclusion) {
     case JobStatus.Success:

--- a/torchci/pages/api/auth/[...nextauth].js
+++ b/torchci/pages/api/auth/[...nextauth].js
@@ -1,38 +1,39 @@
 import NextAuth from "next-auth";
 import GithubProvider from "next-auth/providers/github";
 
-export default (req, res) =>
-  NextAuth(req, res, {
-    providers: [
-      GithubProvider({
-        clientId: process.env.GITHUB_CLIENT_ID,
-        clientSecret: process.env.GITHUB_CLIENT_SECRET,
-        authorization: { params: { scope: "repo" } },
-      }),
-    ],
-    debug: process.env.NODE_ENV === "development",
-    secret: process.env.AUTH_SECRET,
-    jwt: {
-      secret: process.env.JWT_SECRET,
+export const authOptions = {
+  providers: [
+    GithubProvider({
+      clientId: process.env.GITHUB_CLIENT_ID,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET,
+      authorization: { params: { scope: "repo" } },
+    }),
+  ],
+  debug: process.env.NODE_ENV === "development",
+  secret: process.env.AUTH_SECRET,
+  jwt: {
+    secret: process.env.JWT_SECRET,
+  },
+  theme: {
+    colorScheme: "light",
+  },
+  callbacks: {
+    async session({ session, token, user }) {
+      session.user.id = token.id;
+      session.accessToken = token.accessToken;
+      session.userData = user;
+      return session;
     },
-    theme: {
-      colorScheme: "light",
+    async jwt({ token, user, account, profile, isNewUser }) {
+      if (user) {
+        token.id = user.id;
+      }
+      if (account) {
+        token.accessToken = account.access_token;
+      }
+      return token;
     },
-    callbacks: {
-      async session({ session, token, user }) {
-        session.user.id = token.id;
-        session.accessToken = token.accessToken;
-        session.userData = user;
-        return session;
-      },
-      async jwt({ token, user, account, profile, isNewUser }) {
-        if (user) {
-          token.id = user.id;
-        }
-        if (account) {
-          token.accessToken = account.access_token;
-        }
-        return token;
-      },
-    },
-  });
+  },
+};
+
+export default (req, res) => NextAuth(req, res, authOptions);

--- a/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/annotations/[jobIds].ts
+++ b/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/annotations/[jobIds].ts
@@ -1,0 +1,32 @@
+import { getDynamoClient } from "lib/dynamo";
+import { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const client = getDynamoClient();
+  const { jobIds, repoOwner, repoName } = req.query;
+  const jobIdsArr = JSON.parse(jobIds as string);
+  const queries = jobIdsArr.map((jobId: any) => {
+    return client.get({
+      TableName: "torchci-job-annotation",
+      Key: { dynamoKey: `${repoOwner}/${repoName}/${jobId}` },
+    });
+  });
+
+  if (queries.length > 0) {
+    let annotations = await Promise.all(queries);
+    annotations = annotations
+      .map((annotation) => annotation.Item)
+      .filter((item) => item != null);
+    const annotationsMap: any = {};
+
+    for (const annotation of annotations) {
+      annotationsMap[annotation.jobID] = annotation;
+    }
+    return res.status(200).json(annotationsMap);
+  } else {
+    return res.status(200).json({});
+  }
+}

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -26,8 +26,19 @@ import { useRouter } from "next/router";
 import useGroupingPreference from "lib/useGroupingPreference";
 import React, { createContext, useContext, useEffect, useState } from "react";
 import PageSelector from "components/PageSelector";
+import useSWR from "swr";
+import { isFailedJob } from "lib/jobUtils";
+import { fetcher } from "lib/GeneralUtils";
 
-export function JobCell({ sha, job }: { sha: string; job: JobData }) {
+export function JobCell({
+  sha,
+  job,
+  isClassified,
+}: {
+  sha: string;
+  job: JobData;
+  isClassified: boolean;
+}) {
   const [pinnedId, setPinnedId] = useContext(PinnedTooltipContext);
   return (
     <td onDoubleClick={() => window.open(job.htmlUrl)}>
@@ -37,7 +48,7 @@ export function JobCell({ sha, job }: { sha: string; job: JobData }) {
         setPinnedId={setPinnedId}
         tooltipContent={<JobTooltip job={job} />}
       >
-        <JobConclusion conclusion={job.conclusion} />
+        <JobConclusion conclusion={job.conclusion} classified={isClassified} />
       </TooltipTarget>
     </td>
   );
@@ -55,6 +66,20 @@ function HudRow({
   const router = useRouter();
   const params = packHudParams(router.query);
   const sha = rowData.sha;
+
+  const failedJobs = rowData.jobs.filter(isFailedJob);
+  const { repoOwner, repoName } = router.query;
+
+  const { data } = useSWR(
+    `/api/job_annotation/${repoOwner}/${repoName}/annotations/${encodeURIComponent(
+      JSON.stringify(failedJobs.map((failedJob) => failedJob.id))
+    )}`,
+    fetcher
+  );
+  if (data == null) {
+    return null;
+  }
+
   return (
     <tr>
       <td className={styles.jobMetadata}>
@@ -91,6 +116,7 @@ function HudRow({
         </div>
       </td>
       <HudJobCells
+        classifiedJobs={data}
         rowData={rowData}
         expandedGroups={expandedGroups}
         useGrouping={useGrouping}
@@ -103,29 +129,49 @@ function HudJobCells({
   rowData,
   expandedGroups,
   useGrouping,
+  classifiedJobs,
 }: {
   rowData: RowData;
   expandedGroups: Set<string>;
   useGrouping: boolean;
+  classifiedJobs: any;
 }) {
   if (!useGrouping) {
     return (
       <>
-        {rowData.jobs.map((job: JobData) => (
-          <JobCell sha={rowData.sha} key={job.name} job={job} />
-        ))}
+        {rowData.jobs.map((job: JobData) => {
+          const isClassified = (job.id ?? "") in classifiedJobs;
+          return (
+            <JobCell
+              sha={rowData.sha}
+              key={job.name}
+              job={job}
+              isClassified={isClassified}
+            />
+          );
+        })}
       </>
     );
   } else {
     return (
       <>
         {(rowData?.groupedJobs ?? []).map((group, ind) => {
+          let numClassified = 0;
+          for (const job of group.jobs) {
+            if ((job.id ?? "") in classifiedJobs) {
+              numClassified++;
+            }
+          }
+          const failedJobs = group.jobs.filter(isFailedJob);
           return (
             <HudGroupedCell
               sha={rowData.sha}
               key={ind}
               groupData={group}
               isExpanded={expandedGroups.has(group.groupName)}
+              isClassified={
+                numClassified != 0 && numClassified == failedJobs.length
+              }
             />
           );
         })}
@@ -223,14 +269,12 @@ function GroupViewCheckBox({
 }) {
   return (
     <>
-      <div onClick={() => {
+      <div
+        onClick={() => {
           setUseGrouping(!useGrouping);
-        }}>
-        <input
-          type="checkbox"
-          name="groupView"
-          checked={useGrouping}
-        />
+        }}
+      >
+        <input type="checkbox" name="groupView" checked={useGrouping} />
         <label htmlFor="groupView"> Use grouped view</label>
       </div>
       <br />

--- a/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -28,7 +28,10 @@ import {
   useEffect,
   useState,
 } from "react";
-import { SWRConfig } from "swr";
+import useSWR, { SWRConfig } from "swr";
+import JobAnnotationToggle, {
+  JobAnnotation,
+} from "components/JobAnnotationToggle";
 
 function includesCaseInsensitive(value: string, pattern: string): boolean {
   if (pattern === "") {
@@ -37,13 +40,17 @@ function includesCaseInsensitive(value: string, pattern: string): boolean {
   return value.toLowerCase().includes(pattern.toLowerCase());
 }
 
-function FailedJob({ job }: { job: JobData }) {
+function FailedJob({
+  job,
+  classification,
+}: {
+  job: JobData;
+  classification?: string | null;
+}) {
   const [jobFilter, setJobFilter] = useContext(JobFilterContext);
   const [jobHoverContext, setJobHoverContext] = useContext(JobHoverContext);
   const [highlighted, setHighlighted] = useState(false);
-
   const router = useRouter();
-
   useEffect(() => {
     const onHashChanged = () => {
       if (window.location.hash === "") {
@@ -72,7 +79,7 @@ function FailedJob({ job }: { job: JobData }) {
       setJobFilter(job.name!);
     }
   }
-
+  const isClassified = classification != null;
   const linkStyle: CSSProperties = { cursor: "pointer", marginRight: "0.5em" };
   if (job.name === jobHoverContext) {
     linkStyle.backgroundColor = "khaki";
@@ -93,7 +100,7 @@ function FailedJob({ job }: { job: JobData }) {
       }}
     >
       <div>
-        <JobConclusion conclusion={job.conclusion} />
+        <JobConclusion conclusion={job.conclusion} classified={isClassified} />
         <a
           target="_blank"
           rel="noreferrer"
@@ -117,22 +124,40 @@ function FailedJob({ job }: { job: JobData }) {
         <label htmlFor="setfilterbox">Set filter | </label>
         <JobLinks job={job} />
       </div>
+      <div>
+        <JobAnnotationToggle
+          job={job}
+          annotation={(classification ?? "null") as JobAnnotation}
+        />
+      </div>
       <LogViewer job={job} />
     </div>
   );
 }
 
-function FailedJobs({ failedJobs }: { failedJobs: JobData[] }) {
+function FailedJobs({
+  failedJobs,
+  classifiedFailures,
+}: {
+  failedJobs: JobData[];
+  classifiedFailures: any;
+}) {
   if (failedJobs.length === 0) {
     return null;
   }
   return (
     <ul className={styles.failedJobList}>
-      {failedJobs.map((job) => (
-        <li key={job.id}>
-          <FailedJob job={job} />
-        </li>
-      ))}
+      {failedJobs.map((job) => {
+        const classification = classifiedFailures[job?.id ?? ""] ?? {};
+        return (
+          <li key={job.id}>
+            <FailedJob
+              job={job}
+              classification={classification["annotation"] ?? "null"}
+            />
+          </li>
+        );
+      })}
     </ul>
   );
 }
@@ -220,7 +245,6 @@ function CommitSummaryLine({
   showRevert: boolean;
   ttsAlert: boolean;
 }) {
-  const router = useRouter();
   useScrollTo();
 
   return (
@@ -283,7 +307,11 @@ function getTTSChanges(jobs: JobData[], prevJobs: JobData[] | undefined) {
         ) {
           let name = cur.name.substring(0, cur.name.indexOf(","));
           if (!(name in prev)) {
-            prev[name] = { duration: 0, availableData: true, htmlUrl: cur.htmlUrl };
+            prev[name] = {
+              duration: 0,
+              availableData: true,
+              htmlUrl: cur.htmlUrl,
+            };
           }
           if (cur.conclusion != "success" || cur.durationS === undefined) {
             prev[name].availableData = false;
@@ -354,7 +382,12 @@ function getTTSChanges(jobs: JobData[], prevJobs: JobData[] | undefined) {
 
   const [concerningTTS, notConcerningTTS] = _.partition(
     _.map(getAggregateTestTimes(jobs), (value, key) => {
-      return getDurationInfo(key, value.htmlUrl, value.duration, value.availableData);
+      return getDurationInfo(
+        key,
+        value.htmlUrl,
+        value.duration,
+        value.availableData
+      );
     }),
     (e) => e.concerningChange
   );
@@ -389,9 +422,7 @@ function DurationInfo({
     return (
       <tr style={{ color }}>
         <td style={{ width: "750px" }}>
-            <a href={htmlUrl}>
-               {name}
-            </a>
+          <a href={htmlUrl}>{name}</a>
         </td>
         <td style={{ width: "150px" }}>{duration}</td>
         <td style={{ width: "100px" }}>{percentChangeString}</td>
@@ -445,12 +476,24 @@ function CommitSummary({
 
   const failedJobs = jobs.filter(isFailedJob);
   const pendingJobs = jobs.filter((job) => job.conclusion === "pending");
+  const router = useRouter();
+  const { repoOwner, repoName } = router.query;
+
+  const { data } = useSWR(
+    `/api/job_annotation/${repoOwner}/${repoName}/annotations/${encodeURIComponent(
+      JSON.stringify(failedJobs.map((failedJob) => failedJob.id))
+    )}`
+  );
 
   let className;
   if (jobs.length === 0) {
     className = styles.workflowBoxNone;
   } else if (failedJobs.length !== 0) {
-    className = styles.workflowBoxFail;
+    if (Object.keys(data ?? {}).length == failedJobs.length) {
+      className = styles.workflowBoxClassified;
+    } else {
+      className = styles.workflowBoxFail;
+    }
   } else if (pendingJobs.length === 0) {
     className = styles.workflowBoxSuccess;
   } else {
@@ -488,6 +531,10 @@ function CommitSummary({
     };
   }, [row.sha]);
   useScrollTo();
+
+  if (data == null) {
+    return null;
+  }
   return (
     <div id={row.sha} className={className}>
       <div
@@ -499,7 +546,9 @@ function CommitSummary({
           showRevert={failedJobs.length !== 0}
           ttsAlert={concerningTTS.length > 0}
         />
-        {!showDurationInfo && <FailedJobs failedJobs={failedJobs} />}
+        {!showDurationInfo && (
+          <FailedJobs failedJobs={failedJobs} classifiedFailures={data ?? {}} />
+        )}
         {showDurationInfo && (
           <DurationInfo
             concerning={concerningTTS}


### PR DESCRIPTION
Same as before https://github.com/pytorch/test-infra/pull/861 with an additional one-liner undefined check ```(data[job?.id ?? ""] && data[job?.id ?? ""]["annotation"]) ?? JobAnnotation.NULL```.  The API returns `{}` when there is no annotation, so `data[job?.id ?? ""]` can be undefined.

### Testing 

* The classification feature is disabled when not logged in
* [PR 86615](https://torchci-git-fork-huydhn-fix-hud-annotation-fbopensource.vercel.app/pr/86615) loads without any issue
* [A sample commit](https://torchci-git-fork-huydhn-fix-hud-annotation-fbopensource.vercel.app/pytorch/pytorch/commit/8f2dda5bf2451765cebeb111a97be40f70c95989) loads without any issue