### PR TITLE
Fix linux validation script for torchtext

### DIFF
--- a/.github/workflows/validate-domain-library.yml
+++ b/.github/workflows/validate-domain-library.yml
@@ -97,7 +97,7 @@ jobs:
         export ENV_NAME="conda-env-${{ github.run_id }}"
         export SMOKE_TEST="${{ inputs.smoke_test }}"
         if [[ ${{inputs.install_torch}} == 'true' ]]; then
-          source ../test-infra/.github/scripts/install_torch.sh
+          source /test-infra/.github/scripts/install_torch.sh
         fi
         eval $SMOKE_TEST
   validate-windows:


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a88892</samp>

Fix the path to `install_torch.sh` in the workflow for validating domain libraries. Use an absolute path instead of a relative path to avoid errors due to different working directories.
