### PR TITLE
Update Anaconda Prune Job to Avoid Overwhelming the Server

### DIFF
--- a/.github/scripts/anaconda-prune/prune.sh
+++ b/.github/scripts/anaconda-prune/prune.sh
@@ -45,6 +45,7 @@ for platform in ${PLATFORMS}; do
             (
                 set -x
                 anaconda remove --force "${CHANNEL}/${PKG}/${version}/${platform}/${PKG}-${version}-${spec}.tar.bz2"
+                sleep 1
             )
         fi
         done

--- a/.github/scripts/anaconda-prune/prune.sh
+++ b/.github/scripts/anaconda-prune/prune.sh
@@ -45,7 +45,6 @@ for platform in ${PLATFORMS}; do
             (
                 set -x
                 anaconda remove --force "${CHANNEL}/${PKG}/${version}/${platform}/${PKG}-${version}-${spec}.tar.bz2"
-                sleep 1
             )
         fi
         done

--- a/.github/workflows/anaconda-prune.yml
+++ b/.github/workflows/anaconda-prune.yml
@@ -26,6 +26,7 @@ jobs:
   anaconda-prune-pytorch-test:
     name: anaconda-prune-pytorch-test
     uses: ./.github/workflows/_prune-anaconda-packages.yml
+    needs: anaconda-prune-pytorch-nightly
     with:
       packages: "pytorch torchvision torchaudio torchtext torchdata ignite torchcsprng"
       channel: pytorch-test


### PR DESCRIPTION
This link shows Anaconda server was complaining: 
https://github.com/pytorch/test-infra/actions/runs/4430341149/jobs/7771952185#step:4:108

Things seem to fail if we simultaneously delete from two different channels, e.g. things started to fail more often after this PR (https://github.com/pytorch/test-infra/pull/3861) gets merged, which actually fixes a bug that only operates on pytorch-nightly (should be pytorch-nightly and pytorch-test). 
