### PR TITLE
Add `submodule` input for build_wheels_*.yaml

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -60,13 +60,18 @@ on:
         required: false
         type: string
         default: x86_64
-      setup-miniconda:
+      submodules:
         description: Works as stated in actions/checkout, but the default value is recursive
+        required: false
+        type: string
+        default: recursive
+      setup-miniconda:
+        description: Set to true if setup-miniconda is needed
         required: false
         type: boolean
         default: true
       build-platform:
-        description: Platform to build wheels, choose from 'python-build-package' or 'setup-py' 
+        description: Platform to build wheels, choose from 'python-build-package' or 'setup-py'
         required: false
         type: string
         default: 'setup-py'
@@ -147,6 +152,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
+          submodules: ${{ inputs.submodules }}
           setup-miniconda: ${{ inputs.setup-miniconda }}
           python-version: ${{ env.PYTHON_VERSION }}
           cuda-version: ${{ env.CU_VERSION }}
@@ -184,7 +190,7 @@ jobs:
           echo "Successfully installed Python build package"
           ${CONDA_RUN} python -m build --wheel
       - name: Build the wheel (setup-py)
-        if: ${{ inputs.build-platform == 'setup-py' }} 
+        if: ${{ inputs.build-platform == 'setup-py' }}
         working-directory: ${{ inputs.repository }}
         shell: bash -l {0}
         run: |

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -59,6 +59,11 @@ on:
         description: "The key created when saving a cache and the key used to search for a cache."
         default: ""
         type: string
+      submodules:
+        description: "Works as stated in actions/checkout, but the default value is recursive"
+        required: false
+        type: string
+        default: recursive
 
 permissions:
   id-token: write
@@ -105,6 +110,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
+          submodules: ${{ inputs.submodules }}
           setup-miniconda: false
           python-version: ${{ env.PYTHON_VERSION }}
           cuda-version: ${{ env.CU_VERSION }}

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -59,6 +59,11 @@ on:
         description: "The key created when saving a cache and the key used to search for a cache."
         default: ""
         type: string
+      submodules:
+        description: "Works as stated in actions/checkout, but the default value is recursive"
+        required: false
+        type: string
+        default: recursive
 
 permissions:
   id-token: write
@@ -111,6 +116,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
+          submodules: ${{ inputs.submodules }}
           setup-miniconda: false
           python-version: ${{ env.PYTHON_VERSION }}
           cuda-version: ${{ env.CU_VERSION }}


### PR DESCRIPTION
Let users of `build_wheels_*.yml` override the `submodules` input of `setup-binary-build`.

pytorch/executorch does not need (or want) to do a full recursive submodule checkout.