### PR TITLE
Add merge base date to drci comment

### DIFF
--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -336,7 +336,7 @@ export function constructResultsComment(
       "was",
       flakyJobs.length,
       "were"
-    )} present on the merge base ${merge_base}`,
+    )} present on the merge base`,
     brokenTrunkJobs,
     "Rebase onto the `viable/strict` branch to avoid these failures",
     true

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -299,7 +299,7 @@ export function constructResultsComment(
   output += title;
 
   output += `\nAs of commit ${sha} with merge base ${merge_base}`;
-  const timestamp = new Date(merge_base_date).valueOf() / 1000;
+  const timestamp = Math.floor(new Date(merge_base_date).valueOf() / 1000);
   if (!isNaN(timestamp)) {
     output += ` (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/${timestamp}?label=&color=FFFFFF&style=flat-square"></sub></sub>)`;
   }

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -7,7 +7,6 @@ import {
 import { RecentWorkflowsData } from "lib/types";
 import {
   NUM_MINUTES,
-  REPO,
   formDrciComment,
   OWNER,
   getDrciComment,
@@ -27,6 +26,7 @@ interface PRandJobs {
   pr_number: number;
   jobs: Map<string, RecentWorkflowsData>;
   merge_base: string;
+  merge_base_date: string;
 }
 
 export interface FlakyRule {
@@ -89,6 +89,7 @@ export async function updateDrciComments(
       unstableJobs,
       pr_info.head_sha,
       pr_info.merge_base,
+      pr_info.merge_base_date,
       `${HUD_URL}${OWNER}/${repo}/${pr_info.pr_number}`
     );
 
@@ -134,6 +135,8 @@ async function addMergeBaseCommits(
     });
 
     pr_info.merge_base = diff.data.merge_base_commit.sha;
+    pr_info.merge_base_date =
+      diff.data.merge_base_commit.commit.committer?.date ?? "";
   });
 }
 
@@ -237,6 +240,7 @@ export function constructResultsComment(
   unstableJobs: RecentWorkflowsData[],
   sha: string,
   merge_base: string,
+  merge_base_date: string,
   hud_pr_url: string
 ): string {
   let output = `\n`;
@@ -293,7 +297,13 @@ export function constructResultsComment(
 
   let title = headerPrefix + icon + " " + title_messages.join(", ");
   output += title;
-  output += `\nAs of commit ${sha}:`;
+
+  output += `\nAs of commit ${sha} with merge base ${merge_base}`;
+  const timestamp = new Date(merge_base_date).valueOf() / 1000;
+  if (!isNaN(timestamp)) {
+    output += ` (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/${timestamp}?label=&color=FFFFFF&style=flat-square"></sub></sub>)`;
+  }
+  output += ":";
 
   if (!hasAnyFailing) {
     output += `\n:green_heart: Looks good so far! There are no failures yet. :green_heart:`;
@@ -444,6 +454,7 @@ export function reorganizeWorkflows(
         head_sha: workflow.head_sha,
         jobs: new Map(),
         merge_base: "",
+        merge_base_date: "",
       });
     }
     const name = workflow.name!;

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -9,15 +9,13 @@ import {
   getActiveSEVs,
   formDrciSevBody,
 } from "lib/drciUtils";
-import { IssueData } from "lib/types";
-import { testOctokit } from "./utils";
+import { IssueData, RecentWorkflowsData } from "lib/types";
 import dayjs from "dayjs";
 import { removeJobNameSuffix } from "lib/jobUtils";
 import * as fetchRecentWorkflows from "lib/fetchRecentWorkflows";
 
 nock.disableNetConnect();
 
-const dummyBaseSha = "dummyBaseSha";
 export const successfulA = {
   name: "linux-docs / build-docs (cpp)",
   conclusion: "success",
@@ -212,6 +210,40 @@ const closedSev: IssueData = {
   author_association: "MEMBER",
 };
 
+function constructResultsCommentHelper({
+  pending = 3,
+  failedJobs = [],
+  flakyJobs = [],
+  brokenTrunkJobs = [],
+  unstableJobs = [],
+  sha = "random sha",
+  merge_base = "random_merge_base_sha",
+  merge_base_date = "2023-08-08T06:03:21Z",
+  hud_pr_url = "random hud pr url",
+}: {
+  pending?: number;
+  failedJobs?: RecentWorkflowsData[];
+  flakyJobs?: RecentWorkflowsData[];
+  brokenTrunkJobs?: RecentWorkflowsData[];
+  unstableJobs?: RecentWorkflowsData[];
+  sha?: string;
+  merge_base?: string;
+  merge_base_date?: string;
+  hud_pr_url?: string;
+}) {
+  return updateDrciBot.constructResultsComment(
+    pending,
+    failedJobs,
+    flakyJobs,
+    brokenTrunkJobs,
+    unstableJobs,
+    sha,
+    merge_base,
+    merge_base_date,
+    hud_pr_url
+  );
+}
+
 describe("Update Dr. CI Bot Unit Tests", () => {
   beforeEach(() => {});
 
@@ -237,16 +269,12 @@ describe("Update Dr. CI Bot Unit Tests", () => {
       [],
       new Map()
     );
-    const failureInfo = updateDrciBot.constructResultsComment(
+    const failureInfo = constructResultsCommentHelper({
       pending,
       failedJobs,
-      [],
-      [],
-      [],
-      pr_1001.head_sha,
-      "random sha",
-      "hudlink"
-    );
+      sha: pr_1001.head_sha,
+      hud_pr_url: "hudlink",
+    });
     const failedJobName = failedA.name;
 
     expect(failureInfo.includes("3 New Failures, 1 Pending")).toBeTruthy();
@@ -311,16 +339,11 @@ describe("Update Dr. CI Bot Unit Tests", () => {
       new Map()
     );
 
-    const failureInfo = updateDrciBot.constructResultsComment(
+    const failureInfo = constructResultsCommentHelper({
       pending,
       failedJobs,
-      [],
-      [],
-      [],
-      pr_1001.head_sha,
-      "random sha",
-      "hudlink"
-    );
+      sha: pr_1001.head_sha,
+    });
     const comment = formDrciComment(1001, "pytorch", "pytorch", failureInfo);
     expect(comment.includes("1 New Failure, 1 Pending")).toBeTruthy();
     expect(comment.includes("Helpful Links")).toBeTruthy();
@@ -355,16 +378,11 @@ describe("Update Dr. CI Bot Unit Tests", () => {
       new Map()
     );
 
-    const failureInfo = updateDrciBot.constructResultsComment(
+    const failureInfo = constructResultsCommentHelper({
       pending,
       failedJobs,
-      [],
-      [],
-      [],
-      pr_1001.head_sha,
-      "random sha",
-      "hudlink"
-    );
+      sha: pr_1001.head_sha,
+    });
     const comment = formDrciComment(
       1001,
       "pytorch",
@@ -395,16 +413,11 @@ describe("Update Dr. CI Bot Unit Tests", () => {
       [],
       new Map()
     );
-    const failureInfo = updateDrciBot.constructResultsComment(
+    const failureInfo = constructResultsCommentHelper({
       pending,
       failedJobs,
-      [],
-      [],
-      [],
-      pr_1001.head_sha,
-      "random sha",
-      "hudlink"
-    );
+      sha: pr_1001.head_sha,
+    });
     const comment = formDrciComment(1001, "pytorch", "pytorch", failureInfo);
     expect(comment.includes("## :link: Helpful Links")).toBeTruthy();
     expect(
@@ -430,16 +443,11 @@ describe("Update Dr. CI Bot Unit Tests", () => {
       [],
       new Map()
     );
-    const failureInfo = updateDrciBot.constructResultsComment(
+    const failureInfo = constructResultsCommentHelper({
       pending,
       failedJobs,
-      [],
-      [],
-      [],
-      pr_1001.head_sha,
-      "random sha",
-      "hudlink"
-    );
+      sha: pr_1001.head_sha,
+    });
     const comment = formDrciComment(1001, "pytorch", "pytorch", failureInfo);
     expect(comment.includes("## :link: Helpful Links")).toBeTruthy();
     expect(comment.includes("## :x: 1 New Failure, 1 Pending")).toBeTruthy();
@@ -516,16 +524,14 @@ describe("Update Dr. CI Bot Unit Tests", () => {
   });
 
   test("test flaky, broken trunk, and unstable jobs are included in the comment", async () => {
-    const failureInfoComment = updateDrciBot.constructResultsComment(
-      1,
-      [failedA],
-      [failedB],
-      [failedC],
-      [unstableA],
-      "random head sha",
-      "random base sha",
-      "hudlink"
-    );
+    const failureInfoComment = constructResultsCommentHelper({
+      pending: 1,
+      failedJobs: [failedA],
+      flakyJobs: [failedB],
+      brokenTrunkJobs: [failedC],
+      unstableJobs: [unstableA],
+      merge_base: "random base sha",
+    });
     const expectToContain = [
       "1 New Failure, 1 Pending, 3 Unrelated Failures",
       "The following job has failed",
@@ -543,16 +549,12 @@ describe("Update Dr. CI Bot Unit Tests", () => {
   });
 
   test("test flaky, broken trunk, unstable jobs don't affect the Dr. CI icon", async () => {
-    const failureInfoComment = updateDrciBot.constructResultsComment(
-      1,
-      [],
-      [failedB],
-      [failedC],
-      [unstableA],
-      "random head sha",
-      "random base sha",
-      "hudlink"
-    );
+    const failureInfoComment = constructResultsCommentHelper({
+      pending: 1,
+      flakyJobs: [failedB],
+      brokenTrunkJobs: [failedC],
+      unstableJobs: [unstableA],
+    });
 
     const expectToContain = [
       ":hourglass_flowing_sand:",
@@ -564,6 +566,36 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     expect(
       expectToContain.every((s) => failureInfoComment.includes(s))
     ).toBeTruthy();
+  });
+
+  test("test merge base time shows up in results comment", async () => {
+    const failureInfoComment = constructResultsCommentHelper({
+      sha: "sha",
+      merge_base: "merge_base",
+      merge_base_date: "2023-08-08T06:03:21Z",
+    });
+    console.log(failureInfoComment);
+    expect(
+      failureInfoComment.includes("commit sha with merge base merge_base")
+    ).toBeTruthy();
+    expect(
+      failureInfoComment.includes(
+        "https://img.shields.io/date/1691474601?label=&color=FFFFFF&style=flat-square"
+      )
+    ).toBeTruthy();
+  });
+
+  test("test bad merge base time is handled correctly", async () => {
+    const failureInfoComment = constructResultsCommentHelper({
+      sha: "sha",
+      merge_base: "merge_base",
+      merge_base_date: "definitely not a timestamp",
+    });
+    console.log(failureInfoComment);
+    expect(
+      failureInfoComment.includes("commit sha with merge base merge_base")
+    ).toBeTruthy();
+    expect(!failureInfoComment.includes("img")).toBeTruthy();
   });
 
   test("test formDrciHeader for pytorch/pytorch", async () => {

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -536,7 +536,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
       "1 New Failure, 1 Pending, 3 Unrelated Failures",
       "The following job has failed",
       "The following job failed but was likely due to flakiness present on trunk",
-      "The following job failed but was present on the merge base random base sha",
+      "The following job failed but was present on the merge base",
       "The following job failed but was likely due to flakiness present on trunk and has been marked as unstable",
       failedA.name,
       failedB.name,

--- a/torchci/test/drciBot.test.ts
+++ b/torchci/test/drciBot.test.ts
@@ -185,7 +185,16 @@ describe("verify-drci-functionality", () => {
       )
       .reply(200, {})
       .get((url) => url.includes(`/repos/${OWNER}/${REPO}/compare/`))
-      .reply(200, { merge_base_commit: { sha: "dummyMergeBaseSha" } })
+      .reply(200, {
+        merge_base_commit: {
+          sha: "dummyMergeBaseSha",
+          commit: {
+            committer: {
+              date: "2023-08-08T06:03:21Z",
+            },
+          },
+        },
+      })
       .get(`/repos/${OWNER}/${REPO}/issues/1000/comments`)
       .reply(200, [
         {


### PR DESCRIPTION
I don't know how helpful the average dev is going to find this, but it might be a good indicator for a rebase, and for us it is an easy shortcut to the merge base (previously it only showed up if there were broken trunk classification jobs).

I also added a helper function for `constructResultsComment` testing that populates it with default values so we don't have to keep changing every call in the tests whenever the function signature is changed.  Hopefully it also makes it clearer what parts of the function is being tested.

Old:
<img width="344" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/0acb1fbc-a9d1-425a-bd02-52851cd455ea">

New:
<img width="407" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/8da9ad97-fcd1-4496-9493-cfe96e0a662c">
