### PR TITLE
[flakybot] Add retry for fetching file

### DIFF
--- a/torchci/lib/bot/utils.ts
+++ b/torchci/lib/bot/utils.ts
@@ -83,9 +83,24 @@ export class CachedIssueTracker extends CachedConfigTracker {
 
 // returns undefined if the request fails
 export async function fetchJSON(path: string): Promise<any> {
-  const result = await urllib.request(path);
+  const result = await retryRequest(path);
   if (result.res.statusCode !== 200) {
     return;
   }
   return JSON.parse(result.data.toString());
+}
+
+export async function retryRequest(
+  path: string,
+  numRetries: number = 3,
+  delay: number = 500
+): Promise<urllib.HttpClientResponse<any>> {
+  for (let i = 0; i < numRetries; i++) {
+    const result = await urllib.request(path);
+    if (result.res.statusCode == 200) {
+      return result;
+    }
+    await new Promise((f) => setTimeout(f, delay));
+  }
+  return await urllib.request(path);
 }


### PR DESCRIPTION
Add retry function for retrieving the test file and add info on the issue to track better, since we've had some issues with labeling.

Reduce amount of logs b/c vercel cuts off logs that are too long https://github.com/vercel/community/discussions/1012

I spent a long time trying to figure out how to get retries using some other library but kept failing.  If someone figures out how to do it with another library, would be much appreciated.
