### PR TITLE
Add cpu, macos or windows and release channel to pypi default

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -164,8 +164,8 @@ def get_libtorch_install_command(os: str, channel: str, gpu_arch_type: str, libt
 
     return f"{get_base_download_url_for_repo('libtorch', channel, gpu_arch_type, desired_cuda)}/{build_name}"
 
-def get_wheel_install_command(channel: str, gpu_arch_type: str, desired_cuda: str, python_version: str, with_pypi: bool = False) -> str:
-    if with_pypi == True and channel == RELEASE:
+def get_wheel_install_command(channel: str, gpu_arch_type: str, desired_cuda: str, python_version: str) -> str:
+    if channel == RELEASE and ((arch_version == "11.7" and os == "linux") or (gpu_arch_type == "cpu" and (os == "windows" or os == "macos"))):
         return f"{WHL_INSTALL_BASE} {PACKAGES_TO_INSTALL_WHL}"
     else:
         packages_to_install = PACKAGES_TO_INSTALL_WHL_TORCHONLY if python_version == "3.11" else PACKAGES_TO_INSTALL_WHL
@@ -339,13 +339,6 @@ def generate_wheels_matrix(
             if python_version == "3.11" and gpu_arch_type == "rocm":
                 continue
             desired_cuda = translate_desired_cuda(gpu_arch_type, gpu_arch_version)
-
-            installation = get_wheel_install_command(channel, gpu_arch_type, desired_cuda, python_version)
-            # special 11.7 wheels package without dependencies
-            # dependency downloaded via pip install
-            if arch_version == "11.7" and os == "linux" and channel == RELEASE:
-                installation = get_wheel_install_command(channel, gpu_arch_type, desired_cuda, python_version, True)
-
             ret.append(
                 {
                     "python_version": python_version,
@@ -358,7 +351,7 @@ def generate_wheels_matrix(
                         ".", "_"
                     ),
                     "validation_runner": validation_runner(gpu_arch_type, os),
-                    "installation": installation,
+                    "installation": get_wheel_install_command(channel, gpu_arch_type, desired_cuda, python_version),
                     "channel": channel,
                 }
             )


### PR DESCRIPTION
Fix release install command to use pypi for following use cases:
Linux, cuda 11.7
CPU, Windows
CPU, MacOS