### PR TITLE
Cleanup sccache process on Windows runner

### DIFF
--- a/.github/actions/cleanup-runner/action.yml
+++ b/.github/actions/cleanup-runner/action.yml
@@ -13,7 +13,7 @@ runs:
         # This needs to be run before checking out PyTorch to avoid locking the working directory.
         # Below is the list of commands that could lock $GITHUB_WORKSPACE gathered from sysinternals
         # handle tool
-        $processes = "python", "ninja", "cl", "nvcc", "cmd"
+        $processes = "python", "ninja", "cl", "nvcc", "cmd", "sccache"
         Foreach ($process In $processes) {
           Try {
             # https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/stop-process


### PR DESCRIPTION
I have been able to root cause this `rm: cannot remove 'C:\actions-runner\_work\pytorch\pytorch/build/win_tmp/bin': Device or resource busy` issue happening on Windows from time to time, for example https://github.com/pytorch/pytorch/actions/runs/5053644794/jobs/9067740477.  It turns out that the process hooking up that directory is `sccache`.  Here is how it happened:

1. A Windows build job was running, for example https://github.com/pytorch/pytorch/actions/runs/5053412501/jobs/9067234773
2. A new version of the PR was pushed, thus the job on step 1 was cancelled 
3. The process `sccache` wasn't terminated properly as `sccache --stop-server` wasn't run, so I saw ` "C:\actions-runner\_work\pytorch\pytorch\build\win_tmp\bin\sccache.exe" ` in the list of processes
4. The next job would fail to clean up the workspace as sccache was still running, for example https://github.com/pytorch/pytorch/actions/runs/5053644794/jobs/9067740477

Thus, we need to make sure that `sccache` process is terminated.