### PR TITLE
[HUD] Fix DataGrid widget not scrolling on metrics page

### DIFF
--- a/torchci/components/metrics/panels/TablePanel.tsx
+++ b/torchci/components/metrics/panels/TablePanel.tsx
@@ -103,7 +103,7 @@ export function TablePanelWithData({
       rows={data}
       columns={columns}
       hideFooter={!showFooter}
-      autoPageSize
+      autoPageSize={showFooter}
       components={{
         Toolbar: Header,
       }}


### PR DESCRIPTION
Fixes https://github.com/pytorch/test-infra/issues/5054
Probably due to https://github.com/pytorch/test-infra/pull/4745, the tables on the metrics page where not scrollable 
<img width="853" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/b9f301f8-0b63-40d1-961a-4f9b974345e3">

This change makes them scrollable and also preserves the footer behavior introduced by the above PR for the benchmarks page

Pages of interest in preview: 
https://torchci-git-csl-fixmetricstablegridscroll-fbopensource.vercel.app/metrics
https://torchci-git-csl-fixmetricstablegridscroll-fbopensource.vercel.app/torchbench/userbenchmark