### PR TITLE
Remove wrong job names in HUD reliability metric page

### DIFF
--- a/torchci/rockset/commons/__sql/master_commit_red_jobs.sql
+++ b/torchci/rockset/commons/__sql/master_commit_red_jobs.sql
@@ -8,11 +8,7 @@ WITH all_jobs AS (
             workflow.name,
             ' / ',
             ELEMENT_AT(SPLIT(job.name, ' / '), 1),
-            IF(
-                job.name LIKE '%/%',
-                CONCAT(' / ', ELEMENT_AT(SPLIT(ELEMENT_AT(SPLIT(job.name, ' / '), 2), ', '), 1)),
-                ''
-            )
+            CONCAT(' / ', ELEMENT_AT(SPLIT(ELEMENT_AT(SPLIT(job.name, ' / '), 2), ', '), 1))
         ) AS name,
         (
             CASE
@@ -29,10 +25,7 @@ WITH all_jobs AS (
         AND job.name != 'generate-test-matrix'
         AND job.name NOT LIKE '%rerun_disabled_tests%'
         AND job.name NOT LIKE '%filter%'
-        AND (
-            LOWER(workflow.name) = 'lint'
-            OR job.name LIKE '%/%'
-        )
+        AND job.name LIKE '%/%'
         AND ARRAY_CONTAINS(SPLIT(:workflowNames, ','), LOWER(workflow.name))
         AND workflow.event != 'workflow_run' -- Filter out worflow_run-triggered jobs, which have nothing to do with the SHA
         AND push.ref = 'refs/heads/main'

--- a/torchci/rockset/commons/master_commit_red_jobs.lambda.json
+++ b/torchci/rockset/commons/master_commit_red_jobs.lambda.json
@@ -4,12 +4,12 @@
     {
       "name": "startTime",
       "type": "string",
-      "value": "2023-02-01T00:00:00.000Z"
+      "value": "2023-04-01T00:00:00.000Z"
     },
     {
       "name": "stopTime",
       "type": "string",
-      "value": "2023-03-01T00:00:00.000Z"
+      "value": "2023-05-01T00:00:00.000Z"
     },
     {
       "name": "workflowNames",

--- a/torchci/rockset/metrics/__sql/master_commit_red_percent_groups.sql
+++ b/torchci/rockset/metrics/__sql/master_commit_red_percent_groups.sql
@@ -7,11 +7,7 @@ WITH all_jobs AS (
             workflow.name,
             ' / ',
             ELEMENT_AT(SPLIT(job.name, ' / '), 1),
-            IF(
-                job.name LIKE '%/%',
-                CONCAT(' / ', ELEMENT_AT(SPLIT(ELEMENT_AT(SPLIT(job.name, ' / '), 2), ', '), 1)),
-                ''
-            )
+            CONCAT(' / ', ELEMENT_AT(SPLIT(ELEMENT_AT(SPLIT(job.name, ' / '), 2), ', '), 1))
         ) AS name,
     FROM
         commons.workflow_job job
@@ -22,10 +18,7 @@ WITH all_jobs AS (
         AND job.name != 'generate-test-matrix'
         AND job.name NOT LIKE '%rerun_disabled_tests%'
         AND job.name NOT LIKE '%filter%'
-        AND (
-            LOWER(workflow.name) = 'lint'
-            OR job.name LIKE '%/%'
-        )
+        AND job.name LIKE '%/%'
         AND ARRAY_CONTAINS(SPLIT(:workflowNames, ','), LOWER(workflow.name))
         AND workflow.event != 'workflow_run' -- Filter out worflow_run-triggered jobs, which have nothing to do with the SHA
         AND push.ref = 'refs/heads/main'

--- a/torchci/rockset/metrics/__sql/top_reds.sql
+++ b/torchci/rockset/metrics/__sql/top_reds.sql
@@ -7,11 +7,7 @@ WITH all_jobs AS (
             workflow.name,
             ' / ',
             ELEMENT_AT(SPLIT(job.name, ' / '), 1),
-            IF(
-                job.name LIKE '%/%',
-                CONCAT(' / ', ELEMENT_AT(SPLIT(ELEMENT_AT(SPLIT(job.name, ' / '), 2), ', '), 1)),
-                ''
-            )
+            CONCAT(' / ', ELEMENT_AT(SPLIT(ELEMENT_AT(SPLIT(job.name, ' / '), 2), ', '), 1))
         ) AS name,
     FROM
         commons.workflow_job job
@@ -22,10 +18,7 @@ WITH all_jobs AS (
         AND job.name != 'generate-test-matrix'
         AND job.name NOT LIKE '%rerun_disabled_tests%'
         AND job.name NOT LIKE '%filter%'
-        AND (
-            LOWER(workflow.name) = 'lint'
-            OR job.name LIKE '%/%'
-        )
+        AND job.name LIKE '%/%'
         AND ARRAY_CONTAINS(SPLIT(:workflowNames, ','), LOWER(workflow.name))
         AND workflow.event != 'workflow_run' -- Filter out worflow_run-triggered jobs, which have nothing to do with the SHA
         AND push.ref = 'refs/heads/main'

--- a/torchci/rockset/metrics/master_commit_red_percent_groups.lambda.json
+++ b/torchci/rockset/metrics/master_commit_red_percent_groups.lambda.json
@@ -9,12 +9,12 @@
     {
       "name": "startTime",
       "type": "string",
-      "value": "2022-12-01T00:00:00.000Z"
+      "value": "2023-04-01T00:00:00.000Z"
     },
     {
       "name": "stopTime",
       "type": "string",
-      "value": "2023-02-01T00:00:00.000Z"
+      "value": "2023-05-01T00:00:00.000Z"
     },
     {
       "name": "workflowNames",

--- a/torchci/rockset/metrics/top_reds.lambda.json
+++ b/torchci/rockset/metrics/top_reds.lambda.json
@@ -4,12 +4,12 @@
     {
       "name": "startTime",
       "type": "string",
-      "value": "2022-12-01T00:00:00.000Z"
+      "value": "2023-04-01T00:00:00.000Z"
     },
     {
       "name": "stopTime",
       "type": "string",
-      "value": "2023-02-01T00:00:00.000Z"
+      "value": "2023-05-01T00:00:00.000Z"
     },
     {
       "name": "workflowNames",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -25,7 +25,7 @@
     "unclassified": "1b31a2d8f4ab7230",
     "test_insights_overview": "42dbd5232f45fd53",
     "test_insights_latest_runs": "1871833a91cb8b1b",
-    "master_commit_red_jobs": "8df20997470b8991"
+    "master_commit_red_jobs": "4ec75f3db61627a8"
   },
   "pytorch_dev_infra_kpis": {
     "monthly_contribution_stats": "c1a8751a22f6b6ce",
@@ -53,7 +53,7 @@
     "master_commit_red_avg": "4b3396ced7d92f76",
     "master_commit_red": "b05a2786103f135c",
     "master_commit_red_percent": "c53a0eb5c0d17df0",
-    "master_commit_red_percent_groups": "df5aae32a1fe9ea8",
+    "master_commit_red_percent_groups": "ebda9595c8357e51",
     "master_jobs_red_avg": "084ae0664e81bc00",
     "master_jobs_red": "44c34a7f339dff68",
     "number_of_force_pushes": "7c12c25f00d85d5d",
@@ -61,7 +61,7 @@
     "queued_jobs_by_label": "52ab0f4570516f6b",
     "queued_jobs": "7b5ef18c1273bab2",
     "reverts": "f5bc84a10c4065a3",
-    "top_reds": "59ab17e9756d1d79",
+    "top_reds": "dddc995859014109",
     "tts_avg": "2dd4a04e091c58aa",
     "tts_percentile": "912c8ad61a1772a4",
     "tts_duration_historical": "88c02c6e25d59854",


### PR DESCRIPTION
I just notice that https://hud.pytorch.org/reliability is showing some invalid job names for jobs from Lint workflow such as `Lint / lintrunner`, the correct name should be `Lint / lintrunner / linux-job` in the `% / % / %` format.  The wrong name only shows up when there is something wrong, thus it has 100% failure rate I think.  Historically, Lint job names was only `Lint / lintrunner` before I dockerized it.  It then follows Nova syntax since.