### PR TITLE
Update Windows pip dependencies for opt-einsum

### DIFF
--- a/aws/ami/windows/scripts/Installers/Install-Pip-Dependencies.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-Pip-Dependencies.ps1
@@ -12,5 +12,5 @@ if (-Not (Test-Path -Path $condaHook -PathType Leaf)) {
 # and activate it (without this, python and pip commands won't be recognized)
 conda activate base
 
-# Some dependencies are installed by pip before testing, copying them exactly
-pip install "ninja==1.10.0.post1" future "hypothesis==5.35.1" "expecttest==0.1.3" "librosa>=0.6.2" "scipy==1.6.3" "psutil==5.9.1" "pynvml==11.4.1" pillow "unittest-xml-reporting<=3.2.0,>=2.0.0" pytest pytest-xdist pytest-rerunfailures
+# Some dependencies are installed by pip before testing, pin all of them
+pip install "ninja==1.10.0.post1" "future==0.18.2" "hypothesis==5.35.1" "expecttest==0.1.3" "librosa>=0.6.2" "scipy==1.6.3" "psutil==5.9.1" "pynvml==11.4.1" "pillow==9.2.0" "unittest-xml-reporting<=3.2.0,>=2.0.0" "pytest==7.1.3" "pytest-xdist==2.5.0" "pytest-rerunfailures==10.2" "pytest-shard==0.1.2" "sympy==1.11.1" "xdoctest==1.0.2" "pygments==2.12.0" "opt-einsum>=3.3" "networkx==2.8.8" "mpmath==1.2.1"


### PR DESCRIPTION
This will put all the new dependencies recently added to Windows into the AMI and allow the clean up of Windows conda and pip dependencies

### Testing 

* Build the new AMI `packer build -var 'skip_create_ami=false' .` to generate the new AMI:

```
us-east-1: ami-09867229e1a23e4a4
us-east-2: ami-0d86430cb9c2aa0a8
```

* Launch canary runners with the new AMI `terraform apply -target=module.canary_runners`
* Testing on canary https://github.com/pytorch/pytorch-canary/pull/149

