### PR TITLE
Hide suppressed bc linter failure on Dr.CI (and mergebot)

### DIFF
--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -601,7 +601,7 @@ export async function getWorkflowJobsStatuses(
   prInfo: PRandJobs,
   flakyRules: FlakyRule[],
   baseJobs: Map<string, RecentWorkflowsData[]>,
-  labels: string[]
+  labels: string[] = []
 ): Promise<{
   pending: number;
   failedJobs: RecentWorkflowsData[];
@@ -626,7 +626,10 @@ export async function getWorkflowJobsStatuses(
         unstableJobs.push(job);
       } else if (isBrokenTrunk(job, baseJobs)) {
         brokenTrunkJobs.push(job);
-      } else if (await isSuppressedByLabels(job, labels)) {
+      } else if (
+        prInfo.repo === "pytorch" &&
+        (await isSuppressedByLabels(job, labels))
+      ) {
         flakyJobs.push(job);
       } else if (
         isFlaky(job, flakyRules) ||

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -308,7 +308,8 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     const { pending, failedJobs } = await updateDrciBot.getWorkflowJobsStatuses(
       pr_1001,
       [],
-      new Map()
+      new Map(),
+      []
     );
     const failureInfo = constructResultsCommentHelper({
       pending,
@@ -355,7 +356,8 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     const { pending, failedJobs } = await updateDrciBot.getWorkflowJobsStatuses(
       pr_1001,
       [],
-      new Map()
+      new Map(),
+      []
     );
 
     expect(pending).toBe(1);
@@ -386,7 +388,8 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     const { pending, failedJobs } = await updateDrciBot.getWorkflowJobsStatuses(
       pr_1001,
       [],
-      new Map()
+      new Map(),
+      []
     );
 
     const failureInfo = constructResultsCommentHelper({
@@ -427,7 +430,8 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     const { pending, failedJobs } = await updateDrciBot.getWorkflowJobsStatuses(
       pr_1001,
       [],
-      new Map()
+      new Map(),
+      []
     );
 
     const failureInfo = constructResultsCommentHelper({
@@ -465,7 +469,8 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     const { pending, failedJobs } = await updateDrciBot.getWorkflowJobsStatuses(
       pr_1001,
       [],
-      new Map()
+      new Map(),
+      []
     );
     const failureInfo = constructResultsCommentHelper({
       pending,
@@ -497,7 +502,8 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     const { pending, failedJobs } = await updateDrciBot.getWorkflowJobsStatuses(
       pr_1001,
       [],
-      new Map()
+      new Map(),
+      []
     );
     const failureInfo = constructResultsCommentHelper({
       pending,
@@ -521,7 +527,8 @@ describe("Update Dr. CI Bot Unit Tests", () => {
       await updateDrciBot.getWorkflowJobsStatuses(
         pr_1001,
         [{ name: failedB.name, captures: failedB.failure_captures }],
-        new Map().set(failedA.name, [failedA])
+        new Map().set(failedA.name, [failedA]),
+        []
       );
     expect(failedJobs.length).toBe(0);
     expect(brokenTrunkJobs.length).toBe(1);
@@ -556,7 +563,8 @@ describe("Update Dr. CI Bot Unit Tests", () => {
             captures: ["test_torchinductor_opinfo .+ Received signal: SIGSEGV"],
           },
         ],
-        new Map()
+        new Map(),
+        []
       );
     expect(failedJobs.length).toBe(1);
     expect(brokenTrunkJobs.length).toBe(0);
@@ -578,7 +586,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     baseJobs.set(removeJobNameSuffix(failedF.name), [unstableA]);
 
     const { failedJobs, brokenTrunkJobs, flakyJobs, unstableJobs } =
-      await updateDrciBot.getWorkflowJobsStatuses(pr_1001, [], baseJobs);
+      await updateDrciBot.getWorkflowJobsStatuses(pr_1001, [], baseJobs, []);
     expect(failedJobs.length).toBe(1);
     expect(brokenTrunkJobs.length).toBe(2);
     expect(flakyJobs.length).toBe(0);
@@ -700,7 +708,8 @@ describe("Update Dr. CI Bot Unit Tests", () => {
       await updateDrciBot.getWorkflowJobsStatuses(
         workflowsByPR.get(1001)!,
         [],
-        baseCommitJobs.get(failedA.head_sha)!
+        baseCommitJobs.get(failedA.head_sha)!,
+        []
       );
     expect(failedJobs.length).toBe(0);
     expect(brokenTrunkJobs.length).toBe(2);
@@ -720,7 +729,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     );
     const pr_1001 = workflowsByPR.get(1001)!;
     const { failedJobs, brokenTrunkJobs, flakyJobs, unstableJobs } =
-      await updateDrciBot.getWorkflowJobsStatuses(pr_1001, [], new Map());
+      await updateDrciBot.getWorkflowJobsStatuses(pr_1001, [], new Map(), []);
     expect(failedJobs.length).toBe(0);
     expect(brokenTrunkJobs.length).toBe(0);
     expect(flakyJobs.length).toBe(2);
@@ -750,7 +759,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
 
     const pr_1001 = workflowsByPR.get(1001)!;
     const { pending, failedJobs, flakyJobs, brokenTrunkJobs, unstableJobs } =
-      await updateDrciBot.getWorkflowJobsStatuses(pr_1001, [], new Map());
+      await updateDrciBot.getWorkflowJobsStatuses(pr_1001, [], new Map(), []);
 
     expect(failedJobs.length).toBe(1);
     expect(brokenTrunkJobs.length).toBe(0);

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -308,8 +308,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     const { pending, failedJobs } = await updateDrciBot.getWorkflowJobsStatuses(
       pr_1001,
       [],
-      new Map(),
-      []
+      new Map()
     );
     const failureInfo = constructResultsCommentHelper({
       pending,
@@ -356,8 +355,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     const { pending, failedJobs } = await updateDrciBot.getWorkflowJobsStatuses(
       pr_1001,
       [],
-      new Map(),
-      []
+      new Map()
     );
 
     expect(pending).toBe(1);
@@ -388,8 +386,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     const { pending, failedJobs } = await updateDrciBot.getWorkflowJobsStatuses(
       pr_1001,
       [],
-      new Map(),
-      []
+      new Map()
     );
 
     const failureInfo = constructResultsCommentHelper({
@@ -430,8 +427,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     const { pending, failedJobs } = await updateDrciBot.getWorkflowJobsStatuses(
       pr_1001,
       [],
-      new Map(),
-      []
+      new Map()
     );
 
     const failureInfo = constructResultsCommentHelper({
@@ -469,8 +465,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     const { pending, failedJobs } = await updateDrciBot.getWorkflowJobsStatuses(
       pr_1001,
       [],
-      new Map(),
-      []
+      new Map()
     );
     const failureInfo = constructResultsCommentHelper({
       pending,
@@ -502,8 +497,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     const { pending, failedJobs } = await updateDrciBot.getWorkflowJobsStatuses(
       pr_1001,
       [],
-      new Map(),
-      []
+      new Map()
     );
     const failureInfo = constructResultsCommentHelper({
       pending,
@@ -527,8 +521,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
       await updateDrciBot.getWorkflowJobsStatuses(
         pr_1001,
         [{ name: failedB.name, captures: failedB.failure_captures }],
-        new Map().set(failedA.name, [failedA]),
-        []
+        new Map().set(failedA.name, [failedA])
       );
     expect(failedJobs.length).toBe(0);
     expect(brokenTrunkJobs.length).toBe(1);
@@ -563,8 +556,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
             captures: ["test_torchinductor_opinfo .+ Received signal: SIGSEGV"],
           },
         ],
-        new Map(),
-        []
+        new Map()
       );
     expect(failedJobs.length).toBe(1);
     expect(brokenTrunkJobs.length).toBe(0);
@@ -586,7 +578,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     baseJobs.set(removeJobNameSuffix(failedF.name), [unstableA]);
 
     const { failedJobs, brokenTrunkJobs, flakyJobs, unstableJobs } =
-      await updateDrciBot.getWorkflowJobsStatuses(pr_1001, [], baseJobs, []);
+      await updateDrciBot.getWorkflowJobsStatuses(pr_1001, [], baseJobs);
     expect(failedJobs.length).toBe(1);
     expect(brokenTrunkJobs.length).toBe(2);
     expect(flakyJobs.length).toBe(0);
@@ -708,8 +700,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
       await updateDrciBot.getWorkflowJobsStatuses(
         workflowsByPR.get(1001)!,
         [],
-        baseCommitJobs.get(failedA.head_sha)!,
-        []
+        baseCommitJobs.get(failedA.head_sha)!
       );
     expect(failedJobs.length).toBe(0);
     expect(brokenTrunkJobs.length).toBe(2);
@@ -729,7 +720,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     );
     const pr_1001 = workflowsByPR.get(1001)!;
     const { failedJobs, brokenTrunkJobs, flakyJobs, unstableJobs } =
-      await updateDrciBot.getWorkflowJobsStatuses(pr_1001, [], new Map(), []);
+      await updateDrciBot.getWorkflowJobsStatuses(pr_1001, [], new Map());
     expect(failedJobs.length).toBe(0);
     expect(brokenTrunkJobs.length).toBe(0);
     expect(flakyJobs.length).toBe(2);
@@ -759,7 +750,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
 
     const pr_1001 = workflowsByPR.get(1001)!;
     const { pending, failedJobs, flakyJobs, brokenTrunkJobs, unstableJobs } =
-      await updateDrciBot.getWorkflowJobsStatuses(pr_1001, [], new Map(), []);
+      await updateDrciBot.getWorkflowJobsStatuses(pr_1001, [], new Map());
 
     expect(failedJobs.length).toBe(1);
     expect(brokenTrunkJobs.length).toBe(0);

--- a/torchci/test/drciBot.test.ts
+++ b/torchci/test/drciBot.test.ts
@@ -196,6 +196,8 @@ describe("verify-drci-functionality", () => {
         }
       )
       .reply(200, {})
+      .get((url) => url.includes(`/repos/${OWNER}/${REPO}/issues/1000/labels`))
+      .reply(200, {})
       .get((url) => url.includes(`/repos/${OWNER}/${REPO}/compare/`))
       .reply(200, {
         merge_base_commit: {

--- a/torchci/test/drciUtils.test.ts
+++ b/torchci/test/drciUtils.test.ts
@@ -4,6 +4,7 @@ import {
   isInfraFlakyJob,
   isExcludedFromFlakiness,
   isLogClassifierFailed,
+  isSuppressedByLabels,
 } from "../lib/drciUtils";
 import * as searchUtils from "../lib/searchUtils";
 import * as jobUtils from "../lib/jobUtils";
@@ -459,5 +460,37 @@ describe("Test various utils used by Dr.CI", () => {
       runnerName: "dummy",
     };
     expect(isExcludedFromFlakiness(notExcludedJob)).toEqual(false);
+  });
+
+  test("test isSuppressedByLabels", () => {
+    const job: RecentWorkflowsData = {
+      jobName: "not suppressed job",
+
+      // Doesn't matter, just mocking
+      id: "A",
+      completed_at: "2023-08-01T00:00:00Z",
+      html_url: "A",
+      head_sha: "A",
+      failure_captures: ["ERROR"],
+    };
+
+    // Not supported
+    expect(isSuppressedByLabels(job, ["anything goes"])).toEqual(false);
+
+    job.jobName = "bc_linter";
+    // Not suppressed
+    expect(isSuppressedByLabels(job, [])).toEqual(false);
+    expect(isSuppressedByLabels(job, ["anything goes"])).toEqual(false);
+    // Suppress, the job will be hidden on CI and doesn't block merge
+    expect(isSuppressedByLabels(job, ["suppress-bc-linter"])).toEqual(true);
+    expect(
+      isSuppressedByLabels(job, ["suppress-api-compatibility-check"])
+    ).toEqual(true);
+    expect(
+      isSuppressedByLabels(job, [
+        "suppress-bc-linter",
+        "suppress-api-compatibility-check",
+      ])
+    ).toEqual(true);
   });
 });


### PR DESCRIPTION
This is to address https://github.com/pytorch/test-infra/issues/4938 where Dr.CI will hide bc linter failures on a PR if the PR has `suppress-bc-linter` or `suppress-api-compatibility-check` labels.  This is done dynamically whenever Dr.CI is run (periodically and during merge).

The only supported use case atm is bc linter.

### Testing

https://github.com/pytorch/pytorch/pull/118857 has a bc linter failure that has been suppressed.  Running the following curl command locally will update Dr.CI and hide the bc linter failure there.

```
curl --request POST \
  --url 'http://localhost:3000/api/drci/drci?prNumber=118857' \
  --header 'Authorization: TOKEN' \
  --data 'repo=pytorch'
```

---

<!-- drci-comment-start -->

## :link: Helpful Links
### :test_tube: See artifacts and rendered test results at [hud.pytorch.org/pr/118857](https://hud.pytorch.org/pr/118857)
* :page_facing_up: Preview [Python docs built from this PR](https://docs-preview.pytorch.org/pytorch/pytorch/118857/index.html)
* :page_facing_up: Preview [C++ docs built from this PR](https://docs-preview.pytorch.org/pytorch/pytorch/118857/cppdocs/index.html)
* :question: Need help or want to give feedback on the CI? Visit the [bot commands wiki](https://github.com/pytorch/pytorch/wiki/Bot-commands) or our [office hours](https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours)

Note: Links to docs will display an error until the docs builds have been completed.


## :white_check_mark: You can merge normally! (2 Unrelated Failures)
As of commit af3d1d0f1a787f8f29138637720a14a532809b3c with merge base cf42dd09ca47e293736ebbc80a919b4d53ede0f8 (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1707503059?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details ><summary><b>FLAKY</b> - The following jobs failed but were likely due to flakiness present on trunk:</summary><p>

* [BC Lint / bc_linter](https://hud.pytorch.org/pr/pytorch/pytorch/118857#21674959713) ([gh](https://github.com/pytorch/pytorch/actions/runs/7937546958/job/21674959713))
    `Process completed with exit code 1.`
* [pull / linux-focal-py3.11-clang10 / test (dynamo, 1, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/118857#21421118040) ([gh](https://github.com/pytorch/pytorch/actions/runs/7848165710/job/21421118040))
    `test_autograd.py::TestAutograd::test_post_accumulate_grad_hook_gets_cleaned_up`
</p></details>


This comment was automatically generated by Dr. CI and updates every 15 minutes.
<!-- drci-comment-end -->