### PR TITLE
Reduce the threshold to display test insights overview to 60s

### DIFF
--- a/torchci/pages/tests.tsx
+++ b/torchci/pages/tests.tsx
@@ -16,6 +16,7 @@ import { RocksetParam } from "lib/rockset";
 import { useState } from "react";
 
 const ROW_HEIGHT = 500;
+const THRESHOLD_IN_SECOND = 60;
 
 function GenerateTestInsightsOverviewTable({
   workflowName,
@@ -26,9 +27,6 @@ function GenerateTestInsightsOverviewTable({
   startTime : dayjs.Dayjs,
   stopTime: dayjs.Dayjs,
 }) {
-  // TODO: Because of the size of the result from Rockset, we're only fetching jobs
-  // that take more than 30m at the moment. This can be addressed later if we see
-  // the value of adding the rest of them
   const queryParams: RocksetParam[] = [
     {
       name: "startTime",
@@ -44,6 +42,11 @@ function GenerateTestInsightsOverviewTable({
       name: "workflowName",
       type: "string",
       value: workflowName,
+    },
+    {
+      name: "thresholdInSecond",
+      type: "int",
+      value: THRESHOLD_IN_SECOND,
     }
   ];
 
@@ -196,6 +199,12 @@ export default function GatherTestsInfo() {
 
         <GenerateTestInsightsOverviewTable
           workflowName={"periodic"}
+          startTime={startTime}
+          stopTime={stopTime}
+        />
+
+        <GenerateTestInsightsOverviewTable
+          workflowName={"inductor"}
           startTime={startTime}
           stopTime={stopTime}
         />


### PR DESCRIPTION
When I tried to find `test_torchinductor` on https://hud.pytorch.org/tests today to see its duration, I couldn't find it because this test takes less than 30m to run.  Originally, I have this parameter set at 30m or 1800s so that it's faster to load https://hud.pytorch.org/tests given that Dev Infra doesn't care much about short tests while we have longer poles to deal with.

* Reducing the threshold to 60s allows all test files taking longer than this to show up. This will include all inductor-related tests
* I don't want to set this to 0 just yet because it would make the size of the returning JSON from Rockset bigger than 4MB and Vercel would throw a perf warning (rightly so)

### Testing

`test_torchinductor` now shows up correctly on https://torchci-git-fork-huydhn-show-inductor-test-e993f1-fbopensource.vercel.app/tests
 