### PR TITLE
Support fuzzy string matching to compare failures

### DIFF
--- a/torchci/lib/jobUtils.ts
+++ b/torchci/lib/jobUtils.ts
@@ -3,12 +3,13 @@ import dayjs from "dayjs";
 import TrieSearch from "trie-search";
 import getRocksetClient from "./rockset";
 import rocksetVersions from "rockset/prodVersions.json";
-import { isEqual } from "lodash";
 import { RecentWorkflowsData, JobData, BasicJobData } from "lib/types";
+import { jaroWinkler } from "jaro-winkler-typescript";
 
 export const REMOVE_JOB_NAME_SUFFIX_REGEX = new RegExp(
   ", [0-9]+, [0-9]+, .+\\)"
 );
+export const STRING_SIMILARITY_THRESHOLD = 0.85;
 
 export function isFailedJob(job: JobData) {
   return (
@@ -176,7 +177,13 @@ export function isSameFailure(
 
   return (
     jobA.conclusion === jobB.conclusion &&
-    isEqual(jobA.failure_captures, jobB.failure_captures)
+    jobA.failure_captures.length === jobB.failure_captures.length &&
+    _.every(
+      _.zip(jobA.failure_captures, jobB.failure_captures),
+      (p: string[]) =>
+        jaroWinkler(p[0], p[1], { caseSensitive: false }) >=
+        STRING_SIMILARITY_THRESHOLD
+    )
   );
 }
 

--- a/torchci/package.json
+++ b/torchci/package.json
@@ -36,6 +36,7 @@
     "dayjs-plugin-utc": "^0.1.2",
     "echarts": "^5.3.2",
     "echarts-for-react": "^3.0.2",
+    "jaro-winkler-typescript": "^1.0.1",
     "lodash": "^4.17.21",
     "minimist": "^1.2.6",
     "next": "12.1.5",

--- a/torchci/test/jobUtils.test.ts
+++ b/torchci/test/jobUtils.test.ts
@@ -141,6 +141,21 @@ describe("Test various job utils", () => {
     jobB.failure_captures = ["ERROR"];
     // Same failure
     expect(isSameFailure(jobA, jobB)).toEqual(true);
+
+    jobA.name =
+      "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)";
+    jobA.conclusion = "failure";
+    jobA.failure_captures = [
+      "/tmp/pip-install-sdv7mx3q/fbgemm-gpu_fa0c79131309402191fdda37c97e4b4b/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp:129:7: error: ‘optTypeMetaToScalarType’ was not declared in this scope; did you mean ‘c10::optTypeMetaToScalarType’?",
+    ];
+    jobB.name =
+      "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 2, 5, linux.g5.4xlarge.nvidia.gpu)";
+    jobB.conclusion = "failure";
+    jobB.failure_captures = [
+      "/tmp/pip-install-todusv3h/fbgemm-gpu_a5f04fd26b01466c9b9ed5c461ed8857/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp:129:7: error: ‘optTypeMetaToScalarType’ was not declared in this scope; did you mean ‘c10::optTypeMetaToScalarType’?",
+    ];
+    // Fuzzy comparison of the same failure
+    expect(isSameFailure(jobA, jobB)).toEqual(true);
   });
 
   test("test removeCancelledJobAfterRetry", async () => {

--- a/torchci/yarn.lock
+++ b/torchci/yarn.lock
@@ -5602,6 +5602,11 @@ istanbul-reports@^3.1.3:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+jaro-winkler-typescript@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jaro-winkler-typescript/-/jaro-winkler-typescript-1.0.1.tgz#d976d269eef10675c58ce28d304d40f642ef93ed"
+  integrity sha512-MsXieUkvK2Lv5CCVu42ddaE2tALmerhEY46DQb1ry0AEl/Au6HFi7zFemIKlbc3md93NDijfOj0AFuSfUJST3g==
+
 jclass@^1.0.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/jclass/-/jclass-1.2.1.tgz#eaafeec0dd6a5bf8b3ea43c04e010c637638768b"


### PR DESCRIPTION
Use Jaro-Winkler string matching to compare failures.  This helps the case where there are random generated string in the error, for example, https://github.com/pytorch/pytorch/pull/114697.  For example,

```
jaroWinkler(
  "/tmp/pip-install-1ffb916n/fbgemm-gpu_a232bb6f0fa24cea8b498f73f367969c/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp:129:7: error: ‘optTypeMetaToScalarType’ was not declared in this scope; did you mean ‘c10::optTypeMetaToScalarType’?", 
  "/tmp/pip-install-g1l1attb/fbgemm-gpu_a8335f2b184946059273dcfd4193adee/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp:129:7: error: ‘optTypeMetaToScalarType’ was not declared in this scope; did you mean ‘c10::optTypeMetaToScalarType’?"
) returns

0.8987928326805548
```

So I set the threshold to be 0.85, and try it out.

### Testing

Failures on https://github.com/pytorch/pytorch/pull/114697 are correctly shown as flaky and broken trunk

```
curl --request POST \
--url "http://localhost:3000/api/drci/drci?prNumber=114697" \
--header "Authorization: TOKEN" \
--data 'repo=pytorch'
```