### PR TITLE
Remove ROCm 5.6 and add ROCm 6.0

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -32,8 +32,8 @@ CUDA_ARCHES_DICT = {
 }
 ROCM_ARCHES_DICT = {
     "nightly": ["5.7", "6.0"],
-    "test": ["5.6", "5.7"],
-    "release": ["5.6", "5.7"],
+    "test": ["5.7", "6.0"],
+    "release": ["5.7", "6.0"],
 }
 
 PACKAGE_TYPES = ["wheel", "conda", "libtorch"]

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -33,7 +33,7 @@ CUDA_ARCHES_DICT = {
 ROCM_ARCHES_DICT = {
     "nightly": ["5.7", "6.0"],
     "test": ["5.7", "6.0"],
-    "release": ["5.7", "6.0"],
+    "release": ["5.6", "5.7"],
 }
 
 PACKAGE_TYPES = ["wheel", "conda", "libtorch"]


### PR DESCRIPTION
Another follow-up for 2.3 release