### PR TITLE
Temp Use conda-forge for release build

### DIFF
--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -136,13 +136,25 @@ jobs:
           fi
           export FFMPEG_ROOT="${PWD}/third_party/ffmpeg"
 
-          ${CONDA_RUN} conda build \
-            -c defaults \
-            -c "pytorch-${CHANNEL}" \
-            --no-anaconda-upload \
-            --python "${PYTHON_VERSION}" \
-            --output-folder distr/ \
-            "${CONDA_PACKAGE_DIRECTORY}"
+          arch_name="$(uname -m)"
+          if [[ "${arch_name}" = "x86_64" ]] && [[ "${PYTHON_VERSION}" = "3.10" || "${PYTHON_VERSION}" = "3.11" ]]; then
+            ${CONDA_RUN} conda build \
+              -c defaults \
+              -c conda-forge \
+              -c "pytorch-${CHANNEL}" \
+              --no-anaconda-upload \
+              --python "${PYTHON_VERSION}" \
+              --output-folder distr/ \
+              "${CONDA_PACKAGE_DIRECTORY}"
+          else
+            ${CONDA_RUN} conda build \
+              -c defaults \
+              -c "pytorch-${CHANNEL}" \
+              --no-anaconda-upload \
+              --python "${PYTHON_VERSION}" \
+              --output-folder distr/ \
+              "${CONDA_PACKAGE_DIRECTORY}"
+          fi
 
       - name: Upload artifact to GitHub
         continue-on-error: true


### PR DESCRIPTION
Temp Use conda-forge for release build

Already tested here: https://github.com/pytorch/test-infra/actions/runs/4887292374/jobs/8723703363

We are doing it to fix this issue: https://github.com/pytorch/audio/actions/runs/4887939314/jobs/8725107510
To be able to produce build for python 3.10 and maybe 3.11