### PR TITLE
Add tutorials to drci

### DIFF
--- a/.github/workflows/update-drci-comments.yml
+++ b/.github/workflows/update-drci-comments.yml
@@ -41,3 +41,10 @@ jobs:
           --url 'https://www.torch-ci.com/api/drci/drci' \
           --header 'Authorization: ${{ secrets.DRCI_BOT_KEY }}' \
           --data 'repo=audio'
+
+      - name: Retrieve rockset query results and update Dr. CI comments for the Tutorials repo
+        run: |
+          curl --request POST \
+          --url 'https://www.torch-ci.com/api/drci/drci' \
+          --header 'Authorization: ${{ secrets.DRCI_BOT_KEY }}' \
+          --data 'repo=tutorials'

--- a/torchci/lib/bot/utils.ts
+++ b/torchci/lib/bot/utils.ts
@@ -19,7 +19,14 @@ export function isPyTorchPyTorch(owner: string, repo: string): boolean {
 export function isDrCIEnabled(owner: string, repo: string): boolean {
   return (
     isPyTorchOrg(owner) &&
-    ["pytorch", "vision", "text", "audio", "pytorch-canary"].includes(repo)
+    [
+      "pytorch",
+      "vision",
+      "text",
+      "audio",
+      "pytorch-canary",
+      "tutorials",
+    ].includes(repo)
   );
 }
 


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 56f3660</samp>

This pull request enables the Dr. CI service for the Tutorials repo. It adds a workflow step to update the Dr. CI comments with the latest test results and modifies the `isDrCIEnabled` function to include the Tutorials repo.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 56f3660</samp>

> _`Tutorials` repo_
> _joins the Dr. CI service_
> _curling in winter_