### PR TITLE
Exclude lint and backwards_compat from Dr.CI flaky check

### DIFF
--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -44,6 +44,7 @@ export const EXCLUDED_FROM_FLAKINESS = [
   "lint",
   "linux-docs",
   "ghstack-mergeability-check",
+  "backwards_compat",
 ];
 // If the base commit is too old, don't query for similar failures because
 // it increases the risk of getting misclassification. This guardrail can

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -19,6 +19,7 @@ import {
   isLogClassifierFailed,
   fetchIssueLabels,
   isSuppressedByLabels,
+  isExcludedFromFlakiness,
 } from "lib/drciUtils";
 import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
 import { Octokit } from "octokit";
@@ -664,7 +665,10 @@ export async function getWorkflowJobsStatuses(
           (await hasSimilarFailures(job, prInfo.merge_base_date)))
       ) {
         flakyJobs.push(job);
-      } else if (await isLogClassifierFailed(job)) {
+      } else if (
+        (await isLogClassifierFailed(job)) &&
+        !isExcludedFromFlakiness(job)
+      ) {
         flakyJobs.push(job);
         await backfillMissingLog(prInfo.owner, prInfo.repo, job);
       } else {


### PR DESCRIPTION
This is to address some new comments on https://github.com/pytorch/test-infra/issues/5063.

1. Exclude `backwards_compat` from Dr.CI flaky check, as this job is deem stable enough most of the time.
2. Lint jobs have already been excluded, but there is a bug when it would still be treated as flaky when there is no associated log on S3.  This case surfaces in https://github.com/pytorch/pytorch/pull/124321 where there is a mix of signals from `pytorch` and` pytorch-canary` for the same commit. For example, there is no https://ossci-raw-job-status.s3.amazonaws.com/log/pytorch/pytorch-canary/24002161738 for the lint job there

```
{
  workflowId: 8745622961,
  workflowUniqueId: 13175283,
  id: 24002161738,
  runnerName: 'i-0cdd9180550988c58',
  authorEmail: 'ZainR@meta.com',
  name: 'Lint / workflow-checks / linux-job',
  jobName: 'workflow-checks / linux-job',
  conclusion: 'failure',
  completed_at: '2024-04-18T23:42:46Z',
  html_url: 'https://github.com/pytorch/pytorch-canary/actions/runs/8745622961/job/24002161738',
  head_branch: 'zainr/arn-fix',
  pr_number: 124321,
  head_sha: 'fa03725fa8512af211691a5164073ab7e2c4ee10',
  failure_captures: null,
  failure_lines: null,
  failure_context: null,
  time: '2024-04-18T23:42:51.131823Z'
}
```

The latter is probably a canary testing one-off thing, so I didn't follow up further.  But it's good to exclude lint properly anyway.