### PR TITLE
Fix typo in variable name WITH_FLAKY_TEST_ALERT in check-alerts.yml

### DIFF
--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -25,7 +25,7 @@ jobs:
     env:
       REPO_TO_CHECK: ${{ matrix.repo }}
       BRANCH_TO_CHECK: ${{ matrix.branch }}
-      WITH_FLAKY_TEST_ALERTING: ${{ matrix.with_flaky_test_alerting }}
+      WITH_FLAKY_TEST_ALERT: ${{ matrix.with_flaky_test_alerting }}
       # Don't do actual work on pull request
       DRY_RUN: ${{ github.event_name == 'pull_request'}}
     runs-on: ubuntu-18.04


### PR DESCRIPTION
The .env variable name should be the same as expected in https://github.com/pytorch/test-infra/blob/2c9f126bc39ba59625fb069b84b0f9d0c32cb0fd/torchci/scripts/check_alerts.py#L504