### PR TITLE
Fixes setting INSTALL command for env vars

### DIFF
--- a/.github/actions/export-matrix-variables/action.yml
+++ b/.github/actions/export-matrix-variables/action.yml
@@ -24,16 +24,26 @@ runs:
         TARGET_OS: ${{ inputs.target-os }}
       run: |
         set -ex
-        # Fix for windows to make sure python is initialized
         echo "${MATRIX_TO_EXPORT}" > "${RUNNER_TEMP}"/matrix_to_export.json
+
+        # For linux environment variables are passed via docker file
+        # for all other OS's we execute export line by line.
+        # hence the quotes around the value
+        export ADD_QUOTES_AROUND_VAR=""
+        if [[ ${TARGET_OS} != "linux" ]]; then
+          export ADD_QUOTES_AROUND_VAR="--add-quotes-around-value"
+        fi
+
+        # Fix for windows we need to make sure python is initialized
+        # hence we are using conda environment
         if [[ ${TARGET_OS} == 'windows' ]]; then
           source /c/Jenkins/Miniconda3/etc/profile.d/conda.sh
           conda activate base
           python \
-            test-infra/.github/scripts/export_matrix_variables.py  \
-            --input-file "${RUNNER_TEMP}"/matrix_to_export.json >> ${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}
+            test-infra/.github/scripts/export_matrix_variables.py ${ADD_QUOTES_AROUND_VAR}  \
+            --input-file "${RUNNER_TEMP}"/matrix_to_export.json  >> ${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}
         else
           python3 \
-            test-infra/.github/scripts/export_matrix_variables.py  \
+            test-infra/.github/scripts/export_matrix_variables.py ${ADD_QUOTES_AROUND_VAR} \
             --input-file "${RUNNER_TEMP}"/matrix_to_export.json >> ${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}
         fi

--- a/.github/scripts/export_matrix_variables.py
+++ b/.github/scripts/export_matrix_variables.py
@@ -11,15 +11,18 @@ def main(args) -> None:
         help="Input file to use, must be JSON",
         type=str,
     )
+    parser.add_argument('--add-quotes-around-value', dest='add_quotes_around_value', action='store_true')
+    parser.set_defaults(add_quotes_around_value=False)
     options = parser.parse_args(args)
 
     with open(options.input_file) as fp:
         variables_to_export: Dict[str, str] = json.loads(fp.read())
 
     for key, value in variables_to_export.items():
-        print(
-            f"MATRIX_{key.upper().replace('-', '_')}={value}"
-        )
+        if options.add_quotes_around_value:
+            value = f"\"{value}\""
+
+        print(f"MATRIX_{key.upper().replace('-', '_')}={value}")
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -131,6 +131,7 @@ jobs:
         if: ${{ inputs.binary-matrix != '' }}
         with:
           binary-matrix: ${{ inputs.binary-matrix }}
+          target-os: "linux"
 
       - name: Run script in container
         continue-on-error: ${{ inputs.continue-on-error }}

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -107,6 +107,7 @@ jobs:
         if: ${{ inputs.binary-matrix != '' }}
         with:
           binary-matrix: ${{ inputs.binary-matrix }}
+          target-os: "macos"
 
       - name: Run script
         shell: bash -l {0}

--- a/.github/workflows/test-export-matrix-variables.yml
+++ b/.github/workflows/test-export-matrix-variables.yml
@@ -12,31 +12,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        job_type:
-          - linux_job
+        installation:
+          - pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
     with:
       binary-matrix: ${{ toJSON(matrix) }}
       script: |
-        [[ "${MATRIX_JOB_TYPE}" = "${{ matrix.job_type }}" ]] || exit 1
+        [[ "${MATRIX_INSTALLATION}" = "${{ matrix.installation }}" ]] || exit 1
   test-windows:
     uses: ./.github/workflows/windows_job.yml
     strategy:
       fail-fast: false
       matrix:
-        job_type:
-          - windows_job
+        installation:
+          - pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
     with:
       binary-matrix: ${{ toJSON(matrix) }}
       script: |
-        [[ "${MATRIX_JOB_TYPE}" = "${{ matrix.job_type }}" ]] || exit 1
+        [[ "${MATRIX_INSTALLATION}" = "${{ matrix.installation }}" ]] || exit 1
   test-macos:
     uses: ./.github/workflows/macos_job.yml
     strategy:
       fail-fast: false
       matrix:
-        job_type:
-          - macos_job
+        installation:
+          - pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
     with:
       binary-matrix: ${{ toJSON(matrix) }}
       script: |
-        [[ "${MATRIX_JOB_TYPE}" = "${{ matrix.job_type }}" ]] || exit 1
+        [[ "${MATRIX_INSTALLATION}" = "${{ matrix.installation }}" ]] || exit 1


### PR DESCRIPTION
Fixes an issue when using install command with MATRIX env var. Without this change only first word of install command is assigned to env var. For example if install is:
```
conda install pytorch torchvision torchaudio cpuonly -c pytorch
```
the MATRIX_INSTALL would be:
```
conda
```
With this fix, it should be resolved. 