### PR TITLE
Add oncall pt2 label for dynamo and inductor disabled issues

### DIFF
--- a/torchci/test/disableFlakyBot.test.ts
+++ b/torchci/test/disableFlakyBot.test.ts
@@ -578,10 +578,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
       );
 
     const { labels, additionalErrMessage } =
-      await disableFlakyTestBot.getTestOwnerLabels(
-        flakyTestA.file,
-        flakyTestA.invoking_file
-      );
+      await disableFlakyTestBot.getTestOwnerLabels(flakyTestA);
     expect(additionalErrMessage).toEqual(undefined);
     expect(labels).toEqual(["module: fft", "triaged"]);
 
@@ -601,10 +598,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
         )
       );
 
-    const { labels } = await disableFlakyTestBot.getTestOwnerLabels(
-      flakyTestA.file,
-      flakyTestA.invoking_file
-    );
+    const { labels } = await disableFlakyTestBot.getTestOwnerLabels(flakyTestA);
     expect(labels).toEqual(["oncall: distributed"]);
 
     if (!scope.isDone()) {
@@ -624,10 +618,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
       );
 
     const { labels, additionalErrMessage } =
-      await disableFlakyTestBot.getTestOwnerLabels(
-        flakyTestA.file,
-        flakyTestA.invoking_file
-      );
+      await disableFlakyTestBot.getTestOwnerLabels(flakyTestA);
     expect(labels).toEqual(["module: unknown"]);
     expect(additionalErrMessage).toEqual(undefined);
 
@@ -646,10 +637,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
       );
 
     const { labels, additionalErrMessage } =
-      await disableFlakyTestBot.getTestOwnerLabels(
-        flakyTestA.file,
-        flakyTestA.invoking_file
-      );
+      await disableFlakyTestBot.getTestOwnerLabels(flakyTestA);
     expect(labels).toEqual(["module: unknown"]);
     expect(additionalErrMessage).toEqual(undefined);
 
@@ -679,10 +667,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
       .reply(404);
 
     const { labels, additionalErrMessage } =
-      await disableFlakyTestBot.getTestOwnerLabels(
-        flakyTestA.file,
-        flakyTestA.invoking_file
-      );
+      await disableFlakyTestBot.getTestOwnerLabels(flakyTestA);
     expect(labels).toEqual(["module: unknown"]);
     expect(additionalErrMessage).toEqual(
       "Error: Error retrieving file_a.py: 404, file_a: 404"
@@ -704,10 +689,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
         Buffer.from(`# Owner(s): ["module: fft"]\nimport blah;\nrest of file`)
       );
     const { labels, additionalErrMessage } =
-      await disableFlakyTestBot.getTestOwnerLabels(
-        flakyTestA.file,
-        flakyTestA.invoking_file
-      );
+      await disableFlakyTestBot.getTestOwnerLabels(flakyTestA);
     expect(labels).toEqual(["module: fft", "triaged"]);
     expect(additionalErrMessage).toEqual(undefined);
 
@@ -733,10 +715,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
         Buffer.from(`# Owner(s): ["module: fft"]\nimport blah;\nrest of file`)
       );
     const { labels, additionalErrMessage } =
-      await disableFlakyTestBot.getTestOwnerLabels(
-        flakyTestAcrossJobA.file,
-        flakyTestAcrossJobA.invoking_file
-      );
+      await disableFlakyTestBot.getTestOwnerLabels(flakyTestAcrossJobA);
     expect(labels).toEqual(["module: fft", "triaged"]);
     expect(additionalErrMessage).toEqual(undefined);
 
@@ -744,6 +723,41 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
       console.error("pending mocks: %j", scope.pendingMocks());
     }
     scope.done();
+  });
+
+  test("getTestOwnerLabels: give dynamo and inductor oncall: pt2 label", async () => {
+    const test = { ...flakyTestA };
+    test.jobNames = ["dynamo linux"];
+
+    let scope = nock("https://raw.githubusercontent.com/")
+      .get(`/pytorch/pytorch/main/test/${test.file}`)
+      .reply(
+        200,
+        Buffer.from(`# Owner(s): ["module: fft"]\nimport blah;\nrest of file`)
+      );
+
+    let { labels, additionalErrMessage } =
+      await disableFlakyTestBot.getTestOwnerLabels(test);
+    expect(additionalErrMessage).toEqual(undefined);
+    expect(labels).toEqual(["module: fft", "oncall: pt2", "triaged"]);
+
+    handleScope(scope);
+  });
+
+  test("getTestOwnerLabels: give dynamo and inductor oncall: pt2 label, unknown owner", async () => {
+    const test = { ...flakyTestA };
+    test.jobNames = ["inductor linux", "linux"];
+
+    let scope = nock("https://raw.githubusercontent.com/")
+      .get(`/pytorch/pytorch/main/test/${test.file}`)
+      .reply(200, Buffer.from(`import blah;\nrest of file`));
+
+    let { labels, additionalErrMessage } =
+      await disableFlakyTestBot.getTestOwnerLabels(test);
+    expect(additionalErrMessage).toEqual(undefined);
+    expect(labels).toEqual(["module: unknown", "oncall: pt2"]);
+
+    handleScope(scope);
   });
 
   test("getLatestTrunkJobURL: should return URL of last trunk job if it exists", async () => {
@@ -815,7 +829,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
 
     expectJobsToDisablePlatforms(
       ["linux rocm", "dynamo linux", "inductor linux", "linux"],
-      ["linux", "rocm", "dynamo", "inductor"]
+      ["linux", "rocm"]
     );
 
     expectJobsToDisablePlatforms(
@@ -830,22 +844,26 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
 
     expectJobsToDisablePlatforms(
       ["linux rocm", "dynamo linux", "linux"],
-      ["linux", "rocm", "dynamo"]
+      ["linux", "rocm"]
     );
 
     expectJobsToDisablePlatforms(
       ["linux rocm", "inductor linux", "linux"],
-      ["linux", "rocm", "inductor"]
+      ["linux", "rocm"]
+    );
+
+    expectJobsToDisablePlatforms(["dynamo linux", "linux"], ["linux"]);
+
+    expectJobsToDisablePlatforms(["inductor linux", "linux"], ["linux"]);
+
+    expectJobsToDisablePlatforms(
+      ["inductor linux", "rocm linux"],
+      ["rocm", "inductor"]
     );
 
     expectJobsToDisablePlatforms(
-      ["dynamo linux", "linux"],
-      ["linux", "dynamo"]
-    );
-
-    expectJobsToDisablePlatforms(
-      ["inductor linux", "linux"],
-      ["linux", "inductor"]
+      ["inductor linux", "dynamo linux"],
+      ["dynamo", "inductor"]
     );
   });
 

--- a/torchci/test/disableFlakyBot.test.ts
+++ b/torchci/test/disableFlakyBot.test.ts
@@ -746,7 +746,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
 
   test("getTestOwnerLabels: give dynamo and inductor oncall: pt2 label, unknown owner", async () => {
     const test = { ...flakyTestA };
-    test.jobNames = ["inductor linux", "linux"];
+    test.jobNames = ["inductor linux"];
 
     let scope = nock("https://raw.githubusercontent.com/")
       .get(`/pytorch/pytorch/main/test/${test.file}`)
@@ -861,10 +861,9 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
       ["rocm", "inductor"]
     );
 
-    expectJobsToDisablePlatforms(
-      ["inductor linux", "dynamo linux"],
-      ["dynamo", "inductor"]
-    );
+    expectJobsToDisablePlatforms(["inductor linux"], ["inductor"]);
+
+    expectJobsToDisablePlatforms(["dynamo linux"], ["dynamo"]);
   });
 
   test("getIssueBodyForFlakyTest: should contain Platforms line", async () => {


### PR DESCRIPTION
Add oncall pt2 label for issues that have dynamo and inductor as groups.  Change rule for dynamo and inductor platforms so that they only get added if linux is not present since they are subsets of linux.

