### PR TITLE
MACOSX_DEPLOYMENT_TARGET 10.9 -> 10.13

### DIFF
--- a/tools/pkg-helpers/pytorch_pkg_helpers/macos.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/macos.py
@@ -1,6 +1,6 @@
 def get_macos_variables(arch_name: str, python_version: str = "3.8") -> list:
     variables = [
-        "export MACOSX_DEPLOYMENT_TARGET=10.9",
+        "export MACOSX_DEPLOYMENT_TARGET=10.13",
         "export CC=clang",
         "export CXX=clang++",
     ]


### PR DESCRIPTION
We're currently targeting MacOS 10.9, which is very old OS. Updating this to target 10.13