### PR TITLE
[BE] Add periodic group

### DIFF
--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -15,16 +15,16 @@ export const groups = [
   },
   {
     regex: /unstable/,
-    name: "Unstable Jobs",
+    name: "Unstable",
     persistent: true,
   },
   {
     regex: /periodic/,
-    name: "Periodic Jobs",
+    name: "Periodic",
   },
   {
     regex: /Lint/,
-    name: "Lint Jobs",
+    name: "Lint",
   },
   {
     regex: /inductor/,

--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -236,5 +236,5 @@ export function isPersistentGroup(name: string) {
 }
 
 export function isUnstableGroup(name: string) {
-  return name === "Unstable Jobs";
+  return name.toLocaleLowerCase().includes("unstable");
 }

--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -1,6 +1,7 @@
 import { GroupedJobStatus, JobStatus } from "components/GroupJobConclusion";
 import { GroupData, RowData } from "./types";
 
+// Jobs will be grouped with the first regex they match in this list
 export const groups = [
   {
     regex: /mem_leak_check/,
@@ -16,6 +17,10 @@ export const groups = [
     regex: /unstable/,
     name: "Unstable Jobs",
     persistent: true,
+  },
+  {
+    regex: /periodic/,
+    name: "Periodic Jobs",
   },
   {
     regex: /Lint/,


### PR DESCRIPTION
Adds a periodic group so that it's easy to tell when periodic jobs are failing (otherwise it can easily be mistaken for a flaky test)

Also standardize the names for the Lint & Unstable job groups