### PR TITLE
[stronghold][bc-linter] add #suppress-bc-linter as an alternative suppression tag

### DIFF
--- a/tools/stronghold/src/api/checker.py
+++ b/tools/stronghold/src/api/checker.py
@@ -52,7 +52,8 @@ def run() -> None:
         check=True,
         stdout=subprocess.PIPE,
     )
-    suppressed = '#suppress-api-compatibility-check' in pinfo.stdout or args.suppressed
+    suppression_tags = ['#suppress-api-compatibility-check', '#suppress-bc-linter']
+    suppressed = args.suppressed or any(tag in pinfo.stdout for tag in suppression_tags)
     level = 'notice' if suppressed else 'warning'
 
     for file, file_violations in violations.items():


### PR DESCRIPTION
Now either `#suppress-api-compatibility-check` or `#suppress-bc-linter` in the commit message will suppress BC-linter.