### PR TITLE
add a function to render a violation as a github warning

### DIFF
--- a/tools/stronghold/src/api/__init__.py
+++ b/tools/stronghold/src/api/__init__.py
@@ -18,6 +18,8 @@ class Parameters:
     variadic_args: bool
     # Whether or not the function takes variadic keyword arguments.
     variadic_kwargs: bool
+    # The line where the function is defined.
+    line: int
 
 
 @dataclasses.dataclass

--- a/tools/stronghold/src/api/ast.py
+++ b/tools/stronghold/src/api/ast.py
@@ -70,6 +70,7 @@ def _function_def_to_parameters(node: ast.FunctionDef) -> api.Parameters:
         parameters=params,
         variadic_args=args.vararg is not None,
         variadic_kwargs=args.kwarg is not None,
+        line=node.lineno,
     )
 
 

--- a/tools/stronghold/src/api/github.py
+++ b/tools/stronghold/src/api/github.py
@@ -1,0 +1,12 @@
+"""GitHub integration for the API compatibility checker."""
+
+import pathlib
+
+import api.compatibility
+
+
+def render_violation(file: pathlib.Path, violation: api.compatibility.Violation) -> str:
+    return (
+        f'::warning file={file},line={violation.line}::'
+        f'Function {violation.func}: {violation.message}'
+    )

--- a/tools/stronghold/tests/api/test_ast.py
+++ b/tools/stronghold/tests/api/test_ast.py
@@ -15,7 +15,7 @@ def test_extract_empty(tmp_path: pathlib.Path) -> None:
     funcs = api.ast.extract(source.make_file(tmp_path, func))
     assert funcs == {
         'func': api.Parameters(
-            parameters=[], variadic_args=False, variadic_kwargs=False
+            parameters=[], variadic_args=False, variadic_kwargs=False, line=1
         )
     }
 
@@ -32,6 +32,7 @@ def test_extract_positional(tmp_path: pathlib.Path) -> None:
             ],
             variadic_args=False,
             variadic_kwargs=False,
+            line=1,
         )
     }
 
@@ -48,6 +49,7 @@ def test_extract_positional_with_default(tmp_path: pathlib.Path) -> None:
             ],
             variadic_args=False,
             variadic_kwargs=False,
+            line=1,
         )
     }
 
@@ -64,6 +66,7 @@ def test_extract_flexible(tmp_path: pathlib.Path) -> None:
             ],
             variadic_args=False,
             variadic_kwargs=False,
+            line=1,
         )
     }
 
@@ -80,6 +83,7 @@ def test_extract_flexible_with_default(tmp_path: pathlib.Path) -> None:
             ],
             variadic_args=False,
             variadic_kwargs=False,
+            line=1,
         )
     }
 
@@ -96,6 +100,7 @@ def test_extract_keyword(tmp_path: pathlib.Path) -> None:
             ],
             variadic_args=False,
             variadic_kwargs=False,
+            line=1,
         )
     }
 
@@ -112,6 +117,7 @@ def test_extract_keyword_with_default(tmp_path: pathlib.Path) -> None:
             ],
             variadic_args=False,
             variadic_kwargs=False,
+            line=1,
         )
     }
 
@@ -122,7 +128,9 @@ def test_extract_variadic_args(tmp_path: pathlib.Path) -> None:
 
     funcs = api.ast.extract(source.make_file(tmp_path, func))
     assert funcs == {
-        'func': api.Parameters(parameters=[], variadic_args=True, variadic_kwargs=False)
+        'func': api.Parameters(
+            parameters=[], variadic_args=True, variadic_kwargs=False, line=1
+        )
     }
 
 
@@ -132,7 +140,9 @@ def test_extract_variadic_kwargs(tmp_path: pathlib.Path) -> None:
 
     funcs = api.ast.extract(source.make_file(tmp_path, func))
     assert funcs == {
-        'func': api.Parameters(parameters=[], variadic_args=False, variadic_kwargs=True)
+        'func': api.Parameters(
+            parameters=[], variadic_args=False, variadic_kwargs=True, line=1
+        )
     }
 
 
@@ -154,6 +164,7 @@ def test_extract_class_method(tmp_path: pathlib.Path) -> None:
             ],
             variadic_args=False,
             variadic_kwargs=False,
+            line=2,
         )
     }
 
@@ -196,5 +207,6 @@ def test_extract_comprehensive(tmp_path: pathlib.Path) -> None:
             ],
             variadic_args=True,
             variadic_kwargs=True,
+            line=2,
         )
     }

--- a/tools/stronghold/tests/api/test_compatibility.py
+++ b/tools/stronghold/tests/api/test_compatibility.py
@@ -19,7 +19,7 @@ def test_deleted_function(tmp_path: pathlib.Path) -> None:
     after = source.make_file(tmp_path, lambda: None)
 
     assert api.compatibility.check(before, after) == [
-        api.compatibility.Violation('func', 'function deleted')
+        api.compatibility.Violation('func', 'function deleted', line=1)
     ]
 
 
@@ -39,7 +39,7 @@ def test_renamed_function(tmp_path: pathlib.Path) -> None:
     after = source.make_file(tmp_path, rose_by_any_other_name)
 
     assert api.compatibility.check(before, after) == [
-        api.compatibility.Violation('rose', 'function deleted')
+        api.compatibility.Violation('rose', 'function deleted', line=1)
     ]
 
 
@@ -53,7 +53,7 @@ def test_deleted_method(tmp_path: pathlib.Path) -> None:
     after = source.make_file(tmp_path, lambda: None)
 
     assert api.compatibility.check(before, after) == [
-        api.compatibility.Violation('Class.func', 'function deleted')
+        api.compatibility.Violation('Class.func', 'function deleted', line=1)
     ]
 
 
@@ -69,7 +69,7 @@ def test_deleted_variadic_args(tmp_path: pathlib.Path) -> None:
     after = source.make_file(tmp_path, func)
 
     assert api.compatibility.check(before, after) == [
-        api.compatibility.Violation('func', 'removed *varargs')
+        api.compatibility.Violation('func', 'removed *varargs', line=1)
     ]
 
 
@@ -85,7 +85,7 @@ def test_deleted_variadic_kwargs(tmp_path: pathlib.Path) -> None:
     after = source.make_file(tmp_path, func)
 
     assert api.compatibility.check(before, after) == [
-        api.compatibility.Violation('func', 'removed **kwargs')
+        api.compatibility.Violation('func', 'removed **kwargs', line=1)
     ]
 
 
@@ -113,7 +113,7 @@ def test_new_renamed_positional_parameter(tmp_path: pathlib.Path) -> None:
     after = source.make_file(tmp_path, func)
 
     assert api.compatibility.check(before, after) == [
-        api.compatibility.Violation('func', 'x was renamed to y')
+        api.compatibility.Violation('func', 'x was renamed to y', line=1)
     ]
 
 
@@ -129,7 +129,7 @@ def test_removed_positional_parameter(tmp_path: pathlib.Path) -> None:
     after = source.make_file(tmp_path, func)
 
     assert api.compatibility.check(before, after) == [
-        api.compatibility.Violation('func', 'x was removed')
+        api.compatibility.Violation('func', 'x was removed', line=1)
     ]
 
 
@@ -145,7 +145,7 @@ def test_removed_flexible_parameter(tmp_path: pathlib.Path) -> None:
     after = source.make_file(tmp_path, func)
 
     assert api.compatibility.check(before, after) == [
-        api.compatibility.Violation('func', 'x was removed')
+        api.compatibility.Violation('func', 'x was removed', line=1)
     ]
 
 
@@ -161,7 +161,7 @@ def test_removed_keyword_parameter(tmp_path: pathlib.Path) -> None:
     after = source.make_file(tmp_path, func)
 
     assert api.compatibility.check(before, after) == [
-        api.compatibility.Violation('func', 'x was removed')
+        api.compatibility.Violation('func', 'x was removed', line=1)
     ]
 
 
@@ -177,7 +177,7 @@ def test_new_required_positional_parameter(tmp_path: pathlib.Path) -> None:
     after = source.make_file(tmp_path, func)
 
     assert api.compatibility.check(before, after) == [
-        api.compatibility.Violation('func', 'x was added and is required')
+        api.compatibility.Violation('func', 'x was added and is required', line=1)
     ]
 
 
@@ -193,7 +193,7 @@ def test_new_required_flexible_parameter(tmp_path: pathlib.Path) -> None:
     after = source.make_file(tmp_path, func)
 
     assert api.compatibility.check(before, after) == [
-        api.compatibility.Violation('func', 'x was added and is required')
+        api.compatibility.Violation('func', 'x was added and is required', line=1)
     ]
 
 
@@ -209,7 +209,7 @@ def test_new_required_keyword_parameter(tmp_path: pathlib.Path) -> None:
     after = source.make_file(tmp_path, func)
 
     assert api.compatibility.check(before, after) == [
-        api.compatibility.Violation('func', 'x was added and is required')
+        api.compatibility.Violation('func', 'x was added and is required', line=1)
     ]
 
 
@@ -225,7 +225,7 @@ def test_positional_parameter_becomes_required(tmp_path: pathlib.Path) -> None:
     after = source.make_file(tmp_path, func)
 
     assert api.compatibility.check(before, after) == [
-        api.compatibility.Violation('func', 'x became required')
+        api.compatibility.Violation('func', 'x became required', line=1)
     ]
 
 
@@ -241,7 +241,7 @@ def test_flexible_parameter_becomes_required(tmp_path: pathlib.Path) -> None:
     after = source.make_file(tmp_path, func)
 
     assert api.compatibility.check(before, after) == [
-        api.compatibility.Violation('func', 'x became required')
+        api.compatibility.Violation('func', 'x became required', line=1)
     ]
 
 
@@ -257,7 +257,7 @@ def test_keyword_parameter_becomes_required(tmp_path: pathlib.Path) -> None:
     after = source.make_file(tmp_path, func)
 
     assert api.compatibility.check(before, after) == [
-        api.compatibility.Violation('func', 'x became required')
+        api.compatibility.Violation('func', 'x became required', line=1)
     ]
 
 
@@ -273,8 +273,8 @@ def test_positional_parameters_reordered(tmp_path: pathlib.Path) -> None:
     after = source.make_file(tmp_path, func)
 
     assert api.compatibility.check(before, after) == [
-        api.compatibility.Violation('func', 'x was renamed to y'),
-        api.compatibility.Violation('func', 'y was renamed to x'),
+        api.compatibility.Violation('func', 'x was renamed to y', line=1),
+        api.compatibility.Violation('func', 'y was renamed to x', line=1),
     ]
 
 
@@ -290,8 +290,12 @@ def test_flexible_parameters_reordered(tmp_path: pathlib.Path) -> None:
     after = source.make_file(tmp_path, func)
 
     assert api.compatibility.check(before, after) == [
-        api.compatibility.Violation('func', 'the position of x moved from 0 to 1'),
-        api.compatibility.Violation('func', 'the position of y moved from 1 to 0'),
+        api.compatibility.Violation(
+            'func', 'the position of x moved from 0 to 1', line=1
+        ),
+        api.compatibility.Violation(
+            'func', 'the position of y moved from 1 to 0', line=1
+        ),
     ]
 
 
@@ -378,6 +382,6 @@ def test_check_range(git_repo: api.git.Repository) -> None:
 
     assert violations == {
         pathlib.Path('module.py'): [
-            api.compatibility.Violation('will_be_deleted', 'function deleted')
+            api.compatibility.Violation('will_be_deleted', 'function deleted', line=1)
         ],
     }

--- a/tools/stronghold/tests/api/test_github.py
+++ b/tools/stronghold/tests/api/test_github.py
@@ -1,0 +1,18 @@
+import pathlib
+
+import api.compatibility
+import api.github
+
+
+def test_render_violation() -> None:
+    assert (
+        api.github.render_violation(
+            pathlib.Path('test.py'),
+            api.compatibility.Violation(
+                func='foo',
+                message='**kwargs was removed',
+                line=3,
+            ),
+        )
+        == '::warning file=test.py,line=3::Function foo: **kwargs was removed'
+    )


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/test-infra/pull/1210).
* #1143
* #1142
* #1211
* __->__ #1210
* #1209
* #1208

add a function to render a violation as a github warning

Summary:
When printed to the log, this will render a warning in the GitHub UI.

Test Plan: Visually inspect with downstream test PRs.

