### PR TITLE
Add cudagraphs_low_precision backend and quant dtype to inductor dashboard

### DIFF
--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -64,6 +64,7 @@ export const COMPILER_NAMES_TO_DISPLAY_NAMES: { [k: string]: string } = {
   inductor_cpp_wrapper: "cpp_wrapper",
   inductor_aot_inductor: "aot_inductor",
   inductor_with_cudagraphs_freezing: "cudagraphs_freezing",
+  inductor_cudagraphs_low_precision: "cudagraphs_low_precision",
 };
 export const DISPLAY_NAMES_TO_COMPILER_NAMES: { [k: string]: string } = {
   inductor_default: "inductor_no_cudagraphs",
@@ -73,6 +74,7 @@ export const DISPLAY_NAMES_TO_COMPILER_NAMES: { [k: string]: string } = {
   cpp_wrapper: "inductor_cpp_wrapper",
   aot_inductor: "inductor_aot_inductor",
   cudagraphs_freezing: "inductor_with_cudagraphs_freezing",
+  cudagraphs_low_precision: "inductor_cudagraphs_low_precision",
 };
 export const BLOCKLIST_COMPILERS = ["aot_eager", "eager"];
 export const SUITES: { [k: string]: string } = {
@@ -88,7 +90,7 @@ export const MODES: { [k: string]: string } = {
   training: "amp",
   inference: "bfloat16",
 };
-export const DTYPES = ["amp", "float16", "bfloat16"];
+export const DTYPES = ["amp", "float16", "bfloat16", "quant"];
 export const PASSING_ACCURACY = ["pass", "pass_due_to_skip", "eager_variation"];
 
 // Relative thresholds


### PR DESCRIPTION
This goes together with https://github.com/pytorch/pytorch/pull/123419.  I can see the mock data is being uploaded to Rockset and shows up there correctly https://github.com/pytorch/pytorch/actions/runs/8567300438/job/23478811801