### PR TITLE
[TorchFix] Update version to 0.1.0

### DIFF
--- a/tools/torchfix/README.md
+++ b/tools/torchfix/README.md
@@ -11,7 +11,7 @@ reporting issues.
 TorchFix can be used as a Flake8 plugin (linting only) or as a standalone
 program (with autofix available for a subset of the lint violations).
 
-Currently TorchFix is in a **prototype/alpha version** stage, so there are a lot of rough
+Currently TorchFix is in a **beta version** stage, so there are still a lot of rough
 edges and many things can and will change.
 
 ## Installation
@@ -35,7 +35,7 @@ Add `--fix` parameter to try to autofix some of the issues (the files will be ov
 To see some additional debug info, add `--show-stderr` parameter.
 
 Please keep in mind that autofix is a best-effort mechanism. Given the dynamic nature of Python,
-and especially the prototype/alpha version status of TorchFix, it's very difficult to have
+and especially the beta version status of TorchFix, it's very difficult to have
 certainty when making changes to code, even for the seemingly trivial fixes.
 
 Warnings for issues with codes starting with TOR0, TOR1, and TOR2 are enabled by default.

--- a/tools/torchfix/torchfix/torchfix.py
+++ b/tools/torchfix/torchfix/torchfix.py
@@ -16,7 +16,7 @@ from .visitors.vision import (
     TorchVisionDeprecatedPretrainedVisitor, TorchVisionDeprecatedToTensorVisitor
 )
 
-__version__ = "0.0.3"
+__version__ = "0.1"
 
 DEPRECATED_CONFIG_PATH = Path(__file__).absolute().parent / "deprecated_symbols.yaml"
 

--- a/tools/torchfix/torchfix/torchfix.py
+++ b/tools/torchfix/torchfix/torchfix.py
@@ -16,7 +16,7 @@ from .visitors.vision import (
     TorchVisionDeprecatedPretrainedVisitor, TorchVisionDeprecatedToTensorVisitor
 )
 
-__version__ = "0.1"
+__version__ = "0.1.0"
 
 DEPRECATED_CONFIG_PATH = Path(__file__).absolute().parent / "deprecated_symbols.yaml"
 


### PR DESCRIPTION
TorchFix has been used in GitHub CI for several Meta projects and has received its first non-Meta contribution recently, so let's update it to Beta status before the presentation on PyTorch Conference 2023.

The main change from 0.0.2 release is new rules for deprecated TorchVision APIs.