### PR TITLE
Add the option to upload a selected list of CUDA arch to pypi

### DIFF
--- a/.github/workflows/_binary_upload.yml
+++ b/.github/workflows/_binary_upload.yml
@@ -117,8 +117,7 @@ jobs:
           done
 
       - name: Upload package to pypi
-        # if: ${{ env.NIGHTLY_OR_TEST == '1' && contains(inputs.upload-to-pypi, matrix.desired_cuda) }}
-        if: ${{ contains(inputs.upload-to-pypi, matrix.desired_cuda) }}
+        if: ${{ env.NIGHTLY_OR_TEST == '1' && contains(inputs.upload-to-pypi, matrix.desired_cuda) }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/_binary_upload.yml
+++ b/.github/workflows/_binary_upload.yml
@@ -36,6 +36,10 @@ on:
         description: The comma-separated list of CUDA arch to be uploaded to pypi
         default: ''
         type: string
+    secrets:
+      PYPI_API_TOKEN:
+        description: An optional token to upload to pypi
+        required: false
 
 jobs:
   upload:

--- a/.github/workflows/_binary_upload.yml
+++ b/.github/workflows/_binary_upload.yml
@@ -32,6 +32,10 @@ on:
         description: "Trigger Event in caller that determines whether or not to upload"
         type: string
         default: ''
+      upload-to-pypi:
+        description: The comma-separated list of CUDA arch to be uploaded to pypi
+        default: ''
+        type: string
 
 jobs:
   upload:
@@ -82,7 +86,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Nightly or release RC
-        if: ${{ (inputs.trigger-event == 'push' && startsWith(github.event.ref, 'refs/heads/nightly')) || (env.CHANNEL == 'test' && startsWith(github.event.ref, 'refs/tags/')) }}
+        if: ${{ inputs.trigger-event == 'schedule' || (inputs.trigger-event == 'push' && startsWith(github.event.ref, 'refs/heads/nightly')) || (env.CHANNEL == 'test' && startsWith(github.event.ref, 'refs/tags/')) }}
         shell: bash
         run: |
           set -ex
@@ -107,3 +111,13 @@ jobs:
           for pkg in dist/*; do
             ${AWS_CMD} "$pkg" "${PYTORCH_S3_BUCKET_PATH}" --acl public-read
           done
+
+      - name: Upload package to pypi
+        if: ${{ env.NIGHTLY_OR_TEST == '1' && secrets.PYPI_API_TOKEN != '' && contains(inputs.upload-to-pypi, matrix.desired_cuda) }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          repository-url: https://upload.pypi.org/legacy/
+          packages-dir: ${{ inputs.repository }}/dist/
+          skip-existing: true

--- a/.github/workflows/_binary_upload.yml
+++ b/.github/workflows/_binary_upload.yml
@@ -117,7 +117,8 @@ jobs:
           done
 
       - name: Upload package to pypi
-        if: ${{ env.NIGHTLY_OR_TEST == '1' && contains(inputs.upload-to-pypi, matrix.desired_cuda) }}
+        # if: ${{ env.NIGHTLY_OR_TEST == '1' && contains(inputs.upload-to-pypi, matrix.desired_cuda) }}
+        if: ${{ contains(inputs.upload-to-pypi, matrix.desired_cuda) }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/_binary_upload.yml
+++ b/.github/workflows/_binary_upload.yml
@@ -117,7 +117,7 @@ jobs:
           done
 
       - name: Upload package to pypi
-        if: ${{ env.NIGHTLY_OR_TEST == '1' && secrets.PYPI_API_TOKEN != '' && contains(inputs.upload-to-pypi, matrix.desired_cuda) }}
+        if: ${{ env.NIGHTLY_OR_TEST == '1' && contains(inputs.upload-to-pypi, matrix.desired_cuda) }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -79,6 +79,10 @@ on:
         description: The comma-separated list of CUDA arch to be uploaded to pypi
         default: ""
         type: string
+    secrets:
+      PYPI_API_TOKEN:
+        description: An optional token to upload to pypi
+        required: false
 
 permissions:
   id-token: write
@@ -265,6 +269,8 @@ jobs:
       architecture: ${{ inputs.architecture }}
       trigger-event: ${{ inputs.trigger-event }}
       upload-to-pypi: ${{ inputs.upload-to-pypi }}
+    secrets:
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -75,6 +75,10 @@ on:
         required: false
         type: string
         default: 'setup-py'
+      upload-to-pypi:
+        description: The comma-separated list of CUDA arch to be uploaded to pypi
+        default: ""
+        type: string
 
 permissions:
   id-token: write
@@ -260,6 +264,7 @@ jobs:
       build-matrix: ${{ inputs.build-matrix }}
       architecture: ${{ inputs.architecture }}
       trigger-event: ${{ inputs.trigger-event }}
+      upload-to-pypi: ${{ inputs.upload-to-pypi }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
This is to support torchao use case where it uploads 12.1 CUDA nightly build to https://pypi.org/project/torchao-nightly

### Testing

Do some testing on torchao https://github.com/pytorch/ao/pull/250:

* CUDA 12.1 is uploaded https://github.com/pytorch/ao/actions/runs/9144442527/job/25142401608?pr=250 to https://pypi.org/project/torchao-nightly/2024.5.19/#files
* Other CUDA versions are skipped https://github.com/pytorch/ao/actions/runs/9144442527/job/25142401944