### PR TITLE
track the line number of variadic *args/**kwds

### DIFF
--- a/tools/stronghold/src/api/__init__.py
+++ b/tools/stronghold/src/api/__init__.py
@@ -14,10 +14,12 @@ class Parameters:
     # The function's parameters in the order in which they are
     # defined.
     parameters: Sequence[Parameter]
-    # Whether or not the function takes variadic positional arguments.
-    variadic_args: bool
-    # Whether or not the function takes variadic keyword arguments.
-    variadic_kwargs: bool
+    # If variadic positional arguments are allowed, the line it is
+    # defined on.
+    variadic_args: Optional[int]
+    # If variadic keyword arguments are allowed, the line it is
+    # defined on.
+    variadic_kwargs: Optional[int]
     # The line where the function is defined.
     line: int
 

--- a/tools/stronghold/src/api/ast.py
+++ b/tools/stronghold/src/api/ast.py
@@ -68,8 +68,8 @@ def _function_def_to_parameters(node: ast.FunctionDef) -> api.Parameters:
     ]
     return api.Parameters(
         parameters=params,
-        variadic_args=args.vararg is not None,
-        variadic_kwargs=args.kwarg is not None,
+        variadic_args=args.vararg.lineno if args.vararg is not None else None,
+        variadic_kwargs=args.kwarg.lineno if args.kwarg is not None else None,
         line=node.lineno,
     )
 

--- a/tools/stronghold/tests/api/test_ast.py
+++ b/tools/stronghold/tests/api/test_ast.py
@@ -15,7 +15,7 @@ def test_extract_empty(tmp_path: pathlib.Path) -> None:
     funcs = api.ast.extract(source.make_file(tmp_path, func))
     assert funcs == {
         'func': api.Parameters(
-            parameters=[], variadic_args=False, variadic_kwargs=False, line=1
+            parameters=[], variadic_args=None, variadic_kwargs=None, line=1
         )
     }
 
@@ -30,8 +30,8 @@ def test_extract_positional(tmp_path: pathlib.Path) -> None:
             parameters=[
                 api.Parameter(name='x', position=0, keyword=False, required=True)
             ],
-            variadic_args=False,
-            variadic_kwargs=False,
+            variadic_args=None,
+            variadic_kwargs=None,
             line=1,
         )
     }
@@ -47,8 +47,8 @@ def test_extract_positional_with_default(tmp_path: pathlib.Path) -> None:
             parameters=[
                 api.Parameter(name='x', position=0, keyword=False, required=False)
             ],
-            variadic_args=False,
-            variadic_kwargs=False,
+            variadic_args=None,
+            variadic_kwargs=None,
             line=1,
         )
     }
@@ -64,8 +64,8 @@ def test_extract_flexible(tmp_path: pathlib.Path) -> None:
             parameters=[
                 api.Parameter(name='x', position=0, keyword=True, required=True)
             ],
-            variadic_args=False,
-            variadic_kwargs=False,
+            variadic_args=None,
+            variadic_kwargs=None,
             line=1,
         )
     }
@@ -81,8 +81,8 @@ def test_extract_flexible_with_default(tmp_path: pathlib.Path) -> None:
             parameters=[
                 api.Parameter(name='x', position=0, keyword=True, required=False)
             ],
-            variadic_args=False,
-            variadic_kwargs=False,
+            variadic_args=None,
+            variadic_kwargs=None,
             line=1,
         )
     }
@@ -98,8 +98,8 @@ def test_extract_keyword(tmp_path: pathlib.Path) -> None:
             parameters=[
                 api.Parameter(name='x', position=None, keyword=True, required=True)
             ],
-            variadic_args=False,
-            variadic_kwargs=False,
+            variadic_args=None,
+            variadic_kwargs=None,
             line=1,
         )
     }
@@ -115,8 +115,8 @@ def test_extract_keyword_with_default(tmp_path: pathlib.Path) -> None:
             parameters=[
                 api.Parameter(name='x', position=None, keyword=True, required=False)
             ],
-            variadic_args=False,
-            variadic_kwargs=False,
+            variadic_args=None,
+            variadic_kwargs=None,
             line=1,
         )
     }
@@ -129,7 +129,7 @@ def test_extract_variadic_args(tmp_path: pathlib.Path) -> None:
     funcs = api.ast.extract(source.make_file(tmp_path, func))
     assert funcs == {
         'func': api.Parameters(
-            parameters=[], variadic_args=True, variadic_kwargs=False, line=1
+            parameters=[], variadic_args=1, variadic_kwargs=None, line=1
         )
     }
 
@@ -141,7 +141,7 @@ def test_extract_variadic_kwargs(tmp_path: pathlib.Path) -> None:
     funcs = api.ast.extract(source.make_file(tmp_path, func))
     assert funcs == {
         'func': api.Parameters(
-            parameters=[], variadic_args=False, variadic_kwargs=True, line=1
+            parameters=[], variadic_args=None, variadic_kwargs=1, line=1
         )
     }
 
@@ -162,8 +162,8 @@ def test_extract_class_method(tmp_path: pathlib.Path) -> None:
                     required=True,
                 ),
             ],
-            variadic_args=False,
-            variadic_kwargs=False,
+            variadic_args=None,
+            variadic_kwargs=None,
             line=2,
         )
     }
@@ -205,8 +205,8 @@ def test_extract_comprehensive(tmp_path: pathlib.Path) -> None:
                     required=True,
                 ),
             ],
-            variadic_args=True,
-            variadic_kwargs=True,
+            variadic_args=3,
+            variadic_kwargs=3,
             line=2,
         )
     }


### PR DESCRIPTION
track the line number of variadic *args/**kwds

Summary:
We can use this to put the warning on the right line.

Test Plan: Verify manually in the GitHub UI with subsequent changes.
