### PR TITLE
Add workflow call to pr dependencies check

### DIFF
--- a/.github/workflows/pr-dependencies-check.yml
+++ b/.github/workflows/pr-dependencies-check.yml
@@ -1,6 +1,16 @@
 name: PR Dependency Check
 
 on:
+  workflow_call:
+    inputs:
+      pr_number:
+        description: 'PR number or URL'
+        type: string
+        required: true
+      search_depth:
+        description: 'Dependencies search depth'
+        default: '100'
+        type: string
   workflow_dispatch:
     inputs:
       pr_number:
@@ -9,7 +19,6 @@ on:
         required: true
       search_depth:
         description: 'Dependencies search depth'
-        required: true
         default: '100'
         type: choice
         options: ['100', '200', '500']


### PR DESCRIPTION
Add workflow call to pr dependencies check

Works to solve https://github.com/pytorch/test-infra/issues/4816

In conjunction with https://github.com/pytorch/pytorch/pull/115944 this pr should make it such that all ghstack prs kick off a job which is a mergability check.
