### PR TITLE
Update correlation script to use hamming distance and ignore flaky results

### DIFF
--- a/torchci/lib/correlation_matrix.json
+++ b/torchci/lib/correlation_matrix.json
@@ -1,127 +1,81 @@
 {
     "names": [
-        "linux-bionic-cuda11.7-py3.10-gcc7 / test (functorch)",
-        "linux-bionic-cuda11.8-py3.10-gcc7 / test (default)",
-        "linux-bionic-cuda11.7-py3.10-gcc7 / test (distributed)",
-        "macos-12-py3-arm64 / test (default)",
-        "macos-12-py3-arm64 / test (functorch)",
-        "linux-bionic-cuda11.7-py3.10-gcc7 / test (nogpu_NO_AVX2)",
-        "linux-bionic-cuda11.8-py3.10-gcc7 / test (nogpu_NO_AVX2)",
-        "linux-bionic-cuda11.7-py3.10-gcc7 / test (nogpu_AVX512)",
-        "macos-12-py3-arm64-mps / Run MPS tests",
-        "linux-bionic-cuda11.8-py3.10-gcc7 / test (distributed)",
-        "linux-bionic-py3.8-clang9-slow / test (slow)",
-        "linux-bionic-cuda11.8-py3.10-gcc7 / test (nogpu_AVX512)",
-        "linux-bionic-cuda11.8-py3.10-gcc7 / test (functorch)",
-        "linux-bionic-cuda11.8-py3.10-gcc7 / test (jit_legacy)",
-        "win-vs2019-cuda11.7-py3 / test (force_on_cpu)",
-        "android-emulator-build-test / build-and-test",
-        "linux-bionic-cuda11.7-py3.10-gcc7 / test (default)",
-        "macos-12-py3-x86-64 / test (default)",
-        "win-vs2019-cuda11.7-py3 / test (default)",
-        "macos-12-py3-x86-64 / test (functorch)",
-        "linux-focal-rocm5.4.2-py3.8 / test (default)",
-        "win-vs2019-cuda11.7-py3 / test (functorch)",
-        "linux-focal-py3.9-clang7-tsan / test (tsan)",
-        "linux-bionic-cuda11.7-py3.10-gcc7 / test (jit_legacy)",
-        "linux-focal-py3.7-gcc7 / test (docs_test)",
-        "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit / build-and-test",
-        "linux-focal-py3.7-clang7-asan / test (default)",
-        "linux-bionic-cuda11.6-py3.10-gcc7 / test (default)",
-        "linux-focal-py3.7-gcc7 / test (default)",
-        "linux-bionic-cuda11.6-py3.10-gcc7-bazel-test / build-and-test",
-        "linux-focal-py3.7-clang10-onnx / test (default)",
-        "win-vs2019-cpu-py3 / test (default)",
-        "linux-focal-py3.7-clang7-asan / test (functorch)",
-        "linux-bionic-cuda11.6-py3.10-gcc7 / test (deploy)",
-        "linux-focal-py3.7-gcc7 / test (distributed)",
-        "linux-bionic-py3.7-clang9 / test (crossref)",
-        "linux-bionic-py3.7-clang9 / test (dynamo)",
-        "linux-bionic-cuda11.6-py3.10-gcc7 / test (distributed)",
-        "linux-bionic-cuda11.6-py3.10-gcc7 / test (functorch)",
-        "linux-focal-py3.7-gcc7 / test (jit_legacy)",
-        "linux-bionic-py3_7-clang8-xla / test (xla)",
-        "linux-focal-py3.7-gcc7 / test (backwards_compat)",
-        "linux-bionic-py3.7-clang9 / test (default)",
-        "linux-bionic-py3.7-clang9 / test (functorch)",
-        "win-vs2019-cpu-py3 / test (functorch)",
-        "linux-focal-py3.7-gcc7 / test (functorch)",
-        "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single / build-and-test",
-        "linux-vulkan-bionic-py3.7-clang9 / test (default)",
-        "linux-bionic-cuda11.7-py3.10-gcc7-sm86 / test (default)",
-        "linux-bionic-py3.8-clang9 / test (crossref)",
-        "linux-bionic-py3.11-clang9 / test (smoke)",
-        "linux-bionic-cuda11.7-py3.10-gcc7-sm86 / test (slow)",
-        "linux-bionic-cuda11.7-py3.10-gcc7 / test (deploy)",
-        "linux-focal-py3.9-clang7-asan / test (default)",
-        "linux-bionic-py3.8-clang9 / test (default)",
-        "linux-bionic-cuda11.7-py3.10-gcc7-bazel-test / build-and-test",
-        "linux-bionic-py3.8-clang9 / test (functorch)",
-        "linux-focal-py3.8-gcc7 / test (backwards_compat)",
-        "linux-bionic-cuda11.7-py3.10-gcc7-sm86 / test (functorch)",
-        "linux-focal-py3.9-clang7-asan / test (functorch)",
-        "linux-focal-py3.8-gcc7 / test (functorch)",
-        "linux-focal-py3.8-gcc7 / test (default)",
-        "linux-vulkan-bionic-py3.11-clang9 / test (default)",
-        "linux-focal-py3.8-gcc7 / test (distributed)",
-        "linux-focal-py3.8-clang10-onnx / test (default)",
-        "linux-bionic-py3.8-clang9 / test (dynamo)",
-        "linux-focal-py3.8-gcc7 / test (jit_legacy)",
-        "linux-bionic-py3_8-clang8-xla / test (xla)",
-        "linux-focal-py3.8-gcc7 / test (docs_test)",
-        "linux-bionic-py3.11-clang9 / test (crossref)",
-        "linux-bionic-py3.11-clang9 / test (dynamo)",
-        "linux-bionic-py3.11-clang9 / test (functorch)",
-        "linux-bionic-py3.11-clang9 / test (default)",
-        "cuda11.7-py3.10-gcc7-sm86-periodic-dynamo-benchmarks / test (aot_eager_all)",
-        "win-vs2019-cuda11.8-py3 / test (default)",
-        "linux-bionic-cuda11.7-py3.10-gcc7-debug / test (default)",
-        "linux-bionic-cuda11.7-py3-gcc7-slow-gradcheck / test (default)",
-        "cuda11.7-py3.10-gcc7-sm86-periodic-dynamo-benchmarks / test (dynamic_aot_eager_torchbench)",
-        "linux-bionic-cuda11.8-py3.8-gcc7-debug / test (default)",
-        "cuda11.7-py3.10-gcc7-sm86-periodic-dynamo-benchmarks / test (dynamic_aot_eager_huggingface)",
-        "linux-focal-rocm5.4.2-py3.8 / test (slow)",
-        "linux-bionic-cuda11.7-py3.9-gcc7 / test (multigpu)",
-        "linux-focal-rocm5.4.2-py3.8 / test (distributed)",
-        "parallelnative-linux-focal-py3.8-gcc7 / test (default)",
-        "win-vs2019-cuda11.8-py3 / test (force_on_cpu)",
-        "cuda11.7-py3.10-gcc7-sm86-periodic-dynamo-benchmarks / test (dynamic_aot_eager_timm)",
-        "buck-build-test / buck-build-test",
-        "linux-focal-rocm5.3-py3.8 / test (slow)",
-        "linux-bionic-cuda11.6-py3.7-gcc7-debug / test (default)",
-        "linux-bionic-cuda11.6-py3.10-gcc7-sm86 / test (slow)",
-        "cuda11.6-py3.10-gcc7-sm86-periodic-dynamo-benchmarks / test (dynamic_aot_eager_torchbench)",
-        "cuda11.6-py3.10-gcc7-sm86-periodic-dynamo-benchmarks / test (dynamic_aot_eager_timm)",
-        "linux-bionic-cuda11.7-py3.7-gcc7-debug / test (default)",
-        "linux-bionic-cuda11.6-py3.9-gcc7 / test (multigpu)",
-        "cuda11.6-py3.10-gcc7-sm86-periodic-dynamo-benchmarks / test (aot_eager_all)",
-        "win-vs2019-cuda11.6-py3 / test (default)",
-        "linux-bionic-cuda11.6-py3.10-gcc7-sm86 / test (functorch)",
-        "linux-focal-rocm5.3-py3.8 / test (default)",
-        "win-vs2019-cuda11.6-py3 / test (functorch)",
-        "linux-bionic-cuda11.6-py3-gcc7-slow-gradcheck / test (default)",
-        "win-vs2019-cuda11.6-py3 / test (force_on_cpu)",
-        "linux-bionic-cuda11.6-py3.10-gcc7-sm86 / test (default)",
-        "cuda11.6-py3.10-gcc7-sm86-periodic-dynamo-benchmarks / test (dynamic_aot_eager_huggingface)",
-        "linux-focal-py3.7-clang7-tsan / test (tsan)",
-        "linux-bionic-py3.7-clang9-slow / test (slow)",
-        "parallelnative-linux-focal-py3.7-gcc7 / test (default)",
-        "linux-bionic-cuda11.7-py3.11-gcc7-sm86 / test (default)",
-        "linux-bionic-cuda11.7-py3.11-gcc7-sm86 / test (functorch)",
-        "linux-bionic-cuda11.7-py3.11-gcc7-sm86 / test (slow)",
-        "macos-12-py3-arm64-mps / test (default)",
-        "android-emulator-build-test / filter",
-        "linux-bionic-cuda11.7-py3.10-gcc7-bazel-test / filter",
-        "linux-bionic-cuda11.7-py3.10-gcc7-bazel-test / build-and-test (default)",
-        "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit / build-and-test (default)",
         "buck-build-test / buck-build-test (default)",
-        "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single / build-and-test (default)",
-        "buck-build-test / filter",
         "android-emulator-build-test / build-and-test (default)",
-        "cuda11.6-py3.10-gcc7-sm86 / test (functorch)",
-        "cuda11.6-py3.10-gcc7-sm86 / test (default)",
-        "cuda11.6-py3.10-gcc7-sm86 / test (slow)",
-        "linux-bionic-cpu-py3.10-gcc7-bazel-test / build-and-test (default)"
+        "linux-bionic-cuda11.8-py3.10-gcc7 / test (jit_legacy)",
+        "linux-focal-py3.9-clang7-tsan / test (tsan)",
+        "macos-12-py3-arm64-mps / test (default)",
+        "linux-bionic-cuda11.7-py3.10-gcc7 / test (jit_legacy)",
+        "macos-12-py3-arm64 / test (functorch)",
+        "linux-bionic-cuda11.7-py3.10-gcc7 / test (deploy)",
+        "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit / build-and-test (default)",
+        "linux-bionic-cpu-py3.10-gcc7-bazel-test / build-and-test (default)",
+        "linux-focal-py3.8-clang10-onnx / test (default)",
+        "linux-focal-py3.8-gcc7 / test (docs_test)",
+        "linux-bionic-cuda11.7-py3.10-gcc7-bazel-test / build-and-test (default)",
+        "linux-focal-py3.8-gcc7 / test (jit_legacy)",
+        "linux-vulkan-bionic-py3.11-clang9 / test (default)",
+        "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single / build-and-test (default)",
+        "linux-focal-py3.8-gcc7 / test (backwards_compat)",
+        "macos-12-py3-arm64 / test (default)",
+        "linux-bionic-py3.11-clang9 / test (dynamo)",
+        "linux-bionic-cuda11.7-py3.10-gcc7-sm86 / test (functorch)",
+        "linux-bionic-cuda11.8-py3.10-gcc7 / test (nogpu_NO_AVX2)",
+        "linux-bionic-cuda11.7-py3.10-gcc7 / test (nogpu_NO_AVX2)",
+        "linux-bionic-cuda11.7-py3.10-gcc7 / test (nogpu_AVX512)",
+        "linux-bionic-cuda11.8-py3.10-gcc7 / test (nogpu_AVX512)",
+        "linux-bionic-py3.8-clang9 / test (functorch)",
+        "linux-bionic-cuda11.7-py3.10-gcc7-sm86 / test (default)",
+        "linux-focal-py3.8-gcc7 / test (functorch)",
+        "linux-bionic-py3.8-clang9 / test (dynamo)",
+        "linux-bionic-py3.11-clang9 / test (default)",
+        "linux-bionic-py3_8-clang8-xla / test (xla)",
+        "linux-bionic-py3.11-clang9 / test (crossref)",
+        "linux-bionic-py3.8-clang9 / test (crossref)",
+        "linux-bionic-py3.11-clang9 / test (functorch)",
+        "linux-bionic-cuda11.8-py3.10-gcc7 / test (default)",
+        "linux-bionic-py3.8-clang9-slow / test (slow)",
+        "linux-bionic-cuda11.8-py3.10-gcc7 / test (functorch)",
+        "win-vs2019-cuda11.7-py3 / test (force_on_cpu)",
+        "win-vs2019-cpu-py3 / test (functorch)",
+        "linux-bionic-cuda11.7-py3.10-gcc7 / test (distributed)",
+        "win-vs2019-cpu-py3 / test (default)",
+        "linux-bionic-cuda11.7-py3.10-gcc7 / test (functorch)",
+        "linux-bionic-py3.8-clang9 / test (default)",
+        "linux-focal-py3.9-clang7-asan / test (default)",
+        "linux-focal-py3.8-gcc7 / test (default)",
+        "linux-bionic-cuda11.7-py3.10-gcc7 / test (default)",
+        "linux-bionic-cuda11.8-py3.10-gcc7 / test (distributed)",
+        "win-vs2019-cuda11.7-py3 / test (functorch)",
+        "linux-focal-rocm5.4.2-py3.8 / test (default)",
+        "win-vs2019-cuda11.7-py3 / test (default)",
+        "linux-focal-py3.9-clang7-asan / test (functorch)",
+        "macos-12-py3-x86-64 / test (functorch)",
+        "macos-12-py3-x86-64 / test (default)",
+        "linux-bionic-cuda11.7-py3.10-gcc7-sm86 / test (slow)",
+        "linux-bionic-cuda11.7-py3-gcc7-slow-gradcheck / test (default)",
+        "linux-bionic-cuda11.7-py3.10-gcc7-debug / test (default)",
+        "win-vs2019-cuda11.8-py3 / test (default)",
+        "linux-bionic-cuda11.7-py3.9-gcc7 / test (multigpu)",
+        "cuda11.7-py3.10-gcc7-sm86-periodic-dynamo-benchmarks / test (dynamic_aot_eager_torchbench)",
+        "linux-focal-rocm5.4.2-py3.8 / test (distributed)",
+        "cuda11.7-py3.10-gcc7-sm86-periodic-dynamo-benchmarks / test (aot_eager_torchbench)",
+        "linux-bionic-cuda11.8-py3.8-gcc7-debug / test (default)",
+        "parallelnative-linux-focal-py3.8-gcc7 / test (default)",
+        "cuda11.7-py3.10-gcc7-sm86-periodic-dynamo-benchmarks / test (aot_eager_timm)",
+        "cuda11.7-py3.10-gcc7-sm86-periodic-dynamo-benchmarks / test (aot_eager_huggingface)",
+        "win-vs2019-cuda11.8-py3 / test (force_on_cpu)",
+        "linux-focal-rocm5.4.2-py3.8 / test (slow)",
+        "cuda11.7-py3.10-gcc7-sm86-periodic-dynamo-benchmarks / test (dynamic_aot_eager_timm)",
+        "cuda11.7-py3.10-gcc7-sm86-periodic-dynamo-benchmarks / test (dynamic_aot_eager_huggingface)",
+        "cuda11.7-py3.10-gcc7-sm86-periodic-dynamo-benchmarks / test (aot_eager_all)",
+        "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single / build-and-test",
+        "linux-focal-py3-clang7-android-ndk-r19c-gradle-custom-build-single-full-jit / build-and-test",
+        "android-emulator-build-test / build-and-test",
+        "macos-12-py3-arm64-mps / Run MPS tests",
+        "buck-build-test / buck-build-test",
+        "linux-bionic-cuda11.7-py3.10-gcc7-bazel-test / build-and-test",
+        "linux-focal-py3.8-gcc7 / test (distributed)"
     ],
     "data": [
         [
@@ -132,472 +86,382 @@
         [
             0,
             1,
-            0.6272723883943456
+            0.8213114754098361
         ],
         [
             0,
             2,
-            0.7022329872231278
+            0.06885245901639347
         ],
         [
             0,
             3,
-            0.4166971710328061
+            0.06885245901639347
         ],
         [
             0,
             4,
-            0.5355400513320638
+            0.8213114754098361
         ],
         [
             0,
             5,
-            0.6920293839238062
+            0.06885245901639347
         ],
         [
             0,
             6,
-            0.673590172280232
+            0.13770491803278684
         ],
         [
             0,
             7,
-            0.6985521224910617
+            0.06885245901639347
         ],
         [
             0,
             8,
-            0.28861258238040766
+            0.8213114754098361
         ],
         [
             0,
             9,
-            0.6258274246733996
+            0.8098360655737705
         ],
         [
             0,
             10,
-            0.6978964173211687
+            0.06885245901639347
         ],
         [
             0,
             11,
-            0.682064647525656
+            0.06885245901639347
         ],
         [
             0,
             12,
-            0.9463278452760162
+            0.8098360655737705
         ],
         [
             0,
             13,
-            0.533198397672303
+            0.06885245901639347
         ],
         [
             0,
             14,
-            0.411216901701936
+            0.06885245901639347
         ],
         [
             0,
             15,
-            0.49633040516493754
+            0.8213114754098361
         ],
         [
             0,
             16,
-            0.6490886500447565
+            0.06885245901639347
         ],
         [
             0,
             17,
-            0.3657764755667685
+            0.15081967213114755
         ],
         [
             0,
             18,
-            0.40314493904553506
+            0.08360655737704914
         ],
         [
             0,
             19,
-            0.5069477880712527
+            0.07049180327868854
         ],
         [
             0,
             20,
-            0.5876607128143644
+            0.0901639344262295
         ],
         [
             0,
             21,
-            0.5611469368381391
+            0.08852459016393444
         ],
         [
             0,
             22,
-            0.5705408872857092
+            0.0901639344262295
         ],
         [
             0,
             23,
-            0.51377401137897
+            0.0901639344262295
         ],
         [
             0,
             24,
-            0.5
+            0.07540983606557372
         ],
         [
             0,
             25,
-            0.20987699489547598
+            0.1081967213114754
         ],
         [
             0,
             26,
-            0.6324555320336758
+            0.07540983606557372
         ],
         [
             0,
             27,
-            0.48795003647426655
+            0.08852459016393444
         ],
         [
             0,
             28,
-            0.6324555320336758
+            0.08852459016393444
         ],
         [
             0,
             29,
-            1.0
+            0.0770491803278689
         ],
         [
             0,
             30,
-            0.5
+            0.08852459016393444
         ],
         [
             0,
             31,
-            0.5867597240198822
+            0.08688524590163937
         ],
         [
             0,
             32,
-            0.7905694150420948
+            0.07540983606557372
+        ],
+        [
+            0,
+            33,
+            0.09508196721311479
         ],
         [
             0,
             34,
-            0.7905694150420948
+            0.09672131147540985
         ],
         [
             0,
             35,
-            0.6324555320336758
+            0.0770491803278689
         ],
         [
             0,
             36,
-            0.6324555320336758
+            0.07540983606557372
         ],
         [
             0,
             37,
-            0.6831300510639732
+            0.07868852459016396
         ],
         [
             0,
             38,
-            1.0
+            0.08852459016393444
+        ],
+        [
+            0,
+            39,
+            0.08196721311475408
         ],
         [
             0,
             40,
-            1.0
+            0.0770491803278689
+        ],
+        [
+            0,
+            41,
+            0.09180327868852456
         ],
         [
             0,
             42,
-            0.6324555320336758
+            0.09508196721311479
         ],
         [
             0,
             43,
-            0.7559289460184545
+            0.09180327868852456
         ],
         [
             0,
             44,
-            0.7355818674669264
+            0.09508196721311479
         ],
         [
             0,
             45,
-            0.7559289460184545
+            0.08852459016393444
         ],
         [
             0,
             46,
-            0.0303941361359476
+            0.0770491803278689
+        ],
+        [
+            0,
+            47,
+            0.12295081967213117
         ],
         [
             0,
             48,
-            0.5838798885359712
+            0.0770491803278689
         ],
         [
             0,
             49,
-            0.7628398627477878
+            0.08032786885245902
         ],
         [
             0,
             50,
-            -0.06286946134619319
+            0.07868852459016396
         ],
         [
             0,
             51,
-            0.6806709508239852
+            0.09180327868852456
         ],
         [
             0,
             52,
-            0.48982387398079563
+            0.10491803278688527
         ],
         [
             0,
             53,
-            0.6686609764968598
+            0.9377049180327869
         ],
         [
             0,
             54,
-            0.6733966405755691
+            0.8573770491803279
         ],
         [
             0,
             55,
-            0.7628237733371179
+            0.8442622950819672
         ],
         [
             0,
             56,
-            0.8857021247184436
+            0.8442622950819672
         ],
         [
             0,
             57,
-            0.19885283358835296
+            0.8180327868852459
         ],
         [
             0,
             58,
-            0.8950760306633044
+            0.9114754098360656
         ],
         [
             0,
             59,
-            0.8654439824489241
+            0.9524590163934427
         ],
         [
             0,
             60,
-            0.8827456901518842
+            0.862295081967213
         ],
         [
             0,
             61,
-            0.6787435187743633
+            0.8459016393442623
         ],
         [
             0,
             62,
-            0.11087872889514538
+            0.9508196721311475
         ],
         [
             0,
             63,
-            0.7269375994659236
+            0.9508196721311475
         ],
         [
             0,
             64,
-            0.4424017052256498
+            0.8442622950819672
         ],
         [
             0,
             65,
-            0.6885151977189432
+            0.8459016393442623
         ],
         [
             0,
             66,
-            0.0959910821547985
+            0.8426229508196721
         ],
         [
             0,
             67,
-            0.8423775402549631
+            0.8540983606557377
         ],
         [
             0,
             68,
-            0.11513977523798995
+            0.8901639344262295
         ],
         [
             0,
             69,
-            0.723205844087994
+            0.18688524590163935
         ],
         [
             0,
             70,
-            0.7006015217963227
+            0.18688524590163935
         ],
         [
             0,
             71,
-            0.8379086303347835
+            0.18360655737704923
         ],
         [
             0,
             72,
-            0.715478160026064
+            0.2426229508196721
         ],
         [
             0,
             73,
-            0.40953501547413074
+            0.7901639344262295
         ],
         [
             0,
             74,
-            0.4867954331366181
+            0.1983606557377049
         ],
         [
             0,
             75,
-            0.6075891987525746
-        ],
-        [
-            0,
-            76,
-            0.35627115215558447
-        ],
-        [
-            0,
-            77,
-            0.6922519063747795
-        ],
-        [
-            0,
-            78,
-            0.6016241128197226
-        ],
-        [
-            0,
-            79,
-            0.6172746357502668
-        ],
-        [
-            0,
-            80,
-            0.5445029526777365
-        ],
-        [
-            0,
-            81,
-            0.5107240733669339
-        ],
-        [
-            0,
-            82,
-            0.28948405493948726
-        ],
-        [
-            0,
-            83,
-            0.6207818948568742
-        ],
-        [
-            0,
-            84,
-            0.636272288923178
-        ],
-        [
-            0,
-            85,
-            0.5398744190894337
-        ],
-        [
-            0,
-            86,
-            0.4536899487117063
-        ],
-        [
-            0,
-            89,
-            0.6831300510639732
-        ],
-        [
-            0,
-            95,
-            0.30151134457776374
-        ],
-        [
-            0,
-            96,
-            1.0
-        ],
-        [
-            0,
-            97,
-            0.5714285714285715
-        ],
-        [
-            0,
-            98,
-            0.5222329678670934
-        ],
-        [
-            0,
-            100,
-            0.42640143271122094
-        ],
-        [
-            0,
-            101,
-            0.48795003647426655
-        ],
-        [
-            0,
-            104,
-            0.8164965809277261
-        ],
-        [
-            0,
-            105,
-            0.6666666666666665
-        ],
-        [
-            0,
-            112,
-            1.0
-        ],
-        [
-            0,
-            121,
-            1.0
+            0.8147540983606557
         ],
         [
             1,
             0,
-            0.6272723883943456
+            0.8213114754098361
         ],
         [
             1,
@@ -607,402 +471,382 @@
         [
             1,
             2,
-            0.7267300337057391
+            0.2475409836065574
         ],
         [
             1,
             3,
-            0.574015448032658
+            0.2475409836065574
         ],
         [
             1,
             4,
-            0.3573552013448843
-        ],
-        [
-            1,
-            5,
-            0.8174556276778531
-        ],
-        [
-            1,
-            6,
-            0.8037853445102376
-        ],
-        [
-            1,
-            7,
-            0.8174684167206631
-        ],
-        [
-            1,
-            8,
-            0.22041151202959425
-        ],
-        [
-            1,
-            9,
-            0.768838779300196
-        ],
-        [
-            1,
-            10,
-            0.8029806098962583
-        ],
-        [
-            1,
-            11,
-            0.8178760973241855
-        ],
-        [
-            1,
-            12,
-            0.67149561757249
-        ],
-        [
-            1,
-            13,
-            0.3697097981314795
-        ],
-        [
-            1,
-            14,
-            0.621158741339205
-        ],
-        [
-            1,
-            15,
-            0.40128077892001607
-        ],
-        [
-            1,
-            16,
-            0.8896849195307587
-        ],
-        [
-            1,
-            17,
-            0.6046973004224284
-        ],
-        [
-            1,
-            18,
-            0.6400250164182175
-        ],
-        [
-            1,
-            19,
-            0.5909947587569504
-        ],
-        [
-            1,
-            20,
-            0.8277173810054355
-        ],
-        [
-            1,
-            21,
-            0.6017118801178262
-        ],
-        [
-            1,
-            22,
-            0.4165598504331851
-        ],
-        [
-            1,
-            23,
-            0.3424968287799702
-        ],
-        [
-            1,
-            25,
-            0.15703986430467515
-        ],
-        [
-            1,
-            27,
             1.0
         ],
         [
             1,
+            5,
+            0.2475409836065574
+        ],
+        [
+            1,
+            6,
+            0.31639344262295077
+        ],
+        [
+            1,
+            7,
+            0.2475409836065574
+        ],
+        [
+            1,
+            8,
+            1.0
+        ],
+        [
+            1,
+            9,
+            0.9885245901639345
+        ],
+        [
+            1,
+            10,
+            0.2475409836065574
+        ],
+        [
+            1,
+            11,
+            0.2475409836065574
+        ],
+        [
+            1,
+            12,
+            0.9885245901639345
+        ],
+        [
+            1,
+            13,
+            0.2475409836065574
+        ],
+        [
+            1,
+            14,
+            0.2475409836065574
+        ],
+        [
+            1,
+            15,
+            1.0
+        ],
+        [
+            1,
+            16,
+            0.2475409836065574
+        ],
+        [
+            1,
+            17,
+            0.3295081967213115
+        ],
+        [
+            1,
+            18,
+            0.2622950819672131
+        ],
+        [
+            1,
+            19,
+            0.24590163934426235
+        ],
+        [
+            1,
+            20,
+            0.2622950819672131
+        ],
+        [
+            1,
+            21,
+            0.260655737704918
+        ],
+        [
+            1,
+            22,
+            0.2622950819672131
+        ],
+        [
+            1,
+            23,
+            0.2622950819672131
+        ],
+        [
+            1,
+            24,
+            0.2475409836065574
+        ],
+        [
+            1,
+            25,
+            0.280327868852459
+        ],
+        [
+            1,
+            26,
+            0.2475409836065574
+        ],
+        [
+            1,
+            27,
+            0.260655737704918
+        ],
+        [
+            1,
+            28,
+            0.260655737704918
+        ],
+        [
+            1,
+            29,
+            0.24918032786885247
+        ],
+        [
+            1,
+            30,
+            0.260655737704918
+        ],
+        [
+            1,
             31,
-            0.6524318068267971
+            0.25901639344262295
+        ],
+        [
+            1,
+            32,
+            0.2475409836065574
+        ],
+        [
+            1,
+            33,
+            0.26393442622950825
+        ],
+        [
+            1,
+            34,
+            0.2655737704918033
+        ],
+        [
+            1,
+            35,
+            0.24590163934426235
+        ],
+        [
+            1,
+            36,
+            0.24426229508196717
         ],
         [
             1,
             37,
-            0.5
+            0.2475409836065574
+        ],
+        [
+            1,
+            38,
+            0.2573770491803279
+        ],
+        [
+            1,
+            39,
+            0.25081967213114753
+        ],
+        [
+            1,
+            40,
+            0.24590163934426235
+        ],
+        [
+            1,
+            41,
+            0.260655737704918
+        ],
+        [
+            1,
+            42,
+            0.26393442622950825
+        ],
+        [
+            1,
+            43,
+            0.260655737704918
         ],
         [
             1,
             44,
-            0.6000635132837553
+            0.260655737704918
+        ],
+        [
+            1,
+            45,
+            0.2573770491803279
         ],
         [
             1,
             46,
-            0.04754364728687035
+            0.24590163934426235
+        ],
+        [
+            1,
+            47,
+            0.2918032786885246
         ],
         [
             1,
             48,
-            0.7238596901560045
+            0.24590163934426235
         ],
         [
             1,
             49,
-            0.7991838718169643
+            0.24918032786885247
         ],
         [
             1,
             50,
-            0.5222329678670935
+            0.24426229508196717
         ],
         [
             1,
             51,
-            0.7658289047617725
+            0.2573770491803279
         ],
         [
             1,
             52,
-            0.298778774238436
+            0.2704918032786885
         ],
         [
             1,
             53,
-            0.854488471332478
+            0.759016393442623
         ],
         [
             1,
             54,
-            0.8625556165743687
+            0.6786885245901639
         ],
         [
             1,
             55,
-            0.554827225567293
+            0.6655737704918032
         ],
         [
             1,
             56,
-            0.5848716446266828
+            0.6655737704918032
         ],
         [
             1,
             57,
-            0.18339965449967066
+            0.639344262295082
         ],
         [
             1,
             58,
-            0.5689641585147028
+            0.7327868852459016
         ],
         [
             1,
             59,
-            0.7001220017444355
+            0.7737704918032787
         ],
         [
             1,
             60,
-            0.5774023624157275
+            0.6836065573770491
         ],
         [
             1,
             61,
-            0.8562279255784957
+            0.6672131147540983
         ],
         [
             1,
             62,
-            0.05485034409678747
+            0.7721311475409836
         ],
         [
             1,
             63,
-            0.5654753306682656
+            0.7721311475409836
         ],
         [
             1,
             64,
-            0.34701522273971264
+            0.6655737704918032
         ],
         [
             1,
             65,
-            0.659573361605372
+            0.6672131147540983
         ],
         [
             1,
             66,
-            0.15024204041040873
+            0.6639344262295082
         ],
         [
             1,
             67,
-            0.5983490078800613
+            0.6754098360655738
         ],
         [
             1,
             68,
-            0.05826418561378327
+            0.7114754098360656
         ],
         [
             1,
             69,
-            0.7741452011548068
+            0.008196721311475419
         ],
         [
             1,
             70,
-            0.7317681270861476
+            0.008196721311475419
         ],
         [
             1,
             71,
-            0.5575671876210618
+            0.004918032786885296
         ],
         [
             1,
             72,
-            0.801396102621767
+            0.06393442622950818
         ],
         [
             1,
             73,
-            0.22870887905848217
+            0.6114754098360655
         ],
         [
             1,
             74,
-            0.45336734022117003
+            0.01967213114754096
         ],
         [
             1,
             75,
-            0.9381250996851901
-        ],
-        [
-            1,
-            76,
-            0.34011568055963987
-        ],
-        [
-            1,
-            77,
-            0.4330342793957001
-        ],
-        [
-            1,
-            78,
-            0.9390521978179235
-        ],
-        [
-            1,
-            79,
-            0.34055735510680046
-        ],
-        [
-            1,
-            80,
-            0.7373229221923706
-        ],
-        [
-            1,
-            81,
-            0.6999196930849415
-        ],
-        [
-            1,
-            82,
-            0.42080268215331684
-        ],
-        [
-            1,
-            83,
-            0.9153479868341301
-        ],
-        [
-            1,
-            84,
-            0.5533344076659201
-        ],
-        [
-            1,
-            85,
-            0.3815947467563174
-        ],
-        [
-            1,
-            86,
-            0.2525872830735344
-        ],
-        [
-            1,
-            88,
-            1.0
-        ],
-        [
-            1,
-            89,
-            0.5
-        ],
-        [
-            1,
-            90,
-            1.0
-        ],
-        [
-            1,
-            92,
-            1.0
-        ],
-        [
-            1,
-            93,
-            1.0
-        ],
-        [
-            1,
-            94,
-            1.0
-        ],
-        [
-            1,
-            95,
-            0.6666666666666667
-        ],
-        [
-            1,
-            98,
-            0.6123724356957946
-        ],
-        [
-            1,
-            99,
-            1.0
-        ],
-        [
-            1,
-            100,
-            0.6123724356957946
-        ],
-        [
-            1,
-            101,
-            1.0
+            0.6360655737704918
         ],
         [
             2,
             0,
-            0.7022329872231278
+            0.06885245901639347
         ],
         [
             2,
             1,
-            0.7267300337057391
+            0.2475409836065574
         ],
         [
             2,
@@ -1012,502 +856,382 @@
         [
             2,
             3,
-            0.40838419734087056
+            1.0
         ],
         [
             2,
             4,
-            0.33730160825626726
+            0.2475409836065574
         ],
         [
             2,
             5,
-            0.6583677311807979
+            1.0
         ],
         [
             2,
             6,
-            0.6292578562234712
+            0.9311475409836065
         ],
         [
             2,
             7,
-            0.6583677311807978
+            1.0
         ],
         [
             2,
             8,
-            0.20571444848891765
+            0.2475409836065574
         ],
         [
             2,
             9,
-            0.9292757101511696
+            0.25901639344262295
         ],
         [
             2,
             10,
-            0.718062303708798
+            1.0
         ],
         [
             2,
             11,
-            0.6400615682662393
+            1.0
         ],
         [
             2,
             12,
-            0.6599235100202895
+            0.25901639344262295
         ],
         [
             2,
             13,
-            0.38377691219836413
+            1.0
         ],
         [
             2,
             14,
-            0.5553614602732948
+            1.0
         ],
         [
             2,
             15,
-            0.3560272926761639
+            0.2475409836065574
         ],
         [
             2,
             16,
-            0.7017297880665369
+            1.0
         ],
         [
             2,
             17,
-            0.4409605041854958
+            0.9180327868852459
         ],
         [
             2,
             18,
-            0.5264090737667061
+            0.9852459016393442
         ],
         [
             2,
             19,
-            0.5793978816671871
+            0.9983606557377049
         ],
         [
             2,
             20,
-            0.6908120777691572
+            0.978688524590164
         ],
         [
             2,
             21,
-            0.5803628197294115
+            0.980327868852459
         ],
         [
             2,
             22,
-            0.4269014271415623
+            0.978688524590164
         ],
         [
             2,
             23,
-            0.3739153282594999
+            0.978688524590164
         ],
         [
             2,
             24,
-            0.39528470752104744
+            0.9934426229508196
         ],
         [
             2,
             25,
-            0.16610910216324293
+            0.9606557377049181
         ],
         [
             2,
             26,
-            0.7999999999999999
+            0.9934426229508196
         ],
         [
             2,
             27,
-            0.7142857142857144
+            0.980327868852459
         ],
         [
             2,
             28,
-            0.7999999999999999
+            0.980327868852459
         ],
         [
             2,
             29,
-            0.6708203932499368
+            0.9918032786885246
         ],
         [
             2,
             30,
-            0.39528470752104744
+            0.980327868852459
         ],
         [
             2,
             31,
-            0.6746888216547782
+            0.9819672131147541
         ],
         [
             2,
             32,
-            1.0
+            0.9934426229508196
+        ],
+        [
+            2,
+            33,
+            0.9737704918032787
         ],
         [
             2,
             34,
-            1.0
+            0.9721311475409836
         ],
         [
             2,
             35,
-            0.7999999999999999
+            0.9918032786885246
         ],
         [
             2,
             36,
-            0.7999999999999999
+            0.9868852459016394
         ],
         [
             2,
             37,
-            1.0
+            0.9868852459016394
         ],
         [
             2,
             38,
-            0.6831300510639732
+            0.980327868852459
+        ],
+        [
+            2,
+            39,
+            0.9836065573770492
         ],
         [
             2,
             40,
-            0.6546536707079772
+            0.9918032786885246
+        ],
+        [
+            2,
+            41,
+            0.9770491803278688
         ],
         [
             2,
             42,
-            0.7999999999999999
+            0.9737704918032787
         ],
         [
             2,
             43,
-            0.5976143046671969
+            0.9770491803278688
         ],
         [
             2,
             44,
-            0.7055027741801932
+            0.9704918032786886
         ],
         [
             2,
             45,
-            0.5976143046671969
+            0.980327868852459
         ],
         [
             2,
             46,
-            0.022585877718926034
+            0.9885245901639345
+        ],
+        [
+            2,
+            47,
+            0.9459016393442623
         ],
         [
             2,
             48,
-            0.5856651491594542
+            0.9852459016393442
         ],
         [
             2,
             49,
-            0.6697342218471222
+            0.9885245901639345
         ],
         [
             2,
             50,
-            0.46625240412015717
+            0.9836065573770492
         ],
         [
             2,
             51,
-            0.752070648404761
+            0.9704918032786886
         ],
         [
             2,
             52,
-            0.3733282307763728
+            0.9639344262295082
         ],
         [
             2,
             53,
-            0.6811253040916233
+            0.12459016393442623
         ],
         [
             2,
             54,
-            0.6777640672946363
+            0.20491803278688525
         ],
         [
             2,
             55,
-            0.5863921757572743
+            0.19180327868852454
         ],
         [
             2,
             56,
-            0.6213304565718285
+            0.1852459016393443
         ],
         [
             2,
             57,
-            0.15947523023673743
+            0.19508196721311477
         ],
         [
             2,
             58,
-            0.6329062896402649
+            0.1081967213114754
         ],
         [
             2,
             59,
-            0.7667975142212906
+            0.021311475409836023
         ],
         [
             2,
             60,
-            0.6172245091604891
+            0.2065573770491803
         ],
         [
             2,
             61,
-            0.6685095907486841
+            0.22295081967213115
         ],
         [
             2,
             62,
-            0.08419146406637444
+            0.01967213114754096
         ],
         [
             2,
             63,
-            0.7149395143099547
+            0.01967213114754096
         ],
         [
             2,
             64,
-            0.36246067647322394
+            0.2213114754098361
         ],
         [
             2,
             65,
-            0.5883705311810214
+            0.2163934426229508
         ],
         [
             2,
             66,
-            0.1074587235441961
+            0.16065573770491803
         ],
         [
             2,
             67,
-            0.7449137244046414
+            0.2114754098360656
         ],
         [
             2,
             68,
-            0.10667458360753708
+            0.139344262295082
         ],
         [
             2,
             69,
-            0.6294693144550257
+            0.760655737704918
         ],
         [
             2,
             70,
-            0.586430785134082
+            0.760655737704918
         ],
         [
             2,
             71,
-            0.5836606218825335
+            0.7573770491803279
         ],
         [
             2,
             72,
-            0.6510939892210053
+            0.7049180327868853
         ],
         [
             2,
             73,
-            0.3054951331824168
+            0.1573770491803279
         ],
         [
             2,
             74,
-            0.4398931013693864
+            0.7491803278688525
         ],
         [
             2,
             75,
-            0.8588857820901721
-        ],
-        [
-            2,
-            76,
-            0.3001667296966772
-        ],
-        [
-            2,
-            77,
-            0.4641013057093143
-        ],
-        [
-            2,
-            78,
-            0.8607017918258185
-        ],
-        [
-            2,
-            79,
-            0.44486513237857067
-        ],
-        [
-            2,
-            80,
-            0.7477385158209185
-        ],
-        [
-            2,
-            81,
-            0.7343256096662497
-        ],
-        [
-            2,
-            82,
-            0.4976341996480998
-        ],
-        [
-            2,
-            83,
-            0.8609292044196345
-        ],
-        [
-            2,
-            84,
-            0.48574618514864737
-        ],
-        [
-            2,
-            85,
-            0.42789580294248225
-        ],
-        [
-            2,
-            86,
-            0.268010730224046
-        ],
-        [
-            2,
-            88,
-            1.0
-        ],
-        [
-            2,
-            89,
-            1.0
-        ],
-        [
-            2,
-            90,
-            1.0
-        ],
-        [
-            2,
-            92,
-            1.0
-        ],
-        [
-            2,
-            93,
-            1.0
-        ],
-        [
-            2,
-            94,
-            1.0
-        ],
-        [
-            2,
-            95,
-            0.5773502691896255
-        ],
-        [
-            2,
-            96,
-            0.6831300510639732
-        ],
-        [
-            2,
-            97,
-            0.8280786712108251
-        ],
-        [
-            2,
-            98,
-            0.5555555555555555
-        ],
-        [
-            2,
-            99,
-            1.0
-        ],
-        [
-            2,
-            100,
-            0.8164965809277259
-        ],
-        [
-            2,
-            101,
-            0.7142857142857144
-        ],
-        [
-            2,
-            104,
-            1.0
-        ],
-        [
-            2,
-            105,
-            0.8164965809277263
-        ],
-        [
-            2,
-            112,
-            1.0
-        ],
-        [
-            2,
-            121,
-            1.0
+            0.13278688524590165
         ],
         [
             3,
             0,
-            0.4166971710328061
+            0.06885245901639347
         ],
         [
             3,
             1,
-            0.574015448032658
+            0.2475409836065574
         ],
         [
             3,
             2,
-            0.40838419734087056
+            1.0
         ],
         [
             3,
@@ -1517,487 +1241,382 @@
         [
             3,
             4,
-            0.5708028546693775
+            0.2475409836065574
         ],
         [
             3,
             5,
-            0.5510075772539665
+            1.0
         ],
         [
             3,
             6,
-            0.5323598461013103
+            0.9311475409836065
         ],
         [
             3,
             7,
-            0.5565538579141491
+            1.0
         ],
         [
             3,
             8,
-            0.4603974265843398
+            0.2475409836065574
         ],
         [
             3,
             9,
-            0.4125452023546624
+            0.25901639344262295
         ],
         [
             3,
             10,
-            0.5384660949154696
+            1.0
         ],
         [
             3,
             11,
-            0.5469131870765537
+            1.0
         ],
         [
             3,
             12,
-            0.4589067474990755
+            0.25901639344262295
         ],
         [
             3,
             13,
-            0.1574039435731719
+            1.0
         ],
         [
             3,
             14,
-            0.42959298718925126
+            1.0
         ],
         [
             3,
             15,
-            0.15853495919645344
+            0.2475409836065574
         ],
         [
             3,
             16,
-            0.5557102608607607
+            1.0
         ],
         [
             3,
             17,
-            0.6967779477767176
+            0.9180327868852459
         ],
         [
             3,
             18,
-            0.4175851485613976
+            0.9852459016393442
         ],
         [
             3,
             19,
-            0.4098700450721337
+            0.9983606557377049
         ],
         [
             3,
             20,
-            0.5707231679907154
+            0.978688524590164
         ],
         [
             3,
             21,
-            0.38664327468052007
+            0.980327868852459
         ],
         [
             3,
             22,
-            0.18826791988071173
+            0.978688524590164
         ],
         [
             3,
             23,
-            0.15152122850850722
+            0.978688524590164
         ],
         [
             3,
             24,
-            0.12500000000000003
+            0.9934426229508196
         ],
         [
             3,
             25,
-            0.03281707314118289
+            0.9606557377049181
         ],
         [
             3,
             26,
-            0.3952847075210473
+            0.9934426229508196
         ],
         [
             3,
             27,
-            0.529150262212918
+            0.980327868852459
         ],
         [
             3,
             28,
-            0.3952847075210473
+            0.980327868852459
         ],
         [
             3,
             29,
-            0.288675134594813
+            0.9918032786885246
         ],
         [
             3,
             30,
-            0.12500000000000003
+            0.980327868852459
         ],
         [
             3,
             31,
-            0.45749653318138056
+            0.9819672131147541
         ],
         [
             3,
             32,
-            0.3162277660168379
+            0.9934426229508196
+        ],
+        [
+            3,
+            33,
+            0.9737704918032787
         ],
         [
             3,
             34,
-            0.3162277660168379
+            0.9721311475409836
         ],
         [
             3,
             35,
-            0.3952847075210473
+            0.9918032786885246
         ],
         [
             3,
             36,
-            0.3952847075210474
+            0.9868852459016394
         ],
         [
             3,
             37,
-            0.3779644730092272
+            0.9868852459016394
         ],
         [
             3,
             38,
-            0.2581988897471611
+            0.980327868852459
+        ],
+        [
+            3,
+            39,
+            0.9836065573770492
         ],
         [
             3,
             40,
-            0.21821789023599242
+            0.9918032786885246
+        ],
+        [
+            3,
+            41,
+            0.9770491803278688
         ],
         [
             3,
             42,
-            0.3952847075210473
+            0.9737704918032787
         ],
         [
             3,
             43,
-            0.18898223650461363
+            0.9770491803278688
         ],
         [
             3,
             44,
-            0.3897113440021563
+            0.9704918032786886
         ],
         [
             3,
             45,
-            0.18898223650461363
+            0.980327868852459
         ],
         [
             3,
             46,
-            -0.02397093678464215
+            0.9885245901639345
+        ],
+        [
+            3,
+            47,
+            0.9459016393442623
         ],
         [
             3,
             48,
-            0.4545247381964273
+            0.9852459016393442
         ],
         [
             3,
             49,
-            0.5303188276947495
+            0.9885245901639345
         ],
         [
             3,
             50,
-            0.5222329678670935
+            0.9836065573770492
         ],
         [
             3,
             51,
-            0.46209994258266274
+            0.9704918032786886
         ],
         [
             3,
             52,
-            0.12833366285844527
+            0.9639344262295082
         ],
         [
             3,
             53,
-            0.5783607208631983
+            0.12459016393442623
         ],
         [
             3,
             54,
-            0.5913922100062655
+            0.20491803278688525
         ],
         [
             3,
             55,
-            0.31908562656224926
+            0.19180327868852454
         ],
         [
             3,
             56,
-            0.3798985332068976
+            0.1852459016393443
         ],
         [
             3,
             57,
-            0.10598662203401162
+            0.19508196721311477
         ],
         [
             3,
             58,
-            0.3448443145747924
+            0.1081967213114754
         ],
         [
             3,
             59,
-            0.46894506769031624
+            0.021311475409836023
         ],
         [
             3,
             60,
-            0.36681641647432905
+            0.2065573770491803
         ],
         [
             3,
             61,
-            0.5907746510728373
+            0.22295081967213115
+        ],
+        [
+            3,
+            62,
+            0.01967213114754096
         ],
         [
             3,
             63,
-            0.3086187848496843
+            0.01967213114754096
         ],
         [
             3,
             64,
-            0.11934529336606564
+            0.2213114754098361
         ],
         [
             3,
             65,
-            0.4634624612317765
+            0.2163934426229508
         ],
         [
             3,
             66,
-            0.047998031775434255
+            0.16065573770491803
         ],
         [
             3,
             67,
-            0.4034908849790441
+            0.2114754098360656
         ],
         [
             3,
             68,
-            -0.025803299620380728
+            0.139344262295082
         ],
         [
             3,
             69,
-            0.5070469598606773
+            0.760655737704918
         ],
         [
             3,
             70,
-            0.48481359562861914
+            0.760655737704918
         ],
         [
             3,
             71,
-            0.34162145828795804
+            0.7573770491803279
         ],
         [
             3,
             72,
-            0.5275624563300312
+            0.7049180327868853
         ],
         [
             3,
             73,
-            0.32345344370572576
+            0.1573770491803279
         ],
         [
             3,
             74,
-            0.4303297889902683
+            0.7491803278688525
         ],
         [
             3,
             75,
-            0.5091917285863291
-        ],
-        [
-            3,
-            76,
-            0.2542899176518616
-        ],
-        [
-            3,
-            77,
-            0.39059876846073116
-        ],
-        [
-            3,
-            78,
-            0.5184383548760653
-        ],
-        [
-            3,
-            79,
-            0.33017672256485686
-        ],
-        [
-            3,
-            80,
-            0.31377408239584653
-        ],
-        [
-            3,
-            81,
-            0.3407328773843053
-        ],
-        [
-            3,
-            82,
-            0.0978724666583036
-        ],
-        [
-            3,
-            83,
-            0.5392926790675338
-        ],
-        [
-            3,
-            84,
-            0.47064217115720663
-        ],
-        [
-            3,
-            85,
-            0.2537823630689847
-        ],
-        [
-            3,
-            86,
-            0.19429954381970735
-        ],
-        [
-            3,
-            88,
-            1.0
-        ],
-        [
-            3,
-            89,
-            0.3779644730092272
-        ],
-        [
-            3,
-            90,
-            1.0
-        ],
-        [
-            3,
-            92,
-            1.0
-        ],
-        [
-            3,
-            93,
-            1.0
-        ],
-        [
-            3,
-            94,
-            1.0
-        ],
-        [
-            3,
-            95,
-            0.35355339059327373
-        ],
-        [
-            3,
-            96,
-            0.2581988897471611
-        ],
-        [
-            3,
-            97,
-            0.4183300132670378
-        ],
-        [
-            3,
-            98,
-            0.4082482904638631
-        ],
-        [
-            3,
-            99,
-            1.0
-        ],
-        [
-            3,
-            100,
-            0.49999999999999994
-        ],
-        [
-            3,
-            101,
-            0.529150262212918
-        ],
-        [
-            3,
-            104,
-            0.33333333333333326
-        ],
-        [
-            3,
-            105,
-            0.40824829046386296
+            0.13278688524590165
         ],
         [
             4,
             0,
-            0.5355400513320638
+            0.8213114754098361
         ],
         [
             4,
             1,
-            0.3573552013448843
+            1.0
         ],
         [
             4,
             2,
-            0.33730160825626726
+            0.2475409836065574
         ],
         [
             4,
             3,
-            0.5708028546693775
+            0.2475409836065574
         ],
         [
             4,
@@ -2007,442 +1626,382 @@
         [
             4,
             5,
-            0.4077693859257316
+            0.2475409836065574
         ],
         [
             4,
             6,
-            0.38755108071567795
+            0.31639344262295077
         ],
         [
             4,
             7,
-            0.41595033912298757
+            0.2475409836065574
         ],
         [
             4,
             8,
-            0.7276611039362653
-        ],
-        [
-            4,
-            9,
-            0.3396781017763302
-        ],
-        [
-            4,
-            10,
-            0.4010398761045766
-        ],
-        [
-            4,
-            11,
-            0.3929710605195581
-        ],
-        [
-            4,
-            12,
-            0.5695882976556774
-        ],
-        [
-            4,
-            13,
-            0.1205113043216582
-        ],
-        [
-            4,
-            14,
-            0.27755802395140305
-        ],
-        [
-            4,
-            15,
-            0.288415308811709
-        ],
-        [
-            4,
-            16,
-            0.363556700655475
-        ],
-        [
-            4,
-            17,
-            0.2524480707755679
-        ],
-        [
-            4,
-            18,
-            0.26431406161052035
-        ],
-        [
-            4,
-            19,
-            0.3419697902658569
-        ],
-        [
-            4,
-            20,
-            0.3374235910587102
-        ],
-        [
-            4,
-            21,
-            0.3457598070620011
-        ],
-        [
-            4,
-            22,
-            0.2637670269242714
-        ],
-        [
-            4,
-            23,
-            0.10097156181908831
-        ],
-        [
-            4,
-            24,
-            0.5
-        ],
-        [
-            4,
-            25,
-            0.0754235995602094
-        ],
-        [
-            4,
-            26,
-            0.6324555320336758
-        ],
-        [
-            4,
-            27,
-            0.48795003647426655
-        ],
-        [
-            4,
-            28,
-            0.6324555320336758
-        ],
-        [
-            4,
-            29,
             1.0
         ],
         [
             4,
+            9,
+            0.9885245901639345
+        ],
+        [
+            4,
+            10,
+            0.2475409836065574
+        ],
+        [
+            4,
+            11,
+            0.2475409836065574
+        ],
+        [
+            4,
+            12,
+            0.9885245901639345
+        ],
+        [
+            4,
+            13,
+            0.2475409836065574
+        ],
+        [
+            4,
+            14,
+            0.2475409836065574
+        ],
+        [
+            4,
+            15,
+            1.0
+        ],
+        [
+            4,
+            16,
+            0.2475409836065574
+        ],
+        [
+            4,
+            17,
+            0.3295081967213115
+        ],
+        [
+            4,
+            18,
+            0.2622950819672131
+        ],
+        [
+            4,
+            19,
+            0.24590163934426235
+        ],
+        [
+            4,
+            20,
+            0.2622950819672131
+        ],
+        [
+            4,
+            21,
+            0.260655737704918
+        ],
+        [
+            4,
+            22,
+            0.2622950819672131
+        ],
+        [
+            4,
+            23,
+            0.2622950819672131
+        ],
+        [
+            4,
+            24,
+            0.2475409836065574
+        ],
+        [
+            4,
+            25,
+            0.280327868852459
+        ],
+        [
+            4,
+            26,
+            0.2475409836065574
+        ],
+        [
+            4,
+            27,
+            0.260655737704918
+        ],
+        [
+            4,
+            28,
+            0.260655737704918
+        ],
+        [
+            4,
+            29,
+            0.24918032786885247
+        ],
+        [
+            4,
             30,
-            0.5
+            0.260655737704918
         ],
         [
             4,
             31,
-            0.3357058893372323
+            0.25901639344262295
         ],
         [
             4,
             32,
-            0.7905694150420948
+            0.2475409836065574
+        ],
+        [
+            4,
+            33,
+            0.26393442622950825
         ],
         [
             4,
             34,
-            0.7905694150420948
+            0.2655737704918033
         ],
         [
             4,
             35,
-            0.6324555320336758
+            0.24590163934426235
         ],
         [
             4,
             36,
-            0.6324555320336758
+            0.24426229508196717
         ],
         [
             4,
             37,
-            0.6831300510639732
+            0.2475409836065574
         ],
         [
             4,
             38,
-            1.0
+            0.2573770491803279
+        ],
+        [
+            4,
+            39,
+            0.25081967213114753
         ],
         [
             4,
             40,
-            1.0
+            0.24590163934426235
+        ],
+        [
+            4,
+            41,
+            0.260655737704918
         ],
         [
             4,
             42,
-            0.6324555320336758
+            0.26393442622950825
         ],
         [
             4,
             43,
-            0.7559289460184545
+            0.260655737704918
         ],
         [
             4,
             44,
-            0.3946288056831667
+            0.260655737704918
         ],
         [
             4,
             45,
-            0.7559289460184545
+            0.2573770491803279
         ],
         [
             4,
             46,
-            0.027769626707270668
+            0.24590163934426235
+        ],
+        [
+            4,
+            47,
+            0.2918032786885246
         ],
         [
             4,
             48,
-            0.2959603197070847
+            0.24590163934426235
         ],
         [
             4,
             49,
-            0.3984327568439004
+            0.24918032786885247
         ],
         [
             4,
             50,
-            -0.09090909090909086
+            0.24426229508196717
         ],
         [
             4,
             51,
-            0.2994505381442801
+            0.2573770491803279
         ],
         [
             4,
             52,
-            0.15678065182064072
+            0.2704918032786885
         ],
         [
             4,
             53,
-            0.3815977709733618
+            0.759016393442623
         ],
         [
             4,
             54,
-            0.38189313552646387
+            0.6786885245901639
         ],
         [
             4,
             55,
-            0.4366609607608188
+            0.6655737704918032
         ],
         [
             4,
             56,
-            0.5577008943251115
+            0.6655737704918032
         ],
         [
             4,
             57,
-            0.15351169930468328
+            0.639344262295082
         ],
         [
             4,
             58,
-            0.47976111972498914
+            0.7327868852459016
         ],
         [
             4,
             59,
-            0.4924963057074394
+            0.7737704918032787
         ],
         [
             4,
             60,
-            0.5503299488500253
+            0.6836065573770491
         ],
         [
             4,
             61,
-            0.3771905966741625
+            0.6672131147540983
+        ],
+        [
+            4,
+            62,
+            0.7721311475409836
         ],
         [
             4,
             63,
-            0.4029945218006074
+            0.7721311475409836
         ],
         [
             4,
             64,
-            0.1815908373502995
+            0.6655737704918032
         ],
         [
             4,
             65,
-            0.30807122468058407
+            0.6672131147540983
         ],
         [
             4,
             66,
-            0.0219077516295579
+            0.6639344262295082
         ],
         [
             4,
             67,
-            0.47133073686788646
+            0.6754098360655738
         ],
         [
             4,
             68,
-            -0.016020944008442048
+            0.7114754098360656
         ],
         [
             4,
             69,
-            0.3720995894598457
+            0.008196721311475419
         ],
         [
             4,
             70,
-            0.357148200333189
+            0.008196721311475419
         ],
         [
             4,
             71,
-            0.5200476392358735
+            0.004918032786885296
         ],
         [
             4,
             72,
-            0.36888657289223586
+            0.06393442622950818
         ],
         [
             4,
             73,
-            0.37876989646047204
+            0.6114754098360655
         ],
         [
             4,
             74,
-            0.40322875943402453
+            0.01967213114754096
         ],
         [
             4,
             75,
-            0.2916816597461576
-        ],
-        [
-            4,
-            76,
-            0.30626441352464534
-        ],
-        [
-            4,
-            77,
-            0.41829330884294824
-        ],
-        [
-            4,
-            78,
-            0.2866125763007559
-        ],
-        [
-            4,
-            79,
-            0.29141730820341627
-        ],
-        [
-            4,
-            80,
-            0.18794305290132032
-        ],
-        [
-            4,
-            81,
-            0.2916625261406942
-        ],
-        [
-            4,
-            82,
-            0.10094679649981633
-        ],
-        [
-            4,
-            83,
-            0.2999333418706646
-        ],
-        [
-            4,
-            84,
-            0.33993636916197745
-        ],
-        [
-            4,
-            85,
-            0.27553628690024295
-        ],
-        [
-            4,
-            86,
-            0.17019381114452506
-        ],
-        [
-            4,
-            89,
-            0.6831300510639732
-        ],
-        [
-            4,
-            96,
-            1.0
-        ],
-        [
-            4,
-            97,
-            0.46291004988627565
-        ],
-        [
-            4,
-            101,
-            0.48795003647426655
-        ],
-        [
-            4,
-            104,
-            0.6546536707079772
-        ],
-        [
-            4,
-            105,
-            0.5345224838248488
+            0.6360655737704918
         ],
         [
             5,
             0,
-            0.6920293839238062
+            0.06885245901639347
         ],
         [
             5,
             1,
-            0.8174556276778531
+            0.2475409836065574
         ],
         [
             5,
             2,
-            0.6583677311807979
+            1.0
         ],
         [
             5,
             3,
-            0.5510075772539665
+            1.0
         ],
         [
             5,
             4,
-            0.4077693859257316
+            0.2475409836065574
         ],
         [
             5,
@@ -2452,492 +2011,382 @@
         [
             5,
             6,
-            0.9633481869623121
+            0.9311475409836065
         ],
         [
             5,
             7,
-            0.9948270209552671
+            1.0
         ],
         [
             5,
             8,
-            0.193777823135779
+            0.2475409836065574
         ],
         [
             5,
             9,
-            0.657677074764197
+            0.25901639344262295
         ],
         [
             5,
             10,
-            0.8514274957240066
+            1.0
         ],
         [
             5,
             11,
-            0.983870723502142
+            1.0
         ],
         [
             5,
             12,
-            0.7277517111461023
+            0.25901639344262295
         ],
         [
             5,
             13,
-            0.4364677118846604
+            1.0
         ],
         [
             5,
             14,
-            0.43076756015630846
+            1.0
         ],
         [
             5,
             15,
-            0.4706868617302253
+            0.2475409836065574
         ],
         [
             5,
             16,
-            0.8116770340194187
+            1.0
         ],
         [
             5,
             17,
-            0.4783497984477372
+            0.9180327868852459
         ],
         [
             5,
             18,
-            0.3934205161581788
+            0.9852459016393442
         ],
         [
             5,
             19,
-            0.38445591180701433
+            0.9983606557377049
         ],
         [
             5,
             20,
-            0.7399127547044878
+            0.978688524590164
         ],
         [
             5,
             21,
-            0.36565699105849925
+            0.980327868852459
         ],
         [
             5,
             22,
-            0.5097846564180384
+            0.978688524590164
         ],
         [
             5,
             23,
-            0.4220667965509516
+            0.978688524590164
         ],
         [
             5,
             24,
-            0.3162277660168379
+            0.9934426229508196
         ],
         [
             5,
             25,
-            0.19204554133718937
+            0.9606557377049181
         ],
         [
             5,
             26,
-            1.0
+            0.9934426229508196
         ],
         [
             5,
             27,
-            1.0
+            0.980327868852459
         ],
         [
             5,
             28,
-            1.0
+            0.980327868852459
         ],
         [
             5,
             29,
-            0.5590169943749475
+            0.9918032786885246
         ],
         [
             5,
             30,
-            0.3162277660168379
+            0.980327868852459
         ],
         [
             5,
             31,
-            0.539600239558513
+            0.9819672131147541
         ],
         [
             5,
             32,
-            0.7999999999999999
+            0.9934426229508196
+        ],
+        [
+            5,
+            33,
+            0.9737704918032787
         ],
         [
             5,
             34,
-            0.7999999999999999
+            0.9721311475409836
         ],
         [
             5,
             35,
-            1.0
+            0.9918032786885246
         ],
         [
             5,
             36,
-            0.5499999999999999
+            0.9868852459016394
         ],
         [
             5,
             37,
-            0.7142857142857144
+            0.9868852459016394
         ],
         [
             5,
             38,
-            0.48795003647426655
+            0.980327868852459
+        ],
+        [
+            5,
+            39,
+            0.9836065573770492
         ],
         [
             5,
             40,
-            0.5345224838248487
+            0.9918032786885246
+        ],
+        [
+            5,
+            41,
+            0.9770491803278688
         ],
         [
             5,
             42,
-            1.0
+            0.9737704918032787
         ],
         [
             5,
             43,
-            0.47809144373375745
+            0.9770491803278688
         ],
         [
             5,
             44,
-            0.5054212299689212
+            0.9704918032786886
         ],
         [
             5,
             45,
-            0.47809144373375745
+            0.980327868852459
         ],
         [
             5,
             46,
-            0.06087522533246546
+            0.9885245901639345
+        ],
+        [
+            5,
+            47,
+            0.9459016393442623
         ],
         [
             5,
             48,
-            0.7339434939239653
+            0.9852459016393442
         ],
         [
             5,
             49,
-            0.8919163253374234
+            0.9885245901639345
         ],
         [
             5,
             50,
-            0.5222329678670935
+            0.9836065573770492
         ],
         [
             5,
             51,
-            0.7477240788977773
+            0.9704918032786886
         ],
         [
             5,
             52,
-            0.37944298857289194
+            0.9639344262295082
         ],
         [
             5,
             53,
-            0.8621991709032293
+            0.12459016393442623
         ],
         [
             5,
             54,
-            0.8657307768047895
+            0.20491803278688525
         ],
         [
             5,
             55,
-            0.6467451167180107
+            0.19180327868852454
         ],
         [
             5,
             56,
-            0.6816135261249185
+            0.1852459016393443
         ],
         [
             5,
             57,
-            0.21195444093308272
+            0.19508196721311477
         ],
         [
             5,
             58,
-            0.6567465852989299
+            0.1081967213114754
         ],
         [
             5,
             59,
-            0.6700472884847827
+            0.021311475409836023
         ],
         [
             5,
             60,
-            0.6727861889899942
+            0.2065573770491803
         ],
         [
             5,
             61,
-            0.8724433924246752
+            0.22295081967213115
         ],
         [
             5,
             62,
-            0.06576072102610128
+            0.01967213114754096
         ],
         [
             5,
             63,
-            0.5845559251514315
+            0.01967213114754096
         ],
         [
             5,
             64,
-            0.4039137278827744
+            0.2213114754098361
         ],
         [
             5,
             65,
-            0.7494500282727253
+            0.2163934426229508
         ],
         [
             5,
             66,
-            0.17397837827671106
+            0.16065573770491803
         ],
         [
             5,
             67,
-            0.6438295006737756
+            0.2114754098360656
         ],
         [
             5,
             68,
-            0.07406851169568873
+            0.139344262295082
         ],
         [
             5,
             69,
-            0.8581514716844596
+            0.760655737704918
         ],
         [
             5,
             70,
-            0.8222666295839873
+            0.760655737704918
         ],
         [
             5,
             71,
-            0.6507823355822662
+            0.7573770491803279
         ],
         [
             5,
             72,
-            0.8567696304016332
+            0.7049180327868853
         ],
         [
             5,
             73,
-            0.20474520765451018
+            0.1573770491803279
         ],
         [
             5,
             74,
-            0.26029252942632736
+            0.7491803278688525
         ],
         [
             5,
             75,
-            0.861908451554913
-        ],
-        [
-            5,
-            76,
-            0.24220755792081175
-        ],
-        [
-            5,
-            77,
-            0.45851362346413654
-        ],
-        [
-            5,
-            78,
-            0.8640987597877144
-        ],
-        [
-            5,
-            79,
-            0.40374911728157065
-        ],
-        [
-            5,
-            80,
-            0.852269705207385
-        ],
-        [
-            5,
-            81,
-            0.5933861639453609
-        ],
-        [
-            5,
-            82,
-            0.4093383110976321
-        ],
-        [
-            5,
-            83,
-            0.8876253645985951
-        ],
-        [
-            5,
-            84,
-            0.26796419589164416
-        ],
-        [
-            5,
-            85,
-            0.4317900732394964
-        ],
-        [
-            5,
-            86,
-            0.25939858057303494
-        ],
-        [
-            5,
-            88,
-            1.0
-        ],
-        [
-            5,
-            89,
-            0.7142857142857144
-        ],
-        [
-            5,
-            90,
-            1.0
-        ],
-        [
-            5,
-            92,
-            1.0
-        ],
-        [
-            5,
-            93,
-            1.0
-        ],
-        [
-            5,
-            94,
-            1.0
-        ],
-        [
-            5,
-            95,
-            0.8451542547285169
-        ],
-        [
-            5,
-            96,
-            0.48795003647426655
-        ],
-        [
-            5,
-            97,
-            1.0
-        ],
-        [
-            5,
-            98,
-            0.6831300510639732
-        ],
-        [
-            5,
-            99,
-            1.0
-        ],
-        [
-            5,
-            100,
-            0.8366600265340753
-        ],
-        [
-            5,
-            101,
-            1.0
-        ],
-        [
-            5,
-            104,
-            0.8164965809277261
-        ],
-        [
-            5,
-            105,
-            1.0
+            0.13278688524590165
         ],
         [
             6,
             0,
-            0.673590172280232
+            0.13770491803278684
         ],
         [
             6,
             1,
-            0.8037853445102376
+            0.31639344262295077
         ],
         [
             6,
             2,
-            0.6292578562234712
+            0.9311475409836065
         ],
         [
             6,
             3,
-            0.5323598461013103
+            0.9311475409836065
         ],
         [
             6,
             4,
-            0.38755108071567795
+            0.31639344262295077
         ],
         [
             6,
             5,
-            0.9633481869623121
+            0.9311475409836065
         ],
         [
             6,
@@ -2947,402 +2396,382 @@
         [
             6,
             7,
-            0.968656602890492
+            0.9311475409836065
         ],
         [
             6,
             8,
-            0.19308359644257692
+            0.31639344262295077
         ],
         [
             6,
             9,
-            0.6500680868311797
+            0.3278688524590164
         ],
         [
             6,
             10,
-            0.8364204896330685
+            0.9311475409836065
         ],
         [
             6,
             11,
-            0.9792515882265956
+            0.9311475409836065
         ],
         [
             6,
             12,
-            0.7247377567715131
+            0.3278688524590164
         ],
         [
             6,
             13,
-            0.4266976636466902
+            0.9311475409836065
         ],
         [
             6,
             14,
-            0.4306894984318691
+            0.9311475409836065
         ],
         [
             6,
             15,
-            0.455561100001928
+            0.31639344262295077
         ],
         [
             6,
             16,
-            0.7826422631024679
+            0.9311475409836065
         ],
         [
             6,
             17,
-            0.46076065556624823
+            0.9868852459016394
         ],
         [
             6,
             18,
-            0.3769471227496217
+            0.9163934426229509
         ],
         [
             6,
             19,
-            0.3744892382486824
+            0.9295081967213115
         ],
         [
             6,
             20,
-            0.735368004858024
+            0.9098360655737705
         ],
         [
             6,
             21,
-            0.3648603167114656
+            0.9114754098360656
         ],
         [
             6,
             22,
-            0.48151664333840466
+            0.9098360655737705
         ],
         [
             6,
             23,
-            0.3959336863957457
+            0.9098360655737705
+        ],
+        [
+            6,
+            24,
+            0.9245901639344263
         ],
         [
             6,
             25,
-            0.15934893965109156
+            0.8918032786885246
+        ],
+        [
+            6,
+            26,
+            0.9245901639344263
         ],
         [
             6,
             27,
-            1.0
+            0.9114754098360656
+        ],
+        [
+            6,
+            28,
+            0.9114754098360656
+        ],
+        [
+            6,
+            29,
+            0.9229508196721311
+        ],
+        [
+            6,
+            30,
+            0.9114754098360656
         ],
         [
             6,
             31,
-            0.5145835548336041
+            0.9131147540983606
+        ],
+        [
+            6,
+            32,
+            0.9245901639344263
+        ],
+        [
+            6,
+            33,
+            0.9049180327868852
+        ],
+        [
+            6,
+            34,
+            0.9032786885245901
+        ],
+        [
+            6,
+            35,
+            0.9229508196721311
+        ],
+        [
+            6,
+            36,
+            0.9180327868852459
         ],
         [
             6,
             37,
-            0.5
+            0.9180327868852459
+        ],
+        [
+            6,
+            38,
+            0.9114754098360656
+        ],
+        [
+            6,
+            39,
+            0.9147540983606557
+        ],
+        [
+            6,
+            40,
+            0.9229508196721311
+        ],
+        [
+            6,
+            41,
+            0.9081967213114754
+        ],
+        [
+            6,
+            42,
+            0.9049180327868852
+        ],
+        [
+            6,
+            43,
+            0.9081967213114754
         ],
         [
             6,
             44,
-            0.48672241060949306
+            0.9016393442622951
+        ],
+        [
+            6,
+            45,
+            0.9114754098360656
         ],
         [
             6,
             46,
-            0.06007606855521771
+            0.919672131147541
+        ],
+        [
+            6,
+            47,
+            0.8770491803278688
         ],
         [
             6,
             48,
-            0.7064614568374011
+            0.9163934426229509
         ],
         [
             6,
             49,
-            0.8690306734411086
+            0.919672131147541
         ],
         [
             6,
             50,
-            0.5222329678670935
+            0.9147540983606557
         ],
         [
             6,
             51,
-            0.7206457581031055
+            0.9016393442622951
         ],
         [
             6,
             52,
-            0.34749583647495125
+            0.8950819672131147
         ],
         [
             6,
             53,
-            0.8339584624502578
+            0.1573770491803279
         ],
         [
             6,
             54,
-            0.8373471059871187
+            0.22786885245901645
         ],
         [
             6,
             55,
-            0.6146376183841887
+            0.2213114754098361
         ],
         [
             6,
             56,
-            0.6562830332523588
+            0.23114754098360657
         ],
         [
             6,
             57,
-            0.21427535136257153
+            0.2114754098360656
         ],
         [
             6,
             58,
-            0.6326569544962423
+            0.15409836065573768
         ],
         [
             6,
             59,
-            0.6443417059387045
+            0.0901639344262295
         ],
         [
             6,
             60,
-            0.647614750415156
+            0.23278688524590163
         ],
         [
             6,
             61,
-            0.844134893035422
+            0.239344262295082
         ],
         [
             6,
             62,
-            0.06435660656394311
+            0.08852459016393444
         ],
         [
             6,
             63,
-            0.550089461152626
+            0.08852459016393444
         ],
         [
             6,
             64,
-            0.37893584173515066
+            0.23770491803278693
         ],
         [
             6,
             65,
-            0.7425964871827637
+            0.23278688524590163
         ],
         [
             6,
             66,
-            0.16916928532895625
+            0.180327868852459
         ],
         [
             6,
             67,
-            0.6181451479584993
+            0.22786885245901645
         ],
         [
             6,
             68,
-            0.07188111750300614
+            0.20819672131147537
         ],
         [
             6,
             69,
-            0.8349390589800723
+            0.6918032786885246
         ],
         [
             6,
             70,
-            0.800391381258423
+            0.6918032786885246
         ],
         [
             6,
             71,
-            0.6253300367517108
+            0.6885245901639344
         ],
         [
             6,
             72,
-            0.8335067400724928
+            0.7475409836065574
         ],
         [
             6,
             73,
-            0.20468961762862
+            0.17377049180327864
         ],
         [
             6,
             74,
-            0.27858692253443756
+            0.680327868852459
         ],
         [
             6,
             75,
-            0.8604785629355204
-        ],
-        [
-            6,
-            76,
-            0.2367470196367491
-        ],
-        [
-            6,
-            77,
-            0.47594615361975584
-        ],
-        [
-            6,
-            78,
-            0.8626969831117973
-        ],
-        [
-            6,
-            79,
-            0.38648844520092773
-        ],
-        [
-            6,
-            80,
-            0.8543123543123546
-        ],
-        [
-            6,
-            81,
-            0.5907955471728582
-        ],
-        [
-            6,
-            82,
-            0.42281479204709893
-        ],
-        [
-            6,
-            83,
-            0.8865435185909953
-        ],
-        [
-            6,
-            84,
-            0.2971315101924956
-        ],
-        [
-            6,
-            85,
-            0.41245365726755473
-        ],
-        [
-            6,
-            86,
-            0.26616879602704263
-        ],
-        [
-            6,
-            88,
-            1.0
-        ],
-        [
-            6,
-            89,
-            0.5
-        ],
-        [
-            6,
-            90,
-            1.0
-        ],
-        [
-            6,
-            92,
-            1.0
-        ],
-        [
-            6,
-            93,
-            1.0
-        ],
-        [
-            6,
-            94,
-            1.0
-        ],
-        [
-            6,
-            95,
-            0.6666666666666667
-        ],
-        [
-            6,
-            98,
-            0.6123724356957946
-        ],
-        [
-            6,
-            99,
-            1.0
-        ],
-        [
-            6,
-            100,
-            0.6123724356957946
-        ],
-        [
-            6,
-            101,
-            1.0
+            0.20163934426229513
         ],
         [
             7,
             0,
-            0.6985521224910617
+            0.06885245901639347
         ],
         [
             7,
             1,
-            0.8174684167206631
+            0.2475409836065574
         ],
         [
             7,
             2,
-            0.6583677311807978
+            1.0
         ],
         [
             7,
             3,
-            0.5565538579141491
+            1.0
         ],
         [
             7,
             4,
-            0.41595033912298757
+            0.2475409836065574
         ],
         [
             7,
             5,
-            0.9948270209552671
+            1.0
         ],
         [
             7,
             6,
-            0.968656602890492
+            0.9311475409836065
         ],
         [
             7,
@@ -3352,492 +2781,382 @@
         [
             7,
             8,
-            0.20319197796377783
+            0.2475409836065574
         ],
         [
             7,
             9,
-            0.6576770747641977
+            0.25901639344262295
         ],
         [
             7,
             10,
-            0.8567341594567514
+            1.0
         ],
         [
             7,
             11,
-            0.9839402771872598
+            1.0
         ],
         [
             7,
             12,
-            0.7342499200025656
+            0.25901639344262295
         ],
         [
             7,
             13,
-            0.43646771188466016
+            1.0
         ],
         [
             7,
             14,
-            0.43946142101706964
+            1.0
         ],
         [
             7,
             15,
-            0.46944865454770596
+            0.2475409836065574
         ],
         [
             7,
             16,
-            0.8116904756544427
+            1.0
         ],
         [
             7,
             17,
-            0.48175615933172355
+            0.9180327868852459
         ],
         [
             7,
             18,
-            0.3934477048533054
+            0.9852459016393442
         ],
         [
             7,
             19,
-            0.3899283897807742
+            0.9983606557377049
         ],
         [
             7,
             20,
-            0.7399127547044883
+            0.978688524590164
         ],
         [
             7,
             21,
-            0.37626452669497834
+            0.980327868852459
         ],
         [
             7,
             22,
-            0.5097846564180387
+            0.978688524590164
         ],
         [
             7,
             23,
-            0.4220667965509512
+            0.978688524590164
         ],
         [
             7,
             24,
-            0.3162277660168379
+            0.9934426229508196
         ],
         [
             7,
             25,
-            0.19150576261518504
+            0.9606557377049181
         ],
         [
             7,
             26,
-            1.0
+            0.9934426229508196
         ],
         [
             7,
             27,
-            1.0
+            0.980327868852459
         ],
         [
             7,
             28,
-            1.0
+            0.980327868852459
         ],
         [
             7,
             29,
-            0.5590169943749475
+            0.9918032786885246
         ],
         [
             7,
             30,
-            0.3162277660168379
+            0.980327868852459
         ],
         [
             7,
             31,
-            0.5396268105801126
+            0.9819672131147541
         ],
         [
             7,
             32,
-            0.7999999999999999
+            0.9934426229508196
+        ],
+        [
+            7,
+            33,
+            0.9737704918032787
         ],
         [
             7,
             34,
-            0.7999999999999999
+            0.9721311475409836
         ],
         [
             7,
             35,
-            1.0
+            0.9918032786885246
         ],
         [
             7,
             36,
-            0.5499999999999999
+            0.9868852459016394
         ],
         [
             7,
             37,
-            0.7142857142857144
+            0.9868852459016394
         ],
         [
             7,
             38,
-            0.48795003647426655
+            0.980327868852459
+        ],
+        [
+            7,
+            39,
+            0.9836065573770492
         ],
         [
             7,
             40,
-            0.5345224838248487
+            0.9918032786885246
+        ],
+        [
+            7,
+            41,
+            0.9770491803278688
         ],
         [
             7,
             42,
-            1.0
+            0.9737704918032787
         ],
         [
             7,
             43,
-            0.47809144373375745
+            0.9770491803278688
         ],
         [
             7,
             44,
-            0.5054212299689214
+            0.9704918032786886
         ],
         [
             7,
             45,
-            0.47809144373375745
+            0.980327868852459
         ],
         [
             7,
             46,
-            0.06066787359428632
+            0.9885245901639345
+        ],
+        [
+            7,
+            47,
+            0.9459016393442623
         ],
         [
             7,
             48,
-            0.7339632595013426
+            0.9852459016393442
         ],
         [
             7,
             49,
-            0.8973234326660444
+            0.9885245901639345
         ],
         [
             7,
             50,
-            0.5222329678670935
+            0.9836065573770492
         ],
         [
             7,
             51,
-            0.7477240788977776
+            0.9704918032786886
         ],
         [
             7,
             52,
-            0.3794429885728916
+            0.9639344262295082
         ],
         [
             7,
             53,
-            0.8622088505459301
+            0.12459016393442623
         ],
         [
             7,
             54,
-            0.8657401873412734
+            0.20491803278688525
         ],
         [
             7,
             55,
-            0.641709829689413
+            0.19180327868852454
         ],
         [
             7,
             56,
-            0.6816135261249182
+            0.1852459016393443
         ],
         [
             7,
             57,
-            0.211954440933083
+            0.19508196721311477
         ],
         [
             7,
             58,
-            0.6567465852989304
+            0.1081967213114754
         ],
         [
             7,
             59,
-            0.6700472884847828
+            0.021311475409836023
         ],
         [
             7,
             60,
-            0.6727861889899939
+            0.2065573770491803
         ],
         [
             7,
             61,
-            0.8724523315005893
+            0.22295081967213115
         ],
         [
             7,
             62,
-            0.06576286520308809
+            0.01967213114754096
         ],
         [
             7,
             63,
-            0.5845559251514315
+            0.01967213114754096
         ],
         [
             7,
             64,
-            0.4039332904783342
+            0.2213114754098361
         ],
         [
             7,
             65,
-            0.7434522300059475
+            0.2163934426229508
         ],
         [
             7,
             66,
-            0.17397837827671084
+            0.16065573770491803
         ],
         [
             7,
             67,
-            0.6438295006737753
+            0.2114754098360656
         ],
         [
             7,
             68,
-            0.0740685116956887
+            0.139344262295082
         ],
         [
             7,
             69,
-            0.8581514716844583
+            0.760655737704918
         ],
         [
             7,
             70,
-            0.8173334815135952
+            0.760655737704918
         ],
         [
             7,
             71,
-            0.6507823355822663
+            0.7573770491803279
         ],
         [
             7,
             72,
-            0.8567794703463714
+            0.7049180327868853
         ],
         [
             7,
             73,
-            0.2166215713535596
+            0.1573770491803279
         ],
         [
             7,
             74,
-            0.2882375776397517
+            0.7491803278688525
         ],
         [
             7,
             75,
-            0.874543409939793
-        ],
-        [
-            7,
-            76,
-            0.25126114696909535
-        ],
-        [
-            7,
-            77,
-            0.48453407746664806
-        ],
-        [
-            7,
-            78,
-            0.8765230646861664
-        ],
-        [
-            7,
-            79,
-            0.39500608242483076
-        ],
-        [
-            7,
-            80,
-            0.8678962167265862
-        ],
-        [
-            7,
-            81,
-            0.6043996065558523
-        ],
-        [
-            7,
-            82,
-            0.41608779787235456
-        ],
-        [
-            7,
-            83,
-            0.9001655975324931
-        ],
-        [
-            7,
-            84,
-            0.3055369462903217
-        ],
-        [
-            7,
-            85,
-            0.42199775533108874
-        ],
-        [
-            7,
-            86,
-            0.25002092938839754
-        ],
-        [
-            7,
-            88,
-            1.0
-        ],
-        [
-            7,
-            89,
-            0.7142857142857144
-        ],
-        [
-            7,
-            90,
-            1.0
-        ],
-        [
-            7,
-            92,
-            1.0
-        ],
-        [
-            7,
-            93,
-            1.0
-        ],
-        [
-            7,
-            94,
-            1.0
-        ],
-        [
-            7,
-            95,
-            0.8451542547285169
-        ],
-        [
-            7,
-            96,
-            0.48795003647426655
-        ],
-        [
-            7,
-            97,
-            1.0
-        ],
-        [
-            7,
-            98,
-            0.6831300510639732
-        ],
-        [
-            7,
-            99,
-            1.0
-        ],
-        [
-            7,
-            100,
-            0.8366600265340753
-        ],
-        [
-            7,
-            101,
-            1.0
-        ],
-        [
-            7,
-            104,
-            0.8164965809277261
-        ],
-        [
-            7,
-            105,
-            1.0
+            0.13278688524590165
         ],
         [
             8,
             0,
-            0.28861258238040766
+            0.8213114754098361
         ],
         [
             8,
             1,
-            0.22041151202959425
+            1.0
         ],
         [
             8,
             2,
-            0.20571444848891765
+            0.2475409836065574
         ],
         [
             8,
             3,
-            0.4603974265843398
+            0.2475409836065574
         ],
         [
             8,
             4,
-            0.7276611039362653
+            1.0
         ],
         [
             8,
             5,
-            0.193777823135779
+            0.2475409836065574
         ],
         [
             8,
             6,
-            0.19308359644257692
+            0.31639344262295077
         ],
         [
             8,
             7,
-            0.20319197796377783
+            0.2475409836065574
         ],
         [
             8,
@@ -3847,377 +3166,382 @@
         [
             8,
             9,
-            0.2079409881880556
+            0.9885245901639345
         ],
         [
             8,
             10,
-            0.24561274325635862
+            0.2475409836065574
         ],
         [
             8,
             11,
-            0.19185362631512753
+            0.2475409836065574
         ],
         [
             8,
             12,
-            0.3011163005061666
+            0.9885245901639345
         ],
         [
             8,
             13,
-            0.09594680975606924
+            0.2475409836065574
         ],
         [
             8,
             14,
-            0.17251638983558887
+            0.2475409836065574
         ],
         [
             8,
             15,
-            0.23719383871918726
+            1.0
         ],
         [
             8,
             16,
-            0.22409000148846817
+            0.2475409836065574
         ],
         [
             8,
             17,
-            0.14931310499111874
+            0.3295081967213115
         ],
         [
             8,
             18,
-            0.170362618642645
+            0.2622950819672131
         ],
         [
             8,
             19,
-            0.1834531436465184
+            0.24590163934426235
         ],
         [
             8,
             20,
-            0.21332997318222696
+            0.2622950819672131
         ],
         [
             8,
             21,
-            0.1893456590221429
+            0.260655737704918
         ],
         [
             8,
             22,
-            0.19176363741825206
+            0.2622950819672131
         ],
         [
             8,
             23,
-            0.052986212363762844
+            0.2622950819672131
+        ],
+        [
+            8,
+            24,
+            0.2475409836065574
         ],
         [
             8,
             25,
-            0.0197547622838507
+            0.280327868852459
+        ],
+        [
+            8,
+            26,
+            0.2475409836065574
+        ],
+        [
+            8,
+            27,
+            0.260655737704918
+        ],
+        [
+            8,
+            28,
+            0.260655737704918
+        ],
+        [
+            8,
+            29,
+            0.24918032786885247
+        ],
+        [
+            8,
+            30,
+            0.260655737704918
         ],
         [
             8,
             31,
-            0.1994078008101592
+            0.25901639344262295
+        ],
+        [
+            8,
+            32,
+            0.2475409836065574
+        ],
+        [
+            8,
+            33,
+            0.26393442622950825
+        ],
+        [
+            8,
+            34,
+            0.2655737704918033
+        ],
+        [
+            8,
+            35,
+            0.24590163934426235
+        ],
+        [
+            8,
+            36,
+            0.24426229508196717
+        ],
+        [
+            8,
+            37,
+            0.2475409836065574
+        ],
+        [
+            8,
+            38,
+            0.2573770491803279
+        ],
+        [
+            8,
+            39,
+            0.25081967213114753
+        ],
+        [
+            8,
+            40,
+            0.24590163934426235
+        ],
+        [
+            8,
+            41,
+            0.260655737704918
+        ],
+        [
+            8,
+            42,
+            0.26393442622950825
+        ],
+        [
+            8,
+            43,
+            0.260655737704918
         ],
         [
             8,
             44,
-            0.21184648506824794
+            0.260655737704918
+        ],
+        [
+            8,
+            45,
+            0.2573770491803279
         ],
         [
             8,
             46,
-            -0.012368944202009846
+            0.24590163934426235
+        ],
+        [
+            8,
+            47,
+            0.2918032786885246
         ],
         [
             8,
             48,
-            0.20272240699067595
+            0.24590163934426235
         ],
         [
             8,
             49,
-            0.21167603615957195
+            0.24918032786885247
         ],
         [
             8,
             50,
-            -0.09090909090909086
+            0.24426229508196717
         ],
         [
             8,
             51,
-            0.19746540518900774
+            0.2573770491803279
         ],
         [
             8,
             52,
-            0.08261286676913716
+            0.2704918032786885
         ],
         [
             8,
             53,
-            0.2501415047251222
+            0.759016393442623
         ],
         [
             8,
             54,
-            0.2496735355909357
+            0.6786885245901639
         ],
         [
             8,
             55,
-            0.23344504402712982
+            0.6655737704918032
         ],
         [
             8,
             56,
-            0.27126492897756155
+            0.6655737704918032
         ],
         [
             8,
             57,
-            0.11461854129344866
+            0.639344262295082
         ],
         [
             8,
             58,
-            0.25452206052034576
+            0.7327868852459016
         ],
         [
             8,
             59,
-            0.26974032121022573
+            0.7737704918032787
         ],
         [
             8,
             60,
-            0.2742031462815061
+            0.6836065573770491
         ],
         [
             8,
             61,
-            0.25178046736619214
+            0.6672131147540983
+        ],
+        [
+            8,
+            62,
+            0.7721311475409836
         ],
         [
             8,
             63,
-            0.3107986489394715
+            0.7721311475409836
         ],
         [
             8,
             64,
-            0.162440362234423
+            0.6655737704918032
         ],
         [
             8,
             65,
-            0.1447453511938786
+            0.6672131147540983
         ],
         [
             8,
             66,
-            0.03488170989322612
+            0.6639344262295082
         ],
         [
             8,
             67,
-            0.2983214503811019
+            0.6754098360655738
         ],
         [
             8,
             68,
-            -0.013599498463913362
+            0.7114754098360656
         ],
         [
             8,
             69,
-            0.19953315538444547
+            0.008196721311475419
         ],
         [
             8,
             70,
-            0.21683856510140978
+            0.008196721311475419
         ],
         [
             8,
             71,
-            0.29502161939293753
+            0.004918032786885296
         ],
         [
             8,
             72,
-            0.22375011064492364
+            0.06393442622950818
         ],
         [
             8,
             73,
-            0.366420600010132
+            0.6114754098360655
         ],
         [
             8,
             74,
-            0.3948386723725146
+            0.01967213114754096
         ],
         [
             8,
             75,
-            0.26142002459090075
-        ],
-        [
-            8,
-            76,
-            0.2734513698875298
-        ],
-        [
-            8,
-            77,
-            0.3047263149392472
-        ],
-        [
-            8,
-            78,
-            0.24131759681132894
-        ],
-        [
-            8,
-            79,
-            0.18995604488688028
-        ],
-        [
-            8,
-            80,
-            0.12723323549870977
-        ],
-        [
-            8,
-            81,
-            0.2659972052971536
-        ],
-        [
-            8,
-            82,
-            0.09784517688247725
-        ],
-        [
-            8,
-            83,
-            0.29365912300746716
-        ],
-        [
-            8,
-            84,
-            0.2762983217465941
-        ],
-        [
-            8,
-            85,
-            0.18768977965393627
-        ],
-        [
-            8,
-            86,
-            0.12411735281897085
-        ],
-        [
-            8,
-            88,
-            -1.0
-        ],
-        [
-            8,
-            90,
-            -1.0
-        ],
-        [
-            8,
-            92,
-            -1.0
-        ],
-        [
-            8,
-            93,
-            -1.0
-        ],
-        [
-            8,
-            94,
-            -1.0
-        ],
-        [
-            8,
-            95,
-            0.30151134457776363
-        ],
-        [
-            8,
-            98,
-            -0.17407765595569774
-        ],
-        [
-            8,
-            99,
-            -1.0
-        ],
-        [
-            8,
-            100,
-            -0.2132007163556104
+            0.6360655737704918
         ],
         [
             9,
             0,
-            0.6258274246733996
+            0.8098360655737705
         ],
         [
             9,
             1,
-            0.768838779300196
+            0.9885245901639345
         ],
         [
             9,
             2,
-            0.9292757101511696
+            0.25901639344262295
         ],
         [
             9,
             3,
-            0.4125452023546624
+            0.25901639344262295
         ],
         [
             9,
             4,
-            0.3396781017763302
+            0.9885245901639345
         ],
         [
             9,
             5,
-            0.657677074764197
+            0.25901639344262295
         ],
         [
             9,
             6,
-            0.6500680868311797
+            0.3278688524590164
         ],
         [
             9,
             7,
-            0.6576770747641977
+            0.25901639344262295
         ],
         [
             9,
             8,
-            0.2079409881880556
+            0.9885245901639345
         ],
         [
             9,
@@ -4227,402 +3551,382 @@
         [
             9,
             10,
-            0.7342627492288559
+            0.25901639344262295
         ],
         [
             9,
             11,
-            0.6609107022569264
+            0.25901639344262295
         ],
         [
             9,
             12,
-            0.679048334776542
+            1.0
         ],
         [
             9,
             13,
-            0.38983133899746863
+            0.25901639344262295
         ],
         [
             9,
             14,
-            0.6034618554805068
+            0.25901639344262295
         ],
         [
             9,
             15,
-            0.42581030794514757
+            0.9885245901639345
         ],
         [
             9,
             16,
-            0.706342056133523
+            0.25901639344262295
         ],
         [
             9,
             17,
-            0.48546597976355593
+            0.34098360655737703
         ],
         [
             9,
             18,
-            0.5775839996292046
+            0.2704918032786885
         ],
         [
             9,
             19,
-            0.6366645808324106
+            0.2573770491803279
         ],
         [
             9,
             20,
-            0.7257594676980584
+            0.26393442622950825
         ],
         [
             9,
             21,
-            0.6314067394365128
+            0.2655737704918033
         ],
         [
             9,
             22,
-            0.4514044508922154
+            0.26393442622950825
         ],
         [
             9,
             23,
-            0.3601913413321177
+            0.26393442622950825
+        ],
+        [
+            9,
+            24,
+            0.2524590163934426
         ],
         [
             9,
             25,
-            0.1305766215180346
+            0.28196721311475414
+        ],
+        [
+            9,
+            26,
+            0.2524590163934426
         ],
         [
             9,
             27,
-            0.5
+            0.2655737704918033
+        ],
+        [
+            9,
+            28,
+            0.2655737704918033
+        ],
+        [
+            9,
+            29,
+            0.25081967213114753
+        ],
+        [
+            9,
+            30,
+            0.2655737704918033
         ],
         [
             9,
             31,
-            0.5944357334293789
+            0.26721311475409837
+        ],
+        [
+            9,
+            32,
+            0.2524590163934426
+        ],
+        [
+            9,
+            33,
+            0.2655737704918033
+        ],
+        [
+            9,
+            34,
+            0.26721311475409837
+        ],
+        [
+            9,
+            35,
+            0.25081967213114753
+        ],
+        [
+            9,
+            36,
+            0.24590163934426235
         ],
         [
             9,
             37,
-            1.0
+            0.24590163934426235
+        ],
+        [
+            9,
+            38,
+            0.2557377049180328
+        ],
+        [
+            9,
+            39,
+            0.24918032786885247
+        ],
+        [
+            9,
+            40,
+            0.25081967213114753
+        ],
+        [
+            9,
+            41,
+            0.2622950819672131
+        ],
+        [
+            9,
+            42,
+            0.2655737704918033
+        ],
+        [
+            9,
+            43,
+            0.2622950819672131
         ],
         [
             9,
             44,
-            0.6128341912757952
+            0.2622950819672131
+        ],
+        [
+            9,
+            45,
+            0.2557377049180328
         ],
         [
             9,
             46,
-            0.0023661736314343766
+            0.2475409836065574
+        ],
+        [
+            9,
+            47,
+            0.29016393442622945
         ],
         [
             9,
             48,
-            0.5658530723636707
+            0.24426229508196717
         ],
         [
             9,
             49,
-            0.6378083767904101
+            0.2475409836065574
         ],
         [
             9,
             50,
-            1.0
+            0.2426229508196721
         ],
         [
             9,
             51,
-            0.7037005659473914
+            0.2557377049180328
         ],
         [
             9,
             52,
-            0.32254659430189614
+            0.26885245901639343
         ],
         [
             9,
             53,
-            0.7003244540777719
+            0.7508196721311475
         ],
         [
             9,
             54,
-            0.693338714514738
+            0.6704918032786885
         ],
         [
             9,
             55,
-            0.5713546863460388
+            0.6573770491803279
         ],
         [
             9,
             56,
-            0.5779738877697849
+            0.6573770491803279
         ],
         [
             9,
             57,
-            0.19873674693739007
+            0.6311475409836065
         ],
         [
             9,
             58,
-            0.5586904301632339
+            0.7245901639344262
         ],
         [
             9,
             59,
-            0.7149131029816572
+            0.7622950819672132
         ],
         [
             9,
             60,
-            0.5700033104231804
+            0.6754098360655738
         ],
         [
             9,
             61,
-            0.6857094114255845
+            0.659016393442623
         ],
         [
             9,
             62,
-            0.05999972024735531
+            0.760655737704918
         ],
         [
             9,
             63,
-            0.6260767418673101
+            0.760655737704918
         ],
         [
             9,
             64,
-            0.3506711476174269
+            0.6573770491803279
         ],
         [
             9,
             65,
-            0.5780101605883959
+            0.659016393442623
         ],
         [
             9,
             66,
-            0.1657658925495808
+            0.6557377049180328
         ],
         [
             9,
             67,
-            0.6285992980044047
+            0.6672131147540983
         ],
         [
             9,
             68,
-            0.06506784794443027
+            0.7032786885245902
         ],
         [
             9,
             69,
-            0.6289294992042427
+            0.01967213114754096
         ],
         [
             9,
             70,
-            0.628595765246618
+            0.01967213114754096
         ],
         [
             9,
             71,
-            0.544392912472306
+            0.016393442622950838
         ],
         [
             9,
             72,
-            0.6529470605134109
+            0.07540983606557372
         ],
         [
             9,
             73,
-            0.2619470517073567
+            0.6032786885245902
         ],
         [
             9,
             74,
-            0.42509772500306886
+            0.008196721311475419
         ],
         [
             9,
             75,
-            0.8734892707168821
-        ],
-        [
-            9,
-            76,
-            0.27605157841078154
-        ],
-        [
-            9,
-            77,
-            0.4868949633804611
-        ],
-        [
-            9,
-            78,
-            0.8754371556885315
-        ],
-        [
-            9,
-            79,
-            0.4214937876118211
-        ],
-        [
-            9,
-            80,
-            0.7416068091227004
-        ],
-        [
-            9,
-            81,
-            0.7376175645191969
-        ],
-        [
-            9,
-            82,
-            0.4927629756768466
-        ],
-        [
-            9,
-            83,
-            0.8753561253561253
-        ],
-        [
-            9,
-            84,
-            0.4552712929736526
-        ],
-        [
-            9,
-            85,
-            0.40607801503318774
-        ],
-        [
-            9,
-            86,
-            0.229471641697587
-        ],
-        [
-            9,
-            88,
-            1.0
-        ],
-        [
-            9,
-            89,
-            1.0
-        ],
-        [
-            9,
-            90,
-            1.0
-        ],
-        [
-            9,
-            92,
-            1.0
-        ],
-        [
-            9,
-            93,
-            1.0
-        ],
-        [
-            9,
-            94,
-            1.0
-        ],
-        [
-            9,
-            95,
-            0.4082482904638631
-        ],
-        [
-            9,
-            98,
-            -0.25
-        ],
-        [
-            9,
-            99,
-            1.0
-        ],
-        [
-            9,
-            100,
-            1.0
-        ],
-        [
-            9,
-            101,
-            0.5
+            0.6245901639344262
         ],
         [
             10,
             0,
-            0.6978964173211687
+            0.06885245901639347
         ],
         [
             10,
             1,
-            0.8029806098962583
+            0.2475409836065574
         ],
         [
             10,
             2,
-            0.718062303708798
+            1.0
         ],
         [
             10,
             3,
-            0.5384660949154696
+            1.0
         ],
         [
             10,
             4,
-            0.4010398761045766
+            0.2475409836065574
         ],
         [
             10,
             5,
-            0.8514274957240066
+            1.0
         ],
         [
             10,
             6,
-            0.8364204896330685
+            0.9311475409836065
         ],
         [
             10,
             7,
-            0.8567341594567514
+            1.0
         ],
         [
             10,
             8,
-            0.24561274325635862
+            0.2475409836065574
         ],
         [
             10,
             9,
-            0.7342627492288559
+            0.25901639344262295
         ],
         [
             10,
@@ -4632,402 +3936,382 @@
         [
             10,
             11,
-            0.8495124791275689
+            1.0
         ],
         [
             10,
             12,
-            0.7495505723307243
+            0.25901639344262295
         ],
         [
             10,
             13,
-            0.43917724209849623
+            1.0
         ],
         [
             10,
             14,
-            0.5157189658302692
+            1.0
         ],
         [
             10,
             15,
-            0.5724009205543327
+            0.2475409836065574
         ],
         [
             10,
             16,
-            0.7785214538085226
+            1.0
         ],
         [
             10,
             17,
-            0.48612756578100713
+            0.9180327868852459
         ],
         [
             10,
             18,
-            0.4708047858083588
+            0.9852459016393442
         ],
         [
             10,
             19,
-            0.46544208317292457
+            0.9983606557377049
         ],
         [
             10,
             20,
-            0.7600060053985785
+            0.978688524590164
         ],
         [
             10,
             21,
-            0.5133464431391139
+            0.980327868852459
         ],
         [
             10,
             22,
-            0.6042986245607924
+            0.978688524590164
         ],
         [
             10,
             23,
-            0.42230944459670294
+            0.978688524590164
+        ],
+        [
+            10,
+            24,
+            0.9934426229508196
         ],
         [
             10,
             25,
-            0.3177485005667296
+            0.9606557377049181
+        ],
+        [
+            10,
+            26,
+            0.9934426229508196
         ],
         [
             10,
             27,
-            0.5
+            0.980327868852459
+        ],
+        [
+            10,
+            28,
+            0.980327868852459
+        ],
+        [
+            10,
+            29,
+            0.9918032786885246
+        ],
+        [
+            10,
+            30,
+            0.980327868852459
         ],
         [
             10,
             31,
-            0.5647801816483201
+            0.9819672131147541
+        ],
+        [
+            10,
+            32,
+            0.9934426229508196
+        ],
+        [
+            10,
+            33,
+            0.9737704918032787
+        ],
+        [
+            10,
+            34,
+            0.9721311475409836
+        ],
+        [
+            10,
+            35,
+            0.9918032786885246
+        ],
+        [
+            10,
+            36,
+            0.9868852459016394
         ],
         [
             10,
             37,
-            1.0
+            0.9868852459016394
+        ],
+        [
+            10,
+            38,
+            0.980327868852459
+        ],
+        [
+            10,
+            39,
+            0.9836065573770492
+        ],
+        [
+            10,
+            40,
+            0.9918032786885246
+        ],
+        [
+            10,
+            41,
+            0.9770491803278688
+        ],
+        [
+            10,
+            42,
+            0.9737704918032787
+        ],
+        [
+            10,
+            43,
+            0.9770491803278688
         ],
         [
             10,
             44,
-            0.5773018072405885
+            0.9704918032786886
+        ],
+        [
+            10,
+            45,
+            0.980327868852459
         ],
         [
             10,
             46,
-            0.18199895675914052
+            0.9885245901639345
+        ],
+        [
+            10,
+            47,
+            0.9459016393442623
         ],
         [
             10,
             48,
-            0.6930787609380564
+            0.9852459016393442
         ],
         [
             10,
             49,
-            0.8488044499859198
+            0.9885245901639345
         ],
         [
             10,
             50,
-            0.674199862463242
+            0.9836065573770492
         ],
         [
             10,
             51,
-            0.8301212096169832
+            0.9704918032786886
         ],
         [
             10,
             52,
-            0.3764202596454769
+            0.9639344262295082
         ],
         [
             10,
             53,
-            0.8248587099359223
+            0.12459016393442623
         ],
         [
             10,
             54,
-            0.8435240480619688
+            0.20491803278688525
         ],
         [
             10,
             55,
-            0.6605504827393988
+            0.19180327868852454
         ],
         [
             10,
             56,
-            0.6918829216402781
+            0.1852459016393443
         ],
         [
             10,
             57,
-            0.3810770961284182
+            0.19508196721311477
         ],
         [
             10,
             58,
-            0.6266739995128833
+            0.1081967213114754
         ],
         [
             10,
             59,
-            0.7446312123687505
+            0.021311475409836023
         ],
         [
             10,
             60,
-            0.680548375129879
+            0.2065573770491803
         ],
         [
             10,
             61,
-            0.8391769156969572
+            0.22295081967213115
         ],
         [
             10,
             62,
-            0.2303619724913795
+            0.01967213114754096
         ],
         [
             10,
             63,
-            0.6631330642378719
+            0.01967213114754096
         ],
         [
             10,
             64,
-            0.487924723438099
+            0.2213114754098361
         ],
         [
             10,
             65,
-            0.7650936323258094
+            0.2163934426229508
         ],
         [
             10,
             66,
-            0.26459014850811974
+            0.16065573770491803
         ],
         [
             10,
             67,
-            0.717935720832681
+            0.2114754098360656
         ],
         [
             10,
             68,
-            0.1898561078308093
+            0.139344262295082
         ],
         [
             10,
             69,
-            0.8165836749402925
+            0.760655737704918
         ],
         [
             10,
             70,
-            0.8203681683819434
+            0.760655737704918
         ],
         [
             10,
             71,
-            0.6639914958457512
+            0.7573770491803279
         ],
         [
             10,
             72,
-            0.8381863868289483
+            0.7049180327868853
         ],
         [
             10,
             73,
-            0.27467735211178473
+            0.1573770491803279
         ],
         [
             10,
             74,
-            0.33254304146769126
+            0.7491803278688525
         ],
         [
             10,
             75,
-            0.8860387486806305
-        ],
-        [
-            10,
-            76,
-            0.27786494901108155
-        ],
-        [
-            10,
-            77,
-            0.49320785833463854
-        ],
-        [
-            10,
-            78,
-            0.8878316123577739
-        ],
-        [
-            10,
-            79,
-            0.4008826360373775
-        ],
-        [
-            10,
-            80,
-            0.8570036569654218
-        ],
-        [
-            10,
-            81,
-            0.6371256356823043
-        ],
-        [
-            10,
-            82,
-            0.4362116992246639
-        ],
-        [
-            10,
-            83,
-            0.9143469184364625
-        ],
-        [
-            10,
-            84,
-            0.36943729983679036
-        ],
-        [
-            10,
-            85,
-            0.4505058887804784
-        ],
-        [
-            10,
-            86,
-            0.24336910149661603
-        ],
-        [
-            10,
-            88,
-            1.0
-        ],
-        [
-            10,
-            89,
-            1.0
-        ],
-        [
-            10,
-            90,
-            1.0
-        ],
-        [
-            10,
-            92,
-            1.0
-        ],
-        [
-            10,
-            93,
-            1.0
-        ],
-        [
-            10,
-            94,
-            1.0
-        ],
-        [
-            10,
-            95,
-            0.4082482904638631
-        ],
-        [
-            10,
-            98,
-            -0.25
-        ],
-        [
-            10,
-            99,
-            1.0
-        ],
-        [
-            10,
-            100,
-            1.0
-        ],
-        [
-            10,
-            101,
-            0.5
+            0.13278688524590165
         ],
         [
             11,
             0,
-            0.682064647525656
+            0.06885245901639347
         ],
         [
             11,
             1,
-            0.8178760973241855
+            0.2475409836065574
         ],
         [
             11,
             2,
-            0.6400615682662393
+            1.0
         ],
         [
             11,
             3,
-            0.5469131870765537
+            1.0
         ],
         [
             11,
             4,
-            0.3929710605195581
+            0.2475409836065574
         ],
         [
             11,
             5,
-            0.983870723502142
+            1.0
         ],
         [
             11,
             6,
-            0.9792515882265956
+            0.9311475409836065
         ],
         [
             11,
             7,
-            0.9839402771872598
+            1.0
         ],
         [
             11,
             8,
-            0.19185362631512753
+            0.2475409836065574
         ],
         [
             11,
             9,
-            0.6609107022569264
+            0.25901639344262295
         ],
         [
             11,
             10,
-            0.8495124791275689
+            1.0
         ],
         [
             11,
@@ -5037,402 +4321,382 @@
         [
             11,
             12,
-            0.7339589148248621
+            0.25901639344262295
         ],
         [
             11,
             13,
-            0.4357385464336411
+            1.0
         ],
         [
             11,
             14,
-            0.43219952107966203
+            1.0
         ],
         [
             11,
             15,
-            0.4644476935788989
+            0.2475409836065574
         ],
         [
             11,
             16,
-            0.7967650385415217
+            1.0
         ],
         [
             11,
             17,
-            0.475136977061247
+            0.9180327868852459
         ],
         [
             11,
             18,
-            0.38658378886776773
+            0.9852459016393442
         ],
         [
             11,
             19,
-            0.3829922048881917
+            0.9983606557377049
         ],
         [
             11,
             20,
-            0.7403917704401323
+            0.978688524590164
         ],
         [
             11,
             21,
-            0.3701025330300382
+            0.980327868852459
         ],
         [
             11,
             22,
-            0.49181334908846325
+            0.978688524590164
         ],
         [
             11,
             23,
-            0.4044138021056562
+            0.978688524590164
+        ],
+        [
+            11,
+            24,
+            0.9934426229508196
         ],
         [
             11,
             25,
-            0.16281394544552324
+            0.9606557377049181
+        ],
+        [
+            11,
+            26,
+            0.9934426229508196
         ],
         [
             11,
             27,
-            1.0
+            0.980327868852459
+        ],
+        [
+            11,
+            28,
+            0.980327868852459
+        ],
+        [
+            11,
+            29,
+            0.9918032786885246
+        ],
+        [
+            11,
+            30,
+            0.980327868852459
         ],
         [
             11,
             31,
-            0.5193112478808601
+            0.9819672131147541
+        ],
+        [
+            11,
+            32,
+            0.9934426229508196
+        ],
+        [
+            11,
+            33,
+            0.9737704918032787
+        ],
+        [
+            11,
+            34,
+            0.9721311475409836
+        ],
+        [
+            11,
+            35,
+            0.9918032786885246
+        ],
+        [
+            11,
+            36,
+            0.9868852459016394
         ],
         [
             11,
             37,
-            0.5
+            0.9868852459016394
+        ],
+        [
+            11,
+            38,
+            0.980327868852459
+        ],
+        [
+            11,
+            39,
+            0.9836065573770492
+        ],
+        [
+            11,
+            40,
+            0.9918032786885246
+        ],
+        [
+            11,
+            41,
+            0.9770491803278688
+        ],
+        [
+            11,
+            42,
+            0.9737704918032787
+        ],
+        [
+            11,
+            43,
+            0.9770491803278688
         ],
         [
             11,
             44,
-            0.48749295662530706
+            0.9704918032786886
+        ],
+        [
+            11,
+            45,
+            0.980327868852459
         ],
         [
             11,
             46,
-            0.061690798566690824
+            0.9885245901639345
+        ],
+        [
+            11,
+            47,
+            0.9459016393442623
         ],
         [
             11,
             48,
-            0.7204265839851172
+            0.9852459016393442
         ],
         [
             11,
             49,
-            0.8829858416753936
+            0.9885245901639345
         ],
         [
             11,
             50,
-            0.5222329678670935
+            0.9836065573770492
         ],
         [
             11,
             51,
-            0.7335275784873174
+            0.9704918032786886
         ],
         [
             11,
             52,
-            0.35550614319003954
+            0.9639344262295082
         ],
         [
             11,
             53,
-            0.8481134287795166
+            0.12459016393442623
         ],
         [
             11,
             54,
-            0.8515810619273081
+            0.20491803278688525
         ],
         [
             11,
             55,
-            0.6304920685384328
+            0.19180327868852454
         ],
         [
             11,
             56,
-            0.6708219003558078
+            0.1852459016393443
         ],
         [
             11,
             57,
-            0.21923035161004079
+            0.19508196721311477
         ],
         [
             11,
             58,
-            0.6471880593958907
+            0.1081967213114754
         ],
         [
             11,
             59,
-            0.6532512899679145
+            0.021311475409836023
         ],
         [
             11,
             60,
-            0.6619391449815145
+            0.2065573770491803
         ],
         [
             11,
             61,
-            0.8583587474728072
+            0.22295081967213115
         ],
         [
             11,
             62,
-            0.06575427435132448
+            0.01967213114754096
         ],
         [
             11,
             63,
-            0.5717510299293135
+            0.01967213114754096
         ],
         [
             11,
             64,
-            0.3879643434237635
+            0.2213114754098361
         ],
         [
             11,
             65,
-            0.7439439423511436
+            0.2163934426229508
         ],
         [
             11,
             66,
-            0.17389988595800918
+            0.16065573770491803
         ],
         [
             11,
             67,
-            0.6265627001675333
+            0.2114754098360656
         ],
         [
             11,
             68,
-            0.07402659345059856
+            0.139344262295082
         ],
         [
             11,
             69,
-            0.8488847743406271
+            0.760655737704918
         ],
         [
             11,
             70,
-            0.8135972054785021
+            0.760655737704918
         ],
         [
             11,
             71,
-            0.6394323170431304
+            0.7573770491803279
         ],
         [
             11,
             72,
-            0.8475086236072493
+            0.7049180327868853
         ],
         [
             11,
             73,
-            0.20474520765451018
+            0.1573770491803279
         ],
         [
             11,
             74,
-            0.26029252942632736
+            0.7491803278688525
         ],
         [
             11,
             75,
-            0.861908451554913
-        ],
-        [
-            11,
-            76,
-            0.24220755792081175
-        ],
-        [
-            11,
-            77,
-            0.45851362346413654
-        ],
-        [
-            11,
-            78,
-            0.8640987597877144
-        ],
-        [
-            11,
-            79,
-            0.40374911728157065
-        ],
-        [
-            11,
-            80,
-            0.852269705207385
-        ],
-        [
-            11,
-            81,
-            0.5933861639453609
-        ],
-        [
-            11,
-            82,
-            0.4093383110976321
-        ],
-        [
-            11,
-            83,
-            0.8876253645985951
-        ],
-        [
-            11,
-            84,
-            0.26796419589164416
-        ],
-        [
-            11,
-            85,
-            0.4317900732394964
-        ],
-        [
-            11,
-            86,
-            0.25939858057303494
-        ],
-        [
-            11,
-            88,
-            1.0
-        ],
-        [
-            11,
-            89,
-            0.5
-        ],
-        [
-            11,
-            90,
-            1.0
-        ],
-        [
-            11,
-            92,
-            1.0
-        ],
-        [
-            11,
-            93,
-            1.0
-        ],
-        [
-            11,
-            94,
-            1.0
-        ],
-        [
-            11,
-            95,
-            0.6666666666666667
-        ],
-        [
-            11,
-            98,
-            0.6123724356957946
-        ],
-        [
-            11,
-            99,
-            1.0
-        ],
-        [
-            11,
-            100,
-            0.6123724356957946
-        ],
-        [
-            11,
-            101,
-            1.0
+            0.13278688524590165
         ],
         [
             12,
             0,
-            0.9463278452760162
+            0.8098360655737705
         ],
         [
             12,
             1,
-            0.67149561757249
+            0.9885245901639345
         ],
         [
             12,
             2,
-            0.6599235100202895
+            0.25901639344262295
         ],
         [
             12,
             3,
-            0.4589067474990755
+            0.25901639344262295
         ],
         [
             12,
             4,
-            0.5695882976556774
+            0.9885245901639345
         ],
         [
             12,
             5,
-            0.7277517111461023
+            0.25901639344262295
         ],
         [
             12,
             6,
-            0.7247377567715131
+            0.3278688524590164
         ],
         [
             12,
             7,
-            0.7342499200025656
+            0.25901639344262295
         ],
         [
             12,
             8,
-            0.3011163005061666
+            0.9885245901639345
         ],
         [
             12,
             9,
-            0.679048334776542
+            1.0
         ],
         [
             12,
             10,
-            0.7495505723307243
+            0.25901639344262295
         ],
         [
             12,
             11,
-            0.7339589148248621
+            0.25901639344262295
         ],
         [
             12,
@@ -5442,332 +4706,382 @@
         [
             12,
             13,
-            0.5326182919010559
+            0.25901639344262295
         ],
         [
             12,
             14,
-            0.44849382448010294
+            0.25901639344262295
         ],
         [
             12,
             15,
-            0.5888831673831372
+            0.9885245901639345
         ],
         [
             12,
             16,
-            0.6427661662039201
+            0.25901639344262295
         ],
         [
             12,
             17,
-            0.3978573485403148
+            0.34098360655737703
         ],
         [
             12,
             18,
-            0.4381999046073426
+            0.2704918032786885
         ],
         [
             12,
             19,
-            0.5475788853813157
+            0.2573770491803279
         ],
         [
             12,
             20,
-            0.6180191481717833
+            0.26393442622950825
         ],
         [
             12,
             21,
-            0.6288977393842315
+            0.2655737704918033
         ],
         [
             12,
             22,
-            0.6057576144721192
+            0.26393442622950825
         ],
         [
             12,
             23,
-            0.49388908832043377
+            0.26393442622950825
+        ],
+        [
+            12,
+            24,
+            0.2524590163934426
         ],
         [
             12,
             25,
-            0.16700529169014308
+            0.28196721311475414
+        ],
+        [
+            12,
+            26,
+            0.2524590163934426
+        ],
+        [
+            12,
+            27,
+            0.2655737704918033
+        ],
+        [
+            12,
+            28,
+            0.2655737704918033
+        ],
+        [
+            12,
+            29,
+            0.25081967213114753
+        ],
+        [
+            12,
+            30,
+            0.2655737704918033
         ],
         [
             12,
             31,
-            0.5709077718057288
+            0.26721311475409837
+        ],
+        [
+            12,
+            32,
+            0.2524590163934426
+        ],
+        [
+            12,
+            33,
+            0.2655737704918033
+        ],
+        [
+            12,
+            34,
+            0.26721311475409837
+        ],
+        [
+            12,
+            35,
+            0.25081967213114753
+        ],
+        [
+            12,
+            36,
+            0.24590163934426235
+        ],
+        [
+            12,
+            37,
+            0.24590163934426235
+        ],
+        [
+            12,
+            38,
+            0.2557377049180328
+        ],
+        [
+            12,
+            39,
+            0.24918032786885247
+        ],
+        [
+            12,
+            40,
+            0.25081967213114753
+        ],
+        [
+            12,
+            41,
+            0.2622950819672131
+        ],
+        [
+            12,
+            42,
+            0.2655737704918033
+        ],
+        [
+            12,
+            43,
+            0.2622950819672131
         ],
         [
             12,
             44,
-            0.7020682800472419
+            0.2622950819672131
+        ],
+        [
+            12,
+            45,
+            0.2557377049180328
         ],
         [
             12,
             46,
-            0.016253961229434406
+            0.2475409836065574
+        ],
+        [
+            12,
+            47,
+            0.29016393442622945
         ],
         [
             12,
             48,
-            0.578910086497819
+            0.24426229508196717
         ],
         [
             12,
             49,
-            0.7119560611409992
+            0.2475409836065574
+        ],
+        [
+            12,
+            50,
+            0.2426229508196721
         ],
         [
             12,
             51,
-            0.6432223996719644
+            0.2557377049180328
         ],
         [
             12,
             52,
-            0.44761349099675085
+            0.26885245901639343
         ],
         [
             12,
             53,
-            0.6726042710784025
+            0.7508196721311475
         ],
         [
             12,
             54,
-            0.674329267180953
+            0.6704918032786885
         ],
         [
             12,
             55,
-            0.7632536912092387
+            0.6573770491803279
         ],
         [
             12,
             56,
-            0.8595548679344744
+            0.6573770491803279
         ],
         [
             12,
             57,
-            0.2569932539820991
+            0.6311475409836065
         ],
         [
             12,
             58,
-            0.8496823523781272
+            0.7245901639344262
         ],
         [
             12,
             59,
-            0.8467813333099384
+            0.7622950819672132
         ],
         [
             12,
             60,
-            0.8477164857413069
+            0.6754098360655738
         ],
         [
             12,
             61,
-            0.6806972624924542
+            0.659016393442623
         ],
         [
             12,
             62,
-            0.08228240284757059
+            0.760655737704918
         ],
         [
             12,
             63,
-            0.6887405313735887
+            0.760655737704918
         ],
         [
             12,
             64,
-            0.4717318519128013
+            0.6573770491803279
         ],
         [
             12,
             65,
-            0.6331316057959903
+            0.659016393442623
         ],
         [
             12,
             66,
-            0.12426960513700673
+            0.6557377049180328
         ],
         [
             12,
             67,
-            0.805863378699337
+            0.6672131147540983
         ],
         [
             12,
             68,
-            0.06908929870751943
+            0.7032786885245902
         ],
         [
             12,
             69,
-            0.6934544349408354
+            0.01967213114754096
         ],
         [
             12,
             70,
-            0.6874480125859487
+            0.01967213114754096
         ],
         [
             12,
             71,
-            0.8147380155009736
+            0.016393442622950838
         ],
         [
             12,
             72,
-            0.6943726194890341
+            0.07540983606557372
         ],
         [
             12,
             73,
-            0.3654121117662344
+            0.6032786885245902
         ],
         [
             12,
             74,
-            0.4300030598728164
+            0.008196721311475419
         ],
         [
             12,
             75,
-            0.5447657885888424
-        ],
-        [
-            12,
-            76,
-            0.32382844974594943
-        ],
-        [
-            12,
-            77,
-            0.7342456505403109
-        ],
-        [
-            12,
-            78,
-            0.5385384041559945
-        ],
-        [
-            12,
-            79,
-            0.5968970907532994
-        ],
-        [
-            12,
-            80,
-            0.4480716406799287
-        ],
-        [
-            12,
-            81,
-            0.4667311847400118
-        ],
-        [
-            12,
-            82,
-            0.255386411719591
-        ],
-        [
-            12,
-            83,
-            0.561197522208027
-        ],
-        [
-            12,
-            84,
-            0.569831108409643
-        ],
-        [
-            12,
-            85,
-            0.5100895957884068
-        ],
-        [
-            12,
-            86,
-            0.4189655012608076
+            0.6245901639344262
         ],
         [
             13,
             0,
-            0.533198397672303
+            0.06885245901639347
         ],
         [
             13,
             1,
-            0.3697097981314795
+            0.2475409836065574
         ],
         [
             13,
             2,
-            0.38377691219836413
+            1.0
         ],
         [
             13,
             3,
-            0.1574039435731719
+            1.0
         ],
         [
             13,
             4,
-            0.1205113043216582
+            0.2475409836065574
         ],
         [
             13,
             5,
-            0.4364677118846604
+            1.0
         ],
         [
             13,
             6,
-            0.4266976636466902
+            0.9311475409836065
         ],
         [
             13,
             7,
-            0.43646771188466016
+            1.0
         ],
         [
             13,
             8,
-            0.09594680975606924
+            0.2475409836065574
         ],
         [
             13,
             9,
-            0.38983133899746863
+            0.25901639344262295
         ],
         [
             13,
             10,
-            0.43917724209849623
+            1.0
         ],
         [
             13,
             11,
-            0.4357385464336411
+            1.0
         ],
         [
             13,
             12,
-            0.5326182919010559
+            0.25901639344262295
         ],
         [
             13,
@@ -5777,332 +5091,382 @@
         [
             13,
             14,
-            0.08280815046853222
+            1.0
         ],
         [
             13,
             15,
-            0.6382920826418852
+            0.2475409836065574
         ],
         [
             13,
             16,
-            0.36497823742195573
+            1.0
         ],
         [
             13,
             17,
-            0.15012539979443126
+            0.9180327868852459
         ],
         [
             13,
             18,
-            0.07447971132586566
+            0.9852459016393442
         ],
         [
             13,
             19,
-            0.16934902707485855
+            0.9983606557377049
         ],
         [
             13,
             20,
-            0.34939211503190104
+            0.978688524590164
         ],
         [
             13,
             21,
-            -0.005367996218330222
+            0.980327868852459
         ],
         [
             13,
             22,
-            0.7726495624290881
+            0.978688524590164
         ],
         [
             13,
             23,
-            0.9390681851574992
+            0.978688524590164
+        ],
+        [
+            13,
+            24,
+            0.9934426229508196
         ],
         [
             13,
             25,
-            0.28256879946778557
+            0.9606557377049181
+        ],
+        [
+            13,
+            26,
+            0.9934426229508196
+        ],
+        [
+            13,
+            27,
+            0.980327868852459
+        ],
+        [
+            13,
+            28,
+            0.980327868852459
+        ],
+        [
+            13,
+            29,
+            0.9918032786885246
+        ],
+        [
+            13,
+            30,
+            0.980327868852459
         ],
         [
             13,
             31,
-            0.2127489569944044
+            0.9819672131147541
+        ],
+        [
+            13,
+            32,
+            0.9934426229508196
+        ],
+        [
+            13,
+            33,
+            0.9737704918032787
+        ],
+        [
+            13,
+            34,
+            0.9721311475409836
+        ],
+        [
+            13,
+            35,
+            0.9918032786885246
+        ],
+        [
+            13,
+            36,
+            0.9868852459016394
+        ],
+        [
+            13,
+            37,
+            0.9868852459016394
+        ],
+        [
+            13,
+            38,
+            0.980327868852459
+        ],
+        [
+            13,
+            39,
+            0.9836065573770492
+        ],
+        [
+            13,
+            40,
+            0.9918032786885246
+        ],
+        [
+            13,
+            41,
+            0.9770491803278688
+        ],
+        [
+            13,
+            42,
+            0.9737704918032787
+        ],
+        [
+            13,
+            43,
+            0.9770491803278688
         ],
         [
             13,
             44,
-            0.2323602598822318
+            0.9704918032786886
+        ],
+        [
+            13,
+            45,
+            0.980327868852459
         ],
         [
             13,
             46,
-            0.04831210719512372
+            0.9885245901639345
+        ],
+        [
+            13,
+            47,
+            0.9459016393442623
         ],
         [
             13,
             48,
-            0.3242948862567506
+            0.9852459016393442
         ],
         [
             13,
             49,
-            0.4400663575232731
+            0.9885245901639345
+        ],
+        [
+            13,
+            50,
+            0.9836065573770492
         ],
         [
             13,
             51,
-            0.37676316119476716
+            0.9704918032786886
         ],
         [
             13,
             52,
-            0.7862733066153151
+            0.9639344262295082
         ],
         [
             13,
             53,
-            0.39998004583912994
+            0.12459016393442623
         ],
         [
             13,
             54,
-            0.4026869684979679
+            0.20491803278688525
         ],
         [
             13,
             55,
-            0.5717939132910798
+            0.19180327868852454
         ],
         [
             13,
             56,
-            0.5717864248830148
+            0.1852459016393443
         ],
         [
             13,
             57,
-            0.3361274449100647
+            0.19508196721311477
         ],
         [
             13,
             58,
-            0.54934710174954
+            0.1081967213114754
         ],
         [
             13,
             59,
-            0.48065508000545815
+            0.021311475409836023
         ],
         [
             13,
             60,
-            0.571801393445781
+            0.2065573770491803
         ],
         [
             13,
             61,
-            0.40462213040488954
+            0.22295081967213115
         ],
         [
             13,
             62,
-            0.149023485488455
+            0.01967213114754096
         ],
         [
             13,
             63,
-            0.4276023984851669
+            0.01967213114754096
         ],
         [
             13,
             64,
-            0.6672304116625589
+            0.2213114754098361
         ],
         [
             13,
             65,
-            0.404737416042256
+            0.2163934426229508
         ],
         [
             13,
             66,
-            0.15808501483286475
+            0.16065573770491803
         ],
         [
             13,
             67,
-            0.4891026278085175
+            0.2114754098360656
         ],
         [
             13,
             68,
-            0.09122348300266349
+            0.139344262295082
         ],
         [
             13,
             69,
-            0.4250902896867496
+            0.760655737704918
         ],
         [
             13,
             70,
-            0.47563463972074443
+            0.760655737704918
         ],
         [
             13,
             71,
-            0.578750165544422
+            0.7573770491803279
         ],
         [
             13,
             72,
-            0.42178633292122664
+            0.7049180327868853
         ],
         [
             13,
             73,
-            0.24549048274731483
+            0.1573770491803279
         ],
         [
             13,
             74,
-            0.16187781529083392
+            0.7491803278688525
         ],
         [
             13,
             75,
-            0.35887028128263676
-        ],
-        [
-            13,
-            76,
-            0.20020650495950207
-        ],
-        [
-            13,
-            77,
-            0.4696150793422089
-        ],
-        [
-            13,
-            78,
-            0.35496478698597705
-        ],
-        [
-            13,
-            79,
-            0.4092076124389627
-        ],
-        [
-            13,
-            80,
-            0.3227580161440406
-        ],
-        [
-            13,
-            81,
-            0.2388537346290343
-        ],
-        [
-            13,
-            82,
-            0.12014076573099595
-        ],
-        [
-            13,
-            83,
-            0.3800584750330461
-        ],
-        [
-            13,
-            84,
-            0.21225476044916708
-        ],
-        [
-            13,
-            85,
-            0.3521811567360959
-        ],
-        [
-            13,
-            86,
-            0.30370632184980423
+            0.13278688524590165
         ],
         [
             14,
             0,
-            0.411216901701936
+            0.06885245901639347
         ],
         [
             14,
             1,
-            0.621158741339205
+            0.2475409836065574
         ],
         [
             14,
             2,
-            0.5553614602732948
+            1.0
         ],
         [
             14,
             3,
-            0.42959298718925126
+            1.0
         ],
         [
             14,
             4,
-            0.27755802395140305
+            0.2475409836065574
         ],
         [
             14,
             5,
-            0.43076756015630846
+            1.0
         ],
         [
             14,
             6,
-            0.4306894984318691
+            0.9311475409836065
         ],
         [
             14,
             7,
-            0.43946142101706964
+            1.0
         ],
         [
             14,
             8,
-            0.17251638983558887
+            0.2475409836065574
         ],
         [
             14,
             9,
-            0.6034618554805068
+            0.25901639344262295
         ],
         [
             14,
             10,
-            0.5157189658302692
+            1.0
         ],
         [
             14,
             11,
-            0.43219952107966203
+            1.0
         ],
         [
             14,
             12,
-            0.44849382448010294
+            0.25901639344262295
         ],
         [
             14,
             13,
-            0.08280815046853222
+            1.0
         ],
         [
             14,
@@ -6112,367 +5476,382 @@
         [
             14,
             15,
-            0.042868263288316166
+            0.2475409836065574
         ],
         [
             14,
             16,
-            0.5642873775451028
+            1.0
         ],
         [
             14,
             17,
-            0.5785434188507899
+            0.9180327868852459
         ],
         [
             14,
             18,
-            0.8144269251927451
+            0.9852459016393442
         ],
         [
             14,
             19,
-            0.6729358422576857
+            0.9983606557377049
         ],
         [
             14,
             20,
-            0.5746612659365838
+            0.978688524590164
         ],
         [
             14,
             21,
-            0.744705338962567
+            0.980327868852459
         ],
         [
             14,
             22,
-            0.07580356563802085
+            0.978688524590164
         ],
         [
             14,
             23,
-            0.05383167779540021
+            0.978688524590164
+        ],
+        [
+            14,
+            24,
+            0.9934426229508196
         ],
         [
             14,
             25,
-            0.06831692322622522
+            0.9606557377049181
+        ],
+        [
+            14,
+            26,
+            0.9934426229508196
+        ],
+        [
+            14,
+            27,
+            0.980327868852459
+        ],
+        [
+            14,
+            28,
+            0.980327868852459
+        ],
+        [
+            14,
+            29,
+            0.9918032786885246
+        ],
+        [
+            14,
+            30,
+            0.980327868852459
         ],
         [
             14,
             31,
-            0.7873278207195984
+            0.9819672131147541
+        ],
+        [
+            14,
+            32,
+            0.9934426229508196
+        ],
+        [
+            14,
+            33,
+            0.9737704918032787
+        ],
+        [
+            14,
+            34,
+            0.9721311475409836
+        ],
+        [
+            14,
+            35,
+            0.9918032786885246
+        ],
+        [
+            14,
+            36,
+            0.9868852459016394
+        ],
+        [
+            14,
+            37,
+            0.9868852459016394
+        ],
+        [
+            14,
+            38,
+            0.980327868852459
+        ],
+        [
+            14,
+            39,
+            0.9836065573770492
+        ],
+        [
+            14,
+            40,
+            0.9918032786885246
+        ],
+        [
+            14,
+            41,
+            0.9770491803278688
+        ],
+        [
+            14,
+            42,
+            0.9737704918032787
+        ],
+        [
+            14,
+            43,
+            0.9770491803278688
         ],
         [
             14,
             44,
-            0.6579459553823546
+            0.9704918032786886
+        ],
+        [
+            14,
+            45,
+            0.980327868852459
         ],
         [
             14,
             46,
-            0.019491864587767745
+            0.9885245901639345
+        ],
+        [
+            14,
+            47,
+            0.9459016393442623
         ],
         [
             14,
             48,
-            0.4300762849900987
+            0.9852459016393442
         ],
         [
             14,
             49,
-            0.4593833739376394
+            0.9885245901639345
         ],
         [
             14,
             50,
-            0.6666666666666667
+            0.9836065573770492
         ],
         [
             14,
             51,
-            0.5478431389718883
+            0.9704918032786886
         ],
         [
             14,
             52,
-            -0.011601400710326677
+            0.9639344262295082
         ],
         [
             14,
             53,
-            0.5521965077170402
+            0.12459016393442623
         ],
         [
             14,
             54,
-            0.5443367529048875
+            0.20491803278688525
         ],
         [
             14,
             55,
-            0.2783328815752712
+            0.19180327868852454
         ],
         [
             14,
             56,
-            0.3274116118175144
+            0.1852459016393443
         ],
         [
             14,
             57,
-            0.0829770226555521
+            0.19508196721311477
         ],
         [
             14,
             58,
-            0.29714587502700207
+            0.1081967213114754
         ],
         [
             14,
             59,
-            0.5627422783230598
+            0.021311475409836023
         ],
         [
             14,
             60,
-            0.303055332280905
+            0.2065573770491803
         ],
         [
             14,
             61,
-            0.5412007121596085
+            0.22295081967213115
+        ],
+        [
+            14,
+            62,
+            0.01967213114754096
         ],
         [
             14,
             63,
-            0.33992751375601366
+            0.01967213114754096
         ],
         [
             14,
             64,
-            0.09380840434758851
+            0.2213114754098361
         ],
         [
             14,
             65,
-            0.3494959276278665
+            0.2163934426229508
         ],
         [
             14,
             66,
-            0.03333472300469445
+            0.16065573770491803
         ],
         [
             14,
             67,
-            0.47123791805739423
+            0.2114754098360656
         ],
         [
             14,
             68,
-            0.01967868614218527
+            0.139344262295082
         ],
         [
             14,
             69,
-            0.4486177031210063
+            0.760655737704918
         ],
         [
             14,
             70,
-            0.37060526545287986
+            0.760655737704918
         ],
         [
             14,
             71,
-            0.2538502384852887
+            0.7573770491803279
         ],
         [
             14,
             72,
-            0.4895799389533342
+            0.7049180327868853
         ],
         [
             14,
             73,
-            0.2912678058662001
+            0.1573770491803279
         ],
         [
             14,
             74,
-            0.7693323057174861
+            0.7491803278688525
         ],
         [
             14,
             75,
-            0.5224486524396773
-        ],
-        [
-            14,
-            76,
-            0.29593453804451786
-        ],
-        [
-            14,
-            77,
-            0.3559342484071871
-        ],
-        [
-            14,
-            78,
-            0.5341433936578357
-        ],
-        [
-            14,
-            79,
-            0.26767166212907617
-        ],
-        [
-            14,
-            80,
-            0.22297260515793077
-        ],
-        [
-            14,
-            81,
-            0.41190396987360905
-        ],
-        [
-            14,
-            82,
-            0.2192979205994453
-        ],
-        [
-            14,
-            83,
-            0.5066348486870673
-        ],
-        [
-            14,
-            84,
-            0.9069949172805473
-        ],
-        [
-            14,
-            85,
-            0.22970906366668498
-        ],
-        [
-            14,
-            86,
-            0.1914199895544468
-        ],
-        [
-            14,
-            88,
-            1.0
-        ],
-        [
-            14,
-            90,
-            1.0
-        ],
-        [
-            14,
-            92,
-            1.0
-        ],
-        [
-            14,
-            93,
-            1.0
-        ],
-        [
-            14,
-            94,
-            1.0
-        ],
-        [
-            14,
-            99,
-            1.0
-        ],
-        [
-            14,
-            100,
-            1.0
+            0.13278688524590165
         ],
         [
             15,
             0,
-            0.49633040516493754
+            0.8213114754098361
         ],
         [
             15,
             1,
-            0.40128077892001607
+            1.0
         ],
         [
             15,
             2,
-            0.3560272926761639
+            0.2475409836065574
         ],
         [
             15,
             3,
-            0.15853495919645344
+            0.2475409836065574
         ],
         [
             15,
             4,
-            0.288415308811709
+            1.0
         ],
         [
             15,
             5,
-            0.4706868617302253
+            0.2475409836065574
         ],
         [
             15,
             6,
-            0.455561100001928
+            0.31639344262295077
         ],
         [
             15,
             7,
-            0.46944865454770596
+            0.2475409836065574
         ],
         [
             15,
             8,
-            0.23719383871918726
+            1.0
         ],
         [
             15,
             9,
-            0.42581030794514757
+            0.9885245901639345
         ],
         [
             15,
             10,
-            0.5724009205543327
+            0.2475409836065574
         ],
         [
             15,
             11,
-            0.4644476935788989
+            0.2475409836065574
         ],
         [
             15,
             12,
-            0.5888831673831372
+            0.9885245901639345
         ],
         [
             15,
             13,
-            0.6382920826418852
+            0.2475409836065574
         ],
         [
             15,
             14,
-            0.042868263288316166
+            0.2475409836065574
         ],
         [
             15,
@@ -6482,397 +5861,382 @@
         [
             15,
             16,
-            0.34466733233098534
+            0.2475409836065574
         ],
         [
             15,
             17,
-            0.00025633106049296773
+            0.3295081967213115
         ],
         [
             15,
             18,
-            0.03340703905463755
+            0.2622950819672131
         ],
         [
             15,
             19,
-            0.018665922961482093
+            0.24590163934426235
         ],
         [
             15,
             20,
-            0.3919759865901132
+            0.2622950819672131
         ],
         [
             15,
             21,
-            0.06675877943767008
+            0.260655737704918
         ],
         [
             15,
             22,
-            0.8386189773954288
+            0.2622950819672131
         ],
         [
             15,
             23,
-            0.6000394216234113
+            0.2622950819672131
         ],
         [
             15,
             24,
-            0.6666666666666666
+            0.2475409836065574
         ],
         [
             15,
             25,
-            0.7163395945517217
+            0.280327868852459
         ],
         [
             15,
             26,
-            0.2721655269759087
+            0.2475409836065574
+        ],
+        [
+            15,
+            27,
+            0.260655737704918
         ],
         [
             15,
             28,
-            0.2721655269759087
+            0.260655737704918
         ],
         [
             15,
             29,
-            0.5393598899705935
+            0.24918032786885247
         ],
         [
             15,
             30,
-            0.6666666666666666
+            0.260655737704918
         ],
         [
             15,
             31,
-            0.195110640267748
+            0.25901639344262295
         ],
         [
             15,
             32,
-            0.3333333333333333
+            0.2475409836065574
+        ],
+        [
+            15,
+            33,
+            0.26393442622950825
         ],
         [
             15,
             34,
-            0.3333333333333333
+            0.2655737704918033
         ],
         [
             15,
             35,
-            0.2721655269759087
+            0.24590163934426235
         ],
         [
             15,
             36,
-            0.2721655269759087
+            0.24426229508196717
+        ],
+        [
+            15,
+            37,
+            0.2475409836065574
+        ],
+        [
+            15,
+            38,
+            0.2573770491803279
+        ],
+        [
+            15,
+            39,
+            0.25081967213114753
         ],
         [
             15,
             40,
-            0.41833001326703767
+            0.24590163934426235
+        ],
+        [
+            15,
+            41,
+            0.260655737704918
         ],
         [
             15,
             42,
-            0.2721655269759087
+            0.26393442622950825
         ],
         [
             15,
             43,
-            0.5091750772173155
+            0.260655737704918
         ],
         [
             15,
             44,
-            0.22947062012637998
+            0.260655737704918
         ],
         [
             15,
             45,
-            0.5091750772173155
+            0.2573770491803279
         ],
         [
             15,
             46,
-            0.640862839151883
+            0.24590163934426235
+        ],
+        [
+            15,
+            47,
+            0.2918032786885246
         ],
         [
             15,
             48,
-            0.361045430873923
+            0.24590163934426235
         ],
         [
             15,
             49,
-            0.48627175780883286
+            0.24918032786885247
+        ],
+        [
+            15,
+            50,
+            0.24426229508196717
         ],
         [
             15,
             51,
-            0.3765539748902697
+            0.2573770491803279
         ],
         [
             15,
             52,
-            0.4926101210186795
+            0.2704918032786885
         ],
         [
             15,
             53,
-            0.4402053308162498
+            0.759016393442623
         ],
         [
             15,
             54,
-            0.4613114234477723
+            0.6786885245901639
         ],
         [
             15,
             55,
-            0.7737848281120586
+            0.6655737704918032
         ],
         [
             15,
             56,
-            0.6383926689803836
+            0.6655737704918032
         ],
         [
             15,
             57,
-            0.45420603845895535
+            0.639344262295082
         ],
         [
             15,
             58,
-            0.5248954540241377
+            0.7327868852459016
         ],
         [
             15,
             59,
-            0.5279962543051453
+            0.7737704918032787
         ],
         [
             15,
             60,
-            0.6385348613753524
+            0.6836065573770491
         ],
         [
             15,
             61,
-            0.4568666562709804
+            0.6672131147540983
         ],
         [
             15,
             62,
-            0.35936524509285267
+            0.7721311475409836
         ],
         [
             15,
             63,
-            0.45373055561314046
+            0.7721311475409836
         ],
         [
             15,
             64,
-            0.6649106125617232
+            0.6655737704918032
         ],
         [
             15,
             65,
-            0.45962898742600655
+            0.6672131147540983
         ],
         [
             15,
             66,
-            0.2832872021803779
+            0.6639344262295082
         ],
         [
             15,
             67,
-            0.5612509319210403
+            0.6754098360655738
         ],
         [
             15,
             68,
-            0.27648329645840203
+            0.7114754098360656
         ],
         [
             15,
             69,
-            0.476125503251337
+            0.008196721311475419
         ],
         [
             15,
             70,
-            0.5230903490592194
+            0.008196721311475419
         ],
         [
             15,
             71,
-            0.6651565290812117
+            0.004918032786885296
         ],
         [
             15,
             72,
-            0.4817626829202607
+            0.06393442622950818
         ],
         [
             15,
             73,
-            0.21444227631651455
+            0.6114754098360655
         ],
         [
             15,
             74,
-            0.09213937111163573
+            0.01967213114754096
         ],
         [
             15,
             75,
-            0.32825729726450664
-        ],
-        [
-            15,
-            76,
-            0.210083421847237
-        ],
-        [
-            15,
-            77,
-            0.5037815643157092
-        ],
-        [
-            15,
-            78,
-            0.32452085139664355
-        ],
-        [
-            15,
-            79,
-            0.43934690294981227
-        ],
-        [
-            15,
-            80,
-            0.2926194044420368
-        ],
-        [
-            15,
-            81,
-            0.25809700653998235
-        ],
-        [
-            15,
-            82,
-            0.13272132959982982
-        ],
-        [
-            15,
-            83,
-            0.33778628567227126
-        ],
-        [
-            15,
-            84,
-            0.13321879059870784
-        ],
-        [
-            15,
-            85,
-            0.3785747520337368
-        ],
-        [
-            15,
-            86,
-            0.40251124147431866
+            0.6360655737704918
         ],
         [
             16,
             0,
-            0.6490886500447565
+            0.06885245901639347
         ],
         [
             16,
             1,
-            0.8896849195307587
+            0.2475409836065574
         ],
         [
             16,
             2,
-            0.7017297880665369
+            1.0
         ],
         [
             16,
             3,
-            0.5557102608607607
+            1.0
         ],
         [
             16,
             4,
-            0.363556700655475
+            0.2475409836065574
         ],
         [
             16,
             5,
-            0.8116770340194187
+            1.0
         ],
         [
             16,
             6,
-            0.7826422631024679
+            0.9311475409836065
         ],
         [
             16,
             7,
-            0.8116904756544427
+            1.0
         ],
         [
             16,
             8,
-            0.22409000148846817
+            0.2475409836065574
         ],
         [
             16,
             9,
-            0.706342056133523
+            0.25901639344262295
         ],
         [
             16,
             10,
-            0.7785214538085226
+            1.0
         ],
         [
             16,
             11,
-            0.7967650385415217
+            1.0
         ],
         [
             16,
             12,
-            0.6427661662039201
+            0.25901639344262295
         ],
         [
             16,
             13,
-            0.36497823742195573
+            1.0
         ],
         [
             16,
             14,
-            0.5642873775451028
+            1.0
         ],
         [
             16,
             15,
-            0.34466733233098534
+            0.2475409836065574
         ],
         [
             16,
@@ -6882,502 +6246,382 @@
         [
             16,
             17,
-            0.5532644471927939
+            0.9180327868852459
         ],
         [
             16,
             18,
-            0.5799128291660127
+            0.9852459016393442
         ],
         [
             16,
             19,
-            0.5184947514749599
+            0.9983606557377049
         ],
         [
             16,
             20,
-            0.7821773386138654
+            0.978688524590164
         ],
         [
             16,
             21,
-            0.5500107218001311
+            0.980327868852459
         ],
         [
             16,
             22,
-            0.39467556350977
+            0.978688524590164
         ],
         [
             16,
             23,
-            0.35543513114847725
+            0.978688524590164
         ],
         [
             16,
             24,
-            0.3162277660168379
+            0.9934426229508196
         ],
         [
             16,
             25,
-            0.16220167164383925
+            0.9606557377049181
         ],
         [
             16,
             26,
-            1.0
+            0.9934426229508196
         ],
         [
             16,
             27,
-            1.0
+            0.980327868852459
         ],
         [
             16,
             28,
-            1.0
+            0.980327868852459
         ],
         [
             16,
             29,
-            0.5590169943749475
+            0.9918032786885246
         ],
         [
             16,
             30,
-            0.3162277660168379
+            0.980327868852459
         ],
         [
             16,
             31,
-            0.684848598180402
+            0.9819672131147541
         ],
         [
             16,
             32,
-            0.7999999999999999
+            0.9934426229508196
+        ],
+        [
+            16,
+            33,
+            0.9737704918032787
         ],
         [
             16,
             34,
-            0.7999999999999999
+            0.9721311475409836
         ],
         [
             16,
             35,
-            1.0
+            0.9918032786885246
         ],
         [
             16,
             36,
-            0.5499999999999999
+            0.9868852459016394
         ],
         [
             16,
             37,
-            0.7142857142857144
+            0.9868852459016394
         ],
         [
             16,
             38,
-            0.48795003647426655
+            0.980327868852459
+        ],
+        [
+            16,
+            39,
+            0.9836065573770492
         ],
         [
             16,
             40,
-            0.5345224838248487
+            0.9918032786885246
+        ],
+        [
+            16,
+            41,
+            0.9770491803278688
         ],
         [
             16,
             42,
-            1.0
+            0.9737704918032787
         ],
         [
             16,
             43,
-            0.47809144373375745
+            0.9770491803278688
         ],
         [
             16,
             44,
-            0.6306759165063986
+            0.9704918032786886
         ],
         [
             16,
             45,
-            0.47809144373375745
+            0.980327868852459
         ],
         [
             16,
             46,
-            0.040850420281152475
+            0.9885245901639345
+        ],
+        [
+            16,
+            47,
+            0.9459016393442623
         ],
         [
             16,
             48,
-            0.8138381762808107
+            0.9852459016393442
         ],
         [
             16,
             49,
-            0.7767545596269781
+            0.9885245901639345
         ],
         [
             16,
             50,
-            0.24671758189758472
+            0.9836065573770492
         ],
         [
             16,
             51,
-            0.7433189806388155
+            0.9704918032786886
         ],
         [
             16,
             52,
-            0.3296814943682546
+            0.9639344262295082
         ],
         [
             16,
             53,
-            0.8830332496877165
+            0.12459016393442623
         ],
         [
             16,
             54,
-            0.9027926624886612
+            0.20491803278688525
         ],
         [
             16,
             55,
-            0.5338600469226643
+            0.19180327868852454
         ],
         [
             16,
             56,
-            0.5889405261047629
+            0.1852459016393443
         ],
         [
             16,
             57,
-            0.14432540789764808
+            0.19508196721311477
         ],
         [
             16,
             58,
-            0.5899976305553488
+            0.1081967213114754
         ],
         [
             16,
             59,
-            0.7047521368668394
+            0.021311475409836023
         ],
         [
             16,
             60,
-            0.5842417178988564
+            0.2065573770491803
         ],
         [
             16,
             61,
-            0.8933863735914109
+            0.22295081967213115
         ],
         [
             16,
             62,
-            0.0735527814811363
+            0.01967213114754096
         ],
         [
             16,
             63,
-            0.5916663394220595
+            0.01967213114754096
         ],
         [
             16,
             64,
-            0.36451156934318996
+            0.2213114754098361
         ],
         [
             16,
             65,
-            0.658014692387257
+            0.2163934426229508
         ],
         [
             16,
             66,
-            0.11589279677100943
+            0.16065573770491803
         ],
         [
             16,
             67,
-            0.6580438333425016
+            0.2114754098360656
         ],
         [
             16,
             68,
-            0.10544291943073224
+            0.139344262295082
         ],
         [
             16,
             69,
-            0.7201981442371338
+            0.760655737704918
         ],
         [
             16,
             70,
-            0.658097425958747
+            0.760655737704918
         ],
         [
             16,
             71,
-            0.5587289096710709
+            0.7573770491803279
         ],
         [
             16,
             72,
-            0.7430122417031367
+            0.7049180327868853
         ],
         [
             16,
             73,
-            0.3238415706813383
+            0.1573770491803279
         ],
         [
             16,
             74,
-            0.4843929639092114
+            0.7491803278688525
         ],
         [
             16,
             75,
-            0.9468858107159137
-        ],
-        [
-            16,
-            76,
-            0.3405740986436113
-        ],
-        [
-            16,
-            77,
-            0.450805247440741
-        ],
-        [
-            16,
-            78,
-            0.9475587842407402
-        ],
-        [
-            16,
-            79,
-            0.4066712914404367
-        ],
-        [
-            16,
-            80,
-            0.7525121326622721
-        ],
-        [
-            16,
-            81,
-            0.7123838003508416
-        ],
-        [
-            16,
-            82,
-            0.38734148042766214
-        ],
-        [
-            16,
-            83,
-            0.9061231430088035
-        ],
-        [
-            16,
-            84,
-            0.5884620343444873
-        ],
-        [
-            16,
-            85,
-            0.43616904356804986
-        ],
-        [
-            16,
-            86,
-            0.3194517526672785
-        ],
-        [
-            16,
-            88,
-            1.0
-        ],
-        [
-            16,
-            89,
-            0.7142857142857144
-        ],
-        [
-            16,
-            90,
-            1.0
-        ],
-        [
-            16,
-            92,
-            1.0
-        ],
-        [
-            16,
-            93,
-            1.0
-        ],
-        [
-            16,
-            94,
-            1.0
-        ],
-        [
-            16,
-            95,
-            0.8451542547285169
-        ],
-        [
-            16,
-            96,
-            0.48795003647426655
-        ],
-        [
-            16,
-            97,
-            1.0
-        ],
-        [
-            16,
-            98,
-            0.6831300510639732
-        ],
-        [
-            16,
-            99,
-            1.0
-        ],
-        [
-            16,
-            100,
-            0.8366600265340753
-        ],
-        [
-            16,
-            101,
-            1.0
-        ],
-        [
-            16,
-            104,
-            0.8164965809277261
-        ],
-        [
-            16,
-            105,
-            1.0
-        ],
-        [
-            16,
-            112,
-            1.0
-        ],
-        [
-            16,
-            121,
-            1.0
+            0.13278688524590165
         ],
         [
             17,
             0,
-            0.3657764755667685
+            0.15081967213114755
         ],
         [
             17,
             1,
-            0.6046973004224284
+            0.3295081967213115
         ],
         [
             17,
             2,
-            0.4409605041854958
+            0.9180327868852459
         ],
         [
             17,
             3,
-            0.6967779477767176
+            0.9180327868852459
         ],
         [
             17,
             4,
-            0.2524480707755679
+            0.3295081967213115
         ],
         [
             17,
             5,
-            0.4783497984477372
+            0.9180327868852459
         ],
         [
             17,
             6,
-            0.46076065556624823
+            0.9868852459016394
         ],
         [
             17,
             7,
-            0.48175615933172355
+            0.9180327868852459
         ],
         [
             17,
             8,
-            0.14931310499111874
+            0.3295081967213115
         ],
         [
             17,
             9,
-            0.48546597976355593
+            0.34098360655737703
         ],
         [
             17,
             10,
-            0.48612756578100713
+            0.9180327868852459
         ],
         [
             17,
             11,
-            0.475136977061247
+            0.9180327868852459
         ],
         [
             17,
             12,
-            0.3978573485403148
+            0.34098360655737703
         ],
         [
             17,
             13,
-            0.15012539979443126
+            0.9180327868852459
         ],
         [
             17,
             14,
-            0.5785434188507899
+            0.9180327868852459
         ],
         [
             17,
             15,
-            0.00025633106049296773
+            0.3295081967213115
         ],
         [
             17,
             16,
-            0.5532644471927939
+            0.9180327868852459
         ],
         [
             17,
@@ -7387,487 +6631,382 @@
         [
             17,
             18,
-            0.5691929746050317
+            0.9295081967213115
         ],
         [
             17,
             19,
-            0.6921728063390649
+            0.9163934426229509
         ],
         [
             17,
             20,
-            0.6328452409491424
+            0.9229508196721311
         ],
         [
             17,
             21,
-            0.49706167665420525
+            0.9245901639344263
         ],
         [
             17,
             22,
-            0.12561953195613157
+            0.9229508196721311
         ],
         [
             17,
             23,
-            0.14554005156871647
+            0.9229508196721311
         ],
         [
             17,
             24,
-            0.14285714285714288
+            0.9114754098360656
         ],
         [
             17,
             25,
-            -0.001191463742368934
+            0.9049180327868852
         ],
         [
             17,
             26,
-            0.3779644730092272
+            0.9114754098360656
         ],
         [
             17,
             27,
-            0.5163977794943222
+            0.9245901639344263
         ],
         [
             17,
             28,
-            0.3779644730092272
+            0.9245901639344263
         ],
         [
             17,
             29,
-            0.25
+            0.9098360655737705
         ],
         [
             17,
             30,
-            0.14285714285714288
+            0.9245901639344263
         ],
         [
             17,
             31,
-            0.5805762109370033
+            0.9262295081967213
         ],
         [
             17,
             32,
-            0.29277002188455997
+            0.9114754098360656
+        ],
+        [
+            17,
+            33,
+            0.9180327868852459
         ],
         [
             17,
             34,
-            0.29277002188455997
+            0.9163934426229509
         ],
         [
             17,
             35,
-            0.3779644730092272
+            0.9098360655737705
         ],
         [
             17,
             36,
-            0.3779644730092272
+            0.9049180327868852
         ],
         [
             17,
             37,
-            0.3563483225498992
+            0.9049180327868852
         ],
         [
             17,
             38,
-            0.22222222222222227
+            0.898360655737705
+        ],
+        [
+            17,
+            39,
+            0.9016393442622951
         ],
         [
             17,
             40,
-            0.18898223650461363
+            0.9098360655737705
+        ],
+        [
+            17,
+            41,
+            0.921311475409836
         ],
         [
             17,
             42,
-            0.3779644730092272
+            0.9180327868852459
         ],
         [
             17,
             43,
-            0.21821789023599233
+            0.921311475409836
         ],
         [
             17,
             44,
-            0.44438436733519976
+            0.9147540983606557
         ],
         [
             17,
             45,
-            0.21821789023599233
+            0.898360655737705
         ],
         [
             17,
             46,
-            -0.022130996175241648
+            0.9065573770491804
+        ],
+        [
+            17,
+            47,
+            0.8901639344262295
         ],
         [
             17,
             48,
-            0.4339324872513432
+            0.9032786885245901
         ],
         [
             17,
             49,
-            0.4721992024059799
+            0.9065573770491804
         ],
         [
             17,
             50,
-            0.426401432711221
+            0.9016393442622951
         ],
         [
             17,
             51,
-            0.4766776072481858
+            0.9147540983606557
         ],
         [
             17,
             52,
-            0.10677095900138293
+            0.9081967213114754
         ],
         [
             17,
             53,
-            0.5491135075645177
+            0.17049180327868851
         ],
         [
             17,
             54,
-            0.5774277438455978
+            0.24098360655737705
         ],
         [
             17,
             55,
-            0.21190573396243906
+            0.23114754098360657
         ],
         [
             17,
             56,
-            0.2977702417052971
+            0.24098360655737705
         ],
         [
             17,
             57,
-            0.07612038620627128
+            0.2213114754098361
         ],
         [
             17,
             58,
-            0.27381370018937834
+            0.1672131147540984
         ],
         [
             17,
             59,
-            0.47033297004187447
+            0.10327868852459021
         ],
         [
             17,
             60,
-            0.28146737231827945
+            0.24590163934426235
         ],
         [
             17,
             61,
-            0.5657640708204567
+            0.2524590163934426
+        ],
+        [
+            17,
+            62,
+            0.10163934426229504
         ],
         [
             17,
             63,
-            0.2534377451375266
+            0.10163934426229504
         ],
         [
             17,
             64,
-            0.10736966163690068
+            0.2475409836065574
         ],
         [
             17,
             65,
-            0.4045129084658906
+            0.24590163934426235
         ],
         [
             17,
             66,
-            0.02721550093590012
+            0.19016393442622948
         ],
         [
             17,
             67,
-            0.3352278920967524
+            0.24098360655737705
         ],
         [
             17,
             68,
-            0.0036018142543925687
+            0.21803278688524586
         ],
         [
             17,
             69,
-            0.4651312746589619
+            0.6786885245901639
         ],
         [
             17,
             70,
-            0.40356236617997643
+            0.6786885245901639
         ],
         [
             17,
             71,
-            0.25372616826117345
+            0.6754098360655738
         ],
         [
             17,
             72,
-            0.4818241659959489
+            0.7344262295081967
         ],
         [
             17,
             73,
-            0.1833846351385
+            0.18360655737704923
         ],
         [
             17,
             74,
-            0.5566389634348341
+            0.6672131147540983
         ],
         [
             17,
             75,
-            0.4707862603025948
-        ],
-        [
-            17,
-            76,
-            0.24422790627920174
-        ],
-        [
-            17,
-            77,
-            0.47269958175305965
-        ],
-        [
-            17,
-            78,
-            0.48200334442200726
-        ],
-        [
-            17,
-            79,
-            0.40809398459340374
-        ],
-        [
-            17,
-            80,
-            0.2162583389440027
-        ],
-        [
-            17,
-            81,
-            0.32530694218935374
-        ],
-        [
-            17,
-            82,
-            0.17854996292479888
-        ],
-        [
-            17,
-            83,
-            0.5228641123953888
-        ],
-        [
-            17,
-            84,
-            0.7123336289633032
-        ],
-        [
-            17,
-            85,
-            0.273249853074652
-        ],
-        [
-            17,
-            86,
-            0.18796341545409873
-        ],
-        [
-            17,
-            88,
-            1.0
-        ],
-        [
-            17,
-            89,
-            0.3563483225498992
-        ],
-        [
-            17,
-            90,
-            1.0
-        ],
-        [
-            17,
-            92,
-            1.0
-        ],
-        [
-            17,
-            93,
-            1.0
-        ],
-        [
-            17,
-            94,
-            1.0
-        ],
-        [
-            17,
-            95,
-            0.35355339059327373
-        ],
-        [
-            17,
-            96,
-            0.22222222222222227
-        ],
-        [
-            17,
-            97,
-            0.40824829046386296
-        ],
-        [
-            17,
-            98,
-            0.4082482904638631
-        ],
-        [
-            17,
-            99,
-            1.0
-        ],
-        [
-            17,
-            100,
-            0.49999999999999994
-        ],
-        [
-            17,
-            101,
-            0.5163977794943222
-        ],
-        [
-            17,
-            104,
-            0.3162277660168379
-        ],
-        [
-            17,
-            105,
-            0.3952847075210473
+            0.1885245901639344
         ],
         [
             18,
             0,
-            0.40314493904553506
+            0.08360655737704914
         ],
         [
             18,
             1,
-            0.6400250164182175
+            0.2622950819672131
         ],
         [
             18,
             2,
-            0.5264090737667061
+            0.9852459016393442
         ],
         [
             18,
             3,
-            0.4175851485613976
+            0.9852459016393442
         ],
         [
             18,
             4,
-            0.26431406161052035
+            0.2622950819672131
         ],
         [
             18,
             5,
-            0.3934205161581788
+            0.9852459016393442
         ],
         [
             18,
             6,
-            0.3769471227496217
+            0.9163934426229509
         ],
         [
             18,
             7,
-            0.3934477048533054
+            0.9852459016393442
         ],
         [
             18,
             8,
-            0.170362618642645
+            0.2622950819672131
         ],
         [
             18,
             9,
-            0.5775839996292046
+            0.2704918032786885
         ],
         [
             18,
             10,
-            0.4708047858083588
+            0.9852459016393442
         ],
         [
             18,
             11,
-            0.38658378886776773
+            0.9852459016393442
         ],
         [
             18,
             12,
-            0.4381999046073426
+            0.2704918032786885
         ],
         [
             18,
             13,
-            0.07447971132586566
+            0.9852459016393442
         ],
         [
             18,
             14,
-            0.8144269251927451
+            0.9852459016393442
         ],
         [
             18,
             15,
-            0.03340703905463755
+            0.2622950819672131
         ],
         [
             18,
             16,
-            0.5799128291660127
+            0.9852459016393442
         ],
         [
             18,
             17,
-            0.5691929746050317
+            0.9295081967213115
         ],
         [
             18,
@@ -7877,332 +7016,382 @@
         [
             18,
             19,
-            0.6505388794541339
+            0.9836065573770492
         ],
         [
             18,
             20,
-            0.581017283951803
+            0.9934426229508196
         ],
         [
             18,
             21,
-            0.6893126151219368
+            0.9950819672131147
         ],
         [
             18,
             22,
-            0.06680820173482006
+            0.9934426229508196
         ],
         [
             18,
             23,
-            0.047416846691136424
+            0.9934426229508196
+        ],
+        [
+            18,
+            24,
+            0.9819672131147541
         ],
         [
             18,
             25,
-            0.03093320667924764
+            0.9754098360655737
+        ],
+        [
+            18,
+            26,
+            0.9819672131147541
+        ],
+        [
+            18,
+            27,
+            0.9950819672131147
+        ],
+        [
+            18,
+            28,
+            0.9950819672131147
+        ],
+        [
+            18,
+            29,
+            0.980327868852459
+        ],
+        [
+            18,
+            30,
+            0.9950819672131147
         ],
         [
             18,
             31,
-            0.7185482932113774
+            0.9967213114754099
+        ],
+        [
+            18,
+            32,
+            0.9819672131147541
+        ],
+        [
+            18,
+            33,
+            0.9885245901639345
+        ],
+        [
+            18,
+            34,
+            0.9868852459016394
+        ],
+        [
+            18,
+            35,
+            0.980327868852459
+        ],
+        [
+            18,
+            36,
+            0.9754098360655737
+        ],
+        [
+            18,
+            37,
+            0.9754098360655737
+        ],
+        [
+            18,
+            38,
+            0.9688524590163934
+        ],
+        [
+            18,
+            39,
+            0.9721311475409836
+        ],
+        [
+            18,
+            40,
+            0.980327868852459
+        ],
+        [
+            18,
+            41,
+            0.9918032786885246
+        ],
+        [
+            18,
+            42,
+            0.9885245901639345
+        ],
+        [
+            18,
+            43,
+            0.9918032786885246
         ],
         [
             18,
             44,
-            0.5646573703574895
+            0.9852459016393442
+        ],
+        [
+            18,
+            45,
+            0.9688524590163934
         ],
         [
             18,
             46,
-            -0.01858470558997977
+            0.9770491803278688
+        ],
+        [
+            18,
+            47,
+            0.9606557377049181
         ],
         [
             18,
             48,
-            0.42539517538009336
+            0.9737704918032787
         ],
         [
             18,
             49,
-            0.44901911715102516
+            0.9770491803278688
         ],
         [
             18,
             50,
-            0.6666666666666667
+            0.9721311475409836
         ],
         [
             18,
             51,
-            0.5100786019626584
+            0.9852459016393442
         ],
         [
             18,
             52,
-            -0.01290222581399861
+            0.978688524590164
         ],
         [
             18,
             53,
-            0.5183547146044386
+            0.139344262295082
         ],
         [
             18,
             54,
-            0.5317111843517718
+            0.21967213114754103
         ],
         [
             18,
             55,
-            0.2608437521827303
+            0.2032786885245902
         ],
         [
             18,
             56,
-            0.31911819057862717
+            0.19672131147540983
         ],
         [
             18,
             57,
-            0.07258049243232154
+            0.2065573770491803
         ],
         [
             18,
             58,
-            0.30599148131218423
+            0.12295081967213117
         ],
         [
             18,
             59,
-            0.5321591227158408
+            0.0360655737704918
         ],
         [
             18,
             60,
-            0.29727749541933074
+            0.2213114754098361
         ],
         [
             18,
             61,
-            0.5226494061525803
+            0.23770491803278693
+        ],
+        [
+            18,
+            62,
+            0.03442622950819674
         ],
         [
             18,
             63,
-            0.29578472360087343
+            0.03442622950819674
         ],
         [
             18,
             64,
-            0.0747780830813584
+            0.23278688524590163
         ],
         [
             18,
             65,
-            0.35532733950140616
+            0.23114754098360657
         ],
         [
             18,
             66,
-            0.03950423778172483
+            0.17213114754098358
         ],
         [
             18,
             67,
-            0.43021836214804704
+            0.22622950819672127
         ],
         [
             18,
             68,
-            0.014830349899453341
+            0.15081967213114755
         ],
         [
             18,
             69,
-            0.4503693700795846
+            0.7459016393442623
         ],
         [
             18,
             70,
-            0.4086579614252298
+            0.7459016393442623
         ],
         [
             18,
             71,
-            0.26949414939265043
+            0.7426229508196721
         ],
         [
             18,
             72,
-            0.4857768155059835
+            0.6901639344262296
         ],
         [
             18,
             73,
-            0.24104664797764197
+            0.16885245901639345
         ],
         [
             18,
             74,
-            0.8138090013881376
+            0.7377049180327868
         ],
         [
             18,
             75,
-            0.5042650304221448
-        ],
-        [
-            18,
-            76,
-            0.3112812606881815
-        ],
-        [
-            18,
-            77,
-            0.30638167667268595
-        ],
-        [
-            18,
-            78,
-            0.5023578857529274
-        ],
-        [
-            18,
-            79,
-            0.22312752265922187
-        ],
-        [
-            18,
-            80,
-            0.23559266469029913
-        ],
-        [
-            18,
-            81,
-            0.45402298850574746
-        ],
-        [
-            18,
-            82,
-            0.26224750589280055
-        ],
-        [
-            18,
-            83,
-            0.5114751187740824
-        ],
-        [
-            18,
-            84,
-            0.7998749328214972
-        ],
-        [
-            18,
-            85,
-            0.18297231724430765
-        ],
-        [
-            18,
-            86,
-            0.16733486127657732
+            0.12131147540983611
         ],
         [
             19,
             0,
-            0.5069477880712527
+            0.07049180327868854
         ],
         [
             19,
             1,
-            0.5909947587569504
+            0.24590163934426235
         ],
         [
             19,
             2,
-            0.5793978816671871
+            0.9983606557377049
         ],
         [
             19,
             3,
-            0.4098700450721337
+            0.9983606557377049
         ],
         [
             19,
             4,
-            0.3419697902658569
+            0.24590163934426235
         ],
         [
             19,
             5,
-            0.38445591180701433
+            0.9983606557377049
         ],
         [
             19,
             6,
-            0.3744892382486824
+            0.9295081967213115
         ],
         [
             19,
             7,
-            0.3899283897807742
+            0.9983606557377049
         ],
         [
             19,
             8,
-            0.1834531436465184
+            0.24590163934426235
         ],
         [
             19,
             9,
-            0.6366645808324106
+            0.2573770491803279
         ],
         [
             19,
             10,
-            0.46544208317292457
+            0.9983606557377049
         ],
         [
             19,
             11,
-            0.3829922048881917
+            0.9983606557377049
         ],
         [
             19,
             12,
-            0.5475788853813157
+            0.2573770491803279
         ],
         [
             19,
             13,
-            0.16934902707485855
+            0.9983606557377049
         ],
         [
             19,
             14,
-            0.6729358422576857
+            0.9983606557377049
         ],
         [
             19,
             15,
-            0.018665922961482093
+            0.24590163934426235
         ],
         [
             19,
             16,
-            0.5184947514749599
+            0.9983606557377049
         ],
         [
             19,
             17,
-            0.6921728063390649
+            0.9163934426229509
         ],
         [
             19,
             18,
-            0.6505388794541339
+            0.9836065573770492
         ],
         [
             19,
@@ -8212,457 +7401,382 @@
         [
             19,
             20,
-            0.5512656338749684
+            0.980327868852459
         ],
         [
             19,
             21,
-            0.695266057708542
+            0.9819672131147541
         ],
         [
             19,
             22,
-            0.1716647543957647
+            0.980327868852459
         ],
         [
             19,
             23,
-            0.16990414367745854
+            0.980327868852459
         ],
         [
             19,
             24,
-            0.4879500364742666
+            0.9950819672131147
         ],
         [
             19,
             25,
-            0.01159884898743776
+            0.9622950819672131
         ],
         [
             19,
             26,
-            0.7745966692414834
+            0.9950819672131147
         ],
         [
             19,
             27,
-            0.5590169943749473
+            0.9819672131147541
         ],
         [
             19,
             28,
-            0.7745966692414834
+            0.9819672131147541
         ],
         [
             19,
             29,
-            0.7637626158259734
+            0.9934426229508196
         ],
         [
             19,
             30,
-            0.4879500364742666
+            0.9819672131147541
         ],
         [
             19,
             31,
-            0.6496840925012893
+            0.9836065573770492
         ],
         [
             19,
             32,
-            1.0
+            0.9950819672131147
+        ],
+        [
+            19,
+            33,
+            0.9754098360655737
         ],
         [
             19,
             34,
-            1.0
+            0.9737704918032787
         ],
         [
             19,
             35,
-            0.7745966692414834
+            0.9934426229508196
         ],
         [
             19,
             36,
-            0.7745966692414834
+            0.9885245901639345
         ],
         [
             19,
             37,
-            0.8100925873009824
+            0.9885245901639345
         ],
         [
             19,
             38,
-            0.7698003589195009
+            0.9819672131147541
+        ],
+        [
+            19,
+            39,
+            0.9852459016393442
         ],
         [
             19,
             40,
-            0.7559289460184545
+            0.9934426229508196
+        ],
+        [
+            19,
+            41,
+            0.978688524590164
         ],
         [
             19,
             42,
-            0.7745966692414834
+            0.9754098360655737
         ],
         [
             19,
             43,
-            0.7453559924999299
+            0.978688524590164
         ],
         [
             19,
             44,
-            0.6150682772489574
+            0.9721311475409836
         ],
         [
             19,
             45,
-            0.7453559924999299
+            0.9819672131147541
         ],
         [
             19,
             46,
-            -0.016638657720158646
+            0.9901639344262295
+        ],
+        [
+            19,
+            47,
+            0.9475409836065574
         ],
         [
             19,
             48,
-            0.3710247698636945
+            0.9868852459016394
         ],
         [
             19,
             49,
-            0.3734949387874955
+            0.9901639344262295
         ],
         [
             19,
             50,
-            -0.09090909090909086
+            0.9852459016393442
         ],
         [
             19,
             51,
-            0.4813091676548979
+            0.9721311475409836
         ],
         [
             19,
             52,
-            0.1465326572596161
+            0.9655737704918033
         ],
         [
             19,
             53,
-            0.49117447181225354
+            0.1262295081967213
         ],
         [
             19,
             54,
-            0.49103598621438704
+            0.2065573770491803
         ],
         [
             19,
             55,
-            0.28585883558295444
+            0.1934426229508197
         ],
         [
             19,
             56,
-            0.44087504165678276
+            0.18688524590163935
         ],
         [
             19,
             57,
-            0.13871959237770615
+            0.19672131147540983
         ],
         [
             19,
             58,
-            0.3837794940769163
+            0.10983606557377046
         ],
         [
             19,
             59,
-            0.6471308742678128
+            0.022950819672131195
         ],
         [
             19,
             60,
-            0.4206829010249306
+            0.20819672131147537
         ],
         [
             19,
             61,
-            0.47419106204725964
+            0.2245901639344262
+        ],
+        [
+            19,
+            62,
+            0.021311475409836023
         ],
         [
             19,
             63,
-            0.39170251612917933
+            0.021311475409836023
         ],
         [
             19,
             64,
-            0.13066365437327487
+            0.22295081967213115
         ],
         [
             19,
             65,
-            0.2873943504245631
+            0.21803278688524586
         ],
         [
             19,
             66,
-            -0.006204730570558137
+            0.1622950819672131
         ],
         [
             19,
             67,
-            0.4452819835679484
+            0.21311475409836067
         ],
         [
             19,
             68,
-            0.01610068369868449
+            0.14098360655737707
         ],
         [
             19,
             69,
-            0.38140977496802325
+            0.7622950819672132
         ],
         [
             19,
             70,
-            0.3078650057718318
+            0.7622950819672132
         ],
         [
             19,
             71,
-            0.38526550850010044
+            0.759016393442623
         ],
         [
             19,
             72,
-            0.41243015123227983
+            0.7065573770491803
         ],
         [
             19,
             73,
-            0.2796844506510743
+            0.15901639344262297
         ],
         [
             19,
             74,
-            0.5496455529845583
+            0.7508196721311475
         ],
         [
             19,
             75,
-            0.44279974170407715
-        ],
-        [
-            19,
-            76,
-            0.29221773636400494
-        ],
-        [
-            19,
-            77,
-            0.6308844116495895
-        ],
-        [
-            19,
-            78,
-            0.43611102238721877
-        ],
-        [
-            19,
-            79,
-            0.4186657443249605
-        ],
-        [
-            19,
-            80,
-            0.18574862685722884
-        ],
-        [
-            19,
-            81,
-            0.422854353016479
-        ],
-        [
-            19,
-            82,
-            0.25366432537426714
-        ],
-        [
-            19,
-            83,
-            0.48135414095959117
-        ],
-        [
-            19,
-            84,
-            0.6141410062885246
-        ],
-        [
-            19,
-            85,
-            0.3272774205482736
-        ],
-        [
-            19,
-            86,
-            0.26167267846888675
-        ],
-        [
-            19,
-            89,
-            0.8100925873009824
-        ],
-        [
-            19,
-            95,
-            0.4472135954999578
-        ],
-        [
-            19,
-            96,
-            0.7698003589195009
-        ],
-        [
-            19,
-            97,
-            0.6666666666666665
-        ],
-        [
-            19,
-            98,
-            0.7745966692414833
-        ],
-        [
-            19,
-            100,
-            0.6324555320336758
-        ],
-        [
-            19,
-            101,
-            0.5590169943749473
-        ],
-        [
-            19,
-            104,
-            1.0
-        ],
-        [
-            19,
-            105,
-            0.7999999999999999
+            0.13442622950819672
         ],
         [
             20,
             0,
-            0.5876607128143644
+            0.0901639344262295
         ],
         [
             20,
             1,
-            0.8277173810054355
+            0.2622950819672131
         ],
         [
             20,
             2,
-            0.6908120777691572
+            0.978688524590164
         ],
         [
             20,
             3,
-            0.5707231679907154
+            0.978688524590164
         ],
         [
             20,
             4,
-            0.3374235910587102
+            0.2622950819672131
         ],
         [
             20,
             5,
-            0.7399127547044878
+            0.978688524590164
         ],
         [
             20,
             6,
-            0.735368004858024
+            0.9098360655737705
         ],
         [
             20,
             7,
-            0.7399127547044883
+            0.978688524590164
         ],
         [
             20,
             8,
-            0.21332997318222696
+            0.2622950819672131
         ],
         [
             20,
             9,
-            0.7257594676980584
+            0.26393442622950825
         ],
         [
             20,
             10,
-            0.7600060053985785
+            0.978688524590164
         ],
         [
             20,
             11,
-            0.7403917704401323
+            0.978688524590164
         ],
         [
             20,
             12,
-            0.6180191481717833
+            0.26393442622950825
         ],
         [
             20,
             13,
-            0.34939211503190104
+            0.978688524590164
         ],
         [
             20,
             14,
-            0.5746612659365838
+            0.978688524590164
         ],
         [
             20,
             15,
-            0.3919759865901132
+            0.2622950819672131
         ],
         [
             20,
             16,
-            0.7821773386138654
+            0.978688524590164
         ],
         [
             20,
             17,
-            0.6328452409491424
+            0.9229508196721311
         ],
         [
             20,
             18,
-            0.581017283951803
+            0.9934426229508196
         ],
         [
             20,
             19,
-            0.5512656338749684
+            0.980327868852459
         ],
         [
             20,
@@ -8672,352 +7786,382 @@
         [
             20,
             21,
-            0.5426320129546006
+            0.9983606557377049
         ],
         [
             20,
             22,
-            0.429631484819795
+            1.0
         ],
         [
             20,
             23,
-            0.33571773248030246
+            1.0
+        ],
+        [
+            20,
+            24,
+            0.9852459016393442
         ],
         [
             20,
             25,
-            0.1733880203142543
+            0.9819672131147541
+        ],
+        [
+            20,
+            26,
+            0.9852459016393442
         ],
         [
             20,
             27,
-            1.0
+            0.9983606557377049
+        ],
+        [
+            20,
+            28,
+            0.9983606557377049
+        ],
+        [
+            20,
+            29,
+            0.9868852459016394
+        ],
+        [
+            20,
+            30,
+            0.9983606557377049
         ],
         [
             20,
             31,
-            0.605288184438665
+            0.9967213114754099
+        ],
+        [
+            20,
+            32,
+            0.9852459016393442
+        ],
+        [
+            20,
+            33,
+            0.9950819672131147
+        ],
+        [
+            20,
+            34,
+            0.9934426229508196
+        ],
+        [
+            20,
+            35,
+            0.9836065573770492
+        ],
+        [
+            20,
+            36,
+            0.9819672131147541
+        ],
+        [
+            20,
+            37,
+            0.9819672131147541
+        ],
+        [
+            20,
+            38,
+            0.9754098360655737
+        ],
+        [
+            20,
+            39,
+            0.978688524590164
+        ],
+        [
+            20,
+            40,
+            0.9836065573770492
+        ],
+        [
+            20,
+            41,
+            0.9983606557377049
+        ],
+        [
+            20,
+            42,
+            0.9950819672131147
+        ],
+        [
+            20,
+            43,
+            0.9983606557377049
         ],
         [
             20,
             44,
-            0.5279540680531329
+            0.9918032786885246
+        ],
+        [
+            20,
+            45,
+            0.9754098360655737
         ],
         [
             20,
             46,
-            0.018843837183134034
+            0.9836065573770492
+        ],
+        [
+            20,
+            47,
+            0.9672131147540983
         ],
         [
             20,
             48,
-            0.6337811001097985
+            0.980327868852459
         ],
         [
             20,
             49,
-            0.7608176376620894
+            0.9836065573770492
+        ],
+        [
+            20,
+            50,
+            0.978688524590164
         ],
         [
             20,
             51,
-            0.7110687823197125
+            0.9918032786885246
         ],
         [
             20,
             52,
-            0.3027033329744559
+            0.9852459016393442
         ],
         [
             20,
             53,
-            0.7714352445168458
+            0.14590163934426226
         ],
         [
             20,
             54,
-            0.7882344470571088
+            0.22622950819672127
         ],
         [
             20,
             55,
-            0.5158608054374759
+            0.20983606557377055
         ],
         [
             20,
             56,
-            0.561645352314298
+            0.2032786885245902
         ],
         [
             20,
             57,
-            0.2290774101860604
+            0.21311475409836067
         ],
         [
             20,
             58,
-            0.5333851668523795
+            0.12950819672131153
         ],
         [
             20,
             59,
-            0.6667811351757049
+            0.042622950819672156
         ],
         [
             20,
             60,
-            0.5544220488432409
+            0.22786885245901645
         ],
         [
             20,
             61,
-            0.782008339206638
+            0.24426229508196717
         ],
         [
             20,
             62,
-            0.07471988492357075
+            0.040983606557377095
         ],
         [
             20,
             63,
-            0.5069873163858972
+            0.040983606557377095
         ],
         [
             20,
             64,
-            0.3577935552584234
+            0.239344262295082
         ],
         [
             20,
             65,
-            0.7113513348061469
+            0.23770491803278693
         ],
         [
             20,
             66,
-            0.16701404063422742
+            0.17868852459016393
         ],
         [
             20,
             67,
-            0.56853895239575
+            0.23278688524590163
         ],
         [
             20,
             68,
-            0.06691114233142935
+            0.1573770491803279
         ],
         [
             20,
             69,
-            0.7377464948843132
+            0.7459016393442623
         ],
         [
             20,
             70,
-            0.7031088067753299
+            0.7459016393442623
         ],
         [
             20,
             71,
-            0.5340145649054935
+            0.7426229508196721
         ],
         [
             20,
             72,
-            0.7562343716474574
+            0.6901639344262296
         ],
         [
             20,
             73,
-            0.25444501310078627
+            0.1754098360655738
         ],
         [
             20,
             74,
-            0.4171219929975563
+            0.7442622950819673
         ],
         [
             20,
             75,
-            0.8952991452991448
-        ],
-        [
-            20,
-            76,
-            0.2636323198273602
-        ],
-        [
-            20,
-            77,
-            0.42774775623975264
-        ],
-        [
-            20,
-            78,
-            0.8954907161803707
-        ],
-        [
-            20,
-            79,
-            0.3696202121033678
-        ],
-        [
-            20,
-            80,
-            0.7800917544849286
-        ],
-        [
-            20,
-            81,
-            0.6499434476679972
-        ],
-        [
-            20,
-            82,
-            0.4604508863857979
-        ],
-        [
-            20,
-            83,
-            0.9481691292762744
-        ],
-        [
-            20,
-            84,
-            0.4682271001182218
-        ],
-        [
-            20,
-            85,
-            0.34731347478416774
-        ],
-        [
-            20,
-            86,
-            0.2233288842774767
-        ],
-        [
-            20,
-            95,
-            0.5773502691896257
-        ],
-        [
-            20,
-            98,
-            1.0
-        ],
-        [
-            20,
-            101,
-            1.0
+            0.12786885245901636
         ],
         [
             21,
             0,
-            0.5611469368381391
+            0.08852459016393444
         ],
         [
             21,
             1,
-            0.6017118801178262
+            0.260655737704918
         ],
         [
             21,
             2,
-            0.5803628197294115
+            0.980327868852459
         ],
         [
             21,
             3,
-            0.38664327468052007
+            0.980327868852459
         ],
         [
             21,
             4,
-            0.3457598070620011
+            0.260655737704918
         ],
         [
             21,
             5,
-            0.36565699105849925
+            0.980327868852459
         ],
         [
             21,
             6,
-            0.3648603167114656
+            0.9114754098360656
         ],
         [
             21,
             7,
-            0.37626452669497834
+            0.980327868852459
         ],
         [
             21,
             8,
-            0.1893456590221429
+            0.260655737704918
         ],
         [
             21,
             9,
-            0.6314067394365128
+            0.2655737704918033
         ],
         [
             21,
             10,
-            0.5133464431391139
+            0.980327868852459
         ],
         [
             21,
             11,
-            0.3701025330300382
+            0.980327868852459
         ],
         [
             21,
             12,
-            0.6288977393842315
+            0.2655737704918033
         ],
         [
             21,
             13,
-            -0.005367996218330222
+            0.980327868852459
         ],
         [
             21,
             14,
-            0.744705338962567
+            0.980327868852459
         ],
         [
             21,
             15,
-            0.06675877943767008
+            0.260655737704918
         ],
         [
             21,
             16,
-            0.5500107218001311
+            0.980327868852459
         ],
         [
             21,
             17,
-            0.49706167665420525
+            0.9245901639344263
         ],
         [
             21,
             18,
-            0.6893126151219368
+            0.9950819672131147
         ],
         [
             21,
             19,
-            0.695266057708542
+            0.9819672131147541
         ],
         [
             21,
             20,
-            0.5426320129546006
+            0.9983606557377049
         ],
         [
             21,
@@ -9027,327 +8171,382 @@
         [
             21,
             22,
-            0.09744118087300699
+            0.9983606557377049
         ],
         [
             21,
             23,
-            -0.007597926134567493
+            0.9983606557377049
+        ],
+        [
+            21,
+            24,
+            0.9868852459016394
         ],
         [
             21,
             25,
-            0.056298719403169564
+            0.980327868852459
+        ],
+        [
+            21,
+            26,
+            0.9868852459016394
+        ],
+        [
+            21,
+            27,
+            1.0
+        ],
+        [
+            21,
+            28,
+            1.0
+        ],
+        [
+            21,
+            29,
+            0.9852459016393442
+        ],
+        [
+            21,
+            30,
+            1.0
         ],
         [
             21,
             31,
-            0.6191642853409365
+            0.9983606557377049
+        ],
+        [
+            21,
+            32,
+            0.9868852459016394
+        ],
+        [
+            21,
+            33,
+            0.9934426229508196
+        ],
+        [
+            21,
+            34,
+            0.9918032786885246
+        ],
+        [
+            21,
+            35,
+            0.9852459016393442
+        ],
+        [
+            21,
+            36,
+            0.980327868852459
+        ],
+        [
+            21,
+            37,
+            0.980327868852459
+        ],
+        [
+            21,
+            38,
+            0.9737704918032787
+        ],
+        [
+            21,
+            39,
+            0.9770491803278688
+        ],
+        [
+            21,
+            40,
+            0.9852459016393442
+        ],
+        [
+            21,
+            41,
+            0.9967213114754099
+        ],
+        [
+            21,
+            42,
+            0.9934426229508196
+        ],
+        [
+            21,
+            43,
+            0.9967213114754099
         ],
         [
             21,
             44,
-            0.7394265522389314
+            0.9901639344262295
+        ],
+        [
+            21,
+            45,
+            0.9737704918032787
         ],
         [
             21,
             46,
-            -0.013380672059507933
+            0.9819672131147541
+        ],
+        [
+            21,
+            47,
+            0.9655737704918033
         ],
         [
             21,
             48,
-            0.40307440917406095
+            0.978688524590164
         ],
         [
             21,
             49,
-            0.4007479723169497
+            0.9819672131147541
+        ],
+        [
+            21,
+            50,
+            0.9770491803278688
         ],
         [
             21,
             51,
-            0.5481309631086673
+            0.9901639344262295
         ],
         [
             21,
             52,
-            -0.009295348533830959
+            0.9836065573770492
         ],
         [
             21,
             53,
-            0.5217351995274047
+            0.1442622950819672
         ],
         [
             21,
             54,
-            0.5201068424563684
+            0.2245901639344262
         ],
         [
             21,
             55,
-            0.309799675628025
+            0.20819672131147537
         ],
         [
             21,
             56,
-            0.4613914879638394
+            0.20163934426229513
         ],
         [
             21,
             57,
-            0.10909180261740532
+            0.2114754098360656
         ],
         [
             21,
             58,
-            0.4442157436031792
+            0.12786885245901636
         ],
         [
             21,
             59,
-            0.6795050958516755
+            0.040983606557377095
         ],
         [
             21,
             60,
-            0.43160575787782174
+            0.22622950819672127
         ],
         [
             21,
             61,
-            0.5241894556577359
+            0.2426229508196721
+        ],
+        [
+            21,
+            62,
+            0.03934426229508192
         ],
         [
             21,
             63,
-            0.36955036896495486
+            0.03934426229508192
         ],
         [
             21,
             64,
-            0.107216385836292
+            0.23770491803278693
         ],
         [
             21,
             65,
-            0.32915536491997116
+            0.23606557377049175
         ],
         [
             21,
             66,
-            -0.006588816930623473
+            0.17704918032786887
         ],
         [
             21,
             67,
-            0.5494454776233867
+            0.23114754098360657
         ],
         [
             21,
             68,
-            0.031082172010650243
+            0.15573770491803274
         ],
         [
             21,
             69,
-            0.3863751183858698
+            0.7475409836065574
         ],
         [
             21,
             70,
-            0.33749174489765393
+            0.7475409836065574
         ],
         [
             21,
             71,
-            0.37992019961255485
+            0.7442622950819673
         ],
         [
             21,
             72,
-            0.4394340738770906
+            0.6918032786885246
         ],
         [
             21,
             73,
-            0.28183678671747003
+            0.17377049180327864
         ],
         [
             21,
             74,
-            0.5998137513535762
+            0.7426229508196721
         ],
         [
             21,
             75,
-            0.45034100140211464
-        ],
-        [
-            21,
-            76,
-            0.21516574145596754
-        ],
-        [
-            21,
-            77,
-            0.5297257466612708
-        ],
-        [
-            21,
-            78,
-            0.45034100140211486
-        ],
-        [
-            21,
-            79,
-            0.33427046548397604
-        ],
-        [
-            21,
-            80,
-            0.21502824253951516
-        ],
-        [
-            21,
-            81,
-            0.39208112103365517
-        ],
-        [
-            21,
-            82,
-            0.2306555233315467
-        ],
-        [
-            21,
-            83,
-            0.4579277041704312
-        ],
-        [
-            21,
-            84,
-            0.7069352132943885
-        ],
-        [
-            21,
-            85,
-            0.2512055594727398
-        ],
-        [
-            21,
-            86,
-            0.16580068899589212
+            0.1262295081967213
         ],
         [
             22,
             0,
-            0.5705408872857092
+            0.0901639344262295
         ],
         [
             22,
             1,
-            0.4165598504331851
+            0.2622950819672131
         ],
         [
             22,
             2,
-            0.4269014271415623
+            0.978688524590164
         ],
         [
             22,
             3,
-            0.18826791988071173
+            0.978688524590164
         ],
         [
             22,
             4,
-            0.2637670269242714
+            0.2622950819672131
         ],
         [
             22,
             5,
-            0.5097846564180384
+            0.978688524590164
         ],
         [
             22,
             6,
-            0.48151664333840466
+            0.9098360655737705
         ],
         [
             22,
             7,
-            0.5097846564180387
+            0.978688524590164
         ],
         [
             22,
             8,
-            0.19176363741825206
+            0.2622950819672131
         ],
         [
             22,
             9,
-            0.4514044508922154
+            0.26393442622950825
         ],
         [
             22,
             10,
-            0.6042986245607924
+            0.978688524590164
         ],
         [
             22,
             11,
-            0.49181334908846325
+            0.978688524590164
         ],
         [
             22,
             12,
-            0.6057576144721192
+            0.26393442622950825
         ],
         [
             22,
             13,
-            0.7726495624290881
+            0.978688524590164
         ],
         [
             22,
             14,
-            0.07580356563802085
+            0.978688524590164
         ],
         [
             22,
             15,
-            0.8386189773954288
+            0.2622950819672131
         ],
         [
             22,
             16,
-            0.39467556350977
+            0.978688524590164
         ],
         [
             22,
             17,
-            0.12561953195613157
+            0.9229508196721311
         ],
         [
             22,
             18,
-            0.06680820173482006
+            0.9934426229508196
         ],
         [
             22,
             19,
-            0.1716647543957647
+            0.980327868852459
         ],
         [
             22,
             20,
-            0.429631484819795
+            1.0
         ],
         [
             22,
             21,
-            0.09744118087300699
+            0.9983606557377049
         ],
         [
             22,
@@ -9357,332 +8556,382 @@
         [
             22,
             23,
-            0.7471536096723044
+            1.0
+        ],
+        [
+            22,
+            24,
+            0.9852459016393442
         ],
         [
             22,
             25,
-            0.5166522699331266
+            0.9819672131147541
+        ],
+        [
+            22,
+            26,
+            0.9852459016393442
+        ],
+        [
+            22,
+            27,
+            0.9983606557377049
+        ],
+        [
+            22,
+            28,
+            0.9983606557377049
+        ],
+        [
+            22,
+            29,
+            0.9868852459016394
+        ],
+        [
+            22,
+            30,
+            0.9983606557377049
         ],
         [
             22,
             31,
-            0.2367597065049865
+            0.9967213114754099
+        ],
+        [
+            22,
+            32,
+            0.9852459016393442
+        ],
+        [
+            22,
+            33,
+            0.9950819672131147
+        ],
+        [
+            22,
+            34,
+            0.9934426229508196
+        ],
+        [
+            22,
+            35,
+            0.9836065573770492
+        ],
+        [
+            22,
+            36,
+            0.9819672131147541
+        ],
+        [
+            22,
+            37,
+            0.9819672131147541
+        ],
+        [
+            22,
+            38,
+            0.9754098360655737
+        ],
+        [
+            22,
+            39,
+            0.978688524590164
+        ],
+        [
+            22,
+            40,
+            0.9836065573770492
+        ],
+        [
+            22,
+            41,
+            0.9983606557377049
+        ],
+        [
+            22,
+            42,
+            0.9950819672131147
+        ],
+        [
+            22,
+            43,
+            0.9983606557377049
         ],
         [
             22,
             44,
-            0.2796441723710375
+            0.9918032786885246
+        ],
+        [
+            22,
+            45,
+            0.9754098360655737
         ],
         [
             22,
             46,
-            0.31854676701854284
+            0.9836065573770492
+        ],
+        [
+            22,
+            47,
+            0.9672131147540983
         ],
         [
             22,
             48,
-            0.3921501490609633
+            0.980327868852459
         ],
         [
             22,
             49,
-            0.5441146060029758
+            0.9836065573770492
+        ],
+        [
+            22,
+            50,
+            0.978688524590164
         ],
         [
             22,
             51,
-            0.4391236200595292
+            0.9918032786885246
         ],
         [
             22,
             52,
-            0.6787722191643806
+            0.9852459016393442
         ],
         [
             22,
             53,
-            0.48567619705117776
+            0.14590163934426226
         ],
         [
             22,
             54,
-            0.5085388749710523
+            0.22622950819672127
         ],
         [
             22,
             55,
-            0.7057409344773885
+            0.20983606557377055
         ],
         [
             22,
             56,
-            0.690993539561976
+            0.2032786885245902
         ],
         [
             22,
             57,
-            0.5600522414226432
+            0.21311475409836067
         ],
         [
             22,
             58,
-            0.595944252486587
+            0.12950819672131153
         ],
         [
             22,
             59,
-            0.5784822258948306
+            0.042622950819672156
         ],
         [
             22,
             60,
-            0.6913326467027627
+            0.22786885245901645
         ],
         [
             22,
             61,
-            0.5030141810505884
+            0.24426229508196717
         ],
         [
             22,
             62,
-            0.39110058136742837
+            0.040983606557377095
         ],
         [
             22,
             63,
-            0.5129039343834969
+            0.040983606557377095
         ],
         [
             22,
             64,
-            0.7681661641973107
+            0.239344262295082
         ],
         [
             22,
             65,
-            0.5064180827688534
+            0.23770491803278693
         ],
         [
             22,
             66,
-            0.29131040150636256
+            0.17868852459016393
         ],
         [
             22,
             67,
-            0.6008968877702303
+            0.23278688524590163
         ],
         [
             22,
             68,
-            0.28930422804359207
+            0.1573770491803279
         ],
         [
             22,
             69,
-            0.5250882691993974
+            0.7459016393442623
         ],
         [
             22,
             70,
-            0.5804906566705917
+            0.7459016393442623
         ],
         [
             22,
             71,
-            0.709568166328381
+            0.7426229508196721
         ],
         [
             22,
             72,
-            0.5213488005139442
+            0.6901639344262296
         ],
         [
             22,
             73,
-            0.19764064288978733
+            0.1754098360655738
         ],
         [
             22,
             74,
-            0.16187781529083387
+            0.7442622950819673
         ],
         [
             22,
             75,
-            0.35887028128263654
-        ],
-        [
-            22,
-            76,
-            0.20020650495950226
-        ],
-        [
-            22,
-            77,
-            0.4696150793422086
-        ],
-        [
-            22,
-            78,
-            0.35496478698597667
-        ],
-        [
-            22,
-            79,
-            0.40920761243896236
-        ],
-        [
-            22,
-            80,
-            0.322758016144041
-        ],
-        [
-            22,
-            81,
-            0.28850446049541273
-        ],
-        [
-            22,
-            82,
-            0.12014076573099625
-        ],
-        [
-            22,
-            83,
-            0.3625318393663303
-        ],
-        [
-            22,
-            84,
-            -0.024538122595279533
-        ],
-        [
-            22,
-            85,
-            0.35218115673609623
-        ],
-        [
-            22,
-            86,
-            0.3357573690514622
+            0.12786885245901636
         ],
         [
             23,
             0,
-            0.51377401137897
+            0.0901639344262295
         ],
         [
             23,
             1,
-            0.3424968287799702
+            0.2622950819672131
         ],
         [
             23,
             2,
-            0.3739153282594999
+            0.978688524590164
         ],
         [
             23,
             3,
-            0.15152122850850722
+            0.978688524590164
         ],
         [
             23,
             4,
-            0.10097156181908831
+            0.2622950819672131
         ],
         [
             23,
             5,
-            0.4220667965509516
+            0.978688524590164
         ],
         [
             23,
             6,
-            0.3959336863957457
+            0.9098360655737705
         ],
         [
             23,
             7,
-            0.4220667965509512
+            0.978688524590164
         ],
         [
             23,
             8,
-            0.052986212363762844
+            0.2622950819672131
         ],
         [
             23,
             9,
-            0.3601913413321177
+            0.26393442622950825
         ],
         [
             23,
             10,
-            0.42230944459670294
+            0.978688524590164
         ],
         [
             23,
             11,
-            0.4044138021056562
+            0.978688524590164
         ],
         [
             23,
             12,
-            0.49388908832043377
+            0.26393442622950825
         ],
         [
             23,
             13,
-            0.9390681851574992
+            0.978688524590164
         ],
         [
             23,
             14,
-            0.05383167779540021
+            0.978688524590164
         ],
         [
             23,
             15,
-            0.6000394216234113
+            0.2622950819672131
         ],
         [
             23,
             16,
-            0.35543513114847725
+            0.978688524590164
         ],
         [
             23,
             17,
-            0.14554005156871647
+            0.9229508196721311
         ],
         [
             23,
             18,
-            0.047416846691136424
+            0.9934426229508196
         ],
         [
             23,
             19,
-            0.16990414367745854
+            0.980327868852459
         ],
         [
             23,
             20,
-            0.33571773248030246
+            1.0
         ],
         [
             23,
             21,
-            -0.007597926134567493
+            0.9983606557377049
         ],
         [
             23,
             22,
-            0.7471536096723044
+            1.0
         ],
         [
             23,
@@ -9691,293 +8940,383 @@
         ],
         [
             23,
+            24,
+            0.9852459016393442
+        ],
+        [
+            23,
             25,
-            0.3612686573799396
+            0.9819672131147541
+        ],
+        [
+            23,
+            26,
+            0.9852459016393442
+        ],
+        [
+            23,
+            27,
+            0.9983606557377049
+        ],
+        [
+            23,
+            28,
+            0.9983606557377049
+        ],
+        [
+            23,
+            29,
+            0.9868852459016394
+        ],
+        [
+            23,
+            30,
+            0.9983606557377049
         ],
         [
             23,
             31,
-            0.1873003530680309
+            0.9967213114754099
+        ],
+        [
+            23,
+            32,
+            0.9852459016393442
+        ],
+        [
+            23,
+            33,
+            0.9950819672131147
+        ],
+        [
+            23,
+            34,
+            0.9934426229508196
+        ],
+        [
+            23,
+            35,
+            0.9836065573770492
+        ],
+        [
+            23,
+            36,
+            0.9819672131147541
+        ],
+        [
+            23,
+            37,
+            0.9819672131147541
+        ],
+        [
+            23,
+            38,
+            0.9754098360655737
+        ],
+        [
+            23,
+            39,
+            0.978688524590164
+        ],
+        [
+            23,
+            40,
+            0.9836065573770492
+        ],
+        [
+            23,
+            41,
+            0.9983606557377049
+        ],
+        [
+            23,
+            42,
+            0.9950819672131147
+        ],
+        [
+            23,
+            43,
+            0.9983606557377049
         ],
         [
             23,
             44,
-            0.20257529572733432
+            0.9918032786885246
+        ],
+        [
+            23,
+            45,
+            0.9754098360655737
         ],
         [
             23,
             46,
-            0.04837236977919666
+            0.9836065573770492
+        ],
+        [
+            23,
+            47,
+            0.9672131147540983
         ],
         [
             23,
             48,
-            0.30873929570902714
+            0.980327868852459
         ],
         [
             23,
             49,
-            0.42538528505220985
+            0.9836065573770492
+        ],
+        [
+            23,
+            50,
+            0.978688524590164
         ],
         [
             23,
             51,
-            0.3588721504586567
+            0.9918032786885246
         ],
         [
             23,
             52,
-            0.8360454540973505
+            0.9852459016393442
         ],
         [
             23,
             53,
-            0.3868367741753892
+            0.14590163934426226
         ],
         [
             23,
             54,
-            0.38943462479984214
+            0.22622950819672127
         ],
         [
             23,
             55,
-            0.5497102209718047
+            0.20983606557377055
         ],
         [
             23,
             56,
-            0.5496941960840582
+            0.2032786885245902
         ],
         [
             23,
             57,
-            0.32692468856086204
+            0.21311475409836067
         ],
         [
             23,
             58,
-            0.5202482707123366
+            0.12950819672131153
         ],
         [
             23,
             59,
-            0.4633403751161498
+            0.042622950819672156
         ],
         [
             23,
             60,
-            0.5497102209718051
+            0.22786885245901645
         ],
         [
             23,
             61,
-            0.3912999880520132
+            0.24426229508196717
         ],
         [
             23,
             62,
-            0.1490271805728858
+            0.040983606557377095
         ],
         [
             23,
             63,
-            0.40687616127774484
+            0.040983606557377095
         ],
         [
             23,
             64,
-            0.6522493256649947
+            0.239344262295082
         ],
         [
             23,
             65,
-            0.3911490180062329
+            0.23770491803278693
         ],
         [
             23,
             66,
-            0.15812359753709934
+            0.17868852459016393
         ],
         [
             23,
             67,
-            0.47138615430592057
+            0.23278688524590163
         ],
         [
             23,
             68,
-            0.09124342745733326
+            0.1573770491803279
         ],
         [
             23,
             69,
-            0.4109889934999873
+            0.7459016393442623
         ],
         [
             23,
             70,
-            0.4594599048512422
+            0.7459016393442623
         ],
         [
             23,
             71,
-            0.5555385275082075
+            0.7426229508196721
         ],
         [
             23,
             72,
-            0.4078079222015236
+            0.6901639344262296
         ],
         [
             23,
             73,
-            0.24549048274731483
+            0.1754098360655738
         ],
         [
             23,
             74,
-            0.16187781529083392
+            0.7442622950819673
         ],
         [
             23,
             75,
-            0.35887028128263676
-        ],
-        [
-            23,
-            76,
-            0.20020650495950207
-        ],
-        [
-            23,
-            77,
-            0.4696150793422089
-        ],
-        [
-            23,
-            78,
-            0.35496478698597705
-        ],
-        [
-            23,
-            79,
-            0.4092076124389627
-        ],
-        [
-            23,
-            80,
-            0.3227580161440406
-        ],
-        [
-            23,
-            81,
-            0.2388537346290343
-        ],
-        [
-            23,
-            82,
-            0.12014076573099595
-        ],
-        [
-            23,
-            83,
-            0.3800584750330461
-        ],
-        [
-            23,
-            84,
-            0.21225476044916708
-        ],
-        [
-            23,
-            85,
-            0.3521811567360959
-        ],
-        [
-            23,
-            86,
-            0.30370632184980423
-        ],
-        [
-            23,
-            95,
-            0.30151134457776374
-        ],
-        [
-            23,
-            97,
-            0.23904572186687878
-        ],
-        [
-            23,
-            98,
-            0.5222329678670934
-        ],
-        [
-            23,
-            100,
-            0.42640143271122094
-        ],
-        [
-            23,
-            104,
-            0.3333333333333333
-        ],
-        [
-            23,
-            105,
-            0.2721655269759088
+            0.12786885245901636
         ],
         [
             24,
             0,
-            0.5
+            0.07540983606557372
+        ],
+        [
+            24,
+            1,
+            0.2475409836065574
         ],
         [
             24,
             2,
-            0.39528470752104744
+            0.9934426229508196
         ],
         [
             24,
             3,
-            0.12500000000000003
+            0.9934426229508196
         ],
         [
             24,
             4,
-            0.5
+            0.2475409836065574
         ],
         [
             24,
             5,
-            0.3162277660168379
+            0.9934426229508196
+        ],
+        [
+            24,
+            6,
+            0.9245901639344263
         ],
         [
             24,
             7,
-            0.3162277660168379
+            0.9934426229508196
+        ],
+        [
+            24,
+            8,
+            0.2475409836065574
+        ],
+        [
+            24,
+            9,
+            0.2524590163934426
+        ],
+        [
+            24,
+            10,
+            0.9934426229508196
+        ],
+        [
+            24,
+            11,
+            0.9934426229508196
+        ],
+        [
+            24,
+            12,
+            0.2524590163934426
+        ],
+        [
+            24,
+            13,
+            0.9934426229508196
+        ],
+        [
+            24,
+            14,
+            0.9934426229508196
         ],
         [
             24,
             15,
-            0.6666666666666666
+            0.2475409836065574
         ],
         [
             24,
             16,
-            0.3162277660168379
+            0.9934426229508196
         ],
         [
             24,
             17,
-            0.14285714285714288
+            0.9114754098360656
+        ],
+        [
+            24,
+            18,
+            0.9819672131147541
         ],
         [
             24,
             19,
-            0.4879500364742666
+            0.9950819672131147
+        ],
+        [
+            24,
+            20,
+            0.9852459016393442
+        ],
+        [
+            24,
+            21,
+            0.9868852459016394
+        ],
+        [
+            24,
+            22,
+            0.9852459016393442
+        ],
+        [
+            24,
+            23,
+            0.9852459016393442
         ],
         [
             24,
@@ -9987,272 +9326,382 @@
         [
             24,
             25,
-            -0.0928476690885259
+            0.9672131147540983
         ],
         [
             24,
             26,
-            0.28867513459481287
+            1.0
         ],
         [
             24,
             27,
-            0.24845199749997662
+            0.9868852459016394
         ],
         [
             24,
             28,
-            0.28867513459481287
+            0.9868852459016394
         ],
         [
             24,
             29,
-            0.4842001247062522
+            0.9983606557377049
         ],
         [
             24,
             30,
-            0.6236095644623236
+            0.9868852459016394
         ],
         [
             24,
             31,
-            0.020515248496555446
+            0.9852459016393442
         ],
         [
             24,
             32,
-            0.5491696473652762
+            1.0
         ],
         [
             24,
             33,
-            -0.11111111111111112
+            0.980327868852459
         ],
         [
             24,
             34,
-            0.5491696473652762
+            0.978688524590164
         ],
         [
             24,
             35,
-            0.3333333333333334
+            0.9983606557377049
         ],
         [
             24,
             36,
-            0.45732956038002365
+            0.9934426229508196
         ],
         [
             24,
             37,
-            0.11318329168362205
+            0.9934426229508196
         ],
         [
             24,
             38,
-            0.30508307783296046
+            0.9868852459016394
         ],
         [
             24,
             39,
-            0.5925925925925927
+            0.9901639344262295
         ],
         [
             24,
             40,
-            0.6236095644623237
+            0.9983606557377049
         ],
         [
             24,
             41,
-            0.7878385971583358
+            0.9836065573770492
         ],
         [
             24,
             42,
-            0.28867513459481287
+            0.980327868852459
         ],
         [
             24,
             43,
-            0.7149203529842406
+            0.9836065573770492
         ],
         [
             24,
             44,
-            0.08070002078437537
+            0.9770491803278688
         ],
         [
             24,
             45,
-            0.7149203529842406
+            0.9868852459016394
         ],
         [
             24,
             46,
-            -0.0928476690885259
+            0.9950819672131147
         ],
         [
             24,
             47,
-            0.7878385971583358
+            0.9524590163934427
         ],
         [
             24,
-            89,
-            0.39528470752104744
+            48,
+            0.9918032786885246
         ],
         [
             24,
-            96,
-            0.5
+            49,
+            0.9950819672131147
         ],
         [
             24,
-            97,
-            0.3162277660168379
+            50,
+            0.9901639344262295
         ],
         [
             24,
-            101,
-            0.3162277660168379
+            51,
+            0.9770491803278688
         ],
         [
             24,
-            104,
-            0.39528470752104744
+            52,
+            0.9704918032786886
         ],
         [
             24,
-            105,
-            0.3162277660168379
+            53,
+            0.1311475409836066
+        ],
+        [
+            24,
+            54,
+            0.2114754098360656
+        ],
+        [
+            24,
+            55,
+            0.1983606557377049
+        ],
+        [
+            24,
+            56,
+            0.19180327868852454
+        ],
+        [
+            24,
+            57,
+            0.20163934426229513
+        ],
+        [
+            24,
+            58,
+            0.11475409836065575
+        ],
+        [
+            24,
+            59,
+            0.02786885245901638
+        ],
+        [
+            24,
+            60,
+            0.21311475409836067
+        ],
+        [
+            24,
+            61,
+            0.2295081967213115
+        ],
+        [
+            24,
+            62,
+            0.02622950819672132
+        ],
+        [
+            24,
+            63,
+            0.02622950819672132
+        ],
+        [
+            24,
+            64,
+            0.22786885245901645
+        ],
+        [
+            24,
+            65,
+            0.22295081967213115
+        ],
+        [
+            24,
+            66,
+            0.1672131147540984
+        ],
+        [
+            24,
+            67,
+            0.21803278688524586
+        ],
+        [
+            24,
+            68,
+            0.14590163934426226
+        ],
+        [
+            24,
+            69,
+            0.760655737704918
+        ],
+        [
+            24,
+            70,
+            0.760655737704918
+        ],
+        [
+            24,
+            71,
+            0.7573770491803279
+        ],
+        [
+            24,
+            72,
+            0.7049180327868853
+        ],
+        [
+            24,
+            73,
+            0.16393442622950816
+        ],
+        [
+            24,
+            74,
+            0.7557377049180328
+        ],
+        [
+            24,
+            75,
+            0.139344262295082
         ],
         [
             25,
             0,
-            0.20987699489547598
+            0.1081967213114754
         ],
         [
             25,
             1,
-            0.15703986430467515
+            0.280327868852459
         ],
         [
             25,
             2,
-            0.16610910216324293
+            0.9606557377049181
         ],
         [
             25,
             3,
-            0.03281707314118289
+            0.9606557377049181
         ],
         [
             25,
             4,
-            0.0754235995602094
+            0.280327868852459
         ],
         [
             25,
             5,
-            0.19204554133718937
+            0.9606557377049181
         ],
         [
             25,
             6,
-            0.15934893965109156
+            0.8918032786885246
         ],
         [
             25,
             7,
-            0.19150576261518504
+            0.9606557377049181
         ],
         [
             25,
             8,
-            0.0197547622838507
+            0.280327868852459
         ],
         [
             25,
             9,
-            0.1305766215180346
+            0.28196721311475414
         ],
         [
             25,
             10,
-            0.3177485005667296
+            0.9606557377049181
         ],
         [
             25,
             11,
-            0.16281394544552324
+            0.9606557377049181
         ],
         [
             25,
             12,
-            0.16700529169014308
+            0.28196721311475414
         ],
         [
             25,
             13,
-            0.28256879946778557
+            0.9606557377049181
         ],
         [
             25,
             14,
-            0.06831692322622522
+            0.9606557377049181
         ],
         [
             25,
             15,
-            0.7163395945517217
+            0.280327868852459
         ],
         [
             25,
             16,
-            0.16220167164383925
+            0.9606557377049181
         ],
         [
             25,
             17,
-            -0.001191463742368934
+            0.9049180327868852
         ],
         [
             25,
             18,
-            0.03093320667924764
+            0.9754098360655737
         ],
         [
             25,
             19,
-            0.01159884898743776
+            0.9622950819672131
         ],
         [
             25,
             20,
-            0.1733880203142543
+            0.9819672131147541
         ],
         [
             25,
             21,
-            0.056298719403169564
+            0.980327868852459
         ],
         [
             25,
             22,
-            0.5166522699331266
+            0.9819672131147541
         ],
         [
             25,
             23,
-            0.3612686573799396
+            0.9819672131147541
         ],
         [
             25,
             24,
-            -0.0928476690885259
+            0.9672131147540983
         ],
         [
             25,
@@ -10262,362 +9711,382 @@
         [
             25,
             26,
-            0.11677484162422848
+            0.9672131147540983
         ],
         [
             25,
             27,
-            0.1138550085106623
+            0.980327868852459
         ],
         [
             25,
             28,
-            0.12156613477096621
+            0.980327868852459
         ],
         [
             25,
             29,
-            0.4729467696627822
+            0.9688524590163934
         ],
         [
             25,
             30,
-            0.2148344622118299
+            0.980327868852459
         ],
         [
             25,
             31,
-            0.06780073471555205
+            0.978688524590164
         ],
         [
             25,
             32,
-            -0.17677669529663692
+            0.9672131147540983
         ],
         [
             25,
             33,
-            -0.03580574370197195
+            0.9836065573770492
         ],
         [
             25,
             34,
-            -0.1737020834449128
+            0.9754098360655737
         ],
         [
             25,
             35,
-            -0.24405148745018085
+            0.9655737704918033
         ],
         [
             25,
             36,
-            0.16238586255274196
+            0.9639344262295082
         ],
         [
             25,
             37,
-            -0.1264911064067352
+            0.9639344262295082
         ],
         [
             25,
             38,
-            -0.0898026510133875
+            0.9573770491803278
         ],
         [
             25,
             39,
-            -0.092847669088526
+            0.9672131147540983
         ],
         [
             25,
             40,
-            -0.14002800840280102
+            0.9655737704918033
         ],
         [
             25,
             41,
-            -0.07283570407292303
+            0.980327868852459
         ],
         [
             25,
             42,
-            0.12156613477096621
+            0.9836065573770492
         ],
         [
             25,
             43,
-            -0.13130643285972257
+            0.980327868852459
         ],
         [
             25,
             44,
-            0.049511055339234444
+            0.980327868852459
         ],
         [
             25,
             45,
-            -0.13130643285972257
+            0.9573770491803278
         ],
         [
             25,
             46,
-            0.9080113270615588
+            0.9655737704918033
         ],
         [
             25,
             47,
-            -0.07027283689263071
+            0.9557377049180328
         ],
         [
             25,
             48,
-            0.1412020791437809
+            0.9622950819672131
         ],
         [
             25,
             49,
-            0.36654704807155014
+            0.9655737704918033
+        ],
+        [
+            25,
+            50,
+            0.9606557377049181
         ],
         [
             25,
             51,
-            0.15188275147941446
+            0.9737704918032787
         ],
         [
             25,
             52,
-            0.3961276302462554
+            0.9770491803278688
         ],
         [
             25,
             53,
-            0.2754246748432608
+            0.16393442622950816
         ],
         [
             25,
             54,
-            0.3231436939186752
+            0.24098360655737705
         ],
         [
             25,
             55,
-            0.6986199223263727
+            0.2213114754098361
         ],
         [
             25,
             56,
-            0.4592509600605416
+            0.21475409836065573
         ],
         [
             25,
             57,
-            0.7292034847297477
+            0.22786885245901645
         ],
         [
             25,
             58,
-            0.21755512662921295
+            0.1442622950819672
         ],
         [
             25,
             59,
-            0.33344638002155336
+            0.060655737704918056
         ],
         [
             25,
             60,
-            0.4594950773793081
+            0.2426229508196721
         ],
         [
             25,
             61,
-            0.32415629227020815
+            0.2557377049180328
         ],
         [
             25,
             62,
-            0.6023119612131889
+            0.059016393442622994
         ],
         [
             25,
             63,
-            0.39308754368311305
+            0.059016393442622994
         ],
         [
             25,
             64,
-            0.5603107247253949
+            0.25081967213114753
         ],
         [
             25,
             65,
-            0.3472833937714275
+            0.24918032786885247
         ],
         [
             25,
             66,
-            0.4288664886359749
+            0.1934426229508197
         ],
         [
             25,
             67,
-            0.3596629855064653
+            0.24426229508196717
         ],
         [
             25,
             68,
-            0.4862564591865675
+            0.16885245901639345
         ],
         [
             25,
             69,
-            0.34577019806808074
+            0.7278688524590164
         ],
         [
             25,
             70,
-            0.386205995225849
+            0.7278688524590164
         ],
         [
             25,
             71,
-            0.46015338972211867
+            0.7245901639344262
         ],
         [
             25,
             72,
-            0.3403623935464614
+            0.6721311475409837
         ],
         [
             25,
             73,
-            0.00935139855373222
+            0.18360655737704923
         ],
         [
             25,
             74,
-            -0.030814239057475656
+            0.7262295081967214
         ],
         [
             25,
             75,
-            0.047380842315833
-        ],
-        [
-            25,
-            76,
-            0.08326452535088533
-        ],
-        [
-            25,
-            77,
-            0.0805753204862889
-        ],
-        [
-            25,
-            78,
-            0.046678183498039476
-        ],
-        [
-            25,
-            79,
-            0.07350605457604845
-        ],
-        [
-            25,
-            80,
-            0.057457293325064614
-        ],
-        [
-            25,
-            81,
-            0.12119357448701656
-        ],
-        [
-            25,
-            82,
-            -0.02082279205300753
-        ],
-        [
-            25,
-            83,
-            0.09868876541696521
-        ],
-        [
-            25,
-            84,
-            -0.02425883673714219
-        ],
-        [
-            25,
-            85,
-            0.05995352128425513
-        ],
-        [
-            25,
-            86,
-            0.3378656589654642
+            0.14590163934426226
         ],
         [
             26,
             0,
-            0.6324555320336758
+            0.07540983606557372
+        ],
+        [
+            26,
+            1,
+            0.2475409836065574
         ],
         [
             26,
             2,
-            0.7999999999999999
+            0.9934426229508196
         ],
         [
             26,
             3,
-            0.3952847075210473
+            0.9934426229508196
         ],
         [
             26,
             4,
-            0.6324555320336758
+            0.2475409836065574
         ],
         [
             26,
             5,
-            1.0
+            0.9934426229508196
+        ],
+        [
+            26,
+            6,
+            0.9245901639344263
         ],
         [
             26,
             7,
-            1.0
+            0.9934426229508196
+        ],
+        [
+            26,
+            8,
+            0.2475409836065574
+        ],
+        [
+            26,
+            9,
+            0.2524590163934426
+        ],
+        [
+            26,
+            10,
+            0.9934426229508196
+        ],
+        [
+            26,
+            11,
+            0.9934426229508196
+        ],
+        [
+            26,
+            12,
+            0.2524590163934426
+        ],
+        [
+            26,
+            13,
+            0.9934426229508196
+        ],
+        [
+            26,
+            14,
+            0.9934426229508196
         ],
         [
             26,
             15,
-            0.2721655269759087
+            0.2475409836065574
         ],
         [
             26,
             16,
-            1.0
+            0.9934426229508196
         ],
         [
             26,
             17,
-            0.3779644730092272
+            0.9114754098360656
+        ],
+        [
+            26,
+            18,
+            0.9819672131147541
         ],
         [
             26,
             19,
-            0.7745966692414834
+            0.9950819672131147
+        ],
+        [
+            26,
+            20,
+            0.9852459016393442
+        ],
+        [
+            26,
+            21,
+            0.9868852459016394
+        ],
+        [
+            26,
+            22,
+            0.9852459016393442
+        ],
+        [
+            26,
+            23,
+            0.9852459016393442
         ],
         [
             26,
             24,
-            0.28867513459481287
+            1.0
         ],
         [
             26,
             25,
-            0.11677484162422848
+            0.9672131147540983
         ],
         [
             26,
@@ -10627,242 +10096,382 @@
         [
             26,
             27,
-            0.9229582069908976
+            0.9868852459016394
         ],
         [
             26,
             28,
-            1.0
+            0.9868852459016394
         ],
         [
             26,
             29,
-            0.5083042452524145
+            0.9983606557377049
         ],
         [
             26,
             30,
-            0.4720774754816656
+            0.9868852459016394
         ],
         [
             26,
             31,
-            0.6527777777777779
+            0.9852459016393442
         ],
         [
             26,
             32,
-            0.5331139899831832
+            1.0
         ],
         [
             26,
             33,
-            -0.12562244381357193
+            0.980327868852459
         ],
         [
             26,
             34,
-            0.5256574830378469
+            0.978688524590164
         ],
         [
             26,
             35,
-            0.8660254037844388
+            0.9983606557377049
         ],
         [
             26,
             36,
-            0.4950737714883371
+            0.9934426229508196
         ],
         [
             26,
             37,
-            0.4483136495254827
+            0.9934426229508196
         ],
         [
             26,
             38,
-            0.39130434782608703
+            0.9868852459016394
         ],
         [
             26,
             39,
-            0.11226255234242713
+            0.9901639344262295
         ],
         [
             26,
             40,
-            0.47207747548166573
+            0.9983606557377049
         ],
         [
             26,
             41,
-            0.22742941307367087
+            0.9836065573770492
         ],
         [
             26,
             42,
-            1.0
+            0.980327868852459
         ],
         [
             26,
             43,
-            0.4037864265436241
+            0.9836065573770492
         ],
         [
             26,
             44,
-            0.22634157113224265
+            0.9770491803278688
         ],
         [
             26,
             45,
-            0.4037864265436241
+            0.9868852459016394
         ],
         [
             26,
             46,
-            0.11677484162422846
+            0.9950819672131147
         ],
         [
             26,
             47,
-            0.21908902300206634
+            0.9524590163934427
         ],
         [
             26,
-            89,
-            0.7999999999999999
+            48,
+            0.9918032786885246
         ],
         [
             26,
-            95,
-            1.0
+            49,
+            0.9950819672131147
         ],
         [
             26,
-            96,
-            0.6324555320336758
+            50,
+            0.9901639344262295
         ],
         [
             26,
-            97,
-            1.0
+            51,
+            0.9770491803278688
         ],
         [
             26,
-            98,
-            0.6324555320336759
+            52,
+            0.9704918032786886
         ],
         [
             26,
-            100,
-            1.0
+            53,
+            0.1311475409836066
         ],
         [
             26,
-            101,
-            1.0
+            54,
+            0.2114754098360656
         ],
         [
             26,
-            104,
-            0.7999999999999999
+            55,
+            0.1983606557377049
         ],
         [
             26,
-            105,
-            1.0
+            56,
+            0.19180327868852454
+        ],
+        [
+            26,
+            57,
+            0.20163934426229513
+        ],
+        [
+            26,
+            58,
+            0.11475409836065575
+        ],
+        [
+            26,
+            59,
+            0.02786885245901638
+        ],
+        [
+            26,
+            60,
+            0.21311475409836067
+        ],
+        [
+            26,
+            61,
+            0.2295081967213115
+        ],
+        [
+            26,
+            62,
+            0.02622950819672132
+        ],
+        [
+            26,
+            63,
+            0.02622950819672132
+        ],
+        [
+            26,
+            64,
+            0.22786885245901645
+        ],
+        [
+            26,
+            65,
+            0.22295081967213115
+        ],
+        [
+            26,
+            66,
+            0.1672131147540984
+        ],
+        [
+            26,
+            67,
+            0.21803278688524586
+        ],
+        [
+            26,
+            68,
+            0.14590163934426226
+        ],
+        [
+            26,
+            69,
+            0.760655737704918
+        ],
+        [
+            26,
+            70,
+            0.760655737704918
+        ],
+        [
+            26,
+            71,
+            0.7573770491803279
+        ],
+        [
+            26,
+            72,
+            0.7049180327868853
+        ],
+        [
+            26,
+            73,
+            0.16393442622950816
+        ],
+        [
+            26,
+            74,
+            0.7557377049180328
+        ],
+        [
+            26,
+            75,
+            0.139344262295082
         ],
         [
             27,
             0,
-            0.48795003647426655
+            0.08852459016393444
         ],
         [
             27,
             1,
-            1.0
+            0.260655737704918
         ],
         [
             27,
             2,
-            0.7142857142857144
+            0.980327868852459
         ],
         [
             27,
             3,
-            0.529150262212918
+            0.980327868852459
         ],
         [
             27,
             4,
-            0.48795003647426655
+            0.260655737704918
         ],
         [
             27,
             5,
-            1.0
+            0.980327868852459
         ],
         [
             27,
             6,
-            1.0
+            0.9114754098360656
         ],
         [
             27,
             7,
-            1.0
+            0.980327868852459
+        ],
+        [
+            27,
+            8,
+            0.260655737704918
         ],
         [
             27,
             9,
-            0.5
+            0.2655737704918033
         ],
         [
             27,
             10,
-            0.5
+            0.980327868852459
         ],
         [
             27,
             11,
-            1.0
+            0.980327868852459
+        ],
+        [
+            27,
+            12,
+            0.2655737704918033
+        ],
+        [
+            27,
+            13,
+            0.980327868852459
+        ],
+        [
+            27,
+            14,
+            0.980327868852459
+        ],
+        [
+            27,
+            15,
+            0.260655737704918
         ],
         [
             27,
             16,
-            1.0
+            0.980327868852459
         ],
         [
             27,
             17,
-            0.5163977794943222
+            0.9245901639344263
+        ],
+        [
+            27,
+            18,
+            0.9950819672131147
         ],
         [
             27,
             19,
-            0.5590169943749473
+            0.9819672131147541
         ],
         [
             27,
             20,
+            0.9983606557377049
+        ],
+        [
+            27,
+            21,
             1.0
+        ],
+        [
+            27,
+            22,
+            0.9983606557377049
+        ],
+        [
+            27,
+            23,
+            0.9983606557377049
         ],
         [
             27,
             24,
-            0.24845199749997662
+            0.9868852459016394
         ],
         [
             27,
             25,
-            0.1138550085106623
+            0.980327868852459
         ],
         [
             27,
             26,
-            0.9229582069908976
+            0.9868852459016394
         ],
         [
             27,
@@ -10872,277 +10481,382 @@
         [
             27,
             28,
-            0.9229582069908974
+            1.0
         ],
         [
             27,
             29,
-            0.4236592728681619
+            0.9852459016393442
         ],
         [
             27,
             30,
-            0.41785544701867244
+            1.0
         ],
         [
             27,
             31,
-            0.7772119669423792
+            0.9983606557377049
         ],
         [
             27,
             32,
-            0.47756693294091923
+            0.9868852459016394
         ],
         [
             27,
             33,
-            -0.085183541999992
+            0.9934426229508196
         ],
         [
             27,
             34,
-            0.47756693294091923
+            0.9918032786885246
         ],
         [
             27,
             35,
-            0.7977240352174657
+            0.9852459016393442
         ],
         [
             27,
             36,
-            0.4330127018922194
+            0.980327868852459
         ],
         [
             27,
             37,
-            0.595538971576728
+            0.980327868852459
         ],
         [
             27,
             38,
-            0.37047928681747416
+            0.9737704918032787
         ],
         [
             27,
             39,
-            0.09245003270420488
+            0.9770491803278688
         ],
         [
             27,
             40,
-            0.42497294818489695
+            0.9852459016393442
         ],
         [
             27,
             41,
-            0.21821789023599245
+            0.9967213114754099
         ],
         [
             27,
             42,
-            0.9229582069908974
+            0.9934426229508196
         ],
         [
             27,
             43,
-            0.36115755925730775
+            0.9967213114754099
         ],
         [
             27,
             44,
-            0.42640143271122094
+            0.9901639344262295
         ],
         [
             27,
             45,
-            0.36115755925730775
+            0.9737704918032787
         ],
         [
             27,
             46,
-            0.11385500851066237
+            0.9819672131147541
         ],
         [
             27,
             47,
-            0.21821789023599245
+            0.9655737704918033
+        ],
+        [
+            27,
+            48,
+            0.978688524590164
         ],
         [
             27,
             49,
-            1.0
+            0.9819672131147541
         ],
         [
             27,
             50,
-            0.5773502691896257
+            0.9770491803278688
+        ],
+        [
+            27,
+            51,
+            0.9901639344262295
+        ],
+        [
+            27,
+            52,
+            0.9836065573770492
         ],
         [
             27,
             53,
-            1.0
+            0.1442622950819672
         ],
         [
             27,
             54,
-            1.0
+            0.2245901639344262
+        ],
+        [
+            27,
+            55,
+            0.20819672131147537
         ],
         [
             27,
             56,
-            0.4472135954999579
+            0.20163934426229513
+        ],
+        [
+            27,
+            57,
+            0.2114754098360656
+        ],
+        [
+            27,
+            58,
+            0.12786885245901636
         ],
         [
             27,
             59,
-            0.5773502691896257
+            0.040983606557377095
         ],
         [
             27,
             60,
-            0.4472135954999579
+            0.22622950819672127
         ],
         [
             27,
             61,
-            1.0
+            0.2426229508196721
+        ],
+        [
+            27,
+            62,
+            0.03934426229508192
         ],
         [
             27,
             63,
-            0.5773502691896257
+            0.03934426229508192
+        ],
+        [
+            27,
+            64,
+            0.23770491803278693
         ],
         [
             27,
             65,
-            0.50709255283711
+            0.23606557377049175
         ],
         [
             27,
             66,
-            0.5773502691896257
+            0.17704918032786887
         ],
         [
             27,
             67,
-            0.7745966692414834
+            0.23114754098360657
         ],
         [
             27,
-            89,
-            0.8257228238447704
+            68,
+            0.15573770491803274
         ],
         [
             27,
-            95,
-            1.0
+            69,
+            0.7475409836065574
         ],
         [
             27,
-            96,
-            0.46249729006288015
+            70,
+            0.7475409836065574
         ],
         [
             27,
-            97,
-            1.0
+            71,
+            0.7442622950819673
         ],
         [
             27,
-            98,
-            0.5976143046671969
+            72,
+            0.6918032786885246
         ],
         [
             27,
-            100,
-            0.7905694150420948
+            73,
+            0.17377049180327864
         ],
         [
             27,
-            101,
-            1.0
+            74,
+            0.7426229508196721
         ],
         [
             27,
-            104,
-            0.7999999999999999
-        ],
-        [
-            27,
-            105,
-            1.0
+            75,
+            0.1262295081967213
         ],
         [
             28,
             0,
-            0.6324555320336758
+            0.08852459016393444
+        ],
+        [
+            28,
+            1,
+            0.260655737704918
         ],
         [
             28,
             2,
-            0.7999999999999999
+            0.980327868852459
         ],
         [
             28,
             3,
-            0.3952847075210473
+            0.980327868852459
         ],
         [
             28,
             4,
-            0.6324555320336758
+            0.260655737704918
         ],
         [
             28,
             5,
-            1.0
+            0.980327868852459
+        ],
+        [
+            28,
+            6,
+            0.9114754098360656
         ],
         [
             28,
             7,
-            1.0
+            0.980327868852459
+        ],
+        [
+            28,
+            8,
+            0.260655737704918
+        ],
+        [
+            28,
+            9,
+            0.2655737704918033
+        ],
+        [
+            28,
+            10,
+            0.980327868852459
+        ],
+        [
+            28,
+            11,
+            0.980327868852459
+        ],
+        [
+            28,
+            12,
+            0.2655737704918033
+        ],
+        [
+            28,
+            13,
+            0.980327868852459
+        ],
+        [
+            28,
+            14,
+            0.980327868852459
         ],
         [
             28,
             15,
-            0.2721655269759087
+            0.260655737704918
         ],
         [
             28,
             16,
-            1.0
+            0.980327868852459
         ],
         [
             28,
             17,
-            0.3779644730092272
+            0.9245901639344263
+        ],
+        [
+            28,
+            18,
+            0.9950819672131147
         ],
         [
             28,
             19,
-            0.7745966692414834
+            0.9819672131147541
+        ],
+        [
+            28,
+            20,
+            0.9983606557377049
+        ],
+        [
+            28,
+            21,
+            1.0
+        ],
+        [
+            28,
+            22,
+            0.9983606557377049
+        ],
+        [
+            28,
+            23,
+            0.9983606557377049
         ],
         [
             28,
             24,
-            0.28867513459481287
+            0.9868852459016394
         ],
         [
             28,
             25,
-            0.12156613477096621
+            0.980327868852459
         ],
         [
             28,
             26,
-            1.0
+            0.9868852459016394
         ],
         [
             28,
             27,
-            0.9229582069908974
+            1.0
         ],
         [
             28,
@@ -11152,217 +10866,382 @@
         [
             28,
             29,
-            0.49811675413689865
+            0.9852459016393442
         ],
         [
             28,
             30,
-            0.46291004988627554
+            1.0
         ],
         [
             28,
             31,
-            0.6527777777777779
+            0.9983606557377049
         ],
         [
             28,
             32,
-            0.5256574830378469
+            0.9868852459016394
         ],
         [
             28,
             33,
-            -0.12562244381357193
+            0.9934426229508196
         ],
         [
             28,
             34,
-            0.5256574830378469
+            0.9918032786885246
         ],
         [
             28,
             35,
-            0.8660254037844388
+            0.9852459016393442
         ],
         [
             28,
             36,
-            0.4950737714883371
+            0.980327868852459
         ],
         [
             28,
             37,
-            0.4483136495254827
+            0.980327868852459
         ],
         [
             28,
             38,
-            0.39130434782608703
+            0.9737704918032787
         ],
         [
             28,
             39,
-            0.11226255234242713
+            0.9770491803278688
         ],
         [
             28,
             40,
-            0.46291004988627565
+            0.9852459016393442
         ],
         [
             28,
             41,
-            0.22742941307367087
+            0.9967213114754099
         ],
         [
             28,
             42,
-            1.0
+            0.9934426229508196
         ],
         [
             28,
             43,
-            0.4037864265436241
+            0.9967213114754099
         ],
         [
             28,
             44,
-            0.22634157113224265
+            0.9901639344262295
         ],
         [
             28,
             45,
-            0.4037864265436241
+            0.9737704918032787
         ],
         [
             28,
             46,
-            0.1215661347709662
+            0.9819672131147541
         ],
         [
             28,
             47,
-            0.22742941307367087
+            0.9655737704918033
         ],
         [
             28,
-            89,
-            0.7999999999999999
+            48,
+            0.978688524590164
         ],
         [
             28,
-            95,
-            1.0
+            49,
+            0.9819672131147541
         ],
         [
             28,
-            96,
-            0.6324555320336758
+            50,
+            0.9770491803278688
         ],
         [
             28,
-            97,
-            1.0
+            51,
+            0.9901639344262295
         ],
         [
             28,
-            98,
-            0.6324555320336759
+            52,
+            0.9836065573770492
         ],
         [
             28,
-            100,
-            1.0
+            53,
+            0.1442622950819672
         ],
         [
             28,
-            101,
-            1.0
+            54,
+            0.2245901639344262
         ],
         [
             28,
-            104,
-            0.7999999999999999
+            55,
+            0.20819672131147537
         ],
         [
             28,
-            105,
-            1.0
+            56,
+            0.20163934426229513
+        ],
+        [
+            28,
+            57,
+            0.2114754098360656
+        ],
+        [
+            28,
+            58,
+            0.12786885245901636
+        ],
+        [
+            28,
+            59,
+            0.040983606557377095
+        ],
+        [
+            28,
+            60,
+            0.22622950819672127
+        ],
+        [
+            28,
+            61,
+            0.2426229508196721
+        ],
+        [
+            28,
+            62,
+            0.03934426229508192
+        ],
+        [
+            28,
+            63,
+            0.03934426229508192
+        ],
+        [
+            28,
+            64,
+            0.23770491803278693
+        ],
+        [
+            28,
+            65,
+            0.23606557377049175
+        ],
+        [
+            28,
+            66,
+            0.17704918032786887
+        ],
+        [
+            28,
+            67,
+            0.23114754098360657
+        ],
+        [
+            28,
+            68,
+            0.15573770491803274
+        ],
+        [
+            28,
+            69,
+            0.7475409836065574
+        ],
+        [
+            28,
+            70,
+            0.7475409836065574
+        ],
+        [
+            28,
+            71,
+            0.7442622950819673
+        ],
+        [
+            28,
+            72,
+            0.6918032786885246
+        ],
+        [
+            28,
+            73,
+            0.17377049180327864
+        ],
+        [
+            28,
+            74,
+            0.7426229508196721
+        ],
+        [
+            28,
+            75,
+            0.1262295081967213
         ],
         [
             29,
             0,
-            1.0
+            0.0770491803278689
+        ],
+        [
+            29,
+            1,
+            0.24918032786885247
         ],
         [
             29,
             2,
-            0.6708203932499368
+            0.9918032786885246
         ],
         [
             29,
             3,
-            0.288675134594813
+            0.9918032786885246
         ],
         [
             29,
             4,
-            1.0
+            0.24918032786885247
         ],
         [
             29,
             5,
-            0.5590169943749475
+            0.9918032786885246
+        ],
+        [
+            29,
+            6,
+            0.9229508196721311
         ],
         [
             29,
             7,
-            0.5590169943749475
+            0.9918032786885246
+        ],
+        [
+            29,
+            8,
+            0.24918032786885247
+        ],
+        [
+            29,
+            9,
+            0.25081967213114753
+        ],
+        [
+            29,
+            10,
+            0.9918032786885246
+        ],
+        [
+            29,
+            11,
+            0.9918032786885246
+        ],
+        [
+            29,
+            12,
+            0.25081967213114753
+        ],
+        [
+            29,
+            13,
+            0.9918032786885246
+        ],
+        [
+            29,
+            14,
+            0.9918032786885246
         ],
         [
             29,
             15,
-            0.5393598899705935
+            0.24918032786885247
         ],
         [
             29,
             16,
-            0.5590169943749475
+            0.9918032786885246
         ],
         [
             29,
             17,
-            0.25
+            0.9098360655737705
+        ],
+        [
+            29,
+            18,
+            0.980327868852459
         ],
         [
             29,
             19,
-            0.7637626158259734
+            0.9934426229508196
+        ],
+        [
+            29,
+            20,
+            0.9868852459016394
+        ],
+        [
+            29,
+            21,
+            0.9852459016393442
+        ],
+        [
+            29,
+            22,
+            0.9868852459016394
+        ],
+        [
+            29,
+            23,
+            0.9868852459016394
         ],
         [
             29,
             24,
-            0.4842001247062522
+            0.9983606557377049
         ],
         [
             29,
             25,
-            0.4729467696627822
+            0.9688524590163934
         ],
         [
             29,
             26,
-            0.5083042452524145
+            0.9983606557377049
         ],
         [
             29,
             27,
-            0.4236592728681619
+            0.9852459016393442
         ],
         [
             29,
             28,
-            0.49811675413689865
+            0.9852459016393442
         ],
         [
             29,
@@ -11372,257 +11251,382 @@
         [
             29,
             30,
-            0.5325124418027843
+            0.9852459016393442
         ],
         [
             29,
             31,
-            0.22510108414730307
+            0.9836065573770492
         ],
         [
             29,
             32,
-            0.820782681668123
+            0.9983606557377049
         ],
         [
             29,
             33,
-            0.1324532357065044
+            0.9819672131147541
         ],
         [
             29,
             34,
-            0.813421253311189
+            0.980327868852459
         ],
         [
             29,
             35,
-            0.5789473684210527
+            0.9967213114754099
         ],
         [
             29,
             36,
-            0.6653754265107288
+            0.9950819672131147
         ],
         [
             29,
             37,
-            0.5892556509887895
+            0.9950819672131147
         ],
         [
             29,
             38,
-            0.8666666666666668
+            0.9885245901639345
         ],
         [
             29,
             39,
-            0.31127150873973364
+            0.9918032786885246
         ],
         [
             29,
             40,
-            0.8207677342949545
+            0.9967213114754099
         ],
         [
             29,
             41,
-            0.31200964472696996
+            0.9852459016393442
         ],
         [
             29,
             42,
-            0.49811675413689877
+            0.9819672131147541
         ],
         [
             29,
             43,
-            0.7825855808712294
+            0.9852459016393442
         ],
         [
             29,
             44,
-            0.357006415771281
+            0.978688524590164
         ],
         [
             29,
             45,
-            0.7825855808712294
+            0.9885245901639345
         ],
         [
             29,
             46,
-            0.47294676966278226
+            0.9967213114754099
         ],
         [
             29,
             47,
-            0.2867696673382023
+            0.9540983606557377
+        ],
+        [
+            29,
+            48,
+            0.9934426229508196
         ],
         [
             29,
             49,
-            0.39477101697586137
+            0.9967213114754099
         ],
         [
             29,
             50,
-            -0.23354968324845696
+            0.9918032786885246
+        ],
+        [
+            29,
+            51,
+            0.978688524590164
+        ],
+        [
+            29,
+            52,
+            0.9721311475409836
         ],
         [
             29,
             53,
-            0.39477101697586137
+            0.13278688524590165
         ],
         [
             29,
             54,
-            0.39477101697586137
+            0.21311475409836067
+        ],
+        [
+            29,
+            55,
+            0.19999999999999996
         ],
         [
             29,
             56,
-            0.2724746304565331
+            0.1934426229508197
+        ],
+        [
+            29,
+            57,
+            0.2032786885245902
+        ],
+        [
+            29,
+            58,
+            0.11639344262295082
         ],
         [
             29,
             59,
-            0.17766726362967522
+            0.02950819672131144
         ],
         [
             29,
             60,
-            0.2724746304565331
+            0.21475409836065573
         ],
         [
             29,
             61,
-            0.39477101697586137
+            0.23114754098360657
+        ],
+        [
+            29,
+            62,
+            0.02786885245901638
         ],
         [
             29,
             63,
-            0.17766726362967522
+            0.02786885245901638
+        ],
+        [
+            29,
+            64,
+            0.2295081967213115
         ],
         [
             29,
             65,
-            0.39477101697586137
+            0.2245901639344262
         ],
         [
             29,
             66,
-            -0.23354968324845696
+            0.16885245901639345
         ],
         [
             29,
-            89,
-            0.46442036401282405
+            67,
+            0.21967213114754103
         ],
         [
             29,
-            96,
-            0.8401680504168055
+            68,
+            0.14754098360655743
         ],
         [
             29,
-            97,
-            0.5345224838248488
+            69,
+            0.759016393442623
         ],
         [
             29,
-            101,
-            0.42008402520840304
+            70,
+            0.759016393442623
         ],
         [
             29,
-            104,
-            0.7905694150420948
+            71,
+            0.7557377049180328
         ],
         [
             29,
-            105,
-            0.6324555320336758
+            72,
+            0.7032786885245902
+        ],
+        [
+            29,
+            73,
+            0.16557377049180333
+        ],
+        [
+            29,
+            74,
+            0.7573770491803279
+        ],
+        [
+            29,
+            75,
+            0.14098360655737707
         ],
         [
             30,
             0,
-            0.5
+            0.08852459016393444
+        ],
+        [
+            30,
+            1,
+            0.260655737704918
         ],
         [
             30,
             2,
-            0.39528470752104744
+            0.980327868852459
         ],
         [
             30,
             3,
-            0.12500000000000003
+            0.980327868852459
         ],
         [
             30,
             4,
-            0.5
+            0.260655737704918
         ],
         [
             30,
             5,
-            0.3162277660168379
+            0.980327868852459
+        ],
+        [
+            30,
+            6,
+            0.9114754098360656
         ],
         [
             30,
             7,
-            0.3162277660168379
+            0.980327868852459
+        ],
+        [
+            30,
+            8,
+            0.260655737704918
+        ],
+        [
+            30,
+            9,
+            0.2655737704918033
+        ],
+        [
+            30,
+            10,
+            0.980327868852459
+        ],
+        [
+            30,
+            11,
+            0.980327868852459
+        ],
+        [
+            30,
+            12,
+            0.2655737704918033
+        ],
+        [
+            30,
+            13,
+            0.980327868852459
+        ],
+        [
+            30,
+            14,
+            0.980327868852459
         ],
         [
             30,
             15,
-            0.6666666666666666
+            0.260655737704918
         ],
         [
             30,
             16,
-            0.3162277660168379
+            0.980327868852459
         ],
         [
             30,
             17,
-            0.14285714285714288
+            0.9245901639344263
+        ],
+        [
+            30,
+            18,
+            0.9950819672131147
         ],
         [
             30,
             19,
-            0.4879500364742666
+            0.9819672131147541
+        ],
+        [
+            30,
+            20,
+            0.9983606557377049
+        ],
+        [
+            30,
+            21,
+            1.0
+        ],
+        [
+            30,
+            22,
+            0.9983606557377049
+        ],
+        [
+            30,
+            23,
+            0.9983606557377049
         ],
         [
             30,
             24,
-            0.6236095644623236
+            0.9868852459016394
         ],
         [
             30,
             25,
-            0.2148344622118299
+            0.980327868852459
         ],
         [
             30,
             26,
-            0.4720774754816656
+            0.9868852459016394
         ],
         [
             30,
             27,
-            0.41785544701867244
+            1.0
         ],
         [
             30,
             28,
-            0.46291004988627554
+            1.0
         ],
         [
             30,
             29,
-            0.5325124418027843
+            0.9852459016393442
         ],
         [
             30,
@@ -11632,272 +11636,382 @@
         [
             30,
             31,
-            0.09651100402393101
+            0.9983606557377049
         ],
         [
             30,
             32,
-            0.5198334821596408
+            0.9868852459016394
         ],
         [
             30,
             33,
-            0.08494119857293761
+            0.9934426229508196
         ],
         [
             30,
             34,
-            0.4982515077587706
+            0.9918032786885246
         ],
         [
             30,
             35,
-            0.40089186286863643
+            0.9852459016393442
         ],
         [
             30,
             36,
-            0.7333587976225692
+            0.980327868852459
         ],
         [
             30,
             37,
-            0.1112468401110025
+            0.980327868852459
         ],
         [
             30,
             38,
-            0.4252964776724257
+            0.9737704918032787
         ],
         [
             30,
             39,
-            0.46028324996028624
+            0.9770491803278688
         ],
         [
             30,
             40,
-            0.6263736263736263
+            0.9852459016393442
         ],
         [
             30,
             41,
-            0.4913036844405173
+            0.9967213114754099
         ],
         [
             30,
             42,
-            0.46291004988627554
+            0.9934426229508196
         ],
         [
             30,
             43,
-            0.7352060597618597
+            0.9967213114754099
         ],
         [
             30,
             44,
-            0.06675015657623452
+            0.9901639344262295
         ],
         [
             30,
             45,
-            0.7352060597618597
+            0.9737704918032787
         ],
         [
             30,
             46,
-            0.2148344622118299
+            0.9819672131147541
         ],
         [
             30,
             47,
-            0.46409548089225694
+            0.9655737704918033
         ],
         [
             30,
-            89,
-            0.39528470752104744
+            48,
+            0.978688524590164
         ],
         [
             30,
-            96,
-            0.5
+            49,
+            0.9819672131147541
         ],
         [
             30,
-            97,
-            0.3162277660168379
+            50,
+            0.9770491803278688
         ],
         [
             30,
-            101,
-            0.3162277660168379
+            51,
+            0.9901639344262295
         ],
         [
             30,
-            104,
-            0.39528470752104744
+            52,
+            0.9836065573770492
         ],
         [
             30,
-            105,
-            0.3162277660168379
+            53,
+            0.1442622950819672
+        ],
+        [
+            30,
+            54,
+            0.2245901639344262
+        ],
+        [
+            30,
+            55,
+            0.20819672131147537
+        ],
+        [
+            30,
+            56,
+            0.20163934426229513
+        ],
+        [
+            30,
+            57,
+            0.2114754098360656
+        ],
+        [
+            30,
+            58,
+            0.12786885245901636
+        ],
+        [
+            30,
+            59,
+            0.040983606557377095
+        ],
+        [
+            30,
+            60,
+            0.22622950819672127
+        ],
+        [
+            30,
+            61,
+            0.2426229508196721
+        ],
+        [
+            30,
+            62,
+            0.03934426229508192
+        ],
+        [
+            30,
+            63,
+            0.03934426229508192
+        ],
+        [
+            30,
+            64,
+            0.23770491803278693
+        ],
+        [
+            30,
+            65,
+            0.23606557377049175
+        ],
+        [
+            30,
+            66,
+            0.17704918032786887
+        ],
+        [
+            30,
+            67,
+            0.23114754098360657
+        ],
+        [
+            30,
+            68,
+            0.15573770491803274
+        ],
+        [
+            30,
+            69,
+            0.7475409836065574
+        ],
+        [
+            30,
+            70,
+            0.7475409836065574
+        ],
+        [
+            30,
+            71,
+            0.7442622950819673
+        ],
+        [
+            30,
+            72,
+            0.6918032786885246
+        ],
+        [
+            30,
+            73,
+            0.17377049180327864
+        ],
+        [
+            30,
+            74,
+            0.7426229508196721
+        ],
+        [
+            30,
+            75,
+            0.1262295081967213
         ],
         [
             31,
             0,
-            0.5867597240198822
+            0.08688524590163937
         ],
         [
             31,
             1,
-            0.6524318068267971
+            0.25901639344262295
         ],
         [
             31,
             2,
-            0.6746888216547782
+            0.9819672131147541
         ],
         [
             31,
             3,
-            0.45749653318138056
+            0.9819672131147541
         ],
         [
             31,
             4,
-            0.3357058893372323
+            0.25901639344262295
         ],
         [
             31,
             5,
-            0.539600239558513
+            0.9819672131147541
         ],
         [
             31,
             6,
-            0.5145835548336041
+            0.9131147540983606
         ],
         [
             31,
             7,
-            0.5396268105801126
+            0.9819672131147541
         ],
         [
             31,
             8,
-            0.1994078008101592
+            0.25901639344262295
         ],
         [
             31,
             9,
-            0.5944357334293789
+            0.26721311475409837
         ],
         [
             31,
             10,
-            0.5647801816483201
+            0.9819672131147541
         ],
         [
             31,
             11,
-            0.5193112478808601
+            0.9819672131147541
         ],
         [
             31,
             12,
-            0.5709077718057288
+            0.26721311475409837
         ],
         [
             31,
             13,
-            0.2127489569944044
+            0.9819672131147541
         ],
         [
             31,
             14,
-            0.7873278207195984
+            0.9819672131147541
         ],
         [
             31,
             15,
-            0.195110640267748
+            0.25901639344262295
         ],
         [
             31,
             16,
-            0.684848598180402
+            0.9819672131147541
         ],
         [
             31,
             17,
-            0.5805762109370033
+            0.9262295081967213
         ],
         [
             31,
             18,
-            0.7185482932113774
+            0.9967213114754099
         ],
         [
             31,
             19,
-            0.6496840925012893
+            0.9836065573770492
         ],
         [
             31,
             20,
-            0.605288184438665
+            0.9967213114754099
         ],
         [
             31,
             21,
-            0.6191642853409365
+            0.9983606557377049
         ],
         [
             31,
             22,
-            0.2367597065049865
+            0.9967213114754099
         ],
         [
             31,
             23,
-            0.1873003530680309
+            0.9967213114754099
         ],
         [
             31,
             24,
-            0.020515248496555446
+            0.9852459016393442
         ],
         [
             31,
             25,
-            0.06780073471555205
+            0.978688524590164
         ],
         [
             31,
             26,
-            0.6527777777777779
+            0.9852459016393442
         ],
         [
             31,
             27,
-            0.7772119669423792
+            0.9983606557377049
         ],
         [
             31,
             28,
-            0.6527777777777779
+            0.9983606557377049
         ],
         [
             31,
             29,
-            0.22510108414730307
+            0.9836065573770492
         ],
         [
             31,
             30,
-            0.09651100402393101
+            0.9983606557377049
         ],
         [
             31,
@@ -11907,452 +12021,382 @@
         [
             31,
             32,
-            0.22634157113224274
+            0.9852459016393442
         ],
         [
             31,
             33,
-            -0.027116307227332024
+            0.9918032786885246
         ],
         [
             31,
             34,
-            0.22634157113224274
+            0.9901639344262295
         ],
         [
             31,
             35,
-            0.6782343280546951
+            0.9836065573770492
         ],
         [
             31,
             36,
-            0.04166666666666667
+            0.978688524590164
         ],
         [
             31,
             37,
-            0.5932958789676529
+            0.978688524590164
         ],
         [
             31,
             38,
-            0.26967994498529696
+            0.9721311475409836
         ],
         [
             31,
             39,
-            -0.1272937693043289
+            0.9754098360655737
         ],
         [
             31,
             40,
-            0.16867477123499666
+            0.9836065573770492
         ],
         [
             31,
             41,
-            -0.0860078077570234
+            0.9950819672131147
         ],
         [
             31,
             42,
-            0.6527777777777779
+            0.9918032786885246
         ],
         [
             31,
             43,
-            0.10001653302482982
+            0.9950819672131147
         ],
         [
             31,
             44,
-            0.8010710580158935
+            0.9885245901639345
         ],
         [
             31,
             45,
-            0.10001653302482982
+            0.9721311475409836
         ],
         [
             31,
             46,
-            0.06419364740540222
+            0.980327868852459
         ],
         [
             31,
             47,
-            -0.0860078077570234
+            0.9639344262295082
         ],
         [
             31,
             48,
-            0.5796138737028416
+            0.9770491803278688
         ],
         [
             31,
             49,
-            0.6946928551806679
+            0.980327868852459
         ],
         [
             31,
             50,
-            0.4770599615316209
+            0.9754098360655737
         ],
         [
             31,
             51,
-            0.6530320124256694
+            0.9885245901639345
         ],
         [
             31,
             52,
-            0.1671463956718534
+            0.9819672131147541
         ],
         [
             31,
             53,
-            0.6877619765887935
+            0.14262295081967213
         ],
         [
             31,
             54,
-            0.7007004756305579
+            0.22295081967213115
         ],
         [
             31,
             55,
-            0.443812360022392
+            0.2065573770491803
         ],
         [
             31,
             56,
-            0.5133184439423685
+            0.19999999999999996
         ],
         [
             31,
             57,
-            0.1053599429286665
+            0.20983606557377055
         ],
         [
             31,
             58,
-            0.5130856767551647
+            0.1262295081967213
         ],
         [
             31,
             59,
-            0.6736524127263145
+            0.03934426229508192
         ],
         [
             31,
             60,
-            0.511325995321613
+            0.2245901639344262
         ],
         [
             31,
             61,
-            0.6947410550097296
+            0.24098360655737705
         ],
         [
             31,
             62,
-            0.04312271891658416
+            0.03770491803278686
         ],
         [
             31,
             63,
-            0.5017437066658404
+            0.03770491803278686
         ],
         [
             31,
             64,
-            0.24425716286583435
+            0.23606557377049175
         ],
         [
             31,
             65,
-            0.5615860447959994
+            0.2344262295081967
         ],
         [
             31,
             66,
-            0.10198328474636399
+            0.1754098360655738
         ],
         [
             31,
             67,
-            0.618498595089551
+            0.2295081967213115
         ],
         [
             31,
             68,
-            0.0813523005451957
+            0.15409836065573768
         ],
         [
             31,
             69,
-            0.6598772338361155
+            0.7491803278688525
         ],
         [
             31,
             70,
-            0.5845418435266074
+            0.7491803278688525
         ],
         [
             31,
             71,
-            0.4853667490000888
+            0.7459016393442623
         ],
         [
             31,
             72,
-            0.6810667472704788
+            0.6934426229508197
         ],
         [
             31,
             73,
-            0.24582754544427393
+            0.17213114754098358
         ],
         [
             31,
             74,
-            0.6661920649654863
+            0.740983606557377
         ],
         [
             31,
             75,
-            0.5413390485524624
-        ],
-        [
-            31,
-            76,
-            0.346102626727885
-        ],
-        [
-            31,
-            77,
-            0.40908350901657886
-        ],
-        [
-            31,
-            78,
-            0.5505387951222553
-        ],
-        [
-            31,
-            79,
-            0.36069557494875876
-        ],
-        [
-            31,
-            80,
-            0.2997018811488428
-        ],
-        [
-            31,
-            81,
-            0.4417982377304587
-        ],
-        [
-            31,
-            82,
-            0.2037697700075005
-        ],
-        [
-            31,
-            83,
-            0.5590892730920617
-        ],
-        [
-            31,
-            84,
-            0.8044163417795342
-        ],
-        [
-            31,
-            85,
-            0.2762825248058982
-        ],
-        [
-            31,
-            86,
-            0.25369504653545316
-        ],
-        [
-            31,
-            88,
-            1.0
-        ],
-        [
-            31,
-            89,
-            0.8864052604279185
-        ],
-        [
-            31,
-            90,
-            1.0
-        ],
-        [
-            31,
-            92,
-            1.0
-        ],
-        [
-            31,
-            93,
-            1.0
-        ],
-        [
-            31,
-            94,
-            1.0
-        ],
-        [
-            31,
-            95,
-            0.6546536707079771
-        ],
-        [
-            31,
-            96,
-            0.4432026302139592
-        ],
-        [
-            31,
-            97,
-            1.0
-        ],
-        [
-            31,
-            98,
-            0.2182178902359923
-        ],
-        [
-            31,
-            99,
-            1.0
-        ],
-        [
-            31,
-            100,
-            1.0
-        ],
-        [
-            31,
-            101,
-            0.8918825850158448
-        ],
-        [
-            31,
-            104,
-            0.7302967433402214
-        ],
-        [
-            31,
-            105,
-            1.0
-        ],
-        [
-            31,
-            112,
-            1.0
-        ],
-        [
-            31,
-            121,
-            1.0
+            0.12459016393442623
         ],
         [
             32,
             0,
-            0.7905694150420948
+            0.07540983606557372
+        ],
+        [
+            32,
+            1,
+            0.2475409836065574
         ],
         [
             32,
             2,
-            1.0
+            0.9934426229508196
         ],
         [
             32,
             3,
-            0.3162277660168379
+            0.9934426229508196
         ],
         [
             32,
             4,
-            0.7905694150420948
+            0.2475409836065574
         ],
         [
             32,
             5,
-            0.7999999999999999
+            0.9934426229508196
+        ],
+        [
+            32,
+            6,
+            0.9245901639344263
         ],
         [
             32,
             7,
-            0.7999999999999999
+            0.9934426229508196
+        ],
+        [
+            32,
+            8,
+            0.2475409836065574
+        ],
+        [
+            32,
+            9,
+            0.2524590163934426
+        ],
+        [
+            32,
+            10,
+            0.9934426229508196
+        ],
+        [
+            32,
+            11,
+            0.9934426229508196
+        ],
+        [
+            32,
+            12,
+            0.2524590163934426
+        ],
+        [
+            32,
+            13,
+            0.9934426229508196
+        ],
+        [
+            32,
+            14,
+            0.9934426229508196
         ],
         [
             32,
             15,
-            0.3333333333333333
+            0.2475409836065574
         ],
         [
             32,
             16,
-            0.7999999999999999
+            0.9934426229508196
         ],
         [
             32,
             17,
-            0.29277002188455997
+            0.9114754098360656
+        ],
+        [
+            32,
+            18,
+            0.9819672131147541
         ],
         [
             32,
             19,
-            1.0
+            0.9950819672131147
+        ],
+        [
+            32,
+            20,
+            0.9852459016393442
+        ],
+        [
+            32,
+            21,
+            0.9868852459016394
+        ],
+        [
+            32,
+            22,
+            0.9852459016393442
+        ],
+        [
+            32,
+            23,
+            0.9852459016393442
         ],
         [
             32,
             24,
-            0.5491696473652762
+            1.0
         ],
         [
             32,
             25,
-            -0.17677669529663692
+            0.9672131147540983
         ],
         [
             32,
             26,
-            0.5331139899831832
+            1.0
         ],
         [
             32,
             27,
-            0.47756693294091923
+            0.9868852459016394
         ],
         [
             32,
             28,
-            0.5256574830378469
+            0.9868852459016394
         ],
         [
             32,
             29,
-            0.820782681668123
+            0.9983606557377049
         ],
         [
             32,
             30,
-            0.5198334821596408
+            0.9868852459016394
         ],
         [
             32,
             31,
-            0.22634157113224274
+            0.9852459016393442
         ],
         [
             32,
@@ -12362,167 +12406,382 @@
         [
             32,
             33,
-            0.04928640580901451
+            0.980327868852459
         ],
         [
             32,
             34,
-            1.0
+            0.978688524590164
         ],
         [
             32,
             35,
-            0.476910483238266
+            0.9983606557377049
         ],
         [
             32,
             36,
-            0.710081334771074
+            0.9934426229508196
         ],
         [
             32,
             37,
-            0.6255774501577783
+            0.9934426229508196
         ],
         [
             32,
             38,
-            0.7562449037944323
+            0.9868852459016394
         ],
         [
             32,
             39,
-            0.390199486285854
+            0.9901639344262295
         ],
         [
             32,
             40,
-            0.8855094489202158
+            0.9983606557377049
         ],
         [
             32,
             41,
-            0.43265704458219684
+            0.9836065573770492
         ],
         [
             32,
             42,
-            0.5256574830378469
+            0.980327868852459
         ],
         [
             32,
             43,
-            0.7681550050616364
+            0.9836065573770492
         ],
         [
             32,
             44,
-            0.5614035087719299
+            0.9770491803278688
         ],
         [
             32,
             45,
-            0.7681550050616364
+            0.9868852459016394
         ],
         [
             32,
             46,
-            -0.17677669529663687
+            0.9950819672131147
         ],
         [
             32,
             47,
-            0.4109609335312651
+            0.9524590163934427
         ],
         [
             32,
-            89,
-            1.0
+            48,
+            0.9918032786885246
         ],
         [
             32,
-            95,
-            0.6324555320336759
+            49,
+            0.9950819672131147
         ],
         [
             32,
-            96,
-            0.7905694150420948
+            50,
+            0.9901639344262295
         ],
         [
             32,
-            97,
-            0.7999999999999999
+            51,
+            0.9770491803278688
         ],
         [
             32,
-            98,
-            1.0
+            52,
+            0.9704918032786886
         ],
         [
             32,
-            100,
-            0.6324555320336759
+            53,
+            0.1311475409836066
         ],
         [
             32,
-            101,
-            0.7999999999999999
+            54,
+            0.2114754098360656
         ],
         [
             32,
-            104,
-            1.0
+            55,
+            0.1983606557377049
         ],
         [
             32,
-            105,
-            0.7999999999999999
+            56,
+            0.19180327868852454
+        ],
+        [
+            32,
+            57,
+            0.20163934426229513
+        ],
+        [
+            32,
+            58,
+            0.11475409836065575
+        ],
+        [
+            32,
+            59,
+            0.02786885245901638
+        ],
+        [
+            32,
+            60,
+            0.21311475409836067
+        ],
+        [
+            32,
+            61,
+            0.2295081967213115
+        ],
+        [
+            32,
+            62,
+            0.02622950819672132
+        ],
+        [
+            32,
+            63,
+            0.02622950819672132
+        ],
+        [
+            32,
+            64,
+            0.22786885245901645
+        ],
+        [
+            32,
+            65,
+            0.22295081967213115
+        ],
+        [
+            32,
+            66,
+            0.1672131147540984
+        ],
+        [
+            32,
+            67,
+            0.21803278688524586
+        ],
+        [
+            32,
+            68,
+            0.14590163934426226
+        ],
+        [
+            32,
+            69,
+            0.760655737704918
+        ],
+        [
+            32,
+            70,
+            0.760655737704918
+        ],
+        [
+            32,
+            71,
+            0.7573770491803279
+        ],
+        [
+            32,
+            72,
+            0.7049180327868853
+        ],
+        [
+            32,
+            73,
+            0.16393442622950816
+        ],
+        [
+            32,
+            74,
+            0.7557377049180328
+        ],
+        [
+            32,
+            75,
+            0.139344262295082
+        ],
+        [
+            33,
+            0,
+            0.09508196721311479
+        ],
+        [
+            33,
+            1,
+            0.26393442622950825
+        ],
+        [
+            33,
+            2,
+            0.9737704918032787
+        ],
+        [
+            33,
+            3,
+            0.9737704918032787
+        ],
+        [
+            33,
+            4,
+            0.26393442622950825
+        ],
+        [
+            33,
+            5,
+            0.9737704918032787
+        ],
+        [
+            33,
+            6,
+            0.9049180327868852
+        ],
+        [
+            33,
+            7,
+            0.9737704918032787
+        ],
+        [
+            33,
+            8,
+            0.26393442622950825
+        ],
+        [
+            33,
+            9,
+            0.2655737704918033
+        ],
+        [
+            33,
+            10,
+            0.9737704918032787
+        ],
+        [
+            33,
+            11,
+            0.9737704918032787
+        ],
+        [
+            33,
+            12,
+            0.2655737704918033
+        ],
+        [
+            33,
+            13,
+            0.9737704918032787
+        ],
+        [
+            33,
+            14,
+            0.9737704918032787
+        ],
+        [
+            33,
+            15,
+            0.26393442622950825
+        ],
+        [
+            33,
+            16,
+            0.9737704918032787
+        ],
+        [
+            33,
+            17,
+            0.9180327868852459
+        ],
+        [
+            33,
+            18,
+            0.9885245901639345
+        ],
+        [
+            33,
+            19,
+            0.9754098360655737
+        ],
+        [
+            33,
+            20,
+            0.9950819672131147
+        ],
+        [
+            33,
+            21,
+            0.9934426229508196
+        ],
+        [
+            33,
+            22,
+            0.9950819672131147
+        ],
+        [
+            33,
+            23,
+            0.9950819672131147
         ],
         [
             33,
             24,
-            -0.11111111111111112
+            0.980327868852459
         ],
         [
             33,
             25,
-            -0.03580574370197195
+            0.9836065573770492
         ],
         [
             33,
             26,
-            -0.12562244381357193
+            0.980327868852459
         ],
         [
             33,
             27,
-            -0.085183541999992
+            0.9934426229508196
         ],
         [
             33,
             28,
-            -0.12562244381357193
+            0.9934426229508196
         ],
         [
             33,
             29,
-            0.1324532357065044
+            0.9819672131147541
         ],
         [
             33,
             30,
-            0.08494119857293761
+            0.9934426229508196
         ],
         [
             33,
             31,
-            -0.027116307227332024
+            0.9918032786885246
         ],
         [
             33,
             32,
-            0.04928640580901451
+            0.980327868852459
         ],
         [
             33,
@@ -12532,172 +12791,382 @@
         [
             33,
             34,
-            0.04928640580901448
+            0.9918032786885246
         ],
         [
             33,
             35,
-            -0.08494119857293761
+            0.9819672131147541
         ],
         [
             33,
             36,
-            -1.4332917616497526e-17
+            0.980327868852459
         ],
         [
             33,
             37,
-            0.03003757045930556
+            0.980327868852459
         ],
         [
             33,
             38,
-            0.1420143204993453
+            0.9737704918032787
         ],
         [
             33,
             39,
-            0.20672455764868072
+            0.9836065573770492
         ],
         [
             33,
             40,
-            0.0815016078203043
+            0.9819672131147541
         ],
         [
             33,
             41,
-            -0.09759000729485338
+            0.9967213114754099
         ],
         [
             33,
             42,
-            -0.12562244381357193
+            0.9934426229508196
         ],
         [
             33,
             43,
-            0.125622443813572
+            0.9967213114754099
         ],
         [
             33,
             44,
-            0.16205093088804104
+            0.9967213114754099
         ],
         [
             33,
             45,
-            0.125622443813572
+            0.9737704918032787
         ],
         [
             33,
             46,
-            -0.035805743701971995
+            0.9819672131147541
         ],
         [
             33,
             47,
-            -0.09759000729485338
+            0.9721311475409836
+        ],
+        [
+            33,
+            48,
+            0.978688524590164
+        ],
+        [
+            33,
+            49,
+            0.9819672131147541
+        ],
+        [
+            33,
+            50,
+            0.9770491803278688
+        ],
+        [
+            33,
+            51,
+            0.9901639344262295
+        ],
+        [
+            33,
+            52,
+            0.9836065573770492
+        ],
+        [
+            33,
+            53,
+            0.15081967213114755
+        ],
+        [
+            33,
+            54,
+            0.23114754098360657
+        ],
+        [
+            33,
+            55,
+            0.2114754098360656
+        ],
+        [
+            33,
+            56,
+            0.20491803278688525
+        ],
+        [
+            33,
+            57,
+            0.21475409836065573
+        ],
+        [
+            33,
+            58,
+            0.13442622950819672
+        ],
+        [
+            33,
+            59,
+            0.04754098360655734
+        ],
+        [
+            33,
+            60,
+            0.23278688524590163
+        ],
+        [
+            33,
+            61,
+            0.24590163934426235
+        ],
+        [
+            33,
+            62,
+            0.04590163934426228
+        ],
+        [
+            33,
+            63,
+            0.04590163934426228
+        ],
+        [
+            33,
+            64,
+            0.24098360655737705
+        ],
+        [
+            33,
+            65,
+            0.239344262295082
+        ],
+        [
+            33,
+            66,
+            0.180327868852459
+        ],
+        [
+            33,
+            67,
+            0.2344262295081967
+        ],
+        [
+            33,
+            68,
+            0.15901639344262297
+        ],
+        [
+            33,
+            69,
+            0.7442622950819673
+        ],
+        [
+            33,
+            70,
+            0.7442622950819673
+        ],
+        [
+            33,
+            71,
+            0.740983606557377
+        ],
+        [
+            33,
+            72,
+            0.6885245901639344
+        ],
+        [
+            33,
+            73,
+            0.17377049180327864
+        ],
+        [
+            33,
+            74,
+            0.7426229508196721
+        ],
+        [
+            33,
+            75,
+            0.13278688524590165
         ],
         [
             34,
             0,
-            0.7905694150420948
+            0.09672131147540985
+        ],
+        [
+            34,
+            1,
+            0.2655737704918033
         ],
         [
             34,
             2,
-            1.0
+            0.9721311475409836
         ],
         [
             34,
             3,
-            0.3162277660168379
+            0.9721311475409836
         ],
         [
             34,
             4,
-            0.7905694150420948
+            0.2655737704918033
         ],
         [
             34,
             5,
-            0.7999999999999999
+            0.9721311475409836
+        ],
+        [
+            34,
+            6,
+            0.9032786885245901
         ],
         [
             34,
             7,
-            0.7999999999999999
+            0.9721311475409836
+        ],
+        [
+            34,
+            8,
+            0.2655737704918033
+        ],
+        [
+            34,
+            9,
+            0.26721311475409837
+        ],
+        [
+            34,
+            10,
+            0.9721311475409836
+        ],
+        [
+            34,
+            11,
+            0.9721311475409836
+        ],
+        [
+            34,
+            12,
+            0.26721311475409837
+        ],
+        [
+            34,
+            13,
+            0.9721311475409836
+        ],
+        [
+            34,
+            14,
+            0.9721311475409836
         ],
         [
             34,
             15,
-            0.3333333333333333
+            0.2655737704918033
         ],
         [
             34,
             16,
-            0.7999999999999999
+            0.9721311475409836
         ],
         [
             34,
             17,
-            0.29277002188455997
+            0.9163934426229509
+        ],
+        [
+            34,
+            18,
+            0.9868852459016394
         ],
         [
             34,
             19,
-            1.0
+            0.9737704918032787
+        ],
+        [
+            34,
+            20,
+            0.9934426229508196
+        ],
+        [
+            34,
+            21,
+            0.9918032786885246
+        ],
+        [
+            34,
+            22,
+            0.9934426229508196
+        ],
+        [
+            34,
+            23,
+            0.9934426229508196
         ],
         [
             34,
             24,
-            0.5491696473652762
+            0.978688524590164
         ],
         [
             34,
             25,
-            -0.1737020834449128
+            0.9754098360655737
         ],
         [
             34,
             26,
-            0.5256574830378469
+            0.978688524590164
         ],
         [
             34,
             27,
-            0.47756693294091923
+            0.9918032786885246
         ],
         [
             34,
             28,
-            0.5256574830378469
+            0.9918032786885246
         ],
         [
             34,
             29,
-            0.813421253311189
+            0.980327868852459
         ],
         [
             34,
             30,
-            0.4982515077587706
+            0.9918032786885246
         ],
         [
             34,
             31,
-            0.22634157113224274
+            0.9901639344262295
         ],
         [
             34,
             32,
-            1.0
+            0.978688524590164
         ],
         [
             34,
             33,
-            0.04928640580901448
+            0.9918032786885246
         ],
         [
             34,
@@ -12707,217 +13176,382 @@
         [
             34,
             35,
-            0.476910483238266
+            0.980327868852459
         ],
         [
             34,
             36,
-            0.710081334771074
+            0.978688524590164
         ],
         [
             34,
             37,
-            0.6255774501577783
+            0.978688524590164
         ],
         [
             34,
             38,
-            0.7562449037944323
+            0.9721311475409836
         ],
         [
             34,
             39,
-            0.390199486285854
+            0.9754098360655737
         ],
         [
             34,
             40,
-            0.880630571852711
+            0.980327868852459
         ],
         [
             34,
             41,
-            0.43265704458219684
+            0.9950819672131147
         ],
         [
             34,
             42,
-            0.5256574830378469
+            0.9918032786885246
         ],
         [
             34,
             43,
-            0.7681550050616364
+            0.9950819672131147
         ],
         [
             34,
             44,
-            0.5614035087719299
+            0.9885245901639345
         ],
         [
             34,
             45,
-            0.7681550050616364
+            0.9721311475409836
         ],
         [
             34,
             46,
-            -0.17370208344491278
+            0.980327868852459
         ],
         [
             34,
             47,
-            0.43265704458219684
+            0.9639344262295082
         ],
         [
             34,
-            89,
-            1.0
+            48,
+            0.9770491803278688
         ],
         [
             34,
-            95,
-            0.6324555320336759
+            49,
+            0.980327868852459
         ],
         [
             34,
-            96,
-            0.7905694150420948
+            50,
+            0.9754098360655737
         ],
         [
             34,
-            97,
-            0.7999999999999999
+            51,
+            0.9885245901639345
         ],
         [
             34,
-            98,
-            1.0
+            52,
+            0.9918032786885246
         ],
         [
             34,
-            100,
-            0.6324555320336759
+            53,
+            0.15245901639344261
         ],
         [
             34,
-            101,
-            0.7999999999999999
+            54,
+            0.2295081967213115
         ],
         [
             34,
-            104,
-            1.0
+            55,
+            0.21311475409836067
         ],
         [
             34,
-            105,
-            0.7999999999999999
+            56,
+            0.2065573770491803
+        ],
+        [
+            34,
+            57,
+            0.2163934426229508
+        ],
+        [
+            34,
+            58,
+            0.13606557377049178
+        ],
+        [
+            34,
+            59,
+            0.049180327868852514
+        ],
+        [
+            34,
+            60,
+            0.23114754098360657
+        ],
+        [
+            34,
+            61,
+            0.2475409836065574
+        ],
+        [
+            34,
+            62,
+            0.04754098360655734
+        ],
+        [
+            34,
+            63,
+            0.04754098360655734
+        ],
+        [
+            34,
+            64,
+            0.2426229508196721
+        ],
+        [
+            34,
+            65,
+            0.24426229508196717
+        ],
+        [
+            34,
+            66,
+            0.1852459016393443
+        ],
+        [
+            34,
+            67,
+            0.23606557377049175
+        ],
+        [
+            34,
+            68,
+            0.16393442622950816
+        ],
+        [
+            34,
+            69,
+            0.7426229508196721
+        ],
+        [
+            34,
+            70,
+            0.7426229508196721
+        ],
+        [
+            34,
+            71,
+            0.739344262295082
+        ],
+        [
+            34,
+            72,
+            0.6868852459016394
+        ],
+        [
+            34,
+            73,
+            0.17868852459016393
+        ],
+        [
+            34,
+            74,
+            0.740983606557377
+        ],
+        [
+            34,
+            75,
+            0.13442622950819672
         ],
         [
             35,
             0,
-            0.6324555320336758
+            0.0770491803278689
+        ],
+        [
+            35,
+            1,
+            0.24590163934426235
         ],
         [
             35,
             2,
-            0.7999999999999999
+            0.9918032786885246
         ],
         [
             35,
             3,
-            0.3952847075210473
+            0.9918032786885246
         ],
         [
             35,
             4,
-            0.6324555320336758
+            0.24590163934426235
         ],
         [
             35,
             5,
-            1.0
+            0.9918032786885246
+        ],
+        [
+            35,
+            6,
+            0.9229508196721311
         ],
         [
             35,
             7,
-            1.0
+            0.9918032786885246
+        ],
+        [
+            35,
+            8,
+            0.24590163934426235
+        ],
+        [
+            35,
+            9,
+            0.25081967213114753
+        ],
+        [
+            35,
+            10,
+            0.9918032786885246
+        ],
+        [
+            35,
+            11,
+            0.9918032786885246
+        ],
+        [
+            35,
+            12,
+            0.25081967213114753
+        ],
+        [
+            35,
+            13,
+            0.9918032786885246
+        ],
+        [
+            35,
+            14,
+            0.9918032786885246
         ],
         [
             35,
             15,
-            0.2721655269759087
+            0.24590163934426235
         ],
         [
             35,
             16,
-            1.0
+            0.9918032786885246
         ],
         [
             35,
             17,
-            0.3779644730092272
+            0.9098360655737705
+        ],
+        [
+            35,
+            18,
+            0.980327868852459
         ],
         [
             35,
             19,
-            0.7745966692414834
+            0.9934426229508196
+        ],
+        [
+            35,
+            20,
+            0.9836065573770492
+        ],
+        [
+            35,
+            21,
+            0.9852459016393442
+        ],
+        [
+            35,
+            22,
+            0.9836065573770492
+        ],
+        [
+            35,
+            23,
+            0.9836065573770492
         ],
         [
             35,
             24,
-            0.3333333333333334
+            0.9983606557377049
         ],
         [
             35,
             25,
-            -0.24405148745018085
+            0.9655737704918033
         ],
         [
             35,
             26,
-            0.8660254037844388
+            0.9983606557377049
         ],
         [
             35,
             27,
-            0.7977240352174657
+            0.9852459016393442
         ],
         [
             35,
             28,
-            0.8660254037844388
+            0.9852459016393442
         ],
         [
             35,
             29,
-            0.5789473684210527
+            0.9967213114754099
         ],
         [
             35,
             30,
-            0.40089186286863643
+            0.9852459016393442
         ],
         [
             35,
             31,
-            0.6782343280546951
+            0.9836065573770492
         ],
         [
             35,
             32,
-            0.476910483238266
+            0.9983606557377049
         ],
         [
             35,
             33,
-            -0.08494119857293761
+            0.9819672131147541
         ],
         [
             35,
             34,
-            0.476910483238266
+            0.980327868852459
         ],
         [
             35,
@@ -12927,217 +13561,382 @@
         [
             35,
             36,
-            0.47162110914189925
+            0.9950819672131147
         ],
         [
             35,
             37,
-            0.41614558708189847
+            0.9950819672131147
         ],
         [
             35,
             38,
-            0.4527349601029051
+            0.9885245901639345
         ],
         [
             35,
             39,
-            0.16666666666666666
+            0.9918032786885246
         ],
         [
             35,
             40,
-            0.5345224838248487
+            1.0
         ],
         [
             35,
             41,
-            0.26261286571944503
+            0.9852459016393442
         ],
         [
             35,
             42,
-            0.8660254037844388
+            0.9819672131147541
         ],
         [
             35,
             43,
-            0.46625240412015695
+            0.9852459016393442
         ],
         [
             35,
             44,
-            0.12075557676046031
+            0.978688524590164
         ],
         [
             35,
             45,
-            0.46625240412015695
+            0.9885245901639345
         ],
         [
             35,
             46,
-            -0.24405148745018082
+            0.9967213114754099
         ],
         [
             35,
             47,
-            0.26261286571944503
+            0.9540983606557377
         ],
         [
             35,
-            89,
-            0.7999999999999999
+            48,
+            0.9934426229508196
         ],
         [
             35,
-            95,
-            1.0
+            49,
+            0.9967213114754099
         ],
         [
             35,
-            96,
-            0.6324555320336758
+            50,
+            0.9918032786885246
         ],
         [
             35,
-            97,
-            1.0
+            51,
+            0.978688524590164
         ],
         [
             35,
-            98,
-            0.6324555320336759
+            52,
+            0.9721311475409836
         ],
         [
             35,
-            100,
-            1.0
+            53,
+            0.13278688524590165
         ],
         [
             35,
-            101,
-            1.0
+            54,
+            0.21311475409836067
         ],
         [
             35,
-            104,
-            0.7999999999999999
+            55,
+            0.19999999999999996
         ],
         [
             35,
-            105,
-            1.0
+            56,
+            0.1934426229508197
+        ],
+        [
+            35,
+            57,
+            0.2032786885245902
+        ],
+        [
+            35,
+            58,
+            0.11639344262295082
+        ],
+        [
+            35,
+            59,
+            0.02950819672131144
+        ],
+        [
+            35,
+            60,
+            0.21475409836065573
+        ],
+        [
+            35,
+            61,
+            0.23114754098360657
+        ],
+        [
+            35,
+            62,
+            0.02786885245901638
+        ],
+        [
+            35,
+            63,
+            0.02786885245901638
+        ],
+        [
+            35,
+            64,
+            0.2295081967213115
+        ],
+        [
+            35,
+            65,
+            0.2245901639344262
+        ],
+        [
+            35,
+            66,
+            0.16885245901639345
+        ],
+        [
+            35,
+            67,
+            0.21967213114754103
+        ],
+        [
+            35,
+            68,
+            0.14754098360655743
+        ],
+        [
+            35,
+            69,
+            0.7622950819672132
+        ],
+        [
+            35,
+            70,
+            0.7622950819672132
+        ],
+        [
+            35,
+            71,
+            0.759016393442623
+        ],
+        [
+            35,
+            72,
+            0.7065573770491803
+        ],
+        [
+            35,
+            73,
+            0.16557377049180333
+        ],
+        [
+            35,
+            74,
+            0.7573770491803279
+        ],
+        [
+            35,
+            75,
+            0.14098360655737707
         ],
         [
             36,
             0,
-            0.6324555320336758
+            0.07540983606557372
+        ],
+        [
+            36,
+            1,
+            0.24426229508196717
         ],
         [
             36,
             2,
-            0.7999999999999999
+            0.9868852459016394
         ],
         [
             36,
             3,
-            0.3952847075210474
+            0.9868852459016394
         ],
         [
             36,
             4,
-            0.6324555320336758
+            0.24426229508196717
         ],
         [
             36,
             5,
-            0.5499999999999999
+            0.9868852459016394
+        ],
+        [
+            36,
+            6,
+            0.9180327868852459
         ],
         [
             36,
             7,
-            0.5499999999999999
+            0.9868852459016394
+        ],
+        [
+            36,
+            8,
+            0.24426229508196717
+        ],
+        [
+            36,
+            9,
+            0.24590163934426235
+        ],
+        [
+            36,
+            10,
+            0.9868852459016394
+        ],
+        [
+            36,
+            11,
+            0.9868852459016394
+        ],
+        [
+            36,
+            12,
+            0.24590163934426235
+        ],
+        [
+            36,
+            13,
+            0.9868852459016394
+        ],
+        [
+            36,
+            14,
+            0.9868852459016394
         ],
         [
             36,
             15,
-            0.2721655269759087
+            0.24426229508196717
         ],
         [
             36,
             16,
-            0.5499999999999999
+            0.9868852459016394
         ],
         [
             36,
             17,
-            0.3779644730092272
+            0.9049180327868852
+        ],
+        [
+            36,
+            18,
+            0.9754098360655737
         ],
         [
             36,
             19,
-            0.7745966692414834
+            0.9885245901639345
+        ],
+        [
+            36,
+            20,
+            0.9819672131147541
+        ],
+        [
+            36,
+            21,
+            0.980327868852459
+        ],
+        [
+            36,
+            22,
+            0.9819672131147541
+        ],
+        [
+            36,
+            23,
+            0.9819672131147541
         ],
         [
             36,
             24,
-            0.45732956038002365
+            0.9934426229508196
         ],
         [
             36,
             25,
-            0.16238586255274196
+            0.9639344262295082
         ],
         [
             36,
             26,
-            0.4950737714883371
+            0.9934426229508196
         ],
         [
             36,
             27,
-            0.4330127018922194
+            0.980327868852459
         ],
         [
             36,
             28,
-            0.4950737714883371
+            0.980327868852459
         ],
         [
             36,
             29,
-            0.6653754265107288
+            0.9950819672131147
         ],
         [
             36,
             30,
-            0.7333587976225692
+            0.980327868852459
         ],
         [
             36,
             31,
-            0.04166666666666667
+            0.978688524590164
         ],
         [
             36,
             32,
-            0.710081334771074
+            0.9934426229508196
         ],
         [
             36,
             33,
-            -1.4332917616497526e-17
+            0.980327868852459
         ],
         [
             36,
             34,
-            0.710081334771074
+            0.978688524590164
         ],
         [
             36,
             35,
-            0.47162110914189925
+            0.9950819672131147
         ],
         [
             36,
@@ -13147,237 +13946,382 @@
         [
             36,
             37,
-            0.3131121455425747
+            0.9967213114754099
         ],
         [
             36,
             38,
-            0.625543242171224
+            0.9868852459016394
         ],
         [
             36,
             39,
-            0.30012252399939043
+            0.9934426229508196
         ],
         [
             36,
             40,
-            0.7333587976225691
+            0.9950819672131147
         ],
         [
             36,
             41,
-            0.36030187928883606
+            0.9836065573770492
         ],
         [
             36,
             42,
-            0.4950737714883371
+            0.980327868852459
         ],
         [
             36,
             43,
-            0.6396930210072015
+            0.9836065573770492
         ],
         [
             36,
             44,
-            0.16390251702679642
+            0.9770491803278688
         ],
         [
             36,
             45,
-            0.6396930210072015
+            0.9868852459016394
         ],
         [
             36,
             46,
-            0.16238586255274196
+            0.9983606557377049
         ],
         [
             36,
             47,
-            0.36030187928883606
+            0.9524590163934427
         ],
         [
             36,
-            89,
-            0.8000000000000002
+            48,
+            0.9983606557377049
         ],
         [
             36,
-            95,
-            0.25
+            49,
+            0.9950819672131147
         ],
         [
             36,
-            96,
-            0.6324555320336758
+            50,
+            0.9967213114754099
         ],
         [
             36,
-            97,
-            0.5499999999999999
+            51,
+            0.9836065573770492
         ],
         [
             36,
-            98,
-            0.6324555320336759
+            52,
+            0.9704918032786886
         ],
         [
             36,
-            100,
-            0.25
+            53,
+            0.1311475409836066
         ],
         [
             36,
-            101,
-            0.5499999999999999
+            54,
+            0.2114754098360656
         ],
         [
             36,
-            104,
-            0.8000000000000002
+            55,
+            0.20163934426229513
         ],
         [
             36,
-            105,
-            0.5499999999999999
+            56,
+            0.19180327868852454
+        ],
+        [
+            36,
+            57,
+            0.20163934426229513
+        ],
+        [
+            36,
+            58,
+            0.11475409836065575
+        ],
+        [
+            36,
+            59,
+            0.02786885245901638
+        ],
+        [
+            36,
+            60,
+            0.21311475409836067
+        ],
+        [
+            36,
+            61,
+            0.2295081967213115
+        ],
+        [
+            36,
+            62,
+            0.02622950819672132
+        ],
+        [
+            36,
+            63,
+            0.02622950819672132
+        ],
+        [
+            36,
+            64,
+            0.23114754098360657
+        ],
+        [
+            36,
+            65,
+            0.22295081967213115
+        ],
+        [
+            36,
+            66,
+            0.1672131147540984
+        ],
+        [
+            36,
+            67,
+            0.21803278688524586
+        ],
+        [
+            36,
+            68,
+            0.14590163934426226
+        ],
+        [
+            36,
+            69,
+            0.7573770491803279
+        ],
+        [
+            36,
+            70,
+            0.7573770491803279
+        ],
+        [
+            36,
+            71,
+            0.7573770491803279
+        ],
+        [
+            36,
+            72,
+            0.701639344262295
+        ],
+        [
+            36,
+            73,
+            0.16393442622950816
+        ],
+        [
+            36,
+            74,
+            0.7557377049180328
+        ],
+        [
+            36,
+            75,
+            0.139344262295082
         ],
         [
             37,
             0,
-            0.6831300510639732
+            0.07868852459016396
         ],
         [
             37,
             1,
-            0.5
+            0.2475409836065574
         ],
         [
             37,
             2,
-            1.0
+            0.9868852459016394
         ],
         [
             37,
             3,
-            0.3779644730092272
+            0.9868852459016394
         ],
         [
             37,
             4,
-            0.6831300510639732
+            0.2475409836065574
         ],
         [
             37,
             5,
-            0.7142857142857144
+            0.9868852459016394
         ],
         [
             37,
             6,
-            0.5
+            0.9180327868852459
         ],
         [
             37,
             7,
-            0.7142857142857144
+            0.9868852459016394
+        ],
+        [
+            37,
+            8,
+            0.2475409836065574
         ],
         [
             37,
             9,
-            1.0
+            0.24590163934426235
         ],
         [
             37,
             10,
-            1.0
+            0.9868852459016394
         ],
         [
             37,
             11,
-            0.5
+            0.9868852459016394
+        ],
+        [
+            37,
+            12,
+            0.24590163934426235
+        ],
+        [
+            37,
+            13,
+            0.9868852459016394
+        ],
+        [
+            37,
+            14,
+            0.9868852459016394
+        ],
+        [
+            37,
+            15,
+            0.2475409836065574
         ],
         [
             37,
             16,
-            0.7142857142857144
+            0.9868852459016394
         ],
         [
             37,
             17,
-            0.3563483225498992
+            0.9049180327868852
+        ],
+        [
+            37,
+            18,
+            0.9754098360655737
         ],
         [
             37,
             19,
-            0.8100925873009824
+            0.9885245901639345
+        ],
+        [
+            37,
+            20,
+            0.9819672131147541
+        ],
+        [
+            37,
+            21,
+            0.980327868852459
+        ],
+        [
+            37,
+            22,
+            0.9819672131147541
+        ],
+        [
+            37,
+            23,
+            0.9819672131147541
         ],
         [
             37,
             24,
-            0.11318329168362205
+            0.9934426229508196
         ],
         [
             37,
             25,
-            -0.1264911064067352
+            0.9639344262295082
         ],
         [
             37,
             26,
-            0.4483136495254827
+            0.9934426229508196
         ],
         [
             37,
             27,
-            0.595538971576728
+            0.980327868852459
         ],
         [
             37,
             28,
-            0.4483136495254827
+            0.980327868852459
         ],
         [
             37,
             29,
-            0.5892556509887895
+            0.9950819672131147
         ],
         [
             37,
             30,
-            0.1112468401110025
+            0.980327868852459
         ],
         [
             37,
             31,
-            0.5932958789676529
+            0.978688524590164
         ],
         [
             37,
             32,
-            0.6255774501577783
+            0.9934426229508196
         ],
         [
             37,
             33,
-            0.03003757045930556
+            0.980327868852459
         ],
         [
             37,
             34,
-            0.6255774501577783
+            0.978688524590164
         ],
         [
             37,
             35,
-            0.41614558708189847
+            0.9950819672131147
         ],
         [
             37,
             36,
-            0.3131121455425747
+            0.9967213114754099
         ],
         [
             37,
@@ -13387,272 +14331,382 @@
         [
             37,
             38,
-            0.6220907522417995
+            0.9901639344262295
         ],
         [
             37,
             39,
-            0.030082841879809342
+            0.9967213114754099
         ],
         [
             37,
             40,
-            0.5023860845676614
+            0.9950819672131147
         ],
         [
             37,
             41,
-            0.023669053416557537
+            0.9836065573770492
         ],
         [
             37,
             42,
-            0.44831364952548275
+            0.980327868852459
         ],
         [
             37,
             43,
-            0.38737781366765006
+            0.9836065573770492
         ],
         [
             37,
             44,
-            0.80582296402538
+            0.9770491803278688
         ],
         [
             37,
             45,
-            0.38737781366765006
+            0.9901639344262295
         ],
         [
             37,
             46,
-            -0.12649110640673517
+            0.9983606557377049
         ],
         [
             37,
             47,
-            0.023669053416557537
+            0.9557377049180328
+        ],
+        [
+            37,
+            48,
+            0.9983606557377049
         ],
         [
             37,
             49,
-            0.7071067811865475
+            0.9983606557377049
         ],
         [
             37,
             50,
-            0.40824829046386296
+            0.9967213114754099
+        ],
+        [
+            37,
+            51,
+            0.9836065573770492
+        ],
+        [
+            37,
+            52,
+            0.9737704918032787
         ],
         [
             37,
             53,
-            0.7071067811865475
+            0.13442622950819672
         ],
         [
             37,
             54,
-            0.7071067811865475
+            0.21475409836065573
+        ],
+        [
+            37,
+            55,
+            0.20163934426229513
         ],
         [
             37,
             56,
-            0.15811388300841894
+            0.19508196721311477
+        ],
+        [
+            37,
+            57,
+            0.20491803278688525
+        ],
+        [
+            37,
+            58,
+            0.11803278688524588
         ],
         [
             37,
             59,
-            0.40824829046386296
+            0.031147540983606503
         ],
         [
             37,
             60,
-            0.15811388300841894
+            0.2163934426229508
         ],
         [
             37,
             61,
-            0.7071067811865475
+            0.23278688524590163
+        ],
+        [
+            37,
+            62,
+            0.02950819672131144
         ],
         [
             37,
             63,
-            0.40824829046386296
+            0.02950819672131144
+        ],
+        [
+            37,
+            64,
+            0.23114754098360657
         ],
         [
             37,
             65,
-            0.47809144373375745
+            0.22622950819672127
         ],
         [
             37,
             66,
-            0.40824829046386296
+            0.17049180327868851
         ],
         [
             37,
             67,
-            0.5773502691896258
+            0.2213114754098361
         ],
         [
             37,
-            89,
-            0.9058216273156765
+            68,
+            0.1491803278688525
         ],
         [
             37,
-            95,
-            0.5976143046671969
+            69,
+            0.7573770491803279
         ],
         [
             37,
-            96,
-            0.6183469424008423
+            70,
+            0.7573770491803279
         ],
         [
             37,
-            97,
-            0.8164965809277263
+            71,
+            0.7573770491803279
         ],
         [
             37,
-            98,
-            0.3571428571428571
+            72,
+            0.701639344262295
         ],
         [
             37,
-            100,
-            0.7559289460184544
+            73,
+            0.1672131147540984
         ],
         [
             37,
-            101,
-            0.7479575920067657
+            74,
+            0.759016393442623
         ],
         [
             37,
-            104,
-            1.0
-        ],
-        [
-            37,
-            105,
-            0.7999999999999999
+            75,
+            0.14262295081967213
         ],
         [
             38,
             0,
-            1.0
+            0.08852459016393444
+        ],
+        [
+            38,
+            1,
+            0.2573770491803279
         ],
         [
             38,
             2,
-            0.6831300510639732
+            0.980327868852459
         ],
         [
             38,
             3,
-            0.2581988897471611
+            0.980327868852459
         ],
         [
             38,
             4,
-            1.0
+            0.2573770491803279
         ],
         [
             38,
             5,
-            0.48795003647426655
+            0.980327868852459
+        ],
+        [
+            38,
+            6,
+            0.9114754098360656
         ],
         [
             38,
             7,
-            0.48795003647426655
+            0.980327868852459
+        ],
+        [
+            38,
+            8,
+            0.2573770491803279
+        ],
+        [
+            38,
+            9,
+            0.2557377049180328
+        ],
+        [
+            38,
+            10,
+            0.980327868852459
+        ],
+        [
+            38,
+            11,
+            0.980327868852459
+        ],
+        [
+            38,
+            12,
+            0.2557377049180328
+        ],
+        [
+            38,
+            13,
+            0.980327868852459
+        ],
+        [
+            38,
+            14,
+            0.980327868852459
+        ],
+        [
+            38,
+            15,
+            0.2573770491803279
         ],
         [
             38,
             16,
-            0.48795003647426655
+            0.980327868852459
         ],
         [
             38,
             17,
-            0.22222222222222227
+            0.898360655737705
+        ],
+        [
+            38,
+            18,
+            0.9688524590163934
         ],
         [
             38,
             19,
-            0.7698003589195009
+            0.9819672131147541
+        ],
+        [
+            38,
+            20,
+            0.9754098360655737
+        ],
+        [
+            38,
+            21,
+            0.9737704918032787
+        ],
+        [
+            38,
+            22,
+            0.9754098360655737
+        ],
+        [
+            38,
+            23,
+            0.9754098360655737
         ],
         [
             38,
             24,
-            0.30508307783296046
+            0.9868852459016394
         ],
         [
             38,
             25,
-            -0.0898026510133875
+            0.9573770491803278
         ],
         [
             38,
             26,
-            0.39130434782608703
+            0.9868852459016394
         ],
         [
             38,
             27,
-            0.37047928681747416
+            0.9737704918032787
         ],
         [
             38,
             28,
-            0.39130434782608703
+            0.9737704918032787
         ],
         [
             38,
             29,
-            0.8666666666666668
+            0.9885245901639345
         ],
         [
             38,
             30,
-            0.4252964776724257
+            0.9737704918032787
         ],
         [
             38,
             31,
-            0.26967994498529696
+            0.9721311475409836
         ],
         [
             38,
             32,
-            0.7562449037944323
+            0.9868852459016394
         ],
         [
             38,
             33,
-            0.1420143204993453
+            0.9737704918032787
         ],
         [
             38,
             34,
-            0.7562449037944323
+            0.9721311475409836
         ],
         [
             38,
             35,
-            0.4527349601029051
+            0.9885245901639345
         ],
         [
             38,
             36,
-            0.625543242171224
+            0.9868852459016394
         ],
         [
             38,
             37,
-            0.6220907522417995
+            0.9901639344262295
         ],
         [
             38,
@@ -13662,212 +14716,382 @@
         [
             38,
             39,
-            0.23372319715296225
+            0.9868852459016394
         ],
         [
             38,
             40,
-            0.8145314840210528
+            0.9885245901639345
         ],
         [
             38,
             41,
-            0.18389242812245685
+            0.9770491803278688
         ],
         [
             38,
             42,
-            0.39130434782608686
+            0.9737704918032787
         ],
         [
             38,
             43,
-            0.6908212560386473
+            0.9770491803278688
         ],
         [
             38,
             44,
-            0.5640760748177662
+            0.9704918032786886
         ],
         [
             38,
             45,
-            0.6908212560386473
-        ],
-        [
-            38,
-            46,
-            -0.08980265101338751
-        ],
-        [
-            38,
-            47,
-            0.18389242812245685
-        ],
-        [
-            38,
-            49,
-            0.3015113445777636
-        ],
-        [
-            38,
-            50,
-            0.5222329678670934
-        ],
-        [
-            38,
-            53,
-            0.3015113445777636
-        ],
-        [
-            38,
-            54,
-            0.3015113445777636
-        ],
-        [
-            38,
-            56,
-            0.6741998624632421
-        ],
-        [
-            38,
-            59,
-            0.5222329678670934
-        ],
-        [
-            38,
-            60,
-            0.6741998624632421
-        ],
-        [
-            38,
-            61,
-            0.3015113445777636
-        ],
-        [
-            38,
-            63,
-            -0.17407765595569782
-        ],
-        [
-            38,
-            65,
-            0.35675303400633784
-        ],
-        [
-            38,
-            66,
-            0.5222329678670934
-        ],
-        [
-            38,
-            67,
-            0.3779644730092272
-        ],
-        [
-            38,
-            89,
-            0.560112033611204
-        ],
-        [
-            38,
-            96,
             1.0
         ],
         [
             38,
-            97,
-            0.5345224838248488
+            46,
+            0.9885245901639345
         ],
         [
             38,
-            101,
-            0.46249729006288015
+            47,
+            0.9491803278688524
         ],
         [
             38,
-            104,
-            0.7905694150420948
+            48,
+            0.9885245901639345
         ],
         [
             38,
-            105,
-            0.6324555320336758
+            49,
+            0.9918032786885246
+        ],
+        [
+            38,
+            50,
+            0.9868852459016394
+        ],
+        [
+            38,
+            51,
+            0.9737704918032787
+        ],
+        [
+            38,
+            52,
+            0.9672131147540983
+        ],
+        [
+            38,
+            53,
+            0.1442622950819672
+        ],
+        [
+            38,
+            54,
+            0.2213114754098361
+        ],
+        [
+            38,
+            55,
+            0.20819672131147537
+        ],
+        [
+            38,
+            56,
+            0.20491803278688525
+        ],
+        [
+            38,
+            57,
+            0.2114754098360656
+        ],
+        [
+            38,
+            58,
+            0.12786885245901636
+        ],
+        [
+            38,
+            59,
+            0.040983606557377095
+        ],
+        [
+            38,
+            60,
+            0.22295081967213115
+        ],
+        [
+            38,
+            61,
+            0.239344262295082
+        ],
+        [
+            38,
+            62,
+            0.03934426229508192
+        ],
+        [
+            38,
+            63,
+            0.03934426229508192
+        ],
+        [
+            38,
+            64,
+            0.23770491803278693
+        ],
+        [
+            38,
+            65,
+            0.23278688524590163
+        ],
+        [
+            38,
+            66,
+            0.17704918032786887
+        ],
+        [
+            38,
+            67,
+            0.23114754098360657
+        ],
+        [
+            38,
+            68,
+            0.15573770491803274
+        ],
+        [
+            38,
+            69,
+            0.7508196721311475
+        ],
+        [
+            38,
+            70,
+            0.7508196721311475
+        ],
+        [
+            38,
+            71,
+            0.7475409836065574
+        ],
+        [
+            38,
+            72,
+            0.6950819672131148
+        ],
+        [
+            38,
+            73,
+            0.17377049180327864
+        ],
+        [
+            38,
+            74,
+            0.7524590163934426
+        ],
+        [
+            38,
+            75,
+            0.13606557377049178
+        ],
+        [
+            39,
+            0,
+            0.08196721311475408
+        ],
+        [
+            39,
+            1,
+            0.25081967213114753
+        ],
+        [
+            39,
+            2,
+            0.9836065573770492
+        ],
+        [
+            39,
+            3,
+            0.9836065573770492
+        ],
+        [
+            39,
+            4,
+            0.25081967213114753
+        ],
+        [
+            39,
+            5,
+            0.9836065573770492
+        ],
+        [
+            39,
+            6,
+            0.9147540983606557
+        ],
+        [
+            39,
+            7,
+            0.9836065573770492
+        ],
+        [
+            39,
+            8,
+            0.25081967213114753
+        ],
+        [
+            39,
+            9,
+            0.24918032786885247
+        ],
+        [
+            39,
+            10,
+            0.9836065573770492
+        ],
+        [
+            39,
+            11,
+            0.9836065573770492
+        ],
+        [
+            39,
+            12,
+            0.24918032786885247
+        ],
+        [
+            39,
+            13,
+            0.9836065573770492
+        ],
+        [
+            39,
+            14,
+            0.9836065573770492
+        ],
+        [
+            39,
+            15,
+            0.25081967213114753
+        ],
+        [
+            39,
+            16,
+            0.9836065573770492
+        ],
+        [
+            39,
+            17,
+            0.9016393442622951
+        ],
+        [
+            39,
+            18,
+            0.9721311475409836
+        ],
+        [
+            39,
+            19,
+            0.9852459016393442
+        ],
+        [
+            39,
+            20,
+            0.978688524590164
+        ],
+        [
+            39,
+            21,
+            0.9770491803278688
+        ],
+        [
+            39,
+            22,
+            0.978688524590164
+        ],
+        [
+            39,
+            23,
+            0.978688524590164
         ],
         [
             39,
             24,
-            0.5925925925925927
+            0.9901639344262295
         ],
         [
             39,
             25,
-            -0.092847669088526
+            0.9672131147540983
         ],
         [
             39,
             26,
-            0.11226255234242713
+            0.9901639344262295
         ],
         [
             39,
             27,
-            0.09245003270420488
+            0.9770491803278688
         ],
         [
             39,
             28,
-            0.11226255234242713
+            0.9770491803278688
         ],
         [
             39,
             29,
-            0.31127150873973364
+            0.9918032786885246
         ],
         [
             39,
             30,
-            0.46028324996028624
+            0.9770491803278688
         ],
         [
             39,
             31,
-            -0.1272937693043289
+            0.9754098360655737
         ],
         [
             39,
             32,
-            0.390199486285854
+            0.9901639344262295
         ],
         [
             39,
             33,
-            0.20672455764868072
+            0.9836065573770492
         ],
         [
             39,
             34,
-            0.390199486285854
+            0.9754098360655737
         ],
         [
             39,
             35,
-            0.16666666666666666
+            0.9918032786885246
         ],
         [
             39,
             36,
-            0.30012252399939043
+            0.9934426229508196
         ],
         [
             39,
             37,
-            0.030082841879809342
+            0.9967213114754099
         ],
         [
             39,
             38,
-            0.23372319715296225
+            0.9868852459016394
         ],
         [
             39,
@@ -13877,172 +15101,382 @@
         [
             39,
             40,
-            0.46028324996028636
+            0.9918032786885246
         ],
         [
             39,
             41,
-            0.7878385971583354
+            0.980327868852459
         ],
         [
             39,
             42,
-            0.11226255234242717
+            0.9770491803278688
         ],
         [
             39,
             43,
-            0.5439611381401829
+            0.980327868852459
         ],
         [
             39,
             44,
-            0.010218988991416128
+            0.980327868852459
         ],
         [
             39,
             45,
-            0.5439611381401829
+            0.9868852459016394
         ],
         [
             39,
             46,
-            -0.09284766908852603
+            0.9950819672131147
         ],
         [
             39,
             47,
-            0.7878385971583354
+            0.9590163934426229
+        ],
+        [
+            39,
+            48,
+            0.9950819672131147
+        ],
+        [
+            39,
+            49,
+            0.9950819672131147
+        ],
+        [
+            39,
+            50,
+            0.9934426229508196
+        ],
+        [
+            39,
+            51,
+            0.980327868852459
+        ],
+        [
+            39,
+            52,
+            0.9704918032786886
+        ],
+        [
+            39,
+            53,
+            0.13770491803278684
+        ],
+        [
+            39,
+            54,
+            0.21803278688524586
+        ],
+        [
+            39,
+            55,
+            0.20163934426229513
+        ],
+        [
+            39,
+            56,
+            0.19508196721311477
+        ],
+        [
+            39,
+            57,
+            0.20491803278688525
+        ],
+        [
+            39,
+            58,
+            0.12131147540983611
+        ],
+        [
+            39,
+            59,
+            0.03442622950819674
+        ],
+        [
+            39,
+            60,
+            0.21967213114754103
+        ],
+        [
+            39,
+            61,
+            0.23278688524590163
+        ],
+        [
+            39,
+            62,
+            0.032786885245901676
+        ],
+        [
+            39,
+            63,
+            0.032786885245901676
+        ],
+        [
+            39,
+            64,
+            0.23114754098360657
+        ],
+        [
+            39,
+            65,
+            0.22622950819672127
+        ],
+        [
+            39,
+            66,
+            0.17049180327868851
+        ],
+        [
+            39,
+            67,
+            0.2213114754098361
+        ],
+        [
+            39,
+            68,
+            0.1491803278688525
+        ],
+        [
+            39,
+            69,
+            0.7540983606557377
+        ],
+        [
+            39,
+            70,
+            0.7540983606557377
+        ],
+        [
+            39,
+            71,
+            0.7540983606557377
+        ],
+        [
+            39,
+            72,
+            0.6983606557377049
+        ],
+        [
+            39,
+            73,
+            0.16393442622950816
+        ],
+        [
+            39,
+            74,
+            0.7557377049180328
+        ],
+        [
+            39,
+            75,
+            0.14590163934426226
         ],
         [
             40,
             0,
-            1.0
+            0.0770491803278689
+        ],
+        [
+            40,
+            1,
+            0.24590163934426235
         ],
         [
             40,
             2,
-            0.6546536707079772
+            0.9918032786885246
         ],
         [
             40,
             3,
-            0.21821789023599242
+            0.9918032786885246
         ],
         [
             40,
             4,
-            1.0
+            0.24590163934426235
         ],
         [
             40,
             5,
-            0.5345224838248487
+            0.9918032786885246
+        ],
+        [
+            40,
+            6,
+            0.9229508196721311
         ],
         [
             40,
             7,
-            0.5345224838248487
+            0.9918032786885246
+        ],
+        [
+            40,
+            8,
+            0.24590163934426235
+        ],
+        [
+            40,
+            9,
+            0.25081967213114753
+        ],
+        [
+            40,
+            10,
+            0.9918032786885246
+        ],
+        [
+            40,
+            11,
+            0.9918032786885246
+        ],
+        [
+            40,
+            12,
+            0.25081967213114753
+        ],
+        [
+            40,
+            13,
+            0.9918032786885246
+        ],
+        [
+            40,
+            14,
+            0.9918032786885246
         ],
         [
             40,
             15,
-            0.41833001326703767
+            0.24590163934426235
         ],
         [
             40,
             16,
-            0.5345224838248487
+            0.9918032786885246
         ],
         [
             40,
             17,
-            0.18898223650461363
+            0.9098360655737705
+        ],
+        [
+            40,
+            18,
+            0.980327868852459
         ],
         [
             40,
             19,
-            0.7559289460184545
+            0.9934426229508196
+        ],
+        [
+            40,
+            20,
+            0.9836065573770492
+        ],
+        [
+            40,
+            21,
+            0.9852459016393442
+        ],
+        [
+            40,
+            22,
+            0.9836065573770492
+        ],
+        [
+            40,
+            23,
+            0.9836065573770492
         ],
         [
             40,
             24,
-            0.6236095644623237
+            0.9983606557377049
         ],
         [
             40,
             25,
-            -0.14002800840280102
+            0.9655737704918033
         ],
         [
             40,
             26,
-            0.47207747548166573
+            0.9983606557377049
         ],
         [
             40,
             27,
-            0.42497294818489695
+            0.9852459016393442
         ],
         [
             40,
             28,
-            0.46291004988627565
+            0.9852459016393442
         ],
         [
             40,
             29,
-            0.8207677342949545
+            0.9967213114754099
         ],
         [
             40,
             30,
-            0.6263736263736263
+            0.9852459016393442
         ],
         [
             40,
             31,
-            0.16867477123499666
+            0.9836065573770492
         ],
         [
             40,
             32,
-            0.8855094489202158
+            0.9983606557377049
         ],
         [
             40,
             33,
-            0.0815016078203043
+            0.9819672131147541
         ],
         [
             40,
             34,
-            0.880630571852711
+            0.980327868852459
         ],
         [
             40,
             35,
-            0.5345224838248487
+            1.0
         ],
         [
             40,
             36,
-            0.7333587976225691
+            0.9950819672131147
         ],
         [
             40,
             37,
-            0.5023860845676614
+            0.9950819672131147
         ],
         [
             40,
             38,
-            0.8145314840210528
+            0.9885245901639345
         ],
         [
             40,
             39,
-            0.46028324996028636
+            0.9918032786885246
         ],
         [
             40,
@@ -14052,192 +15486,382 @@
         [
             40,
             41,
-            0.4913036844405175
+            0.9852459016393442
         ],
         [
             40,
             42,
-            0.4629100498862758
+            0.9819672131147541
         ],
         [
             40,
             43,
-            0.8722783759886468
+            0.9852459016393442
         ],
         [
             40,
             44,
-            0.38251842611872494
+            0.978688524590164
         ],
         [
             40,
             45,
-            0.8722783759886468
+            0.9885245901639345
         ],
         [
             40,
             46,
-            -0.14002800840280097
+            0.9967213114754099
         ],
         [
             40,
             47,
-            0.4640954808922571
+            0.9540983606557377
+        ],
+        [
+            40,
+            48,
+            0.9934426229508196
         ],
         [
             40,
             49,
-            0.33333333333333337
+            0.9967213114754099
         ],
         [
             40,
             50,
-            -0.33333333333333337
+            0.9918032786885246
+        ],
+        [
+            40,
+            51,
+            0.978688524590164
+        ],
+        [
+            40,
+            52,
+            0.9721311475409836
         ],
         [
             40,
             53,
-            0.33333333333333337
+            0.13278688524590165
         ],
         [
             40,
             54,
-            0.33333333333333337
+            0.21311475409836067
+        ],
+        [
+            40,
+            55,
+            0.19999999999999996
+        ],
+        [
+            40,
+            56,
+            0.1934426229508197
+        ],
+        [
+            40,
+            57,
+            0.2032786885245902
+        ],
+        [
+            40,
+            58,
+            0.11639344262295082
+        ],
+        [
+            40,
+            59,
+            0.02950819672131144
+        ],
+        [
+            40,
+            60,
+            0.21475409836065573
         ],
         [
             40,
             61,
-            0.33333333333333337
+            0.23114754098360657
+        ],
+        [
+            40,
+            62,
+            0.02786885245901638
         ],
         [
             40,
             63,
-            -0.33333333333333337
+            0.02786885245901638
+        ],
+        [
+            40,
+            64,
+            0.2295081967213115
         ],
         [
             40,
             65,
-            -0.5773502691896258
+            0.2245901639344262
         ],
         [
             40,
             66,
-            -0.33333333333333337
+            0.16885245901639345
         ],
         [
             40,
-            89,
-            0.7071067811865475
+            67,
+            0.21967213114754103
         ],
         [
             40,
-            96,
-            0.8164965809277259
+            68,
+            0.14754098360655743
         ],
         [
             40,
-            97,
-            0.5345224838248488
+            69,
+            0.7622950819672132
         ],
         [
             40,
-            101,
-            0.5976143046671968
+            70,
+            0.7622950819672132
         ],
         [
             40,
-            104,
-            0.7905694150420948
+            71,
+            0.759016393442623
         ],
         [
             40,
-            105,
-            0.6324555320336758
+            72,
+            0.7065573770491803
+        ],
+        [
+            40,
+            73,
+            0.16557377049180333
+        ],
+        [
+            40,
+            74,
+            0.7573770491803279
+        ],
+        [
+            40,
+            75,
+            0.14098360655737707
+        ],
+        [
+            41,
+            0,
+            0.09180327868852456
+        ],
+        [
+            41,
+            1,
+            0.260655737704918
+        ],
+        [
+            41,
+            2,
+            0.9770491803278688
+        ],
+        [
+            41,
+            3,
+            0.9770491803278688
+        ],
+        [
+            41,
+            4,
+            0.260655737704918
+        ],
+        [
+            41,
+            5,
+            0.9770491803278688
+        ],
+        [
+            41,
+            6,
+            0.9081967213114754
+        ],
+        [
+            41,
+            7,
+            0.9770491803278688
+        ],
+        [
+            41,
+            8,
+            0.260655737704918
+        ],
+        [
+            41,
+            9,
+            0.2622950819672131
+        ],
+        [
+            41,
+            10,
+            0.9770491803278688
+        ],
+        [
+            41,
+            11,
+            0.9770491803278688
+        ],
+        [
+            41,
+            12,
+            0.2622950819672131
+        ],
+        [
+            41,
+            13,
+            0.9770491803278688
+        ],
+        [
+            41,
+            14,
+            0.9770491803278688
+        ],
+        [
+            41,
+            15,
+            0.260655737704918
+        ],
+        [
+            41,
+            16,
+            0.9770491803278688
+        ],
+        [
+            41,
+            17,
+            0.921311475409836
+        ],
+        [
+            41,
+            18,
+            0.9918032786885246
+        ],
+        [
+            41,
+            19,
+            0.978688524590164
+        ],
+        [
+            41,
+            20,
+            0.9983606557377049
+        ],
+        [
+            41,
+            21,
+            0.9967213114754099
+        ],
+        [
+            41,
+            22,
+            0.9983606557377049
+        ],
+        [
+            41,
+            23,
+            0.9983606557377049
         ],
         [
             41,
             24,
-            0.7878385971583358
+            0.9836065573770492
         ],
         [
             41,
             25,
-            -0.07283570407292303
+            0.980327868852459
         ],
         [
             41,
             26,
-            0.22742941307367087
+            0.9836065573770492
         ],
         [
             41,
             27,
-            0.21821789023599245
+            0.9967213114754099
         ],
         [
             41,
             28,
-            0.22742941307367087
+            0.9967213114754099
         ],
         [
             41,
             29,
-            0.31200964472696996
+            0.9852459016393442
         ],
         [
             41,
             30,
-            0.4913036844405173
+            0.9967213114754099
         ],
         [
             41,
             31,
-            -0.0860078077570234
+            0.9950819672131147
         ],
         [
             41,
             32,
-            0.43265704458219684
+            0.9836065573770492
         ],
         [
             41,
             33,
-            -0.09759000729485338
+            0.9967213114754099
         ],
         [
             41,
             34,
-            0.43265704458219684
+            0.9950819672131147
         ],
         [
             41,
             35,
-            0.26261286571944503
+            0.9852459016393442
         ],
         [
             41,
             36,
-            0.36030187928883606
+            0.9836065573770492
         ],
         [
             41,
             37,
-            0.023669053416557537
+            0.9836065573770492
         ],
         [
             41,
             38,
-            0.18389242812245685
+            0.9770491803278688
         ],
         [
             41,
             39,
-            0.7878385971583354
+            0.980327868852459
         ],
         [
             41,
             40,
-            0.4913036844405175
+            0.9852459016393442
         ],
         [
             41,
@@ -14247,172 +15871,382 @@
         [
             41,
             42,
-            0.22742941307367093
+            0.9967213114754099
         ],
         [
             41,
             43,
-            0.563241847975046
+            1.0
         ],
         [
             41,
             44,
-            -0.16571045299983217
+            0.9934426229508196
         ],
         [
             41,
             45,
-            0.563241847975046
+            0.9770491803278688
         ],
         [
             41,
             46,
-            -0.07283570407292302
+            0.9852459016393442
         ],
         [
             41,
             47,
-            1.0
+            0.9688524590163934
+        ],
+        [
+            41,
+            48,
+            0.9819672131147541
+        ],
+        [
+            41,
+            49,
+            0.9852459016393442
+        ],
+        [
+            41,
+            50,
+            0.980327868852459
+        ],
+        [
+            41,
+            51,
+            0.9934426229508196
+        ],
+        [
+            41,
+            52,
+            0.9868852459016394
+        ],
+        [
+            41,
+            53,
+            0.14754098360655743
+        ],
+        [
+            41,
+            54,
+            0.22786885245901645
+        ],
+        [
+            41,
+            55,
+            0.2114754098360656
+        ],
+        [
+            41,
+            56,
+            0.20491803278688525
+        ],
+        [
+            41,
+            57,
+            0.21475409836065573
+        ],
+        [
+            41,
+            58,
+            0.1311475409836066
+        ],
+        [
+            41,
+            59,
+            0.04426229508196722
+        ],
+        [
+            41,
+            60,
+            0.2295081967213115
+        ],
+        [
+            41,
+            61,
+            0.24590163934426235
+        ],
+        [
+            41,
+            62,
+            0.042622950819672156
+        ],
+        [
+            41,
+            63,
+            0.042622950819672156
+        ],
+        [
+            41,
+            64,
+            0.24098360655737705
+        ],
+        [
+            41,
+            65,
+            0.239344262295082
+        ],
+        [
+            41,
+            66,
+            0.180327868852459
+        ],
+        [
+            41,
+            67,
+            0.2344262295081967
+        ],
+        [
+            41,
+            68,
+            0.15901639344262297
+        ],
+        [
+            41,
+            69,
+            0.7475409836065574
+        ],
+        [
+            41,
+            70,
+            0.7475409836065574
+        ],
+        [
+            41,
+            71,
+            0.7442622950819673
+        ],
+        [
+            41,
+            72,
+            0.6918032786885246
+        ],
+        [
+            41,
+            73,
+            0.17704918032786887
+        ],
+        [
+            41,
+            74,
+            0.7459016393442623
+        ],
+        [
+            41,
+            75,
+            0.12950819672131153
         ],
         [
             42,
             0,
-            0.6324555320336758
+            0.09508196721311479
+        ],
+        [
+            42,
+            1,
+            0.26393442622950825
         ],
         [
             42,
             2,
-            0.7999999999999999
+            0.9737704918032787
         ],
         [
             42,
             3,
-            0.3952847075210473
+            0.9737704918032787
         ],
         [
             42,
             4,
-            0.6324555320336758
+            0.26393442622950825
         ],
         [
             42,
             5,
-            1.0
+            0.9737704918032787
+        ],
+        [
+            42,
+            6,
+            0.9049180327868852
         ],
         [
             42,
             7,
-            1.0
+            0.9737704918032787
+        ],
+        [
+            42,
+            8,
+            0.26393442622950825
+        ],
+        [
+            42,
+            9,
+            0.2655737704918033
+        ],
+        [
+            42,
+            10,
+            0.9737704918032787
+        ],
+        [
+            42,
+            11,
+            0.9737704918032787
+        ],
+        [
+            42,
+            12,
+            0.2655737704918033
+        ],
+        [
+            42,
+            13,
+            0.9737704918032787
+        ],
+        [
+            42,
+            14,
+            0.9737704918032787
         ],
         [
             42,
             15,
-            0.2721655269759087
+            0.26393442622950825
         ],
         [
             42,
             16,
-            1.0
+            0.9737704918032787
         ],
         [
             42,
             17,
-            0.3779644730092272
+            0.9180327868852459
+        ],
+        [
+            42,
+            18,
+            0.9885245901639345
         ],
         [
             42,
             19,
-            0.7745966692414834
+            0.9754098360655737
+        ],
+        [
+            42,
+            20,
+            0.9950819672131147
+        ],
+        [
+            42,
+            21,
+            0.9934426229508196
+        ],
+        [
+            42,
+            22,
+            0.9950819672131147
+        ],
+        [
+            42,
+            23,
+            0.9950819672131147
         ],
         [
             42,
             24,
-            0.28867513459481287
+            0.980327868852459
         ],
         [
             42,
             25,
-            0.12156613477096621
+            0.9836065573770492
         ],
         [
             42,
             26,
-            1.0
+            0.980327868852459
         ],
         [
             42,
             27,
-            0.9229582069908974
+            0.9934426229508196
         ],
         [
             42,
             28,
-            1.0
+            0.9934426229508196
         ],
         [
             42,
             29,
-            0.49811675413689877
+            0.9819672131147541
         ],
         [
             42,
             30,
-            0.46291004988627554
+            0.9934426229508196
         ],
         [
             42,
             31,
-            0.6527777777777779
+            0.9918032786885246
         ],
         [
             42,
             32,
-            0.5256574830378469
+            0.980327868852459
         ],
         [
             42,
             33,
-            -0.12562244381357193
+            0.9934426229508196
         ],
         [
             42,
             34,
-            0.5256574830378469
+            0.9918032786885246
         ],
         [
             42,
             35,
-            0.8660254037844388
+            0.9819672131147541
         ],
         [
             42,
             36,
-            0.4950737714883371
+            0.980327868852459
         ],
         [
             42,
             37,
-            0.44831364952548275
+            0.980327868852459
         ],
         [
             42,
             38,
-            0.39130434782608686
+            0.9737704918032787
         ],
         [
             42,
             39,
-            0.11226255234242717
+            0.9770491803278688
         ],
         [
             42,
             40,
-            0.4629100498862758
+            0.9819672131147541
         ],
         [
             42,
             41,
-            0.22742941307367093
+            0.9967213114754099
         ],
         [
             42,
@@ -14422,217 +16256,382 @@
         [
             42,
             43,
-            0.4037864265436241
+            0.9967213114754099
         ],
         [
             42,
             44,
-            0.22634157113224265
+            0.9901639344262295
         ],
         [
             42,
             45,
-            0.4037864265436241
+            0.9737704918032787
         ],
         [
             42,
             46,
-            0.1215661347709662
+            0.9819672131147541
         ],
         [
             42,
             47,
-            0.22742941307367087
+            0.9655737704918033
         ],
         [
             42,
-            89,
-            0.7999999999999999
+            48,
+            0.978688524590164
         ],
         [
             42,
-            95,
-            1.0
+            49,
+            0.9819672131147541
         ],
         [
             42,
-            96,
-            0.6324555320336758
+            50,
+            0.9770491803278688
         ],
         [
             42,
-            97,
-            1.0
+            51,
+            0.9901639344262295
         ],
         [
             42,
-            98,
-            0.6324555320336759
+            52,
+            0.9836065573770492
         ],
         [
             42,
-            100,
-            1.0
+            53,
+            0.15081967213114755
         ],
         [
             42,
-            101,
-            1.0
+            54,
+            0.23114754098360657
         ],
         [
             42,
-            104,
-            0.7999999999999999
+            55,
+            0.21475409836065573
         ],
         [
             42,
-            105,
-            1.0
+            56,
+            0.20819672131147537
+        ],
+        [
+            42,
+            57,
+            0.21803278688524586
+        ],
+        [
+            42,
+            58,
+            0.13442622950819672
+        ],
+        [
+            42,
+            59,
+            0.04754098360655734
+        ],
+        [
+            42,
+            60,
+            0.23278688524590163
+        ],
+        [
+            42,
+            61,
+            0.24918032786885247
+        ],
+        [
+            42,
+            62,
+            0.04590163934426228
+        ],
+        [
+            42,
+            63,
+            0.04590163934426228
+        ],
+        [
+            42,
+            64,
+            0.24426229508196717
+        ],
+        [
+            42,
+            65,
+            0.2426229508196721
+        ],
+        [
+            42,
+            66,
+            0.18360655737704923
+        ],
+        [
+            42,
+            67,
+            0.23770491803278693
+        ],
+        [
+            42,
+            68,
+            0.1622950819672131
+        ],
+        [
+            42,
+            69,
+            0.7442622950819673
+        ],
+        [
+            42,
+            70,
+            0.7442622950819673
+        ],
+        [
+            42,
+            71,
+            0.740983606557377
+        ],
+        [
+            42,
+            72,
+            0.6885245901639344
+        ],
+        [
+            42,
+            73,
+            0.180327868852459
+        ],
+        [
+            42,
+            74,
+            0.7426229508196721
+        ],
+        [
+            42,
+            75,
+            0.13278688524590165
         ],
         [
             43,
             0,
-            0.7559289460184545
+            0.09180327868852456
+        ],
+        [
+            43,
+            1,
+            0.260655737704918
         ],
         [
             43,
             2,
-            0.5976143046671969
+            0.9770491803278688
         ],
         [
             43,
             3,
-            0.18898223650461363
+            0.9770491803278688
         ],
         [
             43,
             4,
-            0.7559289460184545
+            0.260655737704918
         ],
         [
             43,
             5,
-            0.47809144373375745
+            0.9770491803278688
+        ],
+        [
+            43,
+            6,
+            0.9081967213114754
         ],
         [
             43,
             7,
-            0.47809144373375745
+            0.9770491803278688
+        ],
+        [
+            43,
+            8,
+            0.260655737704918
+        ],
+        [
+            43,
+            9,
+            0.2622950819672131
+        ],
+        [
+            43,
+            10,
+            0.9770491803278688
+        ],
+        [
+            43,
+            11,
+            0.9770491803278688
+        ],
+        [
+            43,
+            12,
+            0.2622950819672131
+        ],
+        [
+            43,
+            13,
+            0.9770491803278688
+        ],
+        [
+            43,
+            14,
+            0.9770491803278688
         ],
         [
             43,
             15,
-            0.5091750772173155
+            0.260655737704918
         ],
         [
             43,
             16,
-            0.47809144373375745
+            0.9770491803278688
         ],
         [
             43,
             17,
-            0.21821789023599233
+            0.921311475409836
+        ],
+        [
+            43,
+            18,
+            0.9918032786885246
         ],
         [
             43,
             19,
-            0.7453559924999299
+            0.978688524590164
+        ],
+        [
+            43,
+            20,
+            0.9983606557377049
+        ],
+        [
+            43,
+            21,
+            0.9967213114754099
+        ],
+        [
+            43,
+            22,
+            0.9983606557377049
+        ],
+        [
+            43,
+            23,
+            0.9983606557377049
         ],
         [
             43,
             24,
-            0.7149203529842406
+            0.9836065573770492
         ],
         [
             43,
             25,
-            -0.13130643285972257
+            0.980327868852459
         ],
         [
             43,
             26,
-            0.4037864265436241
+            0.9836065573770492
         ],
         [
             43,
             27,
-            0.36115755925730775
+            0.9967213114754099
         ],
         [
             43,
             28,
-            0.4037864265436241
+            0.9967213114754099
         ],
         [
             43,
             29,
-            0.7825855808712294
+            0.9852459016393442
         ],
         [
             43,
             30,
-            0.7352060597618597
+            0.9967213114754099
         ],
         [
             43,
             31,
-            0.10001653302482982
+            0.9950819672131147
         ],
         [
             43,
             32,
-            0.7681550050616364
+            0.9836065573770492
         ],
         [
             43,
             33,
-            0.125622443813572
+            0.9967213114754099
         ],
         [
             43,
             34,
-            0.7681550050616364
+            0.9950819672131147
         ],
         [
             43,
             35,
-            0.46625240412015695
+            0.9852459016393442
         ],
         [
             43,
             36,
-            0.6396930210072015
+            0.9836065573770492
         ],
         [
             43,
             37,
-            0.38737781366765006
+            0.9836065573770492
         ],
         [
             43,
             38,
-            0.6908212560386473
+            0.9770491803278688
         ],
         [
             43,
             39,
-            0.5439611381401829
+            0.980327868852459
         ],
         [
             43,
             40,
-            0.8722783759886468
+            0.9852459016393442
         ],
         [
             43,
             41,
-            0.563241847975046
+            1.0
         ],
         [
             43,
             42,
-            0.4037864265436241
+            0.9967213114754099
         ],
         [
             43,
@@ -14642,272 +16641,382 @@
         [
             43,
             44,
-            0.2656937137768185
+            0.9934426229508196
         ],
         [
             43,
             45,
-            1.0
+            0.9770491803278688
         ],
         [
             43,
             46,
-            -0.13130643285972257
+            0.9852459016393442
         ],
         [
             43,
             47,
-            0.563241847975046
+            0.9688524590163934
         ],
         [
             43,
-            89,
-            0.5976143046671969
+            48,
+            0.9819672131147541
         ],
         [
             43,
-            96,
-            0.7559289460184544
+            49,
+            0.9852459016393442
         ],
         [
             43,
-            97,
-            0.47809144373375745
+            50,
+            0.980327868852459
         ],
         [
             43,
-            101,
-            0.47809144373375745
+            51,
+            0.9934426229508196
         ],
         [
             43,
-            104,
-            0.5976143046671969
+            52,
+            0.9868852459016394
         ],
         [
             43,
-            105,
-            0.47809144373375745
+            53,
+            0.14754098360655743
+        ],
+        [
+            43,
+            54,
+            0.22786885245901645
+        ],
+        [
+            43,
+            55,
+            0.2114754098360656
+        ],
+        [
+            43,
+            56,
+            0.20491803278688525
+        ],
+        [
+            43,
+            57,
+            0.21475409836065573
+        ],
+        [
+            43,
+            58,
+            0.1311475409836066
+        ],
+        [
+            43,
+            59,
+            0.04426229508196722
+        ],
+        [
+            43,
+            60,
+            0.2295081967213115
+        ],
+        [
+            43,
+            61,
+            0.24590163934426235
+        ],
+        [
+            43,
+            62,
+            0.042622950819672156
+        ],
+        [
+            43,
+            63,
+            0.042622950819672156
+        ],
+        [
+            43,
+            64,
+            0.24098360655737705
+        ],
+        [
+            43,
+            65,
+            0.239344262295082
+        ],
+        [
+            43,
+            66,
+            0.180327868852459
+        ],
+        [
+            43,
+            67,
+            0.2344262295081967
+        ],
+        [
+            43,
+            68,
+            0.15901639344262297
+        ],
+        [
+            43,
+            69,
+            0.7475409836065574
+        ],
+        [
+            43,
+            70,
+            0.7475409836065574
+        ],
+        [
+            43,
+            71,
+            0.7442622950819673
+        ],
+        [
+            43,
+            72,
+            0.6918032786885246
+        ],
+        [
+            43,
+            73,
+            0.17704918032786887
+        ],
+        [
+            43,
+            74,
+            0.7459016393442623
+        ],
+        [
+            43,
+            75,
+            0.12950819672131153
         ],
         [
             44,
             0,
-            0.7355818674669264
+            0.09508196721311479
         ],
         [
             44,
             1,
-            0.6000635132837553
+            0.260655737704918
         ],
         [
             44,
             2,
-            0.7055027741801932
+            0.9704918032786886
         ],
         [
             44,
             3,
-            0.3897113440021563
+            0.9704918032786886
         ],
         [
             44,
             4,
-            0.3946288056831667
+            0.260655737704918
         ],
         [
             44,
             5,
-            0.5054212299689212
+            0.9704918032786886
         ],
         [
             44,
             6,
-            0.48672241060949306
+            0.9016393442622951
         ],
         [
             44,
             7,
-            0.5054212299689214
+            0.9704918032786886
         ],
         [
             44,
             8,
-            0.21184648506824794
+            0.260655737704918
         ],
         [
             44,
             9,
-            0.6128341912757952
+            0.2622950819672131
         ],
         [
             44,
             10,
-            0.5773018072405885
+            0.9704918032786886
         ],
         [
             44,
             11,
-            0.48749295662530706
+            0.9704918032786886
         ],
         [
             44,
             12,
-            0.7020682800472419
+            0.2622950819672131
         ],
         [
             44,
             13,
-            0.2323602598822318
+            0.9704918032786886
         ],
         [
             44,
             14,
-            0.6579459553823546
+            0.9704918032786886
         ],
         [
             44,
             15,
-            0.22947062012637998
+            0.260655737704918
         ],
         [
             44,
             16,
-            0.6306759165063986
+            0.9704918032786886
         ],
         [
             44,
             17,
-            0.44438436733519976
+            0.9147540983606557
         ],
         [
             44,
             18,
-            0.5646573703574895
+            0.9852459016393442
         ],
         [
             44,
             19,
-            0.6150682772489574
+            0.9721311475409836
         ],
         [
             44,
             20,
-            0.5279540680531329
+            0.9918032786885246
         ],
         [
             44,
             21,
-            0.7394265522389314
+            0.9901639344262295
         ],
         [
             44,
             22,
-            0.2796441723710375
+            0.9918032786885246
         ],
         [
             44,
             23,
-            0.20257529572733432
+            0.9918032786885246
         ],
         [
             44,
             24,
-            0.08070002078437537
+            0.9770491803278688
         ],
         [
             44,
             25,
-            0.049511055339234444
+            0.980327868852459
         ],
         [
             44,
             26,
-            0.22634157113224265
+            0.9770491803278688
         ],
         [
             44,
             27,
-            0.42640143271122094
+            0.9901639344262295
         ],
         [
             44,
             28,
-            0.22634157113224265
+            0.9901639344262295
         ],
         [
             44,
             29,
-            0.357006415771281
+            0.978688524590164
         ],
         [
             44,
             30,
-            0.06675015657623452
+            0.9901639344262295
         ],
         [
             44,
             31,
-            0.8010710580158935
+            0.9885245901639345
         ],
         [
             44,
             32,
-            0.5614035087719299
+            0.9770491803278688
         ],
         [
             44,
             33,
-            0.16205093088804104
+            0.9967213114754099
         ],
         [
             44,
             34,
-            0.5614035087719299
+            0.9885245901639345
         ],
         [
             44,
             35,
-            0.12075557676046031
+            0.978688524590164
         ],
         [
             44,
             36,
-            0.16390251702679642
+            0.9770491803278688
         ],
         [
             44,
             37,
-            0.80582296402538
+            0.9770491803278688
         ],
         [
             44,
             38,
-            0.5640760748177662
+            0.9704918032786886
         ],
         [
             44,
             39,
-            0.010218988991416128
+            0.980327868852459
         ],
         [
             44,
             40,
-            0.38251842611872494
+            0.978688524590164
         ],
         [
             44,
             41,
-            -0.16571045299983217
+            0.9934426229508196
         ],
         [
             44,
             42,
-            0.22634157113224265
+            0.9901639344262295
         ],
         [
             44,
             43,
-            0.2656937137768185
+            0.9934426229508196
         ],
         [
             44,
@@ -14917,422 +17026,382 @@
         [
             44,
             45,
-            0.2656937137768186
+            0.9704918032786886
         ],
         [
             44,
             46,
-            0.04035683513149589
+            0.978688524590164
         ],
         [
             44,
             47,
-            -0.16571045299983217
+            0.9688524590163934
         ],
         [
             44,
             48,
-            0.5258368109897522
+            0.9754098360655737
         ],
         [
             44,
             49,
-            0.612351907488237
+            0.978688524590164
         ],
         [
             44,
             50,
-            0.202610224618277
+            0.9737704918032787
         ],
         [
             44,
             51,
-            0.6644615465948323
+            0.9868852459016394
         ],
         [
             44,
             52,
-            0.20680375268461787
+            0.980327868852459
         ],
         [
             44,
             53,
-            0.6313825586808371
+            0.15081967213114755
         ],
         [
             44,
             54,
-            0.6320585868424646
+            0.23114754098360657
         ],
         [
             44,
             55,
-            0.5081956215508513
+            0.2114754098360656
         ],
         [
             44,
             56,
-            0.6501271580858727
+            0.20491803278688525
         ],
         [
             44,
             57,
-            0.12387907982816328
+            0.21475409836065573
         ],
         [
             44,
             58,
-            0.649446696159509
+            0.13770491803278684
         ],
         [
             44,
             59,
-            0.8100488863494064
+            0.050819672131147575
         ],
         [
             44,
             60,
-            0.647552925470892
+            0.23278688524590163
         ],
         [
             44,
             61,
-            0.6260667162786813
+            0.24590163934426235
         ],
         [
             44,
             62,
-            0.05255930803421452
+            0.049180327868852514
         ],
         [
             44,
             63,
-            0.5435737720153095
+            0.049180327868852514
         ],
         [
             44,
             64,
-            0.22613933218033166
+            0.24098360655737705
         ],
         [
             44,
             65,
-            0.5008993652040925
+            0.239344262295082
         ],
         [
             44,
             66,
-            0.05791814444351586
+            0.180327868852459
         ],
         [
             44,
             67,
-            0.7260972342828865
+            0.2344262295081967
         ],
         [
             44,
             68,
-            0.08785399016131934
+            0.1622950819672131
         ],
         [
             44,
             69,
-            0.5735935755443576
+            0.7475409836065574
         ],
         [
             44,
             70,
-            0.49470639242627723
+            0.7475409836065574
         ],
         [
             44,
             71,
-            0.6172463011363291
+            0.7442622950819673
         ],
         [
             44,
             72,
-            0.6045427066554235
+            0.6918032786885246
         ],
         [
             44,
             73,
-            0.26845443951491743
+            0.17704918032786887
         ],
         [
             44,
             74,
-            0.4980679550425732
+            0.7459016393442623
         ],
         [
             44,
             75,
-            0.47908232546152735
-        ],
-        [
-            44,
-            76,
-            0.32799046653904307
-        ],
-        [
-            44,
-            77,
-            0.48848093932856
-        ],
-        [
-            44,
-            78,
-            0.4725464393714521
-        ],
-        [
-            44,
-            79,
-            0.3964331447645081
-        ],
-        [
-            44,
-            80,
-            0.31085676548025976
-        ],
-        [
-            44,
-            81,
-            0.4372135165172474
-        ],
-        [
-            44,
-            82,
-            0.2280932256188991
-        ],
-        [
-            44,
-            83,
-            0.47997347903437126
-        ],
-        [
-            44,
-            84,
-            0.6653892197719429
-        ],
-        [
-            44,
-            85,
-            0.314312856101024
-        ],
-        [
-            44,
-            86,
-            0.2143264697148131
-        ],
-        [
-            44,
-            89,
-            0.7559289460184546
-        ],
-        [
-            44,
-            95,
-            0.3333333333333334
-        ],
-        [
-            44,
-            96,
-            0.6614378277661477
-        ],
-        [
-            44,
-            97,
-            0.5773502691896258
-        ],
-        [
-            44,
-            98,
-            0.6666666666666669
-        ],
-        [
-            44,
-            100,
-            0.5091750772173155
-        ],
-        [
-            44,
-            101,
-            0.5976143046671968
-        ],
-        [
-            44,
-            104,
-            1.0
-        ],
-        [
-            44,
-            105,
-            0.7302967433402214
-        ],
-        [
-            44,
-            112,
-            1.0
-        ],
-        [
-            44,
-            121,
-            1.0
+            0.13606557377049178
         ],
         [
             45,
             0,
-            0.7559289460184545
+            0.08852459016393444
+        ],
+        [
+            45,
+            1,
+            0.2573770491803279
         ],
         [
             45,
             2,
-            0.5976143046671969
+            0.980327868852459
         ],
         [
             45,
             3,
-            0.18898223650461363
+            0.980327868852459
         ],
         [
             45,
             4,
-            0.7559289460184545
+            0.2573770491803279
         ],
         [
             45,
             5,
-            0.47809144373375745
+            0.980327868852459
+        ],
+        [
+            45,
+            6,
+            0.9114754098360656
         ],
         [
             45,
             7,
-            0.47809144373375745
+            0.980327868852459
+        ],
+        [
+            45,
+            8,
+            0.2573770491803279
+        ],
+        [
+            45,
+            9,
+            0.2557377049180328
+        ],
+        [
+            45,
+            10,
+            0.980327868852459
+        ],
+        [
+            45,
+            11,
+            0.980327868852459
+        ],
+        [
+            45,
+            12,
+            0.2557377049180328
+        ],
+        [
+            45,
+            13,
+            0.980327868852459
+        ],
+        [
+            45,
+            14,
+            0.980327868852459
         ],
         [
             45,
             15,
-            0.5091750772173155
+            0.2573770491803279
         ],
         [
             45,
             16,
-            0.47809144373375745
+            0.980327868852459
         ],
         [
             45,
             17,
-            0.21821789023599233
+            0.898360655737705
+        ],
+        [
+            45,
+            18,
+            0.9688524590163934
         ],
         [
             45,
             19,
-            0.7453559924999299
+            0.9819672131147541
+        ],
+        [
+            45,
+            20,
+            0.9754098360655737
+        ],
+        [
+            45,
+            21,
+            0.9737704918032787
+        ],
+        [
+            45,
+            22,
+            0.9754098360655737
+        ],
+        [
+            45,
+            23,
+            0.9754098360655737
         ],
         [
             45,
             24,
-            0.7149203529842406
+            0.9868852459016394
         ],
         [
             45,
             25,
-            -0.13130643285972257
+            0.9573770491803278
         ],
         [
             45,
             26,
-            0.4037864265436241
+            0.9868852459016394
         ],
         [
             45,
             27,
-            0.36115755925730775
+            0.9737704918032787
         ],
         [
             45,
             28,
-            0.4037864265436241
+            0.9737704918032787
         ],
         [
             45,
             29,
-            0.7825855808712294
+            0.9885245901639345
         ],
         [
             45,
             30,
-            0.7352060597618597
+            0.9737704918032787
         ],
         [
             45,
             31,
-            0.10001653302482982
+            0.9721311475409836
         ],
         [
             45,
             32,
-            0.7681550050616364
+            0.9868852459016394
         ],
         [
             45,
             33,
-            0.125622443813572
+            0.9737704918032787
         ],
         [
             45,
             34,
-            0.7681550050616364
+            0.9721311475409836
         ],
         [
             45,
             35,
-            0.46625240412015695
+            0.9885245901639345
         ],
         [
             45,
             36,
-            0.6396930210072015
+            0.9868852459016394
         ],
         [
             45,
             37,
-            0.38737781366765006
+            0.9901639344262295
         ],
         [
             45,
             38,
-            0.6908212560386473
+            1.0
         ],
         [
             45,
             39,
-            0.5439611381401829
+            0.9868852459016394
         ],
         [
             45,
             40,
-            0.8722783759886468
+            0.9885245901639345
         ],
         [
             45,
             41,
-            0.563241847975046
+            0.9770491803278688
         ],
         [
             45,
             42,
-            0.4037864265436241
+            0.9737704918032787
         ],
         [
             45,
             43,
-            1.0
+            0.9770491803278688
         ],
         [
             45,
             44,
-            0.2656937137768186
+            0.9704918032786886
         ],
         [
             45,
@@ -15342,272 +17411,382 @@
         [
             45,
             46,
-            -0.13130643285972257
+            0.9885245901639345
         ],
         [
             45,
             47,
-            0.563241847975046
+            0.9491803278688524
         ],
         [
             45,
-            89,
-            0.5976143046671969
+            48,
+            0.9885245901639345
         ],
         [
             45,
-            96,
-            0.7559289460184544
+            49,
+            0.9918032786885246
         ],
         [
             45,
-            97,
-            0.47809144373375745
+            50,
+            0.9868852459016394
         ],
         [
             45,
-            101,
-            0.47809144373375745
+            51,
+            0.9737704918032787
         ],
         [
             45,
-            104,
-            0.5976143046671969
+            52,
+            0.9672131147540983
         ],
         [
             45,
-            105,
-            0.47809144373375745
+            53,
+            0.1442622950819672
+        ],
+        [
+            45,
+            54,
+            0.2213114754098361
+        ],
+        [
+            45,
+            55,
+            0.20819672131147537
+        ],
+        [
+            45,
+            56,
+            0.20491803278688525
+        ],
+        [
+            45,
+            57,
+            0.2114754098360656
+        ],
+        [
+            45,
+            58,
+            0.12786885245901636
+        ],
+        [
+            45,
+            59,
+            0.040983606557377095
+        ],
+        [
+            45,
+            60,
+            0.22295081967213115
+        ],
+        [
+            45,
+            61,
+            0.239344262295082
+        ],
+        [
+            45,
+            62,
+            0.03934426229508192
+        ],
+        [
+            45,
+            63,
+            0.03934426229508192
+        ],
+        [
+            45,
+            64,
+            0.23770491803278693
+        ],
+        [
+            45,
+            65,
+            0.23278688524590163
+        ],
+        [
+            45,
+            66,
+            0.17704918032786887
+        ],
+        [
+            45,
+            67,
+            0.23114754098360657
+        ],
+        [
+            45,
+            68,
+            0.15573770491803274
+        ],
+        [
+            45,
+            69,
+            0.7508196721311475
+        ],
+        [
+            45,
+            70,
+            0.7508196721311475
+        ],
+        [
+            45,
+            71,
+            0.7475409836065574
+        ],
+        [
+            45,
+            72,
+            0.6950819672131148
+        ],
+        [
+            45,
+            73,
+            0.17377049180327864
+        ],
+        [
+            45,
+            74,
+            0.7524590163934426
+        ],
+        [
+            45,
+            75,
+            0.13606557377049178
         ],
         [
             46,
             0,
-            0.0303941361359476
+            0.0770491803278689
         ],
         [
             46,
             1,
-            0.04754364728687035
+            0.24590163934426235
         ],
         [
             46,
             2,
-            0.022585877718926034
+            0.9885245901639345
         ],
         [
             46,
             3,
-            -0.02397093678464215
+            0.9885245901639345
         ],
         [
             46,
             4,
-            0.027769626707270668
+            0.24590163934426235
         ],
         [
             46,
             5,
-            0.06087522533246546
+            0.9885245901639345
         ],
         [
             46,
             6,
-            0.06007606855521771
+            0.919672131147541
         ],
         [
             46,
             7,
-            0.06066787359428632
+            0.9885245901639345
         ],
         [
             46,
             8,
-            -0.012368944202009846
+            0.24590163934426235
         ],
         [
             46,
             9,
-            0.0023661736314343766
+            0.2475409836065574
         ],
         [
             46,
             10,
-            0.18199895675914052
+            0.9885245901639345
         ],
         [
             46,
             11,
-            0.061690798566690824
+            0.9885245901639345
         ],
         [
             46,
             12,
-            0.016253961229434406
+            0.2475409836065574
         ],
         [
             46,
             13,
-            0.04831210719512372
+            0.9885245901639345
         ],
         [
             46,
             14,
-            0.019491864587767745
+            0.9885245901639345
         ],
         [
             46,
             15,
-            0.640862839151883
+            0.24590163934426235
         ],
         [
             46,
             16,
-            0.040850420281152475
+            0.9885245901639345
         ],
         [
             46,
             17,
-            -0.022130996175241648
+            0.9065573770491804
         ],
         [
             46,
             18,
-            -0.01858470558997977
+            0.9770491803278688
         ],
         [
             46,
             19,
-            -0.016638657720158646
+            0.9901639344262295
         ],
         [
             46,
             20,
-            0.018843837183134034
+            0.9836065573770492
         ],
         [
             46,
             21,
-            -0.013380672059507933
+            0.9819672131147541
         ],
         [
             46,
             22,
-            0.31854676701854284
+            0.9836065573770492
         ],
         [
             46,
             23,
-            0.04837236977919666
+            0.9836065573770492
         ],
         [
             46,
             24,
-            -0.0928476690885259
+            0.9950819672131147
         ],
         [
             46,
             25,
-            0.9080113270615588
+            0.9655737704918033
         ],
         [
             46,
             26,
-            0.11677484162422846
+            0.9950819672131147
         ],
         [
             46,
             27,
-            0.11385500851066237
+            0.9819672131147541
         ],
         [
             46,
             28,
-            0.1215661347709662
+            0.9819672131147541
         ],
         [
             46,
             29,
-            0.47294676966278226
+            0.9967213114754099
         ],
         [
             46,
             30,
-            0.2148344622118299
+            0.9819672131147541
         ],
         [
             46,
             31,
-            0.06419364740540222
+            0.980327868852459
         ],
         [
             46,
             32,
-            -0.17677669529663687
+            0.9950819672131147
         ],
         [
             46,
             33,
-            -0.035805743701971995
+            0.9819672131147541
         ],
         [
             46,
             34,
-            -0.17370208344491278
+            0.980327868852459
         ],
         [
             46,
             35,
-            -0.24405148745018082
+            0.9967213114754099
         ],
         [
             46,
             36,
-            0.16238586255274196
+            0.9983606557377049
         ],
         [
             46,
             37,
-            -0.12649110640673517
+            0.9983606557377049
         ],
         [
             46,
             38,
-            -0.08980265101338751
+            0.9885245901639345
         ],
         [
             46,
             39,
-            -0.09284766908852603
+            0.9950819672131147
         ],
         [
             46,
             40,
-            -0.14002800840280097
+            0.9967213114754099
         ],
         [
             46,
             41,
-            -0.07283570407292302
+            0.9852459016393442
         ],
         [
             46,
             42,
-            0.1215661347709662
+            0.9819672131147541
         ],
         [
             46,
             43,
-            -0.13130643285972257
+            0.9852459016393442
         ],
         [
             46,
             44,
-            0.04035683513149589
+            0.978688524590164
         ],
         [
             46,
             45,
-            -0.13130643285972257
+            0.9885245901639345
         ],
         [
             46,
@@ -15617,252 +17796,382 @@
         [
             46,
             47,
-            -0.07027283689263071
+            0.9540983606557377
         ],
         [
             46,
             48,
-            0.03825879033836463
+            0.9967213114754099
         ],
         [
             46,
             49,
-            0.2573391964374366
+            0.9967213114754099
+        ],
+        [
+            46,
+            50,
+            0.9950819672131147
         ],
         [
             46,
             51,
-            0.0265575676350065
+            0.9819672131147541
         ],
         [
             46,
             52,
-            0.006722313553838051
+            0.9721311475409836
         ],
         [
             46,
             53,
-            0.1424408512027475
+            0.13278688524590165
         ],
         [
             46,
             54,
-            0.2215094546918919
+            0.21311475409836067
         ],
         [
             46,
             55,
-            0.634860795026937
+            0.19999999999999996
         ],
         [
             46,
             56,
-            0.3177471342965577
+            0.1934426229508197
         ],
         [
             46,
             57,
-            0.5827154894540385
+            0.2032786885245902
         ],
         [
             46,
             58,
-            0.03291234517356976
+            0.11639344262295082
         ],
         [
             46,
             59,
-            0.16584120172163094
+            0.02950819672131144
         ],
         [
             46,
             60,
-            0.3210452064997757
+            0.21475409836065573
         ],
         [
             46,
             61,
-            0.22433692106596143
+            0.23114754098360657
         ],
         [
             46,
             62,
-            0.7606806276054251
+            0.02786885245901638
         ],
         [
             46,
             63,
-            0.2853325622438602
+            0.02786885245901638
         ],
         [
             46,
             64,
-            0.39445373790540167
+            0.2295081967213115
         ],
         [
             46,
             65,
-            0.2393983042410439
+            0.2245901639344262
         ],
         [
             46,
             66,
-            0.5398624279729676
+            0.16885245901639345
         ],
         [
             46,
             67,
-            0.20038536432514242
+            0.21967213114754103
         ],
         [
             46,
             68,
-            0.6398990262079147
+            0.14754098360655743
         ],
         [
             46,
             69,
-            0.23795013241955656
+            0.759016393442623
         ],
         [
             46,
             70,
-            0.25982467081151095
+            0.759016393442623
         ],
         [
             46,
             71,
-            0.3120497048382957
+            0.759016393442623
         ],
         [
             46,
             72,
-            0.23104269203643224
+            0.7032786885245902
         ],
         [
             46,
-            83,
-            0.10494520621550063
+            73,
+            0.16557377049180333
         ],
         [
             46,
-            86,
-            0.33431778832516756
+            74,
+            0.7573770491803279
+        ],
+        [
+            46,
+            75,
+            0.14098360655737707
+        ],
+        [
+            47,
+            0,
+            0.12295081967213117
+        ],
+        [
+            47,
+            1,
+            0.2918032786885246
+        ],
+        [
+            47,
+            2,
+            0.9459016393442623
+        ],
+        [
+            47,
+            3,
+            0.9459016393442623
+        ],
+        [
+            47,
+            4,
+            0.2918032786885246
+        ],
+        [
+            47,
+            5,
+            0.9459016393442623
+        ],
+        [
+            47,
+            6,
+            0.8770491803278688
+        ],
+        [
+            47,
+            7,
+            0.9459016393442623
+        ],
+        [
+            47,
+            8,
+            0.2918032786885246
+        ],
+        [
+            47,
+            9,
+            0.29016393442622945
+        ],
+        [
+            47,
+            10,
+            0.9459016393442623
+        ],
+        [
+            47,
+            11,
+            0.9459016393442623
+        ],
+        [
+            47,
+            12,
+            0.29016393442622945
+        ],
+        [
+            47,
+            13,
+            0.9459016393442623
+        ],
+        [
+            47,
+            14,
+            0.9459016393442623
+        ],
+        [
+            47,
+            15,
+            0.2918032786885246
+        ],
+        [
+            47,
+            16,
+            0.9459016393442623
+        ],
+        [
+            47,
+            17,
+            0.8901639344262295
+        ],
+        [
+            47,
+            18,
+            0.9606557377049181
+        ],
+        [
+            47,
+            19,
+            0.9475409836065574
+        ],
+        [
+            47,
+            20,
+            0.9672131147540983
+        ],
+        [
+            47,
+            21,
+            0.9655737704918033
+        ],
+        [
+            47,
+            22,
+            0.9672131147540983
+        ],
+        [
+            47,
+            23,
+            0.9672131147540983
         ],
         [
             47,
             24,
-            0.7878385971583358
+            0.9524590163934427
         ],
         [
             47,
             25,
-            -0.07027283689263071
+            0.9557377049180328
         ],
         [
             47,
             26,
-            0.21908902300206634
+            0.9524590163934427
         ],
         [
             47,
             27,
-            0.21821789023599245
+            0.9655737704918033
         ],
         [
             47,
             28,
-            0.22742941307367087
+            0.9655737704918033
         ],
         [
             47,
             29,
-            0.2867696673382023
+            0.9540983606557377
         ],
         [
             47,
             30,
-            0.46409548089225694
+            0.9655737704918033
         ],
         [
             47,
             31,
-            -0.0860078077570234
+            0.9639344262295082
         ],
         [
             47,
             32,
-            0.4109609335312651
+            0.9524590163934427
         ],
         [
             47,
             33,
-            -0.09759000729485338
+            0.9721311475409836
         ],
         [
             47,
             34,
-            0.43265704458219684
+            0.9639344262295082
         ],
         [
             47,
             35,
-            0.26261286571944503
+            0.9540983606557377
         ],
         [
             47,
             36,
-            0.36030187928883606
+            0.9524590163934427
         ],
         [
             47,
             37,
-            0.023669053416557537
+            0.9557377049180328
         ],
         [
             47,
             38,
-            0.18389242812245685
+            0.9491803278688524
         ],
         [
             47,
             39,
-            0.7878385971583354
+            0.9590163934426229
         ],
         [
             47,
             40,
-            0.4640954808922571
+            0.9540983606557377
         ],
         [
             47,
             41,
-            1.0
+            0.9688524590163934
         ],
         [
             47,
             42,
-            0.22742941307367087
+            0.9655737704918033
         ],
         [
             47,
             43,
-            0.563241847975046
+            0.9688524590163934
         ],
         [
             47,
             44,
-            -0.16571045299983217
+            0.9688524590163934
         ],
         [
             47,
             45,
-            0.563241847975046
+            0.9491803278688524
         ],
         [
             47,
             46,
-            -0.07027283689263071
+            0.9540983606557377
         ],
         [
             47,
@@ -15870,16988 +18179,10783 @@
             1.0
         ],
         [
+            47,
+            48,
+            0.9540983606557377
+        ],
+        [
+            47,
+            49,
+            0.9573770491803278
+        ],
+        [
+            47,
+            50,
+            0.9524590163934427
+        ],
+        [
+            47,
+            51,
+            0.9655737704918033
+        ],
+        [
+            47,
+            52,
+            0.9590163934426229
+        ],
+        [
+            47,
+            53,
+            0.1754098360655738
+        ],
+        [
+            47,
+            54,
+            0.2524590163934426
+        ],
+        [
+            47,
+            55,
+            0.23278688524590163
+        ],
+        [
+            47,
+            56,
+            0.22622950819672127
+        ],
+        [
+            47,
+            57,
+            0.23606557377049175
+        ],
+        [
+            47,
+            58,
+            0.1622950819672131
+        ],
+        [
+            47,
+            59,
+            0.07540983606557372
+        ],
+        [
+            47,
+            60,
+            0.25409836065573765
+        ],
+        [
+            47,
+            61,
+            0.26721311475409837
+        ],
+        [
+            47,
+            62,
+            0.07377049180327866
+        ],
+        [
+            47,
+            63,
+            0.07377049180327866
+        ],
+        [
+            47,
+            64,
+            0.2622950819672131
+        ],
+        [
+            47,
+            65,
+            0.260655737704918
+        ],
+        [
+            47,
+            66,
+            0.20163934426229513
+        ],
+        [
+            47,
+            67,
+            0.25901639344262295
+        ],
+        [
+            47,
+            68,
+            0.18360655737704923
+        ],
+        [
+            47,
+            69,
+            0.7163934426229508
+        ],
+        [
+            47,
+            70,
+            0.7163934426229508
+        ],
+        [
+            47,
+            71,
+            0.7131147540983607
+        ],
+        [
+            47,
+            72,
+            0.660655737704918
+        ],
+        [
+            47,
+            73,
+            0.1983606557377049
+        ],
+        [
+            47,
+            74,
+            0.7180327868852459
+        ],
+        [
+            47,
+            75,
+            0.11475409836065575
+        ],
+        [
             48,
             0,
-            0.5838798885359712
+            0.0770491803278689
         ],
         [
             48,
             1,
-            0.7238596901560045
+            0.24590163934426235
         ],
         [
             48,
             2,
-            0.5856651491594542
+            0.9852459016393442
         ],
         [
             48,
             3,
-            0.4545247381964273
+            0.9852459016393442
         ],
         [
             48,
             4,
-            0.2959603197070847
+            0.24590163934426235
         ],
         [
             48,
             5,
-            0.7339434939239653
+            0.9852459016393442
         ],
         [
             48,
             6,
-            0.7064614568374011
+            0.9163934426229509
         ],
         [
             48,
             7,
-            0.7339632595013426
+            0.9852459016393442
         ],
         [
             48,
             8,
-            0.20272240699067595
+            0.24590163934426235
         ],
         [
             48,
             9,
-            0.5658530723636707
+            0.24426229508196717
         ],
         [
             48,
             10,
-            0.6930787609380564
+            0.9852459016393442
         ],
         [
             48,
             11,
-            0.7204265839851172
+            0.9852459016393442
         ],
         [
             48,
             12,
-            0.578910086497819
+            0.24426229508196717
         ],
         [
             48,
             13,
-            0.3242948862567506
+            0.9852459016393442
         ],
         [
             48,
             14,
-            0.4300762849900987
+            0.9852459016393442
         ],
         [
             48,
             15,
-            0.361045430873923
+            0.24590163934426235
         ],
         [
             48,
             16,
-            0.8138381762808107
+            0.9852459016393442
         ],
         [
             48,
             17,
-            0.4339324872513432
+            0.9032786885245901
         ],
         [
             48,
             18,
-            0.42539517538009336
+            0.9737704918032787
         ],
         [
             48,
             19,
-            0.3710247698636945
+            0.9868852459016394
         ],
         [
             48,
             20,
-            0.6337811001097985
+            0.980327868852459
         ],
         [
             48,
             21,
-            0.40307440917406095
+            0.978688524590164
         ],
         [
             48,
             22,
-            0.3921501490609633
+            0.980327868852459
         ],
         [
             48,
             23,
-            0.30873929570902714
+            0.980327868852459
         ],
         [
             48,
-            25,
-            0.1412020791437809
-        ],
-        [
-            48,
-            31,
-            0.5796138737028416
-        ],
-        [
-            48,
-            44,
-            0.5258368109897522
-        ],
-        [
-            48,
-            46,
-            0.03825879033836463
-        ],
-        [
-            48,
-            48,
-            1.0
-        ],
-        [
-            48,
-            49,
-            0.6998557571053878
-        ],
-        [
-            48,
-            51,
-            0.7235861601368387
-        ],
-        [
-            48,
-            52,
-            0.29016370859953733
-        ],
-        [
-            48,
-            53,
-            0.7853422170530676
-        ],
-        [
-            48,
-            54,
-            0.7939496143312738
-        ],
-        [
-            48,
-            55,
-            0.4801399594612589
-        ],
-        [
-            48,
-            56,
-            0.5344626316860024
-        ],
-        [
-            48,
-            57,
-            0.11813151764295128
-        ],
-        [
-            48,
-            58,
-            0.5422064004166708
-        ],
-        [
-            48,
-            59,
-            0.6128983260938583
-        ],
-        [
-            48,
-            60,
-            0.529935423449672
-        ],
-        [
-            48,
-            61,
-            0.7943377373358524
-        ],
-        [
-            48,
-            62,
-            0.07050277087923619
-        ],
-        [
-            48,
-            63,
-            0.5252416428601482
-        ],
-        [
-            48,
-            64,
-            0.3197472158862051
-        ],
-        [
-            48,
-            65,
-            0.5885946125248084
-        ],
-        [
-            48,
-            66,
-            0.10546146579168413
-        ],
-        [
-            48,
-            67,
-            0.5910856875025373
-        ],
-        [
-            48,
-            68,
-            0.0863448573701275
-        ],
-        [
-            48,
-            69,
-            0.6452980594574388
-        ],
-        [
-            48,
-            70,
-            0.5911279994797357
-        ],
-        [
-            48,
-            71,
-            0.5050113634618714
-        ],
-        [
-            48,
-            72,
-            0.6694926610573531
-        ],
-        [
-            48,
-            73,
-            0.1985151474481492
-        ],
-        [
-            48,
-            74,
-            0.37306932719210034
-        ],
-        [
-            48,
-            75,
-            0.8355654373511302
-        ],
-        [
-            48,
-            76,
-            0.3186891868093627
-        ],
-        [
-            48,
-            77,
-            0.46932327100492965
-        ],
-        [
-            48,
-            78,
-            0.8358316859472515
-        ],
-        [
-            48,
-            79,
-            0.37497527032921707
-        ],
-        [
-            48,
-            80,
-            0.7090819174235541
-        ],
-        [
-            48,
-            81,
-            0.6020142234071966
-        ],
-        [
-            48,
-            82,
-            0.37830543812186895
-        ],
-        [
-            48,
-            83,
-            0.8167036203755575
-        ],
-        [
-            48,
-            84,
-            0.46547069410825626
-        ],
-        [
-            48,
-            85,
-            0.42340516367869563
-        ],
-        [
-            48,
-            86,
-            0.34911117944693165
-        ],
-        [
-            48,
-            112,
-            1.0
-        ],
-        [
-            48,
-            121,
-            1.0
-        ],
-        [
-            49,
-            0,
-            0.7628398627477878
-        ],
-        [
-            49,
-            1,
-            0.7991838718169643
-        ],
-        [
-            49,
-            2,
-            0.6697342218471222
-        ],
-        [
-            49,
-            3,
-            0.5303188276947495
-        ],
-        [
-            49,
-            4,
-            0.3984327568439004
-        ],
-        [
-            49,
-            5,
-            0.8919163253374234
-        ],
-        [
-            49,
-            6,
-            0.8690306734411086
-        ],
-        [
-            49,
-            7,
-            0.8973234326660444
-        ],
-        [
-            49,
-            8,
-            0.21167603615957195
-        ],
-        [
-            49,
-            9,
-            0.6378083767904101
-        ],
-        [
-            49,
-            10,
-            0.8488044499859198
-        ],
-        [
-            49,
-            11,
-            0.8829858416753936
-        ],
-        [
-            49,
-            12,
-            0.7119560611409992
-        ],
-        [
-            49,
-            13,
-            0.4400663575232731
-        ],
-        [
-            49,
-            14,
-            0.4593833739376394
-        ],
-        [
-            49,
-            15,
-            0.48627175780883286
-        ],
-        [
-            49,
-            16,
-            0.7767545596269781
-        ],
-        [
-            49,
-            17,
-            0.4721992024059799
-        ],
-        [
-            49,
-            18,
-            0.44901911715102516
-        ],
-        [
-            49,
-            19,
-            0.3734949387874955
-        ],
-        [
-            49,
-            20,
-            0.7608176376620894
-        ],
-        [
-            49,
-            21,
-            0.4007479723169497
-        ],
-        [
-            49,
-            22,
-            0.5441146060029758
-        ],
-        [
-            49,
-            23,
-            0.42538528505220985
-        ],
-        [
-            49,
-            25,
-            0.36654704807155014
-        ],
-        [
-            49,
-            27,
-            1.0
-        ],
-        [
-            49,
-            29,
-            0.39477101697586137
-        ],
-        [
-            49,
-            31,
-            0.6946928551806679
-        ],
-        [
-            49,
-            37,
-            0.7071067811865475
-        ],
-        [
-            49,
-            38,
-            0.3015113445777636
-        ],
-        [
-            49,
-            40,
-            0.33333333333333337
-        ],
-        [
-            49,
-            44,
-            0.612351907488237
-        ],
-        [
-            49,
-            46,
-            0.2573391964374366
-        ],
-        [
-            49,
-            48,
-            0.6998557571053878
-        ],
-        [
-            49,
-            49,
-            1.0
-        ],
-        [
-            49,
-            50,
-            0.3535533905932737
-        ],
-        [
-            49,
-            51,
-            0.7310662747385661
-        ],
-        [
-            49,
-            52,
-            0.4020951947795516
-        ],
-        [
-            49,
-            53,
-            0.8250944847118427
-        ],
-        [
-            49,
-            54,
-            0.8669769720968662
-        ],
-        [
-            49,
-            55,
-            0.6870647205512307
-        ],
-        [
-            49,
-            56,
-            0.7550242844955223
-        ],
-        [
-            49,
-            57,
-            0.36633335036829245
-        ],
-        [
-            49,
-            58,
-            0.7011176793378677
-        ],
-        [
-            49,
-            59,
-            0.7728317091588468
-        ],
-        [
-            49,
-            60,
-            0.7497497306006466
-        ],
-        [
-            49,
-            61,
-            0.8682971567320099
-        ],
-        [
-            49,
-            62,
-            0.26523681714162195
-        ],
-        [
-            49,
-            63,
-            0.7191060631171521
-        ],
-        [
-            49,
-            64,
-            0.497983437426278
-        ],
-        [
-            49,
-            65,
-            0.8310533503574572
-        ],
-        [
-            49,
-            66,
-            0.2754475624773887
-        ],
-        [
-            49,
-            67,
-            0.7674556742516695
-        ],
-        [
-            49,
-            68,
-            0.2538869346894688
-        ],
-        [
-            49,
-            69,
-            0.9265320007920668
-        ],
-        [
-            49,
-            70,
-            0.857962763864767
-        ],
-        [
-            49,
-            71,
-            0.7251614476812358
-        ],
-        [
-            49,
-            72,
-            0.915792081672577
-        ],
-        [
-            49,
-            73,
-            0.2893741588813536
-        ],
-        [
-            49,
-            74,
-            0.4001034417947443
-        ],
-        [
-            49,
-            75,
-            0.9021150582355415
-        ],
-        [
-            49,
-            76,
-            0.3161098148649569
-        ],
-        [
-            49,
-            77,
-            0.48053613953515056
-        ],
-        [
-            49,
-            78,
-            0.9034036509716439
-        ],
-        [
-            49,
-            79,
-            0.43769362322598737
-        ],
-        [
-            49,
-            80,
-            0.8315667549715151
-        ],
-        [
-            49,
-            81,
-            0.6386908625478129
-        ],
-        [
-            49,
-            82,
-            0.44331034746678655
-        ],
-        [
-            49,
-            83,
-            0.9259777038413898
-        ],
-        [
-            49,
-            84,
-            0.4598850925135676
-        ],
-        [
-            49,
-            85,
-            0.45113300645186216
-        ],
-        [
-            49,
-            86,
-            0.3365552767215637
-        ],
-        [
-            49,
-            88,
-            1.0
-        ],
-        [
-            49,
-            89,
-            0.8451542547285166
-        ],
-        [
-            49,
-            90,
-            1.0
-        ],
-        [
-            49,
-            92,
-            1.0
-        ],
-        [
-            49,
-            93,
-            1.0
-        ],
-        [
-            49,
-            94,
-            1.0
-        ],
-        [
-            49,
-            95,
-            0.5773502691896258
-        ],
-        [
-            49,
-            96,
-            0.3015113445777636
-        ],
-        [
-            49,
-            98,
-            0.5773502691896258
-        ],
-        [
-            49,
-            99,
-            1.0
-        ],
-        [
-            49,
-            100,
-            0.5773502691896257
-        ],
-        [
-            49,
-            101,
-            1.0
-        ],
-        [
-            49,
-            112,
-            1.0
-        ],
-        [
-            49,
-            121,
-            1.0
-        ],
-        [
-            50,
-            0,
-            -0.06286946134619319
-        ],
-        [
-            50,
-            1,
-            0.5222329678670935
-        ],
-        [
-            50,
-            2,
-            0.46625240412015717
-        ],
-        [
-            50,
-            3,
-            0.5222329678670935
-        ],
-        [
-            50,
-            4,
-            -0.09090909090909086
-        ],
-        [
-            50,
-            5,
-            0.5222329678670935
-        ],
-        [
-            50,
-            6,
-            0.5222329678670935
-        ],
-        [
-            50,
-            7,
-            0.5222329678670935
-        ],
-        [
-            50,
-            8,
-            -0.09090909090909086
-        ],
-        [
-            50,
-            9,
-            1.0
-        ],
-        [
-            50,
-            10,
-            0.674199862463242
-        ],
-        [
-            50,
-            11,
-            0.5222329678670935
-        ],
-        [
-            50,
-            14,
-            0.6666666666666667
-        ],
-        [
-            50,
-            16,
-            0.24671758189758472
-        ],
-        [
-            50,
-            17,
-            0.426401432711221
-        ],
-        [
-            50,
-            18,
-            0.6666666666666667
-        ],
-        [
-            50,
-            19,
-            -0.09090909090909086
-        ],
-        [
-            50,
-            27,
-            0.5773502691896257
-        ],
-        [
-            50,
-            29,
-            -0.23354968324845696
-        ],
-        [
-            50,
-            31,
-            0.4770599615316209
-        ],
-        [
-            50,
-            37,
-            0.40824829046386296
-        ],
-        [
-            50,
-            38,
-            0.5222329678670934
-        ],
-        [
-            50,
-            40,
-            -0.33333333333333337
-        ],
-        [
-            50,
-            44,
-            0.202610224618277
-        ],
-        [
-            50,
-            49,
-            0.3535533905932737
-        ],
-        [
-            50,
-            50,
-            1.0
-        ],
-        [
-            50,
-            53,
-            0.3535533905932737
-        ],
-        [
-            50,
-            54,
-            0.3535533905932737
-        ],
-        [
-            50,
-            56,
-            0.45833333333333337
-        ],
-        [
-            50,
-            59,
-            0.40233989938361225
-        ],
-        [
-            50,
-            60,
-            0.45833333333333337
-        ],
-        [
-            50,
-            61,
-            0.3535533905932737
-        ],
-        [
-            50,
-            63,
-            0.40233989938361225
-        ],
-        [
-            50,
-            64,
-            -0.10998533626601505
-        ],
-        [
-            50,
-            65,
-            0.35355339059327373
-        ],
-        [
-            50,
-            66,
-            1.0
-        ],
-        [
-            50,
-            67,
-            0.5932958789676532
-        ],
-        [
-            50,
-            74,
-            0.5773502691896257
-        ],
-        [
-            50,
-            78,
-            1.0
-        ],
-        [
-            50,
-            83,
-            1.0
-        ],
-        [
-            50,
-            84,
-            1.0
-        ],
-        [
-            50,
-            89,
-            0.6831300510639732
-        ],
-        [
-            50,
-            95,
-            0.5
-        ],
-        [
-            50,
-            96,
-            0.5222329678670935
-        ],
-        [
-            50,
-            98,
-            -0.49999999999999994
-        ],
-        [
-            50,
-            100,
-            1.0
-        ],
-        [
-            50,
-            101,
-            0.5773502691896256
-        ],
-        [
-            51,
-            0,
-            0.6806709508239852
-        ],
-        [
-            51,
-            1,
-            0.7658289047617725
-        ],
-        [
-            51,
-            2,
-            0.752070648404761
-        ],
-        [
-            51,
-            3,
-            0.46209994258266274
-        ],
-        [
-            51,
-            4,
-            0.2994505381442801
-        ],
-        [
-            51,
-            5,
-            0.7477240788977773
-        ],
-        [
-            51,
-            6,
-            0.7206457581031055
-        ],
-        [
-            51,
-            7,
-            0.7477240788977776
-        ],
-        [
-            51,
-            8,
-            0.19746540518900774
-        ],
-        [
-            51,
-            9,
-            0.7037005659473914
-        ],
-        [
-            51,
-            10,
-            0.8301212096169832
-        ],
-        [
-            51,
-            11,
-            0.7335275784873174
-        ],
-        [
-            51,
-            12,
-            0.6432223996719644
-        ],
-        [
-            51,
-            13,
-            0.37676316119476716
-        ],
-        [
-            51,
-            14,
-            0.5478431389718883
-        ],
-        [
-            51,
-            15,
-            0.3765539748902697
-        ],
-        [
-            51,
-            16,
-            0.7433189806388155
-        ],
-        [
-            51,
-            17,
-            0.4766776072481858
-        ],
-        [
-            51,
-            18,
-            0.5100786019626584
-        ],
-        [
-            51,
-            19,
-            0.4813091676548979
-        ],
-        [
-            51,
-            20,
-            0.7110687823197125
-        ],
-        [
-            51,
-            21,
-            0.5481309631086673
-        ],
-        [
-            51,
-            22,
-            0.4391236200595292
-        ],
-        [
-            51,
-            23,
-            0.3588721504586567
-        ],
-        [
-            51,
-            25,
-            0.15188275147941446
-        ],
-        [
-            51,
-            31,
-            0.6530320124256694
-        ],
-        [
-            51,
-            44,
-            0.6644615465948323
-        ],
-        [
-            51,
-            46,
-            0.0265575676350065
-        ],
-        [
-            51,
-            48,
-            0.7235861601368387
-        ],
-        [
-            51,
-            49,
-            0.7310662747385661
-        ],
-        [
-            51,
-            51,
-            1.0
-        ],
-        [
-            51,
-            52,
-            0.35542647500802765
-        ],
-        [
-            51,
-            53,
-            0.7262276068012369
-        ],
-        [
-            51,
-            54,
-            0.7399899825292293
-        ],
-        [
-            51,
-            55,
-            0.5727494951270035
-        ],
-        [
-            51,
-            56,
-            0.6090066340211281
-        ],
-        [
-            51,
-            57,
-            0.1640939241713145
-        ],
-        [
-            51,
-            58,
-            0.6283722165968118
-        ],
-        [
-            51,
-            59,
-            0.7433358487152304
-        ],
-        [
-            51,
-            60,
-            0.604688935386922
-        ],
-        [
-            51,
-            61,
-            0.731562109009004
-        ],
-        [
-            51,
-            62,
-            0.08592437456044154
-        ],
-        [
-            51,
-            63,
-            0.6747963762362861
-        ],
-        [
-            51,
-            64,
-            0.3400297564915117
-        ],
-        [
-            51,
-            65,
-            0.6374337604334754
-        ],
-        [
-            51,
-            66,
-            0.10650629778846638
-        ],
-        [
-            51,
-            67,
-            0.7163098750262133
-        ],
-        [
-            51,
-            68,
-            0.12491555460600934
-        ],
-        [
-            51,
-            69,
-            0.6805962306481751
-        ],
-        [
-            51,
-            70,
-            0.6478502099193182
-        ],
-        [
-            51,
-            71,
-            0.5706536428612597
-        ],
-        [
-            51,
-            72,
-            0.6993454647241769
-        ],
-        [
-            51,
-            73,
-            0.29525198901989747
-        ],
-        [
-            51,
-            74,
-            0.397033333588372
-        ],
-        [
-            51,
-            75,
-            0.8919348802395209
-        ],
-        [
-            51,
-            76,
-            0.34634034629899585
-        ],
-        [
-            51,
-            77,
-            0.534183427346822
-        ],
-        [
-            51,
-            78,
-            0.8921130952380959
-        ],
-        [
-            51,
-            79,
-            0.4133185231840147
-        ],
-        [
-            51,
-            80,
-            0.7849115999782721
-        ],
-        [
-            51,
-            81,
-            0.6430524620718616
-        ],
-        [
-            51,
-            82,
-            0.40153288138680876
-        ],
-        [
-            51,
-            83,
-            0.892506234761633
-        ],
-        [
-            51,
-            84,
-            0.47299885932255115
-        ],
-        [
-            51,
-            85,
-            0.46658512079158704
-        ],
-        [
-            51,
-            86,
-            0.28740321894319243
-        ],
-        [
-            51,
-            112,
-            1.0
-        ],
-        [
-            51,
-            121,
-            1.0
-        ],
-        [
-            52,
-            0,
-            0.48982387398079563
-        ],
-        [
-            52,
-            1,
-            0.298778774238436
-        ],
-        [
-            52,
-            2,
-            0.3733282307763728
-        ],
-        [
-            52,
-            3,
-            0.12833366285844527
-        ],
-        [
-            52,
-            4,
-            0.15678065182064072
-        ],
-        [
-            52,
-            5,
-            0.37944298857289194
-        ],
-        [
-            52,
-            6,
-            0.34749583647495125
-        ],
-        [
-            52,
-            7,
-            0.3794429885728916
-        ],
-        [
-            52,
-            8,
-            0.08261286676913716
-        ],
-        [
-            52,
-            9,
-            0.32254659430189614
-        ],
-        [
-            52,
-            10,
-            0.3764202596454769
-        ],
-        [
-            52,
-            11,
-            0.35550614319003954
-        ],
-        [
-            52,
-            12,
-            0.44761349099675085
-        ],
-        [
-            52,
-            13,
-            0.7862733066153151
-        ],
-        [
-            52,
-            14,
-            -0.011601400710326677
-        ],
-        [
-            52,
-            15,
-            0.4926101210186795
-        ],
-        [
-            52,
-            16,
-            0.3296814943682546
-        ],
-        [
-            52,
-            17,
-            0.10677095900138293
-        ],
-        [
-            52,
-            18,
-            -0.01290222581399861
-        ],
-        [
-            52,
-            19,
-            0.1465326572596161
-        ],
-        [
-            52,
-            20,
-            0.3027033329744559
-        ],
-        [
-            52,
-            21,
-            -0.009295348533830959
-        ],
-        [
-            52,
-            22,
-            0.6787722191643806
-        ],
-        [
-            52,
-            23,
-            0.8360454540973505
-        ],
-        [
-            52,
-            25,
-            0.3961276302462554
-        ],
-        [
-            52,
-            31,
-            0.1671463956718534
-        ],
-        [
-            52,
-            44,
-            0.20680375268461787
-        ],
-        [
-            52,
-            46,
-            0.006722313553838051
-        ],
-        [
-            52,
-            48,
-            0.29016370859953733
-        ],
-        [
-            52,
-            49,
-            0.4020951947795516
-        ],
-        [
-            52,
-            51,
-            0.35542647500802765
-        ],
-        [
-            52,
-            52,
-            1.0
-        ],
-        [
-            52,
-            53,
-            0.34278975562900404
-        ],
-        [
-            52,
-            54,
-            0.3466393412155487
-        ],
-        [
-            52,
-            55,
-            0.49763249182719416
-        ],
-        [
-            52,
-            56,
-            0.5263705451370229
-        ],
-        [
-            52,
-            57,
-            0.33236452678615847
-        ],
-        [
-            52,
-            58,
-            0.5142906059902381
-        ],
-        [
-            52,
-            59,
-            0.43463956269969356
-        ],
-        [
-            52,
-            60,
-            0.5251950283248994
-        ],
-        [
-            52,
-            61,
-            0.3444585820557006
-        ],
-        [
-            52,
-            62,
-            0.21847205262765929
-        ],
-        [
-            52,
-            63,
-            0.39925659450642254
-        ],
-        [
-            52,
-            64,
-            0.5735164591845869
-        ],
-        [
-            52,
-            65,
-            0.3786862669407705
-        ],
-        [
-            52,
-            66,
-            0.13191499759222625
-        ],
-        [
-            52,
-            67,
-            0.4630716852051444
-        ],
-        [
-            52,
-            68,
-            0.11808404499788042
-        ],
-        [
-            52,
-            69,
-            0.38142870193488615
-        ],
-        [
-            52,
-            70,
-            0.4354583858112672
-        ],
-        [
-            52,
-            71,
-            0.5234517197108727
-        ],
-        [
-            52,
-            72,
-            0.3727526409020546
-        ],
-        [
-            52,
-            73,
-            0.20623973278043936
-        ],
-        [
-            52,
-            74,
-            -0.031097661401635283
-        ],
-        [
-            52,
-            75,
-            0.3157836464689797
-        ],
-        [
-            52,
-            76,
-            0.16148960208279683
-        ],
-        [
-            52,
-            77,
-            0.43469810612489657
-        ],
-        [
-            52,
-            78,
-            0.31608526385698715
-        ],
-        [
-            52,
-            79,
-            0.4089918311153384
-        ],
-        [
-            52,
-            80,
-            0.2824724531410804
-        ],
-        [
-            52,
-            81,
-            0.24789615613975569
-        ],
-        [
-            52,
-            82,
-            0.12962422189735173
-        ],
-        [
-            52,
-            83,
-            0.29534065433833334
-        ],
-        [
-            52,
-            84,
-            -0.023782574707724897
-        ],
-        [
-            52,
-            85,
-            0.3611830218196948
-        ],
-        [
-            52,
-            86,
-            0.30979654361223
-        ],
-        [
-            52,
-            112,
-            1.0
-        ],
-        [
-            52,
-            121,
-            1.0
-        ],
-        [
-            53,
-            0,
-            0.6686609764968598
-        ],
-        [
-            53,
-            1,
-            0.854488471332478
-        ],
-        [
-            53,
-            2,
-            0.6811253040916233
-        ],
-        [
-            53,
-            3,
-            0.5783607208631983
-        ],
-        [
-            53,
-            4,
-            0.3815977709733618
-        ],
-        [
-            53,
-            5,
-            0.8621991709032293
-        ],
-        [
-            53,
-            6,
-            0.8339584624502578
-        ],
-        [
-            53,
-            7,
-            0.8622088505459301
-        ],
-        [
-            53,
-            8,
-            0.2501415047251222
-        ],
-        [
-            53,
-            9,
-            0.7003244540777719
-        ],
-        [
-            53,
-            10,
-            0.8248587099359223
-        ],
-        [
-            53,
-            11,
-            0.8481134287795166
-        ],
-        [
-            53,
-            12,
-            0.6726042710784025
-        ],
-        [
-            53,
-            13,
-            0.39998004583912994
-        ],
-        [
-            53,
-            14,
-            0.5521965077170402
-        ],
-        [
-            53,
-            15,
-            0.4402053308162498
-        ],
-        [
-            53,
-            16,
-            0.8830332496877165
-        ],
-        [
-            53,
-            17,
-            0.5491135075645177
-        ],
-        [
-            53,
-            18,
-            0.5183547146044386
-        ],
-        [
-            53,
-            19,
-            0.49117447181225354
-        ],
-        [
-            53,
-            20,
-            0.7714352445168458
-        ],
-        [
-            53,
-            21,
-            0.5217351995274047
-        ],
-        [
-            53,
-            22,
-            0.48567619705117776
-        ],
-        [
-            53,
-            23,
-            0.3868367741753892
-        ],
-        [
-            53,
-            25,
-            0.2754246748432608
-        ],
-        [
-            53,
-            27,
-            1.0
-        ],
-        [
-            53,
-            29,
-            0.39477101697586137
-        ],
-        [
-            53,
-            31,
-            0.6877619765887935
-        ],
-        [
-            53,
-            37,
-            0.7071067811865475
-        ],
-        [
-            53,
-            38,
-            0.3015113445777636
-        ],
-        [
-            53,
-            40,
-            0.33333333333333337
-        ],
-        [
-            53,
-            44,
-            0.6313825586808371
-        ],
-        [
-            53,
-            46,
-            0.1424408512027475
-        ],
-        [
-            53,
-            48,
-            0.7853422170530676
-        ],
-        [
-            53,
-            49,
-            0.8250944847118427
-        ],
-        [
-            53,
-            50,
-            0.3535533905932737
-        ],
-        [
-            53,
-            51,
-            0.7262276068012369
-        ],
-        [
-            53,
-            52,
-            0.34278975562900404
-        ],
-        [
-            53,
-            53,
-            1.0
-        ],
-        [
-            53,
-            54,
-            0.9454607813799566
-        ],
-        [
-            53,
-            55,
-            0.5869027101362561
-        ],
-        [
-            53,
-            56,
-            0.6445402415871689
-        ],
-        [
-            53,
-            57,
-            0.2644460559824947
-        ],
-        [
-            53,
-            58,
-            0.6110451541862113
-        ],
-        [
-            53,
-            59,
-            0.7820501952467214
-        ],
-        [
-            53,
-            60,
-            0.6406049654959997
-        ],
-        [
-            53,
-            61,
-            0.9397509313518312
-        ],
-        [
-            53,
-            62,
-            0.15297253257980162
-        ],
-        [
-            53,
-            63,
-            0.666357684354488
-        ],
-        [
-            53,
-            64,
-            0.4359468918429124
-        ],
-        [
-            53,
-            65,
-            0.7026952952479391
-        ],
-        [
-            53,
-            66,
-            0.17538704655561912
-        ],
-        [
-            53,
-            67,
-            0.7101432284932838
-        ],
-        [
-            53,
-            68,
-            0.13660208201618076
-        ],
-        [
-            53,
-            69,
-            0.7586525059839169
-        ],
-        [
-            53,
-            70,
-            0.7000299163547444
-        ],
-        [
-            53,
-            71,
-            0.6185617221789343
-        ],
-        [
-            53,
-            72,
-            0.7770882957627085
-        ],
-        [
-            53,
-            73,
-            0.3264039867003976
-        ],
-        [
-            53,
-            74,
-            0.4912456842785716
-        ],
-        [
-            53,
-            75,
-            0.9679722821357292
-        ],
-        [
-            53,
-            76,
-            0.332435131435923
-        ],
-        [
-            53,
-            77,
-            0.47788709341091834
-        ],
-        [
-            53,
-            78,
-            0.9683853030036478
-        ],
-        [
-            53,
-            79,
-            0.4339565163726142
-        ],
-        [
-            53,
-            80,
-            0.7903813599053088
-        ],
-        [
-            53,
-            81,
-            0.6959928263731637
-        ],
-        [
-            53,
-            82,
-            0.4452650280184789
-        ],
-        [
-            53,
-            83,
-            0.9478004327110218
-        ],
-        [
-            53,
-            84,
-            0.5870512379769168
-        ],
-        [
-            53,
-            85,
-            0.4430520211965393
-        ],
-        [
-            53,
-            86,
-            0.34329988782872434
-        ],
-        [
-            53,
-            88,
-            1.0
-        ],
-        [
-            53,
-            89,
-            0.8451542547285166
-        ],
-        [
-            53,
-            90,
-            1.0
-        ],
-        [
-            53,
-            92,
-            1.0
-        ],
-        [
-            53,
-            93,
-            1.0
-        ],
-        [
-            53,
-            94,
-            1.0
-        ],
-        [
-            53,
-            95,
-            0.5773502691896258
-        ],
-        [
-            53,
-            96,
-            0.3015113445777636
-        ],
-        [
-            53,
-            98,
-            0.5773502691896258
-        ],
-        [
-            53,
-            99,
-            1.0
-        ],
-        [
-            53,
-            100,
-            0.5773502691896257
-        ],
-        [
-            53,
-            101,
-            1.0
-        ],
-        [
-            53,
-            112,
-            1.0
-        ],
-        [
-            53,
-            121,
-            1.0
-        ],
-        [
-            54,
-            0,
-            0.6733966405755691
-        ],
-        [
-            54,
-            1,
-            0.8625556165743687
-        ],
-        [
-            54,
-            2,
-            0.6777640672946363
-        ],
-        [
-            54,
-            3,
-            0.5913922100062655
-        ],
-        [
-            54,
-            4,
-            0.38189313552646387
-        ],
-        [
-            54,
-            5,
-            0.8657307768047895
-        ],
-        [
-            54,
-            6,
-            0.8373471059871187
-        ],
-        [
-            54,
-            7,
-            0.8657401873412734
-        ],
-        [
-            54,
-            8,
-            0.2496735355909357
-        ],
-        [
-            54,
-            9,
-            0.693338714514738
-        ],
-        [
-            54,
-            10,
-            0.8435240480619688
-        ],
-        [
-            54,
-            11,
-            0.8515810619273081
-        ],
-        [
-            54,
-            12,
-            0.674329267180953
-        ],
-        [
-            54,
-            13,
-            0.4026869684979679
-        ],
-        [
-            54,
-            14,
-            0.5443367529048875
-        ],
-        [
-            54,
-            15,
-            0.4613114234477723
-        ],
-        [
-            54,
-            16,
-            0.9027926624886612
-        ],
-        [
-            54,
-            17,
-            0.5774277438455978
-        ],
-        [
-            54,
-            18,
-            0.5317111843517718
-        ],
-        [
-            54,
-            19,
-            0.49103598621438704
-        ],
-        [
-            54,
-            20,
-            0.7882344470571088
-        ],
-        [
-            54,
-            21,
-            0.5201068424563684
-        ],
-        [
-            54,
-            22,
-            0.5085388749710523
-        ],
-        [
-            54,
-            23,
-            0.38943462479984214
-        ],
-        [
-            54,
-            25,
-            0.3231436939186752
-        ],
-        [
-            54,
-            27,
-            1.0
-        ],
-        [
-            54,
-            29,
-            0.39477101697586137
-        ],
-        [
-            54,
-            31,
-            0.7007004756305579
-        ],
-        [
-            54,
-            37,
-            0.7071067811865475
-        ],
-        [
-            54,
-            38,
-            0.3015113445777636
-        ],
-        [
-            54,
-            40,
-            0.33333333333333337
-        ],
-        [
-            54,
-            44,
-            0.6320585868424646
-        ],
-        [
-            54,
-            46,
-            0.2215094546918919
-        ],
-        [
-            54,
-            48,
-            0.7939496143312738
-        ],
-        [
-            54,
-            49,
-            0.8669769720968662
-        ],
-        [
-            54,
-            50,
-            0.3535533905932737
-        ],
-        [
-            54,
-            51,
-            0.7399899825292293
-        ],
-        [
-            54,
-            52,
-            0.3466393412155487
-        ],
-        [
-            54,
-            53,
-            0.9454607813799566
-        ],
-        [
-            54,
-            54,
-            1.0
-        ],
-        [
-            54,
-            55,
-            0.6061555585739284
-        ],
-        [
-            54,
-            56,
-            0.6670617510652772
-        ],
-        [
-            54,
-            57,
-            0.3242991087060567
-        ],
-        [
-            54,
-            58,
-            0.6159220650573066
-        ],
-        [
-            54,
-            59,
-            0.7588180863884523
-        ],
-        [
-            54,
-            60,
-            0.6618916866556807
-        ],
-        [
-            54,
-            61,
-            0.9863211203055313
-        ],
-        [
-            54,
-            62,
-            0.23150356389768062
-        ],
-        [
-            54,
-            63,
-            0.6813215623362829
-        ],
-        [
-            54,
-            64,
-            0.46963391034511953
-        ],
-        [
-            54,
-            65,
-            0.7529674992730518
-        ],
-        [
-            54,
-            66,
-            0.2406483592930872
-        ],
-        [
-            54,
-            67,
-            0.7145689531849779
-        ],
-        [
-            54,
-            68,
-            0.22861084535688006
-        ],
-        [
-            54,
-            69,
-            0.8017822930357289
-        ],
-        [
-            54,
-            70,
-            0.7471615404345975
-        ],
-        [
-            54,
-            71,
-            0.6397323356523144
-        ],
-        [
-            54,
-            72,
-            0.8213701063690703
-        ],
-        [
-            54,
-            73,
-            0.3066659445727034
-        ],
-        [
-            54,
-            74,
-            0.4602301726438759
-        ],
-        [
-            54,
-            75,
-            0.9462672319050619
-        ],
-        [
-            54,
-            76,
-            0.33243513143592296
-        ],
-        [
-            54,
-            77,
-            0.4778870934109186
-        ],
-        [
-            54,
-            78,
-            0.9469647986054095
-        ],
-        [
-            54,
-            79,
-            0.4339565163726144
-        ],
-        [
-            54,
-            80,
-            0.790381359905308
-        ],
-        [
-            54,
-            81,
-            0.6756369832823921
-        ],
-        [
-            54,
-            82,
-            0.4246236028785493
-        ],
-        [
-            54,
-            83,
-            0.9478004327110213
-        ],
-        [
-            54,
-            84,
-            0.5489310277186753
-        ],
-        [
-            54,
-            85,
-            0.44305202119653914
-        ],
-        [
-            54,
-            86,
-            0.32983700690570444
-        ],
-        [
-            54,
-            88,
-            1.0
-        ],
-        [
-            54,
-            89,
-            0.8451542547285166
-        ],
-        [
-            54,
-            90,
-            1.0
-        ],
-        [
-            54,
-            92,
-            1.0
-        ],
-        [
-            54,
-            93,
-            1.0
-        ],
-        [
-            54,
-            94,
-            1.0
-        ],
-        [
-            54,
-            95,
-            0.5773502691896258
-        ],
-        [
-            54,
-            96,
-            0.3015113445777636
-        ],
-        [
-            54,
-            98,
-            0.5773502691896258
-        ],
-        [
-            54,
-            99,
-            1.0
-        ],
-        [
-            54,
-            100,
-            0.5773502691896257
-        ],
-        [
-            54,
-            101,
-            1.0
-        ],
-        [
-            54,
-            112,
-            1.0
-        ],
-        [
-            54,
-            113,
-            1.0
-        ],
-        [
-            54,
-            114,
-            1.0
-        ],
-        [
-            54,
-            115,
-            1.0
-        ],
-        [
-            54,
-            121,
-            1.0
-        ],
-        [
-            55,
-            0,
-            0.7628237733371179
-        ],
-        [
-            55,
-            1,
-            0.554827225567293
-        ],
-        [
-            55,
-            2,
-            0.5863921757572743
-        ],
-        [
-            55,
-            3,
-            0.31908562656224926
-        ],
-        [
-            55,
-            4,
-            0.4366609607608188
-        ],
-        [
-            55,
-            5,
-            0.6467451167180107
-        ],
-        [
-            55,
-            6,
-            0.6146376183841887
-        ],
-        [
-            55,
-            7,
-            0.641709829689413
-        ],
-        [
-            55,
-            8,
-            0.23344504402712982
-        ],
-        [
-            55,
-            9,
-            0.5713546863460388
-        ],
-        [
-            55,
-            10,
-            0.6605504827393988
-        ],
-        [
-            55,
-            11,
-            0.6304920685384328
-        ],
-        [
-            55,
-            12,
-            0.7632536912092387
-        ],
-        [
-            55,
-            13,
-            0.5717939132910798
-        ],
-        [
-            55,
-            14,
-            0.2783328815752712
-        ],
-        [
-            55,
-            15,
-            0.7737848281120586
-        ],
-        [
-            55,
-            16,
-            0.5338600469226643
-        ],
-        [
-            55,
-            17,
-            0.21190573396243906
-        ],
-        [
-            55,
-            18,
-            0.2608437521827303
-        ],
-        [
-            55,
-            19,
-            0.28585883558295444
-        ],
-        [
-            55,
-            20,
-            0.5158608054374759
-        ],
-        [
-            55,
-            21,
-            0.309799675628025
-        ],
-        [
-            55,
-            22,
-            0.7057409344773885
-        ],
-        [
-            55,
-            23,
-            0.5497102209718047
-        ],
-        [
-            55,
-            25,
-            0.6986199223263727
-        ],
-        [
-            55,
-            31,
-            0.443812360022392
-        ],
-        [
-            55,
-            44,
-            0.5081956215508513
-        ],
-        [
-            55,
-            46,
-            0.634860795026937
-        ],
-        [
-            55,
-            48,
-            0.4801399594612589
-        ],
-        [
-            55,
-            49,
-            0.6870647205512307
-        ],
-        [
-            55,
-            51,
-            0.5727494951270035
-        ],
-        [
-            55,
-            52,
-            0.49763249182719416
-        ],
-        [
-            55,
-            53,
-            0.5869027101362561
-        ],
-        [
-            55,
-            54,
-            0.6061555585739284
-        ],
-        [
-            55,
-            55,
-            1.0
-        ],
-        [
-            55,
-            56,
-            0.8400031796971499
-        ],
-        [
-            55,
-            57,
-            0.4518734145906132
-        ],
-        [
-            55,
-            58,
-            0.7618925320772764
-        ],
-        [
-            55,
-            59,
-            0.7140488756276994
-        ],
-        [
-            55,
-            60,
-            0.8359977731780722
-        ],
-        [
-            55,
-            61,
-            0.6086452073138777
-        ],
-        [
-            55,
-            62,
-            0.32260011773432906
-        ],
-        [
-            55,
-            63,
-            0.6643284231317302
-        ],
-        [
-            55,
-            64,
-            0.609835234568412
-        ],
-        [
-            55,
-            65,
-            0.6629289664830292
-        ],
-        [
-            55,
-            66,
-            0.2893730870933857
-        ],
-        [
-            55,
-            67,
-            0.7519994452789295
-        ],
-        [
-            55,
-            68,
-            0.29618827166758466
-        ],
-        [
-            55,
-            69,
-            0.6557805879745032
-        ],
-        [
-            55,
-            70,
-            0.7294168320860803
-        ],
-        [
-            55,
-            71,
-            0.8119590815514477
-        ],
-        [
-            55,
-            72,
-            0.6479948295063939
-        ],
-        [
-            55,
-            73,
-            0.3477583153055676
-        ],
-        [
-            55,
-            74,
-            0.3496466033765337
-        ],
-        [
-            55,
-            75,
-            0.5197133095965225
-        ],
-        [
-            55,
-            76,
-            0.27483562731087363
-        ],
-        [
-            55,
-            77,
-            0.7063856517368761
-        ],
-        [
-            55,
-            78,
-            0.5200499630204675
-        ],
-        [
-            55,
-            79,
-            0.6656237542138637
-        ],
-        [
-            55,
-            80,
-            0.5314271964678814
-        ],
-        [
-            55,
-            81,
-            0.44167623400802813
-        ],
-        [
-            55,
-            82,
-            0.2118768346683168
-        ],
-        [
-            55,
-            83,
-            0.5244829033003676
-        ],
-        [
-            55,
-            84,
-            0.35440871367981336
-        ],
-        [
-            55,
-            85,
-            0.5899920143010966
-        ],
-        [
-            55,
-            86,
-            0.5939160993596
-        ],
-        [
-            56,
-            0,
-            0.8857021247184436
-        ],
-        [
-            56,
-            1,
-            0.5848716446266828
-        ],
-        [
-            56,
-            2,
-            0.6213304565718285
-        ],
-        [
-            56,
-            3,
-            0.3798985332068976
-        ],
-        [
-            56,
-            4,
-            0.5577008943251115
-        ],
-        [
-            56,
-            5,
-            0.6816135261249185
-        ],
-        [
-            56,
-            6,
-            0.6562830332523588
-        ],
-        [
-            56,
-            7,
-            0.6816135261249182
-        ],
-        [
-            56,
-            8,
-            0.27126492897756155
-        ],
-        [
-            56,
-            9,
-            0.5779738877697849
-        ],
-        [
-            56,
-            10,
-            0.6918829216402781
-        ],
-        [
-            56,
-            11,
-            0.6708219003558078
-        ],
-        [
-            56,
-            12,
-            0.8595548679344744
-        ],
-        [
-            56,
-            13,
-            0.5717864248830148
-        ],
-        [
-            56,
-            14,
-            0.3274116118175144
-        ],
-        [
-            56,
-            15,
-            0.6383926689803836
-        ],
-        [
-            56,
-            16,
-            0.5889405261047629
-        ],
-        [
-            56,
-            17,
-            0.2977702417052971
-        ],
-        [
-            56,
-            18,
-            0.31911819057862717
-        ],
-        [
-            56,
-            19,
-            0.44087504165678276
-        ],
-        [
-            56,
-            20,
-            0.561645352314298
-        ],
-        [
-            56,
-            21,
-            0.4613914879638394
-        ],
-        [
-            56,
-            22,
-            0.690993539561976
-        ],
-        [
-            56,
-            23,
-            0.5496941960840582
-        ],
-        [
-            56,
-            25,
-            0.4592509600605416
-        ],
-        [
-            56,
-            27,
-            0.4472135954999579
-        ],
-        [
-            56,
-            29,
-            0.2724746304565331
-        ],
-        [
-            56,
-            31,
-            0.5133184439423685
-        ],
-        [
-            56,
-            37,
-            0.15811388300841894
-        ],
-        [
-            56,
-            38,
-            0.6741998624632421
-        ],
-        [
-            56,
-            44,
-            0.6501271580858727
-        ],
-        [
-            56,
-            46,
-            0.3177471342965577
-        ],
-        [
-            56,
-            48,
-            0.5344626316860024
-        ],
-        [
-            56,
-            49,
-            0.7550242844955223
-        ],
-        [
-            56,
-            50,
-            0.45833333333333337
-        ],
-        [
-            56,
-            51,
-            0.6090066340211281
-        ],
-        [
-            56,
-            52,
-            0.5263705451370229
-        ],
-        [
-            56,
-            53,
-            0.6445402415871689
-        ],
-        [
-            56,
-            54,
-            0.6670617510652772
-        ],
-        [
-            56,
-            55,
-            0.8400031796971499
-        ],
-        [
-            56,
-            56,
-            1.0
-        ],
-        [
-            56,
-            57,
-            0.4688183072582491
-        ],
-        [
-            56,
-            58,
-            0.9031925290899491
-        ],
-        [
-            56,
-            59,
-            0.8268527299166218
-        ],
-        [
-            56,
-            60,
-            0.9889787456143357
-        ],
-        [
-            56,
-            61,
-            0.6687052628099383
-        ],
-        [
-            56,
-            62,
-            0.337588982252086
-        ],
-        [
-            56,
-            63,
-            0.6979848506184965
-        ],
-        [
-            56,
-            64,
-            0.6048702122846451
-        ],
-        [
-            56,
-            65,
-            0.714428767380802
-        ],
-        [
-            56,
-            66,
-            0.29089141945115626
-        ],
-        [
-            56,
-            67,
-            0.7960591813614702
-        ],
-        [
-            56,
-            68,
-            0.30821529199830094
-        ],
-        [
-            56,
-            69,
-            0.7194259198539756
-        ],
-        [
-            56,
-            70,
-            0.7799237517195576
-        ],
-        [
-            56,
-            71,
-            0.9565204964698407
-        ],
-        [
-            56,
-            72,
-            0.7092513973886432
-        ],
-        [
-            56,
-            73,
-            0.3191827844811588
-        ],
-        [
-            56,
-            74,
-            0.26046905136144144
-        ],
-        [
-            56,
-            75,
-            0.4771735646265864
-        ],
-        [
-            56,
-            76,
-            0.2861638757417288
-        ],
-        [
-            56,
-            77,
-            0.6510258876444032
-        ],
-        [
-            56,
-            78,
-            0.47257040686521745
-        ],
-        [
-            56,
-            79,
-            0.6133521640983414
-        ],
-        [
-            56,
-            80,
-            0.5189542483660132
-        ],
-        [
-            56,
-            81,
-            0.378977249675833
-        ],
-        [
-            56,
-            82,
-            0.25186730546402214
-        ],
-        [
-            56,
-            83,
-            0.50876051610712
-        ],
-        [
-            56,
-            84,
-            0.3452958451208224
-        ],
-        [
-            56,
-            85,
-            0.5434312250732404
-        ],
-        [
-            56,
-            86,
-            0.49184808824491777
-        ],
-        [
-            56,
-            89,
-            0.5291502622129182
-        ],
-        [
-            56,
-            96,
-            0.6741998624632421
-        ],
-        [
-            56,
-            101,
-            0.4472135954999579
-        ],
-        [
-            56,
-            112,
-            1.0
-        ],
-        [
-            56,
-            121,
-            1.0
-        ],
-        [
-            57,
-            0,
-            0.19885283358835296
-        ],
-        [
-            57,
-            1,
-            0.18339965449967066
-        ],
-        [
-            57,
-            2,
-            0.15947523023673743
-        ],
-        [
-            57,
-            3,
-            0.10598662203401162
-        ],
-        [
-            57,
-            4,
-            0.15351169930468328
-        ],
-        [
-            57,
-            5,
-            0.21195444093308272
-        ],
-        [
-            57,
-            6,
-            0.21427535136257153
-        ],
-        [
-            57,
-            7,
-            0.211954440933083
-        ],
-        [
-            57,
-            8,
-            0.11461854129344866
-        ],
-        [
-            57,
-            9,
-            0.19873674693739007
-        ],
-        [
-            57,
-            10,
-            0.3810770961284182
-        ],
-        [
-            57,
-            11,
-            0.21923035161004079
-        ],
-        [
-            57,
-            12,
-            0.2569932539820991
-        ],
-        [
-            57,
-            13,
-            0.3361274449100647
-        ],
-        [
-            57,
-            14,
-            0.0829770226555521
-        ],
-        [
-            57,
-            15,
-            0.45420603845895535
-        ],
-        [
-            57,
-            16,
-            0.14432540789764808
-        ],
-        [
-            57,
-            17,
-            0.07612038620627128
-        ],
-        [
-            57,
-            18,
-            0.07258049243232154
-        ],
-        [
-            57,
-            19,
-            0.13871959237770615
-        ],
-        [
-            57,
-            20,
-            0.2290774101860604
-        ],
-        [
-            57,
-            21,
-            0.10909180261740532
-        ],
-        [
-            57,
-            22,
-            0.5600522414226432
-        ],
-        [
-            57,
-            23,
-            0.32692468856086204
-        ],
-        [
-            57,
-            25,
-            0.7292034847297477
-        ],
-        [
-            57,
-            31,
-            0.1053599429286665
-        ],
-        [
-            57,
-            44,
-            0.12387907982816328
-        ],
-        [
-            57,
-            46,
-            0.5827154894540385
-        ],
-        [
-            57,
-            48,
-            0.11813151764295128
-        ],
-        [
-            57,
-            49,
-            0.36633335036829245
-        ],
-        [
-            57,
-            51,
-            0.1640939241713145
-        ],
-        [
-            57,
-            52,
-            0.33236452678615847
-        ],
-        [
-            57,
-            53,
-            0.2644460559824947
-        ],
-        [
-            57,
-            54,
-            0.3242991087060567
-        ],
-        [
-            57,
-            55,
-            0.4518734145906132
-        ],
-        [
-            57,
-            56,
-            0.4688183072582491
-        ],
-        [
-            57,
-            57,
-            1.0
-        ],
-        [
-            57,
-            58,
-            0.21345842094878983
-        ],
-        [
-            57,
-            59,
-            0.33450094727782054
-        ],
-        [
-            57,
-            60,
-            0.47217477841296285
-        ],
-        [
-            57,
-            61,
-            0.3306368892006492
-        ],
-        [
-            57,
-            62,
-            0.6397468651777577
-        ],
-        [
-            57,
-            63,
-            0.4130834752865758
-        ],
-        [
-            57,
-            64,
-            0.5163189479703278
-        ],
-        [
-            57,
-            65,
-            0.3543155475691485
-        ],
-        [
-            57,
-            66,
-            0.48370889419821295
-        ],
-        [
-            57,
-            67,
-            0.36823109233675627
-        ],
-        [
-            57,
-            68,
-            0.5421234694403447
-        ],
-        [
-            57,
-            69,
-            0.34500462121843295
-        ],
-        [
-            57,
-            70,
-            0.397838522702318
-        ],
-        [
-            57,
-            71,
-            0.4670498718299589
-        ],
-        [
-            57,
-            72,
-            0.34002985641061056
-        ],
-        [
-            57,
-            73,
-            0.07998679856095454
-        ],
-        [
-            57,
-            74,
-            -0.031463242906325996
-        ],
-        [
-            57,
-            75,
-            0.14027823411273221
-        ],
-        [
-            57,
-            76,
-            0.12012457834424939
-        ],
-        [
-            57,
-            77,
-            0.2022017259074317
-        ],
-        [
-            57,
-            78,
-            0.13880511306950935
-        ],
-        [
-            57,
-            79,
-            0.18897140558743192
-        ],
-        [
-            57,
-            80,
-            0.1604361257498846
-        ],
-        [
-            57,
-            81,
-            0.10340973183051785
-        ],
-        [
-            57,
-            82,
-            0.03944190142157378
-        ],
-        [
-            57,
-            83,
-            0.17056147793191553
-        ],
-        [
-            57,
-            84,
-            -0.024258836737142193
-        ],
-        [
-            57,
-            85,
-            0.1641417704257158
-        ],
-        [
-            57,
-            86,
-            0.18122868148026197
-        ],
-        [
-            58,
-            0,
-            0.8950760306633044
-        ],
-        [
-            58,
-            1,
-            0.5689641585147028
-        ],
-        [
-            58,
-            2,
-            0.6329062896402649
-        ],
-        [
-            58,
-            3,
-            0.3448443145747924
-        ],
-        [
-            58,
-            4,
-            0.47976111972498914
-        ],
-        [
-            58,
-            5,
-            0.6567465852989299
-        ],
-        [
-            58,
-            6,
-            0.6326569544962423
-        ],
-        [
-            58,
-            7,
-            0.6567465852989304
-        ],
-        [
-            58,
-            8,
-            0.25452206052034576
-        ],
-        [
-            58,
-            9,
-            0.5586904301632339
-        ],
-        [
-            58,
-            10,
-            0.6266739995128833
-        ],
-        [
-            58,
-            11,
-            0.6471880593958907
-        ],
-        [
-            58,
-            12,
-            0.8496823523781272
-        ],
-        [
-            58,
-            13,
-            0.54934710174954
-        ],
-        [
-            58,
-            14,
-            0.29714587502700207
-        ],
-        [
-            58,
-            15,
-            0.5248954540241377
-        ],
-        [
-            58,
-            16,
-            0.5899976305553488
-        ],
-        [
-            58,
-            17,
-            0.27381370018937834
-        ],
-        [
-            58,
-            18,
-            0.30599148131218423
-        ],
-        [
-            58,
-            19,
-            0.3837794940769163
-        ],
-        [
-            58,
-            20,
-            0.5333851668523795
-        ],
-        [
-            58,
-            21,
-            0.4442157436031792
-        ],
-        [
-            58,
-            22,
-            0.595944252486587
-        ],
-        [
-            58,
-            23,
-            0.5202482707123366
-        ],
-        [
-            58,
-            25,
-            0.21755512662921295
-        ],
-        [
-            58,
-            31,
-            0.5130856767551647
-        ],
-        [
-            58,
-            44,
-            0.649446696159509
-        ],
-        [
-            58,
-            46,
-            0.03291234517356976
-        ],
-        [
-            58,
-            48,
-            0.5422064004166708
-        ],
-        [
-            58,
-            49,
-            0.7011176793378677
-        ],
-        [
-            58,
-            51,
-            0.6283722165968118
-        ],
-        [
-            58,
-            52,
-            0.5142906059902381
-        ],
-        [
-            58,
-            53,
-            0.6110451541862113
-        ],
-        [
-            58,
-            54,
-            0.6159220650573066
-        ],
-        [
-            58,
-            55,
-            0.7618925320772764
-        ],
-        [
-            58,
-            56,
-            0.9031925290899491
-        ],
-        [
-            58,
-            57,
-            0.21345842094878983
-        ],
-        [
-            58,
-            58,
-            1.0
-        ],
-        [
-            58,
-            59,
-            0.786187918352447
-        ],
-        [
-            58,
-            60,
-            0.9090085139876811
-        ],
-        [
-            58,
-            61,
-            0.6206924778578552
-        ],
-        [
-            58,
-            62,
-            0.1260916727292475
-        ],
-        [
-            58,
-            63,
-            0.6613894031672441
-        ],
-        [
-            58,
-            64,
-            0.47096950793507386
-        ],
-        [
-            58,
-            65,
-            0.6480966668643782
-        ],
-        [
-            58,
-            66,
-            0.10823308919078947
-        ],
-        [
-            58,
-            67,
-            0.7637758799001311
-        ],
-        [
-            58,
-            68,
-            0.12908975846783685
-        ],
-        [
-            58,
-            69,
-            0.6638869673553293
-        ],
-        [
-            58,
-            70,
-            0.721268786503766
-        ],
-        [
-            58,
-            71,
-            0.873786185137349
-        ],
-        [
-            58,
-            72,
-            0.6540324431100847
-        ],
-        [
-            58,
-            73,
-            0.34775831530556794
-        ],
-        [
-            58,
-            74,
-            0.30658731711203996
-        ],
-        [
-            58,
-            75,
-            0.5183319369734622
-        ],
-        [
-            58,
-            76,
-            0.3081309034443368
-        ],
-        [
-            58,
-            77,
-            0.7439072914365253
-        ],
-        [
-            58,
-            78,
-            0.5186826015030329
-        ],
-        [
-            58,
-            79,
-            0.6656237542138634
-        ],
-        [
-            58,
-            80,
-            0.4970425367310802
-        ],
-        [
-            58,
-            81,
-            0.4122822716753176
-        ],
-        [
-            58,
-            82,
-            0.2419913086313263
-        ],
-        [
-            58,
-            83,
-            0.5382765057464942
-        ],
-        [
-            58,
-            84,
-            0.4078636389723285
-        ],
-        [
-            58,
-            85,
-            0.6237645785841365
-        ],
-        [
-            58,
-            86,
-            0.4761121283284595
-        ],
-        [
-            58,
-            112,
-            1.0
-        ],
-        [
-            58,
-            121,
-            1.0
-        ],
-        [
-            59,
-            0,
-            0.8654439824489241
-        ],
-        [
-            59,
-            1,
-            0.7001220017444355
-        ],
-        [
-            59,
-            2,
-            0.7667975142212906
-        ],
-        [
-            59,
-            3,
-            0.46894506769031624
-        ],
-        [
-            59,
-            4,
-            0.4924963057074394
-        ],
-        [
-            59,
-            5,
-            0.6700472884847827
-        ],
-        [
-            59,
-            6,
-            0.6443417059387045
-        ],
-        [
-            59,
-            7,
-            0.6700472884847828
-        ],
-        [
-            59,
-            8,
-            0.26974032121022573
-        ],
-        [
-            59,
-            9,
-            0.7149131029816572
-        ],
-        [
-            59,
-            10,
-            0.7446312123687505
-        ],
-        [
-            59,
-            11,
-            0.6532512899679145
-        ],
-        [
-            59,
-            12,
-            0.8467813333099384
-        ],
-        [
-            59,
-            13,
-            0.48065508000545815
-        ],
-        [
-            59,
-            14,
-            0.5627422783230598
-        ],
-        [
-            59,
-            15,
-            0.5279962543051453
-        ],
-        [
-            59,
-            16,
-            0.7047521368668394
-        ],
-        [
-            59,
-            17,
-            0.47033297004187447
-        ],
-        [
-            59,
-            18,
-            0.5321591227158408
-        ],
-        [
-            59,
-            19,
-            0.6471308742678128
-        ],
-        [
-            59,
-            20,
-            0.6667811351757049
-        ],
-        [
-            59,
-            21,
-            0.6795050958516755
-        ],
-        [
-            59,
-            22,
-            0.5784822258948306
-        ],
-        [
-            59,
-            23,
-            0.4633403751161498
-        ],
-        [
-            59,
-            25,
-            0.33344638002155336
-        ],
-        [
-            59,
-            27,
-            0.5773502691896257
-        ],
-        [
-            59,
-            29,
-            0.17766726362967522
-        ],
-        [
-            59,
-            31,
-            0.6736524127263145
-        ],
-        [
-            59,
-            37,
-            0.40824829046386296
-        ],
-        [
-            59,
-            38,
-            0.5222329678670934
-        ],
-        [
-            59,
-            44,
-            0.8100488863494064
-        ],
-        [
-            59,
-            46,
-            0.16584120172163094
-        ],
-        [
-            59,
-            48,
-            0.6128983260938583
-        ],
-        [
-            59,
-            49,
-            0.7728317091588468
-        ],
-        [
-            59,
-            50,
-            0.40233989938361225
-        ],
-        [
-            59,
-            51,
-            0.7433358487152304
-        ],
-        [
-            59,
-            52,
-            0.43463956269969356
-        ],
-        [
-            59,
-            53,
-            0.7820501952467214
-        ],
-        [
-            59,
-            54,
-            0.7588180863884523
-        ],
-        [
-            59,
-            55,
-            0.7140488756276994
-        ],
-        [
-            59,
-            56,
-            0.8268527299166218
-        ],
-        [
-            59,
-            57,
-            0.33450094727782054
-        ],
-        [
-            59,
-            58,
-            0.786187918352447
-        ],
-        [
-            59,
-            59,
-            1.0
-        ],
-        [
-            59,
-            60,
-            0.8220706079137264
-        ],
-        [
-            59,
-            61,
-            0.7538521978548166
-        ],
-        [
-            59,
-            62,
-            0.19331817236537469
-        ],
-        [
-            59,
-            63,
-            0.7670507596064783
-        ],
-        [
-            59,
-            64,
-            0.47129820530134614
-        ],
-        [
-            59,
-            65,
-            0.6687711372816816
-        ],
-        [
-            59,
-            66,
-            0.15845655155414082
-        ],
-        [
-            59,
-            67,
-            0.8709546434029642
-        ],
-        [
-            59,
-            68,
-            0.14737152407467238
-        ],
-        [
-            59,
-            69,
-            0.724296593902598
-        ],
-        [
-            59,
-            70,
-            0.6781857213584614
-        ],
-        [
-            59,
-            71,
-            0.7902671475363868
-        ],
-        [
-            59,
-            72,
-            0.7470220869315664
-        ],
-        [
-            59,
-            73,
-            0.4345237670891239
-        ],
-        [
-            59,
-            74,
-            0.5606895113749062
-        ],
-        [
-            59,
-            75,
-            0.6437786667115414
-        ],
-        [
-            59,
-            76,
-            0.3759422658250896
-        ],
-        [
-            59,
-            77,
-            0.6815024920568703
-        ],
-        [
-            59,
-            78,
-            0.637417502745566
-        ],
-        [
-            59,
-            79,
-            0.6071769823062519
-        ],
-        [
-            59,
-            80,
-            0.5019274296061491
-        ],
-        [
-            59,
-            81,
-            0.5136257265342967
-        ],
-        [
-            59,
-            82,
-            0.3343583460028043
-        ],
-        [
-            59,
-            83,
-            0.6660680285814269
-        ],
-        [
-            59,
-            84,
-            0.7316269686196134
-        ],
-        [
-            59,
-            85,
-            0.5284165040202013
-        ],
-        [
-            59,
-            86,
-            0.4301449054038492
-        ],
-        [
-            59,
-            89,
-            0.6831300510639732
-        ],
-        [
-            59,
-            96,
-            0.5222329678670935
-        ],
-        [
-            59,
-            101,
-            0.5773502691896256
-        ],
-        [
-            59,
-            112,
-            1.0
-        ],
-        [
-            59,
-            121,
-            1.0
-        ],
-        [
-            60,
-            0,
-            0.8827456901518842
-        ],
-        [
-            60,
-            1,
-            0.5774023624157275
-        ],
-        [
-            60,
-            2,
-            0.6172245091604891
-        ],
-        [
-            60,
-            3,
-            0.36681641647432905
-        ],
-        [
-            60,
-            4,
-            0.5503299488500253
-        ],
-        [
-            60,
-            5,
-            0.6727861889899942
-        ],
-        [
-            60,
-            6,
-            0.647614750415156
-        ],
-        [
-            60,
-            7,
-            0.6727861889899939
-        ],
-        [
-            60,
-            8,
-            0.2742031462815061
-        ],
-        [
-            60,
-            9,
-            0.5700033104231804
-        ],
-        [
-            60,
-            10,
-            0.680548375129879
-        ],
-        [
-            60,
-            11,
-            0.6619391449815145
-        ],
-        [
-            60,
-            12,
-            0.8477164857413069
-        ],
-        [
-            60,
-            13,
-            0.571801393445781
-        ],
-        [
-            60,
-            14,
-            0.303055332280905
-        ],
-        [
-            60,
-            15,
-            0.6385348613753524
-        ],
-        [
-            60,
-            16,
-            0.5842417178988564
-        ],
-        [
-            60,
-            17,
-            0.28146737231827945
-        ],
-        [
-            60,
-            18,
-            0.29727749541933074
-        ],
-        [
-            60,
-            19,
-            0.4206829010249306
-        ],
-        [
-            60,
-            20,
-            0.5544220488432409
-        ],
-        [
-            60,
-            21,
-            0.43160575787782174
-        ],
-        [
-            60,
-            22,
-            0.6913326467027627
-        ],
-        [
-            60,
-            23,
-            0.5497102209718051
-        ],
-        [
-            60,
-            25,
-            0.4594950773793081
-        ],
-        [
-            60,
-            27,
-            0.4472135954999579
-        ],
-        [
-            60,
-            29,
-            0.2724746304565331
-        ],
-        [
-            60,
-            31,
-            0.511325995321613
-        ],
-        [
-            60,
-            37,
-            0.15811388300841894
-        ],
-        [
-            60,
-            38,
-            0.6741998624632421
-        ],
-        [
-            60,
-            44,
-            0.647552925470892
-        ],
-        [
-            60,
-            46,
-            0.3210452064997757
-        ],
-        [
-            60,
-            48,
-            0.529935423449672
-        ],
-        [
-            60,
-            49,
-            0.7497497306006466
-        ],
-        [
-            60,
-            50,
-            0.45833333333333337
-        ],
-        [
-            60,
-            51,
-            0.604688935386922
-        ],
-        [
-            60,
-            52,
-            0.5251950283248994
-        ],
-        [
-            60,
-            53,
-            0.6406049654959997
-        ],
-        [
-            60,
-            54,
-            0.6618916866556807
-        ],
-        [
-            60,
-            55,
-            0.8359977731780722
-        ],
-        [
-            60,
-            56,
-            0.9889787456143357
-        ],
-        [
-            60,
-            57,
-            0.47217477841296285
-        ],
-        [
-            60,
-            58,
-            0.9090085139876811
-        ],
-        [
-            60,
-            59,
-            0.8220706079137264
-        ],
-        [
-            60,
-            60,
-            1.0
-        ],
-        [
-            60,
-            61,
-            0.6685995396901891
-        ],
-        [
-            60,
-            62,
-            0.3348503361874041
-        ],
-        [
-            60,
-            63,
-            0.6937968569971092
-        ],
-        [
-            60,
-            64,
-            0.5998824393116029
-        ],
-        [
-            60,
-            65,
-            0.7078844326623216
-        ],
-        [
-            60,
-            66,
-            0.29878170526016157
-        ],
-        [
-            60,
-            67,
-            0.7903379527209393
-        ],
-        [
-            60,
-            68,
-            0.31690978693560645
-        ],
-        [
-            60,
-            69,
-            0.7140392953634501
-        ],
-        [
-            60,
-            70,
-            0.7758801735894011
-        ],
-        [
-            60,
-            71,
-            0.9595544132870687
-        ],
-        [
-            60,
-            72,
-            0.7023637472717941
-        ],
-        [
-            60,
-            73,
-            0.3191827844811588
-        ],
-        [
-            60,
-            74,
-            0.26046905136144144
-        ],
-        [
-            60,
-            75,
-            0.4771735646265864
-        ],
-        [
-            60,
-            76,
-            0.2861638757417288
-        ],
-        [
-            60,
-            77,
-            0.6510258876444032
-        ],
-        [
-            60,
-            78,
-            0.47257040686521745
-        ],
-        [
-            60,
-            79,
-            0.6133521640983414
-        ],
-        [
-            60,
-            80,
-            0.5189542483660132
-        ],
-        [
-            60,
-            81,
-            0.378977249675833
-        ],
-        [
-            60,
-            82,
-            0.25186730546402214
-        ],
-        [
-            60,
-            83,
-            0.50876051610712
-        ],
-        [
-            60,
-            84,
-            0.3452958451208224
-        ],
-        [
-            60,
-            85,
-            0.5434312250732404
-        ],
-        [
-            60,
-            86,
-            0.49184808824491777
-        ],
-        [
-            60,
-            89,
-            0.5291502622129182
-        ],
-        [
-            60,
-            96,
-            0.6741998624632421
-        ],
-        [
-            60,
-            101,
-            0.4472135954999579
-        ],
-        [
-            60,
-            112,
-            1.0
-        ],
-        [
-            60,
-            121,
-            1.0
-        ],
-        [
-            61,
-            0,
-            0.6787435187743633
-        ],
-        [
-            61,
-            1,
-            0.8562279255784957
-        ],
-        [
-            61,
-            2,
-            0.6685095907486841
-        ],
-        [
-            61,
-            3,
-            0.5907746510728373
-        ],
-        [
-            61,
-            4,
-            0.3771905966741625
-        ],
-        [
-            61,
-            5,
-            0.8724433924246752
-        ],
-        [
-            61,
-            6,
-            0.844134893035422
-        ],
-        [
-            61,
-            7,
-            0.8724523315005893
-        ],
-        [
-            61,
-            8,
-            0.25178046736619214
-        ],
-        [
-            61,
-            9,
-            0.6857094114255845
-        ],
-        [
-            61,
-            10,
-            0.8391769156969572
-        ],
-        [
-            61,
-            11,
-            0.8583587474728072
-        ],
-        [
-            61,
-            12,
-            0.6806972624924542
-        ],
-        [
-            61,
-            13,
-            0.40462213040488954
-        ],
-        [
-            61,
-            14,
-            0.5412007121596085
-        ],
-        [
-            61,
-            15,
-            0.4568666562709804
-        ],
-        [
-            61,
-            16,
-            0.8933863735914109
-        ],
-        [
-            61,
-            17,
-            0.5657640708204567
-        ],
-        [
-            61,
-            18,
-            0.5226494061525803
-        ],
-        [
-            61,
-            19,
-            0.47419106204725964
-        ],
-        [
-            61,
-            20,
-            0.782008339206638
-        ],
-        [
-            61,
-            21,
-            0.5241894556577359
-        ],
-        [
-            61,
-            22,
-            0.5030141810505884
-        ],
-        [
-            61,
-            23,
-            0.3912999880520132
-        ],
-        [
-            61,
-            25,
-            0.32415629227020815
-        ],
-        [
-            61,
-            27,
-            1.0
-        ],
-        [
-            61,
-            29,
-            0.39477101697586137
-        ],
-        [
-            61,
-            31,
-            0.6947410550097296
-        ],
-        [
-            61,
-            37,
-            0.7071067811865475
-        ],
-        [
-            61,
-            38,
-            0.3015113445777636
-        ],
-        [
-            61,
-            40,
-            0.33333333333333337
-        ],
-        [
-            61,
-            44,
-            0.6260667162786813
-        ],
-        [
-            61,
-            46,
-            0.22433692106596143
-        ],
-        [
-            61,
-            48,
-            0.7943377373358524
-        ],
-        [
-            61,
-            49,
-            0.8682971567320099
-        ],
-        [
-            61,
-            50,
-            0.3535533905932737
-        ],
-        [
-            61,
-            51,
-            0.731562109009004
-        ],
-        [
-            61,
-            52,
-            0.3444585820557006
-        ],
-        [
-            61,
-            53,
-            0.9397509313518312
-        ],
-        [
-            61,
-            54,
-            0.9863211203055313
-        ],
-        [
-            61,
-            55,
-            0.6086452073138777
-        ],
-        [
-            61,
-            56,
-            0.6687052628099383
-        ],
-        [
-            61,
-            57,
-            0.3306368892006492
-        ],
-        [
-            61,
-            58,
-            0.6206924778578552
-        ],
-        [
-            61,
-            59,
-            0.7538521978548166
-        ],
-        [
-            61,
-            60,
-            0.6685995396901891
-        ],
-        [
-            61,
-            61,
-            1.0
-        ],
-        [
-            61,
-            62,
-            0.23014889093921517
-        ],
-        [
-            61,
-            63,
-            0.6804420225320976
-        ],
-        [
-            61,
-            64,
-            0.46612337425905603
-        ],
-        [
-            61,
-            65,
-            0.7526909573952122
-        ],
-        [
-            61,
-            66,
-            0.24688655799023856
-        ],
-        [
-            61,
-            67,
-            0.7157978115856868
-        ],
-        [
-            61,
-            68,
-            0.2356048554823083
-        ],
-        [
-            61,
-            69,
-            0.802769744245175
-        ],
-        [
-            61,
-            70,
-            0.7479153138141772
-        ],
-        [
-            61,
-            71,
-            0.6425032403633865
-        ],
-        [
-            61,
-            72,
-            0.8221766201775859
-        ],
-        [
-            61,
-            73,
-            0.29739581517422825
-        ],
-        [
-            61,
-            74,
-            0.4602301726438759
-        ],
-        [
-            61,
-            75,
-            0.9354812379934845
-        ],
-        [
-            61,
-            76,
-            0.3255798715502322
-        ],
-        [
-            61,
-            77,
-            0.45885395892849706
-        ],
-        [
-            61,
-            78,
-            0.936322193973667
-        ],
-        [
-            61,
-            79,
-            0.4159112812308164
-        ],
-        [
-            61,
-            80,
-            0.8003445988338292
-        ],
-        [
-            61,
-            81,
-            0.6664249685364119
-        ],
-        [
-            61,
-            82,
-            0.43950711711150586
-        ],
-        [
-            61,
-            83,
-            0.9582097685952232
-        ],
-        [
-            61,
-            84,
-            0.5489310277186753
-        ],
-        [
-            61,
-            85,
-            0.427318433757171
-        ],
-        [
-            61,
-            86,
-            0.31739730956373535
-        ],
-        [
-            61,
-            88,
-            1.0
-        ],
-        [
-            61,
-            89,
-            0.8451542547285166
-        ],
-        [
-            61,
-            90,
-            1.0
-        ],
-        [
-            61,
-            92,
-            1.0
-        ],
-        [
-            61,
-            93,
-            1.0
-        ],
-        [
-            61,
-            94,
-            1.0
-        ],
-        [
-            61,
-            95,
-            0.5773502691896258
-        ],
-        [
-            61,
-            96,
-            0.3015113445777636
-        ],
-        [
-            61,
-            98,
-            0.5773502691896258
-        ],
-        [
-            61,
-            99,
-            1.0
-        ],
-        [
-            61,
-            100,
-            0.5773502691896257
-        ],
-        [
-            61,
-            101,
-            1.0
-        ],
-        [
-            61,
-            112,
-            1.0
-        ],
-        [
-            61,
-            113,
-            1.0
-        ],
-        [
-            61,
-            114,
-            1.0
-        ],
-        [
-            61,
-            115,
-            1.0
-        ],
-        [
-            61,
-            121,
-            1.0
-        ],
-        [
-            62,
-            0,
-            0.11087872889514538
-        ],
-        [
-            62,
-            1,
-            0.05485034409678747
-        ],
-        [
-            62,
-            2,
-            0.08419146406637444
-        ],
-        [
-            62,
-            5,
-            0.06576072102610128
-        ],
-        [
-            62,
-            6,
-            0.06435660656394311
-        ],
-        [
-            62,
-            7,
-            0.06576286520308809
-        ],
-        [
-            62,
-            9,
-            0.05999972024735531
-        ],
-        [
-            62,
-            10,
-            0.2303619724913795
-        ],
-        [
-            62,
-            11,
-            0.06575427435132448
-        ],
-        [
-            62,
-            12,
-            0.08228240284757059
-        ],
-        [
-            62,
-            13,
-            0.149023485488455
-        ],
-        [
-            62,
-            15,
-            0.35936524509285267
-        ],
-        [
-            62,
-            16,
-            0.0735527814811363
-        ],
-        [
-            62,
-            20,
-            0.07471988492357075
-        ],
-        [
-            62,
-            22,
-            0.39110058136742837
-        ],
-        [
-            62,
-            23,
-            0.1490271805728858
-        ],
-        [
-            62,
-            25,
-            0.6023119612131889
-        ],
-        [
-            62,
-            31,
-            0.04312271891658416
-        ],
-        [
-            62,
-            44,
-            0.05255930803421452
-        ],
-        [
-            62,
-            46,
-            0.7606806276054251
-        ],
-        [
-            62,
-            48,
-            0.07050277087923619
-        ],
-        [
-            62,
-            49,
-            0.26523681714162195
-        ],
-        [
-            62,
-            51,
-            0.08592437456044154
-        ],
-        [
-            62,
-            52,
-            0.21847205262765929
-        ],
-        [
-            62,
-            53,
-            0.15297253257980162
-        ],
-        [
-            62,
-            54,
-            0.23150356389768062
-        ],
-        [
-            62,
-            55,
-            0.32260011773432906
-        ],
-        [
-            62,
-            56,
-            0.337588982252086
-        ],
-        [
-            62,
-            57,
-            0.6397468651777577
-        ],
-        [
-            62,
-            58,
-            0.1260916727292475
-        ],
-        [
-            62,
-            59,
-            0.19331817236537469
-        ],
-        [
-            62,
-            60,
-            0.3348503361874041
-        ],
-        [
-            62,
-            61,
-            0.23014889093921517
-        ],
-        [
-            62,
-            62,
-            1.0
-        ],
-        [
-            62,
-            63,
-            0.28575012271830247
-        ],
-        [
-            62,
-            64,
-            0.4045078259585906
-        ],
-        [
-            62,
-            65,
-            0.2549947064500671
-        ],
-        [
-            62,
-            66,
-            0.6200120464392653
-        ],
-        [
-            62,
-            67,
-            0.23360626123144201
-        ],
-        [
-            62,
-            68,
-            0.7588125783082897
-        ],
-        [
-            62,
-            69,
-            0.25299595052312984
-        ],
-        [
-            62,
-            70,
-            0.2869812882258832
-        ],
-        [
-            62,
-            71,
-            0.3410075257700312
-        ],
-        [
-            62,
-            72,
-            0.2475623411630831
-        ],
-        [
-            62,
-            83,
-            0.10527057192443806
-        ],
-        [
-            62,
-            86,
-            0.09783581227068176
-        ],
-        [
-            62,
-            112,
-            0.6324555320336758
-        ],
-        [
-            62,
-            113,
-            1.0
-        ],
-        [
-            62,
-            114,
-            1.0
-        ],
-        [
-            62,
-            115,
-            1.0
-        ],
-        [
-            63,
-            0,
-            0.7269375994659236
-        ],
-        [
-            63,
-            1,
-            0.5654753306682656
-        ],
-        [
-            63,
-            2,
-            0.7149395143099547
-        ],
-        [
-            63,
-            3,
-            0.3086187848496843
-        ],
-        [
-            63,
-            4,
-            0.4029945218006074
-        ],
-        [
-            63,
-            5,
-            0.5845559251514315
-        ],
-        [
-            63,
-            6,
-            0.550089461152626
-        ],
-        [
-            63,
-            7,
-            0.5845559251514315
-        ],
-        [
-            63,
-            8,
-            0.3107986489394715
-        ],
-        [
-            63,
-            9,
-            0.6260767418673101
-        ],
-        [
-            63,
-            10,
-            0.6631330642378719
-        ],
-        [
-            63,
-            11,
-            0.5717510299293135
-        ],
-        [
-            63,
-            12,
-            0.6887405313735887
-        ],
-        [
-            63,
-            13,
-            0.4276023984851669
-        ],
-        [
-            63,
-            14,
-            0.33992751375601366
-        ],
-        [
-            63,
-            15,
-            0.45373055561314046
-        ],
-        [
-            63,
-            16,
-            0.5916663394220595
-        ],
-        [
-            63,
-            17,
-            0.2534377451375266
-        ],
-        [
-            63,
-            18,
-            0.29578472360087343
-        ],
-        [
-            63,
-            19,
-            0.39170251612917933
-        ],
-        [
-            63,
-            20,
-            0.5069873163858972
-        ],
-        [
-            63,
-            21,
-            0.36955036896495486
-        ],
-        [
-            63,
-            22,
-            0.5129039343834969
-        ],
-        [
-            63,
-            23,
-            0.40687616127774484
-        ],
-        [
-            63,
-            25,
-            0.39308754368311305
-        ],
-        [
-            63,
-            27,
-            0.5773502691896257
-        ],
-        [
-            63,
-            29,
-            0.17766726362967522
-        ],
-        [
-            63,
-            31,
-            0.5017437066658404
-        ],
-        [
-            63,
-            37,
-            0.40824829046386296
-        ],
-        [
-            63,
-            38,
-            -0.17407765595569782
-        ],
-        [
-            63,
-            40,
-            -0.33333333333333337
-        ],
-        [
-            63,
-            44,
-            0.5435737720153095
-        ],
-        [
-            63,
-            46,
-            0.2853325622438602
-        ],
-        [
-            63,
-            48,
-            0.5252416428601482
-        ],
-        [
-            63,
-            49,
-            0.7191060631171521
-        ],
-        [
-            63,
-            50,
-            0.40233989938361225
-        ],
-        [
-            63,
-            51,
-            0.6747963762362861
-        ],
-        [
-            63,
-            52,
-            0.39925659450642254
-        ],
-        [
-            63,
-            53,
-            0.666357684354488
-        ],
-        [
-            63,
-            54,
-            0.6813215623362829
-        ],
-        [
-            63,
-            55,
-            0.6643284231317302
-        ],
-        [
-            63,
-            56,
-            0.6979848506184965
-        ],
-        [
-            63,
-            57,
-            0.4130834752865758
-        ],
-        [
-            63,
-            58,
-            0.6613894031672441
-        ],
-        [
-            63,
-            59,
-            0.7670507596064783
-        ],
-        [
-            63,
-            60,
-            0.6937968569971092
-        ],
-        [
-            63,
-            61,
-            0.6804420225320976
-        ],
-        [
-            63,
-            62,
-            0.28575012271830247
-        ],
-        [
-            63,
-            63,
-            1.0
-        ],
-        [
-            63,
-            64,
-            0.4318832414908167
-        ],
-        [
-            63,
-            65,
-            0.6228102473866006
-        ],
-        [
-            63,
-            66,
-            0.2845769457592032
-        ],
-        [
-            63,
-            67,
-            0.7725337210001214
-        ],
-        [
-            63,
-            68,
-            0.2808379332859318
-        ],
-        [
-            63,
-            69,
-            0.6502760944490801
-        ],
-        [
-            63,
-            70,
-            0.6568776210431516
-        ],
-        [
-            63,
-            71,
-            0.6448348944788839
-        ],
-        [
-            63,
-            72,
-            0.6589920955963994
-        ],
-        [
-            63,
-            73,
-            0.6748085293303295
-        ],
-        [
-            63,
-            74,
-            0.45148822014812534
-        ],
-        [
-            63,
-            75,
-            0.7637626158259732
-        ],
-        [
-            63,
-            76,
-            0.7392722422010126
-        ],
-        [
-            63,
-            77,
-            0.6387501924213125
-        ],
-        [
-            63,
-            78,
-            0.7713097659557537
-        ],
-        [
-            63,
-            79,
-            0.5814327982484203
-        ],
-        [
-            63,
-            80,
-            0.5249223545067114
-        ],
-        [
-            63,
-            81,
-            0.7577754301140095
-        ],
-        [
-            63,
-            82,
-            0.406734898468146
-        ],
-        [
-            63,
-            83,
-            0.721687836487032
-        ],
-        [
-            63,
-            84,
-            0.5981411919861926
-        ],
-        [
-            63,
-            85,
-            0.6929348671835834
-        ],
-        [
-            63,
-            86,
-            0.2999059282665924
-        ],
-        [
-            63,
-            88,
-            1.0
-        ],
-        [
-            63,
-            89,
-            0.6831300510639732
-        ],
-        [
-            63,
-            90,
-            1.0
-        ],
-        [
-            63,
-            92,
-            1.0
-        ],
-        [
-            63,
-            93,
-            1.0
-        ],
-        [
-            63,
-            94,
-            1.0
-        ],
-        [
-            63,
-            95,
-            0.33333333333333326
-        ],
-        [
-            63,
-            96,
-            -0.17407765595569782
-        ],
-        [
-            63,
-            98,
-            -0.33333333333333326
-        ],
-        [
-            63,
-            99,
-            1.0
-        ],
-        [
-            63,
-            100,
-            1.0
-        ],
-        [
-            63,
-            101,
-            0.5773502691896256
-        ],
-        [
-            64,
-            0,
-            0.4424017052256498
-        ],
-        [
-            64,
-            1,
-            0.34701522273971264
-        ],
-        [
-            64,
-            2,
-            0.36246067647322394
-        ],
-        [
-            64,
-            3,
-            0.11934529336606564
-        ],
-        [
-            64,
-            4,
-            0.1815908373502995
-        ],
-        [
-            64,
-            5,
-            0.4039137278827744
-        ],
-        [
-            64,
-            6,
-            0.37893584173515066
-        ],
-        [
-            64,
-            7,
-            0.4039332904783342
-        ],
-        [
-            64,
-            8,
-            0.162440362234423
-        ],
-        [
-            64,
-            9,
-            0.3506711476174269
-        ],
-        [
-            64,
-            10,
-            0.487924723438099
-        ],
-        [
-            64,
-            11,
-            0.3879643434237635
-        ],
-        [
-            64,
-            12,
-            0.4717318519128013
-        ],
-        [
-            64,
-            13,
-            0.6672304116625589
-        ],
-        [
-            64,
-            14,
-            0.09380840434758851
-        ],
-        [
-            64,
-            15,
-            0.6649106125617232
-        ],
-        [
-            64,
-            16,
-            0.36451156934318996
-        ],
-        [
-            64,
-            17,
-            0.10736966163690068
-        ],
-        [
-            64,
-            18,
-            0.0747780830813584
-        ],
-        [
-            64,
-            19,
-            0.13066365437327487
-        ],
-        [
-            64,
-            20,
-            0.3577935552584234
-        ],
-        [
-            64,
-            21,
-            0.107216385836292
-        ],
-        [
-            64,
-            22,
-            0.7681661641973107
-        ],
-        [
-            64,
-            23,
-            0.6522493256649947
-        ],
-        [
-            64,
-            25,
-            0.5603107247253949
-        ],
-        [
-            64,
-            31,
-            0.24425716286583435
-        ],
-        [
-            64,
-            44,
-            0.22613933218033166
-        ],
-        [
-            64,
-            46,
-            0.39445373790540167
-        ],
-        [
-            64,
-            48,
-            0.3197472158862051
-        ],
-        [
-            64,
-            49,
-            0.497983437426278
-        ],
-        [
-            64,
-            50,
-            -0.10998533626601505
-        ],
-        [
-            64,
-            51,
-            0.3400297564915117
-        ],
-        [
-            64,
-            52,
-            0.5735164591845869
-        ],
-        [
-            64,
-            53,
-            0.4359468918429124
-        ],
-        [
-            64,
-            54,
-            0.46963391034511953
-        ],
-        [
-            64,
-            55,
-            0.609835234568412
-        ],
-        [
-            64,
-            56,
-            0.6048702122846451
-        ],
-        [
-            64,
-            57,
-            0.5163189479703278
-        ],
-        [
-            64,
-            58,
-            0.47096950793507386
-        ],
-        [
-            64,
-            59,
-            0.47129820530134614
-        ],
-        [
-            64,
-            60,
-            0.5998824393116029
-        ],
-        [
-            64,
-            61,
-            0.46612337425905603
-        ],
-        [
-            64,
-            62,
-            0.4045078259585906
-        ],
-        [
-            64,
-            63,
-            0.4318832414908167
-        ],
-        [
-            64,
-            64,
-            1.0
-        ],
-        [
-            64,
-            65,
-            0.47423611005683747
-        ],
-        [
-            64,
-            66,
-            0.3550379390560744
-        ],
-        [
-            64,
-            67,
-            0.5168128545463331
-        ],
-        [
-            64,
-            68,
-            0.3554260661666482
-        ],
-        [
-            64,
-            69,
-            0.5172637636210127
-        ],
-        [
-            64,
-            70,
-            0.5354611643161
-        ],
-        [
-            64,
-            71,
-            0.6072399405125201
-        ],
-        [
-            64,
-            72,
-            0.5129377920900761
-        ],
-        [
-            64,
-            73,
-            0.19434053838790832
-        ],
-        [
-            64,
-            74,
-            0.15620606554917618
-        ],
-        [
-            64,
-            75,
-            0.3546361159446285
-        ],
-        [
-            64,
-            76,
-            0.21540033982634835
-        ],
-        [
-            64,
-            77,
-            0.38442503545486645
-        ],
-        [
-            64,
-            78,
-            0.35124011133817773
-        ],
-        [
-            64,
-            79,
-            0.3596328748515543
-        ],
-        [
-            64,
-            80,
-            0.3294300174833315
-        ],
-        [
-            64,
-            81,
-            0.2778056908631048
-        ],
-        [
-            64,
-            82,
-            0.11018798355373481
-        ],
-        [
-            64,
-            83,
-            0.34315307742620704
-        ],
-        [
-            64,
-            84,
-            -0.04222003309207508
-        ],
-        [
-            64,
-            85,
-            0.3578719646004937
-        ],
-        [
-            64,
-            86,
-            0.30845591166702774
-        ],
-        [
-            64,
-            112,
-            1.0
-        ],
-        [
-            64,
-            113,
-            1.0
-        ],
-        [
-            64,
-            114,
-            1.0
-        ],
-        [
-            64,
-            115,
-            1.0
-        ],
-        [
-            64,
-            121,
-            1.0
-        ],
-        [
-            65,
-            0,
-            0.6885151977189432
-        ],
-        [
-            65,
-            1,
-            0.659573361605372
-        ],
-        [
-            65,
-            2,
-            0.5883705311810214
-        ],
-        [
-            65,
-            3,
-            0.4634624612317765
-        ],
-        [
-            65,
-            4,
-            0.30807122468058407
-        ],
-        [
-            65,
-            5,
-            0.7494500282727253
-        ],
-        [
-            65,
-            6,
-            0.7425964871827637
-        ],
-        [
-            65,
-            7,
-            0.7434522300059475
-        ],
-        [
-            65,
-            8,
-            0.1447453511938786
-        ],
-        [
-            65,
-            9,
-            0.5780101605883959
-        ],
-        [
-            65,
-            10,
-            0.7650936323258094
-        ],
-        [
-            65,
-            11,
-            0.7439439423511436
-        ],
-        [
-            65,
-            12,
-            0.6331316057959903
-        ],
-        [
-            65,
-            13,
-            0.404737416042256
-        ],
-        [
-            65,
-            14,
-            0.3494959276278665
-        ],
-        [
-            65,
-            15,
-            0.45962898742600655
-        ],
-        [
-            65,
-            16,
-            0.658014692387257
-        ],
-        [
-            65,
-            17,
-            0.4045129084658906
-        ],
-        [
-            65,
-            18,
-            0.35532733950140616
-        ],
-        [
-            65,
-            19,
-            0.2873943504245631
-        ],
-        [
-            65,
-            20,
-            0.7113513348061469
-        ],
-        [
-            65,
-            21,
-            0.32915536491997116
-        ],
-        [
-            65,
-            22,
-            0.5064180827688534
-        ],
-        [
-            65,
-            23,
-            0.3911490180062329
-        ],
-        [
-            65,
-            25,
-            0.3472833937714275
-        ],
-        [
-            65,
-            27,
-            0.50709255283711
-        ],
-        [
-            65,
-            29,
-            0.39477101697586137
-        ],
-        [
-            65,
-            31,
-            0.5615860447959994
-        ],
-        [
-            65,
-            37,
-            0.47809144373375745
-        ],
-        [
-            65,
-            38,
-            0.35675303400633784
-        ],
-        [
-            65,
-            40,
-            -0.5773502691896258
-        ],
-        [
-            65,
-            44,
-            0.5008993652040925
-        ],
-        [
-            65,
-            46,
-            0.2393983042410439
-        ],
-        [
-            65,
-            48,
-            0.5885946125248084
-        ],
-        [
-            65,
-            49,
-            0.8310533503574572
-        ],
-        [
-            65,
-            50,
-            0.35355339059327373
-        ],
-        [
-            65,
-            51,
-            0.6374337604334754
-        ],
-        [
-            65,
-            52,
-            0.3786862669407705
-        ],
-        [
-            65,
-            53,
-            0.7026952952479391
-        ],
-        [
-            65,
-            54,
-            0.7529674992730518
-        ],
-        [
-            65,
-            55,
-            0.6629289664830292
-        ],
-        [
-            65,
-            56,
-            0.714428767380802
-        ],
-        [
-            65,
-            57,
-            0.3543155475691485
-        ],
-        [
-            65,
-            58,
-            0.6480966668643782
-        ],
-        [
-            65,
-            59,
-            0.6687711372816816
-        ],
-        [
-            65,
-            60,
-            0.7078844326623216
-        ],
-        [
-            65,
-            61,
-            0.7526909573952122
-        ],
-        [
-            65,
-            62,
-            0.2549947064500671
-        ],
-        [
-            65,
-            63,
-            0.6228102473866006
-        ],
-        [
-            65,
-            64,
-            0.47423611005683747
-        ],
-        [
-            65,
-            65,
-            1.0
-        ],
-        [
-            65,
-            66,
-            0.2575448430729538
-        ],
-        [
-            65,
-            67,
-            0.6788665283371045
-        ],
-        [
-            65,
-            68,
-            0.24349932170625294
-        ],
-        [
-            65,
-            69,
-            0.7921166351724477
-        ],
-        [
-            65,
-            70,
-            0.8354344464981935
-        ],
-        [
-            65,
-            71,
-            0.6865355220017576
-        ],
-        [
-            65,
-            72,
-            0.7802968412236649
-        ],
-        [
-            65,
-            73,
-            0.17842860083688405
-        ],
-        [
-            65,
-            74,
-            0.2376484480265768
-        ],
-        [
-            65,
-            75,
-            0.7783573694716192
-        ],
-        [
-            65,
-            76,
-            0.20734633959320667
-        ],
-        [
-            65,
-            77,
-            0.4078793163259738
-        ],
-        [
-            65,
-            78,
-            0.7813435390135716
-        ],
-        [
-            65,
-            79,
-            0.4194848929394833
-        ],
-        [
-            65,
-            80,
-            0.8182025900253902
-        ],
-        [
-            65,
-            81,
-            0.5456543594390102
-        ],
-        [
-            65,
-            82,
-            0.3739395654006905
-        ],
-        [
-            65,
-            83,
-            0.8069821705754358
-        ],
-        [
-            65,
-            84,
-            0.26383176440181505
-        ],
-        [
-            65,
-            85,
-            0.41126362910503567
-        ],
-        [
-            65,
-            86,
-            0.30332272127808224
-        ],
-        [
-            65,
-            88,
-            1.0
-        ],
-        [
-            65,
-            89,
-            0.6571428571428571
-        ],
-        [
-            65,
-            90,
-            1.0
-        ],
-        [
-            65,
-            92,
-            1.0
-        ],
-        [
-            65,
-            93,
-            1.0
-        ],
-        [
-            65,
-            94,
-            1.0
-        ],
-        [
-            65,
-            95,
-            0.33333333333333326
-        ],
-        [
-            65,
-            96,
-            0.35675303400633784
-        ],
-        [
-            65,
-            98,
-            -0.33333333333333326
-        ],
-        [
-            65,
-            99,
-            1.0
-        ],
-        [
-            65,
-            100,
-            1.0
-        ],
-        [
-            65,
-            101,
-            0.50709255283711
-        ],
-        [
-            65,
-            112,
-            1.0
-        ],
-        [
-            65,
-            121,
-            1.0
-        ],
-        [
-            66,
-            0,
-            0.0959910821547985
-        ],
-        [
-            66,
-            1,
-            0.15024204041040873
-        ],
-        [
-            66,
-            2,
-            0.1074587235441961
-        ],
-        [
-            66,
-            3,
-            0.047998031775434255
-        ],
-        [
-            66,
-            4,
-            0.0219077516295579
-        ],
-        [
-            66,
-            5,
-            0.17397837827671106
-        ],
-        [
-            66,
-            6,
-            0.16916928532895625
-        ],
-        [
-            66,
-            7,
-            0.17397837827671084
-        ],
-        [
-            66,
-            8,
-            0.03488170989322612
-        ],
-        [
-            66,
-            9,
-            0.1657658925495808
-        ],
-        [
-            66,
-            10,
-            0.26459014850811974
-        ],
-        [
-            66,
-            11,
-            0.17389988595800918
-        ],
-        [
-            66,
-            12,
-            0.12426960513700673
-        ],
-        [
-            66,
-            13,
-            0.15808501483286475
-        ],
-        [
-            66,
-            14,
-            0.03333472300469445
-        ],
-        [
-            66,
-            15,
-            0.2832872021803779
-        ],
-        [
-            66,
-            16,
-            0.11589279677100943
-        ],
-        [
-            66,
-            17,
-            0.02721550093590012
-        ],
-        [
-            66,
-            18,
-            0.03950423778172483
-        ],
-        [
-            66,
-            19,
-            -0.006204730570558137
-        ],
-        [
-            66,
-            20,
-            0.16701404063422742
-        ],
-        [
-            66,
-            21,
-            -0.006588816930623473
-        ],
-        [
-            66,
-            22,
-            0.29131040150636256
-        ],
-        [
-            66,
-            23,
-            0.15812359753709934
-        ],
-        [
-            66,
-            25,
-            0.4288664886359749
-        ],
-        [
-            66,
-            27,
-            0.5773502691896257
-        ],
-        [
-            66,
-            29,
-            -0.23354968324845696
-        ],
-        [
-            66,
-            31,
-            0.10198328474636399
-        ],
-        [
-            66,
-            37,
-            0.40824829046386296
-        ],
-        [
-            66,
-            38,
-            0.5222329678670934
-        ],
-        [
-            66,
-            40,
-            -0.33333333333333337
-        ],
-        [
-            66,
-            44,
-            0.05791814444351586
-        ],
-        [
-            66,
-            46,
-            0.5398624279729676
-        ],
-        [
-            66,
-            48,
-            0.10546146579168413
-        ],
-        [
-            66,
-            49,
-            0.2754475624773887
-        ],
-        [
-            66,
-            50,
-            1.0
-        ],
-        [
-            66,
-            51,
-            0.10650629778846638
-        ],
-        [
-            66,
-            52,
-            0.13191499759222625
-        ],
-        [
-            66,
-            53,
-            0.17538704655561912
-        ],
-        [
-            66,
-            54,
-            0.2406483592930872
-        ],
-        [
-            66,
-            55,
-            0.2893730870933857
-        ],
-        [
-            66,
-            56,
-            0.29089141945115626
-        ],
-        [
-            66,
-            57,
-            0.48370889419821295
-        ],
-        [
-            66,
-            58,
-            0.10823308919078947
-        ],
-        [
-            66,
-            59,
-            0.15845655155414082
-        ],
-        [
-            66,
-            60,
-            0.29878170526016157
-        ],
-        [
-            66,
-            61,
-            0.24688655799023856
-        ],
-        [
-            66,
-            62,
-            0.6200120464392653
-        ],
-        [
-            66,
-            63,
-            0.2845769457592032
-        ],
-        [
-            66,
-            64,
-            0.3550379390560744
-        ],
-        [
-            66,
-            65,
-            0.2575448430729538
-        ],
-        [
-            66,
-            66,
-            1.0
-        ],
-        [
-            66,
-            67,
-            0.17994913852530645
-        ],
-        [
-            66,
-            68,
-            0.584383293203092
-        ],
-        [
-            66,
-            69,
-            0.2502171205598712
-        ],
-        [
-            66,
-            70,
-            0.28305209298296286
-        ],
-        [
-            66,
-            71,
-            0.2868420458624457
-        ],
-        [
-            66,
-            72,
-            0.24652613573083781
-        ],
-        [
-            66,
-            73,
-            -0.03891315712838477
-        ],
-        [
-            66,
-            74,
-            0.028518460342899194
-        ],
-        [
-            66,
-            75,
-            0.270362711017962
-        ],
-        [
-            66,
-            76,
-            -0.0019456578564192488
-        ],
-        [
-            66,
-            77,
-            0.05842716480173336
-        ],
-        [
-            66,
-            78,
-            0.2880272773273383
-        ],
-        [
-            66,
-            79,
-            0.09819407399024647
-        ],
-        [
-            66,
-            80,
-            0.2583148259400218
-        ],
-        [
-            66,
-            81,
-            0.20578676477185032
-        ],
-        [
-            66,
-            82,
-            0.14049989542313537
-        ],
-        [
-            66,
-            83,
-            0.30473984055004616
-        ],
-        [
-            66,
-            84,
-            0.0763617018347741
-        ],
-        [
-            66,
-            85,
-            0.022508202291617648
-        ],
-        [
-            66,
-            86,
-            0.10152241385149395
-        ],
-        [
-            66,
-            88,
-            1.0
-        ],
-        [
-            66,
-            89,
-            0.6831300510639732
-        ],
-        [
-            66,
-            90,
-            1.0
-        ],
-        [
-            66,
-            92,
-            1.0
-        ],
-        [
-            66,
-            93,
-            1.0
-        ],
-        [
-            66,
-            94,
-            1.0
-        ],
-        [
-            66,
-            95,
-            0.33333333333333326
-        ],
-        [
-            66,
-            96,
-            0.5222329678670935
-        ],
-        [
-            66,
-            98,
-            -0.33333333333333326
-        ],
-        [
-            66,
-            99,
-            1.0
-        ],
-        [
-            66,
-            100,
-            1.0
-        ],
-        [
-            66,
-            101,
-            0.5773502691896256
-        ],
-        [
-            67,
-            0,
-            0.8423775402549631
-        ],
-        [
-            67,
-            1,
-            0.5983490078800613
-        ],
-        [
-            67,
-            2,
-            0.7449137244046414
-        ],
-        [
-            67,
-            3,
-            0.4034908849790441
-        ],
-        [
-            67,
-            4,
-            0.47133073686788646
-        ],
-        [
-            67,
-            5,
-            0.6438295006737756
-        ],
-        [
-            67,
-            6,
-            0.6181451479584993
-        ],
-        [
-            67,
-            7,
-            0.6438295006737753
-        ],
-        [
-            67,
-            8,
-            0.2983214503811019
-        ],
-        [
-            67,
-            9,
-            0.6285992980044047
-        ],
-        [
-            67,
-            10,
-            0.717935720832681
-        ],
-        [
-            67,
-            11,
-            0.6265627001675333
-        ],
-        [
-            67,
-            12,
-            0.805863378699337
-        ],
-        [
-            67,
-            13,
-            0.4891026278085175
-        ],
-        [
-            67,
-            14,
-            0.47123791805739423
-        ],
-        [
-            67,
-            15,
-            0.5612509319210403
-        ],
-        [
-            67,
-            16,
-            0.6580438333425016
-        ],
-        [
-            67,
-            17,
-            0.3352278920967524
-        ],
-        [
-            67,
-            18,
-            0.43021836214804704
-        ],
-        [
-            67,
-            19,
-            0.4452819835679484
-        ],
-        [
-            67,
-            20,
-            0.56853895239575
-        ],
-        [
-            67,
-            21,
-            0.5494454776233867
-        ],
-        [
-            67,
-            22,
-            0.6008968877702303
-        ],
-        [
-            67,
-            23,
-            0.47138615430592057
-        ],
-        [
-            67,
-            25,
-            0.3596629855064653
-        ],
-        [
-            67,
-            27,
-            0.7745966692414834
-        ],
-        [
-            67,
-            31,
-            0.618498595089551
-        ],
-        [
-            67,
-            37,
-            0.5773502691896258
-        ],
-        [
-            67,
-            38,
-            0.3779644730092272
-        ],
-        [
-            67,
-            44,
-            0.7260972342828865
-        ],
-        [
-            67,
-            46,
-            0.20038536432514242
-        ],
-        [
-            67,
-            48,
-            0.5910856875025373
-        ],
-        [
-            67,
-            49,
-            0.7674556742516695
-        ],
-        [
-            67,
-            50,
-            0.5932958789676532
-        ],
-        [
-            67,
-            51,
-            0.7163098750262133
-        ],
-        [
-            67,
-            52,
-            0.4630716852051444
-        ],
-        [
-            67,
-            53,
-            0.7101432284932838
-        ],
-        [
-            67,
-            54,
-            0.7145689531849779
-        ],
-        [
-            67,
-            55,
-            0.7519994452789295
-        ],
-        [
-            67,
-            56,
-            0.7960591813614702
-        ],
-        [
-            67,
-            57,
-            0.36823109233675627
-        ],
-        [
-            67,
-            58,
-            0.7637758799001311
-        ],
-        [
-            67,
-            59,
-            0.8709546434029642
-        ],
-        [
-            67,
-            60,
-            0.7903379527209393
-        ],
-        [
-            67,
-            61,
-            0.7157978115856868
-        ],
-        [
-            67,
-            62,
-            0.23360626123144201
-        ],
-        [
-            67,
-            63,
-            0.7725337210001214
-        ],
-        [
-            67,
-            64,
-            0.5168128545463331
-        ],
-        [
-            67,
-            65,
-            0.6788665283371045
-        ],
-        [
-            67,
-            66,
-            0.17994913852530645
-        ],
-        [
-            67,
-            67,
-            1.0
-        ],
-        [
-            67,
-            68,
-            0.19659368150092754
-        ],
-        [
-            67,
-            69,
-            0.7209088309967269
-        ],
-        [
-            67,
-            70,
-            0.6855809094820573
-        ],
-        [
-            67,
-            71,
-            0.7627657307199578
-        ],
-        [
-            67,
-            72,
-            0.7408407691260454
-        ],
-        [
-            67,
-            73,
-            0.44270450690737195
-        ],
-        [
-            67,
-            74,
-            0.4949156556649775
-        ],
-        [
-            67,
-            75,
-            0.5477249978090998
-        ],
-        [
-            67,
-            76,
-            0.3095989990166173
-        ],
-        [
-            67,
-            77,
-            0.6997975415720488
-        ],
-        [
-            67,
-            78,
-            0.5481888975263102
-        ],
-        [
-            67,
-            79,
-            0.62486002571806
-        ],
-        [
-            67,
-            80,
-            0.48877841097968855
-        ],
-        [
-            67,
-            81,
-            0.498177006269537
-        ],
-        [
-            67,
-            82,
-            0.26385233120297996
-        ],
-        [
-            67,
-            83,
-            0.5486621990759066
-        ],
-        [
-            67,
-            84,
-            0.5317337572725112
-        ],
-        [
-            67,
-            85,
-            0.5442673265096629
-        ],
-        [
-            67,
-            86,
-            0.43452166374311363
-        ],
-        [
-            67,
-            89,
-            0.7745966692414832
-        ],
-        [
-            67,
-            96,
-            0.3779644730092272
-        ],
-        [
-            67,
-            101,
-            0.7745966692414832
-        ],
-        [
-            67,
-            112,
-            1.0
-        ],
-        [
-            67,
-            121,
-            1.0
-        ],
-        [
-            68,
-            0,
-            0.11513977523798995
-        ],
-        [
-            68,
-            1,
-            0.05826418561378327
-        ],
-        [
-            68,
-            2,
-            0.10667458360753708
-        ],
-        [
-            68,
-            3,
-            -0.025803299620380728
-        ],
-        [
-            68,
-            4,
-            -0.016020944008442048
-        ],
-        [
-            68,
-            5,
-            0.07406851169568873
-        ],
-        [
-            68,
-            6,
-            0.07188111750300614
-        ],
-        [
-            68,
-            7,
-            0.0740685116956887
-        ],
-        [
-            68,
-            8,
-            -0.013599498463913362
-        ],
-        [
-            68,
-            9,
-            0.06506784794443027
-        ],
-        [
-            68,
-            10,
-            0.1898561078308093
-        ],
-        [
-            68,
-            11,
-            0.07402659345059856
-        ],
-        [
-            68,
-            12,
-            0.06908929870751943
-        ],
-        [
-            68,
-            13,
-            0.09122348300266349
-        ],
-        [
-            68,
-            14,
-            0.01967868614218527
-        ],
-        [
-            68,
-            15,
-            0.27648329645840203
-        ],
-        [
-            68,
-            16,
-            0.10544291943073224
-        ],
-        [
-            68,
-            17,
-            0.0036018142543925687
-        ],
-        [
-            68,
-            18,
-            0.014830349899453341
-        ],
-        [
-            68,
-            19,
-            0.01610068369868449
-        ],
-        [
-            68,
-            20,
-            0.06691114233142935
-        ],
-        [
-            68,
-            21,
-            0.031082172010650243
-        ],
-        [
-            68,
-            22,
-            0.28930422804359207
-        ],
-        [
-            68,
-            23,
-            0.09124342745733326
-        ],
-        [
-            68,
-            25,
-            0.4862564591865675
-        ],
-        [
-            68,
-            31,
-            0.0813523005451957
-        ],
-        [
-            68,
-            44,
-            0.08785399016131934
-        ],
-        [
-            68,
-            46,
-            0.6398990262079147
-        ],
-        [
-            68,
-            48,
-            0.0863448573701275
-        ],
-        [
-            68,
-            49,
-            0.2538869346894688
-        ],
-        [
-            68,
-            51,
-            0.12491555460600934
-        ],
-        [
-            68,
-            52,
-            0.11808404499788042
-        ],
-        [
-            68,
-            53,
-            0.13660208201618076
-        ],
-        [
-            68,
-            54,
-            0.22861084535688006
-        ],
-        [
-            68,
-            55,
-            0.29618827166758466
-        ],
-        [
-            68,
-            56,
-            0.30821529199830094
-        ],
-        [
-            68,
-            57,
-            0.5421234694403447
-        ],
-        [
-            68,
-            58,
-            0.12908975846783685
-        ],
-        [
-            68,
-            59,
-            0.14737152407467238
-        ],
-        [
-            68,
-            60,
-            0.31690978693560645
-        ],
-        [
-            68,
-            61,
-            0.2356048554823083
-        ],
-        [
-            68,
-            62,
-            0.7588125783082897
-        ],
-        [
-            68,
-            63,
-            0.2808379332859318
-        ],
-        [
-            68,
-            64,
-            0.3554260661666482
-        ],
-        [
-            68,
-            65,
-            0.24349932170625294
-        ],
-        [
-            68,
-            66,
-            0.584383293203092
-        ],
-        [
-            68,
-            67,
-            0.19659368150092754
-        ],
-        [
-            68,
-            68,
-            1.0
-        ],
-        [
-            68,
-            69,
-            0.22677669620779586
-        ],
-        [
-            68,
-            70,
-            0.2611775337760881
-        ],
-        [
-            68,
-            71,
-            0.29364416005044447
-        ],
-        [
-            68,
-            72,
-            0.22505079634050423
-        ],
-        [
-            68,
-            86,
-            0.09660996857675344
-        ],
-        [
-            69,
-            0,
-            0.723205844087994
-        ],
-        [
-            69,
-            1,
-            0.7741452011548068
-        ],
-        [
-            69,
-            2,
-            0.6294693144550257
-        ],
-        [
-            69,
-            3,
-            0.5070469598606773
-        ],
-        [
-            69,
-            4,
-            0.3720995894598457
-        ],
-        [
-            69,
-            5,
-            0.8581514716844596
-        ],
-        [
-            69,
-            6,
-            0.8349390589800723
-        ],
-        [
-            69,
-            7,
-            0.8581514716844583
-        ],
-        [
-            69,
-            8,
-            0.19953315538444547
-        ],
-        [
-            69,
-            9,
-            0.6289294992042427
-        ],
-        [
-            69,
-            10,
-            0.8165836749402925
-        ],
-        [
-            69,
-            11,
-            0.8488847743406271
-        ],
-        [
-            69,
-            12,
-            0.6934544349408354
-        ],
-        [
-            69,
-            13,
-            0.4250902896867496
-        ],
-        [
-            69,
-            14,
-            0.4486177031210063
-        ],
-        [
-            69,
-            15,
-            0.476125503251337
-        ],
-        [
-            69,
-            16,
-            0.7201981442371338
-        ],
-        [
-            69,
-            17,
-            0.4651312746589619
-        ],
-        [
-            69,
-            18,
-            0.4503693700795846
-        ],
-        [
-            69,
-            19,
-            0.38140977496802325
-        ],
-        [
-            69,
-            20,
-            0.7377464948843132
-        ],
-        [
-            69,
-            21,
-            0.3863751183858698
-        ],
-        [
-            69,
-            22,
-            0.5250882691993974
-        ],
-        [
-            69,
-            23,
-            0.4109889934999873
-        ],
-        [
-            69,
-            25,
-            0.34577019806808074
-        ],
-        [
-            69,
-            31,
-            0.6598772338361155
-        ],
-        [
-            69,
-            44,
-            0.5735935755443576
-        ],
-        [
-            69,
-            46,
-            0.23795013241955656
-        ],
-        [
-            69,
-            48,
-            0.6452980594574388
-        ],
-        [
-            69,
-            49,
-            0.9265320007920668
-        ],
-        [
-            69,
-            51,
-            0.6805962306481751
-        ],
-        [
-            69,
-            52,
-            0.38142870193488615
-        ],
-        [
-            69,
-            53,
-            0.7586525059839169
-        ],
-        [
-            69,
-            54,
-            0.8017822930357289
-        ],
-        [
-            69,
-            55,
-            0.6557805879745032
-        ],
-        [
-            69,
-            56,
-            0.7194259198539756
-        ],
-        [
-            69,
-            57,
-            0.34500462121843295
-        ],
-        [
-            69,
-            58,
-            0.6638869673553293
-        ],
-        [
-            69,
-            59,
-            0.724296593902598
-        ],
-        [
-            69,
-            60,
-            0.7140392953634501
-        ],
-        [
-            69,
-            61,
-            0.802769744245175
-        ],
-        [
-            69,
-            62,
-            0.25299595052312984
-        ],
-        [
-            69,
-            63,
-            0.6502760944490801
-        ],
-        [
-            69,
-            64,
-            0.5172637636210127
-        ],
-        [
-            69,
-            65,
-            0.7921166351724477
-        ],
-        [
-            69,
-            66,
-            0.2502171205598712
-        ],
-        [
-            69,
-            67,
-            0.7209088309967269
-        ],
-        [
-            69,
-            68,
-            0.22677669620779586
-        ],
-        [
-            69,
-            69,
-            1.0
-        ],
-        [
-            69,
-            70,
-            0.8746537815862384
-        ],
-        [
-            69,
-            71,
-            0.7117329457986579
-        ],
-        [
-            69,
-            72,
-            0.9722787967531418
-        ],
-        [
-            69,
-            73,
-            0.26437184630417737
-        ],
-        [
-            69,
-            74,
-            0.4193436306185919
-        ],
-        [
-            69,
-            75,
-            0.9016696346674316
-        ],
-        [
-            69,
-            76,
-            0.3109615270124767
-        ],
-        [
-            69,
-            77,
-            0.47876400120215185
-        ],
-        [
-            69,
-            78,
-            0.8903683219062298
-        ],
-        [
-            69,
-            79,
-            0.43563352240286196
-        ],
-        [
-            69,
-            80,
-            0.8201258650610442
-        ],
-        [
-            69,
-            81,
-            0.6367284928726596
-        ],
-        [
-            69,
-            82,
-            0.4223054471202945
-        ],
-        [
-            69,
-            83,
-            0.9137394994588096
-        ],
-        [
-            69,
-            84,
-            0.43469375328927146
-        ],
-        [
-            69,
-            85,
-            0.4579160553113219
-        ],
-        [
-            69,
-            86,
-            0.32493595897122235
-        ],
-        [
-            69,
-            112,
-            1.0
-        ],
-        [
-            69,
-            121,
-            1.0
-        ],
-        [
-            70,
-            0,
-            0.7006015217963227
-        ],
-        [
-            70,
-            1,
-            0.7317681270861476
-        ],
-        [
-            70,
-            2,
-            0.586430785134082
-        ],
-        [
-            70,
-            3,
-            0.48481359562861914
-        ],
-        [
-            70,
-            4,
-            0.357148200333189
-        ],
-        [
-            70,
-            5,
-            0.8222666295839873
-        ],
-        [
-            70,
-            6,
-            0.800391381258423
-        ],
-        [
-            70,
-            7,
-            0.8173334815135952
-        ],
-        [
-            70,
-            8,
-            0.21683856510140978
-        ],
-        [
-            70,
-            9,
-            0.628595765246618
-        ],
-        [
-            70,
-            10,
-            0.8203681683819434
-        ],
-        [
-            70,
-            11,
-            0.8135972054785021
-        ],
-        [
-            70,
-            12,
-            0.6874480125859487
-        ],
-        [
-            70,
-            13,
-            0.47563463972074443
-        ],
-        [
-            70,
-            14,
-            0.37060526545287986
-        ],
-        [
-            70,
-            15,
-            0.5230903490592194
-        ],
-        [
-            70,
-            16,
-            0.658097425958747
-        ],
-        [
-            70,
-            17,
-            0.40356236617997643
-        ],
-        [
-            70,
-            18,
-            0.4086579614252298
-        ],
-        [
-            70,
-            19,
-            0.3078650057718318
-        ],
-        [
-            70,
-            20,
-            0.7031088067753299
-        ],
-        [
-            70,
-            21,
-            0.33749174489765393
-        ],
-        [
-            70,
-            22,
-            0.5804906566705917
-        ],
-        [
-            70,
-            23,
-            0.4594599048512422
-        ],
-        [
-            70,
-            25,
-            0.386205995225849
-        ],
-        [
-            70,
-            31,
-            0.5845418435266074
-        ],
-        [
-            70,
-            44,
-            0.49470639242627723
-        ],
-        [
-            70,
-            46,
-            0.25982467081151095
-        ],
-        [
-            70,
-            48,
-            0.5911279994797357
-        ],
-        [
-            70,
-            49,
-            0.857962763864767
-        ],
-        [
-            70,
-            51,
-            0.6478502099193182
-        ],
-        [
-            70,
-            52,
-            0.4354583858112672
-        ],
-        [
-            70,
-            53,
-            0.7000299163547444
-        ],
-        [
-            70,
-            54,
-            0.7471615404345975
-        ],
-        [
-            70,
-            55,
-            0.7294168320860803
-        ],
-        [
-            70,
-            56,
-            0.7799237517195576
-        ],
-        [
-            70,
-            57,
-            0.397838522702318
-        ],
-        [
-            70,
-            58,
-            0.721268786503766
-        ],
-        [
-            70,
-            59,
-            0.6781857213584614
-        ],
-        [
-            70,
-            60,
-            0.7758801735894011
-        ],
-        [
-            70,
-            61,
-            0.7479153138141772
-        ],
-        [
-            70,
-            62,
-            0.2869812882258832
-        ],
-        [
-            70,
-            63,
-            0.6568776210431516
-        ],
-        [
-            70,
-            64,
-            0.5354611643161
-        ],
-        [
-            70,
-            65,
-            0.8354344464981935
-        ],
-        [
-            70,
-            66,
-            0.28305209298296286
-        ],
-        [
-            70,
-            67,
-            0.6855809094820573
-        ],
-        [
-            70,
-            68,
-            0.2611775337760881
-        ],
-        [
-            70,
-            69,
-            0.8746537815862384
-        ],
-        [
-            70,
-            70,
-            1.0
-        ],
-        [
-            70,
-            71,
-            0.7842230456605529
-        ],
-        [
-            70,
-            72,
-            0.8599780891443287
-        ],
-        [
-            70,
-            73,
-            0.21827203187936012
-        ],
-        [
-            70,
-            74,
-            0.2786402358456586
-        ],
-        [
-            70,
-            75,
-            0.826639784509149
-        ],
-        [
-            70,
-            76,
-            0.24393583301053354
-        ],
-        [
-            70,
-            77,
-            0.41176325770658023
-        ],
-        [
-            70,
-            78,
-            0.8140202768975969
-        ],
-        [
-            70,
-            79,
-            0.4010763229358247
-        ],
-        [
-            70,
-            80,
-            0.7986235400810321
-        ],
-        [
-            70,
-            81,
-            0.5963447299359413
-        ],
-        [
-            70,
-            82,
-            0.3921365961350671
-        ],
-        [
-            70,
-            83,
-            0.838506918125452
-        ],
-        [
-            70,
-            84,
-            0.24223002563411564
-        ],
-        [
-            70,
-            85,
-            0.43653540662076007
-        ],
-        [
-            70,
-            86,
-            0.3166692538532453
-        ],
-        [
-            70,
-            112,
-            1.0
-        ],
-        [
-            70,
-            121,
-            1.0
-        ],
-        [
-            71,
-            0,
-            0.8379086303347835
-        ],
-        [
-            71,
-            1,
-            0.5575671876210618
-        ],
-        [
-            71,
-            2,
-            0.5836606218825335
-        ],
-        [
-            71,
-            3,
-            0.34162145828795804
-        ],
-        [
-            71,
-            4,
-            0.5200476392358735
-        ],
-        [
-            71,
-            5,
-            0.6507823355822662
-        ],
-        [
-            71,
-            6,
-            0.6253300367517108
-        ],
-        [
-            71,
-            7,
-            0.6507823355822663
-        ],
-        [
-            71,
-            8,
-            0.29502161939293753
-        ],
-        [
-            71,
-            9,
-            0.544392912472306
-        ],
-        [
-            71,
-            10,
-            0.6639914958457512
-        ],
-        [
-            71,
-            11,
-            0.6394323170431304
-        ],
-        [
-            71,
-            12,
-            0.8147380155009736
-        ],
-        [
-            71,
-            13,
-            0.578750165544422
-        ],
-        [
-            71,
-            14,
-            0.2538502384852887
-        ],
-        [
-            71,
-            15,
-            0.6651565290812117
-        ],
-        [
-            71,
-            16,
-            0.5587289096710709
-        ],
-        [
-            71,
-            17,
-            0.25372616826117345
-        ],
-        [
-            71,
-            18,
-            0.26949414939265043
-        ],
-        [
-            71,
-            19,
-            0.38526550850010044
-        ],
-        [
-            71,
-            20,
-            0.5340145649054935
-        ],
-        [
-            71,
-            21,
-            0.37992019961255485
-        ],
-        [
-            71,
-            22,
-            0.709568166328381
-        ],
-        [
-            71,
-            23,
-            0.5555385275082075
-        ],
-        [
-            71,
-            25,
-            0.46015338972211867
-        ],
-        [
-            71,
-            31,
-            0.4853667490000888
-        ],
-        [
-            71,
-            44,
-            0.6172463011363291
-        ],
-        [
-            71,
-            46,
-            0.3120497048382957
-        ],
-        [
-            71,
-            48,
-            0.5050113634618714
-        ],
-        [
-            71,
-            49,
-            0.7251614476812358
-        ],
-        [
-            71,
-            51,
-            0.5706536428612597
-        ],
-        [
-            71,
-            52,
-            0.5234517197108727
-        ],
-        [
-            71,
-            53,
-            0.6185617221789343
-        ],
-        [
-            71,
-            54,
-            0.6397323356523144
-        ],
-        [
-            71,
-            55,
-            0.8119590815514477
-        ],
-        [
-            71,
-            56,
-            0.9565204964698407
-        ],
-        [
-            71,
-            57,
-            0.4670498718299589
-        ],
-        [
-            71,
-            58,
-            0.873786185137349
-        ],
-        [
-            71,
-            59,
-            0.7902671475363868
-        ],
-        [
-            71,
-            60,
-            0.9595544132870687
-        ],
-        [
-            71,
-            61,
-            0.6425032403633865
-        ],
-        [
-            71,
-            62,
-            0.3410075257700312
-        ],
-        [
-            71,
-            63,
-            0.6448348944788839
-        ],
-        [
-            71,
-            64,
-            0.6072399405125201
-        ],
-        [
-            71,
-            65,
-            0.6865355220017576
-        ],
-        [
-            71,
-            66,
-            0.2868420458624457
-        ],
-        [
-            71,
-            67,
-            0.7627657307199578
-        ],
-        [
-            71,
-            68,
-            0.29364416005044447
-        ],
-        [
-            71,
-            69,
-            0.7117329457986579
-        ],
-        [
-            71,
-            70,
-            0.7842230456605529
-        ],
-        [
-            71,
-            71,
-            1.0
-        ],
-        [
-            71,
-            72,
-            0.7001952830761136
-        ],
-        [
-            71,
-            73,
-            0.3074639545010552
-        ],
-        [
-            71,
-            74,
-            0.3118069149515164
-        ],
-        [
-            71,
-            75,
-            0.46187659230037786
-        ],
-        [
-            71,
-            76,
-            0.27652993831367956
-        ],
-        [
-            71,
-            77,
-            0.6312874858517875
-        ],
-        [
-            71,
-            78,
-            0.4427516151395504
-        ],
-        [
-            71,
-            79,
-            0.5945956802980112
-        ],
-        [
-            71,
-            80,
-            0.4813159338237721
-        ],
-        [
-            71,
-            81,
-            0.36596838057408315
-        ],
-        [
-            71,
-            82,
-            0.24478424227441586
-        ],
-        [
-            71,
-            83,
-            0.48143926900350553
-        ],
-        [
-            71,
-            84,
-            0.3139751087370715
-        ],
-        [
-            71,
-            85,
-            0.5332429699288117
-        ],
-        [
-            71,
-            86,
-            0.4530182104751649
-        ],
-        [
-            71,
-            112,
-            1.0
-        ],
-        [
-            71,
-            121,
-            1.0
-        ],
-        [
-            72,
-            0,
-            0.715478160026064
-        ],
-        [
-            72,
-            1,
-            0.801396102621767
-        ],
-        [
-            72,
-            2,
-            0.6510939892210053
-        ],
-        [
-            72,
-            3,
-            0.5275624563300312
-        ],
-        [
-            72,
-            4,
-            0.36888657289223586
-        ],
-        [
-            72,
-            5,
-            0.8567696304016332
-        ],
-        [
-            72,
-            6,
-            0.8335067400724928
-        ],
-        [
-            72,
-            7,
-            0.8567794703463714
-        ],
-        [
-            72,
-            8,
-            0.22375011064492364
-        ],
-        [
-            72,
-            9,
-            0.6529470605134109
-        ],
-        [
-            72,
-            10,
-            0.8381863868289483
-        ],
-        [
-            72,
-            11,
-            0.8475086236072493
-        ],
-        [
-            72,
-            12,
-            0.6943726194890341
-        ],
-        [
-            72,
-            13,
-            0.42178633292122664
-        ],
-        [
-            72,
-            14,
-            0.4895799389533342
-        ],
-        [
-            72,
-            15,
-            0.4817626829202607
-        ],
-        [
-            72,
-            16,
-            0.7430122417031367
-        ],
-        [
-            72,
-            17,
-            0.4818241659959489
-        ],
-        [
-            72,
-            18,
-            0.4857768155059835
-        ],
-        [
-            72,
-            19,
-            0.41243015123227983
-        ],
-        [
-            72,
-            20,
-            0.7562343716474574
-        ],
-        [
-            72,
-            21,
-            0.4394340738770906
-        ],
-        [
-            72,
-            22,
-            0.5213488005139442
-        ],
-        [
-            72,
-            23,
-            0.4078079222015236
-        ],
-        [
-            72,
-            25,
-            0.3403623935464614
-        ],
-        [
-            72,
-            31,
-            0.6810667472704788
-        ],
-        [
-            72,
-            44,
-            0.6045427066554235
-        ],
-        [
-            72,
-            46,
-            0.23104269203643224
-        ],
-        [
-            72,
-            48,
-            0.6694926610573531
-        ],
-        [
-            72,
-            49,
-            0.915792081672577
-        ],
-        [
-            72,
-            51,
-            0.6993454647241769
-        ],
-        [
-            72,
-            52,
-            0.3727526409020546
-        ],
-        [
-            72,
-            53,
-            0.7770882957627085
-        ],
-        [
-            72,
-            54,
-            0.8213701063690703
-        ],
-        [
-            72,
-            55,
-            0.6479948295063939
-        ],
-        [
-            72,
-            56,
-            0.7092513973886432
-        ],
-        [
-            72,
-            57,
-            0.34002985641061056
-        ],
-        [
-            72,
-            58,
-            0.6540324431100847
-        ],
-        [
-            72,
-            59,
-            0.7470220869315664
-        ],
-        [
-            72,
-            60,
-            0.7023637472717941
-        ],
-        [
-            72,
-            61,
-            0.8221766201775859
-        ],
-        [
-            72,
-            62,
-            0.2475623411630831
-        ],
-        [
-            72,
-            63,
-            0.6589920955963994
-        ],
-        [
-            72,
-            64,
-            0.5129377920900761
-        ],
-        [
-            72,
-            65,
-            0.7802968412236649
-        ],
-        [
-            72,
-            66,
-            0.24652613573083781
-        ],
-        [
-            72,
-            67,
-            0.7408407691260454
-        ],
-        [
-            72,
-            68,
-            0.22505079634050423
-        ],
-        [
-            72,
-            69,
-            0.9722787967531418
-        ],
-        [
-            72,
-            70,
-            0.8599780891443287
-        ],
-        [
-            72,
-            71,
-            0.7001952830761136
-        ],
-        [
-            72,
-            72,
-            1.0
-        ],
-        [
-            72,
-            73,
-            0.26437184630417737
-        ],
-        [
-            72,
-            74,
-            0.4124846794100691
-        ],
-        [
-            72,
-            75,
-            0.9026853006017749
-        ],
-        [
-            72,
-            76,
-            0.2997871532448683
-        ],
-        [
-            72,
-            77,
-            0.47876400120215185
-        ],
-        [
-            72,
-            78,
-            0.8915141061160049
-        ],
-        [
-            72,
-            79,
-            0.43563352240286196
-        ],
-        [
-            72,
-            80,
-            0.8201258650610442
-        ],
-        [
-            72,
-            81,
-            0.6367284928726596
-        ],
-        [
-            72,
-            82,
-            0.4223054471202945
-        ],
-        [
-            72,
-            83,
-            0.9146614613296359
-        ],
-        [
-            72,
-            84,
-            0.43469375328927146
-        ],
-        [
-            72,
-            85,
-            0.4579160553113219
-        ],
-        [
-            72,
-            86,
-            0.3295707136849689
-        ],
-        [
-            72,
-            112,
-            1.0
-        ],
-        [
-            72,
-            113,
-            1.0
-        ],
-        [
-            72,
-            114,
-            1.0
-        ],
-        [
-            72,
-            115,
-            1.0
-        ],
-        [
-            72,
-            121,
-            1.0
-        ],
-        [
-            73,
-            0,
-            0.40953501547413074
-        ],
-        [
-            73,
-            1,
-            0.22870887905848217
-        ],
-        [
-            73,
-            2,
-            0.3054951331824168
-        ],
-        [
-            73,
-            3,
-            0.32345344370572576
-        ],
-        [
-            73,
-            4,
-            0.37876989646047204
-        ],
-        [
-            73,
-            5,
-            0.20474520765451018
-        ],
-        [
-            73,
-            6,
-            0.20468961762862
-        ],
-        [
-            73,
-            7,
-            0.2166215713535596
-        ],
-        [
-            73,
-            8,
-            0.366420600010132
-        ],
-        [
-            73,
-            9,
-            0.2619470517073567
-        ],
-        [
-            73,
-            10,
-            0.27467735211178473
-        ],
-        [
-            73,
-            11,
-            0.20474520765451018
-        ],
-        [
-            73,
-            12,
-            0.3654121117662344
-        ],
-        [
-            73,
-            13,
-            0.24549048274731483
-        ],
-        [
-            73,
-            14,
-            0.2912678058662001
-        ],
-        [
-            73,
-            15,
-            0.21444227631651455
-        ],
-        [
-            73,
-            16,
-            0.3238415706813383
-        ],
-        [
-            73,
-            17,
-            0.1833846351385
-        ],
-        [
-            73,
-            18,
-            0.24104664797764197
-        ],
-        [
-            73,
-            19,
-            0.2796844506510743
-        ],
-        [
-            73,
-            20,
-            0.25444501310078627
-        ],
-        [
-            73,
-            21,
-            0.28183678671747003
-        ],
-        [
-            73,
-            22,
-            0.19764064288978733
-        ],
-        [
-            73,
-            23,
-            0.24549048274731483
-        ],
-        [
-            73,
-            25,
-            0.00935139855373222
-        ],
-        [
-            73,
-            31,
-            0.24582754544427393
-        ],
-        [
-            73,
-            44,
-            0.26845443951491743
-        ],
-        [
-            73,
-            48,
-            0.1985151474481492
-        ],
-        [
-            73,
-            49,
-            0.2893741588813536
-        ],
-        [
-            73,
-            51,
-            0.29525198901989747
-        ],
-        [
-            73,
-            52,
-            0.20623973278043936
-        ],
-        [
-            73,
-            53,
-            0.3264039867003976
-        ],
-        [
-            73,
-            54,
-            0.3066659445727034
-        ],
-        [
-            73,
-            55,
-            0.3477583153055676
-        ],
-        [
-            73,
-            56,
-            0.3191827844811588
-        ],
-        [
-            73,
-            57,
-            0.07998679856095454
-        ],
-        [
-            73,
-            58,
-            0.34775831530556794
-        ],
-        [
-            73,
-            59,
-            0.4345237670891239
-        ],
-        [
-            73,
-            60,
-            0.3191827844811588
-        ],
-        [
-            73,
-            61,
-            0.29739581517422825
-        ],
-        [
-            73,
-            63,
-            0.6748085293303295
-        ],
-        [
-            73,
-            64,
-            0.19434053838790832
-        ],
-        [
-            73,
-            65,
-            0.17842860083688405
-        ],
-        [
-            73,
-            66,
-            -0.03891315712838477
-        ],
-        [
-            73,
-            67,
-            0.44270450690737195
-        ],
-        [
-            73,
-            69,
-            0.26437184630417737
-        ],
-        [
-            73,
-            70,
-            0.21827203187936012
-        ],
-        [
-            73,
-            71,
-            0.3074639545010552
-        ],
-        [
-            73,
-            72,
-            0.26437184630417737
-        ],
-        [
-            73,
-            73,
-            1.0
-        ],
-        [
-            73,
-            74,
-            0.30462880665719044
-        ],
-        [
-            73,
-            75,
-            0.31067177734385204
-        ],
-        [
-            73,
-            76,
-            0.061267341582302196
-        ],
-        [
-            73,
-            77,
-            0.4178515459109814
-        ],
-        [
-            73,
-            78,
-            0.3106717773438524
-        ],
-        [
-            73,
-            79,
-            0.2656844656620288
-        ],
-        [
-            73,
-            80,
-            0.21297129987688335
-        ],
-        [
-            73,
-            81,
-            0.3580554270685587
-        ],
-        [
-            73,
-            82,
-            0.11488127902407433
-        ],
-        [
-            73,
-            83,
-            0.2923558193666062
-        ],
-        [
-            73,
-            84,
-            0.2632909158185694
-        ],
-        [
-            73,
-            85,
-            0.390980206495477
-        ],
-        [
-            73,
-            86,
-            0.06907443024002319
-        ],
-        [
-            74,
-            0,
-            0.4867954331366181
-        ],
-        [
-            74,
-            1,
-            0.45336734022117003
-        ],
-        [
-            74,
-            2,
-            0.4398931013693864
-        ],
-        [
-            74,
-            3,
-            0.4303297889902683
-        ],
-        [
-            74,
-            4,
-            0.40322875943402453
-        ],
-        [
-            74,
-            5,
-            0.26029252942632736
-        ],
-        [
-            74,
-            6,
-            0.27858692253443756
-        ],
-        [
-            74,
-            7,
-            0.2882375776397517
-        ],
-        [
-            74,
-            8,
-            0.3948386723725146
-        ],
-        [
-            74,
-            9,
-            0.42509772500306886
-        ],
-        [
-            74,
-            10,
-            0.33254304146769126
-        ],
-        [
-            74,
-            11,
-            0.26029252942632736
-        ],
-        [
-            74,
-            12,
-            0.4300030598728164
-        ],
-        [
-            74,
-            13,
-            0.16187781529083392
-        ],
-        [
-            74,
-            14,
-            0.7693323057174861
-        ],
-        [
-            74,
-            15,
-            0.09213937111163573
-        ],
-        [
-            74,
-            16,
-            0.4843929639092114
-        ],
-        [
-            74,
-            17,
-            0.5566389634348341
-        ],
-        [
-            74,
-            18,
-            0.8138090013881376
-        ],
-        [
-            74,
-            19,
-            0.5496455529845583
-        ],
-        [
-            74,
-            20,
-            0.4171219929975563
-        ],
-        [
-            74,
-            21,
-            0.5998137513535762
-        ],
-        [
-            74,
-            22,
-            0.16187781529083387
-        ],
-        [
-            74,
-            23,
-            0.16187781529083392
-        ],
-        [
-            74,
-            25,
-            -0.030814239057475656
-        ],
-        [
-            74,
-            31,
-            0.6661920649654863
-        ],
-        [
-            74,
-            44,
-            0.4980679550425732
-        ],
-        [
-            74,
-            48,
-            0.37306932719210034
-        ],
-        [
-            74,
-            49,
-            0.4001034417947443
-        ],
-        [
-            74,
-            50,
-            0.5773502691896257
-        ],
-        [
-            74,
-            51,
-            0.397033333588372
-        ],
-        [
-            74,
-            52,
-            -0.031097661401635283
-        ],
-        [
-            74,
-            53,
-            0.4912456842785716
-        ],
-        [
-            74,
-            54,
-            0.4602301726438759
-        ],
-        [
-            74,
-            55,
-            0.3496466033765337
-        ],
-        [
-            74,
-            56,
-            0.26046905136144144
-        ],
-        [
-            74,
-            57,
-            -0.031463242906325996
-        ],
-        [
-            74,
-            58,
-            0.30658731711203996
-        ],
-        [
-            74,
-            59,
-            0.5606895113749062
-        ],
-        [
-            74,
-            60,
-            0.26046905136144144
-        ],
-        [
-            74,
-            61,
-            0.4602301726438759
-        ],
-        [
-            74,
-            63,
-            0.45148822014812534
-        ],
-        [
-            74,
-            64,
-            0.15620606554917618
-        ],
-        [
-            74,
-            65,
-            0.2376484480265768
-        ],
-        [
-            74,
-            66,
-            0.028518460342899194
-        ],
-        [
-            74,
-            67,
-            0.4949156556649775
-        ],
-        [
-            74,
-            69,
-            0.4193436306185919
-        ],
-        [
-            74,
-            70,
-            0.2786402358456586
-        ],
-        [
-            74,
-            71,
-            0.3118069149515164
-        ],
-        [
-            74,
-            72,
-            0.4124846794100691
-        ],
-        [
-            74,
-            73,
-            0.30462880665719044
-        ],
-        [
-            74,
-            74,
-            1.0
-        ],
-        [
-            74,
-            75,
-            0.4729897176214104
-        ],
-        [
-            74,
-            76,
-            0.3311405081753204
-        ],
-        [
-            74,
-            77,
-            0.2659920673780284
-        ],
-        [
-            74,
-            78,
-            0.47287444210269003
-        ],
-        [
-            74,
-            79,
-            0.18617166314248287
-        ],
-        [
-            74,
-            80,
-            0.22364320097329737
-        ],
-        [
-            74,
-            81,
-            0.4377095643060562
-        ],
-        [
-            74,
-            82,
-            0.25106198665130747
-        ],
-        [
-            74,
-            83,
-            0.48218477959803147
-        ],
-        [
-            74,
-            84,
-            0.7307478922144289
-        ],
-        [
-            74,
-            85,
-            0.2896025499161649
-        ],
-        [
-            74,
-            86,
-            0.09334468046122887
-        ],
-        [
-            75,
-            0,
-            0.6075891987525746
-        ],
-        [
-            75,
-            1,
-            0.9381250996851901
-        ],
-        [
-            75,
-            2,
-            0.8588857820901721
-        ],
-        [
-            75,
-            3,
-            0.5091917285863291
-        ],
-        [
-            75,
-            4,
-            0.2916816597461576
-        ],
-        [
-            75,
-            5,
-            0.861908451554913
-        ],
-        [
-            75,
-            6,
-            0.8604785629355204
-        ],
-        [
-            75,
-            7,
-            0.874543409939793
-        ],
-        [
-            75,
-            8,
-            0.26142002459090075
-        ],
-        [
-            75,
-            9,
-            0.8734892707168821
-        ],
-        [
-            75,
-            10,
-            0.8860387486806305
-        ],
-        [
-            75,
-            11,
-            0.861908451554913
-        ],
-        [
-            75,
-            12,
-            0.5447657885888424
-        ],
-        [
-            75,
-            13,
-            0.35887028128263676
-        ],
-        [
-            75,
-            14,
-            0.5224486524396773
-        ],
-        [
-            75,
-            15,
-            0.32825729726450664
-        ],
-        [
-            75,
-            16,
-            0.9468858107159137
-        ],
-        [
-            75,
-            17,
-            0.4707862603025948
-        ],
-        [
-            75,
-            18,
-            0.5042650304221448
-        ],
-        [
-            75,
-            19,
-            0.44279974170407715
-        ],
-        [
-            75,
-            20,
-            0.8952991452991448
-        ],
-        [
-            75,
-            21,
-            0.45034100140211464
-        ],
-        [
-            75,
-            22,
-            0.35887028128263654
-        ],
-        [
-            75,
-            23,
-            0.35887028128263676
-        ],
-        [
-            75,
-            25,
-            0.047380842315833
-        ],
-        [
-            75,
-            31,
-            0.5413390485524624
-        ],
-        [
-            75,
-            44,
-            0.47908232546152735
-        ],
-        [
-            75,
-            48,
-            0.8355654373511302
-        ],
-        [
-            75,
-            49,
-            0.9021150582355415
-        ],
-        [
-            75,
-            51,
-            0.8919348802395209
-        ],
-        [
-            75,
-            52,
-            0.3157836464689797
-        ],
-        [
-            75,
-            53,
-            0.9679722821357292
-        ],
-        [
-            75,
-            54,
-            0.9462672319050619
-        ],
-        [
-            75,
-            55,
-            0.5197133095965225
-        ],
-        [
-            75,
-            56,
-            0.4771735646265864
-        ],
-        [
-            75,
-            57,
-            0.14027823411273221
-        ],
-        [
-            75,
-            58,
-            0.5183319369734622
-        ],
-        [
-            75,
-            59,
-            0.6437786667115414
-        ],
-        [
-            75,
-            60,
-            0.4771735646265864
-        ],
-        [
-            75,
-            61,
-            0.9354812379934845
-        ],
-        [
-            75,
-            63,
-            0.7637626158259732
-        ],
-        [
-            75,
-            64,
-            0.3546361159446285
-        ],
-        [
-            75,
-            65,
-            0.7783573694716192
-        ],
-        [
-            75,
-            66,
-            0.270362711017962
-        ],
-        [
-            75,
-            67,
-            0.5477249978090998
-        ],
-        [
-            75,
-            69,
-            0.9016696346674316
-        ],
-        [
-            75,
-            70,
-            0.826639784509149
-        ],
-        [
-            75,
-            71,
-            0.46187659230037786
-        ],
-        [
-            75,
-            72,
-            0.9026853006017749
-        ],
-        [
-            75,
-            73,
-            0.31067177734385204
-        ],
-        [
-            75,
-            74,
-            0.4729897176214104
-        ],
-        [
-            75,
-            75,
-            1.0
-        ],
-        [
-            75,
-            76,
-            0.35444772920959394
-        ],
-        [
-            75,
-            77,
-            0.4719077113117678
-        ],
-        [
-            75,
-            78,
-            0.978660714285715
-        ],
-        [
-            75,
-            79,
-            0.4387013019530821
-        ],
-        [
-            75,
-            80,
-            0.7849115999782722
-        ],
-        [
-            75,
-            81,
-            0.7037881017051668
-        ],
-        [
-            75,
-            82,
-            0.41866129205726516
-        ],
-        [
-            75,
-            83,
-            0.935558650649283
-        ],
-        [
-            75,
-            84,
-            0.5582194487041
-        ],
-        [
-            75,
-            85,
-            0.44435841339357923
-        ],
-        [
-            75,
-            86,
-            0.3192184000858287
-        ],
-        [
-            76,
-            0,
-            0.35627115215558447
-        ],
-        [
-            76,
-            1,
-            0.34011568055963987
-        ],
-        [
-            76,
-            2,
-            0.3001667296966772
-        ],
-        [
-            76,
-            3,
-            0.2542899176518616
-        ],
-        [
-            76,
-            4,
-            0.30626441352464534
-        ],
-        [
-            76,
-            5,
-            0.24220755792081175
-        ],
-        [
-            76,
-            6,
-            0.2367470196367491
-        ],
-        [
-            76,
-            7,
-            0.25126114696909535
-        ],
-        [
-            76,
-            8,
-            0.2734513698875298
-        ],
-        [
-            76,
-            9,
-            0.27605157841078154
-        ],
-        [
-            76,
-            10,
-            0.27786494901108155
-        ],
-        [
-            76,
-            11,
-            0.24220755792081175
-        ],
-        [
-            76,
-            12,
-            0.32382844974594943
-        ],
-        [
-            76,
-            13,
-            0.20020650495950207
-        ],
-        [
-            76,
-            14,
-            0.29593453804451786
-        ],
-        [
-            76,
-            15,
-            0.210083421847237
-        ],
-        [
-            76,
-            16,
-            0.3405740986436113
-        ],
-        [
-            76,
-            17,
-            0.24422790627920174
-        ],
-        [
-            76,
-            18,
-            0.3112812606881815
-        ],
-        [
-            76,
-            19,
-            0.29221773636400494
-        ],
-        [
-            76,
-            20,
-            0.2636323198273602
-        ],
-        [
-            76,
-            21,
-            0.21516574145596754
-        ],
-        [
-            76,
-            22,
-            0.20020650495950226
-        ],
-        [
-            76,
-            23,
-            0.20020650495950207
-        ],
-        [
-            76,
-            25,
-            0.08326452535088533
-        ],
-        [
-            76,
-            31,
-            0.346102626727885
-        ],
-        [
-            76,
-            44,
-            0.32799046653904307
-        ],
-        [
-            76,
-            48,
-            0.3186891868093627
-        ],
-        [
-            76,
-            49,
-            0.3161098148649569
-        ],
-        [
-            76,
-            51,
-            0.34634034629899585
-        ],
-        [
-            76,
-            52,
-            0.16148960208279683
-        ],
-        [
-            76,
-            53,
-            0.332435131435923
-        ],
-        [
-            76,
-            54,
-            0.33243513143592296
-        ],
-        [
-            76,
-            55,
-            0.27483562731087363
-        ],
-        [
-            76,
-            56,
-            0.2861638757417288
-        ],
-        [
-            76,
-            57,
-            0.12012457834424939
-        ],
-        [
-            76,
-            58,
-            0.3081309034443368
-        ],
-        [
-            76,
-            59,
-            0.3759422658250896
-        ],
-        [
-            76,
-            60,
-            0.2861638757417288
-        ],
-        [
-            76,
-            61,
-            0.3255798715502322
-        ],
-        [
-            76,
-            63,
-            0.7392722422010126
-        ],
-        [
-            76,
-            64,
-            0.21540033982634835
-        ],
-        [
-            76,
-            65,
-            0.20734633959320667
-        ],
-        [
-            76,
-            66,
-            -0.0019456578564192488
-        ],
-        [
-            76,
-            67,
-            0.3095989990166173
-        ],
-        [
-            76,
-            69,
-            0.3109615270124767
-        ],
-        [
-            76,
-            70,
-            0.24393583301053354
-        ],
-        [
-            76,
-            71,
-            0.27652993831367956
-        ],
-        [
-            76,
-            72,
-            0.2997871532448683
-        ],
-        [
-            76,
-            73,
-            0.061267341582302196
-        ],
-        [
-            76,
-            74,
-            0.3311405081753204
-        ],
-        [
-            76,
-            75,
-            0.35444772920959394
-        ],
-        [
-            76,
-            76,
-            1.0
-        ],
-        [
-            76,
-            77,
-            0.2420229251068553
-        ],
-        [
-            76,
-            78,
-            0.3544477292095939
-        ],
-        [
-            76,
-            79,
-            0.24354409352352613
-        ],
-        [
-            76,
-            80,
-            0.2283634678802453
-        ],
-        [
-            76,
-            81,
-            0.23543370546973727
-        ],
-        [
-            76,
-            82,
-            0.2069603395559282
-        ],
-        [
-            76,
-            83,
-            0.32169268684679153
-        ],
-        [
-            76,
-            84,
-            0.34135994294037736
-        ],
-        [
-            76,
-            85,
-            0.332709118027401
-        ],
-        [
-            76,
-            86,
-            -0.11034872038605088
-        ],
-        [
-            77,
-            0,
-            0.6922519063747795
-        ],
-        [
-            77,
-            1,
-            0.4330342793957001
-        ],
-        [
-            77,
-            2,
-            0.4641013057093143
-        ],
-        [
-            77,
-            3,
-            0.39059876846073116
-        ],
-        [
-            77,
-            4,
-            0.41829330884294824
-        ],
-        [
-            77,
-            5,
-            0.45851362346413654
-        ],
-        [
-            77,
-            6,
-            0.47594615361975584
-        ],
-        [
-            77,
-            7,
-            0.48453407746664806
-        ],
-        [
-            77,
-            8,
-            0.3047263149392472
-        ],
-        [
-            77,
-            9,
-            0.4868949633804611
-        ],
-        [
-            77,
-            10,
-            0.49320785833463854
-        ],
-        [
-            77,
-            11,
-            0.45851362346413654
-        ],
-        [
-            77,
-            12,
-            0.7342456505403109
-        ],
-        [
-            77,
-            13,
-            0.4696150793422089
-        ],
-        [
-            77,
-            14,
-            0.3559342484071871
-        ],
-        [
-            77,
-            15,
-            0.5037815643157092
-        ],
-        [
-            77,
-            16,
-            0.450805247440741
-        ],
-        [
-            77,
-            17,
-            0.47269958175305965
-        ],
-        [
-            77,
-            18,
-            0.30638167667268595
-        ],
-        [
-            77,
-            19,
-            0.6308844116495895
-        ],
-        [
-            77,
-            20,
-            0.42774775623975264
-        ],
-        [
-            77,
-            21,
-            0.5297257466612708
-        ],
-        [
-            77,
-            22,
-            0.4696150793422086
-        ],
-        [
-            77,
-            23,
-            0.4696150793422089
-        ],
-        [
-            77,
-            25,
-            0.0805753204862889
-        ],
-        [
-            77,
-            31,
-            0.40908350901657886
-        ],
-        [
-            77,
-            44,
-            0.48848093932856
-        ],
-        [
-            77,
-            48,
-            0.46932327100492965
-        ],
-        [
-            77,
-            49,
-            0.48053613953515056
-        ],
-        [
-            77,
-            51,
-            0.534183427346822
-        ],
-        [
-            77,
-            52,
-            0.43469810612489657
-        ],
-        [
-            77,
-            53,
-            0.47788709341091834
-        ],
-        [
-            77,
-            54,
-            0.4778870934109186
-        ],
-        [
-            77,
-            55,
-            0.7063856517368761
-        ],
-        [
-            77,
-            56,
-            0.6510258876444032
-        ],
-        [
-            77,
-            57,
-            0.2022017259074317
-        ],
-        [
-            77,
-            58,
-            0.7439072914365253
-        ],
-        [
-            77,
-            59,
-            0.6815024920568703
-        ],
-        [
-            77,
-            60,
-            0.6510258876444032
-        ],
-        [
-            77,
-            61,
-            0.45885395892849706
-        ],
-        [
-            77,
-            63,
-            0.6387501924213125
-        ],
-        [
-            77,
-            64,
-            0.38442503545486645
-        ],
-        [
-            77,
-            65,
-            0.4078793163259738
-        ],
-        [
-            77,
-            66,
-            0.05842716480173336
-        ],
-        [
-            77,
-            67,
-            0.6997975415720488
-        ],
-        [
-            77,
-            69,
-            0.47876400120215185
-        ],
-        [
-            77,
-            70,
-            0.41176325770658023
-        ],
-        [
-            77,
-            71,
-            0.6312874858517875
-        ],
-        [
-            77,
-            72,
-            0.47876400120215185
-        ],
-        [
-            77,
-            73,
-            0.4178515459109814
-        ],
-        [
-            77,
-            74,
-            0.2659920673780284
-        ],
-        [
-            77,
-            75,
-            0.4719077113117678
-        ],
-        [
-            77,
-            76,
-            0.2420229251068553
-        ],
-        [
-            77,
-            77,
-            1.0
-        ],
-        [
-            77,
-            78,
-            0.4719077113117681
-        ],
-        [
-            77,
-            79,
-            0.6691227191780629
-        ],
-        [
-            77,
-            80,
-            0.4185026331062114
-        ],
-        [
-            77,
-            81,
-            0.3922472379295075
-        ],
-        [
-            77,
-            82,
-            0.2280564876134559
-        ],
-        [
-            77,
-            83,
-            0.4601210462176678
-        ],
-        [
-            77,
-            84,
-            0.3250442795052225
-        ],
-        [
-            77,
-            85,
-            0.6087943763720852
-        ],
-        [
-            77,
-            86,
-            0.46423477169980953
-        ],
-        [
-            78,
-            0,
-            0.6016241128197226
-        ],
-        [
-            78,
-            1,
-            0.9390521978179235
-        ],
-        [
-            78,
-            2,
-            0.8607017918258185
-        ],
-        [
-            78,
-            3,
-            0.5184383548760653
-        ],
-        [
-            78,
-            4,
-            0.2866125763007559
-        ],
-        [
-            78,
-            5,
-            0.8640987597877144
-        ],
-        [
-            78,
-            6,
-            0.8626969831117973
-        ],
-        [
-            78,
-            7,
-            0.8765230646861664
-        ],
-        [
-            78,
-            8,
-            0.24131759681132894
-        ],
-        [
-            78,
-            9,
-            0.8754371556885315
-        ],
-        [
-            78,
-            10,
-            0.8878316123577739
-        ],
-        [
-            78,
-            11,
-            0.8640987597877144
-        ],
-        [
-            78,
-            12,
-            0.5385384041559945
-        ],
-        [
-            78,
-            13,
-            0.35496478698597705
-        ],
-        [
-            78,
-            14,
-            0.5341433936578357
-        ],
-        [
-            78,
-            15,
-            0.32452085139664355
-        ],
-        [
-            78,
-            16,
-            0.9475587842407402
-        ],
-        [
-            78,
-            17,
-            0.48200334442200726
-        ],
-        [
-            78,
-            18,
-            0.5023578857529274
-        ],
-        [
-            78,
-            19,
-            0.43611102238721877
-        ],
-        [
-            78,
-            20,
-            0.8954907161803707
-        ],
-        [
-            78,
-            21,
-            0.45034100140211486
-        ],
-        [
-            78,
-            22,
-            0.35496478698597667
-        ],
-        [
-            78,
-            23,
-            0.35496478698597705
-        ],
-        [
-            78,
-            25,
-            0.046678183498039476
-        ],
-        [
-            78,
-            31,
-            0.5505387951222553
-        ],
-        [
-            78,
-            44,
-            0.4725464393714521
-        ],
-        [
-            78,
-            48,
-            0.8358316859472515
-        ],
-        [
-            78,
-            49,
-            0.9034036509716439
-        ],
-        [
-            78,
-            50,
-            1.0
-        ],
-        [
-            78,
-            51,
-            0.8921130952380959
-        ],
-        [
-            78,
-            52,
-            0.31608526385698715
-        ],
-        [
-            78,
-            53,
-            0.9683853030036478
-        ],
-        [
-            78,
-            54,
-            0.9469647986054095
-        ],
-        [
-            78,
-            55,
-            0.5200499630204675
-        ],
-        [
-            78,
-            56,
-            0.47257040686521745
-        ],
-        [
-            78,
-            57,
-            0.13880511306950935
-        ],
-        [
-            78,
-            58,
-            0.5186826015030329
-        ],
-        [
-            78,
-            59,
-            0.637417502745566
-        ],
-        [
-            78,
-            60,
-            0.47257040686521745
-        ],
-        [
-            78,
-            61,
-            0.936322193973667
-        ],
-        [
-            78,
-            63,
-            0.7713097659557537
-        ],
-        [
-            78,
-            64,
-            0.35124011133817773
-        ],
-        [
-            78,
-            65,
-            0.7813435390135716
-        ],
-        [
-            78,
-            66,
-            0.2880272773273383
-        ],
-        [
-            78,
-            67,
-            0.5481888975263102
-        ],
-        [
-            78,
-            69,
-            0.8903683219062298
-        ],
-        [
-            78,
-            70,
-            0.8140202768975969
-        ],
-        [
-            78,
-            71,
-            0.4427516151395504
-        ],
-        [
-            78,
-            72,
-            0.8915141061160049
-        ],
-        [
-            78,
-            73,
-            0.3106717773438524
-        ],
-        [
-            78,
-            74,
-            0.47287444210269003
-        ],
-        [
-            78,
-            75,
-            0.978660714285715
-        ],
-        [
-            78,
-            76,
-            0.3544477292095939
-        ],
-        [
-            78,
-            77,
-            0.4719077113117681
-        ],
-        [
-            78,
-            78,
-            1.0
-        ],
-        [
-            78,
-            79,
-            0.43870130195308216
-        ],
-        [
-            78,
-            80,
-            0.7852414252787587
-        ],
-        [
-            78,
-            81,
-            0.7037881017051678
-        ],
-        [
-            78,
-            82,
-            0.4186612920572651
-        ],
-        [
-            78,
-            83,
-            0.9363933799130153
-        ],
-        [
-            78,
-            84,
-            0.5691240562586639
-        ],
-        [
-            78,
-            85,
-            0.4443584133935798
-        ],
-        [
-            78,
-            86,
-            0.31385780143100755
-        ],
-        [
-            78,
-            88,
-            1.0
-        ],
-        [
-            78,
-            90,
-            1.0
-        ],
-        [
-            78,
-            92,
-            1.0
-        ],
-        [
-            78,
-            93,
-            1.0
-        ],
-        [
-            78,
-            94,
-            1.0
-        ],
-        [
-            78,
-            99,
-            1.0
-        ],
-        [
-            78,
-            100,
-            1.0
-        ],
-        [
-            79,
-            0,
-            0.6172746357502668
-        ],
-        [
-            79,
-            1,
-            0.34055735510680046
-        ],
-        [
-            79,
-            2,
-            0.44486513237857067
-        ],
-        [
-            79,
-            3,
-            0.33017672256485686
-        ],
-        [
-            79,
-            4,
-            0.29141730820341627
-        ],
-        [
-            79,
-            5,
-            0.40374911728157065
-        ],
-        [
-            79,
-            6,
-            0.38648844520092773
-        ],
-        [
-            79,
-            7,
-            0.39500608242483076
-        ],
-        [
-            79,
-            8,
-            0.18995604488688028
-        ],
-        [
-            79,
-            9,
-            0.4214937876118211
-        ],
-        [
-            79,
-            10,
-            0.4008826360373775
-        ],
-        [
-            79,
-            11,
-            0.40374911728157065
-        ],
-        [
-            79,
-            12,
-            0.5968970907532994
-        ],
-        [
-            79,
-            13,
-            0.4092076124389627
-        ],
-        [
-            79,
-            14,
-            0.26767166212907617
-        ],
-        [
-            79,
-            15,
-            0.43934690294981227
-        ],
-        [
-            79,
-            16,
-            0.4066712914404367
-        ],
-        [
-            79,
-            17,
-            0.40809398459340374
-        ],
-        [
-            79,
-            18,
-            0.22312752265922187
-        ],
-        [
-            79,
-            19,
-            0.4186657443249605
-        ],
-        [
-            79,
-            20,
-            0.3696202121033678
-        ],
-        [
-            79,
-            21,
-            0.33427046548397604
-        ],
-        [
-            79,
-            22,
-            0.40920761243896236
-        ],
-        [
-            79,
-            23,
-            0.4092076124389627
-        ],
-        [
-            79,
-            25,
-            0.07350605457604845
-        ],
-        [
-            79,
-            31,
-            0.36069557494875876
-        ],
-        [
-            79,
-            44,
-            0.3964331447645081
-        ],
-        [
-            79,
-            48,
-            0.37497527032921707
-        ],
-        [
-            79,
-            49,
-            0.43769362322598737
-        ],
-        [
-            79,
-            51,
-            0.4133185231840147
-        ],
-        [
-            79,
-            52,
-            0.4089918311153384
-        ],
-        [
-            79,
-            53,
-            0.4339565163726142
-        ],
-        [
-            79,
-            54,
-            0.4339565163726144
-        ],
-        [
-            79,
-            55,
-            0.6656237542138637
-        ],
-        [
-            79,
-            56,
-            0.6133521640983414
-        ],
-        [
-            79,
-            57,
-            0.18897140558743192
-        ],
-        [
-            79,
-            58,
-            0.6656237542138634
-        ],
-        [
-            79,
-            59,
-            0.6071769823062519
-        ],
-        [
-            79,
-            60,
-            0.6133521640983414
-        ],
-        [
-            79,
-            61,
-            0.4159112812308164
-        ],
-        [
-            79,
-            63,
-            0.5814327982484203
-        ],
-        [
-            79,
-            64,
-            0.3596328748515543
-        ],
-        [
-            79,
-            65,
-            0.4194848929394833
-        ],
-        [
-            79,
-            66,
-            0.09819407399024647
-        ],
-        [
-            79,
-            67,
-            0.62486002571806
-        ],
-        [
-            79,
-            69,
-            0.43563352240286196
-        ],
-        [
-            79,
-            70,
-            0.4010763229358247
-        ],
-        [
-            79,
-            71,
-            0.5945956802980112
-        ],
-        [
-            79,
-            72,
-            0.43563352240286196
-        ],
-        [
-            79,
-            73,
-            0.2656844656620288
-        ],
-        [
-            79,
-            74,
-            0.18617166314248287
-        ],
-        [
-            79,
-            75,
-            0.4387013019530821
-        ],
-        [
-            79,
-            76,
-            0.24354409352352613
-        ],
-        [
-            79,
-            77,
-            0.6691227191780629
-        ],
-        [
-            79,
-            78,
-            0.43870130195308216
-        ],
-        [
-            79,
-            79,
-            1.0
-        ],
-        [
-            79,
-            80,
-            0.4143060602000128
-        ],
-        [
-            79,
-            81,
-            0.3561936399581806
-        ],
-        [
-            79,
-            82,
-            0.22561413290506496
-        ],
-        [
-            79,
-            83,
-            0.4276746892533939
-        ],
-        [
-            79,
-            84,
-            0.2375366568914957
-        ],
-        [
-            79,
-            85,
-            0.5481029353547141
-        ],
-        [
-            79,
-            86,
-            0.3578640602399778
-        ],
-        [
-            80,
-            0,
-            0.5445029526777365
-        ],
-        [
-            80,
-            1,
-            0.7373229221923706
-        ],
-        [
-            80,
-            2,
-            0.7477385158209185
-        ],
-        [
-            80,
-            3,
-            0.31377408239584653
-        ],
-        [
-            80,
-            4,
-            0.18794305290132032
-        ],
-        [
-            80,
-            5,
-            0.852269705207385
-        ],
-        [
-            80,
-            6,
-            0.8543123543123546
-        ],
-        [
-            80,
-            7,
-            0.8678962167265862
-        ],
-        [
-            80,
-            8,
-            0.12723323549870977
-        ],
-        [
-            80,
-            9,
-            0.7416068091227004
-        ],
-        [
-            80,
-            10,
-            0.8570036569654218
-        ],
-        [
-            80,
-            11,
-            0.852269705207385
-        ],
-        [
-            80,
-            12,
-            0.4480716406799287
-        ],
-        [
-            80,
-            13,
-            0.3227580161440406
-        ],
-        [
-            80,
-            14,
-            0.22297260515793077
-        ],
-        [
-            80,
-            15,
-            0.2926194044420368
-        ],
-        [
-            80,
-            16,
-            0.7525121326622721
-        ],
-        [
-            80,
-            17,
-            0.2162583389440027
-        ],
-        [
-            80,
-            18,
-            0.23559266469029913
-        ],
-        [
-            80,
-            19,
-            0.18574862685722884
-        ],
-        [
-            80,
-            20,
-            0.7800917544849286
-        ],
-        [
-            80,
-            21,
-            0.21502824253951516
-        ],
-        [
-            80,
-            22,
-            0.322758016144041
-        ],
-        [
-            80,
-            23,
-            0.3227580161440406
-        ],
-        [
-            80,
-            25,
-            0.057457293325064614
-        ],
-        [
-            80,
-            31,
-            0.2997018811488428
-        ],
-        [
-            80,
-            44,
-            0.31085676548025976
-        ],
-        [
-            80,
-            48,
-            0.7090819174235541
-        ],
-        [
-            80,
-            49,
-            0.8315667549715151
-        ],
-        [
-            80,
-            51,
-            0.7849115999782721
-        ],
-        [
-            80,
-            52,
-            0.2824724531410804
-        ],
-        [
-            80,
-            53,
-            0.7903813599053088
-        ],
-        [
-            80,
-            54,
-            0.790381359905308
-        ],
-        [
-            80,
-            55,
-            0.5314271964678814
-        ],
-        [
-            80,
-            56,
-            0.5189542483660132
-        ],
-        [
-            80,
-            57,
-            0.1604361257498846
-        ],
-        [
-            80,
-            58,
-            0.4970425367310802
-        ],
-        [
-            80,
-            59,
-            0.5019274296061491
-        ],
-        [
-            80,
-            60,
-            0.5189542483660132
-        ],
-        [
-            80,
-            61,
-            0.8003445988338292
-        ],
-        [
-            80,
-            63,
-            0.5249223545067114
-        ],
-        [
-            80,
-            64,
-            0.3294300174833315
-        ],
-        [
-            80,
-            65,
-            0.8182025900253902
-        ],
-        [
-            80,
-            66,
-            0.2583148259400218
-        ],
-        [
-            80,
-            67,
-            0.48877841097968855
-        ],
-        [
-            80,
-            69,
-            0.8201258650610442
-        ],
-        [
-            80,
-            70,
-            0.7986235400810321
-        ],
-        [
-            80,
-            71,
-            0.4813159338237721
-        ],
-        [
-            80,
-            72,
-            0.8201258650610442
-        ],
-        [
-            80,
-            73,
-            0.21297129987688335
-        ],
-        [
-            80,
-            74,
-            0.22364320097329737
-        ],
-        [
-            80,
-            75,
-            0.7849115999782722
-        ],
-        [
-            80,
-            76,
-            0.2283634678802453
-        ],
-        [
-            80,
-            77,
-            0.4185026331062114
-        ],
-        [
-            80,
-            78,
-            0.7852414252787587
-        ],
-        [
-            80,
-            79,
-            0.4143060602000128
-        ],
-        [
-            80,
-            80,
-            1.0
-        ],
-        [
-            80,
-            81,
-            0.5916753691294128
-        ],
-        [
-            80,
-            82,
-            0.42771524424845025
-        ],
-        [
-            80,
-            83,
-            0.8043663549617933
-        ],
-        [
-            80,
-            84,
-            0.2458827382964676
-        ],
-        [
-            80,
-            85,
-            0.4317293859862356
-        ],
-        [
-            80,
-            86,
-            0.22575288565513313
-        ],
-        [
-            81,
-            0,
-            0.5107240733669339
-        ],
-        [
-            81,
-            1,
-            0.6999196930849415
-        ],
-        [
-            81,
-            2,
-            0.7343256096662497
-        ],
-        [
-            81,
-            3,
-            0.3407328773843053
-        ],
-        [
-            81,
-            4,
-            0.2916625261406942
-        ],
-        [
-            81,
-            5,
-            0.5933861639453609
-        ],
-        [
-            81,
-            6,
-            0.5907955471728582
-        ],
-        [
-            81,
-            7,
-            0.6043996065558523
-        ],
-        [
-            81,
-            8,
-            0.2659972052971536
-        ],
-        [
-            81,
-            9,
-            0.7376175645191969
-        ],
-        [
-            81,
-            10,
-            0.6371256356823043
-        ],
-        [
-            81,
-            11,
-            0.5933861639453609
-        ],
-        [
-            81,
-            12,
-            0.4667311847400118
-        ],
-        [
-            81,
-            13,
-            0.2388537346290343
-        ],
-        [
-            81,
-            14,
-            0.41190396987360905
-        ],
-        [
-            81,
-            15,
-            0.25809700653998235
-        ],
-        [
-            81,
-            16,
-            0.7123838003508416
-        ],
-        [
-            81,
-            17,
-            0.32530694218935374
-        ],
-        [
-            81,
-            18,
-            0.45402298850574746
-        ],
-        [
-            81,
-            19,
-            0.422854353016479
-        ],
-        [
-            81,
-            20,
-            0.6499434476679972
-        ],
-        [
-            81,
-            21,
-            0.39208112103365517
-        ],
-        [
-            81,
-            22,
-            0.28850446049541273
-        ],
-        [
-            81,
-            23,
-            0.2388537346290343
-        ],
-        [
-            81,
-            25,
-            0.12119357448701656
-        ],
-        [
-            81,
-            31,
-            0.4417982377304587
-        ],
-        [
-            81,
-            44,
-            0.4372135165172474
-        ],
-        [
-            81,
-            48,
-            0.6020142234071966
-        ],
-        [
-            81,
-            49,
-            0.6386908625478129
-        ],
-        [
-            81,
-            51,
-            0.6430524620718616
-        ],
-        [
-            81,
-            52,
-            0.24789615613975569
-        ],
-        [
-            81,
-            53,
-            0.6959928263731637
-        ],
-        [
-            81,
-            54,
-            0.6756369832823921
-        ],
-        [
-            81,
-            55,
-            0.44167623400802813
-        ],
-        [
-            81,
-            56,
-            0.378977249675833
-        ],
-        [
-            81,
-            57,
-            0.10340973183051785
-        ],
-        [
-            81,
-            58,
-            0.4122822716753176
-        ],
-        [
-            81,
-            59,
-            0.5136257265342967
-        ],
-        [
-            81,
-            60,
-            0.378977249675833
-        ],
-        [
-            81,
-            61,
-            0.6664249685364119
-        ],
-        [
-            81,
-            63,
-            0.7577754301140095
-        ],
-        [
-            81,
-            64,
-            0.2778056908631048
-        ],
-        [
-            81,
-            65,
-            0.5456543594390102
-        ],
-        [
-            81,
-            66,
-            0.20578676477185032
-        ],
-        [
-            81,
-            67,
-            0.498177006269537
-        ],
-        [
-            81,
-            69,
-            0.6367284928726596
-        ],
-        [
-            81,
-            70,
-            0.5963447299359413
-        ],
-        [
-            81,
-            71,
-            0.36596838057408315
-        ],
-        [
-            81,
-            72,
-            0.6367284928726596
-        ],
-        [
-            81,
-            73,
-            0.3580554270685587
-        ],
-        [
-            81,
-            74,
-            0.4377095643060562
-        ],
-        [
-            81,
-            75,
-            0.7037881017051668
-        ],
-        [
-            81,
-            76,
-            0.23543370546973727
-        ],
-        [
-            81,
-            77,
-            0.3922472379295075
-        ],
-        [
-            81,
-            78,
-            0.7037881017051678
-        ],
-        [
-            81,
-            79,
-            0.3561936399581806
-        ],
-        [
-            81,
-            80,
-            0.5916753691294128
-        ],
-        [
-            81,
-            81,
-            1.0
-        ],
-        [
-            81,
-            82,
-            0.3022696922191916
-        ],
-        [
-            81,
-            83,
-            0.6854354738022492
-        ],
-        [
-            81,
-            84,
-            0.3465234088789005
-        ],
-        [
-            81,
-            85,
-            0.367775566922703
-        ],
-        [
-            81,
-            86,
-            0.18219024967706574
-        ],
-        [
-            82,
-            0,
-            0.28948405493948726
-        ],
-        [
-            82,
-            1,
-            0.42080268215331684
-        ],
-        [
-            82,
-            2,
-            0.4976341996480998
-        ],
-        [
-            82,
-            3,
-            0.0978724666583036
-        ],
-        [
-            82,
-            4,
-            0.10094679649981633
-        ],
-        [
-            82,
-            5,
-            0.4093383110976321
-        ],
-        [
-            82,
-            6,
-            0.42281479204709893
-        ],
-        [
-            82,
-            7,
-            0.41608779787235456
-        ],
-        [
-            82,
-            8,
-            0.09784517688247725
-        ],
-        [
-            82,
-            9,
-            0.4927629756768466
-        ],
-        [
-            82,
-            10,
-            0.4362116992246639
-        ],
-        [
-            82,
-            11,
-            0.4093383110976321
-        ],
-        [
-            82,
-            12,
-            0.255386411719591
-        ],
-        [
-            82,
-            13,
-            0.12014076573099595
-        ],
-        [
-            82,
-            14,
-            0.2192979205994453
-        ],
-        [
-            82,
-            15,
-            0.13272132959982982
-        ],
-        [
-            82,
-            16,
-            0.38734148042766214
-        ],
-        [
-            82,
-            17,
-            0.17854996292479888
-        ],
-        [
-            82,
-            18,
-            0.26224750589280055
-        ],
-        [
-            82,
-            19,
-            0.25366432537426714
-        ],
-        [
-            82,
-            20,
-            0.4604508863857979
-        ],
-        [
-            82,
-            21,
-            0.2306555233315467
-        ],
-        [
-            82,
-            22,
-            0.12014076573099625
-        ],
-        [
-            82,
-            23,
-            0.12014076573099595
-        ],
-        [
-            82,
-            25,
-            -0.02082279205300753
-        ],
-        [
-            82,
-            31,
-            0.2037697700075005
-        ],
-        [
-            82,
-            44,
-            0.2280932256188991
-        ],
-        [
-            82,
-            48,
-            0.37830543812186895
-        ],
-        [
-            82,
-            49,
-            0.44331034746678655
-        ],
-        [
-            82,
-            51,
-            0.40153288138680876
-        ],
-        [
-            82,
-            52,
-            0.12962422189735173
-        ],
-        [
-            82,
-            53,
-            0.4452650280184789
-        ],
-        [
-            82,
-            54,
-            0.4246236028785493
-        ],
-        [
-            82,
-            55,
-            0.2118768346683168
-        ],
-        [
-            82,
-            56,
-            0.25186730546402214
-        ],
-        [
-            82,
-            57,
-            0.03944190142157378
-        ],
-        [
-            82,
-            58,
-            0.2419913086313263
-        ],
-        [
-            82,
-            59,
-            0.3343583460028043
-        ],
-        [
-            82,
-            60,
-            0.25186730546402214
-        ],
-        [
-            82,
-            61,
-            0.43950711711150586
-        ],
-        [
-            82,
-            63,
-            0.406734898468146
-        ],
-        [
-            82,
-            64,
-            0.11018798355373481
-        ],
-        [
-            82,
-            65,
-            0.3739395654006905
-        ],
-        [
-            82,
-            66,
-            0.14049989542313537
-        ],
-        [
-            82,
-            67,
-            0.26385233120297996
-        ],
-        [
-            82,
-            69,
-            0.4223054471202945
-        ],
-        [
-            82,
-            70,
-            0.3921365961350671
-        ],
-        [
-            82,
-            71,
-            0.24478424227441586
-        ],
-        [
-            82,
-            72,
-            0.4223054471202945
-        ],
-        [
-            82,
-            73,
-            0.11488127902407433
-        ],
-        [
-            82,
-            74,
-            0.25106198665130747
-        ],
-        [
-            82,
-            75,
-            0.41866129205726516
-        ],
-        [
-            82,
-            76,
-            0.2069603395559282
-        ],
-        [
-            82,
-            77,
-            0.2280564876134559
-        ],
-        [
-            82,
-            78,
-            0.4186612920572651
-        ],
-        [
-            82,
-            79,
-            0.22561413290506496
-        ],
-        [
-            82,
-            80,
-            0.42771524424845025
-        ],
-        [
-            82,
-            81,
-            0.3022696922191916
-        ],
-        [
-            82,
-            82,
-            1.0
-        ],
-        [
-            82,
-            83,
-            0.4683042111671771
-        ],
-        [
-            82,
-            84,
-            0.2347610401609496
-        ],
-        [
-            82,
-            85,
-            0.17782256552203143
-        ],
-        [
-            82,
-            86,
-            0.10047207809629713
-        ],
-        [
-            83,
-            0,
-            0.6207818948568742
-        ],
-        [
-            83,
-            1,
-            0.9153479868341301
-        ],
-        [
-            83,
-            2,
-            0.8609292044196345
-        ],
-        [
-            83,
-            3,
-            0.5392926790675338
-        ],
-        [
-            83,
-            4,
-            0.2999333418706646
-        ],
-        [
-            83,
-            5,
-            0.8876253645985951
-        ],
-        [
-            83,
-            6,
-            0.8865435185909953
-        ],
-        [
-            83,
-            7,
-            0.9001655975324931
-        ],
-        [
-            83,
-            8,
-            0.29365912300746716
-        ],
-        [
-            83,
-            9,
-            0.8753561253561253
-        ],
-        [
-            83,
-            10,
-            0.9143469184364625
-        ],
-        [
-            83,
-            11,
-            0.8876253645985951
-        ],
-        [
-            83,
-            12,
-            0.561197522208027
-        ],
-        [
-            83,
-            13,
-            0.3800584750330461
-        ],
-        [
-            83,
-            14,
-            0.5066348486870673
-        ],
-        [
-            83,
-            15,
-            0.33778628567227126
-        ],
-        [
-            83,
-            16,
-            0.9061231430088035
-        ],
-        [
-            83,
-            17,
-            0.5228641123953888
-        ],
-        [
-            83,
-            18,
-            0.5114751187740824
-        ],
-        [
-            83,
-            19,
-            0.48135414095959117
-        ],
-        [
-            83,
-            20,
-            0.9481691292762744
-        ],
-        [
-            83,
-            21,
-            0.4579277041704312
-        ],
-        [
-            83,
-            22,
-            0.3625318393663303
-        ],
-        [
-            83,
-            23,
-            0.3800584750330461
-        ],
-        [
-            83,
-            25,
-            0.09868876541696521
-        ],
-        [
-            83,
-            31,
-            0.5590892730920617
-        ],
-        [
-            83,
-            44,
-            0.47997347903437126
-        ],
-        [
-            83,
-            46,
-            0.10494520621550063
-        ],
-        [
-            83,
-            48,
-            0.8167036203755575
-        ],
-        [
-            83,
-            49,
-            0.9259777038413898
-        ],
-        [
-            83,
-            50,
-            1.0
-        ],
-        [
-            83,
-            51,
-            0.892506234761633
-        ],
-        [
-            83,
-            52,
-            0.29534065433833334
-        ],
-        [
-            83,
-            53,
-            0.9478004327110218
-        ],
-        [
-            83,
-            54,
-            0.9478004327110213
-        ],
-        [
-            83,
-            55,
-            0.5244829033003676
-        ],
-        [
-            83,
-            56,
-            0.50876051610712
-        ],
-        [
-            83,
-            57,
-            0.17056147793191553
-        ],
-        [
-            83,
-            58,
-            0.5382765057464942
-        ],
-        [
-            83,
-            59,
-            0.6660680285814269
-        ],
-        [
-            83,
-            60,
-            0.50876051610712
-        ],
-        [
-            83,
-            61,
-            0.9582097685952232
-        ],
-        [
-            83,
-            62,
-            0.10527057192443806
-        ],
-        [
-            83,
-            63,
-            0.721687836487032
-        ],
-        [
-            83,
-            64,
-            0.34315307742620704
-        ],
-        [
-            83,
-            65,
-            0.8069821705754358
-        ],
-        [
-            83,
-            66,
-            0.30473984055004616
-        ],
-        [
-            83,
-            67,
-            0.5486621990759066
-        ],
-        [
-            83,
-            69,
-            0.9137394994588096
-        ],
-        [
-            83,
-            70,
-            0.838506918125452
-        ],
-        [
-            83,
-            71,
-            0.48143926900350553
-        ],
-        [
-            83,
-            72,
-            0.9146614613296359
-        ],
-        [
-            83,
-            73,
-            0.2923558193666062
-        ],
-        [
-            83,
-            74,
-            0.48218477959803147
-        ],
-        [
-            83,
-            75,
-            0.935558650649283
-        ],
-        [
-            83,
-            76,
-            0.32169268684679153
-        ],
-        [
-            83,
-            77,
-            0.4601210462176678
-        ],
-        [
-            83,
-            78,
-            0.9363933799130153
-        ],
-        [
-            83,
-            79,
-            0.4276746892533939
-        ],
-        [
-            83,
-            80,
-            0.8043663549617933
-        ],
-        [
-            83,
-            81,
-            0.6854354738022492
-        ],
-        [
-            83,
-            82,
-            0.4683042111671771
-        ],
-        [
-            83,
-            83,
-            1.0
-        ],
-        [
-            83,
-            84,
-            0.5403500943850599
-        ],
-        [
-            83,
-            85,
-            0.4362167011718386
-        ],
-        [
-            83,
-            86,
-            0.30951902499928746
-        ],
-        [
-            83,
-            88,
-            1.0
-        ],
-        [
-            83,
-            90,
-            1.0
-        ],
-        [
-            83,
-            92,
-            1.0
-        ],
-        [
-            83,
-            93,
-            1.0
-        ],
-        [
-            83,
-            94,
-            1.0
-        ],
-        [
-            83,
-            99,
-            1.0
-        ],
-        [
-            83,
-            100,
-            1.0
-        ],
-        [
-            84,
-            0,
-            0.636272288923178
-        ],
-        [
-            84,
-            1,
-            0.5533344076659201
-        ],
-        [
-            84,
-            2,
-            0.48574618514864737
-        ],
-        [
-            84,
-            3,
-            0.47064217115720663
-        ],
-        [
-            84,
-            4,
-            0.33993636916197745
-        ],
-        [
-            84,
-            5,
-            0.26796419589164416
-        ],
-        [
-            84,
-            6,
-            0.2971315101924956
-        ],
-        [
-            84,
-            7,
-            0.3055369462903217
-        ],
-        [
-            84,
-            8,
-            0.2762983217465941
-        ],
-        [
-            84,
-            9,
-            0.4552712929736526
-        ],
-        [
-            84,
-            10,
-            0.36943729983679036
-        ],
-        [
-            84,
-            11,
-            0.26796419589164416
-        ],
-        [
-            84,
-            12,
-            0.569831108409643
-        ],
-        [
-            84,
-            13,
-            0.21225476044916708
-        ],
-        [
-            84,
-            14,
-            0.9069949172805473
-        ],
-        [
-            84,
-            15,
-            0.13321879059870784
-        ],
-        [
-            84,
-            16,
-            0.5884620343444873
-        ],
-        [
-            84,
-            17,
-            0.7123336289633032
-        ],
-        [
-            84,
-            18,
-            0.7998749328214972
-        ],
-        [
-            84,
-            19,
-            0.6141410062885246
-        ],
-        [
-            84,
-            20,
-            0.4682271001182218
-        ],
-        [
-            84,
-            21,
-            0.7069352132943885
-        ],
-        [
-            84,
-            22,
-            -0.024538122595279533
-        ],
-        [
-            84,
-            23,
-            0.21225476044916708
-        ],
-        [
-            84,
-            25,
-            -0.02425883673714219
-        ],
-        [
-            84,
-            31,
-            0.8044163417795342
-        ],
-        [
-            84,
-            44,
-            0.6653892197719429
-        ],
-        [
-            84,
-            48,
-            0.46547069410825626
-        ],
-        [
-            84,
-            49,
-            0.4598850925135676
-        ],
-        [
-            84,
-            50,
-            1.0
-        ],
-        [
-            84,
-            51,
-            0.47299885932255115
-        ],
-        [
-            84,
-            52,
-            -0.023782574707724897
-        ],
-        [
-            84,
-            53,
-            0.5870512379769168
-        ],
-        [
-            84,
-            54,
-            0.5489310277186753
-        ],
-        [
-            84,
-            55,
-            0.35440871367981336
-        ],
-        [
-            84,
-            56,
-            0.3452958451208224
-        ],
-        [
-            84,
-            57,
-            -0.024258836737142193
-        ],
-        [
-            84,
-            58,
-            0.4078636389723285
-        ],
-        [
-            84,
-            59,
-            0.7316269686196134
-        ],
-        [
-            84,
-            60,
-            0.3452958451208224
-        ],
-        [
-            84,
-            61,
-            0.5489310277186753
-        ],
-        [
-            84,
-            63,
-            0.5981411919861926
-        ],
-        [
-            84,
-            64,
-            -0.04222003309207508
-        ],
-        [
-            84,
-            65,
-            0.26383176440181505
-        ],
-        [
-            84,
-            66,
-            0.0763617018347741
-        ],
-        [
-            84,
-            67,
-            0.5317337572725112
-        ],
-        [
-            84,
-            69,
-            0.43469375328927146
-        ],
-        [
-            84,
-            70,
-            0.24223002563411564
-        ],
-        [
-            84,
-            71,
-            0.3139751087370715
-        ],
-        [
-            84,
-            72,
-            0.43469375328927146
-        ],
-        [
-            84,
-            73,
-            0.2632909158185694
-        ],
-        [
-            84,
-            74,
-            0.7307478922144289
-        ],
-        [
-            84,
-            75,
-            0.5582194487041
-        ],
-        [
-            84,
-            76,
-            0.34135994294037736
-        ],
-        [
-            84,
-            77,
-            0.3250442795052225
-        ],
-        [
-            84,
-            78,
-            0.5691240562586639
-        ],
-        [
-            84,
-            79,
-            0.2375366568914957
-        ],
-        [
-            84,
-            80,
-            0.2458827382964676
-        ],
-        [
-            84,
-            81,
-            0.3465234088789005
-        ],
-        [
-            84,
-            82,
-            0.2347610401609496
-        ],
-        [
-            84,
-            83,
-            0.5403500943850599
-        ],
-        [
-            84,
-            84,
-            1.0
-        ],
-        [
-            84,
-            85,
-            0.20724124620517206
-        ],
-        [
-            84,
-            86,
-            0.21410382713641868
-        ],
-        [
-            84,
-            88,
-            1.0
-        ],
-        [
-            84,
-            90,
-            1.0
-        ],
-        [
-            84,
-            92,
-            1.0
-        ],
-        [
-            84,
-            93,
-            1.0
-        ],
-        [
-            84,
-            94,
-            1.0
-        ],
-        [
-            84,
-            99,
-            1.0
-        ],
-        [
-            84,
-            100,
-            1.0
-        ],
-        [
-            85,
-            0,
-            0.5398744190894337
-        ],
-        [
-            85,
-            1,
-            0.3815947467563174
-        ],
-        [
-            85,
-            2,
-            0.42789580294248225
-        ],
-        [
-            85,
-            3,
-            0.2537823630689847
-        ],
-        [
-            85,
-            4,
-            0.27553628690024295
-        ],
-        [
-            85,
-            5,
-            0.4317900732394964
-        ],
-        [
-            85,
-            6,
-            0.41245365726755473
-        ],
-        [
-            85,
-            7,
-            0.42199775533108874
-        ],
-        [
-            85,
-            8,
-            0.18768977965393627
-        ],
-        [
-            85,
-            9,
-            0.40607801503318774
-        ],
-        [
-            85,
-            10,
-            0.4505058887804784
-        ],
-        [
-            85,
-            11,
-            0.4317900732394964
-        ],
-        [
-            85,
-            12,
-            0.5100895957884068
-        ],
-        [
-            85,
-            13,
-            0.3521811567360959
-        ],
-        [
-            85,
-            14,
-            0.22970906366668498
-        ],
-        [
-            85,
-            15,
-            0.3785747520337368
-        ],
-        [
-            85,
-            16,
-            0.43616904356804986
-        ],
-        [
-            85,
-            17,
-            0.273249853074652
-        ],
-        [
-            85,
-            18,
-            0.18297231724430765
-        ],
-        [
-            85,
-            19,
-            0.3272774205482736
-        ],
-        [
-            85,
-            20,
-            0.34731347478416774
-        ],
-        [
-            85,
-            21,
-            0.2512055594727398
-        ],
-        [
-            85,
-            22,
-            0.35218115673609623
-        ],
-        [
-            85,
-            23,
-            0.3521811567360959
-        ],
-        [
-            85,
-            25,
-            0.05995352128425513
-        ],
-        [
-            85,
-            31,
-            0.2762825248058982
-        ],
-        [
-            85,
-            44,
-            0.314312856101024
-        ],
-        [
-            85,
-            48,
-            0.42340516367869563
-        ],
-        [
-            85,
-            49,
-            0.45113300645186216
-        ],
-        [
-            85,
-            51,
-            0.46658512079158704
-        ],
-        [
-            85,
-            52,
-            0.3611830218196948
-        ],
-        [
-            85,
-            53,
-            0.4430520211965393
-        ],
-        [
-            85,
-            54,
-            0.44305202119653914
-        ],
-        [
-            85,
-            55,
-            0.5899920143010966
-        ],
-        [
-            85,
-            56,
-            0.5434312250732404
-        ],
-        [
-            85,
-            57,
-            0.1641417704257158
-        ],
-        [
-            85,
-            58,
-            0.6237645785841365
-        ],
-        [
-            85,
-            59,
-            0.5284165040202013
-        ],
-        [
-            85,
-            60,
-            0.5434312250732404
-        ],
-        [
-            85,
-            61,
-            0.427318433757171
-        ],
-        [
-            85,
-            63,
-            0.6929348671835834
-        ],
-        [
-            85,
-            64,
-            0.3578719646004937
-        ],
-        [
-            85,
-            65,
-            0.41126362910503567
-        ],
-        [
-            85,
-            66,
-            0.022508202291617648
-        ],
-        [
-            85,
-            67,
-            0.5442673265096629
-        ],
-        [
-            85,
-            69,
-            0.4579160553113219
-        ],
-        [
-            85,
-            70,
-            0.43653540662076007
-        ],
-        [
-            85,
-            71,
-            0.5332429699288117
-        ],
-        [
-            85,
-            72,
-            0.4579160553113219
-        ],
-        [
-            85,
-            73,
-            0.390980206495477
-        ],
-        [
-            85,
-            74,
-            0.2896025499161649
-        ],
-        [
-            85,
-            75,
-            0.44435841339357923
-        ],
-        [
-            85,
-            76,
-            0.332709118027401
-        ],
-        [
-            85,
-            77,
-            0.6087943763720852
-        ],
-        [
-            85,
-            78,
-            0.4443584133935798
-        ],
-        [
-            85,
-            79,
-            0.5481029353547141
-        ],
-        [
-            85,
-            80,
-            0.4317293859862356
-        ],
-        [
-            85,
-            81,
-            0.367775566922703
-        ],
-        [
-            85,
-            82,
-            0.17782256552203143
-        ],
-        [
-            85,
-            83,
-            0.4362167011718386
-        ],
-        [
-            85,
-            84,
-            0.20724124620517206
-        ],
-        [
-            85,
-            85,
-            1.0
-        ],
-        [
-            85,
-            86,
-            0.31872491701109823
-        ],
-        [
-            86,
-            0,
-            0.4536899487117063
-        ],
-        [
-            86,
-            1,
-            0.2525872830735344
-        ],
-        [
-            86,
-            2,
-            0.268010730224046
-        ],
-        [
-            86,
-            3,
-            0.19429954381970735
-        ],
-        [
-            86,
-            4,
-            0.17019381114452506
-        ],
-        [
-            86,
-            5,
-            0.25939858057303494
-        ],
-        [
-            86,
-            6,
-            0.26616879602704263
-        ],
-        [
-            86,
-            7,
-            0.25002092938839754
-        ],
-        [
-            86,
-            8,
-            0.12411735281897085
-        ],
-        [
-            86,
-            9,
-            0.229471641697587
-        ],
-        [
-            86,
-            10,
-            0.24336910149661603
-        ],
-        [
-            86,
-            11,
-            0.25939858057303494
-        ],
-        [
-            86,
-            12,
-            0.4189655012608076
-        ],
-        [
-            86,
-            13,
-            0.30370632184980423
-        ],
-        [
-            86,
-            14,
-            0.1914199895544468
-        ],
-        [
-            86,
-            15,
-            0.40251124147431866
-        ],
-        [
-            86,
-            16,
-            0.3194517526672785
-        ],
-        [
-            86,
-            17,
-            0.18796341545409873
-        ],
-        [
-            86,
-            18,
-            0.16733486127657732
-        ],
-        [
-            86,
-            19,
-            0.26167267846888675
-        ],
-        [
-            86,
-            20,
-            0.2233288842774767
-        ],
-        [
-            86,
-            21,
-            0.16580068899589212
-        ],
-        [
-            86,
-            22,
-            0.3357573690514622
-        ],
-        [
-            86,
-            23,
-            0.30370632184980423
-        ],
-        [
-            86,
-            25,
-            0.3378656589654642
-        ],
-        [
-            86,
-            31,
-            0.25369504653545316
-        ],
-        [
-            86,
-            44,
-            0.2143264697148131
-        ],
-        [
-            86,
-            46,
-            0.33431778832516756
-        ],
-        [
-            86,
-            48,
-            0.34911117944693165
-        ],
-        [
-            86,
-            49,
-            0.3365552767215637
-        ],
-        [
-            86,
-            51,
-            0.28740321894319243
-        ],
-        [
-            86,
-            52,
-            0.30979654361223
-        ],
-        [
-            86,
-            53,
-            0.34329988782872434
-        ],
-        [
-            86,
-            54,
-            0.32983700690570444
-        ],
-        [
-            86,
-            55,
-            0.5939160993596
-        ],
-        [
-            86,
-            56,
-            0.49184808824491777
-        ],
-        [
-            86,
-            57,
-            0.18122868148026197
-        ],
-        [
-            86,
-            58,
-            0.4761121283284595
-        ],
-        [
-            86,
-            59,
-            0.4301449054038492
-        ],
-        [
-            86,
-            60,
-            0.49184808824491777
-        ],
-        [
-            86,
-            61,
-            0.31739730956373535
-        ],
-        [
-            86,
-            62,
-            0.09783581227068176
-        ],
-        [
-            86,
-            63,
-            0.2999059282665924
-        ],
-        [
-            86,
-            64,
-            0.30845591166702774
-        ],
-        [
-            86,
-            65,
-            0.30332272127808224
-        ],
-        [
-            86,
-            66,
-            0.10152241385149395
-        ],
-        [
-            86,
-            67,
-            0.43452166374311363
-        ],
-        [
-            86,
-            68,
-            0.09660996857675344
-        ],
-        [
-            86,
-            69,
-            0.32493595897122235
-        ],
-        [
-            86,
-            70,
-            0.3166692538532453
-        ],
-        [
-            86,
-            71,
-            0.4530182104751649
-        ],
-        [
-            86,
-            72,
-            0.3295707136849689
-        ],
-        [
-            86,
-            73,
-            0.06907443024002319
-        ],
-        [
-            86,
-            74,
-            0.09334468046122887
-        ],
-        [
-            86,
-            75,
-            0.3192184000858287
-        ],
-        [
-            86,
-            76,
-            -0.11034872038605088
-        ],
-        [
-            86,
-            77,
-            0.46423477169980953
-        ],
-        [
-            86,
-            78,
-            0.31385780143100755
-        ],
-        [
-            86,
-            79,
-            0.3578640602399778
-        ],
-        [
-            86,
-            80,
-            0.22575288565513313
-        ],
-        [
-            86,
-            81,
-            0.18219024967706574
-        ],
-        [
-            86,
-            82,
-            0.10047207809629713
-        ],
-        [
-            86,
-            83,
-            0.30951902499928746
-        ],
-        [
-            86,
-            84,
-            0.21410382713641868
-        ],
-        [
-            86,
-            85,
-            0.31872491701109823
-        ],
-        [
-            86,
-            86,
-            1.0
-        ],
-        [
-            88,
-            1,
-            1.0
-        ],
-        [
-            88,
-            2,
-            1.0
-        ],
-        [
-            88,
-            3,
-            1.0
-        ],
-        [
-            88,
-            5,
-            1.0
-        ],
-        [
-            88,
-            6,
-            1.0
-        ],
-        [
-            88,
-            7,
-            1.0
-        ],
-        [
-            88,
-            8,
-            -1.0
-        ],
-        [
-            88,
-            9,
-            1.0
-        ],
-        [
-            88,
-            10,
-            1.0
-        ],
-        [
-            88,
-            11,
-            1.0
-        ],
-        [
-            88,
-            14,
-            1.0
-        ],
-        [
-            88,
-            16,
-            1.0
-        ],
-        [
-            88,
-            17,
-            1.0
-        ],
-        [
-            88,
-            31,
-            1.0
-        ],
-        [
-            88,
-            49,
-            1.0
-        ],
-        [
-            88,
-            53,
-            1.0
-        ],
-        [
-            88,
-            54,
-            1.0
-        ],
-        [
-            88,
-            61,
-            1.0
-        ],
-        [
-            88,
-            63,
-            1.0
-        ],
-        [
-            88,
-            65,
-            1.0
-        ],
-        [
-            88,
-            66,
-            1.0
-        ],
-        [
-            88,
-            78,
-            1.0
-        ],
-        [
-            88,
-            83,
-            1.0
-        ],
-        [
-            88,
-            84,
-            1.0
-        ],
-        [
-            88,
-            88,
-            1.0
-        ],
-        [
-            88,
-            90,
-            1.0
-        ],
-        [
-            88,
-            92,
-            1.0
-        ],
-        [
-            88,
-            93,
-            1.0
-        ],
-        [
-            88,
-            94,
-            1.0
-        ],
-        [
-            88,
-            99,
-            1.0
-        ],
-        [
-            88,
-            100,
-            1.0
-        ],
-        [
-            89,
-            0,
-            0.6831300510639732
-        ],
-        [
-            89,
-            1,
-            0.5
-        ],
-        [
-            89,
-            2,
-            1.0
-        ],
-        [
-            89,
-            3,
-            0.3779644730092272
-        ],
-        [
-            89,
-            4,
-            0.6831300510639732
-        ],
-        [
-            89,
-            5,
-            0.7142857142857144
-        ],
-        [
-            89,
-            6,
-            0.5
-        ],
-        [
-            89,
-            7,
-            0.7142857142857144
-        ],
-        [
-            89,
-            9,
-            1.0
-        ],
-        [
-            89,
-            10,
-            1.0
-        ],
-        [
-            89,
-            11,
-            0.5
-        ],
-        [
-            89,
-            16,
-            0.7142857142857144
-        ],
-        [
-            89,
-            17,
-            0.3563483225498992
-        ],
-        [
-            89,
-            19,
-            0.8100925873009824
-        ],
-        [
-            89,
             24,
-            0.39528470752104744
+            0.9918032786885246
         ],
         [
-            89,
+            48,
+            25,
+            0.9622950819672131
+        ],
+        [
+            48,
             26,
-            0.7999999999999999
+            0.9918032786885246
         ],
         [
-            89,
+            48,
             27,
-            0.8257228238447704
+            0.978688524590164
         ],
         [
-            89,
+            48,
             28,
-            0.7999999999999999
+            0.978688524590164
         ],
         [
-            89,
+            48,
             29,
-            0.46442036401282405
+            0.9934426229508196
         ],
         [
-            89,
+            48,
             30,
-            0.39528470752104744
+            0.978688524590164
         ],
         [
-            89,
+            48,
             31,
-            0.8864052604279185
+            0.9770491803278688
         ],
         [
-            89,
+            48,
             32,
-            1.0
+            0.9918032786885246
         ],
         [
-            89,
+            48,
+            33,
+            0.978688524590164
+        ],
+        [
+            48,
             34,
-            1.0
+            0.9770491803278688
         ],
         [
-            89,
+            48,
             35,
-            0.7999999999999999
+            0.9934426229508196
         ],
         [
-            89,
+            48,
             36,
-            0.8000000000000002
+            0.9983606557377049
         ],
         [
-            89,
+            48,
             37,
-            0.9058216273156765
+            0.9983606557377049
         ],
         [
-            89,
+            48,
             38,
-            0.560112033611204
+            0.9885245901639345
         ],
         [
-            89,
+            48,
+            39,
+            0.9950819672131147
+        ],
+        [
+            48,
             40,
-            0.7071067811865475
+            0.9934426229508196
         ],
         [
-            89,
+            48,
+            41,
+            0.9819672131147541
+        ],
+        [
+            48,
             42,
-            0.7999999999999999
+            0.978688524590164
         ],
         [
-            89,
+            48,
             43,
-            0.5976143046671969
+            0.9819672131147541
         ],
         [
-            89,
+            48,
             44,
-            0.7559289460184546
+            0.9754098360655737
         ],
         [
-            89,
+            48,
             45,
-            0.5976143046671969
+            0.9885245901639345
         ],
         [
-            89,
-            49,
-            0.8451542547285166
+            48,
+            46,
+            0.9967213114754099
         ],
         [
-            89,
-            50,
-            0.6831300510639732
+            48,
+            47,
+            0.9540983606557377
         ],
         [
-            89,
-            53,
-            0.8451542547285166
-        ],
-        [
-            89,
-            54,
-            0.8451542547285166
-        ],
-        [
-            89,
-            56,
-            0.5291502622129182
-        ],
-        [
-            89,
-            59,
-            0.6831300510639732
-        ],
-        [
-            89,
-            60,
-            0.5291502622129182
-        ],
-        [
-            89,
-            61,
-            0.8451542547285166
-        ],
-        [
-            89,
-            63,
-            0.6831300510639732
-        ],
-        [
-            89,
-            65,
-            0.6571428571428571
-        ],
-        [
-            89,
-            66,
-            0.6831300510639732
-        ],
-        [
-            89,
-            67,
-            0.7745966692414832
-        ],
-        [
-            89,
-            89,
-            1.0
-        ],
-        [
-            89,
-            95,
-            0.5976143046671969
-        ],
-        [
-            89,
-            96,
-            0.5601120336112039
-        ],
-        [
-            89,
-            97,
-            0.8164965809277263
-        ],
-        [
-            89,
-            98,
-            0.3571428571428571
-        ],
-        [
-            89,
-            100,
-            0.7559289460184544
-        ],
-        [
-            89,
-            101,
-            0.8257228238447704
-        ],
-        [
-            89,
-            104,
-            1.0
-        ],
-        [
-            89,
-            105,
-            0.7999999999999999
-        ],
-        [
-            90,
-            1,
-            1.0
-        ],
-        [
-            90,
-            2,
-            1.0
-        ],
-        [
-            90,
-            3,
-            1.0
-        ],
-        [
-            90,
-            5,
-            1.0
-        ],
-        [
-            90,
-            6,
-            1.0
-        ],
-        [
-            90,
-            7,
-            1.0
-        ],
-        [
-            90,
-            8,
-            -1.0
-        ],
-        [
-            90,
-            9,
-            1.0
-        ],
-        [
-            90,
-            10,
-            1.0
-        ],
-        [
-            90,
-            11,
-            1.0
-        ],
-        [
-            90,
-            14,
-            1.0
-        ],
-        [
-            90,
-            16,
-            1.0
-        ],
-        [
-            90,
-            17,
-            1.0
-        ],
-        [
-            90,
-            31,
-            1.0
-        ],
-        [
-            90,
-            49,
-            1.0
-        ],
-        [
-            90,
-            53,
-            1.0
-        ],
-        [
-            90,
-            54,
-            1.0
-        ],
-        [
-            90,
-            61,
-            1.0
-        ],
-        [
-            90,
-            63,
-            1.0
-        ],
-        [
-            90,
-            65,
-            1.0
-        ],
-        [
-            90,
-            66,
-            1.0
-        ],
-        [
-            90,
-            78,
-            1.0
-        ],
-        [
-            90,
-            83,
-            1.0
-        ],
-        [
-            90,
-            84,
-            1.0
-        ],
-        [
-            90,
-            88,
-            1.0
-        ],
-        [
-            90,
-            90,
-            1.0
-        ],
-        [
-            90,
-            92,
-            1.0
-        ],
-        [
-            90,
-            93,
-            1.0
-        ],
-        [
-            90,
-            94,
-            1.0
-        ],
-        [
-            90,
-            99,
-            1.0
-        ],
-        [
-            90,
-            100,
-            1.0
-        ],
-        [
-            92,
-            1,
-            1.0
-        ],
-        [
-            92,
-            2,
-            1.0
-        ],
-        [
-            92,
-            3,
-            1.0
-        ],
-        [
-            92,
-            5,
-            1.0
-        ],
-        [
-            92,
-            6,
-            1.0
-        ],
-        [
-            92,
-            7,
-            1.0
-        ],
-        [
-            92,
-            8,
-            -1.0
-        ],
-        [
-            92,
-            9,
-            1.0
-        ],
-        [
-            92,
-            10,
-            1.0
-        ],
-        [
-            92,
-            11,
-            1.0
-        ],
-        [
-            92,
-            14,
-            1.0
-        ],
-        [
-            92,
-            16,
-            1.0
-        ],
-        [
-            92,
-            17,
-            1.0
-        ],
-        [
-            92,
-            31,
-            1.0
-        ],
-        [
-            92,
-            49,
-            1.0
-        ],
-        [
-            92,
-            53,
-            1.0
-        ],
-        [
-            92,
-            54,
-            1.0
-        ],
-        [
-            92,
-            61,
-            1.0
-        ],
-        [
-            92,
-            63,
-            1.0
-        ],
-        [
-            92,
-            65,
-            1.0
-        ],
-        [
-            92,
-            66,
-            1.0
-        ],
-        [
-            92,
-            78,
-            1.0
-        ],
-        [
-            92,
-            83,
-            1.0
-        ],
-        [
-            92,
-            84,
-            1.0
-        ],
-        [
-            92,
-            88,
-            1.0
-        ],
-        [
-            92,
-            90,
-            1.0
-        ],
-        [
-            92,
-            92,
-            1.0
-        ],
-        [
-            92,
-            93,
-            1.0
-        ],
-        [
-            92,
-            94,
-            1.0
-        ],
-        [
-            92,
-            99,
-            1.0
-        ],
-        [
-            92,
-            100,
-            1.0
-        ],
-        [
-            93,
-            1,
-            1.0
-        ],
-        [
-            93,
-            2,
-            1.0
-        ],
-        [
-            93,
-            3,
-            1.0
-        ],
-        [
-            93,
-            5,
-            1.0
-        ],
-        [
-            93,
-            6,
-            1.0
-        ],
-        [
-            93,
-            7,
-            1.0
-        ],
-        [
-            93,
-            8,
-            -1.0
-        ],
-        [
-            93,
-            9,
-            1.0
-        ],
-        [
-            93,
-            10,
-            1.0
-        ],
-        [
-            93,
-            11,
-            1.0
-        ],
-        [
-            93,
-            14,
-            1.0
-        ],
-        [
-            93,
-            16,
-            1.0
-        ],
-        [
-            93,
-            17,
-            1.0
-        ],
-        [
-            93,
-            31,
-            1.0
-        ],
-        [
-            93,
-            49,
-            1.0
-        ],
-        [
-            93,
-            53,
-            1.0
-        ],
-        [
-            93,
-            54,
-            1.0
-        ],
-        [
-            93,
-            61,
-            1.0
-        ],
-        [
-            93,
-            63,
-            1.0
-        ],
-        [
-            93,
-            65,
-            1.0
-        ],
-        [
-            93,
-            66,
-            1.0
-        ],
-        [
-            93,
-            78,
-            1.0
-        ],
-        [
-            93,
-            83,
-            1.0
-        ],
-        [
-            93,
-            84,
-            1.0
-        ],
-        [
-            93,
-            88,
-            1.0
-        ],
-        [
-            93,
-            90,
-            1.0
-        ],
-        [
-            93,
-            92,
-            1.0
-        ],
-        [
-            93,
-            93,
-            1.0
-        ],
-        [
-            93,
-            94,
-            1.0
-        ],
-        [
-            93,
-            99,
-            1.0
-        ],
-        [
-            93,
-            100,
-            1.0
-        ],
-        [
-            94,
-            1,
-            1.0
-        ],
-        [
-            94,
-            2,
-            1.0
-        ],
-        [
-            94,
-            3,
-            1.0
-        ],
-        [
-            94,
-            5,
-            1.0
-        ],
-        [
-            94,
-            6,
-            1.0
-        ],
-        [
-            94,
-            7,
-            1.0
-        ],
-        [
-            94,
-            8,
-            -1.0
-        ],
-        [
-            94,
-            9,
-            1.0
-        ],
-        [
-            94,
-            10,
-            1.0
-        ],
-        [
-            94,
-            11,
-            1.0
-        ],
-        [
-            94,
-            14,
-            1.0
-        ],
-        [
-            94,
-            16,
-            1.0
-        ],
-        [
-            94,
-            17,
-            1.0
-        ],
-        [
-            94,
-            31,
-            1.0
-        ],
-        [
-            94,
-            49,
-            1.0
-        ],
-        [
-            94,
-            53,
-            1.0
-        ],
-        [
-            94,
-            54,
-            1.0
-        ],
-        [
-            94,
-            61,
-            1.0
-        ],
-        [
-            94,
-            63,
-            1.0
-        ],
-        [
-            94,
-            65,
-            1.0
-        ],
-        [
-            94,
-            66,
-            1.0
-        ],
-        [
-            94,
-            78,
-            1.0
-        ],
-        [
-            94,
-            83,
-            1.0
-        ],
-        [
-            94,
-            84,
-            1.0
-        ],
-        [
-            94,
-            88,
-            1.0
-        ],
-        [
-            94,
-            90,
-            1.0
-        ],
-        [
-            94,
-            92,
-            1.0
-        ],
-        [
-            94,
-            93,
-            1.0
-        ],
-        [
-            94,
-            94,
-            1.0
-        ],
-        [
-            94,
-            99,
-            1.0
-        ],
-        [
-            94,
-            100,
-            1.0
-        ],
-        [
-            95,
-            0,
-            0.30151134457776374
-        ],
-        [
-            95,
-            1,
-            0.6666666666666667
-        ],
-        [
-            95,
-            2,
-            0.5773502691896255
-        ],
-        [
-            95,
-            3,
-            0.35355339059327373
-        ],
-        [
-            95,
-            5,
-            0.8451542547285169
-        ],
-        [
-            95,
-            6,
-            0.6666666666666667
-        ],
-        [
-            95,
-            7,
-            0.8451542547285169
-        ],
-        [
-            95,
-            8,
-            0.30151134457776363
-        ],
-        [
-            95,
-            9,
-            0.4082482904638631
-        ],
-        [
-            95,
-            10,
-            0.4082482904638631
-        ],
-        [
-            95,
-            11,
-            0.6666666666666667
-        ],
-        [
-            95,
-            16,
-            0.8451542547285169
-        ],
-        [
-            95,
-            17,
-            0.35355339059327373
-        ],
-        [
-            95,
-            19,
-            0.4472135954999578
-        ],
-        [
-            95,
-            20,
-            0.5773502691896257
-        ],
-        [
-            95,
-            23,
-            0.30151134457776374
-        ],
-        [
-            95,
-            26,
-            1.0
-        ],
-        [
-            95,
-            27,
-            1.0
-        ],
-        [
-            95,
-            28,
-            1.0
-        ],
-        [
-            95,
-            31,
-            0.6546536707079771
-        ],
-        [
-            95,
-            32,
-            0.6324555320336759
-        ],
-        [
-            95,
-            34,
-            0.6324555320336759
-        ],
-        [
-            95,
-            35,
-            1.0
-        ],
-        [
-            95,
-            36,
-            0.25
-        ],
-        [
-            95,
-            37,
-            0.5976143046671969
-        ],
-        [
-            95,
-            42,
-            1.0
-        ],
-        [
-            95,
-            44,
-            0.3333333333333334
-        ],
-        [
-            95,
-            49,
-            0.5773502691896258
-        ],
-        [
-            95,
-            50,
-            0.5
-        ],
-        [
-            95,
-            53,
-            0.5773502691896258
-        ],
-        [
-            95,
-            54,
-            0.5773502691896258
-        ],
-        [
-            95,
-            61,
-            0.5773502691896258
-        ],
-        [
-            95,
-            63,
-            0.33333333333333326
-        ],
-        [
-            95,
-            65,
-            0.33333333333333326
-        ],
-        [
-            95,
-            66,
-            0.33333333333333326
-        ],
-        [
-            95,
-            89,
-            0.5976143046671969
-        ],
-        [
-            95,
-            95,
-            1.0
-        ],
-        [
-            95,
-            97,
-            1.0
-        ],
-        [
-            95,
-            98,
-            0.5773502691896257
-        ],
-        [
-            95,
-            100,
-            0.7071067811865475
-        ],
-        [
-            95,
-            101,
-            1.0
-        ],
-        [
-            95,
-            104,
-            0.7302967433402214
-        ],
-        [
-            95,
-            105,
-            1.0
-        ],
-        [
-            96,
-            0,
-            1.0
-        ],
-        [
-            96,
-            2,
-            0.6831300510639732
-        ],
-        [
-            96,
-            3,
-            0.2581988897471611
-        ],
-        [
-            96,
-            4,
-            1.0
-        ],
-        [
-            96,
-            5,
-            0.48795003647426655
-        ],
-        [
-            96,
-            7,
-            0.48795003647426655
-        ],
-        [
-            96,
-            16,
-            0.48795003647426655
-        ],
-        [
-            96,
-            17,
-            0.22222222222222227
-        ],
-        [
-            96,
-            19,
-            0.7698003589195009
-        ],
-        [
-            96,
-            24,
-            0.5
-        ],
-        [
-            96,
-            26,
-            0.6324555320336758
-        ],
-        [
-            96,
-            27,
-            0.46249729006288015
-        ],
-        [
-            96,
-            28,
-            0.6324555320336758
-        ],
-        [
-            96,
-            29,
-            0.8401680504168055
-        ],
-        [
-            96,
-            30,
-            0.5
-        ],
-        [
-            96,
-            31,
-            0.4432026302139592
-        ],
-        [
-            96,
-            32,
-            0.7905694150420948
-        ],
-        [
-            96,
-            34,
-            0.7905694150420948
-        ],
-        [
-            96,
-            35,
-            0.6324555320336758
-        ],
-        [
-            96,
-            36,
-            0.6324555320336758
-        ],
-        [
-            96,
-            37,
-            0.6183469424008423
-        ],
-        [
-            96,
-            38,
-            1.0
-        ],
-        [
-            96,
-            40,
-            0.8164965809277259
-        ],
-        [
-            96,
-            42,
-            0.6324555320336758
-        ],
-        [
-            96,
-            43,
-            0.7559289460184544
-        ],
-        [
-            96,
-            44,
-            0.6614378277661477
-        ],
-        [
-            96,
-            45,
-            0.7559289460184544
-        ],
-        [
-            96,
-            49,
-            0.3015113445777636
-        ],
-        [
-            96,
-            50,
-            0.5222329678670935
-        ],
-        [
-            96,
-            53,
-            0.3015113445777636
-        ],
-        [
-            96,
-            54,
-            0.3015113445777636
-        ],
-        [
-            96,
-            56,
-            0.6741998624632421
-        ],
-        [
-            96,
-            59,
-            0.5222329678670935
-        ],
-        [
-            96,
-            60,
-            0.6741998624632421
-        ],
-        [
-            96,
-            61,
-            0.3015113445777636
-        ],
-        [
-            96,
-            63,
-            -0.17407765595569782
-        ],
-        [
-            96,
-            65,
-            0.35675303400633784
-        ],
-        [
-            96,
-            66,
-            0.5222329678670935
-        ],
-        [
-            96,
-            67,
-            0.3779644730092272
-        ],
-        [
-            96,
-            89,
-            0.5601120336112039
-        ],
-        [
-            96,
-            96,
-            1.0
-        ],
-        [
-            96,
-            97,
-            0.5345224838248488
-        ],
-        [
-            96,
-            101,
-            0.46249729006288015
-        ],
-        [
-            96,
-            104,
-            0.7905694150420948
-        ],
-        [
-            96,
-            105,
-            0.6324555320336758
-        ],
-        [
-            97,
-            0,
-            0.5714285714285715
-        ],
-        [
-            97,
-            2,
-            0.8280786712108251
-        ],
-        [
-            97,
-            3,
-            0.4183300132670378
-        ],
-        [
-            97,
-            4,
-            0.46291004988627565
-        ],
-        [
-            97,
-            5,
-            1.0
-        ],
-        [
-            97,
-            7,
-            1.0
-        ],
-        [
-            97,
-            16,
-            1.0
-        ],
-        [
-            97,
-            17,
-            0.40824829046386296
-        ],
-        [
-            97,
-            19,
-            0.6666666666666665
-        ],
-        [
-            97,
-            23,
-            0.23904572186687878
-        ],
-        [
-            97,
-            24,
-            0.3162277660168379
-        ],
-        [
-            97,
-            26,
-            1.0
-        ],
-        [
-            97,
-            27,
-            1.0
-        ],
-        [
-            97,
-            28,
-            1.0
-        ],
-        [
-            97,
-            29,
-            0.5345224838248488
-        ],
-        [
-            97,
-            30,
-            0.3162277660168379
-        ],
-        [
-            97,
-            31,
-            1.0
-        ],
-        [
-            97,
-            32,
-            0.7999999999999999
-        ],
-        [
-            97,
-            34,
-            0.7999999999999999
-        ],
-        [
-            97,
-            35,
-            1.0
-        ],
-        [
-            97,
-            36,
-            0.5499999999999999
-        ],
-        [
-            97,
-            37,
-            0.8164965809277263
-        ],
-        [
-            97,
-            38,
-            0.5345224838248488
-        ],
-        [
-            97,
-            40,
-            0.5345224838248488
-        ],
-        [
-            97,
-            42,
-            1.0
-        ],
-        [
-            97,
-            43,
-            0.47809144373375745
-        ],
-        [
-            97,
-            44,
-            0.5773502691896258
-        ],
-        [
-            97,
-            45,
-            0.47809144373375745
-        ],
-        [
-            97,
-            89,
-            0.8164965809277263
-        ],
-        [
-            97,
-            95,
-            1.0
-        ],
-        [
-            97,
-            96,
-            0.5345224838248488
-        ],
-        [
-            97,
-            97,
-            1.0
-        ],
-        [
-            97,
-            98,
-            0.5773502691896257
-        ],
-        [
-            97,
-            100,
-            1.0
-        ],
-        [
-            97,
-            101,
-            1.0
-        ],
-        [
-            97,
-            104,
-            0.8164965809277261
-        ],
-        [
-            97,
-            105,
-            1.0
-        ],
-        [
-            98,
-            0,
-            0.5222329678670934
-        ],
-        [
-            98,
-            1,
-            0.6123724356957946
-        ],
-        [
-            98,
-            2,
-            0.5555555555555555
-        ],
-        [
-            98,
-            3,
-            0.4082482904638631
-        ],
-        [
-            98,
-            5,
-            0.6831300510639732
-        ],
-        [
-            98,
-            6,
-            0.6123724356957946
-        ],
-        [
-            98,
-            7,
-            0.6831300510639732
-        ],
-        [
-            98,
-            8,
-            -0.17407765595569774
-        ],
-        [
-            98,
-            9,
-            -0.25
-        ],
-        [
-            98,
-            10,
-            -0.25
-        ],
-        [
-            98,
-            11,
-            0.6123724356957946
-        ],
-        [
-            98,
-            16,
-            0.6831300510639732
-        ],
-        [
-            98,
-            17,
-            0.4082482904638631
-        ],
-        [
-            98,
-            19,
-            0.7745966692414833
-        ],
-        [
-            98,
-            20,
-            1.0
-        ],
-        [
-            98,
-            23,
-            0.5222329678670934
-        ],
-        [
-            98,
-            26,
-            0.6324555320336759
-        ],
-        [
-            98,
-            27,
-            0.5976143046671969
-        ],
-        [
-            98,
-            28,
-            0.6324555320336759
-        ],
-        [
-            98,
-            31,
-            0.2182178902359923
-        ],
-        [
-            98,
-            32,
-            1.0
-        ],
-        [
-            98,
-            34,
-            1.0
-        ],
-        [
-            98,
-            35,
-            0.6324555320336759
-        ],
-        [
-            98,
-            36,
-            0.6324555320336759
-        ],
-        [
-            98,
-            37,
-            0.3571428571428571
-        ],
-        [
-            98,
-            42,
-            0.6324555320336759
-        ],
-        [
-            98,
-            44,
-            0.6666666666666669
-        ],
-        [
-            98,
-            49,
-            0.5773502691896258
-        ],
-        [
-            98,
-            50,
-            -0.49999999999999994
-        ],
-        [
-            98,
-            53,
-            0.5773502691896258
-        ],
-        [
-            98,
-            54,
-            0.5773502691896258
-        ],
-        [
-            98,
-            61,
-            0.5773502691896258
-        ],
-        [
-            98,
-            63,
-            -0.33333333333333326
-        ],
-        [
-            98,
-            65,
-            -0.33333333333333326
-        ],
-        [
-            98,
-            66,
-            -0.33333333333333326
-        ],
-        [
-            98,
-            89,
-            0.3571428571428571
-        ],
-        [
-            98,
-            95,
-            0.5773502691896257
-        ],
-        [
-            98,
-            97,
-            0.5773502691896257
-        ],
-        [
-            98,
-            98,
-            1.0
-        ],
-        [
-            98,
-            100,
-            0.4082482904638631
-        ],
-        [
-            98,
-            101,
-            0.5976143046671969
-        ],
-        [
-            98,
-            104,
-            1.0
-        ],
-        [
-            98,
-            105,
-            0.7302967433402214
-        ],
-        [
-            99,
-            1,
-            1.0
-        ],
-        [
-            99,
-            2,
-            1.0
-        ],
-        [
-            99,
-            3,
-            1.0
-        ],
-        [
-            99,
-            5,
-            1.0
-        ],
-        [
-            99,
-            6,
-            1.0
-        ],
-        [
-            99,
-            7,
-            1.0
-        ],
-        [
-            99,
-            8,
-            -1.0
-        ],
-        [
-            99,
-            9,
-            1.0
-        ],
-        [
-            99,
-            10,
-            1.0
-        ],
-        [
-            99,
-            11,
-            1.0
-        ],
-        [
-            99,
-            14,
-            1.0
-        ],
-        [
-            99,
-            16,
-            1.0
-        ],
-        [
-            99,
-            17,
-            1.0
-        ],
-        [
-            99,
-            31,
-            1.0
-        ],
-        [
-            99,
-            49,
-            1.0
-        ],
-        [
-            99,
-            53,
-            1.0
-        ],
-        [
-            99,
-            54,
-            1.0
-        ],
-        [
-            99,
-            61,
-            1.0
-        ],
-        [
-            99,
-            63,
-            1.0
-        ],
-        [
-            99,
-            65,
-            1.0
-        ],
-        [
-            99,
-            66,
-            1.0
-        ],
-        [
-            99,
-            78,
-            1.0
-        ],
-        [
-            99,
-            83,
-            1.0
-        ],
-        [
-            99,
-            84,
-            1.0
-        ],
-        [
-            99,
-            88,
-            1.0
-        ],
-        [
-            99,
-            90,
-            1.0
-        ],
-        [
-            99,
-            92,
-            1.0
-        ],
-        [
-            99,
-            93,
-            1.0
-        ],
-        [
-            99,
-            94,
-            1.0
-        ],
-        [
-            99,
-            99,
-            1.0
-        ],
-        [
-            99,
-            100,
-            1.0
-        ],
-        [
-            100,
-            0,
-            0.42640143271122094
-        ],
-        [
-            100,
-            1,
-            0.6123724356957946
-        ],
-        [
-            100,
-            2,
-            0.8164965809277259
-        ],
-        [
-            100,
-            3,
-            0.49999999999999994
-        ],
-        [
-            100,
-            5,
-            0.8366600265340753
-        ],
-        [
-            100,
-            6,
-            0.6123724356957946
-        ],
-        [
-            100,
-            7,
-            0.8366600265340753
-        ],
-        [
-            100,
-            8,
-            -0.2132007163556104
-        ],
-        [
-            100,
-            9,
-            1.0
-        ],
-        [
-            100,
-            10,
-            1.0
-        ],
-        [
-            100,
-            11,
-            0.6123724356957946
-        ],
-        [
-            100,
-            14,
-            1.0
-        ],
-        [
-            100,
-            16,
-            0.8366600265340753
-        ],
-        [
-            100,
-            17,
-            0.49999999999999994
-        ],
-        [
-            100,
-            19,
-            0.6324555320336758
-        ],
-        [
-            100,
-            23,
-            0.42640143271122094
-        ],
-        [
-            100,
-            26,
-            1.0
-        ],
-        [
-            100,
-            27,
-            0.7905694150420948
-        ],
-        [
-            100,
-            28,
-            1.0
-        ],
-        [
-            100,
-            31,
-            1.0
-        ],
-        [
-            100,
-            32,
-            0.6324555320336759
-        ],
-        [
-            100,
-            34,
-            0.6324555320336759
-        ],
-        [
-            100,
-            35,
-            1.0
-        ],
-        [
-            100,
-            36,
-            0.25
-        ],
-        [
-            100,
-            37,
-            0.7559289460184544
-        ],
-        [
-            100,
-            42,
-            1.0
-        ],
-        [
-            100,
-            44,
-            0.5091750772173155
-        ],
-        [
-            100,
-            49,
-            0.5773502691896257
-        ],
-        [
-            100,
-            50,
-            1.0
-        ],
-        [
-            100,
-            53,
-            0.5773502691896257
-        ],
-        [
-            100,
-            54,
-            0.5773502691896257
-        ],
-        [
-            100,
-            61,
-            0.5773502691896257
-        ],
-        [
-            100,
-            63,
-            1.0
-        ],
-        [
-            100,
-            65,
-            1.0
-        ],
-        [
-            100,
-            66,
-            1.0
-        ],
-        [
-            100,
-            78,
-            1.0
-        ],
-        [
-            100,
-            83,
-            1.0
-        ],
-        [
-            100,
-            84,
-            1.0
-        ],
-        [
-            100,
-            88,
-            1.0
-        ],
-        [
-            100,
-            89,
-            0.7559289460184544
-        ],
-        [
-            100,
-            90,
-            1.0
-        ],
-        [
-            100,
-            92,
-            1.0
-        ],
-        [
-            100,
-            93,
-            1.0
-        ],
-        [
-            100,
-            94,
-            1.0
-        ],
-        [
-            100,
-            95,
-            0.7071067811865475
-        ],
-        [
-            100,
-            97,
-            1.0
-        ],
-        [
-            100,
-            98,
-            0.4082482904638631
-        ],
-        [
-            100,
-            99,
-            1.0
-        ],
-        [
-            100,
-            100,
-            1.0
-        ],
-        [
-            100,
-            101,
-            0.7905694150420948
-        ],
-        [
-            100,
-            104,
-            0.7302967433402214
-        ],
-        [
-            100,
-            105,
-            1.0
-        ],
-        [
-            101,
-            0,
-            0.48795003647426655
-        ],
-        [
-            101,
-            1,
-            1.0
-        ],
-        [
-            101,
-            2,
-            0.7142857142857144
-        ],
-        [
-            101,
-            3,
-            0.529150262212918
-        ],
-        [
-            101,
-            4,
-            0.48795003647426655
-        ],
-        [
-            101,
-            5,
-            1.0
-        ],
-        [
-            101,
-            6,
-            1.0
-        ],
-        [
-            101,
-            7,
-            1.0
-        ],
-        [
-            101,
-            9,
-            0.5
-        ],
-        [
-            101,
-            10,
-            0.5
-        ],
-        [
-            101,
-            11,
-            1.0
-        ],
-        [
-            101,
-            16,
-            1.0
-        ],
-        [
-            101,
-            17,
-            0.5163977794943222
-        ],
-        [
-            101,
-            19,
-            0.5590169943749473
-        ],
-        [
-            101,
-            20,
-            1.0
-        ],
-        [
-            101,
-            24,
-            0.3162277660168379
-        ],
-        [
-            101,
-            26,
-            1.0
-        ],
-        [
-            101,
-            27,
-            1.0
-        ],
-        [
-            101,
-            28,
-            1.0
-        ],
-        [
-            101,
-            29,
-            0.42008402520840304
-        ],
-        [
-            101,
-            30,
-            0.3162277660168379
-        ],
-        [
-            101,
-            31,
-            0.8918825850158448
-        ],
-        [
-            101,
-            32,
-            0.7999999999999999
-        ],
-        [
-            101,
-            34,
-            0.7999999999999999
-        ],
-        [
-            101,
-            35,
-            1.0
-        ],
-        [
-            101,
-            36,
-            0.5499999999999999
-        ],
-        [
-            101,
-            37,
-            0.7479575920067657
-        ],
-        [
-            101,
-            38,
-            0.46249729006288015
-        ],
-        [
-            101,
-            40,
-            0.5976143046671968
-        ],
-        [
-            101,
-            42,
-            1.0
-        ],
-        [
-            101,
-            43,
-            0.47809144373375745
-        ],
-        [
-            101,
-            44,
-            0.5976143046671968
-        ],
-        [
-            101,
-            45,
-            0.47809144373375745
-        ],
-        [
-            101,
-            49,
-            1.0
-        ],
-        [
-            101,
-            50,
-            0.5773502691896256
-        ],
-        [
-            101,
-            53,
-            1.0
-        ],
-        [
-            101,
-            54,
-            1.0
-        ],
-        [
-            101,
-            56,
-            0.4472135954999579
-        ],
-        [
-            101,
-            59,
-            0.5773502691896256
-        ],
-        [
-            101,
-            60,
-            0.4472135954999579
-        ],
-        [
-            101,
-            61,
-            1.0
-        ],
-        [
-            101,
-            63,
-            0.5773502691896256
-        ],
-        [
-            101,
-            65,
-            0.50709255283711
-        ],
-        [
-            101,
-            66,
-            0.5773502691896256
-        ],
-        [
-            101,
-            67,
-            0.7745966692414832
-        ],
-        [
-            101,
-            89,
-            0.8257228238447704
-        ],
-        [
-            101,
-            95,
-            1.0
-        ],
-        [
-            101,
-            96,
-            0.46249729006288015
-        ],
-        [
-            101,
-            97,
-            1.0
-        ],
-        [
-            101,
-            98,
-            0.5976143046671969
-        ],
-        [
-            101,
-            100,
-            0.7905694150420948
-        ],
-        [
-            101,
-            101,
-            1.0
-        ],
-        [
-            101,
-            104,
-            0.7999999999999999
-        ],
-        [
-            101,
-            105,
-            1.0
-        ],
-        [
-            104,
-            0,
-            0.8164965809277261
-        ],
-        [
-            104,
-            2,
-            1.0
-        ],
-        [
-            104,
-            3,
-            0.33333333333333326
-        ],
-        [
-            104,
-            4,
-            0.6546536707079772
-        ],
-        [
-            104,
-            5,
-            0.8164965809277261
-        ],
-        [
-            104,
-            7,
-            0.8164965809277261
-        ],
-        [
-            104,
-            16,
-            0.8164965809277261
-        ],
-        [
-            104,
-            17,
-            0.3162277660168379
-        ],
-        [
-            104,
-            19,
-            1.0
-        ],
-        [
-            104,
-            23,
-            0.3333333333333333
-        ],
-        [
-            104,
-            24,
-            0.39528470752104744
-        ],
-        [
-            104,
-            26,
-            0.7999999999999999
-        ],
-        [
-            104,
-            27,
-            0.7999999999999999
-        ],
-        [
-            104,
-            28,
-            0.7999999999999999
-        ],
-        [
-            104,
-            29,
-            0.7905694150420948
-        ],
-        [
-            104,
-            30,
-            0.39528470752104744
-        ],
-        [
-            104,
-            31,
-            0.7302967433402214
-        ],
-        [
-            104,
-            32,
-            1.0
-        ],
-        [
-            104,
-            34,
-            1.0
-        ],
-        [
-            104,
-            35,
-            0.7999999999999999
-        ],
-        [
-            104,
-            36,
-            0.8000000000000002
-        ],
-        [
-            104,
-            37,
-            1.0
-        ],
-        [
-            104,
-            38,
-            0.7905694150420948
-        ],
-        [
-            104,
-            40,
-            0.7905694150420948
-        ],
-        [
-            104,
-            42,
-            0.7999999999999999
-        ],
-        [
-            104,
-            43,
-            0.5976143046671969
-        ],
-        [
-            104,
-            44,
-            1.0
-        ],
-        [
-            104,
-            45,
-            0.5976143046671969
-        ],
-        [
-            104,
-            89,
-            1.0
-        ],
-        [
-            104,
-            95,
-            0.7302967433402214
-        ],
-        [
-            104,
-            96,
-            0.7905694150420948
-        ],
-        [
-            104,
-            97,
-            0.8164965809277261
-        ],
-        [
-            104,
-            98,
-            1.0
-        ],
-        [
-            104,
-            100,
-            0.7302967433402214
-        ],
-        [
-            104,
-            101,
-            0.7999999999999999
-        ],
-        [
-            104,
-            104,
-            1.0
-        ],
-        [
-            104,
-            105,
-            0.8164965809277263
-        ],
-        [
-            105,
-            0,
-            0.6666666666666665
-        ],
-        [
-            105,
-            2,
-            0.8164965809277263
-        ],
-        [
-            105,
-            3,
-            0.40824829046386296
-        ],
-        [
-            105,
-            4,
-            0.5345224838248488
-        ],
-        [
-            105,
-            5,
-            1.0
-        ],
-        [
-            105,
-            7,
-            1.0
-        ],
-        [
-            105,
-            16,
-            1.0
-        ],
-        [
-            105,
-            17,
-            0.3952847075210473
-        ],
-        [
-            105,
-            19,
-            0.7999999999999999
-        ],
-        [
-            105,
-            23,
-            0.2721655269759088
-        ],
-        [
-            105,
-            24,
-            0.3162277660168379
-        ],
-        [
-            105,
-            26,
-            1.0
-        ],
-        [
-            105,
-            27,
-            1.0
-        ],
-        [
-            105,
-            28,
-            1.0
-        ],
-        [
-            105,
-            29,
-            0.6324555320336758
-        ],
-        [
-            105,
-            30,
-            0.3162277660168379
-        ],
-        [
-            105,
-            31,
-            1.0
-        ],
-        [
-            105,
-            32,
-            0.7999999999999999
-        ],
-        [
-            105,
-            34,
-            0.7999999999999999
-        ],
-        [
-            105,
-            35,
-            1.0
-        ],
-        [
-            105,
-            36,
-            0.5499999999999999
-        ],
-        [
-            105,
-            37,
-            0.7999999999999999
-        ],
-        [
-            105,
-            38,
-            0.6324555320336758
-        ],
-        [
-            105,
-            40,
-            0.6324555320336758
-        ],
-        [
-            105,
-            42,
-            1.0
-        ],
-        [
-            105,
-            43,
-            0.47809144373375745
-        ],
-        [
-            105,
-            44,
-            0.7302967433402214
-        ],
-        [
-            105,
-            45,
-            0.47809144373375745
-        ],
-        [
-            105,
-            89,
-            0.7999999999999999
-        ],
-        [
-            105,
-            95,
-            1.0
-        ],
-        [
-            105,
-            96,
-            0.6324555320336758
-        ],
-        [
-            105,
-            97,
-            1.0
-        ],
-        [
-            105,
-            98,
-            0.7302967433402214
-        ],
-        [
-            105,
-            100,
-            1.0
-        ],
-        [
-            105,
-            101,
-            1.0
-        ],
-        [
-            105,
-            104,
-            0.8164965809277263
-        ],
-        [
-            105,
-            105,
-            1.0
-        ],
-        [
-            112,
-            0,
-            1.0
-        ],
-        [
-            112,
-            2,
-            1.0
-        ],
-        [
-            112,
-            16,
-            1.0
-        ],
-        [
-            112,
-            31,
-            1.0
-        ],
-        [
-            112,
-            44,
-            1.0
-        ],
-        [
-            112,
+            48,
             48,
             1.0
         ],
         [
-            112,
-            49,
-            1.0
-        ],
-        [
-            112,
-            51,
-            1.0
-        ],
-        [
-            112,
-            52,
-            1.0
-        ],
-        [
-            112,
-            53,
-            1.0
-        ],
-        [
-            112,
-            54,
-            1.0
-        ],
-        [
-            112,
-            56,
-            1.0
-        ],
-        [
-            112,
-            58,
-            1.0
-        ],
-        [
-            112,
-            59,
-            1.0
-        ],
-        [
-            112,
-            60,
-            1.0
-        ],
-        [
-            112,
-            61,
-            1.0
-        ],
-        [
-            112,
-            62,
-            0.6324555320336758
-        ],
-        [
-            112,
-            64,
-            1.0
-        ],
-        [
-            112,
-            65,
-            1.0
-        ],
-        [
-            112,
-            67,
-            1.0
-        ],
-        [
-            112,
-            69,
-            1.0
-        ],
-        [
-            112,
-            70,
-            1.0
-        ],
-        [
-            112,
-            71,
-            1.0
-        ],
-        [
-            112,
-            72,
-            1.0
-        ],
-        [
-            112,
-            112,
-            1.0
-        ],
-        [
-            112,
-            113,
-            1.0
-        ],
-        [
-            112,
-            114,
-            1.0
-        ],
-        [
-            112,
-            115,
-            1.0
-        ],
-        [
-            112,
-            117,
-            1.0
-        ],
-        [
-            112,
-            121,
-            1.0
-        ],
-        [
-            113,
-            54,
-            1.0
-        ],
-        [
-            113,
-            61,
-            1.0
-        ],
-        [
-            113,
-            62,
-            1.0
-        ],
-        [
-            113,
-            64,
-            1.0
-        ],
-        [
-            113,
-            72,
-            1.0
-        ],
-        [
-            113,
-            112,
-            1.0
-        ],
-        [
-            113,
-            113,
-            1.0
-        ],
-        [
-            113,
-            114,
-            1.0
-        ],
-        [
-            113,
-            115,
-            1.0
-        ],
-        [
-            113,
-            117,
-            1.0
-        ],
-        [
-            114,
-            54,
-            1.0
-        ],
-        [
-            114,
-            61,
-            1.0
-        ],
-        [
-            114,
-            62,
-            1.0
-        ],
-        [
-            114,
-            64,
-            1.0
-        ],
-        [
-            114,
-            72,
-            1.0
-        ],
-        [
-            114,
-            112,
-            1.0
-        ],
-        [
-            114,
-            113,
-            1.0
-        ],
-        [
-            114,
-            114,
-            1.0
-        ],
-        [
-            114,
-            115,
-            1.0
-        ],
-        [
-            114,
-            117,
-            1.0
-        ],
-        [
-            115,
-            54,
-            1.0
-        ],
-        [
-            115,
-            61,
-            1.0
-        ],
-        [
-            115,
-            62,
-            1.0
-        ],
-        [
-            115,
-            64,
-            1.0
-        ],
-        [
-            115,
-            72,
-            1.0
-        ],
-        [
-            115,
-            112,
-            1.0
-        ],
-        [
-            115,
-            113,
-            1.0
-        ],
-        [
-            115,
-            114,
-            1.0
-        ],
-        [
-            115,
-            115,
-            1.0
-        ],
-        [
-            115,
-            117,
-            1.0
-        ],
-        [
-            117,
-            112,
-            1.0
-        ],
-        [
-            117,
-            113,
-            1.0
-        ],
-        [
-            117,
-            114,
-            1.0
-        ],
-        [
-            117,
-            115,
-            1.0
-        ],
-        [
-            117,
-            117,
-            1.0
-        ],
-        [
-            121,
-            0,
-            1.0
-        ],
-        [
-            121,
-            2,
-            1.0
-        ],
-        [
-            121,
-            16,
-            1.0
-        ],
-        [
-            121,
-            31,
-            1.0
-        ],
-        [
-            121,
-            44,
-            1.0
-        ],
-        [
-            121,
             48,
-            1.0
+            49,
+            0.9967213114754099
         ],
         [
-            121,
+            48,
+            50,
+            0.9983606557377049
+        ],
+        [
+            48,
+            51,
+            0.9852459016393442
+        ],
+        [
+            48,
+            52,
+            0.9721311475409836
+        ],
+        [
+            48,
+            53,
+            0.13278688524590165
+        ],
+        [
+            48,
+            54,
+            0.21311475409836067
+        ],
+        [
+            48,
+            55,
+            0.2032786885245902
+        ],
+        [
+            48,
+            56,
+            0.1934426229508197
+        ],
+        [
+            48,
+            57,
+            0.2032786885245902
+        ],
+        [
+            48,
+            58,
+            0.11639344262295082
+        ],
+        [
+            48,
+            59,
+            0.02950819672131144
+        ],
+        [
+            48,
+            60,
+            0.21475409836065573
+        ],
+        [
+            48,
+            61,
+            0.23114754098360657
+        ],
+        [
+            48,
+            62,
+            0.02786885245901638
+        ],
+        [
+            48,
+            63,
+            0.02786885245901638
+        ],
+        [
+            48,
+            64,
+            0.23278688524590163
+        ],
+        [
+            48,
+            65,
+            0.2245901639344262
+        ],
+        [
+            48,
+            66,
+            0.16885245901639345
+        ],
+        [
+            48,
+            67,
+            0.21967213114754103
+        ],
+        [
+            48,
+            68,
+            0.14754098360655743
+        ],
+        [
+            48,
+            69,
+            0.7557377049180328
+        ],
+        [
+            48,
+            70,
+            0.7557377049180328
+        ],
+        [
+            48,
+            71,
+            0.7557377049180328
+        ],
+        [
+            48,
+            72,
+            0.7
+        ],
+        [
+            48,
+            73,
+            0.16557377049180333
+        ],
+        [
+            48,
+            74,
+            0.7573770491803279
+        ],
+        [
+            48,
+            75,
+            0.14098360655737707
+        ],
+        [
+            49,
+            0,
+            0.08032786885245902
+        ],
+        [
+            49,
+            1,
+            0.24918032786885247
+        ],
+        [
+            49,
+            2,
+            0.9885245901639345
+        ],
+        [
+            49,
+            3,
+            0.9885245901639345
+        ],
+        [
+            49,
+            4,
+            0.24918032786885247
+        ],
+        [
+            49,
+            5,
+            0.9885245901639345
+        ],
+        [
+            49,
+            6,
+            0.919672131147541
+        ],
+        [
+            49,
+            7,
+            0.9885245901639345
+        ],
+        [
+            49,
+            8,
+            0.24918032786885247
+        ],
+        [
+            49,
+            9,
+            0.2475409836065574
+        ],
+        [
+            49,
+            10,
+            0.9885245901639345
+        ],
+        [
+            49,
+            11,
+            0.9885245901639345
+        ],
+        [
+            49,
+            12,
+            0.2475409836065574
+        ],
+        [
+            49,
+            13,
+            0.9885245901639345
+        ],
+        [
+            49,
+            14,
+            0.9885245901639345
+        ],
+        [
+            49,
+            15,
+            0.24918032786885247
+        ],
+        [
+            49,
+            16,
+            0.9885245901639345
+        ],
+        [
+            49,
+            17,
+            0.9065573770491804
+        ],
+        [
+            49,
+            18,
+            0.9770491803278688
+        ],
+        [
+            49,
+            19,
+            0.9901639344262295
+        ],
+        [
+            49,
+            20,
+            0.9836065573770492
+        ],
+        [
+            49,
+            21,
+            0.9819672131147541
+        ],
+        [
+            49,
+            22,
+            0.9836065573770492
+        ],
+        [
+            49,
+            23,
+            0.9836065573770492
+        ],
+        [
+            49,
+            24,
+            0.9950819672131147
+        ],
+        [
+            49,
+            25,
+            0.9655737704918033
+        ],
+        [
+            49,
+            26,
+            0.9950819672131147
+        ],
+        [
+            49,
+            27,
+            0.9819672131147541
+        ],
+        [
+            49,
+            28,
+            0.9819672131147541
+        ],
+        [
+            49,
+            29,
+            0.9967213114754099
+        ],
+        [
+            49,
+            30,
+            0.9819672131147541
+        ],
+        [
+            49,
+            31,
+            0.980327868852459
+        ],
+        [
+            49,
+            32,
+            0.9950819672131147
+        ],
+        [
+            49,
+            33,
+            0.9819672131147541
+        ],
+        [
+            49,
+            34,
+            0.980327868852459
+        ],
+        [
+            49,
+            35,
+            0.9967213114754099
+        ],
+        [
+            49,
+            36,
+            0.9950819672131147
+        ],
+        [
+            49,
+            37,
+            0.9983606557377049
+        ],
+        [
+            49,
+            38,
+            0.9918032786885246
+        ],
+        [
+            49,
+            39,
+            0.9950819672131147
+        ],
+        [
+            49,
+            40,
+            0.9967213114754099
+        ],
+        [
+            49,
+            41,
+            0.9852459016393442
+        ],
+        [
+            49,
+            42,
+            0.9819672131147541
+        ],
+        [
+            49,
+            43,
+            0.9852459016393442
+        ],
+        [
+            49,
+            44,
+            0.978688524590164
+        ],
+        [
+            49,
+            45,
+            0.9918032786885246
+        ],
+        [
+            49,
+            46,
+            0.9967213114754099
+        ],
+        [
+            49,
+            47,
+            0.9573770491803278
+        ],
+        [
+            49,
+            48,
+            0.9967213114754099
+        ],
+        [
+            49,
             49,
             1.0
         ],
         [
-            121,
+            49,
+            50,
+            0.9950819672131147
+        ],
+        [
+            49,
+            51,
+            0.9819672131147541
+        ],
+        [
+            49,
+            52,
+            0.9754098360655737
+        ],
+        [
+            49,
+            53,
+            0.13606557377049178
+        ],
+        [
+            49,
+            54,
+            0.2163934426229508
+        ],
+        [
+            49,
+            55,
+            0.2032786885245902
+        ],
+        [
+            49,
+            56,
+            0.19672131147540983
+        ],
+        [
+            49,
+            57,
+            0.2065573770491803
+        ],
+        [
+            49,
+            58,
+            0.11967213114754094
+        ],
+        [
+            49,
+            59,
+            0.032786885245901676
+        ],
+        [
+            49,
+            60,
+            0.21803278688524586
+        ],
+        [
+            49,
+            61,
+            0.2344262295081967
+        ],
+        [
+            49,
+            62,
+            0.031147540983606503
+        ],
+        [
+            49,
+            63,
+            0.031147540983606503
+        ],
+        [
+            49,
+            64,
+            0.23278688524590163
+        ],
+        [
+            49,
+            65,
+            0.22786885245901645
+        ],
+        [
+            49,
+            66,
+            0.17213114754098358
+        ],
+        [
+            49,
+            67,
+            0.22295081967213115
+        ],
+        [
+            49,
+            68,
+            0.15081967213114755
+        ],
+        [
+            49,
+            69,
+            0.759016393442623
+        ],
+        [
+            49,
+            70,
+            0.759016393442623
+        ],
+        [
+            49,
+            71,
+            0.7557377049180328
+        ],
+        [
+            49,
+            72,
+            0.7032786885245902
+        ],
+        [
+            49,
+            73,
+            0.16885245901639345
+        ],
+        [
+            49,
+            74,
+            0.760655737704918
+        ],
+        [
+            49,
+            75,
+            0.1442622950819672
+        ],
+        [
+            50,
+            0,
+            0.07868852459016396
+        ],
+        [
+            50,
+            1,
+            0.24426229508196717
+        ],
+        [
+            50,
+            2,
+            0.9836065573770492
+        ],
+        [
+            50,
+            3,
+            0.9836065573770492
+        ],
+        [
+            50,
+            4,
+            0.24426229508196717
+        ],
+        [
+            50,
+            5,
+            0.9836065573770492
+        ],
+        [
+            50,
+            6,
+            0.9147540983606557
+        ],
+        [
+            50,
+            7,
+            0.9836065573770492
+        ],
+        [
+            50,
+            8,
+            0.24426229508196717
+        ],
+        [
+            50,
+            9,
+            0.2426229508196721
+        ],
+        [
+            50,
+            10,
+            0.9836065573770492
+        ],
+        [
+            50,
+            11,
+            0.9836065573770492
+        ],
+        [
+            50,
+            12,
+            0.2426229508196721
+        ],
+        [
+            50,
+            13,
+            0.9836065573770492
+        ],
+        [
+            50,
+            14,
+            0.9836065573770492
+        ],
+        [
+            50,
+            15,
+            0.24426229508196717
+        ],
+        [
+            50,
+            16,
+            0.9836065573770492
+        ],
+        [
+            50,
+            17,
+            0.9016393442622951
+        ],
+        [
+            50,
+            18,
+            0.9721311475409836
+        ],
+        [
+            50,
+            19,
+            0.9852459016393442
+        ],
+        [
+            50,
+            20,
+            0.978688524590164
+        ],
+        [
+            50,
+            21,
+            0.9770491803278688
+        ],
+        [
+            50,
+            22,
+            0.978688524590164
+        ],
+        [
+            50,
+            23,
+            0.978688524590164
+        ],
+        [
+            50,
+            24,
+            0.9901639344262295
+        ],
+        [
+            50,
+            25,
+            0.9606557377049181
+        ],
+        [
+            50,
+            26,
+            0.9901639344262295
+        ],
+        [
+            50,
+            27,
+            0.9770491803278688
+        ],
+        [
+            50,
+            28,
+            0.9770491803278688
+        ],
+        [
+            50,
+            29,
+            0.9918032786885246
+        ],
+        [
+            50,
+            30,
+            0.9770491803278688
+        ],
+        [
+            50,
+            31,
+            0.9754098360655737
+        ],
+        [
+            50,
+            32,
+            0.9901639344262295
+        ],
+        [
+            50,
+            33,
+            0.9770491803278688
+        ],
+        [
+            50,
+            34,
+            0.9754098360655737
+        ],
+        [
+            50,
+            35,
+            0.9918032786885246
+        ],
+        [
+            50,
+            36,
+            0.9967213114754099
+        ],
+        [
+            50,
+            37,
+            0.9967213114754099
+        ],
+        [
+            50,
+            38,
+            0.9868852459016394
+        ],
+        [
+            50,
+            39,
+            0.9934426229508196
+        ],
+        [
+            50,
+            40,
+            0.9918032786885246
+        ],
+        [
+            50,
+            41,
+            0.980327868852459
+        ],
+        [
+            50,
+            42,
+            0.9770491803278688
+        ],
+        [
+            50,
+            43,
+            0.980327868852459
+        ],
+        [
+            50,
+            44,
+            0.9737704918032787
+        ],
+        [
+            50,
+            45,
+            0.9868852459016394
+        ],
+        [
+            50,
+            46,
+            0.9950819672131147
+        ],
+        [
+            50,
+            47,
+            0.9524590163934427
+        ],
+        [
+            50,
+            48,
+            0.9983606557377049
+        ],
+        [
+            50,
+            49,
+            0.9950819672131147
+        ],
+        [
+            50,
+            50,
+            1.0
+        ],
+        [
+            50,
+            51,
+            0.9868852459016394
+        ],
+        [
+            50,
+            52,
+            0.9737704918032787
+        ],
+        [
+            50,
+            53,
+            0.13442622950819672
+        ],
+        [
+            50,
+            54,
+            0.21475409836065573
+        ],
+        [
+            50,
+            55,
+            0.20491803278688525
+        ],
+        [
+            50,
+            56,
+            0.19508196721311477
+        ],
+        [
+            50,
+            57,
+            0.20491803278688525
+        ],
+        [
+            50,
+            58,
+            0.11803278688524588
+        ],
+        [
+            50,
+            59,
+            0.031147540983606503
+        ],
+        [
+            50,
+            60,
+            0.2163934426229508
+        ],
+        [
+            50,
+            61,
+            0.23278688524590163
+        ],
+        [
+            50,
+            62,
+            0.02950819672131144
+        ],
+        [
+            50,
+            63,
+            0.02950819672131144
+        ],
+        [
+            50,
+            64,
+            0.2344262295081967
+        ],
+        [
+            50,
+            65,
+            0.22622950819672127
+        ],
+        [
+            50,
+            66,
+            0.17049180327868851
+        ],
+        [
+            50,
+            67,
+            0.2213114754098361
+        ],
+        [
+            50,
+            68,
+            0.1491803278688525
+        ],
+        [
+            50,
+            69,
+            0.7573770491803279
+        ],
+        [
+            50,
+            70,
+            0.7573770491803279
+        ],
+        [
+            50,
+            71,
+            0.7573770491803279
+        ],
+        [
+            50,
+            72,
+            0.701639344262295
+        ],
+        [
+            50,
+            73,
+            0.1672131147540984
+        ],
+        [
+            50,
+            74,
+            0.759016393442623
+        ],
+        [
+            50,
+            75,
+            0.14262295081967213
+        ],
+        [
+            51,
+            0,
+            0.09180327868852456
+        ],
+        [
+            51,
+            1,
+            0.2573770491803279
+        ],
+        [
+            51,
+            2,
+            0.9704918032786886
+        ],
+        [
+            51,
+            3,
+            0.9704918032786886
+        ],
+        [
+            51,
+            4,
+            0.2573770491803279
+        ],
+        [
+            51,
+            5,
+            0.9704918032786886
+        ],
+        [
+            51,
+            6,
+            0.9016393442622951
+        ],
+        [
+            51,
+            7,
+            0.9704918032786886
+        ],
+        [
+            51,
+            8,
+            0.2573770491803279
+        ],
+        [
+            51,
+            9,
+            0.2557377049180328
+        ],
+        [
+            51,
+            10,
+            0.9704918032786886
+        ],
+        [
+            51,
+            11,
+            0.9704918032786886
+        ],
+        [
+            51,
+            12,
+            0.2557377049180328
+        ],
+        [
+            51,
+            13,
+            0.9704918032786886
+        ],
+        [
+            51,
+            14,
+            0.9704918032786886
+        ],
+        [
+            51,
+            15,
+            0.2573770491803279
+        ],
+        [
+            51,
+            16,
+            0.9704918032786886
+        ],
+        [
+            51,
+            17,
+            0.9147540983606557
+        ],
+        [
+            51,
+            18,
+            0.9852459016393442
+        ],
+        [
+            51,
+            19,
+            0.9721311475409836
+        ],
+        [
+            51,
+            20,
+            0.9918032786885246
+        ],
+        [
+            51,
+            21,
+            0.9901639344262295
+        ],
+        [
+            51,
+            22,
+            0.9918032786885246
+        ],
+        [
+            51,
+            23,
+            0.9918032786885246
+        ],
+        [
+            51,
+            24,
+            0.9770491803278688
+        ],
+        [
+            51,
+            25,
+            0.9737704918032787
+        ],
+        [
+            51,
+            26,
+            0.9770491803278688
+        ],
+        [
+            51,
+            27,
+            0.9901639344262295
+        ],
+        [
+            51,
+            28,
+            0.9901639344262295
+        ],
+        [
+            51,
+            29,
+            0.978688524590164
+        ],
+        [
+            51,
+            30,
+            0.9901639344262295
+        ],
+        [
+            51,
+            31,
+            0.9885245901639345
+        ],
+        [
+            51,
+            32,
+            0.9770491803278688
+        ],
+        [
+            51,
+            33,
+            0.9901639344262295
+        ],
+        [
+            51,
+            34,
+            0.9885245901639345
+        ],
+        [
+            51,
+            35,
+            0.978688524590164
+        ],
+        [
+            51,
+            36,
+            0.9836065573770492
+        ],
+        [
+            51,
+            37,
+            0.9836065573770492
+        ],
+        [
+            51,
+            38,
+            0.9737704918032787
+        ],
+        [
+            51,
+            39,
+            0.980327868852459
+        ],
+        [
+            51,
+            40,
+            0.978688524590164
+        ],
+        [
+            51,
+            41,
+            0.9934426229508196
+        ],
+        [
+            51,
+            42,
+            0.9901639344262295
+        ],
+        [
+            51,
+            43,
+            0.9934426229508196
+        ],
+        [
+            51,
+            44,
+            0.9868852459016394
+        ],
+        [
+            51,
+            45,
+            0.9737704918032787
+        ],
+        [
+            51,
+            46,
+            0.9819672131147541
+        ],
+        [
+            51,
+            47,
+            0.9655737704918033
+        ],
+        [
+            51,
+            48,
+            0.9852459016393442
+        ],
+        [
+            51,
+            49,
+            0.9819672131147541
+        ],
+        [
+            51,
+            50,
+            0.9868852459016394
+        ],
+        [
+            51,
             51,
             1.0
         ],
         [
-            121,
+            51,
+            52,
+            0.9868852459016394
+        ],
+        [
+            51,
+            53,
+            0.14754098360655743
+        ],
+        [
+            51,
+            54,
+            0.22786885245901645
+        ],
+        [
+            51,
+            55,
+            0.21475409836065573
+        ],
+        [
+            51,
+            56,
+            0.20491803278688525
+        ],
+        [
+            51,
+            57,
+            0.21475409836065573
+        ],
+        [
+            51,
+            58,
+            0.1311475409836066
+        ],
+        [
+            51,
+            59,
+            0.04426229508196722
+        ],
+        [
+            51,
+            60,
+            0.2295081967213115
+        ],
+        [
+            51,
+            61,
+            0.24590163934426235
+        ],
+        [
+            51,
+            62,
+            0.042622950819672156
+        ],
+        [
+            51,
+            63,
+            0.042622950819672156
+        ],
+        [
+            51,
+            64,
+            0.24426229508196717
+        ],
+        [
+            51,
+            65,
+            0.239344262295082
+        ],
+        [
+            51,
+            66,
+            0.180327868852459
+        ],
+        [
+            51,
+            67,
+            0.2344262295081967
+        ],
+        [
+            51,
+            68,
+            0.15901639344262297
+        ],
+        [
+            51,
+            69,
+            0.7442622950819673
+        ],
+        [
+            51,
+            70,
+            0.7442622950819673
+        ],
+        [
+            51,
+            71,
+            0.7442622950819673
+        ],
+        [
+            51,
+            72,
+            0.6885245901639344
+        ],
+        [
+            51,
+            73,
+            0.17704918032786887
+        ],
+        [
+            51,
+            74,
+            0.7459016393442623
+        ],
+        [
+            51,
+            75,
+            0.12950819672131153
+        ],
+        [
+            52,
+            0,
+            0.10491803278688527
+        ],
+        [
+            52,
+            1,
+            0.2704918032786885
+        ],
+        [
+            52,
+            2,
+            0.9639344262295082
+        ],
+        [
+            52,
+            3,
+            0.9639344262295082
+        ],
+        [
+            52,
+            4,
+            0.2704918032786885
+        ],
+        [
+            52,
+            5,
+            0.9639344262295082
+        ],
+        [
+            52,
+            6,
+            0.8950819672131147
+        ],
+        [
+            52,
+            7,
+            0.9639344262295082
+        ],
+        [
+            52,
+            8,
+            0.2704918032786885
+        ],
+        [
+            52,
+            9,
+            0.26885245901639343
+        ],
+        [
+            52,
+            10,
+            0.9639344262295082
+        ],
+        [
+            52,
+            11,
+            0.9639344262295082
+        ],
+        [
+            52,
+            12,
+            0.26885245901639343
+        ],
+        [
+            52,
+            13,
+            0.9639344262295082
+        ],
+        [
+            52,
+            14,
+            0.9639344262295082
+        ],
+        [
+            52,
+            15,
+            0.2704918032786885
+        ],
+        [
+            52,
+            16,
+            0.9639344262295082
+        ],
+        [
+            52,
+            17,
+            0.9081967213114754
+        ],
+        [
+            52,
+            18,
+            0.978688524590164
+        ],
+        [
+            52,
+            19,
+            0.9655737704918033
+        ],
+        [
+            52,
+            20,
+            0.9852459016393442
+        ],
+        [
+            52,
+            21,
+            0.9836065573770492
+        ],
+        [
+            52,
+            22,
+            0.9852459016393442
+        ],
+        [
+            52,
+            23,
+            0.9852459016393442
+        ],
+        [
+            52,
+            24,
+            0.9704918032786886
+        ],
+        [
+            52,
+            25,
+            0.9770491803278688
+        ],
+        [
+            52,
+            26,
+            0.9704918032786886
+        ],
+        [
+            52,
+            27,
+            0.9836065573770492
+        ],
+        [
+            52,
+            28,
+            0.9836065573770492
+        ],
+        [
+            52,
+            29,
+            0.9721311475409836
+        ],
+        [
+            52,
+            30,
+            0.9836065573770492
+        ],
+        [
+            52,
+            31,
+            0.9819672131147541
+        ],
+        [
+            52,
+            32,
+            0.9704918032786886
+        ],
+        [
+            52,
+            33,
+            0.9836065573770492
+        ],
+        [
+            52,
+            34,
+            0.9918032786885246
+        ],
+        [
+            52,
+            35,
+            0.9721311475409836
+        ],
+        [
+            52,
+            36,
+            0.9704918032786886
+        ],
+        [
+            52,
+            37,
+            0.9737704918032787
+        ],
+        [
+            52,
+            38,
+            0.9672131147540983
+        ],
+        [
+            52,
+            39,
+            0.9704918032786886
+        ],
+        [
+            52,
+            40,
+            0.9721311475409836
+        ],
+        [
+            52,
+            41,
+            0.9868852459016394
+        ],
+        [
+            52,
+            42,
+            0.9836065573770492
+        ],
+        [
+            52,
+            43,
+            0.9868852459016394
+        ],
+        [
+            52,
+            44,
+            0.980327868852459
+        ],
+        [
+            52,
+            45,
+            0.9672131147540983
+        ],
+        [
+            52,
+            46,
+            0.9721311475409836
+        ],
+        [
+            52,
+            47,
+            0.9590163934426229
+        ],
+        [
+            52,
+            48,
+            0.9721311475409836
+        ],
+        [
+            52,
+            49,
+            0.9754098360655737
+        ],
+        [
+            52,
+            50,
+            0.9737704918032787
+        ],
+        [
+            52,
+            51,
+            0.9868852459016394
+        ],
+        [
+            52,
             52,
             1.0
         ],
         [
-            121,
+            52,
+            53,
+            0.16065573770491803
+        ],
+        [
+            52,
+            54,
+            0.2344262295081967
+        ],
+        [
+            52,
+            55,
+            0.21803278688524586
+        ],
+        [
+            52,
+            56,
+            0.2114754098360656
+        ],
+        [
+            52,
+            57,
+            0.2245901639344262
+        ],
+        [
+            52,
+            58,
+            0.14098360655737707
+        ],
+        [
+            52,
+            59,
+            0.05737704918032782
+        ],
+        [
+            52,
+            60,
+            0.23606557377049175
+        ],
+        [
+            52,
+            61,
+            0.2524590163934426
+        ],
+        [
+            52,
+            62,
+            0.05573770491803276
+        ],
+        [
+            52,
+            63,
+            0.05573770491803276
+        ],
+        [
+            52,
+            64,
+            0.2475409836065574
+        ],
+        [
+            52,
+            65,
+            0.24918032786885247
+        ],
+        [
+            52,
+            66,
+            0.1934426229508197
+        ],
+        [
+            52,
+            67,
+            0.24098360655737705
+        ],
+        [
+            52,
+            68,
+            0.16885245901639345
+        ],
+        [
+            52,
+            69,
+            0.7377049180327868
+        ],
+        [
+            52,
+            70,
+            0.7377049180327868
+        ],
+        [
+            52,
+            71,
+            0.7344262295081967
+        ],
+        [
+            52,
+            72,
+            0.6819672131147541
+        ],
+        [
+            52,
+            73,
+            0.18360655737704923
+        ],
+        [
+            52,
+            74,
+            0.739344262295082
+        ],
+        [
+            52,
+            75,
+            0.14262295081967213
+        ],
+        [
+            53,
+            0,
+            0.9377049180327869
+        ],
+        [
+            53,
+            1,
+            0.759016393442623
+        ],
+        [
+            53,
+            2,
+            0.12459016393442623
+        ],
+        [
+            53,
+            3,
+            0.12459016393442623
+        ],
+        [
+            53,
+            4,
+            0.759016393442623
+        ],
+        [
+            53,
+            5,
+            0.12459016393442623
+        ],
+        [
+            53,
+            6,
+            0.1573770491803279
+        ],
+        [
+            53,
+            7,
+            0.12459016393442623
+        ],
+        [
+            53,
+            8,
+            0.759016393442623
+        ],
+        [
+            53,
+            9,
+            0.7508196721311475
+        ],
+        [
+            53,
+            10,
+            0.12459016393442623
+        ],
+        [
+            53,
+            11,
+            0.12459016393442623
+        ],
+        [
+            53,
+            12,
+            0.7508196721311475
+        ],
+        [
+            53,
+            13,
+            0.12459016393442623
+        ],
+        [
+            53,
+            14,
+            0.12459016393442623
+        ],
+        [
+            53,
+            15,
+            0.759016393442623
+        ],
+        [
+            53,
+            16,
+            0.12459016393442623
+        ],
+        [
+            53,
+            17,
+            0.17049180327868851
+        ],
+        [
+            53,
+            18,
+            0.139344262295082
+        ],
+        [
+            53,
+            19,
+            0.1262295081967213
+        ],
+        [
+            53,
+            20,
+            0.14590163934426226
+        ],
+        [
+            53,
+            21,
+            0.1442622950819672
+        ],
+        [
+            53,
+            22,
+            0.14590163934426226
+        ],
+        [
+            53,
+            23,
+            0.14590163934426226
+        ],
+        [
+            53,
+            24,
+            0.1311475409836066
+        ],
+        [
+            53,
+            25,
+            0.16393442622950816
+        ],
+        [
+            53,
+            26,
+            0.1311475409836066
+        ],
+        [
+            53,
+            27,
+            0.1442622950819672
+        ],
+        [
+            53,
+            28,
+            0.1442622950819672
+        ],
+        [
+            53,
+            29,
+            0.13278688524590165
+        ],
+        [
+            53,
+            30,
+            0.1442622950819672
+        ],
+        [
+            53,
+            31,
+            0.14262295081967213
+        ],
+        [
+            53,
+            32,
+            0.1311475409836066
+        ],
+        [
+            53,
+            33,
+            0.15081967213114755
+        ],
+        [
+            53,
+            34,
+            0.15245901639344261
+        ],
+        [
+            53,
+            35,
+            0.13278688524590165
+        ],
+        [
+            53,
+            36,
+            0.1311475409836066
+        ],
+        [
+            53,
+            37,
+            0.13442622950819672
+        ],
+        [
+            53,
+            38,
+            0.1442622950819672
+        ],
+        [
+            53,
+            39,
+            0.13770491803278684
+        ],
+        [
+            53,
+            40,
+            0.13278688524590165
+        ],
+        [
+            53,
+            41,
+            0.14754098360655743
+        ],
+        [
+            53,
+            42,
+            0.15081967213114755
+        ],
+        [
+            53,
+            43,
+            0.14754098360655743
+        ],
+        [
+            53,
+            44,
+            0.15081967213114755
+        ],
+        [
+            53,
+            45,
+            0.1442622950819672
+        ],
+        [
+            53,
+            46,
+            0.13278688524590165
+        ],
+        [
+            53,
+            47,
+            0.1754098360655738
+        ],
+        [
+            53,
+            48,
+            0.13278688524590165
+        ],
+        [
+            53,
+            49,
+            0.13606557377049178
+        ],
+        [
+            53,
+            50,
+            0.13442622950819672
+        ],
+        [
+            53,
+            51,
+            0.14754098360655743
+        ],
+        [
+            53,
+            52,
+            0.16065573770491803
+        ],
+        [
+            53,
             53,
             1.0
         ],
         [
-            121,
+            53,
+            54,
+            0.9131147540983606
+        ],
+        [
+            53,
+            55,
+            0.8901639344262295
+        ],
+        [
+            53,
+            56,
+            0.8704918032786886
+        ],
+        [
+            53,
+            57,
+            0.8737704918032787
+        ],
+        [
+            53,
+            58,
+            0.9049180327868852
+        ],
+        [
+            53,
+            59,
+            0.8934426229508197
+        ],
+        [
+            53,
+            60,
+            0.9147540983606557
+        ],
+        [
+            53,
+            61,
+            0.9016393442622951
+        ],
+        [
+            53,
+            62,
+            0.8918032786885246
+        ],
+        [
+            53,
+            63,
+            0.8918032786885246
+        ],
+        [
+            53,
+            64,
+            0.9
+        ],
+        [
+            53,
+            65,
+            0.9016393442622951
+        ],
+        [
+            53,
+            66,
+            0.8918032786885246
+        ],
+        [
+            53,
+            67,
+            0.9065573770491804
+        ],
+        [
+            53,
+            68,
+            0.8737704918032787
+        ],
+        [
+            53,
+            69,
+            0.24918032786885247
+        ],
+        [
+            53,
+            70,
+            0.24918032786885247
+        ],
+        [
+            53,
+            71,
+            0.24590163934426235
+        ],
+        [
+            53,
+            72,
+            0.27213114754098355
+        ],
+        [
+            53,
+            73,
+            0.8360655737704918
+        ],
+        [
+            53,
+            74,
+            0.2573770491803279
+        ],
+        [
+            53,
+            75,
+            0.7786885245901639
+        ],
+        [
+            54,
+            0,
+            0.8573770491803279
+        ],
+        [
+            54,
+            1,
+            0.6786885245901639
+        ],
+        [
+            54,
+            2,
+            0.20491803278688525
+        ],
+        [
+            54,
+            3,
+            0.20491803278688525
+        ],
+        [
+            54,
+            4,
+            0.6786885245901639
+        ],
+        [
+            54,
+            5,
+            0.20491803278688525
+        ],
+        [
+            54,
+            6,
+            0.22786885245901645
+        ],
+        [
+            54,
+            7,
+            0.20491803278688525
+        ],
+        [
+            54,
+            8,
+            0.6786885245901639
+        ],
+        [
+            54,
+            9,
+            0.6704918032786885
+        ],
+        [
+            54,
+            10,
+            0.20491803278688525
+        ],
+        [
+            54,
+            11,
+            0.20491803278688525
+        ],
+        [
+            54,
+            12,
+            0.6704918032786885
+        ],
+        [
+            54,
+            13,
+            0.20491803278688525
+        ],
+        [
+            54,
+            14,
+            0.20491803278688525
+        ],
+        [
+            54,
+            15,
+            0.6786885245901639
+        ],
+        [
+            54,
+            16,
+            0.20491803278688525
+        ],
+        [
+            54,
+            17,
+            0.24098360655737705
+        ],
+        [
+            54,
+            18,
+            0.21967213114754103
+        ],
+        [
+            54,
+            19,
+            0.2065573770491803
+        ],
+        [
+            54,
+            20,
+            0.22622950819672127
+        ],
+        [
+            54,
+            21,
+            0.2245901639344262
+        ],
+        [
+            54,
+            22,
+            0.22622950819672127
+        ],
+        [
+            54,
+            23,
+            0.22622950819672127
+        ],
+        [
+            54,
+            24,
+            0.2114754098360656
+        ],
+        [
+            54,
+            25,
+            0.24098360655737705
+        ],
+        [
+            54,
+            26,
+            0.2114754098360656
+        ],
+        [
+            54,
+            27,
+            0.2245901639344262
+        ],
+        [
+            54,
+            28,
+            0.2245901639344262
+        ],
+        [
+            54,
+            29,
+            0.21311475409836067
+        ],
+        [
+            54,
+            30,
+            0.2245901639344262
+        ],
+        [
+            54,
+            31,
+            0.22295081967213115
+        ],
+        [
+            54,
+            32,
+            0.2114754098360656
+        ],
+        [
+            54,
+            33,
+            0.23114754098360657
+        ],
+        [
+            54,
+            34,
+            0.2295081967213115
+        ],
+        [
+            54,
+            35,
+            0.21311475409836067
+        ],
+        [
+            54,
+            36,
+            0.2114754098360656
+        ],
+        [
+            54,
+            37,
+            0.21475409836065573
+        ],
+        [
+            54,
+            38,
+            0.2213114754098361
+        ],
+        [
+            54,
+            39,
+            0.21803278688524586
+        ],
+        [
+            54,
+            40,
+            0.21311475409836067
+        ],
+        [
+            54,
+            41,
+            0.22786885245901645
+        ],
+        [
+            54,
+            42,
+            0.23114754098360657
+        ],
+        [
+            54,
+            43,
+            0.22786885245901645
+        ],
+        [
+            54,
+            44,
+            0.23114754098360657
+        ],
+        [
+            54,
+            45,
+            0.2213114754098361
+        ],
+        [
+            54,
+            46,
+            0.21311475409836067
+        ],
+        [
+            54,
+            47,
+            0.2524590163934426
+        ],
+        [
+            54,
+            48,
+            0.21311475409836067
+        ],
+        [
+            54,
+            49,
+            0.2163934426229508
+        ],
+        [
+            54,
+            50,
+            0.21475409836065573
+        ],
+        [
+            54,
+            51,
+            0.22786885245901645
+        ],
+        [
+            54,
+            52,
+            0.2344262295081967
+        ],
+        [
+            54,
+            53,
+            0.9131147540983606
+        ],
+        [
+            54,
             54,
             1.0
         ],
         [
-            121,
+            54,
+            55,
+            0.9540983606557377
+        ],
+        [
+            54,
+            56,
+            0.940983606557377
+        ],
+        [
+            54,
+            57,
+            0.9573770491803278
+        ],
+        [
+            54,
+            58,
+            0.9
+        ],
+        [
+            54,
+            59,
+            0.8163934426229509
+        ],
+        [
+            54,
+            60,
+            0.9918032786885246
+        ],
+        [
+            54,
+            61,
+            0.9819672131147541
+        ],
+        [
+            54,
+            62,
+            0.8147540983606557
+        ],
+        [
+            54,
+            63,
+            0.8147540983606557
+        ],
+        [
+            54,
+            64,
+            0.9770491803278688
+        ],
+        [
+            54,
+            65,
+            0.9819672131147541
+        ],
+        [
+            54,
+            66,
+            0.9295081967213115
+        ],
+        [
+            54,
+            67,
+            0.9704918032786886
+        ],
+        [
+            54,
+            68,
+            0.9081967213114754
+        ],
+        [
+            54,
+            69,
+            0.3295081967213115
+        ],
+        [
+            54,
+            70,
+            0.3295081967213115
+        ],
+        [
+            54,
+            71,
+            0.32622950819672136
+        ],
+        [
+            54,
+            72,
+            0.3426229508196721
+        ],
+        [
+            54,
+            73,
+            0.9163934426229509
+        ],
+        [
+            54,
+            74,
+            0.3377049180327869
+        ],
+        [
+            54,
+            75,
+            0.7147540983606557
+        ],
+        [
+            55,
+            0,
+            0.8442622950819672
+        ],
+        [
+            55,
+            1,
+            0.6655737704918032
+        ],
+        [
+            55,
+            2,
+            0.19180327868852454
+        ],
+        [
+            55,
+            3,
+            0.19180327868852454
+        ],
+        [
+            55,
+            4,
+            0.6655737704918032
+        ],
+        [
+            55,
+            5,
+            0.19180327868852454
+        ],
+        [
+            55,
+            6,
+            0.2213114754098361
+        ],
+        [
+            55,
+            7,
+            0.19180327868852454
+        ],
+        [
+            55,
+            8,
+            0.6655737704918032
+        ],
+        [
+            55,
+            9,
+            0.6573770491803279
+        ],
+        [
+            55,
+            10,
+            0.19180327868852454
+        ],
+        [
+            55,
+            11,
+            0.19180327868852454
+        ],
+        [
+            55,
+            12,
+            0.6573770491803279
+        ],
+        [
+            55,
+            13,
+            0.19180327868852454
+        ],
+        [
+            55,
+            14,
+            0.19180327868852454
+        ],
+        [
+            55,
+            15,
+            0.6655737704918032
+        ],
+        [
+            55,
+            16,
+            0.19180327868852454
+        ],
+        [
+            55,
+            17,
+            0.23114754098360657
+        ],
+        [
+            55,
+            18,
+            0.2032786885245902
+        ],
+        [
+            55,
+            19,
+            0.1934426229508197
+        ],
+        [
+            55,
+            20,
+            0.20983606557377055
+        ],
+        [
+            55,
+            21,
+            0.20819672131147537
+        ],
+        [
+            55,
+            22,
+            0.20983606557377055
+        ],
+        [
+            55,
+            23,
+            0.20983606557377055
+        ],
+        [
+            55,
+            24,
+            0.1983606557377049
+        ],
+        [
+            55,
+            25,
+            0.2213114754098361
+        ],
+        [
+            55,
+            26,
+            0.1983606557377049
+        ],
+        [
+            55,
+            27,
+            0.20819672131147537
+        ],
+        [
+            55,
+            28,
+            0.20819672131147537
+        ],
+        [
+            55,
+            29,
+            0.19999999999999996
+        ],
+        [
+            55,
+            30,
+            0.20819672131147537
+        ],
+        [
+            55,
+            31,
+            0.2065573770491803
+        ],
+        [
+            55,
+            32,
+            0.1983606557377049
+        ],
+        [
+            55,
+            33,
+            0.2114754098360656
+        ],
+        [
+            55,
+            34,
+            0.21311475409836067
+        ],
+        [
+            55,
+            35,
+            0.19999999999999996
+        ],
+        [
+            55,
+            36,
+            0.20163934426229513
+        ],
+        [
+            55,
+            37,
+            0.20163934426229513
+        ],
+        [
+            55,
+            38,
+            0.20819672131147537
+        ],
+        [
+            55,
+            39,
+            0.20163934426229513
+        ],
+        [
+            55,
+            40,
+            0.19999999999999996
+        ],
+        [
+            55,
+            41,
+            0.2114754098360656
+        ],
+        [
+            55,
+            42,
+            0.21475409836065573
+        ],
+        [
+            55,
+            43,
+            0.2114754098360656
+        ],
+        [
+            55,
+            44,
+            0.2114754098360656
+        ],
+        [
+            55,
+            45,
+            0.20819672131147537
+        ],
+        [
+            55,
+            46,
+            0.19999999999999996
+        ],
+        [
+            55,
+            47,
+            0.23278688524590163
+        ],
+        [
+            55,
+            48,
+            0.2032786885245902
+        ],
+        [
+            55,
+            49,
+            0.2032786885245902
+        ],
+        [
+            55,
+            50,
+            0.20491803278688525
+        ],
+        [
+            55,
+            51,
+            0.21475409836065573
+        ],
+        [
+            55,
+            52,
+            0.21803278688524586
+        ],
+        [
+            55,
+            53,
+            0.8901639344262295
+        ],
+        [
+            55,
+            54,
+            0.9540983606557377
+        ],
+        [
+            55,
+            55,
+            1.0
+        ],
+        [
+            55,
+            56,
+            0.9475409836065574
+        ],
+        [
+            55,
+            57,
+            0.9508196721311475
+        ],
+        [
+            55,
+            58,
+            0.8901639344262295
+        ],
+        [
+            55,
+            59,
+            0.8262295081967213
+        ],
+        [
+            55,
+            60,
+            0.9557377049180328
+        ],
+        [
+            55,
+            61,
+            0.9655737704918033
+        ],
+        [
+            55,
+            62,
+            0.8245901639344262
+        ],
+        [
+            55,
+            63,
+            0.8245901639344262
+        ],
+        [
+            55,
+            64,
+            0.9704918032786886
+        ],
+        [
+            55,
+            65,
+            0.9590163934426229
+        ],
+        [
+            55,
+            66,
+            0.9262295081967213
+        ],
+        [
+            55,
+            67,
+            0.9540983606557377
+        ],
+        [
+            55,
+            68,
+            0.9114754098360656
+        ],
+        [
+            55,
+            69,
+            0.33934426229508197
+        ],
+        [
+            55,
+            70,
+            0.33934426229508197
+        ],
+        [
+            55,
+            71,
+            0.33606557377049184
+        ],
+        [
+            55,
+            72,
+            0.3590163934426229
+        ],
+        [
+            55,
+            73,
+            0.9262295081967213
+        ],
+        [
+            55,
+            74,
+            0.3475409836065574
+        ],
+        [
+            55,
+            75,
+            0.7278688524590164
+        ],
+        [
+            56,
+            0,
+            0.8442622950819672
+        ],
+        [
+            56,
+            1,
+            0.6655737704918032
+        ],
+        [
+            56,
+            2,
+            0.1852459016393443
+        ],
+        [
+            56,
+            3,
+            0.1852459016393443
+        ],
+        [
+            56,
+            4,
+            0.6655737704918032
+        ],
+        [
+            56,
+            5,
+            0.1852459016393443
+        ],
+        [
+            56,
+            6,
+            0.23114754098360657
+        ],
+        [
+            56,
+            7,
+            0.1852459016393443
+        ],
+        [
+            56,
+            8,
+            0.6655737704918032
+        ],
+        [
+            56,
+            9,
+            0.6573770491803279
+        ],
+        [
+            56,
+            10,
+            0.1852459016393443
+        ],
+        [
+            56,
+            11,
+            0.1852459016393443
+        ],
+        [
+            56,
+            12,
+            0.6573770491803279
+        ],
+        [
+            56,
+            13,
+            0.1852459016393443
+        ],
+        [
+            56,
+            14,
+            0.1852459016393443
+        ],
+        [
+            56,
+            15,
+            0.6655737704918032
+        ],
+        [
+            56,
+            16,
+            0.1852459016393443
+        ],
+        [
+            56,
+            17,
+            0.24098360655737705
+        ],
+        [
+            56,
+            18,
+            0.19672131147540983
+        ],
+        [
+            56,
+            19,
+            0.18688524590163935
+        ],
+        [
+            56,
+            20,
+            0.2032786885245902
+        ],
+        [
+            56,
+            21,
+            0.20163934426229513
+        ],
+        [
+            56,
+            22,
+            0.2032786885245902
+        ],
+        [
+            56,
+            23,
+            0.2032786885245902
+        ],
+        [
+            56,
+            24,
+            0.19180327868852454
+        ],
+        [
+            56,
+            25,
+            0.21475409836065573
+        ],
+        [
+            56,
+            26,
+            0.19180327868852454
+        ],
+        [
+            56,
+            27,
+            0.20163934426229513
+        ],
+        [
+            56,
+            28,
+            0.20163934426229513
+        ],
+        [
+            56,
+            29,
+            0.1934426229508197
+        ],
+        [
+            56,
+            30,
+            0.20163934426229513
+        ],
+        [
+            56,
+            31,
+            0.19999999999999996
+        ],
+        [
+            56,
+            32,
+            0.19180327868852454
+        ],
+        [
+            56,
+            33,
+            0.20491803278688525
+        ],
+        [
+            56,
+            34,
+            0.2065573770491803
+        ],
+        [
+            56,
+            35,
+            0.1934426229508197
+        ],
+        [
+            56,
+            36,
+            0.19180327868852454
+        ],
+        [
+            56,
+            37,
+            0.19508196721311477
+        ],
+        [
+            56,
+            38,
+            0.20491803278688525
+        ],
+        [
+            56,
+            39,
+            0.19508196721311477
+        ],
+        [
+            56,
+            40,
+            0.1934426229508197
+        ],
+        [
+            56,
+            41,
+            0.20491803278688525
+        ],
+        [
+            56,
+            42,
+            0.20819672131147537
+        ],
+        [
+            56,
+            43,
+            0.20491803278688525
+        ],
+        [
+            56,
+            44,
+            0.20491803278688525
+        ],
+        [
+            56,
+            45,
+            0.20491803278688525
+        ],
+        [
+            56,
+            46,
+            0.1934426229508197
+        ],
+        [
+            56,
+            47,
+            0.22622950819672127
+        ],
+        [
+            56,
+            48,
+            0.1934426229508197
+        ],
+        [
+            56,
+            49,
+            0.19672131147540983
+        ],
+        [
+            56,
+            50,
+            0.19508196721311477
+        ],
+        [
+            56,
+            51,
+            0.20491803278688525
+        ],
+        [
+            56,
+            52,
+            0.2114754098360656
+        ],
+        [
+            56,
+            53,
+            0.8704918032786886
+        ],
+        [
+            56,
+            54,
+            0.940983606557377
+        ],
+        [
+            56,
+            55,
+            0.9475409836065574
+        ],
+        [
+            56,
             56,
             1.0
         ],
         [
-            121,
+            56,
+            57,
+            0.9442622950819672
+        ],
+        [
+            56,
+            58,
+            0.8901639344262295
+        ],
+        [
+            56,
+            59,
+            0.8098360655737705
+        ],
+        [
+            56,
+            60,
+            0.9459016393442623
+        ],
+        [
+            56,
+            61,
+            0.9590163934426229
+        ],
+        [
+            56,
+            62,
+            0.8114754098360656
+        ],
+        [
+            56,
+            63,
+            0.8114754098360656
+        ],
+        [
+            56,
+            64,
+            0.9573770491803278
+        ],
+        [
+            56,
+            65,
+            0.9524590163934427
+        ],
+        [
+            56,
+            66,
+            0.9131147540983606
+        ],
+        [
+            56,
+            67,
+            0.9540983606557377
+        ],
+        [
+            56,
+            68,
+            0.9344262295081968
+        ],
+        [
+            56,
+            69,
+            0.3426229508196721
+        ],
+        [
+            56,
+            70,
+            0.3426229508196721
+        ],
+        [
+            56,
+            71,
+            0.33934426229508197
+        ],
+        [
+            56,
+            72,
+            0.37540983606557377
+        ],
+        [
+            56,
+            73,
+            0.9295081967213115
+        ],
+        [
+            56,
+            74,
+            0.3508196721311475
+        ],
+        [
+            56,
+            75,
+            0.7344262295081967
+        ],
+        [
+            57,
+            0,
+            0.8180327868852459
+        ],
+        [
+            57,
+            1,
+            0.639344262295082
+        ],
+        [
+            57,
+            2,
+            0.19508196721311477
+        ],
+        [
+            57,
+            3,
+            0.19508196721311477
+        ],
+        [
+            57,
+            4,
+            0.639344262295082
+        ],
+        [
+            57,
+            5,
+            0.19508196721311477
+        ],
+        [
+            57,
+            6,
+            0.2114754098360656
+        ],
+        [
+            57,
+            7,
+            0.19508196721311477
+        ],
+        [
+            57,
+            8,
+            0.639344262295082
+        ],
+        [
+            57,
+            9,
+            0.6311475409836065
+        ],
+        [
+            57,
+            10,
+            0.19508196721311477
+        ],
+        [
+            57,
+            11,
+            0.19508196721311477
+        ],
+        [
+            57,
+            12,
+            0.6311475409836065
+        ],
+        [
+            57,
+            13,
+            0.19508196721311477
+        ],
+        [
+            57,
+            14,
+            0.19508196721311477
+        ],
+        [
+            57,
+            15,
+            0.639344262295082
+        ],
+        [
+            57,
+            16,
+            0.19508196721311477
+        ],
+        [
+            57,
+            17,
+            0.2213114754098361
+        ],
+        [
+            57,
+            18,
+            0.2065573770491803
+        ],
+        [
+            57,
+            19,
+            0.19672131147540983
+        ],
+        [
+            57,
+            20,
+            0.21311475409836067
+        ],
+        [
+            57,
+            21,
+            0.2114754098360656
+        ],
+        [
+            57,
+            22,
+            0.21311475409836067
+        ],
+        [
+            57,
+            23,
+            0.21311475409836067
+        ],
+        [
+            57,
+            24,
+            0.20163934426229513
+        ],
+        [
+            57,
+            25,
+            0.22786885245901645
+        ],
+        [
+            57,
+            26,
+            0.20163934426229513
+        ],
+        [
+            57,
+            27,
+            0.2114754098360656
+        ],
+        [
+            57,
+            28,
+            0.2114754098360656
+        ],
+        [
+            57,
+            29,
+            0.2032786885245902
+        ],
+        [
+            57,
+            30,
+            0.2114754098360656
+        ],
+        [
+            57,
+            31,
+            0.20983606557377055
+        ],
+        [
+            57,
+            32,
+            0.20163934426229513
+        ],
+        [
+            57,
+            33,
+            0.21475409836065573
+        ],
+        [
+            57,
+            34,
+            0.2163934426229508
+        ],
+        [
+            57,
+            35,
+            0.2032786885245902
+        ],
+        [
+            57,
+            36,
+            0.20163934426229513
+        ],
+        [
+            57,
+            37,
+            0.20491803278688525
+        ],
+        [
+            57,
+            38,
+            0.2114754098360656
+        ],
+        [
+            57,
+            39,
+            0.20491803278688525
+        ],
+        [
+            57,
+            40,
+            0.2032786885245902
+        ],
+        [
+            57,
+            41,
+            0.21475409836065573
+        ],
+        [
+            57,
+            42,
+            0.21803278688524586
+        ],
+        [
+            57,
+            43,
+            0.21475409836065573
+        ],
+        [
+            57,
+            44,
+            0.21475409836065573
+        ],
+        [
+            57,
+            45,
+            0.2114754098360656
+        ],
+        [
+            57,
+            46,
+            0.2032786885245902
+        ],
+        [
+            57,
+            47,
+            0.23606557377049175
+        ],
+        [
+            57,
+            48,
+            0.2032786885245902
+        ],
+        [
+            57,
+            49,
+            0.2065573770491803
+        ],
+        [
+            57,
+            50,
+            0.20491803278688525
+        ],
+        [
+            57,
+            51,
+            0.21475409836065573
+        ],
+        [
+            57,
+            52,
+            0.2245901639344262
+        ],
+        [
+            57,
+            53,
+            0.8737704918032787
+        ],
+        [
+            57,
+            54,
+            0.9573770491803278
+        ],
+        [
+            57,
+            55,
+            0.9508196721311475
+        ],
+        [
+            57,
+            56,
+            0.9442622950819672
+        ],
+        [
+            57,
+            57,
+            1.0
+        ],
+        [
+            57,
+            58,
+            0.8901639344262295
+        ],
+        [
+            57,
+            59,
+            0.8229508196721311
+        ],
+        [
+            57,
+            60,
+            0.9524590163934427
+        ],
+        [
+            57,
+            61,
+            0.9688524590163934
+        ],
+        [
+            57,
+            62,
+            0.8213114754098361
+        ],
+        [
+            57,
+            63,
+            0.8245901639344262
+        ],
+        [
+            57,
+            64,
+            0.9672131147540983
+        ],
+        [
+            57,
+            65,
+            0.9688524590163934
+        ],
+        [
+            57,
+            66,
+            0.9622950819672131
+        ],
+        [
+            57,
+            67,
+            0.9606557377049181
+        ],
+        [
+            57,
+            68,
+            0.8918032786885246
+        ],
+        [
+            57,
+            69,
+            0.3688524590163934
+        ],
+        [
+            57,
+            70,
+            0.3688524590163934
+        ],
+        [
+            57,
+            71,
+            0.3655737704918033
+        ],
+        [
+            57,
+            72,
+            0.37540983606557377
+        ],
+        [
+            57,
+            73,
+            0.9557377049180328
+        ],
+        [
+            57,
+            74,
+            0.3770491803278688
+        ],
+        [
+            57,
+            75,
+            0.7278688524590164
+        ],
+        [
+            58,
+            0,
+            0.9114754098360656
+        ],
+        [
+            58,
+            1,
+            0.7327868852459016
+        ],
+        [
+            58,
+            2,
+            0.1081967213114754
+        ],
+        [
+            58,
+            3,
+            0.1081967213114754
+        ],
+        [
+            58,
+            4,
+            0.7327868852459016
+        ],
+        [
+            58,
+            5,
+            0.1081967213114754
+        ],
+        [
+            58,
+            6,
+            0.15409836065573768
+        ],
+        [
+            58,
+            7,
+            0.1081967213114754
+        ],
+        [
+            58,
+            8,
+            0.7327868852459016
+        ],
+        [
+            58,
+            9,
+            0.7245901639344262
+        ],
+        [
+            58,
+            10,
+            0.1081967213114754
+        ],
+        [
+            58,
+            11,
+            0.1081967213114754
+        ],
+        [
+            58,
+            12,
+            0.7245901639344262
+        ],
+        [
+            58,
+            13,
+            0.1081967213114754
+        ],
+        [
+            58,
+            14,
+            0.1081967213114754
+        ],
+        [
+            58,
+            15,
+            0.7327868852459016
+        ],
+        [
+            58,
+            16,
+            0.1081967213114754
+        ],
+        [
+            58,
+            17,
+            0.1672131147540984
+        ],
+        [
+            58,
+            18,
+            0.12295081967213117
+        ],
+        [
+            58,
+            19,
+            0.10983606557377046
+        ],
+        [
+            58,
+            20,
+            0.12950819672131153
+        ],
+        [
+            58,
+            21,
+            0.12786885245901636
+        ],
+        [
+            58,
+            22,
+            0.12950819672131153
+        ],
+        [
+            58,
+            23,
+            0.12950819672131153
+        ],
+        [
+            58,
+            24,
+            0.11475409836065575
+        ],
+        [
+            58,
+            25,
+            0.1442622950819672
+        ],
+        [
+            58,
+            26,
+            0.11475409836065575
+        ],
+        [
+            58,
+            27,
+            0.12786885245901636
+        ],
+        [
+            58,
+            28,
+            0.12786885245901636
+        ],
+        [
+            58,
+            29,
+            0.11639344262295082
+        ],
+        [
+            58,
+            30,
+            0.12786885245901636
+        ],
+        [
+            58,
+            31,
+            0.1262295081967213
+        ],
+        [
+            58,
+            32,
+            0.11475409836065575
+        ],
+        [
+            58,
+            33,
+            0.13442622950819672
+        ],
+        [
+            58,
+            34,
+            0.13606557377049178
+        ],
+        [
+            58,
+            35,
+            0.11639344262295082
+        ],
+        [
+            58,
+            36,
+            0.11475409836065575
+        ],
+        [
+            58,
+            37,
+            0.11803278688524588
+        ],
+        [
+            58,
+            38,
+            0.12786885245901636
+        ],
+        [
+            58,
+            39,
+            0.12131147540983611
+        ],
+        [
+            58,
+            40,
+            0.11639344262295082
+        ],
+        [
+            58,
+            41,
+            0.1311475409836066
+        ],
+        [
+            58,
+            42,
+            0.13442622950819672
+        ],
+        [
+            58,
+            43,
+            0.1311475409836066
+        ],
+        [
+            58,
+            44,
+            0.13770491803278684
+        ],
+        [
+            58,
+            45,
+            0.12786885245901636
+        ],
+        [
+            58,
+            46,
+            0.11639344262295082
+        ],
+        [
+            58,
+            47,
+            0.1622950819672131
+        ],
+        [
+            58,
+            48,
+            0.11639344262295082
+        ],
+        [
+            58,
+            49,
+            0.11967213114754094
+        ],
+        [
+            58,
+            50,
+            0.11803278688524588
+        ],
+        [
+            58,
+            51,
+            0.1311475409836066
+        ],
+        [
+            58,
+            52,
+            0.14098360655737707
+        ],
+        [
+            58,
+            53,
+            0.9049180327868852
+        ],
+        [
+            58,
+            54,
+            0.9
+        ],
+        [
+            58,
+            55,
+            0.8901639344262295
+        ],
+        [
+            58,
+            56,
+            0.8901639344262295
+        ],
+        [
+            58,
+            57,
+            0.8901639344262295
+        ],
+        [
+            58,
             58,
             1.0
         ],
         [
-            121,
+            58,
+            59,
+            0.9065573770491804
+        ],
+        [
+            58,
+            60,
+            0.898360655737705
+        ],
+        [
+            58,
+            61,
+            0.8852459016393442
+        ],
+        [
+            58,
+            62,
+            0.9049180327868852
+        ],
+        [
+            58,
+            63,
+            0.9049180327868852
+        ],
+        [
+            58,
+            64,
+            0.8836065573770492
+        ],
+        [
+            58,
+            65,
+            0.8918032786885246
+        ],
+        [
+            58,
+            66,
+            0.8950819672131147
+        ],
+        [
+            58,
+            67,
+            0.8934426229508197
+        ],
+        [
+            58,
+            68,
+            0.8901639344262295
+        ],
+        [
+            58,
+            69,
+            0.2754098360655738
+        ],
+        [
+            58,
+            70,
+            0.2754098360655738
+        ],
+        [
+            58,
+            71,
+            0.27213114754098355
+        ],
+        [
+            58,
+            72,
+            0.30819672131147546
+        ],
+        [
+            58,
+            73,
+            0.8754098360655738
+        ],
+        [
+            58,
+            74,
+            0.2836065573770492
+        ],
+        [
+            58,
+            75,
+            0.7786885245901639
+        ],
+        [
+            59,
+            0,
+            0.9524590163934427
+        ],
+        [
+            59,
+            1,
+            0.7737704918032787
+        ],
+        [
+            59,
+            2,
+            0.021311475409836023
+        ],
+        [
+            59,
+            3,
+            0.021311475409836023
+        ],
+        [
+            59,
+            4,
+            0.7737704918032787
+        ],
+        [
+            59,
+            5,
+            0.021311475409836023
+        ],
+        [
+            59,
+            6,
+            0.0901639344262295
+        ],
+        [
+            59,
+            7,
+            0.021311475409836023
+        ],
+        [
+            59,
+            8,
+            0.7737704918032787
+        ],
+        [
+            59,
+            9,
+            0.7622950819672132
+        ],
+        [
+            59,
+            10,
+            0.021311475409836023
+        ],
+        [
+            59,
+            11,
+            0.021311475409836023
+        ],
+        [
+            59,
+            12,
+            0.7622950819672132
+        ],
+        [
+            59,
+            13,
+            0.021311475409836023
+        ],
+        [
+            59,
+            14,
+            0.021311475409836023
+        ],
+        [
+            59,
+            15,
+            0.7737704918032787
+        ],
+        [
+            59,
+            16,
+            0.021311475409836023
+        ],
+        [
+            59,
+            17,
+            0.10327868852459021
+        ],
+        [
+            59,
+            18,
+            0.0360655737704918
+        ],
+        [
+            59,
+            19,
+            0.022950819672131195
+        ],
+        [
+            59,
+            20,
+            0.042622950819672156
+        ],
+        [
+            59,
+            21,
+            0.040983606557377095
+        ],
+        [
+            59,
+            22,
+            0.042622950819672156
+        ],
+        [
+            59,
+            23,
+            0.042622950819672156
+        ],
+        [
+            59,
+            24,
+            0.02786885245901638
+        ],
+        [
+            59,
+            25,
+            0.060655737704918056
+        ],
+        [
+            59,
+            26,
+            0.02786885245901638
+        ],
+        [
+            59,
+            27,
+            0.040983606557377095
+        ],
+        [
+            59,
+            28,
+            0.040983606557377095
+        ],
+        [
+            59,
+            29,
+            0.02950819672131144
+        ],
+        [
+            59,
+            30,
+            0.040983606557377095
+        ],
+        [
+            59,
+            31,
+            0.03934426229508192
+        ],
+        [
+            59,
+            32,
+            0.02786885245901638
+        ],
+        [
+            59,
+            33,
+            0.04754098360655734
+        ],
+        [
+            59,
+            34,
+            0.049180327868852514
+        ],
+        [
+            59,
+            35,
+            0.02950819672131144
+        ],
+        [
+            59,
+            36,
+            0.02786885245901638
+        ],
+        [
+            59,
+            37,
+            0.031147540983606503
+        ],
+        [
+            59,
+            38,
+            0.040983606557377095
+        ],
+        [
+            59,
+            39,
+            0.03442622950819674
+        ],
+        [
+            59,
+            40,
+            0.02950819672131144
+        ],
+        [
+            59,
+            41,
+            0.04426229508196722
+        ],
+        [
+            59,
+            42,
+            0.04754098360655734
+        ],
+        [
+            59,
+            43,
+            0.04426229508196722
+        ],
+        [
+            59,
+            44,
+            0.050819672131147575
+        ],
+        [
+            59,
+            45,
+            0.040983606557377095
+        ],
+        [
+            59,
+            46,
+            0.02950819672131144
+        ],
+        [
+            59,
+            47,
+            0.07540983606557372
+        ],
+        [
+            59,
+            48,
+            0.02950819672131144
+        ],
+        [
+            59,
+            49,
+            0.032786885245901676
+        ],
+        [
+            59,
+            50,
+            0.031147540983606503
+        ],
+        [
+            59,
+            51,
+            0.04426229508196722
+        ],
+        [
+            59,
+            52,
+            0.05737704918032782
+        ],
+        [
+            59,
+            53,
+            0.8934426229508197
+        ],
+        [
+            59,
+            54,
+            0.8163934426229509
+        ],
+        [
+            59,
+            55,
+            0.8262295081967213
+        ],
+        [
+            59,
+            56,
+            0.8098360655737705
+        ],
+        [
+            59,
+            57,
+            0.8229508196721311
+        ],
+        [
+            59,
+            58,
+            0.9065573770491804
+        ],
+        [
+            59,
             59,
             1.0
         ],
         [
-            121,
+            59,
+            60,
+            0.8147540983606557
+        ],
+        [
+            59,
+            61,
+            0.798360655737705
+        ],
+        [
+            59,
+            62,
+            0.9983606557377049
+        ],
+        [
+            59,
+            63,
+            0.9983606557377049
+        ],
+        [
+            59,
+            64,
+            0.7967213114754098
+        ],
+        [
+            59,
+            65,
+            0.8049180327868852
+        ],
+        [
+            59,
+            66,
+            0.8540983606557377
+        ],
+        [
+            59,
+            67,
+            0.8065573770491803
+        ],
+        [
+            59,
+            68,
+            0.8557377049180328
+        ],
+        [
+            59,
+            69,
+            0.2344262295081967
+        ],
+        [
+            59,
+            70,
+            0.2344262295081967
+        ],
+        [
+            59,
+            71,
+            0.23114754098360657
+        ],
+        [
+            59,
+            72,
+            0.29016393442622945
+        ],
+        [
+            59,
+            73,
+            0.8377049180327869
+        ],
+        [
+            59,
+            74,
+            0.24590163934426235
+        ],
+        [
+            59,
+            75,
+            0.862295081967213
+        ],
+        [
+            60,
+            0,
+            0.862295081967213
+        ],
+        [
+            60,
+            1,
+            0.6836065573770491
+        ],
+        [
+            60,
+            2,
+            0.2065573770491803
+        ],
+        [
+            60,
+            3,
+            0.2065573770491803
+        ],
+        [
+            60,
+            4,
+            0.6836065573770491
+        ],
+        [
+            60,
+            5,
+            0.2065573770491803
+        ],
+        [
+            60,
+            6,
+            0.23278688524590163
+        ],
+        [
+            60,
+            7,
+            0.2065573770491803
+        ],
+        [
+            60,
+            8,
+            0.6836065573770491
+        ],
+        [
+            60,
+            9,
+            0.6754098360655738
+        ],
+        [
+            60,
+            10,
+            0.2065573770491803
+        ],
+        [
+            60,
+            11,
+            0.2065573770491803
+        ],
+        [
+            60,
+            12,
+            0.6754098360655738
+        ],
+        [
+            60,
+            13,
+            0.2065573770491803
+        ],
+        [
+            60,
+            14,
+            0.2065573770491803
+        ],
+        [
+            60,
+            15,
+            0.6836065573770491
+        ],
+        [
+            60,
+            16,
+            0.2065573770491803
+        ],
+        [
+            60,
+            17,
+            0.24590163934426235
+        ],
+        [
+            60,
+            18,
+            0.2213114754098361
+        ],
+        [
+            60,
+            19,
+            0.20819672131147537
+        ],
+        [
+            60,
+            20,
+            0.22786885245901645
+        ],
+        [
+            60,
+            21,
+            0.22622950819672127
+        ],
+        [
+            60,
+            22,
+            0.22786885245901645
+        ],
+        [
+            60,
+            23,
+            0.22786885245901645
+        ],
+        [
+            60,
+            24,
+            0.21311475409836067
+        ],
+        [
+            60,
+            25,
+            0.2426229508196721
+        ],
+        [
+            60,
+            26,
+            0.21311475409836067
+        ],
+        [
+            60,
+            27,
+            0.22622950819672127
+        ],
+        [
+            60,
+            28,
+            0.22622950819672127
+        ],
+        [
+            60,
+            29,
+            0.21475409836065573
+        ],
+        [
+            60,
+            30,
+            0.22622950819672127
+        ],
+        [
+            60,
+            31,
+            0.2245901639344262
+        ],
+        [
+            60,
+            32,
+            0.21311475409836067
+        ],
+        [
+            60,
+            33,
+            0.23278688524590163
+        ],
+        [
+            60,
+            34,
+            0.23114754098360657
+        ],
+        [
+            60,
+            35,
+            0.21475409836065573
+        ],
+        [
+            60,
+            36,
+            0.21311475409836067
+        ],
+        [
+            60,
+            37,
+            0.2163934426229508
+        ],
+        [
+            60,
+            38,
+            0.22295081967213115
+        ],
+        [
+            60,
+            39,
+            0.21967213114754103
+        ],
+        [
+            60,
+            40,
+            0.21475409836065573
+        ],
+        [
+            60,
+            41,
+            0.2295081967213115
+        ],
+        [
+            60,
+            42,
+            0.23278688524590163
+        ],
+        [
+            60,
+            43,
+            0.2295081967213115
+        ],
+        [
+            60,
+            44,
+            0.23278688524590163
+        ],
+        [
+            60,
+            45,
+            0.22295081967213115
+        ],
+        [
+            60,
+            46,
+            0.21475409836065573
+        ],
+        [
+            60,
+            47,
+            0.25409836065573765
+        ],
+        [
+            60,
+            48,
+            0.21475409836065573
+        ],
+        [
+            60,
+            49,
+            0.21803278688524586
+        ],
+        [
+            60,
+            50,
+            0.2163934426229508
+        ],
+        [
+            60,
+            51,
+            0.2295081967213115
+        ],
+        [
+            60,
+            52,
+            0.23606557377049175
+        ],
+        [
+            60,
+            53,
+            0.9147540983606557
+        ],
+        [
+            60,
+            54,
+            0.9918032786885246
+        ],
+        [
+            60,
+            55,
+            0.9557377049180328
+        ],
+        [
+            60,
+            56,
+            0.9459016393442623
+        ],
+        [
+            60,
+            57,
+            0.9524590163934427
+        ],
+        [
+            60,
+            58,
+            0.898360655737705
+        ],
+        [
+            60,
+            59,
+            0.8147540983606557
+        ],
+        [
+            60,
             60,
             1.0
         ],
         [
-            121,
+            60,
+            61,
+            0.9836065573770492
+        ],
+        [
+            60,
+            62,
+            0.8131147540983606
+        ],
+        [
+            60,
+            63,
+            0.8131147540983606
+        ],
+        [
+            60,
+            64,
+            0.978688524590164
+        ],
+        [
+            60,
+            65,
+            0.9770491803278688
+        ],
+        [
+            60,
+            66,
+            0.9245901639344263
+        ],
+        [
+            60,
+            67,
+            0.9721311475409836
+        ],
+        [
+            60,
+            68,
+            0.9131147540983606
+        ],
+        [
+            60,
+            69,
+            0.3245901639344262
+        ],
+        [
+            60,
+            70,
+            0.3245901639344262
+        ],
+        [
+            60,
+            71,
+            0.32131147540983607
+        ],
+        [
+            60,
+            72,
+            0.34098360655737703
+        ],
+        [
+            60,
+            73,
+            0.9114754098360656
+        ],
+        [
+            60,
+            74,
+            0.3327868852459016
+        ],
+        [
+            60,
+            75,
+            0.7131147540983607
+        ],
+        [
+            61,
+            0,
+            0.8459016393442623
+        ],
+        [
+            61,
+            1,
+            0.6672131147540983
+        ],
+        [
+            61,
+            2,
+            0.22295081967213115
+        ],
+        [
+            61,
+            3,
+            0.22295081967213115
+        ],
+        [
+            61,
+            4,
+            0.6672131147540983
+        ],
+        [
+            61,
+            5,
+            0.22295081967213115
+        ],
+        [
+            61,
+            6,
+            0.239344262295082
+        ],
+        [
+            61,
+            7,
+            0.22295081967213115
+        ],
+        [
+            61,
+            8,
+            0.6672131147540983
+        ],
+        [
+            61,
+            9,
+            0.659016393442623
+        ],
+        [
+            61,
+            10,
+            0.22295081967213115
+        ],
+        [
+            61,
+            11,
+            0.22295081967213115
+        ],
+        [
+            61,
+            12,
+            0.659016393442623
+        ],
+        [
+            61,
+            13,
+            0.22295081967213115
+        ],
+        [
+            61,
+            14,
+            0.22295081967213115
+        ],
+        [
+            61,
+            15,
+            0.6672131147540983
+        ],
+        [
+            61,
+            16,
+            0.22295081967213115
+        ],
+        [
+            61,
+            17,
+            0.2524590163934426
+        ],
+        [
+            61,
+            18,
+            0.23770491803278693
+        ],
+        [
+            61,
+            19,
+            0.2245901639344262
+        ],
+        [
+            61,
+            20,
+            0.24426229508196717
+        ],
+        [
+            61,
+            21,
+            0.2426229508196721
+        ],
+        [
+            61,
+            22,
+            0.24426229508196717
+        ],
+        [
+            61,
+            23,
+            0.24426229508196717
+        ],
+        [
+            61,
+            24,
+            0.2295081967213115
+        ],
+        [
+            61,
+            25,
+            0.2557377049180328
+        ],
+        [
+            61,
+            26,
+            0.2295081967213115
+        ],
+        [
+            61,
+            27,
+            0.2426229508196721
+        ],
+        [
+            61,
+            28,
+            0.2426229508196721
+        ],
+        [
+            61,
+            29,
+            0.23114754098360657
+        ],
+        [
+            61,
+            30,
+            0.2426229508196721
+        ],
+        [
+            61,
+            31,
+            0.24098360655737705
+        ],
+        [
+            61,
+            32,
+            0.2295081967213115
+        ],
+        [
+            61,
+            33,
+            0.24590163934426235
+        ],
+        [
+            61,
+            34,
+            0.2475409836065574
+        ],
+        [
+            61,
+            35,
+            0.23114754098360657
+        ],
+        [
+            61,
+            36,
+            0.2295081967213115
+        ],
+        [
+            61,
+            37,
+            0.23278688524590163
+        ],
+        [
+            61,
+            38,
+            0.239344262295082
+        ],
+        [
+            61,
+            39,
+            0.23278688524590163
+        ],
+        [
+            61,
+            40,
+            0.23114754098360657
+        ],
+        [
+            61,
+            41,
+            0.24590163934426235
+        ],
+        [
+            61,
+            42,
+            0.24918032786885247
+        ],
+        [
+            61,
+            43,
+            0.24590163934426235
+        ],
+        [
+            61,
+            44,
+            0.24590163934426235
+        ],
+        [
+            61,
+            45,
+            0.239344262295082
+        ],
+        [
+            61,
+            46,
+            0.23114754098360657
+        ],
+        [
+            61,
+            47,
+            0.26721311475409837
+        ],
+        [
+            61,
+            48,
+            0.23114754098360657
+        ],
+        [
+            61,
+            49,
+            0.2344262295081967
+        ],
+        [
+            61,
+            50,
+            0.23278688524590163
+        ],
+        [
+            61,
+            51,
+            0.24590163934426235
+        ],
+        [
+            61,
+            52,
+            0.2524590163934426
+        ],
+        [
+            61,
+            53,
+            0.9016393442622951
+        ],
+        [
+            61,
+            54,
+            0.9819672131147541
+        ],
+        [
+            61,
+            55,
+            0.9655737704918033
+        ],
+        [
+            61,
+            56,
+            0.9590163934426229
+        ],
+        [
+            61,
+            57,
+            0.9688524590163934
+        ],
+        [
+            61,
+            58,
+            0.8852459016393442
+        ],
+        [
+            61,
+            59,
+            0.798360655737705
+        ],
+        [
+            61,
+            60,
+            0.9836065573770492
+        ],
+        [
+            61,
             61,
             1.0
         ],
         [
-            121,
+            61,
+            62,
+            0.7967213114754098
+        ],
+        [
+            61,
+            63,
+            0.7967213114754098
+        ],
+        [
+            61,
+            64,
+            0.9950819672131147
+        ],
+        [
+            61,
+            65,
+            0.9934426229508196
+        ],
+        [
+            61,
+            66,
+            0.9344262295081968
+        ],
+        [
+            61,
+            67,
+            0.9885245901639345
+        ],
+        [
+            61,
+            68,
+            0.9131147540983606
+        ],
+        [
+            61,
+            69,
+            0.34098360655737703
+        ],
+        [
+            61,
+            70,
+            0.34098360655737703
+        ],
+        [
+            61,
+            71,
+            0.3377049180327869
+        ],
+        [
+            61,
+            72,
+            0.3475409836065574
+        ],
+        [
+            61,
+            73,
+            0.9278688524590164
+        ],
+        [
+            61,
+            74,
+            0.34918032786885245
+        ],
+        [
+            61,
+            75,
+            0.6967213114754098
+        ],
+        [
+            62,
+            0,
+            0.9508196721311475
+        ],
+        [
+            62,
+            1,
+            0.7721311475409836
+        ],
+        [
+            62,
+            2,
+            0.01967213114754096
+        ],
+        [
+            62,
+            3,
+            0.01967213114754096
+        ],
+        [
+            62,
+            4,
+            0.7721311475409836
+        ],
+        [
+            62,
+            5,
+            0.01967213114754096
+        ],
+        [
+            62,
+            6,
+            0.08852459016393444
+        ],
+        [
+            62,
+            7,
+            0.01967213114754096
+        ],
+        [
+            62,
+            8,
+            0.7721311475409836
+        ],
+        [
+            62,
+            9,
+            0.760655737704918
+        ],
+        [
+            62,
+            10,
+            0.01967213114754096
+        ],
+        [
+            62,
+            11,
+            0.01967213114754096
+        ],
+        [
+            62,
+            12,
+            0.760655737704918
+        ],
+        [
+            62,
+            13,
+            0.01967213114754096
+        ],
+        [
+            62,
+            14,
+            0.01967213114754096
+        ],
+        [
+            62,
+            15,
+            0.7721311475409836
+        ],
+        [
+            62,
+            16,
+            0.01967213114754096
+        ],
+        [
+            62,
+            17,
+            0.10163934426229504
+        ],
+        [
+            62,
+            18,
+            0.03442622950819674
+        ],
+        [
+            62,
+            19,
+            0.021311475409836023
+        ],
+        [
+            62,
+            20,
+            0.040983606557377095
+        ],
+        [
+            62,
+            21,
+            0.03934426229508192
+        ],
+        [
+            62,
+            22,
+            0.040983606557377095
+        ],
+        [
+            62,
+            23,
+            0.040983606557377095
+        ],
+        [
+            62,
+            24,
+            0.02622950819672132
+        ],
+        [
+            62,
+            25,
+            0.059016393442622994
+        ],
+        [
+            62,
+            26,
+            0.02622950819672132
+        ],
+        [
+            62,
+            27,
+            0.03934426229508192
+        ],
+        [
+            62,
+            28,
+            0.03934426229508192
+        ],
+        [
+            62,
+            29,
+            0.02786885245901638
+        ],
+        [
+            62,
+            30,
+            0.03934426229508192
+        ],
+        [
+            62,
+            31,
+            0.03770491803278686
+        ],
+        [
+            62,
+            32,
+            0.02622950819672132
+        ],
+        [
+            62,
+            33,
+            0.04590163934426228
+        ],
+        [
+            62,
+            34,
+            0.04754098360655734
+        ],
+        [
+            62,
+            35,
+            0.02786885245901638
+        ],
+        [
+            62,
+            36,
+            0.02622950819672132
+        ],
+        [
+            62,
+            37,
+            0.02950819672131144
+        ],
+        [
+            62,
+            38,
+            0.03934426229508192
+        ],
+        [
+            62,
+            39,
+            0.032786885245901676
+        ],
+        [
+            62,
+            40,
+            0.02786885245901638
+        ],
+        [
+            62,
+            41,
+            0.042622950819672156
+        ],
+        [
+            62,
+            42,
+            0.04590163934426228
+        ],
+        [
+            62,
+            43,
+            0.042622950819672156
+        ],
+        [
+            62,
+            44,
+            0.049180327868852514
+        ],
+        [
+            62,
+            45,
+            0.03934426229508192
+        ],
+        [
+            62,
+            46,
+            0.02786885245901638
+        ],
+        [
+            62,
+            47,
+            0.07377049180327866
+        ],
+        [
+            62,
+            48,
+            0.02786885245901638
+        ],
+        [
+            62,
+            49,
+            0.031147540983606503
+        ],
+        [
+            62,
+            50,
+            0.02950819672131144
+        ],
+        [
+            62,
+            51,
+            0.042622950819672156
+        ],
+        [
+            62,
+            52,
+            0.05573770491803276
+        ],
+        [
+            62,
+            53,
+            0.8918032786885246
+        ],
+        [
+            62,
+            54,
+            0.8147540983606557
+        ],
+        [
+            62,
+            55,
+            0.8245901639344262
+        ],
+        [
+            62,
+            56,
+            0.8114754098360656
+        ],
+        [
+            62,
+            57,
+            0.8213114754098361
+        ],
+        [
+            62,
+            58,
+            0.9049180327868852
+        ],
+        [
+            62,
+            59,
+            0.9983606557377049
+        ],
+        [
+            62,
+            60,
+            0.8131147540983606
+        ],
+        [
+            62,
+            61,
+            0.7967213114754098
+        ],
+        [
+            62,
+            62,
+            1.0
+        ],
+        [
+            62,
+            63,
+            0.9967213114754099
+        ],
+        [
+            62,
+            64,
+            0.7950819672131147
+        ],
+        [
+            62,
+            65,
+            0.8032786885245902
+        ],
+        [
+            62,
+            66,
+            0.8524590163934427
+        ],
+        [
+            62,
+            67,
+            0.8049180327868852
+        ],
+        [
+            62,
+            68,
+            0.8573770491803279
+        ],
+        [
+            62,
+            69,
+            0.23606557377049175
+        ],
+        [
+            62,
+            70,
+            0.23606557377049175
+        ],
+        [
+            62,
+            71,
+            0.23278688524590163
+        ],
+        [
+            62,
+            72,
+            0.2918032786885246
+        ],
+        [
+            62,
+            73,
+            0.839344262295082
+        ],
+        [
+            62,
+            74,
+            0.2475409836065574
+        ],
+        [
+            62,
+            75,
+            0.8639344262295082
+        ],
+        [
+            63,
+            0,
+            0.9508196721311475
+        ],
+        [
+            63,
+            1,
+            0.7721311475409836
+        ],
+        [
+            63,
+            2,
+            0.01967213114754096
+        ],
+        [
+            63,
+            3,
+            0.01967213114754096
+        ],
+        [
+            63,
+            4,
+            0.7721311475409836
+        ],
+        [
+            63,
+            5,
+            0.01967213114754096
+        ],
+        [
+            63,
+            6,
+            0.08852459016393444
+        ],
+        [
+            63,
+            7,
+            0.01967213114754096
+        ],
+        [
+            63,
+            8,
+            0.7721311475409836
+        ],
+        [
+            63,
+            9,
+            0.760655737704918
+        ],
+        [
+            63,
+            10,
+            0.01967213114754096
+        ],
+        [
+            63,
+            11,
+            0.01967213114754096
+        ],
+        [
+            63,
+            12,
+            0.760655737704918
+        ],
+        [
+            63,
+            13,
+            0.01967213114754096
+        ],
+        [
+            63,
+            14,
+            0.01967213114754096
+        ],
+        [
+            63,
+            15,
+            0.7721311475409836
+        ],
+        [
+            63,
+            16,
+            0.01967213114754096
+        ],
+        [
+            63,
+            17,
+            0.10163934426229504
+        ],
+        [
+            63,
+            18,
+            0.03442622950819674
+        ],
+        [
+            63,
+            19,
+            0.021311475409836023
+        ],
+        [
+            63,
+            20,
+            0.040983606557377095
+        ],
+        [
+            63,
+            21,
+            0.03934426229508192
+        ],
+        [
+            63,
+            22,
+            0.040983606557377095
+        ],
+        [
+            63,
+            23,
+            0.040983606557377095
+        ],
+        [
+            63,
+            24,
+            0.02622950819672132
+        ],
+        [
+            63,
+            25,
+            0.059016393442622994
+        ],
+        [
+            63,
+            26,
+            0.02622950819672132
+        ],
+        [
+            63,
+            27,
+            0.03934426229508192
+        ],
+        [
+            63,
+            28,
+            0.03934426229508192
+        ],
+        [
+            63,
+            29,
+            0.02786885245901638
+        ],
+        [
+            63,
+            30,
+            0.03934426229508192
+        ],
+        [
+            63,
+            31,
+            0.03770491803278686
+        ],
+        [
+            63,
+            32,
+            0.02622950819672132
+        ],
+        [
+            63,
+            33,
+            0.04590163934426228
+        ],
+        [
+            63,
+            34,
+            0.04754098360655734
+        ],
+        [
+            63,
+            35,
+            0.02786885245901638
+        ],
+        [
+            63,
+            36,
+            0.02622950819672132
+        ],
+        [
+            63,
+            37,
+            0.02950819672131144
+        ],
+        [
+            63,
+            38,
+            0.03934426229508192
+        ],
+        [
+            63,
+            39,
+            0.032786885245901676
+        ],
+        [
+            63,
+            40,
+            0.02786885245901638
+        ],
+        [
+            63,
+            41,
+            0.042622950819672156
+        ],
+        [
+            63,
+            42,
+            0.04590163934426228
+        ],
+        [
+            63,
+            43,
+            0.042622950819672156
+        ],
+        [
+            63,
+            44,
+            0.049180327868852514
+        ],
+        [
+            63,
+            45,
+            0.03934426229508192
+        ],
+        [
+            63,
+            46,
+            0.02786885245901638
+        ],
+        [
+            63,
+            47,
+            0.07377049180327866
+        ],
+        [
+            63,
+            48,
+            0.02786885245901638
+        ],
+        [
+            63,
+            49,
+            0.031147540983606503
+        ],
+        [
+            63,
+            50,
+            0.02950819672131144
+        ],
+        [
+            63,
+            51,
+            0.042622950819672156
+        ],
+        [
+            63,
+            52,
+            0.05573770491803276
+        ],
+        [
+            63,
+            53,
+            0.8918032786885246
+        ],
+        [
+            63,
+            54,
+            0.8147540983606557
+        ],
+        [
+            63,
+            55,
+            0.8245901639344262
+        ],
+        [
+            63,
+            56,
+            0.8114754098360656
+        ],
+        [
+            63,
+            57,
+            0.8245901639344262
+        ],
+        [
+            63,
+            58,
+            0.9049180327868852
+        ],
+        [
+            63,
+            59,
+            0.9983606557377049
+        ],
+        [
+            63,
+            60,
+            0.8131147540983606
+        ],
+        [
+            63,
+            61,
+            0.7967213114754098
+        ],
+        [
+            63,
+            62,
+            0.9967213114754099
+        ],
+        [
+            63,
+            63,
+            1.0
+        ],
+        [
+            63,
+            64,
+            0.7950819672131147
+        ],
+        [
+            63,
+            65,
+            0.8032786885245902
+        ],
+        [
+            63,
+            66,
+            0.8524590163934427
+        ],
+        [
+            63,
+            67,
+            0.8081967213114754
+        ],
+        [
+            63,
+            68,
+            0.8573770491803279
+        ],
+        [
+            63,
+            69,
+            0.23606557377049175
+        ],
+        [
+            63,
+            70,
+            0.23606557377049175
+        ],
+        [
+            63,
+            71,
+            0.23278688524590163
+        ],
+        [
+            63,
+            72,
+            0.2918032786885246
+        ],
+        [
+            63,
+            73,
+            0.839344262295082
+        ],
+        [
+            63,
+            74,
+            0.2475409836065574
+        ],
+        [
+            63,
+            75,
+            0.8639344262295082
+        ],
+        [
+            64,
+            0,
+            0.8442622950819672
+        ],
+        [
+            64,
+            1,
+            0.6655737704918032
+        ],
+        [
+            64,
+            2,
+            0.2213114754098361
+        ],
+        [
+            64,
+            3,
+            0.2213114754098361
+        ],
+        [
+            64,
+            4,
+            0.6655737704918032
+        ],
+        [
+            64,
+            5,
+            0.2213114754098361
+        ],
+        [
+            64,
+            6,
+            0.23770491803278693
+        ],
+        [
+            64,
+            7,
+            0.2213114754098361
+        ],
+        [
+            64,
+            8,
+            0.6655737704918032
+        ],
+        [
+            64,
+            9,
+            0.6573770491803279
+        ],
+        [
+            64,
+            10,
+            0.2213114754098361
+        ],
+        [
+            64,
+            11,
+            0.2213114754098361
+        ],
+        [
+            64,
+            12,
+            0.6573770491803279
+        ],
+        [
+            64,
+            13,
+            0.2213114754098361
+        ],
+        [
+            64,
+            14,
+            0.2213114754098361
+        ],
+        [
+            64,
+            15,
+            0.6655737704918032
+        ],
+        [
+            64,
+            16,
+            0.2213114754098361
+        ],
+        [
+            64,
+            17,
+            0.2475409836065574
+        ],
+        [
+            64,
+            18,
+            0.23278688524590163
+        ],
+        [
+            64,
+            19,
+            0.22295081967213115
+        ],
+        [
+            64,
+            20,
+            0.239344262295082
+        ],
+        [
+            64,
+            21,
+            0.23770491803278693
+        ],
+        [
+            64,
+            22,
+            0.239344262295082
+        ],
+        [
+            64,
+            23,
+            0.239344262295082
+        ],
+        [
+            64,
+            24,
+            0.22786885245901645
+        ],
+        [
+            64,
+            25,
+            0.25081967213114753
+        ],
+        [
+            64,
+            26,
+            0.22786885245901645
+        ],
+        [
+            64,
+            27,
+            0.23770491803278693
+        ],
+        [
+            64,
+            28,
+            0.23770491803278693
+        ],
+        [
+            64,
+            29,
+            0.2295081967213115
+        ],
+        [
+            64,
+            30,
+            0.23770491803278693
+        ],
+        [
+            64,
+            31,
+            0.23606557377049175
+        ],
+        [
+            64,
+            32,
+            0.22786885245901645
+        ],
+        [
+            64,
+            33,
+            0.24098360655737705
+        ],
+        [
+            64,
+            34,
+            0.2426229508196721
+        ],
+        [
+            64,
+            35,
+            0.2295081967213115
+        ],
+        [
+            64,
+            36,
+            0.23114754098360657
+        ],
+        [
+            64,
+            37,
+            0.23114754098360657
+        ],
+        [
+            64,
+            38,
+            0.23770491803278693
+        ],
+        [
+            64,
+            39,
+            0.23114754098360657
+        ],
+        [
+            64,
+            40,
+            0.2295081967213115
+        ],
+        [
+            64,
+            41,
+            0.24098360655737705
+        ],
+        [
+            64,
+            42,
+            0.24426229508196717
+        ],
+        [
+            64,
+            43,
+            0.24098360655737705
+        ],
+        [
+            64,
+            44,
+            0.24098360655737705
+        ],
+        [
+            64,
+            45,
+            0.23770491803278693
+        ],
+        [
+            64,
+            46,
+            0.2295081967213115
+        ],
+        [
+            64,
+            47,
+            0.2622950819672131
+        ],
+        [
+            64,
+            48,
+            0.23278688524590163
+        ],
+        [
+            64,
+            49,
+            0.23278688524590163
+        ],
+        [
+            64,
+            50,
+            0.2344262295081967
+        ],
+        [
+            64,
+            51,
+            0.24426229508196717
+        ],
+        [
+            64,
+            52,
+            0.2475409836065574
+        ],
+        [
+            64,
+            53,
+            0.9
+        ],
+        [
+            64,
+            54,
+            0.9770491803278688
+        ],
+        [
+            64,
+            55,
+            0.9704918032786886
+        ],
+        [
+            64,
+            56,
+            0.9573770491803278
+        ],
+        [
+            64,
+            57,
+            0.9672131147540983
+        ],
+        [
+            64,
+            58,
+            0.8836065573770492
+        ],
+        [
+            64,
+            59,
+            0.7967213114754098
+        ],
+        [
+            64,
+            60,
+            0.978688524590164
+        ],
+        [
+            64,
+            61,
+            0.9950819672131147
+        ],
+        [
+            64,
+            62,
+            0.7950819672131147
+        ],
+        [
+            64,
+            63,
+            0.7950819672131147
+        ],
+        [
+            64,
             64,
             1.0
         ],
         [
-            121,
+            64,
+            65,
+            0.9885245901639345
+        ],
+        [
+            64,
+            66,
+            0.9327868852459016
+        ],
+        [
+            64,
+            67,
+            0.9836065573770492
+        ],
+        [
+            64,
+            68,
+            0.9114754098360656
+        ],
+        [
+            64,
+            69,
+            0.33934426229508197
+        ],
+        [
+            64,
+            70,
+            0.33934426229508197
+        ],
+        [
+            64,
+            71,
+            0.33606557377049184
+        ],
+        [
+            64,
+            72,
+            0.3459016393442623
+        ],
+        [
+            64,
+            73,
+            0.9262295081967213
+        ],
+        [
+            64,
+            74,
+            0.3475409836065574
+        ],
+        [
+            64,
+            75,
+            0.6983606557377049
+        ],
+        [
+            65,
+            0,
+            0.8459016393442623
+        ],
+        [
+            65,
+            1,
+            0.6672131147540983
+        ],
+        [
+            65,
+            2,
+            0.2163934426229508
+        ],
+        [
+            65,
+            3,
+            0.2163934426229508
+        ],
+        [
+            65,
+            4,
+            0.6672131147540983
+        ],
+        [
+            65,
+            5,
+            0.2163934426229508
+        ],
+        [
+            65,
+            6,
+            0.23278688524590163
+        ],
+        [
+            65,
+            7,
+            0.2163934426229508
+        ],
+        [
+            65,
+            8,
+            0.6672131147540983
+        ],
+        [
+            65,
+            9,
+            0.659016393442623
+        ],
+        [
+            65,
+            10,
+            0.2163934426229508
+        ],
+        [
+            65,
+            11,
+            0.2163934426229508
+        ],
+        [
+            65,
+            12,
+            0.659016393442623
+        ],
+        [
+            65,
+            13,
+            0.2163934426229508
+        ],
+        [
+            65,
+            14,
+            0.2163934426229508
+        ],
+        [
+            65,
+            15,
+            0.6672131147540983
+        ],
+        [
+            65,
+            16,
+            0.2163934426229508
+        ],
+        [
+            65,
+            17,
+            0.24590163934426235
+        ],
+        [
+            65,
+            18,
+            0.23114754098360657
+        ],
+        [
+            65,
+            19,
+            0.21803278688524586
+        ],
+        [
+            65,
+            20,
+            0.23770491803278693
+        ],
+        [
+            65,
+            21,
+            0.23606557377049175
+        ],
+        [
+            65,
+            22,
+            0.23770491803278693
+        ],
+        [
+            65,
+            23,
+            0.23770491803278693
+        ],
+        [
+            65,
+            24,
+            0.22295081967213115
+        ],
+        [
+            65,
+            25,
+            0.24918032786885247
+        ],
+        [
+            65,
+            26,
+            0.22295081967213115
+        ],
+        [
+            65,
+            27,
+            0.23606557377049175
+        ],
+        [
+            65,
+            28,
+            0.23606557377049175
+        ],
+        [
+            65,
+            29,
+            0.2245901639344262
+        ],
+        [
+            65,
+            30,
+            0.23606557377049175
+        ],
+        [
+            65,
+            31,
+            0.2344262295081967
+        ],
+        [
+            65,
+            32,
+            0.22295081967213115
+        ],
+        [
+            65,
+            33,
+            0.239344262295082
+        ],
+        [
+            65,
+            34,
+            0.24426229508196717
+        ],
+        [
+            65,
+            35,
+            0.2245901639344262
+        ],
+        [
+            65,
+            36,
+            0.22295081967213115
+        ],
+        [
+            65,
+            37,
+            0.22622950819672127
+        ],
+        [
+            65,
+            38,
+            0.23278688524590163
+        ],
+        [
+            65,
+            39,
+            0.22622950819672127
+        ],
+        [
+            65,
+            40,
+            0.2245901639344262
+        ],
+        [
+            65,
+            41,
+            0.239344262295082
+        ],
+        [
+            65,
+            42,
+            0.2426229508196721
+        ],
+        [
+            65,
+            43,
+            0.239344262295082
+        ],
+        [
+            65,
+            44,
+            0.239344262295082
+        ],
+        [
+            65,
+            45,
+            0.23278688524590163
+        ],
+        [
+            65,
+            46,
+            0.2245901639344262
+        ],
+        [
+            65,
+            47,
+            0.260655737704918
+        ],
+        [
+            65,
+            48,
+            0.2245901639344262
+        ],
+        [
+            65,
+            49,
+            0.22786885245901645
+        ],
+        [
+            65,
+            50,
+            0.22622950819672127
+        ],
+        [
+            65,
+            51,
+            0.239344262295082
+        ],
+        [
+            65,
+            52,
+            0.24918032786885247
+        ],
+        [
+            65,
+            53,
+            0.9016393442622951
+        ],
+        [
+            65,
+            54,
+            0.9819672131147541
+        ],
+        [
+            65,
+            55,
+            0.9590163934426229
+        ],
+        [
+            65,
+            56,
+            0.9524590163934427
+        ],
+        [
+            65,
+            57,
+            0.9688524590163934
+        ],
+        [
+            65,
+            58,
+            0.8918032786885246
+        ],
+        [
+            65,
+            59,
+            0.8049180327868852
+        ],
+        [
+            65,
+            60,
+            0.9770491803278688
+        ],
+        [
+            65,
+            61,
+            0.9934426229508196
+        ],
+        [
+            65,
+            62,
+            0.8032786885245902
+        ],
+        [
+            65,
+            63,
+            0.8032786885245902
+        ],
+        [
+            65,
+            64,
+            0.9885245901639345
+        ],
+        [
+            65,
             65,
             1.0
         ],
         [
-            121,
+            65,
+            66,
+            0.9377049180327869
+        ],
+        [
+            65,
+            67,
+            0.9819672131147541
+        ],
+        [
+            65,
+            68,
+            0.9098360655737705
+        ],
+        [
+            65,
+            69,
+            0.34098360655737703
+        ],
+        [
+            65,
+            70,
+            0.34098360655737703
+        ],
+        [
+            65,
+            71,
+            0.3377049180327869
+        ],
+        [
+            65,
+            72,
+            0.3475409836065574
+        ],
+        [
+            65,
+            73,
+            0.9278688524590164
+        ],
+        [
+            65,
+            74,
+            0.34918032786885245
+        ],
+        [
+            65,
+            75,
+            0.7032786885245902
+        ],
+        [
+            66,
+            0,
+            0.8426229508196721
+        ],
+        [
+            66,
+            1,
+            0.6639344262295082
+        ],
+        [
+            66,
+            2,
+            0.16065573770491803
+        ],
+        [
+            66,
+            3,
+            0.16065573770491803
+        ],
+        [
+            66,
+            4,
+            0.6639344262295082
+        ],
+        [
+            66,
+            5,
+            0.16065573770491803
+        ],
+        [
+            66,
+            6,
+            0.180327868852459
+        ],
+        [
+            66,
+            7,
+            0.16065573770491803
+        ],
+        [
+            66,
+            8,
+            0.6639344262295082
+        ],
+        [
+            66,
+            9,
+            0.6557377049180328
+        ],
+        [
+            66,
+            10,
+            0.16065573770491803
+        ],
+        [
+            66,
+            11,
+            0.16065573770491803
+        ],
+        [
+            66,
+            12,
+            0.6557377049180328
+        ],
+        [
+            66,
+            13,
+            0.16065573770491803
+        ],
+        [
+            66,
+            14,
+            0.16065573770491803
+        ],
+        [
+            66,
+            15,
+            0.6639344262295082
+        ],
+        [
+            66,
+            16,
+            0.16065573770491803
+        ],
+        [
+            66,
+            17,
+            0.19016393442622948
+        ],
+        [
+            66,
+            18,
+            0.17213114754098358
+        ],
+        [
+            66,
+            19,
+            0.1622950819672131
+        ],
+        [
+            66,
+            20,
+            0.17868852459016393
+        ],
+        [
+            66,
+            21,
+            0.17704918032786887
+        ],
+        [
+            66,
+            22,
+            0.17868852459016393
+        ],
+        [
+            66,
+            23,
+            0.17868852459016393
+        ],
+        [
+            66,
+            24,
+            0.1672131147540984
+        ],
+        [
+            66,
+            25,
+            0.1934426229508197
+        ],
+        [
+            66,
+            26,
+            0.1672131147540984
+        ],
+        [
+            66,
+            27,
+            0.17704918032786887
+        ],
+        [
+            66,
+            28,
+            0.17704918032786887
+        ],
+        [
+            66,
+            29,
+            0.16885245901639345
+        ],
+        [
+            66,
+            30,
+            0.17704918032786887
+        ],
+        [
+            66,
+            31,
+            0.1754098360655738
+        ],
+        [
+            66,
+            32,
+            0.1672131147540984
+        ],
+        [
+            66,
+            33,
+            0.180327868852459
+        ],
+        [
+            66,
+            34,
+            0.1852459016393443
+        ],
+        [
+            66,
+            35,
+            0.16885245901639345
+        ],
+        [
+            66,
+            36,
+            0.1672131147540984
+        ],
+        [
+            66,
+            37,
+            0.17049180327868851
+        ],
+        [
+            66,
+            38,
+            0.17704918032786887
+        ],
+        [
+            66,
+            39,
+            0.17049180327868851
+        ],
+        [
+            66,
+            40,
+            0.16885245901639345
+        ],
+        [
+            66,
+            41,
+            0.180327868852459
+        ],
+        [
+            66,
+            42,
+            0.18360655737704923
+        ],
+        [
+            66,
+            43,
+            0.180327868852459
+        ],
+        [
+            66,
+            44,
+            0.180327868852459
+        ],
+        [
+            66,
+            45,
+            0.17704918032786887
+        ],
+        [
+            66,
+            46,
+            0.16885245901639345
+        ],
+        [
+            66,
+            47,
+            0.20163934426229513
+        ],
+        [
+            66,
+            48,
+            0.16885245901639345
+        ],
+        [
+            66,
+            49,
+            0.17213114754098358
+        ],
+        [
+            66,
+            50,
+            0.17049180327868851
+        ],
+        [
+            66,
+            51,
+            0.180327868852459
+        ],
+        [
+            66,
+            52,
+            0.1934426229508197
+        ],
+        [
+            66,
+            53,
+            0.8918032786885246
+        ],
+        [
+            66,
+            54,
+            0.9295081967213115
+        ],
+        [
+            66,
+            55,
+            0.9262295081967213
+        ],
+        [
+            66,
+            56,
+            0.9131147540983606
+        ],
+        [
+            66,
+            57,
+            0.9622950819672131
+        ],
+        [
+            66,
+            58,
+            0.8950819672131147
+        ],
+        [
+            66,
+            59,
+            0.8540983606557377
+        ],
+        [
+            66,
+            60,
+            0.9245901639344263
+        ],
+        [
+            66,
+            61,
+            0.9344262295081968
+        ],
+        [
+            66,
+            62,
+            0.8524590163934427
+        ],
+        [
+            66,
+            63,
+            0.8524590163934427
+        ],
+        [
+            66,
+            64,
+            0.9327868852459016
+        ],
+        [
+            66,
+            65,
+            0.9377049180327869
+        ],
+        [
+            66,
+            66,
+            1.0
+        ],
+        [
+            66,
+            67,
+            0.9295081967213115
+        ],
+        [
+            66,
+            68,
+            0.8934426229508197
+        ],
+        [
+            66,
+            69,
+            0.34426229508196726
+        ],
+        [
+            66,
+            70,
+            0.34426229508196726
+        ],
+        [
+            66,
+            71,
+            0.34098360655737703
+        ],
+        [
+            66,
+            72,
+            0.35409836065573774
+        ],
+        [
+            66,
+            73,
+            0.9344262295081968
+        ],
+        [
+            66,
+            74,
+            0.35245901639344257
+        ],
+        [
+            66,
+            75,
+            0.7524590163934426
+        ],
+        [
+            67,
+            0,
+            0.8540983606557377
+        ],
+        [
+            67,
+            1,
+            0.6754098360655738
+        ],
+        [
+            67,
+            2,
+            0.2114754098360656
+        ],
+        [
+            67,
+            3,
+            0.2114754098360656
+        ],
+        [
+            67,
+            4,
+            0.6754098360655738
+        ],
+        [
+            67,
+            5,
+            0.2114754098360656
+        ],
+        [
+            67,
+            6,
+            0.22786885245901645
+        ],
+        [
+            67,
+            7,
+            0.2114754098360656
+        ],
+        [
+            67,
+            8,
+            0.6754098360655738
+        ],
+        [
+            67,
+            9,
+            0.6672131147540983
+        ],
+        [
+            67,
+            10,
+            0.2114754098360656
+        ],
+        [
+            67,
+            11,
+            0.2114754098360656
+        ],
+        [
+            67,
+            12,
+            0.6672131147540983
+        ],
+        [
+            67,
+            13,
+            0.2114754098360656
+        ],
+        [
+            67,
+            14,
+            0.2114754098360656
+        ],
+        [
+            67,
+            15,
+            0.6754098360655738
+        ],
+        [
+            67,
+            16,
+            0.2114754098360656
+        ],
+        [
+            67,
+            17,
+            0.24098360655737705
+        ],
+        [
+            67,
+            18,
+            0.22622950819672127
+        ],
+        [
+            67,
+            19,
+            0.21311475409836067
+        ],
+        [
+            67,
+            20,
+            0.23278688524590163
+        ],
+        [
+            67,
+            21,
+            0.23114754098360657
+        ],
+        [
+            67,
+            22,
+            0.23278688524590163
+        ],
+        [
+            67,
+            23,
+            0.23278688524590163
+        ],
+        [
+            67,
+            24,
+            0.21803278688524586
+        ],
+        [
+            67,
+            25,
+            0.24426229508196717
+        ],
+        [
+            67,
+            26,
+            0.21803278688524586
+        ],
+        [
+            67,
+            27,
+            0.23114754098360657
+        ],
+        [
+            67,
+            28,
+            0.23114754098360657
+        ],
+        [
+            67,
+            29,
+            0.21967213114754103
+        ],
+        [
+            67,
+            30,
+            0.23114754098360657
+        ],
+        [
+            67,
+            31,
+            0.2295081967213115
+        ],
+        [
+            67,
+            32,
+            0.21803278688524586
+        ],
+        [
+            67,
+            33,
+            0.2344262295081967
+        ],
+        [
+            67,
+            34,
+            0.23606557377049175
+        ],
+        [
+            67,
+            35,
+            0.21967213114754103
+        ],
+        [
+            67,
+            36,
+            0.21803278688524586
+        ],
+        [
+            67,
+            37,
+            0.2213114754098361
+        ],
+        [
+            67,
+            38,
+            0.23114754098360657
+        ],
+        [
+            67,
+            39,
+            0.2213114754098361
+        ],
+        [
+            67,
+            40,
+            0.21967213114754103
+        ],
+        [
+            67,
+            41,
+            0.2344262295081967
+        ],
+        [
+            67,
+            42,
+            0.23770491803278693
+        ],
+        [
+            67,
+            43,
+            0.2344262295081967
+        ],
+        [
+            67,
+            44,
+            0.2344262295081967
+        ],
+        [
+            67,
+            45,
+            0.23114754098360657
+        ],
+        [
+            67,
+            46,
+            0.21967213114754103
+        ],
+        [
+            67,
+            47,
+            0.25901639344262295
+        ],
+        [
+            67,
+            48,
+            0.21967213114754103
+        ],
+        [
+            67,
+            49,
+            0.22295081967213115
+        ],
+        [
+            67,
+            50,
+            0.2213114754098361
+        ],
+        [
+            67,
+            51,
+            0.2344262295081967
+        ],
+        [
+            67,
+            52,
+            0.24098360655737705
+        ],
+        [
+            67,
+            53,
+            0.9065573770491804
+        ],
+        [
+            67,
+            54,
+            0.9704918032786886
+        ],
+        [
+            67,
+            55,
+            0.9540983606557377
+        ],
+        [
+            67,
+            56,
+            0.9540983606557377
+        ],
+        [
+            67,
+            57,
+            0.9606557377049181
+        ],
+        [
+            67,
+            58,
+            0.8934426229508197
+        ],
+        [
+            67,
+            59,
+            0.8065573770491803
+        ],
+        [
+            67,
+            60,
+            0.9721311475409836
+        ],
+        [
+            67,
+            61,
+            0.9885245901639345
+        ],
+        [
+            67,
+            62,
+            0.8049180327868852
+        ],
+        [
+            67,
+            63,
+            0.8081967213114754
+        ],
+        [
+            67,
+            64,
+            0.9836065573770492
+        ],
+        [
+            67,
+            65,
+            0.9819672131147541
+        ],
+        [
+            67,
+            66,
+            0.9295081967213115
+        ],
+        [
+            67,
             67,
             1.0
         ],
         [
-            121,
+            67,
+            68,
+            0.9147540983606557
+        ],
+        [
+            67,
+            69,
+            0.3327868852459016
+        ],
+        [
+            67,
+            70,
+            0.3327868852459016
+        ],
+        [
+            67,
+            71,
+            0.3295081967213115
+        ],
+        [
+            67,
+            72,
+            0.33934426229508197
+        ],
+        [
+            67,
+            73,
+            0.919672131147541
+        ],
+        [
+            67,
+            74,
+            0.34098360655737703
+        ],
+        [
+            67,
+            75,
+            0.6885245901639344
+        ],
+        [
+            68,
+            0,
+            0.8901639344262295
+        ],
+        [
+            68,
+            1,
+            0.7114754098360656
+        ],
+        [
+            68,
+            2,
+            0.139344262295082
+        ],
+        [
+            68,
+            3,
+            0.139344262295082
+        ],
+        [
+            68,
+            4,
+            0.7114754098360656
+        ],
+        [
+            68,
+            5,
+            0.139344262295082
+        ],
+        [
+            68,
+            6,
+            0.20819672131147537
+        ],
+        [
+            68,
+            7,
+            0.139344262295082
+        ],
+        [
+            68,
+            8,
+            0.7114754098360656
+        ],
+        [
+            68,
+            9,
+            0.7032786885245902
+        ],
+        [
+            68,
+            10,
+            0.139344262295082
+        ],
+        [
+            68,
+            11,
+            0.139344262295082
+        ],
+        [
+            68,
+            12,
+            0.7032786885245902
+        ],
+        [
+            68,
+            13,
+            0.139344262295082
+        ],
+        [
+            68,
+            14,
+            0.139344262295082
+        ],
+        [
+            68,
+            15,
+            0.7114754098360656
+        ],
+        [
+            68,
+            16,
+            0.139344262295082
+        ],
+        [
+            68,
+            17,
+            0.21803278688524586
+        ],
+        [
+            68,
+            18,
+            0.15081967213114755
+        ],
+        [
+            68,
+            19,
+            0.14098360655737707
+        ],
+        [
+            68,
+            20,
+            0.1573770491803279
+        ],
+        [
+            68,
+            21,
+            0.15573770491803274
+        ],
+        [
+            68,
+            22,
+            0.1573770491803279
+        ],
+        [
+            68,
+            23,
+            0.1573770491803279
+        ],
+        [
+            68,
+            24,
+            0.14590163934426226
+        ],
+        [
+            68,
+            25,
+            0.16885245901639345
+        ],
+        [
+            68,
+            26,
+            0.14590163934426226
+        ],
+        [
+            68,
+            27,
+            0.15573770491803274
+        ],
+        [
+            68,
+            28,
+            0.15573770491803274
+        ],
+        [
+            68,
+            29,
+            0.14754098360655743
+        ],
+        [
+            68,
+            30,
+            0.15573770491803274
+        ],
+        [
+            68,
+            31,
+            0.15409836065573768
+        ],
+        [
+            68,
+            32,
+            0.14590163934426226
+        ],
+        [
+            68,
+            33,
+            0.15901639344262297
+        ],
+        [
+            68,
+            34,
+            0.16393442622950816
+        ],
+        [
+            68,
+            35,
+            0.14754098360655743
+        ],
+        [
+            68,
+            36,
+            0.14590163934426226
+        ],
+        [
+            68,
+            37,
+            0.1491803278688525
+        ],
+        [
+            68,
+            38,
+            0.15573770491803274
+        ],
+        [
+            68,
+            39,
+            0.1491803278688525
+        ],
+        [
+            68,
+            40,
+            0.14754098360655743
+        ],
+        [
+            68,
+            41,
+            0.15901639344262297
+        ],
+        [
+            68,
+            42,
+            0.1622950819672131
+        ],
+        [
+            68,
+            43,
+            0.15901639344262297
+        ],
+        [
+            68,
+            44,
+            0.1622950819672131
+        ],
+        [
+            68,
+            45,
+            0.15573770491803274
+        ],
+        [
+            68,
+            46,
+            0.14754098360655743
+        ],
+        [
+            68,
+            47,
+            0.18360655737704923
+        ],
+        [
+            68,
+            48,
+            0.14754098360655743
+        ],
+        [
+            68,
+            49,
+            0.15081967213114755
+        ],
+        [
+            68,
+            50,
+            0.1491803278688525
+        ],
+        [
+            68,
+            51,
+            0.15901639344262297
+        ],
+        [
+            68,
+            52,
+            0.16885245901639345
+        ],
+        [
+            68,
+            53,
+            0.8737704918032787
+        ],
+        [
+            68,
+            54,
+            0.9081967213114754
+        ],
+        [
+            68,
+            55,
+            0.9114754098360656
+        ],
+        [
+            68,
+            56,
+            0.9344262295081968
+        ],
+        [
+            68,
+            57,
+            0.8918032786885246
+        ],
+        [
+            68,
+            58,
+            0.8901639344262295
+        ],
+        [
+            68,
+            59,
+            0.8557377049180328
+        ],
+        [
+            68,
+            60,
+            0.9131147540983606
+        ],
+        [
+            68,
+            61,
+            0.9131147540983606
+        ],
+        [
+            68,
+            62,
+            0.8573770491803279
+        ],
+        [
+            68,
+            63,
+            0.8573770491803279
+        ],
+        [
+            68,
+            64,
+            0.9114754098360656
+        ],
+        [
+            68,
+            65,
+            0.9098360655737705
+        ],
+        [
+            68,
+            66,
+            0.8934426229508197
+        ],
+        [
+            68,
+            67,
+            0.9147540983606557
+        ],
+        [
+            68,
+            68,
+            1.0
+        ],
+        [
+            68,
+            69,
+            0.2967213114754098
+        ],
+        [
+            68,
+            70,
+            0.2967213114754098
+        ],
+        [
+            68,
+            71,
+            0.2934426229508197
+        ],
+        [
+            68,
+            72,
+            0.35245901639344257
+        ],
+        [
+            68,
+            73,
+            0.8836065573770492
+        ],
+        [
+            68,
+            74,
+            0.30491803278688523
+        ],
+        [
+            68,
+            75,
+            0.7737704918032787
+        ],
+        [
+            69,
+            0,
+            0.18688524590163935
+        ],
+        [
+            69,
+            1,
+            0.008196721311475419
+        ],
+        [
+            69,
+            2,
+            0.760655737704918
+        ],
+        [
+            69,
+            3,
+            0.760655737704918
+        ],
+        [
+            69,
+            4,
+            0.008196721311475419
+        ],
+        [
+            69,
+            5,
+            0.760655737704918
+        ],
+        [
+            69,
+            6,
+            0.6918032786885246
+        ],
+        [
+            69,
+            7,
+            0.760655737704918
+        ],
+        [
+            69,
+            8,
+            0.008196721311475419
+        ],
+        [
+            69,
+            9,
+            0.01967213114754096
+        ],
+        [
+            69,
+            10,
+            0.760655737704918
+        ],
+        [
+            69,
+            11,
+            0.760655737704918
+        ],
+        [
+            69,
+            12,
+            0.01967213114754096
+        ],
+        [
+            69,
+            13,
+            0.760655737704918
+        ],
+        [
+            69,
+            14,
+            0.760655737704918
+        ],
+        [
+            69,
+            15,
+            0.008196721311475419
+        ],
+        [
+            69,
+            16,
+            0.760655737704918
+        ],
+        [
+            69,
+            17,
+            0.6786885245901639
+        ],
+        [
+            69,
+            18,
+            0.7459016393442623
+        ],
+        [
+            69,
+            19,
+            0.7622950819672132
+        ],
+        [
+            69,
+            20,
+            0.7459016393442623
+        ],
+        [
+            69,
+            21,
+            0.7475409836065574
+        ],
+        [
+            69,
+            22,
+            0.7459016393442623
+        ],
+        [
+            69,
+            23,
+            0.7459016393442623
+        ],
+        [
+            69,
+            24,
+            0.760655737704918
+        ],
+        [
+            69,
+            25,
+            0.7278688524590164
+        ],
+        [
+            69,
+            26,
+            0.760655737704918
+        ],
+        [
+            69,
+            27,
+            0.7475409836065574
+        ],
+        [
+            69,
+            28,
+            0.7475409836065574
+        ],
+        [
+            69,
+            29,
+            0.759016393442623
+        ],
+        [
+            69,
+            30,
+            0.7475409836065574
+        ],
+        [
+            69,
+            31,
+            0.7491803278688525
+        ],
+        [
+            69,
+            32,
+            0.760655737704918
+        ],
+        [
+            69,
+            33,
+            0.7442622950819673
+        ],
+        [
+            69,
+            34,
+            0.7426229508196721
+        ],
+        [
+            69,
+            35,
+            0.7622950819672132
+        ],
+        [
+            69,
+            36,
+            0.7573770491803279
+        ],
+        [
+            69,
+            37,
+            0.7573770491803279
+        ],
+        [
+            69,
+            38,
+            0.7508196721311475
+        ],
+        [
+            69,
+            39,
+            0.7540983606557377
+        ],
+        [
+            69,
+            40,
+            0.7622950819672132
+        ],
+        [
+            69,
+            41,
+            0.7475409836065574
+        ],
+        [
+            69,
+            42,
+            0.7442622950819673
+        ],
+        [
+            69,
+            43,
+            0.7475409836065574
+        ],
+        [
+            69,
+            44,
+            0.7475409836065574
+        ],
+        [
+            69,
+            45,
+            0.7508196721311475
+        ],
+        [
+            69,
+            46,
+            0.759016393442623
+        ],
+        [
+            69,
+            47,
+            0.7163934426229508
+        ],
+        [
+            69,
+            48,
+            0.7557377049180328
+        ],
+        [
+            69,
+            49,
+            0.759016393442623
+        ],
+        [
+            69,
+            50,
+            0.7573770491803279
+        ],
+        [
+            69,
+            51,
+            0.7442622950819673
+        ],
+        [
+            69,
+            52,
+            0.7377049180327868
+        ],
+        [
+            69,
+            53,
+            0.24918032786885247
+        ],
+        [
+            69,
+            54,
+            0.3295081967213115
+        ],
+        [
+            69,
+            55,
+            0.33934426229508197
+        ],
+        [
+            69,
+            56,
+            0.3426229508196721
+        ],
+        [
+            69,
+            57,
+            0.3688524590163934
+        ],
+        [
+            69,
+            58,
+            0.2754098360655738
+        ],
+        [
+            69,
+            59,
+            0.2344262295081967
+        ],
+        [
+            69,
+            60,
+            0.3245901639344262
+        ],
+        [
+            69,
+            61,
+            0.34098360655737703
+        ],
+        [
+            69,
+            62,
+            0.23606557377049175
+        ],
+        [
+            69,
+            63,
+            0.23606557377049175
+        ],
+        [
+            69,
+            64,
+            0.33934426229508197
+        ],
+        [
+            69,
+            65,
+            0.34098360655737703
+        ],
+        [
+            69,
+            66,
+            0.34426229508196726
+        ],
+        [
+            69,
+            67,
+            0.3327868852459016
+        ],
+        [
+            69,
+            68,
+            0.2967213114754098
+        ],
+        [
+            69,
             69,
             1.0
         ],
         [
-            121,
+            69,
             70,
             1.0
         ],
         [
-            121,
+            69,
+            71,
+            0.9967213114754099
+        ],
+        [
+            69,
+            72,
+            0.9442622950819672
+        ],
+        [
+            69,
+            73,
+            0.3967213114754098
+        ],
+        [
+            69,
+            74,
+            0.9885245901639345
+        ],
+        [
+            69,
+            75,
+            0.37213114754098364
+        ],
+        [
+            70,
+            0,
+            0.18688524590163935
+        ],
+        [
+            70,
+            1,
+            0.008196721311475419
+        ],
+        [
+            70,
+            2,
+            0.760655737704918
+        ],
+        [
+            70,
+            3,
+            0.760655737704918
+        ],
+        [
+            70,
+            4,
+            0.008196721311475419
+        ],
+        [
+            70,
+            5,
+            0.760655737704918
+        ],
+        [
+            70,
+            6,
+            0.6918032786885246
+        ],
+        [
+            70,
+            7,
+            0.760655737704918
+        ],
+        [
+            70,
+            8,
+            0.008196721311475419
+        ],
+        [
+            70,
+            9,
+            0.01967213114754096
+        ],
+        [
+            70,
+            10,
+            0.760655737704918
+        ],
+        [
+            70,
+            11,
+            0.760655737704918
+        ],
+        [
+            70,
+            12,
+            0.01967213114754096
+        ],
+        [
+            70,
+            13,
+            0.760655737704918
+        ],
+        [
+            70,
+            14,
+            0.760655737704918
+        ],
+        [
+            70,
+            15,
+            0.008196721311475419
+        ],
+        [
+            70,
+            16,
+            0.760655737704918
+        ],
+        [
+            70,
+            17,
+            0.6786885245901639
+        ],
+        [
+            70,
+            18,
+            0.7459016393442623
+        ],
+        [
+            70,
+            19,
+            0.7622950819672132
+        ],
+        [
+            70,
+            20,
+            0.7459016393442623
+        ],
+        [
+            70,
+            21,
+            0.7475409836065574
+        ],
+        [
+            70,
+            22,
+            0.7459016393442623
+        ],
+        [
+            70,
+            23,
+            0.7459016393442623
+        ],
+        [
+            70,
+            24,
+            0.760655737704918
+        ],
+        [
+            70,
+            25,
+            0.7278688524590164
+        ],
+        [
+            70,
+            26,
+            0.760655737704918
+        ],
+        [
+            70,
+            27,
+            0.7475409836065574
+        ],
+        [
+            70,
+            28,
+            0.7475409836065574
+        ],
+        [
+            70,
+            29,
+            0.759016393442623
+        ],
+        [
+            70,
+            30,
+            0.7475409836065574
+        ],
+        [
+            70,
+            31,
+            0.7491803278688525
+        ],
+        [
+            70,
+            32,
+            0.760655737704918
+        ],
+        [
+            70,
+            33,
+            0.7442622950819673
+        ],
+        [
+            70,
+            34,
+            0.7426229508196721
+        ],
+        [
+            70,
+            35,
+            0.7622950819672132
+        ],
+        [
+            70,
+            36,
+            0.7573770491803279
+        ],
+        [
+            70,
+            37,
+            0.7573770491803279
+        ],
+        [
+            70,
+            38,
+            0.7508196721311475
+        ],
+        [
+            70,
+            39,
+            0.7540983606557377
+        ],
+        [
+            70,
+            40,
+            0.7622950819672132
+        ],
+        [
+            70,
+            41,
+            0.7475409836065574
+        ],
+        [
+            70,
+            42,
+            0.7442622950819673
+        ],
+        [
+            70,
+            43,
+            0.7475409836065574
+        ],
+        [
+            70,
+            44,
+            0.7475409836065574
+        ],
+        [
+            70,
+            45,
+            0.7508196721311475
+        ],
+        [
+            70,
+            46,
+            0.759016393442623
+        ],
+        [
+            70,
+            47,
+            0.7163934426229508
+        ],
+        [
+            70,
+            48,
+            0.7557377049180328
+        ],
+        [
+            70,
+            49,
+            0.759016393442623
+        ],
+        [
+            70,
+            50,
+            0.7573770491803279
+        ],
+        [
+            70,
+            51,
+            0.7442622950819673
+        ],
+        [
+            70,
+            52,
+            0.7377049180327868
+        ],
+        [
+            70,
+            53,
+            0.24918032786885247
+        ],
+        [
+            70,
+            54,
+            0.3295081967213115
+        ],
+        [
+            70,
+            55,
+            0.33934426229508197
+        ],
+        [
+            70,
+            56,
+            0.3426229508196721
+        ],
+        [
+            70,
+            57,
+            0.3688524590163934
+        ],
+        [
+            70,
+            58,
+            0.2754098360655738
+        ],
+        [
+            70,
+            59,
+            0.2344262295081967
+        ],
+        [
+            70,
+            60,
+            0.3245901639344262
+        ],
+        [
+            70,
+            61,
+            0.34098360655737703
+        ],
+        [
+            70,
+            62,
+            0.23606557377049175
+        ],
+        [
+            70,
+            63,
+            0.23606557377049175
+        ],
+        [
+            70,
+            64,
+            0.33934426229508197
+        ],
+        [
+            70,
+            65,
+            0.34098360655737703
+        ],
+        [
+            70,
+            66,
+            0.34426229508196726
+        ],
+        [
+            70,
+            67,
+            0.3327868852459016
+        ],
+        [
+            70,
+            68,
+            0.2967213114754098
+        ],
+        [
+            70,
+            69,
+            1.0
+        ],
+        [
+            70,
+            70,
+            1.0
+        ],
+        [
+            70,
+            71,
+            0.9967213114754099
+        ],
+        [
+            70,
+            72,
+            0.9442622950819672
+        ],
+        [
+            70,
+            73,
+            0.3967213114754098
+        ],
+        [
+            70,
+            74,
+            0.9885245901639345
+        ],
+        [
+            70,
+            75,
+            0.37213114754098364
+        ],
+        [
+            71,
+            0,
+            0.18360655737704923
+        ],
+        [
+            71,
+            1,
+            0.004918032786885296
+        ],
+        [
+            71,
+            2,
+            0.7573770491803279
+        ],
+        [
+            71,
+            3,
+            0.7573770491803279
+        ],
+        [
+            71,
+            4,
+            0.004918032786885296
+        ],
+        [
+            71,
+            5,
+            0.7573770491803279
+        ],
+        [
+            71,
+            6,
+            0.6885245901639344
+        ],
+        [
+            71,
+            7,
+            0.7573770491803279
+        ],
+        [
+            71,
+            8,
+            0.004918032786885296
+        ],
+        [
+            71,
+            9,
+            0.016393442622950838
+        ],
+        [
+            71,
+            10,
+            0.7573770491803279
+        ],
+        [
+            71,
+            11,
+            0.7573770491803279
+        ],
+        [
+            71,
+            12,
+            0.016393442622950838
+        ],
+        [
+            71,
+            13,
+            0.7573770491803279
+        ],
+        [
+            71,
+            14,
+            0.7573770491803279
+        ],
+        [
+            71,
+            15,
+            0.004918032786885296
+        ],
+        [
+            71,
+            16,
+            0.7573770491803279
+        ],
+        [
+            71,
+            17,
+            0.6754098360655738
+        ],
+        [
+            71,
+            18,
+            0.7426229508196721
+        ],
+        [
+            71,
+            19,
+            0.759016393442623
+        ],
+        [
+            71,
+            20,
+            0.7426229508196721
+        ],
+        [
+            71,
+            21,
+            0.7442622950819673
+        ],
+        [
+            71,
+            22,
+            0.7426229508196721
+        ],
+        [
+            71,
+            23,
+            0.7426229508196721
+        ],
+        [
+            71,
+            24,
+            0.7573770491803279
+        ],
+        [
+            71,
+            25,
+            0.7245901639344262
+        ],
+        [
+            71,
+            26,
+            0.7573770491803279
+        ],
+        [
+            71,
+            27,
+            0.7442622950819673
+        ],
+        [
+            71,
+            28,
+            0.7442622950819673
+        ],
+        [
+            71,
+            29,
+            0.7557377049180328
+        ],
+        [
+            71,
+            30,
+            0.7442622950819673
+        ],
+        [
+            71,
+            31,
+            0.7459016393442623
+        ],
+        [
+            71,
+            32,
+            0.7573770491803279
+        ],
+        [
+            71,
+            33,
+            0.740983606557377
+        ],
+        [
+            71,
+            34,
+            0.739344262295082
+        ],
+        [
+            71,
+            35,
+            0.759016393442623
+        ],
+        [
+            71,
+            36,
+            0.7573770491803279
+        ],
+        [
+            71,
+            37,
+            0.7573770491803279
+        ],
+        [
+            71,
+            38,
+            0.7475409836065574
+        ],
+        [
+            71,
+            39,
+            0.7540983606557377
+        ],
+        [
+            71,
+            40,
+            0.759016393442623
+        ],
+        [
+            71,
+            41,
+            0.7442622950819673
+        ],
+        [
+            71,
+            42,
+            0.740983606557377
+        ],
+        [
+            71,
+            43,
+            0.7442622950819673
+        ],
+        [
+            71,
+            44,
+            0.7442622950819673
+        ],
+        [
+            71,
+            45,
+            0.7475409836065574
+        ],
+        [
+            71,
+            46,
+            0.759016393442623
+        ],
+        [
+            71,
+            47,
+            0.7131147540983607
+        ],
+        [
+            71,
+            48,
+            0.7557377049180328
+        ],
+        [
+            71,
+            49,
+            0.7557377049180328
+        ],
+        [
+            71,
+            50,
+            0.7573770491803279
+        ],
+        [
+            71,
+            51,
+            0.7442622950819673
+        ],
+        [
+            71,
+            52,
+            0.7344262295081967
+        ],
+        [
+            71,
+            53,
+            0.24590163934426235
+        ],
+        [
+            71,
+            54,
+            0.32622950819672136
+        ],
+        [
+            71,
+            55,
+            0.33606557377049184
+        ],
+        [
+            71,
+            56,
+            0.33934426229508197
+        ],
+        [
+            71,
+            57,
+            0.3655737704918033
+        ],
+        [
+            71,
+            58,
+            0.27213114754098355
+        ],
+        [
+            71,
+            59,
+            0.23114754098360657
+        ],
+        [
+            71,
+            60,
+            0.32131147540983607
+        ],
+        [
+            71,
+            61,
+            0.3377049180327869
+        ],
+        [
+            71,
+            62,
+            0.23278688524590163
+        ],
+        [
+            71,
+            63,
+            0.23278688524590163
+        ],
+        [
+            71,
+            64,
+            0.33606557377049184
+        ],
+        [
+            71,
+            65,
+            0.3377049180327869
+        ],
+        [
+            71,
+            66,
+            0.34098360655737703
+        ],
+        [
+            71,
+            67,
+            0.3295081967213115
+        ],
+        [
+            71,
+            68,
+            0.2934426229508197
+        ],
+        [
+            71,
+            69,
+            0.9967213114754099
+        ],
+        [
+            71,
+            70,
+            0.9967213114754099
+        ],
+        [
+            71,
             71,
             1.0
         ],
         [
-            121,
+            71,
+            72,
+            0.940983606557377
+        ],
+        [
+            71,
+            73,
+            0.39344262295081966
+        ],
+        [
+            71,
+            74,
+            0.9852459016393442
+        ],
+        [
+            71,
+            75,
+            0.3688524590163934
+        ],
+        [
+            72,
+            0,
+            0.2426229508196721
+        ],
+        [
+            72,
+            1,
+            0.06393442622950818
+        ],
+        [
+            72,
+            2,
+            0.7049180327868853
+        ],
+        [
+            72,
+            3,
+            0.7049180327868853
+        ],
+        [
+            72,
+            4,
+            0.06393442622950818
+        ],
+        [
+            72,
+            5,
+            0.7049180327868853
+        ],
+        [
+            72,
+            6,
+            0.7475409836065574
+        ],
+        [
+            72,
+            7,
+            0.7049180327868853
+        ],
+        [
+            72,
+            8,
+            0.06393442622950818
+        ],
+        [
+            72,
+            9,
+            0.07540983606557372
+        ],
+        [
+            72,
+            10,
+            0.7049180327868853
+        ],
+        [
+            72,
+            11,
+            0.7049180327868853
+        ],
+        [
+            72,
+            12,
+            0.07540983606557372
+        ],
+        [
+            72,
+            13,
+            0.7049180327868853
+        ],
+        [
+            72,
+            14,
+            0.7049180327868853
+        ],
+        [
+            72,
+            15,
+            0.06393442622950818
+        ],
+        [
+            72,
+            16,
+            0.7049180327868853
+        ],
+        [
+            72,
+            17,
+            0.7344262295081967
+        ],
+        [
+            72,
+            18,
+            0.6901639344262296
+        ],
+        [
+            72,
+            19,
+            0.7065573770491803
+        ],
+        [
+            72,
+            20,
+            0.6901639344262296
+        ],
+        [
+            72,
+            21,
+            0.6918032786885246
+        ],
+        [
+            72,
+            22,
+            0.6901639344262296
+        ],
+        [
+            72,
+            23,
+            0.6901639344262296
+        ],
+        [
+            72,
+            24,
+            0.7049180327868853
+        ],
+        [
+            72,
+            25,
+            0.6721311475409837
+        ],
+        [
+            72,
+            26,
+            0.7049180327868853
+        ],
+        [
+            72,
+            27,
+            0.6918032786885246
+        ],
+        [
+            72,
+            28,
+            0.6918032786885246
+        ],
+        [
+            72,
+            29,
+            0.7032786885245902
+        ],
+        [
+            72,
+            30,
+            0.6918032786885246
+        ],
+        [
+            72,
+            31,
+            0.6934426229508197
+        ],
+        [
+            72,
+            32,
+            0.7049180327868853
+        ],
+        [
+            72,
+            33,
+            0.6885245901639344
+        ],
+        [
+            72,
+            34,
+            0.6868852459016394
+        ],
+        [
+            72,
+            35,
+            0.7065573770491803
+        ],
+        [
+            72,
+            36,
+            0.701639344262295
+        ],
+        [
+            72,
+            37,
+            0.701639344262295
+        ],
+        [
+            72,
+            38,
+            0.6950819672131148
+        ],
+        [
+            72,
+            39,
+            0.6983606557377049
+        ],
+        [
+            72,
+            40,
+            0.7065573770491803
+        ],
+        [
+            72,
+            41,
+            0.6918032786885246
+        ],
+        [
+            72,
+            42,
+            0.6885245901639344
+        ],
+        [
+            72,
+            43,
+            0.6918032786885246
+        ],
+        [
+            72,
+            44,
+            0.6918032786885246
+        ],
+        [
+            72,
+            45,
+            0.6950819672131148
+        ],
+        [
+            72,
+            46,
+            0.7032786885245902
+        ],
+        [
+            72,
+            47,
+            0.660655737704918
+        ],
+        [
+            72,
+            48,
+            0.7
+        ],
+        [
+            72,
+            49,
+            0.7032786885245902
+        ],
+        [
+            72,
+            50,
+            0.701639344262295
+        ],
+        [
+            72,
+            51,
+            0.6885245901639344
+        ],
+        [
+            72,
+            52,
+            0.6819672131147541
+        ],
+        [
+            72,
+            53,
+            0.27213114754098355
+        ],
+        [
+            72,
+            54,
+            0.3426229508196721
+        ],
+        [
+            72,
+            55,
+            0.3590163934426229
+        ],
+        [
+            72,
+            56,
+            0.37540983606557377
+        ],
+        [
+            72,
+            57,
+            0.37540983606557377
+        ],
+        [
+            72,
+            58,
+            0.30819672131147546
+        ],
+        [
+            72,
+            59,
+            0.29016393442622945
+        ],
+        [
+            72,
+            60,
+            0.34098360655737703
+        ],
+        [
+            72,
+            61,
+            0.3475409836065574
+        ],
+        [
+            72,
+            62,
+            0.2918032786885246
+        ],
+        [
+            72,
+            63,
+            0.2918032786885246
+        ],
+        [
+            72,
+            64,
+            0.3459016393442623
+        ],
+        [
+            72,
+            65,
+            0.3475409836065574
+        ],
+        [
+            72,
+            66,
+            0.35409836065573774
+        ],
+        [
+            72,
+            67,
+            0.33934426229508197
+        ],
+        [
+            72,
+            68,
+            0.35245901639344257
+        ],
+        [
+            72,
+            69,
+            0.9442622950819672
+        ],
+        [
+            72,
+            70,
+            0.9442622950819672
+        ],
+        [
+            72,
+            71,
+            0.940983606557377
+        ],
+        [
+            72,
             72,
             1.0
         ],
         [
-            121,
-            112,
+            72,
+            73,
+            0.40327868852459015
+        ],
+        [
+            72,
+            74,
+            0.9327868852459016
+        ],
+        [
+            72,
+            75,
+            0.4278688524590164
+        ],
+        [
+            73,
+            0,
+            0.7901639344262295
+        ],
+        [
+            73,
+            1,
+            0.6114754098360655
+        ],
+        [
+            73,
+            2,
+            0.1573770491803279
+        ],
+        [
+            73,
+            3,
+            0.1573770491803279
+        ],
+        [
+            73,
+            4,
+            0.6114754098360655
+        ],
+        [
+            73,
+            5,
+            0.1573770491803279
+        ],
+        [
+            73,
+            6,
+            0.17377049180327864
+        ],
+        [
+            73,
+            7,
+            0.1573770491803279
+        ],
+        [
+            73,
+            8,
+            0.6114754098360655
+        ],
+        [
+            73,
+            9,
+            0.6032786885245902
+        ],
+        [
+            73,
+            10,
+            0.1573770491803279
+        ],
+        [
+            73,
+            11,
+            0.1573770491803279
+        ],
+        [
+            73,
+            12,
+            0.6032786885245902
+        ],
+        [
+            73,
+            13,
+            0.1573770491803279
+        ],
+        [
+            73,
+            14,
+            0.1573770491803279
+        ],
+        [
+            73,
+            15,
+            0.6114754098360655
+        ],
+        [
+            73,
+            16,
+            0.1573770491803279
+        ],
+        [
+            73,
+            17,
+            0.18360655737704923
+        ],
+        [
+            73,
+            18,
+            0.16885245901639345
+        ],
+        [
+            73,
+            19,
+            0.15901639344262297
+        ],
+        [
+            73,
+            20,
+            0.1754098360655738
+        ],
+        [
+            73,
+            21,
+            0.17377049180327864
+        ],
+        [
+            73,
+            22,
+            0.1754098360655738
+        ],
+        [
+            73,
+            23,
+            0.1754098360655738
+        ],
+        [
+            73,
+            24,
+            0.16393442622950816
+        ],
+        [
+            73,
+            25,
+            0.18360655737704923
+        ],
+        [
+            73,
+            26,
+            0.16393442622950816
+        ],
+        [
+            73,
+            27,
+            0.17377049180327864
+        ],
+        [
+            73,
+            28,
+            0.17377049180327864
+        ],
+        [
+            73,
+            29,
+            0.16557377049180333
+        ],
+        [
+            73,
+            30,
+            0.17377049180327864
+        ],
+        [
+            73,
+            31,
+            0.17213114754098358
+        ],
+        [
+            73,
+            32,
+            0.16393442622950816
+        ],
+        [
+            73,
+            33,
+            0.17377049180327864
+        ],
+        [
+            73,
+            34,
+            0.17868852459016393
+        ],
+        [
+            73,
+            35,
+            0.16557377049180333
+        ],
+        [
+            73,
+            36,
+            0.16393442622950816
+        ],
+        [
+            73,
+            37,
+            0.1672131147540984
+        ],
+        [
+            73,
+            38,
+            0.17377049180327864
+        ],
+        [
+            73,
+            39,
+            0.16393442622950816
+        ],
+        [
+            73,
+            40,
+            0.16557377049180333
+        ],
+        [
+            73,
+            41,
+            0.17704918032786887
+        ],
+        [
+            73,
+            42,
+            0.180327868852459
+        ],
+        [
+            73,
+            43,
+            0.17704918032786887
+        ],
+        [
+            73,
+            44,
+            0.17704918032786887
+        ],
+        [
+            73,
+            45,
+            0.17377049180327864
+        ],
+        [
+            73,
+            46,
+            0.16557377049180333
+        ],
+        [
+            73,
+            47,
+            0.1983606557377049
+        ],
+        [
+            73,
+            48,
+            0.16557377049180333
+        ],
+        [
+            73,
+            49,
+            0.16885245901639345
+        ],
+        [
+            73,
+            50,
+            0.1672131147540984
+        ],
+        [
+            73,
+            51,
+            0.17704918032786887
+        ],
+        [
+            73,
+            52,
+            0.18360655737704923
+        ],
+        [
+            73,
+            53,
+            0.8360655737704918
+        ],
+        [
+            73,
+            54,
+            0.9163934426229509
+        ],
+        [
+            73,
+            55,
+            0.9262295081967213
+        ],
+        [
+            73,
+            56,
+            0.9295081967213115
+        ],
+        [
+            73,
+            57,
+            0.9557377049180328
+        ],
+        [
+            73,
+            58,
+            0.8754098360655738
+        ],
+        [
+            73,
+            59,
+            0.8377049180327869
+        ],
+        [
+            73,
+            60,
+            0.9114754098360656
+        ],
+        [
+            73,
+            61,
+            0.9278688524590164
+        ],
+        [
+            73,
+            62,
+            0.839344262295082
+        ],
+        [
+            73,
+            63,
+            0.839344262295082
+        ],
+        [
+            73,
+            64,
+            0.9262295081967213
+        ],
+        [
+            73,
+            65,
+            0.9278688524590164
+        ],
+        [
+            73,
+            66,
+            0.9344262295081968
+        ],
+        [
+            73,
+            67,
+            0.919672131147541
+        ],
+        [
+            73,
+            68,
+            0.8836065573770492
+        ],
+        [
+            73,
+            69,
+            0.3967213114754098
+        ],
+        [
+            73,
+            70,
+            0.3967213114754098
+        ],
+        [
+            73,
+            71,
+            0.39344262295081966
+        ],
+        [
+            73,
+            72,
+            0.40327868852459015
+        ],
+        [
+            73,
+            73,
             1.0
         ],
         [
-            121,
-            121,
+            73,
+            74,
+            0.4049180327868852
+        ],
+        [
+            73,
+            75,
+            0.7491803278688525
+        ],
+        [
+            74,
+            0,
+            0.1983606557377049
+        ],
+        [
+            74,
+            1,
+            0.01967213114754096
+        ],
+        [
+            74,
+            2,
+            0.7491803278688525
+        ],
+        [
+            74,
+            3,
+            0.7491803278688525
+        ],
+        [
+            74,
+            4,
+            0.01967213114754096
+        ],
+        [
+            74,
+            5,
+            0.7491803278688525
+        ],
+        [
+            74,
+            6,
+            0.680327868852459
+        ],
+        [
+            74,
+            7,
+            0.7491803278688525
+        ],
+        [
+            74,
+            8,
+            0.01967213114754096
+        ],
+        [
+            74,
+            9,
+            0.008196721311475419
+        ],
+        [
+            74,
+            10,
+            0.7491803278688525
+        ],
+        [
+            74,
+            11,
+            0.7491803278688525
+        ],
+        [
+            74,
+            12,
+            0.008196721311475419
+        ],
+        [
+            74,
+            13,
+            0.7491803278688525
+        ],
+        [
+            74,
+            14,
+            0.7491803278688525
+        ],
+        [
+            74,
+            15,
+            0.01967213114754096
+        ],
+        [
+            74,
+            16,
+            0.7491803278688525
+        ],
+        [
+            74,
+            17,
+            0.6672131147540983
+        ],
+        [
+            74,
+            18,
+            0.7377049180327868
+        ],
+        [
+            74,
+            19,
+            0.7508196721311475
+        ],
+        [
+            74,
+            20,
+            0.7442622950819673
+        ],
+        [
+            74,
+            21,
+            0.7426229508196721
+        ],
+        [
+            74,
+            22,
+            0.7442622950819673
+        ],
+        [
+            74,
+            23,
+            0.7442622950819673
+        ],
+        [
+            74,
+            24,
+            0.7557377049180328
+        ],
+        [
+            74,
+            25,
+            0.7262295081967214
+        ],
+        [
+            74,
+            26,
+            0.7557377049180328
+        ],
+        [
+            74,
+            27,
+            0.7426229508196721
+        ],
+        [
+            74,
+            28,
+            0.7426229508196721
+        ],
+        [
+            74,
+            29,
+            0.7573770491803279
+        ],
+        [
+            74,
+            30,
+            0.7426229508196721
+        ],
+        [
+            74,
+            31,
+            0.740983606557377
+        ],
+        [
+            74,
+            32,
+            0.7557377049180328
+        ],
+        [
+            74,
+            33,
+            0.7426229508196721
+        ],
+        [
+            74,
+            34,
+            0.740983606557377
+        ],
+        [
+            74,
+            35,
+            0.7573770491803279
+        ],
+        [
+            74,
+            36,
+            0.7557377049180328
+        ],
+        [
+            74,
+            37,
+            0.759016393442623
+        ],
+        [
+            74,
+            38,
+            0.7524590163934426
+        ],
+        [
+            74,
+            39,
+            0.7557377049180328
+        ],
+        [
+            74,
+            40,
+            0.7573770491803279
+        ],
+        [
+            74,
+            41,
+            0.7459016393442623
+        ],
+        [
+            74,
+            42,
+            0.7426229508196721
+        ],
+        [
+            74,
+            43,
+            0.7459016393442623
+        ],
+        [
+            74,
+            44,
+            0.7459016393442623
+        ],
+        [
+            74,
+            45,
+            0.7524590163934426
+        ],
+        [
+            74,
+            46,
+            0.7573770491803279
+        ],
+        [
+            74,
+            47,
+            0.7180327868852459
+        ],
+        [
+            74,
+            48,
+            0.7573770491803279
+        ],
+        [
+            74,
+            49,
+            0.760655737704918
+        ],
+        [
+            74,
+            50,
+            0.759016393442623
+        ],
+        [
+            74,
+            51,
+            0.7459016393442623
+        ],
+        [
+            74,
+            52,
+            0.739344262295082
+        ],
+        [
+            74,
+            53,
+            0.2573770491803279
+        ],
+        [
+            74,
+            54,
+            0.3377049180327869
+        ],
+        [
+            74,
+            55,
+            0.3475409836065574
+        ],
+        [
+            74,
+            56,
+            0.3508196721311475
+        ],
+        [
+            74,
+            57,
+            0.3770491803278688
+        ],
+        [
+            74,
+            58,
+            0.2836065573770492
+        ],
+        [
+            74,
+            59,
+            0.24590163934426235
+        ],
+        [
+            74,
+            60,
+            0.3327868852459016
+        ],
+        [
+            74,
+            61,
+            0.34918032786885245
+        ],
+        [
+            74,
+            62,
+            0.2475409836065574
+        ],
+        [
+            74,
+            63,
+            0.2475409836065574
+        ],
+        [
+            74,
+            64,
+            0.3475409836065574
+        ],
+        [
+            74,
+            65,
+            0.34918032786885245
+        ],
+        [
+            74,
+            66,
+            0.35245901639344257
+        ],
+        [
+            74,
+            67,
+            0.34098360655737703
+        ],
+        [
+            74,
+            68,
+            0.30491803278688523
+        ],
+        [
+            74,
+            69,
+            0.9885245901639345
+        ],
+        [
+            74,
+            70,
+            0.9885245901639345
+        ],
+        [
+            74,
+            71,
+            0.9852459016393442
+        ],
+        [
+            74,
+            72,
+            0.9327868852459016
+        ],
+        [
+            74,
+            73,
+            0.4049180327868852
+        ],
+        [
+            74,
+            74,
+            1.0
+        ],
+        [
+            74,
+            75,
+            0.3836065573770492
+        ],
+        [
+            75,
+            0,
+            0.8147540983606557
+        ],
+        [
+            75,
+            1,
+            0.6360655737704918
+        ],
+        [
+            75,
+            2,
+            0.13278688524590165
+        ],
+        [
+            75,
+            3,
+            0.13278688524590165
+        ],
+        [
+            75,
+            4,
+            0.6360655737704918
+        ],
+        [
+            75,
+            5,
+            0.13278688524590165
+        ],
+        [
+            75,
+            6,
+            0.20163934426229513
+        ],
+        [
+            75,
+            7,
+            0.13278688524590165
+        ],
+        [
+            75,
+            8,
+            0.6360655737704918
+        ],
+        [
+            75,
+            9,
+            0.6245901639344262
+        ],
+        [
+            75,
+            10,
+            0.13278688524590165
+        ],
+        [
+            75,
+            11,
+            0.13278688524590165
+        ],
+        [
+            75,
+            12,
+            0.6245901639344262
+        ],
+        [
+            75,
+            13,
+            0.13278688524590165
+        ],
+        [
+            75,
+            14,
+            0.13278688524590165
+        ],
+        [
+            75,
+            15,
+            0.6360655737704918
+        ],
+        [
+            75,
+            16,
+            0.13278688524590165
+        ],
+        [
+            75,
+            17,
+            0.1885245901639344
+        ],
+        [
+            75,
+            18,
+            0.12131147540983611
+        ],
+        [
+            75,
+            19,
+            0.13442622950819672
+        ],
+        [
+            75,
+            20,
+            0.12786885245901636
+        ],
+        [
+            75,
+            21,
+            0.1262295081967213
+        ],
+        [
+            75,
+            22,
+            0.12786885245901636
+        ],
+        [
+            75,
+            23,
+            0.12786885245901636
+        ],
+        [
+            75,
+            24,
+            0.139344262295082
+        ],
+        [
+            75,
+            25,
+            0.14590163934426226
+        ],
+        [
+            75,
+            26,
+            0.139344262295082
+        ],
+        [
+            75,
+            27,
+            0.1262295081967213
+        ],
+        [
+            75,
+            28,
+            0.1262295081967213
+        ],
+        [
+            75,
+            29,
+            0.14098360655737707
+        ],
+        [
+            75,
+            30,
+            0.1262295081967213
+        ],
+        [
+            75,
+            31,
+            0.12459016393442623
+        ],
+        [
+            75,
+            32,
+            0.139344262295082
+        ],
+        [
+            75,
+            33,
+            0.13278688524590165
+        ],
+        [
+            75,
+            34,
+            0.13442622950819672
+        ],
+        [
+            75,
+            35,
+            0.14098360655737707
+        ],
+        [
+            75,
+            36,
+            0.139344262295082
+        ],
+        [
+            75,
+            37,
+            0.14262295081967213
+        ],
+        [
+            75,
+            38,
+            0.13606557377049178
+        ],
+        [
+            75,
+            39,
+            0.14590163934426226
+        ],
+        [
+            75,
+            40,
+            0.14098360655737707
+        ],
+        [
+            75,
+            41,
+            0.12950819672131153
+        ],
+        [
+            75,
+            42,
+            0.13278688524590165
+        ],
+        [
+            75,
+            43,
+            0.12950819672131153
+        ],
+        [
+            75,
+            44,
+            0.13606557377049178
+        ],
+        [
+            75,
+            45,
+            0.13606557377049178
+        ],
+        [
+            75,
+            46,
+            0.14098360655737707
+        ],
+        [
+            75,
+            47,
+            0.11475409836065575
+        ],
+        [
+            75,
+            48,
+            0.14098360655737707
+        ],
+        [
+            75,
+            49,
+            0.1442622950819672
+        ],
+        [
+            75,
+            50,
+            0.14262295081967213
+        ],
+        [
+            75,
+            51,
+            0.12950819672131153
+        ],
+        [
+            75,
+            52,
+            0.14262295081967213
+        ],
+        [
+            75,
+            53,
+            0.7786885245901639
+        ],
+        [
+            75,
+            54,
+            0.7147540983606557
+        ],
+        [
+            75,
+            55,
+            0.7278688524590164
+        ],
+        [
+            75,
+            56,
+            0.7344262295081967
+        ],
+        [
+            75,
+            57,
+            0.7278688524590164
+        ],
+        [
+            75,
+            58,
+            0.7786885245901639
+        ],
+        [
+            75,
+            59,
+            0.862295081967213
+        ],
+        [
+            75,
+            60,
+            0.7131147540983607
+        ],
+        [
+            75,
+            61,
+            0.6967213114754098
+        ],
+        [
+            75,
+            62,
+            0.8639344262295082
+        ],
+        [
+            75,
+            63,
+            0.8639344262295082
+        ],
+        [
+            75,
+            64,
+            0.6983606557377049
+        ],
+        [
+            75,
+            65,
+            0.7032786885245902
+        ],
+        [
+            75,
+            66,
+            0.7524590163934426
+        ],
+        [
+            75,
+            67,
+            0.6885245901639344
+        ],
+        [
+            75,
+            68,
+            0.7737704918032787
+        ],
+        [
+            75,
+            69,
+            0.37213114754098364
+        ],
+        [
+            75,
+            70,
+            0.37213114754098364
+        ],
+        [
+            75,
+            71,
+            0.3688524590163934
+        ],
+        [
+            75,
+            72,
+            0.4278688524590164
+        ],
+        [
+            75,
+            73,
+            0.7491803278688525
+        ],
+        [
+            75,
+            74,
+            0.3836065573770492
+        ],
+        [
+            75,
+            75,
             1.0
         ]
     ]

--- a/torchci/rockset/metrics/__sql/correlation_matrix.sql
+++ b/torchci/rockset/metrics/__sql/correlation_matrix.sql
@@ -19,21 +19,37 @@ WITH all_jobs AS (
       WHEN job.conclusion = 'skipped' THEN NULL
       ELSE 1
     END AS is_green,
+    workflow._event_time AS event_time,
+    ROW_NUMBER() OVER(PARTITION BY job.name, push.head_commit.id ORDER BY job.run_attempt DESC) AS attempt,
 FROM
   workflow_run workflow
   INNER JOIN commons.workflow_job job ON workflow.id = job.run_id
+  INNER JOIN push on workflow.head_commit.id = push.head_commit.id
 WHERE
   job._event_time > CURRENT_TIMESTAMP() - INTERVAL 21 DAY
   AND ARRAY_CONTAINS(SPLIT(:workflowNames, ','), LOWER(workflow.name))
+  AND workflow.event != 'workflow_run'
+  AND push.ref = 'refs/heads/master'
+  AND push.repository.owner.name = 'pytorch'
+  AND push.repository.name = 'pytorch'
   AND job.name LIKE '%test%'
+  AND job.name NOT LIKE '%filter%'
+  AND job.name NOT LIKE '%rerun_disabled_tests%'
 )
 SELECT
   IF (name LIKE '%(%' AND name NOT LIKE '%)%', CONCAT(name, ')'), name) AS name,
   head_sha,
   is_green,
+  event_time,
 FROM
   all_jobs
+WHERE
+  is_green IS NOT NULL
+  AND attempt = 1
 GROUP BY
   name,
   head_sha,
-  is_green
+  is_green,
+  event_time
+ORDER BY
+  event_time DESC

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -31,7 +31,7 @@
     "strict_lag_historical": "d2a09d13caf8b76a"
   },
   "metrics": {
-    "correlation_matrix": "d2ed6c1941a799c7",
+    "correlation_matrix": "35c05e04047123f0",
     "disabled_test_historical": "daa2413a4750aa87",
     "disabled_test_total": "da5f834a6501fc63",
     "external_contribution_stats": "f0b640aebc4a5b74",

--- a/torchci/scripts/compute_correlation.py
+++ b/torchci/scripts/compute_correlation.py
@@ -1,65 +1,121 @@
-from collections import defaultdict
 import json
 import math
 import os
+from collections import defaultdict
 
-from rockset import RocksetClient
+from typing import Any, List
+
 import pandas as pd
+from rockset import RocksetClient
+from sklearn.metrics.pairwise import pairwise_distances
 
 
 ROCKSET_API_KEY = os.environ.get("ROCKSET_API_KEY")
 if ROCKSET_API_KEY is None:
     raise RuntimeError("ROCKSET_API_KEY not set")
 
-with open("rockset/prodVersions.json") as f:
-    prod_versions = json.load(f)
 
-client = RocksetClient(
-    api_key=ROCKSET_API_KEY,
-    host="https://api.usw2a1.rockset.com",
-)
-response = client.QueryLambdas.execute_query_lambda(
-    query_lambda="correlation_matrix",
-    version=prod_versions["metrics"]["correlation_matrix"],
-    workspace="metrics",
-)
+def parse_args() -> Any:
+    from argparse import ArgumentParser
 
-pivot = defaultdict(dict)
-# Results look like (is_green, head_sha, name)
-# Turn results into a nested dict of head_sha => name => is_green
-for result in response.results:
-    # skip pending jobs
-    if result["is_green"] is None:
-        continue
+    parser = ArgumentParser("Compute the correlation matrix across all CI jobs")
+    parser.add_argument(
+        "--ignore-flaky", action="store_true", help="ignore flaky results"
+    )
+    return parser.parse_args()
 
-    head_sha = result["head_sha"]
-    if head_sha not in pivot:
-        pivot[head_sha] = {}
 
-    name = result["name"]
+def ignore_flaky(df: pd.DataFrame) -> pd.DataFrame:
+    # A flaky failure is consider as G(1) R(0) G(1)
+    def _is_flaky(window: List[int]) -> bool:
+        return window[0] == 1 and window[1] == 0 and window[2] == 1
 
-    name = name.split("/", 1)[1].strip()
-    if name not in pivot[head_sha]:
-        pivot[head_sha][name] = 1
+    # Each column captures a CI job, and rows are commits sorted by time.
+    return (
+        df.rolling(window=3, center=True)
+        .apply(lambda x: 1 if _is_flaky(x) else x[1])
+        .fillna(0)
+    )
 
-    pivot[head_sha][name] *= result["is_green"]
 
-df = pd.DataFrame(pivot).transpose()
-correlation_matrix = df.corr()
+def compute():
+    args = parse_args()
 
-# Prepare for rendering in json:
-# Turn the nested dict of name => name => corr to Array<xAxis, yAxis, corr>
-correlation_matrix = correlation_matrix.to_dict()
-data = []
+    with open("rockset/prodVersions.json") as f:
+        prod_versions = json.load(f)
 
-for xIdx, xName in enumerate(correlation_matrix):
-    for yIdx, yName in enumerate(correlation_matrix[xName]):
-        value = correlation_matrix[xName][yName]
-        # nans mean we couldn't find any examples with both jobs populated.
-        if math.isnan(value):
+    client = RocksetClient(
+        api_key=ROCKSET_API_KEY,
+        host="https://api.usw2a1.rockset.com",
+    )
+    response = client.QueryLambdas.execute_query_lambda(
+        query_lambda="correlation_matrix",
+        version=prod_versions["metrics"]["correlation_matrix"],
+        workspace="metrics",
+    )
+
+    pivot = defaultdict(dict)
+    # Results look like (is_green, head_sha, name)
+    # Turn results into a nested dict of head_sha => name => is_green
+    for result in response.results:
+        # skip pending jobs
+        if result["is_green"] is None:
             continue
 
-        data.append((xIdx, yIdx, value))
+        head_sha = result["head_sha"]
+        if head_sha not in pivot:
+            pivot[head_sha] = {}
 
-with open("lib/correlation_matrix.json", "w") as f:
-    json.dump({"names": list(correlation_matrix.keys()), "data": data}, f, indent=4)
+        name = result["name"]
+
+        name = name.split("/", 1)[1].strip()
+        if name not in pivot[head_sha]:
+            pivot[head_sha][name] = 1
+
+        pivot[head_sha][name] *= result["is_green"]
+
+    pd.options.display.max_columns = None
+    pd.options.display.max_rows = None
+    pd.options.display.width = 0
+
+    df = pd.DataFrame(pivot).transpose().fillna(0)
+    if args.ignore_flaky:
+        # Ignore flaky results
+        df = ignore_flaky(df)
+
+    # TLDR; Use hamming distance to calculate the similarity between jobs instead
+    # of the default peason correlation provided by pandas df.corr()
+    #
+    # We should not use the default pearson correlation for categorical values here
+    # because the result makes little sense. As an example, I gather MacOS data for
+    # x86-64 and arm64 functorch as an example. They rarely fail except flaky, and
+    # the two data series are mostly 1. I expect to see a value indicating a high
+    # correlation between the twos, but the calculation returns 0 no correlation.
+    # Correlation metrics for continuous data measure how the change (increase or
+    # decrease) in one correlates with the other. Here there are just 0 and 1.
+    correlation_matrix = pd.DataFrame(
+        1 - pairwise_distances(df.transpose(), metric="hamming"),
+        index=df.columns,
+        columns=df.columns,
+    )
+
+    # Prepare for rendering in json:
+    # Turn the nested dict of name => name => corr to Array<xAxis, yAxis, corr>
+    correlation_matrix = correlation_matrix.to_dict()
+    data = []
+
+    for xIdx, xName in enumerate(correlation_matrix):
+        for yIdx, yName in enumerate(correlation_matrix[xName]):
+            value = correlation_matrix[xName][yName]
+            # nans mean we couldn't find any examples with both jobs populated.
+            if math.isnan(value):
+                continue
+
+            data.append((xIdx, yIdx, value))
+
+    with open("lib/correlation_matrix.json", "w") as f:
+        json.dump({"names": list(correlation_matrix.keys()), "data": data}, f, indent=4)
+
+
+if __name__ == "__main__":
+    compute()


### PR DESCRIPTION
Update the correlation script to use hamming distance to calculate the similarity between jobs instead of the default Peason correlation provided by pandas `df.corr()`.  The latter doesn't work for binary data like what we have `is_green: boolean`, so its correlation value didn't make no sense.

I also update the Rockset query to:

* Use the latest retry result to remove flakiness
* Remove untracked jobs like `rerun_disabled_tests`
* Sort by event time

Finally, I detect the GREEN RED GREEN pattern in the job results, and approximate the RED one as flaky.

The result shows a **~91%** correlation between MacOS x86-64 and arm64 `python scripts/compute_correlation.py --ignore-flaky` in the past 21 days

```
print(
    correlation_matrix["macos-12-py3-x86-64 / test (default)"][
        "macos-12-py3-arm64 / test (default)"
    ]
)
0.9132569558101473

print(
    correlation_matrix["macos-12-py3-x86-64 / test (functorch)"][
        "macos-12-py3-arm64 / test (functorch)"
    ]
)
0.9116202945990179
```

If I look at only one week results, the correlation is higher at **95%**.  After a manual check, the differences were due to:

* https://github.com/pytorch/pytorch/issues/95922 GitHub outage. x86_64 jobs failed while arm64 succeeded ([hud](https://hud.pytorch.org/hud/pytorch/pytorch/master/4?per_page=50&name_filter=macos))
* https://github.com/pytorch/pytorch/issues/95510, M1 queuing issue where M1 jobs were disabled. x86_64 job succeeded while arm64 was disabled (missing result, default to failed)

Using this number, we have high confidence that we can tone down x86_64 jobs.

### Correlation results

https://torchci-git-fork-huydhn-improve-correlation-9b4670-fbopensource.vercel.app/correlation
