### PR TITLE
Fix geomean calculation by using the lower bound of 1.0

### DIFF
--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -67,6 +67,9 @@ const SPEEDUP_HEADER = `Performance speedup (threshold = ${SPEEDUP_THRESHOLD}x)`
 const LATENCY_HEADER = `Compilation latency in seconds (threshold = ${COMPILATION_lATENCY_THRESHOLD_IN_SECONDS}s)`;
 const MEMORY_HEADER = `Peak memory compression ratio (threshold = ${COMPRESSION_RATIO_THRESHOLD}x)`;
 
+// The number of digit after decimal to display on the detail page
+const SCALE = 4;
+
 function CommitPanel({
   suite,
   branch,
@@ -362,7 +365,11 @@ function ModelPanel({
                 }
 
                 if (v.r === undefined) {
-                  return <>{v.l} (<strong>NEW!</strong>)</>;
+                  return (
+                    <>
+                      {v.l} (<strong>NEW!</strong>)
+                    </>
+                  );
                 } else if (lCommit === rCommit || v.l === v.r) {
                   return v.l;
                 } else {
@@ -418,8 +425,8 @@ function ModelPanel({
                   return "";
                 }
 
-                const l = Number(v.l).toFixed(2);
-                const r = Number(v.r).toFixed(2);
+                const l = Number(v.l).toFixed(SCALE);
+                const r = Number(v.r).toFixed(SCALE);
 
                 if (lCommit === rCommit || l === r || v.r === 0) {
                   return l;
@@ -557,8 +564,8 @@ function ModelPanel({
                   return "";
                 }
 
-                const l = Number(v.l).toFixed(2);
-                const r = Number(v.r).toFixed(2);
+                const l = Number(v.l).toFixed(SCALE);
+                const r = Number(v.r).toFixed(SCALE);
 
                 if (lCommit === rCommit || l === r || v.r === 0) {
                   return l;
@@ -647,11 +654,13 @@ function GraphPanel({
       );
     })
     .map((record: CompilerPerformanceData) => {
-      record.speedup = Number(record.speedup.toFixed(2));
+      record.speedup = Number(record.speedup.toFixed(SCALE));
       record.compilation_latency = Number(
         record.compilation_latency.toFixed(0)
       );
-      record.compression_ratio = Number(record.compression_ratio.toFixed(2));
+      record.compression_ratio = Number(
+        record.compression_ratio.toFixed(SCALE)
+      );
       // Truncate the data to make it consistent with the display value
       return record;
     });
@@ -689,115 +698,126 @@ function GraphPanel({
 
   return (
     <>
-    <div>
-    <h2>Details for {model}</h2>
-    <Grid container spacing={2}>
-      <Grid item xs={12} lg={4} height={GRAPH_ROW_HEIGHT}>
-        <TimeSeriesPanelWithData
-          data={chartData}
-          series={geomeanSeries}
-          title={`Geomean`}
-          groupByFieldName={groupByFieldName}
-          yAxisRenderer={(unit) => {
-            return `${unit.toFixed(2)}`;
-          }}
-          additionalOptions={{
-            yAxis: {
-              scale: true,
-            },
-            label: {
-              show: true,
-              align: "left",
-              formatter: (r: any) => {
-                return Number(r.value[1]).toFixed(2);
-              },
-            },
-          }}
-        />
-      </Grid>
-
-      <Grid item xs={12} lg={4} height={GRAPH_ROW_HEIGHT}>
-        <TimeSeriesPanelWithData
-          data={chartData}
-          series={compTimeSeries}
-          title={`Mean compilation time`}
-          groupByFieldName={groupByFieldName}
-          yAxisLabel={"second"}
-          yAxisRenderer={(unit) => {
-            return `${unit.toFixed(0)}`;
-          }}
-          additionalOptions={{
-            yAxis: {
-              scale: true,
-            },
-            label: {
-              show: true,
-              align: "left",
-              formatter: (r: any) => {
-                return Number(r.value[1]).toFixed(0);
-              },
-            },
-          }}
-        />
-      </Grid>
-
-      <Grid item xs={12} lg={4} height={GRAPH_ROW_HEIGHT}>
-        <TimeSeriesPanelWithData
-          data={chartData}
-          series={memorySeries}
-          title={`Peak memory footprint compression ratio`}
-          groupByFieldName={groupByFieldName}
-          yAxisRenderer={(unit) => {
-            return `${unit.toFixed(2)}`;
-          }}
-          additionalOptions={{
-            yAxis: {
-              scale: true,
-            },
-            label: {
-              show: true,
-              align: "left",
-              formatter: (r: any) => {
-                return Number(r.value[1]).toFixed(2);
-              },
-            },
-          }}
-        />
-      </Grid>
-    </Grid>
-    </div>
-    <div>
-      <table>
-        <thead>
-          <tr>
-            <th>Date</th>
-            <th>Commit</th>
-            <th>Accuracy</th>
-            <th>Speedup</th>
-            <th>Comptime</th>
-            <th>Memory</th>
-          </tr>
-        </thead>
-        <tbody>
-          {chartData.map((entry: any, index: number) => {
-            let commit = WORKFLOW_ID_TO_COMMIT[entry.workflow_id];
-            return (
-              <tr key={index}>
-                <td>{entry.granularity_bucket}</td>
-                <td><code><a onClick={() => navigator.clipboard.writeText(commit)} className="animate-on-click">{commit}</a></code></td>
-                <td>{entry.accuracy}</td>
-                <td>{entry.speedup}</td>
-                <td>{entry.compilation_latency}</td>
-                <td>{entry.compression_ratio}</td>
-              </tr>
-            )
-          })}
-        </tbody>
-      </table>
       <div>
-        Tip: to view all commits between two commits, run <code>git log --oneline START..END</code> (NB: this will exclude the START commit itself, which is typically what you want.)
+        <h2>Details for {model}</h2>
+        <Grid container spacing={2}>
+          <Grid item xs={12} lg={4} height={GRAPH_ROW_HEIGHT}>
+            <TimeSeriesPanelWithData
+              data={chartData}
+              series={geomeanSeries}
+              title={`Geomean`}
+              groupByFieldName={groupByFieldName}
+              yAxisRenderer={(unit) => {
+                return `${unit.toFixed(SCALE)}`;
+              }}
+              additionalOptions={{
+                yAxis: {
+                  scale: true,
+                },
+                label: {
+                  show: true,
+                  align: "left",
+                  formatter: (r: any) => {
+                    return Number(r.value[1]).toFixed(SCALE);
+                  },
+                },
+              }}
+            />
+          </Grid>
+
+          <Grid item xs={12} lg={4} height={GRAPH_ROW_HEIGHT}>
+            <TimeSeriesPanelWithData
+              data={chartData}
+              series={compTimeSeries}
+              title={`Mean compilation time`}
+              groupByFieldName={groupByFieldName}
+              yAxisLabel={"second"}
+              yAxisRenderer={(unit) => {
+                return `${unit.toFixed(0)}`;
+              }}
+              additionalOptions={{
+                yAxis: {
+                  scale: true,
+                },
+                label: {
+                  show: true,
+                  align: "left",
+                  formatter: (r: any) => {
+                    return Number(r.value[1]).toFixed(0);
+                  },
+                },
+              }}
+            />
+          </Grid>
+
+          <Grid item xs={12} lg={4} height={GRAPH_ROW_HEIGHT}>
+            <TimeSeriesPanelWithData
+              data={chartData}
+              series={memorySeries}
+              title={`Peak memory footprint compression ratio`}
+              groupByFieldName={groupByFieldName}
+              yAxisRenderer={(unit) => {
+                return `${unit.toFixed(SCALE)}`;
+              }}
+              additionalOptions={{
+                yAxis: {
+                  scale: true,
+                },
+                label: {
+                  show: true,
+                  align: "left",
+                  formatter: (r: any) => {
+                    return Number(r.value[1]).toFixed(SCALE);
+                  },
+                },
+              }}
+            />
+          </Grid>
+        </Grid>
       </div>
-    </div>
+      <div>
+        <table>
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Commit</th>
+              <th>Accuracy</th>
+              <th>Speedup</th>
+              <th>Comptime</th>
+              <th>Memory</th>
+            </tr>
+          </thead>
+          <tbody>
+            {chartData.map((entry: any, index: number) => {
+              let commit = WORKFLOW_ID_TO_COMMIT[entry.workflow_id];
+              return (
+                <tr key={index}>
+                  <td>{entry.granularity_bucket}</td>
+                  <td>
+                    <code>
+                      <a
+                        onClick={() => navigator.clipboard.writeText(commit)}
+                        className="animate-on-click"
+                      >
+                        {commit}
+                      </a>
+                    </code>
+                  </td>
+                  <td>{entry.accuracy}</td>
+                  <td>{entry.speedup}</td>
+                  <td>{entry.compilation_latency}</td>
+                  <td>{entry.compression_ratio}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+        <div>
+          Tip: to view all commits between two commits, run{" "}
+          <code>git log --oneline START..END</code> (NB: this will exclude the
+          START commit itself, which is typically what you want.)
+        </div>
+      </div>
     </>
   );
 }

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -79,6 +79,13 @@ export const SPEEDUP_THRESHOLD = 0.95;
 export const COMPILATION_lATENCY_THRESHOLD_IN_SECONDS = 120;
 export const COMPRESSION_RATIO_THRESHOLD = 0.9;
 
+// When calculating geomean, all the values are clipped to the lower bound of 1.0
+// because if the speed up is less than 1.0, one can use eager mode instead
+export const GEOMEAN_LOWER_BOUND = 1.0;
+
+// The number of digit after decimal to display on the summary page
+const SCALE = 2;
+
 // Headers
 export const DIFF_HEADER = "Base value (L) → New value (R)";
 const PASSRATE_HEADER = `Passrate (threshold = ${ACCURACY_THRESHOLD}%)`;
@@ -229,9 +236,9 @@ function geomean(data: number[]) {
 
   var gm = 1.0;
   data.forEach((v) => {
-    gm *= v;
+    gm *= v < GEOMEAN_LOWER_BOUND ? GEOMEAN_LOWER_BOUND : v;
   });
-  return Math.pow(gm, 1.0 / data.length).toFixed(2);
+  return Math.pow(gm, 1.0 / data.length).toFixed(SCALE);
 }
 
 function computeGeomean(
@@ -363,7 +370,7 @@ function computeCompilationTime(
               workflow_id: workflowId,
               suite: suite,
               compiler: compiler,
-              compilation_latency: m.toFixed(2),
+              compilation_latency: m.toFixed(SCALE),
             });
           }
         );
@@ -436,7 +443,7 @@ function computeMemoryCompressionRatio(
               workflow_id: workflowId,
               suite: suite,
               compiler: compiler,
-              compression_ratio: m.toFixed(2),
+              compression_ratio: m.toFixed(SCALE),
             });
           }
         );
@@ -1092,8 +1099,8 @@ function SummaryPanel({
                       params.row.compiler
                     }?startTime=${startTime}&stopTime=${stopTime}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
 
-                    const l = Number(v.l).toFixed(2);
-                    const r = Number(v.r).toFixed(2);
+                    const l = Number(v.l).toFixed(SCALE);
+                    const r = Number(v.r).toFixed(SCALE);
 
                     if (
                       lCommit === rCommit ||
@@ -1287,8 +1294,8 @@ function SummaryPanel({
                       params.row.compiler
                     }?startTime=${startTime}&stopTime=${stopTime}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
 
-                    const l = Number(v.l).toFixed(2);
-                    const r = Number(v.r).toFixed(2);
+                    const l = Number(v.l).toFixed(SCALE);
+                    const r = Number(v.r).toFixed(SCALE);
 
                     if (
                       lCommit === rCommit ||


### PR DESCRIPTION
Fixes https://github.com/pytorch/test-infra/issues/4196

* Update the geomean calculation to set the lower bound value to be `1.0` same as https://github.com/pytorch/pytorch/blob/main/benchmarks/dynamo/runner.py#L760-L764.  The logic behind is that if the speed up is less than 1.0, one can use eager mode instead
* Use a higher scale when displaying speed up and memory compression ratio values on the model detail pages (4 digits after decimal)
* Run `yarn format` to reformat the files

### Testing

* https://torchci-git-fork-huydhn-fix-geomean-calculation-fbopensource.vercel.app/benchmark/compilers?startTime=Mon%2C%2015%20May%202023%2017%3A09%3A51%20GMT&stopTime=Mon%2C%2022%20May%202023%2017%3A09%3A51%20GMT&suite=torchbench&mode=inference&dtype=amp&lBranch=main&lCommit=351c2ea2fbb09add93980e2942435f31b114047c&rBranch=main&rCommit=f994d0b619d4643af24b4c49672e534fec729024 now shows a decrease `1.67x → 1.65x` matching the regression in the [detail page](https://torchci-git-fork-huydhn-fix-geomean-calculation-fbopensource.vercel.app/benchmark/torchbench/inductor_with_cudagraphs?startTime=Mon,%2015%20May%202023%2017:09:51%20GMT&stopTime=Mon,%2022%20May%202023%2017:09:51%20GMT&mode=inference&dtype=amp&lBranch=main&lCommit=351c2ea2fbb09add93980e2942435f31b114047c&rBranch=main&rCommit=f994d0b619d4643af24b4c49672e534fec729024)
* https://torchci-git-fork-huydhn-fix-geomean-calculation-fbopensource.vercel.app/benchmark/torchbench/inductor_with_cudagraphs?startTime=Tue,%2016%20May%202023%2015:24:09%20GMT&stopTime=Tue,%2023%20May%202023%2015:24:09%20GMT&mode=training&dtype=amp&lBranch=main&lCommit=b91eb97d34536dbdf22bbf7555a8e64ca7932c51&rBranch=main&rCommit=e9a7115605ee5b6ae38ea5716a4abea5aa415333 displays 4 digits after decimal to avoid hiding the difference
