### PR TITLE
Fix .env.example template

### DIFF
--- a/torchci/.env.example
+++ b/torchci/.env.example
@@ -19,4 +19,5 @@ GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 AUTH_SECRET=
 JWT_SECRET=
-# NEXTAUTH_URL= # uncomment this line if you want to enter a custom url for the next-auth module
+# Custom url for the next-auth module
+NEXTAUTH_URL=http://localhost:3000

--- a/torchci/.env.example
+++ b/torchci/.env.example
@@ -19,4 +19,4 @@ GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 AUTH_SECRET=
 JWT_SECRET=
-NEXTAUTH_URL=
+# NEXTAUTH_URL= # uncomment this line if you want to enter a custom url for the next-auth module


### PR DESCRIPTION
If anyone moves an uncommented NEXTAUTH_URL= to their .env.local file without giving it a proper value, they'll get the below Invalid URL error.

Instead, keep it commented out unless it's actually being used

```
error - TypeError [ERR_INVALID_URL]: Invalid URL
TypeError [ERR_INVALID_URL]: Invalid URL
    at new NodeError (node:internal/errors:371:5)
    at onParseError (node:internal/url:552:9)
    at new URL (node:internal/url:628:5)
    at parseUrl (/Users/dberard/Documents/test-infra/torchci/node_modules/next-auth/utils/parse-url.js:17:16)
    at Object.<anonymous> (/Users/dberard/Documents/test-infra/torchci/node_modules/next-auth/react/index.js:70:34)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19) {
  input: '',
  code: 'ERR_INVALID_URL'
}
```