### PR TITLE
Binary build matrix. Add macos arm64 libtorch builds. Fix macos x86 filename

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -241,7 +241,7 @@ def get_libtorch_install_command(
         arch = "x86_64" if os == MACOS else "arm64"
         build_name = f"libtorch-macos-{arch}-latest.zip"
         if channel in [RELEASE, TEST]:
-            build_name = f"libtorch-macos-{mod.CURRENT_VERSION}.zip"
+            build_name = f"libtorch-macos-{arch}-{mod.CURRENT_VERSION}.zip"
 
     elif os == LINUX and (channel == RELEASE or channel == TEST):
         build_name = (

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -21,8 +21,8 @@ from typing import Dict, List, Optional, Tuple
 mod = sys.modules[__name__]
 
 PYTHON_ARCHES_DICT = {
-    # TODO (huydhn): 3.12 is only enabled in nightly for now, test and release
-    # will come later
+    # TODO (huydhn): 3.12 is only enabled in nightly and test.
+    # Release should be enabled after release is complete.
     "nightly": ["3.8", "3.9", "3.10", "3.11", "3.12"],
     "test": ["3.8", "3.9", "3.10", "3.11", "3.12"],
     "release": ["3.8", "3.9", "3.10", "3.11"],
@@ -360,8 +360,9 @@ def generate_libtorch_matrix(
 ) -> List[Dict[str, str]]:
     ret: List[Dict[str, str]] = []
 
-    # macos-arm64 does not have any libtorch builds
-    if os == MACOS_ARM64 and channel != "release":
+    # TODO: macos-arm64 have libtorch only in test and nightly now
+    # release will be enabled after release 2.2.0 is complete
+    if os == MACOS_ARM64 and channel == "release":
         return ret
 
     if arches is None:

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -361,7 +361,7 @@ def generate_libtorch_matrix(
     ret: List[Dict[str, str]] = []
 
     # macos-arm64 does not have any libtorch builds
-    if os == MACOS_ARM64 and channel != "nightly":
+    if os == MACOS_ARM64 and channel != "release":
         return ret
 
     if arches is None:


### PR DESCRIPTION
Test ARM64:
```
python generate_binary_build_matrix.py  --channel test --package-type libtorch --operating-system macos-arm64
{"include": [{"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-shared-with-deps-cxx11-abi", "validation_runner": "macos-m1-12", "installation": "https://download.pytorch.org/libtorch/test/cpu/libtorch-macos-arm64-2.2.0.zip", "channel": "test", "stable_version": "2.2.0"}]}
```

Test x86:
```
python generate_binary_build_matrix.py  --channel test --package-type libtorch --operating-system macos
{"include": [{"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-shared-with-deps-cxx11-abi", "validation_runner": "macos-12", "installation": "https://download.pytorch.org/libtorch/test/cpu/libtorch-macos-x86_64-2.2.0.zip", "channel": "test", "stable_version": "2.2.0"}]}
```
