### PR TITLE
Don't check for authorization in issue_query

### DIFF
--- a/torchci/lib/bot/drciBot.ts
+++ b/torchci/lib/bot/drciBot.ts
@@ -8,7 +8,6 @@ import {
   formDrciSevBody,
   upsertDrCiComment,
 } from "lib/drciUtils";
-import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
 
 export default function drciBot(app: Probot): void {
   app.on(

--- a/torchci/rockset/commons/__sql/issue_query.sql
+++ b/torchci/rockset/commons/__sql/issue_query.sql
@@ -1,20 +1,13 @@
 SELECT
-  issue.number,
-  issue.title,
-  issue.html_url,
-  issue.state,
-  issue.body,
-  issue.updated_at,
-  issue.author_association,
+    issue.number,
+    issue.title,
+    issue.html_url,
+    issue.state,
+    issue.body,
+    issue.updated_at,
+    issue.author_association,
 FROM
-  issues AS issue CROSS
-  JOIN UNNEST(issue.labels AS label) AS labels
+    issues AS issue
+    CROSS JOIN UNNEST(issue.labels AS label) AS labels
 WHERE
-  labels.label.name = : label
-  AND (
-    ARRAY_CONTAINS(
-      SPLIT(: associations, ','),
-      LOWER(issue.author_association)
-    )
-    OR : associations = ''
-  )
+    labels.label.name =: label

--- a/torchci/rockset/commons/issue_query.lambda.json
+++ b/torchci/rockset/commons/issue_query.lambda.json
@@ -2,11 +2,6 @@
   "sql_path": "__sql/issue_query.sql",
   "default_parameters": [
     {
-      "name": "associations",
-      "type": "string",
-      "value": "member,contributor,collaborator"
-    },
-    {
       "name": "label",
       "type": "string",
       "value": "skipped"

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -19,7 +19,7 @@
     "test_time_per_oncall": "a85f4d3243d90f51",
     "test_time_and_price_per_oncall": "7af6d14035a19439",
     "test_times_per_workflow_type": "3ab0de839b95d22c",
-    "issue_query": "e30d683c63d74f22",
+    "issue_query": "e4d338de89980044",
     "failure_samples_query": "18e7e696b4949f05",
     "num_commits_master": "e4a864147cf3bf44",
     "recent_pr_workflows_query": "dc6152f7ab81a336",


### PR DESCRIPTION
I originally considered adding pytorchbot as a special exception, but I think this is fine because issues are almost immediately closed if they don't have authorization.  

Also I'm a little worried that reopening an old issue that was created by someone without write permissions would not disable the test.  While this is acceptable since a new issue could also be created, I think it creates some confusion between which issues work and which don't.  Also not sure what happens to the author association in rockset when people leave/join pytorch.

