### PR TITLE
add CUDA VS intregration install to Windows AMI build script

### DIFF
--- a/aws/ami/windows/scripts/Installers/Install-CUDA-Tools.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-CUDA-Tools.ps1
@@ -80,6 +80,9 @@ function Install-CudaToolkit() {
     Get-Content -Path "$cudaInstallLogs\LOG.setup.exe.log"
     exit 1
   }
+
+  Write-Output "Installing VS 2019 integration"
+  Copy-Item -Force -Verbose -Recurse "$tmpExtractedInstaller\visual_studio_integration\CUDAVisualStudioIntegration\extras\visual_studio_integration\MSBuildExtensions\*.*" "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VC\v160\BuildCustomizations"
 }
 
 function Install-Cudnn() {


### PR DESCRIPTION
Follow-up to https://github.com/pytorch/vision/pull/7417#discussion_r1199655988. Untested, but should work.