### PR TITLE
[Nova] Use windows.4xlarge for non-CUDA Windows conda builds

### DIFF
--- a/.github/workflows/build_conda_windows.yml
+++ b/.github/workflows/build_conda_windows.yml
@@ -79,11 +79,20 @@ jobs:
           repository: ${{ inputs.test-infra-repository }}
           ref: ${{ inputs.test-infra-ref }}
           path: test-infra
+      - uses: ./test-infra/.github/actions/setup-ssh
+        name: Setup SSH
+        with:
+          github-secret: ${{ secrets.GITHUB_TOKEN }}
+          activate-with-label: false
+          instructions: "SSH with rdesktop using ssh -L 3389:localhost:3389 %%username%%@%%hostname%%"
+      - name: Add Conda scripts to GitHub path
+        run: |
+          echo "C:/Jenkins/Miniconda3/Scripts" >> $GITHUB_PATH
       - uses: ./test-infra/.github/actions/setup-binary-builds
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-          setup-miniconda: true
+          setup-miniconda: false
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Run pre-script
         working-directory: ${{ inputs.repository }}
@@ -167,6 +176,9 @@ jobs:
           set ANACONDA_PATH
           echo "$ANACONDA_PATH"
           "$ANACONDA_PATH/anaconda" -t "${CONDA_PYTORCHBOT_TOKEN}" upload dist/win-64/*.tar.bz2 -u "pytorch-${CHANNEL}" --label main --no-progress --force
+      - uses: ./test-infra/.github/actions/teardown-windows
+        if: always()
+        name: Teardown Windows
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/test_build_conda_windows_without_cuda.yml
+++ b/.github/workflows/test_build_conda_windows_without_cuda.yml
@@ -44,7 +44,7 @@ jobs:
     name: ${{ matrix.repository }}
     uses: ./.github/workflows/build_conda_windows.yml
     with:
-      runner-type: windows-2019
+      runner-type: windows.4xlarge
       conda-package-directory: ${{ matrix.conda-package-directory }}
       repository: ${{ matrix.repository }}
       ref: nightly


### PR DESCRIPTION
- Change machine to windows.4xlarge for non-CUDA Windows conda builds
- Add setup-ssh/teardown