### PR TITLE
Increase max_available for linux.g5.4xlarge.nvidia.gpu runners

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -83,7 +83,7 @@ runner_types:
   linux.g5.4xlarge.nvidia.gpu:
     instance_type: g5.4xlarge
     os: linux
-    max_available: 100
+    max_available: 200
     disk_size: 150
     is_ephemeral: false
   linux.large:


### PR DESCRIPTION
![Screenshot 2022-10-20 at 19 56 48](https://user-images.githubusercontent.com/4520845/197023709-23c65e5b-bf79-407d-bd25-02295f74f27b.png)
