### PR TITLE
move disable flaky tests workflow to newer runner

### DIFF
--- a/.github/workflows/disable-flaky-tests.yml
+++ b/.github/workflows/disable-flaky-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   cron:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Fetch and file issues for flaky tests
         run: |


### PR DESCRIPTION
it's been failing as 18.04 is getting deprecated

e.g., https://github.com/pytorch/test-infra/actions/runs/4232797576