### PR TITLE
Override channel priority on installing. Add check for default channel

### DIFF
--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -178,11 +178,21 @@ jobs:
           ${CONDA_RUN_SMOKE} conda install \
             --yes \
             --quiet \
+            -c "${CONDA_LOCAL_CHANNEL}" \
             -c pytorch-"${CHANNEL}" \
             -c nvidia \
-            -c "${CONDA_LOCAL_CHANNEL}" \
-            distr::"${PACKAGE_NAME}" \
-            ${CONSTRAINTS}
+            -c defaults \
+            "${PACKAGE_NAME}" \
+            ${CONSTRAINTS} \
+            --override-channels
+
+          # check for installed package channel
+          CONDA_PKG=$(${CONDA_RUN_SMOKE} conda list | grep "${PACKAGE_NAME}" | grep "${CONDA_LOCAL_CHANNEL}")
+          if [[ -z "${CONDA_PKG}" ]]; then
+            ${CONDA_RUN_SMOKE} conda list | grep "${PACKAGE_NAME}"
+            echo "${PACKAGE_NAME} is not installed from local channel"
+            exit 1
+          fi
 
           if [[ ! -f "${{ inputs.repository }}"/${SMOKE_TEST_SCRIPT} ]]; then
             echo "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT} not found"

--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -181,14 +181,24 @@ jobs:
           export CONDA_RUN_SMOKE="conda run -p ${CONDA_ENV_SMOKE}"
           export OLD_PATH=${PATH}
           export PATH="${CONDA_ENV_SMOKE}/bin:${PATH}"
-
           CONDA_LOCAL_CHANNEL="file://$(readlink -f ${{ inputs.repository }}/distr)"
+
           ${CONDA_RUN_SMOKE} conda install \
             --quiet \
             --yes \
             -c "${CONDA_LOCAL_CHANNEL}" \
             -c pytorch-${CHANNEL} \
-            "${PACKAGE_NAME}"
+            -c defaults \
+            "${PACKAGE_NAME}" \
+            "--override-channels"
+
+          # check for installed package channel
+          CONDA_PKG=$(${CONDA_RUN_SMOKE} conda list | grep "${PACKAGE_NAME}" | grep "${CONDA_LOCAL_CHANNEL}")
+          if [[ -z "${CONDA_PKG}" ]]; then
+            ${CONDA_RUN_SMOKE} conda list | grep "${PACKAGE_NAME}"
+            echo "${PACKAGE_NAME} is not installed from local channel"
+            exit 1
+          fi
 
           if [[ ! -f "${{ inputs.repository }}"/${SMOKE_TEST_SCRIPT} ]]; then
             echo "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT} not found"

--- a/.github/workflows/build_conda_windows.yml
+++ b/.github/workflows/build_conda_windows.yml
@@ -203,11 +203,21 @@ jobs:
           ${CONDA_RUN_SMOKE} conda install \
             --quiet \
             --yes \
+            -c "${CONDA_LOCAL_CHANNEL}" \
             -c pytorch-"${CHANNEL}" \
             -c nvidia \
-            -c "${CONDA_LOCAL_CHANNEL}" \
-            distr::"${PACKAGE_NAME}" \
-            ${CONSTRAINTS}
+            -c defaults \
+            "${PACKAGE_NAME}" \
+            ${CONSTRAINTS} \
+            --override-channels
+
+          # fow windows we use BUILD_VERSION to validate the package
+          CONDA_PKG=$(${CONDA_RUN_SMOKE} conda list | grep "${PACKAGE_NAME}" | grep "${BUILD_VERSION}")
+          if [[ -z "${CONDA_PKG}" ]]; then
+            ${CONDA_RUN_SMOKE} conda list | grep "${BUILD_VERSION}"
+            echo "${PACKAGE_NAME} is not installed with a correct version"
+            exit 1
+          fi
 
           if [[ ! -f "${{ inputs.repository }}"/${SMOKE_TEST_SCRIPT} ]]; then
             echo "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT} not found"


### PR DESCRIPTION
Forward fix for: https://github.com/pytorch/test-infra/pull/4766

Related to issue: https://github.com/conda/conda/issues/13374

1. Make sure packages are searched in particular order during install. Use override-channel option when installing packages for smoke test: From Conda documentation:

https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/channels.html#specifying-channels-when-installing-packages
```
From the command line use --c
You may specify multiple channels by passing the argument multiple times.
Priority decreases from left to right - the first argument is higher priority than the second.
From the command line use --override-channels to only search the specified channel(s),
 rather than any channels configured in .condarc.
```

2. Add check for validating that required package is actually installed from required channel