### PR TITLE
Raise priority of sig codes 

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -141,6 +141,14 @@ name = 'undefined reference linker error'
 pattern = 'undefined reference to .*'
 
 [[rule]]
+name = "Python Test SIG Code"
+pattern = '^.*(Received Signal: SIG.*)'
+
+[[rule]]
+name = "Any SIGKILL"
+pattern = 'SIGKILL'
+
+[[rule]]
 name = 'Python AttributeError'
 pattern = '^AttributeError: .*'
 
@@ -183,3 +191,7 @@ pattern = 'An unexpected error has occurred. Conda has prepared the above report
 [[rule]]
 name = 'GHA error'
 pattern = '^##\[error\](.*)'
+
+[[rule]]
+name = 'Pytest Failure from summary'
+pattern = '^[-:\.\d+Z\s]* (FAILED .*)'

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -191,7 +191,3 @@ pattern = 'An unexpected error has occurred. Conda has prepared the above report
 [[rule]]
 name = 'GHA error'
 pattern = '^##\[error\](.*)'
-
-[[rule]]
-name = 'Pytest Failure from summary'
-pattern = '^[-:\.\d+Z\s]* (FAILED .*)'

--- a/torchci/pages/api/classifier/rules.ts
+++ b/torchci/pages/api/classifier/rules.ts
@@ -180,7 +180,7 @@ export default async function handler(
         priority: 200,
       },
       {
-        name: "SIG Code",
+        name: "Python Test SIG Code",
         pattern: r`^.*Received Signal: SIG.*`,
         priority: 150,
       },
@@ -243,6 +243,11 @@ export default async function handler(
         name: "GHA error",
         pattern: r`^##\[error\](.*)`,
         priority: 94,
+      },
+      {
+        name: "pytest test failure from summary",
+        pattern: r`^FAILED .*`,
+        priority: 93,
       },
     ]);
 }

--- a/torchci/pages/api/classifier/rules.ts
+++ b/torchci/pages/api/classifier/rules.ts
@@ -180,16 +180,6 @@ export default async function handler(
         priority: 200,
       },
       {
-        name: "Python Test SIG Code",
-        pattern: r`^.*Received Signal: SIG.*`,
-        priority: 150,
-      },
-      {
-        name: "SIGKILL",
-        pattern: r`^.*SIGKILL.*`,
-        priority: 150,
-      },
-      {
         name: "Python AttributeError",
         pattern: r`^AttributeError: .*`,
         priority: 100,
@@ -243,11 +233,6 @@ export default async function handler(
         name: "GHA error",
         pattern: r`^##\[error\](.*)`,
         priority: 94,
-      },
-      {
-        name: "pytest test failure from summary",
-        pattern: r`^FAILED .*`,
-        priority: 93,
       },
     ]);
 }

--- a/torchci/pages/api/classifier/rules.ts
+++ b/torchci/pages/api/classifier/rules.ts
@@ -180,6 +180,16 @@ export default async function handler(
         priority: 200,
       },
       {
+        name: "SIG Code",
+        pattern: r`^.*Received Signal: SIG.*`,
+        priority: 150,
+      },
+      {
+        name: "SIGKILL",
+        pattern: r`^.*SIGKILL.*`,
+        priority: 150,
+      },
+      {
         name: "Python AttributeError",
         pattern: r`^AttributeError: .*`,
         priority: 100,


### PR DESCRIPTION
In the pytorch test logs, prioritize the tasks that fail with SIGKILL or any SIG*error

Also adding an extra rule which should capture the test from the summary line in pytest unit tests like the one below. The [job](https://github.com/pytorch/pytorch/actions/runs/3290106686/jobs/5422888053) for this failed with a test failure, but none of the capture rules matched the logs in this file: https://hud.pytorch.org/pytorch/pytorch/commit/c4cf701889864dceba779569ae642cf95932538a 

The matching string is fairly generic looking, so keeping it as the lowest priority rule for now

```
2022-10-20T14:33:19.0437877Z -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
2022-10-20T14:33:19.0438272Z - generated xml file: /var/lib/jenkins/workspace/test/test-reports/python-pytest/test_ops/test_ops-185b97efc20d0656.xml -
2022-10-20T14:33:19.0438437Z =========================== short test summary info ============================
2022-10-20T14:33:19.0438702Z FAILED test_ops.py::TestCommonCUDA::test_noncontiguous_samples_nn_functional_conv_transpose2d_cuda_float32
2022-10-20T14:33:19.0438871Z !!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
2022-10-20T14:33:19.0439091Z = 1 failed, 1152 passed, 810 skipped, 23 deselected, 10 xfailed, 1 warning, 2 rerun in 587.79s (0:09:47) =
2022-10-20T14:33:19.0439337Z If in CI, skip info is located in the xml test reports, please either go to s3 or the hud to download them
2022-10-20T14:33:19.0439670Z FINISHED PRINTING LOG FILE of test_ops (/var/lib/jenkins/workspace/test/test-reports/test_ops_fjrv5px6)
```