### PR TITLE
[aarch64] Adding aarch64 TorchData

### DIFF
--- a/.github/workflows/test_build_wheels_linux_aarch64_without_cuda.yml
+++ b/.github/workflows/test_build_wheels_linux_aarch64_without_cuda.yml
@@ -34,6 +34,11 @@ jobs:
           - repository: pytorch/audio
             smoke-test-script: test/smoke_test/smoke_test.py
             package-name: torchaudio
+          - repository: pytorch/data
+            pre-script: packaging/pre_build_script_linux.sh
+            post-script: packaging/post_build_script_linux.sh
+            smoke-test-script: test/smoke_test/smoke_test.py
+            package-name: torchdata
     uses: ./.github/workflows/build_wheels_linux.yml
     name: ${{ matrix.repository }}
     with:


### PR DESCRIPTION
# Changes
* Adding aarch64 TorchData to matrix in `test_build_wheels_linux_aarch64_without_cuda.yml` to build/test aarch64 TorchData
