### PR TITLE
Replace array indexing

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -260,8 +260,8 @@ function myBot(app: Probot): void {
 
     // OpInfo related
     if (filesChanged.length === 1 &&
-        (filesChanged.at(0)?.includes("torch/testing/_internal/common_methods_invocations.py") ||
-        filesChanged.at(0)?.includes("torch/_torch_docs.py"))) {
+        (filesChanged[0].includes("torch/testing/_internal/common_methods_invocations.py") ||
+        filesChanged[0].includes("torch/_torch_docs.py"))) {
           return ["release notes: python_frontend", topic];
     }
 


### PR DESCRIPTION
The old version would result in:

`"Error","msg":"filesChanged.at is not a function"`

Seems like the original invocation feature is not supported on older versions of typescript