### PR TITLE
Add functorch docs when checking for last doc push

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -635,7 +635,7 @@ export default function Page() {
                   name: "jobNames",
                   type: "string",
                   value:
-                    "docs push / build-docs (python, 30);docs push / build-docs (cpp, 180)",
+                    "docs push / build-docs (python, linux.2xlarge, 30);docs push / build-docs (cpp, linux.12xlarge, 180);docs push / build-docs (functorch, linux.2xlarge, 15)",
                 },
               ]}
               badThreshold={(value) => value > 3 * 24 * 60 * 60} // 3 day


### PR DESCRIPTION
This also uses the correct name for python and cpp docs. With the incorrect names, HUD couldn't find the jobs and reports the wrong last docs push status even though doc build jobs are ok now.

The Rockset query uses exact string matching for job names `AND ARRAY_CONTAINS(SPLIT(:jobNames, ';'), job.name)`.