### PR TITLE
Create a new action to check and clean up disk space

### DIFF
--- a/.github/actions/check-disk-space/action.yml
+++ b/.github/actions/check-disk-space/action.yml
@@ -1,0 +1,68 @@
+name: Check remaining disk space
+
+description: Clean workspace and check out PyTorch
+
+inputs:
+  minimum-available-space-in-gb:
+    description: If set to any value, ensure that there is that number of GB left before continue
+    required: false
+    type: number
+    default: 4
+
+runs:
+  using: composite
+  steps:
+    - name: Get disk space usage and throw an error for low disk space
+      shell: bash
+      env:
+        MINIMUM_AVAILABLE_SPACE_IN_GB: ${{ inputs.minimum-available-space-in-gb }}
+      run: |
+        echo "Print the available disk space for manual inspection"
+        df -h
+
+        function check_disk_space() {
+          set +e
+
+          # Set the minimum requirement space to 4GB
+          MINIMUM_AVAILABLE_SPACE_IN_KB=$(($MINIMUM_AVAILABLE_SPACE_IN_GB * 1024 * 1024))
+
+          # Use KB to avoid floating point warning like 3.1GB
+          df -k | tr -s ' ' | cut -d' ' -f 4,9 | while read -r LINE;
+          do
+            AVAIL=$(echo $LINE | cut -f1 -d' ')
+            MOUNT=$(echo $LINE | cut -f2 -d' ')
+
+            if [ "${MOUNT}" = "/" ]; then
+              if [ "${AVAIL}" -lt "${MINIMUM_AVAILABLE_SPACE_IN_KB}" ]; then
+                echo "Failure: There is only ${AVAIL}KB free space left in ${MOUNT}, which is less than the minimum requirement of ${MINIMUM_AVAILABLE_SPACE_IN_KB}KB for ${RUNNER_OS}"
+              else
+                echo "Success: There is ${AVAIL}KB free space left in ${MOUNT} for ${RUNNER_OS}, continue"
+              fi
+            fi
+          done
+
+          set -e
+        }
+
+        RESULT=$(check_disk_space)
+        echo "${RESULT}"
+
+        if [[ "${RESULT}" == *Failure* && "${RUNNER_OS}" == "macOS" ]]; then
+          # We can clean up /System/Library/Caches/com.apple.coresymbolicationd on MacOS to free up the space and this should free up enough space
+          # https://github.com/pytorch/pytorch/issues/85440
+          sudo rm "/System/Library/Caches/com.apple.coresymbolicationd/data" || true
+          # Stop the daemon and launchctl will automatically start it again, thus accomplish a restart and free up the above file
+          sudo launchctl stop com.apple.coresymbolicationd || true
+
+          echo "Re-run disk space check for ${RUNNER_OS} after cleaning up"
+          # Re-run the check
+          RESULT=$(check_disk_space)
+          echo "${RESULT}"
+        fi
+
+        if [[ "${RESULT}" == *Failure* ]]; then
+          df -h
+
+          echo "Please help create an issue to PyTorch Release Engineering via https://github.com/pytorch/test-infra/issues and provide the link to the workflow run."
+          exit 1
+        fi

--- a/.github/actions/check-disk-space/action.yml
+++ b/.github/actions/check-disk-space/action.yml
@@ -1,6 +1,8 @@
-name: Check remaining disk space
+name: Check and clean up the runner disk space
 
-description: Clean workspace and check out PyTorch
+description: |
+  Checking for remaining space works for Linux and MacOS. Cleaning up the volume
+  is only supported in MacOS (pet instances)
 
 inputs:
   minimum-available-space-in-gb:
@@ -53,6 +55,9 @@ runs:
           sudo rm "/System/Library/Caches/com.apple.coresymbolicationd/data" || true
           # Stop the daemon and launchctl will automatically start it again, thus accomplish a restart and free up the above file
           sudo launchctl stop com.apple.coresymbolicationd || true
+
+          # Also try to clean up torch.hub caching directory
+          rm -rf "${HOME}/.cache/torch/hub" || true
 
           echo "Re-run disk space check for ${RUNNER_OS} after cleaning up"
           # Re-run the check

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -28,7 +28,7 @@ runs:
   using: composite
   steps:
       - name: Get disk space usage and throw an error for low disk space
-        uses: ./test-infra/.github/actions/check-disk-space
+        uses: ./.github/actions/check-disk-space
 
       # Use the same trick from https://github.com/marketplace/actions/setup-miniconda
       # to refresh the cache daily. This is kind of optional though

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -28,58 +28,7 @@ runs:
   using: composite
   steps:
       - name: Get disk space usage and throw an error for low disk space
-        shell: bash
-        run: |
-          echo "Print the available disk space for manual inspection"
-          df -h
-
-          function check_disk_space() {
-            set +e
-
-            # Set the minimum requirement space to 4GB
-            MINIMUM_AVAILABLE_SPACE_IN_GB=4
-            MINIMUM_AVAILABLE_SPACE_IN_KB=$(($MINIMUM_AVAILABLE_SPACE_IN_GB * 1024 * 1024))
-
-            # Use KB to avoid floating point warning like 3.1GB
-            df -k | tr -s ' ' | cut -d' ' -f 4,9 | while read -r LINE;
-            do
-              AVAIL=$(echo $LINE | cut -f1 -d' ')
-              MOUNT=$(echo $LINE | cut -f2 -d' ')
-
-              if [ "${MOUNT}" = "/" ]; then
-                if [ "${AVAIL}" -lt "${MINIMUM_AVAILABLE_SPACE_IN_KB}" ]; then
-                  echo "Failure: There is only ${AVAIL}KB free space left in ${MOUNT}, which is less than the minimum requirement of ${MINIMUM_AVAILABLE_SPACE_IN_KB}KB for ${RUNNER_OS}"
-                else
-                  echo "Success: There is ${AVAIL}KB free space left in ${MOUNT} for ${RUNNER_OS}, continue"
-                fi
-              fi
-            done
-
-            set -e
-          }
-
-          RESULT=$(check_disk_space)
-          echo "${RESULT}"
-
-          if [[ "${RESULT}" == *Failure* && "${RUNNER_OS}" == "macOS" ]]; then
-            # We can clean up /System/Library/Caches/com.apple.coresymbolicationd on MacOS to free up the space and this should free up enough space
-            # https://github.com/pytorch/pytorch/issues/85440
-            sudo rm "/System/Library/Caches/com.apple.coresymbolicationd/data" || true
-            # Stop the daemon and launchctl will automatically start it again, thus accomplish a restart and free up the above file
-            sudo launchctl stop com.apple.coresymbolicationd || true
-
-            echo "Re-run disk space check for ${RUNNER_OS} after cleaning up"
-            # Re-run the check
-            RESULT=$(check_disk_space)
-            echo "${RESULT}"
-          fi
-
-          if [[ "${RESULT}" == *Failure* ]]; then
-            df -h
-
-            echo "Please help create an issue to PyTorch Release Engineering via https://github.com/pytorch/test-infra/issues and provide the link to the workflow run."
-            exit 1
-          fi
+        uses: ./test-infra/.github/actions/check-disk-space
 
       # Use the same trick from https://github.com/marketplace/actions/setup-miniconda
       # to refresh the cache daily. This is kind of optional though

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -27,9 +27,6 @@ inputs:
 runs:
   using: composite
   steps:
-      - name: Get disk space usage and throw an error for low disk space
-        uses: ./test-infra/.github/actions/check-disk-space
-
       # Use the same trick from https://github.com/marketplace/actions/setup-miniconda
       # to refresh the cache daily. This is kind of optional though
       - name: Get date

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -28,7 +28,7 @@ runs:
   using: composite
   steps:
       - name: Get disk space usage and throw an error for low disk space
-        uses: ./.github/actions/check-disk-space
+        uses: ./test-infra/.github/actions/check-disk-space
 
       # Use the same trick from https://github.com/marketplace/actions/setup-miniconda
       # to refresh the cache daily. This is kind of optional though

--- a/.github/workflows/test-setup-miniconda.yml
+++ b/.github/workflows/test-setup-miniconda.yml
@@ -42,8 +42,6 @@ jobs:
       PYTHON_VERSION: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          path: test-infra
 
       - name: Test that setup-miniconda works
         uses: ./.github/actions/setup-miniconda

--- a/.github/workflows/test-setup-miniconda.yml
+++ b/.github/workflows/test-setup-miniconda.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
       - .github/workflows/test-setup-miniconda.yml
-      - .github/actions/check-disk-space/*
       - .github/actions/setup-miniconda/*
 
 jobs:

--- a/.github/workflows/test-setup-miniconda.yml
+++ b/.github/workflows/test-setup-miniconda.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/test-setup-miniconda.yml
+      - .github/actions/check-disk-space/*
       - .github/actions/setup-miniconda/*
 
 jobs:

--- a/.github/workflows/test-setup-miniconda.yml
+++ b/.github/workflows/test-setup-miniconda.yml
@@ -42,6 +42,8 @@ jobs:
       PYTHON_VERSION: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          path: test-infra
 
       - name: Test that setup-miniconda works
         uses: ./.github/actions/setup-miniconda

--- a/.github/workflows/test-setup-miniconda.yml
+++ b/.github/workflows/test-setup-miniconda.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/test-setup-miniconda.yml
+      - .github/actions/check-disk-space/*
       - .github/actions/setup-miniconda/*
 
 jobs:
@@ -42,6 +43,9 @@ jobs:
       PYTHON_VERSION: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
+
+      - name: Get disk space usage and throw an error for low disk space
+        uses: ./.github/actions/check-disk-space
 
       - name: Test that setup-miniconda works
         uses: ./.github/actions/setup-miniconda


### PR DESCRIPTION
This basically takes the step in `setup-miniconda` to check and clean up disk space on MacOS and puts it into a separate GitHub action so that it can be invokes in PyTorch to clean up the space AFTER the workflow finishes.

The context is that we are seeing disk space issues on MacOS M1, for example https://hud.pytorch.org/pytorch/pytorch/commit/d1807dc1f467a3abfbe866f1f0775d53a5964500.  While `setup-miniconda` checks and cleans up everything BEFORE running, the recent failures fail too early, not even being able to download the GitHub actions.  So, we would need to clean things up both BEFORE and AFTER the workflow run.

Note:  I realize that `setup-miniconda` and `check-disk-space` are better be in two separate GitHub actions because 1) GitHub doesn't know which paths to use between `.github/actions/check-disk-space` and `test-infra/.github/actions/check-disk-space` when actions in the same repo call each other and 2) they are better modularize that way.