### PR TITLE
Give slow tests update workflow write perms to repo contents

### DIFF
--- a/.github/workflows/update-slow-tests.yml
+++ b/.github/workflows/update-slow-tests.yml
@@ -6,8 +6,6 @@ on:
     - cron: "5 21 * * *"
   # Have the ability to trigger this job manually
   workflow_dispatch:
-  pull_request:
-
 
 permissions:
   id-token: write

--- a/.github/workflows/update-slow-tests.yml
+++ b/.github/workflows/update-slow-tests.yml
@@ -6,6 +6,8 @@ on:
     - cron: "5 21 * * *"
   # Have the ability to trigger this job manually
   workflow_dispatch:
+  pull_request:
+
 
 permissions:
   id-token: write

--- a/.github/workflows/update-slow-tests.yml
+++ b/.github/workflows/update-slow-tests.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 defaults:
   run:


### PR DESCRIPTION
Fix after https://github.com/pytorch/test-infra/pull/4802

Example: 
https://github.com/pytorch/test-infra/actions/runs/7225953817/job/19690485654
```
+ git push -u origin HEAD:generated-stats
remote: Permission to pytorch/test-infra.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/pytorch/test-infra.git/': The requested URL returned error: 403
```