### PR TITLE
Remove shard ID and unstable suffix when comparing failed job names with the base commit

### DIFF
--- a/torchci/lib/jobUtils.ts
+++ b/torchci/lib/jobUtils.ts
@@ -2,6 +2,10 @@ import { JobData } from "lib/types";
 import getRocksetClient from "./rockset";
 import rocksetVersions from "rockset/prodVersions.json";
 
+export const REMOVE_JOB_NAME_SUFFIX_REGEX = new RegExp(
+  ", [0-9]+, [0-9]+, (.+)\\)"
+);
+
 export function isFailedJob(job: JobData) {
   return (
     job.conclusion === "failure" ||
@@ -79,4 +83,15 @@ export async function getFlakyJobsFromPreviousWorkflow(
 
   // The query returns all the flaky jobs from the previous workflow
   return flakyJobs;
+}
+
+export function removeJobNameSuffix(
+  jobName: string,
+  replaceWith: string = ")"
+): string {
+  if (!jobName) {
+    return jobName;
+  }
+
+  return jobName.replace(REMOVE_JOB_NAME_SUFFIX_REGEX, replaceWith);
 }

--- a/torchci/lib/jobUtils.ts
+++ b/torchci/lib/jobUtils.ts
@@ -3,7 +3,7 @@ import getRocksetClient from "./rockset";
 import rocksetVersions from "rockset/prodVersions.json";
 
 export const REMOVE_JOB_NAME_SUFFIX_REGEX = new RegExp(
-  ", [0-9]+, [0-9]+, (.+)\\)"
+  ", [0-9]+, [0-9]+, .+\\)"
 );
 
 export function isFailedJob(job: JobData) {

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -373,16 +373,16 @@ function isBrokenTrunk(
     return false;
   }
 
-  return (
-    baseJobs.get(jobNameNoSuffix)!.filter((baseJob) => {
-      if (
-        baseJob.conclusion == job.conclusion &&
-        isEqual(baseJob.failure_captures, job.failure_captures)
-      ) {
-        return true;
-      }
-    }).length !== 0
-  );
+  return baseJobs.get(jobNameNoSuffix)!.some((baseJob) => {
+    if (
+      baseJob.conclusion == job.conclusion &&
+      isEqual(baseJob.failure_captures, job.failure_captures)
+    ) {
+      return true;
+    }
+
+    return false;
+  });
 }
 
 export function getWorkflowJobsStatuses(

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -20,6 +20,7 @@ import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
 import { Octokit } from "octokit";
 import { isEqual } from "lodash";
 import { fetchJSON } from "lib/bot/utils";
+import { removeJobNameSuffix } from "lib/jobUtils";
 
 interface PRandJobs {
   head_sha: string;
@@ -138,7 +139,7 @@ async function addMergeBaseCommits(
 
 async function getBaseCommitJobs(
   workflowsByPR: Map<number, PRandJobs>
-): Promise<Map<string, Map<string, RecentWorkflowsData>>> {
+): Promise<Map<string, Map<string, RecentWorkflowsData[]>>> {
   // get merge base shas
   let baseShas = [];
   for (const [_, pr_info] of workflowsByPR) {
@@ -162,7 +163,30 @@ async function getBaseCommitJobs(
       jobsBySha.get(job.head_sha).set(job.name, job);
     }
   }
-  return jobsBySha;
+
+  const jobsByShaByName = new Map();
+  // regroup the list of failed jobs one more time to remove the shard ID and
+  // the unstable suffix. The former is not needed because the tests could be
+  // run by another shard and failed the same way. The unstable suffix is also
+  // not needed because it's there only to decorate the job name.
+  Object.keys(jobsBySha).forEach((sha: string) => {
+    if (!jobsByShaByName.has(sha)) {
+      jobsByShaByName.set(sha, new Map());
+    }
+
+    Object.keys(jobsBySha.get(sha)).forEach((jobName: string) => {
+      const jobNameNoSuffix = removeJobNameSuffix(jobName);
+      const job = jobsBySha.get(sha).get(jobName);
+
+      if (!jobsByShaByName.get(sha).has(jobNameNoSuffix)) {
+        jobsByShaByName.get(sha).set(jobNameNoSuffix, []);
+      }
+
+      jobsByShaByName.get(sha).get(jobNameNoSuffix).add(job);
+    });
+  });
+
+  return jobsByShaByName;
 }
 
 function constructResultsJobsSections(
@@ -338,10 +362,33 @@ function isFlaky(
   );
 }
 
+function isBrokenTrunk(
+  job: RecentWorkflowsData,
+  baseJobs: Map<string, RecentWorkflowsData[]>
+): boolean {
+  const jobNameNoSuffix = removeJobNameSuffix(job.name);
+
+  // This job doesn't exist in the base commit, thus not a broken trunk failure
+  if (!baseJobs.has(jobNameNoSuffix)) {
+    return false;
+  }
+
+  return (
+    baseJobs.get(jobNameNoSuffix)!.filter((baseJob) => {
+      if (
+        baseJob.conclusion == job.conclusion &&
+        isEqual(baseJob.failure_captures, job.failure_captures)
+      ) {
+        return true;
+      }
+    }).length !== 0
+  );
+}
+
 export function getWorkflowJobsStatuses(
   prInfo: PRandJobs,
   flakyRules: FlakyRule[],
-  baseJobs: Map<string, RecentWorkflowsData>
+  baseJobs: Map<string, RecentWorkflowsData[]>
 ): {
   pending: number;
   failedJobs: RecentWorkflowsData[];
@@ -360,10 +407,7 @@ export function getWorkflowJobsStatuses(
     } else if (job.conclusion === "failure" || job.conclusion === "cancelled") {
       if (job.name !== undefined && job.name.includes("unstable")) {
         unstableJobs.push(job);
-      } else if (
-        baseJobs.get(job.name)?.conclusion == job.conclusion &&
-        isEqual(job.failure_captures, baseJobs.get(job.name)?.failure_captures)
-      ) {
+      } else if (isBrokenTrunk(job, baseJobs)) {
         brokenTrunkJobs.push(job);
       } else if (isFlaky(job, flakyRules)) {
         flakyJobs.push(job);

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -93,6 +93,41 @@ const failedC = {
   failure_captures: ["a"],
 };
 
+const failedD = {
+  name: "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)",
+  conclusion: "failure",
+  completed_at: "2022-07-13T19:34:03Z",
+  html_url: "a",
+  head_sha: "abcdefg",
+  id: "1",
+  pr_number: 1001,
+  failure_captures: ["a", "b"],
+};
+
+// Same as failedD but has a different shard ID
+const failedE = {
+  name: "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 3, 5, linux.g5.4xlarge.nvidia.gpu)",
+  conclusion: "failure",
+  completed_at: "2022-07-13T19:34:03Z",
+  html_url: "a",
+  head_sha: "abcdefg",
+  id: "1",
+  pr_number: 1001,
+  failure_captures: ["a", "b"],
+};
+
+// Same as unstable A but without the unstable suffix
+const failedF = {
+  name: "win-vs2019-cpu-py3 / test (default, 2, 3, windows.4xlarge)",
+  conclusion: "failure",
+  completed_at: "2022-07-13T19:34:03Z",
+  html_url: "a",
+  head_sha: "abcdefg",
+  id: "1",
+  pr_number: 1001,
+  failure_captures: ["a", "b"],
+};
+
 const unstableA = {
   name: "win-vs2019-cpu-py3 / test (default, 1, 3, windows.4xlarge, unstable)",
   conclusion: "failure",
@@ -101,7 +136,7 @@ const unstableA = {
   head_sha: "abcdefg",
   id: "1",
   pr_number: 1001,
-  failure_captures: ["a"],
+  failure_captures: ["a", "b"],
 };
 
 const sev: IssueData = {
@@ -377,7 +412,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
       updateDrciBot.getWorkflowJobsStatuses(
         pr_1001,
         [{ name: failedB.name, captures: failedB.failure_captures }],
-        new Map().set(failedA.name, failedA)
+        new Map().set(failedA.name, [failedA])
       );
     expect(failedJobs.length).toBe(0);
     expect(brokenTrunkJobs.length).toBe(1);

--- a/torchci/test/jobUtils.test.ts
+++ b/torchci/test/jobUtils.test.ts
@@ -1,0 +1,40 @@
+import { removeJobNameSuffix } from "../lib/jobUtils";
+
+describe("Test removing job name suffix", () => {
+  test("no input", () => {
+    expect(removeJobNameSuffix("")).toStrictEqual("");
+  });
+
+  test("various job names", () => {
+    expect(
+      removeJobNameSuffix(
+        "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)"
+      )
+    ).toStrictEqual("linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default)");
+    expect(
+      removeJobNameSuffix(
+        "android-emulator-build-test / build-and-test (default, 1, 1, ubuntu-20.04-16x)"
+      )
+    ).toStrictEqual("android-emulator-build-test / build-and-test (default)");
+    expect(
+      removeJobNameSuffix("linux-focal-rocm5.4.2-py3.8 / build")
+    ).toStrictEqual("linux-focal-rocm5.4.2-py3.8 / build");
+    expect(
+      removeJobNameSuffix("libtorch-cpu-shared-with-deps-release-build")
+    ).toStrictEqual("libtorch-cpu-shared-with-deps-release-build");
+    expect(
+      removeJobNameSuffix(
+        "libtorch-cpu-shared-with-deps-pre-cxx11-build / build"
+      )
+    ).toStrictEqual("libtorch-cpu-shared-with-deps-pre-cxx11-build / build");
+    expect(
+      removeJobNameSuffix("manywheel-py3_8-cuda11_8-test / test")
+    ).toStrictEqual("manywheel-py3_8-cuda11_8-test / test");
+    expect(removeJobNameSuffix("lintrunner / linux-job")).toStrictEqual(
+      "lintrunner / linux-job"
+    );
+    expect(
+      removeJobNameSuffix("Test `run_test.py` is usable without boto3/rockset")
+    ).toStrictEqual("Test `run_test.py` is usable without boto3/rockset");
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/pytorch/test-infra/issues/4328

At the moment, Dr.CI uses the exact job name, i.e. `linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)` when identifying broken trunk failures.  This approach has 2 issues:

* If the job failed due to a bad test, the same test could be run in a different shards between the PR and the base commit.  Thus, Dr.CI failed to capture this case.
* If it was an unstable job, it might or might not have the `unstable` suffix depending if the corresponding unstable issue still remained open or not.  It's fair to remove the suffix too, as it's only a decoration and does't change the job in anyway.

Note that, the logic where the capture failures are compared still applies, i.e. broken trunk = same name without shard id and suffix + same capture failures.

~~I will need to do a similar change in trymerge in a separate PR~~ https://github.com/pytorch/pytorch/pull/104821
