### PR TITLE
Remove numpy from default install since not available for 3.11 python

### DIFF
--- a/.github/scripts/install_torch.sh
+++ b/.github/scripts/install_torch.sh
@@ -1,4 +1,4 @@
-conda create -y -n ${ENV_NAME} python=${MATRIX_PYTHON_VERSION} numpy
+conda create -y -n ${ENV_NAME} python=${MATRIX_PYTHON_VERSION}
 conda activate ${ENV_NAME}
 export MATRIX_INSTALLATION="${MATRIX_INSTALLATION/torchvision}"
 export MATRIX_INSTALLATION="${MATRIX_INSTALLATION/torchaudio}"


### PR DESCRIPTION
Remove numpy from default install since not available for 3.11 python