### PR TITLE
Upgrade to secure version of minimatch & upgrade deprecated lambda nodejs12 runtime

### DIFF
--- a/terraform-aws-github-runner/modules/runner-binaries-syncer/runner-binaries-syncer.tf
+++ b/terraform-aws-github-runner/modules/runner-binaries-syncer/runner-binaries-syncer.tf
@@ -11,7 +11,7 @@ resource "aws_lambda_function" "syncer" {
   function_name     = "${var.environment}-syncer"
   role              = aws_iam_role.syncer_lambda.arn
   handler           = "index.handler"
-  runtime           = "nodejs12.x"
+  runtime           = "nodejs16.x"
   timeout           = var.lambda_timeout
   memory_size       = 500
 

--- a/terraform-aws-github-runner/modules/webhook/lambdas/webhook/package.json
+++ b/terraform-aws-github-runner/modules/webhook/lambdas/webhook/package.json
@@ -35,5 +35,8 @@
   "dependencies": {
     "@octokit/rest": "^18.3.5",
     "@octokit/webhooks": "^9.14.0"
+  },
+  "resolutions": {
+    "minimatch": "^3.0.5"
   }
 }

--- a/terraform-aws-github-runner/modules/webhook/lambdas/webhook/yarn.lock
+++ b/terraform-aws-github-runner/modules/webhook/lambdas/webhook/yarn.lock
@@ -3443,10 +3443,10 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-minimatch@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
-  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+minimatch@^3.0.4, minimatch@^3.0.5:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 

--- a/terraform-aws-github-runner/modules/webhook/webhook.tf
+++ b/terraform-aws-github-runner/modules/webhook/webhook.tf
@@ -35,7 +35,7 @@ resource "aws_lambda_function" "webhook" {
   function_name     = "${var.environment}-webhook"
   role              = aws_iam_role.webhook_lambda.arn
   handler           = "index.githubWebhook"
-  runtime           = "nodejs12.x"
+  runtime           = "nodejs16.x"
   timeout           = var.lambda_timeout
 
   environment {


### PR DESCRIPTION
This PR contains two changes:
1. Fixes a security vuln with the minimatch package (identified by github). More details below
2. Upgrades the aws nodejs runtime past the now End-of-support nodejs12 runtime, which the tflint complained about after fixing the above security vuln

# Package Dependency
- Repository: [pytorch/test-infra](https://github.com/pytorch/test-infra)
- Manifest file: [terraform-aws-github-runner/modules/webhook/lambdas/webhook/yarn.lock](https://github.com/pytorch/test-infra/blob/main/terraform-aws-github-runner/modules/webhook/lambdas/webhook/yarn.lock)
- Package name: [minimatch](https://npmjs.com/package/minimatch)
- Affected versions: < 3.0.5
- Fixed in version: 3.0.5
- Severity: HIGH

# References
https://nvd.nist.gov/vuln/detail/CVE-2022-3517
https://github.com/grafana/grafana-image-renderer/issues/329
https://github.com/isaacs/minimatch/commit/a8763f4388e51956be62dc6025cec1126beeb5e6
https://github.com/nodejs/node/issues/42510
https://github.com/advisories/GHSA-f8q6-p94x-37v3