### PR TITLE
Downgrade aws-actions/configure-aws-credentials to v3

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -238,13 +238,13 @@ jobs:
       # TODO (huydhn): Move the following step to a separate build job
       - name: Configure aws credentials (pytorch account)
         if: ${{ inputs.trigger-event == 'push' && startsWith(github.event.ref, 'refs/heads/nightly') }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_nightly_build_wheels
           aws-region: us-east-1
       - name: Configure aws credentials (pytorch account)
         if: ${{ env.CHANNEL == 'test' && startsWith(github.event.ref, 'refs/tags/') }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_test_build_wheels
           aws-region: us-east-1

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -212,13 +212,13 @@ jobs:
       # TODO (huydhn): Move the following step to a separate build job
       - name: Configure aws credentials (pytorch account)
         if: ${{ inputs.trigger-event == 'push' && startsWith(github.event.ref, 'refs/heads/nightly') }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_nightly_build_wheels
           aws-region: us-east-1
       - name: Configure aws credentials (pytorch account)
         if: ${{ env.CHANNEL == 'test' && startsWith(github.event.ref, 'refs/tags/') }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_test_build_wheels
           aws-region: us-east-1

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -202,13 +202,13 @@ jobs:
       # TODO (huydhn): Move the following step to a separate build job
       - name: Configure aws credentials (pytorch account)
         if: ${{ inputs.trigger-event == 'push' && startsWith(github.event.ref, 'refs/heads/nightly') }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_nightly_build_wheels
           aws-region: us-east-1
       - name: Configure aws credentials (pytorch account)
         if: ${{ env.CHANNEL == 'test' && startsWith(github.event.ref, 'refs/tags/') }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_test_build_wheels
           aws-region: us-east-1


### PR DESCRIPTION
Node20 used by v4 is too new for AmazonLinux2 and this causes the action to fail https://github.com/pytorch/vision/actions/runs/7495933674/job/20406996434. v3 should be fine as they are using Node16 https://github.com/aws-actions/configure-aws-credentials