### PR TITLE
use smaller docker images for stronghold runs

### DIFF
--- a/.github/workflows/stronghold.yml
+++ b/.github/workflows/stronghold.yml
@@ -40,6 +40,8 @@ jobs:
 
         black --check --diff .
 
+      docker-image: python:3.11.0-slim-bullseye
+
   flake8:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
@@ -53,6 +55,8 @@ jobs:
 
         flake8 .
 
+      docker-image: python:3.11.0-slim-bullseye
+
   mypy:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
@@ -65,6 +69,8 @@ jobs:
         echo ::endgroup::
 
         mypy .
+
+      docker-image: python:3.11.0-slim-bullseye
 
   pytest:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/test-infra/pull/1158).
* #1159
* #1148
* __->__ #1158

use smaller docker images for stronghold runs

Summary:
The smaller image takes 2s to download as opposed to 50s for
pytorch/conda-builder.

Test Plan: Verified in CI.

