### PR TITLE
move the git fetch into the checker program

### DIFF
--- a/.github/workflows/stronghold.yml
+++ b/.github/workflows/stronghold.yml
@@ -21,9 +21,7 @@ jobs:
       script: |
         cd tools/stronghold/
         bin/build-check-api-compatibility
-        # We need to fetch the base otherwise, we can't diff against it.
-        git fetch origin ${{ github.event.pull_request.base.sha }}
-        bin/check-api-compatibility                              \
+        bin/check-api-compatibility                                 \
             --base-commit=${{ github.event.pull_request.base.sha }} \
             --head-commit=${{ github.event.pull_request.head.sha }}
 

--- a/tools/stronghold/src/api/checker.py
+++ b/tools/stronghold/src/api/checker.py
@@ -16,6 +16,12 @@ def run() -> None:
     args = parser.parse_args(sys.argv[1:])
 
     repo = api.git.Repository(pathlib.Path('.'))
+
+    # By default, our GitHub jobs only fetch to a depth of one. This
+    # means that the base commit will not be known to our local
+    # clone. We must fetch it in order to compare head and base.
+    repo.run(['fetch', 'origin', args.base_commit], check=True)
+
     violations = api.compatibility.check_range(
         repo, head=args.head_commit, base=args.base_commit
     )


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/test-infra/pull/1252).
* #1227
* #1226
* #1225
* #1224
* #1223
* #1221
* #1256
* #1255
* #1253
* __->__ #1252

move the git fetch into the checker program

Summary:
When we push this to other repos, we'll want as much of the
implementation embedded in the binary as possible.

Test Plan: Rely on CI.

