### PR TITLE
[EZ] [HUD] Always show a "Prev" button

### DIFF
--- a/torchci/components/PageSelector.tsx
+++ b/torchci/components/PageSelector.tsx
@@ -22,10 +22,12 @@ export default function PageSelector({
             })}
           >
             Prev
-          </Link>{" "}
-          |{" "}
+          </Link>
         </span>
-      ) : null}
+      ) : (
+        <span>Prev</span>
+      )}{" "}
+      |{" "}
       <Link
         prefetch={false}
         href={formatHudUrlForRoute(baseUrl, {


### PR DESCRIPTION
UX improvement for when you want to scroll back (or "Next") multiple pages.

Previously, when you went to hud, scolled to the bottom, click the "Next" button, and scrolled down again, the "Next" button would have moved to the right because "Prev" suddenly appeared.

You no longer have to do that

Old:
<img width="115" alt="image" src="https://github.com/pytorch/test-infra/assets/4468967/d22c4e1d-b8ef-444c-adc8-1620c13cac00">

New:
<img width="167" alt="image" src="https://github.com/pytorch/test-infra/assets/4468967/6ae6b616-26eb-41a8-b297-b05613c89f7f">
