### PR TITLE
Add some experiment Windows G5 runners for CI

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -132,3 +132,9 @@ runner_types:
     is_ephemeral: false
     max_available: 150
     os: windows
+  windows.g5.4xlarge.nvidia.gpu:
+    disk_size: 256
+    instance_type: g5.4xlarge
+    is_ephemeral: false
+    max_available: 10
+    os: windows


### PR DESCRIPTION
It looks like Windows G5 runners is running fine with the current AMI when testing with canary here https://github.com/pytorch/pytorch-canary/actions/runs/3840601762/jobs/6539860392.  The only required change is to build PyTorch with `sm_86` on Windows accordingly.

This PR actually adds some of these runners to PyTorch so that they can be tested there on PyTorch CI as canary code base is not fully in sync.  Running the final test on PyTorch CI also gives me a better estimation of the performance gain with the new runner v.s. the existing one `p3.2xlarge`

This is similar to https://github.com/pytorch/pytorch-canary/pull/156