### PR TITLE
Fix useEffect regression on benchmark pages

### DIFF
--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -252,7 +252,7 @@ export default function Page() {
         window.location.host
       }${router.asPath.replace(/\?.+/, "")}`
     );
-  }, [defaultStartTime, defaultStopTime, router.asPath, router.query]);
+  }, [router.query]);
 
   if (suite === undefined || compiler === undefined) {
     return <Skeleton variant={"rectangular"} height={"100%"} />;

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -241,7 +241,7 @@ export default function Page() {
         window.location.host
       }${router.asPath.replace(/\?.+/, "")}`
     );
-  }, [defaultStartTime, defaultStopTime, router.asPath, router.query]);
+  }, [router.query]);
 
   const queryParams: RocksetParam[] = [
     {


### PR DESCRIPTION
I added these changes as they are flagged as lint warning in https://github.com/pytorch/test-infra/pull/5256.  However, this is  false positives and causes a regression in the benchmark page where selecting different options doesn't reflect in the URL anymore.

For example, selecting different suites does nothing now on HUD https://hud.pytorch.org/benchmark/compilers?startTime=Fri%2C%2017%20May%202024%2022%3A17%3A06%20GMT&stopTime=Fri%2C%2024%20May%202024%2022%3A17%3A06%20GMT&granularity=hour&suite=torchbench&mode=training&dtype=amp&lBranch=main&lCommit=aa6de7618139644d440decd824b787add3dc59e5&rBranch=main&rCommit=15ca562f863ffe69d76c0ccaf448b27d18ceb2e8

### Testing

Working on https://torchci-git-fork-huydhn-fix-use-effect-regression-fbopensource.vercel.app/benchmark/compilers?startTime=Fri%2C%2017%20May%202024%2022%3A22%3A30%20GMT&stopTime=Fri%2C%2024%20May%202024%2022%3A22%3A30%20GMT&granularity=hour&suite=torchbench&mode=training&dtype=amp&lBranch=main&lCommit=aa6de7618139644d440decd824b787add3dc59e5&rBranch=main&rCommit=15ca562f863ffe69d76c0ccaf448b27d18ceb2e8 now