### PR TITLE
Create Dr.CI comment if it doesn't exist

### DIFF
--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -91,7 +91,7 @@ export default function JobLinks({
         <ReproductionCommand
           job={job}
           separator={" | "}
-          testName={getTestName(job.failureLines[0] ?? "")}
+          testName={getTestName(job.failureLines[0] ?? "", true)}
         />
       )}
     </span>
@@ -101,14 +101,16 @@ export default function JobLinks({
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 const unittestFailureRe = /^(?:FAIL|ERROR) \[.*\]: (test_.* \(.*Test.*\))/;
 const pytestFailureRe = /^FAILED .*.py::(.*)::(test_\S*)/;
-
-function getTestName(failureCapture: string) {
+function getTestName(failureCapture: string, reproduction: boolean = false) {
   const unittestMatch = failureCapture.match(unittestFailureRe);
   if (unittestMatch !== null) {
     return unittestMatch[1];
   }
   const pytestMatch = failureCapture.match(pytestFailureRe);
   if (pytestMatch !== null) {
+    if (reproduction) {
+      return `python ${pytestMatch[0]}.py ${pytestMatch[1]}.${pytestMatch[2]}`;
+    }
     return `${pytestMatch[2]} (__main__.${pytestMatch[1]})`;
   }
   return null;


### PR DESCRIPTION
This happened in https://github.com/pytorch/pytorch/pull/119774#issuecomment-1942910517 where the bot failed to create the comment due to a GitHub hiccup losing the event.

Atm, the comment is only created by the bot when the PR is opened or sync https://github.com/pytorch/test-infra/blob/main/torchci/lib/bot/drciBot.ts#L6.

When a workflow finishes, making an API call to Dr.CI returns early when there is no Dr.CI comment https://github.com/pytorch/test-infra/blob/main/torchci/pages/api/drci/drci.ts#L136-L141

### Testing

Not sure how to test this because there is no mock setup.  But this looks benign enough to jump the bullet?
