### PR TITLE
[BE] Sort similar failures by recency

### DIFF
--- a/torchci/pages/failure/[capture].tsx
+++ b/torchci/pages/failure/[capture].tsx
@@ -189,7 +189,15 @@ function FailureInfo({
       </div>
       <h3>Failures ({totalCount} total)</h3>
       <ul>
-        {samples.map((sample) => (
+        {samples
+          // Keep the most recent samples on top
+          .sort(function(sampleA: JobData, sampleB: JobData) {
+            if (sampleA.time == sampleB.time) {
+              return 0 
+            }
+            return dayjs(sampleA.time).isBefore(dayjs(sampleB.time)) ? 1 : -1
+          })
+          .map((sample) => (
           <li key={sample.id}>
             <JobSummary job={sample} highlight={sample.branch ? highlighted.has(sample.branch) : false} />
             <div>


### PR DESCRIPTION
In the "similar failures" view, sort the matches by recency (currently they're randomly ordered)

Example page: https://hud.pytorch.org/failure/test_fs_sharing%2CTestMultiprocessing

Old sorting, which shows months old results at the top:
<img width="819" alt="image" src="https://user-images.githubusercontent.com/4468967/209862716-368a791d-fd65-4491-ad32-fe8926f7ad7e.png">

New sorting, which shows todays failures up top:
<img width="766" alt="image" src="https://user-images.githubusercontent.com/4468967/209862752-24c33b45-f492-478f-9d2c-c5d036478f90.png">
