### PR TITLE
Add userbenchmark viewer

### DIFF
--- a/torchci/components/hud.module.css
+++ b/torchci/components/hud.module.css
@@ -91,3 +91,9 @@
   padding: 0px;
   padding-left: 4px;
 }
+
+.userbenchmarkTable {
+  border: 1px solid black;
+  border-collapse: collapse;
+  padding: 3px;
+}

--- a/torchci/pages/userbenchmark_view.tsx
+++ b/torchci/pages/userbenchmark_view.tsx
@@ -46,12 +46,12 @@ class UserbenchmarkResults extends React.Component {
         return (
             <thead>
                 <tr className={styles.userbenchmarkTable}>
-                    {headers.map((val, idx) => {
-                        return <th className={styles.userbenchmarkTable}>{val}</th>;
-                    })}
+                    {headers.map((val, idx) => (
+                        <th className={styles.userbenchmarkTable} key={idx}>{val}</th>
+                    ))}
                 </tr>
             </thead>
-        )
+        );
     }
 
     getRow(row, minSpeedup, maxSpeedup) {
@@ -78,13 +78,13 @@ class UserbenchmarkResults extends React.Component {
         return (
             <tbody>
                 <tr className={styles.userbenchmarkTable}>
-                    {row.slice(0, 3).map((val, idx) => {
-                        return <td className={styles.userbenchmarkTable}>{val}</td>;
-                    })}
+                    {row.slice(0, 3).map((val, idx) => (
+                        <td className={styles.userbenchmarkTable} key={idx}>{val}</td>
+                    ))}
                     {convertSpeedup(row[3])}
                 </tr>
             </tbody>
-        )
+        );
     }
 
     csvToTable(csvString) {
@@ -134,9 +134,9 @@ class UserbenchmarkResults extends React.Component {
                 <h1> Userbenchmark results from <span>{this.state.url}</span> </h1>
                 <p>
                     Userbenchmarks can be optionally run in the CI by adding
-                    "RUN_TORCHBENCH: [userbenchmark]" in the body of PRs in the
-                    pytorch repo, where [userbenchmark] should be replaced by
-                    one of the userbenchmark options, e.g. nvfuser. The CI job
+                    &quot;RUN_TORCHBENCH: [userbenchmark]&quot; in the body of PRs
+                    in the pytorch repo, where [userbenchmark] should be replaced
+                    by one of the userbenchmark options, e.g. nvfuser. The CI job
                     will generate a CSV of the results, showing result times
                     from the base revision as well as the PR revision. This
                     page displays the speedup/slowdown by comparing the base

--- a/torchci/pages/userbenchmark_view.tsx
+++ b/torchci/pages/userbenchmark_view.tsx
@@ -6,9 +6,10 @@ import React, { useState } from "react";
 import styles from "components/hud.module.css";
 
 const ROW_HEIGHT = 240;
-
-class UserbenchmarkResults extends React.Component {
-    constructor(props) {
+type UserbenchmarkProps = {};
+type UserbenchmarkState = {url: string | null, content: any};
+class UserbenchmarkResults extends React.Component<UserbenchmarkProps, UserbenchmarkState> {
+    constructor(props: UserbenchmarkProps) {
         super(props);
 
         this.state = {
@@ -24,29 +25,31 @@ class UserbenchmarkResults extends React.Component {
     //   1. Base revision latency
     //   2. PR revision latency
     //   3. Speedup from the PR revision
-    parseCsv(msg) {
-        let as_array = msg.split("\n").map(x => x.split(";"));
-        as_array = as_array.filter(subarray => subarray.length == 3);
+    parseCsv(msg: string) {
+        let as_array = msg.split("\n").map((x: any) => x.split(";"));
+        as_array = as_array.filter((subarray: any[]) => subarray.length == 3);
         as_array[0].push("Speedup");
         for (let i=1; i<as_array.length; ++i) {
             for (let j=1; j<=2; ++j) {
                 as_array[i][j] = parseFloat(as_array[i][j]);
             }
-            as_array[i].push(as_array[i][1] / as_array[i][2] - 1);
+            const base_value = as_array[i][1] as number;
+            const pr_value = as_array[i][2] as number;
+            as_array[i].push(base_value / pr_value - 1);
         }
         return as_array;
     }
 
-    getHeader(row) {
-        const metric_header = row[0];
-        const base_revision = row[1] + " (base)";
-        const change_revision = row[2] + " (change)";
-        const speedup_header = row[3];
+    getHeader(row: any[]) {
+        const metric_header = row[0] as string;
+        const base_revision = row[1] + " (base)" as string;
+        const change_revision = row[2] + " (change)" as string;
+        const speedup_header = row[3] as string;
         const headers = [metric_header, base_revision, change_revision, speedup_header]
         return (
             <thead>
                 <tr className={styles.userbenchmarkTable}>
-                    {headers.map((val, idx) => (
+                    {headers.map((val: string, idx: number) => (
                         <th className={styles.userbenchmarkTable} key={idx}>{val}</th>
                     ))}
                 </tr>
@@ -54,19 +57,19 @@ class UserbenchmarkResults extends React.Component {
         );
     }
 
-    getRow(row, minSpeedup, maxSpeedup) {
-        const convertSpeedup = (speedupRaw) => {
+    getRow(row: any[], minSpeedup: number, maxSpeedup: number) {
+        const convertSpeedup = (speedupRaw: number) => {
             if (typeof speedupRaw === 'number') {
                 const text = (speedupRaw * 100).toFixed(2) + '%';
                 // assign a color
                 let color = "rgb(255, 255, 255)";
                 if (speedupRaw >= 0) {
                     const ratio = speedupRaw / maxSpeedup;
-                    const otherColor = parseInt(255 * (1 - ratio)).toString();
+                    const otherColor = Math.floor(255 * (1 - ratio)).toString();
                     color = "rgb(" + otherColor + ", 255, " + otherColor + ")";
                 } else {
                     const ratio = speedupRaw / minSpeedup;
-                    const otherColor = parseInt(255 * (1 - ratio)).toString();
+                    const otherColor = Math.floor(255 * (1 - ratio)).toString();
                     color = "rgb(255, " + otherColor + ", " + otherColor + ")";
                 }
                 return <td style={{backgroundColor: color}} className={styles.userbenchmarkTable}>{text}</td>;
@@ -78,20 +81,20 @@ class UserbenchmarkResults extends React.Component {
         return (
             <tbody>
                 <tr className={styles.userbenchmarkTable}>
-                    {row.slice(0, 3).map((val, idx) => (
+                    {row.slice(0, 3).map((val: any, idx: number) => (
                         <td className={styles.userbenchmarkTable} key={idx}>{val}</td>
                     ))}
-                    {convertSpeedup(row[3])}
+                    {convertSpeedup(parseFloat(row[3]))}
                 </tr>
             </tbody>
         );
     }
 
-    csvToTable(csvString) {
+    csvToTable(csvString: string) {
         const data = this.parseCsv(csvString);
 
-        const minSpeedup = Math.min(...data.slice(1).map(subarr => subarr[3]), 0.0)
-        const maxSpeedup = Math.max(...data.slice(1).map(subarr => subarr[3]), 0.0)
+        const minSpeedup = Math.min(...data.slice(1).map((subarr: any[]) => subarr[3]), 0.0)
+        const maxSpeedup = Math.max(...data.slice(1).map((subarr: any[]) => subarr[3]), 0.0)
         return (
             <table className={styles.userbenchmarkTable}>
                 {this.getHeader(data[0])}
@@ -101,9 +104,9 @@ class UserbenchmarkResults extends React.Component {
     }
 
     componentDidMount() {
-        let url = null;
+        let url: string | null = null;
         if (typeof document !== 'undefined') {
-            const searchParams = (new URL(document.location)).searchParams;
+            const searchParams = (new URL(document.location.toString())).searchParams;
             if (!searchParams.has("url")) {
                 console.log("!has_url");
                 // setDataMessage("No URL provided (e.g. ?url=[...])")

--- a/torchci/pages/userbenchmark_view.tsx
+++ b/torchci/pages/userbenchmark_view.tsx
@@ -37,17 +37,21 @@ class UserbenchmarkResults extends React.Component<UserbenchmarkProps, Userbench
                             .map((x: any) => x.split(";"))
                             .filter((subarray: any[]) => subarray.length == 3);
         let result: UserbenchmarkRow[] = [];
+        const HEADER_COL: number = 0;
+        const METRIC_ROW: number = 0;
+        const BASE_VALUE_ROW: number = 0;
+        const PR_VALUE_ROW: number = 0;
         result.push({
-            metric_name: as_array[0][0],
-            base_value: as_array[0][1],
-            pr_value: as_array[0][2],
+            metric_name: as_array[HEADER_COL][METRIC_ROW],
+            base_value: as_array[HEADER_COL][BASE_VALUE_ROW],
+            pr_value: as_array[HEADER_COL][PR_VALUE_ROW],
             speedup: "Speedup",
         });
         for (let i=1; i<as_array.length; ++i) {
-            const base_value: number = parseFloat(as_array[i][1]);
-            const pr_value: number = parseFloat(as_array[i][2]);
+            const base_value: number = parseFloat(as_array[i][BASE_VALUE_ROW]);
+            const pr_value: number = parseFloat(as_array[i][PR_VALUE_ROW]);
             result.push({
-                metric_name: as_array[i][0],
+                metric_name: as_array[i][METRIC_ROW],
                 base_value: base_value,
                 pr_value: pr_value,
                 speedup: (base_value / pr_value - 1),

--- a/torchci/pages/userbenchmark_view.tsx
+++ b/torchci/pages/userbenchmark_view.tsx
@@ -1,0 +1,153 @@
+import { Grid } from "@mui/material";
+import TimeSeriesPanel from "components/metrics/panels/TimeSeriesPanel";
+import dayjs from "dayjs";
+import { RocksetParam } from "lib/rockset";
+import React, { useState } from "react";
+import styles from "components/hud.module.css";
+
+const ROW_HEIGHT = 240;
+
+class UserbenchmarkResults extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            url: null,
+            content: null,
+        };
+    }
+
+    // returns a list[list[data]]
+    // outer list: first a row of headers; and then rows of data.
+    // data order in the inner list:
+    //   0. Metric name
+    //   1. Base revision latency
+    //   2. PR revision latency
+    //   3. Speedup from the PR revision
+    parseCsv(msg) {
+        let as_array = msg.split("\n").map(x => x.split(";"));
+        as_array = as_array.filter(subarray => subarray.length == 3);
+        as_array[0].push("Speedup");
+        for (let i=1; i<as_array.length; ++i) {
+            for (let j=1; j<=2; ++j) {
+                as_array[i][j] = parseFloat(as_array[i][j]);
+            }
+            as_array[i].push(as_array[i][1] / as_array[i][2] - 1);
+        }
+        return as_array;
+    }
+
+    getHeader(row) {
+        const metric_header = row[0];
+        const base_revision = row[1] + " (base)";
+        const change_revision = row[2] + " (change)";
+        const speedup_header = row[3];
+        const headers = [metric_header, base_revision, change_revision, speedup_header]
+        return (
+            <thead>
+                <tr className={styles.userbenchmarkTable}>
+                    {headers.map((val, idx) => {
+                        return <th className={styles.userbenchmarkTable}>{val}</th>;
+                    })}
+                </tr>
+            </thead>
+        )
+    }
+
+    getRow(row, minSpeedup, maxSpeedup) {
+        const convertSpeedup = (speedupRaw) => {
+            if (typeof speedupRaw === 'number') {
+                const text = (speedupRaw * 100).toFixed(2) + '%';
+                // assign a color
+                let color = "rgb(255, 255, 255)";
+                if (speedupRaw >= 0) {
+                    const ratio = speedupRaw / maxSpeedup;
+                    const otherColor = parseInt(255 * (1 - ratio)).toString();
+                    color = "rgb(" + otherColor + ", 255, " + otherColor + ")";
+                } else {
+                    const ratio = speedupRaw / minSpeedup;
+                    const otherColor = parseInt(255 * (1 - ratio)).toString();
+                    color = "rgb(255, " + otherColor + ", " + otherColor + ")";
+                }
+                return <td style={{backgroundColor: color}} className={styles.userbenchmarkTable}>{text}</td>;
+            } else {
+                console.log("error out");
+                return <td className={styles.userbenchmarkTable}>{speedupRaw}</td>;
+            }
+        };
+        return (
+            <tbody>
+                <tr className={styles.userbenchmarkTable}>
+                    {row.slice(0, 3).map((val, idx) => {
+                        return <td className={styles.userbenchmarkTable}>{val}</td>;
+                    })}
+                    {convertSpeedup(row[3])}
+                </tr>
+            </tbody>
+        )
+    }
+
+    csvToTable(csvString) {
+        const data = this.parseCsv(csvString);
+
+        const minSpeedup = Math.min(...data.slice(1).map(subarr => subarr[3]), 0.0)
+        const maxSpeedup = Math.max(...data.slice(1).map(subarr => subarr[3]), 0.0)
+        return (
+            <table className={styles.userbenchmarkTable}>
+                {this.getHeader(data[0])}
+                {data.slice(1).map(row => this.getRow(row, minSpeedup, maxSpeedup))}
+            </table>
+        );
+    }
+
+    componentDidMount() {
+        let url = null;
+        if (typeof document !== 'undefined') {
+            const searchParams = (new URL(document.location)).searchParams;
+            if (!searchParams.has("url")) {
+                console.log("!has_url");
+                // setDataMessage("No URL provided (e.g. ?url=[...])")
+                return;
+            }
+            url = searchParams.get("url");
+        }
+
+
+        if (typeof url === 'string') {
+            console.log(url)
+            fetch(url)
+                .then((response) => {
+                    const text = response.text();
+                    return text;
+                }).then((response) => {
+                    this.setState({
+                        content: this.csvToTable(response),
+                        url: url,
+                    })
+                })
+        }
+    }
+
+    render() {
+        return (
+            <div>
+                <h1> Userbenchmark results from <span>{this.state.url}</span> </h1>
+                <p>
+                    Userbenchmarks can be optionally run in the CI by adding
+                    "RUN_TORCHBENCH: [userbenchmark]" in the body of PRs in the
+                    pytorch repo, where [userbenchmark] should be replaced by
+                    one of the userbenchmark options, e.g. nvfuser. The CI job
+                    will generate a CSV of the results, showing result times
+                    from the base revision as well as the PR revision. This
+                    page displays the speedup/slowdown by comparing the base
+                    and PR revision results.
+                </p>
+                <div> {this.state.content} </div>
+            </div>
+        )
+    }
+}
+
+export default function Userbenchmark() {
+    return <UserbenchmarkResults/>;
+}


### PR DESCRIPTION
Basic UI for viewing userbenchmark CSV results.

Usage: go to hud.pytorch.org/userbenchmark_view?url=[url]

where [url] is the path to the S3 csv, e.g.
```
https:%2F%2Fossci-metrics.s3.amazonaws.com%2Ftorchbench-pr-test%2Fpr84626%2Fresult.csv
```

These CSV results are generated on pytorch CI by the run_torchbench job, which runs if "RUN_TORCHBENCH: [userbenchmark name]" is added in the PR body. The userbenchmarks generate CSVs showing performance on a base revision and on the PR revision, for a number of metrics. The CSV is difficult to read on its own.

<img width="1497" alt="Screen Shot 2022-10-20 at 8 48 59 PM" src="https://user-images.githubusercontent.com/5067123/197235788-7d77029e-882a-4f14-a26a-31bd999b3951.png">
