### PR TITLE
[alerts] More descriptive alert message

### DIFF
--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -16,7 +16,7 @@ SIMILARITY_THRESHOLD = 0.75
 FAILURE_CHAIN_THRESHOLD = 2
 HUD_API_URL = "https://hud.pytorch.org/api/hud/pytorch/pytorch/master/0"
 MAX_CONCURRENT_ALERTS = 1
-UPDATING_ALERT_COMMENT = "Updating alert"
+FAILED_JOB_PATTERN = r'^- \[(.*)\]\(.*\) failed consecutively starting with commit \[.*\]\(.*\)$'
 
 PENDING = "pending"
 NEUTRAL = "neutral"
@@ -227,10 +227,9 @@ def gen_update_comment(original_body: str, jobs: List[JobStatus]) -> str:
     Returns empty string if nothing signficant changed. Otherwise returns a
     short string meant for updating the issue.
     """
-    regex_pattern = r'^- \[(.*)\]\(.*\) failed consecutively starting with commit \[.*\]\(.*\)$'
     original_jobs = []
     for line in original_body.splitlines():
-        match = re.match(regex_pattern, line.strip())
+        match = re.match(FAILED_JOB_PATTERN, line.strip())
         if match is not None:
             original_jobs.append(match.group(1))
 

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -222,25 +222,18 @@ def generate_failed_job_issue(failed_jobs: List[JobStatus]) -> Any:
     return issue
 
 
-def parse_failing_job_issue(body: str) -> List[str]:
-    '''
-    Get a list of jobs that is mentioned in the failing job issue
-    '''
-    jobs = []
-    regex_pattern = r'^- \[(.*)\]\(.*\) failed consecutively starting with commit \[.*\]\(.*\)$'
-    for line in body.splitlines():
-        match = re.match(regex_pattern, line.strip())
-        if match is not None:
-            jobs.append(match.group(1))
-    return jobs
-
-
 def gen_update_comment(original_body: str, jobs: List[JobStatus]) -> str:
     """
     Returns empty string if nothing signficant changed. Otherwise returns a
     short string meant for updating the issue.
     """
-    original_jobs = parse_failing_job_issue(original_body)
+    regex_pattern = r'^- \[(.*)\]\(.*\) failed consecutively starting with commit \[.*\]\(.*\)$'
+    original_jobs = []
+    for line in original_body.splitlines():
+        match = re.match(regex_pattern, line.strip())
+        if match is not None:
+            original_jobs.append(match.group(1))
+
     new_jobs = [job.job_name for job in jobs]
     stopped_failing_jobs = [job for job in original_jobs if job not in new_jobs]
     started_failing_jobs = [job for job in new_jobs if job not in original_jobs]


### PR DESCRIPTION
Only alerts if the jobs change (previously I think I was getting messages whenever the commit sha changed, which I think is much less important)

Change the message from just "updating alert" to ![image](https://user-images.githubusercontent.com/44682903/210650062-80e8f5f2-a760-49f0-a604-420a85386f40.png)

