### PR TITLE
[TD] Collect test class durations

### DIFF
--- a/.github/workflows/update-test-times.yml
+++ b/.github/workflows/update-test-times.yml
@@ -35,13 +35,27 @@ jobs:
         env:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
 
-      - name: Push file to this repository
+      - name: Push test file times file to this repository
         if: github.event_name != 'pull_request'
         uses: dmnemec/copy_file_to_another_repo_action@5f40763ccee2954067adba7fb8326e4df33bcb92
         env:
            API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
         with:
           source_file: 'torchci/test-times.json'
+          destination_repo: 'pytorch/test-infra'
+          destination_folder: 'stats'
+          destination_branch: generated-stats
+          user_email: 'test-infra@pytorch.org'
+          user_name: 'PyTorch Test Infra'
+          commit_message: 'Updating test time stats'
+
+      - name: Push test class times file to this repository
+        if: github.event_name != 'pull_request'
+        uses: dmnemec/copy_file_to_another_repo_action@5f40763ccee2954067adba7fb8326e4df33bcb92
+        env:
+            API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          source_file: 'torchci/test-class-times.json'
           destination_repo: 'pytorch/test-infra'
           destination_folder: 'stats'
           destination_branch: generated-stats

--- a/torchci/rockset/commons/__sql/test_time_per_class.sql
+++ b/torchci/rockset/commons/__sql/test_time_per_class.sql
@@ -1,0 +1,69 @@
+WITH most_recent_strict_commits AS (
+    SELECT
+        push.head_commit.id as sha,
+    FROM
+        commons.push
+    WHERE
+        push.ref = 'refs/heads/viable/strict'
+        AND push.repository.full_name = 'pytorch/pytorch'
+    ORDER BY
+        push._event_time DESC
+    LIMIT
+        3
+), workflow AS (
+    SELECT
+        id
+    FROM
+        commons.workflow_run w
+        INNER JOIN most_recent_strict_commits c on w.head_sha = c.sha
+),
+job AS (
+    SELECT
+        j.name,
+        j.id,
+  		j.run_id
+    FROM
+        commons.workflow_job j
+        INNER JOIN workflow w on w.id = j.run_id
+),
+class_duration_per_job AS (
+    SELECT
+        test_run.invoking_file as file,
+        test_run.classname as classname,
+        SUM(time) as time,
+        REGEXP_EXTRACT(job.name, '^(.*) /', 1) as base_name,
+        REGEXP_EXTRACT(job.name, '/ test \((\w*),', 1) as test_config,
+    FROM
+        commons.test_run_summary test_run
+        /* `test_run` is ginormous and `job` is small, so lookup join is essential */
+        INNER JOIN job ON test_run.job_id = job.id HINT(join_strategy = lookup)
+    WHERE
+        /* cpp tests do not populate `file` for some reason. */
+        /* Exclude them as we don't include them in our slow test infra */
+        test_run.file IS NOT NULL
+    GROUP BY
+        test_run.invoking_file,
+        test_run.classname,
+        base_name,
+  		test_config,
+  		job.run_id
+)
+SELECT
+    REPLACE(file, '.', '/') AS file,
+    classname,
+    base_name,
+    test_config,
+    AVG(time) as time
+FROM
+    class_duration_per_job
+GROUP BY
+    file,
+    classname,
+    base_name,
+    test_config
+ORDER BY
+    base_name,
+    test_config,
+    file,
+    classname
+

--- a/torchci/rockset/commons/test_time_per_class.lambda.json
+++ b/torchci/rockset/commons/test_time_per_class.lambda.json
@@ -1,0 +1,5 @@
+{
+  "sql_path": "__sql/test_time_per_class.sql",
+  "default_parameters": [],
+  "description": "Test time for each class"
+}

--- a/torchci/rockset/commons/test_time_per_class_periodic_jobs.lambda.json
+++ b/torchci/rockset/commons/test_time_per_class_periodic_jobs.lambda.json
@@ -1,0 +1,5 @@
+{
+  "sql_path": "__sql/test_time_per_class_periodic_jobs.sql",
+  "default_parameters": [],
+  "description": ""
+}

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -30,7 +30,9 @@
     "test_insights_latest_runs": "1871833a91cb8b1b",
     "master_commit_red_jobs": "4869b467679a616a",
     "weekly_force_merge_stats": "d2264131599bcf6e",
-    "pr_commits": "7ef5e3d100a56edc"
+    "pr_commits": "7ef5e3d100a56edc",
+    "test_time_per_class": "630fa1ba72a3222b",
+    "test_time_per_class_periodic_jobs": "8984c4105920b6e5"
   },
   "pytorch_dev_infra_kpis": {
     "monthly_contribution_stats": "c1a8751a22f6b6ce",

--- a/torchci/scripts/test_update_test_times.py
+++ b/torchci/scripts/test_update_test_times.py
@@ -1,20 +1,20 @@
 import json
 import unittest
 
-from update_test_times import gen_test_times
+from update_test_times import gen_test_file_times, gen_test_class_times
 
 
-class TestUpdateTestTimes(unittest.TestCase):
+class TestUpdateTestTimesFile(unittest.TestCase):
     def make_rockset_row(self, job: str, config: str, file: str, time: float):
         return {"base_name": job, "test_config": config, "file": file, "time": time}
 
-    def test_gen_test_times_create_default(self) -> None:
+    def test_gen_test_file_times_create_default(self) -> None:
         data = [
             self.make_rockset_row("job", "config", "a", 1),
             self.make_rockset_row("job", "config", "b", 1),
             self.make_rockset_row("job", "config", "c", 1),
         ]
-        res = gen_test_times(data, {})
+        res = gen_test_file_times(data, {})
         expected = {
             "job": {"config": {"a": 1, "b": 1, "c": 1}},
             "default": {
@@ -24,13 +24,13 @@ class TestUpdateTestTimes(unittest.TestCase):
         }
         self.assertDictEqual(res, expected)
 
-    def test_gen_test_times_defaults_average(self) -> None:
+    def test_gen_test_file_times_defaults_average(self) -> None:
         data = [
             self.make_rockset_row("job", "config", "a", 1),
             self.make_rockset_row("job", "config2", "a", 6),
             self.make_rockset_row("job2", "config", "a", 5),
         ]
-        res = gen_test_times(data, {})
+        res = gen_test_file_times(data, {})
         expected = {
             "job": {"config": {"a": 1}, "config2": {"a": 6}},
             "job2": {"config": {"a": 5}},
@@ -43,26 +43,26 @@ class TestUpdateTestTimes(unittest.TestCase):
 
         self.assertDictEqual(res, expected)
 
-    def test_gen_test_times_override_default(self) -> None:
+    def test_gen_test_file_times_override_default(self) -> None:
         data = [
             self.make_rockset_row("default", "config", "a", 1),
             self.make_rockset_row("job", "config", "a", 6),
             self.make_rockset_row("default", "default", "a", 5),
         ]
-        res = gen_test_times(data, {})
+        res = gen_test_file_times(data, {})
         expected = {
             "default": {"config": {"a": 3.5}, "default": {"a": 4.0}},
             "job": {"config": {"a": 6}},
         }
         self.assertDictEqual(res, expected)
 
-    def test_gen_test_times_override_old_default(self) -> None:
+    def test_gen_test_file_times_override_old_default(self) -> None:
         data = [
             self.make_rockset_row("default", "config", "a", 1),
             self.make_rockset_row("job", "config", "a", 6),
             self.make_rockset_row("default", "default", "a", 5),
         ]
-        res = gen_test_times(data, {"default": {"config": {"a": 57}}})
+        res = gen_test_file_times(data, {"default": {"config": {"a": 57}}})
         expected = {
             "default": {"config": {"a": 3.5}, "default": {"a": 4.0}},
             "job": {"config": {"a": 6}},
@@ -72,7 +72,7 @@ class TestUpdateTestTimes(unittest.TestCase):
         data = [
             self.make_rockset_row("env", "config", "a", 1),
         ]
-        res = gen_test_times(
+        res = gen_test_file_times(
             data, {"default": {"config": {"a": 57}, "default": {"a": 100}}}
         )
         expected = {
@@ -81,14 +81,105 @@ class TestUpdateTestTimes(unittest.TestCase):
         }
         self.assertDictEqual(res, expected)
 
-    def test_gen_test_times_old_values_still_present(self) -> None:
+    def test_gen_test_file_times_old_values_still_present(self) -> None:
         data = [
             self.make_rockset_row("env", "config", "a", 5),
         ]
-        res = gen_test_times(data, {"env": {"config": {"b": 57}}})
+        res = gen_test_file_times(data, {"env": {"config": {"b": 57}}})
         expected = {
             "env": {"config": {"b": 57, "a": 5}},
             "default": {"config": {"a": 5.0}, "default": {"a": 5.0}},
+        }
+        self.assertDictEqual(res, expected)
+
+
+class TestUpdateTestTimesClass(unittest.TestCase):
+    def make_rockset_row(self, job: str, config: str, file: str, classname: str, time: float):
+        return {"base_name": job, "test_config": config, "file": file, "classname": classname, "time": time}
+
+    def test_gen_test_class_times_create_default(self) -> None:
+        data = [
+            self.make_rockset_row("job", "config", "a", "classa", 1),
+            self.make_rockset_row("job", "config", "a", "classb", 1),
+            self.make_rockset_row("job", "config", "c", "classc", 1),
+        ]
+        res = gen_test_class_times(data, {})
+        expected = {
+            "job": {"config": {"a": {"classa": 1, "classb": 1}, "c": {"classc": 1}}},
+            "default": {
+                "config": {"a": {"classa": 1.0, "classb": 1.0}, "c": {"classc": 1.0}},
+                "default": {"a": {"classa": 1.0, "classb": 1.0}, "c": {"classc": 1.0}},
+            },
+        }
+        self.assertDictEqual(res, expected)
+
+    def test_gen_test_class_times_defaults_average(self) -> None:
+        self.maxDiff = None
+        data = [
+            self.make_rockset_row("job", "config", "a", "classa", 1),
+            self.make_rockset_row("job", "config2", "a", "classa", 6),
+            self.make_rockset_row("job2", "config", "a", "classa", 5),
+        ]
+        res = gen_test_class_times(data, {})
+        expected = {
+            "job": {"config": {"a": {"classa": 1}}, "config2": {"a": {"classa": 6}}},
+            "job2": {"config": {"a": {"classa": 5}}},
+            "default": {
+                "config": {"a": {"classa": 3.0}},
+                "config2": {"a": {"classa": 6.0}},
+                "default": {"a": {"classa": 4.0}},
+            },
+        }
+
+        self.assertDictEqual(res, expected)
+
+    def test_gen_test_class_times_override_default(self) -> None:
+        data = [
+            self.make_rockset_row("default", "config", "a", "classa", 1),
+            self.make_rockset_row("job", "config", "a", "classa", 6),
+            self.make_rockset_row("default", "default", "a", "classa", 5),
+        ]
+        res = gen_test_class_times(data, {})
+        expected = {
+            "default": {"config": {"a": {"classa": 3.5}}, "default": {"a": {"classa": 4.0}}},
+            "job": {"config": {"a": {"classa": 6}}},
+        }
+        self.assertDictEqual(res, expected)
+
+    def test_gen_test_class_times_override_old_default(self) -> None:
+        self.maxDiff = None
+        data = [
+            self.make_rockset_row("default", "config", "a", "classa", 1),
+            self.make_rockset_row("job", "config", "a", "classa", 6),
+            self.make_rockset_row("default", "default", "a", "classa", 5),
+        ]
+        res = gen_test_class_times(data, {"default": {"config": {"a": {"classa": 57}}}})
+        expected = {
+            "default": {"config": {"a": {"classa": 3.5}}, "default": {"a": {"classa": 4.0}}},
+            "job": {"config": {"a": {"classa": 6}}},
+        }
+        self.assertDictEqual(res, expected)
+
+        data = [
+            self.make_rockset_row("env", "config", "a", "classa", 1),
+        ]
+        res = gen_test_class_times(
+            data, {"default": {"config": {"a": {"classa": 57}}, "default": {"a": {"classa": 100}}}}
+        )
+        expected = {
+            "default": {"config": {"a": {"classa": 1.0}}, "default": {"a": {"classa": 1.0}}},
+            "env": {"config": {"a": {"classa": 1}}},
+        }
+        self.assertDictEqual(res, expected)
+
+    def test_gen_test_class_times_old_values_still_present(self) -> None:
+        data = [
+            self.make_rockset_row("env", "config", "a", "classa", 5),
+        ]
+        res = gen_test_class_times(data, {"env": {"config": {"b": {"classb": 57}}}})
+        expected = {
+            "env": {"config": {"b": {"classb": 57}, "a": {"classa": 5}}},
+            "default": {"config": {"a": {"classa": 5.0}}, "default": {"a": {"classa": 5.0}}},
         }
         self.assertDictEqual(res, expected)
 

--- a/torchci/scripts/update_test_times.py
+++ b/torchci/scripts/update_test_times.py
@@ -11,9 +11,23 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 PROD_VERSIONS_FILE = REPO_ROOT / "torchci" / "rockset" / "prodVersions.json"
 TEST_TIMES_URL = "https://raw.githubusercontent.com/pytorch/test-infra/generated-stats/stats/test-times.json"
+TEST_CLASS_TIMES_URL = "https://raw.githubusercontent.com/pytorch/test-infra/generated-stats/stats/test-class-times.json"
 
+TEST_TIME_PER_FILE_QUERY_NAME = "test_time_per_file"
+TEST_TIME_PER_FILE_PERIODIC_JOBS_QUERY_NAME = "test_time_per_file_periodic_jobs"
+TEST_TIME_PER_CLASS_QUERY_NAME = "test_time_per_class"
+TEST_TIME_PER_CLASS_PERIODIC_JOBS_QUERY_NAME = "test_time_per_class_periodic_jobs"
 
-def get_data_from_rockset():
+def get_file_data_from_rockset():
+    return get_data_from_rockset(file_mode=True)
+
+def get_class_data_from_rockset():
+    return get_data_from_rockset(file_mode=False)
+
+def get_data_from_rockset(file_mode: bool):
+    general_query_name = TEST_TIME_PER_FILE_QUERY_NAME if file_mode else TEST_TIME_PER_CLASS_QUERY_NAME
+    periodic_query_name = TEST_TIME_PER_FILE_PERIODIC_JOBS_QUERY_NAME if file_mode else TEST_TIME_PER_CLASS_PERIODIC_JOBS_QUERY_NAME
+
     rockset_client = rockset.RocksetClient(
         host="api.usw2a1.rockset.com", api_key=os.environ["ROCKSET_API_KEY"]
     )
@@ -21,23 +35,33 @@ def get_data_from_rockset():
         prod_versions = json.load(f)
 
     rockset_result = rockset_client.QueryLambdas.execute_query_lambda(
-        query_lambda="test_time_per_file",
-        version=prod_versions["commons"]["test_time_per_file"],
+        query_lambda=general_query_name,
+        version=prod_versions["commons"][general_query_name],
         workspace="commons",
     ).results
     periodic_rockset_result = rockset_client.QueryLambdas.execute_query_lambda(
-        query_lambda="test_time_per_file_periodic_jobs",
-        version=prod_versions["commons"]["test_time_per_file_periodic_jobs"],
+        query_lambda=periodic_query_name,
+        version=prod_versions["commons"][periodic_query_name],
         workspace="commons",
     ).results
     return rockset_result + periodic_rockset_result
 
 
-def download_old_test_times():
-    return json.loads(requests.get(url=TEST_TIMES_URL).text)
+def download_old_test_file_times():
+    return download_json(TEST_TIMES_URL)
 
+def download_old_test_class_times():
+    return download_json(TEST_CLASS_TIMES_URL)
 
-def convert_to_default_dict(d):
+def download_json(url):
+    req = requests.get(url=url)
+    if req.status_code == 404:
+        print(f"Did not find any test times at {url}")
+        return {}
+    req.raise_for_status()
+    return json.loads(req.text)
+
+def convert_test_file_times_to_default_dict(d):
     new_d = defaultdict(lambda: defaultdict(lambda: defaultdict(float)))
     for env in d:
         for config in d[env]:
@@ -46,12 +70,21 @@ def convert_to_default_dict(d):
     return new_d
 
 
-def gen_test_times(rockset_results, old_test_times):
+def convert_test_class_times_to_default_dict(d):
+    new_d = defaultdict(lambda: defaultdict(lambda: defaultdict((lambda: defaultdict(float)))))
+    for env in d:
+        for config in d[env]:
+            for file in d[env][config]:
+                for testclass in d[env][config][file]:
+                    new_d[env][config][file][testclass] = d[env][config][file][testclass]
+    return new_d
+
+def gen_test_file_times(rockset_results, old_test_times):
     # Use old test times because sometimes we want to manually edit the test
     # times json and want those changes to persist.  Unfortunately this means
     # that the test times json grows and never shrinks, but we can edit the json
     # to make it smaller.  Defaults are always overriden.
-    test_times = convert_to_default_dict(old_test_times)
+    test_times = convert_test_file_times_to_default_dict(old_test_times)
     test_times_no_build_env = defaultdict(lambda: defaultdict(list))
     test_times_no_test_config = defaultdict(list)
     for row in rockset_results:
@@ -74,11 +107,48 @@ def gen_test_times(rockset_results, old_test_times):
     return test_times
 
 
+def gen_test_class_times(rockset_results, old_test_times):
+    # Use old test times because sometimes we want to manually edit the test
+    # times json and want those changes to persist.  Unfortunately this means
+    # that the test times json grows and never shrinks, but we can edit the json
+    # to make it smaller.  Defaults are always overriden.
+    test_times = convert_test_class_times_to_default_dict(old_test_times)
+
+    test_times_no_build_env = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
+    test_times_no_test_config = defaultdict(lambda: defaultdict(list))
+    for row in rockset_results:
+        test_times[row["base_name"]][row["test_config"]][row["file"]][row["classname"]] = row["time"]
+        test_times_no_build_env[row["test_config"]][row["file"]][row["classname"]].append(row["time"])
+        test_times_no_test_config[row["file"]][row["classname"]].append(row["time"])
+
+    # Add defaults
+    for config in test_times_no_build_env:
+        for file in test_times_no_build_env[config]:
+            for testclass, times in test_times_no_build_env[config][file].items():
+                test_times_no_build_env[config][file][testclass] = sum(times) / len(times)
+    for file in test_times_no_test_config:
+        for testclass, times in test_times_no_test_config[file].items():
+            test_times_no_test_config[file][testclass] = sum(times) / len(times)
+
+    # Default should never be a build env
+    test_times["default"] = test_times_no_build_env
+    # Replace default's default with our own to account for tests that aren't
+    # usually in the default test config like distributed
+    test_times["default"]["default"] = test_times_no_test_config
+    return test_times
+
+
 def main() -> None:
-    test_times = gen_test_times(get_data_from_rockset(), download_old_test_times())
+    test_file_times = gen_test_file_times(get_file_data_from_rockset(), download_old_test_file_times())
 
     with open("test-times.json", "w") as f:
-        f.write(json.dumps(test_times, indent=2, sort_keys=True))
+        f.write(json.dumps(test_file_times, indent=2, sort_keys=True))
+
+
+    test_class_times = gen_test_class_times(get_class_data_from_rockset(), download_old_test_class_times())
+
+    with open("test-class-times.json", "w") as f:
+        f.write(json.dumps(test_class_times, indent=2, sort_keys=True))
 
 
 if __name__ == "__main__":

--- a/torchci/scripts/update_test_times.py
+++ b/torchci/scripts/update_test_times.py
@@ -144,7 +144,6 @@ def main() -> None:
     with open("test-times.json", "w") as f:
         f.write(json.dumps(test_file_times, indent=2, sort_keys=True))
 
-
     test_class_times = gen_test_class_times(get_class_data_from_rockset(), download_old_test_class_times())
 
     with open("test-class-times.json", "w") as f:


### PR DESCRIPTION
This will later be used by test class granularity heuristics.

Patterns are all based off of how we currently collect this data at the test file granularity level