### PR TITLE
Use packaging.version to compare python versions

### DIFF
--- a/tools/pkg-helpers/pyproject.toml
+++ b/tools/pkg-helpers/pyproject.toml
@@ -9,6 +9,7 @@ pytorch_pkg_helper = "pytorch_pkg_helpers.__main__:main"
 
 [tool.poetry.dependencies]
 python = "^3.8"
+packaging = "*"
 
 [tool.poetry.dev-dependencies]
 black = "^22.6.0"

--- a/tools/pkg-helpers/pytorch_pkg_helpers/wheel.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/wheel.py
@@ -1,11 +1,11 @@
 from typing import List
-
+from packaging import version
 
 def get_python_path_variables(python_version: str) -> List[str]:
     m = ""
     # For some reason python versions <= 3.7 require an m
     # probably better not to ask why
-    if float(python_version) <= 3.7:
+    if version.parse(python_version) <= version.parse(3.7):
         m = "m"
     python_nodot = python_version.replace(".", "")
     python_abi = f"cp{python_nodot}-cp{python_nodot}{m}"


### PR DESCRIPTION
Logic here is flawed: https://github.com/pytorch/test-infra/blob/3e4f2888c72f0b102afa223b5a41bdb1946b4906/tools/pkg-helpers/pytorch_pkg_helpers/wheel.py#L8
```
>>> float("3.10")
3.1
>>> if float("3.10") <= 3.7:
...   print("yes")
...
yes
```