### PR TITLE
Add BUILD_ENV_FILE to pre-script step

### DIFF
--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -94,6 +94,7 @@ jobs:
             echo "::error::Specified pre-script file (${PRE_SCRIPT}) not found, not going execute it"
             exit 1
           else
+            source "${BUILD_ENV_FILE}"
             ${CONDA_RUN} bash "${PRE_SCRIPT}"
           fi
       - name: Setup base environment variables

--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -98,6 +98,7 @@ jobs:
             echo "::error::Specified pre-script file (${PRE_SCRIPT}) not found, not going execute it"
             exit 1
           else
+            source "${BUILD_ENV_FILE}"
             ${CONDA_RUN} bash "${PRE_SCRIPT}"
           fi
       - name: Setup base environment variables

--- a/.github/workflows/build_conda_windows.yml
+++ b/.github/workflows/build_conda_windows.yml
@@ -95,6 +95,7 @@ jobs:
             echo "::error::Specified pre-script file (${PRE_SCRIPT}) not found, not going execute it"
             exit 1
           else
+            source "${BUILD_ENV_FILE}"
             ${CONDA_RUN} bash "${PRE_SCRIPT}"
           fi
       - name: Setup base environment variables

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -97,6 +97,7 @@ jobs:
             echo "::error::Specified pre-script file (${PRE_SCRIPT}) not found, not going execute it"
             exit 1
           else
+            source "${BUILD_ENV_FILE}"
             ${CONDA_RUN} bash "${PRE_SCRIPT}"
           fi
       - name: Build clean

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -101,6 +101,7 @@ jobs:
             echo "::error::Specified pre-script file (${PRE_SCRIPT}) not found, not going execute it"
             exit 1
           else
+            source "${BUILD_ENV_FILE}"
             ${CONDA_RUN} bash "${PRE_SCRIPT}"
           fi
       - name: Build clean

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -109,6 +109,7 @@ jobs:
             echo "::error::Specified pre-script file (${PRE_SCRIPT}) not found, not going execute it"
             exit 1
           else
+            source "${BUILD_ENV_FILE}"
             ${CONDA_RUN} bash "${PRE_SCRIPT}"
           fi
       - name: Build clean


### PR DESCRIPTION
I am working on making torchdata as a hard dependency of torchtext. Before the step of building torchtext binary, we need to install the right version of `torchdata`.
This PR will give `pre-script` access to the build_type (wheel or conda) and channel (nightly or test) to download/install the right torchdata via `BUILD_ENV_FILE`.

For context: https://github.com/pytorch/text/pull/1985