### PR TITLE
Use old libtorch package for test channel

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -240,6 +240,10 @@ def get_libtorch_install_command(
         build_name = f"libtorch-macos-{arch}-latest.zip"
         if channel == RELEASE:
             build_name = f"libtorch-macos-{mod.CURRENT_VERSION}.zip"
+        # Please note this is temporary, to be removed when doing branch cut for 2.2 release
+        elif channel == TEST:
+            build_name = "libtorch-macos-latest.zip"
+
     elif os == LINUX and (channel == RELEASE or channel == TEST):
         build_name = (
             f"{prefix}-{devtoolset}-{_libtorch_variant}-{mod.CURRENT_VERSION}%2B{desired_cuda}.zip"


### PR DESCRIPTION
This should use old libtorch file and fix validation error:
https://github.com/pytorch/builder/actions/runs/6801641578/job/18496782857