### PR TITLE
ci: Add action to export matrix variables

### DIFF
--- a/.github/actions/export-matrix-variables/action.yml
+++ b/.github/actions/export-matrix-variables/action.yml
@@ -1,0 +1,17 @@
+name: Export Matrix variables (if any)
+
+description: Export matrix variables so that users can reference them directly in their workflows
+
+runs:
+  using: composite
+  steps:
+    - name: Export variables
+      shell: bash
+      if: ${{ toJSON(matrix) != 'null' }}
+      env:
+        MATRIX_TO_EXPORT: ${{ toJSON(matrix) }}
+      run: |
+        echo "${MATRIX_TO_EXPORT}" > "${RUNNER_TEMP}"/matrix_to_export.json
+        python3 \
+          test-infra/.github/scripts/export_matrix_variables.py \
+          "${RUNNER_TEMP}"/matrix_to_export.json >> "${GITHUB_ENV}"

--- a/.github/actions/export-matrix-variables/action.yml
+++ b/.github/actions/export-matrix-variables/action.yml
@@ -1,17 +1,39 @@
 name: Export Matrix variables (if any)
 
 description: Export matrix variables so that users can reference them directly in their workflows
+inputs:
+  binary-matrix:
+    description: Binary matrix
+    required: false
+    default: ""
+    type: string
+  target-os:
+    description: Target OS
+    required: false
+    default: ""
+    type: string
 
 runs:
   using: composite
   steps:
     - name: Export variables
       shell: bash
-      if: ${{ toJSON(matrix) != 'null' }}
+      if: ${{ inputs.binary-matrix != '' }}
       env:
-        MATRIX_TO_EXPORT: ${{ toJSON(matrix) }}
+        MATRIX_TO_EXPORT: ${{ inputs.binary-matrix }}
+        TARGET_OS: ${{ inputs.target-os }}
       run: |
+        set -ex
+        # Fix for windows to make sure python is initialized
         echo "${MATRIX_TO_EXPORT}" > "${RUNNER_TEMP}"/matrix_to_export.json
-        python3 \
-          test-infra/.github/scripts/export_matrix_variables.py \
-          "${RUNNER_TEMP}"/matrix_to_export.json >> "${GITHUB_ENV}"
+        if [[ ${TARGET_OS} == 'windows' ]]; then
+          source /c/Jenkins/Miniconda3/etc/profile.d/conda.sh
+          conda activate base
+          python \
+            test-infra/.github/scripts/export_matrix_variables.py  \
+            --input-file "${RUNNER_TEMP}"/matrix_to_export.json >> ${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}
+        else
+          python3 \
+            test-infra/.github/scripts/export_matrix_variables.py  \
+            --input-file "${RUNNER_TEMP}"/matrix_to_export.json >> ${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}
+        fi

--- a/.github/scripts/export_matrix_variables.py
+++ b/.github/scripts/export_matrix_variables.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+
+from typing import Dict
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create variables for usage within generic Github Actions workflows"
+    )
+    parser.add_argument("input_file", help="Input file to use, must be JSON")
+    return parser.parse_args()
+
+
+def main(input_file: str) -> None:
+    with open(input_file) as fp:
+        variables_to_export: Dict[str, str] = json.loads(fp.read())
+    for key, value in variables_to_export.items():
+        print(
+            f"MATRIX_{key.upper().replace('-', '_')}={value.upper().replace('-', '_')}"
+        )
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args.input_file)

--- a/.github/scripts/export_matrix_variables.py
+++ b/.github/scripts/export_matrix_variables.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 import argparse
 import json
 import sys
@@ -12,27 +11,15 @@ def main(args) -> None:
         help="Input file to use, must be JSON",
         type=str,
     )
-    parser.add_argument(
-        "--operating-system",
-        help="Operating system to generate for",
-        type=str,
-        default="linux",
-    )
     options = parser.parse_args(args)
 
     with open(options.input_file) as fp:
         variables_to_export: Dict[str, str] = json.loads(fp.read())
 
-    if options.operating_system == "linux":
-        for key, value in variables_to_export.items():
-            print(
-                f"MATRIX_{key.upper().replace('-', '_')}={value.replace('-', '_')}"
-            )
-    elif options.operating_system == "windows":
-        import subprocess
-        for key, value in variables_to_export.items():
-            subprocess.call(['setx', f"MATRIX_{key.upper().replace('-', '_')}", f"{value.replace('-', '_')}"], shell=True)
-
+    for key, value in variables_to_export.items():
+        print(
+            f"MATRIX_{key.upper().replace('-', '_')}={value.replace('-', '_')}"
+        )
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/.github/scripts/export_matrix_variables.py
+++ b/.github/scripts/export_matrix_variables.py
@@ -2,27 +2,37 @@
 
 import argparse
 import json
-
+import sys
 from typing import Dict
 
-
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Create variables for usage within generic Github Actions workflows"
+def main(args) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--input-file",
+        help="Input file to use, must be JSON",
+        type=str,
     )
-    parser.add_argument("input_file", help="Input file to use, must be JSON")
-    return parser.parse_args()
+    parser.add_argument(
+        "--operating-system",
+        help="Operating system to generate for",
+        type=str,
+        default="linux",
+    )
+    options = parser.parse_args(args)
 
-
-def main(input_file: str) -> None:
-    with open(input_file) as fp:
+    with open(options.input_file) as fp:
         variables_to_export: Dict[str, str] = json.loads(fp.read())
-    for key, value in variables_to_export.items():
-        print(
-            f"MATRIX_{key.upper().replace('-', '_')}={value.upper().replace('-', '_')}"
-        )
+
+    if options.operating_system == "linux":
+        for key, value in variables_to_export.items():
+            print(
+                f"MATRIX_{key.upper().replace('-', '_')}={value.replace('-', '_')}"
+            )
+    elif options.operating_system == "windows":
+        import subprocess
+        for key, value in variables_to_export.items():
+            subprocess.call(['setx', f"MATRIX_{key.upper().replace('-', '_')}", f"{value.replace('-', '_')}"], shell=True)
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    main(args.input_file)
+    main(sys.argv[1:])

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -59,6 +59,10 @@ on:
         description: "Prevents a job from failing when a step fails. Set to true to allow a job to pass when exec script step fails."
         default: false
         type: boolean
+      uses-binary-build-matrix:
+        description: "If we are calling this workflow with binary build matrix entry, will initialize matrix entries and env vars"
+        default: false
+        type: boolean
 
 jobs:
   job:
@@ -120,6 +124,11 @@ jobs:
         with:
           name: ${{ inputs.download-artifact }}
           path: ${{ runner.temp }}/artifacts/
+
+      - name: Initialize env vars from matrix
+        if: ${{ inputs.uses-binary-build-matrix }}
+        run: |
+          echo "Python version is: ${{ matrix.python_version }}"
 
       - name: Run script in container
         continue-on-error: ${{ inputs.continue-on-error }}

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -59,10 +59,11 @@ on:
         description: "Prevents a job from failing when a step fails. Set to true to allow a job to pass when exec script step fails."
         default: false
         type: boolean
-      uses-binary-build-matrix:
+      binary-matrix:
         description: "If we are calling this workflow with binary build matrix entry, will initialize matrix entries and env vars"
-        default: false
-        type: boolean
+        required: false
+        default: ''
+        type: string
 
 jobs:
   job:
@@ -127,11 +128,15 @@ jobs:
 
       - name: Export matrix variables (if any)
         uses: ./test-infra/.github/actions/export-matrix-variables
+        if: ${{ inputs.binary-matrix != '' }}
+        with:
+          binary-matrix: ${{ inputs.binary-matrix }}
 
       - name: Run script in container
         continue-on-error: ${{ inputs.continue-on-error }}
         working-directory: ${{ inputs.repository }}
         run: |
+          set -ex
           {
             echo "#!/usr/bin/env bash";
             echo "set -eou pipefail";
@@ -145,7 +150,6 @@ jobs:
           container_name=$(docker run \
             -e RUNNER_ARTIFACT_DIR=/artifacts \
             --env-file="${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}" \
-            --env-file="${GITHUB_ENV}" \
             `# It is unknown why the container sees a different value for this.` \
             --env=GITHUB_STEP_SUMMARY \
             --cap-add=SYS_PTRACE \

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -125,10 +125,8 @@ jobs:
           name: ${{ inputs.download-artifact }}
           path: ${{ runner.temp }}/artifacts/
 
-      - name: Initialize env vars from matrix
-        if: ${{ inputs.uses-binary-build-matrix }}
-        run: |
-          echo "Python version is: ${{ matrix.python_version }}"
+      - name: Export matrix variables (if any)
+        uses: ./test-infra/.github/actions/export-matrix-variables
 
       - name: Run script in container
         continue-on-error: ${{ inputs.continue-on-error }}
@@ -147,6 +145,7 @@ jobs:
           container_name=$(docker run \
             -e RUNNER_ARTIFACT_DIR=/artifacts \
             --env-file="${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}" \
+            --env-file="${GITHUB_ENV}" \
             `# It is unknown why the container sees a different value for this.` \
             --env=GITHUB_STEP_SUMMARY \
             --cap-add=SYS_PTRACE \

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -47,6 +47,11 @@ on:
         description: "Prevents a job from failing when a step fails. Set to true to allow a job to pass when exec script step fails."
         default: false
         type: boolean
+      binary-matrix:
+        description: "If we are calling this workflow with binary build matrix entry, will initialize matrix entries and env vars"
+        required: false
+        default: ''
+        type: string
 
 jobs:
   job:
@@ -99,6 +104,9 @@ jobs:
 
       - name: Export matrix variables (if any)
         uses: ./test-infra/.github/actions/export-matrix-variables
+        if: ${{ inputs.binary-matrix != '' }}
+        with:
+          binary-matrix: ${{ inputs.binary-matrix }}
 
       - name: Run script
         shell: bash -l {0}
@@ -112,6 +120,9 @@ jobs:
             echo 'eval "$(conda shell.bash hook)"';
             echo "${SCRIPT}";
           } > "${RUNNER_TEMP}/exec_script"
+          while read line; do
+            eval "export ${line}"
+          done < "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
           bash "${RUNNER_TEMP}/exec_script"
 
       - name: Check if there are potential artifacts and move them to the correct artifact location

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -97,6 +97,9 @@ jobs:
           name: ${{ inputs.download-artifact }}
           path: ${{ runner.temp }}/artifacts/
 
+      - name: Export matrix variables (if any)
+        uses: ./test-infra/.github/actions/export-matrix-variables
+
       - name: Run script
         shell: bash -l {0}
         continue-on-error: ${{ inputs.continue-on-error }}

--- a/.github/workflows/test-export-matrix-variables.yml
+++ b/.github/workflows/test-export-matrix-variables.yml
@@ -1,0 +1,39 @@
+name: Test export-matrix-variables
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/test-export-matrix-variables.yml
+      - .github/actions/export-matrix-variables/*
+
+jobs:
+  test-linux:
+    uses: ./.github/workflows/linux_job.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        job_type:
+          - linux_job
+    with:
+      script: |
+        [[ "${MATRIX_JOB_TYPE}" = "${{ matrix.job_type }}" ]] || exit 1
+  test-windows:
+    uses: ./.github/workflows/windows_job.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        job_type:
+          - windows_job
+    with:
+      script: |
+        [[ "${MATRIX_JOB_TYPE}" = "${{ matrix.job_type }}" ]] || exit 1
+  test-macos:
+    uses: ./.github/workflows/macos_job.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        job_type:
+          - macos_job
+    with:
+      script: |
+        [[ "${MATRIX_JOB_TYPE}" = "${{ matrix.job_type }}" ]] || exit 1

--- a/.github/workflows/test-export-matrix-variables.yml
+++ b/.github/workflows/test-export-matrix-variables.yml
@@ -15,6 +15,7 @@ jobs:
         job_type:
           - linux_job
     with:
+      binary-matrix: ${{ toJSON(matrix) }}
       script: |
         [[ "${MATRIX_JOB_TYPE}" = "${{ matrix.job_type }}" ]] || exit 1
   test-windows:
@@ -25,6 +26,7 @@ jobs:
         job_type:
           - windows_job
     with:
+      binary-matrix: ${{ toJSON(matrix) }}
       script: |
         [[ "${MATRIX_JOB_TYPE}" = "${{ matrix.job_type }}" ]] || exit 1
   test-macos:
@@ -35,5 +37,6 @@ jobs:
         job_type:
           - macos_job
     with:
+      binary-matrix: ${{ toJSON(matrix) }}
       script: |
         [[ "${MATRIX_JOB_TYPE}" = "${{ matrix.job_type }}" ]] || exit 1

--- a/.github/workflows/test_linux_job.yml
+++ b/.github/workflows/test_linux_job.yml
@@ -85,7 +85,7 @@ jobs:
       runner: linux.2xlarge
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
-      uses-binary-build-matrix: true
+      binary-matrix: ${{ toJSON(matrix) }}
       script: |
         set -x
         PYTHON_VERSION="${{ matrix.python_version }}"

--- a/.github/workflows/test_linux_job.yml
+++ b/.github/workflows/test_linux_job.yml
@@ -80,10 +80,12 @@ jobs:
     strategy:
       matrix:
         python_version: ["3.7", "3.8", "3.9", "3.10"]
+
     with:
       runner: linux.2xlarge
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
+      uses-binary-build-matrix: true
       script: |
         set -x
         PYTHON_VERSION="${{ matrix.python_version }}"

--- a/.github/workflows/test_linux_job.yml
+++ b/.github/workflows/test_linux_job.yml
@@ -80,7 +80,6 @@ jobs:
     strategy:
       matrix:
         python_version: ["3.7", "3.8", "3.9", "3.10"]
-
     with:
       runner: linux.2xlarge
       test-infra-repository: ${{ github.repository }}

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -47,6 +47,11 @@ on:
         description: "Prevents a job from failing when a step fails. Set to true to allow a job to pass when exec script step fails."
         default: false
         type: boolean
+      binary-matrix:
+        description: "If we are calling this workflow with binary build matrix entry, will initialize matrix entries and env vars"
+        required: false
+        default: ''
+        type: string
 
 jobs:
   job:
@@ -98,6 +103,10 @@ jobs:
 
       - name: Export matrix variables (if any)
         uses: ./test-infra/.github/actions/export-matrix-variables
+        if: ${{ inputs.binary-matrix != '' }}
+        with:
+          binary-matrix: ${{ inputs.binary-matrix }}
+          target-os: "windows"
 
       - name: Run script
         shell: bash -l {0}
@@ -114,6 +123,9 @@ jobs:
             echo "source /c/Jenkins/Miniconda3/etc/profile.d/conda.sh";
             echo "${SCRIPT}";
           } > "${RUNNER_TEMP}/exec_script"
+          while read line; do
+            eval "export ${line}"
+          done < "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
           bash "${RUNNER_TEMP}/exec_script"
 
       - name: Check if there are potential artifacts and move them to the correct artifact location

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -96,6 +96,9 @@ jobs:
           name: ${{ inputs.download-artifact }}
           path: ${{ runner.temp }}/artifacts/
 
+      - name: Export matrix variables (if any)
+        uses: ./test-infra/.github/actions/export-matrix-variables
+
       - name: Run script
         shell: bash -l {0}
         continue-on-error: ${{ inputs.continue-on-error }}


### PR DESCRIPTION
Its based on @seemethere work here: https://github.com/pytorch/test-infra/pull/1201


Adds the ability for the workflow to export matrix variables as environment variables for our generic workflows. All environment variables will be reference like so:

```
MATRIX_${var_name}
```

With this we can remove all the environment initialization in the validation workflows, here is an example: https://github.com/pytorch/builder/blob/main/.github/workflows/validate-linux-binaries.yml#L54