### PR TITLE
[Nova] Fix call to anaconda during upload in Mac Conda builds

### DIFF
--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -191,7 +191,7 @@ jobs:
           else
             export ARCH_NAME="osx-64"
           fi
-          ${CONDA_RUN} anaconda -t "${CONDA_PYTORCHBOT_TOKEN}" upload "dist/${ARCH_NAME}"/*.tar.bz2 -u "pytorch-${CHANNEL}" --label main --no-progress --force
+          ${CONDA_RUN} "${CONDA_PREFIX}/bin/anaconda" -t "${CONDA_PYTORCHBOT_TOKEN}" upload "dist/${ARCH_NAME}"/*.tar.bz2 -u "pytorch-${CHANNEL}" --label main --no-progress --force
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -191,7 +191,7 @@ jobs:
           else
             export ARCH_NAME="osx-64"
           fi
-          ${CONDA_RUN} "${CONDA_PREFIX}/bin/anaconda" -t "${CONDA_PYTORCHBOT_TOKEN}" upload "dist/${ARCH_NAME}"/*.tar.bz2 -u "pytorch-${CHANNEL}" --label main --no-progress --force
+          ${CONDA_RUN} anaconda -t "${CONDA_PYTORCHBOT_TOKEN}" upload "dist/${ARCH_NAME}"/*.tar.bz2 -u "pytorch-${CHANNEL}" --label main --no-progress --force
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -185,15 +185,13 @@ jobs:
           source "${BUILD_ENV_FILE}"
           ${CONDA_RUN} conda install -yq anaconda-client
           set -x
-          ANACONDA_PATH=$(${CONDA_RUN} conda info --base)/bin
-          export ANACONDA_PATH
           arch_name="$(uname -m)"
           if [ "${arch_name}" = "arm64" ]; then
             export ARCH_NAME="osx-arm64"
           else
             export ARCH_NAME="osx-64"
           fi
-          ${CONDA_RUN} "$ANACONDA_PATH/anaconda" -t "${CONDA_PYTORCHBOT_TOKEN}" upload "dist/${ARCH_NAME}"/*.tar.bz2 -u "pytorch-${CHANNEL}" --label main --no-progress --force
+          ${CONDA_RUN} anaconda -t "${CONDA_PYTORCHBOT_TOKEN}" upload "dist/${ARCH_NAME}"/*.tar.bz2 -u "pytorch-${CHANNEL}" --label main --no-progress --force
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
I found that the path to the anaconda binary after manipulating the output of `conda info --base` does not seem to be correct, since the command gives us the path of the base environment. I tested removing this and just using the anaconda executable (which should be on the path). I've tried this on my local machine - would need some testing on an M1 machine.