### PR TITLE
Fix the number of hooks conditionally rendered by hasArtifacts

### DIFF
--- a/torchci/components/WorkflowBox.tsx
+++ b/torchci/components/WorkflowBox.tsx
@@ -8,7 +8,7 @@ import JobSummary from "./JobSummary";
 import LogViewer from "./LogViewer";
 import { getConclusionSeverityForSorting } from "../lib/JobClassifierUtil";
 import TestInsightsLink from "./TestInsights";
-import { useState } from "react";
+import { useState, CSSProperties } from "react";
 
 function sortJobsByConclusion(jobA: JobData, jobB: JobData): number {
   // Show failed jobs first, then pending jobs, then successful jobs
@@ -46,6 +46,7 @@ function WorkflowJobSummary(job: JobData, artifacts?: Artifact[]) {
 
   const [showArtifacts, setShowArtifacts] = useState(false);
   const hasArtifacts = artifacts && artifacts.length > 0;
+  const hidden: CSSProperties = { visibility: "hidden" };
 
   return (
     <>
@@ -57,12 +58,12 @@ function WorkflowJobSummary(job: JobData, artifacts?: Artifact[]) {
         {separator}
         {durationInfo}
         <TestInsightsLink job={job} separator={", "} />,{" "}
-        {hasArtifacts && (
-          <a onClick={() => setShowArtifacts(!showArtifacts)}>
-            {" "}
-            Show artifacts,{" "}
-          </a>
-        )}
+        <a
+          onClick={() => setShowArtifacts(!showArtifacts)}
+          style={hasArtifacts ? {} : hidden}
+        >
+          {hasArtifacts ? "Show artifacts," : ""}
+        </a>
         <a target="_blank" rel="noreferrer" href={job.logUrl}>
           Raw logs
         </a>

--- a/torchci/components/WorkflowBox.tsx
+++ b/torchci/components/WorkflowBox.tsx
@@ -43,10 +43,7 @@ function WorkflowJobSummary(job: JobData, artifacts?: Artifact[]) {
   }
 
   var separator = queueTimeInfo && durationInfo ? ", " : "";
-
-  const [showArtifacts, setShowArtifacts] = useState(false);
   const hasArtifacts = artifacts && artifacts.length > 0;
-  const hidden: CSSProperties = { visibility: "hidden" };
 
   return (
     <>
@@ -58,20 +55,17 @@ function WorkflowJobSummary(job: JobData, artifacts?: Artifact[]) {
         {separator}
         {durationInfo}
         <TestInsightsLink job={job} separator={", "} />,{" "}
-        <a
-          onClick={() => setShowArtifacts(!showArtifacts)}
-          style={hasArtifacts ? {} : hidden}
-        >
-          {hasArtifacts ? "Show artifacts," : ""}
-        </a>
         <a target="_blank" rel="noreferrer" href={job.logUrl}>
           Raw logs
         </a>
-        {hasArtifacts &&
-          showArtifacts &&
-          artifacts?.map((artifact, ind) => {
-            return <JobArtifact key={ind} {...artifact} />;
-          })}
+        {hasArtifacts && (
+          <details>
+            <summary>{hasArtifacts ? "Show artifacts" : ""}</summary>
+            {artifacts?.map((artifact, ind) => {
+              return <JobArtifact key={ind} {...artifact} />;
+            })}
+          </details>
+        )}
       </small>
     </>
   );

--- a/torchci/lib/searchUtils.ts
+++ b/torchci/lib/searchUtils.ts
@@ -5,7 +5,7 @@ export const WORKFLOW_JOB_INDEX = "torchci-workflow-job";
 // https://www.elastic.co/guide/en/elasticsearch/reference/7.17/similarity.html#similarity
 // OpenSearch uses https://en.wikipedia.org/wiki/Okapi_BM25 by default.  TODO: learn more
 // about which is a reasonable value here and how to tune it
-export const MIN_SCORE = 10.0;
+export const MIN_SCORE = 1.0;
 export const MAX_SIZE = 20;
 
 export async function searchSimilarFailures(


### PR DESCRIPTION
Keep the number of hooks the same but hide the <a> tag if there is no artifacts.  This probably fixes the error reported on Tree Hugger when loading https://hud.pytorch.org/pr/111935 

Also we cannot use hook, i.e. `useState` in `WorkflowBox` because the number of jobs can change dynamically on PR or commit pages.