### PR TITLE
Add docker failures to nightly HUD page. Change org of nightly page

### DIFF
--- a/torchci/pages/nightlies.tsx
+++ b/torchci/pages/nightlies.tsx
@@ -82,22 +82,24 @@ function ValidationRedPanel({
   channel: string;
   query_type: string;
 }) {
-
-  const url = `/api/query/nightlies/`+query_type+`_jobs_red?parameters=${encodeURIComponent(
-    JSON.stringify([
-      ...params,
-      {
-        name: "timezone",
-        type: "string",
-        value: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      },
-      {
-        name: "channel",
-        type: "string",
-        value: channel,
-      },
-    ])
-  )}`;
+  const url =
+    `/api/query/nightlies/` +
+    query_type +
+    `_jobs_red?parameters=${encodeURIComponent(
+      JSON.stringify([
+        ...params,
+        {
+          name: "timezone",
+          type: "string",
+          value: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        },
+        {
+          name: "channel",
+          type: "string",
+          value: channel,
+        },
+      ])
+    )}`;
 
   const { data } = useSWR(url, fetcher, {
     refreshInterval: 5 * 60 * 1000, // refresh every 5 minutes
@@ -109,12 +111,13 @@ function ValidationRedPanel({
 
   const options: EChartsOption = {
     title: {
-      text: channel.charAt(0).toUpperCase()+
-      channel.slice(1)+
-      " "+
-      query_type.charAt(0).toUpperCase()+
-      query_type.slice(1)+
-      " workflows failures"
+      text:
+        channel.charAt(0).toUpperCase() +
+        channel.slice(1) +
+        " " +
+        query_type.charAt(0).toUpperCase() +
+        query_type.slice(1) +
+        " workflows failures",
     },
     grid: { top: 60, right: 8, bottom: 24, left: 36 },
     dataset: { source: data },
@@ -220,10 +223,7 @@ export default function Page() {
         />
       </Stack>
 
-      
-
       <Grid container spacing={2}>
-        
         <Grid item xs={6} height={ROW_HEIGHT}>
           <NightlyJobsRedPanel params={timeParams} repo={"pytorch"} />
         </Grid>
@@ -232,11 +232,13 @@ export default function Page() {
           <TablePanel
             title={"Nightly PyTorch build jobs for past 24hrs"}
             queryName={"nightly_jobs_red_past_day"}
-            queryParams={[{
+            queryParams={[
+              {
                 name: "repo",
                 type: "string",
                 value: "pytorch",
-              }]}
+              },
+            ]}
             queryCollection="nightlies"
             columns={[
               { field: "COUNT", headerName: "Count", flex: 1 },
@@ -254,11 +256,13 @@ export default function Page() {
           <TablePanel
             title={"Nightly Vision build jobs for past 24hrs"}
             queryName={"nightly_jobs_red_past_day"}
-            queryParams={[{
+            queryParams={[
+              {
                 name: "repo",
                 type: "string",
                 value: "vision",
-              }]}
+              },
+            ]}
             queryCollection="nightlies"
             columns={[
               { field: "COUNT", headerName: "Count", flex: 1 },
@@ -276,11 +280,13 @@ export default function Page() {
           <TablePanel
             title={"Nightly Audio build jobs for past 24hrs"}
             queryName={"nightly_jobs_red_past_day"}
-            queryParams={[{
+            queryParams={[
+              {
                 name: "repo",
                 type: "string",
                 value: "audio",
-              }]}
+              },
+            ]}
             queryCollection="nightlies"
             columns={[
               { field: "COUNT", headerName: "Count", flex: 1 },
@@ -303,7 +309,8 @@ export default function Page() {
                 name: "repo",
                 type: "string",
                 value: "text",
-              }]}
+              },
+            ]}
             queryCollection="nightlies"
             columns={[
               { field: "COUNT", headerName: "Count", flex: 1 },
@@ -314,18 +321,24 @@ export default function Page() {
         </Grid>
 
         <Grid item xs={6} height={ROW_HEIGHT}>
-          <ValidationRedPanel params={timeParams} channel={"release"} query_type={"validation"}/>
+          <ValidationRedPanel
+            params={timeParams}
+            channel={"release"}
+            query_type={"validation"}
+          />
         </Grid>
 
         <Grid item xs={6} height={ROW_HEIGHT}>
           <TablePanel
             title={"Release failed validation jobs for past 24hrs"}
             queryName={"validation_jobs_red_past_day"}
-            queryParams={[{
+            queryParams={[
+              {
                 name: "channel",
                 type: "string",
                 value: "release",
-              }]}
+              },
+            ]}
             queryCollection="nightlies"
             columns={[
               { field: "COUNT", headerName: "Count", flex: 1 },
@@ -336,18 +349,24 @@ export default function Page() {
         </Grid>
 
         <Grid item xs={6} height={ROW_HEIGHT}>
-          <ValidationRedPanel params={timeParams} channel={"nightly"} query_type={"validation"}/>
+          <ValidationRedPanel
+            params={timeParams}
+            channel={"nightly"}
+            query_type={"validation"}
+          />
         </Grid>
 
         <Grid item xs={6} height={ROW_HEIGHT}>
           <TablePanel
             title={"Nightly failed validation jobs for past 24hrs"}
             queryName={"validation_jobs_red_past_day"}
-            queryParams={[{
+            queryParams={[
+              {
                 name: "channel",
                 type: "string",
                 value: "nightly",
-              }]}
+              },
+            ]}
             queryCollection="nightlies"
             columns={[
               { field: "COUNT", headerName: "Count", flex: 1 },
@@ -358,7 +377,11 @@ export default function Page() {
         </Grid>
 
         <Grid item xs={6} height={ROW_HEIGHT}>
-          <ValidationRedPanel params={timeParams} channel={""} query_type={"docker"}/>
+          <ValidationRedPanel
+            params={timeParams}
+            channel={""}
+            query_type={"docker"}
+          />
         </Grid>
 
         <Grid item xs={6} height={ROW_HEIGHT}>

--- a/torchci/pages/nightlies.tsx
+++ b/torchci/pages/nightlies.tsx
@@ -7,6 +7,7 @@ import { Grid, Paper, Typography, Stack, Skeleton } from "@mui/material";
 import { useState } from "react";
 import { RocksetParam } from "lib/rockset";
 import { fetcher } from "lib/GeneralUtils";
+
 import TablePanel from "components/metrics/panels/TablePanel";
 import { TimeRangePicker } from "pages/metrics";
 
@@ -75,11 +76,14 @@ function NightlyJobsRedPanel({
 function ValidationRedPanel({
   params,
   channel,
+  query_type,
 }: {
   params: RocksetParam[];
   channel: string;
+  query_type: string;
 }) {
-  const url = `/api/query/nightlies/validation_jobs_red?parameters=${encodeURIComponent(
+
+  const url = `/api/query/nightlies/`+query_type+`_jobs_red?parameters=${encodeURIComponent(
     JSON.stringify([
       ...params,
       {
@@ -105,11 +109,12 @@ function ValidationRedPanel({
 
   const options: EChartsOption = {
     title: {
-      text:
-        channel.charAt(0).toUpperCase() +
-        channel.slice(1) +
-        " validation workflows failures, by day",
-      subtext: "Installation of PyTorch, Vision and Audio an smoke test",
+      text: channel.charAt(0).toUpperCase()+
+      channel.slice(1)+
+      " "+
+      query_type.charAt(0).toUpperCase()+
+      query_type.slice(1)+
+      " workflows failures"
     },
     grid: { top: 60, right: 8, bottom: 24, left: 36 },
     dataset: { source: data },
@@ -215,9 +220,30 @@ export default function Page() {
         />
       </Stack>
 
+      
+
       <Grid container spacing={2}>
+        
         <Grid item xs={6} height={ROW_HEIGHT}>
           <NightlyJobsRedPanel params={timeParams} repo={"pytorch"} />
+        </Grid>
+
+        <Grid item xs={6} height={ROW_HEIGHT}>
+          <TablePanel
+            title={"Nightly PyTorch build jobs for past 24hrs"}
+            queryName={"nightly_jobs_red_past_day"}
+            queryParams={[{
+                name: "repo",
+                type: "string",
+                value: "pytorch",
+              }]}
+            queryCollection="nightlies"
+            columns={[
+              { field: "COUNT", headerName: "Count", flex: 1 },
+              { field: "name", headerName: "Name", flex: 4 },
+            ]}
+            dataGridProps={{ getRowId: (el: any) => el.name }}
+          />
         </Grid>
 
         <Grid item xs={6} height={ROW_HEIGHT}>
@@ -225,92 +251,14 @@ export default function Page() {
         </Grid>
 
         <Grid item xs={6} height={ROW_HEIGHT}>
-          <NightlyJobsRedPanel params={timeParams} repo={"audio"} />
-        </Grid>
-
-        <Grid item xs={6} height={ROW_HEIGHT}>
-          <NightlyJobsRedPanel params={timeParams} repo={"text"} />
-        </Grid>
-
-        <Grid item xs={6} height={ROW_HEIGHT}>
-          <ValidationRedPanel params={timeParams} channel={"release"} />
-        </Grid>
-
-        <Grid item xs={6} height={ROW_HEIGHT}>
-          <ValidationRedPanel params={timeParams} channel={"nightly"} />
-        </Grid>
-
-        <Grid item xs={6} height={ROW_HEIGHT}>
-          <TablePanel
-            title={"Release failed validation jobs for past 24hrs"}
-            queryName={"validation_jobs_red_past_day"}
-            queryParams={[
-              {
-                name: "channel",
-                type: "string",
-                value: "release",
-              },
-            ]}
-            queryCollection="nightlies"
-            columns={[
-              { field: "COUNT", headerName: "Count", flex: 1 },
-              { field: "name", headerName: "Name", flex: 4 },
-            ]}
-            dataGridProps={{ getRowId: (el: any) => el.name }}
-          />
-        </Grid>
-
-        <Grid item xs={6} height={ROW_HEIGHT}>
-          <TablePanel
-            title={"Nightly failed validation jobs for past 24hrs"}
-            queryName={"validation_jobs_red_past_day"}
-            queryParams={[
-              {
-                name: "channel",
-                type: "string",
-                value: "nightly",
-              },
-            ]}
-            queryCollection="nightlies"
-            columns={[
-              { field: "COUNT", headerName: "Count", flex: 1 },
-              { field: "name", headerName: "Name", flex: 4 },
-            ]}
-            dataGridProps={{ getRowId: (el: any) => el.name }}
-          />
-        </Grid>
-
-        <Grid item xs={6} height={ROW_HEIGHT}>
-          <TablePanel
-            title={"Nightly PyTorch build jobs for past 24hrs"}
-            queryName={"nightly_jobs_red_past_day"}
-            queryParams={[
-              {
-                name: "repo",
-                type: "string",
-                value: "pytorch",
-              },
-            ]}
-            queryCollection="nightlies"
-            columns={[
-              { field: "COUNT", headerName: "Count", flex: 1 },
-              { field: "name", headerName: "Name", flex: 4 },
-            ]}
-            dataGridProps={{ getRowId: (el: any) => el.name }}
-          />
-        </Grid>
-
-        <Grid item xs={6} height={ROW_HEIGHT}>
           <TablePanel
             title={"Nightly Vision build jobs for past 24hrs"}
             queryName={"nightly_jobs_red_past_day"}
-            queryParams={[
-              {
+            queryParams={[{
                 name: "repo",
                 type: "string",
                 value: "vision",
-              },
-            ]}
+              }]}
             queryCollection="nightlies"
             columns={[
               { field: "COUNT", headerName: "Count", flex: 1 },
@@ -318,19 +266,21 @@ export default function Page() {
             ]}
             dataGridProps={{ getRowId: (el: any) => el.name }}
           />
+        </Grid>
+
+        <Grid item xs={6} height={ROW_HEIGHT}>
+          <NightlyJobsRedPanel params={timeParams} repo={"audio"} />
         </Grid>
 
         <Grid item xs={6} height={ROW_HEIGHT}>
           <TablePanel
             title={"Nightly Audio build jobs for past 24hrs"}
             queryName={"nightly_jobs_red_past_day"}
-            queryParams={[
-              {
+            queryParams={[{
                 name: "repo",
                 type: "string",
                 value: "audio",
-              },
-            ]}
+              }]}
             queryCollection="nightlies"
             columns={[
               { field: "COUNT", headerName: "Count", flex: 1 },
@@ -338,6 +288,10 @@ export default function Page() {
             ]}
             dataGridProps={{ getRowId: (el: any) => el.name }}
           />
+        </Grid>
+
+        <Grid item xs={6} height={ROW_HEIGHT}>
+          <NightlyJobsRedPanel params={timeParams} repo={"text"} />
         </Grid>
 
         <Grid item xs={6} height={ROW_HEIGHT}>
@@ -349,8 +303,69 @@ export default function Page() {
                 name: "repo",
                 type: "string",
                 value: "text",
-              },
+              }]}
+            queryCollection="nightlies"
+            columns={[
+              { field: "COUNT", headerName: "Count", flex: 1 },
+              { field: "name", headerName: "Name", flex: 4 },
             ]}
+            dataGridProps={{ getRowId: (el: any) => el.name }}
+          />
+        </Grid>
+
+        <Grid item xs={6} height={ROW_HEIGHT}>
+          <ValidationRedPanel params={timeParams} channel={"release"} query_type={"validation"}/>
+        </Grid>
+
+        <Grid item xs={6} height={ROW_HEIGHT}>
+          <TablePanel
+            title={"Release failed validation jobs for past 24hrs"}
+            queryName={"validation_jobs_red_past_day"}
+            queryParams={[{
+                name: "channel",
+                type: "string",
+                value: "release",
+              }]}
+            queryCollection="nightlies"
+            columns={[
+              { field: "COUNT", headerName: "Count", flex: 1 },
+              { field: "name", headerName: "Name", flex: 4 },
+            ]}
+            dataGridProps={{ getRowId: (el: any) => el.name }}
+          />
+        </Grid>
+
+        <Grid item xs={6} height={ROW_HEIGHT}>
+          <ValidationRedPanel params={timeParams} channel={"nightly"} query_type={"validation"}/>
+        </Grid>
+
+        <Grid item xs={6} height={ROW_HEIGHT}>
+          <TablePanel
+            title={"Nightly failed validation jobs for past 24hrs"}
+            queryName={"validation_jobs_red_past_day"}
+            queryParams={[{
+                name: "channel",
+                type: "string",
+                value: "nightly",
+              }]}
+            queryCollection="nightlies"
+            columns={[
+              { field: "COUNT", headerName: "Count", flex: 1 },
+              { field: "name", headerName: "Name", flex: 4 },
+            ]}
+            dataGridProps={{ getRowId: (el: any) => el.name }}
+          />
+        </Grid>
+
+        <Grid item xs={6} height={ROW_HEIGHT}>
+          <ValidationRedPanel params={timeParams} channel={""} query_type={"docker"}/>
+        </Grid>
+
+        <Grid item xs={6} height={ROW_HEIGHT}>
+          <TablePanel
+            title={"Docker failed  jobs for past 24hrs"}
+            queryName={"docker_jobs_red_past_day"}
+            queryParams={[]}
             queryCollection="nightlies"
             columns={[
               { field: "COUNT", headerName: "Count", flex: 1 },

--- a/torchci/rockset/nightlies/__sql/docker_jobs_red.sql
+++ b/torchci/rockset/nightlies/__sql/docker_jobs_red.sql
@@ -1,0 +1,53 @@
+with commit_overall_conclusion as (
+    SELECT
+        time,
+        CASE
+            WHEN COUNT_IF(conclusion = 'red') > 0 THEN 'red'
+            WHEN COUNT_IF(conclusion = 'pending') > 0 THEN 'pending'
+            ELSE 'green'
+        END as overall_conclusion
+    FROM
+        (
+            SELECT
+                job._event_time as time,
+                CASE
+                    WHEN job.conclusion = 'failure' THEN 'red'
+                    WHEN job.conclusion = 'timed_out' THEN 'red'
+                    WHEN job.conclusion = 'cancelled' THEN 'red'
+                    WHEN job.conclusion IS NULL THEN 'pending'
+                    ELSE 'green'
+                END as conclusion
+            FROM
+                commons.workflow_job job
+                JOIN commons.workflow_run workflow on workflow.id = job.run_id
+            WHERE
+                job.head_branch = 'main' 
+                AND job.name like '%docker%'
+                AND workflow.repository.full_name = 'pytorch/builder' 
+                AND job._event_time >= PARSE_DATETIME_ISO8601(:startTime)
+                AND job._event_time < PARSE_DATETIME_ISO8601(:stopTime)
+        ) as all_job
+    GROUP BY
+        time
+    ORDER BY
+        time DESC
+)
+SELECT
+    FORMAT_TIMESTAMP(
+        '%Y-%m-%d',
+        DATE_TRUNC('hour', time),
+        :timezone
+    ) AS granularity_bucket,
+    COUNT_IF(overall_conclusion = 'red') AS red,
+    COUNT_IF(overall_conclusion = 'pending') AS pending,
+    COUNT_IF(overall_conclusion = 'green') AS green,
+    COUNT(*) as total,
+FROM
+    commit_overall_conclusion
+GROUP BY
+    granularity_bucket
+ORDER BY
+    granularity_bucket ASC
+
+
+

--- a/torchci/rockset/nightlies/__sql/docker_jobs_red_past_day.sql
+++ b/torchci/rockset/nightlies/__sql/docker_jobs_red_past_day.sql
@@ -1,0 +1,14 @@
+SELECT
+  COUNT(*) COUNT,
+  job.name
+FROM
+  commons.workflow_job job
+  JOIN commons.workflow_run workflow on workflow.id = job.run_id
+WHERE
+  job.head_branch = 'main' 
+  AND job.name like '%docker%'
+  AND job.conclusion in ('failure', 'timed_out', 'cancelled') 
+  AND workflow.repository.full_name = 'pytorch/builder' 
+  AND job._event_time >= CURRENT_DATE() - INTERVAL 1 DAY
+GROUP BY job.name
+ORDER BY COUNT DESC

--- a/torchci/rockset/nightlies/docker_jobs_red.lambda.json
+++ b/torchci/rockset/nightlies/docker_jobs_red.lambda.json
@@ -1,0 +1,26 @@
+{
+  "sql_path": "__sql/docker_jobs_red.sql",
+  "default_parameters": [
+    {
+      "name": "granularity",
+      "type": "string",
+      "value": "day"
+    },
+    {
+      "name": "startTime",
+      "type": "string",
+      "value": "2023-06-19T00:00:38.270Z"
+    },
+    {
+      "name": "stopTime",
+      "type": "string",
+      "value": "2023-07-11T20:20:38.270Z"
+    },
+    {
+      "name": "timezone",
+      "type": "string",
+      "value": "America/Los_Angeles"
+    }
+  ],
+  "description": ""
+}

--- a/torchci/rockset/nightlies/docker_jobs_red_past_day.lambda.json
+++ b/torchci/rockset/nightlies/docker_jobs_red_past_day.lambda.json
@@ -1,0 +1,5 @@
+{
+  "sql_path": "__sql/docker_jobs_red_past_day.sql",
+  "default_parameters": [],
+  "description": ""
+}

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -86,6 +86,8 @@
     "runner_utilization_by_activity": "343929e0ebeee379"
   },
   "nightlies": {
+    "docker_jobs_red": "5ccfc6bee649dc8a",
+    "docker_jobs_red_past_day": "13b52e7005825031",
     "nightly_jobs_red": "d49bc5633c5aac10",
     "nightly_jobs_red_by_name": "bb6eeb316157ed2b",
     "nightly_jobs_red_by_platform": "d5ab478e83ff2dae",


### PR DESCRIPTION
This
1. Adds docker failures to nightly page
2. Arranges the page in logical way having failure graph on the left and table with list of jobs failed for past 24hrs on the right
<img width="1623" alt="Screenshot 2023-07-10 at 5 08 45 PM" src="https://github.com/pytorch/test-infra/assets/7563158/405bbda0-6119-42bf-8b3a-eda57bbf60d9">

