### PR TITLE
Add continue on error input param to generic jobs

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -55,6 +55,10 @@ on:
         description: "Name for the job, which is displayed in the GitHub UI"
         default: "linux-job"
         type: string
+      continue-on-error:
+        description: "Prevents a job from failing when a step fails. Set to true to allow a job to pass when exec script step fails."
+        default: false
+        type: boolean
 
 jobs:
   job:
@@ -111,6 +115,7 @@ jobs:
           path: ${{ runner.temp }}/artifacts/
 
       - name: Run script in container
+        continue-on-error: ${{ inputs.continue-on-error }}
         working-directory: ${{ inputs.repository }}
         run: |
           {

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -43,6 +43,10 @@ on:
         description: "Name for the job, which is displayed in the GitHub UI"
         default: "macos-job"
         type: string
+      continue-on-error:
+        description: "Prevents a job from failing when a step fails. Set to true to allow a job to pass when exec script step fails."
+        default: false
+        type: boolean
 
 jobs:
   job:
@@ -88,6 +92,7 @@ jobs:
 
       - name: Run script
         shell: bash -l {0}
+        continue-on-error: ${{ inputs.continue-on-error }}
         working-directory: ${{ inputs.repository }}
         run: |
           {

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -43,6 +43,10 @@ on:
         description: "Name for the job, which is displayed in the GitHub UI"
         default: "windows-job"
         type: string
+      continue-on-error:
+        description: "Prevents a job from failing when a step fails. Set to true to allow a job to pass when exec script step fails."
+        default: false
+        type: boolean
 
 jobs:
   job:
@@ -86,6 +90,7 @@ jobs:
 
       - name: Run script
         shell: bash -l {0}
+        continue-on-error: ${{ inputs.continue-on-error }}
         working-directory: ${{ inputs.repository }}
         run: |
           {


### PR DESCRIPTION
This is important for validation workflow to continue and execute all the test plan. Hence adding this input param.