### PR TITLE
Apply lint to aws directory

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,8 +7,11 @@ on:
     tags:
       - v*
   pull_request:
-    paths:
-      - '!tools/torchfix/**'
+    # A caveat https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions:
+    # If you define a path with the ! character, you must also define at least one path without
+    # the ! character. If you only want to exclude paths, use paths-ignore instead
+    paths-ignore:
+      - 'tools/torchfix/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/aws/lambda/github-webhook-rds-sync/generate_schema.py
+++ b/aws/lambda/github-webhook-rds-sync/generate_schema.py
@@ -13,7 +13,7 @@ import asyncio
 import json
 from collections import defaultdict
 from pathlib import Path
-from typing import *
+from typing import Any, Dict
 
 from sqlalchemy.orm import declarative_base
 
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     webhooks = defaultdict(dict)
 
     # Go over and combine all webhooks of the same type
-    n = len([x for x in samples_path.glob("*/*.json")])
+    n = len(list(samples_path.glob("*/*.json")))
     for i, name in enumerate(samples_path.glob("*/*.json")):
         if i % 1000 == 0:
             print(f"{i} / {n}")

--- a/aws/lambda/github-webhook-rds-sync/lambda_function.py
+++ b/aws/lambda/github-webhook-rds-sync/lambda_function.py
@@ -4,11 +4,11 @@ import hashlib
 import hmac
 import json
 import os
+from typing import Any, Dict
 
 import boto3
-from typing import *
 from existing_schema import existing_schema
-from sqlalchemy import column, insert, table
+from sqlalchemy import column, table
 from sqlalchemy.dialects.mysql import insert
 
 from utils import (
@@ -104,7 +104,7 @@ def lambda_handler(event, context):
     if check_hash(payload, expected):
         body = event["body"]
         if body.startswith("payload="):
-            body = body[len("payload=") :]
+            body = body[len("payload=") :]  # noqa: E203
         try:
             payload = json.loads(body)
         except Exception as e:

--- a/aws/lambda/github-webhook-rds-sync/test_lambda.py
+++ b/aws/lambda/github-webhook-rds-sync/test_lambda.py
@@ -4,24 +4,22 @@ be done with these steps: https://www.digitalocean.com/community/tutorials/how-t
 
 Once done, set the db_host, db_password and db_user env variables accordingly.
 """
-import os
-
-os.environ["gh_secret"] = "test"
-
 import asyncio
-import io
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
 
 import lambda_function
 
+os.environ["gh_secret"] = "test"
+
 
 class TestWebhook(unittest.TestCase):
     def test_real_webhooks(self):
         samples_path = Path(__file__).resolve().parent / "hooks"
-        with tempfile.NamedTemporaryFile() as f:
+        with tempfile.NamedTemporaryFile() as f:  # noqa: F841
 
             def load_hook(name: str):
                 name = samples_path / name
@@ -33,14 +31,14 @@ class TestWebhook(unittest.TestCase):
 
             glob_path = os.getenv("TEST", "*.json")
 
-            n = len([x for x in samples_path.glob(glob_path)])
+            n = len(list(samples_path.glob(glob_path)))
             for i, name in enumerate(samples_path.glob(glob_path)):
                 type, data = load_hook(name)
                 type = type.split("-")[0]
                 if i % 20 == 0:
                     print(f"{i} / {n}")
                 try:
-                    r = asyncio.run(lambda_function.handle_webhook(data, type=type))
+                    asyncio.run(lambda_function.handle_webhook(data, type=type))
                 except Exception as e:
                     print(f"Failed on {name.name}")
                     raise e

--- a/aws/lambda/github-webhook-rds-sync/utils.py
+++ b/aws/lambda/github-webhook-rds-sync/utils.py
@@ -1,8 +1,8 @@
 import datetime
 import json
 import os
-from typing import *
-
+from contextlib import suppress
+from typing import Any, Dict, List, Tuple, Union
 
 from sqlalchemy import (
     Boolean,
@@ -387,10 +387,8 @@ def transform_data(obj: Dict[str, Any]) -> Dict[str, Any]:
                 date = None
 
                 for format in formats:
-                    try:
+                    with suppress(ValueError):
                         date = datetime.datetime.strptime(value, format)
-                    except ValueError:
-                        pass
 
                 if date is None:
                     raise RuntimeError(value)

--- a/aws/lambda/log-classifier/src/main.rs
+++ b/aws/lambda/log-classifier/src/main.rs
@@ -253,7 +253,10 @@ mod test {
         assert_eq!(match_.line_number, 4);
 
         let match_json = SerializedMatch::new(&match_, &log, 12);
-        assert_eq!(match_json.context, ["++ exit 1", "++ echo DUMMY", "+ python testing"]);
+        assert_eq!(
+            match_json.context,
+            ["++ exit 1", "++ echo DUMMY", "+ python testing"]
+        );
     }
 
     // Actually download some id.

--- a/aws/lambda/log-classifier/src/rule_match.rs
+++ b/aws/lambda/log-classifier/src/rule_match.rs
@@ -36,7 +36,7 @@ impl SerializedMatch {
         // PowerShell. But Windows support could be added later.
         for i in (1..=m.line_number).rev() {
             if context.len() == context_depth {
-                break
+                break;
             }
 
             let l = log.lines.get(&i).unwrap();

--- a/aws/lambda/usage-log-aggregator/lambda_function.py
+++ b/aws/lambda/usage-log-aggregator/lambda_function.py
@@ -200,17 +200,10 @@ async def aggregate(body: str, context: Any) -> str:
     owner = params.get("owner", PYTORCH)
     repo = params.get("repo", PYTORCH)
 
-    # i.e. pull
-    workflow_name = params.get("workflowName")
     # i.e. linux-bionic-cuda11.6-py3.10-gcc7 / test (default, 1, 4, linux.4xlarge.nvidia.gpu)
     job_name = params.get("jobName")
-    # i.e. test_ops
-    test_file = params.get("testFile")
-    # i.e. TestCommonCUDA
-    test_class = params.get("testClass")
-
-    # Other parameters are not needed right now at the current level of granularity. However,
-    # we keep them here for future usage
+    # Other parameters including workflowName, testFile, and testClass are not needed right
+    # now at the current level of granularity. However, they're there for future usage
     if not job_name:
         return json.dumps({"error": "Missing jobName"})
 


### PR DESCRIPTION
My https://github.com/pytorch/test-infra/pull/4649 broke lint and I was surprise that lint didn't run on that PR.  I suspect that the reason is this caveat from https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions:

> If you define a path with the ! character, you must also define at least one path without the ! character. If you only want to exclude paths, use paths-ignore instead

* Switch to `paths-ignore` on lint workflow
* Run `lintrunner -a aws/lambda/**/*.py` and `lintrunner -a aws/lambda/**/*.rs`