### PR TITLE
Handle the weekly max autotune run on TorchInductor dashboard

### DIFF
--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -121,11 +121,13 @@ function CommitPanel({
     }
 
     const suite = m[1];
-    const index = m[2];
-    const total = m[3];
+    const setting = m[2];
+    const index = m[3];
+    const total = m[4];
 
     return {
       index: index,
+      setting: setting,
       total: total,
       url: url,
     };
@@ -182,7 +184,7 @@ function ModelPanel({
   });
 
   // Combine with right data
-  if (lCommit !== rCommit) {
+  if (lCommit !== rCommit && rData !== undefined) {
     rData.forEach((record: CompilerPerformanceData) => {
       if (record.name in dataGroupedByModel) {
         dataGroupedByModel[record.name]["r"] = record;
@@ -324,7 +326,7 @@ function ModelPanel({
               flex: 1,
               cellClassName: (params: GridCellParams<any>) => {
                 const v = params.value;
-                if (v === undefined) {
+                if (v === undefined || v.r == undefined) {
                   return "";
                 }
 
@@ -358,7 +360,7 @@ function ModelPanel({
                   return "";
                 }
 
-                if (lCommit === rCommit || v.l === v.r) {
+                if (lCommit === rCommit || v.l === v.r || v.r === undefined) {
                   return v.l;
                 } else {
                   return `${v.r} → ${v.l}`;
@@ -371,7 +373,7 @@ function ModelPanel({
               flex: 1,
               cellClassName: (params: GridCellParams<any>) => {
                 const v = params.value;
-                if (v === undefined) {
+                if (v === undefined || v.r === 0) {
                   return "";
                 }
 
@@ -416,7 +418,7 @@ function ModelPanel({
                 const l = Number(v.l).toFixed(2);
                 const r = Number(v.r).toFixed(2);
 
-                if (lCommit === rCommit || l === r) {
+                if (lCommit === rCommit || l === r || v.r === 0) {
                   return l;
                 } else {
                   return `${r} → ${l} ${
@@ -433,7 +435,7 @@ function ModelPanel({
               flex: 1,
               cellClassName: (params: GridCellParams<any>) => {
                 const v = params.value;
-                if (v === undefined) {
+                if (v === undefined || v.r === 0) {
                   return "";
                 }
 
@@ -487,7 +489,7 @@ function ModelPanel({
                 const l = Number(v.l).toFixed(0);
                 const r = Number(v.r).toFixed(0);
 
-                if (lCommit === rCommit || l === r) {
+                if (lCommit === rCommit || l === r || v.r === 0) {
                   return l;
                 } else {
                   return `${r} → ${l} ${
@@ -504,7 +506,7 @@ function ModelPanel({
               flex: 1,
               cellClassName: (params: GridCellParams<any>) => {
                 const v = params.value;
-                if (v === undefined) {
+                if (v === undefined || v.r === 0) {
                   return "";
                 }
 
@@ -555,7 +557,7 @@ function ModelPanel({
                 const l = Number(v.l).toFixed(2);
                 const r = Number(v.r).toFixed(2);
 
-                if (lCommit === rCommit || l === r) {
+                if (lCommit === rCommit || l === r || v.r === 0) {
                   return l;
                 } else {
                   return `${r} → ${l} ${
@@ -844,12 +846,7 @@ function Report({
     refreshInterval: 60 * 60 * 1000, // refresh every hour
   });
 
-  if (
-    lData === undefined ||
-    lData.length === 0 ||
-    rData === undefined ||
-    rData.length === 0
-  ) {
+  if (lData === undefined || lData.length === 0) {
     return <Skeleton variant={"rectangular"} height={"100%"} />;
   }
 
@@ -1022,7 +1019,11 @@ export default function Page() {
         </Typography>
         <CopyLink
           textToCopy={
-            `${baseUrl}?startTime=${startTime}&stopTime=${stopTime}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}` +
+            `${baseUrl}?startTime=${encodeURIComponent(
+              startTime.toString()
+            )}&stopTime=${encodeURIComponent(
+              stopTime.toString()
+            )}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}` +
             (model === undefined ? "" : `&model=${model}`)
           }
         />


### PR DESCRIPTION
This includes several fixes:

* Fix the regex to match the new weekly benchmark with max autotune setting.  The job name has a new `_max_autotune` suffix, for example `inductor_huggingface_perf_max_autotune`.  This is the issue that broke the dashboard.
* Tweak the display of max autotune job on the dashboard when it has no previous run.
  * Also increase the default view window to 7 days, as max autotune only runs weekly at the moment
* Fix https://github.com/pytorch/test-infra/issues/4054 to properly encode the view window start and stop time.

### Testing

* On a run without max autotune https://torchci-git-fork-huydhn-handle-max-autotune-fbopensource.vercel.app/benchmark/compilers?startTime=Mon%2C%2017%20Apr%202023%2002%3A50%3A37%20GMT&stopTime=Mon%2C%2024%20Apr%202023%2002%3A50%3A37%20GMT&suite=torchbench&mode=training&dtype=amp&lBranch=main&lCommit=a89d6b0a82b1c0b48c153235d4dfe88953ed2243&rBranch=main&rCommit=3d8498f926e533f31eee14c980ae447f784be52c
* On a run with max autotune https://torchci-git-fork-huydhn-handle-max-autotune-fbopensource.vercel.app/benchmark/compilers?startTime=Mon%2C%2017%20Apr%202023%2002%3A50%3A37%20GMT&stopTime=Mon%2C%2024%20Apr%202023%2002%3A50%3A37%20GMT&suite=torchbench&mode=training&dtype=amp&lBranch=main&lCommit=7a8d0ccddff9480b3ca86bfed2f77c5ad43f35b2&rBranch=main&rCommit=57e1a50da3f0252f168b733f2709d407f40e45b0