### PR TITLE
[TorchFix] Add TorchRequireGradVisitor

### DIFF
--- a/tools/torchfix/tests/fixtures/misc/checker/require_grad.py
+++ b/tools/torchfix/tests/fixtures/misc/checker/require_grad.py
@@ -1,0 +1,9 @@
+import torch
+x = torch.zeros(1)
+x.require_grad = False
+x.require_grad = True
+
+# Don't trigger
+x.requires_grad = False
+require_grad = False
+x.require_grad = 10

--- a/tools/torchfix/tests/fixtures/misc/checker/require_grad.txt
+++ b/tools/torchfix/tests/fixtures/misc/checker/require_grad.txt
@@ -1,2 +1,2 @@
-3:1 TOR002 Likely typo `require_grad` in assignment.
-4:1 TOR002 Likely typo `require_grad` in assignment.
+3:1 TOR002 Likely typo `require_grad` in assignment. Did you mean `requires_grad`?
+4:1 TOR002 Likely typo `require_grad` in assignment. Did you mean `requires_grad`?

--- a/tools/torchfix/tests/fixtures/misc/checker/require_grad.txt
+++ b/tools/torchfix/tests/fixtures/misc/checker/require_grad.txt
@@ -1,0 +1,2 @@
+3:1 TOR002 Likely typo `require_grad` in assignment.
+4:1 TOR002 Likely typo `require_grad` in assignment.

--- a/tools/torchfix/tests/fixtures/misc/codemod/require_grad.py
+++ b/tools/torchfix/tests/fixtures/misc/codemod/require_grad.py
@@ -1,0 +1,4 @@
+import torch
+x = torch.zeros(1)
+x.require_grad = False
+x.require_grad = True

--- a/tools/torchfix/tests/fixtures/misc/codemod/require_grad.py.out
+++ b/tools/torchfix/tests/fixtures/misc/codemod/require_grad.py.out
@@ -1,0 +1,4 @@
+import torch
+x = torch.zeros(1)
+x.requires_grad = False
+x.requires_grad = True

--- a/tools/torchfix/torchfix/torchfix.py
+++ b/tools/torchfix/torchfix/torchfix.py
@@ -9,10 +9,19 @@ from .visitors.deprecated_symbols import (
 )
 
 from .visitors.performance import TorchSynchronizedDataLoaderVisitor
+from .visitors.misc import TorchRequireGradVisitor
 
 __version__ = "0.0.2"
 
 DEPRECATED_CONFIG_PATH = Path(__file__).absolute().parent / "deprecated_symbols.yaml"
+
+
+def GET_ALL_VISITORS():
+    return [
+        TorchDeprecatedSymbolsVisitor(DEPRECATED_CONFIG_PATH),
+        TorchRequireGradVisitor(),
+        TorchSynchronizedDataLoaderVisitor(),
+    ]
 
 
 class TorchChecker:
@@ -26,10 +35,7 @@ class TorchChecker:
         module = cst.parse_module("".join(lines))
         self.module = cst.MetadataWrapper(module, unsafe_skip_copy=True)
         self.violations = []
-        self.visitors = [
-            TorchDeprecatedSymbolsVisitor(DEPRECATED_CONFIG_PATH),
-            TorchSynchronizedDataLoaderVisitor(),
-        ]
+        self.visitors = GET_ALL_VISITORS()
 
     def run(self):
         self.module.visit_batched(self.visitors)
@@ -49,10 +55,7 @@ class TorchCodemod(codemod.Codemod):
         wrapped_module = cst.MetadataWrapper(module, unsafe_skip_copy=True)
 
         violations = []
-        visitors = [
-            TorchDeprecatedSymbolsVisitor(DEPRECATED_CONFIG_PATH),
-            TorchSynchronizedDataLoaderVisitor(),
-        ]
+        visitors = GET_ALL_VISITORS()
         wrapped_module.visit_batched(visitors)
         for v in visitors:
             violations += v.violations

--- a/tools/torchfix/torchfix/visitors/misc/__init__.py
+++ b/tools/torchfix/torchfix/visitors/misc/__init__.py
@@ -11,7 +11,7 @@ class TorchRequireGradVisitor(TorchVisitor):
     """
 
     ERROR_CODE = "TOR002"
-    MESSAGE = "Likely typo `require_grad` in assignment."
+    MESSAGE = "Likely typo `require_grad` in assignment. Did you mean `requires_grad`?"
 
     def visit_Assign(self, node):
         # Look for any assignment with `require_grad` attribute on the left

--- a/tools/torchfix/torchfix/visitors/misc/__init__.py
+++ b/tools/torchfix/torchfix/visitors/misc/__init__.py
@@ -1,0 +1,51 @@
+import libcst as cst
+import libcst.matchers as m
+
+
+from ...common import TorchVisitor, LintViolation
+
+
+class TorchRequireGradVisitor(TorchVisitor):
+    """
+    Find and fix common misspelling `require_grad` (instead of `requires_grad`).
+    """
+
+    ERROR_CODE = "TOR002"
+    MESSAGE = "Likely typo `require_grad` in assignment."
+
+    def visit_Assign(self, node):
+        # Look for any assignment with `require_grad` attribute on the left
+        # and `False` or `True` on the right.
+        #
+        # If this causes false-positives on real code (unlikely),
+        # we can do type inference (not sure if feasible here) or
+        # at least check that `torch` is imported in the file.
+        if m.matches(
+            node,
+            m.Assign(
+                targets=[
+                    m.AssignTarget(
+                        target=m.Attribute(attr=m.Name(value="require_grad"))
+                    )
+                ],
+                value=(m.Name("True") | m.Name("False")),
+            ),
+        ):
+            replacement = node.with_deep_changes(
+                old_node=node.targets[0].target.attr, value="requires_grad"
+            )
+
+            position_metadata = self.get_metadata(
+                cst.metadata.WhitespaceInclusivePositionProvider, node
+            )
+
+            self.violations.append(
+                LintViolation(
+                    error_code=self.ERROR_CODE,
+                    message=self.MESSAGE,
+                    line=position_metadata.start.line,
+                    column=position_metadata.start.column,
+                    node=node,
+                    replacement=replacement,
+                )
+            )


### PR DESCRIPTION
Find and fix common misspelling `require_grad` (instead of `requires_grad`).

This was reported as a common issue on PyTorch Slack by Stas Bekman from Huggingface.