### PR TITLE
TD: Denoise TTRS metric

### DIFF
--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -71,7 +71,7 @@ export default function Kpis() {
 
       <Grid item xs={12} lg={6} height={ROW_HEIGHT}>
         <TimeSeriesPanel
-          title={"Time to Red Signal - (Weekly, 2 week rolling avg)"}
+          title={"Time to Red Signal - (Weekly)"}
           queryName={"ttrs_percentiles"}
           queryCollection={"pytorch_dev_infra_kpis"}
           queryParams={[...timeParams]}

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -40,7 +40,7 @@
     "time_to_signal": "ff332d025976c103",
     "strict_lag_historical": "d2a09d13caf8b76a",
     "ci_wait_time": "b1080f26b20ea142",
-    "ttrs_percentiles": "741a33da87028cdf"
+    "ttrs_percentiles": "cb34ea79098652f2"
   },
   "metrics": {
     "correlation_matrix": "35c05e04047123f0",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -40,7 +40,7 @@
     "time_to_signal": "ff332d025976c103",
     "strict_lag_historical": "d2a09d13caf8b76a",
     "ci_wait_time": "b1080f26b20ea142",
-    "ttrs_percentiles": "679a7c2817a67561"
+    "ttrs_percentiles": "4cd846f64b76e8fb"
   },
   "metrics": {
     "correlation_matrix": "35c05e04047123f0",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -40,7 +40,7 @@
     "time_to_signal": "ff332d025976c103",
     "strict_lag_historical": "d2a09d13caf8b76a",
     "ci_wait_time": "b1080f26b20ea142",
-    "ttrs_percentiles": "4cd846f64b76e8fb"
+    "ttrs_percentiles": "741a33da87028cdf"
   },
   "metrics": {
     "correlation_matrix": "35c05e04047123f0",

--- a/torchci/rockset/pytorch_dev_infra_kpis/__sql/ttrs_percentiles.sql
+++ b/torchci/rockset/pytorch_dev_infra_kpis/__sql/ttrs_percentiles.sql
@@ -114,7 +114,7 @@ commit_job_durations AS (
     INNER JOIN commons.workflow_run r ON j.run_id = r.id
   WHERE
     1 = 1
-    AND r.name = 'pull' -- Stick to pull workflows to reduce noise. Trendlines are the same within other workflows
+    AND r.name = :workflow -- Stick to pull workflows to reduce noise. Trendlines are the same within other workflows
     AND j.conclusion = 'failure' -- we just care about failed jobs
     AND js.conclusion = 'failure'
     AND j.run_attempt = 1 -- only look at the first run attempt since reruns will either 1) succeed, so are irrelevant or 2) repro the failure, biasing our data

--- a/torchci/rockset/pytorch_dev_infra_kpis/__sql/ttrs_percentiles.sql
+++ b/torchci/rockset/pytorch_dev_infra_kpis/__sql/ttrs_percentiles.sql
@@ -217,12 +217,12 @@ kpi_results AS (
     FORMAT_TIMESTAMP('%Y-%m-%d', d.bucket) AS bucket,
     -- rolling average
     (
-      AVG(ttrs_mins) OVER(
+      ROUND(AVG(ttrs_mins) OVER(
         PARTITION BY percentile
         ORDER BY
           -- Average over this many + 1 buckets (two weeks)
-          bucket ROWS 1 PRECEDING
-      )
+          bucket ROWS 0 PRECEDING
+      ))
     ) AS ttrs_mins,
     d.percentile
   FROM

--- a/torchci/rockset/pytorch_dev_infra_kpis/ttrs_percentiles.lambda.json
+++ b/torchci/rockset/pytorch_dev_infra_kpis/ttrs_percentiles.lambda.json
@@ -20,6 +20,11 @@
       "name": "stopTime",
       "type": "string",
       "value": "2024-08-16T00:06:32.839Z"
+    },
+    {
+      "name": "workflow",
+      "type": "string",
+      "value": "pull"
     }
   ],
   "description": "Computes the TTRS kpi"

--- a/torchci/rockset/pytorch_dev_infra_kpis/ttrs_percentiles.lambda.json
+++ b/torchci/rockset/pytorch_dev_infra_kpis/ttrs_percentiles.lambda.json
@@ -14,12 +14,12 @@
     {
       "name": "startTime",
       "type": "string",
-      "value": "2022-12-16T00:06:32.839Z"
+      "value": "2023-02-16T00:06:32.839Z"
     },
     {
       "name": "stopTime",
       "type": "string",
-      "value": "2023-08-16T00:06:32.839Z"
+      "value": "2024-08-16T00:06:32.839Z"
     }
   ],
   "description": "Computes the TTRS kpi"


### PR DESCRIPTION
Reduces two sources of noise in the TTRS metric, which is supposed to measure how long the test step ran for before a failure occurred.

Changes being made are:
1. Removes noise from queuing times 
2. Only look at the pull workflow, since other workflows are run at a much more variable number of times.

The second one is a bit more controversial, so here's the reasoning:

1. The pull workflow makes up more than 85% of workflows run. 
2. The ratio of how often pull was run to other workflows varies from month to month based on user behavior, adding noise
3. If you look at TTRS rates for pull and trunk workflows separately, they have similar trend lines, making pull workflows a good representative for them all.
 
Old values:
<img width="703" alt="image" src="https://github.com/pytorch/test-infra/assets/4468967/56c635ef-ce80-4b26-906d-da7d2de075af">

New values:
Note that the spike in Old values p90 ttrs that goes away are from trunk jobs that were timing out last Aug
<img width="783" alt="image" src="https://github.com/pytorch/test-infra/assets/4468967/7d9962ce-793b-45a0-a21d-d94dc23410f9">
