### PR TITLE
Collect and publish the list of unstable jobs

### DIFF
--- a/.github/scripts/update_disabled_issues.py
+++ b/.github/scripts/update_disabled_issues.py
@@ -253,7 +253,7 @@ def main() -> None:
         "disabled-jobs.json",
     )
 
-    # Also handle UNSTABLE issues that mars CI jobs as unstable
+    # Also handle UNSTABLE issues that mark CI jobs as unstable
     unstable_issues = get_disable_issues(prefix=UNSTABLE_PREFIX)
     validate_and_sort(unstable_issues)
 

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -31,9 +31,10 @@ jobs:
         run: |
           cat disabled-tests-condensed.json
 
-      - name: Print the list of disabled jobs
+      - name: Print the list of disabled and unstable jobs
         run: |
           cat disabled-jobs.json
+          cat unstable-jobs.json
 
       - name: Push disable tests to test-infra repository
         if: github.event_name != 'pull_request'
@@ -63,13 +64,28 @@ jobs:
           user_name: "Pytorch Test Infra"
           commit_message: "Updating disabled jobs"
 
+      - name: Push unstanle jobs to test-infra repository
+        # if: github.event_name != 'pull_request'
+        uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          source_file: "unstable-jobs.json"
+          destination_repo: "pytorch/test-infra"
+          destination_folder: "stats"
+          destination_branch: generated-stats
+          user_email: "test-infra@pytorch.org"
+          user_name: "Pytorch Test Infra"
+          commit_message: "Updating unstable jobs"
+
       - name: Upload file to s3
-        if: github.event_name != 'pull_request'
+        # if: github.event_name != 'pull_request'
         run: |
           python3 -mpip install awscli==1.27.69
 
           aws s3 cp disabled-tests-condensed.json s3://ossci-metrics/disabled-tests-condensed.json
           aws s3 cp disabled-jobs.json s3://ossci-metrics/disabled-jobs.json
+          aws s3 cp unstable-jobs.json s3://ossci-metrics/unstable-jobs.json
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -33,7 +33,10 @@ jobs:
 
       - name: Print the list of disabled and unstable jobs
         run: |
+          echo "Disabled jobs:"
           cat disabled-jobs.json
+
+          echo "Unstable jobs:"
           cat unstable-jobs.json
 
       - name: Push disable tests to test-infra repository
@@ -64,7 +67,7 @@ jobs:
           user_name: "Pytorch Test Infra"
           commit_message: "Updating disabled jobs"
 
-      - name: Push unstanle jobs to test-infra repository
+      - name: Push unstable jobs to test-infra repository
         # if: github.event_name != 'pull_request'
         uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
         env:

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -36,6 +36,7 @@ jobs:
           echo "Disabled jobs:"
           cat disabled-jobs.json
 
+          echo
           echo "Unstable jobs:"
           cat unstable-jobs.json
 
@@ -68,7 +69,7 @@ jobs:
           commit_message: "Updating disabled jobs"
 
       - name: Push unstable jobs to test-infra repository
-        # if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
         env:
           API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
@@ -82,7 +83,7 @@ jobs:
           commit_message: "Updating unstable jobs"
 
       - name: Upload file to s3
-        # if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         run: |
           python3 -mpip install awscli==1.27.69
 


### PR DESCRIPTION
This is the first step to be able to mark CI jobs as unstable automatically.  This is done in the same way as disabling CI jobs by creating issues in the following format `UNSTABLE [WORKFLOW_NAME] / [PLATFORM_NAME] / [JOB_NAME]`

Some issues for testing:

* https://github.com/pytorch/pytorch/issues/102299
* https://github.com/pytorch/pytorch/issues/102298
* https://github.com/pytorch/pytorch/issues/102297
* https://github.com/pytorch/pytorch/issues/102433

### Testing

Export `GH_PYTORCHBOT_TOKEN` using my own token, run `python update_disabled_issues.py`, then verify that the list of unstable jobs is correct:

```
cat unstable-jobs.json
{
  "linux-binary-manywheel / manywheel-py3_8-cuda11_8": [
    "huydhn",
    "102433",
    "https://github.com/pytorch/pytorch/issues/102433",
    "linux-binary-manywheel",
    "manywheel-py3_8-cuda11_8",
    ""
  ],
  "pull / linux-bionic-py3.11-clang9 / test (dynamo)": [
    "huydhn",
    "102298",
    "https://github.com/pytorch/pytorch/issues/102298",
    "pull",
    "linux-bionic-py3.11-clang9",
    "test (dynamo)"
  ],
  "trunk / macos-12-py3-arm64": [
    "huydhn",
    "102299",
    "https://github.com/pytorch/pytorch/issues/102299",
    "trunk",
    "macos-12-py3-arm64",
    ""
  ],
  "trunk / win-vs2019-cpu-py3 / test": [
    "huydhn",
    "102297",
    "https://github.com/pytorch/pytorch/issues/102297",
    "trunk",
    "win-vs2019-cpu-py3",
    "test"
  ]
}
```