### PR TITLE
Update flaky test query

### DIFF
--- a/torchci/rockset/commons/__sql/flaky_tests.sql
+++ b/torchci/rockset/commons/__sql/flaky_tests.sql
@@ -30,11 +30,12 @@ WITH flaky_tests AS (
         INNER JOIN commons.test_run_s3 test_run ON test_run.job_id = job.id HINT(join_strategy = lookup)
         INNER JOIN commons.workflow_run workflow ON job.run_id = workflow.id
     WHERE
-        test_run.skipped.message LIKE '{"flaky": True%'
+        test_run.skipped.message LIKE '{%"flaky": _rue%'
         AND test_run._event_time > (CURRENT_TIMESTAMP() - HOURs(:numHours))
         AND test_run.name LIKE :name
         AND test_run.classname LIKE :suite
         AND test_run.file LIKE :file
+        AND job.name not like '%rerun_disabled_tests%'
     GROUP BY
         name,
         suite,
@@ -69,6 +70,7 @@ WITH flaky_tests AS (
         AND test_run.name LIKE :name
         AND test_run.classname LIKE :suite
         AND test_run.file LIKE :file
+        AND job.name not like '%rerun_disabled_tests%'
     GROUP BY
         name,
         suite,

--- a/torchci/rockset/commons/__sql/flaky_tests.sql
+++ b/torchci/rockset/commons/__sql/flaky_tests.sql
@@ -35,7 +35,7 @@ WITH flaky_tests AS (
         AND test_run.name LIKE :name
         AND test_run.classname LIKE :suite
         AND test_run.file LIKE :file
-        AND job.name not like '%rerun_disabled_tests%'
+        AND job.name NOT LIKE '%rerun_disabled_tests%'
     GROUP BY
         name,
         suite,
@@ -70,7 +70,7 @@ WITH flaky_tests AS (
         AND test_run.name LIKE :name
         AND test_run.classname LIKE :suite
         AND test_run.file LIKE :file
-        AND job.name not like '%rerun_disabled_tests%'
+        AND job.name NOT LIKE '%rerun_disabled_tests%'
     GROUP BY
         name,
         suite,

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -4,7 +4,7 @@
     "hud_query": "bf634305df7c3129",
     "commit_jobs_query": "442a6f64bd44f351",
     "filter_forced_merge_pr": "7264f7c4160646ec",
-    "flaky_tests": "86bd9b8156c33dca",
+    "flaky_tests": "61d92fef1e951b65",
     "flaky_workflows_jobs": "8b16d1b8d733291d",
     "slow_tests": "ef8d035d23aa8ab6",
     "test_time_per_file": "1c8d6289623181d8",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -4,7 +4,7 @@
     "hud_query": "bf634305df7c3129",
     "commit_jobs_query": "442a6f64bd44f351",
     "filter_forced_merge_pr": "7264f7c4160646ec",
-    "flaky_tests": "61d92fef1e951b65",
+    "flaky_tests": "a869115d6650c28c",
     "flaky_workflows_jobs": "8b16d1b8d733291d",
     "slow_tests": "ef8d035d23aa8ab6",
     "test_time_per_file": "1c8d6289623181d8",


### PR DESCRIPTION
There are some changes needed due to changes in common_utils as a result of rerun disabled tests
* the skipped message now looks like `"message": "{\"num_red\": 1, \"num_green\": 1, \"max_num_retries\": 3, \"rerun_disabled_test\": false, \"flaky\": true}"`
* we don't want to include anything coming from rerun_disabled_tests