### PR TITLE
Add ciflow/unstable as a valid tag

### DIFF
--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -140,32 +140,13 @@ async function handleLabelEvent(context: Context<"pull_request.labeled">) {
     "ciflow/periodic",
     "ciflow/android",
     "ciflow/binaries",
+    "ciflow/experiment",
     "ciflow/inductor",
     "ciflow/mps",
     "ciflow/nightly",
     "ciflow/binaries_conda",
     "ciflow/binaries_libtorch",
     "ciflow/binaries_wheel",
-  ];
-
-  // The following labels control the test subsets we want to run,
-  // so their names are the same as shard names
-  const valid_test_config_labels = [
-    "ciflow/backwards_compat",
-    "ciflow/crossref",
-    "ciflow/default",
-    "ciflow/deploy",
-    "ciflow/distributed",
-    "ciflow/docs_tests",
-    "ciflow/dynamo",
-    "ciflow/force_on_cpu",
-    "ciflow/functorch",
-    "ciflow/jit_legacy",
-    "ciflow/multigpu",
-    "ciflow/nogpu_AVX512",
-    "ciflow/nogpu_NO_AVX2",
-    "ciflow/slow",
-    "ciflow/xla",
   ];
 
   if (!valid_labels.includes(label) && !valid_test_config_labels.includes(label)) {
@@ -189,14 +170,16 @@ async function handleLabelEvent(context: Context<"pull_request.labeled">) {
       "- `ciflow/android` (`.github/workflows/run_android_tests.yml`): android build and test\n";
     body +=
       "- `ciflow/nightly` (`.github/workflows/nightly.yml`): all jobs we run nightly\n";
-    body += "- `ciflow/binaries`: all binary build and upload jobs\n";
+    body +=
+      "- `ciflow/binaries`: all binary build and upload jobs\n";
     body +=
       " - `ciflow/binaries_conda`: binary build and upload job for conda\n";
     body +=
       " - `ciflow/binaries_libtorch`: binary build and upload job for libtorch\n";
-    body += " - `ciflow/binaries_wheel`: binary build and upload job for wheel\n";
-    body += "In addition, you can use the following labels to select the test subsets to run: ";
-    body += valid_test_config_labels.join(", ");
+    body +=
+      " - `ciflow/binaries_wheel`: binary build and upload job for wheel\n";
+    body +=
+      " - `ciflow/experiment`: run all experimental jobs\n";
     await context.octokit.issues.createComment(
       context.repo({
         body,

--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -149,7 +149,7 @@ async function handleLabelEvent(context: Context<"pull_request.labeled">) {
     "ciflow/binaries_wheel",
   ];
 
-  if (!valid_labels.includes(label) && !valid_test_config_labels.includes(label)) {
+  if (!valid_labels.includes(label)) {
     let body;
     if (label === "ciflow/all") {
       body =
@@ -186,15 +186,6 @@ async function handleLabelEvent(context: Context<"pull_request.labeled">) {
         issue_number: context.payload.pull_request.number,
       })
     );
-    return;
-  }
-
-  // TODO: Convert the test config label to tag is not yet supported and could
-  // only be done once we refactor the current workflows to support smaller
-  // workflow granularity per test config. After that, we can remove this check
-  // and do the same for these ciflow test config labels as what we are currently
-  // doing with ciflow/trunk, ciflow/periodic, and others
-  if (valid_test_config_labels.includes(label)) {
     return;
   }
 

--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -140,7 +140,7 @@ async function handleLabelEvent(context: Context<"pull_request.labeled">) {
     "ciflow/periodic",
     "ciflow/android",
     "ciflow/binaries",
-    "ciflow/experiment",
+    "ciflow/unstable",
     "ciflow/inductor",
     "ciflow/mps",
     "ciflow/nightly",
@@ -179,7 +179,7 @@ async function handleLabelEvent(context: Context<"pull_request.labeled">) {
     body +=
       " - `ciflow/binaries_wheel`: binary build and upload job for wheel\n";
     body +=
-      " - `ciflow/experiment`: run all experimental jobs\n";
+      " - `ciflow/unstable`: run all flaky or experimental jobs that are not yet stable enough to be part of pull or trunk\n";
     await context.octokit.issues.createComment(
       context.repo({
         body,


### PR DESCRIPTION
~~I call it `ciflow/experiment` to kind of water down its unstable nature.  Please feel free to suggest a better name if you have one in mind.~~

Also cleaning up the `ciflow/test-config-name` that I added a while back because we ends up not using `ciflow` for test config selection.

- [ ] Allow `ciflow/unstable` as a valid tag https://github.com/pytorch/test-infra/pull/1394
- [ ] Create the unstable workflow on PyTorch https://github.com/pytorch/pytorch/pull/92106
- [ ] Gather reliability metrics for ROCm runner
- [ ] Decide if we want to move ROCMs trunk jobs to the unstable workflow
- [ ] Add redness metrics for the unstable workflow