### PR TITLE
Fix setup-nvidia GPU healthcheck

### DIFF
--- a/.github/actions/setup-nvidia/action.yml
+++ b/.github/actions/setup-nvidia/action.yml
@@ -142,7 +142,38 @@ runs:
 
                   (
                       set +e
+
                       nvidia-smi
+                      # NB: Annoyingly, nvidia-smi command returns successfully with return code 0 even in
+                      # the case where the driver has already crashed as it still can get the driver version
+                      # and some basic information like the bus ID.  However, the rest of the information
+                      # would be missing (ERR!), for example:
+                      #
+                      # +-----------------------------------------------------------------------------+
+                      # | NVIDIA-SMI 525.89.02    Driver Version: 525.89.02    CUDA Version: 12.0     |
+                      # |-------------------------------+----------------------+----------------------+
+                      # | GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
+                      # | Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
+                      # |                               |                      |               MIG M. |
+                      # |===============================+======================+======================|
+                      # |   0  ERR!                Off  | 00000000:00:1E.0 Off |                 ERR! |
+                      # |ERR!  ERR! ERR!    ERR! / ERR! |   4184MiB / 23028MiB |    ERR!      Default |
+                      # |                               |                      |                 ERR! |
+                      # +-------------------------------+----------------------+----------------------+
+                      #
+                      # +-----------------------------------------------------------------------------+
+                      # | Processes:                                                                  |
+                      # |  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
+                      # |        ID   ID                                                   Usage      |
+                      # |=============================================================================|
+                      # +-----------------------------------------------------------------------------+
+                      #
+                      # This should be reported as a failure instead as it will guarantee to fail when
+                      # Docker tries to run with --gpus all
+                      #
+                      # So, the correct check here is to query one of the missing piece of info like
+                      # GPU name, so that the command can fail accordingly
+                      nvidia-smi --query-gpu=gpu_name --format=csv,noheader --id=0
                       NVIDIA_SMI_STATUS=$?
 
                       # Allowable exit statuses for nvidia-smi, see: https://github.com/NVIDIA/gpu-operator/issues/285


### PR DESCRIPTION
As I learn today that `nvidia-smi` command returns successfully with return code 0 even in the case where the GPU has already crashed, for example https://github.com/pytorch/pytorch/actions/runs/4569152841/jobs/8065422319

```
nvidia-smi
Thu Mar 30 22:41:19 2023 
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 525.89.02    Driver Version: 525.89.02    CUDA Version: 12.0     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  ERR!                Off  | 00000000:00:1E.0 Off |                 ERR! |
|ERR!  ERR! ERR!    ERR! / ERR! |   4184MiB / 23028MiB |    ERR!      Default |
|                               |                      |                 ERR! |
+-------------------------------+----------------------+----------------------+
                                                                               
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
+-----------------------------------------------------------------------------+
+ NVIDIA_SMI_STATUS=0
```

This explicitly queries for the GPU name  with `nvidia-smi --query-gpu=gpu_name --format=csv,noheader --id=0` and as that information is missing (ERR!), the command would fail accordingly (may be?  Need to try it out)

### Testing
https://github.com/pytorch/pytorch/pull/98036