### PR TITLE
[drci] fix cancelled workflows showing up

### DIFF
--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -107,6 +107,7 @@ export interface DisabledNonFlakyTestData {
 }
 
 export interface RecentWorkflowsData {
+  // only included in this is a job and not a workflow, if it is a workflow, the name is in the name field
   workflow_id?: string;
   id: string;
   name: string;

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -107,6 +107,7 @@ export interface DisabledNonFlakyTestData {
 }
 
 export interface RecentWorkflowsData {
+  workflow_id?: string;
   id: string;
   name: string;
   conclusion: string | null;

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -82,7 +82,6 @@ export async function updateDrciComments(octokit: Octokit, prNumber?: string) {
 
       await updateCommentWithWorkflow(octokit, pr_info, comment);
     });
-    console.log("done")
 }
 
 async function forAllPRs(workflowsByPR: Map<number, PRandJobs>, func: CallableFunction) {

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -82,6 +82,7 @@ export async function updateDrciComments(octokit: Octokit, prNumber?: string) {
 
       await updateCommentWithWorkflow(octokit, pr_info, comment);
     });
+    console.log("done")
 }
 
 async function forAllPRs(workflowsByPR: Map<number, PRandJobs>, func: CallableFunction) {
@@ -261,7 +262,7 @@ export function getWorkflowJobsStatuses(
 export function reorganizeWorkflows(
   recentWorkflows: RecentWorkflowsData[]
 ): Map<number, PRandJobs> {
-  const workflowsByPR = new Map();
+  const workflowsByPR: Map<number, PRandJobs> = new Map();
 
   for (const workflow of recentWorkflows) {
     const pr_number = workflow.pr_number!;
@@ -270,14 +271,29 @@ export function reorganizeWorkflows(
         pr_number: pr_number,
         head_sha: workflow.head_sha,
         jobs: new Map(),
+        merge_base: "",
       });
     }
     const name = workflow.name!;
-    const existing_job = workflowsByPR.get(pr_number).jobs.get(name);
+    const existing_job = workflowsByPR.get(pr_number)?.jobs.get(name);
     if (!existing_job || existing_job.id < workflow.id!) {
       // if rerun, choose the job with the larger id as that is more recent
-      workflowsByPR.get(pr_number).jobs.set(name, workflow);
+      workflowsByPR.get(pr_number)!.jobs.set(name, workflow);
     }
+  }
+
+  // clean up the workflows - remove workflows that have jobs
+  for (const [, prInfo] of workflowsByPR) {
+    const workflowIds = Array.from(prInfo.jobs.values()).map(
+      (jobInfo: RecentWorkflowsData) => jobInfo.workflow_id
+    );
+    const newJobs: Map<string, RecentWorkflowsData> = new Map();
+    for (const [jobName, jobInfo] of prInfo.jobs) {
+      if (!workflowIds.includes(jobInfo.id)) {
+        newJobs.set(jobName, jobInfo);
+      }
+    }
+    prInfo.jobs = newJobs;
   }
   return workflowsByPR;
 }

--- a/torchci/rockset/commons/__sql/recent_pr_workflows_query.sql
+++ b/torchci/rockset/commons/__sql/recent_pr_workflows_query.sql
@@ -1,6 +1,7 @@
 WITH recent_shas as (
     SELECT
-        p.head.sha as sha
+        p.head.sha as sha,
+        p.number as number
     FROM
         workflow_job j
         JOIN commons.pull_request p ON j.head_sha = p.head.sha
@@ -15,32 +16,30 @@ WITH recent_shas as (
         and p.base.repo.full_name = 'pytorch/pytorch'
 )
 SELECT
+    w.id as workflow_id,
     j.id,
     j.name,
     j.conclusion,
     j.completed_at,
     j.html_url,
-    p.number AS pr_number,
-    p.head.sha as head_sha,
+    recent_shas.number AS pr_number,
+    recent_shas.sha as head_sha,
     j.torchci_classification.captures as failure_captures,
 FROM
     recent_shas
     join commons.workflow_job j ON j.head_sha = recent_shas.sha
-    left outer join commons.pull_request p on p.head.sha = j.head_sha
+    join commons.workflow_run w on w.id = j.run_id
 UNION
 SELECT
+    null as workflow_name,
     w.id,
-    w.name,
+    w.name as name,
     w.conclusion,
     w.completed_at,
     w.html_url,
-    p.number AS pr_number,
+    recent_shas.number AS pr_number,
     w.head_sha,
     null as failure_line
 FROM
     recent_shas
     join commons.workflow_run w ON w.head_sha = recent_shas.sha
-    left outer join commons.workflow_job j on j.run_id = w.id
-    left outer join commons.pull_request p on p.head.sha = w.head_sha
-WHERE
-    j.name is null

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -15,7 +15,7 @@
     "issue_query": "5d4dfeb992e2f29b",
     "failure_samples_query": "18e7e696b4949f05",
     "num_commits_master": "08d299a1b7386dbb",
-    "recent_pr_workflows_query": "2f29ecdcc1011b6b",
+    "recent_pr_workflows_query": "0deed4379aec49ce",
     "reverted_prs_with_reason": "00a65a0aa7d97431",
     "unclassified": "1b31a2d8f4ab7230",
     "test_insights_overview": "c9be5cbdda1030af",


### PR DESCRIPTION
change sql query to get all workflows (previously got only the ones that didnt have any jobs), then the code that removes reruns removes the workflows that are rerun, then remove workflows if there is a job belonging to the workflow -> no double counting