### PR TITLE
[BE] Make metrics page cleaner

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -547,7 +547,22 @@ export default function Page() {
             />
           </Stack>
         </Grid>
-
+        <Grid container item lg={2} md={3} xs={6} justifyContent={"stretch"}>
+          <Stack justifyContent={"space-between"} flexGrow={1} flexWrap="wrap" spacing={1}>
+            <ScalarPanelWithValue
+              title={"Time to Red Signal (p90 TTRS - mins)"}
+              value={"TBD"}
+              valueRenderer={(value) => (value)}
+              badThreshold={(value) => value > 50}
+            />
+            <ScalarPanelWithValue
+              title={"Time to Red Signal (p75 TTRS - mins)"}
+              value={"TBD"}
+              valueRenderer={(value) => (value)}
+              badThreshold={(value) => value > 40}
+            />
+            </Stack>
+        </Grid>
         <Grid container item lg={2} md={3} xs={6} justifyContent={"stretch"}>
           <Stack justifyContent={"space-between"} flexGrow={1} flexWrap="wrap" spacing={1}>
             <ScalarPanel

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -507,13 +507,17 @@ export default function Page() {
       </Stack>
 
       <Grid container spacing={2}>
-
         <Grid item md={6} xs={12} height={ROW_HEIGHT}>
           <MasterCommitRedPanel params={timeParams} />
         </Grid>
 
         <Grid container item lg={2} md={3} xs={6} justifyContent={"stretch"}>
-          <Stack justifyContent={"space-between"} flexGrow={1} flexWrap="wrap" spacing={1}>
+          <Stack
+            justifyContent={"space-between"}
+            flexGrow={1}
+            flexWrap="wrap"
+            spacing={1}
+          >
             <ScalarPanelWithValue
               title={"% commits red on main (broken trunk)"}
               value={brokenTrunkRed}
@@ -530,8 +534,13 @@ export default function Page() {
         </Grid>
 
         <Grid container item lg={2} md={3} xs={6} justifyContent={"stretch"}>
-          <Stack justifyContent={"space-between"} flexGrow={1} flexWrap="wrap" spacing={1}>
-           <ScalarPanel
+          <Stack
+            justifyContent={"space-between"}
+            flexGrow={1}
+            flexWrap="wrap"
+            spacing={1}
+          >
+            <ScalarPanel
               title={"% force merges due to failed PR checks"}
               queryName={"force_merge_red_avg"}
               metricName={"force_merges_red"}
@@ -542,29 +551,39 @@ export default function Page() {
             <ScalarPanelWithValue
               title={"% force merges due to impatience"}
               value={"TBD"}
-              valueRenderer={(value) => (value)}
+              valueRenderer={(value) => value}
               badThreshold={(value) => value > 0.055}
             />
           </Stack>
         </Grid>
         <Grid container item lg={2} md={3} xs={6} justifyContent={"stretch"}>
-          <Stack justifyContent={"space-between"} flexGrow={1} flexWrap="wrap" spacing={1}>
+          <Stack
+            justifyContent={"space-between"}
+            flexGrow={1}
+            flexWrap="wrap"
+            spacing={1}
+          >
             <ScalarPanelWithValue
               title={"Time to Red Signal (p90 TTRS - mins)"}
               value={"TBD"}
-              valueRenderer={(value) => (value)}
+              valueRenderer={(value) => value}
               badThreshold={(value) => value > 50}
             />
             <ScalarPanelWithValue
               title={"Time to Red Signal (p75 TTRS - mins)"}
               value={"TBD"}
-              valueRenderer={(value) => (value)}
+              valueRenderer={(value) => value}
               badThreshold={(value) => value > 40}
             />
-            </Stack>
+          </Stack>
         </Grid>
         <Grid container item lg={2} md={3} xs={6} justifyContent={"stretch"}>
-          <Stack justifyContent={"space-between"} flexGrow={1} flexWrap="wrap" spacing={1}>
+          <Stack
+            justifyContent={"space-between"}
+            flexGrow={1}
+            flexWrap="wrap"
+            spacing={1}
+          >
             <ScalarPanel
               title={"viable/strict lag"}
               queryName={"strict_lag_sec"}
@@ -584,9 +603,13 @@ export default function Page() {
           </Stack>
         </Grid>
 
-
         <Grid container item lg={2} md={3} xs={6} justifyContent={"stretch"}>
-          <Stack justifyContent={"space-between"} flexGrow={1} flexWrap="wrap" spacing={1}>
+          <Stack
+            justifyContent={"space-between"}
+            flexGrow={1}
+            flexWrap="wrap"
+            spacing={1}
+          >
             <ScalarPanel
               title={"Last main push"}
               queryName={"last_branch_push"}
@@ -618,9 +641,13 @@ export default function Page() {
           </Stack>
         </Grid>
 
-
         <Grid container item lg={2} md={3} xs={6} justifyContent={"stretch"}>
-          <Stack justifyContent={"space-between"} flexGrow={1} flexWrap="wrap" spacing={1}>
+          <Stack
+            justifyContent={"space-between"}
+            flexGrow={1}
+            flexWrap="wrap"
+            spacing={1}
+          >
             <ScalarPanel
               title={"Last docker build"}
               queryName={"last_successful_workflow"}
@@ -652,12 +679,16 @@ export default function Page() {
               ]}
               badThreshold={(value) => value > 3 * 24 * 60 * 60} // 3 day
             />
-            </Stack>
+          </Stack>
         </Grid>
 
-
         <Grid container item lg={2} md={3} xs={6} justifyContent={"stretch"}>
-          <Stack justifyContent={"space-between"} flexGrow={1} flexWrap="wrap" spacing={1}>
+          <Stack
+            justifyContent={"space-between"}
+            flexGrow={1}
+            flexWrap="wrap"
+            spacing={1}
+          >
             <ScalarPanel
               title={"# reverts"}
               queryName={"reverts"}
@@ -679,13 +710,18 @@ export default function Page() {
         </Grid>
 
         <Grid container item lg={2} md={3} xs={6} justifyContent={"stretch"}>
-          <Stack justifyContent={"space-between"} flexGrow={1} flexWrap="wrap" spacing={1}>
+          <Stack
+            justifyContent={"space-between"}
+            flexGrow={1}
+            flexWrap="wrap"
+            spacing={1}
+          >
             <WorkflowDuration
               percentileParam={percentileParam}
               timeParams={timeParams}
               workflowNames={["pull", "trunk"]}
             />
-            </Stack>
+          </Stack>
         </Grid>
 
         <Grid item xs={6} height={ROW_HEIGHT}>

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -483,7 +483,7 @@ function JobsDuration({
   );
 }
 
-const ROW_HEIGHT = 340;
+const ROW_HEIGHT = 375;
 
 function getCommitRedMetrics(queryParams: RocksetParam[]) {}
 
@@ -560,72 +560,49 @@ export default function Page() {
       </Stack>
 
       <Grid container spacing={2}>
-        <Grid item xs={6} height={ROW_HEIGHT}>
-          <MasterJobsRedPanel params={timeParams} />
+
+        <Grid item md={6} xs={12} height={ROW_HEIGHT}>
+          <MasterCommitRedPanel params={timeParams} />
         </Grid>
-        <Grid container item xs={2} justifyContent={"stretch"}>
-          <Stack justifyContent={"space-between"} flexGrow={1}>
+
+        <Grid container item lg={2} md={3} xs={6} justifyContent={"stretch"}>
+          <Stack justifyContent={"space-between"} flexGrow={1} flexWrap="wrap" spacing={1}>
             <ScalarPanelWithValue
               title={"% commits red on main (broken trunk)"}
               value={brokenTrunkRed}
               valueRenderer={(value) => (value * 100).toFixed(1) + "%"}
               badThreshold={(value) => value > 0.2}
             />
-            <ScalarPanel
-              title={"# commits"}
-              queryName={"num_commits_master"}
-              queryCollection={"commons"}
-              metricName={"num"}
-              valueRenderer={(value) => value}
-              queryParams={timeParams}
-              badThreshold={(_) => false}
-            />
-          </Stack>
-        </Grid>
-
-        <Grid container item xs={2} justifyContent={"stretch"}>
-          <Stack justifyContent={"space-between"} flexGrow={1}>
             <ScalarPanelWithValue
               title={"% commits red on main (flaky)"}
               value={flakyRed}
               valueRenderer={(value) => (value * 100).toFixed(1) + "%"}
               badThreshold={(value) => value > 0.2}
             />
-            <ScalarPanel
-              title={"# reverts"}
-              queryName={"reverts"}
-              metricName={"num"}
-              valueRenderer={(value: string) => value}
-              queryParams={timeParams}
-              badThreshold={(value) => value > 10}
-            />
           </Stack>
         </Grid>
 
-        <Grid container item xs={2} justifyContent={"stretch"}>
-          <Stack justifyContent={"space-between"} flexGrow={1}>
-            <ScalarPanel
+        <Grid container item lg={2} md={3} xs={6} justifyContent={"stretch"}>
+          <Stack justifyContent={"space-between"} flexGrow={1} flexWrap="wrap" spacing={1}>
+           <ScalarPanel
               title={"% force merges due to failed PR checks"}
               queryName={"force_merge_red_avg"}
               metricName={"force_merges_red"}
               valueRenderer={(value) => (value * 100).toFixed(1) + "%"}
               queryParams={timeParams}
-              badThreshold={(value) => value > 0.2}
+              badThreshold={(value) => value > 0.055}
             />
-            <WorkflowDuration
-              percentileParam={percentileParam}
-              timeParams={timeParams}
-              workflowNames={["pull", "trunk"]}
+            <ScalarPanelWithValue
+              title={"% force merges due to impatience"}
+              value={"TBD"}
+              valueRenderer={(value) => (value)}
+              badThreshold={(value) => value > 0.055}
             />
           </Stack>
         </Grid>
 
-        <Grid item xs={6} height={ROW_HEIGHT}>
-          <MasterCommitRedPanel params={timeParams} />
-        </Grid>
-
-        <Grid container item xs={2} justifyContent={"stretch"}>
-          <Stack justifyContent={"space-between"} flexGrow={1}>
+        <Grid container item lg={2} md={3} xs={6} justifyContent={"stretch"}>
+          <Stack justifyContent={"space-between"} flexGrow={1} flexWrap="wrap" spacing={1}>
             <ScalarPanel
               title={"viable/strict lag"}
               queryName={"strict_lag_sec"}
@@ -645,8 +622,9 @@ export default function Page() {
           </Stack>
         </Grid>
 
-        <Grid container item xs={2} justifyContent={"stretch"}>
-          <Stack justifyContent={"space-between"} flexGrow={1}>
+
+        <Grid container item lg={2} md={3} xs={6} justifyContent={"stretch"}>
+          <Stack justifyContent={"space-between"} flexGrow={1} flexWrap="wrap" spacing={1}>
             <ScalarPanel
               title={"Last main push"}
               queryName={"last_branch_push"}
@@ -678,8 +656,9 @@ export default function Page() {
           </Stack>
         </Grid>
 
-        <Grid container item xs={2} justifyContent={"stretch"}>
-          <Stack justifyContent={"space-between"} flexGrow={1}>
+
+        <Grid container item lg={2} md={3} xs={6} justifyContent={"stretch"}>
+          <Stack justifyContent={"space-between"} flexGrow={1} flexWrap="wrap" spacing={1}>
             <ScalarPanel
               title={"Last docker build"}
               queryName={"last_successful_workflow"}
@@ -711,7 +690,40 @@ export default function Page() {
               ]}
               badThreshold={(value) => value > 3 * 24 * 60 * 60} // 3 day
             />
+            </Stack>
+        </Grid>
+
+
+        <Grid container item lg={2} md={3} xs={6} justifyContent={"stretch"}>
+          <Stack justifyContent={"space-between"} flexGrow={1} flexWrap="wrap" spacing={1}>
+            <ScalarPanel
+              title={"# reverts"}
+              queryName={"reverts"}
+              metricName={"num"}
+              valueRenderer={(value: string) => value}
+              queryParams={timeParams}
+              badThreshold={(value) => value > 10}
+            />
+            <ScalarPanel
+              title={"# commits"}
+              queryName={"num_commits_master"}
+              queryCollection={"commons"}
+              metricName={"num"}
+              valueRenderer={(value) => value}
+              queryParams={timeParams}
+              badThreshold={(_) => false}
+            />
           </Stack>
+        </Grid>
+
+        <Grid container item lg={2} md={3} xs={6} justifyContent={"stretch"}>
+          <Stack justifyContent={"space-between"} flexGrow={1} flexWrap="wrap" spacing={1}>
+            <WorkflowDuration
+              percentileParam={percentileParam}
+              timeParams={timeParams}
+              workflowNames={["pull", "trunk"]}
+            />
+            </Stack>
         </Grid>
 
         <Grid item xs={6} height={ROW_HEIGHT}>

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -33,59 +33,6 @@ import TablePanel from "components/metrics/panels/TablePanel";
 import TimeSeriesPanel from "components/metrics/panels/TimeSeriesPanel";
 import { durationDisplay } from "components/TimeUtils";
 
-function MasterJobsRedPanel({ params }: { params: RocksetParam[] }) {
-  const url = `/api/query/metrics/master_jobs_red?parameters=${encodeURIComponent(
-    JSON.stringify(params)
-  )}`;
-
-  const { data } = useSWR(url, fetcher, {
-    refreshInterval: 5 * 60 * 1000, // refresh every 5 minutes
-  });
-
-  if (data === undefined) {
-    return <Skeleton variant={"rectangular"} height={"100%"} />;
-  }
-
-  const options: EChartsOption = {
-    title: { text: "% main jobs by red" },
-    grid: { top: 48, right: 8, bottom: 24, left: 36 },
-    dataset: { source: data },
-    xAxis: { type: "time" },
-    yAxis: {
-      type: "value",
-      axisLabel: {
-        formatter: (value: number) => {
-          return (value * 100).toString() + "%";
-        },
-      },
-    },
-    series: [
-      {
-        type: "bar",
-        encode: {
-          x: "granularity_bucket",
-          y: "red",
-        },
-      },
-    ],
-    tooltip: {
-      trigger: "axis",
-      valueFormatter: (value: any) => {
-        return (value * 100).toFixed(2) + "%";
-      },
-    },
-  };
-
-  return (
-    <Paper sx={{ p: 2, height: "100%" }} elevation={3}>
-      <ReactECharts
-        style={{ height: "100%", width: "100%" }}
-        option={options}
-      />
-    </Paper>
-  );
-}
-
 function MasterCommitRedPanel({ params }: { params: RocksetParam[] }) {
   const url = `/api/query/metrics/master_commit_red?parameters=${encodeURIComponent(
     JSON.stringify([


### PR DESCRIPTION
Makes the following changes to the metrics page:
- Removes the irrelevant master jobs red chart, and moves the red commit chart into it's position. That chart had been more useful back when we'd randomly have large sets of jobs failing, over a year ago, but we now have much better metrics for this purpose and no one pays attention to this chart.
- Rearranges scalar stats to open make most important stats most prominent (none of these are removed)
- Makes the scalar stats more responsive, so the numbers remain readable as you shrink your browser window
- Reserves slots for key kpis for the half

Old vs New, when window width is smaller:
<img width="1804" alt="image" src="https://github.com/pytorch/test-infra/assets/4468967/90f6cf7b-41ef-4cf4-be7f-80213fb9350b">

