### PR TITLE
Add Sha and Branch to alerting schema

### DIFF
--- a/tools/tests/test_validate_alerts.py
+++ b/tools/tests/test_validate_alerts.py
@@ -10,6 +10,7 @@ valid_json = json.dumps([
         "AlertObject": "Bar",
         "OncallTeams": ["Team1", "Team2"],
         "OncallIndividuals": ["Individual1", "Individual2"],
+        "branch": "main",
         "Flags": ["Flag1", "Flag2"]
     },
     {
@@ -17,6 +18,7 @@ valid_json = json.dumps([
         "AlertObject": "BarFoo",
         "OncallTeams": ["Team1", "Team2"],
         "OncallIndividuals": ["Individual1", "Individual2"],
+        "branch": "main",
         "Flags": ["Flag1", "Flag2"]
     }
 ])
@@ -25,13 +27,43 @@ valid_json = json.dumps([
 invalid_json = '{"invalid_json"}'
 
 # valid json but invalid schema
-valid_json_invalid_schema = json.dumps({
+valid_json_invalid_schema = json.dumps([{
     "AlertType": "Foo",
     "AlertObject": "Bar",
     "OncallTeams": "Team1",  # should be list
     "OncallIndividuals": ["Individual1", "Individual2"],
     "Flags": ["Flag1", "Flag2"]
-})
+}])
+
+valid_json_valid_recurrently_failing_job_alert_schema = json.dumps([{
+    "AlertType": "RecurentlyFailingJobAlert",
+    "AlertObject": "Bar",
+    "OncallTeams": ["Team1", "Team2"],
+    "OncallIndividuals": ["Individual1", "Individual2"],
+    "Flags": ["Flag1", "Flag2"],
+    "branch": "main",
+    "sha": "1234567890123456789012345678901234567890"
+}   ,
+{
+    "AlertType": "FooBar",
+    "AlertObject": "BarFoo",
+    "OncallTeams": ["Team1", "Team2"],
+    "OncallIndividuals": ["Individual1", "Individual2"],
+    "branch": "main",
+    "Flags": ["Flag1", "Flag2"]
+}])
+
+valid_json_invalid_recurrently_failing_job_alert_schema = json.dumps([{
+    "AlertType": "RecurentlyFailingJobAlert",
+    "AlertObject": "Bar",
+    "OncallTeams": ["Team1", "Team2"],
+    "OncallIndividuals": ["Individual1", "Individual2"],
+    "Flags": ["Flag1", "Flag2"],
+    "branch": "main",
+}])
+    
+
+
 class AlertValidationTest(TestCase):
     def test_validate_json(self):
         # Test whether valid json is correctly validated
@@ -48,3 +80,14 @@ class AlertValidationTest(TestCase):
         # Test whether valid json that does not conform to the schema raises an error
         with self.assertRaises(jsonschema.exceptions.ValidationError):
             validate_alerts.validate_schema(valid_json_invalid_schema)
+    
+    def test_validate_recurrently_failing_job_alert_schema(self):
+        # Test whether valid json that conforms to the schema is correctly validated
+        assert validate_alerts.validate_schema(valid_json_valid_recurrently_failing_job_alert_schema) is None
+
+        # Test whether valid json that does not conform to the schema raises an error
+        with self.assertRaises(jsonschema.exceptions.ValidationError):
+            validate_alerts.validate_schema(valid_json_invalid_recurrently_failing_job_alert_schema)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b3ce44</samp>

The pull request enhances the alert validation script and tests in the `pytorch/test-infra` repository. It adds a new alert type for recurrently failing jobs, and requires all alerts to specify a branch. It also allows for extra properties for different alert types. \n <!--
copilot:poem
-->

For testing ran `python tools/scripts/validate_alerts.py` command from https://pipelines.actions.githubusercontent.com/serviceHosts/7d146c05-69c3-4c20-a0e7-818111670117/_apis/pipelines/1/runs/3080125/signedlogcontent/2?urlExpires=2023-06-20T17%3A11%3A00.0267556Z&urlSigningMethod=HMACV1&urlSignature=nol%2FiWA8JsCrYtu1xTP0X9V%2Bg7foizP0MP711D8BO10%3D

### <samp>🤖 Generated by Copilot at 2b3ce44</samp>

> _We are the watchers of the failing jobs_
> _We raise the `RecurrentlyFailingJobAlert`_
> _We validate the alerts with different schemas_
> _We branch out from the common properties_