### PR TITLE
[Refactor] Extract out a utility function: getFilesChangedByPr 

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -6,6 +6,7 @@ import {
   hasApprovedPullRuns,
   hasWritePermissions,
   isPyTorchPyTorch,
+  getFilesChangedByPr,
 } from "./utils";
 import { minimatch } from "minimatch";
 import {
@@ -388,16 +389,12 @@ function myBot(app: Probot): void {
       const owner = context.payload.repository.owner.login;
       const repo = context.payload.repository.name;
       const title = context.payload.pull_request.title;
-      const filesChangedRes = await context.octokit.paginate(
-        "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
-        {
-          owner,
-          repo,
-          pull_number: context.payload.pull_request.number,
-          per_page: 100,
-        }
+      const filesChanged = await getFilesChangedByPr(
+        context.octokit,
+        owner,
+        repo,
+        context.payload.pull_request.number
       );
-      const filesChanged = filesChangedRes.map((f: any) => f.filename);
       context.log({ labels, title, filesChanged });
 
       var labelsToAdd = getLabelsToAddFromTitle(title);

--- a/torchci/lib/bot/index.ts
+++ b/torchci/lib/bot/index.ts
@@ -1,30 +1,30 @@
 import { Probot } from "probot";
 import autoCcBot from "./autoCcBot";
 import autoLabelBot from "./autoLabelBot";
+import cancelWorkflowsOnCloseBot from "./cancelWorkflowsOnCloseBot";
 import ciflowPushTrigger from "./ciflowPushTrigger";
+import codevNoWritePerm from "./codevNoWritePermBot";
 import drciBot from "./drciBot";
+import isTheBotStateful from "./statefulBot";
 import pytorchBot from "./pytorchBot";
 import retryBot from "./retryBot";
+import stripApprovalBot from "./stripApprovalBot";
 import triggerCircleCIWorkflows from "./triggerCircleCIWorkflows";
 import verifyDisableTestIssueBot from "./verifyDisableTestIssueBot";
 import webhookToDynamo from "./webhookToDynamo";
-import cancelWorkflowsOnCloseBot from "./cancelWorkflowsOnCloseBot";
-import stripApprovalBot from "./stripApprovalBot";
-import codevNoWritePerm from "./codevNoWritePermBot";
-import isTheBotStateful from "./statefulBot";
 
 export default function bot(app: Probot) {
   autoCcBot(app);
-  stripApprovalBot(app);
   autoLabelBot(app);
-  verifyDisableTestIssueBot(app);
-  ciflowPushTrigger(app);
-  webhookToDynamo(app);
-  triggerCircleCIWorkflows(app);
-  pytorchBot(app);
-  drciBot(app);
-  retryBot(app);
   cancelWorkflowsOnCloseBot(app);
+  ciflowPushTrigger(app);
   codevNoWritePerm(app);
+  drciBot(app);
   isTheBotStateful(app);
+  pytorchBot(app);
+  retryBot(app);
+  stripApprovalBot(app);
+  triggerCircleCIWorkflows(app);
+  verifyDisableTestIssueBot(app);
+  webhookToDynamo(app);
 }

--- a/torchci/lib/bot/utils.ts
+++ b/torchci/lib/bot/utils.ts
@@ -266,3 +266,21 @@ export async function isFirstTimeContributor(
   });
   return commits?.data?.length === 0;
 }
+
+export async function getFilesChangedByPr(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number
+): Promise<string[]> {
+  const filesChangedRes = await octokit.paginate(
+    "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
+    {
+      owner,
+      repo,
+      pull_number: prNumber,
+      per_page: 100,
+    }
+  );
+  return filesChangedRes.map((f: any) => f.filename);
+}


### PR DESCRIPTION
Two refactorings in this PR, setting the stage for a follow up:
- Extract a method to get a list of files changed in the given PR
- Sort all bots alphabetically (fixing an eyesore)