### PR TITLE
Use generic ci windows runners

### DIFF
--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -88,7 +88,7 @@ jobs:
             echo "set -eou pipefail";
             # Without this specific version of pywin32 conda the default conda installation does not work
             # See https://github.com/conda/conda/issues/11503
-            echo "/c/Jenkins/Miniconda3/python.exe -m pip install --upgrade pywin32==304"
+            echo "/c/Jenkins/Miniconda3/python.exe -m pip install --upgrade pywin32==300"
             # Source conda so it's available to the script environment
             echo "source /c/Jenkins/Miniconda3/etc/profile.d/conda.sh";
             echo "${SCRIPT}";

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -39,8 +39,8 @@ mod.CUDA_ARCHES = CUDA_ACRHES_DICT["nightly"]
 
 LINUX_GPU_RUNNER = "ubuntu-20.04-m60"
 LINUX_CPU_RUNNER = "ubuntu-20.04"
-WIN_GPU_RUNNER = "windows-2019-m60"
-WIN_CPU_RUNNER = "windows-2019"
+WIN_GPU_RUNNER = "windows.8xlarge.nvidia.gpu"
+WIN_CPU_RUNNER = "windows.4xlarge"
 MACOS_M1_RUNNER = "macos-m1-12"
 MACOS_RUNNER = "macos-12"
 


### PR DESCRIPTION
Use windows generic CI workers https://github.com/pytorch/test-infra/wiki/Writing-generic-CI-jobs for the Validation.
Change pywin version to 300 according to [conda issue 11503
](https://github.com/conda/conda/issues/11503)
