### PR TITLE
[BE] Streamline rockset query updating experience

### DIFF
--- a/torchci/README.md
+++ b/torchci/README.md
@@ -83,9 +83,9 @@ console.
 
 1. Edit the query on console.rockset.com.
 2. Save the query, creating a new version.
-3. Download the query with `yarn node scripts/downloadQueryLambda.mjs <workspace> <queryname> <version>`. (You can skip `<version>` if you want the latest version)
-4. Update `rockset/prodVersion.json` with the new version of the lambda.
+3. Download the query with `yarn node scripts/downloadQueryLambda.mjs <workspace> <queryname> <version>`. (You can skip `<version>` if you want the latest version).
 
+This will autoupdate sql and lambda files in the `rockset/<workspace>` dir and the version in `rockset/prodVersion.json`.
 
 ### Alerts
 

--- a/torchci/README.md
+++ b/torchci/README.md
@@ -83,7 +83,7 @@ console.
 
 1. Edit the query on console.rockset.com.
 2. Save the query, creating a new version.
-3. Download the query with `yarn node scripts/downloadQueryLambda.mjs <workspace> <queryname> <version>`.
+3. Download the query with `yarn node scripts/downloadQueryLambda.mjs <workspace> <queryname> <version>`. (You can skip `<version>` if you want the latest version)
 4. Update `rockset/prodVersion.json` with the new version of the lambda.
 
 

--- a/torchci/scripts/downloadQueryLambda.mjs
+++ b/torchci/scripts/downloadQueryLambda.mjs
@@ -44,15 +44,19 @@ const metadata = {
   default_parameters: qLambda.sql.default_parameters,
   description: qLambda.description ?? "",
 };
+
+const workspaceDir = `./rockset/${args.workspace}`
+
+await fs.mkdir(`${workspaceDir}/__sql`, { recursive: true });
 await fs.writeFile(
-  `./rockset/${args.workspace}/__sql/${args.query}.sql`,
+  `${workspaceDir}/__sql/${args.query}.sql`,
   sql,
   "utf8"
 );
 
 const metadaJson = JSON.stringify(metadata, null, 2);
 await fs.writeFile(
-  `./rockset/${args.workspace}/${args.query}.lambda.json`,
+  `${workspaceDir}/${args.query}.lambda.json`,
   metadaJson,
   "utf8"
 );

--- a/torchci/scripts/downloadQueryLambda.mjs
+++ b/torchci/scripts/downloadQueryLambda.mjs
@@ -1,9 +1,16 @@
 import rockset from "@rockset/client";
 import { ArgumentParser } from "argparse";
-import { promises as fs } from "fs";
+import { promises as fs, existsSync } from "fs";
 import dotenv from "dotenv";
 import path from "path";
+import { exit } from "process";
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+// Sanity check. Generally not an issue though since we invoke this file via yarn
+if (!existsSync(`./rockset`)) {
+  console.error("Please cd to the test-infra/torchci folder before running downloadQueryLambda")
+  exit(-1)
+}
 
 const parser = new ArgumentParser({
   description: "Download a Rockset query lambda to the repo.",
@@ -45,6 +52,7 @@ const metadata = {
   description: qLambda.description ?? "",
 };
 
+// Update the sql query and parameters in the lambda.json file
 const workspaceDir = `./rockset/${args.workspace}`
 
 await fs.mkdir(`${workspaceDir}/__sql`, { recursive: true });
@@ -58,5 +66,21 @@ const metadaJson = JSON.stringify(metadata, null, 2);
 await fs.writeFile(
   `${workspaceDir}/${args.query}.lambda.json`,
   metadaJson,
+  "utf8"
+);
+
+// Update the version in the prodVersions.json file
+const prodVersionsFilePath = `./rockset/prodVersions.json`
+
+const prodVersions = JSON.parse(await fs.readFile(prodVersionsFilePath, "utf8"))
+if (!prodVersions[qLambda.workspace]) {
+  prodVersions[qLambda.workspace] = {}
+}
+
+prodVersions[qLambda.workspace][qLambda.name] = qLambda.version
+
+await fs.writeFile(
+  prodVersionsFilePath,
+  JSON.stringify(prodVersions, null, 2),
   "utf8"
 );


### PR DESCRIPTION
This PR has three changes:

1. Auto-update the sql version number in prodVersion.json when you download a rockset query (and update docs accordingly)
2. Fix a bug where if you try downloading a rockset query belonging to a new workspace, the download fails because its directory doesn't exist
3. Doc improvement to mention that the version number doesn't have to be specified if you're downloading the latest version (which most folks are!)