### PR TITLE
Update linux cuda driver to 535.54.03

### DIFF
--- a/.github/actions/setup-nvidia/action.yml
+++ b/.github/actions/setup-nvidia/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: which driver version to install
     required: false
     type: string
-    default: "525.105.17"   # From https://www.nvidia.com/en-us/drivers/unix
+    default: "535.54.03"   # From https://www.nvidia.com/en-us/drivers/unix
 
 runs:
   using: composite


### PR DESCRIPTION
Fixes failure in nightly conda test:
https://github.com/pytorch/pytorch/actions/runs/5505079662/jobs/10033840450

According to https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
We need to update to: CUDA 12.1 GA | >=530.30.02 | >=531.14

```
CUDA Toolkit | Toolkit Driver Version
  | Linux x86_64 Driver Version | Windows x86_64 Driver Version
CUDA 12.2 GA | >=535.54.03 | >=536.25
CUDA 12.1 Update 1 | >=530.30.02 | >=531.14
CUDA 12.1 GA | >=530.30.02 | >=531.14
CUDA 12.0 Update 1 | >=525.85.12 | >=528.33
CUDA 12.0 GA | >=525.60.13 | >=527.41
CUDA 11.8 GA | >=520.61.05 | >=520.06
```

Test Plan:

```
[ec2-user@ip-10-0-2-162 ~]$ nvidia-smi
Mon Jul 10 15:26:48 2023       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 525.105.17   Driver Version: 525.105.17   CUDA Version: 12.0     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  Tesla M60           Off  | 00000000:00:1E.0 Off |                    0 |
| N/A   41C    P0    37W / 150W |      0MiB /  7680MiB |     84%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
                                                                               
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+
[ec2-user@ip-10-0-2-162 ~]$ docker ps -a
CONTAINER ID   IMAGE                            COMMAND       CREATED         STATUS    PORTS     NAMES
509943fceaef   pytorch/conda-builder:cuda12.1   "/bin/bash"   5 minutes ago   Created             loving_varahamihira
[ec2-user@ip-10-0-2-162 ~]$ docker exec -it 509943fceaef /bin/bash
Error response from daemon: Container 509943fceaefbe18071801728d91b63832abb5f63db6f6ee2a6ca6ef5eace544 is not running
[ec2-user@ip-10-0-2-162 ~]$ docker start 509943fceaef
Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error running hook #0: error running hook: exit status 1, stdout: , stderr: Auto-detected mode as 'legacy'
nvidia-container-cli: requirement error: unsatisfied condition: cuda>=12.1, please update your driver to a newer version, or use an earlier cuda container: unknown
Error: failed to start containers: 509943fceaef

curl -O https://ossci-linux.s3.amazonaws.com/nvidia_driver/NVIDIA-Linux-x86_64-535.54.03.run
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  331M  100  331M    0     0  58.0M      0  0:00:05  0:00:05 --:--:-- 54.9M
[ec2-user@ip-10-0-2-162 _temp]$ sudo /bin/bash NVIDIA-Linux-x86_64-535.54.03.run -s --no-drm
Verifying archive integrity... OK
Uncompressing NVIDIA Accelerated Graphics Driver for Linux-x86_64 535.54.03......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

WARNING: The nvidia-drm module will not be installed. As a result, DRM-KMS will not function with this installation of the NVIDIA
         driver.


WARNING: nvidia-installer was forced to guess the X library path '/usr/lib64' and X module path '/usr/lib64/xorg/modules'; these paths
         were not queryable from the system.  If X fails to find the NVIDIA X driver module, please install the `pkg-config` utility
         and the X.Org SDK/development package for your distribution and reinstall the driver.


WARNING: This NVIDIA driver package includes Vulkan components, but no Vulkan ICD loader was detected on this system. The NVIDIA
         Vulkan ICD will not function without the loader. Most distributions package the Vulkan loader; try installing the
         "vulkan-loader", "vulkan-icd-loader", or "libvulkan1" package.

[ec2-user@ip-10-0-2-162 _temp]$ nvidia-smi
Mon Jul 10 15:46:19 2023       
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.54.03              Driver Version: 535.54.03    CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  Tesla M60                      Off | 00000000:00:1E.0 Off |                    0 |
| N/A   41C    P0              38W / 150W |      0MiB /  7680MiB |     12%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
                                                                                         
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|  No running processes found                                                           |
+---------------------------------------------------------------------------------------+
[ec2-user@ip-10-0-2-162 _temp]$ docker start 509943fceaef
509943fceaef
[ec2-user@ip-10-0-2-162 _temp]$ docker ps -a
CONTAINER ID   IMAGE                            COMMAND       CREATED          STATUS         PORTS     NAMES
509943fceaef   pytorch/conda-builder:cuda12.1   "/bin/bash"   25 minutes ago   Up 4 seconds             loving_varahamihira
[ec2-user@ip-10-0-2-162 _temp]$ docker exec -it 509943fceaef /bin/bash
[root@509943fceaef /]# ls
anaconda-post.log  builder  etc         home             lib    media  opt   pytorch  run   srv  tmp  var
bin                dev      final_pkgs  install_cuda.sh  lib64  mnt    proc  root     sbin  sys  usr
```