### PR TITLE
ci: Switch windows runners to all be non-ephemeral

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -123,13 +123,13 @@ runner_types:
   windows.4xlarge:
     disk_size: 256
     instance_type: c5d.4xlarge
-    is_ephemeral: true
+    is_ephemeral: false
     max_available: 420
     os: windows
   windows.8xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: p3.2xlarge
-    is_ephemeral: true
+    is_ephemeral: false
     max_available: 150
     os: windows
   windows.g5.4xlarge.nvidia.gpu:


### PR DESCRIPTION
Looks like issues that we saw previously don't necessarily exist anymore for windows ephemeral issues so setting these all to be non-ephemeral as an experiment to keep capacity