### PR TITLE
track the line number where functions are defined

### DIFF
--- a/tools/stronghold/src/api/__init__.py
+++ b/tools/stronghold/src/api/__init__.py
@@ -18,6 +18,8 @@ class Parameters:
     variadic_args: bool
     # Whether or not the function takes variadic keyword arguments.
     variadic_kwargs: bool
+    # The line where the function is defined.
+    line: int
 
 
 @dataclasses.dataclass

--- a/tools/stronghold/src/api/ast.py
+++ b/tools/stronghold/src/api/ast.py
@@ -70,6 +70,7 @@ def _function_def_to_parameters(node: ast.FunctionDef) -> api.Parameters:
         parameters=params,
         variadic_args=args.vararg is not None,
         variadic_kwargs=args.kwarg is not None,
+        line=node.lineno,
     )
 
 

--- a/tools/stronghold/tests/api/test_ast.py
+++ b/tools/stronghold/tests/api/test_ast.py
@@ -15,7 +15,7 @@ def test_extract_empty(tmp_path: pathlib.Path) -> None:
     funcs = api.ast.extract(source.make_file(tmp_path, func))
     assert funcs == {
         'func': api.Parameters(
-            parameters=[], variadic_args=False, variadic_kwargs=False
+            parameters=[], variadic_args=False, variadic_kwargs=False, line=1
         )
     }
 
@@ -32,6 +32,7 @@ def test_extract_positional(tmp_path: pathlib.Path) -> None:
             ],
             variadic_args=False,
             variadic_kwargs=False,
+            line=1,
         )
     }
 
@@ -48,6 +49,7 @@ def test_extract_positional_with_default(tmp_path: pathlib.Path) -> None:
             ],
             variadic_args=False,
             variadic_kwargs=False,
+            line=1,
         )
     }
 
@@ -64,6 +66,7 @@ def test_extract_flexible(tmp_path: pathlib.Path) -> None:
             ],
             variadic_args=False,
             variadic_kwargs=False,
+            line=1,
         )
     }
 
@@ -80,6 +83,7 @@ def test_extract_flexible_with_default(tmp_path: pathlib.Path) -> None:
             ],
             variadic_args=False,
             variadic_kwargs=False,
+            line=1,
         )
     }
 
@@ -96,6 +100,7 @@ def test_extract_keyword(tmp_path: pathlib.Path) -> None:
             ],
             variadic_args=False,
             variadic_kwargs=False,
+            line=1,
         )
     }
 
@@ -112,6 +117,7 @@ def test_extract_keyword_with_default(tmp_path: pathlib.Path) -> None:
             ],
             variadic_args=False,
             variadic_kwargs=False,
+            line=1,
         )
     }
 
@@ -122,7 +128,9 @@ def test_extract_variadic_args(tmp_path: pathlib.Path) -> None:
 
     funcs = api.ast.extract(source.make_file(tmp_path, func))
     assert funcs == {
-        'func': api.Parameters(parameters=[], variadic_args=True, variadic_kwargs=False)
+        'func': api.Parameters(
+            parameters=[], variadic_args=True, variadic_kwargs=False, line=1
+        )
     }
 
 
@@ -132,7 +140,9 @@ def test_extract_variadic_kwargs(tmp_path: pathlib.Path) -> None:
 
     funcs = api.ast.extract(source.make_file(tmp_path, func))
     assert funcs == {
-        'func': api.Parameters(parameters=[], variadic_args=False, variadic_kwargs=True)
+        'func': api.Parameters(
+            parameters=[], variadic_args=False, variadic_kwargs=True, line=1
+        )
     }
 
 
@@ -154,6 +164,7 @@ def test_extract_class_method(tmp_path: pathlib.Path) -> None:
             ],
             variadic_args=False,
             variadic_kwargs=False,
+            line=2,
         )
     }
 
@@ -196,5 +207,6 @@ def test_extract_comprehensive(tmp_path: pathlib.Path) -> None:
             ],
             variadic_args=True,
             variadic_kwargs=True,
+            line=2,
         )
     }


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/test-infra/pull/1208).
* #1143
* #1142
* #1211
* #1210
* #1209
* __->__ #1208

track the line number where functions are defined

Summary:
We can use this to write our annotations to the GitHub UI.

Test Plan: Rely on CI.

