### PR TITLE
Remove conda-forge in macos builds

### DIFF
--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -150,7 +150,6 @@ jobs:
           else
             ${CONDA_RUN} conda build \
               -c defaults \
-              -c conda-forge \
               -c nvidia \
               -c "pytorch-${CHANNEL}" \
               --no-anaconda-upload \


### PR DESCRIPTION
Remove conda-forge in macos builds.
We don't want to relay on conda-forge since it creates more problems that it solves!