### PR TITLE
Use PyTorch bot token when checking for write permission

### DIFF
--- a/.github/scripts/update_disabled_issues.py
+++ b/.github/scripts/update_disabled_issues.py
@@ -34,7 +34,7 @@ def github_api_request(url: str, token: Optional[str] = "") -> Any:
     headers = {"Accept": "application/vnd.github.v3+json"}
 
     if token:
-        headers["Authorization"] = f"Bearer {token}"
+        headers["Authorization"] = f"token {token}"
 
     return _read_url(Request(url, headers=headers))
 

--- a/.github/scripts/update_disabled_issues.py
+++ b/.github/scripts/update_disabled_issues.py
@@ -121,7 +121,7 @@ def filter_disable_issues(issues_json: Dict[str, Any]) -> Tuple[List[Any], List[
 
 @lru_cache()
 def can_disable_jobs(owner: str, repo: str, username: str) -> bool:
-    token = os.getenv("API_TOKEN_GITHUB", "")
+    token = os.getenv("GH_PYTORCHBOT_TOKEN", "")
     url = f"https://api.github.com/repos/{owner}/{repo}/collaborators/{username}/permission"
 
     try:

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -20,8 +20,10 @@ jobs:
       - name: Generate new disabled tests and jobs jsons
         env:
           # The token is used to confirm issue creator's write permission before
-          # allowing them to disable jobs
-          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+          # allowing them to disable jobs. Note that the token needs to have access
+          # to the target repo, i.e. pytorch/pytorch instead of test-infra. Using
+          # PyTorch bot token is the most obvious choice.
+          GH_PYTORCHBOT_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
         run: |
           python3 .github/scripts/update_disabled_issues.py
 


### PR DESCRIPTION
It looks like I'm using the wrong syntax here.  There are `Authorization: Bearer` and `Authorization: token`.  The latter should be used instead.  Let's try it out.

https://docs.github.com/en/rest/overview/other-authentication-methods?apiVersion=2022-11-28#authenticating-for-saml-sso