### PR TITLE
Fix Dr.CI flaky FP when GH fails to dispatch the workflow

### DIFF
--- a/torchci/test/drciUtils.test.ts
+++ b/torchci/test/drciUtils.test.ts
@@ -334,6 +334,7 @@ describe("Test various utils used by Dr.CI", () => {
   });
 
   test("test isInfraFlakyJob", () => {
+    // Not a workflow job
     const notInfraFlakyFailure: RecentWorkflowsData = {
       id: "A",
       name: "A",
@@ -348,8 +349,13 @@ describe("Test various utils used by Dr.CI", () => {
     };
     expect(isInfraFlakyJob(notInfraFlakyFailure)).toEqual(false);
 
+    // Set the workflow ID to mark this as a workflow job
+    notInfraFlakyFailure.workflowId = "A";
+    expect(isInfraFlakyJob(notInfraFlakyFailure)).toEqual(false);
+
     const notInfraFlakyFailureAgain: RecentWorkflowsData = {
       id: "A",
+      workflowId: "A",
       name: "A",
       html_url: "A",
       head_sha: "A",
@@ -364,6 +370,7 @@ describe("Test various utils used by Dr.CI", () => {
 
     const isInfraFlakyFailure: RecentWorkflowsData = {
       id: "A",
+      workflowId: "A",
       name: "A",
       html_url: "A",
       head_sha: "A",
@@ -381,8 +388,8 @@ describe("Test various utils used by Dr.CI", () => {
     const mockJobUtils = jest.spyOn(jobUtils, "hasS3Log");
     mockJobUtils.mockImplementation(() => Promise.resolve(true));
 
-    // Has log and failure lines
-    const validFailure: RecentWorkflowsData = {
+    // Not a workflow job
+    const mockFailure: RecentWorkflowsData = {
       id: "A",
       name: "A",
       html_url: "A",
@@ -394,11 +401,16 @@ describe("Test various utils used by Dr.CI", () => {
       head_branch: "whatever",
       runnerName: "dummy",
     };
-    expect(await isLogClassifierFailed(validFailure)).toEqual(false);
+    expect(await isLogClassifierFailed(mockFailure)).toEqual(false);
+
+    // Has log and failure lines and is a workflow job
+    mockFailure.workflowId = "A";
+    expect(await isLogClassifierFailed(mockFailure)).toEqual(false);
 
     // Has log but not failure lines (log classifier not triggered)
     const logClassifierNotTriggered: RecentWorkflowsData = {
       id: "A",
+      workflowId: "A",
       name: "A",
       html_url: "A",
       head_sha: "A",
@@ -415,7 +427,7 @@ describe("Test various utils used by Dr.CI", () => {
 
     // No S3 log
     mockJobUtils.mockImplementation(() => Promise.resolve(false));
-    expect(await isLogClassifierFailed(validFailure)).toEqual(true);
+    expect(await isLogClassifierFailed(mockFailure)).toEqual(true);
   });
 
   test("test isExcludedFromFlakiness", () => {


### PR DESCRIPTION
Fixes https://github.com/pytorch/test-infra/issues/4987

Dr.CI logic to detect `isInfraFlakyJob` and `isLogClassifierFailed` has a FP where it misclassifies the GH failure to dispatch the whole workflow as flaky, for example https://github.com/pytorch/pytorch/pull/121317.

These logic should only be applicable to workflow job, not workflow run.  The way to separate them is to check the `workflowId` field where it is set to `null` whenever it is a workflow run.

### Testing

Unit test + local curl command will mark them as legit failures:

```
curl --request POST \
--url "http://localhost:3000/api/drci/drci?prNumber=121317" \
--header "Authorization: TOKEN" \
--data 'repo=pytorch'
```