### PR TITLE
[BE] Change icon during pending runs to be an hourglass

### DIFF
--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -57,17 +57,29 @@ export function constructResultsComment(
 ): string {
     let output = `\n`;
     const failing = failedJobs.length;
-    const noneFailing = `## :white_check_mark: No Failures`;
+    const headerPrefix = `## `
+    const pendingIcon = `:hourglass_flowing_sand:`
+    const successIcon = `:white_check_mark:`
+    const noneFailing = ` No Failures`;
     const someFailing = `## :x: ${failing} Failures`;
     const somePending = `, ${pending} Pending`;
 
     const hasFailing = failing > 0;
     const hasPending = pending > 0;
     if (!hasFailing) {
+        output += headerPrefix
+        if (hasPending) {
+            output += pendingIcon
+        } else {
+            output += successIcon
+        }
+
         output += noneFailing;
+
         if (hasPending) {
             output += somePending;
         }
+
         output += `\nAs of commit ${sha}:`;
         output += `\n:green_heart: Looks good so far! There are no failures yet. :green_heart:`;
     }

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -256,7 +256,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
       );
       expect(comment.includes("## :link: Helpful Links")).toBeTruthy();
       expect(
-        comment.includes("## :white_check_mark: No Failures, 1 Pending")
+        comment.includes("## :hourglass_flowing_sand: No Failures, 1 Pending")
       ).toBeTruthy();
       expect(
         comment.includes(":green_heart:")


### PR DESCRIPTION
If jobs are still pending, don't use a misleading ✅  icon to summarize the job status. Use a hourglass icon instead to show that jobs are still running

Folks have been getting confused while looking at the Dr. CI summary

Old:
<img width="777" alt="image" src="https://user-images.githubusercontent.com/4468967/198721556-463293c1-49fc-4f55-852d-3ebf1ad405d7.png">

New:
<img width="778" alt="image" src="https://user-images.githubusercontent.com/4468967/198721510-97a59ff2-57af-4f70-a8ba-66746de605f8.png">
