### PR TITLE
tools: Update to require PyGithub directly

### DIFF
--- a/tools/self-hosted-runner-utils/requirements.txt
+++ b/tools/self-hosted-runner-utils/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/jorgegarciarey/PyGithub@master
+PyGithub
 black
 tqdm


### PR DESCRIPTION
Looks like the repository we were previously relying on has become non-existent and so we can rely on upstream PyGithub to supply the correct thing here.