### PR TITLE
Use the correct github user id

### DIFF
--- a/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/[jobId]/[annotation].ts
+++ b/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/[jobId]/[annotation].ts
@@ -6,7 +6,7 @@ import { authOptions } from "pages/api/auth/[...nextauth]";
 // Get number by going to https://api.github.com/users/<username>
 // and copying the "id" field
 export const annotationEditAllowlist = new Set([
-  "34172846", // ZainRizvi
+  "4468967", // ZainRizvi
   "44682903", // clee2000
   "475357", // huydhn
   "420184", // kit1980


### PR DESCRIPTION
Old one was a copy/pasta error which resulted in me getting a 401 when I tried to categorize a failure on the HUD commit page

New ID can be verified by going to https://api.github.com/users/ZainRizvi and checking the id