### PR TITLE
Fix AWS credentials for update_ci_wait_time_metric.yml workflow

### DIFF
--- a/.github/workflows/update_ci_wait_time_metric.yml
+++ b/.github/workflows/update_ci_wait_time_metric.yml
@@ -19,7 +19,7 @@ jobs:
         id: aws_creds
         uses: aws-actions/configure-aws-credentials@v3
         with:
-          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_update_ci_wait_time_metric
+          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_s3_update
           aws-region: us-east-1
 
       - name: Checkout repo

--- a/.github/workflows/update_ci_wait_time_metric.yml
+++ b/.github/workflows/update_ci_wait_time_metric.yml
@@ -14,12 +14,13 @@ jobs:
   update-kpi:
     runs-on: ubuntu-22.04
     if: ${{ github.repository == 'pytorch/test-infra' }}
+    environment: pytorchbot-env
     steps:
       - name: configure aws credentials
         id: aws_creds
         uses: aws-actions/configure-aws-credentials@v3
         with:
-          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_s3_update
+          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_update_ci_wait_time_metric
           aws-region: us-east-1
 
       - name: Checkout repo

--- a/.github/workflows/update_ci_wait_time_metric.yml
+++ b/.github/workflows/update_ci_wait_time_metric.yml
@@ -19,7 +19,7 @@ jobs:
         id: aws_creds
         uses: aws-actions/configure-aws-credentials@v3
         with:
-          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_s3_update
+          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_update_ci_wait_time_metric
           aws-region: us-east-1
 
       - name: Checkout repo

--- a/.github/workflows/update_ci_wait_time_metric.yml
+++ b/.github/workflows/update_ci_wait_time_metric.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   id-token: write
+  contents: read
 
 jobs:
   update-kpi:

--- a/.github/workflows/update_ci_wait_time_metric.yml
+++ b/.github/workflows/update_ci_wait_time_metric.yml
@@ -3,7 +3,7 @@ on:
   schedule:
     # Update the indices every day at 5am
     - cron: "0 5 * * *"
-  # Enable triggering this job manually using the API as well 
+  # Enable triggering this job manually using the API as well
   workflow_dispatch:
 
 jobs:
@@ -11,6 +11,13 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ github.repository == 'pytorch/test-infra' }}
     steps:
+      - name: configure aws credentials
+        id: aws_creds
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_s3_update
+          aws-region: us-east-1
+
       - name: Checkout repo
         uses: actions/checkout@v3
 
@@ -29,8 +36,6 @@ jobs:
 
       - name: Compute kpi and upload to RDS
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
         run: |
           python3 .github/scripts/compute_and_upload_ci_wait_time_metric.py

--- a/.github/workflows/update_ci_wait_time_metric.yml
+++ b/.github/workflows/update_ci_wait_time_metric.yml
@@ -6,6 +6,9 @@ on:
   # Enable triggering this job manually using the API as well
   workflow_dispatch:
 
+permissions:
+  id-token: write
+
 jobs:
   update-kpi:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
The old way of getting AWS creds is no longer supported

Should fix https://github.com/pytorch/test-infra/issues/5113

Unfortunately there's no way to test this without merging it to main first since the role policy requires [the environment](https://github.com/pytorch/test-infra/pull/5115/files#diff-dc712cd14c95e5480d9dd162a6bc2d804eeedd03155533176d23a363fe99c744R17) to be set to pytorchbot-env, and github rules are configured to only allow workflows merged into main to be run with this environment.  
But the workflow is already broken, so I don't feel to bad about it