### PR TITLE
Setting CHANNEL correctly for RC branches in Reusable Workflows

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -63,7 +63,8 @@ runs:
         run: |
           echo "CHANNEL=nightly" >> "${GITHUB_ENV}"
       - name: Set CHANNEL for tagged pushes
-        if: ${{ GITHUB_EVENT_NAME == 'push' && startsWith(GITHUB_REF, 'refs/tags/') }}
+        if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/') }}
+        # if: ${{ GITHUB_EVENT_NAME == 'push' && startsWith(GITHUB_REF, 'refs/tags/') }}
         shell: bash -l {0}
         run: |
           # Use GITHUB_EVENT_NAME or trigger-event above?
@@ -73,7 +74,9 @@ runs:
             echo "CHANNEL=test" >> "${GITHUB_ENV}"
           fi
       - name: Set Release CHANNEL for release
-        if: ${{ (GITHUB_EVENT_NAME == 'pull_request' && startsWith(GITHUB_BASE_REF, 'release')) || startsWith(GITHUB_REF, 'refs/heads/release') }}
+        if: ${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'refs/heads/release') }}
+        # if: ${{ (GITHUB_EVENT_NAME == 'pull_request' && startsWith(GITHUB_BASE_REF, 'release')) || startsWith(GITHUB_REF, 'refs/heads/release') }}
+        shell: bash -l {0}
         run: |
           set -euxo pipefail
           echo "CHANNEL=test" >> "$GITHUB_ENV"

--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -48,6 +48,15 @@ runs:
       - name: Set release CHANNEL
         shell: bash -l {0}
         run: |
+          echo "${GITHUB_REF_NAME}"
+          echo "${GITHUB_EVENT_REF}"
+          echo "${GITHUB_REF}"
+          echo "${GITHUB_BASE_REF}"
+
+          echo "${{ github.ref_name }}"
+          echo "${{ github.event.ref }}"
+          echo "${{ github.ref }}"
+          echo "${{ github.base_ref }}"
           set -euxo pipefail
           # reference ends with an RC suffix
           if [[ ${GITHUB_REF_NAME} = *-rc[0-9]* ]]; then

--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -64,7 +64,6 @@ runs:
           echo "CHANNEL=nightly" >> "${GITHUB_ENV}"
       - name: Set CHANNEL for tagged pushes
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/') }}
-        # if: ${{ GITHUB_EVENT_NAME == 'push' && startsWith(GITHUB_REF, 'refs/tags/') }}
         shell: bash -l {0}
         run: |
           # Use GITHUB_EVENT_NAME or trigger-event above?
@@ -75,7 +74,6 @@ runs:
           fi
       - name: Set Release CHANNEL for release
         if: ${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'refs/heads/release') }}
-        # if: ${{ (GITHUB_EVENT_NAME == 'pull_request' && startsWith(GITHUB_BASE_REF, 'release')) || startsWith(GITHUB_REF, 'refs/heads/release') }}
         shell: bash -l {0}
         run: |
           set -euxo pipefail

--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -45,13 +45,11 @@ runs:
           ref: ${{ inputs.ref }}
           submodules: ${{ inputs.submodules }}
           path: ${{ inputs.repository }}
-      - name: Set release CHANNEL
+      - name: Log Available Webhook Fields
         shell: bash -l {0}
         run: |
-          set -euxo pipefail
           echo "ENV VARS"
           echo "${GITHUB_REF_NAME}"
-          echo "${GITHUB_EVENT_REF}"
           echo "${GITHUB_REF}"
           echo "${GITHUB_BASE_REF}"
 
@@ -60,12 +58,25 @@ runs:
           echo "${{ github.event.ref }}"
           echo "${{ github.ref }}"
           echo "${{ github.base_ref }}"
+      - name: Set default CHANNEL
+        shell: bash -l {0}
+        run: |
+          echo "CHANNEL=nightly" >> "${GITHUB_ENV}"
+      - name: Set CHANNEL for tagged pushes
+        if: ${{ GITHUB_EVENT_NAME == 'push' && startsWith(GITHUB_REF, 'refs/tags/') }}
+        shell: bash -l {0}
+        run: |
+          # Use GITHUB_EVENT_NAME or trigger-event above?
+          set -euxo pipefail
           # reference ends with an RC suffix
           if [[ ${GITHUB_REF_NAME} = *-rc[0-9]* ]]; then
             echo "CHANNEL=test" >> "${GITHUB_ENV}"
-          else
-            echo "CHANNEL=nightly" >> "${GITHUB_ENV}"
           fi
+      - name: Set Release CHANNEL for release
+        if: ${{ (GITHUB_EVENT_NAME == 'pull_request' && startsWith(GITHUB_BASE_REF, 'release')) || startsWith(GITHUB_REF, 'refs/heads/release') }}
+        run: |
+          set -euxo pipefail
+          echo "CHANNEL=test" >> "$GITHUB_ENV"
       - name: Set artifact name
         shell: bash -l {0}
         env:

--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -48,16 +48,18 @@ runs:
       - name: Set release CHANNEL
         shell: bash -l {0}
         run: |
+          set -euxo pipefail
+          echo "ENV VARS"
           echo "${GITHUB_REF_NAME}"
           echo "${GITHUB_EVENT_REF}"
           echo "${GITHUB_REF}"
           echo "${GITHUB_BASE_REF}"
 
+          echo "GITHUB PROVIDED"
           echo "${{ github.ref_name }}"
           echo "${{ github.event.ref }}"
           echo "${{ github.ref }}"
           echo "${{ github.base_ref }}"
-          set -euxo pipefail
           # reference ends with an RC suffix
           if [[ ${GITHUB_REF_NAME} = *-rc[0-9]* ]]; then
             echo "CHANNEL=test" >> "${GITHUB_ENV}"


### PR DESCRIPTION
To support the release, we must handle tagged pushes and RC branches. Using https://github.com/pytorch/vision/blob/09030c02ae88c87bbeafded72d27df7ea4213196/.github/workflows/build-m1-binaries.yml#L29 as a reference for how this was handled in the old M1 build job for vision.

This involves:
1. Adding the appropriate branches and tag regexes as `on:` triggers in the caller workflows (will be done in PR's in the domain repos).
3. Set `CHANNEL=test` for tagged pushes/releases using the same `if` conditions as the reference workflow, just using env vars instead of GHA-provided webhook variables (done in this PR).
4. Currently uploads occur when `github.event_name == 'push'`. Is this a sufficient condition? Looks like it should be because all the added `on:` triggers are push-based triggers.
5. Ensuring `pytorch-pkg-helpers` provides the correct version names in the release case.
