### PR TITLE
[BE] HUD can show jobs run on a PR against commits before it was rebased

### DIFF
--- a/torchci/lib/fetchPR.ts
+++ b/torchci/lib/fetchPR.ts
@@ -8,7 +8,6 @@ export default async function fetchPR(
   repo: string,
   prNumber: string
 ): Promise<PRData> {
-
   // We pull data from both Rockset and Github to get all commits, including
   // the ones that have been force merged out of the git history.
   // Rockset is the primary source, GitHub covers anything newer that might

--- a/torchci/lib/fetchPR.ts
+++ b/torchci/lib/fetchPR.ts
@@ -1,5 +1,6 @@
 import { getOctokit } from "./github";
 import getRocksetClient from "./rockset";
+import rocksetVersions from "rockset/prodVersions.json";
 import { PRData } from "./types";
 
 export default async function fetchPR(
@@ -7,8 +8,15 @@ export default async function fetchPR(
   repo: string,
   prNumber: string
 ): Promise<PRData> {
+  // First pull data from Rockset to get everything including commits that have been force merged past.
+  // Then pull data from GitHub to get anything newer that was missed.
+
+  const rocksetClient = getRocksetClient();
+
+
+
   const octokit = await getOctokit(owner, repo);
-  const [pull, commits] = await Promise.all([
+  const [pull, commits, historicalCommits] = await Promise.all([
     octokit.rest.pulls.get({
       owner,
       repo,
@@ -20,11 +28,46 @@ export default async function fetchPR(
       pull_number: parseInt(prNumber),
       per_page: 100,
     }),
+    await rocksetClient.queryLambdas.executeQueryLambda(
+      "commons",
+      "pr_commits",
+      rocksetVersions.commons.pr_commits as string,
+      {
+        parameters: [
+          {
+            name: "pr_number",
+            type: "int",
+            value: prNumber,
+          },
+          {
+            name: "owner",
+            type: "string",
+            value: `${owner}`,
+          },
+          {
+            name: "repo",
+            type: "string",
+            value: `${repo}`,
+          },
+        ],
+      }
+    ),
   ]);
   const title = pull.data.title;
-  const shas = commits.map((commit) => {
-    return { sha: commit.sha, title: commit.commit.message.split("\n")[0] };
+
+  console.log("Fetcing PRS ZZZZZZZZZZ")
+  console.log(historicalCommits)
+  const shas = historicalCommits.results!.map((commit) => {
+    return { sha: commit.sha, title: commit.message.split("\n")[0] };
   });
+
+  // Ideally historicalCommits will be a superset of commits, but if there's a propagation delay with
+  // getting the data to rockset it may be missing recent commits for a bit.
+  // For the very last sha, checking to see if the shas themselves match offer a good proxy for detecting a missing commit.
+  const lastCommit = commits[commits.length - 1];
+  if (lastCommit.sha !== shas[shas.length - 1].sha) {
+    shas.push({ sha: lastCommit.sha, title: lastCommit.commit.message.split("\n")[0] });
+  }
 
   return { title, shas };
 }

--- a/torchci/lib/fetchPR.ts
+++ b/torchci/lib/fetchPR.ts
@@ -67,9 +67,12 @@ export default async function fetchPR(
   } else {
     // For the very last sha, check to see if the shas themselves match as a proxy for detecting any missing commit.
     const lastCommit = commits[commits.length - 1];
-    const lastHistoricalCommit = shas[shas.length - 1]
+    const lastHistoricalCommit = shas[shas.length - 1];
     if (lastCommit.sha != lastHistoricalCommit.sha) {
-      shas.push({ sha: lastCommit.sha, title: lastCommit.commit.message.split("\n")[0] });
+      shas.push({
+        sha: lastCommit.sha,
+        title: lastCommit.commit.message.split("\n")[0],
+      });
     }
   }
 

--- a/torchci/rockset/commons/__sql/pr_commits.sql
+++ b/torchci/rockset/commons/__sql/pr_commits.sql
@@ -14,14 +14,18 @@ pr_shas AS (
     j.head_sha AS sha,
     p.head_commit.message,
     CONCAT(
-      'https://github.com/pytorch/pytorch/pull/',
+      'https://github.com/',
+      :owner,
+      '/',
+      :repo,
+      '/',
       r.pull_requests[1].number
     ) AS pr_url,
     p.head_commit.url AS commit_url,
   FROM
     commons.workflow_job j
     INNER JOIN commons.workflow_run r ON j.run_id = r.id
-    INNER JOIN commons.push p ON p.head_commit.id = j.head_sha
+    JOIN commons.push p ON p.head_commit.id = j.head_sha
   WHERE
     1 = 1
     AND LENGTH(r.pull_requests) = 1

--- a/torchci/rockset/commons/__sql/pr_commits.sql
+++ b/torchci/rockset/commons/__sql/pr_commits.sql
@@ -1,0 +1,37 @@
+-- This query is used by the HUD's /pull page to populate the list of historical commits
+-- made against a given PR.
+-- This improves upon the default github commits view because it allows HUD to show jobs 
+-- that ran on a PR before it was rebased
+
+WITH
+-- Get all PRs that were merged into master, and get all the SHAs for commits from that PR which CI jobs ran against
+-- We need the shas because some jobs (like trunk) don't have a PR they explicitly ran against, but they _were_ run against
+-- a commit from a PR
+pr_shas AS (
+  SELECT DISTINCT
+    p.head_commit.timestamp as timestamp,
+    r.pull_requests[1].number AS pr_number,
+    j.head_sha AS sha,
+    p.head_commit.message,
+    CONCAT(
+      'https://github.com/pytorch/pytorch/pull/',
+      r.pull_requests[1].number
+    ) AS pr_url,
+    p.head_commit.url AS commit_url,
+  FROM
+    commons.workflow_job j
+    INNER JOIN commons.workflow_run r ON j.run_id = r.id
+    INNER JOIN commons.push p ON p.head_commit.id = j.head_sha
+  WHERE
+    1 = 1
+    AND LENGTH(r.pull_requests) = 1
+    AND r.repository.owner.login = :owner
+    AND r.pull_requests[1].head.repo.name = :repo
+    AND r.pull_requests[1].number = :pr_num
+
+)
+SELECT
+  *
+FROM
+  pr_shas
+ORDER BY timestamp

--- a/torchci/rockset/commons/__sql/pr_commits.sql
+++ b/torchci/rockset/commons/__sql/pr_commits.sql
@@ -9,16 +9,19 @@ WITH
 -- a commit from a PR
 pr_shas AS (
   SELECT DISTINCT
-    p.head_commit.timestamp as timestamp,
+    FORMAT_ISO8601(
+        PARSE_TIMESTAMP_ISO8601(p.head_commit.timestamp),
+        'America/Los_Angeles'
+    ) as timestamp,
     r.pull_requests[1].number AS pr_number,
-    j.head_sha AS sha,
+    p.head_commit.id AS sha,
     p.head_commit.message,
     CONCAT(
       'https://github.com/',
       :owner,
       '/',
       :repo,
-      '/',
+      '/pull/',
       r.pull_requests[1].number
     ) AS pr_url,
     p.head_commit.url AS commit_url,

--- a/torchci/rockset/commons/pr_commits.lambda.json
+++ b/torchci/rockset/commons/pr_commits.lambda.json
@@ -9,7 +9,7 @@
     {
       "name": "pr_num",
       "type": "int",
-      "value": "110578"
+      "value": "110976"
     },
     {
       "name": "repo",

--- a/torchci/rockset/commons/pr_commits.lambda.json
+++ b/torchci/rockset/commons/pr_commits.lambda.json
@@ -1,0 +1,21 @@
+{
+  "sql_path": "__sql/pr_commits.sql",
+  "default_parameters": [
+    {
+      "name": "owner",
+      "type": "string",
+      "value": "pytorch"
+    },
+    {
+      "name": "pr_num",
+      "type": "int",
+      "value": "110578"
+    },
+    {
+      "name": "repo",
+      "type": "string",
+      "value": "pytorch"
+    }
+  ],
+  "description": "Shows all commits for a PR"
+}

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -29,7 +29,8 @@
     "test_insights_overview": "42dbd5232f45fd53",
     "test_insights_latest_runs": "1871833a91cb8b1b",
     "master_commit_red_jobs": "4869b467679a616a",
-    "weekly_force_merge_stats": "d2264131599bcf6e"
+    "weekly_force_merge_stats": "d2264131599bcf6e",
+    "pr_commits": "914df76ede698de8"
   },
   "pytorch_dev_infra_kpis": {
     "monthly_contribution_stats": "c1a8751a22f6b6ce",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -30,7 +30,7 @@
     "test_insights_latest_runs": "1871833a91cb8b1b",
     "master_commit_red_jobs": "4869b467679a616a",
     "weekly_force_merge_stats": "d2264131599bcf6e",
-    "pr_commits": "94d1bf6f96a2cff0"
+    "pr_commits": "7ef5e3d100a56edc"
   },
   "pytorch_dev_infra_kpis": {
     "monthly_contribution_stats": "c1a8751a22f6b6ce",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -30,7 +30,7 @@
     "test_insights_latest_runs": "1871833a91cb8b1b",
     "master_commit_red_jobs": "4869b467679a616a",
     "weekly_force_merge_stats": "d2264131599bcf6e",
-    "pr_commits": "914df76ede698de8"
+    "pr_commits": "94d1bf6f96a2cff0"
   },
   "pytorch_dev_infra_kpis": {
     "monthly_contribution_stats": "c1a8751a22f6b6ce",


### PR DESCRIPTION
Makes it so that the HUD's commit dropdown shows all commits that have had CI run against them, _even if that commit has been rebased past_

This makes it so that you don't loose CI data when you rebase your PR or amend and force push your latest commit.

As a tradeoff, commits that were only committed locally but didn't have CI run against them (e.g. they were pushed to github as part of a set) will no longer show up in that dropdown, but they weren't useful anyways so it's fine

## Example
Old list from https://hud.pytorch.org/pr/110578
Hud lost all my commits before I squashed and rebased
<img width="505" alt="image" src="https://github.com/pytorch/test-infra/assets/4468967/3d49d647-af9d-4ac1-a42e-e90364010119">

New list, showing all my old commits. The commits with the same name are from amended commits that were force pushed.
Source: https://torchci-git-zainr-rebase-proof-fbopensource.vercel.app/pr/110578
<img width="605" alt="image" src="https://github.com/pytorch/test-infra/assets/4468967/8b4c2479-bf8b-4b85-b37e-adf6ec801b77">
