### PR TITLE
Fix regex for detecting revert type

### DIFF
--- a/torchci/rockset/commons/__sql/reverted_prs_with_reason.sql
+++ b/torchci/rockset/commons/__sql/reverted_prs_with_reason.sql
@@ -1,7 +1,7 @@
 SELECT 
     ic._event_time revert_time,
 	ic.user.login as reverter,
-    REGEXP_EXTRACT(ic.body, '(-c|--classification)[\s =]+"?(\w+)"?', 2) as code,
+    REGEXP_EXTRACT(ic.body, '(-c|--classification)[\s =]+["'']?(\w+)["'']?', 2) as code,
     REGEXP_EXTRACT(ic.body, '(-m|--message)[\s =]+["'']?([^"'']+)["'']?', 2) as message,
     ic.html_url as comment_url
 FROM commons.issue_comment AS ic

--- a/torchci/rockset/commons/reverted_prs_with_reason.lambda.json
+++ b/torchci/rockset/commons/reverted_prs_with_reason.lambda.json
@@ -4,12 +4,12 @@
     {
       "name": "startTime",
       "type": "string",
-      "value": "2022-07-25T00:06:32.839Z"
+      "value": "2022-10-17T00:06:32.839Z"
     },
     {
       "name": "stopTime",
       "type": "string",
-      "value": "2022-08-01T00:06:32.839Z"
+      "value": "2022-10-24T00:06:32.839Z"
     }
   ],
   "description": "Displays the PRs that were reverted and their classifications"

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -11,7 +11,7 @@
     "issue_query": "5d4dfeb992e2f29b",
     "failure_samples_query": "ab2b589414b966a8",
     "recent_pr_workflows_query": "7486549578f7a837",
-    "reverted_prs_with_reason": "bf2b0607bddcc552",
+    "reverted_prs_with_reason": "65117d657817418b",
     "unclassified": "1b31a2d8f4ab7230",
     "test_insights_overview": "c9be5cbdda1030af",
     "test_insights_latest_runs": "949f5e49f76bfdd4"


### PR DESCRIPTION
Fix a bug where the revert tracker doesn't detect the revert type if single quotes are used instead of double quotes, even though that's a valid input

Example of a command it currently fails to detect: `@pytorchbot revert -m "This caused. a failure" -c 'landrace'`
