### PR TITLE
Fix test insight page

### DIFF
--- a/.github/workflows/usage-log-aggregator-lambda.yml
+++ b/.github/workflows/usage-log-aggregator-lambda.yml
@@ -1,0 +1,49 @@
+name: Test and deploy usage-log-aggregator lambda
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/usage-log-aggregator-lambda.yml
+      - aws/lambda/usage-log-aggregator/**
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/usage-log-aggregator-lambda.yml
+      - aws/lambda/usage-log-aggregator/**
+
+defaults:
+  run:
+    working-directory: aws/lambda/usage-log-aggregator/
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+          cache: pip
+      - run: pip install -r requirements.txt
+      - run: pytest -v test_lambda_function.py
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+          cache: pip
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1.7.0
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_usage-log-aggregator-lambda
+          aws-region: us-east-1
+      - run: make deploy

--- a/aws/lambda/usage-log-aggregator/Makefile
+++ b/aws/lambda/usage-log-aggregator/Makefile
@@ -1,0 +1,15 @@
+prepare: clean
+	mkdir -p ./packages
+	pip3 install --target ./packages -r requirements.txt
+	cd packages && zip -r ../usage-log-aggregator.zip .
+	zip -g usage-log-aggregator.zip lambda_function.py
+
+deploy: prepare
+	# NB: Don't run this manually on your MacOS laptop as this will ends up with a broken
+	# numpy on AWS lambda. This needs to be run on a Linux server compatible with lambda
+	# instead
+	aws s3 cp usage-log-aggregator.zip s3://gha-artifacts/lambda/usage-log-aggregator.zip
+	aws lambda update-function-code --function-name usage-log-aggregator --s3-bucket gha-artifacts --s3-key lambda/usage-log-aggregator.zip
+
+clean:
+	rm -rf usage-log-aggregator.zip packages

--- a/aws/lambda/usage-log-aggregator/lambda_function.py
+++ b/aws/lambda/usage-log-aggregator/lambda_function.py
@@ -108,7 +108,12 @@ async def _process_raw_logs(raw_logs: List[Tuple[str, str, str]]) -> Dict[str, s
         stop_time = 0
 
         for line in usage_log.splitlines():
-            datapoint = json.loads(line)
+            try:
+                datapoint = json.loads(line)
+            except json.decoder.JSONDecodeError as error:
+                # This is to handle invalid lines on the log, it's ok to ingore them
+                warn(f"Failed to load {line}: {error}")
+                continue
 
             if (
                 "time" not in datapoint
@@ -259,12 +264,12 @@ def lambda_handler(event: Any, context: Any):
 
 if os.getenv("DEBUG", "0") == "1":
     mock_body = {
-        "jobName": "macos-12-py3-arm64 / test (default, 2, 3, macos-m1-12)",
+        "jobName": "win-vs2019-cpu-py3 / test (default, 1, 3, windows.4xlarge.nonephemeral)",
         "workflowIds": [
-            "7823281540",
+            "7824285997",
         ],
         "jobIds": [
-            21344164554,
+            21347334930,
         ],
     }
     # For local development

--- a/aws/lambda/usage-log-aggregator/lambda_function.py
+++ b/aws/lambda/usage-log-aggregator/lambda_function.py
@@ -124,14 +124,14 @@ async def _process_raw_logs(raw_logs: List[Tuple[str, str, str]]) -> Dict[str, s
             if "per_process_cpu_info" not in datapoint:
                 total_mem_usage.append(0)
             else:
-                total_mem_usage.append(
-                    sum(
-                        [
-                            e.get("rss_memory", 0)
-                            for e in datapoint["per_process_cpu_info"]
-                        ]
-                    )
-                )
+                s = 0
+                for e in datapoint["per_process_cpu_info"]:
+                    v = e.get("rss_memory", 0)
+                    # The value can be None
+                    if not v:
+                        v = 0
+                    s += v
+                total_mem_usage.append(s)
 
             # TODO: Remove this logic once https://github.com/pytorch/pytorch/pull/86250 has been running for a while.
             #  In the meantime, both keys can be presented in usage log
@@ -145,14 +145,14 @@ async def _process_raw_logs(raw_logs: List[Tuple[str, str, str]]) -> Dict[str, s
             if "per_process_gpu_info" not in datapoint:
                 total_gpu_mem_usage.append(0)
             else:
-                total_gpu_mem_usage.append(
-                    sum(
-                        [
-                            e.get("gpu_memory", 0)
-                            for e in datapoint["per_process_gpu_info"]
-                        ]
-                    )
-                )
+                s = 0
+                for e in datapoint["per_process_gpu_info"]:
+                    v = e.get("gpu_memory", 0)
+                    # The value can be None
+                    if not v:
+                        v = 0
+                    s += v
+                total_gpu_mem_usage.append(s)
 
         uniq_id = f"{workflow_id} / {job_id}"
         # Let's also keep the starting time and ending time of the job run, so the usage can be mapped to
@@ -257,50 +257,12 @@ def lambda_handler(event: Any, context: Any):
 
 if os.getenv("DEBUG", "0") == "1":
     mock_body = {
-        "jobName": "win-vs2019-cpu-py3 / test (functorch, 1, 1, windows.4xlarge)",
+        "jobName": "linux-focal-cuda12.1-py3.10-gcc9-sm86 / test (default, 2, 5, linux.g5.4xlarge.nvidia.gpu)",
         "workflowIds": [
-            "3190793389",
-            "3190721571",
-            "3190637266",
-            "3190634736",
-            "3190506239",
-            "3190443293",
-            "3189983758",
-            "3189709206",
-            "3189651768",
-            "3189512294",
-            "3189428641",
-            "3189345038",
-            "3189314334",
-            "3189282022",
-            "3189125171",
-            "3189013497",
-            "3188150968",
-            "3188140050",
-            "3188068038",
-            "3188079769",
+            "7823281538",
         ],
         "jobIds": [
-            8725009912,
-            8724904966,
-            8724811861,
-            8724762262,
-            8724298558,
-            8724203742,
-            8722636066,
-            8721853447,
-            8721609722,
-            8721288973,
-            8720825008,
-            8720594880,
-            8720515505,
-            8720468097,
-            8720016748,
-            8719644525,
-            8717292485,
-            8717237728,
-            8716982768,
-            8717015257,
+            21344846871,
         ],
     }
     # For local development

--- a/aws/lambda/usage-log-aggregator/lambda_function.py
+++ b/aws/lambda/usage-log-aggregator/lambda_function.py
@@ -85,7 +85,7 @@ async def _get_usage_log_prefix(job_name: str) -> str:
     shard_count = m.group("s_count")
     platform = m.group("platform")
 
-    return f"usage-log-test-{shard_name}-{shard_id}-{shard_count}-{platform}"
+    return f"logs-test-{shard_name}-{shard_id}-{shard_count}-{platform}"
 
 
 async def _process_raw_logs(raw_logs: List[Tuple[str, str, str]]) -> Dict[str, str]:

--- a/aws/lambda/usage-log-aggregator/test_lambda_function.py
+++ b/aws/lambda/usage-log-aggregator/test_lambda_function.py
@@ -8,7 +8,6 @@ from lambda_function import (
     ARTIFACTS_S3_BUCKET,
     get_usage_log,
     PYTORCH,
-    RUN_ATTEMPT,
 )
 
 TEST_SAMPLES_DIR = "test_samples"
@@ -112,5 +111,5 @@ async def test_get_usage_log():
                 assert content == f.read()
 
     for i in range(NUMBER_OF_SAMPLES):
-        key = f"{PYTORCH}/{PYTORCH}/{i}/{RUN_ATTEMPT}/artifact/{TEST_PREFIX}_{i}.zip"
+        key = f"{PYTORCH}/{PYTORCH}/{i}/1/artifact/{TEST_PREFIX}_{i}.zip"
         m.get_object.assert_any_call(Bucket=ARTIFACTS_S3_BUCKET, Key=key)

--- a/aws/lambda/usage-log-aggregator/test_lambda_function.py
+++ b/aws/lambda/usage-log-aggregator/test_lambda_function.py
@@ -21,7 +21,7 @@ async def test_get_usage_log_prefix():
     cases = [
         {
             "job_name": "win-vs2019-cpu-py3 / test (functorch, 2, 4, windows.4xlarge)",
-            "expected": "usage-log-test-functorch-2-4-windows.4xlarge",
+            "expected": "logs-test-functorch-2-4-windows.4xlarge",
         },
         {
             "job_name": "not matched",

--- a/torchci/components/TestInsights.tsx
+++ b/torchci/components/TestInsights.tsx
@@ -22,8 +22,8 @@ export default function TestInsightsLink({
   }
 
   const workflowId = job.htmlUrl?.match(
-    // https://github.com/pytorch/pytorch/actions/runs/3228501114/jobs/5284857665
-    new RegExp("^.+/(?<workflowId>\\d+)/jobs/.+$")
+    // https://github.com/pytorch/pytorch/actions/runs/3228501114/job/5284857665
+    new RegExp("^.+/(?<workflowId>\\d+)/job/.+$")
   )?.groups?.workflowId;
 
   const jobId = job.logUrl?.match(

--- a/torchci/components/TestInsights.tsx
+++ b/torchci/components/TestInsights.tsx
@@ -21,15 +21,19 @@ export default function TestInsightsLink({
     return <></>;
   }
 
-  const workflowId = job.htmlUrl?.match(
-    // https://github.com/pytorch/pytorch/actions/runs/3228501114/job/5284857665
-    new RegExp("^.+/(?<workflowId>\\d+)/job/.+$")
-  )?.groups?.workflowId;
+  const workflowId =
+    job.workflowId ??
+    job.htmlUrl?.match(
+      // https://github.com/pytorch/pytorch/actions/runs/3228501114/job/5284857665
+      new RegExp("^.+/(?<workflowId>\\d+)/job/.+$")
+    )?.groups?.workflowId;
 
-  const jobId = job.logUrl?.match(
-    // https://ossci-raw-job-status.s3.amazonaws.com/log/9018026324
-    new RegExp("^.+/log/(?<jobId>\\d+)$")
-  )?.groups?.jobId;
+  const jobId =
+    job.id ??
+    job.logUrl?.match(
+      // https://ossci-raw-job-status.s3.amazonaws.com/log/9018026324
+      new RegExp("^.+/log/(?<jobId>\\d+)$")
+    )?.groups?.jobId;
 
   if (workflowId === null || jobId === null) {
     return <></>;

--- a/torchci/pages/test/insights.tsx
+++ b/torchci/pages/test/insights.tsx
@@ -147,6 +147,24 @@ function GetUsage({
     return <></>;
   }
 
+  // When the returning data is empty, we know that the lambda has failed to find the
+  // usage log. This is expected to happend on MacOS and ROCm where the monitor script
+  // isn't run
+  if (data["timestamp"] === undefined || data["timestamp"].length === 0) {
+    return (
+      <>
+        The job didn't generate any usage stats, so there is nothing to analyze.
+        Please submit an issue to PyTorch Dev Infra team.
+        <a
+          target="_blank"
+          href="https://github.com/pytorch/pytorch/issues/new/choose"
+        >
+          Create an issue
+        </a>
+      </>
+    );
+  }
+
   const transformedData = [];
   // Transform the data a bit to fit into the same rockset schema
   for (const idx in data["timestamp"]) {

--- a/torchci/pages/test/insights.tsx
+++ b/torchci/pages/test/insights.tsx
@@ -153,7 +153,7 @@ function GetUsage({
   if (data["timestamp"] === undefined || data["timestamp"].length === 0) {
     return (
       <>
-        The job didn't generate any usage stats, so there is nothing to analyze.
+        The job didn&apos;t generate any usage stats, so there is nothing to analyze.
         Please submit an issue to PyTorch Dev Infra team.
         <a
           target="_blank" rel="noreferrer"

--- a/torchci/pages/test/insights.tsx
+++ b/torchci/pages/test/insights.tsx
@@ -156,7 +156,7 @@ function GetUsage({
         The job didn't generate any usage stats, so there is nothing to analyze.
         Please submit an issue to PyTorch Dev Infra team.
         <a
-          target="_blank"
+          target="_blank" rel="noreferrer"
           href="https://github.com/pytorch/pytorch/issues/new/choose"
         >
           Create an issue

--- a/torchci/pages/test/insights.tsx
+++ b/torchci/pages/test/insights.tsx
@@ -153,10 +153,11 @@ function GetUsage({
   if (data["timestamp"] === undefined || data["timestamp"].length === 0) {
     return (
       <>
-        The job didn&apos;t generate any usage stats, so there is nothing to analyze.
-        Please submit an issue to PyTorch Dev Infra team.
+        The job didn&apos;t generate any usage stats, so there is nothing to
+        analyze. Please submit an issue to PyTorch Dev Infra team.
         <a
-          target="_blank" rel="noreferrer"
+          target="_blank"
+          rel="noreferrer"
           href="https://github.com/pytorch/pytorch/issues/new/choose"
         >
           Create an issue


### PR DESCRIPTION
Fixes https://github.com/pytorch/test-infra/issues/4933.  There are several issues with the page:

1. The workflow ID regex was wrong with an extra `s` in `jobs`.  Thus the link fails to find the workflow ID.  I'm not sure why it was missed earlier (blaming myself)
1. The artifact `usage-log-test-` is now called `logs-test-`.  The filename was wrong
1. The script failed to handle `None` values in some cases, i.e. `{'pid': 260046848, 'gpu_memory': None}`, and ended up with `TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'` error
1. The script failed to handle retried job because it hardcoded the run attempt to 1
1. S3 NoSuchKey error wasn't handled correctly by the lambda and surfaces as 500 Internal Server Failure
1. Handle invalid JSON in the log when `tools.stats.monitor` failed to run, i.e. `ERROR conda.cli.main_run:execute(49): `conda run python -m tools.stats.monitor` failed`

I also add a deployment workflow for the lambda, and will create the necessary OIDC role.

### Testing

* Jobs with `usage_log` are displayed correctly now https://torchci-git-fix-test-insight-page-fbopensource.vercel.app/test/insights?jobName=linux-focal-cuda12.1-py3.10-gcc9%20%2F%20test%20(default%2C%205%2C%205%2C%20linux.4xlarge.nvidia.gpu)&workflowId=7824285894&jobId=21347098056
* Another example where the job was retried https://torchci-git-fix-test-insight-page-fbopensource.vercel.app/test/insights?jobName=linux-jammy-py3.10-clang15-asan%20%2F%20test%20(default%2C%201%2C%206%2C%20linux.4xlarge)&workflowId=7823281538&jobId=21347722901
* On MacOS or ROCm where there is not usage log available atm.  ~The page will show empty chart instead of a blank one https://torchci-git-fix-test-insight-page-fbopensource.vercel.app/test/insights?jobName=macos-12-py3-arm64%20%2F%20test%20(default%2C%201%2C%203%2C%20macos-m1-12)&workflowId=7824285997&jobId=21346784227~
  * It now prints a clearer message about the missing usage log https://torchci-git-fix-test-insight-page-fbopensource.vercel.app/test/insights?jobName=macos-12-py3-arm64%20%2F%20test%20(default%2C%201%2C%203%2C%20macos-m1-12)&workflowId=7824285997&jobId=21346784227 
* This is an example of a job whose usage log contains invalid JSON entries https://torchci-git-fix-test-insight-page-fbopensource.vercel.app/test/insights?jobName=win-vs2019-cpu-py3%20%2F%20test%20(default%2C%201%2C%203%2C%20windows.4xlarge.nonephemeral)&workflowId=7824285997&jobId=21347334930