### PR TITLE
Nova / TorchData / Fix smoke tests

### DIFF
--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -162,6 +162,9 @@ jobs:
               ${CONDA_RUN} conda install -y 'numpy>=1.11'
               ${CONDA_RUN} conda install pillow
           fi
+          if [[ "${{ inputs.package-name }}" = "torchdata" ]]; then
+              ${CONDA_RUN} conda install -y portalocker>=2.0.0
+          fi
           ${CONDA_RUN} conda install "$BINARY_NAME"
 
           if [[ ! -f "${{ inputs.repository }}"/${SMOKE_TEST_SCRIPT} ]]; then


### PR DESCRIPTION
Nova / TorchData / Fix smoke tests

To be able to run smoke tests for TorchData, we need to install the portalocker library. Related PR https://github.com/pytorch/data/pull/921