### PR TITLE
Update VS 2019 and add VS 2022 to Windows AMI

### DIFF
--- a/aws/ami/windows/scripts/Installers/Install-VS.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-VS.ps1
@@ -1,8 +1,10 @@
 # https://developercommunity.visualstudio.com/t/install-specific-version-of-vs-component/1142479
-# Where to find the links: https://docs.microsoft.com/en-us/visualstudio/releases/2019/history#release-dates-and-build-numbers
-
+# Where to find the links: 
+#   - https://docs.microsoft.com/en-us/visualstudio/releases/2019/history#release-dates-and-build-numbers
+#   - https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-history#fixed-version-bootstrappers
 # BuildTools from S3
-$VS_DOWNLOAD_LINK = "https://s3.amazonaws.com/ossci-windows/vs${env:VS_VERSION}_BuildTools.exe"
+$VS_VERSION_major = [int] ${env:VS_VERSION}.split(".")[0]
+$VS_DOWNLOAD_LINK = "https://aka.ms/vs/$VS_VERSION_major/release/vs_BuildTools.exe"
 $COLLECT_DOWNLOAD_LINK = "https://aka.ms/vscollect.exe"
 $VS_INSTALL_ARGS = @("--nocache","--quiet","--wait", "--add Microsoft.VisualStudio.Workload.VCTools",
                                                      "--add Microsoft.Component.MSBuild",
@@ -19,8 +21,7 @@ if (${env:INSTALL_WINDOWS_SDK} -eq "1") {
 }
 
 if (Test-Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe") {
-    $VS_VERSION_major = [int] ${env:VS_VERSION}.split(".")[0]
-    $existingPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -products "Microsoft.VisualStudio.Product.BuildTools" -version "[${env:VS_VERSION}, ${env:VS_VERSION_major + 1})" -property installationPath
+    $existingPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -products "Microsoft.VisualStudio.Product.BuildTools" -version "[${env:VS_VERSION}, ${VS_VERSION_major + 1})" -property installationPath
     if (($existingPath -ne $null) -and (!${env:CIRCLECI})) {
         echo "Found correctly versioned existing BuildTools installation in $existingPath"
         exit 0
@@ -28,10 +29,10 @@ if (Test-Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswher
     $pathToRemove = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -products "Microsoft.VisualStudio.Product.BuildTools" -property installationPath
 }
 
-echo "Downloading VS installer from S3."
+echo "Downloading Visual Studio installer from $VS_DOWNLOAD_LINK."
 curl.exe --retry 3 -kL $VS_DOWNLOAD_LINK --output vs_installer.exe
 if ($LASTEXITCODE -ne 0) {
-    echo "Download of the VS 2019 Version ${env:VS_VERSION} installer failed"
+    echo "Download of the VS ${env:VS_YEAR} Version ${env:VS_VERSION} installer failed"
     exit 1
 }
 
@@ -52,7 +53,7 @@ $process = Start-Process "${PWD}\vs_installer.exe" -ArgumentList $VS_INSTALL_ARG
 Remove-Item -Path vs_installer.exe -Force
 $exitCode = $process.ExitCode
 if (($exitCode -ne 0) -and ($exitCode -ne 3010)) {
-    echo "VS 2019 installer exited with code $exitCode, which should be one of [0, 3010]."
+    echo "VS ${env:VS_YEAR} installer exited with code $exitCode, which should be one of [0, 3010]."
     curl.exe --retry 3 -kL $COLLECT_DOWNLOAD_LINK --output Collect.exe
     if ($LASTEXITCODE -ne 0) {
         echo "Download of the VS Collect tool failed."

--- a/aws/ami/windows/windows.pkr.hcl
+++ b/aws/ami/windows/windows.pkr.hcl
@@ -55,15 +55,31 @@ build {
     ]
   }
 
+  # Install the Visual Studio 2019
+  provisioner "powershell" {
+    environment_vars = ["INSTALL_WINDOWS_SDK=1", "VS_YEAR=2019", "VS_VERSION=16.11.21"]
+    execution_policy = "unrestricted"
+    scripts = [
+      "${path.root}/scripts/Installers/Install-VS.ps1",
+    ]
+  }
+
+  # Install the Visual Studio 2022
+  provisioner "powershell" {
+    environment_vars = ["INSTALL_WINDOWS_SDK=1", "VS_YEAR=2022", "VS_VERSION=17.4.1"]
+    execution_policy = "unrestricted"
+    scripts = [
+      "${path.root}/scripts/Installers/Install-VS.ps1",
+    ]
+  }
+
   # Install the rest of the dependencies
   provisioner "powershell" {
-    environment_vars = ["INSTALL_WINDOWS_SDK=1", "VS_VERSION=16.8.6"]
     execution_policy = "unrestricted"
     scripts = [
       "${path.root}/scripts/Helpers/Reset-UserData.ps1",
       "${path.root}/scripts/Installers/Install-Choco.ps1",
       "${path.root}/scripts/Installers/Install-Tools.ps1",
-      "${path.root}/scripts/Installers/Install-VS.ps1",
     ]
   }
 


### PR DESCRIPTION
This adds VS 2022 to Windows AMI. The line with [https://aka.ms/](https://aka.ms/) link might be reverted once `vs16.11.21_BuildTools.exe` and `vs17.4.1_BuildTools.exe` files will be uploaded to [https://s3.amazonaws.com/ossci-windows/](https://s3.amazonaws.com/ossci-windows/.).

Note that there is a fix of [thread\_local causing fatal error LNK1161: invalid export specification on VS 2022 - Visual Studio Feedback](https://developercommunity.visualstudio.com/t/thread_local-causing-fatal-error-LNK1161/10199441) pending, required e.g. for pytorch/pytorch#89511, which will require another VS 2022 version update. Alternatively, the VS 2022 version installed by this change can be downgraded to 16.3.6 which does not suffer this issue.

This is needed to finish pytorch/pytorch#86591