### PR TITLE
ci: Add linux.large.ephemeral SKU

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -92,6 +92,11 @@ runner_types:
     max_available: 20
     disk_size: 150
     is_ephemeral: false
+  linux.large.ephemeral:
+    disk_size: 15
+    instance_type: c5.large
+    is_ephemeral: true
+    os: linux
   linux.large:
     disk_size: 15
     instance_type: c5.large


### PR DESCRIPTION
Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

This will replace the Github Custom Hosted runners we were using previously to run merge bot operations