### PR TITLE
ci: Add generic macos_job

### DIFF
--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -59,13 +59,12 @@ jobs:
       - name: Setup miniconda
         uses: ./test-infra/.github/actions/setup-miniconda
 
-    - name: Setup useful environment variables
-      shell: bash
-      working-directory: ${{ inputs.repository }}
-      run: |
-        RUNNER_ARTIFACT_DIR="${RUNNER_TEMP}/artifacts"
-        mkdir -p "${RUNNER_ARTIFACT_DIR}"
-        echo "RUNNER_ARTIFACT_DIR=${RUNNER_TEMP}/artifacts" >> "${GITHUB_ENV}"
+      - name: Setup useful environment variables
+        working-directory: ${{ inputs.repository }}
+        run: |
+          RUNNER_ARTIFACT_DIR="${RUNNER_TEMP}/artifacts"
+          mkdir -p "${RUNNER_ARTIFACT_DIR}"
+          echo "RUNNER_ARTIFACT_DIR=${RUNNER_TEMP}/artifacts" >> "${GITHUB_ENV}"
 
       - name: Checkout repository (${{ inputs.repository || github.repository }}@${{ inputs.ref }})
         uses: actions/checkout@v3

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -1,0 +1,124 @@
+name: Run a macOS job
+
+on:
+  workflow_call:
+    inputs:
+      script:
+        description: 'Script to utilize'
+        default: "python setup.py bdist_wheel"
+        type: string
+      timeout:
+        description: 'Timeout for the job (in minutes)'
+        default: 30
+        type: number
+      runner:
+        description: 'Runner type to utilize'
+        default: "macos-12"
+        type: string
+      upload-artifact:
+        description: 'Name to give artifacts uploaded from ${RUNNER_ARTIFACT_DIR}'
+        default: ''
+        type: string
+      download-artifact:
+        description: 'Name to download artifacts to ${RUNNER_ARTIFACT_DIR}'
+        default: ''
+        type: string
+      repository:
+        description: 'Repository to checkout, defaults to ""'
+        default: ""
+        type: string
+      ref:
+        description: 'Reference to checkout, defaults to "nightly"'
+        default: ""
+        type: string
+      test-infra-repository:
+        description: "Test infra repository to use"
+        default: "pytorch/test-infra"
+        type: string
+      test-infra-ref:
+        description: "Test infra reference to use"
+        default: ""
+        type: string
+
+jobs:
+  job:
+    env:
+      REPOSITORY: ${{ inputs.repository || github.repository }}
+      SCRIPT: ${{ inputs.script }}
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.timeout }}
+    steps:
+      - name: Checkout repository (${{ inputs.test-infra-repository }}@${{ inputs.test-infra-ref }})
+        uses: actions/checkout@v3
+        with:
+          # Support the use case where we need to checkout someone's fork
+          repository: ${{ inputs.test-infra-repository }}
+          ref: ${{ inputs.test-infra-ref }}
+          path: test-infra
+
+      - name: Setup miniconda
+        uses: ./test-infra/.github/actions/setup-miniconda
+
+    - name: Setup useful environment variables
+      shell: bash
+      working-directory: ${{ inputs.repository }}
+      run: |
+        RUNNER_ARTIFACT_DIR="${RUNNER_TEMP}/artifacts"
+        mkdir -p "${RUNNER_ARTIFACT_DIR}"
+        echo "RUNNER_ARTIFACT_DIR=${RUNNER_TEMP}/artifacts" >> "${GITHUB_ENV}"
+
+      - name: Checkout repository (${{ inputs.repository || github.repository }}@${{ inputs.ref }})
+        uses: actions/checkout@v3
+        with:
+          # Support the use case where we need to checkout someone's fork
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          path: ${{ inputs.repository || github.repository }}
+
+      - name: Download artifacts (if any)
+        uses: actions/download-artifact@v3
+        if: ${{ inputs.download-artifact != '' }}
+        with:
+          name: ${{ inputs.download-artifact }}
+          path: ${{ runner.temp }}/artifacts/
+
+      - name: Run script
+        shell: bash -l {0}
+        working-directory: ${{ inputs.repository }}
+        run: |
+          {
+            echo "#!/usr/bin/env bash";
+            echo "set -eou pipefail";
+            # Source conda so it's available to the script environment
+            echo 'eval "$(conda shell.bash hook)"';
+            echo "${SCRIPT}";
+          } > "${RUNNER_TEMP}/exec_script"
+          bash "${RUNNER_TEMP}/exec_script"
+
+      - name: Check if there are potential artifacts and move them to the correct artifact location
+        shell: bash -l {0}
+        working-directory: ${{ inputs.repository }}
+        id: check-artifacts
+        if: ${{ inputs.upload-artifact != '' }}
+        env:
+          UPLOAD_ARTIFACT_NAME: ${{ inputs.upload-artifact }}
+        run: |
+          # If the default execution path is followed then we should get a wheel in the dist/ folder
+          # attempt to just grab whatever is in there and scoop it all up
+          if find "dist/" -name "*.whl" >/dev/null 2>/dev/null; then
+            mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
+          fi
+          # Set to fail upload step if there are no files for upload and expected files for upload
+          echo '::set-output name=if-no-files-found::error'
+
+      - name: Upload artifacts to GitHub (if any)
+        uses: actions/upload-artifact@v3
+        if: ${{ inputs.upload-artifact != '' }}
+        with:
+          name: ${{ inputs.upload-artifact }}
+          path: ${{ runner.temp }}/artifacts/
+          if-no-files-found: ${{ steps.check-artifacts.outputs.if-no-files-found }}
+
+      - name: Teardown Windows
+        if: ${{ always() }}
+        uses: ./test-infra/.github/actions/teardown-windows

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -17,11 +17,11 @@ on:
         type: string
       upload-artifact:
         description: 'Name to give artifacts uploaded from ${RUNNER_ARTIFACT_DIR}'
-        default: ''
+        default: ""
         type: string
       download-artifact:
         description: 'Name to download artifacts to ${RUNNER_ARTIFACT_DIR}'
-        default: ''
+        default: ""
         type: string
       repository:
         description: 'Repository to checkout, defaults to ""'

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -117,7 +117,3 @@ jobs:
           name: ${{ inputs.upload-artifact }}
           path: ${{ runner.temp }}/artifacts/
           if-no-files-found: ${{ steps.check-artifacts.outputs.if-no-files-found }}
-
-      - name: Teardown Windows
-        if: ${{ always() }}
-        uses: ./test-infra/.github/actions/teardown-windows

--- a/.github/workflows/test_macos_job.yml
+++ b/.github/workflows/test_macos_job.yml
@@ -1,0 +1,56 @@
+name: Test build/test macos workflow
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/macos_job.yml
+      - .github/workflows/test_macos_job.yml
+  workflow_dispatch:
+
+jobs:
+  test-x86:
+    uses: ./.github/workflows/macos_job.yml
+    with:
+      runner: macos-12
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      gpu-arch-type: cpu
+      gpu-arch-version: ""
+      script: |
+        conda create -y -n test python=3.8
+        conda activate test
+        python3 -m pip install --extra-index-url https://download.pytorch.org/whl/nightly/cpu --pre torch
+        # Can import pytorch
+        python3 -c 'import torch'
+  test-m1:
+    uses: ./.github/workflows/macos_job.yml
+    with:
+      runner: macos-m1-12
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      timeout: 60
+      script: |
+        conda create -y -n test python=3.8
+        conda activate test
+        python3 -m pip install --extra-index-url https://download.pytorch.org/whl/nightly/cpu --pre torch
+        # Can import pytorch, cuda is available
+        python3 -c 'import torch;assert(torch.cuda.is_available())'
+  test-upload-artifact:
+    uses: ./.github/workflows/macos_job.yml
+    with:
+      runner: macos-12
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      upload-artifact: my-cool-artifact
+      script: |
+        echo "hello" > "${RUNNER_ARTIFACT_DIR}/cool_beans"
+  test-download-artifact:
+    needs: test-upload-artifact
+    uses: ./.github/workflows/macos_job.yml
+    with:
+      runner: macos-12
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      download-artifact: my-cool-artifact
+      script: |
+        grep  "hello" "${RUNNER_ARTIFACT_DIR}/cool_beans"

--- a/.github/workflows/test_macos_job.yml
+++ b/.github/workflows/test_macos_job.yml
@@ -32,11 +32,11 @@ jobs:
         conda activate test
         python3 -m pip install --extra-index-url https://download.pytorch.org/whl/nightly/cpu --pre torch
         # Can import pytorch, cuda is available
-        python3 -c 'import torch;assert(torch.cuda.is_available())'
+        python3 -c 'import torch'
   test-upload-artifact:
     uses: ./.github/workflows/macos_job.yml
     with:
-      runner: macos-12
+      runner: macos-m1-12
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       upload-artifact: my-cool-artifact
@@ -46,7 +46,7 @@ jobs:
     needs: test-upload-artifact
     uses: ./.github/workflows/macos_job.yml
     with:
-      runner: macos-12
+      runner: macos-m1-12
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       download-artifact: my-cool-artifact

--- a/.github/workflows/test_macos_job.yml
+++ b/.github/workflows/test_macos_job.yml
@@ -14,8 +14,6 @@ jobs:
       runner: macos-12
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
-      gpu-arch-type: cpu
-      gpu-arch-version: ""
       script: |
         conda create -y -n test python=3.8
         conda activate test


### PR DESCRIPTION
Adds a generic macOS job that users can use to write actions with similar to our generic linux_job

This PR also adds a testing workflow to validate that this generic workflow will work on both x86 as well as M1.

One major benefit of this workflow is that it utilizes our own `setup-miniconda` action which sets up a temporary conda install in `RUNNER_TEMP` pushes that version of conda into our path meaning that users of this script should never have access to a conda install that doesn't get deleted at the end of each run.

Another potential benefit / addition later on is to add the cleanup steps that we do for maintenance to this workflow so it'll get run on every subsequent run.

## Example Usage:

```yaml
name: Test build/test macos
on:
  pull_request:
  push:
    branches:
      - main

jobs:
  build-test:
    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
    with:
      script: |
        pip install -r requirements.txt
        python setup.py develop
        make test
```

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>