### PR TITLE
Increase A10G runner max count to 100

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -83,7 +83,7 @@ runner_types:
   linux.g5.4xlarge.nvidia.gpu:
     instance_type: g5.4xlarge
     os: linux
-    max_available: 30
+    max_available: 100
     disk_size: 150
     is_ephemeral: false
   linux.large:


### PR DESCRIPTION
As those runners will be used by the following trunk job: https://github.com/pytorch/pytorch/pull/87228