### PR TITLE
[security] Add nova workflows to environment: pytorchbot-env

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -88,6 +88,7 @@ jobs:
       ARCH: ${{ inputs.architecture }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
+    environment: pytorchbot-env
     container:
       image: ${{ matrix.container_image }}
       options: ${{ matrix.gpu_arch_type == 'cuda' && '--gpus all' || ' ' }}

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -79,6 +79,7 @@ jobs:
       REF: ${{ inputs.ref }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ inputs.runner-type }}
+    environment: pytorchbot-env
     # If a build is taking longer than 60 minutes on these runners we need
     # to have a conversation
     timeout-minutes: 60

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -81,6 +81,7 @@ jobs:
       UPLOAD_TO_BASE_BUCKET: ${{ matrix.upload_to_base_bucket }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
+    environment: pytorchbot-env
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
Same as : https://github.com/pytorch/test-infra/pull/4485

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 76f170b</samp>

Add `environment: pytorchbot-env` to the `build` jobs in the `build_wheels_*.yml` workflows. This enables the PyTorch bot to upload the built wheels to S3 and PyPI.