### PR TITLE
try linux job with non-test-infra repo

### DIFF
--- a/.github/workflows/test_linux_job.yml
+++ b/.github/workflows/test_linux_job.yml
@@ -83,3 +83,17 @@ jobs:
         conda create -y -n test python="${PYTHON_VERSION}"
         conda activate test
         python --version | grep "${PYTHON_VERSION}"
+  test-with-repo:
+    uses: ./.github/workflows/linux_job.yml
+    with:
+      job-name: "Checkout Repo"
+      runner: linux.2xlarge
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      repository: pytorch/torchrec
+      ref: main
+      gpu-arch-type: cpu
+      gpu-arch-version: ""
+      script: |
+        ls
+        echo "Checked out pytorch/torchrec"


### PR DESCRIPTION
Testing whether https://github.com/pytorch/vision/pull/7019#issuecomment-1343649705 is a result of a repo argument being passed in or something else.