### PR TITLE
Fix missing job on HUD due to wrongly trie match

### DIFF
--- a/torchci/lib/fetchCommit.ts
+++ b/torchci/lib/fetchCommit.ts
@@ -54,8 +54,21 @@ export default async function fetchCommit(
     (job) => job.workflowId === null || job.workflowId === undefined
   );
 
+  for (const debug of onlyJobs) {
+    if (debug["jobName"] === "linux-jammy-py3.8-gcc11 / build") {
+      console.log(JSON.stringify(debug));
+    }
+  }
+  console.log("DONE");
+
   const filteredJobs = removeCancelledJobAfterRetry<JobData>(onlyJobs);
 
+  // for (const debug of filteredJobs) {
+  //   if (debug["jobName"] === "linux-jammy-py3.8-gcc11 / build") {
+  //     console.log(JSON.stringify(debug));
+  //   }
+  // }
+  console.log("REALLY");
   const workflowIdsWithJobs = _.map(filteredJobs, (job) => job.workflowId);
 
   const badWorkflows = _.filter(

--- a/torchci/lib/fetchCommit.ts
+++ b/torchci/lib/fetchCommit.ts
@@ -54,21 +54,8 @@ export default async function fetchCommit(
     (job) => job.workflowId === null || job.workflowId === undefined
   );
 
-  for (const debug of onlyJobs) {
-    if (debug["jobName"] === "linux-jammy-py3.8-gcc11 / build") {
-      console.log(JSON.stringify(debug));
-    }
-  }
-  console.log("DONE");
-
   const filteredJobs = removeCancelledJobAfterRetry<JobData>(onlyJobs);
 
-  // for (const debug of filteredJobs) {
-  //   if (debug["jobName"] === "linux-jammy-py3.8-gcc11 / build") {
-  //     console.log(JSON.stringify(debug));
-  //   }
-  // }
-  console.log("REALLY");
   const workflowIdsWithJobs = _.map(filteredJobs, (job) => job.workflowId);
 
   const badWorkflows = _.filter(

--- a/torchci/lib/jobUtils.ts
+++ b/torchci/lib/jobUtils.ts
@@ -396,7 +396,7 @@ export function removeCancelledJobAfterRetry<T extends BasicJobData>(
   // So the fix here is to check if a cancelled job has been retried successfully and
   // keep or remove it from the list accordingly.
   const trie: TrieSearch<T> = new TrieSearch<T>("name", {
-    splitOnRegEx: /\s\/\s/g,
+    splitOnRegEx: /\//g,
   });
   trie.addAll(jobs);
 

--- a/torchci/test/jobUtils.test.ts
+++ b/torchci/test/jobUtils.test.ts
@@ -433,6 +433,41 @@ describe("Test various job utils", () => {
         conclusion: "cancelled",
         time: "2023-08-23T09:10:01.259562Z",
       },
+
+      // Do not match with other jobs with similar prefix
+      {
+        name: "pull / linux-jammy-py3.8-gcc11 / build",
+        conclusion: "success",
+        time: "2023-08-23T08:57:27.732608Z",
+      },
+      {
+        name: "pull / linux-jammy-py3.8-gcc11 / build",
+        conclusion: "cancelled",
+        time: "2023-08-23T09:10:01.259562Z",
+      },
+      {
+        name: "pull / linux-jammy-py3.8-gcc11-mobile-lightweight-dispatch-build / build",
+        conclusion: "success",
+        // Set the timestamp here to be after the previous timestamp indicating that this
+        // job runs after pull / linux-jammy-py3.8-gcc11 / build. The latter should not be
+        // removed from the list
+        time: "2023-08-23T09:15:01.259562Z",
+      },
+      {
+        name: "pull / linux-jammy-py3.8-gcc11-no-ops / build",
+        conclusion: "success",
+        time: "2023-08-23T09:15:01.259562Z",
+      },
+      {
+        name: "pull / linux-jammy-py3.8-gcc11-no-ops / build",
+        conclusion: "cancelled",
+        time: "2023-08-23T08:57:27.732608Z",
+      },
+      {
+        name: "pull / linux-jammy-py3.8-gcc11-pch / build",
+        conclusion: "success",
+        time: "2023-08-23T08:57:27.732608Z",
+      },
     ];
 
     const results = removeCancelledJobAfterRetry(jobs);
@@ -504,6 +539,28 @@ describe("Test various job utils", () => {
           name: "pull / linux-focal-py3.8-clang10 / test (default, 3, 3, linux.2xlarge)",
           conclusion: "cancelled",
           time: "2023-08-23T09:10:01.259562Z",
+        },
+
+        // Do not match with other jobs with similar prefix
+        {
+          name: "pull / linux-jammy-py3.8-gcc11 / build",
+          conclusion: "cancelled",
+          time: "2023-08-23T09:10:01.259562Z",
+        },
+        {
+          name: "pull / linux-jammy-py3.8-gcc11-mobile-lightweight-dispatch-build / build",
+          conclusion: "success",
+          time: "2023-08-23T09:15:01.259562Z",
+        },
+        {
+          name: "pull / linux-jammy-py3.8-gcc11-no-ops / build",
+          conclusion: "success",
+          time: "2023-08-23T09:15:01.259562Z",
+        },
+        {
+          name: "pull / linux-jammy-py3.8-gcc11-pch / build",
+          conclusion: "success",
+          time: "2023-08-23T08:57:27.732608Z",
         },
       ])
     );


### PR DESCRIPTION
Fixes https://github.com/pytorch/test-infra/issues/5103

I think the wrong match is fixed by setting the separator correctly to `/`.  I also add a test to make sure that the final list looks correct and the latest run of `pull / linux-jammy-py3.8-gcc11 / build` job is not removed.

### Testing

`linux-jammy-py3.8-gcc11 / build` and `linux-focal-cuda12.1-py3.10-gcc9 / build` are showing up correctly on the preview page now https://torchci-git-fork-huydhn-fix-missing-jobs-on-hud-fbopensource.vercel.app/pr/124281

Also spot check some commits https://torchci-git-fork-huydhn-fix-missing-jobs-on-hud-fbopensource.vercel.app/pytorch/pytorch/commit/0ca1ff3dce71b3fa4a905512ec7be381be753240