### PR TITLE
Highlight selected jobs on reliability metric page

### DIFF
--- a/torchci/components/hud.module.css
+++ b/torchci/components/hud.module.css
@@ -101,3 +101,8 @@
 .forcedMergeWarning {
   background-color: lightyellow;
 }
+
+.selectedRow {
+  background-color: lightblue;
+  font-weight: bold;
+}

--- a/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
+++ b/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
@@ -29,11 +29,12 @@ import React from "react";
 import { TimeRangePicker } from "../../../metrics";
 import TablePanel from "components/metrics/panels/TablePanel";
 import { GridRenderCellParams } from "@mui/x-data-grid";
+import styles from "components/hud.module.css";
 
 const PRIMARY_WORKFLOWS = ["lint", "pull", "trunk"];
 const SECONDARY_WORKFLOWS = ["periodic", "inductor"];
 const UNSTABLE_WORKFLOWS = ["unstable"];
-const LAST_MONTH = 30;
+const LAST_WEEK = 7;
 const ROW_HEIGHT = 340;
 const ROW_GAP = 30;
 const URL_PREFIX = `/reliability/pytorch/pytorch?jobName=`;
@@ -45,12 +46,14 @@ function GroupReliabilityPanel({
   queryParams,
   metricHeaderName,
   metricName,
+  filter,
 }: {
   title: string;
   queryName: string;
   queryParams: RocksetParam[];
   metricHeaderName: string;
   metricName: string;
+  filter: any;
 }) {
   return (
     <TablePanel
@@ -77,6 +80,14 @@ function GroupReliabilityPanel({
 
             const encodedJobName = encodeURIComponent(jobName);
             return <a href={URL_PREFIX + encodedJobName}>{jobName}</a>;
+          },
+          cellClassName: (params: GridCellParams<string>) => {
+            const jobName = params.value;
+            if (jobName === undefined) {
+              return "";
+            }
+
+            return filter.has(jobName) ? styles.selectedRow : "";
           },
         },
       ]}
@@ -135,13 +146,15 @@ function Graphs({
   queryParams,
   granularity,
   checkboxRef,
+  filter,
+  toggleFilter,
 }: {
   queryParams: RocksetParam[];
   granularity: Granularity;
   checkboxRef: any;
+  filter: any;
+  toggleFilter: any;
 }) {
-  const [filter, setFilter] = useState(new Set());
-
   const queryName = "master_commit_red_percent_groups";
   const url = `/api/query/metrics/${queryName}?parameters=${encodeURIComponent(
     JSON.stringify(queryParams)
@@ -160,17 +173,6 @@ function Graphs({
   }
   if (data === undefined) {
     return <Skeleton variant={"rectangular"} height={"100%"} />;
-  }
-
-  function toggleFilter(e: any) {
-    var jobName = e.target.id;
-    const next = new Set(filter);
-    if (filter.has(jobName)) {
-      next.delete(jobName);
-    } else {
-      next.add(jobName);
-    }
-    setFilter(next);
   }
 
   // Clamp to the nearest granularity (e.g. nearest hour) so that the times will
@@ -212,7 +214,7 @@ function Graphs({
           ref={checkboxRef}
         >
           {redPercentages.map((job) => (
-            <div key={job["name"]}>
+            <div key={job["name"]} className={filter.has(job[groupByFieldName]) ? styles.selectedRow : ""}>
               <input
                 type="checkbox"
                 id={job[groupByFieldName]}
@@ -265,9 +267,21 @@ export default function Page() {
   const router = useRouter();
   const jobName: string = (router.query.jobName as string) ?? "none";
 
-  const [startTime, setStartTime] = useState(dayjs().subtract(1, "month"));
+  const [startTime, setStartTime] = useState(dayjs().subtract(1, "week"));
   const [stopTime, setStopTime] = useState(dayjs());
   const [granularity, setGranularity] = useState<Granularity>("day");
+
+  const [filter, setFilter] = useState(new Set());
+  function toggleFilter(e: any) {
+    var jobName = e.target.id;
+    const next = new Set(filter);
+    if (filter.has(jobName)) {
+      next.delete(jobName);
+    } else {
+      next.add(jobName);
+    }
+    setFilter(next);
+  }
 
   const queryParams: RocksetParam[] = [
     {
@@ -313,7 +327,7 @@ export default function Page() {
           stopTime={stopTime}
           setStartTime={setStartTime}
           setStopTime={setStopTime}
-          defaultValue={LAST_MONTH}
+          defaultValue={LAST_WEEK}
         />
         <GranularityPicker
           granularity={granularity}
@@ -332,6 +346,8 @@ export default function Page() {
           ])}
           granularity={granularity}
           checkboxRef={checkboxRef}
+          filter={filter}
+          toggleFilter={toggleFilter}
         />
       </Grid>
 
@@ -349,6 +365,7 @@ export default function Page() {
             ])}
             metricName={"red"}
             metricHeaderName={"Failures %"}
+            filter={filter}
           />
         </Grid>
 
@@ -365,6 +382,7 @@ export default function Page() {
             ])}
             metricName={"red"}
             metricHeaderName={"Failures %"}
+            filter={filter}
           />
         </Grid>
 
@@ -381,6 +399,7 @@ export default function Page() {
             ])}
             metricName={"red"}
             metricHeaderName={"Failures %"}
+            filter={filter}
           />
         </Grid>
       </Grid>

--- a/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
+++ b/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
@@ -28,7 +28,7 @@ import { durationDisplay } from "components/TimeUtils";
 import React from "react";
 import { TimeRangePicker } from "../../../metrics";
 import TablePanel from "components/metrics/panels/TablePanel";
-import { GridRenderCellParams } from "@mui/x-data-grid";
+import { GridRenderCellParams, GridCellParams } from "@mui/x-data-grid";
 import styles from "components/hud.module.css";
 
 const PRIMARY_WORKFLOWS = ["lint", "pull", "trunk"];
@@ -214,7 +214,12 @@ function Graphs({
           ref={checkboxRef}
         >
           {redPercentages.map((job) => (
-            <div key={job["name"]} className={filter.has(job[groupByFieldName]) ? styles.selectedRow : ""}>
+            <div
+              key={job["name"]}
+              className={
+                filter.has(job[groupByFieldName]) ? styles.selectedRow : ""
+              }
+            >
               <input
                 type="checkbox"
                 id={job[groupByFieldName]}

--- a/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -27,6 +27,7 @@ import {
 import { durationDisplay } from "components/TimeUtils";
 import React from "react";
 import { TimeRangePicker, TtsPercentilePicker } from "../../../../metrics";
+import styles from "components/hud.module.css";
 
 const SUPPORTED_WORKFLOWS = [
   "pull",
@@ -90,6 +91,8 @@ function Graphs({
   selectedJobName,
   checkboxRef,
   branchName,
+  filter,
+  toggleFilter,
 }: {
   queryParams: RocksetParam[];
   granularity: Granularity;
@@ -97,8 +100,9 @@ function Graphs({
   selectedJobName: string;
   checkboxRef: any;
   branchName: string;
+  filter: any;
+  toggleFilter: any;
 }) {
-  const [filter, setFilter] = useState(new Set());
   const ROW_HEIGHT = 800;
 
   let queryName = "tts_duration_historical_percentile";
@@ -137,16 +141,6 @@ function Graphs({
     return <Skeleton variant={"rectangular"} height={"100%"} />;
   }
 
-  function toggleFilter(e: any) {
-    var jobName = e.target.id;
-    const next = new Set(filter);
-    if (filter.has(jobName)) {
-      next.delete(jobName);
-    } else {
-      next.add(jobName);
-    }
-    setFilter(next);
-  }
   let startTime = queryParams.find((p) => p.name === "startTime")?.value;
   let stopTime = queryParams.find((p) => p.name === "stopTime")?.value;
 
@@ -199,7 +193,10 @@ function Graphs({
           ref={checkboxRef}
         >
           {tts_true_series.map((job) => (
-            <div key={job["name"]}>
+            <div
+              key={job["name"]}
+              className={filter.has(job["name"]) ? styles.selectedRow : ""}
+            >
               <input
                 type="checkbox"
                 id={job["name"]}
@@ -261,6 +258,18 @@ export default function Page() {
   const [stopTime, setStopTime] = useState(dayjs());
   const [granularity, setGranularity] = useState<Granularity>("day");
   const [ttsPercentile, setTtsPercentile] = useState<number>(percentile);
+
+  const [filter, setFilter] = useState(new Set());
+  function toggleFilter(e: any) {
+    var jobName = e.target.id;
+    const next = new Set(filter);
+    if (filter.has(jobName)) {
+      next.delete(jobName);
+    } else {
+      next.add(jobName);
+    }
+    setFilter(next);
+  }
 
   const queryParams: RocksetParam[] = [
     {
@@ -335,6 +344,8 @@ export default function Page() {
         selectedJobName={jobName}
         checkboxRef={checkboxRef}
         branchName={branch}
+        filter={filter}
+        toggleFilter={toggleFilter}
       />
     </div>
   );

--- a/torchci/rockset/metrics/__sql/master_commit_red_percent_groups.sql
+++ b/torchci/rockset/metrics/__sql/master_commit_red_percent_groups.sql
@@ -61,15 +61,23 @@ reds AS(
         AND SUM(IF(conclusion IS NULL, 1, 0)) = 0 -- Filter out commits that still have pending jobs.
     ORDER BY
         time DESC
+),
+reds_percentage AS (
+    SELECT
+        FORMAT_TIMESTAMP('%Y-%m-%d', DATE_TRUNC(:granularity, time)) AS granularity_bucket,
+        name,
+        ROUND(AVG(any_red) * 100, 2) AS red,
+    FROM
+        reds
+    GROUP BY
+        granularity_bucket,
+        name
 )
 SELECT
-    FORMAT_TIMESTAMP('%Y-%m-%d', DATE_TRUNC(:granularity, time)) AS granularity_bucket,
-    name,
-    ROUND(AVG(any_red) * 100, 2) AS red,
+    *
 FROM
-    reds
-GROUP BY
-    granularity_bucket,
-    name
+    reds_percentage
+WHERE
+    red > 0
 ORDER BY
     name ASC

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -42,7 +42,7 @@
     "master_commit_red_avg": "18c967f80a2cb6c5",
     "master_commit_red": "b05a2786103f135c",
     "master_commit_red_percent": "5246c800e886b537",
-    "master_commit_red_percent_groups": "224122f2a006f130",
+    "master_commit_red_percent_groups": "448110ed411a2ff6",
     "master_jobs_red_avg": "084ae0664e81bc00",
     "master_jobs_red": "44c34a7f339dff68",
     "number_of_force_pushes": "7c12c25f00d85d5d",


### PR DESCRIPTION
Several small tweaks from the team review:

* Highlight selected jobs on reliability and TTS pages
* Get rid of jobs with no failure during the selected period, i.e. 0% red
* Make the default period of 1 week, same as others

### Testing

https://torchci-git-fork-huydhn-highlight-reliabili-8fe0d0-fbopensource.vercel.app/reliability/pytorch/pytorch?jobName=Lint%20%2F%20lintrunner