### PR TITLE
ci: Switch generic linux_job to use conda images

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -51,7 +51,7 @@ on:
 jobs:
   job:
     env:
-      DOCKER_IMAGE: pytorch/manylinux-builder:${{ inputs.gpu-arch-type }}${{ inputs.gpu-arch-version }}
+      DOCKER_IMAGE: pytorch/conda-builder:${{ inputs.gpu-arch-type }}${{ inputs.gpu-arch-version }}
       REPOSITORY: ${{ inputs.repository || github.repository }}
       SCRIPT: ${{ inputs.script }}
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -98,10 +98,13 @@ jobs:
       - name: Run script in container
         working-directory: ${{ inputs.repository }}
         run: |
-          echo "#!/usr/bin/env bash" > "${RUNNER_TEMP}/exec_script"
-          echo "set -eou pipefail" >> "${RUNNER_TEMP}/exec_script"
-          echo 'eval "$(conda shell.bash hook)"' >> "${RUNNER_TEMP}/exec_script"
-          echo "${SCRIPT}" >> "${RUNNER_TEMP}/exec_script"
+          {
+            echo "#!/usr/bin/env bash";
+            echo "set -eou pipefail";
+            # shellcheck disable=SC2016
+            echo 'eval "$(conda shell.bash hook)"';
+            echo "${SCRIPT}";
+          } > "${RUNNER_TEMP}/exec_script"
           chmod +x "${RUNNER_TEMP}/exec_script"
           # detached container should get cleaned up by teardown_ec2_linux
           # shellcheck disable=SC2086,SC2090

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -98,6 +98,9 @@ jobs:
       - name: Run script in container
         working-directory: ${{ inputs.repository }}
         run: |
+          echo "#!/usr/bin/env bash" > "${RUNNER_TEMP}/exec_script"
+          echo "set -eou pipefail" >> "${RUNNER_TEMP}/exec_script"
+          echo "conda init" >> "${RUNNER_TEMP}/exec_script"
           echo "${SCRIPT}" >> "${RUNNER_TEMP}/exec_script"
           chmod +x "${RUNNER_TEMP}/exec_script"
           # detached container should get cleaned up by teardown_ec2_linux

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           echo "#!/usr/bin/env bash" > "${RUNNER_TEMP}/exec_script"
           echo "set -eou pipefail" >> "${RUNNER_TEMP}/exec_script"
-          echo "eval \"$(conda shell.bash hook)\"" >> "${RUNNER_TEMP}/exec_script"
+          echo 'eval "$(conda shell.bash hook)"' >> "${RUNNER_TEMP}/exec_script"
           echo "${SCRIPT}" >> "${RUNNER_TEMP}/exec_script"
           chmod +x "${RUNNER_TEMP}/exec_script"
           # detached container should get cleaned up by teardown_ec2_linux

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           echo "#!/usr/bin/env bash" > "${RUNNER_TEMP}/exec_script"
           echo "set -eou pipefail" >> "${RUNNER_TEMP}/exec_script"
-          echo "conda init" >> "${RUNNER_TEMP}/exec_script"
+          echo "eval \"$(conda shell.bash hook)\"" >> "${RUNNER_TEMP}/exec_script"
           echo "${SCRIPT}" >> "${RUNNER_TEMP}/exec_script"
           chmod +x "${RUNNER_TEMP}/exec_script"
           # detached container should get cleaned up by teardown_ec2_linux

--- a/.github/workflows/test_linux_job.yml
+++ b/.github/workflows/test_linux_job.yml
@@ -17,7 +17,8 @@ jobs:
       gpu-arch-type: cpu
       gpu-arch-version: ""
       script: |
-        export PATH="/opt/python/cp38-cp38/bin:${PATH}"
+        conda create -y -n test python=3.8
+        conda activate test
         python3 -m pip install --extra-index-url https://download.pytorch.org/whl/nightly/cpu --pre torch
         # Can import pytorch
         python3 -c 'import torch'
@@ -31,7 +32,8 @@ jobs:
       gpu-arch-version: "11.6"
       timeout: 60
       script: |
-        export PATH="/opt/python/cp38-cp38/bin:${PATH}"
+        conda create -y -n test python=3.8
+        conda activate test
         python3 -m pip install --extra-index-url https://download.pytorch.org/whl/nightly/cu116 --pre torch
         # Can import pytorch, cuda is available
         python3 -c 'import torch;assert(torch.cuda.is_available())'


### PR DESCRIPTION
conda images are better since conda automatically comes with all of the python versions and people tend to like conda better for test environments

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>