### PR TITLE
Make compiler names more concise and clear

### DIFF
--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -57,11 +57,18 @@ export const JOB_NAME_REGEX = new RegExp(
 // After https://github.com/pytorch/pytorch/pull/96986, there is no perf data
 // for eager and aot_eager because they are not run anymore (not needed)
 export const COMPILER_NAMES_TO_DISPLAY_NAMES: { [k: string]: string } = {
-  inductor: "inductor_with_cudagraphs",
-  inductor_no_cudagraphs: "inductor_default",
+  inductor: "cudagraphs",
+  inductor_with_cudagraphs: "cudagraphs",
+  inductor_dynamic: "cudagraphs_dynamic",
+  inductor_no_cudagraphs: "default",
+  inductor_cpp_wrapper: "cpp_wrapper",
 };
 export const DISPLAY_NAMES_TO_COMPILER_NAMES: { [k: string]: string } = {
   inductor_default: "inductor_no_cudagraphs",
+  default: "inductor_no_cudagraphs",
+  cudagraphs: "inductor_with_cudagraphs",
+  cudagraphs_dynamic: "inductor_dynamic",
+  cpp_wrapper: "inductor_cpp_wrapper",
 };
 export const BLOCKLIST_COMPILERS = ["aot_eager", "eager"];
 export const SUITES: { [k: string]: string } = {
@@ -1017,7 +1024,7 @@ function SummaryPanel({
   const columns = [
     {
       field: "compiler",
-      headerName: "Compiler",
+      headerName: "Inductor config",
       flex: 1,
     },
   ];


### PR DESCRIPTION
Before:

<img width="728" alt="image" src="https://github.com/pytorch/test-infra/assets/13564/15df376d-42df-41ed-a45b-e85b52c07721">

<img width="694" alt="image" src="https://github.com/pytorch/test-infra/assets/13564/5944212b-3b61-451b-b7dd-3f8b07f1da89">


After:

<img width="708" alt="image" src="https://github.com/pytorch/test-infra/assets/13564/d8b40429-8ea0-49d0-a58d-801ae9e3b851">

<img width="675" alt="image" src="https://github.com/pytorch/test-infra/assets/13564/a7258bcb-c9c2-45f1-ba4f-6affd7d25cda">

cc @gchanan 

Signed-off-by: Edward Z. Yang <ezyang@meta.com>
