### PR TITLE
Add log classifier rule for ET model tests

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -208,6 +208,23 @@ pattern = '^\s*(test.*) failed - num_retries_left:'
 name = 'Python flaky unittest - errored'
 pattern = '^\s*(test.*) errored - num_retries_left:'
 
+# TODO (huydhn): Update ET test script to include the model name in the error message
+[[rule]]
+name = 'ExecuTorch portable model test - failed'
+pattern = 'Portable fp32 error'
+
+[[rule]]
+name = 'ExecuTorch quantized portable model test - failed'
+pattern = 'Portable q8 error'
+
+[[rule]]
+name = 'ExecuTorch delegation model test - failed'
+pattern = 'Delegation fp32 error'
+
+[[rule]]
+name = 'ExecuTorch quantized delegation model test - failed'
+pattern = 'Delegation q8 error'
+
 [[rule]]
 name = 'Python RuntimeError'
 pattern = '^RuntimeError: .*'


### PR DESCRIPTION
ExecuTorch failures in trunk are not well captured atm, for example https://github.com/pytorch/pytorch/actions/runs/7742624704/job/21112923644

### Testing

`cargo lambda invoke --data-file=fixtures/request.json` locally with an example in trunk https://hud.pytorch.org/pytorch/pytorch/commit/4a5a3bcc89c7658499aa36f24b02ec4648f41220

