### PR TITLE
Add retry mechanism before using conda for the first time

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -77,6 +77,7 @@ runs:
         shell: bash -l {0}
         run: |
           set -euxo pipefail
+          conda info | grep -i 'base environment'
           conda clean --all --quiet --yes
       - name: Reset channel priority
         shell: bash -l {0}

--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -33,12 +33,15 @@ runs:
   using: composite
   steps:
       - name: Remove repository directory (if exists)
-        shell: bash -l {0}
-        env:
-          REPOSITORY: ${{ inputs.repository }}
-        run: |
-          set -euxo pipefail
-          rm -rf "${REPOSITORY}"
+        uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
+        with:
+          shell: bash
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            set -euxo pipefail
+            rm -rf "${{ inputs.repository }}"
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repository }}
@@ -76,7 +79,7 @@ runs:
       - name: Clean conda environment
         uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
         with:
-          shell: bash -l {0}
+          shell: bash
           timeout_minutes: 5
           max_attempts: 3
           retry_wait_seconds: 30

--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -74,11 +74,15 @@ runs:
           miniconda-version: "py39_4.12.0"
           python-version: 3.9
       - name: Clean conda environment
-        shell: bash -l {0}
-        run: |
-          set -euxo pipefail
-          conda info | grep -i 'base environment'
-          conda clean --all --quiet --yes
+        uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
+        with:
+          shell: bash -l {0}
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            set -euxo pipefail
+            conda clean --all --quiet --yes
       - name: Reset channel priority
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
Trying to fix conda related errors: https://github.com/pytorch/test-infra/issues/4155
Error happens during at the beginning of workflow
```
Prepare all required actions
Getting action download info
Download action repository 'conda-incubator/setup-miniconda@v[2](https://github.com/pytorch/test-infra/actions/runs/5448274683/jobs/9911282747?pr=4337#step:7:2).1.1' (SHA:[3](https://github.com/pytorch/test-infra/actions/runs/5448274683/jobs/9911282747?pr=4337#step:7:3)5d1[4](https://github.com/pytorch/test-infra/actions/runs/5448274683/jobs/9911282747?pr=4337#step:7:4)05e78aa3f784fe3ce9a2eb378d5eeb62169)
Run ./test-infra/.github/actions/setup-binary-builds
Run set -euxo pipefail
/github/home/.profile: line 22: conda: command not found
Error: Process completed with exit code 127.
```
And like this as well:

```
Prepare all required actions
Getting action download info
Download action repository 'conda-incubator/setup-miniconda@v[2](https://github.com/pytorch/vision/actions/runs/5443958536/jobs/9901166137#step:6:2).1.1' (SHA:[3](https://github.com/pytorch/vision/actions/runs/5443958536/jobs/9901166137#step:6:3)5d1[4](https://github.com/pytorch/vision/actions/runs/5443958536/jobs/9901166137#step:6:4)05e78aa3f784fe3ce9a2eb378d5eeb62169)
Run ./test-infra/.github/actions/setup-binary-builds
Run set -euxo pipefail

CommandNotFoundError: Your shell has not been properly configured to use 'conda activate'.
To initialize your shell, run

    $ conda init <SHELL_NAME>

Currently supported shells are:
  - bash
  - fish
  - tcsh
  - xonsh
  - zsh
  - powershell

See 'conda init --help' for more information and options.

IMPORTANT: You may need to close and restart your shell after running 'conda init'.
```