### PR TITLE
Update Dr.CI to use the list of unstable issues

### DIFF
--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -41,8 +41,6 @@ export const BOT_COMMANDS_WIKI_URL =
   "https://github.com/pytorch/pytorch/wiki/Bot-commands";
 export const FLAKY_RULES_JSON =
   "https://raw.githubusercontent.com/pytorch/test-infra/generated-stats/stats/flaky-rules.json";
-export const UNSTABLE_JOBS_JSON =
-  "https://ossci-metrics.s3.amazonaws.com/unstable-jobs-debug.json";
 
 export const EXCLUDED_FROM_FLAKINESS = [
   "lint",
@@ -404,22 +402,6 @@ export function isInfraFlakyJob(job: RecentWorkflowsData): boolean {
       job.runnerName === undefined ||
       job.runnerName === "")
   );
-}
-
-export async function isUnstableJob(
-  job: RecentWorkflowsData,
-  unstableIssues: IssueData[],
-): Promise<boolean> {
-  if (job.name === undefined || job.name === null) {
-    return false;
-  }
-
-  // The job name has the unstable keyword
-  if (job.name.includes("unstable")) {
-    return true;
-  }
-
-  return false;
 }
 
 export async function isLogClassifierFailed(

--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -21,7 +21,6 @@ import {
   hasS3Log,
   isFailureFromPrevMergeCommit,
   getPRMergeCommits,
-  hasOpenUnstableIssue,
 } from "lib/jobUtils";
 
 export const NUM_MINUTES = 30;

--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -21,6 +21,7 @@ import {
   hasS3Log,
   isFailureFromPrevMergeCommit,
   getPRMergeCommits,
+  hasOpenUnstableIssue,
 } from "lib/jobUtils";
 
 export const NUM_MINUTES = 30;
@@ -40,6 +41,9 @@ export const BOT_COMMANDS_WIKI_URL =
   "https://github.com/pytorch/pytorch/wiki/Bot-commands";
 export const FLAKY_RULES_JSON =
   "https://raw.githubusercontent.com/pytorch/test-infra/generated-stats/stats/flaky-rules.json";
+export const UNSTABLE_JOBS_JSON =
+  "https://ossci-metrics.s3.amazonaws.com/unstable-jobs-debug.json";
+
 export const EXCLUDED_FROM_FLAKINESS = [
   "lint",
   "linux-docs",
@@ -400,6 +404,22 @@ export function isInfraFlakyJob(job: RecentWorkflowsData): boolean {
       job.runnerName === undefined ||
       job.runnerName === "")
   );
+}
+
+export async function isUnstableJob(
+  job: RecentWorkflowsData,
+  unstableIssues: IssueData[],
+): Promise<boolean> {
+  if (job.name === undefined || job.name === null) {
+    return false;
+  }
+
+  // The job name has the unstable keyword
+  if (job.name.includes("unstable")) {
+    return true;
+  }
+
+  return false;
 }
 
 export async function isLogClassifierFailed(

--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -41,7 +41,6 @@ export const BOT_COMMANDS_WIKI_URL =
   "https://github.com/pytorch/pytorch/wiki/Bot-commands";
 export const FLAKY_RULES_JSON =
   "https://raw.githubusercontent.com/pytorch/test-infra/generated-stats/stats/flaky-rules.json";
-
 export const EXCLUDED_FROM_FLAKINESS = [
   "lint",
   "linux-docs",

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -110,6 +110,8 @@ export async function updateDrciComments(
   );
 
   const unstableIssues: IssueData[] = [];
+  const debug = await fetchJSON(UNSTABLE_JOBS_JSON);
+  console.log(debug);
 
   // Return the list of all failed jobs grouped by their classification
   const failures: { [pr: number]: { [cat: string]: RecentWorkflowsData[] } } =

--- a/torchci/test/drciBot.test.ts
+++ b/torchci/test/drciBot.test.ts
@@ -174,6 +174,8 @@ describe("verify-drci-functionality", () => {
       .reply(200, { results: [] })
       .post((url) => url.includes("commit_failed_jobs"))
       .reply(200, { results: [] })
+      .post((url) => url.includes("issue_query"))
+      .reply(200, { results: [] })
       .post(
         (url) => url.includes("self/queries"),
         (body) => JSON.stringify(body).includes("merge_base_commit_date")


### PR DESCRIPTION
This is the next part of https://github.com/pytorch/test-infra/pull/5122 where Dr.CI also uses the list of unstable issues to check if a job is an unstable job.  The same function `isUnstableJob` that powers HUD from https://github.com/pytorch/test-infra/pull/5122 is used.

### Testing

Mark a job on ET as unstable https://github.com/pytorch/executorch/issues/3344 as shown on HUD https://hud.pytorch.org/hud/pytorch/executorch/main and Dr.CI applies the same logic on a PR https://github.com/pytorch/executorch/pull/3318 to show the job as unstable.

```
curl --request POST \
--url "http://localhost:3000/api/drci/drci?prNumber=3318" \
--header "Authorization: TOKEN" \
--data 'repo=executorch'
```

<!-- drci-comment-start -->

## :link: Helpful Links
### :test_tube: See artifacts and rendered test results at [hud.pytorch.org/pr/pytorch/executorch/3318](https://hud.pytorch.org/pr/pytorch/executorch/3318)
* :page_facing_up: Preview [Python docs built from this PR](https://docs-preview.pytorch.org/pytorch/executorch/3318/index.html)

Note: Links to docs will display an error until the docs builds have been completed.


## :white_check_mark: You can merge normally! (1 Unrelated Failure)
As of commit f712e381c161901b733baa6b1fe7d85dc25404d3 with merge base b669056c1cff5f7fe3786df9e68a14447cd5410b (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1713981882?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details ><summary><b>UNSTABLE</b> - The following job failed but was likely due to flakiness present on trunk and has been marked as unstable:</summary><p>

* [Android / test-llama-app / mobile-job (android)](https://hud.pytorch.org/pr/pytorch/executorch/3318#24225451316) ([gh](https://github.com/pytorch/executorch/actions/runs/8821313480/job/24225451316))
    `Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers`
</p></details>


This comment was automatically generated by Dr. CI and updates every 15 minutes.
<!-- drci-comment-end -->