### PR TITLE
Add m7g.2xlarge workers for linux-aarch64 gpu builds

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -122,6 +122,12 @@ runner_types:
     is_ephemeral: false
     max_available: 200
     os: linux
+  linux.arm64.m7g.2xlarge:
+    disk_size: 256
+    instance_type: m7g.2xlarge
+    is_ephemeral: false
+    max_available: 20
+    os: linux
   windows.4xlarge:
     disk_size: 256
     instance_type: c5d.4xlarge


### PR DESCRIPTION
Trying to explore options to help land: https://github.com/pytorch/pytorch/pull/126174

Current [manywheel-py3_9-cuda-aarch64-build / build](https://github.com/pytorch/pytorch/actions/runs/9112985273/job/25053413689?pr=126174#logs)
Takes around 6hrs (building only sm90 arch). Hence trying to bring slightly bigger worker, see if we can bring build time to manageable time 3-3.5hrs.