### PR TITLE
Extend retrybot to trunk and *-binaries workflows

### DIFF
--- a/torchci/lib/bot/retryBot.ts
+++ b/torchci/lib/bot/retryBot.ts
@@ -6,11 +6,21 @@ function retryBot(app: Probot): void {
   app.on("workflow_run.completed", async (ctx) => {
     const workflowName = ctx.payload.workflow_run.name;
     const attemptNumber = ctx.payload.workflow_run.run_attempt;
+    const allowedWorkflowPrefixes = [
+      "lint",
+      "pull",
+      "trunk",
+      "linux-binary",
+      "windows-binary"
+    ]
+
     if (
       ctx.payload.workflow_run.conclusion === "success" ||
       ctx.payload.workflow_run.head_branch !== "master" ||
       attemptNumber > 1 ||
-      !["lint", "pull"].includes(workflowName.toLowerCase()) // only do lint and pull for now because they are fast
+      allowedWorkflowPrefixes.every(
+        allwedWorkflow => !workflowName.toLowerCase().includes(allwedWorkflow)
+      )
     ) {
       return;
     }

--- a/torchci/lib/bot/retryBot.ts
+++ b/torchci/lib/bot/retryBot.ts
@@ -19,7 +19,7 @@ function retryBot(app: Probot): void {
       ctx.payload.workflow_run.head_branch !== "master" ||
       attemptNumber > 1 ||
       allowedWorkflowPrefixes.every(
-        allwedWorkflow => !workflowName.toLowerCase().includes(allwedWorkflow)
+        allowedWorkflow => !workflowName.toLowerCase().includes(allowedWorkflow)
       )
     ) {
       return;


### PR DESCRIPTION
So far we've limited retry bot to just the lint and pull workflows on the master branch as a way to limit the blast radius while experimenting with this new feature.

The logic seems to work well, so we'll extend this behavior to all workflows that block viable/strict upgrades (which should help reduce TTS).

As a future step, we can also start enabling retrys on PRs requests as well, except there we prob shouldn't retry the build step either.