### PR TITLE
Also trigger nightly build on schedule

### DIFF
--- a/.github/workflows/_binary_upload.yml
+++ b/.github/workflows/_binary_upload.yml
@@ -76,7 +76,7 @@ jobs:
           path: ${{ inputs.repository }}/dist/
 
       - name: Configure aws credentials (pytorch account)
-        if: ${{ inputs.trigger-event == 'push' && startsWith(github.event.ref, 'refs/heads/nightly') }}
+        if: ${{ inputs.trigger-event == 'schedule' || (inputs.trigger-event == 'push' && startsWith(github.event.ref, 'refs/heads/nightly')) }}
         uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_nightly_build_wheels


### PR DESCRIPTION
A follow-up after https://github.com/pytorch/test-infra/pull/5217 and https://github.com/pytorch/ao/pull/250, repo like `torch/ao` doesn't have a nightly branch and build nightly directly out of main on a daily schedule.