### PR TITLE
[log classifier] Deprioritized npm error, new rule to capture xla cpp test failures

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -101,10 +101,6 @@ name = 'inductor model failure'
 pattern = '^([a-zA-Z0-9_]+) +(fail_accuracy|fail_to_run|eager_variation|infra_error|0\.0000|(?:(?:FAIL|IMPROVED): +(?:.*)))$'
 
 [[rule]]
-name = 'npm error'
-pattern = '^npm ERR! code .*'
-
-[[rule]]
 name = 'NVIDIA installation failure'
 pattern = '^ERROR: Installation has failed.*?nvidia'
 
@@ -251,6 +247,10 @@ pattern = 'FAIL:\s+graph_breaks='
 [[rule]]
 name = 'Improved graph breaks'
 pattern = 'IMPROVED:\s+graph_breaks='
+
+[[rule]]
+name = 'npm error'
+pattern = '^npm ERR! code (?!EEXIST).*'
 
 [[rule]]
 name = 'GHA error'

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -249,9 +249,9 @@ name = 'Improved graph breaks'
 pattern = 'IMPROVED:\s+graph_breaks='
 
 [[rule]]
-name = 'npm error'
-pattern = '^npm ERR! code (?!EEXIST).*'
-
-[[rule]]
 name = 'GHA error'
 pattern = '^##\[error\](.*)'
+
+[[rule]]
+name = 'npm error'
+pattern = '^npm ERR! code .*'

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -97,6 +97,10 @@ name = 'pytest test error'
 pattern = '^ERROR (?:\[.*s\] )?(\S*.py::\S*::test_\S*)'
 
 [[rule]]
+name = 'xla cpp test failure'
+pattern = 'Build completed, \d+ test FAILED, \d+ total actions'
+
+[[rule]]
 name = 'inductor model failure'
 pattern = '^([a-zA-Z0-9_]+) +(fail_accuracy|fail_to_run|eager_variation|infra_error|0\.0000|(?:(?:FAIL|IMPROVED): +(?:.*)))$'
 
@@ -247,6 +251,10 @@ pattern = 'FAIL:\s+graph_breaks='
 [[rule]]
 name = 'Improved graph breaks'
 pattern = 'IMPROVED:\s+graph_breaks='
+
+[[rule]]
+name = 'npm error'
+pattern = '^npm ERR! code .*'
 
 [[rule]]
 name = 'GHA error'

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -251,7 +251,3 @@ pattern = 'IMPROVED:\s+graph_breaks='
 [[rule]]
 name = 'GHA error'
 pattern = '^##\[error\](.*)'
-
-[[rule]]
-name = 'npm error'
-pattern = '^npm ERR! code .*'


### PR DESCRIPTION
The log classifier keeps getting stuck on `npm ERR! code EEXIST` for XLA