### PR TITLE
Fix after #4269

### DIFF
--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -485,8 +485,8 @@ function GroupedHudTable({
     names = [...data.jobNames];
     groups.forEach((group) => {
       if (
-        (groupNames.includes(group.name) && group.persistent) ||
-        (isUnstableGroup(group.name) && hideUnstable)
+        groupNames.includes(group.name) &&
+        (group.persistent || (isUnstableGroup(group.name) && hideUnstable))
       ) {
         // Add group name, take out all the jobs that belong to that group
         // unless the group is expanded


### PR DESCRIPTION
Accidentally broke hud view for other repos + branches after https://github.com/pytorch/test-infra/pull/4269 due to unstable being included in the job names