### PR TITLE
Disable core dump on Nova Linux jobs

### DIFF
--- a/.github/scripts/run_with_env_secrets.py
+++ b/.github/scripts/run_with_env_secrets.py
@@ -78,6 +78,7 @@ def main():
             --shm-size=2g \
             --tty \
             --ulimit stack=10485760:83886080 \
+            --ulimit core=0 \
             { os.environ.get('GPU_FLAG', '') } \
             -v "{ os.environ.get('GITHUB_WORKSPACE', '') }/{ os.environ.get('REPOSITORY', '') }:/{ os.environ.get('REPOSITORY', 'work') }" \
             -v "{ os.environ.get('GITHUB_WORKSPACE', '') }/test-infra:/test-infra" \


### PR DESCRIPTION
Generating core dump usually brings more problems than it solves.  Recently, we have an incident when a wip PR from https://github.com/pytorch/TensorRT/actions/runs/9083569083/job/24963212460 crashed multiple times, generated too many core dump, and ran out of space on the runner.  Subsequent jobs on the same runner also ran out of space.  So, instead of complex clean up logic, it's easier to disable core dump completely until it's proven necessary.