### PR TITLE
Remove mkl in for MacOS builds

### DIFF
--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -133,7 +133,6 @@ jobs:
             export USE_FFMPEG="1"
             export USE_OPENMP="0"
           fi
-
           export FFMPEG_ROOT="${PWD}/third_party/ffmpeg"
 
           if [[ "${PYTHON_VERSION}" = "3.11" ]]; then

--- a/tools/pkg-helpers/pytorch_pkg_helpers/macos.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/macos.py
@@ -5,7 +5,4 @@ def get_macos_variables(arch_name: str, python_version: str = "3.8") -> list:
         "export CXX=clang++",
     ]
 
-    if arch_name != "arm64" and python_version != "3.11":
-        variables.append("export CONDA_EXTRA_BUILD_CONSTRAINT='- mkl<=2023.0.0'")
-
     return variables

--- a/tools/pkg-helpers/pytorch_pkg_helpers/macos.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/macos.py
@@ -6,6 +6,6 @@ def get_macos_variables(arch_name: str, python_version: str = "3.8") -> list:
     ]
 
     if arch_name != "arm64" and python_version != "3.11":
-        variables.append("export CONDA_EXTRA_BUILD_CONSTRAINT='- mkl<=2021.2.0'")
+        variables.append("export CONDA_EXTRA_BUILD_CONSTRAINT='- mkl<=2023.0.0'")
 
     return variables


### PR DESCRIPTION
Remove mkl constraint to fix MacOS builds

This is used to fail, here is an example: https://github.com/pytorch/test-infra/actions/runs/4431671908/jobs/7774880091