### PR TITLE
Add an auto-label rule for ciflow/rocm

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -3,6 +3,7 @@ import { addLabels, isPyTorchPyTorch } from "./utils";
 
 const titleRegexToLabel: [RegExp, string][] = [
   [/rocm/gi, "module: rocm"],
+  [/rocm/gi, "ciflow/rocm"],
   [/vulkan/gi, "module: vulkan"],
   [/vulkan/gi, "ciflow/periodic"], // Vulkan tests are run periodically
   [/DISABLED\s+test.*\(.*\)/g, "skipped"],

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -58,7 +58,9 @@ describe("auto-label-bot", () => {
       .post(
         "/repos/ezyang/testing-ideal-computing-machine/issues/5/labels",
         (body) => {
-          expect(body).toMatchObject({ labels: ["module: rocm", "ciflow/rocm"] });
+          expect(body).toMatchObject({
+            labels: ["module: rocm", "ciflow/rocm"],
+          });
           return true;
         }
       )

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -58,7 +58,7 @@ describe("auto-label-bot", () => {
       .post(
         "/repos/ezyang/testing-ideal-computing-machine/issues/5/labels",
         (body) => {
-          expect(body).toMatchObject({ labels: ["module: rocm"] });
+          expect(body).toMatchObject({ labels: ["module: rocm", "ciflow/rocm"] });
           return true;
         }
       )
@@ -84,7 +84,7 @@ describe("auto-label-bot", () => {
       .get("/repos/zhouzhuojie/gha-ci-playground/pulls/31/files?per_page=100")
       .reply(200)
       .post("/repos/zhouzhuojie/gha-ci-playground/issues/31/labels", (body) => {
-        expect(body).toMatchObject({ labels: ["module: rocm"] });
+        expect(body).toMatchObject({ labels: ["module: rocm", "ciflow/rocm"] });
         return true;
       })
       .reply(200);


### PR DESCRIPTION
This is needed after https://github.com/pytorch/pytorch/pull/111394.