### PR TITLE
Fix obsolete recent example links

### DIFF
--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -115,11 +115,7 @@ function getTestName(failureCapture: string) {
 }
 
 function formatDisableTestBody(job: JobData) {
-  const examplesURL = `http://torch-ci.com/failure?name=${encodeURIComponent(
-    job.name as string
-  )}&jobName=${encodeURIComponent(
-    job.jobName as string
-  )}&failureCaptures=${encodeURIComponent(
+  const examplesURL = `https://torch-ci.com/failure?failureCaptures=${encodeURIComponent(
     JSON.stringify(job.failureCaptures)
   )}`;
   return encodeURIComponent(`Platforms: <fill this in or delete. Valid labels are: asan, linux, mac, macos, rocm, win, windows.>

--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -114,9 +114,13 @@ function getTestName(failureCapture: string) {
   return null;
 }
 
-function formatDisableTestBody(failureCaptures: string[]) {
-  const examplesURL = `http://torch-ci.com/failure/${encodeURIComponent(
-    failureCaptures.join(",")
+function formatDisableTestBody(job: JobData) {
+  const examplesURL = `http://torch-ci.com/failure?name=${encodeURIComponent(
+    job.name as string
+  )}&jobName=${encodeURIComponent(
+    job.jobName as string
+  )}&failureCaptures=${encodeURIComponent(
+    JSON.stringify(job.failureCaptures)
   )}`;
   return encodeURIComponent(`Platforms: <fill this in or delete. Valid labels are: asan, linux, mac, macos, rocm, win, windows.>
 
@@ -157,7 +161,7 @@ function DisableTest({ job, label }: { job: JobData; label: string }) {
   // At this point, we should show something. Search the existing disable issues
   // for a matching one.
   const issueTitle = `DISABLED ${testName}`;
-  const issueBody = formatDisableTestBody(job.failureCaptures!);
+  const issueBody = formatDisableTestBody(job);
 
   const issues: IssueData[] = data.issues;
   const matchingIssues = issues.filter((issue) => issue.title === issueTitle);


### PR DESCRIPTION
After https://github.com/pytorch/test-infra/pull/4668, the failure API endpoint has changed, and the example URL needs to be updated accordingly.

I think I will need to update the links from existing DISABLED issues, but that can be done independently.  Basically, the link changes from `/failure/export%2Ftest_serialize.py%3A%3ATestSerialize%3A%3Atest_canonicalize` to include parameters such as job name and failures `/failure?failureCaptures=%5B"export%2Ftest_serialize.py%3A%3ATestSerialize%3A%3Atest_canonicalize"%5D`