### PR TITLE
Replace the hardcode list of DevX members with GitHub team

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -4,7 +4,7 @@ import { addLabels, isPyTorchPyTorch } from "./utils";
 const titleRegexToLabel: [RegExp, string][] = [
   [/rocm/gi, "module: rocm"],
   [/vulkan/gi, "module: vulkan"],
-  [/vulkan/gi, "ciflow/periodic"],  // Vulkan tests are run periodically
+  [/vulkan/gi, "ciflow/periodic"], // Vulkan tests are run periodically
   [/DISABLED\s+test.*\(.*\)/g, "skipped"],
 ];
 

--- a/torchci/lib/useTableFilter.ts
+++ b/torchci/lib/useTableFilter.ts
@@ -21,21 +21,23 @@ export default function useTableFilter(params: HudParams) {
       }
     });
   }, []);
-  const handleInput = useCallback((f: any) => {
-    setJobFilter(f);
-    router.push(
-      formatHudUrlForRoute("hud", {
-        ...params,
-        nameFilter: f ?? undefined,
-      }),
-      undefined,
-      {
-        shallow: true,
-      }
-    );
-  }, [params, router]);
-  const handleSubmit = () => {
-  };
+  const handleInput = useCallback(
+    (f: any) => {
+      setJobFilter(f);
+      router.push(
+        formatHudUrlForRoute("hud", {
+          ...params,
+          nameFilter: f ?? undefined,
+        }),
+        undefined,
+        {
+          shallow: true,
+        }
+      );
+    },
+    [params, router]
+  );
+  const handleSubmit = () => {};
 
   // We have to use an effect hook here because query params are undefined at
   // static generation time; they only become available after hydration.

--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -290,8 +290,7 @@ export async function getTestOwnerLabels(
   testFile: string,
   invokingFile: string
 ): Promise<{ labels: string[]; additionalErrMessage?: string }> {
-  const urlkey =
-    "https://raw.githubusercontent.com/pytorch/pytorch/main/test/";
+  const urlkey = "https://raw.githubusercontent.com/pytorch/pytorch/main/test/";
 
   try {
     let result = await retryRequest(`${urlkey}${testFile}`);

--- a/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/[annotation].ts
+++ b/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/[annotation].ts
@@ -48,15 +48,15 @@ export default async function handler(
 
   // @ts-ignore
   const session = await getServerSession(req, res, authOptions);
-  if (session === undefined || session === null) {
+  if (session === undefined || session === null || session.user === undefined) {
     return res.status(401).end();
   }
 
   const { repoOwner, repoName, annotation } = req.query;
-  // @ts-ignore
   const hasPermission = await isPyTorchDevInfraMember(
-    repoOwner,
-    repoName,
+    repoOwner as string,
+    repoName as string,
+    // @ts-ignore
     session.user.id
   );
   if (!hasPermission) {


### PR DESCRIPTION
Per title, the hardcode list doesn't make sense anymore, so I replace it with an API call to check the team membership (worth the price of an API call IMO and this API endpoint is only infrequently used)