### PR TITLE
Fix runaway runner deletion on scale-down when API quota is hit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode
 .venv
+.idea
 
 *.env
 *.zip

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/package.json
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/package.json
@@ -34,6 +34,7 @@
     "@octokit/auth-app": "^3.0.0",
     "@octokit/rest": "^18.3.5",
     "@octokit/types": "^6.12.2",
+    "@octokit/request-error": "^2.1.0",
     "@types/aws-lambda": "^8.10.72",
     "@types/express": "^4.17.11",
     "@types/node": "^14.14.34",

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/yarn.lock
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/yarn.lock
@@ -600,6 +600,15 @@
     deprecation "^2.0.0"
     once "^1.4.0"
 
+"@octokit/request-error@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.1.0.tgz#9e150357831bfc788d13a4fd4b1913d60c74d677"
+  integrity sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
 "@octokit/request@^5.3.0", "@octokit/request@^5.4.11", "@octokit/request@^5.4.12":
   version "5.4.12"
   resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.12.tgz#b04826fa934670c56b135a81447be2c1723a2ffc"


### PR DESCRIPTION
Rethrow the octokit 'API rate limit exceeded' errors when fetching runner info on `scale-down` instead of consuming it.

Please see SEV  pytorch/pytorch#87500 for details.

Note: I've decided on the least invasive implementation (re-throwing only very specific class of exceptions) to avoid unintended side effects. Need to discuss with @jeanschmidt if all exceptions could be safely rethrown.

Testing:
* Unit tests