### PR TITLE
Exclude pr-dependencies-check check from Dr.CI flaky classification

### DIFF
--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -41,7 +41,11 @@ export const BOT_COMMANDS_WIKI_URL =
   "https://github.com/pytorch/pytorch/wiki/Bot-commands";
 export const FLAKY_RULES_JSON =
   "https://raw.githubusercontent.com/pytorch/test-infra/generated-stats/stats/flaky-rules.json";
-export const EXCLUDED_FROM_FLAKINESS = ["lint", "linux-docs"];
+export const EXCLUDED_FROM_FLAKINESS = [
+  "lint",
+  "linux-docs",
+  "pr-dependencies-check",
+];
 
 export function formDrciHeader(
   owner: string,


### PR DESCRIPTION
When it fails, the check exits with a generic GHA error `Process completed with exit code 1`, i.e. 
https://github.com/pytorch/pytorch/pull/116942.  Like lint, we don't need flaky classification for this new check.

### Testing

```
curl --request POST \
--url "http://localhost:3000/api/drci/drci?prNumber=116942" \
--header "Authorization: TOKEN" \
--data 'repo=pytorch'
```

And pr-dependencies-check shows up correctly as a new failure on https://github.com/pytorch/pytorch/pull/116942.