### PR TITLE
Support fuzzy string matching to compare failure context

### DIFF
--- a/torchci/package.json
+++ b/torchci/package.json
@@ -36,6 +36,7 @@
     "dayjs-plugin-utc": "^0.1.2",
     "echarts": "^5.3.2",
     "echarts-for-react": "^3.0.2",
+    "jaro-winkler-typescript": "^1.0.1",
     "lodash": "^4.17.21",
     "minimist": "^1.2.6",
     "next": "12.1.5",

--- a/torchci/test/jobUtils.test.ts
+++ b/torchci/test/jobUtils.test.ts
@@ -289,6 +289,12 @@ describe("Test various job utils", () => {
     // Same error with same context
     expect(isSameContext(jobA, jobB)).toEqual(true);
     expect(isSameFailure(jobA, jobB)).toEqual(true);
+
+    jobA.failure_context = ["FOO --shard 1 2"];
+    jobB.failure_context = ["FOO --shard 2 2"];
+    // Same error with similar context
+    expect(isSameContext(jobA, jobB)).toEqual(true);
+    expect(isSameFailure(jobA, jobB)).toEqual(true);
   });
 
   test("test isFailureFromPrevMergeCommit", () => {

--- a/torchci/yarn.lock
+++ b/torchci/yarn.lock
@@ -5574,6 +5574,11 @@ istanbul-reports@^3.1.3:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+jaro-winkler-typescript@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jaro-winkler-typescript/-/jaro-winkler-typescript-1.0.1.tgz#d976d269eef10675c58ce28d304d40f642ef93ed"
+  integrity sha512-MsXieUkvK2Lv5CCVu42ddaE2tALmerhEY46DQb1ry0AEl/Au6HFi7zFemIKlbc3md93NDijfOj0AFuSfUJST3g==
+
 jclass@^1.0.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/jclass/-/jclass-1.2.1.tgz#eaafeec0dd6a5bf8b3ea43c04e010c637638768b"


### PR DESCRIPTION
Use Jaro-Winkler string matching to compare failure context.  This is a safe way to use fuzzy string matching IMO because comparing context is an additional comparison step added by https://github.com/pytorch/test-infra/pull/4776 when we already have exact matching failures.

This helps fix the wrong classifications when same tests are failing flakily on different shards, for examples:

* https://github.com/pytorch/pytorch/pull/115844
* https://github.com/pytorch/pytorch/pull/114895

The similarity threshold is set high at 0.95, but can be tweaked later.

### Testing

Try it out locally with the above examples

```
curl --request POST \
--url "http://localhost:3000/api/drci/drci?prNumber=115844" \
--header "Authorization: TOKEN" \
--data 'repo=pytorch'
```

classifies flaky failures correctly:

```
{"115844":{"FAILED":[],"FLAKY":[{"workflowId":7214436961,"id":19657422814,"runnerName":"pytorch-rocm-hw-01","authorEmail":"nshulga@meta.com","name":"rocm / linux-focal-rocm5.7-py3.8 / test (default, 2, 6, linux.rocm.gpu)","jobName":"linux-focal-rocm5.7-py3.8 / test (default, 2, 6, linux.rocm.gpu)","conclusion":"failure","completed_at":"2023-12-14T21:36:54Z","html_url":"https://github.com/pytorch/pytorch/actions/runs/7214436961/job/19657422814","head_branch":"ciflow/rocm/115844","pr_number":115844,"head_sha":"c1c989cfed5067c4ec220fbd5655560d04eb15a5","failure_captures":["dynamo/test_dynamic_shapes.py::DynamicShapesCtxManagerTests::test_autocast_sdpa_dynamic_shapes"],"failure_lines":["FAILED [1.7489s] dynamo/test_dynamic_shapes.py::DynamicShapesCtxManagerTests::test_autocast_sdpa_dynamic_shapes - torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:"],"failure_context":["+ python test/run_test.py --exclude-jit-executor --exclude-distributed-tests --shard 2 6 --verbose","+ [[ -z 6 ]]","+ test_python_shard 2","+ '[' -n '' ']'","+ pip install --progress-bar off --no-use-pep517 --user git+https://github.com/pytorch/vision.git@e12d200c97d7aab668b976e92b46513c9ca7a0d8","+ pip_install --no-use-pep517 --user git+https://github.com/pytorch/vision.git@e12d200c97d7aab668b976e92b46513c9ca7a0d8","+ '[' -n '' ']'","+ orig_preload=","+ commit=e12d200c97d7aab668b976e92b46513c9ca7a0d8","++ cat .github/ci_commit_pins/vision.txt","++ get_pinned_commit vision","+ local commit"],"time":"2023-12-14T21:43:23.113518Z"}],"BROKEN_TRUNK":[],"UNSTABLE":[]}}
```

<!-- drci-comment-start -->

## :link: Helpful Links
### :test_tube: See artifacts and rendered test results at [hud.pytorch.org/pr/115844](https://hud.pytorch.org/pr/115844)
* :page_facing_up: Preview [Python docs built from this PR](https://docs-preview.pytorch.org/pytorch/pytorch/115844/index.html)
* :page_facing_up: Preview [C++ docs built from this PR](https://docs-preview.pytorch.org/pytorch/pytorch/115844/cppdocs/index.html)
* :question: Need help or want to give feedback on the CI? Visit the [bot commands wiki](https://github.com/pytorch/pytorch/wiki/Bot-commands) or our [office hours](https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours)

Note: Links to docs will display an error until the docs builds have been completed.


## :white_check_mark: You can merge normally! (1 Unrelated Failure)
As of commit c1c989cfed5067c4ec220fbd5655560d04eb15a5 with merge base 7ecddaef23fe536e8e2d12b9b7f77ce7090b3916 (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1702585990?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details ><summary><b>FLAKY</b> - The following job failed but was likely due to flakiness present on trunk:</summary><p>

* [rocm / linux-focal-rocm5.7-py3.8 / test (default, 2, 6, linux.rocm.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/115844#19657422814) ([gh](https://github.com/pytorch/pytorch/actions/runs/7214436961/job/19657422814))
    `dynamo/test_dynamic_shapes.py::DynamicShapesCtxManagerTests::test_autocast_sdpa_dynamic_shapes`
</p></details>


This comment was automatically generated by Dr. CI and updates every 15 minutes.
<!-- drci-comment-end -->