### PR TITLE
[ez][HUD] Optimize query for TTRS, previous commits on PR

### DIFF
--- a/torchci/rockset/commons/__sql/pr_commits.sql
+++ b/torchci/rockset/commons/__sql/pr_commits.sql
@@ -1,6 +1,6 @@
 -- This query is used by the HUD's /pull page to populate the list of historical commits
 -- made against a given PR.
--- This improves upon the default github commits view because it allows HUD to show jobs 
+-- This improves upon the default github commits view because it allows HUD to show jobs
 -- that ran on a PR before it was rebased
 
 WITH
@@ -26,9 +26,11 @@ pr_shas AS (
     ) AS pr_url,
     p.head_commit.url AS commit_url,
   FROM
-    commons.workflow_job j
-    INNER JOIN commons.workflow_run r ON j.run_id = r.id
-    JOIN commons.push p ON p.head_commit.id = j.head_sha
+    commons.push p
+    JOIN (
+      commons.workflow_job j
+      INNER JOIN commons.workflow_run r ON j.run_id = r.id HINT(join_strategy = lookup)
+    ) ON p.head_commit.id = j.head_sha HINT(join_strategy = lookup)
   WHERE
     1 = 1
     AND LENGTH(r.pull_requests) = 1

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -30,7 +30,7 @@
     "test_insights_latest_runs": "1871833a91cb8b1b",
     "master_commit_red_jobs": "4869b467679a616a",
     "weekly_force_merge_stats": "d2264131599bcf6e",
-    "pr_commits": "7ef5e3d100a56edc",
+    "pr_commits": "cc14c0d3a5091636",
     "test_time_per_class": "630fa1ba72a3222b",
     "test_time_per_class_periodic_jobs": "c91054c7a10b377e"
   },
@@ -43,7 +43,7 @@
     "time_to_signal": "ff332d025976c103",
     "strict_lag_historical": "d2a09d13caf8b76a",
     "ci_wait_time": "b1080f26b20ea142",
-    "ttrs_percentiles": "cb34ea79098652f2"
+    "ttrs_percentiles": "ea95e9b56ab6900f"
   },
   "metrics": {
     "correlation_matrix": "35c05e04047123f0",

--- a/torchci/rockset/pytorch_dev_infra_kpis/__sql/ttrs_percentiles.sql
+++ b/torchci/rockset/pytorch_dev_infra_kpis/__sql/ttrs_percentiles.sql
@@ -13,7 +13,7 @@
 WITH
 -- All the percentiles that we want the query to determine
 percentiles_desired AS (
-  SELECT 
+  SELECT
     CONCAT('p', n.percentile) as percentile,
     n.percentile / 100.0 as percentile_num
   FROM  UNNEST(ARRAY_CREATE(25, 50, 75, 90) AS percentile) AS n
@@ -108,9 +108,9 @@ commit_job_durations AS (
     r.id AS workflow_run_id,
     s.url -- for debugging
   FROM
-    commons.workflow_job j CROSS
-    JOIN UNNEST (j.steps) js
-    INNER JOIN merged_pr_shas s ON j.head_sha = s.sha
+    commons.workflow_job j
+    INNER JOIN merged_pr_shas s ON j.head_sha = s.sha HINT(join_strategy = lookup)
+    CROSS JOIN UNNEST (j.steps) js
     INNER JOIN commons.workflow_run r ON j.run_id = r.id
   WHERE
     1 = 1


### PR DESCRIPTION
Small optimizations for some queries, not super necessary 

TTRS:
The query_logs table claims it takes ~17000ms on avg, but in the console it usually takes ~5000ms.  Using lookup brings to about ~1000ms on the console

PR commits (used on HUD PR page to fetch previous commits)
This was already pretty fast, but its one of the most used queries.  Original time: ~1500ms.  Moving the joins brings it to ~100ms 