### PR TITLE
fix removed parameter check to only suppress when new version has variadic args

### DIFF
--- a/tools/stronghold/src/api/compatibility.py
+++ b/tools/stronghold/src/api/compatibility.py
@@ -184,7 +184,7 @@ def _check_by_position(
         if tag == 'delete':
             param = before_params[i1]
             assert param.positional
-            if not before.variadic_args or (param.keyword and not before.variadic_kwargs):
+            if not after.variadic_args or (param.keyword and not after.variadic_kwargs):
                 yield Violation(
                     func,
                     f'{before_params[i1].name} was removed',

--- a/tools/stronghold/tests/api/test_compatibility.py
+++ b/tools/stronghold/tests/api/test_compatibility.py
@@ -207,6 +207,20 @@ def test_removed_keyword_parameter_with_kwargs(tmp_path: pathlib.Path) -> None:
     assert api.compatibility.check(before, after) == []
 
 
+def test_create_forwarding_function(tmp_path: pathlib.Path) -> None:
+    def func(positional: int, /, flexible: int, *, keyword: int) -> None:
+        pass  # pragma: no cover
+
+    before = source.make_file(tmp_path, func)
+
+    def func(*args: int, **kwargs: int) -> None:  # type: ignore[no-redef]
+        pass  # pragma: no cover
+
+    after = source.make_file(tmp_path, func)
+
+    assert api.compatibility.check(before, after) == []
+
+
 def test_new_required_positional_parameter(tmp_path: pathlib.Path) -> None:
     def func() -> None:
         pass  # pragma: no cover

--- a/tools/stronghold/tests/api/test_compatibility.py
+++ b/tools/stronghold/tests/api/test_compatibility.py
@@ -165,6 +165,48 @@ def test_removed_keyword_parameter(tmp_path: pathlib.Path) -> None:
     ]
 
 
+def test_removed_positional_parameter_with_varargs(tmp_path: pathlib.Path) -> None:
+    def func(x: int, /, *args: int) -> None:
+        pass  # pragma: no cover
+
+    before = source.make_file(tmp_path, func)
+
+    def func(*args: int) -> None:  # type: ignore[no-redef]
+        pass  # pragma: no cover
+
+    after = source.make_file(tmp_path, func)
+
+    assert api.compatibility.check(before, after) == []
+
+
+def test_removed_flexible_parameter_with_varargs_and_kwargs(tmp_path: pathlib.Path) -> None:
+    def func(x: int, *args: int, **kwargs: int) -> None:
+        pass  # pragma: no cover
+
+    before = source.make_file(tmp_path, func)
+
+    def func(*args: int, **kwargs: int) -> None:  # type: ignore[no-redef]
+        pass  # pragma: no cover
+
+    after = source.make_file(tmp_path, func)
+
+    assert api.compatibility.check(before, after) == []
+
+
+def test_removed_keyword_parameter_with_kwargs(tmp_path: pathlib.Path) -> None:
+    def func(*, x: int, **kwargs: int) -> None:
+        pass  # pragma: no cover
+
+    before = source.make_file(tmp_path, func)
+
+    def func(**kwargs: int) -> None:  # type: ignore[no-redef]
+        pass  # pragma: no cover
+
+    after = source.make_file(tmp_path, func)
+
+    assert api.compatibility.check(before, after) == []
+
+
 def test_new_required_positional_parameter(tmp_path: pathlib.Path) -> None:
     def func() -> None:
         pass  # pragma: no cover


### PR DESCRIPTION
fix removed parameter check to only suppress when new version has variadic args

Summary:
The before version having variadic args is meaningless.

Test Plan: Verified broken test is fixed.
