### PR TITLE
Add inputs.delocate-wheel to build_wheels_macos.yaml

### DIFF
--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -64,6 +64,11 @@ on:
         required: false
         type: string
         default: recursive
+      delocate-wheel:
+        description: "Whether to run delocate-wheel after building."
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   id-token: write
@@ -121,6 +126,7 @@ jobs:
         run: |
           cat "${{ inputs.env-var-script }}" >> "${BUILD_ENV_FILE}"
       - name: Install delocate-wheel
+        if: ${{ inputs.delocate-wheel }}
         run: |
           set -euxo pipefail
           ${CONDA_RUN} python3 -m pip install delocate==0.10.7
@@ -161,6 +167,7 @@ jobs:
 
           ${CONDA_RUN} python3 setup.py bdist_wheel
       - name: Delocate wheel
+        if: ${{ inputs.delocate-wheel }}
         working-directory: ${{ inputs.repository }}
         run: |
           set -euxo pipefail


### PR DESCRIPTION
Give clients a way to disable wheel delocation.

This step is only run on macOS, so there's no equivalent change necessary in the linux or windows workflows.

https://github.com/pytorch/executorch/actions/runs/8759506663/job/24042678714?pr=3049 is an example run using a forked copy of this file (see https://github.com/pytorch/executorch/commit/aca550bf97e86415a66194b7e8ddd0f608562ad6). It successfully skips the "Install delocate-wheel" and "Delocate wheel" steps.

While on the testing for this PR, both of those steps run by default: https://github.com/pytorch/test-infra/actions/runs/8759967852/job/24044074480?pr=5107