### PR TITLE
Have KPIs be annual for a fuller pic

### DIFF
--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -7,8 +7,8 @@ import { useState } from "react";
 const ROW_HEIGHT = 240;
 
 export default function Kpis() {
-    // Looking at data from the past 6 months
-    const [startTime, setStartTime] = useState(dayjs().subtract(6, 'month'));
+    // Looking at data from the past year
+    const [startTime, setStartTime] = useState(dayjs().subtract(1, 'year'));
     const [stopTime, setStopTime] = useState(dayjs());
 
     const timeParams: RocksetParam[] = [


### PR DESCRIPTION
<img width="1247" alt="image" src="https://user-images.githubusercontent.com/31798555/210457396-4754a178-01ef-4d26-aa1c-de965ecfd3c9.png">
is more telling than 
<img width="1568" alt="image" src="https://user-images.githubusercontent.com/31798555/210457417-ea577828-5114-4851-a5db-6d92a43b95c9.png">
