### PR TITLE
RetryBot enhancements: Better retry logic & Extend retry mechanism to PRs

### DIFF
--- a/torchci/lib/bot/retryBot.ts
+++ b/torchci/lib/bot/retryBot.ts
@@ -74,7 +74,7 @@ function retryBot(app: Probot): void {
 
       // rerun if the linter didn't fail on the actual linting steps
       if (workflowName === "lint" &&
-        doesLookLikeInfraFailure(job, step => !step.name.toLowerCase().startsWith("[nonretryable]"))){
+        doesLookLikeInfraFailure(job, step => !step.name.toLowerCase().startsWith("(nonretryable)"))){
           return true
       }
 

--- a/torchci/lib/bot/retryBot.ts
+++ b/torchci/lib/bot/retryBot.ts
@@ -74,7 +74,7 @@ function retryBot(app: Probot): void {
 
       // rerun if the linter didn't fail on the actual linting steps
       if (workflowName === "lint" &&
-        doesLookLikeInfraFailure(job, step => !step.name.toLowerCase().startsWith("run lint - "))){
+        doesLookLikeInfraFailure(job, step => !step.name.toLowerCase().startsWith("[nonretryable]"))){
           return true
       }
 

--- a/torchci/lib/bot/retryBot.ts
+++ b/torchci/lib/bot/retryBot.ts
@@ -54,7 +54,7 @@ function retryBot(app: Probot): void {
       return;
     }
 
-    // @ts-expect-error
+    // @ts-expect-error - we don't have types for these
     let jobsDoesntFailStepsLike = (job, predicate: (step: any) => boolean) => {
       return job.steps?.filter(
         // @ts-expect-error


### PR DESCRIPTION
This PR introduces two changes:
1. It pairs with https://github.com/pytorch/pytorch/pull/90705 to avoid retrying linter steps which do the actual linting or building, limiting retrys to infra level steps which are actually likely to be flaky 
2. Extend retry mechanism to all PRs, not just trunk.

If a retryable step fails before a nonretryable step, the behavior will be determined by the if [the conditions](https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions) defined on that step allow that step to run.  By default, steps get skipped if a previous step is skipped (and its conclusion will be `skipped`, which retry bot treats the same way as successful steps). This is the case for all the nonretryable steps today. However, if a step is set to run on `failure()` or `always()` then it'll have its status populated appropriately and is taken into consideration by retrybot. 