### PR TITLE
Track the daily number of open disabled issues

### DIFF
--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -206,6 +206,19 @@ export default function Kpis() {
           groupByFieldName={"percentile"}
         />
       </Grid>
+
+      <Grid item xs={12} lg={6} height={ROW_HEIGHT}>
+        <TimeSeriesPanel
+          title={"Total number of open disabled tests (Daily)"}
+          queryName={"disabled_test_historical"}
+          queryCollection={"metrics"}
+          queryParams={[...timeParams]}
+          granularity={"day"}
+          timeFieldName={"granularity_bucket"}
+          yAxisFieldName={"number_of_open_disabled_tests"}
+          yAxisRenderer={(duration) => duration}
+        />
+      </Grid>
     </Grid>
   );
 }

--- a/torchci/rockset/metrics/__sql/disabled_test_historical.sql
+++ b/torchci/rockset/metrics/__sql/disabled_test_historical.sql
@@ -1,6 +1,7 @@
 --- This query returns the number of new disabled tests (number_of_new_disabled_tests)
 --- and the number of open disabled tests (number_of_open_disabled_tests) daily
-WITH --- There could be day where there is no new issue or no issue is closed and we want
+WITH
+--- There could be day where there is no new issue or no issue is closed and we want
 --- the count on that day to be 0
 buckets AS (
   SELECT

--- a/torchci/rockset/metrics/__sql/disabled_test_historical.sql
+++ b/torchci/rockset/metrics/__sql/disabled_test_historical.sql
@@ -1,34 +1,121 @@
-WITH
-disabled_tests AS (
-    SELECT
-        FORMAT_ISO8601(
-            DATE_TRUNC(
-                :granularity,
-                issues._event_time AT TIME ZONE :timezone
-            )
-        ) AS granularity_bucket,
-        COUNT(issues.title) as number_of_new_disabled_tests,
-    FROM
-        commons.issues
-    WHERE
-        issues.title LIKE '%DISABLED%'
-    GROUP BY
-        granularity_bucket
+--- This query returns the number of new disabled tests (number_of_new_disabled_tests)
+--- and the number of open disabled tests (number_of_open_disabled_tests) daily
+WITH --- There could be day where there is no new issue or no issue is closed and we want
+--- the count on that day to be 0
+buckets AS (
+  SELECT
+    DATE_TRUNC(
+      : granularity,
+      CAST(issues.created_at AS TIMESTAMP) AT TIME ZONE : timezone
+    ) AS granularity_bucket
+  FROM
+    commons.issues
+  WHERE
+    issues.created_at IS NOT NULL
+  UNION
+  SELECT
+    DATE_TRUNC(
+      : granularity,
+      CAST(issues.closed_at AS TIMESTAMP) AT TIME ZONE : timezone
+    ) AS granularity_bucket
+  FROM
+    commons.issues
+  WHERE
+    issues.closed_at IS NOT NULL
 ),
-total_disabled_tests AS (
-    SELECT
-        granularity_bucket,
-        number_of_new_disabled_tests,
-        SUM(number_of_new_disabled_tests) OVER (ORDER BY granularity_bucket) AS total_number_of_disabled_tests
-    FROM
-        disabled_tests
+--- Count the newly created disabled tests
+raw_new_disabled_tests AS (
+  SELECT
+    DATE_TRUNC(
+      : granularity,
+      CAST(issues.created_at AS TIMESTAMP) AT TIME ZONE : timezone
+    ) AS granularity_bucket,
+    COUNT(title) AS number_of_new_disabled_tests,
+  FROM
+    commons.issues
+  WHERE
+    issues.title LIKE '%DISABLED%'
+  GROUP BY
+    granularity_bucket
+),
+new_disabled_tests AS (
+  SELECT
+    buckets.granularity_bucket,
+    COALESCE(number_of_new_disabled_tests, 0) AS number_of_new_disabled_tests,
+  FROM
+    buckets
+    LEFT JOIN raw_new_disabled_tests ON buckets.granularity_bucket = raw_new_disabled_tests.granularity_bucket
+),
+aggregated_new_disabled_tests AS (
+  SELECT
+    granularity_bucket,
+    number_of_new_disabled_tests,
+    SUM(number_of_new_disabled_tests) OVER (
+      ORDER BY
+        granularity_bucket
+    ) AS total_number_of_new_disabled_tests
+  FROM
+    new_disabled_tests
+),
+--- Count the closed disabled tests
+raw_closed_disabled_tests AS (
+  SELECT
+    DATE_TRUNC(
+      : granularity,
+      CAST(issues.closed_at AS TIMESTAMP) AT TIME ZONE : timezone
+    ) AS granularity_bucket,
+    COUNT(title) AS number_of_closed_disabled_tests,
+  FROM
+    commons.issues
+  WHERE
+    issues.title LIKE '%DISABLED%'
+    AND issues.closed_at IS NOT NULL
+  GROUP BY
+    granularity_bucket
+),
+closed_disabled_tests AS (
+  SELECT
+    buckets.granularity_bucket,
+    COALESCE(
+      number_of_closed_disabled_tests,
+      0
+    ) AS number_of_closed_disabled_tests,
+  FROM
+    buckets
+    LEFT JOIN raw_closed_disabled_tests ON buckets.granularity_bucket = raw_closed_disabled_tests.granularity_bucket
+),
+aggregated_closed_disabled_tests AS (
+  SELECT
+    granularity_bucket,
+    number_of_closed_disabled_tests,
+    SUM(
+      number_of_closed_disabled_tests
+    ) OVER (
+      ORDER BY
+        granularity_bucket
+    ) AS total_number_of_closed_disabled_tests
+  FROM
+    closed_disabled_tests
+),
+--- The final aggregated count
+aggregated_disabled_tests AS (
+  SELECT
+    FORMAT_ISO8601(aggregated_new_disabled_tests.granularity_bucket) AS granularity_bucket,
+    number_of_new_disabled_tests,
+    number_of_closed_disabled_tests,
+    total_number_of_new_disabled_tests,
+    total_number_of_closed_disabled_tests,
+    total_number_of_new_disabled_tests - total_number_of_closed_disabled_tests AS number_of_open_disabled_tests
+  FROM
+    aggregated_new_disabled_tests
+    LEFT JOIN aggregated_closed_disabled_tests ON aggregated_new_disabled_tests.granularity_bucket = aggregated_closed_disabled_tests.granularity_bucket
 )
 SELECT
-    *
+  *
 FROM
-    total_disabled_tests
+  aggregated_disabled_tests
 WHERE
-    PARSE_DATETIME_ISO8601(granularity_bucket) >= PARSE_DATETIME_ISO8601(:startTime)
-    AND PARSE_DATETIME_ISO8601(granularity_bucket) < PARSE_DATETIME_ISO8601(:stopTime)
+  PARSE_DATETIME_ISO8601(granularity_bucket) >= PARSE_DATETIME_ISO8601(: startTime)
+  AND PARSE_DATETIME_ISO8601(granularity_bucket) < PARSE_DATETIME_ISO8601(: stopTime)
 ORDER BY
-    granularity_bucket DESC
+  granularity_bucket DESC

--- a/torchci/rockset/metrics/disabled_test_historical.lambda.json
+++ b/torchci/rockset/metrics/disabled_test_historical.lambda.json
@@ -9,7 +9,7 @@
     {
       "name": "startTime",
       "type": "string",
-      "value": "2022-10-01T00:00:00.000Z"
+      "value": "2023-07-01T00:00:00.000Z"
     },
     {
       "name": "state",
@@ -19,7 +19,7 @@
     {
       "name": "stopTime",
       "type": "string",
-      "value": "2022-10-17T00:00:00.000Z"
+      "value": "2023-12-01T00:00:00.000Z"
     },
     {
       "name": "timezone",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -47,7 +47,7 @@
   },
   "metrics": {
     "correlation_matrix": "35c05e04047123f0",
-    "disabled_test_historical": "daa2413a4750aa87",
+    "disabled_test_historical": "0ba29e302b6774ce",
     "disabled_test_total": "da5f834a6501fc63",
     "external_contribution_stats": "d98863128f502cdb",
     "job_duration_avg": "10a88ea2ebb80647",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -47,7 +47,7 @@
   },
   "metrics": {
     "correlation_matrix": "35c05e04047123f0",
-    "disabled_test_historical": "0ba29e302b6774ce",
+    "disabled_test_historical": "27c9ab055ba7a5ad",
     "disabled_test_total": "da5f834a6501fc63",
     "external_contribution_stats": "d98863128f502cdb",
     "job_duration_avg": "10a88ea2ebb80647",


### PR DESCRIPTION
This change completely reworks the `torchci/rockset/metrics/__sql/disabled_test_historical.sql` query to:

* Keep track of not only the daily `number_of_new_disabled_tests` but also `number_of_closed_disabled_tests`
* Add a new chart to keep track of the daily `number_of_open_disabled_tests` on KPIs page.  This is calculated by deducting the aggregated `total_number_of_closed_disabled_tests` from the aggregated `total_number_of_new_disabled_tests`

This also fixes a bug in the counting of `number_of_new_disabled_tests`.  Previously, it was counted using `_event_time` as follows:

```
FORMAT_ISO8601(
    DATE_TRUNC(
        :granularity,
        issues._event_time AT TIME ZONE :timezone
    )
) AS granularity_bucket,
COUNT(issues.title) as number_of_new_disabled_tests
```

This is wrong because the `_event_time` is also updated when the issue is commented on.  The correct way is to use `issues.created_at` timestamp.

### Testing

* New KPI to count the daily number of open disabled issues https://torchci-git-fork-huydhn-add-total-disabled-2fe797-fbopensource.vercel.app/kpis.  This matches with the value we are seeing on https://hud.pytorch.org/metrics
* Reflect the correct number of new disabled tests on https://torchci-git-fork-huydhn-add-total-disabled-2fe797-fbopensource.vercel.app/metrics