### PR TITLE
[ez] Update mergeability check job name in the flakiness exclusion list

### DIFF
--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -43,7 +43,7 @@ export const FLAKY_RULES_JSON =
 export const EXCLUDED_FROM_FLAKINESS = [
   "lint",
   "linux-docs",
-  "pr-dependencies-check",
+  "ghstack-mergeability-check",
 ];
 
 export function formDrciHeader(


### PR DESCRIPTION
In pytorch/pytorch#118258 mergeability check job was renamed to `ghstack-mergeability-check`. This PR updates flakiness exclusion accordingly.