### PR TITLE
Set GPU `capabilities=all` for Docker

### DIFF
--- a/.github/actions/setup-nvidia/action.yml
+++ b/.github/actions/setup-nvidia/action.yml
@@ -233,4 +233,4 @@ runs:
                   exit 1
                   ;;
           esac
-          echo "GPU_FLAG=--gpus all" >> "${GITHUB_ENV}"
+          echo "GPU_FLAG=--gpus all,capabilities=all" >> "${GITHUB_ENV}"


### PR DESCRIPTION
Currently, GPU_FLAGS is set to `--gpus all`.
This exposes all the runner GPUs to container with default capabilities which is `utility` and `compute`.

https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html

This does not expose GPU video encoder/decoder libraries, and attempting to use it will cause the error where the corresponding libraries are not found.

https://github.com/pytorch/audio/actions/runs/4899270270/jobs/8749113374#step:10:2022

This commit specified `capabilities=all`, so that non-default capability, including video become available.