### PR TITLE
Clean up macos com.apple.coresymbolicationd

### DIFF
--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -154,34 +154,51 @@ runs:
           echo "Print the available disk space for manual inspection"
           df -h
 
-          # Set the minimum requirement space to 4GB
-          MINIMUM_AVAILABLE_SPACE_IN_GB=4
-          MINIMUM_AVAILABLE_SPACE_IN_KB=$(($MINIMUM_AVAILABLE_SPACE_IN_GB * 1024 * 1024))
+          function check_disk_space() {
+            set +e
 
-          # Use KB to avoid floating point warning like 3.1GB
-          df -k | tr -s ' ' | cut -d' ' -f 4,9 | while read -r LINE;
-          do
-            AVAIL=$(echo $LINE | cut -f1 -d' ')
-            MOUNT=$(echo $LINE | cut -f2 -d' ')
+            # Set the minimum requirement space to 4GB
+            MINIMUM_AVAILABLE_SPACE_IN_GB=4
+            MINIMUM_AVAILABLE_SPACE_IN_KB=$(($MINIMUM_AVAILABLE_SPACE_IN_GB * 1024 * 1024))
 
-            if [ "${MOUNT}" = "/" ]; then
-              if [ "${AVAIL}" -lt "${MINIMUM_AVAILABLE_SPACE_IN_KB}" ]; then
-                echo "There is only ${AVAIL}KB free space left in ${MOUNT}, which is less than the minimum requirement of ${MINIMUM_AVAILABLE_SPACE_IN_KB}KB for ${RUNNER_OS}"
+            # Use KB to avoid floating point warning like 3.1GB
+            df -k | tr -s ' ' | cut -d' ' -f 4,9 | while read -r LINE;
+            do
+              AVAIL=$(echo $LINE | cut -f1 -d' ')
+              MOUNT=$(echo $LINE | cut -f2 -d' ')
 
-                if [ "${RUNNER_OS}" = "macOS" ]; then
-                  # We can clean up /System/Library/Caches/com.apple.coresymbolicationd on MacOS to free up the space and this should free up enough space
-                  # https://github.com/pytorch/pytorch/issues/85440
-                  sudo rm "/System/Library/Caches/com.apple.coresymbolicationd/data" || true
-                  # Stop the daemon and launchctl will automatically start it again, thus accomplish a restart and free up the above file
-                  sudo launchctl stop com.apple.coresymbolicationd
-
-                  df -h
+              if [ "${MOUNT}" = "/" ]; then
+                if [ "${AVAIL}" -lt "${MINIMUM_AVAILABLE_SPACE_IN_KB}" ]; then
+                  echo "Failure: There is only ${AVAIL}KB free space left in ${MOUNT}, which is less than the minimum requirement of ${MINIMUM_AVAILABLE_SPACE_IN_KB}KB for ${RUNNER_OS}"
                 else
-                  echo "Please help create an issue to PyTorch Release Engineering via https://github.com/pytorch/test-infra/issues and provide the link to the workflow run."
-                  exit 1;
+                  echo "Success: There is ${AVAIL}KB free space left in ${MOUNT} for ${RUNNER_OS}, continue"
                 fi
-              else
-                echo "There is ${AVAIL}KB free space left in ${MOUNT} for ${RUNNER_OS}, continue"
               fi
-            fi
-          done
+            done
+
+            set -e
+          }
+
+          RESULT=$(check_disk_space)
+          echo "${RESULT}"
+
+          if [[ "${RESULT}" == *Failure* && "${RUNNER_OS}" == "macOS" ]]; then
+            # We can clean up /System/Library/Caches/com.apple.coresymbolicationd on MacOS to free up the space and this should free up enough space
+            # https://github.com/pytorch/pytorch/issues/85440
+            sudo rm "/System/Library/Caches/com.apple.coresymbolicationd/data" || true
+            # Stop the daemon and launchctl will automatically start it again, thus accomplish a restart and free up the above file
+            sudo launchctl stop com.apple.coresymbolicationd || true
+
+            echo "Re-run disk space check for ${RUNNER_OS} after cleaning up"
+            # Re-run the check
+            RESULT=$(check_disk_space)
+            echo "${RESULT}"
+          fi
+
+          if [[ "${RESULT}" == *Failure* ]]; then
+            echo "Please help create an issue to PyTorch Release Engineering via https://github.com/pytorch/test-infra/issues and provide the link to the workflow run."
+            exit 1
+          fi
+
+          echo "Print the available disk space for manual inspection after cleaning up"
+          df -h

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -164,12 +164,24 @@ runs:
             AVAIL=$(echo $LINE | cut -f1 -d' ')
             MOUNT=$(echo $LINE | cut -f2 -d' ')
 
-            if [ "$MOUNT" = "/" ]; then
-              if [ "$AVAIL" -lt "$MINIMUM_AVAILABLE_SPACE_IN_KB" ]; then
-                echo "There is only ${AVAIL}KB free space left in $MOUNT, which is less than the minimum requirement of ${MINIMUM_AVAILABLE_SPACE_IN_KB}KB. Please help create an issue to PyTorch Release Engineering via https://github.com/pytorch/test-infra/issues and provide the link to the workflow run."
-                exit 1;
+            if [ "${MOUNT}" = "/" ]; then
+              if [ "${AVAIL}" -lt "${MINIMUM_AVAILABLE_SPACE_IN_KB}" ]; then
+                echo "There is only ${AVAIL}KB free space left in ${MOUNT}, which is less than the minimum requirement of ${MINIMUM_AVAILABLE_SPACE_IN_KB}KB for ${RUNNER_OS}"
+
+                if [ "${RUNNER_OS}" = "macOS" ]; then
+                  # We can clean up /System/Library/Caches/com.apple.coresymbolicationd on MacOS to free up the space and this should free up enough space
+                  # https://github.com/pytorch/pytorch/issues/85440
+                  sudo rm "/System/Library/Caches/com.apple.coresymbolicationd/data"
+                  # Stop the daemon and launchctl will automatically start it again, thus accomplish a restart and free up the above file
+                  sudo launchctl stop com.apple.coresymbolicationd
+
+                  df -h
+                else
+                  echo "Please help create an issue to PyTorch Release Engineering via https://github.com/pytorch/test-infra/issues and provide the link to the workflow run."
+                  exit 1;
+                fi
               else
-                echo "There is ${AVAIL}KB free space left in $MOUNT, continue"
+                echo "There is ${AVAIL}KB free space left in ${MOUNT} for ${RUNNER_OS}, continue"
               fi
             fi
           done

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -171,7 +171,7 @@ runs:
                 if [ "${RUNNER_OS}" = "macOS" ]; then
                   # We can clean up /System/Library/Caches/com.apple.coresymbolicationd on MacOS to free up the space and this should free up enough space
                   # https://github.com/pytorch/pytorch/issues/85440
-                  sudo rm "/System/Library/Caches/com.apple.coresymbolicationd/data"
+                  sudo rm "/System/Library/Caches/com.apple.coresymbolicationd/data" || true
                   # Stop the daemon and launchctl will automatically start it again, thus accomplish a restart and free up the above file
                   sudo launchctl stop com.apple.coresymbolicationd
 

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -196,9 +196,8 @@ runs:
           fi
 
           if [[ "${RESULT}" == *Failure* ]]; then
+            df -h
+
             echo "Please help create an issue to PyTorch Release Engineering via https://github.com/pytorch/test-infra/issues and provide the link to the workflow run."
             exit 1
           fi
-
-          echo "Print the available disk space for manual inspection after cleaning up"
-          df -h


### PR DESCRIPTION
This addresses https://github.com/pytorch/pytorch/issues/88968 by cleaning up `com.apple.coresymbolicationd` on macos whenever it runs out of space

### Testing

Running the change manually on macos runner:

* Do-nothing case case
```
Print the available disk space for manual inspection
Filesystem       Size   Used  Avail Capacity iused      ifree %iused  Mounted on
/dev/disk5s2s1  100Gi   14Gi   33Gi    31%  501138  342681360    0%   /
devfs           219Ki  219Ki    0Bi   100%     758          0  100%   /dev
/dev/disk5s5    100Gi  6.0Gi   33Gi    16%       6  342681360    0%   /System/Volumes/VM
/dev/disk5s3    100Gi  296Mi   33Gi     1%     700  342681360    0%   /System/Volumes/Preboot
/dev/disk1s2    500Mi  6.0Mi  393Mi     2%       1    4028080    0%   /System/Volumes/xarts
/dev/disk1s1    500Mi   51Mi  393Mi    12%      53    4028080    0%   /System/Volumes/iSCPreboot
/dev/disk1s3    500Mi  224Ki  393Mi     1%      34    4028080    0%   /System/Volumes/Hardware
/dev/disk5s1    100Gi   46Gi   33Gi    59% 3649912  342681360    1%   /System/Volumes/Data
map auto_home     0Bi    0Bi    0Bi   100%       0          0  100%   /System/Volumes/Data/home
/dev/disk3s4    228Gi  400Ki  212Gi     1%      17 2226090120    0%   /private/tmp/tmp-mount-WJ5j4o
Success: There is 34268136KB free space left in / for macOS, continue
```

* Out of space case, try to clean up (I manually set the minimum threshold to 50GB instead of 4 GB)
```
Print the available disk space for manual inspection
Filesystem       Size   Used  Avail Capacity iused      ifree %iused  Mounted on
/dev/disk5s2s1  100Gi   14Gi   33Gi    31%  501138  342680040    0%   /
devfs           219Ki  219Ki    0Bi   100%     758          0  100%   /dev
/dev/disk5s5    100Gi  6.0Gi   33Gi    16%       6  342680040    0%   /System/Volumes/VM
/dev/disk5s3    100Gi  296Mi   33Gi     1%     700  342680040    0%   /System/Volumes/Preboot
/dev/disk1s2    500Mi  6.0Mi  393Mi     2%       1    4028080    0%   /System/Volumes/xarts
/dev/disk1s1    500Mi   51Mi  393Mi    12%      53    4028080    0%   /System/Volumes/iSCPreboot
/dev/disk1s3    500Mi  224Ki  393Mi     1%      34    4028080    0%   /System/Volumes/Hardware
/dev/disk5s1    100Gi   46Gi   33Gi    59% 3649924  342680040    1%   /System/Volumes/Data
map auto_home     0Bi    0Bi    0Bi   100%       0          0  100%   /System/Volumes/Data/home
/dev/disk3s4    228Gi  400Ki  212Gi     1%      17 2226090120    0%   /private/tmp/tmp-mount-WJ5j4o
Failure: There is only 34369660KB free space left in /, which is less than the minimum requirement of 52428800KB for macOS
Re-run disk space check for macOS after cleaning up
Failure: There is only 34369660KB free space left in /, which is less than the minimum requirement of 52428800KB for macOS
Filesystem       Size   Used  Avail Capacity iused      ifree %iused  Mounted on
/dev/disk5s2s1  100Gi   14Gi   33Gi    31%  501138  343696600    0%   /
devfs           219Ki  219Ki    0Bi   100%     758          0  100%   /dev
/dev/disk5s5    100Gi  6.0Gi   33Gi    16%       6  343696600    0%   /System/Volumes/VM
/dev/disk5s3    100Gi  296Mi   33Gi     1%     700  343696600    0%   /System/Volumes/Preboot
/dev/disk1s2    500Mi  6.0Mi  393Mi     2%       1    4028080    0%   /System/Volumes/xarts
/dev/disk1s1    500Mi   51Mi  393Mi    12%      53    4028080    0%   /System/Volumes/iSCPreboot
/dev/disk1s3    500Mi  224Ki  393Mi     1%      34    4028080    0%   /System/Volumes/Hardware
/dev/disk5s1    100Gi   46Gi   33Gi    59% 3650200  343696600    1%   /System/Volumes/Data
map auto_home     0Bi    0Bi    0Bi   100%       0          0  100%   /System/Volumes/Data/home
/dev/disk3s4    228Gi  400Ki  212Gi     1%      17 2226090120    0%   /private/tmp/tmp-mount-WJ5j4o
Please help create an issue to PyTorch Release Engineering via https://github.com/pytorch/test-infra/issues and provide the link to the workflow run.
```