### PR TITLE
[ez] Backfill PR logs as well

### DIFF
--- a/torchci/scripts/backfillJobs.mjs
+++ b/torchci/scripts/backfillJobs.mjs
@@ -164,7 +164,6 @@ from
     join commons.workflow_run w on w.id = j.run_id
 where
     j.torchci_classification is null
-    and w.head_branch = 'master'
     and j.conclusion in ('failure', 'cancelled')
     and PARSE_TIMESTAMP_ISO8601(j.completed_at) > CURRENT_DATETIME() - INTERVAL 30 MINUTE
     and j.name != 'ciflow_should_run'


### PR DESCRIPTION
no clue why i only did master at first

```
(forpytorch) csl@csl-mbp ~/zzzzzzzz/test-infra/torchci % yarn node scripts/backfillJobs.mjs
```