### PR TITLE
Migrate Validate Domain Library workflow

### DIFF
--- a/.github/scripts/install_torch.sh
+++ b/.github/scripts/install_torch.sh
@@ -1,0 +1,19 @@
+conda create -y -n ${ENV_NAME} python=${MATRIX_PYTHON_VERSION} numpy
+conda activate ${ENV_NAME}
+export MATRIX_INSTALLATION="${MATRIX_INSTALLATION/torchvision}"
+export MATRIX_INSTALLATION="${MATRIX_INSTALLATION/torchaudio}"
+eval $MATRIX_INSTALLATION
+
+export PYTORCH_PIP_PREFIX=""
+
+if [[ ${MATRIX_CHANNEL} = "nightly" ]]; then
+    export PYTORCH_PIP_PREFIX="--pre"
+fi
+
+if [[ ${MATRIX_CHANNEL} = "nightly" || ${MATRIX_CHANNEL} = "test" ]]; then
+    export PYTORCH_PIP_DOWNLOAD_URL="https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}"
+    export PYTORCH_CONDA_CHANNEL="pytorch-${MATRIX_CHANNEL}"
+else
+    export PYTORCH_CONDA_CHANNEL="pytorch"
+    export PYTORCH_PIP_DOWNLOAD_URL="https://download.pytorch.org/whl/${MATRIX_DESIRED_CUDA}"
+fi

--- a/.github/workflows/lint_actions.yml
+++ b/.github/workflows/lint_actions.yml
@@ -35,4 +35,5 @@ jobs:
           # Would like to eventually have this in a config file but it's here until then
           actionlint \
             -ignore "SC1090" \
-            -ignore 'when a reusable workflow is called with "uses", "strategy" is not available.'
+            -ignore 'when a reusable workflow is called with "uses", "strategy" is not available.' \
+            -ignore 'reusable workflow cannot be nested.'

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -162,6 +162,7 @@ jobs:
             --ulimit stack=10485760:83886080 \
             ${GPU_FLAG:-} \
             -v "${GITHUB_WORKSPACE}/${REPOSITORY}:/work" \
+            -v "${GITHUB_WORKSPACE}/test-infra:/test-infra" \
             -v "${RUNNER_ARTIFACT_DIR}:/artifacts" \
             -v "${RUNNER_TEMP}/exec_script:/exec" \
             -v "${GITHUB_STEP_SUMMARY}":"${GITHUB_STEP_SUMMARY}" \

--- a/.github/workflows/test-validate-domain-library.yml
+++ b/.github/workflows/test-validate-domain-library.yml
@@ -1,0 +1,21 @@
+name: Test validate domain library
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/validate-domain-library.yml
+      - .github/workflows/test-validate-domain-library.yml
+  workflow_dispatch:
+
+jobs:
+  test-validate-domain-library:
+    uses: ./.github/workflows/validate-domain-library.yml
+    with:
+      package_type: "conda,wheel"
+      os: "all"
+      channel: "nightly"
+      repository: "pytorch/text"
+      ref: main
+      install_torch: true
+      smoke_test: |
+        echo test

--- a/.github/workflows/test-validate-domain-library.yml
+++ b/.github/workflows/test-validate-domain-library.yml
@@ -11,7 +11,7 @@ jobs:
   test-validate-domain-library:
     uses: ./.github/workflows/validate-domain-library.yml
     with:
-      package_type: "conda,wheel"
+      package_type: "wheel"
       os: "all"
       channel: "nightly"
       repository: "pytorch/text"

--- a/.github/workflows/validate-domain-library.yml
+++ b/.github/workflows/validate-domain-library.yml
@@ -164,6 +164,7 @@ jobs:
         set -ex
         export ENV_NAME="conda-env-${{ github.run_id }}"
         export TARGET_OS="macos-arm64"
+        export SMOKE_TEST="${{ inputs.smoke_test }}"
         if [[ ${{inputs.install_torch}} == 'true' ]]; then
           source "${GITHUB_WORKSPACE}/test-infra/.github/scripts/install_torch.sh"
         fi

--- a/.github/workflows/validate-domain-library.yml
+++ b/.github/workflows/validate-domain-library.yml
@@ -1,0 +1,170 @@
+name: Validate domain libary
+
+# A reusable workflow that triggers a set of jobs that perform a smoke test / validation of pytorch binaries.
+# Optionally restricts validation to the specified OS and channel.
+# For the details about parameter values, see:
+#   pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: "Operating system to generate for (linux, windows, macos, macos-arm64)"
+        required: false
+        type: string
+        default: "all"
+      channel:
+        description: "Channel to use (nightly, test, release, all)"
+        required: true
+        type: string
+      ref:
+        description: 'Reference to checkout, defaults to empty'
+        default: ""
+        required: false
+        type: string
+      package_type:
+        description: "Package type (conda, wheel, all)"
+        required: false
+        type: string
+        default: "all"
+      repository:
+        description: "Path to repository to checkout"
+        required: true
+        type: string
+      smoke_test:
+        description: "Path to a smoke test script"
+        required: true
+        type: string
+      with_cuda:
+        description: "With cuda enable/disable"
+        required: false
+        type: string
+        default: disable
+      install_torch:
+        description: "Create new conda environment and preinstall torch"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  generate-linux-matrix:
+    if:  (inputs.os == 'linux' || inputs.os == 'all')
+    uses: ./.github/workflows/generate_binary_build_matrix.yml
+    with:
+      package-type: ${{ inputs.package_type }}
+      os: linux
+      channel: ${{ inputs.channel }}
+      with-cuda: ${{ inputs.with_cuda }}
+  generate-windows-matrix:
+    if:  (inputs.os == 'windows' || inputs.os == 'all')
+    uses: ./.github/workflows/generate_binary_build_matrix.yml
+    with:
+      package-type: ${{ inputs.package_type }}
+      os: windows
+      channel: ${{ inputs.channel }}
+      with-cuda: ${{ inputs.with_cuda }}
+  generate-macos-matrix:
+    if:  (inputs.os == 'macos' || inputs.os == 'all')
+    uses: ./.github/workflows/generate_binary_build_matrix.yml
+    with:
+      package-type: ${{ inputs.package_type }}
+      os: macos
+      channel: ${{ inputs.channel }}
+      with-cuda: ${{ inputs.with_cuda }}
+  generate-macos-arm64-matrix:
+    if:  (inputs.os == 'macos-arm64' || inputs.os == 'all')
+    uses: ./.github/workflows/generate_binary_build_matrix.yml
+    with:
+      package-type: ${{ inputs.package_type }}
+      os: macos-arm64
+      channel: ${{ inputs.channel }}
+      with-cuda: ${{ inputs.with_cuda }}
+  validate-linux:
+    if:  (inputs.os == 'linux' || inputs.os == 'all')
+    needs: generate-linux-matrix
+    strategy:
+      matrix: ${{ fromJson(needs.generate-linux-matrix.outputs.matrix) }}
+      fail-fast: false
+    uses: ./.github/workflows/linux_job.yml
+    name: "linux-${{ matrix.package_type }}-${{ matrix.python_version }}-${{ matrix.desired_cuda }}"
+    with:
+      runner: ${{ matrix.validation_runner }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref || github.ref }}
+      job-name: "linux-${{ matrix.package_type }}-${{ matrix.python_version }}-${{ matrix.desired_cuda }}"
+      binary-matrix: ${{ toJSON(matrix) }}
+      script: |
+        set -ex
+        export ENV_NAME="conda-env-${{ github.run_id }}"
+        export SMOKE_TEST="${{ inputs.smoke_test }}"
+        if [[ ${{inputs.install_torch}} == 'true' ]]; then
+          source ../test-infra/.github/scripts/install_torch.sh
+        fi
+        eval $SMOKE_TEST
+  validate-windows:
+    if:  (inputs.os == 'windows' || inputs.os == 'all')
+    needs: generate-windows-matrix
+    strategy:
+      matrix: ${{ fromJson(needs.generate-windows-matrix.outputs.matrix) }}
+      fail-fast: false
+    uses: ./.github/workflows/windows_job.yml
+    name: "windows-${{ matrix.package_type }}-${{ matrix.python_version }}-${{ matrix.desired_cuda }}"
+    with:
+      runner: ${{ matrix.validation_runner }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref || github.ref }}
+      job-name: "windows-${{ matrix.package_type }}-${{ matrix.python_version }}-${{ matrix.desired_cuda }}"
+      binary-matrix: ${{ toJSON(matrix) }}
+      script: |
+        set -ex
+        export ENV_NAME="conda-env-${{ github.run_id }}"
+        export SMOKE_TEST="${{ inputs.smoke_test }}"
+        export TARGET_OS="windows"
+        if [[ ${{inputs.install_torch}} == 'true' ]]; then
+          source "${GITHUB_WORKSPACE}/test-infra/.github/scripts/install_torch.sh"
+        fi
+        eval $SMOKE_TEST
+  validate-macos:
+    if:  (inputs.os == 'macos' || inputs.os == 'all')
+    needs: generate-macos-matrix
+    strategy:
+      matrix: ${{ fromJson(needs.generate-macos-matrix.outputs.matrix) }}
+      fail-fast: false
+    uses: ./.github/workflows/macos_job.yml
+    name: "macos-${{ matrix.package_type }}-${{ matrix.python_version }}-${{ matrix.desired_cuda }}"
+    with:
+      runner:  ${{ matrix.validation_runner }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref || github.ref }}
+      job-name: "macos-${{ matrix.package_type }}-${{ matrix.python_version }}-${{ matrix.desired_cuda }}"
+      binary-matrix: ${{ toJSON(matrix) }}
+      script: |
+        set -ex
+        export ENV_NAME="conda-env-${{ github.run_id }}"
+        export TARGET_OS="macos"
+        export SMOKE_TEST="${{ inputs.smoke_test }}"
+        if [[ ${{inputs.install_torch}} == 'true' ]]; then
+          source "${GITHUB_WORKSPACE}/test-infra/.github/scripts/install_torch.sh"
+        fi
+        eval $SMOKE_TEST
+  validate-macos-arm64:
+    if:  (inputs.os == 'macos-arm64' || inputs.os == 'all')
+    needs: generate-macos-arm64-matrix
+    strategy:
+      matrix: ${{ fromJson(needs.generate-macos-arm64-matrix.outputs.matrix) }}
+      fail-fast: false
+    uses: ./.github/workflows/macos_job.yml
+    name: "macos-${{ matrix.package_type }}-${{ matrix.python_version }}-${{ matrix.desired_cuda }}"
+    with:
+      runner:  ${{ matrix.validation_runner }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref || github.ref }}
+      job-name: "macos-arm64-${{ matrix.package_type }}-${{ matrix.python_version }}-${{ matrix.desired_cuda }}"
+      binary-matrix: ${{ toJSON(matrix) }}
+      script: |
+        set -ex
+        export ENV_NAME="conda-env-${{ github.run_id }}"
+        export TARGET_OS="macos-arm64"
+        if [[ ${{inputs.install_torch}} == 'true' ]]; then
+          source "${GITHUB_WORKSPACE}/test-infra/.github/scripts/install_torch.sh"
+        fi
+        eval $SMOKE_TEST


### PR DESCRIPTION
This brings Validate Domain Library workflow to test-infra repo.
Please see wiki: https://github.com/pytorch/builder/wiki/Using-Validation-Framework