### PR TITLE
Connect OIDC when building nightly on schedule

### DIFF
--- a/.github/workflows/_binary_upload.yml
+++ b/.github/workflows/_binary_upload.yml
@@ -44,7 +44,7 @@ on:
 jobs:
   upload:
     runs-on: ubuntu-22.04
-    environment: ${{(inputs.trigger-event == 'push' && (startsWith(github.event.ref, 'refs/heads/nightly') || startsWith(github.event.ref, 'refs/tags/v'))) && 'pytorchbot-env' || ''}}
+    environment: ${{(inputs.trigger-event == 'schedule' || (inputs.trigger-event == 'push' && (startsWith(github.event.ref, 'refs/heads/nightly') || startsWith(github.event.ref, 'refs/tags/v')))) && 'pytorchbot-env' || ''}}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.build-matrix) }}
@@ -76,7 +76,7 @@ jobs:
           path: ${{ inputs.repository }}/dist/
 
       - name: Configure aws credentials (pytorch account)
-        if: ${{ inputs.trigger-event == 'push' && startsWith(github.event.ref, 'refs/heads/nightly') }}
+        if: ${{ inputs.trigger-event == 'schedule' || (inputs.trigger-event == 'push' && startsWith(github.event.ref, 'refs/heads/nightly')) }}
         uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_nightly_build_wheels


### PR DESCRIPTION
A follow-up after https://github.com/pytorch/test-infra/pull/5217 and https://github.com/pytorch/ao/pull/250, repo like torch/ao doesn't have a nightly branch and build nightly directly out of main on a daily schedule.  This was missed in https://github.com/pytorch/test-infra/pull/5222.  It's a bit tricky to get this right off the bat.

Also need to land D57657633 to allow nightly upload on the AWS side.