### PR TITLE
Exclude build jobs from flakiness check

### DIFF
--- a/aws/lambda/log-classifier/fixtures/request.json
+++ b/aws/lambda/log-classifier/fixtures/request.json
@@ -2,7 +2,7 @@
   "version": "2.0",
   "routeKey": "$default",
   "rawPath": "/",
-  "rawQueryString": "job_id=17986337626&repo=pytorch%2Fpytorch",
+  "rawQueryString": "job_id=25360415440&repo=pytorch%2Fpytorch",
   "headers": {
     "accept": "*/*",
     "content-length": "0",

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -262,6 +262,10 @@ name = 'Docker error'
 pattern = '^docker: Error.*'
 
 [[rule]]
+name = 'Build error'
+pattern = 'ninja: build stopped: subcommand failed'
+
+[[rule]]
 name = 'sccache error'
 pattern = '^sccache: error: .*'
 

--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -37,6 +37,7 @@ export const EXCLUDED_FROM_FLAKINESS = [
   "linux-docs",
   "ghstack-mergeability-check",
   "backwards_compat",
+  // TODO (huydhn): Figure out a way to do flaky check accurately for build jobs
   "/ build",
 ];
 // If the base commit is too old, don't query for similar failures because

--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -37,6 +37,7 @@ export const EXCLUDED_FROM_FLAKINESS = [
   "linux-docs",
   "ghstack-mergeability-check",
   "backwards_compat",
+  "/ build",
 ];
 // If the base commit is too old, don't query for similar failures because
 // it increases the risk of getting misclassification. This guardrail can


### PR DESCRIPTION
From https://github.com/pytorch/pytorch/pull/125946, it looks like build job is stable enough to be excluded from flakiness check.  I also add a rule to capture ninja build failure, it doesn't say much, but it's still better than the misleading sccache error.

### Testing

On https://github.com/pytorch/pytorch/pull/125946 itself

## :x: 2 New Failures, 27 Pending
As of commit 490d2e80af89a6a5506d8908814bcaa4a31c996a with merge base 980f5ac0499447cd6d39b6241ae30ae30937a3e5 (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1716299107?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details open><summary><b>NEW FAILURES</b> - The following jobs have failed:</summary><p>

* [pull / linux-focal-py3.8-clang10 / test (dynamo, 2, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/125946#25360697493) ([gh](https://github.com/pytorch/pytorch/actions/runs/9217828094/job/25360697493))
    `##[error]The operation was canceled.`
* [trunk / win-vs2019-cuda11.8-py3 / build](https://hud.pytorch.org/pr/pytorch/pytorch/125946#25360415440) ([gh](https://github.com/pytorch/pytorch/actions/runs/9217828926/job/25360415440))
    `ninja: build stopped: subcommand failed`
</p></details>