### PR TITLE
Allow specifing PyTorch version when validating domain libraries

### DIFF
--- a/.github/scripts/install_torch.sh
+++ b/.github/scripts/install_torch.sh
@@ -5,6 +5,12 @@ export MATRIX_INSTALLATION="${MATRIX_INSTALLATION/torchaudio}"
 if [[ ${MATRIX_PACKAGE_TYPE} = "conda" ]]; then
     export MATRIX_INSTALLATION=${MATRIX_INSTALLATION/"conda install"/"conda install --yes --quiet"}
 fi
+# if RELESE version is passed as parameter - install speific version
+if [[ ! -z ${RELEASE_VERSION} ]]; then
+    MATRIX_INSTALLATION=${MATRIX_INSTALLATION/"torch "/"torch==${RELEASE_VERSION} "}
+    MATRIX_INSTALLATION=${MATRIX_INSTALLATION/"-y pytorch "/"-y pytorch==${RELEASE_VERSION} "}
+    MATRIX_INSTALLATION=${MATRIX_INSTALLATION/"::pytorch "/"::pytorch==${RELEASE_VERSION} "}
+fi
 eval $MATRIX_INSTALLATION
 
 export PYTORCH_PIP_PREFIX=""

--- a/.github/workflows/validate-domain-library.yml
+++ b/.github/workflows/validate-domain-library.yml
@@ -44,6 +44,11 @@ on:
         required: false
         type: boolean
         default: false
+      version:
+        description: "Version to validate - optional"
+        default: ""
+        required: false
+        type: string
 
 jobs:
   generate-linux-matrix:
@@ -96,6 +101,7 @@ jobs:
         set -ex
         export ENV_NAME="conda-env-${{ github.run_id }}"
         export SMOKE_TEST="${{ inputs.smoke_test }}"
+        export RELEASE_VERSION=${{ inputs.version }}
         if [[ ${{inputs.install_torch}} == 'true' ]]; then
           source /test-infra/.github/scripts/install_torch.sh
         fi
@@ -119,6 +125,7 @@ jobs:
         export ENV_NAME="conda-env-${{ github.run_id }}"
         export SMOKE_TEST="${{ inputs.smoke_test }}"
         export TARGET_OS="windows"
+        export RELEASE_VERSION=${{ inputs.version }}
         if [[ ${{inputs.install_torch}} == 'true' ]]; then
           source "${GITHUB_WORKSPACE}/test-infra/.github/scripts/install_torch.sh"
         fi
@@ -142,6 +149,7 @@ jobs:
         export ENV_NAME="conda-env-${{ github.run_id }}"
         export TARGET_OS="macos"
         export SMOKE_TEST="${{ inputs.smoke_test }}"
+        export RELEASE_VERSION=${{ inputs.version }}
         if [[ ${{inputs.install_torch}} == 'true' ]]; then
           source "${GITHUB_WORKSPACE}/test-infra/.github/scripts/install_torch.sh"
         fi
@@ -165,6 +173,7 @@ jobs:
         export ENV_NAME="conda-env-${{ github.run_id }}"
         export TARGET_OS="macos-arm64"
         export SMOKE_TEST="${{ inputs.smoke_test }}"
+        export RELEASE_VERSION=${{ inputs.version }}
         if [[ ${{inputs.install_torch}} == 'true' ]]; then
           source "${GITHUB_WORKSPACE}/test-infra/.github/scripts/install_torch.sh"
         fi


### PR DESCRIPTION
This will allow any domain libraries like text to be able to specify the PyTorch version that they want to validate in their validation workflows.  This is the same as what we have on validation workflow on builder.