### PR TITLE
[flakybot] Fix for time diff between job complete and test uploading

### DIFF
--- a/torchci/rockset/commons/__sql/flaky_tests_across_jobs.sql
+++ b/torchci/rockset/commons/__sql/flaky_tests_across_jobs.sql
@@ -25,7 +25,6 @@ with failed_jobs as (
         w.head_branch,
         w.name as workflow_name,
         w.run_attempt as workflow_run_attempt,
-        job._event_time as event_time
     from
         commons.workflow_job job
         join commons.workflow_run w on w.id = job.run_id
@@ -63,7 +62,8 @@ flaky_tests as (
             test_run.failure is null,
             test_run.error.message,
             test_run.failure.message
-        ) as failure_or_err_message
+        ) as failure_or_err_message,
+        test_run._event_time as event_time
     from
         test_run_s3 test_run
         join flaky_jobs job on test_run.job_id = job.id

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -7,7 +7,7 @@
     "commit_failed_jobs": "7e5b39f3ec22b89f",
     "filter_forced_merge_pr": "7264f7c4160646ec",
     "flaky_tests": "a869115d6650c28c",
-    "flaky_tests_across_jobs": "8abcbbb06ce4c46c",
+    "flaky_tests_across_jobs": "49a1dd16770d2954",
     "flaky_workflows_jobs": "7cd42666f6eac62b",
     "slow_tests": "ef8d035d23aa8ab6",
     "test_time_per_file": "1c8d6289623181d8",


### PR DESCRIPTION
I noticed some tests didn't get flaky issues but the query seem to show them just fine, I forgot that that test stats don't get uploaded into rockset when the job finishes but rather when the workflow finishes, so the test for if the test was recent or not was using the wrong time