### PR TITLE
Send no alert when job fails flakily because of different failure reasons

### DIFF
--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -172,8 +172,6 @@ class JobStatus:
         # of the longest unique chain
         unique_failures = self.get_unique_failures(self.failure_chain)
 
-        print(self.current_status)
-
         return (
             self.current_status is not None
             and self.current_status["conclusion"] != SUCCESS

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -176,10 +176,8 @@ class JobStatus:
             self.current_status is not None
             and self.current_status["conclusion"] != SUCCESS
             and any(
-                [
-                    len(failure_chain) >= FAILURE_CHAIN_THRESHOLD
-                    for failure_chain in unique_failures.values()
-                ]
+                len(failure_chain) >= FAILURE_CHAIN_THRESHOLD
+                for failure_chain in unique_failures.values()
             )
             and all(
                 [

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -103,7 +103,14 @@ class JobStatus:
         self.flaky_jobs = self.get_flaky_jobs()
 
     def get_current_status(self) -> Any:
-        return self.filtered_statuses[0] if len(self.filtered_statuses) > 0 else None
+        """
+        When getting the current status, we want the latest status which is not pending,
+        be it success or failure
+        """
+        for status in self.filtered_statuses:
+            if status["conclusion"] != PENDING:
+                return status
+        return None
 
     def get_unique_failures(self, jobs: List[Any]) -> Dict[str, List[Any]]:
         """
@@ -165,9 +172,11 @@ class JobStatus:
         # of the longest unique chain
         unique_failures = self.get_unique_failures(self.failure_chain)
 
+        print(self.current_status)
+
         return (
             self.current_status is not None
-            and self.current_status["conclusion"] != "success"
+            and self.current_status["conclusion"] != SUCCESS
             and any(
                 [
                     len(failure_chain) >= FAILURE_CHAIN_THRESHOLD

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -397,7 +397,7 @@ def find_first_sha(categorized_sha: List[Tuple[str, str]], status: str):
     return -1
 
 
-def clear_alerts(alerts: List[Any]) -> bool:
+def clear_alerts(alerts: List[Any], dry_run: bool) -> bool:
     cleared_alerts = 0
     for alert in alerts:
         r = requests.patch(
@@ -525,7 +525,7 @@ def check_for_recurrently_failing_jobs_alert(
     # Auto-clear any existing alerts if the current status is green
     if len(jobs_to_alert_on) == 0 or trunk_is_green(sha_grid):
         print(f"Didn't find anything to alert on for {repo} {branch}")
-        clear_alerts(existing_alerts)
+        clear_alerts(existing_alerts, dry_run=dry_run)
         return
 
     # In the current design, there should be at most one alert issue per repo and branch

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -180,10 +180,8 @@ class JobStatus:
                 for failure_chain in unique_failures.values()
             )
             and all(
-                [
-                    disabled_alert not in self.job_name
-                    for disabled_alert in DISABLED_ALERTS
-                ]
+                disabled_alert not in self.job_name
+                for disabled_alert in DISABLED_ALERTS
             )
         )
 

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -398,6 +398,9 @@ def find_first_sha(categorized_sha: List[Tuple[str, str]], status: str):
 
 
 def clear_alerts(alerts: List[Any], dry_run: bool) -> bool:
+    if dry_run:
+        print("NOTE: Dry run, not doing any real work")
+        return
     cleared_alerts = 0
     for alert in alerts:
         r = requests.patch(

--- a/torchci/scripts/test_check_alerts.py
+++ b/torchci/scripts/test_check_alerts.py
@@ -48,6 +48,21 @@ MOCK_TEST_DATA = [
         "repo": "pytorch/pytorch",
     },
 ]
+ANOTHER_MOCK_TEST_DATA = [
+    {
+        "sha": "2936c8b9ce4ef4d81cc3fe6e43531cb440209c61",
+        "id": 4364234624,
+        "conclusion": "failure",
+        "htmlUrl": "https://github.com/pytorch/pytorch/runs/4364234624?check_suite_focus=true",
+        "logUrl": "https://ossci-raw-job-status.s3.amazonaws.com/log/4364234624",
+        "durationS": 14342,
+        "failureLine": "##[error]An unique error here.",
+        "failureContext": "",
+        "failureCaptures": ["##[error]An unique error here."],
+        "failureLineNumber": 12345,
+        "repo": "pytorch/pytorch",
+    },
+]
 
 
 def mock_fetch_alerts(*args, **kwargs):
@@ -116,6 +131,13 @@ class TestGitHubPR(TestCase):
         status = JobStatus(
             JOB_NAME,
             [MOCK_TEST_DATA[0]] + [{"conclusion": "pending"}] + [MOCK_TEST_DATA[1]],
+        )
+        self.assertFalse(status.should_alert())
+
+    # Shouldn't alert when failures are different ? Fail (1) Fail (2)
+    def test_no_alert_when_different_failures(self) -> None:
+        status = JobStatus(
+            JOB_NAME, [{}] + [MOCK_TEST_DATA[0]] + ANOTHER_MOCK_TEST_DATA
         )
         self.assertFalse(status.should_alert())
 

--- a/torchci/scripts/test_check_alerts.py
+++ b/torchci/scripts/test_check_alerts.py
@@ -113,10 +113,17 @@ class TestGitHubPR(TestCase):
 
     # Shouldn't alert when jobs are Success ? Fail Fail
     def test_no_alert_when_cleared(self) -> None:
-        status = JobStatus(
-            JOB_NAME, [{"conclusion": "success"}] + [{}] + MOCK_TEST_DATA
-        )
-        self.assertFalse(status.should_alert())
+        cases = [
+            JobStatus(JOB_NAME, [{"conclusion": "success"}] + [{}] + MOCK_TEST_DATA),
+            JobStatus(
+                JOB_NAME,
+                [{"conclusion": "pending"}]
+                + [{"conclusion": "success"}]
+                + MOCK_TEST_DATA,
+            ),
+        ]
+        for case in cases:
+            self.assertFalse(case.should_alert())
 
     # Shouldn't alert when jobs are Fail Success Fail
     def test_no_alert_when_not_consecutive(self) -> None:

--- a/torchci/scripts/test_check_alerts.py
+++ b/torchci/scripts/test_check_alerts.py
@@ -111,7 +111,7 @@ class TestGitHubPR(TestCase):
         status = JobStatus(JOB_NAME, [{}] + [{}] + MOCK_TEST_DATA)
         self.assertTrue(status.should_alert())
 
-    # Shouldn't alert when jobs are Success ? Fail Fail
+    # Shouldn't alert when a newer job has already succeeded
     def test_no_alert_when_cleared(self) -> None:
         cases = [
             JobStatus(JOB_NAME, [{"conclusion": "success"}] + [{}] + MOCK_TEST_DATA),


### PR DESCRIPTION
Address another part of https://github.com/pytorch/test-infra/issues/1083.  We don't want to send alert when job fails flakily because of different failure reasons.  It turns out that the script already has a nice function `get_unique_failures` to group failures by reason.

Also fix an issue with the `get_current_status` function. This returns the status of the latest job which could be pending.  This causes some alerts to be raise even though there is already a green signal.  The alert is clear when the pending signal turns green, i.e.

![Screenshot 2023-03-02 at 11 22 45](https://user-images.githubusercontent.com/475357/222535161-8c9169e9-336e-4825-9b82-ea9e36a5ba04.png)

### Testing

Unit testing `test_no_alert_when_different_failures`