### PR TITLE
Clear conda and pip cache when low disk space on MacOS M1 pet runners

### DIFF
--- a/.github/actions/check-disk-space/action.yml
+++ b/.github/actions/check-disk-space/action.yml
@@ -59,6 +59,11 @@ runs:
           # Also try to clean up torch.hub caching directory
           rm -rf "${HOME}/.cache/torch/hub" || true
 
+          # Purge conda
+          conda clean -p -t -y || true
+          # and pip cache
+          pip cache purge || true
+
           echo "Re-run disk space check for ${RUNNER_OS} after cleaning up"
           # Re-run the check
           RESULT=$(check_disk_space)


### PR DESCRIPTION
Desperate times call for desperate measures before https://github.com/pytorch/test-infra/issues/2101 is done.