### PR TITLE
Identify docker errors

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -198,7 +198,7 @@ pattern = 'An unexpected error has occurred. Conda has prepared the above report
 
 [[rule]]
 name = 'Docker error'
-pattern = 'docker: Error.*'
+pattern = '^docker: Error.*'
 
 [[rule]]
 name = 'GHA error'

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -197,5 +197,9 @@ name = 'conda failure'
 pattern = 'An unexpected error has occurred. Conda has prepared the above report.'
 
 [[rule]]
+name = 'Docker error'
+pattern = 'docker: Error.*'
+
+[[rule]]
 name = 'GHA error'
 pattern = '^##\[error\](.*)'


### PR DESCRIPTION
Better identify failures caused by docker, especially docker daemon errors

Keeping the regex a bit generic in case docker has other error messages beyond `docker: Error response from daemon`

Example log that this will correctly classify: https://hud.pytorch.org/pytorch/pytorch/commit/98ecd06580b667441a45bfe7a67bc95ddb8a9353

```
2022-11-10T19:56:18.0780433Z ++ docker run --gpus all -e BUILD_ENVIRONMENT -e PR_NUMBER -e GITHUB_ACTIONS -e BASE_SHA -e BRANCH -e SHA1 -e AWS_DEFAULT_REGION -e IN_WHEEL_TEST -e SHARD_NUMBER -e TEST_CONFIG -e NUM_TEST_SHARDS -e PR_BODY -e COMMIT_MESSAGES -e PYTORCH_RETRY_TEST_CASES -e PYTORCH_OVERRIDE_FLAKY_SIGNAL -e PR_LABELS -e MAX_JOBS=14 -e SCCACHE_BUCKET -e SCCACHE_S3_KEY_PREFIX -e XLA_CUDA -e XLA_CLANG_CACHE_S3_BUCKET_NAME -e PYTORCH_TEST_CUDA_MEM_LEAK_CHECK --env-file=/tmp/github_env_3439825433 --ulimit stack=10485760:83886080 --security-opt seccomp=unconfined --cap-add=SYS_PTRACE --ipc=host --shm-size=2g --tty --detach --name= --user jenkins -v /home/ec2-user/actions-runner/_work/pytorch/pytorch:/var/lib/jenkins/workspace -w /var/lib/jenkins/workspace 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-cuda11.6-cudnn8-py3-gcc7:1401ccaeefe6e3354ad5dfae8aca135851e7408b
2022-11-10T19:56:31.3728100Z docker: Error response from daemon: unable to find user jenkins: no matching entries in passwd file.
2022-11-10T19:56:31.3763062Z + container_name=cd4c3be285ee90a49d83ca7716a7a4edf74081ed09016a602a1bbf28d7966394
2022-11-10T19:56:31.3769972Z ##[error]Process completed with exit code 125.
```