### PR TITLE
Push back rockset scale down

### DIFF
--- a/.github/workflows/rockset_autoscale.yml
+++ b/.github/workflows/rockset_autoscale.yml
@@ -1,11 +1,11 @@
 name: Scale Rockset VM
 on:
   schedule:
-    # Trigger scaling at 8:10am PST and 8:10pm PST on Weekdays (note: chron schedule is in UTC) 
+    # Trigger scaling at 8:10am PST and 10:10pm PST on Weekdays (note: chron schedule is in UTC)
     # We do 10 mins past the hour to account for any clock skew on the machine this job runs on
-    - cron: "10 3,15 * * 1-5"
+    - cron: "10 5,15 * * 1-5"
     # Also trigger it on Saturday morning UTC, since that'll be Fri evening PST. This scales it down for the weekend
-    - cron: "10 3 * * 6"
+    - cron: "10 5 * * 6"
   push:
     branches:
       - "zainr/rockset-autoscale" # For testing. To be removed before merging

--- a/tools/scripts/rockset_autoscale.py
+++ b/tools/scripts/rockset_autoscale.py
@@ -3,7 +3,7 @@ import os
 import time
 from datetime import datetime, time
 
-scale_down_time = datetime.strptime("3:00", "%H:%M").time() # 3am UTC, which is 8pm PST 
+scale_down_time = datetime.strptime("5:00", "%H:%M").time() # 5am UTC, which is 10pm PST
 scale_up_time = datetime.strptime("15:00", "%H:%M").time() # 3pm UTC, which is 8am PST
 
 scale_down_size = "LARGE"


### PR DESCRIPTION
Scale down rockset at 10pm PST instead of 8pm PST. Tweak made based on observing Rockset had high cpu for a bit after the scale down, likely due to jobs that were still running on CI