### PR TITLE
[ez] uploadQueryLambdas - Allow description for lambdas to be different types

### DIFF
--- a/torchci/scripts/uploadQueryLambda.mjs
+++ b/torchci/scripts/uploadQueryLambda.mjs
@@ -53,7 +53,8 @@ async function upload(workspace, queryName, queryLambdas) {
   }
 
   if (
-    queryLambda.description == config.description &&
+    (queryLambda.description == config.description ||
+      (queryLambda.description == null && config.description == "")) &&
     equalParametersList(
       queryLambda.default_parameters,
       config.default_parameters


### PR DESCRIPTION
Sometimes the description from the query lambda on rockset is null and the local description is empty, and the script attempts to update the lambda.  This made me hit rate limits when trying to update from local.
I assume this is just a typing thing and that this is just two different ways of saying that there is no description, so add a check for that.