### PR TITLE
Add a % red on trunk metric with retry

### DIFF
--- a/torchci/lib/rockset.ts
+++ b/torchci/lib/rockset.ts
@@ -4,7 +4,7 @@ import rockset, { MainApi } from "@rockset/client";
 export interface RocksetParam {
   name: string;
   // This is not complete, but we only really have string/int/float params atm.
-  type: "string" | "int" | "float";
+  type: "string" | "int" | "float" | "bool";
   value: any;
 }
 

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -107,7 +107,7 @@ function MasterCommitRedPanel({ params }: { params: RocksetParam[] }) {
   const options: EChartsOption = {
     title: {
       text: "Commits red on master, by day",
-      subtext: "Based on workflows which block viable/strict upgrade"
+      subtext: "Based on workflows which block viable/strict upgrade",
     },
     grid: { top: 60, right: 8, bottom: 24, left: 36 },
     dataset: { source: data },
@@ -175,7 +175,7 @@ function TTSPanel({
   queryParams,
   metricHeaderName,
   metricName,
-  branchName
+  branchName,
 }: {
   title: string;
   queryName: string;
@@ -213,11 +213,13 @@ function TTSPanel({
             const encodedJobName = encodeURIComponent(jobName);
             const encodedBranchName = encodeURIComponent(branchName);
             return (
-              <a href={`/tts/pytorch/pytorch/${encodedBranchName}?jobName=${encodedJobName}`}>
+              <a
+                href={`/tts/pytorch/pytorch/${encodedBranchName}?jobName=${encodedJobName}`}
+              >
                 {jobName}
               </a>
             );
-          }
+          },
         },
       ]}
       dataGridProps={{ getRowId: (el: any) => el.name }}
@@ -344,7 +346,9 @@ export function TtsPercentilePicker({
   return (
     <>
       <FormControl>
-        <InputLabel id="tts-percentile-picker-select-label">Percentile</InputLabel>
+        <InputLabel id="tts-percentile-picker-select-label">
+          Percentile
+        </InputLabel>
         <Select
           defaultValue={ttsPercentile}
           label="Percentile"
@@ -352,11 +356,11 @@ export function TtsPercentilePicker({
           onChange={handleChange}
         >
           <MenuItem value={-1.0}>avg</MenuItem>
-          <MenuItem value={0.50}>p50</MenuItem>
-          <MenuItem value={0.90}>p90</MenuItem>
+          <MenuItem value={0.5}>p50</MenuItem>
+          <MenuItem value={0.9}>p90</MenuItem>
           <MenuItem value={0.95}>p95</MenuItem>
           <MenuItem value={0.99}>p99</MenuItem>
-          <MenuItem value={1.00}>p100</MenuItem>
+          <MenuItem value={1.0}>p100</MenuItem>
         </Select>
       </FormControl>
     </>
@@ -374,7 +378,9 @@ function WorkflowDuration({
 }) {
   const ttsPercentile = percentileParam.value;
 
-  let title: string = `p${ttsPercentile * 100} ${workflowNames.join(", ") } workflows duration`;
+  let title: string = `p${ttsPercentile * 100} ${workflowNames.join(
+    ", "
+  )} workflows duration`;
   let queryName: string = "workflow_duration_percentile";
 
   // -1 is the specical case where we will show the avg instead
@@ -390,7 +396,11 @@ function WorkflowDuration({
       metricName={"duration_sec"}
       valueRenderer={(value) => durationDisplay(value)}
       queryParams={[
-        { name: "workflowNames", type: "string", value: workflowNames.join(",") },
+        {
+          name: "workflowNames",
+          type: "string",
+          value: workflowNames.join(","),
+        },
         percentileParam,
         ...timeParams,
       ]}
@@ -466,7 +476,7 @@ export default function Page() {
     },
   ];
 
-  const [ttsPercentile, setTtsPercentile] = useState<number>(0.50);
+  const [ttsPercentile, setTtsPercentile] = useState<number>(0.5);
 
   const percentileParam: RocksetParam = {
     name: "percentile",
@@ -474,9 +484,9 @@ export default function Page() {
     value: ttsPercentile,
   };
 
-  var numberFormat = Intl.NumberFormat('en-US', {
+  var numberFormat = Intl.NumberFormat("en-US", {
     notation: "compact",
-    maximumFractionDigits: 1
+    maximumFractionDigits: 1,
   });
 
   return (
@@ -536,7 +546,7 @@ export default function Page() {
                   type: "bool",
                   value: true,
                 },
-              ...timeParams,
+                ...timeParams,
               ]}
               badThreshold={(value) => value > 0.2}
             />
@@ -566,7 +576,6 @@ export default function Page() {
               queryParams={timeParams}
               badThreshold={(_) => false} // we haven't decided on the threshold here yet
             />
-
           </Stack>
         </Grid>
 

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -404,7 +404,7 @@ function WorkflowDuration({
         percentileParam,
         ...timeParams,
       ]}
-      badThreshold={(value) => value > 60 * 60 * 3} // 3 hours
+      badThreshold={(value) => value > 60 * 60 * 4} // 3 hours
     />
   );
 }

--- a/torchci/rockset/metrics/__sql/master_commit_red_avg.sql
+++ b/torchci/rockset/metrics/__sql/master_commit_red_avg.sql
@@ -1,72 +1,83 @@
-WITH any_red as (
+WITH all_jobs AS (
+    SELECT
+        push._event_time AS time,
+        job.conclusion AS conclusion,
+        push.head_commit.id AS sha,
+        IF(:useRetryConclusion,
+            ROW_NUMBER() OVER(PARTITION BY job.name, push.head_commit.id ORDER BY job.run_attempt DESC),
+            ''
+        ) AS attempt
+    FROM
+        commons.workflow_job job
+        JOIN commons.workflow_run workflow ON workflow.id = job.run_id
+        JOIN push ON workflow.head_commit.id = push.head_commit.id
+    WHERE
+        job.name != 'ciflow_should_run'
+        AND job.name != 'generate-test-matrix'
+        AND ( -- Limit it to workflows which block viable/strict upgrades
+            ARRAY_CONTAINS(SPLIT(:workflowNames, ','), LOWER(workflow.name))
+            OR workflow.name like 'linux-binary%'
+            OR workflow.name like 'windows-binary%'
+        )
+        AND job.name NOT LIKE '%rerun_disabled_tests%'
+        AND workflow.event != 'workflow_run' -- Filter out worflow_run-triggered jobs, which have nothing to do with the SHA
+        AND push.ref IN ('refs/heads/master', 'refs/heads/main')
+        AND push.repository.owner.name = 'pytorch'
+        AND push.repository.name = 'pytorch'
+        AND push._event_time >= PARSE_DATETIME_ISO8601(:startTime)
+        AND push._event_time < PARSE_DATETIME_ISO8601(:stopTime)
+    UNION ALL
+    SELECT
+        push._event_time AS time,
+        CASE
+            WHEN job.job.status = 'failed' then 'failure'
+            WHEN job.job.status = 'canceled' then 'cancelled'
+            ELSE job.job.status
+        END AS conclusion,
+        push.head_commit.id AS sha,
+        IF(:useRetryConclusion,
+            ROW_NUMBER() OVER(PARTITION BY job.name, push.head_commit.id ORDER BY job.run_attempt DESC),
+            ''
+        ) AS attempt
+    FROM
+        circleci.job job
+        JOIN push ON job.pipeline.vcs.revision = push.head_commit.id
+    WHERE
+        push.ref IN ('refs/heads/master', 'refs/heads/main')
+        AND push.repository.owner.name = 'pytorch'
+        AND push.repository.name = 'pytorch'
+        AND push._event_time >= PARSE_DATETIME_ISO8601(:startTime)
+        AND push._event_time < PARSE_DATETIME_ISO8601(:stopTime)
+),
+reds AS (
     SELECT
         time,
         sha,
         CAST(
             SUM(
                 CASE
-                    when conclusion = 'failure' THEN 1
-                    when conclusion = 'timed_out' THEN 1
-                    when conclusion = 'cancelled' THEN 1
+                    WHEN conclusion = 'failure' THEN 1
+                    WHEN conclusion = 'timed_out' THEN 1
+                    WHEN conclusion = 'cancelled' THEN 1
                     ELSE 0
                 END
-            ) > 0 as int
-        ) as any_red,
+            ) > 0 AS int
+        ) AS any_red,
         COUNT(*)
     FROM
-        (
-            SELECT
-                push._event_time as time,
-                job.conclusion as conclusion,
-                push.head_commit.id as sha,
-            FROM
-                commons.workflow_job job
-                JOIN commons.workflow_run workflow on workflow.id = job.run_id
-                JOIN push on workflow.head_commit.id = push.head_commit.id
-            WHERE
-                job.name != 'ciflow_should_run'
-                AND job.name != 'generate-test-matrix'
-          		AND ( -- Limit it to workflows which block viable/strict upgrades
-                  workflow.name in ('Lint', 'pull', 'trunk')
-                  OR workflow.name like 'linux-binary%'
-                  OR workflow.name like 'windows-binary%'
-                )
-                AND job.name NOT LIKE '%rerun_disabled_tests%'
-                AND workflow.event != 'workflow_run' -- Filter out worflow_run-triggered jobs, which have nothing to do with the SHA
-                AND push.ref IN ('refs/heads/master', 'refs/heads/main')
-                AND push.repository.owner.name = 'pytorch'
-                AND push.repository.name = 'pytorch'
-                AND push._event_time >= PARSE_DATETIME_ISO8601(:startTime)
-                AND push._event_time < PARSE_DATETIME_ISO8601(:stopTime)
-            UNION ALL
-            SELECT
-                push._event_time as time,
-                case
-                    WHEN job.job.status = 'failed' then 'failure'
-                    WHEN job.job.status = 'canceled' then 'cancelled'
-                    else job.job.status
-                END as conclusion,
-                push.head_commit.id as sha,
-            FROM
-                circleci.job job
-                JOIN push on job.pipeline.vcs.revision = push.head_commit.id
-            WHERE
-                push.ref IN ('refs/heads/master', 'refs/heads/main')
-                AND push.repository.owner.name = 'pytorch'
-                AND push.repository.name = 'pytorch'
-                AND push._event_time >= PARSE_DATETIME_ISO8601(:startTime)
-                AND push._event_time < PARSE_DATETIME_ISO8601(:stopTime)
-        ) as all_job
+        all_jobs
+    WHERE
+        all_jobs.attempt = IF(:useRetryConclusion, 1, '')
     GROUP BY
         time,
         sha
     HAVING
-        count(*) > 10 -- Filter out jobs that didn't run anything.
-        AND SUM(IF(conclusion is NULL, 1, 0)) = 0 -- Filter out commits that still have pending jobs.
+        COUNT(*) > 10 -- Filter out jobs that didn't run anything.
+        AND SUM(IF(conclusion IS NULL, 1, 0)) = 0 -- Filter out commits that still have pending jobs.
     ORDER BY
         time DESC
 )
 SELECT
-    AVG(any_red) as red
+    AVG(any_red) AS red
 FROM
-    any_red
+    reds

--- a/torchci/rockset/metrics/__sql/workflow_duration_avg.sql
+++ b/torchci/rockset/metrics/__sql/workflow_duration_avg.sql
@@ -11,7 +11,7 @@ FROM
     commons.workflow_run workflow
 WHERE
     conclusion = 'success'
-    AND name = :name
+    AND ARRAY_CONTAINS(SPLIT(:workflowNames, ','), LOWER(workflow.name))
     AND workflow._event_time >= PARSE_DATETIME_ISO8601(:startTime)
     AND workflow._event_time < PARSE_DATETIME_ISO8601(:stopTime)
     AND workflow.run_attempt = 1

--- a/torchci/rockset/metrics/__sql/workflow_duration_percentile.sql
+++ b/torchci/rockset/metrics/__sql/workflow_duration_percentile.sql
@@ -17,7 +17,7 @@ FROM (
         	commons.workflow_run workflow
     	WHERE
     		conclusion = 'success'
-        	AND workflow.name = :name
+            AND ARRAY_CONTAINS(SPLIT(:workflowNames, ','), LOWER(workflow.name))
         	AND workflow._event_time >= PARSE_DATETIME_ISO8601(:startTime)
         	AND workflow._event_time < PARSE_DATETIME_ISO8601(:stopTime)
             AND workflow.run_attempt = 1

--- a/torchci/rockset/metrics/__sql/workflow_duration_percentile.sql
+++ b/torchci/rockset/metrics/__sql/workflow_duration_percentile.sql
@@ -4,7 +4,7 @@ SELECT
 FROM (
     SELECT
     	tts.*,
-    	PERCENT_RANK() OVER (ORDER BY duration_sec DESC) AS percentile
+    	PERCENT_RANK() OVER (PARTITION BY name ORDER BY duration_sec DESC) AS percentile
     FROM (
     	SELECT
         	DATE_DIFF(

--- a/torchci/rockset/metrics/master_commit_red_avg.lambda.json
+++ b/torchci/rockset/metrics/master_commit_red_avg.lambda.json
@@ -10,6 +10,16 @@
       "name": "stopTime",
       "type": "string",
       "value": "2022-10-12T00:06:32.839Z"
+    },
+    {
+      "name": "useRetryConclusion",
+      "type": "bool",
+      "value": "False"
+    },
+    {
+      "name": "workflowNames",
+      "type": "string",
+      "value": "lint,pull,trunk"
     }
   ],
   "description": ""

--- a/torchci/rockset/metrics/workflow_duration_avg.lambda.json
+++ b/torchci/rockset/metrics/workflow_duration_avg.lambda.json
@@ -2,11 +2,6 @@
   "sql_path": "__sql/workflow_duration_avg.sql",
   "default_parameters": [
     {
-      "name": "name",
-      "type": "string",
-      "value": "pull"
-    },
-    {
       "name": "startTime",
       "type": "string",
       "value": "2022-02-22T00:08:03.395Z"
@@ -15,6 +10,11 @@
       "name": "stopTime",
       "type": "string",
       "value": "2022-03-01T00:08:03.395Z"
+    },
+    {
+      "name": "workflowNames",
+      "type": "string",
+      "value": "pull,trunk"
     }
   ],
   "description": ""

--- a/torchci/rockset/metrics/workflow_duration_percentile.lambda.json
+++ b/torchci/rockset/metrics/workflow_duration_percentile.lambda.json
@@ -2,11 +2,6 @@
   "sql_path": "__sql/workflow_duration_percentile.sql",
   "default_parameters": [
     {
-      "name": "name",
-      "type": "string",
-      "value": "pull"
-    },
-    {
       "name": "percentile",
       "type": "float",
       "value": "0.95"
@@ -20,6 +15,11 @@
       "name": "stopTime",
       "type": "string",
       "value": "2022-08-01T00:00:00.000Z"
+    },
+    {
+      "name": "workflowNames",
+      "type": "string",
+      "value": "pull,trunk"
     }
   ],
   "description": "Query workflow duration at different percentiles"

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -39,7 +39,7 @@
     "last_successful_jobs": "2e04949378c58607",
     "last_successful_workflow": "5d22927dd0b0956b",
     "log_captures_count": "9cbd496ad254c3de",
-    "master_commit_red_avg": "4c9d8b4e6c17a000",
+    "master_commit_red_avg": "18c967f80a2cb6c5",
     "master_commit_red": "b05a2786103f135c",
     "master_commit_red_percent": "5246c800e886b537",
     "master_commit_red_percent_groups": "224122f2a006f130",
@@ -57,8 +57,8 @@
     "tts_duration_historical_percentile": "f6824cbe03e1b6d8",
     "strict_lag_sec": "f9523e8c8c3a3311",
     "queue_times_historical": "7f4d6599362e70ba",
-    "workflow_duration_avg": "b92d60f09ac39069",
-    "workflow_duration_percentile": "a69732c03132613c",
+    "workflow_duration_avg": "7bae00900097a486",
+    "workflow_duration_percentile": "7b2262fa67d20a35",
     "workflow_load": "eff394d8e0b76436"
   }
 }

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -58,7 +58,7 @@
     "strict_lag_sec": "f9523e8c8c3a3311",
     "queue_times_historical": "7f4d6599362e70ba",
     "workflow_duration_avg": "7bae00900097a486",
-    "workflow_duration_percentile": "7b2262fa67d20a35",
+    "workflow_duration_percentile": "0b28cf65de7cfe07",
     "workflow_load": "eff394d8e0b76436"
   }
 }


### PR DESCRIPTION
The new metric only counts the signal from the latest attempt (retry).  This would give us an approximated view on how much of the red signal is due to flaky and becomes greens after retrying.

I also consolidate the TTS KPI from pull and trunk into a single metric as we are only referring to that number.

Also run `yarn format` to format the file and lower the display threshold to 20% to match our current goal.

### Testing

https://torchci-git-fork-huydhn-red-with-retry-fbopensource.vercel.app/metrics