### PR TITLE
[dr ci] Use rockset for merge bases

### DIFF
--- a/.github/scripts/get_merge_base_info.py
+++ b/.github/scripts/get_merge_base_info.py
@@ -70,9 +70,7 @@ def upload_merge_base_info(sha: str) -> None:
 
 
 if __name__ == "__main__":
-    failed_test_shas = [x["head_sha"] for x in query_rockset(FAILED_TEST_SHAS_QUERY)][
-        :100
-    ]
+    failed_test_shas = [x["head_sha"] for x in query_rockset(FAILED_TEST_SHAS_QUERY)]
     interval = 100
     print(f"There are {len(failed_test_shas)}, uploading in batches of {interval}")
     for i in range(0, len(failed_test_shas), interval):

--- a/.github/scripts/get_merge_base_info.py
+++ b/.github/scripts/get_merge_base_info.py
@@ -82,6 +82,7 @@ def upload_merge_base_info(shas: List[str]) -> None:
                     "merge_base": merge_base,
                     "changed_files": changed_files.splitlines(),
                     "merge_base_commit_date": timestamp,
+                    "repo": "pytorch/pytorch",
                 }
             )
         except Exception as e:

--- a/.github/scripts/get_merge_base_info.py
+++ b/.github/scripts/get_merge_base_info.py
@@ -62,7 +62,7 @@ def upload_merge_base_info(sha: str) -> None:
             "changed_files": changed_files.splitlines(),
             "merge_base_commit_date": timestamp,
         }
-        upload_to_s3(s3,
+        upload_to_s3(
             "ossci-metrics", f"merge_bases/pytorch/{sha}", json.dumps(t, indent=2)
         )
     except Exception as e:

--- a/.github/scripts/get_merge_base_info.py
+++ b/.github/scripts/get_merge_base_info.py
@@ -1,15 +1,10 @@
-import json
 import subprocess
-from pathlib import Path
-from typing import List, Any
-from multiprocessing import Pool
 from datetime import datetime
+from multiprocessing import Pool
+from pathlib import Path
+from typing import List
 
-from rockset_utils import query_rockset
-import boto3
-
-s3 = boto3.resource("s3")
-
+from rockset_utils import query_rockset, remove_from_rockset, upload_to_rockset
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -19,7 +14,33 @@ SELECT
 FROM
     commons.failed_tests_run t
     join workflow_job j on t.job_id = j.id
+    left outer join commons.merge_bases mb on j.head_sha = mb.sha
+where
+    mb.merge_base is null
 """
+
+
+DUP_MERGE_BASE_INFO = """
+select
+    ARRAY_AGG(m._id) as ids
+from
+    commons.merge_bases m
+group by
+    m.sha
+having
+    count(*) > 1
+"""
+
+
+def dedup_merge_base_info() -> None:
+    ids = []
+    for item in query_rockset(DUP_MERGE_BASE_INFO):
+        for val in item.values():
+            ids.extend(val)
+    interval = 500
+
+    for i in range(0, len(ids), interval):
+        remove_from_rockset("merge_bases", ids[i : i + interval])
 
 
 def run_command(command: str) -> str:
@@ -34,51 +55,59 @@ def run_command(command: str) -> str:
     )
 
 
-def upload_to_s3(bucket: str, key: str, body: str):
-    s3.Object(bucket, key).put(Body=body, ContentType="application/json")
-
-
-def pull_shas(shas: List[str]):
+def pull_shas(shas: List[str]) -> None:
     all_shas = " ".join(shas)
     run_command(
         f"git -c protocol.version=2 fetch --no-tags --prune --quiet --no-recurse-submodules origin {all_shas}"
     )
 
 
-def upload_merge_base_info(sha: str) -> None:
-    try:
-        merge_base = run_command(f"git merge-base main {sha}")
-        if merge_base == sha:
-            # The commit was probably already on main, so take the previous
-            # commit as the merge base
-            merge_base = run_command(f"git rev-parse {sha}^")
-        changed_files = run_command(f"git diff {sha} {merge_base} --name-only")
-        unix_timestamp = run_command(f"git show --no-patch --format=%ct {merge_base}")
-        timestamp = datetime.utcfromtimestamp(int(unix_timestamp)).isoformat() + "Z"
+def upload_merge_base_info(shas: List[str]) -> None:
+    docs = []
+    for sha in shas:
+        try:
+            merge_base = run_command(f"git merge-base main {sha}")
+            if merge_base == sha:
+                # The commit was probably already on main, so take the previous
+                # commit as the merge base
+                merge_base = run_command(f"git rev-parse {sha}^")
+            changed_files = run_command(f"git diff {sha} {merge_base} --name-only")
+            unix_timestamp = run_command(
+                f"git show --no-patch --format=%ct {merge_base}"
+            )
+            timestamp = datetime.utcfromtimestamp(int(unix_timestamp)).isoformat() + "Z"
+            docs.append(
+                {
+                    "sha": sha,
+                    "merge_base": merge_base,
+                    "changed_files": changed_files.splitlines(),
+                    "merge_base_commit_date": timestamp,
+                }
+            )
+        except Exception as e:
+            return e
 
-        t = {
-            "sha": sha,
-            "merge_base": merge_base,
-            "changed_files": changed_files.splitlines(),
-            "merge_base_commit_date": timestamp,
-        }
-        upload_to_s3(
-            "ossci-metrics", f"merge_bases/pytorch/{sha}", json.dumps(t, indent=2)
-        )
-    except Exception as e:
-        return e
+    upload_to_rockset(collection="merge_bases", docs=docs, workspace="commons")
 
 
 if __name__ == "__main__":
+    dedup_merge_base_info()
+
     failed_test_shas = [x["head_sha"] for x in query_rockset(FAILED_TEST_SHAS_QUERY)]
     interval = 100
-    print(f"There are {len(failed_test_shas)}, uploading in batches of {interval}")
+    print(
+        f"There are {len(failed_test_shas)} shas, uploading in intervals of {interval}"
+    )
+    pool = Pool(20)
+    errors = []
     for i in range(0, len(failed_test_shas), interval):
         pull_shas(failed_test_shas[i : i + interval])
-    errors = []
-    pool = Pool(20)
-    for sha in failed_test_shas:
-        errors.append(pool.apply_async(upload_merge_base_info, args=(sha,)))
+        errors.append(
+            pool.apply_async(
+                upload_merge_base_info, args=(failed_test_shas[i : i + interval],)
+            )
+        )
+    print("done pulling")
     pool.close()
     pool.join()
     for i in errors:

--- a/.github/scripts/rockset_utils.py
+++ b/.github/scripts/rockset_utils.py
@@ -1,7 +1,15 @@
+from functools import lru_cache
 import os
 from typing import Any, Dict, List, Optional
 
 import rockset  # type: ignore[import]
+
+
+@lru_cache
+def get_rockset_client():
+    return rockset.RocksetClient(
+        host="api.usw2a1.rockset.com", api_key=os.environ["ROCKSET_API_KEY"]
+    )
 
 
 def query_rockset(
@@ -20,11 +28,21 @@ def query_rockset(
 def upload_to_rockset(
     collection: str, docs: List[Any], workspace: str = "commons"
 ) -> None:
-    client = rockset.RocksetClient(
-        host="api.usw2a1.rockset.com", api_key=os.environ["ROCKSET_API_KEY"]
-    )
+    client = get_rockset_client()
     client.Documents.add_documents(
         collection=collection,
         data=docs,
+        workspace=workspace,
+    )
+
+
+def remove_from_rockset(
+    collection: str, ids: List[str], workspace: str = "commons"
+) -> None:
+    client = get_rockset_client()
+    ids_to_map = [{"id": id} for id in ids]
+    client.Documents.delete_documents(
+        collection=collection,
+        data=ids_to_map,
         workspace=workspace,
     )

--- a/.github/workflows/update_test_file_ratings.yml
+++ b/.github/workflows/update_test_file_ratings.yml
@@ -42,8 +42,6 @@ jobs:
           python3 test-infra/.github/scripts/get_merge_base_info.py
         env:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Generate file test ratings
         run: |

--- a/.github/workflows/update_test_file_ratings.yml
+++ b/.github/workflows/update_test_file_ratings.yml
@@ -42,6 +42,8 @@ jobs:
           python3 test-infra/.github/scripts/get_merge_base_info.py
         env:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Generate file test ratings
         run: |

--- a/.github/workflows/update_test_file_ratings.yml
+++ b/.github/workflows/update_test_file_ratings.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/update_test_file_ratings.yml"
       - ".github/scripts/calculate_file_test_rating.py"
+      - ".github/scripts/get_merge_base_info.py"
   schedule:
     - cron: 5 11 * * *  # At 11:05 UTC every day or about 4am PT
 

--- a/torchci/lib/fetchCommit.ts
+++ b/torchci/lib/fetchCommit.ts
@@ -52,37 +52,3 @@ export default async function fetchCommit(
     jobs: await removeCancelledJobAfterRetry<JobData>(jobs),
   };
 }
-
-export async function fetchBaseCommitTimeStamp(
-  baseCommitSha: string
-): Promise<string> {
-  if (baseCommitSha === "") {
-    return "";
-  }
-
-  const rocksetClient = getRocksetClient();
-  // Decide to get the commit timestamp from merges collection instead because
-  // it's small. But this only works for base commits in trunk. May be we can
-  // refactor this later on to a proper query lambda that handles any commits
-  const rocksetQuery = await rocksetClient.queries.query({
-    sql: {
-      query:
-        "SELECT _event_time AS time FROM commons.merges WHERE merge_commit_sha = :sha",
-      parameters: [
-        {
-          name: "sha",
-          type: "string",
-          value: baseCommitSha,
-        },
-      ],
-      default_row_limit: 1,
-    },
-  });
-
-  if (rocksetQuery.results === undefined || rocksetQuery.results.length === 0) {
-    return "";
-  }
-
-  // There is at most one record
-  return rocksetQuery.results[0].time;
-}

--- a/torchci/lib/s3.ts
+++ b/torchci/lib/s3.ts
@@ -1,11 +1,19 @@
-import { S3Client } from "@aws-sdk/client-s3";
+import { PutObjectCommand, S3 } from "@aws-sdk/client-s3";
 
-const s3client = new S3Client({
-  region: "us-east-1",
-  credentials: {
-    accessKeyId: process.env.OUR_AWS_ACCESS_KEY_ID!,
-    secretAccessKey: process.env.OUR_AWS_SECRET_ACCESS_KEY!,
-  },
-});
+export async function uploadToS3(bucket: string, key: string, body: string) {
+  const client = new S3({
+    region: "us-east-1",
+    credentials: {
+      accessKeyId: process.env.OUR_AWS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.OUR_AWS_SECRET_ACCESS_KEY!,
+    },
+  });
 
-export default s3client;
+  try {
+    const data = await client.send(
+      new PutObjectCommand({ Bucket: bucket, Key: key, Body: body })
+    );
+  } catch (error) {
+    console.log(error);
+  }
+}

--- a/torchci/lib/s3.ts
+++ b/torchci/lib/s3.ts
@@ -1,19 +1,11 @@
-import { PutObjectCommand, S3 } from "@aws-sdk/client-s3";
+import { S3Client } from "@aws-sdk/client-s3";
 
-export async function uploadToS3(bucket: string, key: string, body: string) {
-  const client = new S3({
-    region: "us-east-1",
-    credentials: {
-      accessKeyId: process.env.OUR_AWS_ACCESS_KEY_ID!,
-      secretAccessKey: process.env.OUR_AWS_SECRET_ACCESS_KEY!,
-    },
-  });
+const s3client = new S3Client({
+  region: "us-east-1",
+  credentials: {
+    accessKeyId: process.env.OUR_AWS_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.OUR_AWS_SECRET_ACCESS_KEY!,
+  },
+});
 
-  try {
-    const data = await client.send(
-      new PutObjectCommand({ Bucket: bucket, Key: key, Body: body })
-    );
-  } catch (error) {
-    console.log(error);
-  }
-}
+export default s3client;

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -202,7 +202,7 @@ where
       });
     } else {
       pr_info.merge_base = rocksetMergeBase.merge_base;
-      pr_info.merge_base = rocksetMergeBase.merge_base_commit_date;
+      pr_info.merge_base_date = rocksetMergeBase.merge_base_commit_date;
     }
   });
   rocksetClient.documents.addDocuments("commons", "merge_bases", {

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -157,6 +157,7 @@ from
 where
     ARRAY_CONTAINS(SPLIT(:shas, ','), sha)
     and merge_base_commit_date is not null
+    and repo = :repo
   `;
   const rocksetClient = getRocksetClient();
 
@@ -172,6 +173,11 @@ where
               value: Array.from(workflowsByPR.values())
                 .map((v) => v.head_sha)
                 .join(","),
+            },
+            {
+              name: "repo",
+              type: "string",
+              value: `${OWNER}/${repo}`,
             },
           ],
         },
@@ -199,6 +205,7 @@ where
         merge_base: pr_info.merge_base,
         changed_files: diff.data.files?.map((e) => e.filename),
         merge_base_commit_date: pr_info.merge_base_date ?? "",
+        repo: `${OWNER}/${repo}`,
       });
     } else {
       pr_info.merge_base = rocksetMergeBase.merge_base;

--- a/torchci/test/drciBot.test.ts
+++ b/torchci/test/drciBot.test.ts
@@ -174,8 +174,13 @@ describe("verify-drci-functionality", () => {
       .reply(200, { results: [] })
       .post((url) => url.includes("commit_failed_jobs"))
       .reply(200, { results: [] })
-      .post((url) => url.includes("self/queries")) // This is the query to get the base commit date
-      .reply(200, { results: [] });
+      .post(
+        (url) => url.includes("self/queries"),
+        (body) => JSON.stringify(body).includes("merge_base_commit_date")
+      )
+      .reply(200, { results: [] }) // query to get merge bases
+      .post((url) => url.includes("merge_bases"))
+      .reply(200, { results: [] }); // query to insert back to rockset
 
     const scope = nock("https://api.github.com")
       .post(


### PR DESCRIPTION
Put merge base date info into rockset, also query rockset for merge base info if possible to reduce number of github api calls.  If the info can't be found, it still uses the gh api

Dedup merge base table to fix errors that might happen