### PR TITLE
Support for Users to provide their own Env Vars to Build Pipelines

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -35,6 +35,10 @@ on:
         description: "Script for Smoke Test for a specific domain"
         default: ""
         type: string
+      env-var-script:
+        description: "Script that sets Domain-Specific Environment Variables"
+        default: ""
+        type: string
       package-name:
         description: "Name of the actual python package that is imported"
         default: ""
@@ -82,6 +86,11 @@ jobs:
           ref: ${{ inputs.ref }}
           setup-miniconda: true
           python-version: ${{ env.PYTHON_VERSION }}
+      - name: Combine Env Var and Build Env Files
+        if: ${{ inputs.env-var-script != '' }}
+        run: |
+          cat "${BUILD_ENV_FILE}" "${{ inputs.env-var-script }}" > tmp_file
+          cat tmp_file > "${BUILD_ENV_FILE}"
       - name: Install torch dependency
         run: |
           source "${BUILD_ENV_FILE}"

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -89,8 +89,7 @@ jobs:
       - name: Combine Env Var and Build Env Files
         if: ${{ inputs.env-var-script != '' }}
         run: |
-          cat "${BUILD_ENV_FILE}" "${{ inputs.env-var-script }}" > tmp_file
-          cat tmp_file > "${BUILD_ENV_FILE}"
+          cat "${{ inputs.env-var-script }}" >> "${BUILD_ENV_FILE}"
       - name: Install torch dependency
         run: |
           source "${BUILD_ENV_FILE}"


### PR DESCRIPTION
Should be useful for xFormers adoption: https://github.com/facebookresearch/xformers/pull/573, and others like torch/data. Can clean up much domain-specific logic in the existing workflows with this as well.

The script provided to the `env-var-script` arg would have to be formatted as follows:
```
export MY_ENV_VAR_1="1"
export MY_ENV_VAR_2="2"
...
```

This PR only adds this for Linux Wheels, though we can add this for everything afterwards. We merge the env var script with the `BUILD_ENV_FILE` script created by `pytorch-pkg-helpers` so we only need to source one file before the critical build steps.