### PR TITLE
Skip uploading slow tests, disabled tests/jobs, and unstable jobs to test-infra

### DIFF
--- a/.github/workflows/update-slow-tests.yml
+++ b/.github/workflows/update-slow-tests.yml
@@ -19,18 +19,6 @@ jobs:
       - run: yarn --silent node scripts/updateSlowTests.mjs > slow-tests.json
         env:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
-      - name: Push file to this repository
-        uses: dmnemec/copy_file_to_another_repo_action@5f40763ccee2954067adba7fb8326e4df33bcb92
-        env:
-           API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          source_file: 'torchci/slow-tests.json'
-          destination_repo: 'pytorch/test-infra'
-          destination_folder: 'stats'
-          destination_branch: generated-stats
-          user_email: 'test-infra@pytorch.org'
-          user_name: 'PyTorch Test Infra'
-          commit_message: 'Updating slow tests stats'
       - name: Upload file to s3
         run: |
           python3 -mpip install awscli==1.27.69

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -40,48 +40,6 @@ jobs:
           echo "Unstable jobs:"
           cat unstable-jobs.json
 
-      - name: Push disable tests to test-infra repository
-        if: github.event_name != 'pull_request'
-        uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          source_file: "disabled-tests-condensed.json"
-          destination_repo: "pytorch/test-infra"
-          destination_folder: "stats"
-          destination_branch: generated-stats
-          user_email: "test-infra@pytorch.org"
-          user_name: "Pytorch Test Infra"
-          commit_message: "Updating condensed disabled tests stats"
-
-      - name: Push disable jobs to test-infra repository
-        if: github.event_name != 'pull_request'
-        uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          source_file: "disabled-jobs.json"
-          destination_repo: "pytorch/test-infra"
-          destination_folder: "stats"
-          destination_branch: generated-stats
-          user_email: "test-infra@pytorch.org"
-          user_name: "Pytorch Test Infra"
-          commit_message: "Updating disabled jobs"
-
-      - name: Push unstable jobs to test-infra repository
-        if: github.event_name != 'pull_request'
-        uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          source_file: "unstable-jobs.json"
-          destination_repo: "pytorch/test-infra"
-          destination_folder: "stats"
-          destination_branch: generated-stats
-          user_email: "test-infra@pytorch.org"
-          user_name: "Pytorch Test Infra"
-          commit_message: "Updating unstable jobs"
-
       - name: Upload file to s3
         if: github.event_name != 'pull_request'
         run: |

--- a/stats/README.md
+++ b/stats/README.md
@@ -1,1 +1,5 @@
-slow-tests.json and disabled-tests-condensed.json files are now in the [generated-stats branch](https://github.com/pytorch/test-infra/tree/generated-stats/stats).
+The following files are now on S3 [ossci-metrics](https://ossci-metrics.s3.amazonaws.com) bucket:
+* [slow-tests.json](https://ossci-metrics.s3.amazonaws.com/slow-tests.json)
+* [disabled-tests-condensed.json](https://ossci-metrics.s3.amazonaws.com/disabled-tests-condensed.json)
+* [disabled-jobs.json](https://ossci-metrics.s3.amazonaws.com/disabled-jobs.json)
+* [unstable-jobs.json](https://ossci-metrics.s3.amazonaws.com/unstable-jobs.json)


### PR DESCRIPTION
As these files are now on S3, uploading them to test-infra seems redundant.  The only potential benefit to version track them on test-infra is to keep an audit history, but I guess we don't care much about that