### PR TITLE
Do not retry unstable jobs

### DIFF
--- a/torchci/lib/bot/retryBot.ts
+++ b/torchci/lib/bot/retryBot.ts
@@ -97,6 +97,11 @@ async function retryCurrentWorkflow(
       return false;
     }
 
+    // don't rerun unstable jobs as this is not needed
+    if (job.name.toLocaleLowerCase().includes("unstable")) {
+      return false;
+    }
+
     // if no test steps failed, can rerun
     return !doesLookLikeUserFailure(job, (step) =>
       step.name.toLowerCase().includes("test")

--- a/torchci/rockset/commons/__sql/flaky_workflows_jobs.sql
+++ b/torchci/rockset/commons/__sql/flaky_workflows_jobs.sql
@@ -1,3 +1,6 @@
+-- This query is used to get flaky job on trunk so that they can be retried. A flaky job is the
+-- one that has the green / red / green pattern. The failure in the middle is considered flaky
+-- and can be retried
 WITH dedups AS (
   -- Note that there can be more than one commit with the same ID with the actual author and pytorchmergebot.
   -- This mess up the results in some cases, so this removes all redundant information and only keeps what is
@@ -39,6 +42,7 @@ WITH dedups AS (
     )
     AND job.name NOT LIKE '%mem_leak_check%'
     AND job.name NOT LIKE '%rerun_disabled_tests%'
+    AND job.name NOT LIKE :excludedJobName
 ),
 latest_attempts AS (
   -- Keep the latest run attempt to know if the job has already been retried

--- a/torchci/rockset/commons/__sql/flaky_workflows_jobs.sql
+++ b/torchci/rockset/commons/__sql/flaky_workflows_jobs.sql
@@ -42,7 +42,7 @@ WITH dedups AS (
     )
     AND job.name NOT LIKE '%mem_leak_check%'
     AND job.name NOT LIKE '%rerun_disabled_tests%'
-    AND job.name NOT LIKE :excludedJobName
+    AND job.name NOT LIKE '%unstable%'
 ),
 latest_attempts AS (
   -- Keep the latest run attempt to know if the job has already been retried

--- a/torchci/rockset/commons/flaky_workflows_jobs.lambda.json
+++ b/torchci/rockset/commons/flaky_workflows_jobs.lambda.json
@@ -7,11 +7,6 @@
       "value": "master,main"
     },
     {
-      "name": "excludedJobName",
-      "type": "string",
-      "value": "%rocm%"
-    },
-    {
       "name": "maxAttempt",
       "type": "int",
       "value": "1"

--- a/torchci/rockset/commons/flaky_workflows_jobs.lambda.json
+++ b/torchci/rockset/commons/flaky_workflows_jobs.lambda.json
@@ -7,6 +7,11 @@
       "value": "master,main"
     },
     {
+      "name": "excludedJobName",
+      "type": "string",
+      "value": "%rocm%"
+    },
+    {
       "name": "maxAttempt",
       "type": "int",
       "value": "1"

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -11,7 +11,7 @@
     "get_relevant_alerts": "727014a49bef2c20",
     "individual_test_stats_per_workflow_per_oncall": "559b6735965f1eb2",
     "individual_test_times_per_oncall_per_workflow": "6b63c3dde3032bea",
-    "flaky_workflows_jobs": "c981afe1305bc809",
+    "flaky_workflows_jobs": "3ac657ca40327f94",
     "failed_workflow_jobs": "6ec4fd3f36a72071",
     "get_workflow_jobs": "6ed2029b19691a4b",
     "slow_tests": "ef8d035d23aa8ab6",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -11,7 +11,7 @@
     "get_relevant_alerts": "727014a49bef2c20",
     "individual_test_stats_per_workflow_per_oncall": "559b6735965f1eb2",
     "individual_test_times_per_oncall_per_workflow": "6b63c3dde3032bea",
-    "flaky_workflows_jobs": "d5783ef1fe73fa5b",
+    "flaky_workflows_jobs": "c981afe1305bc809",
     "failed_workflow_jobs": "6ec4fd3f36a72071",
     "get_workflow_jobs": "6ed2029b19691a4b",
     "slow_tests": "ef8d035d23aa8ab6",


### PR DESCRIPTION
This is a small tweak to not retry unstable jobs as they are unstable anyway.  This helps with the ROCm queue atm when retrying doesn't help.  The job has been marked as unstable.