### PR TITLE
[ez][bot] Disable bot to not add triaged if oncall: pt2 label is present

### DIFF
--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -409,7 +409,12 @@ export async function getTestOwnerLabels(
     labels.push("module: unknown");
   }
 
-  if (labels.some((x) => x.startsWith("module: ") && x !== "module: unknown")) {
+  if (
+    labels.some((x) => x.startsWith("module: ") && x !== "module: unknown") &&
+    !labels.includes("oncall: pt2")
+  ) {
+    // Add triaged if there is a module label and none of labels are oncall: pt2
+    // (see https://github.com/pytorch/pytorch/issues/117846)
     labels.push("triaged");
   }
   return { labels, additionalErrMessage };

--- a/torchci/test/disableFlakyBot.test.ts
+++ b/torchci/test/disableFlakyBot.test.ts
@@ -732,7 +732,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
     let { labels, additionalErrMessage } =
       await disableFlakyTestBot.getTestOwnerLabels(test);
     expect(additionalErrMessage).toEqual(undefined);
-    expect(labels).toEqual(["module: fft", "oncall: pt2", "triaged"]);
+    expect(labels).toEqual(["module: fft", "oncall: pt2"]);
 
     handleScope(scope);
   });


### PR DESCRIPTION

Only impacts disable bot, there might be other bots that auto add triaged label but I can't find them