### PR TITLE
[Nova] Add windows smoke test script to test wheels workflow for audio

### DIFF
--- a/.github/workflows/build_conda_windows.yml
+++ b/.github/workflows/build_conda_windows.yml
@@ -106,8 +106,6 @@ jobs:
           export VSTOOLCHAIN_PACKAGE=vs2019
           export VSDEVCMD_ARGS=''
           source "${BUILD_ENV_FILE}"
-          export FFMPEG_ROOT="${PWD}"/third_party/ffmpeg
-          export USE_FFMPEG="1"
           ${CONDA_RUN} conda build \
             -c defaults \
             -c "${CUDATOOLKIT_CHANNEL}" \

--- a/.github/workflows/build_conda_windows.yml
+++ b/.github/workflows/build_conda_windows.yml
@@ -106,6 +106,8 @@ jobs:
           export VSTOOLCHAIN_PACKAGE=vs2019
           export VSDEVCMD_ARGS=''
           source "${BUILD_ENV_FILE}"
+          export FFMPEG_ROOT="${PWD}"/third_party/ffmpeg
+          export USE_FFMPEG="1"
           ${CONDA_RUN} conda build \
             -c defaults \
             -c "${CUDATOOLKIT_CHANNEL}" \

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -112,6 +112,8 @@ jobs:
           BUILD_PARAMS: ${{ inputs.wheel-build-params }}
         run: |
           source "${BUILD_ENV_FILE}"
+          set USE_FFMPEG="1"
+          set FFMPEG_ROOT="%cd%"/third_party/ffmpeg
           if [[ -z "${ENV_SCRIPT}" ]]; then
             ${CONDA_RUN} python setup.py bdist_wheel
           else

--- a/.github/workflows/test_build_wheels_windows.yml
+++ b/.github/workflows/test_build_wheels_windows.yml
@@ -28,7 +28,7 @@ jobs:
             env-script: packaging/vc_env_helper.bat
             wheel-build-params: "--plat-name win_amd64"
             post-script: ""
-            smoke-test-script: ""
+            smoke-test-script: test/smoke_test/smoke_test.py
             package-name: torchaudio
           - repository: pytorch/vision
             pre-script: ""


### PR DESCRIPTION
The actual smoke test script was not passed from the test workflow for windows wheels builds. Once it was, we found that the Stremreader import (the last import in the smoke tests) failed because the wheel is not built with FFMPEG support. We will need to add this support + any env var changes needed to let the installed wheel link to the FFMPEG library we built from source.