### PR TITLE
[alerts] Close issue if there are too many comments

### DIFF
--- a/tools/torchci/check_alerts.py
+++ b/tools/torchci/check_alerts.py
@@ -639,7 +639,7 @@ def parse_args() -> argparse.Namespace:
 def main():
     args = parse_args()
     check_for_recurrently_failing_jobs_alert(
-        args.repo, args.branch, args.job_name_regex, False
+        args.repo, args.branch, args.job_name_regex, args.dry_run
     )
     # TODO: Fill out dry run for flaky test alerting, not going to do in one PR
     if args.with_flaky_test_alert:


### PR DESCRIPTION
We hit the comment threshold of 2500 and no new commends could be made, and the alert couldn't be updated.

This change closes alert issues with >2400 comments and forces the script to make a new issue instead.

Still investigating why the alert/task syncing isn't working for the new issue