### PR TITLE
Add no-sudo option to linux_job. Required for aarch64 builds

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -77,6 +77,10 @@ on:
         description: "List of secrets to be exported to environment variables"
         type: string
         default: ''
+      no-sudo:
+        description: If set to any value, don't use sudo to clean the workspace
+        required: false
+        default: false
 jobs:
   job:
     name: ${{ inputs.job-name }}
@@ -98,9 +102,17 @@ jobs:
     timeout-minutes: ${{ inputs.timeout }}
     steps:
       - name: Clean workspace
+        env:
+          NO_SUDO: ${{ inputs.no-sudo }}
         run: |
           echo "::group::Cleanup debug output"
-          sudo rm -rfv "${GITHUB_WORKSPACE}"
+
+          if [ -z "${NO_SUDO}" ]; then
+            sudo rm -rfv "${GITHUB_WORKSPACE}"
+          else
+            rm -rfv "${GITHUB_WORKSPACE}"
+          fi
+
           mkdir -p "${GITHUB_WORKSPACE}"
           echo "::endgroup::"
 

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -80,6 +80,7 @@ on:
       no-sudo:
         description: If set to any value, don't use sudo to clean the workspace
         required: false
+        default: false
         type: boolean
 jobs:
   job:
@@ -105,7 +106,7 @@ jobs:
         env:
           NO_SUDO: ${{ inputs.no-sudo }}
         run: |
-          if [ -z "${NO_SUDO}" ]; then
+          if [[ "${NO_SUDO}" == "false" ]]; then
             echo "::group::Cleanup with-sudo debug output"
             sudo rm -rfv "${GITHUB_WORKSPACE}"
           else

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -105,11 +105,11 @@ jobs:
         env:
           NO_SUDO: ${{ inputs.no-sudo }}
         run: |
-          echo "::group::Cleanup debug output"
-
           if [ -z "${NO_SUDO}" ]; then
+            echo "::group::Cleanup with-sudo debug output"
             sudo rm -rfv "${GITHUB_WORKSPACE}"
           else
+            echo "::group::Cleanup no-sudo debug output"
             rm -rfv "${GITHUB_WORKSPACE}"
           fi
 

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -80,7 +80,6 @@ on:
       no-sudo:
         description: If set to any value, don't use sudo to clean the workspace
         required: false
-        default: false
 jobs:
   job:
     name: ${{ inputs.job-name }}

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -80,6 +80,7 @@ on:
       no-sudo:
         description: If set to any value, don't use sudo to clean the workspace
         required: false
+        type: boolean
 jobs:
   job:
     name: ${{ inputs.job-name }}


### PR DESCRIPTION
Add no-sudo option to linux_job. Required for aarch64 builds.
See similar workflow: https://github.com/pytorch/pytorch/blob/main/.github/actions/checkout-pytorch/action.yml