### PR TITLE
PT2 dashboard: Highlight speedup as red if a model started failing to run

### DIFF
--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -428,6 +428,11 @@ function ModelPanel({
                     return "";
                   }
 
+                  // It didn't error in the past, but now it does error
+                  if (r === 0) {
+                    return styles.error;
+                  }
+
                   // Increasing more than x%
                   if (l - r > RELATIVE_THRESHOLD * r) {
                     return styles.ok;

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -423,13 +423,15 @@ function ModelPanel({
                 if (lCommit === rCommit) {
                   return l >= SPEEDUP_THRESHOLD ? "" : styles.warning;
                 } else {
-                  if (l === 0 || l === r) {
+                  // l is the new value, r is the old value
+
+                  if (l === r) {
                     // 0 means the model isn't run at all
                     return "";
                   }
 
                   // It didn't error in the past, but now it does error
-                  if (r === 0) {
+                  if (l === 0) {
                     return styles.error;
                   }
 


### PR DESCRIPTION
If a model used to run fine but now shows up as "0" because it started failing/we don't get results, we should highlight it as red.