### PR TITLE
group Python environment setup output into its own section

### DIFF
--- a/.github/workflows/stronghold.yml
+++ b/.github/workflows/stronghold.yml
@@ -17,38 +17,50 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       script: |
+        echo ::group::setup Python environment
         cd tools/stronghold/
         python -m venv .venv/
         source .venv/bin/activate
         pip install --requirement=requirements.txt
+        echo ::endgroup::
+
         black --check --diff .
 
   flake8:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       script: |
+        echo ::group::setup Python environment
         cd tools/stronghold/
         python -m venv .venv/
         source .venv/bin/activate
         pip install --requirement=requirements.txt
+        echo ::endgroup::
+
         flake8 .
 
   mypy:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       script: |
+        echo ::group::setup Python environment
         cd tools/stronghold/
         python -m venv .venv/
         source .venv/bin/activate
         pip install --requirement=requirements.txt
+        echo ::endgroup::
+
         mypy .
 
   pytest:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       script: |
+        echo ::group::setup Python environment
         cd tools/stronghold/
         python -m venv .venv/
         source .venv/bin/activate
         pip install --requirement=requirements.txt
+        echo ::endgroup::
+
         pytest


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/test-infra/pull/1147).
* #1148
* __->__ #1147

group Python environment setup output into its own section

Summary:
This makes it easier to distinguish setup failures from actual command
failures.

Test Plan: Manually inspect workflow output.

