### PR TITLE
Fix passing gpu_arch_version to  get_wheel_install_command()

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -164,8 +164,8 @@ def get_libtorch_install_command(os: str, channel: str, gpu_arch_type: str, libt
 
     return f"{get_base_download_url_for_repo('libtorch', channel, gpu_arch_type, desired_cuda)}/{build_name}"
 
-def get_wheel_install_command(channel: str, gpu_arch_type: str, desired_cuda: str, python_version: str) -> str:
-    if channel == RELEASE and ((arch_version == "11.7" and os == "linux") or (gpu_arch_type == "cpu" and (os == "windows" or os == "macos"))):
+def get_wheel_install_command(channel: str, gpu_arch_type: str, gpu_arch_version: str, desired_cuda: str, python_version: str) -> str:
+    if channel == RELEASE and ((gpu_arch_version == "11.7" and os == "linux") or (gpu_arch_type == "cpu" and (os == "windows" or os == "macos"))):
         return f"{WHL_INSTALL_BASE} {PACKAGES_TO_INSTALL_WHL}"
     else:
         packages_to_install = PACKAGES_TO_INSTALL_WHL_TORCHONLY if python_version == "3.11" else PACKAGES_TO_INSTALL_WHL
@@ -351,7 +351,7 @@ def generate_wheels_matrix(
                         ".", "_"
                     ),
                     "validation_runner": validation_runner(gpu_arch_type, os),
-                    "installation": get_wheel_install_command(channel, gpu_arch_type, desired_cuda, python_version),
+                    "installation": get_wheel_install_command(channel, gpu_arch_type, gpu_arch_version, desired_cuda, python_version),
                     "channel": channel,
                 }
             )


### PR DESCRIPTION
Fix passing gpu_arch_version to  get_wheel_install_command()
Test:
```
.venv) [atalman@devvm214.ftw0 /data/users/atalman/test-infra (fix_install_command)]$ python tools/scripts/generate_binary_build_matrix.py --operating-system windows --channel release
{"include": [{"python_version": "3.7", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "wheel", "build_name": "wheel-py3_7-cpu", "validation_runner": "windows.4xlarge", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu", "channel": "release"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "wheel", "build_name": "wheel-py3_7-cuda11_6", "validation_runner": "windows.8xlarge.nvidia.gpu", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu116", "channel": "release"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "wheel", "build_name": "wheel-py3_7-cuda11_7", "validation_runner": "windows.8xlarge.nvidia.gpu", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu117", "channel": "release"}, {"python_version": "3.8", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "wheel", "build_name": "wheel-py3_8-cpu", "validation_runner": "windows.4xlarge", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu", "channel": "release"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "wheel", "build_name": "wheel-py3_8-cuda11_6", "validation_runner": "windows.8xlarge.nvidia.gpu", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu116", "channel": "release"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "wheel", "build_name": "wheel-py3_8-cuda11_7", "validation_runner": "windows.8xlarge.nvidia.gpu", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu117", "channel": "release"}, {"python_version": "3.9", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "wheel", "build_name": "wheel-py3_9-cpu", "validation_runner": "windows.4xlarge", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu", "channel": "release"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "wheel", "build_name": "wheel-py3_9-cuda11_6", "validation_runner": "windows.8xlarge.nvidia.gpu", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu116", "channel": "release"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "wheel", "build_name": "wheel-py3_9-cuda11_7", "validation_runner": "windows.8xlarge.nvidia.gpu", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu117", "channel": "release"}, {"python_version": "3.10", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "wheel", "build_name": "wheel-py3_10-cpu", "validation_runner": "windows.4xlarge", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu", "channel": "release"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "wheel", "build_name": "wheel-py3_10-cuda11_6", "validation_runner": "windows.8xlarge.nvidia.gpu", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu116", "channel": "release"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "wheel", "build_name": "wheel-py3_10-cuda11_7", "validation_runner": "windows.8xlarge.nvidia.gpu", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu117", "channel": "release"}]}
```