### PR TITLE
Improve the userbenchmark dashboard with pytorch commit date

### DIFF
--- a/torchci/pages/torchbench/userbenchmark.tsx
+++ b/torchci/pages/torchbench/userbenchmark.tsx
@@ -142,13 +142,13 @@ function CommitPicker({
           commitDescToDate(x) < commitDescToDate(y) ? 1 : -1
         )
         .slice(0, MAX_PYTORCH_VERSIONS);
-    
+
       if (commit === undefined || commit === "" || commit.length === 0) {
         if (allCommits.length === 1) {
           fallbackIndex = 0;
         }
         const index = (allCommits.length + fallbackIndex) % allCommits.length;
-        const desc = objToCommitDesc(allCommits[index])
+        const desc = objToCommitDesc(allCommits[index]);
         setCommit(desc);
       }
     }
@@ -167,12 +167,12 @@ function CommitPicker({
   }
 
   const allCommits: string[] = data
-      .map((r: any) => objToCommitDesc(r))
-      .filter((s: any) => s !== undefined)
-      .sort((x: string, y: string) =>
-        commitDescToDate(x) < commitDescToDate(y) ? 1 : -1
-      )
-      .slice(0, MAX_PYTORCH_VERSIONS);
+    .map((r: any) => objToCommitDesc(r))
+    .filter((s: any) => s !== undefined)
+    .sort((x: string, y: string) =>
+      commitDescToDate(x) < commitDescToDate(y) ? 1 : -1
+    )
+    .slice(0, MAX_PYTORCH_VERSIONS);
 
   return (
     <div>
@@ -321,11 +321,7 @@ function Report({
   ];
   // We only submit the query if both commit IDs are available
   if (lCommitHash.length === 0 || rCommitHash.length === 0) {
-    return (
-      <div>
-        Please select both left and right commits.
-      </div>
-    );
+    return <div>Please select both left and right commits.</div>;
   }
   let cMetrics = QueryMetrics(getQueryUrl(queryControlParams));
   cMetrics = cMetrics === undefined ? {} : cMetrics[0];
@@ -455,7 +451,7 @@ export default function Page() {
           commit={rCommit}
           setCommit={setRCommit}
           titlePrefix={"New"}
-          fallbackIndex={0}  // default to the latest commit available
+          fallbackIndex={0} // default to the latest commit available
         />
       </Stack>
 

--- a/torchci/pages/torchbench/userbenchmark.tsx
+++ b/torchci/pages/torchbench/userbenchmark.tsx
@@ -88,16 +88,22 @@ function CommitPicker({
   }
 
   function objToCommitDesc(data: any) {
-    if (data["pytorch_git_version"] === undefined ||
-        data["pytorch_nightly_date"] === undefined) {
+    if (
+      data["pytorch_git_version"] === undefined ||
+      data["pytorch_nightly_date"] === undefined
+    ) {
       return undefined;
     }
-    return data["pytorch_nightly_date"] + " (" +
-           data["pytorch_git_version"].substring(0, SHA_DISPLAY_LENGTH) + ")";
+    return (
+      data["pytorch_nightly_date"] +
+      " (" +
+      data["pytorch_git_version"].substring(0, SHA_DISPLAY_LENGTH) +
+      ")"
+    );
   }
 
   function commitDescToDate(desc: string) {
-    const [firstGroup] = desc.split(' ');
+    const [firstGroup] = desc.split(" ");
     return firstGroup;
   }
 
@@ -132,7 +138,9 @@ function CommitPicker({
   let all_commits: string[] = data
     .map((r: any) => objToCommitDesc(r))
     .filter((s: any) => s !== undefined)
-    .sort((x: string, y: string) => (commitDescToDate(x) < commitDescToDate(y) ? 1 : -1))
+    .sort((x: string, y: string) =>
+      commitDescToDate(x) < commitDescToDate(y) ? 1 : -1
+    )
     .slice(0, MAX_PYTORCH_VERSIONS);
 
   return (
@@ -328,8 +336,7 @@ function Report({
               },
               {
                 field: "control",
-                headerName:
-                  "Base Commit: " + lCommit,
+                headerName: "Base Commit: " + lCommit,
                 flex: 1,
                 cellClassName: (params: GridCellParams<any>) => {
                   const v = params.value.v;
@@ -344,8 +351,7 @@ function Report({
               },
               {
                 field: "treatment",
-                headerName:
-                  "New Commit: " + rCommit,
+                headerName: "New Commit: " + rCommit,
                 flex: 1,
                 cellClassName: (params: GridCellParams<any>) => {
                   const v = params.value.v;

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -86,7 +86,7 @@
   },
   "torchbench": {
     "torchbench_list_userbenchmarks": "fcfa85c5d1056e8f",
-    "torchbench_userbenchmark_list_commits": "f491c4089f7c49c6",
+    "torchbench_userbenchmark_list_commits": "ecbcda0f8e0a3526",
     "torchbench_userbenchmark_query_metrics": "39d10fce6485c0a3"
   },
   "utilization": {

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -86,7 +86,7 @@
   },
   "torchbench": {
     "torchbench_list_userbenchmarks": "fcfa85c5d1056e8f",
-    "torchbench_userbenchmark_list_commits": "3a4b7347d500209e",
+    "torchbench_userbenchmark_list_commits": "f491c4089f7c49c6",
     "torchbench_userbenchmark_query_metrics": "39d10fce6485c0a3"
   },
   "utilization": {

--- a/torchci/rockset/torchbench/__sql/torchbench_userbenchmark_list_commits.sql
+++ b/torchci/rockset/torchbench/__sql/torchbench_userbenchmark_list_commits.sql
@@ -3,8 +3,11 @@ WITH w AS (
   ARBITRARY("torchbench-userbenchmark".environ.pytorch_version) as pytorch_version,
   FROM torchbench."torchbench-userbenchmark"
   WHERE name = :userbenchmark
-  AND "torchbench-userbenchmark".environ.pytorch_version IS NOT NULL
   GROUP BY "torchbench-userbenchmark".environ.pytorch_git_version
+),
+s AS (
+  SELECT push._event_time as pytorch_commit_time, push.head_commit.id as sha from push
 )
-SELECT name, pytorch_git_version, pytorch_version, REGEXP_EXTRACT(pytorch_version, 'dev([0-9]+)', 1) AS pytorch_nightly_date FROM w
-  ORDER BY pytorch_nightly_date DESC;
+SELECT name, pytorch_git_version, pytorch_version, s.pytorch_commit_time FROM w
+INNER JOIN s ON w.pytorch_git_version = s.sha
+  ORDER BY s.pytorch_commit_time DESC;

--- a/torchci/rockset/torchbench/__sql/torchbench_userbenchmark_list_commits.sql
+++ b/torchci/rockset/torchbench/__sql/torchbench_userbenchmark_list_commits.sql
@@ -1,4 +1,10 @@
-SELECT ARBITRARY(name) AS name, "torchbench-userbenchmark".environ.pytorch_git_version as pytorch_git_version
+WITH w AS (
+  SELECT ARBITRARY(name) AS name, "torchbench-userbenchmark".environ.pytorch_git_version as pytorch_git_version,
+  ARBITRARY("torchbench-userbenchmark".environ.pytorch_version) as pytorch_version,
   FROM torchbench."torchbench-userbenchmark"
   WHERE name = :userbenchmark
-  GROUP BY "torchbench-userbenchmark".environ.pytorch_git_version;
+  AND "torchbench-userbenchmark".environ.pytorch_version IS NOT NULL
+  GROUP BY "torchbench-userbenchmark".environ.pytorch_git_version
+)
+SELECT name, pytorch_git_version, pytorch_version, REGEXP_EXTRACT(pytorch_version, 'dev([0-9]+)', 1) AS pytorch_nightly_date FROM w
+  ORDER BY pytorch_nightly_date DESC;


### PR DESCRIPTION
Add the pytorch commit date time to the commit picker and metrics table header.

Demo screenshot:
<img width="1670" alt="image" src="https://github.com/pytorch/test-infra/assets/502017/4fb37303-05ae-4b3b-9a17-e4581355fa53">

