### PR TITLE
Add the list of previous commands as optional context on log classifier

### DIFF
--- a/aws/lambda/log-classifier/fixtures/request.json
+++ b/aws/lambda/log-classifier/fixtures/request.json
@@ -2,7 +2,7 @@
   "version": "2.0",
   "routeKey": "$default",
   "rawPath": "/",
-  "rawQueryString": "job_id=8233334431",
+  "rawQueryString": "job_id=8233334431&repo=pytorch%2Fpytorch",
   "headers": {
     "accept": "*/*",
     "content-length": "0",

--- a/aws/lambda/log-classifier/fixtures/request.json
+++ b/aws/lambda/log-classifier/fixtures/request.json
@@ -2,7 +2,7 @@
   "version": "2.0",
   "routeKey": "$default",
   "rawPath": "/",
-  "rawQueryString": "job_id=8233334431&repo=pytorch%2Fpytorch",
+  "rawQueryString": "job_id=17764650210&repo=pytorch%2Fpytorch",
   "headers": {
     "accept": "*/*",
     "content-length": "0",

--- a/aws/lambda/log-classifier/src/main.rs
+++ b/aws/lambda/log-classifier/src/main.rs
@@ -14,10 +14,14 @@ use log_classifier::rule_match::SerializedMatch;
 
 struct ShouldWriteDynamo(bool);
 
+/// Set the default depth of the context stack
+static CONTEXT_DEPTH: &str = "12";
+
 async fn handle(
     job_id: usize,
     repo: &str,
     should_write_dynamo: ShouldWriteDynamo,
+    context_depth: usize,
 ) -> Result<String> {
     let client = get_s3_client().await;
     // Download the log from S3.
@@ -38,7 +42,7 @@ async fn handle(
 
     match maybe_match {
         Some(best_match) => {
-            let match_json = SerializedMatch::new(&best_match, &log);
+            let match_json = SerializedMatch::new(&best_match, &log, context_depth);
             let body = serde_json::to_string_pretty(&match_json)?;
             info!("match: {}", body);
             if should_write_dynamo.0 {
@@ -63,7 +67,11 @@ async fn function_handler(event: Request) -> Result<Response<Body>, Error> {
             let repo = query_string_parameters
                 .first("repo")
                 .unwrap_or_else(|| "pytorch/pytorch");
-            handle(job_id, repo, ShouldWriteDynamo(true))
+            let context_depth = query_string_parameters
+                .first("context_depth")
+                .unwrap_or_else(|| CONTEXT_DEPTH)
+                .parse::<usize>()?;
+            handle(job_id, repo, ShouldWriteDynamo(true), context_depth)
                 .await?
                 .into_response()
                 .await
@@ -244,7 +252,7 @@ mod test {
         let match_ = evaluate_ruleset(&ruleset, &log).unwrap();
         assert_eq!(match_.line_number, 4);
 
-        let match_json = SerializedMatch::new(&match_, &log);
+        let match_json = SerializedMatch::new(&match_, &log, 12);
         assert_eq!(match_json.context, ["++ exit 1", "++ echo DUMMY", "+ python testing"]);
     }
 

--- a/aws/lambda/log-classifier/src/main.rs
+++ b/aws/lambda/log-classifier/src/main.rs
@@ -235,18 +235,17 @@ mod test {
         let log = Log::new(
             "\
             + python testing\n\
-            + exit 1\n\
-            ++ return 2\n\
             ++ echo DUMMY\n\
+            ++ exit 1\n\
             testt\n\
             "
             .into(),
         );
         let match_ = evaluate_ruleset(&ruleset, &log).unwrap();
-        assert_eq!(match_.line_number, 5);
+        assert_eq!(match_.line_number, 4);
 
         let match_json = SerializedMatch::new(&match_, &log);
-        assert_eq!(match_json.context, ["++ echo DUMMY", "+ python testing"]);
+        assert_eq!(match_json.context, ["++ exit 1", "++ echo DUMMY", "+ python testing"]);
     }
 
     // Actually download some id.

--- a/aws/lambda/log-classifier/src/main.rs
+++ b/aws/lambda/log-classifier/src/main.rs
@@ -228,6 +228,27 @@ mod test {
         }
     }
 
+    #[test]
+    fn gather_optional_context() {
+        let mut ruleset = RuleSet::new();
+        ruleset.add("test", r"^test");
+        let log = Log::new(
+            "\
+            + python testing\n\
+            + exit 1\n\
+            ++ return 2\n\
+            ++ echo DUMMY\n\
+            testt\n\
+            "
+            .into(),
+        );
+        let match_ = evaluate_ruleset(&ruleset, &log).unwrap();
+        assert_eq!(match_.line_number, 5);
+
+        let match_json = SerializedMatch::new(&match_, &log);
+        assert_eq!(match_json.context, ["++ echo DUMMY", "+ python testing"]);
+    }
+
     // Actually download some id.
     // #[tokio::test]
     // async fn test_real() {

--- a/aws/lambda/log-classifier/src/rule_match.rs
+++ b/aws/lambda/log-classifier/src/rule_match.rs
@@ -2,6 +2,9 @@ use crate::log::Log;
 use crate::rule::Rule;
 use serde::Serialize;
 
+/// Set the maximum depth of the context stack
+static CONTEXT_DEPTH: usize = 5;
+
 /// Represents a successful match of a log line against a rule.
 #[derive(Debug)]
 pub struct Match {
@@ -19,17 +22,40 @@ pub struct SerializedMatch {
     line: String,
     line_num: usize,
     captures: Vec<String>,
+    /// The optional context where this failure occurs. This is a free-form
+    /// stack of strings that includes the last commands before the failure
+    pub context: Vec<String>,
 }
 
 impl SerializedMatch {
     pub fn new(m: &Match, log: &Log) -> SerializedMatch {
         // Unwrap because we know this is a valid key (since the Log object is never mutated.)
         let line = log.lines.get(&m.line_number).unwrap();
+
+        let mut context = Vec::with_capacity(CONTEXT_DEPTH);
+        // NB: backtrack the log till we find the previous command. This relies
+        // on GitHub console log convention to prefix a bash command with +. An
+        // important note is that this only works for bash though, not Windows
+        // PowerShell. But Windows support could be added later.
+        for i in (1..=m.line_number).rev() {
+            if context.len() == CONTEXT_DEPTH {
+                break
+            }
+
+            let l = log.lines.get(&i).unwrap();
+            // Choose to ignore exit N and return N command because they don't
+            // mean anything and just fill up the context
+            if l.starts_with("+") && !l.contains("+ exit") && !l.contains("+ return") {
+                context.push(l.clone());
+            }
+        }
+
         SerializedMatch {
             rule: m.rule.name.clone(),
             line: line.clone(),
             line_num: m.line_number,
             captures: m.captures.clone(),
+            context: context.clone(),
         }
     }
 }

--- a/aws/lambda/log-classifier/src/rule_match.rs
+++ b/aws/lambda/log-classifier/src/rule_match.rs
@@ -2,9 +2,6 @@ use crate::log::Log;
 use crate::rule::Rule;
 use serde::Serialize;
 
-/// Set the maximum depth of the context stack
-static CONTEXT_DEPTH: usize = 5;
-
 /// Represents a successful match of a log line against a rule.
 #[derive(Debug)]
 pub struct Match {
@@ -28,17 +25,17 @@ pub struct SerializedMatch {
 }
 
 impl SerializedMatch {
-    pub fn new(m: &Match, log: &Log) -> SerializedMatch {
+    pub fn new(m: &Match, log: &Log, context_depth: usize) -> SerializedMatch {
         // Unwrap because we know this is a valid key (since the Log object is never mutated.)
         let line = log.lines.get(&m.line_number).unwrap();
 
-        let mut context = Vec::with_capacity(CONTEXT_DEPTH);
+        let mut context = Vec::with_capacity(context_depth);
         // NB: backtrack the log till we find the previous command. This relies
         // on GitHub console log convention to prefix a bash command with +. An
         // important note is that this only works for bash though, not Windows
         // PowerShell. But Windows support could be added later.
         for i in (1..=m.line_number).rev() {
-            if context.len() == CONTEXT_DEPTH {
+            if context.len() == context_depth {
                 break
             }
 

--- a/aws/lambda/log-classifier/src/rule_match.rs
+++ b/aws/lambda/log-classifier/src/rule_match.rs
@@ -45,7 +45,7 @@ impl SerializedMatch {
             let l = log.lines.get(&i).unwrap();
             // Choose to ignore exit N and return N command because they don't
             // mean anything and just fill up the context
-            if l.starts_with("+") && !l.contains("+ exit") && !l.contains("+ return") {
+            if l.starts_with("+") {
                 context.push(l.clone());
             }
         }

--- a/aws/lambda/log-classifier/src/rule_match.rs
+++ b/aws/lambda/log-classifier/src/rule_match.rs
@@ -43,8 +43,6 @@ impl SerializedMatch {
             }
 
             let l = log.lines.get(&i).unwrap();
-            // Choose to ignore exit N and return N command because they don't
-            // mean anything and just fill up the context
             if l.starts_with("+") {
                 context.push(l.clone());
             }


### PR DESCRIPTION
I have this change to add the list of N (5) previous commands as optional context on log classifier.  This relies on GitHub console log convention to prefix a **bash** command with `+`.  This new `context` field should just become a new field on `workflow_job` for future query.

This is mainly an attempt to provide more context on GHA generic failures that are not well captured by the log classifier.