### PR TITLE
Revert "Only show status from push event on trunk HUD"

### DIFF
--- a/torchci/rockset/commons/__sql/commit_jobs_query.sql
+++ b/torchci/rockset/commons/__sql/commit_jobs_query.sql
@@ -37,7 +37,6 @@ WITH job as (
         AND workflow.head_sha = :sha
         AND job.head_sha = :sha
         AND workflow.repository.full_name = :repo
-        AND workflow.event = :event
     UNION
         -- Handle CircleCI
         -- IMPORTANT: this needs to have the same order as the query above

--- a/torchci/rockset/commons/__sql/hud_query.sql
+++ b/torchci/rockset/commons/__sql/hud_query.sql
@@ -30,7 +30,6 @@ WITH job AS (
         AND ARRAY_CONTAINS(SPLIT(:shas, ','), job.head_sha)
         AND ARRAY_CONTAINS(SPLIT(:shas, ','), workflow.head_sha)
         AND workflow.repository.full_name = :repo
-        AND workflow.event = :event
     UNION
         -- Handle CircleCI
         -- IMPORTANT: this needs to have the same order as the query above

--- a/torchci/rockset/commons/commit_jobs_query.lambda.json
+++ b/torchci/rockset/commons/commit_jobs_query.lambda.json
@@ -2,11 +2,6 @@
   "sql_path": "__sql/commit_jobs_query.sql",
   "default_parameters": [
     {
-      "name": "event",
-      "type": "string",
-      "value": "push"
-    },
-    {
       "name": "repo",
       "type": "string",
       "value": "pytorch/pytorch"

--- a/torchci/rockset/commons/hud_query.lambda.json
+++ b/torchci/rockset/commons/hud_query.lambda.json
@@ -2,11 +2,6 @@
   "sql_path": "__sql/hud_query.sql",
   "default_parameters": [
     {
-      "name": "event",
-      "type": "string",
-      "value": "push"
-    },
-    {
       "name": "repo",
       "type": "string",
       "value": "pytorch/pytorch"

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -1,8 +1,8 @@
 {
   "commons": {
     "annotated_flaky_jobs": "1e7bd01a839ae4d1",
-    "hud_query": "5c6e11d6c9657540",
-    "commit_jobs_query": "f79f9f3eeb8fa59f",
+    "hud_query": "f5ebefcdd53b6ff5",
+    "commit_jobs_query": "442a6f64bd44f351",
     "filter_forced_merge_pr": "b92dcaa7d28e5db5",
     "flaky_tests": "86bd9b8156c33dca",
     "flaky_workflows_jobs": "8b16d1b8d733291d",


### PR DESCRIPTION
Reverts pytorch/test-infra#992 to restore periodic job display on HUD