### PR TITLE
Fix lintrunner MacOS builds

### DIFF
--- a/.github/workflows/lintrunner_ci.yml
+++ b/.github/workflows/lintrunner_ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'tools/lintrunner/**'
+      - '.github/workflows/lintrunner_ci.yml'
   push:
     branches:
       - main
@@ -96,7 +97,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
-    - uses: messense/maturin-action@v1
+    - uses: messense/maturin-action@v1.40.2
       with:
         command: build
         args: --release --target universal2-apple-darwin -o dist


### PR DESCRIPTION
By pinning it to  https://github.com/PyO3/maturin-action/tree/v1.40.2
As it fails with https://github.com/PyO3/maturin-action/tree/v1.40.3 that was released 3 days ago

Also, run lintrunner_ci.yml on pull if yml itself is modified