### PR TITLE
Add HUD button to mark a job as unstable

### DIFF
--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -215,7 +215,7 @@ function DisableIssue({
   let linkText = isDisabledTest
     ? "Disable test"
     : issueTitle.includes("UNSTABLE")
-    ? "Unstable job"
+    ? "Mark unstable job"
     : "Disable job";
   let buttonStyle = "";
 

--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -60,7 +60,7 @@ export default function JobLinks({ job }: { job: JobData }) {
       {eventTime}
       <TestInsightsLink job={job} separator={" | "} />
       <DisableTest job={job} label={"skipped"} />
-      <DisableJob job={job} label={"skipped"} />
+      <UnstableJob job={job} label={"unstable"} />
     </span>
   );
 }
@@ -150,13 +150,13 @@ function transformJobName(jobName?: string) {
   return jobName;
 }
 
-function formatDisableJobBody() {
+function formatUnstableJobBody() {
   return encodeURIComponent(
     "> Please provide a brief reason on why you need to disable/unstable this job."
   );
 }
 
-function DisableJob({ job, label }: { job: JobData; label: string }) {
+function UnstableJob({ job, label }: { job: JobData; label: string }) {
   const swrKey = isFailure(job.conclusion) ? `/api/issue/${label}` : null;
   const { data } = useSWR(swrKey, fetcher, {
     // Set a 60s cache for the request, so that lots of tooltip hovers don't
@@ -183,8 +183,8 @@ function DisableJob({ job, label }: { job: JobData; label: string }) {
 
   // At this point, we should show something. Search the existing disable issues
   // for a matching one.
-  const issueTitle = `DISABLED ${jobName}`;
-  const issueBody = formatDisableJobBody();
+  const issueTitle = `UNSTABLE ${jobName}`;
+  const issueBody = formatUnstableJobBody();
 
   const issues: IssueData[] = data.issues;
   const matchingIssues = issues.filter((issue) =>

--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -151,7 +151,7 @@ function transformJobName(jobName?: string) {
 
 function formatUnstableJobBody() {
   return encodeURIComponent(
-    "> Please provide a brief reason on why you need to disable/unstable this job."
+    "> Please provide a brief reason on why you need to mark this job as unstable."
   );
 }
 

--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -4,6 +4,8 @@ import React from "react";
 import { IssueData, JobData } from "../lib/types";
 import styles from "./JobLinks.module.css";
 import TestInsightsLink from "./TestInsights";
+import { useSession } from "next-auth/react";
+import { isFailure } from "../lib/JobClassifierUtil";
 
 export default function JobLinks({ job }: { job: JobData }) {
   const rawLogs =
@@ -47,6 +49,8 @@ export default function JobLinks({ job }: { job: JobData }) {
       </span>
     ) : null;
 
+  const session = useSession();
+
   return (
     <span>
       {rawLogs}
@@ -55,7 +59,8 @@ export default function JobLinks({ job }: { job: JobData }) {
       {durationS}
       {eventTime}
       <TestInsightsLink job={job} separator={" | "} />
-      <DisableIssue job={job} />
+      <DisableTest job={job} label={"skipped"} />
+      <DisableJob job={job} label={"skipped"} />
     </span>
   );
 }
@@ -76,7 +81,7 @@ function getTestName(failureCapture: string) {
   return null;
 }
 
-function formatIssueBody(failureCaptures: string) {
+function formatDisableTestBody(failureCaptures: string) {
   const examplesURL = `http://torch-ci.com/failure/${encodeURIComponent(
     failureCaptures
   )}`;
@@ -85,9 +90,9 @@ function formatIssueBody(failureCaptures: string) {
 This test was disabled because it is failing on master ([recent examples](${examplesURL})).`);
 }
 
-function DisableIssue({ job }: { job: JobData }) {
+function DisableTest({ job, label }: { job: JobData; label: string }) {
   const hasFailureClassification = job.failureLine != null;
-  const swrKey = hasFailureClassification ? "/api/issue/skipped" : null;
+  const swrKey = hasFailureClassification ? `/api/issue/${label}` : null;
   const { data } = useSWR(swrKey, fetcher, {
     // Set a 60s cache for the request, so that lots of tooltip hovers don't
     // spam the backend. Since actually mutating the state (through filing a
@@ -109,33 +114,132 @@ function DisableIssue({ job }: { job: JobData }) {
   }
   // - If we don't yet have any data, show a loading state.
   if (data === undefined) {
-    return <span>{" | "} checking for disable issues.</span>;
+    return <span>{" | "} checking for disable tests</span>;
   }
 
   // At this point, we should show something. Search the existing disable issues
   // for a matching one.
   const issueTitle = `DISABLED ${testName}`;
+  const issueBody = formatDisableTestBody(job.failureCaptures!);
+
   const issues: IssueData[] = data.issues;
-  let issueLink;
-  let linkText;
-  let buttonStyle;
   const matchingIssues = issues.filter((issue) => issue.title === issueTitle);
+
+  return (
+    <DisableIssue
+      matchingIssues={matchingIssues}
+      issueTitle={issueTitle}
+      issueBody={issueBody}
+      isDisabledTest={true}
+    />
+  );
+}
+
+const jobNameRe = /^(.*) \(([^,]*),.*\)/;
+function transformJobName(jobName?: string) {
+  if (jobName == undefined) {
+    return null;
+  }
+
+  // We want to have the job name in the following format WORKFLOW / JOB (CONFIG)
+  const jobNameMatch = jobName.match(jobNameRe);
+  if (jobNameMatch !== null) {
+    return `${jobNameMatch[1]} (${jobNameMatch[2]})`;
+  }
+
+  return jobName;
+}
+
+function formatDisableJobBody() {
+  return encodeURIComponent(
+    "> Please provide a brief reason on why you need to disable/unstable this job."
+  );
+}
+
+function DisableJob({ job, label }: { job: JobData; label: string }) {
+  const swrKey = isFailure(job.conclusion) ? `/api/issue/${label}` : null;
+  const { data } = useSWR(swrKey, fetcher, {
+    // Set a 60s cache for the request, so that lots of tooltip hovers don't
+    // spam the backend. Since actually mutating the state (through filing a
+    // disable issue) is a pretty heavy operation, 60s of staleness is fine.
+    dedupingInterval: 60 * 1000,
+    refreshInterval: 60 * 1000, // refresh every minute
+  });
+
+  if (!isFailure(job.conclusion)) {
+    return null;
+  }
+
+  const jobName = transformJobName(job.name);
+  // Ignore invalid job name
+  if (jobName === null) {
+    return null;
+  }
+
+  // If we don't yet have any data, show a loading state.
+  if (data === undefined) {
+    return <span>{" | "} checking for disable jobs</span>;
+  }
+
+  // At this point, we should show something. Search the existing disable issues
+  // for a matching one.
+  const issueTitle = `DISABLED ${jobName}`;
+  const issueBody = formatDisableJobBody();
+
+  const issues: IssueData[] = data.issues;
+  const matchingIssues = issues.filter((issue) =>
+    issueTitle.includes(issue.title)
+  );
+
+  return (
+    <DisableIssue
+      matchingIssues={matchingIssues}
+      issueTitle={issueTitle}
+      issueBody={issueBody}
+      isDisabledTest={false}
+    />
+  );
+}
+
+function DisableIssue({
+  matchingIssues,
+  issueTitle,
+  issueBody,
+  isDisabledTest,
+}: {
+  matchingIssues: IssueData[];
+  issueTitle: string;
+  issueBody: string;
+  isDisabledTest: boolean;
+}) {
+  let issueLink = `https://github.com/pytorch/pytorch/issues/new?title=${issueTitle}&body=${issueBody}`;
+  let linkText = isDisabledTest
+    ? "Disable test"
+    : issueTitle.includes("UNSTABLE")
+    ? "Unstable job"
+    : "Disable job";
+  let buttonStyle = "";
 
   if (matchingIssues.length !== 0) {
     // There is a matching issue, show that in the tooltip box.
     const matchingIssue = matchingIssues[0];
     if (matchingIssue.state === "open") {
-      linkText = "Test is disabled";
+      linkText = isDisabledTest
+        ? "Test is disabled"
+        : issueTitle.includes("UNSTABLE")
+        ? "Job is unstable"
+        : "Job is disabled";
     } else {
       buttonStyle = styles.closedDisableIssueButton;
-      linkText = "Previously disabled";
+      linkText = isDisabledTest
+        ? "Previously disabled test"
+        : issueTitle.includes("UNSTABLE")
+        ? "Previously unstable job"
+        : "Previously disabled job";
     }
     issueLink = matchingIssues[0].html_url;
   } else {
     // No matching issue, show a link to create one.
-    const issueBody = formatIssueBody(job.failureCaptures!);
-    linkText = "Disable test";
-    issueLink = `https://github.com/pytorch/pytorch/issues/new?title=${issueTitle}&body=${issueBody}`;
     buttonStyle = styles.disableTestButton;
   }
 

--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -49,8 +49,7 @@ export default function JobLinks({ job }: { job: JobData }) {
       </span>
     ) : null;
 
-  const session = useSession();
-
+  const authenticated = useSession().status === "authenticated";
   return (
     <span>
       {rawLogs}
@@ -60,7 +59,7 @@ export default function JobLinks({ job }: { job: JobData }) {
       {eventTime}
       <TestInsightsLink job={job} separator={" | "} />
       <DisableTest job={job} label={"skipped"} />
-      <UnstableJob job={job} label={"unstable"} />
+      {authenticated && <UnstableJob job={job} label={"unstable"} />}
     </span>
   );
 }

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -6,10 +6,6 @@ const titleRegexToLabel: [RegExp, string][] = [
   [/vulkan/gi, "module: vulkan"],
   [/vulkan/gi, "ciflow/periodic"], // Vulkan tests are run periodically
   [/DISABLED\s+test.*\(.*\)/g, "skipped"],
-
-  // TODO: See if we can support multiple labels here
-  [/DISABLED\s+.*\s+\/\s+.*/g, "skipped"],
-  [/DISABLED\s+.*\s+\/\s+.*/g, "module: ci"],
   [/UNSTABLE\s+.*\s+\/\s+.*/g, "unstable"],
   [/UNSTABLE\s+.*\s+\/\s+.*/g, "module: ci"],
 ];

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -7,7 +7,7 @@ const titleRegexToLabel: [RegExp, string][] = [
   [/vulkan/gi, "ciflow/periodic"], // Vulkan tests are run periodically
   [/DISABLED\s+test.*\(.*\)/g, "skipped"],
 
-  // TODO: Let's see if we can support multiple labels here
+  // TODO: See if we can support multiple labels here
   [/DISABLED\s+.*\s+\/\s+.*/g, "skipped"],
   [/DISABLED\s+.*\s+\/\s+.*/g, "module: ci"],
   [/UNSTABLE\s+.*\s+\/\s+.*/g, "unstable"],

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -6,6 +6,12 @@ const titleRegexToLabel: [RegExp, string][] = [
   [/vulkan/gi, "module: vulkan"],
   [/vulkan/gi, "ciflow/periodic"], // Vulkan tests are run periodically
   [/DISABLED\s+test.*\(.*\)/g, "skipped"],
+
+  // TODO: Let's see if we can support multiple labels here
+  [/DISABLED\s+.*\s+\/\s+.*/g, "skipped"],
+  [/DISABLED\s+.*\s+\/\s+.*/g, "module: ci"],
+  [/UNSTABLE\s+.*\s+\/\s+.*/g, "unstable"],
+  [/UNSTABLE\s+.*\s+\/\s+.*/g, "module: ci"],
 ];
 
 const filenameRegexToReleaseCategory: [RegExp, string][] = [


### PR DESCRIPTION
The new button "Unstable job" is right next to the familiar "Disable test" button.  Here are how it works:

* The button only shows up when user login to HUD.  As this is mainly used by Dev Infra.
* The button only shows up for failed jobs
* Click the "Unstable job" will open a new issue with title `UNSTABLE JOB_NAME`
    * The new UNSTABLE issue will be tagged with `module: ci` label to CC us and `unstable` label so that they can be searched quickly
* If a job has already been marked as unstable, a link to the existing unstable issue is provided instead with the text `Job is unstable`
* If a job was marked as unstable in the past, a link to the closed unstable issue is provided with the text `Previously unstable job`.  Reopening the issue will mark the job as unstable again

This process mimics the behavior of "Disable test" that we're familiar with.

### Testing

* Not logged in https://torchci-git-fork-huydhn-disable-unstable-job-hud-fbopensource.vercel.app/pytorch/pytorch/commit/def01eafc5c1e8f1f4f04b161986ca821f062624
* As GitHub logging is not working with the preview page atm, here is the screenshot from my local dev:

![Screenshot 2023-06-15 at 19 24 48](https://github.com/pytorch/test-infra/assets/475357/335b4f3e-745f-4783-8ae6-d9914c0f8388)
