### PR TITLE
Add constraint for version to conda build when in test channel

### DIFF
--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -181,6 +181,11 @@ jobs:
             CONSTRAINTS="cpuonly"
           fi
 
+          CONSTRAINT_BUILD=""
+          if [[ "${CHANNEL}" = "test" ]]; then
+            CONSTRAINT_BUILD="=${BUILD_VERSION}"
+          fi
+
           ${CONDA_RUN_SMOKE} conda install \
             --yes \
             --quiet \
@@ -188,7 +193,7 @@ jobs:
             -c pytorch-"${CHANNEL}" \
             -c nvidia \
             -c defaults \
-            "${PACKAGE_NAME}" \
+            "${PACKAGE_NAME}${CONSTRAINT_BUILD}" \
             ${CONSTRAINTS} \
             --override-channels
 

--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -189,13 +189,18 @@ jobs:
           export PATH="${CONDA_ENV_SMOKE}/bin:${PATH}"
           CONDA_LOCAL_CHANNEL="file://$(readlink -f ${{ inputs.repository }}/distr)"
 
+          CONSTRAINT_BUILD=""
+          if [[ "${CHANNEL}" = "test" ]]; then
+            CONSTRAINT_BUILD="=${BUILD_VERSION}"
+          fi
+
           ${CONDA_RUN_SMOKE} conda install \
             --quiet \
             --yes \
             -c "${CONDA_LOCAL_CHANNEL}" \
             -c pytorch-${CHANNEL} \
             -c defaults \
-            "${PACKAGE_NAME}" \
+            "${PACKAGE_NAME}${CONSTRAINT_BUILD}" \
             "--override-channels"
 
           # check for installed package channel

--- a/.github/workflows/build_conda_windows.yml
+++ b/.github/workflows/build_conda_windows.yml
@@ -206,6 +206,11 @@ jobs:
             CONSTRAINTS="cpuonly"
           fi
 
+          CONSTRAINT_BUILD=""
+          if [[ "${CHANNEL}" = "test" ]]; then
+            CONSTRAINT_BUILD="=${BUILD_VERSION}"
+          fi
+
           ${CONDA_RUN_SMOKE} conda install \
             --quiet \
             --yes \
@@ -213,7 +218,7 @@ jobs:
             -c pytorch-"${CHANNEL}" \
             -c nvidia \
             -c defaults \
-            "${PACKAGE_NAME}" \
+            "${PACKAGE_NAME}${CONSTRAINT_BUILD}" \
             ${CONSTRAINTS} \
             --override-channels
 


### PR DESCRIPTION
Cherry Pick of: https://github.com/pytorch/test-infra/pull/4805
Fixes conda prioritizing latest version rather then required version