### PR TITLE
Use job run_attempt instead of workflow run_attempt in flaky_workflows_jobs

### DIFF
--- a/torchci/lib/jobUtils.ts
+++ b/torchci/lib/jobUtils.ts
@@ -64,7 +64,7 @@ export async function getFlakyJobsFromPreviousWorkflow(
           value: branch,
         },
         {
-          name: "max_attempt",
+          name: "maxAttempt",
           type: "int",
           value: "1", // If the job was retried and still failed, it wasn't flaky
         },

--- a/torchci/lib/jobUtils.ts
+++ b/torchci/lib/jobUtils.ts
@@ -64,7 +64,7 @@ export async function getFlakyJobsFromPreviousWorkflow(
           value: branch,
         },
         {
-          name: "attempt",
+          name: "max_attempt",
           type: "int",
           value: "1", // If the job was retried and still failed, it wasn't flaky
         },

--- a/torchci/rockset/commons/__sql/flaky_workflows_jobs.sql
+++ b/torchci/rockset/commons/__sql/flaky_workflows_jobs.sql
@@ -98,8 +98,8 @@ flaky_jobs AS (
     latest_attempts
   WHERE
     (
-      latest_attempts.run_attempt <= : max_attempt
-      OR : max_attempt = 0
+      latest_attempts.run_attempt <= : maxAttempt
+      OR : maxAttempt = 0
     )
 )
 SELECT

--- a/torchci/rockset/commons/__sql/flaky_workflows_jobs.sql
+++ b/torchci/rockset/commons/__sql/flaky_workflows_jobs.sql
@@ -1,48 +1,24 @@
-WITH flaky_jobs AS (
+WITH dedups AS (
+  -- Note that there can be more than one commit with the same ID with the actual author and pytorchmergebot.
+  -- This mess up the results in some cases, so this removes all redundant information and only keeps what is
+  -- needed for the later query
   SELECT
+    DISTINCT CONCAT(w.name, ' / ', job.name) AS fullname,
     w.name AS workflow_name,
+    w.id AS workflow_id,
     job.name AS job_name,
-    -- Next commit
-    w.id AS next_workflow_id,
-    job.id AS next_job_id,
-    -- The flaky status of the job
-    FIRST_VALUE(job.conclusion) OVER(
-      PARTITION BY CONCAT(w.name, ' / ', job.name)
+    job.id AS job_id,
+    job.conclusion AS conclusion,
+    push.head_commit.id AS head_commit,
+    push.head_commit.timestamp AS head_commit_timestamp,
+    job.run_attempt AS run_attempt,
+    ROW_NUMBER() OVER(
+      PARTITION BY w.id,
+      w.name,
+      job.name
       ORDER BY
-        push.head_commit.timestamp DESC ROWS BETWEEN CURRENT ROW
-        AND 2 FOLLOWING
-    ) = 'success'
-    AND NTH_VALUE(job.conclusion, 2) OVER(
-      PARTITION BY CONCAT(w.name, ' / ', job.name)
-      ORDER BY
-        push.head_commit.timestamp DESC ROWS BETWEEN CURRENT ROW
-        AND 2 FOLLOWING
-    ) = 'failure'
-    AND LAST_VALUE(job.conclusion) OVER(
-      PARTITION BY CONCAT(w.name, ' / ', job.name)
-      ORDER BY
-        push.head_commit.timestamp DESC ROWS BETWEEN CURRENT ROW
-        AND 2 FOLLOWING
-    ) = 'success' AS flaky,
-    -- The current commit
-    NTH_VALUE(w.id, 2) OVER(
-      PARTITION BY CONCAT(w.name, ' / ', job.name)
-      ORDER BY
-        push.head_commit.timestamp DESC ROWS BETWEEN CURRENT ROW
-        AND 2 FOLLOWING
-    ) AS workflow_id,
-    NTH_VALUE(job.id, 2) OVER(
-      PARTITION BY CONCAT(w.name, ' / ', job.name)
-      ORDER BY
-        push.head_commit.timestamp DESC ROWS BETWEEN CURRENT ROW
-        AND 2 FOLLOWING
-    ) AS job_id,
-    NTH_VALUE(w.run_attempt, 2) OVER(
-      PARTITION BY CONCAT(w.name, ' / ', job.name)
-      ORDER BY
-        push.head_commit.timestamp DESC ROWS BETWEEN CURRENT ROW
-        AND 2 FOLLOWING
-    ) AS workflow_run_attempt,
+        job.run_attempt DESC
+    ) AS row_num,
   FROM
     commons.workflow_run w
     JOIN commons.workflow_job job ON w.id = job.run_id HINT(join_strategy = lookup)
@@ -53,13 +29,78 @@ WITH flaky_jobs AS (
       OR : numHours = 0
     )
     AND w.head_repository.full_name = : repo
-    AND ARRAY_CONTAINS(SPLIT(:branches, ','), w.head_branch)
+    AND ARRAY_CONTAINS(
+      SPLIT(: branches, ','),
+      w.head_branch
+    )
     AND ARRAY_CONTAINS(
       SPLIT(: workflowNames, ','),
       w.name
     )
     AND job.name NOT LIKE '%mem_leak_check%'
     AND job.name NOT LIKE '%rerun_disabled_tests%'
+),
+latest_attempts AS (
+  -- Keep the latest run attempt to know if the job has already been retried
+  SELECT
+    *
+  FROM
+    dedups
+  WHERE
+    row_num = 1
+),
+flaky_jobs AS (
+  SELECT
+    workflow_name,
+    job_name,
+    -- Next commit
+    workflow_id AS next_workflow_id,
+    job_id AS next_job_id,
+    -- The flaky status of the job
+    FIRST_VALUE(conclusion) OVER(
+      PARTITION BY fullname
+      ORDER BY
+        head_commit_timestamp DESC ROWS BETWEEN CURRENT ROW
+        AND 2 FOLLOWING
+    ) = 'success'
+    AND NTH_VALUE(conclusion, 2) OVER(
+      PARTITION BY fullname
+      ORDER BY
+        head_commit_timestamp DESC ROWS BETWEEN CURRENT ROW
+        AND 2 FOLLOWING
+    ) = 'failure'
+    AND LAST_VALUE(conclusion) OVER(
+      PARTITION BY fullname
+      ORDER BY
+        head_commit_timestamp DESC ROWS BETWEEN CURRENT ROW
+        AND 2 FOLLOWING
+    ) = 'success' AS flaky,
+    -- The current commit
+    NTH_VALUE(workflow_id, 2) OVER(
+      PARTITION BY fullname
+      ORDER BY
+        head_commit_timestamp DESC ROWS BETWEEN CURRENT ROW
+        AND 2 FOLLOWING
+    ) AS workflow_id,
+    NTH_VALUE(job_id, 2) OVER(
+      PARTITION BY fullname
+      ORDER BY
+        head_commit_timestamp DESC ROWS BETWEEN CURRENT ROW
+        AND 2 FOLLOWING
+    ) AS job_id,
+    NTH_VALUE(run_attempt, 2) OVER(
+      PARTITION BY fullname
+      ORDER BY
+        head_commit_timestamp DESC ROWS BETWEEN CURRENT ROW
+        AND 2 FOLLOWING
+    ) AS run_attempt,
+  FROM
+    latest_attempts
+  WHERE
+    (
+      latest_attempts.run_attempt <= : max_attempt
+      OR : max_attempt = 0
+    )
 )
 SELECT
   DISTINCT flaky_jobs.workflow_name,
@@ -67,7 +108,7 @@ SELECT
   flaky_jobs.job_name,
   flaky_jobs.job_id,
   flaky_jobs.flaky,
-  flaky_jobs.workflow_run_attempt AS run_attempt,
+  flaky_jobs.run_attempt,
   flaky_jobs.next_workflow_id,
   flaky_jobs.next_job_id,
   annotation.annotation,
@@ -89,8 +130,4 @@ WHERE
   AND (
     flaky_jobs.next_workflow_id = : nextWorkflowId
     OR : nextWorkflowId = 0
-  )
-  AND (
-    flaky_jobs.workflow_run_attempt = : attempt
-    OR : attempt = 0
   )

--- a/torchci/rockset/commons/flaky_workflows_jobs.lambda.json
+++ b/torchci/rockset/commons/flaky_workflows_jobs.lambda.json
@@ -2,14 +2,14 @@
   "sql_path": "__sql/flaky_workflows_jobs.sql",
   "default_parameters": [
     {
-      "name": "attempt",
-      "type": "int",
-      "value": "1"
-    },
-    {
       "name": "branches",
       "type": "string",
       "value": "master,main"
+    },
+    {
+      "name": "max_attempt",
+      "type": "int",
+      "value": "1"
     },
     {
       "name": "nextWorkflowId",
@@ -19,7 +19,7 @@
     {
       "name": "numHours",
       "type": "int",
-      "value": "48"
+      "value": "24"
     },
     {
       "name": "repo",

--- a/torchci/rockset/commons/flaky_workflows_jobs.lambda.json
+++ b/torchci/rockset/commons/flaky_workflows_jobs.lambda.json
@@ -7,7 +7,7 @@
       "value": "master,main"
     },
     {
-      "name": "max_attempt",
+      "name": "maxAttempt",
       "type": "int",
       "value": "1"
     },

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -8,7 +8,7 @@
     "filter_forced_merge_pr": "5cdaa020d6b71414",
     "flaky_tests": "9f7a1abcebb7f027",
     "flaky_tests_across_jobs": "9609d34ca73adf3d",
-    "flaky_workflows_jobs": "a1c7e34872854b7a",
+    "flaky_workflows_jobs": "1b5074df185bedec",
     "failed_workflow_jobs": "6ec4fd3f36a72071",
     "get_workflow_jobs": "6ed2029b19691a4b",
     "slow_tests": "ef8d035d23aa8ab6",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -8,7 +8,7 @@
     "filter_forced_merge_pr": "5cdaa020d6b71414",
     "flaky_tests": "9f7a1abcebb7f027",
     "flaky_tests_across_jobs": "9609d34ca73adf3d",
-    "flaky_workflows_jobs": "1b5074df185bedec",
+    "flaky_workflows_jobs": "d5783ef1fe73fa5b",
     "failed_workflow_jobs": "6ec4fd3f36a72071",
     "get_workflow_jobs": "6ed2029b19691a4b",
     "slow_tests": "ef8d035d23aa8ab6",


### PR DESCRIPTION
As retry bot now starts to retry flaky test jobs in trunk, i.e. https://github.com/pytorch/pytorch/actions/runs/4641785459, I discover an edge in the use of workflow `workflow_run_attempt` as a condition in the query where it's set to be equal to 1.  This prevents some legit flaky test jobs from being retried.  

Here is how it happens:
1. Workflow A failed with two failed jobs in which one is a flaky test job and the other is a regular failure such as network flaky that retry bot could handle, i.e. https://github.com/pytorch/pytorch/actions/runs/4641652767/attempts/1
2. Retry bot retried only the regular failure.  The workflow run attempt was increased from 1 to 2.  The regular job run attempt was increased from 1 to 2.  The flaky test job run attempt remained the same (1), i.e. https://github.com/pytorch/pytorch/actions/runs/4641652767/attempts/2
3. The immediately subsequent workflow B finished successfully, it should retry the flaky test job from A but it didn't because the workflow run attempt had already been set to 2 (>1)

The correct way should be to use the job `run_attempt` instead as it correctly tells if the job has been retried or not.  This is due to how GitHub allows retry individual job or the whole workflow.

### Testing
Run https://console.rockset.com/lambdas/details/commons.flaky_workflows_jobs to get all flaky jobs in the past 24 hours and visually confirming that all of them are correct including the above edge case.