### PR TITLE
Add CI Wait Time kpi to dashboard

### DIFF
--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -162,6 +162,34 @@ export default function Kpis() {
           additionalOptions={{ yAxis: { scale: true } }}
         />
       </Grid>
+
+      <Grid item xs={12} lg={6} height={ROW_HEIGHT}>
+        <TimeSeriesPanel
+          title={"Minutes Devs spent waiting on CI per PR (Weekly)"}
+          queryName={"ci_wait_time"}
+          queryCollection={"pytorch_dev_infra_kpis"}
+          queryParams={[...timeParams]}
+          granularity={"week"}
+          timeFieldName={"bucket"}
+          yAxisFieldName={"duration_mins"}
+          yAxisRenderer={(duration) => duration}
+          groupByFieldName={"percentile"}
+        />
+      </Grid>
+
+      <Grid item xs={12} lg={6} height={ROW_HEIGHT}>
+        <TimeSeriesPanel
+          title={"Number of commits per PR (Weekly)"}
+          queryName={"ci_wait_time"}
+          queryCollection={"pytorch_dev_infra_kpis"}
+          queryParams={[...timeParams]}
+          granularity={"week"}
+          timeFieldName={"bucket"}
+          yAxisFieldName={"num_commits"}
+          yAxisRenderer={(duration) => duration}
+          groupByFieldName={"percentile"}
+        />
+      </Grid>
     </Grid>
   );
 }

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -31,7 +31,8 @@
     "time_to_merge": "be1c2a28cf75fe32",
     "time_to_review": "adfbcdfc51ede11a",
     "time_to_signal": "ff332d025976c103",
-    "strict_lag_historical": "d2a09d13caf8b76a"
+    "strict_lag_historical": "d2a09d13caf8b76a",
+    "ci_wait_time": "b1080f26b20ea142"
   },
   "metrics": {
     "correlation_matrix": "35c05e04047123f0",

--- a/torchci/rockset/pytorch_dev_infra_kpis/__sql/ci_wait_time.sql
+++ b/torchci/rockset/pytorch_dev_infra_kpis/__sql/ci_wait_time.sql
@@ -1,0 +1,74 @@
+WITH percentiles_desired AS (
+  -- All the percentiles that we want the query to return
+  SELECT 'p25' as percentile, 0.25 as percentile_num
+  UNION ALL
+  SELECT 'p50', 0.50
+  UNION ALL
+  SELECT 'p75', 0.75
+  UNION ALL
+  SELECT 'p90', 0.90
+),
+-- Set the bucket to the desired granularity
+granular_pr_stats as (
+    SELECT
+      DATE_TRUNC(:granularity, end_time) AS bucket,
+      *
+    FROM metrics.pr_stats
+),
+-- Within each bucket, figure out what percentile duration and num_commits each PR falls under
+percentiles as (
+  SELECT
+      pr_number,
+      bucket,
+      duration_mins,
+      PERCENT_RANK() OVER(
+          PARTITION BY bucket
+          ORDER by duration_mins
+      ) as duration_percentile,
+      num_commits,
+      PERCENT_RANK() OVER(
+          PARTITION BY bucket
+          ORDER by num_commits
+      ) as num_commits_percentile
+  FROM
+      granular_pr_stats
+  WHERE 1 = 1
+    AND PARSE_DATETIME_ISO8601(:startTime) <= bucket
+    AND DATE(PARSE_DATETIME_ISO8601(:stopTime)) >= bucket 
+),
+-- For each bucket, get just the durations corresponding to the desired percentiles
+duration_percentile as (
+  SELECT 
+    p.bucket,
+    pd.percentile,
+    MIN(p.duration_mins) as duration_mins
+  FROM percentiles p 
+    CROSS JOIN percentiles_desired pd 
+  WHERE p.duration_percentile >= pd.percentile_num
+  GROUP BY
+   p.bucket, pd.percentile
+),
+-- For each bucket, get just the number of commits corresponding to the desired percentiles
+num_commits_percentile as (
+  SELECT 
+    p.bucket,
+    pd.percentile,
+    MIN(p.num_commits) as num_commits
+  FROM percentiles p 
+    CROSS JOIN percentiles_desired pd 
+  WHERE p.num_commits_percentile >= pd.percentile_num
+  GROUP BY
+   p.bucket, pd.percentile
+)
+-- Keep the percentiles on the same row so that this one query can give the results for both types of data
+SELECT 
+  FORMAT_TIMESTAMP('%Y-%m-%d', d.bucket) as bucket,
+  d.percentile,
+  d.duration_mins,
+  c.num_commits
+FROM 
+  duration_percentile d 
+  INNER JOIN num_commits_percentile c on d.bucket = c.bucket and d.percentile = c.percentile
+WHERE
+  d.bucket < (SELECT max(bucket) from granular_pr_stats) -- discard the latest bucket, which will have noisy, partial data
+ORDER BY bucket DESC, duration_mins

--- a/torchci/rockset/pytorch_dev_infra_kpis/ci_wait_time.lambda.json
+++ b/torchci/rockset/pytorch_dev_infra_kpis/ci_wait_time.lambda.json
@@ -1,0 +1,21 @@
+{
+  "sql_path": "__sql/ci_wait_time.sql",
+  "default_parameters": [
+    {
+      "name": "granularity",
+      "type": "string",
+      "value": "week"
+    },
+    {
+      "name": "startTime",
+      "type": "string",
+      "value": "2022-05-01T00:00:00.000Z"
+    },
+    {
+      "name": "stopTime",
+      "type": "string",
+      "value": "2023-06-01T00:06:32.839Z"
+    }
+  ],
+  "description": "Common percentiles for how much time CI is running per PR and how many commits a PR has"
+}


### PR DESCRIPTION
Add two new charts to the KPI page:
1. Time Devs spent waiting on CI to complete per PR. This is bucketed by the when a PR's last CI job completed, which is presumably around when the PR was merged. (It only considers merged PRs)
2. Number of commits per PR, showing the number of CI iterations

This is part 2, continuing the work from https://github.com/pytorch/test-infra/pull/4009

Visual:
<img width="1472" alt="image" src="https://user-images.githubusercontent.com/4468967/231009827-e3631e3b-97cc-4344-b65b-784ee59fc522.png">
