### PR TITLE
parameterize the api checker on head and base commits

### DIFF
--- a/tools/stronghold/src/api/checker.py
+++ b/tools/stronghold/src/api/checker.py
@@ -2,6 +2,7 @@
 
 import argparse
 import pathlib
+import pprint
 import sys
 
 import api.compatibility
@@ -10,7 +11,17 @@ import api.git
 
 def run() -> None:
     parser = argparse.ArgumentParser(prog=sys.argv[0], description=__doc__)
-    parser.parse_args(sys.argv[1:])
+    parser.add_argument('--base-commit', type=str, required=True)
+    parser.add_argument('--head-commit', type=str, required=True)
+    args = parser.parse_args(sys.argv[1:])
 
     repo = api.git.Repository(pathlib.Path('.'))
-    api.compatibility.check_range(repo, head='HEAD', base='HEAD~')
+    violations = api.compatibility.check_range(
+        repo, head=args.head_commit, base=args.base_commit
+    )
+    if len(violations) == 0:
+        return
+    for file, file_violations in violations.items():
+        print(file)
+        pprint.pp(file_violations)
+    sys.exit(1)


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/test-infra/pull/1140).
* #1143
* #1142
* #1141
* __->__ #1140

parameterize the api checker on head and base commits

