### PR TITLE
remove mypy disabling of warn_unused_ignores

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,12 +3,14 @@ name: Lint
 on:
   pull_request:
     paths:
+      - mypy.ini
       - '**.py'
       - '**requirements.txt'
   push:
     branches:
       - main
     paths:
+      - mypy.ini
       - '**.py'
       - '**requirements.txt'
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -24,9 +24,5 @@ warn_return_any = True
 implicit_reexport = False
 strict_equality = True
 
-# do not reenable this:
-# https://github.com/pytorch/pytorch/pull/60006#issuecomment-866130657
-warn_unused_ignores = False
-
 files =
     aws/lambda/github-status-sync/lambda_function.py


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/test-infra/pull/1124).
* #1125
* __->__ #1124
* #1126

remove mypy disabling of warn_unused_ignores

Summary:
This makes sense for the pytorch/pytorch repo where we have a very
diverse band of committers using diverse hardware and setups, but it
makes less sense for pytorch/test-infra where we have a small core
team who have very similar hardware and all work for Meta.

We can all use a similar enough setup to avoid compatibility problems
with this setting.

Test Plan:
Rely on CI.

