### PR TITLE
[HUD] Change workflow startup failure

### DIFF
--- a/torchci/rockset/commons/__sql/commit_jobs_query.sql
+++ b/torchci/rockset/commons/__sql/commit_jobs_query.sql
@@ -107,15 +107,11 @@ WITH
             workflow._event_time AS time,
             workflow.head_sha AS sha,
             workflow.name AS job_name,
-            'Workflow Startup Failure' AS workflow_name,
+            workflow.name AS workflow_name,
             workflow.id,
             null AS workflow_id,
             workflow.artifacts_url AS github_artifact_url,
-            IF(
-                workflow.conclusion IS NULL and workflow.completed_at IS NULL and workflow.status = 'queued',
-                'failure',
-                workflow.conclusion
-            ) as conclusion,
+            workflow.conclusion,
             workflow.html_url,
             null AS log_url,
             DATE_DIFF(

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -2,7 +2,7 @@
   "commons": {
     "annotated_flaky_jobs": "bd991c8c9782f339",
     "hud_query": "69f0bc9a618c82b1",
-    "commit_jobs_query": "10d4a302d49906bb",
+    "commit_jobs_query": "1e5918d703bb9240",
     "disabled_non_flaky_tests": "f909abf9eec15b56",
     "commit_failed_jobs": "2884aac8948770e4",
     "filter_forced_merge_pr": "a28350c863e36239",


### PR DESCRIPTION
* Follow up to https://github.com/pytorch/test-infra/pull/5164 and https://github.com/pytorch/test-infra/pull/5124

Previously I assumed that startup failures are always queued and it is always safe to 