### PR TITLE
Better libtorch definitions for test channel

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -238,11 +238,8 @@ def get_libtorch_install_command(
     if os in [MACOS, MACOS_ARM64]:
         arch = "x86_64" if os == MACOS else "arm64"
         build_name = f"libtorch-macos-{arch}-latest.zip"
-        if channel == RELEASE:
+        if channel in [RELEASE, TEST]:
             build_name = f"libtorch-macos-{mod.CURRENT_VERSION}.zip"
-        # Please note this is temporary, to be removed when doing branch cut for 2.2 release
-        elif channel == TEST:
-            build_name = "libtorch-macos-latest.zip"
 
     elif os == LINUX and (channel == RELEASE or channel == TEST):
         build_name = (


### PR DESCRIPTION
We should be testing particular version rather than latest
```
% python tools/scripts/generate_binary_build_matrix.py --operating-system macos --channel test --package-type libtorch|jq
{
  "include": [
    {
      "gpu_arch_type": "cpu",
      "gpu_arch_version": "",
      "desired_cuda": "cpu",
      "libtorch_variant": "shared-with-deps",
      "libtorch_config": "",
      "devtoolset": "cxx11-abi",
      "container_image": "pytorch/libtorch-cxx11-builder:cpu",
      "package_type": "libtorch",
      "build_name": "libtorch-cpu-shared-with-deps-cxx11-abi",
      "validation_runner": "macos-12",
      "installation": "https://download.pytorch.org/libtorch/test/cpu/libtorch-macos-2.1.1.zip",
      "channel": "test",
      "stable_version": "2.1.1"
    }
  ]
}
```
