### PR TITLE
[HUD] Adds ability to change url for flakytest and failure page from inputs on page

### DIFF
--- a/torchci/lib/ParamSelector.tsx
+++ b/torchci/lib/ParamSelector.tsx
@@ -39,6 +39,8 @@ export function ParamSelector({
           // @ts-ignore
           e.target.value = value;
           setSize(value.length);
+          // @ts-ignore
+          e.target.blur();
         }
       }}
     >

--- a/torchci/lib/ParamSelector.tsx
+++ b/torchci/lib/ParamSelector.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import styles from "components/hud.module.css";
+
+export function handleSubmitURL(
+  e: React.FormEvent<HTMLFormElement>,
+  getNewUrl: (submission: string) => string
+) {
+  e.preventDefault();
+  // @ts-ignore
+  const submission = e.target[0].value;
+  window.location.href = getNewUrl(submission);
+}
+
+export function ParamSelector({
+  value,
+  handleSubmit,
+}: {
+  value: string;
+  handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+}) {
+  const [size, setSize] = useState(value?.length || 0);
+  useEffect(() => {
+    setSize(value?.length || 0);
+  }, [value]);
+  return (
+    <form
+      className={styles.branchForm}
+      onSubmit={handleSubmit}
+      onChange={(e) => {
+        // @ts-ignore
+        setSize(e.target.value.length);
+      }}
+      onFocus={(e) => {
+        e.target.select();
+      }}
+    >
+      <input
+        size={size}
+        className={styles.branchFormInput}
+        type="text"
+        defaultValue={value}
+      ></input>
+    </form>
+  );
+}

--- a/torchci/lib/ParamSelector.tsx
+++ b/torchci/lib/ParamSelector.tsx
@@ -1,22 +1,12 @@
 import { useEffect, useState } from "react";
 import styles from "components/hud.module.css";
 
-export function handleSubmitURL(
-  e: React.FormEvent<HTMLFormElement>,
-  getNewUrl: (submission: string) => string
-) {
-  e.preventDefault();
-  // @ts-ignore
-  const submission = e.target[0].value;
-  window.location.href = getNewUrl(submission);
-}
-
 export function ParamSelector({
   value,
   handleSubmit,
 }: {
   value: string;
-  handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  handleSubmit: (submission: string) => void;
 }) {
   const [size, setSize] = useState(value?.length || 0);
   useEffect(() => {
@@ -25,13 +15,31 @@ export function ParamSelector({
   return (
     <form
       className={styles.branchForm}
-      onSubmit={handleSubmit}
+      onSubmit={(e) => {
+        e.preventDefault();
+        // @ts-ignore
+        handleSubmit(e.target[0].value);
+      }}
       onChange={(e) => {
         // @ts-ignore
         setSize(e.target.value.length);
       }}
       onFocus={(e) => {
         e.target.select();
+      }}
+      onBlur={(e) => {
+        if (e.target.value !== value && e.target.value.length > 0) {
+          e.preventDefault();
+          handleSubmit(e.target.value);
+        }
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          e.preventDefault();
+          // @ts-ignore
+          e.target.value = value;
+          setSize(value.length);
+        }
       }}
     >
       <input

--- a/torchci/pages/failure.tsx
+++ b/torchci/pages/failure.tsx
@@ -11,7 +11,7 @@ import JobSummary from "components/JobSummary";
 import LogViewer from "components/LogViewer";
 import JobLinks from "components/JobLinks";
 import { usePreference } from "lib/useGroupingPreference";
-import { ParamSelector, handleSubmitURL } from "lib/ParamSelector";
+import { ParamSelector } from "lib/ParamSelector";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 import { CSSProperties } from "react";
@@ -246,8 +246,8 @@ function FailureInfo({
   );
 }
 
-function getURL(name: string, jobName: string, failureCaptures: string) {
-  return `/failure?name=${encodeURIComponent(
+function setURL(name: string, jobName: string, failureCaptures: string) {
+  window.location.href = `/failure?name=${encodeURIComponent(
     name
   )}&jobName=${encodeURIComponent(
     jobName
@@ -285,20 +285,12 @@ export default function Page() {
           Job:{" "}
           <ParamSelector
             value={name}
-            handleSubmit={(e: any) =>
-              handleSubmitURL(e, (submission) =>
-                getURL(submission, jobName, failureCaptures)
-              )
-            }
+            handleSubmit={(e: any) => setURL(e, jobName, failureCaptures)}
           />
         </div>
         <ParamSelector
           value={failureCaptures}
-          handleSubmit={(e: any) =>
-            handleSubmitURL(e, (submission) =>
-              getURL(name, jobName, submission)
-            )
-          }
+          handleSubmit={(e: any) => setURL(name, jobName, e)}
         />
       </h2>
       <FuzzySearchCheckBox

--- a/torchci/pages/failure.tsx
+++ b/torchci/pages/failure.tsx
@@ -10,14 +10,11 @@ import { JobData } from "lib/types";
 import JobSummary from "components/JobSummary";
 import LogViewer from "components/LogViewer";
 import JobLinks from "components/JobLinks";
+import { usePreference } from "lib/useGroupingPreference";
+import { ParamSelector, handleSubmitURL } from "lib/ParamSelector";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 import { CSSProperties } from "react";
-
-import {
-  useGroupingPreference,
-  usePreference,
-} from "lib/useGroupingPreference";
 
 function FuzzySearchCheckBox({
   useFuzzySearch,
@@ -249,6 +246,14 @@ function FailureInfo({
   );
 }
 
+function getURL(name: string, jobName: string, failureCaptures: string) {
+  return `/failure?name=${encodeURIComponent(
+    name
+  )}&jobName=${encodeURIComponent(
+    jobName
+  )}&failureCaptures=${encodeURIComponent(failureCaptures)}`;
+}
+
 export default function Page() {
   const router = useRouter();
   const name = router.query.name as string;
@@ -276,7 +281,25 @@ export default function Page() {
     <div>
       <h1>PyTorch CI Failure Info</h1>
       <h2>
-        <code>{failureCaptures}</code>
+        <div>
+          Job:{" "}
+          <ParamSelector
+            value={name}
+            handleSubmit={(e: any) =>
+              handleSubmitURL(e, (submission) =>
+                getURL(submission, jobName, failureCaptures)
+              )
+            }
+          />
+        </div>
+        <ParamSelector
+          value={failureCaptures}
+          handleSubmit={(e: any) =>
+            handleSubmitURL(e, (submission) =>
+              getURL(name, jobName, submission)
+            )
+          }
+        />
       </h2>
       <FuzzySearchCheckBox
         useFuzzySearch={useFuzzySearch}

--- a/torchci/pages/flakytest.tsx
+++ b/torchci/pages/flakytest.tsx
@@ -4,8 +4,17 @@ import LogViewer from "components/LogViewer";
 import { FlakyTestInfoHUD } from "./api/flaky-tests/flakytest";
 import JobLinks from "components/JobLinks";
 import JobSummary from "components/JobSummary";
+import { ParamSelector, handleSubmitURL } from "lib/ParamSelector";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+function getURL(name: string, suite: string, file: string, limit: string) {
+  return `/flakytest?name=${encodeURIComponent(
+    name
+  )}&suite=${encodeURIComponent(suite)}&file=${encodeURIComponent(
+    file
+  )}&limit=${encodeURIComponent(limit)}`;
+}
 
 export default function Page() {
   const router = useRouter();
@@ -34,9 +43,33 @@ export default function Page() {
         name.
       </div>
       <h3>
-        Test Name Filter: <code>{name === "%" ? "<any>" : name}</code> | Test
-        Suite Filter: <code>{suite === "%" ? "<any>" : suite}</code> | Test File
-        Filter: <code>{file === "%" ? "<any>" : file}</code>
+        Test Name Filter:{" "}
+        <ParamSelector
+          value={name}
+          handleSubmit={(e) =>
+            handleSubmitURL(e, (submission) =>
+              getURL(submission, suite, file, limit)
+            )
+          }
+        />{" "}
+        | Test Suite Filter:{" "}
+        <ParamSelector
+          value={suite}
+          handleSubmit={(e) =>
+            handleSubmitURL(e, (submission) =>
+              getURL(name, submission, file, limit)
+            )
+          }
+        />{" "}
+        | Test File Filter:{" "}
+        <ParamSelector
+          value={file}
+          handleSubmit={(e) =>
+            handleSubmitURL(e, (submission) =>
+              getURL(name, suite, submission, limit)
+            )
+          }
+        />
       </h3>
       {data === undefined ? (
         <div>Loading...</div>

--- a/torchci/pages/flakytest.tsx
+++ b/torchci/pages/flakytest.tsx
@@ -4,12 +4,12 @@ import LogViewer from "components/LogViewer";
 import { FlakyTestInfoHUD } from "./api/flaky-tests/flakytest";
 import JobLinks from "components/JobLinks";
 import JobSummary from "components/JobSummary";
-import { ParamSelector, handleSubmitURL } from "lib/ParamSelector";
+import { ParamSelector } from "lib/ParamSelector";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
-function getURL(name: string, suite: string, file: string, limit: string) {
-  return `/flakytest?name=${encodeURIComponent(
+function setURL(name: string, suite: string, file: string, limit: string) {
+  window.location.href = `/flakytest?name=${encodeURIComponent(
     name
   )}&suite=${encodeURIComponent(suite)}&file=${encodeURIComponent(
     file
@@ -46,29 +46,17 @@ export default function Page() {
         Test Name Filter:{" "}
         <ParamSelector
           value={name}
-          handleSubmit={(e) =>
-            handleSubmitURL(e, (submission) =>
-              getURL(submission, suite, file, limit)
-            )
-          }
+          handleSubmit={(e) => setURL(e, suite, file, limit)}
         />{" "}
         | Test Suite Filter:{" "}
         <ParamSelector
           value={suite}
-          handleSubmit={(e) =>
-            handleSubmitURL(e, (submission) =>
-              getURL(name, submission, file, limit)
-            )
-          }
+          handleSubmit={(s) => setURL(name, s, file, limit)}
         />{" "}
         | Test File Filter:{" "}
         <ParamSelector
           value={file}
-          handleSubmit={(e) =>
-            handleSubmitURL(e, (submission) =>
-              getURL(name, suite, submission, limit)
-            )
-          }
+          handleSubmit={(s) => setURL(name, suite, s, limit)}
         />
       </h3>
       {data === undefined ? (

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -372,16 +372,10 @@ function HudTable({ params }: { params: HudParams }) {
 }
 
 function HudHeader({ params }: { params: HudParams }) {
-  function handleBranchSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    // @ts-ignore
-    const branch = e.target[0].value;
+  function handleBranchSubmit(branch: string) {
     window.location.href = formatHudUrlForRoute("hud", { ...params, branch });
   }
-  function handleRepoSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    // @ts-ignore
-    const repoOwnerAndName = e.target[0].value;
+  function handleRepoSubmit(repoOwnerAndName: string) {
     const split = repoOwnerAndName.split("/");
     window.location.href = formatHudUrlForRoute("hud", {
       ...params,

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -43,6 +43,7 @@ import {
 import { track } from "lib/track";
 import useSWR from "swr";
 import { fetcher } from "lib/GeneralUtils";
+import { ParamSelector } from "lib/ParamSelector";
 
 export function JobCell({
   sha,
@@ -368,37 +369,6 @@ function UnstableCheckBox({
 
 function HudTable({ params }: { params: HudParams }) {
   return <GroupedView params={params} />;
-}
-
-function ParamSelector({
-  value,
-  handleSubmit,
-}: {
-  value: string;
-  handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
-}) {
-  const [isInput, setIsInput] = useState(false);
-  if (isInput) {
-    return (
-      <form
-        className={styles.branchForm}
-        onSubmit={handleSubmit}
-        onKeyDown={(e) => {
-          if (e.key === "Escape") {
-            setIsInput(false);
-          }
-        }}
-      >
-        <input autoFocus className={styles.branchFormInput} type="text"></input>
-      </form>
-    );
-  }
-
-  return (
-    <code style={{ cursor: "pointer" }} onClick={() => setIsInput(true)}>
-      {value}
-    </code>
-  );
 }
 
 function HudHeader({ params }: { params: HudParams }) {


### PR DESCRIPTION
Makes the displays for the failure captures/flaky test name etc into form inputs so you can edit them, hit enter, and it will send you to the new url, which basically lets you search for a different failure without needing to change the url directly.

* hit enter or click away to submit/change url
* hit escape to reset the value to original value and unfocus

Play around on
https://torchci-git-csl-paramselectorfailureflakytest-fbopensource.vercel.app/ (the branch/repo, this previously existed but the PR changes some behavior)

https://torchci-git-csl-paramselectorfailureflakytest-fbopensource.vercel.app//failure?name=periodic%20%2F%20win-vs2019-cuda11.8-py3%20%2F%20test%20(default%2C%201%2C%204%2C%20windows.g5.4xlarge.nvidia.gpu)&jobName=undefined&failureCaptures=%5B%22test_linalg.py%3A%3ATestLinalgCUDA%3A%3Atest_matmul_small_brute_force_1d_Nd_cuda_float32%22%5D

https://torchci-git-csl-paramselectorfailureflakytest-fbopensource.vercel.app/flakytest?name=test_requires_grad&suite=TestAutogradWithCompiledAutograd&limit=300