### PR TITLE
default the linux_job workflow to pull submodules recursively

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -112,6 +112,11 @@ jobs:
           ref: ${{ inputs.test-infra-ref }}
           path: test-infra
 
+          # PyTorch, the primary target for this job template, heavily
+          # relies on submodules. Clone them by default to avoid
+          # surprises.
+          submodules: 'recursive'
+
       - name: Setup Linux
         uses: ./test-infra/.github/actions/setup-linux
 


### PR DESCRIPTION
default the linux_job workflow to pull submodules recursively

Summary:
When trying to use this for the "codegen diff" job in PyTorch, I
noticed it was failing because we did not have submodules
available. After discussing with @seemethere, he suggested to just
make this the default.

Test Plan:
Verifying in local CI.

This can't be tested in the pytorch/pytorch repo because I this is
pushed to the dagitses/test-infra fork, which fails with the error:
> Called workflows cannot be queued onto self-hosted runners across
> organisations/enterprises. Failed to queue this job.
> Labels: 'linux.large'.

See https://github.com/pytorch/pytorch/actions/runs/5169464586/attempts/2
