### PR TITLE
[HUD] Fix log URLs for commit views

### DIFF
--- a/torchci/rockset/commons/__sql/commit_jobs_query.sql
+++ b/torchci/rockset/commons/__sql/commit_jobs_query.sql
@@ -9,9 +9,18 @@ WITH job as (
         workflow.artifacts_url as github_artifact_url,
         job.conclusion,
         job.html_url,
-        CONCAT(
-            'https://ossci-raw-job-status.s3.amazonaws.com/log/',
-            CAST(job.id as string)
+        IF(
+          :repo = 'pytorch/pytorch',
+          CONCAT(
+              'https://ossci-raw-job-status.s3.amazonaws.com/log/',
+              CAST(job.id as string)
+            ),
+          CONCAT(
+              'https://ossci-raw-job-status.s3.amazonaws.com/log/',
+              :repo,
+              '/',
+              CAST(job.id as string)
+            )
         ) as log_url,
         DATE_DIFF(
             'SECOND',
@@ -56,7 +65,9 @@ WITH job as (
         END as conclusion,
         -- cirleci doesn't provide a url, piece one together out of the info we have
         CONCAT(
-            'https://app.circleci.com/pipelines/github/pytorch/pytorch/',
+            'https://app.circleci.com/pipelines/github/',
+            :repo,
+            '/',
             CAST(job.pipeline.number as string),
             '/workflows/',
             job.workflow.id,

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -2,7 +2,7 @@
   "commons": {
     "annotated_flaky_jobs": "1e7bd01a839ae4d1",
     "hud_query": "ae178387db09b145",
-    "commit_jobs_query": "442a6f64bd44f351",
+    "commit_jobs_query": "cc524c5036e78794",
     "disabled_non_flaky_tests": "f909abf9eec15b56",
     "commit_failed_jobs": "7e5b39f3ec22b89f",
     "filter_forced_merge_pr": "5cdaa020d6b71414",


### PR DESCRIPTION
If repo is not `pytorch/pytorch`, then it's log must be prefixed with
repo full name.

Also, fix CircleCI select unions (although it looks like ingest for CircleCI jobs is currently broken)

Test plan: look at failure logs at https://torchci-git-malfet-fix-log-url-for-commit-fbopensource.vercel.app/pytorch/vision/commit/e3da44bb02cbcbb4e7269606905590b754b712e8

Followup after https://github.com/pytorch/test-infra/pull/3830
