### PR TITLE
Fix python 3.11 wheel builds

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -124,16 +124,27 @@ runs:
           CONDA_ENV="${RUNNER_TEMP}/conda_environment_${GITHUB_RUN_ID}"
 
           if [[ "${PYTHON_VERSION}" = "3.11" ]]; then
-            # conda-build not available for Python 3.11
-            conda create \
-              --yes \
-              --prefix "${CONDA_ENV}" \
-              "python=3.8" \
-              cmake=3.22 \
-              conda-build=3.21 \
-              ninja=1.10 \
-              pkg-config=0.29 \
-              wheel=0.37
+
+            if [[ "${PACKAGE_TYPE:-}" == "conda" ]]; then
+              conda create \
+                --yes \
+                --prefix "${CONDA_ENV}" \
+                "python=3.8" \
+                cmake=3.22 \
+                conda-build=3.21 \
+                ninja=1.10 \
+                pkg-config=0.29 \
+                wheel=0.37
+            else
+              conda create \
+                --yes \
+                --prefix "${CONDA_ENV}" \
+                "python=${PYTHON_VERSION}" \
+                cmake=3.22 \
+                ninja=1.10 \
+                pkg-config=0.29 \
+                wheel=0.37
+            fi
           else
             conda create \
               --yes \


### PR DESCRIPTION
Fix python 3.11 wheel builds.
Regression found for wheel builds:
https://github.com/pytorch/vision/actions/runs/4208207025/jobs/7303969466#step:13:116

We build with Python 3.11, but actual build name is python 3.8:
```
+ /__w/vision/vision/3/bin/conda run -p /__w/_temp/conda_environment_4208207025 aws s3 cp dist/torchvision-0.15.0+cu118-cp38-cp38-linux_x86_64.whl 
```
 For python 3.11 we should build on Python 3.8 only for conda builds but not wheel. 