### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/pr-dependencies-check.yml
+++ b/.github/workflows/pr-dependencies-check.yml
@@ -159,8 +159,8 @@ jobs:
             for CONFLICT in "${CONFLICTING_COMMITS[@]}"; do
               echo "- $(git show --oneline -s "$CONFLICT")" >> "$GITHUB_STEP_SUMMARY"
             done
-            echo "::set-output name=conflicting_commits::${CONFLICTING_COMMITS[*]}"
-            echo "::set-output name=num_conflicting_commits::${#CONFLICTING_COMMITS[*]}"
+            echo "conflicting_commits=${CONFLICTING_COMMITS[*]}" >> $GITHUB_OUTPUT
+            echo "num_conflicting_commits=${#CONFLICTING_COMMITS[*]}" >> $GITHUB_OUTPUT
             {
               echo ""
               echo "---"


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter