### PR TITLE
Add infra_error to inductor model failure log classifier rule

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -102,7 +102,7 @@ pattern = '^ERROR (?:\[.*s\] )?(\S*.py::\S*::test_\S*)'
 
 [[rule]]
 name = 'inductor model failure'
-pattern = '^([a-zA-Z0-9_]+) +(fail_accuracy|fail_to_run|eager_variation|0\.0000|(?:(?:FAIL|IMPROVED): +(?:.*)))$'
+pattern = '^([a-zA-Z0-9_]+) +(fail_accuracy|fail_to_run|eager_variation|infra_error|0\.0000|(?:(?:FAIL|IMPROVED): +(?:.*)))$'
 
 [[rule]]
 name = 'NVIDIA installation failure'


### PR DESCRIPTION
For example https://hud.pytorch.org/pytorch/pytorch/commit/4de5e1775ab4664a4bc9221132c979f059b94b51:

* `linux-jammy-cpu-py3.8-gcc11-inductor / test (inductor_torchbench_cpu_accuracy, 1, 1, linux.4xlarge)`
* or `linux-jammy-cpu-py3.8-gcc11-inductor / test (inductor_torchbench_dynamic_cpu_accuracy, 1, 1, linux.12xlarge)`

```
2023-08-16T09:22:09.7791143Z BERT_pytorch                       pass
2023-08-16T09:22:09.7791467Z Background_Matting                 pass_due_to_skip
2023-08-16T09:22:09.7791723Z LearningToPaint                    pass
2023-08-16T09:22:09.7794233Z Super_SloMo                        pass
2023-08-16T09:22:09.7794693Z alexnet                            pass
2023-08-16T09:22:09.7795039Z attention_is_all_you_need_pytorch  pass
2023-08-16T09:22:09.7795295Z basic_gnn_edgecnn                  pass
2023-08-16T09:22:09.7795512Z basic_gnn_gcn                      pass
2023-08-16T09:22:09.7795724Z basic_gnn_gin                      pass
2023-08-16T09:22:09.7796062Z basic_gnn_sage                     pass
2023-08-16T09:22:09.7796320Z clip                               pass
2023-08-16T09:22:09.7796799Z dcgan                              pass
2023-08-16T09:22:09.7796987Z demucs                             pass
2023-08-16T09:22:09.7800681Z densenet121                        pass
2023-08-16T09:22:09.7800911Z dlrm                               pass
2023-08-16T09:22:09.7801139Z fastNLP_Bert                       pass
2023-08-16T09:22:09.7801369Z functorch_dp_cifar10               pass
2023-08-16T09:22:09.7801597Z functorch_maml_omniglot            pass
2023-08-16T09:22:09.7802044Z hf_Albert                          infra_error
2023-08-16T09:22:09.7802259Z hf_Bart                            pass
2023-08-16T09:22:09.7802470Z hf_DistilBert                      pass
2023-08-16T09:22:09.7802678Z hf_GPT2                            pass
2023-08-16T09:22:09.7802869Z hf_Reformer                        pass
2023-08-16T09:22:09.7803091Z hf_T5_large                        pass_due_to_skip
2023-08-16T09:22:09.7803315Z hf_Whisper                         pass
2023-08-16T09:22:09.7803539Z lennard_jones                      pass
2023-08-16T09:22:09.7803725Z llama                              pass
2023-08-16T09:22:09.7803927Z maml_omniglot                      pass
2023-08-16T09:22:09.7804132Z mnasnet1_0                         pass
2023-08-16T09:22:09.7804332Z mobilenet_v2                       pass
2023-08-16T09:22:09.7804529Z mobilenet_v3_large                 pass
2023-08-16T09:22:09.7804753Z nvidia_deeprecommender             pass
2023-08-16T09:22:09.7804978Z phlippe_densenet                   pass
2023-08-16T09:22:09.7805202Z phlippe_resnet                     pass
2023-08-16T09:22:09.7805718Z pyhpc_equation_of_state            pass
2023-08-16T09:22:09.7805976Z pytorch_CycleGAN_and_pix2pix       pass
2023-08-16T09:22:09.7806406Z pytorch_stargan                    pass
2023-08-16T09:22:09.7807081Z pytorch_unet                       pass
2023-08-16T09:22:09.7807379Z resnet152                          pass
2023-08-16T09:22:09.7807758Z resnet18                           pass
2023-08-16T09:22:09.7808272Z resnet50                           pass
2023-08-16T09:22:09.7808795Z resnext50_32x4d                    pass
2023-08-16T09:22:09.7809223Z shufflenet_v2_x1_0                 pass
2023-08-16T09:22:09.7809875Z soft_actor_critic                  pass
2023-08-16T09:22:09.7810236Z speech_transformer                 pass
2023-08-16T09:22:09.7810687Z squeezenet1_1                      pass
2023-08-16T09:22:09.7811221Z timm_efficientnet                  pass
2023-08-16T09:22:09.7811611Z timm_nfnet                         pass
2023-08-16T09:22:09.7812062Z timm_regnet                        pass
2023-08-16T09:22:09.7812560Z timm_resnest                       pass
2023-08-16T09:22:09.7812999Z timm_vision_transformer            pass
2023-08-16T09:22:09.7813482Z timm_vision_transformer_large      pass_due_to_skip
2023-08-16T09:22:09.7813937Z timm_vovnet                        pass
2023-08-16T09:22:09.7814377Z tts_angular                        pass
2023-08-16T09:22:09.7814829Z vgg16                              pass
2023-08-16T09:22:09.7815314Z vision_maskrcnn                    pass
2023-08-16T09:22:09.7815754Z yolov3                             pass
2023-08-16T09:22:09.7816666Z 
2023-08-16T09:22:09.7816736Z Error 1 models failed
2023-08-16T09:22:09.7816928Z     hf_Albert
```