### PR TITLE
[HUD] Disable issue button - specify if issue is recent

### DIFF
--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -269,7 +269,7 @@ function DisableIssue({
     : issueTitle.includes("UNSTABLE")
     ? "Mark unstable job"
     : "Disable job";
-  let buttonStyle = "";
+  let buttonStyle = styles.disableTestButton;
 
   if (matchingIssues.length !== 0) {
     // There is a matching issue, show that in the tooltip box.
@@ -280,17 +280,11 @@ function DisableIssue({
         : issueTitle.includes("UNSTABLE")
         ? "Job is unstable"
         : "Job is disabled";
+      buttonStyle = "";
     } else if (
       dayjs().diff(dayjs(matchingIssue.updated_at), "hours") <
       recentThresholdHours
     ) {
-      buttonStyle = styles.closedDisableIssueButton;
-      linkText = isDisabledTest
-        ? "Recent previously disabled test"
-        : issueTitle.includes("UNSTABLE")
-        ? "Recent previously unstable job"
-        : "Recent previously disabled job";
-    } else {
       buttonStyle = styles.closedDisableIssueButton;
       linkText = isDisabledTest
         ? "Previously disabled test"
@@ -299,9 +293,6 @@ function DisableIssue({
         : "Previously disabled job";
     }
     issueLink = matchingIssues[0].html_url;
-  } else {
-    // No matching issue, show a link to create one.
-    buttonStyle = styles.disableTestButton;
   }
 
   return (

--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -8,6 +8,7 @@ import ReproductionCommand from "./ReproductionCommand";
 import { useSession } from "next-auth/react";
 import { isFailure } from "../lib/JobClassifierUtil";
 import { transformJobName } from "../lib/jobUtils";
+import dayjs from "dayjs";
 
 export default function JobLinks({
   job,
@@ -260,6 +261,8 @@ function DisableIssue({
   issueBody: string;
   isDisabledTest: boolean;
 }) {
+  const recentThresholdHours = 14 * 24;
+
   let issueLink = `https://github.com/${repo}/issues/new?title=${issueTitle}&body=${issueBody}`;
   let linkText = isDisabledTest
     ? "Disable test"
@@ -277,6 +280,14 @@ function DisableIssue({
         : issueTitle.includes("UNSTABLE")
         ? "Job is unstable"
         : "Job is disabled";
+    } else if (
+      dayjs().diff(dayjs(matchingIssue.updated_at), "hours") >
+      recentThresholdHours
+    ) {
+      // There is a closed issue but it's a bit old, so use the style that says
+      // nothing exists, but link back to the issue
+      issueLink = matchingIssue.html_url;
+      buttonStyle = styles.disableTestButton;
     } else {
       buttonStyle = styles.closedDisableIssueButton;
       linkText = isDisabledTest

--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -281,13 +281,15 @@ function DisableIssue({
         ? "Job is unstable"
         : "Job is disabled";
     } else if (
-      dayjs().diff(dayjs(matchingIssue.updated_at), "hours") >
+      dayjs().diff(dayjs(matchingIssue.updated_at), "hours") <
       recentThresholdHours
     ) {
-      // There is a closed issue but it's a bit old, so use the style that says
-      // nothing exists, but link back to the issue
-      issueLink = matchingIssue.html_url;
-      buttonStyle = styles.disableTestButton;
+      buttonStyle = styles.closedDisableIssueButton;
+      linkText = isDisabledTest
+        ? "Recent previously disabled test"
+        : issueTitle.includes("UNSTABLE")
+        ? "Recent previously unstable job"
+        : "Recent previously disabled job";
     } else {
       buttonStyle = styles.closedDisableIssueButton;
       linkText = isDisabledTest


### PR DESCRIPTION
Maybe controversial change?  


Change the look of the disable/unstable button that links to the issue that disables the test/marks the job unstable if the issue was not updated recently. Changes it to the style that makes it seem like there is no issue, so you have to click the button to make a new one, but the button will still go to the old issue so you can reopen it.


I keep getting confused since when I see "previously disabled test" I assume that the issue was wrongly closed recently and that I should reopen, but then I discover that the issue is from 3 months ago and that this is a new problem

Results in a change in expectations but it's not like "mark unstable job" or "disable test" imply that a new issue always gets made.

I guess as a side note, if we don't do something like this, probably every job is going to get the "previously unstable job" button eventually

Example
old
<img width="611" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/b84097b3-0c96-48e9-895e-9f856d1f1d07">

new
![image](https://github.com/pytorch/test-infra/assets/44682903/bedd3d7d-684a-4fb1-9cec-920727f59f73)
