### PR TITLE
[autolabel] Add heuristic for optim to add nn

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -54,6 +54,7 @@ const filenameRegexToReleaseCategory: [RegExp, string][] = [
   // nn_frontend => also did not exist
   [/test\/test_nn.py/gi, "release notes: nn"],
   [/test\/test_module.py/gi, "release notes: nn"],
+  [/torch\/optim/gi, "release notes: nn"],
   [/tools\/nn\/modules/gi, "release notes: nn"],
   [/tools\/nn\/functional.py/gi, "release notes: nn"],
   // jit

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -599,7 +599,7 @@ describe("auto-label-bot", () => {
     scope.done();
   });
 
-  test("topic: not user facing is added for unusing facing files", async () => {
+  test("topic: not user facing is added for unuser facing files", async () => {
     nock("https://api.github.com")
       .post("/app/installations/2/access_tokens")
       .reply(200, { token: "test" });


### PR DESCRIPTION
torch/optim files should trigger a release notes: nn label