### PR TITLE
Avoid spamming for the same alert when its count increases

### DIFF
--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -195,7 +195,7 @@ def generate_failed_job_issue(failed_jobs: List[JobStatus]) -> Any:
         hud_link = "https://hud.pytorch.org/minihud?name_filter=" + urllib.parse.quote(
             job.job_name
         )
-        body += f"- [{job.job_name}]({hud_link}) failed {len(job.failure_chain)} times consecutively starting with "
+        body += f"- [{job.job_name}]({hud_link}) failed consecutively starting with "
         body += f"commit [{failing_sha}](https://hud.pytorch.org/commit/{REPO_OWNER}/{REPO_OWNER}/{failing_sha})"
         body += "\n\n"
 
@@ -383,7 +383,7 @@ def check_for_recurrently_failing_jobs_alert():
 
     # Auto-clear any existing alerts if the current status is green
     if len(jobs_to_alert_on) == 0 or trunk_is_green(sha_grid):
-        print("Didn't find anything to alert on.")        
+        print("Didn't find anything to alert on.")
         clear_alerts(existing_alerts)
         return
 


### PR DESCRIPTION
The new butterfly rule works well, but the alert is a bit too spammy at the moment when it tries to send a new workplace chat message whenever the counting of the same alert increases. IMO, oncall doesn't really need to know how many times the same thing breaks as long as we know that it breaks. Keeping the message body the same when there is no new failure type makes this less spammy.

For example, https://github.com/pytorch/test-infra/issues/1002, instead of seeing,

> Within the last 50 commits, there are the following failures on the master branch of pytorch:
* [pull / linux-focal-py3.7-clang7-asan / test (default, 4, 5, linux.2xlarge)](https://hud.pytorch.org/minihud?name_filter=pull%20/%20linux-focal-py3.7-clang7-asan%20/%20test%20%28default%2C%204%2C%205%2C%20linux.2xlarge%29) failed 8 times consecutively starting with commit [70782981f06a042796d4604df2ec1491f4f5b194](https://hud.pytorch.org/commit/pytorch/pytorch/70782981f06a042796d4604df2ec1491f4f5b194)
* [trunk / cuda11.6-py3.10-gcc7-sm86 / test (default, 2, 4, linux.g5.4xlarge.nvidia.gpu)](https://hud.pytorch.org/minihud?name_filter=trunk%20/%20cuda11.6-py3.10-gcc7-sm86%20/%20test%20%28default%2C%202%2C%204%2C%20linux.g5.4xlarge.nvidia.gpu%29) failed 15 times consecutively starting with commit [98f09c9ab3d0796ffd68c06daa408f0400835173](https://hud.pytorch.org/commit/pytorch/pytorch/98f09c9ab3d0796ffd68c06daa408f0400835173)

The message could stay the same as

> Within the last 50 commits, there are the following failures on the master branch of pytorch:
* [pull / linux-focal-py3.7-clang7-asan / test (default, 4, 5, linux.2xlarge)](https://hud.pytorch.org/minihud?name_filter=pull%20/%20linux-focal-py3.7-clang7-asan%20/%20test%20%28default%2C%204%2C%205%2C%20linux.2xlarge%29) failed consecutively starting with commit [70782981f06a042796d4604df2ec1491f4f5b194](https://hud.pytorch.org/commit/pytorch/pytorch/70782981f06a042796d4604df2ec1491f4f5b194)
* [trunk / cuda11.6-py3.10-gcc7-sm86 / test (default, 2, 4, linux.g5.4xlarge.nvidia.gpu)](https://hud.pytorch.org/minihud?name_filter=trunk%20/%20cuda11.6-py3.10-gcc7-sm86%20/%20test%20%28default%2C%202%2C%204%2C%20linux.g5.4xlarge.nvidia.gpu%29) failed consecutively starting with commit [98f09c9ab3d0796ffd68c06daa408f0400835173](https://hud.pytorch.org/commit/pytorch/pytorch/98f09c9ab3d0796ffd68c06daa408f0400835173)

