### PR TITLE
[PyTorchBot] Limit CIFLow tags assignment

### DIFF
--- a/torchci/lib/bot/utils.ts
+++ b/torchci/lib/bot/utils.ts
@@ -203,6 +203,26 @@ export async function hasWritePermissionsUsingOctokit(
   return permissions === "admin" || permissions === "write";
 }
 
+export async function hasApprovedPullRuns(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  sha: string
+): Promise<boolean> {
+  const res = await octokit.rest.actions.listWorkflowRunsForRepo({
+    owner: owner,
+    repo: repo,
+    head_sha: sha,
+  });
+  const pr_runs = res?.data?.workflow_runs?.filter(
+    (run) => run.event == "pull_request"
+  );
+  if (pr_runs == null || pr_runs?.length == 0) {
+    return false;
+  }
+  return pr_runs.every((run) => run.conclusion != "action_required");
+}
+
 export async function isFirstTimeContributor(
   ctx: any,
   username: string

--- a/torchci/test/ciflow-push-trigger.test.ts
+++ b/torchci/test/ciflow-push-trigger.test.ts
@@ -55,7 +55,9 @@ describe("Push trigger integration tests", () => {
           `tags/${label}/${prNum}`
         )}`
       )
-      .reply(200, []);
+      .reply(200, [])
+      .get("/repos/suo/actions-test/collaborators/suo/permission")
+      .reply(200, { permission: "admin" });
 
     nock("https://api.github.com")
       .post("/repos/suo/actions-test/git/refs", (body) => {
@@ -103,7 +105,9 @@ describe("Push trigger integration tests", () => {
           node_id: "123",
           object: { sha: "abc" },
         },
-      ]);
+      ])
+      .get("/repos/suo/actions-test/collaborators/suo/permission")
+      .reply(200, { permission: "admin" });
 
     nock("https://api.github.com")
       .delete(
@@ -325,11 +329,10 @@ describe("Push trigger integration tests", () => {
     payload.label.name = "ciflow/test";
     payload.pull_request.user.login = "fake_user";
     const login = payload.pull_request.user.login;
+    const head_sha = payload.pull_request.head.sha;
     nock("https://api.github.com")
-      .get(
-        `/repos/suo/actions-test/commits?author=${login}&sha=main&per_page=1`
-      )
-      .reply(200, [])
+      .get(`/repos/suo/actions-test/actions/runs?head_sha=${head_sha}`)
+      .reply(200, {})
       .get(`/repos/suo/actions-test/collaborators/${login}/permission`)
       .reply(200, {
         message: "fake_user is not a user",


### PR DESCRIPTION
Instead of checking whether or not user contributed to the repo in the
past, check that workflows triggered on pull_request has been approved


This fixes a bug where ciflow workflows would still be scheduled for the first time contributors, but adapts it to a scenario when scheduling can be done only after workflow is approved

If workflow is not approved, it will have `action_require` conslusion for `pull_request` event, for example see:
```
[
  {
    id: 7546214676,
    name: 'Check mergeability and dependencies for ghstack prs',
    node_id: 'WFR_kwLOA-j9z88AAAABwcoZFA',
    head_branch: 'export-D52808000',
    head_sha: '8e3a8e0458354194e6683f804e3c6964b9f1b238',
    path: '.github/workflows/check_mergeability_ghstack.yml',
    display_title: 'Reland D52653337',
    run_number: 7682,
    event: 'pull_request',
    status: 'completed',
    conclusion: 'action_required',
    workflow_id: 79569117,
    check_suite_id: 19843961097,
    check_suite_node_id: 'CS_kwDOA-j9z88AAAAEnsrRCQ',
    url: 'https://api.github.com/repos/pytorch/pytorch/actions/runs/7546214676',
    html_url: 'https://github.com/pytorch/pytorch/actions/runs/7546214676',
    pull_requests: [],
    created_at: '2024-01-16T18:54:39Z',
    updated_at: '2024-01-16T18:54:39Z',
    actor: {
      login: 'pytorch-bot[bot]',
      id: 54816060,
      node_id: 'MDM6Qm90NTQ4MTYwNjA=',
      avatar_url: 'https://avatars.githubusercontent.com/in/40112?v=4',
      gravatar_id: '',
      url: 'https://api.github.com/users/pytorch-bot%5Bbot%5D',
      html_url: 'https://github.com/apps/pytorch-bot',
      followers_url: 'https://api.github.com/users/pytorch-bot%5Bbot%5D/followers',
      following_url: 'https://api.github.com/users/pytorch-bot%5Bbot%5D/following{/other_user}',
      gists_url: 'https://api.github.com/users/pytorch-bot%5Bbot%5D/gists{/gist_id}',
      starred_url: 'https://api.github.com/users/pytorch-bot%5Bbot%5D/starred{/owner}{/repo}',
      subscriptions_url: 'https://api.github.com/users/pytorch-bot%5Bbot%5D/subscriptions',
      organizations_url: 'https://api.github.com/users/pytorch-bot%5Bbot%5D/orgs',
      repos_url: 'https://api.github.com/users/pytorch-bot%5Bbot%5D/repos',
      events_url: 'https://api.github.com/users/pytorch-bot%5Bbot%5D/events{/privacy}',
      received_events_url: 'https://api.github.com/users/pytorch-bot%5Bbot%5D/received_events',
      type: 'Bot',
      site_admin: false
    },
...
```
