### PR TITLE
[domain library validations] Add -y for conda installs

### DIFF
--- a/.github/scripts/install_torch.sh
+++ b/.github/scripts/install_torch.sh
@@ -2,6 +2,9 @@ conda create -y -n ${ENV_NAME} python=${MATRIX_PYTHON_VERSION} numpy
 conda activate ${ENV_NAME}
 export MATRIX_INSTALLATION="${MATRIX_INSTALLATION/torchvision}"
 export MATRIX_INSTALLATION="${MATRIX_INSTALLATION/torchaudio}"
+if [[ ${MATRIX_PACKAGE_TYPE} = "conda" ]]; then
+    export MATRIX_INSTALLATION=${MATRIX_INSTALLATION/"conda install"/"conda install -y"}
+fi
 eval $MATRIX_INSTALLATION
 
 export PYTORCH_PIP_PREFIX=""


### PR DESCRIPTION
[domain library validations] Add -y for conda installs
Fixes the timeout observed here: https://github.com/pytorch/data/actions/runs/4126797215/jobs/7129188534