### PR TITLE
Only upload Dr.CI classification results for the target PR

### DIFF
--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -156,7 +156,7 @@ export async function updateDrciComments(
         title: "Dr.CI classification results",
         // NB: the summary contains the classification result from Dr.CI,
         // so that it can be queried elsewhere
-        summary: JSON.stringify(failures),
+        summary: JSON.stringify(failures[pr_info.pr_number]),
       },
     });
   });


### PR DESCRIPTION
I forgot (again) that Dr.CI could handle more than one PR at a times.  So, it prints all the results from the run, i.e. https://github.com/pytorch/pytorch/pull/110511/checks?check_run_id=17834281447, which is working but has too much redundant information.  And the summary field has an upper limit of 65535 characters.

### Testing
Only the classification of the target PR is print and the redundant PR number is removed https://github.com/pytorch/pytorch/pull/111493/checks?check_run_id=17835502442