### PR TITLE
Restrict windows builds to one python one cuda version

### DIFF
--- a/.github/workflows/generate_binary_build_matrix.yml
+++ b/.github/workflows/generate_binary_build_matrix.yml
@@ -31,6 +31,10 @@ on:
         description: "Include Python 3.11"
         default: "disable"
         type: string
+      limit-win-builds:
+        description: "Limit windows builds to single python/cuda config"
+        default: "disable"
+        type: string
     outputs:
       matrix:
         description: "Generated build matrix"
@@ -58,6 +62,7 @@ jobs:
           CHANNEL: ${{ inputs.channel }}
           WITH_CUDA: ${{ inputs.with-cuda }}
           WITH_PY311: ${{ inputs.with-py311 }}
+          LIMIT_WIN_BUILDS: ${{ inputs.limit-win-builds }}
         run: |
           set -eou pipefail
           MATRIX_BLOB="$(python3 tools/scripts/generate_binary_build_matrix.py)"

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -210,7 +210,7 @@ def generate_conda_matrix(os: str, channel: str, with_cuda: str, limit_win_build
     arches = ["cpu"]
     python_versions = PYTHON_ARCHES_DICT[channel]
 
-    if with_cuda == ENABLE and os == "linux":
+    if with_cuda == ENABLE and (os == "linux" or os == "windows"):
         arches += mod.CUDA_ARCHES
 
     if os == "macos-arm64":

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -205,20 +205,19 @@ def get_wheel_install_command(os: str, channel: str, gpu_arch_type: str, gpu_arc
         index_arg = "--index-url" if channel == "nightly" else "--extra-index-url"
         return f"{whl_install_command} {index_arg} {get_base_download_url_for_repo('whl', channel, gpu_arch_type, desired_cuda)}"
 
-def generate_conda_matrix(os: str, channel: str, with_cuda: str) -> List[Dict[str, str]]:
+def generate_conda_matrix(os: str, channel: str, with_cuda: str, limit_win_builds: str) -> List[Dict[str, str]]:
     ret: List[Dict[str, str]] = []
     arches = ["cpu"]
     python_versions = PYTHON_ARCHES_DICT[channel]
 
-    if with_cuda == ENABLE:
-        if os == "linux":
-            arches += mod.CUDA_ARCHES
-        elif os == "windows":
-            # We don't build CUDA 10.2 for window see https://github.com/pytorch/pytorch/issues/65648
-            arches += list_without(mod.CUDA_ARCHES, ["10.2"])
+    if with_cuda == ENABLE and os == "linux":
+        arches += mod.CUDA_ARCHES
 
     if os == "macos-arm64":
         python_versions = list_without(python_versions, ["3.7"])
+
+    if os == "windows" and limit_win_builds == ENABLE:
+        python_versions = [ python_versions[0] ]
 
     for python_version in python_versions:
         # We don't currently build conda packages for rocm
@@ -245,6 +244,7 @@ def generate_conda_matrix(os: str, channel: str, with_cuda: str) -> List[Dict[st
                     "installation": get_conda_install_command(channel, gpu_arch_type, arch_version, os)
                 }
             )
+
     return ret
 
 
@@ -341,6 +341,7 @@ def generate_wheels_matrix(
     channel: str,
     with_cuda: str,
     with_py311: str,
+    limit_win_builds: str,
     arches: Optional[List[str]] = None,
     python_versions: Optional[List[str]] = None,
 ) -> List[Dict[str, str]]:
@@ -370,6 +371,9 @@ def generate_wheels_matrix(
             elif os == "windows":
                 # We don't build CUDA 10.2 for window see https://github.com/pytorch/pytorch/issues/65648
                 arches += list_without(mod.CUDA_ARCHES, ["10.2"])
+
+    if (os == "windows" and limit_win_builds == ENABLE):
+        python_versions = [ python_versions[0] ]
 
     ret: List[Dict[str, str]] = []
     for python_version in python_versions:
@@ -442,6 +446,15 @@ def main(args) -> None:
         choices=[ENABLE, DISABLE],
         default=os.getenv("WITH_PY311", DISABLE),
     )
+    parser.add_argument(
+        "--limit-win-builds",
+        help="Limit windows builds to single python/cuda config",
+        type=str,
+        choices=[ENABLE, DISABLE],
+        default=os.getenv("LIMIT_WIN_BUILDS", DISABLE),
+    )
+
+
 
     options = parser.parse_args(args)
     includes = []
@@ -460,13 +473,15 @@ def main(args) -> None:
                     GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[package](options.operating_system,
                                                                 channel,
                                                                 options.with_cuda,
-                                                                options.with_py311)
+                                                                options.with_py311,
+                                                                options.limit_win_builds)
                     )
             else:
                 includes.extend(
                     GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[package](options.operating_system,
                                                                 channel,
-                                                                options.with_cuda)
+                                                                options.with_cuda,
+                                                                options.limit_win_builds)
                     )
 
 


### PR DESCRIPTION
Restrict windows builds to one python one cuda version to save on workers

Test:
```
python generate_binary_build_matrix.py  --operating-system windows --limit-win-builds enable --channel nightly
{"include": [{"python_version": "3.8", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "wheel", "build_name": "wheel-py3_8-cpu", "validation_runner": "windows.4xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "wheel", "build_name": "wheel-py3_8-cuda11_7", "validation_runner": "windows.8xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/manylinux-builder:cuda11.8", "package_type": "wheel", "build_name": "wheel-py3_8-cuda11_8", "validation_runner": "windows.8xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}]}
```