### PR TITLE
Make kpi window smaller

### DIFF
--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -7,8 +7,8 @@ import { useState } from "react";
 const ROW_HEIGHT = 240;
 
 export default function Kpis() {
-    // Looking at data from the past year
-    const [startTime, setStartTime] = useState(dayjs().subtract(1, 'year'));
+    // Looking at data from the past six months
+    const [startTime, setStartTime] = useState(dayjs().subtract(6, 'month'));
     const [stopTime, setStopTime] = useState(dayjs());
 
     const timeParams: RocksetParam[] = [


### PR DESCRIPTION
Make the kpi chart show data for just the past 6 months.

The 1 year view is helpful for seeing how far we've come, but to track how we're doing a 6 month view is better (plus it loads faster)

A toggle that lets you choose how far back the chart should go would be ideal, but that juice isn't worth the squeeze just yet.