### PR TITLE
Add dropdown to hud header

### DIFF
--- a/.github/workflows/update-test-times.yml
+++ b/.github/workflows/update-test-times.yml
@@ -2,7 +2,7 @@ name: Update test times
 
 on:
   schedule:
-    # Every day at 3:05am UTC
+    # Every day at 3:05am UTC approximately 8:05 PM PT (depending on DST)
     - cron: "5 3 * * *"
   # Have the ability to trigger this job manually
   workflow_dispatch:

--- a/torchci/components/NavBar.module.css
+++ b/torchci/components/NavBar.module.css
@@ -1,37 +1,60 @@
-.menu li {
-  display: inline;
+.navbar {
+  display: flex;
+  padding: 0 1rem;
   font: bold;
-  margin-right: 1em;
-  color: red;
-  padding-left: 1em;
-}
-
-.menu {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.linksContainer {
-  padding: 10px;
   background: rgb(255, 227, 227);
   background: linear-gradient(326deg, rgb(255 246 246), rgb(255 247 236));
   box-shadow: 0 -4px 20px 0px #c2c2c2;
   width: 100%;
 }
 
-.links {
-  display: flex;
-  flex-direction: row;
-  padding-bottom: 3px;
-  z-index: 100;
+.navbar li {
+  padding: 0.7rem 1rem;
   position: relative;
+  z-index: 9999;
 }
 
-.links > ul {
-  margin-bottom: 0;
+.navbar a {
+  display: block;
+}
+
+.navbar span {
+  padding: 0;
+  margin: 0;
+}
+
+.navbar ul {
+  list-style: none;
+}
+
+.navbar {
+  margin: 0;
+  z-index: 100;
+}
+
+.navbarlinkslist {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
 }
 
 .homeLink {
   font-weight: bold;
   padding-right: 10px;
+}
+
+.dropdowntitle {
+  padding: 0.7rem 1rem;
+}
+
+.dropdown {
+  position: absolute;
+  box-shadow: 0 -4px 20px 0px #c2c2c2;
+  z-index: 9999;
+  min-width: 10rem;
+  padding: 0.5rem 0;
+  background-color: white;
+  display: none;
 }

--- a/torchci/components/NavBar.tsx
+++ b/torchci/components/NavBar.tsx
@@ -22,10 +22,10 @@ const NavBarDropdown = ({
     >
       <div className={styles.dropdowntitle}>{title} ▾</div>
       <ul className={styles.dropdown} style={dropdownStyle}>
-        {items.map((submenu: any) => (
-          <li>
-            <Link href={submenu.href} prefetch={false}>
-              {submenu.name}
+        {items.map((item: any) => (
+          <li key={item.href}>
+            <Link href={item.href} prefetch={false}>
+              {item.name}
             </Link>
           </li>
         ))}
@@ -66,17 +66,6 @@ function NavBar() {
     //   href: "/testingoverhead"
     // }
   ];
-
-  const otherReposDropdown = [
-    {
-      name: "TorchVision",
-      href: "/hud/pytorch/vision/main"
-    },
-    {
-      name: "TorchAudio",
-      href: "/hud/pytorch/audio/main"
-    }
-  ]
 
   return (
     <div className={styles.navbar}>

--- a/torchci/components/NavBar.tsx
+++ b/torchci/components/NavBar.tsx
@@ -37,10 +37,6 @@ const NavBarDropdown = ({
 function NavBar() {
   const devInfraDropdown = [
     {
-      name: "KPIs",
-      href: "/kpis",
-    },
-    {
       name: "SLIs",
       href: "/sli",
     },
@@ -49,7 +45,11 @@ function NavBar() {
       href: "/tts",
     },
     {
-      name: "Nightlies",
+      name: "Nightly Branch",
+      href: "/hud/pytorch/pytorch/nightly",
+    },
+    {
+      name: "Nightly Dashboard",
       href: "/nightlies",
     },
     {
@@ -79,11 +79,6 @@ function NavBar() {
           <li>
             <Link prefetch={false} href="/minihud">
               MiniHUD
-            </Link>
-          </li>
-          <li>
-            <Link prefetch={false} href="/hud/pytorch/pytorch/nightly">
-              Nightly
             </Link>
           </li>
           <li>
@@ -118,6 +113,11 @@ function NavBar() {
           <li>
             <Link prefetch={false} href="/metrics">
               Metrics
+            </Link>
+          </li>
+          <li>
+            <Link prefetch={false} href="/kpis">
+              KPIs
             </Link>
           </li>
           <li>

--- a/torchci/components/NavBar.tsx
+++ b/torchci/components/NavBar.tsx
@@ -2,126 +2,155 @@ import styles from "components/NavBar.module.css";
 import Link from "next/link";
 import { AiFillGithub } from "react-icons/ai";
 import LoginSection from "./LoginSection";
-function NavBar() {
+import { useState } from "react";
+
+const NavBarDropdown = ({
+  title,
+  items,
+}: {
+  title: string;
+  items: any;
+}): JSX.Element => {
+  const [dropdown, setDropdown] = useState(false);
+  const dropdownStyle = dropdown ? { display: "block" } : {};
+
   return (
-    <div className={styles.linksContainer}>
-      <div className={styles.links}>
-        <div>
-          <ul className={styles.menu}>
-            <span className={styles.homeLink}>
-              <Link prefetch={false} href="/">
-                PyTorch CI HUD
-              </Link>
-            </span>
-            <li>
-              <Link prefetch={false} href="/minihud">
-                MiniHUD
-              </Link>
-            </li>
-            <li>
-              <Link prefetch={false} href="/hud/pytorch/pytorch/main">
-                Main
-              </Link>
-            </li>
-            <li>
-              <Link prefetch={false} href="/hud/pytorch/pytorch/nightly">
-                Nightly
-              </Link>
-            </li>
-            <li>
-              <Link prefetch={false} href="/hud/pytorch/vision/main">
-                TorchVision
-              </Link>
-            </li>
-            <li>
-              <Link prefetch={false} href="/hud/pytorch/audio/main">
-                TorchAudio
-              </Link>
-            </li>
-          </ul>
-        </div>
-        <div
-          style={{
-            display: "inline",
-            marginLeft: "auto",
-            marginRight: "0px",
-            whiteSpace: "nowrap",
-          }}
-        >
-          <ul style={{ marginBottom: "0" }} className={styles.menu}>
-            <li>
-              <Link href="https://github.com/pytorch/pytorch/wiki/Using-hud.pytorch.org">
-                Help
-              </Link>
-            </li>
-            <li>
-              <Link href="https://github.com/pytorch/test-infra/issues/new?assignees=&labels=&template=feature_request.yaml&title=%5Bfeature%5D%3A+">
-                Requests
-              </Link>
-            </li>
-            <li>
-              <Link prefetch={false} href="/metrics">
-                Metrics
-              </Link>
-            </li>
-            <li>
-              <Link prefetch={false} href="/kpis">
-                KPIs
-              </Link>
-            </li>
-            <li>
-              <Link prefetch={false} href="/sli">
-                SLIs
-              </Link>
-            </li>
-            <li>
-              <Link prefetch={false} href="/tts">
-                TTS
-              </Link>
-            </li>
-            <li>
-              <Link prefetch={false} href="/nightlies">
-                Nightly
-              </Link>
-            </li>
-            <li>
-              <Link prefetch={false} href="/reliability">
-                Failures Metric
-              </Link>
-            </li>
-            {/* uncomment after some eyeballs are on this */}
-            {/* <li>
-              <Link prefetch={false} href="/testing_overhead">
-                Testing Overhead
-              </Link>
-            </li> */}
-            <li>
-              <Link prefetch={false} href="/failedjobs/pytorch/pytorch/main">
-                Failures Classifier
-              </Link>
-            </li>
-            <li>
-              <Link prefetch={false} href="/benchmark/compilers">
-                TorchInductor
-              </Link>
-            </li>
-            <li>
-              <span style={{ cursor: "pointer" }}>
-                <Link
-                  href="https://github.com/pytorch/test-infra/tree/main/torchci"
-                  passHref
-                >
-                  <a style={{ color: "black" }}>
-                    <AiFillGithub />
-                  </a>
-                </Link>
-              </span>
-            </li>
-            <li>
-              <LoginSection />
-            </li>
-          </ul>
-        </div>
+    <li
+      onMouseEnter={() => setDropdown(true)}
+      onMouseLeave={() => setDropdown(false)}
+      style={{ padding: 0 }}
+    >
+      <div className={styles.dropdowntitle}>{title} ▾</div>
+      <ul className={styles.dropdown} style={dropdownStyle}>
+        {items.map((submenu: any) => (
+          <li>
+            <Link href={submenu.href} prefetch={false}>
+              {submenu.name}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </li>
+  );
+};
+
+function NavBar() {
+  const devInfraDropdown = [
+    {
+      name: "KPIs",
+      href: "/kpis",
+    },
+    {
+      name: "SLIs",
+      href: "/sli",
+    },
+    {
+      name: "TTS",
+      href: "/tts",
+    },
+    {
+      name: "Nightlies",
+      href: "/nightlies",
+    },
+    {
+      name: "Failures Metric",
+      href: "/reliability",
+    },
+    {
+      name: "Failures Classifier",
+      href: "/failedjobs/pytorch/pytorch/main",
+    },
+    // uncomment after some eyeballs are on this
+    // {
+    //   name: "Testing Overhead",
+    //   href: "/testingoverhead"
+    // }
+  ];
+
+  const otherReposDropdown = [
+    {
+      name: "TorchVision",
+      href: "/hud/pytorch/vision/main"
+    },
+    {
+      name: "TorchAudio",
+      href: "/hud/pytorch/audio/main"
+    }
+  ]
+
+  return (
+    <div className={styles.navbar}>
+      <div>
+        <ul className={styles.navbarlinkslist}>
+          <li className={styles.homeLink}>
+            <Link prefetch={false} href="/">
+              PyTorch CI HUD
+            </Link>
+          </li>
+          <li>
+            <Link prefetch={false} href="/minihud">
+              MiniHUD
+            </Link>
+          </li>
+          <li>
+            <Link prefetch={false} href="/hud/pytorch/pytorch/nightly">
+              Nightly
+            </Link>
+          </li>
+          <li>
+            <Link prefetch={false} href="/hud/pytorch/vision/main">
+              TorchVision
+            </Link>
+          </li>
+          <li>
+            <Link prefetch={false} href="/hud/pytorch/audio/main">
+              TorchAudio
+            </Link>
+          </li>
+        </ul>
+      </div>
+      <div
+        style={{
+          marginLeft: "auto",
+          marginRight: "0px",
+        }}
+      >
+        <ul className={styles.navbarlinkslist}>
+          <li>
+            <Link href="https://github.com/pytorch/pytorch/wiki/Using-hud.pytorch.org">
+              Help
+            </Link>
+          </li>
+          <li>
+            <Link href="https://github.com/pytorch/test-infra/issues/new?assignees=&labels=&template=feature_request.yaml&title=%5Bfeature%5D%3A+">
+              Requests
+            </Link>
+          </li>
+          <li>
+            <Link prefetch={false} href="/metrics">
+              Metrics
+            </Link>
+          </li>
+          <li>
+            <Link prefetch={false} href="/benchmark/compilers">
+              TorchInductor
+            </Link>
+          </li>
+          <NavBarDropdown title="Dev Infra" items={devInfraDropdown} />
+          <li style={{ cursor: "pointer" }}>
+            <Link
+              href="https://github.com/pytorch/test-infra/tree/main/torchci"
+              passHref
+            >
+              <a style={{ color: "black" }}>
+                <AiFillGithub />
+              </a>
+            </Link>
+          </li>
+          <li style={{ padding: "0 1rem" }}>
+            <LoginSection></LoginSection>
+          </li>
+        </ul>
       </div>
     </div>
   );


### PR DESCRIPTION
Referenced css from https://blog.logrocket.com/how-create-multilevel-dropdown-menu-react/ and its source code at https://github.com/Ibaslogic/react-multilevel-dropdown-menu

On my smaller screen, the HUD header was becoming a bit full, so I added a dropdown and moved a lot of the dev infra links into it.  I left metrics in the bar since I think it is used frequently, but I am open to moving links around if people want fewer clicks for pages they visit often.  

The dropdown component is reusable so if we also want to add a lot of repositories and the header doesn't have space for that, we can move them all into a dropdown as well.  I have no idea how the dropdown reacts to having so many things in it it takes up the entire page but that's a problem for future me (probably either make it tiered or scrollable).

Also remove the main branch link since the homepage is main.

Please visit the vercel preview to see if you like it.

Fixes https://github.com/pytorch/test-infra/issues/4439