### PR TITLE
Keep exporting CONDA_ENV

### DIFF
--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -181,6 +181,9 @@ runs:
             fi
           fi
 
+          # Keep exporting CONDA_PREFIX under CONDA_ENV because the latter could be used elsewhere
+          echo "CONDA_ENV=${CONDA_PREFIX}" >> "${GITHUB_ENV}"
+
           echo "CONDA_PREFIX=${CONDA_PREFIX}" >> "${GITHUB_ENV}"
           echo "CONDA_RUN=${CONDA_RUNTIME} run -p ${CONDA_PREFIX} --no-capture-output" >> "${GITHUB_ENV}"
           if [[ "${PYTHON_VERSION}" == "3.11" ]]; then


### PR DESCRIPTION
I rename the variable to CONDA_PREFIX in https://github.com/pytorch/test-infra/pull/4697 to match with what conda is using https://docs.conda.io/projects/conda-build/en/stable/user-guide/environment-variables.html, but it looks like the CONDA_ENV variable could still be used elsewhere by the callers https://github.com/search?type=code&q=org%3Apytorch+CONDA_ENV