### PR TITLE
Fix cudnn path copy for cuda 11.8 and up

### DIFF
--- a/aws/ami/windows/scripts/Installers/Install-CUDA-Tools.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-CUDA-Tools.ps1
@@ -98,10 +98,11 @@ function Install-Cudnn() {
   Write-Output "Copying cudnn to $expectedInstallLocation"
 
   Copy-Item -Force -Verbose -Recurse "$tmpCudnnExtracted\$cudnn_subfolder\bin\*" "$expectedInstallLocation\bin"
-  if ($cudaVersion -eq "11.8") {
-    Copy-Item -Force -Verbose -Recurse "$tmpCudnnExtracted\$cudnn_subfolder\$cudnn_lib_folder\x64\*" "$expectedInstallLocation\lib\x64"
-  } else {
+  # TODO: Remove when CUDA 11.7 is deprecated
+  if ($cudaVersion -eq "11.7") {
     Copy-Item -Force -Verbose -Recurse "$tmpCudnnExtracted\$cudnn_subfolder\$cudnn_lib_folder\*" "$expectedInstallLocation\lib\x64"
+  } else {
+    Copy-Item -Force -Verbose -Recurse "$tmpCudnnExtracted\$cudnn_subfolder\$cudnn_lib_folder\x64\*" "$expectedInstallLocation\lib\x64"
   }
   Copy-Item -Force -Verbose -Recurse "$tmpCudnnExtracted\$cudnn_subfolder\include\*" "$expectedInstallLocation\include"
 


### PR DESCRIPTION
Fix cudnn path copy for cuda 11.8 and up.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0aa2ef7</samp>

Fix CUDA tools installation bug on Windows AMIs. The change ensures the correct library files are copied for different CUDA versions in `Install-CUDA-Tools.ps1`. The change is part of a pull request to improve Windows testing.