### PR TITLE
Revert "Temporarily add a debug message for OIDC in Nova workflow (#4871)"

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -79,21 +79,6 @@ permissions:
   contents: read
 
 jobs:
-  oidc_debug_test:
-    runs-on: ubuntu-latest
-    name: A test of the oidc debugger
-    steps:
-      - name: Checkout actions-oidc-debugger
-        uses: actions/checkout@v3
-        with:
-          repository: github/actions-oidc-debugger
-          ref: main
-          path: ./.github/actions/actions-oidc-debugger
-      - name: Debug OIDC claims
-        uses: ./.github/actions/actions-oidc-debugger
-        with:
-          audience: 'https://github.com/github'
-
   build:
     strategy:
       fail-fast: false


### PR DESCRIPTION
This reverts commit 1fe7f4d28018acf9ebfe08925b34edf29e0d12d5.  Not needed anymore.