### PR TITLE
[BE] Add shareable calculate-docker-image GHA

### DIFF
--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -74,7 +74,7 @@ runs:
       id: check-image
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      if: ${{ !steps.calculate-image.outputs.skip && !inputs.always-rebuild }}
+      if: ${{ steps.calculate-image.outputs.skip != 'true' && !inputs.always-rebuild }}
       env:
         DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
         BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
@@ -112,7 +112,7 @@ runs:
     - name: Build and push docker image
       shell: bash
       working-directory: ${{ inputs.working-directory }}/${{ inputs.docker-build-dir }}
-      if: ${{ !steps.calculate-image.outputs.skip && (inputs.always-rebuild || steps.check-image.outputs.rebuild) }}
+      if: ${{ steps.calculate-image.outputs.skip != 'true' && (inputs.always-rebuild || steps.check-image.outputs.rebuild) }}
       env:
         REPO_NAME: ${{ github.event.repository.name }}
         DOCKER_PUSH: ${{ inputs.push }}

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -74,7 +74,7 @@ runs:
       id: check-image
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      if: ${{ steps.calculate-image.outputs.skip != 'true' }}
+      if: ${{ steps.calculate-image.outputs.skip != 'true' && !inputs.always-rebuild }}
       env:
         DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
         BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -27,18 +27,19 @@ outputs:
     description: The docker image to use for the rest of the workflow
     value: ${{ steps.calculate-image.outputs.docker-image }}
 
+env:
+  DOCKER_REGISTRY: "308535385114.dkr.ecr.us-east-1.amazonaws.com"
+
 runs:
   using: composite
-  env:
-    DOCKER_REGISTRY: "308535385114.dkr.ecr.us-east-1.amazonaws.com"
-    DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
-    REPO_NAME: ${{ github.event.repository.name }}
   steps:
     - name: Calculate docker image
       shell: bash
       id: calculate-image
       env:
+        REPO_NAME: ${{ github.event.repository.name }}
         DOCKER_IMAGE_NAME: ${{ inputs.docker-image-name }}
+        DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
       run: |
         set -ex
 
@@ -59,6 +60,7 @@ runs:
       id: check-image
       if: ${{ !inputs.always-rebuild }}
       env:
+        DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
         BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
         DOCKER_TAG: ${{ steps.calculate-image.outputs.docker-tag }}
@@ -94,6 +96,7 @@ runs:
     - name: Build and push docker image
       if: inputs.always-rebuild || steps.check-image.outputs.rebuild
       env:
+        REPO_NAME: ${{ github.event.repository.name }}
         DOCKER_PUSH: ${{ inputs.push }}
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
       working-directory: ${{ inputs.docker-build-dir }}

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -50,7 +50,7 @@ runs:
         # If the docker build directory doesn't exist, the action will gracefully
         # return the docker image name as it is. The pull docker image step could
         # then download the pre-built image as usual
-        if[[ ! -d "${DOCKER_BUILD_DIR}" ]]; then
+        if [[ ! -d "${DOCKER_BUILD_DIR}" ]]; then
           echo "skip=true" >> "${GITHUB_OUTPUT}"
           echo "docker-image=${DOCKER_IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
           exit 0

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -1,0 +1,130 @@
+name: Calculate docker image
+
+description: Determine docker image to pull, building a new one if necessary.
+
+inputs:
+  docker-build-dir:
+    description: |
+      The directory containing the build.sh shell script to build the docker image.
+      The script parameters can be passed to docker build similar to how it is used
+      in PyTorch, i.e. build.sh "${IMAGE_NAME}" -t "${DOCKER_IMAGE}"
+    required: true
+  docker-image-name:
+    description: |
+      The name of a docker image, like `pytorch-linux-focal-linter`. A fullname
+      with ECR prefix is also supported.
+    required: true
+  always-rebuild:
+    description: If set to any value, always build a fresh docker image.
+    required: false
+  push:
+    description: If set to any value, push the image to ECR.
+    required: false
+
+outputs:
+  docker-image:
+    description: The docker image to use for the rest of the workflow
+    value: ${{ steps.calculate-image.outputs.docker-image }}
+
+runs:
+  using: composite
+  env:
+    DOCKER_REGISTRY: "308535385114.dkr.ecr.us-east-1.amazonaws.com"
+    DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
+    REPO_NAME: ${{ github.event.repository.name }}
+  steps:
+    - name: Calculate docker image
+      shell: bash
+      id: calculate-image
+      env:
+        DOCKER_IMAGE_NAME: ${{ inputs.docker-image-name }}
+      run: |
+        set -ex
+
+        if [[ "${DOCKER_IMAGE_NAME}" == *"${DOCKER_REGISTRY}/${REPO_NAME}"* ]]; then
+          # The docker image name already includes the ECR prefix and tag, so we can just
+          # use it as it is, but first let's extract the tag
+          DOCKER_TAG=$(echo "${DOCKER_IMAGE_NAME}" | awk -F '[:,]' '{print $2}')
+          echo "docker-tag=${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "docker-image=${DOCKER_IMAGE_NAME}" >> "${GITHUB_OUTPUT}"always-rebuild
+        else
+          DOCKER_TAG=$(git rev-parse HEAD:"${DOCKER_BUILD_DIR}")
+          echo "docker-tag=${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "docker-image=${DOCKER_REGISTRY}/${REPO_NAME}/${DOCKER_IMAGE_NAME}:${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
+        fi
+
+    - name: Check if image should be built
+      shell: bash
+      id: check-image
+      if: ${{ !inputs.always-rebuild }}
+      env:
+        BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
+        DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
+        DOCKER_TAG: ${{ steps.calculate-image.outputs.docker-tag }}
+      run: |
+        set -ex
+
+        # Check if image already exists, if it does then skip building it
+        if docker manifest inspect "${DOCKER_IMAGE}"; then
+          exit 0
+        fi
+
+        if [[ "$BASE_REVISION" = "$(git rev-parse HEAD)" ]]; then
+          # if we're on the base branch then use the parent commit
+          MERGE_BASE=$(git rev-parse HEAD~)
+        else
+          # otherwise we're on a PR, so use the most recent base commit
+          MERGE_BASE=$(git merge-base HEAD "$BASE_REVISION")
+        fi
+
+        if ! git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}"; then
+          echo "Directory '${DOCKER_BUILD_DIR}' not found in commit $MERGE_BASE, you should rebase onto a more recent commit"
+          exit 1
+        fi
+        PREVIOUS_DOCKER_TAG=$(git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}")
+        # If no image exists but the hash is the same as the previous hash then we should error out here
+        if [[ "${PREVIOUS_DOCKER_TAG}" == "${DOCKER_TAG}" ]]; then
+          echo "WARNING: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
+          echo "         Will re-build docker image to store in local cache, TTS may be longer"
+        fi
+
+        echo "rebuild=yes" >> "${GITHUB_OUTPUT}"
+
+    - name: Build and push docker image
+      if: inputs.always-rebuild || steps.check-image.outputs.rebuild
+      env:
+        DOCKER_PUSH: ${{ inputs.push }}
+        DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
+      working-directory: ${{ inputs.docker-build-dir }}
+      shell: bash
+      run: |
+        set -ex
+
+        login() {
+          aws ecr get-authorization-token --region us-east-1 --output text --query 'authorizationData[].authorizationToken' |
+            base64 -d |
+            cut -d: -f2 |
+            docker login -u AWS --password-stdin "$1"
+        }
+
+        retry () {
+          $*  || (sleep 1 && $*) || (sleep 2 && $*)
+        }
+
+        # Only run these steps if not on github actions
+        if [[ -z "${GITHUB_ACTIONS}" ]]; then
+          retry login "${DOCKER_REGISTRY}"
+          # Logout on exit
+          trap "docker logout ${DOCKER_REGISTRY}" EXIT
+        fi
+
+        IMAGE_NAME=$(echo ${DOCKER_IMAGE#"${DOCKER_REGISTRY}/${REPO_NAME}/"} | awk -F '[:,]' '{print $1}')
+        # Build new image
+        ./build.sh "${IMAGE_NAME}" -t "${DOCKER_IMAGE}"
+
+        if [ "${DOCKER_PUSH:-false}" == "true" ]; then
+          # Only push if docker image doesn't exist already
+          if ! docker manifest inspect "${DOCKER_IMAGE}" >/dev/null 2>/dev/null; then
+            docker push "${DOCKER_IMAGE}"
+          fi
+        fi

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -83,14 +83,16 @@ runs:
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
         DOCKER_TAG: ${{ steps.calculate-image.outputs.docker-tag }}
       run: |
-        set -ex
+        set +e
+        set -x
 
         # Check if image already exists, if it does then skip building it
         if docker manifest inspect "${DOCKER_IMAGE}"; then
           exit 0
         fi
 
-        # NB: This part requires a full checkout
+        # NB: This part requires a full checkout. Otherwise, the merge base will
+        # be empty.  The default action would be to continue rebuild the image
         if [[ "$BASE_REVISION" = "$(git rev-parse HEAD)" ]]; then
           # if we're on the base branch then use the parent commit
           MERGE_BASE=$(git rev-parse HEAD~)
@@ -99,10 +101,18 @@ runs:
           MERGE_BASE=$(git merge-base HEAD "$BASE_REVISION")
         fi
 
+        if [[ -z "${MERGE_BASE}" ]]; then
+          echo "rebuild=true" >> "${GITHUB_OUTPUT}"
+
+          echo "Finding merge base only works with full checkout, please set fetch-depth to 0, continuing ..."
+          exit 0
+        fi
+
         if ! git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}"; then
           echo "Directory '${DOCKER_BUILD_DIR}' not found in commit $MERGE_BASE, you should rebase onto a more recent commit"
           exit 1
         fi
+
         PREVIOUS_DOCKER_TAG=$(git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}")
         # If no image exists but the hash is the same as the previous hash then we should error out here
         if [[ "${PREVIOUS_DOCKER_TAG}" == "${DOCKER_TAG}" ]]; then

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -12,12 +12,13 @@ inputs:
     description: |
       The directory containing the build.sh shell script to build the docker image.
       The script parameters can be passed to docker build similar to how it is used
-      in PyTorch, i.e. build.sh "${IMAGE_NAME}" -t "${DOCKER_IMAGE}"
-    required: false
+      in PyTorch, i.e. build.sh "${IMAGE_NAME}" -t "${DOCKER_IMAGE}".
     default: .ci/docker
+  working-directory:
+    description: The working directory where the repo is checked out.
+    default: .
   docker-registry:
     description: The registry to store the image after it is built.
-    required: false
     default: 308535385114.dkr.ecr.us-east-1.amazonaws.com
   always-rebuild:
     description: If set to any value, always build a fresh docker image.
@@ -35,8 +36,9 @@ runs:
   using: composite
   steps:
     - name: Calculate docker image
-      shell: bash
       id: calculate-image
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
       env:
         REPO_NAME: ${{ github.event.repository.name }}
         DOCKER_IMAGE_NAME: ${{ inputs.docker-image-name }}
@@ -58,8 +60,9 @@ runs:
         fi
 
     - name: Check if image should be built
-      shell: bash
       id: check-image
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
       if: ${{ !inputs.always-rebuild }}
       env:
         DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
@@ -96,14 +99,14 @@ runs:
         echo "rebuild=yes" >> "${GITHUB_OUTPUT}"
 
     - name: Build and push docker image
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}/${{ inputs.docker-build-dir }}
       if: inputs.always-rebuild || steps.check-image.outputs.rebuild
       env:
         REPO_NAME: ${{ github.event.repository.name }}
         DOCKER_PUSH: ${{ inputs.push }}
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
-      working-directory: ${{ inputs.docker-build-dir }}
-      shell: bash
       run: |
         set -ex
 

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -3,17 +3,18 @@ name: Calculate docker image
 description: Determine docker image to pull, building a new one if necessary.
 
 inputs:
-  docker-build-dir:
-    description: |
-      The directory containing the build.sh shell script to build the docker image.
-      The script parameters can be passed to docker build similar to how it is used
-      in PyTorch, i.e. build.sh "${IMAGE_NAME}" -t "${DOCKER_IMAGE}"
-    required: true
   docker-image-name:
     description: |
       The name of a docker image, like `pytorch-linux-focal-linter`. A fullname
       with ECR prefix is also supported.
     required: true
+  docker-build-dir:
+    description: |
+      The directory containing the build.sh shell script to build the docker image.
+      The script parameters can be passed to docker build similar to how it is used
+      in PyTorch, i.e. build.sh "${IMAGE_NAME}" -t "${DOCKER_IMAGE}"
+    required: false
+    default: .ci/docker
   always-rebuild:
     description: If set to any value, always build a fresh docker image.
     required: false

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -47,6 +47,17 @@ runs:
       run: |
         set -ex
 
+        # If the docker build directory doesn't exist, the action will gracefully
+        # return the docker image name as it is. The pull docker image step could
+        # then download the pre-built image as usual
+        if[[ ! -d "${DOCKER_BUILD_DIR}" ]]; then
+          echo "skip=true" >> "${GITHUB_OUTPUT}"
+          echo "docker-image=${DOCKER_IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
+          exit 0
+        else
+          echo "skip=false" >> "${GITHUB_OUTPUT}"
+        fi
+
         if [[ "${DOCKER_IMAGE_NAME}" == *"${DOCKER_REGISTRY}/${REPO_NAME}"* ]]; then
           # The docker image name already includes the ECR prefix and tag, so we can just
           # use it as it is, but first let's extract the tag
@@ -63,7 +74,7 @@ runs:
       id: check-image
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      if: ${{ !inputs.always-rebuild }}
+      if: ${{ !steps.calculate-image.outputs.skip && !inputs.always-rebuild }}
       env:
         DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
         BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
@@ -96,12 +107,12 @@ runs:
           echo "         Will re-build docker image to store in local cache, TTS may be longer"
         fi
 
-        echo "rebuild=yes" >> "${GITHUB_OUTPUT}"
+        echo "rebuild=true" >> "${GITHUB_OUTPUT}"
 
     - name: Build and push docker image
       shell: bash
       working-directory: ${{ inputs.working-directory }}/${{ inputs.docker-build-dir }}
-      if: inputs.always-rebuild || steps.check-image.outputs.rebuild
+      if: ${{ !steps.calculate-image.outputs.skip && (inputs.always-rebuild || steps.check-image.outputs.rebuild) }}
       env:
         REPO_NAME: ${{ github.event.repository.name }}
         DOCKER_PUSH: ${{ inputs.push }}

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -74,7 +74,7 @@ runs:
       id: check-image
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      if: ${{ steps.calculate-image.outputs.skip != 'true' && !inputs.always-rebuild }}
+      if: ${{ steps.calculate-image.outputs.skip != 'true' }}
       env:
         DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
         BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -15,6 +15,10 @@ inputs:
       in PyTorch, i.e. build.sh "${IMAGE_NAME}" -t "${DOCKER_IMAGE}"
     required: false
     default: .ci/docker
+  docker-registry:
+    description: The registry to store the image after it is built.
+    required: false
+    default: 308535385114.dkr.ecr.us-east-1.amazonaws.com
   always-rebuild:
     description: If set to any value, always build a fresh docker image.
     required: false
@@ -27,9 +31,6 @@ outputs:
     description: The docker image to use for the rest of the workflow
     value: ${{ steps.calculate-image.outputs.docker-image }}
 
-env:
-  DOCKER_REGISTRY: "308535385114.dkr.ecr.us-east-1.amazonaws.com"
-
 runs:
   using: composite
   steps:
@@ -40,6 +41,7 @@ runs:
         REPO_NAME: ${{ github.event.repository.name }}
         DOCKER_IMAGE_NAME: ${{ inputs.docker-image-name }}
         DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
+        DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
         set -ex
 
@@ -99,6 +101,7 @@ runs:
         REPO_NAME: ${{ github.event.repository.name }}
         DOCKER_PUSH: ${{ inputs.push }}
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
+        DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       working-directory: ${{ inputs.docker-build-dir }}
       shell: bash
       run: |

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -47,12 +47,14 @@ runs:
       run: |
         set -ex
 
-        # If the docker build directory doesn't exist, the action will gracefully
-        # return the docker image name as it is. The pull docker image step could
-        # then download the pre-built image as usual
-        if [[ ! -d "${DOCKER_BUILD_DIR}" ]]; then
+        # If the docker build directory or the build script doesn't exist, the action will
+        # gracefully return the docker image name as it is.  Pulling docker image in Linux
+        # job could then download the pre-built image as usual
+        if [[ ! -d "${DOCKER_BUILD_DIR}" ]] || [[ ! -f "${DOCKER_BUILD_DIR}/build.sh" ]]; then
           echo "skip=true" >> "${GITHUB_OUTPUT}"
           echo "docker-image=${DOCKER_IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
+
+          echo "There is no Docker build script in ${REPO_NAME} repo, skipping..."
           exit 0
         else
           echo "skip=false" >> "${GITHUB_OUTPUT}"
@@ -88,6 +90,7 @@ runs:
           exit 0
         fi
 
+        # NB: This part requires a full checkout
         if [[ "$BASE_REVISION" = "$(git rev-parse HEAD)" ]]; then
           # if we're on the base branch then use the parent commit
           MERGE_BASE=$(git rev-parse HEAD~)

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -50,7 +50,7 @@ runs:
           # use it as it is, but first let's extract the tag
           DOCKER_TAG=$(echo "${DOCKER_IMAGE_NAME}" | awk -F '[:,]' '{print $2}')
           echo "docker-tag=${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
-          echo "docker-image=${DOCKER_IMAGE_NAME}" >> "${GITHUB_OUTPUT}"always-rebuild
+          echo "docker-image=${DOCKER_IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
         else
           DOCKER_TAG=$(git rev-parse HEAD:"${DOCKER_BUILD_DIR}")
           echo "docker-tag=${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: If set to any value, always build a fresh docker image.
     required: false
   push:
-    description: If set to any value, push the image to ECR.
+    description: If set to true, push the image to ECR.
     required: false
 
 outputs:


### PR DESCRIPTION
This refactors the logic in PyTorch https://github.com/pytorch/pytorch/blob/main/.github/actions/calculate-docker-image/action.yml to a shareable GHA.  Notably, the changes include:

* Accept a docker build directory input, i.e. `.ci/docker`, with a `build.sh` script entry.  The usage is `build.sh "${IMAGE_NAME}" -t "${DOCKER_IMAGE}"` as how it's used in PyTorch atm
* Accept a working directory input because Nova Linux job could checkout the repo in a different directory
* Simplify the list of configurable options to only 2 `always-rebuild` and `push` (set to true to push the image to ECR)

One hidden caveat is that `calculate-docker-image` requires a full checkout to work as it tries to figure out the Docker tag of the base commit.  This means that `fetch-depth: 0` is needed to use this action.

This action can then be used in the upcoming CI change on Executorch where the repo could build and use its own Docker image(s).

### Testing

* Use the GHA on Nova Linux job https://github.com/pytorch/test-infra/pull/4399
* Use the GHA on PyTorch https://github.com/pytorch/pytorch/pull/105372
* Executorch
  * Publish Docker image: https://github.com/pytorch/executorch/pull/11
  * Use Docker image in Linux job: https://github.com/pytorch/executorch/pull/12