### PR TITLE
userbenchmark_view - fix column indices

### DIFF
--- a/torchci/pages/userbenchmark_view.tsx
+++ b/torchci/pages/userbenchmark_view.tsx
@@ -112,7 +112,6 @@ class UserbenchmarkResults extends React.Component<UserbenchmarkProps, Userbench
 
     csvToTable(csvString: string) {
         const data = this.parseCsv(csvString);
-        console.log(data);
 
         const minSpeedup = Math.min(
             0.0,
@@ -143,7 +142,6 @@ class UserbenchmarkResults extends React.Component<UserbenchmarkProps, Userbench
 
 
         if (typeof url === 'string') {
-            console.log(url)
             fetch(url)
                 .then((response) => {
                     const text = response.text();

--- a/torchci/pages/userbenchmark_view.tsx
+++ b/torchci/pages/userbenchmark_view.tsx
@@ -39,8 +39,8 @@ class UserbenchmarkResults extends React.Component<UserbenchmarkProps, Userbench
         let result: UserbenchmarkRow[] = [];
         const HEADER_COL: number = 0;
         const METRIC_ROW: number = 0;
-        const BASE_VALUE_ROW: number = 0;
-        const PR_VALUE_ROW: number = 0;
+        const BASE_VALUE_ROW: number = 1;
+        const PR_VALUE_ROW: number = 2;
         result.push({
             metric_name: as_array[HEADER_COL][METRIC_ROW],
             base_value: as_array[HEADER_COL][BASE_VALUE_ROW],
@@ -112,6 +112,7 @@ class UserbenchmarkResults extends React.Component<UserbenchmarkProps, Userbench
 
     csvToTable(csvString: string) {
         const data = this.parseCsv(csvString);
+        console.log(data);
 
         const minSpeedup = Math.min(
             0.0,


### PR DESCRIPTION
All indices were set to 0 before. Updated them to their correct values.

I was probably running `yarn dev` in the wrong directory last time which would have been why I didn't catch this.

<img width="945" alt="Screen Shot 2022-10-25 at 11 13 07 AM" src="https://user-images.githubusercontent.com/5067123/197850789-28cff5a5-5985-49f6-95fa-1112d749ad1e.png">
