### PR TITLE
Update disabled issues from other repos

### DIFF
--- a/.github/scripts/update_disabled_issues.py
+++ b/.github/scripts/update_disabled_issues.py
@@ -84,7 +84,6 @@ def gh_graphql(query: str, token: str, **kwargs: Any) -> Dict[str, Any]:
 def get_disable_issues(
     token: str, prefix: str = DISABLED_PREFIX
 ) -> List[Dict[str, Any]]:
-    # q = f"is:issue is:open org:{OWNER} in:title {prefix}"
     q = f"is:issue is:open org:{OWNER} in:title {prefix}"
     cursor = None
     has_next_page = True

--- a/.github/scripts/update_disabled_issues.py
+++ b/.github/scripts/update_disabled_issues.py
@@ -84,7 +84,8 @@ def gh_graphql(query: str, token: str, **kwargs: Any) -> Dict[str, Any]:
 def get_disable_issues(
     token: str, prefix: str = DISABLED_PREFIX
 ) -> List[Dict[str, Any]]:
-    q = f"is:issue is:open repo:{OWNER}/{REPO} in:title {prefix}"
+    # q = f"is:issue is:open org:{OWNER} in:title {prefix}"
+    q = f"is:issue is:open org:{OWNER} in:title {prefix}"
     cursor = None
     has_next_page = True
     res = []


### PR DESCRIPTION
This is to capture disabled and unstable issues from other repos, i.e. https://github.com/pytorch/executorch/issues/3264.  The easiest way is to gather all these issues in the same file instead of having one per repo.  There is a Rockset query https://github.com/pytorch/test-infra/blob/main/torchci/rockset/commons/__sql/issue_query.sql that we use to query the issue by their labels, but it already covers all repos in the org.