### PR TITLE
tidy up table header names and add total testing time per workflow on testing overhead dashboard

### DIFF
--- a/torchci/components/metrics/panels/GenerateIndividualTestsLeaderboard.tsx
+++ b/torchci/components/metrics/panels/GenerateIndividualTestsLeaderboard.tsx
@@ -55,13 +55,26 @@ export default function GenerateIndividualTestsLeaderboard({
   return (
     <Grid item xs={12} height={ROW_HEIGHT}>
       <TablePanel
-        title={`Longest Tests on Runner: ${workflowName} on ${queryDate.format(
+        title={`Longest Tests: ${workflowName} on ${queryDate.format(
           "YYYY-MM-DD"
         )}`}
         queryCollection={"commons"}
         queryName={"individual_test_times_per_oncall_per_workflow"}
         queryParams={queryParamsForLongTestTable}
         columns={[
+          {
+            field: "oncall",
+            headerName: "Oncall",
+            flex: 1,
+            renderCell: (params: GridRenderCellParams<string>) => {
+              const oncall = params.value;
+              return (
+                <a href={`/testing_overhead/oncall_insights?oncall=${oncall}`}>
+                  {oncall}
+                </a>
+              );
+            },
+          },
           {
             field: "test_name",
             headerName: "Test Name",
@@ -70,7 +83,7 @@ export default function GenerateIndividualTestsLeaderboard({
           },
           {
             field: "test_class",
-            headerName: "Test class",
+            headerName: "Test Class",
             flex: 1,
             renderCell: (params: GridRenderCellParams<string>) => {
               const testFile = params.row.test_file;
@@ -92,24 +105,19 @@ export default function GenerateIndividualTestsLeaderboard({
           },
           {
             field: "avg_time_in_seconds",
-            headerName: "Avg duration",
+            headerName: "Avg Duration per Runner",
             flex: 1,
             valueFormatter: (params: GridValueFormatterParams<number>) =>
               durationDisplay(params.value),
             filterable: false,
           },
           {
-            field: "oncall",
-            headerName: "Oncall",
+            field: "time_per_wokflow_in_seconds",
+            headerName: "Total Duration per Workflow",
             flex: 1,
-            renderCell: (params: GridRenderCellParams<string>) => {
-              const oncall = params.value;
-              return (
-                <a href={`/testing_overhead/oncall_insights?oncall=${oncall}`}>
-                  {oncall}
-                </a>
-              );
-            },
+            valueFormatter: (params: GridValueFormatterParams<number>) =>
+              durationDisplay(params.value),
+            filterable: false,
           },
         ]}
         dataGridProps={{

--- a/torchci/pages/testing_overhead.tsx
+++ b/torchci/pages/testing_overhead.tsx
@@ -99,7 +99,7 @@ export default function TestingOverhead() {
             },
             {
               field: "time_in_seconds",
-              headerName: "Total duration per day",
+              headerName: "Total duration",
               flex: 1,
               valueFormatter: (params: GridValueFormatterParams<number>) =>
                 durationDisplay(params.value),

--- a/torchci/rockset/commons/__sql/individual_test_times_per_oncall_per_workflow.sql
+++ b/torchci/rockset/commons/__sql/individual_test_times_per_oncall_per_workflow.sql
@@ -45,6 +45,7 @@ WITH
             test_runs.invoking_file,
             test_runs.name,
             wid.workflow_name,
+            wid.workflow_id,
         FROM
             commons.test_run_s3 test_runs
             INNER JOIN workflow_id_table wid ON (test_runs.workflow_id = wid.workflow_id) HINT(join_strategy = lookup)
@@ -52,13 +53,13 @@ WITH
             test_runs.workflow_run_attempt = 1
             AND test_runs.classname IS NOT NULL
             AND test_runs.classname LIKE :classname
-            
     ),
     test_times_with_oncalls as (
         SELECT
             time,
             classname,
             workflow_name,
+            workflow_id,
             name,
             invoking_file,
             oncall
@@ -68,6 +69,7 @@ WITH
     )
 SELECT
     AVG(time) as avg_time_in_seconds,
+    SUM(time) / COUNT(DISTINCT(workflow_id)) as time_per_wokflow_in_seconds,
     classname as test_class,
     invoking_file as test_file,
     name as test_name,

--- a/torchci/rockset/commons/individual_test_times_per_oncall_per_workflow.lambda.json
+++ b/torchci/rockset/commons/individual_test_times_per_oncall_per_workflow.lambda.json
@@ -14,7 +14,7 @@
     {
       "name": "queryDate",
       "type": "string",
-      "value": "2023-05-04T21:08:08.862Z"
+      "value": "2023-05-06T21:08:08.862Z"
     },
     {
       "name": "thresholdInSecond",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -9,7 +9,7 @@
     "flaky_tests": "9f7a1abcebb7f027",
     "flaky_tests_across_jobs": "474e5454bda0c5bb",
     "individual_test_stats_per_workflow_per_oncall": "559b6735965f1eb2",
-    "individual_test_times_per_oncall_per_workflow": "171d625f4c2004d7",
+    "individual_test_times_per_oncall_per_workflow": "6b63c3dde3032bea",
     "flaky_workflows_jobs": "d5783ef1fe73fa5b",
     "failed_workflow_jobs": "6ec4fd3f36a72071",
     "get_workflow_jobs": "6ed2029b19691a4b",


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed1567c</samp>

This pull request enhances the oncall testing overhead dashboard by adding and renaming columns in the table panels, and updating the SQL query to include workflow ID and average time per workflow. It also changes the query date parameter and the version ID for testing purposes. The files affected are `GenerateIndividualTestsLeaderboard.tsx`, `individual_test_times_per_oncall_per_workflow.sql`, `testing_overhead.tsx`, `individual_test_times_per_oncall_per_workflow.lambda.json`, and `prodVersions.json`. \n <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ed1567c</samp>

> _We are the oncall testers of doom_
> _We measure our time with `total duration`_
> _We face the workflows of despair_
> _We analyze our tests with `average time`_