### PR TITLE
fix: add cleanup step prior to checkout

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -78,6 +78,13 @@ jobs:
     #       ec2-user prior to a checkout being able to be run by ec2-user
     timeout-minutes: ${{ inputs.timeout }}
     steps:
+      - name: Clean workspace
+        run: |
+          echo "::group::Cleanup debug output"
+          rm -rfv "${GITHUB_WORKSPACE}"
+          mkdir -p "${GITHUB_WORKSPACE}"
+          echo "::endgroup::"
+
       - name: Checkout repository (${{ inputs.test-infra-repository }}@${{ inputs.test-infra-ref }})
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -57,6 +57,13 @@ jobs:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout }}
     steps:
+      - name: Clean workspace
+        run: |
+          echo "::group::Cleanup debug output"
+          rm -rfv "${GITHUB_WORKSPACE}"
+          mkdir -p "${GITHUB_WORKSPACE}"
+          echo "::endgroup::"
+
       - name: Checkout repository (${{ inputs.test-infra-repository }}@${{ inputs.test-infra-ref }})
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -58,6 +58,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout }}
     steps:
       - name: Clean workspace
+        shell: bash -l {0}
         run: |
           echo "::group::Cleanup debug output"
           rm -rfv "${GITHUB_WORKSPACE}"

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -57,6 +57,13 @@ jobs:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout }}
     steps:
+      - name: Clean workspace
+        run: |
+          echo "::group::Cleanup debug output"
+          rm -rfv "${GITHUB_WORKSPACE}"
+          mkdir -p "${GITHUB_WORKSPACE}"
+          echo "::endgroup::"
+
       - name: Checkout repository (${{ inputs.test-infra-repository }}@${{ inputs.test-infra-ref }})
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
To fix issues related to:
```
 Error: fatal: No url found for submodule path 'test-infra' in .gitmodules
  Error: The process '/usr/bin/git' failed with exit code 128
  ```

Also adds verbose output to the cleanup that's hidden behind a collapsible log group

This is a follow up to #1203 

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>