### PR TITLE
improved HUD (barcharts and joblist) failures page with branch information

### DIFF
--- a/torchci/components/JobSummary.tsx
+++ b/torchci/components/JobSummary.tsx
@@ -6,6 +6,7 @@ export default function JobSummary({ job }: { job: JobData }) {
     <>
       <JobConclusion conclusion={job.conclusion} />
       <a href={job.htmlUrl}> {job.jobName} </a>
+      <b> [{job.branch}] </b>
     </>
   );
 }

--- a/torchci/components/JobSummary.tsx
+++ b/torchci/components/JobSummary.tsx
@@ -6,7 +6,7 @@ export default function JobSummary({ job }: { job: JobData }) {
     <>
       <JobConclusion conclusion={job.conclusion} />
       <a href={job.htmlUrl}> {job.jobName} </a>
-      <b> [{job.branch}] </b>
+      <b> {job.branch} </b>
     </>
   );
 }

--- a/torchci/components/JobSummary.tsx
+++ b/torchci/components/JobSummary.tsx
@@ -10,3 +10,7 @@ export default function JobSummary({ job, highlight }: { job: JobData; highlight
     </>
   );
 }
+
+JobSummary.defaultProps = {
+  highlight: false
+}

--- a/torchci/components/JobSummary.tsx
+++ b/torchci/components/JobSummary.tsx
@@ -1,12 +1,23 @@
 import { JobData } from "lib/types";
 import JobConclusion from "./JobConclusion";
 
+function BranchName({ name, highlight }: { name: string | undefined; highlight:boolean; }) {
+  if (name) {
+    if (highlight) {
+      return (<b> [{name}] </b>)
+    } else {
+      return (<span>[{name}]</span>)
+    }
+  }
+  return <></>
+}
+
 export default function JobSummary({ job, highlight }: { job: JobData; highlight: boolean; }) {
   return (
     <>
       <JobConclusion conclusion={job.conclusion} />
       <a href={job.htmlUrl}> {job.jobName} </a>
-      {!job.branch? <></> : (highlight ? <b> [{job.branch}] </b> : <span>[{job.branch}]</span>) }
+      <BranchName name={job.branch} highlight={highlight} />
     </>
   );
 }

--- a/torchci/components/JobSummary.tsx
+++ b/torchci/components/JobSummary.tsx
@@ -6,7 +6,7 @@ export default function JobSummary({ job, highlight }: { job: JobData; highlight
     <>
       <JobConclusion conclusion={job.conclusion} />
       <a href={job.htmlUrl}> {job.jobName} </a>
-      {highlight ? <b> [{job.branch}] </b> : <span>[{job.branch}]</span> }
+      {!job.branch? <></> : (highlight ? <b> [{job.branch}] </b> : <span>[{job.branch}]</span>) }
     </>
   );
 }

--- a/torchci/components/JobSummary.tsx
+++ b/torchci/components/JobSummary.tsx
@@ -1,12 +1,12 @@
 import { JobData } from "lib/types";
 import JobConclusion from "./JobConclusion";
 
-export default function JobSummary({ job }: { job: JobData }) {
+export default function JobSummary({ job, highlight }: { job: JobData; highlight: boolean; }) {
   return (
     <>
       <JobConclusion conclusion={job.conclusion} />
       <a href={job.htmlUrl}> {job.jobName} </a>
-      <b> {job.branch} </b>
+      {highlight ? <b> [{job.branch}] </b> : <span>[{job.branch}]</span> }
     </>
   );
 }

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -7,6 +7,7 @@ export interface JobData {
   jobName?: string;
   sha?: string;
   id?: string;
+  branch?: string;
   workflowId?: string;
   githubArtifactUrl?: string;
   time?: string;

--- a/torchci/pages/failure/[capture].tsx
+++ b/torchci/pages/failure/[capture].tsx
@@ -184,7 +184,7 @@ function FailureInfo({
       <ul>
         {samples.map((sample) => (
           <li key={sample.id}>
-            <JobSummary job={sample} />
+            <JobSummary job={sample} highlight={sample.branch ? highlighted.has(sample.branch) : false} />
             <div>
               <JobLinks job={sample} />
             </div>

--- a/torchci/rockset/commons/__sql/failure_samples_query.sql
+++ b/torchci/rockset/commons/__sql/failure_samples_query.sql
@@ -23,6 +23,7 @@ SELECT
     CONCAT(w.name, ' / ', job.name) AS name,
     w.head_sha AS sha,
     job.id AS id,
+    w.head_branch as branch,
     CASE
         WHEN job.conclusion IS NULL THEN 'pending'
         ELSE job.conclusion

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -9,7 +9,7 @@
     "test_time_per_file": "1c8d6289623181d8",
     "test_time_per_file_periodic_jobs": "39c105542e297c09",
     "issue_query": "5d4dfeb992e2f29b",
-    "failure_samples_query": "ab2b589414b966a8",
+    "failure_samples_query": "fe81f29218d2bafb",
     "recent_pr_workflows_query": "7486549578f7a837",
     "reverted_prs_with_reason": "65117d657817418b",
     "unclassified": "1b31a2d8f4ab7230",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -9,7 +9,7 @@
     "test_time_per_file": "1c8d6289623181d8",
     "test_time_per_file_periodic_jobs": "39c105542e297c09",
     "issue_query": "5d4dfeb992e2f29b",
-    "failure_samples_query": "fe81f29218d2bafb",
+    "failure_samples_query": "cf0c2266b396b6e0",
     "recent_pr_workflows_query": "7486549578f7a837",
     "reverted_prs_with_reason": "65117d657817418b",
     "unclassified": "1b31a2d8f4ab7230",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #969

Pytorch CI's [failure page](https://hud.pytorch.org/failure/test_aot_autograd) can show us failures dashboard for information. However, that page shows errors across all branches, spanning both master and private branches, and doesn't offer any hint of which branch a given failure occurred on. Knowing if failures are happening on the master branch or on private branches would help debug issues much faster.



This change on the failures page, will highlight failures that occurred on the master branch in barcharts so that we could easily see master branch's problem but also show the branch for the failure job detailed list.

This new view could help better identify master branch issues and also get a feeling (distribution) of overall job failures.


# Old view:
![image](https://user-images.githubusercontent.com/17696526/198701028-4514a2af-41db-4c5a-80e1-069609f38c3e.png)

![image](https://user-images.githubusercontent.com/17696526/198700971-0bb0b6a3-446b-4958-9fac-16e6ff95353e.png)


# New view:
![image](https://user-images.githubusercontent.com/17696526/198701130-4e5d8c85-fd1c-4d53-a20f-b5d20c8070d0.png)
![image](https://user-images.githubusercontent.com/17696526/198706228-7e9db7bd-64a1-41f9-bb19-eb491418f0d3.png)


