### PR TITLE
Comment on alert change

### DIFF
--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -5,11 +5,10 @@ on:
     - cron: "*/5 * * * *"
   # Have the ability to trigger this job manually through the API
   workflow_dispatch:
-  pull_request:
 
 
 jobs:
-  update-disabled-tests:
+  update-alerts:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout

--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -5,6 +5,7 @@ on:
     - cron: "*/5 * * * *"
   # Have the ability to trigger this job manually through the API
   workflow_dispatch:
+  pull_request:
 
 
 jobs:

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -419,7 +419,7 @@ def check_for_recurrently_failing_jobs_alert():
     if existing_recurrent_job_failure_alert:
         new_issue = generate_failed_job_issue(jobs_to_alert_on)
         if existing_recurrent_job_failure_alert["body"] != new_issue["body"]:
-            update_issue(new_issue, existing_recurrent_job_failure_alert["number"])
+            update_issue(new_issue, existing_recurrent_job_failure_alert)
         else:
             print("No new updates. Not updating any alerts.")
     else:

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -64,6 +64,7 @@ UPDATE_ISSUE_URL = (
     f"https://api.github.com/repos/{REPO_OWNER}/{TEST_INFRA_REPO_NAME}/issues/"
 )
 
+
 GRAPHQL_URL = "https://api.github.com/graphql"
 
 
@@ -227,6 +228,8 @@ def update_issue(issue: Dict, issue_number: int) -> Dict:
         UPDATE_ISSUE_URL + str(issue_number), json=issue, headers=headers
     )
     r.raise_for_status()
+    r = requests.post(f"https://api.github.com/repos/{REPO_OWNER}/{TEST_INFRA_REPO_NAME}/issues/{issue_number}/comments", data=json.dumps({"body": "updating alert"}), headers=headers)
+    r.raise_for_status()
     return issue
 
 
@@ -383,7 +386,7 @@ def check_for_recurrently_failing_jobs_alert():
 
     # Auto-clear any existing alerts if the current status is green
     if len(jobs_to_alert_on) == 0 or trunk_is_green(sha_grid):
-        print("Didn't find anything to alert on.")        
+        print("Didn't find anything to alert on.")
         clear_alerts(existing_alerts)
         return
 

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -401,10 +401,7 @@ def check_for_recurrently_failing_jobs_alert():
     # Create a new alert if no alerts are active or edit the original one if there's a new update
     if existing_recurrent_job_failure_alert:
         new_issue = generate_failed_job_issue(jobs_to_alert_on)
-        if existing_recurrent_job_failure_alert["body"] != new_issue["body"]:
-            update_issue(new_issue, existing_recurrent_job_failure_alert["number"])
-        else:
-            print("No new updates. Not updating any alerts.")
+        update_issue(new_issue, existing_recurrent_job_failure_alert["number"])
     else:
         create_issue(generate_failed_job_issue(jobs_to_alert_on))
 

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -228,7 +228,8 @@ def update_issue(issue: Dict, issue_number: int) -> Dict:
         UPDATE_ISSUE_URL + str(issue_number), json=issue, headers=headers
     )
     r.raise_for_status()
-    r = requests.post(f"https://api.github.com/repos/{REPO_OWNER}/{TEST_INFRA_REPO_NAME}/issues/{issue_number}/comments", data=json.dumps({"body": "updating alert"}), headers=headers)
+    r = requests.post(f"https://api.github.com/repos/{REPO_OWNER}/{TEST_INFRA_REPO_NAME}/issues/{issue_number}/comments",
+                      data=json.dumps({"body": "Updating alert"}), headers=headers)
     r.raise_for_status()
     return issue
 

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -228,18 +228,8 @@ def generate_no_flaky_tests_issue() -> Any:
     return issue
 
 
-def delete_old_comments(old_issue: Any) -> None:
-    # delete old comments from github bot
-    comments = old_issue["comments"]["nodes"]
-    for comment in comments:
-        if comment["bodyText"] == UPDATING_ALERT_COMMENT:
-            requests.delete(
-                f"https://api.github.com/repos/{REPO_OWNER}/{TEST_INFRA_REPO_NAME}/issues/comments/{comment['databaseId']}")
-
-
 def update_issue(issue: Dict, old_issue: Any) -> Dict:
     print("Updating issue", issue)
-    delete_old_comments(old_issue)
     r = requests.patch(
         UPDATE_ISSUE_URL + str(old_issue["number"]), json=issue, headers=headers
     )


### PR DESCRIPTION
Add a comment every time the alert is changed in order to trigger a sync on the internal task, as simply changing the body and title will not trigger the internal task to change.

Then we can make a butterfly bot rule that triggers on comment made on task to message the oncall on workchat.  However, I still have not discovered a way to cause a UBN alert for the oncall aside from make a completely new task.