### PR TITLE
[HUD] [BE] Add permalink to home screen

### DIFF
--- a/torchci/components/CopyLink.tsx
+++ b/torchci/components/CopyLink.tsx
@@ -1,7 +1,16 @@
+import { css } from "@emotion/react";
 import React, { useState } from "react";
 import useCopyClipboard from "react-use-clipboard";
 
-export default function CopyLink({ textToCopy }: { textToCopy: string }) {
+export default function CopyLink({
+  textToCopy,
+  style,
+  compressed = true, // Whether a small or large button should be used
+}: {
+  textToCopy: string;
+  style?: React.CSSProperties;
+  compressed?: boolean;
+}) {
   const [isCopied, setCopied] = useCopyClipboard(textToCopy);
   const [showCopied, setShowCopied] = useState(false);
   const onClick = () => {
@@ -12,13 +21,30 @@ export default function CopyLink({ textToCopy }: { textToCopy: string }) {
       setShowCopied(false);
     }, 3000);
   };
+
+  const copy_prompt = "Permalink";
+  const copy_ack = "Copied";
+
+  function getButtonText(baseIcon: string, elaboration: string) {
+    if (compressed) {
+      return baseIcon;
+    } else {
+      return `${baseIcon} ${elaboration}`;
+    }
+  }
+
+  let css_style: React.CSSProperties = compressed ? { background: "none" } : {};
+  css_style = { ...css_style, ...style };
+
   return (
     <button
-      style={{ fontSize: "smaller", background: "none", border: "none" }}
-      title={isCopied ? "Copied" : "Copy Link"}
+      style={css_style}
+      title={isCopied ? copy_ack : copy_prompt}
       onClick={onClick}
     >
-      {showCopied ? "✅" : "🔗"}
+      {showCopied
+        ? getButtonText("✅", copy_ack)
+        : getButtonText("🔗", copy_prompt)}
     </button>
   );
 }

--- a/torchci/components/CopyLink.tsx
+++ b/torchci/components/CopyLink.tsx
@@ -18,7 +18,7 @@ export default function CopyLink({ textToCopy }: { textToCopy: string }) {
       title={isCopied ? "Copied" : "Copy Link"}
       onClick={onClick}
     >
-      {showCopied ? "✔️" : "📋"}
+      {showCopied ? "✅" : "🔗"}
     </button>
   );
 }

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -29,7 +29,7 @@ import useHudData from "lib/useHudData";
 import useTableFilter from "lib/useTableFilter";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import React, { createContext, useContext, useEffect, useState } from "react";
+import React, { createContext, useContext, useEffect, useRef, useState } from "react";
 import PageSelector from "components/PageSelector";
 import {
   isFailedJob,
@@ -475,17 +475,20 @@ function useLatestCommitSha(params: HudParams) {
   return data.shaGrid[0].sha;
 }
 
-function getPermalinkCopiedState(params: HudParams) {
+function usePermalinkCopiedState(params: HudParams) {
   // We ensure that the "Copied" state is reset when the params change
   // since that would change the permalink url.
   // Params can change on things like page navigation, changing job filter, etc.
 
   const [copied, setCopied] = useState(false);
-  const [oldParams, setOldParams] = useState(params);
+
+  // Store the old params to know when the actual params
+  // change instead of just the reference to them
+  const prevParamsRef = useRef(params);
 
   useEffect(() => {
-    if (!_.isEqual(oldParams, params)) {
-      setOldParams(params);
+    if (!_.isEqual(prevParamsRef.current, params)) {
+      prevParamsRef.current = params;
       setCopied(false);
     }
   }, [params]);
@@ -501,7 +504,7 @@ function CopyPermanentLink({
   style?: React.CSSProperties;
 }) {
   // Used to let users know that the permalink has been successfully copied to their clipboard
-  const { copied, setCopied } = getPermalinkCopiedState(params);
+  const { copied, setCopied } = usePermalinkCopiedState(params);
 
   // Branch and tag pointers can change over time.
   // For a permanent, we take the latest immutable commit as our reference

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -536,7 +536,7 @@ function CopyPermanentLink({
         }}
         style={style}
       >
-        {copied ? "📋 ✅ Copied" : "📋 Permalink"}
+        {copied ? "✅ Copied" : "🔗 Permalink"}
       </button>
     </>
   );

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -440,9 +440,12 @@ export default function Hud() {
       <PinnedTooltipContext.Provider value={[pinnedTooltip, setPinnedTooltip]}>
         {params.branch !== undefined && (
           <div onClick={handleClick}>
-            <div style={{ display: 'flex', alignItems: 'flex-end'}}>
+            <div style={{ display: "flex", alignItems: "flex-end" }}>
               <HudHeader params={params} />
-              <CopyPermanentLink params={params} style={{ marginLeft: '10px' }}/>
+              <CopyPermanentLink
+                params={params}
+                style={{ marginLeft: "10px" }}
+              />
             </div>
             <HudTable params={params} />
             <PageSelector params={params} baseUrl="hud" />
@@ -472,20 +475,33 @@ function getLatestCommitSha(params: HudParams) {
   return data.shaGrid[0].sha;
 }
 
-function CopyPermanentLink({ params, style }: { params: HudParams; style?: React.CSSProperties }) {
-  // Used to let users know that the permalink has been successfully copied to their clipboard
+function getPermalinkCopiedState(params: HudParams) {
+  // We ensure that the "Copied" state is reset when the params change
+  // since that would change the permalink url.
+  // Params can change on things like page navigation, changing job filter, etc.
+
   const [copied, setCopied] = useState(false);
   const [oldParams, setOldParams] = useState(params);
 
-  // Ensure that the "Copied" message is reset when the params change
-  // since that would change the permalink url.
-  // Params can change on things like page navigation, changing job filter, etc.
   useEffect(() => {
     if (!_.isEqual(oldParams, params)) {
       setOldParams(params);
       setCopied(false);
     }
   }, [params]);
+
+  return { copied, setCopied };
+}
+
+function CopyPermanentLink({
+  params,
+  style,
+}: {
+  params: HudParams;
+  style?: React.CSSProperties;
+}) {
+  // Used to let users know that the permalink has been successfully copied to their clipboard
+  const { copied, setCopied } = getPermalinkCopiedState(params);
 
   // Branch and tag pointers can change over time.
   // For a permanent, we take the latest immutable commit as our reference

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -52,6 +52,7 @@ import { fetcher } from "lib/GeneralUtils";
 import { ParamSelector } from "lib/ParamSelector";
 
 import _ from "lodash";
+import CopyLink from "components/CopyLink";
 
 export function JobCell({
   sha,
@@ -481,27 +482,6 @@ function useLatestCommitSha(params: HudParams) {
   return data.shaGrid[0].sha;
 }
 
-function usePermalinkCopiedState(params: HudParams) {
-  // We ensure that the "Copied" state is reset when the params change
-  // since that would change the permalink url.
-  // Params can change on things like page navigation, changing job filter, etc.
-
-  const [copied, setCopied] = useState(false);
-
-  // Store the old params to know when the actual params
-  // change instead of just the reference to them
-  const prevParamsRef = useRef(params);
-
-  useEffect(() => {
-    if (!_.isEqual(prevParamsRef.current, params)) {
-      prevParamsRef.current = params;
-      setCopied(false);
-    }
-  }, [params]);
-
-  return { copied, setCopied };
-}
-
 function CopyPermanentLink({
   params,
   style,
@@ -509,9 +489,6 @@ function CopyPermanentLink({
   params: HudParams;
   style?: React.CSSProperties;
 }) {
-  // Used to let users know that the permalink has been successfully copied to their clipboard
-  const { copied, setCopied } = usePermalinkCopiedState(params);
-
   // Branch and tag pointers can change over time.
   // For a permanent, we take the latest immutable commit as our reference
   const latestCommitSha = useLatestCommitSha(params);
@@ -523,23 +500,7 @@ function CopyPermanentLink({
   const domain = window.location.origin;
   const path = formatHudUrlForRoute("hud", permaParams);
   const url = `${domain}${path}`;
-  return (
-    <>
-      <button
-        onClick={() => {
-          navigator.clipboard.writeText(url);
-          setCopied(true);
-
-          setTimeout(() => {
-            setCopied(false);
-          }, 10 * 1000); // 10000 milliseconds = 10 seconds
-        }}
-        style={style}
-      >
-        {copied ? "✅ Copied" : "🔗 Permalink"}
-      </button>
-    </>
-  );
+  return <CopyLink textToCopy={url} compressed={false} style={style} />;
 }
 
 function GroupedView({ params }: { params: HudParams }) {

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -29,7 +29,13 @@ import useHudData from "lib/useHudData";
 import useTableFilter from "lib/useTableFilter";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import React, { createContext, useContext, useEffect, useRef, useState } from "react";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import PageSelector from "components/PageSelector";
 import {
   isFailedJob,

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -460,7 +460,7 @@ export default function Hud() {
   );
 }
 
-function getLatestCommitSha(params: HudParams) {
+function useLatestCommitSha(params: HudParams) {
   const data = useHudData(params);
   if (data === undefined) {
     return null;
@@ -505,7 +505,7 @@ function CopyPermanentLink({
 
   // Branch and tag pointers can change over time.
   // For a permanent, we take the latest immutable commit as our reference
-  const latestCommitSha = getLatestCommitSha(params);
+  const latestCommitSha = useLatestCommitSha(params);
   if (latestCommitSha === null) {
     return <></>;
   }


### PR DESCRIPTION
Adds a permalink button at the top of the home screen, next to the branch name.

When clicked, the button offers visual feedback that the url was copied to the clipboard. The button resets after 3 seconds.

Extended the existing CopyLink component to support this use case, and also updated the icons it uses to better match standard convention

Button:
<img width="492" alt="image" src="https://github.com/pytorch/test-infra/assets/4468967/3e42a2e8-6745-44d3-a8be-34168d8b9e25">
When clicked:
<img width="496" alt="image" src="https://github.com/pytorch/test-infra/assets/4468967/79d2557e-a9ab-4302-bc80-ba81a2c06f8e">