### PR TITLE
Adding option to run without docker to linux generic job

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -179,7 +179,6 @@ jobs:
             echo "set -eou pipefail";
             # Source conda so it's available to the script environment
             echo 'eval "$(conda shell.bash hook)"';
-            echo 'export DOCKER_IMAGE="${{ env.DOCKER_IMAGE }}"';
             echo "${SCRIPT}";
           } > "${RUNNER_TEMP}/exec_script"
           echo "Script below:"

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -182,6 +182,8 @@ jobs:
             echo 'export DOCKER_IMAGE="${{ env.DOCKER_IMAGE }}"';
             echo "${SCRIPT}";
           } > "${RUNNER_TEMP}/exec_script"
+          echo "Script below:"
+          cat "${RUNNER_TEMP}/exec_script"
           while read line; do
             eval "export ${line}"
           done < "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -178,7 +178,6 @@ jobs:
             echo "#!/usr/bin/env bash";
             echo "set -eou pipefail";
             # Source conda so it's available to the script environment
-            echo 'eval "$(conda shell.bash hook)"';
             echo "${SCRIPT}";
           } > "${RUNNER_TEMP}/exec_script"
           echo "Script below:"

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -185,7 +185,7 @@ jobs:
           cat "${RUNNER_TEMP}/exec_script"
           cat "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
           while read line; do
-            eval "export ${line}"
+            eval "if [[ \"${line}\" != \"GITHUB_WORKFLOW=\"* ]]; then export ${line}; fi"
           done < "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
           bash "${RUNNER_TEMP}/exec_script"
 

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -68,6 +68,11 @@ on:
         required: false
         default: ''
         type: string
+      run-with-docker:
+        description: "Whether the provided script should run inside a docker container"
+        required: false
+        default: true
+        type: boolean
       secrets-env:
         description: "List of secrets to be exported to environment variables"
         type: string
@@ -144,6 +149,7 @@ jobs:
           target-os: "linux"
 
       - name: Run script in container
+        if: ${{ inputs.run-with-docker == true }}
         continue-on-error: ${{ inputs.continue-on-error }}
         working-directory: ${{ inputs.repository }}
         env:
@@ -160,6 +166,27 @@ jobs:
           } > "${RUNNER_TEMP}/exec_script"
           chmod +x "${RUNNER_TEMP}/exec_script"
           python3 "${{ github.workspace }}/test-infra/.github/scripts/run_docker_with_env_secrets.py" "${{ inputs.secrets-env }}"
+
+      - name: Run script outside container
+        if: ${{ inputs.run-with-docker == false }}
+        continue-on-error: ${{ inputs.continue-on-error }}
+        working-directory: ${{ inputs.repository }}
+        env:
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+          DOCKER_IMAGE: ${{  }}
+        run: |
+          {
+            echo "#!/usr/bin/env bash";
+            echo "set -eou pipefail";
+            # Source conda so it's available to the script environment
+            echo 'eval "$(conda shell.bash hook)"';
+            echo 'export DOCKER_IMAGE=${{ env.DOCKER_IMAGE }}';
+            echo "${SCRIPT}";
+          } > "${RUNNER_TEMP}/exec_script"
+          while read line; do
+            eval "export ${line}"
+          done < "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
+          bash "${RUNNER_TEMP}/exec_script"
 
       - name: Surface failing tests
         if: always()

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -185,7 +185,7 @@ jobs:
           # enclosed in quotes in the env file, so simply eval-ing each line in
           # the file will fail. As a workaround, we eval all env vars except
           # for GITHUB_WORKFLOW here.
-          while read line; do
+          while read -r line; do
             eval "if [[ \"${line}\" != \"GITHUB_WORKFLOW=\"* ]]; then export ${line}; fi"
           done < "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
           bash "${RUNNER_TEMP}/exec_script"

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -180,9 +180,11 @@ jobs:
             # Source conda so it's available to the script environment
             echo "${SCRIPT}";
           } > "${RUNNER_TEMP}/exec_script"
-          echo "Script below:"
-          cat "${RUNNER_TEMP}/exec_script"
-          cat "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
+          # The GITHUB_WORKFLOW env var contains the name of the workflow
+          # defined at the top of the workflow file. Unfortunately this is not
+          # enclosed in quotes in the env file, so simply eval-ing each line in
+          # the file will fail. As a workaround, we eval all env vars except
+          # for GITHUB_WORKFLOW here.
           while read line; do
             eval "if [[ \"${line}\" != \"GITHUB_WORKFLOW=\"* ]]; then export ${line}; fi"
           done < "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -173,14 +173,13 @@ jobs:
         working-directory: ${{ inputs.repository }}
         env:
           ALL_SECRETS: ${{ toJSON(secrets) }}
-          DOCKER_IMAGE: ${{  }}
         run: |
           {
             echo "#!/usr/bin/env bash";
             echo "set -eou pipefail";
             # Source conda so it's available to the script environment
             echo 'eval "$(conda shell.bash hook)"';
-            echo 'export DOCKER_IMAGE=${{ env.DOCKER_IMAGE }}';
+            echo 'export DOCKER_IMAGE="${{ env.DOCKER_IMAGE }}"';
             echo "${SCRIPT}";
           } > "${RUNNER_TEMP}/exec_script"
           while read line; do

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -183,6 +183,7 @@ jobs:
           } > "${RUNNER_TEMP}/exec_script"
           echo "Script below:"
           cat "${RUNNER_TEMP}/exec_script"
+          cat "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
           while read line; do
             eval "export ${line}"
           done < "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -130,7 +130,6 @@ jobs:
             echo 'eval "$(conda shell.bash hook)"';
             echo "${SCRIPT}";
           } > "${RUNNER_TEMP}/exec_script"
-          cat "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
           while read line; do
             eval "export ${line}"
           done < "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -130,6 +130,7 @@ jobs:
             echo 'eval "$(conda shell.bash hook)"';
             echo "${SCRIPT}";
           } > "${RUNNER_TEMP}/exec_script"
+          cat "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
           while read line; do
             eval "export ${line}"
           done < "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"

--- a/.github/workflows/test_linux_job.yml
+++ b/.github/workflows/test_linux_job.yml
@@ -137,3 +137,17 @@ jobs:
         conda create --yes --quiet -n test python="${PYTHON_VERSION}"
         conda activate test
         python --version | grep "${PYTHON_VERSION}"
+  test-no-docker:
+    uses: ./.github/workflows/linux_job.yml
+    with:
+      job-name: "No Docker Test"
+      runner: linux.2xlarge
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      gpu-arch-type: cpu
+      gpu-arch-version: ""
+      run-with-docker: false
+      script: |
+        export PYTHON_VERSION="3.8"
+        docker run -e PYTHON_VERSION -t -v $PWD:$PWD -w $PWD "${DOCKER_IMAGE}" echo "hello from inside docker"
+        echo "hello from outside docker"

--- a/.github/workflows/test_linux_job.yml
+++ b/.github/workflows/test_linux_job.yml
@@ -140,7 +140,7 @@ jobs:
   test-no-docker:
     uses: ./.github/workflows/linux_job.yml
     with:
-      job-name: "No Docker Test"
+      job-name: "no-docker-test"
       runner: linux.2xlarge
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}


### PR DESCRIPTION
TorchRL requires some scripts to be run outside of the docker container. Previously, the generic linux_job requires all jobs to be run inside a conda-builder container. This PR introduces the option for scripts to be run on bare metal, but still fetches the docker container in case other scripts need to be run on the container.