### PR TITLE
Fix gpu pass-though for conda builds

### DIFF
--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -80,6 +80,7 @@ jobs:
     runs-on: ${{ matrix.validation_runner }}
     container:
       image: ${{ matrix.container_image }}
+      options: ${{ matrix.gpu_arch_type == 'cuda' && '--gpus all' || ' ' }}
     # If a build is taking longer than 60 minutes on these runners we need
     # to have a conversation
     timeout-minutes: 60


### PR DESCRIPTION
Execute gpu tests on nightly cuda binaries
Same as : https://github.com/pytorch/test-infra/pull/4349

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7b8db43</samp>

> _`docker run` options_
> _enable GPU tests on `cuda`_
> _cutting edge in spring_

