### PR TITLE
Add nightly trigger for pytorch/pytorch

### DIFF
--- a/.github/workflows/trigger_nightly_core.yml
+++ b/.github/workflows/trigger_nightly_core.yml
@@ -1,0 +1,21 @@
+name: Trigger nightly builds for pytorch core
+
+on:
+  schedule:
+    # every night at 7:30AM UTC, 3:30AM EST, 0:30AM PST
+    - cron: 30 7 * * *
+  workflow_dispatch:
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
+      - name: Trigger nightly core build
+        uses: ./.github/actions/trigger-nightly
+        with:
+          ref: viable/strict
+          repository: pytorch/pytorch
+          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+          path: pytorch


### PR DESCRIPTION
Deprecating pytorch.warm package. Replacing nightly trigger of pytorch/pytorch via GHA. This should allow us close following chronos job: https://www.internalfb.com/chronos/job/chronos_gp_admin_client/9007207428341147

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6f26233</samp>

Add a new workflow to trigger nightly builds for pytorch core. The workflow uses a custom action to run the `pytorch` workflow in the `pytorch/pytorch` repository with the `viable/strict` branch.