### PR TITLE
Add Android support to mobile job workflow

### DIFF
--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -30,6 +30,10 @@ on:
         description: The AWS Device Farm project where the test runs
         default: 'arn:aws:devicefarm:us-west-2:308535385114:project:b531574a-fb82-40ae-b687-8f0b81341ae0'
         type: string
+      device-pool-arn:
+        description: The device pool associated with the project
+        default: 'arn:aws:devicefarm:us-west-2:308535385114:devicepool:082d10e5-d7d7-48a5-ba5c-b33d66efa1f5'
+        type: string
 
       # Pulling test-infra itself for device farm runner script
       test-infra-repository:
@@ -67,7 +71,10 @@ on:
 
       # Some share test inputs, TODO (huydhn): Support S3 links for the test spec here
       test-spec:
-        description: Specify how the test should be run on device
+        description: |
+          Specify how the test should be run on device. This could either be a link to
+          download the spec or an existing ARN if the spec has previously been uploaded
+          to AWS
         required: false
         type: string
         default: ''
@@ -148,13 +155,6 @@ jobs:
           name: ${{ inputs.android-test-archive }}
           path: test-infra/tools/device-farm-runner/
 
-      - name: Download the test spec
-        if: ${{ inputs.test-spec != '' }}
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ inputs.test-spec }}
-          path: test-infra/tools/device-farm-runner/
-
       - name: Verify iOS artifacts
         if: ${{ inputs.device-type == 'ios' }}
         shell: bash
@@ -184,7 +184,6 @@ jobs:
         env:
           APP_ARCHIVE: ${{ inputs.android-app-archive }}
           TEST_ARCHIVE: ${{ inputs.android-test-archive }}
-          TEST_SPEC: ${{ inputs.test-spec }}
         run: |
           set -ex
 
@@ -201,6 +200,7 @@ jobs:
           ls -lah ci.apk ci.test.apk
 
       - name: Verify test spec
+        id: verify-test-spec
         shell: bash
         working-directory: test-infra/tools/device-farm-runner
         env:
@@ -208,10 +208,16 @@ jobs:
         run: |
           set -ex
 
-          if [ -n "${TEST_SPEC}" ]; then
-            mv "${TEST_SPEC}" ci.yml
-            cat ci.yml
+          if [[ "${TEST_SPEC}" == http* ]]; then
+            TEST_SPEC_OUTPUT="ci.yml"
+
+            curl -s "${TEST_SPEC}" -o "${TEST_SPEC_OUTPUT}"
+            cat "${TEST_SPEC_OUTPUT}"
+          else
+            TEST_SPEC_OUTPUT="${TEST_SPEC}"
           fi
+
+          echo "test-spec-output=${TEST_SPEC_OUTPUT}" >> "${GITHUB_OUTPUT}"
 
       - name: Verify extra data archive
         id: verify-extra-data
@@ -223,7 +229,7 @@ jobs:
           set -ex
 
           if [ -n "${EXTRA_DATA}" ]; then
-            if [ "${EXTRA_DATA}" == http* ]; then
+            if [[ "${EXTRA_DATA}" == http* ]]; then
               EXTRA_DATA_OUTPUT="extra-data.zip"
 
               curl -s "${EXTRA_DATA}" -o "${EXTRA_DATA_OUTPUT}"
@@ -243,6 +249,8 @@ jobs:
         working-directory: test-infra/tools/device-farm-runner
         env:
           PROJECT_ARN: ${{ inputs.project-arn }}
+          DEVICE_POOL_ARN: ${{ inputs.device-pool-arn }}
+          TEST_SPEC: ${{ steps.verify-test-spec.outputs.test-spec-output }}
           EXTRA_DATA: ${{ steps.verify-extra-data.outputs.extra-data-output }}
           # For record keeping
           JOB_NAME: ${{ inputs.job-name }}
@@ -254,10 +262,11 @@ jobs:
 
           ${CONDA_RUN} python run_on_aws_devicefarm.py \
             --project-arn "${PROJECT_ARN}" \
+            --device-pool-arn "${DEVICE_POOL_ARN}" \
             --app-file ci.ipa \
             --ios-xctestrun-file ci.xctestrun.zip \
             --extra-data "${EXTRA_DATA}" \
-            --test-spec ci.yml \
+            --test-spec "${TEST_SPEC}" \
             --name-prefix "${JOB_NAME}-${DEVICE_TYPE}" \
             --workflow-id "${RUN_ID}" \
             --workflow-attempt "${RUN_ATTEMPT}"
@@ -268,6 +277,8 @@ jobs:
         working-directory: test-infra/tools/device-farm-runner
         env:
           PROJECT_ARN: ${{ inputs.project-arn }}
+          DEVICE_POOL_ARN: ${{ inputs.device-pool-arn }}
+          TEST_SPEC: ${{ steps.verify-test-spec.outputs.test-spec-output }}
           EXTRA_DATA: ${{ steps.verify-extra-data.outputs.extra-data-output }}
           # For record keeping
           JOB_NAME: ${{ inputs.job-name }}
@@ -279,10 +290,11 @@ jobs:
 
           ${CONDA_RUN} python run_on_aws_devicefarm.py \
             --project-arn "${PROJECT_ARN}" \
+            --device-pool-arn "${DEVICE_POOL_ARN}" \
             --app-file ci.apk \
             --android-instrumention-test-file ci.test.apk \
             --extra-data "${EXTRA_DATA}" \
-            --test-spec ci.yml \
+            --test-spec "${TEST_SPEC}" \
             --name-prefix "${JOB_NAME}-${DEVICE_TYPE}" \
             --workflow-id "${RUN_ID}" \
             --workflow-attempt "${RUN_ATTEMPT}"

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -45,31 +45,36 @@ on:
         default: ''
         type: string
 
-      # iOS-specific inputs, TODO (huydhn): Support S3 links here
+      # iOS-specific inputs
       ios-ipa-archive:
-        description: The name of the iOS app IPA archive to run the tests
+        description: |
+          Either a link to the iOS app IPA archive to run the tests or an existing ARN
         required: false
         type: string
         default: ''
       ios-xctestrun-zip:
-        description: The name of the iOS xctestrun zip archive
+        description: |
+          Either a link to the iOS xctestrun zip archive or an existing ARN
         required: false
         type: string
         default: ''
 
-      # Android-specific inputs, TODO (huydhn): Support S3 links here
+      # Android-specific inputs
       android-app-archive:
-        description: The name of the Android app APK archive to run
+        description: |
+          Either a link to the Android app APK archive to run or an existing ARN
         required: false
         type: string
         default: ''
       android-test-archive:
-        description: The name of the Android instrumention tests APK archive to run
+        description: |
+          Either a link to the Android instrumentation tests APK archive to run or
+          an existing ARN
         required: false
         type: string
         default: ''
 
-      # Some share test inputs, TODO (huydhn): Support S3 links for the test spec here
+      # Some share test inputs
       test-spec:
         description: |
           Specify how the test should be run on device. This could either be a link to
@@ -127,35 +132,8 @@ jobs:
         run: |
           ${CONDA_RUN} pip install -r requirements.txt
 
-      - name: Download iOS app
-        if: ${{ inputs.device-type == 'ios' && inputs.ios-ipa-archive != '' }}
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ inputs.ios-ipa-archive }}
-          path: test-infra/tools/device-farm-runner/
-
-      - name: Download iOS test suite
-        if: ${{ inputs.device-type == 'ios' && inputs.ios-xctestrun-zip != '' }}
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ inputs.ios-xctestrun-zip }}
-          path: test-infra/tools/device-farm-runner/
-
-      - name: Download Android app
-        if: ${{ inputs.device-type == 'android' && inputs.android-app-archive != '' }}
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ inputs.android-app-archive }}
-          path: test-infra/tools/device-farm-runner/
-
-      - name: Download Android test suite
-        if: ${{ inputs.device-type == 'android' && inputs.android-test-archive != '' }}
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ inputs.android-test-archive }}
-          path: test-infra/tools/device-farm-runner/
-
       - name: Verify iOS artifacts
+        id: verify-ios-artifacts
         if: ${{ inputs.device-type == 'ios' }}
         shell: bash
         working-directory: test-infra/tools/device-farm-runner
@@ -170,14 +148,30 @@ jobs:
             exit 1
           fi
 
-          # NP: The suffix needs to be exact, otherwise, AWS will reject them
-          mv "${IPA_ARCHIVE}" ci.ipa
-          mv "${XCTESTRUN_ZIP}" ci.xctestrun.zip
+          if [[ "${IPA_ARCHIVE}" == http* ]]; then
+            IPA_ARCHIVE_OUTPUT="ci.ipa"
 
-          # Print the artifacts to manually verify them if needed
-          ls -lah ci.ipa ci.xctestrun.zip
+            curl -s "${IPA_ARCHIVE}" -o "${IPA_ARCHIVE_OUTPUT}"
+            ls -lah "${IPA_ARCHIVE_OUTPUT}"
+          else
+            IPA_ARCHIVE_OUTPUT="${IPA_ARCHIVE}"
+          fi
+
+          echo "ipa-archive-output=${IPA_ARCHIVE_OUTPUT}" >> "${GITHUB_OUTPUT}"
+
+          if [[ "${XCTESTRUN_ZIP}" == http* ]]; then
+            XCTESTRUN_ZIP_OUTPUT="ci.xctestrun.zip"
+
+            curl -s "${XCTESTRUN_ZIP}" -o "${XCTESTRUN_ZIP_OUTPUT}"
+            ls -lah "${XCTESTRUN_ZIP_OUTPUT}"
+          else
+            XCTESTRUN_ZIP_OUTPUT="${XCTESTRUN_ZIP}"
+          fi
+
+          echo "xctestrun-zip-output=${XCTESTRUN_ZIP_OUTPUT}" >> "${GITHUB_OUTPUT}"
 
       - name: Verify Android artifacts
+        id: verify-android-artifacts
         if: ${{ inputs.device-type == 'android' }}
         shell: bash
         working-directory: test-infra/tools/device-farm-runner
@@ -192,12 +186,27 @@ jobs:
             exit 1
           fi
 
-          # NP: The suffix needs to be exact, otherwise, AWS will reject them
-          mv "${APP_ARCHIVE}" ci.apk
-          mv "${TEST_ARCHIVE}" ci.test.apk
+          if [[ "${APP_ARCHIVE}" == http* ]]; then
+            APP_ARCHIVE_OUTPUT="ci.apk"
 
-          # Print the artifacts to manually verify them if needed
-          ls -lah ci.apk ci.test.apk
+            curl -s "${APP_ARCHIVE}" -o "${APP_ARCHIVE_OUTPUT}"
+            ls -lah "${APP_ARCHIVE_OUTPUT}"
+          else
+            APP_ARCHIVE_OUTPUT="${APP_ARCHIVE}"
+          fi
+
+          echo "app-archive-output=${APP_ARCHIVE_OUTPUT}" >> "${GITHUB_OUTPUT}"
+
+          if [[ "${TEST_ARCHIVE}" == http* ]]; then
+            TEST_ARCHIVE_OUTPUT="ci.test.apk"
+
+            curl -s "${TEST_ARCHIVE}" -o "${TEST_ARCHIVE_OUTPUT}"
+            ls -lah "${TEST_ARCHIVE_OUTPUT}"
+          else
+            TEST_ARCHIVE_OUTPUT="${TEST_ARCHIVE}"
+          fi
+
+          echo "test-archive-output=${TEST_ARCHIVE_OUTPUT}" >> "${GITHUB_OUTPUT}"
 
       - name: Verify test spec
         id: verify-test-spec
@@ -250,6 +259,8 @@ jobs:
         env:
           PROJECT_ARN: ${{ inputs.project-arn }}
           DEVICE_POOL_ARN: ${{ inputs.device-pool-arn }}
+          IPA_ARCHIVE: ${{ steps.verify-ios-artifacts.outputs.ipa-archive-output }}
+          XCTESTRUN_ZIP: ${{ steps.verify-ios-artifacts.outputs.xctestrun-zip-output }}
           TEST_SPEC: ${{ steps.verify-test-spec.outputs.test-spec-output }}
           EXTRA_DATA: ${{ steps.verify-extra-data.outputs.extra-data-output }}
           # For record keeping
@@ -263,8 +274,8 @@ jobs:
           ${CONDA_RUN} python run_on_aws_devicefarm.py \
             --project-arn "${PROJECT_ARN}" \
             --device-pool-arn "${DEVICE_POOL_ARN}" \
-            --app-file ci.ipa \
-            --ios-xctestrun-file ci.xctestrun.zip \
+            --app "${IPA_ARCHIVE}" \
+            --ios-xctestrun "${XCTESTRUN_ZIP}" \
             --extra-data "${EXTRA_DATA}" \
             --test-spec "${TEST_SPEC}" \
             --name-prefix "${JOB_NAME}-${DEVICE_TYPE}" \
@@ -278,6 +289,8 @@ jobs:
         env:
           PROJECT_ARN: ${{ inputs.project-arn }}
           DEVICE_POOL_ARN: ${{ inputs.device-pool-arn }}
+          APP_ARCHIVE: ${{ steps.verify-android-artifacts.outputs.app-archive-output }}
+          TEST_ARCHIVE: ${{ steps.verify-android-artifacts.outputs.test-archive-output }}
           TEST_SPEC: ${{ steps.verify-test-spec.outputs.test-spec-output }}
           EXTRA_DATA: ${{ steps.verify-extra-data.outputs.extra-data-output }}
           # For record keeping
@@ -291,8 +304,8 @@ jobs:
           ${CONDA_RUN} python run_on_aws_devicefarm.py \
             --project-arn "${PROJECT_ARN}" \
             --device-pool-arn "${DEVICE_POOL_ARN}" \
-            --app-file ci.apk \
-            --android-instrumention-test-file ci.test.apk \
+            --app "${APP_ARCHIVE}" \
+            --android-instrumentation-test "${TEST_ARCHIVE}" \
             --extra-data "${EXTRA_DATA}" \
             --test-spec "${TEST_SPEC}" \
             --name-prefix "${JOB_NAME}-${DEVICE_TYPE}" \

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -41,7 +41,7 @@ on:
         default: ''
         type: string
 
-      # iOS-specific inputs
+      # iOS-specific inputs, TODO (huydhn): Support S3 links here
       ios-ipa-archive:
         description: The name of the iOS app IPA archive to run the tests
         required: false
@@ -52,8 +52,30 @@ on:
         required: false
         type: string
         default: ''
-      ios-test-spec:
+
+      # Android-specific inputs, TODO (huydhn): Support S3 links here
+      android-app-archive:
+        description: The name of the Android app APK archive to run
+        required: false
+        type: string
+        default: ''
+      android-test-archive:
+        description: The name of the Android instrumention tests APK archive to run
+        required: false
+        type: string
+        default: ''
+
+      # Some share test inputs, TODO (huydhn): Support S3 links for the test spec here
+      test-spec:
         description: Specify how the test should be run on device
+        required: false
+        type: string
+        default: ''
+      # The extra data archive could be large, so it's better to keep them on S3
+      extra-data:
+        description: |
+          Either a link to a zip archive on S3 to be uploaded to the test device or
+          an existing ARN, for example, exported models
         required: false
         type: string
         default: ''
@@ -112,11 +134,25 @@ jobs:
           name: ${{ inputs.ios-xctestrun-zip }}
           path: test-infra/tools/device-farm-runner/
 
-      - name: Download iOS test spec
-        if: ${{ inputs.device-type == 'ios' && inputs.ios-test-spec != '' }}
+      - name: Download Android app
+        if: ${{ inputs.device-type == 'android' && inputs.android-app-archive != '' }}
         uses: actions/download-artifact@v3
         with:
-          name: ${{ inputs.ios-test-spec }}
+          name: ${{ inputs.android-app-archive }}
+          path: test-infra/tools/device-farm-runner/
+
+      - name: Download Android test suite
+        if: ${{ inputs.device-type == 'android' && inputs.android-test-archive != '' }}
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.android-test-archive }}
+          path: test-infra/tools/device-farm-runner/
+
+      - name: Download the test spec
+        if: ${{ inputs.test-spec != '' }}
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.test-spec }}
           path: test-infra/tools/device-farm-runner/
 
       - name: Verify iOS artifacts
@@ -126,7 +162,6 @@ jobs:
         env:
           IPA_ARCHIVE: ${{ inputs.ios-ipa-archive }}
           XCTESTRUN_ZIP: ${{ inputs.ios-xctestrun-zip }}
-          IOS_TEST_SPEC: ${{ inputs.ios-test-spec }}
         run: |
           set -ex
 
@@ -142,10 +177,65 @@ jobs:
           # Print the artifacts to manually verify them if needed
           ls -lah ci.ipa ci.xctestrun.zip
 
-          if [ -n "${IOS_TEST_SPEC}" ]; then
-            mv "${IOS_TEST_SPEC}" ci.yml
+      - name: Verify Android artifacts
+        if: ${{ inputs.device-type == 'android' }}
+        shell: bash
+        working-directory: test-infra/tools/device-farm-runner
+        env:
+          APP_ARCHIVE: ${{ inputs.android-app-archive }}
+          TEST_ARCHIVE: ${{ inputs.android-test-archive }}
+          TEST_SPEC: ${{ inputs.test-spec }}
+        run: |
+          set -ex
+
+          if [ -z "${APP_ARCHIVE}" ] || [ -z "${TEST_ARCHIVE}" ]; then
+            echo "Missing the app or test archives"
+            exit 1
+          fi
+
+          # NP: The suffix needs to be exact, otherwise, AWS will reject them
+          mv "${APP_ARCHIVE}" ci.apk
+          mv "${TEST_ARCHIVE}" ci.test.apk
+
+          # Print the artifacts to manually verify them if needed
+          ls -lah ci.apk ci.test.apk
+
+      - name: Verify test spec
+        shell: bash
+        working-directory: test-infra/tools/device-farm-runner
+        env:
+          TEST_SPEC: ${{ inputs.test-spec }}
+        run: |
+          set -ex
+
+          if [ -n "${TEST_SPEC}" ]; then
+            mv "${TEST_SPEC}" ci.yml
             cat ci.yml
           fi
+
+      - name: Verify extra data archive
+        id: verify-extra-data
+        shell: bash
+        working-directory: test-infra/tools/device-farm-runner
+        env:
+          EXTRA_DATA: ${{ inputs.extra-data }}
+        run: |
+          set -ex
+
+          if [ -n "${EXTRA_DATA}" ]; then
+            if [ "${EXTRA_DATA}" == http* ]; then
+              EXTRA_DATA_OUTPUT="extra-data.zip"
+
+              curl -s "${EXTRA_DATA}" -o "${EXTRA_DATA_OUTPUT}"
+              ls -lah "${EXTRA_DATA_OUTPUT}"
+            else
+              EXTRA_DATA_OUTPUT="${EXTRA_DATA}"
+            fi
+          else
+            EXTRA_DATA_OUTPUT=""
+          fi
+
+          echo "extra-data-output=${EXTRA_DATA_OUTPUT}" >> "${GITHUB_OUTPUT}"
 
       - name: Run iOS tests on devices
         if: ${{ inputs.device-type == 'ios' }}
@@ -153,6 +243,7 @@ jobs:
         working-directory: test-infra/tools/device-farm-runner
         env:
           PROJECT_ARN: ${{ inputs.project-arn }}
+          EXTRA_DATA: ${{ steps.verify-extra-data.outputs.extra-data-output }}
           # For record keeping
           JOB_NAME: ${{ inputs.job-name }}
           DEVICE_TYPE: ${{ inputs.device-type }}
@@ -161,21 +252,37 @@ jobs:
         run: |
           set -ex
 
-          if [ -f ci.yml ]; then
-            ${CONDA_RUN} python run_on_aws_devicefarm.py \
-              --project-arn "${PROJECT_ARN}" \
-              --app-file ci.ipa \
-              --xctestrun-file ci.xctestrun.zip \
-              --appium-test-spec ci.yml \
-              --name-prefix "${JOB_NAME}-${DEVICE_TYPE}" \
-              --workflow-id "${RUN_ID}" \
-              --workflow-attempt "${RUN_ATTEMPT}"
-          else
-            ${CONDA_RUN} python run_on_aws_devicefarm.py \
-              --project-arn "${PROJECT_ARN}" \
-              --app-file ci.ipa \
-              --xctestrun-file ci.xctestrun.zip \
-              --name-prefix "${JOB_NAME}-${DEVICE_TYPE}" \
-              --workflow-id "${RUN_ID}" \
-              --workflow-attempt "${RUN_ATTEMPT}"
-          fi
+          ${CONDA_RUN} python run_on_aws_devicefarm.py \
+            --project-arn "${PROJECT_ARN}" \
+            --app-file ci.ipa \
+            --ios-xctestrun-file ci.xctestrun.zip \
+            --extra-data "${EXTRA_DATA}" \
+            --test-spec ci.yml \
+            --name-prefix "${JOB_NAME}-${DEVICE_TYPE}" \
+            --workflow-id "${RUN_ID}" \
+            --workflow-attempt "${RUN_ATTEMPT}"
+
+      - name: Run Android tests on devices
+        if: ${{ inputs.device-type == 'android' }}
+        shell: bash
+        working-directory: test-infra/tools/device-farm-runner
+        env:
+          PROJECT_ARN: ${{ inputs.project-arn }}
+          EXTRA_DATA: ${{ steps.verify-extra-data.outputs.extra-data-output }}
+          # For record keeping
+          JOB_NAME: ${{ inputs.job-name }}
+          DEVICE_TYPE: ${{ inputs.device-type }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          set -ex
+
+          ${CONDA_RUN} python run_on_aws_devicefarm.py \
+            --project-arn "${PROJECT_ARN}" \
+            --app-file ci.apk \
+            --android-instrumention-test-file ci.test.apk \
+            --extra-data "${EXTRA_DATA}" \
+            --test-spec ci.yml \
+            --name-prefix "${JOB_NAME}-${DEVICE_TYPE}" \
+            --workflow-id "${RUN_ID}" \
+            --workflow-attempt "${RUN_ATTEMPT}"

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -32,7 +32,7 @@ on:
         type: string
       device-pool-arn:
         description: The device pool associated with the project
-        default: 'arn:aws:devicefarm:us-west-2:308535385114:devicepool:082d10e5-d7d7-48a5-ba5c-b33d66efa1f5'
+        default: 'arn:aws:devicefarm:us-west-2::devicepool:082d10e5-d7d7-48a5-ba5c-b33d66efa1f5'
         type: string
 
       # Pulling test-infra itself for device farm runner script

--- a/.github/workflows/test_mobile_job.yml
+++ b/.github/workflows/test_mobile_job.yml
@@ -57,4 +57,54 @@ jobs:
       project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:02a2cf0f-6d9b-45ee-ba1a-a086587469e6
       ios-ipa-archive: DeviceFarm.ipa
       ios-xctestrun-zip: MobileNetClassifierTest_MobileNetClassifierTest_iphoneos17.4-arm64.xctestrun.zip
-      ios-test-spec: default-ios-device-farm-appium-test-spec.yml
+      test-spec: default-ios-device-farm-appium-test-spec.yml
+
+  setup-android-job:
+    runs-on: ubuntu-latest
+    env:
+      APP_ARCHIVE: app-debug.apk
+      TEST_ARCHIVE: app-debug-androidTest.apk
+      ANDROID_TEST_SPEC: android-llama2-device-farm-test-spec.yml
+    steps:
+      - name: Download the prebuilt PyTorch Android app and test suite from S3
+        run: |
+          set -ex
+          wget -q "https://ossci-assets.s3.amazonaws.com/${APP_ARCHIVE}"
+          wget -q "https://ossci-assets.s3.amazonaws.com/${TEST_ARCHIVE}"
+          wget -q "https://ossci-assets.s3.amazonaws.com/${ANDROID_TEST_SPEC}"
+
+          # Print the artifacts to manually verify them if needed
+          ls -lah "${APP_ARCHIVE}" "${TEST_ARCHIVE}" "${ANDROID_TEST_SPEC}"
+
+      - name: Upload the iOS app
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.APP_ARCHIVE }}
+          path: ${{ env.APP_ARCHIVE }}
+
+      - name: Upload the test suite
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.TEST_ARCHIVE }}
+          path: ${{ env.TEST_ARCHIVE }}
+
+      - name: Upload the test spec
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.ANDROID_TEST_SPEC }}
+          path: ${{ env.ANDROID_TEST_SPEC }}
+
+  test-android-job:
+    needs: setup-android-job
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/mobile_job.yml
+    with:
+      device-type: android
+      runner: ubuntu-latest
+      project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:02a2cf0f-6d9b-45ee-ba1a-a086587469e6
+      android-app-archive: app-debug.apk
+      android-test-archive: app-debug-androidTest.apk
+      test-spec: android-llama2-device-farm-test-spec.yml
+      extra-data: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/bd15825b-ddab-4e47-9fef-a9c8935778dd

--- a/.github/workflows/test_mobile_job.yml
+++ b/.github/workflows/test_mobile_job.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   test-ios-job:
-    needs: setup-ios-job
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/test_mobile_job.yml
+++ b/.github/workflows/test_mobile_job.yml
@@ -9,41 +9,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  setup-ios-job:
-    runs-on: ubuntu-latest
-    env:
-      IPA_ARCHIVE: DeviceFarm.ipa
-      XCTESTRUN_ZIP: MobileNetClassifierTest_MobileNetClassifierTest_iphoneos17.4-arm64.xctestrun.zip
-      IOS_TEST_SPEC: default-ios-device-farm-appium-test-spec.yml
-    steps:
-      - name: Download the prebuilt PyTorch iOS app and test suite from S3
-        run: |
-          set -ex
-          wget -q "https://ossci-assets.s3.amazonaws.com/${IPA_ARCHIVE}"
-          wget -q "https://ossci-assets.s3.amazonaws.com/${XCTESTRUN_ZIP}"
-          wget -q "https://ossci-assets.s3.amazonaws.com/${IOS_TEST_SPEC}"
-
-          # Print the artifacts to manually verify them if needed
-          ls -lah "${IPA_ARCHIVE}" "${XCTESTRUN_ZIP}" "${IOS_TEST_SPEC}"
-
-      - name: Upload the iOS app
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.IPA_ARCHIVE }}
-          path: ${{ env.IPA_ARCHIVE }}
-
-      - name: Upload the test suite
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.XCTESTRUN_ZIP }}
-          path: ${{ env.XCTESTRUN_ZIP }}
-
-      - name: Upload the test spec
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.IOS_TEST_SPEC }}
-          path: ${{ env.IOS_TEST_SPEC }}
-
   test-ios-job:
     needs: setup-ios-job
     permissions:
@@ -54,48 +19,13 @@ jobs:
       device-type: ios
       # For iOS testing, the runner just needs to call AWS Device Farm, so there is no need to run this on macOS
       runner: ubuntu-latest
+      # There values are prepared beforehand for the test
       project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:02a2cf0f-6d9b-45ee-ba1a-a086587469e6
-      ios-ipa-archive: DeviceFarm.ipa
-      ios-xctestrun-zip: MobileNetClassifierTest_MobileNetClassifierTest_iphoneos17.4-arm64.xctestrun.zip
-      test-spec: default-ios-device-farm-appium-test-spec.yml
+      ios-ipa-archive: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/56b109f3-64b4-48c0-b1c8-b19dafc80647
+      ios-xctestrun-zip: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/8aeaf73f-3a42-4304-8eda-7a8d6b5a770c
+      test-spec: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/68677456-2999-47ec-a3a1-722db2b69b69
 
-  setup-android-job:
-    runs-on: ubuntu-latest
-    env:
-      APP_ARCHIVE: app-debug.apk
-      TEST_ARCHIVE: app-debug-androidTest.apk
-      ANDROID_TEST_SPEC: android-llama2-device-farm-test-spec.yml
-    steps:
-      - name: Download the prebuilt PyTorch Android app and test suite from S3
-        run: |
-          set -ex
-          wget -q "https://ossci-assets.s3.amazonaws.com/${APP_ARCHIVE}"
-          wget -q "https://ossci-assets.s3.amazonaws.com/${TEST_ARCHIVE}"
-          wget -q "https://ossci-assets.s3.amazonaws.com/${ANDROID_TEST_SPEC}"
-
-          # Print the artifacts to manually verify them if needed
-          ls -lah "${APP_ARCHIVE}" "${TEST_ARCHIVE}" "${ANDROID_TEST_SPEC}"
-
-      - name: Upload the iOS app
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.APP_ARCHIVE }}
-          path: ${{ env.APP_ARCHIVE }}
-
-      - name: Upload the test suite
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.TEST_ARCHIVE }}
-          path: ${{ env.TEST_ARCHIVE }}
-
-      - name: Upload the test spec
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.ANDROID_TEST_SPEC }}
-          path: ${{ env.ANDROID_TEST_SPEC }}
-
-  test-android-job:
-    needs: setup-android-job
+  test-android-llama2-job:
     permissions:
       id-token: write
       contents: read
@@ -103,8 +33,10 @@ jobs:
     with:
       device-type: android
       runner: ubuntu-latest
+      # There values are prepared beforehand for the test
       project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:02a2cf0f-6d9b-45ee-ba1a-a086587469e6
-      android-app-archive: app-debug.apk
-      android-test-archive: app-debug-androidTest.apk
-      test-spec: android-llama2-device-farm-test-spec.yml
+      device-pool-arn: arn:aws:devicefarm:us-west-2:308535385114:devicepool:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/e59f866a-30aa-4aa1-87b7-4510e5820dfa
+      android-app-archive: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/8a7276b7-03ac-4053-8b09-1305c429f59d
+      android-test-archive: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/528113d6-2003-420b-aedb-4242b6d14254
+      test-spec: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/414cb54d-4d83-4576-8317-93244e4dc50e
       extra-data: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/bd15825b-ddab-4e47-9fef-a9c8935778dd

--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -105,7 +105,7 @@ def parse_args() -> Any:
         "--project-arn", type=str, required=True, help="the ARN of the project on AWS"
     )
     parser.add_argument(
-        "--app-file",
+        "--app",
         type=str,
         required=True,
         action=ValidateApp,
@@ -115,14 +115,14 @@ def parse_args() -> Any:
     # One way or the other
     test_group = parser.add_mutually_exclusive_group()
     test_group.add_argument(
-        "--ios-xctestrun-file",
+        "--ios-xctestrun",
         type=str,
         required=False,
         action=ValidateArchive,
         help="the iOS XCTest suite to run",
     )
     test_group.add_argument(
-        "--android-instrumentation-test-file",
+        "--android-instrumentation-test",
         type=str,
         required=False,
         action=ValidateApp,
@@ -365,13 +365,13 @@ def print_report(
 
 
 def generate_ios_xctestrun(
-    client: Any, project_arn: str, prefix: str, ios_xctestrun_file: str, test_spec: str
+    client: Any, project_arn: str, prefix: str, ios_xctestrun: str, test_spec: str
 ) -> Dict[str, str]:
     """
     A helper function to generate the iOS test run
     """
-    if ios_xctestrun_file.startswith(AWS_ARN_PREFIX):
-        xctest_arn = ios_xctestrun_file
+    if ios_xctestrun.startswith(AWS_ARN_PREFIX):
+        xctest_arn = ios_xctestrun
         info(f"Use the existing xctestrun: {xctest_arn}")
     else:
         # Upload the xctestrun file as an appium node test package, this allows us
@@ -380,7 +380,7 @@ def generate_ios_xctestrun(
             client=client,
             project_arn=project_arn,
             prefix=prefix,
-            filename=ios_xctestrun_file,
+            filename=ios_xctestrun,
             filetype="APPIUM_NODE_TEST_PACKAGE",
         )
         info(f"Uploaded xctestrun: {xctest_arn}")
@@ -409,14 +409,14 @@ def generate_android_instrumentation_test(
     client: Any,
     project_arn: str,
     prefix: str,
-    android_instrumentation_test_file: str,
+    android_instrumentation_test: str,
     test_spec: str,
 ) -> Dict[str, str]:
     """
     A helper function to generate the Android test run
     """
-    if android_instrumentation_test_file.startswith(AWS_ARN_PREFIX):
-        instrumentation_test_arn = android_instrumentation_test_file
+    if android_instrumentation_test.startswith(AWS_ARN_PREFIX):
+        instrumentation_test_arn = android_instrumentation_test
         info(f"Use the existing instrumentation test: {instrumentation_test_arn}")
     else:
         # Upload the instrumentation test suite archive
@@ -424,7 +424,7 @@ def generate_android_instrumentation_test(
             client=client,
             project_arn=project_arn,
             prefix=prefix,
-            filename=android_instrumentation_test_file,
+            filename=android_instrumentation_test,
             filetype="INSTRUMENTATION_TEST_PACKAGE",
         )
         info(f"Uploaded instrumentation test: {instrumentation_test_arn}")
@@ -488,33 +488,33 @@ def main() -> None:
         + f"{datetime.date.today().isoformat()}-{''.join(random.sample(string.ascii_letters, 8))}"
     )
 
-    if args.app_file.startswith(AWS_ARN_PREFIX):
-        appfile_arn = args.app_file
+    if args.app.startswith(AWS_ARN_PREFIX):
+        appfile_arn = args.app
         info(f"Use the existing app: {appfile_arn}")
     else:
         # Only Android and iOS app are supported atm
-        app_type = "ANDROID_APP" if args.app_file.endswith(".apk") else "IOS_APP"
+        app_type = "ANDROID_APP" if args.app.endswith(".apk") else "IOS_APP"
         # Upload the test app
         appfile_arn = upload_file(
             client=client,
             project_arn=project_arn,
             prefix=unique_prefix,
-            filename=args.app_file,
+            filename=args.app,
             filetype=app_type,
         )
         info(f"Uploaded app: {appfile_arn}")
 
-    if args.ios_xctestrun_file:
+    if args.ios_xctestrun:
         test_to_run = generate_ios_xctestrun(
-            client, project_arn, unique_prefix, args.ios_xctestrun_file, args.test_spec
+            client, project_arn, unique_prefix, args.ios_xctestrun, args.test_spec
         )
 
-    if args.android_instrumentation_test_file:
+    if args.android_instrumentation_test:
         test_to_run = generate_android_instrumentation_test(
             client,
             project_arn,
             unique_prefix,
-            args.android_instrumentation_test_file,
+            args.android_instrumentation_test,
             args.test_spec,
         )
 


### PR DESCRIPTION
This extends the current mobile job workflow to support instrumentation tests on Android https://docs.aws.amazon.com/devicefarm/latest/developerguide/test-types-android-instrumentation.html.  As part of this change, I also add the support to upload an extra data archive to the device to be used by the test.  In the context of performance benchmark, the extra data archive usually contains exported models that the benchmark needs to cover.

### Testing

I'm using ExecuTorch llama2 demo app as inputs of the test https://github.com/pytorch/executorch/tree/main/examples/demo-apps/android/LlamaDemo.  It uses the exported llama2 7B model.

The script can be run locally as follows and its inputs can be downloaded from S3 `ossci-assets` bucket:

```
python run_on_aws_devicefarm.py \
    --project-arn "arn:aws:devicefarm:us-west-2:308535385114:project:02a2cf0f-6d9b-45ee-ba1a-a086587469e6" \
    --device-pool-arn "arn:aws:devicefarm:us-west-2:308535385114:devicepool:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/e59f866a-30aa-4aa1-87b7-4510e5820dfa" \
    --app ~/executorch/examples/demo-apps/android/LlamaDemo/app/build/outputs/apk/debug/app-debug.apk \
    --android-instrumention-test ~/executorch/examples/demo-apps/android/LlamaDemo/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk \
    --extra-data "arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/bd15825b-ddab-4e47-9fef-a9c8935778dd" \
    --test-spec ~/android-llama2-device-farm-test-spec.yml \
    --name-prefix "DEBUG-ANDROID-LLAMA2" \
    --workflow-id "1" \
    --workflow-attempt "1"
```

Because these inputs are already on AWS, the script can also refer to them directly without re-uploading.  This is needed because the exported llama2 7b model is 3+ GB.

```
python run_on_aws_devicefarm.py \
    --project-arn "arn:aws:devicefarm:us-west-2:308535385114:project:02a2cf0f-6d9b-45ee-ba1a-a086587469e6" \
    --device-pool-arn "arn:aws:devicefarm:us-west-2:308535385114:devicepool:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/e59f866a-30aa-4aa1-87b7-4510e5820dfa" \
    --app "arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/56b109f3-64b4-48c0-b1c8-b19dafc80647"  \
    --android-instrumentation-test "arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/528113d6-2003-420b-aedb-4242b6d14254" \
    --extra-data "arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/bd15825b-ddab-4e47-9fef-a9c8935778dd" \
    --test-spec "arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/414cb54d-4d83-4576-8317-93244e4dc50e" \
    --name-prefix "DEBUG-ANDROID-LLAMA2" \
    --workflow-id "1" \
    --workflow-attempt "1"
```

The observed TPS is print to console, i.e. https://github.com/pytorch/test-infra/actions/runs/8641760330/job/23692276850#step:12:70.  As this is run as part of JUnit test, I surface the value via an assert statement for now and plan to improve that later.


cc @kirklandsign 