### PR TITLE
Pass os: str to get_wheel_install_command()

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -164,7 +164,7 @@ def get_libtorch_install_command(os: str, channel: str, gpu_arch_type: str, libt
 
     return f"{get_base_download_url_for_repo('libtorch', channel, gpu_arch_type, desired_cuda)}/{build_name}"
 
-def get_wheel_install_command(channel: str, gpu_arch_type: str, gpu_arch_version: str, desired_cuda: str, python_version: str) -> str:
+def get_wheel_install_command(os: str, channel: str, gpu_arch_type: str, gpu_arch_version: str, desired_cuda: str, python_version: str) -> str:
     if channel == RELEASE and ((gpu_arch_version == "11.7" and os == "linux") or (gpu_arch_type == "cpu" and (os == "windows" or os == "macos"))):
         return f"{WHL_INSTALL_BASE} {PACKAGES_TO_INSTALL_WHL}"
     else:
@@ -351,7 +351,7 @@ def generate_wheels_matrix(
                         ".", "_"
                     ),
                     "validation_runner": validation_runner(gpu_arch_type, os),
-                    "installation": get_wheel_install_command(channel, gpu_arch_type, gpu_arch_version, desired_cuda, python_version),
+                    "installation": get_wheel_install_command(os, channel, gpu_arch_type, gpu_arch_version, desired_cuda, python_version),
                     "channel": channel,
                 }
             )


### PR DESCRIPTION
Pass os param to get_wheel_install_command()

 
Test:
```
python tools/scripts/generate_binary_build_matrix.py --operating-system linux --channel release
{"include": [{"python_version": "3.7", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_7-cpu", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu", "channel": "release"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_7-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu116", "channel": "release"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_7-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio", "channel": "release"}, {"python_version": "3.7", "gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "container_image": "pytorch/manylinux-builder:rocm5.1.1", "package_type": "manywheel", "build_name": "manywheel-py3_7-rocm5_1_1", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/rocm5.1.1", "channel": "release"}, {"python_version": "3.7", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_7-rocm5_2", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/rocm5.2", "channel": "release"}, {"python_version": "3.8", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_8-cpu", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu", "channel": "release"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_8-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu116", "channel": "release"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_8-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio", "channel": "release"}, {"python_version": "3.8", "gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "container_image": "pytorch/manylinux-builder:rocm5.1.1", "package_type": "manywheel", "build_name": "manywheel-py3_8-rocm5_1_1", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/rocm5.1.1", "channel": "release"}, {"python_version": "3.8", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_8-rocm5_2", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/rocm5.2", "channel": "release"}, {"python_version": "3.9", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_9-cpu", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu", "channel": "release"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu116", "channel": "release"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio", "channel": "release"}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "container_image": "pytorch/manylinux-builder:rocm5.1.1", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm5_1_1", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/rocm5.1.1", "channel": "release"}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm5_2", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/rocm5.2", "channel": "release"}, {"python_version": "3.10", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_10-cpu", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu", "channel": "release"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_10-cuda11_6", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu116", "channel": "release"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_10-cuda11_7", "validation_runner": "ubuntu-20.04-m60", "installation": "pip3 install torch torchvision torchaudio", "channel": "release"}, {"python_version": "3.10", "gpu_arch_type": "rocm", "gpu_arch_version": "5.1.1", "desired_cuda": "rocm5.1.1", "container_image": "pytorch/manylinux-builder:rocm5.1.1", "package_type": "manywheel", "build_name": "manywheel-py3_10-rocm5_1_1", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/rocm5.1.1", "channel": "release"}, {"python_version": "3.10", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_10-rocm5_2", "validation_runner": "ubuntu-20.04", "installation": "pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/rocm5.2", "channel": "release"}]}
```