### PR TITLE
Classify sccache errors

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -193,10 +193,6 @@ name = 'Python flaky unittest - errored'
 pattern = '^\s*(test.*) errored - num_retries_left:'
 
 [[rule]]
-name = 'sccache error'
-pattern = '^sccache: error: .*'
-
-[[rule]]
 name = 'Python RuntimeError'
 pattern = '^RuntimeError: .*'
 
@@ -219,6 +215,10 @@ pattern = 'An unexpected error has occurred. Conda has prepared the above report
 [[rule]]
 name = 'Docker error'
 pattern = '^docker: Error.*'
+
+[[rule]]
+name = 'sccache error'
+pattern = '^sccache: error: .*'
 
 [[rule]]
 name = 'GHA error'

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -193,6 +193,10 @@ name = 'Python flaky unittest - errored'
 pattern = '^\s*(test.*) errored - num_retries_left:'
 
 [[rule]]
+name = 'sccache error'
+pattern = '^sccache: error: .*'
+
+[[rule]]
 name = 'Python RuntimeError'
 pattern = '^RuntimeError: .*'
 


### PR DESCRIPTION
For example, this build failed because it timed out while waiting for the sccache server to startup
https://github.com/pytorch/pytorch/actions/runs/3946315315/jobs/6754126326

Relevant logs:

```
sccache: Starting the server...
sccache: error: Timed out waiting for server startup
Error: Process completed with exit code 2.
```