### PR TITLE
Send the classification category when cherry picking a PR

### DIFF
--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -456,6 +456,7 @@ The explanation needs to be clear on why this is needed. Here are some good exam
     await this.dispatchEvent("try-cherry-pick", {
       branch: branch,
       fixes: fixes,
+      classification: classification,
       requiresIssue: classificationData.requiresIssue,
       classificationHelp: classificationData.help,
     });


### PR DESCRIPTION
Fixes a small bug in https://github.com/pytorch/test-infra/pull/4758 where the classification category itself wasn't sent over in the dispatch event.