### PR TITLE
Do not fail shutdown if no sshd is running

### DIFF
--- a/.github/actions/teardown-windows/action.yml
+++ b/.github/actions/teardown-windows/action.yml
@@ -38,9 +38,11 @@ runs:
       if: always()
       run: |
         function Get-SSH-Sessions {
-            Get-Process sshd -IncludeUserName |
-                Where-Object UserName -notLike "*SYSTEM*" |
-                Select-Object Id
+            try {
+                Get-Process sshd -IncludeUserName -ErrorAction 'Stop' |
+                    Where-Object UserName -notLike "*SYSTEM*" |
+                    Select-Object Id
+            } catch { @() }
         }
 
         $runningSessions = Get-SSH-Sessions


### PR DESCRIPTION
Useful if teardown-windows is used on stock GHA runners
