### PR TITLE
Limit MacOS libtorch to just one flavor

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -379,8 +379,8 @@ def generate_libtorch_matrix(
             abi_versions = [RELEASE, DEBUG]
         elif os == LINUX:
             abi_versions = [PRE_CXX11_ABI, CXX11_ABI]
-        elif os == MACOS:
-            abi_versions = [PRE_CXX11_ABI, CXX11_ABI]
+        elif os in [MACOS, MACOS_ARM64]:
+            abi_versions = [CXX11_ABI]
 
     if libtorch_variants is None:
         libtorch_variants = [
@@ -388,7 +388,7 @@ def generate_libtorch_matrix(
             "shared-without-deps",
             "static-with-deps",
             "static-without-deps",
-        ]
+        ] if os not in [MACOS, MACOS_ARM64] else ["shared-with-deps"]
 
     for abi_version in abi_versions:
         for arch_version in arches:


### PR DESCRIPTION
As one can not really build pre-CXX11 binaries for MacOS, and to the best of my knowledge static-with-deps binaries were never generated

Test plan:
```
$ python3 tools/scripts/generate_binary_build_matrix.py --package-type libtorch --operating-system macos --channel nightly|jq
{
  "include": [
    {
      "gpu_arch_type": "cpu",
      "gpu_arch_version": "",
      "desired_cuda": "cpu",
      "libtorch_variant": "shared-with-deps",
      "libtorch_config": "",
      "devtoolset": "cxx11-abi",
      "container_image": "pytorch/libtorch-cxx11-builder:cpu",
      "package_type": "libtorch",
      "build_name": "libtorch-cpu-shared-with-deps-cxx11-abi",
      "validation_runner": "macos-12",
      "installation": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-latest.zip",
      "channel": "nightly",
      "stable_version": "2.1.0"
    }
  ]
}
```