### PR TITLE
Modifying generate binary build matrix. Prepare to migrate Pytorch core to this script

### DIFF
--- a/.github/workflows/test_build_conda_linux_with_cuda.yml
+++ b/.github/workflows/test_build_conda_linux_with_cuda.yml
@@ -7,7 +7,7 @@ on:
       - .github/workflows/test_build_conda_linux.yml
       - .github/workflows/build_conda_linux.yml
       - .github/workflows/generate_binary_build_matrix.yml
-      - tools/scripts/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.py
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_build_conda_linux_with_cuda.yml
+++ b/.github/workflows/test_build_conda_linux_with_cuda.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/test_build_conda_linux.yml
       - .github/workflows/build_conda_linux.yml
       - .github/workflows/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.yml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_build_conda_linux_without_cuda.yml
+++ b/.github/workflows/test_build_conda_linux_without_cuda.yml
@@ -7,7 +7,7 @@ on:
       - .github/workflows/test_build_conda_linux.yml
       - .github/workflows/build_conda_linux.yml
       - .github/workflows/generate_binary_build_matrix.yml
-      - tools/scripts/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.py
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_build_conda_linux_without_cuda.yml
+++ b/.github/workflows/test_build_conda_linux_without_cuda.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/test_build_conda_linux.yml
       - .github/workflows/build_conda_linux.yml
       - .github/workflows/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.yml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_build_conda_m1.yml
+++ b/.github/workflows/test_build_conda_m1.yml
@@ -7,7 +7,7 @@ on:
       - .github/workflows/test_build_conda_m1.yml
       - .github/workflows/build_conda_macos.yml
       - .github/workflows/generate_binary_build_matrix.yml
-      - tools/scripts/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.py
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_build_conda_m1.yml
+++ b/.github/workflows/test_build_conda_m1.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/test_build_conda_m1.yml
       - .github/workflows/build_conda_macos.yml
       - .github/workflows/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.yml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_build_conda_macos.yml
+++ b/.github/workflows/test_build_conda_macos.yml
@@ -7,7 +7,7 @@ on:
       - .github/workflows/test_build_conda_macos.yml
       - .github/workflows/build_conda_macos.yml
       - .github/workflows/generate_binary_build_matrix.yml
-      - tools/scripts/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.py
 
 jobs:
   generate-matrix:

--- a/.github/workflows/test_build_conda_macos.yml
+++ b/.github/workflows/test_build_conda_macos.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/test_build_conda_macos.yml
       - .github/workflows/build_conda_macos.yml
       - .github/workflows/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.yml
 
 jobs:
   generate-matrix:

--- a/.github/workflows/test_build_conda_windows_without_cuda.yml
+++ b/.github/workflows/test_build_conda_windows_without_cuda.yml
@@ -7,7 +7,7 @@ on:
       - .github/workflows/test_build_conda_windows_without_cuda.yml
       - .github/workflows/build_conda_windows.yml
       - .github/workflows/generate_binary_build_matrix.yml
-      - tools/scripts/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.py
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_build_conda_windows_without_cuda.yml
+++ b/.github/workflows/test_build_conda_windows_without_cuda.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/test_build_conda_windows_without_cuda.yml
       - .github/workflows/build_conda_windows.yml
       - .github/workflows/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.yml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_build_wheels_linux_with_cuda.yml
+++ b/.github/workflows/test_build_wheels_linux_with_cuda.yml
@@ -8,6 +8,7 @@ on:
       - .github/workflows/build_wheels_linux.yml
       - .github/workflows/generate_binary_build_matrix.yml
       - .github/workflows/test_build_wheels_linux_with_cuda.yml
+      - tools/scripts/generate_binary_build_matrix.yml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_build_wheels_linux_with_cuda.yml
+++ b/.github/workflows/test_build_wheels_linux_with_cuda.yml
@@ -8,7 +8,7 @@ on:
       - .github/workflows/build_wheels_linux.yml
       - .github/workflows/generate_binary_build_matrix.yml
       - .github/workflows/test_build_wheels_linux_with_cuda.yml
-      - tools/scripts/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.py
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_build_wheels_linux_without_cuda.yml
+++ b/.github/workflows/test_build_wheels_linux_without_cuda.yml
@@ -8,6 +8,7 @@ on:
       - .github/workflows/build_wheels_linux.yml
       - .github/workflows/generate_binary_build_matrix.yml
       - .github/workflows/test_build_wheels_linux_without_cuda.yml
+      - tools/scripts/generate_binary_build_matrix.yml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_build_wheels_linux_without_cuda.yml
+++ b/.github/workflows/test_build_wheels_linux_without_cuda.yml
@@ -8,7 +8,7 @@ on:
       - .github/workflows/build_wheels_linux.yml
       - .github/workflows/generate_binary_build_matrix.yml
       - .github/workflows/test_build_wheels_linux_without_cuda.yml
-      - tools/scripts/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.py
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_build_wheels_m1.yml
+++ b/.github/workflows/test_build_wheels_m1.yml
@@ -7,7 +7,7 @@ on:
       - .github/workflows/test_build_wheels_m1.yml
       - .github/workflows/build_wheels_macos.yml
       - .github/workflows/generate_binary_build_matrix.yml
-      - tools/scripts/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.py
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_build_wheels_m1.yml
+++ b/.github/workflows/test_build_wheels_m1.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/test_build_wheels_m1.yml
       - .github/workflows/build_wheels_macos.yml
       - .github/workflows/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.yml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_build_wheels_macos.yml
+++ b/.github/workflows/test_build_wheels_macos.yml
@@ -7,7 +7,7 @@ on:
       - .github/workflows/test_build_wheels_macos.yml
       - .github/workflows/build_wheels_macos.yml
       - .github/workflows/generate_binary_build_matrix.yml
-      - tools/scripts/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.py
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_build_wheels_macos.yml
+++ b/.github/workflows/test_build_wheels_macos.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/test_build_wheels_macos.yml
       - .github/workflows/build_wheels_macos.yml
       - .github/workflows/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.yml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_build_wheels_windows.yml
+++ b/.github/workflows/test_build_wheels_windows.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/test_build_wheels_windows.yml
       - .github/workflows/build_wheels_windows.yml
       - .github/workflows/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.yml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_build_wheels_windows.yml
+++ b/.github/workflows/test_build_wheels_windows.yml
@@ -7,7 +7,7 @@ on:
       - .github/workflows/test_build_wheels_windows.yml
       - .github/workflows/build_wheels_windows.yml
       - .github/workflows/generate_binary_build_matrix.yml
-      - tools/scripts/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.py
   workflow_dispatch:
 
 jobs:

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -297,6 +297,7 @@ def generate_wheels_matrix(
     channel: str,
     with_cuda: str,
     with_py311: str,
+    with_pypi_cudnn: str = DISABLE,
     arches: Optional[List[str]] = None,
     python_versions: Optional[List[str]] = None,
 ) -> List[Dict[str, str]]:
@@ -338,7 +339,7 @@ def generate_wheels_matrix(
             installation_pypi = ""
             # special 11.7 wheels package without dependencies
             # dependency downloaded via pip install
-            if arch_version == "11.7" and os == "linux":
+            if arch_version == "11.7" and os == "linux" and with_pypi_cudnn == ENABLE:
                 installation_pypi = get_wheel_install_command(channel, gpu_arch_type, desired_cuda, python_version, True)
                 ret.append(
                     {


### PR DESCRIPTION
This is first PR in consolidating release matrix script logic. Make sure test-infra script creates matrix compatible with pytorch/core

Test PR: https://github.com/pytorch/pytorch/pull/88997
Called regenerate.sh
(note: No generated workflows updated after calling regenerate.sh)