### PR TITLE
[Nova] Don't constraint 3.11 builds to mkl=2021

### DIFF
--- a/tools/pkg-helpers/pytorch_pkg_helpers/__main__.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/__main__.py
@@ -117,7 +117,7 @@ def main():
         )
 
     if options.platform == "darwin":
-        variables.extend(get_macos_variables(options.arch_name))
+        variables.extend(get_macos_variables(options.arch_name, options.python_version))
 
     variables.extend(
         get_cuda_variables(

--- a/tools/pkg-helpers/pytorch_pkg_helpers/macos.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/macos.py
@@ -1,11 +1,11 @@
-def get_macos_variables(arch_name: str) -> list:
+def get_macos_variables(arch_name: str, python_version: str = "3.8") -> list:
     variables = [
         "export MACOSX_DEPLOYMENT_TARGET=10.9",
         "export CC=clang",
         "export CXX=clang++",
     ]
 
-    if arch_name != "arm64":
+    if arch_name != "arm64" and python_version != "3.11":
         variables.append("export CONDA_EXTRA_BUILD_CONSTRAINT='- mkl<=2021.2.0'")
 
     return variables


### PR DESCRIPTION
Because 3.11 was release in 2022
