### PR TITLE
Add g5.48xlarge (8gpu) instance type

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -93,6 +93,12 @@ runner_types:
     is_ephemeral: false
     max_available: 30
     os: linux
+  linux.g5.48xlarge.nvidia.gpu:
+    disk_size: 150
+    instance_type: g5.48xlarge
+    is_ephemeral: false
+    max_available: 2
+    os: linux
   linux.g5.12xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g5.12xlarge


### PR DESCRIPTION
Currently the largest instance is g5.12xlarge and it is only 4-gpu.  We need 8-gpu for 3D parallelism tests.