### PR TITLE
Add ROCm5.6 entry to test-times.json

### DIFF
--- a/stats/test-times.json
+++ b/stats/test-times.json
@@ -657,7 +657,7 @@
       "inductor/test_cpu_repro": 113.001
     }
   },
-  "linux-focal-rocm5.5-py3.8": {
+  "linux-focal-rocm5.6-py3.8": {
     "distributed": {
       "distributed/_composable/fully_shard/test_fully_shard_init": 68.47399999999999,
       "distributed/_composable/fully_shard/test_fully_shard_mixed_precision": 13.576,


### PR DESCRIPTION
@clee2000 We would like to skip ROCm5.5 upgrade and go straight to ROCm5.6 in CI. This changes helps enable sharding and prevent timeouts in the CI testing for the upgrade PR.

cc @huydhn 