### PR TITLE
Add name parameter to windows ci worker

### DIFF
--- a/.github/workflows/test_windows_job.yml
+++ b/.github/workflows/test_windows_job.yml
@@ -14,6 +14,7 @@ jobs:
       runner: windows.4xlarge
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
+      job-name: "win-py3.8-cpu"
       script: |
         conda create -y -n test python=3.8
         conda activate test
@@ -26,6 +27,7 @@ jobs:
       runner: windows.8xlarge.nvidia.gpu
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
+      job-name: "win-py3.8-cu116"
       timeout: 60
       script: |
         conda create -y -n test python=3.8

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -93,7 +93,7 @@ jobs:
             echo "set -eou pipefail";
             # Without this specific version of pywin32 conda the default conda installation does not work
             # See https://github.com/conda/conda/issues/11503
-            echo "/c/Jenkins/Miniconda3/python.exe -m pip install --upgrade pywin32==30"
+            echo "/c/Jenkins/Miniconda3/python.exe -m pip install --upgrade pywin32==300"
             # Source conda so it's available to the script environment
             echo "source /c/Jenkins/Miniconda3/etc/profile.d/conda.sh";
             echo "${SCRIPT}";

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -39,9 +39,14 @@ on:
         description: "Test infra reference to use"
         default: ""
         type: string
+      job-name:
+        description: "Name for the job, which is displayed in the GitHub UI"
+        default: "windows-job"
+        type: string
 
 jobs:
   job:
+    name: ${{ inputs.job-name }}
     env:
       REPOSITORY: ${{ inputs.repository || github.repository }}
       SCRIPT: ${{ inputs.script }}
@@ -88,7 +93,7 @@ jobs:
             echo "set -eou pipefail";
             # Without this specific version of pywin32 conda the default conda installation does not work
             # See https://github.com/conda/conda/issues/11503
-            echo "/c/Jenkins/Miniconda3/python.exe -m pip install --upgrade pywin32==300"
+            echo "/c/Jenkins/Miniconda3/python.exe -m pip install --upgrade pywin32==30"
             # Source conda so it's available to the script environment
             echo "source /c/Jenkins/Miniconda3/etc/profile.d/conda.sh";
             echo "${SCRIPT}";


### PR DESCRIPTION
This sets job name so that devs can acutally pass job name as a param for example: "win-py3.8-cpu", otherwise it displays as "job". This is specially important since we need to visualize output of this in HUD later