### PR TITLE
Uninstall Windows Defender

### DIFF
--- a/aws/ami/windows/scripts/Helpers/Uninstall-WinDefend.ps1
+++ b/aws/ami/windows/scripts/Helpers/Uninstall-WinDefend.ps1
@@ -1,0 +1,7 @@
+Get-MpComputerStatus
+Get-Service -Name "WinDefend"
+
+# Other approaches like Stop-Service -Name "WinDefend" or Set-Service -Name "WinDefend" -StartupType Disabled
+# lack the permission to remove Windows Defender. Note that uninstalling Windows Defender requires a restart,
+# so it would need to be baked into the AMI instead of being part of the CI
+Uninstall-WindowsFeature -Name Windows-Defender

--- a/aws/ami/windows/scripts/Installers/Install-Pip-Dependencies.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-Pip-Dependencies.ps1
@@ -13,4 +13,4 @@ if (-Not (Test-Path -Path $condaHook -PathType Leaf)) {
 conda activate base
 
 # Some dependencies are installed by pip before testing, pin all of them
-pip install "ninja==1.10.0.post1" "future==0.18.2" "hypothesis==5.35.1" "expecttest==0.1.3" "librosa>=0.6.2" "scipy==1.6.3" "psutil==5.9.1" "pynvml==11.4.1" "pillow==9.2.0" "unittest-xml-reporting<=3.2.0,>=2.0.0" "pytest==7.1.3" "pytest-xdist==2.5.0" "pytest-flakefinder==1.1.0" "pytest-rerunfailures==10.2" "pytest-shard==0.1.2" "sympy==1.11.1" "xdoctest==1.0.2" "pygments==2.12.0" "opt-einsum>=3.3" "networkx==2.8.8" "mpmath==1.2.1" "pytest-rerunfailures==10.3" "pytest-cpp==2.3.0" "rockset==1.0.3"
+pip install "ninja==1.10.0.post1" "future==0.18.2" "hypothesis==5.35.1" "expecttest==0.1.3" "librosa>=0.6.2" "scipy==1.6.3" "psutil==5.9.1" "pynvml==11.4.1" "pillow==9.2.0" "unittest-xml-reporting<=3.2.0,>=2.0.0" "pytest==7.1.3" "pytest-xdist==2.5.0" "pytest-flakefinder==1.1.0" "pytest-rerunfailures==10.2" "pytest-shard==0.1.2" "sympy==1.11.1" "xdoctest==1.0.2" "pygments==2.12.0" "opt-einsum>=3.3" "networkx==2.8.8" "mpmath==1.2.1" "pytest-rerunfailures==10.2" "pytest-cpp==2.3.0" "rockset==1.0.3"

--- a/aws/ami/windows/scripts/Installers/Install-Pip-Dependencies.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-Pip-Dependencies.ps1
@@ -13,4 +13,4 @@ if (-Not (Test-Path -Path $condaHook -PathType Leaf)) {
 conda activate base
 
 # Some dependencies are installed by pip before testing, pin all of them
-pip install "ninja==1.10.0.post1" "future==0.18.2" "hypothesis==5.35.1" "expecttest==0.1.3" "librosa>=0.6.2" "scipy==1.6.3" "psutil==5.9.1" "pynvml==11.4.1" "pillow==9.2.0" "unittest-xml-reporting<=3.2.0,>=2.0.0" "pytest==7.1.3" "pytest-xdist==2.5.0" "pytest-flakefinder==1.1.0" "pytest-rerunfailures==10.2" "pytest-shard==0.1.2" "sympy==1.11.1" "xdoctest==1.0.2" "pygments==2.12.0" "opt-einsum>=3.3" "networkx==2.8.8" "mpmath==1.2.1"
+pip install "ninja==1.10.0.post1" "future==0.18.2" "hypothesis==5.35.1" "expecttest==0.1.3" "librosa>=0.6.2" "scipy==1.6.3" "psutil==5.9.1" "pynvml==11.4.1" "pillow==9.2.0" "unittest-xml-reporting<=3.2.0,>=2.0.0" "pytest==7.1.3" "pytest-xdist==2.5.0" "pytest-flakefinder==1.1.0" "pytest-rerunfailures==10.2" "pytest-shard==0.1.2" "sympy==1.11.1" "xdoctest==1.0.2" "pygments==2.12.0" "opt-einsum>=3.3" "networkx==2.8.8" "mpmath==1.2.1" "pytest-rerunfailures==10.3" "pytest-cpp==2.3.0" "rockset==1.0.3"

--- a/aws/ami/windows/windows.pkr.hcl
+++ b/aws/ami/windows/windows.pkr.hcl
@@ -40,6 +40,15 @@ source "amazon-ebs" "windows_ebs_builder" {
 build {
   sources = ["source.amazon-ebs.windows_ebs_builder"]
 
+  # Uninstall Windows Defender, it brings more trouble than it's worth
+  provisioner "powershell" {
+    elevated_user     = "SYSTEM"
+    elevated_password = ""
+    scripts = [
+      "${path.root}/scripts/Helpers/Uninstall-WinDefend.ps1",
+    ]
+  }
+
   # Install sshd_config
   provisioner "file" {
     source      = "${path.root}/configs/sshd_config"


### PR DESCRIPTION
Per title, this PR uninstalls Windows Defender.  I couldn't find any other ways to disable this service on CI.  Also piggy back this change with some new dependencies for Windows that are added recently.

### Testing

* Build the new AMI

```
packer build -var 'skip_create_ami=false' .

us-east-1: ami-0e1d863a1d020eac3
us-east-2: ami-074ac5fc91f640663
```

* Update the AMI on canary https://github.com/fairinternal/pytorch-gha-infra/pull/192
* [TODO] Testing on canary
* [TODO] Update the AMI on PyTorch