### PR TITLE
Remove ssh from linux conda/wheel builds since they are in a container

### DIFF
--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -95,10 +95,6 @@ jobs:
           repository: ${{ inputs.test-infra-repository }}
           ref: ${{ inputs.test-infra-ref }}
           path: test-infra
-      - name: Setup SSH
-        uses: ./test-infra/.github/actions/setup-ssh
-        with:
-          github-secret: ${{ github.token }}
       - uses: ./test-infra/.github/actions/set-channel
       - uses: ./test-infra/.github/actions/setup-binary-builds
         with:

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -122,10 +122,6 @@ jobs:
           repository: "pytorch/builder"
           ref: "main"
           path: builder
-      - name: Setup SSH
-        uses: ./test-infra/.github/actions/setup-ssh
-        with:
-          github-secret: ${{ github.token }}
       - name: Set linux aarch64 CI
         if: ${{ inputs.architecture == 'aarch64' }}
         shell: bash -l {0}


### PR DESCRIPTION
I don't think we can ssh into a container 

See https://github.com/pytorch/test-infra/issues/4546