### PR TITLE
Only show status from push event on trunk HUD

### DIFF
--- a/torchci/rockset/commons/__sql/commit_jobs_query.sql
+++ b/torchci/rockset/commons/__sql/commit_jobs_query.sql
@@ -37,6 +37,7 @@ WITH job as (
         AND workflow.head_sha = :sha
         AND job.head_sha = :sha
         AND workflow.repository.full_name = :repo
+        AND workflow.event = :event
     UNION
         -- Handle CircleCI
         -- IMPORTANT: this needs to have the same order as the query above

--- a/torchci/rockset/commons/__sql/hud_query.sql
+++ b/torchci/rockset/commons/__sql/hud_query.sql
@@ -30,6 +30,7 @@ WITH job AS (
         AND ARRAY_CONTAINS(SPLIT(:shas, ','), job.head_sha)
         AND ARRAY_CONTAINS(SPLIT(:shas, ','), workflow.head_sha)
         AND workflow.repository.full_name = :repo
+        AND workflow.event = :event
     UNION
         -- Handle CircleCI
         -- IMPORTANT: this needs to have the same order as the query above

--- a/torchci/rockset/commons/commit_jobs_query.lambda.json
+++ b/torchci/rockset/commons/commit_jobs_query.lambda.json
@@ -10,6 +10,11 @@
       "name": "sha",
       "type": "string",
       "value": "ae93a4dc43a7103b1856b83456b247dd3395fe47"
+    },
+    {
+      "name": "event",
+      "type": "string",
+      "value": "push"
     }
   ],
   "description": ""

--- a/torchci/rockset/commons/commit_jobs_query.lambda.json
+++ b/torchci/rockset/commons/commit_jobs_query.lambda.json
@@ -2,6 +2,11 @@
   "sql_path": "__sql/commit_jobs_query.sql",
   "default_parameters": [
     {
+      "name": "event",
+      "type": "string",
+      "value": "push"
+    },
+    {
       "name": "repo",
       "type": "string",
       "value": "pytorch/pytorch"
@@ -10,11 +15,6 @@
       "name": "sha",
       "type": "string",
       "value": "ae93a4dc43a7103b1856b83456b247dd3395fe47"
-    },
-    {
-      "name": "event",
-      "type": "string",
-      "value": "push"
     }
   ],
   "description": ""

--- a/torchci/rockset/commons/hud_query.lambda.json
+++ b/torchci/rockset/commons/hud_query.lambda.json
@@ -10,6 +10,11 @@
       "name": "shas",
       "type": "string",
       "value": "90c8623c2ec874b5a1d7092a56a9a83abad78f78,b33831dcd89b99318b703b90c0fffee7bd710b2f"
+    },
+    {
+      "name": "event",
+      "type": "string",
+      "value": "push"
     }
   ],
   "description": ""

--- a/torchci/rockset/commons/hud_query.lambda.json
+++ b/torchci/rockset/commons/hud_query.lambda.json
@@ -2,6 +2,11 @@
   "sql_path": "__sql/hud_query.sql",
   "default_parameters": [
     {
+      "name": "event",
+      "type": "string",
+      "value": "push"
+    },
+    {
       "name": "repo",
       "type": "string",
       "value": "pytorch/pytorch"
@@ -10,11 +15,6 @@
       "name": "shas",
       "type": "string",
       "value": "90c8623c2ec874b5a1d7092a56a9a83abad78f78,b33831dcd89b99318b703b90c0fffee7bd710b2f"
-    },
-    {
-      "name": "event",
-      "type": "string",
-      "value": "push"
     }
   ],
   "description": ""

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -1,8 +1,8 @@
 {
   "commons": {
     "annotated_flaky_jobs": "1e7bd01a839ae4d1",
-    "hud_query": "f5ebefcdd53b6ff5",
-    "commit_jobs_query": "442a6f64bd44f351",
+    "hud_query": "5c6e11d6c9657540",
+    "commit_jobs_query": "f79f9f3eeb8fa59f",
     "filter_forced_merge_pr": "b92dcaa7d28e5db5",
     "flaky_tests": "86bd9b8156c33dca",
     "flaky_workflows_jobs": "8b16d1b8d733291d",


### PR DESCRIPTION
https://hud.pytorch.org/ is currently showing lots of red signals right now but they are all invalid signals coming from this draft PR https://github.com/pytorch/pytorch/pull/88161. This looks like a bug in the way we associate job status with the head sha of the commit.  Take an example:

```
SELECT
    job.head_sha as sha,
    job.name as job_name,
    workflow.name as workflow_name,
    job.id,
    job.conclusion,
    job.html_url as html_url,
    CONCAT(
        'https://ossci-raw-job-status.s3.amazonaws.com/log/',
        CAST(job.id as string)
    ) as log_url,
    DATE_DIFF(
        'SECOND',
        PARSE_TIMESTAMP_ISO8601(job.started_at),
        PARSE_TIMESTAMP_ISO8601(job.completed_at)
    ) as duration_s,
    workflow.repository.full_name as repo,
    job.torchci_classification.line,
    job.torchci_classification.captures,
    job.torchci_classification.line_num,
    workflow.event,
    workflow.head_branch
FROM
    workflow_job job
    INNER JOIN workflow_run workflow on workflow.id = job.run_id
WHERE
    job.name != 'ciflow_should_run'
    AND job.name != 'generate-test-matrix'
    AND workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
    AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
    AND ARRAY_CONTAINS(SPLIT('d596b048e5b7fba24e2dfb33413462c646950d93', ','), job.head_sha)
    AND ARRAY_CONTAINS(SPLIT('d596b048e5b7fba24e2dfb33413462c646950d93', ','), workflow.head_sha)
    AND workflow.repository.full_name = 'pytorch/pytorch'
    AND workflow.head_branch = 'master'
    AND job.name = 'pr-sanity-checks'
```

returns 4 rows:

```
[
  {
    "sha": "d596b048e5b7fba24e2dfb33413462c646950d93",
    "job_name": "pr-sanity-checks",
    "workflow_name": "Lint",
    "id": 9215934005,
    "conclusion": "failure",
    "html_url": "https://github.com/pytorch/pytorch/actions/runs/3365927872/jobs/5581906216",
    "log_url": "https://ossci-raw-job-status.s3.amazonaws.com/log/9215934005",
    "duration_s": 86,
    "repo": "pytorch/pytorch",
    "line": "##[error]Process completed with exit code 1.",
    "captures": [
      "Process completed with exit code 1."
    ],
    "line_num": 522,
    "event": "pull_request",
    "head_branch": "master"
  },
  {
    "sha": "d596b048e5b7fba24e2dfb33413462c646950d93",
    "job_name": "pr-sanity-checks",
    "workflow_name": "Lint",
    "id": 9215932847,
    "conclusion": "skipped",
    "html_url": "https://github.com/pytorch/pytorch/actions/runs/3365927505/jobs/5581905277",
    "log_url": "https://ossci-raw-job-status.s3.amazonaws.com/log/9215932847",
    "duration_s": 0,
    "repo": "pytorch/pytorch",
    "line": null,
    "captures": null,
    "line_num": null,
    "event": "push",
    "head_branch": "master"
  },
  {
    "sha": "d596b048e5b7fba24e2dfb33413462c646950d93",
    "job_name": "pr-sanity-checks",
    "workflow_name": "Lint",
    "id": 9216867952,
    "conclusion": "skipped",
    "html_url": "https://github.com/pytorch/pytorch/actions/runs/3365927505/jobs/5582624437",
    "log_url": "https://ossci-raw-job-status.s3.amazonaws.com/log/9216867952",
    "duration_s": 0,
    "repo": "pytorch/pytorch",
    "line": null,
    "captures": null,
    "line_num": null,
    "event": "push",
    "head_branch": "master"
  },
  {
    "sha": "d596b048e5b7fba24e2dfb33413462c646950d93",
    "job_name": "pr-sanity-checks",
    "workflow_name": "Lint",
    "id": 9216036426,
    "conclusion": "failure",
    "html_url": "https://github.com/pytorch/pytorch/actions/runs/3365927872/jobs/5581981658",
    "log_url": "https://ossci-raw-job-status.s3.amazonaws.com/log/9216036426",
    "duration_s": 76,
    "repo": "pytorch/pytorch",
    "line": null,
    "captures": null,
    "line_num": null,
    "event": "pull_request",
    "head_branch": "master"
  }
]
```

2 of them come from that https://github.com/pytorch/pytorch/pull/88161.  The only difference is that the correct one has push event while the wrong one is from the pull request.

### Testing

https://torchci-git-fork-huydhn-fix-hud-query-fbopensource.vercel.app/