### PR TITLE
Correctly highlight force merges with failures on HUD

### DIFF
--- a/torchci/components/hud.module.css
+++ b/torchci/components/hud.module.css
@@ -98,8 +98,12 @@
   padding: 3px;
 }
 
-.forcedMergeWarning {
+.forcedMerge {
   background-color: lightyellow;
+}
+
+.forcedMergeWithFailure {
+  background-color: lightpink;
 }
 
 .selectedRow {

--- a/torchci/components/hud.module.css
+++ b/torchci/components/hud.module.css
@@ -103,7 +103,7 @@
 }
 
 .forcedMergeWithFailure {
-  background-color: lightpink;
+  background-color: #f8b88b;
 }
 
 .selectedRow {

--- a/torchci/components/hud.module.css
+++ b/torchci/components/hud.module.css
@@ -103,7 +103,7 @@
 }
 
 .forcedMergeWithFailure {
-  background-color: #f8b88b;
+  background-color: #ffe0b3;
 }
 
 .selectedRow {

--- a/torchci/lib/fetchHud.ts
+++ b/torchci/lib/fetchHud.ts
@@ -53,19 +53,26 @@ export default async function fetchHud(params: HudParams): Promise<{
       {
         parameters: [
           {
-            name: "issueUrls",
+            name: "shas",
             type: "string",
-            value: _.map(commits, (commit) => {
-              // Get the PR number to figure out if this is forced merged
-              return `https://api.github.com/repos/${params.repoOwner}/${params.repoName}/issues/${commit.prNum}`;
-            }).join(","),
+            value: shas.join(","),
+          },
+          {
+            name: "owner",
+            type: "string",
+            value: params.repoOwner,
+          },
+          {
+            name: "project",
+            type: "string",
+            value: params.repoName,
           },
         ],
       }
     );
-  const forcedMergePrNums = new Set(
+  const forcedMergeShas = new Set(
     _.map(filterForcedMergePr.results, (result) => {
-      return result.issue_url.split("/").pop();
+      return result.merge_commit_sha;
     })
   );
 
@@ -137,10 +144,7 @@ export default async function fetchHud(params: HudParams): Promise<{
     const row: RowData = {
       ...commit,
       jobs: jobs,
-      // Revert commits won't have any associated PR number
-      isForcedMerge: forcedMergePrNums.has(
-        commit.prNum !== null ? commit.prNum.toString() : ""
-      ),
+      isForcedMerge: forcedMergeShas.has(commit.sha),
     };
     shaGrid.push(row);
   });

--- a/torchci/lib/fetchHud.ts
+++ b/torchci/lib/fetchHud.ts
@@ -71,9 +71,19 @@ export default async function fetchHud(params: HudParams): Promise<{
       }
     );
   const forcedMergeShas = new Set(
-    _.map(filterForcedMergePr.results, (result) => {
-      return result.merge_commit_sha;
+    _.map(filterForcedMergePr.results, (r) => {
+      return r.merge_commit_sha;
     })
+  );
+  const forcedMergeWithFailuresShas = new Set(
+    _.map(
+      _.filter(filterForcedMergePr.results, (r) => {
+        return r.force_merge_with_failures !== 0;
+      }),
+      (r) => {
+        return r.merge_commit_sha;
+      }
+    )
   );
 
   const commitsBySha = _.keyBy(commits, "sha");
@@ -145,6 +155,7 @@ export default async function fetchHud(params: HudParams): Promise<{
       ...commit,
       jobs: jobs,
       isForcedMerge: forcedMergeShas.has(commit.sha),
+      isForcedMergeWithFailures: forcedMergeWithFailuresShas.has(commit.sha),
     };
     shaGrid.push(row);
   });

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -58,6 +58,7 @@ export interface RowData extends CommitData {
   jobs: JobData[];
   groupedJobs?: Map<string, GroupData>;
   isForcedMerge: boolean | false;
+  isForcedMergeWithFailures: boolean | false;
   nameToJobs?: Map<string, JobData>;
 }
 

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -115,7 +115,13 @@ function HudRow({
             href={`https://github.com/${params.repoOwner}/${params.repoName}/pull/${rowData.prNum}`}
           >
             {rowData.isForcedMerge ? (
-              <mark className={styles.forcedMergeWarning}>
+              <mark
+                className={
+                  rowData.isForcedMergeWithFailures
+                    ? styles.forcedMergeWithFailure
+                    : styles.forcedMerge
+                }
+              >
                 #{rowData.prNum}
               </mark>
             ) : (

--- a/torchci/rockset/commons/__sql/filter_forced_merge_pr.sql
+++ b/torchci/rockset/commons/__sql/filter_forced_merge_pr.sql
@@ -19,17 +19,14 @@ WITH all_merges AS (
 force_merges_with_failed_checks AS (
   SELECT
     IF(
-      (
-        skip_mandatory_checks = true
-        AND failed_checks_count > 0
-      )
+      (skip_mandatory_checks = true)
       OR (
         ignore_current = true
         AND is_failed = false
       ),
       1,
       0
-    ) AS force_merges_red,
+    ) AS force_merge,
     pr_num,
     merge_commit_sha,
   FROM
@@ -40,4 +37,4 @@ SELECT
 FROM
   force_merges_with_failed_checks
 WHERE
-  force_merges_red = 1
+  force_merge = 1

--- a/torchci/rockset/commons/__sql/filter_forced_merge_pr.sql
+++ b/torchci/rockset/commons/__sql/filter_forced_merge_pr.sql
@@ -1,12 +1,43 @@
+WITH all_merges AS (
+  SELECT
+    skip_mandatory_checks,
+    LENGTH(failed_checks) AS failed_checks_count,
+    ignore_current,
+    is_failed,
+    pr_num,
+    merge_commit_sha,
+  FROM
+    commons.merges
+  WHERE
+    owner = : owner
+    AND project = : project
+    AND ARRAY_CONTAINS(
+      SPLIT(: shas, ','),
+      merge_commit_sha
+    )
+),
+force_merges_with_failed_checks AS (
+  SELECT
+    IF(
+      (
+        skip_mandatory_checks = true
+        AND failed_checks_count > 0
+      )
+      OR (
+        ignore_current = true
+        AND is_failed = false
+      ),
+      1,
+      0
+    ) AS force_merges_red,
+    pr_num,
+    merge_commit_sha,
+  FROM
+    all_merges
+)
 SELECT
-    issue_comment.issue_url
+  *
 FROM
-    commons.issue_comment
+  force_merges_with_failed_checks
 WHERE
-    REGEXP_LIKE(issue_comment.body, '@pytorch(merge)?bot merge -f')
-    AND issue_comment.user.login NOT LIKE '%pytorch-bot%'
-    AND issue_comment.user.login NOT LIKE '%facebook-github-bot%'
-    AND issue_comment.user.login NOT LIKE '%pytorchmergebot%'
-    AND ARRAY_CONTAINS(SPLIT(:issueUrls, ','), issue_comment.issue_url)
-GROUP BY
-    issue_comment.issue_url
+  force_merges_red = 1

--- a/torchci/rockset/commons/__sql/filter_forced_merge_pr.sql
+++ b/torchci/rockset/commons/__sql/filter_forced_merge_pr.sql
@@ -27,13 +27,24 @@ force_merges_with_failed_checks AS (
       1,
       0
     ) AS force_merge,
+    failed_checks_count,
     pr_num,
     merge_commit_sha,
   FROM
     all_merges
 )
 SELECT
-  *
+  pr_num,
+  merge_commit_sha,
+  force_merge,
+  IF(
+    (
+      force_merge = 1
+      AND failed_checks_count > 0
+    ),
+    1,
+    0
+  ) AS force_merge_with_failures
 FROM
   force_merges_with_failed_checks
 WHERE

--- a/torchci/rockset/commons/filter_forced_merge_pr.lambda.json
+++ b/torchci/rockset/commons/filter_forced_merge_pr.lambda.json
@@ -2,9 +2,19 @@
   "sql_path": "__sql/filter_forced_merge_pr.sql",
   "default_parameters": [
     {
-      "name": "issueUrls",
+      "name": "owner",
       "type": "string",
-      "value": "https://api.github.com/repos/pytorch/pytorch/issues/87809,https://api.github.com/repos/pytorch/pytorch/issues/87797,https://api.github.com/repos/pytorch/pytorch/issues/12345"
+      "value": "pytorch"
+    },
+    {
+      "name": "project",
+      "type": "string",
+      "value": "pytorch"
+    },
+    {
+      "name": "shas",
+      "type": "string",
+      "value": "dafa009c3c0198d501fc7bc6cdcc7df14f800852,a0e6f82087af53299c70c09834db42787e750caf,c73923473d4ed0ab08143cb8fe3e8c3f86f2cf73"
     }
   ],
   "description": "Check if these PRs are forced merge"

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -5,7 +5,7 @@
     "commit_jobs_query": "cc524c5036e78794",
     "disabled_non_flaky_tests": "f909abf9eec15b56",
     "commit_failed_jobs": "7e5b39f3ec22b89f",
-    "filter_forced_merge_pr": "aab7c41ed19a2c3c",
+    "filter_forced_merge_pr": "98786319ff984d95",
     "flaky_tests": "9f7a1abcebb7f027",
     "flaky_tests_across_jobs": "474e5454bda0c5bb",
     "individual_test_stats_per_workflow_per_oncall": "559b6735965f1eb2",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -5,7 +5,7 @@
     "commit_jobs_query": "cc524c5036e78794",
     "disabled_non_flaky_tests": "f909abf9eec15b56",
     "commit_failed_jobs": "7e5b39f3ec22b89f",
-    "filter_forced_merge_pr": "5cdaa020d6b71414",
+    "filter_forced_merge_pr": "2c897e36b16b98cc",
     "flaky_tests": "9f7a1abcebb7f027",
     "flaky_tests_across_jobs": "474e5454bda0c5bb",
     "individual_test_stats_per_workflow_per_oncall": "559b6735965f1eb2",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -5,7 +5,7 @@
     "commit_jobs_query": "cc524c5036e78794",
     "disabled_non_flaky_tests": "f909abf9eec15b56",
     "commit_failed_jobs": "7e5b39f3ec22b89f",
-    "filter_forced_merge_pr": "2c897e36b16b98cc",
+    "filter_forced_merge_pr": "aab7c41ed19a2c3c",
     "flaky_tests": "9f7a1abcebb7f027",
     "flaky_tests_across_jobs": "474e5454bda0c5bb",
     "individual_test_stats_per_workflow_per_oncall": "559b6735965f1eb2",


### PR DESCRIPTION
Now that we have the merges information on Rockset `merges` collection, we can correctly highlight force merges with failures on HUD.  This PR covers several things:

* It fixes the known issue in which a PR will always be highlight as a force merges once it was forced merges in the past.  For example, force merge -> revert -> merge again normally, the second merge would be highlighted wrongly as a force merge
* HUD shows all force merges ~~with failures~~ (`-f`, `--ignore-current`) ~~to stay consistent with our KPI metric~~
* Forcer merges with failures are highlight differently

### Testing

https://torchci-git-fork-huydhn-fix-force-merge-highlight-fbopensource.vercel.app/ correctly highlight force merges for each commits.  Other cases on https://hud.pytorch.org/ are ok and won't be hightlighted