### PR TITLE
Denoise revert kpi metric

### DIFF
--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -63,7 +63,7 @@ export default function Kpis() {
 
             <Grid item xs={12} lg={6} height={ROW_HEIGHT}>
                 <TimeSeriesPanel
-                title={"# of Reverts (Weekly)"}
+                title={"# of Reverts/week (2 week moving avg)"}
                 queryName={"num_reverts"}
                 queryCollection={"pytorch_dev_infra_kpis"}
                 queryParams={[

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -23,7 +23,7 @@
     "master_commit_red_jobs": "5e921da7a05fedad"
   },
   "pytorch_dev_infra_kpis": {
-    "num_reverts": "f39141336b6ea956",
+    "num_reverts": "463d78bc8ace3979",
     "number_of_force_pushes_historical": "6a8bcb873ed6a08e",
     "time_to_merge": "be1c2a28cf75fe32",
     "time_to_review": "adfbcdfc51ede11a",

--- a/torchci/rockset/pytorch_dev_infra_kpis/__sql/num_reverts.sql
+++ b/torchci/rockset/pytorch_dev_infra_kpis/__sql/num_reverts.sql
@@ -1,69 +1,108 @@
-(
-    SELECT
-        FORMAT_TIMESTAMP(
-            '%Y-%m-%d',
-            DATE_TRUNC(:granularity, push._event_time)
-        ) AS bucket,
-        'total' AS code,
-        COUNT(*) AS num
-    FROM
-        push
-    WHERE
-        push.ref IN ('refs/heads/master', 'refs/heads/main')
-        AND push.repository.owner.name = 'pytorch'
-        AND push.repository.name = 'pytorch'
-        AND (
-            push.head_commit.message LIKE 'Revert %'
-            OR push.head_commit.message LIKE 'Back out%'
-        )
-        AND push._event_time >= PARSE_DATETIME_ISO8601(:startTime)
-        AND push._event_time <= PARSE_DATETIME_ISO8601(:stopTime)
-    GROUP BY
-        bucket
-    ORDER BY
-        bucket
-)
-UNION
-(
-    SELECT
-        FORMAT_TIMESTAMP(
-            '%Y-%m-%d',
-            DATE_TRUNC(:granularity, ic._event_time)
-        ) AS bucket,
-        REGEXP_EXTRACT(
-            ic.body,
-            '(-c|--classification)[\s =]+["'']?(\w+)["'']?',
-            2
-        ) AS code,
-        COUNT(*) AS num
-    FROM
-        commons.issue_comment AS ic
-        INNER JOIN (
+WITH
+    coded_reverts as (
+        SELECT
+            FORMAT_TIMESTAMP(
+                '%Y-%m-%d',
+                DATE_TRUNC(:granularity, ic._event_time)
+            ) AS bucket,
+            REGEXP_EXTRACT(
+                ic.body,
+                '(-c|--classification)[\s =]+["'']?(\w+)["'']?',
+                2
+            ) AS code,
+            COUNT(*) AS num
+        FROM
+            commons.issue_comment AS ic
+            INNER JOIN (
+                SELECT
+                    issue_comment.issue_url,
+                    MAX(issue_comment._event_time) AS event_time -- Use the max for when invalid revert commands are tried first
+                FROM
+                    commons.issue_comment
+                WHERE
+                    REGEXP_LIKE(
+                        issue_comment.body,
+                        ' *@pytorch(merge|)bot revert'
+                    )
+                GROUP BY
+                    issue_comment.issue_url
+            ) AS rc ON ic.issue_url = rc.issue_url
+        WHERE
+            ic._event_time = rc.event_time
+            AND ic._event_time >= PARSE_DATETIME_ISO8601(:startTime)
+            AND ic._event_time <= PARSE_DATETIME_ISO8601(:stopTime)
+            AND ic.user.login != 'pytorch-bot[bot]'
+            AND REGEXP_EXTRACT(
+                ic.body,
+                '(-c|--classification)[\s =]+["'']?(\w+)["'']?',
+                2
+            ) IS NOT NULL
+        GROUP BY
+            code,
+            bucket
+    ),
+    weekly_results as (
+        (
             SELECT
-                issue_comment.issue_url,
-                MAX(issue_comment._event_time) AS event_time -- Use the max for when invalid revert commands are tried first
+                FORMAT_TIMESTAMP(
+                    '%Y-%m-%d',
+                    DATE_TRUNC(:granularity, push._event_time)
+                ) AS bucket,
+                'total' AS code,
+                COUNT(*) AS num
             FROM
-                commons.issue_comment
+                push
             WHERE
-                REGEXP_LIKE(
-                    issue_comment.body,
-                    ' *@pytorch(merge|)bot revert'
+                push.ref IN ('refs/heads/master', 'refs/heads/main')
+                AND push.repository.owner.name = 'pytorch'
+                AND push.repository.name = 'pytorch'
+                AND (
+                    push.head_commit.message LIKE 'Revert %'
+                    OR push.head_commit.message LIKE 'Back out%'
                 )
+                AND push._event_time >= PARSE_DATETIME_ISO8601(:startTime)
+                AND push._event_time <= PARSE_DATETIME_ISO8601(:stopTime)
             GROUP BY
-                issue_comment.issue_url
-        ) AS rc ON ic.issue_url = rc.issue_url
-    WHERE
-        ic._event_time = rc.event_time
-        AND ic._event_time >= PARSE_DATETIME_ISO8601(:startTime)
-        AND ic._event_time <= PARSE_DATETIME_ISO8601(:stopTime)
-        AND ic.user.login != 'pytorch-bot[bot]'
-        AND REGEXP_EXTRACT(
-            ic.body,
-            '(-c|--classification)[\s =]+["'']?(\w+)["'']?',
-            2
-        ) IS NOT NULL
-    GROUP BY
-        code,
-        bucket
-)
+                bucket
+            ORDER BY
+                bucket
+        )
+        UNION
+        (
+            SELECT
+                bucket,
+                code,
+                num
+            FROM
+                coded_reverts
+        )
+        UNION
+        (
+            SELECT
+                bucket,
+                'non-ghfirst-total' AS code,
+                SUM(num)
+            FROM
+                coded_reverts
+            WHERE
+                code != 'ghfirst'
+            GROUP BY
+                bucket
+        )
+    )
+SELECT
+    bucket,
+    -- 2 week rolling average
+    (
+        SUM(num) OVER(
+            PARTITION BY code
+            ORDER BY
+                bucket ROWS 2 PRECEDING
+        )
+    ) / 2.0 AS num,
+    code,
+FROM
+    weekly_results
+ORDER BY
+    bucket DESC, code
    

--- a/torchci/rockset/pytorch_dev_infra_kpis/num_reverts.lambda.json
+++ b/torchci/rockset/pytorch_dev_infra_kpis/num_reverts.lambda.json
@@ -9,13 +9,13 @@
     {
       "name": "startTime",
       "type": "string",
-      "value": "2022-01-01T00:00:00.000Z"
+      "value": "2022-11-01T00:00:00.000Z"
     },
     {
       "name": "stopTime",
       "type": "string",
-      "value": "2023-01-01T00:00:00.000Z"
+      "value": "2023-03-01T00:00:00.000Z"
     }
   ],
-  "description": "accept Revent % instead of Revert %D"
+  "description": "the count of various revert types over time"
 }


### PR DESCRIPTION
Update the kpi metric to:

1. More easily show the portion of reverts relevant to the kpi: the non github first reverts
2. Change the metric to a 2 week rolling window to denoise weekly variations


**Before**:
<img width="736" alt="image" src="https://user-images.githubusercontent.com/4468967/228910850-8b9e459e-b9d1-4847-b49f-23f57ae77857.png">

**After**: 
lines are smoother and a new `non-ghfirst-total` entry now appears.  Not really in love with the name, but that seemed like the most descriptive option.  `kpi-total` seemed too vague, but open to suggestions here
<img width="734" alt="image" src="https://user-images.githubusercontent.com/4468967/228910895-9aa591d0-ab99-4b5f-bce2-94a7cec48d34.png">
