### PR TITLE
Fix failures query

### DIFF
--- a/torchci/rockset/commons/__sql/failure_samples_query.sql
+++ b/torchci/rockset/commons/__sql/failure_samples_query.sql
@@ -1,21 +1,3 @@
-WITH classifications AS (
-    SELECT
-        c.job_id,
-        c._event_time,
-        c.line,
-        c.line_num,
-        c.context,
-        -- c.captures can be an array or a string type. Make it always be a string
-        CASE
-            IS_SCALAR(c.captures)
-            WHEN true THEN c.captures
-            WHEN false THEN ARRAY_JOIN(c.captures, '\n')
-        END AS captures,
-    FROM
-        "GitHub-Actions".classification c
-    WHERE
-        c._event_time > (CURRENT_TIMESTAMP() - INTERVAL 14 day)
-)
 SELECT
     job._event_time AS time,
     w.name AS workflowName,
@@ -38,17 +20,16 @@ SELECT
         PARSE_TIMESTAMP_ISO8601(job.started_at),
         PARSE_TIMESTAMP_ISO8601(job.completed_at)
     ) AS durationS,
-    c.line AS failureLine,
-    c.line_num AS failureLineNumber,
-    c.context AS failureContext,
-    c.captures AS failureCaptures,
+    job.torchci_classification.line AS failureLine,
+    job.torchci_classification.line_num AS failureLineNumber,
+    job.torchci_classification.context AS failureContext,
+    job.torchci_classification.captures AS failureCaptures,
 FROM
-    classifications c
-    JOIN commons.workflow_job job ON job.id = c.job_id
+    commons.workflow_job job
     JOIN commons.workflow_run w HINT(access_path = column_scan) ON w.id = job.run_id
 WHERE
-    w.head_branch LIKE :branch
-    AND w.repository.full_name = :repo
-    AND c.captures LIKE FORMAT('%{}%', :captures)
+    w.head_branch LIKE 'master'
+    AND w.head_repository.full_name = :repo
+    AND job.torchci_classification.line LIKE FORMAT('%{}%', REGEXP_REPLACE(:captures, ',', '%'))
 ORDER BY
-    c._event_time DESC
+    job.torchci_classification._event_time DESC

--- a/torchci/rockset/commons/__sql/failure_samples_query.sql
+++ b/torchci/rockset/commons/__sql/failure_samples_query.sql
@@ -28,7 +28,7 @@ FROM
     commons.workflow_job job
     JOIN commons.workflow_run w HINT(access_path = column_scan) ON w.id = job.run_id
 WHERE
-    w.head_branch LIKE 'master'
+    w.head_branch LIKE :branch
     AND w.head_repository.full_name = :repo
     AND job.torchci_classification.line LIKE FORMAT('%{}%', REGEXP_REPLACE(:captures, ',', '%'))
 ORDER BY

--- a/torchci/rockset/commons/failure_samples_query.lambda.json
+++ b/torchci/rockset/commons/failure_samples_query.lambda.json
@@ -9,7 +9,7 @@
     {
       "name": "captures",
       "type": "string",
-      "value": "timeout "
+      "value": "test_cublas_baddbmm_large_input_1_10000_10000_10000_cuda_float32,TestMatmulCudaCUDA"
     },
     {
       "name": "repo",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -11,7 +11,7 @@
     "test_time_per_file": "1c8d6289623181d8",
     "test_time_per_file_periodic_jobs": "39c105542e297c09",
     "issue_query": "5d4dfeb992e2f29b",
-    "failure_samples_query": "cf0c2266b396b6e0",
+    "failure_samples_query": "a3b943605b5710c5",
     "num_commits_master": "08d299a1b7386dbb",
     "recent_pr_workflows_query": "e34d3838c3b3eb2d",
     "reverted_prs_with_reason": "00a65a0aa7d97431",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -11,7 +11,7 @@
     "test_time_per_file": "1c8d6289623181d8",
     "test_time_per_file_periodic_jobs": "39c105542e297c09",
     "issue_query": "5d4dfeb992e2f29b",
-    "failure_samples_query": "a3b943605b5710c5",
+    "failure_samples_query": "18e7e696b4949f05",
     "num_commits_master": "08d299a1b7386dbb",
     "recent_pr_workflows_query": "e34d3838c3b3eb2d",
     "reverted_prs_with_reason": "00a65a0aa7d97431",


### PR DESCRIPTION
http://localhost:3000/failure/test_backward_symeig_cuda_float32
http://localhost:3000/failure/test_cublas_baddbmm_large_input_1_10000_10000_10000_cuda_float32%2CTestMatmulCudaCUDA 
should both work now

* uses the torchci_classifications column in the workflow_jobs table (which is populated after the log classifier got changed by suo?)
* commas get replaced with % so that the captures arrays can be used