### PR TITLE
Move external contributor metrics to weekly moving average

### DIFF
--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -111,12 +111,12 @@ export default function Kpis() {
             </Grid>
             <Grid item xs={6} height={ROW_HEIGHT}>
                 <TimeSeriesPanel
-                    title={"External PR Count"}
+                    title={"External PR Count (7 day moving average)"}
                     queryName={"external_contribution_stats"}
                     queryParams={[...timeParams]}
                     granularity={"day"}
                     timeFieldName={"granularity_bucket"}
-                    yAxisFieldName={"pr_count"}
+                    yAxisFieldName={"weekly_moving_average_pr_count"}
                     yAxisRenderer={(value) => value}
                     additionalOptions={{ yAxis: { scale: true } }}
                 />
@@ -124,12 +124,12 @@ export default function Kpis() {
 
             <Grid item xs={6} height={ROW_HEIGHT}>
                 <TimeSeriesPanel
-                    title={"Unique External Contributor Count"}
+                    title={"Unique External Contributor Count (7 day moving average)"}
                     queryName={"external_contribution_stats"}
                     queryParams={[...timeParams]}
                     granularity={"day"}
                     timeFieldName={"granularity_bucket"}
-                    yAxisFieldName={"user_count"}
+                    yAxisFieldName={"weekly_moving_average_user_count"}
                     yAxisRenderer={(value) => value}
                     additionalOptions={{ yAxis: { scale: true } }}
                 />

--- a/torchci/rockset/metrics/__sql/external_contribution_stats.sql
+++ b/torchci/rockset/metrics/__sql/external_contribution_stats.sql
@@ -4,6 +4,12 @@ SELECT
     ) AS granularity_bucket,
     pr_count as pr_count,
     user_count as user_count,
+    TRUNC(AVG(pr_count)
+           OVER(ORDER BY date ROWS BETWEEN 6 PRECEDING AND CURRENT ROW),2)
+           AS weekly_moving_average_pr_count,
+    TRUNC(AVG(user_count)
+           OVER(ORDER BY date ROWS BETWEEN 6 PRECEDING AND CURRENT ROW),2)
+           AS weekly_moving_average_user_count,
 FROM
     metrics.external_contribution_stats
     WHERE CAST(date as date) >= PARSE_DATETIME_ISO8601(:startTime)

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -34,7 +34,7 @@
     "correlation_matrix": "d2ed6c1941a799c7",
     "disabled_test_historical": "daa2413a4750aa87",
     "disabled_test_total": "da5f834a6501fc63",
-    "external_contribution_stats": "d86b6f01367c3d6f",
+    "external_contribution_stats": "f0b640aebc4a5b74",
     "job_duration_avg": "10a88ea2ebb80647",
     "job_duration_percentile": "96507ed62db7a3a8",
     "last_branch_push": "3d995ac2143586dc",


### PR DESCRIPTION
Moves contributor metrics to a 7 day moving average, to make the graph a bit easier to parse + reduce noise from the weekends.
<img width="1509" alt="Screenshot 2023-03-02 at 11 12 56 AM" src="https://user-images.githubusercontent.com/13758638/222528487-4af1f5a8-1400-462d-aa46-93da0a84db3f.png">
