### PR TITLE
[BE] Make skipped jobs more distinct from successful jobs

### DIFF
--- a/torchci/components/GroupJobConclusion.tsx
+++ b/torchci/components/GroupJobConclusion.tsx
@@ -103,6 +103,7 @@ export default function HudGroupedCell({
                   ? styles["classified"]
                   : styles[conclusion ?? "none"]
               }
+              style={{ border: "1px solid gainsboro" , padding: "0 1px"}}
             >
               {getGroupConclusionChar(conclusion)}
             </span>

--- a/torchci/components/GroupJobConclusion.tsx
+++ b/torchci/components/GroupJobConclusion.tsx
@@ -103,7 +103,6 @@ export default function HudGroupedCell({
                   ? styles["classified"]
                   : styles[conclusion ?? "none"]
               }
-              style={{ border: "1px solid gainsboro" }}
             >
               {getGroupConclusionChar(conclusion)}
             </span>

--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -193,7 +193,7 @@ export function getGroupConclusionChar(conclusion?: GroupedJobStatus): string {
     case GroupedJobStatus.Pending:
       return "?";
     case GroupedJobStatus.AllNull:
-      return "O";
+      return "~";
     case GroupedJobStatus.Classified:
       return "X";
     case GroupedJobStatus.Flaky:
@@ -243,7 +243,7 @@ export function getConclusionChar(
     case JobStatus.Pending:
       return "?";
     case undefined:
-      return "O";
+      return "~";
     default:
       return "U";
   }


### PR DESCRIPTION
Currently, you might have to look closely at jobs to tell if it's skipped or hud, since the dark green and grey can be hard to tell apart

Fix that by using a distinct symbol for skipped jobs. 

Old:
<img width="780" alt="image" src="https://user-images.githubusercontent.com/4468967/220713632-79ec3f5d-4ef8-485d-b69e-17b0534f411a.png">

New:
<img width="725" alt="image" src="https://user-images.githubusercontent.com/4468967/220713729-93d6806c-9b3c-4b81-88b0-d311c9cef329.png">

