### PR TITLE
FIX: Don't remove EC2 instance when fails to remove githubRunner

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.test.ts
@@ -14,7 +14,6 @@ import {
   removeGithubRunnerRepo,
   resetGHRunnersCaches,
 } from './gh-runners';
-import { RunnerInfo } from './utils';
 import { createGithubAuth, createOctoClient } from './gh-auth';
 import { ScaleUpMetrics } from './metrics';
 
@@ -390,12 +389,6 @@ describe('listGithubRunners', () => {
 });
 
 describe('removeGithubRunnerRepo', () => {
-  const repo = { owner: 'owner', repo: 'repo' };
-  const irrelevantRunnerInfo: RunnerInfo = {
-    ...repo,
-    instanceId: '113',
-  };
-
   it('succeeds', async () => {
     const runnerId = 33;
     const repo = { owner: 'owner', repo: 'repo' };
@@ -419,16 +412,13 @@ describe('removeGithubRunnerRepo', () => {
     mockCreateOctoClient.mockReturnValueOnce(mockedOctokit as unknown as Octokit);
 
     resetGHRunnersCaches();
-    await removeGithubRunnerRepo(irrelevantRunnerInfo, runnerId, repo, metrics);
+    await removeGithubRunnerRepo(runnerId, repo, metrics);
 
     expect(mockedOctokit.actions.deleteSelfHostedRunnerFromRepo).toBeCalledWith({
       ...repo,
       runner_id: runnerId,
     });
     expect(getRepoInstallation).toBeCalled();
-    expect(mockEC2.terminateInstances).toBeCalledWith({
-      InstanceIds: [irrelevantRunnerInfo.instanceId],
-    });
   });
 
   it('fails', async () => {
@@ -454,23 +444,18 @@ describe('removeGithubRunnerRepo', () => {
     mockCreateOctoClient.mockReturnValueOnce(mockedOctokit as unknown as Octokit);
 
     resetGHRunnersCaches();
-    await removeGithubRunnerRepo(irrelevantRunnerInfo, runnerId, repo, metrics);
+    await expect(removeGithubRunnerRepo(runnerId, repo, metrics)).rejects.toThrow();
 
     expect(mockedOctokit.actions.deleteSelfHostedRunnerFromRepo).toBeCalledWith({
       ...repo,
       runner_id: runnerId,
     });
     expect(getRepoInstallation).toBeCalled();
-    expect(mockEC2.terminateInstances).not.toBeCalled();
   });
 });
 
 describe('removeGithubRunnerOrg', () => {
   const org = 'mockedOrg';
-  const irrelevantRunnerInfo: RunnerInfo = {
-    org: org,
-    instanceId: '113',
-  };
 
   it('succeeds', async () => {
     const runnerId = 33;
@@ -494,16 +479,13 @@ describe('removeGithubRunnerOrg', () => {
     mockCreateOctoClient.mockReturnValueOnce(mockedOctokit as unknown as Octokit);
 
     resetGHRunnersCaches();
-    await removeGithubRunnerOrg(irrelevantRunnerInfo, runnerId, org, metrics);
+    await removeGithubRunnerOrg(runnerId, org, metrics);
 
     expect(mockedOctokit.actions.deleteSelfHostedRunnerFromOrg).toBeCalledWith({
       org: org,
       runner_id: runnerId,
     });
     expect(getOrgInstallation).toBeCalled();
-    expect(mockEC2.terminateInstances).toBeCalledWith({
-      InstanceIds: [irrelevantRunnerInfo.instanceId],
-    });
   });
 
   it('fails', async () => {
@@ -528,14 +510,13 @@ describe('removeGithubRunnerOrg', () => {
     mockCreateOctoClient.mockReturnValueOnce(mockedOctokit as unknown as Octokit);
 
     resetGHRunnersCaches();
-    await removeGithubRunnerOrg(irrelevantRunnerInfo, runnerId, org, metrics);
+    await expect(removeGithubRunnerOrg(runnerId, org, metrics)).rejects.toThrow();
 
     expect(mockedOctokit.actions.deleteSelfHostedRunnerFromOrg).toBeCalledWith({
       org: org,
       runner_id: runnerId,
     });
     expect(getOrgInstallation).toBeCalled();
-    expect(mockEC2.terminateInstances).not.toBeCalled();
   });
 });
 

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/metrics.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/metrics.ts
@@ -692,6 +692,48 @@ export class ScaleDownMetrics extends Metrics {
   }
 
   /* istanbul ignore next */
+  runnerGhTerminateSuccessOrg(org: string, ec2runner: RunnerInfo) {
+    this.countEntry(`run.ghRunner.byOrg.${org}.terminate.success`);
+    this.countEntry(`run.ghRunner.byOrg.${org}.byType.${ec2runner.runnerType}.terminate.success`);
+    this.countEntry(`run.ghRunner.byType.${ec2runner.runnerType}.terminate.success`);
+  }
+
+  /* istanbul ignore next */
+  runnerGhTerminateSuccessRepo(repo: Repo, ec2runner: RunnerInfo) {
+    this.countEntry(`run.ghRunner.byRepo.${repo.owner}.${repo.repo}.terminate.success`);
+    this.countEntry(`run.ghRunner.byRepo.${repo.owner}.${repo.repo}.byType.${ec2runner.runnerType}.terminate.success`);
+    this.countEntry(`run.ghRunner.byType.${ec2runner.runnerType}.terminate.success`);
+  }
+
+  /* istanbul ignore next */
+  runnerGhTerminateFailureOrg(org: string, ec2runner: RunnerInfo) {
+    this.countEntry(`run.ghRunner.byOrg.${org}.terminate.failure`);
+    this.countEntry(`run.ghRunner.byOrg.${org}.byType.${ec2runner.runnerType}.terminate.failure`);
+    this.countEntry(`run.ghRunner.byType.${ec2runner.runnerType}.terminate.failure`);
+  }
+
+  /* istanbul ignore next */
+  runnerGhTerminateFailureRepo(repo: Repo, ec2runner: RunnerInfo) {
+    this.countEntry(`run.ghRunner.byRepo.${repo.owner}.${repo.repo}.terminate.failure`);
+    this.countEntry(`run.ghRunner.byRepo.${repo.owner}.${repo.repo}.byType.${ec2runner.runnerType}.terminate.failure`);
+    this.countEntry(`run.ghRunner.byType.${ec2runner.runnerType}.terminate.failure`);
+  }
+
+  /* istanbul ignore next */
+  runnerGhTerminateNotFoundOrg(org: string, ec2runner: RunnerInfo) {
+    this.countEntry(`run.ghRunner.byOrg.${org}.terminate.notfound`);
+    this.countEntry(`run.ghRunner.byOrg.${org}.byType.${ec2runner.runnerType}.terminate.notfound`);
+    this.countEntry(`run.ghRunner.byType.${ec2runner.runnerType}.terminate.notfound`);
+  }
+
+  /* istanbul ignore next */
+  runnerGhTerminateNotFoundRepo(repo: Repo, ec2runner: RunnerInfo) {
+    this.countEntry(`run.ghRunner.byRepo.${repo.owner}.${repo.repo}.terminate.notfound`);
+    this.countEntry(`run.ghRunner.byRepo.${repo.owner}.${repo.repo}.byType.${ec2runner.runnerType}.terminate.notfound`);
+    this.countEntry(`run.ghRunner.byType.${ec2runner.runnerType}.terminate.notfound`);
+  }
+
+  /* istanbul ignore next */
   runnerTerminateSuccess(ec2Runner: RunnerInfo) {
     this.countEntry('run.ec2Runners.terminate.success');
     this.countEntry(`run.ec2runners.${ec2Runner.runnerType}.terminate.success`);
@@ -722,6 +764,23 @@ export class ScaleDownMetrics extends Metrics {
       const repo = getRepo(ec2Runner.repo as string);
       this.countEntry(`run.ec2runners.${repo.owner}.${repo.repo}.${ec2Runner.runnerType}.terminate.failure`);
       this.countEntry(`run.ec2runners.${repo.owner}.${repo.repo}.terminate.failure`);
+    }
+  }
+
+  /* istanbul ignore next */
+  runnerTerminateSkipped(ec2Runner: RunnerInfo) {
+    this.countEntry('run.ec2Runners.terminate.skipped');
+    this.countEntry(`run.ec2runners.${ec2Runner.runnerType}.terminate.skipped`);
+
+    if (ec2Runner.org !== undefined) {
+      this.countEntry(`run.ec2runners.${ec2Runner.org}.${ec2Runner.runnerType}.terminate.skipped`);
+      this.countEntry(`run.ec2runners.${ec2Runner.org}.terminate.skipped`);
+    }
+
+    if (ec2Runner.repo !== undefined) {
+      const repo = getRepo(ec2Runner.repo as string);
+      this.countEntry(`run.ec2runners.${repo.owner}.${repo.repo}.${ec2Runner.runnerType}.terminate.skipped`);
+      this.countEntry(`run.ec2runners.${repo.owner}.${repo.repo}.terminate.skipped`);
     }
   }
 }

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
@@ -163,7 +163,7 @@ describe('scale-down', () => {
       mockRunner({ id: '0004', name: 'keep-this-is-busy-02', busy: true }),
       mockRunner({ id: '0005', name: 'keep-this-not-min-time-03', busy: false }),
       mockRunner({ id: '0006', name: 'keep-this-is-busy-03', busy: true }),
-      mockRunner({ id: '0007', name: 'remove-ephemeral-01', busy: false }),
+      mockRunner({ id: '0007', name: 'remove-ephemeral-01-fail-ghr', busy: false }),
       mockRunner({ id: '0008', name: 'keep-min-runners-not-oldest-01', busy: false }),
       mockRunner({ id: '0009', name: 'keep-min-runners-oldest-01', busy: false }),
       mockRunner({ id: '0010', name: 'keep-min-runners-not-oldest-02', busy: false }),
@@ -264,7 +264,7 @@ describe('scale-down', () => {
       },
       {
         runnerType: 'a-ephemeral-runner',
-        instanceId: 'remove-ephemeral-01', // X
+        instanceId: 'remove-ephemeral-01-fail-ghr', // X
         org: theOrg,
         launchTime: dateRef
           .clone()
@@ -380,6 +380,14 @@ describe('scale-down', () => {
       mockedListRunners.mockResolvedValueOnce(listRunnersRet);
       mockedListGithubRunnersOrg.mockResolvedValue(ghRunners);
       mockedGetRunnerTypes.mockResolvedValue(runnerTypes);
+      mockedRemoveGithubRunnerOrg.mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        async (runnerId: number, org: string, metrics: MetricsModule.Metrics) => {
+          if (runnerId == 7) {
+            throw 'Failure';
+          }
+        },
+      );
 
       await scaleDown();
 
@@ -395,46 +403,36 @@ describe('scale-down', () => {
       expect(mockedRemoveGithubRunnerOrg).toBeCalledTimes(3);
       {
         const { awsR, ghR } = getRunnerPair('keep-min-runners-oldest-02');
-        expect(mockedRemoveGithubRunnerOrg).toBeCalledWith(awsR, ghR.id, awsR.org as string, metrics);
+        expect(mockedRemoveGithubRunnerOrg).toBeCalledWith(ghR.id, awsR.org as string, metrics);
       }
       {
         const { awsR, ghR } = getRunnerPair('keep-min-runners-oldest-01');
-        expect(mockedRemoveGithubRunnerOrg).toBeCalledWith(awsR, ghR.id, awsR.org as string, metrics);
+        expect(mockedRemoveGithubRunnerOrg).toBeCalledWith(ghR.id, awsR.org as string, metrics);
       }
       {
-        const { awsR, ghR } = getRunnerPair('remove-ephemeral-01');
-        expect(mockedRemoveGithubRunnerOrg).toBeCalledWith(awsR, ghR.id, awsR.org as string, metrics);
+        const { awsR, ghR } = getRunnerPair('remove-ephemeral-01-fail-ghr');
+        expect(mockedRemoveGithubRunnerOrg).toBeCalledWith(ghR.id, awsR.org as string, metrics);
       }
 
-      expect(mockedTerminateRunner).toBeCalledTimes(6);
+      expect(mockedTerminateRunner).toBeCalledTimes(5);
       {
-        /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-        const { awsR, ghR } = getRunnerPair('keep-lt-min-no-ghrunner-no-ghr-02');
+        const { awsR } = getRunnerPair('keep-lt-min-no-ghrunner-no-ghr-02');
         expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
       }
       {
-        /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-        const { awsR, ghR } = getRunnerPair('keep-lt-min-no-ghrunner-no-ghr-01');
+        const { awsR } = getRunnerPair('keep-lt-min-no-ghrunner-no-ghr-01');
         expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
       }
       {
-        /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-        const { awsR, ghR } = getRunnerPair('keep-min-runners-oldest-02');
+        const { awsR } = getRunnerPair('keep-min-runners-oldest-02');
         expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
       }
       {
-        /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-        const { awsR, ghR } = getRunnerPair('keep-min-runners-oldest-01');
+        const { awsR } = getRunnerPair('keep-min-runners-oldest-01');
         expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
       }
       {
-        /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-        const { awsR, ghR } = getRunnerPair('remove-ephemeral-02');
-        expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
-      }
-      {
-        /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-        const { awsR, ghR } = getRunnerPair('remove-ephemeral-01');
+        const { awsR } = getRunnerPair('remove-ephemeral-02');
         expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
       }
     });
@@ -460,7 +458,7 @@ describe('scale-down', () => {
       mockRunner({ id: '0004', name: 'keep-this-is-busy-02', busy: true }),
       mockRunner({ id: '0005', name: 'keep-this-not-min-time-03', busy: false }),
       mockRunner({ id: '0006', name: 'keep-this-is-busy-03', busy: true }),
-      mockRunner({ id: '0007', name: 'remove-ephemeral-01', busy: false }),
+      mockRunner({ id: '0007', name: 'remove-ephemeral-01-fail-ghr', busy: false }),
       mockRunner({ id: '0008', name: 'keep-min-runners-not-oldest-01', busy: false }),
       mockRunner({ id: '0009', name: 'keep-min-runners-oldest-01', busy: false }),
       mockRunner({ id: '0010', name: 'keep-min-runners-not-oldest-02', busy: false }),
@@ -561,7 +559,7 @@ describe('scale-down', () => {
       },
       {
         runnerType: 'a-ephemeral-runner',
-        instanceId: 'remove-ephemeral-01', // X
+        instanceId: 'remove-ephemeral-01-fail-ghr', // X
         repo: theRepo,
         launchTime: dateRef
           .clone()
@@ -676,6 +674,14 @@ describe('scale-down', () => {
       mockedListRunners.mockResolvedValueOnce(listRunnersRet);
       mockedListGithubRunnersRepo.mockResolvedValue(ghRunners);
       mockedGetRunnerTypes.mockResolvedValue(runnerTypes);
+      mockedRemoveGithubRunnerRepo.mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        async (runnerId: number, repo: Repo, metrics: MetricsModule.Metrics) => {
+          if (runnerId == 7) {
+            throw 'Failure';
+          }
+        },
+      );
 
       await scaleDown();
 
@@ -690,47 +696,37 @@ describe('scale-down', () => {
 
       expect(mockedRemoveGithubRunnerRepo).toBeCalledTimes(3);
       {
-        const { awsR, ghR } = getRunnerPair('keep-min-runners-oldest-02');
-        expect(mockedRemoveGithubRunnerRepo).toBeCalledWith(awsR, ghR.id, repo, metrics);
+        const { ghR } = getRunnerPair('keep-min-runners-oldest-02');
+        expect(mockedRemoveGithubRunnerRepo).toBeCalledWith(ghR.id, repo, metrics);
       }
       {
-        const { awsR, ghR } = getRunnerPair('keep-min-runners-oldest-01');
-        expect(mockedRemoveGithubRunnerRepo).toBeCalledWith(awsR, ghR.id, repo, metrics);
+        const { ghR } = getRunnerPair('keep-min-runners-oldest-01');
+        expect(mockedRemoveGithubRunnerRepo).toBeCalledWith(ghR.id, repo, metrics);
       }
       {
-        const { awsR, ghR } = getRunnerPair('remove-ephemeral-01');
-        expect(mockedRemoveGithubRunnerRepo).toBeCalledWith(awsR, ghR.id, repo, metrics);
+        const { ghR } = getRunnerPair('remove-ephemeral-01-fail-ghr');
+        expect(mockedRemoveGithubRunnerRepo).toBeCalledWith(ghR.id, repo, metrics);
       }
 
-      expect(mockedTerminateRunner).toBeCalledTimes(6);
+      expect(mockedTerminateRunner).toBeCalledTimes(5);
       {
-        /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-        const { awsR, ghR } = getRunnerPair('keep-lt-min-no-ghrunner-no-ghr-02');
+        const { awsR } = getRunnerPair('keep-lt-min-no-ghrunner-no-ghr-02');
         expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
       }
       {
-        /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-        const { awsR, ghR } = getRunnerPair('keep-lt-min-no-ghrunner-no-ghr-01');
+        const { awsR } = getRunnerPair('keep-lt-min-no-ghrunner-no-ghr-01');
         expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
       }
       {
-        /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-        const { awsR, ghR } = getRunnerPair('keep-min-runners-oldest-02');
+        const { awsR } = getRunnerPair('keep-min-runners-oldest-02');
         expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
       }
       {
-        /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-        const { awsR, ghR } = getRunnerPair('keep-min-runners-oldest-01');
+        const { awsR } = getRunnerPair('keep-min-runners-oldest-01');
         expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
       }
       {
-        /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-        const { awsR, ghR } = getRunnerPair('remove-ephemeral-02');
-        expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
-      }
-      {
-        /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-        const { awsR, ghR } = getRunnerPair('remove-ephemeral-01');
+        const { awsR } = getRunnerPair('remove-ephemeral-02');
         expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
       }
     });

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -97,21 +97,22 @@ export async function scaleDown(): Promise<void> {
 
         removedRunners += 1;
 
+        // removeGithubRunner[Org || Repo] already call terminateRunner if successful
         if (ghRunner !== undefined) {
           if (Config.Instance.enableOrganizationRunners) {
             await removeGithubRunnerOrg(ec2runner, ghRunner.id, ec2runner.org as string, metrics);
           } else {
             await removeGithubRunnerRepo(ec2runner, ghRunner.id, getRepo(ec2runner.repo as string), metrics);
           }
-        }
-
-        console.info(`Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}] will be removed.`);
-        try {
-          await terminateRunner(ec2runner, metrics);
-          metrics.runnerTerminateSuccess(ec2runner);
-        } catch (e) {
-          metrics.runnerTerminateFailure(ec2runner);
-          console.error(`Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}] cannot be removed: ${e}`);
+        } else {
+          console.info(`Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}] will be removed.`);
+          try {
+            await terminateRunner(ec2runner, metrics);
+            metrics.runnerTerminateSuccess(ec2runner);
+          } catch (e) {
+            metrics.runnerTerminateFailure(ec2runner);
+            console.error(`Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}] cannot be removed: ${e}`);
+          }
         }
       }
     }

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -95,16 +95,61 @@ export async function scaleDown(): Promise<void> {
           break;
         }
 
-        removedRunners += 1;
-
-        // removeGithubRunner[Org || Repo] already call terminateRunner if successful
+        let shouldRemoveEC2 = true;
         if (ghRunner !== undefined) {
           if (Config.Instance.enableOrganizationRunners) {
-            await removeGithubRunnerOrg(ec2runner, ghRunner.id, ec2runner.org as string, metrics);
+            console.info(
+              `GH Runner instance '${ghRunner.id}'[${ec2runner.org}] for EC2 '${ec2runner.instanceId}' ` +
+                `[${ec2runner.runnerType}] will be removed.`,
+            );
+            try {
+              await removeGithubRunnerOrg(ghRunner.id, ec2runner.org as string, metrics);
+              metrics.runnerGhTerminateSuccessOrg(ec2runner.org as string, ec2runner);
+              console.info(
+                `GH Runner instance '${ghRunner.id}'[${ec2runner.org}] for EC2 '${ec2runner.instanceId}' ` +
+                  `[${ec2runner.runnerType}] successfuly removed.`,
+              );
+            } catch (e) {
+              console.warn(
+                `GH Runner instance '${ghRunner.id}'[${ec2runner.org}] for EC2 '${ec2runner.instanceId}' ` +
+                  `[${ec2runner.runnerType}] failed to be removed.`,
+              );
+              metrics.runnerGhTerminateFailureOrg(ec2runner.org as string, ec2runner);
+              shouldRemoveEC2 = false;
+            }
           } else {
-            await removeGithubRunnerRepo(ec2runner, ghRunner.id, getRepo(ec2runner.repo as string), metrics);
+            const repo = getRepo(ec2runner.repo as string);
+            console.info(
+              `GH Runner instance '${ghRunner.id}'[${ec2runner.repo}] for EC2 '${ec2runner.instanceId}' ` +
+                `[${ec2runner.runnerType}] will be removed.`,
+            );
+            try {
+              await removeGithubRunnerRepo(ghRunner.id, repo, metrics);
+              metrics.runnerGhTerminateSuccessRepo(repo, ec2runner);
+              console.info(
+                `GH Runner instance '${ghRunner.id}'[${ec2runner.repo}] for EC2 '${ec2runner.instanceId}' ` +
+                  `[${ec2runner.runnerType}] successfuly removed.`,
+              );
+            } catch (e) {
+              console.warn(
+                `GH Runner instance '${ghRunner.id}'[${ec2runner.repo}] for EC2 '${ec2runner.instanceId}' ` +
+                  `[${ec2runner.runnerType}] failed to be removed.`,
+              );
+              metrics.runnerGhTerminateFailureRepo(repo, ec2runner);
+              shouldRemoveEC2 = false;
+            }
           }
         } else {
+          if (Config.Instance.enableOrganizationRunners) {
+            metrics.runnerGhTerminateNotFoundOrg(ec2runner.org as string, ec2runner);
+          } else {
+            metrics.runnerGhTerminateFailureRepo(getRepo(ec2runner.repo as string), ec2runner);
+          }
+        }
+
+        if (shouldRemoveEC2) {
+          removedRunners += 1;
+
           console.info(`Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}] will be removed.`);
           try {
             await terminateRunner(ec2runner, metrics);
@@ -113,6 +158,8 @@ export async function scaleDown(): Promise<void> {
             metrics.runnerTerminateFailure(ec2runner);
             console.error(`Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}] cannot be removed: ${e}`);
           }
+        } else {
+          metrics.runnerTerminateSkipped(ec2runner);
         }
       }
     }

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -98,7 +98,7 @@ export async function scaleDown(): Promise<void> {
         let shouldRemoveEC2 = true;
         if (ghRunner !== undefined) {
           if (Config.Instance.enableOrganizationRunners) {
-            console.info(
+            console.debug(
               `GH Runner instance '${ghRunner.id}'[${ec2runner.org}] for EC2 '${ec2runner.instanceId}' ` +
                 `[${ec2runner.runnerType}] will be removed.`,
             );
@@ -112,14 +112,14 @@ export async function scaleDown(): Promise<void> {
             } catch (e) {
               console.warn(
                 `GH Runner instance '${ghRunner.id}'[${ec2runner.org}] for EC2 '${ec2runner.instanceId}' ` +
-                  `[${ec2runner.runnerType}] failed to be removed.`,
+                  `[${ec2runner.runnerType}] failed to be removed. ${e}`,
               );
               metrics.runnerGhTerminateFailureOrg(ec2runner.org as string, ec2runner);
               shouldRemoveEC2 = false;
             }
           } else {
             const repo = getRepo(ec2runner.repo as string);
-            console.info(
+            console.debug(
               `GH Runner instance '${ghRunner.id}'[${ec2runner.repo}] for EC2 '${ec2runner.instanceId}' ` +
                 `[${ec2runner.runnerType}] will be removed.`,
             );
@@ -133,7 +133,7 @@ export async function scaleDown(): Promise<void> {
             } catch (e) {
               console.warn(
                 `GH Runner instance '${ghRunner.id}'[${ec2runner.repo}] for EC2 '${ec2runner.instanceId}' ` +
-                  `[${ec2runner.runnerType}] failed to be removed.`,
+                  `[${ec2runner.runnerType}] failed to be removed. ${e}`,
               );
               metrics.runnerGhTerminateFailureRepo(repo, ec2runner);
               shouldRemoveEC2 = false;


### PR DESCRIPTION
`removeGithubRunner[Org || Repo]` used to remove the EC2 instance, so no need to call `terminateRunner` again. This potentially could cause runners that failed to be unregistered from GHA to be terminated on EC2.

As a fix, `removeGithubRunner` won't terminate the instance, nor generate logs. This will enable `scaleDown` to control when to call `terminateRunner` and generate the proper logs and metrics. Avoiding having this issue in the future.

This bug also explains why we had in the past more EC2 instances being kept at its minimum time: instances with less than minimum time got unregistered and terminated without being tracked on main application metric. This is obvious when we compare the API calls to terminate and the count of app level termination.

![Screenshot 2022-10-18 at 09 21 47](https://user-images.githubusercontent.com/4520845/196364535-5aaab331-2080-44be-b6af-0702f99d50d9.png)
![Screenshot 2022-10-18 at 09 26 19](https://user-images.githubusercontent.com/4520845/196364542-376ff99f-617e-4e82-b459-dfc8364219ad.png)

Bug initially flagged on [87134](https://github.com/pytorch/pytorch/issues/87134)