### PR TITLE
Remove redundant AugmentData call that causes page to refresh

### DIFF
--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -602,7 +602,6 @@ export function BranchAndCommitPicker({
   let { data, error } = useSWR(url, fetcher, {
     refreshInterval: 60 * 60 * 1000, // refresh every hour
   });
-  data = AugmentData(data);
 
   useEffect(() => {
     if (data !== undefined && data.length !== 0) {


### PR DESCRIPTION
It turns out that this calls updates the data structure and causes the page to refresh back to the base and new commits.  There is no need to augment the data here as it only contains branch and commits info for the dropdown list, not the actual benchmark data.

### Testing

https://torchci-git-fork-huydhn-fix-pt2-dashboard-d-428da8-fbopensource.vercel.app/benchmark/compilers