### PR TITLE
New rule for file level retries

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -186,7 +186,7 @@ pattern = '^AttributeError: .*'
 
 [[rule]]
 name = 'File level retry'
-patther = '^Got exit code -.*, retrying \(retries left=.*\)$'
+pattern = '^Got exit code -.*, retrying \(retries left=.*\)$'
 
 [[rule]]
 name = 'Python flaky unittest - failed'

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -185,6 +185,10 @@ name = 'Python AttributeError'
 pattern = '^AttributeError: .*'
 
 [[rule]]
+name = 'File level retry'
+patther = '^Got exit code -.*, retrying \(retries left=.*\)$'
+
+[[rule]]
 name = 'Python flaky unittest - failed'
 pattern = '^\s*(test.*) failed - num_retries_left:'
 


### PR DESCRIPTION
Much like the unittest flaky rule, this isn't a rule that points to a line that explains why the job failed, but makes it easier to find jobs that needed to do retries.  It's relatively near the bottom of the rules to make sure it doesn't interfere with the rules that do point to failing lines.