### PR TITLE
Add nightly trigger for executorch

### DIFF
--- a/.github/workflows/trigger_nightly.yml
+++ b/.github/workflows/trigger_nightly.yml
@@ -19,6 +19,7 @@ on:
           - tensorrt
           - data
           - fbgemm
+          - executorch
           - all
 jobs:
   trigger:
@@ -83,3 +84,11 @@ jobs:
           repository: pytorch/fbgemm
           token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
           path: fbgemm
+      - name: Trigger nightly executorch build
+        if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'executorch' || inputs.domain == 'all' }}
+        uses: ./.github/actions/trigger-nightly
+        with:
+          ref: main
+          repository: pytorch/executorch
+          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+          path: executorch


### PR DESCRIPTION
I have the approval from ExecuTorch to onboard to Nova binary build workflows https://github.com/pytorch/executorch/pull/2363.  That covers wheel first.  Once the PR lands, we can add a nightly trigger to start generating ExecuTorch wheels.

I'm seeing pytorchbot with write access to the repo from `bunnylol oss pytorch/executorch`, so I think this is the only step needed.