### PR TITLE
[HUD][ez] Double click log viewer in job tooltip (hud main page) no longer opens gh job 

### DIFF
--- a/torchci/components/LogViewer.tsx
+++ b/torchci/components/LogViewer.tsx
@@ -176,7 +176,9 @@ function JumpToLineButton({
       >
         <div>
           {isCurrentLine ? "▼ " : "▶ "}
-          <code>{lineText ?? "Show log"}</code>
+          <code onDoubleClick={(e) => e.stopPropagation()}>
+            {lineText ?? "Show log"}
+          </code>
         </div>
       </button>
     </div>
@@ -245,7 +247,7 @@ function Log({
     }
   }, [currentLine, data]);
 
-  return <div ref={viewer}></div>;
+  return <div ref={viewer} onDoubleClick={(e) => e.stopPropagation()}></div>;
 }
 
 function LogWithLineSelector({

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -13,7 +13,6 @@ import {
   getGroupingData,
   groups,
   sortGroupNamesForHUD,
-  isPersistentGroup,
   isUnstableGroup,
 } from "lib/JobClassifierUtil";
 import {
@@ -31,13 +30,11 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import React, { createContext, useContext, useEffect, useState } from "react";
 import PageSelector from "components/PageSelector";
-import useSWR from "swr";
 import {
   isFailedJob,
   isRerunDisabledTestsJob,
   isUnstableJob,
 } from "lib/jobUtils";
-import { fetcher } from "lib/GeneralUtils";
 import {
   useGroupingPreference,
   usePreference,


### PR DESCRIPTION
Double clicking in the job tooltip (the blue box that comes up on the main page of hud when you click a job conclusion) opens up a the gh job page for that job.  This also applies to the log viewer in the tooltip, which can be really annoying when you are trying to highlight something in the log, so this PR stops the gh page from opening when you double click on the log viewer in the tooltip

Also remove some unused imports

Set the function twice separately instead of in parent element because I want the blue space after the log toggle to still trigger opening the gh job page, see image for area
<img width="939" alt="Screenshot 2024-02-09 at 3 53 23 PM" src="https://github.com/pytorch/test-infra/assets/44682903/a3158f44-d5d3-414b-9cd0-ea3739d560cd">
