### PR TITLE
Increase max Windows G5 count to 150 (same as windows.8xlarge.nvidia.gpu)

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -136,5 +136,5 @@ runner_types:
     disk_size: 256
     instance_type: g5.4xlarge
     is_ephemeral: false
-    max_available: 10
+    max_available: 150
     os: windows


### PR DESCRIPTION
I have obtained good results when trying to run Windows CUDA tests on G5 runners https://github.com/pytorch/pytorch/pull/91727.  It's not only faster but also cheaper with a 25% job duration gain and 45% cost reduction.

So I'm looking forward to roll this out by increase the max capacity of Windows G5 to 150 (same as windows.8xlarge.nvidia.gpu).  Do we have any concern or limitation on the number of G5 runners on AWS us-east-1?

