### PR TITLE
[hud] Set navbar links to be in front

### DIFF
--- a/torchci/components/NavBar.module.css
+++ b/torchci/components/NavBar.module.css
@@ -23,6 +23,8 @@
   display: flex;
   flex-direction: row;
   padding-bottom: 3px;
+  z-index: 100;
+  position: relative;
 }
 
 .links > ul {


### PR DESCRIPTION
Small, but it's really hard to click the links on the navbar in the hud main page because the job names get in the way.

Set z-index to be a very large number so that it's in front.
Set position because z-index has no effect if otherwise.