### PR TITLE
Do not set the merge base date to the mock value of 0

### DIFF
--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -261,7 +261,9 @@ export async function querySimilarFailures(
   const failure = job.failure_captures.join(" ");
   const endDate = dayjs(job.completed_at);
   const startDate = dayjs(
-    baseCommitDate !== "" ? baseCommitDate : job.completed_at
+    baseCommitDate !== "" && baseCommitDate !== "0"
+      ? baseCommitDate
+      : job.completed_at
   ).subtract(lookbackPeriodInHours, "hour");
 
   // Get the workflow name if possible

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -292,12 +292,16 @@ where
         pr_info.merge_base_date = rocksetMergeBase.merge_base_commit_date;
       }
     },
+    // NB (huydhn): This function couldn't find merge base for ghstack PR and
+    // always throw an error in that case, so I decide to not print anything
+    // here to void confusion when seeing this error in the log
     async (pr_info: PRandJobs, e: Error) => {
-      console.log("Failed to retrieve merge base for PR", pr_info.pr_number, e);
       // Insert dummy values if merge base can't be found
       pr_info.merge_base =
         "failed to retrieve merge base, please contact dev infra";
-      pr_info.merge_base_date = "0";
+      // NB: Leave the merge base date empty or undefined here, any mock value
+      // like 0 is treated as a timestamp to use when quering similar failures
+      pr_info.merge_base_date = "";
     }
   );
   rocksetClient.documents.addDocuments("commons", "merge_bases", {


### PR DESCRIPTION
Fixes https://github.com/pytorch/test-infra/issues/5028

This is a regression after https://github.com/pytorch/test-infra/pull/5005 and I should have document the way Dr.CI checks for similar failures better.  Here is what happens:

1. A known fact is that Dr.CI won't be able to find the merge base for ghstack PRs and https://github.com/pytorch/test-infra/pull/5005 fixes the way this is handled
2. The issue, however, comes from the fact that `pr_info.merge_base_date` is default to `0` instead of an empty string or an undefined value
3. The date of the merge base is used to limit the range of the similar search query here https://github.com/pytorch/test-infra/blob/main/torchci/lib/drciUtils.ts#L263-L264.  This is used exactly to avoid FP.  If the merge base date is not set, it will fall back to the job timestamp.
4. The gotcha is when `merge_base_date` is set to 0 and `dayjs` is "smart" enough to take this as a timestamp meaning searching for everything since "the beginning of time".  This query is bound to return one match or another causing the FP in https://github.com/pytorch/pytorch/pull/122273 where all failures are marked as flaky.

### Testing

Rerun https://github.com/pytorch/pytorch/pull/122273 with the fix and failures are shown up correctly.

<!-- drci-comment-start -->

## :link: Helpful Links
### :test_tube: See artifacts and rendered test results at [hud.pytorch.org/pr/122273](https://hud.pytorch.org/pr/122273)
* :page_facing_up: Preview [Python docs built from this PR](https://docs-preview.pytorch.org/pytorch/pytorch/122273/index.html)
* :page_facing_up: Preview [C++ docs built from this PR](https://docs-preview.pytorch.org/pytorch/pytorch/122273/cppdocs/index.html)
* :question: Need help or want to give feedback on the CI? Visit the [bot commands wiki](https://github.com/pytorch/pytorch/wiki/Bot-commands) or our [office hours](https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours)

Note: Links to docs will display an error until the docs builds have been completed.


## :x: 10 New Failures, 2 Unrelated Failures
As of commit 19314f56e1424a1d6ae82ed624f093c4a96301a7 with merge base failed to retrieve merge base, please contact dev infra:
<details open><summary><b>NEW FAILURES</b> - The following jobs have failed:</summary><p>

* [inductor / cuda12.1-py3.10-gcc9-sm86 / test (inductor_distributed, 1, 1, linux.g5.12xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/122273#22866231062) ([gh](https://github.com/pytorch/pytorch/actions/runs/8353553791/job/22866231062))
    `distributed/test_dynamo_distributed.py::TestFakeDistributedSingleProc::test_hf_bert_ddp_aot_eager`
* [inductor / cuda12.1-py3.10-gcc9-sm86 / test (inductor, 1, 1, linux.g5.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/122273#22866230947) ([gh](https://github.com/pytorch/pytorch/actions/runs/8353553791/job/22866230947))
    `distributed/test_dynamo_distributed.py::TestFakeDistributedSingleProc::test_hf_bert_ddp_aot_eager`
* [inductor / rocm6.0-py3.8-inductor / test (inductor, 1, 1, linux.rocm.gpu.2)](https://hud.pytorch.org/pr/pytorch/pytorch/122273#22867013227) ([gh](https://github.com/pytorch/pytorch/actions/runs/8353553791/job/22867013227))
    `distributed/test_dynamo_distributed.py::TestFakeDistributedSingleProc::test_symbol_splitting`
* [inductor-periodic / cuda12.1-py3.10-gcc9-sm86-periodic-dynamo-benchmarks / test (aot_eager_torchbench, 2, 2, linux.g5.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/122273#22866211029) ([gh](https://github.com/pytorch/pytorch/actions/runs/8353553788/job/22866211029))
    `moco`
* [inductor-periodic / cuda12.1-py3.10-gcc9-sm86-periodic-dynamo-benchmarks / test (dynamic_aot_eager_torchbench, 2, 2, linux.g5.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/122273#22866211580) ([gh](https://github.com/pytorch/pytorch/actions/runs/8353553788/job/22866211580))
    `moco`
* [inductor-periodic / cuda12.1-py3.10-gcc9-sm86-periodic-dynamo-benchmarks / test (dynamo_eager_torchbench, 2, 2, linux.g5.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/122273#22866210396) ([gh](https://github.com/pytorch/pytorch/actions/runs/8353553788/job/22866210396))
    `moco`
* [pull / linux-focal-cuda11.8-py3.10-gcc9 / test (distributed, 2, 3, linux.8xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/122273#22865921586) ([gh](https://github.com/pytorch/pytorch/actions/runs/8353552343/job/22865921586))
    `distributed/test_dynamo_distributed.py::TestFakeDistributedSingleProc::test_symbol_splitting`
* [pull / linux-focal-cuda12.1-py3.10-gcc9-sm86 / test (default, 3, 5, linux.g5.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/122273#22866209746) ([gh](https://github.com/pytorch/pytorch/actions/runs/8353552343/job/22866209746))
    `dynamo/test_logging.py::LoggingTests::test_ddp_graphs`
* [pull / linux-focal-cuda12.1-py3.10-gcc9-sm86 / test (default, 5, 5, linux.g5.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/122273#22866210045) ([gh](https://github.com/pytorch/pytorch/actions/runs/8353552343/job/22866210045))
    `inductor/test_layout_optim.py::TestLayoutOptim::test_2conv_with_graph_break`
* [pull / linux-jammy-py3.8-gcc11 / test (distributed, 1, 2, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/122273#22865715793) ([gh](https://github.com/pytorch/pytorch/actions/runs/8353552343/job/22865715793))
    `distributed/test_dynamo_distributed.py::TestFakeDistributedSingleProc::test_symbol_splitting`
</p></details>
<details ><summary><b>FLAKY</b> - The following jobs failed but were likely due to flakiness present on trunk:</summary><p>

* [inductor / cuda12.1-py3.10-gcc9-sm86 / test (dynamic_inductor_torchbench, 2, 2, linux.g5.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/122273#22866232124) ([gh](https://github.com/pytorch/pytorch/actions/runs/8353553791/job/22866232124))
    `moco`
* [inductor / cuda12.1-py3.10-gcc9-sm86 / test (inductor_torchbench, 2, 2, linux.g5.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/122273#22866231585) ([gh](https://github.com/pytorch/pytorch/actions/runs/8353553791/job/22866231585))
    `moco`
</p></details>


This comment was automatically generated by Dr. CI and updates every 15 minutes.
<!-- drci-comment-end -->