### PR TITLE
ci: Add hook to limit PR builds automatically to one version of python

### DIFF
--- a/.github/workflows/generate_binary_build_matrix.yml
+++ b/.github/workflows/generate_binary_build_matrix.yml
@@ -27,10 +27,13 @@ on:
         description: "Build with Cuda?"
         default: "enable"
         type: string
+      # ========================================================================
+      # TODO: Remove this once we can ensure that no one is using this anymore
       limit-win-builds:
         description: "Limit windows builds to single python/cuda config"
         default: "disable"
         type: string
+      # ========================================================================
     outputs:
       matrix:
         description: "Generated build matrix"
@@ -58,7 +61,9 @@ jobs:
           OS: ${{ inputs.os }}
           CHANNEL: ${{ inputs.channel }}
           WITH_CUDA: ${{ inputs.with-cuda }}
-          LIMIT_WIN_BUILDS: ${{ inputs.limit-win-builds }}
+          # limit pull request builds to one version of python unless ciflow/binaries/all is applied to the workflow
+          # should not affect builds that are from events that are not the pull_request event
+          LIMIT_PR_BUILDS: ${{ github.event_name == 'pull_request' && !contains( github.event.pull_request.labels.*.name, 'ciflow/binaries/all') }}
         run: |
           set -eou pipefail
           MATRIX_BLOB="$(python3 tools/scripts/generate_binary_build_matrix.py)"


### PR DESCRIPTION
Adds a hook to limit PR builds automatically for our nova pipelines.

Testing for every configuration of python on every pull request sync seems a little bit overboard so this attempts to reel it in by making it so that every pull request will be limited to one version of python _by default_.

There is an option to enable all Python versions by adding the label `ciflow/binaries/all` to your pull request so that previous functionality can be retained.

This is mainly targeted towards windows / macOS workflows but will also be unilaterally applied to all pull requests to keep the behavior consistent.

Example output:
<details>
<summary> `With limiting`
</summary>

```
python3 tools/scripts/generate_binary_build_matrix.py --package-type wheel --operating-system linux --with-cuda enable --limit-pr-builds true | jq
{
  "include": [
    {
      "python_version": "3.8",
      "gpu_arch_type": "cpu",
      "gpu_arch_version": "",
      "desired_cuda": "cpu",
      "container_image": "pytorch/manylinux-builder:cpu",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-cpu",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "cuda",
      "gpu_arch_version": "11.7",
      "desired_cuda": "cu117",
      "container_image": "pytorch/manylinux-builder:cuda11.7",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-cuda11_7",
      "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu117",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "cuda",
      "gpu_arch_version": "11.8",
      "desired_cuda": "cu118",
      "container_image": "pytorch/manylinux-builder:cuda11.8",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-cuda11_8",
      "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "rocm",
      "gpu_arch_version": "5.3",
      "desired_cuda": "rocm5.3",
      "container_image": "pytorch/manylinux-builder:rocm5.3",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-rocm5_3",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.3",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "rocm",
      "gpu_arch_version": "5.4.2",
      "desired_cuda": "rocm5.4.2",
      "container_image": "pytorch/manylinux-builder:rocm5.4.2",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-rocm5_4_2",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.4.2",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    }
  ]
}

```

</details>

<details>
<summary> `Without limiting`
</summary>

```
> python3 tools/scripts/generate_binary_build_matrix.py --package-type wheel --operating-system linux --with-cuda enable --limit-pr-builds false | jq
{
  "include": [
    {
      "python_version": "3.8",
      "gpu_arch_type": "cpu",
      "gpu_arch_version": "",
      "desired_cuda": "cpu",
      "container_image": "pytorch/manylinux-builder:cpu",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-cpu",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "cuda",
      "gpu_arch_version": "11.7",
      "desired_cuda": "cu117",
      "container_image": "pytorch/manylinux-builder:cuda11.7",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-cuda11_7",
      "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu117",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "cuda",
      "gpu_arch_version": "11.8",
      "desired_cuda": "cu118",
      "container_image": "pytorch/manylinux-builder:cuda11.8",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-cuda11_8",
      "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "rocm",
      "gpu_arch_version": "5.3",
      "desired_cuda": "rocm5.3",
      "container_image": "pytorch/manylinux-builder:rocm5.3",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-rocm5_3",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.3",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "rocm",
      "gpu_arch_version": "5.4.2",
      "desired_cuda": "rocm5.4.2",
      "container_image": "pytorch/manylinux-builder:rocm5.4.2",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-rocm5_4_2",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.4.2",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.9",
      "gpu_arch_type": "cpu",
      "gpu_arch_version": "",
      "desired_cuda": "cpu",
      "container_image": "pytorch/manylinux-builder:cpu",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_9-cpu",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.9",
      "gpu_arch_type": "cuda",
      "gpu_arch_version": "11.7",
      "desired_cuda": "cu117",
      "container_image": "pytorch/manylinux-builder:cuda11.7",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_9-cuda11_7",
      "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu117",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.9",
      "gpu_arch_type": "cuda",
      "gpu_arch_version": "11.8",
      "desired_cuda": "cu118",
      "container_image": "pytorch/manylinux-builder:cuda11.8",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_9-cuda11_8",
      "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.9",
      "gpu_arch_type": "rocm",
      "gpu_arch_version": "5.3",
      "desired_cuda": "rocm5.3",
      "container_image": "pytorch/manylinux-builder:rocm5.3",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_9-rocm5_3",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.3",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.9",
      "gpu_arch_type": "rocm",
      "gpu_arch_version": "5.4.2",
      "desired_cuda": "rocm5.4.2",
      "container_image": "pytorch/manylinux-builder:rocm5.4.2",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_9-rocm5_4_2",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.4.2",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.10",
      "gpu_arch_type": "cpu",
      "gpu_arch_version": "",
      "desired_cuda": "cpu",
      "container_image": "pytorch/manylinux-builder:cpu",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_10-cpu",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.10",
      "gpu_arch_type": "cuda",
      "gpu_arch_version": "11.7",
      "desired_cuda": "cu117",
      "container_image": "pytorch/manylinux-builder:cuda11.7",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_10-cuda11_7",
      "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu117",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.10",
      "gpu_arch_type": "cuda",
      "gpu_arch_version": "11.8",
      "desired_cuda": "cu118",
      "container_image": "pytorch/manylinux-builder:cuda11.8",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_10-cuda11_8",
      "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.10",
      "gpu_arch_type": "rocm",
      "gpu_arch_version": "5.3",
      "desired_cuda": "rocm5.3",
      "container_image": "pytorch/manylinux-builder:rocm5.3",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_10-rocm5_3",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.3",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.10",
      "gpu_arch_type": "rocm",
      "gpu_arch_version": "5.4.2",
      "desired_cuda": "rocm5.4.2",
      "container_image": "pytorch/manylinux-builder:rocm5.4.2",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_10-rocm5_4_2",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.4.2",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.11",
      "gpu_arch_type": "cpu",
      "gpu_arch_version": "",
      "desired_cuda": "cpu",
      "container_image": "pytorch/manylinux-builder:cpu",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_11-cpu",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.11",
      "gpu_arch_type": "cuda",
      "gpu_arch_version": "11.7",
      "desired_cuda": "cu117",
      "container_image": "pytorch/manylinux-builder:cuda11.7",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_11-cuda11_7",
      "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu117",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.11",
      "gpu_arch_type": "cuda",
      "gpu_arch_version": "11.8",
      "desired_cuda": "cu118",
      "container_image": "pytorch/manylinux-builder:cuda11.8",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_11-cuda11_8",
      "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.11",
      "gpu_arch_type": "rocm",
      "gpu_arch_version": "5.3",
      "desired_cuda": "rocm5.3",
      "container_image": "pytorch/manylinux-builder:rocm5.3",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_11-rocm5_3",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.3",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    },
    {
      "python_version": "3.11",
      "gpu_arch_type": "rocm",
      "gpu_arch_version": "5.4.2",
      "desired_cuda": "rocm5.4.2",
      "container_image": "pytorch/manylinux-builder:rocm5.4.2",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_11-rocm5_4_2",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.4.2",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.0.0"
    }
  ]
}

```

</details>

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9e3d392</samp>

> _Sing, O Muse, of the cunning code that changed the binary builds_
> _And how the wise `LIMIT_PR_BUILDS` variable was introduced_
> _To tame the endless flow of pull requests that strained the workflow_
> _And how the old `limit-win-builds` input was rendered useless_