### PR TITLE
[Stronghold][bc-linter] add --suppressed flag as an alternative way to suppress linter

### DIFF
--- a/.github/workflows/stronghold.yml
+++ b/.github/workflows/stronghold.yml
@@ -25,7 +25,6 @@ jobs:
             --base-commit=${{ github.event.pull_request.base.sha }} \
             --head-commit=${{ github.event.pull_request.head.sha }}
 
-      docker-image: buildpack-deps:scm
       runner: linux.large
 
   black:

--- a/tools/stronghold/src/api/checker.py
+++ b/tools/stronghold/src/api/checker.py
@@ -14,6 +14,14 @@ def run() -> None:
     parser = argparse.ArgumentParser(prog=sys.argv[0], description=__doc__)
     parser.add_argument('--base-commit', type=str, required=True)
     parser.add_argument('--head-commit', type=str, required=True)
+    parser.add_argument(
+        '--suppressed',
+        default=False,
+        required=False,
+        action='store_true',
+        help='Failures are suppressed'
+        '(alternative to #suppress-api-compatibility-check commit message tag).',
+    )
     args = parser.parse_args(sys.argv[1:])
 
     repo = api.git.Repository(pathlib.Path('.'))
@@ -44,7 +52,7 @@ def run() -> None:
         check=True,
         stdout=subprocess.PIPE,
     )
-    suppressed = '#suppress-api-compatibility-check' in pinfo.stdout
+    suppressed = '#suppress-api-compatibility-check' in pinfo.stdout or args.suppressed
     level = 'notice' if suppressed else 'warning'
 
     for file, file_violations in violations.items():


### PR DESCRIPTION
Suppressing the linter failure via commit message may not be the most convenient option.

This change introduces a flag parameter `--suppressed` (false by default) that works exactly like the presence of the tag `#suppress-api-compatibility-check` in commit message.

Usage:
```
./check-api-compatibility --base-commit ... --head-commit ... --suppressed
```

---

Please note the seemingly unrelated docker image removal is related to the following failure:
https://github.com/pytorch/test-infra/actions/runs/4538297045/jobs/7997261316

Seems like the docker image used in that job previously is borked.