### PR TITLE
[ez][HUD] Add log url to opensearch output 

### DIFF
--- a/torchci/lib/searchUtils.ts
+++ b/torchci/lib/searchUtils.ts
@@ -117,6 +117,7 @@ export async function searchSimilarFailures(
       failureLines: [data.torchci_classification.line],
       failureLineNumbers: [data.torchci_classification.line_num],
       failureCaptures: data.torchci_classification.captures,
+      logUrl: `https://ossci-raw-job-status.s3.amazonaws.com/log/${data.id}`,
       // NB: The author information, unfortunately, is not available atm in
       // torchci-workflow-job DynamoDB table. We might be able to update the
       // lambda to add it in the future though, but that's not a guarantee


### PR DESCRIPTION
The logs on the failures pages (linked to by the More like this buttons) didn't work: the link for raw logs didn't link anywhere, and the log viewer didn't show anything.

Fixed by adding the a logUrl to the output of the search