### PR TITLE
[TorchFix] Use TOR001 for removed functions

### DIFF
--- a/tools/torchfix/tests/fixtures/checker/removed_symeig.txt
+++ b/tools/torchfix/tests/fixtures/checker/removed_symeig.txt
@@ -1,2 +1,2 @@
-4:8 TOR201 Use of removed function torch.symeig
-5:8 TOR201 Use of removed function torch.symeig
+4:8 TOR001 Use of removed function torch.symeig
+5:8 TOR001 Use of removed function torch.symeig

--- a/tools/torchfix/torchfix/torchfix.py
+++ b/tools/torchfix/torchfix/torchfix.py
@@ -65,7 +65,7 @@ class TorchVisitor(cst.CSTVisitor):
                 error_code = "TOR101"
                 message = f"Use of deprecated function {qualified_name}"
             else:
-                error_code = "TOR201"
+                error_code = "TOR001"
                 message = f"Use of removed function {qualified_name}"
 
             replacement = None


### PR DESCRIPTION
So it's like priority 0.
Deprecated but not removed functions have TOR101, priority 1.