### PR TITLE
Enable GPU support for generic Windows job

### DIFF
--- a/.github/workflows/test_windows_job.yml
+++ b/.github/workflows/test_windows_job.yml
@@ -27,12 +27,12 @@ jobs:
       runner: windows.8xlarge.nvidia.gpu
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
-      job-name: "win-py3.8-cu116"
+      job-name: "win-py3.8-cu117"
       timeout: 60
       script: |
         conda create --yes --quiet -n test python=3.8
         conda activate test
-        python -m pip install --extra-index-url https://download.pytorch.org/whl/nightly/cu116 --pre torch
+        python -m pip install ---index-url=https://download.pytorch.org/whl/nightly/cu117 --pre torch
         # Can import pytorch, cuda is available
         python -c 'import torch;assert(torch.cuda.is_available())'
   test-upload-artifact:

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -135,9 +135,6 @@ jobs:
             # Source conda so it's available to the script environment
             echo "source /c/Jenkins/Miniconda3/etc/profile.d/conda.sh";
             echo 'export PATH="/c/Jenkins/Miniconda3/Scripts:${PATH}"'
-            echo 'echo ### DEBUG ########################'
-            echo 'cat /c/Jenkins/Miniconda3/etc/profile.d/conda.sh'
-            echo 'echo ##################################'
             # Setup CUDA paths
             echo 'if [[ ${{ inputs.gpu-arch-type }} == '\''cuda'\'' ]]; then'
             echo '  export CUDA_HOME="/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${{ inputs.gpu-arch-version }}"'

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -131,7 +131,7 @@ jobs:
           echo "###########################"
           {
             echo "#!/usr/bin/env bash";
-            echo "set -eou pipefail";
+            echo "set -euxo pipefail";
             # Without this specific version of pywin32 conda the default conda installation does not work
             # See https://github.com/conda/conda/issues/11503
             echo "/c/Jenkins/Miniconda3/python.exe -m pip install --upgrade pywin32==300"
@@ -139,7 +139,7 @@ jobs:
             echo "source /c/Jenkins/Miniconda3/etc/profile.d/conda.sh";
             echo 'export PATH="/c/Jenkins/Miniconda3/Scripts:${PATH}"'
             # Setup CUDA paths
-            echo 'if [[ ${{ inputs.gpu-arch-type }} == '\''cuda'\'' ]]; then'
+            echo 'if [[ ${{ inputs.gpu-arch-type }} == cuda ]]; then'
             echo '  export CUDA_HOME="/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${{ inputs.gpu-arch-version }}"'
             echo '  export CUDA_PATH="${CUDA_HOME}"'
             echo '  export PATH="${CUDA_PATH}/bin:${PATH}"'
@@ -149,6 +149,9 @@ jobs:
           while read line; do
             eval "export ${line}"
           done < "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
+          echo "### DEBUG #################"
+          cat "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
+          echo "###########################"
           bash "${RUNNER_TEMP}/exec_script"
 
       - name: Surface failing tests

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -146,9 +146,6 @@ jobs:
           while read line; do
             eval "export ${line}"
           done < "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
-          echo "### DEBUG #################"
-          cat "${RUNNER_TEMP}/exec_script"
-          echo "###########################"
           bash "${RUNNER_TEMP}/exec_script"
 
       - name: Surface failing tests

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -137,7 +137,7 @@ jobs:
             echo 'export PATH="/c/Jenkins/Miniconda3/Scripts:${PATH}"'
             # Setup CUDA paths
             echo 'if [[ ${{ inputs.gpu-arch-type }} == cuda ]]; then'
-            echo '  export CUDA_HOME="/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${{ inputs.gpu-arch-version }}"'
+            echo '  export CUDA_HOME="/c/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${{ inputs.gpu-arch-version }}"'
             echo '  export CUDA_PATH="${CUDA_HOME}"'
             echo '  export PATH="${CUDA_PATH}/bin:${PATH}"'
             echo 'fi'

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -126,12 +126,9 @@ jobs:
         continue-on-error: ${{ inputs.continue-on-error }}
         working-directory: ${{ inputs.repository }}
         run: |
-          echo "### DEBUG #################"
-          echo "${RUNNER_TEMP}"
-          echo "###########################"
           {
             echo "#!/usr/bin/env bash";
-            echo "set -euxo pipefail";
+            echo "set -eou pipefail";
             # Without this specific version of pywin32 conda the default conda installation does not work
             # See https://github.com/conda/conda/issues/11503
             echo "/c/Jenkins/Miniconda3/python.exe -m pip install --upgrade pywin32==300"
@@ -150,7 +147,7 @@ jobs:
             eval "export ${line}"
           done < "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
           echo "### DEBUG #################"
-          cat "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
+          cat "${RUNNER_TEMP}/exec_script"
           echo "###########################"
           bash "${RUNNER_TEMP}/exec_script"
 

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -126,6 +126,7 @@ jobs:
         continue-on-error: ${{ inputs.continue-on-error }}
         working-directory: ${{ inputs.repository }}
         run: |
+          EXEC_SCRIPT="${RUNNER_TEMP}/exec_script"
           {
             echo "#!/usr/bin/env bash";
             echo "set -eou pipefail";
@@ -135,18 +136,19 @@ jobs:
             # Source conda so it's available to the script environment
             echo "source /c/Jenkins/Miniconda3/etc/profile.d/conda.sh";
             echo 'export PATH="/c/Jenkins/Miniconda3/Scripts:${PATH}"'
-            # Setup CUDA paths
-            echo 'if [[ ${{ inputs.gpu-arch-type }} == cuda ]]; then'
-            echo '  export CUDA_HOME="/c/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${{ inputs.gpu-arch-version }}"'
-            echo '  export CUDA_PATH="${CUDA_HOME}"'
-            echo '  export PATH="${CUDA_PATH}/bin:${PATH}"'
-            echo 'fi'
-            echo "${SCRIPT}";
-          } > "${RUNNER_TEMP}/exec_script"
+          } > "${EXEC_SCRIPT}"
+          if [[ ${{ inputs.gpu-arch-type }} == cuda ]]; then
+            {
+              echo 'export CUDA_HOME="/c/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${{ inputs.gpu-arch-version }}"'
+              echo 'export CUDA_PATH="${CUDA_HOME}"'
+              echo 'export PATH="${CUDA_PATH}/bin:${PATH}"'
+            } >> "${EXEC_SCRIPT}"
+          fi
+          echo "${SCRIPT}" >> "${EXEC_SCRIPT}"
           while read line; do
             eval "export ${line}"
           done < "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
-          bash "${RUNNER_TEMP}/exec_script"
+          bash "${EXEC_SCRIPT}"
 
       - name: Surface failing tests
         if: always()

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -56,6 +56,14 @@ on:
         required: false
         default: ''
         type: string
+      gpu-arch-type:
+        description: "GPU arch type to use"
+        default: "cpu"
+        type: string
+      gpu-arch-version:
+        description: "GPU arch version to use"
+        default: ""
+        type: string
 
 jobs:
   job:
@@ -126,6 +134,16 @@ jobs:
             echo "/c/Jenkins/Miniconda3/python.exe -m pip install --upgrade pywin32==300"
             # Source conda so it's available to the script environment
             echo "source /c/Jenkins/Miniconda3/etc/profile.d/conda.sh";
+            echo 'export PATH="/c/Jenkins/Miniconda3/Scripts:${PATH}"'
+            echo 'echo ### DEBUG ########################'
+            echo 'cat /c/Jenkins/Miniconda3/etc/profile.d/conda.sh'
+            echo 'echo ##################################'
+            # Setup CUDA paths
+            echo 'if [[ ${{ inputs.gpu-arch-type }} == '\''cuda'\'' ]]; then'
+            echo '  export CUDA_HOME="/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${{ inputs.gpu-arch-version }}"'
+            echo '  export CUDA_PATH="${CUDA_HOME}"'
+            echo '  export PATH="${CUDA_PATH}/bin:${PATH}"'
+            echo 'fi'
             echo "${SCRIPT}";
           } > "${RUNNER_TEMP}/exec_script"
           while read line; do

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -126,6 +126,9 @@ jobs:
         continue-on-error: ${{ inputs.continue-on-error }}
         working-directory: ${{ inputs.repository }}
         run: |
+          echo "### DEBUG #################"
+          echo "${RUNNER_TEMP}"
+          echo "###########################"
           {
             echo "#!/usr/bin/env bash";
             echo "set -eou pipefail";

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -134,6 +134,13 @@ jobs:
             echo "/c/Jenkins/Miniconda3/python.exe -m pip install --upgrade pywin32==300"
             # Source conda so it's available to the script environment
             echo "source /c/Jenkins/Miniconda3/etc/profile.d/conda.sh";
+            echo 'export PATH="/c/Jenkins/Miniconda3/Scripts:${PATH}"'
+            # Setup CUDA paths
+            echo 'if [[ ${{ inputs.gpu-arch-type }} == cuda ]]; then'
+            echo '  export CUDA_HOME="/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${{ inputs.gpu-arch-version }}"'
+            echo '  export CUDA_PATH="${CUDA_HOME}"'
+            echo '  export PATH="${CUDA_PATH}/bin:${PATH}"'
+            echo 'fi'
             echo "${SCRIPT}";
           } > "${RUNNER_TEMP}/exec_script"
           while read line; do

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -134,13 +134,6 @@ jobs:
             echo "/c/Jenkins/Miniconda3/python.exe -m pip install --upgrade pywin32==300"
             # Source conda so it's available to the script environment
             echo "source /c/Jenkins/Miniconda3/etc/profile.d/conda.sh";
-            echo 'export PATH="/c/Jenkins/Miniconda3/Scripts:${PATH}"'
-            # Setup CUDA paths
-            echo 'if [[ ${{ inputs.gpu-arch-type }} == cuda ]]; then'
-            echo '  export CUDA_HOME="/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${{ inputs.gpu-arch-version }}"'
-            echo '  export CUDA_PATH="${CUDA_HOME}"'
-            echo '  export PATH="${CUDA_PATH}/bin:${PATH}"'
-            echo 'fi'
             echo "${SCRIPT}";
           } > "${RUNNER_TEMP}/exec_script"
           while read line; do


### PR DESCRIPTION
The Linux job has these inputs to control the GPU support:

https://github.com/pytorch/test-infra/blob/92814dfe9af9ea152bf35df359934742387abb10/.github/workflows/linux_job.yml#L50-L57

They were missing before from the Windows job. Without them, users are forced to use [workarounds](https://github.com/pytorch/vision/blob/14553fb9eb78e053100e966feee6149905f9922c/.github/workflows/test-windows.yml#L44-L49).

This PR adds them to the Windows job as well. Since we have multiple versions of CUDA already present on the AMI, we only need to set some paths.