### PR TITLE
Add support for g5.12xlarge instance

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -89,7 +89,7 @@ runner_types:
   linux.g5.12xlarge.nvidia.gpu:
     instance_type: g5.12xlarge
     os: linux
-    max_available: 200
+    max_available: 20
     disk_size: 150
     is_ephemeral: false
   linux.large:

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -86,6 +86,12 @@ runner_types:
     max_available: 200
     disk_size: 150
     is_ephemeral: false
+  linux.g5.12xlarge.nvidia.gpu:
+    instance_type: g5.12xlarge
+    os: linux
+    max_available: 200
+    disk_size: 150
+    is_ephemeral: false
   linux.large:
     disk_size: 15
     instance_type: c5.large


### PR DESCRIPTION
Inductor+DDP/FSDP testing requires multiple GPUs of  recent architecture.