### PR TITLE
Fix anaconda path in conda environment on GH ephemeral runner

### DIFF
--- a/.github/workflows/_binary_conda_upload.yml
+++ b/.github/workflows/_binary_conda_upload.yml
@@ -92,11 +92,11 @@ jobs:
           # shellcheck disable=SC1090
           source "${BUILD_ENV_FILE}"
           conda install --yes --quiet anaconda-client
-          conda run anaconda --version
+          conda run --no-capture-output anaconda --version
 
           if [[ "${NIGHTLY_OR_TEST:-0}" == "1" ]]; then
             for pkg in distr/**/*.tar.bz2; do
-              conda run anaconda \
+              conda run --no-capture-output anaconda \
                 -t "${CONDA_TOKEN}" \
                 upload "${pkg}" \
                 -u "pytorch-${CHANNEL}" \

--- a/.github/workflows/_binary_conda_upload.yml
+++ b/.github/workflows/_binary_conda_upload.yml
@@ -92,10 +92,11 @@ jobs:
           # shellcheck disable=SC1090
           source "${BUILD_ENV_FILE}"
           conda install --yes --quiet anaconda-client
+          conda run anaconda --version
 
           if [[ "${NIGHTLY_OR_TEST:-0}" == "1" ]]; then
             for pkg in distr/**/*.tar.bz2; do
-              anaconda \
+              conda run anaconda \
                 -t "${CONDA_TOKEN}" \
                 upload "${pkg}" \
                 -u "pytorch-${CHANNEL}" \
@@ -104,7 +105,6 @@ jobs:
                 --force
             done
           else
-            conda run anaconda --help
             echo "Testing the upload of the following files to pytorch-${CHANNEL} conda channel:"
             for pkg in distr/**/*.tar.bz2; do
               ls -lah "${pkg}"

--- a/.github/workflows/_binary_conda_upload.yml
+++ b/.github/workflows/_binary_conda_upload.yml
@@ -104,6 +104,7 @@ jobs:
                 --force
             done
           else
+            conda run anaconda --help
             echo "Testing the upload of the following files to pytorch-${CHANNEL} conda channel:"
             for pkg in distr/**/*.tar.bz2; do
               ls -lah "${pkg}"

--- a/.github/workflows/test_build_conda_linux_with_cuda.yml
+++ b/.github/workflows/test_build_conda_linux_with_cuda.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/test_build_conda_linux.yml
       - .github/workflows/build_conda_linux.yml
       - .github/workflows/generate_binary_build_matrix.yml
+      - .github/workflows/build_conda_linux.yml
       - tools/scripts/generate_binary_build_matrix.py
   workflow_dispatch:
 

--- a/.github/workflows/test_build_conda_linux_with_cuda.yml
+++ b/.github/workflows/test_build_conda_linux_with_cuda.yml
@@ -7,7 +7,7 @@ on:
       - .github/workflows/test_build_conda_linux.yml
       - .github/workflows/build_conda_linux.yml
       - .github/workflows/generate_binary_build_matrix.yml
-      - .github/workflows/build_conda_linux.yml
+      - .github/workflows/_binary_conda_upload.yml
       - tools/scripts/generate_binary_build_matrix.py
   workflow_dispatch:
 

--- a/.github/workflows/test_build_conda_linux_without_cuda.yml
+++ b/.github/workflows/test_build_conda_linux_without_cuda.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/test_build_conda_linux.yml
       - .github/workflows/build_conda_linux.yml
       - .github/workflows/generate_binary_build_matrix.yml
+      - .github/workflows/build_conda_linux.yml
       - tools/scripts/generate_binary_build_matrix.py
   workflow_dispatch:
 

--- a/.github/workflows/test_build_conda_linux_without_cuda.yml
+++ b/.github/workflows/test_build_conda_linux_without_cuda.yml
@@ -7,7 +7,7 @@ on:
       - .github/workflows/test_build_conda_linux.yml
       - .github/workflows/build_conda_linux.yml
       - .github/workflows/generate_binary_build_matrix.yml
-      - .github/workflows/build_conda_linux.yml
+      - .github/workflows/_binary_conda_upload.yml
       - tools/scripts/generate_binary_build_matrix.py
   workflow_dispatch:
 

--- a/.github/workflows/test_build_conda_m1.yml
+++ b/.github/workflows/test_build_conda_m1.yml
@@ -7,7 +7,7 @@ on:
       - .github/workflows/test_build_conda_m1.yml
       - .github/workflows/build_conda_macos.yml
       - .github/workflows/generate_binary_build_matrix.yml
-      - .github/workflows/build_conda_linux.yml
+      - .github/workflows/_binary_conda_upload.yml
       - tools/scripts/generate_binary_build_matrix.py
   workflow_dispatch:
 

--- a/.github/workflows/test_build_conda_m1.yml
+++ b/.github/workflows/test_build_conda_m1.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/test_build_conda_m1.yml
       - .github/workflows/build_conda_macos.yml
       - .github/workflows/generate_binary_build_matrix.yml
+      - .github/workflows/build_conda_linux.yml
       - tools/scripts/generate_binary_build_matrix.py
   workflow_dispatch:
 

--- a/.github/workflows/test_build_conda_macos.yml
+++ b/.github/workflows/test_build_conda_macos.yml
@@ -7,7 +7,7 @@ on:
       - .github/workflows/test_build_conda_macos.yml
       - .github/workflows/build_conda_macos.yml
       - .github/workflows/generate_binary_build_matrix.yml
-      - .github/workflows/build_conda_linux.yml
+      - .github/workflows/_binary_conda_upload.yml
       - tools/scripts/generate_binary_build_matrix.py
 
 jobs:

--- a/.github/workflows/test_build_conda_macos.yml
+++ b/.github/workflows/test_build_conda_macos.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/test_build_conda_macos.yml
       - .github/workflows/build_conda_macos.yml
       - .github/workflows/generate_binary_build_matrix.yml
+      - .github/workflows/build_conda_linux.yml
       - tools/scripts/generate_binary_build_matrix.py
 
 jobs:

--- a/.github/workflows/test_build_conda_windows_with_cuda.yml
+++ b/.github/workflows/test_build_conda_windows_with_cuda.yml
@@ -7,7 +7,7 @@ on:
       - .github/workflows/test_build_conda_windows_with_cuda.yml
       - .github/workflows/build_conda_windows.yml
       - .github/workflows/generate_binary_build_matrix.yml
-      - .github/workflows/build_conda_linux.yml
+      - .github/workflows/_binary_conda_upload.yml
       - tools/scripts/generate_binary_build_matrix.py
   workflow_dispatch:
 

--- a/.github/workflows/test_build_conda_windows_with_cuda.yml
+++ b/.github/workflows/test_build_conda_windows_with_cuda.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/test_build_conda_windows_with_cuda.yml
       - .github/workflows/build_conda_windows.yml
       - .github/workflows/generate_binary_build_matrix.yml
+      - .github/workflows/build_conda_linux.yml
       - tools/scripts/generate_binary_build_matrix.py
   workflow_dispatch:
 

--- a/.github/workflows/test_build_conda_windows_without_cuda.yml
+++ b/.github/workflows/test_build_conda_windows_without_cuda.yml
@@ -7,7 +7,7 @@ on:
       - .github/workflows/test_build_conda_windows_without_cuda.yml
       - .github/workflows/build_conda_windows.yml
       - .github/workflows/generate_binary_build_matrix.yml
-      - .github/workflows/build_conda_linux.yml
+      - .github/workflows/_binary_conda_upload.yml
       - tools/scripts/generate_binary_build_matrix.py
   workflow_dispatch:
 

--- a/.github/workflows/test_build_conda_windows_without_cuda.yml
+++ b/.github/workflows/test_build_conda_windows_without_cuda.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/test_build_conda_windows_without_cuda.yml
       - .github/workflows/build_conda_windows.yml
       - .github/workflows/generate_binary_build_matrix.yml
+      - .github/workflows/build_conda_linux.yml
       - tools/scripts/generate_binary_build_matrix.py
   workflow_dispatch:
 


### PR DESCRIPTION
I tested https://github.com/pytorch/test-infra/pull/4886 with vision nightly and found out that I need to set the path to anaconda on GH ephemeral runner used by the upload job. 
 It would fail otherwise, i.e. https://github.com/pytorch/vision/actions/runs/7550404642/job/20556529100#step:7:121

### Testing

https://github.com/pytorch/test-infra/actions/runs/7550720719/job/20557072841?pr=4891#step:7:117 shows that conda can find anaconda client version correctly.