### PR TITLE
[TorchFix] Add test for non-static SynchronizedDataLoader case

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,8 @@ on:
     tags:
       - v*
   pull_request:
+    paths:
+      - '!tools/torchfix/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ on:
       - mypy.ini
       - '**.py'
       - '**requirements.txt'
+      - '!tools/torchfix/**'
   push:
     branches:
       - main
@@ -13,6 +14,7 @@ on:
       - mypy.ini
       - '**.py'
       - '**requirements.txt'
+      - '!tools/torchfix/**'
 
 jobs:
   test-tools:

--- a/tools/torchfix/tests/fixtures/performance/checker/dataloader.py
+++ b/tools/torchfix/tests/fixtures/performance/checker/dataloader.py
@@ -5,3 +5,10 @@ async_dataloader = torch.utils.data.DataLoader(dataset, batch_size=10, num_worke
 sync_again_dataloader = torch.utils.data.DataLoader(dataset, batch_size=10, num_workers=0)
 sync3_dataloader = torch.utils.data.DataLoader(dataset, 10, False, None, None, 0)
 async2_dataloader = torch.utils.data.DataLoader(dataset, 10, False, None, None, 2)
+
+# For these we can't determine statically.
+# The checker should be silent on these to reduce noise.
+num_workers = 0
+sync_dyn_dataloader = torch.utils.data.DataLoader(dataset, batch_size=10, num_workers=num_workers)
+num_workers = 4
+async_dyn_dataloader = torch.utils.data.DataLoader(dataset, batch_size=10, num_workers=num_workers)


### PR DESCRIPTION
Verify that TorchSynchronizedDataLoaderVisitor doesn't create noise when it's not possible to determine statically.

Also don't run Test tools / linux-job and lintrunner on TorchFix PRs.