### PR TITLE
Don't let digits get cutoff the "Number of tests run" chart

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -782,7 +782,7 @@ export default function Page() {
             groupByFieldName={"workflow_name"}
             timeFieldName={"push_event_time"}
             yAxisFieldName={"avg_num_tests"}
-            yAxisRenderer={(value) => value}
+            yAxisRenderer={(value) => (parseInt(value) / 1000000) + "M"}
             additionalOptions={{ yAxis: { scale: true } }}
           />
         </Grid>

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -472,6 +472,11 @@ export default function Page() {
     value: ttsPercentile,
   };
 
+  var numberFormat = Intl.NumberFormat('en-US', {
+    notation: "compact",
+    maximumFractionDigits: 1
+  });
+
   return (
     <div>
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
@@ -782,7 +787,7 @@ export default function Page() {
             groupByFieldName={"workflow_name"}
             timeFieldName={"push_event_time"}
             yAxisFieldName={"avg_num_tests"}
-            yAxisRenderer={(value) => (parseInt(value) / 1000000) + "M"}
+            yAxisRenderer={(value) => numberFormat.format(parseInt(value))}
             additionalOptions={{ yAxis: { scale: true } }}
           />
         </Grid>


### PR DESCRIPTION
This modifies how we show the Y axis on the "Number of tests run" chart to ensure the most significant digit is visible

Old:
<img width="728" alt="image" src="https://user-images.githubusercontent.com/4468967/198394285-fff32e38-ebf8-44db-ad3b-69de6d92a176.png">

New:
<img width="925" alt="image" src="https://user-images.githubusercontent.com/4468967/198405869-3cf5a901-bbee-4415-afd5-79081ff32162.png">
