### PR TITLE
Make "Commits red on master by day" chart consistent

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -105,8 +105,11 @@ function MasterCommitRedPanel({ params }: { params: RocksetParam[] }) {
   }
 
   const options: EChartsOption = {
-    title: { text: "Commits red on master, by day" },
-    grid: { top: 48, right: 8, bottom: 24, left: 36 },
+    title: { 
+      text: "Commits red on master, by day", 
+      subtext: "Based on workflows which block viable/strict upgrade"
+    },
+    grid: { top: 60, right: 8, bottom: 24, left: 36 },
     dataset: { source: data },
     xAxis: { type: "category" },
     yAxis: {

--- a/torchci/rockset/metrics/__sql/master_commit_red.sql
+++ b/torchci/rockset/metrics/__sql/master_commit_red.sql
@@ -26,6 +26,11 @@ with commit_overall_conclusion as (
             WHERE
                 job.name != 'ciflow_should_run'
                 AND job.name != 'generate-test-matrix'
+          		AND ( -- Limit it to workflows which block viable/strict upgrades
+                  workflow.name in ('Lint', 'pull', 'trunk')
+                  OR workflow.name like 'linux-binary%'
+                  OR workflow.name like 'windows-binary%'
+                )
                 AND workflow.event != 'workflow_run' -- Filter out worflow_run-triggered jobs, which have nothing to do with the SHA
                 AND push.ref IN ('refs/heads/master', 'refs/heads/main')
                 AND push.repository.owner.name = 'pytorch'

--- a/torchci/rockset/metrics/__sql/master_commit_red.sql
+++ b/torchci/rockset/metrics/__sql/master_commit_red.sql
@@ -26,10 +26,11 @@ with commit_overall_conclusion as (
             WHERE
                 job.name != 'ciflow_should_run'
                 AND job.name != 'generate-test-matrix'
-          		AND ( -- Limit it to workflows which block viable/strict upgrades
-                  workflow.name in ('Lint', 'pull', 'trunk')
-                  OR workflow.name like 'linux-binary%'
-                  OR workflow.name like 'windows-binary%'
+                AND (
+                    -- Limit it to workflows which block viable/strict upgrades
+                    workflow.name in ('Lint', 'pull', 'trunk')
+                    OR workflow.name like 'linux-binary%'
+                    OR workflow.name like 'windows-binary%'
                 )
                 AND workflow.event != 'workflow_run' -- Filter out worflow_run-triggered jobs, which have nothing to do with the SHA
                 AND push.ref IN ('refs/heads/master', 'refs/heads/main')

--- a/torchci/rockset/metrics/master_commit_red.lambda.json
+++ b/torchci/rockset/metrics/master_commit_red.lambda.json
@@ -9,12 +9,12 @@
     {
       "name": "startTime",
       "type": "string",
-      "value": "2022-03-13T00:06:32.839Z"
+      "value": "2022-10-12T00:06:32.839Z"
     },
     {
       "name": "stopTime",
       "type": "string",
-      "value": "2022-03-21T00:06:32.839Z"
+      "value": "2022-10-21T00:06:32.839Z"
     },
     {
       "name": "timezone",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -32,7 +32,7 @@
     "last_successful_jobs": "814fb497003c9625",
     "last_successful_workflow": "5d22927dd0b0956b",
     "master_commit_red_avg": "a88bee94d93198ed",
-    "master_commit_red": "835b457c9482d640",
+    "master_commit_red": "4c39daa3ac2f30e4",
     "master_commit_red_percent": "65bc4585d9e42bb0",
     "master_jobs_red_avg": "e5cc28eb51fc9fe9",
     "master_jobs_red": "aa08fa7af455e1b9",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -32,7 +32,7 @@
     "last_successful_jobs": "814fb497003c9625",
     "last_successful_workflow": "5d22927dd0b0956b",
     "master_commit_red_avg": "a88bee94d93198ed",
-    "master_commit_red": "e4e5cb062864bf1f",
+    "master_commit_red": "835b457c9482d640",
     "master_commit_red_percent": "65bc4585d9e42bb0",
     "master_jobs_red_avg": "e5cc28eb51fc9fe9",
     "master_jobs_red": "aa08fa7af455e1b9",


### PR DESCRIPTION
Makes the `Commits red on master, by day` chart consistent with the other measurements of master redness, which are based on whether viable/strict upgrades are allowed (change rationale and impact described in https://github.com/pytorch/test-infra/pull/883)

Removing the invalid sources of redness results in a small but noticeable uptick in greenness

Old chart:
<img width="918" alt="image" src="https://user-images.githubusercontent.com/4468967/196765060-419a8b3c-3f95-49fa-827f-6d44fff98c0d.png">

New chart:
<img width="918" alt="image" src="https://user-images.githubusercontent.com/4468967/196765324-ea4ea073-0b85-4258-888d-5796028cc8c8.png">

