### PR TITLE
Remove `conda-build` from setup-miniconda action

### DIFF
--- a/.github/actions/setup-miniconda/README.md
+++ b/.github/actions/setup-miniconda/README.md
@@ -1,6 +1,6 @@
 # setup-miniconda
 
-Sets up miniconda in your `${RUNNER_TEMP}` environment and gives you the `${CONDA_RUN}` environment variable so you don't have to worry about polluting non-empeheral runners anymore
+Sets up miniconda in your `${RUNNER_TEMP}` environment and gives you the `${CONDA_RUN}` environment variable so you don't have to worry about polluting non-empeheral runners anymore. Intended to be used for CI, rather than binary builds (specifically it does not install `conda-build`)
 
 ## Supported platforms
 
@@ -13,7 +13,6 @@ Sets up miniconda in your `${RUNNER_TEMP}` environment and gives you the `${COND
 This action provides the following environment variables to use with the provided conda environment:
 
 * `CONDA_RUN` to run specific commands (including python within the environment)
-* `CONDA_BUILD` to run conda-build from the created environment
 * `CONDA_INSTALL` to install extra dependencies within the provided environment
 
 ```yaml
@@ -29,8 +28,4 @@ This action provides the following environment variables to use with the provide
       - name: Can use ${CONDA_INSTALL}, installs older numpy
         run: |
           ${CONDA_INSTALL} numpy=1.17
-      - name: Can use ${CONDA_BUILD}, outputs version
-        run: |
-          ${CONDA_BUILD} --version
-          ${CONDA_BUILD} path/to/mypackage
 ```

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -116,7 +116,6 @@ runs:
             ${ENV_FILE_FLAG} \
             python="${PYTHON_VERSION}" \
             cmake=3.22 \
-            conda-build=3.21 \
             ninja=1.10 \
             pkg-config=0.29 \
             wheel=0.37

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -138,10 +138,6 @@ runs:
             --prefix "${CONDA_ENV}" \
             --clone "${CONDA_BASE_ENV}"
 
-          # TODO: conda-build could not be cloned because it hardcodes the path, so it
-          # could not be cached
-          conda install --yes -p ${CONDA_ENV} conda-build=3.21
-
           echo "CONDA_ENV=${CONDA_ENV}" >> "${GITHUB_ENV}"
           echo "CONDA_RUN=conda run -p ${CONDA_ENV} --no-capture-output" >> "${GITHUB_ENV}"
           echo "CONDA_BUILD=conda run -p ${CONDA_ENV} conda-build" >> "${GITHUB_ENV}"

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -110,6 +110,11 @@ runs:
             echo "::warning::Specified env file (${ENV_FILE}) not found, not going to include it"
           fi
 
+          CONDA_EXTRA_FLAGS=""
+          if [[ "${PYTHON_VERSION}" == "3.11" ]]; then
+            CONDA_EXTRA_FLAGS=" -c pytorch-nightly"
+          fi
+
           conda create \
             --yes \
             --prefix "${CONDA_BASE_ENV}" \
@@ -118,7 +123,8 @@ runs:
             cmake=3.22 \
             ninja=1.10 \
             pkg-config=0.29 \
-            wheel=0.37
+            wheel=0.37 \
+            ${CONDA_EXTRA_FLAGS}
 
           if [[ -f "${PIP_REQUIREMENTS_FILE}" ]]; then
             conda run -p "${CONDA_BASE_ENV}" --no-capture-output python3 -mpip install -r "${PIP_REQUIREMENTS_FILE}"
@@ -140,4 +146,9 @@ runs:
 
           echo "CONDA_ENV=${CONDA_ENV}" >> "${GITHUB_ENV}"
           echo "CONDA_RUN=conda run -p ${CONDA_ENV} --no-capture-output" >> "${GITHUB_ENV}"
-          echo "CONDA_INSTALL=conda install -p ${CONDA_ENV}" >> "${GITHUB_ENV}"
+          if [[ "${PYTHON_VERSION}" == "3.11" ]]; then
+            # TODO: Remove me, when more packages will be available on default channel
+            echo "CONDA_INSTALL=conda install -p ${CONDA_ENV} -c pytorch-nightly" >> "${GITHUB_ENV}"
+          else
+            echo "CONDA_INSTALL=conda install -p ${CONDA_ENV}" >> "${GITHUB_ENV}"
+          fi

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -140,5 +140,4 @@ runs:
 
           echo "CONDA_ENV=${CONDA_ENV}" >> "${GITHUB_ENV}"
           echo "CONDA_RUN=conda run -p ${CONDA_ENV} --no-capture-output" >> "${GITHUB_ENV}"
-          echo "CONDA_BUILD=conda run -p ${CONDA_ENV} conda-build" >> "${GITHUB_ENV}"
           echo "CONDA_INSTALL=conda install -p ${CONDA_ENV}" >> "${GITHUB_ENV}"

--- a/.github/workflows/test-setup-miniconda.yml
+++ b/.github/workflows/test-setup-miniconda.yml
@@ -19,7 +19,7 @@ jobs:
         # Only testing minimum and maximum versions here
         python-version:
           - "3.8"
-          - "3.10"
+          - "3.11"
         env-file:
           - ""
           - "./.github/workflows/test-setup-miniconda-env-file"

--- a/.github/workflows/test-setup-miniconda.yml
+++ b/.github/workflows/test-setup-miniconda.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Can use ${CONDA_INSTALL}, installs some conda packages
         run: |
-          ${CONDA_INSTALL} numpy cmake cffi ninja typing_extensions dataclasses pip
+          ${CONDA_INSTALL} numpy cmake ninja typing_extensions dataclasses pip
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/test-setup-miniconda.yml
+++ b/.github/workflows/test-setup-miniconda.yml
@@ -18,16 +18,8 @@ jobs:
           - linux.2xlarge
         # Only testing minimum and maximum versions here
         python-version:
-          - "3.7"
           - "3.8"
           - "3.10"
-        exclude:
-          - runner-type: macos-m1-12
-            python-version: "3.7"
-          - runner-type: macos-12
-            python-version: "3.8"
-          - runner-type: linux.2xlarge
-            python-version: "3.8"
         env-file:
           - ""
           - "./.github/workflows/test-setup-miniconda-env-file"
@@ -62,11 +54,6 @@ jobs:
       - name: Can use ${CONDA_INSTALL}, installs some conda packages
         run: |
           ${CONDA_INSTALL} numpy cmake cffi ninja typing_extensions dataclasses pip
-
-      - name: Can use ${CONDA_BUILD}, outputs correct version
-        run: |
-          ${CONDA_BUILD} --version
-          ${CONDA_BUILD} --version | grep "3.21"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
As it is only needed for binary builds, which are executed using their own `setup-binary-builds`

Updated documentation to highlight, that this is not the workflow to use for binary builds (it's almost sad that `setup-binary-builds` copy-pastes a lots of code rather than reuse it)

Bumped minimum version to 3.8 and maximum to 3.11, but added `-c pytorch-nightly` temp workaround for 3.11 installations.

Checked using https://cs.github.com/?scope=org%3Apytorch&scopeName=pytorch&q=setup-miniconda+NOT+conda-incubator that it's currently not used for binary builds