### PR TITLE
downgrade severity from warning to info if the compat check is supressed

### DIFF
--- a/.github/workflows/stronghold.yml
+++ b/.github/workflows/stronghold.yml
@@ -21,9 +21,7 @@ jobs:
       script: |
         cd tools/stronghold/
         bin/build-check-api-compatibility
-        # We need to fetch the base otherwise, we can't diff against it.
-        git fetch origin ${{ github.event.pull_request.base.sha }}
-        bin/check-api-compatibility                              \
+        bin/check-api-compatibility                                 \
             --base-commit=${{ github.event.pull_request.base.sha }} \
             --head-commit=${{ github.event.pull_request.head.sha }}
 

--- a/tools/stronghold/src/api/checker.py
+++ b/tools/stronghold/src/api/checker.py
@@ -16,6 +16,12 @@ def run() -> None:
     args = parser.parse_args(sys.argv[1:])
 
     repo = api.git.Repository(pathlib.Path('.'))
+
+    # By default, our GitHub jobs only fetch to a depth of one. This
+    # means that the base commit will not be known to our local
+    # clone. We must fetch it in order to compare head and base.
+    repo.run(['fetch', 'origin', args.base_commit], check=True)
+
     violations = api.compatibility.check_range(
         repo, head=args.head_commit, base=args.base_commit
     )

--- a/tools/stronghold/src/api/checker.py
+++ b/tools/stronghold/src/api/checker.py
@@ -20,7 +20,11 @@ def run() -> None:
     # By default, our GitHub jobs only fetch to a depth of one. This
     # means that the base commit will not be known to our local
     # clone. We must fetch it in order to compare head and base.
+    #
+    # The fetch is a smidge noisy, hide it by default.
+    print('::group::fetch github.event.pull_request.base.sha')
     repo.run(['fetch', 'origin', args.base_commit], check=True)
+    print('::endgroup::')
 
     violations = api.compatibility.check_range(
         repo, head=args.head_commit, base=args.base_commit

--- a/tools/stronghold/src/api/checker.py
+++ b/tools/stronghold/src/api/checker.py
@@ -45,8 +45,9 @@ def run() -> None:
         stdout=subprocess.PIPE,
     )
     suppressed = '#suppress-api-compatibility-check' in pinfo.stdout
+    level = 'info' if suppressed else 'warning'
 
     for file, file_violations in violations.items():
         for violation in file_violations:
-            print(api.github.render_violation(file, violation), file=sys.stderr)
+            print(api.github.render_violation(level, file, violation), file=sys.stderr)
     sys.exit(not suppressed)

--- a/tools/stronghold/src/api/github.py
+++ b/tools/stronghold/src/api/github.py
@@ -5,8 +5,8 @@ import pathlib
 import api.compatibility
 
 
-def render_violation(file: pathlib.Path, violation: api.compatibility.Violation) -> str:
+def render_violation(level: str, file: pathlib.Path, violation: api.compatibility.Violation) -> str:
     return (
-        f'::warning file={file},line={violation.line}::'
+        f'::{level} file={file},line={violation.line}::'
         f'Function {violation.func}: {violation.message}'
     )


### PR DESCRIPTION
downgrade severity from warning to info if the compat check is supressed

Summary:
We wish to still see violations when suppressing, but they should be
at info level, rather than warning.

Test Plan: Verify with a sample PR.
