### PR TITLE
Move conda and conda-builds to latest conda versions

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -114,8 +114,8 @@ runs:
             --prefix "${CONDA_ENV}" \
             "python=${PYTHON_VERSION}" \
             cmake=3.22 \
-            conda-build=3.26.1 \
-            conda=23.9.0 \
+            conda-build=3.27.0 \
+            conda=23.10.0 \
             ninja=1.10 \
             pkg-config=0.29 \
             wheel=0.37

--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -114,8 +114,8 @@ runs:
             --prefix "${CONDA_ENV}" \
             "python=${PYTHON_VERSION}" \
             cmake=3.22 \
-            conda-build=3.21 \
-            conda=23.7.3 \
+            conda-build=3.26.1 \
+            conda=23.9.0 \
             ninja=1.10 \
             pkg-config=0.29 \
             wheel=0.37

--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -141,10 +141,6 @@ jobs:
             export USE_OPENMP="0"
           fi
 
-          # conda 23.9 is installed by default on macos M1
-          # and this creates an issue. Hence downgrading it here
-          conda install --yes conda=23.9
-
           ${CONDA_RUN} conda build \
             -c defaults \
             -c "pytorch-${CHANNEL}" \

--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -141,9 +141,9 @@ jobs:
             export USE_OPENMP="0"
           fi
 
-          # conda 23.10 is installed by default on macos M1
+          # conda 23.9 is installed by default on macos M1
           # and this creates an issue. Hence downgrading it here
-          conda install --yes conda=23.7.3
+          conda install --yes conda=23.9
 
           ${CONDA_RUN} conda build \
             -c defaults \


### PR DESCRIPTION
Move conda and conda builds to latest conda versions.
This failure I believe is pre existing issue in nightly : 
https://github.com/pytorch/test-infra/actions/runs/6984665829/job/19007831651?pr=4757
Here is nightly failure:
https://github.com/pytorch/vision/actions/runs/6980248443/job/18995117245#step:13:279
