### PR TITLE
Adding cuda 11.8 to matrix

### DIFF
--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -158,15 +158,12 @@ jobs:
           echo "$CONDA_OUTPUT_PATH"
           BINARY_NAME=$(ls "$CONDA_OUTPUT_PATH"/*.tar.bz2)
           echo "$BINARY_NAME"
-          if [[ "${GPU_ARCH}" = "cpu" ]]; then
-            ${CONDA_RUN} conda install -v -y -c pytorch-"${CHANNEL}" pytorch
-          elif [[ "${GPU_ARCH}" = "cuda" && ("${DESIRED_CUDA}" = "cu116" || "${DESIRED_CUDA}" = "cu117") ]]; then
+          if [[ "${GPU_ARCH}" = "cuda" ]]; then
             ${CONDA_RUN} conda install -v -y -c pytorch-"${CHANNEL}" -c nvidia pytorch pytorch-cuda="${GPU_ARCH_VERSION}"
-          elif [[ "${GPU_ARCH}" = "cuda" ]]; then
-            conda install -v -y -c pytorch-"${CHANNEL}" pytorch cudatoolkit="${GPU_ARCH_VERSION}"
           else
             ${CONDA_RUN} conda install -v -y -c pytorch-"${CHANNEL}" pytorch
           fi
+
           if [[ "${{ inputs.package-name }}" = "torchvision" ]]; then
               ${CONDA_RUN} conda install -y 'numpy>=1.11'
               ${CONDA_RUN} conda install pillow

--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -161,7 +161,7 @@ jobs:
           if [[ "${GPU_ARCH}" = "cuda" ]]; then
             ${CONDA_RUN} conda install -v -y -c pytorch-"${CHANNEL}" -c nvidia pytorch pytorch-cuda="${GPU_ARCH_VERSION}"
           else
-            ${CONDA_RUN} conda install -v -y -c pytorch-"${CHANNEL}" pytorch
+            ${CONDA_RUN} conda install -v -y -c pytorch-"${CHANNEL}" pytorch cpuonly
           fi
 
           if [[ "${{ inputs.package-name }}" = "torchvision" ]]; then

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -23,7 +23,7 @@ mod = sys.modules[__name__]
 FULL_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10"]
 
 CUDA_ACRHES_DICT = {
-    "nightly": ["11.6", "11.7"],
+    "nightly": ["11.6", "11.7", "11.8"],
     "test": ["11.6", "11.7"],
     "release": ["11.6", "11.7"],
 }


### PR DESCRIPTION
This adds CUDA 11.8 to release matrix.
We already support CUDA 11.8 in PyTorch nightly: https://hud.pytorch.org/hud/pytorch/pytorch/nightly

Please note: We don't need cudatoolkit installation anymore. It was used for CUDA 10.2, 11.3, 11.5 . For CUDA version 11.6 and forward we will be using pytorch-cuda package