### PR TITLE
Various fixes and improvements for TorchInductor performance dashboard

### DIFF
--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -607,18 +607,24 @@ function GraphPanel({
   const rWorkflowId = COMMIT_TO_WORKFLOW_ID[rCommit];
 
   const groupByFieldName = "name";
-  const chartData = data.filter(
-    (record: CompilerPerformanceData) => record.name == model
-  ).filter((record: CompilerPerformanceData) => {
-    const id = record.workflow_id;
-    return (id >= lWorkflowId && id <= rWorkflowId) || (id <= lWorkflowId && id >= rWorkflowId);
-  }).map((record: CompilerPerformanceData) => {
-    record.speedup = Number(record.speedup).toFixed(2);
-    record.compilation_latency = Number(record.compilation_latency).toFixed(0);
-    record.compression_ratio = Number(record.compression_ratio).toFixed(2);
-    // Truncate the data to make it consistent with the display value
-    return record;
-  });
+  const chartData = data
+    .filter((record: CompilerPerformanceData) => record.name == model)
+    .filter((record: CompilerPerformanceData) => {
+      const id = record.workflow_id;
+      return (
+        (id >= lWorkflowId && id <= rWorkflowId) ||
+        (id <= lWorkflowId && id >= rWorkflowId)
+      );
+    })
+    .map((record: CompilerPerformanceData) => {
+      record.speedup = Number(record.speedup.toFixed(2));
+      record.compilation_latency = Number(
+        record.compilation_latency.toFixed(0)
+      );
+      record.compression_ratio = Number(record.compression_ratio.toFixed(2));
+      // Truncate the data to make it consistent with the display value
+      return record;
+    });
 
   const geomeanSeries = seriesWithInterpolatedTimes(
     chartData,
@@ -669,7 +675,7 @@ function GraphPanel({
             label: {
               show: true,
               align: "left",
-              formatter: (r) => {
+              formatter: (r: any) => {
                 return Number(r.value[1]).toFixed(2);
               },
             },
@@ -694,7 +700,7 @@ function GraphPanel({
             label: {
               show: true,
               align: "left",
-              formatter: (r) => {
+              formatter: (r: any) => {
                 return Number(r.value[1]).toFixed(0);
               },
             },
@@ -718,7 +724,7 @@ function GraphPanel({
             label: {
               show: true,
               align: "left",
-              formatter: (r) => {
+              formatter: (r: any) => {
                 return Number(r.value[1]).toFixed(2);
               },
             },

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -55,9 +55,9 @@ import { CompilerPerformanceData } from "lib/types";
 import styles from "components/metrics.module.css";
 import CopyLink from "components/CopyLink";
 
-const TABLE_ROW_HEIGHT = 1000;
 const GRAPH_ROW_HEIGHT = 245;
 const ROW_GAP = 30;
+const ROW_HEIGHT = 38;
 
 // Headers
 const ACCURACY_HEADER = "Accuracy";
@@ -237,8 +237,8 @@ function ModelPanel({
   });
 
   return (
-    <Grid container spacing={2}>
-      <Grid item xs={12} lg={12} height={TABLE_ROW_HEIGHT + ROW_GAP}>
+    <Grid container spacing={2} style={{ height: "100%" }}>
+      <Grid item xs={12} lg={12} height={data.length * ROW_HEIGHT + ROW_GAP}>
         <TablePanelWithData
           title={"Models"}
           data={data}
@@ -357,7 +357,7 @@ function ModelPanel({
                   return "";
                 }
 
-                if (lCommit === rCommit) {
+                if (lCommit === rCommit || v.l === v.r) {
                   return v.l;
                 } else {
                   return `${v.r} → ${v.l}`;
@@ -410,7 +410,7 @@ function ModelPanel({
                 const l = Number(v.l).toFixed(2);
                 const r = Number(v.r).toFixed(2);
 
-                if (lCommit === rCommit) {
+                if (lCommit === rCommit || l === r) {
                   return l;
                 } else {
                   return `${r} → ${l} ${
@@ -474,7 +474,7 @@ function ModelPanel({
                 const l = Number(v.l).toFixed(0);
                 const r = Number(v.r).toFixed(0);
 
-                if (lCommit === rCommit) {
+                if (lCommit === rCommit || l === r) {
                   return l;
                 } else {
                   return `${r} → ${l} ${
@@ -537,7 +537,7 @@ function ModelPanel({
                 const l = Number(v.l).toFixed(2);
                 const r = Number(v.r).toFixed(2);
 
-                if (lCommit === rCommit) {
+                if (lCommit === rCommit || l === r) {
                   return l;
                 } else {
                   return `${r} → ${l} ${
@@ -1001,7 +1001,10 @@ export default function Page() {
           {COMPILER_NAMES_TO_DISPLAY_NAMES[compiler] || compiler})
         </Typography>
         <CopyLink
-          textToCopy={`${baseUrl}?startTime=${startTime}&stopTime=${stopTime}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}&model=${model}`}
+          textToCopy={
+            `${baseUrl}?startTime=${startTime}&stopTime=${stopTime}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}` +
+            (model === undefined ? "" : `&model=${model}`)
+          }
         />
       </Stack>
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -380,6 +380,11 @@ function ModelPanel({
                 if (lCommit === rCommit) {
                   return l >= SPEEDUP_THRESHOLD ? "" : styles.warning;
                 } else {
+                  if (l === 0) {
+                    // This means the model isn't run at all
+                    return "";
+                  }
+
                   if (l >= SPEEDUP_THRESHOLD && r < SPEEDUP_THRESHOLD) {
                     return styles.ok;
                   }
@@ -414,7 +419,9 @@ function ModelPanel({
                   return l;
                 } else {
                   return `${r} → ${l} ${
-                    Number(l) < Number(r) ? "\uD83D\uDD3B" : ""
+                    Number(l) < Number(r) && Number(r) != 0 && Number(l) != 0
+                      ? "\uD83D\uDD3B"
+                      : ""
                   }`;
                 }
               },
@@ -437,6 +444,11 @@ function ModelPanel({
                     ? styles.warning
                     : "";
                 } else {
+                  if (l === 0) {
+                    // This means the model isn't run at all
+                    return "";
+                  }
+
                   if (
                     l <= COMPILATION_lATENCY_THRESHOLD_IN_SECONDS &&
                     r > COMPILATION_lATENCY_THRESHOLD_IN_SECONDS
@@ -478,7 +490,7 @@ function ModelPanel({
                   return l;
                 } else {
                   return `${r} → ${l} ${
-                    Number(l) > Number(r) && Number(r) != 0
+                    Number(l) > Number(r) && Number(r) != 0 && Number(l) != 0
                       ? "\uD83D\uDD3A"
                       : ""
                   }`;
@@ -501,6 +513,11 @@ function ModelPanel({
                 if (lCommit === rCommit) {
                   return l >= COMPRESSION_RATIO_THRESHOLD ? "" : styles.warning;
                 } else {
+                  if (l === 0) {
+                    // This means the model isn't run at all
+                    return "";
+                  }
+
                   if (
                     l >= COMPRESSION_RATIO_THRESHOLD &&
                     r < COMPRESSION_RATIO_THRESHOLD
@@ -541,7 +558,9 @@ function ModelPanel({
                   return l;
                 } else {
                   return `${r} → ${l} ${
-                    Number(l) < Number(r) ? "\uD83D\uDD3B" : ""
+                    Number(l) < Number(r) && Number(r) != 0 && Number(l) != 0
+                      ? "\uD83D\uDD3B"
+                      : ""
                   }`;
                 }
               },

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -53,6 +53,7 @@ import {
 } from "../../compilers";
 import { CompilerPerformanceData } from "lib/types";
 import styles from "components/metrics.module.css";
+import CopyLink from "components/CopyLink";
 
 const TABLE_ROW_HEIGHT = 1000;
 const GRAPH_ROW_HEIGHT = 245;
@@ -888,6 +889,7 @@ export default function Page() {
   const [lCommit, setLCommit] = useState<string>("");
   const [rBranch, setRBranch] = useState<string>(MAIN_BRANCH);
   const [rCommit, setRCommit] = useState<string>("");
+  const [baseUrl, setBaseUrl] = useState<string>("");
 
   // Set the dropdown value what is in the param
   useEffect(() => {
@@ -930,6 +932,8 @@ export default function Page() {
     if (rCommit !== undefined) {
       setRCommit(rCommit);
     }
+
+    setBaseUrl(`${window.location.host}${router.pathname}`);
   }, [router.query]);
 
   if (suite === undefined || compiler === undefined) {
@@ -986,6 +990,9 @@ export default function Page() {
           TorchInductor Performance DashBoard (
           {COMPILER_NAMES_TO_DISPLAY_NAMES[compiler] || compiler})
         </Typography>
+        <CopyLink
+          textToCopy={`${baseUrl}?startTime=${startTime}&stopTime=${stopTime}&suite=${suite}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`}
+        />
       </Stack>
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
         <TimeRangePicker

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -144,6 +144,8 @@ function CommitPanel({
 }
 
 function ModelPanel({
+  startTime,
+  stopTime,
   suite,
   mode,
   dtype,
@@ -156,6 +158,8 @@ function ModelPanel({
   rCommit,
   rData,
 }: {
+  startTime: dayjs.Dayjs;
+  stopTime: dayjs.Dayjs;
   suite: string;
   mode: string;
   dtype: string;
@@ -268,7 +272,7 @@ function ModelPanel({
                     : undefined;
 
                 const encodedName = encodeURIComponent(name);
-                const url = `/benchmark/${suite}/${compiler}?mode=${mode}&model=${encodedName}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
+                const url = `/benchmark/${suite}/${compiler}?startTime=${startTime}&stopTime=${stopTime}&mode=${mode}&model=${encodedName}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
 
                 if (lLog === undefined) {
                   return (
@@ -737,6 +741,8 @@ function GraphPanel({
 
 function Report({
   queryParams,
+  startTime,
+  stopTime,
   granularity,
   suite,
   mode,
@@ -749,6 +755,8 @@ function Report({
   rCommit,
 }: {
   queryParams: RocksetParam[];
+  startTime: dayjs.Dayjs;
+  stopTime: dayjs.Dayjs;
   granularity: Granularity;
   suite: string;
   mode: string;
@@ -843,6 +851,8 @@ function Report({
         rCommit={rCommit}
       />
       <ModelPanel
+        startTime={startTime}
+        stopTime={stopTime}
         suite={suite}
         mode={mode}
         dtype={dtype}
@@ -881,6 +891,16 @@ export default function Page() {
 
   // Set the dropdown value what is in the param
   useEffect(() => {
+    const startTime: string = (router.query.startTime as string) ?? undefined;
+    if (startTime !== undefined) {
+      setStartTime(dayjs(startTime));
+    }
+
+    const stopTime: string = (router.query.stopTime as string) ?? undefined;
+    if (stopTime !== undefined) {
+      setStopTime(dayjs(stopTime));
+    }
+
     const mode: string = (router.query.mode as string) ?? undefined;
     if (mode !== undefined) {
       setMode(mode);
@@ -973,7 +993,7 @@ export default function Page() {
           stopTime={stopTime}
           setStartTime={setStartTime}
           setStopTime={setStopTime}
-          defaultValue={LAST_N_DAYS}
+          defaultValue={-1}
         />
         <GranularityPicker
           granularity={granularity}
@@ -1007,6 +1027,8 @@ export default function Page() {
       <Grid item xs={12}>
         <Report
           queryParams={queryParams}
+          startTime={startTime}
+          stopTime={stopTime}
           granularity={granularity}
           suite={suite}
           mode={mode}

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -878,10 +878,12 @@ export default function Page() {
   const compiler: string = (router.query.compiler as string) ?? undefined;
   const model: string = (router.query.model as string) ?? undefined;
 
-  const [startTime, setStartTime] = useState(
-    dayjs().subtract(LAST_N_DAYS, "day")
-  );
-  const [stopTime, setStopTime] = useState(dayjs());
+  const defaultStartTime = dayjs().subtract(LAST_N_DAYS, "day");
+  const [startTime, setStartTime] = useState(defaultStartTime);
+  const defaultStopTime = dayjs();
+  const [stopTime, setStopTime] = useState(defaultStopTime);
+  const [timeRange, setTimeRange] = useState<number>(LAST_N_DAYS);
+
   const [granularity, setGranularity] = useState<Granularity>("hour");
   const [mode, setMode] = useState<string>(MODES[0]);
   const [dtype, setDType] = useState<string>(DTYPES[0]);
@@ -896,11 +898,19 @@ export default function Page() {
     const startTime: string = (router.query.startTime as string) ?? undefined;
     if (startTime !== undefined) {
       setStartTime(dayjs(startTime));
+
+      if (dayjs(startTime).valueOf() !== defaultStartTime.valueOf()) {
+        setTimeRange(-1);
+      }
     }
 
     const stopTime: string = (router.query.stopTime as string) ?? undefined;
     if (stopTime !== undefined) {
       setStopTime(dayjs(stopTime));
+
+      if (dayjs(stopTime).valueOf() !== defaultStopTime.valueOf()) {
+        setTimeRange(-1);
+      }
     }
 
     const mode: string = (router.query.mode as string) ?? undefined;
@@ -933,7 +943,7 @@ export default function Page() {
       setRCommit(rCommit);
     }
 
-    setBaseUrl(`${window.location.host}${router.pathname}`);
+    setBaseUrl(`${window.location.host}${router.asPath.replace(/\?.+/, "")}`);
   }, [router.query]);
 
   if (suite === undefined || compiler === undefined) {
@@ -991,16 +1001,17 @@ export default function Page() {
           {COMPILER_NAMES_TO_DISPLAY_NAMES[compiler] || compiler})
         </Typography>
         <CopyLink
-          textToCopy={`${baseUrl}?startTime=${startTime}&stopTime=${stopTime}&suite=${suite}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`}
+          textToCopy={`${baseUrl}?startTime=${startTime}&stopTime=${stopTime}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}&model=${model}`}
         />
       </Stack>
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
         <TimeRangePicker
           startTime={startTime}
-          stopTime={stopTime}
           setStartTime={setStartTime}
+          stopTime={stopTime}
           setStopTime={setStopTime}
-          defaultValue={-1}
+          timeRange={timeRange}
+          setTimeRange={setTimeRange}
         />
         <GranularityPicker
           granularity={granularity}

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -36,6 +36,7 @@ import { TimeRangePicker } from "../metrics";
 import { CompilerPerformanceData } from "lib/types";
 import styles from "components/metrics.module.css";
 import { useRouter } from "next/router";
+import CopyLink from "components/CopyLink";
 
 const ROW_HEIGHT = 245;
 const ROW_GAP = 30;
@@ -1567,6 +1568,8 @@ function Report({
   rBranch: string;
   rCommit: string;
 }) {
+  const router = useRouter();
+
   const queryCollection = "inductor";
   const queryName = "compilers_benchmark_performance";
 
@@ -1678,9 +1681,25 @@ export default function Page() {
   const [lCommit, setLCommit] = useState<string>("");
   const [rBranch, setRBranch] = useState<string>(MAIN_BRANCH);
   const [rCommit, setRCommit] = useState<string>("");
+  const [baseUrl, setBaseUrl] = useState<string>("");
 
   // Set the dropdown value what is in the param
   useEffect(() => {
+    const startTime: string = (router.query.startTime as string) ?? undefined;
+    if (startTime !== undefined) {
+      setStartTime(dayjs(startTime));
+    }
+
+    const stopTime: string = (router.query.stopTime as string) ?? undefined;
+    if (stopTime !== undefined) {
+      setStopTime(dayjs(stopTime));
+    }
+
+    const suite: string = (router.query.suite as string) ?? undefined;
+    if (suite !== undefined) {
+      setSuite(suite);
+    }
+
     const mode: string = (router.query.mode as string) ?? undefined;
     if (mode !== undefined) {
       setMode(mode);
@@ -1710,6 +1729,8 @@ export default function Page() {
     if (rCommit !== undefined) {
       setRCommit(rCommit);
     }
+
+    setBaseUrl(`${window.location.host}${router.pathname}`);
   }, [router.query]);
 
   const queryParams: RocksetParam[] = [
@@ -1751,6 +1772,9 @@ export default function Page() {
         <Typography fontSize={"2rem"} fontWeight={"bold"}>
           TorchInductor Performance DashBoard
         </Typography>
+        <CopyLink
+          textToCopy={`${baseUrl}?startTime=${startTime}&stopTime=${stopTime}&suite=${suite}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`}
+        />
       </Stack>
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
         <TimeRangePicker
@@ -1758,7 +1782,12 @@ export default function Page() {
           stopTime={stopTime}
           setStartTime={setStartTime}
           setStopTime={setStopTime}
-          defaultValue={LAST_N_DAYS}
+          defaultValue={
+            router.query.startTime !== undefined &&
+            router.query.stopTime !== undefined
+              ? -1
+              : LAST_N_DAYS
+          }
         />
         <GranularityPicker
           granularity={granularity}

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -980,7 +980,7 @@ function SummaryPanel({
                       return "";
                     }
 
-                    if (lCommit === rCommit) {
+                    if (lCommit === rCommit || l === r) {
                       return <a href={url}>{v.l}</a>;
                     } else {
                       return (
@@ -1059,7 +1059,7 @@ function SummaryPanel({
                     const l = Number(v.l).toFixed(2);
                     const r = Number(v.r).toFixed(2);
 
-                    if (lCommit === rCommit) {
+                    if (lCommit === rCommit || l === r) {
                       return <a href={url}>{l}x</a>;
                     } else {
                       return (
@@ -1134,7 +1134,7 @@ function SummaryPanel({
                     const l = Number(v.l).toFixed(0);
                     const r = Number(v.r).toFixed(0);
 
-                    if (lCommit === rCommit) {
+                    if (lCommit === rCommit || l === r) {
                       return <a href={url}>{l}s</a>;
                     } else {
                       return (
@@ -1222,7 +1222,7 @@ function SummaryPanel({
                     const l = Number(v.l).toFixed(2);
                     const r = Number(v.r).toFixed(2);
 
-                    if (lCommit === rCommit) {
+                    if (lCommit === rCommit || l === r) {
                       return <a href={url}>{l}x</a>;
                     } else {
                       return (

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -35,6 +35,7 @@ import GranularityPicker from "components/GranularityPicker";
 import { TimeRangePicker } from "../metrics";
 import { CompilerPerformanceData } from "lib/types";
 import styles from "components/metrics.module.css";
+import { useRouter } from "next/router";
 
 const ROW_HEIGHT = 245;
 const ROW_GAP = 30;
@@ -863,6 +864,8 @@ function extractPercentage(value: string) {
 }
 
 function SummaryPanel({
+  startTime,
+  stopTime,
   mode,
   dtype,
   lBranch,
@@ -872,6 +875,8 @@ function SummaryPanel({
   rCommit,
   rData,
 }: {
+  startTime: dayjs.Dayjs;
+  stopTime: dayjs.Dayjs;
   mode: string;
   dtype: string;
   lBranch: string;
@@ -965,7 +970,7 @@ function SummaryPanel({
                     const url = `/benchmark/${suite}/${
                       DISPLAY_NAMES_TO_COMPILER_NAMES[params.row.compiler] ??
                       params.row.compiler
-                    }?mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
+                    }?startTime=${startTime}&stopTime=${stopTime}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
 
                     const l = extractPercentage(v.l);
                     const r = extractPercentage(v.r);
@@ -1048,7 +1053,7 @@ function SummaryPanel({
                     const url = `/benchmark/${suite}/${
                       DISPLAY_NAMES_TO_COMPILER_NAMES[params.row.compiler] ??
                       params.row.compiler
-                    }?mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
+                    }?startTime=${startTime}&stopTime=${stopTime}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
 
                     const l = Number(v.l).toFixed(2);
                     const r = Number(v.r).toFixed(2);
@@ -1123,7 +1128,7 @@ function SummaryPanel({
                     const url = `/benchmark/${suite}/${
                       DISPLAY_NAMES_TO_COMPILER_NAMES[params.row.compiler] ??
                       params.row.compiler
-                    }?mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
+                    }?startTime=${startTime}&stopTime=${stopTime}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
 
                     const l = Number(v.l).toFixed(0);
                     const r = Number(v.r).toFixed(0);
@@ -1211,7 +1216,7 @@ function SummaryPanel({
                     const url = `/benchmark/${suite}/${
                       DISPLAY_NAMES_TO_COMPILER_NAMES[params.row.compiler] ??
                       params.row.compiler
-                    }?mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
+                    }?startTime=${startTime}&stopTime=${stopTime}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
 
                     const l = Number(v.l).toFixed(2);
                     const r = Number(v.r).toFixed(2);
@@ -1539,6 +1544,8 @@ function GraphPanel({
 
 function Report({
   queryParams,
+  startTime,
+  stopTime,
   granularity,
   suite,
   mode,
@@ -1549,6 +1556,8 @@ function Report({
   rCommit,
 }: {
   queryParams: RocksetParam[];
+  startTime: dayjs.Dayjs;
+  stopTime: dayjs.Dayjs;
   granularity: Granularity;
   suite: string;
   mode: string;
@@ -1631,6 +1640,8 @@ function Report({
         date={lData[0].granularity_bucket}
       />
       <SummaryPanel
+        startTime={startTime}
+        stopTime={stopTime}
         mode={mode}
         dtype={dtype}
         lBranch={lBranch}
@@ -1653,6 +1664,8 @@ function Report({
 }
 
 export default function Page() {
+  const router = useRouter();
+
   const [startTime, setStartTime] = useState(
     dayjs().subtract(LAST_N_DAYS, "day")
   );
@@ -1665,6 +1678,39 @@ export default function Page() {
   const [lCommit, setLCommit] = useState<string>("");
   const [rBranch, setRBranch] = useState<string>(MAIN_BRANCH);
   const [rCommit, setRCommit] = useState<string>("");
+
+  // Set the dropdown value what is in the param
+  useEffect(() => {
+    const mode: string = (router.query.mode as string) ?? undefined;
+    if (mode !== undefined) {
+      setMode(mode);
+    }
+
+    const dtype: string = (router.query.dtype as string) ?? undefined;
+    if (dtype !== undefined) {
+      setDType(dtype);
+    }
+
+    const lBranch: string = (router.query.lBranch as string) ?? undefined;
+    if (lBranch !== undefined) {
+      setLBranch(lBranch);
+    }
+
+    const lCommit: string = (router.query.lCommit as string) ?? undefined;
+    if (lCommit !== undefined) {
+      setLCommit(lCommit);
+    }
+
+    const rBranch: string = (router.query.rBranch as string) ?? undefined;
+    if (rBranch !== undefined) {
+      setRBranch(rBranch);
+    }
+
+    const rCommit: string = (router.query.rCommit as string) ?? undefined;
+    if (rCommit !== undefined) {
+      setRCommit(rCommit);
+    }
+  }, [router.query]);
 
   const queryParams: RocksetParam[] = [
     {
@@ -1747,6 +1793,8 @@ export default function Page() {
       <Grid item xs={12}>
         <Report
           queryParams={queryParams}
+          startTime={startTime}
+          stopTime={stopTime}
           granularity={granularity}
           suite={suite}
           mode={mode}

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -1669,10 +1669,12 @@ function Report({
 export default function Page() {
   const router = useRouter();
 
-  const [startTime, setStartTime] = useState(
-    dayjs().subtract(LAST_N_DAYS, "day")
-  );
-  const [stopTime, setStopTime] = useState(dayjs());
+  const defaultStartTime = dayjs().subtract(LAST_N_DAYS, "day");
+  const [startTime, setStartTime] = useState(defaultStartTime);
+  const defaultStopTime = dayjs();
+  const [stopTime, setStopTime] = useState(defaultStopTime);
+  const [timeRange, setTimeRange] = useState<number>(LAST_N_DAYS);
+
   const [granularity, setGranularity] = useState<Granularity>("hour");
   const [suite, setSuite] = useState<string>(Object.keys(SUITES)[0]);
   const [mode, setMode] = useState<string>(MODES[0]);
@@ -1688,11 +1690,19 @@ export default function Page() {
     const startTime: string = (router.query.startTime as string) ?? undefined;
     if (startTime !== undefined) {
       setStartTime(dayjs(startTime));
+
+      if (dayjs(startTime).valueOf() !== defaultStartTime.valueOf()) {
+        setTimeRange(-1);
+      }
     }
 
     const stopTime: string = (router.query.stopTime as string) ?? undefined;
     if (stopTime !== undefined) {
       setStopTime(dayjs(stopTime));
+
+      if (dayjs(stopTime).valueOf() !== defaultStopTime.valueOf()) {
+        setTimeRange(-1);
+      }
     }
 
     const suite: string = (router.query.suite as string) ?? undefined;
@@ -1730,7 +1740,7 @@ export default function Page() {
       setRCommit(rCommit);
     }
 
-    setBaseUrl(`${window.location.host}${router.pathname}`);
+    setBaseUrl(`${window.location.host}${router.asPath.replace(/\?.+/, "")}`);
   }, [router.query]);
 
   const queryParams: RocksetParam[] = [
@@ -1779,15 +1789,11 @@ export default function Page() {
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
         <TimeRangePicker
           startTime={startTime}
-          stopTime={stopTime}
           setStartTime={setStartTime}
+          stopTime={stopTime}
           setStopTime={setStopTime}
-          defaultValue={
-            router.query.startTime !== undefined &&
-            router.query.stopTime !== undefined
-              ? -1
-              : LAST_N_DAYS
-          }
+          timeRange={timeRange}
+          setTimeRange={setTimeRange}
         />
         <GranularityPicker
           granularity={granularity}

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -564,9 +564,16 @@ export function BranchAndCommitPicker({
 
   useEffect(() => {
     if (data !== undefined) {
-      const branchCommits = data.filter((r: any) => r.head_branch === branch).map((r: any) => r.head_sha);
-      if (commit === undefined || commit === "" || !branchCommits.includes(commit)) {
-        const index = (branchCommits.length + fallbackIndex) % branchCommits.length;
+      const branchCommits = data
+        .filter((r: any) => r.head_branch === branch)
+        .map((r: any) => r.head_sha);
+      if (
+        commit === undefined ||
+        commit === "" ||
+        !branchCommits.includes(commit)
+      ) {
+        const index =
+          (branchCommits.length + fallbackIndex) % branchCommits.length;
         setCommit(branchCommits[index]);
       }
 
@@ -1352,7 +1359,10 @@ function GraphPanel({
   // Accuracy
   const passrate = computePassrate(data, models).filter((r: any) => {
     const id = r.workflow_id;
-    return (id >= lWorkflowId && id <= rWorkflowId) || (id <= lWorkflowId && id >= rWorkflowId);
+    return (
+      (id >= lWorkflowId && id <= rWorkflowId) ||
+      (id <= lWorkflowId && id >= rWorkflowId)
+    );
   });
   const passrateSeries = seriesWithInterpolatedTimes(
     passrate,
@@ -1368,8 +1378,11 @@ function GraphPanel({
   // Geomean speedup
   const geomean = computeGeomean(data, models).filter((r: any) => {
     const id = r.workflow_id;
-    return (id >= lWorkflowId && id <= rWorkflowId) || (id <= lWorkflowId && id >= rWorkflowId);
-  });;
+    return (
+      (id >= lWorkflowId && id <= rWorkflowId) ||
+      (id <= lWorkflowId && id >= rWorkflowId)
+    );
+  });
   const geomeanSeries = seriesWithInterpolatedTimes(
     geomean,
     startTime,
@@ -1384,8 +1397,11 @@ function GraphPanel({
   // Compilation time
   const compTime = computeCompilationTime(data, models).filter((r: any) => {
     const id = r.workflow_id;
-    return (id >= lWorkflowId && id <= rWorkflowId) || (id <= lWorkflowId && id >= rWorkflowId);
-  });;
+    return (
+      (id >= lWorkflowId && id <= rWorkflowId) ||
+      (id <= lWorkflowId && id >= rWorkflowId)
+    );
+  });
   const compTimeSeries = seriesWithInterpolatedTimes(
     compTime,
     startTime,
@@ -1398,10 +1414,15 @@ function GraphPanel({
   );
 
   // Memory compression ratio
-  const memory = computeMemoryCompressionRatio(data, models).filter((r: any) => {
-    const id = r.workflow_id;
-    return (id >= lWorkflowId && id <= rWorkflowId) || (id <= lWorkflowId && id >= rWorkflowId);
-  });;
+  const memory = computeMemoryCompressionRatio(data, models).filter(
+    (r: any) => {
+      const id = r.workflow_id;
+      return (
+        (id >= lWorkflowId && id <= rWorkflowId) ||
+        (id <= lWorkflowId && id >= rWorkflowId)
+      );
+    }
+  );
   const memorySeries = seriesWithInterpolatedTimes(
     memory,
     startTime,
@@ -1432,7 +1453,7 @@ function GraphPanel({
             label: {
               show: true,
               align: "left",
-              formatter: (r) => {
+              formatter: (r: any) => {
                 return (r.value[1] * 100).toFixed(0);
               },
             },
@@ -1456,7 +1477,7 @@ function GraphPanel({
             label: {
               show: true,
               align: "left",
-              formatter: (r) => {
+              formatter: (r: any) => {
                 return r.value[1];
               },
             },
@@ -1481,7 +1502,7 @@ function GraphPanel({
             label: {
               show: true,
               align: "left",
-              formatter: (r) => {
+              formatter: (r: any) => {
                 return Number(r.value[1]).toFixed(0);
               },
             },
@@ -1505,7 +1526,7 @@ function GraphPanel({
             label: {
               show: true,
               align: "left",
-              formatter: (r) => {
+              formatter: (r: any) => {
                 return r.value[1];
               },
             },

--- a/torchci/pages/failedjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/failedjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -235,6 +235,7 @@ export default function Page() {
   const { repoName, repoOwner, branch } = router.query;
   const [startTime, setStartTime] = useState(dayjs().subtract(1, "week"));
   const [stopTime, setStopTime] = useState(dayjs());
+  const [timeRange, setTimeRange] = useState<number>(7);
 
   const queryParams: RocksetParam[] = [
     {
@@ -272,9 +273,11 @@ export default function Page() {
         </Typography>
         <TimeRangePicker
           startTime={startTime}
-          stopTime={stopTime}
           setStartTime={setStartTime}
+          stopTime={stopTime}
           setStopTime={setStopTime}
+          timeRange={timeRange}
+          setTimeRange={setTimeRange}
         />
       </Stack>
 

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -249,21 +249,19 @@ function TimePicker({ label, value, setValue }: any) {
  */
 export function TimeRangePicker({
   startTime,
-  stopTime,
   setStartTime,
+  stopTime,
   setStopTime,
-  defaultValue,
+  timeRange,
+  setTimeRange,
 }: {
   startTime: dayjs.Dayjs;
-  stopTime: dayjs.Dayjs;
   setStartTime: any;
+  stopTime: dayjs.Dayjs;
   setStopTime: any;
-  defaultValue?: number;
+  timeRange: any;
+  setTimeRange: any;
 }) {
-  // User-selected time range. If it's a number, the range is (#days to now). If
-  // it's -1, the time range has been to a custom value.
-  const [timeRange, setTimeRange] = useState<number>(defaultValue ?? 7);
-
   function updateTimeRange() {
     if (timeRange === -1) {
       return;
@@ -297,7 +295,7 @@ export function TimeRangePicker({
       <FormControl>
         <InputLabel id="time-picker-select-label">Time Range</InputLabel>
         <Select
-          defaultValue={defaultValue ?? 7}
+          value={timeRange}
           label="Time Range"
           labelId="time-picker-select-label"
           onChange={handleChange}
@@ -310,7 +308,7 @@ export function TimeRangePicker({
           <MenuItem value={90}>Last Quarter</MenuItem>
           <MenuItem value={180}>Last Half</MenuItem>
           <MenuItem value={365}>Last Year</MenuItem>
-          <MenuItem value={-1}>Custom Time Range</MenuItem>
+          <MenuItem value={-1}>Custom</MenuItem>
         </Select>
       </FormControl>
       {timeRange === -1 && (
@@ -466,6 +464,7 @@ function getCommitRedMetrics(queryParams: RocksetParam[]) {}
 export default function Page() {
   const [startTime, setStartTime] = useState(dayjs().subtract(1, "week"));
   const [stopTime, setStopTime] = useState(dayjs());
+  const [timeRange, setTimeRange] = useState<number>(7);
 
   const timeParams: RocksetParam[] = [
     {
@@ -522,9 +521,11 @@ export default function Page() {
         </Typography>
         <TimeRangePicker
           startTime={startTime}
-          stopTime={stopTime}
           setStartTime={setStartTime}
+          stopTime={stopTime}
           setStopTime={setStopTime}
+          timeRange={timeRange}
+          setTimeRange={setTimeRange}
         />
         <TtsPercentilePicker
           ttsPercentile={ttsPercentile}

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -262,7 +262,7 @@ export function TimeRangePicker({
 }) {
   // User-selected time range. If it's a number, the range is (#days to now). If
   // it's -1, the time range has been to a custom value.
-  const [timeRange, setTimeRange] = useState<number>(7);
+  const [timeRange, setTimeRange] = useState<number>(defaultValue ?? 7);
 
   function updateTimeRange() {
     if (timeRange === -1) {

--- a/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
+++ b/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
@@ -308,6 +308,7 @@ export default function Page() {
 
   const [startTime, setStartTime] = useState(dayjs().subtract(1, "week"));
   const [stopTime, setStopTime] = useState(dayjs());
+  const [timeRange, setTimeRange] = useState<number>(LAST_WEEK);
   const [granularity, setGranularity] = useState<Granularity>("day");
 
   const [filter, setFilter] = useState(new Set());
@@ -368,10 +369,11 @@ export default function Page() {
         </Typography>
         <TimeRangePicker
           startTime={startTime}
-          stopTime={stopTime}
           setStartTime={setStartTime}
+          stopTime={stopTime}
           setStopTime={setStopTime}
-          defaultValue={LAST_WEEK}
+          timeRange={timeRange}
+          setTimeRange={setTimeRange}
         />
         <GranularityPicker
           granularity={granularity}

--- a/torchci/pages/tests.tsx
+++ b/torchci/pages/tests.tsx
@@ -169,6 +169,7 @@ function GenerateTestInsightsOverviewTable({
 export default function GatherTestsInfo() {
   const [startTime, setStartTime] = useState(dayjs().subtract(1, "week"));
   const [stopTime, setStopTime] = useState(dayjs());
+  const [timeRange, setTimeRange] = useState<number>(7);
 
   return (
     <div>
@@ -178,9 +179,11 @@ export default function GatherTestsInfo() {
         </Typography>
         <TimeRangePicker
           startTime={startTime}
-          stopTime={stopTime}
           setStartTime={setStartTime}
+          stopTime={stopTime}
           setStopTime={setStopTime}
+          timeRange={timeRange}
+          setTimeRange={setTimeRange}
         />
       </Stack>
 

--- a/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -223,6 +223,7 @@ export default function Page() {
 
   const [startTime, setStartTime] = useState(dayjs().subtract(1, "week"));
   const [stopTime, setStopTime] = useState(dayjs());
+  const [timeRange, setTimeRange] = useState<number>(7);
   const [granularity, setGranularity] = useState<Granularity>("day");
   const [ttsPercentile, setTtsPercentile] = useState<number>(percentile);
 
@@ -291,9 +292,11 @@ export default function Page() {
         </Typography>
         <TimeRangePicker
           startTime={startTime}
-          stopTime={stopTime}
           setStartTime={setStartTime}
+          stopTime={stopTime}
           setStopTime={setStopTime}
+          timeRange={timeRange}
+          setTimeRange={setTimeRange}
         />
         <GranularityPicker
           granularity={granularity}

--- a/torchci/rockset/inductor/__sql/compilers_benchmark_performance_branches.sql
+++ b/torchci/rockset/inductor/__sql/compilers_benchmark_performance_branches.sql
@@ -1,7 +1,10 @@
 SELECT DISTINCT
   w.head_branch,
   w.head_sha,
-  w._event_time AS event_time
+  w.id,
+  FORMAT_ISO8601(
+    DATE_TRUNC(: granularity, torch_dynamo_perf_stats._event_time)
+  ) AS event_time
 FROM
   inductor.torch_dynamo_perf_stats LEFT JOIN commons.workflow_run w ON torch_dynamo_perf_stats.workflow_id = w.id
 WHERE
@@ -9,4 +12,4 @@ WHERE
   AND torch_dynamo_perf_stats._event_time < PARSE_DATETIME_ISO8601(:stopTime)
 ORDER BY
   w.head_branch,
-  w._event_time DESC
+  event_time DESC

--- a/torchci/rockset/inductor/compilers_benchmark_performance_branches.lambda.json
+++ b/torchci/rockset/inductor/compilers_benchmark_performance_branches.lambda.json
@@ -2,6 +2,11 @@
   "sql_path": "__sql/compilers_benchmark_performance_branches.sql",
   "default_parameters": [
     {
+      "name": "granularity",
+      "type": "string",
+      "value": "day"
+    },
+    {
       "name": "startTime",
       "type": "string",
       "value": "2023-02-01T00:00:00.00Z"

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -72,7 +72,7 @@
   },
   "inductor": {
     "compilers_benchmark_performance": "d3434f5f6c89f51c",
-    "compilers_benchmark_performance_branches": "2bea08ef6c510f85",
+    "compilers_benchmark_performance_branches": "f259d06862b41888",
     "compilers_benchmark_performance_latest_runs": "ea73304f42a9316e"
   }
 }


### PR DESCRIPTION
Based on various feedbacks on how folks use the dashboard, the list of change includes:

1. Add shareable links to snapshot the dashboard https://github.com/pytorch/pytorch/issues/96953#issuecomment-1503766492
![Screenshot 2023-04-12 at 23 55 38](https://user-images.githubusercontent.com/475357/231678382-a7565009-909f-44bc-b3f0-cc0e65c95b83.png)
1. Move dropdown menu to a new line so that it can be displayed better on a smaller screen https://github.com/pytorch/pytorch/issues/96953#issuecomment-1503927036
1. Swap left and right so that base commit  → new commit and base value  → new value
1. When selecting commits, the graph is zoomed in and out accordingly.  The first data point in the chart is from the selected base commit while the last data point is from the selected new commit (thank @wconstab for this suggestion)
1. Make sure that geomean calculation doesn't include zero speedup value
1. Display the data point value in the chart

### Testing

https://torchci-git-fork-huydhn-torchinductor-dashb-9ca473-fbopensource.vercel.app/benchmark/compilers