### PR TITLE
RetryBot enhancements v2: Better retry logic & Extend retry mechanism to PRs

### DIFF
--- a/torchci/lib/bot/retryBot.ts
+++ b/torchci/lib/bot/retryBot.ts
@@ -16,7 +16,6 @@ function retryBot(app: Probot): void {
 
     if (
       ctx.payload.workflow_run.conclusion === "success" ||
-      ctx.payload.workflow_run.head_branch !== "master" ||
       attemptNumber > 1 ||
       allowedWorkflowPrefixes.every(
         allowedWorkflow => !workflowName.toLowerCase().includes(allowedWorkflow)
@@ -54,27 +53,41 @@ function retryBot(app: Probot): void {
       // or a widespread outage that wouldn't be helped by retries
       return;
     }
+
+    // @ts-expect-error - we don't have types for these
+    let doesLookLikeUserFailure = (job, isCodeValiationStep: (step: any) => boolean) => {
+      // Ensure if any of the steps that failed are not infra related steps (e.g. they're lint, build or test steps)
+      return job.steps?.filter(
+        // @ts-expect-error
+        (step) =>
+          step.conclusion !== null &&
+          FAILURE_CONCLUSIONS.includes(step.conclusion) &&
+          isCodeValiationStep(step) 
+      ).length > 0
+    }
+
     const shouldRetry = failedJobs.filter((job) => {
-      // always rerun lint
-      if (workflowName === "lint") {
-        return true;
-      }
       // if the job was cancelled, it was probably an infra error, so rerun
       if (job.conclusion === "cancelled") {
         return true;
       }
-      // if no test steps failed, can rerun
-      if (
-        job.steps?.filter(
-          (step) =>
-            step.conclusion !== null &&
-            step.name.toLowerCase().includes("test") &&
-            FAILURE_CONCLUSIONS.includes(step.conclusion)
-        ).length === 0
-      ) {
-        return true;
+
+      // don't rerun if the linter failed on the actual linting steps, which have the nonretryable suffix
+      if (workflowName.toLocaleLowerCase() === "lint") {
+          return !doesLookLikeUserFailure(job, step => step.name.toLowerCase().includes("(nonretryable)"))
       }
+
+      // for builds, don't rerun if it failed on the actual build step
+      if (job.name.toLocaleLowerCase().startsWith("build") &&
+          doesLookLikeUserFailure(job, step => step.name.toLowerCase().startsWith("build"))){
+          // we continue our retry checks even if this test passes in case this is a build-and-test job
+          return false
+      }
+
+      // if no test steps failed, can rerun
+      return !doesLookLikeUserFailure(job, step => step.name.toLowerCase().includes("test"))
     });
+    
     if (shouldRetry.length === 0) {
       return;
     }


### PR DESCRIPTION
2nd attempt of https://github.com/pytorch/test-infra/pull/1275

This time we limit only cancelled jobs and workflows on the `master` branch. This approach will result in false negatives, where we won't retry some jobs on PRs which should be retried, but it's better than the current situation of never retrying on pulls and we can iterate on it going forward while still catching many kinds of infra flakes