### PR TITLE
Adds alert if the  flaky tests bot does not file issues for a long period

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.venv
 
 *.env
 *.zip

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -212,15 +212,12 @@ def generate_no_flaky_tests_issue() -> Any:
     issue[
         "title"
     ] = f"[Pytorch][Warning] No flaky test issues have been detected in the past {FLAKY_TESTS_SEARCH_PERIOD_DAYS} days!"
-    issue[
-        "body"
-    ] = (
-    f"No issues has been filed in the past {FLAKY_TESTS_SEARCH_PERIOD_DAYS} days for the repository {REPO_OWNER}/{TEST_INFRA_REPO_NAME}. \n"
-    "This can be an indication that the flaky test bot has stopped filing tests."
- )
+    issue["body"] = (
+        f"No issues has been filed in the past {FLAKY_TESTS_SEARCH_PERIOD_DAYS} days for the repository {REPO_OWNER}/{TEST_INFRA_REPO_NAME}. \n"
+        "This can be an indication that the flaky test bot has stopped filing tests."
+    )
     issue["labels"] = [NO_FLAKY_TESTS_LABEL]
 
-    print("Generating issue for no_flaky_tests!")
     return issue
 
 
@@ -373,10 +370,9 @@ def handle_flaky_tests_alert(existing_alerts: List[Dict]) -> Dict:
         )
         if num_issues_with_flaky_tests_lables == 0:
             return create_issue(generate_no_flaky_tests_issue())
-    
+
     print("No new alert for flaky tests bots.")
     return None
-
 
 
 def main():
@@ -385,9 +381,6 @@ def main():
 
     # Fetch alerts
     existing_alerts = fetch_alerts(TEST_INFRA_REPO_NAME, PYTORCH_ALERT_LABEL)
-    existing_no_flaky_tests_alerts = fetch_alerts(
-        TEST_INFRA_REPO_NAME, NO_FLAKY_TESTS_LABEL
-    )
 
     # Alerts should also be cleared if the current status of HUD is green
     if len(jobs_to_alert_on) == 0:
@@ -415,7 +408,11 @@ def main():
     else:
         create_issue(generate_failed_job_issue(jobs_to_alert_on))
 
+    existing_no_flaky_tests_alerts = fetch_alerts(
+        TEST_INFRA_REPO_NAME, NO_FLAKY_TESTS_LABEL
+    )
     handle_flaky_tests_alert(existing_no_flaky_tests_alerts)
+
 
 if __name__ == "__main__":
     main()

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -214,10 +214,10 @@ def generate_no_flaky_tests_issue() -> Any:
     ] = f"[Pytorch][Warning] No flaky test issues have been detected in the past {FLAKY_TESTS_SEARCH_PERIOD_DAYS} days!"
     issue[
         "body"
-    ] = f"No issues has been filed in the past {FLAKY_TESTS_SEARCH_PERIOD_DAYS} days for the repository {REPO_OWNER}/{TEST_INFRA_REPO_NAME}. \n"
-    issue[
-        "body"
-    ] += "This can be an indication that the flaky test bot has stopped filing tests."
+    ] = (
+    f"No issues has been filed in the past {FLAKY_TESTS_SEARCH_PERIOD_DAYS} days for the repository {REPO_OWNER}/{TEST_INFRA_REPO_NAME}. \n"
+    "This can be an indication that the flaky test bot has stopped filing tests."
+ )
     issue["labels"] = [NO_FLAKY_TESTS_LABEL]
 
     print("Generating issue for no_flaky_tests!")

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -213,7 +213,7 @@ def generate_no_flaky_tests_issue() -> Any:
         "title"
     ] = f"[Pytorch][Warning] No flaky test issues have been detected in the past {FLAKY_TESTS_SEARCH_PERIOD_DAYS} days!"
     issue["body"] = (
-        f"No issues has been filed in the past {FLAKY_TESTS_SEARCH_PERIOD_DAYS} days for the repository {REPO_OWNER}/{TEST_INFRA_REPO_NAME}. \n"
+        f"No issues have been filed in the past {FLAKY_TESTS_SEARCH_PERIOD_DAYS} days for the repository {REPO_OWNER}/{TEST_INFRA_REPO_NAME}. \n"
         "This can be an indication that the flaky test bot has stopped filing tests."
     )
     issue["labels"] = [NO_FLAKY_TESTS_LABEL]

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -211,7 +211,7 @@ def generate_no_flaky_tests_issue() -> Any:
     issue = {}
     issue[
         "title"
-    ] = f"[Pytorch][Warning] No flaky test issues has been detected in the past {FLAKY_TESTS_SEARCH_PERIOD_DAYS} days!"
+    ] = f"[Pytorch][Warning] No flaky test issues have been detected in the past {FLAKY_TESTS_SEARCH_PERIOD_DAYS} days!"
     issue[
         "body"
     ] = f"No issues has been filed in the past {FLAKY_TESTS_SEARCH_PERIOD_DAYS} days for the repository {REPO_OWNER}/{TEST_INFRA_REPO_NAME}. \n"


### PR DESCRIPTION
If for any reason the flaky tests bot breaks, no issues will be created to report flaky tests. This PR monitors the number of issues (in pytorch/pytorch repo) created in the past 14 days that contains label `module: flaky-tests`.  If no issues with the above conditions is found, a new issue is filed on the test infra repository.

See a sample issue here: https://github.com/pytorch/test-infra/issues/908
