### PR TITLE
Add a log classifier rule for Docker failures

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -221,5 +221,9 @@ name = 'sccache error'
 pattern = '^sccache: error: .*'
 
 [[rule]]
+name = 'Docker error'
+pattern = '^Error response from daemon: .*'
+
+[[rule]]
 name = 'GHA error'
 pattern = '^##\[error\](.*)'

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -221,7 +221,7 @@ name = 'sccache error'
 pattern = '^sccache: error: .*'
 
 [[rule]]
-name = 'Generic Docker error'
+name = 'Docker daemon error'
 pattern = '^Error response from daemon: .*'
 
 [[rule]]

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -221,7 +221,7 @@ name = 'sccache error'
 pattern = '^sccache: error: .*'
 
 [[rule]]
-name = 'Docker error'
+name = 'Generic Docker error'
 pattern = '^Error response from daemon: .*'
 
 [[rule]]

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -225,5 +225,9 @@ name = 'Docker daemon error'
 pattern = '^Error response from daemon: .*'
 
 [[rule]]
+name = 'Out of space error'
+pattern = 'no space left on device'
+
+[[rule]]
 name = 'GHA error'
 pattern = '^##\[error\](.*)'


### PR DESCRIPTION
Given some recent issues:

* with Docker https://hud.pytorch.org/pytorch/pytorch/commit/afe6ea884fa21d424d614efff6bd3a75ec4357af (Docker daemon error)
* with ROCm https://hud.pytorch.org/pytorch/pytorch/commit/9c6433ce48c27f4b6ecf585bf6049176c217bbbe (out of space)