### PR TITLE
Allow retry bot to check the previous workflow when the current one succeeds

### DIFF
--- a/torchci/lib/bot/retryBot.ts
+++ b/torchci/lib/bot/retryBot.ts
@@ -166,25 +166,25 @@ function retryBot(app: Probot): void {
       return;
     }
 
-    let workflowJobs = [];
-    let total_count = 1;
-    const jobs_per_page = 100;
-    for (let i = 0; i * jobs_per_page < total_count; i++) {
-      const data = (
-        await ctx.octokit.rest.actions.listJobsForWorkflowRunAttempt({
-          owner,
-          repo,
-          run_id: runId,
-          attempt_number: attemptNumber,
-          page: i + 1,
-          per_page: jobs_per_page,
-        })
-      ).data;
-      total_count = data.total_count;
-      workflowJobs.push(...data.jobs);
-    }
-
     if (ctx.payload.workflow_run.conclusion !== "success") {
+      let workflowJobs = [];
+      let total_count = 1;
+      const jobs_per_page = 100;
+      for (let i = 0; i * jobs_per_page < total_count; i++) {
+        const data = (
+          await ctx.octokit.rest.actions.listJobsForWorkflowRunAttempt({
+            owner,
+            repo,
+            run_id: runId,
+            attempt_number: attemptNumber,
+            page: i + 1,
+            per_page: jobs_per_page,
+          })
+        ).data;
+        total_count = data.total_count;
+        workflowJobs.push(...data.jobs);
+      }
+
       // Retry jobs from the current workflow only when it fails
       await retryCurrentWorkflow(
         ctx,


### PR DESCRIPTION
I missed removing a check in https://github.com/pytorch/test-infra/pull/3989 to allow the bot to check the previous workflow to see if it's flaky when the current one succeeds.  At the moment, retry bot only kicks in when the current workflow fails.