### PR TITLE
Add config nullability ternary in retryBot

### DIFF
--- a/torchci/lib/bot/retryBot.ts
+++ b/torchci/lib/bot/retryBot.ts
@@ -137,7 +137,7 @@ function retryBot(app: Probot): void {
 
     const config: any = await tracker.loadConfig(ctx);
     const allowedWorkflowPrefixes: string[] | undefined =
-      config["retryable_workflows"];
+      config != null ? config["retryable_workflows"] : undefined;
 
     if (allowedWorkflowPrefixes === undefined) {
       return;


### PR DESCRIPTION
Should fix:
```
    at async Router.execute (/var/task/torchci/node_modules/next/dist/server/router.js:233:32)
    at async NextNodeServer.run (/var/task/torchci/node_modules/next/dist/server/base-server.js:583:29)
    at async NextNodeServer.handleRequest (/var/task/torchci/node_modules/next/dist/server/base-server.js:298:20)
    at async module.exports (/var/task/torchci/___next_launcher.cjs:29:9)","type":"Error","msg":"Cannot read properties of null (reading 'retryable_workflows')"}
```