### PR TITLE
Allow old packages to default to setup.py-based build

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -65,11 +65,11 @@ on:
         required: false
         type: boolean
         default: true
-      build-command:
-        description: Python command to build package.
+      use-python-build-package:
+        description: Utilize the standard build package from PyPA.
         required: false
-        type: string
-        default: "python setup.py bdist_wheel"
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -173,13 +173,21 @@ jobs:
           repository: ${{ inputs.repository  }}
           script: ${{ inputs.pre-script }}
       - name: Install python build dependency
-        if: contains( ${{ inputs.build-command }}, 'python -m build')
+        if: ${{ inputs.use-python-build-package }}
         run: |
           set -euxo pipefail
           # shellcheck disable=SC1090
           source "${BUILD_ENV_FILE}"
           # shellcheck disable=SC2086
           ${CONDA_RUN} python -m pip install build
+      - name: Build clean
+        if: ${{ !inputs.use-python-build-package }} 
+        working-directory: ${{ inputs.repository }}
+        shell: bash -l {0}
+        run: |
+          set -euxo pipefail
+          source "${BUILD_ENV_FILE}"
+          ${CONDA_RUN} python setup.py clean
       - name: Build the wheel (bdist_wheel)
         working-directory: ${{ inputs.repository }}
         shell: bash -l {0}
@@ -187,7 +195,11 @@ jobs:
           set -euxo pipefail
           source "${BUILD_ENV_FILE}"
           export PYTORCH_VERSION="$(${CONDA_RUN} pip show torch | grep ^Version: | sed 's/Version:  *//' | sed 's/+.\+//')"
-          ${CONDA_RUN} ${{ inputs.build-command }}
+          if [[ ${{ inputs.use-python-build-package }} == 'true' ]]; then
+            ${CONDA_RUN} python -m build --wheel
+          else
+            ${CONDA_RUN} python setup.py bdist_wheel
+          fi
       - name: Run Post-Script
         if: ${{ inputs.post-script != '' }}
         uses: ./test-infra/.github/actions/run-script-with-cache

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -65,11 +65,11 @@ on:
         required: false
         type: boolean
         default: true
-      use-python-build-package:
-        description: Utilize the standard build package from PyPA.
+      build-platform:
+        description: Platform to build wheels, choose from 'python-build-package' or 'setup-py' 
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: 'setup-py'
 
 permissions:
   id-token: write
@@ -173,7 +173,7 @@ jobs:
           repository: ${{ inputs.repository  }}
           script: ${{ inputs.pre-script }}
       - name: Install python build dependency
-        if: ${{ inputs.use-python-build-package }}
+        if: ${{ inputs.build-platform == 'python-build-package' }}
         run: |
           set -euxo pipefail
           # shellcheck disable=SC1090
@@ -181,7 +181,7 @@ jobs:
           # shellcheck disable=SC2086
           ${CONDA_RUN} python -m pip install build
       - name: Build clean
-        if: ${{ !inputs.use-python-build-package }} 
+        if: ${{ inputs.build-platform == 'setup-py' }} 
         working-directory: ${{ inputs.repository }}
         shell: bash -l {0}
         run: |
@@ -195,7 +195,7 @@ jobs:
           set -euxo pipefail
           source "${BUILD_ENV_FILE}"
           export PYTORCH_VERSION="$(${CONDA_RUN} pip show torch | grep ^Version: | sed 's/Version:  *//' | sed 's/+.\+//')"
-          if [[ ${{ inputs.use-python-build-package }} == 'true' ]]; then
+          if [[ ${{ inputs.build-platform }} == 'python-build-package' ]]; then
             ${CONDA_RUN} python -m build --wheel
           else
             ${CONDA_RUN} python setup.py bdist_wheel

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -65,6 +65,11 @@ on:
         required: false
         type: boolean
         default: true
+      build-command:
+        description: Python command to build package.
+        required: false
+        type: string
+        default: "python setup.py bdist_wheel"
 
 permissions:
   id-token: write
@@ -168,6 +173,7 @@ jobs:
           repository: ${{ inputs.repository  }}
           script: ${{ inputs.pre-script }}
       - name: Install python build dependency
+        if: contains( ${{ inputs.build-command }}, 'python -m build')
         run: |
           set -euxo pipefail
           # shellcheck disable=SC1090
@@ -181,7 +187,7 @@ jobs:
           set -euxo pipefail
           source "${BUILD_ENV_FILE}"
           export PYTORCH_VERSION="$(${CONDA_RUN} pip show torch | grep ^Version: | sed 's/Version:  *//' | sed 's/+.\+//')"
-          ${CONDA_RUN} python -m build --wheel -n
+          ${CONDA_RUN} ${{ inputs.build-command }}
       - name: Run Post-Script
         if: ${{ inputs.post-script != '' }}
         uses: ./test-infra/.github/actions/run-script-with-cache

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -172,34 +172,28 @@ jobs:
           cache-key: ${{ inputs.cache-key }}
           repository: ${{ inputs.repository  }}
           script: ${{ inputs.pre-script }}
-      - name: Install python build dependency
+      - name: Build the wheel (python-build-package)
         if: ${{ inputs.build-platform == 'python-build-package' }}
+        working-directory: ${{ inputs.repository }}
+        shell: bash -l {0}
         run: |
           set -euxo pipefail
-          # shellcheck disable=SC1090
           source "${BUILD_ENV_FILE}"
-          # shellcheck disable=SC2086
+          export PYTORCH_VERSION="$(${CONDA_RUN} pip show torch | grep ^Version: | sed 's/Version: *//' | sed 's/+.\+//')"
           ${CONDA_RUN} python -m pip install build
-      - name: Build clean
+          echo "Successfully installed Python build package"
+          ${CONDA_RUN} python -m build --wheel
+      - name: Build the wheel (setup-py)
         if: ${{ inputs.build-platform == 'setup-py' }} 
         working-directory: ${{ inputs.repository }}
         shell: bash -l {0}
         run: |
           set -euxo pipefail
           source "${BUILD_ENV_FILE}"
+          export PYTORCH_VERSION="$(${CONDA_RUN} pip show torch | grep ^Version: | sed 's/Version: *//' | sed 's/+.\+//')"
           ${CONDA_RUN} python setup.py clean
-      - name: Build the wheel (bdist_wheel)
-        working-directory: ${{ inputs.repository }}
-        shell: bash -l {0}
-        run: |
-          set -euxo pipefail
-          source "${BUILD_ENV_FILE}"
-          export PYTORCH_VERSION="$(${CONDA_RUN} pip show torch | grep ^Version: | sed 's/Version:  *//' | sed 's/+.\+//')"
-          if [[ ${{ inputs.build-platform }} == 'python-build-package' ]]; then
-            ${CONDA_RUN} python -m build --wheel
-          else
-            ${CONDA_RUN} python setup.py bdist_wheel
-          fi
+          echo "Successfully ran `python setup.py clean`"
+          ${CONDA_RUN} python setup.py bdist_wheel
       - name: Run Post-Script
         if: ${{ inputs.post-script != '' }}
         uses: ./test-infra/.github/actions/run-script-with-cache

--- a/.github/workflows/test_build_wheels_linux_without_cuda.yml
+++ b/.github/workflows/test_build_wheels_linux_without_cuda.yml
@@ -43,3 +43,4 @@ jobs:
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       package-name: ${{ matrix.package-name }}
       trigger-event: "${{ github.event_name }}"
+      build-platform: 'python-build-package'


### PR DESCRIPTION
It was brought up [here](https://github.com/pytorch/test-infra/pull/5071#issuecomment-2046202327) that various workflows may still be reliant on the old way of installing python packages (invoking setup.py directly). 

While these workflows *should* enable their packages to work with `build` eventually, they should have ample time to do so. Therefore, this change established a default for the build command on Linux workflows. Therefore, newer packages can start to specify `python -m build --wheel`, without disrupting the other workflows reliant on Nova.