### PR TITLE
Resurrect the option to force push the Docker image

### DIFF
--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -162,11 +162,7 @@ runs:
 
         if [ "${DOCKER_PUSH:-false}" == "true" ]; then
           # Only push if docker image doesn't exist already
-          if ! docker manifest inspect "${DOCKER_IMAGE}" >/dev/null 2>/dev/null; then
+          if [! docker manifest inspect "${DOCKER_IMAGE}" >/dev/null 2>/dev/null] || [ "${DOCKER_FORCE_PUSH:-false}" == "true" ]; then
             docker push "${DOCKER_IMAGE}"
           fi
-        fi
-
-        if [ "${DOCKER_FORCE_PUSH:-false}" == "true" ]; then
-          docker push "${DOCKER_IMAGE}"
         fi

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -29,6 +29,7 @@ inputs:
   force-push:
     description: If set to true, always push the image to ECR even if it exists.
     required: false
+    default: false
 
 outputs:
   docker-image:

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -26,6 +26,9 @@ inputs:
   push:
     description: If set to true, push the image to ECR.
     required: false
+  force-push:
+    description: If set to true, always push the image to ECR even if it exists.
+    required: false
 
 outputs:
   docker-image:
@@ -129,6 +132,7 @@ runs:
       env:
         REPO_NAME: ${{ github.event.repository.name }}
         DOCKER_PUSH: ${{ inputs.push }}
+        DOCKER_FORCE_PUSH: ${{ inputs.force-push }}
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
@@ -161,4 +165,8 @@ runs:
           if ! docker manifest inspect "${DOCKER_IMAGE}" >/dev/null 2>/dev/null; then
             docker push "${DOCKER_IMAGE}"
           fi
+        fi
+
+        if [ "${DOCKER_FORCE_PUSH:-false}" == "true" ]; then
+          docker push "${DOCKER_IMAGE}"
         fi


### PR DESCRIPTION
IIRC, we used to have this option, but nothing was using it.  I have found an use case for this in https://github.com/pytorch/executorch/pull/1335#discussion_r1448247422 where ExecuTorch team copies the content of `examples/arm` into `.ci/docker` before starting the build https://github.com/pytorch/executorch/blob/main/.ci/docker/build.sh#L40-L46:

* The docker image was rebuilt, but its hash tag remained the same because the copy step above is not version tracked.
* The new image was not pushed.

I have tried to move `examples/arm` into `.ci/docker` and setup softlinks, but the result looks weird https://github.com/pytorch/executorch/pull/1574#discussion_r1447762323, so I'll probably drop that approach.

The remaining option here is to add a `force-push` flag that can be used to, well, force push the image even if its hash tag already exists.