### PR TITLE
[hud] when esc pressed, clear pinned tooltip before clearing the job filter

### DIFF
--- a/torchci/lib/useTableFilter.ts
+++ b/torchci/lib/useTableFilter.ts
@@ -1,6 +1,7 @@
 import { useRouter } from "next/router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import { formatHudUrlForRoute, HudParams } from "./types";
+import { PinnedTooltipContext } from "../pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]]";
 
 export default function useTableFilter(params: HudParams) {
   const router = useRouter();
@@ -11,16 +12,25 @@ export default function useTableFilter(params: HudParams) {
   const normalizedJobFilter =
     jobFilter === null || jobFilter === "" ? null : jobFilter.toLowerCase();
 
+  const [pinnedId] = useContext(PinnedTooltipContext);
+
   useEffect(() => {
-    document.addEventListener("keydown", (e) => {
+    const sha = pinnedId.sha;
+    const listener = (e) => {
       if (e.code === "Escape") {
         setJobFilter(null);
         router.push(formatHudUrlForRoute("hud", params), undefined, {
           shallow: true,
         });
       }
-    });
-  }, []);
+    };
+    if (!sha) {
+      document.addEventListener("keydown", listener);
+      return () => {
+        document.removeEventListener("keydown", listener);
+      };
+    }
+  }, [pinnedId.sha]);
   const handleInput = useCallback(
     (f: any) => {
       setJobFilter(f);

--- a/torchci/lib/useTableFilter.ts
+++ b/torchci/lib/useTableFilter.ts
@@ -16,7 +16,7 @@ export default function useTableFilter(params: HudParams) {
 
   useEffect(() => {
     const sha = pinnedId.sha;
-    const listener = (e) => {
+    const listener = (e: KeyboardEvent) => {
       if (e.code === "Escape") {
         setJobFilter(null);
         router.push(formatHudUrlForRoute("hud", params), undefined, {


### PR DESCRIPTION
Before this change, when Esc is pressed to close pinned job tooltip, it also cleared the job filter, which is pretty annoying (imo).


### Demo (esc pressed two times):
![hud-key-demo](https://github.com/pytorch/test-infra/assets/108101595/f21d618b-6355-444a-a8ef-ad010bd7b625)
