### PR TITLE
[security] Add run in environment for trigger nightly

### DIFF
--- a/.github/workflows/trigger_nightly.yml
+++ b/.github/workflows/trigger_nightly.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   trigger:
     runs-on: ubuntu-latest
+    environment: trigger-nightly
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/trigger_nightly_core.yml
+++ b/.github/workflows/trigger_nightly_core.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   trigger:
     runs-on: ubuntu-latest
+    environment: trigger-nightly
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f371d1d</samp>

This pull request adds environment names to two workflows that trigger nightly builds for pytorch and pytorch core. The environment names enable better security and visibility for the nightly build process.