### PR TITLE
Handle false positive flaky detection on reverted PRs

### DIFF
--- a/torchci/lib/searchUtils.ts
+++ b/torchci/lib/searchUtils.ts
@@ -7,6 +7,8 @@ export const WORKFLOW_JOB_INDEX = "torchci-workflow-job";
 // about which is a reasonable value here and how to tune it
 export const MIN_SCORE = 1.0;
 export const MAX_SIZE = 20;
+export const NEWEST_FIRST = "desc";
+export const OLDEST_FIRST = "asc";
 
 export async function searchSimilarFailures(
   client: Client,
@@ -17,7 +19,8 @@ export async function searchSimilarFailures(
   startDate: string,
   endDate: string,
   minScore: number,
-  maxSize: number = MAX_SIZE
+  maxSize: number = MAX_SIZE,
+  sortByTimeStamp: string = OLDEST_FIRST
 ): Promise<{ jobs: JobData[] }> {
   const must: any[] = [
     {
@@ -75,7 +78,7 @@ export async function searchSimilarFailures(
     sort: [
       "_score",
       {
-        completed_at: "desc",
+        completed_at: sortByTimeStamp,
       },
     ],
   };

--- a/torchci/pages/api/failure.ts
+++ b/torchci/pages/api/failure.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import fetchFailureSamples from "lib/fetchFailureSamples";
 import { querySimilarFailures } from "lib/drciUtils";
+import { NEWEST_FIRST } from "lib/searchUtils";
 import dayjs from "dayjs";
 import { RecentWorkflowsData } from "lib/types";
 import _ from "lodash";
@@ -33,13 +34,15 @@ export default async function handler(
     head_sha: "",
   };
 
-  // The current HUD page shows the last 14 days
+  // The current HUD page shows the last 14 days. Newer results are preferred
+  // here, thus NEWEST_FIRST
   const lookbackPeriodInHours = 14 * 24;
   const samples = await querySimilarFailures(
     failure,
     "",
     lookbackPeriodInHours,
-    MAX_SIZE
+    MAX_SIZE,
+    NEWEST_FIRST
   );
 
   // NB: This filter step keeps only exact matchs of the failure, this is the current

--- a/torchci/test/drciUtils.test.ts
+++ b/torchci/test/drciUtils.test.ts
@@ -67,6 +67,7 @@ describe("Test various utils used by Dr.CI", () => {
         emptyBaseCommitDate,
         lookbackPeriodInHours,
         searchUtils.MAX_SIZE,
+        searchUtils.OLDEST_FIRST,
         "TESTING" as unknown as Client
       )
     ).toStrictEqual([]);
@@ -80,6 +81,7 @@ describe("Test various utils used by Dr.CI", () => {
         emptyBaseCommitDate,
         lookbackPeriodInHours,
         searchUtils.MAX_SIZE,
+        searchUtils.OLDEST_FIRST,
         "TESTING" as unknown as Client
       )
     ).toStrictEqual([]);
@@ -93,6 +95,7 @@ describe("Test various utils used by Dr.CI", () => {
         emptyBaseCommitDate,
         lookbackPeriodInHours,
         searchUtils.MAX_SIZE,
+        searchUtils.OLDEST_FIRST,
         "TESTING" as unknown as Client
       )
     ).toStrictEqual([]);
@@ -106,6 +109,7 @@ describe("Test various utils used by Dr.CI", () => {
         emptyBaseCommitDate,
         lookbackPeriodInHours,
         searchUtils.MAX_SIZE,
+        searchUtils.OLDEST_FIRST,
         "TESTING" as unknown as Client
       )
     ).toStrictEqual([mockJobData]);
@@ -121,6 +125,7 @@ describe("Test various utils used by Dr.CI", () => {
           mockEndDate,
           searchUtils.MIN_SCORE,
           searchUtils.MAX_SIZE,
+          searchUtils.OLDEST_FIRST,
         ],
       ])
     );
@@ -135,6 +140,7 @@ describe("Test various utils used by Dr.CI", () => {
         baseCommitDate,
         lookbackPeriodInHours,
         searchUtils.MAX_SIZE,
+        searchUtils.OLDEST_FIRST,
         "TESTING" as unknown as Client
       )
     ).toStrictEqual([mockJobData]);
@@ -152,6 +158,7 @@ describe("Test various utils used by Dr.CI", () => {
           mockEndDate,
           searchUtils.MIN_SCORE,
           searchUtils.MAX_SIZE,
+          searchUtils.OLDEST_FIRST,
         ],
       ])
     );
@@ -168,6 +175,7 @@ describe("Test various utils used by Dr.CI", () => {
         baseCommitDate,
         lookbackPeriodInHours,
         searchUtils.MAX_SIZE,
+        searchUtils.OLDEST_FIRST,
         "TESTING" as unknown as Client
       )
     ).toStrictEqual([mockJobData]);
@@ -185,6 +193,7 @@ describe("Test various utils used by Dr.CI", () => {
           mockEndDate,
           searchUtils.MIN_SCORE,
           searchUtils.MAX_SIZE,
+          searchUtils.OLDEST_FIRST,
         ],
       ])
     );


### PR DESCRIPTION
This addresses the edge case in https://github.com/pytorch/pytorch/pull/113432 where the PR was reverted due to a land race failure.  Here is what happened:

1. PR was green and merged normally
2. The merge commit broke trunk due to landrace, and was reverted
3. PR was rebase.  The failure was reproducible on the PR, but Dr.CI classified it as flaky because it found similar failures from trunk commits from different authors

The fix here is to check if the failure comes from a previous merge commit of the PR, and if it does, do not mark it as flaky.  Here are the steps to achieve this:

1. When searching for similar results, return the oldest most relevant match first.  Previously, the timestamp didn't matter as long as there was a match
2. Using this sorted list, if the very first match from main comes from one of the previous merge commits of the PRs, it is a legit failure and Dr.CI shouldn't mark it as flaky regardless of any subsequent matches after that

### Testing

I replayed the older commit of https://github.com/pytorch/pytorch/pull/113432 after the PR was reverted and rebased but before the landrace issue was fixed at https://hud.pytorch.org/pytorch/pytorch/pull/113432?sha=ff8938d52667fcbf32d06d9a06b9e2b68e4eb193

Before the fix, all 4 failures in https://hud.pytorch.org/pytorch/pytorch/pull/113432?sha=ff8938d52667fcbf32d06d9a06b9e2b68e4eb193 was marked as flaky.  The dynamo failures are false positives.

After the fix, the 2 dynamo failures are now marked as failures correctly:

```
{"113432":{"FAILED":[{"workflowId":7146564427,"id":19464861300,"runnerName":"i-04f86a6adb63b1b30","authorEmail":"ybliang8@gmail.com","name":"pull / linux-focal-py3.11-clang10 / test (dynamo, 2, 2, linux.2xlarge)","jobName":"linux-focal-py3.11-clang10 / test (dynamo, 2, 2, linux.2xlarge)","conclusion":"failure","completed_at":"2023-12-08T23:36:01Z","html_url":"https://github.com/pytorch/pytorch/actions/runs/7146564427/job/19464861300","head_branch":"graph61","pr_number":113432,"head_sha":"ff8938d52667fcbf32d06d9a06b9e2b68e4eb193","failure_captures":["functorch/test_vmap.py::TestRandomnessCPU::test_bernoulli_in_place_use_generator_False_randomness_different_batched_input_first_batched_probability_first_cpu"],"failure_lines":["FAILED [0.0293s] functorch/test_vmap.py::TestRandomnessCPU::test_bernoulli_in_place_use_generator_False_randomness_different_batched_input_first_batched_probability_first_cpu - torch._dynamo.exc.TorchRuntimeError: Failed running call_function <method 'get_state' of 'torch._C.Generator' objects>(*(), **{}):"],"failure_context":["+ python test/run_test.py --dynamo --exclude-jit-executor --exclude-distributed-tests --exclude test_autograd test_jit test_proxy_tensor test_quantization test_public_bindings test_dataloader test_reductions test_namedtensor test_namedtuple_return_api profiler/test_profiler profiler/test_profiler_tree test_overrides test_python_dispatch test_fx test_package test_legacy_vmap test_custom_ops test_content_store export/test_db functorch/test_dims functorch/test_aotdispatch --shard 2 2 --verbose","+ python tools/dynamo/verify_dynamo.py","+ [[ -z 2 ]]","+ test_dynamo_shard 2","+ '[' -n '' ']'","+ pip install --progress-bar off --no-use-pep517 --user git+https://github.com/pytorch/vision.git@e12d200c97d7aab668b976e92b46513c9ca7a0d8","+ pip_install --no-use-pep517 --user git+https://github.com/pytorch/vision.git@e12d200c97d7aab668b976e92b46513c9ca7a0d8","+ '[' -n '' ']'","+ orig_preload=","+ commit=e12d200c97d7aab668b976e92b46513c9ca7a0d8","++ cat .github/ci_commit_pins/vision.txt","++ get_pinned_commit vision"],"time":"2023-12-08T23:36:08.513132Z"},{"workflowId":7146564427,"id":19464840984,"runnerName":"i-019747c8cba4707ef","authorEmail":"ybliang8@gmail.com","name":"pull / linux-focal-py3.8-clang10 / test (dynamo, 2, 2, linux.2xlarge)","jobName":"linux-focal-py3.8-clang10 / test (dynamo, 2, 2, linux.2xlarge)","conclusion":"failure","completed_at":"2023-12-08T23:23:04Z","html_url":"https://github.com/pytorch/pytorch/actions/runs/7146564427/job/19464840984","head_branch":"graph61","pr_number":113432,"head_sha":"ff8938d52667fcbf32d06d9a06b9e2b68e4eb193","failure_captures":["functorch/test_vmap.py::TestRandomnessCPU::test_bernoulli_in_place_use_generator_False_randomness_different_batched_input_first_batched_probability_first_cpu"],"failure_lines":["FAILED [0.0238s] functorch/test_vmap.py::TestRandomnessCPU::test_bernoulli_in_place_use_generator_False_randomness_different_batched_input_first_batched_probability_first_cpu - torch._dynamo.exc.TorchRuntimeError: Failed running call_function <method 'get_state' of 'torch._C.Generator' objects>(*(), **{}):"],"failure_context":["+ python test/run_test.py --dynamo --exclude-jit-executor --exclude-distributed-tests --exclude test_autograd test_jit test_proxy_tensor test_quantization test_public_bindings test_dataloader test_reductions test_namedtensor test_namedtuple_return_api profiler/test_profiler profiler/test_profiler_tree test_overrides test_python_dispatch test_fx test_package test_legacy_vmap test_custom_ops test_content_store export/test_db functorch/test_dims functorch/test_aotdispatch --shard 2 2 --verbose","+ python tools/dynamo/verify_dynamo.py","+ [[ -z 2 ]]","+ test_dynamo_shard 2","+ '[' -n '' ']'","+ pip install --progress-bar off --no-use-pep517 --user git+https://github.com/pytorch/vision.git@e12d200c97d7aab668b976e92b46513c9ca7a0d8","+ pip_install --no-use-pep517 --user git+https://github.com/pytorch/vision.git@e12d200c97d7aab668b976e92b46513c9ca7a0d8","+ '[' -n '' ']'","+ orig_preload=","+ commit=e12d200c97d7aab668b976e92b46513c9ca7a0d8","++ cat .github/ci_commit_pins/vision.txt","++ get_pinned_commit vision"],"time":"2023-12-08T23:23:12.303861Z"}],"FLAKY":[{"workflowId":7146565827,"id":19465449034,"runnerName":"i-0fabffaafd970ab9f","authorEmail":"ybliang8@gmail.com","name":"inductor-periodic / cuda12.1-py3.10-gcc9-sm86-periodic-dynamo-benchmarks / test (dynamic_aot_eager_torchbench, 1, 2, linux.g5.4xlarge.nvidia.gpu)","jobName":"cuda12.1-py3.10-gcc9-sm86-periodic-dynamo-benchmarks / test (dynamic_aot_eager_torchbench, 1, 2, linux.g5.4xlarge.nvidia.gpu)","conclusion":"failure","completed_at":"2023-12-09T00:35:51Z","html_url":"https://github.com/pytorch/pytorch/actions/runs/7146565827/job/19465449034","head_branch":"ciflow/inductor/113432","pr_number":113432,"head_sha":"ff8938d52667fcbf32d06d9a06b9e2b68e4eb193","failure_captures":["hf_T5_base","FAIL:     accuracy=OOM, expected=pass"],"failure_lines":["hf_T5_base                          FAIL:     accuracy=OOM, expected=pass"],"failure_context":["+ python benchmarks/dynamo/check_accuracy.py --actual /var/lib/jenkins/workspace/test/test-reports/training_torchbench.csv --expected benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_torchbench_training.csv","+ python benchmarks/dynamo/torchbench.py --ci --accuracy --timing --explain --backend aot_eager --dynamic-shapes --dynamic-batch-only --device cuda --training --amp --total-partitions 2 --partition-id 0 --output /var/lib/jenkins/workspace/test/test-reports/training_torchbench.csv","+ [[ dynamic_aot_eager_torchbench == *perf* ]]","+ [[ dynamic_aot_eager_torchbench == *perf_compare* ]]","+ partition_flags=(--total-partitions \"$NUM_TEST_SHARDS\" --partition-id \"$shard_id\")","+ [[ -n 0 ]]","+ [[ -n 2 ]]","+ local partition_flags","+ partition_flags=()","+ shift","+ local shard_id=0","+ shift"],"time":"2023-12-09T00:35:54.602210Z"},{"workflowId":7146565711,"id":19465047283,"runnerName":"i-0d62ef2bd5cbfc940","authorEmail":"ybliang8@gmail.com","name":"trunk / win-vs2019-cpu-py3 / test (default, 3, 3, windows.4xlarge.nonephemeral)","jobName":"win-vs2019-cpu-py3 / test (default, 3, 3, windows.4xlarge.nonephemeral)","conclusion":"failure","completed_at":"2023-12-08T22:06:03Z","html_url":"https://github.com/pytorch/pytorch/actions/runs/7146565711/job/19465047283","head_branch":"ciflow/trunk/113432","pr_number":113432,"head_sha":"ff8938d52667fcbf32d06d9a06b9e2b68e4eb193","failure_captures":["The process cannot access the file 'C:\\actions-runner\\_work\\_actions\\pytorch\\pytorch\\main\\benchmarks\\dynamo\\microbenchmarks\\operator_inp_logs' because it is being used by another process."],"failure_lines":["##[error]The process cannot access the file 'C:\\actions-runner\\_work\\_actions\\pytorch\\pytorch\\main\\benchmarks\\dynamo\\microbenchmarks\\operator_inp_logs' because it is being used by another process."],"failure_context":[],"time":"2023-12-08T22:06:06.245275Z"}],"BROKEN_TRUNK":[],"UNSTABLE":[{"workflowId":7146565711,"id":19465048465,"runnerName":"worker-rocm-amd-72","authorEmail":"ybliang8@gmail.com","name":"trunk / linux-focal-rocm5.7-py3.8 / test (default, 1, 1, linux.rocm.gpu, unstable)","jobName":"linux-focal-rocm5.7-py3.8 / test (default, 1, 1, linux.rocm.gpu, unstable)","conclusion":"cancelled","completed_at":"2023-12-09T01:29:51Z","html_url":"https://github.com/pytorch/pytorch/actions/runs/7146565711/job/19465048465","head_branch":"ciflow/trunk/113432","pr_number":113432,"head_sha":"ff8938d52667fcbf32d06d9a06b9e2b68e4eb193","failure_captures":["##[error]The operation was canceled."],"failure_lines":["##[error]The operation was canceled."],"failure_context":["+ python test/run_test.py --exclude-jit-executor --exclude-distributed-tests --include test_nn test_torch test_cuda test_ops test_unary_ufuncs test_binary_ufuncs test_autograd --verbose","+ test_python","+ '[' -n '' ']'","+ pip install --progress-bar off --no-use-pep517 --user git+https://github.com/pytorch/vision.git@e12d200c97d7aab668b976e92b46513c9ca7a0d8","+ pip_install --no-use-pep517 --user git+https://github.com/pytorch/vision.git@e12d200c97d7aab668b976e92b46513c9ca7a0d8","+ '[' -n '' ']'","+ orig_preload=","+ commit=e12d200c97d7aab668b976e92b46513c9ca7a0d8","++ cat .github/ci_commit_pins/vision.txt","++ get_pinned_commit vision","+ local commit","+ local orig_preload"],"time":"2023-12-09T01:29:58.704248Z"}]}}
```

<!-- drci-comment-start -->

## :link: Helpful Links
### :test_tube: See artifacts and rendered test results at [hud.pytorch.org/pr/113432](https://hud.pytorch.org/pr/113432)
* :page_facing_up: Preview [Python docs built from this PR](https://docs-preview.pytorch.org/pytorch/pytorch/113432/index.html)
* :page_facing_up: Preview [C++ docs built from this PR](https://docs-preview.pytorch.org/pytorch/pytorch/113432/cppdocs/index.html)
* :question: Need help or want to give feedback on the CI? Visit the [bot commands wiki](https://github.com/pytorch/pytorch/wiki/Bot-commands) or our [office hours](https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours)

Note: Links to docs will display an error until the docs builds have been completed.


## :x: 2 New Failures, 3 Unrelated Failures
As of commit ff8938d52667fcbf32d06d9a06b9e2b68e4eb193 with merge base af925a56a195cc095c589af687513cdc22caf33a (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1702070276?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details open><summary><b>NEW FAILURES</b> - The following jobs have failed:</summary><p>

* [pull / linux-focal-py3.11-clang10 / test (dynamo, 2, 2, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/113432#19464861300) ([gh](https://github.com/pytorch/pytorch/actions/runs/7146564427/job/19464861300))
* [pull / linux-focal-py3.8-clang10 / test (dynamo, 2, 2, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/113432#19464840984) ([gh](https://github.com/pytorch/pytorch/actions/runs/7146564427/job/19464840984))
</p></details>
<details ><summary><b>FLAKY</b> - The following jobs failed but were likely due to flakiness present on trunk:</summary><p>

* [inductor-periodic / cuda12.1-py3.10-gcc9-sm86-periodic-dynamo-benchmarks / test (dynamic_aot_eager_torchbench, 1, 2, linux.g5.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/113432#19465449034) ([gh](https://github.com/pytorch/pytorch/actions/runs/7146565827/job/19465449034))
* [trunk / win-vs2019-cpu-py3 / test (default, 3, 3, windows.4xlarge.nonephemeral)](https://hud.pytorch.org/pr/pytorch/pytorch/113432#19465047283) ([gh](https://github.com/pytorch/pytorch/actions/runs/7146565711/job/19465047283))
</p></details>
<details ><summary><b>UNSTABLE</b> - The following job failed but was likely due to flakiness present on trunk and has been marked as unstable:</summary><p>

* [trunk / linux-focal-rocm5.7-py3.8 / test (default, 1, 1, linux.rocm.gpu, unstable)](https://hud.pytorch.org/pr/pytorch/pytorch/113432#19465048465) ([gh](https://github.com/pytorch/pytorch/actions/runs/7146565711/job/19465048465))
</p></details>


This comment was automatically generated by Dr. CI and updates every 15 minutes.
<!-- drci-comment-end -->
