### PR TITLE
Clean up redundant AWS credential used to access public S3 buckets

### DIFF
--- a/torchci/lib/fetchS3Links.ts
+++ b/torchci/lib/fetchS3Links.ts
@@ -1,6 +1,7 @@
 import { Artifact } from "./types";
 import { ListObjectsV2Command, S3Client } from "@aws-sdk/client-s3";
-import s3client from "./s3";
+import getS3Client from "./s3";
+
 export default async function fetchS3Links(
   suiteId: string
 ): Promise<Artifact[]> {
@@ -8,6 +9,7 @@ export default async function fetchS3Links(
     Bucket: "gha-artifacts",
     Prefix: `pytorch/pytorch/${suiteId}`,
   });
+  const s3client = await getS3Client();
   const response = await s3client.send(command);
 
   const artifacts =

--- a/torchci/lib/s3.ts
+++ b/torchci/lib/s3.ts
@@ -1,11 +1,8 @@
 import { S3Client } from "@aws-sdk/client-s3";
 
-const s3client = new S3Client({
-  region: "us-east-1",
-  credentials: {
-    accessKeyId: process.env.OUR_AWS_ACCESS_KEY_ID!,
-    secretAccessKey: process.env.OUR_AWS_SECRET_ACCESS_KEY!,
-  },
-});
-
-export default s3client;
+export default async function getS3Client(): Promise<S3Client> {
+  const s3client = new S3Client({
+    region: "us-east-1",
+  });
+  return s3client;
+}


### PR DESCRIPTION
This is the first step to clean up the AWS credentials used by Vercel (https://github.com/pytorch/test-infra/issues/4789).  The artifact bucket is public, so the credentials are not needed here.