### PR TITLE
[log classifier] Improve capture group for pytest matching rules

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -90,7 +90,7 @@ pattern = 'XPASS(?: \[.*\])?: (test.*) \((?:__main__\.)?(.*)\)'
 
 [[rule]]
 name = 'pytest failure'
-pattern = '^FAILED .*.py::.*::test_.*$'
+pattern = '^FAILED (\S*.py::\S*::test_\S*)'
 
 [[rule]]
 name = 'Python unittest error'
@@ -98,7 +98,7 @@ pattern = 'ERROR(?: \[.*\])?: (test.*) \((?:__main__\.)?(.*)\)'
 
 [[rule]]
 name = 'pytest test error'
-pattern = '^ERROR .*.py::.*::test_.*$'
+pattern = '^ERROR (\S*.py::\S*::test_\S*)'
 
 [[rule]]
 name = 'inductor model failure'


### PR DESCRIPTION
Previously, lines like `FAILED distributed/checkpoint/test_dtensor_checkpoint.py::DTensorPlanner::test_distributed_tensor_planner - RuntimeError: Process 0 exited with error code 10 and exception:` would include the `RuntimeError: Process 0 exited with error code 10 and exception:` in the failure capture.

Instead, only include the test name `distributed/checkpoint/test_dtensor_checkpoint.py::DTensorPlanner::test_distributed_tensor_planner` as the failure capture