### PR TITLE
[ez][log classifier] More specific bazel build failure rule

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -73,6 +73,10 @@ name = 'Windows PyLong API usage check'
 pattern = '^Usage of PyLong_\{From,As\}\{Unsigned\}Long API may lead to overflow errors on Windows'
 
 [[rule]]
+name = 'Specific bazel build failure'
+pattern = '^ERROR: (.*(?:bazel|WORKSPACE|target).*)'
+
+[[rule]]
 name = 'Bazel build failure'
 pattern = '^FAILED: Build did NOT complete successfully'
 

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -73,7 +73,7 @@ name = 'Windows PyLong API usage check'
 pattern = '^Usage of PyLong_\{From,As\}\{Unsigned\}Long API may lead to overflow errors on Windows'
 
 [[rule]]
-name = 'Specific bazel build failure'
+name = 'Bazel build failure (specific)'
 pattern = '^ERROR: (.*(?:bazel|WORKSPACE|target).*)'
 
 [[rule]]


### PR DESCRIPTION
This might be too specific...
Should give better matches for:
https://github.com/pytorch/pytorch/actions/runs/8454738001/job/23160545092
https://github.com/pytorch/pytorch/actions/runs/8425535599/job/23071873165