### PR TITLE
Remove macos x86 py3.11 limitation

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -208,10 +208,6 @@ def generate_conda_matrix(os: str, channel: str, with_cuda: str, limit_pr_builds
     arches = ["cpu"]
     python_versions = list(mod.PYTHON_ARCHES)
 
-    # remove python 3.11 conda from macos x86
-    if(os == "macos"):
-        python_versions = list_without(python_versions, ["3.11"])
-
     if with_cuda == ENABLE and (os == "linux" or os == "windows"):
         arches += mod.CUDA_ARCHES
 


### PR DESCRIPTION
Remove macos x86 py3.11 limitation.

This should resolve following issue: https://github.com/pytorch/pytorch/issues/97031

The blas mkl variant of osx-64 py311 packages should now be available. as per comment : https://github.com/ContinuumIO/anaconda-issues/issues/13157#issuecomment-1517033935

The osx-64 py311 binaries are here: https://anaconda.org/anaconda/mkl-service/files?sort=time&sort_order=desc