### PR TITLE
[TorchFix] Add range-arange codemod

### DIFF
--- a/tools/torchfix/tests/fixtures/codemod/range-arange.py
+++ b/tools/torchfix/tests/fixtures/codemod/range-arange.py
@@ -1,0 +1,33 @@
+import torch
+torch.range(0, 1)
+torch.range(-4, -2)
+torch.range(0, 6, 2)
+torch.range(4, 2, -2)
+torch.range(0, -5, -1)
+torch.range(start=0, end=1)
+torch.range(end=1, start=0)
+
+res2 = torch.Tensor()
+torch.range(4, 29, out=res2)
+res3 = torch.Tensor()
+torch.range(1, 0, -1, out=res3)
+res4 = torch.range(-2, -1)
+
+features_size = 5
+torch.range(0, features_size - 1)
+torch.range(0, features_size - 2)
+torch.range(0, 2 * features_size - features_size - 1)
+
+torch.range(start=0, end=features_size - 1)
+torch.range(start=0, end=-1 + features_size)
+
+dim = 5
+torch.range(1, dim, dtype=torch.long)
+torch.range(1, dim + 1, dtype=torch.long)
+torch.range(1, end=dim, step=1, dtype=torch.long)
+
+# will not codemod
+torch.range(0, 1, 1.0)
+torch.range(-4, -2, 1 + 0)
+torch.range(0, 6, 2.0)
+torch.range(4, 2, 0 - 2)

--- a/tools/torchfix/tests/fixtures/codemod/range-arange.py.out
+++ b/tools/torchfix/tests/fixtures/codemod/range-arange.py.out
@@ -1,0 +1,33 @@
+import torch
+torch.arange(0, 2)
+torch.arange(-4, -1)
+torch.arange(0, 8, 2)
+torch.arange(4, 0, -2)
+torch.arange(0, -6, -1)
+torch.arange(start=0, end=2)
+torch.arange(end=2, start=0)
+
+res2 = torch.Tensor()
+torch.arange(4, 30, out=res2)
+res3 = torch.Tensor()
+torch.arange(1, -1, -1, out=res3)
+res4 = torch.arange(-2, 0)
+
+features_size = 5
+torch.arange(0, features_size)
+torch.arange(0, features_size - 2 + 1)
+torch.arange(0, 2 * features_size - features_size)
+
+torch.arange(start=0, end=features_size)
+torch.arange(start=0, end=-1 + features_size + 1)
+
+dim = 5
+torch.arange(1, dim + 1, dtype=torch.long)
+torch.arange(1, dim + 1 + 1, dtype=torch.long)
+torch.arange(1, end=dim + 1, step=1, dtype=torch.long)
+
+# will not codemod
+torch.range(0, 1, 1.0)
+torch.range(-4, -2, 1 + 0)
+torch.range(0, 6, 2.0)
+torch.range(4, 2, 0 - 2)

--- a/tools/torchfix/torchfix/torchfix.py
+++ b/tools/torchfix/torchfix/torchfix.py
@@ -9,7 +9,6 @@ import argparse
 import contextlib
 import io
 import sys
-from typing import Optional
 
 __version__ = "0.0.1"
 
@@ -95,7 +94,7 @@ class TorchVisitor(cst.CSTVisitor):
             replacement = node.with_deep_changes(old_node=node.func.attr, value="outer")
 
         # Replace `range` with `arange`.
-        # Add `step` to the `end` argument as for `arange` the interval is `[start, end)`.
+        # Add `step` to the `end` argument as `arange` has the interval `[start, end)`.
         if qualified_name == "torch.range":
             end_arg, step_arg = _get_range_args(node)
             step = 1

--- a/tools/torchfix/torchfix/torchfix.py
+++ b/tools/torchfix/torchfix/torchfix.py
@@ -2,12 +2,14 @@ from pathlib import Path
 import yaml
 import libcst as cst
 import libcst.codemod as codemod
+import libcst.matchers as m
 from dataclasses import dataclass
-from typing import Optional, List
+from typing import Optional, List, Tuple
 import argparse
 import contextlib
 import io
 import sys
+from typing import Optional
 
 __version__ = "0.0.1"
 
@@ -59,6 +61,131 @@ class TorchVisitor(cst.CSTVisitor):
         cst.metadata.WhitespaceInclusivePositionProvider,
     )
 
+    def _call_replacement(self, node: cst.Call, qualified_name) -> cst.Call:
+
+        # `torch.range` documented signature is not a valid Python signature,
+        # so it's hard to generalize this.
+        def _get_range_args(node: cst.Call) -> Tuple[cst.Arg, Optional[cst.Arg]]:
+            "Return (`end`, `step`) from a `range` call"
+            end_arg = None
+            step_arg = None
+            non_kw_args = []
+            for arg in node.args:
+                if arg.keyword is None:
+                    non_kw_args.append(arg)
+                else:
+                    if arg.keyword.value == "end":
+                        end_arg = arg
+                    elif arg.keyword.value == "step":
+                        step_arg = arg
+
+            if end_arg is None:
+                if len(non_kw_args) == 1:
+                    end_arg = non_kw_args[0]
+                elif len(non_kw_args) == 2:
+                    end_arg = non_kw_args[1]
+                elif len(non_kw_args) == 3:
+                    end_arg = non_kw_args[1]
+                    step_arg = non_kw_args[2]
+
+            return end_arg, step_arg
+
+        replacement = None
+        if qualified_name == "torch.ger":
+            replacement = node.with_deep_changes(old_node=node.func.attr, value="outer")
+
+        # Replace `range` with `arange`.
+        # Add `step` to the `end` argument as for `arange` the interval is `[start, end)`.
+        if qualified_name == "torch.range":
+            end_arg, step_arg = _get_range_args(node)
+            step = 1
+            if step_arg is not None:
+                # `step` is a literal integer
+                if isinstance(step_arg.value, cst.Integer):
+                    step = int(step_arg.value.value)
+
+                # `step` is unary minus and an integer (i.e. negative integer)
+                elif m.matches(
+                    step_arg,
+                    m.Arg(
+                        value=m.UnaryOperation(
+                            operator=m.Minus(), expression=m.Integer()
+                        )
+                    ),
+                ):
+                    step = -int(step_arg.value.expression.value)
+
+                # Bail out, don't know how to update with non-integer `step`.
+                else:
+                    return None
+
+            updated_end_arg = None
+
+            # `end` is a literal (positive) integer
+            if isinstance(end_arg.value, cst.Integer):
+                end = int(end_arg.value.value) + step
+                if end >= 0:
+                    updated_end_arg = end_arg.with_deep_changes(
+                        old_node=end_arg.value, value=str(end)
+                    )
+                else:
+                    # `end` became negative
+                    updated_end_arg = end_arg.with_changes(
+                        value=cst.UnaryOperation(
+                            operator=cst.Minus(),
+                            expression=cst.Integer(value=str(-end)),
+                        )
+                    )
+
+            # `end` is a unary minus and an integer (i.e. negative integer)
+            elif m.matches(
+                end_arg,
+                m.Arg(
+                    value=m.UnaryOperation(operator=m.Minus(), expression=m.Integer())
+                ),
+            ):
+                end = -int(end_arg.value.expression.value) + step
+                if end < 0:
+                    updated_end_arg = end_arg.with_deep_changes(
+                        old_node=end_arg.value.expression, value=str(-end)
+                    )
+                else:
+                    # `end` became non-negative
+                    updated_end_arg = end_arg.with_changes(
+                        value=cst.Integer(value=str(end))
+                    )
+
+            # `end` is an expression with `- 1` at the end: remove the `- 1`.
+            # This is a common occurrence, thus special handling.
+            elif m.matches(
+                end_arg,
+                m.Arg(
+                    value=m.BinaryOperation(
+                        operator=m.Subtract(), right=m.Integer(value="1")
+                    )
+                ),
+            ):
+                updated_end_arg = end_arg.with_changes(value=end_arg.value.left)
+
+            # `end` something else: add `+ 1` at the end
+            else:
+                updated_end_arg = end_arg.with_changes(
+                    value=cst.BinaryOperation(
+                        left=end_arg.value,
+                        operator=cst.Add(),
+                        right=cst.Integer(value="1"),
+                    )
+                )
+
+            replacement = node
+            if updated_end_arg is not None:
+                replacement = replacement.deep_replace(end_arg, updated_end_arg)
+            replacement = replacement.with_deep_changes(
+                old_node=replacement.func.attr, value="arange"
+            )
+
+        return replacement
+
     def __init__(self, deprecated_config=None):
         self.deprecated_config = {} if deprecated_config is None else deprecated_config
         self.violations: List[LintViolation] = []
@@ -82,11 +209,7 @@ class TorchVisitor(cst.CSTVisitor):
                 error_code = "TOR001"
                 message = f"Use of removed function {qualified_name}"
 
-            replacement = None
-            if qualified_name == "torch.ger":
-                replacement = node.with_deep_changes(
-                    old_node=node.func.attr, value="outer"
-                )
+            replacement = self._call_replacement(node, qualified_name)
 
             self.violations.append(
                 LintViolation(


### PR DESCRIPTION
The `torch.range` is deprecated, and in the replacement `torch.arange` the `end` parameter is not inclusive.