### PR TITLE
Add ciflow/trunk to reviewed prs

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -129,6 +129,8 @@ const repoSpecificAutoLabels: { [repo: string]: [RegExp, string][] } = {
   "pytorch/fake-test-repo": [[/somefolder/gi, "cool-label"]],
 };
 
+const CIFLOW_TRUNK_LABEL = "ciflow/trunk";
+
 function getRepoSpecificLabels(
   owner: string,
   repo: string
@@ -374,17 +376,28 @@ function myBot(app: Probot): void {
   });
 
   app.on("pull_request_review.submitted", async (context) => {
-    // Apply `ciflow/trunk` to PRs in PyTorch/PyTorch that has been reviewed
+    // Apply `ciflow/trunk` to PRs in PyTorch/PyTorch that has been reviewed a
+    const owner = context.payload.repository.owner.login;
+    const repo = context.payload.repository.name;
+
     if (context.payload.review.state !== "approved") {
       return;
     }
-    const owner = context.payload.repository.owner.login;
-    const repo = context.payload.repository.name;
+
     if (!isPyTorchPyTorch(owner, repo)) {
       return;
     }
-    // TEMP disable for 24 hours to see if it affects number of reverts / queueing
-    // await addLabels(context, [CIFLOW_TRUNK_LABEL]);
+
+    // only applies label to codev diffs.
+    if (
+      !JSON.stringify(context.payload.pull_request.body).includes(
+        "Differential Revision: D"
+      )
+    ) {
+      return;
+    }
+
+    await addLabels(context, [CIFLOW_TRUNK_LABEL]);
   });
 }
 

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -291,10 +291,13 @@ The explanation needs to be clear on why this is needed. Here are some good exam
           (e: any) => e["name"]
         );
       }
-
+      const pr_body =
+        JSON.stringify(this.ctx.payload?.pull_request?.body) || "";
       if (
         labels !== undefined &&
-        !labels.find((x) => x === CIFLOW_TRUNK_LABEL)
+        !labels.find((x) => x === CIFLOW_TRUNK_LABEL) &&
+        // skip applying label to codev diffs
+        !pr_body.includes("Differential Revision: D")
       ) {
         await addLabels(this.ctx, [CIFLOW_TRUNK_LABEL]);
       }


### PR DESCRIPTION
Add ciflow/trunk to reviewed prs


Adds ciflow/trunk to reviewed prs in pytorch/pytorch. Specifically if they are codev / approved.

Specifically deals with the first bit of pytorch/pytorch#115594

Furthermore, we might expand this to non codev prs assuming we don't see a workflow spike.
See: https://github.com/pytorch/test-infra/issues/4811
