### PR TITLE
[EZ] update boto3 (Fix AWS credentials for update_ci_wait_time_metric.yml workflow)

### DIFF
--- a/.github/workflows/update_ci_wait_time_metric.yml
+++ b/.github/workflows/update_ci_wait_time_metric.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Python Packages
         run: |
           pip3 install rockset==1.0.3
-          pip3 install boto3==1.19.12
+          pip3 install boto3==1.34.92
           pip3 install pandas==1.5
 
       - name: Compute kpi and upload to RDS


### PR DESCRIPTION
https://github.com/pytorch/test-infra/pull/5115 solved the assume role part, but even with that role the upload still fails with:

```
botocore.exceptions.ClientError: An error occurred (AccessDeniedException) when calling the UpdateItem operation: User: arn:aws:sts::749337293305:assumed-role/gha_workflow_update_ci_wait_time_metric/GitHubActions is not authorized to perform: dynamodb:UpdateItem on resource: arn:aws:dynamodb:us-east-1:749337293305:table/torchci-metrics-ci-wait-time because no identity-based policy allows the dynamodb:UpdateItem action
```

That's weird because that permission appears to be given.  After comparing this against a workflow that works, trying to upgrade boto library to see if that was the problem

Testing: As explained in the [other PR](https://github.com/pytorch/test-infra/pull/5115), this can only be tested in `main`. But that's okay since the workflow has been broken for months anyways