### PR TITLE
Add AVX512 supported ARC nodes

### DIFF
--- a/.github/arc-node-config.yaml
+++ b/.github/arc-node-config.yaml
@@ -16,6 +16,26 @@ nodeConfig:
       - key: kubernetes.io/os
         operator: In
         values: ["linux"]
+  - nodeType: compute-amd64-avx512
+    requirements:
+      - key: "karpenter.k8s.aws/instance-category"
+        operator: In
+        values: ["c"]
+      - key: "karpenter.k8s.aws/instance-family"
+        operator: In
+        values: ["c7a", "c6i", "c6in", "c5", "c5n"]
+      - key: "karpenter.k8s.aws/instance-cpu"
+        operator: In
+        values: ["16", "32", "64"]
+      - key: "kubernetes.io/arch"
+        operator: In
+        values: ["amd64"]
+      - key: "karpenter.sh/capacity-type"
+        operator: In
+        values: ["spot", "on-demand"]
+      - key: kubernetes.io/os
+        operator: In
+        values: ["linux"]
   - nodeType: compute-amd64-nvidia-v100
     requirements:
       - key: "karpenter.k8s.aws/instance-category"

--- a/.github/arc-runner-config.yaml
+++ b/.github/arc-runner-config.yaml
@@ -15,12 +15,20 @@ runnerConfig:
     runnerLabel: linux.2xlarge
     containerMode: dind-rootless
     workingDiskSpace: 150Gi
+  - cpu: 8.0
+    maxRunners: 300
+    memory: 16128Mi
+    minRunners: 0
+    nodeType: compute-amd64-avx512
+    runnerLabel: linux.2xlarge.avx512
+    containerMode: dind-rootless
+    workingDiskSpace: 150Gi
   - cpu: 4.0
     maxRunners: 150
     memory: 16Gi
     minRunners: 0
     nodeType: compute-amd64-nvidia-v100
     nvidiaGpus: 1
-    runnerLabel: linux-gpu.large
+    runnerLabel: linux.large.nvidia
     containerMode: dind-rootless
     workingDiskSpace: 150Gi


### PR DESCRIPTION
This adds ARC Runners with AVX512 supported CPUs in them. Check with `grep avx512 /proc/cpuinfo`.

Issue: pytorch/ci-infra#117