### PR TITLE
Restrict windows builds to one python one cuda version

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -252,6 +252,7 @@ def generate_libtorch_matrix(
     os: str,
     channel: str,
     with_cuda: str,
+    limit_win_builds: str,
     abi_versions: Optional[List[str]] = None,
     arches: Optional[List[str]] = None,
     libtorch_variants: Optional[List[str]] = None,


### PR DESCRIPTION
Restrict windows builds to one python one cuda version
Fix error with previous checkin.
Test:
```
 python generate_binary_build_matrix.py  --operating-system linux --limit-win-builds enable  --package-type all 
{"include": [{"python_version": "3.8", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_8-cpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_8-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/manylinux-builder:cuda11.8", "package_type": "manywheel", "build_name": "manywheel-py3_8-cuda11_8", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.8", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_8-rocm5_2", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.8", "gpu_arch_type": "rocm", "gpu_arch_version": "5.3", "desired_cuda": "rocm5.3", "container_image": "pytorch/manylinux-builder:rocm5.3", "package_type": "manywheel", "build_name": "manywheel-py3_8-rocm5_3", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.3", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.9", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_9-cpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/manylinux-builder:cuda11.8", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda11_8", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm5_2", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "5.3", "desired_cuda": "rocm5.3", "container_image": "pytorch/manylinux-builder:rocm5.3", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm5_3", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.3", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.10", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_10-cpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_10-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/manylinux-builder:cuda11.8", "package_type": "manywheel", "build_name": "manywheel-py3_10-cuda11_8", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.10", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_10-rocm5_2", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.10", "gpu_arch_type": "rocm", "gpu_arch_version": "5.3", "desired_cuda": "rocm5.3", "container_image": "pytorch/manylinux-builder:rocm5.3", "package_type": "manywheel", "build_name": "manywheel-py3_10-rocm5_3", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.3", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.11", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_11-cpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.11", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_11-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.11", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/manylinux-builder:cuda11.8", "package_type": "manywheel", "build_name": "manywheel-py3_11-cuda11_8", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu118", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.8", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_8-cpu", "validation_runner": "linux.2xlarge", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/conda-builder:cuda11.7", "package_type": "conda", "build_name": "conda-py3_8-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch-nightly -c nvidia"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/conda-builder:cuda11.8", "package_type": "conda", "build_name": "conda-py3_8-cuda11_8", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.8 -c pytorch-nightly -c nvidia"}, {"python_version": "3.9", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_9-cpu", "validation_runner": "linux.2xlarge", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/conda-builder:cuda11.7", "package_type": "conda", "build_name": "conda-py3_9-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch-nightly -c nvidia"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/conda-builder:cuda11.8", "package_type": "conda", "build_name": "conda-py3_9-cuda11_8", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.8 -c pytorch-nightly -c nvidia"}, {"python_version": "3.10", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_10-cpu", "validation_runner": "linux.2xlarge", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/conda-builder:cuda11.7", "package_type": "conda", "build_name": "conda-py3_10-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch-nightly -c nvidia"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/conda-builder:cuda11.8", "package_type": "conda", "build_name": "conda-py3_10-cuda11_8", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.8 -c pytorch-nightly -c nvidia"}, {"python_version": "3.11", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_11-cpu", "validation_runner": "linux.2xlarge", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.11", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/conda-builder:cuda11.7", "package_type": "conda", "build_name": "conda-py3_11-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch-nightly -c nvidia"}, {"python_version": "3.11", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/conda-builder:cuda11.8", "package_type": "conda", "build_name": "conda-py3_11-cuda11_8", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.8 -c pytorch-nightly -c nvidia"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-shared-with-deps-pre-cxx11", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-shared-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-shared-without-deps-pre-cxx11", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-shared-without-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-static-with-deps-pre-cxx11", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-static-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-static-without-deps-pre-cxx11", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-static-without-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "libtorch", "build_name": "libtorch-cuda11_7-shared-with-deps-pre-cxx11", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "https://download.pytorch.org/libtorch/nightly/cu117/libtorch-shared-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "libtorch", "build_name": "libtorch-cuda11_7-shared-without-deps-pre-cxx11", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "https://download.pytorch.org/libtorch/nightly/cu117/libtorch-shared-without-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "libtorch", "build_name": "libtorch-cuda11_7-static-with-deps-pre-cxx11", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "https://download.pytorch.org/libtorch/nightly/cu117/libtorch-static-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "libtorch", "build_name": "libtorch-cuda11_7-static-without-deps-pre-cxx11", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "https://download.pytorch.org/libtorch/nightly/cu117/libtorch-static-without-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.8", "package_type": "libtorch", "build_name": "libtorch-cuda11_8-shared-with-deps-pre-cxx11", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "https://download.pytorch.org/libtorch/nightly/cu118/libtorch-shared-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.8", "package_type": "libtorch", "build_name": "libtorch-cuda11_8-shared-without-deps-pre-cxx11", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "https://download.pytorch.org/libtorch/nightly/cu118/libtorch-shared-without-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.8", "package_type": "libtorch", "build_name": "libtorch-cuda11_8-static-with-deps-pre-cxx11", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "https://download.pytorch.org/libtorch/nightly/cu118/libtorch-static-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:cuda11.8", "package_type": "libtorch", "build_name": "libtorch-cuda11_8-static-without-deps-pre-cxx11", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "https://download.pytorch.org/libtorch/nightly/cu118/libtorch-static-without-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "libtorch", "build_name": "libtorch-rocm5_2-shared-with-deps-pre-cxx11", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/rocm5.2/libtorch-shared-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "libtorch", "build_name": "libtorch-rocm5_2-static-with-deps-pre-cxx11", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/rocm5.2/libtorch-static-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "rocm", "gpu_arch_version": "5.3", "desired_cuda": "rocm5.3", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:rocm5.3", "package_type": "libtorch", "build_name": "libtorch-rocm5_3-shared-with-deps-pre-cxx11", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/rocm5.3/libtorch-shared-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "rocm", "gpu_arch_version": "5.3", "desired_cuda": "rocm5.3", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "pre-cxx11", "container_image": "pytorch/manylinux-builder:rocm5.3", "package_type": "libtorch", "build_name": "libtorch-rocm5_3-static-with-deps-pre-cxx11", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/rocm5.3/libtorch-static-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-shared-with-deps-cxx11-abi", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-cxx11-abi-shared-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-shared-without-deps-cxx11-abi", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-cxx11-abi-shared-without-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-static-with-deps-cxx11-abi", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-cxx11-abi-static-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-static-without-deps-cxx11-abi", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-cxx11-abi-static-without-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.7", "package_type": "libtorch", "build_name": "libtorch-cuda11_7-shared-with-deps-cxx11-abi", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "https://download.pytorch.org/libtorch/nightly/cu117/libtorch-cxx11-abi-shared-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.7", "package_type": "libtorch", "build_name": "libtorch-cuda11_7-shared-without-deps-cxx11-abi", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "https://download.pytorch.org/libtorch/nightly/cu117/libtorch-cxx11-abi-shared-without-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.7", "package_type": "libtorch", "build_name": "libtorch-cuda11_7-static-with-deps-cxx11-abi", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "https://download.pytorch.org/libtorch/nightly/cu117/libtorch-cxx11-abi-static-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.7", "package_type": "libtorch", "build_name": "libtorch-cuda11_7-static-without-deps-cxx11-abi", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "https://download.pytorch.org/libtorch/nightly/cu117/libtorch-cxx11-abi-static-without-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.8", "package_type": "libtorch", "build_name": "libtorch-cuda11_8-shared-with-deps-cxx11-abi", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "https://download.pytorch.org/libtorch/nightly/cu118/libtorch-cxx11-abi-shared-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "libtorch_variant": "shared-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.8", "package_type": "libtorch", "build_name": "libtorch-cuda11_8-shared-without-deps-cxx11-abi", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "https://download.pytorch.org/libtorch/nightly/cu118/libtorch-cxx11-abi-shared-without-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.8", "package_type": "libtorch", "build_name": "libtorch-cuda11_8-static-with-deps-cxx11-abi", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "https://download.pytorch.org/libtorch/nightly/cu118/libtorch-cxx11-abi-static-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "libtorch_variant": "static-without-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda11.8", "package_type": "libtorch", "build_name": "libtorch-cuda11_8-static-without-deps-cxx11-abi", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "https://download.pytorch.org/libtorch/nightly/cu118/libtorch-cxx11-abi-static-without-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:rocm5.2", "package_type": "libtorch", "build_name": "libtorch-rocm5_2-shared-with-deps-cxx11-abi", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/rocm5.2/libtorch-cxx11-abi-shared-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:rocm5.2", "package_type": "libtorch", "build_name": "libtorch-rocm5_2-static-with-deps-cxx11-abi", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/rocm5.2/libtorch-cxx11-abi-static-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "rocm", "gpu_arch_version": "5.3", "desired_cuda": "rocm5.3", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:rocm5.3", "package_type": "libtorch", "build_name": "libtorch-rocm5_3-shared-with-deps-cxx11-abi", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/rocm5.3/libtorch-cxx11-abi-shared-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}, {"gpu_arch_type": "rocm", "gpu_arch_version": "5.3", "desired_cuda": "rocm5.3", "libtorch_variant": "static-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:rocm5.3", "package_type": "libtorch", "build_name": "libtorch-rocm5_3-static-with-deps-cxx11-abi", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/rocm5.3/libtorch-cxx11-abi-static-with-deps-latest.zip", "channel": "nightly", "stable_version": "1.13.1"}]}
```