### PR TITLE
Increase max runners for 'linux.g4dn.12xlarge.nvidia.gpu' and 'linux.g5.12xlarge.nvidia.gpu' to 50

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -67,13 +67,13 @@ runner_types:
     disk_size: 150
     instance_type: g4dn.12xlarge
     is_ephemeral: false
-    max_available: 25
+    max_available: 50
     os: linux
   linux.g5.12xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g5.12xlarge
     is_ephemeral: false
-    max_available: 20
+    max_available: 50
     os: linux
   linux.g5.4xlarge.nvidia.gpu:
     disk_size: 150


### PR DESCRIPTION
Increasing the number of `linux.g5.12xlarge.nvidia.gpu` as it hit the ceil for runners in a healthy state. Increasing for `linux.g4dn.12xlarge.nvidia.gpu` as the current value seems very low.

![Screenshot 2023-08-18 at 10 53 41](https://github.com/pytorch/test-infra/assets/4520845/d3aafdd0-a3e9-426c-ae7c-b705e360fd86)

