### PR TITLE
Alert for long machine queues

### DIFF
--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -4,6 +4,7 @@ on:
     paths:
       - .github/workflows/check-alerts.yml
       - torchci/scripts/check_alerts.py
+      - torchci/scripts/queue_alert.py
   schedule:
     # Every 5 minutes
     - cron: "*/5 * * * *"

--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -51,3 +51,23 @@ jobs:
         env:
           # NOTE: Should be a blank string for pull requests
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update-queue-alert:
+    env:
+      DRY_RUN: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install requests
+        run: |
+           pip3 install requests setuptools
+      - name: Run tests
+        run: |
+          python3 torchci/scripts/test_queue_alert.py
+      - name: Check for alerts and creates issue
+        run: |
+          python3 torchci/scripts/queue_alert.py
+        env:
+          # NOTE: Should be a blank string for pull requests
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install requests
         run: |
-           pip3 install requests setuptools
+           pip3 install requests setuptools rockset==1.0.3
       - name: Run tests
         run: |
           python3 torchci/scripts/test_queue_alert.py

--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -55,6 +55,7 @@ jobs:
   update-queue-alert:
     env:
       DRY_RUN: ${{ github.event_name == 'pull_request' }}
+      ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/torchci/scripts/queue_alert.py
+++ b/torchci/scripts/queue_alert.py
@@ -1,0 +1,172 @@
+import argparse
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, NamedTuple
+
+import requests
+import rockset  # type: ignore[import]
+from check_alerts import (
+    GRAPHQL_URL,
+    REPO_OWNER,
+    TEST_INFRA_REPO_NAME,
+    clear_alerts,
+    headers,
+    update_issue,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+PROD_VERSIONS_FILE = REPO_ROOT / "torchci" / "rockset" / "prodVersions.json"
+
+QUEUE_ALERT_LABEL = "queue-alert"
+
+MAX_HOURS = 3
+MAX_MACHINES = 50
+EXCEPTIONS = {"linux.gcp.a100.large": (10, 20)}
+ISSUES_WITH_LABEL_QUERY = """
+query ($owner: String!, $name: String!, $labels: [String!]) {
+  repository(owner: $owner, name: $name, followRenames: false) {
+    issues(last: 10, labels: $labels) {
+      nodes {
+        number
+        body
+        state
+      }
+    }
+  }
+}
+"""
+
+
+class QueueInfo(NamedTuple):
+    machine: str
+    count: int
+    hours: float
+
+
+def gen_queue_info_str(q: QueueInfo) -> str:
+    return f"- {q.machine}, {q.count} machines, {round(q.hours, 2)} hours\n"
+
+
+def gen_update_comment(original_issue: Any, new_queues: List[QueueInfo]) -> str:
+    original_machines = []
+    if original_issue["state"] == "OPEN":
+        original_body = original_issue["body"]
+        for line in original_body.splitlines():
+            match = re.match(r"^- (.*), .* machines, .* hours$", line.strip())
+            if match is not None:
+                original_machines.append(match.group(1))
+
+    started_queueing = [q for q in new_queues if q.machine not in original_machines]
+
+    s = ""
+    if len(started_queueing) > 0:
+        s += "These machines started queueing:\n"
+        for q in started_queueing:
+            s += gen_queue_info_str(q)
+        s += "\n"
+    return s
+
+
+def gen_issue(queues: List[QueueInfo]) -> Any:
+    queues.sort(key=lambda q: q.machine)
+    body = "Within the last 5 minutes, these machines had long queues (exact numbers may be out of date):\n"
+    for q in queues:
+        body += gen_queue_info_str(q)
+    body += "\nPlease look at the hud metrics page for more info."
+
+    issue = {}
+    issue["title"] = f"[Pytorch] There are {len(queues)} machines with long queues"
+    issue["body"] = body
+    issue["labels"] = [QUEUE_ALERT_LABEL]
+    issue["state"] = "open"
+
+    return issue
+
+
+def fetch_alert(owner: str, alert_repo: str, label=QUEUE_ALERT_LABEL) -> List[Any]:
+    try:
+        variables = {"owner": owner, "name": alert_repo, "labels": [label]}
+        r = requests.post(
+            GRAPHQL_URL,
+            json={"query": ISSUES_WITH_LABEL_QUERY, "variables": variables},
+            headers=headers,
+        )
+        r.raise_for_status()
+        return json.loads(r.text)["data"]["repository"]["issues"]["nodes"]
+    except Exception as e:
+        raise RuntimeError("Error fetching alerts", e)
+
+
+def filter_long_queues(rockset_result: List[Dict[str, Any]]) -> List[QueueInfo]:
+    large_queue: List[QueueInfo] = []
+
+    for result in rockset_result:
+        avg_queue_s, count, machine_type = (
+            result["avg_queue_s"],
+            result["count"],
+            result["machine_type"],
+        )
+
+        max_hours, max_machines = EXCEPTIONS.get(
+            machine_type, (MAX_HOURS, MAX_MACHINES)
+        )
+
+        if avg_queue_s / 3600 > max_hours or count > max_machines:
+            queue_info = QueueInfo(machine_type, count, avg_queue_s / 3600)
+            large_queue.append(queue_info)
+
+    return large_queue
+
+
+def queuing_alert(dry_run: bool) -> None:
+    rs_client = rockset.RocksetClient(
+        host="api.usw2a1.rockset.com", api_key=os.environ["ROCKSET_API_KEY"]
+    )
+    with open(PROD_VERSIONS_FILE) as f:
+        prod_versions = json.load(f)
+
+    # same lambda as the same used by the chart on the hud metrics page
+    response = rs_client.QueryLambdas.execute_query_lambda(
+        query_lambda="queued_jobs_by_label",
+        version=prod_versions["metrics"]["queued_jobs_by_label"],
+        workspace="metrics",
+    )
+
+    large_queue = filter_long_queues(response.results)
+
+    existing_alerts = fetch_alert(
+        REPO_OWNER,
+        TEST_INFRA_REPO_NAME,
+    )
+
+    if len(large_queue) == 0:
+        print("Closing queuing alert")
+        clear_alerts(existing_alerts, dry_run=dry_run)
+        return
+
+    existing_issue = existing_alerts[0]
+    update_comment = gen_update_comment(existing_issue, large_queue)
+
+    if update_comment:
+        new_issue = gen_issue(large_queue)
+        update_issue(new_issue, existing_issue, update_comment, dry_run=dry_run)
+    else:
+        print(f"No new change for queuing alert")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=bool(os.getenv("DRY_RUN")),
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    queuing_alert(args.dry_run)

--- a/torchci/scripts/queue_alert.py
+++ b/torchci/scripts/queue_alert.py
@@ -23,9 +23,9 @@ PROD_VERSIONS_FILE = REPO_ROOT / "torchci" / "rockset" / "prodVersions.json"
 
 QUEUE_ALERT_LABEL = "queue-alert"
 
-MAX_HOURS = 2.5
-MAX_MACHINES = 40
-EXCEPTIONS = {"linux.gcp.a100.large": (0, 20)}
+MAX_HOURS = 4
+MAX_MACHINES = 75
+EXCEPTIONS = {"linux.gcp.a100.large": (10, 20)}
 ISSUES_WITH_LABEL_QUERY = """
 query ($owner: String!, $name: String!, $labels: [String!]) {
   repository(owner: $owner, name: $name, followRenames: false) {

--- a/torchci/scripts/queue_alert.py
+++ b/torchci/scripts/queue_alert.py
@@ -47,6 +47,12 @@ class QueueInfo(NamedTuple):
     hours: float
 
 
+def close_other_alerts(issues: Any, dry_run: bool) -> None:
+    for issue in issues:
+        if issue['state'] != 'CLOSED':
+            clear_alerts([issue], dry_run=dry_run)
+
+
 def gen_queue_info_str(q: QueueInfo) -> str:
     return f"- {q.machine}, {q.count} machines, {round(q.hours, 2)} hours\n"
 
@@ -158,7 +164,10 @@ def queuing_alert(dry_run: bool) -> None:
             TEST_INFRA_REPO_NAME,
         )
 
-    existing_issue = existing_alerts[0]
+    # Favor the most recent issue and close the rest
+    existing_issue = existing_alerts[-1]
+    close_other_alerts(existing_alerts[:-1], dry_run)
+
     update_comment = gen_update_comment(existing_issue, large_queue)
 
     if update_comment:

--- a/torchci/scripts/queue_alert.py
+++ b/torchci/scripts/queue_alert.py
@@ -23,8 +23,8 @@ PROD_VERSIONS_FILE = REPO_ROOT / "torchci" / "rockset" / "prodVersions.json"
 
 QUEUE_ALERT_LABEL = "queue-alert"
 
-MAX_HOURS = 3
-MAX_MACHINES = 50
+MAX_HOURS = 2.5
+MAX_MACHINES = 40
 EXCEPTIONS = {"linux.gcp.a100.large": (0, 20)}
 ISSUES_WITH_LABEL_QUERY = """
 query ($owner: String!, $name: String!, $labels: [String!]) {

--- a/torchci/scripts/test_queue_alert.py
+++ b/torchci/scripts/test_queue_alert.py
@@ -1,0 +1,49 @@
+from queue_alert import filter_long_queues, gen_update_comment, QueueInfo
+from unittest import main, TestCase
+
+
+class TestGitHubPR(TestCase):
+    def test_filter_long_queues(self):
+        rockset_results = [
+            {"count": 30, "avg_queue_s": 0, "machine_type": "linux.gcp.a100.large"},
+            {"count": 100, "avg_queue_s": 0, "machine_type": "machine1"},
+            {"count": 30, "avg_queue_s": 3600 * 5, "machine_type": "machine2"},
+        ]
+        long_queues = filter_long_queues(rockset_results)
+        self.assertEqual(len(long_queues), 3)
+
+        rockset_results = [
+            {
+                "count": 0,
+                "avg_queue_s": 3600 * 20,
+                "machine_type": "linux.gcp.a100.large",
+            },
+            {"count": 10, "avg_queue_s": 0, "machine_type": "machine1"},
+            {"count": 10, "avg_queue_s": 3600 * 1, "machine_type": "machine2"},
+        ]
+        long_queues = filter_long_queues(rockset_results)
+        self.assertEqual(len(long_queues), 1)
+        self.assertEqual(long_queues[0].machine, "linux.gcp.a100.large")
+
+    def test_gen_update_comment(self):
+        original_issue = {"state": "CLOSED"}
+        new_queues = [
+            QueueInfo("machine1", 1, 2),
+            QueueInfo("machine2", 2, 3),
+        ]
+        comment = gen_update_comment(original_issue, new_queues)
+        self.assertTrue("- machine1, 1 machines, 2 hours" in comment)
+        self.assertTrue("- machine2, 2 machines, 3 hours" in comment)
+
+        original_issue = {"state": "OPEN", "body": "- machine2, 2 machines, 3 hours"}
+        new_queues = [
+            QueueInfo("machine1", 1, 2),
+            QueueInfo("machine2", 2, 3),
+        ]
+        comment = gen_update_comment(original_issue, new_queues)
+        self.assertTrue("- machine1, 1 machines, 2 hours" in comment)
+        self.assertTrue("- machine2, 2 machines, 3 hours" not in comment)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Create an alert for long queues

The limit is 4 hours or 75 machines for most machines and a separate category for the gcp a100 runners since they generally have longer queue times but fewer machines.  The avg non zero queue seems to be about 2.5 hours and 40 machines for most machine types.

It uses a new label queue-alerts and attempts to re open issues when there is an issue with the queue-alert label if it is closed.