### PR TITLE
Parse graph-break failures in log-classifier

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -229,13 +229,13 @@ name = 'Out of space error'
 pattern = 'no space left on device'
 
 [[rule]]
-name = 'GHA error'
-pattern = '^##\[error\](.*)'
-
-[[rule]]
 name = 'New graph breaks'
 pattern = 'FAIL:\s+graph_breaks='
 
 [[rule]]
 name = 'Improved graph breaks'
 pattern = 'IMPROVED:\s+graph_breaks='
+
+[[rule]]
+name = 'GHA error'
+pattern = '^##\[error\](.*)'

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -231,3 +231,11 @@ pattern = 'no space left on device'
 [[rule]]
 name = 'GHA error'
 pattern = '^##\[error\](.*)'
+
+[[rule]]
+name = 'New graph breaks'
+pattern = 'FAIL:\s+graph_breaks='
+
+[[rule]]
+name = 'Improved graph breaks'
+pattern = 'IMPROVED:\s+graph_breaks='


### PR DESCRIPTION
Replaces a less usefull "process exited with code" with a summary of graph-break failure or improvement.

See pytorch/benchmarks/dynamo/check_graph_breaks.py for source of these messages.