### PR TITLE
[log classifier][ez] Change timed out rule

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -26,7 +26,7 @@ pattern = '^>>> Lint for.*'
 
 [[rule]]
 name = 'GHA timeout'
-pattern = '^##\[error\]The action (.*) has timed out after .* minutes.'
+pattern = '^##\[error\]The action (.*)has timed out(?: after .* minutes|)?.'
 
 [[rule]]
 name = 'Faulty ROCM runner'

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -26,7 +26,7 @@ pattern = '^>>> Lint for.*'
 
 [[rule]]
 name = 'GHA timeout'
-pattern = '^##\[error\]The action has timed out.'
+pattern = '^##\[error\]The action (.*) has timed out after .* minutes.'
 
 [[rule]]
 name = 'Faulty ROCM runner'


### PR DESCRIPTION
It changed to 
<img width="442" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/e8b112b8-48ec-4ba1-87bf-1553bdc9537f">
