### PR TITLE
ci: Add linux.c5.4xlarge.ephemeral

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -51,6 +51,12 @@ runner_types:
     is_ephemeral: false
     max_available: 1000
     os: linux
+  linux.c5.4xlarge.ephemeral:
+    disk_size: 150
+    instance_type: c5.4xlarge
+    is_ephemeral: true
+    max_available: 1000
+    os: linux
   linux.4xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g3.4xlarge


### PR DESCRIPTION
Adds an ephemeral variant to our linux.4xlarge instances and also makes the name reflect the instance type used

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>