### PR TITLE
Exclude `benchmarks` from BC linter

### DIFF
--- a/tools/stronghold/src/api/compatibility.py
+++ b/tools/stronghold/src/api/compatibility.py
@@ -37,7 +37,7 @@ def check_range(
             continue
         if any(dir.name == 'benchmarks' for dir in file.parents):
             # Ignore benchmarks (not part of PyTorch package).
-            continue            
+            continue
         if file.name.startswith('test_') or file.stem.endswith('_test'):
             # Ignore test files.
             continue

--- a/tools/stronghold/src/api/compatibility.py
+++ b/tools/stronghold/src/api/compatibility.py
@@ -32,9 +32,12 @@ def check_range(
         if file.name.startswith('_'):
             # Ignore internal modules.
             continue
-        if any(dir.name.startswith('test') for dir in file.parents):
-            # Ignore test packages.
+        if any(dir.name == 'test' for dir in file.parents):
+            # Ignore tests (not part of PyTorch package).
             continue
+        if any(dir.name == 'benchmarks' for dir in file.parents):
+            # Ignore benchmarks (not part of PyTorch package).
+            continue            
         if file.name.startswith('test_') or file.stem.endswith('_test'):
             # Ignore test files.
             continue


### PR DESCRIPTION
Because they are not packages as part of `PyTorch`

Also, make `tests` folder check more precise, as right now it matches `torch.testing.` package that is part of public API and should be BC-linted.