### PR TITLE
[hud] Turn on vercel analytics? 

### DIFF
--- a/torchci/package.json
+++ b/torchci/package.json
@@ -30,6 +30,7 @@
     "@opensearch-project/opensearch": "^2.3.1",
     "@rockset/client": "^0.8.9",
     "@types/minimist": "^1.2.2",
+    "@vercel/analytics": "^1.1.1",
     "ansicolor": "^1.1.100",
     "axios": "^0.26.1",
     "dayjs": "^1.11.3",

--- a/torchci/pages/_app.tsx
+++ b/torchci/pages/_app.tsx
@@ -5,6 +5,7 @@ import { SessionProvider } from "next-auth/react";
 import type { AppProps } from "next/app";
 import Head from "next/head";
 import "styles/globals.css";
+import { Analytics } from '@vercel/analytics/react';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
@@ -19,6 +20,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         <div style={{ margin: "20px" }}>
           <Component {...pageProps} />
         </div>
+        <Analytics />
       </SessionProvider>
     </>
   );

--- a/torchci/pages/_app.tsx
+++ b/torchci/pages/_app.tsx
@@ -5,7 +5,7 @@ import { SessionProvider } from "next-auth/react";
 import type { AppProps } from "next/app";
 import Head from "next/head";
 import "styles/globals.css";
-import { Analytics } from '@vercel/analytics/react';
+import { Analytics } from "@vercel/analytics/react";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/torchci/yarn.lock
+++ b/torchci/yarn.lock
@@ -3130,6 +3130,13 @@
     "@typescript-eslint/types" "5.10.1"
     eslint-visitor-keys "^3.0.0"
 
+"@vercel/analytics@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@vercel/analytics/-/analytics-1.1.1.tgz#2a712378a95014a548b4f9d2ae1ea0721433908d"
+  integrity sha512-+NqgNmSabg3IFfxYhrWCfB/H+RCUOCR5ExRudNG2+pcRehq628DJB5e1u1xqwpLtn4pAYii4D98w7kofORAGQA==
+  dependencies:
+    server-only "^0.0.1"
+
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
@@ -7866,6 +7873,11 @@ serve-static@1.15.0:
     escape-html "~1.0.3"
     parseurl "~1.3.3"
     send "0.18.0"
+
+server-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/server-only/-/server-only-0.0.1.tgz#0f366bb6afb618c37c9255a314535dc412cd1c9e"
+  integrity sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==
 
 setprototypeof@1.2.0:
   version "1.2.0"


### PR DESCRIPTION
I went to the vercel analytics page https://vercel.com/fbopensource/torchci/analytics and saw that there are 0 visitors to hud, which is wrong.

I think the only thing that could be an issue is logging in via github, but I don't know enough to know if its going to be an issue.  Afaict it only saves page views at the moment, and that includes information about URLs but idt the github signin stores any info in the url.  I would appreciate more eyes on this.

Here is the privacy policy: https://vercel.com/docs/analytics/privacy-policy

I have no idea when this got turned on or if we pay for it.