### PR TITLE
Replace AWS credentials on upload-tutorials-stats with OIDC

### DIFF
--- a/.github/workflows/upload-tutorials-stats.yml
+++ b/.github/workflows/upload-tutorials-stats.yml
@@ -18,26 +18,35 @@ jobs:
   get-tutorials-stats:
     if: ${{ github.repository == 'pytorch/test-infra' }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
+      - name: Configure aws credentials
+        id: aws_creds
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_upload-tutorials-stats
+          aws-region: us-east-1
+
       - name: Checkout the tutorials repo
         uses: actions/checkout@v3
         with:
           repository: 'pytorch/tutorials'
           path: './tutorials'
           fetch-depth: 0
+
       - name: Checkout the test-infra repo
         uses: actions/checkout@v3
         with:
           path: test-infra
+
       - name: Install dependencies
         run: |
           python3 -m pip install boto3==1.26.69 typing==3.7.4.3
 
       - name: Run the script
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.TORCHCI_TUTORIAL_DYNAMODB_READ_WRITE_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.TORCHCI_TUTORIAL_DYNAMODB_READ_WRITE_AWS_SECRET_ACCESS_KEY }}
+        # if: ${{ github.event_name == 'schedule' }}
         run: |
           set -x
           python3 test-infra/.github/scripts/get_tutorials_stats.py

--- a/.github/workflows/upload-tutorials-stats.yml
+++ b/.github/workflows/upload-tutorials-stats.yml
@@ -46,7 +46,7 @@ jobs:
           python3 -m pip install boto3==1.26.69 typing==3.7.4.3
 
       - name: Run the script
-        # if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'schedule' }}
         run: |
           set -x
           python3 test-infra/.github/scripts/get_tutorials_stats.py

--- a/.github/workflows/upload-tutorials-stats.yml
+++ b/.github/workflows/upload-tutorials-stats.yml
@@ -4,10 +4,6 @@ name: Upload tutorials stat
 
 # Controls when the workflow will run
 on:
-  pull_request: 
-    paths:
-      - .github/workflows/upload-tutorials-stats.yml
-      - .github/scripts/get_tutorials_stats.py
   schedule:
   # Run this once per day.
     - cron: "0 0 * * *"
@@ -46,7 +42,6 @@ jobs:
           python3 -m pip install boto3==1.26.69 typing==3.7.4.3
 
       - name: Run the script
-        if: ${{ github.event_name == 'schedule' }}
         run: |
           set -x
           python3 test-infra/.github/scripts/get_tutorials_stats.py


### PR DESCRIPTION
This fixes the broken workflow after https://github.com/pytorch-labs/pytorch-gha-infra/pull/342 lands

### Testing

Manually update gha_workflow_upload-tutorials-stats with the content of https://github.com/pytorch-labs/pytorch-gha-infra/pull/342 and let the CI run the job https://github.com/pytorch/test-infra/actions/runs/7750598806/job/21137192582?pr=4918

