### PR TITLE
Keep nightly 20231010 for ExecuTorch alpha 0.1 for now

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -7,6 +7,7 @@ import dataclasses
 import functools
 import time
 
+from contextlib import suppress
 from os import path, makedirs
 from datetime import datetime
 from collections import defaultdict
@@ -112,6 +113,12 @@ PACKAGE_DATE_REGEX = r"([a-zA-z]*-[0-9.]*.dev)([0-9]*)"
 # How many packages should we keep of a specific package?
 KEEP_THRESHOLD = 60
 
+# TODO (huydhn): Clean this up once ExecuTorch has a new stable release that
+# match PyTorch stable release cadence. This nightly version is currently
+# referred to publicly in ExecuTorch alpha 0.1 release. So we want to keep
+# nightly binaries around for now
+KEEP_NIGHTLY_PACKAGES_FOR_EXECUTORCH = {datetime(2023, 10, 10, 0, 0)}
+
 S3IndexType = TypeVar('S3IndexType', bound='S3Index')
 
 
@@ -139,11 +146,9 @@ class S3Object:
 def extract_package_build_time(full_package_name: str) -> datetime:
     result = search(PACKAGE_DATE_REGEX, full_package_name)
     if result is not None:
-        try:
-            return datetime.strptime(result.group(2), "%Y%m%d")
-        except ValueError:
+        with suppress(ValueError):
             # Ignore any value errors since they probably shouldn't be hidden anyways
-            pass
+            return datetime.strptime(result.group(2), "%Y%m%d")
     return datetime.now()
 
 
@@ -158,7 +163,6 @@ def safe_parse_version(ver_str: str) -> Version:
         return _parse_version(ver_str)
     except InvalidVersion:
         return Version("0.0.0")
-
 
 
 class S3Index:
@@ -201,7 +205,10 @@ class S3Index:
             if package_name not in PACKAGE_ALLOW_LIST:
                 to_hide.add(obj)
                 continue
-            if packages[package_name] >= KEEP_THRESHOLD or between_bad_dates(package_build_time):
+            if package_build_time not in KEEP_NIGHTLY_PACKAGES_FOR_EXECUTORCH and (
+                packages[package_name] >= KEEP_THRESHOLD
+                or between_bad_dates(package_build_time)
+            ):
                 to_hide.add(obj)
             else:
                 packages[package_name] += 1
@@ -447,7 +454,7 @@ class S3Index:
                            checksum=None,
                            size=None) for key in obj_names], prefix)
         if prefix == "whl/nightly":
-           rc.objects = rc.nightly_packages_to_show()
+            rc.objects = rc.nightly_packages_to_show()
         if with_metadata:
             rc.fetch_metadata()
         return rc


### PR DESCRIPTION
https://github.com/pytorch/executorch/issues/1663.  The indexing script was migrated recently from builder to test-infra in https://github.com/pytorch/test-infra/pull/4879.  But there was a mistake in which my [recent change](https://github.com/pytorch/builder/commit/6f3cb2ba1753c5ecade8b800c29fc18d18d149db) to keep nightly 20231010 for ExecuTorch wasn't copied over.

So, this PR copies the missing logic https://github.com/pytorch/builder/pull/1642.  It also fixes some linter issues flagged by test-infra lintrunner.