### PR TITLE
[TorchFix] Add functorch deprecation linter/codemod

### DIFF
--- a/tools/torchfix/tests/fixtures/codemod/functorch.py
+++ b/tools/torchfix/tests/fixtures/codemod/functorch.py
@@ -45,3 +45,10 @@ def f():
     jacfwd()
     hessian()
     functionalize()
+
+# Don't modify, as some symbols are not in func.torch.
+from functorch import (
+    make_functional_with_buffers as make_functional_functorch,
+    vmap,
+)
+from functorch import FunctionalModule, FunctionalModuleWithBuffers

--- a/tools/torchfix/tests/fixtures/codemod/functorch.py
+++ b/tools/torchfix/tests/fixtures/codemod/functorch.py
@@ -24,6 +24,7 @@ print(result)
 
 # Non-runnable, just to check name changes.
 def f():
+    td_out = functorch.vmap(tdmodule, (None, 0))(td, params)
     functorch.vmap()
     functorch.grad()
     functorch.vjp()
@@ -35,6 +36,7 @@ def f():
 
 # Don't modify these, change the imports in the beginning
 def f():
+    td_out = vmap(tdmodule, (None, 0))(td, params)
     vmap()
     grad()
     vjp()

--- a/tools/torchfix/tests/fixtures/codemod/functorch.py
+++ b/tools/torchfix/tests/fixtures/codemod/functorch.py
@@ -1,0 +1,24 @@
+import torch
+import functorch
+
+batch_size, feature_size = 3, 5
+weights = torch.randn(feature_size, requires_grad=True)
+
+def model(feature_vec):
+    # Very simple linear model with activation
+    return feature_vec.dot(weights).relu()
+
+examples = torch.randn(batch_size, feature_size)
+result = functorch.vmap(model)(examples)
+print(result)
+
+# Non-runnable, just to check name changes.
+def f():
+    functorch.vmap()
+    functorch.grad()
+    functorch.vjp()
+    functorch.jvp()
+    functorch.jacrev()
+    functorch.jacfwd()
+    functorch.hessian()
+    functorch.functionalize()

--- a/tools/torchfix/tests/fixtures/codemod/functorch.py
+++ b/tools/torchfix/tests/fixtures/codemod/functorch.py
@@ -1,5 +1,15 @@
 import torch
 import functorch
+from functorch import (
+    vmap,
+    grad,
+    vjp,
+    jvp,
+    jacrev,
+    jacfwd,
+    hessian,
+    functionalize,
+)
 
 batch_size, feature_size = 3, 5
 weights = torch.randn(feature_size, requires_grad=True)
@@ -22,3 +32,14 @@ def f():
     functorch.jacfwd()
     functorch.hessian()
     functorch.functionalize()
+
+# Don't modify these, change the imports in the beginning
+def f():
+    vmap()
+    grad()
+    vjp()
+    jvp()
+    jacrev()
+    jacfwd()
+    hessian()
+    functionalize()

--- a/tools/torchfix/tests/fixtures/codemod/functorch.py.out
+++ b/tools/torchfix/tests/fixtures/codemod/functorch.py.out
@@ -45,3 +45,10 @@ def f():
     jacfwd()
     hessian()
     functionalize()
+
+# Don't modify, as some symbols are not in func.torch.
+from functorch import (
+    make_functional_with_buffers as make_functional_functorch,
+    vmap,
+)
+from functorch import FunctionalModule, FunctionalModuleWithBuffers

--- a/tools/torchfix/tests/fixtures/codemod/functorch.py.out
+++ b/tools/torchfix/tests/fixtures/codemod/functorch.py.out
@@ -1,5 +1,15 @@
 import torch
 import functorch
+from torch.func import (
+    vmap,
+    grad,
+    vjp,
+    jvp,
+    jacrev,
+    jacfwd,
+    hessian,
+    functionalize,
+)
 
 batch_size, feature_size = 3, 5
 weights = torch.randn(feature_size, requires_grad=True)
@@ -22,3 +32,14 @@ def f():
     torch.func.jacfwd()
     torch.func.hessian()
     torch.func.functionalize()
+
+# Don't modify these, change the imports in the beginning
+def f():
+    vmap()
+    grad()
+    vjp()
+    jvp()
+    jacrev()
+    jacfwd()
+    hessian()
+    functionalize()

--- a/tools/torchfix/tests/fixtures/codemod/functorch.py.out
+++ b/tools/torchfix/tests/fixtures/codemod/functorch.py.out
@@ -1,0 +1,24 @@
+import torch
+import functorch
+
+batch_size, feature_size = 3, 5
+weights = torch.randn(feature_size, requires_grad=True)
+
+def model(feature_vec):
+    # Very simple linear model with activation
+    return feature_vec.dot(weights).relu()
+
+examples = torch.randn(batch_size, feature_size)
+result = torch.func.vmap(examples)
+print(result)
+
+# Non-runnable, just to check name changes.
+def f():
+    torch.func.vmap()
+    torch.func.grad()
+    torch.func.vjp()
+    torch.func.jvp()
+    torch.func.jacrev()
+    torch.func.jacfwd()
+    torch.func.hessian()
+    torch.func.functionalize()

--- a/tools/torchfix/tests/fixtures/codemod/functorch.py.out
+++ b/tools/torchfix/tests/fixtures/codemod/functorch.py.out
@@ -19,11 +19,12 @@ def model(feature_vec):
     return feature_vec.dot(weights).relu()
 
 examples = torch.randn(batch_size, feature_size)
-result = torch.func.vmap(examples)
+result = torch.func.vmap(model)(examples)
 print(result)
 
 # Non-runnable, just to check name changes.
 def f():
+    td_out = torch.func.vmap(tdmodule, (None, 0))(td, params)
     torch.func.vmap()
     torch.func.grad()
     torch.func.vjp()
@@ -35,6 +36,7 @@ def f():
 
 # Don't modify these, change the imports in the beginning
 def f():
+    td_out = vmap(tdmodule, (None, 0))(td, params)
     vmap()
     grad()
     vjp()

--- a/tools/torchfix/torchfix/deprecated_symbols.yaml
+++ b/tools/torchfix/torchfix/deprecated_symbols.yaml
@@ -17,6 +17,7 @@
 - name: torch.ger
   deprecate_pr: TBA
   remove_pr:
+  replacement: torch.outer
 
 - name: torch.lu_solve
   deprecate_pr: TBA
@@ -53,3 +54,44 @@
 - name: torch.testing.assert_allclose
   deprecate_pr: TBA
   remove_pr:
+
+# functorch
+- name: functorch.vmap
+  deprecate_pr: TBA
+  remove_pr:
+  replacement: torch.func.vmap
+
+- name: functorch.grad
+  deprecate_pr: TBA
+  remove_pr:
+  replacement: torch.func.grad
+
+- name: functorch.vjp
+  deprecate_pr: TBA
+  remove_pr:
+  replacement: torch.func.vjp
+
+- name: functorch.jvp
+  deprecate_pr: TBA
+  remove_pr:
+  replacement: torch.func.jvp
+
+- name: functorch.jacrev
+  deprecate_pr: TBA
+  remove_pr:
+  replacement: torch.func.jacrev
+
+- name: functorch.jacfwd
+  deprecate_pr: TBA
+  remove_pr:
+  replacement: torch.func.jacfwd
+
+- name: functorch.hessian
+  deprecate_pr: TBA
+  remove_pr:
+  replacement: torch.func.hessian
+
+- name: functorch.functionalize
+  deprecate_pr: TBA
+  remove_pr:
+  replacement: torch.func.functionalize

--- a/tools/torchfix/torchfix/torchfix.py
+++ b/tools/torchfix/torchfix/torchfix.py
@@ -61,6 +61,23 @@ class TorchVisitor(cst.CSTVisitor):
     )
 
     def _call_replacement(self, node: cst.Call, qualified_name) -> cst.Call:
+        def call_with_name_changes(
+            node: cst.Call, old_qualified_name: str, new_qualified_name: str
+        ) -> cst.Call:
+            # If the only difference is the last name part.
+            if (
+                old_qualified_name.rpartition(".")[0]
+                == new_qualified_name.rpartition(".")[0]
+            ):
+                replacement = node.with_deep_changes(
+                    old_node=node.func.attr,
+                    value=function_name_replacement.rpartition(".")[-1],
+                )
+            else:
+                replacement = node.with_changes(
+                    func=cst.parse_expression(new_qualified_name)
+                )
+            return replacement
 
         # `torch.range` documented signature is not a valid Python signature,
         # so it's hard to generalize this.
@@ -90,8 +107,15 @@ class TorchVisitor(cst.CSTVisitor):
             return end_arg, step_arg
 
         replacement = None
-        if qualified_name == "torch.ger":
-            replacement = node.with_deep_changes(old_node=node.func.attr, value="outer")
+
+        # Replace names for functions that have drop-in replacement.
+        function_name_replacement = self.deprecated_config.get(qualified_name, {}).get(
+            "replacement", ""
+        )
+        if function_name_replacement:
+            replacement = call_with_name_changes(
+                node, qualified_name, function_name_replacement
+            )
 
         # Replace `range` with `arange`.
         # Add `step` to the `end` argument as `arange` has the interval `[start, end)`.
@@ -304,6 +328,13 @@ def main() -> None:
         type=int,
         default=None,
     )
+    # XXX TODO: Get rid of this!
+    # Silence "Failed to determine module name"
+    # https://github.com/Instagram/LibCST/issues/944
+    parser.add_argument(
+        "--ignore-stderr",
+        action="store_true",
+    )
 
     args = parser.parse_args()
 
@@ -311,10 +342,11 @@ def main() -> None:
     command_instance = TorchCodemod(codemod.CodemodContext())
     DIFF_CONTEXT = 5
     try:
-        # XXX TODO: Get rid of this!
-        # Silence "Failed to determine module name"
-        # https://github.com/Instagram/LibCST/issues/944
-        with contextlib.redirect_stderr(io.StringIO()):
+        if args.ignore_stderr:
+            context = contextlib.redirect_stderr(io.StringIO())
+        else:
+            context = contextlib.nullcontext()
+        with context:
             result = codemod.parallel_exec_transform_with_prettyprint(
                 command_instance,
                 files,


### PR DESCRIPTION
According to the https://pytorch.org/docs/main/func.migrating.html

The codemod doesn't try to remove `import functorch` because if it's not used, it can be removed by existing tolls like Ruff.