### PR TITLE
Specific PYTORCH_VERSION when building RC for test channel

### DIFF
--- a/.github/actions/set-channel/action.yml
+++ b/.github/actions/set-channel/action.yml
@@ -6,11 +6,6 @@ description: Add CHANNEL to GITHUB_ENV
 runs:
   using: composite
   steps:
-    - name: Set default CHANNEL
-      shell: bash
-      run: |
-        set -euxo pipefail
-        echo "CHANNEL=nightly" >> "${GITHUB_ENV}"
     - name: Set CHANNEL for tagged pushes
       if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/') }}
       shell: bash
@@ -26,3 +21,12 @@ runs:
       run: |
         set -euxo pipefail
         echo "CHANNEL=test" >> "$GITHUB_ENV"
+    - name: Set default CHANNEL
+      # Set this to nightly only when the CHANNEL hasn't been set yet. In GHA, once
+      # an env is set, it's fixed unless we can figure out a way to overwrite it in
+      # $GITHUB_ENV
+      if: ${{ env.CHANNEL == '' }}
+      shell: bash
+      run: |
+        set -euxo pipefail
+        echo "CHANNEL=nightly" >> "${GITHUB_ENV}"

--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -81,7 +81,7 @@ jobs:
       CU_VERSION: ${{ matrix.desired_cuda }}
       # When building RC, set the version to be the current candidate version, otherwise, leave
       # it empty so nightly will pick up the latest
-      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version || '' }}
+      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
     environment: ${{(inputs.trigger-event == 'push' || startsWith(github.event.ref, 'refs/tags/')) && 'pytorchbot-env' || ''}}

--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -79,6 +79,9 @@ jobs:
       REPOSITORY: ${{ inputs.repository }}
       REF: ${{ inputs.ref }}
       CU_VERSION: ${{ matrix.desired_cuda }}
+      # When building RC, set the version to be the current candidate version, otherwise, leave
+      # it empty so nightly will pick up the latest
+      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version || '' }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
     environment: ${{(inputs.trigger-event == 'push' || startsWith(github.event.ref, 'refs/tags/')) && 'pytorchbot-env' || ''}}

--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -79,9 +79,6 @@ jobs:
       REPOSITORY: ${{ inputs.repository }}
       REF: ${{ inputs.ref }}
       CU_VERSION: ${{ matrix.desired_cuda }}
-      # When building RC, set the version to be the current candidate version, otherwise, leave
-      # it empty so nightly will pick up the latest
-      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
     environment: ${{(inputs.trigger-event == 'push' || startsWith(github.event.ref, 'refs/tags/')) && 'pytorchbot-env' || ''}}
@@ -99,6 +96,12 @@ jobs:
           ref: ${{ inputs.test-infra-ref }}
           path: test-infra
       - uses: ./test-infra/.github/actions/set-channel
+      - name: Set PYTORCH_VERSION
+        if: ${{ env.CHANNEL == 'test' }}
+        run: |
+          # When building RC, set the version to be the current candidate version,
+          # otherwise, leave it alone so nightly will pick up the latest
+          echo "PYTORCH_VERSION=${{ matrix.stable_version }}" >> "${GITHUB_ENV}"
       - uses: ./test-infra/.github/actions/setup-binary-builds
         with:
           repository: ${{ inputs.repository }}

--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -83,6 +83,9 @@ jobs:
       REPOSITORY: ${{ inputs.repository }}
       REF: ${{ inputs.ref }}
       CU_VERSION: cpu
+      # When building RC, set the version to be the current candidate version, otherwise, leave
+      # it empty so nightly will pick up the latest
+      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version || '' }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ inputs.runner-type }}
     environment: ${{(inputs.trigger-event == 'push' || startsWith(github.event.ref, 'refs/tags/')) && 'pytorchbot-env' || ''}}

--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -85,7 +85,7 @@ jobs:
       CU_VERSION: cpu
       # When building RC, set the version to be the current candidate version, otherwise, leave
       # it empty so nightly will pick up the latest
-      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version || '' }}
+      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ inputs.runner-type }}
     environment: ${{(inputs.trigger-event == 'push' || startsWith(github.event.ref, 'refs/tags/')) && 'pytorchbot-env' || ''}}

--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -83,9 +83,6 @@ jobs:
       REPOSITORY: ${{ inputs.repository }}
       REF: ${{ inputs.ref }}
       CU_VERSION: cpu
-      # When building RC, set the version to be the current candidate version, otherwise, leave
-      # it empty so nightly will pick up the latest
-      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ inputs.runner-type }}
     environment: ${{(inputs.trigger-event == 'push' || startsWith(github.event.ref, 'refs/tags/')) && 'pytorchbot-env' || ''}}
@@ -109,6 +106,12 @@ jobs:
       - name: Set env variable for architecture name
         run: echo "ARCH_NAME=$(uname -m)" >> "${GITHUB_ENV}"
       - uses: ./test-infra/.github/actions/set-channel
+      - name: Set PYTORCH_VERSION
+        if: ${{ env.CHANNEL == 'test' }}
+        run: |
+          # When building RC, set the version to be the current candidate version,
+          # otherwise, leave it alone so nightly will pick up the latest
+          echo "PYTORCH_VERSION=${{ matrix.stable_version }}" >> "${GITHUB_ENV}"
       - uses: ./test-infra/.github/actions/setup-binary-builds
         with:
           repository: ${{ inputs.repository }}

--- a/.github/workflows/build_conda_windows.yml
+++ b/.github/workflows/build_conda_windows.yml
@@ -81,7 +81,7 @@ jobs:
       CU_VERSION: ${{ matrix.desired_cuda }}
       # When building RC, set the version to be the current candidate version, otherwise, leave
       # it empty so nightly will pick up the latest
-      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version || '' }}
+      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
     environment: ${{(inputs.trigger-event == 'push' || startsWith(github.event.ref, 'refs/tags/')) && 'pytorchbot-env' || ''}}

--- a/.github/workflows/build_conda_windows.yml
+++ b/.github/workflows/build_conda_windows.yml
@@ -79,6 +79,9 @@ jobs:
       REPOSITORY: ${{ inputs.repository }}
       REF: ${{ inputs.ref }}
       CU_VERSION: ${{ matrix.desired_cuda }}
+      # When building RC, set the version to be the current candidate version, otherwise, leave
+      # it empty so nightly will pick up the latest
+      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version || '' }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
     environment: ${{(inputs.trigger-event == 'push' || startsWith(github.event.ref, 'refs/tags/')) && 'pytorchbot-env' || ''}}

--- a/.github/workflows/build_conda_windows.yml
+++ b/.github/workflows/build_conda_windows.yml
@@ -79,9 +79,6 @@ jobs:
       REPOSITORY: ${{ inputs.repository }}
       REF: ${{ inputs.ref }}
       CU_VERSION: ${{ matrix.desired_cuda }}
-      # When building RC, set the version to be the current candidate version, otherwise, leave
-      # it empty so nightly will pick up the latest
-      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
     environment: ${{(inputs.trigger-event == 'push' || startsWith(github.event.ref, 'refs/tags/')) && 'pytorchbot-env' || ''}}
@@ -99,6 +96,12 @@ jobs:
           ref: ${{ inputs.test-infra-ref }}
           path: test-infra
       - uses: ./test-infra/.github/actions/set-channel
+      - name: Set PYTORCH_VERSION
+        if: ${{ env.CHANNEL == 'test' }}
+        run: |
+          # When building RC, set the version to be the current candidate version,
+          # otherwise, leave it alone so nightly will pick up the latest
+          echo "PYTORCH_VERSION=${{ matrix.stable_version }}" >> "${GITHUB_ENV}"
       - uses: ./test-infra/.github/actions/setup-ssh
         name: Setup SSH
         with:

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -88,7 +88,7 @@ jobs:
       ARCH: ${{ inputs.architecture }}
       # When building RC, set the version to be the current candidate version, otherwise, leave
       # it empty so nightly will pick up the latest
-      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version || '' }}
+      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
     environment: ${{(inputs.trigger-event == 'push' || startsWith(github.event.ref, 'refs/tags/')) && 'pytorchbot-env' || ''}}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -86,9 +86,6 @@ jobs:
       CU_VERSION: ${{ matrix.desired_cuda }}
       UPLOAD_TO_BASE_BUCKET: ${{ matrix.upload_to_base_bucket }}
       ARCH: ${{ inputs.architecture }}
-      # When building RC, set the version to be the current candidate version, otherwise, leave
-      # it empty so nightly will pick up the latest
-      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
     environment: ${{(inputs.trigger-event == 'push' || startsWith(github.event.ref, 'refs/tags/')) && 'pytorchbot-env' || ''}}
@@ -137,6 +134,12 @@ jobs:
           echo "/opt/conda/bin" >> $GITHUB_PATH
           set -e
       - uses: ./test-infra/.github/actions/set-channel
+      - name: Set PYTORCH_VERSION
+        if: ${{ env.CHANNEL == 'test' }}
+        run: |
+          # When building RC, set the version to be the current candidate version,
+          # otherwise, leave it alone so nightly will pick up the latest
+          echo "PYTORCH_VERSION=${{ matrix.stable_version }}" >> "${GITHUB_ENV}"
       - uses: ./test-infra/.github/actions/setup-binary-builds
         env:
           PLATFORM: ${{ inputs.architecture == 'aarch64'  && 'linux-aarch64' || ''}}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -86,6 +86,9 @@ jobs:
       CU_VERSION: ${{ matrix.desired_cuda }}
       UPLOAD_TO_BASE_BUCKET: ${{ matrix.upload_to_base_bucket }}
       ARCH: ${{ inputs.architecture }}
+      # When building RC, set the version to be the current candidate version, otherwise, leave
+      # it empty so nightly will pick up the latest
+      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version || '' }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
     environment: ${{(inputs.trigger-event == 'push' || startsWith(github.event.ref, 'refs/tags/')) && 'pytorchbot-env' || ''}}

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -77,9 +77,6 @@ jobs:
       PACKAGE_TYPE: wheel
       REPOSITORY: ${{ inputs.repository }}
       REF: ${{ inputs.ref }}
-      # When building RC, set the version to be the current candidate version, otherwise, leave
-      # it empty so nightly will pick up the latest
-      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ inputs.runner-type }}
     environment: ${{(inputs.trigger-event == 'push' || startsWith(github.event.ref, 'refs/tags/')) && 'pytorchbot-env' || ''}}
@@ -101,6 +98,12 @@ jobs:
           ref: ${{ inputs.test-infra-ref }}
           path: test-infra
       - uses: ./test-infra/.github/actions/set-channel
+      - name: Set PYTORCH_VERSION
+        if: ${{ env.CHANNEL == 'test' }}
+        run: |
+          # When building RC, set the version to be the current candidate version,
+          # otherwise, leave it alone so nightly will pick up the latest
+          echo "PYTORCH_VERSION=${{ matrix.stable_version }}" >> "${GITHUB_ENV}"
       - uses: ./test-infra/.github/actions/setup-binary-builds
         with:
           repository: ${{ inputs.repository }}

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -77,6 +77,9 @@ jobs:
       PACKAGE_TYPE: wheel
       REPOSITORY: ${{ inputs.repository }}
       REF: ${{ inputs.ref }}
+      # When building RC, set the version to be the current candidate version, otherwise, leave
+      # it empty so nightly will pick up the latest
+      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version || '' }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ inputs.runner-type }}
     environment: ${{(inputs.trigger-event == 'push' || startsWith(github.event.ref, 'refs/tags/')) && 'pytorchbot-env' || ''}}

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -79,7 +79,7 @@ jobs:
       REF: ${{ inputs.ref }}
       # When building RC, set the version to be the current candidate version, otherwise, leave
       # it empty so nightly will pick up the latest
-      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version || '' }}
+      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ inputs.runner-type }}
     environment: ${{(inputs.trigger-event == 'push' || startsWith(github.event.ref, 'refs/tags/')) && 'pytorchbot-env' || ''}}

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -79,6 +79,9 @@ jobs:
       REF: ${{ inputs.ref }}
       CU_VERSION: ${{ matrix.desired_cuda }}
       UPLOAD_TO_BASE_BUCKET: ${{ matrix.upload_to_base_bucket }}
+      # When building RC, set the version to be the current candidate version, otherwise, leave
+      # it empty so nightly will pick up the latest
+      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version || '' }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
     environment: ${{(inputs.trigger-event == 'push' || startsWith(github.event.ref, 'refs/tags/')) && 'pytorchbot-env' || ''}}

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -81,7 +81,7 @@ jobs:
       UPLOAD_TO_BASE_BUCKET: ${{ matrix.upload_to_base_bucket }}
       # When building RC, set the version to be the current candidate version, otherwise, leave
       # it empty so nightly will pick up the latest
-      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version || '' }}
+      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
     environment: ${{(inputs.trigger-event == 'push' || startsWith(github.event.ref, 'refs/tags/')) && 'pytorchbot-env' || ''}}

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -79,9 +79,6 @@ jobs:
       REF: ${{ inputs.ref }}
       CU_VERSION: ${{ matrix.desired_cuda }}
       UPLOAD_TO_BASE_BUCKET: ${{ matrix.upload_to_base_bucket }}
-      # When building RC, set the version to be the current candidate version, otherwise, leave
-      # it empty so nightly will pick up the latest
-      PYTORCH_VERSION: ${{ matrix.channel == 'test' && matrix.stable_version }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
     environment: ${{(inputs.trigger-event == 'push' || startsWith(github.event.ref, 'refs/tags/')) && 'pytorchbot-env' || ''}}
@@ -108,6 +105,12 @@ jobs:
         run: |
           echo "C:/Jenkins/Miniconda3/Scripts" >> $GITHUB_PATH
       - uses: ./test-infra/.github/actions/set-channel
+      - name: Set PYTORCH_VERSION
+        if: ${{ env.CHANNEL == 'test' }}
+        run: |
+          # When building RC, set the version to be the current candidate version,
+          # otherwise, leave it alone so nightly will pick up the latest
+          echo "PYTORCH_VERSION=${{ matrix.stable_version }}" >> "${GITHUB_ENV}"
       - uses: ./test-infra/.github/actions/setup-binary-builds
         with:
           repository: ${{ inputs.repository }}

--- a/.github/workflows/generate_binary_build_matrix.yml
+++ b/.github/workflows/generate_binary_build_matrix.yml
@@ -13,7 +13,7 @@ on:
         type: string
       channel:
         description: "Channel to use (nightly, test, release, all)"
-        default: "nightly"
+        default: ""
         type: string
       test-infra-repository:
         description: "Test infra repository to use"
@@ -60,7 +60,7 @@ jobs:
         env:
           PACKAGE_TYPE: ${{ inputs.package-type }}
           OS: ${{ inputs.os }}
-          CHANNEL: ${{ inputs.channel }}
+          CHANNEL: ${{ inputs.channel != '' && inputs.channel || env.CHANNEL }}
           WITH_CUDA: ${{ inputs.with-cuda }}
           WITH_ROCM: ${{ inputs.with-rocm }}
           WITH_CPU: ${{ inputs.with-cpu }}

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -58,7 +58,7 @@ CUDA = "cuda"
 ROCM = "rocm"
 
 
-CURRENT_CANDIDATE_VERSION = "2.1.2"
+CURRENT_CANDIDATE_VERSION = "2.2.0"
 CURRENT_STABLE_VERSION = "2.1.1"
 mod.CURRENT_VERSION = CURRENT_STABLE_VERSION
 
@@ -564,7 +564,7 @@ def generate_build_matrix(
 
     for channel in channels:
         for package in package_types:
-            initialize_globals(channel)
+            initialize_globals(ggchannel)
             includes.extend(
                 GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[package](
                     operating_system,

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -564,7 +564,7 @@ def generate_build_matrix(
 
     for channel in channels:
         for package in package_types:
-            initialize_globals(ggchannel)
+            initialize_globals(channel)
             includes.extend(
                 GENERATING_FUNCTIONS_BY_PACKAGE_TYPE[package](
                     operating_system,


### PR DESCRIPTION
With 2 candidate RC in the test channel (2.1.2 and 2.2.0), we need to have a way to specify which PYTORCH_VERSION to use.  The issue surfaces when we are trying to cut RC3 for 2.1.2 today while there is already RC1 for 2.2.0 in place.  In the current state, `PYTHON_VERSION=3.11 PACKAGE_TYPE=conda CU_VERSION=cpu ARCH_NAME=arm64 CHANNEL=test python -m pytorch_pkg_helpers` will set `PYTORCH_VERSION` to 2.2.0 whenever domains are built

For example, https://github.com/pytorch/vision/actions/runs/7190086502/job/19582646141#step:6:743 build M1 conda for vision 0.16.2 and it's expected to use 2.1.2 there, not 2.2.0.

The fix here is to:

1. Correctly set the channel to `test` when building RC
2. If the channel is test, use the current candidate version as PYTORCH_VERSION.  The value is exposed via the build matrix as `stable_version`
3. When doing branch cut for test-infra, the `CURRENT_CANDIDATE_VERSION` variable could be set accordingly, for example, use 2.1.2 for `release/2.1` and 2.2.0 for `release/2.2`

### Testing plan

This PR https://github.com/pytorch/test-infra/pull/4803 tests `nightly` while the cherry pick https://github.com/pytorch/test-infra/pull/4804 covers `test` channel