### PR TITLE
[ez][bot] Fix cancelWorkflowsOnClose when head sha actually belongs to main

### DIFF
--- a/torchci/lib/bot/cancelWorkflowsOnCloseBot.ts
+++ b/torchci/lib/bot/cancelWorkflowsOnCloseBot.ts
@@ -8,6 +8,10 @@ function cancelWorkflowsOnCloseBot(app: Probot): void {
     const senderId = ctx.payload.sender.id;
     const headSha = ctx.payload.pull_request.head.sha;
 
+    if (owner !== "pytorch" || repo !== "pytorch") {
+      return;
+    }
+
     if (
       senderLogin == "pytorchmergebot" ||
       senderLogin == "pytorchbot" ||
@@ -16,6 +20,18 @@ function cancelWorkflowsOnCloseBot(app: Probot): void {
       senderId == 54816060 || // pytorch-bot's id
       senderId == 21957446 // pytorchbot's id
     ) {
+      return;
+    }
+
+    const diff = await ctx.octokit.rest.repos.compareCommits({
+      owner,
+      repo,
+      base: "main",
+      head: headSha,
+    });
+
+    if (diff.data.merge_base_commit.sha == headSha) {
+      // PR got made with main branch as head
       return;
     }
 

--- a/torchci/test/cancelWorkflowsOnCloseBot.test.ts
+++ b/torchci/test/cancelWorkflowsOnCloseBot.test.ts
@@ -15,18 +15,27 @@ describe("accept bot", () => {
 
   test("Cancel in progress workflows when not pytorchmergebot closes thr PR", async () => {
     const event = requireDeepCopy("./fixtures/pull_request.closed.json");
+    event.payload.repository.owner.login = "pytorch";
+    event.payload.repository.name = "pytorch";
+
     const scope = nock("https://api.github.com")
       .get(
-        "/repos/clee2000/random-testing/actions/runs?head_sha=381ace654ad6474357cedad09418340896d16d90&per_page=30"
+        "/repos/pytorch/pytorch/compare/main...381ace654ad6474357cedad09418340896d16d90"
+      )
+      .reply(200, {
+        merge_base_commit: { sha: "idk something else" },
+      })
+      .get(
+        "/repos/pytorch/pytorch/actions/runs?head_sha=381ace654ad6474357cedad09418340896d16d90&per_page=30"
       )
       .reply(200, [
         { id: 6647495490, status: "in_progress" },
         { id: 6647495495, status: "in_progress" },
         { id: 6647495497, status: "completed" },
       ])
-      .post(`/repos/clee2000/random-testing/actions/runs/6647495490/cancel`)
+      .post(`/repos/pytorch/pytorch/actions/runs/6647495490/cancel`)
       .reply(200, {})
-      .post(`/repos/clee2000/random-testing/actions/runs/6647495495/cancel`)
+      .post(`/repos/pytorch/pytorch/actions/runs/6647495495/cancel`)
       .reply(200, {});
     await probot.receive(event);
 
@@ -37,6 +46,28 @@ describe("accept bot", () => {
     const event = requireDeepCopy("./fixtures/pull_request.closed.json");
     event.payload.sender.login = "pytorchmergebot";
     const scope = nock("https://api.github.com");
+    await probot.receive(event);
+    handleScope(scope);
+  });
+
+  test("Do not cancel in progress workflows when not pytorch/pytorch", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request.closed.json");
+    const scope = nock("https://api.github.com");
+    await probot.receive(event);
+    handleScope(scope);
+  });
+
+  test("Do not cancel in progress workflows when not pytorch/pytorch", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request.closed.json");
+    event.payload.repository.owner.login = "pytorch";
+    event.payload.repository.name = "pytorch";
+    const scope = nock("https://api.github.com")
+      .get(
+        "/repos/pytorch/pytorch/compare/main...381ace654ad6474357cedad09418340896d16d90"
+      )
+      .reply(200, {
+        merge_base_commit: { sha: "381ace654ad6474357cedad09418340896d16d90" },
+      });
     await probot.receive(event);
     handleScope(scope);
   });


### PR DESCRIPTION
I forgot that people can make PRs with the head sha being a main branch commit.

Also restrict this to pytorch/pytorch since I don't know if other repos want it.