### PR TITLE
[DrCI] Link to hud instead of gh issue for related disabled test

### DIFF
--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -823,7 +823,13 @@ export async function getWorkflowJobsStatuses(
         )
       ) {
         const disabledTestIssuesMsg = matchDisabledTestIssues
-          .map((issue) => `[#${issue.number}](${issue.html_url})`)
+          .map(
+            (issue) =>
+              `[#${issue.number}](${issue.html_url.replace(
+                "https://github.com",
+                HUD_URL
+              )})`
+          )
           .join(", ");
         relatedInfo.set(
           job.id,


### PR DESCRIPTION
After https://github.com/pytorch/test-infra/pull/5186

Link to hud which then redirects to the issue to prevent the PR getting included in the issue's events like the below 
![image](https://github.com/pytorch/test-infra/assets/44682903/89023fe4-f649-42d3-bfd6-be7523055fde)


Ran on one of my PRs, worked fine

<!-- drci-comment-start -->

## :link: Helpful Links
### :test_tube: See artifacts and rendered test results at [hud.pytorch.org/pr/125799](https://hud.pytorch.org/pr/125799)
* :page_facing_up: Preview [Python docs built from this PR](https://docs-preview.pytorch.org/pytorch/pytorch/125799/index.html)
* :page_facing_up: Preview [C++ docs built from this PR](https://docs-preview.pytorch.org/pytorch/pytorch/125799/cppdocs/index.html)
* :question: Need help or want to give feedback on the CI? Visit the [bot commands wiki](https://github.com/pytorch/pytorch/wiki/Bot-commands) or our [office hours](https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours)

Note: Links to docs will display an error until the docs builds have been completed.


## :x: 1 New Failure, 5 Pending, 3 Unrelated Failures
As of commit 852acd87cd5384ac7c61a93d1e0d894f39a6df13 with merge base 8f27c7f181f05ecac5f1948dc070d7781d3da137 (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1715204973?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details open><summary><b>NEW FAILURE</b> - The following job has failed:</summary><p>

* [Lint / lintrunner-noclang / linux-job](https://hud.pytorch.org/pr/pytorch/pytorch/125799#24795916616) ([gh](https://github.com/pytorch/pytorch/actions/runs/9023455827/job/24795916616))
    `>>> Lint for tools/testing/upload_artifacts.py:`
</p></details>
<details ><summary><b>FLAKY</b> - The following jobs failed but were likely due to flakiness present on trunk:</summary><p>

* [pull / linux-focal-py3.8-clang10 / test (crossref, 1, 2, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/125799#24795855797) ([gh](https://github.com/pytorch/pytorch/actions/runs/9023455802/job/24795855797)) (disabled by [#104012](https://hud.pytorch.org/pytorch/pytorch/issues/104012) but the issue was closed recently and a rebase is needed to make it pass)
    `test_fx.py::TestFXAPIBackwardCompatibility::test_public_api_surface`
* [pull / linux-focal-py3.8-clang10 / test (default, 1, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/125799#24795855164) ([gh](https://github.com/pytorch/pytorch/actions/runs/9023455802/job/24795855164)) (disabled by [#104012](https://hud.pytorch.org/pytorch/pytorch/issues/104012) but the issue was closed recently and a rebase is needed to make it pass)
    `test_fx.py::TestFXAPIBackwardCompatibility::test_public_api_surface`
* [pull / linux-focal-py3.8-clang10 / test (dynamo, 1, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/125799#24795856213) ([gh](https://github.com/pytorch/pytorch/actions/runs/9023455802/job/24795856213)) (disabled by [#104012](https://hud.pytorch.org/pytorch/pytorch/issues/104012) but the issue was closed recently and a rebase is needed to make it pass)
    `test_fx.py::TestFXAPIBackwardCompatibility::test_public_api_surface`
</p></details>


This comment was automatically generated by Dr. CI and updates every 15 minutes.
<!-- drci-comment-end -->