### PR TITLE
Show rerun_disabled_tests failures as only warnings

### DIFF
--- a/torchci/components/CommitStatus.tsx
+++ b/torchci/components/CommitStatus.tsx
@@ -4,7 +4,7 @@ import { CommitData, JobData } from "lib/types";
 import WorkflowBox from "./WorkflowBox";
 import styles from "components/commit.module.css";
 import _ from "lodash";
-import { isFailedJob } from "lib/jobUtils";
+import { isFailedJob, isRerunDisabledTestsJob } from "lib/jobUtils";
 import { linkIt, UrlComponent, urlRegex } from "react-linkify-it";
 import { getConclusionSeverityForSorting } from "../lib/JobClassifierUtil";
 import useScrollTo from "lib/useScrollTo";
@@ -72,8 +72,13 @@ export default function CommitStatus({
       <FilteredJobList
         filterName="Failed jobs"
         jobs={jobs}
-        pred={isFailedJob}
+        pred={(job) => isFailedJob(job) && !isRerunDisabledTestsJob(job)}
         showClassification
+      />
+      <FilteredJobList
+        filterName="Daily rerunning disabled jobs"
+        jobs={jobs}
+        pred={(job) => isFailedJob(job) && isRerunDisabledTestsJob(job)}
       />
       <FilteredJobList
         filterName="Pending jobs"

--- a/torchci/components/JobConclusion.module.css
+++ b/torchci/components/JobConclusion.module.css
@@ -47,3 +47,7 @@
 .flaky {
   color: lightgreen;
 }
+
+.warning {
+  color: lightpink;
+}

--- a/torchci/components/JobConclusion.tsx
+++ b/torchci/components/JobConclusion.tsx
@@ -6,12 +6,16 @@ export default function JobConclusion({
   conclusion,
   classified = false,
   failedPreviousRun = false,
+  warningOnly = false,
 }: {
   conclusion?: string;
   classified?: boolean;
   failedPreviousRun?: boolean;
+  warningOnly?: boolean;
 }) {
-  const style = classified
+  const style = warningOnly
+    ? styles["warning"]
+    : classified
     ? styles["classified"]
     : conclusion == JobStatus.Success && failedPreviousRun
     ? styles["flaky"]

--- a/torchci/components/JobSummary.tsx
+++ b/torchci/components/JobSummary.tsx
@@ -1,5 +1,6 @@
 import { JobData } from "lib/types";
 import JobConclusion from "./JobConclusion";
+import { isFailedJob, isRerunDisabledTestsJob } from "lib/jobUtils";
 
 function BranchName({ name, highlight }: { name: string | undefined; highlight:boolean; }) {
   if (name) {
@@ -15,7 +16,10 @@ function BranchName({ name, highlight }: { name: string | undefined; highlight:b
 export default function JobSummary({ job, highlight }: { job: JobData; highlight: boolean; }) {
   return (
     <>
-      <JobConclusion conclusion={job.conclusion} />
+      <JobConclusion
+        conclusion={job.conclusion}
+        warningOnly={isFailedJob(job) && isRerunDisabledTestsJob(job)}
+      />
       <a href={job.htmlUrl}> {job.jobName} </a>
       <BranchName name={job.branch} highlight={highlight} />
     </>

--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -116,6 +116,8 @@ export function getGroupConclusionChar(conclusion?: GroupedJobStatus): string {
       return "X";
     case GroupedJobStatus.Flaky:
       return "F";
+    case GroupedJobStatus.WarningOnly:
+      return "W";
     default:
       return "U";
   }

--- a/torchci/lib/jobUtils.ts
+++ b/torchci/lib/jobUtils.ts
@@ -7,3 +7,9 @@ export function isFailedJob(job: JobData) {
     job.conclusion === "timed_out"
   );
 }
+
+export function isRerunDisabledTestsJob(job: JobData) {
+  // Rerunning disabled tests are expected to fail from time to time depending
+  // on the nature of the disabled tests, so we don't want to count them sometimes
+  return job.name !== undefined && job.name.includes("rerun_disabled_tests");
+}

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -26,7 +26,7 @@ import useGroupingPreference from "lib/useGroupingPreference";
 import React, { createContext, useContext, useEffect, useState } from "react";
 import PageSelector from "components/PageSelector";
 import useSWR from "swr";
-import { isFailedJob } from "lib/jobUtils";
+import { isFailedJob, isRerunDisabledTestsJob } from "lib/jobUtils";
 import { fetcher } from "lib/GeneralUtils";
 
 export function JobCell({
@@ -49,6 +49,7 @@ export function JobCell({
           conclusion={job.conclusion}
           failedPreviousRun={job.failedPreviousRun}
           classified={job.failureAnnotation != null}
+          warningOnly={isFailedJob(job) && isRerunDisabledTestsJob(job)}
         />
       </TooltipTarget>
     </td>
@@ -68,7 +69,6 @@ function HudRow({
   const params = packHudParams(router.query);
   const sha = rowData.sha;
 
-  const failedJobs = rowData.jobs.filter(isFailedJob);
   const { repoOwner, repoName } = router.query;
 
   return (


### PR DESCRIPTION
This provides a cleaner view on HUD for warning-only jobs such as `rerun_disabled_tests` failures where they only serve to provide signals to a specific group of devs, i.e. PyTorch Dev Infra.  In addition, some `rerun_disabled_tests` jobs are expected to fail or hang depending on the nature of the disabled tests.

### Before

Everything is shown as failed jobs on HUD, i.e.
* https://hud.pytorch.org/pytorch/pytorch/commit/5030929c5d124e68e4d73b8933973f754d2d5d43
* https://hud.pytorch.org/hud/pytorch/pytorch/master/1?per_page=50&name_filter=rerun

### After

Failures jobs from `rerun_disabled_tests` are only shown as warnings in their separate section and with a lighter red:
* https://torchci-git-fork-huydhn-better-jobs-view-fbopensource.vercel.app/pytorch/pytorch/commit/5030929c5d124e68e4d73b8933973f754d2d5d43
* https://torchci-git-fork-huydhn-better-jobs-view-fbopensource.vercel.app/hud/pytorch/pytorch/master/1?per_page=50&name_filter=rerun