### PR TITLE
Fix VS2022 Build Tools installation removing VS2019, fixes #1175

### DIFF
--- a/aws/ami/windows/scripts/Installers/Install-VS.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-VS.ps1
@@ -21,7 +21,7 @@ if (${env:INSTALL_WINDOWS_SDK} -eq "1") {
 }
 
 if (Test-Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe") {
-    $existingPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -products "Microsoft.VisualStudio.Product.BuildTools" -version "[${env:VS_VERSION}, ${VS_VERSION_major + 1})" -property installationPath
+    $existingPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -products "Microsoft.VisualStudio.Product.BuildTools" -version "[${env:VS_VERSION}, $($VS_VERSION_major + 1))" -property installationPath
     if (($existingPath -ne $null) -and (!${env:CIRCLECI})) {
         echo "Found correctly versioned existing BuildTools installation in $existingPath"
         exit 0
@@ -36,7 +36,7 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
-if ($pathToRemove -ne $null) {
+if (($null -ne $pathToRemove) -and (${env:VS_UNINSTALL_PREVIOUS} -eq "1")) {
     echo "Uninstalling $pathToRemove."
     $VS_UNINSTALL_ARGS = @("uninstall", "--installPath", "`"$pathToRemove`"", "--quiet","--wait")
     $process = Start-Process "${PWD}\vs_installer.exe" -ArgumentList $VS_UNINSTALL_ARGS -NoNewWindow -Wait -PassThru

--- a/aws/ami/windows/windows.pkr.hcl
+++ b/aws/ami/windows/windows.pkr.hcl
@@ -57,7 +57,7 @@ build {
 
   # Install the Visual Studio 2019
   provisioner "powershell" {
-    environment_vars = ["INSTALL_WINDOWS_SDK=1", "VS_YEAR=2019", "VS_VERSION=16.11.21"]
+    environment_vars = ["INSTALL_WINDOWS_SDK=1", "VS_YEAR=2019", "VS_VERSION=16.11.21", "VS_UNINSTALL_PREVIOUS=1"]
     execution_policy = "unrestricted"
     scripts = [
       "${path.root}/scripts/Installers/Install-VS.ps1",
@@ -66,7 +66,7 @@ build {
 
   # Install the Visual Studio 2022
   provisioner "powershell" {
-    environment_vars = ["INSTALL_WINDOWS_SDK=1", "VS_YEAR=2022", "VS_VERSION=17.4.1"]
+    environment_vars = ["INSTALL_WINDOWS_SDK=1", "VS_YEAR=2022", "VS_VERSION=17.4.1", "VS_UNINSTALL_PREVIOUS=0"]
     execution_policy = "unrestricted"
     scripts = [
       "${path.root}/scripts/Installers/Install-VS.ps1",


### PR DESCRIPTION
Fixes issue that the VS2022 Build Tools installation is removing VS2019 Build Tools installation. This is a follow up fix of already merged #1175.