### PR TITLE
[TDB] Compare test/time counts with a sha

### DIFF
--- a/torchci/components/additionalTestInfo/TestCounts.tsx
+++ b/torchci/components/additionalTestInfo/TestCounts.tsx
@@ -1,0 +1,153 @@
+import { JobData } from "lib/types";
+import { CSSProperties } from "react";
+import _ from "lodash";
+import useSWR from "swr";
+import { fetcher } from "lib/GeneralUtils";
+import { durationDisplay } from "components/TimeUtils";
+import { DataGrid, GridRenderCellParams } from "@mui/x-data-grid";
+import { RecursiveDetailsSummary } from "./TestInfo";
+
+function TestCountsDataGrid({ info }: { info: any }) {
+  return (
+    <DataGrid
+      initialState={{
+        sorting: {
+          sortModel: [{ field: "file", sort: "desc" }],
+        },
+      }}
+      density={"compact"}
+      rows={Object.keys(info).map((file) => {
+        return {
+          file: file,
+          count: info[file].count,
+          time: Math.round(info[file].time * 100) / 100,
+          id: file,
+        };
+      })}
+      columns={[
+        { field: "file", headerName: "Name", flex: 3 },
+        { field: "count", headerName: "Total Tests", flex: 1 },
+        {
+          field: "time",
+          headerName: "Time",
+          flex: 1,
+          renderCell: (params: GridRenderCellParams<string>) => {
+            const humanReadable = durationDisplay(
+              params.value ? parseFloat(params.value) : 0
+            );
+            return <>{humanReadable}</>;
+          },
+        },
+      ]}
+      hideFooter={true}
+      autoPageSize={false}
+    />
+  );
+}
+
+export function TestCountsInfo({
+  workflowId,
+  jobs,
+  runAttempt,
+}: {
+  workflowId: string;
+  jobs: JobData[];
+  runAttempt: string;
+}) {
+  const shouldShow =
+    jobs.every((job) => job.conclusion !== "pending") &&
+    jobs.some((job) => job.name!.includes("/ test "));
+  const { data: info, error } = useSWR(
+    shouldShow
+      ? `https://ossci-raw-job-status.s3.amazonaws.com/additional_info/invoking_file_summary/${workflowId}/${runAttempt}`
+      : null,
+    fetcher
+  );
+
+  console.log(info);
+  if (!shouldShow) {
+    return <div>Workflow is still pending or there are no test jobs</div>;
+  }
+
+  if (error) {
+    return <div>Error retrieving data {`${error}`}</div>;
+  }
+
+  if (!info) {
+    return <div>Loading...</div>;
+  }
+
+  if (Object.keys(info).length == 0) {
+    return <div>There was trouble parsing data</div>;
+  }
+
+  function getTestCountsTime(info: any): any {
+    const keys = Object.keys(info);
+    if (keys.includes("time") && keys.includes("count")) {
+      return [
+        {
+          time: info.time,
+          count: info.count,
+        },
+      ];
+    }
+    return keys.map((key) => {
+      const subInfo = getTestCountsTime(info[key]);
+      return {
+        time: subInfo.reduce((prev: number, curr: any) => prev + curr.time, 0),
+        count: subInfo.reduce(
+          (prev: number, curr: any) => prev + curr.count,
+          0
+        ),
+        file: key,
+      };
+    });
+  }
+
+  const divStyle: CSSProperties = {
+    overflowY: "auto",
+    height: "50vh",
+    borderStyle: "solid",
+    borderWidth: "1px",
+    padding: "0em 0.5em",
+  };
+  return (
+    <div>
+      <div
+        style={{ fontSize: "1.17em", fontWeight: "bold", paddingTop: "1em" }}
+      >
+        Test Times and Counts
+      </div>
+      <RecursiveDetailsSummary
+        info={info}
+        level={1}
+        bodyFunction={(name: any, info: any) => {
+          const testCountsTimeInfo = _.keyBy(getTestCountsTime(info), "file");
+          return (
+            <div
+              style={{
+                ...divStyle,
+                height: `15vh`,
+              }}
+            >
+              <TestCountsDataGrid info={testCountsTimeInfo} />
+            </div>
+          );
+        }}
+      >
+        {(config: any, configInfo: any, numSiblings: number) => {
+          return (
+            <details>
+              <summary>{config}</summary>
+              <div style={{ paddingLeft: "1em" }}>
+                <div style={divStyle}>
+                  <TestCountsDataGrid info={configInfo} />
+                </div>
+              </div>
+            </details>
+          );
+        }}
+      </RecursiveDetailsSummary>
+    </div>
+  );
+}

--- a/torchci/components/additionalTestInfo/TestCounts.tsx
+++ b/torchci/components/additionalTestInfo/TestCounts.tsx
@@ -56,27 +56,27 @@ function TestCountsDataGrid({
       })}
       columns={[
         { field: "file", headerName: "Name", flex: 4 },
-        { field: "count", headerName: "Total Tests", flex: 1 },
+        { field: "count", headerName: "Test Count", flex: 1 },
         {
           field: "time",
-          headerName: "Time",
+          headerName: "Test Time",
           flex: 1,
           renderCell: renderTime,
         },
         {
           field: "comparisonCount",
-          headerName: "Other SHA Test Count",
+          headerName: "vs Test Count",
           flex: 1,
         },
         {
           field: "comparisonTime",
-          headerName: "Other SHA Time",
+          headerName: "vs Test Time",
           flex: 1,
           renderCell: renderTime,
         },
         {
           field: "diffCount",
-          headerName: "Diff Test Count",
+          headerName: "Δ Test Count",
           flex: 1,
           renderCell: (params) => {
             if (params.value === undefined) {
@@ -95,7 +95,7 @@ function TestCountsDataGrid({
         },
         {
           field: "diffTime",
-          headerName: "Diff Time",
+          headerName: "Δ Test Time",
           flex: 1,
           renderCell: (params) => {
             if (params.value === undefined) {
@@ -272,7 +272,15 @@ export function TestCountsInfo({
       <div style={{ fontSize: "1.17em", fontWeight: "bold", padding: "1em 0" }}>
         Test Times and Counts
       </div>
-      <div style={{ paddingBottom: "1em" }}>
+      <div>
+        This shows the total number of tests and total time taken to run them.
+        Click on the columns names to sort the table by that column. The finest
+        granularity supported is the file level. Expand the build environment
+        names and test configs to see the individual test files. You can also
+        enter a sha below to compare the counts and times with the other sha.
+        The Δ is current sha - comparison sha.
+      </div>
+      <div style={{ padding: "1em 0" }}>
         <form
           onSubmit={(e) => {
             e.preventDefault();

--- a/torchci/components/additionalTestInfo/TestInfo.tsx
+++ b/torchci/components/additionalTestInfo/TestInfo.tsx
@@ -1,14 +1,12 @@
 import { JobData } from "lib/types";
-import { CSSProperties, useState } from "react";
+import { useState } from "react";
 import _ from "lodash";
 import styles from "./TestInfo.module.css";
 import useSWR from "swr";
 import { fetcher } from "lib/GeneralUtils";
-import { AiOutlineConsoleSql } from "react-icons/ai";
-import { durationDisplay } from "components/TimeUtils";
-import { DataGrid, GridRenderCellParams } from "@mui/x-data-grid";
+import { TestCountsInfo } from "./TestCounts";
 
-function RecursiveDetailsSummary({
+export function RecursiveDetailsSummary({
   info,
   level,
   summaryFunction = (name: any, info: any) => <>{name}</>,
@@ -269,151 +267,6 @@ function TDInfo({
             </div>
           </details>
         )}
-      </RecursiveDetailsSummary>
-    </div>
-  );
-}
-
-function TestCountsDataGrid({ info }: { info: any }) {
-  return (
-    <DataGrid
-      initialState={{
-        sorting: {
-          sortModel: [{ field: "file", sort: "desc" }],
-        },
-      }}
-      density={"compact"}
-      rows={Object.keys(info).map((file) => {
-        return {
-          file: file,
-          count: info[file].count,
-          time: Math.round(info[file].time * 100) / 100,
-          id: file,
-        };
-      })}
-      columns={[
-        { field: "file", headerName: "Name", flex: 3 },
-        { field: "count", headerName: "Total Tests", flex: 1 },
-        {
-          field: "time",
-          headerName: "Time",
-          flex: 1,
-          renderCell: (params: GridRenderCellParams<string>) => {
-            const humanReadable = durationDisplay(
-              params.value ? parseFloat(params.value) : 0
-            );
-            return <>{humanReadable}</>;
-          },
-        },
-      ]}
-      hideFooter={true}
-      autoPageSize={false}
-    />
-  );
-}
-
-function TestCountsInfo({
-  workflowId,
-  jobs,
-  runAttempt,
-}: {
-  workflowId: string;
-  jobs: JobData[];
-  runAttempt: string;
-}) {
-  const shouldShow =
-    jobs.every((job) => job.conclusion !== "pending") &&
-    jobs.some((job) => job.name!.includes("/ test "));
-  const { data: info, error } = useSWR(
-    shouldShow
-      ? `https://ossci-raw-job-status.s3.amazonaws.com/additional_info/invoking_file_summary/${workflowId}/${runAttempt}`
-      : null,
-    fetcher
-  );
-
-  console.log(info);
-  if (!shouldShow) {
-    return <div>Workflow is still pending or there are no test jobs</div>;
-  }
-
-  if (error) {
-    return <div>Error retrieving data {`${error}`}</div>;
-  }
-
-  if (!info) {
-    return <div>Loading...</div>;
-  }
-
-  if (Object.keys(info).length == 0) {
-    return <div>There was trouble parsing data</div>;
-  }
-
-  function getTestCountsTime(info: any): any {
-    const keys = Object.keys(info);
-    if (keys.includes("time") && keys.includes("count")) {
-      return [
-        {
-          time: info.time,
-          count: info.count,
-        },
-      ];
-    }
-    return keys.map((key) => {
-      const subInfo = getTestCountsTime(info[key]);
-      return {
-        time: subInfo.reduce((prev: number, curr: any) => prev + curr.time, 0),
-        count: subInfo.reduce(
-          (prev: number, curr: any) => prev + curr.count,
-          0
-        ),
-        file: key,
-      };
-    });
-  }
-
-  const divStyle: CSSProperties = {
-    overflowY: "auto",
-    height: "50vh",
-    borderStyle: "solid",
-    borderWidth: "1px",
-    padding: "0em 0.5em",
-  };
-  return (
-    <div>
-      <div
-        style={{ fontSize: "1.17em", fontWeight: "bold", paddingTop: "1em" }}
-      >
-        Test Times and Counts
-      </div>
-      <RecursiveDetailsSummary
-        info={info}
-        level={1}
-        bodyFunction={(name: any, info: any) => {
-          const testCountsTimeInfo = _.keyBy(getTestCountsTime(info), "file");
-          return (
-            <div
-              style={{
-                ...divStyle,
-                height: `15vh`,
-              }}
-            >
-              <TestCountsDataGrid info={testCountsTimeInfo} />
-            </div>
-          );
-        }}
-      >
-        {(config: any, configInfo: any, numSiblings: number) => {
-          return (
-            <details>
-              <summary>{config}</summary>
-              <div style={{ paddingLeft: "1em" }}>
-                <div style={divStyle}>
-                  <TestCountsDataGrid info={configInfo} />
-                </div>
-              </div>
-            </details>
-          );
-        }}
       </RecursiveDetailsSummary>
     </div>
   );

--- a/torchci/pages/api/corresponding_workflow_id.ts
+++ b/torchci/pages/api/corresponding_workflow_id.ts
@@ -1,0 +1,45 @@
+// For a given workflow id and sha, finds a corresponding workflow on the sha
+// and returns its workflow id.  For example, if the workflow id is 123 and is
+// the trunk workflow, then this will return the workflow id for the trunk
+// workflow on the provided sha
+
+import type { NextApiRequest, NextApiResponse } from "next";
+import getRocksetClient, { RocksetParam } from "lib/rockset";
+
+async function getCorrespondingWorkflowID(sha: string, workflowId: string) {
+  const parameters: RocksetParam[] = [
+    { name: "sha", type: "string", value: sha },
+    { name: "workflow_id", type: "int", value: workflowId },
+  ];
+
+  const query = `
+select
+    w2.id
+from
+    workflow_run w1
+    join workflow_run w2 on w1.workflow_id = w2.workflow_id
+where
+    w1.id = :workflow_id
+    and w2.head_sha = :sha
+order by w2.id desc
+`;
+
+  const client = getRocksetClient();
+  const results = await client.queries.query({
+    sql: {
+      query,
+      parameters,
+    },
+  });
+  return results.results;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const sha = req.query.sha as string;
+  const workflowId = req.query.workflowId as string;
+
+  res.status(200).json(await getCorrespondingWorkflowID(sha, workflowId));
+}


### PR DESCRIPTION
Adds the ability to compare the test counts and times with another run of the workflow for a different sha.

Assumes the most recent workflow is the best (probably not ideal)

first commit is moving stuff into a different file, second commit is real changes

https://torchci-git-csl-tdatestcountscomparison-fbopensource.vercel.app/pr/125114
and then put in some random shas from anything