### PR TITLE
Re-enable alert checking in pytorch/builder

### DIFF
--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -24,6 +24,10 @@ jobs:
             branch: nightly
             with_flaky_test_alerting: NO
             job_filter_regex: ""
+          - repo: pytorch/builder
+            branch: main
+            with_flaky_test_alerting: NO
+            job_filter_regex: "nightly.pypi.binary.size.validation"
     env:
       REPO_TO_CHECK: ${{ matrix.repo }}
       BRANCH_TO_CHECK: ${{ matrix.branch }}


### PR DESCRIPTION
Reverts https://github.com/pytorch/test-infra/pull/3765, re-enabling the alerts in `pytorch/builder`, since the underlying issue is fixed in https://github.com/pytorch/test-infra/pull/3766.