### PR TITLE
Add regex support to flaky rules

### DIFF
--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -356,9 +356,15 @@ function isFlaky(
   return masterFlakyJobs.some(
     (masterFlakyJob) =>
       job.name.includes(masterFlakyJob.name) &&
-      masterFlakyJob.captures.every((capture) =>
-        job.failure_captures?.includes(capture)
-      )
+      masterFlakyJob.captures.every((capture: string) => {
+        const captureRegex = new RegExp(capture);
+        return (
+          job.failure_captures &&
+          job.failure_captures.some((failureCapture) =>
+            failureCapture.match(captureRegex)
+          )
+        );
+      })
   );
 }
 

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -349,14 +349,13 @@ export function constructResultsComment(
   return output;
 }
 
-function isFlaky(
-  job: RecentWorkflowsData,
-  masterFlakyJobs: FlakyRule[]
-): boolean {
-  return masterFlakyJobs.some(
-    (masterFlakyJob) =>
-      job.name.includes(masterFlakyJob.name) &&
-      masterFlakyJob.captures.every((capture: string) => {
+function isFlaky(job: RecentWorkflowsData, flakyRules: FlakyRule[]): boolean {
+  return flakyRules.some((flakyRule) => {
+    const jobNameRegex = new RegExp(flakyRule.name);
+
+    return (
+      job.name.match(jobNameRegex) &&
+      flakyRule.captures.every((capture: string) => {
         const captureRegex = new RegExp(capture);
         return (
           job.failure_captures &&
@@ -365,7 +364,8 @@ function isFlaky(
           )
         );
       })
-  );
+    );
+  });
 }
 
 function isBrokenTrunk(


### PR DESCRIPTION
So we can use regex like `The process cannot access the file .+ because it is being used by another process` or substring like `The runner has received a shutdown signal` in the flaky rules https://github.com/pytorch/test-infra/blob/generated-stats/stats/flaky-rules.json.

There would be another PR on trymerge coming up next.