### PR TITLE
Migrate update-viablestrict to test-infra as a generic GHA

### DIFF
--- a/.github/actions/update-viablestrict/action.yml
+++ b/.github/actions/update-viablestrict/action.yml
@@ -63,6 +63,7 @@ runs:
         fetch-depth: 0
 
     - name: Install Python Packages
+      shell: bash
       run: |
         pip install rockset==1.0.3 boto3==1.19.12
 
@@ -71,6 +72,7 @@ runs:
       working-directory: ${{ inputs.repository }}
       env:
         ROCKSET_API_KEY: ${{ inputs.rockset-api-key }}
+      shell: bash
       run: |
         set -ex
 
@@ -84,6 +86,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.secret-bot-token }}
         STABLE_BRANCH: ${{ inputs.stable-branch }}
         LATEST_VIABLE_SHA: ${{ steps.get-latest-commit.outputs.latest_viable_sha }}
+      shell: bash
       run: |
         git config --global user.email "pytorchmergebot@users.noreply.github.com"
         git config --global user.name "PyTorch MergeBot"

--- a/.github/actions/update-viablestrict/action.yml
+++ b/.github/actions/update-viablestrict/action.yml
@@ -15,6 +15,12 @@ inputs:
     required: false
     default: 'viable/strict'
     type: string
+  requires:
+    description: |
+      The list of required jobs that need to pass before the commit can be
+      considered stable
+    required: true
+    type: string
   secret-bot-token:
     description: The token to use to push to the stable protected branch
     required: true
@@ -66,7 +72,9 @@ runs:
       env:
         ROCKSET_API_KEY: ${{ inputs.rockset-api-key }}
       run: |
-        output=$(python ${GITHUB_WORKSPACE}/test-infra/.github/scripts/fetch_latest_green_commit.py)
+        set -ex
+
+        output=$(python ${GITHUB_WORKSPACE}/test-infra/.github/scripts/fetch_latest_green_commit.py --requires "${{ inputs.requires }}")
         echo "latest_viable_sha=$output" >> "${GITHUB_OUTPUT}"
 
     - name: Push SHA to viable/strict branch

--- a/.github/actions/update-viablestrict/action.yml
+++ b/.github/actions/update-viablestrict/action.yml
@@ -44,7 +44,6 @@ runs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.11'
-        cache: pip
 
     - name: Checkout test-infra for the fetch_latest_green_commit scripts
       uses: actions/checkout@v3

--- a/.github/actions/update-viablestrict/action.yml
+++ b/.github/actions/update-viablestrict/action.yml
@@ -1,0 +1,86 @@
+name: Update viable/strict to the latest green commit from a PyTorch repo
+
+description: |
+  The latest green commit is the newest commit that have passed all the required
+  test in trunk and can be consider stable. This GHA only works for repos that
+  have been onboard to PyTorch Dev Infra.
+
+inputs:
+  repository:
+    description: The repository name, i.e. pytorch/pytorch
+    required: true
+    type: string
+  stable-branch:
+    description: The name of the stable branch to push to
+    required: false
+    default: 'viable/strict'
+    type: string
+  secret-bot-token:
+    description: The token to use to push to the stable protected branch
+    required: true
+    type: string
+  rockset-api-key:
+    description: The API key to query Rockset, read-only
+    required: true
+    type: string
+  test-infra-repository:
+    description: Test infra repository to use
+    default: 'pytorch/test-infra'
+    type: string
+  test-infra-ref:
+    description: Test infra reference to use
+    default: ''
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+        cache: pip
+
+    - name: Checkout test-infra for the fetch_latest_green_commit scripts
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ inputs.test-infra-repository }}
+        ref: ${{ inputs.test-infra-ref }}
+        path: test-infra
+
+    - uses: actions/checkout@v3
+      with:
+        repository: ${{ inputs.repository }}
+        token: ${{ inputs.secret-bot-token }}
+        path: ${{ inputs.repository }}
+        # Need the whole history here to get the lastest green commit, which is
+        # usually few hours behind main
+        fetch-depth: 0
+
+    - name: Install Python Packages
+      run: |
+        pip install rockset==1.0.3 boto3==1.19.12
+
+    - name: Get latest viable commit
+      id: get-latest-commit
+      working-directory: ${{ inputs.repository }}
+      env:
+        ROCKSET_API_KEY: ${{ inputs.rockset-api-key }}
+      run: |
+        output=$(python ${GITHUB_WORKSPACE}/test-infra/.github/scripts/fetch_latest_green_commit.py)
+        echo "latest_viable_sha=$output" >> "${GITHUB_OUTPUT}"
+
+    - name: Push SHA to viable/strict branch
+      if: steps.get-latest-commit.outputs.latest_viable_sha != 'None'
+      working-directory: ${{ inputs.repository }}
+      env:
+        GITHUB_TOKEN: ${{ inputs.secret-bot-token }}
+        STABLE_BRANCH: ${{ inputs.stable-branch }}
+        LATEST_VIABLE_SHA: ${{ steps.get-latest-commit.outputs.latest_viable_sha }}
+      run: |
+        git config --global user.email "pytorchmergebot@users.noreply.github.com"
+        git config --global user.name "PyTorch MergeBot"
+
+        echo "Set the latest sha variable to be ${LATEST_VIABLE_SHA}"
+        # Pushing an older green commit here will fail because it's non-fast-forward, which is ok
+        # to ignore because we already have the later green commit in visable/strict
+        git push origin "${LATEST_VIABLE_SHA}":"${STABLE_BRANCH}" || true

--- a/.github/scripts/fetch_latest_green_commit.py
+++ b/.github/scripts/fetch_latest_green_commit.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 import sys
@@ -134,8 +135,7 @@ def parse_args() -> Any:
         "--requires",
         type=str,
         required=True,
-        help="the list of required jobs that need to pass for the commit to be considered green",
-        nargs="*",
+        help="the JSON list of required jobs that need to pass for the commit to be green",
     )
     return parser.parse_args()
 
@@ -146,7 +146,9 @@ def main() -> None:
     commits = get_latest_commits()
     results = query_commits(commits)
 
-    latest_viable_commit = get_latest_green_commit(commits, args.requires, results)
+    latest_viable_commit = get_latest_green_commit(
+        commits, json.loads(args.requires), results
+    )
     print(latest_viable_commit)
 
 

--- a/.github/scripts/fetch_latest_green_commit.py
+++ b/.github/scripts/fetch_latest_green_commit.py
@@ -144,10 +144,12 @@ def main() -> None:
     args = parse_args()
 
     commits = get_latest_commits()
-    results = query_commits(commits)
+    import json
+    print(json.dumps(commits))
+    # results = query_commits(commits)
 
-    latest_viable_commit = get_latest_green_commit(commits, args.requires, results)
-    print(latest_viable_commit)
+    # latest_viable_commit = get_latest_green_commit(commits, args.requires, results)
+    # print(latest_viable_commit)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/fetch_latest_green_commit.py
+++ b/.github/scripts/fetch_latest_green_commit.py
@@ -2,7 +2,7 @@ import json
 import os
 import re
 import sys
-from typing import Any, cast, Dict, List, NamedTuple, Tuple
+from typing import Any, cast, Dict, List, NamedTuple, Optional, Tuple
 
 import rockset  # type: ignore[import]
 from gitutils import _check_output
@@ -115,7 +115,7 @@ def is_green(
 
 def get_latest_green_commit(
     commits: List[str], requires: List[str], results: List[Dict[str, Any]]
-) -> Any:
+) -> Optional[str]:
     for commit in commits:
         eprint(f"Checking {commit}")
         green, msg = is_green(commit, requires, results)

--- a/.github/scripts/fetch_latest_green_commit.py
+++ b/.github/scripts/fetch_latest_green_commit.py
@@ -144,12 +144,10 @@ def main() -> None:
     args = parse_args()
 
     commits = get_latest_commits()
-    import json
-    print(json.dumps(commits))
-    # results = query_commits(commits)
+    results = query_commits(commits)
 
-    # latest_viable_commit = get_latest_green_commit(commits, args.requires, results)
-    # print(latest_viable_commit)
+    latest_viable_commit = get_latest_green_commit(commits, args.requires, results)
+    print(latest_viable_commit)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/fetch_latest_green_commit.py
+++ b/.github/scripts/fetch_latest_green_commit.py
@@ -1,0 +1,154 @@
+import os
+import re
+import sys
+from typing import Any, cast, Dict, List, NamedTuple, Tuple
+
+import rockset  # type: ignore[import]
+from gitutils import _check_output
+
+
+def eprint(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+class WorkflowCheck(NamedTuple):
+    workflowName: str
+    name: str
+    jobName: str
+    conclusion: str
+
+
+def get_latest_commits() -> List[str]:
+    latest_viable_commit = _check_output(
+        [
+            "git",
+            "log",
+            "-n",
+            "1",
+            "--pretty=format:%H",
+            "origin/viable/strict",
+        ],
+        encoding="ascii",
+    )
+    commits = _check_output(
+        [
+            "git",
+            "rev-list",
+            f"{latest_viable_commit}^..HEAD",
+            "--remotes=*origin/main",
+        ],
+        encoding="ascii",
+    ).splitlines()
+
+    return commits
+
+
+def query_commits(commits: List[str]) -> List[Dict[str, Any]]:
+    rs = rockset.RocksetClient(
+        host="api.usw2a1.rockset.com", api_key=os.environ["ROCKSET_API_KEY"]
+    )
+    params = [{"name": "shas", "type": "string", "value": ",".join(commits)}]
+    res = rs.QueryLambdas.execute_query_lambda(
+        # https://console.rockset.com/lambdas/details/commons.commit_jobs_batch_query
+        query_lambda="commit_jobs_batch_query",
+        version="19c74e10819104f9",
+        workspace="commons",
+        parameters=params,
+    )
+
+    return cast(List[Dict[str, Any]], res.results)
+
+
+def print_commit_status(commit: str, results: Dict[str, Any]) -> None:
+    print(commit)
+    for check in results["results"]:
+        if check["sha"] == commit:
+            print(f"\t{check['conclusion']:>10}: {check['name']}")
+
+
+def get_commit_results(
+    commit: str, results: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    workflow_checks = []
+    for check in results:
+        if check["sha"] == commit:
+            workflow_checks.append(
+                WorkflowCheck(
+                    workflowName=check["workflowName"],
+                    name=check["name"],
+                    jobName=check["jobName"],
+                    conclusion=check["conclusion"],
+                )._asdict()
+            )
+    return workflow_checks
+
+
+def is_green(
+    commit: str, requires: List[str], results: List[Dict[str, Any]]
+) -> Tuple[bool, str]:
+    workflow_checks = get_commit_results(commit, results)
+
+    regex = {name: False for name in requires}
+
+    for check in workflow_checks:
+        jobName = check["jobName"]
+        # Ignore result from unstable job, be it success or failure
+        if "unstable" in jobName:
+            continue
+
+        workflowName = check["workflowName"]
+        conclusion = check["conclusion"]
+        for required_check in regex:
+            if re.match(required_check, workflowName, flags=re.IGNORECASE):
+                if conclusion not in ["success", "skipped"]:
+                    return (False, workflowName + " checks were not successful")
+                else:
+                    regex[required_check] = True
+
+    missing_workflows = [x for x in regex.keys() if not regex[x]]
+    if len(missing_workflows) > 0:
+        return (False, "missing required workflows: " + ", ".join(missing_workflows))
+
+    return (True, "")
+
+
+def get_latest_green_commit(
+    commits: List[str], requires: List[str], results: List[Dict[str, Any]]
+) -> Any:
+    for commit in commits:
+        eprint(f"Checking {commit}")
+        green, msg = is_green(commit, requires, results)
+        if green:
+            eprint("GREEN")
+            return commit
+        else:
+            eprint("RED: " + msg)
+    return None
+
+
+def parse_args() -> Any:
+    from argparse import ArgumentParser
+
+    parser = ArgumentParser("Return the latest green commit from a PyTorch repo")
+    parser.add_argument(
+        "--requires",
+        type=str,
+        required=True,
+        help="the list of required jobs that need to pass for the commit to be considered green",
+        nargs="*",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    commits = get_latest_commits()
+    results = query_commits(commits)
+
+    latest_viable_commit = get_latest_green_commit(commits, args.requires, results)
+    print(latest_viable_commit)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -1,0 +1,444 @@
+import os
+import re
+import tempfile
+from collections import defaultdict
+from datetime import datetime
+from functools import wraps
+from typing import (
+    Any,
+    Callable,
+    cast,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
+
+T = TypeVar("T")
+
+RE_GITHUB_URL_MATCH = re.compile("^https://.*@?github.com/(.+)/(.+)$")
+
+
+def get_git_remote_name() -> str:
+    return os.getenv("GIT_REMOTE_NAME", "origin")
+
+
+def get_git_repo_dir() -> str:
+    from pathlib import Path
+
+    return os.getenv("GIT_REPO_DIR", str(Path(__file__).resolve().parent.parent.parent))
+
+
+def fuzzy_list_to_dict(items: List[Tuple[str, str]]) -> Dict[str, List[str]]:
+    """
+    Converts list to dict preserving elements with duplicate keys
+    """
+    rc: Dict[str, List[str]] = defaultdict(list)
+    for key, val in items:
+        rc[key].append(val)
+    return dict(rc)
+
+
+def _check_output(items: List[str], encoding: str = "utf-8") -> str:
+    from subprocess import CalledProcessError, check_output, STDOUT
+
+    try:
+        return check_output(items, stderr=STDOUT).decode(encoding)
+    except CalledProcessError as e:
+        msg = f"Command `{' '.join(e.cmd)}` returned non-zero exit code {e.returncode}"
+        stdout = e.stdout.decode(encoding) if e.stdout is not None else ""
+        stderr = e.stderr.decode(encoding) if e.stderr is not None else ""
+        # These get swallowed up, so print them here for debugging
+        print(f"stdout: \n{stdout}")
+        print(f"stderr: \n{stderr}")
+        if len(stderr) == 0:
+            msg += f"\n```\n{stdout}```"
+        else:
+            msg += f"\nstdout:\n```\n{stdout}```\nstderr:\n```\n{stderr}```"
+        raise RuntimeError(msg) from e
+
+
+class GitCommit:
+    commit_hash: str
+    title: str
+    body: str
+    author: str
+    author_date: datetime
+    commit_date: Optional[datetime]
+
+    def __init__(
+        self,
+        commit_hash: str,
+        author: str,
+        author_date: datetime,
+        title: str,
+        body: str,
+        commit_date: Optional[datetime] = None,
+    ) -> None:
+        self.commit_hash = commit_hash
+        self.author = author
+        self.author_date = author_date
+        self.commit_date = commit_date
+        self.title = title
+        self.body = body
+
+    def __repr__(self) -> str:
+        return f"{self.title} ({self.commit_hash})"
+
+    def __contains__(self, item: Any) -> bool:
+        return item in self.body or item in self.title
+
+
+def parse_fuller_format(lines: Union[str, List[str]]) -> GitCommit:
+    """
+    Expect commit message generated using `--format=fuller --date=unix` format, i.e.:
+        commit <sha1>
+        Author:     <author>
+        AuthorDate: <author date>
+        Commit:     <committer>
+        CommitDate: <committer date>
+
+        <title line>
+
+        <full commit message>
+
+    """
+    if isinstance(lines, str):
+        lines = lines.split("\n")
+    # TODO: Handle merge commits correctly
+    if len(lines) > 1 and lines[1].startswith("Merge:"):
+        del lines[1]
+    assert len(lines) > 7
+    assert lines[0].startswith("commit")
+    assert lines[1].startswith("Author: ")
+    assert lines[2].startswith("AuthorDate: ")
+    assert lines[3].startswith("Commit: ")
+    assert lines[4].startswith("CommitDate: ")
+    assert len(lines[5]) == 0
+    return GitCommit(
+        commit_hash=lines[0].split()[1].strip(),
+        author=lines[1].split(":", 1)[1].strip(),
+        author_date=datetime.fromtimestamp(int(lines[2].split(":", 1)[1].strip())),
+        commit_date=datetime.fromtimestamp(int(lines[4].split(":", 1)[1].strip())),
+        title=lines[6].strip(),
+        body="\n".join(lines[7:]),
+    )
+
+
+class GitRepo:
+    def __init__(self, path: str, remote: str = "origin", debug: bool = False) -> None:
+        self.repo_dir = path
+        self.remote = remote
+        self.debug = debug
+
+    def _run_git(self, *args: Any) -> str:
+        if self.debug:
+            print(f"+ git -C {self.repo_dir} {' '.join(args)}")
+        return _check_output(["git", "-C", self.repo_dir] + list(args))
+
+    def revlist(self, revision_range: str) -> List[str]:
+        rc = self._run_git("rev-list", revision_range, "--", ".").strip()
+        return rc.split("\n") if len(rc) > 0 else []
+
+    def branches_containing_ref(
+        self, ref: str, *, include_remote: bool = True
+    ) -> List[str]:
+        rc = (
+            self._run_git("branch", "--remote", "--contains", ref)
+            if include_remote
+            else self._run_git("branch", "--contains", ref)
+        )
+        return [x.strip() for x in rc.split("\n") if x.strip()] if len(rc) > 0 else []
+
+    def current_branch(self) -> str:
+        return self._run_git("symbolic-ref", "--short", "HEAD").strip()
+
+    def checkout(self, branch: str) -> None:
+        self._run_git("checkout", branch)
+
+    def fetch(self, ref: Optional[str] = None, branch: Optional[str] = None) -> None:
+        if branch is None and ref is None:
+            self._run_git("fetch", self.remote)
+        elif branch is None:
+            self._run_git("fetch", self.remote, ref)
+        else:
+            self._run_git("fetch", self.remote, f"{ref}:{branch}")
+
+    def show_ref(self, name: str) -> str:
+        refs = self._run_git("show-ref", "-s", name).strip().split("\n")
+        if not all(refs[i] == refs[0] for i in range(1, len(refs))):
+            raise RuntimeError(f"reference {name} is ambiguous")
+        return refs[0]
+
+    def rev_parse(self, name: str) -> str:
+        return self._run_git("rev-parse", "--verify", name).strip()
+
+    def get_merge_base(self, from_ref: str, to_ref: str) -> str:
+        return self._run_git("merge-base", from_ref, to_ref).strip()
+
+    def patch_id(self, ref: Union[str, List[str]]) -> List[Tuple[str, str]]:
+        is_list = isinstance(ref, list)
+        if is_list:
+            if len(ref) == 0:
+                return []
+            ref = " ".join(ref)
+        rc = _check_output(
+            ["sh", "-c", f"git -C {self.repo_dir} show {ref}|git patch-id --stable"]
+        ).strip()
+        return [cast(Tuple[str, str], x.split(" ", 1)) for x in rc.split("\n")]
+
+    def commits_resolving_gh_pr(self, pr_num: int) -> List[str]:
+        owner, name = self.gh_owner_and_name()
+        msg = f"Pull Request resolved: https://github.com/{owner}/{name}/pull/{pr_num}"
+        rc = self._run_git("log", "--format=%H", "--grep", msg).strip()
+        return rc.split("\n") if len(rc) > 0 else []
+
+    def get_commit(self, ref: str) -> GitCommit:
+        return parse_fuller_format(
+            self._run_git("show", "--format=fuller", "--date=unix", "--shortstat", ref)
+        )
+
+    def cherry_pick(self, ref: str) -> None:
+        self._run_git("cherry-pick", "-x", ref)
+
+    def revert(self, ref: str) -> None:
+        self._run_git("revert", "--no-edit", ref)
+
+    def compute_branch_diffs(
+        self, from_branch: str, to_branch: str
+    ) -> Tuple[List[str], List[str]]:
+        """
+        Returns list of commmits that are missing in each other branch since their merge base
+        Might be slow if merge base is between two branches is pretty far off
+        """
+        from_ref = self.rev_parse(from_branch)
+        to_ref = self.rev_parse(to_branch)
+        merge_base = self.get_merge_base(from_ref, to_ref)
+        from_commits = self.revlist(f"{merge_base}..{from_ref}")
+        to_commits = self.revlist(f"{merge_base}..{to_ref}")
+        from_ids = fuzzy_list_to_dict(self.patch_id(from_commits))
+        to_ids = fuzzy_list_to_dict(self.patch_id(to_commits))
+        for patch_id in set(from_ids).intersection(set(to_ids)):
+            from_values = from_ids[patch_id]
+            to_values = to_ids[patch_id]
+            if len(from_values) != len(to_values):
+                # Eliminate duplicate commits+reverts from the list
+                while len(from_values) > 0 and len(to_values) > 0:
+                    frc = self.get_commit(from_values.pop())
+                    toc = self.get_commit(to_values.pop())
+                    # FRC branch might have PR number added to the title
+                    if (  # noqa: SIM102
+                        frc.title != toc.title or frc.author_date != toc.author_date
+                    ):
+                        # HACK: Same commit were merged, reverted and landed again
+                        # which creates a tracking problem
+                        if (
+                            "pytorch/pytorch" not in self.remote_url()
+                            or frc.commit_hash
+                            not in {
+                                "0a6a1b27a464ba5be5f587cce2ee12ab8c504dbf",
+                                "6d0f4a1d545a8f161df459e8d4ccafd4b9017dbe",
+                                "edf909e58f06150f7be41da2f98a3b9de3167bca",
+                                "a58c6aea5a0c9f8759a4154e46f544c8b03b8db1",
+                                "7106d216c29ca16a3504aa2bedad948ebcf4abc2",
+                            }
+                        ):
+                            raise RuntimeError(
+                                f"Unexpected differences between {frc} and {toc}"
+                            )
+                    from_commits.remove(frc.commit_hash)
+                    to_commits.remove(toc.commit_hash)
+                continue
+            for commit in from_values:
+                from_commits.remove(commit)
+            for commit in to_values:
+                to_commits.remove(commit)
+        # Another HACK: Patch-id is not stable for commits with binary files or for big changes across commits
+        # I.e. cherry-picking those from one branch into another will change patchid
+        if "pytorch/pytorch" in self.remote_url():
+            for excluded_commit in {
+                "8e09e20c1dafcdbdb45c2d1574da68a32e54a3a5",
+                "5f37e5c2a39c3acb776756a17730b865f0953432",
+                "b5222584e6d6990c6585981a936defd1af14c0ba",
+                "84d9a2e42d5ed30ec3b8b4140c38dd83abbce88d",
+                "f211ec90a6cdc8a2a5795478b5b5c8d7d7896f7e",
+            }:
+                if excluded_commit in from_commits:
+                    from_commits.remove(excluded_commit)
+
+        return (from_commits, to_commits)
+
+    def cherry_pick_commits(self, from_branch: str, to_branch: str) -> None:
+        orig_branch = self.current_branch()
+        self.checkout(to_branch)
+        from_commits, to_commits = self.compute_branch_diffs(from_branch, to_branch)
+        if len(from_commits) == 0:
+            print("Nothing to do")
+            self.checkout(orig_branch)
+            return
+        for commit in reversed(from_commits):
+            print(f"Cherry picking commit {commit}")
+            self.cherry_pick(commit)
+        self.checkout(orig_branch)
+
+    def push(self, branch: str, dry_run: bool, retry: int = 3) -> None:
+        for cnt in range(retry):
+            try:
+                if dry_run:
+                    self._run_git("push", "--dry-run", self.remote, branch)
+                else:
+                    self._run_git("push", self.remote, branch)
+            except RuntimeError as e:
+                print(f"{cnt} push attempt failed with {e}")
+                self.fetch()
+                self._run_git("rebase", f"{self.remote}/{branch}")
+
+    def head_hash(self) -> str:
+        return self._run_git("show-ref", "--hash", "HEAD").strip()
+
+    def remote_url(self) -> str:
+        return self._run_git("remote", "get-url", self.remote)
+
+    def gh_owner_and_name(self) -> Tuple[str, str]:
+        url = os.getenv("GIT_REMOTE_URL", None)
+        if url is None:
+            url = self.remote_url()
+        rc = RE_GITHUB_URL_MATCH.match(url)
+        if rc is None:
+            raise RuntimeError(f"Unexpected url format {url}")
+        return cast(Tuple[str, str], rc.groups())
+
+    def commit_message(self, ref: str) -> str:
+        return self._run_git("log", "-1", "--format=%B", ref)
+
+    def amend_commit_message(self, msg: str) -> None:
+        self._run_git("commit", "--amend", "-m", msg)
+
+    def diff(self, from_ref: str, to_ref: Optional[str] = None) -> str:
+        if to_ref is None:
+            return self._run_git("diff", f"{from_ref}^!")
+        return self._run_git("diff", f"{from_ref}..{to_ref}")
+
+
+def clone_repo(username: str, password: str, org: str, project: str) -> GitRepo:
+    path = tempfile.mkdtemp()
+    _check_output(
+        [
+            "git",
+            "clone",
+            f"https://{username}:{password}@github.com/{org}/{project}",
+            path,
+        ]
+    ).strip()
+    return GitRepo(path=path)
+
+
+class PeekableIterator(Iterator[str]):
+    def __init__(self, val: str) -> None:
+        self._val = val
+        self._idx = -1
+
+    def peek(self) -> Optional[str]:
+        if self._idx + 1 >= len(self._val):
+            return None
+        return self._val[self._idx + 1]
+
+    def __iter__(self) -> "PeekableIterator":
+        return self
+
+    def __next__(self) -> str:
+        rc = self.peek()
+        if rc is None:
+            raise StopIteration
+        self._idx += 1
+        return rc
+
+
+def patterns_to_regex(allowed_patterns: List[str]) -> Any:
+    """
+    pattern is glob-like, i.e. the only special sequences it has are:
+      - ? - matches single character
+      - * - matches any non-folder separator characters or no character
+      - ** - matches any characters or no character
+      Assuming that patterns are free of braces and backslashes
+      the only character that needs to be escaped are dot and plus
+    """
+    rc = "("
+    for idx, pattern in enumerate(allowed_patterns):
+        if idx > 0:
+            rc += "|"
+        pattern_ = PeekableIterator(pattern)
+        assert not any(c in pattern for c in "{}()[]\\")
+        for c in pattern_:
+            if c == ".":
+                rc += "\\."
+            elif c == "+":
+                rc += "\\+"
+            elif c == "*":
+                if pattern_.peek() == "*":
+                    next(pattern_)
+                    rc += ".*"
+                else:
+                    rc += "[^/]*"
+            else:
+                rc += c
+    rc += ")"
+    return re.compile(rc)
+
+
+def _shasum(value: str) -> str:
+    import hashlib
+
+    m = hashlib.sha256()
+    m.update(value.encode("utf-8"))
+    return m.hexdigest()
+
+
+def is_commit_hash(ref: str) -> bool:
+    "True if ref is hexadecimal number, else false"
+    try:
+        int(ref, 16)
+    except ValueError:
+        return False
+    return True
+
+
+def are_ghstack_branches_in_sync(
+    repo: GitRepo, head_ref: str, base_ref: Optional[str] = None
+) -> bool:
+    """Checks that diff between base and head is the same as diff between orig and its parent"""
+    orig_ref = re.sub(r"/head$", "/orig", head_ref)
+    if base_ref is None:
+        base_ref = re.sub(r"/head$", "/base", head_ref)
+    orig_diff_sha = _shasum(repo.diff(f"{repo.remote}/{orig_ref}"))
+    head_diff_sha = _shasum(
+        repo.diff(
+            base_ref if is_commit_hash(base_ref) else f"{repo.remote}/{base_ref}",
+            f"{repo.remote}/{head_ref}",
+        )
+    )
+    return orig_diff_sha == head_diff_sha
+
+
+def retries_decorator(
+    rc: Any = None, num_retries: int = 3
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    def decorator(f: Callable[..., T]) -> Callable[..., T]:
+        @wraps(f)
+        def wrapper(*args: List[Any], **kwargs: Dict[str, Any]) -> T:
+            for idx in range(num_retries):
+                try:
+                    return f(*args, **kwargs)
+                except Exception as e:
+                    print(
+                        f'Attempt {idx} of {num_retries} to call {f.__name__} failed with "{e}"'
+                    )
+                    pass
+            return cast(T, rc)
+
+        return wrapper
+
+    return decorator

--- a/.github/scripts/test_fetch_latest_green_commit.py
+++ b/.github/scripts/test_fetch_latest_green_commit.py
@@ -1,0 +1,155 @@
+from typing import Any, Dict, List
+from unittest import main, mock, TestCase
+
+from fetch_latest_green_commit import is_green, WorkflowCheck
+
+workflowNames = [
+    "pull",
+    "trunk",
+    "Lint",
+    "linux-binary-libtorch-pre-cxx11",
+    "android-tests",
+    "windows-binary-wheel",
+    "periodic",
+    "docker-release-builds",
+    "nightly",
+    "pr-labels",
+    "Close stale pull requests",
+    "Update S3 HTML indices for download.pytorch.org",
+    "Create Release",
+]
+
+requires = [
+    "pull",
+    "trunk",
+    "lint",
+    "linux-binary"
+]
+
+
+def set_workflow_job_status(
+    workflow: List[Dict[str, Any]], name: str, status: str
+) -> List[Dict[str, Any]]:
+    for check in workflow:
+        if check["workflowName"] == name:
+            check["conclusion"] = status
+    return workflow
+
+
+class TestChecks:
+    def make_test_checks(self) -> List[Dict[str, Any]]:
+        workflow_checks = []
+        for i in range(len(workflowNames)):
+            workflow_checks.append(
+                WorkflowCheck(
+                    workflowName=workflowNames[i],
+                    name="test/job",
+                    jobName="job",
+                    conclusion="success",
+                )._asdict()
+            )
+        return workflow_checks
+
+
+class TestPrintCommits(TestCase):
+    @mock.patch(
+        "fetch_latest_green_commit.get_commit_results",
+        return_value=TestChecks().make_test_checks(),
+    )
+    def test_all_successful(self, mock_get_commit_results: Any) -> None:
+        "Test with workflows are successful"
+        workflow_checks = mock_get_commit_results()
+        self.assertTrue(is_green("sha", requires, workflow_checks)[0])
+
+    @mock.patch(
+        "fetch_latest_green_commit.get_commit_results",
+        return_value=TestChecks().make_test_checks(),
+    )
+    def test_necessary_successful(self, mock_get_commit_results: Any) -> None:
+        "Test with necessary workflows are successful"
+        workflow_checks = mock_get_commit_results()
+        workflow_checks = set_workflow_job_status(
+            workflow_checks, workflowNames[8], "failed"
+        )
+        workflow_checks = set_workflow_job_status(
+            workflow_checks, workflowNames[9], "failed"
+        )
+        workflow_checks = set_workflow_job_status(
+            workflow_checks, workflowNames[10], "failed"
+        )
+        workflow_checks = set_workflow_job_status(
+            workflow_checks, workflowNames[11], "failed"
+        )
+        workflow_checks = set_workflow_job_status(
+            workflow_checks, workflowNames[12], "failed"
+        )
+        self.assertTrue(is_green("sha", requires, workflow_checks)[0])
+
+    @mock.patch(
+        "fetch_latest_green_commit.get_commit_results",
+        return_value=TestChecks().make_test_checks(),
+    )
+    def test_necessary_skipped(self, mock_get_commit_results: Any) -> None:
+        "Test with necessary job (ex: pull) skipped"
+        workflow_checks = mock_get_commit_results()
+        workflow_checks = set_workflow_job_status(workflow_checks, "pull", "skipped")
+        result = is_green("sha", requires, workflow_checks)
+        self.assertTrue(result[0])
+
+    @mock.patch(
+        "fetch_latest_green_commit.get_commit_results",
+        return_value=TestChecks().make_test_checks(),
+    )
+    def test_skippable_skipped(self, mock_get_commit_results: Any) -> None:
+        "Test with skippable jobs (periodic and docker-release-builds skipped"
+        workflow_checks = mock_get_commit_results()
+        workflow_checks = set_workflow_job_status(
+            workflow_checks, "periodic", "skipped"
+        )
+        workflow_checks = set_workflow_job_status(
+            workflow_checks, "docker-release-builds", "skipped"
+        )
+        self.assertTrue(is_green("sha", requires, workflow_checks))
+
+    @mock.patch(
+        "fetch_latest_green_commit.get_commit_results",
+        return_value=TestChecks().make_test_checks(),
+    )
+    def test_necessary_failed(self, mock_get_commit_results: Any) -> None:
+        "Test with necessary job (ex: Lint) failed"
+        workflow_checks = mock_get_commit_results()
+        workflow_checks = set_workflow_job_status(workflow_checks, "Lint", "failed")
+        result = is_green("sha", requires, workflow_checks)
+        self.assertFalse(result[0])
+        self.assertEqual(result[1], "Lint checks were not successful")
+
+    @mock.patch(
+        "fetch_latest_green_commit.get_commit_results",
+        return_value=TestChecks().make_test_checks(),
+    )
+    def test_skippable_failed(self, mock_get_commit_results: Any) -> None:
+        "Test with failing skippable jobs (ex: docker-release-builds) should pass"
+        workflow_checks = mock_get_commit_results()
+        workflow_checks = set_workflow_job_status(
+            workflow_checks, "periodic", "skipped"
+        )
+        workflow_checks = set_workflow_job_status(
+            workflow_checks, "docker-release-builds", "failed"
+        )
+        result = is_green("sha", requires, workflow_checks)
+        self.assertTrue(result[0])
+
+    @mock.patch("fetch_latest_green_commit.get_commit_results", return_value={})
+    def test_no_workflows(self, mock_get_commit_results: Any) -> None:
+        "Test with missing workflows"
+        workflow_checks = mock_get_commit_results()
+        result = is_green("sha", requires, workflow_checks)
+        self.assertFalse(result[0])
+        self.assertEqual(
+            result[1],
+            "missing required workflows: pull, trunk, lint, linux-binary",
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_fetch_latest_green_commit.py
+++ b/.github/scripts/test_fetch_latest_green_commit.py
@@ -19,12 +19,7 @@ workflowNames = [
     "Create Release",
 ]
 
-requires = [
-    "pull",
-    "trunk",
-    "lint",
-    "linux-binary"
-]
+requires = ["pull", "trunk", "lint", "linux-binary"]
 
 
 def set_workflow_job_status(

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,8 @@ jobs:
         echo ::group::setup Python environment
         python -m venv .venv/
         source .venv/bin/activate
-        pip install pip==23.0.1 pytest==7.2.0 rockset==1.0.3 jsonschema==4.17.3 numpy==1.24.1 pandas==2.1.4
+        pip install pip==23.0.1 pytest==7.2.0 rockset==1.0.3 \
+          jsonschema==4.17.3 numpy==1.24.1 pandas==2.1.4 boto3==1.19.12
         echo ::endgroup::
 
         # Test tools

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
         echo ::group::setup Python environment
         python -m venv .venv/
         source .venv/bin/activate
-        pip install pip==23.0.1 pytest==7.2.0 rockset==1.0.3 jsonschema==4.17.3
+        pip install pip==23.0.1 pytest==7.2.0 rockset==1.0.3 jsonschema==4.17.3 numpy==1.24.1
         echo ::endgroup::
 
         # Test tools

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ on:
       - mypy.ini
       - '**.py'
       - '**requirements.txt'
+      - .github/scripts/**
   push:
     branches:
       - main
@@ -13,6 +14,7 @@ on:
       - mypy.ini
       - '**.py'
       - '**requirements.txt'
+      - .github/scripts/**
 
 jobs:
   test-tools:
@@ -32,3 +34,21 @@ jobs:
 
         # Test tools
         python3 -m unittest discover -vs tools/tests -p 'test_*.py'
+
+  test-github-scripts:
+    name: Test github scripts
+    if: ${{ github.repository == 'pytorch/test-infra' }}
+    uses: ./.github/workflows/linux_job.yml
+    with:
+      docker-image: python:3.11.0-slim-bullseye
+      runner: linux.large
+      script: |
+        # Environment setup
+        echo ::group::setup Python environment
+        python -m venv .venv/
+        source .venv/bin/activate
+        pip install pip==23.0.1 pytest==7.2.0 rockset==1.0.3 jsonschema==4.17.3
+        echo ::endgroup::
+
+        # Test tools
+        pytest -v .github/scripts/test_*.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
         echo ::group::setup Python environment
         python -m venv .venv/
         source .venv/bin/activate
-        pip install pip==23.0.1 pytest==7.2.0 rockset==1.0.3 jsonschema==4.17.3 numpy==1.24.1
+        pip install pip==23.0.1 pytest==7.2.0 rockset==1.0.3 jsonschema==4.17.3 numpy==1.24.1 pandas==2.1.4
         echo ::endgroup::
 
         # Test tools


### PR DESCRIPTION
This will be needed by ExecuTorch too. So, I think it's time to move this to test-infra as a generic GHA.  The list includes:

* The `update-viablestrict` GHA that could be used by PyTorch and ExecuTorch.
* The `fetch_latest_green_commit.py` script and its unit tests.  I also refactor the `is_green` function to accept a list of required jobs that need to be pass before marking a commit as green.  Before this, the list is fixed https://github.com/pytorch/pytorch/blob/main/.github/scripts/fetch_latest_green_commit.py#L89-L94 to match what we have on PyTorch.
* Also move the test script and run it on CI.

### Testing

Locally on PyTorch:

```
(py3.11) huydo@huydo-mbp pytorch % python ~/Storage/mine/test-infra/.github/scripts/fetch_latest_green_commit.py --requires '["pull", "trunk", "lint", "linux-binary"]'
Checking 41a56f782856b2717da4c45998bdd3d42c70fa1f
RED: Lint checks were not successful
Checking fc30c4d769a58b7b7b84f73ef7bcfe84ab9504f8
RED: Lint checks were not successful
Checking 5b671ce48650c1769e1daa92a7462ff2b592eab4
RED: linux-binary-manywheel checks were not successful
Checking b7b1affe9780fe4106a07376d44a9fab8cd10446
RED: linux-binary-manywheel checks were not successful
Checking c0732c8d5e23dc1b66d970d6a7f12308d59b3fa0
RED: pull checks were not successful
Checking cd084c4909017b71a520d15b45129dc7ccfd8dbf
RED: pull checks were not successful
Checking abd759d50d87fa56078de95a444fe658de2983f9
RED: pull checks were not successful
Checking b369888bec64d7ee80ff347f513cf57d3e73a34a
RED: pull checks were not successful
Checking 6ac284122bf58fe45433943eeaba2c6c095ba7eb
RED: pull checks were not successful
Checking c6930aad46e5751eae7504655532d170f39db47e
RED: trunk checks were not successful
Checking 13d2cdffa29803c73cf6a4282894d5c4ee42cf1b
RED: trunk checks were not successful
Checking 77705e74865c70cae940f34c59c0a31250ce4431
RED: trunk checks were not successful
Checking 58e7ec5843e63ee044e0a4f5aa2583a056a64078
RED: trunk checks were not successful
Checking 364728b27bfdb6316354da9c0ba15de09b7fc9b6
RED: trunk checks were not successful
Checking 5ec2d7959d1ef1e8eeacc5e59bbf0f8b2dda1ea6
GREEN
5ec2d7959d1ef1e8eeacc5e59bbf0f8b2dda1ea6
```

On PyTorch, https://github.com/pytorch/pytorch/pull/118163 and manually dispatch the job https://github.com/pytorch/pytorch/actions/runs/7634906738/job/20799502532#step:2:15480