### PR TITLE
Count models with 0 speedup as failures

### DIFF
--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -182,6 +182,7 @@ function computePassrate(
     const workflowId = record.workflow_id;
     const suite = record.suite;
     const model = record.name;
+    const accuracy = record.accuracy;
 
     // Use clear compiler name to avoid confusion about what they do
     const compiler =
@@ -210,9 +211,13 @@ function computePassrate(
       passCount[bucket][workflowId][suite][compiler] = 0;
     }
 
+    // If the model pass accuracy check but fails the performance benchmark with an
+    // 0 speedup, it should be counted as a failure. However, `pass_due_to_skip` is
+    // an exception and it's ok to have 0 speedup there
     if (
-      isPass(bucket, workflowId, suite, compiler, model, passingModels) &&
-      record.speedup !== 0.0
+      (isPass(bucket, workflowId, suite, compiler, model, passingModels) &&
+        record.speedup !== 0.0) ||
+      accuracy === "pass_due_to_skip"
     ) {
       passCount[bucket][workflowId][suite][compiler] += 1;
     }

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -210,7 +210,10 @@ function computePassrate(
       passCount[bucket][workflowId][suite][compiler] = 0;
     }
 
-    if (isPass(bucket, workflowId, suite, compiler, model, passingModels)) {
+    if (
+      isPass(bucket, workflowId, suite, compiler, model, passingModels) &&
+      record.speedup !== 0.0
+    ) {
       passCount[bucket][workflowId][suite][compiler] += 1;
     }
 


### PR DESCRIPTION
Reported by @xmfan where the dashboard counts models with 0 speedup (failed perf benchmark) as success.  They should be count as failures instead.

### Testing
https://torchci-git-fork-huydhn-failed-benchmark-models-fbopensource.vercel.app/benchmark/compilers