### PR TITLE
Use shareable calculate-docker-image GHA

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -47,6 +47,13 @@ on:
         description: Identifies the Docker image by name.
         default: "pytorch/conda-builder"
         type: string
+      docker-build-dir:
+        description: |
+          The directory containing the build.sh shell script to build the docker image.
+          The script parameters can be passed to docker build similar to how it is used
+          in PyTorch, i.e. build.sh "${IMAGE_NAME}" -t "${DOCKER_IMAGE}"
+        default: ".ci/docker"
+        type: string
       gpu-arch-type:
         description: "GPU arch type to use"
         default: "cpu"
@@ -138,10 +145,17 @@ jobs:
         with:
           github-secret: ${{ github.token }}
 
+      - name: Calculate docker image
+        id: calculate-docker-image
+        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        with:
+          docker-image-name: ${{ env.DOCKER_IMAGE }}
+          docker-build-dir: ${{ inputs.docker-build-dir }}
+
       - name: Pull docker image
         uses: ./test-infra/.github/actions/pull-docker-image
         with:
-          docker-image: ${{ env.DOCKER_IMAGE }}
+          docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
 
       - name: Checkout repository (${{ inputs.repository || github.repository }}@${{ inputs.ref }})
         uses: actions/checkout@v3

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -49,8 +49,9 @@ on:
         type: string
       docker-build-dir:
         description: |
-          The directory containing the build.sh shell script to build the docker image. The
-          path is relative to where the repo is checked out.
+          The directory containing the build.sh shell script to build the docker image.
+          The script parameters can be passed to docker build similar to how it is used
+          in PyTorch, i.e. build.sh "${IMAGE_NAME}" -t "${DOCKER_IMAGE}".
         default: ".ci/docker"
         type: string
       gpu-arch-type:
@@ -155,7 +156,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        uses: ./test-infra/.github/actions/calculate-docker-image
         with:
           docker-image-name: ${{ env.DOCKER_IMAGE }}
           docker-build-dir: ${{ inputs.docker-build-dir }}

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -49,9 +49,8 @@ on:
         type: string
       docker-build-dir:
         description: |
-          The directory containing the build.sh shell script to build the docker image.
-          The script parameters can be passed to docker build similar to how it is used
-          in PyTorch, i.e. build.sh "${IMAGE_NAME}" -t "${DOCKER_IMAGE}"
+          The directory containing the build.sh shell script to build the docker image. The
+          path is relative to where the repo is checked out.
         default: ".ci/docker"
         type: string
       gpu-arch-type:
@@ -157,11 +156,11 @@ jobs:
       - name: Calculate docker image
         id: calculate-docker-image
         uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
-        # This needs to be where the repository is checked out
-        working-directory: ${{ inputs.repository || github.repository }}
         with:
           docker-image-name: ${{ env.DOCKER_IMAGE }}
           docker-build-dir: ${{ inputs.docker-build-dir }}
+          # This needs to be where the repository is checked out
+          working-directory: ${{ inputs.repository || github.repository }}
 
       - name: Pull docker image
         uses: ./test-infra/.github/actions/pull-docker-image

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -187,6 +187,7 @@ jobs:
         working-directory: ${{ inputs.repository }}
         env:
           ALL_SECRETS: ${{ toJSON(secrets) }}
+          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
         run: |
           set -ex
           {

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -145,18 +145,6 @@ jobs:
         with:
           github-secret: ${{ github.token }}
 
-      - name: Calculate docker image
-        id: calculate-docker-image
-        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
-        with:
-          docker-image-name: ${{ env.DOCKER_IMAGE }}
-          docker-build-dir: ${{ inputs.docker-build-dir }}
-
-      - name: Pull docker image
-        uses: ./test-infra/.github/actions/pull-docker-image
-        with:
-          docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
-
       - name: Checkout repository (${{ inputs.repository || github.repository }}@${{ inputs.ref }})
         uses: actions/checkout@v3
         with:
@@ -165,6 +153,20 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           path: ${{ inputs.repository || github.repository }}
           fetch-depth: ${{ inputs.fetch-depth }}
+
+      - name: Calculate docker image
+        id: calculate-docker-image
+        uses: huydhn/test-infra/.github/actions/calculate-docker-image@calculate-docker-image
+        # This needs to be where the repository is checked out
+        working-directory: ${{ inputs.repository || github.repository }}
+        with:
+          docker-image-name: ${{ env.DOCKER_IMAGE }}
+          docker-build-dir: ${{ inputs.docker-build-dir }}
+
+      - name: Pull docker image
+        uses: ./test-infra/.github/actions/pull-docker-image
+        with:
+          docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
 
       - name: Download artifacts (if any)
         uses: actions/download-artifact@v3


### PR DESCRIPTION
Add a step in Linux job to calculate and build Docker image if needed.  This is similar to how PyTorch CI rebuilds its Docker images atm.

### Testing

https://github.com/pytorch/pytorch/pull/105372, PyTorch Lint job uses Linux jobs.