### PR TITLE
Use extra-index-url for linux-aarch64 testing

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -256,6 +256,8 @@ def get_wheel_install_command(
     desired_cuda: str,
     python_version: str,
 ) -> str:
+
+    index_url_option = "--index-url" if os != "linux-aarch64" else "--extra-index-url"
     if channel == RELEASE and (
         (gpu_arch_version == "11.7" and os == "linux")
         or (
@@ -270,7 +272,7 @@ def get_wheel_install_command(
             if channel == "nightly"
             else f"{WHL_INSTALL_BASE} {PACKAGES_TO_INSTALL_WHL}"
         )
-        return f"{whl_install_command} --index-url {get_base_download_url_for_repo('whl', channel, gpu_arch_type, desired_cuda)}"
+        return f"{whl_install_command} {index_url_option} {get_base_download_url_for_repo('whl', channel, gpu_arch_type, desired_cuda)}"
 
 
 def generate_conda_matrix(


### PR DESCRIPTION
These wheels are published on pypi officially hence no reason to test with index-url

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 31a9def</samp>

> _We're sailing on the Python sea, with wheels of every kind_
> _We need to use the right pip option, or else we'll fall behind_
> _So `get_wheel_install_command` will check the OS for us_
> _And set the variable `option` with a minimum of fuss_