### PR TITLE
Create script for posting alerts as issues

### DIFF
--- a/tools/scripts/alert_registry.py
+++ b/tools/scripts/alert_registry.py
@@ -1,0 +1,105 @@
+import re
+from typing import Dict, Any, List, Union
+
+import urllib
+import os
+from alert_utils import create_issue, clear_alerts, fetch_alerts_filter, REPO_OWNER, TEST_INFRA_REPO_NAME, GRAPHQL_URL, UPDATE_ISSUE_URL, ISSUES_WITH_LABEL_QUERY,CREATE_ISSUE_URL, PYTORCH_ALERT_LABEL, update_issue
+import requests
+import json
+import pprint
+ALERT_REGISTRY = {}
+
+PENDING = "pending"
+NEUTRAL = "neutral"
+SKIPPED = "skipped"
+SUCCESS = "success"
+FAILURE = "failure"
+CANCELED = "canceled"
+
+# rename this when these are ready
+# PYTORCH_ALERT_LABEL = "pytorch-alert"
+PYTORCH_ALERT_LABEL = "pytorch-alert-test"
+
+headers = {"Authorization": f"token {os.environ.get('GITHUB_TOKEN')}"}
+
+def register_alert(alert_type):
+    if alert_type in ALERT_REGISTRY:
+        raise ValueError(f"Alert type {alert_type} is already registered")
+    def inner(func):
+        ALERT_REGISTRY[alert_type] = func
+        return func
+    return inner
+
+def _assert_same_repo_and_type(alerts: List[Dict[str, Any]]) -> None:
+    print(alerts[0])
+    repo = alerts[0]["repo"]
+    alert_type = alerts[0]["AlertType"]
+    alert_org = alerts[0]["organization"]
+    for alert in alerts:
+        if alert["repo"] != repo:
+            raise ValueError(
+                f"Alerts must be from the same repository, got {repo} and {alert['repo']}"
+            )
+        if alert["AlertType"] != alert_type:
+            raise ValueError(
+                f"Alerts must be of the same type, got {alert_type} and {alert['AlertType']}"
+            )
+        if alert["organization"] != alert_org:
+            raise ValueError(
+                f"Alerts must be of the same org, got {alert_org} and {alert['org']}"
+            )
+
+@register_alert('Recurrently Failing Job')
+def handle_recurrently_failing_jobs(alerts: List[Dict[str, Any]]) -> Any:
+    _assert_same_repo_and_type(alerts)
+    repo = alerts[0]["repo"]
+    issue =  generate_failed_job_issue(alerts)
+    existing_alerts = fetch_alerts_filter(repo, [PYTORCH_ALERT_LABEL], alerts[0]["AlertType"])
+    clear_alerts(existing_alerts[:-1])
+    if len(existing_alerts) == 0:
+        existing_alerts.push(issue)
+        create_issue(issue)
+    else:
+        update_issue(issue, existing_alerts[-1])
+    return issue
+
+def generate_failed_job_hud_link(failed_job_name: str) -> str:
+    # TODO: I don't think minihud is universal across multiple repositories
+    #       would be good to just replace this with something that is
+    hud_link = "https://hud.pytorch.org/minihud?name_filter=" + urllib.parse.quote(
+        failed_job_name
+    )
+    return f"[{failed_job_name}]({hud_link})"
+
+def generate_failed_job_issue(
+    alerts
+) -> Any:
+    alerts.sort(key=lambda alert: alert["AlertObject"])
+    issue = {}
+    issue[
+        "title"
+    ] = f"[{alerts[0]['repo']}] [{alerts[0]['AlertType']}] [TEST ALERT PAY NO ATTENTION TO THIS] There are {len(alerts)}"
+    body = "Within the last 50 commits, there are the following failures on the main branch of pytorch: \n"
+    closed_alerts = []
+    for alert in alerts:
+        if alert["closed"]:
+            closed_alerts.append(job_name)
+            continue
+        job_name = alert["AlertObject"]
+        body += (
+            f"- {generate_failed_job_hud_link(job_name)} failed consecutively."
+        )
+        body += "\n\n"
+    if len(closed_alerts) > 0:
+        body += "These jobs stopped failing:\n"
+        for job in closed_alerts:
+            job_name = alert["AlertObject"]
+            body += f"* {job_name}\n" 
+        
+        body += f"* {job_name}\n" 
+    body += "Please review the errors and revert if needed."
+    issue["body"] = body
+    issue["labels"] = [PYTORCH_ALERT_LABEL]
+
+    # print("Generating alerts for: ", alerts)
+    return issue

--- a/tools/scripts/alert_utils.py
+++ b/tools/scripts/alert_utils.py
@@ -1,0 +1,169 @@
+import re
+from typing import Dict, Any, List, Union
+
+import urllib
+import os
+import requests
+import json
+
+ALL_SKIPPED_THRESHOLD = 100
+SIMILARITY_THRESHOLD = 0.75
+FAILURE_CHAIN_THRESHOLD = 2
+MAX_CONCURRENT_ALERTS = 1
+FAILED_JOB_PATTERN = (
+    r"^- \[(.*)\]\(.*\) failed consecutively starting with commit \[.*\]\(.*\)$"
+)
+
+PENDING = "pending"
+NEUTRAL = "neutral"
+SKIPPED = "skipped"
+SUCCESS = "success"
+FAILURE = "failure"
+CANCELED = "canceled"
+
+ISSUES_WITH_LABEL_QUERY = """
+query ($owner: String!, $name: String!, $labels: [String!]) {
+  repository(owner: $owner, name: $name, followRenames: false) {
+    issues(last: 20, labels: $labels, orderBy: {field: UPDATED_AT, direction: ASC} ) {
+      nodes {
+        id
+        title
+        closed
+        number
+        body
+        createdAt
+        comments(first: 100) {
+          nodes {
+            bodyText
+            databaseId
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+NUM_ISSUES_QUERY = """
+query ($query: String!) {
+  search(type: ISSUE, query: $query) {
+    issueCount
+  }
+}
+"""
+
+REPO_OWNER = "pytorch"
+PYTORCH_REPO_NAME = "pytorch"
+TEST_INFRA_REPO_NAME = "test-infra"
+PYTORCH_ALERT_LABEL = "pytorch-alert"
+FLAKY_TESTS_LABEL = "module: flaky-tests"
+NO_FLAKY_TESTS_LABEL = "no-flaky-tests-alert"
+FLAKY_TESTS_SEARCH_PERIOD_DAYS = 14
+DISABLED_ALERTS = [
+    "rerun_disabled_tests",
+    "unstable",
+]
+
+headers = {"Authorization": f"token {os.environ.get('GITHUB_TOKEN')}"}
+CREATE_ISSUE_URL = (
+    f"https://api.github.com/repos/{REPO_OWNER}/{TEST_INFRA_REPO_NAME}/issues"
+)
+UPDATE_ISSUE_URL = (
+    f"https://api.github.com/repos/{REPO_OWNER}/{TEST_INFRA_REPO_NAME}/issues/"
+)
+
+GRAPHQL_URL = "https://api.github.com/graphql"
+
+# rename this when these are ready
+# PYTORCH_ALERT_LABEL = "pytorch-alert"
+PYTORCH_ALERT_LABEL = "pytorch-alert-test"
+
+headers = {"Authorization": f"token {os.environ.get('GITHUB_TOKEN')}"}
+
+def fetch_alerts(
+    labels: List[str],
+    alert_repo_owner: str = REPO_OWNER,
+    alert_repo_name: str = TEST_INFRA_REPO_NAME,
+) -> List[Any]:
+    try:
+        variables = {
+            "owner": alert_repo_owner,
+            "name": alert_repo_name,
+            "labels": labels,
+        }
+        r = requests.post(
+            GRAPHQL_URL,
+            json={"query": ISSUES_WITH_LABEL_QUERY, "variables": variables},
+            headers=headers,
+        )
+        r.raise_for_status()
+        return json.loads(r.text)["data"]["repository"]["issues"]["nodes"]
+    except Exception as e:
+        raise RuntimeError("Error fetching alerts", e)
+
+ 
+
+def fetch_alerts_filter(repo: str, labels: List[str], alertType: str) -> List[Any]:
+    alerts = fetch_alerts(labels)
+    return [
+        alert
+        for alert in alerts
+        if f"{repo}" in alert["title"] and alertType in alert["title"]
+    ]
+
+def _assert_same_repo_and_type(alerts: List[Dict[str, Any]]) -> None:
+    repo = alerts[0]["repo"]
+    alert_type = alerts[0]["AlertType"]
+    alert_org = alerts[0]["org"]
+    for alert in alerts:
+        if alert["repo"] != repo:
+            raise ValueError(
+                f"Alerts must be from the same repository, got {repo} and {alert['repo']}"
+            )
+        if alert["AlertType"] != alert_type:
+            raise ValueError(
+                f"Alerts must be of the same type, got {alert_type} and {alert['AlertType']}"
+            )
+        if alert["org"] != alert_org:
+            raise ValueError(
+                f"Alerts must be of the same org, got {alert_org} and {alert['org']}"
+            )
+
+def update_issue(
+    issue: Dict, old_issue: Any, dry_run: bool = False
+) -> None:
+    # print(f"Updating issue {issue} with content:{os.linesep}{issue}")
+    issue["state"] = "open"
+    if dry_run:
+        print("NOTE: Dry run, not doing any real work")
+        return
+    r = requests.patch(
+        UPDATE_ISSUE_URL + str(old_issue["number"]), json=issue, headers=headers
+    )
+    r.raise_for_status()
+
+def clear_alerts(alerts: List[Any], dry_run: bool = False) -> bool:
+    if dry_run:
+        print("NOTE: Dry run, not doing any real work")
+        return
+    cleared_alerts = 0
+    for alert in alerts:
+        if not alert["closed"]:
+            r = requests.patch(
+                UPDATE_ISSUE_URL + str(alert["number"]),
+                json={"state": "closed"},
+                headers=headers,
+            )
+            r.raise_for_status()
+            cleared_alerts += 1
+    print(f"Clearing {cleared_alerts} previously open alerts.")
+    return cleared_alerts > 0
+
+def create_issue(issue: Dict, dry_run: bool = False) -> Dict:
+    print(f"Creating issue with content:{os.linesep}{issue}")
+    if dry_run:
+        print("NOTE: Dry run activated, not doing any real work")
+        return
+    r = requests.post(CREATE_ISSUE_URL, json=issue, headers=headers)
+    r.raise_for_status()
+    return {"number": r.json()["number"], "closed": False}

--- a/tools/scripts/publish_alerts.py
+++ b/tools/scripts/publish_alerts.py
@@ -1,0 +1,110 @@
+from collections import defaultdict
+import json
+import pprint
+from typing import Any, List, Dict
+import requests
+import rockset
+import os
+
+from alert_registry import ALERT_REGISTRY
+
+ENABLED_REPOS = [
+    # format is (org, repo)
+    ("pytorch", "pytorch"),
+]
+
+REPO_OWNER = "pytorch"
+PYTORCH_REPO_NAME = "pytorch"
+TEST_INFRA_REPO_NAME = "test-infra"
+PYTORCH_ALERT_LABEL = "pytorch-alert"
+FLAKY_TESTS_LABEL = "module: flaky-tests"
+NO_FLAKY_TESTS_LABEL = "no-flaky-tests-alert"
+FLAKY_TESTS_SEARCH_PERIOD_DAYS = 14
+DISABLED_ALERTS = [
+    "rerun_disabled_tests",
+    "unstable",
+]
+
+HEADERS = {"Authorization": f"token {os.environ.get('GITHUB_TOKEN')}"}
+CREATE_ISSUE_URL = (
+    f"https://api.github.com/repos/{REPO_OWNER}/{TEST_INFRA_REPO_NAME}/issues"
+)
+UPDATE_ISSUE_URL = (
+    f"https://api.github.com/repos/{REPO_OWNER}/{TEST_INFRA_REPO_NAME}/issues/"
+)
+
+GRAPHQL_URL = "https://api.github.com/graphql"
+
+ISSUES_WITH_LABEL_QUERY = """
+query ($owner: String!, $name: String!, $labels: [String!]) {
+  repository(owner: $owner, name: $name, followRenames: false) {
+    issues(last: 10, labels: $labels, states: [OPEN]) {
+      nodes {
+        id
+        title
+        closed
+        number
+        body
+        createdAt
+        comments(first: 100) {
+          nodes {
+            bodyText
+            databaseId
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+NUM_ISSUES_QUERY = """
+query ($query: String!) {
+  search(type: ISSUE, query: $query) {
+    issueCount
+  }
+}
+"""
+
+RELEVANT_QUERIES_VERSION = "5a66b6108b2ac5b1"
+def get_recent_alerts(orgname, reponame):
+    rockset_api_key = os.environ["ROCKSET_API_KEY"]
+    rockset_api_server = "api.rs2.usw2.rockset.com"
+    rs = rockset.RocksetClient(
+        host="api.usw2a1.rockset.com", api_key=rockset_api_key
+    )
+
+    # Define the name of the Rockset collection and lambda function
+    collection_name = "commons"
+    lambda_function_name = "get_relevant_alerts"
+    query_parameters = [
+        rockset.models.QueryParameter(name="repo", type="string", value=reponame),
+        rockset.models.QueryParameter(name="organization", type="string", value=orgname),
+    ]
+    api_response = rs.QueryLambdas.execute_query_lambda(query_lambda=lambda_function_name, 
+                                                        workspace=collection_name,
+                                                        version=RELEVANT_QUERIES_VERSION, 
+                                                        parameters=query_parameters)
+    return api_response["results"]
+
+def publish_alerts(alerts: List[Dict[str, Any]]):
+    # alert_dict is indexed as: org: repo: alert_type: List of Alerts
+    alert_dict =  defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: [])))
+    for alert in alerts:
+        if (alert["organization"], alert["repo"]) not in ENABLED_REPOS:
+            continue
+        alert_dict[alert["organization"]][alert["repo"]][alert["AlertType"]].append(alert)
+    
+    for org, repo_dict in alert_dict.items():
+        for repo, alert_type_dict in repo_dict.items():
+            for alert_type, alerts in alert_type_dict.items():
+                if alert_type in DISABLED_ALERTS:
+                    continue
+                ALERT_REGISTRY[alert_type](alerts)
+    
+
+if __name__ == "__main__":
+    alerts = get_recent_alerts("pytorch", "pytorch")
+    pprint.pprint(alerts) 
+    published_alerts = publish_alerts(alerts)
+    # pprint.pprint(published_alerts)


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b0a688</samp>

This pull request adds a new feature to publish alerts for recurrently failing jobs in PyTorch repositories. It introduces three new modules: `alert_registry.py` to define and register alert types and handlers, `alert_utils.py` to provide common functions and constants for alert processing, and `publish_alerts.py` to fetch, filter, and handle alerts using the Rockset and GitHub APIs. \n <!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7b0a688</samp>

> _`publish_alerts.py`_
> _Fetches and handles alerts_
> _Autumn of failures_