### PR TITLE
Prevent alert issue spam

### DIFF
--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
            pip3 install requests setuptools
       - name: Run tests
+        if: ${{ github.event_name == 'pull_request'}}
         run: |
           python3 torchci/scripts/test_check_alerts.py
       - name: Check for alerts and creates issue
@@ -65,6 +66,7 @@ jobs:
         run: |
            pip3 install requests setuptools rockset==1.0.3
       - name: Run tests
+        if: ${{ github.event_name == 'pull_request'}}
         run: |
           python3 torchci/scripts/test_queue_alert.py
       - name: Check for alerts and creates issue

--- a/torchci/scripts/check_alerts.py
+++ b/torchci/scripts/check_alerts.py
@@ -566,10 +566,7 @@ def check_for_recurrently_failing_jobs_alert(
 
 def check_for_no_flaky_tests_alert(repo: str, branch: str):
     existing_no_flaky_tests_alerts = fetch_alerts(
-        repo=repo,
-        branch=branch,
-        alert_repo=TEST_INFRA_REPO_NAME,
-        labels=NO_FLAKY_TESTS_LABEL,
+        labels=[NO_FLAKY_TESTS_LABEL],
     )
     handle_flaky_tests_alert(existing_no_flaky_tests_alerts)
 

--- a/torchci/scripts/queue_alert.py
+++ b/torchci/scripts/queue_alert.py
@@ -21,7 +21,7 @@ QUEUE_ALERT_LABEL = "queue-alert"
 
 MAX_HOURS = 4
 MAX_MACHINES = 75
-EXCEPTIONS = {"linux.gcp.a100.large": (10, 20)}
+EXCEPTIONS = {"linux.gcp.a100.large": (20, 20)}
 
 
 class QueueInfo(NamedTuple):
@@ -118,8 +118,8 @@ def queuing_alert(dry_run: bool) -> None:
         # Generate a blank issue if there are no issues with the label and
         # re-fetch the issues so we can post an update comment, which will
         # trigger a more informative workchat ping
-        create_issue(gen_issue([]), dry_run)
-        existing_alerts = fetch_alerts([QUEUE_ALERT_LABEL])
+        new_issue = create_issue(gen_issue([]), dry_run)
+        existing_alerts.push(new_issue)
 
     # Favor the most recent issue and close the rest
     existing_issue = existing_alerts[-1]

--- a/torchci/scripts/test_queue_alert.py
+++ b/torchci/scripts/test_queue_alert.py
@@ -15,7 +15,7 @@ class TestGitHubPR(TestCase):
         rockset_results = [
             {
                 "count": 0,
-                "avg_queue_s": 3600 * 20,
+                "avg_queue_s": 3600 * 30,
                 "machine_type": "linux.gcp.a100.large",
             },
             {"count": 10, "avg_queue_s": 0, "machine_type": "machine1"},

--- a/torchci/scripts/test_queue_alert.py
+++ b/torchci/scripts/test_queue_alert.py
@@ -26,7 +26,7 @@ class TestGitHubPR(TestCase):
         self.assertEqual(long_queues[0].machine, "linux.gcp.a100.large")
 
     def test_gen_update_comment(self):
-        original_issue = {"state": "CLOSED"}
+        original_issue = {"closed": True}
         new_queues = [
             QueueInfo("machine1", 1, 2),
             QueueInfo("machine2", 2, 3),
@@ -35,7 +35,7 @@ class TestGitHubPR(TestCase):
         self.assertTrue("- machine1, 1 machines, 2 hours" in comment)
         self.assertTrue("- machine2, 2 machines, 3 hours" in comment)
 
-        original_issue = {"state": "OPEN", "body": "- machine2, 2 machines, 3 hours"}
+        original_issue = {"closed": False, "body": "- machine2, 2 machines, 3 hours"}
         new_queues = [
             QueueInfo("machine1", 1, 2),
             QueueInfo("machine2", 2, 3),


### PR DESCRIPTION
Prevent spam by opening most recently updated issue that matches.  If it can't find a issue, it will create a new one (hopefully this doesn't happen that often)

tested via running locally with dryrun, also not dry run for queue alert

