### PR TITLE
Fix the wrong upload of vs2019 conda package on Windows

### DIFF
--- a/.github/workflows/build_conda_windows.yml
+++ b/.github/workflows/build_conda_windows.yml
@@ -169,6 +169,14 @@ jobs:
             --no-test  --python "${PYTHON_VERSION}" \
             --output-folder distr/ \
             "${CONDA_PACKAGE_DIRECTORY}"
+
+          # This is to remove the vs20xx conda package that sneaks into distr
+          for pkg in distr/**/*.tar.bz2; do
+            if [[ "${pkg}" == *vs20* ]]; then
+              rm -f "${pkg}"
+            fi
+          done
+
       - name: Upload artifact to GitHub
         continue-on-error: true
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_conda_windows.yml
+++ b/.github/workflows/build_conda_windows.yml
@@ -154,6 +154,7 @@ jobs:
         working-directory: ${{ inputs.repository }}
         env:
           CUDATOOLKIT_CHANNEL: ${{ env.CUDATOOLKIT_CHANNEL }}
+          PACKAGE_NAME: ${{ inputs.package-name }}
         run: |
           set -euxo pipefail
           cat "${BUILD_ENV_FILE}"
@@ -172,7 +173,7 @@ jobs:
 
           # This is to remove the vs20xx conda package that sneaks into distr
           for pkg in distr/**/*.tar.bz2; do
-            if [[ "${pkg}" == *vs20* ]]; then
+            if [[ "${pkg}" != *"${PACKAGE_NAME}"* ]]; then
               rm -f "${pkg}"
             fi
           done


### PR DESCRIPTION
In the new setup, the conda upload job will just upload any `tar.bz2` packages it finds because it doesn't have any additional information about the target.  This leads to the wrong and duplicated upload of vs2019 conda package in Windows build job, i.e. https://github.com/pytorch/vision/actions/runs/7555102811/job/20584135167#step:7:170.

I'm not sure what's the best way to fix this here, but removing this file explicitly helps.  Also, this only happens on Windows.