### PR TITLE
Make sure the nightly trigger executes on schedule

### DIFF
--- a/.github/workflows/trigger_nightly.yml
+++ b/.github/workflows/trigger_nightly.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   tag_nightly_vision:
-    if:  inputs.domain == 'text' || inputs.domain == 'all'
+    if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'text' || inputs.domain == 'all' }}
     name: Trigger nightly text build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/trigger_nightly.yml
+++ b/.github/workflows/trigger_nightly.yml
@@ -18,7 +18,7 @@ on:
           - all
 
 jobs:
-  tag_nightly_vision:
+  tag_nightly_text:
     if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'text' || inputs.domain == 'all' }}
     name: Trigger nightly text build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Make sure the nightly trigger executes on schedule.
This workflow is currently getting skipped: https://github.com/pytorch/test-infra/actions/runs/5515831720 during nightly but works on manual activation