### PR TITLE
[TorchFix] Deprecated codemods to honor aliases

### DIFF
--- a/tools/torchfix/tests/fixtures/deprecated_symbols/codemod/aliased_import.py
+++ b/tools/torchfix/tests/fixtures/deprecated_symbols/codemod/aliased_import.py
@@ -1,5 +1,10 @@
-import torch as troch
+import torch
+import torch as foo
+import torch as bar
+import torch as baz
 
-A = troch.arange(9).reshape(3, 3)
-A3 = troch.chain_matmul(A, A, A)
+A = torch.arange(9.0).reshape(3, 3)
+A3 = foo.chain_matmul(A, A, A)
+rc1 = bar.cholesky(torch.mm(A3.t(), A3))
+rc2 = baz.qr(torch.mm(A.t(), A))
 

--- a/tools/torchfix/tests/fixtures/deprecated_symbols/codemod/aliased_import.py
+++ b/tools/torchfix/tests/fixtures/deprecated_symbols/codemod/aliased_import.py
@@ -1,0 +1,5 @@
+import torch as troch
+
+A = troch.arange(9).reshape(3, 3)
+A3 = troch.chain_matmul(A, A, A)
+

--- a/tools/torchfix/tests/fixtures/deprecated_symbols/codemod/aliased_import.py.out
+++ b/tools/torchfix/tests/fixtures/deprecated_symbols/codemod/aliased_import.py.out
@@ -1,5 +1,10 @@
-import torch as troch
+import torch
+import torch as foo
+import torch as bar
+import torch as baz
 
-A = troch.arange(9).reshape(3, 3)
-A3 = troch.linalg.multi_dot([A, A, A])
+A = torch.arange(9.0).reshape(3, 3)
+A3 = foo.linalg.multi_dot([A, A, A])
+rc1 = bar.linalg.cholesky(torch.mm(A3.t(), A3))
+rc2 = baz.linalg.qr(torch.mm(A.t(), A))
 

--- a/tools/torchfix/tests/fixtures/deprecated_symbols/codemod/aliased_import.py.out
+++ b/tools/torchfix/tests/fixtures/deprecated_symbols/codemod/aliased_import.py.out
@@ -1,0 +1,5 @@
+import torch as troch
+
+A = troch.arange(9).reshape(3, 3)
+A3 = troch.linalg.multi_dot([A, A, A])
+

--- a/tools/torchfix/torchfix/common.py
+++ b/tools/torchfix/torchfix/common.py
@@ -122,7 +122,7 @@ def deep_multi_replace(tree, replacement_map):
     return tree.visit(MultiChildReplacementTransformer(replacement_map))
 
 
-def get_module_name(node: cst.Call, default: Optional[str]=None) -> Optional[str]:
+def get_module_name(node: cst.Call, default: Optional[str] = None) -> Optional[str]:
     if not isinstance(node.func, cst.Attribute):
         return default
     if not isinstance(node.func.value, cst.Name):

--- a/tools/torchfix/torchfix/common.py
+++ b/tools/torchfix/torchfix/common.py
@@ -120,3 +120,11 @@ def deep_multi_replace(tree, replacement_map):
             return updated_node
 
     return tree.visit(MultiChildReplacementTransformer(replacement_map))
+
+
+def get_module_name(node: cst.Call, default: Optional[str]=None) -> Optional[str]:
+    if not isinstance(node.func, cst.Attribute):
+        return default
+    if not isinstance(node.func.value, cst.Name):
+        return default
+    return node.func.value.value

--- a/tools/torchfix/torchfix/visitors/deprecated_symbols/chain_matmul.py
+++ b/tools/torchfix/torchfix/visitors/deprecated_symbols/chain_matmul.py
@@ -1,4 +1,5 @@
 import libcst as cst
+from ...common import get_module_name
 
 
 def call_replacement_chain_matmul(node: cst.Call) -> cst.CSTNode:
@@ -19,7 +20,7 @@ def call_replacement_chain_matmul(node: cst.Call) -> cst.CSTNode:
         replacement_args = [matrices_arg]
     else:
         replacement_args = [matrices_arg, out_arg]
-    replacement = cst.parse_expression("torch.linalg.multi_dot(args)")
+    replacement = cst.parse_expression(f"{get_module_name(node, 'torch')}.linalg.multi_dot(args)")
     replacement = replacement.with_changes(args=replacement_args)
 
     return replacement

--- a/tools/torchfix/torchfix/visitors/deprecated_symbols/chain_matmul.py
+++ b/tools/torchfix/torchfix/visitors/deprecated_symbols/chain_matmul.py
@@ -20,7 +20,8 @@ def call_replacement_chain_matmul(node: cst.Call) -> cst.CSTNode:
         replacement_args = [matrices_arg]
     else:
         replacement_args = [matrices_arg, out_arg]
-    replacement = cst.parse_expression(f"{get_module_name(node, 'torch')}.linalg.multi_dot(args)")
+    module_name = get_module_name(node, 'torch')
+    replacement = cst.parse_expression(f"{module_name}.linalg.multi_dot(args)")
     replacement = replacement.with_changes(args=replacement_args)
 
     return replacement

--- a/tools/torchfix/torchfix/visitors/deprecated_symbols/cholesky.py
+++ b/tools/torchfix/torchfix/visitors/deprecated_symbols/cholesky.py
@@ -25,8 +25,7 @@ def call_replacement_cholesky(node: cst.Call) -> cst.CSTNode:
             value=[input_arg],
         )
     else:
-        replacement = cst.parse_expression(f"{module_name}.linalg.cholesky(A)").with_changes(
-            args=[input_arg]
-        )
+        replacement = cst.parse_expression(f"{module_name}.linalg.cholesky(A)")
+        replacement = replacement.with_changes(args=[input_arg])
 
     return replacement

--- a/tools/torchfix/torchfix/visitors/deprecated_symbols/qr.py
+++ b/tools/torchfix/torchfix/visitors/deprecated_symbols/qr.py
@@ -1,6 +1,6 @@
 import libcst as cst
 from typing import Optional
-from ...common import TorchVisitor
+from ...common import (TorchVisitor, get_module_name)
 
 
 def call_replacement_qr(node: cst.Call) -> Optional[cst.CSTNode]:
@@ -27,7 +27,7 @@ def call_replacement_qr(node: cst.Call) -> Optional[cst.CSTNode]:
             comma=cst.MaybeSentinel.DEFAULT
         )
         replacement_args = [input_arg]
-    replacement = cst.parse_expression("torch.linalg.qr(args)")
+    replacement = cst.parse_expression(f"{get_module_name(node, 'torch')}.linalg.qr(args)")
     replacement = replacement.with_changes(args=replacement_args)
 
     return replacement

--- a/tools/torchfix/torchfix/visitors/deprecated_symbols/qr.py
+++ b/tools/torchfix/torchfix/visitors/deprecated_symbols/qr.py
@@ -27,7 +27,8 @@ def call_replacement_qr(node: cst.Call) -> Optional[cst.CSTNode]:
             comma=cst.MaybeSentinel.DEFAULT
         )
         replacement_args = [input_arg]
-    replacement = cst.parse_expression(f"{get_module_name(node, 'torch')}.linalg.qr(args)")
+    module_name = get_module_name(node, "torch")
+    replacement = cst.parse_expression(f"{module_name}.linalg.qr(args)")
     replacement = replacement.with_changes(args=replacement_args)
 
     return replacement


### PR DESCRIPTION
By introducing `torchfix.common.get_module_name(node: cst.Call)` and using it in deprecated symbols codemods


Fixes https://github.com/pytorch/test-infra/issues/4452