### PR TITLE
Wheel installation instructions: --extra-index-url -> --index-url

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -197,7 +197,7 @@ def get_wheel_install_command(os: str, channel: str, gpu_arch_type: str, gpu_arc
     else:
         packages_to_install = PACKAGES_TO_INSTALL_WHL_TORCHONLY if python_version == "3.11" else PACKAGES_TO_INSTALL_WHL
         whl_install_command = f"{WHL_INSTALL_BASE} --pre {packages_to_install}" if channel == "nightly" else f"{WHL_INSTALL_BASE} {packages_to_install}"
-        return f"{whl_install_command} --extra-index-url {get_base_download_url_for_repo('whl', channel, gpu_arch_type, desired_cuda)}"
+        return f"{whl_install_command} --index-url {get_base_download_url_for_repo('whl', channel, gpu_arch_type, desired_cuda)}"
 
 def generate_conda_matrix(os: str, channel: str, with_cuda: str) -> List[Dict[str, str]]:
     ret: List[Dict[str, str]] = []

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -197,7 +197,7 @@ def get_wheel_install_command(os: str, channel: str, gpu_arch_type: str, gpu_arc
     else:
         packages_to_install = PACKAGES_TO_INSTALL_WHL_TORCHONLY if python_version == "3.11" else PACKAGES_TO_INSTALL_WHL
         whl_install_command = f"{WHL_INSTALL_BASE} --pre {packages_to_install}" if channel == "nightly" else f"{WHL_INSTALL_BASE} {packages_to_install}"
-        index_arg = "--index_url" if channel == "nightly" else "--extra-index-url"
+        index_arg = "--index-url" if channel == "nightly" else "--extra-index-url"
         return f"{whl_install_command} {index_arg} {get_base_download_url_for_repo('whl', channel, gpu_arch_type, desired_cuda)}"
 
 def generate_conda_matrix(os: str, channel: str, with_cuda: str) -> List[Dict[str, str]]:

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -197,7 +197,8 @@ def get_wheel_install_command(os: str, channel: str, gpu_arch_type: str, gpu_arc
     else:
         packages_to_install = PACKAGES_TO_INSTALL_WHL_TORCHONLY if python_version == "3.11" else PACKAGES_TO_INSTALL_WHL
         whl_install_command = f"{WHL_INSTALL_BASE} --pre {packages_to_install}" if channel == "nightly" else f"{WHL_INSTALL_BASE} {packages_to_install}"
-        return f"{whl_install_command} --index-url {get_base_download_url_for_repo('whl', channel, gpu_arch_type, desired_cuda)}"
+        index_arg = "--index_url" if channel == "nightly" else "--extra-index-url"
+        return f"{whl_install_command} {index_arg} {get_base_download_url_for_repo('whl', channel, gpu_arch_type, desired_cuda)}"
 
 def generate_conda_matrix(os: str, channel: str, with_cuda: str) -> List[Dict[str, str]]:
     ret: List[Dict[str, str]] = []


### PR DESCRIPTION
This PR makes a change in `generate-binary-build-matrix.yml` so that the installation instructions generated in the build matrix JSON uses `--index-url` instead of `--extra-index-url`. 

Testing:
This PR in builder ensures all the libraries still install correctly with this change using the validation framework: https://github.com/pytorch/builder/pull/1279. All the wheels builds (which are the only ones affected by this change) are all green. Conda failures are unrelated.

Fixes: https://github.com/pytorch/pytorch/issues/92622