### PR TITLE
Remove no-op force merges masquerading as impatient force merges

### DIFF
--- a/torchci/rockset/commons/__sql/filter_forced_merge_pr.sql
+++ b/torchci/rockset/commons/__sql/filter_forced_merge_pr.sql
@@ -22,14 +22,16 @@ WITH all_merges AS (
       merge_commit_sha
     )
 ),
--- A legit force merge needs to satisfy one of the conditions belows:
+-- A legit force merge needs to satisfy one of the two conditions below:
 -- 1. skip_mandatory_checks is true (-f) and failed_checks_count > 0 (with failures) or pending_checks_count > 0 (impatience).
---    If a force merge is done when there is no failures and all jobs have finished, it's arguably just a regular merge
--- 2. ignore_current is true (-i) and is_failed is false (indicating a succesful merge) and ignored_checks_count > 0 (with failures).
---    As -i still waits for all remaining jobs to finish, this shouldn't be counted toward force merge due to impatience
+--    Under this condition, if a force merge (-f) is done when there is no failure and all jobs have finished, it's arguably
+--    just a regular merge in disguise.
+-- 2. ignore_current is true (-i) and is_failed is false (indicating a successful merge) and ignored_checks_count > 0 (has failures).
+--    As -i still waits for all remaining jobs to finish, this shouldn't be counted toward force merge due to impatience.
 --
--- If none applies, the merge will be counted as a regular merge regardless of the use of -f or -i. We could also
--- track that here (regular merges masquerade as force merges) if there is a need
+-- If none applies, the merge should be counted as a regular merge regardless of the use of -f or -i. We could track that
+-- (regular merges masquerading as force merges) to understand how devs use (or abuse) these flags, but that's arguably a
+-- different case altogether.
 force_merges_with_failed_checks AS (
   SELECT
     IF(

--- a/torchci/rockset/commons/__sql/weekly_force_merge_stats.sql
+++ b/torchci/rockset/commons/__sql/weekly_force_merge_stats.sql
@@ -6,213 +6,214 @@
 --               otherwise there is not bucketing
 --   merge_type: If set, will return only data about the requested force merge type.
 --               Can be one of: "All", "Impatience", "Failures", or " " (to get everything)
-
-WITH
-    issue_comments AS (
-        SELECT
-            issue_comment.user.login,
-            issue_comment.author_association,
-            issue_comment.body,
-            issue_comment.issue_url,
-            issue_comment.html_url,
-            issue_comment.created_at,
-            issue_comment._event_time,
-            CAST(
-                SUBSTR(
-                    issue_comment.issue_url,
-                    LENGTH(
-                        'https://api.github.com/repos/pytorch/pytorch/issues/'
-                    ) + 1
-                ) as INT
-            ) as pr_num
-        FROM
-            commons.issue_comment
-        WHERE
-            (
-                issue_comment.body LIKE '%pytorchbot merge%'
-                OR issue_comment.body LIKE '%pytorchmergebot merge%'
-            )
-            AND issue_comment.user.login NOT LIKE '%pytorch-bot%'
-            AND issue_comment.user.login NOT LIKE '%facebook-github-bot%'
-            AND issue_comment.user.login NOT LIKE '%pytorchmergebot%'
-            AND issue_comment.issue_url LIKE '%https://api.github.com/repos/pytorch/pytorch/issues/%'
-    ),
-    all_merges AS (
-        SELECT
-            DISTINCT m.skip_mandatory_checks,
-            LENGTH(m.failed_checks) AS failed_checks_count,
-            LENGTH(m.ignore_current_checks) as ignored_checks_count,
-            LENGTH(m.pending_checks) AS pending_checks_count,
-            m.ignore_current,
-            m.is_failed,
-            m.pr_num,
-            m.merge_commit_sha,
-            max(c._event_time) as time,
-        FROM
-            commons.merges m
-            inner join issue_comments c on m.pr_num = c.pr_num
-        WHERE
-            m.owner = 'pytorch'
-            AND m.project = 'pytorch'
-            AND m.merge_commit_sha != '' -- only consider successful merges
-            AND m._event_time >= PARSE_DATETIME_ISO8601(:startTime)
-            AND m._event_time < PARSE_DATETIME_ISO8601(:stopTime)
-        GROUP BY
-            m.skip_mandatory_checks,
-            m.failed_checks,
-            m.ignore_current,
-            m.is_failed,
-            m.pr_num,
-            m.merge_commit_sha,
-            m.ignore_current_checks,
-            m.pending_checks
-    ),
-    -- A legit force merge needs to satisfy one of the two conditions below:
-    -- 1. skip_mandatory_checks is true (-f) and failed_checks_count > 0 (with failures) or pending_checks_count > 0 (impatience).
-    --    Under this condition, if a force merge (-f) is done when there is no failure and all jobs have finished, it's arguably
-    --    just a regular merge in disguise.
-    -- 2. ignore_current is true (-i) and is_failed is false (indicating a successful merge) and ignored_checks_count > 0 (has failures).
-    --    As -i still waits for all remaining jobs to finish, this shouldn't be counted toward force merge due to impatience.
-    --
-    -- If none applies, the merge should be counted as a regular merge regardless of the use of -f or -i. We could track that
-    -- (regular merges masquerading as force merges) to understand how devs use (or abuse) these flags, but that's arguably a
-    -- different case altogether.
-    merges_identifying_force_merges AS (
-        SELECT
-            IF(
-                (
-                  skip_mandatory_checks = true
-                  AND (
-                    failed_checks_count > 0
-                    OR pending_checks_count > 0
-                  )
-                )
-                OR (
-                    ignore_current = true
-                    AND is_failed = false
-                    AND ignored_checks_count > 0 -- if no checks were ignored, it's not a force merge
-                ),
-                1,
-                0
-            ) AS force_merge,
-            failed_checks_count,
-            pr_num,
-            merge_commit_sha,
-            ignore_current,
-            ignored_checks_count,
-            time,
-        FROM
-            all_merges
-    ),
-    results as (
-        SELECT
-            pr_num,
-            merge_commit_sha,
-            force_merge,
-            IF(
-                force_merge = 1
-                AND (
-                    failed_checks_count > 0
-                    OR ignored_checks_count > 0
-                ),
-                1,
-                0
-            ) AS force_merge_with_failures,
-            CAST(time as DATE) as date
-        FROM
-            merges_identifying_force_merges
-        ORDER BY
-            date DESC
-    ),
-    bucketed_counts as (
-        select
-            IF(
-                :one_bucket,
-                'Overall',
-                FORMAT_TIMESTAMP('%Y-%m-%d', DATE_TRUNC(:granularity, date))
-            ) AS granularity_bucket,
-            SUM(force_merge_with_failures) AS with_failures_cnt,
-            SUM(force_merge) - SUM(force_merge_with_failures) as impatience_cnt,
-            COUNT(*) as total,
-            SUM(force_merge) as total_force_merge_cnt
-        from
-            results
-        group by
-            granularity_bucket
-    ),
-    rolling_raw_stats as (
-        -- Average over the past buckets
-        SELECT
-            granularity_bucket,
-            sum(with_failures_cnt) OVER(
-                ORDER BY
-                    granularity_bucket ROWS 1 PRECEDING
-            ) as with_failures_cnt,
-            sum(impatience_cnt) OVER(
-                ORDER BY
-                    granularity_bucket ROWS 1 PRECEDING
-            ) as impatience_cnt,
-            sum(total_force_merge_cnt) OVER(
-                ORDER BY
-                    granularity_bucket ROWS 1 PRECEDING
-            ) as total_force_merge_cnt,
-            sum(total) OVER(
-                ORDER BY
-                    granularity_bucket ROWS 1 PRECEDING
-            ) as total,
-        FROM
-            bucketed_counts
-    ),
-    stats_per_bucket as (
-        SELECT
-            granularity_bucket,
-            with_failures_cnt * 100.0 / total as with_failures_percent,
-            impatience_cnt * 100.0 / total as impatience_percent,
-            total_force_merge_cnt * 100.0 / total as force_merge_percent,
-        from
-            rolling_raw_stats
-    ),
-    final_table as (
-        (
-            select
-                granularity_bucket,
-                with_failures_percent as metric,
-                'From Failures' as name
-            from
-                stats_per_bucket
-        )
-        UNION ALL
-        (
-            select
-                granularity_bucket,
-                impatience_percent as metric,
-                'From Impatience' as name
-            from
-                stats_per_bucket
-        )
-        UNION ALL
-        (
-            select
-                granularity_bucket,
-                force_merge_percent as metric,
-                'All Force Merges' as name
-            from
-                stats_per_bucket
-        )
-    ),
-    filtered_result as (
-        select
-            *
-        from
-            final_table
-        WHERE
-            TRIM(:merge_type) = ''
-            OR name like CONCAT('%', :merge_type, '%')
+WITH issue_comments AS (
+  SELECT
+    issue_comment.user.login,
+    issue_comment.author_association,
+    issue_comment.body,
+    issue_comment.issue_url,
+    issue_comment.html_url,
+    issue_comment.created_at,
+    issue_comment._event_time,
+    CAST(
+      SUBSTR(
+        issue_comment.issue_url,
+        LENGTH(
+          'https://api.github.com/repos/pytorch/pytorch/issues/'
+        ) + 1
+      ) AS INT
+    ) AS pr_num
+  FROM
+    commons.issue_comment
+  WHERE
+    (
+      issue_comment.body LIKE '%pytorchbot merge%'
+      OR issue_comment.body LIKE '%pytorchmergebot merge%'
     )
-select
+    AND issue_comment.user.login NOT LIKE '%pytorch-bot%'
+    AND issue_comment.user.login NOT LIKE '%facebook-github-bot%'
+    AND issue_comment.user.login NOT LIKE '%pytorchmergebot%'
+    AND issue_comment.issue_url LIKE '%https://api.github.com/repos/pytorch/pytorch/issues/%'
+),
+all_merges AS (
+  SELECT
+    DISTINCT m.skip_mandatory_checks,
+    LENGTH(m.failed_checks) AS failed_checks_count,
+    LENGTH(m.ignore_current_checks) AS ignored_checks_count,
+    LENGTH(m.pending_checks) AS pending_checks_count,
+    m.ignore_current,
+    m.is_failed,
+    m.pr_num,
+    m.merge_commit_sha,
+    max(c._event_time) AS time,
+  FROM
+    commons.merges m
+    INNER JOIN issue_comments c ON m.pr_num = c.pr_num
+  WHERE
+    m.owner = 'pytorch'
+    AND m.project = 'pytorch'
+    AND m.merge_commit_sha != '' -- only consider successful merges
+    AND m._event_time >= PARSE_DATETIME_ISO8601(: startTime)
+    AND m._event_time < PARSE_DATETIME_ISO8601(: stopTime)
+  GROUP BY
+    m.skip_mandatory_checks,
+    m.failed_checks,
+    m.ignore_current,
+    m.is_failed,
+    m.pr_num,
+    m.merge_commit_sha,
+    m.ignore_current_checks,
+    m.pending_checks
+),
+-- A legit force merge needs to satisfy one of the two conditions below:
+-- 1. skip_mandatory_checks is true (-f) and failed_checks_count > 0 (with failures) or pending_checks_count > 0 (impatience).
+--    Under this condition, if a force merge (-f) is done when there is no failure and all jobs have finished, it's arguably
+--    just a regular merge in disguise.
+-- 2. ignore_current is true (-i) and is_failed is false (indicating a successful merge) and ignored_checks_count > 0 (has failures).
+--    As -i still waits for all remaining jobs to finish, this shouldn't be counted toward force merge due to impatience.
+--
+-- If none applies, the merge should be counted as a regular merge regardless of the use of -f or -i. We could track that
+-- (regular merges masquerading as force merges) to understand how devs use (or abuse) these flags, but that's arguably a
+-- different case altogether.
+merges_identifying_force_merges AS (
+  SELECT
+    IF(
+      (
+        skip_mandatory_checks = true
+        AND (
+          failed_checks_count > 0
+          OR pending_checks_count > 0
+        )
+      )
+      OR (
+        ignore_current = true
+        AND is_failed = false
+        AND ignored_checks_count > 0 -- if no checks were ignored, it's not a force merge
+        ),
+      1,
+      0
+    ) AS force_merge,
+    failed_checks_count,
+    pr_num,
+    merge_commit_sha,
+    ignore_current,
+    ignored_checks_count,
+    time,
+  FROM
+    all_merges
+),
+results AS (
+  SELECT
+    pr_num,
+    merge_commit_sha,
+    force_merge,
+    IF(
+      force_merge = 1
+      AND (
+        failed_checks_count > 0
+        OR ignored_checks_count > 0
+      ),
+      1,
+      0
+    ) AS force_merge_with_failures,
+    CAST(time as DATE) AS date
+  FROM
+    merges_identifying_force_merges
+  ORDER BY
+    date DESC
+),
+bucketed_counts AS (
+  SELECT
+    IF(
+      : one_bucket,
+      'Overall',
+      FORMAT_TIMESTAMP(
+        '%Y-%m-%d',
+        DATE_TRUNC(: granularity, date)
+      )
+    ) AS granularity_bucket,
+    SUM(force_merge_with_failures) AS with_failures_cnt,
+    SUM(force_merge) - SUM(force_merge_with_failures) AS impatience_cnt,
+    COUNT(*) AS total,
+    SUM(force_merge) AS total_force_merge_cnt
+  FROM
+    results
+  GROUP BY
+    granularity_bucket
+),
+rolling_raw_stats AS (
+  -- Average over the past buckets
+  SELECT
+    granularity_bucket,
+    SUM(with_failures_cnt) OVER(
+      ORDER BY
+        granularity_bucket ROWS 1 PRECEDING
+    ) AS with_failures_cnt,
+    SUM(impatience_cnt) OVER(
+      ORDER BY
+        granularity_bucket ROWS 1 PRECEDING
+    ) AS impatience_cnt,
+    SUM(total_force_merge_cnt) OVER(
+      ORDER BY
+        granularity_bucket ROWS 1 PRECEDING
+    ) AS total_force_merge_cnt,
+    SUM(total) OVER(
+      ORDER BY
+        granularity_bucket ROWS 1 PRECEDING
+    ) AS total,
+  FROM
+    bucketed_counts
+),
+stats_per_bucket AS (
+  SELECT
+    granularity_bucket,
+    with_failures_cnt * 100.0 / total AS with_failures_percent,
+    impatience_cnt * 100.0 / total AS impatience_percent,
+    total_force_merge_cnt * 100.0 / total AS force_merge_percent,
+  FROM
+    rolling_raw_stats
+),
+final_table AS (
+  (
+    SELECT
+      granularity_bucket,
+      with_failures_percent AS metric,
+      'From Failures' AS name
+    FROM
+      stats_per_bucket
+  )
+  UNION ALL
+    (
+      SELECT
+        granularity_bucket,
+        impatience_percent AS metric,
+        'From Impatience' AS name
+      FROM
+        stats_per_bucket
+    )
+  UNION ALL
+    (
+      SELECT
+        granularity_bucket,
+        force_merge_percent AS metric,
+        'All Force Merges' AS name
+      FROM
+        stats_per_bucket
+    )
+),
+filtered_result AS (
+  SELECT
     *
-from
-    filtered_result
-order by
-    granularity_bucket desc,
-    name
+  FROM
+    final_table
+  WHERE
+    TRIM(: merge_type) = ''
+    OR name LIKE CONCAT('%', : merge_type, '%')
+)
+SELECT
+  *
+FROM
+  filtered_result
+ORDER BY
+  granularity_bucket DESC,
+  name

--- a/torchci/rockset/commons/__sql/weekly_force_merge_stats.sql
+++ b/torchci/rockset/commons/__sql/weekly_force_merge_stats.sql
@@ -67,14 +67,16 @@ WITH
             m.ignore_current_checks,
             m.pending_checks
     ),
-    -- A legit force merge needs to satisfy one of the conditions belows:
+    -- A legit force merge needs to satisfy one of the two conditions below:
     -- 1. skip_mandatory_checks is true (-f) and failed_checks_count > 0 (with failures) or pending_checks_count > 0 (impatience).
-    --    If a force merge is done when there is no failures and all jobs have finished, it's arguably just a regular merge
-    -- 2. ignore_current is true (-i) and is_failed is false (indicating a succesful merge) and ignored_checks_count > 0 (with failures).
-    --    As -i still waits for all remaining jobs to finish, this shouldn't be counted toward force merge due to impatience
+    --    Under this condition, if a force merge (-f) is done when there is no failure and all jobs have finished, it's arguably
+    --    just a regular merge in disguise.
+    -- 2. ignore_current is true (-i) and is_failed is false (indicating a successful merge) and ignored_checks_count > 0 (has failures).
+    --    As -i still waits for all remaining jobs to finish, this shouldn't be counted toward force merge due to impatience.
     --
-    -- If none applies, the merge will be counted as a regular merge regardless of the use of -f or -i. We could also
-    -- track that here (regular merges masquerade as force merges) if there is a need
+    -- If none applies, the merge should be counted as a regular merge regardless of the use of -f or -i. We could track that
+    -- (regular merges masquerading as force merges) to understand how devs use (or abuse) these flags, but that's arguably a
+    -- different case altogether.
     merges_identifying_force_merges AS (
         SELECT
             IF(

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -29,7 +29,7 @@
     "test_insights_overview": "42dbd5232f45fd53",
     "test_insights_latest_runs": "1871833a91cb8b1b",
     "master_commit_red_jobs": "4869b467679a616a",
-    "weekly_force_merge_stats": "73ca60c255958d3a"
+    "weekly_force_merge_stats": "2741e81f30d21a01"
   },
   "pytorch_dev_infra_kpis": {
     "monthly_contribution_stats": "c1a8751a22f6b6ce",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -5,7 +5,7 @@
     "commit_jobs_query": "cc524c5036e78794",
     "disabled_non_flaky_tests": "f909abf9eec15b56",
     "commit_failed_jobs": "45095418d71a3778",
-    "filter_forced_merge_pr": "00d662e98c8bdbdc",
+    "filter_forced_merge_pr": "54586548ed49b31b",
     "flaky_tests": "9f7a1abcebb7f027",
     "flaky_tests_across_jobs": "474e5454bda0c5bb",
     "get_relevant_alerts": "727014a49bef2c20",
@@ -29,7 +29,7 @@
     "test_insights_overview": "42dbd5232f45fd53",
     "test_insights_latest_runs": "1871833a91cb8b1b",
     "master_commit_red_jobs": "4869b467679a616a",
-    "weekly_force_merge_stats": "dfaa6ff235e277a4"
+    "weekly_force_merge_stats": "81141b801570b27e"
   },
   "pytorch_dev_infra_kpis": {
     "monthly_contribution_stats": "c1a8751a22f6b6ce",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -5,7 +5,7 @@
     "commit_jobs_query": "cc524c5036e78794",
     "disabled_non_flaky_tests": "f909abf9eec15b56",
     "commit_failed_jobs": "45095418d71a3778",
-    "filter_forced_merge_pr": "54586548ed49b31b",
+    "filter_forced_merge_pr": "a28350c863e36239",
     "flaky_tests": "9f7a1abcebb7f027",
     "flaky_tests_across_jobs": "474e5454bda0c5bb",
     "get_relevant_alerts": "727014a49bef2c20",
@@ -29,7 +29,7 @@
     "test_insights_overview": "42dbd5232f45fd53",
     "test_insights_latest_runs": "1871833a91cb8b1b",
     "master_commit_red_jobs": "4869b467679a616a",
-    "weekly_force_merge_stats": "81141b801570b27e"
+    "weekly_force_merge_stats": "73ca60c255958d3a"
   },
   "pytorch_dev_infra_kpis": {
     "monthly_contribution_stats": "c1a8751a22f6b6ce",


### PR DESCRIPTION
This is a proposal to remove no-op force merges masquerading as impatient force merges.  IMO, a legit force merge needs to satisfy one of the two conditions below:

1. `skip_mandatory_checks` is true (-f) and `failed_checks_count > 0` (with failures) or `pending_checks_count > 0` (impatience).  Under this condition, If a force merge (-f) is done when there is no failure and all jobs have finished, it's arguably just a regular merge in disguise. This is the main point of this proposal.  Here is an example of a no-op force merge https://github.com/pytorch/pytorch/pull/106912#issuecomment-1680999969 (out of many)
2. `ignore_current` is true (-i) and `is_failed` is false (indicating a successful merge) and `ignored_checks_count > 0` (with failures).  As `-i` still waits for all remaining jobs to finish, this shouldn't be counted toward force merge due to impatience

If none applies, the merge should be counted as a regular merge regardless of the use of `-f` or `-i`.  We could track that (regular merges masquerading as force merges) to understand how devs use (or abuse) these flags, but that should be tracked separately IMO because it's arguably a different case altogether.

Technically, this uses `pending_checks` field from the `merges` collection that we haven't made use of till date to remove a significant portion of no-op force merges masquerading as impatient force merges.  IMO, impatient force merges is not the negative part of force merge with failures, thus the way these queries are atm is a bit wrong (a force merge is either due to failures or due to impatience, there is no other).  This PR fixes them according to the definition above.

### Testing

https://torchci-git-fork-huydhn-force-merge-no-pending-fbopensource.vercel.app/metrics.  As expected, % force merges with failures remains unchanged but we get a more accurate view of % impatient force merges.  The latter now requires `pending_checks_count > 0`.

Same goes for https://torchci-git-fork-huydhn-force-merge-no-pending-fbopensource.vercel.app/kpis.