### PR TITLE
ci: Add workflow to label open source PRs

### DIFF
--- a/.github/workflows/label-open-source.yml
+++ b/.github/workflows/label-open-source.yml
@@ -1,0 +1,28 @@
+on:
+  workflow_call:
+
+jobs:
+  label-open-source:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const creator = context.payload.sender.login
+            try {
+              // result of this does not matter, we only care about 404 (no member ship found)
+              await github.rest.teams.getMembershipForUserInOrg({
+                org: context.repo.owner,
+                team_slug: 'metamates',
+                username: creator
+              })
+            } catch (err) {
+              if (err.status === 404) {
+                github.rest.issues.addLabels({
+                    issue_number: context.issue.number,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    labels: ['open source']
+                })
+              }
+            }


### PR DESCRIPTION
Adds a simple workflow to check group membership in the metamates group and label as "open source" if the group membership is not met.