### PR TITLE
Change some log rules

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -161,8 +161,12 @@ name = "Python Test SIG Code"
 pattern = '^.*(Received Signal: SIG.*)'
 
 [[rule]]
-name = "Any SIGKILL"
-pattern = 'SIGKILL'
+name = 'Library not loaded'
+pattern = 'Library not loaded: .*$'
+
+[[rule]]
+name = 'Bad response status code'
+pattern = '^##\[error\]Response status code does not indicate success: .*$'
 
 [[rule]]
 name = 'Python AttributeError'
@@ -174,7 +178,7 @@ pattern = '^RuntimeError: CUDA out of memory.'
 
 [[rule]]
 name = 'Python Test File RuntimeError'
-pattern = '^RuntimeError: test.* failed'
+pattern = '^RuntimeError: .*test.* failed'
 
 [[rule]]
 name = 'Python flaky unittest - failed'


### PR DESCRIPTION
* `Any SIGKILL` keeps matching test names that have sigkill in them or skip test messages
* `RuntimeError: functorch/test_aotdispatch failed!` kept getting matched to `Python RuntimeError` but `Python Test File RuntimeError` is probably more accurate
* `Library not loaded` for an error I keep seeing on mac that looks like 
```
2022-12-06T04:06:15.0506380Z Testing custom script operators
2022-12-06T04:06:15.0506520Z + [[ 1 == 1 ]]
2022-12-06T04:06:15.0506640Z + test_libtorch
2022-12-06T04:06:15.0506860Z ~/runner/_work/pytorch/pytorch/test/custom_operator ~/runner/_work/pytorch/pytorch
2022-12-06T04:06:15.0507060Z + [[ 0 == \1 ]]
2022-12-06T04:06:15.0507190Z + test_custom_script_ops
2022-12-06T04:06:15.0507390Z + echo 'Testing custom script operators'
2022-12-06T04:06:15.0507580Z + pushd test/custom_operator
2022-12-06T04:06:15.0507740Z + rm -rf build
2022-12-06T04:06:15.0533870Z + mkdir build
2022-12-06T04:06:15.0553850Z + pushd build
2022-12-06T04:06:15.0554160Z ~/runner/_work/pytorch/pytorch/test/custom_operator/build ~/runner/_work/pytorch/pytorch/test/custom_operator ~/runner/_work/pytorch/pytorch
2022-12-06T04:06:15.0556830Z ++ python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())'
2022-12-06T04:06:15.1450980Z + SITE_PACKAGES=/Users/ec2-user/runner/_work/_temp/conda_environment_3626163498/lib/python3.9/site-packages
2022-12-06T04:06:15.1451400Z + CMAKE_PREFIX_PATH=/Users/ec2-user/runner/_work/_temp/conda_environment_3626163498/lib/python3.9/site-packages/torch
2022-12-06T04:06:15.1451620Z + cmake ..
2022-12-06T04:06:15.2706690Z dyld[97987]: Library not loaded: @rpath/libzstd.1.dylib
2022-12-06T04:06:15.2707330Z   Referenced from: /Users/ec2-user/runner/_work/_temp/miniconda/pkgs/cmake-3.22.1-hae769c0_0/bin/cmake
2022-12-06T04:06:15.2708920Z   Reason: tried: '/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/croot-myzr18j9/cmake_1641978514075/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/lib/libzstd.1.dylib' (no such file), '/Users/ec2-user/runner/_work/_temp/miniconda/pkgs/cmake-3.22.1-hae769c0_0/bin/../lib/libzstd.1.dylib' (no such file), '/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/croot-myzr18j9/cmake_1641978514075/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/lib/libzstd.1.dylib' (no such file), '/Users/ec2-user/runner/_work/_temp/miniconda/pkgs/cmake-3.22.1-hae769c0_0/bin/../lib/libzstd.1.dylib' (no such file), '/usr/local/lib/libzstd.1.dylib' (no such file), '/usr/lib/libzstd.1.dylib' (no such file)
2022-12-06T04:06:15.2709930Z .jenkins/pytorch/macos-test.sh: line 118: 97987 Abort trap: 6           CMAKE_PREFIX_PATH="$SITE_PACKAGES/torch" cmake ..
2022-12-06T04:06:15.2718490Z ERROR conda.cli.main_run:execute(41): `conda run .jenkins/pytorch/macos-test.sh` failed. (See above for error)
2022-12-06T04:06:15.3005960Z ##[error]Process completed with exit code 134.
```
* `Bad response status code` because I see it a lot