### PR TITLE
Fix pytest log classifier rule to handle the test time

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -86,7 +86,7 @@ pattern = 'XPASS(?: \[.*\])?: (test.*) \((?:__main__\.)?(.*)\)'
 
 [[rule]]
 name = 'pytest failure'
-pattern = '^FAILED (\S*.py::\S*::test_\S*)'
+pattern = '^FAILED (?:\[.*s\])?(\S*.py::\S*::test_\S*)'
 
 [[rule]]
 name = 'Python unittest error'
@@ -94,7 +94,7 @@ pattern = 'ERROR(?: \[.*\])?: (test.*) \((?:__main__\.)?(.*)\)'
 
 [[rule]]
 name = 'pytest test error'
-pattern = '^ERROR (\S*.py::\S*::test_\S*)'
+pattern = '^ERROR (?:\[.*s\])?(\S*.py::\S*::test_\S*)'
 
 [[rule]]
 name = 'inductor model failure'


### PR DESCRIPTION
Previously could not match 
`ERROR [19.7410s] distributed/test_inductor_collectives.py::TestCollectivesMultiProc::test_reduce_scatter_tensor_inductor - RuntimeError: Process 2 exited with error code 10 and exception:`
due to `[19.7410s]`