### PR TITLE
[HUD] Bring back workflow load chart on metrics page

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -858,14 +858,27 @@ export default function Page() {
 
         <Grid item xs={6} height={ROW_HEIGHT}>
           <TimeSeriesPanel
-            title={"Number of new disabled tests"}
-            queryName={"disabled_test_historical"}
-            queryParams={[...timeParams]}
-            granularity={"day"}
+            title={"Workflow load per Day"}
+            queryName={"workflow_load"}
+            queryParams={[
+              {
+                name: "timezone",
+                type: "string",
+                value: Intl.DateTimeFormat().resolvedOptions().timeZone,
+              },
+              {
+                name: "repo",
+                type: "string",
+                value: "pytorch/pytorch",
+              },
+              ...timeParams,
+            ]}
+            granularity={"hour"}
+            groupByFieldName={"name"}
             timeFieldName={"granularity_bucket"}
-            yAxisFieldName={"number_of_new_disabled_tests"}
+            yAxisFieldName={"count"}
+            yAxisLabel={"workflows started"}
             yAxisRenderer={(value) => value}
-            additionalOptions={{ yAxis: { scale: true } }}
           />
         </Grid>
         <JobsDuration
@@ -931,6 +944,18 @@ export default function Page() {
               getRowId: (el: any) =>
                 el.search_string ? el.search_string : "null",
             }}
+          />
+        </Grid>
+        <Grid item xs={6} height={ROW_HEIGHT}>
+          <TimeSeriesPanel
+            title={"Number of new disabled tests"}
+            queryName={"disabled_test_historical"}
+            queryParams={[...timeParams]}
+            granularity={"day"}
+            timeFieldName={"granularity_bucket"}
+            yAxisFieldName={"number_of_new_disabled_tests"}
+            yAxisRenderer={(value) => value}
+            additionalOptions={{ yAxis: { scale: true } }}
           />
         </Grid>
       </Grid>

--- a/torchci/pages/testing_overhead.tsx
+++ b/torchci/pages/testing_overhead.tsx
@@ -177,31 +177,6 @@ export default function TestingOverhead() {
               additionalOptions={{ yAxis: { scale: true } }}
             />
           </Grid>
-          <Grid item xs={6} lg={12} height={ROW_HEIGHT}>
-            <TimeSeriesPanel
-              title={"Workflow load per Day"}
-              queryName={"workflow_load"}
-              queryParams={[
-                {
-                  name: "timezone",
-                  type: "string",
-                  value: Intl.DateTimeFormat().resolvedOptions().timeZone,
-                },
-                {
-                  name: "repo",
-                  type: "string",
-                  value: "pytorch/%",
-                },
-                ...timeParams,
-              ]}
-              granularity={"hour"}
-              groupByFieldName={"name"}
-              timeFieldName={"granularity_bucket"}
-              yAxisFieldName={"count"}
-              yAxisLabel={"# of workflows run"}
-              yAxisRenderer={(value) => value}
-            />
-          </Grid>
         </Grid>
       </>
       <GenerateOncallTestingOverheadLeaderboard workflowName={workflow} />


### PR DESCRIPTION
It's a pretty chart

Shuffle the disabled tests chart to the bottom to maintain horizontal alignment/current placement of duration/tts tables

<img width="854" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/a67154fb-f481-4dd8-9c2b-8bcccc92f088">
