### PR TITLE
Remove linter rerun logic

### DIFF
--- a/torchci/lib/bot/retryBot.ts
+++ b/torchci/lib/bot/retryBot.ts
@@ -79,11 +79,9 @@ async function retryCurrentWorkflow(
       return true;
     }
 
-    // don't rerun if the linter failed on the actual linting steps, which have the nonretryable suffix
+    // don't rerun linter
     if (workflowName.toLocaleLowerCase() === "lint") {
-      return !doesLookLikeUserFailure(job, (step) =>
-        step.name.toLowerCase().includes("(nonretryable)")
-      );
+      return false;
     }
 
     // for builds, don't rerun if it failed on the actual build step

--- a/torchci/lib/bot/retryBot.ts
+++ b/torchci/lib/bot/retryBot.ts
@@ -79,11 +79,6 @@ async function retryCurrentWorkflow(
       return true;
     }
 
-    // don't rerun linter
-    if (workflowName.toLocaleLowerCase() === "lint") {
-      return false;
-    }
-
     // for builds, don't rerun if it failed on the actual build step
     if (
       job.name.toLocaleLowerCase().startsWith("build") &&

--- a/torchci/test/retryBot.test.ts
+++ b/torchci/test/retryBot.test.ts
@@ -46,7 +46,7 @@ describe("retry-bot", () => {
       )
       .reply(
         200,
-        '{retryable_workflows: ["lint", "pull", "trunk", "linux-binary", "windows-binary"]}'
+        '{retryable_workflows: ["", "pull", "trunk", "linux-binary", "windows-binary"]}'
       );
 
     process.env.ROCKSET_API_KEY = "random key doesnt matter";
@@ -88,88 +88,7 @@ describe("retry-bot", () => {
       )
       .reply(
         200,
-        '{retryable_workflows: ["lint", "pull", "trunk", "linux-binary", "windows-binary"]}'
-      );
-
-    process.env.ROCKSET_API_KEY = "random key doesnt matter";
-    const rockset = nock("https://api.rs2.usw2.rockset.com")
-      .persist()
-      .post((uri) => true)
-      .reply(200, { results: [] });
-
-    await probot.receive(event);
-
-    handleScope(scope);
-    handleScope(rockset);
-  });
-
-  test("rerun lint if no nonretryable step failed", async () => {
-    const event = requireDeepCopy("./fixtures/workflow_run.completed.json");
-    event.payload.workflow_run.name = "Lint";
-    const workflow_jobs = requireDeepCopy("./fixtures/workflow_jobs.json");
-    workflow_jobs.jobs[0].conclusion = "failure";
-    workflow_jobs.jobs[1].conclusion = "failure";
-
-    const owner = event.payload.repository.owner.login;
-    const repo = event.payload.repository.name;
-    const attempt_number = event.payload.workflow_run.run_attempt;
-    const run_id = event.payload.workflow_run.id;
-
-    const scope = nock("https://api.github.com")
-      .get(
-        `/repos/${owner}/${repo}/actions/runs/${run_id}/attempts/${attempt_number}/jobs?page=1&per_page=100`
-      )
-      .reply(200, workflow_jobs)
-      .post(`/repos/${owner}/${repo}/actions/runs/${run_id}/rerun-failed-jobs`)
-      .reply(200)
-      .get(
-        `/repos/${owner}/${repo}/contents/${encodeURIComponent(
-          ".github/pytorch-probot.yml"
-        )}`
-      )
-      .reply(
-        200,
-        '{retryable_workflows: ["lint", "pull", "trunk", "linux-binary", "windows-binary"]}'
-      );
-
-    process.env.ROCKSET_API_KEY = "random key doesnt matter";
-    const rockset = nock("https://api.rs2.usw2.rockset.com")
-      .persist()
-      .post((uri) => true)
-      .reply(200, { results: [] });
-
-    await probot.receive(event);
-
-    handleScope(scope);
-    handleScope(rockset);
-  });
-
-  test("don't rerun lint if nonretryable step failed", async () => {
-    const event = requireDeepCopy("./fixtures/workflow_run.completed.json");
-    event.payload.workflow_run.name = "Lint";
-    const workflow_jobs = requireDeepCopy("./fixtures/workflow_jobs.json");
-    workflow_jobs.jobs[3].conclusion = "failure";
-    workflow_jobs.jobs[3].steps[0].name = "Do the lints (nonretryable)";
-    workflow_jobs.jobs[3].steps[0].conclusion = "failure";
-
-    const owner = event.payload.repository.owner.login;
-    const repo = event.payload.repository.name;
-    const attempt_number = event.payload.workflow_run.run_attempt;
-    const run_id = event.payload.workflow_run.id;
-
-    const scope = nock("https://api.github.com")
-      .get(
-        `/repos/${owner}/${repo}/actions/runs/${run_id}/attempts/${attempt_number}/jobs?page=1&per_page=100`
-      )
-      .reply(200, workflow_jobs)
-      .get(
-        `/repos/${owner}/${repo}/contents/${encodeURIComponent(
-          ".github/pytorch-probot.yml"
-        )}`
-      )
-      .reply(
-        200,
-        '{retryable_workflows: ["lint", "pull", "trunk", "linux-binary", "windows-binary"]}'
+        '{retryable_workflows: ["", "pull", "trunk", "linux-binary", "windows-binary"]}'
       );
 
     process.env.ROCKSET_API_KEY = "random key doesnt matter";

--- a/torchci/test/retryBot.test.ts
+++ b/torchci/test/retryBot.test.ts
@@ -46,7 +46,7 @@ describe("retry-bot", () => {
       )
       .reply(
         200,
-        '{retryable_workflows: ["", "pull", "trunk", "linux-binary", "windows-binary"]}'
+        '{retryable_workflows: ["pull", "trunk", "linux-binary", "windows-binary"]}'
       );
 
     process.env.ROCKSET_API_KEY = "random key doesnt matter";
@@ -88,7 +88,7 @@ describe("retry-bot", () => {
       )
       .reply(
         200,
-        '{retryable_workflows: ["", "pull", "trunk", "linux-binary", "windows-binary"]}'
+        '{retryable_workflows: ["pull", "trunk", "linux-binary", "windows-binary"]}'
       );
 
     process.env.ROCKSET_API_KEY = "random key doesnt matter";

--- a/torchci/test/retryBot.test.ts
+++ b/torchci/test/retryBot.test.ts
@@ -128,7 +128,7 @@ describe("retry-bot", () => {
       )
       .reply(
         200,
-        '{retryable_workflows: ["lint", "pull", "trunk", "linux-binary", "windows-binary"]}'
+        '{retryable_workflows: ["pull", "trunk", "linux-binary", "windows-binary"]}'
       )
       .post(
         `/repos/${owner}/${repo}/actions/jobs/${workflow_jobs.jobs[0].id}/rerun`
@@ -172,7 +172,7 @@ describe("retry-bot", () => {
       )
       .reply(
         200,
-        '{retryable_workflows: ["lint", "pull", "trunk", "linux-binary", "windows-binary"]}'
+        '{retryable_workflows: ["pull", "trunk", "linux-binary", "windows-binary"]}'
       );
 
     process.env.ROCKSET_API_KEY = "random key doesnt matter";
@@ -213,7 +213,7 @@ describe("retry-bot", () => {
       )
       .reply(
         200,
-        '{retryable_workflows: ["lint", "pull", "trunk", "linux-binary", "windows-binary"]}'
+        '{retryable_workflows: ["pull", "trunk", "linux-binary", "windows-binary"]}'
       )
       .post(
         `/repos/${owner}/${repo}/actions/runs/${prev_run_id}/rerun-failed-jobs`
@@ -268,7 +268,7 @@ describe("retry-bot", () => {
       )
       .reply(
         200,
-        '{retryable_workflows: ["lint", "pull", "trunk", "linux-binary", "windows-binary"]}'
+        '{retryable_workflows: ["pull", "trunk", "linux-binary", "windows-binary"]}'
       )
       .post(
         `/repos/${owner}/${repo}/actions/runs/${prev_run_id}/rerun-failed-jobs`
@@ -318,7 +318,7 @@ describe("retry-bot", () => {
       )
       .reply(
         200,
-        '{retryable_workflows: ["lint", "pull", "trunk", "linux-binary", "windows-binary"]}'
+        '{retryable_workflows: ["pull", "trunk", "linux-binary", "windows-binary"]}'
       )
       .post(
         `/repos/${owner}/${repo}/actions/runs/${prev_run_id}/rerun-failed-jobs`
@@ -355,7 +355,7 @@ describe("retry-bot", () => {
       )
       .reply(
         200,
-        '{retryable_workflows: ["lint", "pull", "trunk", "linux-binary", "windows-binary"]}'
+        '{retryable_workflows: ["pull", "trunk", "linux-binary", "windows-binary"]}'
       );
 
     await probot.receive(event);
@@ -365,7 +365,7 @@ describe("retry-bot", () => {
 
   test("get more pages of workflow_jobs", async () => {
     const event = requireDeepCopy("./fixtures/workflow_run.completed.json");
-    event.payload.workflow_run.name = "Lint";
+    event.payload.workflow_run.name = "Pull";
     const workflow_jobs1 = requireDeepCopy("./fixtures/workflow_jobs.json");
     const workflow_jobs2 = requireDeepCopy("./fixtures/workflow_jobs.json");
     workflow_jobs2.jobs[0].conclusion = "failure";
@@ -396,7 +396,7 @@ describe("retry-bot", () => {
       )
       .reply(
         200,
-        '{retryable_workflows: ["lint", "pull", "trunk", "linux-binary", "windows-binary"]}'
+        '{retryable_workflows: ["pull", "trunk", "linux-binary", "windows-binary"]}'
       );
 
     process.env.ROCKSET_API_KEY = "random key doesnt matter";


### PR DESCRIPTION
Currently lint jobs are re-run even if it's an actual lint failure, because `step.name.toLowerCase().includes("(nonretryable)")` doesn't work since moving to Nova.

This PR removes the lint retrying logic in conjunction with removing lint from retryable workflows in https://github.com/pytorch/pytorch/pull/126806