### PR TITLE
Lower the priority of scribe error in log classifier rule

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -173,10 +173,6 @@ name = 'Python AttributeError'
 pattern = '^AttributeError: .*'
 
 [[rule]]
-name = 'Scribe upload failure'
-pattern = '^ERROR ENCOUNTERED WHEN UPLOADING TO SCRIBE: .*'
-
-[[rule]]
 name = 'CUDA out of memory error'
 pattern = '^RuntimeError: CUDA out of memory.'
 
@@ -191,6 +187,10 @@ pattern = '^\s*(test.*) failed - num_retries_left:'
 [[rule]]
 name = 'Python flaky unittest - errored'
 pattern = '^\s*(test.*) errored - num_retries_left:'
+
+[[rule]]
+name = 'Scribe upload failure'
+pattern = '^ERROR ENCOUNTERED WHEN UPLOADING TO SCRIBE: .*'
 
 [[rule]]
 name = 'Python RuntimeError'


### PR DESCRIPTION
After https://github.com/pytorch/test-infra/pull/1243, scribe error was added into the log classifier ruleset.  However, it has a higher priority than some actual failures such as https://hud.pytorch.org/pytorch/pytorch/commit/dcb73aa291816d0ee2d2e21b6b8a966da97945ad in which the job fails with a flaky SIGSEGV `RuntimeError: test_meta failed! Received signal: SIGSEGV`

This PR lowers the priority of this rule so that valid test failures can be shown on HUD