### PR TITLE
Added 'distributed (torchelastic)' release notes label tagging

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -37,6 +37,7 @@ const filenameRegexToReleaseCategory: [RegExp, string][] = [
   [/distributed.*pipeline/gi, "release notes: distributed (pipeline)"],
   [/distributed.*fsdp/gi, "release notes: distributed (fsdp)"],
   [/distributed.*rpc/gi, "release notes: distributed (rpc)"],
+  [/distributed.*elastic/gi, "release notes: distributed (torchelastic)"],
   // vulkan
   [/vulkan/gi, "release notes: vulkan"],
   // foreach_frontend


### PR DESCRIPTION
Adding automated release note tagging for `distributed/elastic` per instructions on https://github.com/pytorch/pytorch/wiki/PyTorch-AutoLabel-Bot#why-categorize-for-release-notes-and-how-does-it-work