### PR TITLE
Return most relevant similar failure first, not the newest one

### DIFF
--- a/torchci/lib/searchUtils.ts
+++ b/torchci/lib/searchUtils.ts
@@ -6,6 +6,7 @@ export const WORKFLOW_JOB_INDEX = "torchci-workflow-job";
 // OpenSearch uses https://en.wikipedia.org/wiki/Okapi_BM25 by default.  TODO: learn more
 // about which is a reasonable value here and how to tune it
 export const MIN_SCORE = 1.0;
+export const MAX_SIZE = 20;
 
 export async function searchSimilarFailures(
   client: Client,
@@ -13,10 +14,12 @@ export async function searchSimilarFailures(
   index: string,
   startDate: string,
   endDate: string,
-  minScore: number
+  minScore: number,
+  maxSize: number = MAX_SIZE
 ): Promise<{ jobs: JobData[] }> {
   const body = {
     min_score: minScore,
+    size: maxSize,
     query: {
       bool: {
         must: [
@@ -36,11 +39,13 @@ export async function searchSimilarFailures(
         ],
       },
     },
+    // NB: It's important to sort by score first so that the most relevant results
+    // are at the top because we will only retrieve up to MAX_SIZE records
     sort: [
+      "_score",
       {
         completed_at: "desc",
       },
-      "_score",
     ],
   };
 


### PR DESCRIPTION
This is a bug in my search query where the newer records were preferred over more relevant ones.  Because there is a limit on the number of returned records, the query failed to find some legit similar failures, i.e. https://github.com/pytorch/pytorch/pull/107584 (both MacOS jobs failed in periodic).

This also explains the confusion I have where some irrelevant results are at the top.

### Testing

* The current [HUD](https://hud.pytorch.org/api/search?failure=inductor/test_torchinductor.py::CpuTests::test_multilayer_var_cpu?startDate=2023-08-20T12:13:23.916Z&endDate=2023-08-25T15:11:10.000Z) returns mostly junks while https://torchci-git-fork-huydhn-fix-similar-failure-46268c-fbopensource.vercel.app/api/search?failure=inductor/test_torchinductor.py::CpuTests::test_multilayer_var_cpu?startDate=2023-08-20T12:13:23.916Z&endDate=2023-08-25T15:11:10.000Z has all the relevant results correctly assembled.
* Take the same https://github.com/pytorch/pytorch/pull/107584 and both failures are now classified correctly as unrelated:

<!-- drci-comment-start -->

## :link: Helpful Links
### :test_tube: See artifacts and rendered test results at [hud.pytorch.org/pr/107584](https://hud.pytorch.org/pr/107584)
* :page_facing_up: Preview [Python docs built from this PR](https://docs-preview.pytorch.org/pytorch/pytorch/107584/index.html)
* :page_facing_up: Preview [C++ docs built from this PR](https://docs-preview.pytorch.org/pytorch/pytorch/107584/cppdocs/index.html)
* :question: Need help or want to give feedback on the CI? Visit the [bot commands wiki](https://github.com/pytorch/pytorch/wiki/Bot-commands) or our [office hours](https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours)

Note: Links to docs will display an error until the docs builds have been completed.


## :white_check_mark: You can merge normally! (2 Unrelated Failures)
As of commit 07477a04cd89f128224f9eb1f6568fc4c6366b4a with merge base 97a291f6bdea9f04e4128e85b5665d00ca214851 (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1692965598?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details ><summary><b>FLAKY</b> - The following job failed but was likely due to flakiness present on trunk:</summary><p>

* [macos-12-py3-x86-64 / test (default, 3, 4, macos-12)](https://hud.pytorch.org/pr/pytorch/pytorch/107584#16214763110) ([gh](https://github.com/pytorch/pytorch/actions/runs/5975932049/job/16214763110))
</p></details>
<details ><summary><b>BROKEN TRUNK</b> - The following job failed but was present on the merge base:</summary><p>👉 <b>Rebase onto the `viable/strict` branch to avoid these failures</b></p><p>

* [macos-12-py3-x86-64 / test (default, 1, 4, macos-12)](https://hud.pytorch.org/pr/pytorch/pytorch/107584#16214762630) ([gh](https://github.com/pytorch/pytorch/actions/runs/5975932049/job/16214762630))
</p></details>


This comment was automatically generated by Dr. CI and updates every 15 minutes.
<!-- drci-comment-end -->