### PR TITLE
Upgrade NVIDIA UNIX driver to latest prod 525.89.02

### DIFF
--- a/.github/actions/setup-nvidia/action.yml
+++ b/.github/actions/setup-nvidia/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: which driver version to install
     required: false
     type: string
-    default: "515.76"
+    default: "525.89.02"
 
 runs:
   using: composite


### PR DESCRIPTION
Doing it here rather than in PyTorch to make the shared runner consistent.  After https://github.com/pytorch/pytorch/pull/96904, I haven't seen the [CUDA not available](https://hud.pytorch.org/failure/RuntimeError%3A%20No%20CUDA%20GPUs%20are%20available) error again after the update which is a good sign.  On the other hand, we see a new group of issues about hanging process and Docker error today https://github.com/pytorch/pytorch/pull/97585.  So I'll try to use the latest production NVIDIA UNIX driver from https://www.nvidia.com/en-us/drivers/unix

### Testing
https://hud.pytorch.org/pr/97840