### PR TITLE
[security] Update disabled tests

### DIFF
--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   update-disabled-tests:
     runs-on: ubuntu-latest
+    environment: trigger-nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Same as : https://github.com/pytorch/test-infra/pull/4485
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0ee3dc3</samp>

Added `environment` key to `trigger-nightly` job in `.github/workflows/update_disabled_tests.yml` to use a secret token for updating disabled tests in pytorch/pytorch. This job runs daily and syncs the test status based on the latest results.