### PR TITLE
[NovaX] set -eax in all build shell scripts for correctness/debuggability

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -37,6 +37,7 @@ runs:
         env:
           REPOSITORY: ${{ inputs.repository }}
         run: |
+          set -eax
           rm -rf "${REPOSITORY}"
       - uses: actions/checkout@v3
         with:
@@ -47,6 +48,7 @@ runs:
       - name: Set release CHANNEL
         shell: bash -l {0}
         run: |
+          set -eax
           # reference ends with an RC suffix
           if [[ ${GITHUB_REF_NAME} = *-rc[0-9]* ]]; then
             echo "CHANNEL=test" >> "${GITHUB_ENV}"
@@ -58,6 +60,7 @@ runs:
         env:
           PYTHON_VERSION: ${{ inputs.python-version }}
         run: |
+          set -eax
           # Set artifact name here since github actions doesn't have string manipulation tools
           # and "/" is not allowed in artifact names
           echo "ARTIFACT_NAME=${REPOSITORY/\//_}_${REF}_${PYTHON_VERSION}" >> "${GITHUB_ENV}"
@@ -70,11 +73,13 @@ runs:
       - name: Clean conda environment
         shell: bash -l {0}
         run: |
+          set -eax
           conda clean --all --quiet --yes
       - name: Generate file from pytorch_pkg_helpers
         working-directory: ${{ inputs.repository }}
         shell: bash -l {0}
         run: |
+          set -eax
           CONDA_ENV="${RUNNER_TEMP}/pytorch_pkg_helpers_${GITHUB_RUN_ID}"
           conda create \
             --yes \
@@ -92,6 +97,7 @@ runs:
         env:
           PYTHON_VERSION: ${{ inputs.python-version }}
         run: |
+          set -eax
           CONDA_ENV="${RUNNER_TEMP}/conda_environment_${GITHUB_RUN_ID}"
 
           conda create \

--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -92,6 +92,7 @@ jobs:
         if: ${{ inputs.env-var-script != '' }}
         working-directory: ${{ inputs.repository }}
         run: |
+          set -eax
           cat "${{ inputs.env-var-script }}" >> "${BUILD_ENV_FILE}"
       - name: Run pre-script
         working-directory: ${{ inputs.repository }}
@@ -99,6 +100,7 @@ jobs:
           PRE_SCRIPT: ${{ inputs.pre-script }}
         if: ${{ inputs.pre-script != '' }}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
           if [[ ! -f ${PRE_SCRIPT} ]]; then
             echo "::error::Specified pre-script file (${PRE_SCRIPT}) not found, not going execute it"
@@ -108,12 +110,14 @@ jobs:
           fi
       - name: Setup base environment variables
         run: |
+          set -eax
           echo "SOURCE_ROOT_DIR=${GITHUB_WORKSPACE}/${REPOSITORY}" >> "${GITHUB_ENV}"
       - name: Build the conda (conda-build)
         working-directory: ${{ inputs.repository }}
         env:
           CUDATOOLKIT_CHANNEL: ${{ env.CUDATOOLKIT_CHANNEL }}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
           export FFMPEG_ROOT="${PWD}"/third_party/ffmpeg
           export USE_FFMPEG="1"
@@ -137,6 +141,7 @@ jobs:
           POST_SCRIPT: ${{ inputs.post-script }}
         if: ${{ inputs.post-script != '' }}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
           if [[ ! -f ${POST_SCRIPT} ]]; then
             echo "::error::Specified post-script file (${POST_SCRIPT}) not found, not going execute it"
@@ -152,7 +157,7 @@ jobs:
           DESIRED_CUDA: ${{ matrix.desired_cuda }}
           GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
         run: |
-          set -ex
+          set -eax
           source "${BUILD_ENV_FILE}"
           CONDA_OUTPUT_PATH="${{ inputs.repository }}/dist/linux-64/"
           echo "$CONDA_OUTPUT_PATH"
@@ -188,8 +193,8 @@ jobs:
         env:
           CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
-          set -x
           conda create --yes -n upload_env python="${PYTHON_VERSION}"
           conda run -n upload_env conda install -yq anaconda-client
           conda run -n upload_env anaconda -t "${CONDA_PYTORCHBOT_TOKEN}" upload dist/linux-64/*.tar.bz2 -u "pytorch-${CHANNEL}" --label main --no-progress --force

--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -76,6 +76,7 @@ jobs:
     steps:
       - name: Clean workspace
         run: |
+          set -eax
           echo "::group::Cleanup debug output"
           rm -rfv "${GITHUB_WORKSPACE}"
           mkdir -p "${GITHUB_WORKSPACE}"
@@ -100,6 +101,7 @@ jobs:
           PRE_SCRIPT: ${{ inputs.pre-script }}
         if: ${{ inputs.pre-script != '' }}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
           if [[ ! -f ${PRE_SCRIPT} ]]; then
             echo "::error::Specified pre-script file (${PRE_SCRIPT}) not found, not going execute it"
@@ -109,10 +111,12 @@ jobs:
           fi
       - name: Setup base environment variables
         run: |
+          set -eax
           echo "SOURCE_ROOT_DIR=${GITHUB_WORKSPACE}/${REPOSITORY}" >> "${GITHUB_ENV}"
       - name: Build the conda (conda-build)
         working-directory: ${{ inputs.repository }}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
 
           if [[ "${{ inputs.package-name }}" = "torchaudio" ]]; then
@@ -143,6 +147,7 @@ jobs:
           POST_SCRIPT: ${{ inputs.post-script }}
         if: ${{ inputs.post-script != '' }}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
           if [[ ! -f ${POST_SCRIPT} ]]; then
             echo "::error::Specified post-script file (${POST_SCRIPT}) not found, not going execute it"
@@ -156,6 +161,7 @@ jobs:
           PACKAGE_NAME: ${{ inputs.package-name }}
           SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
 
           arch_name="$(uname -m)"
@@ -189,8 +195,8 @@ jobs:
         env:
           CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
-          set -x
           conda create --yes -n upload_env python="${PYTHON_VERSION}"
           conda run -n upload_env conda install -yq anaconda-client
           arch_name="$(uname -m)"

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -91,11 +91,12 @@ jobs:
         if: ${{ inputs.env-var-script != '' }}
         working-directory: ${{ inputs.repository }}
         run: |
+          set -eax
           cat "${{ inputs.env-var-script }}" >> "${BUILD_ENV_FILE}"
       - name: Install torch dependency
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
-          set -ex
           # shellcheck disable=SC2086
           ${CONDA_RUN} ${PIP_INSTALL_TORCH}
       - name: Run pre-script
@@ -105,6 +106,7 @@ jobs:
         if: ${{ inputs.pre-script != '' }}
         shell: bash -l {0}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
           if [[ ! -f ${PRE_SCRIPT} ]]; then
             echo "::error::Specified pre-script file (${PRE_SCRIPT}) not found, not going execute it"
@@ -116,12 +118,14 @@ jobs:
         working-directory: ${{ inputs.repository }}
         shell: bash -l {0}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
           ${CONDA_RUN} python setup.py clean
       - name: Build the wheel (bdist_wheel)
         working-directory: ${{ inputs.repository }}
         shell: bash -l {0}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
           export FFMPEG_ROOT="${PWD}"/third_party/ffmpeg
           export USE_FFMPEG="1"
@@ -139,6 +143,7 @@ jobs:
         if: ${{ inputs.post-script != '' }}
         shell: bash -l {0}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
           if [[ ! -f ${POST_SCRIPT} ]]; then
             echo "::error::Specified post-script file (${POST_SCRIPT}) not found, not going execute it"
@@ -152,6 +157,7 @@ jobs:
           PACKAGE_NAME: ${{ inputs.package-name }}
           SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
           WHEEL_NAME=$(ls "${{ inputs.repository }}/dist/")
           echo "$WHEEL_NAME"
@@ -179,6 +185,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
           ${CONDA_RUN} pip install awscli
           for pkg in dist/*; do

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -73,6 +73,7 @@ jobs:
     steps:
       - name: Clean workspace
         run: |
+          set -eax
           echo "::group::Cleanup debug output"
           rm -rfv "${GITHUB_WORKSPACE}"
           mkdir -p "${GITHUB_WORKSPACE}"
@@ -91,9 +92,11 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install delocate-wheel
         run: |
+          set -eax
           ${CONDA_RUN} python3 -m pip install delocate
       - name: Install torch dependency
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
           # shellcheck disable=SC2086
           ${CONDA_RUN} ${PIP_INSTALL_TORCH}
@@ -103,6 +106,7 @@ jobs:
           PRE_SCRIPT: ${{ inputs.pre-script }}
         if: ${{ inputs.pre-script != '' }}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
           if [[ ! -f ${PRE_SCRIPT} ]]; then
             echo "::error::Specified pre-script file (${PRE_SCRIPT}) not found, not going execute it"
@@ -113,11 +117,13 @@ jobs:
       - name: Build clean
         working-directory: ${{ inputs.repository }}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
           ${CONDA_RUN} python3 setup.py clean
       - name: Build the wheel (bdist_wheel)
         working-directory: ${{ inputs.repository }}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
 
           if [[ "${{ inputs.package-name }}" = "torchaudio" ]]; then
@@ -131,6 +137,7 @@ jobs:
       - name: Delocate wheel
         working-directory: ${{ inputs.repository }}
         run: |
+          set -eax
           ${CONDA_RUN} DYLD_FALLBACK_LIBRARY_PATH="${CONDA_ENV}/lib" delocate-wheel -v --ignore-missing-dependencies dist/*.whl
       - name: Upload wheel to GitHub
         continue-on-error: true
@@ -144,6 +151,7 @@ jobs:
           POST_SCRIPT: ${{ inputs.post-script }}
         if: ${{ inputs.post-script != '' }}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
           if [[ ! -f ${POST_SCRIPT} ]]; then
             echo "::error::Specified post-script file (${POST_SCRIPT}) not found, not going execute it"
@@ -157,6 +165,7 @@ jobs:
           PACKAGE_NAME: ${{ inputs.package-name }}
           SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
           WHEEL_NAME=$(ls "${{ inputs.repository }}/dist/")
           echo "$WHEEL_NAME"
@@ -184,6 +193,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}
         run: |
+          set -eax
           source "${BUILD_ENV_FILE}"
           ${CONDA_RUN} pip install awscli
           for pkg in dist/*; do


### PR DESCRIPTION
For all shell scripts in the Linux/Mac Wheels/Conda builds as well as the `setup-binary-builds` action, this PR adds `set -eax` for better handling in case of errors and debuggability.