### PR TITLE
be: Get rid of deprecated set-output

### DIFF
--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -27,7 +27,9 @@ runs:
       - name: Get date
         id: get-date
         shell: bash
-        run: echo "::set-output name=today::$(/bin/date -u '+%Y%m%d')d"
+        run: |
+
+          echo "today=$(/bin/date -u '+%Y%m%d')d" >> "${GITHUB_OUTPUT}"
       - name: Setup miniconda cache
         id: miniconda-cache
         uses: actions/cache@v2

--- a/.github/workflows/generate_binary_build_matrix.yml
+++ b/.github/workflows/generate_binary_build_matrix.yml
@@ -62,7 +62,7 @@ jobs:
           set -eou pipefail
           MATRIX_BLOB="$(python3 tools/scripts/generate_binary_build_matrix.py)"
           echo "${MATRIX_BLOB}"
-          echo "::set-output name=matrix::${MATRIX_BLOB}"
+          echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.package-type }}-${{ inputs.os }}-${{ inputs.test-infra-repository }}-${{ inputs.test-infra-ref }}

--- a/.github/workflows/lambda-release-tag-runners.yml
+++ b/.github/workflows/lambda-release-tag-runners.yml
@@ -33,7 +33,8 @@ jobs:
           wait-interval: 30
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y%m%d-%H%M%S')"
+        run: |
+          echo "date=$(date +'%Y%m%d-%H%M%S')" >> "${GITHUB_OUTPUT}"
       - name: Tag snapshot
         uses: tvdias/github-tagger@v0.0.1
         env:

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -152,7 +152,7 @@ jobs:
             mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
           fi
           # Set to fail upload step if there are no files for upload and expected files for upload
-          echo '::set-output name=if-no-files-found::error'
+          echo 'if-no-files-found=error' >> "${GITHUB_OUTPUT}"
 
       - name: Upload artifacts to GitHub (if any)
         uses: actions/upload-artifact@v3

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -108,7 +108,7 @@ jobs:
             mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
           fi
           # Set to fail upload step if there are no files for upload and expected files for upload
-          echo '::set-output name=if-no-files-found::error'
+          echo 'if-no-files-found=error' >> "${GITHUB_OUTPUT}"
 
       - name: Upload artifacts to GitHub (if any)
         uses: actions/upload-artifact@v3

--- a/.github/workflows/revert-tracker.yml
+++ b/.github/workflows/revert-tracker.yml
@@ -25,7 +25,7 @@ jobs:
           cd test-infra
           python3 -m pip install rockset==0.8.3
           file=$(python3 -m torchci.scripts.reverts)
-          echo "::set-output name=revert_file::$file"
+          echo "revert_file=$file" >> "${GITHUB_OUTPUT}"
         env:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
 

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -107,7 +107,7 @@ jobs:
             mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
           fi
           # Set to fail upload step if there are no files for upload and expected files for upload
-          echo '::set-output name=if-no-files-found::error'
+          echo 'if-no-files-found=error' >> "${GITHUB_OUTPUT}"
 
       - name: Upload artifacts to GitHub (if any)
         uses: actions/upload-artifact@v3

--- a/aws/websites/metrics.pytorch.org/update_dashboards.py
+++ b/aws/websites/metrics.pytorch.org/update_dashboards.py
@@ -95,7 +95,9 @@ if __name__ == "__main__":
             os.remove(file["path"])
             updated = True
 
-    if updated:
-        print("::set-output name=UPDATED_DASHBOARDS::yes")
-    else:
-        print("::set-output name=UPDATED_DASHBOARDS::no")
+    # Open GITHUB_OUTPUT if available through CI, otherwise just write to stdout
+    with open(os.getenv("GITHUB_OUTPUT", "/dev/stdout"), "ab") as fp:
+        if updated:
+            print("UPDATED_DASHBOARDS=yes", file=fp)
+        else:
+            print("UPDATED_DASHBOARDS=no", file=fp)


### PR DESCRIPTION
set-output is set to be removed in the near future, see

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>