### PR TITLE
use mypy --strict

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,12 +3,14 @@ name: Lint
 on:
   pull_request:
     paths:
+      - mypy.ini
       - '**.py'
       - '**requirements.txt'
   push:
     branches:
       - main
     paths:
+      - mypy.ini
       - '**.py'
       - '**requirements.txt'
 

--- a/aws/lambda/github-status-sync/lambda_function.py
+++ b/aws/lambda/github-status-sync/lambda_function.py
@@ -1,5 +1,5 @@
 import asyncio
-import aiohttp  # type: ignore
+import aiohttp
 import math
 import os
 import datetime
@@ -351,7 +351,7 @@ class GraphQL:
         remaining = headers.get("X-RateLimit-Remaining")
         used = headers.get("X-RateLimit-Used")
         total = headers.get("X-RateLimit-Limit")
-        reset_timestamp = int(headers.get("X-RateLimit-Reset", 0))  # type: ignore
+        reset_timestamp = int(headers.get("X-RateLimit-Reset", 0))
         reset = datetime.datetime.fromtimestamp(reset_timestamp).strftime(
             "%a, %d %b %Y %H:%M:%S"
         )

--- a/mypy.ini
+++ b/mypy.ini
@@ -24,9 +24,5 @@ warn_return_any = True
 implicit_reexport = False
 strict_equality = True
 
-# do not reenable this:
-# https://github.com/pytorch/pytorch/pull/60006#issuecomment-866130657
-warn_unused_ignores = False
-
 files =
     aws/lambda/github-status-sync/lambda_function.py

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,27 +2,10 @@
 [mypy]
 python_version = 3.8
 
-strict_optional = True
 show_error_codes = True
 show_column_numbers = True
-warn_no_return = True
-disallow_any_unimported = True
 
-# Across versions of mypy, the flags toggled by --strict vary.  To ensure
-# we have reproducible type check, we instead manually specify the flags
-warn_unused_configs = True
-disallow_any_generics = True
-disallow_subclassing_any = True
-disallow_untyped_calls = True
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-check_untyped_defs = True
-disallow_untyped_decorators = True
-no_implicit_optional = True
-warn_redundant_casts = True
-warn_return_any = True
-implicit_reexport = False
-strict_equality = True
+strict = True
 
 files =
     aws/lambda/github-status-sync/lambda_function.py


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/test-infra/pull/1125).
* __->__ #1125
* #1124
* #1126

use mypy --strict

Summary:
The advice for the pytorch/pytorch repo doesn't hold in
pytorch/test-infra because we don't have a heterogenous group of
developers. We can converge on a more modern version of mypy, and it
is already fixed in CI.

We eliminate any flags that are included in mypy --strict or that is
already set to the default.

