### PR TITLE
Increase max_available for linux.g5.4xlarge.nvidia.gpu runners to 550

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -79,7 +79,7 @@ runner_types:
     disk_size: 150
     instance_type: g5.4xlarge
     is_ephemeral: false
-    max_available: 400
+    max_available: 550
     os: linux
   linux.large:
     disk_size: 15


### PR DESCRIPTION
as the limit is currently being exceeded by regular usage: 

![Screenshot 2023-06-02 at 11 51 45](https://github.com/pytorch/test-infra/assets/4520845/a5a42d90-45a2-40fd-9e2e-f069269e8eca)
