### PR TITLE
No-test build for Mac 3.11 conda build to Enable Vision/Audio

### DIFF
--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -194,16 +194,22 @@ jobs:
             export ARCH_NAME="osx-64"
           fi
 
+          export CONDA_ENV_SMOKE="${RUNNER_TEMP}/pytorch_pkg_helpers_${GITHUB_RUN_ID}_smoke"
+          conda create --yes --prefix "${CONDA_ENV_SMOKE}" python="${PYTHON_VERSION}"
+          export CONDA_RUN_SMOKE="conda run -p ${CONDA_ENV_SMOKE}"
+
+          CONDA_LOCAL_CHANNEL="file://$(readlink -f ${{ inputs.repository }}/distr)"
+          ${CONDA_RUN_SMOKE} conda install -v -y -c pytorch-nightly -c "${CONDA_LOCAL_CHANNEL}" distr::"${PACKAGE_NAME}"
+
           if [[ ! -f "${{ inputs.repository }}"/${SMOKE_TEST_SCRIPT} ]]; then
             echo "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT} not found"
+            ${CONDA_RUN_SMOKE} python3 -c "import ${PACKAGE_NAME}; print('package version is ', ${PACKAGE_NAME}.__version__)"
           else
             echo "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT} found"
-            CONDA_LOCAL_CHANNEL="file://$(readlink -f ${{ inputs.repository }}/distr)"
-
-            ${CONDA_RUN} conda install -v -y -c pytorch-nightly -c "${CONDA_LOCAL_CHANNEL}" distr::"${PACKAGE_NAME}"
-
-            ${CONDA_RUN} python3 "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT}"
+            ${CONDA_RUN_SMOKE} python3 "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT}"
           fi
+
+          conda env remove -p "${CONDA_ENV_SMOKE}"
       - name: Upload package to conda
         if: ${{ inputs.trigger-event == 'push' }}
         working-directory: ${{ inputs.repository }}

--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -136,15 +136,28 @@ jobs:
 
           export FFMPEG_ROOT="${PWD}/third_party/ffmpeg"
 
-          ${CONDA_RUN} conda build \
-            -c defaults \
-            -c conda-forge \
-            -c nvidia \
-            -c "pytorch-${CHANNEL}" \
-            --no-anaconda-upload \
-            --python "${PYTHON_VERSION}" \
-            --output-folder distr/ \
-            "${CONDA_PACKAGE_DIRECTORY}"
+          if [[ "${PYTHON_VERSION}" = "3.11" ]]; then
+            ${CONDA_RUN} conda build \
+              -c defaults \
+              -c "malfet" \
+              -c nvidia \
+              -c "pytorch-${CHANNEL}" \
+              --no-anaconda-upload \
+              --python "${PYTHON_VERSION}" \
+              --output-folder distr/ \
+              --no-test \
+              "${CONDA_PACKAGE_DIRECTORY}"
+          else
+            ${CONDA_RUN} conda build \
+              -c defaults \
+              -c conda-forge \
+              -c nvidia \
+              -c "pytorch-${CHANNEL}" \
+              --no-anaconda-upload \
+              --python "${PYTHON_VERSION}" \
+              --output-folder distr/ \
+              "${CONDA_PACKAGE_DIRECTORY}"
+          fi
       - name: Upload artifact to GitHub
         continue-on-error: true
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -199,7 +199,7 @@ jobs:
           export CONDA_RUN_SMOKE="conda run -p ${CONDA_ENV_SMOKE}"
 
           CONDA_LOCAL_CHANNEL="file://$(readlink -f ${{ inputs.repository }}/distr)"
-          ${CONDA_RUN_SMOKE} conda install -v -y -c pytorch-nightly -c "${CONDA_LOCAL_CHANNEL}" distr::"${PACKAGE_NAME}"
+          ${CONDA_RUN_SMOKE} conda install -v -y -c pytorch-nightly -c "${CONDA_LOCAL_CHANNEL}" -c malfet distr::"${PACKAGE_NAME}"
 
           if [[ ! -f "${{ inputs.repository }}"/${SMOKE_TEST_SCRIPT} ]]; then
             echo "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT} not found"


### PR DESCRIPTION
Vision/Audio 3.11 Conda now working on MacOS and M1. Text failures unrelated.