### PR TITLE
fix requirements.txt enabling pattern in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.zip
 *.swp
 *.txt
-!.*requirements.txt
+!**/*requirements.txt
 
 __pycache__
 


### PR DESCRIPTION
.gitignore does not use regular expressions, which was the source of
my mistake.
