### PR TITLE
Use fixed names for docs build jobs

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -632,6 +632,8 @@ export default function Page() {
                   name: "jobNames",
                   type: "string",
                   value:
+                    // The new names are fixed at build-docs-${{ DOC_TYPE }}-${{ PUSHED }}. The PUSHED parameter will always be
+                    // true here because docs are pushed to GitHub, for example, nightly
                     "docs push / build-docs-python-true;docs push / build-docs-cpp-true;docs push / build-docs-functorch-true",
                 },
               ]}

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -632,7 +632,7 @@ export default function Page() {
                   name: "jobNames",
                   type: "string",
                   value:
-                    "docs push / build-docs (python, linux.2xlarge, 30);docs push / build-docs (cpp, linux.12xlarge, 180);docs push / build-docs (functorch, linux.2xlarge, 15)",
+                    "linux-docs / build-docs-python-true;linux-docs / build-docs-cpp-true;linux-docs / build-docs-functorch-true",
                 },
               ]}
               badThreshold={(value) => value > 3 * 24 * 60 * 60} // 3 day

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -632,7 +632,7 @@ export default function Page() {
                   name: "jobNames",
                   type: "string",
                   value:
-                    "linux-docs / build-docs-python-true;linux-docs / build-docs-cpp-true;linux-docs / build-docs-functorch-true",
+                    "docs push / build-docs-python-true;docs push / build-docs-cpp-true;docs push / build-docs-functorch-true",
                 },
               ]}
               badThreshold={(value) => value > 3 * 24 * 60 * 60} // 3 day


### PR DESCRIPTION
These names are now available after https://github.com/pytorch/pytorch/pull/88589. The old names were generated from the build matrix, i.e. `docs push / build-docs (cpp, linux.12xlarge, 180)`, and required updating whenever parameters like runner type or timeout value changed.

The new names are fixed at `build-docs-${{ DOC_TYPE }}-${{ PUSHED }}`.  The `PUSHED` parameter will always be true here because built docs are pushed to GitHub

### Testing
https://torchci-git-fork-huydhn-use-fixed-name-for-ce09c0-fbopensource.vercel.app/metrics till https://hud.pytorch.org/pytorch/pytorch/commit/c77368d41615835e5124affe79f88feed93e8855 finishes