### PR TITLE
Sync filter_forced_merge_pr with the newer weekly_force_merge_stats query

### DIFF
--- a/torchci/rockset/commons/__sql/filter_forced_merge_pr.sql
+++ b/torchci/rockset/commons/__sql/filter_forced_merge_pr.sql
@@ -1,7 +1,12 @@
+-- This query is used by fetchHud to get the force merge status of the pull requests so that
+-- they can be highlighted on HUD. Specifically, force merges with failures are highlighted
+-- with a darker shade of orange while regular force merges due to impatience are marked with
+--- yellow. The logic needs to be in sync with weekly_force_merge_stats query.
 WITH all_merges AS (
   SELECT
     skip_mandatory_checks,
     LENGTH(failed_checks) AS failed_checks_count,
+    LENGTH(ignore_current_checks) AS ignored_checks_count,
     ignore_current,
     is_failed,
     pr_num,
@@ -23,11 +28,13 @@ force_merges_with_failed_checks AS (
       OR (
         ignore_current = true
         AND is_failed = false
-      ),
+        AND ignored_checks_count > 0 -- if no checks were ignored, it's not a force merge
+        ),
       1,
       0
     ) AS force_merge,
     failed_checks_count,
+    ignored_checks_count,
     pr_num,
     merge_commit_sha,
   FROM
@@ -40,7 +47,10 @@ SELECT
   IF(
     (
       force_merge = 1
-      AND failed_checks_count > 0
+      AND (
+        failed_checks_count > 0
+        OR ignored_checks_count > 0
+      )
     ),
     1,
     0

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -5,7 +5,7 @@
     "commit_jobs_query": "cc524c5036e78794",
     "disabled_non_flaky_tests": "f909abf9eec15b56",
     "commit_failed_jobs": "45095418d71a3778",
-    "filter_forced_merge_pr": "98786319ff984d95",
+    "filter_forced_merge_pr": "00d662e98c8bdbdc",
     "flaky_tests": "9f7a1abcebb7f027",
     "flaky_tests_across_jobs": "474e5454bda0c5bb",
     "get_relevant_alerts": "727014a49bef2c20",


### PR DESCRIPTION
This query is used by fetchHud to get the force merge status of the pull requests so that they can be highlighted on HUD. Specifically, force merges with failures are highlighted with a darker shade of orange while regular force merges due to impatience are marked with yellow. The logic needs to be in sync with the source of truth [weekly_force_merge_stats](https://github.com/pytorch/test-infra/blob/main/torchci/rockset/commons/__sql/weekly_force_merge_stats.sql) query and uses the recently added `ignore_current_checks` field for `merge -i`

### Testing

I proof check all force merges on the first page of https://torchci-git-fork-huydhn-fix-hud-force-merge-76a8e4-fbopensource.vercel.app and compare them with https://hud.pytorch.org