### PR TITLE
Use the correct conda token for pytorch-test channel

### DIFF
--- a/.github/workflows/anaconda-prune.yml
+++ b/.github/workflows/anaconda-prune.yml
@@ -31,4 +31,4 @@ jobs:
       packages: "pytorch torchvision torchaudio torchtext torchdata ignite torchcsprng"
       channel: pytorch-test
     secrets:
-     conda-pytorchbot-token: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}
+     conda-pytorchbot-token: ${{ secrets.CONDA_PYTORCHBOT_TOKEN_TEST }}


### PR DESCRIPTION
It looks easy enough, the conda token used for `pytorch-test` is not the correct one.  I temporarily add `fix-anaconda-token` to the env, run the test, then remove it after.

Fixes https://github.com/pytorch/test-infra/issues/5114

### Testing

https://github.com/pytorch/test-infra/actions/runs/8793196628/job/24130887625?pr=5116