### PR TITLE
Suggest rebasing off of viable/strict

### DIFF
--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -140,17 +140,24 @@ function constructResultsJobsSections(
   hud_pr_url: string,
   header: string,
   description: string,
-  jobs: RecentWorkflowsData[]
+  jobs: RecentWorkflowsData[],
+  suggestion?: string,
 ): string {
   if (jobs.length === 0) {
     return "";
   }
-  let output = `\n<details open><summary><b>${header}</b> - ${description}:</summary><p>\n\n`;
+  let output = `\n<details open><summary><b>${header}</b> - ${description}:</summary>`;
+
+  if (suggestion) {
+    output += `<p>👉 <b>${suggestion}</b></p>`
+  }
+
+  output += "<p>\n\n" // Two newlines are needed for bullts below to be formattec correctly
   const jobsSorted = jobs.sort((a, b) => a.name.localeCompare(b.name));
   for (const job of jobsSorted) {
     output += `* [${job.name}](${hud_pr_url}#${job.id}) ([gh](${job.html_url}))\n`;
   }
-  output += "<p></details>";
+  output += "</p></details>";
   return output;
 }
 
@@ -201,7 +208,7 @@ export function constructResultsComment(
           hud_pr_url,
           "NEW FAILURES",
           "The following jobs have failed",
-          failedJobs
+          failedJobs,
         );
     }
     output += constructResultsJobsSections(
@@ -214,7 +221,8 @@ export function constructResultsComment(
       hud_pr_url,
       "BROKEN TRUNK",
       `The following jobs failed but were present on the merge base ${merge_base}`,
-      brokenTrunkJobs
+      brokenTrunkJobs,
+      "Rebase onto the `viable/strict` branch to avoid these failures"
     );
     return output;
 }


### PR DESCRIPTION
Suggest rebasing off of `viable/strict` when we see a PR is affected by a broken trunk

## Old version
<img width="823" alt="image" src="https://user-images.githubusercontent.com/4468967/222228330-08976816-0c60-467b-8c65-ca78bd703722.png">

## New version
<img width="823" alt="image" src="https://user-images.githubusercontent.com/4468967/222228400-1bbf7d74-dee6-424b-b8d0-571bca95c040.png">
