### PR TITLE
Fix swapped force merge KPIs

### DIFF
--- a/torchci/rockset/commons/__sql/weekly_force_merge_stats.sql
+++ b/torchci/rockset/commons/__sql/weekly_force_merge_stats.sql
@@ -1,4 +1,5 @@
 -- gets percentage of total force merges, force merges with failures, and force merges without failures (impatient)
+-- specifically this query tracks the force merges kpi on HUD
 WITH
     issue_comments AS(
         SELECT
@@ -39,9 +40,10 @@ WITH
             m.is_failed,
             m.pr_num,
             m.merge_commit_sha,
-            max(m._event_time) as time,
+            max(c._event_time) as time,
         FROM
-            commons.merges m -- inner join issue_comments c on m.pr_num = c.pr_num
+            commons.merges m
+            inner join issue_comments c on m.pr_num = c.pr_num
         WHERE
             m.owner = 'pytorch'
             AND m.project = 'pytorch'
@@ -138,7 +140,8 @@ WITH
             select
                 granularity_bucket,
                 with_failures_percent as metric,
-                'force merges due to impatience' as name
+                'force merges due to failed tests' as name
+                
             from
                 stats_per_week
         )
@@ -147,7 +150,7 @@ WITH
             select
                 granularity_bucket,
                 impatience_percent as metric,
-                'force merges due to failed tests' as name
+                'force merges due to impatience' as name
             from
                 stats_per_week
         )

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -29,7 +29,7 @@
     "test_insights_overview": "42dbd5232f45fd53",
     "test_insights_latest_runs": "1871833a91cb8b1b",
     "master_commit_red_jobs": "4869b467679a616a",
-    "weekly_force_merge_stats": "7c47a3a053a15325"
+    "weekly_force_merge_stats": "3248e3671edb678c"
   },
   "pytorch_dev_infra_kpis": {
     "monthly_contribution_stats": "c1a8751a22f6b6ce",


### PR DESCRIPTION
TSIA.  The 2 lines are wrongly swapped atm.  Also, I edit the latest version of the query instead of the slightly older version committed in https://github.com/pytorch/test-infra/pull/4441 as the former looks more correct having the inner join with `issue_comments` instead of having this part commented out.