### PR TITLE
Detect faulty ROCm runner in logs

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -29,6 +29,10 @@ name = 'GHA timeout'
 pattern = '^##\[error\]The action has timed out.'
 
 [[rule]]
+name = 'Faulty ROCM runner'
+pattern = 'Error: .*[dD]etect.*GPUs on the runner'
+
+[[rule]]
 name = 'GHA cancellation'
 pattern = 'The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.'
 


### PR DESCRIPTION
This PR will result in better diagnosis for workflows that failed due to faulty ROCm runners.

It adds a ruleset for detecting faulty ROCm runners. When a ROCm runner does not have 2 or 4 GPUs, it's considered faulty and the workflow kills the GH action. This manifests in a generic "runner has received a shutdown signal." log line being highlighted in HUD

Example: In [this workflow](https://hud.pytorch.org/pytorch/pytorch/commit/6fe4ccc7cbd5e953e5888947229945f7590e3bfe) the job `linux-focal-rocm5.2-py3.8 / test (default, 2, 2, linux.rocm.gpu)` appeared to fail because of a Github initiated shutdown signal, when in fact the workflow had detected the runner was faulty and initiated the kill signal on it's own

