### PR TITLE
[ez] Give content write permissions for update td rating files workflow and reduce data range

### DIFF
--- a/.github/workflows/update_test_file_ratings.yml
+++ b/.github/workflows/update_test_file_ratings.yml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Generate file test ratings
         run: |
+          set -ex
           python3 test-infra/tools/torchci/td/calculate_file_test_rating.py
           python3 test-infra/tools/torchci/td/td_heuristic_historical_edited_files.py
           # Do not run this one, it won't change

--- a/.github/workflows/update_test_file_ratings.yml
+++ b/.github/workflows/update_test_file_ratings.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
   update-test-file-ratings:
     runs-on: ubuntu-latest

--- a/tools/torchci/td/calculate_file_test_rating.py
+++ b/tools/torchci/td/calculate_file_test_rating.py
@@ -68,7 +68,7 @@ def evaluate(failing_tests, merge_bases, rev_mapping, get_test_name_fn):
     all_failing_tests = {get_test_name_fn(test) for test in failing_tests}
 
     scores = []
-    for test in failing_tests:
+    for test in failing_tests[::10]:
         changed_files = merge_bases[test["head_sha"]]["changed_files"]
 
         prediction = defaultdict(int)

--- a/tools/torchci/td/calculate_file_test_rating.py
+++ b/tools/torchci/td/calculate_file_test_rating.py
@@ -15,6 +15,7 @@ FROM
     join workflow_job j on t.job_id = j.id
 where
     t.file is not null
+    and t._event_time > CURRENT_TIMESTAMP() - DAYS(90)
 """
 
 # See get_merge_base_info for structure, should have sha, merge_base, and

--- a/tools/torchci/td/utils.py
+++ b/tools/torchci/td/utils.py
@@ -93,7 +93,7 @@ def evaluate(
 
     scores = []
     score_per_file = defaultdict(list)
-    for test in tests:
+    for test in tests[::10]:
         changed_files = merge_bases[test["head_sha"]]["changed_files"]
 
         prediction = defaultdict(int)
@@ -166,6 +166,7 @@ def get_filtered_failed_tests() -> List[Dict[str, Any]]:
         join workflow_job j on t.job_id = j.id
     where
         t.file is not null
+        and t._event_time > CURRENT_TIMESTAMP() - DAYS(90)
     """
     failed_tests = query_rockset(failed_tests_query, use_cache=True)
     return filter_tests(failed_tests, get_merge_bases_dict())


### PR DESCRIPTION
It's been broken for 3 months...

Also:
* Reduce data range (last 90 days instead of everything)
* Reduce # test to run evaluate on, since it takes a long time