### PR TITLE
TD: Export TestClass correlations

### DIFF
--- a/.github/workflows/update_test_file_ratings.yml
+++ b/.github/workflows/update_test_file_ratings.yml
@@ -1,4 +1,4 @@
-name: Update test file ratings for TD experiment
+name: Update test file ratings for TD Heuristics
 
 on:
   pull_request:
@@ -56,6 +56,20 @@ jobs:
           API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
         with:
           source_file: "file_test_rating.json"
+          destination_repo: "pytorch/test-infra"
+          destination_folder: "stats"
+          destination_branch: generated-stats
+          user_email: "test-infra@pytorch.org"
+          user_name: "Pytorch Test Infra"
+          commit_message: "Updating file test rating"
+
+      - name: Push file test rating to test-infra repository
+        if: github.event_name != 'pull_request'
+        uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          source_file: "file_test_class_rating.json"
           destination_repo: "pytorch/test-infra"
           destination_folder: "stats"
           destination_branch: generated-stats

--- a/.github/workflows/update_test_file_ratings.yml
+++ b/.github/workflows/update_test_file_ratings.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
 
-      - name: Push file test rating to test-infra repository
+      - name: Push file to test file correlations to test-infra repository
         if: github.event_name != 'pull_request'
         uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
         env:
@@ -61,9 +61,9 @@ jobs:
           destination_branch: generated-stats
           user_email: "test-infra@pytorch.org"
           user_name: "Pytorch Test Infra"
-          commit_message: "Updating file test rating"
+          commit_message: "Updating file to test file correlations"
 
-      - name: Push file test rating to test-infra repository
+      - name: Push file to test class correlations to test-infra repository
         if: github.event_name != 'pull_request'
         uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
         env:
@@ -75,4 +75,4 @@ jobs:
           destination_branch: generated-stats
           user_email: "test-infra@pytorch.org"
           user_name: "Pytorch Test Infra"
-          commit_message: "Updating file test rating"
+          commit_message: "Updating file to test class correlations"

--- a/torchci/scripts/calculate_file_test_rating.py
+++ b/torchci/scripts/calculate_file_test_rating.py
@@ -92,6 +92,7 @@ def evaluate(failing_tests, merge_bases, rev_mapping, get_test_name_fn):
     print(f"median: {sorted(scores)[len(scores) // 2]}")
     print(f"within 10%: {(len([x for x in scores if x < .1]))/len(scores)}")
     print(f"# of failing tests: {len(all_failing_tests)}")
+    print()
 
 def get_test_file_name(test_row):
     return f"{test_row['invoking_file']}"

--- a/torchci/scripts/calculate_file_test_rating.py
+++ b/torchci/scripts/calculate_file_test_rating.py
@@ -109,7 +109,7 @@ def calculate_test_file_ratings(tests, merge_bases):
     return calculate_generic_test_ratings(
         tests,
         merge_bases,
-        get_test_fn=extract_test_file_name
+        get_test_name_fn=extract_test_file_name
         )
 
 
@@ -119,17 +119,17 @@ def calculate_test_class_ratings(tests, merge_bases):
     return calculate_generic_test_ratings(
         tests,
         merge_bases,
-        get_test_fn=extract_test_class_name
+        get_test_name_fn=extract_test_class_name
         )
 
 
-def calculate_generic_test_ratings(tests, merge_bases, get_test_fn):
+def calculate_generic_test_ratings(tests, merge_bases, get_test_name_fn):
     # Should return a mapping of changed file -> correlated test failures -> confidence score
 
     # Get a mapping of failing test -> list of shas that broke it
     failing_tests_to_sha = defaultdict(set)
     for test in tests:
-        failing_test = get_test_fn(test)
+        failing_test = get_test_name_fn(test)
         sha = test["head_sha"]
         failing_tests_to_sha[failing_test].add(sha)
 

--- a/torchci/scripts/calculate_file_test_rating.py
+++ b/torchci/scripts/calculate_file_test_rating.py
@@ -94,11 +94,10 @@ def evaluate(failing_tests, merge_bases, rev_mapping, get_test_name_fn):
     print(f"# of failing tests: {len(all_failing_tests)}")
     print()
 
-def get_test_file_name(test_row):
+def extract_test_file_name(test_row):
     return f"{test_row['invoking_file']}"
 
-def get_test_class_name(test_row):
-    # check if classname is none, blank, or "None"
+def extract_test_class_name(test_row):
     if test_row["classname"]:
         return f"{test_row['invoking_file']}::{test_row['classname']}"
     else:
@@ -110,7 +109,7 @@ def calculate_test_file_ratings(tests, merge_bases):
     return calculate_generic_test_ratings(
         tests,
         merge_bases,
-        get_test_fn=get_test_file_name
+        get_test_fn=extract_test_file_name
         )
 
 
@@ -120,7 +119,7 @@ def calculate_test_class_ratings(tests, merge_bases):
     return calculate_generic_test_ratings(
         tests,
         merge_bases,
-        get_test_fn=get_test_class_name
+        get_test_fn=extract_test_class_name
         )
 
 
@@ -164,10 +163,10 @@ def main() -> None:
     test_class_ratings = calculate_test_class_ratings(filtered_tests, merge_bases)
 
     print("Evaluating test files:")
-    evaluate(filtered_tests, merge_bases, test_file_ratings, get_test_file_name)
+    evaluate(filtered_tests, merge_bases, test_file_ratings, extract_test_file_name)
 
     print("Evaluating test classes:")
-    evaluate(filtered_tests, merge_bases, test_class_ratings, get_test_class_name)
+    evaluate(filtered_tests, merge_bases, test_class_ratings, extract_test_class_name)
 
     with open("file_test_rating.json", mode="w") as file:
         json.dump(test_file_ratings, file, sort_keys=True, indent=2)

--- a/torchci/scripts/test_calculate_file_test_rating.py
+++ b/torchci/scripts/test_calculate_file_test_rating.py
@@ -1,6 +1,6 @@
 from unittest import main, TestCase
 
-from calculate_file_test_rating import calculate_ratings, filter_tests
+from calculate_file_test_rating import calculate_test_file_ratings, calculate_test_class_ratings, filter_tests
 
 
 class TestCalculateFileTestRating(TestCase):
@@ -30,7 +30,7 @@ class TestCalculateFileTestRating(TestCase):
             },
         )
 
-    def test_calculate_rating(self):
+    def test_calculate_test_file_ratings(self):
         # Extrememly simple sanity checks
         tests = [
             self.gen_test(head_sha="head_sha_1"),
@@ -43,7 +43,7 @@ class TestCalculateFileTestRating(TestCase):
             ]
         )
         expected = {"a.txt": {"invoking_file": 1.5}, "b.txt": {"invoking_file": 0.5}}
-        scores = calculate_ratings(tests, merge_bases)
+        scores = calculate_test_file_ratings(tests, merge_bases)
         self.assertDictEqual(scores, expected)
 
         tests = [
@@ -59,7 +59,40 @@ class TestCalculateFileTestRating(TestCase):
             "a.txt": {"invoking_file_1": 0.5, "invoking_file_2": 0.5},
             "b.txt": {"invoking_file_1": 0.5, "invoking_file_2": 0.5},
         }
-        scores = calculate_ratings(tests, merge_bases)
+        scores = calculate_test_file_ratings(tests, merge_bases)
+        self.assertDictEqual(scores, expected)
+
+    def test_calculate_test_class_ratings(self):
+        self.maxDiff = None
+        # Extrememly simple sanity checks
+        tests = [
+            self.gen_test(head_sha="head_sha_1"),
+            self.gen_test(head_sha="head_sha_2"),
+        ]
+        merge_bases = dict(
+            [
+                self.gen_merge_base("head_sha_1", ["a.txt", "b.txt"], "merge_base_1"),
+                self.gen_merge_base("head_sha_2", ["a.txt"], "merge_base_2"),
+            ]
+        )
+        expected = {"a.txt": {"invoking_file::classname": 1.5}, "b.txt": {"invoking_file::classname": 0.5}}
+        scores = calculate_test_class_ratings(tests, merge_bases)
+        self.assertDictEqual(scores, expected)
+
+        tests = [
+            self.gen_test(invoking_file="invoking_file_1", classname="classname1"),
+            self.gen_test(invoking_file="invoking_file_2", classname="classname2"),
+        ]
+        merge_bases = dict(
+            [
+                self.gen_merge_base("head_sha", ["a.txt", "b.txt"], "merge_base_1"),
+            ]
+        )
+        expected = {
+            "a.txt": {"invoking_file_1::classname1": 0.5, "invoking_file_2::classname2": 0.5},
+            "b.txt": {"invoking_file_1::classname1": 0.5, "invoking_file_2::classname2": 0.5},
+        }
+        scores = calculate_test_class_ratings(tests, merge_bases)
         self.assertDictEqual(scores, expected)
 
     def test_filter_tests(self):


### PR DESCRIPTION
Exports historical correlations of which files caused which test classes to fail to test-infra.

Will use this to create a heuristic for test reordering