### PR TITLE
Disable Windows Vision Test Workflows

### DIFF
--- a/.github/workflows/test_build_conda_windows_without_cuda.yml
+++ b/.github/workflows/test_build_conda_windows_without_cuda.yml
@@ -30,11 +30,11 @@ jobs:
             post-script: ""
             package-name: torchaudio
             conda-package-directory: packaging/torchaudio
-          - repository: pytorch/vision
-            pre-script: packaging/pre_build_script.sh
-            post-script: packaging/post_build_script.sh
-            package-name: torchvision
-            conda-package-directory: packaging/torchvision
+          # - repository: pytorch/vision
+          #   pre-script: packaging/pre_build_script.sh
+          #   post-script: packaging/post_build_script.sh
+          #   package-name: torchvision
+          #   conda-package-directory: packaging/torchvision
           - repository: pytorch/text
             pre-script: packaging/install_torchdata.sh
             post-script: ""

--- a/.github/workflows/test_build_conda_windows_without_cuda.yml
+++ b/.github/workflows/test_build_conda_windows_without_cuda.yml
@@ -31,8 +31,8 @@ jobs:
             package-name: torchaudio
             conda-package-directory: packaging/torchaudio
           - repository: pytorch/vision
-            pre-script: ""
-            post-script: ""
+            pre-script: packaging/pre_build_script.sh
+            post-script: packaging/post_build_script.sh
             package-name: torchvision
             conda-package-directory: packaging/torchvision
           - repository: pytorch/text

--- a/.github/workflows/test_build_wheels_windows.yml
+++ b/.github/workflows/test_build_wheels_windows.yml
@@ -31,12 +31,12 @@ jobs:
             post-script: ""
             smoke-test-script: ""
             package-name: torchaudio
-          - repository: pytorch/vision
-            pre-script: packaging/pre_build_script.sh
-            env-script: packaging/windows/internal/vc_env_helper.bat
-            post-script: packaging/post_build_script.sh
-            smoke-test-script: test/smoke_test.py
-            package-name: torchvision
+          # - repository: pytorch/vision
+          #   pre-script: packaging/pre_build_script.sh
+          #   env-script: packaging/windows/internal/vc_env_helper.bat
+          #   post-script: packaging/post_build_script.sh
+          #   smoke-test-script: test/smoke_test.py
+          #   package-name: torchvision
           - repository: pytorch/text
             pre-script: packaging/install_torchdata.sh
             env-script: packaging/vc_env_helper.bat

--- a/.github/workflows/test_build_wheels_windows.yml
+++ b/.github/workflows/test_build_wheels_windows.yml
@@ -32,9 +32,9 @@ jobs:
             smoke-test-script: ""
             package-name: torchaudio
           - repository: pytorch/vision
-            pre-script: ""
+            pre-script: packaging/pre_build_script.sh
             env-script: packaging/windows/internal/vc_env_helper.bat
-            post-script: ""
+            post-script: packaging/post_build_script.sh
             smoke-test-script: test/smoke_test.py
             package-name: torchvision
           - repository: pytorch/text


### PR DESCRIPTION
The recent changes to windows builds with the pre-script is causing windows builds for torchvision to break. I'm going to see if naively adding the pre-script will make these work. If not, I'm going to disable the Windows Vision tests on each PR and create a task for closing later, since we're not migrating Windows builds in the near future, and having clear signal on test-infra PR's is critical for us to smoothly complete the ongoing migrations for the other OS's.