### PR TITLE
Fix macos instructions for nightly and release

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -159,7 +159,11 @@ def get_libtorch_install_command(os: str, channel: str, gpu_arch_type: str, libt
     _libtorch_variant = f"{libtorch_variant}-{libtorch_config}" if libtorch_config == 'debug' else libtorch_variant
     build_name = f"{prefix}-{devtoolset}-{_libtorch_variant}-latest.zip" if devtoolset ==  "cxx11-abi" else f"{prefix}-{_libtorch_variant}-latest.zip"
 
-    if channel == 'release':
+    if os == 'macos':
+        build_name = "libtorch-macos-latest.zip"
+        if channel == RELEASE:
+            build_name = f"libtorch-macos-{CURRENT_STABLE_VERSION}.zip"
+    elif os == 'linux' or os == 'windows' and channel == RELEASE:
         build_name = f"{prefix}-{devtoolset}-{_libtorch_variant}-{CURRENT_STABLE_VERSION}%2B{desired_cuda}.zip" if devtoolset ==  "cxx11-abi" else f"{prefix}-{_libtorch_variant}-{CURRENT_STABLE_VERSION}%2B{desired_cuda}.zip"
 
     return f"{get_base_download_url_for_repo('libtorch', channel, gpu_arch_type, desired_cuda)}/{build_name}"
@@ -266,7 +270,7 @@ def generate_libtorch_matrix(
 
                 # For windows release we support only shared-with-deps variant
                 # see: https://github.com/pytorch/pytorch/issues/87782
-                if os == 'windows' and channel == 'release' and libtorch_variant != "shared-with-deps":
+                if os == 'windows' and channel == RELEASE and libtorch_variant != "shared-with-deps":
                     continue
 
                 desired_cuda = translate_desired_cuda(gpu_arch_type, gpu_arch_version)


### PR DESCRIPTION
Fix macos install instructions. Refer to following jobs:
https://github.com/pytorch/pytorch/actions/runs/3315856876/jobs/5478609124

Test:
```
python tools/scripts/generate_binary_build_matrix.py --operating-system macos --package libtorch --channel release
{"include": [{"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-shared-with-deps-pre-cxx11", "validation_runner": "macos-12", "installation": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.13.0.zip", "channel": "release"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-shared-without-deps-pre-cxx11", "validation_runner": "macos-12", "installation": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.13.0.zip", "channel": "release"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-static-with-deps-pre-cxx11", "validation_runner": "macos-12", "installation": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.13.0.zip", "channel": "release"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-static-without-deps-pre-cxx11", "validation_runner": "macos-12", "installation": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.13.0.zip", "channel": "release"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-shared-with-deps-cxx11-abi", "validation_runner": "macos-12", "installation": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.13.0.zip", "channel": "release"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-shared-without-deps-cxx11-abi", "validation_runner": "macos-12", "installation": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.13.0.zip", "channel": "release"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-static-with-deps-cxx11-abi", "validation_runner": "macos-12", "installation": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.13.0.zip", "channel": "release"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-static-without-deps-cxx11-abi", "validation_runner": "macos-12", "installation": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.13.0.zip", "channel": "release"}]}
```