### PR TITLE
[Nova] Test conda package dependencies

### DIFF
--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -127,14 +127,14 @@ jobs:
             -c "pytorch-${CHANNEL}" \
             --no-anaconda-upload \
             --python "${PYTHON_VERSION}" \
-            --output-folder dist/ \
+            --output-folder distr/ \
             "${CONDA_PACKAGE_DIRECTORY}"
       - name: Upload artifact to GitHub
         continue-on-error: true
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          path: ${{ inputs.repository }}/dist/
+          path: ${{ inputs.repository }}/distr/
       - name: Run post-script
         working-directory: ${{ inputs.repository }}
         env:
@@ -159,26 +159,15 @@ jobs:
         run: |
           set -euxo pipefail
           source "${BUILD_ENV_FILE}"
-          CONDA_OUTPUT_PATH="${{ inputs.repository }}/dist/linux-64/"
-          echo "$CONDA_OUTPUT_PATH"
-          BINARY_NAME=$(ls "$CONDA_OUTPUT_PATH"/*.tar.bz2)
-          echo "$BINARY_NAME"
-
-          if [[ "${{ inputs.package-name }}" = "torchvision" ]]; then
-              ${CONDA_RUN} conda install -y 'numpy>=1.11'
-              ${CONDA_RUN} conda install pillow
-          fi
-          if [[ "${{ inputs.package-name }}" = "torchdata" ]]; then
-              ${CONDA_RUN} conda install -y portalocker>=2.0.0
-          fi
+          CONDA_LOCAL_CHANNEL="file://$(readlink -f ${{ inputs.repository }}/distr)"
 
           if [[ "${GPU_ARCH}" = "cuda" ]]; then
-            ${CONDA_RUN} conda install -v -y -c pytorch-"${CHANNEL}" -c nvidia pytorch pytorch-cuda="${GPU_ARCH_VERSION}"
+            CONSTRAINTS="pytorch-cuda=${GPU_ARCH_VERSION}"
           else
-            ${CONDA_RUN} conda install -v -y -c pytorch-"${CHANNEL}" pytorch cpuonly
+            CONSTRAINTS="cpuonly"
           fi
+          ${CONDA_RUN} conda install -v -y -c pytorch-"${CHANNEL}" -c nvidia -c "${CONDA_LOCAL_CHANNEL}" distr::"${PACKAGE_NAME}" ${CONSTRAINTS}
 
-          ${CONDA_RUN} conda install "$BINARY_NAME"
 
           if [[ ! -f "${{ inputs.repository }}"/${SMOKE_TEST_SCRIPT} ]]; then
             echo "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT} not found"
@@ -199,7 +188,7 @@ jobs:
           source "${BUILD_ENV_FILE}"
           conda create --yes -n upload_env python="${PYTHON_VERSION}"
           conda run -n upload_env conda install -yq anaconda-client
-          conda run -n upload_env anaconda -t "${CONDA_PYTORCHBOT_TOKEN}" upload dist/linux-64/*.tar.bz2 -u "pytorch-${CHANNEL}" --label main --no-progress --force
+          conda run -n upload_env anaconda -t "${CONDA_PYTORCHBOT_TOKEN}" upload distr/linux-64/*.tar.bz2 -u "pytorch-${CHANNEL}" --label main --no-progress --force
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
Rather than guessing what is needed(and hardcoding dependencies in .yml file), make conda figure out it out from package dependencies.
Few quirks:
 - A valid repository is needed to make local channel installation work, so I've created https://anaconda.org/distr and changed output folder to be distr
 - Also, explicitly specify the repo we want to install from, by prefixing package name with `channel_name::`

As result, all explicit dependency installation could be removed