### PR TITLE
Add a log classifiier rule to match ASAN LD_PRELOAD error

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -157,6 +157,10 @@ name = 'Dependency fetch error'
 pattern = '^Error downloading packages:'
 
 [[rule]]
+name = 'ASAN LD_PRELOAD failure'
+pattern = '^ERROR: ld.so: object .+ from LD_PRELOAD cannot be preloaded'
+
+[[rule]]
 name = 'ASAN failure'
 pattern = '^ERROR: AddressSanitizer'
 


### PR DESCRIPTION
This will match this case https://github.com/pytorch/pytorch/pull/106562.  As we just migrate ASAN job from clang7 to clang12, I suspect that some folks will get this error on their PR if they don't have https://github.com/pytorch/pytorch/pull/106355 in their base.