### PR TITLE
Remove extra space when no conda_package_type specified

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -141,6 +141,8 @@ def get_conda_install_command(channel: str, gpu_arch_type: str, arch_version: st
         conda_channels = f"{conda_channels} -c nvidia"
     elif os not in ("macos", "macos-arm64"):
         conda_package_type = "cpuonly"
+    else:
+        return f"{CONDA_INSTALL_BASE} {conda_channels}"
 
     return f"{CONDA_INSTALL_BASE} {conda_package_type} {conda_channels}"
 


### PR DESCRIPTION
Fixes small issue:
```
conda install pytorch torchvision torchaudio  -c pytorch-nightly
```
should be 
```
conda install pytorch torchvision torchaudio -c pytorch-nightly
```

issue can be seen here: https://github.com/atalman/pytorch.github.io/pull/2/files