### PR TITLE
Add pytorch canary to dr ci

### DIFF
--- a/torchci/lib/bot/utils.ts
+++ b/torchci/lib/bot/utils.ts
@@ -17,7 +17,7 @@ export function isPyTorchPyTorch(owner: string, repo: string): boolean {
 }
 
 export function isDrCIEnabled(owner: string, repo: string): boolean {
-  return isPyTorchOrg(owner) && ["pytorch", "vision", "text", "audio"].includes(repo);
+  return isPyTorchOrg(owner) && ["pytorch", "vision", "text", "audio", "pytorch-canary"].includes(repo);
 }
 
 export class CachedConfigTracker {


### PR DESCRIPTION
Adds pytorch-canary to dr. ci, so we can use it to debug dr. ci