### PR TITLE
Fixes to correctly assign the security group to the ec2 runner

### DIFF
--- a/terraform-aws-github-runner/main.tf
+++ b/terraform-aws-github-runner/main.tf
@@ -67,6 +67,7 @@ module "runners" {
   // TODO remove-me
   vpc_id               = var.vpc_id
   vpc_ids              = var.vpc_ids
+  vpc_sgs              = var.vpc_sgs
   subnet_vpc_ids       = var.subnet_vpc_ids
   environment          = var.environment
   tags                 = local.tags

--- a/terraform-aws-github-runner/main.tf
+++ b/terraform-aws-github-runner/main.tf
@@ -67,7 +67,7 @@ module "runners" {
   // TODO remove-me
   vpc_id               = var.vpc_id
   vpc_ids              = var.vpc_ids
-  subnet_ids           = var.subnet_ids
+  subnet_vpc_ids       = var.subnet_vpc_ids
   environment          = var.environment
   tags                 = local.tags
 

--- a/terraform-aws-github-runner/main.tf
+++ b/terraform-aws-github-runner/main.tf
@@ -102,7 +102,6 @@ module "runners" {
   runner_as_root                       = var.runner_as_root
   idle_config                          = var.idle_config
   enable_ssm_on_runners                = var.enable_ssm_on_runners
-  runner_additional_security_group_ids = var.runner_additional_security_group_ids
   secretsmanager_secrets_id            = var.secretsmanager_secrets_id
 
   lambda_s3_bucket                 = var.lambda_s3_bucket

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/config.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/config.test.ts
@@ -37,10 +37,11 @@ describe('Config', () => {
     process.env.SCALE_CONFIG_REPO = 'SCALE_CONFIG_REPO';
     process.env.SCALE_CONFIG_REPO_PATH = '.gh/the.yaml';
     process.env.SECRETSMANAGER_SECRETS_ID = 'SECRETSMANAGER_SECRETS_ID';
-    process.env.SECURITY_GROUP_IDS = 'SECURITY_GROUP_IDS1,SECURITY_GROUP_IDS2,SECURITY_GROUP_IDS3';
+    process.env.SECURITY_GROUP_IDS = 'ADD_SECURITY_GROUP_IDS1,ADD_SECURITY_GROUP_IDS2';
     process.env.SUBNET_IDS =
-      'AWS_REGION|SUBNET_IDS1,AWS_REGION|SUBNET_IDS2,AWS_REGION_INSTANCES_1|SUBNET_IDS3' +
-      ',AWS_REGION_INSTANCES_2|SUBNET_IDS4';
+      'AWS_REGION|SECURITY_GROUP_IDS1|SUBNET_IDS1,AWS_REGION|SECURITY_GROUP_IDS2|SUBNET_IDS2,' +
+      'AWS_REGION|SECURITY_GROUP_IDS2|SUBNET_IDS5,AWS_REGION_INSTANCES_1|SECURITY_GROUP_IDS1|SUBNET_IDS3,' +
+      'AWS_REGION_INSTANCES_2|SECURITY_GROUP_IDS3|SUBNET_IDS4';
 
     expect(Config.Instance.awsRegion).toBe('AWS_REGION');
     expect(Config.Instance.awsRegionInstances).toEqual([
@@ -72,33 +73,52 @@ describe('Config', () => {
     expect(Config.Instance.scaleConfigRepo).toEqual('SCALE_CONFIG_REPO');
     expect(Config.Instance.scaleConfigRepoPath).toEqual('.gh/the.yaml');
     expect(Config.Instance.secretsManagerSecretsId).toBe('SECRETSMANAGER_SECRETS_ID');
-    expect(Config.Instance.securityGroupIds).toEqual([
-      'SECURITY_GROUP_IDS1',
-      'SECURITY_GROUP_IDS2',
-      'SECURITY_GROUP_IDS3',
-    ]);
     expect(Config.Instance.subnetIds.size).toEqual(3);
+    expect(Config.Instance.securityGroupIds).toEqual(['ADD_SECURITY_GROUP_IDS1', 'ADD_SECURITY_GROUP_IDS2']);
     expect(Config.Instance.subnetIds.keys()).toContain('AWS_REGION');
     expect(Config.Instance.subnetIds.keys()).toContain('AWS_REGION_INSTANCES_1');
     expect(Config.Instance.subnetIds.keys()).toContain('AWS_REGION_INSTANCES_2');
-    expect(Config.Instance.subnetIds.get('AWS_REGION')?.size).toEqual(2);
-    expect(Config.Instance.subnetIds.get('AWS_REGION')).toContain('SUBNET_IDS1');
-    expect(Config.Instance.subnetIds.get('AWS_REGION')).toContain('SUBNET_IDS2');
-    expect(Config.Instance.subnetIds.get('AWS_REGION_INSTANCES_1')?.size).toEqual(1);
-    expect(Config.Instance.subnetIds.get('AWS_REGION_INSTANCES_1')).toContain('SUBNET_IDS3');
-    expect(Config.Instance.subnetIds.get('AWS_REGION_INSTANCES_2')?.size).toEqual(1);
-    expect(Config.Instance.subnetIds.get('AWS_REGION_INSTANCES_2')).toContain('SUBNET_IDS4');
+    expect(Config.Instance.subnetIds.get('AWS_REGION')?.length).toEqual(3);
+    expect(Config.Instance.subnetIds.get('AWS_REGION')).toContainEqual(['SECURITY_GROUP_IDS1', 'SUBNET_IDS1']);
+    expect(Config.Instance.subnetIds.get('AWS_REGION')).toContainEqual(['SECURITY_GROUP_IDS2', 'SUBNET_IDS2']);
+    expect(Config.Instance.subnetIds.get('AWS_REGION')).toContainEqual(['SECURITY_GROUP_IDS2', 'SUBNET_IDS5']);
+    expect(Config.Instance.subnetIds.get('AWS_REGION_INSTANCES_1')?.length).toEqual(1);
+    expect(Config.Instance.subnetIds.get('AWS_REGION_INSTANCES_1')).toContainEqual([
+      'SECURITY_GROUP_IDS1',
+      'SUBNET_IDS3',
+    ]);
+    expect(Config.Instance.subnetIds.get('AWS_REGION_INSTANCES_2')?.length).toEqual(1);
+    expect(Config.Instance.subnetIds.get('AWS_REGION_INSTANCES_2')).toContainEqual([
+      'SECURITY_GROUP_IDS3',
+      'SUBNET_IDS4',
+    ]);
     expect(Config.Instance.shuffledAwsRegionInstances.length).toEqual(3);
     expect(Config.Instance.shuffledAwsRegionInstances).toContain('AWS_REGION');
     expect(Config.Instance.shuffledAwsRegionInstances).toContain('AWS_REGION_INSTANCES_2');
     expect(Config.Instance.shuffledAwsRegionInstances).toContain('AWS_REGION_INSTANCES_1');
-    expect(Config.Instance.shuffledSubnetIdsForAwsRegion('AWS_REGION').length).toEqual(2);
-    expect(Config.Instance.shuffledSubnetIdsForAwsRegion('AWS_REGION')).toContain('SUBNET_IDS1');
-    expect(Config.Instance.shuffledSubnetIdsForAwsRegion('AWS_REGION')).toContain('SUBNET_IDS2');
+    expect(Config.Instance.shuffledSubnetIdsForAwsRegion('AWS_REGION').length).toEqual(3);
+    expect(Config.Instance.shuffledSubnetIdsForAwsRegion('AWS_REGION')).toContainEqual([
+      'SECURITY_GROUP_IDS1',
+      'SUBNET_IDS1',
+    ]);
+    expect(Config.Instance.shuffledSubnetIdsForAwsRegion('AWS_REGION')).toContainEqual([
+      'SECURITY_GROUP_IDS2',
+      'SUBNET_IDS2',
+    ]);
+    expect(Config.Instance.shuffledSubnetIdsForAwsRegion('AWS_REGION')).toContainEqual([
+      'SECURITY_GROUP_IDS2',
+      'SUBNET_IDS5',
+    ]);
     expect(Config.Instance.shuffledSubnetIdsForAwsRegion('AWS_REGION_INSTANCES_1').length).toEqual(1);
-    expect(Config.Instance.shuffledSubnetIdsForAwsRegion('AWS_REGION_INSTANCES_1')).toContain('SUBNET_IDS3');
+    expect(Config.Instance.shuffledSubnetIdsForAwsRegion('AWS_REGION_INSTANCES_1')).toContainEqual([
+      'SECURITY_GROUP_IDS1',
+      'SUBNET_IDS3',
+    ]);
     expect(Config.Instance.shuffledSubnetIdsForAwsRegion('AWS_REGION_INSTANCES_2').length).toEqual(1);
-    expect(Config.Instance.shuffledSubnetIdsForAwsRegion('AWS_REGION_INSTANCES_2')).toContain('SUBNET_IDS4');
+    expect(Config.Instance.shuffledSubnetIdsForAwsRegion('AWS_REGION_INSTANCES_2')).toContainEqual([
+      'SECURITY_GROUP_IDS3',
+      'SUBNET_IDS4',
+    ]);
     expect(Config.Instance.enableOrganizationRunners).toBeTruthy();
   });
 
@@ -159,7 +179,6 @@ describe('Config', () => {
     expect(Config.Instance.scaleConfigRepo).toEqual('test-infra');
     expect(Config.Instance.scaleConfigRepoPath).toEqual('.github/scale-config.yml');
     expect(Config.Instance.secretsManagerSecretsId).toBeUndefined();
-    expect(Config.Instance.securityGroupIds.length).toEqual(0);
     expect(Config.Instance.shuffledAwsRegionInstances).toEqual(['us-east-1']);
     expect(Config.Instance.enableOrganizationRunners).toBeFalsy();
   });

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/config.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/config.ts
@@ -4,6 +4,7 @@ export class Config {
   private static _instance: Config | undefined;
 
   readonly awsRegion: string;
+  readonly awsRegionInstances: string[];
   readonly awsRegionsToVpcIds: Map<string, Array<string>>;
   readonly cantHaveIssuesLabels: string[];
   readonly enableOrganizationRunners: boolean;
@@ -33,6 +34,8 @@ export class Config {
 
   protected constructor() {
     this.awsRegion = process.env.AWS_REGION || 'us-east-1';
+    /* istanbul ignore next */
+    this.awsRegionInstances = process.env.AWS_REGION_INSTANCES?.split(',').filter((w) => w.length > 0) || [];
     this.awsRegionsToVpcIds = this.getMapFromFlatEnv(process.env.AWS_REGIONS_TO_VPC_IDS);
     /* istanbul ignore next */
     this.cantHaveIssuesLabels = process.env.CANT_HAVE_ISSUES_LABELS?.split(',').filter((w) => w.length > 0) || [];
@@ -90,7 +93,12 @@ export class Config {
   }
 
   get shuffledAwsRegionInstances(): string[] {
-    const arr = Array.from(this.awsRegionsToVpcIds.keys());
+    let arr: string[];
+    if (this.awsRegionsToVpcIds.size > 0) {
+      arr = Array.from(this.awsRegionsToVpcIds.keys());
+    } else {
+      arr = [...this.awsRegionInstances];
+    }
     return this.shuffleInPlace(arr);
   }
 

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
@@ -41,8 +41,9 @@ function createExpectedRunInstancesLinux(
   runnerParameters: RunnerInputParameters,
   subnetId: number,
   enableOrg = false,
-  awsRegion = Config.Instance.awsRegion,
+  vpcIdx: string | undefined = undefined,
 ) {
+  const vpcId = vpcIdx ?? Config.Instance.shuffledVPCsForAwsRegion(Config.Instance.awsRegion)[0];
   const tags = [
     { Key: 'Application', Value: 'github-action-runner' },
     { Key: 'RunnerType', Value: runnerParameters.runnerType.runnerTypeName },
@@ -58,7 +59,8 @@ function createExpectedRunInstancesLinux(
       Value: runnerParameters.repoName as string,
     });
   }
-  const [secGroup, snetId] = Config.Instance.shuffledSubnetIdsForAwsRegion(awsRegion)[subnetId];
+  const secGroup = Config.Instance.vpcIdToSecurityGroupIds.get(vpcId) || [];
+  const snetId = Config.Instance.shuffledSubnetsForVpcId(vpcId)[subnetId];
   return {
     MaxCount: 1,
     MinCount: 1,
@@ -86,7 +88,7 @@ function createExpectedRunInstancesLinux(
       {
         AssociatePublicIpAddress: true,
         SubnetId: snetId,
-        Groups: Config.Instance.securityGroupIds.concat([secGroup]),
+        Groups: secGroup,
         DeviceIndex: 0,
       },
     ],
@@ -114,6 +116,10 @@ beforeEach(() => {
 
 describe('list instances', () => {
   const mockDescribeInstances = { promise: jest.fn() };
+  const config = {
+    awsRegion: 'us-east-1',
+    shuffledAwsRegionInstances: ['us-east-1'],
+  };
 
   beforeEach(() => {
     mockEC2.describeInstances.mockImplementation(() => mockDescribeInstances);
@@ -144,6 +150,7 @@ describe('list instances', () => {
       ],
     };
     mockDescribeInstances.promise.mockResolvedValue(mockRunningInstances);
+    jest.spyOn(Config, 'Instance', 'get').mockImplementation(() => config as unknown as Config);
   });
 
   it('ec2 fails', async () => {
@@ -352,10 +359,13 @@ describe('createRunner', () => {
       launchTemplateVersionWindows: '1-windows',
       subnetIds: new Map([['us-east-1', subnetIds]]),
       awsRegion: 'us-east-1',
-      securityGroupIds: ['sg1', 'sg2'],
       shuffledAwsRegionInstances: ['us-east-1'],
-      shuffledSubnetIdsForAwsRegion: jest.fn().mockImplementation(() => {
-        return Array.from(subnetIds).sort();
+      vpcIdToSecurityGroupIds: new Map([['vpc-agdgaduwg113', ['sg1', 'sg2']]]),
+      shuffledVPCsForAwsRegion: jest.fn().mockImplementation(() => {
+        return ['vpc-agdgaduwg113'];
+      }),
+      shuffledSubnetsForVpcId: jest.fn().mockImplementation(() => {
+        return ['sub-1234', 'sub-4321'];
       }),
     };
 
@@ -442,7 +452,8 @@ describe('createRunner', () => {
       expect(runnerConfigFn).toBeCalledTimes(1);
       expect(runnerConfigFn).toBeCalledWith(config.awsRegion);
       expect(mockEC2.runInstances).toHaveBeenCalledTimes(1);
-      const [secGroup, snetId] = Config.Instance.shuffledSubnetIdsForAwsRegion(Config.Instance.awsRegion)[0];
+      const secGroup = Config.Instance.vpcIdToSecurityGroupIds.get('vpc-agdgaduwg113') || [];
+      const snetId = Config.Instance.shuffledSubnetsForVpcId('vpc-agdgaduwg113');
       expect(mockEC2.runInstances).toBeCalledWith({
         MaxCount: 1,
         MinCount: 1,
@@ -465,8 +476,8 @@ describe('createRunner', () => {
         NetworkInterfaces: [
           {
             AssociatePublicIpAddress: true,
-            SubnetId: snetId,
-            Groups: Config.Instance.securityGroupIds.concat([secGroup]),
+            SubnetId: snetId[0],
+            Groups: secGroup,
             DeviceIndex: 0,
           },
         ],
@@ -573,33 +584,32 @@ describe('createRunner', () => {
   describe('multiregion', () => {
     const mockRunInstances = { promise: jest.fn() };
     const mockPutParameter = { promise: jest.fn() };
-    const subnetIds = new Map([
-      [
-        'us-east-1',
-        new Set([
-          ['sg3', 'sub-0987'],
-          ['sg4', 'sub-7890'],
-        ]),
-      ],
-      [
-        'us-west-1',
-        new Set([
-          ['sg5', 'sub-1234'],
-          ['sg6', 'sub-4321'],
-        ]),
-      ],
+    const regionToVpc = new Map([
+      ['us-east-1', ['vpc-agdgaduwg113-1']],
+      ['us-west-1', ['vpc-agdgaduwg113-2']],
+    ]);
+    const vpcToSg = new Map([
+      ['vpc-agdgaduwg113-1', ['sg1', 'sg2']],
+      ['vpc-agdgaduwg113-2', ['sg3', 'sg4']],
+    ]);
+    const vpcToSn = new Map([
+      ['vpc-agdgaduwg113-1', ['sub-1234', 'sub-4321']],
+      ['vpc-agdgaduwg113-2', ['sub-113', 'sub-311']],
     ]);
     const config = {
       launchTemplateNameLinux: 'launch-template-name-linux',
       launchTemplateVersionLinux: '1-linux',
       launchTemplateNameWindows: 'launch-template-name-windows',
       launchTemplateVersionWindows: '1-windows',
-      subnetIds: subnetIds,
       awsRegion: 'us-east-1',
+
       shuffledAwsRegionInstances: ['us-east-1', 'us-west-1'],
-      securityGroupIds: ['sg1', 'sg2'],
-      shuffledSubnetIdsForAwsRegion: jest.fn().mockImplementation((awsRegion: string) => {
-        return Array.from(subnetIds.get(awsRegion) ?? []).sort();
+      vpcIdToSecurityGroupIds: vpcToSg,
+      shuffledVPCsForAwsRegion: jest.fn().mockImplementation((awsRegion: string) => {
+        return Array.from(regionToVpc.get(awsRegion) ?? []);
+      }),
+      shuffledSubnetsForVpcId: jest.fn().mockImplementation((vpcId) => {
+        return Array.from(vpcToSn.get(vpcId) ?? []);
       }),
     };
     const runInstanceSuccess = {
@@ -664,12 +674,8 @@ describe('createRunner', () => {
       expect(await createRunner(runnerParameters, metrics)).toEqual(config.shuffledAwsRegionInstances[0]);
 
       expect(mockEC2.runInstances).toHaveBeenCalledTimes(2);
-      expect(mockEC2.runInstances).toBeCalledWith(
-        createExpectedRunInstancesLinux(runnerParameters, 0, false, 'us-east-1'),
-      );
-      expect(mockEC2.runInstances).toBeCalledWith(
-        createExpectedRunInstancesLinux(runnerParameters, 1, false, 'us-east-1'),
-      );
+      expect(mockEC2.runInstances).toBeCalledWith(createExpectedRunInstancesLinux(runnerParameters, 0, false));
+      expect(mockEC2.runInstances).toBeCalledWith(createExpectedRunInstancesLinux(runnerParameters, 1, false));
       expect(runnerConfigFn).toBeCalledTimes(1);
       expect(runnerConfigFn).toBeCalledWith(config.shuffledAwsRegionInstances[0]);
     });
@@ -697,14 +703,15 @@ describe('createRunner', () => {
       expect(await createRunner(runnerParameters, metrics)).toEqual(config.shuffledAwsRegionInstances[1]);
 
       expect(mockEC2.runInstances).toHaveBeenCalledTimes(3);
+      expect(mockEC2.runInstances).toBeCalledWith(createExpectedRunInstancesLinux(runnerParameters, 0, false));
+      expect(mockEC2.runInstances).toBeCalledWith(createExpectedRunInstancesLinux(runnerParameters, 1, false));
       expect(mockEC2.runInstances).toBeCalledWith(
-        createExpectedRunInstancesLinux(runnerParameters, 0, false, 'us-east-1'),
-      );
-      expect(mockEC2.runInstances).toBeCalledWith(
-        createExpectedRunInstancesLinux(runnerParameters, 1, false, 'us-east-1'),
-      );
-      expect(mockEC2.runInstances).toBeCalledWith(
-        createExpectedRunInstancesLinux(runnerParameters, 0, false, 'us-west-1'),
+        createExpectedRunInstancesLinux(
+          runnerParameters,
+          0,
+          false,
+          Config.Instance.shuffledVPCsForAwsRegion('us-west-1')[0],
+        ),
       );
       expect(runnerConfigFn).toBeCalledTimes(1);
       expect(runnerConfigFn).toBeCalledWith(config.shuffledAwsRegionInstances[1]);
@@ -735,16 +742,36 @@ describe('createRunner', () => {
 
       expect(mockEC2.runInstances).toHaveBeenCalledTimes(4);
       expect(mockEC2.runInstances).toBeCalledWith(
-        createExpectedRunInstancesLinux(runnerParameters, 0, false, 'us-east-1'),
+        createExpectedRunInstancesLinux(
+          runnerParameters,
+          0,
+          false,
+          Config.Instance.shuffledVPCsForAwsRegion('us-east-1')[0],
+        ),
       );
       expect(mockEC2.runInstances).toBeCalledWith(
-        createExpectedRunInstancesLinux(runnerParameters, 1, false, 'us-east-1'),
+        createExpectedRunInstancesLinux(
+          runnerParameters,
+          1,
+          false,
+          Config.Instance.shuffledVPCsForAwsRegion('us-east-1')[0],
+        ),
       );
       expect(mockEC2.runInstances).toBeCalledWith(
-        createExpectedRunInstancesLinux(runnerParameters, 0, false, 'us-west-1'),
+        createExpectedRunInstancesLinux(
+          runnerParameters,
+          0,
+          false,
+          Config.Instance.shuffledVPCsForAwsRegion('us-west-1')[0],
+        ),
       );
       expect(mockEC2.runInstances).toBeCalledWith(
-        createExpectedRunInstancesLinux(runnerParameters, 1, false, 'us-west-1'),
+        createExpectedRunInstancesLinux(
+          runnerParameters,
+          1,
+          false,
+          Config.Instance.shuffledVPCsForAwsRegion('us-west-1')[0],
+        ),
       );
       expect(runnerConfigFn).toBeCalledTimes(0);
     });

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -66,7 +66,7 @@ export async function listRunners(
     }
     const runningInstances = (
       await Promise.all(
-        Config.Instance.awsRegionInstances.map((awsRegion) => {
+        Config.Instance.shuffledAwsRegionInstances.map((awsRegion) => {
           return expBackOff(() => {
             return metrics.trackRequestRegion(
               awsRegion,
@@ -301,80 +301,87 @@ export async function createRunner(runnerParameters: RunnerInputParameters, metr
     for (const [awsRegionIdx, awsRegion] of shuffledAwsRegionInstances.entries()) {
       const ec2 = new EC2({ region: awsRegion });
       const ssm = new SSM({ region: awsRegion });
-      const subnets = Config.Instance.shuffledSubnetIdsForAwsRegion(awsRegion);
-      for (const [subnetIdx, [secGroup, subnet]] of subnets.entries()) {
-        try {
-          console.debug(`[${awsRegion}] Attempting to create instance ${runnerParameters.runnerType.instance_type}`);
-          const runInstancesResponse = await expBackOff(() => {
-            return metrics.trackRequestRegion(
-              awsRegion,
-              metrics.ec2RunInstancesAWSCallSuccess,
-              metrics.ec2RunInstancesAWSCallFailure,
-              () => {
-                return ec2
-                  .runInstances({
-                    MaxCount: 1,
-                    MinCount: 1,
-                    LaunchTemplate: {
-                      LaunchTemplateName: launchTemplateName,
-                      Version: launchTemplateVersion,
-                    },
-                    InstanceType: runnerParameters.runnerType.instance_type,
-                    BlockDeviceMappings: [
-                      {
-                        DeviceName: storageDeviceName,
-                        Ebs: {
-                          VolumeSize: runnerParameters.runnerType.disk_size,
-                          VolumeType: 'gp3',
-                          Encrypted: true,
-                          DeleteOnTermination: true,
+      const shuffledVPCsForAwsRegion = Config.Instance.shuffledVPCsForAwsRegion(awsRegion);
+      for (const [vpcIdIdx, vpcId] of shuffledVPCsForAwsRegion.entries()) {
+        const securityGroupIds = Config.Instance.vpcIdToSecurityGroupIds.get(vpcId) ?? [];
+        const subnets = Config.Instance.shuffledSubnetsForVpcId(vpcId);
+        for (const [subnetIdx, subnet] of subnets.entries()) {
+          try {
+            console.debug(
+              `[${awsRegion}] [${vpcId}] Attempting to create instance ${runnerParameters.runnerType.instance_type}`,
+            );
+            const runInstancesResponse = await expBackOff(() => {
+              return metrics.trackRequestRegion(
+                awsRegion,
+                metrics.ec2RunInstancesAWSCallSuccess,
+                metrics.ec2RunInstancesAWSCallFailure,
+                () => {
+                  return ec2
+                    .runInstances({
+                      MaxCount: 1,
+                      MinCount: 1,
+                      LaunchTemplate: {
+                        LaunchTemplateName: launchTemplateName,
+                        Version: launchTemplateVersion,
+                      },
+                      InstanceType: runnerParameters.runnerType.instance_type,
+                      BlockDeviceMappings: [
+                        {
+                          DeviceName: storageDeviceName,
+                          Ebs: {
+                            VolumeSize: runnerParameters.runnerType.disk_size,
+                            VolumeType: 'gp3',
+                            Encrypted: true,
+                            DeleteOnTermination: true,
+                          },
                         },
-                      },
-                    ],
-                    NetworkInterfaces: [
-                      {
-                        AssociatePublicIpAddress: true,
-                        SubnetId: subnet,
-                        Groups: Config.Instance.securityGroupIds.concat([secGroup]),
-                        DeviceIndex: 0,
-                      },
-                    ],
-                    TagSpecifications: [
-                      {
-                        ResourceType: 'instance',
-                        Tags: tags,
-                      },
-                    ],
-                  })
-                  .promise();
-              },
-            );
-          });
+                      ],
+                      NetworkInterfaces: [
+                        {
+                          AssociatePublicIpAddress: true,
+                          SubnetId: subnet,
+                          Groups: securityGroupIds,
+                          DeviceIndex: 0,
+                        },
+                      ],
+                      TagSpecifications: [
+                        {
+                          ResourceType: 'instance',
+                          Tags: tags,
+                        },
+                      ],
+                    })
+                    .promise();
+                },
+              );
+            });
 
-          if (runInstancesResponse.Instances && runInstancesResponse.Instances.length > 0) {
-            console.info(
-              `Created instance(s) [${awsRegion}] [${runnerParameters.runnerType.runnerTypeName}]: `,
-              runInstancesResponse.Instances.map((i) => i.InstanceId).join(','),
-            );
-            addSSMParameterRunnerConfig(runInstancesResponse.Instances, runnerParameters, ssm, metrics, awsRegion);
+            if (runInstancesResponse.Instances && runInstancesResponse.Instances.length > 0) {
+              console.info(
+                `Created instance(s) [${awsRegion}] [${vpcId}] [${runnerParameters.runnerType.runnerTypeName}]: `,
+                runInstancesResponse.Instances.map((i) => i.InstanceId).join(','),
+              );
+              addSSMParameterRunnerConfig(runInstancesResponse.Instances, runnerParameters, ssm, metrics, awsRegion);
 
-            // breaks
-            return awsRegion;
-          } else {
+              // breaks
+              return awsRegion;
+            } else {
+              const msg =
+                `[${awsRegion}] [${vpcId}] [${runnerParameters.runnerType.instance_type}] ` +
+                `[${runnerParameters.runnerType.runnerTypeName}] ec2.runInstances returned empty list of instaces ` +
+                `created, but exit without throwing any exception (?!?!?!)`;
+              errors.push([msg, undefined]);
+              console.warn(msg);
+            }
+          } catch (e) {
             const msg =
-              `[${awsRegion}] [${runnerParameters.runnerType.instance_type}] ` +
-              `[${runnerParameters.runnerType.runnerTypeName}] ec2.runInstances returned empty list of instaces ` +
-              `created, but exit without throwing any exception (?!?!?!)`;
-            errors.push([msg, undefined]);
+              `[${subnetIdx}/${subnets.length} - ${subnet}] ` +
+              `[${vpcIdIdx}/${shuffledVPCsForAwsRegion.length} - ${vpcId}] ` +
+              `[${awsRegionIdx}/${shuffledAwsRegionInstances.length} - ${awsRegion}] Issue creating instance ` +
+              `${runnerParameters.runnerType.instance_type}: ${e}`;
+            errors.push([msg, e]);
             console.warn(msg);
           }
-        } catch (e) {
-          const msg =
-            `[${subnetIdx}/${subnets.length} - ${subnet}] ` +
-            `[${awsRegionIdx}/${shuffledAwsRegionInstances.length} - ${awsRegion}] Issue creating instance ` +
-            `${runnerParameters.runnerType.instance_type}: ${e}`;
-          errors.push([msg, e]);
-          console.warn(msg);
         }
       }
     }
@@ -407,7 +414,7 @@ export async function createRunner(runnerParameters: RunnerInputParameters, metr
       /* istanbul ignore next */
       throw new Error(
         `[${runnerParameters.runnerType.instance_type}] Failed to runInstances without any exception captured! ` +
-          `Check AWS_REGION_INSTANCES and SUBNET_IDS environment variables!`,
+          `Check AWS_REGIONS_TO_VPC_IDS, VPC_ID_TO_SECURITY_GROUP_IDS and VPC_ID_TO_SUBNET_IDS environment variables!`,
       );
     }
   } catch (e) {

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -302,7 +302,7 @@ export async function createRunner(runnerParameters: RunnerInputParameters, metr
       const ec2 = new EC2({ region: awsRegion });
       const ssm = new SSM({ region: awsRegion });
       const subnets = Config.Instance.shuffledSubnetIdsForAwsRegion(awsRegion);
-      for (const [subnetIdx, subnet] of subnets.entries()) {
+      for (const [subnetIdx, [secGroup, subnet]] of subnets.entries()) {
         try {
           console.debug(`[${awsRegion}] Attempting to create instance ${runnerParameters.runnerType.instance_type}`);
           const runInstancesResponse = await expBackOff(() => {
@@ -335,7 +335,7 @@ export async function createRunner(runnerParameters: RunnerInputParameters, metr
                       {
                         AssociatePublicIpAddress: true,
                         SubnetId: subnet,
-                        Groups: Config.Instance.securityGroupIds,
+                        Groups: Config.Instance.securityGroupIds.concat([secGroup]),
                         DeviceIndex: 0,
                       },
                     ],

--- a/terraform-aws-github-runner/modules/runners/main.tf
+++ b/terraform-aws-github-runner/modules/runners/main.tf
@@ -26,6 +26,7 @@ locals {
   userdata_arm_patch                     = "${path.module}/templates/arm-runner-patch.tpl"
   userdata_install_config_runner_linux   = "${path.module}/templates/install-config-runner.sh"
   userdata_install_config_runner_windows = "${path.module}/templates/install-config-runner.ps1"
+  vpc_id_to_idx                          = {for idx, vpc_id in var.vpc_ids: vpc_id => idx}
 }
 
 data "aws_ami" "runner_ami_linux" {

--- a/terraform-aws-github-runner/modules/runners/main.tf
+++ b/terraform-aws-github-runner/modules/runners/main.tf
@@ -26,7 +26,7 @@ locals {
   userdata_arm_patch                     = "${path.module}/templates/arm-runner-patch.tpl"
   userdata_install_config_runner_linux   = "${path.module}/templates/install-config-runner.sh"
   userdata_install_config_runner_windows = "${path.module}/templates/install-config-runner.ps1"
-  vpc_id_to_idx                          = {for idx, vpc_id in var.vpc_ids: vpc_id => idx}
+  vpc_id_to_idx                          = {for idx, vpc in var.vpc_ids: vpc.vpc => idx}
 }
 
 data "aws_ami" "runner_ami_linux" {
@@ -253,7 +253,7 @@ resource "aws_security_group" "runners_sg" {
   count       = length(var.vpc_ids)
   name_prefix = "${var.environment}-github-actions-runner-sg-${count.index}"
   description = "Github Actions Runner security group"
-  vpc_id      = element(var.vpc_ids, count.index)
+  vpc_id      = element(var.vpc_ids, count.index).vpc
 
   egress {
     from_port   = 0

--- a/terraform-aws-github-runner/modules/runners/scale-up.tf
+++ b/terraform-aws-github-runner/modules/runners/scale-up.tf
@@ -30,7 +30,6 @@ resource "aws_lambda_function" "scale_up" {
 
   environment {
     variables = {
-      AWS_REGION_INSTANCES                  = join(",", var.aws_region_instances)
       CANT_HAVE_ISSUES_LABELS               = join(",", var.cant_have_issues_labels)
       ENABLE_ORGANIZATION_RUNNERS           = var.enable_organization_runners
       ENVIRONMENT                           = var.environment
@@ -49,19 +48,18 @@ resource "aws_lambda_function" "scale_up" {
       MUST_HAVE_ISSUES_LABELS               = join(",", var.must_have_issues_labels)
       RUNNER_EXTRA_LABELS                   = var.runner_extra_labels
       SECRETSMANAGER_SECRETS_ID             = var.secretsmanager_secrets_id
-      SECURITY_GROUP_IDS                    = join(",", var.runner_additional_security_group_ids)
-      SUBNET_IDS                            = join(
-                                                  ",",
-                                                  [
-                                                    for subnet_vpc_id in var.subnet_vpc_ids:
-                                                    format(
-                                                      "%s|%s|%s",
-                                                      var.aws_region,
-                                                      resource.aws_security_group.runners_sg[local.vpc_id_to_idx[subnet_vpc_id.vpc]].id,
-                                                      subnet_vpc_id.subnet
-                                                    )
-                                                  ]
-                                              )
+      # SUBNET_IDS                            = join(
+      #                                             ",",
+      #                                             [
+      #                                               for subnet_vpc_id in var.subnet_vpc_ids:
+      #                                               format(
+      #                                                 "%s|%s|%s",
+      #                                                 var.aws_region,
+      #                                                 resource.aws_security_group.runners_sg[local.vpc_id_to_idx[subnet_vpc_id.vpc]].id,
+      #                                                 subnet_vpc_id.subnet
+      #                                               )
+      #                                             ]
+      #                                         )
     }
   }
 

--- a/terraform-aws-github-runner/modules/runners/scale-up.tf
+++ b/terraform-aws-github-runner/modules/runners/scale-up.tf
@@ -48,18 +48,38 @@ resource "aws_lambda_function" "scale_up" {
       MUST_HAVE_ISSUES_LABELS               = join(",", var.must_have_issues_labels)
       RUNNER_EXTRA_LABELS                   = var.runner_extra_labels
       SECRETSMANAGER_SECRETS_ID             = var.secretsmanager_secrets_id
-      # SUBNET_IDS                            = join(
-      #                                             ",",
-      #                                             [
-      #                                               for subnet_vpc_id in var.subnet_vpc_ids:
-      #                                               format(
-      #                                                 "%s|%s|%s",
-      #                                                 var.aws_region,
-      #                                                 resource.aws_security_group.runners_sg[local.vpc_id_to_idx[subnet_vpc_id.vpc]].id,
-      #                                                 subnet_vpc_id.subnet
-      #                                               )
-      #                                             ]
-      #                                         )
+
+      AWS_REGIONS_TO_VPC_IDS                = join(
+        ",",
+        [
+          for region_vpc in var.vpc_ids:
+          format("%s|%s", region_vpc.region, region_vpc.vpc)
+        ]
+      )
+      VPC_ID_TO_SECURITY_GROUP_IDS          = join(
+        ",",
+        concat(
+          [
+            for vpc in var.vpc_ids:
+              format(
+                "%s|%s",
+                vpc.vpc,
+                resource.aws_security_group.runners_sg[local.vpc_id_to_idx[vpc.vpc]].id
+              )
+          ],
+          [
+            for vpc_subnet in var.vpc_sgs:
+              format("%s|%s", vpc_subnet.vpc, vpc_subnet.sg)
+          ]
+        )
+      )
+      VPC_ID_TO_SUBNET_IDS                  = join(
+        ",",
+        [
+          for vpc_subnet in var.subnet_vpc_ids:
+          format("%s|%s", vpc_subnet.vpc, vpc_subnet.subnet)
+        ]
+      )
     }
   }
 

--- a/terraform-aws-github-runner/modules/runners/scale-up.tf
+++ b/terraform-aws-github-runner/modules/runners/scale-up.tf
@@ -49,8 +49,19 @@ resource "aws_lambda_function" "scale_up" {
       MUST_HAVE_ISSUES_LABELS               = join(",", var.must_have_issues_labels)
       RUNNER_EXTRA_LABELS                   = var.runner_extra_labels
       SECRETSMANAGER_SECRETS_ID             = var.secretsmanager_secrets_id
-      SECURITY_GROUP_IDS                    = join(",", concat([for runners_sg in aws_security_group.runners_sg : runners_sg.id], var.runner_additional_security_group_ids))
-      SUBNET_IDS                            = join(",", [for subnet_id in var.subnet_ids: format("%s|%s", var.aws_region, subnet_id) ])
+      SECURITY_GROUP_IDS                    = join(",", var.runner_additional_security_group_ids)
+      SUBNET_IDS                            = join(
+                                                  ",",
+                                                  [
+                                                    for subnet_vpc_id in var.subnet_vpc_ids:
+                                                    format(
+                                                      "%s|%s|%s",
+                                                      var.aws_region,
+                                                      resource.aws_security_group.runners_sg[local.vpc_id_to_idx[subnet_vpc_id.vpc]].id,
+                                                      subnet_vpc_id.subnet
+                                                    )
+                                                  ]
+                                              )
     }
   }
 

--- a/terraform-aws-github-runner/modules/runners/scale-up.tf
+++ b/terraform-aws-github-runner/modules/runners/scale-up.tf
@@ -50,7 +50,7 @@ resource "aws_lambda_function" "scale_up" {
       RUNNER_EXTRA_LABELS                   = var.runner_extra_labels
       SECRETSMANAGER_SECRETS_ID             = var.secretsmanager_secrets_id
       SECURITY_GROUP_IDS                    = join(",", concat([for runners_sg in aws_security_group.runners_sg : runners_sg.id], var.runner_additional_security_group_ids))
-      SUBNET_IDS                            = join(",", var.subnet_ids)
+      SUBNET_IDS                            = join(",", [for subnet_id in var.subnet_ids: format("%s|%s", var.aws_region, subnet_id) ])
     }
   }
 

--- a/terraform-aws-github-runner/modules/runners/variables.tf
+++ b/terraform-aws-github-runner/modules/runners/variables.tf
@@ -16,8 +16,13 @@ variable "vpc_id" {
 }
 
 variable "vpc_ids" {
-  description = "The VPC ids that resides in subnet_vpc_ids"
-  type        = list(string)
+  description = "The list of vpc_id for aws_region. keys; 'vpc' 'region'"
+  type        = list(map(string))
+}
+
+variable "vpc_sgs" {
+  description = "The list of security group ids for vpc ids. keys: 'vpc', 'sg'"
+  type        = list(map(string))
 }
 
 variable "subnet_vpc_ids" {

--- a/terraform-aws-github-runner/modules/runners/variables.tf
+++ b/terraform-aws-github-runner/modules/runners/variables.tf
@@ -16,13 +16,14 @@ variable "vpc_id" {
 }
 
 variable "vpc_ids" {
-  description = "The VPC for the security groups."
+  description = "The VPC ids that resides in subnet_vpc_ids"
   type        = list(string)
 }
 
-variable "subnet_ids" {
-  description = "List of subnets in which the action runners will be launched, the subnets needs to be subnets in the `vpc_ids`."
-  type        = list(string)
+variable "subnet_vpc_ids" {
+  description = "The relation between subnet and vpcs. keys; 'vpc' 'subnet'"
+  type        = list(map(string))
+  default     = []
 }
 
 variable "overrides" {

--- a/terraform-aws-github-runner/modules/runners/variables.tf
+++ b/terraform-aws-github-runner/modules/runners/variables.tf
@@ -304,13 +304,6 @@ variable "key_name" {
   default     = null
 }
 
-variable "runner_additional_security_group_ids" {
-  description = "(optional) List of additional security groups IDs to apply to the runner"
-  type        = list(string)
-  default     = []
-}
-
-
 variable "secretsmanager_secrets_id" {
   description = "(optional) ID for secretsmanager secret to use for Github App credentials"
   type        = string

--- a/terraform-aws-github-runner/variables.tf
+++ b/terraform-aws-github-runner/variables.tf
@@ -16,8 +16,13 @@ variable "vpc_id" {
 }
 
 variable "vpc_ids" {
-  description = "The VPC ids that resides in subnet_vpc_ids"
-  type        = list(string)
+  description = "The list of vpc_id for aws_region. keys; 'vpc' 'region'"
+  type        = list(map(string))
+}
+
+variable "vpc_sgs" {
+  description = "The list of security group ids for vpc ids. keys: 'vpc', 'sg'"
+  type        = list(map(string))
 }
 
 variable "subnet_vpc_ids" {

--- a/terraform-aws-github-runner/variables.tf
+++ b/terraform-aws-github-runner/variables.tf
@@ -16,13 +16,14 @@ variable "vpc_id" {
 }
 
 variable "vpc_ids" {
-  description = "The VPC for security groups of the action runners."
+  description = "The VPC ids that resides in subnet_vpc_ids"
   type        = list(string)
 }
 
-variable "subnet_ids" {
-  description = "List of subnets in which the action runners will be launched, the subnets needs to be subnets in the `vpc_ids`."
-  type        = list(string)
+variable "subnet_vpc_ids" {
+  description = "The relation between subnet and vpcs. keys; 'vpc' 'subnet'"
+  type        = list(map(string))
+  default     = []
 }
 
 variable "tags" {

--- a/terraform-aws-github-runner/variables.tf
+++ b/terraform-aws-github-runner/variables.tf
@@ -325,12 +325,6 @@ variable "key_name" {
   default     = null
 }
 
-variable "runner_additional_security_group_ids" {
-  description = "(optional) List of additional security groups IDs to apply to the runner"
-  type        = list(string)
-  default     = []
-}
-
 variable "secretsmanager_secrets_id" {
   description = "(optional) ID for secretsmanager secret to use for Github App credentials"
   type        = string


### PR DESCRIPTION
AWS security groups need to be assigned to the correct VPC, with the new design of multiple VPCs there is a need to manage multiple SG and the hierarchical relationship for Region -> VPCs -> (subnet, sg);