### PR TITLE
Increase the max number of runners for linux.12xlarge and windows.g5.4xlarge

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -25,7 +25,7 @@ runner_types:
     disk_size: 150
     instance_type: c5.12xlarge
     is_ephemeral: false
-    max_available: 350
+    max_available: 450
     os: linux
   linux.16xlarge.nvidia.gpu:
     disk_size: 150
@@ -136,5 +136,5 @@ runner_types:
     disk_size: 256
     instance_type: g5.4xlarge
     is_ephemeral: false
-    max_available: 150
+    max_available: 250
     os: windows


### PR DESCRIPTION
![Screenshot 2023-04-06 at 12 32 48](https://user-images.githubusercontent.com/4520845/230352309-4b6dd3d0-b08e-48e9-9d19-7d8076e9f24b.png)
