### PR TITLE
Add a ciflow/inductor label

### DIFF
--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -139,6 +139,7 @@ async function handleLabelEvent(context: Context<"pull_request.labeled">) {
     "ciflow/periodic",
     "ciflow/android",
     "ciflow/binaries",
+    "ciflow/inductor",
     "ciflow/mps",
     "ciflow/nightly",
     "ciflow/binaries_conda",


### PR DESCRIPTION
Summary: The label will be used to trigger inductor tests on torchbench/huggingface/timm models