### PR TITLE
remove double doc upload after path unification

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -222,7 +222,8 @@ jobs:
           s3-bucket: doc-previews
           if-no-files-found: error
           path: ${{ env.RUNNER_DOCS_DIR }}
-          s3-prefix: pytorch/${{ env.REPOSITORY }}/${{ github.event.pull_request.number }}
+          # ${{ env.repository }} is $OWNER/$REPO
+          s3-prefix: ${{ env.REPOSITORY }}/${{ github.event.pull_request.number }}
 
       - name: Teardown Linux
         if: ${{ always() }}

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -214,17 +214,6 @@ jobs:
           path: ${{ runner.temp }}/artifacts/
           if-no-files-found: ${{ steps.check-artifacts.outputs.if-no-files-found }}
 
-      # TODO: Remove once we converge on documentation paths
-      - name: (legacy) Upload documentation to S3 (if any)
-        uses: seemethere/upload-artifact-s3@v5
-        if: ${{ steps.check-artifacts.outputs.upload-docs == 1 && github.event.pull_request.number != '' }}
-        with:
-          retention-days: 14
-          s3-bucket: doc-previews
-          if-no-files-found: error
-          path: ${{ env.RUNNER_DOCS_DIR }}
-          s3-prefix: pytorch/${{ env.REPOSITORY }}/${{ github.event.pull_request.number }}
-
       - name: Upload documentation to S3 (if any)
         uses: seemethere/upload-artifact-s3@v5
         if: ${{ steps.check-artifacts.outputs.upload-docs == 1 && github.event.pull_request.number != '' }}
@@ -233,7 +222,7 @@ jobs:
           s3-bucket: doc-previews
           if-no-files-found: error
           path: ${{ env.RUNNER_DOCS_DIR }}
-          s3-prefix: ${{ env.REPOSITORY }}/${{ github.event.pull_request.number }}
+          s3-prefix: pytorch/${{ env.REPOSITORY }}/${{ github.event.pull_request.number }}
 
       - name: Teardown Linux
         if: ${{ always() }}

--- a/.github/workflows/test_linux_job.yml
+++ b/.github/workflows/test_linux_job.yml
@@ -119,9 +119,8 @@ jobs:
       script: |
         # Sleep a couple of seconds just in case S3 is being slow (might not be needed?)
         sleep 10
-        # TODO: Change this eventually to reflect new url path, see https://github.com/pytorch/test-infra/issues/3894
         REPO_NAME="$(echo "${GITHUB_REPOSITORY}" | cut -d '/' -f2)"
-        curl -fsSL "https://docs-preview.pytorch.org/${REPO_NAME}/${PR_NUMBER}/index.html" | grep "hello"
+        curl -fsSL "https://docs-preview.pytorch.org/pytorch/${REPO_NAME}/${PR_NUMBER}/index.html" | grep "hello"
   test-with-matrix:
     uses: ./.github/workflows/linux_job.yml
     strategy:


### PR DESCRIPTION
#3917 was merged so we no longer need to upload to two paths. Note that the new scheme is `{OWNER}/{REPO}/{PR}` and this was dubbed "legacy". Thus, we are actually removing the other one and dropping the legacy label.