### PR TITLE
Add aarch64 torchvision build

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -56,10 +56,10 @@ on:
         default: ""
         type: string
       architecture:
-        description: Architecure to build for x64 for default Linux, or ARM64 for Linux aarch64 builds
+        description: Architecture to build for x86_64 for default Linux, or aarch64 for Linux aarch64 builds
         required: false
         type: string
-        default: x64
+        default: x86_64
       setup-miniconda:
         description: Works as stated in actions/checkout, but the default value is recursive
         required: false
@@ -108,7 +108,7 @@ jobs:
           ref: ${{ inputs.test-infra-ref }}
           path: test-infra
       - uses: actions/checkout@v3
-        if: ${{ inputs.architecture == 'ARM64' }}
+        if: ${{ inputs.architecture == 'aarch64' }}
         with:
           # Support the use case where we need to checkout someone's fork
           repository: "pytorch/builder"
@@ -119,7 +119,7 @@ jobs:
         with:
           github-secret: ${{ github.token }}
       - name: Set linux aarch64 CI
-        if: ${{ inputs.architecture == 'ARM64' }}
+        if: ${{ inputs.architecture == 'aarch64' }}
         shell: bash -l {0}
         env:
           DESIRED_PYTHON: ${{ matrix.python_version }}
@@ -162,7 +162,7 @@ jobs:
         run: |
           set -euxo pipefail
           source "${BUILD_ENV_FILE}"
-          if [[ ${{ inputs.architecture }} == 'ARM64' ]]; then
+          if [[ ${{ inputs.architecture }} == 'aarch64' ]]; then
             ${CONDA_RUN} conda install -y libpng jpeg
           fi
           ${CONDA_RUN} python setup.py clean

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -55,6 +55,16 @@ on:
         description: "The key created when saving a cache and the key used to search for a cache."
         default: ""
         type: string
+      architecture:
+        description: Architecure to use for setup-miniconda
+        required: false
+        type: string
+        default: x64
+      setup-miniconda:
+        description: Works as stated in actions/checkout, but the default value is recursive
+        required: false
+        type: boolean
+        default: true
     secrets:
       AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID:
         description: "AWS Access Key passed from caller workflow"
@@ -97,16 +107,34 @@ jobs:
           repository: ${{ inputs.test-infra-repository }}
           ref: ${{ inputs.test-infra-ref }}
           path: test-infra
+      - uses: actions/checkout@v3
+        if: ${{ inputs.architecture == 'ARM64' }}
+        with:
+          # Support the use case where we need to checkout someone's fork
+          repository: "pytorch/builder"
+          ref: "main"
+          path: builder
       - name: Setup SSH
         uses: ./test-infra/.github/actions/setup-ssh
         with:
           github-secret: ${{ github.token }}
+      - name: Set linux aarch64 CI
+        if: ${{ inputs.architecture == 'ARM64' }}
+        shell: bash -l {0}
+        env:
+          DESIRED_PYTHON: ${{ matrix.python_version }}
+        run: |
+          set +e
+          # TODO: Should we move aarch64 scripts to test-infra folder
+          ${GITHUB_WORKSPACE}/builder/aarch64_linux/aarch64_ci_build.sh
+          echo "/opt/conda/bin" >> $GITHUB_PATH
+          set -e
       - uses: ./test-infra/.github/actions/set-channel
       - uses: ./test-infra/.github/actions/setup-binary-builds
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-          setup-miniconda: true
+          setup-miniconda: ${{ inputs.setup-miniconda }}
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Combine Env Var and Build Env Files
         if: ${{ inputs.env-var-script != '' }}
@@ -134,6 +162,9 @@ jobs:
         run: |
           set -euxo pipefail
           source "${BUILD_ENV_FILE}"
+          if [[ ${{ inputs.architecture }} == 'ARM64' ]]; then
+            ${CONDA_RUN} conda install -y libpng jpeg
+          fi
           ${CONDA_RUN} python setup.py clean
       - name: Build the wheel (bdist_wheel)
         working-directory: ${{ inputs.repository }}
@@ -165,6 +196,7 @@ jobs:
           source "${BUILD_ENV_FILE}"
           WHEEL_NAME=$(ls "${{ inputs.repository }}/dist/")
           echo "$WHEEL_NAME"
+
           ${CONDA_RUN} pip install "${{ inputs.repository }}/dist/$WHEEL_NAME"
           # Checking that we have a pinned version of torch in our dependency tree
           (
@@ -173,6 +205,7 @@ jobs:
             # Ensure that pytorch version is pinned, should output file where it was found
             grep "Requires-Dist: torch (==.*)" -r .
           )
+
           if [[ (! -f "${{ inputs.repository }}"/${SMOKE_TEST_SCRIPT}) ]]; then
             echo "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT} not found"
             if [[ "${PACKAGE_NAME}" = "torchrec" ]]; then

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -56,7 +56,7 @@ on:
         default: ""
         type: string
       architecture:
-        description: Architecure to use for setup-miniconda
+        description: Architecure to build for x64 for default Linux, or ARM64 for Linux aarch64 builds
         required: false
         type: string
         default: x64
@@ -125,8 +125,8 @@ jobs:
           DESIRED_PYTHON: ${{ matrix.python_version }}
         run: |
           set +e
-          # TODO: Should we move aarch64 scripts to test-infra folder
-          ${GITHUB_WORKSPACE}/builder/aarch64_linux/aarch64_ci_build.sh
+          # TODO: This is temporary aarch64 setup script, this should be integrated into aarch64 docker.
+          ${GITHUB_WORKSPACE}/builder/aarch64_linux/aarch64_ci_setup.sh
           echo "/opt/conda/bin" >> $GITHUB_PATH
           set -e
       - uses: ./test-infra/.github/actions/set-channel

--- a/.github/workflows/test_build_wheels_linux_aarch64_without_cuda.yml
+++ b/.github/workflows/test_build_wheels_linux_aarch64_without_cuda.yml
@@ -1,0 +1,48 @@
+name: Test Build Linux Aarch64 Wheels
+
+on:
+  pull_request:
+    paths:
+      - .github/actions/setup-binary-builds/action.yml
+      - .github/workflows/test_build_wheels_linux.yml
+      - .github/workflows/build_wheels_linux.yml
+      - .github/workflows/generate_binary_build_matrix.yml
+      - .github/workflows/test_build_wheels_linux_without_cuda.yml
+      - tools/scripts/generate_binary_build_matrix.py
+  workflow_dispatch:
+
+jobs:
+  generate-matrix:
+    uses: ./.github/workflows/generate_binary_build_matrix.yml
+    with:
+      package-type: wheel
+      os: linux-aarch64
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      with-cuda: disable
+  test:
+    needs: generate-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repository: pytorch/vision
+            pre-script: packaging/pre_build_script.sh
+            post-script: packaging/post_build_script.sh
+            smoke-test-script: test/smoke_test.py
+            package-name: torchvision
+    uses: ./.github/workflows/build_wheels_linux.yml
+    name: ${{ matrix.repository }}
+    with:
+      repository: ${{ matrix.repository }}
+      ref: nightly
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      pre-script: ${{ matrix.pre-script }}
+      post-script: ${{ matrix.post-script }}
+      smoke-test-script: ${{ matrix.smoke-test-script }}
+      package-name: ${{ matrix.package-name }}
+      trigger-event: "${{ github.event_name }}"
+      architecture: ARM64
+      setup-miniconda: false

--- a/.github/workflows/test_build_wheels_linux_aarch64_without_cuda.yml
+++ b/.github/workflows/test_build_wheels_linux_aarch64_without_cuda.yml
@@ -44,5 +44,5 @@ jobs:
       smoke-test-script: ${{ matrix.smoke-test-script }}
       package-name: ${{ matrix.package-name }}
       trigger-event: "${{ github.event_name }}"
-      architecture: ARM64
+      architecture: aarch64
       setup-miniconda: false

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -36,6 +36,7 @@ ROCM_ARCHES_DICT = {
     "release": ["5.3", "5.4.2"],
 }
 
+CPU_AARCH64_ARCH = ["cpu-aarch64"]
 PACKAGE_TYPES = ["wheel", "conda", "libtorch"]
 PRE_CXX11_ABI = "pre-cxx11"
 CXX11_ABI = "cxx11-abi"
@@ -55,6 +56,7 @@ mod.PYTHON_ARCHES = PYTHON_ARCHES_DICT[NIGHTLY]
 
 LINUX_GPU_RUNNER = "linux.g5.4xlarge.nvidia.gpu"
 LINUX_CPU_RUNNER = "linux.2xlarge"
+LINUX_AARCH64_RUNNER = "linux.t4g.2xlarge"
 WIN_GPU_RUNNER = "windows.8xlarge.nvidia.gpu"
 WIN_CPU_RUNNER = "windows.4xlarge"
 MACOS_M1_RUNNER = "macos-m1-12"
@@ -75,6 +77,8 @@ def arch_type(arch_version: str) -> str:
         return "cuda"
     elif arch_version in mod.ROCM_ARCHES:
         return "rocm"
+    elif arch_version in CPU_AARCH64_ARCH:
+        return "cpu-aarch64"
     else:  # arch_version should always be "cpu" in this case
         return "cpu"
 
@@ -84,6 +88,8 @@ def validation_runner(arch_type: str, os: str) -> str:
             return LINUX_GPU_RUNNER
         else:
             return LINUX_CPU_RUNNER
+    elif os == "linux-aarch64":
+        return LINUX_AARCH64_RUNNER
     elif os == "windows":
         if arch_type == "cuda":
             return WIN_GPU_RUNNER
@@ -115,6 +121,7 @@ def initialize_globals(channel: str):
             for gpu_arch in mod.ROCM_ARCHES
         },
         "cpu": "pytorch/manylinux-builder:cpu",
+        "cpu-aarch64": "quay.io/pypa/manylinux2014_aarch64",
     }
     mod.CONDA_CONTAINER_IMAGES = {
         **{gpu_arch: f"pytorch/conda-builder:cuda{gpu_arch}" for gpu_arch in mod.CUDA_ARCHES},
@@ -145,6 +152,7 @@ def initialize_globals(channel: str):
 def translate_desired_cuda(gpu_arch_type: str, gpu_arch_version: str) -> str:
     return {
         "cpu": "cpu",
+        "cpu-aarch64": "cpu",
         "cuda": f"cu{gpu_arch_version.replace('.', '')}",
         "rocm": f"rocm{gpu_arch_version}",
     }.get(gpu_arch_type, gpu_arch_version)
@@ -361,6 +369,11 @@ def generate_wheels_matrix(
         # Define default compute architectures
         arches = ["cpu"]
 
+        if os == "linux-aarch64":
+            # Only want the one arch as the CPU type is different and
+            # uses different build/test scripts
+            arches = ["cpu-aarch64"]
+
         if with_cuda == ENABLE:
             upload_to_base_bucket = "no"
             if os == "linux":
@@ -379,7 +392,12 @@ def generate_wheels_matrix(
     for python_version in python_versions:
         for arch_version in arches:
             gpu_arch_type = arch_type(arch_version)
-            gpu_arch_version = "" if arch_version == "cpu" else arch_version
+            gpu_arch_version = (
+                ""
+                if arch_version == "cpu"
+                or arch_version == "cpu-aarch64"
+                else arch_version
+            )
 
             desired_cuda = translate_desired_cuda(gpu_arch_type, gpu_arch_version)
             ret.append(


### PR DESCRIPTION
This is first PR  to automate aarch64 domains build. Starting with torchvision.
Following this script : 
https://github.com/pytorch/builder/blob/main/aarch64_linux/build_aarch64_wheel.py

cc @osalpekar @malfet @xncqr