### PR TITLE
Fix TorchInductor dashboard threshold and add links to runner log for each model

### DIFF
--- a/torchci/components/metrics.module.css
+++ b/torchci/components/metrics.module.css
@@ -16,5 +16,4 @@
 
 .selectedRow {
   background-color: lightblue;
-  font-weight: bold;
 }

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -156,6 +156,7 @@ export interface CompilerPerformanceData {
   speedup: number;
   suite: string;
   workflow_id: number;
+  job_id?: number;
 }
 
 export enum JobAnnotation {

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -279,11 +279,8 @@ function ModelPanel({
                     return styles.error;
                   }
 
-                  if (
-                    !PASSING_ACCURACY.includes(v.l) &&
-                    !PASSING_ACCURACY.includes(v.r)
-                  ) {
-                    return styles.warning;
+                  if (v.l === v.r) {
+                    return "";
                   }
                 }
 
@@ -326,8 +323,14 @@ function ModelPanel({
                     return styles.error;
                   }
 
-                  if (l < SPEEDUP_THRESHOLD && r < SPEEDUP_THRESHOLD) {
-                    return styles.warning;
+                  if ((l === 0 && r === 0) || l === r) {
+                    return "";
+                  }
+
+                  // If the value decreases more than SPEEDUP_THRESHOLD, this also needs to be marked
+                  // as a regression
+                  if (r * SPEEDUP_THRESHOLD > l) {
+                    return styles.error;
                   }
                 }
 
@@ -381,6 +384,10 @@ function ModelPanel({
                     r <= COMPILATION_lATENCY_THRESHOLD_IN_SECONDS
                   ) {
                     return styles.error;
+                  }
+
+                  if (l === r) {
+                    return "";
                   }
 
                   if (
@@ -443,11 +450,14 @@ function ModelPanel({
                     return styles.error;
                   }
 
-                  if (
-                    l < COMPRESSION_RATIO_THRESHOLD &&
-                    r < COMPRESSION_RATIO_THRESHOLD
-                  ) {
-                    return styles.warning;
+                  if ((l === 0 && r === 0) || l === r) {
+                    return "";
+                  }
+
+                  // If the value decreases more than SPEEDUP_THRESHOLD, this also needs to be marked
+                  // as a regression
+                  if (r * COMPRESSION_RATIO_THRESHOLD > l) {
+                    return styles.error;
                   }
                 }
 
@@ -859,6 +869,7 @@ export default function Page() {
           commit={lCommit}
           setCommit={setLCommit}
           queryParams={queryParams}
+          titlePrefix={"New"}
           fallbackIndex={0} // Default to the latest commit
         />
         <Divider orientation="vertical" flexItem>
@@ -870,6 +881,7 @@ export default function Page() {
           commit={rCommit}
           setCommit={setRCommit}
           queryParams={queryParams}
+          titlePrefix={"Base"}
           fallbackIndex={0} // Default to the latest commit
         />
       </Stack>

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -282,7 +282,7 @@ function ModelPanel({
                         <b>{name}</b>
                       </a>
                       &nbsp;(
-                      <a target="_blank" href={lLog}>
+                      <a target="_blank" rel="noreferrer" href={lLog}>
                         <u>{lCommit.substr(0, 7)}</u>
                       </a>
                       )
@@ -296,11 +296,11 @@ function ModelPanel({
                       <b>{name}</b>
                     </a>
                     &nbsp;(
-                    <a target="_blank" href={lLog}>
+                    <a target="_blank" rel="noreferrer" href={lLog}>
                       <u>{lCommit.substr(0, 7)}</u>
                     </a>{" "}
                     ←{" "}
-                    <a target="_blank" href={rLog}>
+                    <a target="_blank" rel="noreferrer" href={rLog}>
                       <u>{rCommit.substr(0, 7)}</u>
                     </a>
                     )

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -65,7 +65,7 @@ export const SUITES: { [k: string]: string } = {
   timm_models: "TIMM models",
 };
 export const MODES = ["training", "inference"];
-export const DTYPES = ["amp", "float32"];
+export const DTYPES = ["amp"];
 export const PASSING_ACCURACY = ["pass", "pass_due_to_skip", "eager_variation"];
 
 // Thresholds
@@ -75,7 +75,7 @@ export const COMPILATION_lATENCY_THRESHOLD_IN_SECONDS = 120;
 export const COMPRESSION_RATIO_THRESHOLD = 0.9;
 
 // Headers
-export const DIFF_HEADER = "New value (L) ← Old value (R)";
+export const DIFF_HEADER = "New value (L) ← Base value (R)";
 const PASSRATE_HEADER = `Passrate (threshold = ${ACCURACY_THRESHOLD}%)`;
 const GEOMEAN_HEADER = `Geometric mean speedup (threshold = ${SPEEDUP_THRESHOLD}x)`;
 const COMPILATION_LATENCY_HEADER = `Mean compilation time (seconds) (threshold = ${COMPILATION_lATENCY_THRESHOLD_IN_SECONDS}s)`;
@@ -533,6 +533,7 @@ export function BranchAndCommitPicker({
   setBranch,
   commit,
   setCommit,
+  titlePrefix,
   fallbackIndex,
 }: {
   queryParams: RocksetParam[];
@@ -540,6 +541,7 @@ export function BranchAndCommitPicker({
   setBranch: any;
   commit: string;
   setCommit: any;
+  titlePrefix: string;
   fallbackIndex: number;
 }) {
   const queryName = "compilers_benchmark_performance_branches";
@@ -614,7 +616,7 @@ export function BranchAndCommitPicker({
 
       <FormControl>
         <InputLabel id={`commit-picker-input-label-${commit}`}>
-          Commit
+          {titlePrefix} Commit
         </InputLabel>
         <Select
           value={commit}
@@ -637,7 +639,15 @@ export function BranchAndCommitPicker({
   );
 }
 
-export function LogLinks({ key, suite, logs }: { key: string; suite: string; logs: any }) {
+export function LogLinks({
+  key,
+  suite,
+  logs,
+}: {
+  key: string;
+  suite: string;
+  logs: any;
+}) {
   return (
     <>
       {" "}
@@ -725,7 +735,13 @@ function CommitPanel({
         {Object.keys(SUITES).map((suite: string) => {
           // Hack alert: The test configuration uses timm instead of timm_model as its output
           const name = suite.includes("timm") ? "timm" : suite;
-          return <LogLinks key={`log-${name}`} suite={suite} logs={logsBySuite[name]} />;
+          return (
+            <LogLinks
+              key={`log-${name}`}
+              suite={suite}
+              logs={logsBySuite[name]}
+            />
+          );
         })}
         .
       </Typography>
@@ -974,6 +990,10 @@ function SummaryPanel({
                         return styles.error;
                       }
 
+                      if (l === r) {
+                        return "";
+                      }
+
                       if (l < ACCURACY_THRESHOLD && r < ACCURACY_THRESHOLD) {
                         return styles.warning;
                       }
@@ -1043,6 +1063,10 @@ function SummaryPanel({
 
                       if (l < SPEEDUP_THRESHOLD && r >= SPEEDUP_THRESHOLD) {
                         return styles.error;
+                      }
+
+                      if (l === r) {
+                        return "";
                       }
 
                       if (l < SPEEDUP_THRESHOLD && r < SPEEDUP_THRESHOLD) {
@@ -1126,6 +1150,10 @@ function SummaryPanel({
                         return styles.error;
                       }
 
+                      if (l === r) {
+                        return "";
+                      }
+
                       if (
                         l > COMPILATION_lATENCY_THRESHOLD_IN_SECONDS &&
                         r > COMPILATION_lATENCY_THRESHOLD_IN_SECONDS
@@ -1206,6 +1234,10 @@ function SummaryPanel({
                         r >= COMPRESSION_RATIO_THRESHOLD
                       ) {
                         return styles.error;
+                      }
+
+                      if (l === r) {
+                        return "";
                       }
 
                       if (
@@ -1610,6 +1642,7 @@ export default function Page() {
           commit={lCommit}
           setCommit={setLCommit}
           queryParams={queryParams}
+          titlePrefix={"New"}
           fallbackIndex={0} // Default to the latest commit
         />
         <Divider orientation="vertical" flexItem>
@@ -1621,6 +1654,7 @@ export default function Page() {
           commit={rCommit}
           setCommit={setRCommit}
           queryParams={queryParams}
+          titlePrefix={"Base"}
           fallbackIndex={1} // Default to the next to latest commit
         />
       </Stack>

--- a/torchci/rockset/inductor/__sql/compilers_benchmark_performance.sql
+++ b/torchci/rockset/inductor/__sql/compilers_benchmark_performance.sql
@@ -11,7 +11,8 @@ WITH performance_results AS (
     ) AS filename,
     compilation_latency,
     compression_ratio,
-    workflow_id,    
+    workflow_id,
+    CAST(job_id AS INT) AS job_id,
   FROM
     inductor.torch_dynamo_perf_stats
   WHERE
@@ -36,6 +37,7 @@ accuracy_results AS (
       )
     ) AS filename,
     workflow_id,
+    CAST(job_id AS INT) AS job_id,
   FROM
     inductor.torch_dynamo_perf_stats
   WHERE
@@ -51,6 +53,7 @@ accuracy_results AS (
 results AS (
   SELECT
     accuracy_results.workflow_id AS workflow_id,
+    accuracy_results.job_id AS job_id,
     CASE
       WHEN accuracy_results.filename LIKE '%_torchbench' THEN 'torchbench'
       WHEN accuracy_results.filename LIKE '%_timm_models' THEN 'timm_models'
@@ -91,6 +94,8 @@ results AS (
 )
 SELECT DISTINCT
   results.workflow_id,
+  -- As the JSON response is pretty big, only return the field if it's needed
+  IF(:getJobId, results.job_id, NULL) AS job_id,
   results.suite,
   results.compiler,
   results.name,

--- a/torchci/rockset/inductor/compilers_benchmark_performance.lambda.json
+++ b/torchci/rockset/inductor/compilers_benchmark_performance.lambda.json
@@ -27,6 +27,11 @@
       "value": "amp"
     },
     {
+      "name": "getJobId",
+      "type": "bool",
+      "value": "false"
+    },
+    {
       "name": "granularity",
       "type": "string",
       "value": "day"
@@ -34,17 +39,17 @@
     {
       "name": "mode",
       "type": "string",
-      "value": "training"
+      "value": "inference"
     },
     {
       "name": "startTime",
       "type": "string",
-      "value": "2023-02-01T00:00:00.00Z"
+      "value": "2023-04-01T00:00:00.00Z"
     },
     {
       "name": "stopTime",
       "type": "string",
-      "value": "2023-04-01T00:00:00.00Z"
+      "value": "2023-04-06T00:00:00.00Z"
     },
     {
       "name": "suites",

--- a/torchci/rockset/inductor/compilers_benchmark_performance.lambda.json
+++ b/torchci/rockset/inductor/compilers_benchmark_performance.lambda.json
@@ -39,7 +39,7 @@
     {
       "name": "mode",
       "type": "string",
-      "value": "inference"
+      "value": "training"
     },
     {
       "name": "startTime",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -65,7 +65,7 @@
     "workflow_load": "48428f8a7c541b76"
   },
   "inductor": {
-    "compilers_benchmark_performance": "fd8a20f0b9ff873d",
+    "compilers_benchmark_performance": "d3434f5f6c89f51c",
     "compilers_benchmark_performance_branches": "2bea08ef6c510f85",
     "compilers_benchmark_performance_latest_runs": "ea73304f42a9316e"
   }

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -65,7 +65,7 @@
     "workflow_load": "48428f8a7c541b76"
   },
   "inductor": {
-    "compilers_benchmark_performance": "d62584b1c5318576",
+    "compilers_benchmark_performance": "fd8a20f0b9ff873d",
     "compilers_benchmark_performance_branches": "2bea08ef6c510f85",
     "compilers_benchmark_performance_latest_runs": "ea73304f42a9316e"
   }


### PR DESCRIPTION
This PR includes a bunch of minor fixes based on recent feedbacks on the dashboard:

* If the accuracy remains the same, the cell won't be highlighted, i.e. `fail_to_run ← fail_to_run`
* If the speedup and memory compression ratio remains the same, the cell won't be highlighted
  * Compilation latency is still highlighted if it takes longer than the fix threshold of 120 seconds
* Highlight the cell if the new speedup or memory compression ratio decrease "significantly".  Specifically, it means reducing by more than 0.95 for speedup and 0.9 for compression ratio
* Rename the dropdown commit list name to `New Commit` and `Base Commit` to tell explicitly which is newer and which is older.
* Query `job_id` so that a link to the shard log for each model can be shown.  Note that the link points to the whole runner log here.  It would be nice to have a better log viewer capability, but that's for another day.
* Add `inference` mode.  Note that this would only be available in recent commits.  It would take few more days to flush out all older commits without `inference` data
* Remove `float32` accuracy

### Testing

https://torchci-git-fork-huydhn-fix-compilers-bench-e6d428-fbopensource.vercel.app/benchmark/compilers
