### PR TITLE
Increase the retry timeout for scaleUp by using a stochastic overshoot to overcome SQSs limitations

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/metrics.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/metrics.ts
@@ -770,6 +770,11 @@ export class ScaleUpMetrics extends Metrics {
   }
 
   /* istanbul ignore next */
+  stochasticOvershoot() {
+    this.countEntry('run.scaleup.stochasticOvershoot');
+  }
+
+  /* istanbul ignore next */
   scaleUpFailureRetryable(retries: number) {
     this.countEntry('run.scaleup.failure.total.count');
     this.addEntry('run.scaleup.failure.total.retries', retries);

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/utils.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/utils.test.ts
@@ -1,12 +1,14 @@
 import {
   expBackOff,
   getBoolean,
+  getDelay,
   getDelayWithJitter,
   getDelayWithJitterRetryCount,
   getRepo,
   getRepoKey,
   groupBy,
   shuffleArrayInPlace,
+  stochaticRunOvershoot,
 } from './utils';
 import nock from 'nock';
 
@@ -140,6 +142,20 @@ describe('./utils', () => {
     });
   });
 
+  describe('getDelay', () => {
+    it('test some numbers', () => {
+      expect(getDelay(0, 3)).toEqual(3);
+      expect(getDelay(1, 3)).toEqual(6);
+      expect(getDelay(2, 3)).toEqual(12);
+      expect(getDelay(3, 3)).toEqual(24);
+
+      expect(getDelay(0, 5)).toEqual(5);
+      expect(getDelay(1, 5)).toEqual(10);
+      expect(getDelay(2, 5)).toEqual(20);
+      expect(getDelay(3, 5)).toEqual(40);
+    });
+  });
+
   describe('getDelayWithJitter', () => {
     it('have jitter == 0', () => {
       expect(getDelayWithJitter(20, 0.0)).toEqual(20);
@@ -258,5 +274,42 @@ describe('shuffleArrayInPlace', () => {
     for (const number of Array(10).keys()) {
       expect(arr).toContain(number);
     }
+  });
+
+  describe('stochaticRunOvershoot', () => {
+    afterEach(() => {
+      jest.spyOn(global.Math, 'random').mockRestore();
+    });
+
+    it('test some values', () => {
+      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.0);
+      expect(stochaticRunOvershoot(0, 100, 10)).toBe(true);
+      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.5);
+      expect(stochaticRunOvershoot(0, 100, 10)).toBe(true);
+      jest.spyOn(global.Math, 'random').mockReturnValueOnce(1.0);
+      expect(stochaticRunOvershoot(0, 100, 10)).toBe(true);
+
+      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.0);
+      expect(stochaticRunOvershoot(4, 100, 10)).toBe(true);
+      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.5);
+      expect(stochaticRunOvershoot(4, 100, 10)).toBe(true);
+      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.6249);
+      expect(stochaticRunOvershoot(4, 100, 10)).toBe(true);
+      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.6251);
+      expect(stochaticRunOvershoot(4, 100, 10)).toBe(false);
+      jest.spyOn(global.Math, 'random').mockReturnValueOnce(1.0);
+      expect(stochaticRunOvershoot(4, 100, 10)).toBe(false);
+
+      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.0);
+      expect(stochaticRunOvershoot(12, 100, 10)).toBe(true);
+      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.00244139);
+      expect(stochaticRunOvershoot(12, 100, 10)).toBe(true);
+      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.00244141);
+      expect(stochaticRunOvershoot(12, 100, 10)).toBe(false);
+      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.5);
+      expect(stochaticRunOvershoot(12, 100, 10)).toBe(false);
+      jest.spyOn(global.Math, 'random').mockReturnValueOnce(1.0);
+      expect(stochaticRunOvershoot(12, 100, 10)).toBe(false);
+    });
   });
 });

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/utils.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/utils.ts
@@ -119,8 +119,17 @@ export function getDelayWithJitter(delayBase: number, jitter: number) {
   return Math.max(0, delayBase) * (1 + Math.random() * Math.max(0, jitter));
 }
 
+export function getDelay(retryCount: number, delayBase: number) {
+  return Math.max(0, delayBase) * Math.pow(2, Math.max(0, retryCount));
+}
+
 export function getDelayWithJitterRetryCount(retryCount: number, delayBase: number, jitter: number) {
-  return getDelayWithJitter(Math.max(0, delayBase) * Math.pow(2, Math.max(0, retryCount)), jitter);
+  return getDelayWithJitter(getDelay(retryCount, delayBase), jitter);
+}
+
+export function stochaticRunOvershoot(retryCount: number, maxTime: number, delayBase: number) {
+  const prob = maxTime / getDelay(retryCount, delayBase);
+  return Math.random() < prob;
 }
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */

--- a/terraform-aws-github-runner/modules/runners/scale-up.tf
+++ b/terraform-aws-github-runner/modules/runners/scale-up.tf
@@ -46,11 +46,11 @@ resource "aws_lambda_function" "scale_up" {
       LAUNCH_TEMPLATE_VERSION_LINUX         = aws_launch_template.linux_runner.latest_version
       LAUNCH_TEMPLATE_VERSION_LINUX_NVIDIA  = aws_launch_template.linux_runner_nvidia.latest_version
       LAUNCH_TEMPLATE_VERSION_WINDOWS       = aws_launch_template.windows_runner.latest_version
-      MAX_RETRY_SCALEUP_RECORD              = "5"
+      MAX_RETRY_SCALEUP_RECORD              = "10"
       MUST_HAVE_ISSUES_LABELS               = join(",", var.must_have_issues_labels)
       REDIS_ENDPOINT                        = var.redis_endpoint
       REDIS_LOGIN                           = var.redis_login
-      RETRY_SCALE_UP_RECORD_DELAY_S         = "110"
+      RETRY_SCALE_UP_RECORD_DELAY_S         = "60"
       RETRY_SCALE_UP_RECORD_JITTER_PCT      = "0.5"
       RETRY_SCALE_UP_RECORD_QUEUE_URL       = var.sqs_build_queue_retry.url
       RUNNER_EXTRA_LABELS                   = var.runner_extra_labels


### PR DESCRIPTION
Tune retry to scaleUp errors

Currently we do up to 5 retries, with exponential base of 2 and constant of 110. As we use SQS as the main delay limit, and it does not allow delays > 900s we have a effective retry window of ~45minutes. I don't feel confident that we could increase this, due the fact that a multi-hour issue with AWS capacity would bring our systems down. This is mostly by the fact that the linear nature of the cap of this strategy.

With this change, stochastic overshoot is introduced to enable processing of messages with > 900s. When this cap is reached stochastic overshoot takes care of multiples of this value and provide jitter. The disadvantage is the cost of picking up and re-emitting messages over-and-over. I believe this is OK due our current metrics.

New parameters will provide a retry window of ~17h, what proved to be more reliable.

Greater windows can then be further considered after data being gathered. (ideally I would like to see closer to 24h due the ephemeral runners)

# Copilot
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8ceacbd</samp>

This pull request implements a stochastic run overshoot feature for the GitHub runners scaling logic. It adds a probability threshold to skip scaling up runners for some messages based on the expected time limit and the number of retries. It also adds tests and metrics for the new feature and modifies some environment variables to fine-tune the scaling behavior. The files affected are `lambda.ts`, `utils.ts`, `utils.test.ts`, `lambda.test.ts`, `metrics.ts`, and `scale-up.tf`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8ceacbd</samp>

> _Oh we are the GitHub runners and we scale up with the wind_
> _We use `stochasticOvershoot` to keep our costs in trim_
> _We retry the failed messages with a delay and a jitter_
> _And we update the metrics as we go, so we don't lose our glitter_