### PR TITLE
Trigger inductor-periodic workflow on HUD

### DIFF
--- a/torchci/components/WorkflowDispatcher.tsx
+++ b/torchci/components/WorkflowDispatcher.tsx
@@ -15,6 +15,9 @@ const SUPPORTED_WORKFLOWS: { [k: string]: any } = {
 };
 
 function hasWorkflow(jobs: JobData[], workflow: string) {
+  // A custom hack for inductor as ciflow/inductor is used to trigger both
+  // inductor and inductor-periodic workflows
+  workflow = workflow === "inductor" ? "inductor-periodic" : workflow;
   return _.find(
     jobs,
     (job) => job.name !== undefined && job.name.startsWith(workflow)


### PR DESCRIPTION
Per title.  The label is called `ciflow/inductor`, but it triggers both `inductor` and `inductor-periodic`

### Testing

Use this to trigger `inductor-periodic` on https://hud.pytorch.org/pytorch/pytorch/commit/315a77a02d3648caaffa0b6fd56f35606c50aaef