### PR TITLE
only flag param removals if there's no variadic args/kwargs

### DIFF
--- a/tools/stronghold/tests/api/test_compatibility.py
+++ b/tools/stronghold/tests/api/test_compatibility.py
@@ -165,6 +165,48 @@ def test_removed_keyword_parameter(tmp_path: pathlib.Path) -> None:
     ]
 
 
+def test_removed_positional_parameter_with_varargs(tmp_path: pathlib.Path) -> None:
+    def func(x: int, /, *args: int) -> None:
+        pass  # pragma: no cover
+
+    before = source.make_file(tmp_path, func)
+
+    def func(*args: int) -> None:  # type: ignore[no-redef]
+        pass  # pragma: no cover
+
+    after = source.make_file(tmp_path, func)
+
+    assert api.compatibility.check(before, after) == []
+
+
+def test_removed_flexible_parameter_with_varargs_and_kwargs(tmp_path: pathlib.Path) -> None:
+    def func(x: int, *args: int, **kwargs: int) -> None:
+        pass  # pragma: no cover
+
+    before = source.make_file(tmp_path, func)
+
+    def func(*args: int, **kwargs: int) -> None:  # type: ignore[no-redef]
+        pass  # pragma: no cover
+
+    after = source.make_file(tmp_path, func)
+
+    assert api.compatibility.check(before, after) == []
+
+
+def test_removed_keyword_parameter_with_kwargs(tmp_path: pathlib.Path) -> None:
+    def func(*, x: int, **kwargs: int) -> None:
+        pass  # pragma: no cover
+
+    before = source.make_file(tmp_path, func)
+
+    def func(**kwargs: int) -> None:  # type: ignore[no-redef]
+        pass  # pragma: no cover
+
+    after = source.make_file(tmp_path, func)
+
+    assert api.compatibility.check(before, after) == []
+
+
 def test_new_required_positional_parameter(tmp_path: pathlib.Path) -> None:
     def func() -> None:
         pass  # pragma: no cover


### PR DESCRIPTION
only flag param removals if there's no variadic args/kwargs

Summary:
We are able to loosen this check, to support adding forwarding
functions.

Test Plan: Rely on CI.
