### PR TITLE
Add TTRS to metrics page

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -591,16 +591,46 @@ export default function Page() {
             flexWrap="wrap"
             spacing={1}
           >
-            <ScalarPanelWithValue
+            <ScalarPanel
               title={"Time to Red Signal (p90 TTRS - mins)"}
-              value={"TBD"}
+              queryCollection={"pytorch_dev_infra_kpis"}
+              queryName={"ttrs_percentiles"}
+              metricName={"ttrs_mins"}
               valueRenderer={(value) => value}
+              queryParams={[
+                {
+                  name: "one_bucket",
+                  type: "bool",
+                  value: "False",
+                },
+                {
+                  name: "percentile_to_get",
+                  type: "float",
+                  value: "0.90",
+                },
+                ...timeParams,
+              ]}
               badThreshold={(value) => value > 50}
             />
-            <ScalarPanelWithValue
+            <ScalarPanel
               title={"Time to Red Signal (p75 TTRS - mins)"}
-              value={"TBD"}
+              queryCollection={"pytorch_dev_infra_kpis"}
+              queryName={"ttrs_percentiles"}
+              metricName={"ttrs_mins"}
               valueRenderer={(value) => value}
+              queryParams={[
+                {
+                  name: "one_bucket",
+                  type: "bool",
+                  value: "False",
+                },
+                {
+                  name: "percentile_to_get",
+                  type: "float",
+                  value: "0.75",
+                },
+                ...timeParams,
+              ]}
               badThreshold={(value) => value > 40}
             />
           </Stack>

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -601,7 +601,7 @@ export default function Page() {
                 {
                   name: "one_bucket",
                   type: "bool",
-                  value: "False",
+                  value: "True",
                 },
                 {
                   name: "percentile_to_get",
@@ -622,7 +622,7 @@ export default function Page() {
                 {
                   name: "one_bucket",
                   type: "bool",
-                  value: "False",
+                  value: "True",
                 },
                 {
                   name: "percentile_to_get",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -40,7 +40,7 @@
     "time_to_signal": "ff332d025976c103",
     "strict_lag_historical": "d2a09d13caf8b76a",
     "ci_wait_time": "b1080f26b20ea142",
-    "ttrs_percentiles": "d62f6c09ab8b83f4"
+    "ttrs_percentiles": "414f23cc5fcb6753"
   },
   "metrics": {
     "correlation_matrix": "35c05e04047123f0",

--- a/torchci/rockset/pytorch_dev_infra_kpis/ttrs_percentiles.lambda.json
+++ b/torchci/rockset/pytorch_dev_infra_kpis/ttrs_percentiles.lambda.json
@@ -2,9 +2,9 @@
   "sql_path": "__sql/ttrs_percentiles.sql",
   "default_parameters": [
     {
-      "name": "from_days_ago",
-      "type": "int",
-      "value": "180"
+      "name": "one_bucket",
+      "type": "bool",
+      "value": "False"
     },
     {
       "name": "percentile_to_get",
@@ -12,9 +12,14 @@
       "value": "0"
     },
     {
-      "name": "to_days_ago",
-      "type": "int",
-      "value": "0"
+      "name": "startTime",
+      "type": "string",
+      "value": "2022-12-16T00:06:32.839Z"
+    },
+    {
+      "name": "stopTime",
+      "type": "string",
+      "value": "2023-08-16T00:06:32.839Z"
     }
   ],
   "description": "Computes the TTRS kpi"


### PR DESCRIPTION
Features:
- Updates the existing TTRS metric to make it compatible with both: the KPI page with historical results, and the metric page with the current time period's results.
    - Benefit: If we change the query later, there's only one source of truth to remember to modify
- Adds the TTRS to the metrics page with both p75 and p90 results.