### PR TITLE
[ez] End prodversions.json with new line

### DIFF
--- a/torchci/scripts/downloadQueryLambda.mjs
+++ b/torchci/scripts/downloadQueryLambda.mjs
@@ -81,6 +81,6 @@ prodVersions[qLambda.workspace][qLambda.name] = qLambda.version;
 
 await fs.writeFile(
   prodVersionsFilePath,
-  JSON.stringify(prodVersions, null, 2),
+  JSON.stringify(prodVersions, null, 2) + "\n",
   "utf8"
 );

--- a/torchci/scripts/uploadQueryLambda.mjs
+++ b/torchci/scripts/uploadQueryLambda.mjs
@@ -108,6 +108,6 @@ await Promise.all(tasks);
 
 await fs.writeFile(
   "rockset/prodVersions.json",
-  JSON.stringify(prodVersionsNew, null, 2),
+  JSON.stringify(prodVersionsNew, null, 2) + "\n",
   "utf8"
 );


### PR DESCRIPTION
Changes scripts that update the prodversions file to add a new line at the end

Super small thing but I keep thinking I made a change to prodversions but I find out that it's just that I opened up the file and saved, and vsocde and vim automatically add an empty new line on save