### PR TITLE
[ez][hud] Add commit link on more like this/failures page

### DIFF
--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -8,7 +8,26 @@ import ReproductionCommand from "./ReproductionCommand";
 import { useSession } from "next-auth/react";
 import { isFailure } from "../lib/JobClassifierUtil";
 
-export default function JobLinks({ job }: { job: JobData }) {
+export default function JobLinks({
+  job,
+  showCommitLink = false,
+}: {
+  job: JobData;
+  showCommitLink?: boolean;
+}) {
+  const commitLink = showCommitLink ? (
+    <span>
+      <a
+        target="_blank"
+        rel="noreferrer"
+        href={`/pytorch/pytorch/commit/${job.sha}`}
+      >
+        Commit
+      </a>
+      {` | `}
+    </span>
+  ) : null;
+
   const rawLogs =
     job.conclusion !== "pending" ? (
       <span>
@@ -59,6 +78,7 @@ export default function JobLinks({ job }: { job: JobData }) {
   const authenticated = useSession().status === "authenticated";
   return (
     <span>
+      {commitLink}
       {rawLogs}
       {failureCaptures}
       {queueTimeS}

--- a/torchci/pages/failure.tsx
+++ b/torchci/pages/failure.tsx
@@ -238,7 +238,7 @@ function FailureInfo({
                 }
               />
               <div>
-                <JobLinks job={sample} />
+                <JobLinks job={sample} showCommitLink={true} />
               </div>
               <LogViewer job={sample} />
             </li>


### PR DESCRIPTION
Got mildly annoyed at the number of clicks it took me to get to the hud commit page for a job on the more like this page, so add a link to the commit.