### PR TITLE
Breakdown CI reliability metric into categories

### DIFF
--- a/torchci/components/FilteredJobList.tsx
+++ b/torchci/components/FilteredJobList.tsx
@@ -2,10 +2,11 @@ import { fetcher } from "lib/GeneralUtils";
 import { JobData } from "lib/types";
 import { useRouter } from "next/router";
 import useSWR from "swr";
-import JobAnnotationToggle, { JobAnnotation } from "./JobAnnotationToggle";
+import JobAnnotationToggle from "./JobAnnotationToggle";
 import JobLinks from "./JobLinks";
 import JobSummary from "./JobSummary";
 import LogViewer from "./LogViewer";
+import { JobAnnotation } from "lib/types";
 
 export default function FilteredJobList({
   filterName,

--- a/torchci/components/JobAnnotationToggle.tsx
+++ b/torchci/components/JobAnnotationToggle.tsx
@@ -1,17 +1,7 @@
 import React from "react";
-import { JobData } from "../lib/types";
+import { JobData, JobAnnotation } from "../lib/types";
 import { ToggleButtonGroup, ToggleButton } from "@mui/material";
 import { useSession } from "next-auth/react";
-
-export enum JobAnnotation {
-  NULL = "None",
-  BROKEN_TRUNK = "Broken Trunk",
-  TEST_FLAKE = "Test Flake",
-  INFRA_BROKEN = "Broken Infra",
-  INFRA_FLAKE = "Infra Flake",
-  NETWORK = "Network Error",
-  OTHER = "Other"
-}
 
 export default function JobAnnotationToggle({
   job,

--- a/torchci/components/metrics/panels/TablePanel.tsx
+++ b/torchci/components/metrics/panels/TablePanel.tsx
@@ -34,6 +34,31 @@ export default function TablePanel({
     refreshInterval: 5 * 60 * 1000, // refresh every 5 minutes
   });
 
+  return (
+    <TablePanelWithData
+      title={title}
+      data={data}
+      columns={columns}
+      dataGridProps={dataGridProps}
+    />
+  );
+}
+
+export function TablePanelWithData({
+  // Human-readable title for this panel.
+  title,
+  // The raw data to display in the table
+  data,
+  // Column definitions for the data grid.
+  columns,
+  // Props to propagate to the data grid.
+  dataGridProps,
+}: {
+  title: string;
+  data: any;
+  columns: GridColDef[];
+  dataGridProps: any;
+}) {
   if (data === undefined) {
     return <Skeleton variant={"rectangular"} height={"100%"} />;
   }

--- a/torchci/lib/metricUtils.ts
+++ b/torchci/lib/metricUtils.ts
@@ -106,7 +106,7 @@ export function approximateFailureByType(
     // Iterate though all the failures in the commit and aggregate them by name
     failures.forEach((failure: string) => {
       if (!(failure in failuresCount)) {
-        // Start the count
+        // Make sure the dict is initialized
         failuresCount[failure] = 0;
       }
 

--- a/torchci/lib/metricUtils.ts
+++ b/torchci/lib/metricUtils.ts
@@ -174,10 +174,13 @@ export function approximateFailureByTypePercent(
 
   Object.keys(failuresByTypes).forEach((jobName: string) => {
     const successCount = successesByJobName[jobName] ?? 0;
-    const failureCount = Object.values(failuresByTypes[jobName]).reduce(
-      (a, b) => a + b,
-      0
-    );
+    const failureCount = Object.entries(failuresByTypes[jobName])
+      .filter(item => item[0] === JobAnnotation.BROKEN_TRUNK || item[0] === JobAnnotation.TEST_FLAKE)
+      .map(item => item[1])
+      .reduce(
+        (a, b) => a + b,
+        0
+      );
     const totalCount = successCount + failureCount;
 
     Object.keys(failuresByTypes[jobName]).forEach((failure: string) => {

--- a/torchci/lib/metricUtils.ts
+++ b/torchci/lib/metricUtils.ts
@@ -72,7 +72,7 @@ export function approximateSuccessByJobName(
     // Iterate though all the successes in the commit and aggregate them by name
     successes.forEach((success: string) => {
       if (!(success in successesByJobName)) {
-        // Start the count
+        // Make sure the dict is initialized
         successesByJobName[success] = 0;
       }
 
@@ -168,7 +168,7 @@ export function approximateFailureByTypePercent(
     return failuresByTypes;
   }
 
-  // Get the number of times the job successes too, so we can calculate the %
+  // Get the number of times the job succeeds too, so we can calculate the %
   const successesByJobName = approximateSuccessByJobName(data);
 
   Object.keys(failuresByTypes).forEach((jobName: string) => {

--- a/torchci/lib/metricUtils.ts
+++ b/torchci/lib/metricUtils.ts
@@ -175,12 +175,13 @@ export function approximateFailureByTypePercent(
   Object.keys(failuresByTypes).forEach((jobName: string) => {
     const successCount = successesByJobName[jobName] ?? 0;
     const failureCount = Object.entries(failuresByTypes[jobName])
-      .filter(item => item[0] === JobAnnotation.BROKEN_TRUNK || item[0] === JobAnnotation.TEST_FLAKE)
-      .map(item => item[1])
-      .reduce(
-        (a, b) => a + b,
-        0
-      );
+      .filter(
+        (item) =>
+          item[0] === JobAnnotation.BROKEN_TRUNK ||
+          item[0] === JobAnnotation.TEST_FLAKE
+      )
+      .map((item) => item[1])
+      .reduce((a, b) => a + b, 0);
     const totalCount = successCount + failureCount;
 
     Object.keys(failuresByTypes[jobName]).forEach((failure: string) => {

--- a/torchci/lib/metricUtils.ts
+++ b/torchci/lib/metricUtils.ts
@@ -1,0 +1,179 @@
+import { JobsPerCommitData, JobAnnotation } from "lib/types";
+
+// When N consecutive failures of the same type happen, the failures are counted as
+// broken trunk failures (approximately)
+export const BROKEN_TRUNK_THRESHOLD = 3;
+
+// When more than N failures happening in the same commit, the failures are counted
+// as part of an outage (approximately)
+export const OUTAGE_THRESHOLD = 10;
+
+function updateOutageCount(
+  failure: string,
+  count: number,
+  failuresByTypes: { [failure: string]: { [t: string] : number } },
+) {
+  if (!(failure in failuresByTypes)) {
+    // TODO: Only these categories can be approximated at the moment
+    failuresByTypes[failure] = {
+      [JobAnnotation.BROKEN_TRUNK]: 0,
+      [JobAnnotation.INFRA_BROKEN]: 0,
+      [JobAnnotation.TEST_FLAKE]: 0,
+    };
+  }
+
+  failuresByTypes[failure][JobAnnotation.INFRA_BROKEN] += count;
+}
+
+function updateFailuresCount(
+  failure: string,
+  count: number,
+  failuresByTypes: { [failure: string]: { [t: string] : number } },
+  is_broken_trunk: boolean,
+) {
+  // No such failure has been recorded yet
+  if (count === 0) {
+    return;
+  }
+
+  if (!(failure in failuresByTypes)) {
+    // TODO: Only these categories can be approximated at the moment
+    failuresByTypes[failure] = {
+      [JobAnnotation.BROKEN_TRUNK]: 0,
+      [JobAnnotation.INFRA_BROKEN]: 0,
+      [JobAnnotation.TEST_FLAKE]: 0,
+    };
+  }
+
+  if (is_broken_trunk) {
+    failuresByTypes[failure][JobAnnotation.BROKEN_TRUNK] += count;
+  }
+  else {
+    // Not a broken trunk, count as flaky
+    failuresByTypes[failure][JobAnnotation.TEST_FLAKE] += count;
+  }
+}
+
+export function approximateSuccessByJobName(
+  // The data from Rockset is sorted by time DESC, so newer commits come first
+  data?: JobsPerCommitData[],
+) {
+  const successesByJobName: { [success: string]: number } = {};
+
+  if (data === undefined || data === null) {
+    return successesByJobName;
+  }
+
+  data.forEach((commit: JobsPerCommitData) =>  {
+    const successes = new Set(commit.successes.filter(n => n !== null && n !== undefined && n.length > 0));
+
+    // Iterate though all the successes in the commit and aggregate them by name
+    successes.forEach((success: string) => {
+      if (!(success in successesByJobName)) {
+        // Start the count
+        successesByJobName[success] = 0;
+      }
+
+      successesByJobName[success] += 1;
+    });
+  });
+
+  return successesByJobName;
+}
+
+export function approximateFailureByType(
+  // The data from Rockset is sorted by time DESC, so newer commits come first
+  data?: JobsPerCommitData[],
+  broken_trunk_threshold: number = BROKEN_TRUNK_THRESHOLD,
+  outage_threshold: number = OUTAGE_THRESHOLD,
+) {
+  const failuresByTypes: { [failure: string]: { [t: string] : number } } = {};
+
+  if (data === undefined || data === null) {
+    return failuresByTypes;
+  }
+
+  const failuresCount: { [failure: string]: number } = {};
+  data.forEach((commit: JobsPerCommitData) =>  {
+    const failures = new Set(commit.failures.filter(n => n !== null && n !== undefined && n.length > 0));
+
+    // Iterate though all the failures in the commit and aggregate them by name
+    failures.forEach((failure: string) => {
+      if (!(failure in failuresCount)) {
+        // Start the count
+        failuresCount[failure] = 0;
+      }
+
+      failuresCount[failure] += 1;
+    });
+
+    // Check if the job still fail in this commit
+    Object.keys(failuresCount).forEach((failure: string) => {
+      if (failures.has(failure)) {
+        // Count the commit as part of an outage
+        if (failures.size >= outage_threshold) {
+          updateOutageCount(
+            failure,
+            1,
+            failuresByTypes,
+          );
+        }
+
+        // Still failing, its counter has already been updated
+        return;
+      }
+
+      const count = failuresCount[failure];
+      // Reaching here means that the job starts to fail on the commit after this
+      updateFailuresCount(
+        failure,
+        count,
+        failuresByTypes,
+        count >= broken_trunk_threshold,
+      );
+
+      // Reset the count
+      failuresCount[failure] = 0;
+    });
+  });
+
+  Object.keys(failuresCount).forEach((failure: string) => {
+    const count = failuresCount[failure];
+    // Aggregate all remaining jobs
+    updateFailuresCount(
+      failure,
+      count,
+      failuresByTypes,
+      count >= broken_trunk_threshold,
+    );
+  });
+
+  return failuresByTypes;
+}
+
+export function approximateFailureByTypePercent(
+  // The data from Rockset is sorted by time DESC, so newer commits come first
+  data?: JobsPerCommitData[],
+  broken_trunk_threshold: number = BROKEN_TRUNK_THRESHOLD,
+  outage_threshold: number = OUTAGE_THRESHOLD,
+) {
+  const failuresByTypes = approximateFailureByType(data, broken_trunk_threshold, outage_threshold);
+  if (data === undefined || data === null || data.length === 0) {
+    return failuresByTypes;
+  }
+
+  // Get the number of times the job successes too, so we can calculate the %
+  const successesByJobName = approximateSuccessByJobName(data);
+
+  Object.keys(failuresByTypes).forEach((jobName: string) => {
+    const successCount = successesByJobName[jobName] ?? 0;
+    const failureCount = Object.values(failuresByTypes[jobName]).reduce((a, b) => a + b, 0);
+    const totalCount = successCount + failureCount;
+
+    Object.keys(failuresByTypes[jobName]).forEach((failure: string) => {
+      failuresByTypes[jobName][failure] = (failuresByTypes[jobName][failure] / totalCount) * 100;
+    });
+  });
+
+  return failuresByTypes;
+}

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -53,7 +53,7 @@ export interface RowData extends CommitData {
   jobs: JobData[];
   groupedJobs?: Map<string, GroupData>;
   isForcedMerge: boolean | false;
-  nameToJobs?: Map<string, JobData>
+  nameToJobs?: Map<string, JobData>;
 }
 
 export interface HudData {
@@ -148,7 +148,7 @@ export enum JobAnnotation {
   INFRA_BROKEN = "Broken Infra",
   INFRA_FLAKE = "Infra Flake",
   NETWORK = "Network Error",
-  OTHER = "Other"
+  OTHER = "Other",
 }
 
 export function packHudParams(input: any) {
@@ -159,8 +159,8 @@ export function packHudParams(input: any) {
     page: parseInt((input.page as string) ?? 1),
     per_page: parseInt((input.per_page as string) ?? 50),
     nameFilter: input.name_filter as string | undefined,
-    filter_reruns: input.filter_reruns ?? false as boolean,
-    filter_unstable: input.filter_unstable ?? false as boolean,
+    filter_reruns: input.filter_reruns ?? (false as boolean),
+    filter_unstable: input.filter_unstable ?? (false as boolean),
   };
 }
 
@@ -190,11 +190,11 @@ function formatHudURL(
   base += `?per_page=${params.per_page}`;
 
   if (params.filter_reruns) {
-    base += `&filter_reruns=true`
+    base += `&filter_reruns=true`;
   }
 
   if (params.filter_unstable) {
-    base += `&filter_unstable=true`
+    base += `&filter_unstable=true`;
   }
 
   if (params.nameFilter != null && keepFilter) {

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -132,6 +132,25 @@ export interface TTSChange {
   absoluteChangeString: string;
 }
 
+export interface JobsPerCommitData {
+  sha: string;
+  author: string;
+  body?: string;
+  time: string;
+  failures: string[];
+  successes: string[];
+}
+
+export enum JobAnnotation {
+  NULL = "None",
+  BROKEN_TRUNK = "Broken Trunk",
+  TEST_FLAKE = "Test Flake",
+  INFRA_BROKEN = "Broken Infra",
+  INFRA_FLAKE = "Infra Flake",
+  NETWORK = "Network Error",
+  OTHER = "Other"
+}
+
 export function packHudParams(input: any) {
   return {
     repoOwner: input.repoOwner as string,

--- a/torchci/pages/failedjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/failedjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -8,10 +8,8 @@ import React, { useState } from "react";
 import JobSummary from "components/JobSummary";
 import JobLinks from "components/JobLinks";
 import LogViewer from "components/LogViewer";
-import JobAnnotationToggle, {
-  JobAnnotation,
-} from "components/JobAnnotationToggle";
-import { JobData } from "lib/types";
+import JobAnnotationToggle from "components/JobAnnotationToggle";
+import { JobData, JobAnnotation } from "lib/types";
 import { TimeRangePicker } from "pages/metrics";
 import dayjs from "dayjs";
 import { isRerunDisabledTestsJob, isUnstableJob } from "lib/jobUtils";

--- a/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -13,6 +13,7 @@ import {
   packHudParams,
   RowData,
   TTSChange,
+  JobAnnotation,
 } from "lib/types";
 import useHudData from "lib/useHudData";
 import useScrollTo from "lib/useScrollTo";
@@ -29,9 +30,7 @@ import {
   useState,
 } from "react";
 import useSWR, { SWRConfig } from "swr";
-import JobAnnotationToggle, {
-  JobAnnotation,
-} from "components/JobAnnotationToggle";
+import JobAnnotationToggle from "components/JobAnnotationToggle";
 
 function includesCaseInsensitive(value: string, pattern: string): boolean {
   if (pattern === "") {

--- a/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
+++ b/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
@@ -28,9 +28,13 @@ import { durationDisplay } from "components/TimeUtils";
 import React from "react";
 import { TimeRangePicker } from "../../../metrics";
 import { TablePanelWithData } from "components/metrics/panels/TablePanel";
-import { GridRenderCellParams, GridCellParams, GridValueFormatterParams } from "@mui/x-data-grid";
+import {
+  GridRenderCellParams,
+  GridCellParams,
+  GridValueFormatterParams,
+} from "@mui/x-data-grid";
 import styles from "components/hud.module.css";
-import { approximateFailureByTypePercent } from 'lib/metricUtils';
+import { approximateFailureByTypePercent } from "lib/metricUtils";
 import { JobAnnotation } from "lib/types";
 
 const PRIMARY_WORKFLOWS = ["lint", "pull", "trunk"];
@@ -44,7 +48,7 @@ const URL_PREFIX = `/reliability/pytorch/pytorch?jobName=`;
 function fetchData(
   queryName: string,
   queryCollection: string,
-  queryParams: any,
+  queryParams: any
 ) {
   const url = `/api/query/${queryCollection}/${queryName}?parameters=${encodeURIComponent(
     JSON.stringify(queryParams)
@@ -71,20 +75,12 @@ function GroupReliabilityPanel({
   metricName: string;
   filter: any;
 }) {
-  const data = fetchData(
-    "top_reds",
-    "metrics",
-    queryParams,
-  );
+  const data = fetchData("top_reds", "metrics", queryParams);
 
-  const failures = fetchData(
-    "master_commit_red_jobs",
-    "commons",
-    queryParams,
-  );
+  const failures = fetchData("master_commit_red_jobs", "commons", queryParams);
 
   if (data === undefined || failures === undefined) {
-    return (<Skeleton variant={"rectangular"} height={"100%"} />);
+    return <Skeleton variant={"rectangular"} height={"100%"} />;
   }
 
   const failuresByTypes = approximateFailureByTypePercent(failures);
@@ -97,9 +93,12 @@ function GroupReliabilityPanel({
 
     const jobName = row["name"];
     if (jobName in failuresByTypes) {
-      row[JobAnnotation.BROKEN_TRUNK] = failuresByTypes[jobName][JobAnnotation.BROKEN_TRUNK];
-      row[JobAnnotation.INFRA_BROKEN] = failuresByTypes[jobName][JobAnnotation.INFRA_BROKEN];
-      row[JobAnnotation.TEST_FLAKE] = failuresByTypes[jobName][JobAnnotation.TEST_FLAKE];
+      row[JobAnnotation.BROKEN_TRUNK] =
+        failuresByTypes[jobName][JobAnnotation.BROKEN_TRUNK];
+      row[JobAnnotation.INFRA_BROKEN] =
+        failuresByTypes[jobName][JobAnnotation.INFRA_BROKEN];
+      row[JobAnnotation.TEST_FLAKE] =
+        failuresByTypes[jobName][JobAnnotation.TEST_FLAKE];
     }
   });
 

--- a/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
+++ b/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
@@ -80,14 +80,14 @@ function GroupReliabilityPanel({
 
   // const displayFailures: { [jobName: string]: number } = {}
   const failuresByTypes = Object.entries(approximateFailureByTypePercent(data))
-    .map(item => {
+    .map((item) => {
       const jobName = item[0];
       const brokenTrunk = item[1][JobAnnotation.BROKEN_TRUNK];
       const infraBroken = item[1][JobAnnotation.INFRA_BROKEN];
       const testFlake = item[1][JobAnnotation.TEST_FLAKE];
 
       return {
-        "name": jobName,
+        name: jobName,
         [metricName]: brokenTrunk + testFlake,
         [JobAnnotation.BROKEN_TRUNK]: brokenTrunk,
         [JobAnnotation.INFRA_BROKEN]: infraBroken,

--- a/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
+++ b/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
@@ -109,7 +109,7 @@ function GroupReliabilityPanel({
         },
         {
           field: JobAnnotation.BROKEN_TRUNK,
-          headerName: "Approx. Broken Trunk %",
+          headerName: "~Broken Trunk %",
           flex: 1,
           valueFormatter: (params: GridValueFormatterParams<any>) => {
             return Number(params.value).toFixed(2);
@@ -117,7 +117,7 @@ function GroupReliabilityPanel({
         },
         {
           field: JobAnnotation.TEST_FLAKE,
-          headerName: "Approx. Flaky %",
+          headerName: "~Flaky %",
           flex: 1,
           valueFormatter: (params: GridValueFormatterParams<any>) => {
             return Number(params.value).toFixed(2);
@@ -125,7 +125,7 @@ function GroupReliabilityPanel({
         },
         {
           field: JobAnnotation.INFRA_BROKEN,
-          headerName: "Approx. Outage %",
+          headerName: "~Outage %",
           flex: 1,
           valueFormatter: (params: GridValueFormatterParams<any>) => {
             return Number(params.value).toFixed(2);

--- a/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
+++ b/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
@@ -71,20 +71,18 @@ function GroupReliabilityPanel({
     refreshInterval: 60 * 60 * 1000,
   });
 
-  // const data = fetchData("top_reds", "metrics", queryParams);
-  // const failures = fetchData("master_commit_red_jobs", "commons", queryParams);
-
   if (data === undefined) {
     return <Skeleton variant={"rectangular"} height={"100%"} />;
   }
 
-  // const displayFailures: { [jobName: string]: number } = {}
   const failuresByTypes = Object.entries(approximateFailureByTypePercent(data))
     .map((item) => {
       const jobName = item[0];
-      const brokenTrunk = item[1][JobAnnotation.BROKEN_TRUNK];
-      const infraBroken = item[1][JobAnnotation.INFRA_BROKEN];
-      const testFlake = item[1][JobAnnotation.TEST_FLAKE];
+      const percent = item[1];
+
+      const brokenTrunk = percent[JobAnnotation.BROKEN_TRUNK];
+      const infraBroken = percent[JobAnnotation.INFRA_BROKEN];
+      const testFlake = percent[JobAnnotation.TEST_FLAKE];
 
       return {
         name: jobName,
@@ -388,6 +386,11 @@ export default function Page() {
     }
   }, [jobName]);
 
+  const queryName = "master_commit_red_jobs";
+  const queryCollection = "commons";
+  const metricName = "red";
+  const metricHeaderName = "Failures %";
+
   return (
     <div>
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
@@ -427,8 +430,8 @@ export default function Page() {
         <Grid item xs={6} height={ROW_HEIGHT}>
           <GroupReliabilityPanel
             title={`Primary jobs (${PRIMARY_WORKFLOWS.join(", ")})`}
-            queryName="master_commit_red_jobs"
-            queryCollection="commons"
+            queryName={queryName}
+            queryCollection={queryCollection}
             queryParams={queryParams.concat([
               {
                 name: "workflowNames",
@@ -436,8 +439,8 @@ export default function Page() {
                 value: PRIMARY_WORKFLOWS.join(","),
               },
             ])}
-            metricName={"red"}
-            metricHeaderName={"Failures %"}
+            metricName={metricName}
+            metricHeaderName={metricHeaderName}
             filter={filter}
           />
         </Grid>
@@ -445,8 +448,8 @@ export default function Page() {
         <Grid item xs={6} height={ROW_HEIGHT}>
           <GroupReliabilityPanel
             title={`Secondary jobs (${SECONDARY_WORKFLOWS.join(", ")})`}
-            queryName="master_commit_red_jobs"
-            queryCollection="commons"
+            queryName={queryName}
+            queryCollection={queryCollection}
             queryParams={queryParams.concat([
               {
                 name: "workflowNames",
@@ -454,8 +457,8 @@ export default function Page() {
                 value: SECONDARY_WORKFLOWS.join(","),
               },
             ])}
-            metricName={"red"}
-            metricHeaderName={"Failures %"}
+            metricName={metricName}
+            metricHeaderName={metricHeaderName}
             filter={filter}
           />
         </Grid>
@@ -463,8 +466,8 @@ export default function Page() {
         <Grid item xs={6} height={ROW_HEIGHT}>
           <GroupReliabilityPanel
             title={"Unstable jobs"}
-            queryName="master_commit_red_jobs"
-            queryCollection="commons"
+            queryName={queryName}
+            queryCollection={queryCollection}
             queryParams={queryParams.concat([
               {
                 name: "workflowNames",
@@ -472,8 +475,8 @@ export default function Page() {
                 value: UNSTABLE_WORKFLOWS.join(","),
               },
             ])}
-            metricName={"red"}
-            metricHeaderName={"Failures %"}
+            metricName={metricName}
+            metricHeaderName={metricHeaderName}
             filter={filter}
           />
         </Grid>

--- a/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
+++ b/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
@@ -94,7 +94,7 @@ function GroupReliabilityPanel({
         [JobAnnotation.TEST_FLAKE]: testFlake,
       };
     })
-    .sort((a, b) => b[metricName] - a[metricName]);
+    .sort((a, b) => Number(b[metricName]) - Number(a[metricName]));
 
   return (
     <TablePanelWithData

--- a/torchci/rockset/commons/__sql/master_commit_red_jobs.sql
+++ b/torchci/rockset/commons/__sql/master_commit_red_jobs.sql
@@ -1,0 +1,79 @@
+WITH all_jobs AS (
+    SELECT
+        push._event_time AS time,
+        job.conclusion AS conclusion,
+        push.head_commit.id AS sha,
+        push.head_commit.author.username AS author,
+        CONCAT(
+            workflow.name,
+            ' / ',
+            ELEMENT_AT(SPLIT(job.name, ' / '), 1),
+            IF(
+                job.name LIKE '%/%',
+                CONCAT(' / ', ELEMENT_AT(SPLIT(ELEMENT_AT(SPLIT(job.name, ' / '), 2), ', '), 1)),
+                ''
+            )
+        ) AS name,
+        (
+            CASE
+                WHEN push.head_commit.author.username = 'pytorchmergebot' THEN push.head_commit.message
+                ELSE NULL
+            END
+        ) AS body,
+    FROM
+        commons.workflow_job job
+        JOIN commons.workflow_run workflow ON workflow.id = job.run_id
+        JOIN push on workflow.head_commit.id = push.head_commit.id
+    WHERE
+        job.name != 'ciflow_should_run'
+        AND job.name != 'generate-test-matrix'
+        AND job.name NOT LIKE '%rerun_disabled_tests%'
+        AND job.name NOT LIKE '%filter%'
+        AND (
+            LOWER(workflow.name) = 'lint'
+            OR job.name LIKE '%/%'
+        )
+        AND ARRAY_CONTAINS(SPLIT(:workflowNames, ','), LOWER(workflow.name))
+        AND workflow.event != 'workflow_run' -- Filter out worflow_run-triggered jobs, which have nothing to do with the SHA
+        AND push.ref = 'refs/heads/master'
+        AND push.repository.owner.name = 'pytorch'
+        AND push.repository.name = 'pytorch'
+        AND push._event_time >= PARSE_DATETIME_ISO8601(:startTime)
+        AND push._event_time < PARSE_DATETIME_ISO8601(:stopTime)
+),
+reds AS (
+    SELECT
+        time,
+        sha,
+        ARRAY_REMOVE(
+            ARRAY_AGG(
+                IF (conclusion = 'failure' OR conclusion = 'timed_out' OR conclusion = 'cancelled', IF (name LIKE '%(%' AND name NOT LIKE '%)%', CONCAT(name, ')'), name))
+            ),
+            NULL
+        ) AS names,
+        COUNT_IF(conclusion = 'failure' OR conclusion = 'timed_out' OR conclusion = 'cancelled') AS red_count,
+        author,
+        body
+    FROM
+        all_jobs
+    GROUP BY
+        time,
+        sha,
+        author,
+        body
+    HAVING
+        COUNT(*) > 10 -- Filter out jobs that didn't run anything.
+        AND SUM(IF(conclusion IS NULL, 1, 0)) = 0 -- Filter out commits that still have pending jobs.
+)
+SELECT
+    FORMAT_TIMESTAMP('%Y-%m-%d', DATE_TRUNC(:granularity, time)) AS granularity_bucket,
+    time,
+    sha,
+    red_count,
+    author,
+    body,
+    names
+FROM
+    reds
+ORDER BY
+    time DESC

--- a/torchci/rockset/commons/master_commit_red_jobs.lambda.json
+++ b/torchci/rockset/commons/master_commit_red_jobs.lambda.json
@@ -1,0 +1,26 @@
+{
+  "sql_path": "__sql/master_commit_red_jobs.sql",
+  "default_parameters": [
+    {
+      "name": "granularity",
+      "type": "string",
+      "value": "month"
+    },
+    {
+      "name": "startTime",
+      "type": "string",
+      "value": "2023-02-01T00:00:00.000Z"
+    },
+    {
+      "name": "stopTime",
+      "type": "string",
+      "value": "2023-03-01T00:00:00.000Z"
+    },
+    {
+      "name": "workflowNames",
+      "type": "string",
+      "value": "lint,pull,trunk"
+    }
+  ],
+  "description": ""
+}

--- a/torchci/rockset/commons/master_commit_red_jobs.lambda.json
+++ b/torchci/rockset/commons/master_commit_red_jobs.lambda.json
@@ -2,11 +2,6 @@
   "sql_path": "__sql/master_commit_red_jobs.sql",
   "default_parameters": [
     {
-      "name": "granularity",
-      "type": "string",
-      "value": "month"
-    },
-    {
       "name": "startTime",
       "type": "string",
       "value": "2023-02-01T00:00:00.000Z"

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -19,7 +19,8 @@
     "reverted_prs_with_reason": "751f01cba16364f0",
     "unclassified": "1b31a2d8f4ab7230",
     "test_insights_overview": "c9be5cbdda1030af",
-    "test_insights_latest_runs": "aa6c15c6d52860b2"
+    "test_insights_latest_runs": "aa6c15c6d52860b2",
+    "master_commit_red_jobs": "1c1772d77c997259"
   },
   "pytorch_dev_infra_kpis": {
     "num_reverts": "fd6e5a4fae7ef012",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -20,7 +20,7 @@
     "unclassified": "1b31a2d8f4ab7230",
     "test_insights_overview": "c9be5cbdda1030af",
     "test_insights_latest_runs": "aa6c15c6d52860b2",
-    "master_commit_red_jobs": "1c1772d77c997259"
+    "master_commit_red_jobs": "5e921da7a05fedad"
   },
   "pytorch_dev_infra_kpis": {
     "num_reverts": "f39141336b6ea956",

--- a/torchci/test/metricUtils.test.ts
+++ b/torchci/test/metricUtils.test.ts
@@ -1,77 +1,62 @@
-import { approximateFailureByType, approximateFailureByTypePercent, BROKEN_TRUNK_THRESHOLD } from '../lib/metricUtils';
+import {
+  approximateFailureByType,
+  approximateFailureByTypePercent,
+  BROKEN_TRUNK_THRESHOLD,
+} from "../lib/metricUtils";
 import { JobsPerCommitData, JobAnnotation } from "lib/types";
 
-describe('Approximate failures by its categories', () => {
-  test('no data', () => {
+describe("Approximate failures by its categories", () => {
+  test("no data", () => {
     expect(approximateFailureByType(undefined)).toStrictEqual({});
     expect(approximateFailureByType([])).toStrictEqual({});
   });
 
-  test('flaky failures', () => {
+  test("flaky failures", () => {
     const data: JobsPerCommitData[] = [
       {
         sha: "",
         author: "",
-        failures: [
-          "jobA",
-        ],
-        successes: [
-          "jobB",
-        ],
+        failures: ["jobA"],
+        successes: ["jobB"],
         time: "",
       },
       {
         sha: "",
         author: "",
-        failures: [
-          "jobB",
-        ],
-        successes: [
-          "jobA",
-        ],
+        failures: ["jobB"],
+        successes: ["jobA"],
         time: "",
       },
       {
         sha: "",
         author: "",
-        failures: [
-          "jobB",
-        ],
-        successes: [
-          "jobA",
-        ],
+        failures: ["jobB"],
+        successes: ["jobA"],
         time: "",
       },
       {
         sha: "",
         author: "",
         failures: [],
-        successes: [
-          "jobA",
-          "jobB",
-        ],
+        successes: ["jobA", "jobB"],
         time: "",
       },
       {
         sha: "",
         author: "",
-        failures: [
-          "jobA",
-        ],
-        successes: [
-          "jobB",
-        ],
+        failures: ["jobA"],
+        successes: ["jobB"],
         time: "",
       },
     ];
 
     expect(approximateFailureByType(data)).toStrictEqual({
-      "jobA": {
+      jobA: {
         [JobAnnotation.INFRA_BROKEN]: 0,
         [JobAnnotation.BROKEN_TRUNK]: 0,
         [JobAnnotation.TEST_FLAKE]: 2,
       },
-      "jobB": {
+      jobB: {
         [JobAnnotation.INFRA_BROKEN]: 0,
         [JobAnnotation.BROKEN_TRUNK]: 0,
         [JobAnnotation.TEST_FLAKE]: 2,
@@ -79,69 +64,52 @@ describe('Approximate failures by its categories', () => {
     });
   });
 
-  test('broken trunk failures', () => {
+  test("broken trunk failures", () => {
     const data: JobsPerCommitData[] = [
       {
         sha: "",
         author: "",
-        failures: [
-          "jobA",
-        ],
-        successes: [
-          "jobB",
-        ],
+        failures: ["jobA"],
+        successes: ["jobB"],
         time: "",
       },
       {
         sha: "",
         author: "",
-        failures: [
-          "jobA", "jobB"
-        ],
+        failures: ["jobA", "jobB"],
         successes: [],
         time: "",
       },
       {
         sha: "",
         author: "",
-        failures: [
-          "jobA",
-        ],
-        successes: [
-          "jobB",
-        ],
+        failures: ["jobA"],
+        successes: ["jobB"],
         time: "",
       },
       {
         sha: "",
         author: "",
         failures: [],
-        successes: [
-          "jobA",
-          "jobB",
-        ],
+        successes: ["jobA", "jobB"],
         time: "",
       },
       {
         sha: "",
         author: "",
-        failures: [
-          "jobA",
-        ],
-        successes: [
-          "jobB",
-        ],
+        failures: ["jobA"],
+        successes: ["jobB"],
         time: "",
       },
     ];
 
     expect(approximateFailureByType(data)).toStrictEqual({
-      "jobA": {
+      jobA: {
         [JobAnnotation.INFRA_BROKEN]: 0,
         [JobAnnotation.BROKEN_TRUNK]: 3,
         [JobAnnotation.TEST_FLAKE]: 1,
       },
-      "jobB": {
+      jobB: {
         [JobAnnotation.INFRA_BROKEN]: 0,
         [JobAnnotation.BROKEN_TRUNK]: 0,
         [JobAnnotation.TEST_FLAKE]: 1,
@@ -149,83 +117,68 @@ describe('Approximate failures by its categories', () => {
     });
   });
 
-  test('outage failures', () => {
+  test("outage failures", () => {
     const data: JobsPerCommitData[] = [
       {
         sha: "",
         author: "",
-        failures: [
-          "jobA", "jobB", "jobC", "jobD", "jobE",
-        ],
-        successes: [
-          "jobF",
-        ],
+        failures: ["jobA", "jobB", "jobC", "jobD", "jobE"],
+        successes: ["jobF"],
         time: "",
       },
       {
         sha: "",
         author: "",
-        failures: [
-          "jobA", "jobB", "jobC", "jobD", "jobE", "jobF",
-        ],
+        failures: ["jobA", "jobB", "jobC", "jobD", "jobE", "jobF"],
         successes: [],
         time: "",
       },
       {
         sha: "",
         author: "",
-        failures: [
-          "jobA", "jobB", "jobC", "jobD", "jobE",
-        ],
-        successes: [
-          "jobF",
-        ],
+        failures: ["jobA", "jobB", "jobC", "jobD", "jobE"],
+        successes: ["jobF"],
         time: "",
       },
       {
         sha: "",
         author: "",
         failures: [],
-        successes: [
-          "jobA",
-          "jobB",
-          "jobC",
-          "jobD",
-          "jobE",
-          "jobF",
-        ],
+        successes: ["jobA", "jobB", "jobC", "jobD", "jobE", "jobF"],
         time: "",
       },
     ];
 
     const outage_threshold = 5;
-    expect(approximateFailureByType(data, BROKEN_TRUNK_THRESHOLD, outage_threshold)).toStrictEqual({
-      "jobA": {
+    expect(
+      approximateFailureByType(data, BROKEN_TRUNK_THRESHOLD, outage_threshold)
+    ).toStrictEqual({
+      jobA: {
         [JobAnnotation.INFRA_BROKEN]: 3,
         [JobAnnotation.BROKEN_TRUNK]: 3,
         [JobAnnotation.TEST_FLAKE]: 0,
       },
-      "jobB": {
+      jobB: {
         [JobAnnotation.INFRA_BROKEN]: 3,
         [JobAnnotation.BROKEN_TRUNK]: 3,
         [JobAnnotation.TEST_FLAKE]: 0,
       },
-      "jobC": {
+      jobC: {
         [JobAnnotation.INFRA_BROKEN]: 3,
         [JobAnnotation.BROKEN_TRUNK]: 3,
         [JobAnnotation.TEST_FLAKE]: 0,
       },
-      "jobD": {
+      jobD: {
         [JobAnnotation.INFRA_BROKEN]: 3,
         [JobAnnotation.BROKEN_TRUNK]: 3,
         [JobAnnotation.TEST_FLAKE]: 0,
       },
-      "jobE": {
+      jobE: {
         [JobAnnotation.INFRA_BROKEN]: 3,
         [JobAnnotation.BROKEN_TRUNK]: 3,
         [JobAnnotation.TEST_FLAKE]: 0,
       },
-      "jobF": {
+      jobF: {
         [JobAnnotation.INFRA_BROKEN]: 1,
         [JobAnnotation.BROKEN_TRUNK]: 0,
         [JobAnnotation.TEST_FLAKE]: 1,
@@ -233,69 +186,52 @@ describe('Approximate failures by its categories', () => {
     });
   });
 
-  test('show percentage', () => {
+  test("show percentage", () => {
     const data: JobsPerCommitData[] = [
       {
         sha: "",
         author: "",
-        failures: [
-          "jobA",
-        ],
-        successes: [
-          "jobB",
-        ],
+        failures: ["jobA"],
+        successes: ["jobB"],
         time: "",
       },
       {
         sha: "",
         author: "",
-        failures: [
-          "jobA", "jobB"
-        ],
+        failures: ["jobA", "jobB"],
         successes: [],
         time: "",
       },
       {
         sha: "",
         author: "",
-        failures: [
-          "jobA",
-        ],
-        successes: [
-          "jobB",
-        ],
+        failures: ["jobA"],
+        successes: ["jobB"],
         time: "",
       },
       {
         sha: "",
         author: "",
         failures: [],
-        successes: [
-          "jobA",
-          "jobB",
-        ],
+        successes: ["jobA", "jobB"],
         time: "",
       },
       {
         sha: "",
         author: "",
-        failures: [
-          "jobA",
-        ],
-        successes: [
-          "jobB",
-        ],
+        failures: ["jobA"],
+        successes: ["jobB"],
         time: "",
       },
     ];
 
     expect(approximateFailureByTypePercent(data)).toStrictEqual({
-      "jobA": {
+      jobA: {
         [JobAnnotation.INFRA_BROKEN]: 0,
         [JobAnnotation.BROKEN_TRUNK]: 60,
         [JobAnnotation.TEST_FLAKE]: 20,
       },
-      "jobB": {
+      jobB: {
         [JobAnnotation.INFRA_BROKEN]: 0,
         [JobAnnotation.BROKEN_TRUNK]: 0,
         [JobAnnotation.TEST_FLAKE]: 20,

--- a/torchci/test/metricUtils.test.ts
+++ b/torchci/test/metricUtils.test.ts
@@ -1,0 +1,305 @@
+import { approximateFailureByType, approximateFailureByTypePercent, BROKEN_TRUNK_THRESHOLD } from '../lib/metricUtils';
+import { JobsPerCommitData, JobAnnotation } from "lib/types";
+
+describe('Approximate failures by its categories', () => {
+  test('no data', () => {
+    expect(approximateFailureByType(undefined)).toStrictEqual({});
+    expect(approximateFailureByType([])).toStrictEqual({});
+  });
+
+  test('flaky failures', () => {
+    const data: JobsPerCommitData[] = [
+      {
+        sha: "",
+        author: "",
+        failures: [
+          "jobA",
+        ],
+        successes: [
+          "jobB",
+        ],
+        time: "",
+      },
+      {
+        sha: "",
+        author: "",
+        failures: [
+          "jobB",
+        ],
+        successes: [
+          "jobA",
+        ],
+        time: "",
+      },
+      {
+        sha: "",
+        author: "",
+        failures: [
+          "jobB",
+        ],
+        successes: [
+          "jobA",
+        ],
+        time: "",
+      },
+      {
+        sha: "",
+        author: "",
+        failures: [],
+        successes: [
+          "jobA",
+          "jobB",
+        ],
+        time: "",
+      },
+      {
+        sha: "",
+        author: "",
+        failures: [
+          "jobA",
+        ],
+        successes: [
+          "jobB",
+        ],
+        time: "",
+      },
+    ];
+
+    expect(approximateFailureByType(data)).toStrictEqual({
+      "jobA": {
+        [JobAnnotation.INFRA_BROKEN]: 0,
+        [JobAnnotation.BROKEN_TRUNK]: 0,
+        [JobAnnotation.TEST_FLAKE]: 2,
+      },
+      "jobB": {
+        [JobAnnotation.INFRA_BROKEN]: 0,
+        [JobAnnotation.BROKEN_TRUNK]: 0,
+        [JobAnnotation.TEST_FLAKE]: 2,
+      },
+    });
+  });
+
+  test('broken trunk failures', () => {
+    const data: JobsPerCommitData[] = [
+      {
+        sha: "",
+        author: "",
+        failures: [
+          "jobA",
+        ],
+        successes: [
+          "jobB",
+        ],
+        time: "",
+      },
+      {
+        sha: "",
+        author: "",
+        failures: [
+          "jobA", "jobB"
+        ],
+        successes: [],
+        time: "",
+      },
+      {
+        sha: "",
+        author: "",
+        failures: [
+          "jobA",
+        ],
+        successes: [
+          "jobB",
+        ],
+        time: "",
+      },
+      {
+        sha: "",
+        author: "",
+        failures: [],
+        successes: [
+          "jobA",
+          "jobB",
+        ],
+        time: "",
+      },
+      {
+        sha: "",
+        author: "",
+        failures: [
+          "jobA",
+        ],
+        successes: [
+          "jobB",
+        ],
+        time: "",
+      },
+    ];
+
+    expect(approximateFailureByType(data)).toStrictEqual({
+      "jobA": {
+        [JobAnnotation.INFRA_BROKEN]: 0,
+        [JobAnnotation.BROKEN_TRUNK]: 3,
+        [JobAnnotation.TEST_FLAKE]: 1,
+      },
+      "jobB": {
+        [JobAnnotation.INFRA_BROKEN]: 0,
+        [JobAnnotation.BROKEN_TRUNK]: 0,
+        [JobAnnotation.TEST_FLAKE]: 1,
+      },
+    });
+  });
+
+  test('outage failures', () => {
+    const data: JobsPerCommitData[] = [
+      {
+        sha: "",
+        author: "",
+        failures: [
+          "jobA", "jobB", "jobC", "jobD", "jobE",
+        ],
+        successes: [
+          "jobF",
+        ],
+        time: "",
+      },
+      {
+        sha: "",
+        author: "",
+        failures: [
+          "jobA", "jobB", "jobC", "jobD", "jobE", "jobF",
+        ],
+        successes: [],
+        time: "",
+      },
+      {
+        sha: "",
+        author: "",
+        failures: [
+          "jobA", "jobB", "jobC", "jobD", "jobE",
+        ],
+        successes: [
+          "jobF",
+        ],
+        time: "",
+      },
+      {
+        sha: "",
+        author: "",
+        failures: [],
+        successes: [
+          "jobA",
+          "jobB",
+          "jobC",
+          "jobD",
+          "jobE",
+          "jobF",
+        ],
+        time: "",
+      },
+    ];
+
+    const outage_threshold = 5;
+    expect(approximateFailureByType(data, BROKEN_TRUNK_THRESHOLD, outage_threshold)).toStrictEqual({
+      "jobA": {
+        [JobAnnotation.INFRA_BROKEN]: 3,
+        [JobAnnotation.BROKEN_TRUNK]: 3,
+        [JobAnnotation.TEST_FLAKE]: 0,
+      },
+      "jobB": {
+        [JobAnnotation.INFRA_BROKEN]: 3,
+        [JobAnnotation.BROKEN_TRUNK]: 3,
+        [JobAnnotation.TEST_FLAKE]: 0,
+      },
+      "jobC": {
+        [JobAnnotation.INFRA_BROKEN]: 3,
+        [JobAnnotation.BROKEN_TRUNK]: 3,
+        [JobAnnotation.TEST_FLAKE]: 0,
+      },
+      "jobD": {
+        [JobAnnotation.INFRA_BROKEN]: 3,
+        [JobAnnotation.BROKEN_TRUNK]: 3,
+        [JobAnnotation.TEST_FLAKE]: 0,
+      },
+      "jobE": {
+        [JobAnnotation.INFRA_BROKEN]: 3,
+        [JobAnnotation.BROKEN_TRUNK]: 3,
+        [JobAnnotation.TEST_FLAKE]: 0,
+      },
+      "jobF": {
+        [JobAnnotation.INFRA_BROKEN]: 1,
+        [JobAnnotation.BROKEN_TRUNK]: 0,
+        [JobAnnotation.TEST_FLAKE]: 1,
+      },
+    });
+  });
+
+  test('show percentage', () => {
+    const data: JobsPerCommitData[] = [
+      {
+        sha: "",
+        author: "",
+        failures: [
+          "jobA",
+        ],
+        successes: [
+          "jobB",
+        ],
+        time: "",
+      },
+      {
+        sha: "",
+        author: "",
+        failures: [
+          "jobA", "jobB"
+        ],
+        successes: [],
+        time: "",
+      },
+      {
+        sha: "",
+        author: "",
+        failures: [
+          "jobA",
+        ],
+        successes: [
+          "jobB",
+        ],
+        time: "",
+      },
+      {
+        sha: "",
+        author: "",
+        failures: [],
+        successes: [
+          "jobA",
+          "jobB",
+        ],
+        time: "",
+      },
+      {
+        sha: "",
+        author: "",
+        failures: [
+          "jobA",
+        ],
+        successes: [
+          "jobB",
+        ],
+        time: "",
+      },
+    ];
+
+    expect(approximateFailureByTypePercent(data)).toStrictEqual({
+      "jobA": {
+        [JobAnnotation.INFRA_BROKEN]: 0,
+        [JobAnnotation.BROKEN_TRUNK]: 60,
+        [JobAnnotation.TEST_FLAKE]: 20,
+      },
+      "jobB": {
+        [JobAnnotation.INFRA_BROKEN]: 0,
+        [JobAnnotation.BROKEN_TRUNK]: 0,
+        [JobAnnotation.TEST_FLAKE]: 20,
+      },
+    });
+  });
+});


### PR DESCRIPTION
This uses simple heuristics to break down the failure % into smaller categories to provide further insight into the CI reliability:

* If the same failure occurs on N consecutive commits with `N >= 3`, the failure is consider a broken trunk
* Otherwise it's consider a flaky failure

In addition, if the commit has more than `N >= 10` failures, it's counted as an outage.  The threshold here can be tweaked.

### Testing

https://torchci-git-fork-huydhn-ci-reliability-metr-519611-fbopensource.vercel.app/reliability