### PR TITLE
Add ability to use comma separated values for packages

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -405,9 +405,8 @@ def main(args) -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--package-type",
-        help="Package type to lookup for",
+        help="Package type to lookup for, also supports comma separated values",
         type=str,
-        choices=["wheel", "conda", "libtorch", "all"],
         default=os.getenv("PACKAGE_TYPE", "wheel"),
     )
     parser.add_argument(
@@ -441,9 +440,13 @@ def main(args) -> None:
     options = parser.parse_args(args)
     includes = []
 
-    package_types = PACKAGE_TYPES if options.package_type == "all" else [options.package_type]
-    channels = CUDA_ACRHES_DICT.keys() if options.channel == "all" else [options.channel]
+    pckages = options.package_type.split(",")
+    if len(pckages) > 1:
+        package_types = [pkg for pkg in pckages]
+    else
+        package_types = PACKAGE_TYPES if options.package_type == "all" else [options.package_type]
 
+    channels = CUDA_ACRHES_DICT.keys() if options.channel == "all" else [options.channel]
 
     for channel in channels:
         for package in package_types:

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -440,10 +440,8 @@ def main(args) -> None:
     options = parser.parse_args(args)
     includes = []
 
-    pckages = options.package_type.split(",")
-    if len(pckages) > 1:
-        package_types = [pkg for pkg in pckages]
-    else:
+    package_types = options.package_type.split(",")
+    if len(package_types) == 1:
         package_types = PACKAGE_TYPES if options.package_type == "all" else [options.package_type]
 
     channels = CUDA_ACRHES_DICT.keys() if options.channel == "all" else [options.channel]

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -443,7 +443,7 @@ def main(args) -> None:
     pckages = options.package_type.split(",")
     if len(pckages) > 1:
         package_types = [pkg for pkg in pckages]
-    else
+    else:
         package_types = PACKAGE_TYPES if options.package_type == "all" else [options.package_type]
 
     channels = CUDA_ACRHES_DICT.keys() if options.channel == "all" else [options.channel]


### PR DESCRIPTION
Add ability to use comma separated values for packages to generate matrix.

Test
```
python generate_binary_build_matrix.py --package-type conda,wheel
{"include": [{"python_version": "3.7", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_7-cpu", "validation_runner": "linux.2xlarge", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/conda-builder:cuda11.6", "package_type": "conda", "build_name": "conda-py3_7-cuda11_6", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.6 -c pytorch-nightly -c nvidia"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/conda-builder:cuda11.7", "package_type": "conda", "build_name": "conda-py3_7-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch-nightly -c nvidia"}, {"python_version": "3.8", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_8-cpu", "validation_runner": "linux.2xlarge", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/conda-builder:cuda11.6", "package_type": "conda", "build_name": "conda-py3_8-cuda11_6", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.6 -c pytorch-nightly -c nvidia"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/conda-builder:cuda11.7", "package_type": "conda", "build_name": "conda-py3_8-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch-nightly -c nvidia"}, {"python_version": "3.9", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_9-cpu", "validation_runner": "linux.2xlarge", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/conda-builder:cuda11.6", "package_type": "conda", "build_name": "conda-py3_9-cuda11_6", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.6 -c pytorch-nightly -c nvidia"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/conda-builder:cuda11.7", "package_type": "conda", "build_name": "conda-py3_9-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch-nightly -c nvidia"}, {"python_version": "3.10", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_10-cpu", "validation_runner": "linux.2xlarge", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/conda-builder:cuda11.6", "package_type": "conda", "build_name": "conda-py3_10-cuda11_6", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.6 -c pytorch-nightly -c nvidia"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/conda-builder:cuda11.7", "package_type": "conda", "build_name": "conda-py3_10-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch-nightly -c nvidia"}, {"python_version": "3.7", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_7-cpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_7-cuda11_6", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu116", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.7", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_7-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.7", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_7-rocm5_2", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.7", "gpu_arch_type": "rocm", "gpu_arch_version": "5.3", "desired_cuda": "rocm5.3", "container_image": "pytorch/manylinux-builder:rocm5.3", "package_type": "manywheel", "build_name": "manywheel-py3_7-rocm5_3", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.3", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.8", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_8-cpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_8-cuda11_6", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu116", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_8-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.8", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_8-rocm5_2", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.8", "gpu_arch_type": "rocm", "gpu_arch_version": "5.3", "desired_cuda": "rocm5.3", "container_image": "pytorch/manylinux-builder:rocm5.3", "package_type": "manywheel", "build_name": "manywheel-py3_8-rocm5_3", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.3", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.9", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_9-cpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda11_6", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu116", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm5_2", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "5.3", "desired_cuda": "rocm5.3", "container_image": "pytorch/manylinux-builder:rocm5.3", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm5_3", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.3", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.10", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_10-cpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.6", "desired_cuda": "cu116", "container_image": "pytorch/manylinux-builder:cuda11.6", "package_type": "manywheel", "build_name": "manywheel-py3_10-cuda11_6", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu116", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_10-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.10", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_10-rocm5_2", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.10", "gpu_arch_type": "rocm", "gpu_arch_version": "5.3", "desired_cuda": "rocm5.3", "container_image": "pytorch/manylinux-builder:rocm5.3", "package_type": "manywheel", "build_name": "manywheel-py3_10-rocm5_3", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.3", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}]}
```