### PR TITLE
Automate replacing test-infra release branch

### DIFF
--- a/release/cut-release-branch.sh
+++ b/release/cut-release-branch.sh
@@ -62,7 +62,7 @@ for branch in "release/${RELEASE_VERSION}" "orig/release/${RELEASE_VERSION}"; do
 
             if [[ "${DRY_RUN:-enabled}" == "disabled" ]]; then
                 git add .github/workflows/*.yml
-                git commit -m "[RELEASE-ONLY CHANGES] Branch Cut for Release {RELEASE_VERSION}"
+                git commit -m "[RELEASE-ONLY CHANGES] Branch Cut for Release ${RELEASE_VERSION}"
                 git push "${GIT_REMOTE}" "${branch}"
             fi
         )


### PR DESCRIPTION
Thanks to @atalman works in https://github.com/pytorch/test-infra/pull/4515 and @osalpekar example in https://github.com/pytorch/vision/pull/7929/files, this change applies the same step to test-infra to automate its release branch.

From what I see in https://github.com/pytorch/test-infra/commits/release/2.1, this seems to be the only required steps to replace main with release branch.

### Testing

Cutting release branch for test-infra in my own fork repo https://github.com/huydhn/test-infra/commits/release/2.1