### PR TITLE
[BE?] Add td and test folder in torchci/scripts

### DIFF
--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -42,14 +42,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Install requests
         run: |
-           pip3 install requests setuptools
-      - name: Run tests
-        if: ${{ github.event_name == 'pull_request'}}
-        run: |
-          python3 torchci/scripts/test_check_alerts.py
+           pip3 install requests setuptools==61.2.0
       - name: Check for alerts and creates issue
         run: |
-          python3 torchci/scripts/check_alerts.py
+          python3 -m torchci.scripts.check_alerts
         env:
           # NOTE: Should be a blank string for pull requests
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -64,14 +60,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Install requests
         run: |
-           pip3 install requests setuptools rockset==1.0.3
-      - name: Run tests
-        if: ${{ github.event_name == 'pull_request'}}
-        run: |
-          python3 torchci/scripts/test_queue_alert.py
+           pip3 install requests setuptools==61.2.0 rockset==1.0.3
       - name: Check for alerts and creates issue
         run: |
-          python3 torchci/scripts/queue_alert.py
+          python3 -m torchci.scripts.queue_alert
         env:
           # NOTE: Should be a blank string for pull requests
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/torchci.yml
+++ b/.github/workflows/torchci.yml
@@ -27,3 +27,13 @@ jobs:
       - run: yarn node scripts/checkRockset.mjs
         env:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
+
+  python-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          pip3 install --upgrade pip
+          pip3 install setuptools==68.2.2 rockset==1.0.3 boto3==1.19.12 pytest==7.2.0
+          pip3 install -e .
+          pytest scripts/test

--- a/.github/workflows/update-test-times.yml
+++ b/.github/workflows/update-test-times.yml
@@ -8,7 +8,6 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - "torchci/scripts/test_update_test_times.yml"
       - "torchci/scripts/update_test_times.py"
       - ".github/workflows/update-test-times.yml"
 
@@ -25,9 +24,6 @@ jobs:
         run: |
           pip3 install boto3==1.19.12
           pip3 install rockset==1.0.3
-
-      - name: Run tests
-        run: python3 scripts/test_update_test_times.py
 
       - name: Update test times
         run: |

--- a/.github/workflows/update_test_file_ratings.yml
+++ b/.github/workflows/update_test_file_ratings.yml
@@ -4,11 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/update_test_file_ratings.yml"
-      - "torchci/scripts/calculate_file_test_rating.py"
-      - "torchci/scripts/test_calculate_file_test_rating.py"
-      - "torchci/scripts/td_heuristic_historical_edited_files.py"
-      - "torchci/scripts/td_heuristic_profiling.py"
-      - "torchci/scripts/get_merge_base_info.py"
+      - "torchci/scripts/td/**"
   schedule:
     - cron: 5 11 * * *  # At 11:05 UTC every day or about 4am PT
 
@@ -34,24 +30,23 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          pip3 install boto3==1.19.12
-          pip3 install rockset==1.0.3
-
-      - name: Run tests
-        run: python3 test-infra/torchci/scripts/test_calculate_file_test_rating.py
+          pip3 install --upgrade pip
+          pip3 install boto3==1.19.12 rockset==1.0.3
+          cd test-infra/torchci
+          pip3 install -e .
 
       - name: Get merge base info
         run: |
-          python3 test-infra/torchci/scripts/get_merge_base_info.py
+          python3 test-infra/torchci/scripts/td/get_merge_base_info.py
         env:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
 
       - name: Generate file test ratings
         run: |
-          python3 test-infra/torchci/scripts/calculate_file_test_rating.py
-          python3 test-infra/torchci/scripts/td_heuristic_historical_edited_files.py
+          python3 test-infra/torchci/scripts/td/calculate_file_test_rating.py
+          python3 test-infra/torchci/scripts/td/td_heuristic_historical_edited_files.py
           # Do not run this one, it won't change
-          # python3 test-infra/torchci/scripts/td_heuristic_profiling.py
+          # python3 test-infra/torchci/scripts/td/td_heuristic_profiling.py
 
         env:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}

--- a/torchci/pyproject.toml
+++ b/torchci/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "torchci"
+dynamic = ["version"]
+
+[build-system]
+requires = ["setuptools==68.2.2"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.package-dir]
+"torchci.scripts" = "scripts"

--- a/torchci/scripts/queue_alert.py
+++ b/torchci/scripts/queue_alert.py
@@ -7,8 +7,13 @@ from typing import Any, Dict, List, NamedTuple
 
 import rockset  # type: ignore[import]
 
-from check_alerts import clear_alerts, create_issue, fetch_alerts, update_issue
 from setuptools import distutils  # type: ignore[import]
+from torchci.scripts.check_alerts import (
+    clear_alerts,
+    create_issue,
+    fetch_alerts,
+    update_issue,
+)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 

--- a/torchci/scripts/rockset_utils.py
+++ b/torchci/scripts/rockset_utils.py
@@ -3,8 +3,7 @@ from functools import lru_cache
 from typing import Any, Dict, List, Optional
 
 import rockset
-
-from utils import cache_json  # type: ignore[import]
+from torchci.scripts.utils import cache_json  # type: ignore[import]
 
 
 @lru_cache

--- a/torchci/scripts/td/calculate_file_test_rating.py
+++ b/torchci/scripts/td/calculate_file_test_rating.py
@@ -1,10 +1,7 @@
 import json
 from collections import defaultdict
-from pathlib import Path
 
-from rockset_utils import query_rockset
-
-REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+from torchci.scripts.rockset_utils import query_rockset
 
 FAILED_TESTS_QUERY = """
 SELECT

--- a/torchci/scripts/td/get_merge_base_info.py
+++ b/torchci/scripts/td/get_merge_base_info.py
@@ -11,7 +11,7 @@ from torchci.scripts.rockset_utils import (
 from torchci.scripts.td.utils import list_past_year_shas, run_command
 
 
-REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 
 FAILED_TEST_SHAS_QUERY = """
 SELECT
@@ -103,7 +103,7 @@ def upload_merge_base_info(shas: List[str]) -> None:
         except Exception as e:
             return e
 
-    upload_to_rockset(collection="merge_bases", docs=docs, workspace="commons")
+    # upload_to_rockset(collection="merge_bases", docs=docs, workspace="commons")
 
 
 if __name__ == "__main__":

--- a/torchci/scripts/td/get_merge_base_info.py
+++ b/torchci/scripts/td/get_merge_base_info.py
@@ -3,8 +3,13 @@ from datetime import datetime
 from pathlib import Path
 from typing import List
 
-from rockset_utils import query_rockset, remove_from_rockset, upload_to_rockset
-from utils_td_heuristics import list_past_year_shas, run_command
+from torchci.scripts.rockset_utils import (
+    query_rockset,
+    remove_from_rockset,
+    upload_to_rockset,
+)
+from torchci.scripts.td.utils import list_past_year_shas, run_command
+
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 

--- a/torchci/scripts/td/get_merge_base_info.py
+++ b/torchci/scripts/td/get_merge_base_info.py
@@ -103,7 +103,7 @@ def upload_merge_base_info(shas: List[str]) -> None:
         except Exception as e:
             return e
 
-    # upload_to_rockset(collection="merge_bases", docs=docs, workspace="commons")
+    upload_to_rockset(collection="merge_bases", docs=docs, workspace="commons")
 
 
 if __name__ == "__main__":

--- a/torchci/scripts/td/td_heuristic_historical_edited_files.py
+++ b/torchci/scripts/td/td_heuristic_historical_edited_files.py
@@ -2,7 +2,7 @@ import json
 from collections import defaultdict
 from typing import Dict
 
-from utils_td_heuristics import (
+from torchci.scripts.td.utils import (
     cache_json,
     evaluate,
     get_all_invoking_files,

--- a/torchci/scripts/td/td_heuristic_profiling.py
+++ b/torchci/scripts/td/td_heuristic_profiling.py
@@ -2,7 +2,7 @@ import json
 
 import requests
 
-from utils_td_heuristics import (
+from torchci.scripts.td.utils import (
     evaluate,
     get_filtered_failed_tests,
     get_merge_bases_dict,

--- a/torchci/scripts/td/td_rockset_analysis.py
+++ b/torchci/scripts/td/td_rockset_analysis.py
@@ -7,9 +7,9 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 
-from rockset_utils import query_rockset
+from torchci.scripts.rockset_utils import query_rockset
 
-REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 OUTPUT_FOLDER = REPO_ROOT / "_logs" / "td_analysis"
 
 QUERY = """

--- a/torchci/scripts/td/utils.py
+++ b/torchci/scripts/td/utils.py
@@ -6,8 +6,8 @@ from typing import Any, Dict, List
 
 import requests
 
-from rockset_utils import query_rockset
-from utils import cache_json, run_command
+from torchci.scripts.rockset_utils import query_rockset
+from torchci.scripts.utils import cache_json, run_command
 
 
 def list_past_year_shas():

--- a/torchci/scripts/test/test_calculate_file_test_rating.py
+++ b/torchci/scripts/test/test_calculate_file_test_rating.py
@@ -1,6 +1,6 @@
 from unittest import main, TestCase
 
-from calculate_file_test_rating import (
+from torchci.scripts.td.calculate_file_test_rating import (
     calculate_test_class_ratings,
     calculate_test_file_ratings,
     filter_tests,

--- a/torchci/scripts/test/test_check_alerts.py
+++ b/torchci/scripts/test/test_check_alerts.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from unittest import main, TestCase
 from unittest.mock import patch
 
-from check_alerts import (
+from torchci.scripts.check_alerts import (
     fetch_alerts_filter,
     filter_job_names,
     gen_update_comment,
@@ -183,9 +183,9 @@ class TestGitHubPR(TestCase):
         issue = generate_no_flaky_tests_issue()
         self.assertListEqual(issue["labels"], ["no-flaky-tests-alert"])
 
-    @patch("check_alerts.create_issue")
-    @patch("check_alerts.datetime")
-    @patch("check_alerts.get_num_issues_with_label")
+    @patch("torchci.scripts.check_alerts.create_issue")
+    @patch("torchci.scripts.check_alerts.datetime")
+    @patch("torchci.scripts.check_alerts.get_num_issues_with_label")
     def test_handle_flaky_tests_alert(
         self, mock_get_num_issues_with_label, mock_date, mock_create_issue
     ):

--- a/torchci/scripts/test/test_queue_alert.py
+++ b/torchci/scripts/test/test_queue_alert.py
@@ -1,6 +1,10 @@
 from unittest import main, TestCase
 
-from queue_alert import filter_long_queues, gen_update_comment, QueueInfo
+from torchci.scripts.queue_alert import (
+    filter_long_queues,
+    gen_update_comment,
+    QueueInfo,
+)
 
 
 class TestGitHubPR(TestCase):

--- a/torchci/scripts/test/test_update_test_times.py
+++ b/torchci/scripts/test/test_update_test_times.py
@@ -1,7 +1,6 @@
-import json
 import unittest
 
-from update_test_times import gen_test_class_times, gen_test_file_times
+from torchci.scripts.update_test_times import gen_test_class_times, gen_test_file_times
 
 
 class TestUpdateTestTimesFile(unittest.TestCase):


### PR DESCRIPTION
I can't figure out what file structure for python scripts that need imports from parent folders is supposed to be, so I'm going to try and be as noninvasive as possible.

Run `pip install -e .` from inside of `torchci` to easily run scripts without needing to modify REPO_ROOT every time.
Or `PYTHONPATH="${PYTHONPATH}:<path to test infra>"`.

The other version https://github.com/pytorch/test-infra/pull/4703 moved all the python scripts to `tools/torchci/torchci` and was kinda weird now that I think about it more.