### PR TITLE
Fix hasS3Log and disable similarity search on non-PyTorch repos

### DIFF
--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -634,7 +634,8 @@ export async function getWorkflowJobsStatuses(
       } else if (
         isFlaky(job, flakyRules) ||
         isInfraFlakyJob(job) ||
-        (await hasSimilarFailures(job, prInfo.merge_base_date))
+        (prInfo.repo === "pytorch" &&
+          (await hasSimilarFailures(job, prInfo.merge_base_date)))
       ) {
         flakyJobs.push(job);
       } else if (await isLogClassifierFailed(job)) {


### PR DESCRIPTION
This fixes the wrong path used by `hasS3Log` and also disables similarity search on non PyTorch repos.  There is nothing wrong with this feature but I don't think it works well with non-PyTorch repo where there is no dedicated log classifier support.  Specifically, ExecuTorch has lots of generic failures `failed with exit code N`, i.e. https://github.com/pytorch/executorch/pull/1964.  This can be turned back on later when we have a better log classifier.