### PR TITLE
[EZ] [BE] [HUD] Remove invalid Job filter instructions

### DIFF
--- a/torchci/components/JobFilterInput.tsx
+++ b/torchci/components/JobFilterInput.tsx
@@ -19,9 +19,7 @@ export default function JobFilterInput({
           handleSubmit();
         }}
       >
-        <label htmlFor="name_filter">
-          Job filter: (press enter to change url, esc to clear):{" "}
-        </label>
+        <label htmlFor="name_filter">Job filter: </label>
         <input
           style={{ width: width }}
           onChange={(e) => {


### PR DESCRIPTION
The text is no longer accurate. Simply typing something into the filter automatically updates the url

(This is for the job filter box at the top of the HUD home page)