### PR TITLE
Add an option to limit failures search to a specific branch

### DIFF
--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -271,6 +271,7 @@ export async function querySimilarFailures(
     client,
     failure,
     workflowName,
+    "",
     WORKFLOW_JOB_INDEX,
     startDate.toISOString(),
     endDate.toISOString(),

--- a/torchci/lib/searchUtils.ts
+++ b/torchci/lib/searchUtils.ts
@@ -12,6 +12,7 @@ export async function searchSimilarFailures(
   client: Client,
   query: string,
   workflowName: string,
+  branchName: string,
   index: string,
   startDate: string,
   endDate: string,
@@ -39,6 +40,15 @@ export async function searchSimilarFailures(
     must.push({
       match: {
         workflow_name: workflowName,
+      },
+    });
+  }
+  // If specify, limit the query to only this branch name. This is used to
+  // query only failures from specific branches like main or release
+  if (branchName !== "") {
+    must.push({
+      match: {
+        head_branch: branchName,
       },
     });
   }

--- a/torchci/pages/api/search.ts
+++ b/torchci/pages/api/search.ts
@@ -16,6 +16,7 @@ export default async function handler(
 ) {
   const failure = req.query.failure as string;
   const workflowName = (req.query.workflowName as string) ?? "";
+  const branchName = (req.query.branchName as string) ?? "";
   const index = (req.query.index as string) ?? WORKFLOW_JOB_INDEX;
   const startDate = req.query.startDate as string;
   const endDate = req.query.endDate as string;
@@ -45,6 +46,7 @@ export default async function handler(
         client,
         failure,
         workflowName,
+        branchName,
         index,
         startDate,
         endDate,

--- a/torchci/test/drciUtils.test.ts
+++ b/torchci/test/drciUtils.test.ts
@@ -112,6 +112,7 @@ describe("Test various utils used by Dr.CI", () => {
           "TESTING",
           job.failure_captures.join(" "),
           "",
+          "",
           searchUtils.WORKFLOW_JOB_INDEX,
           mockStartDate,
           mockEndDate,
@@ -139,6 +140,7 @@ describe("Test various utils used by Dr.CI", () => {
         [
           "TESTING",
           job.failure_captures.join(" "),
+          "",
           "",
           searchUtils.WORKFLOW_JOB_INDEX,
           dayjs(baseCommitDate)
@@ -172,6 +174,7 @@ describe("Test various utils used by Dr.CI", () => {
           "TESTING",
           job.failure_captures.join(" "),
           workflowName,
+          "",
           searchUtils.WORKFLOW_JOB_INDEX,
           dayjs(baseCommitDate)
             .subtract(lookbackPeriodInHours, "hour")


### PR DESCRIPTION
Expose `branchName` as an option to limit failures search to that specific branch, for example, only failures from `main`

### Testing

Spot check on https://github.com/pytorch/pytorch/pull/111463 to make sure everything still works correctly

```
curl --request POST \
    --url 'http://localhost:3000/api/drci/drci?prNumber=111463' \
    --data 'repo=pytorch'
```