### PR TITLE
[drci] Remove failed workflows if there is a succeeding one

### DIFF
--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -35,6 +35,9 @@ export interface JobData extends BasicJobData {
 export interface RecentWorkflowsData extends BasicJobData {
   // only included if this is a job and not a workflow, if it is a workflow, the name is in the name field
   workflowId?: string;
+  // Each workflow file has an id.  This can be used to group normal workflows
+  // and those that failed to run
+  workflowUniqueId?: number;
   jobName?: string;
   id: string;
   completed_at: string | null;

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -35,8 +35,10 @@ export interface JobData extends BasicJobData {
 export interface RecentWorkflowsData extends BasicJobData {
   // only included if this is a job and not a workflow, if it is a workflow, the name is in the name field
   workflowId?: string;
-  // Each workflow file has an id.  This can be used to group normal workflows
-  // and those that failed to run
+  // Each workflow file has an id. In rockset this is workflow_run.workflow_id.
+  // This can be used to group normal workflows (ex trunk) and those that failed
+  // to run (ex .github/workflows/trunk.yml) together even when they have
+  // different names.
   workflowUniqueId?: number;
   jobName?: string;
   id: string;

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -30,6 +30,7 @@ import {
   backfillMissingLog,
 } from "lib/jobUtils";
 import getRocksetClient from "lib/rockset";
+import _ from "lodash";
 
 interface PRandJobs {
   head_sha: string;
@@ -58,7 +59,7 @@ export default async function handler(
 ) {
   const authorization = req.headers.authorization;
 
-  if (authorization === process.env.DRCI_BOT_KEY) {
+  if (true || authorization === process.env.DRCI_BOT_KEY) {
     const { prNumber } = req.query;
     const { repo }: UpdateCommentBody = req.body;
     const octokit = await getOctokit(OWNER, repo);
@@ -700,27 +701,53 @@ export function reorganizeWorkflows(
   // clean up the workflows - remove retries, remove workflows that have jobs,
   // remove cancelled jobs with weird names
   for (const [, prInfo] of workflowsByPR) {
+    const [workflows, jobs] = _.partition(
+      prInfo.jobs,
+      (job) => job.workflowId === null || job.workflowId === undefined
+    );
+
+    // Get most recent workflow run based on workflowUniqueId (workflow_id in rockset)
+    const recentWorkflows: Map<number, RecentWorkflowsData> = new Map();
+    for (const workflow of workflows) {
+      // Check that this is a workflow, not a job
+      const workflowUniqueId = workflow.workflowUniqueId!;
+      const existingWorkflowId = recentWorkflows.get(workflowUniqueId)?.id;
+      if (!existingWorkflowId || existingWorkflowId! < workflow.id!) {
+        recentWorkflows.set(workflowUniqueId, workflow);
+      }
+    }
+
     // Remove retries
     const removeRetries = new Map();
-    for (const job of prInfo.jobs) {
+    for (const job of jobs) {
+      if (
+        job.workflowUniqueId &&
+        recentWorkflows.get(job.workflowUniqueId) &&
+        job.workflowId !== recentWorkflows.get(job.workflowUniqueId)!.id
+      ) {
+        // This belongs to an older run of the workflow
+        continue;
+      }
       const key = job.name!;
       const existing_job = removeRetries.get(key);
       if (!existing_job || existing_job.id < job.id!) {
         removeRetries.set(key, job);
       }
     }
-    // Remove workflows that have jobs
-    const workflowIds = Array.from(removeRetries.values()).map(
-      (jobInfo: RecentWorkflowsData) => jobInfo.workflowId
+
+
+    const workflowIdsWithJobs = new Set(
+      Array.from(removeRetries.values()).map((job) => job.workflowId)
     );
-    const newJobs = [];
-    for (const jobInfo of removeRetries.values()) {
-      if (!workflowIds.includes(jobInfo.id)) {
-        newJobs.push(jobInfo);
-      }
-    }
+
+    // Keep only workflows with no jobs
+    const goodWorkflows = Array.from(recentWorkflows.values()).filter(
+      (workflow: RecentWorkflowsData) => !workflowIdsWithJobs.has(workflow.id)
+    );
+
+    const allJobs = Array.from(removeRetries.values()).concat(goodWorkflows);
     // Remove cancelled jobs with weird names
-    prInfo.jobs = removeCancelledJobAfterRetry<RecentWorkflowsData>(newJobs);
+    prInfo.jobs = removeCancelledJobAfterRetry<RecentWorkflowsData>(allJobs);
   }
   return workflowsByPR;
 }

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -735,7 +735,6 @@ export function reorganizeWorkflows(
       }
     }
 
-
     const workflowIdsWithJobs = new Set(
       Array.from(removeRetries.values()).map((job) => job.workflowId)
     );

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -59,7 +59,7 @@ export default async function handler(
 ) {
   const authorization = req.headers.authorization;
 
-  if (true || authorization === process.env.DRCI_BOT_KEY) {
+  if (authorization === process.env.DRCI_BOT_KEY) {
     const { prNumber } = req.query;
     const { repo }: UpdateCommentBody = req.body;
     const octokit = await getOctokit(OWNER, repo);

--- a/torchci/rockset/commons/__sql/recent_pr_workflows_query.sql
+++ b/torchci/rockset/commons/__sql/recent_pr_workflows_query.sql
@@ -21,6 +21,7 @@ WITH recent_shas AS (
 )
 SELECT
   w.id AS workflowId,
+  w.workflow_id as workflowUniqueId,
   j.id,
   j.runner_name AS runnerName,
   w.head_commit.author.email as authorEmail,
@@ -49,6 +50,7 @@ FROM
 UNION
 SELECT
   null AS workflowId,
+  w.workflow_id as workflowUniqueId,
   w.id,
   null AS runnerName,
   w.head_commit.author.email as authorEmail,

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -23,7 +23,7 @@
     "issue_query": "e4d338de89980044",
     "failure_samples_query": "7940a636284d0752",
     "num_commits_master": "e4a864147cf3bf44",
-    "recent_pr_workflows_query": "32081d5bbe8e3fb0",
+    "recent_pr_workflows_query": "25ba3e57d82caeb1",
     "reverted_prs_with_reason": "751f01cba16364f0",
     "unclassified": "1b31a2d8f4ab7230",
     "test_insights_overview": "42dbd5232f45fd53",

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -19,7 +19,25 @@ import * as jobUtils from "lib/jobUtils";
 
 nock.disableNetConnect();
 
-export const successfulA = {
+function getDummyJob(nonDefaultInputs: any = {}): RecentWorkflowsData {
+  // Use this function to create a dummy job with default values
+  return {
+    workflowUniqueId: 1,
+    jobName: "dummy job name",
+    name: "dummy name",
+    id: "1",
+    workflowId: "1",
+    completed_at: "2022-07-13T19:34:03Z",
+    html_url: "abcdefg",
+    head_sha: "abcdefg",
+    pr_number: 1001,
+    conclusion: "success",
+    failure_captures: [],
+    ...nonDefaultInputs,
+  };
+}
+
+export const successfulA = getDummyJob({
   name: "linux-docs / build-docs (cpp)",
   conclusion: "success",
   completed_at: "2022-07-13T19:34:03Z",
@@ -29,9 +47,9 @@ export const successfulA = {
   id: "1",
   failure_lines: ["a"],
   failure_captures: ["Doc build successful"],
-};
+});
 
-const pendingA = {
+const pendingA = getDummyJob({
   name: "linux-docs / build-docs (cpp)",
   conclusion: undefined,
   completed_at: null,
@@ -42,9 +60,9 @@ const pendingA = {
   failure_lines: ["a"],
   failure_captures: [],
   runnerName: "dummy",
-};
+});
 
-const failedA = {
+const failedA = getDummyJob({
   name: "Lint",
   conclusion: "failure",
   completed_at: "2022-07-13T19:34:03Z",
@@ -55,9 +73,9 @@ const failedA = {
   failure_lines: ["a"],
   failure_captures: ["mind blown", "ha ha"],
   runnerName: "dummy",
-};
+});
 
-const failedASuccessfulRetry = {
+const failedASuccessfulRetry = getDummyJob({
   name: "Lint",
   conclusion: "success",
   completed_at: "2022-07-14T19:34:03Z",
@@ -67,9 +85,9 @@ const failedASuccessfulRetry = {
   pr_number: 1001,
   failure_captures: ["a"],
   runnerName: "dummy",
-};
+});
 
-const failedAFailedRetry = {
+const failedAFailedRetry = getDummyJob({
   name: "Lint",
   conclusion: "failure",
   completed_at: "2022-07-15T19:34:03Z",
@@ -80,9 +98,9 @@ const failedAFailedRetry = {
   failure_lines: ["a"],
   failure_captures: ["Retired but mind still blown", "ha ha ha"],
   runnerName: "dummy",
-};
+});
 
-const failedB = {
+const failedB = getDummyJob({
   name: "something",
   conclusion: "failure",
   completed_at: "2022-07-13T19:34:03Z",
@@ -93,9 +111,9 @@ const failedB = {
   failure_lines: ["a"],
   failure_captures: ["cde"],
   runnerName: "dummy",
-};
+});
 
-const failedC = {
+const failedC = getDummyJob({
   name: "z-docs / build-docs (cpp)",
   conclusion: "failure",
   completed_at: "2022-07-13T19:34:03Z",
@@ -106,9 +124,9 @@ const failedC = {
   failure_lines: ["a"],
   failure_captures: ["bababa"],
   runnerName: "dummy",
-};
+});
 
-const failedD = {
+const failedD = getDummyJob({
   name: "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)",
   conclusion: "failure",
   completed_at: "2022-07-13T19:34:03Z",
@@ -119,10 +137,10 @@ const failedD = {
   failure_lines: ["a", "b"],
   failure_captures: ["a", "b"],
   runnerName: "dummy",
-};
+});
 
 // Same as failedD but has a different shard ID
-const failedE = {
+const failedE = getDummyJob({
   name: "linux-bionic-cuda12.1-py3.10-gcc9-sm86 / test (default, 3, 5, linux.g5.4xlarge.nvidia.gpu)",
   conclusion: "failure",
   completed_at: "2022-07-13T19:34:03Z",
@@ -133,10 +151,10 @@ const failedE = {
   failure_lines: ["a", "b"],
   failure_captures: ["a", "b"],
   runnerName: "dummy",
-};
+});
 
 // Same as unstable A but without the unstable suffix
-const failedF = {
+const failedF = getDummyJob({
   name: "win-vs2019-cpu-py3 / test (default, 2, 3, windows.4xlarge)",
   conclusion: "failure",
   completed_at: "2022-07-13T19:34:03Z",
@@ -147,10 +165,10 @@ const failedF = {
   failure_lines: ["a", "b"],
   failure_captures: ["a", "b"],
   runnerName: "dummy",
-};
+});
 
 // Some additional mock samples for flaky rules regex match
-const failedG = {
+const failedG = getDummyJob({
   name: "win-vs2019-cpu-py3 / build",
   conclusion: "failure",
   completed_at: "2022-07-13T19:34:03Z",
@@ -165,9 +183,9 @@ const failedG = {
     "The process cannot access the file 'C:\\actions-runner\\_work\\_actions\\mock' because it is being used by another process.",
   ],
   runnerName: "dummy",
-};
+});
 
-const failedH = {
+const failedH = getDummyJob({
   name: "cuda12.1-py3.10-gcc9-sm86-periodic-dynamo-benchmarks / test (dynamo_eager_huggingface, 1, 1, linux.g5.4xlarge.nvidia.gpu)",
   conclusion: "failure",
   completed_at: "2022-07-13T19:34:03Z",
@@ -182,10 +200,10 @@ const failedH = {
     "##[error]The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.",
   ],
   runnerName: "dummy",
-};
+});
 
 // Match with failure line string instead of failure capture array
-const failedI = {
+const failedI = getDummyJob({
   name: "macos-12-py3-arm64 / test (default, 2, 3, macos-m1-stable)",
   conclusion: "failure",
   completed_at: "2022-07-13T19:34:03Z",
@@ -198,9 +216,9 @@ const failedI = {
     "RuntimeError: inductor/test_torchinductor_opinfo 2/2 failed! Received signal: SIGSEGV",
   ],
   runnerName: "dummy",
-};
+});
 
-const unstableA = {
+const unstableA = getDummyJob({
   name: "win-vs2019-cpu-py3 / test (default, 1, 3, windows.4xlarge, unstable)",
   conclusion: "failure",
   completed_at: "2022-07-13T19:34:03Z",
@@ -211,7 +229,7 @@ const unstableA = {
   failure_lines: ["a", "b"],
   failure_captures: ["a", "b"],
   runnerName: "dummy",
-};
+});
 
 const sev: IssueData = {
   number: 85362,
@@ -316,7 +334,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
       sha: pr_1001.head_sha,
       hud_pr_url: "hudlink",
     });
-    const failedJobName = failedA.name;
+    const failedJobName = failedA.name!;
 
     expect(failureInfo.includes("3 New Failures, 1 Pending")).toBeTruthy();
     expect(failureInfo.includes(failedJobName)).toBeTruthy();
@@ -363,7 +381,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
   });
 
   test("Check that dr ci comment is correctly formed", async () => {
-    const comment = formDrciComment(successfulA.pr_number);
+    const comment = formDrciComment(successfulA.pr_number!);
     expect(comment.includes(DRCI_COMMENT_START)).toBeTruthy();
     expect(
       comment.includes("See artifacts and rendered test results")
@@ -520,7 +538,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     const { failedJobs, brokenTrunkJobs, flakyJobs, unstableJobs } =
       await updateDrciBot.getWorkflowJobsStatuses(
         pr_1001,
-        [{ name: failedB.name, captures: failedB.failure_captures }],
+        [{ name: failedB.name!, captures: failedB.failure_captures }],
         new Map().set(failedA.name, [failedA])
       );
     expect(failedJobs.length).toBe(0);
@@ -574,8 +592,8 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     const pr_1001 = workflowsByPR.get(1001)!;
 
     const baseJobs = new Map();
-    baseJobs.set(removeJobNameSuffix(failedD.name), [failedE]);
-    baseJobs.set(removeJobNameSuffix(failedF.name), [unstableA]);
+    baseJobs.set(removeJobNameSuffix(failedD.name!), [failedE]);
+    baseJobs.set(removeJobNameSuffix(failedF.name!), [unstableA]);
 
     const { failedJobs, brokenTrunkJobs, flakyJobs, unstableJobs } =
       await updateDrciBot.getWorkflowJobsStatuses(pr_1001, [], baseJobs);
@@ -606,7 +624,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
       unstableA.name,
     ];
     expect(
-      expectToContain.every((s) => failureInfoComment.includes(s))
+      expectToContain.every((s) => failureInfoComment.includes(s!))
     ).toBeTruthy();
   });
 
@@ -626,7 +644,7 @@ describe("Update Dr. CI Bot Unit Tests", () => {
       unstableA.name,
     ];
     expect(
-      expectToContain.every((s) => failureInfoComment.includes(s))
+      expectToContain.every((s) => failureInfoComment.includes(s!))
     ).toBeTruthy();
   });
 
@@ -752,6 +770,84 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     const { pending, failedJobs, flakyJobs, brokenTrunkJobs, unstableJobs } =
       await updateDrciBot.getWorkflowJobsStatuses(pr_1001, [], new Map());
 
+    expect(failedJobs.length).toBe(1);
+    expect(brokenTrunkJobs.length).toBe(0);
+    expect(flakyJobs.length).toBe(0);
+    expect(unstableJobs.length).toBe(0);
+  });
+
+  test("test failed workflows go away if theres a new one", async () => {
+    const failedWorkflow = getDummyJob({
+      workflowId: undefined,
+      id: "1",
+      name: "weird name",
+      conclusion: "failure",
+    });
+    const newWorkflow = getDummyJob({
+      workflowId: undefined,
+      id: "2",
+      name: "correct name",
+    });
+
+    const originalWorkflows = [failedWorkflow, newWorkflow];
+    const workflowsByPR = await updateDrciBot.reorganizeWorkflows(
+      "pytorch",
+      "pytorch",
+      originalWorkflows
+    );
+
+    const pr_1001 = workflowsByPR.get(1001)!;
+    const { pending, failedJobs, flakyJobs, brokenTrunkJobs, unstableJobs } =
+      await updateDrciBot.getWorkflowJobsStatuses(pr_1001, [], new Map());
+
+    expect(pending).toBe(0);
+    expect(failedJobs.length).toBe(0);
+    expect(brokenTrunkJobs.length).toBe(0);
+    expect(flakyJobs.length).toBe(0);
+    expect(unstableJobs.length).toBe(0);
+  });
+
+  test("test new failed workflow overrides old succeeding workflow", async () => {
+    const newFailedWorkflow = getDummyJob({
+      workflowId: undefined,
+      id: "2",
+      name: "weird name",
+      conclusion: "failure",
+    });
+    const oldSuccessfulWorkflow = getDummyJob({
+      workflowId: undefined,
+      id: "1",
+      name: "correct name",
+    });
+    const oldSuccessfulWorkflowsJobs = [
+      getDummyJob({
+        workflowId: 1,
+        id: "3",
+        name: "correct name",
+      }),
+      getDummyJob({
+        workflowId: 1,
+        id: "4",
+        name: "correct name",
+      }),
+    ];
+
+    const originalWorkflows = [
+      newFailedWorkflow,
+      oldSuccessfulWorkflow,
+      ...oldSuccessfulWorkflowsJobs,
+    ];
+    const workflowsByPR = await updateDrciBot.reorganizeWorkflows(
+      "pytorch",
+      "pytorch",
+      originalWorkflows
+    );
+
+    const pr_1001 = workflowsByPR.get(1001)!;
+    const { pending, failedJobs, flakyJobs, brokenTrunkJobs, unstableJobs } =
+      await updateDrciBot.getWorkflowJobsStatuses(pr_1001, [], new Map());
+
+    expect(pending).toBe(0);
     expect(failedJobs.length).toBe(1);
     expect(brokenTrunkJobs.length).toBe(0);
     expect(flakyJobs.length).toBe(0);


### PR DESCRIPTION
`workflow_run.workflow_id` seems to uniquely identify workflow jobs based on their files
Use the above to tell that `.github/workflows/trunk.yml` is a failed version of `trunk`
Based on this, take the most recent workflow (based on workflow_run.id) and its corresponding jobs to be the truth

Example
<img width="559" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/de099818-827a-43fc-a08d-dc93f45e1a1f">
