### PR TITLE
Only allow users with write permission to disable jobs

### DIFF
--- a/.github/scripts/update_disabled_issues.py
+++ b/.github/scripts/update_disabled_issues.py
@@ -186,7 +186,7 @@ def condense_disable_jobs(
             continue
 
         username = item.get("user", {}).get("login", "")
-        # To keep the CI safe, we will only allow author with admin permission
+        # To keep the CI safe, we will only allow author with write permission
         # to the repo to disable jobs
         if not username or not can_disable_jobs(
             owner=owner, repo=repo, username=username

--- a/.github/scripts/update_disabled_issues.py
+++ b/.github/scripts/update_disabled_issues.py
@@ -23,7 +23,7 @@ JOB_NAME_MAXSPLIT = 2
 OWNER = "pytorch"
 REPO = "pytorch"
 
-PERMISSIONS_TO_DISABLE_JOBS = {"admin"}
+PERMISSIONS_TO_DISABLE_JOBS = {"admin", "write"}
 
 
 def _read_url(url: Any) -> Any:

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -18,7 +18,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Generate new disabled tests and jobs jsons
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Octokit is used to confirm issue creator's admin permission before
+          # allowing them to disable jobs
+          python3 -mpip install octokitpy==0.15.0
           python3 .github/scripts/update_disabled_issues.py
 
       - name: Print the list of disabled tests

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -19,11 +19,10 @@ jobs:
 
       - name: Generate new disabled tests and jobs jsons
         env:
+          # The token is used to confirm issue creator's admin permission before
+          # allowing them to disable jobs
           API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Octokit is used to confirm issue creator's admin permission before
-          # allowing them to disable jobs
-          python3 -mpip install octokitpy==0.15.0
           python3 .github/scripts/update_disabled_issues.py
 
       - name: Print the list of disabled tests

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Generate new disabled tests and jobs jsons
         env:
-          # The token is used to confirm issue creator's admin permission before
+          # The token is used to confirm issue creator's write permission before
           # allowing them to disable jobs
           API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
Per yesterday discussion, I'm restricting the permission to disable jobs to only users with ~~admin~~ write permission to the repo (`pytorch/pytorch`).  ~~This is stricter than `write` permission.~~.  Check with @clee2000, switch to write permission like other bots.

This requires `GITHUB_TOKEN` secret ~~and octokit~~ to query the user permission.  Luckily, the secret is already in use in the workflow.