### PR TITLE
Release only change temporary fix aarch64 builds

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -150,7 +150,7 @@ jobs:
           source "${BUILD_ENV_FILE}"
           # shellcheck disable=SC2086
           # temporary change to force rlease aarch64 vision and audio builds use pre and hence install 2.1.0 torch
-          if [[ ${ARCH} == 'aarch64' && ${CHANNEL} == 'test' ]]; then
+          if [[ ${ARCH} == "aarch64" && ${CHANNEL} == "test" ]]; then
             PIP_INSTALL_TORCH=${PIP_INSTALL_TORCH/"pip install"/"pip install --pre"}
           fi
           ${CONDA_RUN} ${PIP_INSTALL_TORCH}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -149,6 +149,10 @@ jobs:
           set -euxo pipefail
           source "${BUILD_ENV_FILE}"
           # shellcheck disable=SC2086
+          # temporary change to force rlease aarch64 vision and audio builds use pre and hence install 2.1.0 torch
+          if [[ ${ARCH} == 'aarch64' && ${CHANNEL} == 'test' ]]; then
+            PIP_INSTALL_TORCH=${PIP_INSTALL_TORCH/"pip install"/"pip install --pre"}
+          fi
           ${CONDA_RUN} ${PIP_INSTALL_TORCH}
       - name: Run Pre-Script with Caching
         if: ${{ inputs.pre-script != '' }}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -150,7 +150,7 @@ jobs:
           source "${BUILD_ENV_FILE}"
           # shellcheck disable=SC2086
           # temporary change to force rlease aarch64 vision and audio builds use pre and hence install 2.1.0 torch
-          if [[ ${ARCH} == "aarch64" && ${CHANNEL} == "test" ]]; then
+          if [[ "${ARCH}" == "aarch64" ]]; then
             PIP_INSTALL_TORCH=${PIP_INSTALL_TORCH/"pip install"/"pip install --pre"}
           fi
           ${CONDA_RUN} ${PIP_INSTALL_TORCH}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 60a305c</samp>

Use `--pre` option to install PyTorch 2.1.0 on aarch64 for wheel building. This enables testing and releasing vision and audio packages that depend on the latest PyTorch version.


Here is the test:
https://github.com/pytorch/builder/actions/runs/6041507840/job/16394612224#step:11:3131