### PR TITLE
Macos arm64 libtorch fix

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -230,6 +230,10 @@ def generate_libtorch_matrix(
 
     ret: List[Dict[str, str]] = []
 
+    # macos-arm64 does not have any libtorch builds
+    if os == "macos-arm64":
+        return ret
+
     if arches is None:
         arches = ["cpu"]
 


### PR DESCRIPTION
MacOS  Arm64 do not have libtorch builds. Ref HUD: https://hud.pytorch.org/hud/pytorch/pytorch/nightly

Test:
```
 python generate_binary_build_matrix.py --operating-system macos-arm64 --package-type all
{"include": [{"python_version": "3.8", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "wheel", "build_name": "wheel-py3_8-cpu", "validation_runner": "macos-m1-12", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "stable_version": "1.13.0"}, {"python_version": "3.9", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "wheel", "build_name": "wheel-py3_9-cpu", "validation_runner": "macos-m1-12", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "stable_version": "1.13.0"}, {"python_version": "3.10", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "wheel", "build_name": "wheel-py3_10-cpu", "validation_runner": "macos-m1-12", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "stable_version": "1.13.0"}, {"python_version": "3.8", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_8-cpu", "validation_runner": "macos-m1-12", "channel": "nightly", "stable_version": "1.13.0", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.9", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_9-cpu", "validation_runner": "macos-m1-12", "channel": "nightly", "stable_version": "1.13.0", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.10", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_10-cpu", "validation_runner": "macos-m1-12", "channel": "nightly", "stable_version": "1.13.0", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}]}
(.venv) [atalman@devvm214.ftw0 /data/users/atalman/test-infra/tools/scripts (macos_libtorch_fix)]$ python generate_binary_build_matrix.py --operating-system macos --package-type all
{"include": [{"python_version": "3.7", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "wheel", "build_name": "wheel-py3_7-cpu", "validation_runner": "macos-12", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "stable_version": "1.13.0"}, {"python_version": "3.8", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "wheel", "build_name": "wheel-py3_8-cpu", "validation_runner": "macos-12", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "stable_version": "1.13.0"}, {"python_version": "3.9", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "wheel", "build_name": "wheel-py3_9-cpu", "validation_runner": "macos-12", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "stable_version": "1.13.0"}, {"python_version": "3.10", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "wheel", "build_name": "wheel-py3_10-cpu", "validation_runner": "macos-12", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "stable_version": "1.13.0"}, {"python_version": "3.7", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_7-cpu", "validation_runner": "macos-12", "channel": "nightly", "stable_version": "1.13.0", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.8", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_8-cpu", "validation_runner": "macos-12", "channel": "nightly", "stable_version": "1.13.0", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.9", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_9-cpu", "validation_runner": "macos-12", "channel": "nightly", "stable_version": "1.13.0", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.10", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_10-cpu", "validation_runner": "macos-12", "channel": "nightly", "stable_version": "1.13.0", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-shared-with-deps-pre-cxx11", "validation_runner": "macos-12", "installation": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-latest.zip", "channel": "nightly", "stable_version": "1.13.0"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-shared-without-deps-pre-cxx11", "validation_runner": "macos-12", "installation": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-latest.zip", "channel": "nightly", "stable_version": "1.13.0"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-static-with-deps-pre-cxx11", "validation_runner": "macos-12", "installation": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-latest.zip", "channel": "nightly", "stable_version": "1.13.0"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-static-without-deps-pre-cxx11", "validation_runner": "macos-12", "installation": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-latest.zip", "channel": "nightly", "stable_version": "1.13.0"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-shared-with-deps-cxx11-abi", "validation_runner": "macos-12", "installation": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-latest.zip", "channel": "nightly", "stable_version": "1.13.0"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-shared-without-deps-cxx11-abi", "validation_runner": "macos-12", "installation": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-latest.zip", "channel": "nightly", "stable_version": "1.13.0"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-static-with-deps-cxx11-abi", "validation_runner": "macos-12", "installation": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-latest.zip", "channel": "nightly", "stable_version": "1.13.0"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-static-without-deps-cxx11-abi", "validation_runner": "macos-12", "installation": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-latest.zip", "channel": "nightly", "stable_version": "1.13.0"}]}
```