### PR TITLE
Set CUDA capabilities for

### DIFF
--- a/.github/actions/setup-nvidia/action.yml
+++ b/.github/actions/setup-nvidia/action.yml
@@ -233,4 +233,4 @@ runs:
                   exit 1
                   ;;
           esac
-          echo "GPU_FLAG=--gpus all" >> "${GITHUB_ENV}"
+          echo "GPU_FLAG=--gpus all -e NVIDIA_DRIVER_CAPABILITIES=all" >> "${GITHUB_ENV}"


### PR DESCRIPTION
This commit set Nvidia GPU driver capabilities to `all`.

Currently, attempting to use GPU video decoder/encoder with `linux_job` fails 
due to the corresponding driver libraries not exposed to Docker container (though they exist in host)

Example failure: https://github.com/pytorch/audio/actions/runs/4899270270/jobs/8749113374#step:10:2022

This is because, GPU is enabled with `--gpus all` flag, which set default drive capability to `utility` and `compute`.
To run GPU video decoder/encoder, `video` needs to be added or we can specify `all`.

https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities

According to https://github.com/NVIDIA/nvidia-container-runtime/issues/112#issuecomment-712312284, nowadays it should be fine to set `all`.

This change is being tested on https://github.com/pytorch/audio/pull/3045, the job is still failing for different reason, but 
In https://github.com/pytorch/audio/actions/runs/4930570795/jobs/8811634409#step:10:1339, the failure mentioned above is no longer happening.