### PR TITLE
Restrict `api-compatibility-check` job only to pull request events

### DIFF
--- a/.github/workflows/stronghold.yml
+++ b/.github/workflows/stronghold.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   api-compatibility-check:
+    if: github.event_name == 'pull_request'
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       # Fetch the commit, rather than the merge.


### PR DESCRIPTION
The way `api-compatibility-check` is designed, it expects fields that correspond specifically to PR events, causing the job to fail on `main` commits:
https://github.com/pytorch/test-infra/actions/runs/6002572027/job/16281617018

This could be changed in the future, but for now just disabling the job for anything beside PRs to avoid confusion.