### PR TITLE
[log-classifier] Handle None value when getting a log line

### DIFF
--- a/aws/lambda/log-classifier/fixtures/request.json
+++ b/aws/lambda/log-classifier/fixtures/request.json
@@ -2,7 +2,7 @@
   "version": "2.0",
   "routeKey": "$default",
   "rawPath": "/",
-  "rawQueryString": "job_id=17764650210&repo=pytorch%2Fpytorch",
+  "rawQueryString": "job_id=17986337626&repo=pytorch%2Fpytorch",
   "headers": {
     "accept": "*/*",
     "content-length": "0",

--- a/aws/lambda/log-classifier/src/rule_match.rs
+++ b/aws/lambda/log-classifier/src/rule_match.rs
@@ -39,8 +39,7 @@ impl SerializedMatch {
                 break;
             }
 
-            if !log.lines.get(&i).is_none() {
-                let l = log.lines.get(&i).unwrap();
+            if let Some(l) = log.lines.get(&i) {
                 if l.starts_with("+") {
                     context.push(l.clone());
                 }

--- a/aws/lambda/log-classifier/src/rule_match.rs
+++ b/aws/lambda/log-classifier/src/rule_match.rs
@@ -39,9 +39,11 @@ impl SerializedMatch {
                 break;
             }
 
-            let l = log.lines.get(&i).unwrap();
-            if l.starts_with("+") {
-                context.push(l.clone());
+            if !log.lines.get(&i).is_none() {
+                let l = log.lines.get(&i).unwrap();
+                if l.starts_with("+") {
+                    context.push(l.clone());
+                }
             }
         }
 


### PR DESCRIPTION
Log classifier fails on this job https://github.com/pytorch/pytorch/actions/runs/6618894647/job/17986337626.  The issue can  be reproduced by running, which ends up with an `Internal Server Error` error:

```
curl "https://vwg52br27lx5oymv4ouejwf4re0akoeg.lambda-url.us-east-1.on.aws/?job_id=17986337626"
```

It turns out that `log.lines.get(&i)` can be None while gathering the failure context.  This change handles the None value correctly.