### PR TITLE
Let Dr.CI message nudge folks towards a normal merge

### DIFF
--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -294,7 +294,13 @@ export function constructResultsComment(
     title_messages.push(pendingJobs);
   }
   if (hasUnrelatedFailures) {
-    title_messages.push(unrelatedFailures);
+    let unrelatedFailuresMsg = unrelatedFailures;
+    if (title_messages.length == 0) {
+      // If there are no other messages, reassure the user that things are looking good
+      unrelatedFailuresMsg = "You can merge normally! (" + unrelatedFailures + ")";
+    }
+
+    title_messages.push(unrelatedFailuresMsg);
   }
 
   let title = headerPrefix + icon + " " + title_messages.join(", ");

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -297,7 +297,8 @@ export function constructResultsComment(
     let unrelatedFailuresMsg = unrelatedFailures;
     if (title_messages.length == 0) {
       // If there are no other messages, reassure the user that things are looking good
-      unrelatedFailuresMsg = "You can merge normally! (" + unrelatedFailures + ")";
+      unrelatedFailuresMsg =
+        "You can merge normally! (" + unrelatedFailures + ")";
     }
 
     title_messages.push(unrelatedFailuresMsg);


### PR DESCRIPTION
Tweak the Dr. CI message to let devs know that they don't need to force merge if only unrelated failures are failing in CI.

This is quick-n-dirty attempt at nudging devs away from unnecessary force merges

# Before: 
<img width="789" alt="image" src="https://github.com/pytorch/test-infra/assets/4468967/5564de36-5e2c-4b65-90b4-e0f11b7b1c80">

# After:
<img width="768" alt="image" src="https://github.com/pytorch/test-infra/assets/4468967/95ab6587-ad06-41c1-a806-4196230c0275">
