### PR TITLE
change to test times per file query

### DIFF
--- a/torchci/rockset/commons/__sql/test_time_per_file.sql
+++ b/torchci/rockset/commons/__sql/test_time_per_file.sql
@@ -20,7 +20,8 @@ WITH most_recent_strict_commits AS (
 job AS (
     SELECT
         j.name,
-        j.id
+        j.id,
+  		j.run_id
     FROM
         commons.workflow_job j
         INNER JOIN workflow w on w.id = j.run_id
@@ -28,9 +29,9 @@ job AS (
 file_duration_per_job AS (
     SELECT
         test_run.invoking_file as file,
-        job.name,
         SUM(time) as time,
-        job.id
+        REGEXP_EXTRACT(job.name, '^(.*) /', 1) as base_name,
+        REGEXP_EXTRACT(job.name, '/ test \((\w*),', 1) as test_config,
     FROM
         commons.test_run_summary test_run
         /* `test_run` is ginormous and `job` is small, so lookup join is essential */
@@ -41,19 +42,21 @@ file_duration_per_job AS (
         test_run.file IS NOT NULL
     GROUP BY
         test_run.invoking_file,
-        job.name,
-        job.id
+        base_name,
+  		test_config,
+  		job.run_id
 )
 SELECT
     REPLACE(file, '.', '/') AS file,
-    REGEXP_EXTRACT(name, '^(.*) /', 1) as base_name,
-    REGEXP_EXTRACT(name, '/ test \((\w*),', 1) as test_config,
+    base_name,
+    test_config,
     AVG(time) as time
 FROM
     file_duration_per_job
 GROUP BY
     file,
-    name
+    base_name,
+    test_config
 ORDER BY
     base_name,
     test_config,

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -6,7 +6,7 @@
     "flaky_tests": "86bd9b8156c33dca",
     "flaky_workflows_jobs": "8b16d1b8d733291d",
     "slow_tests": "ef8d035d23aa8ab6",
-    "test_time_per_file": "50cb3694334ed63a",
+    "test_time_per_file": "1c8d6289623181d8",
     "test_time_per_file_periodic_jobs": "39c105542e297c09",
     "issue_query": "5d4dfeb992e2f29b",
     "failure_samples_query": "ab2b589414b966a8",


### PR DESCRIPTION
Change test_times_per_file query to account for how test_distributed_spawn is split up among different shards now

The previous query caused test_distributed_spawn to show up 3 times in the end result, this query changes it so that the times are summed across shards and then averaged to get the total time