### PR TITLE
[Nova] Fix Mac Job: Set Env Vars after repo checkout

### DIFF
--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -59,13 +59,6 @@ jobs:
       - name: Setup miniconda
         uses: ./test-infra/.github/actions/setup-miniconda
 
-      - name: Setup useful environment variables
-        working-directory: ${{ inputs.repository }}
-        run: |
-          RUNNER_ARTIFACT_DIR="${RUNNER_TEMP}/artifacts"
-          mkdir -p "${RUNNER_ARTIFACT_DIR}"
-          echo "RUNNER_ARTIFACT_DIR=${RUNNER_TEMP}/artifacts" >> "${GITHUB_ENV}"
-
       - name: Checkout repository (${{ inputs.repository || github.repository }}@${{ inputs.ref }})
         uses: actions/checkout@v3
         with:
@@ -73,6 +66,13 @@ jobs:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.ref }}
           path: ${{ inputs.repository || github.repository }}
+
+      - name: Setup useful environment variables
+        working-directory: ${{ inputs.repository }}
+        run: |
+          RUNNER_ARTIFACT_DIR="${RUNNER_TEMP}/artifacts"
+          mkdir -p "${RUNNER_ARTIFACT_DIR}"
+          echo "RUNNER_ARTIFACT_DIR=${RUNNER_TEMP}/artifacts" >> "${GITHUB_ENV}"
 
       - name: Download artifacts (if any)
         uses: actions/download-artifact@v3

--- a/.github/workflows/test_macos_job.yml
+++ b/.github/workflows/test_macos_job.yml
@@ -40,6 +40,7 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       repository: pytorch/vision
+      ref: main
       script: |
         conda create -y -n test python=3.8
         conda activate test
@@ -53,6 +54,7 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       repository: pytorch/vision
+      ref: main
       timeout: 60
       script: |
         conda create -y -n test python=3.8

--- a/.github/workflows/test_macos_job.yml
+++ b/.github/workflows/test_macos_job.yml
@@ -33,6 +33,33 @@ jobs:
         python3 -m pip install --extra-index-url https://download.pytorch.org/whl/nightly/cpu --pre torch
         # Can import pytorch, cuda is available
         python3 -c 'import torch'
+  test-x86-with-repo:
+    uses: ./.github/workflows/macos_job.yml
+    with:
+      runner: macos-12
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      repository: pytorch/vision
+      script: |
+        conda create -y -n test python=3.8
+        conda activate test
+        python3 -m pip install --extra-index-url https://download.pytorch.org/whl/nightly/cpu --pre torch
+        # Can import pytorch
+        python3 -c 'import torch'
+  test-m1-with-repo:
+    uses: ./.github/workflows/macos_job.yml
+    with:
+      runner: macos-m1-12
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      repository: pytorch/vision
+      timeout: 60
+      script: |
+        conda create -y -n test python=3.8
+        conda activate test
+        python3 -m pip install --extra-index-url https://download.pytorch.org/whl/nightly/cpu --pre torch
+        # Can import pytorch, cuda is available
+        python3 -c 'import torch'
   test-upload-artifact:
     uses: ./.github/workflows/macos_job.yml
     with:


### PR DESCRIPTION
I tried adding macos unittests using the generic mac job in https://github.com/pytorch/text/pull/1969 but ran into failures (https://github.com/pytorch/text/actions/runs/3341528363/jobs/5532831734) due to the target repository being used as the working-directory before it was checked out. This tries to fix that issue by doing the repo checkout before the step that uses it as a working directory. The other option is to simply not use the repo as a working-directory for that step (since that step just sets env vars and should be safe to do). 

Also added a few tests that pass the repo argument to the generic job.