### PR TITLE
Look for similar failures on Dr.CI

### DIFF
--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -43,7 +43,7 @@ export default function JobLinks({ job }: { job: JobData }) {
         <a
           target="_blank"
           rel="noreferrer"
-          href={`/failure/${encodeURIComponent(job.failureCaptures as string)}`}
+          href={`/failure/${encodeURIComponent(job.failureCaptures[0])}`}
         >
           more like this
         </a>
@@ -88,9 +88,9 @@ function getTestName(failureCapture: string) {
   return null;
 }
 
-function formatDisableTestBody(failureCaptures: string) {
+function formatDisableTestBody(failureCaptures: string[]) {
   const examplesURL = `http://torch-ci.com/failure/${encodeURIComponent(
-    failureCaptures
+    failureCaptures[0]
   )}`;
   return encodeURIComponent(`Platforms: <fill this in or delete. Valid labels are: asan, linux, mac, macos, rocm, win, windows.>
 

--- a/torchci/jest.config.js
+++ b/torchci/jest.config.js
@@ -7,6 +7,11 @@ const createJestConfig = nextJest({
 const customJestConfig = {
   moduleDirectories: ["node_modules", "<rootDir>/"],
   reporters: ["<rootDir>/test/reporter.js"],
+  moduleNameMapper: {
+    // A bug in jest config https://github.com/opensearch-project/opensearch-js/issues/410
+    "@opensearch-project/opensearch/aws":
+      "@opensearch-project/opensearch/lib/aws/index.js",
+  },
 };
 
 module.exports = createJestConfig(customJestConfig);

--- a/torchci/lib/jobUtils.ts
+++ b/torchci/lib/jobUtils.ts
@@ -1,6 +1,17 @@
+import dayjs from "dayjs";
 import { JobData } from "lib/types";
 import getRocksetClient from "./rockset";
 import rocksetVersions from "rockset/prodVersions.json";
+import { Client } from "@opensearch-project/opensearch";
+import { RecentWorkflowsData } from "lib/types";
+import { AwsSigv4Signer } from "@opensearch-project/opensearch/aws";
+import { Credentials } from "@aws-sdk/types";
+import {
+  searchSimilarFailures,
+  WORKFLOW_JOB_INDEX,
+  MIN_SCORE,
+} from "lib/searchUtils";
+import { isEqual } from "lodash";
 
 export const REMOVE_JOB_NAME_SUFFIX_REGEX = new RegExp(
   ", [0-9]+, [0-9]+, .+\\)"
@@ -94,4 +105,130 @@ export function removeJobNameSuffix(
   }
 
   return jobName.replace(REMOVE_JOB_NAME_SUFFIX_REGEX, replaceWith);
+}
+
+export function isSameFailure(
+  jobA: RecentWorkflowsData,
+  jobB: RecentWorkflowsData
+): boolean {
+  if (
+    jobA === undefined ||
+    jobA.name === undefined ||
+    jobA.name === "" ||
+    jobB === undefined ||
+    jobB.name === undefined ||
+    jobB.name === ""
+  ) {
+    return false;
+  }
+
+  // Return true if two jobs have the same failures. This is used to figure out
+  // broken trunk and other similar failures
+  const jobANameNoSuffix = removeJobNameSuffix(jobA.name);
+  const jobBNameNoSuffix = removeJobNameSuffix(jobB.name);
+
+  if (
+    !jobANameNoSuffix.includes(jobBNameNoSuffix) &&
+    !jobBNameNoSuffix.includes(jobANameNoSuffix)
+  ) {
+    return false;
+  }
+
+  if (
+    jobA.conclusion == jobB.conclusion &&
+    isEqual(jobA.failure_captures, jobB.failure_captures)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+export async function querySimilarFailure(
+  job: RecentWorkflowsData,
+  lookbackPeriodInDays: number = 1,
+  client?: Client
+): Promise<JobData[]> {
+  // This function queries HUD to find all similar failures during a period of time
+  // before the current job. If a pre-existing job is found with exactly the same
+  // failure and job name and within N days, the failure will be considered flaky
+  if (
+    job === undefined ||
+    job.failure_captures === undefined ||
+    job.failure_captures.length === 0 ||
+    job.completed_at === null
+  ) {
+    return [];
+  }
+
+  if (client === undefined) {
+    // https://opensearch.org/docs/latest/clients/javascript/index
+    client = new Client({
+      ...AwsSigv4Signer({
+        region: process.env.OPENSEARCH_REGION as string,
+        service: "es",
+        getCredentials: () => {
+          const credentials: Credentials = {
+            accessKeyId: process.env.OUR_AWS_ACCESS_KEY_ID as string,
+            secretAccessKey: process.env.OUR_AWS_SECRET_ACCESS_KEY as string,
+          };
+          return Promise.resolve(credentials);
+        },
+      }),
+      node: process.env.OPENSEARCH_ENDPOINT,
+    });
+  }
+
+  // Search for all captured failure
+  const failure = job.failure_captures.join(" ");
+  const startDate = dayjs(job.completed_at);
+  const endDate = startDate.subtract(lookbackPeriodInDays, "day");
+
+  const results = await searchSimilarFailures(
+    client,
+    failure,
+    WORKFLOW_JOB_INDEX,
+    startDate.toISOString(),
+    endDate.toISOString(),
+    MIN_SCORE
+  );
+
+  return results["jobs"];
+}
+
+export async function hasSimilarFailure(
+  job: RecentWorkflowsData,
+  lookbackPeriodInDays: number = 1
+): Promise<boolean> {
+  if (job === undefined || job.name === undefined || job.name === "") {
+    return false;
+  }
+
+  const records = await querySimilarFailure(job, lookbackPeriodInDays);
+  if (records === undefined || records.length === 0) {
+    return false;
+  }
+
+  let count = 0;
+  for (const record of records) {
+    // Convert the result in JobData to RecentWorkflowsData used by Dr.CI
+    const failure: RecentWorkflowsData = {
+      workflow_id: record.workflowId,
+      id: record.id as string,
+      name: record.jobName as string,
+      conclusion: record.conclusion as string,
+      completed_at: record.time as string,
+      html_url: record.htmlUrl as string,
+      head_sha: record.sha as string,
+      failure_captures: record.failureCaptures as string[],
+      failure_line: record.failureLine,
+    };
+
+    // Same job, skipping
+    if (job.id !== failure.id && isSameFailure(job, failure)) {
+      count += 1;
+    }
+  }
+
+  return count > 0;
 }

--- a/torchci/lib/searchUtils.ts
+++ b/torchci/lib/searchUtils.ts
@@ -1,6 +1,12 @@
 import { Client } from "@opensearch-project/opensearch";
 import { JobData } from "lib/types";
 
+export const WORKFLOW_JOB_INDEX = "torchci-workflow-job";
+// https://www.elastic.co/guide/en/elasticsearch/reference/7.17/similarity.html#similarity
+// OpenSearch uses https://en.wikipedia.org/wiki/Okapi_BM25 by default.  TODO: learn more
+// about which is a reasonable value here and how to tune it
+export const MIN_SCORE = 1.0;
+
 export async function searchSimilarFailures(
   client: Client,
   query: string,

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -18,7 +18,7 @@ export interface JobData {
   queueTimeS?: number;
   failureLine?: string;
   failureLineNumber?: number;
-  failureCaptures?: string;
+  failureCaptures?: string[];
   repo?: string;
   failureAnnotation?: string;
   failedPreviousRun?: boolean;

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -20,7 +20,7 @@ import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
 import { Octokit } from "octokit";
 import { isEqual } from "lodash";
 import { fetchJSON } from "lib/bot/utils";
-import { removeJobNameSuffix } from "lib/jobUtils";
+import { removeJobNameSuffix, isSameFailure } from "lib/jobUtils";
 
 interface PRandJobs {
   head_sha: string;
@@ -385,16 +385,9 @@ function isBrokenTrunk(
     return false;
   }
 
-  return baseJobs.get(jobNameNoSuffix)!.some((baseJob) => {
-    if (
-      baseJob.conclusion == job.conclusion &&
-      isEqual(baseJob.failure_captures, job.failure_captures)
-    ) {
-      return true;
-    }
-
-    return false;
-  });
+  return baseJobs
+    .get(jobNameNoSuffix)!
+    .some((baseJob) => isSameFailure(baseJob, job));
 }
 
 export function getWorkflowJobsStatuses(

--- a/torchci/pages/api/search.ts
+++ b/torchci/pages/api/search.ts
@@ -3,10 +3,12 @@ import { Client } from "@opensearch-project/opensearch";
 import { AwsSigv4Signer } from "@opensearch-project/opensearch/aws";
 import { defaultProvider } from "@aws-sdk/credential-provider-node";
 import { JobData } from "lib/types";
-import { searchSimilarFailures } from "lib/searchUtils";
+import {
+  searchSimilarFailures,
+  WORKFLOW_JOB_INDEX,
+  MIN_SCORE,
+} from "lib/searchUtils";
 import { Credentials } from "@aws-sdk/types";
-
-const WORKFLOW_JOB_INDEX = "torchci-workflow-job";
 
 export default async function handler(
   req: NextApiRequest,
@@ -17,7 +19,7 @@ export default async function handler(
   const startDate = req.query.startDate as string;
   const endDate = req.query.endDate as string;
   // This is a weird way to satisfy TS2352
-  const minScore = (req.query.minScore as unknown as number) ?? 1.0;
+  const minScore = (req.query.minScore as unknown as number) ?? MIN_SCORE;
 
   // https://opensearch.org/docs/latest/clients/javascript/index
   const client = new Client({

--- a/torchci/test/jobUtils.test.ts
+++ b/torchci/test/jobUtils.test.ts
@@ -1,6 +1,25 @@
-import { removeJobNameSuffix } from "../lib/jobUtils";
+import {
+  removeJobNameSuffix,
+  hasSimilarFailures,
+  querySimilarFailures,
+  isSameFailure,
+} from "../lib/jobUtils";
+import * as searchUtils from "../lib/searchUtils";
+import { JobData, RecentWorkflowsData } from "lib/types";
+import nock from "nock";
+import dayjs from "dayjs";
+import { Client } from "@opensearch-project/opensearch";
+
+nock.disableNetConnect();
 
 describe("Test removing job name suffix", () => {
+  beforeEach(() => {});
+
+  afterEach(() => {
+    nock.cleanAll();
+    jest.restoreAllMocks();
+  });
+
   test("no input", () => {
     expect(removeJobNameSuffix("")).toStrictEqual("");
   });
@@ -36,5 +55,264 @@ describe("Test removing job name suffix", () => {
     expect(
       removeJobNameSuffix("Test `run_test.py` is usable without boto3/rockset")
     ).toStrictEqual("Test `run_test.py` is usable without boto3/rockset");
+  });
+
+  test("test isSameFailure", () => {
+    const jobA: RecentWorkflowsData = {
+      id: "A",
+      name: "",
+      html_url: "A",
+      head_sha: "A",
+      failure_captures: [],
+      conclusion: "failure",
+      completed_at: "A",
+    };
+    const jobB: RecentWorkflowsData = {
+      id: "B",
+      name: "",
+      html_url: "B",
+      head_sha: "B",
+      failure_captures: [],
+      conclusion: "failure",
+      completed_at: "B",
+    };
+
+    // Missing job name
+    expect(isSameFailure(jobA, jobB)).toEqual(false);
+
+    jobA.name =
+      "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)";
+    jobB.name =
+      "android-emulator-build-test / build-and-test (default, 1, 1, ubuntu-20.04-16x)";
+    // Different job names
+    expect(isSameFailure(jobA, jobB)).toEqual(false);
+
+    jobA.name =
+      "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)";
+    jobA.conclusion = "cancelled";
+    jobB.name =
+      "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)";
+    jobB.conclusion = "failure";
+    // Different conclusions
+    expect(isSameFailure(jobA, jobB)).toEqual(false);
+
+    jobA.name =
+      "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)";
+    jobA.conclusion = "cancelled";
+    jobA.failure_captures = ["A"];
+    jobB.name =
+      "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)";
+    jobB.conclusion = "failure";
+    jobB.failure_captures = ["B"];
+    // Different failures
+    expect(isSameFailure(jobA, jobB)).toEqual(false);
+
+    jobA.name =
+      "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)";
+    jobA.conclusion = "failure";
+    jobA.failure_captures = ["ERROR"];
+    jobB.name =
+      "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 2, 5, linux.g5.4xlarge.nvidia.gpu, unstable)";
+    jobB.conclusion = "failure";
+    jobB.failure_captures = ["ERROR"];
+    // Same failure
+    expect(isSameFailure(jobA, jobB)).toEqual(true);
+  });
+
+  test("test querySimilarFailures", async () => {
+    const lookbackPeriodInDays = 1;
+    const mockEndDate = dayjs("2023-08-01T00:00:00Z").toISOString();
+    const mockStartDate = dayjs(mockEndDate)
+      .subtract(lookbackPeriodInDays, "day")
+      .toISOString();
+
+    const mockJobData: JobData = {
+      name: "pull / linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 2, 5, linux.g5.4xlarge.nvidia.gpu)",
+      workflowName: "pull",
+      jobName:
+        "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 2, 5, linux.g5.4xlarge.nvidia.gpu)",
+      sha: "ABCD",
+      id: "54321",
+      branch: "mock-branch",
+      workflowId: "12345",
+      time: mockEndDate,
+      conclusion: "failure",
+      htmlUrl: "Anything goes",
+      failureLine: "ERROR",
+      failureLineNumber: 0,
+      failureCaptures: ["ERROR"],
+    };
+    const mock = jest.spyOn(searchUtils, "searchSimilarFailures");
+    mock.mockImplementation(() => Promise.resolve({ jobs: [mockJobData] }));
+
+    const job: RecentWorkflowsData = {
+      id: "A",
+      name: "",
+      html_url: "A",
+      head_sha: "A",
+      failure_captures: ["ERROR"],
+      conclusion: "failure",
+      completed_at: mockEndDate,
+    };
+    // Missing job name
+    expect(
+      await querySimilarFailures(
+        job,
+        lookbackPeriodInDays,
+        "TESTING" as unknown as Client
+      )
+    ).toStrictEqual([]);
+
+    job.name = "A";
+    job.failure_captures = [];
+    // Missing failures
+    expect(
+      await querySimilarFailures(
+        job,
+        lookbackPeriodInDays,
+        "TESTING" as unknown as Client
+      )
+    ).toStrictEqual([]);
+
+    job.failure_captures = ["ERROR"];
+    job.completed_at = null;
+    // Missing date
+    expect(
+      await querySimilarFailures(
+        job,
+        lookbackPeriodInDays,
+        "TESTING" as unknown as Client
+      )
+    ).toStrictEqual([]);
+
+    job.failure_captures = ["ERROR"];
+    job.completed_at = mockEndDate;
+    // Found a similar failure (mocked)
+    expect(
+      await querySimilarFailures(
+        job,
+        lookbackPeriodInDays,
+        "TESTING" as unknown as Client
+      )
+    ).toStrictEqual([mockJobData]);
+    expect(JSON.stringify(mock.mock.calls)).toEqual(
+      JSON.stringify([
+        [
+          "TESTING",
+          job.failure_captures.join(" "),
+          searchUtils.WORKFLOW_JOB_INDEX,
+          mockStartDate,
+          mockEndDate,
+          searchUtils.MIN_SCORE,
+        ],
+      ])
+    );
+  });
+
+  test("test hasSimilarFailures", async () => {
+    const lookbackPeriodInDays = 1;
+    const job: RecentWorkflowsData = {
+      id: "A",
+      name: "A",
+      html_url: "A",
+      head_sha: "A",
+      failure_captures: ["ERROR"],
+      conclusion: "failure",
+      completed_at: "2023-08-01T00:00:00Z",
+    };
+
+    const mock = jest.spyOn(searchUtils, "searchSimilarFailures");
+    mock.mockImplementation(() => Promise.resolve({ jobs: [] }));
+    // Found no similar job
+    expect(
+      await hasSimilarFailures(
+        job,
+        lookbackPeriodInDays,
+        "TESTING" as unknown as Client
+      )
+    ).toEqual(false);
+
+    const id = "54321";
+    const mockJobData: JobData = {
+      name: "pull / linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 2, 5, linux.g5.4xlarge.nvidia.gpu, unstable)",
+      workflowName: "pull",
+      jobName:
+        "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 2, 5, linux.g5.4xlarge.nvidia.gpu, unstable)",
+      sha: "ABCD",
+      id: id,
+      branch: "mock-branch",
+      workflowId: "12345",
+      time: "2023-08-01T00:00:00Z",
+      conclusion: "failure",
+      htmlUrl: "Anything goes",
+      failureLine: "ERROR",
+      failureLineNumber: 0,
+      failureCaptures: ["ERROR"],
+    };
+    mock.mockImplementation(() => Promise.resolve({ jobs: [mockJobData] }));
+
+    job.id = id;
+    // Found a match, but it has the same job ID, thus the same job
+    expect(
+      await hasSimilarFailures(
+        job,
+        lookbackPeriodInDays,
+        "TESTING" as unknown as Client
+      )
+    ).toEqual(false);
+
+    job.id = "0";
+    job.name =
+      "android-emulator-build-test / build-and-test (default, 1, 1, ubuntu-20.04-16x)";
+    job.failure_captures = ["ERROR"];
+    // Found a match but it has a different job name
+    expect(
+      await hasSimilarFailures(
+        job,
+        lookbackPeriodInDays,
+        "TESTING" as unknown as Client
+      )
+    ).toEqual(false);
+
+    job.id = "0";
+    job.name =
+      "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)";
+    job.failure_captures = ["NOT THE SAME ERROR"];
+    // Found a match but it has a different failure
+    expect(
+      await hasSimilarFailures(
+        job,
+        lookbackPeriodInDays,
+        "TESTING" as unknown as Client
+      )
+    ).toEqual(false);
+
+    job.id = "0";
+    job.name =
+      "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)";
+    job.failure_captures = ["ERROR"];
+    job.conclusion = "neutral";
+    // Found a match but it has a different conclusion
+    expect(
+      await hasSimilarFailures(
+        job,
+        lookbackPeriodInDays,
+        "TESTING" as unknown as Client
+      )
+    ).toEqual(false);
+
+    job.id = "0";
+    job.name =
+      "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)";
+    job.failure_captures = ["ERROR"];
+    job.conclusion = "failure";
+    // Found a similar failure
+    expect(
+      await hasSimilarFailures(
+        job,
+        lookbackPeriodInDays,
+        "TESTING" as unknown as Client
+      )
+    ).toEqual(true);
   });
 });


### PR DESCRIPTION
This PR adds a new function `hasSimilarFailures` which accepts a failed PR job plus a look back period and returns true if there are similar failures in the same period or false otherwise:

* The look back period is default to 1 days from the time the job finishes
* A similar failure is defined in exactly the same way as a broken trunk failure in `isSameFailure`. It means same job, job conclusion, and same captured failures
* If a failed job has one or more similar failures as defined above, it will be classified as flaky on Dr.CI.  I reuse this category to avoid introducing yet another flaky category there.