### PR TITLE
Maintain old test times

### DIFF
--- a/.github/workflows/update-test-times.yml
+++ b/.github/workflows/update-test-times.yml
@@ -16,8 +16,8 @@ defaults:
   run:
     working-directory: torchci
 jobs:
-  update-slow-stats:
-    runs-on: ubuntu-20.04
+  update-test-time-stats:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 

--- a/torchci/scripts/test_update_test_times.py
+++ b/torchci/scripts/test_update_test_times.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from update_test_times import gen_test_times
 
@@ -12,7 +13,7 @@ class TestUpdateTestTimes(unittest.TestCase):
             self.make_rockset_row("job", "config", "b", 1),
             self.make_rockset_row("job", "config", "c", 1),
         ]
-        res = gen_test_times(data)
+        res = gen_test_times(data, {})
         expected = {
             "job": {"config": {"a": 1, "b": 1, "c": 1}},
             "default": {
@@ -28,7 +29,7 @@ class TestUpdateTestTimes(unittest.TestCase):
             self.make_rockset_row("job", "config2", "a", 6),
             self.make_rockset_row("job2", "config", "a", 5),
         ]
-        res = gen_test_times(data)
+        res = gen_test_times(data, {})
         expected = {
             "job": {"config": {"a": 1}, "config2": {"a": 6}},
             "job2": {"config": {"a": 5}},
@@ -41,20 +42,53 @@ class TestUpdateTestTimes(unittest.TestCase):
 
         self.assertDictEqual(res, expected)
 
-    def test_gen_test_times_dont_override_default(self) -> None:
+    def test_gen_test_times_override_default(self) -> None:
         data = [
             self.make_rockset_row("default", "config", "a", 1),
             self.make_rockset_row("job", "config", "a", 6),
             self.make_rockset_row("default", "default", "a", 5),
         ]
-        res = gen_test_times(data)
+        res = gen_test_times(data, {})
         expected = {
-            "job": {
-                "config": {"a": 6.0},
-            },
-            "default": {"default": {"a": 5.0}, "config": {"a": 1.0}},
+            "default": {"config": {"a": 3.5}, "default": {"a": 4.0}},
+            "job": {"config": {"a": 6}},
         }
+        self.assertDictEqual(res, expected)
 
+    def test_gen_test_times_override_old_default(self) -> None:
+        data = [
+            self.make_rockset_row("default", "config", "a", 1),
+            self.make_rockset_row("job", "config", "a", 6),
+            self.make_rockset_row("default", "default", "a", 5),
+        ]
+        res = gen_test_times(data, {"default": {"config": {"a": 57}}})
+        expected = {
+            "default": {"config": {"a": 3.5}, "default": {"a": 4.0}},
+            "job": {"config": {"a": 6}},
+        }
+        self.assertDictEqual(res, expected)
+
+        data = [
+            self.make_rockset_row("env", "config", "a", 1),
+        ]
+        res = gen_test_times(
+            data, {"default": {"config": {"a": 57}, "default": {"a": 100}}}
+        )
+        expected = {
+            "default": {"config": {"a": 1.0}, "default": {"a": 1.0}},
+            "env": {"config": {"a": 1}},
+        }
+        self.assertDictEqual(res, expected)
+
+    def test_gen_test_times_old_values_still_present(self) -> None:
+        data = [
+            self.make_rockset_row("env", "config", "a", 5),
+        ]
+        res = gen_test_times(data, {"env": {"config": {"b": 57}}})
+        expected = {
+            "env": {"config": {"b": 57, "a": 5}},
+            "default": {"config": {"a": 5.0}, "default": {"a": 5.0}},
+        }
         self.assertDictEqual(res, expected)
 
 

--- a/torchci/scripts/update_test_times.py
+++ b/torchci/scripts/update_test_times.py
@@ -80,5 +80,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    print(download_old_test_times())
-    # main()
+    main()

--- a/torchci/scripts/update_test_times.py
+++ b/torchci/scripts/update_test_times.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 import json
+import requests
 import rockset
 import os
 from pathlib import Path
@@ -7,6 +8,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 PROD_VERSIONS_FILE = REPO_ROOT / "torchci" / "rockset" / "prodVersions.json"
+TEST_TIMES_URL = "https://raw.githubusercontent.com/pytorch/test-infra/generated-stats/stats/test-times.json"
 
 
 def get_data_from_rockset():
@@ -29,8 +31,25 @@ def get_data_from_rockset():
     return rockset_result + periodic_rockset_result
 
 
-def gen_test_times(rockset_results):
-    test_times = defaultdict(lambda: defaultdict(lambda: defaultdict(float)))
+def download_old_test_times():
+    return json.loads(requests.get(url=TEST_TIMES_URL).text)
+
+
+def convert_to_default_dict(d):
+    new_d = defaultdict(lambda: defaultdict(lambda: defaultdict(float)))
+    for env in d:
+        for config in d[env]:
+            for file in d[env][config]:
+                new_d[env][config][file] = d[env][config][file]
+    return new_d
+
+
+def gen_test_times(rockset_results, old_test_times):
+    # Use old test times because sometimes we want to manually edit the test
+    # times json and want those changes to persist.  Unfortunately this means
+    # that the test times json grows and never shrinks, but we can edit the json
+    # to make it smaller.  Defaults are always overriden.
+    test_times = convert_to_default_dict(old_test_times)
     test_times_no_build_env = defaultdict(lambda: defaultdict(list))
     test_times_no_test_config = defaultdict(list)
     for row in rockset_results:
@@ -45,19 +64,21 @@ def gen_test_times(rockset_results):
     for test, times in test_times_no_test_config.items():
         test_times_no_test_config[test] = sum(times) / len(times)
 
-    if "default" not in test_times:
-        test_times["default"] = test_times_no_build_env
-    if "default" not in test_times["default"]:
-        test_times["default"]["default"] = test_times_no_test_config
+    # Default should never be a build env
+    test_times["default"] = test_times_no_build_env
+    # Replace default's default with our own to account for tests that aren't
+    # usually in the default test config like distributed
+    test_times["default"]["default"] = test_times_no_test_config
     return test_times
 
 
 def main() -> None:
-    test_times = gen_test_times(get_data_from_rockset())
+    test_times = gen_test_times(get_data_from_rockset(), download_old_test_times())
 
     with open("test-times.json", "w") as f:
         f.write(json.dumps(test_times, indent=2, sort_keys=True))
 
 
 if __name__ == "__main__":
-    main()
+    print(download_old_test_times())
+    # main()


### PR DESCRIPTION
In https://github.com/pytorch/test-infra/pull/4476 I removed the code that allows us to edit the test times manually and have it mostly persist because I thought we didn't need it anymore but I was wrong.  This PR adds this ability back in.

This means the test times json never shrinks, but I think that's ok since we can manually edit it.

Also
* rename the job 
* move to ubuntu-latest