### PR TITLE
Add alerts for cron/release validation workflows 

### DIFF
--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -27,7 +27,7 @@ jobs:
           - repo: pytorch/builder
             branch: main
             with_flaky_test_alerting: NO
-            job_filter_regex: "nightly.pypi.binary.size.validation"
+            job_filter_regex: ".*nightly.pypi.binary.size.validation|cron / release /"
     env:
       REPO_TO_CHECK: ${{ matrix.repo }}
       BRANCH_TO_CHECK: ${{ matrix.branch }}

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -482,6 +482,9 @@ def check_for_recurrently_failing_jobs_alert(
     repo: str, branch: str, job_name_regex: str, dry_run: bool
 ):
     job_names, sha_grid = fetch_hud_data(repo=repo, branch=branch)
+    print(f"Found {len(job_names)} jobs for {repo} {branch} branch:")
+    print("\n".join(job_names))
+
     filtered_job_names = set(filter_job_names(job_names, job_name_regex))
     (jobs_to_alert_on, flaky_jobs) = classify_jobs(
         job_names, sha_grid, filtered_job_names

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -486,6 +486,16 @@ def check_for_recurrently_failing_jobs_alert(
     print("\n".join(job_names))
 
     filtered_job_names = set(filter_job_names(job_names, job_name_regex))
+    if job_name_regex:
+        print()
+        print(f"Filtered to {len(filtered_job_names)} jobs:")
+        if len(filtered_job_names) == 0:
+            print("No jobs matched the regex")
+        elif len(filtered_job_names) == len(job_names):
+            print("All jobs matched the regex")
+        else:
+            print("\n".join(filtered_job_names))
+
     (jobs_to_alert_on, flaky_jobs) = classify_jobs(
         job_names, sha_grid, filtered_job_names
     )

--- a/torchci/scripts/test_check_alerts.py
+++ b/torchci/scripts/test_check_alerts.py
@@ -155,6 +155,20 @@ class TestGitHubPR(TestCase):
             msg="malformed regex should throw exception",
         )
 
+    def test_builder_job_filter(self):
+        job_names = [
+            "cron / nightly / win / wheel-py3_8-cuda11_8 / wheel-py3_8-cuda11_8",
+            "cron / release / linux / conda-py3_10-cpu / conda-py3_10-cpu",
+            "Validate Nightly PyPI Wheel Binary Size / nightly-pypi-binary-size-validation",
+            "Build libtorch docker images / build-docker-cuda (11.8)"
+            "Validate binaries / linux",
+        ]
+        self.assertListEqual(
+            filter_job_names(job_names, ".*nightly.pypi.binary.size.validation|cron / release /"), [
+                "cron / release / linux / conda-py3_10-cpu / conda-py3_10-cpu",
+                "Validate Nightly PyPI Wheel Binary Size / nightly-pypi-binary-size-validation",
+            ])
+
     def mock_fetch_alerts(*args, **kwargs):
         """
         Return the mock JSON response when trying to fetch all existing alerts


### PR DESCRIPTION
Add alerts for cron/release validation workflows  (fixes pytorch/pytorch#84765)
Additionally, log all existing job names in the alerting script, to make writing job name filters easier.