### PR TITLE
[TorchFix] Add torch.solve as a removed function

### DIFF
--- a/tools/torchfix/README.md
+++ b/tools/torchfix/README.md
@@ -48,3 +48,19 @@ To enable them, use standard flake8 configuration options for the plugin mode or
 
 If you encounter a bug or some other problem with TorchFix, please file an issue on
 https://github.com/pytorch/test-infra/issues, mentioning [TorchFix] in the title.
+
+
+## Rules
+
+### TOR001 Use of removed function
+
+#### torch.solve
+
+This function was deprecated since PyTorch version 1.9 and is now removed.
+
+`torch.solve` is deprecated in favor of `torch.linalg.solve`.
+`torch.linalg.solve` has its arguments reversed and does not return the LU factorization.
+
+To get the LU factorization see `torch.lu`, which can be used with `torch.lu_solve` or `torch.lu_unpack`.
+
+`X = torch.solve(B, A).solution` should be replaced with `X = torch.linalg.solve(A, B)`.

--- a/tools/torchfix/tests/fixtures/deprecated_symbols/checker/removed_solve.py
+++ b/tools/torchfix/tests/fixtures/deprecated_symbols/checker/removed_solve.py
@@ -1,0 +1,4 @@
+import torch
+A = torch.randn(3, 3)
+b = torch.randn(3)
+torch.solve(A, b).solution

--- a/tools/torchfix/tests/fixtures/deprecated_symbols/checker/removed_solve.txt
+++ b/tools/torchfix/tests/fixtures/deprecated_symbols/checker/removed_solve.txt
@@ -1,0 +1,1 @@
+4:1 TOR001 Use of removed function torch.solve: https://github.com/pytorch/test-infra/tree/main/tools/torchfix#torchsolve

--- a/tools/torchfix/torchfix/deprecated_symbols.yaml
+++ b/tools/torchfix/torchfix/deprecated_symbols.yaml
@@ -1,3 +1,8 @@
+- name: torch.solve
+  deprecate_pr: https://github.com/pytorch/pytorch/pull/57741
+  remove_pr: https://github.com/pytorch/pytorch/pull/70986
+  reference: https://github.com/pytorch/test-infra/tree/main/tools/torchfix#torchsolve
+
 - name: torch.qr
   deprecate_pr: https://github.com/pytorch/pytorch/pull/57745
   remove_pr:

--- a/tools/torchfix/torchfix/visitors/deprecated_symbols/__init__.py
+++ b/tools/torchfix/torchfix/visitors/deprecated_symbols/__init__.py
@@ -72,6 +72,10 @@ class TorchDeprecatedSymbolsVisitor(TorchVisitor):
                 message = f"Use of removed function {qualified_name}"
             replacement = self._call_replacement(node, qualified_name)
 
+            reference = self.deprecated_config[qualified_name].get("reference")
+            if reference is not None:
+                message = f"{message}: {reference}"
+
             self.violations.append(
                 LintViolation(
                     error_code=error_code,


### PR DESCRIPTION
Add torch.solve as a removed function (I somehow missed it before and noticed after https://github.com/pytorch/tutorials/pull/2642).

Also added a mechanism to show reference links in the error messages.