### PR TITLE
allow customizing the linux_job docker image

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -39,6 +39,10 @@ on:
         description: "Test infra reference to use"
         default: ""
         type: string
+      docker-image:
+        description: Identifies the Docker image by name.
+        default: "pytorch/conda-builder"
+        type: string
       gpu-arch-type:
         description: "GPU arch type to use"
         default: "cpu"
@@ -56,7 +60,11 @@ jobs:
   job:
     name: ${{ inputs.job-name }}
     env:
-      DOCKER_IMAGE: pytorch/conda-builder:${{ inputs.gpu-arch-type }}${{ inputs.gpu-arch-version }}
+      DOCKER_IMAGE: >-
+        ${{ inputs.docker-image == 'pytorch/conda-builder' && format('pytorch/conda-builder:{0}{1}',
+                                                                      inputs.gpu-arch-type,
+                                                                      inputs.gpu-arch-version)
+                                                           || inputs.docker-image }}
       REPOSITORY: ${{ inputs.repository || github.repository }}
       SCRIPT: ${{ inputs.script }}
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/test_linux_job.yml
+++ b/.github/workflows/test_linux_job.yml
@@ -40,6 +40,15 @@ jobs:
         python3 -m pip install --extra-index-url https://download.pytorch.org/whl/nightly/cu116 --pre torch
         # Can import pytorch, cuda is available
         python3 -c 'import torch;assert(torch.cuda.is_available())'
+  test-docker-image:
+    uses: ./.github/workflows/linux_job.yml
+    with:
+      runner: linux.2xlarge
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      docker-image: fedora:37@sha256:f2c083c0b7d2367a375f15e002c2dc7baaca2b3181ace61f9d5113a8fe2f6b44
+      script: |
+        source /etc/os-release && [[ "${ID}" = "fedora" ]] || exit 1
   test-upload-artifact:
     uses: ./.github/workflows/linux_job.yml
     with:


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/test-infra/pull/1156).
* __->__ #1156

allow customizing the linux_job docker image

Summary:
The pytorch/conda-builder image is massive and unnecessary for many
use-cases. Allowing a smaller image speeds up CI runs.

Test Plan: Tested with stronghold jobs in draft PR.

