### PR TITLE
[bots] Autolabeler: label to label 

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -334,24 +334,24 @@ function myBot(app: Probot): void {
   app.on("pull_request.labeled", async (context) => {
     // Careful! Read the above comments about label addition
 
-    const label = context.payload.label!.name;
-    const labels: string[] = context.payload.pull_request.labels!.map(
+    const addedLabel = context.payload.label!.name;
+    const existingLabels: string[] = context.payload.pull_request.labels!.map(
       (e) => e["name"]
     );
-    context.log({ label, labels });
+    context.log({ addedLabel, existingLabels });
 
-    const labelSet = new Set(labels);
+    const existingLabelsSet = new Set(existingLabels);
     const newLabels: string[] = [];
 
     const newLabelsFromLabelToLabelConfig =
       await getLabelsFromLabelToLabelConfig(
         context,
         labelToLabelConfigTracker,
-        labels,
-        label
+        existingLabels,
+        addedLabel
       );
     for (const label of newLabelsFromLabelToLabelConfig) {
-      addLabel(labelSet, newLabels, label);
+      addLabel(existingLabelsSet, newLabels, label);
     }
 
     const filtered = await filterCIFlowLabels(

--- a/torchci/lib/bot/utils.ts
+++ b/torchci/lib/bot/utils.ts
@@ -167,7 +167,6 @@ export class LabelToLabelConfigTracker extends CachedConfigTracker {
   }
 }
 
-
 // returns undefined if the request fails
 export async function fetchJSON(path: string): Promise<any> {
   const result = await retryRequest(path);

--- a/torchci/lib/bot/utils.ts
+++ b/torchci/lib/bot/utils.ts
@@ -138,6 +138,36 @@ export class CachedLabelerConfigTracker extends CachedConfigTracker {
   }
 }
 
+export class LabelToLabelConfigTracker extends CachedConfigTracker {
+  repoLabels: any = {};
+  constructor(app: Probot) {
+    super(app);
+    app.on("push", async (context) => {
+      if (
+        context.payload.ref === "refs/heads/master" ||
+        context.payload.ref === "refs/heads/main"
+      ) {
+        await this.loadLabelsConfig(context, /* force */ true);
+      }
+    });
+  }
+
+  async loadLabelsConfig(context: Context, force = false): Promise<object> {
+    const key = repoKey(context);
+    if (!(key in this.repoLabels) || force) {
+      const config: any = await this.loadConfig(context, force);
+
+      if (config != null && "label_to_label_config" in config) {
+        this.repoLabels[key] = context.config(config["label_to_label_config"]);
+      } else {
+        this.repoLabels[key] = {};
+      }
+    }
+    return this.repoLabels[key];
+  }
+}
+
+
 // returns undefined if the request fails
 export async function fetchJSON(path: string): Promise<any> {
   const result = await retryRequest(path);


### PR DESCRIPTION
Pt1 of https://github.com/pytorch/pytorch/issues/117051 but doesn't handle the topic: not user facing thing

Reads a config to add labels based on other labels added.

Config currently only supports if any -> add, if all -> add
Ex if you say if any of (A, B, C), then add (D), then D gets added if an issue or PR gets B

Only adds based on the currently added label in an attempt to prevent concurrency problems

Planning on testing on malfet/deleteme

TIL: if you add a label while making a PR or issue, two webhooks get issued: one for the PR/issue creation, one for the labeling event

Example config:
```
- any:
  - "module: custom operators"
  - "module: aotdispatch"
  then:
  - "module: pt2-dispatcher"
- any:
  - "module: dynamo"
  - "module: pt2-dispatcher"
  - "module: inductor"
  - "module: custom operators"
  then:
  - "oncall: pt2"
 ```

