### PR TITLE
[hud] add page for flaky jobs

### DIFF
--- a/torchci/pages/flakyjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/flakyjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -1,0 +1,194 @@
+import useSWR from "swr";
+import _ from "lodash";
+import { Skeleton, Stack, Typography } from "@mui/material";
+import { useRouter } from "next/router";
+import { RocksetParam } from "lib/rockset";
+import { fetcher } from "lib/GeneralUtils";
+import React, { useState } from "react";
+import JobSummary from "components/JobSummary";
+import JobLinks from "components/JobLinks";
+import LogViewer from "components/LogViewer";
+import JobAnnotationToggle, {
+  JobAnnotation,
+} from "components/JobAnnotationToggle";
+import { JobData } from "lib/types";
+import { TimeRangePicker } from "pages/metrics";
+import dayjs from "dayjs";
+
+function CommitLink({ job }: { job: JobData }) {
+  return (
+    <span>
+      <a
+        target="_blank"
+        rel="noreferrer"
+        href={`/${job.repo}/commit/${job.sha}`}
+      >
+        Commit
+      </a>
+    </span>
+  );
+}
+
+function FlakyJob({
+  job,
+  classification,
+}: {
+  job: JobData;
+  classification: JobAnnotation;
+}) {
+  return (
+    <div style={{ padding: "10px" }}>
+      <li>
+        <JobSummary job={job} />
+        <div>
+          <CommitLink job={job} />
+          {" | "}
+          <JobLinks job={job} />
+        </div>
+        <div>
+          <JobAnnotationToggle job={job} annotation={classification} />
+        </div>
+        <LogViewer job={job} />
+      </li>
+    </div>
+  );
+}
+
+function FlakyJobs({
+  queryParams,
+  repoName,
+  repoOwner,
+}: {
+  queryParams: RocksetParam[];
+  repoName: string;
+  repoOwner: string;
+}) {
+  const url = `/api/query/commons/flaky_workflows_jobs?parameters=${encodeURIComponent(
+    JSON.stringify(queryParams)
+  )}`;
+
+  const { data: rerunJobs } = useSWR(url, fetcher, {
+    refreshInterval: 30 * 60 * 1000, // refresh every 5 minutes
+  });
+
+  const { data: annotatedJobs } = useSWR(
+    `/api/query/commons/annotated_flaky_jobs?parameters=${encodeURIComponent(
+      JSON.stringify(queryParams)
+    )}`,
+    fetcher,
+    {
+      refreshInterval: 30 * 60 * 1000, // refresh every 5 minutes
+    }
+  );
+
+  var allJobs = rerunJobs
+    ?.concat(annotatedJobs)
+    .reduce((map: any, job: JobData) => {
+      if (job && job.id) {
+        map[job.id] = job;
+      }
+      return map;
+    }, {});
+
+  const { data: annotations } = useSWR(
+    `/api/job_annotation/${repoOwner}/${repoName}/annotations/${encodeURIComponent(
+      JSON.stringify(Object.keys(allJobs ? allJobs : {}))
+    )}`,
+    fetcher,
+    {
+      refreshInterval: 30 * 60 * 1000, // refresh every 5 minutes
+    }
+  );
+
+  if (allJobs === undefined || annotations === undefined) {
+    return <Skeleton variant={"rectangular"} height={"100%"} />;
+  }
+
+  const groupedJobs = _.groupBy(_.sortBy(allJobs, ["jobName"]), (job) => {
+    return annotations[job.id.toString()]
+      ? annotations[job.id.toString()].annotation
+      : "Not Annotated";
+  });
+
+  return (
+    <>
+      {_.map(groupedJobs, (val, key) => (
+        <details open key={key}>
+          <summary
+            style={{
+              fontSize: "1em",
+              marginTop: "1.33em",
+              marginBottom: "1.33em",
+              fontWeight: "bold",
+            }}
+          >
+            {key} ({val.length})
+          </summary>
+          <ul>
+            {val.map((job: any) => (
+              <FlakyJob
+                key={job.id}
+                job={job}
+                classification={annotations?.[job.id]?.["annotation"] ?? "null"}
+              />
+            ))}
+          </ul>
+        </details>
+      ))}
+    </>
+  );
+}
+
+export default function Page() {
+  const router = useRouter();
+  const { repoName, repoOwner, branch } = router.query;
+  const [startTime, setStartTime] = useState(dayjs().subtract(1, "week"));
+  const [stopTime, setStopTime] = useState(dayjs());
+
+  const queryParams: RocksetParam[] = [
+    {
+      name: "startTime",
+      type: "string",
+      value: startTime,
+    },
+    {
+      name: "stopTime",
+      type: "string",
+      value: stopTime,
+    },
+    {
+      name: "repo",
+      type: "string",
+      value: `${repoOwner}/${repoName}`,
+    },
+    {
+      name: "branch",
+      type: "string",
+      value: `${branch}`,
+    },
+  ];
+
+  return (
+    <div>
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <Typography fontSize={"2rem"} fontWeight={"bold"}>
+          Flaky Jobs
+        </Typography>
+        <TimeRangePicker
+          startTime={startTime}
+          stopTime={stopTime}
+          setStartTime={setStartTime}
+          setStopTime={setStopTime}
+        />
+
+      </Stack>
+
+
+      <FlakyJobs
+        queryParams={queryParams}
+        repoName={repoName as string}
+        repoOwner={repoOwner as string}
+      />
+    </div>
+  );
+}

--- a/torchci/rockset/commons/__sql/annotated_flaky_jobs.sql
+++ b/torchci/rockset/commons/__sql/annotated_flaky_jobs.sql
@@ -1,0 +1,31 @@
+select
+    job.head_sha as sha,
+    CONCAT(w.name, ' / ', job.name) as jobName,
+    job.id,
+    job.conclusion,
+    job.html_url as htmlUrl,
+    CONCAT(
+        'https://ossci-raw-job-status.s3.amazonaws.com/log/',
+        CAST(job.id as string)
+    ) as logUrl,
+    DATE_DIFF(
+        'SECOND',
+        PARSE_TIMESTAMP_ISO8601(job.started_at),
+        PARSE_TIMESTAMP_ISO8601(job.completed_at)
+    ) as durationS,
+    w.repository.full_name as repo,
+    job.torchci_classification.line as failureLine,
+    job.torchci_classification.captures as failureCaptures,
+    job.torchci_classification.line_num as failureLineNumber,
+from
+    commons.job_annotation a
+    join commons.workflow_job job on job.id = a.jobID
+    join commons.workflow_run w on w.id = job.run_id
+    and w.head_repository.full_name = a.repo and a.repo = :repo
+where
+    a.annotation != 'BROKEN_TRUNK'
+    and w.head_branch = :branch
+    and job._event_time >= PARSE_DATETIME_ISO8601(:startTime)
+    and job._event_time < PARSE_DATETIME_ISO8601(:stopTime)
+order by
+    job._event_time

--- a/torchci/rockset/commons/__sql/flaky_workflows_jobs.sql
+++ b/torchci/rockset/commons/__sql/flaky_workflows_jobs.sql
@@ -6,7 +6,8 @@ with repeats as (
     from
         workflow_job j
     where
-        j._event_time > CURRENT_TIMESTAMP() - DAYS(7)
+        j._event_time >= PARSE_DATETIME_ISO8601(:startTime)
+        and j._event_time < PARSE_DATETIME_ISO8601(:stopTime)
         and j.run_attempt > 1
         and j.conclusion = 'success'
 ) -- When a first time contributor submits a PR, their workflow starts at "attempt 2" so we look for workflows that were repeated above and actually have a first attempt
@@ -32,7 +33,8 @@ select
 from
     workflow_job job
     inner join workflow_run w on w.id = job.run_id
-    inner join repeats on repeats.run_id = job.run_id and repeats.name = job.name
+    inner join repeats on repeats.run_id = job.run_id
+    and repeats.name = job.name
 where
     w.repository.full_name = :repo
     and job._event_time >= PARSE_DATETIME_ISO8601(:startTime)

--- a/torchci/rockset/commons/__sql/flaky_workflows_jobs.sql
+++ b/torchci/rockset/commons/__sql/flaky_workflows_jobs.sql
@@ -1,0 +1,46 @@
+-- Find workflows that succeeded once they were retried
+with repeats as (
+    select
+        j.run_id,
+        j.name
+    from
+        workflow_job j
+    where
+        j._event_time > CURRENT_TIMESTAMP() - DAYS(7)
+        and j.run_attempt > 1
+        and j.conclusion = 'success'
+) -- When a first time contributor submits a PR, their workflow starts at "attempt 2" so we look for workflows that were repeated above and actually have a first attempt
+select
+    job.head_sha as sha,
+    CONCAT(w.name, ' / ', job.name) as jobName,
+    job.id,
+    job.conclusion,
+    job.html_url as htmlUrl,
+    CONCAT(
+        'https://ossci-raw-job-status.s3.amazonaws.com/log/',
+        CAST(job.id as string)
+    ) as logUrl,
+    DATE_DIFF(
+        'SECOND',
+        PARSE_TIMESTAMP_ISO8601(job.started_at),
+        PARSE_TIMESTAMP_ISO8601(job.completed_at)
+    ) as durationS,
+    w.repository.full_name as repo,
+    job.torchci_classification.line as failureLine,
+    job.torchci_classification.captures as failureCaptures,
+    job.torchci_classification.line_num as failureLineNumber,
+from
+    workflow_job job
+    inner join workflow_run w on w.id = job.run_id
+    inner join repeats on repeats.run_id = job.run_id and repeats.name = job.name
+where
+    w.repository.full_name = :repo
+    and job._event_time >= PARSE_DATETIME_ISO8601(:startTime)
+    and job._event_time < PARSE_DATETIME_ISO8601(:stopTime)
+    and job.run_attempt = 1
+    and w.head_branch = :branch
+    and (
+        job.conclusion like 'fail%'
+        or job.conclusion = 'cancelled'
+        or job.conclusion = 'time_out'
+    )

--- a/torchci/rockset/commons/annotated_flaky_jobs.lambda.json
+++ b/torchci/rockset/commons/annotated_flaky_jobs.lambda.json
@@ -1,0 +1,26 @@
+{
+  "sql_path": "__sql/annotated_flaky_jobs.sql",
+  "default_parameters": [
+    {
+      "name": "branch",
+      "type": "string",
+      "value": "master"
+    },
+    {
+      "name": "repo",
+      "type": "string",
+      "value": "pytorch/pytorch"
+    },
+    {
+      "name": "startTime",
+      "type": "string",
+      "value": "2022-10-15T00:06:32.839Z"
+    },
+    {
+      "name": "stopTime",
+      "type": "string",
+      "value": "2022-10-19T00:06:32.839Z"
+    }
+  ],
+  "description": ""
+}

--- a/torchci/rockset/commons/flaky_workflows_jobs.lambda.json
+++ b/torchci/rockset/commons/flaky_workflows_jobs.lambda.json
@@ -1,0 +1,26 @@
+{
+  "sql_path": "__sql/flaky_workflows_jobs.sql",
+  "default_parameters": [
+    {
+      "name": "branch",
+      "type": "string",
+      "value": "master"
+    },
+    {
+      "name": "repo",
+      "type": "string",
+      "value": "pytorch/pytorch"
+    },
+    {
+      "name": "startTime",
+      "type": "string",
+      "value": "2022-10-15T00:06:32.839Z"
+    },
+    {
+      "name": "stopTime",
+      "type": "string",
+      "value": "2022-10-19T00:06:32.839Z"
+    }
+  ],
+  "description": ""
+}

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -1,8 +1,10 @@
 {
   "commons": {
+    "annotated_flaky_jobs": "1e7bd01a839ae4d1",
     "hud_query": "f5ebefcdd53b6ff5",
     "commit_jobs_query": "442a6f64bd44f351",
     "flaky_tests": "86bd9b8156c33dca",
+    "flaky_workflows_jobs": "5a4ed2c58d965f03",
     "slow_tests": "ef8d035d23aa8ab6",
     "test_time_per_file": "50cb3694334ed63a",
     "test_time_per_file_periodic_jobs": "39c105542e297c09",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -4,7 +4,7 @@
     "hud_query": "f5ebefcdd53b6ff5",
     "commit_jobs_query": "442a6f64bd44f351",
     "flaky_tests": "86bd9b8156c33dca",
-    "flaky_workflows_jobs": "5a4ed2c58d965f03",
+    "flaky_workflows_jobs": "8b16d1b8d733291d",
     "slow_tests": "ef8d035d23aa8ab6",
     "test_time_per_file": "50cb3694334ed63a",
     "test_time_per_file_periodic_jobs": "39c105542e297c09",


### PR DESCRIPTION
Add page for flaky jobs and sql queries.  Takes any job that has been rerun and went from red -> green and any joy that has been annotated as not broken trunk

<img width="1191" alt="image" src="https://user-images.githubusercontent.com/44682903/196768883-56372379-6932-48de-ac3c-3c59e2c4ea7c.png">