### PR TITLE
Add `instructions` parameter to setup-ssh

### DIFF
--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -18,6 +18,9 @@ inputs:
     required: true
     description: 'Removes existing keys at ~/.ssh/authorized_keys before adding new ones'
     default: true
+  instructions:
+    required: false
+    description: 'Additional instructions on what to do next'
 
 runs:
   using: 'node16'

--- a/.github/actions/setup-ssh/index.js
+++ b/.github/actions/setup-ssh/index.js
@@ -12812,6 +12812,7 @@ async function run() {
         const activateWithLabel = core.getBooleanInput('activate-with-label');
         const sshLabel = core.getInput('label');
         const github_token = core.getInput('github-secret');
+        const instructions = core.getInput('instructions');
         const removeExistingKeys = core.getBooleanInput('remove-existing-keys');
         let prNumber = (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.number;
         if (github.context.eventName !== 'pull_request') {
@@ -12859,7 +12860,11 @@ async function run() {
             if (hostname === '') {
                 hostname = (await getIPs()).ipv4;
             }
-            core.info(`Login using: ssh ${external_os_default().userInfo().username}@${hostname}`);
+            const username = external_os_default().userInfo().username;
+            core.info(`Login using: ssh ${username}@${hostname}`);
+            if (instructions) {
+                core.info(`{instructions.replace('%%hostname%%', hostname).replace('%%username%%', username)}`);
+            }
             // Return early if we can get the right keys on the first try
             return;
         }

--- a/.github/actions/setup-ssh/index.js
+++ b/.github/actions/setup-ssh/index.js
@@ -12863,7 +12863,7 @@ async function run() {
             const username = external_os_default().userInfo().username;
             core.info(`Login using: ssh ${username}@${hostname}`);
             if (instructions) {
-                core.info(`{instructions.replace('%%hostname%%', hostname).replace('%%username%%', username)}`);
+                core.info(instructions.replace('%%hostname%%', hostname).replace('%%username%%', username));
             }
             // Return early if we can get the right keys on the first try
             return;

--- a/.github/workflows/test-setup-ssh.yml
+++ b/.github/workflows/test-setup-ssh.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
           activate-with-label: false
+          instructions: "First install, username is %%username%%"
       - uses: ./.github/actions/setup-ssh
         name: Check if can overwrite keys
         with:
@@ -55,6 +56,7 @@ jobs:
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
           activate-with-label: false
+          instructions: "SSH with rdesktop using ssh -L 3389:localhost:3389 %%username%%@%%hostname%%"
       - uses: ./.github/actions/setup-ssh
         name: Check if can overwrite keys
         with:

--- a/setup-ssh/src/main.ts
+++ b/setup-ssh/src/main.ts
@@ -19,6 +19,7 @@ async function run(): Promise<void> {
     )
     const sshLabel: string = core.getInput('label')
     const github_token: string = core.getInput('github-secret')
+    const instructions: string = core.getInput('instructions')
     const removeExistingKeys: boolean = core.getBooleanInput(
       'remove-existing-keys'
     )
@@ -76,7 +77,11 @@ async function run(): Promise<void> {
       if (hostname === '') {
         hostname = (await getIPs()).ipv4
       }
-      core.info(`Login using: ssh ${os.userInfo().username}@${hostname}`)
+      const username = os.userInfo().username
+      core.info(`Login using: ssh ${username}@${hostname}`)
+      if (instructions) {
+        core.info(`{instructions.replace('%%hostname%%', hostname).replace('%%username%%', username)}`)
+      }
       // Return early if we can get the right keys on the first try
       return
     }

--- a/setup-ssh/src/main.ts
+++ b/setup-ssh/src/main.ts
@@ -80,7 +80,7 @@ async function run(): Promise<void> {
       const username = os.userInfo().username
       core.info(`Login using: ssh ${username}@${hostname}`)
       if (instructions) {
-        core.info(`{instructions.replace('%%hostname%%', hostname).replace('%%username%%', username)}`)
+        core.info(instructions.replace('%%hostname%%', hostname).replace('%%username%%', username))
       }
       // Return early if we can get the right keys on the first try
       return


### PR DESCRIPTION
Needed to be able to provide better instructions on how to login into container and debug

Test plan: https://github.com/pytorch/test-infra/actions/runs/3499420140/jobs/5860961273#step:3:12