### PR TITLE
Use APPIUM_NODE_TEST_SPEC custom test spec for better test discovery

### DIFF
--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -47,8 +47,13 @@ on:
         required: false
         type: string
         default: ''
-      ios-xctest-zip:
-        description: The name of the iOS test suite itself
+      ios-xctestrun-zip:
+        description: The name of the iOS xctestrun zip archive
+        required: false
+        type: string
+        default: ''
+      ios-test-spec:
+        description: Specify how the test should be run on device
         required: false
         type: string
         default: ''
@@ -108,10 +113,10 @@ jobs:
           path: test-infra/tools/device-farm-runner/
 
       - name: Download iOS test suite
-        if: ${{ inputs.device-type == 'ios' && inputs.ios-xctest-zip != '' }}
+        if: ${{ inputs.device-type == 'ios' && inputs.ios-xctestrun-zip != '' }}
         uses: actions/download-artifact@v3
         with:
-          name: ${{ inputs.ios-xctest-zip }}
+          name: ${{ inputs.ios-xctestrun-zip }}
           path: test-infra/tools/device-farm-runner/
 
       - name: Verify iOS artifacts
@@ -120,21 +125,21 @@ jobs:
         working-directory: test-infra/tools/device-farm-runner
         env:
           IPA_ARCHIVE: ${{ inputs.ios-ipa-archive }}
-          XCTEST_ZIP: ${{ inputs.ios-xctest-zip }}
+          XCTESTRUN_ZIP: ${{ inputs.ios-xctestrun-zip }}
         run: |
           set -ex
 
-          if [ -z "${IPA_ARCHIVE}" ] || [ -z "${XCTEST_ZIP}" ]; then
-            echo "Missing IPA archive or xctest zip"
+          if [ -z "${IPA_ARCHIVE}" ] || [ -z "${XCTESTRUN_ZIP}" ]; then
+            echo "Missing IPA archive or xctestrun zip"
             exit 1
           fi
 
           # NP: The suffix needs to be exact, otherwise, AWS will reject them
           mv "${IPA_ARCHIVE}" ci.ipa
-          mv "${XCTEST_ZIP}" ci.xctest.zip
+          mv "${XCTESTRUN_ZIP}" ci.xctestrun.zip
 
           # Print the artifacts to manually verify them if needed
-          ls -lah ci.ipa ci.xctest.zip
+          ls -lah ci.ipa ci.xctestrun.zip
 
       - name: Run iOS tests on devices
         if: ${{ inputs.device-type == 'ios' }}
@@ -153,7 +158,7 @@ jobs:
           ${CONDA_RUN} python run_on_aws_devicefarm.py \
             --project-arn "${PROJECT_ARN}" \
             --app-file ci.ipa \
-            --xctest-file ci.xctest.zip \
+            --xctestrun-file ci.xctestrun.zip \
             --name-prefix "${JOB_NAME}-${DEVICE_TYPE}" \
             --workflow-id "${RUN_ID}" \
             --workflow-attempt "${RUN_ATTEMPT}"

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -53,6 +53,13 @@ on:
         type: string
         default: ''
 
+      # Android-specific inputs
+      android-app-archive:
+        description: The name of the Android app APK archive to run
+        required: false
+        type: string
+        default: ''
+
 jobs:
   job:
     name: ${{ inputs.job-name }} (${{ inputs.device-type }})

--- a/.github/workflows/test_mobile_job.yml
+++ b/.github/workflows/test_mobile_job.yml
@@ -12,16 +12,19 @@ jobs:
   setup-ios-job:
     runs-on: ubuntu-latest
     env:
-      IPA_ARCHIVE: TestApp.ipa
-      XCTEST_ZIP: TestAppTests.xctest.zip
+      IPA_ARCHIVE: DeviceFarm.ipa
+      XCTESTRUN_ZIP: MobileNetClassifierTest_MobileNetClassifierTest_iphoneos17.4-arm64.xctestrun.zip
+      IOS_TEST_SPEC: default-ios-device-farm-appium-test-spec.yml
     steps:
       - name: Download the prebuilt PyTorch iOS app and test suite from S3
         run: |
           set -ex
           wget -q "https://ossci-assets.s3.amazonaws.com/${IPA_ARCHIVE}"
-          wget -q "https://ossci-assets.s3.amazonaws.com/${XCTEST_ZIP}"
+          wget -q "https://ossci-assets.s3.amazonaws.com/${XCTESTRUN_ZIP}"
+          wget -q "https://ossci-assets.s3.amazonaws.com/${IOS_TEST_SPEC}"
+
           # Print the artifacts to manually verify them if needed
-          ls -lah "${IPA_ARCHIVE}" "${XCTEST_ZIP}"
+          ls -lah "${IPA_ARCHIVE}" "${XCTESTRUN_ZIP}" "${IOS_TEST_SPEC}"
 
       - name: Upload the iOS app
         uses: actions/upload-artifact@v3
@@ -32,8 +35,14 @@ jobs:
       - name: Upload the test suite
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.XCTEST_ZIP }}
-          path: ${{ env.XCTEST_ZIP }}
+          name: ${{ env.XCTESTRUN_ZIP }}
+          path: ${{ env.XCTESTRUN_ZIP }}
+
+      - name: Upload the test spec
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.IOS_TEST_SPEC }}
+          path: ${{ env.IOS_TEST_SPEC }}
 
   test-ios-job:
     needs: setup-ios-job
@@ -46,5 +55,6 @@ jobs:
       # For iOS testing, the runner just needs to call AWS Device Farm, so there is no need to run this on macOS
       runner: ubuntu-latest
       project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:b531574a-fb82-40ae-b687-8f0b81341ae0
-      ios-ipa-archive: TestApp.ipa
-      ios-xctest-zip: TestAppTests.xctest.zip
+      ios-ipa-archive: DeviceFarm.ipa
+      ios-xctestrun-zip: MobileNetClassifierTest_MobileNetClassifierTest_iphoneos17.4-arm64.xctestrun.zip
+      ios-test-spec: default-ios-device-farm-appium-test-spec.yml


### PR DESCRIPTION
Running ExecuTorch tests with the `XCTEST_TEST_PACKAGE` option has the trouble finding the tests.  As suggestion from AWS support, we should try to use `APPIUM_NODE_TEST_SPEC` with a custom test spec instead. s3://ossci-assets/default-ios-device-farm-appium-test-spec.yml.

The test is finally being discovered correctly now https://us-west-2.console.aws.amazon.com/devicefarm/home#/mobile/projects/02a2cf0f-6d9b-45ee-ba1a-a086587469e6/runs/c492a3e2-11a9-456b-82c6-3a92602e8ecf