### PR TITLE
Remove distr prefix from macos builds

### DIFF
--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -187,9 +187,9 @@ jobs:
           ${CONDA_RUN_SMOKE} conda install \
             --quiet \
             --yes \
-            -c pytorch-${CHANNEL} \
             -c "${CONDA_LOCAL_CHANNEL}" \
-            distr::"${PACKAGE_NAME}"
+            -c pytorch-${CHANNEL} \
+            "${PACKAGE_NAME}"
 
           if [[ ! -f "${{ inputs.repository }}"/${SMOKE_TEST_SCRIPT} ]]; then
             echo "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT} not found"


### PR DESCRIPTION
MacOS smoke test started to fail with following error:
```
/opt/homebrew/Caskroom/miniconda/base/bin/conda run -p /Users/ec2-user/runner/_work/_temp/pytorch_pkg_helpers_7018156083_smoke conda install --quiet --yes -c pytorch-nightly -c file:///Users/ec2-user/runner/_work/vision/vision/pytorch/vision/distr distr::torchvision

PackagesNotFoundError: The following packages are not available from current channels:

  - distr::torchvision

Current channels:

  - https://conda.anaconda.org/pytorch-nightly
  - file:///Users/ec2-user/runner/_work/vision/vision/pytorch/vision/distr
  - defaults
  - https://conda.anaconda.org/distr <-- Here is the error

To search for alternate channels that may provide the conda package you're
looking for, navigate to

    https://anaconda.org/

and use the search bar at the top of the page.
```

Hence removing distr channel produces expected result.
Please note: followup may be required to make sure file is actually installed from  expected:
``
file:///Users/ec2-user/runner/_work/vision/vision/pytorch/vision/distr
`` 
and not ``pytorch-nightly`` or ``pytorch-test``