### PR TITLE
tools: Add option to upload to base bucket

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -62,6 +62,7 @@ jobs:
       REPOSITORY: ${{ inputs.repository }}
       REF: ${{ inputs.ref }}
       CU_VERSION: ${{ matrix.desired_cuda }}
+      UPLOAD_TO_BASE_BUCKET: ${{ matrix.upload_to_base_bucket }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
     container:
@@ -172,7 +173,8 @@ jobs:
           source "${BUILD_ENV_FILE}"
           ${CONDA_RUN} pip install awscli
           for pkg in dist/*; do
-            ${CONDA_RUN} aws s3 cp "$pkg" "s3://pytorch/whl/${CHANNEL}/${{ matrix.desired_cuda }}/" --acl public-read
+            # PYTORCH_S3_BUCKET_PATH derived from pkg-helpers
+            ${CONDA_RUN} aws s3 cp "$pkg" "${PYTORCH_S3_BUCKET_PATH}" --acl public-read
           done
 
 concurrency:

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -187,7 +187,8 @@ jobs:
           source "${BUILD_ENV_FILE}"
           ${CONDA_RUN} pip install awscli
           for pkg in dist/*; do
-            ${CONDA_RUN} aws s3 cp "$pkg" "s3://pytorch/whl/${CHANNEL}/${{ matrix.desired_cuda }}/" --acl public-read
+            # PYTORCH_S3_BUCKET_PATH derived from pkg-helpers
+            ${CONDA_RUN} aws s3 cp "$pkg" "${PYTORCH_S3_BUCKET_PATH}" --acl public-read
           done
 
 concurrency:

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -181,7 +181,8 @@ jobs:
           source "${BUILD_ENV_FILE}"
           ${CONDA_RUN} pip install awscli
           for pkg in dist/*; do
-            ${CONDA_RUN} aws s3 cp "$pkg" "s3://pytorch/whl/${CHANNEL}/${{ matrix.desired_cuda }}/" --acl public-read
+            # PYTORCH_S3_BUCKET_PATH derived from pkg-helpers
+            ${CONDA_RUN} aws s3 cp "$pkg" "${PYTORCH_S3_BUCKET_PATH}" --acl public-read
           done
 
 concurrency:

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -73,6 +73,7 @@ jobs:
       PACKAGE_TYPE: wheel
       REPOSITORY: ${{ inputs.repository }}
       REF: ${{ inputs.ref }}
+      UPLOAD_TO_BASE_BUCKET: ${{ matrix.upload_to_base_bucket }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ inputs.runner-type }}
     defaults:

--- a/tools/pkg-helpers/pytorch_pkg_helpers/__main__.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/__main__.py
@@ -25,6 +25,14 @@ def parse_args() -> argparse.Namespace:
         default=os.getenv("PACKAGE_TYPE", os.getenv("BUILD_TYPE", "wheel")),
     )
     parser.add_argument(
+        "--upload-to-base-bucket",
+        help="Determines whether or not to upload to the base bucket",
+        type=str,
+        choices=["yes", "no"],
+        # BUILD_TYPE for legacy scripts
+        default=os.getenv("UPLOAD_TO_BASE_BUCKET", "no"),
+    )
+    parser.add_argument(
         "--channel",
         help="Channel to look in",
         choices=["nightly", "test"],
@@ -105,6 +113,7 @@ def main():
                 python_version=options.python_version,
                 pytorch_version=options.pytorch_version,
                 channel=options.channel,
+                upload_to_base_bucket=options.upload_to_base_bucket == "yes",
             )
         )
 

--- a/tools/pkg-helpers/pytorch_pkg_helpers/__main__.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/__main__.py
@@ -29,7 +29,6 @@ def parse_args() -> argparse.Namespace:
         help="Determines whether or not to upload to the base bucket",
         type=str,
         choices=["yes", "no"],
-        # BUILD_TYPE for legacy scripts
         default=os.getenv("UPLOAD_TO_BASE_BUCKET", "no"),
     )
     parser.add_argument(

--- a/tools/pkg-helpers/pytorch_pkg_helpers/conda.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/conda.py
@@ -51,7 +51,9 @@ def get_conda_cuda_variables(platform: str, gpu_arch_version: str) -> List[str]:
         conda_build_variant = "cuda"
         cmake_use_cuda = "1"
         if float(sanitized_version) >= 11.6:
-            conda_cuda_toolkit_constraint = f"- pytorch-cuda={sanitized_version} # [not osx]"
+            conda_cuda_toolkit_constraint = (
+                f"- pytorch-cuda={sanitized_version} # [not osx]"
+            )
         elif float(sanitized_version) == 11.3:
             conda_cuda_toolkit_constraint = "- cudatoolkit >=11.3,<11.4 # [not osx]"
         elif float(sanitized_version) == 10.2:

--- a/tools/pkg-helpers/pytorch_pkg_helpers/wheel.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/wheel.py
@@ -32,7 +32,7 @@ def get_pytorch_s3_bucket_path(
     channel: str,
     upload_to_base_bucket: bool,
 ) -> List[str]:
-    path = f"s3://pytorch/whl/{channel}/{gpu_arch_version}'"
+    path = f"s3://pytorch/whl/{channel}/{gpu_arch_version}"
     if upload_to_base_bucket:
         path = f"s3://pytorch/whl/{channel}/"
     return [f"export PYTORCH_S3_BUCKET_PATH='{path}'"]

--- a/tools/pkg-helpers/pytorch_pkg_helpers/wheel.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/wheel.py
@@ -27,12 +27,24 @@ def get_pytorch_pip_install_command(
     return [f"export PIP_INSTALL_TORCH='{pip_install} --extra-index-url {extra_index}'"]
 
 
+def get_pytorch_s3_bucket_path(
+    gpu_arch_version: str,
+    channel: str,
+    upload_to_base_bucket: bool,
+) -> List[str]:
+    path = f"s3://pytorch/whl/{channel}/{gpu_arch_version}'"
+    if upload_to_base_bucket:
+        path = f"s3://pytorch/whl/{channel}/'"
+    return [f"export PYTORCH_S3_BUCKET_PATH='{path}'"]
+
+
 def get_wheel_variables(
     platform: str,
     gpu_arch_version: str,
     python_version: str,
     pytorch_version: str,
     channel: str,
+    upload_to_base_bucket: bool,
 ) -> List[str]:
     ret = []
     if platform.startswith("linux"):
@@ -42,6 +54,13 @@ def get_wheel_variables(
             gpu_arch_version=gpu_arch_version,
             pytorch_version=pytorch_version,
             channel=channel,
+        )
+    )
+    ret.extend(
+        get_pytorch_s3_bucket_path(
+            gpu_arch_version=gpu_arch_version,
+            channel=channel,
+            upload_to_base_bucket=upload_to_base_bucket,
         )
     )
     return ret

--- a/tools/pkg-helpers/pytorch_pkg_helpers/wheel.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/wheel.py
@@ -34,7 +34,7 @@ def get_pytorch_s3_bucket_path(
 ) -> List[str]:
     path = f"s3://pytorch/whl/{channel}/{gpu_arch_version}'"
     if upload_to_base_bucket:
-        path = f"s3://pytorch/whl/{channel}/'"
+        path = f"s3://pytorch/whl/{channel}/"
     return [f"export PYTORCH_S3_BUCKET_PATH='{path}'"]
 
 

--- a/tools/pkg-helpers/tests/test_macos.py
+++ b/tools/pkg-helpers/tests/test_macos.py
@@ -6,18 +6,24 @@ from pytorch_pkg_helpers.macos import get_macos_variables
 @pytest.mark.parametrize(
     "arch_name,expected",
     [
-        (("arm64"), [
-            "export MACOSX_DEPLOYMENT_TARGET=10.9",
-            "export CC=clang",
-            "export CXX=clang++",
-        ]),
-        (("x86_64"), [
-            "export MACOSX_DEPLOYMENT_TARGET=10.9",
-            "export CC=clang",
-            "export CXX=clang++",
-            "export CONDA_EXTRA_BUILD_CONSTRAINT='- mkl<=2021.2.0'",
-        ])
-    ]
+        (
+            ("arm64"),
+            [
+                "export MACOSX_DEPLOYMENT_TARGET=10.9",
+                "export CC=clang",
+                "export CXX=clang++",
+            ],
+        ),
+        (
+            ("x86_64"),
+            [
+                "export MACOSX_DEPLOYMENT_TARGET=10.9",
+                "export CC=clang",
+                "export CXX=clang++",
+                "export CONDA_EXTRA_BUILD_CONSTRAINT='- mkl<=2021.2.0'",
+            ],
+        ),
+    ],
 )
 def test_get_macos_variables(arch_name, expected):
     assert get_macos_variables(arch_name) == expected

--- a/tools/pkg-helpers/tests/test_wheel.py
+++ b/tools/pkg-helpers/tests/test_wheel.py
@@ -2,6 +2,7 @@ import pytest
 
 from pytorch_pkg_helpers.wheel import (
     get_pytorch_pip_install_command,
+    get_pytorch_s3_bucket_path,
     get_wheel_variables,
 )
 
@@ -23,6 +24,30 @@ def test_get_wheel_variables_linux_includes_path(python_version, expected_path):
                 python_version=python_version,
                 pytorch_version="",
                 channel="nightly",
+                upload_to_base_bucket=False,
+            )
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "upload_to_base_bucket",
+    [True, False],
+)
+def test_s3_bucket_path(upload_to_base_bucket):
+    def pass_test(variable: str) -> bool:
+        if upload_to_base_bucket:
+            return "cpu" not in variable
+        else:
+            return "cpu" in variable
+
+    assert any(
+        [
+            pass_test(variable)
+            for variable in get_pytorch_s3_bucket_path(
+                gpu_arch_version="cpu",
+                channel="nightly",
+                upload_to_base_bucket=upload_to_base_bucket,
             )
         ]
     )

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -345,11 +345,13 @@ def generate_wheels_matrix(
         if with_py311 == ENABLE and channel != "release":
             python_versions += ["3.11"]
 
+    upload_to_base_bucket = "yes"
     if arches is None:
         # Define default compute archivectures
         arches = ["cpu"]
 
         if with_cuda == ENABLE:
+            upload_to_base_bucket = "no"
             if os == "linux":
                 arches += mod.CUDA_ARCHES + mod.ROCM_ARCHES
             elif os == "windows":
@@ -379,6 +381,7 @@ def generate_wheels_matrix(
                     "validation_runner": validation_runner(gpu_arch_type, os),
                     "installation": get_wheel_install_command(os, channel, gpu_arch_type, gpu_arch_version, desired_cuda, python_version),
                     "channel": channel,
+                    "upload_to_base_bucket": upload_to_base_bucket,
                     "stable_version": CURRENT_STABLE_VERSION
                 }
             )


### PR DESCRIPTION
For repositories that don't offer CUDA support we need a way to have representative binaries in the base bucket (which was the previous behavior from CircleCI). This PR makes it so that the s3 bucket path is derived from pkg_helpers and keys off of a matrix variable that we generate from generate_binary_build_matrix

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>