### PR TITLE
Only close non-flaky issue if it hasn't been updated in 2 weeks

### DIFF
--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -67,6 +67,7 @@ export interface IssueData {
   html_url: string;
   state: "open" | "closed";
   body: string;
+  updated_at: string;
 }
 
 export interface HudParams {

--- a/torchci/rockset/commons/__sql/issue_query.sql
+++ b/torchci/rockset/commons/__sql/issue_query.sql
@@ -3,7 +3,8 @@ SELECT
     issue.title,
     issue.html_url,
     issue.state,
-    issue.body
+    issue.body,
+    issue.updated_at,
 from
     issues as issue
     cross join UNNEST(issue.labels as label) as labels

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -12,7 +12,7 @@
     "slow_tests": "ef8d035d23aa8ab6",
     "test_time_per_file": "1c8d6289623181d8",
     "test_time_per_file_periodic_jobs": "7e2e8ba4f17a398a",
-    "issue_query": "5d4dfeb992e2f29b",
+    "issue_query": "276aea6b8186d808",
     "failure_samples_query": "18e7e696b4949f05",
     "num_commits_master": "08d299a1b7386dbb",
     "recent_pr_workflows_query": "0deed4379aec49ce",

--- a/torchci/test/disableFlakyBot.test.ts
+++ b/torchci/test/disableFlakyBot.test.ts
@@ -156,6 +156,7 @@ describe("Disable Flaky Test Bot Across Jobs", () => {
         html_url: "https://api.github.com/repos/pytorch/pytorch/issues/1",
         state: "open" as "open" | "closed",
         body: "random",
+        updated_at: "2022-12-21T03:39:24Z",
       },
     ];
 
@@ -176,6 +177,7 @@ describe("Disable Flaky Test Bot Across Jobs", () => {
         html_url: "https://api.github.com/repos/pytorch/pytorch/issues/1",
         state: "open" as "open" | "closed",
         body: "random",
+        updated_at: "2022-12-21T03:39:24Z",
       },
     ];
 
@@ -209,6 +211,7 @@ describe("Disable Flaky Test Bot Across Jobs", () => {
         html_url: "https://api.github.com/repos/pytorch/pytorch/issues/1",
         state: "closed" as "open" | "closed",
         body: "random",
+        updated_at: "2022-12-21T03:39:24Z",
       },
     ];
 
@@ -229,6 +232,7 @@ describe("Disable Flaky Test Bot Across Jobs", () => {
         html_url: "https://api.github.com/repos/pytorch/pytorch/issues/1",
         state: "closed" as "open" | "closed",
         body: "random",
+        updated_at: "2022-12-21T03:39:24Z",
       },
     ];
 
@@ -322,6 +326,7 @@ describe("Disable Flaky Test Bot Integration Tests", () => {
         html_url: "https://api.github.com/repos/pytorch/pytorch/issues/1",
         state: "open" as "open" | "closed",
         body: "random",
+        updated_at: "2022-12-21T03:39:24Z",
       },
     ];
 
@@ -357,6 +362,7 @@ describe("Disable Flaky Test Bot Integration Tests", () => {
         html_url: "https://api.github.com/pytorch/pytorch/issues/1",
         state: "closed" as "open" | "closed",
         body: "random",
+        updated_at: "2022-12-21T03:39:24Z",
       },
     ];
 
@@ -400,6 +406,7 @@ describe("Disable Flaky Test Bot Integration Tests", () => {
         html_url: "https://api.github.com/repos/pytorch/pytorch/issues/1",
         state: "open" as "open" | "closed",
         body: "random",
+        updated_at: dayjs().subtract(disableFlakyTestBot.NUM_HOURS_NOT_UPDATED_BEFORE_CLOSING + 1, "hour").toString(),
       },
     ];
 
@@ -411,6 +418,40 @@ describe("Disable Flaky Test Bot Integration Tests", () => {
       console.error("pending mocks: %j", scope.pendingMocks());
     }
     scope.done();
+  });
+
+  test("do not close non flaky test if it's manual updated recently", async () => {
+    const scope = nock("https://api.github.com")
+      .post("/repos/pytorch/pytorch/issues/1/comments", (body) => {
+        const comment = JSON.stringify(body.body);
+        expect(comment).toContain(
+          "Another case of trunk flakiness has been found"
+        );
+        expect(comment).toContain("Please verify");
+        return true;
+      })
+      .reply(200, {});
+
+    const issues = [
+      {
+        number: 1,
+        title: "DISABLED test_a (__main__.suite_a)",
+        html_url: "https://api.github.com/repos/pytorch/pytorch/issues/1",
+        state: "open" as "open" | "closed",
+        body: "random",
+        updated_at: dayjs().subtract(disableFlakyTestBot.NUM_HOURS_NOT_UPDATED_BEFORE_CLOSING - 1, "hour").toString(),
+      },
+    ];
+
+    await disableFlakyTestBot.handleFlakyTest(flakyTestA, issues, octokit);
+    // Close the disabled issue if the test is not flaky anymore
+    await disableFlakyTestBot.handleNonFlakyTest(nonFlakyTestA, issues, octokit);
+
+    if (!scope.isDone()) {
+      console.error("pending mocks: %j", scope.pendingMocks());
+    }
+    scope.done();
+
   });
 });
 

--- a/torchci/test/disableFlakyBot.test.ts
+++ b/torchci/test/disableFlakyBot.test.ts
@@ -156,7 +156,7 @@ describe("Disable Flaky Test Bot Across Jobs", () => {
         html_url: "https://api.github.com/repos/pytorch/pytorch/issues/1",
         state: "open" as "open" | "closed",
         body: "random",
-        updated_at: "2022-12-21T03:39:24Z",
+        updated_at: dayjs().toString(),
       },
     ];
 
@@ -177,7 +177,7 @@ describe("Disable Flaky Test Bot Across Jobs", () => {
         html_url: "https://api.github.com/repos/pytorch/pytorch/issues/1",
         state: "open" as "open" | "closed",
         body: "random",
-        updated_at: "2022-12-21T03:39:24Z",
+        updated_at: dayjs().toString(),
       },
     ];
 
@@ -211,7 +211,7 @@ describe("Disable Flaky Test Bot Across Jobs", () => {
         html_url: "https://api.github.com/repos/pytorch/pytorch/issues/1",
         state: "closed" as "open" | "closed",
         body: "random",
-        updated_at: "2022-12-21T03:39:24Z",
+        updated_at: dayjs().toString(),
       },
     ];
 
@@ -232,7 +232,7 @@ describe("Disable Flaky Test Bot Across Jobs", () => {
         html_url: "https://api.github.com/repos/pytorch/pytorch/issues/1",
         state: "closed" as "open" | "closed",
         body: "random",
-        updated_at: "2022-12-21T03:39:24Z",
+        updated_at: dayjs().toString(),
       },
     ];
 
@@ -326,7 +326,7 @@ describe("Disable Flaky Test Bot Integration Tests", () => {
         html_url: "https://api.github.com/repos/pytorch/pytorch/issues/1",
         state: "open" as "open" | "closed",
         body: "random",
-        updated_at: "2022-12-21T03:39:24Z",
+        updated_at: dayjs().toString(),
       },
     ];
 
@@ -362,7 +362,7 @@ describe("Disable Flaky Test Bot Integration Tests", () => {
         html_url: "https://api.github.com/pytorch/pytorch/issues/1",
         state: "closed" as "open" | "closed",
         body: "random",
-        updated_at: "2022-12-21T03:39:24Z",
+        updated_at: dayjs().toString(),
       },
     ];
 

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -3,6 +3,7 @@ import * as updateDrciBot from "../pages/api/drci/drci";
 import { OH_URL, DOCS_URL, DRCI_COMMENT_START, formDrciComment, getActiveSEVs, formDrciSevBody } from "lib/drciUtils";
 import { IssueData } from "lib/types";
 import { testOctokit } from "./utils";
+import dayjs from "dayjs";
 
 nock.disableNetConnect();
 
@@ -90,7 +91,7 @@ const sev : IssueData= {
   html_url: "https://github.com/pytorch/pytorch/issues/85362",
   state: "open",
   body: "random stuff",
-  updated_at: "2022-12-21T03:39:24Z",
+  updated_at: dayjs().toString(),
 };
 
 const mergeBlockingSev : IssueData= {
@@ -99,7 +100,7 @@ const mergeBlockingSev : IssueData= {
   html_url: "https://github.com/pytorch/pytorch/issues/74967",
   state: "open",
   body: "merge blocking",
-  updated_at: "2022-12-21T03:39:24Z",
+  updated_at: dayjs().toString(),
 };
 
 const closedSev : IssueData= {
@@ -108,7 +109,7 @@ const closedSev : IssueData= {
   html_url: "https://github.com/pytorch/pytorch/issues/74304",
   state: "closed",
   body: "random stuff",
-  updated_at: "2022-12-21T03:39:24Z",
+  updated_at: dayjs().toString(),
 };
 
 describe("Update Dr. CI Bot Unit Tests", () => {

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -89,7 +89,8 @@ const sev : IssueData= {
   title: "docker pulls failing with no space left on disk",
   html_url: "https://github.com/pytorch/pytorch/issues/85362",
   state: "open",
-  body: "random stuff"
+  body: "random stuff",
+  updated_at: "2022-12-21T03:39:24Z",
 };
 
 const mergeBlockingSev : IssueData= {
@@ -97,7 +98,8 @@ const mergeBlockingSev : IssueData= {
   title: "Linux CUDA builds are failing due to missing deps",
   html_url: "https://github.com/pytorch/pytorch/issues/74967",
   state: "open",
-  body: "merge blocking"
+  body: "merge blocking",
+  updated_at: "2022-12-21T03:39:24Z",
 };
 
 const closedSev : IssueData= {
@@ -105,7 +107,8 @@ const closedSev : IssueData= {
   title: "GitHub Outage: No Github Actions workflows can be run",
   html_url: "https://github.com/pytorch/pytorch/issues/74304",
   state: "closed",
-  body: "random stuff"
+  body: "random stuff",
+  updated_at: "2022-12-21T03:39:24Z",
 };
 
 describe("Update Dr. CI Bot Unit Tests", () => {


### PR DESCRIPTION
This is an annoying UX issue that I miss where PyTorch flaky bot keeps trying to resolve issues that it considers non-flaky according to the signals from Rockset, i.e. https://github.com/pytorch/pytorch/issues/67002.  The better approach is to leave the issue open for X days, seeing that there is no update, before closing them.  If closing a supposedly non-flaky issue leads to false positive and redness on HUD, re-opening them or putting a comment there should be sufficient to tell the flaky bot to leave it alone for the time being. The waiting period is 2 weeks (or 14 days)