### PR TITLE
Use ON_DEMAND instances for ARC nodes config to avoid disruptions

### DIFF
--- a/.github/arc-node-config.yaml
+++ b/.github/arc-node-config.yaml
@@ -12,7 +12,7 @@ nodeConfig:
         values: ["amd64"]
       - key: "karpenter.sh/capacity-type"
         operator: In
-        values: ["spot", "on-demand"]
+        values: ["on-demand"]
       - key: kubernetes.io/os
         operator: In
         values: ["linux"]
@@ -29,7 +29,7 @@ nodeConfig:
         values: ["amd64"]
       - key: "karpenter.sh/capacity-type"
         operator: In
-        values: ["spot", "on-demand"]
+        values: ["on-demand"]
       - key: kubernetes.io/os
         operator: In
         values: ["linux"]
@@ -49,7 +49,7 @@ nodeConfig:
         values: ["amd64"]
       - key: "karpenter.sh/capacity-type"
         operator: In
-        values: ["spot", "on-demand"]
+        values: ["on-demand"]
       - key: kubernetes.io/os
         operator: In
         values: ["linux"]


### PR DESCRIPTION
This should help mitigate https://github.com/pytorch/ci-infra/issues/118