### PR TITLE
Fix perf dashboard crash when there is no log

### DIFF
--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -827,6 +827,10 @@ export function BranchAndCommitPicker({
 }
 
 export function LogLinks({ suite, logs }: { suite: string; logs: any }) {
+  if (!logs) {
+    return;
+  }
+
   return (
     <>
       {" "}

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -828,7 +828,7 @@ export function BranchAndCommitPicker({
 
 export function LogLinks({ suite, logs }: { suite: string; logs: any }) {
   if (!logs) {
-    return;
+    return (<></>);
   }
 
   return (

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -828,7 +828,7 @@ export function BranchAndCommitPicker({
 
 export function LogLinks({ suite, logs }: { suite: string; logs: any }) {
   if (!logs) {
-    return (<></>);
+    return <></>;
   }
 
   return (


### PR DESCRIPTION
As reported by @eellison.  When we run the benchmark with only selected suites, only logs from these suites are available.  For example, if TIMM was not selected, TIMM logs should be there expectedly.  The page shouldn't crash.

### Testing

The page is ok now https://torchci-git-fork-huydhn-fix-perf-dashboard-9c59e0-fbopensource.vercel.app/benchmark/compilers?startTime=Wed%2C%2024%20Apr%202024%2019%3A59%3A22%20GMT&stopTime=Wed%2C%2001%20May%202024%2019%3A59%3A22%20GMT&granularity=hour&suite=torchbench&mode=training&dtype=amp&lBranch=gh/eellison/637/head&lCommit=ce334fe472ee0b9a2c05d8fd4e4913695a2c05b2&rBranch=main&rCommit=0848051844181a7ac816b555f84caf16f20f0256