### PR TITLE
Fix wrong rolling average for # of reverts KPI

### DIFF
--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -23,7 +23,7 @@
     "master_commit_red_jobs": "5e921da7a05fedad"
   },
   "pytorch_dev_infra_kpis": {
-    "num_reverts": "463d78bc8ace3979",
+    "num_reverts": "1f1ed48105cf1e74",
     "number_of_force_pushes_historical": "6a8bcb873ed6a08e",
     "time_to_merge": "be1c2a28cf75fe32",
     "time_to_review": "adfbcdfc51ede11a",

--- a/torchci/rockset/pytorch_dev_infra_kpis/__sql/num_reverts.sql
+++ b/torchci/rockset/pytorch_dev_infra_kpis/__sql/num_reverts.sql
@@ -97,7 +97,7 @@ SELECT
         SUM(num) OVER(
             PARTITION BY code
             ORDER BY
-                bucket ROWS 2 PRECEDING
+                bucket ROWS 1 PRECEDING
         )
     ) / 2.0 AS num,
     code,
@@ -105,4 +105,3 @@ FROM
     weekly_results
 ORDER BY
     bucket DESC, code
-   


### PR DESCRIPTION
I think this query looks wrong as it tries to compute the rolling average of 2 weeks but sums over a 3-week period (current week + the preceding 2 weeks).  As such, the number of reverts on https://hud.pytorch.org/kpis looks higher than the correct figure on https://hud.pytorch.org/metrics