### PR TITLE
Update ghstack-mergeability-check flakiness rules

### DIFF
--- a/stats/flaky-rules.json
+++ b/stats/flaky-rules.json
@@ -53,14 +53,6 @@
   },
   {
     "name": "ghstack-mergeability-check",
-    "captures": ["Process completed with exit code 1"]
-  },
-  {
-    "name": "ghstack-mergeability-check",
-    "captures": ["returned non-zero exit code 128"]
-  },
-  {
-    "name": "ghstack-mergeability-check",
-    "captures": ["returned non-zero exit code 1"]
+    "captures": ["fatal: ambiguous argument 'origin/gh.*"]
   }
 ]


### PR DESCRIPTION
Detect only real flaky issues, like this https://github.com/pytorch/pytorch/actions/runs/7745629309/job/21122066764

(it's very rare, only one instance in the recent week)

Other mergeability failures are ligitimate:
https://github.com/pytorch/pytorch/actions/workflows/check_mergeability_ghstack.yml