### PR TITLE
Add some error handling in pushRocksetTags

### DIFF
--- a/torchci/scripts/pushRocksetTags.mjs
+++ b/torchci/scripts/pushRocksetTags.mjs
@@ -7,12 +7,18 @@ async function readJSON(path) {
 }
 
 async function pushProdTag(client, workspace, queryName, version) {
-  const currentRocksetVersion = await client.queryLambdas.getQueryLambdaTagVersion(
-    workspace,
-    queryName,
-    "prod"
-  );
-  if (currentRocksetVersion.data.version.version == version) {
+  let currentRocksetVersion = null;
+  try {
+    currentRocksetVersion = await client.queryLambdas.getQueryLambdaTagVersion(
+      workspace,
+      queryName,
+      "prod"
+    );
+  } catch (error) {
+    console.log(error);
+  }
+
+  if (currentRocksetVersion?.data.version.version == version) {
     console.log(
       `${workspace}.${queryName}:${version} already tagged as 'prod'`
     );


### PR DESCRIPTION
Was previously failing b/c the api call throws an exception when the tag doesnt exist, so add try catch.
Example:
```
node:internal/process/esm_loader:97
    internalBinding('errors').triggerUncaughtException(
                              ^
{
  message: 'Tag "prod" not found for Query Lambda "commons.master_commit_red_jobs".',
  message_key: 'QUERY_TAG_NOT_FOUND',
  type: 'NOTFOUND',
  line: null,
  column: null,
  trace_id: '8e00eadf-[21](https://github.com/pytorch/test-infra/actions/runs/4236687780/jobs/7361778045#step:4:22)35-486b-b67f-a6147c59ab1c',
  error_id: null,
  query_id: null
}
```