### PR TITLE
Always try to upload artifacts even if Nova jobs fail

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -259,6 +259,7 @@ jobs:
           ALPINE_IMAGE: ${{ inputs.runner == 'linux.arm64.2xlarge' && 'arm64v8/alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
 
       - name: Prepare artifacts for upload
+        if: always()
         working-directory: ${{ inputs.repository || github.repository }}
         id: check-artifacts
         env:
@@ -290,7 +291,7 @@ jobs:
 
       - name: Upload artifacts to GitHub (if any)
         uses: actions/upload-artifact@v3
-        if: ${{ inputs.upload-artifact != '' }}
+        if: ${{ always() && inputs.upload-artifact != '' }}
         with:
           name: ${{ inputs.upload-artifact }}
           path: ${{ runner.temp }}/artifacts/

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -168,7 +168,7 @@ jobs:
         shell: bash -l {0}
         working-directory: ${{ inputs.repository || github.repository }}
         id: check-artifacts
-        if: ${{ inputs.upload-artifact != '' }}
+        if: ${{ always() && inputs.upload-artifact != '' }}
         env:
           UPLOAD_ARTIFACT_NAME: ${{ inputs.upload-artifact }}
         run: |
@@ -185,11 +185,12 @@ jobs:
 
       - name: Upload artifacts to GitHub (if any)
         uses: actions/upload-artifact@v3
-        if: ${{ inputs.upload-artifact != '' }}
+        if: ${{ always() && inputs.upload-artifact != '' }}
         with:
           name: ${{ inputs.upload-artifact }}
           path: ${{ runner.temp }}/artifacts/
           if-no-files-found: ${{ steps.check-artifacts.outputs.if-no-files-found }}
+
       - name: Clean up disk space
         if: always()
         continue-on-error: true

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -170,7 +170,7 @@ jobs:
         shell: bash -l {0}
         working-directory: ${{ inputs.repository || github.repository }}
         id: check-artifacts
-        if: ${{ inputs.upload-artifact != '' }}
+        if: ${{ always() && inputs.upload-artifact != '' }}
         env:
           UPLOAD_ARTIFACT_NAME: ${{ inputs.upload-artifact }}
         run: |
@@ -187,7 +187,7 @@ jobs:
 
       - name: Upload artifacts to GitHub (if any)
         uses: actions/upload-artifact@v3
-        if: ${{ inputs.upload-artifact != '' }}
+        if: ${{ always() && inputs.upload-artifact != '' }}
         with:
           name: ${{ inputs.upload-artifact }}
           path: ${{ runner.temp }}/artifacts/


### PR DESCRIPTION
This is reported by @wconstab that Nova jobs didn't upload artifacts to GitHub when the test script failed, so it's not possible to access them, for example, to debug the failure.  It makes sense to always try to upload the artifacts instead:

* If the script fails, but there are artifacts, we should upload them
* If the script fails, and there is no artifact, it doesn't matter if the upload step fails or not because the job is going to fail anyway