### PR TITLE
Trigger executorch nightly off viable/strict

### DIFF
--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -53,13 +53,6 @@ on:
         type: string
         default: ''
 
-      # Android-specific inputs
-      android-app-archive:
-        description: The name of the Android app to run. This needs to be in APK format
-        required: false
-        type: string
-        default: ''
-
 jobs:
   job:
     name: ${{ inputs.job-name }} (${{ inputs.device-type }})

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -53,6 +53,13 @@ on:
         type: string
         default: ''
 
+      # Android-specific inputs
+      android-app-archive:
+        description: The name of the Android app to run. This needs to be in APK format
+        required: false
+        type: string
+        default: ''
+
 jobs:
   job:
     name: ${{ inputs.job-name }} (${{ inputs.device-type }})

--- a/.github/workflows/trigger_nightly.yml
+++ b/.github/workflows/trigger_nightly.yml
@@ -88,7 +88,7 @@ jobs:
         if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'executorch' || inputs.domain == 'all' }}
         uses: ./.github/actions/trigger-nightly
         with:
-          ref: main
+          ref: viable/strict
           repository: pytorch/executorch
           token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
           path: executorch


### PR DESCRIPTION
My copy/paste mistake.  ExecuTorch wants to have `nightly` off `viable/strict` branch like PyTorch instead of `main`