### PR TITLE
[dashboard] Exclude model_fail_to_load and eager_fail_to_run

### DIFF
--- a/torchci/rockset/inductor/__sql/compilers_benchmark_performance.sql
+++ b/torchci/rockset/inductor/__sql/compilers_benchmark_performance.sql
@@ -12,6 +12,8 @@ WITH performance_results AS (
     compilation_latency,
     compression_ratio,
     abs_latency,
+    mfu,
+    memory_bandwidth,
     workflow_id,
     CAST(job_id AS INT) AS job_id,
   FROM
@@ -50,6 +52,8 @@ accuracy_results AS (
     AND _event_time >= PARSE_DATETIME_ISO8601(:startTime)
     AND _event_time < PARSE_DATETIME_ISO8601(:stopTime)
     AND (workflow_id = :workflowId OR :workflowId = 0)
+    AND accuracy != 'model_fail_to_load'
+    AND accuracy != 'eager_fail_to_run'
 ),
 results AS (
   SELECT
@@ -91,6 +95,14 @@ results AS (
       CAST(abs_latency AS FLOAT),
       0.0
     ) AS abs_latency,
+    IF(TRY_CAST(mfu AS FLOAT) IS NOT NULL,
+      CAST(mfu AS FLOAT),
+      0.0
+    ) AS mfu,
+    IF(TRY_CAST(memory_bandwidth AS FLOAT) IS NOT NULL,
+      CAST(memory_bandwidth AS FLOAT),
+      0.0
+    ) AS memory_bandwidth,
   FROM
     accuracy_results
     LEFT JOIN performance_results ON performance_results.name = accuracy_results.name
@@ -109,6 +121,8 @@ SELECT DISTINCT
   results.compilation_latency,
   results.compression_ratio,
   results.abs_latency,
+  results.mfu,
+  results.memory_bandwidth,
   FORMAT_ISO8601(
     DATE_TRUNC(: granularity, w._event_time)
   ) AS granularity_bucket,

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -81,7 +81,7 @@
     "queue_times_historical_pct": "f815ad1732928bb6"
   },
   "inductor": {
-    "compilers_benchmark_performance": "04773901fc1135d4",
+    "compilers_benchmark_performance": "c11fd43a3e2e1fde",
     "compilers_benchmark_performance_branches": "8896fe6bbd61e7dc"
   },
   "torchbench": {


### PR DESCRIPTION
Summary: https://github.com/pytorch/pytorch/pull/114784/ introduces two more fail states, model_fail_to_load and eager_fail_to_run, and they should be excluded from calculating the pass rate.