### PR TITLE
Migrate update-commit-hash GHA to test-infra

### DIFF
--- a/.github/actions/update-commit-hash/action.yml
+++ b/.github/actions/update-commit-hash/action.yml
@@ -44,6 +44,7 @@ runs:
     - name: Checkout the source repo with the pinned commit file
       uses: actions/checkout@v3
       with:
+        submodules: true
         token: ${{ inputs.updatebot-token }}
 
     - name: Checkout test-infra for the update_commit_hashes scripts

--- a/.github/actions/update-commit-hash/action.yml
+++ b/.github/actions/update-commit-hash/action.yml
@@ -20,12 +20,12 @@ inputs:
     required: false
     default: .ci/docker/ci_commit_pins
   test-infra-repository:
-    description: "Test infra repository to use"
+    description: Test infra repository to use
     default: 'pytorch/test-infra'
     type: string
   test-infra-ref:
-    description: "Test infra reference to use"
-    default: ""
+    description: Test infra reference to use
+    default: ''
     type: string
   updatebot-token:
     required: true
@@ -74,6 +74,8 @@ runs:
         PYTORCHBOT_TOKEN: ${{ inputs.pytorchbot-token }}
         NEW_BRANCH_NAME: update-${{ inputs.repo-name }}-commit-hash/${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
       run: |
+        set -ex
+
         # put this here instead of the script to prevent accidentally changing the config when running the script locally
         git config --global user.name "PyTorch UpdateBot"
         git config --global user.email "pytorchupdatebot@users.noreply.github.com"

--- a/.github/actions/update-commit-hash/action.yml
+++ b/.github/actions/update-commit-hash/action.yml
@@ -44,6 +44,7 @@ runs:
     - name: Checkout the source repo with the pinned commit file
       uses: actions/checkout@v3
       with:
+        ref: 'main'
         submodules: true
         token: ${{ inputs.updatebot-token }}
 

--- a/.github/actions/update-commit-hash/action.yml
+++ b/.github/actions/update-commit-hash/action.yml
@@ -63,25 +63,25 @@ runs:
       run: |
         git clone https://github.com/${{ inputs.repo-owner }}/${{ inputs.repo-name }}.git --quiet
 
-    - name: Check if there already exists a PR
-      shell: bash
-      env:
-        SOURCE_REPO: ${{ github.repository }}
-        REPO_NAME: ${{ inputs.repo-name }}
-        BRANCH: ${{ inputs.branch }}
-        PIN_FOLDER: ${{ inputs.pin-folder }}
-        UPDATEBOT_TOKEN: ${{ inputs.updatebot-token }}
-        PYTORCHBOT_TOKEN: ${{ inputs.pytorchbot-token }}
-        NEW_BRANCH_NAME: update-${{ inputs.repo-name }}-commit-hash/${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-      run: |
-        set -ex
+        # - name: Check if there already exists a PR
+        #   shell: bash
+        #   env:
+        #     SOURCE_REPO: ${{ github.repository }}
+        #     REPO_NAME: ${{ inputs.repo-name }}
+        #     BRANCH: ${{ inputs.branch }}
+        #     PIN_FOLDER: ${{ inputs.pin-folder }}
+        #     UPDATEBOT_TOKEN: ${{ inputs.updatebot-token }}
+        #     PYTORCHBOT_TOKEN: ${{ inputs.pytorchbot-token }}
+        #     NEW_BRANCH_NAME: update-${{ inputs.repo-name }}-commit-hash/${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+        #   run: |
+        #     set -ex
 
-        # put this here instead of the script to prevent accidentally changing the config when running the script locally
-        git config --global user.name "PyTorch UpdateBot"
-        git config --global user.email "pytorchupdatebot@users.noreply.github.com"
+        #     # put this here instead of the script to prevent accidentally changing the config when running the script locally
+        #     git config --global user.name "PyTorch UpdateBot"
+        #     git config --global user.email "pytorchupdatebot@users.noreply.github.com"
 
-        python test-infra/.github/scripts/update_commit_hashes.py \
-          --repo-name "${REPO_NAME}" \
-          --branch "${BRANCH}" \
-          --pin-folder "${PIN_FOLDER}" \
-          --source-repo "${SOURCE_REPO}"
+        #     python test-infra/.github/scripts/update_commit_hashes.py \
+        #       --repo-name "${REPO_NAME}" \
+        #       --branch "${BRANCH}" \
+        #       --pin-folder "${PIN_FOLDER}" \
+        #       --source-repo "${SOURCE_REPO}"

--- a/.github/actions/update-commit-hash/action.yml
+++ b/.github/actions/update-commit-hash/action.yml
@@ -1,0 +1,85 @@
+name: Update commit hash
+
+inputs:
+  target-repo-owner:
+    required: false
+    type: string
+    description: Name of the owner of the target repository
+    default: pytorch
+  target-repo-name:
+    required: true
+    type: string
+    description: Name of the target repository we are updating commit hash for
+  target-branch:
+    required: true
+    type: string
+    description: Branch to fetch commit of from the target repository
+  pin-folder:
+    type: string
+    description: Path to folder with commit pin in the source repository
+    required: false
+    default: .ci/docker/ci_commit_pins
+  test-infra-repository:
+    description: "Test infra repository to use"
+    default: 'pytorch/test-infra'
+    type: string
+  test-infra-ref:
+    description: "Test infra reference to use"
+    default: ""
+    type: string
+  updatebot-token:
+    required: true
+    type: string
+    description: Update bot token
+  pytorchbot-token:
+    required: true
+    type: string
+    description: Update bot token
+
+description: Update the pinned commit hash of the target repo on the source repo
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+        cache: pip
+
+    - name: Checkout the source repo with the pinned commit file
+      uses: actions/checkout@v3
+      with:
+        token: ${{ inputs.updatebot-token }}
+
+    - name: Checkout test-infra for the update_commit_hashes scripts
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ inputs.test-infra-repository }}
+        ref: ${{ inputs.test-infra-ref }}
+        path: test-infra
+
+    - name: Checkout the target repo
+      shell: bash
+      run: |
+        git clone https://github.com/${{ inputs.target-repo-owner }}/${{ inputs.target-repo-name }}.git --quiet
+
+    - name: Check if there already exists a PR
+      shell: bash
+      env:
+        SOURCE_REPO: ${{ github.repository }}
+        TARGET_REPO_NAME: ${{ inputs.repo-name }}
+        BRANCH: ${{ inputs.branch }}
+        PIN_FOLDER: ${{ inputs.pin-folder }}
+        UPDATEBOT_TOKEN: ${{ inputs.updatebot-token }}
+        PYTORCHBOT_TOKEN: ${{ inputs.pytorchbot-token }}
+        NEW_BRANCH_NAME: update-${{ inputs.repo-name }}-commit-hash/${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+      run: |
+        # put this here instead of the script to prevent accidentally changing the config when running the script locally
+        git config --global user.name "PyTorch UpdateBot"
+        git config --global user.email "pytorchupdatebot@users.noreply.github.com"
+
+        python test-infra/.github/scripts/update_commit_hashes.py \
+          --repo-name "${REPO_NAME}" \
+          --branch "${BRANCH}" \
+          --pin-folder "${PIN_FOLDER}" \
+          --source-repo "${SOURCE_REPO}"

--- a/.github/actions/update-commit-hash/action.yml
+++ b/.github/actions/update-commit-hash/action.yml
@@ -41,11 +41,6 @@ description: Update the pinned commit hash of the target repo on the source repo
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
-        cache: pip
-
     - name: Checkout the source repo with the pinned commit file
       uses: actions/checkout@v3
       with:
@@ -63,25 +58,30 @@ runs:
       run: |
         git clone https://github.com/${{ inputs.repo-owner }}/${{ inputs.repo-name }}.git --quiet
 
-        # - name: Check if there already exists a PR
-        #   shell: bash
-        #   env:
-        #     SOURCE_REPO: ${{ github.repository }}
-        #     REPO_NAME: ${{ inputs.repo-name }}
-        #     BRANCH: ${{ inputs.branch }}
-        #     PIN_FOLDER: ${{ inputs.pin-folder }}
-        #     UPDATEBOT_TOKEN: ${{ inputs.updatebot-token }}
-        #     PYTORCHBOT_TOKEN: ${{ inputs.pytorchbot-token }}
-        #     NEW_BRANCH_NAME: update-${{ inputs.repo-name }}-commit-hash/${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-        #   run: |
-        #     set -ex
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+        cache: pip
 
-        #     # put this here instead of the script to prevent accidentally changing the config when running the script locally
-        #     git config --global user.name "PyTorch UpdateBot"
-        #     git config --global user.email "pytorchupdatebot@users.noreply.github.com"
+    - name: Check if there already exists a PR
+      shell: bash
+      env:
+        SOURCE_REPO: ${{ github.repository }}
+        REPO_NAME: ${{ inputs.repo-name }}
+        BRANCH: ${{ inputs.branch }}
+        PIN_FOLDER: ${{ inputs.pin-folder }}
+        UPDATEBOT_TOKEN: ${{ inputs.updatebot-token }}
+        PYTORCHBOT_TOKEN: ${{ inputs.pytorchbot-token }}
+        NEW_BRANCH_NAME: update-${{ inputs.repo-name }}-commit-hash/${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+      run: |
+        set -ex
 
-        #     python test-infra/.github/scripts/update_commit_hashes.py \
-        #       --repo-name "${REPO_NAME}" \
-        #       --branch "${BRANCH}" \
-        #       --pin-folder "${PIN_FOLDER}" \
-        #       --source-repo "${SOURCE_REPO}"
+        # put this here instead of the script to prevent accidentally changing the config when running the script locally
+        git config --global user.name "PyTorch UpdateBot"
+        git config --global user.email "pytorchupdatebot@users.noreply.github.com"
+
+        python test-infra/.github/scripts/update_commit_hashes.py \
+          --repo-name "${REPO_NAME}" \
+          --branch "${BRANCH}" \
+          --pin-folder "${PIN_FOLDER}" \
+          --source-repo "${SOURCE_REPO}"

--- a/.github/actions/update-commit-hash/action.yml
+++ b/.github/actions/update-commit-hash/action.yml
@@ -76,6 +76,7 @@ runs:
       run: |
         set -ex
 
+        pip install requests==2.31.0
         # put this here instead of the script to prevent accidentally changing the config when running the script locally
         git config --global user.name "PyTorch UpdateBot"
         git config --global user.email "pytorchupdatebot@users.noreply.github.com"

--- a/.github/actions/update-commit-hash/action.yml
+++ b/.github/actions/update-commit-hash/action.yml
@@ -1,16 +1,16 @@
 name: Update commit hash
 
 inputs:
-  target-repo-owner:
+  repo-owner:
     required: false
     type: string
     description: Name of the owner of the target repository
     default: pytorch
-  target-repo-name:
+  repo-name:
     required: true
     type: string
     description: Name of the target repository we are updating commit hash for
-  target-branch:
+  branch:
     required: true
     type: string
     description: Branch to fetch commit of from the target repository
@@ -61,13 +61,13 @@ runs:
     - name: Checkout the target repo
       shell: bash
       run: |
-        git clone https://github.com/${{ inputs.target-repo-owner }}/${{ inputs.target-repo-name }}.git --quiet
+        git clone https://github.com/${{ inputs.repo-owner }}/${{ inputs.repo-name }}.git --quiet
 
     - name: Check if there already exists a PR
       shell: bash
       env:
         SOURCE_REPO: ${{ github.repository }}
-        TARGET_REPO_NAME: ${{ inputs.repo-name }}
+        REPO_NAME: ${{ inputs.repo-name }}
         BRANCH: ${{ inputs.branch }}
         PIN_FOLDER: ${{ inputs.pin-folder }}
         UPDATEBOT_TOKEN: ${{ inputs.updatebot-token }}

--- a/.github/scripts/update_commit_hashes.py
+++ b/.github/scripts/update_commit_hashes.py
@@ -1,0 +1,173 @@
+import json
+import os
+import subprocess
+from argparse import ArgumentParser
+from typing import Any, Dict
+
+import requests
+
+UPDATEBOT_TOKEN = os.environ["UPDATEBOT_TOKEN"]
+PYTORCHBOT_TOKEN = os.environ["PYTORCHBOT_TOKEN"]
+
+
+def git_api(
+    url: str, params: Dict[str, str], type: str = "get", token: str = UPDATEBOT_TOKEN
+) -> Any:
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "Authorization": f"token {token}",
+    }
+    if type == "post":
+        return requests.post(
+            f"https://api.github.com{url}",
+            data=json.dumps(params),
+            headers=headers,
+        ).json()
+    elif type == "patch":
+        return requests.patch(
+            f"https://api.github.com{url}",
+            data=json.dumps(params),
+            headers=headers,
+        ).json()
+    else:
+        return requests.get(
+            f"https://api.github.com{url}",
+            params=params,
+            headers=headers,
+        ).json()
+
+
+def parse_args() -> Any:
+    parser = ArgumentParser("Rebase PR into branch")
+    parser.add_argument("--repo-name", type=str)
+    parser.add_argument("--branch", type=str)
+    parser.add_argument("--pin-folder", type=str)
+    return parser.parse_args()
+
+
+def make_pr(source_repo: str, repo_name: str, branch_name: str) -> Any:
+    params = {
+        "title": f"[{repo_name} hash update] update the pinned {repo_name} hash",
+        "head": branch_name,
+        "base": "main",
+        "body": f"This PR is auto-generated nightly by [this action](https://github.com/{source_repo}/blob/main/"
+        + f".github/workflows/nightly.yml).\nUpdate the pinned {repo_name} hash.",
+    }
+    response = git_api(f"/repos/{source_repo}/pulls", params, type="post")
+    print(f"made pr {response['html_url']}")
+    return response["number"]
+
+
+def approve_pr(source_repo: str, pr_number: str) -> None:
+    params = {"event": "APPROVE"}
+    # use pytorchbot to approve the pr
+    git_api(
+        f"/repos/{source_repo}/pulls/{pr_number}/reviews",
+        params,
+        type="post",
+        token=PYTORCHBOT_TOKEN,
+    )
+
+
+def make_comment(source_repo: str, pr_number: str, msg: str) -> None:
+    params = {"body": msg}
+    # comment with pytorchbot because pytorchmergebot gets ignored
+    git_api(
+        f"/repos/{source_repo}/issues/{pr_number}/comments",
+        params,
+        type="post",
+        token=PYTORCHBOT_TOKEN,
+    )
+
+
+def close_pr(source_repo: str, pr_number: str) -> None:
+    params = {"state": "closed"}
+    git_api(
+        f"/repos/{source_repo}/pulls/{pr_number}",
+        params,
+        type="patch",
+    )
+
+
+def is_newer_hash(new_hash: str, old_hash: str, repo_name: str) -> bool:
+    def _get_date(hash: str) -> int:
+        # this git command prints the unix timestamp of the hash
+        return int(
+            subprocess.run(
+                f"git show --no-patch --no-notes --pretty=%ct {hash}".split(),
+                capture_output=True,
+                cwd=f"{repo_name}",
+            )
+            .stdout.decode("utf-8")
+            .strip()
+        )
+
+    return _get_date(new_hash) > _get_date(old_hash)
+
+
+def main() -> None:
+    args = parse_args()
+
+    branch_name = os.environ["NEW_BRANCH_NAME"]
+    pr_num = None
+
+    source_repo = args.source_repo
+    # query to see if a pr already exists
+    params = {
+        "q": f"is:pr is:open in:title author:pytorchupdatebot repo:{source_repo} {args.repo_name} hash update",
+        "sort": "created",
+    }
+    response = git_api("/search/issues", params)
+    if response["total_count"] != 0:
+        # pr does exist
+        pr_num = response["items"][0]["number"]
+        link = response["items"][0]["html_url"]
+        response = git_api(f"/repos/{source_repo}/pulls/{pr_num}", {})
+        branch_name = response["head"]["ref"]
+        print(
+            f"pr does exist, number is {pr_num}, branch name is {branch_name}, link is {link}"
+        )
+
+    hash = (
+        subprocess.run(
+            f"git rev-parse {args.branch}".split(),
+            capture_output=True,
+            cwd=f"{args.repo_name}",
+        )
+        .stdout.decode("utf-8")
+        .strip()
+    )
+    with open(f"{args.pin_folder}/{args.repo_name}.txt", "r+") as f:
+        old_hash = f.read().strip()
+        subprocess.run(f"git checkout {old_hash}".split(), cwd=args.repo_name)
+        f.seek(0)
+        f.truncate()
+        f.write(f"{hash}\n")
+    if is_newer_hash(hash, old_hash, args.repo_name):
+        # if there was an update, push to branch
+        subprocess.run(f"git checkout -b {branch_name}".split())
+        subprocess.run(f"git add {args.pin_folder}/{args.repo_name}.txt".split())
+        subprocess.run(
+            "git commit -m".split() + [f"update {args.repo_name} commit hash"]
+        )
+        subprocess.run(f"git push --set-upstream origin {branch_name} -f".split())
+        print(f"changes pushed to branch {branch_name}")
+        if pr_num is None:
+            # no existing pr, so make a new one and approve it
+            pr_num = make_pr(source_repo, args.repo_name, branch_name)
+            approve_pr(source_repo, pr_num)
+        make_comment(source_repo, pr_num, "@pytorchbot merge")
+    else:
+        print(
+            f"tried to update from old hash: {old_hash} to new hash: {hash} but the old hash seems to be newer, not creating pr"
+        )
+        if pr_num is not None:
+            make_comment(
+                source_repo, pr_num, "closing pr as the current hash seems up to date"
+            )
+            close_pr(source_repo, pr_num)
+            print(f"closing PR {pr_num}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/update_commit_hashes.py
+++ b/.github/scripts/update_commit_hashes.py
@@ -157,11 +157,13 @@ def main() -> None:
                 check=True,
                 capture_output=True,
             )
-            third_party_path = r.stdout.decode()
+            third_party_path = r.stdout.decode().strip()
 
             if os.path.exists(third_party_path):
                 has_third_party_path = True
+                subprocess.run(["git", "fetch", "origin"], cwd=third_party_path)
                 subprocess.run(f"git checkout {hash}".split(), cwd=third_party_path)
+
         except CalledProcessError:
             # This exception is thrown when the source repo has no third-party
             # setup for the target repo. So, we can skip this altogether
@@ -171,7 +173,7 @@ def main() -> None:
         subprocess.run(f"git checkout -b {branch_name}".split())
         subprocess.run(f"git add {args.pin_folder}/{args.repo_name}.txt".split())
         if has_third_party_path:
-            subprocess.run(f"git add {third_party_path}.txt".split())
+            subprocess.run(f"git add {third_party_path}".split())
         subprocess.run(
             ["git", "commit", "-m"] + [f"update {args.repo_name} commit hash"]
         )

--- a/.github/scripts/update_commit_hashes.py
+++ b/.github/scripts/update_commit_hashes.py
@@ -42,6 +42,7 @@ def parse_args() -> Any:
     parser.add_argument("--repo-name", type=str)
     parser.add_argument("--branch", type=str)
     parser.add_argument("--pin-folder", type=str)
+    parser.add_argument("--source-repo", type=str)
     return parser.parse_args()
 
 

--- a/.github/scripts/update_commit_hashes.py
+++ b/.github/scripts/update_commit_hashes.py
@@ -158,13 +158,17 @@ def main() -> None:
                 capture_output=True,
             )
             third_party_path = r.stdout.decode().strip()
+            print(f"=== DEBUG third_party_path: {third_party_path}")
 
             if os.path.exists(third_party_path):
                 has_third_party_path = True
                 subprocess.run(["git", "fetch", "origin"], cwd=third_party_path)
-                subprocess.run(f"git checkout {hash}".split(), cwd=third_party_path)
+                debug = subprocess.run(f"git checkout {hash}".split(), cwd=third_party_path, capture_output=True)
 
+            print(f"=== DEBUG has_third_party_path: {has_third_party_path}")
+            print(f"=== DEBUG debug : {debug.stdout.decode()}")
         except CalledProcessError:
+            print(f"=== 3RD-PARTY NOT FOUND")
             # This exception is thrown when the source repo has no third-party
             # setup for the target repo. So, we can skip this altogether
             pass

--- a/.github/scripts/update_commit_hashes.py
+++ b/.github/scripts/update_commit_hashes.py
@@ -155,6 +155,7 @@ def main() -> None:
             ["git", "submodule", "foreach", "--quiet", "'echo $name'"],
             capture_output=True,
         )
+        print(f"=== DEBUG {submodules.stdout.decode().strip()}")
         for submodule in submodules.stdout.decode().strip().splitlines():
             if f"/{args.repo_name}" in submodule:
                 has_third_party_path = True

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -37,6 +37,7 @@ include_patterns = [
     'stats/**/*.pyi',
     'torchci/**/*.py',
     'torchci/**/*.pyi',
+    '.github/scripts/*.py',
 ]
 command = [
     'python3',
@@ -242,6 +243,7 @@ init_command = [
 code = 'UFMT'
 include_patterns = [
     'tools/torchci/**/*.py',
+    '.github/scripts/*.py',
 ]
 command = [
     'python3',


### PR DESCRIPTION
So that it can be re-used by ExecuTorch to update PyTorch pinned commits.  This is a close 1:1 copy of the GHA and the script from `pytorch/pytorch`.  A small modification is made in the `source-repo` parameter to allow the pinned commit files from other repo, i.e. `pytorch/executorch`.

### Testing

Migrate and test the new GHA on pytorch https://github.com/pytorch/pytorch/pull/117506:

* ExecuTorch PR already exists https://github.com/pytorch/pytorch/actions/runs/7534593538/job/20509371346#step:2:1114
* Audio has no new commit https://github.com/pytorch/pytorch/actions/runs/7534593538/job/20509371162#step:2:1107
* Vision has a new commit and a PR should be created, but GH correctly reject `git push` to create a new remote branch https://github.com/pytorch/pytorch/actions/runs/7534593538/job/20509371569#step:2:1109.  This should work when running on nightly schedule.

Also testing this out on ExecuTorch https://github.com/pytorch/executorch/actions/runs/7535757395/job/20513578984?pr=1597#step:2:1255