### PR TITLE
Use HTTP basic auth when querying OpenSearch

### DIFF
--- a/torchci/.env.example
+++ b/torchci/.env.example
@@ -25,3 +25,5 @@ NEXTAUTH_URL=http://localhost:3000
 # AWS OpenSearch cluster. Only needed if testing the search API
 OPENSEARCH_ENDPOINT=
 OPENSEARCH_REGION=
+OPENSEARCH_USERNAME=
+OPENSEARCH_PASSWORD=

--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -4,9 +4,8 @@ import { Octokit } from "octokit";
 import { IssueData } from "./types";
 import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
 import { isDrCIEnabled, isPyTorchPyTorch } from "./bot/utils";
-import { AwsSigv4Signer } from "@opensearch-project/opensearch/aws";
-import { Credentials } from "@aws-sdk/types";
 import { Client } from "@opensearch-project/opensearch";
+import { getOpenSearchClient } from "lib/opensearch";
 import {
   searchSimilarFailures,
   WORKFLOW_JOB_INDEX,
@@ -247,21 +246,7 @@ export async function querySimilarFailures(
   }
 
   if (client === undefined) {
-    // https://opensearch.org/docs/latest/clients/javascript/index
-    client = new Client({
-      ...AwsSigv4Signer({
-        region: process.env.OPENSEARCH_REGION as string,
-        service: "es",
-        getCredentials: () => {
-          const credentials: Credentials = {
-            accessKeyId: process.env.OUR_AWS_ACCESS_KEY_ID as string,
-            secretAccessKey: process.env.OUR_AWS_SECRET_ACCESS_KEY as string,
-          };
-          return Promise.resolve(credentials);
-        },
-      }),
-      node: process.env.OPENSEARCH_ENDPOINT,
-    });
+    client = getOpenSearchClient();
   }
 
   // Search for all captured failure

--- a/torchci/lib/opensearch.ts
+++ b/torchci/lib/opensearch.ts
@@ -1,0 +1,15 @@
+import { Client } from "@opensearch-project/opensearch";
+
+export function getOpenSearchClient(): Client {
+  // Just remove the https protocol
+  const endpoint = process.env.OPENSEARCH_ENDPOINT?.replace(/^https?:\/\//, "");
+  const username = encodeURIComponent(process.env.OPENSEARCH_USERNAME ?? "");
+  const password = encodeURIComponent(process.env.OPENSEARCH_PASSWORD ?? "");
+
+  // https://opensearch.org/docs/latest/clients/javascript/index. Follow the AWS
+  // guide to setup a basic authentcation for a read-only user
+  // https://docs.aws.amazon.com/opensearch-service/latest/developerguide/fgac-http-auth.html
+  return new Client({
+    node: `https://${username}:${password}@${endpoint}`,
+  });
+}

--- a/torchci/pages/api/search.ts
+++ b/torchci/pages/api/search.ts
@@ -1,7 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Client } from "@opensearch-project/opensearch";
-import { AwsSigv4Signer } from "@opensearch-project/opensearch/aws";
-import { defaultProvider } from "@aws-sdk/credential-provider-node";
+import { getOpenSearchClient } from "lib/opensearch";
 import { JobData } from "lib/types";
 import {
   searchSimilarFailures,
@@ -24,20 +23,7 @@ export default async function handler(
   const minScore = (req.query.minScore as unknown as number) ?? MIN_SCORE;
 
   // https://opensearch.org/docs/latest/clients/javascript/index
-  const client = new Client({
-    ...AwsSigv4Signer({
-      region: process.env.OPENSEARCH_REGION as string,
-      service: "es",
-      getCredentials: () => {
-        const credentials: Credentials = {
-          accessKeyId: process.env.OUR_AWS_ACCESS_KEY_ID as string,
-          secretAccessKey: process.env.OUR_AWS_SECRET_ACCESS_KEY as string,
-        };
-        return Promise.resolve(credentials);
-      },
-    }),
-    node: process.env.OPENSEARCH_ENDPOINT,
-  });
+  const client = getOpenSearchClient();
 
   res
     .status(200)


### PR DESCRIPTION
Following https://docs.aws.amazon.com/opensearch-service/latest/developerguide/fgac-http-auth.html, the other option to query OpenSearch here is to use HTTP basic auth.  Although the method is dated, it's ok because we only need read access query.

This change requires:

* [x] Setup the policy to allow HTTP basic auth https://github.com/pytorch-labs/pytorch-gha-infra/pull/316
* [x] Setup the `pytorch-hud` user via OpenSearch dashboard.

###

Testing, once https://github.com/pytorch-labs/pytorch-gha-infra/pull/316 is merged, search for similar failure on HUD should just work, i.e. https://torchci-git-fork-huydhn-remove-opensearch-a-4880e9-fbopensource.vercel.app/failure?name=Lint+%2F+lintrunner+%2F+linux-job&jobName=undefined&failureCaptures=%5B%22%3E%3E%3E+Lint+for+test%2Fquantization%2Fpt2e%2Ftest_xnnpack_quantizer.py%3A%22%5D.  Atm, I modify the policy manually to test this change.