### PR TITLE
Fixes setting matrix env vars

### DIFF
--- a/.github/scripts/export_matrix_variables.py
+++ b/.github/scripts/export_matrix_variables.py
@@ -18,7 +18,7 @@ def main(args) -> None:
 
     for key, value in variables_to_export.items():
         print(
-            f"MATRIX_{key.upper().replace('-', '_')}={value.replace('-', '_')}"
+            f"MATRIX_{key.upper().replace('-', '_')}={value}"
         )
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes bug with values setting.
For example:
```
pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
```
would be converted to:
```
pip3 install torch torchvision torchaudio __extra_index_url https://download.pytorch.org/whl/cpu
```
which is not correct