### PR TITLE
[HUD] Fix common log classifications table links to examples of errors

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -914,13 +914,15 @@ export default function Page() {
               { field: "num", headerName: "Count", flex: 1 },
               { field: "example", headerName: "Example", flex: 4 },
               {
-                field: "search_string",
+                field: "captures",
                 headerName: "Captures",
                 flex: 4,
                 renderCell: (params: GridRenderCellParams<string>) => {
                   const url = params.value
-                    ? `failure/${encodeURIComponent(params.row.search_string)}`
-                    : "failure/";
+                    ? `failure?failureCaptures=${encodeURIComponent(
+                        JSON.stringify(params.row.captures)
+                      )}`
+                    : "failure";
                   return <a href={url}>{params.value}</a>;
                 },
               },


### PR DESCRIPTION
This table on the metrics page (it looks the same, its just that the things it links to changed)
![image](https://github.com/pytorch/test-infra/assets/44682903/a3f0fca3-0e4f-4ce1-ac86-46b1b25c1cd4)


Example
old link: 
https://hud.pytorch.org/failure/%23%23%5Berror%5DThe%20operation%20was%20canceled.
new link:
https://hud.pytorch.org/failure?failureCaptures=%5B%22%23%23%5Berror%5DThe%20operation%20was%20canceled.%22%5D

