### PR TITLE
Change workflow_load query to only care about pytorch/pytorch

### DIFF
--- a/torchci/rockset/metrics/__sql/workflow_load.sql
+++ b/torchci/rockset/metrics/__sql/workflow_load.sql
@@ -13,6 +13,7 @@ WHERE
     PARSE_TIMESTAMP_ISO8601(workflow.created_at) >= PARSE_DATETIME_ISO8601(:startTime)
     AND PARSE_TIMESTAMP_ISO8601(workflow.created_at) < PARSE_DATETIME_ISO8601(:stopTime)
     AND workflow.name IN ('pull', 'trunk', 'nightly', 'periodic')
+    AND workflow.repository.full_name = 'pytorch/pytorch'
 GROUP BY
     granularity_bucket,
     workflow.name

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -61,6 +61,6 @@
     "queue_times_historical": "7f4d6599362e70ba",
     "workflow_duration_avg": "7bae00900097a486",
     "workflow_duration_percentile": "0b28cf65de7cfe07",
-    "workflow_load": "eff394d8e0b76436"
+    "workflow_load": "4ef8256d4b6f7ebf"
   }
 }


### PR DESCRIPTION
Not sure if this is the right move, but currently the query also catches workflows from forks (ex clee2000/pytorch) and pytorch/pytorch-canary.  

While I'm pretty sure we don't want things from forks, because they don't use our machines, I'm not sure about canary.