### PR TITLE
Fix `compilers_benchmark_performance` query

### DIFF
--- a/torchci/rockset/inductor/__sql/compilers_benchmark_performance.sql
+++ b/torchci/rockset/inductor/__sql/compilers_benchmark_performance.sql
@@ -73,19 +73,19 @@ results AS (
       ELSE NULL
     END AS compiler,
     accuracy_results.name,
-    CAST(IF(
-      speedup IS NULL OR speedup = 'timeout', '0.0000',
-      speedup
-    ) AS FLOAT) AS speedup,
+    IF(TRY_CAST(speedup AS FLOAT) IS NOT NULL,
+      CAST(speedup AS FLOAT),
+      0.0
+    ) AS speedup,
     accuracy,
-    CAST(IF(
-      compilation_latency IS NULL, '0.0000',
-      compilation_latency
-    ) AS FLOAT) AS compilation_latency,
-    CAST(IF(
-      compression_ratio IS NULL, '0.0000',
-      compression_ratio
-    ) AS FLOAT) AS compression_ratio,
+    IF(TRY_CAST(compilation_latency AS FLOAT) IS NOT NULL,
+      CAST(compilation_latency AS FLOAT),
+      0.0
+    ) AS compilation_latency,
+    IF(TRY_CAST(compression_ratio AS FLOAT) IS NOT NULL,
+      CAST(compression_ratio AS FLOAT),
+      0.0
+    ) AS compression_ratio,
   FROM
     accuracy_results
     LEFT JOIN performance_results ON performance_results.name = accuracy_results.name

--- a/torchci/rockset/inductor/__sql/compilers_benchmark_performance.sql
+++ b/torchci/rockset/inductor/__sql/compilers_benchmark_performance.sql
@@ -74,7 +74,7 @@ results AS (
     END AS compiler,
     accuracy_results.name,
     CAST(IF(
-      speedup IS NULL, '0.0000',
+      speedup IS NULL OR speedup = 'timeout', '0.0000',
       speedup
     ) AS FLOAT) AS speedup,
     accuracy,

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -74,7 +74,7 @@
     "completed_pr_jobs_aggregate": "7b6b27eeca4dfc6f"
   },
   "inductor": {
-    "compilers_benchmark_performance": "4b2c68b683453c99",
+    "compilers_benchmark_performance": "0d320965e3517707",
     "compilers_benchmark_performance_branches": "f259d06862b41888"
   },
   "utilization": {

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -74,7 +74,7 @@
     "completed_pr_jobs_aggregate": "7b6b27eeca4dfc6f"
   },
   "inductor": {
-    "compilers_benchmark_performance": "0d320965e3517707",
+    "compilers_benchmark_performance": "f024488f6696575d",
     "compilers_benchmark_performance_branches": "f259d06862b41888"
   },
   "utilization": {


### PR DESCRIPTION
By using `TRY_CAST` instead of `CAST()` to ignore string values not castable to float