### PR TITLE
Compute and upload kpi metric

### DIFF
--- a/.github/scripts/compute_and_upload_ci_wait_time_metric.py
+++ b/.github/scripts/compute_and_upload_ci_wait_time_metric.py
@@ -3,15 +3,14 @@ import time
 import warnings
 import rockset
 import pandas as pd
-import boto3 # type: ignore[import]
+import boto3  # type: ignore[import]
 from botocore.exceptions import ClientError  # type: ignore[import]
 from decimal import Decimal
-
 
 TABLE_NAME = "torchci-metrics-ci-wait-time"
 dynamodb = boto3.resource('dynamodb', region_name="us-east-1")
 
-# Make the results more consistent, and ensure proper typing of the columns
+# Make the records more consistent, and ensure colums are proper typed
 def normalize_workflow_runs(records):
     records['start_time'] = pd.to_datetime(records['start_time'])
     records['end_time'] = pd.to_datetime(records['end_time'])
@@ -19,6 +18,7 @@ def normalize_workflow_runs(records):
     records['pr_number'] = records['pr_number'].astype(int)
     records['workflow_run_id'] = records['workflow_run_id'].astype(int)
     return records
+
 
 def query_workflows_from_rockset() -> pd.DataFrame:
     rs = rockset.RocksetClient(
@@ -28,7 +28,7 @@ def query_workflows_from_rockset() -> pd.DataFrame:
         rockset.models.QueryParameter(
             name="from_days_ago",
             type="int",
-            value="15",
+            value="360",
         ),
         rockset.models.QueryParameter(
             name="to_days_ago",
@@ -54,7 +54,7 @@ def query_workflows_from_rockset() -> pd.DataFrame:
         print(f"Got page {page_num}")
         page_num += 1
         data += page
-    
+
     print(f"Total rows received: {len(data)}")
     end_time = time.time()
     print(f"Total query time: {end_time - start_time} seconds ")
@@ -70,72 +70,83 @@ def remove_cancelled_jobs(df):
     # 2. The run was cancelled by a user's push before any job failed
     # 3. The run was cancelled by a user's push after a job failed
 
-    # Identify the cancellations that were timeouts. It's a timeout if the job was cancelled after 5hrs, 
-    df['was_timeout'] = df.apply(lambda row: row['was_cancelled'] and row['duration_mins'] >= 300, axis=1)
+    # Identify the cancellations that were timeouts. It's a timeout if the job was cancelled after 5hrs,
+    df['was_timeout'] = df.apply(
+        lambda row: row['was_cancelled'] and row['duration_mins'] >= 300, axis=1)
 
-    # Consider timeouts to be a type of failures. 
-    df['conclusion'] = df.apply(lambda row: 'failure' if row['was_timeout'] else row['conclusion'], axis=1)
+    # Consider timeouts to be a type of failures.
+    df['conclusion'] = df.apply(
+        lambda row: 'failure' if row['was_timeout'] else row['conclusion'], axis=1)
 
     # For non-timeout cancellations, if the workflows were cancelled _after_ a job already failed, then
     # we say the failure signal gave the "end time" since it provided an actionable signal.
     # This means we can ignore the 'cancelled' jobs for such workflow runs.
     # Thus, if the job failed, and later it's workflow was cancelled then we ignore those cancelled jobs
-    df = df[~( (df['conclusion'] == 'cancelled') & (df['sha'].isin(df[df['conclusion'] == 'failure']['sha'])))]
+    df = df[~((df['conclusion'] == 'cancelled') & (
+        df['sha'].isin(df[df['conclusion'] == 'failure']['sha'])))]
 
     # Now the remaining cancelled jobs are the ones cancelled due to additional commits being pushed
     # _before_ a job failed. We can ignore these entire commits since they did't provide any actionable signal.
     # Thus we drop all shas that still contain a cancelled job
     df = df[~df['sha'].isin(df[df['conclusion'] == 'cancelled']['sha'])]
-    
+
     return df
 
 
 # For each workflow run, set the start_time for the group to the earliest start_time in that group
 # since the first job shows when the user started waiting on CI
 def normalize_start_times(df):
-    # We track each run attempt in a workflow run separately. 
+    # We track each run attempt in a workflow run separately.
     df_grouped = df.groupby(['sha', 'run_attempt', 'workflow_run_id'])
-    df = df.merge(df_grouped['start_time'].min(), on=['sha', 'run_attempt', 'workflow_run_id'], how='left', suffixes=('_orig', ''))
-    
+    df = df.merge(df_grouped['start_time'].min(), on=[
+                  'sha', 'run_attempt', 'workflow_run_id'], how='left', suffixes=('_orig', ''))
+
     # Update the duration accordingly
-    df['duration_mins'] = round((df['end_time'] - df['start_time']).dt.total_seconds() / 60)
+    df['duration_mins'] = round(
+        (df['end_time'] - df['start_time']).dt.total_seconds() / 60)
 
     return df
 
+
 def ignore_failures_from_retried_jobs(df):
     # If this isn't the last run attempt, then the dev was blocked (unable to retry) until the last job completed.
-    # Simulate that experience by having all conclusions for jobs that were retried to 'success', since 
+    # Simulate that experience by having all conclusions for jobs that were retried to 'success', since
     # we don't want to stop the clock early
-    df['conclusion'] = df.apply(lambda row: 'success' if row['run_attempt'] != row['total_attempts'] else row['conclusion'], axis=1)
+    df['conclusion'] = df.apply(lambda row: 'success' if row['run_attempt']
+                                != row['total_attempts'] else row['conclusion'], axis=1)
     return df
 
 
 # Within a run, if there are both successful and failed jobs, the successful jobs are irrelevant. Let's remove them
 def remove_irrelevant_success_jobs(df):
-    df = normalize_start_times(df) # Ensure we keep the earliest start times
-    print ("normalized start times")
+    df = normalize_start_times(df)  # Ensure we keep the earliest start times
+    print("normalized start times")
 
     # If a sha has a failuring job, then remove 'success' jobs for that sha
     # since the failuring row will set the end time
     df_grouped = df.groupby(['sha', 'run_attempt', 'workflow_run_id'])
     for (sha, run_attempt, workflow_run_id), group in df_grouped:
         if group[group['conclusion'] == 'failure'].shape[0] > 0:
-            df = df[~((df['sha'] == sha) & (df['run_attempt'] == run_attempt) & (df['workflow_run_id'] == workflow_run_id) & (df['conclusion'] == 'success'))]
+            df = df[~((df['sha'] == sha) & (df['run_attempt'] == run_attempt) & (
+                df['workflow_run_id'] == workflow_run_id) & (df['conclusion'] == 'success'))]
 
     # If a run attempt has multiple 'success' jobs, preserve the one that ended last
     df_grouped = df.groupby(['sha', 'run_attempt', 'workflow_run_id'])
     for (sha, run_attempt, workflow_run_id), group in df_grouped:
         if group[group['conclusion'] == 'successs'].shape[0] > 1:
-            df = df[~((df['sha'] == sha) & (df['run_attempt'] == run_attempt) & (df['workflow_run_id'] == workflow_run_id) & (df['conclusion'] == 'success') & (df['end_time'] != group['end_time'].max()))]
+            df = df[~((df['sha'] == sha) & (df['run_attempt'] == run_attempt) & (df['workflow_run_id'] == workflow_run_id) & (
+                df['conclusion'] == 'success') & (df['end_time'] != group['end_time'].max()))]
 
     return df
+
 
 # Within a run, if there are multiple batches of failed jobs, the one that ends first gave the first signal
 def remove_irrelevant_failure_jobs(df):
     df_grouped = df.groupby(['sha', 'run_attempt', 'workflow_run_id'])
     for (sha, run_attempt, workflow_run_id), group in df_grouped:
         if group[group['conclusion'] == 'failure'].shape[0] > 1:
-            df = df[~((df['sha'] == sha) & (df['run_attempt'] == run_attempt) & (df['workflow_run_id'] == workflow_run_id) & (df['conclusion'] == 'failure') & (df['end_time'] != group['end_time'].min()))]
+            df = df[~((df['sha'] == sha) & (df['run_attempt'] == run_attempt) & (df['workflow_run_id'] == workflow_run_id) & (
+                df['conclusion'] == 'failure') & (df['end_time'] != group['end_time'].min()))]
 
     return df
 
@@ -149,16 +160,17 @@ def discard_weird_cases(df):
     for _, group in df_grouped:
         if group.shape[0] > 1:
             df = df[~df['pr_number'].isin(group['pr_number'])]
-    
-    # The same workflow can get accidentally triggered against the same commit more than 
+
+    # The same workflow can get accidentally triggered against the same commit more than
     #  once (I'm not talking about retries here).
-    # We remove duplicate workflows that were run against the same commit, keeping only 
-    #  the workflow triggered first. 
+    # We remove duplicate workflows that were run against the same commit, keeping only
+    #  the workflow triggered first.
     # They'll have different workflow_run_ids but the same workflow name
     df_grouped = df.groupby(['sha', 'workflow_name', 'run_attempt'])
     for (sha, workflow_name, run_attempt), group in df_grouped:
         if group.shape[0] > 1:
-            df = df[~((df['sha'] == sha) & (df['workflow_name'] == workflow_name) & (df['run_attempt'] == run_attempt) & (df['start_time'] != group['start_time'].min()))]
+            df = df[~((df['sha'] == sha) & (df['workflow_name'] == workflow_name) & (
+                df['run_attempt'] == run_attempt) & (df['start_time'] != group['start_time'].min()))]
 
     return df
 
@@ -178,18 +190,18 @@ class OverlapableTimeSpan:
             return True
         else:
             return False
-        
+
     def get_duration_mins(self):
         return round((self.end_time - self.start_time).total_seconds() / 60)
 
 
 # Combine the time spans across all jobs in a PR to get the PR's total duration.
-# Some workflows run in parallel, e.g. pull/trunk, and we don't want to double count time 
+# Some workflows run in parallel, e.g. pull/trunk, and we don't want to double count time
 # spent waiting on them
 def get_duration_for_pr(pr_df_group):
     logged_timespans = []
     pr_df_group = pr_df_group.sort_values(by=['start_time'])
-    
+
     # Find the overlapping timespans and combine them
     for _, row in pr_df_group.iterrows():
         timespan = OverlapableTimeSpan(row['start_time'], row['end_time'])
@@ -210,23 +222,27 @@ def get_duration_for_pr(pr_df_group):
 
     return duration
 
+
 def validate_all_data_has_been_deduped(df):
-    unduped_jobs = pd.DataFrame(columns=['sha', 'run_attempt', 'workflow_run_id'])
+    unduped_jobs = pd.DataFrame(
+        columns=['sha', 'run_attempt', 'workflow_run_id'])
 
     df_grouped = df.groupby(['sha', 'run_attempt', 'workflow_run_id'])
     for (sha, run_attempt, workflow_run_id), group in df_grouped:
         if group.shape[0] > 1:
-            print ("Found duplicate rows for sha: %s, run_attempt: %s, workflow_run_id: %s" % (sha, run_attempt, workflow_run_id))
-            print (group)
+            print("Found duplicate rows for sha: %s, run_attempt: %s, workflow_run_id: %s" % (
+                sha, run_attempt, workflow_run_id))
+            print(group)
             unduped_jobs = unduped_jobs.append(group)
 
     if unduped_jobs.shape[0] > 0:
-        raise Exception("Found unduped jobs for records: %s" % unduped_jobs.to_string())
+        raise Exception("Found unduped jobs for records: %s" %
+                        unduped_jobs.to_string())
     else:
-        print ("All data has been deduped")
+        print("All data has been deduped")
 
-# Now that jobs with the same sha, run_attempt, and workflow_run_id have all 
-#  been deduped, we only have a single conclusion for each workflow run attempt
+
+# Now that jobs within a run have been deduped, we only have a single conclusion for each run.
 # We're interested in:
 #  1. The wall clock time spent waiting on the CI per PR
 #  2. The number of commits it had
@@ -234,10 +250,11 @@ def get_pr_level_stats(df):
     # Now, all run attempts should have exactly one row. If not, we missed a corner case
     validate_all_data_has_been_deduped(df)
 
-    df_results = pd.DataFrame(columns=['pr_number', 'duration_mins', 'end_time'])
-    
-    df_grouped = df.groupby('pr_number')    
-    for (pr_number), group in df_grouped:        
+    df_results = pd.DataFrame(
+        columns=['pr_number', 'duration_mins', 'end_time'])
+
+    df_grouped = df.groupby('pr_number')
+    for (pr_number), group in df_grouped:
         pr_ci_duration = get_duration_for_pr(group)
         num_commits = group['sha'].nunique()
         pr_start_time = group['start_time'].min()
@@ -250,35 +267,36 @@ def get_pr_level_stats(df):
 
         # Stats for this PR
         df_results = pd.concat([df_results, pd.DataFrame({
-            'pr_number': [pr_number], 
+            'pr_number': [pr_number],
             'duration_mins': [pr_ci_duration],
             'start_time': [pr_start_time],
             'end_time': [pr_end_time],
             'num_commits': [num_commits],
             'week': [week],
         })])
-    
+
     return df_results
+
 
 def get_pr_stats() -> pd.DataFrame:
     runs = query_workflows_from_rockset()
 
     # Now we have all the raw data and it's ime to start filtering it
     #
-    # We need to figure out the effective start/end times for each workflow run 
+    # We need to figure out the effective start/end times for each workflow run
     # even though that workflows could have concluded in different ways
     #
     # Definitions:
     #   Start time: When the CI jobs were requested (usually when the dev pushes the commit, can
     #                also be when a label is applied to a commit, or when a workflow is rerun)
     #   End time:   When the dev has an actionable signal. Actionable meaning it's either an
-    #                all green signal or it's the first red signal 
+    #                all green signal or it's the first red signal
     #
     # We filter out jobs that don't contribute to determining the end time of the workflow run
     #
     # The rules used to figure that out:
     #   1. If jobs in a workflow are cancelled before any jobs in CI failed, then the dev
-    #       must have pushed a new commit before getting a signal from CI. 
+    #       must have pushed a new commit before getting a signal from CI.
     #       Since they were not blocked on CI, we ignore that entire commit's workflow.
     #       The only exception is when the job duration was >5hrs, in which case they actually
     #       ran into a timeout
@@ -288,14 +306,16 @@ def get_pr_stats() -> pd.DataFrame:
     #       succeed or fail after that one are irrelevant
     #   3. If all jobs complete successfully, the last job that completed is what gives the
     #       signal (i.e. sets the end time)
+
     runs = remove_cancelled_jobs(runs)
-    runs = normalize_start_times(runs) # Ensure all jobs with a workflow have the same start time
+    runs = normalize_start_times(runs) # Ensure all jobs from a workflow run have the same start time
     runs = ignore_failures_from_retried_jobs(runs)
     runs = remove_irrelevant_success_jobs(runs)
     runs = remove_irrelevant_failure_jobs(runs)
     runs = discard_weird_cases(runs)
 
     return get_pr_level_stats(runs)
+
 
 def table_exists(table_name: str) -> bool:
     """
@@ -317,6 +337,7 @@ def table_exists(table_name: str) -> bool:
             print(err.response)
     return exists
 
+
 def upload_stats(pr_stats):
     print(f"Uploading data to {TABLE_NAME}")
 
@@ -325,18 +346,6 @@ def upload_stats(pr_stats):
     for _, row in pr_stats.iterrows():
         dynamoKey = str(row['pr_number'])
 
-        # # # Check if stats table already has the row
-        # print (f"Checking for key {dynamoKey}")
-        # record = statsTable.get_item(
-        #     Key={
-        #         'dynamoKey': dynamoKey,
-        #     }
-        # )
-
-        # print(f"Got record: {record}")
-
-        # If record exists, update it
-        # if 'Item' in record:
         print("Updating record for key: %s" % dynamoKey)
         statsTable.update_item(
             Key={
@@ -352,36 +361,6 @@ def upload_stats(pr_stats):
                 ':w': row['week'].isoformat(),
             }
         )
-        # else:    
-        #     # If it doesn't, insert it
-        #     print("Inserting record for key: %s" % dynamoKey)
-        #     statsTable.put_item(
-        #         Item={
-        #             'dynamoKey': dynamoKey,
-        #             'week': row['week'].isoformat(),
-        #             'pr_number': row['pr_number'],
-        #             'duration_mins': int(row['duration_mins']),
-        #             'start_time': row['start_time'].isoformat(),
-        #             'end_time': row['end_time'].isoformat(),
-        #             'num_commits': int(row['num_commits']),
-        #         }
-        #     )
-
-        # statsTable.update_item(
-        #     Key={
-        #         'dynamoKey': f"{row['week'].isoformat()}_{row['pr_number']}",
-        #     },
-        #     UpdateExpression="set pr_number=:p, duration_mins=:d, start_time=:s, end_time=:e, num_commits=:n, week=:w",
-        #     ExpressionAttributeValues={
-        #         ':p': row['pr_number'],
-        #         ':d': int(row['duration_mins']),
-        #         ':s': row['start_time'].isoformat(),
-        #         ':e': row['end_time'].isoformat(),
-        #         ':n': int(row['num_commits']),
-        #         ':w': row['week'].isoformat(),
-        #     },
-        #     ReturnValues="UPDATED_NEW"
-        # ) 
 
     print(f"Finished uploading data to {TABLE_NAME}")
 
@@ -394,6 +373,7 @@ def main() -> None:
     upload_stats(pr_stats)
 
     return 0
+
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/compute_and_upload_ci_wait_time_metric.py
+++ b/.github/scripts/compute_and_upload_ci_wait_time_metric.py
@@ -381,7 +381,7 @@ def upload_stats(pr_stats):
         #         ':w': row['week'].isoformat(),
         #     },
         #     ReturnValues="UPDATED_NEW"
-        # )
+        # ) 
 
     print(f"Finished uploading data to {TABLE_NAME}")
 

--- a/.github/scripts/compute_and_upload_ci_wait_time_metric.py
+++ b/.github/scripts/compute_and_upload_ci_wait_time_metric.py
@@ -320,14 +320,13 @@ def upload_stats(pr_stats):
     statsTable = dynamodb.Table(TABLE_NAME)
 
     for _, row in pr_stats.iterrows():
-        dynamoKey = f"{row['week'].isoformat()}_{row['pr_number']}"
+        weekKey = str(row['week'].isoformat())
 
         # # Check if stats table already has the row
-        print (f"Checking for key {dynamoKey}")
+        print (f"Checking for key {weekKey}")
         record = statsTable.get_item(
             Key={
-                'dynamoKey': dynamoKey,
-                'pr_number': str(row['pr_number']),
+                'week': weekKey,
             }
         )
 
@@ -335,11 +334,10 @@ def upload_stats(pr_stats):
 
         # If record exists, update it
         if 'Item' in record:
-            print("Updating record for dynamoKey: %s" % dynamoKey)
+            print("Updating record for week: %s" % weekKey)
             statsTable.update_item(
                 Key={
-                    'dynamoKey': dynamoKey,
-                    'pr_number': str(row['pr_number']),
+                    'week': weekKey,
                 },
                 UpdateExpression="set pr_number=:p duration_mins=:d, start_time=:s, end_time=:e, num_commits=:n, week=:w",
                 ExpressionAttributeValues={
@@ -353,16 +351,15 @@ def upload_stats(pr_stats):
             )
         else:    
             # If it doesn't, insert it
-            print("Inserting record for dynamoKey: %s" % dynamoKey)
+            print("Inserting record for week: %s" % weekKey)
             statsTable.put_item(
                 Item={
-                    'dynamoKey': dynamoKey,
+                    'week': row['week'].isoformat(),
                     'pr_number': row['pr_number'],
                     'duration_mins': int(row['duration_mins']),
                     'start_time': row['start_time'].isoformat(),
                     'end_time': row['end_time'].isoformat(),
                     'num_commits': int(row['num_commits']),
-                    'week': row['week'].isoformat(),
                 }
             )
 

--- a/.github/scripts/compute_and_upload_ci_wait_time_metric.py
+++ b/.github/scripts/compute_and_upload_ci_wait_time_metric.py
@@ -330,36 +330,15 @@ def get_pr_stats() -> pd.DataFrame:
     return get_pr_level_stats(runs)
 
 
-def table_exists(table_name: str) -> bool:
-    """
-    Determines whether a table exists. As a side effect, stores the table in
-    a member variable.
-    """
-    exists = None
-    try:
-        table = dynamodb.Table(table_name)
-        table.load()
-        exists = True
-        print(f"Table '{table_name}' exists")
-    except ClientError as err:
-        if err.response["Error"]["Code"] == "ResourceNotFoundException":
-            print(f"Table '{table_name}' does not exist")
-            exists = False
-        else:
-            print("Unknown error")
-            print(err.response)
-    return exists
-
-
 def upload_stats(pr_stats):
     print(f"Uploading data to {TABLE_NAME}")
 
     statsTable = dynamodb.Table(TABLE_NAME)
 
+    start_time = time.time()
     for _, row in pr_stats.iterrows():
         dynamoKey = str(row['pr_number'])
 
-        print("Updating record for key: %s" % dynamoKey)
         statsTable.update_item(
             Key={
                 'dynamoKey': dynamoKey,
@@ -375,7 +354,9 @@ def upload_stats(pr_stats):
             }
         )
 
-    print(f"Finished uploading data to {TABLE_NAME}")
+    end_time = time.time()
+
+    print(f"Finished uploading data to {TABLE_NAME}, updated {pr_stats.shape[0]} rows in  {round((end_time - start_time)/60.0, 1)} minutes")
 
 
 def main() -> None:

--- a/.github/scripts/compute_and_upload_ci_wait_time_metric.py
+++ b/.github/scripts/compute_and_upload_ci_wait_time_metric.py
@@ -329,6 +329,12 @@ def get_pr_stats() -> pd.DataFrame:
 
     return get_pr_level_stats(runs)
 
+# Shares that the the last num_prs_updated PRs from pr_list have been updated
+def log_recently_updated_prs(pr_list, num_prs_updated):
+    if num_prs_updated > 0:
+        latest_updates = ", ".join(pr_list[(-num_prs_updated):])
+        print(f"Updated PRs: {latest_updates}")
+
 
 def upload_stats(pr_stats):
     print(f"Uploading data to {TABLE_NAME}")
@@ -359,15 +365,10 @@ def upload_stats(pr_stats):
 
         updated_prs.append(dynamoKey)
         if len(updated_prs) % UPDATE_ANNOUNCEMENT_BATCH_SIZE == 0:
-            # print the last 10 prs updated
-            latest_updates = ", ".join(updated_prs[(-UPDATE_ANNOUNCEMENT_BATCH_SIZE):])
-            print(f"Updated {latest_updates}")
+            log_recently_updated_prs(updated_prs, UPDATE_ANNOUNCEMENT_BATCH_SIZE)
 
     # print the last batch of prs updated (if any)
-    last_updates = len(updated_prs) % UPDATE_ANNOUNCEMENT_BATCH_SIZE
-    if last_updates > 0:
-        latest_updates = ", ".join(updated_prs[-last_updates:])
-        print(f"Updated {latest_updates}")
+    log_recently_updated_prs(updated_prs, len(updated_prs) % UPDATE_ANNOUNCEMENT_BATCH_SIZE)
 
     end_time = time.time()
 

--- a/.github/scripts/compute_and_upload_ci_wait_time_metric.py
+++ b/.github/scripts/compute_and_upload_ci_wait_time_metric.py
@@ -327,7 +327,7 @@ def upload_stats(pr_stats):
         record = statsTable.get_item(
             Key={
                 'dynamoKey': dynamoKey,
-                'pr_number': row['pr_number'],
+                'pr_number': str(row['pr_number']),
             }
         )
 
@@ -339,6 +339,7 @@ def upload_stats(pr_stats):
             statsTable.update_item(
                 Key={
                     'dynamoKey': dynamoKey,
+                    'pr_number': str(row['pr_number']),
                 },
                 UpdateExpression="set pr_number=:p duration_mins=:d, start_time=:s, end_time=:e, num_commits=:n, week=:w",
                 ExpressionAttributeValues={

--- a/.github/scripts/compute_and_upload_ci_wait_time_metric.py
+++ b/.github/scripts/compute_and_upload_ci_wait_time_metric.py
@@ -327,6 +327,7 @@ def upload_stats(pr_stats):
         record = statsTable.get_item(
             Key={
                 'dynamoKey': dynamoKey,
+                'pr_number': row['pr_number'],
             }
         )
 

--- a/.github/scripts/compute_and_upload_ci_wait_time_metric.py
+++ b/.github/scripts/compute_and_upload_ci_wait_time_metric.py
@@ -276,7 +276,7 @@ def get_pr_level_stats(df):
         # Suppress warning "Converting to Period representation will drop timezone information."
         with warnings.catch_warnings():
             warnings.simplefilter(action='ignore', category=UserWarning)
-            week = pr_end_time.to_period('W').start_time
+            week = pr_end_time.to_period('W').start_time # The week that CI was last run against the PR. Usually the week it was merged.
 
         # Stats for this PR
         df_results = pd.concat([df_results, pd.DataFrame({

--- a/.github/scripts/compute_and_upload_ci_wait_time_metric.py
+++ b/.github/scripts/compute_and_upload_ci_wait_time_metric.py
@@ -342,7 +342,7 @@ def upload_stats(pr_stats):
                 Key={
                     'dynamoKey': dynamoKey,
                 },
-                UpdateExpression="set pr_number=:p duration_mins=:d, start_time=:s, end_time=:e, num_commits=:n, week=:w",
+                UpdateExpression="set pr_number=:p, duration_mins=:d, start_time=:s, end_time=:e, num_commits=:n, week=:w",
                 ExpressionAttributeValues={
                     ':p': row['pr_number'],
                     ':d': int(row['duration_mins']),

--- a/.github/scripts/compute_and_upload_ci_wait_time_metric.py
+++ b/.github/scripts/compute_and_upload_ci_wait_time_metric.py
@@ -325,53 +325,53 @@ def upload_stats(pr_stats):
     for _, row in pr_stats.iterrows():
         dynamoKey = str(row['pr_number'])
 
-        # # Check if stats table already has the row
-        print (f"Checking for key {dynamoKey}")
-        record = statsTable.get_item(
-            Key={
-                'dynamoKey': dynamoKey,
-            }
-        )
+        # # # Check if stats table already has the row
+        # print (f"Checking for key {dynamoKey}")
+        # record = statsTable.get_item(
+        #     Key={
+        #         'dynamoKey': dynamoKey,
+        #     }
+        # )
 
-        print(f"Got record: {record}")
+        # print(f"Got record: {record}")
 
         # If record exists, update it
-        if 'Item' in record:
-            print("Updating record for key: %s" % dynamoKey)
-            statsTable.update_item(
-                Key={
-                    'dynamoKey': dynamoKey,
-                },
-                UpdateExpression="set pr_number=:p, duration_mins=:d, start_time=:s, end_time=:e, num_commits=:n, week=:w",
-                ExpressionAttributeValues={
-                    ':p': row['pr_number'],
-                    ':d': int(row['duration_mins']),
-                    ':s': row['start_time'].isoformat(),
-                    ':e': row['end_time'].isoformat(),
-                    ':n': int(row['num_commits']),
-                    ':w': row['week'].isoformat(),
-                }
-            )
-        else:    
-            # If it doesn't, insert it
-            print("Inserting record for key: %s" % dynamoKey)
-            statsTable.put_item(
-                Item={
-                    'dynamoKey': dynamoKey,
-                    'week': row['week'].isoformat(),
-                    'pr_number': row['pr_number'],
-                    'duration_mins': int(row['duration_mins']),
-                    'start_time': row['start_time'].isoformat(),
-                    'end_time': row['end_time'].isoformat(),
-                    'num_commits': int(row['num_commits']),
-                }
-            )
+        # if 'Item' in record:
+        print("Updating record for key: %s" % dynamoKey)
+        statsTable.update_item(
+            Key={
+                'dynamoKey': dynamoKey,
+            },
+            UpdateExpression="set pr_number=:p, duration_mins=:d, start_time=:s, end_time=:e, num_commits=:n, week=:w",
+            ExpressionAttributeValues={
+                ':p': row['pr_number'],
+                ':d': int(row['duration_mins']),
+                ':s': row['start_time'].isoformat(),
+                ':e': row['end_time'].isoformat(),
+                ':n': int(row['num_commits']),
+                ':w': row['week'].isoformat(),
+            }
+        )
+        # else:    
+        #     # If it doesn't, insert it
+        #     print("Inserting record for key: %s" % dynamoKey)
+        #     statsTable.put_item(
+        #         Item={
+        #             'dynamoKey': dynamoKey,
+        #             'week': row['week'].isoformat(),
+        #             'pr_number': row['pr_number'],
+        #             'duration_mins': int(row['duration_mins']),
+        #             'start_time': row['start_time'].isoformat(),
+        #             'end_time': row['end_time'].isoformat(),
+        #             'num_commits': int(row['num_commits']),
+        #         }
+        #     )
 
         # statsTable.update_item(
         #     Key={
         #         'dynamoKey': f"{row['week'].isoformat()}_{row['pr_number']}",
         #     },
-        #     UpdateExpression="set pr_number=:p duration_mins=:d, start_time=:s, end_time=:e, num_commits=:n, week=:w",
+        #     UpdateExpression="set pr_number=:p, duration_mins=:d, start_time=:s, end_time=:e, num_commits=:n, week=:w",
         #     ExpressionAttributeValues={
         #         ':p': row['pr_number'],
         #         ':d': int(row['duration_mins']),

--- a/.github/scripts/compute_and_upload_ci_wait_time_metric.py
+++ b/.github/scripts/compute_and_upload_ci_wait_time_metric.py
@@ -107,8 +107,12 @@ def remove_cancelled_jobs(df):
 def normalize_start_times(df):
     # We track each run attempt in a workflow run separately.
     df_grouped = df.groupby(['sha', 'run_attempt', 'workflow_run_id'])
-    df = df.merge(df_grouped['start_time'].min(), on=[
-                  'sha', 'run_attempt', 'workflow_run_id'], how='left', suffixes=('_orig', ''))
+
+    # Suppress warning "FutureWarning: Passing 'suffixes' which cause duplicate columns {'start_time_orig'} in the result is deprecated and will raise a MergeError in a future version."
+    with warnings.catch_warnings():
+        warnings.simplefilter(action='ignore', category=FutureWarning)
+        df = df.merge(df_grouped['start_time'].min(), on=[
+                    'sha', 'run_attempt', 'workflow_run_id'], how='left', suffixes=('_orig', ''))
 
     # Update the duration accordingly
     df['duration_mins'] = round(

--- a/.github/scripts/compute_and_upload_ci_wait_time_metric.py
+++ b/.github/scripts/compute_and_upload_ci_wait_time_metric.py
@@ -28,7 +28,7 @@ def query_workflows_from_rockset() -> pd.DataFrame:
         rockset.models.QueryParameter(
             name="from_days_ago",
             type="int",
-            value="300",
+            value="30",
         ),
         rockset.models.QueryParameter(
             name="to_days_ago",

--- a/.github/scripts/compute_and_upload_ci_wait_time_metric.py
+++ b/.github/scripts/compute_and_upload_ci_wait_time_metric.py
@@ -1,0 +1,392 @@
+import os
+import time
+import rockset
+import pandas as pd
+import boto3 # type: ignore[import]
+from botocore.exceptions import ClientError  # type: ignore[import]
+from decimal import Decimal
+
+
+TABLE_NAME = "torchci-metrics-ci-wait-time"
+dynamodb = boto3.resource('dynamodb', region_name="us-east-1")
+
+# Make the results more consistent, and ensure proper typing of the columns
+def normalize_workflow_runs(records):
+    records['start_time'] = pd.to_datetime(records['start_time'])
+    records['end_time'] = pd.to_datetime(records['end_time'])
+
+    records['pr_number'] = records['pr_number'].astype(int)
+    records['workflow_run_id'] = records['workflow_run_id'].astype(int)
+    return records
+
+def query_workflows_from_rockset() -> pd.DataFrame:
+    rs = rockset.RocksetClient(
+        host="api.usw2a1.rockset.com", api_key=os.environ["ROCKSET_API_KEY"]
+    )
+    params = [
+        rockset.models.QueryParameter(
+            name="from_days_ago",
+            type="int",
+            value="15",
+        ),
+        rockset.models.QueryParameter(
+            name="to_days_ago",
+            type="int",
+            value="0",
+        ),
+    ]
+
+    data = []
+    page_num = 1
+    start_time = time.time()
+    for page in rockset.QueryPaginator(
+        rs,
+        rs.QueryLambdas.execute_query_lambda(
+            query_lambda="completed_pr_jobs_aggregate",
+            version="01fc2a697ae85856",
+            workspace="metrics",
+            parameters=params,
+            paginate=True,
+            initial_paginate_response_doc_count=10000,
+        )
+    ):
+        print(f"Got page {page_num}")
+        page_num += 1
+        data += page
+    
+    print(f"Total rows received: {len(data)}")
+    end_time = time.time()
+    print(f"Total query time: {end_time - start_time} seconds ")
+
+    results_df = pd.json_normalize(data)
+
+    return normalize_workflow_runs(results_df)
+
+
+def remove_cancelled_jobs(df):
+    # Cancelled jobs can fall into one of three categories:
+    # 1. The job timed out
+    # 2. The run was cancelled by a user's push before any job failed
+    # 3. The run was cancelled by a user's push after a job failed
+
+    # Identify the cancellations that were timeouts. It's a timeout if the job was cancelled after 5hrs, 
+    df['was_timeout'] = df.apply(lambda row: row['was_cancelled'] and row['duration_mins'] >= 300, axis=1)
+
+    # Consider timeouts to be a type of failures. 
+    df['conclusion'] = df.apply(lambda row: 'failure' if row['was_timeout'] else row['conclusion'], axis=1)
+
+    # For non-timeout cancellations, if the workflows were cancelled _after_ a job already failed, then
+    # we say the failure signal gave the "end time" since it provided an actionable signal.
+    # This means we can ignore the 'cancelled' jobs for such workflow runs.
+    # Thus, if the job failed, and later it's workflow was cancelled then we ignore those cancelled jobs
+    df = df[~( (df['conclusion'] == 'cancelled') & (df['sha'].isin(df[df['conclusion'] == 'failure']['sha'])))]
+
+    # Now the remaining cancelled jobs are the ones cancelled due to additional commits being pushed
+    # _before_ a job failed. We can ignore these entire commits since they did't provide any actionable signal.
+    # Thus we drop all shas that still contain a cancelled job
+    df = df[~df['sha'].isin(df[df['conclusion'] == 'cancelled']['sha'])]
+    
+    return df
+
+
+# For each workflow run, set the start_time for the group to the earliest start_time in that group
+# since the first job shows when the user started waiting on CI
+def normalize_start_times(df):
+    # We track each run attempt in a workflow run separately. 
+    df_grouped = df.groupby(['sha', 'run_attempt', 'workflow_run_id'])
+    df = df.merge(df_grouped['start_time'].min(), on=['sha', 'run_attempt', 'workflow_run_id'], how='left', suffixes=('_orig', ''))
+    
+    # Update the duration accordingly
+    df['duration_mins'] = round((df['end_time'] - df['start_time']).dt.total_seconds() / 60)
+
+    return df
+
+def ignore_failures_from_retried_jobs(df):
+    # If this isn't the last run attempt, then the dev was blocked (unable to retry) until the last job completed.
+    # Simulate that experience by having all conclusions for jobs that were retried to 'success', since 
+    # we don't want to stop the clock early
+    df['conclusion'] = df.apply(lambda row: 'success' if row['run_attempt'] != row['total_attempts'] else row['conclusion'], axis=1)
+    return df
+
+
+# Within a run, if there are both successful and failed jobs, the successful jobs are irrelevant. Let's remove them
+def remove_irrelevant_success_jobs(df):
+    df = normalize_start_times(df) # Ensure we keep the earliest start times
+    print ("normalized start times")
+
+    # If a sha has a failuring job, then remove 'success' jobs for that sha
+    # since the failuring row will set the end time
+    df_grouped = df.groupby(['sha', 'run_attempt', 'workflow_run_id'])
+    for (sha, run_attempt, workflow_run_id), group in df_grouped:
+        if group[group['conclusion'] == 'failure'].shape[0] > 0:
+            df = df[~((df['sha'] == sha) & (df['run_attempt'] == run_attempt) & (df['workflow_run_id'] == workflow_run_id) & (df['conclusion'] == 'success'))]
+
+    # If a run attempt has multiple 'success' jobs, preserve the one that ended last
+    df_grouped = df.groupby(['sha', 'run_attempt', 'workflow_run_id'])
+    for (sha, run_attempt, workflow_run_id), group in df_grouped:
+        if group[group['conclusion'] == 'successs'].shape[0] > 1:
+            df = df[~((df['sha'] == sha) & (df['run_attempt'] == run_attempt) & (df['workflow_run_id'] == workflow_run_id) & (df['conclusion'] == 'success') & (df['end_time'] != group['end_time'].max()))]
+
+    return df
+
+# Within a run, if there are multiple batches of failed jobs, the one that ends first gave the first signal
+def remove_irrelevant_failure_jobs(df):
+    df_grouped = df.groupby(['sha', 'run_attempt', 'workflow_run_id'])
+    for (sha, run_attempt, workflow_run_id), group in df_grouped:
+        if group[group['conclusion'] == 'failure'].shape[0] > 1:
+            df = df[~((df['sha'] == sha) & (df['run_attempt'] == run_attempt) & (df['workflow_run_id'] == workflow_run_id) & (df['conclusion'] == 'failure') & (df['end_time'] != group['end_time'].min()))]
+
+    return df
+
+
+# Some jobs are extra funky. Remove them from our data to donoise it and decomplicate the logic.
+def discard_weird_cases(df):
+    # Multiple PRs could potentially share the same commit in their history
+    #  (this only affected 4 PRs over a 6 month window)
+    # Discard those PRs.
+    df_grouped = df.groupby(['sha', 'run_attempt', 'workflow_run_id'])
+    for _, group in df_grouped:
+        if group.shape[0] > 1:
+            df = df[~df['pr_number'].isin(group['pr_number'])]
+    
+    # The same workflow can get accidentally triggered against the same commit more than 
+    #  once (I'm not talking about retries here).
+    # We remove duplicate workflows that were run against the same commit, keeping only 
+    #  the workflow triggered first. 
+    # They'll have different workflow_run_ids but the same workflow name
+    df_grouped = df.groupby(['sha', 'workflow_name', 'run_attempt'])
+    for (sha, workflow_name, run_attempt), group in df_grouped:
+        if group.shape[0] > 1:
+            df = df[~((df['sha'] == sha) & (df['workflow_name'] == workflow_name) & (df['run_attempt'] == run_attempt) & (df['start_time'] != group['start_time'].min()))]
+
+    return df
+
+
+class OverlapableTimeSpan:
+    def __init__(self, start_time, end_time):
+        self.start_time = start_time
+        self.end_time = end_time
+
+    def overlaps_with(self, timespan):
+        return self.start_time < timespan.end_time and self.end_time > timespan.start_time
+
+    def union_with(self, timespan):
+        if self.overlaps_with(timespan):
+            self.start_time = min(self.start_time, timespan.start_time)
+            self.end_time = max(self.end_time, timespan.end_time)
+            return True
+        else:
+            return False
+        
+    def get_duration_mins(self):
+        return round((self.end_time - self.start_time).total_seconds() / 60)
+
+
+# Combine the time spans across all jobs in a PR to get the PR's total duration.
+# Some workflows run in parallel, e.g. pull/trunk, and we don't want to double count time 
+# spent waiting on them
+def get_duration_for_pr(pr_df_group):
+    logged_timespans = []
+    pr_df_group = pr_df_group.sort_values(by=['start_time'])
+    
+    # Find the overlapping timespans and combine them
+    for _, row in pr_df_group.iterrows():
+        timespan = OverlapableTimeSpan(row['start_time'], row['end_time'])
+        found_match = False
+        for existing_span in logged_timespans:
+            if existing_span.overlaps_with(timespan):
+                # Found an overlapping set of timestamps
+                existing_span.union_with(timespan)
+                found_match = True
+                break
+
+        if not found_match:
+            logged_timespans.append(timespan)
+
+    duration = 0
+    for timespan in logged_timespans:
+        duration += timespan.get_duration_mins()
+
+    return duration
+
+def validate_all_data_has_been_deduped(df):
+    unduped_jobs = pd.DataFrame(columns=['sha', 'run_attempt', 'workflow_run_id'])
+
+    df_grouped = df.groupby(['sha', 'run_attempt', 'workflow_run_id'])
+    for (sha, run_attempt, workflow_run_id), group in df_grouped:
+        if group.shape[0] > 1:
+            print ("Found duplicate rows for sha: %s, run_attempt: %s, workflow_run_id: %s" % (sha, run_attempt, workflow_run_id))
+            print (group)
+            unduped_jobs = unduped_jobs.append(group)
+
+    if unduped_jobs.shape[0] > 0:
+        raise Exception("Found unduped jobs for records: %s" % unduped_jobs.to_string())
+    else:
+        print ("All data has been deduped")
+
+# Now that jobs with the same sha, run_attempt, and workflow_run_id have all 
+#  been deduped, we only have a single conclusion for each workflow run attempt
+# We're interested in:
+#  1. The wall clock time spent waiting on the CI per PR
+#  2. The number of commits it had
+def get_pr_level_stats(df):
+    # Now, all run attempts should have exactly one row. If not, we missed a corner case
+    validate_all_data_has_been_deduped(df)
+
+    df_results = pd.DataFrame(columns=['pr_number', 'duration_mins', 'end_time'])
+    
+    df_grouped = df.groupby('pr_number')    
+    for (pr_number), group in df_grouped:        
+        pr_ci_duration = get_duration_for_pr(group)
+        num_commits = group['sha'].nunique()
+        pr_start_time = group['start_time'].min()
+        pr_end_time = group['end_time'].max()
+        week = pr_end_time.to_period('W').start_time
+
+        # Stats for this PR
+        df_results = pd.concat([df_results, pd.DataFrame({
+            'pr_number': [pr_number], 
+            'duration_mins': [pr_ci_duration],
+            'start_time': [pr_start_time],
+            'end_time': [pr_end_time],
+            'num_commits': [num_commits],
+            'week': [week],
+        })])
+    
+    return df_results
+
+def get_pr_stats() -> pd.DataFrame:
+    runs = query_workflows_from_rockset()
+
+    # Now we have all the raw data and it's ime to start filtering it
+    #
+    # We need to figure out the effective start/end times for each workflow run 
+    # even though that workflows could have concluded in different ways
+    #
+    # Definitions:
+    #   Start time: When the CI jobs were requested (usually when the dev pushes the commit, can
+    #                also be when a label is applied to a commit, or when a workflow is rerun)
+    #   End time:   When the dev has an actionable signal. Actionable meaning it's either an
+    #                all green signal or it's the first red signal 
+    #
+    # We filter out jobs that don't contribute to determining the end time of the workflow run
+    #
+    # The rules used to figure that out:
+    #   1. If jobs in a workflow are cancelled before any jobs in CI failed, then the dev
+    #       must have pushed a new commit before getting a signal from CI. 
+    #       Since they were not blocked on CI, we ignore that entire commit's workflow.
+    #       The only exception is when the job duration was >5hrs, in which case they actually
+    #       ran into a timeout
+    #   2. If a workflow is retried after it failed, then count the entire duration of the workflow
+    #       since the dev had to wait for it to complete before doing the retry
+    #   2. If any job fails on the final retry attempt then the dev has gotten a signal. Jobs that
+    #       succeed or fail after that one are irrelevant
+    #   3. If all jobs complete successfully, the last job that completed is what gives the
+    #       signal (i.e. sets the end time)
+    runs = remove_cancelled_jobs(runs)
+    runs = normalize_start_times(runs) # Ensure all jobs with a workflow have the same start time
+    runs = ignore_failures_from_retried_jobs(runs)
+    runs = remove_irrelevant_success_jobs(runs)
+    runs = remove_irrelevant_failure_jobs(runs)
+    runs = discard_weird_cases(runs)
+
+    return get_pr_level_stats(runs)
+
+def table_exists(table_name: str) -> bool:
+    """
+    Determines whether a table exists. As a side effect, stores the table in
+    a member variable.
+    """
+    exists = None
+    try:
+        table = dynamodb.Table(table_name)
+        table.load()
+        exists = True
+        print(f"Table '{table_name}' exists")
+    except ClientError as err:
+        if err.response["Error"]["Code"] == "ResourceNotFoundException":
+            print(f"Table '{table_name}' does not exist")
+            exists = False
+        else:
+            print("Unknown error")
+            print(err.response)
+    return exists
+
+def upload_stats(pr_stats):
+    print(pr_stats.head(30))
+
+    print(f"Uploading data to {TABLE_NAME}")
+
+    statsTable = dynamodb.Table(TABLE_NAME)
+
+    for _, row in pr_stats.iterrows():
+        dynamoKey = f"{row['week'].isoformat()}_{row['pr_number']}"
+
+        # # Check if stats table already has the row
+
+        record = statsTable.get_item(
+            Key={
+                'dynamoKey': dynamoKey,
+            }
+        )
+
+        # If record exists, update it
+        if 'Item' in record:
+            print("Updating record for dynamoKey: %s" % dynamoKey)
+            statsTable.update_item(
+                Key={
+                    'dynamoKey': dynamoKey,
+                },
+                UpdateExpression="set pr_number=:p duration_mins=:d, start_time=:s, end_time=:e, num_commits=:n, week=:w",
+                ExpressionAttributeValues={
+                    ':p': row['pr_number'],
+                    ':d': int(row['duration_mins']),
+                    ':s': row['start_time'].isoformat(),
+                    ':e': row['end_time'].isoformat(),
+                    ':n': int(row['num_commits']),
+                    ':w': row['week'].isoformat(),
+                }
+            )
+        else:    
+            # If it doesn't, insert it
+            print("Inserting record for dynamoKey: %s" % dynamoKey)
+            statsTable.put_item(
+                Item={
+                    'dynamoKey': dynamoKey,
+                    'pr_number': row['pr_number'],
+                    'duration_mins': int(row['duration_mins']),
+                    'start_time': row['start_time'].isoformat(),
+                    'end_time': row['end_time'].isoformat(),
+                    'num_commits': int(row['num_commits']),
+                    'week': row['week'].isoformat(),
+                }
+            )
+
+        # statsTable.update_item(
+        #     Key={
+        #         'dynamoKey': f"{row['week'].isoformat()}_{row['pr_number']}",
+        #     },
+        #     UpdateExpression="set pr_number=:p duration_mins=:d, start_time=:s, end_time=:e, num_commits=:n, week=:w",
+        #     ExpressionAttributeValues={
+        #         ':p': row['pr_number'],
+        #         ':d': int(row['duration_mins']),
+        #         ':s': row['start_time'].isoformat(),
+        #         ':e': row['end_time'].isoformat(),
+        #         ':n': int(row['num_commits']),
+        #         ':w': row['week'].isoformat(),
+        #     },
+        #     ReturnValues="UPDATED_NEW"
+        # )
+
+    print(f"Finished uploading data to {TABLE_NAME}")
+
+
+def main() -> None:
+    print("Getting the PR's stats")
+    pr_stats = get_pr_stats()
+
+    print("Uploading stats to dynamo")
+    upload_stats(pr_stats)
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/compute_and_upload_ci_wait_time_metric.py
+++ b/.github/scripts/compute_and_upload_ci_wait_time_metric.py
@@ -28,7 +28,7 @@ def query_workflows_from_rockset() -> pd.DataFrame:
         rockset.models.QueryParameter(
             name="from_days_ago",
             type="int",
-            value="360",
+            value="300",
         ),
         rockset.models.QueryParameter(
             name="to_days_ago",

--- a/.github/scripts/compute_and_upload_ci_wait_time_metric.py
+++ b/.github/scripts/compute_and_upload_ci_wait_time_metric.py
@@ -358,13 +358,13 @@ def upload_stats(pr_stats):
         )
 
         updated_prs.append(dynamoKey)
-        if updated_prs % UPDATE_ANNOUNCEMENT_BATCH_SIZE == 0:
+        if len(updated_prs) % UPDATE_ANNOUNCEMENT_BATCH_SIZE == 0:
             # print the last 10 prs updated
             latest_updates = ", ".join(updated_prs[(-UPDATE_ANNOUNCEMENT_BATCH_SIZE):])
             print(f"Updated {latest_updates}")
 
     # print the last batch of prs updated (if any)
-    last_updates = updated_prs % UPDATE_ANNOUNCEMENT_BATCH_SIZE
+    last_updates = len(updated_prs) % UPDATE_ANNOUNCEMENT_BATCH_SIZE
     if last_updates > 0:
         latest_updates = ", ".join(updated_prs[-last_updates:])
         print(f"Updated {latest_updates}")

--- a/.github/scripts/compute_and_upload_ci_wait_time_metric.py
+++ b/.github/scripts/compute_and_upload_ci_wait_time_metric.py
@@ -323,13 +323,15 @@ def upload_stats(pr_stats):
         dynamoKey = f"{row['week'].isoformat()}_{row['pr_number']}"
 
         # # Check if stats table already has the row
-
+        print (f"Checking for key {dynamoKey}")
         record = statsTable.get_item(
             Key={
                 'dynamoKey': dynamoKey,
                 'pr_number': row['pr_number'],
             }
         )
+
+        print(f"Got record: {record}")
 
         # If record exists, update it
         if 'Item' in record:
@@ -388,6 +390,8 @@ def main() -> None:
 
     print("Uploading stats to dynamo")
     upload_stats(pr_stats)
+
+    return 0
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/compute_and_upload_ci_wait_time_metric.py
+++ b/.github/scripts/compute_and_upload_ci_wait_time_metric.py
@@ -335,6 +335,9 @@ def upload_stats(pr_stats):
 
     statsTable = dynamodb.Table(TABLE_NAME)
 
+    UPDATE_ANNOUNCEMENT_BATCH_SIZE = 10
+
+    updated_prs = []
     start_time = time.time()
     for _, row in pr_stats.iterrows():
         dynamoKey = str(row['pr_number'])
@@ -353,6 +356,18 @@ def upload_stats(pr_stats):
                 ':w': row['week'].isoformat(),
             }
         )
+
+        updated_prs.append(dynamoKey)
+        if updated_prs % UPDATE_ANNOUNCEMENT_BATCH_SIZE == 0:
+            # print the last 10 prs updated
+            latest_updates = ", ".join(updated_prs[(-UPDATE_ANNOUNCEMENT_BATCH_SIZE):])
+            print(f"Updated {latest_updates}")
+
+    # print the last batch of prs updated (if any)
+    last_updates = updated_prs % UPDATE_ANNOUNCEMENT_BATCH_SIZE
+    if last_updates > 0:
+        latest_updates = ", ".join(updated_prs[-last_updates:])
+        print(f"Updated {latest_updates}")
 
     end_time = time.time()
 

--- a/.github/scripts/test_compute_and_upload_ci_wait_time_metric.py
+++ b/.github/scripts/test_compute_and_upload_ci_wait_time_metric.py
@@ -1,0 +1,299 @@
+from unittest import main, TestCase
+
+import pandas as pd
+import numpy as np
+
+from compute_and_upload_ci_wait_time_metric import (
+    remove_cancelled_jobs,
+    normalize_start_times,
+    remove_irrelevant_success_jobs,
+    remove_irrelevant_failure_jobs,
+    get_pr_level_stats,
+)
+
+def normalize_workflow_runs(records: pd.DataFrame) -> pd.DataFrame:
+    records['start_time'] = pd.to_datetime(records['start_time'])
+    records['end_time'] = pd.to_datetime(records['end_time'])
+    return records
+
+class TestComputeAndUploadCiWaitTimeMetric(TestCase):
+    def assertDataFramesAreEqual(self, df1: pd.DataFrame, df2: pd.DataFrame):
+        # Validate the results. We use numpy because the indexes on the dataframes is expected to be different
+        self.assertTrue(np.array_equal(df1.values, df2.values))
+
+    def test_removing_cancelled_jobs(self):
+        records = pd.json_normalize([
+            {
+                "conclusion": "cancelled",  
+                "was_cancelled": True,
+                "duration_mins": 305,
+                "sha": "12345",
+            },
+            {
+                "conclusion": "cancelled",
+                "was_cancelled": True,
+                "duration_mins": 23,
+                "sha": "aaaaa",
+            },
+            {
+                "conclusion": "success",
+                "was_cancelled": False,
+                "duration_mins": 15,
+                "sha": "aaaaa",
+            }, 
+            {
+                "conclusion": "cancelled",
+                "was_cancelled": True,
+                "duration_mins": 23,
+                "sha": "bbbbb",
+            }, 
+            {
+                "conclusion": "failure",
+                "was_cancelled": False,
+                "duration_mins": 10,
+                "sha": "bbbbb",
+            }, 
+        ])
+
+        expected = pd.json_normalize([
+            {
+                "conclusion": "failure",
+                "was_cancelled": True,
+                "duration_mins": 305,
+                "sha": "12345",
+            },
+            {
+                "conclusion": "failure",
+                "was_cancelled": False,
+                "duration_mins": 10,
+                "sha": "bbbbb",
+            }, 
+        ])
+
+        actual = remove_cancelled_jobs(records)
+        self.assertDataFramesAreEqual(actual, expected)
+
+    def test_normalizing_start_times(self):
+        records = pd.json_normalize([
+            {
+                "run_attempt": 1,  
+                "workflow_run_id": 10,
+                "start_time": "2021-01-01T00:00:00Z",
+                "end_time": "2021-01-01T00:10:00Z",
+                "sha": "12345",
+            },
+            {
+                "run_attempt": 1,  
+                "workflow_run_id": 10,
+                "start_time": "2021-01-01T00:05:00Z",
+                "end_time": "2021-01-01T00:15:00Z",
+                "sha": "12345",
+            },
+            {
+                "run_attempt": 2,  
+                "workflow_run_id": 11,
+                "start_time": "2021-01-01T01:05:00Z",
+                "end_time": "2021-01-01T01:15:00Z",
+                "sha": "12345",
+            }, 
+            {
+                "run_attempt": 1,  
+                "workflow_run_id": 12,
+                "start_time": "2021-02-01T00:00:00Z",
+                "end_time": "2021-02-01T00:10:00Z",
+                "sha": "6789",
+            },
+            {
+                "run_attempt": 1,  
+                "workflow_run_id": 12,
+                "start_time": "2021-02-01T00:05:00Z",
+                "end_time": "2021-02-01T00:15:00Z",
+                "sha": "6789",
+            },
+        ])
+
+        expected = pd.json_normalize([
+            {
+                "run_attempt": 1,  
+                "workflow_run_id": 10,
+                "start_time": "2021-01-01T00:00:00Z",
+                "end_time": "2021-01-01T00:10:00Z",
+                "sha": "12345",
+                "duration_mins": 10.0,
+            },
+            {
+                "run_attempt": 1,  
+                "workflow_run_id": 10,
+                "start_time": "2021-01-01T00:00:00Z",
+                "end_time": "2021-01-01T00:15:00Z",
+                "sha": "12345",
+                "duration_mins": 15.0,
+            },
+            {
+                "run_attempt": 2,  
+                "workflow_run_id": 11,
+                "start_time": "2021-01-01T01:05:00Z",
+                "end_time": "2021-01-01T01:15:00Z",
+                "sha": "12345",
+                "duration_mins": 10.0,
+            }, 
+            {
+                "run_attempt": 1,  
+                "workflow_run_id": 12,
+                "start_time": "2021-02-01T00:00:00Z",
+                "end_time": "2021-02-01T00:10:00Z",
+                "sha": "6789",
+                "duration_mins": 10.0,
+            },
+            {
+                "run_attempt": 1,  
+                "workflow_run_id": 12,
+                "start_time": "2021-02-01T00:00:00Z",
+                "end_time": "2021-02-01T00:15:00Z",
+                "sha": "6789",
+                "duration_mins": 15.0,
+            },
+        ])
+
+        records = normalize_workflow_runs(records)
+        expected = normalize_workflow_runs(expected)
+
+        # Rearrange the colums for the later comparison
+        actual = normalize_start_times(records)[['run_attempt', 'workflow_run_id', 'start_time', 'end_time', 'sha', 'duration_mins']]
+        self.assertDataFramesAreEqual(actual, expected)
+
+    def test_remove_irrelevant_success_jobs(self):
+        records = normalize_workflow_runs(pd.json_normalize([
+            {
+                "run_attempt": 1,  
+                "workflow_run_id": 10,
+                "sha": "12345",
+                "conclusion": "success",
+                "start_time": "2021-01-01T00:00:00Z",
+                "end_time": "2021-01-01T01:50:00Z",
+            },
+            {
+                "run_attempt": 1,  
+                "workflow_run_id": 10,
+                "sha": "12345",
+                "conclusion": "failure",
+                "start_time": "2021-01-01T00:05:00Z",
+                "end_time": "2021-01-01T00:25:00Z",
+            },
+            {
+                "run_attempt": 1,  
+                "workflow_run_id": 11,
+                "sha": "4566",
+                "conclusion": "success",
+                "start_time": "2021-01-01T00:05:00Z",
+                "end_time": "2021-01-01T01:05:00Z",
+            },
+            {
+                "run_attempt": 1,  
+                "workflow_run_id": 11,
+                "sha": "4566",
+                "conclusion": "success",
+                "start_time": "2021-01-01T00:15:00Z",
+                "end_time": "2021-01-01T00:50:00Z",
+            },
+        ]))
+        
+        expected = normalize_workflow_runs(pd.json_normalize([
+            {
+                "run_attempt": 1,  
+                "workflow_run_id": 10,
+                "sha": "12345",
+                "conclusion": "failure",
+                "start_time": "2021-01-01T00:00:00Z",
+                "end_time": "2021-01-01T00:25:00Z",
+                "duration_mins": 25.0,
+            },
+            {
+                "run_attempt": 1,  
+                "workflow_run_id": 11,
+                "sha": "4566",
+                "conclusion": "success",
+                "start_time": "2021-01-01T00:05:00Z",
+                "end_time": "2021-01-01T01:05:00Z",
+                "duration_mins": 60.0,
+            },
+        ]))
+        
+        # Rearrange coluns for the comparison later
+        actual = remove_irrelevant_success_jobs(records)[['run_attempt', 'workflow_run_id', 'sha', 'conclusion', 'start_time', 'end_time', 'duration_mins']]
+        self.assertDataFramesAreEqual(actual, expected)
+
+    def test_remove_irrelevant_failure_jobs(self):
+        records = normalize_workflow_runs(pd.json_normalize([
+            {
+                "run_attempt": 1,  
+                "workflow_run_id": 10,
+                "sha": "12345",
+                "conclusion": "failure",
+                "start_time": "2021-01-01T00:00:00Z",
+                "end_time": "2021-01-01T01:50:00Z",
+            },
+            {
+                "run_attempt": 1,  
+                "workflow_run_id": 10,
+                "sha": "12345",
+                "conclusion": "failure",
+                "start_time": "2021-01-01T00:05:00Z",
+                "end_time": "2021-01-01T00:25:00Z",
+            },
+        ]))
+        
+        expected = normalize_workflow_runs(pd.json_normalize([
+            {
+                "run_attempt": 1,  
+                "workflow_run_id": 10,
+                "sha": "12345",
+                "conclusion": "failure",
+                "start_time": "2021-01-01T00:05:00Z",
+                "end_time": "2021-01-01T00:25:00Z",
+            },
+        ]))
+
+        actual = remove_irrelevant_failure_jobs(records)
+        self.assertDataFramesAreEqual(actual, expected)
+
+
+    def test_get_pr_level_stats(self):
+        records = normalize_workflow_runs(pd.json_normalize([
+            {
+                "pr_number": 1,
+                "run_attempt": 1,  
+                "workflow_run_id": 10,
+                "sha": "12345",
+                "conclusion": "failure",
+                "start_time": "2021-01-01T00:00:00Z",
+                "end_time": "2021-01-01T01:05:00Z",
+                "duration_mins": 65.0,
+            },
+            {
+                "pr_number": 1,
+                "run_attempt": 1,  
+                "workflow_run_id": 12,
+                "sha": "12345",
+                "conclusion": "failure",
+                "start_time": "2021-01-01T00:25:00Z",
+                "end_time": "2021-01-01T01:25:00Z",
+                "duration_mins": 60.0,
+            },
+        ]))
+
+        expected = normalize_workflow_runs(pd.json_normalize([
+            {
+                "pr_number": 1,
+                "start_time": "2021-01-01T00:00:00Z",
+                "end_time": "2021-01-01T01:25:00Z",
+                "duration_mins": 85,
+                "num_commits": 1.0,
+            }
+        ]))
+
+        actual = get_pr_level_stats(records)[['pr_number', 'start_time', 'end_time', 'duration_mins', 'num_commits']]
+        self.assertDataFramesAreEqual(actual, expected)
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/update_ci_wait_time_metric.yml
+++ b/.github/workflows/update_ci_wait_time_metric.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   update-kpi:
     runs-on: ubuntu-22.04
-    if: ${{ github.repository == 'pytorch/pytorch' }}
+    if: ${{ github.repository == 'pytorch/test-infra' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/update_ci_wait_time_metric.yml
+++ b/.github/workflows/update_ci_wait_time_metric.yml
@@ -24,9 +24,6 @@ jobs:
           architecture: x64
           check-latest: false
           cache: pip
-          cache-dependency-path: |
-            **/.ci/docker/requirements-ci.txt
-            **/.github/requirements-gha-cache.txt
 
       - name: Install Python Packages
         run: |

--- a/.github/workflows/update_ci_wait_time_metric.yml
+++ b/.github/workflows/update_ci_wait_time_metric.yml
@@ -1,0 +1,45 @@
+name: Update CI Wait Time Metric
+on:
+#  schedule:
+    # Update the indices every 30 minutes
+#    - cron: "*/30 * * * *"
+  # Enable triggering this job manually using the API as well
+  push:
+    branches:
+      - 'zainr/ci-wait-metric'
+  workflow_dispatch:
+
+jobs:
+  update-kpi:
+    runs-on: ubuntu-22.04
+    if: ${{ github.repository == 'pytorch/pytorch' }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.MERGEBOT_TOKEN }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+          architecture: x64
+          check-latest: false
+          cache: pip
+          cache-dependency-path: |
+            **/.ci/docker/requirements-ci.txt
+            **/.github/requirements-gha-cache.txt
+
+      - name: Install Python Packages
+        run: |
+          pip3 install rockset==1.0.3
+          pip3 install boto3==1.19.12
+          pip3 install pandas==1.5
+
+      - name: Compute kpi and upload to RDS
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
+        run: |
+          python3 .github/scripts/compute_and_upload_ci_wait_time_metric.py

--- a/.github/workflows/update_ci_wait_time_metric.yml
+++ b/.github/workflows/update_ci_wait_time_metric.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.MERGEBOT_TOKEN }}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/update_ci_wait_time_metric.yml
+++ b/.github/workflows/update_ci_wait_time_metric.yml
@@ -3,7 +3,7 @@ on:
 #  schedule:
     # Update the indices every 30 minutes
 #    - cron: "*/30 * * * *"
-  # Enable triggering this job manually using the API as well
+  # Enable triggering this job manually using the API as well 
   push:
     branches:
       - 'zainr/kpi-ci-wait'

--- a/.github/workflows/update_ci_wait_time_metric.yml
+++ b/.github/workflows/update_ci_wait_time_metric.yml
@@ -6,7 +6,7 @@ on:
   # Enable triggering this job manually using the API as well
   push:
     branches:
-      - 'zainr/ci-wait-metric'
+      - 'zainr/kpi-ci-wait'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/update_ci_wait_time_metric.yml
+++ b/.github/workflows/update_ci_wait_time_metric.yml
@@ -1,12 +1,12 @@
 name: Update CI Wait Time Metric
 on:
-#  schedule:
-    # Update the indices every 30 minutes
-#    - cron: "*/30 * * * *"
-  # Enable triggering this job manually using the API as well 
+  schedule:
+    # Update the indices every 6 hours
+    - cron: "30 */6 * * *"
   push:
     branches:
-      - 'zainr/kpi-ci-wait'
+      - 'zainr/kpi-ci-wait' # to be removed before merging
+  # Enable triggering this job manually using the API as well 
   workflow_dispatch:
 
 jobs:
@@ -22,7 +22,6 @@ jobs:
         with:
           python-version: '3.8'
           architecture: x64
-          check-latest: false
           cache: pip
 
       - name: Install Python Packages

--- a/.github/workflows/update_ci_wait_time_metric.yml
+++ b/.github/workflows/update_ci_wait_time_metric.yml
@@ -1,11 +1,8 @@
 name: Update CI Wait Time Metric
 on:
   schedule:
-    # Update the indices every 6 hours
-    - cron: "30 */6 * * *"
-  push:
-    branches:
-      - 'zainr/kpi-ci-wait' # to be removed before merging
+    # Update the indices every day at 5am
+    - cron: "0 5 * * *"
   # Enable triggering this job manually using the API as well 
   workflow_dispatch:
 

--- a/torchci/rockset/metrics/__sql/completed_pr_jobs_aggregate.sql
+++ b/torchci/rockset/metrics/__sql/completed_pr_jobs_aggregate.sql
@@ -1,0 +1,117 @@
+-- This query is used to generate the CI Wait Time KPI for the pytorch/pytorch repo
+-- It's not the full kpi. Rather, this performs some early data processing and aggregation, which
+-- is then used by a python script to generate the final KPI, which gets uploaded back to rockset 
+-- to be generally queryable
+WITH
+    -- Get all PRs that were merged into master, and get all the SHAs for commits from that PR which CI jobs ran against
+    -- We need the shas because some jobs (like trunk) don't have a PR they explicitly ran against, but they _were_ run against
+    -- a commit from a PR
+    pr_shas AS (
+        SELECT  
+            r.pull_requests[1].number AS pr_number,
+            CONCAT(
+                'https://github.com/pytorch/pytorch/pull/',
+                r.pull_requests[1].number
+            ) AS url,
+            j.head_sha AS sha,
+        FROM
+            commons.workflow_job j
+            INNER JOIN commons.workflow_run r on j.run_id = r.id
+        WHERE
+            1 = 1
+            AND j._event_time > (
+                CURRENT_DATETIME() - DAYS(:from_days_ago)
+            )
+            AND r._event_time > (
+                CURRENT_DATETIME() - DAYS(:from_days_ago)
+            )
+            AND j._event_time < (CURRENT_DATETIME() - DAYS(:to_days_ago))
+            AND r._event_time < (CURRENT_DATETIME() - DAYS(:to_days_ago))
+            AND LENGTH(r.pull_requests) = 1
+            AND r.head_branch NOT IN ('master', 'main', 'nightly')
+            AND r.pull_requests[1].head.repo.name = 'pytorch'
+            AND r.name IN ('pull', 'trunk', 'Lint') -- Ensure we don't pull in random PRs we don't care about
+            AND (
+                r.pull_requests[1].base.ref = 'master'
+                OR r.pull_requests[1].base.ref like 'gh/%/base'
+            )
+        GROUP BY
+            pr_number,
+            url,
+            sha
+    ),
+    -- Now filter the list to just closed PRs
+    merged_pr_shas AS (
+        SELECT  
+            DISTINCT s.pr_number,
+            s.url,
+            s.sha
+        FROM
+            pr_shas s
+            INNER JOIN commons.pull_request pr on s.pr_number = pr.number
+        WHERE
+            pr.closed_at IS NOT NULL 
+            -- Ensure the PR was actaully merged
+            AND 'Merged' IN (
+                SELECT  
+                    name
+                FROM
+                    UNNEST(pr.labels)
+            )
+    ),
+    -- Get all the workflows and partially aggregate the jobs run against each commit (based on the job's conclusion)
+    commit_job_durations AS (
+        SELECT  
+            s.pr_number,
+            r.name AS workflow_name,
+            s.sha,
+            j.conclusion AS conclusion,
+            j.conclusion = 'cancelled' AS was_cancelled, -- For convenience
+            j.run_attempt, -- the attemp # this job was run on
+            r.run_attempt AS total_attempts,
+            r.id AS workflow_run_id,
+            min(j._event_time) AS start_time,
+            max(PARSE_TIMESTAMP_ISO8601(j.completed_at)) AS end_time,
+            DATE_DIFF(
+                'MINUTE',
+                min(j._event_time),
+                max(PARSE_TIMESTAMP_ISO8601(j.completed_at))
+            ) AS duration_mins,
+            CONCAT(
+                'https://github.com/pytorch/pytorch/actions/runs/',
+                r.id
+            ) AS workflow_url, -- for debugging
+            s.url, -- for debugging 
+        FROM
+            commons.workflow_job j
+            INNER JOIN merged_pr_shas s on j.head_sha = s.sha
+            INNER JOIN commons.workflow_run r on j.run_id = r.id
+        WHERE
+            1 = 1
+            AND j._event_time > (
+                CURRENT_DATETIME() - DAYS(:from_days_ago)
+            )
+            AND j._event_time < (CURRENT_DATETIME() - DAYS(:to_days_ago))
+            AND (
+                r.name IN ('pull', 'trunk', 'Lint')
+                OR r.name like 'linux-binary%'
+                OR r.name like 'windows-binary%'
+            ) 
+            -- skipped jobs are irrelevant to us
+            AND j.conclusion NOT IN ('skipped')
+        GROUP BY
+            pr_number,
+            workflow_name,
+            url,
+            sha,
+            run_attempt,
+            total_attempts,
+            conclusion,
+            was_cancelled,
+            workflow_run_id,
+            workflow_url
+    )
+SELECT  
+    *
+FROM
+    commit_job_durations

--- a/torchci/rockset/metrics/completed_pr_jobs_aggregate.lambda.json
+++ b/torchci/rockset/metrics/completed_pr_jobs_aggregate.lambda.json
@@ -1,0 +1,16 @@
+{
+  "sql_path": "__sql/completed_pr_jobs_aggregate.sql",
+  "default_parameters": [
+    {
+      "name": "from_days_ago",
+      "type": "int",
+      "value": "30"
+    },
+    {
+      "name": "to_days_ago",
+      "type": "int",
+      "value": "0"
+    }
+  ],
+  "description": "Intermediate data for the CI Wait TIme kpi"
+}

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -67,7 +67,7 @@
     "workflow_duration_avg": "7bae00900097a486",
     "workflow_duration_percentile": "0b28cf65de7cfe07",
     "workflow_load": "48428f8a7c541b76",
-    "completed_pr_jobs_aggregate": "01fc2a697ae85856"
+    "completed_pr_jobs_aggregate": "7b6b27eeca4dfc6f"
   },
   "inductor": {
     "compilers_benchmark_performance": "d3434f5f6c89f51c",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -66,7 +66,8 @@
     "queue_times_historical": "7f4d6599362e70ba",
     "workflow_duration_avg": "7bae00900097a486",
     "workflow_duration_percentile": "0b28cf65de7cfe07",
-    "workflow_load": "48428f8a7c541b76"
+    "workflow_load": "48428f8a7c541b76",
+    "completed_pr_jobs_aggregate": "01fc2a697ae85856"
   },
   "inductor": {
     "compilers_benchmark_performance": "d3434f5f6c89f51c",


### PR DESCRIPTION
Stores the data for the CI Wait Time metric, which measures how much time a dev spent waiting on CI for every merged PR.

The flow:
1. Every day, kick off a chron job
2. The job triggers a script to download the raw data from Rockset. The Rockset query only provides a partial aggregation of the data, grouping all jobs run based on their final success status.  The logic we want to power this KPI is complicated enough that doing more than this in Rockset will result in unmaintainable and very slow SQL
3. Further processes the data locally, computing per PR stats
4. Upload the stats to dynamodb, which will in turn be ingested into a new Rockset table
5. A new chart on HUD's kpi page queries this data from the new Rockset table (implemented in https://github.com/pytorch/test-infra/pull/4011)