### PR TITLE
increase linux.g5.4xlarge.nvidia.gpu max_available to 300

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -83,7 +83,7 @@ runner_types:
   linux.g5.4xlarge.nvidia.gpu:
     instance_type: g5.4xlarge
     os: linux
-    max_available: 200
+    max_available: 300
     disk_size: 150
     is_ephemeral: false
   linux.g5.12xlarge.nvidia.gpu:


### PR DESCRIPTION
![Screenshot 2022-10-31 at 14 40 43](https://user-images.githubusercontent.com/4520845/199021811-0c3a6e17-975a-4899-8290-f3751de97f68.png)
