### PR TITLE
[bots] Move labeler action to test-infra

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -138,7 +138,7 @@ const repoSpecificAutoLabels: { [repo: string]: [RegExp, string][] } = {
 
 const CIFLOW_TRUNK_LABEL = "ciflow/trunk";
 
-export async function getLabelFromLabelerConfig(
+export async function getLabelsFromLabelerConfig(
   context: Context,
   changed_files: string[]
 ): Promise<string[]> {
@@ -397,7 +397,7 @@ function myBot(app: Probot): void {
       // Add a repo specific labels (if any)
       var repoSpecificLabels = getRepoSpecificLabels(owner, repo);
 
-      var labelsFromLabelerConfig = await getLabelFromLabelerConfig(
+      var labelsFromLabelerConfig = await getLabelsFromLabelerConfig(
         context,
         filesChanged
       );

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -1,5 +1,12 @@
 import { Context, Probot } from "probot";
-import { addLabels, isPyTorchPyTorch } from "./utils";
+import {
+  addLabels,
+  hasApprovedPullRuns,
+  hasWritePermissions,
+  isPyTorchPyTorch,
+  repoKey,
+} from "./utils";
+import { minimatch } from "minimatch";
 
 const titleRegexToLabel: [RegExp, string][] = [
   [/rocm/gi, "module: rocm"],
@@ -130,6 +137,31 @@ const repoSpecificAutoLabels: { [repo: string]: [RegExp, string][] } = {
 };
 
 const CIFLOW_TRUNK_LABEL = "ciflow/trunk";
+
+export async function getLabelFromLabelerConfig(
+  context: Context,
+  changed_files: string[]
+): Promise<string[]> {
+  const config: Map<string, string[]> = (await context.config(
+    "labeler.yml"
+  )) as Map<string, string[]>;
+  if (config === null) {
+    return [];
+  }
+
+  const labels = [];
+
+  for (const [label, globs] of Object.entries(config)) {
+    if (
+      globs.some((glob: string) =>
+        changed_files.some((file: string) => minimatch(file, glob))
+      )
+    ) {
+      labels.push(label);
+    }
+  }
+  return labels;
+}
 
 function getRepoSpecificLabels(
   owner: string,
@@ -324,56 +356,83 @@ function myBot(app: Probot): void {
     await addNewLabels(labels, labelsToAdd, context);
   });
 
-  app.on(["pull_request.opened", "pull_request.edited"], async (context) => {
-    const labels: string[] = context.payload.pull_request.labels.map(
-      (e) => e["name"]
-    );
-    const owner = context.payload.repository.owner.login;
-    const repo = context.payload.repository.name;
-    const title = context.payload.pull_request.title;
-    const filesChangedRes = await context.octokit.paginate(
-      "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
-      {
-        owner,
-        repo,
-        pull_number: context.payload.pull_request.number,
-        per_page: 100,
-      }
-    );
-    const filesChanged = filesChangedRes.map((f: any) => f.filename);
-    context.log({ labels, title, filesChanged });
-
-    const labelsToAdd = getLabelsToAddFromTitle(title);
-
-    // only categorize for release notes for prs in pytorch/pytorch
-    if (isPyTorchPyTorch(owner, repo)) {
-      const [category, topic] = getReleaseNotesCategoryAndTopic(
-        title,
-        labels,
-        filesChanged
+  app.on(
+    ["pull_request.opened", "pull_request.edited", "pull_request.synchronize"],
+    async (context) => {
+      const labels: string[] = context.payload.pull_request.labels.map(
+        (e) => e["name"]
       );
-      if (category !== "uncategorized" && category !== "skip") {
-        labelsToAdd.push(category);
-      }
-      if (topic !== "untopiced" && topic !== "skip") {
-        labelsToAdd.push(topic);
-      }
-    }
+      const owner = context.payload.repository.owner.login;
+      const repo = context.payload.repository.name;
+      const title = context.payload.pull_request.title;
+      const filesChangedRes = await context.octokit.paginate(
+        "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
+        {
+          owner,
+          repo,
+          pull_number: context.payload.pull_request.number,
+          per_page: 100,
+        }
+      );
+      const filesChanged = filesChangedRes.map((f: any) => f.filename);
+      context.log({ labels, title, filesChanged });
 
-    // Add a repo specific labels (if any)
-    var repoSpecificLabels = getRepoSpecificLabels(owner, repo);
+      var labelsToAdd = getLabelsToAddFromTitle(title);
 
-    for (const file of filesChanged) {
-      // check for typical matches
-      for (const [regex, label] of repoSpecificLabels) {
-        if (file.match(regex)) {
-          labelsToAdd.push(label);
+      // only categorize for release notes for prs in pytorch/pytorch
+      if (isPyTorchPyTorch(owner, repo)) {
+        const [category, topic] = getReleaseNotesCategoryAndTopic(
+          title,
+          labels,
+          filesChanged
+        );
+        if (category !== "uncategorized" && category !== "skip") {
+          labelsToAdd.push(category);
+        }
+        if (topic !== "untopiced" && topic !== "skip") {
+          labelsToAdd.push(topic);
         }
       }
-    }
 
-    await addNewLabels(labels, labelsToAdd, context);
-  });
+      // Add a repo specific labels (if any)
+      var repoSpecificLabels = getRepoSpecificLabels(owner, repo);
+
+      var labelsFromLabelerConfig = await getLabelFromLabelerConfig(
+        context,
+        filesChanged
+      );
+      for (const label of labelsFromLabelerConfig) {
+        labelsToAdd.push(label);
+      }
+
+      for (const file of filesChanged) {
+        // check for typical matches
+        for (const [regex, label] of repoSpecificLabels) {
+          if (file.match(regex)) {
+            labelsToAdd.push(label);
+          }
+        }
+      }
+
+      // Filter ciflow/* labels if the PR author does not have write permissions
+      if (
+        !(await hasApprovedPullRuns(
+          context.octokit,
+          owner,
+          repo,
+          context.payload.pull_request.head.sha
+        )) &&
+        !(await hasWritePermissions(
+          context,
+          context.payload.pull_request.user.login
+        ))
+      ) {
+        labelsToAdd = labelsToAdd.filter((l) => !l.startsWith("ciflow/"));
+      }
+
+      await addNewLabels(labels, labelsToAdd, context);
+    }
+  );
 
   app.on("pull_request_review.submitted", async (context) => {
     // Apply `ciflow/trunk` to PRs in PyTorch/PyTorch that has been reviewed a

--- a/torchci/lib/bot/utils.ts
+++ b/torchci/lib/bot/utils.ts
@@ -107,6 +107,35 @@ export class CachedIssueTracker extends CachedConfigTracker {
   }
 }
 
+export class CachedLabelerConfigTracker extends CachedConfigTracker {
+  repoLabels: any = {};
+  constructor(app: Probot) {
+    super(app);
+    app.on("push", async (context) => {
+      if (
+        context.payload.ref === "refs/heads/master" ||
+        context.payload.ref === "refs/heads/main"
+      ) {
+        await this.loadLabelsConfig(context, /* force */ true);
+      }
+    });
+  }
+
+  async loadLabelsConfig(context: Context, force = false): Promise<object> {
+    const key = repoKey(context);
+    if (!(key in this.repoLabels) || force) {
+      const config: any = await this.loadConfig(context, force);
+
+      if (config != null && "labeler_config" in config) {
+        this.repoLabels[key] = context.config(config["labeler_config"]);
+      } else {
+        this.repoLabels[key] = {};
+      }
+    }
+    return this.repoLabels[key];
+  }
+}
+
 // returns undefined if the request fails
 export async function fetchJSON(path: string): Promise<any> {
   const result = await retryRequest(path);

--- a/torchci/package.json
+++ b/torchci/package.json
@@ -38,6 +38,7 @@
     "echarts-for-react": "^3.0.2",
     "jaro-winkler-typescript": "^1.0.1",
     "lodash": "^4.17.21",
+    "minimatch": "^9.0.3",
     "minimist": "^1.2.6",
     "next": "12.1.5",
     "next-auth": "^4.24.5",

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -38,6 +38,7 @@ describe("auto-label-bot", () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+    nock.cleanAll();
   });
 
   test("add triage review when issue is labeled high priority", async () => {
@@ -907,9 +908,10 @@ describe("auto-label-bot: labeler.yml config", () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+    nock.cleanAll();
   });
 
-  test("getLabelFromLabelerConfig no matches", async () => {
+  test("getLabelsFromLabelerConfig no matches", async () => {
     const event = requireDeepCopy("./fixtures/pull_request.opened");
     const prFiles = requireDeepCopy("./fixtures/pull_files");
     prFiles["items"] = [{ filename: "torch/blah.py" }];
@@ -922,7 +924,7 @@ describe("auto-label-bot: labeler.yml config", () => {
     scope.done();
   });
 
-  test("getLabelFromLabelerConfig one match", async () => {
+  test("getLabelsFromLabelerConfig one match", async () => {
     const event = requireDeepCopy("./fixtures/pull_request.opened");
     const prFiles = requireDeepCopy("./fixtures/pull_files");
     prFiles["items"] = [{ filename: "torch/csrc/dynamo/blah.py" }];
@@ -937,7 +939,7 @@ describe("auto-label-bot: labeler.yml config", () => {
     scope2.done();
   });
 
-  test("getLabelFromLabelerConfig multiple match for single file", async () => {
+  test("getLabelsFromLabelerConfig multiple match for single file", async () => {
     const event = requireDeepCopy("./fixtures/pull_request.opened");
     const prFiles = requireDeepCopy("./fixtures/pull_files");
     prFiles["items"] = [{ filename: "torch/_dynamo/blah.py" }];
@@ -956,7 +958,7 @@ describe("auto-label-bot: labeler.yml config", () => {
     scope2.done();
   });
 
-  test("getLabelFromLabelerConfig multiple match with multiple file", async () => {
+  test("getLabelsFromLabelerConfig multiple match with multiple file", async () => {
     const event = requireDeepCopy("./fixtures/pull_request.opened");
     const prFiles = requireDeepCopy("./fixtures/pull_files");
     prFiles["items"] = [
@@ -978,7 +980,7 @@ describe("auto-label-bot: labeler.yml config", () => {
     scope2.done();
   });
 
-  test("getLabelFromLabelerConfig multiple match but no workflow permissions", async () => {
+  test("getLabelsFromLabelerConfig multiple match but no workflow permissions", async () => {
     // Matches both module: dynamo and ciflow/inductor, but removes ciflow due to lacking perms
     const event = requireDeepCopy("./fixtures/pull_request.opened");
     const prFiles = requireDeepCopy("./fixtures/pull_files");

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -23,7 +23,7 @@ function mockHasApprovedWorkflowRun(repoFullName: string) {
 describe("auto-label-bot", () => {
   let probot: Probot;
   function emptyMockConfig(repoFullName: string) {
-    utils.mockConfig("labeler.yml", "", repoFullName);
+    utils.mockConfig("pytorch-probot.yml", "", repoFullName);
   }
 
   beforeEach(() => {
@@ -879,6 +879,11 @@ describe("auto-label-bot: labeler.yml config", () => {
 - torch/_decomp/**
 - torch/_dynamo/**
 `;
+    utils.mockConfig(
+      "pytorch-probot.yml",
+      "labeler_config: labeler.yml",
+      repoFullName
+    );
     utils.mockConfig("labeler.yml", config, repoFullName);
   }
 

--- a/torchci/yarn.lock
+++ b/torchci/yarn.lock
@@ -2512,7 +2512,7 @@
   resolved "https://registry.yarnpkg.com/@octokit/webhooks-types/-/webhooks-types-6.5.0.tgz#536a22edc816d307de0d2fc1e6303022453a50eb"
   integrity sha512-SNx1YKBvi9IQvXo/SQ0p+9OKO2HMdzpCWcKsYxpGW1tlkE9TojYiGnFfxcXddyrsK4mC1UiyXY8+NYjWjtkVmA==
 
-"@octokit/webhooks@^9.0.1", "@octokit/webhooks@^9.26.3", "@octokit/webhooks@^9.26.3":
+"@octokit/webhooks@^9.0.1", "@octokit/webhooks@^9.26.3":
   version "9.26.3"
   resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-9.26.3.tgz#44353c4915229efeb3d01f9ab7adfdc2911535ae"
   integrity sha512-DLGk+gzeVq5oK89Bo601txYmyrelMQ7Fi5EnjHE0Xs8CWicy2xkmnJMKptKJrBJpstqbd/9oeDFi/Zj2pudBDQ==
@@ -6630,6 +6630,13 @@ minimatch@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
   integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
+  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
   dependencies:
     brace-expansion "^2.0.1"
 


### PR DESCRIPTION
Attempts to mimic the behavior of https://github.com/pytorch/pytorch/blob/89add71168faf48ea408829678897befcf0136b4/.github/workflows/labeler.yml

* Downloads the config based on a "labeler_config" key in .github/pytorch-probot.yml.  By nature of `context.config`, it looks in .github/ + configfile for the config file
* Uses minimatch (linked in https://github.com/actions/labeler/blob/83720bce8638d1b5b7b15ae76465522ca7ea2eec/README.md) to match the paths against globs
* Adds pull_request.synchronize to list of event types the labeler is run on

Other
* Adds check for ciflow label (no idea why this wasn't done before) 

Want to test this on malfet/deleteme before actually enabling on pytorch