### PR TITLE
Comment and close unauthorized DISABLED test and job issues

### DIFF
--- a/torchci/lib/bot/verifyDisableTestIssueBot.ts
+++ b/torchci/lib/bot/verifyDisableTestIssueBot.ts
@@ -100,7 +100,7 @@ export function formValidationComment(
   body += "The information I have parsed is below:\n\n";
   body += `* Test name: \`${testName}\`\n`;
   body += `* Platforms for which to skip the test: ${platformMsg}\n`;
-  body += `* Credential: \`${username}\`\n\n`;
+  body += `* Disabled by  \`${username}\`\n\n`;
 
   if (invalidPlatforms.length > 0) {
     body +=

--- a/torchci/lib/bot/verifyDisableTestIssueBot.ts
+++ b/torchci/lib/bot/verifyDisableTestIssueBot.ts
@@ -100,7 +100,7 @@ export function formValidationComment(
   body += "The information I have parsed is below:\n\n";
   body += `* Test name: \`${testName}\`\n`;
   body += `* Platforms for which to skip the test: ${platformMsg}\n`;
-  body += `* Disabled by  \`${username}\`\n\n`;
+  body += `* Disabled by \`${username}\`\n\n`;
 
   if (invalidPlatforms.length > 0) {
     body +=


### PR DESCRIPTION
Per title, this fixes https://github.com/pytorch/pytorch/issues/100327 by rejecting both unauthorized DISABLED test and job issues (previously done only in the latter).  The bot will then close the issue immediately if it's created by unauthorized user.

DISABLED test issues could be created automatically by `pytorch-bot`, AFAIK, the bot has full write permission to the repo.  Note that it's not a GitHub user, but an app.