### PR TITLE
Fix indexes for mixed upper/lower case names

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -252,7 +252,7 @@ class S3Index:
         )
 
     def obj_to_package_name(self, obj: S3Object) -> str:
-        return path.basename(obj.key).split('-', 1)[0]
+        return path.basename(obj.key).split('-', 1)[0].lower()
 
     def to_legacy_html(
         self,


### PR DESCRIPTION
According to [PEP508](https://peps.python.org/pep-0508/#names) package names should match case insensitive regex, i.e. both `Pillow-10.1.0` and `pillow-10.2.0` should be part of the same index

Achieve it by adding `.lower()` to `obj_to_package_name` method

Test Plan: `manage.py --generate-pep503 --do-not-upload whl/test` and observe that PEP503 index generated for pillow includes both old a new packages