### PR TITLE
Increasing max runners for linux.g5.48xlarge.nvidia.gpu

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -97,7 +97,7 @@ runner_types:
     disk_size: 150
     instance_type: g5.48xlarge
     is_ephemeral: false
-    max_available: 2
+    max_available: 20
     os: linux
   linux.g5.12xlarge.nvidia.gpu:
     disk_size: 150


### PR DESCRIPTION
PR introduced https://github.com/pytorch/test-infra/pull/5201 but only with max 2

Adding max of 20 to temporarily mitigate