### PR TITLE
[TorchFix] Filter out files that don't have torch string

### DIFF
--- a/tools/torchfix/torchfix/__main__.py
+++ b/tools/torchfix/torchfix/__main__.py
@@ -43,7 +43,7 @@ def main() -> None:
 
     # Filter out files that don't have "torch" string in them.
     # This avoids expensive parsing.
-    MARKER = "torch" #  this will catch import torch or functorch
+    MARKER = "torch"  # this will catch import torch or functorch
     torch_files = []
     for file in files:
         with open(file) as f:

--- a/tools/torchfix/torchfix/__main__.py
+++ b/tools/torchfix/torchfix/__main__.py
@@ -46,7 +46,7 @@ def main() -> None:
     MARKER = "torch"  # this will catch import torch or functorch
     torch_files = []
     for file in files:
-        with open(file) as f:
+        with open(file, errors='replace') as f:
             for line in f:
                 if MARKER in line:
                     torch_files.append(file)

--- a/tools/torchfix/torchfix/__main__.py
+++ b/tools/torchfix/torchfix/__main__.py
@@ -40,6 +40,18 @@ def main() -> None:
     args = parser.parse_args()
 
     files = codemod.gather_files(args.path)
+
+    # Filter out files that don't have "torch" string in them.
+    # This avoids expensive parsing.
+    MARKER = "torch" # this will catch import torch or functorch
+    torch_files = []
+    for file in files:
+        with open(file) as f:
+            for line in f:
+                if MARKER in line:
+                    torch_files.append(file)
+                    break
+
     command_instance = TorchCodemod(codemod.CodemodContext())
     DIFF_CONTEXT = 5
     try:
@@ -51,7 +63,7 @@ def main() -> None:
         with context:
             result = codemod.parallel_exec_transform_with_prettyprint(
                 command_instance,
-                files,
+                torch_files,
                 jobs=args.jobs,
                 unified_diff=(None if args.fix else DIFF_CONTEXT),
                 hide_progress=True,

--- a/tools/torchfix/torchfix/__main__.py
+++ b/tools/torchfix/torchfix/__main__.py
@@ -43,7 +43,7 @@ def main() -> None:
 
     # Filter out files that don't have "torch" string in them.
     # This avoids expensive parsing.
-    MARKER = "torch" # this will catch import torch or functorch
+    MARKER = "torch" #  this will catch import torch or functorch
     torch_files = []
     for file in files:
         with open(file) as f:

--- a/tools/torchfix/torchfix/torchfix.py
+++ b/tools/torchfix/torchfix/torchfix.py
@@ -8,7 +8,7 @@ from .visitors.deprecated_symbols import (
     _UpdateFunctorchImports,
 )
 
-from .visitors.performance import TorchSynchronizedDataLoaderVisitor
+from .visitors.performance import TorchSynchronizedDataLoaderVisitor, TorchExtraCUDACopyPatternVisitor
 from .visitors.misc import TorchRequireGradVisitor
 
 __version__ = "0.0.2"
@@ -20,7 +20,8 @@ def GET_ALL_VISITORS():
     return [
         TorchDeprecatedSymbolsVisitor(DEPRECATED_CONFIG_PATH),
         TorchRequireGradVisitor(),
-        TorchSynchronizedDataLoaderVisitor(),
+        #TorchSynchronizedDataLoaderVisitor(),
+        TorchExtraCUDACopyPatternVisitor(),
     ]
 
 
@@ -32,17 +33,28 @@ class TorchChecker:
     # See https://flake8.pycqa.org/en/latest/plugin-development/plugin-parameters.html
     # `tree` is unused, but the plugin doesn't work without it.
     def __init__(self, tree, lines):
-        module = cst.parse_module("".join(lines))
-        self.module = cst.MetadataWrapper(module, unsafe_skip_copy=True)
-        self.violations = []
-        self.visitors = GET_ALL_VISITORS()
+        # Filter out files that don't have "torch" string in them.
+        # This avoids expensive parsing.
+        MARKER = "torch" # this will catch import torch or functorch
+        has_marker = False
+        self.module = None
+        for line in lines:
+            if MARKER in line:
+                has_marker = True
+                break
+        if has_marker:
+            module = cst.parse_module("".join(lines))
+            self.module = cst.MetadataWrapper(module, unsafe_skip_copy=True)
+            self.violations = []
+            self.visitors = GET_ALL_VISITORS()
 
     def run(self):
-        self.module.visit_batched(self.visitors)
-        for v in self.visitors:
-            self.violations += v.violations
-        for violation in self.violations:
-            yield violation.flake8_result()
+        if self.module:
+            self.module.visit_batched(self.visitors)
+            for v in self.visitors:
+                self.violations += v.violations
+            for violation in self.violations:
+                yield violation.flake8_result()
 
 
 class TorchCodemod(codemod.Codemod):

--- a/tools/torchfix/torchfix/torchfix.py
+++ b/tools/torchfix/torchfix/torchfix.py
@@ -8,7 +8,7 @@ from .visitors.deprecated_symbols import (
     _UpdateFunctorchImports,
 )
 
-from .visitors.performance import TorchSynchronizedDataLoaderVisitor, TorchExtraCUDACopyPatternVisitor
+from .visitors.performance import TorchSynchronizedDataLoaderVisitor
 from .visitors.misc import TorchRequireGradVisitor
 
 __version__ = "0.0.2"
@@ -20,8 +20,7 @@ def GET_ALL_VISITORS():
     return [
         TorchDeprecatedSymbolsVisitor(DEPRECATED_CONFIG_PATH),
         TorchRequireGradVisitor(),
-        #TorchSynchronizedDataLoaderVisitor(),
-        TorchExtraCUDACopyPatternVisitor(),
+        TorchSynchronizedDataLoaderVisitor(),
     ]
 
 

--- a/tools/torchfix/torchfix/torchfix.py
+++ b/tools/torchfix/torchfix/torchfix.py
@@ -34,7 +34,7 @@ class TorchChecker:
     def __init__(self, tree, lines):
         # Filter out files that don't have "torch" string in them.
         # This avoids expensive parsing.
-        MARKER = "torch" # this will catch import torch or functorch
+        MARKER = "torch" #  this will catch import torch or functorch
         has_marker = False
         self.module = None
         for line in lines:

--- a/tools/torchfix/torchfix/torchfix.py
+++ b/tools/torchfix/torchfix/torchfix.py
@@ -34,7 +34,7 @@ class TorchChecker:
     def __init__(self, tree, lines):
         # Filter out files that don't have "torch" string in them.
         # This avoids expensive parsing.
-        MARKER = "torch" #  this will catch import torch or functorch
+        MARKER = "torch"  # this will catch import torch or functorch
         has_marker = False
         self.module = None
         for line in lines:


### PR DESCRIPTION
No point in even parsing a file if it doesn't have "torch" string in it.

The change is in two places because one is for the standalone torchfix, and another one for the flake8 plugin.

The change gives significant speedup.

For huggingface/transformers on my machine, it goes from 
```
real	0m41.974s
user	34m7.410s
sys	0m13.530s
```
to 
```
real	0m33.837s
user	25m50.892s
sys	0m12.785s
```

The speedup will be even more if a directory has more files unrelated to PyTorch.