### PR TITLE
[dr ci] Include workflow name in job name

### DIFF
--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -314,3 +314,7 @@ export async function hasSimilarFailures(
 
   return false;
 }
+
+export function getJobFullName(job: RecentWorkflowsData): string {
+  return job.workflow_name ? `${job.workflow_name} / ${job.name}` : job.name!;
+}

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -30,8 +30,9 @@ export interface JobData extends BasicJobData {
 
 // Used by Dr.CI
 export interface RecentWorkflowsData extends BasicJobData {
-  // only included in this is a job and not a workflow, if it is a workflow, the name is in the name field
+  // only included if this is a job and not a workflow, if it is a workflow, the name is in the name field
   workflow_id?: string;
+  workflow_name?: string;
   id: string;
   completed_at: string | null;
   html_url: string;

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -15,6 +15,7 @@ import {
   FLAKY_RULES_JSON,
   HUD_URL,
   hasSimilarFailures,
+  getJobFullName,
 } from "lib/drciUtils";
 import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
 import { Octokit } from "octokit";
@@ -289,9 +290,13 @@ function constructResultsJobsSections(
   }
 
   output += "<p>\n\n"; // Two newlines are needed for bullts below to be formattec correctly
-  const jobsSorted = jobs.sort((a, b) => a.name!.localeCompare(b.name!));
+  const jobsSorted = jobs.sort((a, b) =>
+    getJobFullName(a).localeCompare(getJobFullName(b))
+  );
   for (const job of jobsSorted) {
-    output += `* [${job.name}](${hud_pr_url}#${job.id}) ([gh](${job.html_url}))\n`;
+    output += `* [${getJobFullName(job)}](${hud_pr_url}#${job.id}) ([gh](${
+      job.html_url
+    }))\n`;
   }
   output += "</p></details>";
   return output;
@@ -541,11 +546,11 @@ export function reorganizeWorkflows(
         merge_base_date: "",
       });
     }
-    const name = workflow.name!;
-    const existing_job = workflowsByPR.get(pr_number)?.jobs.get(name);
+    const key = getJobFullName(workflow);
+    const existing_job = workflowsByPR.get(pr_number)?.jobs.get(key);
     if (!existing_job || existing_job.id < workflow.id!) {
       // if rerun, choose the job with the larger id as that is more recent
-      workflowsByPR.get(pr_number)!.jobs.set(name, workflow);
+      workflowsByPR.get(pr_number)!.jobs.set(key, workflow);
     }
   }
 

--- a/torchci/rockset/commons/__sql/recent_pr_workflows_query.sql
+++ b/torchci/rockset/commons/__sql/recent_pr_workflows_query.sql
@@ -22,7 +22,7 @@ WITH recent_shas AS (
 SELECT
   w.id AS workflow_id,
   j.id,
-  j.name,
+  CONCAT(w.name, ' / ', j.name) as name,
   j.conclusion,
   j.completed_at,
   j.html_url,

--- a/torchci/rockset/commons/__sql/recent_pr_workflows_query.sql
+++ b/torchci/rockset/commons/__sql/recent_pr_workflows_query.sql
@@ -21,8 +21,9 @@ WITH recent_shas AS (
 )
 SELECT
   w.id AS workflow_id,
+  w.name as workflow_name,
   j.id,
-  CONCAT(w.name, ' / ', j.name) as name,
+  j.name as name,
   j.conclusion,
   j.completed_at,
   j.html_url,
@@ -39,6 +40,7 @@ FROM
 UNION
 SELECT
   null AS workflow_id,
+  null as workflow_name,
   w.id,
   w.name AS name,
   w.conclusion,

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -23,7 +23,7 @@
     "issue_query": "e4d338de89980044",
     "failure_samples_query": "18e7e696b4949f05",
     "num_commits_master": "e4a864147cf3bf44",
-    "recent_pr_workflows_query": "6f1186760435f452",
+    "recent_pr_workflows_query": "cea6442ca913682d",
     "reverted_prs_with_reason": "751f01cba16364f0",
     "unclassified": "1b31a2d8f4ab7230",
     "test_insights_overview": "42dbd5232f45fd53",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -23,7 +23,7 @@
     "issue_query": "e4d338de89980044",
     "failure_samples_query": "18e7e696b4949f05",
     "num_commits_master": "e4a864147cf3bf44",
-    "recent_pr_workflows_query": "1a016c5a69fb79a2",
+    "recent_pr_workflows_query": "6f1186760435f452",
     "reverted_prs_with_reason": "751f01cba16364f0",
     "unclassified": "1b31a2d8f4ab7230",
     "test_insights_overview": "42dbd5232f45fd53",

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -74,6 +74,7 @@ const failedAFailedRetry = {
 
 const failedB = {
   name: "something",
+  workflow_name: "workflow_name_dummy",
   conclusion: "failure",
   completed_at: "2022-07-13T19:34:03Z",
   html_url: "a",
@@ -284,7 +285,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     expect(failureInfo.includes("3 New Failures, 1 Pending")).toBeTruthy();
     expect(failureInfo.includes(failedJobName)).toBeTruthy();
     const expectedFailureOrder = `* [Lint](hudlink#1) ([gh](a))
-* [something](hudlink#1) ([gh](a))
+* [workflow_name_dummy / something](hudlink#1) ([gh](a))
 * [z-docs / build-docs (cpp)](hudlink#1) ([gh](a))`;
     expect(failureInfo.includes(expectedFailureOrder)).toBeTruthy();
   });
@@ -543,6 +544,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
       "The following job failed but was present on the merge base",
       "The following job failed but was likely due to flakiness present on trunk and has been marked as unstable",
       failedA.name,
+      failedB.workflow_name,
       failedB.name,
       failedC.name,
       unstableA.name,
@@ -563,6 +565,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     const expectToContain = [
       ":hourglass_flowing_sand:",
       "1 Pending, 3 Unrelated Failures",
+      failedB.workflow_name,
       failedB.name,
       failedC.name,
       unstableA.name,

--- a/torchci/test/drciUtils.test.ts
+++ b/torchci/test/drciUtils.test.ts
@@ -1,4 +1,8 @@
-import { hasSimilarFailures, querySimilarFailures } from "../lib/drciUtils";
+import {
+  getJobFullName,
+  hasSimilarFailures,
+  querySimilarFailures,
+} from "../lib/drciUtils";
 import * as searchUtils from "../lib/searchUtils";
 import { JobData, RecentWorkflowsData } from "lib/types";
 import nock from "nock";
@@ -265,5 +269,19 @@ describe("Test various utils used by Dr.CI", () => {
         "TESTING" as unknown as Client
       )
     ).toEqual(true);
+  });
+
+  test("test getJobFullName", async () => {
+    let job: RecentWorkflowsData = {
+      id: "",
+      name: "name",
+      completed_at: null,
+      html_url: "",
+      head_sha: "",
+      failure_captures: [],
+    };
+    expect(getJobFullName(job)).toEqual("name");
+    job.workflow_name = "workflow";
+    expect(getJobFullName(job)).toEqual("workflow / name");
   });
 });


### PR DESCRIPTION
We have jobs with the same name but in different workflows sometimes (ex rocm and windows builds), and one will override the other in dr ci but still show up on hud (and mergebot)