### PR TITLE
[TorchFix] Fix crash with from . import

### DIFF
--- a/tools/torchfix/tests/fixtures/deprecated_symbols/codemod/functorch.py
+++ b/tools/torchfix/tests/fixtures/deprecated_symbols/codemod/functorch.py
@@ -1,4 +1,4 @@
-# Check no crash on no-value import
+# Check no crash on no-module import
 from . import residue_constants as rc
 
 import torch

--- a/tools/torchfix/tests/fixtures/deprecated_symbols/codemod/functorch.py
+++ b/tools/torchfix/tests/fixtures/deprecated_symbols/codemod/functorch.py
@@ -1,3 +1,6 @@
+# Check no crash on no-value import
+from . import residue_constants as rc
+
 import torch
 import functorch
 from functorch import (

--- a/tools/torchfix/tests/fixtures/deprecated_symbols/codemod/functorch.py.out
+++ b/tools/torchfix/tests/fixtures/deprecated_symbols/codemod/functorch.py.out
@@ -1,4 +1,4 @@
-# Check no crash on no-value import
+# Check no crash on no-module import
 from . import residue_constants as rc
 
 import torch

--- a/tools/torchfix/tests/fixtures/deprecated_symbols/codemod/functorch.py.out
+++ b/tools/torchfix/tests/fixtures/deprecated_symbols/codemod/functorch.py.out
@@ -1,3 +1,6 @@
+# Check no crash on no-value import
+from . import residue_constants as rc
+
 import torch
 import functorch
 from torch.func import (

--- a/tools/torchfix/torchfix/visitors/deprecated_symbols/__init__.py
+++ b/tools/torchfix/torchfix/visitors/deprecated_symbols/__init__.py
@@ -89,7 +89,7 @@ class _UpdateFunctorchImports(cst.CSTTransformer):
     def leave_ImportFrom(
         self, node: cst.ImportFrom, updated_node: cst.ImportFrom
     ) -> cst.ImportFrom:
-        if getattr(node.module, "value", None)  == "functorch" and all(
+        if getattr(node.module, "value", None) == "functorch" and all(
             name.name.value in self.REPLACEMENTS for name in node.names
         ):
             self.changed = True

--- a/tools/torchfix/torchfix/visitors/deprecated_symbols/__init__.py
+++ b/tools/torchfix/torchfix/visitors/deprecated_symbols/__init__.py
@@ -89,7 +89,7 @@ class _UpdateFunctorchImports(cst.CSTTransformer):
     def leave_ImportFrom(
         self, node: cst.ImportFrom, updated_node: cst.ImportFrom
     ) -> cst.ImportFrom:
-        if node.module.value == "functorch" and all(
+        if node.module is not None and node.module.value == "functorch" and all(
             name.name.value in self.REPLACEMENTS for name in node.names
         ):
             self.changed = True

--- a/tools/torchfix/torchfix/visitors/deprecated_symbols/__init__.py
+++ b/tools/torchfix/torchfix/visitors/deprecated_symbols/__init__.py
@@ -89,7 +89,7 @@ class _UpdateFunctorchImports(cst.CSTTransformer):
     def leave_ImportFrom(
         self, node: cst.ImportFrom, updated_node: cst.ImportFrom
     ) -> cst.ImportFrom:
-        if node.module is not None and node.module.value == "functorch" and all(
+        if getattr(node.module, "value", None)  == "functorch" and all(
             name.name.value in self.REPLACEMENTS for name in node.names
         ):
             self.changed = True


### PR DESCRIPTION
Before things like `from . import residue_constants as rc` crash.