### PR TITLE
Trigger nightly builds (text only)

### DIFF
--- a/.github/workflows/trigger_nightly.yml
+++ b/.github/workflows/trigger_nightly.yml
@@ -29,6 +29,8 @@ jobs:
           repository: pytorch/text
           token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
       - run: |
+          git config --global user.email "pytorchbot@pytorch.com"
+          git config --global user.name "pytorchbot"
           git checkout origin/main
           git fetch origin nightly
           HEAD_COMMIT_HASH=$(git rev-parse HEAD)


### PR DESCRIPTION
Follow up: https://github.com/pytorch/test-infra/pull/4348

Trigger nightly builds (text only).
This is first step to deprecate pytorch.warm package. Trigger nightly builds from this workflow rather from the internal cron job: https://github.com/pytorch/text/pull/792

Tested in this commit: https://github.com/pytorch/text/commit/2c3b0b5d33dd283021fab7dc10aae9e55f5cfd95