### PR TITLE
Correctly identify error logs for Scribe upload failures

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -169,6 +169,10 @@ name = 'Python AttributeError'
 pattern = '^AttributeError: .*'
 
 [[rule]]
+name = 'Scribe upload failure'
+pattern = '^ERROR ENCOUNTERED WHEN UPLOADING TO SCRIBE: .*'
+
+[[rule]]
 name = 'CUDA out of memory error'
 pattern = '^RuntimeError: CUDA out of memory.'
 


### PR DESCRIPTION
Example that this fixes:
In https://hud.pytorch.org/pr/90405 the real error is "ERROR ENCOUNTERED WHEN UPLOADING TO SCRIBE" but the regexes are matching an irrelevant error line