### PR TITLE
[bot][ez] Fix cancel workflows on close

### DIFF
--- a/torchci/lib/bot/cancelWorkflowsOnCloseBot.ts
+++ b/torchci/lib/bot/cancelWorkflowsOnCloseBot.ts
@@ -26,7 +26,7 @@ function cancelWorkflowsOnCloseBot(app: Probot): void {
         repo,
         head_sha: headSha,
         per_page: 30,
-      },
+      }
     );
 
     await Promise.all(

--- a/torchci/lib/bot/cancelWorkflowsOnCloseBot.ts
+++ b/torchci/lib/bot/cancelWorkflowsOnCloseBot.ts
@@ -27,7 +27,6 @@ function cancelWorkflowsOnCloseBot(app: Probot): void {
         head_sha: headSha,
         per_page: 30,
       },
-      (o) => o.data.workflow_runs
     );
 
     await Promise.all(

--- a/torchci/test/cancelWorkflowsOnCloseBot.test.ts
+++ b/torchci/test/cancelWorkflowsOnCloseBot.test.ts
@@ -19,13 +19,11 @@ describe("accept bot", () => {
       .get(
         "/repos/clee2000/random-testing/actions/runs?head_sha=381ace654ad6474357cedad09418340896d16d90&per_page=30"
       )
-      .reply(200, {
-        workflow_runs: [
-          { id: 6647495490, status: "in_progress" },
-          { id: 6647495495, status: "in_progress" },
-          { id: 6647495497, status: "completed" },
-        ],
-      })
+      .reply(200, [
+        { id: 6647495490, status: "in_progress" },
+        { id: 6647495495, status: "in_progress" },
+        { id: 6647495497, status: "completed" },
+      ])
       .post(`/repos/clee2000/random-testing/actions/runs/6647495490/cancel`)
       .reply(200, {})
       .post(`/repos/clee2000/random-testing/actions/runs/6647495495/cancel`)


### PR DESCRIPTION
I thought the data would be returned in the form of { total_count: idk, workflow_runs: [list]} and that I had to unwrap it myself, but apparently it is already unwrapped into a list.