### PR TITLE
[TorchFix] Ignore stderr by default

### DIFF
--- a/tools/torchfix/README.md
+++ b/tools/torchfix/README.md
@@ -30,8 +30,9 @@ Flake8 normally will run the TorchFix linter.
 To see only TorchFix warnings without the rest of the Flake8 linters, you can run
 `flake8 --isolated --select=TOR`
 
-TorchFix can also be run as a standalone program: `torchfix --ignore-stderr .`
+TorchFix can also be run as a standalone program: `torchfix .`
 Add `--fix` parameter to try to autofix some of the issues (the files will be overwritten!)
+To see some additional debug info, add `--show-stderr` parameter.
 
 Please keep in mind that autofix is a best-effort mechanism. Given the dynamic nature of Python,
 and especially the prototype/alpha version status of TorchFix, it's very difficult to have

--- a/tools/torchfix/torchfix/__main__.py
+++ b/tools/torchfix/torchfix/__main__.py
@@ -34,7 +34,7 @@ def main() -> None:
     # Silence "Failed to determine module name"
     # https://github.com/Instagram/LibCST/issues/944
     parser.add_argument(
-        "--ignore-stderr",
+        "--show-stderr",
         action="store_true",
     )
 
@@ -58,7 +58,7 @@ def main() -> None:
     command_instance = TorchCodemod(codemod.CodemodContext())
     DIFF_CONTEXT = 5
     try:
-        if args.ignore_stderr:
+        if not args.show_stderr:
             context = contextlib.redirect_stderr(io.StringIO())
         else:
             # Should get rid of this code eventually.


### PR DESCRIPTION
The whole "ignore stderr" is an ugly hack and should be eventually removed by resolving https://github.com/Instagram/LibCST/issues/944, but for now it's better to make the ignoring behavior default to don't confuse new TorchFix users.