### PR TITLE
Show unstable failures as only warnings

### DIFF
--- a/torchci/components/CommitStatus.tsx
+++ b/torchci/components/CommitStatus.tsx
@@ -7,7 +7,7 @@ import _ from "lodash";
 import {
   isFailedJob,
   isRerunDisabledTestsJob,
-  isUnstableJobs,
+  isUnstableJob,
 } from "lib/jobUtils";
 import { linkIt, UrlComponent, urlRegex } from "react-linkify-it";
 import { getConclusionSeverityForSorting } from "../lib/JobClassifierUtil";
@@ -79,14 +79,14 @@ export default function CommitStatus({
         pred={(job) =>
           isFailedJob(job) &&
           !isRerunDisabledTestsJob(job) &&
-          !isUnstableJobs(job)
+          !isUnstableJob(job)
         }
         showClassification
       />
       <FilteredJobList
         filterName="Failed unstable jobs"
         jobs={jobs}
-        pred={(job) => isFailedJob(job) && isUnstableJobs(job)}
+        pred={(job) => isFailedJob(job) && isUnstableJob(job)}
       />
       <FilteredJobList
         filterName="Daily rerunning disabled jobs"

--- a/torchci/components/CommitStatus.tsx
+++ b/torchci/components/CommitStatus.tsx
@@ -4,7 +4,11 @@ import { CommitData, JobData } from "lib/types";
 import WorkflowBox from "./WorkflowBox";
 import styles from "components/commit.module.css";
 import _ from "lodash";
-import { isFailedJob, isRerunDisabledTestsJob } from "lib/jobUtils";
+import {
+  isFailedJob,
+  isRerunDisabledTestsJob,
+  isUnstableJobs,
+} from "lib/jobUtils";
 import { linkIt, UrlComponent, urlRegex } from "react-linkify-it";
 import { getConclusionSeverityForSorting } from "../lib/JobClassifierUtil";
 import useScrollTo from "lib/useScrollTo";
@@ -72,8 +76,17 @@ export default function CommitStatus({
       <FilteredJobList
         filterName="Failed jobs"
         jobs={jobs}
-        pred={(job) => isFailedJob(job) && !isRerunDisabledTestsJob(job)}
+        pred={(job) =>
+          isFailedJob(job) &&
+          !isRerunDisabledTestsJob(job) &&
+          !isUnstableJobs(job)
+        }
         showClassification
+      />
+      <FilteredJobList
+        filterName="Failed unstable jobs"
+        jobs={jobs}
+        pred={(job) => isFailedJob(job) && isUnstableJobs(job)}
       />
       <FilteredJobList
         filterName="Daily rerunning disabled jobs"

--- a/torchci/components/GroupJobConclusion.tsx
+++ b/torchci/components/GroupJobConclusion.tsx
@@ -7,7 +7,11 @@ import {
   JobCell,
   PinnedTooltipContext,
 } from "pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]]";
-import { isFailedJob, isRerunDisabledTestsJob } from "lib/jobUtils";
+import {
+  isFailedJob,
+  isRerunDisabledTestsJob,
+  isUnstableJobs,
+} from "lib/jobUtils";
 
 export enum JobStatus {
   Success = "success",
@@ -47,7 +51,7 @@ export default function HudGroupedCell({
   const failedPreviousRunJobs = [];
   for (const job of groupData.jobs) {
     if (isFailedJob(job)) {
-      if (isRerunDisabledTestsJob(job)) {
+      if (isRerunDisabledTestsJob(job) || isUnstableJobs(job)) {
         warningOnlyJobs.push(job);
       } else {
         erroredJobs.push(job);
@@ -57,7 +61,7 @@ export default function HudGroupedCell({
     } else if (job.conclusion === undefined) {
       noStatusJobs.push(job);
     } else if (job.conclusion === JobStatus.Success && job.failedPreviousRun) {
-      failedPreviousRunJobs.push(job)
+      failedPreviousRunJobs.push(job);
     }
   }
 

--- a/torchci/components/GroupJobConclusion.tsx
+++ b/torchci/components/GroupJobConclusion.tsx
@@ -10,7 +10,7 @@ import {
 import {
   isFailedJob,
   isRerunDisabledTestsJob,
-  isUnstableJobs,
+  isUnstableJob,
 } from "lib/jobUtils";
 
 export enum JobStatus {
@@ -51,7 +51,7 @@ export default function HudGroupedCell({
   const failedPreviousRunJobs = [];
   for (const job of groupData.jobs) {
     if (isFailedJob(job)) {
-      if (isRerunDisabledTestsJob(job) || isUnstableJobs(job)) {
+      if (isRerunDisabledTestsJob(job) || isUnstableJob(job)) {
         warningOnlyJobs.push(job);
       } else {
         erroredJobs.push(job);

--- a/torchci/components/JobConclusion.module.css
+++ b/torchci/components/JobConclusion.module.css
@@ -49,5 +49,5 @@
 }
 
 .warning {
-  color: lightpink;
+  color: #F8B88B;
 }

--- a/torchci/components/JobSummary.tsx
+++ b/torchci/components/JobSummary.tsx
@@ -3,7 +3,7 @@ import JobConclusion from "./JobConclusion";
 import {
   isFailedJob,
   isRerunDisabledTestsJob,
-  isUnstableJobs,
+  isUnstableJob,
 } from "lib/jobUtils";
 
 function BranchName({
@@ -36,7 +36,7 @@ export default function JobSummary({
         conclusion={job.conclusion}
         warningOnly={
           isFailedJob(job) &&
-          (isRerunDisabledTestsJob(job) || isUnstableJobs(job))
+          (isRerunDisabledTestsJob(job) || isUnstableJob(job))
         }
       />
       <a href={job.htmlUrl}> {job.jobName} </a>

--- a/torchci/components/JobSummary.tsx
+++ b/torchci/components/JobSummary.tsx
@@ -1,24 +1,43 @@
 import { JobData } from "lib/types";
 import JobConclusion from "./JobConclusion";
-import { isFailedJob, isRerunDisabledTestsJob } from "lib/jobUtils";
+import {
+  isFailedJob,
+  isRerunDisabledTestsJob,
+  isUnstableJobs,
+} from "lib/jobUtils";
 
-function BranchName({ name, highlight }: { name: string | undefined; highlight:boolean; }) {
+function BranchName({
+  name,
+  highlight,
+}: {
+  name: string | undefined;
+  highlight: boolean;
+}) {
   if (name) {
     if (highlight) {
-      return (<b> [{name}] </b>)
+      return <b> [{name}] </b>;
     } else {
-      return (<span>[{name}]</span>)
+      return <span>[{name}]</span>;
     }
   }
-  return <></>
+  return <></>;
 }
 
-export default function JobSummary({ job, highlight }: { job: JobData; highlight: boolean; }) {
+export default function JobSummary({
+  job,
+  highlight,
+}: {
+  job: JobData;
+  highlight: boolean;
+}) {
   return (
     <>
       <JobConclusion
         conclusion={job.conclusion}
-        warningOnly={isFailedJob(job) && isRerunDisabledTestsJob(job)}
+        warningOnly={
+          isFailedJob(job) &&
+          (isRerunDisabledTestsJob(job) || isUnstableJobs(job))
+        }
       />
       <a href={job.htmlUrl}> {job.jobName} </a>
       <BranchName name={job.branch} highlight={highlight} />
@@ -27,5 +46,5 @@ export default function JobSummary({ job, highlight }: { job: JobData; highlight
 }
 
 JobSummary.defaultProps = {
-  highlight: false
-}
+  highlight: false,
+};

--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -229,3 +229,7 @@ export function isPersistentGroup(name: string) {
     0
   );
 }
+
+export function isUnstableGroup(name: string) {
+  return name === "Unstable Jobs";
+}

--- a/torchci/lib/fetchHud.ts
+++ b/torchci/lib/fetchHud.ts
@@ -4,6 +4,10 @@ import getRocksetClient from "./rockset";
 import { HudParams, JobData, RowData } from "./types";
 import rocksetVersions from "rockset/prodVersions.json";
 import { isFailure } from "./JobClassifierUtil";
+import {
+  isRerunDisabledTestsJob,
+  isUnstableJob,
+} from "./jobUtils";
 
 export default async function fetchHud(params: HudParams): Promise<{
   shaGrid: RowData[];
@@ -67,8 +71,12 @@ export default async function fetchHud(params: HudParams): Promise<{
 
   const commitsBySha = _.keyBy(commits, "sha");
   let results = hudQuery.results;
+
   if (params.filter_reruns) {
-    results = results?.filter((job: JobData) => !job.name?.includes("rerun_disabled_tests"));
+    results = results?.filter((job: JobData) => !isRerunDisabledTestsJob(job));
+  }
+  if (params.filter_unstable) {
+    results = results?.filter((job: JobData) => !isUnstableJob(job));
   }
 
   const namesSet: Set<string> = new Set();

--- a/torchci/lib/jobUtils.ts
+++ b/torchci/lib/jobUtils.ts
@@ -8,8 +8,21 @@ export function isFailedJob(job: JobData) {
   );
 }
 
+export function isMatchingJobByName(job: JobData, name: string) {
+  // Somehow, JobData has both name and jobName field.  They can be populated
+  // by different rockset query, so we need to check both
+  return (
+    (job.name !== undefined && job.name.includes(name)) ||
+    (job.jobName !== undefined && job.jobName.includes(name))
+  );
+}
+
 export function isRerunDisabledTestsJob(job: JobData) {
   // Rerunning disabled tests are expected to fail from time to time depending
   // on the nature of the disabled tests, so we don't want to count them sometimes
-  return job.name !== undefined && job.name.includes("rerun_disabled_tests");
+  return isMatchingJobByName(job, "rerun_disabled_tests");
+}
+
+export function isUnstableJob(job: JobData) {
+  return isMatchingJobByName(job, "unstable");
 }

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -78,6 +78,7 @@ export interface HudParams {
   per_page: number;
   nameFilter?: string;
   filter_reruns: boolean;
+  filter_unstable: boolean;
 }
 
 export interface PRData {

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -140,6 +140,7 @@ export function packHudParams(input: any) {
     per_page: parseInt((input.per_page as string) ?? 50),
     nameFilter: input.name_filter as string | undefined,
     filter_reruns: input.filter_reruns ?? false as boolean,
+    filter_unstable: input.filter_unstable ?? false as boolean,
   };
 }
 
@@ -170,6 +171,10 @@ function formatHudURL(
 
   if (params.filter_reruns) {
     base += `&filter_reruns=true`
+  }
+
+  if (params.filter_unstable) {
+    base += `&filter_unstable=true`
   }
 
   if (params.nameFilter != null && keepFilter) {

--- a/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/failures/[queryParams].ts
+++ b/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/failures/[queryParams].ts
@@ -6,7 +6,7 @@ import { RocksetParam } from "lib/rockset";
 import rocksetVersions from "rockset/prodVersions.json";
 
 async function fetchFailureJobs(
-  queryParams: RocksetParam[],
+  queryParams: RocksetParam[]
 ): Promise<JobData[]> {
   const rocksetClient = getRocksetClient();
   const failedJobs = await rocksetClient.queryLambdas.executeQueryLambda(

--- a/torchci/pages/failedjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/failedjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -14,7 +14,7 @@ import JobAnnotationToggle, {
 import { JobData } from "lib/types";
 import { TimeRangePicker } from "pages/metrics";
 import dayjs from "dayjs";
-import { isRerunDisabledTestsJob, isUnstableJobs } from "lib/jobUtils";
+import { isRerunDisabledTestsJob, isUnstableJob } from "lib/jobUtils";
 
 function CommitLink({ job }: { job: JobData }) {
   return (
@@ -171,7 +171,7 @@ function FailedJobs({
   } = {};
 
   _.forEach(_.sortBy(failedJobs, ["jobName"]), (job) => {
-    if (isRerunDisabledTestsJob(job) || isUnstableJobs(job)) {
+    if (isRerunDisabledTestsJob(job) || isUnstableJob(job)) {
       return;
     }
 

--- a/torchci/pages/failedjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/failedjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -14,6 +14,7 @@ import JobAnnotationToggle, {
 import { JobData } from "lib/types";
 import { TimeRangePicker } from "pages/metrics";
 import dayjs from "dayjs";
+import { isRerunDisabledTestsJob, isUnstableJobs } from "lib/jobUtils";
 
 function CommitLink({ job }: { job: JobData }) {
   return (
@@ -50,15 +51,17 @@ function SimilarFailedJobs({
         style={{ background: "none", cursor: "pointer" }}
         onClick={handleClick}
       >
-       {showDetail ? "▼ " : "▶ "}
+        {showDetail ? "▼ " : "▶ "}
         <code>Failing {similarJobs.length} times</code>
       </button>
-      {showDetail && _.map(similarJobs, (job) => (
-        <FailedJob
-          job={job}
-          similarJobs={[]}
-          classification={classification}
-        />))}
+      {showDetail &&
+        _.map(similarJobs, (job) => (
+          <FailedJob
+            job={job}
+            similarJobs={[]}
+            classification={classification}
+          />
+        ))}
     </div>
   );
 }
@@ -76,7 +79,7 @@ function FailedJob({
 
   return (
     <div style={{ padding: "10px" }}>
-      <li key={ job.id }>
+      <li key={job.id}>
         <JobSummary job={job} />
         <div>
           <CommitLink job={job} />
@@ -91,14 +94,13 @@ function FailedJob({
           />
         </div>
         <LogViewer job={job} />
-        {
-          hasSimilarJobs &&
+        {hasSimilarJobs && (
           <SimilarFailedJobs
             job={job}
             similarJobs={similarJobs}
             classification={classification}
           />
-        }
+        )}
       </li>
     </div>
   );
@@ -108,15 +110,15 @@ function FailedJobsByFailure({
   jobs,
   annotations,
 }: {
-  jobs: JobData[],
-  annotations: { [id: string]: { [key: string]: any } },
+  jobs: JobData[];
+  annotations: { [id: string]: { [key: string]: any } };
 }) {
   // Select a random representative job in the group of similar jobs. Once
   // this job is classified, the rest will be put into the same category
   const job: JobData | undefined = _.sample(jobs);
 
   if (job === undefined) {
-    return (<></>);
+    return <></>;
   }
 
   return (
@@ -164,11 +166,15 @@ function FailedJobs({
   // Grouped by annotation then by job name
   const groupedJobs: {
     [annotation: string]: {
-      [name: string]: JobData[]
-    }
+      [name: string]: JobData[];
+    };
   } = {};
 
   _.forEach(_.sortBy(failedJobs, ["jobName"]), (job) => {
+    if (isRerunDisabledTestsJob(job) || isUnstableJobs(job)) {
+      return;
+    }
+
     const annotation = annotations[job.id.toString()]
       ? annotations[job.id.toString()].annotation
       : "Not Annotated";
@@ -183,14 +189,14 @@ function FailedJobs({
 
     // The failure message might include some variants such as timestamp, so we need
     // to clean that up
-    const failureCaptures = (job.failureCaptures ?? "");
+    const failureCaptures = job.failureCaptures ?? "";
 
     const failure = jobName + workflowName + failureCaptures;
     if (!(failure in groupedJobs[annotation])) {
-      groupedJobs[annotation][failure] = []
+      groupedJobs[annotation][failure] = [];
     }
 
-    groupedJobs[annotation][failure].push(job)
+    groupedJobs[annotation][failure].push(job);
   });
 
   return (
@@ -205,14 +211,19 @@ function FailedJobs({
               fontWeight: "bold",
             }}
           >
-            {key} ({_.reduce(groupedJobsByFailure, (s, v) => { return s + v.length; }, 0)})
+            {key} (
+            {_.reduce(
+              groupedJobsByFailure,
+              (s, v) => {
+                return s + v.length;
+              },
+              0
+            )}
+            )
           </summary>
           <ul>
             {_.map(groupedJobsByFailure, (jobs, failure) => (
-              <FailedJobsByFailure
-                jobs={jobs}
-                annotations={annotations}
-              />
+              <FailedJobsByFailure jobs={jobs} annotations={annotations} />
             ))}
           </ul>
         </details>
@@ -249,9 +260,9 @@ export default function Page() {
       value: `${branch}`,
     },
     {
-      "name": "count",
-      "type": "int",
-      "value": "0",   // Set the count to 0 to query all failures
+      name: "count",
+      type: "int",
+      value: "0", // Set the count to 0 to query all failures
     },
   ];
 

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -26,16 +26,14 @@ import useGroupingPreference from "lib/useGroupingPreference";
 import React, { createContext, useContext, useEffect, useState } from "react";
 import PageSelector from "components/PageSelector";
 import useSWR from "swr";
-import { isFailedJob, isRerunDisabledTestsJob } from "lib/jobUtils";
+import {
+  isFailedJob,
+  isRerunDisabledTestsJob,
+  isUnstableJobs,
+} from "lib/jobUtils";
 import { fetcher } from "lib/GeneralUtils";
 
-export function JobCell({
-  sha,
-  job,
-}: {
-  sha: string;
-  job: JobData;
-}) {
+export function JobCell({ sha, job }: { sha: string; job: JobData }) {
   const [pinnedId, setPinnedId] = useContext(PinnedTooltipContext);
   return (
     <td onDoubleClick={() => window.open(job.htmlUrl)}>
@@ -49,7 +47,10 @@ export function JobCell({
           conclusion={job.conclusion}
           failedPreviousRun={job.failedPreviousRun}
           classified={job.failureAnnotation != null}
-          warningOnly={isFailedJob(job) && isRerunDisabledTestsJob(job)}
+          warningOnly={
+            isFailedJob(job) &&
+            (isRerunDisabledTestsJob(job) || isUnstableJobs(job))
+          }
         />
       </TooltipTarget>
     </td>
@@ -142,7 +143,9 @@ function HudJobCells({
               numClassified++;
             }
           }
-          const failedJobs = rowData.groupedJobs?.get(name)?.jobs.filter(isFailedJob);
+          const failedJobs = rowData.groupedJobs
+            ?.get(name)
+            ?.jobs.filter(isFailedJob);
           return (
             <HudGroupedCell
               sha={rowData.sha}
@@ -156,13 +159,7 @@ function HudJobCells({
           );
         } else {
           const job = rowData.nameToJobs?.get(name);
-          return (
-            <JobCell
-              sha={rowData.sha}
-              key={name}
-              job={job!}
-            />
-          );
+          return <JobCell sha={rowData.sha} key={name} job={job!} />;
         }
       })}
     </>

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -29,7 +29,7 @@ import useSWR from "swr";
 import {
   isFailedJob,
   isRerunDisabledTestsJob,
-  isUnstableJobs,
+  isUnstableJob,
 } from "lib/jobUtils";
 import { fetcher } from "lib/GeneralUtils";
 
@@ -49,7 +49,7 @@ export function JobCell({ sha, job }: { sha: string; job: JobData }) {
           classified={job.failureAnnotation != null}
           warningOnly={
             isFailedJob(job) &&
-            (isRerunDisabledTestsJob(job) || isUnstableJobs(job))
+            (isRerunDisabledTestsJob(job) || isUnstableJob(job))
           }
         />
       </TooltipTarget>

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -198,6 +198,8 @@ function GroupFilterableHudTable({
   setExpandedGroups,
   useGrouping,
   setUseGrouping,
+  hideUnstable,
+  setHideUnstable
 }: {
   params: HudParams;
   groupNameMapping: Map<string, string[]>;
@@ -207,6 +209,8 @@ function GroupFilterableHudTable({
   setExpandedGroups: React.Dispatch<React.SetStateAction<Set<string>>>;
   useGrouping: boolean;
   setUseGrouping: any;
+  hideUnstable: bookean;
+  setHideUnstable: any;
 }) {
   const { jobFilter, handleSubmit, handleInput, normalizedJobFilter } =
     useTableFilter(params);
@@ -224,6 +228,10 @@ function GroupFilterableHudTable({
       <GroupViewCheckBox
         useGrouping={useGrouping}
         setUseGrouping={setUseGrouping}
+      />
+      <UnstableCheckBox
+        hideUnstable={hideUnstable}
+        setHideUnstable={setHideUnstable}
       />
       <table className={styles.hudTable}>
         <GroupHudTableColumns
@@ -260,6 +268,27 @@ function GroupViewCheckBox({
       >
         <input type="checkbox" name="groupView" checked={useGrouping} />
         <label htmlFor="groupView"> Use grouped view</label>
+      </div>
+    </>
+  );
+}
+
+function UnstableCheckBox({
+  hideUnstable,
+  setHideUnstable,
+}: {
+  hideUnstable: boolean;
+  setHideUnstable: any;
+}) {
+  return (
+    <>
+      <div
+        onClick={() => {
+          setHideUnstable(!hideUnstable);
+        }}
+      >
+        <input type="checkbox" name="hideUnstable" checked={hideUnstable} />
+        <label htmlFor="hideUnstable"> Hide unstable jobs</label>
       </div>
       <br />
     </>
@@ -407,6 +436,8 @@ function GroupedHudTable({
   const [useGrouping, setUseGrouping] = useGroupingPreference(
     params.nameFilter != null && params.nameFilter !== ""
   );
+  const [hideUnstable, setHideUnstable] = useState<boolean>(true);
+
   const groupNames = Array.from(groupNameMapping.keys());
   let names = groupNames;
 
@@ -443,6 +474,8 @@ function GroupedHudTable({
       setExpandedGroups={setExpandedGroups}
       useGrouping={useGrouping}
       setUseGrouping={setUseGrouping}
+      hideUnstable={hideUnstable}
+      setHideUnstable={setHideUnstable}
     >
       <HudTableBody
         shaGrid={shaGrid}

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -204,7 +204,7 @@ function GroupFilterableHudTable({
   useGrouping,
   setUseGrouping,
   hideUnstable,
-  setHideUnstable
+  setHideUnstable,
 }: {
   params: HudParams;
   groupNameMapping: Map<string, string[]>;

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -214,7 +214,7 @@ function GroupFilterableHudTable({
   setExpandedGroups: React.Dispatch<React.SetStateAction<Set<string>>>;
   useGrouping: boolean;
   setUseGrouping: any;
-  hideUnstable: bookean;
+  hideUnstable: boolean;
   setHideUnstable: any;
 }) {
   const { jobFilter, handleSubmit, handleInput, normalizedJobFilter } =

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -13,6 +13,7 @@ import {
   getGroupingData,
   groups,
   isPersistentGroup,
+  isUnstableGroup,
 } from "lib/JobClassifierUtil";
 import {
   formatHudUrlForRoute,
@@ -294,7 +295,6 @@ function UnstableCheckBox({
         <input type="checkbox" name="hideUnstable" checked={hideUnstable} />
         <label htmlFor="hideUnstable"> Hide unstable jobs</label>
       </div>
-      <br />
     </>
   );
 }
@@ -451,6 +451,10 @@ function GroupedHudTable({
     )
   );
 
+  if (hideUnstable) {
+    names = names.filter((name) => !isUnstableGroup(name));
+  }
+
   if (useGrouping) {
     expandedGroups.forEach((group) => {
       const nameInd = names.indexOf(group);
@@ -463,6 +467,10 @@ function GroupedHudTable({
   } else {
     names = [...data.jobNames];
     groups.forEach((group) => {
+      if (hideUnstable && isUnstableGroup(group.name)) {
+        return;
+      }
+
       if (isPersistentGroup(group.name)) {
         names.push(group.name);
         names = names.filter(


### PR DESCRIPTION
Same as https://github.com/pytorch/test-infra/pull/1344 to show unstable failures as only warnings:

* Lighter red (#F8B88B)
* Group failed unstable job in a separate section from failed jobs
* Yarn format some files
* Hide unstable jobs by defaults