### PR TITLE
Fix the wrong use of Map with Object.keys in getBaseCommitJobs

### DIFF
--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -137,7 +137,7 @@ async function addMergeBaseCommits(
   });
 }
 
-async function getBaseCommitJobs(
+export async function getBaseCommitJobs(
   workflowsByPR: Map<number, PRandJobs>
 ): Promise<Map<string, Map<string, RecentWorkflowsData[]>>> {
   // get merge base shas
@@ -169,12 +169,12 @@ async function getBaseCommitJobs(
   // the unstable suffix. The former is not needed because the tests could be
   // run by another shard and failed the same way. The unstable suffix is also
   // not needed because it's there only to decorate the job name.
-  Object.keys(jobsBySha).forEach((sha: string) => {
+  for (const sha of jobsBySha.keys()) {
     if (!jobsByShaByName.has(sha)) {
       jobsByShaByName.set(sha, new Map());
     }
 
-    Object.keys(jobsBySha.get(sha)).forEach((jobName: string) => {
+    for (const jobName of jobsBySha.get(sha).keys()) {
       const jobNameNoSuffix = removeJobNameSuffix(jobName);
       const job = jobsBySha.get(sha).get(jobName);
 
@@ -182,9 +182,10 @@ async function getBaseCommitJobs(
         jobsByShaByName.get(sha).set(jobNameNoSuffix, []);
       }
 
-      jobsByShaByName.get(sha).get(jobNameNoSuffix).add(job);
-    });
-  });
+      jobsByShaByName.get(sha).get(jobNameNoSuffix).push(job);
+    }
+  }
+  console.log(jobsByShaByName);
 
   return jobsByShaByName;
 }

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -185,7 +185,6 @@ export async function getBaseCommitJobs(
       jobsByShaByName.get(sha).get(jobNameNoSuffix).push(job);
     }
   }
-  console.log(jobsByShaByName);
 
   return jobsByShaByName;
 }

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -13,6 +13,7 @@ import { IssueData } from "lib/types";
 import { testOctokit } from "./utils";
 import dayjs from "dayjs";
 import { removeJobNameSuffix } from "lib/jobUtils";
+import * as fetchRecentWorkflows from "lib/fetchRecentWorkflows";
 
 nock.disableNetConnect();
 
@@ -509,5 +510,22 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     expect(header.includes("Python docs built from this PR")).toBeTruthy();
     expect(header.includes("C++ docs built from this PR")).toBeFalsy();
     expect(header.includes("bot commands wiki")).toBeFalsy();
+  });
+
+  test("test getBaseCommitJobs", async () => {
+    const originalWorkflows = [failedA, failedB];
+    const workflowsByPR = await updateDrciBot.reorganizeWorkflows(
+      originalWorkflows
+    );
+    const mock = jest.spyOn(fetchRecentWorkflows, "fetchFailedJobsFromCommits");
+    mock.mockImplementation(() => Promise.resolve([failedA, failedB]));
+
+    const baseCommitJobs = await updateDrciBot.getBaseCommitJobs(workflowsByPR);
+    expect(baseCommitJobs).toMatchObject(
+      new Map().set(
+        failedA.head_sha,
+        new Map().set(failedA.name, [failedA]).set(failedB.name, [failedB])
+      )
+    );
   });
 });

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -527,5 +527,16 @@ describe("Update Dr. CI Bot Unit Tests", () => {
         new Map().set(failedA.name, [failedA]).set(failedB.name, [failedB])
       )
     );
+
+    const { pending, failedJobs, flakyJobs, brokenTrunkJobs, unstableJobs } =
+      updateDrciBot.getWorkflowJobsStatuses(
+        workflowsByPR.get(1001)!,
+        [],
+        baseCommitJobs.get(failedA.head_sha)!
+      );
+    expect(failedJobs.length).toBe(0);
+    expect(brokenTrunkJobs.length).toBe(2);
+    expect(flakyJobs.length).toBe(0);
+    expect(unstableJobs.length).toBe(0);
   });
 });


### PR DESCRIPTION
[Object.keys](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys) iterates though all string-keyed property names in the object.  However, this works with `{}` but not with a `Map` object.  In fact, `Object.keys(mapObject)` returns an empty array.

Getting the empty list of base commit jobs means Dr.CI fails to detect broken trunk failures, i.e. https://github.com/pytorch/pytorch/pull/105145

### Testing

This is a big gotcha moment for me, so I add an unit test for `getBaseCommitJobs` to properly test this