### PR TITLE
Upload docs artifacts only when there are files to upload

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -276,8 +276,9 @@ jobs:
           fi
 
           upload_docs=0
-          # Check if there are things in the documentation folder to uplaod
-          if find "${RUNNER_DOCS_DIR}" -mindepth 1 -maxdepth 1 | read -r; then
+          # Check if there are files in the documentation folder to upload, note that
+          # empty folders do not count
+          if find "${RUNNER_DOCS_DIR}" -mindepth 1 -maxdepth 1 -type f | read -r; then
             # TODO: Add a check here to test if on ec2 because if we're not on ec2 then this
             # upload will probably not work correctly
             upload_docs=1


### PR DESCRIPTION
Executorch team reports a flaky issue on their PRs where the Linux job tries to upload non-existing docs artifacts and fails 
[T162571560](https://www.internalfb.com/intern/tasks/?t=162571560).  The upload logic wrongly counts empty directories, so this change fixes the issue by counting only actual files.
