### PR TITLE
[MacOS] Attempt to clean up crash reports when running out of space

### DIFF
--- a/.github/actions/check-disk-space/action.yml
+++ b/.github/actions/check-disk-space/action.yml
@@ -25,7 +25,7 @@ runs:
         function check_disk_space() {
           set +e
 
-          # Set the minimum requirement space to 4GB
+          # Set the minimum requirement space to 6GB
           MINIMUM_AVAILABLE_SPACE_IN_KB=$(($MINIMUM_AVAILABLE_SPACE_IN_GB * 1024 * 1024))
 
           # Use KB to avoid floating point warning like 3.1GB
@@ -55,6 +55,9 @@ runs:
           sudo rm "/System/Library/Caches/com.apple.coresymbolicationd/data" || true
           # Stop the daemon and launchctl will automatically start it again, thus accomplish a restart and free up the above file
           sudo launchctl stop com.apple.coresymbolicationd || true
+
+          # Clean up crash reports on the runner
+          sudo rm -rf "/System/Volumes/Data/Library/Logs/CrashReporter" || true
 
           # Also try to clean up torch.hub caching directory
           rm -rf "${HOME}/.cache/torch/hub" || true


### PR DESCRIPTION
I notice one instance of MacOS ran out space in https://github.com/pytorch/pytorch/actions/runs/5017945771/jobs/8996845812 on `i-082dc48967fe3ba38`.  Logging into the runner reveals that the crash report directory was hooking up all the space.

```
(base) ec2-user@ip-10-0-3-73 WiFi % pwd
/System/Volumes/Data/Library/Logs/CrashReporter/CoreCapture/WiFi
(base) ec2-user@ip-10-0-3-73 CoreCapture % sudo du -sh .
31G	.
(base) ec2-user@ip-10-0-3-73 WiFi % ls -la | wc -l
   51071
```

The error is `BCMWLAN Firmware Boot Failed~instance 1` and it comes from `com.apple.driver.AppleBCMWLANCoreV3.0` and `com.apple.iokit.IO80211Family`.  They are still happening on the runner, so I'll see if I can find any useful information from the crash report there.

In the meantime, adding a step to cleanup this folder when running out of space to keep trunk sanity.  After cleaning up

```
(base) ec2-user@ip-10-0-3-73 WiFi % df -h
Filesystem       Size   Used  Avail Capacity iused      ifree %iused  Mounted on
/dev/disk5s2s1  100Gi  8.3Gi   36Gi    19%  349475  377649320    0%   /
```