### PR TITLE
Add a rule to classify MacOS disk space failure

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -41,6 +41,10 @@ name = 'GHA job was cancelled'
 pattern = '^##\[error\]The operation was canceled.'
 
 [[rule]]
+name = 'MacOS disk space issue'
+pattern = '^Failure: There is only .+ free space left in .+, which is less than the minimum requirement of'
+
+[[rule]]
 name = 'make build failure'
 pattern = '''^Makefile:\d+: recipe for target '.+' failed'''
 

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -41,7 +41,7 @@ name = 'GHA job was cancelled'
 pattern = '^##\[error\]The operation was canceled.'
 
 [[rule]]
-name = 'MacOS disk space issue'
+name = 'Runner disk space issue'
 pattern = '^Failure: There is only .+ free space left in .+, which is less than the minimum requirement of'
 
 [[rule]]


### PR DESCRIPTION
This hasn't been classified yet and show up as the generic `Process completed with exit code 1` on https://hud.pytorch.org/pytorch/pytorch/commit/78fffe890627bc020c9bd82a27a19d042f31695e