### PR TITLE
Mount repo to /repo instead of /work if the repo name is set

### DIFF
--- a/.github/scripts/run_docker_with_env_secrets.py
+++ b/.github/scripts/run_docker_with_env_secrets.py
@@ -81,7 +81,7 @@ def main():
         -v "{ os.environ.get('RUNNER_TEST_RESULTS_DIR', '') }:/test-results" \
         -v "{ os.environ.get('RUNNER_TEMP', '') }/exec_script:/exec" \
         -v "{ os.environ.get('GITHUB_STEP_SUMMARY', '') }":"{ os.environ.get('GITHUB_STEP_SUMMARY', '') }" \
-        -w /work \
+        -w /{ os.environ.get('REPOSITORY', 'work') } \
         "{ os.environ.get('DOCKER_IMAGE', '') }"
     """
         )

--- a/.github/scripts/run_docker_with_env_secrets.py
+++ b/.github/scripts/run_docker_with_env_secrets.py
@@ -74,7 +74,7 @@ def main():
         --tty \
         --ulimit stack=10485760:83886080 \
         { os.environ.get('GPU_FLAG', '') } \
-        -v "{ os.environ.get('GITHUB_WORKSPACE', '') }/{ os.environ.get('REPOSITORY', '') }:/work" \
+        -v "{ os.environ.get('GITHUB_WORKSPACE', '') }/{ os.environ.get('REPOSITORY', '') }:/{ os.environ.get('REPOSITORY', 'work') }" \
         -v "{ os.environ.get('GITHUB_WORKSPACE', '') }/test-infra:/test-infra" \
         -v "{ os.environ.get('RUNNER_ARTIFACT_DIR', '') }:/artifacts" \
         -v "{ os.environ.get('RUNNER_DOCS_DIR', '') }:/docs" \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,7 @@ jobs:
         source .venv/bin/activate
         pip install pip==23.0.1 pytest==7.2.0 rockset==1.0.3 jsonschema==4.17.3
         echo ::endgroup::
-        
+
+        sleep 300
         # Test tools
         python3 -m unittest discover -vs tools/tests -p 'test_*.py'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,5 @@ jobs:
         pip install pip==23.0.1 pytest==7.2.0 rockset==1.0.3 jsonschema==4.17.3
         echo ::endgroup::
 
-        sleep 300
         # Test tools
         python3 -m unittest discover -vs tools/tests -p 'test_*.py'


### PR DESCRIPTION
This is to address the build failure https://github.com/pytorch/executorch/actions/runs/5814461344/job/15764455362?pr=52 where the cmake build expects the repo name in the include path, not `/work`