### PR TITLE
[HUD] Change tooltip mouse hover area

### DIFF
--- a/torchci/components/TooltipTarget.tsx
+++ b/torchci/components/TooltipTarget.tsx
@@ -28,7 +28,7 @@ export default function TooltipTarget({
     clearTimeout(timeoutId.current!);
     timeoutId.current = setTimeout(() => {
       setVisible(true);
-    }, 10);
+    }, 5);
   }
   function handleMouseLeave() {
     setVisible(false);
@@ -60,14 +60,15 @@ export default function TooltipTarget({
     ) : null;
 
   return (
-    <div
-      onMouseOver={handleMouseOver}
-      onMouseLeave={handleMouseLeave}
-      onClick={handleClick}
-      className={styles.target}
-    >
+    <div className={styles.target}>
       {content}
-      {children}
+      <div
+        onMouseOver={handleMouseOver}
+        onMouseLeave={handleMouseLeave}
+        onClick={handleClick}
+      >
+        {children}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Very minor

Changes the tooltip hover area to be just the element that gets shown when not hovering (tooltip target)

Previously, if you were fast enough, you could get your mouse onto the tooltip content and the content would stay, this makes it so that it updates to the next tooltip content for the tooltip target that is currently under your mouse

I don't think anyone but me notices this lol

Also makes the updating for moving away/moving in slightly faster