### PR TITLE
Allow custom file extensions with generic jobs

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -59,6 +59,10 @@ on:
         description: "Prevents a job from failing when a step fails. Set to true to allow a job to pass when exec script step fails."
         default: false
         type: boolean
+      artefact-type:
+        description: 'Extension of files to look for when uploading artefacts, defaults to "whl"'
+        default: "whl"
+        type: string
 
 jobs:
   job:
@@ -178,8 +182,8 @@ jobs:
         run: |
           # If the default execution path is followed then we should get a wheel in the dist/ folder
           # attempt to just grab whatever is in there and scoop it all up
-          if find "dist/" -name "*.whl" >/dev/null 2>/dev/null; then
-            mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
+          if find "dist/" -name "*.${{ artefact-type }}" >/dev/null 2>/dev/null; then
+            mv -v dist/*.${{ artefact-type }} "${RUNNER_ARTIFACT_DIR}/"
           fi
           # Set to fail upload step if there are no files for upload and expected files for upload
           echo 'if-no-files-found=error' >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -47,6 +47,10 @@ on:
         description: "Prevents a job from failing when a step fails. Set to true to allow a job to pass when exec script step fails."
         default: false
         type: boolean
+      artefact-type:
+        description: 'Extension of files to look for when uploading artefacts, defaults to "whl"'
+        default: "whl"
+        type: string
 
 jobs:
   job:
@@ -121,8 +125,8 @@ jobs:
         run: |
           # If the default execution path is followed then we should get a wheel in the dist/ folder
           # attempt to just grab whatever is in there and scoop it all up
-          if find "dist/" -name "*.whl" >/dev/null 2>/dev/null; then
-            mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
+          if find "dist/" -name "*.${{ artefact-type }}" >/dev/null 2>/dev/null; then
+            mv -v dist/*.${{ artefact-type }} "${RUNNER_ARTIFACT_DIR}/"
           fi
           # Set to fail upload step if there are no files for upload and expected files for upload
           echo 'if-no-files-found=error' >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -47,6 +47,10 @@ on:
         description: "Prevents a job from failing when a step fails. Set to true to allow a job to pass when exec script step fails."
         default: false
         type: boolean
+      artefact-type:
+        description: 'Extension of files to look for when uploading artefacts, defaults to "whl"'
+        default: "whl"
+        type: string
 
 jobs:
   job:
@@ -123,8 +127,8 @@ jobs:
         run: |
           # If the default execution path is followed then we should get a wheel in the dist/ folder
           # attempt to just grab whatever is in there and scoop it all up
-          if find "dist/" -name "*.whl" >/dev/null 2>/dev/null; then
-            mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
+          if find "dist/" -name "*.${{ artefact-type }}" >/dev/null 2>/dev/null; then
+            mv -v dist/*.${{ artefact-type }} "${RUNNER_ARTIFACT_DIR}/"
           fi
           # Set to fail upload step if there are no files for upload and expected files for upload
           echo 'if-no-files-found=error' >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
With this PR I propose to allow artefact types other than '.whl' to be registered using the `upload-artifact` action.

This will be helpful e.g. for [pytorch/multipy](https://github.com/pytorch/multipy/blob/main/.github/workflows/runtime_nightly.yaml#L66) where we deal with tarballs.