### PR TITLE
Fix disable bot authorization

### DIFF
--- a/torchci/lib/bot/verifyDisableTestIssueBot.ts
+++ b/torchci/lib/bot/verifyDisableTestIssueBot.ts
@@ -5,6 +5,7 @@ const validationCommentStart = "<!-- validation-comment-start -->";
 const validationCommentEnd = "<!-- validation-comment-end -->";
 const disabledKey = "DISABLED ";
 const disabledTestIssueTitle = new RegExp("DISABLED\\s*test.+\\s*\\(.+\\)");
+export const pytorchBotName = 'pytorch-bot[bot]'
 
 export const supportedPlatforms = new Set([
   "asan",
@@ -204,7 +205,9 @@ export default function verifyDisableTestIssueBot(app: Probot): void {
     const target = parseTitle(title);
     const platforms = parseBody(body!);
     const username = context.payload["issue"]["user"]["login"];
-    const authorized = await hasWritePermissions(context, username);
+    const authorized =
+      username === pytorchBotName ||
+      (await hasWritePermissions(context, username));
 
     const validationComment = isDisabledTest(title)
       ? formValidationComment(username, authorized, target, platforms)

--- a/torchci/lib/bot/verifyDisableTestIssueBot.ts
+++ b/torchci/lib/bot/verifyDisableTestIssueBot.ts
@@ -5,7 +5,7 @@ const validationCommentStart = "<!-- validation-comment-start -->";
 const validationCommentEnd = "<!-- validation-comment-end -->";
 const disabledKey = "DISABLED ";
 const disabledTestIssueTitle = new RegExp("DISABLED\\s*test.+\\s*\\(.+\\)");
-export const pytorchBotName = 'pytorch-bot[bot]'
+export const pytorchBotId = 54816060;
 
 export const supportedPlatforms = new Set([
   "asan",
@@ -206,7 +206,7 @@ export default function verifyDisableTestIssueBot(app: Probot): void {
     const platforms = parseBody(body!);
     const username = context.payload["issue"]["user"]["login"];
     const authorized =
-      username === pytorchBotName ||
+      context.payload["issue"]["user"]["id"] === pytorchBotId ||
       (await hasWritePermissions(context, username));
 
     const validationComment = isDisabledTest(title)

--- a/torchci/test/verifyDisableTestIssue.test.ts
+++ b/torchci/test/verifyDisableTestIssue.test.ts
@@ -3,6 +3,7 @@ import * as utils from "./utils";
 import myProbotApp, * as bot from "../lib/bot/verifyDisableTestIssueBot";
 import nock from "nock";
 import { requireDeepCopy, handleScope } from "./common";
+import { pytorchBotId } from "../lib/bot/verifyDisableTestIssueBot";
 
 nock.disableNetConnect();
 
@@ -289,7 +290,7 @@ describe("verify-disable-test-issue-bot", () => {
   test("pytorch-bot[bot] is authorized", async () => {
     const payload = requireDeepCopy("./fixtures/issues.opened.json");
     payload.issue.title = "DISABLED testMethodName (testClass.TestSuite)";
-    payload.issue.user.login = "pytorch-bot[bot]";
+    payload.issue.user.id = pytorchBotId;
 
     const owner = payload.repository.owner.login;
     const repo = payload.repository.name;

--- a/torchci/test/verifyDisableTestIssue.test.ts
+++ b/torchci/test/verifyDisableTestIssue.test.ts
@@ -1,7 +1,10 @@
 import { Probot } from "probot";
 import * as utils from "./utils";
 import myProbotApp, * as bot from "../lib/bot/verifyDisableTestIssueBot";
-import * as botUtils from "../lib/bot/utils";
+import nock from "nock";
+import { requireDeepCopy, handleScope } from "./common";
+
+nock.disableNetConnect();
 
 describe("verify-disable-test-issue", () => {
   let probot: Probot;
@@ -267,5 +270,73 @@ describe("verify-disable-test-issue", () => {
     expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
     expect(comment.includes(`~15 minutes, \`${jobName}\``)).toBeTruthy();
     expect(comment.includes("ERROR")).toBeFalsy();
+  });
+});
+
+describe("verify-disable-test-issue-bot", () => {
+  let probot: Probot;
+
+  beforeEach(() => {
+    probot = utils.testProbot();
+    probot.load(myProbotApp);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    jest.restoreAllMocks();
+  });
+
+  test("pytorch-bot[bot] is authorized", async () => {
+    const payload = requireDeepCopy("./fixtures/issues.opened.json");
+    payload.issue.title = "DISABLED testMethodName (testClass.TestSuite)";
+    payload.issue.user.login = "pytorch-bot[bot]";
+
+    const owner = payload.repository.owner.login;
+    const repo = payload.repository.name;
+    const number = payload.issue.number;
+
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${owner}/${repo}/issues/${number}/comments?per_page=10`)
+      .reply(200, [])
+      .post(
+        `/repos/${owner}/${repo}/issues/${number}/comments`,
+        (body) => !body.body.includes("don't have permission")
+      )
+      .reply(200);
+
+    await probot.receive({ name: "issues", payload: payload, id: "2" });
+
+    handleScope(scope);
+  });
+
+  test("random user is not authorized", async () => {
+    const payload = requireDeepCopy("./fixtures/issues.opened.json");
+    payload.issue.title = "DISABLED testMethodName (testClass.TestSuite)";
+    payload.issue.user.login = "randomuser";
+
+    const owner = payload.repository.owner.login;
+    const repo = payload.repository.name;
+    const number = payload.issue.number;
+
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${owner}/${repo}/issues/${number}/comments?per_page=10`)
+      .reply(200, [])
+      .get(`/repos/${owner}/${repo}/collaborators/randomuser/permission`)
+      .reply(200, {
+        permission: "read",
+      })
+      .post(`/repos/${owner}/${repo}/issues/${number}/comments`, (body) =>
+        body.body.includes("don't have permission")
+      )
+      .reply(200)
+      .patch(
+        `/repos/${owner}/${repo}/issues/${number}`,
+        (body) => body.state === "closed"
+      )
+      .reply(200);
+
+    await probot.receive({ name: "issues", payload: payload, id: "2" });
+
+    handleScope(scope);
   });
 });


### PR DESCRIPTION
Querying for permissions of pytorch-bot[bot] gives none but it should be allowed to disable tests and added corresponding test cases for this.

There were ~70 issues opened and and immediately closed yesterday due to this, noticed on the hud metrics page chart for number of opened disable tests