### PR TITLE
ci: Option to set number of Nvidia GPUs in ARC

### DIFF
--- a/.github/arc-runner-config.yaml
+++ b/.github/arc-runner-config.yaml
@@ -20,6 +20,7 @@ runnerConfig:
     memory: 16Gi
     minRunners: 0
     nodeType: compute-gpu
+    nvidiaGpus: 1
     runnerLabel: linux-gpu.large
     containerMode: dind-rootless
     workingDiskSpace: 150Gi


### PR DESCRIPTION
Allows arc-runner-config to set the number of Nvidia GPUs for a compute-gpu runner.

Relates to pytorch/ci-infra#89