### PR TITLE
[HUD] Group artifacts under job

### DIFF
--- a/torchci/components/WorkflowBox.tsx
+++ b/torchci/components/WorkflowBox.tsx
@@ -23,7 +23,7 @@ function sortJobsByConclusion(jobA: JobData, jobB: JobData): number {
   return ("" + jobA.jobName).localeCompare("" + jobB.jobName); // the '' forces the type to be a string
 }
 
-function getWorkflowJobSummary(job: JobData, artifacts?: Artifact[]) {
+function WorkflowJobSummary(job: JobData, artifacts?: Artifact[]) {
   var queueTimeInfo = null;
   if (job.queueTimeS != null) {
     queueTimeInfo = (
@@ -101,7 +101,7 @@ export default function WorkflowBox({
       <>
         {jobs.sort(sortJobsByConclusion).map((job) => (
           <div key={job.id}>
-            {getWorkflowJobSummary(job, groupedArtifacts?.get(job.id))}
+            {WorkflowJobSummary(job, groupedArtifacts?.get(job.id))}
             {isFailedJob(job) && <LogViewer job={job} />}
           </div>
         ))}

--- a/torchci/components/WorkflowBox.tsx
+++ b/torchci/components/WorkflowBox.tsx
@@ -160,6 +160,9 @@ function Artifacts({
   if (error != null) {
     return <div>{error}</div>;
   }
+  if (artifacts.length == 0) {
+    return null;
+  }
 
   return (
     <>

--- a/torchci/components/WorkflowBox.tsx
+++ b/torchci/components/WorkflowBox.tsx
@@ -91,7 +91,7 @@ export default function WorkflowBox({
   const workflowId = jobs[0].workflowId;
   const anchorName = encodeURIComponent(workflowName.toLowerCase());
 
-  const { artifacts, error } = getArtifacts(workflowId);
+  const { artifacts, error } = useArtifacts(workflowId);
   const groupedArtifacts = groupArtifacts(artifacts);
 
   return (
@@ -111,7 +111,7 @@ export default function WorkflowBox({
   );
 }
 
-function getArtifacts(workflowId: string | undefined): {
+function useArtifacts(workflowId: string | undefined): {
   artifacts: any;
   error: any;
 } {

--- a/torchci/components/WorkflowBox.tsx
+++ b/torchci/components/WorkflowBox.tsx
@@ -136,7 +136,7 @@ function groupArtifacts(artifacts: Artifact[]) {
   const grouping = new Map<string | undefined, Artifact[]>();
   for (const artifact of artifacts) {
     try {
-      const id = artifact.name.match(new RegExp(".*[_-](\\d+)\\..*$"))?.at(1)!;
+      const id = artifact.name.match(new RegExp(".*[_-](\\d+)\\.[^.]+$"))?.at(1)!;
       parseInt(id); // Should raise exception if not an int
       if (!grouping.has(id)) {
         grouping.set(id, []);

--- a/torchci/components/WorkflowBox.tsx
+++ b/torchci/components/WorkflowBox.tsx
@@ -115,13 +115,13 @@ function useArtifacts(workflowId: string | undefined): {
   artifacts: any;
   error: any;
 } {
-  if (workflowId === undefined) {
-    return { artifacts: [], error: "No workflow ID" };
-  }
   const { data, error } = useSWR(`/api/artifacts/s3/${workflowId}`, fetcher, {
     refreshInterval: 60 * 1000,
     refreshWhenHidden: true,
   });
+  if (workflowId === undefined) {
+    return { artifacts: [], error: "No workflow ID" };
+  }
   if (data == null) {
     return { artifacts: [], error: "Loading..." };
   }
@@ -136,7 +136,9 @@ function groupArtifacts(artifacts: Artifact[]) {
   const grouping = new Map<string | undefined, Artifact[]>();
   for (const artifact of artifacts) {
     try {
-      const id = artifact.name.match(new RegExp(".*[_-](\\d+)\\.[^.]+$"))?.at(1)!;
+      const id = artifact.name
+        .match(new RegExp(".*[_-](\\d+)\\.[^.]+$"))
+        ?.at(1)!;
       parseInt(id); // Should raise exception if not an int
       if (!grouping.has(id)) {
         grouping.set(id, []);


### PR DESCRIPTION
Adds a new `Show artifacts` button/link that if clicked, shows the artifacts for that job.
<img width="477" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/77298898-a04f-4ae6-adeb-52c4cdf772c3">
Which artifacts are shown is based on job name, and it expects it to be in the form `<random stuff><either - or _><job id>.<file extension>`.  This is the current naming convention for test xmls, jsons, and log files.

Build artifacts generally look like `<build env, which is also usually the job name>/artifacts.zip`, so those also go under the corresponding build.

All artifacts are still visible at the bottom just in case.
