### PR TITLE
[HUD] fix localStorage persistence of `useMonsterFailures` preference

### DIFF
--- a/torchci/lib/useGroupingPreference.tsx
+++ b/torchci/lib/useGroupingPreference.tsx
@@ -1,13 +1,20 @@
 import { useState } from "react";
 
+/**
+ * A hook to manage a boolean preference in local storage.
+ * @param name The name of the preference in local storage.
+ * @param override If defined, this value will be used instead of the value in local storage.
+ * @param defaultValue The default value to use if the preference is not set in local storage.
+ */
 export function usePreference(
   name: string,
-  override: boolean | undefined = undefined
+  override: boolean | undefined = undefined,
+  defaultValue: boolean = true
 ): [boolean, (grouping: boolean) => void] {
   const settingFromStorage =
     typeof window === "undefined"
-      ? "true"
-      : window.localStorage.getItem(name) ?? "true";
+      ? String(defaultValue)
+      : window.localStorage.getItem(name) ?? String(defaultValue);
   const initialVal =
     override === undefined ? settingFromStorage === "true" : override;
   const [state, setState] = useState<boolean>(initialVal);
@@ -32,5 +39,9 @@ export function useMonsterFailuresPreference(): [
   boolean,
   (useMonsterFailuresValue: boolean) => void
 ] {
-  return usePreference("useMonsterFailures", /*default*/ false);
+  return usePreference(
+    "useMonsterFailures",
+    /*override*/ undefined,
+    /*default*/ false
+  );
 }


### PR DESCRIPTION
a minor bugfix

I mistook the `override` parameter of `usePreference` for default/initial value, resulting the setting to always be false after refresh.

This change fixes that, and also improves and documents `usePreference` hook API.