### PR TITLE
[ez][HUD] Change checkbox clickable area to be smaller

### DIFF
--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -352,18 +352,20 @@ function GroupViewCheckBox({
 }) {
   return (
     <>
-      <div
-        onClick={() => {
-          setUseGrouping(!useGrouping);
-        }}
-      >
-        <input
-          type="checkbox"
-          name="groupView"
-          checked={useGrouping}
-          onChange={() => {}}
-        />
-        <label htmlFor="groupView"> Use grouped view</label>
+      <div>
+        <span
+          onClick={() => {
+            setUseGrouping(!useGrouping);
+          }}
+        >
+          <input
+            type="checkbox"
+            name="groupView"
+            checked={useGrouping}
+            onChange={() => {}}
+          />
+          <label htmlFor="groupView"> Use grouped view</label>
+        </span>
       </div>
     </>
   );
@@ -378,18 +380,20 @@ function UnstableCheckBox({
 }) {
   return (
     <>
-      <div
-        onClick={() => {
-          setHideUnstable(!hideUnstable);
-        }}
-      >
-        <input
-          type="checkbox"
-          name="hideUnstable"
-          checked={hideUnstable}
-          onChange={() => {}}
-        />
-        <label htmlFor="hideUnstable"> Hide unstable jobs</label>
+      <div>
+        <span
+          onClick={() => {
+            setHideUnstable(!hideUnstable);
+          }}
+        >
+          <input
+            type="checkbox"
+            name="hideUnstable"
+            checked={hideUnstable}
+            onChange={() => {}}
+          />
+          <label htmlFor="hideUnstable"> Hide unstable jobs</label>
+        </span>
       </div>
     </>
   );
@@ -420,19 +424,20 @@ export function MonsterFailuresCheckbox() {
   );
   return (
     <>
-      <div
-        title="Replace `X` with a monster icon based on the error line."
-        onClick={() => {
-          setMonsterFailures && setMonsterFailures(!monsterFailures);
-        }}
-      >
-        <input
-          type="checkbox"
-          name="monsterFailures"
-          checked={monsterFailures}
-          onChange={() => {}}
-        />
-        <label htmlFor="monsterFailures"> Monsterize failures</label>
+      <div title="Replace `X` with a monster icon based on the error line.">
+        <span
+          onClick={() => {
+            setMonsterFailures && setMonsterFailures(!monsterFailures);
+          }}
+        >
+          <input
+            type="checkbox"
+            name="monsterFailures"
+            checked={monsterFailures}
+            onChange={() => {}}
+          />
+          <label htmlFor="monsterFailures"> Monsterize failures</label>
+        </span>
       </div>
     </>
   );


### PR DESCRIPTION
This is tiny but I don't like it when I click on the white space near the checkboxes to escape the job tooltip or something

<img width="741" alt="Screenshot 2024-05-22 at 2 34 25 PM" src="https://github.com/pytorch/test-infra/assets/44682903/7c31fe71-d638-4c41-afbd-1b92be0bfd89">

and it will select the checkbox.

So change the clickable area for the checkboxes to be just the checkbox and the text