### PR TITLE
setup-linux: Reference setup-nvidia by absolute path

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -74,5 +74,5 @@ runs:
         echo "does=${needs}" >> $GITHUB_OUTPUT
 
     - name: Install nvidia driver, nvidia-docker runtime, set GPU_FLAG
-      uses: ./test-infra/.github/actions/setup-nvidia
+      uses: pytorch/test-infra/.github/actions/setup-nvidia@main
       if: ${{ steps.needs-nvidia-driver.outputs.does == 1 }}


### PR DESCRIPTION
Otherwise, if `setup-linux` action is used without checking out the repo previously, it can fail, for example see [this](https://github.com/pytorch/xla/actions/runs/5054171030/jobs/9078201991):
> ##[group]Run pytorch/test-infra/.github/actions/setup-linux@main
> ...
> Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/ec2-user/actions-runner/_work/xla/xla/test-infra/.github/actions/setup-nvidia'. Did you forget to run actions/checkout before running your local action?


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a4dd0af</samp>

> _`setup-nvidia` action_
> _moved to test-infra repo_
> _sharing in autumn_