### PR TITLE
Add a log classfifier rule for makefile build failure

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -37,6 +37,10 @@ name = 'GHA cancellation'
 pattern = 'The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.'
 
 [[rule]]
+name = 'make build failure'
+pattern = '''^Makefile:\d+: recipe for target '.+' failed'''
+
+[[rule]]
 name = 'bazel build failure'
 pattern = '^Target //:\w+ failed to build'
 


### PR DESCRIPTION
At the moment, the error points to `[error]Process completed with exit code 1` https://hud.pytorch.org/pytorch/pytorch/commit/8ebbd5a89a66bf84d7358f4d353ec2708d6c5429.  It should ideally point to `virtual memory exhausted: Cannot allocate memory` instead but that error is too specific, so I'm adding a rule to point to the very next line `Makefile:73: recipe for target '/var/lib/jenkins/cpp-build/caffe2/build/nccl/obj/collectives/device/devlink.o' failed`

```
2022-11-16T05:12:14.3418222Z virtual memory exhausted: Cannot allocate memory
2022-11-16T05:12:14.9425521Z Makefile:73: recipe for target '/var/lib/jenkins/cpp-build/caffe2/build/nccl/obj/collectives/device/devlink.o' failed
2022-11-16T05:12:14.9427141Z make[5]: *** [/var/lib/jenkins/cpp-build/caffe2/build/nccl/obj/collectives/device/devlink.o] Error 1
2022-11-16T05:12:14.9444868Z make[5]: Leaving directory '/var/lib/jenkins/workspace/third_party/nccl/nccl/src/collectives/device'
2022-11-16T05:12:14.9445693Z Makefile:51: recipe for target '/var/lib/jenkins/cpp-build/caffe2/build/nccl/obj/collectives/device/colldevice.a' failed
2022-11-16T05:12:14.9446478Z make[4]: *** [/var/lib/jenkins/cpp-build/caffe2/build/nccl/obj/collectives/device/colldevice.a] Error 2
2022-11-16T05:12:14.9514866Z make[4]: Leaving directory '/var/lib/jenkins/workspace/third_party/nccl/nccl/src'
2022-11-16T05:12:14.9515445Z Makefile:25: recipe for target 'src.build' failed
2022-11-16T05:12:14.9515801Z make[3]: *** [src.build] Error 2
2022-11-16T05:12:14.9516334Z make[3]: Leaving directory '/var/lib/jenkins/workspace/third_party/nccl/nccl'
2022-11-16T05:12:14.9517215Z CMakeFiles/nccl_external.dir/build.make:85: recipe for target 'nccl_external-prefix/src/nccl_external-stamp/nccl_external-build' failed
2022-11-16T05:12:14.9518055Z make[2]: *** [nccl_external-prefix/src/nccl_external-stamp/nccl_external-build] Error 2
2022-11-16T05:12:14.9518715Z make[2]: Leaving directory '/var/lib/jenkins/cpp-build/caffe2/build'
2022-11-16T05:12:14.9519405Z CMakeFiles/Makefile2:2035: recipe for target 'CMakeFiles/nccl_external.dir/all' failed
2022-11-16T05:12:14.9519902Z make[1]: *** [CMakeFiles/nccl_external.dir/all] Error 2
2022-11-16T05:12:14.9520320Z make[1]: *** Waiting for unfinished jobs....
```