### PR TITLE
Fix env file and caching logic bugs in setup-miniconda

### DIFF
--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -83,7 +83,7 @@ runs:
           path: ${{ runner.temp }}/conda-python-${{ inputs.python-version }}
           key: miniconda-env-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}
       - name: Setup conda environment with python (v${{ inputs.python-version }})
-        if: (steps.miniconda-env-cache-env-file.outcome == 'success' && steps.miniconda-env-cache-env-file.outputs.cache-hit != 'true') || (steps.miniconda-env-cache.output == 'success' && steps.miniconda-env-cache.outputs.cache-hit != 'true')
+        if: (steps.miniconda-env-cache-env-file.outcome == 'success' && steps.miniconda-env-cache-env-file.outputs.cache-hit != 'true') || (steps.miniconda-env-cache.outcome == 'success' && steps.miniconda-env-cache.outputs.cache-hit != 'true')
         shell: bash
         env:
           PYTHON_VERSION: ${{ inputs.python-version }}

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -70,20 +70,20 @@ runs:
           echo "${MINICONDA_INSTALL_PATH}/bin" >> $GITHUB_PATH
       - name: Setup miniconda env cache (with env file)
         id: miniconda-env-cache-env-file
-        if: ${{ runner.os }} == 'macOS' && ${{ inputs.environment-file }} != ''
+        if: ${{ inputs.environment-file }} != ''
         uses: actions/cache@v2
         with:
           path: ${{ runner.temp }}/conda-python-${{ inputs.python-version }}
           key: miniconda-env-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}-${{ hashFiles(inputs.environment-file) }}
       - name: Setup miniconda env cache (without env file)
         id: miniconda-env-cache
-        if: ${{ runner.os }} == 'macOS' && ${{ inputs.environment-file }} == ''
+        if: ${{ inputs.environment-file }} == ''
         uses: actions/cache@v2
         with:
           path: ${{ runner.temp }}/conda-python-${{ inputs.python-version }}
           key: miniconda-env-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}
       - name: Setup conda environment with python (v${{ inputs.python-version }})
-        if: steps.miniconda-env-cache-env-file.outputs.cache-hit != 'true' && steps.miniconda-env-cache.outputs.cache-hit != 'true'
+        if: (steps.miniconda-env-cache-env-file.outcome == 'success' && steps.miniconda-env-cache-env-file.outputs.cache-hit != 'true') || (steps.miniconda-env-cache.output == 'success' && steps.miniconda-env-cache.outputs.cache-hit != 'true')
         shell: bash
         env:
           PYTHON_VERSION: ${{ inputs.python-version }}
@@ -99,8 +99,8 @@ runs:
           conda create \
             --yes \
             --prefix "${CONDA_BASE_ENV}" \
-            "python=${PYTHON_VERSION}" \
             ${ENV_FILE_FLAG} \
+            python="${PYTHON_VERSION}" \
             cmake=3.22 \
             conda-build=3.21 \
             ninja=1.10 \

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -28,14 +28,15 @@ runs:
         id: get-date
         shell: bash
         run: |
-
           echo "today=$(/bin/date -u '+%Y%m%d')d" >> "${GITHUB_OUTPUT}"
+
       - name: Setup miniconda cache
         id: miniconda-cache
         uses: actions/cache@v2
         with:
           path: ${{ runner.temp }}/miniconda
           key: miniconda-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}
+
       - name: Install miniconda (${{ inputs.miniconda-version }})
         if: steps.miniconda-cache.outputs.cache-hit != 'true'
         env:
@@ -63,25 +64,29 @@ runs:
           curl -fsSL "${MINICONDA_URL}" -o "${MINICONDA_INSTALL_PATH}/miniconda.sh"
           bash "${MINICONDA_INSTALL_PATH}/miniconda.sh" -b -u -p "${MINICONDA_INSTALL_PATH}"
           rm -rf "${MINICONDA_INSTALL_PATH}/miniconda.sh"
+
       - name: Update GitHub path to include miniconda install
         shell: bash
         run: |
           MINICONDA_INSTALL_PATH="${RUNNER_TEMP}/miniconda"
           echo "${MINICONDA_INSTALL_PATH}/bin" >> $GITHUB_PATH
+
       - name: Setup miniconda env cache (with env file)
         id: miniconda-env-cache-env-file
-        if: ${{ inputs.environment-file }} != ''
+        if: inputs.environment-file != ''
         uses: actions/cache@v2
         with:
           path: ${{ runner.temp }}/conda-python-${{ inputs.python-version }}
           key: miniconda-env-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}-${{ hashFiles(inputs.environment-file) }}
+
       - name: Setup miniconda env cache (without env file)
         id: miniconda-env-cache
-        if: ${{ inputs.environment-file }} == ''
+        if: inputs.environment-file == ''
         uses: actions/cache@v2
         with:
           path: ${{ runner.temp }}/conda-python-${{ inputs.python-version }}
           key: miniconda-env-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}
+
       - name: Setup conda environment with python (v${{ inputs.python-version }})
         if: (steps.miniconda-env-cache-env-file.outcome == 'success' && steps.miniconda-env-cache-env-file.outputs.cache-hit != 'true') || (steps.miniconda-env-cache.outcome == 'success' && steps.miniconda-env-cache.outputs.cache-hit != 'true')
         shell: bash
@@ -106,6 +111,7 @@ runs:
             ninja=1.10 \
             pkg-config=0.29 \
             wheel=0.37
+
       - name: Clone the base conda environment and update GitHub env
         shell: bash
         env:
@@ -126,6 +132,7 @@ runs:
           echo "CONDA_RUN=conda run -p ${CONDA_ENV} --no-capture-output" >> "${GITHUB_ENV}"
           echo "CONDA_BUILD=conda run -p ${CONDA_ENV} conda-build" >> "${GITHUB_ENV}"
           echo "CONDA_INSTALL=conda install -p ${CONDA_ENV}" >> "${GITHUB_ENV}"
+
       - name: Get disk space usage and throw an error for low disk space
         shell: bash
         run: |

--- a/.github/workflows/test-setup-miniconda-env-file
+++ b/.github/workflows/test-setup-miniconda-env-file
@@ -1,0 +1,2 @@
+# Just a dummy file to test miniconda setup
+ninja

--- a/.github/workflows/test-setup-miniconda.yml
+++ b/.github/workflows/test-setup-miniconda.yml
@@ -27,6 +27,9 @@ jobs:
             python-version: "3.8"
           - runner-type: linux.2xlarge
             python-version: "3.8"
+        env-file:
+          - ""
+          - "./.github/workflows/test-setup-miniconda-env-file"
     name: ${{ matrix.runner-type }}-py${{ matrix.python-version }}
     runs-on: ${{ matrix.runner-type }}
     # If a build is taking longer than 60 minutes on these runners we need
@@ -36,17 +39,22 @@ jobs:
       PYTHON_VERSION: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
+
       - name: Test that setup-miniconda works
         uses: ./.github/actions/setup-miniconda
         with:
           python-version: ${{ matrix.python-version }}
+          environment-file: ${{ matrix.env-file }}
+
       - name: Can use ${CONDA_RUN}, outputs correct python version
         run: |
           ${CONDA_RUN} python --version
           ${CONDA_RUN} python --version | grep "${PYTHON_VERSION}"
+
       - name: Can use ${CONDA_INSTALL}, installs some conda packages
         run: |
           ${CONDA_INSTALL} numpy cmake cffi ninja typing_extensions dataclasses pip
+
       - name: Can use ${CONDA_BUILD}, outputs correct version
         run: |
           ${CONDA_BUILD} --version


### PR DESCRIPTION
There are several bugs in setup-miniconda:

* `--file` flag is at the wrong position and it should come before the list of package. Specifically, `conda create --yes --prefix ~/debug/conda-python-3.9 --file FILENAME python=3.9 cmake=3.22` works while `conda create --yes --prefix ~/debug/conda-python-3.9 python=3.9 --file FILENAME cmake=3.22` as it stands right now doesn't and ends up with `unrecognized arguments: cmake=3.22` error
* The syntax `if: ${{ inputs.environment-file }} == 'SOME STRING'` is wrong and will always evaluate to true. The correct way is `if: inputs.environment-file == 'SOME STRING'`. I missed this subtlety
* The cache should be refreshed when either of `miniconda-env-cache-env-file` or `miniconda-env-cache` has cache miss. At the moment, it requires both have a cache miss, which is wrong because only one is used at a time (Although the cache is refreshed daily anyway)
* Also removing the redundant `runner.os` check for macOS because this works for Linux too
* Wrong test workflow filename `test-setup-minconda.yml`

All these issues are discovered when I try to run the job with `environment-file` parameter set.  AFAIK, we don't have any use case using this parameter thus far, so they were missed

### Testing
https://github.com/pytorch/pytorch/pull/87541