### PR TITLE
Revert "Dedicate windows GPU for the release process (#4535)"

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -110,12 +110,6 @@ runner_types:
     is_ephemeral: true
     max_available: 150
     os: windows
-  windows.8xlarge.nvidia.gpu.release:
-    disk_size: 256
-    instance_type: p3.2xlarge
-    is_ephemeral: true
-    max_available: 15
-    os: windows
   windows.8xlarge.nvidia.gpu.nonephemeral:
     disk_size: 256
     instance_type: p3.2xlarge


### PR DESCRIPTION
This reverts commit b7ba5263f9c037153b179f552d77bcc34867953c.

It doesn't make sense to have dedicated GPU windows instances, as for now all the ephemeral GPU windows instances are only being used for the release process.

If this is not the case, makes more sense to update the usage on the tasks itself.