### PR TITLE
fix provisioned concurrency by pushing a version

### DIFF
--- a/terraform-aws-github-runner/main.tf
+++ b/terraform-aws-github-runner/main.tf
@@ -24,11 +24,11 @@ resource "random_string" "random" {
 
 resource "aws_sqs_queue" "queued_builds" {
   name                        = "${var.environment}-queued-builds.fifo"
-  visibility_timeout_seconds  = 180
+  visibility_timeout_seconds  = var.runners_scale_up_lambda_timeout
   fifo_queue                  = true
   content_based_deduplication = true
   max_message_size            = 1024
-  message_retention_seconds   = 1800
+  message_retention_seconds   = 5800
 
   tags = var.tags
 }

--- a/terraform-aws-github-runner/modules/runners/scale-up.tf
+++ b/terraform-aws-github-runner/modules/runners/scale-up.tf
@@ -26,6 +26,7 @@ resource "aws_lambda_function" "scale_up" {
   reserved_concurrent_executions = var.scale_up_lambda_concurrency
   tags                           = local.tags
   memory_size                    = 1024
+  publish                        = true
 
   environment {
     variables = {
@@ -60,11 +61,19 @@ resource "aws_lambda_function" "scale_up" {
   }
 }
 
+resource "aws_lambda_alias" "scale_up_lambda_alias" {
+  count              = var.scale_up_provisioned_concurrent_executions > 0 ? 1 : 0
+  name               = "provisioned-${aws_lambda_function.scale_up.function_name}"
+  description        = "Alias for provisioned instances of ${aws_lambda_function.scale_up.function_name}"
+  function_name      = aws_lambda_function.scale_up.function_name
+  function_version   = aws_lambda_function.scale_up.version
+}
+
 resource "aws_lambda_provisioned_concurrency_config" "scale_up_provisioned_concurrency_config" {
   count                             = var.scale_up_provisioned_concurrent_executions > 0 ? 1 : 0
-  function_name                     = aws_lambda_function.scale_up.function_name
+  function_name                     = aws_lambda_alias.scale_up_lambda_alias.function_name
   provisioned_concurrent_executions = var.scale_up_provisioned_concurrent_executions
-  qualifier                         = aws_lambda_function.scale_up.version
+  qualifier                         = aws_lambda_alias.scale_up_lambda_alias.version
 }
 
 resource "aws_cloudwatch_log_group" "scale_up" {

--- a/terraform-aws-github-runner/modules/runners/scale-up.tf
+++ b/terraform-aws-github-runner/modules/runners/scale-up.tf
@@ -84,7 +84,7 @@ resource "aws_cloudwatch_log_group" "scale_up" {
 
 resource "aws_lambda_event_source_mapping" "scale_up" {
   event_source_arn = var.sqs_build_queue.arn
-  function_name    = aws_lambda_function.scale_up.arn
+  function_name    = aws_lambda_alias.scale_up_lambda_alias.arn
 }
 
 resource "aws_lambda_permission" "scale_runners_lambda" {


### PR DESCRIPTION
In order to have provisioned concurrency for AWS lambda, it is required to publish versions, and to avoid multiple provisioned versions, the correct approach would be using version aliases.