### PR TITLE
Fix release and test libtorch windows file names

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -175,8 +175,10 @@ def get_libtorch_install_command(os: str, channel: str, gpu_arch_type: str, libt
         build_name = "libtorch-macos-latest.zip"
         if channel == RELEASE:
             build_name = f"libtorch-macos-{CURRENT_STABLE_VERSION}.zip"
-    elif (os == 'linux' or os == 'windows') and (channel == RELEASE or channel == TEST):
+    elif os == 'linux' and (channel == RELEASE or channel == TEST):
         build_name = f"{prefix}-{devtoolset}-{_libtorch_variant}-{CURRENT_STABLE_VERSION}%2B{desired_cuda}.zip" if devtoolset ==  "cxx11-abi" else f"{prefix}-{_libtorch_variant}-{CURRENT_STABLE_VERSION}%2B{desired_cuda}.zip"
+    elif os == 'windows' and (channel == RELEASE or channel == TEST):
+        build_name = f"{prefix}-shared-with-deps-debug-{CURRENT_STABLE_VERSION}%2B{desired_cuda}.zip" if libtorch_config == 'debug' else f"{prefix}-shared-with-deps-{CURRENT_STABLE_VERSION}%2B{desired_cuda}.zip"
     elif os == "windows" and channel == NIGHTLY:
         build_name = f"{prefix}-shared-with-deps-debug-latest.zip" if libtorch_config == 'debug' else f"{prefix}-shared-with-deps-latest.zip"
 


### PR DESCRIPTION
Fix release and test libtorch windows file names
Out of the whole matrix we only have these ones:

```
Download here (Release version):
https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-1.13.0%2B<CUDA/CPU VERSION>.zip
Download here (Debug version):
https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-debug-1.13.0%2B<CUDA/CPU VERSION>.zip
```