### PR TITLE
[flakybot] Add traceback/error message to auto generated issue bodies

### DIFF
--- a/torchci/lib/fetchFlakyTests.ts
+++ b/torchci/lib/fetchFlakyTests.ts
@@ -111,7 +111,14 @@ select
             if(TYPEOF(t.rerun) = 'object', 1, Length(t.rerun)),
             if(TYPEOF(t.rerun) = 'object', 2, Length(t.rerun) + 1)
         )
-    ) as numRed
+    ) as numRed,
+    ARBITRARY(
+      if(
+          TYPEOF(t.rerun) = 'object',
+          t.rerun.text,
+          t.rerun[1].text
+      )
+  ) as sampleTraceback
 FROM
     commons.test_run_s3 t
 where
@@ -251,6 +258,7 @@ where
           jobIds: [curr.job_id],
           jobNames: [job_info.name],
           branches: [job_info.head_branch],
+          sampleTraceback: curr.sampleTraceback,
         });
       } else {
         val.jobIds.push(curr.job_id);

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -134,6 +134,7 @@ export interface FlakyTestData {
   jobNames: string[];
   branches: string[];
   eventTimes?: string[];
+  sampleTraceback?: string;
 }
 
 export interface DisabledNonFlakyTestData {

--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -342,6 +342,23 @@ To find relevant log snippets:
   if (test.file !== `${test.invoking_file}.py`) {
     fileInfo += ` or \`${test.invoking_file}\``;
   }
+
+  let sampleTraceback = "";
+  if (test.sampleTraceback) {
+    function toCodeBlock(text: string): string {
+      return `\`\`\`\n${text}\n\`\`\``;
+    }
+    let inDetails = "";
+    // Rather arbitrary length to avoid printing a massive traceback
+    if (test.sampleTraceback.length > 30000) {
+      const truncatedTrackback = test.sampleTraceback.slice(-30000);
+      inDetails = `Truncated for length\n${toCodeBlock(truncatedTrackback)}`;
+    } else {
+      inDetails = toCodeBlock(test.sampleTraceback);
+    }
+    sampleTraceback = `\n\n<details><summary>Sample error message</summary>\n\n${inDetails}\n\n</details>\n\n`;
+  }
+
   if (test.numRed === undefined) {
     // numRed === undefined indicates that is from the 'flaky_tests_across_jobs' query
     numRedGreen = `Over the past ${NUM_HOURS_ACROSS_JOBS} hours, it has flakily failed in ${test.workflowIds.length} workflow(s).`;
@@ -363,7 +380,7 @@ This test was disabled because it is failing in CI. See [recent examples](${exam
 ${numRedGreen}
 
 ${debuggingSteps}
-
+${sampleTraceback}
 ${fileInfo}`;
 }
 

--- a/torchci/rockset/commons/__sql/flaky_tests.sql
+++ b/torchci/rockset/commons/__sql/flaky_tests.sql
@@ -24,7 +24,14 @@
     ARRAY_AGG(workflow.id) as workflowIds,
     ARRAY_AGG(workflow.name) as workflowNames,
     ARRAY_AGG(workflow.head_branch) as branches,
-    ARRAY_AGG(test_run.workflow_run_attempt) as runAttempts
+    ARRAY_AGG(test_run.workflow_run_attempt) as runAttempts,
+    ARBITRARY(
+        if(
+            TYPEOF(test_run.rerun) = 'object',
+            test_run.rerun.text,
+            test_run.rerun[0].text
+        )
+    ) as sampleTraceback
 FROM
     commons.workflow_job job
     INNER JOIN commons.test_run_s3 test_run ON test_run.job_id = job.id HINT(join_strategy = lookup)
@@ -60,7 +67,14 @@ select
     ARRAY_AGG(workflow.id) as workflowIds,
     ARRAY_AGG(workflow.name) as workflowNames,
     ARRAY_AGG(workflow.head_branch) as branches,
-    ARRAY_AGG(test_run.workflow_run_attempt) as runAttempts
+    ARRAY_AGG(test_run.workflow_run_attempt) as runAttempts,
+    ARBITRARY(
+        if(
+            TYPEOF(test_run.rerun) = 'object',
+            test_run.rerun.text,
+            test_run.rerun[0].text
+        )
+    ) as sampleTraceback
 FROM
     commons.workflow_job job
     INNER JOIN commons.test_run_s3 test_run ON test_run.job_id = job.id HINT(join_strategy = lookup)

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -6,7 +6,7 @@
     "disabled_non_flaky_tests": "f909abf9eec15b56",
     "commit_failed_jobs": "2884aac8948770e4",
     "filter_forced_merge_pr": "a28350c863e36239",
-    "flaky_tests": "9f7a1abcebb7f027",
+    "flaky_tests": "eb7ed21e7f1a6d09",
     "flaky_tests_across_jobs": "474e5454bda0c5bb",
     "get_relevant_alerts": "727014a49bef2c20",
     "individual_test_stats_per_workflow_per_oncall": "559b6735965f1eb2",


### PR DESCRIPTION
As in title.
Truncate it to 30000 chars max


Tested via printing out the body and putting it into a github issue and seeing what the preview looked like

Ex (with len 1000) truncation 
<img width="782" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/8c3f7ae9-0fbf-4f2f-9a7b-da92d380ef47">

