### PR TITLE
Handle the recent burst of error on TorchInductor dashboard

### DIFF
--- a/torchci/rockset/inductor/__sql/compilers_benchmark_performance.sql
+++ b/torchci/rockset/inductor/__sql/compilers_benchmark_performance.sql
@@ -1,7 +1,7 @@
 WITH performance_results AS (
   SELECT
     name,
-    speedup,
+    IF(speedup = 'infra_error', NULL, speedup) AS speedup, -- Handle the recent burst of infra error
     REPLACE(
       filename,
       CONCAT(

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -74,7 +74,7 @@
     "completed_pr_jobs_aggregate": "7b6b27eeca4dfc6f"
   },
   "inductor": {
-    "compilers_benchmark_performance": "5ddc9635e18202b9",
+    "compilers_benchmark_performance": "4b2c68b683453c99",
     "compilers_benchmark_performance_branches": "f259d06862b41888"
   },
   "utilization": {


### PR DESCRIPTION
The `speedup` value, which is expected to be a float or NULL, is set to the string `infra_error` introduced recently because of the burst of error on inductor workflow.  This makes https://hud.pytorch.org/benchmark/compilers fail to load at the moment because string couldn't be converted to float.

### Testing
https://torchci-git-fork-huydhn-handle-infra-error-fbopensource.vercel.app/benchmark/compilers now loads successfully