### PR TITLE
increase max_available runners for linux.g5.4xlarge.nvidia.gpu and linux.g5.12xlarge.nvidia.gpu

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -73,13 +73,13 @@ runner_types:
     disk_size: 150
     instance_type: g5.12xlarge
     is_ephemeral: false
-    max_available: 50
+    max_available: 100
     os: linux
   linux.g5.4xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g5.4xlarge
     is_ephemeral: false
-    max_available: 550
+    max_available: 600
     os: linux
   linux.large:
     disk_size: 15


### PR DESCRIPTION
Increase the max_available runners for `linux.g5.4xlarge.nvidia.gpu` from 550 to 600 and `linux.g5.12xlarge.nvidia.gpu` from 50 to 100.

![Screenshot 2023-08-22 at 12 38 24](https://github.com/pytorch/test-infra/assets/4520845/1b03e0b8-3518-47f5-b08b-4c3ff8988523)
