### PR TITLE
Fix rebase help text

### DIFF
--- a/torchci/lib/bot/cliParser.ts
+++ b/torchci/lib/bot/cliParser.ts
@@ -92,7 +92,7 @@ const rebase = commands.add_parser("rebase", {
   help: "Rebase a PR",
   description:
     "Rebase a PR. Rebasing defaults to the stable viable/strict branch of pytorch.\n" +
-    "You, along with any member of the pytorch organization, can rebase your PR.",
+    "You must have write permissions to the repo to rebase a PR.",
   formatter_class: RawTextHelpFormatter,
   add_help: false,
 });


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/90758

Corrects the `@pytorchbot rebase` help text