### PR TITLE
Fix wrong TorchBench graph data on PT2 dashboard

### DIFF
--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -46,6 +46,7 @@ import {
   DIFF_HEADER,
   AugmentData,
   ModePicker,
+  DEFAULT_MODE,
   MODES,
   LogLinks,
   JOB_NAME_REGEX,
@@ -1049,8 +1050,8 @@ export default function Page() {
   const [timeRange, setTimeRange] = useState<number>(LAST_N_DAYS);
 
   const [granularity, setGranularity] = useState<Granularity>("hour");
-  const [mode, setMode] = useState<string>(MODES[0]);
-  const [dtype, setDType] = useState<string>(DTYPES[0]);
+  const [mode, setMode] = useState<string>(DEFAULT_MODE);
+  const [dtype, setDType] = useState<string>(MODES[DEFAULT_MODE]);
   const [lBranch, setLBranch] = useState<string>(MAIN_BRANCH);
   const [lCommit, setLCommit] = useState<string>("");
   const [rBranch, setRBranch] = useState<string>(MAIN_BRANCH);
@@ -1194,7 +1195,7 @@ export default function Page() {
           granularity={granularity}
           setGranularity={setGranularity}
         />
-        <ModePicker mode={mode} setMode={setMode} />
+        <ModePicker mode={mode} setMode={setMode} setDType={setDType} />
         <DTypePicker dtype={dtype} setDType={setDType} />
         <BranchAndCommitPicker
           branch={rBranch}


### PR DESCRIPTION
Fixes https://github.com/pytorch/test-infra/issues/4304.  After https://github.com/pytorch/test-infra/pull/4292, the graph data for Torchbench is wrong while the summary table remain correct.

This PR also fixes:

* Some React warnings when running `yarn dev` locally about missing and duplicated `key` property
* Make `bfloat16` the default dtype in inference mode

### Testing

https://torchci-git-fork-huydhn-inductor-dashboard-8fc60c-fbopensource.vercel.app/benchmark/compilers