### PR TITLE
Add the workflow name as an optional search parameter

### DIFF
--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -259,9 +259,15 @@ export async function querySimilarFailures(
     baseCommitDate !== "" ? baseCommitDate : job.completed_at
   ).subtract(lookbackPeriodInHours, "hour");
 
+  // Get the workflow name if possible
+  const jobNameIndex = job.name.indexOf(` / ${job.jobName}`);
+  const workflowName =
+    jobNameIndex !== -1 ? job.name.substring(0, jobNameIndex) : "";
+
   const results = await searchSimilarFailures(
     client,
     failure,
+    workflowName,
     WORKFLOW_JOB_INDEX,
     startDate.toISOString(),
     endDate.toISOString(),

--- a/torchci/lib/searchUtils.ts
+++ b/torchci/lib/searchUtils.ts
@@ -33,8 +33,8 @@ export async function searchSimilarFailures(
       },
     },
   ];
-  // If specify, restrict by the workflow name too. This makes the query more
-  // accurate for less frequent job like periodic or slow
+  // If specify, query by the workflow name too. This makes the query more
+  // accurate for less frequent jobs like periodic or slow
   if (workflowName !== "") {
     must.push({
       match: {

--- a/torchci/lib/searchUtils.ts
+++ b/torchci/lib/searchUtils.ts
@@ -11,32 +11,44 @@ export const MAX_SIZE = 20;
 export async function searchSimilarFailures(
   client: Client,
   query: string,
+  workflowName: string,
   index: string,
   startDate: string,
   endDate: string,
   minScore: number,
   maxSize: number = MAX_SIZE
 ): Promise<{ jobs: JobData[] }> {
+  const must: any[] = [
+    {
+      match: {
+        "torchci_classification.line": query,
+      },
+    },
+    {
+      range: {
+        completed_at: {
+          gte: startDate,
+          lte: endDate,
+        },
+      },
+    },
+  ];
+  // If specify, restrict by the workflow name too. This makes the query more
+  // accurate for less frequent job like periodic or slow
+  if (workflowName !== "") {
+    must.push({
+      match: {
+        workflow_name: workflowName,
+      },
+    });
+  }
+
   const body = {
     min_score: minScore,
     size: maxSize,
     query: {
       bool: {
-        must: [
-          {
-            match: {
-              "torchci_classification.line": query,
-            },
-          },
-          {
-            range: {
-              completed_at: {
-                gte: startDate,
-                lte: endDate,
-              },
-            },
-          },
-        ],
+        must: must,
       },
     },
     // NB: It's important to sort by score first so that the most relevant results

--- a/torchci/pages/api/search.ts
+++ b/torchci/pages/api/search.ts
@@ -15,6 +15,7 @@ export default async function handler(
   res: NextApiResponse<{ jobs: JobData[] }>
 ) {
   const failure = req.query.failure as string;
+  const workflowName = (req.query.workflowName as string) ?? "";
   const index = (req.query.index as string) ?? WORKFLOW_JOB_INDEX;
   const startDate = req.query.startDate as string;
   const endDate = req.query.endDate as string;
@@ -43,6 +44,7 @@ export default async function handler(
       await searchSimilarFailures(
         client,
         failure,
+        workflowName,
         index,
         startDate,
         endDate,

--- a/torchci/test/drciUtils.test.ts
+++ b/torchci/test/drciUtils.test.ts
@@ -45,6 +45,7 @@ describe("Test various utils used by Dr.CI", () => {
     const job: RecentWorkflowsData = {
       id: "A",
       name: "",
+      jobName: "",
       html_url: "A",
       head_sha: "A",
       failure_captures: ["ERROR"],
@@ -101,6 +102,7 @@ describe("Test various utils used by Dr.CI", () => {
         [
           "TESTING",
           job.failure_captures.join(" "),
+          "",
           searchUtils.WORKFLOW_JOB_INDEX,
           mockStartDate,
           mockEndDate,
@@ -126,6 +128,37 @@ describe("Test various utils used by Dr.CI", () => {
         [
           "TESTING",
           job.failure_captures.join(" "),
+          "",
+          searchUtils.WORKFLOW_JOB_INDEX,
+          dayjs(baseCommitDate)
+            .subtract(lookbackPeriodInHours, "hour")
+            .toISOString(),
+          mockEndDate,
+          searchUtils.MIN_SCORE,
+        ],
+      ])
+    );
+
+    mock.mockClear();
+
+    const workflowName = "pull";
+    job.jobName = "job / test";
+    job.name = `${workflowName} / ${job.jobName}`;
+    // Check if the workflow name is set
+    expect(
+      await querySimilarFailures(
+        job,
+        baseCommitDate,
+        lookbackPeriodInHours,
+        "TESTING" as unknown as Client
+      )
+    ).toStrictEqual([mockJobData]);
+    expect(JSON.stringify(mock.mock.calls)).toEqual(
+      JSON.stringify([
+        [
+          "TESTING",
+          job.failure_captures.join(" "),
+          workflowName,
           searchUtils.WORKFLOW_JOB_INDEX,
           dayjs(baseCommitDate)
             .subtract(lookbackPeriodInHours, "hour")


### PR DESCRIPTION
I notice this force merge today https://github.com/pytorch/pytorch/pull/110487 where a flaky ROCm periodic job shows up as actual an actual failure.  This shouldn't be the case because there is a similar failure from a nearby commit https://hud.pytorch.org/pytorch/pytorch/commit/efb73fe8e4413a0d6db078e85c7ed7c91f05ca5d.

It turns out that the query returns many similar results but they are all from `pull` or `trunk`.  When we limit only to the top 20 results, `periodic` has less chance to show up there as it runs less frequently.

This change, thus, makes the query more focus on relevant results by specifying the workflow name as an optional parameter.

### Testing

Using https://github.com/pytorch/pytorch/pull/110487 as an example, Dr.CI nows classifies the flaky failure correctly:

<!-- drci-comment-start -->

## :link: Helpful Links
### :test_tube: See artifacts and rendered test results at [hud.pytorch.org/pr/110487](https://hud.pytorch.org/pr/110487)
* :page_facing_up: Preview [Python docs built from this PR](https://docs-preview.pytorch.org/pytorch/pytorch/110487/index.html)
* :page_facing_up: Preview [C++ docs built from this PR](https://docs-preview.pytorch.org/pytorch/pytorch/110487/cppdocs/index.html)
* :question: Need help or want to give feedback on the CI? Visit the [bot commands wiki](https://github.com/pytorch/pytorch/wiki/Bot-commands) or our [office hours](https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours)

Note: Links to docs will display an error until the docs builds have been completed.


## :white_check_mark: You can merge normally! (5 Unrelated Failures)
As of commit 09364af04970d5adb397f34b022220d813a855ac with merge base df3ab70dde65397017c6d0280495bc8df3d82933 (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1696356422?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details ><summary><b>FLAKY</b> - The following jobs failed but were likely due to flakiness present on trunk:</summary><p>

* [periodic / linux-focal-rocm5.6-py3.8 / test (distributed, 2, 2, linux.rocm.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/110487#17373955154) ([gh](https://github.com/pytorch/pytorch/actions/runs/6399941367/job/17373955154))
* [periodic / macos-12-py3-x86-64 / test (default, 2, 4, macos-12)](https://hud.pytorch.org/pr/pytorch/pytorch/110487#17373998030) ([gh](https://github.com/pytorch/pytorch/actions/runs/6399941367/job/17373998030))
* [trunk / win-vs2019-cpu-py3 / test (default, 1, 3, windows.4xlarge.nonephemeral)](https://hud.pytorch.org/pr/pytorch/pytorch/110487#17374035239) ([gh](https://github.com/pytorch/pytorch/actions/runs/6399940925/job/17374035239))
</p></details>
<details ><summary><b>UNSTABLE</b> - The following jobs failed but were likely due to flakiness present on trunk and has been marked as unstable:</summary><p>

* [trunk / linux-focal-rocm5.6-py3.8 / test (default, 2, 3, linux.rocm.gpu, unstable)](https://hud.pytorch.org/pr/pytorch/pytorch/110487#17373959619) ([gh](https://github.com/pytorch/pytorch/actions/runs/6399940925/job/17373959619))
* [trunk / linux-focal-rocm5.6-py3.8 / test (default, 3, 3, linux.rocm.gpu, unstable)](https://hud.pytorch.org/pr/pytorch/pytorch/110487#17373959794) ([gh](https://github.com/pytorch/pytorch/actions/runs/6399940925/job/17373959794))
</p></details>


This comment was automatically generated by Dr. CI and updates every 15 minutes.
<!-- drci-comment-end -->