### PR TITLE
Add inductor into the list of workflows triggerable from HUD

### DIFF
--- a/torchci/components/WorkflowDispatcher.tsx
+++ b/torchci/components/WorkflowDispatcher.tsx
@@ -8,6 +8,7 @@ import { Octokit } from "octokit";
 const SUPPORTED_WORKFLOWS: { [k: string]: any } = {
   "pytorch/pytorch": {
     trunk: "Run trunk jobs",
+    inductor: "Run inductor jobs",
     periodic: "Run periodic jobs",
     slow: "Run slow jobs",
   },


### PR DESCRIPTION
Per title, this is to cover the case when inductor workflow breaks on ghstack commits like trunk

### Testing

Local `yarn dev` and inductor option shows up the bottom of the page for http://localhost:3000/pytorch/pytorch/commit/ffb526a2e42fcd63ff8a9111979efd25d966a76b