### PR TITLE
Forces docker login on calculate-docker-image and pull-docker-image

### DIFF
--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -86,6 +86,7 @@ runs:
         BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
         DOCKER_TAG: ${{ steps.calculate-image.outputs.docker-tag }}
+        DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
         set +e
         set -x

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -90,6 +90,19 @@ runs:
         set +e
         set -x
 
+        login() {
+          aws ecr get-login-password --region us-east-1 | docker login -u AWS --password-stdin "$1"
+        }
+
+        retry () {
+          $*  || (sleep 1 && $*) || (sleep 2 && $*)
+        }
+
+        # Only run these steps if not on github actions
+        retry login "${DOCKER_REGISTRY}"
+        # Logout on exit
+        trap "docker logout ${DOCKER_REGISTRY}" EXIT
+
         # Check if image already exists, if it does then skip building it
         if docker manifest inspect "${DOCKER_IMAGE}"; then
           exit 0
@@ -137,13 +150,11 @@ runs:
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
-        set -ex
+        set -x
+        set +e
 
         login() {
-          aws ecr get-authorization-token --region us-east-1 --output text --query 'authorizationData[].authorizationToken' |
-            base64 -d |
-            cut -d: -f2 |
-            docker login -u AWS --password-stdin "$1"
+          aws ecr get-login-password --region us-east-1 | docker login -u AWS --password-stdin "$1"
         }
 
         retry () {
@@ -151,11 +162,11 @@ runs:
         }
 
         # Only run these steps if not on github actions
-        if [[ -z "${GITHUB_ACTIONS}" ]]; then
-          retry login "${DOCKER_REGISTRY}"
-          # Logout on exit
-          trap "docker logout ${DOCKER_REGISTRY}" EXIT
-        fi
+        retry login "${DOCKER_REGISTRY}"
+        # Logout on exit
+        trap "docker logout ${DOCKER_REGISTRY}" EXIT
+
+        set -e
 
         IMAGE_NAME=$(echo ${DOCKER_IMAGE#"${DOCKER_REGISTRY}/${REPO_NAME}/"} | awk -F '[:,]' '{print $1}')
         # Build new image

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -43,7 +43,7 @@ runs:
       id: login-ecr-public
       uses: aws-actions/amazon-ecr-login@v2
       with:
-        registries: ${{ inputs.docker-registry }}
+        registry-type: public
 
     - name: Calculate docker image
       id: calculate-image

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -39,6 +39,12 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Login to Amazon ECR Public
+      id: login-ecr-public
+      uses: aws-actions/amazon-ecr-login@v2
+      with:
+        registry-type: public
+
     - name: Calculate docker image
       id: calculate-image
       shell: bash
@@ -91,17 +97,6 @@ runs:
         set +e
         set -x
 
-        login() {
-          aws ecr get-login-password --region us-east-1 | docker login -u AWS --password-stdin "$1"
-        }
-
-        retry () {
-          $*  || (sleep 1 && $*) || (sleep 2 && $*)
-        }
-
-        retry login "${DOCKER_REGISTRY}"
-        trap 'docker logout "${DOCKER_REGISTRY}"' EXIT
-
         # Check if image already exists, if it does then skip building it
         if docker manifest inspect "${DOCKER_IMAGE}"; then
           exit 0
@@ -149,21 +144,7 @@ runs:
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
-        set -x
-        set +e
-
-        login() {
-          aws ecr get-login-password --region us-east-1 | docker login -u AWS --password-stdin "$1"
-        }
-
-        retry () {
-          $*  || (sleep 1 && $*) || (sleep 2 && $*)
-        }
-
-        retry login "${DOCKER_REGISTRY}"
-        trap 'docker logout "${DOCKER_REGISTRY}"' EXIT
-
-        set -e
+        set -xe
 
         IMAGE_NAME=$(echo ${DOCKER_IMAGE#"${DOCKER_REGISTRY}/${REPO_NAME}/"} | awk -F '[:,]' '{print $1}')
         # Build new image

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -143,21 +143,7 @@ runs:
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
-        login() {
-          aws ecr get-authorization-token --region us-east-1 --output text --query 'authorizationData[].authorizationToken' |
-            base64 -d |
-            cut -d: -f2 |
-            docker login -u AWS --password-stdin "$1"
-        }
-        retry () {
-          $*  || (sleep 1 && $*) || (sleep 2 && $*)
-        }
-        # Only run these steps if not on github actions
-        if [[ -z "${GITHUB_ACTIONS}" ]]; then
-          retry login "${DOCKER_REGISTRY}"
-          # Logout on exit
-          trap "docker logout ${DOCKER_REGISTRY}" EXIT
-        fi
+        set -xe
 
         IMAGE_NAME=$(echo ${DOCKER_IMAGE#"${DOCKER_REGISTRY}/${REPO_NAME}/"} | awk -F '[:,]' '{print $1}')
         # Build new image

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -92,6 +92,7 @@ runs:
         BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
         DOCKER_TAG: ${{ steps.calculate-image.outputs.docker-tag }}
+        DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
         set +e
         set -x

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -76,16 +76,11 @@ runs:
           echo "docker-image=${DOCKER_REGISTRY}/${REPO_NAME}/${DOCKER_IMAGE_NAME}:${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
         fi
 
-    - name: Check if image should be built
-      id: check-image
+    - name: Login to registry
+      id: registry-login
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      if: ${{ steps.calculate-image.outputs.skip != 'true' && !inputs.always-rebuild }}
       env:
-        DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
-        BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
-        DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
-        DOCKER_TAG: ${{ steps.calculate-image.outputs.docker-tag }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
         set +e
@@ -99,10 +94,21 @@ runs:
           $*  || (sleep 1 && $*) || (sleep 2 && $*)
         }
 
-        # Only run these steps if not on github actions
         retry login "${DOCKER_REGISTRY}"
-        # Logout on exit
-        trap "docker logout ${DOCKER_REGISTRY}" EXIT
+
+    - name: Check if image should be built
+      id: check-image
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      if: ${{ steps.calculate-image.outputs.skip != 'true' && !inputs.always-rebuild }}
+      env:
+        DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
+        BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
+        DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
+        DOCKER_TAG: ${{ steps.calculate-image.outputs.docker-tag }}
+      run: |
+        set +e
+        set -x
 
         # Check if image already exists, if it does then skip building it
         if docker manifest inspect "${DOCKER_IMAGE}"; then
@@ -151,23 +157,7 @@ runs:
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
-        set -x
-        set +e
-
-        login() {
-          aws ecr get-login-password --region us-east-1 | docker login -u AWS --password-stdin "$1"
-        }
-
-        retry () {
-          $*  || (sleep 1 && $*) || (sleep 2 && $*)
-        }
-
-        # Only run these steps if not on github actions
-        retry login "${DOCKER_REGISTRY}"
-        # Logout on exit
-        trap "docker logout ${DOCKER_REGISTRY}" EXIT
-
-        set -e
+        set -xe
 
         IMAGE_NAME=$(echo ${DOCKER_IMAGE#"${DOCKER_REGISTRY}/${REPO_NAME}/"} | awk -F '[:,]' '{print $1}')
         # Build new image

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -17,6 +17,9 @@ inputs:
   working-directory:
     description: The working directory where the repo is checked out.
     default: .
+  docker-registry-account:
+    description: The account number of the registry to store the image after it is built.
+    default: 308535385114
   docker-registry:
     description: The registry to store the image after it is built.
     default: 308535385114.dkr.ecr.us-east-1.amazonaws.com
@@ -43,7 +46,7 @@ runs:
       id: login-ecr-public
       uses: aws-actions/amazon-ecr-login@v2
       with:
-        registries: ${{ inputs.docker-registry }}
+        registries: ${{ inputs.docker-registry-account }}
 
     - name: Calculate docker image
       id: calculate-image

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -76,11 +76,16 @@ runs:
           echo "docker-image=${DOCKER_REGISTRY}/${REPO_NAME}/${DOCKER_IMAGE_NAME}:${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
         fi
 
-    - name: Login to registry
-      id: registry-login
+    - name: Check if image should be built
+      id: check-image
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      if: ${{ steps.calculate-image.outputs.skip != 'true' && !inputs.always-rebuild }}
       env:
+        DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
+        BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
+        DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
+        DOCKER_TAG: ${{ steps.calculate-image.outputs.docker-tag }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
         set +e
@@ -95,20 +100,7 @@ runs:
         }
 
         retry login "${DOCKER_REGISTRY}"
-
-    - name: Check if image should be built
-      id: check-image
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-      if: ${{ steps.calculate-image.outputs.skip != 'true' && !inputs.always-rebuild }}
-      env:
-        DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
-        BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
-        DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
-        DOCKER_TAG: ${{ steps.calculate-image.outputs.docker-tag }}
-      run: |
-        set +e
-        set -x
+        trap 'docker logout "${DOCKER_REGISTRY}"' EXIT
 
         # Check if image already exists, if it does then skip building it
         if docker manifest inspect "${DOCKER_IMAGE}"; then
@@ -157,7 +149,21 @@ runs:
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
-        set -xe
+        set -x
+        set +e
+
+        login() {
+          aws ecr get-login-password --region us-east-1 | docker login -u AWS --password-stdin "$1"
+        }
+
+        retry () {
+          $*  || (sleep 1 && $*) || (sleep 2 && $*)
+        }
+
+        retry login "${DOCKER_REGISTRY}"
+        trap 'docker logout "${DOCKER_REGISTRY}"' EXIT
+
+        set -e
 
         IMAGE_NAME=$(echo ${DOCKER_IMAGE#"${DOCKER_REGISTRY}/${REPO_NAME}/"} | awk -F '[:,]' '{print $1}')
         # Build new image

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -17,9 +17,6 @@ inputs:
   working-directory:
     description: The working directory where the repo is checked out.
     default: .
-  docker-registry-account:
-    description: The account number of the registry to store the image after it is built.
-    default: 308535385114
   docker-registry:
     description: The registry to store the image after it is built.
     default: 308535385114.dkr.ecr.us-east-1.amazonaws.com
@@ -46,7 +43,7 @@ runs:
       id: login-ecr-public
       uses: aws-actions/amazon-ecr-login@v2
       with:
-        registries: ${{ inputs.docker-registry-account }}
+        registries: ${{ inputs.docker-registry }}
 
     - name: Calculate docker image
       id: calculate-image

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -43,7 +43,7 @@ runs:
       id: login-ecr-public
       uses: aws-actions/amazon-ecr-login@v2
       with:
-        registry-type: public
+        registries: ${{ inputs.docker-registry }}
 
     - name: Calculate docker image
       id: calculate-image

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -143,7 +143,21 @@ runs:
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
-        set -xe
+        login() {
+          aws ecr get-authorization-token --region us-east-1 --output text --query 'authorizationData[].authorizationToken' |
+            base64 -d |
+            cut -d: -f2 |
+            docker login -u AWS --password-stdin "$1"
+        }
+        retry () {
+          $*  || (sleep 1 && $*) || (sleep 2 && $*)
+        }
+        # Only run these steps if not on github actions
+        if [[ -z "${GITHUB_ACTIONS}" ]]; then
+          retry login "${DOCKER_REGISTRY}"
+          # Logout on exit
+          trap "docker logout ${DOCKER_REGISTRY}" EXIT
+        fi
 
         IMAGE_NAME=$(echo ${DOCKER_IMAGE#"${DOCKER_REGISTRY}/${REPO_NAME}/"} | awk -F '[:,]' '{print $1}')
         # Build new image

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -92,7 +92,6 @@ runs:
         BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
         DOCKER_TAG: ${{ steps.calculate-image.outputs.docker-tag }}
-        DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
         set +e
         set -x

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -39,12 +39,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Login to Amazon ECR Public
-      id: login-ecr-public
-      uses: aws-actions/amazon-ecr-login@v2
-      with:
-        registry-type: public
-
     - name: Calculate docker image
       id: calculate-image
       shell: bash
@@ -97,6 +91,17 @@ runs:
         set +e
         set -x
 
+        login() {
+          aws ecr get-login-password --region us-east-1 | docker login -u AWS --password-stdin "$1"
+        }
+
+        retry () {
+          $*  || (sleep 1 && $*) || (sleep 2 && $*)
+        }
+
+        retry login "${DOCKER_REGISTRY}"
+        trap 'docker logout "${DOCKER_REGISTRY}"' EXIT
+
         # Check if image already exists, if it does then skip building it
         if docker manifest inspect "${DOCKER_IMAGE}"; then
           exit 0
@@ -144,7 +149,21 @@ runs:
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
-        set -xe
+        set -x
+        set +e
+
+        login() {
+          aws ecr get-login-password --region us-east-1 | docker login -u AWS --password-stdin "$1"
+        }
+
+        retry () {
+          $*  || (sleep 1 && $*) || (sleep 2 && $*)
+        }
+
+        retry login "${DOCKER_REGISTRY}"
+        trap 'docker logout "${DOCKER_REGISTRY}"' EXIT
+
+        set -e
 
         IMAGE_NAME=$(echo ${DOCKER_IMAGE#"${DOCKER_REGISTRY}/${REPO_NAME}/"} | awk -F '[:,]' '{print $1}')
         # Build new image

--- a/.github/actions/pull-docker-image/action.yml
+++ b/.github/actions/pull-docker-image/action.yml
@@ -6,9 +6,9 @@ inputs:
   docker-image:
     description: the image to pull
     required: true
-  docker-registry-account:
-    description: The account number of the registry to store the image after it is built.
-    default: 308535385114
+  docker-registry:
+    description: The registry to store the image after it is built.
+    default: 308535385114.dkr.ecr.us-east-1.amazonaws.com
 
 runs:
   using: composite
@@ -17,7 +17,7 @@ runs:
       id: login-ecr-public
       uses: aws-actions/amazon-ecr-login@v2
       with:
-        registries: ${{ inputs.docker-registry-account }}
+        registries: ${{ inputs.docker-registry }}
 
     - name: Pull Docker image
       shell: bash

--- a/.github/actions/pull-docker-image/action.yml
+++ b/.github/actions/pull-docker-image/action.yml
@@ -6,9 +6,6 @@ inputs:
   docker-image:
     description: the image to pull
     required: true
-  docker-registry:
-    description: The registry to store the image after it is built.
-    default: 308535385114.dkr.ecr.us-east-1.amazonaws.com
 
 runs:
   using: composite
@@ -23,7 +20,6 @@ runs:
       shell: bash
       env:
         DOCKER_IMAGE: ${{ inputs.docker-image }}
-        DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
         set -xe
 

--- a/.github/actions/pull-docker-image/action.yml
+++ b/.github/actions/pull-docker-image/action.yml
@@ -23,6 +23,8 @@ runs:
       run: |
         set -xe
 
+        retry () { "$@"  || (sleep 1 && "$@") || (sleep 2 && "$@") }
+
         # ignore output since only exit code is used for conditional
         # only pull docker image if it's not available locally
         if ! docker inspect --type=image "${DOCKER_IMAGE}" >/dev/null 2>/dev/null; then

--- a/.github/actions/pull-docker-image/action.yml
+++ b/.github/actions/pull-docker-image/action.yml
@@ -6,6 +6,9 @@ inputs:
   docker-image:
     description: the image to pull
     required: true
+  docker-registry:
+    description: The registry to store the image after it is built.
+    default: 308535385114.dkr.ecr.us-east-1.amazonaws.com
 
 runs:
   using: composite
@@ -20,6 +23,7 @@ runs:
       shell: bash
       env:
         DOCKER_IMAGE: ${{ inputs.docker-image }}
+        DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
         set -xe
 

--- a/.github/actions/pull-docker-image/action.yml
+++ b/.github/actions/pull-docker-image/action.yml
@@ -23,8 +23,6 @@ runs:
       run: |
         set -xe
 
-        retry () { "$@"  || (sleep 1 && "$@") || (sleep 2 && "$@") }
-
         # ignore output since only exit code is used for conditional
         # only pull docker image if it's not available locally
         if ! docker inspect --type=image "${DOCKER_IMAGE}" >/dev/null 2>/dev/null; then

--- a/.github/actions/pull-docker-image/action.yml
+++ b/.github/actions/pull-docker-image/action.yml
@@ -13,27 +13,20 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Login to Amazon ECR Public
+      id: login-ecr-public
+      uses: aws-actions/amazon-ecr-login@v2
+      with:
+        registry-type: public
+
     - name: Pull Docker image
       shell: bash
       env:
         DOCKER_IMAGE: ${{ inputs.docker-image }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
-        set -x
-        set +e
+        set -xe
 
-        login() {
-          aws ecr get-login-password --region us-east-1 | docker login -u AWS --password-stdin "$1"
-        }
-
-        retry () {
-          $*  || (sleep 1 && $*) || (sleep 2 && $*)
-        }
-
-        retry login "${DOCKER_REGISTRY}"
-        trap 'docker logout "${DOCKER_REGISTRY}"' EXIT
-
-        set -e
         # ignore output since only exit code is used for conditional
         # only pull docker image if it's not available locally
         if ! docker inspect --type=image "${DOCKER_IMAGE}" >/dev/null 2>/dev/null; then

--- a/.github/actions/pull-docker-image/action.yml
+++ b/.github/actions/pull-docker-image/action.yml
@@ -6,9 +6,6 @@ inputs:
   docker-image:
     description: the image to pull
     required: true
-  docker-registry:
-    description: The registry to store the image after it is built.
-    default: 308535385114.dkr.ecr.us-east-1.amazonaws.com
 
 runs:
   using: composite
@@ -17,7 +14,7 @@ runs:
       id: login-ecr-public
       uses: aws-actions/amazon-ecr-login@v2
       with:
-        registries: ${{ inputs.docker-registry }}
+        registry-type: public
 
     - name: Pull Docker image
       shell: bash

--- a/.github/actions/pull-docker-image/action.yml
+++ b/.github/actions/pull-docker-image/action.yml
@@ -13,20 +13,27 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Login to Amazon ECR Public
-      id: login-ecr-public
-      uses: aws-actions/amazon-ecr-login@v2
-      with:
-        registry-type: public
-
     - name: Pull Docker image
       shell: bash
       env:
         DOCKER_IMAGE: ${{ inputs.docker-image }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
-        set -xe
+        set -x
+        set +e
 
+        login() {
+          aws ecr get-login-password --region us-east-1 | docker login -u AWS --password-stdin "$1"
+        }
+
+        retry () {
+          $*  || (sleep 1 && $*) || (sleep 2 && $*)
+        }
+
+        retry login "${DOCKER_REGISTRY}"
+        trap 'docker logout "${DOCKER_REGISTRY}"' EXIT
+
+        set -e
         # ignore output since only exit code is used for conditional
         # only pull docker image if it's not available locally
         if ! docker inspect --type=image "${DOCKER_IMAGE}" >/dev/null 2>/dev/null; then

--- a/.github/actions/pull-docker-image/action.yml
+++ b/.github/actions/pull-docker-image/action.yml
@@ -6,9 +6,9 @@ inputs:
   docker-image:
     description: the image to pull
     required: true
-  docker-registry:
-    description: The registry to store the image after it is built.
-    default: 308535385114.dkr.ecr.us-east-1.amazonaws.com
+  docker-registry-account:
+    description: The account number of the registry to store the image after it is built.
+    default: 308535385114
 
 runs:
   using: composite
@@ -17,7 +17,7 @@ runs:
       id: login-ecr-public
       uses: aws-actions/amazon-ecr-login@v2
       with:
-        registries: ${{ inputs.docker-registry }}
+        registries: ${{ inputs.docker-registry-account }}
 
     - name: Pull Docker image
       shell: bash

--- a/.github/actions/pull-docker-image/action.yml
+++ b/.github/actions/pull-docker-image/action.yml
@@ -6,6 +6,9 @@ inputs:
   docker-image:
     description: the image to pull
     required: true
+  docker-registry:
+    description: The registry to store the image after it is built.
+    default: 308535385114.dkr.ecr.us-east-1.amazonaws.com
 
 runs:
   using: composite
@@ -14,8 +17,23 @@ runs:
       shell: bash
       env:
         DOCKER_IMAGE: ${{ inputs.docker-image }}
+        DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
-        retry () { "$@"  || (sleep 1 && "$@") || (sleep 2 && "$@") }
+        set -x
+        set +e
+
+        login() {
+          aws ecr get-login-password --region us-east-1 | docker login -u AWS --password-stdin "$1"
+        }
+
+        retry () {
+          $*  || (sleep 1 && $*) || (sleep 2 && $*)
+        }
+
+        retry login "${DOCKER_REGISTRY}"
+        trap 'docker logout "${DOCKER_REGISTRY}"' EXIT
+
+        set -e
         # ignore output since only exit code is used for conditional
         # only pull docker image if it's not available locally
         if ! docker inspect --type=image "${DOCKER_IMAGE}" >/dev/null 2>/dev/null; then

--- a/.github/actions/pull-docker-image/action.yml
+++ b/.github/actions/pull-docker-image/action.yml
@@ -6,6 +6,9 @@ inputs:
   docker-image:
     description: the image to pull
     required: true
+  docker-registry:
+    description: The registry to store the image after it is built.
+    default: 308535385114.dkr.ecr.us-east-1.amazonaws.com
 
 runs:
   using: composite
@@ -14,7 +17,7 @@ runs:
       id: login-ecr-public
       uses: aws-actions/amazon-ecr-login@v2
       with:
-        registry-type: public
+        registries: ${{ inputs.docker-registry }}
 
     - name: Pull Docker image
       shell: bash


### PR DESCRIPTION
Docker login is required if the goal is to instead of relying on EC2 node permission, use OIDC to login instead.