### PR TITLE
Skip failing models from geomean computation and don't clip passing ones to 1.0

### DIFF
--- a/torchci/components/metrics/panels/TablePanel.tsx
+++ b/torchci/components/metrics/panels/TablePanel.tsx
@@ -2,6 +2,8 @@ import useSWR from "swr";
 import { DataGrid, DataGridProps, GridColDef } from "@mui/x-data-grid";
 import { Typography, Skeleton } from "@mui/material";
 import { RocksetParam } from "lib/rockset";
+import HelpIcon from "@mui/icons-material/Help";
+import IconButton from "@mui/material/IconButton";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
@@ -18,6 +20,8 @@ export default function TablePanel({
   columns,
   // Props to propagate to the data grid.
   dataGridProps,
+  // An optional help link to display in the title
+  helpLink,
 }: {
   title: string;
   queryCollection?: string;
@@ -25,6 +29,7 @@ export default function TablePanel({
   queryParams: RocksetParam[];
   columns: GridColDef[];
   dataGridProps: any;
+  helpLink?: string;
 }) {
   const url = `/api/query/${queryCollection}/${queryName}?parameters=${encodeURIComponent(
     JSON.stringify(queryParams)
@@ -40,6 +45,7 @@ export default function TablePanel({
       data={data}
       columns={columns}
       dataGridProps={dataGridProps}
+      helpLink={helpLink}
     />
   );
 }
@@ -53,20 +59,32 @@ export function TablePanelWithData({
   columns,
   // Props to propagate to the data grid.
   dataGridProps,
+  // An optional help link to display in the title
+  helpLink,
 }: {
   title: string;
   data: any;
   columns: GridColDef[];
   dataGridProps: any;
+  helpLink?: string;
 }) {
   if (data === undefined) {
     return <Skeleton variant={"rectangular"} height={"100%"} />;
   }
 
+  function helpLinkOnClick() {
+    window.open(helpLink, "_blank");
+  }
+
   function Header() {
     return (
       <Typography fontSize="16px" fontWeight="700" sx={{ p: 1 }}>
-        {title}
+        {title}{" "}
+        {helpLink !== undefined && (
+          <IconButton size="small" onClick={helpLinkOnClick}>
+            <HelpIcon fontSize="inherit" color="info" />
+          </IconButton>
+        )}
       </Typography>
     );
   }

--- a/torchci/package.json
+++ b/torchci/package.json
@@ -19,6 +19,7 @@
     "@codemirror/view": "^0.20.7",
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
+    "@mui/icons-material": "^5.11.16",
     "@mui/lab": "^5.0.0-alpha.78",
     "@mui/material": "^5.6.2",
     "@mui/x-data-grid": "^5.9.0",

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -53,6 +53,7 @@ import {
   COMMIT_TO_WORKFLOW_ID,
   WORKFLOW_ID_TO_COMMIT,
   SHA_DISPLAY_LENGTH,
+  HELP_LINK,
 } from "../../compilers";
 import { CompilerPerformanceData } from "lib/types";
 import styles from "components/metrics.module.css";

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -43,6 +43,10 @@ const ROW_GAP = 100;
 const ROW_HEIGHT = 38;
 const PASSRATE_DISPLAY_NAME_REGEX = new RegExp("^([0-9]+)%,\\s.+$");
 
+// A help link to explain the metrics used in the dashboard
+export const HELP_LINK =
+  "https://pytorch.org/docs/main/compile/performance-dashboard.html";
+
 export const SHA_DISPLAY_LENGTH = 10;
 export const LAST_N_DAYS = 7;
 export const HUD_PREFIX = "/pytorch/pytorch/commit";
@@ -79,10 +83,6 @@ export const ACCURACY_THRESHOLD = 90.0;
 export const SPEEDUP_THRESHOLD = 0.95;
 export const COMPILATION_lATENCY_THRESHOLD_IN_SECONDS = 120;
 export const COMPRESSION_RATIO_THRESHOLD = 0.9;
-
-// When calculating geomean, all the values are clipped to the lower bound of 1.0
-// because if the speed up is less than 1.0, one can use eager mode instead
-export const GEOMEAN_LOWER_BOUND = 1.0;
 
 // The number of digit after decimal to display on the summary page
 const SCALE = 2;
@@ -237,7 +237,7 @@ function geomean(data: number[]) {
 
   var gm = 1.0;
   data.forEach((v) => {
-    gm *= v < GEOMEAN_LOWER_BOUND ? GEOMEAN_LOWER_BOUND : v;
+    gm *= v;
   });
   return Math.pow(gm, 1.0 / data.length).toFixed(SCALE);
 }
@@ -278,14 +278,12 @@ function computeGeomean(
       speedup[bucket][workflowId][suite][compiler] = [];
     }
 
-    let speedupValue = GEOMEAN_LOWER_BOUND;
     if (
       isPass(bucket, workflowId, suite, compiler, model, passingModels) &&
       record.speedup !== 0.0
     ) {
-      speedupValue = record.speedup;
+      speedup[bucket][workflowId][suite][compiler].push(record.speedup);
     }
-    speedup[bucket][workflowId][suite][compiler].push(speedupValue);
   });
 
   Object.keys(speedup).forEach((bucket: string) => {
@@ -1007,6 +1005,7 @@ function SummaryPanel({
                 ? PASSRATE_HEADER
                 : `${PASSRATE_HEADER} ${DIFF_HEADER}`
             }
+            helpLink={HELP_LINK}
             data={Object.values(passrate).sort((a: any, b: any) =>
               a["compiler"].localeCompare(b["compiler"])
             )}
@@ -1095,6 +1094,7 @@ function SummaryPanel({
         >
           <TablePanelWithData
             title={GEOMEAN_HEADER}
+            helpLink={HELP_LINK}
             data={Object.values(geomean).sort((a: any, b: any) =>
               a["compiler"].localeCompare(b["compiler"])
             )}
@@ -1186,6 +1186,7 @@ function SummaryPanel({
         >
           <TablePanelWithData
             title={COMPILATION_LATENCY_HEADER}
+            helpLink={HELP_LINK}
             data={Object.values(compTime).sort((a: any, b: any) =>
               a["compiler"].localeCompare(b["compiler"])
             )}
@@ -1290,6 +1291,7 @@ function SummaryPanel({
         >
           <TablePanelWithData
             title={MEMORY_HEADER}
+            helpLink={HELP_LINK}
             data={Object.values(memory).sort((a: any, b: any) =>
               a["compiler"].localeCompare(b["compiler"])
             )}

--- a/torchci/yarn.lock
+++ b/torchci/yarn.lock
@@ -1686,6 +1686,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.21.0":
+  version "7.22.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.3.tgz#0a7fce51d43adbf0f7b517a71f4c3aaca92ebcbb"
+  integrity sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.16.7", "@babel/template@^7.3.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -2277,6 +2284,13 @@
   version "5.10.3"
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.10.3.tgz#e17a3cd87c7814ff35592284b19ae39ad52b85ac"
   integrity sha512-mX2S0d1oboKBbWQqWIgRmyALAEzh37yiknpD3mKx8bcoMKbp1VtqzIt0aeHP16Uhsd0eValDFILxLNHWi0oddQ==
+
+"@mui/icons-material@^5.11.16":
+  version "5.11.16"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.11.16.tgz#417fa773c56672e39d6ccfed9ac55591985f0d38"
+  integrity sha512-oKkx9z9Kwg40NtcIajF9uOXhxiyTZrrm9nmIJ4UjkU2IdHpd4QVLbCc/5hZN/y0C6qzi2Zlxyr9TGddQx2vx2A==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
 
 "@mui/lab@^5.0.0-alpha.78":
   version "5.0.0-alpha.78"


### PR DESCRIPTION
Fixes https://github.com/pytorch/test-infra/issues/4270

* Skip all failing models with 0 speedup. This reverts https://github.com/pytorch/test-infra/pull/4240
* Calculate geomean using the actual speedup values instead of clipping them to `>= 1.0`
* Add a clickable help icon pointing to https://pytorch.org/docs/main/compile/performance-dashboard.html to explain metrics in the dashboard

### Testing
https://torchci-git-fork-huydhn-unclip-geomean-fbopensource.vercel.app/benchmark/compilers