### PR TITLE
[HUD] Group TTS KPIS by branch

### DIFF
--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -117,6 +117,7 @@ export default function Kpis() {
           yAxisFieldName={"avg_tts"}
           yAxisLabel={"Hours"}
           yAxisRenderer={(unit) => `${unit}`}
+          groupByFieldName="branch"
         />
       </Grid>
 

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -40,7 +40,7 @@
     "number_of_force_pushes_historical": "08c5ab5902940a88",
     "time_to_merge": "be1c2a28cf75fe32",
     "time_to_review": "adfbcdfc51ede11a",
-    "time_to_signal": "ff332d025976c103",
+    "time_to_signal": "8866b339e1a255e6",
     "strict_lag_historical": "d2a09d13caf8b76a",
     "ci_wait_time": "b1080f26b20ea142",
     "ttrs_percentiles": "ea95e9b56ab6900f"

--- a/torchci/rockset/pytorch_dev_infra_kpis/__sql/time_to_signal.sql
+++ b/torchci/rockset/pytorch_dev_infra_kpis/__sql/time_to_signal.sql
@@ -1,68 +1,39 @@
-with failed_workflows as (
-	select
-        distinct(w.head_commit.id)	as sha
-    from commons.workflow_run w
-    where
-        w.conclusion in ('failure', 'startup_failure', 'cancelled')
-        and w.repository.full_name = 'pytorch/pytorch'
-),
-successful_commits as (
-  select 
-      w.head_commit.id as sha,
-      count(*) as cnt,
-      MIN(w.created_at) as created_at
-  from 
-      commons.workflow_run w left outer join failed_workflows f on w.head_commit.id = f.sha
-  where 
-      f.sha is null
-      and PARSE_TIMESTAMP_ISO8601(w.created_at) > PARSE_TIMESTAMP_ISO8601(:startTime)
-      AND w.repository.full_name = 'pytorch/pytorch'
-      and w.conclusion = 'success'
-      and w.run_attempt = 1 
-  group by sha
-),
-completed_workflows as (
-    select
-        w.created_at as created_at,
-        w.id,
-        w.head_sha
-    from
-        commons.workflow_run w
-    where
-        status = 'completed'
-        and w.repository.full_name = 'pytorch/pytorch'
-        and PARSE_TIMESTAMP_ISO8601(w.created_at) > PARSE_TIMESTAMP_ISO8601(:startTime)
-        and w.run_attempt = 1 
-        and w.head_sha in (select sha from successful_commits)
-),
-tts_by_sha as (
-    select
-        c.head_sha,
-        PARSE_TIMESTAMP_ISO8601(c.created_at) as created_at,
-        max(PARSE_TIMESTAMP_ISO8601(job.completed_at)) as completed_at,
-        count(*) as job_cnt
-    from
-        completed_workflows c HINT(access_path = column_scan)
-        inner join commons.workflow_job job on c.id = job.run_id
-    where
-        name like case
-            when :buildOrAll = 'build' then 'build'
-            else '%'
-        end
-    group by
-        head_sha,
-        created_at
-)
+with
+    tts as (
+        SELECT
+            MAX(
+                DATE_DIFF(
+                    'second',
+                    PARSE_TIMESTAMP_ISO8601(w.created_at),
+                    PARSE_TIMESTAMP_ISO8601(w.updated_at)
+                )
+            ) as duration_sec,
+            w.head_sha,
+            ARBITRARY(IF(w.head_branch = 'main', 'main', 'not main')) as branch,
+            MIN(PARSE_TIMESTAMP_ISO8601(w.created_at)) as created_at
+        FROM
+            commons.workflow_run w
+        WHERE
+            ARRAY_CONTAINS(['pull', 'trunk'], LOWER(w.name))
+            AND PARSE_TIMESTAMP_ISO8601(w.created_at) >= PARSE_DATETIME_ISO8601(:startTime)
+            AND w.head_repository.full_name = 'pytorch/pytorch'
+        group by
+            w.head_sha
+        having
+            bool_and(
+                w.conclusion = 'success'
+                and w.run_attempt = 1
+            )
+    )
 select
-    CAST(DATE_TRUNC('WEEK', created_at) as string) AS week_bucket,
-    avg(
-        DATE_DIFF('minute', created_at, completed_at) / 60.0
-    ) as avg_tts,
+    CAST(DATE_TRUNC('week', t.created_at) as string) AS week_bucket,
+    avg(t.duration_sec / 3600.0) as avg_tts,
+    t.branch
 from
-    tts_by_sha
-where
-    job_cnt > 35
+    tts t
 group by
-    week_bucket
+    week_bucket,
+    t.branch
 order by
-    week_bucket desc
+    week_bucket desc,
+    t.branch desc

--- a/torchci/rockset/pytorch_dev_infra_kpis/time_to_signal.lambda.json
+++ b/torchci/rockset/pytorch_dev_infra_kpis/time_to_signal.lambda.json
@@ -2,14 +2,9 @@
   "sql_path": "__sql/time_to_signal.sql",
   "default_parameters": [
     {
-      "name": "buildOrAll",
-      "type": "string",
-      "value": "all"
-    },
-    {
       "name": "startTime",
       "type": "string",
-      "value": "2022-01-01T00:00:00.000Z"
+      "value": "2023-01-01T00:00:00.000Z"
     }
   ],
   "description": "TTS for successful workflows"


### PR DESCRIPTION
Group TTS KPI by branch.

I'm not sure what the reasoning behind the old query was, so I simplified it a lot and only include pull and trunk

Old:
![image](https://github.com/pytorch/test-infra/assets/44682903/9fff6dd4-44a4-4241-b3e0-f5d9eeab1a85)

New:
![image](https://github.com/pytorch/test-infra/assets/44682903/c428847b-16d7-4b76-b057-1407b305385c)
