### PR TITLE
Disable bot to add labels based on platforms

### DIFF
--- a/torchci/lib/bot/verifyDisableTestIssueBot.ts
+++ b/torchci/lib/bot/verifyDisableTestIssueBot.ts
@@ -13,16 +13,16 @@ export const disabledTestIssueTitle = new RegExp(
 export const pytorchBotId = 54816060;
 
 export const supportedPlatforms = new Map([
-  ["asan", undefined],
-  ["linux", undefined],
-  ["mac", "module: macos"],
-  ["macos", "module: macos"],
-  ["rocm", "module: rocm"],
-  ["slow", undefined],
-  ["win", "module: windows"],
-  ["windows", "module: windows"],
-  ["dynamo", "oncall: pt2"],
-  ["inductor", "oncall: pt2"],
+  ["asan", []],
+  ["linux", []],
+  ["mac", ["module: macos"]],
+  ["macos", ["module: macos"]],
+  ["rocm", ["module: rocm"]],
+  ["slow", []],
+  ["win", ["module: windows"]],
+  ["windows", ["module: windows"]],
+  ["dynamo", ["oncall: pt2"]],
+  ["inductor", ["oncall: pt2"]],
 ]);
 
 async function getValidationComment(
@@ -49,7 +49,7 @@ export function getExpectedLabels(
   platforms: string[],
   labels: string[]
 ): string[] {
-  let supportedPlatformLabels = Array.from(supportedPlatforms.values());
+  let supportedPlatformLabels = Array.from(supportedPlatforms.values()).flat();
   let nonIssuePlatformLabels = labels.filter(
     (label) => !supportedPlatformLabels.includes(label)
   );
@@ -232,7 +232,8 @@ export default function verifyDisableTestIssueBot(app: Probot): void {
     const authorized =
       context.payload["issue"]["user"]["id"] === pytorchBotId ||
       (await hasWritePermissions(context, username));
-    const labels = context.payload["issue"]["labels"]?.map((l) => l["name"]) ?? [];
+    const labels =
+      context.payload["issue"]["labels"]?.map((l) => l["name"]) ?? [];
 
     const validationComment = isDisabledTest(title)
       ? formValidationComment(username, authorized, target, platforms)

--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -276,7 +276,7 @@ export function getWorkflowJobNames(test: FlakyTestData): string[] {
 
 export function getPlatformsAffected(workflowJobNames: string[]): string[] {
   const platformsToSkip: string[] = [];
-  supportedPlatforms.forEach((platform: string) =>
+  Array.from(supportedPlatforms.keys()).forEach((platform: string) =>
     workflowJobNames.forEach((workflowJobNames) => {
       if (
         workflowJobNames.includes(platform) &&
@@ -381,15 +381,26 @@ export async function getTestOwnerLabels(
     labels.push("module: unknown");
   }
 
-  let platforms = getPlatformsAffected(getWorkflowJobNames(test));
-  if (platforms.includes("dynamo") || platforms.includes("inductor")) {
-    labels.push("oncall: pt2");
-  }
+  labels.push(
+    ...getPlatformLabels(getPlatformsAffected(getWorkflowJobNames(test)))
+  );
 
   if (labels.some((x) => x.startsWith("module: ") && x !== "module: unknown")) {
     labels.push("triaged");
   }
   return { labels, additionalErrMessage };
+}
+
+export function getPlatformLabels(platforms: string[]): string[] {
+  let labels = new Set(
+    platforms.map((platform) => supportedPlatforms.get(platform))
+  );
+  if (labels.size !== 1) {
+    return [];
+  }
+  return Array.from(labels).filter(
+    (platform) => platform !== undefined
+  ) as string[];
 }
 
 export function wasRecent(test: FlakyTestData) {

--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -11,6 +11,7 @@ import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
 import { retryRequest } from "lib/bot/utils";
 import { Octokit } from "octokit";
 import dayjs from "dayjs";
+import _ from "lodash";
 
 const NUM_HOURS = 3;
 const NUM_HOURS_ACROSS_JOBS = 72;
@@ -392,15 +393,15 @@ export async function getTestOwnerLabels(
 }
 
 export function getPlatformLabels(platforms: string[]): string[] {
-  let labels = new Set(
-    platforms.map((platform) => supportedPlatforms.get(platform))
-  );
-  if (labels.size !== 1) {
-    return [];
+  let labels = undefined;
+  for (const platform of platforms) {
+    if (labels === undefined) {
+      labels = supportedPlatforms.get(platform);
+    } else if (!_.isEqual(supportedPlatforms.get(platform), labels)) {
+      return [];
+    }
   }
-  return Array.from(labels).filter(
-    (platform) => platform !== undefined
-  ) as string[];
+  return labels ?? [];
 }
 
 export function wasRecent(test: FlakyTestData) {

--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -378,13 +378,13 @@ export async function getTestOwnerLabels(
     additionalErrMessage = `${err}`;
   }
 
-  if (labels.length === 0) {
-    labels.push("module: unknown");
-  }
-
   labels.push(
     ...getPlatformLabels(getPlatformsAffected(getWorkflowJobNames(test)))
   );
+
+  if (labels.length === 0) {
+    labels.push("module: unknown");
+  }
 
   if (labels.some((x) => x.startsWith("module: ") && x !== "module: unknown")) {
     labels.push("triaged");

--- a/torchci/test/disableFlakyBot.test.ts
+++ b/torchci/test/disableFlakyBot.test.ts
@@ -645,7 +645,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
 
     const { labels, additionalErrMessage } =
       await disableFlakyTestBot.getTestOwnerLabels(flakyTestA);
-    expect(labels).toEqual(["module: unknown", "module: windows", "triaged"]);
+    expect(labels).toEqual(["module: windows", "triaged"]);
     expect(additionalErrMessage).toEqual(undefined);
 
     if (!scope.isDone()) {
@@ -675,7 +675,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
 
     const { labels, additionalErrMessage } =
       await disableFlakyTestBot.getTestOwnerLabels(flakyTestA);
-    expect(labels).toEqual(["module: unknown", "module: windows", "triaged"]);
+    expect(labels).toEqual(["module: windows", "triaged"]);
     expect(additionalErrMessage).toEqual(
       "Error: Error retrieving file_a.py: 404, file_a: 404"
     );
@@ -762,7 +762,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
     let { labels, additionalErrMessage } =
       await disableFlakyTestBot.getTestOwnerLabels(test);
     expect(additionalErrMessage).toEqual(undefined);
-    expect(labels).toEqual(["module: unknown", "oncall: pt2"]);
+    expect(labels).toEqual(["oncall: pt2"]);
 
     handleScope(scope);
   });
@@ -778,7 +778,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
     let { labels, additionalErrMessage } =
       await disableFlakyTestBot.getTestOwnerLabels(test);
     expect(additionalErrMessage).toEqual(undefined);
-    expect(labels).toEqual(["module: unknown", "module: rocm", "triaged"]);
+    expect(labels).toEqual(["module: rocm", "triaged"]);
 
     handleScope(scope);
   });

--- a/torchci/test/verifyDisableTestIssue.test.ts
+++ b/torchci/test/verifyDisableTestIssue.test.ts
@@ -402,7 +402,7 @@ describe("verify-disable-test-issue-bot", () => {
     const payload = requireDeepCopy("./fixtures/issues.opened.json");
     payload.issue.title = "DISABLED testMethodName (testClass.TestSuite)";
     payload.issue.user.id = pytorchBotId;
-    payload.issue.body = "Platforms: rocm"
+    payload.issue.body = "Platforms: rocm";
 
     const owner = payload.repository.owner.login;
     const repo = payload.repository.name;
@@ -421,7 +421,6 @@ describe("verify-disable-test-issue-bot", () => {
       )
       .reply(200, []);
 
-
     await probot.receive({ name: "issues", payload: payload, id: "2" });
 
     handleScope(scope);
@@ -431,7 +430,7 @@ describe("verify-disable-test-issue-bot", () => {
     const payload = requireDeepCopy("./fixtures/issues.opened.json");
     payload.issue.title = "DISABLED testMethodName (testClass.TestSuite)";
     payload.issue.user.id = pytorchBotId;
-    payload.issue.body = "Platforms: rocm"
+    payload.issue.body = "Platforms: rocm";
     payload.issue.labels = [
       {
         name: "random label",
@@ -453,10 +452,9 @@ describe("verify-disable-test-issue-bot", () => {
       )
       .reply(200)
       .put(`/repos/${owner}/${repo}/issues/${number}/labels`, (body) =>
-        _.isEqual(body.labels, [ "random label", "module: rocm"])
+        _.isEqual(body.labels, ["random label", "module: rocm"])
       )
       .reply(200, []);
-
 
     await probot.receive({ name: "issues", payload: payload, id: "2" });
 

--- a/torchci/test/verifyDisableTestIssue.test.ts
+++ b/torchci/test/verifyDisableTestIssue.test.ts
@@ -8,6 +8,7 @@ import {
   disabledKey,
   unstableKey,
 } from "../lib/bot/verifyDisableTestIssueBot";
+import _ from "lodash";
 
 nock.disableNetConnect();
 
@@ -303,6 +304,31 @@ describe("verify-disable-test-issue", () => {
     expect(comment.includes(`~15 minutes, \`${jobName}\``)).toBeTruthy();
     expect(comment.includes("ERROR")).toBeFalsy();
   });
+
+  test("various getExpectedLabels tests", async () => {
+    expect(await bot.getExpectedLabels(["linux"], ["random"])).toEqual([
+      "random",
+    ]);
+    expect(await bot.getExpectedLabels(["inductor"], ["random"])).toEqual([
+      "random",
+      "oncall: pt2",
+    ]);
+    expect(
+      await bot.getExpectedLabels(["linux"], ["random", "module: rocm"])
+    ).toEqual(["random"]);
+    expect(
+      await bot.getExpectedLabels(["rocm"], ["random", "module: rocm"])
+    ).toEqual(["random", "module: rocm"]);
+    expect(
+      await bot.getExpectedLabels(
+        ["dynamo", "inductor"],
+        ["random", "module: rocm"]
+      )
+    ).toEqual(["random", "oncall: pt2"]);
+    expect(
+      await bot.getExpectedLabels(["linux", "rocm"], ["random", "module: rocm"])
+    ).toEqual(["random"]);
+  });
 });
 
 describe("verify-disable-test-issue-bot", () => {
@@ -367,6 +393,101 @@ describe("verify-disable-test-issue-bot", () => {
       )
       .reply(200);
 
+    await probot.receive({ name: "issues", payload: payload, id: "2" });
+
+    handleScope(scope);
+  });
+
+  test("issue with missing labels gets labels", async () => {
+    const payload = requireDeepCopy("./fixtures/issues.opened.json");
+    payload.issue.title = "DISABLED testMethodName (testClass.TestSuite)";
+    payload.issue.user.id = pytorchBotId;
+    payload.issue.body = "Platforms: rocm"
+
+    const owner = payload.repository.owner.login;
+    const repo = payload.repository.name;
+    const number = payload.issue.number;
+
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${owner}/${repo}/issues/${number}/comments?per_page=10`)
+      .reply(200, [])
+      .post(
+        `/repos/${owner}/${repo}/issues/${number}/comments`,
+        (body) => !body.body.includes("don't have permission")
+      )
+      .reply(200)
+      .put(`/repos/${owner}/${repo}/issues/${number}/labels`, (body) =>
+        _.isEqual(body.labels, ["module: rocm"])
+      )
+      .reply(200, []);
+
+
+    await probot.receive({ name: "issues", payload: payload, id: "2" });
+
+    handleScope(scope);
+  });
+
+  test("issue with wrong labels gets correct labels", async () => {
+    const payload = requireDeepCopy("./fixtures/issues.opened.json");
+    payload.issue.title = "DISABLED testMethodName (testClass.TestSuite)";
+    payload.issue.user.id = pytorchBotId;
+    payload.issue.body = "Platforms: rocm"
+    payload.issue.labels = [
+      {
+        name: "random label",
+      },
+      {
+        name: "module: windows",
+      },
+    ];
+    const owner = payload.repository.owner.login;
+    const repo = payload.repository.name;
+    const number = payload.issue.number;
+
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${owner}/${repo}/issues/${number}/comments?per_page=10`)
+      .reply(200, [])
+      .post(
+        `/repos/${owner}/${repo}/issues/${number}/comments`,
+        (body) => !body.body.includes("don't have permission")
+      )
+      .reply(200)
+      .put(`/repos/${owner}/${repo}/issues/${number}/labels`, (body) =>
+        _.isEqual(body.labels, [ "random label", "module: rocm"])
+      )
+      .reply(200, []);
+
+
+    await probot.receive({ name: "issues", payload: payload, id: "2" });
+
+    handleScope(scope);
+  });
+
+  test("issue with correct labels doesn't change", async () => {
+    const payload = requireDeepCopy("./fixtures/issues.opened.json");
+    payload.issue.title = "DISABLED testMethodName (testClass.TestSuite)";
+    payload.issue.user.id = pytorchBotId;
+    payload.issue.body = "Platforms: rocm";
+    payload.issue.labels = [
+      {
+        name: "module: rocm",
+      },
+      {
+        name: "random label",
+      },
+    ];
+    const owner = payload.repository.owner.login;
+    const repo = payload.repository.name;
+    const number = payload.issue.number;
+
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${owner}/${repo}/issues/${number}/comments?per_page=10`)
+      .reply(200, [])
+      .post(
+        `/repos/${owner}/${repo}/issues/${number}/comments`,
+        (body) => !body.body.includes("don't have permission")
+      )
+      .reply(200);
     await probot.receive({ name: "issues", payload: payload, id: "2" });
 
     handleScope(scope);


### PR DESCRIPTION
Some platforms have corresponding labels so add labels based on platform if there is only one set of relevant labels.  

Check labels when issue is opened or edited and correct labels if needed.
