### PR TITLE
Add isSameAuthor check when classifying flaky tests with Dr.CI

### DIFF
--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -14,7 +14,7 @@ import {
   MAX_SIZE,
 } from "lib/searchUtils";
 import { RecentWorkflowsData, JobData } from "lib/types";
-import { isSameHeadBranch, isSameFailure } from "lib/jobUtils";
+import { isSameAuthor, isSameFailure } from "lib/jobUtils";
 
 export const NUM_MINUTES = 30;
 export const REPO: string = "pytorch";
@@ -319,9 +319,11 @@ export async function hasSimilarFailures(
       failure_lines: record.failureLines,
     };
 
-    // Only count different jobs with the same failure
+    // Only count different jobs with the same failure. To avoid FP, PRs from the
+    // same author are treated as the same till we could figure out a better way
+    // to separate them
     if (
-      !isSameHeadBranch(job.head_branch, record.branch) &&
+      !isSameAuthor(job.head_branch, record.branch) &&
       job.id !== failure.id &&
       isSameFailure(job, failure)
     ) {

--- a/torchci/test/jobUtils.test.ts
+++ b/torchci/test/jobUtils.test.ts
@@ -1,7 +1,7 @@
 import {
   removeJobNameSuffix,
   isSameFailure,
-  isSameHeadBranch,
+  isSameAuthor,
   removeCancelledJobAfterRetry,
 } from "../lib/jobUtils";
 import { JobData, RecentWorkflowsData, BasicJobData } from "lib/types";
@@ -55,30 +55,44 @@ describe("Test various job utils", () => {
     ).toStrictEqual("Test `run_test.py` is usable without boto3/rockset");
   });
 
-  test("test isSameHeadBranch", () => {
-    expect(isSameHeadBranch("", "")).toEqual(false);
+  test("test isSameAuthor", () => {
+    expect(isSameAuthor("", "")).toEqual(false);
 
-    expect(isSameHeadBranch("mock-branch", "")).toEqual(false);
+    expect(isSameAuthor("mock-branch", "")).toEqual(false);
 
-    expect(isSameHeadBranch("", "mock-branch")).toEqual(false);
+    expect(isSameAuthor("", "mock-branch")).toEqual(false);
 
-    expect(isSameHeadBranch("mock-branch", "mock-branch")).toEqual(true);
+    expect(isSameAuthor("mock-branch", "mock-branch")).toEqual(true);
 
-    expect(isSameHeadBranch("ciflow/trunk/1", "ciflow/trunk/2")).toEqual(false);
+    expect(isSameAuthor("one-branch", "another-branch")).toEqual(false);
 
-    expect(isSameHeadBranch("ciflow/trunk/1", "ciflow/trunk/1")).toEqual(true);
+    expect(isSameAuthor("ciflow/trunk/1", "ciflow/trunk/2")).toEqual(false);
 
-    expect(isSameHeadBranch("gh/user/1/head", "gh/user/2/head")).toEqual(true);
+    expect(isSameAuthor("ciflow/trunk/1", "ciflow/trunk/1")).toEqual(true);
 
-    expect(isSameHeadBranch("gh/user/1/head", "gh/user/1/head")).toEqual(true);
+    expect(isSameAuthor("gh/user/1/head", "gh/user/2/head")).toEqual(true);
 
-    expect(
-      isSameHeadBranch("gh/user/1/head", "gh/another-user/2/head")
-    ).toEqual(false);
+    expect(isSameAuthor("gh/user/1/head", "gh/user/1/head")).toEqual(true);
 
-    expect(
-      isSameHeadBranch("gh/user/1/head", "gh/another-user/1/head")
-    ).toEqual(false);
+    expect(isSameAuthor("gh/user/1/head", "user/debug-branch")).toEqual(true);
+
+    expect(isSameAuthor("gh/user/1/head", "gh/another-user/2/head")).toEqual(
+      false
+    );
+
+    expect(isSameAuthor("gh/user/1/head", "gh/another-user/1/head")).toEqual(
+      false
+    );
+
+    expect(isSameAuthor("gh/user/1/head", "debug-branch")).toEqual(false);
+
+    expect(isSameAuthor("user/one-branch", "user/another-branch")).toEqual(
+      true
+    );
+
+    expect(isSameAuthor("user/one-branch", "another-user/one-branch")).toEqual(
+      false
+    );
   });
 
   test("test isSameFailure", () => {


### PR DESCRIPTION
I strengthen the `isSameHeadBranch` check to become `isSameAuthor` to avoid an FP in flaky detection when the same author submits multiple PRs of the same change.  For example,

* Cherry picking https://github.com/pytorch/pytorch/pull/111845
* Draft PR and then submit a real PR (I remember seeing an example of this, but couldn't find the PR number now)

### Testing

```
curl --request POST \
    --url 'http://localhost:3000/api/drci/drci?prNumber=111845' \
    --data 'repo=pytorch'
```