### PR TITLE
Add dependency downloads to alert upload GHA

### DIFF
--- a/.github/actions/upload-alerts/action.yml
+++ b/.github/actions/upload-alerts/action.yml
@@ -27,7 +27,7 @@ runs:
 
     - name: Run Script to Upload Alerts
       shell: bash
-      if: github.event_name != 'pull_request'
+      # if: github.event_name != 'pull_request'
       run: |
        python _test-infra/tools/scripts/upload_alerts_to_aws.py --alerts '${{ inputs.alerts }}' --org "${{ inputs.organization }}" --repo "${{ inputs.repo }}"
 

--- a/.github/actions/upload-alerts/action.yml
+++ b/.github/actions/upload-alerts/action.yml
@@ -19,7 +19,12 @@ runs:
       with:
         repository: pytorch/test-infra
         path: _test-infra
-
+    - name: Install Dependencies
+      run: |
+        pip3 install jsonschema
+        pip3 install boto3==1.19.12
+        pip3 install rockset==1.0.3
+      shell: bash
     - name: Run Script to Validate Alerts
       shell: bash
       run: | 

--- a/.github/actions/upload-alerts/action.yml
+++ b/.github/actions/upload-alerts/action.yml
@@ -23,13 +23,13 @@ runs:
     - name: Run Script to Validate Alerts
       shell: bash
       run: | 
-        python _test-infra/tools/scripts/validate_alerts.py --alerts '${{ inputs.alerts }}'
+        python3 _test-infra/tools/scripts/validate_alerts.py --alerts '${{ inputs.alerts }}'
 
     - name: Run Script to Upload Alerts
       shell: bash
       # if: github.event_name != 'pull_request'
       run: |
-       python _test-infra/tools/scripts/upload_alerts_to_aws.py --alerts '${{ inputs.alerts }}' --org "${{ inputs.organization }}" --repo "${{ inputs.repo }}"
+       python3 _test-infra/tools/scripts/upload_alerts_to_aws.py --alerts '${{ inputs.alerts }}' --org "${{ inputs.organization }}" --repo "${{ inputs.repo }}"
 
     - name: Cleanup
       run: |

--- a/.github/actions/upload-alerts/action.yml
+++ b/.github/actions/upload-alerts/action.yml
@@ -32,7 +32,7 @@ runs:
 
     - name: Run Script to Upload Alerts
       shell: bash
-      # if: github.event_name != 'pull_request'
+      if: github.event_name != 'pull_request'
       run: |
        python3 _test-infra/tools/scripts/upload_alerts_to_aws.py --alerts '${{ inputs.alerts }}' --org "${{ inputs.organization }}" --repo "${{ inputs.repo }}"
 

--- a/tools/scripts/upload_alerts_to_aws.py
+++ b/tools/scripts/upload_alerts_to_aws.py
@@ -6,7 +6,6 @@ import gzip
 import io
 import json
 import os
-import xml.etree.ElementTree as ET
 from typing import Any, Dict, List
 
 import boto3  # type: ignore[import]


### PR DESCRIPTION
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cd91d04</samp>

> _`xml.etree` gone_
> _upload alerts with python3_
> _action more robust_
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cd91d04</samp>

This pull request improves the GitHub action for uploading alerts by installing dependencies and using python3, and cleans up the `upload_alerts_to_aws.py` script by removing an unused import.