### PR TITLE
Expose gpus from docker in cuda-based build pipelines

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -75,10 +75,12 @@ jobs:
       REF: ${{ inputs.ref }}
       CU_VERSION: ${{ matrix.desired_cuda }}
       UPLOAD_TO_BASE_BUCKET: ${{ matrix.upload_to_base_bucket }}
+      GPU_FLAG: "${{ matrix.gpu_arch_type == 'cuda' && '--gpus all' || '' }}"
     name: ${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
     container:
       image: ${{ matrix.container_image }}
+      options: ${{ env.GPU_FLAG }}
     # If a build is taking longer than 60 minutes on these runners we need
     # to have a conversation
     timeout-minutes: 60


### PR DESCRIPTION
Passing `--gpus all` as a docker runtime option ti ensure that, when gpus are available on the runner, the container has pass-through access to them. For instances, `nvidia-smi` will fail on a machine with CUDA devices when run inside a container if pass-through is not enabled.