### PR TITLE
Downgrade node version to 14.x for lambdas

### DIFF
--- a/terraform-aws-github-runner/modules/runner-binaries-syncer/runner-binaries-syncer.tf
+++ b/terraform-aws-github-runner/modules/runner-binaries-syncer/runner-binaries-syncer.tf
@@ -11,7 +11,7 @@ resource "aws_lambda_function" "syncer" {
   function_name     = "${var.environment}-syncer"
   role              = aws_iam_role.syncer_lambda.arn
   handler           = "index.handler"
-  runtime           = "nodejs16.x"
+  runtime           = "nodejs14.x"
   timeout           = var.lambda_timeout
   memory_size       = 500
 

--- a/terraform-aws-github-runner/modules/webhook/webhook.tf
+++ b/terraform-aws-github-runner/modules/webhook/webhook.tf
@@ -35,7 +35,7 @@ resource "aws_lambda_function" "webhook" {
   function_name     = "${var.environment}-webhook"
   role              = aws_iam_role.webhook_lambda.arn
   handler           = "index.githubWebhook"
-  runtime           = "nodejs16.x"
+  runtime           = "nodejs14.x"
   timeout           = var.lambda_timeout
 
   environment {


### PR DESCRIPTION
this is related to the commit: https://github.com/pytorch/test-infra/commit/f7e9783e6ba4186fbb1d0a3904e447265c1adfb0