### PR TITLE
Reduce metric width to fit on narrower window

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -517,7 +517,7 @@ export default function Page() {
               title={"% commits red on master, aggregate"}
               queryName={"master_commit_red_avg"}
               metricName={"red"}
-              valueRenderer={(value) => (value * 100).toFixed(2) + "%"}
+              valueRenderer={(value) => (value * 100).toFixed(1) + "%"}
               queryParams={timeParams}
               badThreshold={(value) => value > 0.2}
             />
@@ -539,7 +539,7 @@ export default function Page() {
               title={"% commits red on master, after retries"}
               queryName={"master_commit_red_avg"}
               metricName={"red"}
-              valueRenderer={(value) => (value * 100).toFixed(2) + "%"}
+              valueRenderer={(value) => (value * 100).toFixed(1) + "%"}
               queryParams={[
                 {
                   name: "useRetryConclusion",


### PR DESCRIPTION
Reduce the number of decimal places on our redness metrics. The extra precision isn't really helpful, and this lets the value appear more cleanly on half a monitor screen.

Before:
<img width="1238" alt="image" src="https://user-images.githubusercontent.com/4468967/228594117-b963a466-b8af-47de-94b4-b7a840202d91.png">


After:
<img width="1236" alt="image" src="https://user-images.githubusercontent.com/4468967/228593826-37f2bf60-49cc-4788-9604-e1f91c4bfddf.png">
