### PR TITLE
remmove unused runners from scale-config.yml

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -45,12 +45,6 @@ runner_types:
     is_ephemeral: false
     max_available: 3120
     os: linux
-  linux.2xlarge.amd:
-    disk_size: 150
-    instance_type: c5a.2xlarge
-    is_ephemeral: false
-    max_available: 120
-    os: linux
   linux.4xlarge:
     disk_size: 150
     instance_type: c5.4xlarge
@@ -68,12 +62,6 @@ runner_types:
     instance_type: g3.8xlarge
     is_ephemeral: false
     max_available: 400
-    os: linux
-  linux.c5.4xlarge.ephemeral:
-    disk_size: 150
-    instance_type: c5.4xlarge
-    is_ephemeral: true
-    max_available: 1000
     os: linux
   linux.g4dn.12xlarge.nvidia.gpu:
     disk_size: 150
@@ -97,28 +85,6 @@ runner_types:
     disk_size: 15
     instance_type: c5.large
     is_ephemeral: false
-    os: linux
-  linux.large.ephemeral:
-    disk_size: 15
-    instance_type: c5.large
-    is_ephemeral: true
-    os: linux
-  linux.p3.8xlarge.nvidia.gpu:
-    disk_size: 150
-    instance_type: p3.8xlarge
-    max_available: 10
-    os: linux
-  linux.p324xlarge.nvidia.gpu:
-    disk_size: 512
-    instance_type: p3dn.24xlarge
-    is_ephemeral: false
-    max_available: 1
-    os: linux
-  linux.p4d24xlarge.nvidia.gpu:
-    disk_size: 512
-    instance_type: p4d.24xlarge
-    is_ephemeral: false
-    max_available: 1
     os: linux
   windows.4xlarge:
     disk_size: 256


### PR DESCRIPTION
Evidence suggest that in the last month the following runners labels were not used:

* linux.2xlarge.amd
* linux.c5.4xlarge.ephemeral
* linux.large.ephemeral
* linux.p3.8xlarge.nvidia.gpu
* linux.p324xlarge.nvidia.gpu
* linux.p4d24xlarge.nvidia.gpu

![Screenshot 2023-04-26 at 15 32 55](https://user-images.githubusercontent.com/4520845/234591842-53f4c589-9ad3-4582-b570-2063775c79fa.png)

so I am removing them from the configuration