### PR TITLE
Add use-only-dl-pytorch-org option to release matrix

### DIFF
--- a/.github/workflows/generate_binary_build_matrix.yml
+++ b/.github/workflows/generate_binary_build_matrix.yml
@@ -35,6 +35,10 @@ on:
         description: "Build with CPU?"
         default: "enable"
         type: string
+      use-only-dl-pytorch-org:
+        description: "Use only download.pytorch.org when generating wheel install command?"
+        default: "false"
+        type: string
     outputs:
       matrix:
         description: "Generated build matrix"
@@ -67,6 +71,9 @@ jobs:
           # limit pull request builds to one version of python unless ciflow/binaries/all is applied to the workflow
           # should not affect builds that are from events that are not the pull_request event
           LIMIT_PR_BUILDS: ${{ github.event_name == 'pull_request' && !contains( github.event.pull_request.labels.*.name, 'ciflow/binaries/all') }}
+          # This is used when testing release binaries only from download.pytorch.org.
+          # In cases when pipy binaries are not published yet.
+          USE_ONLY_DL_PYTORCH_ORG: ${{ inputs.use-only-dl-pytorch-org }}
         run: |
           set -eou pipefail
           MATRIX_BLOB="$(python3 tools/scripts/generate_binary_build_matrix.py)"

--- a/tools/tests/test_generate_binary_build_matrix.py
+++ b/tools/tests/test_generate_binary_build_matrix.py
@@ -26,6 +26,7 @@ class GenerateBuildMatrixTest(TestCase):
             "enable" if rocm else "disable",
             "enable" if cpu else "disable",
             "false",
+            "false",
         )
 
         expected_json_filename = os.path.join(ASSETS_DIR, reference_output_file)


### PR DESCRIPTION
Add option to use only our custom index download.pytorch.org. This will be used in validations in cases when pypi binaries are not published yet.
Test
```
python generate_binary_build_matrix.py --channel release --use-only-dl-pytorch-org true
{"include": [{"python_version": "3.8", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_8-cpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/manylinux-builder:cuda11.8", "package_type": "manywheel", "build_name": "manywheel-py3_8-cuda11_8", "validation_runner": "linux.g5.4xlarge.nvidia.gpu", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.8", "gpu_arch_type": "cuda", "gpu_arch_version": "12.1", "desired_cuda": "cu121", "container_image": "pytorch/manylinux-builder:cuda12.1", "package_type": "manywheel", "build_name": "manywheel-py3_8-cuda12_1", "validation_runner": "linux.g5.4xlarge.nvidia.gpu", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.8", "gpu_arch_type": "rocm", "gpu_arch_version": "5.6", "desired_cuda": "rocm5.6", "container_image": "pytorch/manylinux-builder:rocm5.6", "package_type": "manywheel", "build_name": "manywheel-py3_8-rocm5_6", "validation_runner": "linux.2xlarge", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.6", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.8", "gpu_arch_type": "rocm", "gpu_arch_version": "5.7", "desired_cuda": "rocm5.7", "container_image": "pytorch/manylinux-builder:rocm5.7", "package_type": "manywheel", "build_name": "manywheel-py3_8-rocm5_7", "validation_runner": "linux.2xlarge", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.7", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.9", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_9-cpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/manylinux-builder:cuda11.8", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda11_8", "validation_runner": "linux.g5.4xlarge.nvidia.gpu", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "12.1", "desired_cuda": "cu121", "container_image": "pytorch/manylinux-builder:cuda12.1", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda12_1", "validation_runner": "linux.g5.4xlarge.nvidia.gpu", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "5.6", "desired_cuda": "rocm5.6", "container_image": "pytorch/manylinux-builder:rocm5.6", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm5_6", "validation_runner": "linux.2xlarge", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.6", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "5.7", "desired_cuda": "rocm5.7", "container_image": "pytorch/manylinux-builder:rocm5.7", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm5_7", "validation_runner": "linux.2xlarge", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.7", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.10", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_10-cpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/manylinux-builder:cuda11.8", "package_type": "manywheel", "build_name": "manywheel-py3_10-cuda11_8", "validation_runner": "linux.g5.4xlarge.nvidia.gpu", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.10", "gpu_arch_type": "cuda", "gpu_arch_version": "12.1", "desired_cuda": "cu121", "container_image": "pytorch/manylinux-builder:cuda12.1", "package_type": "manywheel", "build_name": "manywheel-py3_10-cuda12_1", "validation_runner": "linux.g5.4xlarge.nvidia.gpu", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.10", "gpu_arch_type": "rocm", "gpu_arch_version": "5.6", "desired_cuda": "rocm5.6", "container_image": "pytorch/manylinux-builder:rocm5.6", "package_type": "manywheel", "build_name": "manywheel-py3_10-rocm5_6", "validation_runner": "linux.2xlarge", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.6", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.10", "gpu_arch_type": "rocm", "gpu_arch_version": "5.7", "desired_cuda": "rocm5.7", "container_image": "pytorch/manylinux-builder:rocm5.7", "package_type": "manywheel", "build_name": "manywheel-py3_10-rocm5_7", "validation_runner": "linux.2xlarge", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.7", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.11", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_11-cpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.11", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/manylinux-builder:cuda11.8", "package_type": "manywheel", "build_name": "manywheel-py3_11-cuda11_8", "validation_runner": "linux.g5.4xlarge.nvidia.gpu", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.11", "gpu_arch_type": "cuda", "gpu_arch_version": "12.1", "desired_cuda": "cu121", "container_image": "pytorch/manylinux-builder:cuda12.1", "package_type": "manywheel", "build_name": "manywheel-py3_11-cuda12_1", "validation_runner": "linux.g5.4xlarge.nvidia.gpu", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.11", "gpu_arch_type": "rocm", "gpu_arch_version": "5.6", "desired_cuda": "rocm5.6", "container_image": "pytorch/manylinux-builder:rocm5.6", "package_type": "manywheel", "build_name": "manywheel-py3_11-rocm5_6", "validation_runner": "linux.2xlarge", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.6", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.11", "gpu_arch_type": "rocm", "gpu_arch_version": "5.7", "desired_cuda": "rocm5.7", "container_image": "pytorch/manylinux-builder:rocm5.7", "package_type": "manywheel", "build_name": "manywheel-py3_11-rocm5_7", "validation_runner": "linux.2xlarge", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.7", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.12", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_12-cpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.12", "gpu_arch_type": "cuda", "gpu_arch_version": "11.8", "desired_cuda": "cu118", "container_image": "pytorch/manylinux-builder:cuda11.8", "package_type": "manywheel", "build_name": "manywheel-py3_12-cuda11_8", "validation_runner": "linux.g5.4xlarge.nvidia.gpu", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.12", "gpu_arch_type": "cuda", "gpu_arch_version": "12.1", "desired_cuda": "cu121", "container_image": "pytorch/manylinux-builder:cuda12.1", "package_type": "manywheel", "build_name": "manywheel-py3_12-cuda12_1", "validation_runner": "linux.g5.4xlarge.nvidia.gpu", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.12", "gpu_arch_type": "rocm", "gpu_arch_version": "5.6", "desired_cuda": "rocm5.6", "container_image": "pytorch/manylinux-builder:rocm5.6", "package_type": "manywheel", "build_name": "manywheel-py3_12-rocm5_6", "validation_runner": "linux.2xlarge", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.6", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}, {"python_version": "3.12", "gpu_arch_type": "rocm", "gpu_arch_version": "5.7", "desired_cuda": "rocm5.7", "container_image": "pytorch/manylinux-builder:rocm5.7", "package_type": "manywheel", "build_name": "manywheel-py3_12-rocm5_7", "validation_runner": "linux.2xlarge", "installation": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.7", "channel": "release", "upload_to_base_bucket": "no", "stable_version": "2.2.0"}]}
```