### PR TITLE
Nit fix for Generic Linux Job's no-docker option

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -190,10 +190,6 @@ jobs:
               eval "export ${line}"
             fi
           done < "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
-          echo "${RUNNER_TEMP}/exec_script"
-          cat "${RUNNER_TEMP}/exec_script"
-          echo "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
-          cat "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
           bash "${RUNNER_TEMP}/exec_script"
 
       - name: Surface failing tests

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -186,8 +186,14 @@ jobs:
           # the file will fail. As a workaround, we eval all env vars except
           # for GITHUB_WORKFLOW here.
           while read -r line; do
-            eval "if [[ \"${line}\" != \"GITHUB_WORKFLOW=\"* ]]; then export ${line}; fi"
+            if [[ "${line}" != "GITHUB_WORKFLOW="* ]]; then
+              eval "export ${line}"
+            fi
           done < "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
+          echo "${RUNNER_TEMP}/exec_script"
+          cat "${RUNNER_TEMP}/exec_script"
+          echo "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
+          cat "${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}"
           bash "${RUNNER_TEMP}/exec_script"
 
       - name: Surface failing tests


### PR DESCRIPTION
small fix for running `linux_job` with the no-docker option