### PR TITLE
Limit app access to just public repos

### DIFF
--- a/torchci/pages/api/auth/[...nextauth].js
+++ b/torchci/pages/api/auth/[...nextauth].js
@@ -6,7 +6,7 @@ export const authOptions = {
     GithubProvider({
       clientId: process.env.GITHUB_CLIENT_ID,
       clientSecret: process.env.GITHUB_CLIENT_SECRET,
-      authorization: { params: { scope: "repo" } },
+      authorization: { params: { scope: "public_repo" } },
     }),
   ],
   debug: process.env.NODE_ENV === "development",


### PR DESCRIPTION
We don't currently have any need to exposing access to private repos as well