### PR TITLE
Trigger nightly builds (text only)

### DIFF
--- a/.github/workflows/trigger_nightly.yml
+++ b/.github/workflows/trigger_nightly.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       domain:
         description: "What domain to trigger"
-        required: true
+        required: false
         type: choice
         default: all
         options:


### PR DESCRIPTION
Follow up: https://github.com/pytorch/test-infra/pull/4348
Make input parameter not required. Otherwise job is getting skipped when triggered on schedule