### PR TITLE
Support for Test Conda Token

### DIFF
--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -61,7 +61,10 @@ on:
         type: string
     secrets:
       CONDA_PYTORCHBOT_TOKEN:
-        description: "Access Token needed to upload binaries to anaconda"
+        description: "Access Token needed to upload binaries to anaconda nightly channel"
+        required: false
+      CONDA_PYTORCHBOT_TOKEN_TEST:
+        description: "Access Token needed to upload binaries to anaconda test channel"
         required: false
 
 jobs:
@@ -194,12 +197,19 @@ jobs:
         working-directory: ${{ inputs.repository }}
         env:
           CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}
+          CONDA_PYTORCHBOT_TOKEN_TEST: ${{ secrets.CONDA_PYTORCHBOT_TOKEN_TEST }}
         run: |
+          if [[ "${CHANNEL}" = "nightly" ]]; then
+            export CONDA_TOKEN="${CONDA_PYTORCHBOT_TOKEN}"
+          else
+            export CONDA_TOKEN="${CONDA_PYTORCHBOT_TOKEN_TEST}"
+          fi
+
           set -euxo pipefail
           source "${BUILD_ENV_FILE}"
           ${CONDA_RUN} conda install --yes --quiet anaconda-client
           ${CONDA_RUN} anaconda \
-            -t "${CONDA_PYTORCHBOT_TOKEN}" \
+            -t "${CONDA_TOKEN}" \
             upload distr/linux-64/*.tar.bz2 \
             -u "pytorch-${CHANNEL}" \
             --label main \

--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -65,7 +65,10 @@ on:
         type: string
     secrets:
       CONDA_PYTORCHBOT_TOKEN:
-        description: "Access Token needed to upload binaries to anaconda"
+        description: "Access Token needed to upload binaries to anaconda nightly channel"
+        required: false
+      CONDA_PYTORCHBOT_TOKEN_TEST:
+        description: "Access Token needed to upload binaries to anaconda test channel"
         required: false
 
 jobs:
@@ -202,7 +205,14 @@ jobs:
         working-directory: ${{ inputs.repository }}
         env:
           CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}
+          CONDA_PYTORCHBOT_TOKEN_TEST: ${{ secrets.CONDA_PYTORCHBOT_TOKEN_TEST }}
         run: |
+          if [[ "${CHANNEL}" = "nightly" ]]; then
+            export CONDA_TOKEN="${CONDA_PYTORCHBOT_TOKEN}"
+          else
+            export CONDA_TOKEN="${CONDA_PYTORCHBOT_TOKEN_TEST}"
+          fi
+
           set -euxo pipefail
           source "${BUILD_ENV_FILE}"
 
@@ -214,7 +224,7 @@ jobs:
             export ARCH_NAME="osx-64"
           fi
           ${CONDA_RUN} anaconda \
-            -t "${CONDA_PYTORCHBOT_TOKEN}" \
+            -t "${CONDA_TOKEN}" \
             upload "distr/${ARCH_NAME}"/*.tar.bz2 \
             -u "pytorch-${CHANNEL}" \
             --label main \

--- a/.github/workflows/build_conda_windows.yml
+++ b/.github/workflows/build_conda_windows.yml
@@ -61,7 +61,10 @@ on:
         type: string
     secrets:
       CONDA_PYTORCHBOT_TOKEN:
-        description: "Access Token needed to upload binaries to anaconda"
+        description: "Access Token needed to upload binaries to anaconda nightly channel"
+        required: false
+      CONDA_PYTORCHBOT_TOKEN_TEST:
+        description: "Access Token needed to upload binaries to anaconda test channel"
         required: false
 
 jobs:
@@ -225,12 +228,19 @@ jobs:
         env:
           PACKAGE_NAME: ${{ inputs.package-name }}
           CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}
+          CONDA_PYTORCHBOT_TOKEN_TEST: ${{ secrets.CONDA_PYTORCHBOT_TOKEN_TEST }}
         run: |
+          if [[ "${CHANNEL}" = "nightly" ]]; then
+            export CONDA_TOKEN="${CONDA_PYTORCHBOT_TOKEN}"
+          else
+            export CONDA_TOKEN="${CONDA_PYTORCHBOT_TOKEN_TEST}"
+          fi
+
           set -euxo pipefail
           source "${BUILD_ENV_FILE}"
           ${CONDA_RUN} conda install --yes --quiet anaconda-client
           ${CONDA_RUN} anaconda \
-            -t "${CONDA_PYTORCHBOT_TOKEN}" \
+            -t "${CONDA_TOKEN}" \
             upload "distr/win-64/${PACKAGE_NAME}*.tar.bz2" \
             -u "pytorch-${CHANNEL}" \
             --label main \


### PR DESCRIPTION
We will use a separate `CONDA_PYTORCHBOT_TOKEN_TEST` for using in a test environment

Fixes https://github.com/pytorch/test-infra/issues/4529

TODO:
1. Add the token to the other domain repos
2. Add to audio caller: https://github.com/pytorch/audio/pull/3582
3. Add to vision caller: https://github.com/pytorch/vision/pull/7900