### PR TITLE
Add a max search window guardrail when querying similar failures

### DIFF
--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -58,6 +58,13 @@ on:
         type: string
         default: ''
 
+      # Android-specific inputs
+      android-app-archive:
+        description: The name of the Android app APK archive to run
+        required: false
+        type: string
+        default: ''
+
 jobs:
   job:
     name: ${{ inputs.job-name }} (${{ inputs.device-type }})

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -58,13 +58,6 @@ on:
         type: string
         default: ''
 
-      # Android-specific inputs
-      android-app-archive:
-        description: The name of the Android app APK archive to run
-        required: false
-        type: string
-        default: ''
-
 jobs:
   job:
     name: ${{ inputs.job-name }} (${{ inputs.device-type }})

--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -45,6 +45,10 @@ export const EXCLUDED_FROM_FLAKINESS = [
   "linux-docs",
   "ghstack-mergeability-check",
 ];
+// If the base commit is too old, don't query for similar failures because
+// it increases the risk of getting misclassification. This guardrail can
+// be relaxed once we achieve better accuracy from the log classifier
+export const MAX_SEARCH_HOURS_FOR_QUERYING_SIMILAR_FAILURES = 7 * 24;
 // Mapping the job to the list of suppressed labels
 export const SUPPRESSED_JOB_BY_LABELS: { [job: string]: string[] } = {
   bc_linter: ["suppress-bc-linter", "suppress-api-compatibility-check"],
@@ -264,6 +268,15 @@ export async function querySimilarFailures(
       ? baseCommitDate
       : job.completed_at
   ).subtract(lookbackPeriodInHours, "hour");
+
+  if (
+    endDate.diff(startDate, "hour") >
+    MAX_SEARCH_HOURS_FOR_QUERYING_SIMILAR_FAILURES
+  ) {
+    // The base commit is too old, given the current accuracy of the log classifier, it
+    // increases the risk of getting an FP when searching for similar failures
+    return [];
+  }
 
   // Get the workflow name if possible
   const jobNameIndex = job.name.indexOf(` / ${job.jobName}`);

--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -47,7 +47,8 @@ export const EXCLUDED_FROM_FLAKINESS = [
 ];
 // If the base commit is too old, don't query for similar failures because
 // it increases the risk of getting misclassification. This guardrail can
-// be relaxed once we achieve better accuracy from the log classifier
+// be relaxed once we achieve better accuracy from the log classifier. This
+// sets the limit to 7 days
 export const MAX_SEARCH_HOURS_FOR_QUERYING_SIMILAR_FAILURES = 7 * 24;
 // Mapping the job to the list of suppressed labels
 export const SUPPRESSED_JOB_BY_LABELS: { [job: string]: string[] } = {

--- a/torchci/test/drciUtils.test.ts
+++ b/torchci/test/drciUtils.test.ts
@@ -132,7 +132,7 @@ describe("Test various utils used by Dr.CI", () => {
     );
 
     mock.mockClear();
-    const baseCommitDate = "2023-07-01T00:00:00Z";
+    const baseCommitDate = "2023-07-31T00:00:00Z";
 
     // Use base commit date
     expect(
@@ -198,6 +198,21 @@ describe("Test various utils used by Dr.CI", () => {
         ],
       ])
     );
+
+    mock.mockClear();
+    // The base commit date is too old, and flaky detection doesn't apply to avoid FPs
+    const oldBaseCommitDate = "2023-07-01T00:00:00Z";
+
+    expect(
+      await querySimilarFailures(
+        job,
+        oldBaseCommitDate,
+        lookbackPeriodInHours,
+        searchUtils.MAX_SIZE,
+        searchUtils.OLDEST_FIRST,
+        "TESTING" as unknown as Client
+      )
+    ).toStrictEqual([]);
   });
 
   test("test hasSimilarFailures", async () => {

--- a/torchci/test/drciUtils.test.ts
+++ b/torchci/test/drciUtils.test.ts
@@ -5,6 +5,7 @@ import {
   isExcludedFromFlakiness,
   isLogClassifierFailed,
   isSuppressedByLabels,
+  MAX_SEARCH_HOURS_FOR_QUERYING_SIMILAR_FAILURES,
 } from "../lib/drciUtils";
 import * as searchUtils from "../lib/searchUtils";
 import * as jobUtils from "../lib/jobUtils";
@@ -201,7 +202,9 @@ describe("Test various utils used by Dr.CI", () => {
 
     mock.mockClear();
     // The base commit date is too old, and flaky detection doesn't apply to avoid FPs
-    const oldBaseCommitDate = "2023-07-01T00:00:00Z";
+    const oldBaseCommitDate = dayjs(mockEndDate)
+      .subtract(MAX_SEARCH_HOURS_FOR_QUERYING_SIMILAR_FAILURES - 23, "hour")
+      .toISOString();
 
     expect(
       await querySimilarFailures(


### PR DESCRIPTION
This is to address a common source of wrong classifications as shown in https://github.com/pytorch/test-infra/issues/5063 where the merge base commit is too old.  This increases the chance of marking actual failures as flaky because the search window could be big.  We can relax this once we achieve a higher accuracy with the log classifier as explained in https://github.com/pytorch/test-infra/issues/5063#issuecomment-2045925642

### Testing

https://github.com/pytorch/pytorch/pull/123482 has flaky failure and it merge base is a month old.  After this change, the flaky failure won't be marked as flaky anymore:

<!-- drci-comment-start -->

## :link: Helpful Links
### :test_tube: See artifacts and rendered test results at [hud.pytorch.org/pr/123482](https://hud.pytorch.org/pr/123482)
* :page_facing_up: Preview [Python docs built from this PR](https://docs-preview.pytorch.org/pytorch/pytorch/123482/index.html)
* :page_facing_up: Preview [C++ docs built from this PR](https://docs-preview.pytorch.org/pytorch/pytorch/123482/cppdocs/index.html)
* :question: Need help or want to give feedback on the CI? Visit the [bot commands wiki](https://github.com/pytorch/pytorch/wiki/Bot-commands) or our [office hours](https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours)

Note: Links to docs will display an error until the docs builds have been completed.


## :x: 2 New Failures
As of commit 1ab823a683847d8c01b35bda74143876f922586b with merge base 86a2d67bb9db7dae8ff4589930dd505a6c5b4ec6 (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1710217340?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details open><summary><b>NEW FAILURES</b> - The following jobs have failed:</summary><p>

* [pull / linux-focal-py3.11-clang10 / test (default, 1, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/123482#23507840916) ([gh](https://github.com/pytorch/pytorch/actions/runs/8576493039/job/23507840916))
    `Process completed with exit code 1.`
* [pull / linux-jammy-py3.10-clang15-asan / test (default, 6, 6, linux.4xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/123482#23507963375) ([gh](https://github.com/pytorch/pytorch/actions/runs/8576493039/job/23507963375))
    `Process completed with exit code 1.`
</p></details>


This comment was automatically generated by Dr. CI and updates every 15 minutes.
<!-- drci-comment-end -->