### PR TITLE
Revert "Release only change temporary fix aarch64 builds"

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -149,10 +149,6 @@ jobs:
           set -euxo pipefail
           source "${BUILD_ENV_FILE}"
           # shellcheck disable=SC2086
-          # temporary change to force rlease aarch64 vision and audio builds use pre and hence install 2.1.0 torch
-          if [[ "${ARCH}" == "aarch64" ]]; then
-            PIP_INSTALL_TORCH=${PIP_INSTALL_TORCH/"pip install"/"pip install --pre"}
-          fi
           ${CONDA_RUN} ${PIP_INSTALL_TORCH}
       - name: Run Pre-Script with Caching
         if: ${{ inputs.pre-script != '' }}


### PR DESCRIPTION
Reverts pytorch/test-infra#4544

The ``--pre`` argument is not required anymore. This was resolved by following PRs: https://github.com/pytorch/builder/pull/1519 and https://github.com/pytorch/builder/pull/1520

