### PR TITLE
Classify groups of similar failures

### DIFF
--- a/torchci/components/JobAnnotationToggle.tsx
+++ b/torchci/components/JobAnnotationToggle.tsx
@@ -15,10 +15,12 @@ export enum JobAnnotation {
 
 export default function JobAnnotationToggle({
   job,
+  similarJobs,
   annotation,
   repo = null,
 }: {
   job: JobData;
+  similarJobs?: JobData[] | null;
   annotation: JobAnnotation;
   repo?: string | null;
 }) {
@@ -35,6 +37,9 @@ export default function JobAnnotationToggle({
       `/api/job_annotation/${repo ?? job.repo}/${job.id}/${newState}`,
       {
         method: "POST",
+        // Also send over the list of similar jobs so that they can be annotated
+        // in one API call
+        body: JSON.stringify((similarJobs ?? []).map((job) => job.id)),
       }
     );
   }

--- a/torchci/components/JobAnnotationToggle.tsx
+++ b/torchci/components/JobAnnotationToggle.tsx
@@ -24,6 +24,9 @@ export default function JobAnnotationToggle({
   annotation: JobAnnotation;
   repo?: string | null;
 }) {
+  const allJobs = (similarJobs ?? []);
+  allJobs.push(job);
+
   const [state, setState] = React.useState<JobAnnotation>(
     (annotation ?? "null") as JobAnnotation
   );
@@ -34,12 +37,12 @@ export default function JobAnnotationToggle({
   ) {
     setState(newState);
     await fetch(
-      `/api/job_annotation/${repo ?? job.repo}/${job.id}/${newState}`,
+      `/api/job_annotation/${repo ?? job.repo}/${newState}`,
       {
         method: "POST",
         // Also send over the list of similar jobs so that they can be annotated
         // in one API call
-        body: JSON.stringify((similarJobs ?? []).map((job) => job.id)),
+        body: JSON.stringify(allJobs.map((job) => job.id)),
       }
     );
   }

--- a/torchci/components/NavBar.tsx
+++ b/torchci/components/NavBar.tsx
@@ -75,7 +75,7 @@ function NavBar() {
               </Link>
             </li>
             <li>
-              <Link prefetch={false} href="/flakyjobs/pytorch/pytorch/master">
+              <Link prefetch={false} href="/failedjobs/pytorch/pytorch/master">
                 Failures Classfier
               </Link>
             </li>

--- a/torchci/components/NavBar.tsx
+++ b/torchci/components/NavBar.tsx
@@ -75,6 +75,11 @@ function NavBar() {
               </Link>
             </li>
             <li>
+              <Link prefetch={false} href="/flakyjobs/pytorch/pytorch/master">
+                Failures Classfier
+              </Link>
+            </li>
+            <li>
               <span style={{ cursor: "pointer" }}>
                 <Link
                   href="https://github.com/pytorch/test-infra/tree/main/torchci"

--- a/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/[annotation].ts
+++ b/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/[annotation].ts
@@ -29,12 +29,11 @@ export default async function handler(
     return res.status(401).end();
   }
   const client = getDynamoClient();
-  const { jobId, repoOwner, repoName, annotation } = req.query;
+  const { repoOwner, repoName, annotation } = req.query;
 
   // The request body contains an optional list of similar failures. If the list
   // exists, the API will annotate all failures in the list with the same annotation
   const jobIds = JSON.parse(req.body) ?? [];
-  jobIds.push(jobId);
 
   const queries = jobIds.map((jobId: any) => {
     const dynamoKey = `${repoOwner}/${repoName}/${jobId}`;

--- a/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/[jobId]/[annotation].ts
+++ b/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/[jobId]/[annotation].ts
@@ -30,24 +30,36 @@ export default async function handler(
   }
   const client = getDynamoClient();
   const { jobId, repoOwner, repoName, annotation } = req.query;
-  const dynamoKey = `${repoOwner}/${repoName}/${jobId}`;
 
-  const item: any = {
-    dynamoKey,
-    repo: `${repoOwner}/${repoName}`,
-    jobID: parseInt(jobId as string),
-  };
+  // The request body contains an optional list of similar failures. If the list
+  // exists, the API will annotate all failures in the list with the same annotation
+  const jobIds = JSON.parse(req.body) ?? [];
+  jobIds.push(jobId);
 
-  // TODO: we encode annotations as a string, but probably we want to just
-  // serialize a JSON object instead to avoid this silly special case.
-  if (annotation !== "null") {
-    item["annotation"] = annotation;
-  }
+  const queries = jobIds.map((jobId: any) => {
+    const dynamoKey = `${repoOwner}/${repoName}/${jobId}`;
 
-  await client.put({
-    TableName: "torchci-job-annotation",
-    Item: item,
+    const item: any = {
+      dynamoKey,
+      repo: `${repoOwner}/${repoName}`,
+      jobID: parseInt(jobId as string),
+    };
+
+    // TODO: we encode annotations as a string, but probably we want to just
+    // serialize a JSON object instead to avoid this silly special case.
+    if (annotation !== "null") {
+      item["annotation"] = annotation;
+    }
+
+    return client.put({
+      TableName: "torchci-job-annotation",
+      Item: item,
+    });
   });
+
+  if (queries.length > 0) {
+    await Promise.all(queries);
+  }
 
   return res.status(200).end();
 }

--- a/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/failures/[queryParams].ts
+++ b/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/failures/[queryParams].ts
@@ -1,0 +1,63 @@
+import { getDynamoClient } from "lib/dynamo";
+import { JobData } from "lib/types";
+import { NextApiRequest, NextApiResponse } from "next";
+import getRocksetClient from "lib/rockset";
+import { RocksetParam } from "lib/rockset";
+import rocksetVersions from "rockset/prodVersions.json";
+
+async function fetchFailureJobs(
+  queryParams: RocksetParam[],
+): Promise<JobData[]> {
+  const rocksetClient = getRocksetClient();
+  const failedJobs = await rocksetClient.queryLambdas.executeQueryLambda(
+    "commons",
+    "flaky_workflows_jobs",
+    rocksetVersions.commons.flaky_workflows_jobs,
+    {
+      parameters: queryParams,
+    }
+  );
+  return failedJobs.results ?? [];
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const client = getDynamoClient();
+  const { queryParams, repoOwner, repoName } = req.query;
+
+  if (queryParams === undefined) {
+    return res.status(200).json({});
+  }
+
+  // When querying all failed jobs here, we have already included all jobs
+  // that have been annotated
+  const failedJobs = await fetchFailureJobs(JSON.parse(queryParams as string));
+  const queries = failedJobs.map((failedJob: JobData) => {
+    return client.get({
+      TableName: "torchci-job-annotation",
+      Key: { dynamoKey: `${repoOwner}/${repoName}/${failedJob.id}` },
+    });
+  });
+
+  if (queries.length > 0) {
+    const results = await Promise.all(queries);
+    const annotations = results
+      .map((annotation) => annotation.Item)
+      .filter((item) => item != null);
+    const annotationsMap: any = {};
+
+    for (const annotation of annotations) {
+      annotationsMap[annotation!.jobID] = annotation;
+    }
+
+    // For this API, return both the list of failed jobs and their annotations
+    return res.status(200).json({
+      failedJobs: failedJobs,
+      annotationsMap: annotationsMap,
+    });
+  } else {
+    return res.status(200).json({});
+  }
+}

--- a/torchci/pages/failedjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/failedjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -29,7 +29,7 @@ function CommitLink({ job }: { job: JobData }) {
   );
 }
 
-function SimilarFlakyJobs({
+function SimilarFailedJobs({
   job,
   similarJobs,
   classification,
@@ -54,7 +54,7 @@ function SimilarFlakyJobs({
         <code>Failing {similarJobs.length} times</code>
       </button>
       {showDetail && _.map(similarJobs, (job) => (
-        <FlakyJob
+        <FailedJob
           job={job}
           similarJobs={[]}
           classification={classification}
@@ -63,7 +63,7 @@ function SimilarFlakyJobs({
   );
 }
 
-function FlakyJob({
+function FailedJob({
   job,
   similarJobs,
   classification,
@@ -93,7 +93,7 @@ function FlakyJob({
         <LogViewer job={job} />
         {
           hasSimilarJobs &&
-          <SimilarFlakyJobs
+          <SimilarFailedJobs
             job={job}
             similarJobs={similarJobs}
             classification={classification}
@@ -104,7 +104,7 @@ function FlakyJob({
   );
 }
 
-function FlakyJobsByFailure({
+function FailedJobsByFailure({
   jobs,
   annotations,
 }: {
@@ -120,7 +120,7 @@ function FlakyJobsByFailure({
   }
 
   return (
-    <FlakyJob
+    <FailedJob
       job={job}
       similarJobs={jobs}
       classification={annotations?.[job.id!]?.["annotation"] ?? "null"}
@@ -128,7 +128,7 @@ function FlakyJobsByFailure({
   );
 }
 
-function FlakyJobs({
+function FailedJobs({
   queryParams,
   repoName,
   repoOwner,
@@ -168,9 +168,6 @@ function FlakyJobs({
     }
   } = {};
 
-  // To clean up some variants in the failure message such as timestamp
-  const cleanupRegex = /\[.+\]|{.+}/g;
-
   _.forEach(_.sortBy(failedJobs, ["jobName"]), (job) => {
     const annotation = annotations[job.id.toString()]
       ? annotations[job.id.toString()].annotation
@@ -186,9 +183,9 @@ function FlakyJobs({
 
     // The failure message might include some variants such as timestamp, so we need
     // to clean that up
-    const failureLine = (job.failureLine ?? "").replace(cleanupRegex, "");
+    const failureCaptures = (job.failureCaptures ?? "");
 
-    const failure = jobName + workflowName + failureLine;
+    const failure = jobName + workflowName + failureCaptures;
     if (!(failure in groupedJobs[annotation])) {
       groupedJobs[annotation][failure] = []
     }
@@ -212,7 +209,7 @@ function FlakyJobs({
           </summary>
           <ul>
             {_.map(groupedJobsByFailure, (jobs, failure) => (
-              <FlakyJobsByFailure
+              <FailedJobsByFailure
                 jobs={jobs}
                 annotations={annotations}
               />
@@ -272,7 +269,7 @@ export default function Page() {
         />
       </Stack>
 
-      <FlakyJobs
+      <FailedJobs
         queryParams={queryParams}
         repoName={repoName as string}
         repoOwner={repoOwner as string}

--- a/torchci/rockset/commons/__sql/flaky_workflows_jobs.sql
+++ b/torchci/rockset/commons/__sql/flaky_workflows_jobs.sql
@@ -16,7 +16,7 @@ with repeats as (
         j.name,
         w.name
     having
-        count(*) > 1
+        count(*) > :count
         and bool_or(
             j.conclusion in ('failure', 'cancelled', 'time_out')
         )

--- a/torchci/rockset/commons/flaky_workflows_jobs.lambda.json
+++ b/torchci/rockset/commons/flaky_workflows_jobs.lambda.json
@@ -7,6 +7,11 @@
       "value": "master"
     },
     {
+      "name": "count",
+      "type": "int",
+      "value": "1"
+    },
+    {
       "name": "repo",
       "type": "string",
       "value": "pytorch/pytorch"

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -8,7 +8,7 @@
     "filter_forced_merge_pr": "7264f7c4160646ec",
     "flaky_tests": "a869115d6650c28c",
     "flaky_tests_across_jobs": "8abcbbb06ce4c46c",
-    "flaky_workflows_jobs": "1a6051f9565e6bf7",
+    "flaky_workflows_jobs": "7cd42666f6eac62b",
     "slow_tests": "ef8d035d23aa8ab6",
     "test_time_per_file": "1c8d6289623181d8",
     "test_time_per_file_periodic_jobs": "39c105542e297c09",


### PR DESCRIPTION
This change groups failures in https://torchci-git-fork-huydhn-group-failure-classifier-fbopensource.vercel.app/flakyjobs/pytorch/pytorch/master not only by their annotations, but also by a combination of job name, workflow name, and the associated failure message.  The goal is to make is easier to classify similar failures in one go.

### Before

There is a long is of annotated and unannotated failures on https://hud.pytorch.org/flakyjobs/pytorch/pytorch/master.  Many of them are duplication.

### After

Similar failures (same job name, workflow name, and failure message) are group into a single entry, https://torchci-git-fork-huydhn-group-failure-classifier-fbopensource.vercel.app/flakyjobs/pytorch/pytorch/master, represented by a randomly selected failure in the list.  In addition, the list of similar jobs can be expanded and classified individually as before.

The annotation API is also updated to accept an optional list of similar jobs, which are all updated with the same annotation.