### PR TITLE
Clean up leftover git processes when tearing down Windows

### DIFF
--- a/.github/actions/cleanup-runner/action.yml
+++ b/.github/actions/cleanup-runner/action.yml
@@ -13,7 +13,7 @@ runs:
         # This needs to be run before checking out PyTorch to avoid locking the working directory.
         # Below is the list of commands that could lock $GITHUB_WORKSPACE gathered from sysinternals
         # handle tool
-        $processes = "python", "ninja", "cl", "nvcc", "cmd", "sccache"
+        $processes = "python", "ninja", "cl", "nvcc", "cmd", "sccache", "git"
         Foreach ($process In $processes) {
           Try {
             # https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/stop-process


### PR DESCRIPTION
I think this is the root cause of this flaky issue on Windows https://github.com/pytorch/pytorch/actions/runs/5201383887/jobs/9381449915 in which the runner couldn't checkout the actions it needs, for example `The process cannot access the file 'C:\actions-runner\_work\_actions\pytorch\pytorch\main\caffe2\operators\quantized' because it is being used by another process.`

Looking at the previous job on the same runner https://github.com/pytorch/pytorch/actions/runs/5201112432/jobs/9380804301, the process that locks the file was `git`:

```
git.exe                            git.exe -c protocol.version=2 submodule update --init --force --recursive                                                                                                                                                                                                            5064       

sh.exe                             sh "C:/Program Files/Git/mingw64/libexec/git-core\\git-submodule" update --init --force --recursive                                                                                                                                                                                  4376       

sh.exe                             sh "C:/Program Files/Git/mingw64/libexec/git-core\\git-submodule" update --init --force --recursive                                                                                                                                                                                  5844       

git.exe                            "C:\Program Files\Git\mingw64\libexec\git-core\git.exe" submodule--helper update --force --recursive --init --                                                                                                                                                                       5456       

git.exe                            git checkout -q -f a33701196adfad74917046096bf5a2aa0ab0bb50                                                                                                                                                                                                                          3228  
```