### PR TITLE
Don't match the echo command

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -30,7 +30,7 @@ pattern = '^##\[error\]The action has timed out.'
 
 [[rule]]
 name = 'Faulty ROCM runner'
-pattern = '[^"]Error: .*[dD]etect.*GPUs on the runner'
+pattern = '^Error: .*[dD]etect.*GPUs on the runner'
 
 [[rule]]
 name = 'GHA cancellation'

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -30,7 +30,7 @@ pattern = '^##\[error\]The action has timed out.'
 
 [[rule]]
 name = 'Faulty ROCM runner'
-pattern = 'Error: .*[dD]etect.*GPUs on the runner'
+pattern = '[^"]Error: .*[dD]etect.*GPUs on the runner'
 
 [[rule]]
 name = 'GHA cancellation'


### PR DESCRIPTION
Follow up fix for https://github.com/pytorch/test-infra/pull/1092

Since the ROCm workflow logs include the entire command that would result in an echo _if_ there's a bad runner, the log classifier sees those `echo` lines and assumes that they're the error message we want

Tweaking the regex to not match the echo statements by ensuring the line starts with the error message

Example: https://hud.pytorch.org/pytorch/pytorch/commit/cf6003f0469ae1440d4a8585860c2c5f4c738707
```
Run ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
  ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
  if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
      if [[ $ngpu -eq 0 ]]; then
        echo "Error: Failed to detect any GPUs on the runner"
      else
        echo "Error: Detected $ngpu GPUs on the runner, when only 2 or 4 were expected"
      fi
      echo "Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
      exit 1
  fi
  shell: /bin/bash --noprofile --norc -e -o pipefail {0}
```