### PR TITLE
torchci: Add ability to check nightly for alerts

### DIFF
--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -1,5 +1,9 @@
 name: Check Alerts
 on:
+  pull_request:
+    paths:
+      - .github/workflows/check-alerts.yml
+      - torchci/scripts/check_alerts.py
   schedule:
     # Every 5 minutes
     - cron: "*/5 * * * *"
@@ -9,6 +13,21 @@ on:
 
 jobs:
   update-alerts:
+    strategy:
+      matrix:
+        include:
+          - repo: pytorch/pytorch
+            branch: master
+            with_flaky_test_alerting: YES
+          - repo: pytorch/pytorch
+            branch: nightly
+            with_flaky_test_alerting: NO
+    env:
+      REPO_TO_CHECK: ${{ matrix.repo }}
+      BRANCH_TO_CHECK: ${{ matrix.branch }}
+      WITH_FLAKY_TEST_ALERTING: ${{ matrix.with_flaky_test_alerting }}
+      # Don't do actual work on pull request
+      DRY_RUN: ${{ github.event_name == 'pull_request'}}
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
@@ -16,8 +35,12 @@ jobs:
       - name: Install requests
         run: |
            pip3 install requests
+      - name: Run tests
+        run: |
+          python3 torchci/scripts/test_check_alerts.py
       - name: Check for alerts and creates issue
         run: |
           python3 torchci/scripts/check_alerts.py
         env:
+          # NOTE: Should be a blank string for pull requests
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install requests
         run: |
-           pip3 install requests
+           pip3 install requests setuptools
       - name: Run tests
         run: |
           python3 torchci/scripts/test_check_alerts.py

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -248,16 +248,17 @@ def gen_update_comment(original_body: str, jobs: List[JobStatus]) -> str:
     stopped_failing_jobs = [job for job in original_jobs if job not in new_jobs]
     started_failing_jobs = [job for job in new_jobs if job not in original_jobs]
 
+    # TODO: Add real HUD links to these eventually since not having clickable links is bad
     s = ""
     if len(stopped_failing_jobs) > 0:
         s += "These jobs stopped failing:\n"
         for job in stopped_failing_jobs:
-            s += f"* {generate_failed_job_hud_link(job)}\n"
+            s += f"* {job}\n"
         s += "\n"
     if len(started_failing_jobs) > 0:
         s += "These jobs started failing:\n"
         for job in started_failing_jobs:
-            s += f"* {generate_failed_job_hud_link(job)}\n"
+            s += f"* {job}\n"
     return s
 
 
@@ -483,7 +484,7 @@ def check_for_no_flaky_tests_alert():
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--repo", help="Repository to do checks for", type=str, default=os.getenv("BRANCH_TO_CHECK", "pytorch/pytorch"))
+    parser.add_argument("--repo", help="Repository to do checks for", type=str, default=os.getenv("REPO_TO_CHECK", "pytorch/pytorch"))
     parser.add_argument("--branch", help="Branch to do checks for", type=str, default=os.getenv("BRANCH_TO_CHECK", "master"))
     parser.add_argument("--dry-run", help="", action='store_true')
     return parser.parse_args()

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 from difflib import SequenceMatcher
 from email.policy import default
 from typing import Any, Dict, List, Tuple
+from setuptools import distutils  # type: ignore[import]
 
 import requests
 
@@ -484,9 +485,30 @@ def check_for_no_flaky_tests_alert():
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--repo", help="Repository to do checks for", type=str, default=os.getenv("REPO_TO_CHECK", "pytorch/pytorch"))
-    parser.add_argument("--branch", help="Branch to do checks for", type=str, default=os.getenv("BRANCH_TO_CHECK", "master"))
-    parser.add_argument("--dry-run", help="", action='store_true')
+    parser.add_argument(
+        "--repo",
+        help="Repository to do checks for",
+        type=str,
+        default=os.getenv("REPO_TO_CHECK", "pytorch/pytorch")
+    )
+    parser.add_argument(
+        "--branch",
+        help="Branch to do checks for",
+        type=str,
+        default=os.getenv("BRANCH_TO_CHECK", "master")
+    )
+    parser.add_argument(
+        "--with-flaky-test-alert",
+        help="Run this script with the flaky test alerting",
+        type=distutils.util.strtobool,
+        default=os.getenv("WITH_FLAKY_TEST_ALERT", "NO")
+    )
+    parser.add_argument(
+        "--dry-run",
+        help="Whether or not to actually post issues",
+        type=distutils.util.strtobool,
+        default=os.getenv("DRY_RUN", "YES")
+    )
     return parser.parse_args()
 
 
@@ -494,7 +516,7 @@ def main():
     args = parse_args()
     check_for_recurrently_failing_jobs_alert(args.repo, args.branch, args.dry_run)
     # TODO: Fill out dry run for flaky test alerting, not going to do in one PR
-    if not args.dry_run:
+    if args.with_flaky_test_alert:
         check_for_no_flaky_tests_alert()
 
 


### PR DESCRIPTION
Adds the ability to check nightly for alerting as well as create separate issues for separate branches.

Also makes it so that this script isn't hardcoded to 'pytorch/pytorch' and adds a dry-run mode so that we can skip doing real work if you're just developing this script.

Base line functionality shouldn't change with this aside from the following:

* Removed code blocks when posting the update comment and instead replaced it with a link to hud (minihud) so that it's clickable

After this we'll need to create an internal butterfly rule to manage these internally.

<details>
<summary> Click me for dry run details </summary>

```
❯ python3 check_alerts.py --dry-run --repo pytorch/pytorch --branch nightly
The first green SHA was at index -1 at d80585d52dba17745a8eecb4dbdbfdcba5f254bband the first red SHA was at index 0 at 6f611c50305244c6f365e123c49fb4e5ce7eadf0
Generating alerts for:  [jobName: Build Official Docker Images / build (devel, linux/amd64), jobName: Build Official Docker Images / build (runtime, linux/arm64,linux/amd64), jobName: binary_ios_upload-1 / build, jobName: linux-binary-conda / conda-py3_10-cuda11_6-build / build, jobName: linux-binary-conda / conda-py3_10-cuda11_7-build / build, jobName: linux-binary-conda / conda-py3_10-cuda11_8-build / build, jobName: linux-binary-conda / conda-py3_7-cuda11_6-build / build, jobName: linux-binary-conda / conda-py3_7-cuda11_7-build / build, jobName: linux-binary-conda / conda-py3_7-cuda11_8-build / build, jobName: linux-binary-conda / conda-py3_8-cuda11_6-build / build, jobName: linux-binary-conda / conda-py3_8-cuda11_7-build / build, jobName: linux-binary-conda / conda-py3_8-cuda11_8-build / build, jobName: linux-binary-conda / conda-py3_9-cuda11_6-build / build, jobName: linux-binary-conda / conda-py3_9-cuda11_7-build / build, jobName: linux-binary-conda / conda-py3_9-cuda11_8-build / build, jobName: linux-binary-libtorch-cxx11-abi / libtorch-cuda11_6-shared-with-deps-cxx11-abi-build / build, jobName: linux-binary-libtorch-cxx11-abi / libtorch-cuda11_6-static-with-deps-cxx11-abi-build / build, jobName: linux-binary-libtorch-cxx11-abi / libtorch-rocm5_3-shared-with-deps-cxx11-abi-test, jobName: linux-binary-libtorch-cxx11-abi / libtorch-rocm5_3-static-with-deps-cxx11-abi-test, jobName: linux-binary-libtorch-pre-cxx11 / libtorch-cuda11_6-shared-with-deps-pre-cxx11-build / build, jobName: linux-binary-libtorch-pre-cxx11 / libtorch-cuda11_6-static-with-deps-pre-cxx11-build / build, jobName: windows-binary-libtorch-debug / libtorch-cuda11_8-shared-with-deps-debug-build, jobName: windows-binary-libtorch-debug / libtorch-cuda11_8-shared-without-deps-debug-build, jobName: windows-binary-libtorch-debug / libtorch-cuda11_8-static-with-deps-debug-build, jobName: windows-binary-libtorch-debug / libtorch-cuda11_8-static-without-deps-debug-build]
Creating issue with content:
{'title': '[Pytorch] There are 25 Recurrently Failing Jobs on pytorch/pytorch nightly', 'body': 'Within the last 50 commits, there are the following failures on the master branch of pytorch: \n- [Build Official Docker Images / build (devel, linux/amd64)](https://hud.pytorch.org/minihud?name_filter=Build%20Official%20Docker%20Images%20/%20build%20%28devel%2C%20linux/amd64%29) failed consecutively starting with commit [7277d5a8f088683be4265aa36ce28b96316a8009](https://hud.pytorch.org/commit/pytorch/pytorch/7277d5a8f088683be4265aa36ce28b96316a8009)\n\n- [Build Official Docker Images / build (runtime, linux/arm64,linux/amd64)](https://hud.pytorch.org/minihud?name_filter=Build%20Official%20Docker%20Images%20/%20build%20%28runtime%2C%20linux/arm64%2Clinux/amd64%29) failed consecutively starting with commit [7277d5a8f088683be4265aa36ce28b96316a8009](https://hud.pytorch.org/commit/pytorch/pytorch/7277d5a8f088683be4265aa36ce28b96316a8009)\n\n- [binary_ios_upload-1 / build](https://hud.pytorch.org/minihud?name_filter=binary_ios_upload-1%20/%20build) failed consecutively starting with commit [d80585d52dba17745a8eecb4dbdbfdcba5f254bb](https://hud.pytorch.org/commit/pytorch/pytorch/d80585d52dba17745a8eecb4dbdbfdcba5f254bb)\n\n- [linux-binary-conda / conda-py3_10-cuda11_6-build / build](https://hud.pytorch.org/minihud?name_filter=linux-binary-conda%20/%20conda-py3_10-cuda11_6-build%20/%20build) failed consecutively starting with commit [f960e5c8ae2482a03a3f525457a922e9209bc00d](https://hud.pytorch.org/commit/pytorch/pytorch/f960e5c8ae2482a03a3f525457a922e9209bc00d)\n\n- [linux-binary-conda / conda-py3_10-cuda11_7-build / build](https://hud.pytorch.org/minihud?name_filter=linux-binary-conda%20/%20conda-py3_10-cuda11_7-build%20/%20build) failed consecutively starting with commit [f960e5c8ae2482a03a3f525457a922e9209bc00d](https://hud.pytorch.org/commit/pytorch/pytorch/f960e5c8ae2482a03a3f525457a922e9209bc00d)\n\n- [linux-binary-conda / conda-py3_10-cuda11_8-build / build](https://hud.pytorch.org/minihud?name_filter=linux-binary-conda%20/%20conda-py3_10-cuda11_8-build%20/%20build) failed consecutively starting with commit [f960e5c8ae2482a03a3f525457a922e9209bc00d](https://hud.pytorch.org/commit/pytorch/pytorch/f960e5c8ae2482a03a3f525457a922e9209bc00d)\n\n- [linux-binary-conda / conda-py3_7-cuda11_6-build / build](https://hud.pytorch.org/minihud?name_filter=linux-binary-conda%20/%20conda-py3_7-cuda11_6-build%20/%20build) failed consecutively starting with commit [f960e5c8ae2482a03a3f525457a922e9209bc00d](https://hud.pytorch.org/commit/pytorch/pytorch/f960e5c8ae2482a03a3f525457a922e9209bc00d)\n\n- [linux-binary-conda / conda-py3_7-cuda11_7-build / build](https://hud.pytorch.org/minihud?name_filter=linux-binary-conda%20/%20conda-py3_7-cuda11_7-build%20/%20build) failed consecutively starting with commit [f960e5c8ae2482a03a3f525457a922e9209bc00d](https://hud.pytorch.org/commit/pytorch/pytorch/f960e5c8ae2482a03a3f525457a922e9209bc00d)\n\n- [linux-binary-conda / conda-py3_7-cuda11_8-build / build](https://hud.pytorch.org/minihud?name_filter=linux-binary-conda%20/%20conda-py3_7-cuda11_8-build%20/%20build) failed consecutively starting with commit [f960e5c8ae2482a03a3f525457a922e9209bc00d](https://hud.pytorch.org/commit/pytorch/pytorch/f960e5c8ae2482a03a3f525457a922e9209bc00d)\n\n- [linux-binary-conda / conda-py3_8-cuda11_6-build / build](https://hud.pytorch.org/minihud?name_filter=linux-binary-conda%20/%20conda-py3_8-cuda11_6-build%20/%20build) failed consecutively starting with commit [f960e5c8ae2482a03a3f525457a922e9209bc00d](https://hud.pytorch.org/commit/pytorch/pytorch/f960e5c8ae2482a03a3f525457a922e9209bc00d)\n\n- [linux-binary-conda / conda-py3_8-cuda11_7-build / build](https://hud.pytorch.org/minihud?name_filter=linux-binary-conda%20/%20conda-py3_8-cuda11_7-build%20/%20build) failed consecutively starting with commit [f960e5c8ae2482a03a3f525457a922e9209bc00d](https://hud.pytorch.org/commit/pytorch/pytorch/f960e5c8ae2482a03a3f525457a922e9209bc00d)\n\n- [linux-binary-conda / conda-py3_8-cuda11_8-build / build](https://hud.pytorch.org/minihud?name_filter=linux-binary-conda%20/%20conda-py3_8-cuda11_8-build%20/%20build) failed consecutively starting with commit [f960e5c8ae2482a03a3f525457a922e9209bc00d](https://hud.pytorch.org/commit/pytorch/pytorch/f960e5c8ae2482a03a3f525457a922e9209bc00d)\n\n- [linux-binary-conda / conda-py3_9-cuda11_6-build / build](https://hud.pytorch.org/minihud?name_filter=linux-binary-conda%20/%20conda-py3_9-cuda11_6-build%20/%20build) failed consecutively starting with commit [f960e5c8ae2482a03a3f525457a922e9209bc00d](https://hud.pytorch.org/commit/pytorch/pytorch/f960e5c8ae2482a03a3f525457a922e9209bc00d)\n\n- [linux-binary-conda / conda-py3_9-cuda11_7-build / build](https://hud.pytorch.org/minihud?name_filter=linux-binary-conda%20/%20conda-py3_9-cuda11_7-build%20/%20build) failed consecutively starting with commit [f960e5c8ae2482a03a3f525457a922e9209bc00d](https://hud.pytorch.org/commit/pytorch/pytorch/f960e5c8ae2482a03a3f525457a922e9209bc00d)\n\n- [linux-binary-conda / conda-py3_9-cuda11_8-build / build](https://hud.pytorch.org/minihud?name_filter=linux-binary-conda%20/%20conda-py3_9-cuda11_8-build%20/%20build) failed consecutively starting with commit [f960e5c8ae2482a03a3f525457a922e9209bc00d](https://hud.pytorch.org/commit/pytorch/pytorch/f960e5c8ae2482a03a3f525457a922e9209bc00d)\n\n- [linux-binary-libtorch-cxx11-abi / libtorch-cuda11_6-shared-with-deps-cxx11-abi-build / build](https://hud.pytorch.org/minihud?name_filter=linux-binary-libtorch-cxx11-abi%20/%20libtorch-cuda11_6-shared-with-deps-cxx11-abi-build%20/%20build) failed consecutively starting with commit [f960e5c8ae2482a03a3f525457a922e9209bc00d](https://hud.pytorch.org/commit/pytorch/pytorch/f960e5c8ae2482a03a3f525457a922e9209bc00d)\n\n- [linux-binary-libtorch-cxx11-abi / libtorch-cuda11_6-static-with-deps-cxx11-abi-build / build](https://hud.pytorch.org/minihud?name_filter=linux-binary-libtorch-cxx11-abi%20/%20libtorch-cuda11_6-static-with-deps-cxx11-abi-build%20/%20build) failed consecutively starting with commit [f960e5c8ae2482a03a3f525457a922e9209bc00d](https://hud.pytorch.org/commit/pytorch/pytorch/f960e5c8ae2482a03a3f525457a922e9209bc00d)\n\n- [linux-binary-libtorch-cxx11-abi / libtorch-rocm5_3-shared-with-deps-cxx11-abi-test](https://hud.pytorch.org/minihud?name_filter=linux-binary-libtorch-cxx11-abi%20/%20libtorch-rocm5_3-shared-with-deps-cxx11-abi-test) failed consecutively starting with commit [06f81fdbf8817cd986f77ec2c67f50489a40ecf9](https://hud.pytorch.org/commit/pytorch/pytorch/06f81fdbf8817cd986f77ec2c67f50489a40ecf9)\n\n- [linux-binary-libtorch-cxx11-abi / libtorch-rocm5_3-static-with-deps-cxx11-abi-test](https://hud.pytorch.org/minihud?name_filter=linux-binary-libtorch-cxx11-abi%20/%20libtorch-rocm5_3-static-with-deps-cxx11-abi-test) failed consecutively starting with commit [06f81fdbf8817cd986f77ec2c67f50489a40ecf9](https://hud.pytorch.org/commit/pytorch/pytorch/06f81fdbf8817cd986f77ec2c67f50489a40ecf9)\n\n- [linux-binary-libtorch-pre-cxx11 / libtorch-cuda11_6-shared-with-deps-pre-cxx11-build / build](https://hud.pytorch.org/minihud?name_filter=linux-binary-libtorch-pre-cxx11%20/%20libtorch-cuda11_6-shared-with-deps-pre-cxx11-build%20/%20build) failed consecutively starting with commit [f960e5c8ae2482a03a3f525457a922e9209bc00d](https://hud.pytorch.org/commit/pytorch/pytorch/f960e5c8ae2482a03a3f525457a922e9209bc00d)\n\n- [linux-binary-libtorch-pre-cxx11 / libtorch-cuda11_6-static-with-deps-pre-cxx11-build / build](https://hud.pytorch.org/minihud?name_filter=linux-binary-libtorch-pre-cxx11%20/%20libtorch-cuda11_6-static-with-deps-pre-cxx11-build%20/%20build) failed consecutively starting with commit [f960e5c8ae2482a03a3f525457a922e9209bc00d](https://hud.pytorch.org/commit/pytorch/pytorch/f960e5c8ae2482a03a3f525457a922e9209bc00d)\n\n- [windows-binary-libtorch-debug / libtorch-cuda11_8-shared-with-deps-debug-build](https://hud.pytorch.org/minihud?name_filter=windows-binary-libtorch-debug%20/%20libtorch-cuda11_8-shared-with-deps-debug-build) failed consecutively starting with commit [f960e5c8ae2482a03a3f525457a922e9209bc00d](https://hud.pytorch.org/commit/pytorch/pytorch/f960e5c8ae2482a03a3f525457a922e9209bc00d)\n\n- [windows-binary-libtorch-debug / libtorch-cuda11_8-shared-without-deps-debug-build](https://hud.pytorch.org/minihud?name_filter=windows-binary-libtorch-debug%20/%20libtorch-cuda11_8-shared-without-deps-debug-build) failed consecutively starting with commit [f960e5c8ae2482a03a3f525457a922e9209bc00d](https://hud.pytorch.org/commit/pytorch/pytorch/f960e5c8ae2482a03a3f525457a922e9209bc00d)\n\n- [windows-binary-libtorch-debug / libtorch-cuda11_8-static-with-deps-debug-build](https://hud.pytorch.org/minihud?name_filter=windows-binary-libtorch-debug%20/%20libtorch-cuda11_8-static-with-deps-debug-build) failed consecutively starting with commit [f960e5c8ae2482a03a3f525457a922e9209bc00d](https://hud.pytorch.org/commit/pytorch/pytorch/f960e5c8ae2482a03a3f525457a922e9209bc00d)\n\n- [windows-binary-libtorch-debug / libtorch-cuda11_8-static-without-deps-debug-build](https://hud.pytorch.org/minihud?name_filter=windows-binary-libtorch-debug%20/%20libtorch-cuda11_8-static-without-deps-debug-build) failed consecutively starting with commit [284677213e9dab78d8d01c39aa0e94faf67bd029](https://hud.pytorch.org/commit/pytorch/pytorch/284677213e9dab78d8d01c39aa0e94faf67bd029)\n\nPlease review the errors and revert if needed.', 'labels': ['pytorch-alert']}
NOTE: Dry run activated, not doing any real work
```
</details>

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>