### PR TITLE
ci: Set minimum ARC runners to 0

### DIFF
--- a/.github/arc-runner-config.yaml
+++ b/.github/arc-runner-config.yaml
@@ -2,7 +2,7 @@ runnerConfig:
   - cpu: 4.0
     maxRunners: 150
     memory: 16Gi
-    minRunners: 1
+    minRunners: 0
     nodeType: compute-amd64
     runnerLabel: linux.large
     containerMode: dind-rootless
@@ -10,7 +10,7 @@ runnerConfig:
   - cpu: 8.0
     maxRunners: 150
     memory: 32Gi
-    minRunners: 1
+    minRunners: 0
     nodeType: compute-amd64
     runnerLabel: linux.2xlarge
     containerMode: dind-rootless
@@ -18,7 +18,7 @@ runnerConfig:
   - cpu: 4.0
     maxRunners: 150
     memory: 16Gi
-    minRunners: 1
+    minRunners: 0
     nodeType: compute-gpu
     runnerLabel: linux-gpu.large
     containerMode: dind-rootless


### PR DESCRIPTION
Change our minimum runners to 0 to lower costs during times of low usage. In my own testing it takes only a few minutes for a node to come online if there isn't already one and Karpenter keeps nodes online if there is continued usage. We can revisit the minimum if it causes us grief in the future but choosing 0 is likely the right choice at the moment while we build out the ARC infra.