### PR TITLE
[log classifier] Change inductor model regex

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -98,7 +98,7 @@ pattern = '^ERROR (?:\[.*s\] )?(\S*.py::\S*::test_\S*)'
 
 [[rule]]
 name = 'inductor model failure'
-pattern = '^(\S*) *(fail_accuracy|fail_to_run|eager_variation|0\.0000)$'
+pattern = '^([A-Za-z0-9_]+) +(FAIL|IMRPOVED): *(.*)$'
 
 [[rule]]
 name = 'NVIDIA installation failure'


### PR DESCRIPTION
Currently its matching to a line saying `fail_accuracy` on both succeeding and failing jobs for a model that is expected to fail.

I assume model names fit `[A-Za-z0-9_]+`

The extra FAIL and IMPROVED should match https://github.com/pytorch/pytorch/blob/5837e95d303464141009b8072636bb4442e2fcb2/benchmarks/dynamo/check_accuracy.py#L24

<details>
<summary>Lines it should match</summary>

```
15059727721 pytorch_CycleGAN_and_pix2pix        FAIL:     accuracy=fail_accuracy, expected=pass
15052125440 attention_is_all_you_need_pytorch   FAIL:     accuracy=infra_error, expected=pass
15032425916 attention_is_all_you_need_pytorch   FAIL:     accuracy=infra_error, expected=pass
15005462402 pytorch_CycleGAN_and_pix2pix        FAIL:     accuracy=fail_accuracy, expected=pass
15004950473 moco                                FAIL:     accuracy=infra_error, expected=pass
15003327315 moco                                FAIL:     accuracy=infra_error, expected=pass
14992120963 yolov3                              FAIL:     accuracy=fail_to_run, expected=pass
14991959965 yolov3                              FAIL:     accuracy=fail_to_run, expected=pass
14991193445 yolov3                             fail_to_run
14991200383 yolov3                              FAIL:     accuracy=fail_to_run, expected=pass
14991192775 yolov3                             fail_to_run
14991031359 yolov3                             fail_to_run
14991022384 yolov3                              FAIL:     accuracy=fail_to_run, expected=pass
14991030398 yolov3                             fail_to_run
14991021573 yolov3                              FAIL:     accuracy=fail_to_run, expected=pass
14990957539 yolov3                              FAIL:     accuracy=fail_to_run, expected=pass
14990958358 yolov3                              FAIL:     accuracy=fail_to_run, expected=pass
14990745961 yolov3                              FAIL:     accuracy=fail_to_run, expected=pass
14990745110 yolov3                              FAIL:     accuracy=fail_to_run, expected=pass
14991960688 yolov3                              FAIL:     accuracy=fail_to_run, expected=pass
14992120082 yolov3                              FAIL:     accuracy=fail_to_run, expected=pass
14991201343 yolov3                              FAIL:     accuracy=fail_to_run, expected=pass
14990240544 yolov3                             fail_to_run
14990239721 yolov3                             fail_to_run
14990144521 yolov3                              FAIL:     accuracy=fail_to_run, expected=pass
14990099699 yolov3                              FAIL:     accuracy=fail_to_run, expected=pass
14990075279 yolov3                             fail_to_run
14990076131 yolov3                             fail_to_run
14989943257 yolov3                             fail_to_run
14990098774 yolov3                              FAIL:     accuracy=fail_to_run, expected=pass
14989942420 yolov3                             fail_to_run
14989771376 yolov3                             fail_to_run
14990145342 yolov3                              FAIL:     accuracy=fail_to_run, expected=pass
14989770572 yolov3                             fail_to_run
14989138493 yolov3                             fail_to_run
14989137729 yolov3                             fail_to_run
14988560201 yolov3                             fail_to_run
14988559417 yolov3                             fail_to_run
14979033013 pytorch_CycleGAN_and_pix2pix        FAIL:     accuracy=fail_accuracy, expected=pass
14977103591 moco                                FAIL:     accuracy=infra_error, expected=pass
14962681774 moco                                FAIL:     accuracy=infra_error, expected=pass
14955983946 moco                                FAIL:     accuracy=infra_error, expected=pass
14962682169 pytorch_CycleGAN_and_pix2pix        FAIL:     accuracy=fail_accuracy, expected=pass
14928195104 attention_is_all_you_need_pytorch   FAIL:     accuracy=infra_error, expected=pass
14896106512 moco                                FAIL:     accuracy=infra_error, expected=pass
14886115513 moco                                FAIL:     accuracy=infra_error, expected=pass
14877315574 pytorch_CycleGAN_and_pix2pix        FAIL:     accuracy=fail_accuracy, expected=pass
14875915124 drq                                 FAIL:     accuracy=infra_error, expected=pass
14875915124 soft_actor_critic                   FAIL:     accuracy=infra_error, expected=pass
14875945618 pytorch_CycleGAN_and_pix2pix        FAIL:     accuracy=fail_accuracy, expected=pass
14875945815 convnext_base                       FAIL:     accuracy=timeout, expected=pass
14872552175 shufflenet_v2_x1_0                  FAIL:     accuracy=infra_error, expected=pass
14871741158 pytorch_CycleGAN_and_pix2pix        FAIL:     accuracy=fail_accuracy, expected=pass
14869663157 moco                                FAIL:     accuracy=infra_error, expected=pass
14862549270 pytorch_CycleGAN_and_pix2pix        FAIL:     accuracy=fail_accuracy, expected=pass
14863764682 moco                                FAIL:     accuracy=infra_error, expected=pass
14846255280 pytorch_CycleGAN_and_pix2pix        FAIL:     accuracy=fail_accuracy, expected=pass
```
</details>