### PR TITLE
Mark if a benchmark was newly added

### DIFF
--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -360,7 +360,9 @@ function ModelPanel({
                   return "";
                 }
 
-                if (lCommit === rCommit || v.l === v.r || v.r === undefined) {
+                if (v.r === undefined) {
+                  return <>{v.l} (<strong>NEW!</strong>)</>;
+                } else if (lCommit === rCommit || v.l === v.r) {
                   return v.l;
                 } else {
                   return `${v.r} → ${v.l}`;


### PR DESCRIPTION
Looks like this:

<img width="628" alt="image" src="https://github.com/pytorch/test-infra/assets/13564/93c12b15-abfc-46eb-bb1f-a72881e5907a">

Fixes https://github.com/pytorch/test-infra/issues/4190

Signed-off-by: Edward Z. Yang <ezyang@meta.com>
