### PR TITLE
Update arch64 worker to m7g.4xlarge

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -123,7 +123,7 @@ runner_types:
     is_ephemeral: false
     max_available: 200
     os: linux
-  linux.arm64.4xlarge:
+  linux.arm64.m7g.4xlarge:
     disk_size: 256
     instance_type: m7g.4xlarge
     is_ephemeral: false

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -123,9 +123,9 @@ runner_types:
     is_ephemeral: false
     max_available: 200
     os: linux
-  linux.arm64.m7g.2xlarge:
+  linux.arm64.4xlarge:
     disk_size: 256
-    instance_type: m7g.2xlarge
+    instance_type: m7g.4xlarge
     is_ephemeral: false
     max_available: 200
     os: linux


### PR DESCRIPTION
Increasing the worker size, trying to improve build time for arm64 GPU machines. Here is the issue: https://github.com/pytorch/pytorch/issues/126980

AWS Cost: 0.65c/hour
In comparison to our Linux c5.4xlarge worker, AWS Cost: 0.68c/hour
