### PR TITLE
Add a logo to the login screen

### DIFF
--- a/torchci/pages/api/auth/[...nextauth].js
+++ b/torchci/pages/api/auth/[...nextauth].js
@@ -16,6 +16,7 @@ export const authOptions = {
   },
   theme: {
     colorScheme: "light",
+    logo: "/favicon.ico",
   },
   callbacks: {
     async session({ session, token, user }) {


### PR DESCRIPTION
Make the HUD login screen look slightly less sketchy by adding the HUD logo to the page

<img width="364" alt="image" src="https://user-images.githubusercontent.com/4468967/206046924-138c6048-8884-45a6-a063-1d40ceff39b9.png">
