### PR TITLE
Remove enabling non-flaky tests feature gating

### DIFF
--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -15,12 +15,6 @@ const NUM_HOURS_ACROSS_JOBS = 72;
 const owner: string = "pytorch";
 const repo: string = "pytorch";
 
-// TODO: This is to gate the new feature to close disabled non-flaky tests automatically.
-// I don't want to run it to all applicable issues yet, instead trying to roll out this
-// to a smaller subset first to limit any potential bad UX. There will be another follow
-// up PR to remove this gate once everything is confirmed to be working
-const ROLLOUT_PERCENTAGE = 0.05;
-
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<void>
@@ -57,10 +51,7 @@ async function disableFlakyTestsAndReenableNonFlakyTests() {
   const nonFlakyTests = filterOutNonFlakyTests(disabledNonFlakyTests, allFlakyTests);
 
   nonFlakyTests.forEach(async function (test) {
-    const rollout = Math.random();
-    if (rollout < ROLLOUT_PERCENTAGE) {
-      await handleNonFlakyTest(test, issues, octokit);
-    }
+    await handleNonFlakyTest(test, issues, octokit);
   })
 }
 

--- a/torchci/rockset/commons/disabled_non_flaky_tests.lambda.json
+++ b/torchci/rockset/commons/disabled_non_flaky_tests.lambda.json
@@ -9,9 +9,8 @@
     {
       "name": "min_num_green",
       "type": "int",
-      "value": "50"
+      "value": "150"
     }
   ],
   "description": ""
 }
-

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -3,7 +3,7 @@
     "annotated_flaky_jobs": "1e7bd01a839ae4d1",
     "hud_query": "bf634305df7c3129",
     "commit_jobs_query": "442a6f64bd44f351",
-    "disabled_non_flaky_tests": "ab9c422a41efca23",
+    "disabled_non_flaky_tests": "f909abf9eec15b56",
     "commit_failed_jobs": "7e5b39f3ec22b89f",
     "filter_forced_merge_pr": "7264f7c4160646ec",
     "flaky_tests": "a869115d6650c28c",


### PR DESCRIPTION
This PR removes the 5% rollout threshold currently enforced whenever flaky bot runs given that this has been running without any issues for a few weeks.

@clee2000 Per our discussion, I have also raised the minimum number of green signals to 150 instead of the current 50 to ensure that there is no false positive.