### PR TITLE
increase max_available runners for linux.arm64.2xlarge to 100

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -90,7 +90,7 @@ runner_types:
     disk_size: 256
     instance_type: t4g.2xlarge
     is_ephemeral: false
-    max_available: 30
+    max_available: 100
     os: linux
   windows.4xlarge:
     disk_size: 256


### PR DESCRIPTION
![Screenshot 2023-09-01 at 12 38 14](https://github.com/pytorch/test-infra/assets/4520845/56615efa-e7a1-407b-b45b-96a2bf976c48)
