### PR TITLE
[HUD] Add tooltip on timestamps for how long ago

### DIFF
--- a/torchci/components/TimeUtils.tsx
+++ b/torchci/components/TimeUtils.tsx
@@ -20,7 +20,14 @@ export function LocalTimeHuman({ timestamp }: { timestamp: string }) {
       setTime(time.format("M/D h:mm a"));
     }
   }, [timestamp]);
-  return <span>{time}</span>;
+  return (
+    <span
+      title={`${durationDisplay(dayjs().diff(timestamp, "seconds"))} ago`}
+      data-toggle="tooltip"
+    >
+      {time}
+    </span>
+  );
 }
 
 // from: https://gist.github.com/g1eb/62d9a48164fe7336fdf4845e22ae3d2c


### PR DESCRIPTION
When hovering over a timestamp, you can see how long ago it was

<img width="117" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/36774c04-3394-46c4-a87a-c24276c6fcfd">

Ironically this is opposite behavior from github: they like to show how long ago by default and the timestamp on hover

