### PR TITLE
[Nova] More tests for Generic Linux job

### DIFF
--- a/.github/workflows/test_linux_job.yml
+++ b/.github/workflows/test_linux_job.yml
@@ -39,7 +39,8 @@ jobs:
         conda activate test
         python3 -m pip install --extra-index-url https://download.pytorch.org/whl/nightly/cu116 --pre torch
         # Can import pytorch, cuda is available
-        python3 -c 'import torch;assert(torch.cuda.is_available())'
+        python3 -c 'import torch;cuda_avail = torch.cuda.is_available();print("CUDA available: " + str(cuda_avail));assert(cuda_avail)'
+        python3 -c 'import torch;t = torch.ones([2,2], device="cuda:0");print("tensor device:" + str(t.device))'
   test-docker-image:
     uses: ./.github/workflows/linux_job.yml
     with:

--- a/.github/workflows/test_linux_job.yml
+++ b/.github/workflows/test_linux_job.yml
@@ -40,7 +40,8 @@ jobs:
         python3 -m pip install --extra-index-url https://download.pytorch.org/whl/nightly/cu116 --pre torch
         # Can import pytorch, cuda is available
         python3 -c 'import torch;cuda_avail = torch.cuda.is_available();print("CUDA available: " + str(cuda_avail));assert(cuda_avail)'
-        python3 -c 'import torch;t = torch.ones([2,2], device="cuda:0");print("tensor device:" + str(t.device))'
+        python3 -c 'import torch;t = torch.ones([2,2], device="cuda:0");print(t);print("tensor device:" + str(t.device))'
+        nvidia-smi
   test-docker-image:
     uses: ./.github/workflows/linux_job.yml
     with:


### PR DESCRIPTION
Adding a few more checks for the GPU generic linux job to ensure that we can:
1. Create a torch tensor on GPU
2. Verify it's device affinity
3. Run `nvidia-smi`