### PR TITLE
Increase max number of `linux.g5.4xlarge` to 30

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -83,7 +83,7 @@ runner_types:
   linux.g5.4xlarge.nvidia.gpu:
     instance_type: g5.4xlarge
     os: linux
-    max_available: 10
+    max_available: 50
     disk_size: 150
     is_ephemeral: true
   linux.large:

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -83,9 +83,9 @@ runner_types:
   linux.g5.4xlarge.nvidia.gpu:
     instance_type: g5.4xlarge
     os: linux
-    max_available: 50
+    max_available: 30
     disk_size: 150
-    is_ephemeral: true
+    is_ephemeral: false
   linux.large:
     disk_size: 15
     instance_type: c5.large


### PR DESCRIPTION
And make them non-ephemeral to have a more reliable testing for sm86