### PR TITLE
[generate binary matrix] Fix python logic

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -208,10 +208,11 @@ def get_wheel_install_command(os: str, channel: str, gpu_arch_type: str, gpu_arc
 def generate_conda_matrix(os: str, channel: str, with_cuda: str, limit_win_builds: str) -> List[Dict[str, str]]:
     ret: List[Dict[str, str]] = []
     arches = ["cpu"]
-    python_versions = PYTHON_ARCHES_DICT[channel]
+    python_versions = list(mod.PYTHON_ARCHES)
 
     # Excluding Python 3.11 from conda builds for now due to package
     # incompatibility issues with key dependencies.
+    #
     if "3.11" in python_versions:
         python_versions.remove("3.11")
 
@@ -353,7 +354,7 @@ def generate_wheels_matrix(
 
     if python_versions is None:
         # Define default python version
-        python_versions = list(PYTHON_ARCHES_DICT[channel])
+        python_versions = list(mod.PYTHON_ARCHES)
         if os == "macos-arm64":
             python_versions = list_without(python_versions, ["3.7"])
 
@@ -378,6 +379,7 @@ def generate_wheels_matrix(
 
     ret: List[Dict[str, str]] = []
     for python_version in python_versions:
+        print(f"GENERATING for PYTHON {python_version}")
         for arch_version in arches:
             gpu_arch_type = arch_type(arch_version)
             gpu_arch_version = "" if arch_version == "cpu" else arch_version

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -212,7 +212,6 @@ def generate_conda_matrix(os: str, channel: str, with_cuda: str, limit_win_build
 
     # Excluding Python 3.11 from conda builds for now due to package
     # incompatibility issues with key dependencies.
-    #
     if "3.11" in python_versions:
         python_versions.remove("3.11")
 

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -379,7 +379,6 @@ def generate_wheels_matrix(
 
     ret: List[Dict[str, str]] = []
     for python_version in python_versions:
-        print(f"GENERATING for PYTHON {python_version}")
         for arch_version in arches:
             gpu_arch_type = arch_type(arch_version)
             gpu_arch_version = "" if arch_version == "cpu" else arch_version


### PR DESCRIPTION
This make sure we use same logic for Python dict as CUDA dict. Also make sure when we need to provide matrix for multiple packages, we don't accidentally mutate the global dict.
Test
```
(fix_domain_library_conda_install_instructions)]$ python generate_binary_build_matrix.py --package-type conda,wheel

{"include": [{"python_version": "3.8", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_8-cpu", "validation_runner": "linux.2xlarge", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/conda-builder:cuda11.7", "package_type": "conda", "build_name": "conda-py3_8-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch-nightly -c nvidia"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/conda-builder:cuda11.8", "package_type": "conda", "build_name": "conda-py3_8-cuda11_8", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.8 -c pytorch-nightly -c nvidia"}, {"python_version": "3.9", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_9-cpu", "validation_runner": "linux.2xlarge", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/conda-builder:cuda11.7", "package_type": "conda", "build_name": "conda-py3_9-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch-nightly -c nvidia"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/conda-builder:cuda11.8", "package_type": "conda", "build_name": "conda-py3_9-cuda11_8", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.8 -c pytorch-nightly -c nvidia"}, {"python_version": "3.10", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/conda-builder:cpu", "package_type": "conda", "build_name": "conda-py3_10-cpu", "validation_runner": "linux.2xlarge", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/conda-builder:cuda11.7", "package_type": "conda", "build_name": "conda-py3_10-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch-nightly -c nvidia"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/conda-builder:cuda11.8", "package_type": "conda", "build_name": "conda-py3_10-cuda11_8", "validation_runner": "linux.4xlarge.nvidia.gpu", "channel": "nightly", "stable_version": "1.13.1", "installation": "conda install pytorch torchvision torchaudio pytorch-cuda=11.8 -c pytorch-nightly -c nvidia"}, {"python_version": "3.8", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_8-cpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_8-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/manylinux-builder:cuda11.8", "package_type": "manywheel", "build_name": "manywheel-py3_8-cuda11_8", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.8", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_8-rocm5_2", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.8", "gpu_arch_type": "rocm", "gpu_arch_version": "5.3", "desired_cuda": "rocm5.3", "container_image": "pytorch/manylinux-builder:rocm5.3", "package_type": "manywheel", "build_name": "manywheel-py3_8-rocm5_3", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.3", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.9", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_9-cpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/manylinux-builder:cuda11.8", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda11_8", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm5_2", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "5.3", "desired_cuda": "rocm5.3", "container_image": "pytorch/manylinux-builder:rocm5.3", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm5_3", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.3", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.10", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_10-cpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_10-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/manylinux-builder:cuda11.8", "package_type": "manywheel", "build_name": "manywheel-py3_10-cuda11_8", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.10", "gpu_arch_type": "rocm", "gpu_arch_version": "5.2", "desired_cuda": "rocm5.2", "container_image": "pytorch/manylinux-builder:rocm5.2", "package_type": "manywheel", "build_name": "manywheel-py3_10-rocm5_2", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.2", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.10", "gpu_arch_type": "rocm", "gpu_arch_version": "5.3", "desired_cuda": "rocm5.3", "container_image": "pytorch/manylinux-builder:rocm5.3", "package_type": "manywheel", "build_name": "manywheel-py3_10-rocm5_3", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.3", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.11", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_11-cpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.11", "gpu_arch_type": "cuda", "gpu_arch_version": "11.7", "desired_cuda": "cu117", "container_image": "pytorch/manylinux-builder:cuda11.7", "package_type": "manywheel", "build_name": "manywheel-py3_11-cuda11_7", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu117", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}, {"python_version": "3.11", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/manylinux-builder:cuda11.8", "package_type": "manywheel", "build_name": "manywheel-py3_11-cuda11_8", "validation_runner": "linux.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu118", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "1.13.1"}]}
```