### PR TITLE
Break busy loop between jobFilter and router updates

### DIFF
--- a/torchci/lib/useTableFilter.ts
+++ b/torchci/lib/useTableFilter.ts
@@ -42,8 +42,7 @@ export default function useTableFilter(params: HudParams) {
   useEffect(() => {
     const filterValue = (router.query.name_filter as string) || "";
     setJobFilter(filterValue);
-    handleInput(filterValue);
-  }, [router.query.name_filter, handleInput]);
+  }, [router.query.name_filter]);
 
   return { jobFilter, handleSubmit, handleInput, normalizedJobFilter };
 }


### PR DESCRIPTION
This break busy loop between updating the router value and than updating it again. Alternative, one could have checked previous value and only update it if it changed.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ff79724</samp>

Improved table filter component by updating URL query parameter only on form submission. Removed `handleInput` function call from `useEffect` hook in `useTableFilter.ts`.