### PR TITLE
Support the upload of custom artifacts from artifacts-to-be-uploaded folder

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -16,7 +16,9 @@ on:
         default: "linux.2xlarge"
         type: string
       upload-artifact:
-        description: 'Name to give artifacts uploaded from ${RUNNER_ARTIFACT_DIR}'
+        description: |
+          Name to give artifacts uploaded from ${RUNNER_ARTIFACT_DIR}, all the wheel files
+          under dist/ and any files under artifacts-to-be-uploaded/ will be uploaded
         default: ''
         type: string
       download-artifact:
@@ -268,6 +270,9 @@ jobs:
             # attempt to just grab whatever is in there and scoop it all up
             if find "dist/" -name "*.whl" >/dev/null 2>/dev/null; then
               mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
+            fi
+            if [[ -d "artifacts-to-be-uploaded" ]]; then
+              mv -v artifacts-to-be-uploaded/* "${RUNNER_ARTIFACT_DIR}/"
             fi
             # Set to fail upload step if there are no files for upload and expected files for upload
             echo 'if-no-files-found=error' >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -16,7 +16,9 @@ on:
         default: "macos-12"
         type: string
       upload-artifact:
-        description: 'Name to give artifacts uploaded from ${RUNNER_ARTIFACT_DIR}'
+        description: |
+          Name to give artifacts uploaded from ${RUNNER_ARTIFACT_DIR}, all the wheel files
+          under dist/ and any files under artifacts-to-be-uploaded/ will be uploaded
         default: ""
         type: string
       download-artifact:
@@ -174,6 +176,9 @@ jobs:
           # attempt to just grab whatever is in there and scoop it all up
           if find "dist/" -name "*.whl" >/dev/null 2>/dev/null; then
             mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
+          fi
+          if [[ -d "artifacts-to-be-uploaded" ]]; then
+            mv -v artifacts-to-be-uploaded/* "${RUNNER_ARTIFACT_DIR}/"
           fi
           # Set to fail upload step if there are no files for upload and expected files for upload
           echo 'if-no-files-found=error' >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -16,7 +16,9 @@ on:
         default: "windows.4xlarge"
         type: string
       upload-artifact:
-        description: 'Name to give artifacts uploaded from ${RUNNER_ARTIFACT_DIR}'
+        description: |
+          Name to give artifacts uploaded from ${RUNNER_ARTIFACT_DIR}, all the wheel files
+          under dist/ and any files under artifacts-to-be-uploaded/ will be uploaded
         default: ''
         type: string
       download-artifact:
@@ -176,6 +178,9 @@ jobs:
           # attempt to just grab whatever is in there and scoop it all up
           if find "dist/" -name "*.whl" >/dev/null 2>/dev/null; then
             mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
+          fi
+          if [[ -d "artifacts-to-be-uploaded" ]]; then
+            mv -v artifacts-to-be-uploaded/* "${RUNNER_ARTIFACT_DIR}/"
           fi
           # Set to fail upload step if there are no files for upload and expected files for upload
           echo 'if-no-files-found=error' >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
This is to support a new use case where I need to upload different Android and iOS apps instead of the regular wheel files as the artifacts of Nova Linux job.  It looks like the easiest way is to have a folder `artifacts-to-be-uploaded` in the current workspace, and let the job script moves any artifacts it needs to persist there.