### PR TITLE
Setup miniconda for linux conda builds

### DIFF
--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-          setup-miniconda: false
+          setup-miniconda: true
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Combine Env Var and Build Env Files
         if: ${{ inputs.env-var-script != '' }}


### PR DESCRIPTION
For wheel builds we setup miniconda: https://github.com/pytorch/test-infra/blob/main/.github/workflows/build_wheels_linux.yml#L108
We want to do it for conda builds as well, so we can avoid use cases where conda is not found.

This should address issue: https://github.com/pytorch/test-infra/issues/4155