### PR TITLE
Fix React warnings on HUD when running yarn dev

### DIFF
--- a/torchci/pages/failedjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/failedjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -221,7 +221,11 @@ function FailedJobs({
           </summary>
           <ul>
             {_.map(groupedJobsByFailure, (jobs, failure) => (
-              <FailedJobsByFailure jobs={jobs} annotations={annotations} />
+              <FailedJobsByFailure
+                key={failure}
+                jobs={jobs}
+                annotations={annotations}
+              />
             ))}
           </ul>
         </details>

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -295,7 +295,12 @@ function GroupViewCheckBox({
           setUseGrouping(!useGrouping);
         }}
       >
-        <input type="checkbox" name="groupView" checked={useGrouping} />
+        <input
+          type="checkbox"
+          name="groupView"
+          checked={useGrouping}
+          onChange={() => {}}
+        />
         <label htmlFor="groupView"> Use grouped view</label>
       </div>
     </>
@@ -316,7 +321,12 @@ function UnstableCheckBox({
           setHideUnstable(!hideUnstable);
         }}
       >
-        <input type="checkbox" name="hideUnstable" checked={hideUnstable} />
+        <input
+          type="checkbox"
+          name="hideUnstable"
+          checked={hideUnstable}
+          onChange={() => {}}
+        />
         <label htmlFor="hideUnstable"> Hide unstable jobs</label>
       </div>
     </>


### PR DESCRIPTION
This fixes some annoying warnings on HUD browser console log when running `yarn dev`:

* `Each child in a list should have a unique "key" prop` and
* `You provided a checked prop to a form field without an onChange handler. This will render a read-only field. If the field should be mutable use defaultChecked. Otherwise, set either onChange or readOnly`