### PR TITLE
infra: Remove hardcoded ephemeral flag, use config value

### DIFF
--- a/terraform-aws-github-runner/modules/runners/templates/install-config-runner.ps1
+++ b/terraform-aws-github-runner/modules/runners/templates/install-config-runner.ps1
@@ -47,7 +47,7 @@ foreach ($group in @("Administrators", "docker-users")) {
 Set-ItemProperty HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -Name ConsentPromptBehaviorAdmin -Value 0 -Force
 Write-Host "Disabled User Access Control (UAC)"
 
-$configCmd = ".\config.cmd --unattended --ephemeral --name $InstanceId --work `"_work`" $config"
+$configCmd = ".\config.cmd --unattended --name $InstanceId --work `"_work`" $config"
 Write-Host "Invoking config command..."
 Invoke-Expression $configCmd
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1420
* #1419

Windows were hardcoded to be ephemeral but we need the ability to
actually set these to be non-ephemeral

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>