### PR TITLE
[Nova] Use the right runner depending on the GPU/CPU type of the build

### DIFF
--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -61,7 +61,7 @@ jobs:
       REF: ${{ inputs.ref }}
       CU_VERSION: ${{ matrix.desired_cuda }}
     name: ${{ matrix.build_name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.validation_runner }}
     container:
       image: ${{ matrix.container_image }}
     # If a build is taking longer than 60 minutes on these runners we need

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -62,7 +62,7 @@ jobs:
       REPOSITORY: ${{ inputs.repository }}
       REF: ${{ inputs.ref }}
     name: ${{ matrix.build_name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.validation_runner }}
     container:
       image: ${{ matrix.container_image }}
     # If a build is taking longer than 60 minutes on these runners we need


### PR DESCRIPTION
Ignore python 3.11 failures - these will be removed soon.