### PR TITLE
Build clang-tidy for both Intel and M1 Mac machines

### DIFF
--- a/.github/workflows/clang-tidy-linux.yml
+++ b/.github/workflows/clang-tidy-linux.yml
@@ -47,3 +47,7 @@ jobs:
           path: clang-tidy
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true

--- a/.github/workflows/clang-tidy-linux.yml
+++ b/.github/workflows/clang-tidy-linux.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           name: clang-tidy
           if-no-files-found: error
-          s3-prefix: linux64
+          s3-prefix: linux64/11.1.0
           s3-bucket: oss-clang-format
           path: clang-tidy
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/clang-tidy-macos.yml
+++ b/.github/workflows/clang-tidy-macos.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install dependencies
         run: |
           brew install ninja
+      - name: Set xcode version
+        run: |
+            echo "DEVELOPER_DIR=/Applications/Xcode_13.3.1.app/Contents/Developer" >> "${GITHUB_ENV}"
       - name: Build
         working-directory: ./tools/clang-tidy-checks
         run: |
@@ -53,7 +56,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install dependencies
         run: |
-          brew install ninja
+          brew install ninja cmake
       - name: Build
         working-directory: ./tools/clang-tidy-checks
         run: |

--- a/.github/workflows/clang-tidy-macos.yml
+++ b/.github/workflows/clang-tidy-macos.yml
@@ -17,8 +17,8 @@ on:
       - '.github/workflows/clang-tidy-macos.yml'
 
 jobs:
-  build:
-    runs-on: macos-10.15
+  build-Intel:
+    runs-on: macos-12
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -41,7 +41,36 @@ jobs:
         with:
           name: clang-tidy
           if-no-files-found: error
-          s3-prefix: macos
+          s3-prefix: macos-i386
+          s3-bucket: oss-clang-format
+          path: tools/clang-tidy-checks/llvm-project/build/bin/clang-tidy
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  build-M1:
+    runs-on: macos-m1-13
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          brew install ninja
+      - name: Build
+        working-directory: ./tools/clang-tidy-checks
+        run: |
+          set -ex
+
+          # LLVM is installed on the machine, but the binaries are not on the path
+          PATH="$(brew --prefix llvm)/bin:$PATH"
+          export PATH
+
+          ./setup.sh
+      - uses: driazati/upload-artifact-s3@50adbe4ef0b6d9221df25c18c5fc528dfcb7c3f8
+        name: Publish binary
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        with:
+          name: clang-tidy
+          if-no-files-found: error
+          s3-prefix: macos-arm
           s3-bucket: oss-clang-format
           path: tools/clang-tidy-checks/llvm-project/build/bin/clang-tidy
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/clang-tidy-macos.yml
+++ b/.github/workflows/clang-tidy-macos.yml
@@ -80,5 +80,5 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true

--- a/.github/workflows/clang-tidy-macos.yml
+++ b/.github/workflows/clang-tidy-macos.yml
@@ -44,13 +44,13 @@ jobs:
         with:
           name: clang-tidy
           if-no-files-found: error
-          s3-prefix: macos-i386
+          s3-prefix: macos-i386/11.1.0
           s3-bucket: oss-clang-format
           path: tools/clang-tidy-checks/llvm-project/build/bin/clang-tidy
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   build-M1:
-    runs-on: macos-m1-13
+    runs-on: macos-m1-12
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -73,8 +73,12 @@ jobs:
         with:
           name: clang-tidy
           if-no-files-found: error
-          s3-prefix: macos-arm
+          s3-prefix: macos-arm/11.1.0
           s3-bucket: oss-clang-format
           path: tools/clang-tidy-checks/llvm-project/build/bin/clang-tidy
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true

--- a/tools/clang-tidy-checks/README.md
+++ b/tools/clang-tidy-checks/README.md
@@ -1,6 +1,6 @@
 # clang-tidy-checks
 
-This directory contains patches for additional `clang-tidy` that are not part of `llvm v11.0.0`. It includes a setup script that builds and applies the patches to `llvm v11.0.0`.
+This directory contains patches for additional `clang-tidy` that are not part of `llvm v11.1.0`. It includes a setup script that builds and applies the patches to `llvm v11.1.0`.
 
 ## Usage
 

--- a/tools/clang-tidy-checks/setup.sh
+++ b/tools/clang-tidy-checks/setup.sh
@@ -35,7 +35,11 @@ function check_requirements() {
   gcc --version
   python3 --version
   ninja --version
-  ld.lld --version
+  if [ "$(uname)" != "Darwin" ]; then
+    ld.lld --version
+  else
+    echo "ld.lld is no longer available on Darwin"
+  fi
   success
 }
 
@@ -44,7 +48,7 @@ function clone_llvm() {
   if [[ -d llvm-project ]]; then
     rm -rf llvm-project
   fi
-  git clone -b llvmorg-11.0.0 https://github.com/llvm/llvm-project.git --depth=1
+  git clone -b llvmorg-11.1.0 https://github.com/llvm/llvm-project.git --depth=1
   success
 }
 


### PR DESCRIPTION
Update version to 11.1.0 (because why not)
Skip `ld.lld64` checks on MacOS
To avoid regressions similar to https://github.com/pytorch/pytorch/pull/91008 upload new binaries to a different folder

Add concurrency limit to both linux and macos clang-tidy workflows