### PR TITLE
Add linux-aarch64 as platfrom parameter

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -135,6 +135,8 @@ jobs:
           set -e
       - uses: ./test-infra/.github/actions/set-channel
       - uses: ./test-infra/.github/actions/setup-binary-builds
+        env:
+          PLATFORM: ${{ inputs.architecture == 'aarch64'  && 'linux-aarch64' || ''}}
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}

--- a/tools/pkg-helpers/pytorch_pkg_helpers/__main__.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/__main__.py
@@ -42,7 +42,10 @@ def parse_args() -> argparse.Namespace:
         "--platform",
         help="Platform to generate for",
         type=str,
-        default=sys.platform,
+        default= (
+            sys.platform if os.getenv("PLATFORM", sys.platform) == ""
+            else os.getenv("PLATFORM", sys.platform)
+            ),
     )
     parser.add_argument(
         "--gpu-arch-version",

--- a/tools/pkg-helpers/pytorch_pkg_helpers/cuda.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/cuda.py
@@ -22,7 +22,7 @@ def get_cuda_variables(
     version_suffix = ""
     pytorch_version_suffix = ""
     wheel_dir = ""
-    if package_type == "wheel" and platform != "darwin":
+    if package_type == "wheel" and platform != "darwin" and platform != "linux-aarch64":
         version_suffix = f"+{gpu_arch_version}"
         pytorch_version_suffix = f"+{gpu_arch_version}"
         wheel_dir = f"{gpu_arch_version}/"

--- a/tools/pkg-helpers/pytorch_pkg_helpers/version.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/version.py
@@ -104,7 +104,7 @@ def get_version_variables(
 ) -> List[str]:
     version = PytorchVersion(
         gpu_arch_version=gpu_arch_version,
-        no_build_suffix=(platform == "darwin" or package_type == "conda"),
+        no_build_suffix=(platform == "darwin" or platform == "linux-aarch64" or package_type == "conda"),
         base_build_version=base_build_version,
     )
     output_version = version.get_nightly_version()

--- a/tools/pkg-helpers/tests/test_cuda.py
+++ b/tools/pkg-helpers/tests/test_cuda.py
@@ -22,6 +22,15 @@ def test_cuda_variables_cpu_wheel(platform):
     ]
 
 
+@pytest.mark.parametrize("platform", ["linux-aarch64"])
+def test_cuda_variables_cpu_wheel(platform):
+    assert get_cuda_variables("wheel", platform, "cpu") == [
+        "export VERSION_SUFFIX=''",
+        "export PYTORCH_VERSION_SUFFIX=''",
+        "export WHEEL_DIR=''",
+    ]
+
+
 @pytest.mark.parametrize("platform", ["linux", "win32"])
 def test_cuda_variables_cpu_conda(platform):
     assert get_cuda_variables("conda", platform, "cpu") == [


### PR DESCRIPTION
We want linux-aarch64 builds follow same naming scheme as previous manylinux releases and similar to macos builds.
no architecture in version since cpu only.

Current (wrong):
``
torchvision-0.16.0+cpu-cp39-cp39-linux_aarch64.whl
``

Should be:
``
torchvision-0.16.0-cp39-cp39-linux_aarch64.whl
``

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1b3d83a</samp>

This pull request adds support for building wheels for the ARM architecture on Linux. It does so by using the `PLATFORM` environment variable to pass the platform information from the workflow to the Python scripts, and by adjusting the wheel name logic to skip unnecessary suffixes for the `linux-aarch64` platform.