### PR TITLE
Prototype for PyTorch-specific flake8 plugin

### DIFF
--- a/tools/flake8-torch/.flake8
+++ b/tools/flake8-torch/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+exclude = ./tests/fixtures/
+
+# Match black tool's default.
+max-line-length = 88

--- a/tools/flake8-torch/.gitignore
+++ b/tools/flake8-torch/.gitignore
@@ -1,0 +1,3 @@
+.pytest_cache/
+__pycache__/
+*.egg-info/*

--- a/tools/flake8-torch/.gitignore
+++ b/tools/flake8-torch/.gitignore
@@ -1,3 +1,4 @@
+/build/
 .pytest_cache/
 __pycache__/
 *.egg-info/*

--- a/tools/flake8-torch/flake8_torch/checker.py
+++ b/tools/flake8-torch/flake8_torch/checker.py
@@ -38,9 +38,9 @@ class TorchVisitor(ast.NodeVisitor):
         module = "." * node.level + module
         for alias in node.names:
             if alias.asname is None:
-                self._import_info[alias.name] = module + "." + alias.name
+                self._import_info[alias.name] = f"{module}.{alias.name}"
             else:
-                self._import_info[alias.asname] = module + "." + alias.name
+                self._import_info[alias.asname] = f"{module}.{alias.name}"
         self.generic_visit(node)
 
 

--- a/tools/flake8-torch/flake8_torch/checker.py
+++ b/tools/flake8-torch/flake8_torch/checker.py
@@ -2,6 +2,8 @@ from pathlib import Path
 import ast
 import yaml
 
+__version__ = "0.0.1"
+
 
 class TorchVisitor(ast.NodeVisitor):
     def __init__(self):
@@ -46,7 +48,7 @@ class TorchVisitor(ast.NodeVisitor):
 
 class TorchChecker:
     name = "flake8-torch"
-    version = "0.0.1"
+    version = __version__
 
     def __init__(self, tree):
         self.tree = tree

--- a/tools/flake8-torch/flake8_torch/checker.py
+++ b/tools/flake8-torch/flake8_torch/checker.py
@@ -1,0 +1,90 @@
+import os
+from pathlib import Path
+import ast
+import yaml
+
+class TorchVisitor(ast.NodeVisitor):
+    def __init__(self):
+        # Map from import alias (may be the same as name) to import name
+        self._import_info = {}
+        self._call_info = []
+
+    def visit_Call(self, node):
+        func_name = ""
+        curr = node.func
+        while isinstance(curr, ast.Attribute):
+            func_name = "." + curr.attr + func_name
+            curr = curr.value
+        if isinstance(curr, ast.Name):
+            func_name = curr.id + func_name
+
+        self._call_info.append({"name": func_name, "lineno": node.lineno, "col_offset": node.col_offset})
+
+        self.generic_visit(node)
+
+    def visit_Import(self, node):
+        for alias in node.names:
+            if alias.asname is None:
+                self._import_info[alias.name] = alias.name
+            else:
+                self._import_info[alias.asname] = alias.name
+
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node):
+        module = '' if node.module is None else node.module
+        module = "." * node.level + module
+        for alias in node.names:
+            if alias.asname is None:
+                self._import_info[alias.name] = module + '.' + alias.name
+            else:
+                self._import_info[alias.asname] = module + '.' + alias.name
+        self.generic_visit(node)
+
+
+class TorchChecker:
+    name = "flake8-torch"
+    version = "0.0.1"
+
+    def __init__(self, tree):
+        self.tree = tree
+        self.deprecated_config = {}
+        with open(Path(__file__).absolute().parent / 'deprecated_symbols.yaml') as f:
+            for item in yaml.load(f, yaml.SafeLoader):
+                self.deprecated_config[item["name"]] = item
+
+        self.func_calls = []
+        self._get_qualified_func_calls()
+
+    def _get_qualified_func_calls(self):
+        """Return list of function calls in the tree.
+
+        Each item in the list is a tuple
+        (qualified_name, lineno, col_offset).
+        """
+        visitor = TorchVisitor()
+        visitor.visit(self.tree)
+
+        func_calls = visitor._call_info
+
+        self.func_calls = []
+        for call_info in func_calls:
+            name = call_info["name"]
+            dotted_parts = name.split(".")
+            if dotted_parts[0] in visitor._import_info:
+                qualified_name = ".".join([visitor._import_info[dotted_parts[0]]] + dotted_parts[1:])
+            else:
+                qualified_name = name
+            self.func_calls.append((qualified_name, call_info["lineno"], call_info["col_offset"]))
+
+    def _check_deprecated_functions(self):
+        for (name, lineno, col_offset) in self.func_calls:
+            if name in self.deprecated_config:
+                if self.deprecated_config[name]["remove_pr"] is None:
+                    message = f"TOR101 Use of deprecated function {name}"
+                else:
+                    message = f"TOR201 Use of removed function {name}"
+                yield ((lineno, 1 + col_offset, message, TorchChecker))
+
+    def run(self):
+        yield from self._check_deprecated_functions()

--- a/tools/flake8-torch/flake8_torch/checker.py
+++ b/tools/flake8-torch/flake8_torch/checker.py
@@ -1,7 +1,7 @@
-import os
 from pathlib import Path
 import ast
 import yaml
+
 
 class TorchVisitor(ast.NodeVisitor):
     def __init__(self):
@@ -18,7 +18,9 @@ class TorchVisitor(ast.NodeVisitor):
         if isinstance(curr, ast.Name):
             func_name = curr.id + func_name
 
-        self._call_info.append({"name": func_name, "lineno": node.lineno, "col_offset": node.col_offset})
+        self._call_info.append(
+            {"name": func_name, "lineno": node.lineno, "col_offset": node.col_offset}
+        )
 
         self.generic_visit(node)
 
@@ -32,13 +34,13 @@ class TorchVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node):
-        module = '' if node.module is None else node.module
+        module = "" if node.module is None else node.module
         module = "." * node.level + module
         for alias in node.names:
             if alias.asname is None:
-                self._import_info[alias.name] = module + '.' + alias.name
+                self._import_info[alias.name] = module + "." + alias.name
             else:
-                self._import_info[alias.asname] = module + '.' + alias.name
+                self._import_info[alias.asname] = module + "." + alias.name
         self.generic_visit(node)
 
 
@@ -49,7 +51,7 @@ class TorchChecker:
     def __init__(self, tree):
         self.tree = tree
         self.deprecated_config = {}
-        with open(Path(__file__).absolute().parent / 'deprecated_symbols.yaml') as f:
+        with open(Path(__file__).absolute().parent / "deprecated_symbols.yaml") as f:
             for item in yaml.load(f, yaml.SafeLoader):
                 self.deprecated_config[item["name"]] = item
 
@@ -72,10 +74,14 @@ class TorchChecker:
             name = call_info["name"]
             dotted_parts = name.split(".")
             if dotted_parts[0] in visitor._import_info:
-                qualified_name = ".".join([visitor._import_info[dotted_parts[0]]] + dotted_parts[1:])
+                qualified_name = ".".join(
+                    [visitor._import_info[dotted_parts[0]]] + dotted_parts[1:]
+                )
             else:
                 qualified_name = name
-            self.func_calls.append((qualified_name, call_info["lineno"], call_info["col_offset"]))
+            self.func_calls.append(
+                (qualified_name, call_info["lineno"], call_info["col_offset"])
+            )
 
     def _check_deprecated_functions(self):
         for (name, lineno, col_offset) in self.func_calls:

--- a/tools/flake8-torch/flake8_torch/deprecated_symbols.yaml
+++ b/tools/flake8-torch/flake8_torch/deprecated_symbols.yaml
@@ -5,3 +5,47 @@
 - name: torch.symeig
   deprecate_pr: https://github.com/pytorch/pytorch/pull/57732
   remove_pr: https://github.com/pytorch/pytorch/pull/70988
+
+- name: torch.chain_matmul
+  deprecate_pr: https://github.com/pytorch/pytorch/pull/57735
+  remove_pr:
+
+- name: torch.cholesky
+  deprecate_pr: https://github.com/pytorch/pytorch/pull/57725
+  remove_pr:
+
+- name: torch.ger
+  deprecate_pr: TBA
+  remove_pr:
+
+- name: torch.lu_solve
+  deprecate_pr: TBA
+  remove_pr:
+
+- name: torch.norm
+  deprecate_pr: TBA
+  remove_pr:
+
+- name: torch.range
+  deprecate_pr: TBA
+  remove_pr:
+
+- name: torch.svd
+  deprecate_pr: TBA
+  remove_pr:
+
+- name: torch.triangular_solve
+  deprecate_pr: TBA
+  remove_pr:
+
+- name: torch.lu
+  deprecate_pr: TBA
+  remove_pr:
+
+- name: torch.nn.UpsamplingNearest2d
+  deprecate_pr: TBA
+  remove_pr:
+
+- name: torch.nn.UpsamplingBilinear2d
+  deprecate_pr: TBA
+  remove_pr:

--- a/tools/flake8-torch/flake8_torch/deprecated_symbols.yaml
+++ b/tools/flake8-torch/flake8_torch/deprecated_symbols.yaml
@@ -49,3 +49,7 @@
 - name: torch.nn.UpsamplingBilinear2d
   deprecate_pr: TBA
   remove_pr:
+
+- name: torch.testing.assert_allclose
+  deprecate_pr: TBA
+  remove_pr:

--- a/tools/flake8-torch/flake8_torch/deprecated_symbols.yaml
+++ b/tools/flake8-torch/flake8_torch/deprecated_symbols.yaml
@@ -1,0 +1,7 @@
+- name: torch.qr
+  deprecate_pr: https://github.com/pytorch/pytorch/pull/57745
+  remove_pr:
+
+- name: torch.symeig
+  deprecate_pr: https://github.com/pytorch/pytorch/pull/57732
+  remove_pr: https://github.com/pytorch/pytorch/pull/70988

--- a/tools/flake8-torch/pyproject.toml
+++ b/tools/flake8-torch/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "flake8-torch"
 version = "0.0.1"
+dependencies = ["flake8>=3.8.2", "PyYAML"]
 
 [project.entry-points]
 "flake8.extension" = {TOR = "flake8_torch.checker:TorchChecker"}

--- a/tools/flake8-torch/pyproject.toml
+++ b/tools/flake8-torch/pyproject.toml
@@ -10,4 +10,7 @@ log_cli = true
 log_cli_level = "INFO"
 
 [tool.black]
-exclude = 'tests/fixtures/*'
+exclude = "tests/fixtures/*"
+
+[tool.setuptools.package-data]
+"*" = ["*.yaml"]

--- a/tools/flake8-torch/pyproject.toml
+++ b/tools/flake8-torch/pyproject.toml
@@ -8,3 +8,6 @@ version = "0.0.1"
 [tool.pytest.ini_options]
 log_cli = true
 log_cli_level = "INFO"
+
+[tool.black]
+exclude = 'tests/fixtures/*'

--- a/tools/flake8-torch/pyproject.toml
+++ b/tools/flake8-torch/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flake8-torch"
-version = "0.0.1"
+dynamic = ["version"]
 dependencies = ["flake8>=3.8.2", "PyYAML"]
 
 [project.entry-points]
@@ -15,3 +15,6 @@ exclude = "tests/fixtures/*"
 
 [tool.setuptools.package-data]
 "*" = ["*.yaml"]
+
+[tool.setuptools.dynamic]
+version = {attr = "flake8_torch.checker.__version__"}

--- a/tools/flake8-torch/pyproject.toml
+++ b/tools/flake8-torch/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "flake8-torch"
+version = "0.0.1"
+
+[project.entry-points]
+"flake8.extension" = {TOR = "flake8_torch.checker:TorchChecker"}
+
+[tool.pytest.ini_options]
+log_cli = true
+log_cli_level = "INFO"

--- a/tools/flake8-torch/tests/fixtures/deprecated_from_nn.py
+++ b/tools/flake8-torch/tests/fixtures/deprecated_from_nn.py
@@ -1,0 +1,8 @@
+import torch
+torch.nn.UpsamplingNearest2d()
+
+from torch import nn as xx
+xx.UpsamplingNearest2d()
+
+import torch.nn as yy
+yy.UpsamplingNearest2d()

--- a/tools/flake8-torch/tests/fixtures/deprecated_from_nn.txt
+++ b/tools/flake8-torch/tests/fixtures/deprecated_from_nn.txt
@@ -1,0 +1,3 @@
+2:1 TOR101 Use of deprecated function torch.nn.UpsamplingNearest2d
+5:1 TOR101 Use of deprecated function torch.nn.UpsamplingNearest2d
+8:1 TOR101 Use of deprecated function torch.nn.UpsamplingNearest2d

--- a/tools/flake8-torch/tests/fixtures/deprecated_qr.py
+++ b/tools/flake8-torch/tests/fixtures/deprecated_qr.py
@@ -1,0 +1,16 @@
+import torch
+bad = torch.qr()
+good = torch.linalg.qr()
+
+import torch as tt
+bad = tt.qr()
+good = tt.linalg.qr()
+
+from torch import linalg, qr
+bad = qr()
+good = torch.linalg.qr()
+
+from torch import qr as old_qr
+from torch.linalg import qr as new_qr
+good = new_qr()
+bad = old_qr()

--- a/tools/flake8-torch/tests/fixtures/deprecated_qr.txt
+++ b/tools/flake8-torch/tests/fixtures/deprecated_qr.txt
@@ -1,0 +1,4 @@
+2:7 TOR101 Use of deprecated function torch.qr
+6:7 TOR101 Use of deprecated function torch.qr
+10:7 TOR101 Use of deprecated function torch.qr
+16:7 TOR101 Use of deprecated function torch.qr

--- a/tools/flake8-torch/tests/fixtures/removed_symeig.py
+++ b/tools/flake8-torch/tests/fixtures/removed_symeig.py
@@ -1,0 +1,7 @@
+import torch
+from torch import symeig as xxx
+
+E, Z = torch.symeig(A, eigenvectors, True)
+E, Z = xxx(A, eigenvectors, True)
+
+OK = symeig(A, eigenvectors, True)

--- a/tools/flake8-torch/tests/fixtures/removed_symeig.txt
+++ b/tools/flake8-torch/tests/fixtures/removed_symeig.txt
@@ -1,0 +1,2 @@
+4:8 TOR201 Use of removed function torch.symeig
+5:8 TOR201 Use of removed function torch.symeig

--- a/tools/flake8-torch/tests/test_flake8_torch.py
+++ b/tools/flake8-torch/tests/test_flake8_torch.py
@@ -1,27 +1,29 @@
 import ast
 from pathlib import Path
 from flake8_torch.checker import TorchChecker
-
-FIXTURES_PATH = Path(__file__).absolute().parent / 'fixtures'
-
 import logging
 
+FIXTURES_PATH = Path(__file__).absolute().parent / "fixtures"
 LOGGER = logging.getLogger(__name__)
 
+
 def _fixture_path(filename):
-    return Path(__file__).absolute().parent / 'fixtures' / filename
+    return Path(__file__).absolute().parent / "fixtures" / filename
+
 
 def _results(s):
     tree = ast.parse(s)
     checker = TorchChecker(tree)
-    return [f'{line}:{col} {msg}' for line, col, msg, _ in checker.run()]
+    return [f"{line}:{col} {msg}" for line, col, msg, _ in checker.run()]
+
 
 def test_empty():
-    assert _results('') == []
+    assert _results("") == []
+
 
 def test_fixtures():
     for source_path in FIXTURES_PATH.glob("*.py"):
-        LOGGER.info(f'Testing {source_path}')
+        LOGGER.info("Testing %s", source_path)
         expected_path = str(source_path)[:-2] + "txt"
         expected_results = []
         with open(expected_path) as expected:

--- a/tools/flake8-torch/tests/test_flake8_torch.py
+++ b/tools/flake8-torch/tests/test_flake8_torch.py
@@ -7,10 +7,6 @@ FIXTURES_PATH = Path(__file__).absolute().parent / "fixtures"
 LOGGER = logging.getLogger(__name__)
 
 
-def _fixture_path(filename):
-    return Path(__file__).absolute().parent / "fixtures" / filename
-
-
 def _results(s):
     tree = ast.parse(s)
     checker = TorchChecker(tree)

--- a/tools/flake8-torch/tests/test_flake8_torch.py
+++ b/tools/flake8-torch/tests/test_flake8_torch.py
@@ -1,0 +1,32 @@
+import ast
+from pathlib import Path
+from flake8_torch.checker import TorchChecker
+
+FIXTURES_PATH = Path(__file__).absolute().parent / 'fixtures'
+
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+def _fixture_path(filename):
+    return Path(__file__).absolute().parent / 'fixtures' / filename
+
+def _results(s):
+    tree = ast.parse(s)
+    checker = TorchChecker(tree)
+    return [f'{line}:{col} {msg}' for line, col, msg, _ in checker.run()]
+
+def test_empty():
+    assert _results('') == []
+
+def test_fixtures():
+    for source_path in FIXTURES_PATH.glob("*.py"):
+        LOGGER.info(f'Testing {source_path}')
+        expected_path = str(source_path)[:-2] + "txt"
+        expected_results = []
+        with open(expected_path) as expected:
+            for line in expected:
+                expected_results.append(line.rstrip())
+
+        with open(source_path) as source:
+            assert _results(source.read()) == expected_results


### PR DESCRIPTION
The big vision for the plugin is to flag (and for some auto fix) all kinds of problematic usages of PyTorch.

What it is doing so far is printing error messages for the functions from the deprecated_symbols.yaml.
Eventually this list will be in the pytorch/pytorch and also will be used for generating documentation about deprecated and removed functions.

The plugin is in a working state, there is an output from checking torchaudio:

```
 flake8 --isolated --select=TOR
./examples/libtorchaudio/augmentation/create_jittable_pipeline.py:38:22: TOR101 Use of deprecated function torch.norm
./examples/tutorials/audio_data_augmentation_tutorial.py:193:14: TOR101 Use of deprecated function torch.norm
./test/torchaudio_unittest/transforms/transforms_test_impl.py:475:16: TOR101 Use of deprecated function torch.norm
./test/torchaudio_unittest/transforms/transforms_test_impl.py:477:30: TOR101 Use of deprecated function torch.norm
./test/torchaudio_unittest/transforms/transforms_test_impl.py:479:30: TOR101 Use of deprecated function torch.norm
./torchaudio/functional/functional.py:1039:27: TOR101 Use of deprecated function torch.norm
./torchaudio/functional/functional.py:1040:27: TOR101 Use of deprecated function torch.norm
```
