### PR TITLE
[BE] Sort hud groups intelligently

### DIFF
--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -1,107 +1,179 @@
 import { GroupedJobStatus, JobStatus } from "components/GroupJobConclusion";
 import { GroupData, RowData } from "./types";
 
+const GROUP_MEMORY_LEAK_CHECK = "Memory Leak Check"
+const GROUP_RERUN_DISABLED_TESTS = "Rerun Disabled Tests"
+const GROUP_UNSTABLE = "Unstable"
+const GROUP_PERIODIC = "Periodic"
+const GROUP_LINT = "Lint"
+const GROUP_INDUCTOR = "Inductor"
+const GROUP_ANDROID = "Android"
+const GROUP_ROCM = "ROCm"
+const GROUP_XLA = "XLA"
+const GROUP_LINUX = "Linux"
+const GROUP_BINARY_LINUX = "Binary Linux"
+const GROUP_BINARY_WINDOWS = "Binary Windows"
+const GROUP_ANNOTATIONS_AND_LABELING = "Annotations and labeling"
+const GROUP_DOCKER = "Docker"
+const GROUP_WINDOWS = "Windows"
+const GROUP_CALC_DOCKER_IMAGE = "GitHub calculate-docker-image"
+const GROUP_CI_DOCKER_IMAGE_BUILDS = "CI Docker Image Builds"
+const GROUP_CI_CIRCLECI_PYTORCH_IOS = "ci/circleci: pytorch_ios"
+const GROUP_IOS = "iOS"
+const GROUP_MAC = "Mac"
+const GROUP_PARALLEL = "Parallel"
+const GROUP_DOCS = "Docs"
+const GROUP_LIBTORCH = "Libtorch"
+const GROUP_OTHER = "other"
+
 // Jobs will be grouped with the first regex they match in this list
 export const groups = [
   {
     regex: /mem_leak_check/,
-    name: "Memory Leak Check",
+    name: GROUP_MEMORY_LEAK_CHECK,
     persistent: true,
   },
   {
     regex: /rerun_disabled_tests/,
-    name: "Rerun Disabled Tests",
+    name: GROUP_RERUN_DISABLED_TESTS,
     persistent: true,
   },
   {
     regex: /unstable/,
-    name: "Unstable",
+    name: GROUP_UNSTABLE,
     persistent: true,
   },
   {
     regex: /periodic/,
-    name: "Periodic",
+    name: GROUP_PERIODIC,
   },
   {
     regex: /Lint/,
-    name: "Lint",
+    name: GROUP_LINT,
   },
   {
     regex: /inductor/,
-    name: "Inductor",
+    name: GROUP_INDUCTOR,
   },
   {
     regex: /android/,
-    name: "Android",
+    name: GROUP_ANDROID,
   },
   {
     regex: /rocm/,
-    name: "ROCm",
+    name: GROUP_ROCM,
   },
   {
     regex: /-xla/,
-    name: "XLA",
+    name: GROUP_XLA,
   },
   {
     regex: /(\slinux-|sm86)/,
-    name: "Linux",
+    name: GROUP_LINUX,
   },
   {
     regex: /linux-binary/,
-    name: "Binary Linux",
+    name: GROUP_BINARY_LINUX,
   },
   {
     regex: /windows-binary/,
-    name: "Binary Windows",
+    name: GROUP_BINARY_WINDOWS,
   },
   {
     regex:
       /(Add annotations )|(Close stale pull requests)|(Label PRs & Issues)|(Triage )|(Update S3 HTML indices)|(is-properly-labeled)|(Facebook CLA Check)|(auto-label-rocm)/,
-    name: "Annotations and labeling",
+    name: GROUP_ANNOTATIONS_AND_LABELING,
   },
   {
     regex:
       /(ci\/circleci: docker-pytorch-)|(ci\/circleci: ecr_gc_job_)|(ci\/circleci: docker_for_ecr_gc_build_job)|(Garbage Collect ECR Images)/,
-    name: "Docker",
+    name: GROUP_DOCKER,
   },
   {
     regex: /\swin-/,
-    name: "Windows",
+    name: GROUP_WINDOWS,
   },
   {
     regex: / \/ calculate-docker-image/,
-    name: "GitHub calculate-docker-image",
+    name: GROUP_CALC_DOCKER_IMAGE,
   },
   {
     regex: /docker-builds/,
-    name: "CI Docker Image Builds",
+    name: GROUP_CI_DOCKER_IMAGE_BUILDS,
   },
   {
     regex: /ci\/circleci: pytorch_ios_/,
-    name: "ci/circleci: pytorch_ios",
+    name: GROUP_CI_CIRCLECI_PYTORCH_IOS,
   },
   {
     regex: /ios-/,
-    name: "iOS",
+    name: GROUP_IOS,
   },
   {
     regex: /\smacos-/,
-    name: "Mac",
+    name: GROUP_MAC,
   },
   {
     regex:
       /(ci\/circleci: pytorch_parallelnative_)|(ci\/circleci: pytorch_paralleltbb_)|(paralleltbb-linux-)|(parallelnative-linux-)/,
-    name: "Parallel",
+    name: GROUP_PARALLEL,
   },
   {
     regex: /(docs push)|(docs build)/,
-    name: "Docs",
+    name: GROUP_DOCS,
   },
   {
     regex: /libtorch/,
-    name: "libtorch",
+    name: GROUP_LIBTORCH,
   },
 ];
+
+// Jobs on HUD home page will be sorted according to this list, with anything left off at the end
+// Reorder elements in this list to reorder the groups on the HUD
+const HUD_GROUP_SORTING = [
+  GROUP_LINT,
+  GROUP_LINUX,
+  GROUP_WINDOWS,
+  GROUP_IOS,
+  GROUP_MAC,
+  GROUP_ROCM,
+  GROUP_XLA,
+  GROUP_PARALLEL,
+  GROUP_LIBTORCH,
+  GROUP_ANDROID,
+  GROUP_DOCKER,
+  GROUP_MEMORY_LEAK_CHECK,
+  GROUP_CALC_DOCKER_IMAGE,
+  GROUP_CI_DOCKER_IMAGE_BUILDS,
+  GROUP_CI_CIRCLECI_PYTORCH_IOS,
+  GROUP_BINARY_LINUX,
+  GROUP_BINARY_WINDOWS,
+  GROUP_PERIODIC,
+  GROUP_DOCS,
+  GROUP_RERUN_DISABLED_TESTS,
+  GROUP_INDUCTOR,
+  GROUP_ANNOTATIONS_AND_LABELING,
+  GROUP_OTHER,
+  GROUP_UNSTABLE,
+]
+
+// Accepts a list of group names and returns that list sorted according to
+// the order defined in HUD_GROUP_SORTING
+export function sortGroupNamesForHUD(groupNames: string[]) : string[] {
+
+  let result: string[] = []
+  for (const group of HUD_GROUP_SORTING) {
+    if (groupNames.includes(group)) {
+      result.push(group)
+    }
+  }
+  
+  // Be flexible in case against any groups were left out of HUD_GROUP_SORTING
+  let remaining = groupNames.filter(x => !result.includes(x))
+
+  result = result.concat(remaining)
+  return result
+}
 
 export function classifyGroup(jobName: string): string {
   for (const group of groups) {
@@ -109,7 +181,7 @@ export function classifyGroup(jobName: string): string {
       return group.name;
     }
   }
-  return "other";
+  return GROUP_OTHER;
 }
 
 export function getGroupConclusionChar(conclusion?: GroupedJobStatus): string {

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -12,6 +12,7 @@ import TooltipTarget from "components/TooltipTarget";
 import {
   getGroupingData,
   groups,
+  sortGroupNamesForHUD,
   isPersistentGroup,
   isUnstableGroup,
 } from "lib/JobClassifierUtil";
@@ -442,8 +443,8 @@ function GroupedHudTable({
   );
   const [hideUnstable, setHideUnstable] = useState<boolean>(true);
 
-  const groupNames = Array.from(groupNameMapping.keys());
-  let names = groupNames;
+  const groupNames = Array.from(groupNameMapping.keys())
+  let names = sortGroupNamesForHUD(groupNames)
 
   if (hideUnstable) {
     names = names.filter((name) => !isUnstableGroup(name));

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -443,8 +443,8 @@ function GroupedHudTable({
   );
   const [hideUnstable, setHideUnstable] = useState<boolean>(true);
 
-  const groupNames = Array.from(groupNameMapping.keys())
-  let names = sortGroupNamesForHUD(groupNames)
+  const groupNames = Array.from(groupNameMapping.keys());
+  let names = sortGroupNamesForHUD(groupNames);
 
   if (hideUnstable) {
     names = names.filter((name) => !isUnstableGroup(name));


### PR DESCRIPTION
Sorts the grouped jobs so that:
- Groups containing jobs that block viable/strict upgrades show up first
- Similar jobs and jobs that are less critical show up together

The goal is to make it easier for the DevX team to quickly glance at HUD and tell if important jobs are broken. For example, Inductor jobs (which used to be in the middle of viable/strict blocking jobs) are now moved far to the right

(Feel free to call out something that you thing should be sorted differently)

Old sorting:
<img width="401" alt="image" src="https://user-images.githubusercontent.com/4468967/220488619-9dd69de6-7161-43ef-a4cd-9998e11c3f0d.png">


New sorting:
<img width="431" alt="image" src="https://user-images.githubusercontent.com/4468967/220488502-4e6ea119-2dc0-4bc7-a8e4-51dcac512240.png">
