### PR TITLE
infra: Switch nvidia template to utilize regular cloudwatch config

### DIFF
--- a/terraform-aws-github-runner/modules/runners-instances/launch-template.tf
+++ b/terraform-aws-github-runner/modules/runners-instances/launch-template.tf
@@ -139,7 +139,7 @@ resource "aws_launch_template" "linux_runner_nvidia" {
     pre_install                     = var.userdata_pre_install
     post_install                    = var.userdata_post_install
     enable_cloudwatch_agent         = var.enable_cloudwatch_agent
-    ssm_key_cloudwatch_agent_config = var.enable_cloudwatch_agent ? aws_ssm_parameter.cloudwatch_agent_config_runner_linux_nvidia[0].name : ""
+    ssm_key_cloudwatch_agent_config = var.enable_cloudwatch_agent ? aws_ssm_parameter.cloudwatch_agent_config_runner_linux[0].name : ""
     ghes_url                        = var.ghes_url
     install_config_runner           = local.install_config_runner_linux
   }))


### PR DESCRIPTION
We were running into issues where the cloudwatch-agent-ctl was attempting to call out to nvidia-smi, but we actually install that as a later part of our workflow. Since we don't currently use the GPU statistics that we store in cloudwatch this is a temporary fix to get GPU instances unblocked.

Error experienced:

```
E! [telegraf] Error running agent: validate input plugin nvidia_smi failed because of Cannot get file's stat /usr/bin/nvidia-smi: no such file or directory
```

NOTE: This is a short term fix and should be treated as such, the longer term fix would be to have an AMI that has nvidia-smi pre-installed but that is a lot to ask for in an afternoon