### PR TITLE
Add guard for nvidia-docker2 package installation

### DIFF
--- a/.github/actions/setup-nvidia/action.yml
+++ b/.github/actions/setup-nvidia/action.yml
@@ -42,6 +42,12 @@ runs:
           install_nvidia_docker2_ubuntu20() {
               (
                   set -x
+                  # Install nvidia-driver package if not installed
+                  status="$(dpkg-query -W --showformat='${db:Status-Status}' nvidia-docker2 2>&1)"
+                  if [ ! $? = 0 ] || [ ! "$status" = installed ]; then
+                    sudo apt-get install -y nvidia-docker2
+                    sudo systemctl restart docker
+                  fi
               )
           }
 


### PR DESCRIPTION
Install nvidia-docker package if its not installed
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed85efa</samp>

Add a step to the `setup-nvidia` action to install `nvidia-docker2` and restart Docker. This enables GPU support for Docker containers in the GPU testing workflow.