### PR TITLE
Fix cudnn 11.8 lib path on windows AMI

### DIFF
--- a/aws/ami/windows/scripts/Installers/Install-CUDA-Tools.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-CUDA-Tools.ps1
@@ -96,7 +96,11 @@ function Install-Cudnn() {
   Write-Output "Copying cudnn to $expectedInstallLocation"
 
   Copy-Item -Force -Verbose -Recurse "$tmpCudnnExtracted\$cudnn_subfolder\bin\*" "$expectedInstallLocation\bin"
-  Copy-Item -Force -Verbose -Recurse "$tmpCudnnExtracted\$cudnn_subfolder\$cudnn_lib_folder\*" "$expectedInstallLocation\lib\x64"
+  if ($cudaVersion -eq "11.8") {
+    Copy-Item -Force -Verbose -Recurse "$tmpCudnnExtracted\$cudnn_subfolder\$cudnn_lib_folder\x64\*" "$expectedInstallLocation\lib\x64"
+  } else {
+    Copy-Item -Force -Verbose -Recurse "$tmpCudnnExtracted\$cudnn_subfolder\$cudnn_lib_folder\*" "$expectedInstallLocation\lib\x64"
+  }
   Copy-Item -Force -Verbose -Recurse "$tmpCudnnExtracted\$cudnn_subfolder\include\*" "$expectedInstallLocation\include"
 
   if (-Not (Test-Path -Path "$expectedInstallLocation\include\cudnn.h" -PathType Leaf)) {


### PR DESCRIPTION
For cudnn-windows-x86_64-8.7.0.84_cuda11-archive libs are located under lib/x64
For cudnn-windows-x86_64-8.5.0.96_cuda11-archive libs are located under lib/

Failing test (without this fix):
https://github.com/pytorch/pytorch-canary/actions/runs/4027562763/jobs/6925900401

Successful test (with this fix):
https://github.com/pytorch/pytorch-canary/actions/runs/4027562763/jobs/6954158425

Test PR: 
https://github.com/pytorch/pytorch-canary/pull/161

AMI Update PR: 
https://github.com/fairinternal/pytorch-gha-infra/pull/107