### PR TITLE
torchci: Limit -i to users who have write permissions

### DIFF
--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -263,6 +263,16 @@ The explanation needs to be clear on why this is needed. Here are some good exam
         "`-ic` flag is deprecated, please use `-i` instead for the same effect.";
     }
 
+    if (
+      ignore_current &&
+      !(await this.hasWorkflowRunningPermissions(
+        this.ctx.payload?.comment?.user?.login
+      ))
+    ) {
+      rejection_reason =
+        "`-i` flag is only allowed for users who have the ability to run workflows.";
+    }
+
     if (rejection_reason) {
       await this.logger.log("merge-error", extra_data);
       await this.handleConfused(true, rejection_reason);

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -263,14 +263,15 @@ The explanation needs to be clear on why this is needed. Here are some good exam
         "`-ic` flag is deprecated, please use `-i` instead for the same effect.";
     }
 
-    if (
-      ignore_current &&
-      !(await this.hasWorkflowRunningPermissions(
-        this.ctx.payload?.comment?.user?.login
-      ))
-    ) {
-      rejection_reason =
-        "`-i` flag is only allowed for users who have the ability to run workflows.";
+    if (ignore_current) {
+      if (
+        !(await this.hasWorkflowRunningPermissions(
+          this.ctx.payload?.comment?.user?.login
+        ))
+      ) {
+        rejection_reason =
+          "`-i` flag is only allowed for users with write permissions";
+      }
     }
 
     if (rejection_reason) {


### PR DESCRIPTION
Limits the scope of the -i flag to specific users. Should ideally only affect a small amount of users.