### PR TITLE
Add log downloader

### DIFF
--- a/tools/torchci/download_logs.py
+++ b/tools/torchci/download_logs.py
@@ -7,6 +7,7 @@ import argparse
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
+
 def download_log(id):
     "Given an id for a job, returns the log as a string"
     url = f"https://ossci-raw-job-status.s3.amazonaws.com/log/{id}"
@@ -15,6 +16,7 @@ def download_log(id):
         return None
     return data.text
 
+
 def download_log_to_file(id, file, name):
     t = download_log(id)
     if t is None:
@@ -22,6 +24,7 @@ def download_log_to_file(id, file, name):
         return
     with open(file, "w") as f:
         f.write(t)
+
 
 def download_logs_to_dir(commit):
     "Given a commit sha, downloads all test logs for that commit to logs/<commit> folder"
@@ -42,10 +45,14 @@ def download_logs_to_dir(commit):
     pool.join()
     return folder
 
+
 def get_parser():
-    parser = argparse.ArgumentParser(description="Download TEST logs for a particular commit")
+    parser = argparse.ArgumentParser(
+        description="Download TEST logs for a particular commit"
+    )
     parser.add_argument("commit", type=str)
     return parser
+
 
 if __name__ == "__main__":
     args = get_parser().parse_args()

--- a/tools/torchci/download_logs.py
+++ b/tools/torchci/download_logs.py
@@ -1,0 +1,53 @@
+import multiprocessing as mp
+import os
+import requests
+from torchci.rockset_utils import query_rockset
+from pathlib import Path
+import argparse
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+def download_log(id):
+    "Given an id for a job, returns the log as a string"
+    url = f"https://ossci-raw-job-status.s3.amazonaws.com/log/{id}"
+    data = requests.get(url)
+    if data.status_code != 200:
+        return None
+    return data.text
+
+def download_log_to_file(id, file, name):
+    t = download_log(id)
+    if t is None:
+        print(f"Failed to download log for {name} {id}")
+        return
+    with open(file, "w") as f:
+        f.write(t)
+
+def download_logs_to_dir(commit):
+    "Given a commit sha, downloads all test logs for that commit to logs/<commit> folder"
+    res = query_rockset(
+        f"select id, name from workflow_job where head_sha = '{commit}' and name like '% / test%'"
+    )
+
+    folder = REPO_ROOT / "_logs" / "ci_logs" / commit
+    os.makedirs(folder, exist_ok=True)
+
+    pool = mp.Pool(10)
+    for i in res:
+        pool.apply_async(
+            download_log_to_file,
+            (i["id"], f"{folder}/{i['name'].replace('/', '_')}", i["name"]),
+        )
+    pool.close()
+    pool.join()
+    return folder
+
+def get_parser():
+    parser = argparse.ArgumentParser(description="Download TEST logs for a particular commit")
+    parser.add_argument("commit", type=str)
+    return parser
+
+if __name__ == "__main__":
+    args = get_parser().parse_args()
+    download_logs_to_dir(args.commit)
+    print(f"Saved to {REPO_ROOT / '_logs' / 'ci_logs' / args.commit}")

--- a/tools/torchci/download_logs.py
+++ b/tools/torchci/download_logs.py
@@ -1,9 +1,10 @@
+import argparse
 import multiprocessing as mp
 import os
+from pathlib import Path
+
 import requests
 from torchci.rockset_utils import query_rockset
-from pathlib import Path
-import argparse
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 


### PR DESCRIPTION
This is the script I use to download logs if anyone wants it

It only downloads test logs right now but feel free to change the rockset query to suit your purposes

Usage either:
change the main function to whatever you want and call
`tools/torchci/download_logs.py <commit sha>`

Logs get downloaded to `repo root / _logs / ci_logs / commit sha`.  I like to use VSCode's search functionality as grep