### PR TITLE
Removed condition for linux.t4g.2xlarge

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -247,8 +247,7 @@ jobs:
         uses: ./test-infra/.github/actions/chown-directory
         with:
           directory: ${{ github.workspace }}/${{ env.repository }}
-          # TODO - remove linux.t4g.2xlarge after the migration will be fully done
-          ALPINE_IMAGE: ${{ inputs.runner == 'linux.t4g.2xlarge' && 'arm64v8/alpine' || inputs.runner == 'linux.arm64.2xlarge' && 'arm64v8/alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
+          ALPINE_IMAGE: ${{ inputs.runner == 'linux.arm64.2xlarge' && 'arm64v8/alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
 
       - name: Chown runner temp
         if: always()


### PR DESCRIPTION
Remove the use of linux.t4g.2xlarge as part of migrating t4g.2xlarge runners from pet instances.