### PR TITLE
tools: Add ability to build a python only package

### DIFF
--- a/.github/workflows/generate_binary_build_matrix.yml
+++ b/.github/workflows/generate_binary_build_matrix.yml
@@ -39,6 +39,10 @@ on:
         description: "Use only download.pytorch.org when generating wheel install command?"
         default: "false"
         type: string
+      build-python-only:
+        description: "Generate binary build matrix for a python only package (i.e. only one python version)"
+        default: "disable"
+        type: string
     outputs:
       matrix:
         description: "Generated build matrix"
@@ -74,6 +78,7 @@ jobs:
           # This is used when testing release binaries only from download.pytorch.org.
           # In cases when pipy binaries are not published yet.
           USE_ONLY_DL_PYTORCH_ORG: ${{ inputs.use-only-dl-pytorch-org }}
+          BUILD_PYTHON_ONLY: ${{ inputs.build-python-only }}
         run: |
           set -eou pipefail
           MATRIX_BLOB="$(python3 tools/scripts/generate_binary_build_matrix.py)"

--- a/.github/workflows/test_build_wheels_linux_without_cuda.yml
+++ b/.github/workflows/test_build_wheels_linux_without_cuda.yml
@@ -25,6 +25,7 @@ jobs:
       test-infra-ref: ${{ github.ref }}
       with-cuda: disable
       with-rocm: disable
+      build-python-only: enable
   test:
     needs: generate-matrix
     strategy:
@@ -33,7 +34,6 @@ jobs:
         include:
           - repository: pytorch/torchtune
             package-name: torchtune
-            build-python-only: enable
     uses: ./.github/workflows/build_wheels_linux.yml
     name: ${{ matrix.repository }}
     with:
@@ -45,4 +45,3 @@ jobs:
       package-name: ${{ matrix.package-name }}
       trigger-event: "${{ github.event_name }}"
       build-platform: 'python-build-package'
-      build-python-only: ${{ matrix.build-python-only }}

--- a/.github/workflows/test_build_wheels_linux_without_cuda.yml
+++ b/.github/workflows/test_build_wheels_linux_without_cuda.yml
@@ -33,6 +33,7 @@ jobs:
         include:
           - repository: pytorch/torchtune
             package-name: torchtune
+            build-python-only: enable
     uses: ./.github/workflows/build_wheels_linux.yml
     name: ${{ matrix.repository }}
     with:
@@ -44,3 +45,4 @@ jobs:
       package-name: ${{ matrix.package-name }}
       trigger-event: "${{ github.event_name }}"
       build-platform: 'python-build-package'
+      build-python-only: ${{ matrix.build-python-only }}

--- a/tools/tests/test_generate_binary_build_matrix.py
+++ b/tools/tests/test_generate_binary_build_matrix.py
@@ -17,6 +17,7 @@ class GenerateBuildMatrixTest(TestCase):
         rocm: bool,
         cpu: bool,
         reference_output_file: str,
+        build_python_only: bool = False,
     ) -> None:
         out = generate_build_matrix(
             package_type,
@@ -27,6 +28,8 @@ class GenerateBuildMatrixTest(TestCase):
             "enable" if cpu else "disable",
             "false",
             "false",
+            "enable" if build_python_only else "disable",
+
         )
 
         expected_json_filename = os.path.join(ASSETS_DIR, reference_output_file)
@@ -36,6 +39,17 @@ class GenerateBuildMatrixTest(TestCase):
 
         self.maxDiff = None
         self.assertEqual(out, expected)
+
+    def test_linux_wheel_cpu_python_only(self):
+        self.matrix_compare_helper(
+            package_type="wheel",
+            operating_system="linux",
+            cuda=True,
+            rocm=True,
+            cpu=True,
+            reference_output_file="build_matrix_linux_wheel_cuda.json",
+            build_python_only=True,
+        )
 
     def test_linux_wheel_cuda(self):
         self.matrix_compare_helper(

--- a/tools/tests/test_generate_binary_build_matrix.py
+++ b/tools/tests/test_generate_binary_build_matrix.py
@@ -44,8 +44,8 @@ class GenerateBuildMatrixTest(TestCase):
         self.matrix_compare_helper(
             package_type="wheel",
             operating_system="linux",
-            cuda=True,
-            rocm=True,
+            cuda=False,
+            rocm=False,
             cpu=True,
             reference_output_file="build_matrix_linux_wheel_cuda.json",
             build_python_only=True,

--- a/tools/tests/test_generate_binary_build_matrix.py
+++ b/tools/tests/test_generate_binary_build_matrix.py
@@ -40,17 +40,6 @@ class GenerateBuildMatrixTest(TestCase):
         self.maxDiff = None
         self.assertEqual(out, expected)
 
-    def test_linux_wheel_cpu_python_only(self):
-        self.matrix_compare_helper(
-            package_type="wheel",
-            operating_system="linux",
-            cuda=False,
-            rocm=False,
-            cpu=True,
-            reference_output_file="build_matrix_linux_wheel_cuda.json",
-            build_python_only=True,
-        )
-
     def test_linux_wheel_cuda(self):
         self.matrix_compare_helper(
             package_type="wheel",


### PR DESCRIPTION
Adds the ability to generate the binary build matrix with a singular version of python to account for packages that only need to build a package that looks similar to:

`torchtune-0.0.1-py3-none-any.whl`