### PR TITLE
Utilize Python build package instead of setup.py

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -167,13 +167,13 @@ jobs:
           cache-key: ${{ inputs.cache-key }}
           repository: ${{ inputs.repository  }}
           script: ${{ inputs.pre-script }}
-      - name: Build clean
-        working-directory: ${{ inputs.repository }}
-        shell: bash -l {0}
+      - name: Install python build dependency
         run: |
           set -euxo pipefail
+          # shellcheck disable=SC1090
           source "${BUILD_ENV_FILE}"
-          ${CONDA_RUN} python setup.py clean
+          # shellcheck disable=SC2086
+          ${CONDA_RUN} python -m pip install build
       - name: Build the wheel (bdist_wheel)
         working-directory: ${{ inputs.repository }}
         shell: bash -l {0}
@@ -181,7 +181,7 @@ jobs:
           set -euxo pipefail
           source "${BUILD_ENV_FILE}"
           export PYTORCH_VERSION="$(${CONDA_RUN} pip show torch | grep ^Version: | sed 's/Version:  *//' | sed 's/+.\+//')"
-          ${CONDA_RUN} python setup.py bdist_wheel
+          ${CONDA_RUN} python -m build --wheel
       - name: Run Post-Script
         if: ${{ inputs.post-script != '' }}
         uses: ./test-infra/.github/actions/run-script-with-cache

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -181,7 +181,7 @@ jobs:
           set -euxo pipefail
           source "${BUILD_ENV_FILE}"
           export PYTORCH_VERSION="$(${CONDA_RUN} pip show torch | grep ^Version: | sed 's/Version:  *//' | sed 's/+.\+//')"
-          ${CONDA_RUN} python -m build
+          ${CONDA_RUN} python -m build --wheel -x
       - name: Run Post-Script
         if: ${{ inputs.post-script != '' }}
         uses: ./test-infra/.github/actions/run-script-with-cache

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -181,7 +181,7 @@ jobs:
           set -euxo pipefail
           source "${BUILD_ENV_FILE}"
           export PYTORCH_VERSION="$(${CONDA_RUN} pip show torch | grep ^Version: | sed 's/Version:  *//' | sed 's/+.\+//')"
-          ${CONDA_RUN} python -m build --wheel -x
+          ${CONDA_RUN} python -m build --wheel -n
       - name: Run Post-Script
         if: ${{ inputs.post-script != '' }}
         uses: ./test-infra/.github/actions/run-script-with-cache

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -181,7 +181,7 @@ jobs:
           set -euxo pipefail
           source "${BUILD_ENV_FILE}"
           export PYTORCH_VERSION="$(${CONDA_RUN} pip show torch | grep ^Version: | sed 's/Version:  *//' | sed 's/+.\+//')"
-          ${CONDA_RUN} python -m build --wheel
+          ${CONDA_RUN} python -m build
       - name: Run Post-Script
         if: ${{ inputs.post-script != '' }}
         uses: ./test-infra/.github/actions/run-script-with-cache


### PR DESCRIPTION
#### Context

The current method by which NOVA workflows build Python wheels [is deprecated](https://packaging.python.org/en/latest/guides/modernize-setup-py-project/#should-setup-py-be-deleted). Instead of calling `python setup.py bdist_wheel`, all building should be done by the Python Packaging Authority's [build tool](https://build.pypa.io/en/stable/mission.html). Here are a couple more links about the topic:
- https://packaging.python.org/en/latest/discussions/setup-py-deprecated/ 
- https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html

**This only fixes the NOVA Linux workflow, not macOS or Windows**

#### Changelog

- Add step in Linux workflows to pip install the `build` tool
- Remove the "clean" command as it is no longer needed
- Change the build step to utilize the build command

#### Testing
- CI green

#### Considerations

1. `build` is [only compatible with Python>=3.8](https://build.pypa.io/en/stable/installation.html#compatibility)