### PR TITLE
More log classifier changes

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -98,7 +98,7 @@ pattern = '^ERROR .*.py::.*::test_.*$'
 
 [[rule]]
 name = 'inductor model failure'
-pattern = '^(\S*) *(fail_accuracy|fail_to_run)$'
+pattern = '^(\S*) *(fail_accuracy|fail_to_run|eager_variation)$'
 
 [[rule]]
 name = 'failed to download github artifacts'

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -78,11 +78,11 @@ pattern = '^FAILED: Build did NOT complete successfully'
 
 [[rule]]
 name = 'Python unittest failure'
-pattern = 'FAIL \[.*\]: (test.*) \((?:__main__\.)?(.*)\)'
+pattern = 'FAIL(?: \[.*\])?: (test.*) \((?:__main__\.)?(.*)\)'
 
 [[rule]]
 name = 'Python unittest unexpected success'
-pattern = 'XPASS \[.*\]: (test.*) \((?:__main__\.)?(.*)\)'
+pattern = 'XPASS(?: \[.*\])?: (test.*) \((?:__main__\.)?(.*)\)'
 
 [[rule]]
 name = 'pytest failure'
@@ -90,7 +90,7 @@ pattern = '^FAILED .*.py::.*::test_.*$'
 
 [[rule]]
 name = 'Python unittest error'
-pattern = 'ERROR \[.*\]: (test.*) \((?:__main__\.)?(.*)\)'
+pattern = 'ERROR(?: \[.*\])?: (test.*) \((?:__main__\.)?(.*)\)'
 
 [[rule]]
 name = 'pytest test error'

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -37,6 +37,10 @@ name = 'GHA cancellation'
 pattern = 'The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.'
 
 [[rule]]
+name = 'GHA job was cancelled'
+pattern = '^##\[error\]The operation was canceled.'
+
+[[rule]]
 name = 'make build failure'
 pattern = '''^Makefile:\d+: recipe for target '.+' failed'''
 

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -193,10 +193,6 @@ name = 'Python flaky unittest - errored'
 pattern = '^\s*(test.*) errored - num_retries_left:'
 
 [[rule]]
-name = 'Scribe upload failure'
-pattern = '^ERROR ENCOUNTERED WHEN UPLOADING TO SCRIBE: .*'
-
-[[rule]]
 name = 'Python RuntimeError'
 pattern = '^RuntimeError: .*'
 

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -169,16 +169,20 @@ name = 'Bad response status code'
 pattern = '^##\[error\]Response status code does not indicate success: .*$'
 
 [[rule]]
-name = 'Python AttributeError'
-pattern = '^AttributeError: .*'
+name = 'Python Test File RuntimeError'
+pattern = '^RuntimeError: .*test.* failed'
 
 [[rule]]
 name = 'CUDA out of memory error'
 pattern = '^RuntimeError: CUDA out of memory.'
 
 [[rule]]
-name = 'Python Test File RuntimeError'
-pattern = '^RuntimeError: .*test.* failed'
+name = 'Python AttributeError'
+pattern = '^AttributeError: .*'
+
+[[rule]]
+name = 'Scribe upload failure'
+pattern = '^ERROR ENCOUNTERED WHEN UPLOADING TO SCRIBE: .*'
 
 [[rule]]
 name = 'Python flaky unittest - failed'

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -181,10 +181,6 @@ name = 'Python AttributeError'
 pattern = '^AttributeError: .*'
 
 [[rule]]
-name = 'Scribe upload failure'
-pattern = '^ERROR ENCOUNTERED WHEN UPLOADING TO SCRIBE: .*'
-
-[[rule]]
 name = 'Python flaky unittest - failed'
 pattern = '^\s*(test.*) failed - num_retries_left:'
 


### PR DESCRIPTION
* scribe rule is not a real failure? or at least it happens on succeeding jobs as well
* xla tests dont include the time 
* eager_variation for a model fails on inductor
* reorder so that the test file error is higher
* rule specifically for job cancellation b/c it currently matches to the last rule, idk if it should be this high tho