### PR TITLE
Consider pinning cmake and removing use of conda-forge

### DIFF
--- a/aws/ami/windows/scripts/Installers/Install-Conda-Dependencies.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-Conda-Dependencies.ps1
@@ -14,7 +14,6 @@ conda activate base
 
 Write-Output "Installing conda packages for building and testing PyTorch"
 # The list of dependencies is copied from the current PyTorch miniconda installation script
-conda install -y numpy"<1.23" ninja pyyaml setuptools cmake cffi typing_extensions future six requests dataclasses boto3 libuv
-conda install -y -c conda-forge cmake=3.22.3
+conda install -y numpy"<1.23" ninja pyyaml setuptools cmake=3.22.* cffi typing_extensions future six requests dataclasses boto3 libuv
 # and setup_pytorch_env script
 conda install -y mkl protobuf numba scipy=1.6.2 typing_extensions dataclasses conda==22.9.0


### PR DESCRIPTION
### Description
#### Why pin cmake
When cmake was unpinned and cmake version 3.23.0 came out, Windows and Ubuntu builds would break https://github.com/pytorch/pytorch/issues/74985. While this would eventually be fixed, it was determined that it would be safer to pin cmake to a known stable version, 3.22. Finally, it was decided that 3.22 be relaxed to 3.22.* https://github.com/pytorch/pytorch/pull/90307.

#### Why drop `conda-forge`
While `conda-forge` contains much more updated versions of cmake relative to conda's main channel https://github.com/pytorch/pytorch/pull/91739#discussion_r1062989028, it's been revealed that this channel isn't particularly stable https://github.com/pytorch/pytorch/issues/87208. This has lead to the decision to avoid the use of `conda-forge` unless it has been determined that this channel contains updates the main channel doesn't have that are vital to the functionality of PyTorch https://github.com/pytorch/pytorch/pull/91739#discussion_r1063799844.

### How is this tested?
There are some manual testing steps to be done, though I'm not sure how to use them so I'm looking for guidance on this matter.

### People with relevant context
@huydhn 
