### PR TITLE
Assign the speedup of 1.0 to failing models instead of skipping them

### DIFF
--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -278,12 +278,14 @@ function computeGeomean(
       speedup[bucket][workflowId][suite][compiler] = [];
     }
 
+    let speedupValue = GEOMEAN_LOWER_BOUND;
     if (
       isPass(bucket, workflowId, suite, compiler, model, passingModels) &&
       record.speedup !== 0.0
     ) {
-      speedup[bucket][workflowId][suite][compiler].push(record.speedup);
+      speedupValue = record.speedup;
     }
+    speedup[bucket][workflowId][suite][compiler].push(speedupValue);
   });
 
   Object.keys(speedup).forEach((bucket: string) => {


### PR DESCRIPTION
Fixes https://github.com/pytorch/test-infra/issues/4239.  Per the discussion with @ezyang, skipping failed models would invalidate the basis of aggregated speedup comparison because the lists aren't the same.  For the context, this logic came from https://github.com/pytorch/pytorch/blob/main/benchmarks/dynamo/runner.py#L755-L756 where failed models with 0 speedup value was incorrectly removed.

### Testing
https://torchci-git-fork-huydhn-fix-skipping-zero-s-064698-fbopensource.vercel.app/benchmark/compilers