### PR TITLE
Increase the max_available for linux.g5.4xlarge.nvidia.gpu to 800

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -79,7 +79,7 @@ runner_types:
     disk_size: 150
     instance_type: g5.4xlarge
     is_ephemeral: false
-    max_available: 600
+    max_available: 800
     os: linux
   linux.large:
     disk_size: 15


### PR DESCRIPTION
![Screenshot 2023-09-15 at 21 10 22](https://github.com/pytorch/test-infra/assets/4520845/44640d53-e9cd-4be8-bcc4-e7c2b875befa)
