### PR TITLE
[BE] Fix autoscale

### DIFF
--- a/tools/scripts/rockset_autoscale.py
+++ b/tools/scripts/rockset_autoscale.py
@@ -1,10 +1,10 @@
 import rockset
 import os
-import time
+from time import sleep
 from datetime import datetime, time
 
-scale_down_time = datetime.strptime("5:00", "%H:%M").time() # 5am UTC, which is 10pm PST
-scale_up_time = datetime.strptime("15:00", "%H:%M").time() # 3pm UTC, which is 8am PST
+scale_down_time = datetime.strptime("5:00", "%H:%M").time()  # 5am UTC, which is 10pm PST
+scale_up_time = datetime.strptime("15:00", "%H:%M").time()  # 3pm UTC, which is 8am PST
 
 scale_down_size = "LARGE"
 scale_up_size = "XLARGE"
@@ -63,7 +63,7 @@ def is_scaling_needed(desired_size) -> bool:
 def scale_virtual_instance(desired_size) -> None:
     try:
         print(f"Scaling virtual instance to size {desired_size}")
-        
+
         vi_status = rs.VirtualInstances.update(
             virtual_instance_id=virtual_instance_id,
             new_size=desired_size,
@@ -77,8 +77,8 @@ def scale_virtual_instance(desired_size) -> None:
     # It takes ~5 minutes to scale. Keep polling till it's done
     while vi_status.data.state != "ACTIVE":
         print(f"Current virtual instance state: {vi_status.data.state}...")
-        time.sleep(60) 
-        
+        sleep(60)
+
         vi_status = get_virtual_instance_status()
 
     print(f"Virtual instance is now {vi_status.data.state} and scaled to {vi_status.data.current_size}")
@@ -91,11 +91,9 @@ def main() -> None:
     print(f"Desired size: {new_size}")
 
     if not is_scaling_needed(new_size):
-        return 0
-    
-    scale_virtual_instance(new_size)
+        return
 
-    return 0
+    scale_virtual_instance(new_size)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fist of all, fix embarrassing `AttributeError: type object 'datetime.time' has no attribute 'sleep'`. (Hattip to @kit1980 for reporting)

Also, `def main()`  is declared as returning `None` so not point returning zeroes there

Fix all flake8 reported issues except E501