### PR TITLE
Fix wrong bash if condition in calculate docker image

### DIFF
--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -163,7 +163,7 @@ runs:
 
         if [ "${DOCKER_PUSH:-false}" == "true" ]; then
           # Only push if docker image doesn't exist already
-          if [! docker manifest inspect "${DOCKER_IMAGE}" >/dev/null 2>/dev/null] || [ "${DOCKER_FORCE_PUSH:-false}" == "true" ]; then
+          if ! docker manifest inspect "${DOCKER_IMAGE}" >/dev/null 2>/dev/null || [ "${DOCKER_FORCE_PUSH:-false}" == "true" ]; then
             docker push "${DOCKER_IMAGE}"
           fi
         fi


### PR DESCRIPTION
I broke it in https://github.com/pytorch/test-infra/pull/4866 with a pair of redundant square brackets (ouch)

### Testing

```
#!/bin/bash

DOCKER_IMAGE="308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-focal-rocm-n-py3:7b353c02302e5478ea0db69cdfeae5cef6ee2dec"

if [! docker manifest inspect "${DOCKER_IMAGE}" >/dev/null 2>/dev/null] || [ "${DOCKER_FORCE_PUSH:-false}" == "true" ]; then
  echo "THERE"
fi
```

returns `debug.sh: line 5: /dev/null]: Permission denied`

while 

```
#!/bin/bash

DOCKER_IMAGE="308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-focal-rocm-n-py3:7b353c02302e5478ea0db69cdfeae5cef6ee2dec"

if ! docker manifest inspect "${DOCKER_IMAGE}" >/dev/null 2>/dev/null || [ "${DOCKER_FORCE_PUSH:-false}" == "true" ]; then
  echo "THERE"
fi
```

works correctly.

Bash and its subtlety :(