### PR TITLE
Pin miniconda version, fixes vision and audio binary wheel builds

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -63,9 +63,9 @@ runs:
           echo "ARTIFACT_NAME=${REPOSITORY/\//_}_${REF}_${PYTHON_VERSION}" >> "${GITHUB_ENV}"
       - name: Setup miniconda (for pytorch_pkg_helpers)
         if: ${{ inputs.setup-miniconda == 'true' }}
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v2.1.1
         with:
-          miniconda-version: "latest"
+          miniconda-version: "py39_4.12.0"
           python-version: 3.9
       - name: Clean conda environment
         shell: bash -l {0}


### PR DESCRIPTION
This most nightly wheel builds for vision and audio:
https://github.com/pytorch/vision/actions/runs/3800536129/jobs/6466764135

Please note torchrec builds are broken since 15.12.2022 : https://github.com/pytorch/torchrec/actions/runs/3704102590

Had to fix miniconda version as per: https://github.com/conda-incubator/setup-miniconda/issues/261