### PR TITLE
Add a new shareable GH action to clean up non-ephemeral runners

### DIFF
--- a/.github/actions/cleanup-runner/action.yml
+++ b/.github/actions/cleanup-runner/action.yml
@@ -1,0 +1,46 @@
+name: cleanup-runner
+
+description: Cleanup a non-ephemeral runner
+
+runs:
+  using: composite
+  steps:
+    - name: Clean up leftover processes on non-ephemeral Windows runner
+      if: runner.os == 'Windows'
+      shell: powershell
+      continue-on-error: true
+      run: |
+        # This needs to be run before checking out PyTorch to avoid locking the working directory.
+        # Below is the list of commands that could lock $GITHUB_WORKSPACE gathered from sysinternals
+        # handle tool
+        $processes = "python", "ninja", "cl", "nvcc", "cmd"
+        Foreach ($process In $processes) {
+          Try {
+            # https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/stop-process
+            Get-Process -Name $process -ErrorAction Stop | Stop-Process -Force
+          }
+          Catch {
+            Write-Output "No leftover $process process, continuing"
+            Write-Output $_
+          }
+        }
+
+        # Try it again https://stackoverflow.com/questions/40585754/powershell-wont-terminate-hung-process
+        # for hung processes
+        Foreach ($process In $processes) {
+          Try {
+            (Get-WmiObject -Class Win32_Process -Filter "Name LIKE '${process}%'").terminate()
+          }
+          Catch {
+            Write-Output $_
+          }
+        }
+
+        Try {
+          # Print all the processes for debugging
+          Wmic Path Win32_Process Get Caption,Processid,Commandline | Format-List
+        }
+        Catch {
+          # Better to write out whatever exception thrown to help debugging any potential issue
+          Write-Output $_
+        }


### PR DESCRIPTION
The first use case is for Windows non-ephemeral runners.  This logic is copied from `_win_test.yml`