### PR TITLE
Don't use ``bash -l {0}`` for setup-binary-builds initial steps

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -79,7 +79,7 @@ runs:
       - name: Clean conda environment
         uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
         with:
-          shell: bash -l {0}
+          shell: bash
           timeout_minutes: 5
           max_attempts: 3
           retry_wait_seconds: 30

--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -77,11 +77,15 @@ runs:
           miniconda-version: "py39_4.12.0"
           python-version: 3.9
       - name: Clean conda environment
-        shell: bash -l {0}
-        run: |
-          set -euxo pipefail
-          conda info | grep -i 'base environment'
-          conda clean --all --quiet --yes
+        uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
+        with:
+          shell: bash -l {0}
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            set -euxo pipefail
+            conda clean --all --quiet --yes
       - name: Reset channel priority
         shell: bash -l {0}
         run: |

--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -33,15 +33,12 @@ runs:
   using: composite
   steps:
       - name: Remove repository directory (if exists)
-        uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
-        with:
-          shell: bash
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 30
-          command: |
-            set -euxo pipefail
-            rm -rf "${{ inputs.repository }}"
+        shell: bash
+        env:
+          REPOSITORY: ${{ inputs.repository }}
+        run: |
+          set -euxo pipefail
+          rm -rf "${REPOSITORY}"
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repository }}
@@ -49,7 +46,7 @@ runs:
           submodules: ${{ inputs.submodules }}
           path: ${{ inputs.repository }}
       - name: Log Available Webhook Fields
-        shell: bash -l {0}
+        shell: bash
         run: |
           echo "ENV VARS"
           echo "${GITHUB_REF_NAME}"
@@ -62,7 +59,7 @@ runs:
           echo "${{ github.ref }}"
           echo "${{ github.base_ref }}"
       - name: Set artifact name
-        shell: bash -l {0}
+        shell: bash
         env:
           PYTHON_VERSION: ${{ inputs.python-version }}
         run: |
@@ -77,23 +74,18 @@ runs:
           miniconda-version: "py39_4.12.0"
           python-version: 3.9
       - name: Clean conda environment
-        uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
-        with:
-          shell: bash
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 30
-          command: |
-            set -euxo pipefail
-            conda clean --all --quiet --yes
+        shell: bash
+        run: |
+          set -euxo pipefail
+          conda clean --all --quiet --yes
       - name: Reset channel priority
-        shell: bash -l {0}
+        shell: bash
         run: |
           set -euxo pipefail
           conda config --set channel_priority false
       - name: Generate file from pytorch_pkg_helpers
         working-directory: ${{ inputs.repository }}
-        shell: bash -l {0}
+        shell: bash
         run: |
           set -euxo pipefail
           CONDA_ENV="${RUNNER_TEMP}/pytorch_pkg_helpers_${GITHUB_RUN_ID}"
@@ -109,7 +101,7 @@ runs:
           cat "${BUILD_ENV_FILE}"
           echo "BUILD_ENV_FILE=${BUILD_ENV_FILE}" >> "${GITHUB_ENV}"
       - name: Setup conda environment for build
-        shell: bash -l {0}
+        shell: bash
         env:
           PYTHON_VERSION: ${{ inputs.python-version }}
         run: |

--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -77,15 +77,11 @@ runs:
           miniconda-version: "py39_4.12.0"
           python-version: 3.9
       - name: Clean conda environment
-        uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
-        with:
-          shell: bash
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 30
-          command: |
-            set -euxo pipefail
-            conda clean --all --quiet --yes
+        shell: bash -l {0}
+        run: |
+          set -euxo pipefail
+          conda info | grep -i 'base environment'
+          conda clean --all --quiet --yes
       - name: Reset channel priority
         shell: bash -l {0}
         run: |

--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -74,18 +74,19 @@ runs:
           miniconda-version: "py39_4.12.0"
           python-version: 3.9
       - name: Clean conda environment
-        shell: bash
+        shell: bash -l {0}
         run: |
           set -euxo pipefail
+          conda info | grep -i 'base environment'
           conda clean --all --quiet --yes
       - name: Reset channel priority
-        shell: bash
+        shell: bash -l {0}
         run: |
           set -euxo pipefail
           conda config --set channel_priority false
       - name: Generate file from pytorch_pkg_helpers
         working-directory: ${{ inputs.repository }}
-        shell: bash
+        shell: bash -l {0}
         run: |
           set -euxo pipefail
           CONDA_ENV="${RUNNER_TEMP}/pytorch_pkg_helpers_${GITHUB_RUN_ID}"
@@ -101,7 +102,7 @@ runs:
           cat "${BUILD_ENV_FILE}"
           echo "BUILD_ENV_FILE=${BUILD_ENV_FILE}" >> "${GITHUB_ENV}"
       - name: Setup conda environment for build
-        shell: bash
+        shell: bash -l {0}
         env:
           PYTHON_VERSION: ${{ inputs.python-version }}
         run: |


### PR DESCRIPTION
Follow up after: https://github.com/pytorch/test-infra/pull/4337
Still observed a failure with retry mechanism:
https://github.com/pytorch/vision/actions/runs/5443957557/jobs/9911563555

Please refer to this comment: https://github.com/pytorch/test-infra/pull/640#discussion_r961191667
We want to use ``bash -l {0}`` only after the step of conda-incubator/setup-miniconda