### PR TITLE
Add more folders to windows Defender ignore

### DIFF
--- a/.github/actions/setup-windows/action.yml
+++ b/.github/actions/setup-windows/action.yml
@@ -36,6 +36,8 @@ runs:
       shell: powershell
       run: |
         Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
+        Add-MpPreference -ExclusionPath C:\\Users\\runneruser -ErrorAction Ignore
+        Add-MpPreference -ExclusionPath C:\\actions-runner\\_work -ErrorAction Ignore
 
     - name: Setup useful environment variables
       shell: bash


### PR DESCRIPTION
Add more folders to windows Defender ignore
Observing following errors on audio and vision workflows:

Audio:
```
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmp2n2jvobx\\torchaudio_unittest.io.stream_writer_test.StreamWriterCorrectnessTest.test_audio_num_frames_lossy_2_mp3\\test.mp3'
```

Vision:
```
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmpuuvqh5ck\\FlyingThings3D\\optical_flow\\TRAIN\\A\\0001\\into_future\\left'
```


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at abc43af</samp>

> _`Windows Defender`_
> _Scans too much, slows down tests -_
> _`exclusion list` grows_