### PR TITLE
Upgrade MacOS conda to 23.1.0 and ensure that this version is used by the CI

### DIFF
--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -163,7 +163,7 @@ runs:
           # NB: Cloning sometimes doesn't copied pip dependencies (untracked files) over. If this
           # happens, let's attempt to install the pip requirements directly on top of the cloned
           # environment. This is to make sure that no dependency is missing
-          UNTRACKED_FILES_COUNT=$(conda package -p "${CONDA_ENV}" -u | grep -v "^#" | wc -l)
+          UNTRACKED_FILES_COUNT=$(conda package -p "${CONDA_ENV}" -u | grep -v "^#" | wc -l | xargs)
           if [[ -z "${UNTRACKED_FILES_COUNT}" ]] || [[ "${UNTRACKED_FILES_COUNT}" == "0" ]]; then
             if [[ -f "${PIP_REQUIREMENTS_FILE}" ]]; then
               conda run -p "${CONDA_ENV}" --no-capture-output python3 -mpip install -r "${PIP_REQUIREMENTS_FILE}"

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -12,7 +12,8 @@ inputs:
     description: Miniconda version to install
     required: false
     type: string
-    default: "23.1.0-1"
+    # default: "23.1.0-1"
+    default: "4.12.0"
   environment-file:
     description: Environment file to install dependencies from
     required: false

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -163,7 +163,7 @@ runs:
           set +e
           # NB: Cloning sometimes doesn't copied pip dependencies (untracked files) over. If this
           # happens, let's attempt to install the pip requirements directly on top of the cloned
-          # environment. This is to make sure that no dependency is missing
+          # environment. This is to make sure that no dependency is missing.
           UNTRACKED_FILES_COUNT=$(conda package -p "${CONDA_ENV}" -u | grep -v "^#" | wc -l | xargs)
           set -e
 

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -165,6 +165,8 @@ runs:
           # environment. This is to make sure that no dependency is missing
           UNTRACKED_FILES_COUNT=$(conda package -p "${CONDA_ENV}" -u | grep -v "^#" | wc -l | xargs)
           if [[ -z "${UNTRACKED_FILES_COUNT}" ]] || [[ "${UNTRACKED_FILES_COUNT}" == "0" ]]; then
+            echo "REACHING HERE"
+            echo "${PIP_REQUIREMENTS_FILE}"
             if [[ -f "${PIP_REQUIREMENTS_FILE}" ]]; then
               conda run -p "${CONDA_ENV}" --no-capture-output python3 -mpip install -r "${PIP_REQUIREMENTS_FILE}"
             elif [[ -n "${PIP_REQUIREMENTS_FILE}" ]]; then

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -35,15 +35,15 @@ runs:
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')d" >> "${GITHUB_OUTPUT}"
 
-      - name: Setup miniconda cache
-        id: miniconda-cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ runner.temp }}/miniconda
-          key: miniconda-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}
+      # - name: Setup miniconda cache
+      #   id: miniconda-cache
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ${{ runner.temp }}/miniconda
+      #     key: miniconda-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}
 
       - name: Install miniconda (${{ inputs.miniconda-version }})
-        if: steps.miniconda-cache.outputs.cache-hit != 'true'
+        # if: steps.miniconda-cache.outputs.cache-hit != 'true'
         env:
           MINICONDA_VERSION: ${{ inputs.miniconda-version }}
         shell: bash -l {0}
@@ -73,8 +73,15 @@ runs:
       - name: Update GitHub path to include miniconda install
         shell: bash
         run: |
+          set -x
+
           MINICONDA_INSTALL_PATH="${RUNNER_TEMP}/miniconda"
-          echo "${MINICONDA_INSTALL_PATH}/bin" >> $GITHUB_PATH
+          # NB: There might be more than one version of conda running here. And we want
+          # to make sure that the one in MINICONDA_INSTALL_PATH is used. Appending the
+          # path to GITHUB_PATH won't suffice as we need MINICONDA_INSTALL_PATH to come
+          # first
+          GITHUB_PATH_CONTENT=$(cat "${GITHUB_PATH}")
+          echo -n "${MINICONDA_INSTALL_PATH}/bin\n${GITHUB_PATH_CONTENT}" > $GITHUB_PATH
 
       # When the environment-file or pip-requirements-file inputs are not set or are set to invalid paths, the hashFiles
       # function will return an empty string without failing the step. This works out nicely and we can have a various
@@ -85,15 +92,15 @@ runs:
       # - The second one is missing or invalid: miniconda-env-macOS-ARM64-20221022d-HASH(environment-file)-
       #
       # There is no need to skip or run actions/cache with complicated logic
-      - name: Setup miniconda env cache
-        id: miniconda-env-cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ runner.temp }}/conda-python-${{ inputs.python-version }}
-          key: miniconda-env-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}-${{ hashFiles(inputs.environment-file) }}-${{ hashFiles(inputs.pip-requirements-file) }}
+      # - name: Setup miniconda env cache
+      #   id: miniconda-env-cache
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ${{ runner.temp }}/conda-python-${{ inputs.python-version }}
+      #     key: miniconda-env-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}-${{ hashFiles(inputs.environment-file) }}-${{ hashFiles(inputs.pip-requirements-file) }}
 
       - name: Setup conda environment with python (v${{ inputs.python-version }})
-        if: steps.miniconda-env-cache.outcome == 'success' && steps.miniconda-env-cache.outputs.cache-hit != 'true'
+        # if: steps.miniconda-env-cache.outcome == 'success' && steps.miniconda-env-cache.outputs.cache-hit != 'true'
         shell: bash
         env:
           PYTHON_VERSION: ${{ inputs.python-version }}
@@ -114,6 +121,10 @@ runs:
           if [[ "${PYTHON_VERSION}" == "3.11" ]]; then
             CONDA_EXTRA_FLAGS=" -c pytorch-nightly"
           fi
+
+          # Print the conda we are using here in case we need debugging information
+          which conda
+          conda --version
 
           conda create \
             --yes --quiet \
@@ -138,6 +149,10 @@ runs:
           PYTHON_VERSION: ${{ inputs.python-version }}
           CONDA_BASE_ENV: ${{ runner.temp }}/conda-python-${{ inputs.python-version }}
         run: |
+          # Print the conda we are using here in case we need debugging information
+          which conda
+          conda --version
+
           CONDA_ENV="${RUNNER_TEMP}/conda_environment_${GITHUB_RUN_ID}"
           conda create \
             --yes --quiet \
@@ -152,6 +167,7 @@ runs:
           else
             echo "CONDA_INSTALL=conda install --yes --quiet -p ${CONDA_ENV}" >> "${GITHUB_ENV}"
           fi
+
       - name: Reset channel priority
         shell: bash -l {0}
         run: |

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -160,11 +160,14 @@ runs:
             --prefix "${CONDA_ENV}" \
             --clone "${CONDA_BASE_ENV}"
 
+          set +e
           # NB: Cloning sometimes doesn't copied pip dependencies (untracked files) over. If this
           # happens, let's attempt to install the pip requirements directly on top of the cloned
           # environment. This is to make sure that no dependency is missing
           UNTRACKED_FILES_COUNT=$(conda package -p "${CONDA_ENV}" -u | grep -v "^#" | wc -l | xargs)
           echo $?
+          set -e
+
           if [[ -z "${UNTRACKED_FILES_COUNT}" ]] || [[ "${UNTRACKED_FILES_COUNT}" == "0" ]]; then
             echo "REACHING HERE"
             echo "${PIP_REQUIREMENTS_FILE}"

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -12,8 +12,7 @@ inputs:
     description: Miniconda version to install
     required: false
     type: string
-    # default: "23.1.0-1"
-    default: "4.12.0"
+    default: "23.1.0-1"
   environment-file:
     description: Environment file to install dependencies from
     required: false
@@ -77,14 +76,10 @@ runs:
           set -x
 
           MINICONDA_INSTALL_PATH="${RUNNER_TEMP}/miniconda"
-          # NB: There might be more than one version of conda running here. And we want
-          # to make sure that the one in MINICONDA_INSTALL_PATH is used. Appending the
-          # path to GITHUB_PATH won't suffice as we need MINICONDA_INSTALL_PATH to come
-          # first
-          # GITHUB_PATH_CONTENT=$(cat "${GITHUB_PATH}")
           echo "${MINICONDA_INSTALL_PATH}/bin" >> $GITHUB_PATH
+          # NB: GITHUB_PATH has a lower priority than PATH, so also set the path
+          # here to make sure that the correct conda is used
           echo "PATH=${MINICONDA_INSTALL_PATH}/bin:${PATH}" >> $GITHUB_ENV
-          # echo "${GITHUB_PATH_CONTENT}" >> $GITHUB_PATH
 
       # When the environment-file or pip-requirements-file inputs are not set or are set to invalid paths, the hashFiles
       # function will return an empty string without failing the step. This works out nicely and we can have a various
@@ -151,6 +146,7 @@ runs:
         env:
           PYTHON_VERSION: ${{ inputs.python-version }}
           CONDA_BASE_ENV: ${{ runner.temp }}/conda-python-${{ inputs.python-version }}
+          PIP_REQUIREMENTS_FILE: ${{ inputs.pip-requirements-file }}
         run: |
           # Print the conda we are using here in case we need debugging information
           which conda
@@ -161,6 +157,18 @@ runs:
             --yes --quiet \
             --prefix "${CONDA_ENV}" \
             --clone "${CONDA_BASE_ENV}"
+
+          # NB: Cloning sometimes doesn't copied pip dependencies (untracked files) over. If this
+          # happens, let's attempt to install the pip requirements directly on top of the cloned
+          # environment. This is to make sure that no dependency is missing
+          UNTRACKED_FILES_COUNT=$(conda package -p "${CONDA_ENV}" -u | grep -v "^#" | wc -l)
+          if [[ -z "${UNTRACKED_FILES_COUNT}" ]] || [[ "${UNTRACKED_FILES_COUNT}" == "0" ]]; then
+            if [[ -f "${PIP_REQUIREMENTS_FILE}" ]]; then
+              conda run -p "${CONDA_ENV}" --no-capture-output python3 -mpip install -r "${PIP_REQUIREMENTS_FILE}"
+            elif [[ -n "${PIP_REQUIREMENTS_FILE}" ]]; then
+              echo "::warning::Specified pip requirements file (${PIP_REQUIREMENTS_FILE}) not found, not going to include it"
+            fi
+          fi
 
           echo "CONDA_ENV=${CONDA_ENV}" >> "${GITHUB_ENV}"
           echo "CONDA_RUN=conda run -p ${CONDA_ENV} --no-capture-output" >> "${GITHUB_ENV}"

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -164,6 +164,7 @@ runs:
           # happens, let's attempt to install the pip requirements directly on top of the cloned
           # environment. This is to make sure that no dependency is missing
           UNTRACKED_FILES_COUNT=$(conda package -p "${CONDA_ENV}" -u | grep -v "^#" | wc -l | xargs)
+          echo $?
           if [[ -z "${UNTRACKED_FILES_COUNT}" ]] || [[ "${UNTRACKED_FILES_COUNT}" == "0" ]]; then
             echo "REACHING HERE"
             echo "${PIP_REQUIREMENTS_FILE}"

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -165,12 +165,9 @@ runs:
           # happens, let's attempt to install the pip requirements directly on top of the cloned
           # environment. This is to make sure that no dependency is missing
           UNTRACKED_FILES_COUNT=$(conda package -p "${CONDA_ENV}" -u | grep -v "^#" | wc -l | xargs)
-          echo $?
           set -e
 
           if [[ -z "${UNTRACKED_FILES_COUNT}" ]] || [[ "${UNTRACKED_FILES_COUNT}" == "0" ]]; then
-            echo "REACHING HERE"
-            echo "${PIP_REQUIREMENTS_FILE}"
             if [[ -f "${PIP_REQUIREMENTS_FILE}" ]]; then
               conda run -p "${CONDA_ENV}" --no-capture-output python3 -mpip install -r "${PIP_REQUIREMENTS_FILE}"
             elif [[ -n "${PIP_REQUIREMENTS_FILE}" ]]; then

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -35,15 +35,15 @@ runs:
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')d" >> "${GITHUB_OUTPUT}"
 
-      # - name: Setup miniconda cache
-      #   id: miniconda-cache
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ${{ runner.temp }}/miniconda
-      #     key: miniconda-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}
+      - name: Setup miniconda cache
+        id: miniconda-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ runner.temp }}/miniconda
+          key: miniconda-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}
 
       - name: Install miniconda (${{ inputs.miniconda-version }})
-        # if: steps.miniconda-cache.outputs.cache-hit != 'true'
+        if: steps.miniconda-cache.outputs.cache-hit != 'true'
         env:
           MINICONDA_VERSION: ${{ inputs.miniconda-version }}
         shell: bash -l {0}
@@ -90,15 +90,15 @@ runs:
       # - The second one is missing or invalid: miniconda-env-macOS-ARM64-20221022d-HASH(environment-file)-
       #
       # There is no need to skip or run actions/cache with complicated logic
-      # - name: Setup miniconda env cache
-      #   id: miniconda-env-cache
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ${{ runner.temp }}/conda-python-${{ inputs.python-version }}
-      #     key: miniconda-env-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}-${{ hashFiles(inputs.environment-file) }}-${{ hashFiles(inputs.pip-requirements-file) }}
+      - name: Setup miniconda env cache
+        id: miniconda-env-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ runner.temp }}/conda-python-${{ inputs.python-version }}
+          key: miniconda-env-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}-${{ hashFiles(inputs.environment-file) }}-${{ hashFiles(inputs.pip-requirements-file) }}
 
       - name: Setup conda environment with python (v${{ inputs.python-version }})
-        # if: steps.miniconda-env-cache.outcome == 'success' && steps.miniconda-env-cache.outputs.cache-hit != 'true'
+        if: steps.miniconda-env-cache.outcome == 'success' && steps.miniconda-env-cache.outputs.cache-hit != 'true'
         shell: bash
         env:
           PYTHON_VERSION: ${{ inputs.python-version }}
@@ -148,6 +148,8 @@ runs:
           CONDA_BASE_ENV: ${{ runner.temp }}/conda-python-${{ inputs.python-version }}
           PIP_REQUIREMENTS_FILE: ${{ inputs.pip-requirements-file }}
         run: |
+          set -x
+
           # Print the conda we are using here in case we need debugging information
           which conda
           conda --version

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: Miniconda version to install
     required: false
     type: string
-    default: "4.12.0"
+    default: "23.1.0-1"
   environment-file:
     description: Environment file to install dependencies from
     required: false
@@ -80,8 +80,10 @@ runs:
           # to make sure that the one in MINICONDA_INSTALL_PATH is used. Appending the
           # path to GITHUB_PATH won't suffice as we need MINICONDA_INSTALL_PATH to come
           # first
-          GITHUB_PATH_CONTENT=$(cat "${GITHUB_PATH}")
-          echo -n "${MINICONDA_INSTALL_PATH}/bin\n${GITHUB_PATH_CONTENT}" > $GITHUB_PATH
+          # GITHUB_PATH_CONTENT=$(cat "${GITHUB_PATH}")
+          echo "${MINICONDA_INSTALL_PATH}/bin" >> $GITHUB_PATH
+          echo "PATH=${MINICONDA_INSTALL_PATH}/bin:${PATH}" >> $GITHUB_ENV
+          # echo "${GITHUB_PATH_CONTENT}" >> $GITHUB_PATH
 
       # When the environment-file or pip-requirements-file inputs are not set or are set to invalid paths, the hashFiles
       # function will return an empty string without failing the step. This works out nicely and we can have a various


### PR DESCRIPTION
After some debugging, I think I have found the potential root cause of the flaky missing dependencies on MacOS.  It is in the conda clone step in which only conda packages are copied over but not pip (untracked) files.

For example, in this failure example https://github.com/pytorch/pytorch/actions/runs/4692698401/jobs/8318918238 had:

```
Source:      /Users/ec2-user/runner/_work/_temp/conda-python-3.9.12
Destination: /Users/ec2-user/runner/_work/_temp/conda_environment_4692698401
Packages: 58
Files: 0 <--- Nothing here
```

And it used `/Users/ec2-user/runner/_work/_temp/miniconda/bin/conda` as reported by `which conda`.  This conda is correct but old 4.12.0 (https://github.com/pytorch/test-infra/blob/main/.github/actions/setup-miniconda/action.yml#L15).

On the other hand, when working correctly, these files should have been copied over to the cloned env:

```
Source:      /Users/ec2-user/runner/_work/_temp/conda-python-3.9.12
Destination: /Users/ec2-user/runner/_work/_temp/conda_environment_4683905314
Packages: 58
Files: 13010 <-- These files are copied over
```

This conda here was `/opt/homebrew/Caskroom/miniconda/base/bin/conda` on M1 and `/usr/local/bin/conda` on x86_64. 
 Both are  newer (23.1.0).  It seems that **we unknowingly use the newer system-wide conda on MacOS**, which is not part of the CI.

So the attempt fix here is to:

* Upgrade MacOS conda to [23.1.0](https://repo.anaconda.com/miniconda/Miniconda3-py39_23.1.0-1-MacOSX-arm64.sh).  My theory is that the conda clone issue was fixed by this https://github.com/conda/conda/pull/11364
* Always use `/Users/ec2-user/runner/_work/_temp/miniconda/bin/conda` as this is supposed to be the one controlled by the CI
* Check if the number of untracked files (pip dependencies) is 0.  If it is, reinstall pip requirements directly on the cloned conda environment

### Testing

https://github.com/pytorch/pytorch/actions/runs/4695636286/jobs/8338451917

* Use `/Users/ec2-user/runner/_work/_temp/miniconda/bin/conda`
* Use `conda 23.1.0`
* Files are copied correctly