### PR TITLE
Improve contrast

### DIFF
--- a/torchci/components/JobConclusion.module.css
+++ b/torchci/components/JobConclusion.module.css
@@ -5,7 +5,7 @@
 }
 
 .classified {
-  color: lightcoral;
+  color: lightpink;
 }
 
 .success {


### PR DESCRIPTION
Change the color of the red 'X's to have more contrast once a failure is classified. The old color change was subtle enough that it would sometimes be hard to tell if the color was different or not

Old:
<img width="1181" alt="image" src="https://user-images.githubusercontent.com/4468967/197276208-513d4636-d9b6-4329-a6fc-786183e03d78.png">

New:
<img width="1173" alt="image" src="https://user-images.githubusercontent.com/4468967/197276165-3da1e893-d86b-431e-8e7d-08dcb8f2f555.png">

