### PR TITLE
Use self-hosted runners to upload disabled JSONs to S3 

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,6 +4,7 @@ self-hosted-runner:
     - macos-m1-12
     - linux.12xlarge
     - linux.2xlarge
+    - linux.large
     - linux.4xlarge.nvidia.gpu
     - linux.g5.4xlarge.nvidia.gpu
     - linux.g5.12xlarge.nvidia.gpu

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -86,7 +86,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: disabled-tests
+          name: disabled-artifacts
           if-no-files-found: error
           path: |
             disabled-tests-condensed.json
@@ -99,6 +99,17 @@ jobs:
     runs-on: linux.large
     needs: linux.large
     steps:
+      # For awscli S3 upload
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: pip
+
+      - name: Download disabled artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: disabled-artifacts
+
       - name: Upload files to s3
         # if: github.event_name != 'pull_request'
         run: |

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - .github/workflows/update_disabled_tests.yml
       - .github/scripts/update_disabled_issues.py
 
 jobs:
@@ -83,14 +84,26 @@ jobs:
           user_name: "Pytorch Test Infra"
           commit_message: "Updating unstable jobs"
 
-      - name: Upload file to s3
-        if: github.event_name != 'pull_request'
+      - uses: actions/upload-artifact@v3
+        with:
+          name: disabled-tests
+          if-no-files-found: error
+          path: |
+            disabled-tests-condensed.json
+            disabled-jobs.json
+            unstable-jobs.json
+
+  # NB: Use our self-hosted runner to upload the files to S3, the runners already
+  # have access to the bucket
+  upload-disabled-tests-s3:
+    runs-on: linux.large
+    needs: linux.large
+    steps:
+      - name: Upload files to s3
+        # if: github.event_name != 'pull_request'
         run: |
           python3 -mpip install awscli==1.27.69
 
           aws s3 cp disabled-tests-condensed.json s3://ossci-metrics/disabled-tests-condensed.json
           aws s3 cp disabled-jobs.json s3://ossci-metrics/disabled-jobs.json
           aws s3 cp unstable-jobs.json s3://ossci-metrics/unstable-jobs.json
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -97,7 +97,7 @@ jobs:
   # have access to the bucket
   upload-disabled-tests-s3:
     runs-on: linux.large
-    needs: linux.large
+    needs: update-disabled-tests
     steps:
       # For awscli S3 upload
       - uses: actions/setup-python@v4


### PR DESCRIPTION
The credentials have been revoked, so the job is now failing https://github.com/pytorch/test-infra/actions/workflows/update_disabled_tests.yml. This change gets rid of the need to set AWS credential in this workflow.