### PR TITLE
update release flow for lintrunner

### DIFF
--- a/.github/workflows/lintrunner_ci.yml
+++ b/.github/workflows/lintrunner_ci.yml
@@ -110,6 +110,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/lintrunner/v*')"
     needs: [ macos, windows, linux, test ]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lintrunner_ci.yml
+++ b/.github/workflows/lintrunner_ci.yml
@@ -110,17 +110,13 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/lintrunner/v*')"
     needs: [ macos, windows, linux, test ]
     steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: wheels
+      - uses: actions/checkout@v3
       - name: Publish to PyPI
         uses: messense/maturin-action@v1
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
-          command: upload
+          command: publish
           working-directory: tools/lintrunner
-          args: --skip-existing *


### PR DESCRIPTION
Updates the release flow for lintrunner to actually work.

Was tested using https://github.com/pytorch/test-infra/pull/4500