### PR TITLE
Increase max_available for linux.12xlarge to 350

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -25,7 +25,7 @@ runner_types:
     disk_size: 150
     instance_type: c5.12xlarge
     is_ephemeral: false
-    max_available: 250
+    max_available: 350
     os: linux
   linux.16xlarge.nvidia.gpu:
     disk_size: 150


### PR DESCRIPTION
In order to avoid limiting the number of instances artificially:

![Screenshot 2022-12-07 at 18 10 40](https://user-images.githubusercontent.com/4520845/206245141-716f18a8-3674-4e18-aa9a-fcd17bdf1bd2.png)
