### PR TITLE
Use single conda install statement for all conda dependencies

### DIFF
--- a/aws/ami/windows/scripts/Installers/Install-Conda-Dependencies.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-Conda-Dependencies.ps1
@@ -14,6 +14,6 @@ conda activate base
 
 Write-Output "Installing conda packages for building and testing PyTorch"
 # The list of dependencies is copied from the current PyTorch miniconda installation script
-conda install -y numpy"<1.23" ninja pyyaml setuptools cmake=3.22.* cffi typing_extensions future six requests dataclasses boto3 libuv
-# and setup_pytorch_env script
-conda install -y mkl protobuf numba scipy=1.6.2 typing_extensions dataclasses conda==22.9.0
+conda install -y mkl protobuf numba scipy=1.6.2 typing_extensions dataclasses `
+conda==22.9.0 numpy"<1.23" ninja pyyaml setuptools cmake=3.22.* cffi typing_extensions `
+future six requests dataclasses boto3 libuv


### PR DESCRIPTION
Use single conda install statement for all conda dependencies 
Should fix issue of numpy being updated to  numpy>=1.23