### PR TITLE
[BE] Sort the grouped failures in the failure view

### DIFF
--- a/torchci/pages/failure/[capture].tsx
+++ b/torchci/pages/failure/[capture].tsx
@@ -171,12 +171,19 @@ function FailureInfo({
         <h3>Failures by job</h3>
         <table>
           <tbody>
-            {Object.entries(jobCount).map(([job, count]) => (
-              <tr key={job}>
-                <td>{job}</td>
-                <td>{count as number}</td>
-              </tr>
-            ))}
+            {Object.entries(jobCount)
+              .sort(function([jobAName, jobACount], [jobBName, jobBCount]) {
+                if (jobACount != jobBCount) {
+                  return jobBCount-jobACount
+                }
+                return jobAName.localeCompare(jobBName)
+              })
+              .map(([job, count]) => (
+                <tr key={job}>
+                  <td>{job}</td>
+                  <td>{count as number}</td>
+                </tr>
+              ))}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
Sort the `Failures by job` view in the failures page, sorting first by the frequency of the failure, then sorting alphabetically by job name.

Example using https://hud.pytorch.org/failure/RuntimeError%3A%20test_jit_cuda_fuser%20failed

Old view:
<img width="949" alt="image" src="https://user-images.githubusercontent.com/4468967/203391633-d8b71f61-1f00-4690-abee-fbc47c823926.png">

New view:
<img width="959" alt="image" src="https://user-images.githubusercontent.com/4468967/203391565-d5f530b0-06ab-4cca-804c-afff88a28f0d.png">
