### PR TITLE
Remove viable/strict lag per commit chart

### DIFF
--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -109,21 +109,6 @@ export default function Kpis() {
                 additionalOptions={{ yAxis: { max: 7 } }}
               />
             </Grid>
-            <Grid item xs={12} lg={6} height={ROW_HEIGHT}>
-              <TimeSeriesPanel
-                title={"viable/strict Lag (Per Commit)"}
-                queryName={"strict_lag_historical"}
-                queryCollection={"pytorch_dev_infra_kpis"}
-                queryParams={[...timeParams]}
-                granularity={"minute"}
-                timeFieldName={"push_time"}
-                yAxisFieldName={"diff_hr"}
-                yAxisLabel={"Hours"}
-                yAxisRenderer={(unit) => `${unit}`}
-                // the data is very variable, so set the y axis to be something that makes this chart a bit easier to read
-                additionalOptions={{ yAxis: { max: 7 } }}
-              />
-            </Grid>
         </Grid>
     );
 }


### PR DESCRIPTION
Is this possible to remove the viable/strict lag per commit chart on the KPI page?  It's not a big deal, but this chart is really hard to interpret because of its level of detail (per commit)

I couldn't think of any value keeping it there as I only look at the easier-to-understand daily viable/strict lag chart.  But I couldn't be very wrong here.