### PR TITLE
Require at least 6GB on MacOS M1 runner

### DIFF
--- a/.github/actions/check-disk-space/action.yml
+++ b/.github/actions/check-disk-space/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: If set to any value, ensure that there is that number of GB left before continue
     required: false
     type: number
-    default: 10
+    default: 5
 
 runs:
   using: composite

--- a/.github/actions/check-disk-space/action.yml
+++ b/.github/actions/check-disk-space/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: If set to any value, ensure that there is that number of GB left before continue
     required: false
     type: number
-    default: 5
+    default: 6
 
 runs:
   using: composite

--- a/.github/actions/check-disk-space/action.yml
+++ b/.github/actions/check-disk-space/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: If set to any value, ensure that there is that number of GB left before continue
     required: false
     type: number
-    default: 4
+    default: 10
 
 runs:
   using: composite


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/84898

The test ran and failed because there was 4.1GB space left and it was just above the 4GB threshold.  Having a higher threshold here would force the runner to cleanup its space more often

I need to be more conservative in setting the threshold (**6GB** = current threshold + 2GB temp file generated by https://github.com/pytorch/pytorch/issues/84898) because MacOS M1 pet runners have tiny space, so at best there are only 10+ GB free space left.  We need a bigger disk space there eventually

Create an issue to fix this eventually https://github.com/pytorch/test-infra/issues/2101