### PR TITLE
[bots] Bot to rerun workflows that fail due to weird infra error 

### DIFF
--- a/torchci/lib/bot/index.ts
+++ b/torchci/lib/bot/index.ts
@@ -11,6 +11,7 @@ import webhookToDynamo from "./webhookToDynamo";
 import cancelWorkflowsOnCloseBot from "./cancelWorkflowsOnCloseBot";
 import stripApprovalBot from "./stripApprovalBot";
 import codevNoWritePerm from "./codevNoWritePermBot";
+import rerunGithubInfraErrorWorkflow from "./rerunGithubInfraErrorWorkflow";
 
 export default function bot(app: Probot) {
   autoCcBot(app);
@@ -25,4 +26,5 @@ export default function bot(app: Probot) {
   retryBot(app);
   cancelWorkflowsOnCloseBot(app);
   codevNoWritePerm(app);
+  rerunGithubInfraErrorWorkflow(app);
 }

--- a/torchci/lib/bot/rerunGithubInfraErrorWorkflow.ts
+++ b/torchci/lib/bot/rerunGithubInfraErrorWorkflow.ts
@@ -4,7 +4,7 @@ function acceptBot(app: Probot): void {
   // This bot is used to rerun failed workflows on pytorch/pytorch that look
   // like https://github.com/pytorch/pytorch/actions/runs/8454565307
   app.on("workflow_run.completed", async (ctx) => {
-    const tagPrefix = "fightGithubFailures/";
+    const tagPrefix = "rerunGithubInfraFailure/";
     // Only run this if pytorch/pytorch, failed, is a weird infra error, and is
     // not a previous run of this bot
     if (
@@ -16,7 +16,8 @@ function acceptBot(app: Probot): void {
       return;
     }
     // Create a new tag instead of using something like ciflow/ since some
-    // workflows might have been successfully triggered
+    // workflows might have been successfully triggered and we don't want to
+    // rerun those
     const tagName = `${tagPrefix}${ctx.payload.workflow_run.id}`;
     await ctx.octokit.git.createRef({
       owner: ctx.payload.repository.owner.login,

--- a/torchci/lib/bot/rerunGithubInfraErrorWorkflow.ts
+++ b/torchci/lib/bot/rerunGithubInfraErrorWorkflow.ts
@@ -1,0 +1,36 @@
+import { Probot } from "probot";
+
+function acceptBot(app: Probot): void {
+  // This bot is used to rerun failed workflows on pytorch/pytorch that look
+  // like https://github.com/pytorch/pytorch/actions/runs/8454565307
+  app.on("workflow_run.completed", async (ctx) => {
+    const tagPrefix = "fightGithubFailures/";
+    // Only run this if pytorch/pytorch, failed, is a weird infra error, and is
+    // not a previous run of this bot
+    if (
+      ctx.payload.workflow_run.repository.full_name !== "pytorch/pytorch" ||
+      ctx.payload.workflow_run.conclusion !== "failure" ||
+      !ctx.payload.workflow_run.name.startsWith(".github/workflows") ||
+      ctx.payload.workflow_run.head_branch.startsWith(tagPrefix)
+    ) {
+      return;
+    }
+    // Create a new tag instead of using something like ciflow/ since some
+    // workflows might have been successfully triggered
+    const tagName = `${tagPrefix}${ctx.payload.workflow_run.id}`;
+    await ctx.octokit.git.createRef({
+      owner: ctx.payload.repository.owner.login,
+      repo: ctx.payload.repository.name,
+      ref: tagName,
+      sha: ctx.payload.workflow_run.head_sha,
+    });
+    await ctx.octokit.actions.createWorkflowDispatch({
+      owner: ctx.payload.repository.owner.login,
+      repo: ctx.payload.repository.name,
+      workflow_id: ctx.payload.workflow_run.workflow_id,
+      ref: tagName,
+    });
+  });
+}
+
+export default acceptBot;


### PR DESCRIPTION
https://support.github.com/ticket/personal/0/2690822

I've been doing this manually for commits on main to get signal: make tag, trigger workflow dispatches on the tag.
