### PR TITLE
[Nova] Use windows.4xlarge and windows.8xlarge.nvidia.gpu for Windows wheel builds

### DIFF
--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -95,11 +95,14 @@ jobs:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
           activate-with-label: false
           instructions: "SSH with rdesktop using ssh -L 3389:localhost:3389 %%username%%@%%hostname%%"
+      - name: Add Conda scripts to GitHub path
+        run: |
+          echo "C:/Jenkins/Miniconda3/Scripts" >> $GITHUB_PATH
       - uses: ./test-infra/.github/actions/setup-binary-builds
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-          setup-miniconda: true
+          setup-miniconda: false
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install torch dependency
         run: |

--- a/.github/workflows/test_build_wheels_windows_with_cuda.yml
+++ b/.github/workflows/test_build_wheels_windows_with_cuda.yml
@@ -1,10 +1,10 @@
-name: Test Build Windows Wheels
+name: Test Build Windows Wheels with CUDA
 
 on:
   pull_request:
     paths:
       - .github/actions/setup-binary-builds/action.yml
-      - .github/workflows/test_build_wheels_windows.yml
+      - .github/workflows/test_build_wheels_windows_with_cuda.yml
       - .github/workflows/build_wheels_windows.yml
       - .github/workflows/generate_binary_build_matrix.yml
       - tools/scripts/generate_binary_build_matrix.py
@@ -57,5 +57,5 @@ jobs:
       post-script: ${{ matrix.post-script }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
       package-name: ${{ matrix.package-name }}
-      runner-type: windows-2019
+      runner-type: windows.8xlarge.nvidia.gpu
       trigger-event: "${{ github.event_name }}"

--- a/.github/workflows/test_build_wheels_windows_without_cuda.yml
+++ b/.github/workflows/test_build_wheels_windows_without_cuda.yml
@@ -1,0 +1,62 @@
+name: Test Build Windows Wheels without CUDA
+
+on:
+  pull_request:
+    paths:
+      - .github/actions/setup-binary-builds/action.yml
+      - .github/workflows/test_build_wheels_windows_without_cuda.yml
+      - .github/workflows/build_wheels_windows.yml
+      - .github/workflows/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.py
+  workflow_dispatch:
+
+jobs:
+  generate-matrix:
+    uses: ./.github/workflows/generate_binary_build_matrix.yml
+    with:
+      package-type: wheel
+      os: windows
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      with-cuda: disable
+  test:
+    needs: generate-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repository: pytorch/audio
+            pre-script: ""
+            env-script: packaging/vc_env_helper.bat
+            wheel-build-params: "--plat-name win_amd64"
+            post-script: ""
+            smoke-test-script: ""
+            package-name: torchaudio
+          # - repository: pytorch/vision
+          #   pre-script: packaging/pre_build_script.sh
+          #   env-script: packaging/windows/internal/vc_env_helper.bat
+          #   post-script: packaging/post_build_script.sh
+          #   smoke-test-script: test/smoke_test.py
+          #   package-name: torchvision
+          - repository: pytorch/text
+            pre-script: packaging/install_torchdata.sh
+            env-script: packaging/vc_env_helper.bat
+            post-script: ""
+            smoke-test-script: test/smoke_tests/smoke_tests.py
+            package-name: torchtext
+    uses: ./.github/workflows/build_wheels_windows.yml
+    name: ${{ matrix.repository }}
+    with:
+      repository: ${{ matrix.repository }}
+      ref: nightly
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      pre-script: ${{ matrix.pre-script }}
+      env-script: ${{ matrix.env-script }}
+      wheel-build-params: ${{ matrix.wheel-build-params }}
+      post-script: ${{ matrix.post-script }}
+      smoke-test-script: ${{ matrix.smoke-test-script }}
+      package-name: ${{ matrix.package-name }}
+      runner-type: windows.4xlarge
+      trigger-event: "${{ github.event_name }}"


### PR DESCRIPTION
Use self-hosted runners windows.4xlarge and windows.8xlarge.nvidia.gpu instead of GitHub-hosted windows-2019.
Also add separate workflows to tests builds on GPU and non-GPU machines.