### PR TITLE
[BE] Improve  human readable timestamp granularity

### DIFF
--- a/torchci/components/TimeUtils.tsx
+++ b/torchci/components/TimeUtils.tsx
@@ -13,9 +13,11 @@ export function LocalTimeHuman({ timestamp }: { timestamp: string }) {
   useEffect(() => {
     const time = dayjs(timestamp).local();
     if (dayjs().isSame(time, "day")) {
-      setTime(time.format("h:mm A"));
+      setTime(time.format("h:mm a"));
+    } else if (dayjs().isSame(time, 'week')) {
+      setTime(time.format("ddd h:mm a"));
     } else {
-      setTime(time.format("ddd, MMM D"));
+      setTime(time.format("M/D h:mm a"));
     }
   }, [timestamp]);
   return <span>{time}</span>;

--- a/torchci/components/TimeUtils.tsx
+++ b/torchci/components/TimeUtils.tsx
@@ -14,7 +14,7 @@ export function LocalTimeHuman({ timestamp }: { timestamp: string }) {
     const time = dayjs(timestamp).local();
     if (dayjs().isSame(time, "day")) {
       setTime(time.format("h:mm a"));
-    } else if (dayjs().isSame(time, 'week')) {
+    } else if (dayjs().subtract(7, 'days').isBefore(time, 'day')) {
       setTime(time.format("ddd h:mm a"));
     } else {
       setTime(time.format("M/D h:mm a"));


### PR DESCRIPTION
Today, when you look at any of the Hud views, if the PR was submitted before the current day you loose information about the time it was submitted at, only getting the date

This change modifies the human readable time format to:

1. Show the day of the week & time for PRs (and any other time stamps) fall in the past 7 days
2. Show the date & time for timestamps for anything older

This new behavior makes it easy to see things like "this breaking change, and many PRs after it, were submitted after hours last night" (shown in the screenshots below).

It also improves the granularity in views like the [failure view](http://hud.pytorch.org/failure/ImportError%3A%20%2Fopt%2Fconda%2Flib%2Fpython3.8%2Fsite-packages%2Ftorch%2Flib%2Flibtorch_cuda.so%3A%20symbol%20cudaGraphInstantiateWithFlags%20version%20libcudart.so.11.0%20not%20defined%20in%20file%20libcudart.so.11.0%20with%20link%20time%20reference) where we share human readable timestamps

Old behavior:
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/4468967/198683450-99655eda-b7b4-4d51-9a43-523881612aa8.png">

New behavior:
<img width="1119" alt="image" src="https://user-images.githubusercontent.com/4468967/198683485-1f1e8f38-ac2a-419c-8046-030ec428d1eb.png">

And when you got to a date that's one week ago:
<img width="609" alt="image" src="https://user-images.githubusercontent.com/4468967/198683234-b4580ff6-309b-4456-bb20-d6caeba1fe20.png">
