### PR TITLE
Add fetch-depth option to all jobs

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -27,6 +27,10 @@ on:
         description: 'Repository to checkout, defaults to ""'
         default: ""
         type: string
+      fetch-depth:
+        description: 'Number of commits to fetch, defaults to 1 similar to actions/checkout'
+        default: 1
+        type: number
       ref:
         description: 'Reference to checkout, defaults to "nightly"'
         default: ""
@@ -118,6 +122,7 @@ jobs:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.ref }}
           path: ${{ inputs.repository || github.repository }}
+          fetch-depth: ${{ inputs.fetch-depth }}
 
       - name: Download artifacts (if any)
         uses: actions/download-artifact@v3

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -27,6 +27,10 @@ on:
         description: 'Repository to checkout, defaults to ""'
         default: ""
         type: string
+      fetch-depth:
+        description: 'Number of commits to fetch, defaults to 1 similar to actions/checkout'
+        default: 1
+        type: number
       ref:
         description: 'Reference to checkout, defaults to "nightly"'
         default: ""
@@ -87,6 +91,7 @@ jobs:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.ref }}
           path: ${{ inputs.repository || github.repository }}
+          fetch-depth: ${{ inputs.fetch-depth }}
 
       - name: Setup useful environment variables
         working-directory: ${{ inputs.repository }}

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -27,6 +27,10 @@ on:
         description: 'Repository to checkout, defaults to ""'
         default: ""
         type: string
+      fetch-depth:
+        description: 'Number of commits to fetch, defaults to 1 similar to actions/checkout'
+        default: 1
+        type: number
       ref:
         description: 'Reference to checkout, defaults to "nightly"'
         default: ""
@@ -93,6 +97,7 @@ jobs:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.ref }}
           path: ${{ inputs.repository || github.repository }}
+          fetch-depth: ${{ inputs.fetch-depth }}
 
       - name: Download artifacts (if any)
         uses: actions/download-artifact@v3


### PR DESCRIPTION
This allows `actions/checkout@v3` to have a different depth rather than the default depth of 1 as mentioned on their GitHub https://github.com/actions/checkout/tree/v3.  Specifically, this allows the depth of 0 to checkout all the history.