### PR TITLE
Add external metrics dashboard (#3817)

### DIFF
--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -109,6 +109,31 @@ export default function Kpis() {
                 additionalOptions={{ yAxis: { max: 7 } }}
               />
             </Grid>
+            <Grid item xs={6} height={ROW_HEIGHT}>
+                <TimeSeriesPanel
+                    title={"External PR Count"}
+                    queryName={"external_contribution_stats"}
+                    queryParams={[...timeParams]}
+                    granularity={"day"}
+                    timeFieldName={"granularity_bucket"}
+                    yAxisFieldName={"pr_count"}
+                    yAxisRenderer={(value) => value}
+                    additionalOptions={{ yAxis: { scale: true } }}
+                />
+            </Grid>
+
+            <Grid item xs={6} height={ROW_HEIGHT}>
+                <TimeSeriesPanel
+                    title={"Unique External Contributor Count"}
+                    queryName={"external_contribution_stats"}
+                    queryParams={[...timeParams]}
+                    granularity={"day"}
+                    timeFieldName={"granularity_bucket"}
+                    yAxisFieldName={"user_count"}
+                    yAxisRenderer={(value) => value}
+                    additionalOptions={{ yAxis: { scale: true } }}
+                />
+            </Grid>
         </Grid>
     );
 }

--- a/torchci/rockset/metrics/__sql/external_contribution_stats.sql
+++ b/torchci/rockset/metrics/__sql/external_contribution_stats.sql
@@ -1,0 +1,10 @@
+SELECT
+    FORMAT_ISO8601(
+        CAST(date as date)
+    ) AS granularity_bucket,
+    pr_count as pr_count,
+    user_count as user_count,
+FROM
+    metrics.external_contribution_stats
+    WHERE CAST(date as date) >= PARSE_DATETIME_ISO8601(:startTime)
+    AND CAST(date as date) < PARSE_DATETIME_ISO8601(:stopTime)

--- a/torchci/rockset/metrics/external_contribution_stats.lambda.json
+++ b/torchci/rockset/metrics/external_contribution_stats.lambda.json
@@ -1,0 +1,21 @@
+{
+    "sql_path": "__sql/external_contribution_stats.sql",
+    "default_parameters": [
+      {
+        "name": "granularity",
+        "type": "string",
+        "value": "day"
+      },
+      {
+        "name": "startTime",
+        "type": "string",
+        "value": "2023-02-01T00:06:32.839Z"
+      },
+      {
+        "name": "stopTime",
+        "type": "string",
+        "value": "2023-02-07T00:06:32.839Z"
+      }
+    ],
+    "description": "pr count and number of unique external contributors per day"
+  }

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -34,6 +34,7 @@
     "correlation_matrix": "4960260cbb0c5b48",
     "disabled_test_historical": "daa2413a4750aa87",
     "disabled_test_total": "da5f834a6501fc63",
+    "external_contribution_stats": "d86b6f01367c3d6f",
     "job_duration_avg": "10a88ea2ebb80647",
     "job_duration_percentile": "96507ed62db7a3a8",
     "last_branch_push": "3d995ac2143586dc",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3817

Adds dashboards to count unique external contributors and prs created by external contributors per day.

Image of dashboards (will add more data manually)
<img width="1485" alt="Screenshot 2023-03-01 at 1 47 45 PM" src="https://user-images.githubusercontent.com/13758638/222272511-cec8c2a7-6d09-4586-978f-8db7e06fc20c.png">