### PR TITLE
pytorchbot: Label with ciflow/trunk only when attempting to merge

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -2,7 +2,6 @@ import { Context, Probot } from "probot";
 import { addLabels, hasWritePermissions } from "./botUtils";
 import { isPyTorchPyTorch } from "./utils";
 
-export const CIFLOW_TRUNK_LABEL = "ciflow/trunk";
 
 const titleRegexToLabel: [RegExp, string][] = [
   [/rocm/gi, "module: rocm"],
@@ -345,17 +344,6 @@ function myBot(app: Probot): void {
     const owner = context.payload.repository.owner.login;
     const repo = context.payload.repository.name;
     if (!isPyTorchPyTorch(owner, repo)) {
-      return;
-    }
-    const labels: string[] = context.payload.pull_request.labels.map(
-      (e) => e["name"]
-    );
-    if (labels.find( x => x === CIFLOW_TRUNK_LABEL)) {
-      return;
-    }
-    const reviewer = context.payload.review.user.login;
-    // Ignore reviews from users without write permissions
-    if (!await hasWritePermissions(context, reviewer)) {
       return;
     }
     // TEMP disable for 24 hours to see if it affects number of reverts / queueing

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -4,6 +4,8 @@ import { addLabels, hasWritePermissions as _hasWP, reactOnComment } from "./botU
 import { getHelp, getParser } from "./cliParser";
 import PytorchBotLogger from "./pytorchbotLogger";
 
+export const CIFLOW_TRUNK_LABEL = "ciflow/trunk";
+
 export interface PytorchbotParams {
   owner: string;
   repo: string;
@@ -169,6 +171,20 @@ The explanation needs to be clear on why this is needed. Here are some good exam
         rebase = false;
       }
       await this.logger.log("merge", extra_data);
+      if (!forceRequested) {
+        let labels: string[] = this.ctx.payload?.issue?.labels.map(
+          (e: any) => e["name"]
+        );
+        if (labels === undefined) {
+          labels = this.ctx.payload?.pull_request?.labels.map(
+          (e: any) => e["name"]
+          );
+        }
+
+        if (labels !== undefined && ! labels.find( x => x === CIFLOW_TRUNK_LABEL)) {
+          await addLabels(this.ctx, [CIFLOW_TRUNK_LABEL])
+        }
+      }
       await this.dispatchEvent("try-merge", {
         force: forceRequested,
         on_green: mergeOnGreen,

--- a/torchci/test/mergeCommands.test.ts
+++ b/torchci/test/mergeCommands.test.ts
@@ -85,6 +85,13 @@ describe("merge-bot", () => {
     const pr_number = event.payload.issue.number;
     const comment_number = event.payload.comment.id;
     const scope = nock("https://api.github.com")
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/labels`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          `"labels":["ciflow/trunk"]`
+        );
+        return true;
+      })
+      .reply(200, {})
       .post(
         `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
         (body) => {
@@ -296,6 +303,13 @@ describe("merge-bot", () => {
     const pr_number = event.payload.issue.number;
     const comment_number = event.payload.comment.id;
     const scope = nock("https://api.github.com")
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/labels`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          `"labels":["ciflow/trunk"]`
+        );
+        return true;
+      })
+      .reply(200, {})
       .post(
         `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
         (body) => {
@@ -661,6 +675,13 @@ describe("merge-bot", () => {
     const repo = event.payload.repository.name;
     const pr_number = event.payload.pull_request.number;
     const scope = nock("https://api.github.com")
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/labels`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          `"labels":["ciflow/trunk"]`
+        );
+        return true;
+      })
+      .reply(200, {})
       .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
         expect(JSON.stringify(body)).toContain('{"body":"+1"}');
         return true;
@@ -717,6 +738,13 @@ describe("merge-bot", () => {
     const pr_number = event.payload.issue.number;
     const comment_number = event.payload.comment.id;
     const scope = nock("https://api.github.com")
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/labels`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          `"labels":["ciflow/trunk"]`
+        );
+        return true;
+      })
+      .reply(200, {})
       .post(
         `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
         (body) => {
@@ -747,6 +775,13 @@ describe("merge-bot", () => {
     const pr_number = event.payload.issue.number;
     const comment_number = event.payload.comment.id;
     const scope = nock("https://api.github.com")
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/labels`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          `"labels":["ciflow/trunk"]`
+        );
+        return true;
+      })
+      .reply(200, {})
       .post(
         `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
         (body) => {
@@ -777,6 +812,13 @@ describe("merge-bot", () => {
     const pr_number = event.payload.issue.number;
     const comment_number = event.payload.comment.id;
     const scope = nock("https://api.github.com")
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/labels`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          `"labels":["ciflow/trunk"]`
+        );
+        return true;
+      })
+      .reply(200, {})
       .post(
         `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
         (body) => {
@@ -811,6 +853,13 @@ some other text lol
     const pr_number = event.payload.issue.number;
     const comment_number = event.payload.comment.id;
     const scope = nock("https://api.github.com")
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/labels`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          `"labels":["ciflow/trunk"]`
+        );
+        return true;
+      })
+      .reply(200, {})
       .post(
         `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
         (body) => {
@@ -876,6 +925,13 @@ some other text lol
         `/repos/${owner}/${repo}/collaborators/${event.payload.comment.user.login}/permission`
       )
       .reply(200, { permission: "write" })
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/labels`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          `"labels":["ciflow/trunk"]`
+        );
+        return true;
+      })
+      .reply(200, {})
       .post(
         `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
         (body) => {
@@ -910,6 +966,13 @@ some other text lol
         `/repos/${owner}/${repo}/collaborators/${event.payload.comment.user.login}/permission`
       )
       .reply(200, { permission: "write" })
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/labels`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          `"labels":["ciflow/trunk"]`
+        );
+        return true;
+      })
+      .reply(200, {})
       .post(
         `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
         (body) => {
@@ -944,6 +1007,13 @@ some other text lol
         `/repos/${owner}/${repo}/collaborators/${event.payload.comment.user.login}/permission`
       )
       .reply(200, { permission: "read" })
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/labels`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          `"labels":["ciflow/trunk"]`
+        );
+        return true;
+      })
+      .reply(200, {})
       .post(
         `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
         (body) => {


### PR DESCRIPTION
Makes it so that a user needs to input `@pytorchbot merge` for land validations to start instead of just doing it when a pull request is approved.

This is needed since we've observed that the number of trunk workflows has become equal to the number of pull workflows, which has lead to a high strain on our infrastructure as a whole.

![image](https://user-images.githubusercontent.com/1700823/199318506-f1997fa0-7852-4309-b2a5-b5917ffb6d25.png)

Some constraints of this:
* Does not add the label if attempting a force merge
* Does not add the label if label is already applied