### PR TITLE
Fix autoCC bot for pull request

### DIFF
--- a/torchci/lib/bot/autoCcBot.ts
+++ b/torchci/lib/bot/autoCcBot.ts
@@ -81,8 +81,7 @@ function myBot(app: Probot): void {
         if (payloadType === "issue") {
           await context.octokit.issues.update(context.issue({ body: newBody }));
         } else if (payloadType === "pull_request") {
-          // @ts-ignore
-          await context.octokit.pulls.update(context.issue({ body: newBody }));
+          await context.octokit.pulls.update(context.pullRequest({ body: newBody }));
         }
       } else {
         context.log("no action: no change from existing cc list on issue");

--- a/torchci/test/autoCcBot.test.ts
+++ b/torchci/test/autoCcBot.test.ts
@@ -115,9 +115,8 @@ Some header text
     payload["pull_request"]["body"] = "Arf arf";
 
     const scope = nock("https://api.github.com")
-      .patch("/repos/seemethere/test-repo/pulls/", (body: any) => {
+      .patch("/repos/seemethere/test-repo/pulls/20", (body: any) => {
         expect(body).toMatchObject({
-          issue_number: 20,
           body: "Arf arf\n\ncc @ezyang",
         });
         return true;


### PR DESCRIPTION
Looks like GH changed REST API for updating pull request, not it should
look as follows:
https://docs.github.com/en/rest/pulls/pulls#update-a-pull-request
