### PR TITLE
[hud][easy] Fix negative queue times in commit page

### DIFF
--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -17,7 +17,7 @@ export default function JobLinks({ job }: { job: JobData }) {
 
   const queueTimeS =
     job.queueTimeS != null ? (
-      <span>{` | Queued: ${durationHuman(job.queueTimeS!)}`}</span>
+      <span>{` | Queued: ${durationHuman(Math.max(job.queueTimeS!, 0))}`}</span>
     ) : null;
 
   const durationS =


### PR DESCRIPTION
Very small nit thing
When its negative, durationHuman tends to make it -1hr 59min
I assume it is fine to take max(x, 0) because that's what is done in https://github.com/pytorch/test-infra/pull/833