### PR TITLE
Adding with Python 3.11 option

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -52,8 +52,8 @@ CONDA_INSTALL_BASE = f"conda install {PACKAGES_TO_INSTALL_CONDA}"
 WHL_INSTALL_BASE = "pip3 install"
 DOWNLOAD_URL_BASE = "https://download.pytorch.org"
 
-CUDA_ENABLE = "enable"
-CUDA_DISABLE = "disable"
+ENABLE = "enable"
+DISABLE = "disable"
 
 def arch_type(arch_version: str) -> str:
     if arch_version in mod.CUDA_ARCHES:
@@ -170,12 +170,12 @@ def get_wheel_install_command(channel: str, gpu_arch_type: str, desired_cuda: st
     whl_install_command = f"{WHL_INSTALL_BASE} --pre {packages_to_install}" if channel == "nightly" else f"{WHL_INSTALL_BASE} {packages_to_install}"
     return f"{whl_install_command} --extra-index-url {get_base_download_url_for_repo('whl', channel, gpu_arch_type, desired_cuda)}"
 
-def generate_conda_matrix(os: str, channel: str, with_cuda: str) -> List[Dict[str, str]]:
+def generate_conda_matrix(os: str, channel: str, with_cuda: str, with_py311: str) -> List[Dict[str, str]]:
     ret: List[Dict[str, str]] = []
     arches = ["cpu"]
     python_versions = FULL_PYTHON_VERSIONS
 
-    if with_cuda == CUDA_ENABLE:
+    if with_cuda == ENABLE:
         if os == "linux":
             arches += mod.CUDA_ARCHES
         elif os == "windows":
@@ -216,6 +216,7 @@ def generate_libtorch_matrix(
     os: str,
     channel: str,
     with_cuda: str,
+    with_py311: str,
     abi_versions: Optional[List[str]] = None,
     arches: Optional[List[str]] = None,
     libtorch_variants: Optional[List[str]] = None,
@@ -229,7 +230,7 @@ def generate_libtorch_matrix(
     if arches is None:
         arches = ["cpu"]
 
-        if with_cuda == CUDA_ENABLE:
+        if with_cuda == ENABLE:
             if os == "linux":
                 arches += mod.CUDA_ARCHES
                 arches += ROCM_ARCHES
@@ -293,6 +294,7 @@ def generate_wheels_matrix(
     os: str,
     channel: str,
     with_cuda: str,
+    with_py311: str,
     arches: Optional[List[str]] = None,
     python_versions: Optional[List[str]] = None,
 ) -> List[Dict[str, str]]:
@@ -307,14 +309,14 @@ def generate_wheels_matrix(
     if os == "linux":
         # NOTE: We only build manywheel packages for linux
         package_type = "manywheel"
-        if channel != "release":
+        if with_py311 == ENABLE and channel != "release":
             python_versions += ["3.11"]
 
     if arches is None:
         # Define default compute archivectures
         arches = ["cpu"]
 
-        if with_cuda == CUDA_ENABLE:
+        if with_cuda == ENABLE:
             if os == "linux":
                 arches += mod.CUDA_ARCHES + ROCM_ARCHES
             elif os == "windows":
@@ -382,9 +384,17 @@ def main() -> None:
         "--with-cuda",
         help="Build with Cuda?",
         type=str,
-        choices=[CUDA_ENABLE, CUDA_DISABLE],
-        default=os.getenv("WITH_CUDA", CUDA_ENABLE),
+        choices=[ENABLE, DISABLE],
+        default=os.getenv("WITH_CUDA", ENABLE),
     )
+    parser.add_argument(
+        "--with-py311",
+        help="Include Python 3.11 builds",
+        type=str,
+        choices=[ENABLE, DISABLE],
+        default=os.getenv("WITH_PY311", DISABLE),
+    )
+
     options = parser.parse_args()
     includes = []
 
@@ -394,13 +404,15 @@ def main() -> None:
             includes.extend(
                 GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[options.package_type](options.operating_system,
                                                                            channel,
-                                                                           options.with_cuda)
+                                                                           options.with_cuda,
+                                                                           options.with_py311)
             )
     else:
         initialize_globals(options.channel)
         includes = GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[options.package_type](options.operating_system,
                                                                               options.channel,
-                                                                              options.with_cuda)
+                                                                              options.with_cuda,
+                                                                              options.with_py311)
 
     print(json.dumps({"include": includes}))
 


### PR DESCRIPTION
Adding with Python 3.11 option

Calling by default:
```
python generate_binary_build_matrix.py
{"include": [{"python_version": "3.7", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_7-cpu", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_7-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu116", "channel": "nightly"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_7-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly"}, {"python_version": "3.7", "gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "container_image": "pytorch/manylinux-builder:rocm5.1.1", "package_type": "manywheel", "build_name": "manywheel-py3_7-rocm5_1_1", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.1.1", "channel": "nightly"}, {"python_version": "3.7", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_7-rocm5_2", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly"}, {"python_version": "3.8", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_8-cpu", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_8-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu116", "channel": "nightly"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_8-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly"}, {"python_version": "3.8", "gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "container_image": "pytorch/manylinux-builder:rocm5.1.1", "package_type": "manywheel", "build_name": "manywheel-py3_8-rocm5_1_1", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.1.1", "channel": "nightly"}, {"python_version": "3.8", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_8-rocm5_2", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly"}, {"python_version": "3.9", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_9-cpu", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu116", "channel": "nightly"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly"}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "container_image": "pytorch/manylinux-builder:rocm5.1.1", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm5_1_1", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.1.1", "channel": "nightly"}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm5_2", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly"}, {"python_version": "3.10", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_10-cpu", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_10-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu116", "channel": "nightly"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_10-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly"}, {"python_version": "3.10", "gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "container_image": "pytorch/manylinux-builder:rocm5.1.1", "package_type": "manywheel", "build_name": "manywheel-py3_10-rocm5_1_1", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.1.1", "channel": "nightly"}, {"python_version": "3.10", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_10-rocm5_2", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly"}]}
```

Calling with Python 3.11:
```
python generate_binary_build_matrix.py  --with-py311 enable
{"include": [{"python_version": "3.7", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_7-cpu", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_7-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu116", "channel": "nightly"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_7-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly"}, {"python_version": "3.7", "gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "container_image": "pytorch/manylinux-builder:rocm5.1.1", "package_type": "manywheel", "build_name": "manywheel-py3_7-rocm5_1_1", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.1.1", "channel": "nightly"}, {"python_version": "3.7", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_7-rocm5_2", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly"}, {"python_version": "3.8", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_8-cpu", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_8-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu116", "channel": "nightly"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_8-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly"}, {"python_version": "3.8", "gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "container_image": "pytorch/manylinux-builder:rocm5.1.1", "package_type": "manywheel", "build_name": "manywheel-py3_8-rocm5_1_1", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.1.1", "channel": "nightly"}, {"python_version": "3.8", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_8-rocm5_2", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly"}, {"python_version": "3.9", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_9-cpu", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu116", "channel": "nightly"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly"}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "container_image": "pytorch/manylinux-builder:rocm5.1.1", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm5_1_1", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.1.1", "channel": "nightly"}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm5_2", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly"}, {"python_version": "3.10", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_10-cpu", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_10-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu116", "channel": "nightly"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_10-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly"}, {"python_version": "3.10", "gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "container_image": "pytorch/manylinux-builder:rocm5.1.1", "package_type": "manywheel", "build_name": "manywheel-py3_10-rocm5_1_1", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.1.1", "channel": "nightly"}, {"python_version": "3.10", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_10-rocm5_2", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly"}, {"python_version": "3.11", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_11-cpu", "validation_runner": "ubuntu-20.04", "installation": "pip3 install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly"}, {"python_version": "3.11", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_11-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu116", "channel": "nightly"}, {"python_version": "3.11", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_11-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly"}]}
```