### PR TITLE
Enable 3.11 conda for Mac and Windows

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -208,11 +208,6 @@ def generate_conda_matrix(os: str, channel: str, with_cuda: str, limit_win_build
     arches = ["cpu"]
     python_versions = list(mod.PYTHON_ARCHES)
 
-    # Excluding Python 3.11 from conda builds for now due to package
-    # incompatibility issues with key dependencies.
-    if "3.11" in python_versions and os != "linux":
-        python_versions.remove("3.11")
-
     if with_cuda == ENABLE and (os == "linux" or os == "windows"):
         arches += mod.CUDA_ARCHES
 


### PR DESCRIPTION
Enable 3.11 conda for Mac and Windows