### PR TITLE
rename models in benchmark dashboard's model mapping

### DIFF
--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -1712,9 +1712,9 @@ export function AugmentData(data: CompilerPerformanceData[]) {
         // _generate variants are good; they do E2E autoregressive
         // generation and will induce varying context length.
         "cm3leon_generate",
-        "nanogpt_generate",
+        "nanogpt",
         "hf_T5_generate",
-        "nanogpt_generate",
+        "nanogpt",
         // detection models are ok-ish; the good news is they call
         // nonzero internally and exercise dynamic shapes that way,
         // the bad news is we may not run enough iterations with
@@ -1743,12 +1743,12 @@ export function AugmentData(data: CompilerPerformanceData[]) {
     },
     blueberries: {
       torchbench: new Set([
-        "nanogpt_generate",
+        "nanogpt",
         "llama",
         "llama_v2_7b_16h",
         "sam",
         "clip",
-        "stable_diffusion",
+        "stable_diffusion_text_encoder",
         "hf_Whisper",
       ]),
     },


### PR DESCRIPTION
In https://github.com/pytorch/pytorch/commit/88ef126a93234903e4af26d792160862ca54c38e, I bumped the torchbench version, which includes some model names updates:
- nanogpt_generate -> nanogpt (also supports train now)
- stable_diffusion -> stable_diffusion_text_encoder (now we've also added the unet part of the model: https://github.com/pytorch/benchmark/commit/9cbeee3b54981760e977bed0faaff15379a4adef)

We need to update the model names for blueberries dashboard to track the new models