### PR TITLE
tools: Add ability to clear org runners

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install dependencies
         run: |

--- a/.github/workflows/tools-self-hosted-runner-utils.yml
+++ b/.github/workflows/tools-self-hosted-runner-utils.yml
@@ -24,11 +24,11 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
       - name: Run format
         run: |
-          black --check
+          black --check .

--- a/tools/self-hosted-runner-utils/check_runners_state.py
+++ b/tools/self-hosted-runner-utils/check_runners_state.py
@@ -23,7 +23,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "repo",
         help="Repository to remove offline self hosted runners for, (ex. pytorch/pytorch)",
-        type=str
+        type=str,
     )
     parser.add_argument(
         "--include",

--- a/tools/self-hosted-runner-utils/requirements.txt
+++ b/tools/self-hosted-runner-utils/requirements.txt
@@ -1,2 +1,3 @@
-PyGithub
+git+https://github.com/jorgegarciarey/PyGithub@master
 black
+tqdm


### PR DESCRIPTION
Found we didn't actually have a script to do this before and PyGithub doesn't actually support this by default.

Also gives an improvement to the script to give a progress bar when removing the runners.

## Usage:

### For org level

Distinguished by the lack of `/` in the name

```
python clear_offline_runners.py pytorch --include 'i-.*'
```

### For repo level

```
python clear_offline_runners.py pytorch/pytorch --include 'i-.*'
```

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>