### PR TITLE
Add an excluded list for flaky detection on Dr.CI

### DIFF
--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -681,7 +681,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
 
   test("test jobs excluded from flaky detection", async () => {
     const excludedFailure = {
-      id: 1,
+      id: "1",
       runnerName: "dummy",
       name: "Lint / lintrunner / linux-job",
       conclusion: "failure",

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -678,4 +678,33 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     expect(flakyJobs.length).toBe(2);
     expect(unstableJobs.length).toBe(0);
   });
+
+  test("test jobs excluded from flaky detection", async () => {
+    const excludedFailure = {
+      id: 1,
+      runnerName: "dummy",
+      name: "Lint / lintrunner / linux-job",
+      conclusion: "failure",
+      completed_at: "2023-10-13T15:00:48Z",
+      html_url: "a",
+      head_sha: "abcdefg",
+      pr_number: 1001,
+      failure_captures: [">>> Lint for torch/_dynamo/output_graph.py:"],
+      failure_line: ">>> Lint for torch/_dynamo/output_graph.py:",
+    };
+
+    const originalWorkflows = [excludedFailure];
+    const workflowsByPR = await updateDrciBot.reorganizeWorkflows(
+      originalWorkflows
+    );
+
+    const pr_1001 = workflowsByPR.get(1001)!;
+    const { pending, failedJobs, flakyJobs, brokenTrunkJobs, unstableJobs } =
+      await updateDrciBot.getWorkflowJobsStatuses(pr_1001, [], new Map());
+
+    expect(failedJobs.length).toBe(1);
+    expect(brokenTrunkJobs.length).toBe(0);
+    expect(flakyJobs.length).toBe(0);
+    expect(unstableJobs.length).toBe(0);
+  });
 });


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/111207 was merged because Dr.CI detects the lint failure as flaky.  This was an FP because it found an exact match of the same lint failure, on a different branch.  This happens because lint failure only prints the name of the broken file.

```
{
    name: 'Lint / lintrunner / linux-job',
    workflowName: 'Lint',
    jobName: 'lintrunner / linux-job',
    sha: '2b30b63b86ee277b3e70d39db6244ac0360c84c3',
    id: 17653166474,
    workflowId: 6499566593,
    time: '2023-10-12T18:59:16Z',
    conclusion: 'failure',
    htmlUrl: 'https://github.com/pytorch/pytorch/actions/runs/6499566593/job/17653166474',
    failureLine: '>>> Lint for torch/_dynamo/output_graph.py:',
    failureLineNumber: 145946,
    failureCaptures: [ '>>> Lint for torch/_dynamo/output_graph.py:' ]
}
```

In hindsight, lint jobs are stable enough that we shouldn't need to try to see if they are flaky.