### PR TITLE
[ez] Remove pytorch-bot comments from revert generator

### DIFF
--- a/torchci/rockset/commons/__sql/reverted_prs_with_reason.sql
+++ b/torchci/rockset/commons/__sql/reverted_prs_with_reason.sql
@@ -32,5 +32,6 @@ WHERE
     ic._event_time = rc.event_time
     AND ic._event_time >= PARSE_TIMESTAMP_ISO8601(:startTime)
     AND ic._event_time < PARSE_TIMESTAMP_ISO8601(:stopTime)
+    AND ic.user.login != 'pytorch-bot[bot]'
 ORDER BY
     code DESC

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -16,7 +16,7 @@
     "failure_samples_query": "18e7e696b4949f05",
     "num_commits_master": "08d299a1b7386dbb",
     "recent_pr_workflows_query": "0deed4379aec49ce",
-    "reverted_prs_with_reason": "00a65a0aa7d97431",
+    "reverted_prs_with_reason": "751f01cba16364f0",
     "unclassified": "1b31a2d8f4ab7230",
     "test_insights_overview": "c9be5cbdda1030af",
     "test_insights_latest_runs": "aa6c15c6d52860b2"


### PR DESCRIPTION
pytorch-bot makes the help and invalid command comments that get included in the revert tracker, so remove pytorch-bot comments from the sql query to make the revert tracker neater.  