### PR TITLE
improve  force merge kpi readability

### DIFF
--- a/torchci/rockset/commons/__sql/weekly_force_merge_stats.sql
+++ b/torchci/rockset/commons/__sql/weekly_force_merge_stats.sql
@@ -140,7 +140,7 @@ WITH
             select
                 granularity_bucket,
                 with_failures_percent as metric,
-                'force merges due to failed tests' as name
+                'From Failures' as name
                 
             from
                 stats_per_week
@@ -150,7 +150,7 @@ WITH
             select
                 granularity_bucket,
                 impatience_percent as metric,
-                'force merges due to impatience' as name
+                'From Impatience' as name
             from
                 stats_per_week
         )
@@ -159,7 +159,7 @@ WITH
             select
                 granularity_bucket,
                 force_merge_percent as metric,
-                'all force merges' as name
+                'All Force Merges' as name
             from
                 stats_per_week
         )

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -29,7 +29,7 @@
     "test_insights_overview": "42dbd5232f45fd53",
     "test_insights_latest_runs": "1871833a91cb8b1b",
     "master_commit_red_jobs": "4869b467679a616a",
-    "weekly_force_merge_stats": "3248e3671edb678c"
+    "weekly_force_merge_stats": "48bbcbff20f3f5b5"
   },
   "pytorch_dev_infra_kpis": {
     "monthly_contribution_stats": "c1a8751a22f6b6ce",


### PR DESCRIPTION
improve  force merge kpi readability by making the names of the metrics shorter (allowing you to actually access the numbers for the current week).
