### PR TITLE
[Bot] Make `--help` position independent

### DIFF
--- a/torchci/lib/bot/cliParser.ts
+++ b/torchci/lib/bot/cliParser.ts
@@ -58,6 +58,10 @@ merge.add_argument("-r", "--rebase", {
   const: "viable/strict",
   choices: ["viable/strict", "master"],
 });
+merge.add_argument("-h", "--help", {
+  action: "store_true",
+  help: SUPPRESS,
+});
 
 // Revert
 const revert = commands.add_parser("revert", {
@@ -79,6 +83,10 @@ revert.add_argument("-c", "--classification", {
   choices: Object.keys(revertClassifications),
   help: "A machine-friendly classification of the revert reason.",
 });
+revert.add_argument("-h", "--help", {
+  action: "store_true",
+  help: SUPPRESS,
+});
 
 // Rebase
 const rebase = commands.add_parser("rebase", {
@@ -97,6 +105,10 @@ branch_selection.add_argument("-s", "--stable", {
 branch_selection.add_argument("-b", "--branch", {
   help: "Branch you would like to rebase to",
 });
+rebase.add_argument("-h", "--help", {
+  action: "store_true",
+  help: SUPPRESS,
+});
 
 const label = commands.add_parser("label", {
   help: "Add label to a PR",
@@ -109,6 +121,10 @@ label.add_argument("labels", {
   nargs: "+",
   help: "Labels to add to given Pull Request",
 });
+label.add_argument("-h", "--help", {
+  action: "store_true",
+  help: SUPPRESS,
+});
 
 // Dr. CI
 const drCi = commands.add_parser("drci", {
@@ -118,6 +134,10 @@ const drCi = commands.add_parser("drci", {
     "with actual CI results.",
   formatter_class: RawTextHelpFormatter,
   add_help: false,
+});
+drCi.add_argument("-h", "--help", {
+  action: "store_true",
+  help: SUPPRESS,
 });
 
 // Help


### PR DESCRIPTION
I.e. `@pytorchbot --help merge` and `@pytorchbot merge --help` should
yield the same output
