### PR TITLE
no longer track position for each parameter

### DIFF
--- a/tools/stronghold/src/api/__init__.py
+++ b/tools/stronghold/src/api/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 import dataclasses
-from typing import Optional
 
 
 @dataclasses.dataclass
@@ -29,9 +28,8 @@ class Parameter:
     # The name of the parameter, only usable if it may be provided as
     # a keyword argument.
     name: str
-    # The position of the parameter, not present if this is a keyword
-    # only parameter.
-    position: Optional[int]
+    # Whether or not this parameter may be provided positionally.
+    positional: bool
     # Whether or not this parameter may be provided by name.
     keyword: bool
     # Whether or not this parameter must be provided.

--- a/tools/stronghold/src/api/ast.py
+++ b/tools/stronghold/src/api/ast.py
@@ -45,7 +45,7 @@ def _function_def_to_parameters(node: ast.FunctionDef) -> api.Parameters:
     params = [
         api.Parameter(
             name=arg.arg,
-            position=i,
+            positional=True,
             keyword=False,
             required=i < num_required,
             line=arg.lineno,
@@ -57,7 +57,7 @@ def _function_def_to_parameters(node: ast.FunctionDef) -> api.Parameters:
     params += [
         api.Parameter(
             name=arg.arg,
-            position=i,
+            positional=True,
             keyword=True,
             required=i < num_required,
             line=arg.lineno,
@@ -70,7 +70,7 @@ def _function_def_to_parameters(node: ast.FunctionDef) -> api.Parameters:
     params += [
         api.Parameter(
             name=arg.arg,
-            position=None,
+            positional=False,
             keyword=True,
             required=args.kw_defaults[i] is None,
             line=arg.lineno,

--- a/tools/stronghold/src/api/compatibility.py
+++ b/tools/stronghold/src/api/compatibility.py
@@ -132,7 +132,7 @@ def _check_by_name(
 def _keyword_only_parameters(params: api.Parameters) -> Mapping[str, api.Parameter]:
     """Extracts the parameters that can be passed by name."""
     return (
-        {param.name: param for param in params.parameters if param.position is None}
+        {param.name: param for param in params.parameters if not param.positional}
         if len(params.parameters) > 0
         else {}
     )
@@ -143,8 +143,8 @@ def _check_by_position(
 ) -> Iterable[Violation]:
     """Checks for violations among the positional parameters."""
 
-    before_params = [param for param in before.parameters if param.position is not None]
-    after_params = [param for param in after.parameters if param.position is not None]
+    before_params = [param for param in before.parameters if param.positional]
+    after_params = [param for param in after.parameters if param.positional]
 
     before_param_names = [param.name for param in before_params]
     after_param_names = [param.name for param in after_params]

--- a/tools/stronghold/src/api/compatibility.py
+++ b/tools/stronghold/src/api/compatibility.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
 import dataclasses
-import itertools
+import difflib
 import pathlib
 import tempfile
 
@@ -92,7 +92,6 @@ def check(before: pathlib.Path, after: pathlib.Path) -> Sequence[Violation]:
         # function definition.
 
         violations += _check_by_name(name, before_def, after_def)
-        violations += _check_parameter_ordering(name, before_def, after_def)
         violations += _check_by_position(name, before_def, after_def)
         violations += _check_by_requiredness(name, before_def, after_def)
         violations += _check_variadic_parameters(name, before_def, after_def)
@@ -116,32 +115,34 @@ def _check_by_name(
     func: str, before: api.Parameters, after: api.Parameters
 ) -> Iterable[Violation]:
     """Checks for violations among the named parameters."""
-    for name, before_param in _named_parameters(before).items():
+    for name, before_param in _keyword_only_parameters(before).items():
         assert before_param.name == name
-        after_param = _named_parameters(after).get(name)
+        after_param = _keyword_only_parameters(after).get(name)
         if after_param is None:
             yield Violation(func, f'{name} was removed', line=after.line)
             continue
         assert after_param.name == name
 
-    for name, after_param in _named_parameters(after).items():
+    for name, after_param in _keyword_only_parameters(after).items():
         assert after_param.name == name
-        if after_param.required and name not in _named_parameters(before):
+        if after_param.required and name not in _keyword_only_parameters(before):
             yield Violation(func, f'{name} was added and is required', line=after.line)
 
 
-def _named_parameters(params: api.Parameters) -> Mapping[str, api.Parameter]:
+def _keyword_only_parameters(params: api.Parameters) -> Mapping[str, api.Parameter]:
     """Extracts the parameters that can be passed by name."""
     return (
-        {param.name: param for param in params.parameters if param.keyword}
+        {param.name: param for param in params.parameters if param.position is None}
         if len(params.parameters) > 0
         else {}
     )
 
 
-def _check_parameter_ordering(
+def _check_by_position(
     func: str, before: api.Parameters, after: api.Parameters
 ) -> Iterable[Violation]:
+    """Checks for violations among the positional parameters."""
+
     before_params = [param for param in before.parameters if param.position is not None]
     after_params = [param for param in after.parameters if param.position is not None]
 
@@ -149,7 +150,7 @@ def _check_parameter_ordering(
     after_param_names = [param.name for param in after_params]
 
     if before_param_names == after_param_names:
-        return []
+        return
 
     if set(before_param_names) == set(after_param_names):
         yield Violation(
@@ -157,38 +158,33 @@ def _check_parameter_ordering(
             'positional parameters were reordered',
             line=after.line,
         )
+        return
 
-
-def _check_by_position(
-    func: str, before: api.Parameters, after: api.Parameters
-) -> Iterable[Violation]:
-    """Checks for violations among the positional parameters."""
-    before_params = [param for param in before.parameters if not param.keyword]
-    after_params = [param for param in after.parameters if not param.keyword]
-
-    if before_params == after_params:
-        return []
-
-    for i, (before_param, after_param) in enumerate(
-        itertools.zip_longest(before_params, after_params)
-    ):
-        assert before_param is None or before_param.position == i
-        assert after_param is None or after_param.position == i
-
-        if before_param is None:
-            assert after_param is not None
-            if after_param.required:
-                yield Violation(
-                    func,
-                    f'{after_param.name} was added and is required',
-                    line=after.line,
-                )
-        elif after_param is None:
-            assert before_param is not None
-            yield Violation(func, f'{before_param.name} was removed', line=after.line)
-        else:
-            assert before_param is not None
-            assert after_param is not None
+    matcher = difflib.SequenceMatcher(a=before_param_names, b=after_param_names)
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == 'equal':
+            continue
+        if tag == 'replace':
+            yield Violation(
+                func,
+                f'{before_param_names[i1]} was renamed to {after_param_names[j1]}',
+                line=after.line,
+            )
+            continue
+        if tag == 'insert':
+            after_param = after_params[j1]
+            yield Violation(
+                func,
+                f'{after_param.name} was added and is required',
+                line=after_param.line,
+            )
+            continue
+        if tag == 'delete':
+            yield Violation(
+                func,
+                f'{before_params[i1].name} was removed',
+                line=after.line,
+            )
 
     # TODO support renaming parameters.
     # Positional parameters may be renamed, but may not be

--- a/tools/stronghold/tests/api/test_ast.py
+++ b/tools/stronghold/tests/api/test_ast.py
@@ -29,7 +29,7 @@ def test_extract_positional(tmp_path: pathlib.Path) -> None:
         'func': api.Parameters(
             parameters=[
                 api.Parameter(
-                    name='x', position=0, keyword=False, required=True, line=1
+                    name='x', positional=True, keyword=False, required=True, line=1
                 )
             ],
             variadic_args=False,
@@ -48,7 +48,7 @@ def test_extract_positional_with_default(tmp_path: pathlib.Path) -> None:
         'func': api.Parameters(
             parameters=[
                 api.Parameter(
-                    name='x', position=0, keyword=False, required=False, line=1
+                    name='x', positional=True, keyword=False, required=False, line=1
                 )
             ],
             variadic_args=False,
@@ -66,7 +66,9 @@ def test_extract_flexible(tmp_path: pathlib.Path) -> None:
     assert funcs == {
         'func': api.Parameters(
             parameters=[
-                api.Parameter(name='x', position=0, keyword=True, required=True, line=1)
+                api.Parameter(
+                    name='x', positional=True, keyword=True, required=True, line=1
+                )
             ],
             variadic_args=False,
             variadic_kwargs=False,
@@ -84,7 +86,7 @@ def test_extract_flexible_with_default(tmp_path: pathlib.Path) -> None:
         'func': api.Parameters(
             parameters=[
                 api.Parameter(
-                    name='x', position=0, keyword=True, required=False, line=1
+                    name='x', positional=True, keyword=True, required=False, line=1
                 )
             ],
             variadic_args=False,
@@ -103,7 +105,7 @@ def test_extract_keyword(tmp_path: pathlib.Path) -> None:
         'func': api.Parameters(
             parameters=[
                 api.Parameter(
-                    name='x', position=None, keyword=True, required=True, line=1
+                    name='x', positional=False, keyword=True, required=True, line=1
                 )
             ],
             variadic_args=False,
@@ -122,7 +124,7 @@ def test_extract_keyword_with_default(tmp_path: pathlib.Path) -> None:
         'func': api.Parameters(
             parameters=[
                 api.Parameter(
-                    name='x', position=None, keyword=True, required=False, line=1
+                    name='x', positional=False, keyword=True, required=False, line=1
                 )
             ],
             variadic_args=False,
@@ -167,7 +169,7 @@ def test_extract_class_method(tmp_path: pathlib.Path) -> None:
             parameters=[
                 api.Parameter(
                     name='self',
-                    position=0,
+                    positional=True,
                     keyword=False,
                     required=True,
                     line=2,
@@ -193,28 +195,28 @@ def test_extract_comprehensive(tmp_path: pathlib.Path) -> None:
             parameters=[
                 api.Parameter(
                     name='self',
-                    position=0,
+                    positional=True,
                     keyword=False,
                     required=True,
                     line=3,
                 ),
                 api.Parameter(
                     name='a',
-                    position=1,
+                    positional=True,
                     keyword=False,
                     required=True,
                     line=3,
                 ),
                 api.Parameter(
                     name='b',
-                    position=2,
+                    positional=True,
                     keyword=True,
                     required=False,
                     line=3,
                 ),
                 api.Parameter(
                     name='c',
-                    position=None,
+                    positional=False,
                     keyword=True,
                     required=True,
                     line=3,


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/test-infra/pull/1304).
* #1227
* #1226
* #1225
* #1224
* #1223
* #1221
* __->__ #1304
* #1303

no longer track position for each parameter

Summary: This can be tracked by its order in the Parameters object.

Test Plan: Rely on CI.

