### PR TITLE
Fix windows conda 22.11.0 regression

### DIFF
--- a/aws/ami/windows/scripts/Installers/Install-Conda-Dependencies.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-Conda-Dependencies.ps1
@@ -17,4 +17,4 @@ Write-Output "Installing conda packages for building and testing PyTorch"
 conda install -y numpy"<1.23" ninja pyyaml setuptools cmake cffi typing_extensions future six requests dataclasses boto3 libuv
 conda install -y -c conda-forge cmake=3.22.3
 # and setup_pytorch_env script
-conda install -y mkl protobuf numba scipy=1.6.2 typing_extensions dataclasses
+conda install -y mkl protobuf numba scipy=1.6.2 typing_extensions dataclasses conda==22.9.0


### PR DESCRIPTION
Validated by logging into new AMI:
```
cat /c/Jenkins/Miniconda3/etc/profile.d/conda.sh                                       
export CONDA_EXE='C:/Jenkins/Miniconda3\Scripts\conda.exe'                                                                            
...
```

With conda 2.11.0
```
cat /c/Jenkins/Miniconda3/etc/profile.d/conda.sh                                       
export CONDA_EXE='/cygdrive/c/b/abs_67xozs_u6y/croot/conda_1670407450197/_h_env/Scripts/conda.exe'    
.....     
```

Test PR: https://github.com/pytorch/pytorch-canary/pull/153