### PR TITLE
Revert "Temp Use conda-forge for release build"

### DIFF
--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -136,25 +136,13 @@ jobs:
           fi
           export FFMPEG_ROOT="${PWD}/third_party/ffmpeg"
 
-          arch_name="$(uname -m)"
-          if [[ "${arch_name}" = "x86_64" ]] && [[ "${PYTHON_VERSION}" = "3.10" || "${PYTHON_VERSION}" = "3.11" ]]; then
-            ${CONDA_RUN} conda build \
-              -c defaults \
-              -c conda-forge \
-              -c "pytorch-${CHANNEL}" \
-              --no-anaconda-upload \
-              --python "${PYTHON_VERSION}" \
-              --output-folder distr/ \
-              "${CONDA_PACKAGE_DIRECTORY}"
-          else
-            ${CONDA_RUN} conda build \
-              -c defaults \
-              -c "pytorch-${CHANNEL}" \
-              --no-anaconda-upload \
-              --python "${PYTHON_VERSION}" \
-              --output-folder distr/ \
-              "${CONDA_PACKAGE_DIRECTORY}"
-          fi
+          ${CONDA_RUN} conda build \
+            -c defaults \
+            -c "pytorch-${CHANNEL}" \
+            --no-anaconda-upload \
+            --python "${PYTHON_VERSION}" \
+            --output-folder distr/ \
+            "${CONDA_PACKAGE_DIRECTORY}"
 
       - name: Upload artifact to GitHub
         continue-on-error: true


### PR DESCRIPTION
Reverts pytorch/test-infra#4112
Original issue, required conda-forge to resolve mkl dependency on macos x86 builds
Not required anymore, resolved by https://github.com/pytorch/audio/pull/3307