### PR TITLE
Increase max runners for linux.g5.4xlarge.nvidia.gpu to 400

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -89,7 +89,7 @@ runner_types:
   linux.g5.4xlarge.nvidia.gpu:
     instance_type: g5.4xlarge
     os: linux
-    max_available: 300
+    max_available: 400
     disk_size: 150
     is_ephemeral: false
   linux.g5.12xlarge.nvidia.gpu:


### PR DESCRIPTION
During the past week, `linux.g5.4xlarge.nvidia.gpu` hit its max allowed runners, so I am increasing the number of available instances.

![Screenshot 2023-03-20 at 10 33 35](https://user-images.githubusercontent.com/4520845/226300267-856a71d9-85c5-426f-9b8f-debb08512135.png)
