### PR TITLE
Check if rockset version is already correct when tagging prod

### DIFF
--- a/torchci/scripts/pushRocksetTags.mjs
+++ b/torchci/scripts/pushRocksetTags.mjs
@@ -7,11 +7,22 @@ async function readJSON(path) {
 }
 
 async function pushProdTag(client, workspace, queryName, version) {
-  console.log(`Tagging that ${workspace}.${queryName}:${version} as 'prod'`);
-  await client.queryLambdas.createQueryLambdaTag(workspace, queryName, {
-    version,
-    tag_name: "prod",
-  });
+  const currentRocksetVersion = await client.queryLambdas.getQueryLambdaTagVersion(
+    workspace,
+    queryName,
+    "prod"
+  );
+  if (currentRocksetVersion.data.version.version == version) {
+    console.log(
+      `${workspace}.${queryName}:${version} already tagged as 'prod'`
+    );
+  } else {
+    console.log(`Tagging that ${workspace}.${queryName}:${version} as 'prod'`);
+    await client.queryLambdas.createQueryLambdaTag(workspace, queryName, {
+      version,
+      tag_name: "prod",
+    });
+  }
 }
 
 const client = rockset.default(process.env.ROCKSET_API_KEY);

--- a/torchci/scripts/pushRocksetTags.mjs
+++ b/torchci/scripts/pushRocksetTags.mjs
@@ -17,11 +17,11 @@ async function pushProdTag(client, workspace, queryName, version) {
       `${workspace}.${queryName}:${version} already tagged as 'prod'`
     );
   } else {
-    console.log(`Tagging that ${workspace}.${queryName}:${version} as 'prod'`);
     await client.queryLambdas.createQueryLambdaTag(workspace, queryName, {
       version,
       tag_name: "prod",
     });
+    console.log(`Tagged that ${workspace}.${queryName}:${version} as 'prod'`);
   }
 }
 


### PR DESCRIPTION
We have too many query lambdas, resulting in rate limits when we try to tag all of them as prod, so check if the prod tag is already there before tagging.  Rate limit for modifying is lower than just reading apparently.

<details><summary>tested by running locally</summary>

```
(forpytorch) csl@csl-mbp ~/zzzzzzzz/test-infra/torchci % yarn node scripts/pushRocksetTags.mjs 
yarn node v1.22.18
commons.annotated_flaky_jobs:1e7bd01a839ae4d1 already tagged as 'prod'
pytorch_dev_infra_kpis.number_of_force_pushes_historical:7f57dbe505878a81 already tagged as 'prod'
pytorch_dev_infra_kpis.strict_lag_historical:d2a09d13caf8b76a already tagged as 'prod'
metrics.workflow_duration_avg:b92d60f09ac39069 already tagged as 'prod'
metrics.log_captures_count:9cbd496ad254c3de already tagged as 'prod'
commons.flaky_tests_across_jobs:8abcbbb06ce4c46c already tagged as 'prod'
commons.slow_tests:ef8d035d23aa8ab6 already tagged as 'prod'
commons.num_commits_master:08d299a1b7386dbb already tagged as 'prod'
metrics.correlation_matrix:4960260cbb0c5b48 already tagged as 'prod'
metrics.job_duration_percentile:96507ed62db7a3a8 already tagged as 'prod'
commons.reverted_prs_with_reason:00a65a0aa7d97431 already tagged as 'prod'
metrics.disabled_test_historical:daa2413a4750aa87 already tagged as 'prod'
commons.disabled_non_flaky_tests:f909abf9eec15b56 already tagged as 'prod'
metrics.job_duration_avg:10a88ea2ebb80647 already tagged as 'prod'
commons.commit_failed_jobs:7e5b39f3ec22b89f already tagged as 'prod'
commons.filter_forced_merge_pr:7264f7c4160646ec already tagged as 'prod'
pytorch_dev_infra_kpis.num_reverts:dd2bac0ff36ea47f already tagged as 'prod'
metrics.strict_lag_sec:f9523e8c8c3a3311 already tagged as 'prod'
metrics.workflow_load:eff394d8e0b76436 already tagged as 'prod'
commons.test_insights_overview:c9be5cbdda1030af already tagged as 'prod'
metrics.last_successful_workflow:5d22927dd0b0956b already tagged as 'prod'
metrics.last_successful_jobs:2e04949378c58607 already tagged as 'prod'
commons.unclassified:1b31a2d8f4ab7230 already tagged as 'prod'
commons.test_time_per_file:1c8d6289623181d8 already tagged as 'prod'
pytorch_dev_infra_kpis.time_to_review:adfbcdfc51ede11a already tagged as 'prod'
metrics.master_jobs_red_avg:e5cc28eb51fc9fe9 already tagged as 'prod'
metrics.last_branch_push:3d995ac2143586dc already tagged as 'prod'
metrics.queued_jobs_by_label:52ab0f4570516f6b already tagged as 'prod'
commons.test_time_per_file_periodic_jobs:7e2e8ba4f17a398a already tagged as 'prod'
metrics.master_commit_red_percent:65bc4585d9e42bb0 already tagged as 'prod'
metrics.reverts:f5bc84a10c4065a3 already tagged as 'prod'
metrics.disabled_test_total:da5f834a6501fc63 already tagged as 'prod'
metrics.tts_avg:2dd4a04e091c58aa already tagged as 'prod'
metrics.number_of_force_pushes:7c12c25f00d85d5d already tagged as 'prod'
commons.flaky_workflows_jobs:7cd42666f6eac62b already tagged as 'prod'
commons.test_insights_latest_runs:aa6c15c6d52860b2 already tagged as 'prod'
metrics.tts_duration_historical:67a356d17b37f6fb already tagged as 'prod'
metrics.tts_duration_historical_percentile:f6824cbe03e1b6d8 already tagged as 'prod'
pytorch_dev_infra_kpis.time_to_merge:be1c2a28cf75fe32 already tagged as 'prod'
metrics.master_jobs_red:aa08fa7af455e1b9 already tagged as 'prod'
metrics.workflow_duration_percentile:a69732c03132613c already tagged as 'prod'
metrics.master_commit_red_avg:a88bee94d93198ed already tagged as 'prod'
metrics.num_tests_run:e936cba33f530f8a already tagged as 'prod'
commons.issue_query:5d4dfeb992e2f29b already tagged as 'prod'
pytorch_dev_infra_kpis.time_to_signal:ff332d025976c103 already tagged as 'prod'
metrics.queued_jobs:7b5ef18c1273bab2 already tagged as 'prod'
metrics.queue_times_historical:7f4d6599362e70ba already tagged as 'prod'
metrics.tts_percentile:cc993e55cc1804f0 already tagged as 'prod'
commons.flaky_tests:a869115d6650c28c already tagged as 'prod'
metrics.master_commit_red:4c39daa3ac2f30e4 already tagged as 'prod'
commons.recent_pr_workflows_query:0deed4379aec49ce already tagged as 'prod'
commons.failure_samples_query:18e7e696b4949f05 already tagged as 'prod'
commons.commit_jobs_query:442a6f64bd44f351 already tagged as 'prod'
commons.hud_query:bf634305df7c3129 already tagged as 'prod'
✨  Done in 1.19s.
(forpytorch) csl@csl-mbp ~/zzzzzzzz/test-infra/torchci % 
```
</details>