### PR TITLE
Exclude unstable jobs from TTRS computation

### DIFF
--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -40,7 +40,7 @@
     "time_to_signal": "ff332d025976c103",
     "strict_lag_historical": "d2a09d13caf8b76a",
     "ci_wait_time": "b1080f26b20ea142",
-    "ttrs_percentiles": "4440f851a9845938"
+    "ttrs_percentiles": "679a7c2817a67561"
   },
   "metrics": {
     "correlation_matrix": "35c05e04047123f0",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -40,7 +40,7 @@
     "time_to_signal": "ff332d025976c103",
     "strict_lag_historical": "d2a09d13caf8b76a",
     "ci_wait_time": "b1080f26b20ea142",
-    "ttrs_percentiles": "414f23cc5fcb6753"
+    "ttrs_percentiles": "4440f851a9845938"
   },
   "metrics": {
     "correlation_matrix": "35c05e04047123f0",

--- a/torchci/rockset/pytorch_dev_infra_kpis/__sql/ttrs_percentiles.sql
+++ b/torchci/rockset/pytorch_dev_infra_kpis/__sql/ttrs_percentiles.sql
@@ -7,236 +7,254 @@
 -- This query has two special params:
 --     percentile_to_get: When set, it returns only the specified percentile. Otherwise it returns
 --                 p25, p50, p75 and p90 percentiles.
---     one_bucket: When set to false, buckets data into weekly percentiles. When true, it treats 
---                 entire time range as one big bucket and returns percnetiles accordingly
-
+--     one_bucket: When set to false, buckets data into weekly percentiles. When true, it treats
+--                 entire time range AS one big bucket and returns percnetiles accordingly
 
 WITH
-    -- Get all PRs that were merged into master, and get all the SHAs for commits from that PR which CI jobs ran against
-    -- We need the shas because some jobs (like trunk) don't have a PR they explicitly ran against, but they _were_ run against
-    -- a commit from a PR
-    pr_shas AS (
-        SELECT
-            r.pull_requests[1].number AS pr_number,
-            CONCAT(
-                'https://github.com/pytorch/pytorch/pull/',
-                r.pull_requests[1].number
-            ) AS url,
-            j.head_sha AS sha,
-        FROM
-            commons.workflow_job j
-            INNER JOIN commons.workflow_run r on j.run_id = r.id
-        WHERE
-            1 = 1
-            AND j._event_time > PARSE_DATETIME_ISO8601(:startTime)
-            AND r._event_time > PARSE_DATETIME_ISO8601(:startTime)
-            AND j._event_time < PARSE_DATETIME_ISO8601(:stopTime)
-            AND r._event_time < PARSE_DATETIME_ISO8601(:stopTime)
-            AND LENGTH(r.pull_requests) = 1
-            AND r.pull_requests[1].head.repo.name = 'pytorch'
-            AND r.name IN ('pull', 'trunk', 'Lint') -- Ensure we don't pull in random PRs we don't care about
-            AND r.head_branch NOT IN ('master', 'main', 'nightly', 'viable/strict') -- Only measure TTRS against PRs
-            AND (
-                r.pull_requests[1].base.ref = 'master'
-                OR r.pull_requests[1].base.ref = 'main'
-                OR r.pull_requests[1].base.ref like 'gh/%/base'
-            )
-        GROUP BY
-            pr_number,
-            url,
-            sha
-    ),
-    -- Now filter the list to just closed PRs. 
-    -- Open PRs can be noisy experiments which were never meant to be merged.
-    merged_pr_shas AS (
-        SELECT
-            DISTINCT s.pr_number,
-            s.url,
-            s.sha
-        FROM
-            pr_shas s
-            INNER JOIN commons.pull_request pr on s.pr_number = pr.number
-        WHERE
-            pr.closed_at IS NOT NULL -- Ensure the PR was actaully merged
-            AND 'Merged' IN (
-                SELECT
-                    name
-                FROM
-                    UNNEST(pr.labels)
-            )
-    ),
-    -- Get all the workflows run against the PR and find the steps & stats we care about
-    commit_job_durations AS (
-        SELECT
-            s.pr_number,
-            j.steps,
-            js.name as step_name,
-            js.conclusion as step_conclusion,
-            PARSE_TIMESTAMP_ISO8601(js.completed_at) as failure_time,
-            PARSE_TIMESTAMP_ISO8601(js.started_at) AS start_time,
-            PARSE_TIMESTAMP_ISO8601(j.completed_at) AS end_time,
-            r.name AS workflow_name,
-            j.name as job_name,
-            r.html_url AS workflow_url,
-            -- for debugging
-            s.sha,
-            j.conclusion AS conclusion,
-            j.conclusion = 'cancelled' AS was_cancelled,
-            -- For convenience
-            j.run_attempt,
-            -- the attemp # this job was run on
-            r.run_attempt AS total_attempts,
-            r.id AS workflow_run_id,
-            s.url -- for debugging 
-        FROM
-            commons.workflow_job j
-            CROSS JOIN UNNEST (j.steps) js
-            INNER JOIN merged_pr_shas s on j.head_sha = s.sha
-            INNER JOIN commons.workflow_run r on j.run_id = r.id
-        WHERE
-            1 = 1
-            AND (
-                r.name IN ('pull', 'trunk', 'Lint')
-                OR r.name like 'linux-binary%'
-                OR r.name like 'windows-binary%'
-            ) 
-            AND j.conclusion = 'failure' -- we just care about failed jobs  
-            AND js.conclusion = 'failure'
-            AND j.run_attempt = 1 -- only look at the first run attempt since reruns will either 1) succeed, so are irrelevant or 2) repro the failure, biasing our data
-            and j.name not like 'lintrunner%'
-            and j.name not like '%unstable%' -- The PR doesn't wait for unstable jobs, so they should be excluded when computing TTRS
-            and js.name like 'Test%' -- Only consider test steps
-    ),
-    -- Refine our measurements to only collect the first red signal per workflow
-    ci_failure as (
-        Select
-            d.pr_number,
-            MIN(d.step_name) as step_name,
-            min(workflow_name) as workflow_name,
-            DURATION_SECONDS(min(d.failure_time) - min(d.start_time)) / 60 as ttrs_mins,
-            d.sha,
-            min(workflow_url) as workflow_url,
-            d.workflow_run_id,
-            min(d.start_time) as start_time,
-            min(d.failure_time) as failure_time,
-        from
-            commit_job_durations d
-        group by
-            pr_number,
-            workflow_run_id,
-            sha
-    ),
-    -- get the earliest TTRS across each workflow within the same commit
-    workflow_failure as (
-        SELECT
-            f.pr_number,
-            MIN(f.start_time) as start_time,
-            MIN(f.failure_time) as failure_time,
-            MIN(f.step_name) as step_name,
-            MIN(workflow_url) as workflow_url,
-            MIN(f.ttrs_mins) as ttrs_mins,
-            f.sha,
-            f.workflow_run_id
-        FROM
-            ci_failure f
-        GROUP BY
-            pr_number,
-            sha,
-            workflow_run_id
-    ),
-    workflow_failure_buckets as (
-        SELECT
-            -- When :one_bucket is set to true, we want the ttrs percentile over all the data
-            DATE_TRUNC('week', if(:one_bucket, CURRENT_DATETIME(), start_time)) AS bucket,
-            *
-        FROM
-            workflow_failure
-    ),
-    -- Within each bucket, figure out what percentile duration and num_commits each PR falls under
-    percentiles as (
-        SELECT
-            bucket,
-            ttrs_mins,
-            workflow_url,
-            PERCENT_RANK() OVER(
-                PARTITION BY bucket
-                ORDER by
-                    ttrs_mins
-            ) as percentile,
-            sha,
-        FROM
-            workflow_failure_buckets
-    ),
-    -- All the percentiles that we want the query to determine
-    percentiles_desired AS (
-        SELECT
-            'p50' as percentile,
-            0.50 as percentile_num,
-        UNION ALL
-        SELECT
-            'p75',
-            0.75,
-        UNION ALL
-        SELECT
-            'p90',
-            0.90,
-        UNION ALL
-        SELECT
-            'p25',
-            0.25,
-        UNION ALL
-        -- if percentile_to_get is specified, we get and only return that percentile
-        SELECT 
-            CONCAT('p', CAST(ROUND(:percentile_to_get * 100) AS STRING)),
-            :percentile_to_get
-        WHERE :percentile_to_get > 0
-    ),
-    -- Take the full list of percentiles and get just the ones we care about
-    ttrs_percentile as (
-        SELECT
-            p.bucket,
-            pd.percentile,
-            MIN(p.ttrs_mins) as ttrs_mins
-        FROM
-            percentiles p
-            CROSS JOIN percentiles_desired pd
-        WHERE 1=1
-            AND p.percentile >= pd.percentile_num
-            AND (
-              :percentile_to_get <= 0 
-              OR pd.percentile_num = :percentile_to_get
-  )
-        GROUP BY
-            p.bucket,
-            pd.percentile
-    ),
-    kpi_results as (
-        SELECT
-            FORMAT_TIMESTAMP('%Y-%m-%d', d.bucket) as bucket,
-            -- rolling average
-            (
-                AVG(ttrs_mins) OVER(
-                    PARTITION BY percentile
-                    ORDER BY
-                        -- Average over this many + 1 buckets (two weeks)
-                        bucket ROWS 1 PRECEDING
-                )
-            ) as ttrs_mins,
-            d.percentile
-        FROM
-            ttrs_percentile d
-        WHERE
-            :one_bucket
-            OR
-            (d.bucket < CURRENT_TIMESTAMP() - INTERVAL 1 WEEK) -- discard the latest bucket, which will have noisy, partial data
-        ORDER BY
-            bucket ASC,
-            ttrs_mins
+-- Get all PRs that were merged into master, and get all the SHAs for commits from that PR which CI jobs ran against
+-- We need the shas because some jobs (like trunk) don't have a PR they explicitly ran against, but they _were_ run against
+-- a commit from a PR
+pr_shas AS (
+  SELECT
+    r.pull_requests[1].number AS pr_number,
+    CONCAT(
+      'https://github.com/pytorch/pytorch/pull/',
+      r.pull_requests[1].number
+    ) AS url,
+    j.head_sha AS sha,
+  FROM
+    commons.workflow_job j
+    INNER JOIN commons.workflow_run r ON j.run_id = r.id
+  WHERE
+    1 = 1
+    AND j._event_time > PARSE_DATETIME_ISO8601(: startTime)
+    AND r._event_time > PARSE_DATETIME_ISO8601(: startTime)
+    AND j._event_time < PARSE_DATETIME_ISO8601(: stopTime)
+    AND r._event_time < PARSE_DATETIME_ISO8601(: stopTime)
+    AND LENGTH(r.pull_requests) = 1
+    AND r.pull_requests[1].head.repo.name = 'pytorch'
+    AND r.name IN ('pull', 'trunk', 'Lint') -- Ensure we don't pull in random PRs we don't care about
+    AND r.head_branch NOT IN (
+      'master', 'main', 'nightly', 'viable/strict'
+    ) -- Only measure TTRS against PRs
+    AND (
+      r.pull_requests[1].base.ref = 'master'
+      OR r.pull_requests[1].base.ref = 'main'
+      OR r.pull_requests[1].base.ref like 'gh/%/base'
     )
-SELECT
+  GROUP BY
+    pr_number,
+    url,
+    sha
+),
+-- Now filter the list to just closed PRs.
+-- Open PRs can be noisy experiments which were never meant to be merged.
+merged_pr_shas AS (
+  SELECT
+    DISTINCT s.pr_number,
+    s.url,
+    s.sha
+  FROM
+    pr_shas s
+    INNER JOIN commons.pull_request pr ON s.pr_number = pr.number
+  WHERE
+    pr.closed_at IS NOT NULL -- Ensure the PR was actaully merged
+    AND 'Merged' IN (
+      SELECT
+        name
+      FROM
+        UNNEST(pr.labels)
+    )
+),
+-- Get all the workflows run against the PR and find the steps & stats we care about
+commit_job_durations AS (
+  SELECT
+    s.pr_number,
+    j.steps,
+    js.name AS step_name,
+    js.conclusion AS step_conclusion,
+    PARSE_TIMESTAMP_ISO8601(js.completed_at) AS failure_time,
+    PARSE_TIMESTAMP_ISO8601(js.started_at) AS start_time,
+    PARSE_TIMESTAMP_ISO8601(j.completed_at) AS end_time,
+    r.name AS workflow_name,
+    j.name AS job_name,
+    r.html_url AS workflow_url,
+    -- for debugging
+    s.sha,
+    j.conclusion AS conclusion,
+    j.conclusion = 'cancelled' AS was_cancelled,
+    -- For convenience
+    j.run_attempt,
+    -- the attemp number this job was run on
+    r.run_attempt AS total_attempts,
+    r.id AS workflow_run_id,
+    s.url -- for debugging
+  FROM
+    commons.workflow_job j CROSS
+    JOIN UNNEST (j.steps) js
+    INNER JOIN merged_pr_shas s ON j.head_sha = s.sha
+    INNER JOIN commons.workflow_run r ON j.run_id = r.id
+  WHERE
+    1 = 1
+    AND (
+      r.name IN ('pull', 'trunk', 'Lint')
+      OR r.name like 'linux-binary%'
+      OR r.name like 'windows-binary%'
+    )
+    AND j.conclusion = 'failure' -- we just care about failed jobs
+    AND js.conclusion = 'failure'
+    AND j.run_attempt = 1 -- only look at the first run attempt since reruns will either 1) succeed, so are irrelevant or 2) repro the failure, biasing our data
+    and j.name NOT LIKE 'lintrunner%'
+    and j.name NOT LIKE '%unstable%' -- The PR doesn't wait for unstable jobs, so they should be excluded when computing TTRS
+    and js.name LIKE 'Test%' -- Only consider test steps
+    ),
+-- Refine our measurements to only collect the first red signal per workflow
+ci_failure AS (
+  SELECT
+    d.pr_number,
+    MIN(d.step_name) AS step_name,
+    MIN(workflow_name) AS workflow_name,
+    DURATION_SECONDS(
+      MIN(d.failure_time) - MIN(d.start_time)
+    ) / 60 AS ttrs_mins,
+    d.sha,
+    MIN(workflow_url) AS workflow_url,
+    d.workflow_run_id,
+    MIN(d.start_time) AS start_time,
+    MIN(d.failure_time) AS failure_time,
+  FROM
+    commit_job_durations d
+  GROUP BY
+    pr_number,
+    workflow_run_id,
+    sha
+),
+-- get the earliest TTRS across each workflow within the same commit
+workflow_failure AS (
+  SELECT
+    f.pr_number,
+    MIN(f.start_time) AS start_time,
+    MIN(f.failure_time) AS failure_time,
+    MIN(f.step_name) AS step_name,
+    MIN(workflow_url) AS workflow_url,
+    MIN(f.ttrs_mins) AS ttrs_mins,
+    f.sha,
+    f.workflow_run_id
+  FROM
+    ci_failure f
+  GROUP BY
+    pr_number,
+    sha,
+    workflow_run_id
+),
+workflow_failure_buckets AS (
+  SELECT
+    -- When :one_bucket is set to true, we want the ttrs percentile over all the data
+    DATE_TRUNC(
+      'week',
+      IF(
+        : one_bucket,
+        CURRENT_DATETIME(),
+        start_time
+      )
+    ) AS bucket,
     *
+  FROM
+    workflow_failure
+),
+-- Within each bucket, figure out what percentile duration and num_commits each PR falls under
+percentiles AS (
+  SELECT
+    bucket,
+    ttrs_mins,
+    workflow_url,
+    PERCENT_RANK() OVER(
+      PARTITION BY bucket
+      ORDER by
+        ttrs_mins
+    ) AS percentile,
+    sha,
+  FROM
+    workflow_failure_buckets
+),
+-- All the percentiles that we want the query to determine
+percentiles_desired AS (
+  SELECT
+    'p50' AS percentile,
+    0.50 AS percentile_num,
+  UNION ALL
+  SELECT
+    'p75',
+    0.75,
+  UNION ALL
+  SELECT
+    'p90',
+    0.90,
+  UNION ALL
+  SELECT
+    'p25',
+    0.25,
+  UNION ALL
+    -- if percentile_to_get is specified, we get and only return that percentile
+  SELECT
+    CONCAT(
+      'p',
+      CAST(
+        ROUND(: percentile_to_get * 100) AS STRING
+      )
+    ),
+    : percentile_to_get
+  WHERE
+    : percentile_to_get > 0
+),
+-- Take the full list of percentiles and get just the ones we care about
+ttrs_percentile AS (
+  SELECT
+    p.bucket,
+    pd.percentile,
+    MIN(p.ttrs_mins) AS ttrs_mins
+  FROM
+    percentiles p CROSS
+    JOIN percentiles_desired pd
+  WHERE
+    1 = 1
+    AND p.percentile >= pd.percentile_num
+    AND (
+      : percentile_to_get <= 0
+      OR pd.percentile_num = : percentile_to_get
+    )
+  GROUP BY
+    p.bucket,
+    pd.percentile
+),
+kpi_results AS (
+  SELECT
+    FORMAT_TIMESTAMP('%Y-%m-%d', d.bucket) AS bucket,
+    -- rolling average
+    (
+      AVG(ttrs_mins) OVER(
+        PARTITION BY percentile
+        ORDER BY
+          -- Average over this many + 1 buckets (two weeks)
+          bucket ROWS 1 PRECEDING
+      )
+    ) AS ttrs_mins,
+    d.percentile
+  FROM
+    ttrs_percentile d
+  WHERE
+    : one_bucket
+    OR (
+      d.bucket < CURRENT_TIMESTAMP() - INTERVAL 1 WEEK
+    ) -- discard the latest bucket, which will have noisy, partial data
+  ORDER BY
+    bucket ASC,
+    ttrs_mins
+)
+SELECT
+  *
 FROM
   kpi_results
 ORDER BY
-    bucket DESC,
-    ttrs_mins DESC
+  bucket DESC,
+  ttrs_mins DESC

--- a/torchci/rockset/pytorch_dev_infra_kpis/__sql/ttrs_percentiles.sql
+++ b/torchci/rockset/pytorch_dev_infra_kpis/__sql/ttrs_percentiles.sql
@@ -104,6 +104,7 @@ WITH
             AND js.conclusion = 'failure'
             AND j.run_attempt = 1 -- only look at the first run attempt since reruns will either 1) succeed, so are irrelevant or 2) repro the failure, biasing our data
             and j.name not like 'lintrunner%'
+            and j.name not like '%unstable%' -- The PR doesn't wait for unstable jobs, so they should be excluded when computing TTRS
             and js.name like 'Test%' -- Only consider test steps
     ),
     -- Refine our measurements to only collect the first red signal per workflow


### PR DESCRIPTION
Per our discussion, let's exclude unstable jobs from TTR computation because they don't block merge.

### Testing

https://torchci-git-fork-huydhn-remove-unstable-job-tts-fbopensource.vercel.app/metrics and https://torchci-git-fork-huydhn-remove-unstable-job-tts-fbopensource.vercel.app/kpis