### PR TITLE
Remove stale `% red jobs red on master` metric

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -509,14 +509,6 @@ export default function Page() {
               queryParams={timeParams}
               badThreshold={(value) => value > 0.5}
             />
-            <ScalarPanel
-              title={"% red jobs red on master, aggregate"}
-              queryName={"master_jobs_red_avg"}
-              metricName={"red"}
-              valueRenderer={(value) => (value * 100).toFixed(2) + "%"}
-              queryParams={timeParams}
-              badThreshold={(value) => value > 0.01}
-            />
           </Stack>
         </Grid>
 


### PR DESCRIPTION
This metric is currently unused. It used to be valuable 6 months ago, but the class of infra problems that it was helpful to track have been addressed now.

Given that we no longer use this metric let's remove it from the dashboard and free up real estate for a more relevant metric