### PR TITLE
[bots] Do not add ciflow/trunk label if the author does not have permissions

### DIFF
--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -285,9 +285,7 @@ The explanation needs to be clear on why this is needed. Here are some good exam
 
     if (
       rebase &&
-      !(await this.hasRebasePermissions(
-        this.ctx.payload?.comment?.user?.login
-      ))
+      !(await this.hasRebasePermissions(this.ctx.payload?.comment?.user?.login))
     ) {
       await this.addComment(
         "You don't have permissions to rebase this PR since you are a first time contributor.  If you think this is a mistake, please contact PyTorch Dev Infra."
@@ -342,11 +340,7 @@ The explanation needs to be clear on why this is needed. Here are some good exam
   async handleRebase(branch: string) {
     await this.logger.log("rebase", { branch });
     const { ctx } = this;
-    if (
-      await this.hasRebasePermissions(
-        ctx.payload?.comment?.user?.login
-      )
-    ) {
+    if (await this.hasRebasePermissions(ctx.payload?.comment?.user?.login)) {
       await this.dispatchEvent("try-rebase", { branch: branch });
       await this.ackComment();
     } else {

--- a/torchci/lib/bot/utils.ts
+++ b/torchci/lib/bot/utils.ts
@@ -252,3 +252,17 @@ export async function hasApprovedPullRuns(
   }
   return pr_runs.every((run) => run.conclusion != "action_required");
 }
+
+export async function isFirstTimeContributor(
+  ctx: any,
+  username: string
+): Promise<boolean> {
+  const commits = await ctx.octokit.repos.listCommits({
+    owner: ctx.payload.repository.owner.login,
+    repo: ctx.payload.repository.name,
+    author: username,
+    sha: ctx.payload.repository.default_branch,
+    per_page: 1,
+  });
+  return commits?.data?.length === 0;
+}

--- a/torchci/lib/bot/utils.ts
+++ b/torchci/lib/bot/utils.ts
@@ -252,27 +252,3 @@ export async function hasApprovedPullRuns(
   }
   return pr_runs.every((run) => run.conclusion != "action_required");
 }
-
-export async function isFirstTimeContributor(
-  ctx: any,
-  username: string
-): Promise<boolean> {
-  const commits = await ctx.octokit.repos.listCommits({
-    owner: ctx.payload.repository.owner.login,
-    repo: ctx.payload.repository.name,
-    author: username,
-    sha: ctx.payload.repository.default_branch,
-    per_page: 1,
-  });
-  return commits?.data?.length === 0;
-}
-
-export async function hasWorkflowRunningPermissions(
-  ctx: any,
-  username: string
-): Promise<boolean> {
-  return (
-    (await hasWritePermissions(ctx, username)) ||
-    !(await isFirstTimeContributor(ctx, username))
-  );
-}

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -7,7 +7,7 @@ import * as botUtils from "lib/bot/utils";
 
 nock.disableNetConnect();
 
-export function mockHasApprovedWorkflowRun(repoFullName: string) {
+function mockHasApprovedWorkflowRun(repoFullName: string) {
   nock("https://api.github.com")
     .get((uri) => uri.startsWith(`/repos/${repoFullName}/actions/runs`))
     .reply(200, {

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -7,7 +7,7 @@ import * as botUtils from "lib/bot/utils";
 
 nock.disableNetConnect();
 
-function mockHasApprovedWorkflowRun(repoFullName: string) {
+export function mockHasApprovedWorkflowRun(repoFullName: string) {
   nock("https://api.github.com")
     .get((uri) => uri.startsWith(`/repos/${repoFullName}/actions/runs`))
     .reply(200, {

--- a/torchci/test/common.ts
+++ b/torchci/test/common.ts
@@ -33,9 +33,18 @@ export function deepCopy(obj: any) {
   return JSON.parse(JSON.stringify(obj));
 }
 
-export function handleScope(scope: nock.Scope) {
-  if (!scope.isDone()) {
-    console.error("pending mocks: %j", scope.pendingMocks());
+export function handleScope(scope: nock.Scope | nock.Scope[]) {
+  function scopeIsDone(s: nock.Scope) {
+    if (!s.isDone()) {
+      console.error("pending mocks: %j", s.pendingMocks());
+    }
+    s.done();
   }
-  scope.done();
+  if (Array.isArray(scope)) {
+    for (const s of scope) {
+      scopeIsDone(s);
+    }
+  } else {
+    scopeIsDone(scope);
+  }
 }

--- a/torchci/test/labelCommands.test.ts
+++ b/torchci/test/labelCommands.test.ts
@@ -167,23 +167,21 @@ describe("label-bot", () => {
         return true;
       })
       .reply(200, {});
-    const scopes = [scope];
-    scopes.push(utils.mockPermissions(
-      `${owner}/${repo}`,
-      event.payload.comment.user.login,
-      "read"
-    ));
-    scopes.push(utils.mockGetPR(`${owner}/${repo}`, pr_number, {
-      head: { sha: "randomsha" },
-    }));
-    scopes.push(
-      utils.mockApprovedWorkflowRuns(`${owner}/${repo}`, "randomsha", false)
-    );
+    const additionalScopes = [
+      utils.mockPermissions(
+        `${owner}/${repo}`,
+        event.payload.comment.user.login,
+        "read"
+      ),
+      utils.mockGetPR(`${owner}/${repo}`, pr_number, {
+        head: { sha: "randomsha" },
+      }),
+      utils.mockApprovedWorkflowRuns(`${owner}/${repo}`, "randomsha", false),
+    ];
 
     await probot.receive(event);
-    for (const scope of scopes) {
-      handleScope(scope);
-    }
+    handleScope(scope);
+    handleScope(additionalScopes);
   });
 
   test("label with ciflow good permissions", async () => {
@@ -213,24 +211,21 @@ describe("label-bot", () => {
         return true;
       })
       .reply(200, {});
-    const scopes = [scope];
-    scopes.push(utils.mockPermissions(
-      `${owner}/${repo}`,
-      event.payload.comment.user.login,
-      "read"
-    ));
-    scopes.push(utils.mockGetPR(`${owner}/${repo}`, pr_number, {
-      head: { sha: "randomsha" },
-    }));
-    scopes.push(
-      utils.mockApprovedWorkflowRuns(`${owner}/${repo}`, "randomsha", true)
-    );
+    const additionalScopes = [
+      utils.mockPermissions(
+        `${owner}/${repo}`,
+        event.payload.comment.user.login,
+        "read"
+      ),
+      utils.mockGetPR(`${owner}/${repo}`, pr_number, {
+        head: { sha: "randomsha" },
+      }),
+      utils.mockApprovedWorkflowRuns(`${owner}/${repo}`, "randomsha", true),
+    ];
 
     await probot.receive(event);
-    for (const scope of scopes) {
-      handleScope(scope);
-    }
-
+    handleScope(scope);
+    handleScope(additionalScopes);
   });
 
   test("label with ciflow on issue should have no event", async () => {

--- a/torchci/test/mergeCommands.test.ts
+++ b/torchci/test/mergeCommands.test.ts
@@ -154,7 +154,7 @@ describe("merge-bot", () => {
       })
       .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
         expect(JSON.stringify(body)).toContain(
-          `You don't have permissions to run the required trunk workflow`
+          `The author doesn't have permissions to run the required trunk workflow`
         );
         return true;
       })
@@ -440,10 +440,6 @@ describe("merge-bot", () => {
         `/repos/${owner}/${repo}/collaborators/${event.payload.comment.user.login}/permission`
       )
       .reply(200, { permission: "read" })
-      .get(
-        `/repos/${owner}/${repo}/commits?author=${event.payload.comment.user.login}&sha=${default_branch}&per_page=1`
-      )
-      .reply(200, [])
       .post(
         `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
         (body) => {

--- a/torchci/test/mergeCommands.test.ts
+++ b/torchci/test/mergeCommands.test.ts
@@ -109,6 +109,61 @@ describe("merge-bot", () => {
       .reply(200, {})
       .get(`/repos/${owner}/${repo}/pulls/${pr_number}/reviews`)
       .reply(200, requireDeepCopy("./fixtures/pull_request_reviews.json"));
+    utils.mockPermissions(
+      `${owner}/${repo}`,
+      event.payload.issue.user.login,
+      "write"
+    );
+
+    await probot.receive(event);
+    handleScope(scope);
+  });
+
+  test("merge command on pytorch/pytorch pull request does not trigger dispatch if no write permissions for label", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
+
+    event.payload.comment.body = "@pytorchbot merge";
+    event.payload.repository.owner.login = "pytorch";
+    event.payload.repository.name = "pytorch";
+
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    const pr_number = event.payload.issue.number;
+    const comment_number = event.payload.comment.id;
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${owner}/${repo}/pulls/${pr_number}/reviews`)
+      .reply(200, requireDeepCopy("./fixtures/pull_request_reviews.json"))
+      .get(`/repos/${owner}/${repo}/pulls/${pr_number}`)
+      .reply(200, {
+        head: {
+          sha: "randomsha",
+        },
+      })
+      .get((uri) =>
+        uri.startsWith(
+          `/repos/${owner}/${repo}/actions/runs?head_sha=randomsha`
+        )
+      )
+      .reply(200, {
+        workflow_runs: [
+          {
+            event: "pull_request",
+            conclusion: "action_required",
+          },
+        ],
+      })
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          `You don't have permissions to run the required trunk workflow`
+        );
+        return true;
+      })
+      .reply(200, {});
+    utils.mockPermissions(
+      `${owner}/${repo}`,
+      event.payload.issue.user.login,
+      "read"
+    );
 
     await probot.receive(event);
     handleScope(scope);

--- a/torchci/test/mergeCommands.test.ts
+++ b/torchci/test/mergeCommands.test.ts
@@ -115,7 +115,7 @@ describe("merge-bot", () => {
         `${owner}/${repo}`,
         event.payload.issue.user.login,
         "write"
-      )
+      ),
     ];
 
     await probot.receive(event);

--- a/torchci/test/utils.ts
+++ b/torchci/test/utils.ts
@@ -49,10 +49,37 @@ export function mockPermissions(
   repoFullName: string,
   user: string,
   permission: string = "write"
-): void {
-  nock("https://api.github.com")
+) {
+ return nock("https://api.github.com")
     .get(`/repos/${repoFullName}/collaborators/${user}/permission`)
     .reply(200, {
       permission: permission,
     });
+}
+
+export function mockApprovedWorkflowRuns(
+  repoFullname: string,
+  headSha: string,
+  approved: boolean
+) {
+  return nock("https://api.github.com")
+    .get(`/repos/${repoFullname}/actions/runs?head_sha=${headSha}`)
+    .reply(200, {
+      workflow_runs: [
+        {
+          event: "pull_request",
+          conclusion: approved ? "success" : "action_required",
+        },
+      ],
+    });
+}
+
+export function mockGetPR(
+  repoFullName: string,
+  prNumber: number,
+  body: any
+) {
+  return nock("https://api.github.com")
+    .get(`/repos/${repoFullName}/pulls/${prNumber}`)
+    .reply(200, body);
 }

--- a/torchci/test/utils.ts
+++ b/torchci/test/utils.ts
@@ -44,3 +44,15 @@ export function mockAccessToken(): void {
     .post("/app/installations/2/access_tokens")
     .reply(200, { token: "test" });
 }
+
+export function mockPermissions(
+  repoFullName: string,
+  user: string,
+  permission: string = "write"
+): void {
+  nock("https://api.github.com")
+    .get(`/repos/${repoFullName}/collaborators/${user}/permission`)
+    .reply(200, {
+      permission: permission,
+    });
+}

--- a/torchci/test/utils.ts
+++ b/torchci/test/utils.ts
@@ -50,7 +50,7 @@ export function mockPermissions(
   user: string,
   permission: string = "write"
 ) {
- return nock("https://api.github.com")
+  return nock("https://api.github.com")
     .get(`/repos/${repoFullName}/collaborators/${user}/permission`)
     .reply(200, {
       permission: permission,
@@ -74,11 +74,7 @@ export function mockApprovedWorkflowRuns(
     });
 }
 
-export function mockGetPR(
-  repoFullName: string,
-  prNumber: number,
-  body: any
-) {
+export function mockGetPR(repoFullName: string, prNumber: number, body: any) {
   return nock("https://api.github.com")
     .get(`/repos/${repoFullName}/pulls/${prNumber}`)
     .reply(200, body);


### PR DESCRIPTION
Do not add ciflow/trunk on merge if the author has no write permission. Instead, abort merge (it would have failed anyways) and post a comment about seeking approvals

Change -i permission to check for write permissions instead of write permissions OR has other commit on main 

Attempts to move some common mocks to be functions so I don't need to stare at urls as much

Helps reduce bot fighting in the below case:
<img width="884" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/340a999a-38da-4ab5-9c7d-5ee8643bb0df">
