### PR TITLE
Require approval before attempting merges

### DIFF
--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -163,6 +163,8 @@ The explanation needs to be clear on why this is needed. Here are some good exam
       "OWNER",
     ]
 
+    // Find the latest review offered by each authroized reviewer
+    // But first sort them in case Github ever returns the list unsorted
     var latest_reviews: { [user: string]: string } = reviews
       .sort((a: PullRequestReview, b: PullRequestReview) => {
         Date.parse(a.submitted_at + "") < Date.parse(b.submitted_at + "")
@@ -192,13 +194,15 @@ The explanation needs to be clear on why this is needed. Here are some good exam
 
         return latest_reviews;
       }, {})
-      
-      let approval_status = ""
-      for (let [_, review_state] of Object.entries(latest_reviews)) {
-        if (approval_status.toLocaleLowerCase() !=  'changes_requested') {
-          approval_status = review_state
-        }
-      }
+    
+    // Aggregate the reviews to figure out the overall status.
+    // One approval is all that's needed, unless someone blocks it with a `changes_requested`
+    let approval_status = ""
+    for (let [_, review_state] of Object.entries(latest_reviews)) {
+      // if (approval_status.toLocaleLowerCase() !=  'changes_requested') {
+        approval_status = review_state
+      // }
+    }
 
     var result =  approval_status.toLocaleLowerCase() === 'approved'
     console.debug(`Result was ${result}`)

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -199,9 +199,9 @@ The explanation needs to be clear on why this is needed. Here are some good exam
     // One approval is all that's needed, unless someone blocks it with a `changes_requested`
     let approval_status = ""
     for (let [_, review_state] of Object.entries(latest_reviews)) {
-      // if (approval_status.toLocaleLowerCase() !=  'changes_requested') {
+      if (approval_status.toLocaleLowerCase() !=  'changes_requested') {
         approval_status = review_state
-      // }
+      }
     }
 
     var result =  approval_status.toLocaleLowerCase() === 'approved'

--- a/torchci/test/fixtures/pull_request_reviews.json
+++ b/torchci/test/fixtures/pull_request_reviews.json
@@ -1,0 +1,119 @@
+[
+    {
+      "id": 1214331908,
+      "node_id": "PRR_kwDOA-j9z85IYTwE",
+      "user": {
+        "login": "huydhn",
+        "id": 475357,
+        "node_id": "MDQ6VXNlcjQ3NTM1Nw==",
+        "avatar_url": "https://avatars.githubusercontent.com/u/475357?u=e0c635eeaf2cc81fc9af423e0f3d1cc1ac969689&v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/huydhn",
+        "html_url": "https://github.com/huydhn",
+        "followers_url": "https://api.github.com/users/huydhn/followers",
+        "following_url": "https://api.github.com/users/huydhn/following{/other_user}",
+        "gists_url": "https://api.github.com/users/huydhn/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/huydhn/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/huydhn/subscriptions",
+        "organizations_url": "https://api.github.com/users/huydhn/orgs",
+        "repos_url": "https://api.github.com/users/huydhn/repos",
+        "events_url": "https://api.github.com/users/huydhn/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/huydhn/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "body": "LGTM! I think we should put a comment on why `Run lint` prefix is needed",
+      "state": "APPROVED",
+      "html_url": "https://github.com/pytorch/pytorch/pull/90705#pullrequestreview-1214331908",
+      "pull_request_url": "https://api.github.com/repos/pytorch/pytorch/pulls/90705",
+      "author_association": "CONTRIBUTOR",
+      "_links": {
+        "html": {
+          "href": "https://github.com/pytorch/pytorch/pull/90705#pullrequestreview-1214331908"
+        },
+        "pull_request": {
+          "href": "https://api.github.com/repos/pytorch/pytorch/pulls/90705"
+        }
+      },
+      "submitted_at": "2022-12-12T20:58:33Z",
+      "commit_id": "ba9069b8b487a41608e3033e97968b8d14a0dca0"
+    },
+    {
+      "id": 1214391541,
+      "node_id": "PRR_kwDOA-j9z85IYiT1",
+      "user": {
+        "login": "malfet",
+        "id": 2453524,
+        "node_id": "MDQ6VXNlcjI0NTM1MjQ=",
+        "avatar_url": "https://avatars.githubusercontent.com/u/2453524?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/malfet",
+        "html_url": "https://github.com/malfet",
+        "followers_url": "https://api.github.com/users/malfet/followers",
+        "following_url": "https://api.github.com/users/malfet/following{/other_user}",
+        "gists_url": "https://api.github.com/users/malfet/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/malfet/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/malfet/subscriptions",
+        "organizations_url": "https://api.github.com/users/malfet/orgs",
+        "repos_url": "https://api.github.com/users/malfet/repos",
+        "events_url": "https://api.github.com/users/malfet/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/malfet/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "body": "This feels wrong to me: workflow name should be computed as combination of workflow name + job name, as its currently done by the hud, see: \r\n<img width=\"353\" alt=\"image\" src=\"https://user-images.githubusercontent.com/2453524/207161653-95fcb055-1699-48d8-8aa3-02ef079fefc3.png\">\r\n",
+      "state": "CHANGES_REQUESTED",
+      "html_url": "https://github.com/pytorch/pytorch/pull/90705#pullrequestreview-1214391541",
+      "pull_request_url": "https://api.github.com/repos/pytorch/pytorch/pulls/90705",
+      "author_association": "CONTRIBUTOR",
+      "_links": {
+        "html": {
+          "href": "https://github.com/pytorch/pytorch/pull/90705#pullrequestreview-1214391541"
+        },
+        "pull_request": {
+          "href": "https://api.github.com/repos/pytorch/pytorch/pulls/90705"
+        }
+      },
+      "submitted_at": "2022-12-12T21:47:42Z",
+      "commit_id": "ba9069b8b487a41608e3033e97968b8d14a0dca0"
+    },
+    {
+      "id": 1215986780,
+      "node_id": "PRR_kwDOA-j9z85Ienxc",
+      "user": {
+        "login": "malfet",
+        "id": 2453524,
+        "node_id": "MDQ6VXNlcjI0NTM1MjQ=",
+        "avatar_url": "https://avatars.githubusercontent.com/u/2453524?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/malfet",
+        "html_url": "https://github.com/malfet",
+        "followers_url": "https://api.github.com/users/malfet/followers",
+        "following_url": "https://api.github.com/users/malfet/following{/other_user}",
+        "gists_url": "https://api.github.com/users/malfet/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/malfet/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/malfet/subscriptions",
+        "organizations_url": "https://api.github.com/users/malfet/orgs",
+        "repos_url": "https://api.github.com/users/malfet/repos",
+        "events_url": "https://api.github.com/users/malfet/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/malfet/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "body": "LGTM, but I wonder if it could be suffix rather than prefix (as machines do not care about length of the string, but humans do, and sentences written in latin alphabet are usually read from left to right)\r\nAnother suggestion: should we use say #nonretryable ? (or explain how we can add other modifiers to the code?)",
+      "state": "APPROVED",
+      "html_url": "https://github.com/pytorch/pytorch/pull/90705#pullrequestreview-1215986780",
+      "pull_request_url": "https://api.github.com/repos/pytorch/pytorch/pulls/90705",
+      "author_association": "CONTRIBUTOR",
+      "_links": {
+        "html": {
+          "href": "https://github.com/pytorch/pytorch/pull/90705#pullrequestreview-1215986780"
+        },
+        "pull_request": {
+          "href": "https://api.github.com/repos/pytorch/pytorch/pulls/90705"
+        }
+      },
+      "submitted_at": "2022-12-13T17:11:55Z",
+      "commit_id": "cad6b2e4f5569aa53e3a41a5fcc7b3b554ebbead"
+    }
+  ]

--- a/torchci/test/fixtures/pull_request_reviews.json
+++ b/torchci/test/fixtures/pull_request_reviews.json
@@ -22,7 +22,7 @@
         "type": "User",
         "site_admin": false
       },
-      "body": "LGTM! I think we should put a comment on why `Run lint` prefix is needed",
+      "body": "LGTM!",
       "state": "APPROVED",
       "html_url": "https://github.com/pytorch/pytorch/pull/90705#pullrequestreview-1214331908",
       "pull_request_url": "https://api.github.com/repos/pytorch/pytorch/pulls/90705",
@@ -61,7 +61,7 @@
         "type": "User",
         "site_admin": false
       },
-      "body": "This feels wrong to me: workflow name should be computed as combination of workflow name + job name, as its currently done by the hud, see: \r\n<img width=\"353\" alt=\"image\" src=\"https://user-images.githubusercontent.com/2453524/207161653-95fcb055-1699-48d8-8aa3-02ef079fefc3.png\">\r\n",
+      "body": "This feels wrong to me",
       "state": "CHANGES_REQUESTED",
       "html_url": "https://github.com/pytorch/pytorch/pull/90705#pullrequestreview-1214391541",
       "pull_request_url": "https://api.github.com/repos/pytorch/pytorch/pulls/90705",
@@ -100,7 +100,7 @@
         "type": "User",
         "site_admin": false
       },
-      "body": "LGTM, but I wonder if it could be suffix rather than prefix (as machines do not care about length of the string, but humans do, and sentences written in latin alphabet are usually read from left to right)\r\nAnother suggestion: should we use say #nonretryable ? (or explain how we can add other modifiers to the code?)",
+      "body": "LGTM",
       "state": "APPROVED",
       "html_url": "https://github.com/pytorch/pytorch/pull/90705#pullrequestreview-1215986780",
       "pull_request_url": "https://api.github.com/repos/pytorch/pytorch/pulls/90705",

--- a/torchci/test/mergeCommands.test.ts
+++ b/torchci/test/mergeCommands.test.ts
@@ -106,7 +106,10 @@ describe("merge-bot", () => {
         );
         return true;
       })
-      .reply(200, {});
+      .reply(200, {})
+      .get(`/repos/${owner}/${repo}/pulls/${pr_number}/reviews`)
+      .reply(200, requireDeepCopy("./fixtures/pull_request_reviews.json"));
+
     await probot.receive(event);
     handleScope(scope);
   });
@@ -137,7 +140,7 @@ describe("merge-bot", () => {
       })
       .reply(200, {})
       .get(`/repos/${owner}/${repo}/collaborators/${event.payload.comment.user.login}/permission`)
-      .reply(200, {'permission': "write" });;
+      .reply(200, {'permission': "write" });
 
     await probot.receive(event);
     handleScope(scope);
@@ -324,7 +327,9 @@ describe("merge-bot", () => {
         );
         return true;
       })
-      .reply(200, {});
+      .reply(200, {})
+      .get(`/repos/${owner}/${repo}/pulls/${pr_number}/reviews`)
+      .reply(200, requireDeepCopy("./fixtures/pull_request_reviews.json"));
     await probot.receive(event);
 
     handleScope(scope);
@@ -693,7 +698,9 @@ describe("merge-bot", () => {
         );
         return true;
       })
-      .reply(200, {});
+      .reply(200, {})
+      .get(`/repos/${owner}/${repo}/pulls/${pr_number}/reviews`)
+      .reply(200, requireDeepCopy("./fixtures/pull_request_reviews.json"));
 
     await probot.receive(event);
 
@@ -759,7 +766,9 @@ describe("merge-bot", () => {
         );
         return true;
       })
-      .reply(200, {});
+      .reply(200, {})
+      .get(`/repos/${owner}/${repo}/pulls/${pr_number}/reviews`)
+      .reply(200, requireDeepCopy("./fixtures/pull_request_reviews.json"));
     await probot.receive(event);
 
     handleScope(scope);
@@ -796,44 +805,9 @@ describe("merge-bot", () => {
         );
         return true;
       })
-      .reply(200, {});
-    await probot.receive(event);
-
-    handleScope(scope);
-  });
-
-  test("merge on green using CLI", async () => {
-    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
-
-    event.payload.comment.body = "@pytorchbot merge -g";
-
-    const owner = event.payload.repository.owner.login;
-    const repo = event.payload.repository.name;
-    const pr_number = event.payload.issue.number;
-    const comment_number = event.payload.comment.id;
-    const scope = nock("https://api.github.com")
-      .post(`/repos/${owner}/${repo}/issues/${pr_number}/labels`, (body) => {
-        expect(JSON.stringify(body)).toContain(
-          `"labels":["ciflow/trunk"]`
-        );
-        return true;
-      })
       .reply(200, {})
-      .post(
-        `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
-        (body) => {
-          expect(JSON.stringify(body)).toContain('{"content":"+1"}');
-          return true;
-        }
-      )
-      .reply(200, {})
-      .post(`/repos/${owner}/${repo}/dispatches`, (body) => {
-        expect(JSON.stringify(body)).toContain(
-          `{"event_type":"try-merge","client_payload":{"pr_num":${pr_number},"comment_id":${comment_number},"on_green":true}}`
-        );
-        return true;
-      })
-      .reply(200, {});
+      .get(`/repos/${owner}/${repo}/pulls/${pr_number}/reviews`)
+      .reply(200, requireDeepCopy("./fixtures/pull_request_reviews.json"));
     await probot.receive(event);
 
     handleScope(scope);
@@ -874,7 +848,9 @@ some other text lol
         );
         return true;
       })
-      .reply(200, {});
+      .reply(200, {})
+      .get(`/repos/${owner}/${repo}/pulls/${pr_number}/reviews`)
+      .reply(200, requireDeepCopy("./fixtures/pull_request_reviews.json"));
     await probot.receive(event);
     handleScope(scope);
   });
@@ -946,7 +922,9 @@ some other text lol
         );
         return true;
       })
-      .reply(200, {});
+      .reply(200, {})
+      .get(`/repos/${owner}/${repo}/pulls/${pr_number}/reviews`)
+      .reply(200, requireDeepCopy("./fixtures/pull_request_reviews.json"));
 
     await probot.receive(event);
     handleScope(scope);
@@ -987,7 +965,9 @@ some other text lol
         );
         return true;
       })
-      .reply(200, {});
+      .reply(200, {})
+      .get(`/repos/${owner}/${repo}/pulls/${pr_number}/reviews`)
+      .reply(200, requireDeepCopy("./fixtures/pull_request_reviews.json"));
 
     await probot.receive(event);
     handleScope(scope);
@@ -1035,7 +1015,9 @@ some other text lol
         );
         return true;
       })
-      .reply(200, {});
+      .reply(200, {})
+      .get(`/repos/${owner}/${repo}/pulls/${pr_number}/reviews`)
+      .reply(200, requireDeepCopy("./fixtures/pull_request_reviews.json"));
 
     await probot.receive(event);
     handleScope(scope);
@@ -1143,6 +1125,147 @@ some other text lol
     await probot.receive(eventCantMerge);
     await probot.receive(eventWithQuotes);
     await probot.receive(eventQuoted);
+
+    handleScope(scope);
+  });
+
+  test("Any rejected PR blocks the merge workflow", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
+    event.payload.comment.body = "@pytorchbot merge";
+    
+    const pull_requests = requireDeepCopy("./fixtures/pull_request_reviews.json");
+    pull_requests[0].state = "CHANGES_REQUESTED"
+
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    const pr_number = event.payload.issue.number;
+    const comment_number = event.payload.comment.id;
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${owner}/${repo}/pulls/${pr_number}/reviews`)
+      .reply(200, pull_requests)
+      .post(
+        `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
+        (body) => {
+          expect(JSON.stringify(body)).toContain('{"content":"confused"}');
+          return true;
+        }
+      )
+      .reply(200, {})
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          "This PR needs to be approved"
+        );
+        return true;
+      })
+      .reply(200);
+    await probot.receive(event);
+
+    handleScope(scope);
+  });
+
+  test("Comment only workflows don't let a PR get merged", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
+    event.payload.comment.body = "@pytorchbot merge";
+    
+    const pull_requests = requireDeepCopy("./fixtures/pull_request_reviews.json");
+    pull_requests[0].state = "COMMENTED"
+    pull_requests[1].state = "COMMENTED"
+    pull_requests[2].state = "COMMENTED"
+
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    const pr_number = event.payload.issue.number;
+    const comment_number = event.payload.comment.id;
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${owner}/${repo}/pulls/${pr_number}/reviews`)
+      .reply(200, pull_requests)
+      .post(
+        `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
+        (body) => {
+          expect(JSON.stringify(body)).toContain('{"content":"confused"}');
+          return true;
+        }
+      )
+      .reply(200, {})
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          "This PR needs to be approved"
+        );
+        return true;
+      })
+      .reply(200);
+    await probot.receive(event);
+
+    handleScope(scope);
+  });
+
+  test("Zero Reviews blocks the merge", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
+    event.payload.comment.body = "@pytorchbot merge";
+    
+    const pull_requests: any[] = []
+
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    const pr_number = event.payload.issue.number;
+    const comment_number = event.payload.comment.id;
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${owner}/${repo}/pulls/${pr_number}/reviews`)
+      .reply(200, pull_requests)
+      .post(
+        `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
+        (body) => {
+          expect(JSON.stringify(body)).toContain('{"content":"confused"}');
+          return true;
+        }
+      )
+      .reply(200, {})
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          "This PR needs to be approved"
+        );
+        return true;
+      })
+      .reply(200);
+    await probot.receive(event);
+
+    handleScope(scope);
+  });
+
+
+
+  test("Approvals from unauthorized users don't count", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
+    event.payload.comment.body = "@pytorchbot merge";
+    
+    const pull_requests = requireDeepCopy("./fixtures/pull_request_reviews.json");
+    pull_requests[0].author_association = "FIRST_TIME_CONTRIBUTOR"
+    pull_requests[1].author_association = "FIRST_TIME_CONTRIBUTOR"
+    pull_requests[2].author_association = "FIRST_TIME_CONTRIBUTOR"
+
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    const pr_number = event.payload.issue.number;
+    const comment_number = event.payload.comment.id;
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${owner}/${repo}/pulls/${pr_number}/reviews`)
+      .reply(200, pull_requests)
+      .post(
+        `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
+        (body) => {
+          expect(JSON.stringify(body)).toContain('{"content":"confused"}');
+          return true;
+        }
+      )
+      .reply(200, {})
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          "This PR needs to be approved"
+        );
+        return true;
+      })
+      .reply(200);
+    await probot.receive(event);
 
     handleScope(scope);
   });

--- a/torchci/test/mergeCommands.test.ts
+++ b/torchci/test/mergeCommands.test.ts
@@ -1232,8 +1232,6 @@ some other text lol
     handleScope(scope);
   });
 
-
-
   test("Approvals from unauthorized users don't count", async () => {
     const event = requireDeepCopy("./fixtures/pull_request_comment.json");
     event.payload.comment.body = "@pytorchbot merge";


### PR DESCRIPTION
Get pytorchbot to check the approval status of a PR before it forwards a merge request to the trymerge workflow.

This allows devs to know sooner if their merge request is invalid (trymerge already checks the same things, but can take an extra few minutes before offering that feedback)