### PR TITLE
Fix Linux Wheels Smoke Test Failures

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -167,7 +167,7 @@ jobs:
           # Checking that we have a pinned version of torch in our dependency tree
           (
             pushd "${RUNNER_TEMP}"
-            unzip "${GITHUB_WORKSPACE}/${{ inputs.repository }}/dist/$WHEEL_NAME"
+            unzip -o "${GITHUB_WORKSPACE}/${{ inputs.repository }}/dist/$WHEEL_NAME"
             # Ensure that pytorch version is pinned, should output file where it was found
             grep "Requires-Dist: torch (==.*)" -r .
           )

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -75,6 +75,13 @@ jobs:
     # to have a conversation
     timeout-minutes: 60
     steps:
+      - name: Clean workspace
+        run: |
+          set -euxo pipefail
+          echo "::group::Cleanup debug output"
+          rm -rfv "${GITHUB_WORKSPACE}"
+          mkdir -p "${GITHUB_WORKSPACE}"
+          echo "::endgroup::"
       - uses: actions/checkout@v3
         with:
           # Support the use case where we need to checkout someone's fork

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -183,7 +183,7 @@ jobs:
           # Checking that we have a pinned version of torch in our dependency tree
           (
             pushd "${RUNNER_TEMP}"
-            unzip "${GITHUB_WORKSPACE}/${{ inputs.repository }}/dist/$WHEEL_NAME"
+            unzip -o "${GITHUB_WORKSPACE}/${{ inputs.repository }}/dist/$WHEEL_NAME"
             # Ensure that pytorch version is pinned, should output file where it was found
             grep "Requires-Dist: torch (==.*)" -r .
           )


### PR DESCRIPTION
We are seeing smoke-test failures in Linux Wheels builds like the following: https://github.com/pytorch/vision/actions/runs/4500887549/jobs/7920603961?pr=7453.

They appear to error out at this line: https://github.com/pytorch/test-infra/blob/main/.github/workflows/build_wheels_linux.yml#L170.

This PR tries 2 things to address this:
1. Clean up the workspace prior to the build job in Linux Wheels like we do in MacOS Wheels, where we don't see any issues.
2. Use the `unzip -o` option to force unzipping to overwrite. It seems unzip requires user input to specify whether to replace or not, and since we do not provide any such input, it automatically chooses None. 