### PR TITLE
Remove torchtext tests from CI

### DIFF
--- a/.github/workflows/test_build_conda_linux_with_cuda.yml
+++ b/.github/workflows/test_build_conda_linux_with_cuda.yml
@@ -30,8 +30,6 @@ jobs:
             conda-package-directory: packaging/torchaudio
             package-name: torchaudio
           - repository: pytorch/vision
-            pre-script: ""
-            post-script: ""
             smoke-test-script: test/smoke_test.py
             conda-package-directory: packaging/torchvision
             package-name: torchvision
@@ -47,8 +45,6 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      pre-script: ${{ matrix.pre-script }}
-      post-script: ${{ matrix.post-script }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
       package-name: ${{ matrix.package-name }}
       trigger-event: "${{ github.event_name }}"

--- a/.github/workflows/test_build_conda_linux_without_cuda.yml
+++ b/.github/workflows/test_build_conda_linux_without_cuda.yml
@@ -39,8 +39,6 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      pre-script: ${{ matrix.pre-script }}
-      post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}
       trigger-event: "${{ github.event_name }}"
     secrets:

--- a/.github/workflows/test_build_conda_linux_without_cuda.yml
+++ b/.github/workflows/test_build_conda_linux_without_cuda.yml
@@ -26,12 +26,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - repository: pytorch/text
-            pre-script: packaging/install_torchdata.sh
-            post-script: ""
-            conda-package-directory: packaging/torchtext
-            smoke-test-script: test/smoke_tests/smoke_tests.py
-            package-name: torchtext
+          - repository: pytorch/audio
+            smoke-test-script: test/smoke_test/smoke_test.py
+            conda-package-directory: packaging/torchaudio
+            package-name: torchaudio
     name: ${{ matrix.repository }}
     uses: ./.github/workflows/build_conda_linux.yml
     with:

--- a/.github/workflows/test_build_conda_m1.yml
+++ b/.github/workflows/test_build_conda_m1.yml
@@ -30,8 +30,6 @@ jobs:
             smoke-test-script: test/smoke_test/smoke_test.py
             package-name: torchaudio
           - repository: pytorch/vision
-            pre-script: ""
-            post-script: ""
             cache-path: ""
             cache-key: ""
             conda-package-directory: packaging/torchvision
@@ -46,8 +44,6 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      pre-script: ${{ matrix.pre-script }}
-      post-script: ${{ matrix.post-script }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
       runner-type: macos-m1-stable
       package-name: ${{ matrix.package-name }}

--- a/.github/workflows/test_build_conda_m1.yml
+++ b/.github/workflows/test_build_conda_m1.yml
@@ -37,14 +37,6 @@ jobs:
             conda-package-directory: packaging/torchvision
             smoke-test-script: test/smoke_test.py
             package-name: torchvision
-          - repository: pytorch/text
-            pre-script: packaging/install_torchdata.sh
-            cache-path: ""
-            cache-key: ""
-            post-script: ""
-            conda-package-directory: packaging/torchtext
-            smoke-test-script: test/smoke_tests/smoke_tests.py
-            package-name: torchtext
     name: ${{ matrix.repository }}
     uses: ./.github/workflows/build_conda_macos.yml
     with:

--- a/.github/workflows/test_build_conda_macos.yml
+++ b/.github/workflows/test_build_conda_macos.yml
@@ -29,8 +29,6 @@ jobs:
             smoke-test-script: test/smoke_test/smoke_test.py
             package-name: torchaudio
           - repository: pytorch/vision
-            pre-script: ""
-            post-script: ""
             conda-package-directory: packaging/torchvision
             smoke-test-script: test/smoke_test.py
             package-name: torchvision
@@ -45,8 +43,6 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      pre-script: ${{ matrix.pre-script }}
-      post-script: ${{ matrix.post-script }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
       runner-type: macos-12
       package-name: ${{ matrix.package-name }}

--- a/.github/workflows/test_build_conda_macos.yml
+++ b/.github/workflows/test_build_conda_macos.yml
@@ -36,14 +36,6 @@ jobs:
             package-name: torchvision
             cache-path: ""
             cache-key: ""
-          - repository: pytorch/text
-            pre-script: packaging/install_torchdata.sh
-            post-script: ""
-            conda-package-directory: packaging/torchtext
-            smoke-test-script: test/smoke_tests/smoke_tests.py
-            package-name: torchtext
-            cache-path: ""
-            cache-key: ""
     name: ${{ matrix.repository }}
     uses: ./.github/workflows/build_conda_macos.yml
     with:

--- a/.github/workflows/test_build_conda_windows_with_cuda.yml
+++ b/.github/workflows/test_build_conda_windows_with_cuda.yml
@@ -29,6 +29,8 @@ jobs:
             smoke-test-script: test/smoke_test/smoke_test.py
             conda-package-directory: packaging/torchaudio
             package-name: torchaudio
+            post-script: ""
+            pre-script: ""
           - repository: pytorch/vision
             pre-script: packaging/pre_build_script.sh
             env-script: packaging/windows/internal/vc_env_helper.bat

--- a/.github/workflows/test_build_conda_windows_without_cuda.yml
+++ b/.github/workflows/test_build_conda_windows_without_cuda.yml
@@ -40,8 +40,5 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      smoke-test-script: ${{ matrix.smoke-test-script }}
-      pre-script: ${{ matrix.pre-script }}
-      post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}
       trigger-event: "${{ github.event_name }}"

--- a/.github/workflows/test_build_conda_windows_without_cuda.yml
+++ b/.github/workflows/test_build_conda_windows_without_cuda.yml
@@ -26,12 +26,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - repository: pytorch/text
-            pre-script: packaging/install_torchdata.sh
-            post-script: ""
-            package-name: torchtext
-            conda-package-directory: packaging/torchtext
-            smoke-test-script: test/smoke_tests/smoke_tests.py
+          - repository: pytorch/audio
+            smoke-test-script: test/smoke_test/smoke_test.py
+            conda-package-directory: packaging/torchaudio
+            package-name: torchaudio
     name: ${{ matrix.repository }}
     uses: ./.github/workflows/build_conda_windows.yml
     with:

--- a/.github/workflows/test_build_wheels_linux_without_cuda.yml
+++ b/.github/workflows/test_build_wheels_linux_without_cuda.yml
@@ -32,8 +32,6 @@ jobs:
       matrix:
         include:
           - repository: pytorch/torchtune
-            pre-script: ""
-            post-script: ""
             package-name: torchtune
     uses: ./.github/workflows/build_wheels_linux.yml
     name: ${{ matrix.repository }}
@@ -43,8 +41,5 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      pre-script: ${{ matrix.pre-script }}
-      post-script: ${{ matrix.post-script }}
-      smoke-test-script: ${{ matrix.smoke-test-script }}
       package-name: ${{ matrix.package-name }}
       trigger-event: "${{ github.event_name }}"

--- a/.github/workflows/test_build_wheels_linux_without_cuda.yml
+++ b/.github/workflows/test_build_wheels_linux_without_cuda.yml
@@ -24,17 +24,17 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       with-cuda: disable
+      with-rocm: disable
   test:
     needs: generate-matrix
     strategy:
       fail-fast: false
       matrix:
         include:
-          - repository: pytorch/text
-            pre-script: packaging/install_torchdata.sh
+          - repository: pytorch/torchtune
+            pre-script: ""
             post-script: ""
-            smoke-test-script: test/smoke_tests/smoke_tests.py
-            package-name: torchtext
+            package-name: torchtune
     uses: ./.github/workflows/build_wheels_linux.yml
     name: ${{ matrix.repository }}
     with:

--- a/.github/workflows/test_build_wheels_m1.yml
+++ b/.github/workflows/test_build_wheels_m1.yml
@@ -39,13 +39,6 @@ jobs:
             package-name: torchvision
             cache-path: ""
             cache-key: ""
-          - repository: pytorch/text
-            pre-script: packaging/install_torchdata.sh
-            post-script: ""
-            smoke-test-script: test/smoke_tests/smoke_tests.py
-            package-name: torchtext
-            cache-path: ""
-            cache-key: ""
     uses: ./.github/workflows/build_wheels_macos.yml
     name: ${{ matrix.repository }}
     with:

--- a/.github/workflows/test_build_wheels_macos.yml
+++ b/.github/workflows/test_build_wheels_macos.yml
@@ -39,13 +39,6 @@ jobs:
             package-name: torchvision
             cache-path: ""
             cache-key: ""
-          - repository: pytorch/text
-            pre-script: packaging/install_torchdata.sh
-            post-script: ""
-            smoke-test-script: test/smoke_tests/smoke_tests.py
-            package-name: torchtext
-            cache-path: ""
-            cache-key: ""
     uses: ./.github/workflows/build_wheels_macos.yml
     name: ${{ matrix.repository }}
     with:

--- a/.github/workflows/test_build_wheels_windows_without_cuda.yml
+++ b/.github/workflows/test_build_wheels_windows_without_cuda.yml
@@ -42,9 +42,7 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      pre-script: ${{ matrix.pre-script }}
       env-script: ${{ matrix.env-script }}
-      post-script: ${{ matrix.post-script }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
       package-name: ${{ matrix.package-name }}
       trigger-event: "${{ github.event_name }}"

--- a/.github/workflows/test_build_wheels_windows_without_cuda.yml
+++ b/.github/workflows/test_build_wheels_windows_without_cuda.yml
@@ -29,12 +29,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - repository: pytorch/text
-            pre-script: packaging/install_torchdata.sh
+          - repository: pytorch/audio
             env-script: packaging/vc_env_helper.bat
-            post-script: ""
-            smoke-test-script: test/smoke_tests/smoke_tests.py
-            package-name: torchtext
+            wheel-build-params: "--plat-name win_amd64"
+            smoke-test-script: test/smoke_test/smoke_test.py
+            package-name: torchaudio
     uses: ./.github/workflows/build_wheels_windows.yml
     name: ${{ matrix.repository }}
     with:


### PR DESCRIPTION
TorchText tests are constantly failing. The development of torchtext is on hold currently. Hence stopping the CI test for torchtext