### PR TITLE
[hud] fix layout shift in HUD

### DIFF
--- a/torchci/rockset/commons/__sql/hud_query.sql
+++ b/torchci/rockset/commons/__sql/hud_query.sql
@@ -19,9 +19,11 @@ WITH job AS (
         job.torchci_classification.line,
         job.torchci_classification.captures,
         job.torchci_classification.line_num,
+        annotation.annotation,
     FROM
         workflow_job job
         INNER JOIN workflow_run workflow on workflow.id = job.run_id
+        LEFT JOIN job_annotation annotation ON job.id = annotation.jobID
     WHERE
         job.name != 'ciflow_should_run'
         AND job.name != 'generate-test-matrix'
@@ -61,6 +63,7 @@ WITH job AS (
         null,
         null,
         null,
+        null,
     FROM
         circleci.job job
     WHERE
@@ -82,5 +85,6 @@ SELECT
     line as failureLine,
     line_num as failureLineNumber,
     captures as failureCaptures,
+    annotation as failureAnnotation,
 FROM
     job

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -1,9 +1,9 @@
 {
   "commons": {
     "annotated_flaky_jobs": "1e7bd01a839ae4d1",
-    "hud_query": "f5ebefcdd53b6ff5",
+    "hud_query": "bf634305df7c3129",
     "commit_jobs_query": "442a6f64bd44f351",
-    "filter_forced_merge_pr": "b92dcaa7d28e5db5",
+    "filter_forced_merge_pr": "7264f7c4160646ec",
     "flaky_tests": "86bd9b8156c33dca",
     "flaky_workflows_jobs": "8b16d1b8d733291d",
     "slow_tests": "ef8d035d23aa8ab6",
@@ -11,11 +11,11 @@
     "test_time_per_file_periodic_jobs": "39c105542e297c09",
     "issue_query": "5d4dfeb992e2f29b",
     "failure_samples_query": "ab2b589414b966a8",
-    "recent_pr_workflows_query": "7486549578f7a837",
+    "recent_pr_workflows_query": "e34d3838c3b3eb2d",
     "reverted_prs_with_reason": "65117d657817418b",
     "unclassified": "1b31a2d8f4ab7230",
     "test_insights_overview": "c9be5cbdda1030af",
-    "test_insights_latest_runs": "949f5e49f76bfdd4"
+    "test_insights_latest_runs": "aa6c15c6d52860b2"
   },
   "pytorch_dev_infra_kpis": {
     "num_reverts": "dd2bac0ff36ea47f",
@@ -27,12 +27,12 @@
   },
   "metrics": {
     "correlation_matrix": "4960260cbb0c5b48",
-    "disabled_test_historical": "03489867dbafd6fa",
-    "disabled_test_total": "a168f284c9ff3c32",
+    "disabled_test_historical": "daa2413a4750aa87",
+    "disabled_test_total": "da5f834a6501fc63",
     "job_duration_avg": "10a88ea2ebb80647",
     "job_duration_percentile": "96507ed62db7a3a8",
     "last_branch_push": "3d995ac2143586dc",
-    "last_successful_jobs": "814fb497003c9625",
+    "last_successful_jobs": "2e04949378c58607",
     "last_successful_workflow": "5d22927dd0b0956b",
     "master_commit_red_avg": "a88bee94d93198ed",
     "master_commit_red": "4c39daa3ac2f30e4",


### PR DESCRIPTION
We were doing one request per failed row per job annotations, which is
inefficient and caused layout shift as requests raced each other.

Move the job annotation retrieval to the backend.
