### PR TITLE
Fix Windows Miniconda3 to Python3.9 latest Miniconda3-py39_22.11.1-1-Windows-x86_64

### DIFF
--- a/aws/ami/windows/scripts/Installers/Install-Miniconda3.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-Miniconda3.ps1
@@ -32,3 +32,45 @@ if (-Not (Test-Path -Path $condaHook -PathType Leaf)) {
 
 # Clean up the temp file
 Remove-Item -Path "$downloadDir\*" -Recurse -Force -ErrorAction SilentlyContinue
+
+# https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles
+$PS_PROFILE = "$PSHOME\Microsoft.PowerShell_profile.ps1"
+
+$Env:PATH += ";$installationDir"
+# Add conda path to the powershell profile to make its commands available when logging in to Windows
+# runners, for example python
+Add-Content "$PS_PROFILE" '$Env:PATH += ' + "';$installationDir'"
+
+# According to https://docs.conda.io/en/latest/miniconda.html, Miniconda have only one built-in
+# python executable, and it can be Python3 or 2 depending on which installation package is used
+#
+# So we want to have an Python3 alias here in case it's referred to
+try {
+  $PYTHON = (Get-Command python).Source
+} catch {
+  $PYTHON = ""
+}
+
+If ("$PYTHON" -eq "") {
+  Write-Output "Found no Python in $Env:PATH. Double check that Miniconda3 is setup correctly in the AMI"
+}
+Else {
+  Write-Output "Found Python command at $PYTHON"
+}
+
+try {
+  $PYTHON3 = (Get-Command python3).Source
+} catch {
+  $PYTHON3 = ""
+}
+
+If ("$PYTHON3" -eq "") {
+  Write-Output "Found no Python 3 in $Env:PATH. This is expected for Miniconda3, and the command will be an alias to Python"
+}
+Else {
+  Write-Output "Found Python 3 command at $PYTHON3"
+}
+
+If (("$PYTHON3" -eq "") -and ("$PYTHON" -ne "")) {
+  Add-Content "$PS_PROFILE" "Set-Alias -Name python3 -Value $PYTHON"
+}


### PR DESCRIPTION
We need to fix Miniconda3 to 3.9 (latest Miniconda3-py39_22.11.1-1-Windows-x86_64) instead of using Miniconda3-latest-Windows-x86_64.  The latter nows use Python3.10 which will causes conflicts when installing conda dependencies.

This also makes `python` and `python3` command available when SSM into Windows runners or when PowerShell is used in the CI.

### Testing

Windows 2019 GHA CI - 20230117193537

us-east-1: ami-05762847639f4dd95
us-east-2: ami-0ed1deea6abeeed3b

https://github.com/pytorch/pytorch-canary/pull/158