### PR TITLE
Exclude pytorch/pull/26921 from ciflow

### DIFF
--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -221,6 +221,7 @@ async function handleLabelEvent(context: Context<"pull_request.labeled">) {
   // https://github.com/pytorch/pytorch/pull/26921 is a special PR that should
   // never get ciflow tags
   if (prNum == 26921 && isPyTorchPyTorch(owner, repo)) {
+    return;
   }
   const tag = labelToTag(context.payload.label.name, prNum);
   await syncTag(context, tag, context.payload.pull_request.head.sha);

--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -1,4 +1,5 @@
 import { Context, Probot } from "probot";
+import { isPyTorchPyTorch } from "./utils";
 
 function isCIFlowLabel(label: string): boolean {
   return label.startsWith("ciflow/") || label.startsWith("ci/");
@@ -213,8 +214,14 @@ async function handleLabelEvent(context: Context<"pull_request.labeled">) {
   if (valid_test_config_labels.includes(label)) {
     return;
   }
-
+  
   const prNum = context.payload.pull_request.number;
+  const owner = context.payload.repository.owner.login;
+  const repo = context.payload.repository.name;
+  // https://github.com/pytorch/pytorch/pull/26921 is a special PR that should
+  // never get ciflow tags
+  if (prNum == 26921 && isPytorchPytorch(owner, repo)) {
+  }
   const tag = labelToTag(context.payload.label.name, prNum);
   await syncTag(context, tag, context.payload.pull_request.head.sha);
 }

--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -214,13 +214,13 @@ async function handleLabelEvent(context: Context<"pull_request.labeled">) {
   if (valid_test_config_labels.includes(label)) {
     return;
   }
-  
+
   const prNum = context.payload.pull_request.number;
   const owner = context.payload.repository.owner.login;
   const repo = context.payload.repository.name;
   // https://github.com/pytorch/pytorch/pull/26921 is a special PR that should
   // never get ciflow tags
-  if (prNum == 26921 && isPytorchPytorch(owner, repo)) {
+  if (prNum == 26921 && isPyTorchPyTorch(owner, repo)) {
   }
   const tag = labelToTag(context.payload.label.name, prNum);
   await syncTag(context, tag, context.payload.pull_request.head.sha);


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/26921 is a special PR and should not receive ciflow tags.

Discovered while debugging what is causing [`Build Docker Images`](https://github.com/pytorch/pytorch/actions/runs/3417468707/jobs/5688640075#step:8:34) job to fail