### PR TITLE
Remove CUDA 11.6 from binary matrix

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -26,7 +26,7 @@ PYTHON_ARCHES_DICT = {
     "release": ["3.7", "3.8", "3.9", "3.10"],
 }
 CUDA_ARCHES_DICT = {
-    "nightly": ["11.6", "11.7", "11.8"],
+    "nightly": ["11.7", "11.8"],
     "test": ["11.6", "11.7"],
     "release": ["11.6", "11.7"],
 }


### PR DESCRIPTION
Remove cuda 11.6 
Following the Release readme here: https://github.com/pytorch/pytorch/blob/master/RELEASE.md#release-compatibility-matrix