### PR TITLE
Remove duplicated 3.11 config from generated matrix

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -362,7 +362,7 @@ def generate_wheels_matrix(
     if os == "linux":
         # NOTE: We only build manywheel packages for linux
         package_type = "manywheel"
-        if with_py311 == ENABLE and channel != "release":
+        if with_py311 == ENABLE and channel == "test":
             python_versions += ["3.11"]
 
     upload_to_base_bucket = "yes"


### PR DESCRIPTION
This action https://github.com/pytorch/audio/actions/runs/4130125443/jobs/7136494848 shows 3.11 configs were generated twice if when with_py311 == ENABLE is used. 
We may need to deprecate this with_py311 in future but for now, change the code so that  3.11 is only applied to test channel and is no-op for nightly channel. 