### PR TITLE
[TorchFix] Change how weights are imported for TorchVision pretrained codemod

### DIFF
--- a/tools/torchfix/tests/fixtures/vision/checker/pretrained.py
+++ b/tools/torchfix/tests/fixtures/vision/checker/pretrained.py
@@ -14,6 +14,6 @@ pretrained = random.choice([False, True])
 torchvision.models.resnet50(pretrained=pretrained)
 
 # ok
-from torchvision.prototype.models import ResNet50_Weights
+from torchvision.models import ResNet50_Weights
 torchvision.models.resnet50(weights=ResNet50_Weights.IMAGENET1K_V1)
 torchvision.models.resnet50(weights=None)

--- a/tools/torchfix/tests/fixtures/vision/codemod/pretrained.py.out
+++ b/tools/torchfix/tests/fixtures/vision/codemod/pretrained.py.out
@@ -1,21 +1,20 @@
 import torchvision
 import random
-from torchvision.models.segmentation import DeepLabV3_ResNet50_Weights, deeplabv3_resnet50
-from torchvision.models import MobileNet_V3_Large_Weights, ResNet50_Weights
-from torchvision.models.detection import SSDLite320_MobileNet_V3_Large_Weights
+from torchvision.models.segmentation import deeplabv3_resnet50
+from torchvision import models
 
-torchvision.models.resnet50(weights=ResNet50_Weights.IMAGENET1K_V1)
-torchvision.models.resnet50(weights=ResNet50_Weights.IMAGENET1K_V1)
+torchvision.models.resnet50(weights=models.ResNet50_Weights.IMAGENET1K_V1)
+torchvision.models.resnet50(weights=models.ResNet50_Weights.IMAGENET1K_V1)
 torchvision.models.resnet50(weights=None)
 torchvision.models.resnet50(weights=None)
 
-torchvision.models.segmentation.deeplabv3_resnet50(weights=DeepLabV3_ResNet50_Weights.COCO_WITH_VOC_LABELS_V1)
-torchvision.models.segmentation.deeplabv3_resnet50(weights=DeepLabV3_ResNet50_Weights.COCO_WITH_VOC_LABELS_V1)
-deeplabv3_resnet50(weights=DeepLabV3_ResNet50_Weights.COCO_WITH_VOC_LABELS_V1)
-deeplabv3_resnet50(weights=DeepLabV3_ResNet50_Weights.COCO_WITH_VOC_LABELS_V1)
+torchvision.models.segmentation.deeplabv3_resnet50(weights=models.segmentation.DeepLabV3_ResNet50_Weights.COCO_WITH_VOC_LABELS_V1)
+torchvision.models.segmentation.deeplabv3_resnet50(weights=models.segmentation.DeepLabV3_ResNet50_Weights.COCO_WITH_VOC_LABELS_V1)
+deeplabv3_resnet50(weights=models.segmentation.DeepLabV3_ResNet50_Weights.COCO_WITH_VOC_LABELS_V1)
+deeplabv3_resnet50(weights=models.segmentation.DeepLabV3_ResNet50_Weights.COCO_WITH_VOC_LABELS_V1)
 
-torchvision.models.detection.ssdlite320_mobilenet_v3_large(weights=SSDLite320_MobileNet_V3_Large_Weights.COCO_V1, weights_backbone=MobileNet_V3_Large_Weights.IMAGENET1K_V1)
-torchvision.models.detection.ssdlite320_mobilenet_v3_large(weights_backbone=MobileNet_V3_Large_Weights.IMAGENET1K_V1)
+torchvision.models.detection.ssdlite320_mobilenet_v3_large(weights=models.detection.SSDLite320_MobileNet_V3_Large_Weights.COCO_V1, weights_backbone=models.MobileNet_V3_Large_Weights.IMAGENET1K_V1)
+torchvision.models.detection.ssdlite320_mobilenet_v3_large(weights_backbone=models.MobileNet_V3_Large_Weights.IMAGENET1K_V1)
 
 pretrained = random.choice([False, True])
 # can't codemod

--- a/tools/torchfix/tests/fixtures/vision/codemod/pretrained_models_import.py
+++ b/tools/torchfix/tests/fixtures/vision/codemod/pretrained_models_import.py
@@ -1,0 +1,6 @@
+# To check for no extra imports when models already imported
+from torchvision import models
+
+models.resnet50(pretrained=True)
+models.resnet50(pretrained=False)
+models.segmentation.deeplabv3_resnet50(pretrained=True)

--- a/tools/torchfix/tests/fixtures/vision/codemod/pretrained_models_import.py.out
+++ b/tools/torchfix/tests/fixtures/vision/codemod/pretrained_models_import.py.out
@@ -1,0 +1,6 @@
+# To check for no extra imports when models already imported
+from torchvision import models
+
+models.resnet50(weights=models.ResNet50_Weights.IMAGENET1K_V1)
+models.resnet50(weights=None)
+models.segmentation.deeplabv3_resnet50(weights=models.segmentation.DeepLabV3_ResNet50_Weights.COCO_WITH_VOC_LABELS_V1)

--- a/tools/torchfix/tests/fixtures/vision/codemod/pretrained_none_import.py
+++ b/tools/torchfix/tests/fixtures/vision/codemod/pretrained_none_import.py
@@ -1,0 +1,5 @@
+# To check for no extra imports when weights is None
+import torchvision
+
+torchvision.models.resnet50(pretrained=False)
+torchvision.models.segmentation.deeplabv3_resnet50(pretrained=False)

--- a/tools/torchfix/tests/fixtures/vision/codemod/pretrained_none_import.py.out
+++ b/tools/torchfix/tests/fixtures/vision/codemod/pretrained_none_import.py.out
@@ -1,0 +1,5 @@
+# To check for no extra imports when weights is None
+import torchvision
+
+torchvision.models.resnet50(weights=None)
+torchvision.models.segmentation.deeplabv3_resnet50(weights=None)

--- a/tools/torchfix/torchfix/common.py
+++ b/tools/torchfix/torchfix/common.py
@@ -3,7 +3,7 @@ import sys
 import libcst as cst
 from libcst.metadata import QualifiedNameProvider, WhitespaceInclusivePositionProvider
 from libcst.codemod.visitors import ImportItem
-from typing import Optional, List, Union
+from typing import Optional, List, Set, Union
 from abc import ABC
 
 IS_TTY = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
@@ -44,7 +44,7 @@ class TorchVisitor(cst.BatchableCSTVisitor, ABC):
 
     def __init__(self) -> None:
         self.violations: List[LintViolation] = []
-        self.needed_imports: List[ImportItem] = []
+        self.needed_imports: Set[ImportItem] = set()
 
     @staticmethod
     def get_specific_arg(

--- a/tools/torchfix/torchfix/visitors/vision/__init__.py
+++ b/tools/torchfix/torchfix/visitors/vision/__init__.py
@@ -168,6 +168,12 @@ class TorchVisionDeprecatedPretrainedVisitor(TorchVisitor):
                 weights_arg = cst.ensure_type(
                     cst.parse_expression(f"f({new_arg_name}={weights_str})"), cst.Call
                 ).args[0]
+                self.needed_imports.add(
+                    ImportItem(
+                        module_name="torchvision",
+                        obj_name="models",
+                    )
+                )
             elif cst.ensure_type(old_arg.value, cst.Name).value == "False":
                 weights_arg = cst.ensure_type(
                     cst.parse_expression(f"f({new_arg_name}=None)"), cst.Call
@@ -212,15 +218,9 @@ class TorchVisionDeprecatedPretrainedVisitor(TorchVisitor):
                 replacement_args[pos] = new_pretrained_backbone_arg
                 has_replacement = True
 
-            replacement = None
-            if has_replacement:
-                replacement = node.with_changes(args=replacement_args)
-                self.needed_imports.append(
-                    ImportItem(
-                        module_name="torchvision",
-                        obj_name="models",
-                    )
-                )
+            replacement = (
+                node.with_changes(args=replacement_args) if has_replacement else None
+            )
             if message is not None:
                 position_metadata = self.get_metadata(
                     cst.metadata.WhitespaceInclusivePositionProvider, node


### PR DESCRIPTION
A follow-up to https://github.com/pytorch/test-infra/pull/4559

Meta-internal autodeps feature has issues with imports like `from torchvision.models import MobileNet_V3_Large_Weights`, so changed the logic to just do `from torchvision import models` (if not yet imported) and then use full name from `models` for the weights.