### PR TITLE
[EZ] Use correct account (Fix AWS credentials for update_ci_wait_time_metric.yml workflow)

### DIFF
--- a/.github/workflows/update_ci_wait_time_metric.yml
+++ b/.github/workflows/update_ci_wait_time_metric.yml
@@ -14,7 +14,6 @@ jobs:
   update-kpi:
     runs-on: ubuntu-22.04
     if: ${{ github.repository == 'pytorch/test-infra' }}
-    environment: pytorchbot-env
     steps:
       - name: configure aws credentials
         id: aws_creds

--- a/.github/workflows/update_ci_wait_time_metric.yml
+++ b/.github/workflows/update_ci_wait_time_metric.yml
@@ -20,7 +20,7 @@ jobs:
         id: aws_creds
         uses: aws-actions/configure-aws-credentials@v3
         with:
-          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_update_ci_wait_time_metric
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_update_ci_wait_time_metric
           aws-region: us-east-1
 
       - name: Checkout repo


### PR DESCRIPTION
Part of fixing https://github.com/pytorch/test-infra/issues/5113 by correcting a mismatch between the role's account  dynamodb table's account. 

### Changes
- The role now points to a different role (of the same name) in the dynamodb table's account. This new role already existed in aws, but had the [wrong perms](https://github.com/pytorch-labs/pytorch-gha-infra/pull/381)).  
- Since the new role didn't need an environment set, removed that as well (the role instead expects the workflow to always be running on `main`)

### Testing
Temporarily edited the role to
1. Apply the desired permissions 
2. Remove the `main` branch only protection and verified that [the workflow ran successfully](https://github.com/pytorch/test-infra/actions/runs/8840055206/attempts/9)

Those changes have now been reverted

Will need to run this in main one more time to verify that it runs correctly with the `main` branch only protection re-enabled

**Partner to PR**: https://github.com/pytorch-labs/pytorch-gha-infra/pull/381