### PR TITLE
fix: Reduce GPUs for 4xlarge system to 1

### DIFF
--- a/.github/arc-runner-config.yaml
+++ b/.github/arc-runner-config.yaml
@@ -46,7 +46,7 @@ runnerConfig:
     memory: 122Gi
     minRunners: 0
     nodeType: compute-amd64-nvidia-m60
-    nvidiaGpus: 4
+    nvidiaGpus: 1
     runnerLabel: linux.4xlarge.nvidiam60
     containerMode: dind-rootless
     workingDiskSpace: 150Gi


### PR DESCRIPTION
The 4 GPU setting was a mistake and should have been set to 1 GPU.