### PR TITLE
Only query for similar non-success jobs

### DIFF
--- a/torchci/lib/searchUtils.ts
+++ b/torchci/lib/searchUtils.ts
@@ -51,11 +51,13 @@ export async function searchSimilarFailures(
         must: must,
         // This limits the query to search only for failures, which are what we
         // care about
-        must_not: {
-          match: {
-            conclusion: "success",
+        must_not: [
+          {
+            match: {
+              conclusion: "success",
+            },
           },
-        },
+        ],
       },
     },
     // NB: It's important to sort by score first so that the most relevant results

--- a/torchci/lib/searchUtils.ts
+++ b/torchci/lib/searchUtils.ts
@@ -49,6 +49,13 @@ export async function searchSimilarFailures(
     query: {
       bool: {
         must: must,
+        // This limits the query to search only for failures, which are what we
+        // care about
+        must_not: {
+          match: {
+            conclusion: "success",
+          }
+        },
       },
     },
     // NB: It's important to sort by score first so that the most relevant results

--- a/torchci/lib/searchUtils.ts
+++ b/torchci/lib/searchUtils.ts
@@ -54,7 +54,7 @@ export async function searchSimilarFailures(
         must_not: {
           match: {
             conclusion: "success",
-          }
+          },
         },
       },
     },


### PR DESCRIPTION
As the name of the function `searchSimilarFailures` implies, the query shouldn't need to check for successful jobs

### Testing

The new failure on https://github.com/pytorch/pytorch/pull/111596 should be marked as flaky instead as this is a known issue in trunk.


```
curl --request POST \
    --url 'http://localhost:3000/api/drci/drci?prNumber=111596' \
    --data 'repo=pytorch'

{"111596":{"FAILED":[],"FLAKY":[{"workflowId":6579874873,"id":17877767763,"runnerName":"i-0c5ec556b639e35ef","name":"pull / linux-focal-cuda12.1-py3.10-gcc9-sm86 / test (default, 5, 5, linux.g5.4xlarge.nvidia.gpu)","jobName":"linux-focal-cuda12.1-py3.10-gcc9-sm86 / test (default, 5, 5, linux.g5.4xlarge.nvidia.gpu)","conclusion":"failure","completed_at":"2023-10-19T23:22:50Z","html_url":"https://github.com/pytorch/pytorch/actions/runs/6579874873/job/17877767763","head_branch":"gh/ezyang/2391/head","pr_number":111596,"head_sha":"ce9f3eeda5aa3014cd059cdfbd616ef76c76b803","failure_captures":["!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! KeyboardInterrupt !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"],"failure_line":"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! KeyboardInterrupt !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!","time":"2023-10-19T23:22:57.191074Z"}],"BROKEN_TRUNK":[{"workflowId":6579874901,"id":17877430058,"runnerName":"i-06305e4ca21ea7416","name":"Lint / lintrunner / linux-job","jobName":"lintrunner / linux-job","conclusion":"failure","completed_at":"2023-10-19T21:19:52Z","html_url":"https://github.com/pytorch/pytorch/actions/runs/6579874901/job/17877430058","head_branch":"gh/ezyang/2391/head","pr_number":111596,"head_sha":"ce9f3eeda5aa3014cd059cdfbd616ef76c76b803","failure_captures":[">>> Lint for torch/_dynamo/output_graph.py:"],"failure_line":">>> Lint for torch/_dynamo/output_graph.py:","time":"2023-10-19T21:20:03.324482Z"}],"UNSTABLE":[]}}
```