### PR TITLE
[drci] Optimize sql query for recent workflow jobs

### DIFF
--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -23,7 +23,7 @@
     "issue_query": "e4d338de89980044",
     "failure_samples_query": "7940a636284d0752",
     "num_commits_master": "e4a864147cf3bf44",
-    "recent_pr_workflows_query": "d42ec445f05da4d9",
+    "recent_pr_workflows_query": "32081d5bbe8e3fb0",
     "reverted_prs_with_reason": "751f01cba16364f0",
     "unclassified": "1b31a2d8f4ab7230",
     "test_insights_overview": "42dbd5232f45fd53",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -23,7 +23,7 @@
     "issue_query": "e4d338de89980044",
     "failure_samples_query": "7940a636284d0752",
     "num_commits_master": "e4a864147cf3bf44",
-    "recent_pr_workflows_query": "2dd4ad8044ee6c65",
+    "recent_pr_workflows_query": "d42ec445f05da4d9",
     "reverted_prs_with_reason": "751f01cba16364f0",
     "unclassified": "1b31a2d8f4ab7230",
     "test_insights_overview": "42dbd5232f45fd53",


### PR DESCRIPTION
Some Dr. CI queries are failing due to too much resource utilization according to the new query_logs table

To improve speed + reduce memory utilization, I move tables in joins around to be larger table join smaller table and use the broadcast join strategy.  

Approximate improvements according to the query profiler:
All PRs (past 30 minutes):
max memory of a step: 37GB -> 500 MB
time: ~8s -> ~2s

Single PR (used 121717)
max memory of a step: 37GB -> 200 MB
time: ~6s -> ~1s

