### PR TITLE
[stronghold][bc-linter] Add basic typing support

### DIFF
--- a/.github/workflows/stronghold.yml
+++ b/.github/workflows/stronghold.yml
@@ -90,4 +90,5 @@ jobs:
 
         pytest | tee "${GITHUB_STEP_SUMMARY}"
 
+      docker-image: python:3.11.0-bullseye # note: must include git
       runner: linux.large

--- a/tools/stronghold/src/api/__init__.py
+++ b/tools/stronghold/src/api/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 import dataclasses
+from typing import Optional
+import api.types
 
 
 @dataclasses.dataclass
@@ -36,3 +38,5 @@ class Parameter:
     required: bool
     # Which line the parameter is defined on.
     line: int
+    # Type annotation (relies on ast.annotation types)
+    annotation: Optional[api.types.TypeHint] = None

--- a/tools/stronghold/src/api/__init__.py
+++ b/tools/stronghold/src/api/__init__.py
@@ -39,4 +39,4 @@ class Parameter:
     # Which line the parameter is defined on.
     line: int
     # Type annotation (relies on ast.annotation types)
-    annotation: Optional[api.types.TypeHint] = None
+    type_annotation: Optional[api.types.TypeHint] = None

--- a/tools/stronghold/src/api/ast.py
+++ b/tools/stronghold/src/api/ast.py
@@ -50,7 +50,7 @@ def _function_def_to_parameters(node: ast.FunctionDef) -> api.Parameters:
             keyword=False,
             required=i < num_required,
             line=arg.lineno,
-            annotation=api.types.annotation_to_dataclass(arg.annotation),
+            type_annotation=api.types.annotation_to_dataclass(arg.annotation),
         )
         for i, arg in enumerate(args.posonlyargs)
     ]
@@ -63,7 +63,7 @@ def _function_def_to_parameters(node: ast.FunctionDef) -> api.Parameters:
             keyword=True,
             required=i < num_required,
             line=arg.lineno,
-            annotation=api.types.annotation_to_dataclass(arg.annotation),
+            type_annotation=api.types.annotation_to_dataclass(arg.annotation),
         )
         for i, arg in enumerate(args.args, start=len(args.posonlyargs))
     ]
@@ -77,7 +77,7 @@ def _function_def_to_parameters(node: ast.FunctionDef) -> api.Parameters:
             keyword=True,
             required=args.kw_defaults[i] is None,
             line=arg.lineno,
-            annotation=api.types.annotation_to_dataclass(arg.annotation),
+            type_annotation=api.types.annotation_to_dataclass(arg.annotation),
         )
         for i, arg in enumerate(args.kwonlyargs)
     ]

--- a/tools/stronghold/src/api/ast.py
+++ b/tools/stronghold/src/api/ast.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 
 import api
+import api.types
 
 
 def extract(path: pathlib.Path) -> Mapping[str, api.Parameters]:
@@ -49,6 +50,7 @@ def _function_def_to_parameters(node: ast.FunctionDef) -> api.Parameters:
             keyword=False,
             required=i < num_required,
             line=arg.lineno,
+            annotation=api.types.annotation_to_dataclass(arg.annotation),
         )
         for i, arg in enumerate(args.posonlyargs)
     ]
@@ -61,6 +63,7 @@ def _function_def_to_parameters(node: ast.FunctionDef) -> api.Parameters:
             keyword=True,
             required=i < num_required,
             line=arg.lineno,
+            annotation=api.types.annotation_to_dataclass(arg.annotation),
         )
         for i, arg in enumerate(args.args, start=len(args.posonlyargs))
     ]
@@ -74,6 +77,7 @@ def _function_def_to_parameters(node: ast.FunctionDef) -> api.Parameters:
             keyword=True,
             required=args.kw_defaults[i] is None,
             line=arg.lineno,
+            annotation=api.types.annotation_to_dataclass(arg.annotation),
         )
         for i, arg in enumerate(args.kwonlyargs)
     ]

--- a/tools/stronghold/src/api/compatibility.py
+++ b/tools/stronghold/src/api/compatibility.py
@@ -117,14 +117,14 @@ def _check_by_name(
             )
             continue
         if not _check_type_compatibility(
-            before_param.annotation, after_param.annotation
+            before_param.type_annotation, after_param.type_annotation
         ):
             yield api.violations.ParameterTypeChanged(
                 func=func,
                 parameter=name,
                 line=after.line,
-                type_before=str(before_param.annotation),
-                type_after=str(after_param.annotation),
+                type_before=str(before_param.type_annotation),
+                type_after=str(after_param.type_annotation),
             )
         assert after_param.name == name
 
@@ -158,13 +158,15 @@ def _check_by_position(
 
     if before_param_names == after_param_names:
         for p_before, p_after in zip(before_params, after_params):
-            if not _check_type_compatibility(p_before.annotation, p_after.annotation):
+            if not _check_type_compatibility(
+                p_before.type_annotation, p_after.type_annotation
+            ):
                 yield api.violations.ParameterTypeChanged(
                     func=func,
                     parameter=p_before.name,
                     line=p_after.line,
-                    type_before=str(p_before.annotation),
-                    type_after=str(p_after.annotation),
+                    type_before=str(p_before.type_annotation),
+                    type_after=str(p_after.type_annotation),
                 )
         return
 

--- a/tools/stronghold/src/api/compatibility.py
+++ b/tools/stronghold/src/api/compatibility.py
@@ -117,10 +117,15 @@ def _check_by_name(
                 func=func, parameter=name, line=after.line
             )
             continue
-        if not _check_type_compatibility(before_param.annotation, after_param.annotation):
+        if not _check_type_compatibility(
+            before_param.annotation, after_param.annotation
+        ):
             yield api.violations.ParameterTypeChanged(
-                func=func, parameter=name, line=after.line,
-                type_before=str(before_param.annotation), type_after=str(after_param.annotation)
+                func=func,
+                parameter=name,
+                line=after.line,
+                type_before=str(before_param.annotation),
+                type_after=str(after_param.annotation),
             )
         assert after_param.name == name
 
@@ -156,8 +161,11 @@ def _check_by_position(
         for before, after in zip(before_params, after_params):
             if not _check_type_compatibility(before.annotation, after.annotation):
                 yield api.violations.ParameterTypeChanged(
-                    func=func, parameter=before.name, line=after.line,
-                    type_before=str(before.annotation), type_after=str(after.annotation)
+                    func=func,
+                    parameter=before.name,
+                    line=after.line,
+                    type_before=str(before.annotation),
+                    type_after=str(after.annotation),
                 )
         return
 
@@ -239,11 +247,9 @@ def _check_variadic_parameters(
         yield api.violations.KwArgsDeleted(func, line=after.line)
 
 
-def _check_type_compatibility(
-        type_before: Optional, type_after: Optional
-) -> bool:
+def _check_type_compatibility(type_before: Optional, type_after: Optional) -> bool:
     """Checks that the type annotations are compatible.
-        Returns True if compatible.
+    Returns True if compatible.
     """
     # If annotations are identical, they are compatible
     if type_before == type_after:
@@ -255,13 +261,19 @@ def _check_type_compatibility(
         return True
 
     # if either of the types is Unknown, then we can't make a compatibility judgement
-    if isinstance(type_before, api.types.Unknown) or isinstance(type_after, api.types.Unknown):
+    if isinstance(type_before, api.types.Unknown) or isinstance(
+        type_after, api.types.Unknown
+    ):
         return True
 
     # Checks compatibility if one types is Constant
-    if isinstance(type_before, api.types.Constant) or isinstance(type_after, api.types.Constant):
+    if isinstance(type_before, api.types.Constant) or isinstance(
+        type_after, api.types.Constant
+    ):
         # optimistically allow for type expansion: was constant, now is not constant
-        if isinstance(type_before, api.types.Constant) and not isinstance(type_after, api.types.Constant):
+        if isinstance(type_before, api.types.Constant) and not isinstance(
+            type_after, api.types.Constant
+        ):
             return True
 
         # fail if the type was not constant before, but became constant now,
@@ -270,22 +282,35 @@ def _check_type_compatibility(
 
     # Checks compatibility if one types is simple (e.g. int, str, etc.)
     # or Attribute (e.g. api.types.FooBar)
-    if isinstance(type_before, api.types.TypeName) or isinstance(type_after, api.types.TypeName) or\
-            isinstance(type_before, api.types.Attribute) or isinstance(type_after, api.types.Attribute):
+    if (
+        isinstance(type_before, api.types.TypeName)
+        or isinstance(type_after, api.types.TypeName)
+        or isinstance(type_before, api.types.Attribute)
+        or isinstance(type_after, api.types.Attribute)
+    ):
         # fail (the equality is checked earlier)
         return False
 
-    # Checks compatibility if both annotations are generic types (like List[int], Dict[str, int], etc.)
-    if isinstance(type_before, api.types.Generic) or isinstance(type_after, api.types.Generic):
-        if not isinstance(type_before, api.types.Generic) or not isinstance(type_after, api.types.Generic):
+    # Checks compatibility if both annotations are generic types
+    # (like List[int], Dict[str, int], etc.)
+    if isinstance(type_before, api.types.Generic) or isinstance(
+        type_after, api.types.Generic
+    ):
+        if not isinstance(type_before, api.types.Generic) or not isinstance(
+            type_after, api.types.Generic
+        ):
             # fail if one of the types is generic, but the other is not
             return False
 
         # fail if the generic type changed or generic type arguments changed
-        if type_before.base != type_after.base or len(type_before.arguments) != len(type_after.arguments):
+        if type_before.base != type_after.base or len(type_before.arguments) != len(
+            type_after.arguments
+        ):
             return False
 
-        for type_before_arg, type_after_arg in zip(type_before.arguments, type_after.arguments):
+        for type_before_arg, type_after_arg in zip(
+            type_before.arguments, type_after.arguments
+        ):
             if not _check_type_compatibility(type_before_arg, type_after_arg):
                 return False
 

--- a/tools/stronghold/src/api/compatibility.py
+++ b/tools/stronghold/src/api/compatibility.py
@@ -6,7 +6,6 @@ from collections.abc import Iterable, Mapping, Sequence
 import difflib
 import pathlib
 import tempfile
-from typing import Optional
 
 import api
 import api.ast
@@ -158,14 +157,14 @@ def _check_by_position(
     after_param_names = [param.name for param in after_params]
 
     if before_param_names == after_param_names:
-        for before, after in zip(before_params, after_params):
-            if not _check_type_compatibility(before.annotation, after.annotation):
+        for p_before, p_after in zip(before_params, after_params):
+            if not _check_type_compatibility(p_before.annotation, p_after.annotation):
                 yield api.violations.ParameterTypeChanged(
                     func=func,
-                    parameter=before.name,
-                    line=after.line,
-                    type_before=str(before.annotation),
-                    type_after=str(after.annotation),
+                    parameter=p_before.name,
+                    line=p_after.line,
+                    type_before=str(p_before.annotation),
+                    type_after=str(p_after.annotation),
                 )
         return
 
@@ -247,7 +246,9 @@ def _check_variadic_parameters(
         yield api.violations.KwArgsDeleted(func, line=after.line)
 
 
-def _check_type_compatibility(type_before: Optional, type_after: Optional) -> bool:
+def _check_type_compatibility(
+    type_before: api.types.TypeHint, type_after: api.types.TypeHint
+) -> bool:
     """Checks that the type annotations are compatible.
     Returns True if compatible.
     """
@@ -314,4 +315,4 @@ def _check_type_compatibility(type_before: Optional, type_after: Optional) -> bo
             if not _check_type_compatibility(type_before_arg, type_after_arg):
                 return False
 
-        return True
+    return True

--- a/tools/stronghold/src/api/compatibility.py
+++ b/tools/stronghold/src/api/compatibility.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable, Mapping, Sequence
 import difflib
 import pathlib
 import tempfile
+from typing import Optional
 
 import api
 import api.ast
@@ -116,6 +117,11 @@ def _check_by_name(
                 func=func, parameter=name, line=after.line
             )
             continue
+        if not _check_type_compatibility(before_param.annotation, after_param.annotation):
+            yield api.violations.ParameterTypeChanged(
+                func=func, parameter=name, line=after.line,
+                type_before=str(before_param.annotation), type_after=str(after_param.annotation)
+            )
         assert after_param.name == name
 
     for name, after_param in _keyword_only_parameters(after).items():
@@ -147,6 +153,12 @@ def _check_by_position(
     after_param_names = [param.name for param in after_params]
 
     if before_param_names == after_param_names:
+        for before, after in zip(before_params, after_params):
+            if not _check_type_compatibility(before.annotation, after.annotation):
+                yield api.violations.ParameterTypeChanged(
+                    func=func, parameter=before.name, line=after.line,
+                    type_before=str(before.annotation), type_after=str(after.annotation)
+                )
         return
 
     if set(before_param_names) == set(after_param_names):
@@ -225,3 +237,56 @@ def _check_variadic_parameters(
         yield api.violations.VarArgsDeleted(func=func, line=after.line)
     if before.variadic_kwargs and not after.variadic_kwargs:
         yield api.violations.KwArgsDeleted(func, line=after.line)
+
+
+def _check_type_compatibility(
+        type_before: Optional, type_after: Optional
+) -> bool:
+    """Checks that the type annotations are compatible.
+        Returns True if compatible.
+    """
+    # If annotations are identical, they are compatible
+    if type_before == type_after:
+        return True
+
+    # If either of the annotations is None, then we can't make a compatibility judgement
+    # because Python allows functions to have untyped parameters.
+    if type_before is None or type_after is None:
+        return True
+
+    # if either of the types is Unknown, then we can't make a compatibility judgement
+    if isinstance(type_before, api.types.Unknown) or isinstance(type_after, api.types.Unknown):
+        return True
+
+    # Checks compatibility if one types is Constant
+    if isinstance(type_before, api.types.Constant) or isinstance(type_after, api.types.Constant):
+        # optimistically allow for type expansion: was constant, now is not constant
+        if isinstance(type_before, api.types.Constant) and not isinstance(type_after, api.types.Constant):
+            return True
+
+        # fail if the type was not constant before, but became constant now,
+        # or if the constant value changed
+        return False
+
+    # Checks compatibility if one types is simple (e.g. int, str, etc.)
+    # or Attribute (e.g. api.types.FooBar)
+    if isinstance(type_before, api.types.TypeName) or isinstance(type_after, api.types.TypeName) or\
+            isinstance(type_before, api.types.Attribute) or isinstance(type_after, api.types.Attribute):
+        # fail (the equality is checked earlier)
+        return False
+
+    # Checks compatibility if both annotations are generic types (like List[int], Dict[str, int], etc.)
+    if isinstance(type_before, api.types.Generic) or isinstance(type_after, api.types.Generic):
+        if not isinstance(type_before, api.types.Generic) or not isinstance(type_after, api.types.Generic):
+            # fail if one of the types is generic, but the other is not
+            return False
+
+        # fail if the generic type changed or generic type arguments changed
+        if type_before.base != type_after.base or len(type_before.arguments) != len(type_after.arguments):
+            return False
+
+        for type_before_arg, type_after_arg in zip(type_before.arguments, type_after.arguments):
+            if not _check_type_compatibility(type_before_arg, type_after_arg):
+                return False
+
+        return True

--- a/tools/stronghold/src/api/types.py
+++ b/tools/stronghold/src/api/types.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import List, Union, Optional
+import ast
+from typing import Union
+
+@dataclass
+class TypeName:
+    """
+    Represents a simple type name, like `str` or `int`.
+    """
+    name: str
+
+    def __str__(self):
+        return self.name
+
+
+@dataclass
+class Constant:
+    """
+    Represents a constant, like `None` or `True`.
+    """
+    value: str
+
+    def __str__(self):
+        return self.value
+
+
+@dataclass
+class Generic:
+    """
+    Represents a generic type, like `List[int]` or `Dict[str, int]`.
+    """
+    base: Union[TypeName, 'Attribute']
+    arguments: List[TypeHint]
+
+    def __str__(self):
+        arguments_str = ', '.join(str(arg) for arg in self.arguments)
+        return f"{str(self.base)}[{arguments_str}]"
+
+@dataclass
+class Tuple:
+    """
+    Represents a tuple type, like `Tuple[int, str]`.
+    """
+    arguments: List[TypeHint]
+
+    def __str__(self):
+        return ', '.join(str(arg) for arg in self.arguments)
+
+
+@dataclass
+class Attribute:
+    """
+    Represents an attribute, like `foo.bar` or `foo.bar.baz`.
+    """
+    value: Union[TypeName, 'Attribute']
+    attr: str
+
+    def __str__(self):
+        return f"{str(self.value)}.{self.attr}"
+
+
+@dataclass
+class Unknown:
+    """
+    Represents an unknown type (e.g. a type that couldn't be mapped currently).
+    """
+    raw: str
+
+    def __str__(self):
+        return self.raw
+
+
+TypeHint = Union[TypeName, Constant, Generic, Tuple, Attribute, Unknown]
+
+
+def annotation_to_dataclass(annotation) -> Optional[TypeHint]:
+    """Converts an AST annotation to a dataclass."""
+    if annotation is None:
+        return None
+    elif isinstance(annotation, ast.Name):
+        return TypeName(annotation.id)
+    elif isinstance(annotation, ast.Constant):
+        return Constant(str(annotation.value))
+    # tuple
+    elif isinstance(annotation, ast.Tuple):
+        return Tuple([annotation_to_dataclass(el) for el in annotation.elts])
+    elif isinstance(annotation, ast.Subscript):
+        base = annotation_to_dataclass(annotation.value)
+        arguments = annotation_to_dataclass(annotation.slice)
+        # either a single argument or a tuple
+        return Generic(base, [arguments]) if not isinstance(arguments, Tuple) else Generic(base, arguments.arguments)
+    elif isinstance(annotation, ast.Attribute):
+        value = annotation_to_dataclass(annotation.value)
+        return Attribute(value, annotation.attr)
+    else:
+        return Unknown(str(annotation))

--- a/tools/stronghold/src/api/types.py
+++ b/tools/stronghold/src/api/types.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List, Union, Optional
 import ast
-from typing import Union
+
 
 @dataclass
 class TypeName:
     """
     Represents a simple type name, like `str` or `int`.
     """
+
     name: str
 
     def __str__(self):
@@ -20,6 +21,7 @@ class Constant:
     """
     Represents a constant, like `None` or `True`.
     """
+
     value: str
 
     def __str__(self):
@@ -31,6 +33,7 @@ class Generic:
     """
     Represents a generic type, like `List[int]` or `Dict[str, int]`.
     """
+
     base: Union[TypeName, 'Attribute']
     arguments: List[TypeHint]
 
@@ -38,11 +41,13 @@ class Generic:
         arguments_str = ', '.join(str(arg) for arg in self.arguments)
         return f"{str(self.base)}[{arguments_str}]"
 
+
 @dataclass
 class Tuple:
     """
     Represents a tuple type, like `Tuple[int, str]`.
     """
+
     arguments: List[TypeHint]
 
     def __str__(self):
@@ -54,6 +59,7 @@ class Attribute:
     """
     Represents an attribute, like `foo.bar` or `foo.bar.baz`.
     """
+
     value: Union[TypeName, 'Attribute']
     attr: str
 
@@ -66,6 +72,7 @@ class Unknown:
     """
     Represents an unknown type (e.g. a type that couldn't be mapped currently).
     """
+
     raw: str
 
     def __str__(self):
@@ -90,7 +97,11 @@ def annotation_to_dataclass(annotation) -> Optional[TypeHint]:
         base = annotation_to_dataclass(annotation.value)
         arguments = annotation_to_dataclass(annotation.slice)
         # either a single argument or a tuple
-        return Generic(base, [arguments]) if not isinstance(arguments, Tuple) else Generic(base, arguments.arguments)
+        return (
+            Generic(base, [arguments])
+            if not isinstance(arguments, Tuple)
+            else Generic(base, arguments.arguments)
+        )
     elif isinstance(annotation, ast.Attribute):
         value = annotation_to_dataclass(annotation.value)
         return Attribute(value, annotation.attr)

--- a/tools/stronghold/src/api/types.py
+++ b/tools/stronghold/src/api/types.py
@@ -12,7 +12,7 @@ class TypeName:
 
     name: str
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
 
@@ -24,7 +24,7 @@ class Constant:
 
     value: str
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
 
@@ -37,7 +37,7 @@ class Generic:
     base: Union[TypeName, 'Attribute']
     arguments: List[TypeHint]
 
-    def __str__(self):
+    def __str__(self) -> str:
         arguments_str = ', '.join(str(arg) for arg in self.arguments)
         return f"{str(self.base)}[{arguments_str}]"
 
@@ -50,7 +50,7 @@ class Tuple:
 
     arguments: List[TypeHint]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return ', '.join(str(arg) for arg in self.arguments)
 
 
@@ -63,7 +63,7 @@ class Attribute:
     value: Union[TypeName, 'Attribute']
     attr: str
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{str(self.value)}.{self.attr}"
 
 
@@ -75,14 +75,14 @@ class Unknown:
 
     raw: str
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.raw
 
 
-TypeHint = Union[TypeName, Constant, Generic, Tuple, Attribute, Unknown]
+TypeHint = Union[TypeName, Constant, Generic, Tuple, Attribute, Unknown, None]
 
 
-def annotation_to_dataclass(annotation) -> Optional[TypeHint]:
+def annotation_to_dataclass(annotation: Optional[ast.expr]) -> TypeHint:
     """Converts an AST annotation to a dataclass."""
     if annotation is None:
         return None
@@ -98,12 +98,12 @@ def annotation_to_dataclass(annotation) -> Optional[TypeHint]:
         arguments = annotation_to_dataclass(annotation.slice)
         # either a single argument or a tuple
         return (
-            Generic(base, [arguments])
+            Generic(base, [arguments])  # type: ignore
             if not isinstance(arguments, Tuple)
-            else Generic(base, arguments.arguments)
+            else Generic(base, arguments.arguments)  # type: ignore
         )
     elif isinstance(annotation, ast.Attribute):
         value = annotation_to_dataclass(annotation.value)
-        return Attribute(value, annotation.attr)
+        return Attribute(value, annotation.attr)  # type: ignore
     else:
         return Unknown(str(annotation))

--- a/tools/stronghold/src/api/violations.py
+++ b/tools/stronghold/src/api/violations.py
@@ -105,3 +105,18 @@ class ParameterRenamed(ParameterViolation):
 
     def __post_init__(self) -> None:
         self.message = f'{self.parameter} was renamed to {self.parameter_after}'
+
+@dataclass
+class ParameterTypeChanged(ParameterViolation):
+    """Represents when a parameter type has changed in a non-compatible way"""
+
+    # Type before it was changed
+    type_before: str = ''
+
+    # Type after it was changed
+    type_after: str = ''
+
+    message: str = ''
+
+    def __post_init__(self) -> None:
+        self.message = f'{self.parameter} changed from {self.type_before} to {self.type_after}'

--- a/tools/stronghold/src/api/violations.py
+++ b/tools/stronghold/src/api/violations.py
@@ -106,6 +106,7 @@ class ParameterRenamed(ParameterViolation):
     def __post_init__(self) -> None:
         self.message = f'{self.parameter} was renamed to {self.parameter_after}'
 
+
 @dataclass
 class ParameterTypeChanged(ParameterViolation):
     """Represents when a parameter type has changed in a non-compatible way"""
@@ -119,4 +120,6 @@ class ParameterTypeChanged(ParameterViolation):
     message: str = ''
 
     def __post_init__(self) -> None:
-        self.message = f'{self.parameter} changed from {self.type_before} to {self.type_after}'
+        self.message = (
+            f'{self.parameter} changed from {self.type_before} to {self.type_after}'
+        )

--- a/tools/stronghold/tests/api/test_ast.py
+++ b/tools/stronghold/tests/api/test_ast.py
@@ -1,9 +1,11 @@
 """Tests the api.ast module."""
 
 import pathlib
+from typing import List
 
 import api
 import api.ast
+import api.types
 
 from testing import source
 
@@ -29,7 +31,8 @@ def test_extract_positional(tmp_path: pathlib.Path) -> None:
         'func': api.Parameters(
             parameters=[
                 api.Parameter(
-                    name='x', positional=True, keyword=False, required=True, line=1
+                    name='x', positional=True, keyword=False, required=True, line=1,
+                    annotation=api.types.TypeName('int')
                 )
             ],
             variadic_args=False,
@@ -48,7 +51,8 @@ def test_extract_positional_with_default(tmp_path: pathlib.Path) -> None:
         'func': api.Parameters(
             parameters=[
                 api.Parameter(
-                    name='x', positional=True, keyword=False, required=False, line=1
+                    name='x', positional=True, keyword=False, required=False, line=1,
+                    annotation=api.types.TypeName('int')
                 )
             ],
             variadic_args=False,
@@ -67,7 +71,8 @@ def test_extract_flexible(tmp_path: pathlib.Path) -> None:
         'func': api.Parameters(
             parameters=[
                 api.Parameter(
-                    name='x', positional=True, keyword=True, required=True, line=1
+                    name='x', positional=True, keyword=True, required=True, line=1,
+                    annotation=api.types.TypeName('int')
                 )
             ],
             variadic_args=False,
@@ -86,7 +91,8 @@ def test_extract_flexible_with_default(tmp_path: pathlib.Path) -> None:
         'func': api.Parameters(
             parameters=[
                 api.Parameter(
-                    name='x', positional=True, keyword=True, required=False, line=1
+                    name='x', positional=True, keyword=True, required=False, line=1,
+                    annotation=api.types.TypeName('int')
                 )
             ],
             variadic_args=False,
@@ -105,7 +111,8 @@ def test_extract_keyword(tmp_path: pathlib.Path) -> None:
         'func': api.Parameters(
             parameters=[
                 api.Parameter(
-                    name='x', positional=False, keyword=True, required=True, line=1
+                    name='x', positional=False, keyword=True, required=True, line=1,
+                    annotation=api.types.TypeName('int')
                 )
             ],
             variadic_args=False,
@@ -124,7 +131,8 @@ def test_extract_keyword_with_default(tmp_path: pathlib.Path) -> None:
         'func': api.Parameters(
             parameters=[
                 api.Parameter(
-                    name='x', positional=False, keyword=True, required=False, line=1
+                    name='x', positional=False, keyword=True, required=False, line=1,
+                    annotation=api.types.TypeName('int')
                 )
             ],
             variadic_args=False,
@@ -185,7 +193,7 @@ def test_extract_class_method(tmp_path: pathlib.Path) -> None:
 def test_extract_comprehensive(tmp_path: pathlib.Path) -> None:
     class Class:
         def func(
-            self, a: int, /, b: int = 2, *args: int, c: int, **kwargs: int
+            self, a: int, /, b: float = 2, *args: int, c: int, **kwargs: int
         ) -> None:
             pass  # pragma: no cover
 
@@ -206,6 +214,7 @@ def test_extract_comprehensive(tmp_path: pathlib.Path) -> None:
                     keyword=False,
                     required=True,
                     line=3,
+                    annotation=api.types.TypeName('int')
                 ),
                 api.Parameter(
                     name='b',
@@ -213,6 +222,7 @@ def test_extract_comprehensive(tmp_path: pathlib.Path) -> None:
                     keyword=True,
                     required=False,
                     line=3,
+                    annotation=api.types.TypeName('float')
                 ),
                 api.Parameter(
                     name='c',
@@ -220,6 +230,7 @@ def test_extract_comprehensive(tmp_path: pathlib.Path) -> None:
                     keyword=True,
                     required=True,
                     line=3,
+                    annotation=api.types.TypeName('int')
                 ),
             ],
             variadic_args=True,

--- a/tools/stronghold/tests/api/test_ast.py
+++ b/tools/stronghold/tests/api/test_ast.py
@@ -1,7 +1,6 @@
 """Tests the api.ast module."""
 
 import pathlib
-from typing import List
 
 import api
 import api.ast
@@ -31,8 +30,12 @@ def test_extract_positional(tmp_path: pathlib.Path) -> None:
         'func': api.Parameters(
             parameters=[
                 api.Parameter(
-                    name='x', positional=True, keyword=False, required=True, line=1,
-                    annotation=api.types.TypeName('int')
+                    name='x',
+                    positional=True,
+                    keyword=False,
+                    required=True,
+                    line=1,
+                    annotation=api.types.TypeName('int'),
                 )
             ],
             variadic_args=False,
@@ -51,8 +54,12 @@ def test_extract_positional_with_default(tmp_path: pathlib.Path) -> None:
         'func': api.Parameters(
             parameters=[
                 api.Parameter(
-                    name='x', positional=True, keyword=False, required=False, line=1,
-                    annotation=api.types.TypeName('int')
+                    name='x',
+                    positional=True,
+                    keyword=False,
+                    required=False,
+                    line=1,
+                    annotation=api.types.TypeName('int'),
                 )
             ],
             variadic_args=False,
@@ -71,8 +78,12 @@ def test_extract_flexible(tmp_path: pathlib.Path) -> None:
         'func': api.Parameters(
             parameters=[
                 api.Parameter(
-                    name='x', positional=True, keyword=True, required=True, line=1,
-                    annotation=api.types.TypeName('int')
+                    name='x',
+                    positional=True,
+                    keyword=True,
+                    required=True,
+                    line=1,
+                    annotation=api.types.TypeName('int'),
                 )
             ],
             variadic_args=False,
@@ -91,8 +102,12 @@ def test_extract_flexible_with_default(tmp_path: pathlib.Path) -> None:
         'func': api.Parameters(
             parameters=[
                 api.Parameter(
-                    name='x', positional=True, keyword=True, required=False, line=1,
-                    annotation=api.types.TypeName('int')
+                    name='x',
+                    positional=True,
+                    keyword=True,
+                    required=False,
+                    line=1,
+                    annotation=api.types.TypeName('int'),
                 )
             ],
             variadic_args=False,
@@ -111,8 +126,12 @@ def test_extract_keyword(tmp_path: pathlib.Path) -> None:
         'func': api.Parameters(
             parameters=[
                 api.Parameter(
-                    name='x', positional=False, keyword=True, required=True, line=1,
-                    annotation=api.types.TypeName('int')
+                    name='x',
+                    positional=False,
+                    keyword=True,
+                    required=True,
+                    line=1,
+                    annotation=api.types.TypeName('int'),
                 )
             ],
             variadic_args=False,
@@ -131,8 +150,12 @@ def test_extract_keyword_with_default(tmp_path: pathlib.Path) -> None:
         'func': api.Parameters(
             parameters=[
                 api.Parameter(
-                    name='x', positional=False, keyword=True, required=False, line=1,
-                    annotation=api.types.TypeName('int')
+                    name='x',
+                    positional=False,
+                    keyword=True,
+                    required=False,
+                    line=1,
+                    annotation=api.types.TypeName('int'),
                 )
             ],
             variadic_args=False,
@@ -214,7 +237,7 @@ def test_extract_comprehensive(tmp_path: pathlib.Path) -> None:
                     keyword=False,
                     required=True,
                     line=3,
-                    annotation=api.types.TypeName('int')
+                    annotation=api.types.TypeName('int'),
                 ),
                 api.Parameter(
                     name='b',
@@ -222,7 +245,7 @@ def test_extract_comprehensive(tmp_path: pathlib.Path) -> None:
                     keyword=True,
                     required=False,
                     line=3,
-                    annotation=api.types.TypeName('float')
+                    annotation=api.types.TypeName('float'),
                 ),
                 api.Parameter(
                     name='c',
@@ -230,7 +253,7 @@ def test_extract_comprehensive(tmp_path: pathlib.Path) -> None:
                     keyword=True,
                     required=True,
                     line=3,
-                    annotation=api.types.TypeName('int')
+                    annotation=api.types.TypeName('int'),
                 ),
             ],
             variadic_args=True,

--- a/tools/stronghold/tests/api/test_ast.py
+++ b/tools/stronghold/tests/api/test_ast.py
@@ -35,7 +35,7 @@ def test_extract_positional(tmp_path: pathlib.Path) -> None:
                     keyword=False,
                     required=True,
                     line=1,
-                    annotation=api.types.TypeName('int'),
+                    type_annotation=api.types.TypeName('int'),
                 )
             ],
             variadic_args=False,
@@ -59,7 +59,7 @@ def test_extract_positional_with_default(tmp_path: pathlib.Path) -> None:
                     keyword=False,
                     required=False,
                     line=1,
-                    annotation=api.types.TypeName('int'),
+                    type_annotation=api.types.TypeName('int'),
                 )
             ],
             variadic_args=False,
@@ -83,7 +83,7 @@ def test_extract_flexible(tmp_path: pathlib.Path) -> None:
                     keyword=True,
                     required=True,
                     line=1,
-                    annotation=api.types.TypeName('int'),
+                    type_annotation=api.types.TypeName('int'),
                 )
             ],
             variadic_args=False,
@@ -107,7 +107,7 @@ def test_extract_flexible_with_default(tmp_path: pathlib.Path) -> None:
                     keyword=True,
                     required=False,
                     line=1,
-                    annotation=api.types.TypeName('int'),
+                    type_annotation=api.types.TypeName('int'),
                 )
             ],
             variadic_args=False,
@@ -131,7 +131,7 @@ def test_extract_keyword(tmp_path: pathlib.Path) -> None:
                     keyword=True,
                     required=True,
                     line=1,
-                    annotation=api.types.TypeName('int'),
+                    type_annotation=api.types.TypeName('int'),
                 )
             ],
             variadic_args=False,
@@ -155,7 +155,7 @@ def test_extract_keyword_with_default(tmp_path: pathlib.Path) -> None:
                     keyword=True,
                     required=False,
                     line=1,
-                    annotation=api.types.TypeName('int'),
+                    type_annotation=api.types.TypeName('int'),
                 )
             ],
             variadic_args=False,
@@ -237,7 +237,7 @@ def test_extract_comprehensive(tmp_path: pathlib.Path) -> None:
                     keyword=False,
                     required=True,
                     line=3,
-                    annotation=api.types.TypeName('int'),
+                    type_annotation=api.types.TypeName('int'),
                 ),
                 api.Parameter(
                     name='b',
@@ -245,7 +245,7 @@ def test_extract_comprehensive(tmp_path: pathlib.Path) -> None:
                     keyword=True,
                     required=False,
                     line=3,
-                    annotation=api.types.TypeName('float'),
+                    type_annotation=api.types.TypeName('float'),
                 ),
                 api.Parameter(
                     name='c',
@@ -253,7 +253,7 @@ def test_extract_comprehensive(tmp_path: pathlib.Path) -> None:
                     keyword=True,
                     required=True,
                     line=3,
-                    annotation=api.types.TypeName('int'),
+                    type_annotation=api.types.TypeName('int'),
                 ),
             ],
             variadic_args=True,

--- a/tools/stronghold/tests/api/test_ast_param_compatibility.py
+++ b/tools/stronghold/tests/api/test_ast_param_compatibility.py
@@ -1,231 +1,305 @@
 """Tests of the parameter types compatibility"""
 
-import api
-import api.ast
-import api.types
-from api.types import TypeHint, TypeName, Constant, Generic, Tuple, Attribute, Unknown
+from api.types import TypeName, Constant, Generic, Attribute, Unknown
 
-from src.api.compatibility import _check_type_compatibility
+from api.compatibility import _check_type_compatibility
 
 
 def test_none():
-    assert _check_type_compatibility(
-        TypeName('int'),
-        None
-    ) is True
+    assert _check_type_compatibility(TypeName('int'), None) is True
 
-    assert _check_type_compatibility(
-        None,
-        TypeName('int'),
-    ) is True
+    assert (
+        _check_type_compatibility(
+            None,
+            TypeName('int'),
+        )
+        is True
+    )
 
-    assert _check_type_compatibility(
-        None,
-        None,
-    ) is True
+    assert (
+        _check_type_compatibility(
+            None,
+            None,
+        )
+        is True
+    )
 
 
 def test_simple_types():
-    assert _check_type_compatibility(
-        TypeName('int'),
-        TypeName('int'),
-    ) is True
+    assert (
+        _check_type_compatibility(
+            TypeName('int'),
+            TypeName('int'),
+        )
+        is True
+    )
 
-    assert _check_type_compatibility(
-        TypeName('int'),
-        TypeName('str'),
-    ) is False
+    assert (
+        _check_type_compatibility(
+            TypeName('int'),
+            TypeName('str'),
+        )
+        is False
+    )
 
-    assert _check_type_compatibility(
-        Attribute(
-            value=TypeName('types'),
-            attr='Test',
-        ),
-        Attribute(
-            value=TypeName('types'),
-            attr='Test',
-        ),
-    ) is True
+    assert (
+        _check_type_compatibility(
+            Attribute(
+                value=TypeName('types'),
+                attr='Test',
+            ),
+            Attribute(
+                value=TypeName('types'),
+                attr='Test',
+            ),
+        )
+        is True
+    )
 
-    assert _check_type_compatibility(
-        Attribute(
-            value=TypeName('types'),
-            attr='Test',
-        ),
-        Attribute(
-            value=TypeName('types'),
-            attr='Test2',
-        ),
-    ) is False
+    assert (
+        _check_type_compatibility(
+            Attribute(
+                value=TypeName('types'),
+                attr='Test',
+            ),
+            Attribute(
+                value=TypeName('types'),
+                attr='Test2',
+            ),
+        )
+        is False
+    )
 
 
 def test_unknown_types():
-    assert _check_type_compatibility(
-        TypeName('int'),
-        Unknown('?'),
-    ) is True
+    assert (
+        _check_type_compatibility(
+            TypeName('int'),
+            Unknown('?'),
+        )
+        is True
+    )
 
-    assert _check_type_compatibility(
-        Unknown('?'),
-        TypeName('int'),
-    ) is True
+    assert (
+        _check_type_compatibility(
+            Unknown('?'),
+            TypeName('int'),
+        )
+        is True
+    )
 
 
 def test_constant_types():
-    assert _check_type_compatibility(
-        Constant('None'),
-        Constant('None'),
-    ) is True
+    assert (
+        _check_type_compatibility(
+            Constant('None'),
+            Constant('None'),
+        )
+        is True
+    )
 
-    assert _check_type_compatibility(
-        Constant('None'),
-        Constant('True'),
-    ) is False
+    assert (
+        _check_type_compatibility(
+            Constant('None'),
+            Constant('True'),
+        )
+        is False
+    )
 
-    assert _check_type_compatibility(
-        Constant('None'),
-        Constant('False'),
-    ) is False
+    assert (
+        _check_type_compatibility(
+            Constant('None'),
+            Constant('False'),
+        )
+        is False
+    )
 
-    assert _check_type_compatibility(
-        Constant('True'),
-        TypeName('bool'),
-    ) is True
+    assert (
+        _check_type_compatibility(
+            Constant('True'),
+            TypeName('bool'),
+        )
+        is True
+    )
 
     # note: asymmetry
-    assert _check_type_compatibility(
-        TypeName('bool'),
-        Constant('True'),
-    ) is False
+    assert (
+        _check_type_compatibility(
+            TypeName('bool'),
+            Constant('True'),
+        )
+        is False
+    )
 
     # note: not aware of the actual type
     # thus it is compatible with any type
-    assert _check_type_compatibility(
-        Constant('True'),
-        TypeName('int'),
-    ) is True
+    assert (
+        _check_type_compatibility(
+            Constant('True'),
+            TypeName('int'),
+        )
+        is True
+    )
 
 
 def test_generic_types():
-    assert _check_type_compatibility(
-        Generic(
-            base=TypeName('List'),
-            arguments=[TypeName('int')],
-        ),
-        Generic(
-            base=TypeName('List'),
-            arguments=[TypeName('int')],
-        ),
-    ) is True
-
-    assert _check_type_compatibility(
-        Generic(
-            base=TypeName('List'),
-            arguments=[TypeName('int')],
-        ),
-        Generic(
-            base=TypeName('List'),
-            arguments=[TypeName('str')],
-        ),
-    ) is False
-
-    assert _check_type_compatibility(
-        Generic(
-            base=TypeName('List'),
-            arguments=[TypeName('int')],
-        ),
-        Generic(
-            base=TypeName('Tuple'),
-            arguments=[TypeName('int')],
-        ),
-    ) is False
-
-    assert _check_type_compatibility(
-        Generic(
-            base=TypeName('List'),
-            arguments=[TypeName('int'), TypeName('str')],
-        ),
-        Generic(
-            base=TypeName('List'),
-            arguments=[TypeName('str'), TypeName('int')],
-        ),
-    ) is False
-
-    assert _check_type_compatibility(
-        Generic(
-            base=TypeName('List'),
-            arguments=[TypeName('int'), TypeName('str')],
-        ),
-        Generic(
-            base=TypeName('List'),
-            arguments=[TypeName('int'), TypeName('str')],
-        ),
-    ) is True
-
-    assert _check_type_compatibility(
-        Generic(
-            base=TypeName('List'),
-            arguments=[TypeName('int'), TypeName('str')],
-        ),
-        Generic(
-            base=TypeName('List'),
-            arguments=[TypeName('int')],
-        ),
-    ) is False
-
-    assert _check_type_compatibility(
-        Generic(
-            base=TypeName('List'),
-            arguments=[TypeName('int')],
-        ),
-        Generic(
-            base=TypeName('List'),
-            arguments=[Unknown('?')],
-        ),
-    ) is True
-
-    assert _check_type_compatibility(
-        Generic(
-            base=TypeName('List'),
-            arguments=[Unknown('?')],
-        ),
-        Generic(
-            base=TypeName('List'),
-            arguments=[TypeName('int')],
-        ),
-    ) is True
-
-    # recursive types
-    assert _check_type_compatibility(
-        Generic(
-            base=TypeName('List'),
-            arguments=[Generic(
+    assert (
+        _check_type_compatibility(
+            Generic(
                 base=TypeName('List'),
                 arguments=[TypeName('int')],
-            )],
-        ),
-        Generic(
-            base=TypeName('List'),
-            arguments=[Generic(
+            ),
+            Generic(
                 base=TypeName('List'),
                 arguments=[TypeName('int')],
-            )],
-        ),
-    ) is True
+            ),
+        )
+        is True
+    )
 
-    assert _check_type_compatibility(
-        Generic(
-            base=TypeName('List'),
-            arguments=[Generic(
+    assert (
+        _check_type_compatibility(
+            Generic(
                 base=TypeName('List'),
                 arguments=[TypeName('int')],
-            )],
-        ),
-        Generic(
-            base=TypeName('List'),
-            arguments=[Generic(
+            ),
+            Generic(
                 base=TypeName('List'),
                 arguments=[TypeName('str')],
-            )],
-        ),
-    ) is False
+            ),
+        )
+        is False
+    )
+
+    assert (
+        _check_type_compatibility(
+            Generic(
+                base=TypeName('List'),
+                arguments=[TypeName('int')],
+            ),
+            Generic(
+                base=TypeName('Tuple'),
+                arguments=[TypeName('int')],
+            ),
+        )
+        is False
+    )
+
+    assert (
+        _check_type_compatibility(
+            Generic(
+                base=TypeName('List'),
+                arguments=[TypeName('int'), TypeName('str')],
+            ),
+            Generic(
+                base=TypeName('List'),
+                arguments=[TypeName('str'), TypeName('int')],
+            ),
+        )
+        is False
+    )
+
+    assert (
+        _check_type_compatibility(
+            Generic(
+                base=TypeName('List'),
+                arguments=[TypeName('int'), TypeName('str')],
+            ),
+            Generic(
+                base=TypeName('List'),
+                arguments=[TypeName('int'), TypeName('str')],
+            ),
+        )
+        is True
+    )
+
+    assert (
+        _check_type_compatibility(
+            Generic(
+                base=TypeName('List'),
+                arguments=[TypeName('int'), TypeName('str')],
+            ),
+            Generic(
+                base=TypeName('List'),
+                arguments=[TypeName('int')],
+            ),
+        )
+        is False
+    )
+
+    assert (
+        _check_type_compatibility(
+            Generic(
+                base=TypeName('List'),
+                arguments=[TypeName('int')],
+            ),
+            Generic(
+                base=TypeName('List'),
+                arguments=[Unknown('?')],
+            ),
+        )
+        is True
+    )
+
+    assert (
+        _check_type_compatibility(
+            Generic(
+                base=TypeName('List'),
+                arguments=[Unknown('?')],
+            ),
+            Generic(
+                base=TypeName('List'),
+                arguments=[TypeName('int')],
+            ),
+        )
+        is True
+    )
+
+    # recursive types
+    assert (
+        _check_type_compatibility(
+            Generic(
+                base=TypeName('List'),
+                arguments=[
+                    Generic(
+                        base=TypeName('List'),
+                        arguments=[TypeName('int')],
+                    )
+                ],
+            ),
+            Generic(
+                base=TypeName('List'),
+                arguments=[
+                    Generic(
+                        base=TypeName('List'),
+                        arguments=[TypeName('int')],
+                    )
+                ],
+            ),
+        )
+        is True
+    )
+
+    assert (
+        _check_type_compatibility(
+            Generic(
+                base=TypeName('List'),
+                arguments=[
+                    Generic(
+                        base=TypeName('List'),
+                        arguments=[TypeName('int')],
+                    )
+                ],
+            ),
+            Generic(
+                base=TypeName('List'),
+                arguments=[
+                    Generic(
+                        base=TypeName('List'),
+                        arguments=[TypeName('str')],
+                    )
+                ],
+            ),
+        )
+        is False
+    )

--- a/tools/stronghold/tests/api/test_ast_param_compatibility.py
+++ b/tools/stronghold/tests/api/test_ast_param_compatibility.py
@@ -5,7 +5,7 @@ from api.types import TypeName, Constant, Generic, Attribute, Unknown
 from api.compatibility import _check_type_compatibility
 
 
-def test_none():
+def test_none() -> None:
     assert _check_type_compatibility(TypeName('int'), None) is True
 
     assert (
@@ -25,7 +25,7 @@ def test_none():
     )
 
 
-def test_simple_types():
+def test_simple_types() -> None:
     assert (
         _check_type_compatibility(
             TypeName('int'),
@@ -71,7 +71,7 @@ def test_simple_types():
     )
 
 
-def test_unknown_types():
+def test_unknown_types() -> None:
     assert (
         _check_type_compatibility(
             TypeName('int'),
@@ -89,7 +89,7 @@ def test_unknown_types():
     )
 
 
-def test_constant_types():
+def test_constant_types() -> None:
     assert (
         _check_type_compatibility(
             Constant('None'),
@@ -142,7 +142,7 @@ def test_constant_types():
     )
 
 
-def test_generic_types():
+def test_generic_types() -> None:
     assert (
         _check_type_compatibility(
             Generic(

--- a/tools/stronghold/tests/api/test_ast_param_compatibility.py
+++ b/tools/stronghold/tests/api/test_ast_param_compatibility.py
@@ -1,0 +1,231 @@
+"""Tests of the parameter types compatibility"""
+
+import api
+import api.ast
+import api.types
+from api.types import TypeHint, TypeName, Constant, Generic, Tuple, Attribute, Unknown
+
+from src.api.compatibility import _check_type_compatibility
+
+
+def test_none():
+    assert _check_type_compatibility(
+        TypeName('int'),
+        None
+    ) is True
+
+    assert _check_type_compatibility(
+        None,
+        TypeName('int'),
+    ) is True
+
+    assert _check_type_compatibility(
+        None,
+        None,
+    ) is True
+
+
+def test_simple_types():
+    assert _check_type_compatibility(
+        TypeName('int'),
+        TypeName('int'),
+    ) is True
+
+    assert _check_type_compatibility(
+        TypeName('int'),
+        TypeName('str'),
+    ) is False
+
+    assert _check_type_compatibility(
+        Attribute(
+            value=TypeName('types'),
+            attr='Test',
+        ),
+        Attribute(
+            value=TypeName('types'),
+            attr='Test',
+        ),
+    ) is True
+
+    assert _check_type_compatibility(
+        Attribute(
+            value=TypeName('types'),
+            attr='Test',
+        ),
+        Attribute(
+            value=TypeName('types'),
+            attr='Test2',
+        ),
+    ) is False
+
+
+def test_unknown_types():
+    assert _check_type_compatibility(
+        TypeName('int'),
+        Unknown('?'),
+    ) is True
+
+    assert _check_type_compatibility(
+        Unknown('?'),
+        TypeName('int'),
+    ) is True
+
+
+def test_constant_types():
+    assert _check_type_compatibility(
+        Constant('None'),
+        Constant('None'),
+    ) is True
+
+    assert _check_type_compatibility(
+        Constant('None'),
+        Constant('True'),
+    ) is False
+
+    assert _check_type_compatibility(
+        Constant('None'),
+        Constant('False'),
+    ) is False
+
+    assert _check_type_compatibility(
+        Constant('True'),
+        TypeName('bool'),
+    ) is True
+
+    # note: asymmetry
+    assert _check_type_compatibility(
+        TypeName('bool'),
+        Constant('True'),
+    ) is False
+
+    # note: not aware of the actual type
+    # thus it is compatible with any type
+    assert _check_type_compatibility(
+        Constant('True'),
+        TypeName('int'),
+    ) is True
+
+
+def test_generic_types():
+    assert _check_type_compatibility(
+        Generic(
+            base=TypeName('List'),
+            arguments=[TypeName('int')],
+        ),
+        Generic(
+            base=TypeName('List'),
+            arguments=[TypeName('int')],
+        ),
+    ) is True
+
+    assert _check_type_compatibility(
+        Generic(
+            base=TypeName('List'),
+            arguments=[TypeName('int')],
+        ),
+        Generic(
+            base=TypeName('List'),
+            arguments=[TypeName('str')],
+        ),
+    ) is False
+
+    assert _check_type_compatibility(
+        Generic(
+            base=TypeName('List'),
+            arguments=[TypeName('int')],
+        ),
+        Generic(
+            base=TypeName('Tuple'),
+            arguments=[TypeName('int')],
+        ),
+    ) is False
+
+    assert _check_type_compatibility(
+        Generic(
+            base=TypeName('List'),
+            arguments=[TypeName('int'), TypeName('str')],
+        ),
+        Generic(
+            base=TypeName('List'),
+            arguments=[TypeName('str'), TypeName('int')],
+        ),
+    ) is False
+
+    assert _check_type_compatibility(
+        Generic(
+            base=TypeName('List'),
+            arguments=[TypeName('int'), TypeName('str')],
+        ),
+        Generic(
+            base=TypeName('List'),
+            arguments=[TypeName('int'), TypeName('str')],
+        ),
+    ) is True
+
+    assert _check_type_compatibility(
+        Generic(
+            base=TypeName('List'),
+            arguments=[TypeName('int'), TypeName('str')],
+        ),
+        Generic(
+            base=TypeName('List'),
+            arguments=[TypeName('int')],
+        ),
+    ) is False
+
+    assert _check_type_compatibility(
+        Generic(
+            base=TypeName('List'),
+            arguments=[TypeName('int')],
+        ),
+        Generic(
+            base=TypeName('List'),
+            arguments=[Unknown('?')],
+        ),
+    ) is True
+
+    assert _check_type_compatibility(
+        Generic(
+            base=TypeName('List'),
+            arguments=[Unknown('?')],
+        ),
+        Generic(
+            base=TypeName('List'),
+            arguments=[TypeName('int')],
+        ),
+    ) is True
+
+    # recursive types
+    assert _check_type_compatibility(
+        Generic(
+            base=TypeName('List'),
+            arguments=[Generic(
+                base=TypeName('List'),
+                arguments=[TypeName('int')],
+            )],
+        ),
+        Generic(
+            base=TypeName('List'),
+            arguments=[Generic(
+                base=TypeName('List'),
+                arguments=[TypeName('int')],
+            )],
+        ),
+    ) is True
+
+    assert _check_type_compatibility(
+        Generic(
+            base=TypeName('List'),
+            arguments=[Generic(
+                base=TypeName('List'),
+                arguments=[TypeName('int')],
+            )],
+        ),
+        Generic(
+            base=TypeName('List'),
+            arguments=[Generic(
+                base=TypeName('List'),
+                arguments=[TypeName('str')],
+            )],
+        ),
+    ) is False

--- a/tools/stronghold/tests/api/test_ast_param_types.py
+++ b/tools/stronghold/tests/api/test_ast_param_types.py
@@ -1,7 +1,7 @@
 """Tests the api.ast module, specific to parameter types."""
 
 import pathlib
-from typing import List, Optional, Dict, Tuple, Union
+from typing import List, Optional, Dict, Tuple
 
 import api
 import api.ast
@@ -25,6 +25,7 @@ def test_none(tmp_path: pathlib.Path) -> None:
     params = extractParameterTypes(source.make_file(tmp_path, func))
     assert params == [None]
 
+
 def test_named_types(tmp_path: pathlib.Path) -> None:
     def func(a: int, b: float, c: List, /):
         pass  # pragma: no cover
@@ -35,6 +36,7 @@ def test_named_types(tmp_path: pathlib.Path) -> None:
         api.types.TypeName('float'),
         api.types.TypeName('List'),
     ]
+
 
 def test_constant_types(tmp_path: pathlib.Path) -> None:
     def func(a: None, b: True, c: False, /):
@@ -49,7 +51,9 @@ def test_constant_types(tmp_path: pathlib.Path) -> None:
 
 
 def test_generic_types(tmp_path: pathlib.Path) -> None:
-    def func(a: List[int], b: Dict[str, int], c: Tuple[int, str], d: List[Dict[str, int]], /):
+    def func(
+        a: List[int], b: Dict[str, int], c: Tuple[int, str], d: List[Dict[str, int]], /
+    ):
         pass
 
     params = extractParameterTypes(source.make_file(tmp_path, func))

--- a/tools/stronghold/tests/api/test_ast_param_types.py
+++ b/tools/stronghold/tests/api/test_ast_param_types.py
@@ -10,7 +10,9 @@ import api.types
 from testing import source
 
 
-def extractParameterTypes(tmp_path: pathlib.Path) -> List[Optional[api.types.TypeHint]]:
+def extract_parameter_types(
+    tmp_path: pathlib.Path,
+) -> List[Optional[api.types.TypeHint]]:
     """Extracts the parameter types from a function definition."""
     funcs = api.ast.extract(tmp_path)
     if not funcs:
@@ -19,18 +21,18 @@ def extractParameterTypes(tmp_path: pathlib.Path) -> List[Optional[api.types.Typ
 
 
 def test_none(tmp_path: pathlib.Path) -> None:
-    def func(a, /):
+    def func(a, /) -> None:  # type: ignore
         pass  # pragma: no cover
 
-    params = extractParameterTypes(source.make_file(tmp_path, func))
+    params = extract_parameter_types(source.make_file(tmp_path, func))
     assert params == [None]
 
 
 def test_named_types(tmp_path: pathlib.Path) -> None:
-    def func(a: int, b: float, c: List, /):
+    def func(a: int, b: float, c: List, /) -> None:  # type: ignore
         pass  # pragma: no cover
 
-    params = extractParameterTypes(source.make_file(tmp_path, func))
+    params = extract_parameter_types(source.make_file(tmp_path, func))
     assert params == [
         api.types.TypeName('int'),
         api.types.TypeName('float'),
@@ -39,10 +41,10 @@ def test_named_types(tmp_path: pathlib.Path) -> None:
 
 
 def test_constant_types(tmp_path: pathlib.Path) -> None:
-    def func(a: None, b: True, c: False, /):
+    def func(a: None, b: True, c: False, /) -> None:  # type: ignore
         pass  # pragma: no cover
 
-    params = extractParameterTypes(source.make_file(tmp_path, func))
+    params = extract_parameter_types(source.make_file(tmp_path, func))
     assert params == [
         api.types.Constant('None'),
         api.types.Constant('True'),
@@ -53,10 +55,10 @@ def test_constant_types(tmp_path: pathlib.Path) -> None:
 def test_generic_types(tmp_path: pathlib.Path) -> None:
     def func(
         a: List[int], b: Dict[str, int], c: Tuple[int, str], d: List[Dict[str, int]], /
-    ):
+    ) -> None:
         pass
 
-    params = extractParameterTypes(source.make_file(tmp_path, func))
+    params = extract_parameter_types(source.make_file(tmp_path, func))
     assert params == [
         api.types.Generic(
             base=api.types.TypeName('List'),
@@ -83,10 +85,10 @@ def test_generic_types(tmp_path: pathlib.Path) -> None:
 
 
 def test_attribute_types(tmp_path: pathlib.Path) -> None:
-    def func(a: api.types.TypeName, b: api.types.Attribute, /):
+    def func(a: api.types.TypeName, b: api.types.Attribute, /) -> None:
         pass
 
-    params = extractParameterTypes(source.make_file(tmp_path, func))
+    params = extract_parameter_types(source.make_file(tmp_path, func))
     assert params == [
         api.types.Attribute(
             value=api.types.Attribute(
@@ -106,13 +108,13 @@ def test_attribute_types(tmp_path: pathlib.Path) -> None:
 
 
 def test_unknown_types(tmp_path: pathlib.Path) -> None:
-    def func2():
+    def func2() -> None:
         pass
 
-    def func1(a: func2(), b: lambda x: x, /):
+    def func1(a: func2(), b: lambda x: x, /) -> None:  # type: ignore
         pass
 
-    params = extractParameterTypes(source.make_file(tmp_path, func1))
+    params = extract_parameter_types(source.make_file(tmp_path, func1))
 
     assert len(params) == 2
     assert isinstance(params[0], api.types.Unknown)

--- a/tools/stronghold/tests/api/test_ast_param_types.py
+++ b/tools/stronghold/tests/api/test_ast_param_types.py
@@ -1,0 +1,115 @@
+"""Tests the api.ast module, specific to parameter types."""
+
+import pathlib
+from typing import List, Optional, Dict, Tuple, Union
+
+import api
+import api.ast
+import api.types
+
+from testing import source
+
+
+def extractParameterTypes(tmp_path: pathlib.Path) -> List[Optional[api.types.TypeHint]]:
+    """Extracts the parameter types from a function definition."""
+    funcs = api.ast.extract(tmp_path)
+    if not funcs:
+        return []
+    return [param.annotation for func in funcs.values() for param in func.parameters]
+
+
+def test_none(tmp_path: pathlib.Path) -> None:
+    def func(a, /):
+        pass  # pragma: no cover
+
+    params = extractParameterTypes(source.make_file(tmp_path, func))
+    assert params == [None]
+
+def test_named_types(tmp_path: pathlib.Path) -> None:
+    def func(a: int, b: float, c: List, /):
+        pass  # pragma: no cover
+
+    params = extractParameterTypes(source.make_file(tmp_path, func))
+    assert params == [
+        api.types.TypeName('int'),
+        api.types.TypeName('float'),
+        api.types.TypeName('List'),
+    ]
+
+def test_constant_types(tmp_path: pathlib.Path) -> None:
+    def func(a: None, b: True, c: False, /):
+        pass  # pragma: no cover
+
+    params = extractParameterTypes(source.make_file(tmp_path, func))
+    assert params == [
+        api.types.Constant('None'),
+        api.types.Constant('True'),
+        api.types.Constant('False'),
+    ]
+
+
+def test_generic_types(tmp_path: pathlib.Path) -> None:
+    def func(a: List[int], b: Dict[str, int], c: Tuple[int, str], d: List[Dict[str, int]], /):
+        pass
+
+    params = extractParameterTypes(source.make_file(tmp_path, func))
+    assert params == [
+        api.types.Generic(
+            base=api.types.TypeName('List'),
+            arguments=[api.types.TypeName('int')],
+        ),
+        api.types.Generic(
+            base=api.types.TypeName('Dict'),
+            arguments=[api.types.TypeName('str'), api.types.TypeName('int')],
+        ),
+        api.types.Generic(
+            base=api.types.TypeName('Tuple'),
+            arguments=[api.types.TypeName('int'), api.types.TypeName('str')],
+        ),
+        api.types.Generic(
+            base=api.types.TypeName('List'),
+            arguments=[
+                api.types.Generic(
+                    base=api.types.TypeName('Dict'),
+                    arguments=[api.types.TypeName('str'), api.types.TypeName('int')],
+                )
+            ],
+        ),
+    ]
+
+
+def test_attribute_types(tmp_path: pathlib.Path) -> None:
+    def func(a: api.types.TypeName, b: api.types.Attribute, /):
+        pass
+
+    params = extractParameterTypes(source.make_file(tmp_path, func))
+    assert params == [
+        api.types.Attribute(
+            value=api.types.Attribute(
+                value=api.types.TypeName('api'),
+                attr='types',
+            ),
+            attr='TypeName',
+        ),
+        api.types.Attribute(
+            value=api.types.Attribute(
+                value=api.types.TypeName('api'),
+                attr='types',
+            ),
+            attr='Attribute',
+        ),
+    ]
+
+
+def test_unknown_types(tmp_path: pathlib.Path) -> None:
+    def func2():
+        pass
+
+    def func1(a: func2(), b: lambda x: x, /):
+        pass
+
+    params = extractParameterTypes(source.make_file(tmp_path, func1))
+
+    assert len(params) == 2
+    assert isinstance(params[0], api.types.Unknown)
+    assert isinstance(params[1], api.types.Unknown)

--- a/tools/stronghold/tests/api/test_ast_param_types.py
+++ b/tools/stronghold/tests/api/test_ast_param_types.py
@@ -17,7 +17,9 @@ def extract_parameter_types(
     funcs = api.ast.extract(tmp_path)
     if not funcs:
         return []
-    return [param.annotation for func in funcs.values() for param in func.parameters]
+    return [
+        param.type_annotation for func in funcs.values() for param in func.parameters
+    ]
 
 
 def test_none(tmp_path: pathlib.Path) -> None:

--- a/tools/stronghold/tests/api/test_compatibility.py
+++ b/tools/stronghold/tests/api/test_compatibility.py
@@ -431,8 +431,11 @@ def test_parameter_type_change_positional(tmp_path: pathlib.Path) -> None:
 
     assert api.compatibility.check(before, after) == [
         api.violations.ParameterTypeChanged(
-            func=func.__name__, parameter="a", line=1,
-            type_before='int', type_after='str',
+            func=func.__name__,
+            parameter="a",
+            line=1,
+            type_before='int',
+            type_after='str',
         )
     ]
 
@@ -450,8 +453,11 @@ def test_parameter_type_change_named(tmp_path: pathlib.Path) -> None:
 
     assert api.compatibility.check(before, after) == [
         api.violations.ParameterTypeChanged(
-            func=func.__name__, parameter="a", line=1,
-            type_before='int', type_after='str',
+            func=func.__name__,
+            parameter="a",
+            line=1,
+            type_before='int',
+            type_after='str',
         )
     ]
 


### PR DESCRIPTION
Adds basic extracting and checking for the change of types in function parameters.


The BC-linter failures are unrelated (the GH action test-infra is using is outdated and picking up base branch changes, to be fix in a separate PR).

Retroactive tested on 1000 recent PT, here are the NEW type-related failures:

| Commit Message |PR | Note |
| :--- |:--- |:--- |
| \[FSDP\]\[ez\] Type optimizer correctly \(#102637\)\\... | pytorch/pytorch#102637 | Legit type change |
| Make DataParallel generic \(#102455\)\\n\\nFixes #... | pytorch/pytorch#102455 | False-positive (linter doesn't understand that type was expanded in this case) |