### PR TITLE
fixing backfillJobs.mjs script, skipping entries that are too old to be retrieved in GH API

### DIFF
--- a/torchci/scripts/backfillJobs.mjs
+++ b/torchci/scripts/backfillJobs.mjs
@@ -81,7 +81,7 @@ async function backfillWorkflowJob(
     await dClient.put(thing);
   } catch (error) {
     console.log(`Failed to find job id ${id}: ${error}`);
-    console.log(`Assuming job id ${id} cancelled right after start`);
+    console.log(`Marking job id ${id} as incomplete`);
     console.log(`Querying dynamo entry for job id ${id}`);
     const dynamoEntry = await client.queries.query({
       sql: {

--- a/torchci/scripts/backfillJobs.mjs
+++ b/torchci/scripts/backfillJobs.mjs
@@ -202,7 +202,14 @@ LIMIT 10000
 });
 
 // See above for why we're awaiting in a loop.
-for (const { id, repo_name, owner, dynamo_key, created_at, started_at } of queuedJobs.results) {
+for (const {
+  id,
+  repo_name,
+  owner,
+  dynamo_key,
+  created_at,
+  started_at,
+} of queuedJobs.results) {
   await backfillWorkflowJob(
     id,
     repo_name,


### PR DESCRIPTION
If this scripts fails for a while, GH API does not have the information about old jobs anymore, 

as it is not possible to gather this information, the best that can be accomplish at this stage is simply assume some status of a job in order to avoid inconsistent database status and consequent bad data captured from it.

so for now the best is to assume the job is cancelled.