### PR TITLE
Update ruleset.toml to capture KeyboardInterrupt signal in case a test is timed out.

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -174,7 +174,7 @@ pattern = '^##\[error\]Response status code does not indicate success: .*$'
 
 [[rule]]
 name = 'Python Test timeout (KeyboardInterrupt)'
-pattern = '\!+ KeyboardInterrupt \!+'
+pattern = '!+ KeyboardInterrupt !+'
 
 [[rule]]
 name = 'Python Test File RuntimeError'

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -173,6 +173,10 @@ name = 'Bad response status code'
 pattern = '^##\[error\]Response status code does not indicate success: .*$'
 
 [[rule]]
+name = 'Python Test timeout (KeyboardInterrupt)'
+pattern = '\!+ KeyboardInterrupt \!+'
+
+[[rule]]
 name = 'Python Test File RuntimeError'
 pattern = '^RuntimeError: .*test.* failed'
 


### PR DESCRIPTION
The PR updates `ruleset.toml` to locate the `KeyboardInterrupt` signal in jobs' logs on the HUD in case a test is timed out and gets keyboard interrupted.

Here is an [example](https://hud.pytorch.org/pytorch/pytorch/pull/100153?sha=684615d5376d7b23d4e14760daf6fbfd53de9895), the jobs that ran out of time are showing `RuntimeError: test_ops x/x failed!`, which can be improved to be more specific.