### PR TITLE
Temporarily disable alert checking in builder/builder

### DIFF
--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -24,10 +24,6 @@ jobs:
             branch: nightly
             with_flaky_test_alerting: NO
             job_filter_regex: ""
-          - repo: pytorch/builder
-            branch: main
-            with_flaky_test_alerting: NO
-            job_filter_regex: "nightly.pypi.binary.size.validation"
     env:
       REPO_TO_CHECK: ${{ matrix.repo }}
       BRANCH_TO_CHECK: ${{ matrix.branch }}


### PR DESCRIPTION
Quick mitigation for https://github.com/pytorch/test-infra/pull/2681#issuecomment-1428852859

Next steps: fix the check_alerts script.