### PR TITLE
track the line number where a parameter is defined

### DIFF
--- a/tools/stronghold/src/api/__init__.py
+++ b/tools/stronghold/src/api/__init__.py
@@ -36,3 +36,5 @@ class Parameter:
     keyword: bool
     # Whether or not this parameter must be provided.
     required: bool
+    # Which line the parameter is defined on.
+    line: int

--- a/tools/stronghold/src/api/ast.py
+++ b/tools/stronghold/src/api/ast.py
@@ -44,14 +44,24 @@ def _function_def_to_parameters(node: ast.FunctionDef) -> api.Parameters:
     # Collect the position-only parameters.
     params = [
         api.Parameter(
-            name=arg.arg, position=i, keyword=False, required=i < num_required
+            name=arg.arg,
+            position=i,
+            keyword=False,
+            required=i < num_required,
+            line=arg.lineno,
         )
         for i, arg in enumerate(args.posonlyargs)
     ]
     # Collect the parameters that may be provided positionally or by
     # keyword.
     params += [
-        api.Parameter(name=arg.arg, position=i, keyword=True, required=i < num_required)
+        api.Parameter(
+            name=arg.arg,
+            position=i,
+            keyword=True,
+            required=i < num_required,
+            line=arg.lineno,
+        )
         for i, arg in enumerate(args.args, start=len(args.posonlyargs))
     ]
 
@@ -63,6 +73,7 @@ def _function_def_to_parameters(node: ast.FunctionDef) -> api.Parameters:
             position=None,
             keyword=True,
             required=args.kw_defaults[i] is None,
+            line=arg.lineno,
         )
         for i, arg in enumerate(args.kwonlyargs)
     ]

--- a/tools/stronghold/tests/api/test_ast.py
+++ b/tools/stronghold/tests/api/test_ast.py
@@ -28,7 +28,9 @@ def test_extract_positional(tmp_path: pathlib.Path) -> None:
     assert funcs == {
         'func': api.Parameters(
             parameters=[
-                api.Parameter(name='x', position=0, keyword=False, required=True)
+                api.Parameter(
+                    name='x', position=0, keyword=False, required=True, line=1
+                )
             ],
             variadic_args=False,
             variadic_kwargs=False,
@@ -45,7 +47,9 @@ def test_extract_positional_with_default(tmp_path: pathlib.Path) -> None:
     assert funcs == {
         'func': api.Parameters(
             parameters=[
-                api.Parameter(name='x', position=0, keyword=False, required=False)
+                api.Parameter(
+                    name='x', position=0, keyword=False, required=False, line=1
+                )
             ],
             variadic_args=False,
             variadic_kwargs=False,
@@ -62,7 +66,7 @@ def test_extract_flexible(tmp_path: pathlib.Path) -> None:
     assert funcs == {
         'func': api.Parameters(
             parameters=[
-                api.Parameter(name='x', position=0, keyword=True, required=True)
+                api.Parameter(name='x', position=0, keyword=True, required=True, line=1)
             ],
             variadic_args=False,
             variadic_kwargs=False,
@@ -79,7 +83,9 @@ def test_extract_flexible_with_default(tmp_path: pathlib.Path) -> None:
     assert funcs == {
         'func': api.Parameters(
             parameters=[
-                api.Parameter(name='x', position=0, keyword=True, required=False)
+                api.Parameter(
+                    name='x', position=0, keyword=True, required=False, line=1
+                )
             ],
             variadic_args=False,
             variadic_kwargs=False,
@@ -96,7 +102,9 @@ def test_extract_keyword(tmp_path: pathlib.Path) -> None:
     assert funcs == {
         'func': api.Parameters(
             parameters=[
-                api.Parameter(name='x', position=None, keyword=True, required=True)
+                api.Parameter(
+                    name='x', position=None, keyword=True, required=True, line=1
+                )
             ],
             variadic_args=False,
             variadic_kwargs=False,
@@ -113,7 +121,9 @@ def test_extract_keyword_with_default(tmp_path: pathlib.Path) -> None:
     assert funcs == {
         'func': api.Parameters(
             parameters=[
-                api.Parameter(name='x', position=None, keyword=True, required=False)
+                api.Parameter(
+                    name='x', position=None, keyword=True, required=False, line=1
+                )
             ],
             variadic_args=False,
             variadic_kwargs=False,
@@ -160,6 +170,7 @@ def test_extract_class_method(tmp_path: pathlib.Path) -> None:
                     position=0,
                     keyword=False,
                     required=True,
+                    line=2,
                 ),
             ],
             variadic_args=False,
@@ -185,24 +196,28 @@ def test_extract_comprehensive(tmp_path: pathlib.Path) -> None:
                     position=0,
                     keyword=False,
                     required=True,
+                    line=3,
                 ),
                 api.Parameter(
                     name='a',
                     position=1,
                     keyword=False,
                     required=True,
+                    line=3,
                 ),
                 api.Parameter(
                     name='b',
                     position=2,
                     keyword=True,
                     required=False,
+                    line=3,
                 ),
                 api.Parameter(
                     name='c',
                     position=None,
                     keyword=True,
                     required=True,
+                    line=3,
                 ),
             ],
             variadic_args=True,


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/test-infra/pull/1298).
* #1291
* #1221
* #1304
* #1303
* #1302
* #1301
* #1299
* __->__ #1298

track the line number where a parameter is defined

Summary:
This will allow us to propagate the line number to violations.

Test Plan:
Rely on CI.

