### PR TITLE
[CI] Automate clang-format building

### DIFF
--- a/.github/workflows/clang-tidy-linux.yml
+++ b/.github/workflows/clang-tidy-linux.yml
@@ -37,7 +37,7 @@ jobs:
           docker cp "$image_id":/clang-tidy-checks/build/bin/clang-tidy ./clang-tidy
           docker rm -v "$image_id"
       - uses: driazati/upload-artifact-s3@50adbe4ef0b6d9221df25c18c5fc528dfcb7c3f8
-        name: Publish binary
+        name: Publish clang-tidy binary
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
           name: clang-tidy
@@ -45,6 +45,17 @@ jobs:
           s3-prefix: linux64/17.0.6
           s3-bucket: oss-clang-format
           path: clang-tidy
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - uses: driazati/upload-artifact-s3@50adbe4ef0b6d9221df25c18c5fc528dfcb7c3f8
+        name: Publish clang-format binary
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        with:
+          name: clang-format
+          if-no-files-found: error
+          s3-prefix: linux64/17.0.6
+          s3-bucket: oss-clang-format
+          path: clang-format
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 

--- a/.github/workflows/clang-tidy-macos.yml
+++ b/.github/workflows/clang-tidy-macos.yml
@@ -39,7 +39,7 @@ jobs:
 
           ./setup.sh
       - uses: driazati/upload-artifact-s3@50adbe4ef0b6d9221df25c18c5fc528dfcb7c3f8
-        name: Publish binary
+        name: Publish clang-tidy binary
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
           name: clang-tidy
@@ -47,6 +47,17 @@ jobs:
           s3-prefix: macos-i386/17.0.6
           s3-bucket: oss-clang-format
           path: tools/clang-tidy-checks/llvm-project/build/bin/clang-tidy
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - uses: driazati/upload-artifact-s3@50adbe4ef0b6d9221df25c18c5fc528dfcb7c3f8
+        name: Publish clang-format binary
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        with:
+          name: clang-format
+          if-no-files-found: error
+          s3-prefix: macos-i386/17.0.6
+          s3-bucket: oss-clang-format
+          path: tools/clang-tidy-checks/llvm-project/build/bin/clang-format
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   build-M1:
@@ -68,7 +79,7 @@ jobs:
 
           ./setup.sh
       - uses: driazati/upload-artifact-s3@50adbe4ef0b6d9221df25c18c5fc528dfcb7c3f8
-        name: Publish binary
+        name: Publish clang-tidy binary
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
           name: clang-tidy
@@ -76,6 +87,17 @@ jobs:
           s3-prefix: macos-arm/17.0.6
           s3-bucket: oss-clang-format
           path: tools/clang-tidy-checks/llvm-project/build/bin/clang-tidy
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - uses: driazati/upload-artifact-s3@50adbe4ef0b6d9221df25c18c5fc528dfcb7c3f8
+        name: Publish clang-format binary
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        with:
+          name: clang-format
+          if-no-files-found: error
+          s3-prefix: macos-arm/17.0.6
+          s3-bucket: oss-clang-format
+          path: tools/clang-tidy-checks/llvm-project/build/bin/clang-format
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 

--- a/tools/clang-tidy-checks/setup.sh
+++ b/tools/clang-tidy-checks/setup.sh
@@ -103,6 +103,7 @@ function build() {
 
   cmake "${cmake_common_args[@]}" "${cmake_os_args[@]}" ../llvm
   cmake --build . --target clang-tidy
+  cmake --build . --target clang-format
   success
 }
 
@@ -116,6 +117,7 @@ function check_if_static() {
   case $(uname) in
     Linux)
       ldd ./bin/clang-tidy 2>&1 | grep -q -e "not a dynamic executable" -e "statically linked"
+      ldd ./bin/clang-format 2>&1 | grep -q -e "not a dynamic executable" -e "statically linked"
       ;;
     Darwin)
       # No static link check for MacOS


### PR DESCRIPTION
As clang-tidy is build automatically, same should be true of clang-format