### PR TITLE
[Dr.CI] Handle the closing of disabled test issues

### DIFF
--- a/torchci/lib/jobUtils.ts
+++ b/torchci/lib/jobUtils.ts
@@ -195,7 +195,7 @@ export function getDisabledTestIssues(
 
       // Get the list of platforms where the test is disabled
       const platformsMatch = disabledTestIssue.body.match(
-        new RegExp("Platforms: (?<platforms>[\\w,\\s]*)")
+        new RegExp("Platforms: (?<platforms>[\\w,\\s]*)[\\r\\n]?")
       );
       if (!platformsMatch || !platformsMatch.groups) {
         return false;

--- a/torchci/lib/jobUtils.ts
+++ b/torchci/lib/jobUtils.ts
@@ -195,7 +195,7 @@ export function getDisabledTestIssues(
 
       // Get the list of platforms where the test is disabled
       const platformsMatch = disabledTestIssue.body.match(
-        new RegExp("Platforms: (?<platforms>[\\w,\\s]*)[\\r\\n]?")
+        new RegExp("Platforms: (?<platforms>[\\w,\\t ]*)")
       );
       if (!platformsMatch || !platformsMatch.groups) {
         return false;

--- a/torchci/lib/jobUtils.ts
+++ b/torchci/lib/jobUtils.ts
@@ -198,7 +198,9 @@ export function getDisabledTestIssues(
         new RegExp("Platforms: (?<platforms>[\\w,\\t ]*)")
       );
       if (!platformsMatch || !platformsMatch.groups) {
-        return false;
+        // Note that if the list of platforms is not set, the default is to disabled
+        // the test on all of them
+        return true;
       }
 
       return _.some(

--- a/torchci/lib/jobUtils.ts
+++ b/torchci/lib/jobUtils.ts
@@ -122,9 +122,9 @@ export function isDisabledTestMentionedInPR(
   matchDisabledTestIssues: IssueData[],
   prInfo: PRandJobs
 ): boolean {
-  // This captures the rule in PyTorch run_test.py that if the disabled issue
-  // is mentioned anywhere in the PR body or commit, the test should be run
-  // instead of skipping by the PR
+  // This captures the rule in PyTorch CI that if the disabled issue is mentioned
+  // anywhere in the PR body or commit, the test should be run instead of skipping
+  // by the PR
   return matchDisabledTestIssues.some((disabledTestIssue) => {
     // NB: This is the same regex used by filter_test_configs script
     const reenableTestRegex = new RegExp(
@@ -195,7 +195,7 @@ export function getDisabledTestIssues(
 
       // Get the list of platforms where the test is disabled
       const platformsMatch = disabledTestIssue.body.match(
-        new RegExp("Platforms: (?<platforms>[w,s]*)")
+        new RegExp("Platforms: (?<platforms>[\\w,\\s]*)")
       );
       if (!platformsMatch || !platformsMatch.groups) {
         return false;

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -119,7 +119,19 @@ export interface HudParams {
 
 export interface PRData {
   title: string;
+  body: string;
   shas: { sha: string; title: string }[];
+}
+
+export interface PRandJobs extends PRData {
+  head_sha: string;
+  head_sha_timestamp?: string;
+  pr_number: number;
+  jobs: RecentWorkflowsData[];
+  merge_base: string;
+  merge_base_date: string;
+  owner: string;
+  repo: string;
 }
 
 export interface FlakyTestData {

--- a/torchci/pages/api/[repoOwner]/[repoName]/pull/[prNumber].ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/pull/[prNumber].ts
@@ -1,3 +1,4 @@
+import { getOctokit } from "lib/github";
 import type { NextApiRequest, NextApiResponse } from "next";
 import fetchPR from "lib/fetchPR";
 import { PRData } from "lib/types";
@@ -6,9 +7,15 @@ export default async function handler(
   res: NextApiResponse<PRData>
 ) {
   const { prNumber, repoName, repoOwner } = req.query;
+  const octokit = await getOctokit(repoOwner as string, repoName as string);
   res
     .status(200)
     .json(
-      await fetchPR(repoOwner as string, repoName as string, prNumber as string)
+      await fetchPR(
+        repoOwner as string,
+        repoName as string,
+        prNumber as string,
+        octokit
+      )
     );
 }

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -919,7 +919,8 @@ export async function reorganizeWorkflows(
       let prTitle = "";
       let prBody = "";
       let prShas: { sha: string; title: string }[] = [];
-      if (octokit) {
+      // Gate this to PyTorch as disabled tests feature is only available there
+      if (octokit && repo === "pytorch") {
         const prData = await fetchPR(owner, repo, `${prNumber}`, octokit);
         prTitle = prData.title;
         prBody = prData.body;

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -828,7 +828,7 @@ export async function getWorkflowJobsStatuses(
           .join(", ");
         relatedInfo.set(
           job.id,
-          `disabled by ${disabledTestIssuesMsg} but the issue was closed recently`
+          `disabled by ${disabledTestIssuesMsg} but the issue was closed recently and a rebase is needed to make it pass`
         );
         continue;
       }

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -820,7 +820,8 @@ export async function getWorkflowJobsStatuses(
         isRecentlyCloseDisabledTest(
           matchDisabledTestIssues,
           prInfo.merge_base_date
-        )
+        ) &&
+        !isDisabledTestMentionedInPR(matchDisabledTestIssues, prInfo)
       ) {
         flakyJobs.push(job);
         const disabledTestIssuesMsg = matchDisabledTestIssues

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -4,7 +4,7 @@ import {
   fetchRecentWorkflows,
   fetchFailedJobsFromCommits,
 } from "lib/fetchRecentWorkflows";
-import { RecentWorkflowsData, IssueData } from "lib/types";
+import { RecentWorkflowsData, IssueData, PRandJobs } from "lib/types";
 import {
   NUM_MINUTES,
   formDrciComment,
@@ -31,21 +31,15 @@ import {
   backfillMissingLog,
   isUnstableJob,
   getOpenUnstableIssues,
+  getDisabledTestIssues,
+  isRecentlyCloseDisabledTest,
+  isDisabledTest,
+  isDisabledTestMentionedInPR,
 } from "lib/jobUtils";
 import getRocksetClient from "lib/rockset";
 import _ from "lodash";
 import { fetchCommitTimestamp } from "lib/fetchCommit";
-
-interface PRandJobs {
-  head_sha: string;
-  head_sha_timestamp?: string;
-  pr_number: number;
-  jobs: RecentWorkflowsData[];
-  merge_base: string;
-  merge_base_date: string;
-  owner: string;
-  repo: string;
-}
+import fetchPR from "lib/fetchPR";
 
 export interface FlakyRule {
   name: string;
@@ -102,6 +96,7 @@ export async function updateDrciComments(
   const sevs = getActiveSEVs(await fetchIssuesByLabel("ci: sev"));
   const flakyRules: FlakyRule[] = (await fetchJSON(FLAKY_RULES_JSON)) || [];
   const unstableIssues: IssueData[] = await fetchIssuesByLabel("unstable");
+  const disabledTestIssues: IssueData[] = await fetchIssuesByLabel("skipped");
   const baseCommitJobs = await getBaseCommitJobs(workflowsByPR);
   const existingDrCiComments = await getExistingDrCiComments(
     `${OWNER}/${repo}`,
@@ -136,7 +131,8 @@ export async function updateDrciComments(
         flakyRules,
         baseCommitJobs.get(pr_info.merge_base) || new Map(),
         labels || [],
-        unstableIssues || []
+        unstableIssues || [],
+        disabledTestIssues || []
       );
 
       failures[pr_info.pr_number] = {
@@ -608,7 +604,12 @@ export function constructResultsComment(
     prNumber,
     `NEW ${pluralize("FAILURE", failedJobs.length).toLocaleUpperCase()}`,
     `The following ${failedJobs.length > 1 ? "jobs have" : "job has"} failed`,
-    failedJobs
+    failedJobs,
+    "",
+    false,
+    relatedJobs,
+    relatedIssues,
+    relatedInfo
   );
   output += constructResultsJobsSections(
     hudBaseUrl,
@@ -723,7 +724,8 @@ export async function getWorkflowJobsStatuses(
   flakyRules: FlakyRule[],
   baseJobs: Map<string, RecentWorkflowsData[]>,
   labels: string[] = [],
-  unstableIssues: IssueData[] = []
+  unstableIssues: IssueData[] = [],
+  disabledTestIssues: IssueData[] = []
 ): Promise<{
   pending: number;
   failedJobs: RecentWorkflowsData[];
@@ -808,6 +810,29 @@ export async function getWorkflowJobsStatuses(
         continue;
       }
 
+      const matchDisabledTestIssues = getDisabledTestIssues(
+        job,
+        disabledTestIssues
+      );
+      if (
+        matchDisabledTestIssues !== undefined &&
+        matchDisabledTestIssues.length !== 0 &&
+        isRecentlyCloseDisabledTest(
+          matchDisabledTestIssues,
+          prInfo.merge_base_date
+        )
+      ) {
+        flakyJobs.push(job);
+        const disabledTestIssuesMsg = matchDisabledTestIssues
+          .map((issue) => `[#${issue.number}](${issue.html_url})`)
+          .join(", ");
+        relatedInfo.set(
+          job.id,
+          `disabled by ${disabledTestIssuesMsg} but the issue was closed recently`
+        );
+        continue;
+      }
+
       if (prInfo.repo === "pytorch") {
         // NB: Searching for similar failures depends on the accuracy of the log
         // classifier, so we only enable this in PyTorch core atm where the log
@@ -819,6 +844,27 @@ export async function getWorkflowJobsStatuses(
         if (similarFailure !== undefined) {
           flakyJobs.push(job);
           relatedJobs.set(job.id, similarFailure);
+          continue;
+        }
+      }
+
+      if (
+        matchDisabledTestIssues !== undefined &&
+        matchDisabledTestIssues.length !== 0 &&
+        isDisabledTest(matchDisabledTestIssues)
+      ) {
+        if (isDisabledTestMentionedInPR(matchDisabledTestIssues, prInfo)) {
+          // If the test is disabled and it's mentioned in the PR, its failure
+          // would be legit, for example, the PR is trying to fix the flaky test
+          relatedIssues.set(job.id, matchDisabledTestIssues);
+        } else {
+          // If the test is disabled and it's NOT mentioned anywhere in the PR,
+          // its failure is consider flaky
+          flakyJobs.push(job);
+          const disabledTestIssuesMsg = matchDisabledTestIssues
+            .map((issue) => `[#${issue.number}](${issue.html_url})`)
+            .join(", ");
+          relatedInfo.set(job.id, `disabled by ${disabledTestIssuesMsg}`);
           continue;
         }
       }
@@ -849,8 +895,8 @@ export async function reorganizeWorkflows(
   const headShaTimestamps: Map<string, string> = new Map();
 
   for (const workflow of recentWorkflows) {
-    const pr_number = workflow.pr_number!;
-    if (!workflowsByPR.has(pr_number)) {
+    const prNumber = workflow.pr_number!;
+    if (!workflowsByPR.has(prNumber)) {
       let headShaTimestamp = workflow.head_sha_timestamp;
       // NB: The head SHA timestamp is currently used as the end date when searching
       // for similar failures.  However, it's not available on Rockset for commits
@@ -867,8 +913,18 @@ export async function reorganizeWorkflows(
         headShaTimestamps.set(workflow.head_sha, headShaTimestamp);
       }
 
-      workflowsByPR.set(pr_number, {
-        pr_number: pr_number,
+      let prTitle = "";
+      let prBody = "";
+      let prShas: { sha: string; title: string }[] = [];
+      if (octokit) {
+        const prData = await fetchPR(owner, repo, `${prNumber}`, octokit);
+        prTitle = prData.title;
+        prBody = prData.body;
+        prShas = prData.shas;
+      }
+
+      workflowsByPR.set(prNumber, {
+        pr_number: prNumber,
         head_sha: workflow.head_sha,
         head_sha_timestamp: headShaTimestamp,
         jobs: [],
@@ -876,6 +932,9 @@ export async function reorganizeWorkflows(
         merge_base_date: "",
         owner: owner,
         repo: repo,
+        title: prTitle,
+        body: prBody,
+        shas: prShas,
       });
     }
 
@@ -884,7 +943,7 @@ export async function reorganizeWorkflows(
       workflow.head_sha_timestamp = headShaTimestamp;
     }
 
-    workflowsByPR.get(pr_number)!.jobs.push(workflow);
+    workflowsByPR.get(prNumber)!.jobs.push(workflow);
   }
 
   // clean up the workflows - remove retries, remove workflows that have jobs,

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -331,7 +331,6 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     const mockJobUtils = jest.spyOn(jobUtils, "hasS3Log");
     mockJobUtils.mockImplementation(() => Promise.resolve(true));
 
-    // Mocking feels like a dark art sometimes
     const mockfetchPR = jest.spyOn(fetchPR, "default");
     mockfetchPR.mockImplementation(() =>
       Promise.resolve({

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -17,6 +17,7 @@ import { removeJobNameSuffix } from "lib/jobUtils";
 import * as fetchRecentWorkflows from "lib/fetchRecentWorkflows";
 import * as drciUtils from "lib/drciUtils";
 import * as jobUtils from "lib/jobUtils";
+import * as fetchPR from "lib/fetchPR";
 
 nock.disableNetConnect();
 
@@ -329,6 +330,16 @@ describe("Update Dr. CI Bot Unit Tests", () => {
 
     const mockJobUtils = jest.spyOn(jobUtils, "hasS3Log");
     mockJobUtils.mockImplementation(() => Promise.resolve(true));
+
+    // Mocking feels like a dark art sometimes
+    const mockfetchPR = jest.spyOn(fetchPR, "default");
+    mockfetchPR.mockImplementation(() =>
+      Promise.resolve({
+        title: "A mock pull request",
+        body: "Anything goes. Fixes #66",
+        shas: [],
+      })
+    );
   });
 
   afterEach(() => {

--- a/torchci/test/jobUtils.test.ts
+++ b/torchci/test/jobUtils.test.ts
@@ -10,7 +10,13 @@ import {
   isDisabledTest,
   isDisabledTestMentionedInPR,
 } from "../lib/jobUtils";
-import { JobData, RecentWorkflowsData, BasicJobData } from "lib/types";
+import {
+  JobData,
+  RecentWorkflowsData,
+  BasicJobData,
+  IssueData,
+  PRandJobs,
+} from "lib/types";
 import nock from "nock";
 import dayjs from "dayjs";
 import * as getAuthors from "../lib/getAuthors";
@@ -571,30 +577,30 @@ describe("Test various job utils", () => {
   });
 
   test("test isDisabledTest", async () => {
+    const mockIssue: IssueData = {
+      state: "open",
+      number: 123,
+      title: "",
+      body: "",
+      updated_at: "",
+      author_association: "",
+      html_url: "",
+    };
+
     expect(isDisabledTest([])).toEqual(false);
     expect(
       isDisabledTest([
         {
+          ...mockIssue,
           state: "closed",
-          number: 123,
-          title: "",
-          body: "",
-          updated_at: "",
-          author_association: "",
-          html_url: "",
         },
       ])
     ).toEqual(false);
     expect(
       isDisabledTest([
         {
+          ...mockIssue,
           state: "open",
-          number: 123,
-          title: "",
-          body: "",
-          updated_at: "",
-          author_association: "",
-          html_url: "",
         },
       ])
     ).toEqual(true);
@@ -603,29 +609,20 @@ describe("Test various job utils", () => {
     expect(
       isDisabledTest([
         {
+          ...mockIssue,
           state: "open",
-          number: 123,
-          title: "",
-          body: "",
-          updated_at: "",
-          author_association: "",
-          html_url: "",
         },
         {
+          ...mockIssue,
           state: "closed",
-          number: 123,
-          title: "",
-          body: "",
-          updated_at: "",
-          author_association: "",
-          html_url: "",
+          number: 456,
         },
       ])
     ).toEqual(true);
   });
 
   test("test isDisabledTestMentionedInPR", async () => {
-    const prInfo = {
+    const prInfo: PRandJobs = {
       head_sha: "",
       head_sha_timestamp: "",
       pr_number: 12345,
@@ -648,6 +645,15 @@ describe("Test various job utils", () => {
         },
       ],
     };
+    const mockIssue: IssueData = {
+      state: "open",
+      number: 123,
+      title: "",
+      body: "",
+      updated_at: "",
+      author_association: "",
+      html_url: "",
+    };
 
     expect(isDisabledTestMentionedInPR([], prInfo)).toEqual(false);
     // Not mention anywhere
@@ -655,13 +661,8 @@ describe("Test various job utils", () => {
       isDisabledTestMentionedInPR(
         [
           {
+            ...mockIssue,
             state: "closed",
-            number: 123,
-            title: "",
-            body: "",
-            updated_at: "",
-            author_association: "",
-            html_url: "",
           },
         ],
         prInfo
@@ -671,13 +672,8 @@ describe("Test various job utils", () => {
       isDisabledTestMentionedInPR(
         [
           {
+            ...mockIssue,
             state: "open",
-            number: 123,
-            title: "",
-            body: "",
-            updated_at: "",
-            author_association: "",
-            html_url: "",
           },
         ],
         prInfo
@@ -689,13 +685,9 @@ describe("Test various job utils", () => {
       isDisabledTestMentionedInPR(
         [
           {
+            ...mockIssue,
             state: "closed",
             number: 666,
-            title: "",
-            body: "",
-            updated_at: "",
-            author_association: "",
-            html_url: "",
           },
         ],
         prInfo
@@ -705,31 +697,23 @@ describe("Test various job utils", () => {
       isDisabledTestMentionedInPR(
         [
           {
+            ...mockIssue,
             state: "open",
             number: 666,
-            title: "",
-            body: "",
-            updated_at: "",
-            author_association: "",
-            html_url: "",
           },
         ],
         prInfo
       )
     ).toEqual(true);
 
-    // Mention in PR body
+    // Another one mention in PR body
     expect(
       isDisabledTestMentionedInPR(
         [
           {
+            ...mockIssue,
             state: "closed",
             number: 555,
-            title: "",
-            body: "",
-            updated_at: "",
-            author_association: "",
-            html_url: "",
           },
         ],
         prInfo
@@ -739,13 +723,9 @@ describe("Test various job utils", () => {
       isDisabledTestMentionedInPR(
         [
           {
+            ...mockIssue,
             state: "open",
             number: 555,
-            title: "",
-            body: "",
-            updated_at: "",
-            author_association: "",
-            html_url: "",
           },
         ],
         prInfo
@@ -757,13 +737,9 @@ describe("Test various job utils", () => {
       isDisabledTestMentionedInPR(
         [
           {
+            ...mockIssue,
             state: "closed",
             number: 777,
-            title: "",
-            body: "",
-            updated_at: "",
-            author_association: "",
-            html_url: "",
           },
         ],
         prInfo
@@ -773,40 +749,28 @@ describe("Test various job utils", () => {
       isDisabledTestMentionedInPR(
         [
           {
+            ...mockIssue,
             state: "open",
             number: 777,
-            title: "",
-            body: "",
-            updated_at: "",
-            author_association: "",
-            html_url: "",
           },
         ],
         prInfo
       )
     ).toEqual(true);
 
-    // Just one issue is mentioned
+    // Just one issue is mentioned in the list
     expect(
       isDisabledTestMentionedInPR(
         [
           {
+            ...mockIssue,
             state: "open",
             number: 666,
-            title: "",
-            body: "",
-            updated_at: "",
-            author_association: "",
-            html_url: "",
           },
           {
+            ...mockIssue,
             state: "open",
             number: 123,
-            title: "",
-            body: "",
-            updated_at: "",
-            author_association: "",
-            html_url: "",
           },
         ],
         prInfo
@@ -816,22 +780,14 @@ describe("Test various job utils", () => {
       isDisabledTestMentionedInPR(
         [
           {
+            ...mockIssue,
             state: "open",
             number: 666,
-            title: "",
-            body: "",
-            updated_at: "",
-            author_association: "",
-            html_url: "",
           },
           {
+            ...mockIssue,
             state: "closed",
             number: 123,
-            title: "",
-            body: "",
-            updated_at: "",
-            author_association: "",
-            html_url: "",
           },
         ],
         prInfo
@@ -840,18 +796,24 @@ describe("Test various job utils", () => {
   });
 
   test("test isRecentlyCloseDisabledTest", async () => {
+    const mockIssue: IssueData = {
+      state: "open",
+      number: 123,
+      title: "",
+      body: "",
+      updated_at: "",
+      author_association: "",
+      html_url: "",
+    };
+
     // At least one of the issue is still open
     expect(
       isRecentlyCloseDisabledTest(
         [
           {
+            ...mockIssue,
             state: "open",
-            number: 555,
-            title: "",
-            body: "",
             updated_at: "2024-05-05T00:00:00Z",
-            author_association: "",
-            html_url: "",
           },
         ],
         "2024-05-06T00:00:00Z"
@@ -861,22 +823,15 @@ describe("Test various job utils", () => {
       isRecentlyCloseDisabledTest(
         [
           {
+            ...mockIssue,
             state: "open",
-            number: 555,
-            title: "",
-            body: "",
             updated_at: "2024-05-05T00:00:00Z",
-            author_association: "",
-            html_url: "",
           },
           {
+            ...mockIssue,
             state: "closed",
             number: 666,
-            title: "",
-            body: "",
             updated_at: "2024-05-04T00:00:00Z",
-            author_association: "",
-            html_url: "",
           },
         ],
         "2024-05-06T00:00:00Z"
@@ -888,22 +843,15 @@ describe("Test various job utils", () => {
       isRecentlyCloseDisabledTest(
         [
           {
+            ...mockIssue,
             state: "closed",
-            number: 555,
-            title: "",
-            body: "",
             updated_at: "2024-05-05T00:00:00Z",
-            author_association: "",
-            html_url: "",
           },
           {
+            ...mockIssue,
             state: "closed",
             number: 666,
-            title: "",
-            body: "",
             updated_at: "2024-05-04T00:00:00Z",
-            author_association: "",
-            html_url: "",
           },
         ],
         "2024-05-06T00:00:00Z"
@@ -915,22 +863,15 @@ describe("Test various job utils", () => {
       isRecentlyCloseDisabledTest(
         [
           {
+            ...mockIssue,
             state: "closed",
-            number: 555,
-            title: "",
-            body: "",
             updated_at: "2024-05-06T00:30:00Z",
-            author_association: "",
-            html_url: "",
           },
           {
+            ...mockIssue,
             state: "closed",
             number: 666,
-            title: "",
-            body: "",
             updated_at: "2024-05-06T01:00:00Z",
-            author_association: "",
-            html_url: "",
           },
         ],
         "2024-05-06T00:00:00Z"
@@ -939,73 +880,49 @@ describe("Test various job utils", () => {
   });
 
   test("test getDisabledTestIssues", async () => {
+    const mockJob: RecentWorkflowsData = {
+      id: "",
+      completed_at: "",
+      html_url: "",
+      head_sha: "",
+      failure_captures: [
+        "test_cpp_extensions_open_device_registration.py::TestCppExtensionOpenRgistration::test_open_device_registration",
+      ],
+      name: "pull / linux-focal-py3.11-clang10 / test (default, 1, 3, linux.2xlarge)",
+    };
+    const mockIssue: IssueData = {
+      number: 100152,
+      state: "open",
+      title:
+        "DISABLED test_open_device_registration (__main__.TestCppExtensionOpenRgistration)",
+      body: "Platforms: linux, win, mac",
+      updated_at: "2024-05-06T00:30:00Z",
+      author_association: "",
+      html_url: "",
+    };
+
     // Invalid input should return nothing
     expect(
       getDisabledTestIssues(
         {
-          id: "",
-          completed_at: "",
-          html_url: "",
-          head_sha: "",
+          ...mockJob,
           failure_captures: [],
-        },
-        []
-      )
-    ).toEqual([]);
-    expect(
-      getDisabledTestIssues(
-        {
-          id: "",
-          completed_at: "",
-          html_url: "",
-          head_sha: "",
-          failure_captures: [],
-          name: "Anything goes",
         },
         []
       )
     ).toEqual([]);
 
     // Having no disabled test issue
-    expect(
-      getDisabledTestIssues(
-        {
-          id: "",
-          completed_at: "",
-          html_url: "",
-          head_sha: "",
-          failure_captures: [
-            "test_cpp_extensions_open_device_registration.py::TestCppExtensionOpenRgistration::test_open_device_registration",
-          ],
-          name: "Anything goes",
-        },
-        []
-      )
-    ).toEqual([]);
+    expect(getDisabledTestIssues(mockJob, [])).toEqual([]);
 
     // Not matching the failure regex
     expect(
       getDisabledTestIssues(
         {
-          id: "",
-          completed_at: "",
-          html_url: "",
-          head_sha: "",
+          ...mockJob,
           failure_captures: ["Not a failed test"],
-          name: "Anything goes",
         },
-        [
-          {
-            state: "open",
-            number: 100152,
-            title:
-              "DISABLED test_open_device_registration (__main__.TestCppExtensionOpenRgistration)",
-            body: "Platforms: linux, win, mac",
-            updated_at: "2024-05-06T00:30:00Z",
-            author_association: "",
-            html_url: "",
-          },
-        ]
+        [mockIssue]
       )
     ).toEqual([]);
 
@@ -1013,27 +930,12 @@ describe("Test various job utils", () => {
     expect(
       getDisabledTestIssues(
         {
-          id: "",
-          completed_at: "",
-          html_url: "",
-          head_sha: "",
+          ...mockJob,
           failure_captures: [
             "test_cpp_extensions_open_device_registration.py::TestCppExtensionOpenRgistration::test_open_device_registration_no_match",
           ],
-          name: "Anything goes",
         },
-        [
-          {
-            state: "open",
-            number: 100152,
-            title:
-              "DISABLED test_open_device_registration (__main__.TestCppExtensionOpenRgistration)",
-            body: "Platforms: linux, win, mac",
-            updated_at: "2024-05-06T00:30:00Z",
-            author_association: "",
-            html_url: "",
-          },
-        ]
+        [mockIssue]
       )
     ).toEqual([]);
 
@@ -1041,133 +943,57 @@ describe("Test various job utils", () => {
     expect(
       getDisabledTestIssues(
         {
-          id: "",
-          completed_at: "",
-          html_url: "",
-          head_sha: "",
+          ...mockJob,
           failure_captures: [
             "test_cpp_extensions_open_device_registration.py::TestCppExtensionOpenRgistrationNoMatch::test_open_device_registration",
           ],
-          name: "Anything goes",
         },
-        [
-          {
-            state: "open",
-            number: 100152,
-            title:
-              "DISABLED test_open_device_registration (__main__.TestCppExtensionOpenRgistration)",
-            body: "Platforms: linux, win, mac",
-            updated_at: "2024-05-06T00:30:00Z",
-            author_association: "",
-            html_url: "",
-          },
-        ]
+        [mockIssue]
       )
     ).toEqual([]);
 
     // No platforms
     expect(
-      getDisabledTestIssues(
+      getDisabledTestIssues(mockJob, [
         {
-          id: "",
-          completed_at: "",
-          html_url: "",
-          head_sha: "",
-          failure_captures: [
-            "test_cpp_extensions_open_device_registration.py::TestCppExtensionOpenRgistration::test_open_device_registration",
-          ],
-          name: "Anything goes",
+          ...mockIssue,
+          body: "Nothing is specified here.  This means that the test is disabled everywhere",
         },
-        [
-          {
-            state: "open",
-            number: 100152,
-            title:
-              "DISABLED test_open_device_registration (__main__.TestCppExtensionOpenRgistration)",
-            body: "Nothing is specified here.  Does this mean the test is disabled everywhere?",
-            updated_at: "2024-05-06T00:30:00Z",
-            author_association: "",
-            html_url: "",
-          },
-        ]
-      )
-    ).toEqual([]);
+      ])
+    ).toEqual([
+      {
+        ...mockIssue,
+        body: "Nothing is specified here.  This means that the test is disabled everywhere",
+      },
+    ]);
 
     // Match a disable test issue
     expect(
-      getDisabledTestIssues(
+      getDisabledTestIssues(mockJob, [
         {
-          id: "",
-          completed_at: "",
-          html_url: "",
-          head_sha: "",
-          failure_captures: [
-            "test_cpp_extensions_open_device_registration.py::TestCppExtensionOpenRgistration::test_open_device_registration",
-          ],
-          name: "pull / linux-focal-py3.11-clang10 / test (default, 1, 3, linux.2xlarge)",
+          ...mockIssue,
+          body: "Platforms: linux, mac",
         },
-        [
-          {
-            state: "open",
-            number: 100152,
-            title:
-              "DISABLED test_open_device_registration (__main__.TestCppExtensionOpenRgistration)",
-            body: "Platforms: linux, mac",
-            updated_at: "2024-05-06T00:30:00Z",
-            author_association: "",
-            html_url: "",
-          },
-        ]
-      )
+      ])
     ).toEqual([
       {
-        state: "open",
-        number: 100152,
-        title:
-          "DISABLED test_open_device_registration (__main__.TestCppExtensionOpenRgistration)",
+        ...mockIssue,
         body: "Platforms: linux, mac",
-        updated_at: "2024-05-06T00:30:00Z",
-        author_association: "",
-        html_url: "",
       },
     ]);
 
     // Include new lines in issue body
     expect(
-      getDisabledTestIssues(
+      getDisabledTestIssues(mockJob, [
         {
-          id: "",
-          completed_at: "",
-          html_url: "",
-          head_sha: "",
-          failure_captures: [
-            "test_cpp_extensions_open_device_registration.py::TestCppExtensionOpenRgistration::test_open_device_registration",
-          ],
-          name: "pull / linux-focal-py3.11-clang10 / test (default, 1, 3, linux.2xlarge)",
+          ...mockIssue,
+          body: "Platforms: linux, mac \n\rAnother line on the issue body",
         },
-        [
-          {
-            state: "open",
-            number: 100152,
-            title:
-              "DISABLED test_open_device_registration (__main__.TestCppExtensionOpenRgistration)",
-            body: "Platforms: linux, mac \n\rShould not be match",
-            updated_at: "2024-05-06T00:30:00Z",
-            author_association: "",
-            html_url: "",
-          },
-        ]
-      )
+      ])
     ).toEqual([
       {
-        state: "open",
-        number: 100152,
-        title:
-          "DISABLED test_open_device_registration (__main__.TestCppExtensionOpenRgistration)",
-        body: "Platforms: linux, mac \n\rShould not be match",
-        updated_at: "2024-05-06T00:30:00Z",
-        author_association: "",
-        html_url: "",
+        ...mockIssue,
+        body: "Platforms: linux, mac \n\rAnother line on the issue body",
       },
     ]);
   });

--- a/torchci/test/jobUtils.test.ts
+++ b/torchci/test/jobUtils.test.ts
@@ -1131,5 +1131,44 @@ describe("Test various job utils", () => {
         html_url: "",
       },
     ]);
+
+    // Include new lines in issue body
+    expect(
+      getDisabledTestIssues(
+        {
+          id: "",
+          completed_at: "",
+          html_url: "",
+          head_sha: "",
+          failure_captures: [
+            "test_cpp_extensions_open_device_registration.py::TestCppExtensionOpenRgistration::test_open_device_registration",
+          ],
+          name: "pull / linux-focal-py3.11-clang10 / test (default, 1, 3, linux.2xlarge)",
+        },
+        [
+          {
+            state: "open",
+            number: 100152,
+            title:
+              "DISABLED test_open_device_registration (__main__.TestCppExtensionOpenRgistration)",
+            body: "Platforms: linux, mac\n\rShould not be match",
+            updated_at: "2024-05-06T00:30:00Z",
+            author_association: "",
+            html_url: "",
+          },
+        ]
+      )
+    ).toEqual([
+      {
+        state: "open",
+        number: 100152,
+        title:
+          "DISABLED test_open_device_registration (__main__.TestCppExtensionOpenRgistration)",
+        body: "Platforms: linux, mac\n\rShould not be match",
+        updated_at: "2024-05-06T00:30:00Z",
+        author_association: "",
+        html_url: "",
+      },
+    ]);
   });
 });

--- a/torchci/test/jobUtils.test.ts
+++ b/torchci/test/jobUtils.test.ts
@@ -1112,7 +1112,7 @@ describe("Test various job utils", () => {
             number: 100152,
             title:
               "DISABLED test_open_device_registration (__main__.TestCppExtensionOpenRgistration)",
-            body: "Platforms: linux",
+            body: "Platforms: linux, mac",
             updated_at: "2024-05-06T00:30:00Z",
             author_association: "",
             html_url: "",
@@ -1125,7 +1125,7 @@ describe("Test various job utils", () => {
         number: 100152,
         title:
           "DISABLED test_open_device_registration (__main__.TestCppExtensionOpenRgistration)",
-        body: "Platforms: linux",
+        body: "Platforms: linux, mac",
         updated_at: "2024-05-06T00:30:00Z",
         author_association: "",
         html_url: "",

--- a/torchci/test/jobUtils.test.ts
+++ b/torchci/test/jobUtils.test.ts
@@ -1151,7 +1151,7 @@ describe("Test various job utils", () => {
             number: 100152,
             title:
               "DISABLED test_open_device_registration (__main__.TestCppExtensionOpenRgistration)",
-            body: "Platforms: linux, mac\n\rShould not be match",
+            body: "Platforms: linux, mac \n\rShould not be match",
             updated_at: "2024-05-06T00:30:00Z",
             author_association: "",
             html_url: "",
@@ -1164,7 +1164,7 @@ describe("Test various job utils", () => {
         number: 100152,
         title:
           "DISABLED test_open_device_registration (__main__.TestCppExtensionOpenRgistration)",
-        body: "Platforms: linux, mac\n\rShould not be match",
+        body: "Platforms: linux, mac \n\rShould not be match",
         updated_at: "2024-05-06T00:30:00Z",
         author_association: "",
         html_url: "",


### PR DESCRIPTION
This extends Dr.CI to handle disabled test issues in several cases:

1. The closing of disabled test issues whereas a test could start failing on PR after its associated disabled issue is resolved.
2. A disabled test fails on PR where it should be skipped.

In both cases, the failure will be marked as skipped and the reason is provided.

### Testing

https://github.com/pytorch/pytorch/pull/125656

## :x: 1 New Failure, 3 Unrelated Failures
As of commit 3a1e14cc5b5d44fa1b04561bccf14d832f70eb1d with merge base b6bcd0917310c657fc60bc7b20415f6948524eb8 (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1715002918?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details open><summary><b>NEW FAILURE</b> - The following job has failed:</summary><p>

* [pull / linux-focal-cuda12.1-py3.10-gcc9 / test (default, 5, 5, linux.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/125656#24661015414) ([gh](https://github.com/pytorch/pytorch/actions/runs/8979058478/job/24661015414))
    `test_foreach.py::TestForeachCUDA::test_parity__foreach_abs_fastpath_inplace_cuda_complex128`
</p></details>
<details ><summary><b>FLAKY</b> - The following jobs failed but were likely due to flakiness present on trunk:</summary><p>

* [trunk / linux-focal-cuda12.1-py3.10-gcc9 / test (nogpu_AVX512, 1, 1, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/125656#24687436887) ([gh](https://github.com/pytorch/pytorch/actions/runs/8987492536/job/24687436887)) (disabled by [#104012](https://github.com/pytorch/pytorch/issues/104012))
    `test_fx.py::TestFXAPIBackwardCompatibility::test_public_api_surface`
* [trunk / linux-focal-cuda12.1-py3.10-gcc9 / test (nogpu_NO_AVX2, 1, 1, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/125656#24687437259) ([gh](https://github.com/pytorch/pytorch/actions/runs/8987492536/job/24687437259)) (disabled by [#104012](https://github.com/pytorch/pytorch/issues/104012))
    `test_fx.py::TestFXAPIBackwardCompatibility::test_public_api_surface`
* [trunk / macos-12-py3-arm64 / test (default, 1, 3, macos-m1-stable)](https://hud.pytorch.org/pr/pytorch/pytorch/125656#24686497666) ([gh](https://github.com/pytorch/pytorch/actions/runs/8987492536/job/24686497666)) (disabled by [#104012](https://github.com/pytorch/pytorch/issues/104012))
    `test_fx.py::TestFXAPIBackwardCompatibility::test_public_api_surface`
</p></details>

https://github.com/pytorch/pytorch/pull/125634

## :x: 1 New Failure, 1 Unrelated Failure
As of commit 28cdf5b4af9803379b6206b8ffbdf214949f111b with merge base 22bcfc25ef3043db37e88ad61ba69c85f98571e1 (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1715033427?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details open><summary><b>NEW FAILURE</b> - The following job has failed:</summary><p>

* [pull / linux-focal-cuda12.1-py3.10-gcc9-sm86 / test (default, 4, 5, linux.g5.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/125634#24685445893) ([gh](https://github.com/pytorch/pytorch/actions/runs/8986634257/job/24685445893)) ([#98259](https://github.com/pytorch/pytorch/issues/98259))
    `test_type_hints.py::TestTypeHints::test_doc_examples`
</p></details>
<details ><summary><b>FLAKY</b> - The following job failed but was likely due to flakiness present on trunk:</summary><p>

* [pull / linux-focal-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/125634#24685444407) ([gh](https://github.com/pytorch/pytorch/actions/runs/8986634257/job/24685444407)) (disabled by [#104012](https://github.com/pytorch/pytorch/issues/104012))
    `test_fx.py::TestFXAPIBackwardCompatibility::test_public_api_surface`
</p></details>