### PR TITLE
Fix anaconda-prune channel typo

### DIFF
--- a/.github/workflows/_prune-anaconda-packages.yml
+++ b/.github/workflows/_prune-anaconda-packages.yml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ github.ref }}
       - name: Prune binaries
         env:
-          CHANNEl: ${{ inputs.channel }}
+          CHANNEL: ${{ inputs.channel }}
           PACKAGES: ${{ inputs.packages }}
           ANACONDA_API_TOKEN: ${{ secrets.conda-pytorchbot-token }}
         run: |


### PR DESCRIPTION
Fixes the issue that pytorch-test anaconda channel prune job was doing cleanup with pytorch-nightly channel. 
See https://github.com/pytorch/test-infra/actions/runs/4382421428/jobs/7671448102#step:4:110 