### PR TITLE
let pr-dependencies-check throw an error if a pr is not mergable

### DIFF
--- a/.github/workflows/pr-dependencies-check.yml
+++ b/.github/workflows/pr-dependencies-check.yml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Check PR dependencies
         shell: bash
+        id: pr_merge_check
         run: |
           PR_NUMBER="${{ steps.extract_pr_number.outputs.pr_number }}"
           SEARCH_DEPTH="${{ inputs.search_depth }}"
@@ -163,7 +164,7 @@ jobs:
               echo ""
             } >> "$GITHUB_STEP_SUMMARY"
           }
-
+          PR_IS_MERGEABLE=1
           # try merging pr-branch into main
           if ! git merge --no-commit --no-ff pr-branch; then
             # red
@@ -171,12 +172,13 @@ jobs:
 
             git merge --abort
             find_conflicting_commits
+            PR_IS_MERGEABLE=0
             echo "----"
           else
             # same as a github warning
             echo "::notice::PR is mergeable into main."
           fi
-
+          echo "pr_is_mergeable=${PR_IS_MERGEABLE}" >> "$GITHUB_OUTPUT"
           # reset main to MERGE_BASE
           git reset --hard "$MERGE_BASE"
 
@@ -234,3 +236,10 @@ jobs:
 
           echo "Check the job Summary for the results:"
           echo "https://github.com/pytorch/test-infra/actions/runs/${{ github.run_id }}"
+
+      - name: Fail if PR is Not Mergeable
+        if: ${{ steps.pr_merge_check.outputs.pr_is_mergeable == '0' }}
+        run: |
+          echo "The value --- ${{ steps.pr_merge_check.outputs.pr_is_mergeable }} --- == 0 but should be 1."
+          echo "Failing the job as PR_IS_MERGEABLE is not 0."
+          exit 1


### PR DESCRIPTION
If a pr is not mergable pr-dependencies check will throw an error. This is useful for making the mergeability check blocking.

Testing:
Example of mergable pr: https://github.com/pytorch/test-infra/actions/runs/7227998564
Example of unmergable pr: https://github.com/pytorch/test-infra/actions/runs/7227966131 (note: I removed the debugging text from the FAIL if PR is Not Mergeable step)