### PR TITLE
Increase max runners for 'linux.arm64.2xlarge' to 200

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -96,7 +96,7 @@ runner_types:
     disk_size: 256
     instance_type: t4g.2xlarge
     is_ephemeral: false
-    max_available: 100
+    max_available: 200
     os: linux
   windows.4xlarge:
     disk_size: 256


### PR DESCRIPTION
![Screenshot 2023-10-25 at 12 12 47](https://github.com/pytorch/test-infra/assets/4520845/8298a70d-e05a-4d5c-85aa-ac39630296db)
