### PR TITLE
set-output command is deprecated

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -63,7 +63,7 @@ runs:
         if lspci -v | grep -e 'controller.*NVIDIA' >/dev/null 2>/dev/null; then
           needs=1
         fi
-        echo "::set-output name=does::${needs}"
+        echo "does=${needs}" >> $GITHUB_OUTPUT
 
     - name: Install nvidia driver, nvidia-docker runtime, set GPU_FLAG
       uses: ./test-infra/.github/actions/setup-nvidia


### PR DESCRIPTION
[set-output command is deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). Where this is used in a workflow, you will see the following warning message.  
<img width="950" alt="Screenshot 2023-02-21 at 1 06 19 PM" src="https://user-images.githubusercontent.com/95243761/220436282-f1569005-b88e-4786-89a3-a0fc7be9dacb.png">

For example, You see this warning [here](https://github.com/pytorch/rl/actions/runs/4235232065).  

This change removes the use of `set-output` command from the [setup-linux actions](https://github.com/pytorch/test-infra/blob/main/.github/actions/setup-linux/action.yml#L66) and instead uses the `$GITHUB_OUTPUT` environment file [as recommended](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).  