### PR TITLE
Set minimum ARC runners to 0

### DIFF
--- a/.github/arc-runner-config.yaml
+++ b/.github/arc-runner-config.yaml
@@ -10,7 +10,7 @@ runnerConfig:
   - cpu: 8.0
     maxRunners: 300
     memory: 16128Mi
-    minRunners: 20
+    minRunners: 0
     nodeType: compute-amd64
     runnerLabel: linux.2xlarge
     containerMode: dind-rootless
@@ -18,7 +18,7 @@ runnerConfig:
   - cpu: 8.0
     maxRunners: 300
     memory: 16128Mi
-    minRunners: 20
+    minRunners: 0
     nodeType: compute-amd64-avx512
     runnerLabel: linux.2xlarge.avx512
     containerMode: dind-rootless


### PR DESCRIPTION
Relates to pytorch/ci-infra#94.

During the CI Runners standup call on 2024-04-22 we made a decision that setting the minimum runners to 0 allowing the Karpenter autoscaler to handle scale would be a better approach to ensure that nodes eventually get cleaned up.