### PR TITLE
.github: Fix blank repository variable

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -193,7 +193,7 @@ jobs:
       - name: Run script in container
         if: ${{ inputs.run-with-docker == true }}
         continue-on-error: ${{ inputs.continue-on-error }}
-        working-directory: ${{ inputs.repository }}
+        working-directory: ${{ inputs.repository || github.repository }}
         env:
           ALL_SECRETS: ${{ toJSON(secrets) }}
           DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
@@ -213,7 +213,7 @@ jobs:
       - name: Run script outside container
         if: ${{ inputs.run-with-docker == false }}
         continue-on-error: ${{ inputs.continue-on-error }}
-        working-directory: ${{ inputs.repository }}
+        working-directory: ${{ inputs.repository || github.repository }}
         env:
           ALL_SECRETS: ${{ toJSON(secrets) }}
         run: |
@@ -257,7 +257,7 @@ jobs:
           ALPINE_IMAGE: ${{ inputs.runner == 'linux.arm64.2xlarge' && 'arm64v8/alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
 
       - name: Prepare artifacts for upload
-        working-directory: ${{ inputs.repository }}
+        working-directory: ${{ inputs.repository || github.repository }}
         id: check-artifacts
         env:
           UPLOAD_ARTIFACT_NAME: ${{ inputs.upload-artifact }}

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -112,7 +112,7 @@ jobs:
           submodules: ${{ inputs.submodules }}
 
       - name: Setup useful environment variables
-        working-directory: ${{ inputs.repository }}
+        working-directory: ${{ inputs.repository || github.repository }}
         run: |
           RUNNER_ARTIFACT_DIR="${RUNNER_TEMP}/artifacts"
           mkdir -p "${RUNNER_ARTIFACT_DIR}"
@@ -139,7 +139,7 @@ jobs:
       - name: Run script
         shell: bash -l {0}
         continue-on-error: ${{ inputs.continue-on-error }}
-        working-directory: ${{ inputs.repository }}
+        working-directory: ${{ inputs.repository || github.repository }}
         env:
           ALL_SECRETS: ${{ toJSON(secrets) }}
         run: |
@@ -164,7 +164,7 @@ jobs:
 
       - name: Check if there are potential artifacts and move them to the correct artifact location
         shell: bash -l {0}
-        working-directory: ${{ inputs.repository }}
+        working-directory: ${{ inputs.repository || github.repository }}
         id: check-artifacts
         if: ${{ inputs.upload-artifact != '' }}
         env:

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Run script
         shell: bash -l {0}
         continue-on-error: ${{ inputs.continue-on-error }}
-        working-directory: ${{ inputs.repository }}
+        working-directory: ${{ inputs.repository || github.repository }}
         run: |
           EXEC_SCRIPT="${RUNNER_TEMP}/exec_script"
           {
@@ -166,7 +166,7 @@ jobs:
 
       - name: Check if there are potential artifacts and move them to the correct artifact location
         shell: bash -l {0}
-        working-directory: ${{ inputs.repository }}
+        working-directory: ${{ inputs.repository || github.repository }}
         id: check-artifacts
         if: ${{ inputs.upload-artifact != '' }}
         env:


### PR DESCRIPTION
This should fix a bug where the blank repository field didn't work as expected for executing checkouts / scripts correctly.

Should correct errors where users had to fill out the repository section where they should not have had to do that