### PR TITLE
Fix edge cases on #938 'Fix runaway runner deletion on scale-down when API quota is hit'

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -292,6 +292,7 @@ export async function createRunner(runnerParameters: RunnerInputParameters, metr
       { Key: 'Application', Value: 'github-action-runner' },
       { Key: 'RunnerType', Value: runnerParameters.runnerType.runnerTypeName },
     ];
+    /* istanbul ignore next */
     if (Config.Instance.datetimeDeploy) {
       tags.push({ Key: 'ApplicationDeployDatetime', Value: Config.Instance.datetimeDeploy });
     }

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -14,8 +14,7 @@ import {
 } from './gh-runners';
 import { ScaleDownMetrics, sendMetricsAtTimeout, sendMetricsTimeoutVars } from './metrics';
 import { listRunners, resetRunnersCaches, terminateRunner } from './runners';
-import { getRepo, groupBy, Repo, RunnerInfo } from './utils';
-import { RequestError } from '@octokit/request-error';
+import { getRepo, groupBy, Repo, RunnerInfo, isGHRateLimitError } from './utils';
 
 export async function scaleDown(): Promise<void> {
   const metrics = new ScaleDownMetrics();
@@ -161,7 +160,9 @@ export async function scaleDown(): Promise<void> {
             await terminateRunner(ec2runner, metrics);
             metrics.runnerTerminateSuccess(ec2runner);
           } catch (e) {
+            /* istanbul ignore next */
             metrics.runnerTerminateFailure(ec2runner);
+            /* istanbul ignore next */
             console.error(`Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}] cannot be removed: ${e}`);
           }
         } else {
@@ -170,7 +171,9 @@ export async function scaleDown(): Promise<void> {
       }
     }
   } catch (e) {
+    /* istanbul ignore next */
     metrics.exception();
+    /* istanbul ignore next */
     throw e;
   } finally {
     clearTimeout(sndMetricsTimout.setTimeout);
@@ -178,18 +181,6 @@ export async function scaleDown(): Promise<void> {
     sndMetricsTimout.setTimeout = undefined;
     metrics.sendMetrics();
   }
-}
-
-/**
- * Returns true if the argument `e` is an octokit RequestError
- * from the 'API rate limit exceeded' exception.
- * @param e any error type
- * @return true if the argument is 'API rate limit exceeded' exception, false otherwise.
- */
-function isRateLimitError(e: unknown) {
-  const requestErr = e as RequestError | null;
-  const headers = requestErr?.headers || requestErr?.response?.headers;
-  return requestErr?.status === 403 && headers?.['x-ratelimit-remaining'] === '0';
 }
 
 export async function getGHRunnerOrg(ec2runner: RunnerInfo, metrics: ScaleDownMetrics): Promise<GhRunner | undefined> {
@@ -201,7 +192,7 @@ export async function getGHRunnerOrg(ec2runner: RunnerInfo, metrics: ScaleDownMe
     ghRunner = ghRunners.find((runner) => runner.name === ec2runner.instanceId);
   } catch (e) {
     console.warn('Failed to list active gh runners', e);
-    if (isRateLimitError(e)) {
+    if (isGHRateLimitError(e)) {
       throw e;
     }
   }
@@ -219,7 +210,7 @@ export async function getGHRunnerOrg(ec2runner: RunnerInfo, metrics: ScaleDownMe
           `listGithubRunnersOrg call: ${e}`,
       );
       /* istanbul ignore next */
-      if (isRateLimitError(e)) {
+      if (isGHRateLimitError(e)) {
         throw e;
       }
     }
@@ -246,7 +237,7 @@ export async function getGHRunnerRepo(ec2runner: RunnerInfo, metrics: ScaleDownM
   } catch (e) {
     console.warn('Failed to list active gh runners', e);
     /* istanbul ignore next */
-    if (isRateLimitError(e)) {
+    if (isGHRateLimitError(e)) {
       throw e;
     }
   }
@@ -263,7 +254,7 @@ export async function getGHRunnerRepo(ec2runner: RunnerInfo, metrics: ScaleDownM
         `Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}](${repo}) error when getRunnerRepo call: ${e}`,
       );
       /* istanbul ignore next */
-      if (isRateLimitError(e)) {
+      if (isGHRateLimitError(e)) {
         throw e;
       }
     }
@@ -305,6 +296,7 @@ export function isRunnerRemovable(
   ec2runner: RunnerInfo,
   metrics: ScaleDownMetrics,
 ): boolean {
+  /* istanbul ignore next */
   if (ec2runner.instanceManagement?.toLowerCase() === 'pet') {
     return false;
   }

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/utils.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/utils.ts
@@ -1,3 +1,5 @@
+import { RequestError } from '@octokit/request-error';
+
 export interface Repo {
   owner: string;
   repo: string;
@@ -18,6 +20,12 @@ export interface RunnerInfo {
 
 export function getRepoKey(repo: Repo): string {
   return `${repo.owner}/${repo.repo}`;
+}
+
+export function isGHRateLimitError(e: unknown) {
+  const requestErr = e as RequestError | null;
+  const headers = requestErr?.headers || requestErr?.response?.headers;
+  return requestErr?.status === 403 && headers?.['x-ratelimit-remaining'] === '0';
 }
 
 export function getBoolean(value: string | number | undefined | boolean, defaultVal = false): boolean {
@@ -63,7 +71,7 @@ export async function expBackOff<T>(
     try {
       return await callback();
     } catch (e) {
-      if (`${e}`.includes('RequestLimitExceeded') || `${e}`.includes('ThrottlingException')) {
+      if (`${e}`.includes('RequestLimitExceeded') || `${e}`.includes('ThrottlingException') || isGHRateLimitError(e)) {
         if (expBackOffMs > maxMs) {
           throw e;
         }


### PR DESCRIPTION
Added expBackOff for GH API calls that could fail, avoiding both a crash and a retry-storm. 

The behaviour of abrupt stop for scaleDown is still maintained, as it is reasonable to avoid scaleDown when on a pinch