### PR TITLE
ci: Add test for conda in a script for windows

### DIFF
--- a/.github/scripts/test_conda_in_script.sh
+++ b/.github/scripts/test_conda_in_script.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+conda create -y -n test_environment_in_script python=3.8

--- a/.github/workflows/test_windows_job.yml
+++ b/.github/workflows/test_windows_job.yml
@@ -16,6 +16,7 @@ jobs:
       test-infra-ref: ${{ github.ref }}
       job-name: "win-py3.8-cpu"
       script: |
+        bash .github/scripts/test_conda_in_script.sh
         conda create -y -n test python=3.8
         conda activate test
         python -m pip install --extra-index-url https://download.pytorch.org/whl/nightly/cpu --pre torch


### PR DESCRIPTION
Adds a test to verify that we can access conda in a script from the windows job

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>