### PR TITLE
adds monitoring for specific exceptions types for ec2.runInstances

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/metrics.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/metrics.ts
@@ -732,6 +732,18 @@ export class Metrics {
     this.addEntry(`aws.ec2.perRegion.runInstances.wallclock`, ms, dimensions);
   }
 
+  /* istanbul ignore next */
+  ec2RunInstancesAWSCallException(instanceType: string, awsRegion: string, exceptionName: string, count = 1) {
+    this.countEntry('aws.ec2.runInstances.exception', count);
+    this.countEntry(`aws.ec2.perRegion.runInstances.exception`, count, new Map([['Region', awsRegion]]));
+    this.countEntry(
+      `aws.ec2.perInstancesType.runInstances.exception`,
+      count,
+      new Map([['InstanceType', instanceType]]),
+    );
+    this.countEntry(`aws.ec2.perException.runInstances.exception`, count, new Map([['Exception', exceptionName]]));
+  }
+
   // RUN
   /* istanbul ignore next */
   getRunnerTypesSuccess() {


### PR DESCRIPTION
Recently it was identified multiple reasons for failure to scaleUp, mostly related to EC2 limits, such as vCPU quotas, lack of cluster capacity, etc.

In order to gain better insight into its details, and avoid being caught by surprise, I am adding metrics to better evaluate and track the reasons for reject to deploy new instances.

# Copilot

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a523148</samp>

This pull request improves the error handling and metrics reporting of the runner scaling logic, which launches EC2 instances for GitHub runners in different regions. It adds the AWS region to the error information and uses it as a label for the new `ec2RunInstancesAWSCallException` method of the `Metrics` class. It also enhances the extraction of the exception name from the error objects. The changes affect the files `runners.ts` and `metrics.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a523148</samp>

> _Sing, O Muse, of the valiant GitHub runners, who scale the clouds_
> _And launch the swift EC2 instances in many regions, to serve the code_
> _But often face the wrath of AWS, whose errors thwart their noble deeds_
> _And force them to report their woes, with metrics and with labels bold_