### PR TITLE
Switch OSS alert on pytorch/pytorch to main branch

### DIFF
--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           - repo: pytorch/pytorch
-            branch: master
+            branch: main
             with_flaky_test_alerting: YES
             job_filter_regex: ""
           - repo: pytorch/pytorch

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -246,7 +246,7 @@ def generate_failed_job_issue(
     issue[
         "title"
     ] = f"[Pytorch] There are {len(failed_jobs)} Recurrently Failing Jobs on {repo} {branch}"
-    body = "Within the last 50 commits, there are the following failures on the master branch of pytorch: \n"
+    body = "Within the last 50 commits, there are the following failures on the main branch of pytorch: \n"
     for job in failed_jobs:
         failing_sha = job.failure_chain[-1]["sha"]
         body += (
@@ -581,7 +581,7 @@ def parse_args() -> argparse.Namespace:
         "--branch",
         help="Branch to do checks for",
         type=str,
-        default=os.getenv("BRANCH_TO_CHECK", "master"),
+        default=os.getenv("BRANCH_TO_CHECK", "main"),
     )
     parser.add_argument(
         "--job-name-regex",

--- a/torchci/scripts/test_check_alerts.py
+++ b/torchci/scripts/test_check_alerts.py
@@ -84,7 +84,7 @@ def mock_fetch_alerts(*args, **kwargs):
                 "issues": {
                     "nodes": [
                         {
-                            "title": "[Pytorch] There are 3 Recurrently Failing Jobs on pytorch/pytorch master",
+                            "title": "[Pytorch] There are 3 Recurrently Failing Jobs on pytorch/pytorch main",
                             "closed": False,
                             "number": 3763,
                             "body": "",
@@ -269,10 +269,10 @@ class TestGitHubPR(TestCase):
             },
             {
                 "repo": "pytorch/pytorch",
-                "branch": "master",
+                "branch": "main",
                 "expected": [
                     {
-                        "title": "[Pytorch] There are 3 Recurrently Failing Jobs on pytorch/pytorch master",
+                        "title": "[Pytorch] There are 3 Recurrently Failing Jobs on pytorch/pytorch main",
                         "closed": False,
                         "number": 3763,
                         "body": "",


### PR DESCRIPTION
Due to the recent branch renaming, https://github.com/pytorch/test-infra/issues/4023 will be closed and another one reopen for `main`.   I will update the internal Butterfly rules after.