### PR TITLE
.github: Update scale-config to represent reality

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -135,6 +135,6 @@ runner_types:
   windows.g5.4xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: g5.4xlarge
-    is_ephemeral: true
+    is_ephemeral: false
     max_available: 150
     os: windows

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -123,18 +123,18 @@ runner_types:
   windows.4xlarge:
     disk_size: 256
     instance_type: c5d.4xlarge
-    is_ephemeral: false
+    is_ephemeral: true
     max_available: 420
     os: windows
   windows.8xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: p3.2xlarge
-    is_ephemeral: false
+    is_ephemeral: true
     max_available: 150
     os: windows
   windows.g5.4xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: g5.4xlarge
-    is_ephemeral: false
+    is_ephemeral: true
     max_available: 150
     os: windows


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1420
* __->__ #1419

Windows runners had a hardcoded --ephmeral flag in their setup so this
config value didn't actually mean anything

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>