### PR TITLE
Update External Contribution metric KPIs to weekly

### DIFF
--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -24,6 +24,20 @@ export default function Kpis() {
         },
     ];
 
+    // deprecate this in Q3 2023
+    const contributionTimeParams: RocksetParam[] = [
+        {
+        name: "startTime",
+        type: "string",
+        value: "2022-07-03T00:00:00.000Z",
+        },
+        {
+        name: "stopTime",
+        type: "string",
+        value: stopTime,
+        },
+    ];
+
     return (
         <Grid container spacing={2}>
             <Grid item xs={12} lg={6} height={ROW_HEIGHT}>
@@ -111,12 +125,12 @@ export default function Kpis() {
             </Grid>
             <Grid item xs={6} height={ROW_HEIGHT}>
                 <TimeSeriesPanel
-                    title={"External PR Count (7 day moving average)"}
+                    title={"Weekly External PR Count (4 week moving average))"}
                     queryName={"external_contribution_stats"}
-                    queryParams={[...timeParams]}
-                    granularity={"day"}
+                    queryParams={[...contributionTimeParams]}
+                    granularity={"week"}
                     timeFieldName={"granularity_bucket"}
-                    yAxisFieldName={"weekly_moving_average_pr_count"}
+                    yAxisFieldName={"weekly_pr_count_rolling_average"}
                     yAxisRenderer={(value) => value}
                     additionalOptions={{ yAxis: { scale: true } }}
                 />
@@ -124,12 +138,12 @@ export default function Kpis() {
 
             <Grid item xs={6} height={ROW_HEIGHT}>
                 <TimeSeriesPanel
-                    title={"Unique External Contributor Count (7 day moving average)"}
+                    title={"Weekly Unique External Contributor Count (4 week moving average)"}
                     queryName={"external_contribution_stats"}
-                    queryParams={[...timeParams]}
-                    granularity={"day"}
+                    queryParams={[...contributionTimeParams]}
+                    granularity={"week"}
                     timeFieldName={"granularity_bucket"}
-                    yAxisFieldName={"weekly_moving_average_user_count"}
+                    yAxisFieldName={"weekly_user_count_rolling_average"}
                     yAxisRenderer={(value) => value}
                     additionalOptions={{ yAxis: { scale: true } }}
                 />

--- a/torchci/rockset/metrics/external_contribution_stats.lambda.json
+++ b/torchci/rockset/metrics/external_contribution_stats.lambda.json
@@ -9,12 +9,12 @@
       {
         "name": "startTime",
         "type": "string",
-        "value": "2023-02-01T00:06:32.839Z"
+        "value": "2022-05-01T00:06:32.839Z"
       },
       {
         "name": "stopTime",
         "type": "string",
-        "value": "2023-02-07T00:06:32.839Z"
+        "value": "2023-03-07T00:06:32.839Z"
       }
     ],
     "description": "pr count and number of unique external contributors per day"

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -34,7 +34,7 @@
     "correlation_matrix": "35c05e04047123f0",
     "disabled_test_historical": "daa2413a4750aa87",
     "disabled_test_total": "da5f834a6501fc63",
-    "external_contribution_stats": "f0b640aebc4a5b74",
+    "external_contribution_stats": "6ecd4fdee7874867",
     "job_duration_avg": "10a88ea2ebb80647",
     "job_duration_percentile": "96507ed62db7a3a8",
     "last_branch_push": "3d995ac2143586dc",


### PR DESCRIPTION
Updates external contribution metrics to be a weekly (rolling average over 4 weeks).
<img width="1502" alt="Screenshot 2023-03-15 at 3 34 18 PM" src="https://user-images.githubusercontent.com/13758638/225458881-6b887ef4-765c-48f2-842a-dc54349f8079.png">
