### PR TITLE
[EZ] De-emphasize note about the page auto-updating.

### DIFF
--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -441,8 +441,10 @@ export default function Hud() {
             <HudHeader params={params} />
             <HudTable params={params} />
             <PageSelector params={params} baseUrl="hud" />
-            <br/>
-            <div><em>This page automatically updates.</em></div>
+            <br />
+            <div>
+              <em>This page automatically updates.</em>
+            </div>
           </div>
         )}
       </PinnedTooltipContext.Provider>

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -439,9 +439,10 @@ export default function Hud() {
         {params.branch !== undefined && (
           <div onClick={handleClick}>
             <HudHeader params={params} />
-            <div>This page automatically updates.</div>
             <HudTable params={params} />
             <PageSelector params={params} baseUrl="hud" />
+            <br/>
+            <div><em>This page automatically updates.</em></div>
           </div>
         )}
       </PinnedTooltipContext.Provider>


### PR DESCRIPTION
Reduces visual clutter by moving the message to the very bottom of the page

It doesn't need to be made so prominent. Save that real estate for more important stuff