### PR TITLE
Revert "Revert "Fix gpu pass-though" (#4389)"

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -79,6 +79,7 @@ jobs:
     runs-on: ${{ matrix.validation_runner }}
     container:
       image: ${{ matrix.container_image }}
+      options: ${{ matrix.gpu_arch_type == 'cuda' && '--gpus all' || ' ' }}
     # If a build is taking longer than 60 minutes on these runners we need
     # to have a conversation
     timeout-minutes: 60


### PR DESCRIPTION
This reverts commit 86b3577dda0e372fa55c0209aca8df6d813a1da1.

After https://github.com/pytorch/test-infra/pull/4430 we should be good to add GPU pass thru back.