### PR TITLE
[bot] Remove flaky detection for flaky across jobs

### DIFF
--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -36,20 +36,17 @@ async function disableFlakyTestsAndReenableNonFlakyTests() {
     octokit,
     flakyTests,
     flakyTestsAcrossFileReruns,
-    flakyTestsAcrossJobs,
     issues,
     disabledNonFlakyTests,
   ] = await Promise.all([
     getOctokit(owner, repo),
     fetchFlakyTests(`${NUM_HOURS}`),
     fetchFlakyTestsAcrossFileReruns(`${NUM_HOURS}`),
-    fetchFlakyTestsAcrossJobs(`${NUM_HOURS_ACROSS_JOBS}`), // use a larger time window so we can get more data
     fetchIssuesByLabel("skipped"),
     fetchDisabledNonFlakyTests(),
   ]);
 
   const allFlakyTests = flakyTests
-    .concat(flakyTestsAcrossJobs)
     .concat(flakyTestsAcrossFileReruns);
   // If the test is flaky only on PRs, we should not disable it yet.
   const flakyTestsOnTrunk = filterThreshold(

--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -46,8 +46,7 @@ async function disableFlakyTestsAndReenableNonFlakyTests() {
     fetchDisabledNonFlakyTests(),
   ]);
 
-  const allFlakyTests = flakyTests
-    .concat(flakyTestsAcrossFileReruns);
+  const allFlakyTests = flakyTests.concat(flakyTestsAcrossFileReruns);
   // If the test is flaky only on PRs, we should not disable it yet.
   const flakyTestsOnTrunk = filterThreshold(
     filterOutPRFlakyTests(allFlakyTests)


### PR DESCRIPTION
Currently buggy due to tests jumping from shard to shard.