### PR TITLE
[minihud] Filter out reruns

### DIFF
--- a/torchci/lib/fetchHud.ts
+++ b/torchci/lib/fetchHud.ts
@@ -66,7 +66,10 @@ export default async function fetchHud(params: HudParams): Promise<{
   }));
 
   const commitsBySha = _.keyBy(commits, "sha");
-  const results = hudQuery.results;
+  let results = hudQuery.results;
+  if (params.filter_reruns) {
+    results = results?.filter((job: JobData) => !job.name?.includes("rerun_disabled_tests"));
+  }
 
   const namesSet: Set<string> = new Set();
   // Built a list of all the distinct job names.

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -77,6 +77,7 @@ export interface HudParams {
   page: number;
   per_page: number;
   nameFilter?: string;
+  filter_reruns: boolean;
 }
 
 export interface PRData {
@@ -137,6 +138,7 @@ export function packHudParams(input: any) {
     page: parseInt((input.page as string) ?? 1),
     per_page: parseInt((input.per_page as string) ?? 50),
     nameFilter: input.name_filter as string | undefined,
+    filter_reruns: input.filter_reruns ?? false as boolean,
   };
 }
 
@@ -164,6 +166,10 @@ function formatHudURL(
   }/${encodeURIComponent(params.branch)}/${params.page}`;
 
   base += `?per_page=${params.per_page}`;
+
+  if (params.filter_reruns) {
+    base += `&filter_reruns=true`
+  }
 
   if (params.nameFilter != null && keepFilter) {
     base += `&name_filter=${encodeURIComponent(params.nameFilter)}`;

--- a/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -618,6 +618,7 @@ const ShowDurationContext = createContext<[boolean, (name: boolean) => void]>([
 export default function Page() {
   const router = useRouter();
   const params = packHudParams(router.query);
+  params.filter_reruns = true;
   const [jobFilter, setJobFilter] = useState<string | null>(null);
   const [jobHover, setJobHover] = useState<string | null>(null);
   const [showDurationInfo, setShowDurationInfo] = useState<boolean>(false);


### PR DESCRIPTION
Filter out rerun_disabled_tests from minihud because they're not important signal and it results in a long list of failed jobs