### PR TITLE
[TorchFix] Report the same issue once for higher order func calls

### DIFF
--- a/tools/torchfix/tests/fixtures/checker/functorch.py
+++ b/tools/torchfix/tests/fixtures/checker/functorch.py
@@ -1,0 +1,4 @@
+import functorch
+
+# Check that we get only one warning for the line
+functorch.vmap(tdmodule, (None, 0))(td, params)

--- a/tools/torchfix/tests/fixtures/checker/functorch.txt
+++ b/tools/torchfix/tests/fixtures/checker/functorch.txt
@@ -1,0 +1,1 @@
+4:1 TOR101 Use of deprecated function functorch.vmap


### PR DESCRIPTION
Previously the same lint issue was being reported twice for things like `vmap(a)(b)` (but there was a guard already in the code changing path - just moved the guarding code to apply to linting also).

This may be an issue with LibCST https://github.com/Instagram/LibCST/issues/960, but it's easy to check in our code.