### PR TITLE
.github: Relax setup-nvidia distro check for ubuntu

### DIFF
--- a/.github/actions/setup-nvidia/action.yml
+++ b/.github/actions/setup-nvidia/action.yml
@@ -214,7 +214,7 @@ runs:
               amzn*)
                   install_nvidia_driver_amzn2
                   ;;
-              ubuntu20.04)
+              ubuntu*)
                   install_nvidia_driver_ubuntu20
                   ;;
               *)
@@ -229,7 +229,7 @@ runs:
               amzn*)
                   install_nvidia_docker2_amzn2
                   ;;
-              ubuntu20.04)
+              ubuntu*)
                   install_nvidia_docker2_ubuntu20
                   ;;
               *)


### PR DESCRIPTION
Relaxes the distribution check for ubuntu to allow for any version of ubuntu to be referenced here to make it easier to support multiple versions of ubuntu if needed