### PR TITLE
Add python 3.12 to test environment

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -24,7 +24,7 @@ PYTHON_ARCHES_DICT = {
     # TODO (huydhn): 3.12 is only enabled in nightly for now, test and release
     # will come later
     "nightly": ["3.8", "3.9", "3.10", "3.11", "3.12"],
-    "test": ["3.8", "3.9", "3.10", "3.11"],
+    "test": ["3.8", "3.9", "3.10", "3.11", "3.12"],
     "release": ["3.8", "3.9", "3.10", "3.11"],
 }
 CUDA_ARCHES_DICT = {


### PR DESCRIPTION
Follow up of: https://github.com/pytorch/test-infra/pull/4834
Make sure we have python 3.12 in test env