### PR TITLE
[TorchFix] Update version to 0.2.0

### DIFF
--- a/tools/torchfix/torchfix/torchfix.py
+++ b/tools/torchfix/torchfix/torchfix.py
@@ -18,7 +18,7 @@ from .visitors.vision import (
 )
 from .visitors.security import TorchUnsafeLoadVisitor
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 DEPRECATED_CONFIG_PATH = Path(__file__).absolute().parent / "deprecated_symbols.yaml"
 


### PR DESCRIPTION
TorchFix 0.2.0 release

- TorchFix now depends on libcst-0.1.1 and thus can be installed from PyPI on Python 3.12 without requirement of Rust toolchain
- Added a rule to find and fix potentially unsafe usages of `torch.load`
- Codemods for deprecated functions now honor aliases for torch (`import torch as`)
- `torch.solve` added to the list of removed PyTorch functions