### PR TITLE
Update PT2 dashboard high-lighting rules

### DIFF
--- a/torchci/lib/bot/cliParser.ts
+++ b/torchci/lib/bot/cliParser.ts
@@ -42,16 +42,16 @@ const merge = commands.add_parser("merge", {
 const mergeOption = merge.add_mutually_exclusive_group();
 mergeOption.add_argument("-f", "--force", {
   metavar: "MESSAGE",
-  help: `Merge without checking anything. This requires a reason for auditting purpose, for example:
+  help:
+    `Merge without checking anything. This requires a reason for auditting purpose, for example:
 @pytorchbot merge -f 'Minor update to fix lint. Expecting all PR tests to pass'` +
-"\n\n" +
-"Please use `-f` as last resort, prefer `--ignore-current` to continue the merge ignoring current failures. " +
-"This will allow currently pending tests to finish and report signal before the merge.",
+    "\n\n" +
+    "Please use `-f` as last resort, prefer `--ignore-current` to continue the merge ignoring current failures. " +
+    "This will allow currently pending tests to finish and report signal before the merge.",
 });
 mergeOption.add_argument("-i", "--ignore-current", {
   action: "store_true",
-  help:
-    "Merge while ignoring the currently failing jobs.  Behaves like -f if there are no pending jobs.",
+  help: "Merge while ignoring the currently failing jobs.  Behaves like -f if there are no pending jobs.",
 });
 merge.add_argument("-ic", {
   action: "store_true",

--- a/torchci/lib/bot/cliParser.ts
+++ b/torchci/lib/bot/cliParser.ts
@@ -42,16 +42,16 @@ const merge = commands.add_parser("merge", {
 const mergeOption = merge.add_mutually_exclusive_group();
 mergeOption.add_argument("-f", "--force", {
   metavar: "MESSAGE",
-  help:
-    `Merge without checking anything. This requires a reason for auditting purpose, for example:
+  help: `Merge without checking anything. This requires a reason for auditting purpose, for example:
 @pytorchbot merge -f 'Minor update to fix lint. Expecting all PR tests to pass'` +
-    "\n\n" +
-    "Please use `-f` as last resort, prefer `--ignore-current` to continue the merge ignoring current failures. " +
-    "This will allow currently pending tests to finish and report signal before the merge.",
+"\n\n" +
+"Please use `-f` as last resort, prefer `--ignore-current` to continue the merge ignoring current failures. " +
+"This will allow currently pending tests to finish and report signal before the merge.",
 });
 mergeOption.add_argument("-i", "--ignore-current", {
   action: "store_true",
-  help: "Merge while ignoring the currently failing jobs.  Behaves like -f if there are no pending jobs.",
+  help:
+    "Merge while ignoring the currently failing jobs.  Behaves like -f if there are no pending jobs.",
 });
 merge.add_argument("-ic", {
   action: "store_true",

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -238,7 +238,7 @@ The explanation needs to be clear on why this is needed. Here are some good exam
     forceMessage: string,
     ignore_current: boolean,
     rebase: string | boolean,
-    ic: boolean
+    ic: boolean,
   ) {
     const extra_data = {
       forceMessage,
@@ -259,8 +259,7 @@ The explanation needs to be clear on why this is needed. Here are some good exam
     }
 
     if (ic) {
-      rejection_reason =
-        "`-ic` flag is deprecated, please use `-i` instead for the same effect.";
+      rejection_reason = "`-ic` flag is deprecated, please use `-i` instead for the same effect."
     }
 
     if (rejection_reason) {

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -238,7 +238,7 @@ The explanation needs to be clear on why this is needed. Here are some good exam
     forceMessage: string,
     ignore_current: boolean,
     rebase: string | boolean,
-    ic: boolean,
+    ic: boolean
   ) {
     const extra_data = {
       forceMessage,
@@ -259,7 +259,8 @@ The explanation needs to be clear on why this is needed. Here are some good exam
     }
 
     if (ic) {
-      rejection_reason = "`-ic` flag is deprecated, please use `-i` instead for the same effect."
+      rejection_reason =
+        "`-ic` flag is deprecated, please use `-i` instead for the same effect.";
     }
 
     if (rejection_reason) {

--- a/torchci/lib/useGroupingPreference.tsx
+++ b/torchci/lib/useGroupingPreference.tsx
@@ -20,7 +20,7 @@ export function usePreference(
   return [state, setStatePersist];
 }
 
-export function useGroupingPreference(
+export  function useGroupingPreference(
   hasParams: boolean
 ): [boolean, (grouping: boolean) => void] {
   const override = hasParams ? false : undefined;

--- a/torchci/lib/useGroupingPreference.tsx
+++ b/torchci/lib/useGroupingPreference.tsx
@@ -20,7 +20,7 @@ export function usePreference(
   return [state, setStatePersist];
 }
 
-export  function useGroupingPreference(
+export function useGroupingPreference(
   hasParams: boolean
 ): [boolean, (grouping: boolean) => void] {
   const override = hasParams ? false : undefined;

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -422,12 +422,12 @@ function ModelPanel({
                   }
 
                   // Increasing more than x%
-                  if (l - r > (1.0 - SPEEDUP_THRESHOLD) * r) {
+                  if (l - r > RELATIVE_THRESHOLD * r) {
                     return styles.ok;
                   }
 
                   // Decreasing more than x%
-                  if (r - l > (1.0 - SPEEDUP_THRESHOLD) * r) {
+                  if (r - l > RELATIVE_THRESHOLD * r) {
                     return styles.error;
                   }
                 }
@@ -478,12 +478,12 @@ function ModelPanel({
                   }
 
                   // Decreasing more than x%
-                  if (r - l > (1.0 - COMPILATION_lATENCY_THRESHOLD) * r) {
+                  if (r - l > RELATIVE_THRESHOLD * r) {
                     return styles.ok;
                   }
 
                   // Increasing more than x%
-                  if (l - r > (1.0 - COMPILATION_lATENCY_THRESHOLD) * r) {
+                  if (l - r > RELATIVE_THRESHOLD * r) {
                     return styles.error;
                   }
 
@@ -536,12 +536,12 @@ function ModelPanel({
                   }
 
                   // Increasing more than x%
-                  if (l - r > (1.0 - COMPRESSION_RATIO_THRESHOLD) * r) {
+                  if (l - r > RELATIVE_THRESHOLD * r) {
                     return styles.ok;
                   }
 
                   // Decreasing more than x%
-                  if (r - l > (1.0 - COMPRESSION_RATIO_THRESHOLD) * r) {
+                  if (r - l > RELATIVE_THRESHOLD * r) {
                     return styles.error;
                   }
                 }

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -54,7 +54,7 @@ import {
   WORKFLOW_ID_TO_COMMIT,
   SHA_DISPLAY_LENGTH,
   HELP_LINK,
-  COMPILATION_lATENCY_THRESHOLD,
+  RELATIVE_THRESHOLD,
 } from "../../compilers";
 import { CompilerPerformanceData } from "lib/types";
 import styles from "components/metrics.module.css";

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -67,7 +67,7 @@ const ROW_HEIGHT = 38;
 const ACCURACY_HEADER = "Accuracy";
 const SPEEDUP_HEADER = `Performance speedup (threshold = ${SPEEDUP_THRESHOLD}x)`;
 const ABS_LATENCY_HEADER = `Absolute execution time (millisecond)`;
-const COMPILATION_LATENCY_HEADER = `Compilation latency in seconds`;
+const COMPILATION_LATENCY_HEADER = `Compilation latency (seconds)`;
 const MEMORY_HEADER = `Peak memory compression ratio (threshold = ${COMPRESSION_RATIO_THRESHOLD}x)`;
 
 // The number of digit after decimal to display on the detail page
@@ -558,6 +558,33 @@ function ModelPanel({
               headerName: ABS_LATENCY_HEADER,
               flex: 1,
               cellClassName: (params: GridCellParams<any>) => {
+                const v = params.value;
+                if (v === undefined || v.r === 0) {
+                  return "";
+                }
+
+                const l = Number(v.l);
+                const r = Number(v.r);
+
+                if (lCommit === rCommit) {
+                  return "";
+                } else {
+                  if (l === 0 || l === r) {
+                    // 0 means the model isn't run at all
+                    return "";
+                  }
+
+                  // Decreasing more than x%
+                  if (r - l > RELATIVE_THRESHOLD * r) {
+                    return styles.ok;
+                  }
+
+                  // Increasing more than x%
+                  if (l - r > RELATIVE_THRESHOLD * r) {
+                    return styles.error;
+                  }
+                }
+
                 return "";
               },
               renderCell: (params: GridRenderCellParams<any>) => {

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -41,7 +41,6 @@ import {
   MAIN_BRANCH,
   DEFAULT_BRANCHES,
   SPEEDUP_THRESHOLD,
-  COMPILATION_lATENCY_THRESHOLD_IN_SECONDS,
   COMPRESSION_RATIO_THRESHOLD,
   PASSING_ACCURACY,
   DIFF_HEADER,
@@ -68,7 +67,7 @@ const ROW_HEIGHT = 38;
 const ACCURACY_HEADER = "Accuracy";
 const SPEEDUP_HEADER = `Performance speedup (threshold = ${SPEEDUP_THRESHOLD}x)`;
 const ABS_LATENCY_HEADER = `Absolute execution time (millisecond)`;
-const COMPILATION_LATENCY_HEADER = `Compilation latency in seconds (threshold = ${COMPILATION_lATENCY_THRESHOLD_IN_SECONDS}s)`;
+const COMPILATION_LATENCY_HEADER = `Compilation latency in seconds`;
 const MEMORY_HEADER = `Peak memory compression ratio (threshold = ${COMPRESSION_RATIO_THRESHOLD}x)`;
 
 // The number of digit after decimal to display on the detail page
@@ -464,9 +463,7 @@ function ModelPanel({
                 const r = Number(v.r);
 
                 if (lCommit === rCommit) {
-                  return l > COMPILATION_lATENCY_THRESHOLD_IN_SECONDS
-                    ? styles.warning
-                    : "";
+                  return "";
                 } else {
                   if (l === 0 || l === r) {
                     // 0 means the model isn't run at all
@@ -481,10 +478,6 @@ function ModelPanel({
                   // Increasing more than x%
                   if (l - r > RELATIVE_THRESHOLD * r) {
                     return styles.error;
-                  }
-
-                  if (l > COMPILATION_lATENCY_THRESHOLD_IN_SECONDS) {
-                    return styles.warning;
                   }
                 }
 

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -54,6 +54,7 @@ import {
   WORKFLOW_ID_TO_COMMIT,
   SHA_DISPLAY_LENGTH,
   HELP_LINK,
+  COMPILATION_lATENCY_THRESHOLD,
 } from "../../compilers";
 import { CompilerPerformanceData } from "lib/types";
 import styles from "components/metrics.module.css";
@@ -415,26 +416,18 @@ function ModelPanel({
                 if (lCommit === rCommit) {
                   return l >= SPEEDUP_THRESHOLD ? "" : styles.warning;
                 } else {
-                  if (l === 0) {
-                    // This means the model isn't run at all
+                  if (l === 0 || l === r) {
+                    // 0 means the model isn't run at all
                     return "";
                   }
 
-                  if (l >= SPEEDUP_THRESHOLD && r < SPEEDUP_THRESHOLD) {
+                  // Increasing more than x%
+                  if (l - r > (1.0 - SPEEDUP_THRESHOLD) * r) {
                     return styles.ok;
                   }
 
-                  if (l < SPEEDUP_THRESHOLD && r >= SPEEDUP_THRESHOLD) {
-                    return styles.error;
-                  }
-
-                  if ((l === 0 && r === 0) || l === r) {
-                    return "";
-                  }
-
-                  // If the value decreases more than SPEEDUP_THRESHOLD, this also needs to be marked
-                  // as a regression
-                  if (r * SPEEDUP_THRESHOLD > l) {
+                  // Decreasing more than x%
+                  if (r - l > (1.0 - SPEEDUP_THRESHOLD) * r) {
                     return styles.error;
                   }
                 }
@@ -479,33 +472,22 @@ function ModelPanel({
                     ? styles.warning
                     : "";
                 } else {
-                  if (l === 0) {
-                    // This means the model isn't run at all
+                  if (l === 0 || l === r) {
+                    // 0 means the model isn't run at all
                     return "";
                   }
 
-                  if (
-                    l <= COMPILATION_lATENCY_THRESHOLD_IN_SECONDS &&
-                    r > COMPILATION_lATENCY_THRESHOLD_IN_SECONDS
-                  ) {
+                  // Decreasing more than x%
+                  if (r - l > (1.0 - COMPILATION_lATENCY_THRESHOLD) * r) {
                     return styles.ok;
                   }
 
-                  if (
-                    l > COMPILATION_lATENCY_THRESHOLD_IN_SECONDS &&
-                    r <= COMPILATION_lATENCY_THRESHOLD_IN_SECONDS
-                  ) {
+                  // Increasing more than x%
+                  if (l - r > (1.0 - COMPILATION_lATENCY_THRESHOLD) * r) {
                     return styles.error;
                   }
 
-                  if (l === r) {
-                    return "";
-                  }
-
-                  if (
-                    l > COMPILATION_lATENCY_THRESHOLD_IN_SECONDS &&
-                    r > COMPILATION_lATENCY_THRESHOLD_IN_SECONDS
-                  ) {
+                  if (l > COMPILATION_lATENCY_THRESHOLD_IN_SECONDS) {
                     return styles.warning;
                   }
                 }
@@ -548,32 +530,18 @@ function ModelPanel({
                 if (lCommit === rCommit) {
                   return l >= COMPRESSION_RATIO_THRESHOLD ? "" : styles.warning;
                 } else {
-                  if (l === 0) {
-                    // This means the model isn't run at all
+                  if (l === 0 || l === r) {
+                    // 0 means the model isn't run at all
                     return "";
                   }
 
-                  if (
-                    l >= COMPRESSION_RATIO_THRESHOLD &&
-                    r < COMPRESSION_RATIO_THRESHOLD
-                  ) {
+                  // Increasing more than x%
+                  if (l - r > (1.0 - COMPRESSION_RATIO_THRESHOLD) * r) {
                     return styles.ok;
                   }
 
-                  if (
-                    l < COMPRESSION_RATIO_THRESHOLD &&
-                    r >= COMPRESSION_RATIO_THRESHOLD
-                  ) {
-                    return styles.error;
-                  }
-
-                  if ((l === 0 && r === 0) || l === r) {
-                    return "";
-                  }
-
-                  // If the value decreases more than SPEEDUP_THRESHOLD, this also needs to be marked
-                  // as a regression
-                  if (r * COMPRESSION_RATIO_THRESHOLD > l) {
+                  // Decreasing more than x%
+                  if (r - l > (1.0 - COMPRESSION_RATIO_THRESHOLD) * r) {
                     return styles.error;
                   }
                 }

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -544,6 +544,10 @@ function ModelPanel({
                   if (r - l > RELATIVE_THRESHOLD * r) {
                     return styles.error;
                   }
+
+                  if (l < COMPRESSION_RATIO_THRESHOLD) {
+                    return styles.warning;
+                  }
                 }
 
                 return "";

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -446,11 +446,7 @@ function ModelPanel({
                 if (lCommit === rCommit || l === r || v.r === 0) {
                   return l;
                 } else {
-                  return `${r} → ${l} ${
-                    Number(l) < Number(r) && Number(r) != 0 && Number(l) != 0
-                      ? "\uD83D\uDD3B"
-                      : ""
-                  }`;
+                  return `${r} → ${l}`;
                 }
               },
             },
@@ -506,11 +502,7 @@ function ModelPanel({
                 if (lCommit === rCommit || l === r || v.r === 0) {
                   return l;
                 } else {
-                  return `${r} → ${l} ${
-                    Number(l) > Number(r) && Number(r) != 0 && Number(l) != 0
-                      ? "\uD83D\uDD3A"
-                      : ""
-                  }`;
+                  return `${r} → ${l}`;
                 }
               },
             },
@@ -564,11 +556,7 @@ function ModelPanel({
                 if (lCommit === rCommit || l === r || v.r === 0) {
                   return l;
                 } else {
-                  return `${r} → ${l} ${
-                    Number(l) < Number(r) && Number(r) != 0 && Number(l) != 0
-                      ? "\uD83D\uDD3B"
-                      : ""
-                  }`;
+                  return `${r} → ${l}`;
                 }
               },
             },

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -84,7 +84,6 @@ export const RELATIVE_THRESHOLD = 0.05;
 // Thresholds
 export const ACCURACY_THRESHOLD = 90.0;
 export const SPEEDUP_THRESHOLD = 0.95;
-export const COMPILATION_lATENCY_THRESHOLD_IN_SECONDS = 120;
 export const COMPRESSION_RATIO_THRESHOLD = 0.9;
 
 // The number of digit after decimal to display on the summary page
@@ -94,7 +93,7 @@ const SCALE = 2;
 export const DIFF_HEADER = "Base value (L) → New value (R)";
 const PASSRATE_HEADER = `Passrate (threshold = ${ACCURACY_THRESHOLD}%)`;
 const GEOMEAN_HEADER = `Geometric mean speedup (threshold = ${SPEEDUP_THRESHOLD}x)`;
-const COMPILATION_LATENCY_HEADER = `Mean compilation time (seconds) (threshold = ${COMPILATION_lATENCY_THRESHOLD_IN_SECONDS}s)`;
+const COMPILATION_LATENCY_HEADER = `Mean compilation time (seconds)`;
 const MEMORY_HEADER = `Peak memory footprint compression ratio (threshold = ${COMPRESSION_RATIO_THRESHOLD}x)`;
 
 // Keep the mapping from workflow ID to commit, so that we can use it to
@@ -1246,9 +1245,7 @@ function SummaryPanel({
                     const r = Number(v.r);
 
                     if (lCommit === rCommit) {
-                      return l > COMPILATION_lATENCY_THRESHOLD_IN_SECONDS
-                        ? styles.warning
-                        : "";
+                      return "";
                     } else {
                       if (l === r) {
                         return "";
@@ -1262,10 +1259,6 @@ function SummaryPanel({
                       // Increasing more than x%
                       if (l - r > RELATIVE_THRESHOLD * r) {
                         return styles.error;
-                      }
-
-                      if (l > COMPILATION_lATENCY_THRESHOLD_IN_SECONDS) {
-                        return styles.warning;
                       }
                     }
 

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -81,6 +81,7 @@ export const PASSING_ACCURACY = ["pass", "pass_due_to_skip", "eager_variation"];
 // Thresholds
 export const ACCURACY_THRESHOLD = 90.0;
 export const SPEEDUP_THRESHOLD = 0.95;
+export const COMPILATION_lATENCY_THRESHOLD = 0.9;
 export const COMPILATION_lATENCY_THRESHOLD_IN_SECONDS = 120;
 export const COMPRESSION_RATIO_THRESHOLD = 0.9;
 
@@ -1060,19 +1061,21 @@ function SummaryPanel({
                     if (lCommit === rCommit || r === undefined) {
                       return l >= ACCURACY_THRESHOLD ? "" : styles.warning;
                     } else {
-                      if (l >= ACCURACY_THRESHOLD && r < ACCURACY_THRESHOLD) {
-                        return styles.ok;
-                      }
-
-                      if (l < ACCURACY_THRESHOLD && r >= ACCURACY_THRESHOLD) {
-                        return styles.error;
-                      }
-
                       if (l === r) {
                         return "";
                       }
 
-                      if (l < ACCURACY_THRESHOLD && r < ACCURACY_THRESHOLD) {
+                      // Increasing more than x%
+                      if (l - r > (1.0 - ACCURACY_THRESHOLD / 100) * r) {
+                        return styles.ok;
+                      }
+
+                      // Decreasing more than x%
+                      if (r - l > (1.0 - ACCURACY_THRESHOLD / 100) * r) {
+                        return styles.error;
+                      }
+
+                      if (l < ACCURACY_THRESHOLD) {
                         return styles.warning;
                       }
                     }
@@ -1152,19 +1155,21 @@ function SummaryPanel({
                     if (lCommit === rCommit) {
                       return l >= SPEEDUP_THRESHOLD ? "" : styles.warning;
                     } else {
-                      if (l >= SPEEDUP_THRESHOLD && r < SPEEDUP_THRESHOLD) {
-                        return styles.ok;
-                      }
-
-                      if (l < SPEEDUP_THRESHOLD && r >= SPEEDUP_THRESHOLD) {
-                        return styles.error;
-                      }
-
                       if (l === r) {
                         return "";
                       }
 
-                      if (l < SPEEDUP_THRESHOLD && r < SPEEDUP_THRESHOLD) {
+                      // Increasing more than x%
+                      if (l - r > (1.0 - SPEEDUP_THRESHOLD) * r) {
+                        return styles.ok;
+                      }
+
+                      // Decreasing more than x%
+                      if (r - l > (1.0 - SPEEDUP_THRESHOLD) * r) {
+                        return styles.error;
+                      }
+
+                      if (l < SPEEDUP_THRESHOLD) {
                         return styles.warning;
                       }
                     }
@@ -1248,28 +1253,21 @@ function SummaryPanel({
                         ? styles.warning
                         : "";
                     } else {
-                      if (
-                        l <= COMPILATION_lATENCY_THRESHOLD_IN_SECONDS &&
-                        r > COMPILATION_lATENCY_THRESHOLD_IN_SECONDS
-                      ) {
-                        return styles.ok;
-                      }
-
-                      if (
-                        l > COMPILATION_lATENCY_THRESHOLD_IN_SECONDS &&
-                        r <= COMPILATION_lATENCY_THRESHOLD_IN_SECONDS
-                      ) {
-                        return styles.error;
-                      }
-
                       if (l === r) {
                         return "";
                       }
 
-                      if (
-                        l > COMPILATION_lATENCY_THRESHOLD_IN_SECONDS &&
-                        r > COMPILATION_lATENCY_THRESHOLD_IN_SECONDS
-                      ) {
+                      // Decreasing more than x%
+                      if (r - l > (1.0 - COMPILATION_lATENCY_THRESHOLD) * r) {
+                        return styles.ok;
+                      }
+
+                      // Increasing more than x%
+                      if (l - r > (1.0 - COMPILATION_lATENCY_THRESHOLD) * r) {
+                        return styles.error;
+                      }
+
+                      if (l > COMPILATION_lATENCY_THRESHOLD_IN_SECONDS) {
                         return styles.warning;
                       }
                     }
@@ -1351,28 +1349,21 @@ function SummaryPanel({
                         ? ""
                         : styles.warning;
                     } else {
-                      if (
-                        l >= COMPRESSION_RATIO_THRESHOLD &&
-                        r < COMPRESSION_RATIO_THRESHOLD
-                      ) {
-                        return styles.ok;
-                      }
-
-                      if (
-                        l < COMPRESSION_RATIO_THRESHOLD &&
-                        r >= COMPRESSION_RATIO_THRESHOLD
-                      ) {
-                        return styles.error;
-                      }
-
                       if (l === r) {
                         return "";
                       }
 
-                      if (
-                        l < COMPRESSION_RATIO_THRESHOLD &&
-                        r < COMPRESSION_RATIO_THRESHOLD
-                      ) {
+                      // Increasing more than x%
+                      if (l - r > (1.0 - COMPRESSION_RATIO_THRESHOLD) * r) {
+                        return styles.ok;
+                      }
+
+                      // Decreasing more than x%
+                      if (r - l > (1.0 - COMPRESSION_RATIO_THRESHOLD) * r) {
+                        return styles.error;
+                      }
+
+                      if (l < COMPRESSION_RATIO_THRESHOLD) {
                         return styles.warning;
                       }
                     }

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -78,10 +78,12 @@ export const MODES = ["training", "inference"];
 export const DTYPES = ["amp"];
 export const PASSING_ACCURACY = ["pass", "pass_due_to_skip", "eager_variation"];
 
+// Relative thresholds
+export const RELATIVE_THRESHOLD = 0.05;
+
 // Thresholds
 export const ACCURACY_THRESHOLD = 90.0;
 export const SPEEDUP_THRESHOLD = 0.95;
-export const COMPILATION_lATENCY_THRESHOLD = 0.9;
 export const COMPILATION_lATENCY_THRESHOLD_IN_SECONDS = 120;
 export const COMPRESSION_RATIO_THRESHOLD = 0.9;
 
@@ -1066,12 +1068,12 @@ function SummaryPanel({
                       }
 
                       // Increasing more than x%
-                      if (l - r > (1.0 - ACCURACY_THRESHOLD / 100) * r) {
+                      if (l - r > RELATIVE_THRESHOLD * r) {
                         return styles.ok;
                       }
 
                       // Decreasing more than x%
-                      if (r - l > (1.0 - ACCURACY_THRESHOLD / 100) * r) {
+                      if (r - l > RELATIVE_THRESHOLD * r) {
                         return styles.error;
                       }
 
@@ -1160,12 +1162,12 @@ function SummaryPanel({
                       }
 
                       // Increasing more than x%
-                      if (l - r > (1.0 - SPEEDUP_THRESHOLD) * r) {
+                      if (l - r > RELATIVE_THRESHOLD * r) {
                         return styles.ok;
                       }
 
                       // Decreasing more than x%
-                      if (r - l > (1.0 - SPEEDUP_THRESHOLD) * r) {
+                      if (r - l > RELATIVE_THRESHOLD * r) {
                         return styles.error;
                       }
 
@@ -1258,12 +1260,12 @@ function SummaryPanel({
                       }
 
                       // Decreasing more than x%
-                      if (r - l > (1.0 - COMPILATION_lATENCY_THRESHOLD) * r) {
+                      if (r - l > RELATIVE_THRESHOLD * r) {
                         return styles.ok;
                       }
 
                       // Increasing more than x%
-                      if (l - r > (1.0 - COMPILATION_lATENCY_THRESHOLD) * r) {
+                      if (l - r > RELATIVE_THRESHOLD * r) {
                         return styles.error;
                       }
 
@@ -1354,12 +1356,12 @@ function SummaryPanel({
                       }
 
                       // Increasing more than x%
-                      if (l - r > (1.0 - COMPRESSION_RATIO_THRESHOLD) * r) {
+                      if (l - r > RELATIVE_THRESHOLD * r) {
                         return styles.ok;
                       }
 
                       // Decreasing more than x%
-                      if (r - l > (1.0 - COMPRESSION_RATIO_THRESHOLD) * r) {
+                      if (r - l > RELATIVE_THRESHOLD * r) {
                         return styles.error;
                       }
 

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -1041,8 +1041,7 @@ function SummaryPanel({
                     } else {
                       return (
                         <a href={url}>
-                          {v.r} → {v.l}{" "}
-                          {Number(l) < Number(r) ? "\uD83D\uDD3B" : ""}
+                          {v.r} → {v.l}
                         </a>
                       );
                     }
@@ -1133,8 +1132,7 @@ function SummaryPanel({
                     } else {
                       return (
                         <a href={url}>
-                          {r}x → {l}x{" "}
-                          {Number(l) < Number(r) ? "\uD83D\uDD3B" : ""}
+                          {r}x → {l}x
                         </a>
                       );
                     }
@@ -1227,10 +1225,7 @@ function SummaryPanel({
                     } else {
                       return (
                         <a href={url}>
-                          {r}s → {l}s{" "}
-                          {Number(l) > Number(r) && Number(r) != 0
-                            ? "\uD83D\uDD3A"
-                            : ""}
+                          {r}s → {l}s
                         </a>
                       );
                     }
@@ -1325,8 +1320,7 @@ function SummaryPanel({
                     } else {
                       return (
                         <a href={url}>
-                          {r}x → {l}x{" "}
-                          {Number(l) < Number(r) ? "\uD83D\uDD3B" : ""}
+                          {r}x → {l}x
                         </a>
                       );
                     }

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -38,7 +38,10 @@ import {
   isUnstableJob,
 } from "lib/jobUtils";
 import { fetcher } from "lib/GeneralUtils";
-import { useGroupingPreference, usePreference } from "lib/useGroupingPreference";
+import {
+  useGroupingPreference,
+  usePreference,
+} from "lib/useGroupingPreference";
 
 export function JobCell({ sha, job }: { sha: string; job: JobData }) {
   const [pinnedId, setPinnedId] = useContext(PinnedTooltipContext);

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -38,10 +38,7 @@ import {
   isUnstableJob,
 } from "lib/jobUtils";
 import { fetcher } from "lib/GeneralUtils";
-import {
-  useGroupingPreference,
-  usePreference,
-} from "lib/useGroupingPreference";
+import { useGroupingPreference, usePreference } from "lib/useGroupingPreference";
 
 export function JobCell({ sha, job }: { sha: string; job: JobData }) {
   const [pinnedId, setPinnedId] = useContext(PinnedTooltipContext);


### PR DESCRIPTION
Fixes https://github.com/pytorch/test-infra/issues/4257

The high-lighting rules are now as follows:

1. Green (OK) if the new value improves more than 5% over the old value
1. Red (Not OK) if the new value regresses more than 5% when comparing with the old value
1. Yellow (warning) if both 1 and 2 don't hold and:
    1. The new speedup value is still less than 0.95
    2. ~~Or the new compilation time is till more than 120s~~ 
    3. Or the new compression ratio is still less than 0.9

### Testing
https://torchci-git-fork-huydhn-inductor-dashboard-82c51d-fbopensource.vercel.app/benchmark/torchbench/inductor_with_cudagraphs?startTime=Sat,%2003%20Jun%202023%2001:18:34%20GMT&stopTime=Sat,%2010%20Jun%202023%2001:18:34%20GMT&granularity=hour&mode=training&dtype=amp&lBranch=main&lCommit=2961ea80f5d5fbcb9ef86d95ce08f1fa603863bf&rBranch=main&rCommit=8215468870daae5a1da7ac02f98f4e2ddf2d7623