### PR TITLE
[HUD] Use prettier-plugin-organize-imports

### DIFF
--- a/torchci/.prettierrc.json
+++ b/torchci/.prettierrc.json
@@ -1,1 +1,3 @@
-{}
+{
+  "plugins": ["prettier-plugin-organize-imports"]
+}

--- a/torchci/components/CommitStatus.tsx
+++ b/torchci/components/CommitStatus.tsx
@@ -1,20 +1,20 @@
-import FilteredJobList from "./FilteredJobList";
-import VersionControlLinks from "./VersionControlLinks";
-import { CommitData, JobData, IssueData } from "lib/types";
-import WorkflowBox from "./WorkflowBox";
 import styles from "components/commit.module.css";
-import _ from "lodash";
 import {
   isFailedJob,
   isRerunDisabledTestsJob,
   isUnstableJob,
 } from "lib/jobUtils";
-import { linkIt, UrlComponent, urlRegex } from "react-linkify-it";
-import { getConclusionSeverityForSorting } from "../lib/JobClassifierUtil";
+import { CommitData, IssueData, JobData } from "lib/types";
 import useScrollTo from "lib/useScrollTo";
-import WorkflowDispatcher from "./WorkflowDispatcher";
+import _ from "lodash";
 import { useSession } from "next-auth/react";
 import { useState } from "react";
+import { linkIt, UrlComponent, urlRegex } from "react-linkify-it";
+import { getConclusionSeverityForSorting } from "../lib/JobClassifierUtil";
+import FilteredJobList from "./FilteredJobList";
+import VersionControlLinks from "./VersionControlLinks";
+import WorkflowBox from "./WorkflowBox";
+import WorkflowDispatcher from "./WorkflowDispatcher";
 
 function getBoxOrdering(jobs: JobData[], wideBoxes: Set<string>) {
   const byWorkflow = _(jobs)

--- a/torchci/components/DynamicTitle.tsx
+++ b/torchci/components/DynamicTitle.tsx
@@ -1,5 +1,5 @@
 // DynamicTitle.tsx
-import { createContext, useContext, useState, useEffect } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
 
 interface TitleContextProps {
   setTitle: (_title: string) => void;

--- a/torchci/components/FilteredJobList.tsx
+++ b/torchci/components/FilteredJobList.tsx
@@ -1,13 +1,12 @@
 import { fetcher } from "lib/GeneralUtils";
-import { JobData } from "lib/types";
+import { IssueData, JobAnnotation, JobData } from "lib/types";
+import useScrollTo from "lib/useScrollTo";
 import { useRouter } from "next/router";
 import useSWR from "swr";
 import JobAnnotationToggle from "./JobAnnotationToggle";
 import JobLinks from "./JobLinks";
 import JobSummary from "./JobSummary";
 import LogViewer from "./LogViewer";
-import { JobAnnotation, IssueData } from "lib/types";
-import useScrollTo from "lib/useScrollTo";
 
 function FailedJobInfo({
   job,

--- a/torchci/components/GroupJobConclusion.tsx
+++ b/torchci/components/GroupJobConclusion.tsx
@@ -1,15 +1,15 @@
-import { getGroupConclusionChar } from "lib/JobClassifierUtil";
-import { GroupData, JobData, IssueData } from "lib/types";
-import styles from "./JobConclusion.module.css";
-import hudStyles from "./hud.module.css";
 import TooltipTarget from "components/TooltipTarget";
-import { useContext } from "react";
-import { PinnedTooltipContext } from "pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]]";
+import { getGroupConclusionChar } from "lib/JobClassifierUtil";
 import {
   isFailedJob,
   isRerunDisabledTestsJob,
   isUnstableJob,
 } from "lib/jobUtils";
+import { GroupData, IssueData, JobData } from "lib/types";
+import { PinnedTooltipContext } from "pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]]";
+import { useContext } from "react";
+import hudStyles from "./hud.module.css";
+import styles from "./JobConclusion.module.css";
 import { SingleWorkflowDispatcher } from "./WorkflowDispatcher";
 
 export enum JobStatus {

--- a/torchci/components/JobAnnotationToggle.tsx
+++ b/torchci/components/JobAnnotationToggle.tsx
@@ -1,7 +1,7 @@
-import React from "react";
-import { JobData, JobAnnotation } from "../lib/types";
-import { ToggleButtonGroup, ToggleButton } from "@mui/material";
+import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { useSession } from "next-auth/react";
+import React from "react";
+import { JobAnnotation, JobData } from "../lib/types";
 
 export default function JobAnnotationToggle({
   job,

--- a/torchci/components/JobConclusion.tsx
+++ b/torchci/components/JobConclusion.tsx
@@ -1,9 +1,9 @@
 import { getConclusionChar } from "lib/JobClassifierUtil";
+import { useContext } from "react";
+import { JobData } from "../lib/types";
+import { MonsterFailuresContext } from "../pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]]";
 import { JobStatus } from "./GroupJobConclusion";
 import styles from "./JobConclusion.module.css";
-import { JobData } from "../lib/types";
-import { useContext } from "react";
-import { MonsterFailuresContext } from "../pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]]";
 
 /**
  * `getFailureEl` generates a div with a monster sprite element based on the first line of `failureLines` in `jobData`.

--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -1,14 +1,14 @@
-import { durationDisplay, LocalTimeHuman } from "./TimeUtils";
-import useSWR from "swr";
-import React from "react";
-import { IssueData, JobData } from "../lib/types";
-import styles from "./JobLinks.module.css";
-import TestInsightsLink from "./TestInsights";
-import ReproductionCommand from "./ReproductionCommand";
+import dayjs from "dayjs";
 import { useSession } from "next-auth/react";
+import React from "react";
+import useSWR from "swr";
 import { isFailure } from "../lib/JobClassifierUtil";
 import { transformJobName } from "../lib/jobUtils";
-import dayjs from "dayjs";
+import { IssueData, JobData } from "../lib/types";
+import styles from "./JobLinks.module.css";
+import ReproductionCommand from "./ReproductionCommand";
+import TestInsightsLink from "./TestInsights";
+import { durationDisplay, LocalTimeHuman } from "./TimeUtils";
 
 export default function JobLinks({
   job,

--- a/torchci/components/JobSummary.tsx
+++ b/torchci/components/JobSummary.tsx
@@ -1,10 +1,10 @@
-import { JobData, IssueData } from "lib/types";
-import JobConclusion from "./JobConclusion";
 import {
   isFailedJob,
   isRerunDisabledTestsJob,
   isUnstableJob,
 } from "lib/jobUtils";
+import { IssueData, JobData } from "lib/types";
+import JobConclusion from "./JobConclusion";
 
 function BranchName({
   name,

--- a/torchci/components/LogAnnotationToggle.tsx
+++ b/torchci/components/LogAnnotationToggle.tsx
@@ -1,7 +1,7 @@
+import { ToggleButton, ToggleButtonGroup } from "@mui/material";
+import { useSession } from "next-auth/react";
 import React from "react";
 import { JobData, LogAnnotation } from "../lib/types";
-import { ToggleButtonGroup, ToggleButton } from "@mui/material";
-import { useSession } from "next-auth/react";
 
 export default function LogAnnotationToggle({
   job,

--- a/torchci/components/LogViewer.tsx
+++ b/torchci/components/LogViewer.tsx
@@ -1,11 +1,13 @@
 import { basicSetup } from "@codemirror/basic-setup";
 import { codeFolding, foldAll, foldService } from "@codemirror/language";
+import { search } from "@codemirror/search";
 import {
   EditorSelection,
   EditorState,
   Range,
   RangeSet,
 } from "@codemirror/state";
+import { oneDark } from "@codemirror/theme-one-dark";
 import {
   Decoration,
   DecorationSet,
@@ -14,15 +16,12 @@ import {
   ViewUpdate,
 } from "@codemirror/view";
 import { parse } from "ansicolor";
-import { search } from "@codemirror/search";
-
-import { oneDark } from "@codemirror/theme-one-dark";
 import { isFailure } from "lib/JobClassifierUtil";
+import { LogSearchResult } from "lib/searchLogs";
 import { JobData, LogAnnotation } from "lib/types";
 import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
 import useSWRImmutable from "swr";
 import LogAnnotationToggle from "./LogAnnotationToggle";
-import { LogSearchResult } from "lib/searchLogs";
 
 const ESC_CHAR_REGEX = /\x1b\[[0-9;]*m/g;
 // Based on the current editor view, produce a series of decorations that

--- a/torchci/components/LoggedInMenu.tsx
+++ b/torchci/components/LoggedInMenu.tsx
@@ -1,6 +1,6 @@
+import { signOut, useSession } from "next-auth/react";
 import React from "react";
 import styles from "./LoginSection.module.css";
-import { signOut, useSession } from "next-auth/react";
 
 export default function LoggedInMenu() {
   const { data: session, status } = useSession();

--- a/torchci/components/LoginSection.tsx
+++ b/torchci/components/LoginSection.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from "react";
 import { signIn, useSession } from "next-auth/react";
-import styles from "./LoginSection.module.css";
+import React, { useState } from "react";
 import LoggedInMenu from "./LoggedInMenu";
+import styles from "./LoginSection.module.css";
 
 export default function LoginSection() {
   const { data: session, status } = useSession();

--- a/torchci/components/NavBar.tsx
+++ b/torchci/components/NavBar.tsx
@@ -1,8 +1,8 @@
 import styles from "components/NavBar.module.css";
 import Link from "next/link";
+import { useState } from "react";
 import { AiFillGithub } from "react-icons/ai";
 import LoginSection from "./LoginSection";
-import { useState } from "react";
 
 const NavBarDropdown = ({
   title,

--- a/torchci/components/ReproductionCommand.tsx
+++ b/torchci/components/ReproductionCommand.tsx
@@ -1,5 +1,5 @@
-import { JobData } from "../lib/types";
 import React from "react";
+import { JobData } from "../lib/types";
 import CopyLink from "./CopyLink";
 
 export default function ReproductionCommand({

--- a/torchci/components/SevReport.tsx
+++ b/torchci/components/SevReport.tsx
@@ -1,5 +1,5 @@
-import useSWR from "swr";
 import { IssueData } from "lib/types";
+import useSWR from "swr";
 import styles from "./SevReport.module.css";
 
 function SevBox({ issue }: { issue: IssueData }) {

--- a/torchci/components/TestInsights.tsx
+++ b/torchci/components/TestInsights.tsx
@@ -1,5 +1,5 @@
-import { JobData } from "../lib/types";
 import React from "react";
+import { JobData } from "../lib/types";
 
 // The following jobs are not supported at the moment because neither the monitoring
 // script is running there at the moment (libtorch, bazel, android)

--- a/torchci/components/WithCommitData.tsx
+++ b/torchci/components/WithCommitData.tsx
@@ -1,7 +1,7 @@
 /* Wrapper component for fetching commit data */
 
-import useSWR from "swr";
 import { CommitData, JobData } from "lib/types";
+import useSWR from "swr";
 import { fetcher } from "../lib/GeneralUtils";
 
 export function WithCommitData({

--- a/torchci/components/WorkflowBox.tsx
+++ b/torchci/components/WorkflowBox.tsx
@@ -1,17 +1,16 @@
 import styles from "components/commit.module.css";
 import { fetcher } from "lib/GeneralUtils";
 import { isFailedJob } from "lib/jobUtils";
-import { Artifact, JobData, IssueData } from "lib/types";
+import { getSearchRes, LogSearchResult } from "lib/searchLogs";
+import { Artifact, IssueData, JobData } from "lib/types";
+import React, { useEffect, useState } from "react";
 import useSWR from "swr";
+import { getConclusionSeverityForSorting } from "../lib/JobClassifierUtil";
+import { TestInfo } from "./additionalTestInfo/TestInfo";
 import JobArtifact from "./JobArtifact";
 import JobSummary from "./JobSummary";
 import LogViewer, { SearchLogViewer } from "./LogViewer";
-import { getConclusionSeverityForSorting } from "../lib/JobClassifierUtil";
 import TestInsightsLink from "./TestInsights";
-import { useState, useEffect } from "react";
-import { LogSearchResult, getSearchRes } from "lib/searchLogs";
-import React from "react";
-import { TestInfo } from "./additionalTestInfo/TestInfo";
 import { durationDisplay } from "./TimeUtils";
 
 function sortJobsByConclusion(jobA: JobData, jobB: JobData): number {

--- a/torchci/components/WorkflowDispatcher.tsx
+++ b/torchci/components/WorkflowDispatcher.tsx
@@ -1,10 +1,10 @@
+import { fetcherWithToken } from "lib/GeneralUtils";
 import { CommitData, JobData } from "lib/types";
 import _ from "lodash";
-import { useState } from "react";
-import useSWR from "swr";
-import { fetcherWithToken } from "lib/GeneralUtils";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
+import { useState } from "react";
+import useSWR from "swr";
 import { WithCommitData } from "./WithCommitData";
 
 const SUPPORTED_WORKFLOWS: { [k: string]: any } = {

--- a/torchci/components/additionalTestInfo/RerunInfo.tsx
+++ b/torchci/components/additionalTestInfo/RerunInfo.tsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
-import { RecursiveDetailsSummary } from "./TestInfo";
-import useSWR from "swr";
 import { fetcher } from "lib/GeneralUtils";
 import { JobData } from "lib/types";
 import _ from "lodash";
+import { useState } from "react";
+import useSWR from "swr";
+import { RecursiveDetailsSummary } from "./TestInfo";
 
 function groupByStatus(info: any) {
   const flaky = {};

--- a/torchci/components/additionalTestInfo/TestCounts.tsx
+++ b/torchci/components/additionalTestInfo/TestCounts.tsx
@@ -1,10 +1,10 @@
-import { JobData } from "lib/types";
-import { CSSProperties, useState } from "react";
-import _ from "lodash";
-import useSWR from "swr";
-import { fetcher } from "lib/GeneralUtils";
-import { durationDisplay } from "components/TimeUtils";
 import { DataGrid, GridRenderCellParams } from "@mui/x-data-grid";
+import { durationDisplay } from "components/TimeUtils";
+import { fetcher } from "lib/GeneralUtils";
+import { JobData } from "lib/types";
+import _ from "lodash";
+import { CSSProperties, useState } from "react";
+import useSWR from "swr";
 import { RecursiveDetailsSummary } from "./TestInfo";
 
 function TestCountsDataGrid({

--- a/torchci/components/additionalTestInfo/TestInfo.tsx
+++ b/torchci/components/additionalTestInfo/TestInfo.tsx
@@ -1,10 +1,10 @@
+import { fetcher } from "lib/GeneralUtils";
 import { JobData } from "lib/types";
 import { useState } from "react";
-import styles from "./TestInfo.module.css";
 import useSWR from "swr";
-import { fetcher } from "lib/GeneralUtils";
-import { TestCountsInfo } from "./TestCounts";
 import { TestRerunsInfo } from "./RerunInfo";
+import { TestCountsInfo } from "./TestCounts";
+import styles from "./TestInfo.module.css";
 
 export function RecursiveDetailsSummary({
   info,

--- a/torchci/components/benchmark/BranchAndCommitPicker.tsx
+++ b/torchci/components/benchmark/BranchAndCommitPicker.tsx
@@ -1,17 +1,17 @@
-import useSWR from "swr";
-import dayjs from "dayjs";
-import { fetcher } from "lib/GeneralUtils";
-import { useEffect } from "react";
 import {
-  Select,
-  MenuItem,
   FormControl,
   InputLabel,
-  Skeleton,
+  MenuItem,
+  Select,
   SelectChangeEvent,
+  Skeleton,
 } from "@mui/material";
+import { MAIN_BRANCH, SHA_DISPLAY_LENGTH } from "components/benchmark/common";
+import dayjs from "dayjs";
+import { fetcher } from "lib/GeneralUtils";
 import { RocksetParam } from "lib/rockset";
-import { SHA_DISPLAY_LENGTH, MAIN_BRANCH } from "components/benchmark/common";
+import { useEffect } from "react";
+import useSWR from "swr";
 
 // Keep the mapping from workflow ID to commit, so that we can use it to
 // zoom in and out of the graph. NB: this is to avoid sending commit sha

--- a/torchci/components/benchmark/CommitPanel.tsx
+++ b/torchci/components/benchmark/CommitPanel.tsx
@@ -1,8 +1,7 @@
-import dayjs from "dayjs";
 import { Stack, Typography } from "@mui/material";
-import { SHA_DISPLAY_LENGTH } from "components/benchmark/common";
+import { HUD_PREFIX, SHA_DISPLAY_LENGTH } from "components/benchmark/common";
+import dayjs from "dayjs";
 import { BranchAndCommit } from "lib/types";
-import { HUD_PREFIX } from "components/benchmark/common";
 import { ReactNode } from "react";
 
 export function CommitPanel({

--- a/torchci/components/benchmark/ModeAndDTypePicker.tsx
+++ b/torchci/components/benchmark/ModeAndDTypePicker.tsx
@@ -1,8 +1,8 @@
 import {
-  Select,
-  MenuItem,
   FormControl,
   InputLabel,
+  MenuItem,
+  Select,
   SelectChangeEvent,
 } from "@mui/material";
 

--- a/torchci/components/benchmark/compilers/BenchmarkLogs.tsx
+++ b/torchci/components/benchmark/compilers/BenchmarkLogs.tsx
@@ -1,9 +1,9 @@
-import { RocksetParam } from "lib/rockset";
-import { SUITES } from "components/benchmark/compilers/SuitePicker";
-import { LogLinks } from "components/benchmark/compilers/LogLinks";
-import useSWR from "swr";
-import { fetcher } from "lib/GeneralUtils";
 import { LOG_PREFIX } from "components/benchmark/common";
+import { LogLinks } from "components/benchmark/compilers/LogLinks";
+import { SUITES } from "components/benchmark/compilers/SuitePicker";
+import { fetcher } from "lib/GeneralUtils";
+import { RocksetParam } from "lib/rockset";
+import useSWR from "swr";
 
 export const INDUCTOR_JOB_NAME_REGEX = new RegExp(
   ".+\\s/\\stest\\s\\(inductor_(.+)_perf_?(.*), ([0-9]+), ([0-9]+), (.+)\\)"

--- a/torchci/components/benchmark/compilers/ModelGraphPanel.tsx
+++ b/torchci/components/benchmark/compilers/ModelGraphPanel.tsx
@@ -1,20 +1,20 @@
-import { RocksetParam } from "lib/rockset";
-import useSWR from "swr";
-import { fetcher } from "lib/GeneralUtils";
-import {
-  Granularity,
-  TimeSeriesPanelWithData,
-  seriesWithInterpolatedTimes,
-} from "components/metrics/panels/TimeSeriesPanel";
-import { augmentData } from "lib/benchmark/compilerUtils";
 import { Grid, Skeleton } from "@mui/material";
-import dayjs from "dayjs";
 import {
   COMMIT_TO_WORKFLOW_ID,
   WORKFLOW_ID_TO_COMMIT,
 } from "components/benchmark/BranchAndCommitPicker";
 import { TIME_FIELD_NAME } from "components/benchmark/common";
+import {
+  Granularity,
+  seriesWithInterpolatedTimes,
+  TimeSeriesPanelWithData,
+} from "components/metrics/panels/TimeSeriesPanel";
+import dayjs from "dayjs";
+import { augmentData } from "lib/benchmark/compilerUtils";
+import { fetcher } from "lib/GeneralUtils";
+import { RocksetParam } from "lib/rockset";
 import { CompilerPerformanceData } from "lib/types";
+import useSWR from "swr";
 
 const GRAPH_ROW_HEIGHT = 245;
 // The number of digit after decimal to display on the detail page

--- a/torchci/components/benchmark/compilers/ModelPanel.tsx
+++ b/torchci/components/benchmark/compilers/ModelPanel.tsx
@@ -1,20 +1,20 @@
-import dayjs from "dayjs";
+import { Grid } from "@mui/material";
+import { GridCellParams, GridRenderCellParams } from "@mui/x-data-grid";
+import { LOG_PREFIX, SHA_DISPLAY_LENGTH } from "components/benchmark/common";
 import {
+  BranchAndCommitPerfData,
+  COMPRESSION_RATIO_THRESHOLD,
+  DIFF_HEADER,
+  PASSING_ACCURACY,
+  PEAK_MEMORY_USAGE_RELATIVE_THRESHOLD,
   RELATIVE_THRESHOLD,
   SPEEDUP_THRESHOLD,
-  COMPRESSION_RATIO_THRESHOLD,
-  PEAK_MEMORY_USAGE_RELATIVE_THRESHOLD,
-  PASSING_ACCURACY,
-  DIFF_HEADER,
 } from "components/benchmark/compilers/common";
-import { BranchAndCommitPerfData } from "components/benchmark/compilers/common";
 import styles from "components/metrics.module.css";
-import { Grid } from "@mui/material";
-import { GridRenderCellParams, GridCellParams } from "@mui/x-data-grid";
-import { CompilerPerformanceData } from "lib/types";
-import { Granularity } from "components/metrics/panels/TimeSeriesPanel";
 import { TablePanelWithData } from "components/metrics/panels/TablePanel";
-import { SHA_DISPLAY_LENGTH, LOG_PREFIX } from "components/benchmark/common";
+import { Granularity } from "components/metrics/panels/TimeSeriesPanel";
+import dayjs from "dayjs";
+import { CompilerPerformanceData } from "lib/types";
 
 const ROW_GAP = 30;
 const ROW_HEIGHT = 48;

--- a/torchci/components/benchmark/compilers/SuitePicker.tsx
+++ b/torchci/components/benchmark/compilers/SuitePicker.tsx
@@ -1,8 +1,8 @@
 import {
-  Select,
-  MenuItem,
   FormControl,
   InputLabel,
+  MenuItem,
+  Select,
   SelectChangeEvent,
 } from "@mui/material";
 

--- a/torchci/components/benchmark/compilers/SummaryGraphPanel.tsx
+++ b/torchci/components/benchmark/compilers/SummaryGraphPanel.tsx
@@ -1,24 +1,24 @@
-import { RocksetParam } from "lib/rockset";
-import dayjs from "dayjs";
-import useSWR from "swr";
-import { fetcher } from "lib/GeneralUtils";
-import {
-  Granularity,
-  TimeSeriesPanelWithData,
-  seriesWithInterpolatedTimes,
-} from "components/metrics/panels/TimeSeriesPanel";
 import { Grid, Skeleton } from "@mui/material";
-import {
-  getPassingModels,
-  computePassrate,
-  computeGeomean,
-  computeCompilationTime,
-  computePeakMemoryUsage,
-  computeMemoryCompressionRatio,
-} from "lib/benchmark/compilerUtils";
 import { COMMIT_TO_WORKFLOW_ID } from "components/benchmark/BranchAndCommitPicker";
 import { TIME_FIELD_NAME } from "components/benchmark/common";
 import { SUITES } from "components/benchmark/compilers/SuitePicker";
+import {
+  Granularity,
+  seriesWithInterpolatedTimes,
+  TimeSeriesPanelWithData,
+} from "components/metrics/panels/TimeSeriesPanel";
+import dayjs from "dayjs";
+import {
+  computeCompilationTime,
+  computeGeomean,
+  computeMemoryCompressionRatio,
+  computePassrate,
+  computePeakMemoryUsage,
+  getPassingModels,
+} from "lib/benchmark/compilerUtils";
+import { fetcher } from "lib/GeneralUtils";
+import { RocksetParam } from "lib/rockset";
+import useSWR from "swr";
 
 const GRAPH_ROW_HEIGHT = 245;
 

--- a/torchci/components/benchmark/compilers/SummaryPanel.tsx
+++ b/torchci/components/benchmark/compilers/SummaryPanel.tsx
@@ -1,30 +1,30 @@
-import dayjs from "dayjs";
 import { Grid } from "@mui/material";
-import { Granularity } from "components/metrics/panels/TimeSeriesPanel";
-import { CompilerPerformanceData } from "lib/types";
+import { GridCellParams, GridRenderCellParams } from "@mui/x-data-grid";
 import {
-  getPassingModels,
-  computePassrate,
-  computeGeomean,
-  computeCompilationTime,
-  computePeakMemoryUsage,
-  computeMemoryCompressionRatio,
-} from "lib/benchmark/compilerUtils";
-import { SUITES } from "components/benchmark/compilers/SuitePicker";
-import { TablePanelWithData } from "components/metrics/panels/TablePanel";
-import {
-  RELATIVE_THRESHOLD,
   ACCURACY_THRESHOLD,
-  SPEEDUP_THRESHOLD,
+  BranchAndCommitPerfData,
   COMPRESSION_RATIO_THRESHOLD,
   DIFF_HEADER,
   DISPLAY_NAMES_TO_COMPILER_NAMES,
-  SCALE,
   HELP_LINK,
-  BranchAndCommitPerfData,
+  RELATIVE_THRESHOLD,
+  SCALE,
+  SPEEDUP_THRESHOLD,
 } from "components/benchmark/compilers/common";
-import { GridCellParams, GridRenderCellParams } from "@mui/x-data-grid";
+import { SUITES } from "components/benchmark/compilers/SuitePicker";
 import styles from "components/metrics.module.css";
+import { TablePanelWithData } from "components/metrics/panels/TablePanel";
+import { Granularity } from "components/metrics/panels/TimeSeriesPanel";
+import dayjs from "dayjs";
+import {
+  computeCompilationTime,
+  computeGeomean,
+  computeMemoryCompressionRatio,
+  computePassrate,
+  computePeakMemoryUsage,
+  getPassingModels,
+} from "lib/benchmark/compilerUtils";
+import { CompilerPerformanceData } from "lib/types";
 
 const ROW_GAP = 100;
 const ROW_HEIGHT = 38;

--- a/torchci/components/benchmark/compilers/common.tsx
+++ b/torchci/components/benchmark/compilers/common.tsx
@@ -1,4 +1,4 @@
-import { CompilerPerformanceData, BranchAndCommit } from "lib/types";
+import { BranchAndCommit, CompilerPerformanceData } from "lib/types";
 
 // Relative thresholds
 export const RELATIVE_THRESHOLD = 0.05;

--- a/torchci/components/metrics/panels/GenerateIndividualTestsLeaderboard.tsx
+++ b/torchci/components/metrics/panels/GenerateIndividualTestsLeaderboard.tsx
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import { Grid } from "@mui/material";
 import {
   GridRenderCellParams,
@@ -6,6 +5,7 @@ import {
 } from "@mui/x-data-grid";
 import TablePanel from "components/metrics/panels/TablePanel";
 import { durationDisplay } from "components/TimeUtils";
+import dayjs from "dayjs";
 import { RocksetParam } from "lib/rockset";
 import { useState } from "react";
 

--- a/torchci/components/metrics/panels/GenerateTestInsightsOverviewTable.tsx
+++ b/torchci/components/metrics/panels/GenerateTestInsightsOverviewTable.tsx
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import { Grid } from "@mui/material";
 import {
   GridRenderCellParams,
@@ -6,6 +5,7 @@ import {
 } from "@mui/x-data-grid";
 import TablePanel from "components/metrics/panels/TablePanel";
 import { durationDisplay } from "components/TimeUtils";
+import dayjs from "dayjs";
 import { RocksetParam } from "lib/rockset";
 
 const ROW_HEIGHT = 500;

--- a/torchci/components/metrics/panels/ScalarPanel.tsx
+++ b/torchci/components/metrics/panels/ScalarPanel.tsx
@@ -2,9 +2,9 @@
  * A metrics panel that shows a single scalar value.
  */
 
-import { RocksetParam } from "lib/rockset";
-import { Box, Paper, Typography, Skeleton } from "@mui/material";
+import { Box, Paper, Skeleton, Typography } from "@mui/material";
 import { fetcher } from "lib/GeneralUtils";
+import { RocksetParam } from "lib/rockset";
 import useSWR from "swr";
 
 export function ScalarPanelWithValue({

--- a/torchci/components/metrics/panels/TablePanel.tsx
+++ b/torchci/components/metrics/panels/TablePanel.tsx
@@ -1,9 +1,9 @@
-import useSWR from "swr";
-import { DataGrid, GridColDef } from "@mui/x-data-grid";
-import { Typography, Skeleton } from "@mui/material";
-import { RocksetParam } from "lib/rockset";
 import HelpIcon from "@mui/icons-material/Help";
+import { Skeleton, Typography } from "@mui/material";
 import IconButton from "@mui/material/IconButton";
+import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import { RocksetParam } from "lib/rockset";
+import useSWR from "swr";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 

--- a/torchci/components/metrics/panels/TimeSeriesPanel.tsx
+++ b/torchci/components/metrics/panels/TimeSeriesPanel.tsx
@@ -2,15 +2,15 @@
  * A metrics panel that shows a time series line chart.
  */
 
-import { RocksetParam } from "lib/rockset";
-import ReactECharts from "echarts-for-react";
 import { Paper, Skeleton } from "@mui/material";
-import { fetcher } from "lib/GeneralUtils";
-import useSWR from "swr";
-import { EChartsOption } from "echarts";
-import _ from "lodash";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import { EChartsOption } from "echarts";
+import ReactECharts from "echarts-for-react";
+import { fetcher } from "lib/GeneralUtils";
+import { RocksetParam } from "lib/rockset";
+import _ from "lodash";
+import useSWR from "swr";
 dayjs.extend(utc);
 
 export type Granularity = "minute" | "hour" | "day" | "week" | "month" | "year";

--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -1,6 +1,6 @@
 import { GroupedJobStatus, JobStatus } from "components/GroupJobConclusion";
-import { GroupData, RowData, IssueData } from "./types";
 import { getOpenUnstableIssues } from "lib/jobUtils";
+import { GroupData, IssueData, RowData } from "./types";
 
 const GROUP_MEMORY_LEAK_CHECK = "Memory Leak Check";
 const GROUP_RERUN_DISABLED_TESTS = "Rerun Disabled Tests";

--- a/torchci/lib/ParamSelector.tsx
+++ b/torchci/lib/ParamSelector.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
 import styles from "components/hud.module.css";
+import { useEffect, useState } from "react";
 
 export function ParamSelector({
   value,

--- a/torchci/lib/benchmark/compilerUtils.ts
+++ b/torchci/lib/benchmark/compilerUtils.ts
@@ -1,8 +1,8 @@
 import {
-  SCALE,
-  COMPILER_NAMES_TO_DISPLAY_NAMES,
   BLOCKLIST_COMPILERS,
+  COMPILER_NAMES_TO_DISPLAY_NAMES,
   PASSING_ACCURACY,
+  SCALE,
 } from "components/benchmark/compilers/common";
 import { CompilerPerformanceData } from "lib/types";
 

--- a/torchci/lib/bot/autoCcBot.ts
+++ b/torchci/lib/bot/autoCcBot.ts
@@ -1,10 +1,10 @@
+import {
+  IssuesLabeledEvent,
+  PullRequestLabeledEvent,
+} from "@octokit/webhooks-types";
+import { Context, Probot } from "probot";
 import { parseSubscriptions } from "./subscriptions";
 import { CachedIssueTracker } from "./utils";
-import { Probot, Context } from "probot";
-import {
-  PullRequestLabeledEvent,
-  IssuesLabeledEvent,
-} from "@octokit/webhooks-types";
 
 function myBot(app: Probot): void {
   const tracker = new CachedIssueTracker(

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -1,20 +1,20 @@
-import { Context, Probot } from "probot";
-import {
-  CachedIssueTracker,
-  CachedLabelerConfigTracker,
-  addLabels,
-  hasApprovedPullRuns,
-  hasWritePermissions,
-  isPyTorchPyTorch,
-  getFilesChangedByPr,
-  LabelToLabelConfigTracker,
-} from "./utils";
+import assert from "assert";
 import { minimatch } from "minimatch";
+import { Context, Probot } from "probot";
 import {
   CODEV_INDICATOR,
   genCodevNoWritePermComment,
 } from "./codevNoWritePermBot";
-import assert from "assert";
+import {
+  addLabels,
+  CachedIssueTracker,
+  CachedLabelerConfigTracker,
+  getFilesChangedByPr,
+  hasApprovedPullRuns,
+  hasWritePermissions,
+  isPyTorchPyTorch,
+  LabelToLabelConfigTracker,
+} from "./utils";
 
 const titleRegexToLabel: [RegExp, string][] = [
   [/rocm/gi, "module: rocm"],

--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -1,8 +1,8 @@
 import { Context, Probot } from "probot";
 import {
   CachedConfigTracker,
-  hasWritePermissions,
   hasApprovedPullRuns,
+  hasWritePermissions,
   isPyTorchPyTorch,
 } from "./utils";
 

--- a/torchci/lib/bot/cliParser.ts
+++ b/torchci/lib/bot/cliParser.ts
@@ -1,5 +1,5 @@
 import { ArgumentParser, RawTextHelpFormatter, SUPPRESS } from "argparse";
-import { revertClassifications, cherryPickClassifications } from "./Constants";
+import { cherryPickClassifications, revertClassifications } from "./Constants";
 
 // The default ArgumentParser is designed to be used from the command line, so
 // when it encounters an error it calls process.exit. We want to throw an

--- a/torchci/lib/bot/codevNoWritePermBot.ts
+++ b/torchci/lib/bot/codevNoWritePermBot.ts
@@ -1,5 +1,5 @@
-import { hasWritePermissions, isPyTorchPyTorch } from "./utils";
 import { Probot } from "probot";
+import { hasWritePermissions, isPyTorchPyTorch } from "./utils";
 
 export const CODEV_INDICATOR = /Differential Revision: \[?D/;
 const CODEV_WIKI_LINK =

--- a/torchci/lib/bot/drciBot.ts
+++ b/torchci/lib/bot/drciBot.ts
@@ -1,5 +1,5 @@
-import { Probot } from "probot";
 import { upsertDrCiComment } from "lib/drciUtils";
+import { Probot } from "probot";
 
 export default function drciBot(app: Probot): void {
   app.on(

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -6,13 +6,13 @@ import { getHelp, getParser } from "./cliParser";
 import { cherryPickClassifications } from "./Constants";
 import PytorchBotLogger from "./pytorchbotLogger";
 import {
+  addLabels,
+  hasApprovedPullRuns,
+  hasWritePermissions as _hasWP,
+  isFirstTimeContributor,
   isPyTorchOrg,
   isPyTorchPyTorch,
-  addLabels,
-  hasWritePermissions as _hasWP,
   reactOnComment,
-  hasApprovedPullRuns,
-  isFirstTimeContributor,
 } from "./utils";
 
 export const CIFLOW_TRUNK_LABEL = "ciflow/trunk";

--- a/torchci/lib/bot/utils.ts
+++ b/torchci/lib/bot/utils.ts
@@ -1,6 +1,6 @@
+import { Octokit } from "octokit";
 import { Context, Probot } from "probot";
 import urllib from "urllib";
-import { Octokit } from "octokit";
 
 export function repoKey(
   context: Context | Context<"pull_request.labeled">

--- a/torchci/lib/bot/verifyDisableTestIssueBot.ts
+++ b/torchci/lib/bot/verifyDisableTestIssueBot.ts
@@ -1,7 +1,7 @@
+import _ from "lodash";
+import { getPlatformLabels } from "pages/api/flaky-tests/disable";
 import { Context, Probot } from "probot";
 import { hasWritePermissions } from "./utils";
-import { getPlatformLabels } from "pages/api/flaky-tests/disable";
-import _ from "lodash";
 
 const validationCommentStart = "<!-- validation-comment-start -->";
 const validationCommentEnd = "<!-- validation-comment-end -->";

--- a/torchci/lib/bot/webhookToDynamo.ts
+++ b/torchci/lib/bot/webhookToDynamo.ts
@@ -1,10 +1,10 @@
-import { v4 as uuidv4 } from "uuid";
-import { Probot } from "probot";
 import {
   EmitterWebhookEvent as WebhookEvent,
   EmitterWebhookEventName as WebhookEvents,
 } from "@octokit/webhooks";
 import { getDynamoClient } from "lib/dynamo";
+import { Probot } from "probot";
+import { v4 as uuidv4 } from "uuid";
 
 function narrowType<E extends WebhookEvents>(
   event: E,

--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -1,19 +1,19 @@
-import dayjs from "dayjs";
-import _ from "lodash";
-import { Octokit } from "octokit";
-import { IssueData } from "./types";
-import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
-import { isDrCIEnabled, isPyTorchPyTorch } from "./bot/utils";
 import { Client } from "@opensearch-project/opensearch";
-import { MAX_SIZE, OLDEST_FIRST, querySimilarFailures } from "lib/searchUtils";
-import { RecentWorkflowsData } from "lib/types";
+import dayjs from "dayjs";
+import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
 import {
-  isSameAuthor,
-  isSameFailure,
+  getPRMergeCommits,
   hasS3Log,
   isFailureFromPrevMergeCommit,
-  getPRMergeCommits,
+  isSameAuthor,
+  isSameFailure,
 } from "lib/jobUtils";
+import { MAX_SIZE, OLDEST_FIRST, querySimilarFailures } from "lib/searchUtils";
+import { RecentWorkflowsData } from "lib/types";
+import _ from "lodash";
+import { Octokit } from "octokit";
+import { isDrCIEnabled, isPyTorchPyTorch } from "./bot/utils";
+import { IssueData } from "./types";
 
 export const NUM_MINUTES = 30;
 export const REPO: string = "pytorch";

--- a/torchci/lib/fetchCommit.ts
+++ b/torchci/lib/fetchCommit.ts
@@ -1,11 +1,10 @@
 import _ from "lodash";
-import { getOctokit, commitDataFromResponse } from "./github";
-import getRocksetClient from "./rockset";
-import rocksetVersions from "rockset/prodVersions.json";
-
-import { CommitData, JobData } from "./types";
-import { removeCancelledJobAfterRetry } from "./jobUtils";
 import { Octokit } from "octokit";
+import rocksetVersions from "rockset/prodVersions.json";
+import { commitDataFromResponse, getOctokit } from "./github";
+import { removeCancelledJobAfterRetry } from "./jobUtils";
+import getRocksetClient from "./rockset";
+import { CommitData, JobData } from "./types";
 
 export default async function fetchCommit(
   owner: string,

--- a/torchci/lib/fetchDisabledNonFlakyTests.ts
+++ b/torchci/lib/fetchDisabledNonFlakyTests.ts
@@ -1,6 +1,5 @@
-import getRocksetClient from "./rockset";
 import rocksetVersions from "rockset/prodVersions.json";
-
+import getRocksetClient from "./rockset";
 import { DisabledNonFlakyTestData } from "./types";
 
 export default async function fetchDisabledNonFlakyTests(): Promise<

--- a/torchci/lib/fetchFailureSamples.ts
+++ b/torchci/lib/fetchFailureSamples.ts
@@ -1,6 +1,5 @@
 import getRocksetClient from "lib/rockset";
 import rocksetVersions from "rockset/prodVersions.json";
-
 import { JobData } from "./types";
 
 export default async function fetchFailureSamples(

--- a/torchci/lib/fetchFlakyTests.ts
+++ b/torchci/lib/fetchFlakyTests.ts
@@ -1,6 +1,5 @@
-import getRocksetClient from "./rockset";
 import rocksetVersions from "rockset/prodVersions.json";
-
+import getRocksetClient from "./rockset";
 import { FlakyTestData } from "./types";
 
 export default async function fetchFlakyTests(

--- a/torchci/lib/fetchHud.ts
+++ b/torchci/lib/fetchHud.ts
@@ -1,11 +1,11 @@
+import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
 import _ from "lodash";
-import { commitDataFromResponse, getOctokit } from "./github";
-import getRocksetClient from "./rockset";
-import { HudParams, JobData, RowData } from "./types";
 import rocksetVersions from "rockset/prodVersions.json";
+import { commitDataFromResponse, getOctokit } from "./github";
 import { isFailure } from "./JobClassifierUtil";
 import { isRerunDisabledTestsJob, isUnstableJob } from "./jobUtils";
-import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
+import getRocksetClient from "./rockset";
+import { HudParams, JobData, RowData } from "./types";
 
 export default async function fetchHud(params: HudParams): Promise<{
   shaGrid: RowData[];

--- a/torchci/lib/fetchIssuesByLabel.ts
+++ b/torchci/lib/fetchIssuesByLabel.ts
@@ -1,6 +1,5 @@
-import getRocksetClient from "./rockset";
 import rocksetVersions from "rockset/prodVersions.json";
-
+import getRocksetClient from "./rockset";
 import { IssueData } from "./types";
 
 export default async function fetchIssuesByLabel(

--- a/torchci/lib/fetchPR.ts
+++ b/torchci/lib/fetchPR.ts
@@ -1,6 +1,6 @@
 import { Octokit } from "octokit";
-import getRocksetClient from "./rockset";
 import rocksetVersions from "rockset/prodVersions.json";
+import getRocksetClient from "./rockset";
 import { PRData } from "./types";
 
 export default async function fetchPR(

--- a/torchci/lib/fetchRecentWorkflows.ts
+++ b/torchci/lib/fetchRecentWorkflows.ts
@@ -1,6 +1,5 @@
-import getRocksetClient from "./rockset";
 import rocksetVersions from "rockset/prodVersions.json";
-
+import getRocksetClient from "./rockset";
 import { RecentWorkflowsData } from "./types";
 
 export async function fetchRecentWorkflows(

--- a/torchci/lib/fetchS3Links.ts
+++ b/torchci/lib/fetchS3Links.ts
@@ -1,5 +1,5 @@
-import { Artifact } from "./types";
 import _ from "lodash";
+import { Artifact } from "./types";
 
 const GHA_ARTIFACTS_LAMBDA =
   "https://np6xty2nm6jifkuuyb6wllx6ha0qtthb.lambda-url.us-east-1.on.aws";

--- a/torchci/lib/getAuthors.ts
+++ b/torchci/lib/getAuthors.ts
@@ -1,5 +1,5 @@
-import _ from "lodash";
 import { RecentWorkflowsData } from "lib/types";
+import _ from "lodash";
 import getRocksetClient from "./rockset";
 
 // NB: Surprisingly, jest cannot mock function in the same module so we need to

--- a/torchci/lib/github.ts
+++ b/torchci/lib/github.ts
@@ -1,5 +1,5 @@
-import { Octokit, App } from "octokit";
 import { createAppAuth } from "@octokit/auth-app";
+import { App, Octokit } from "octokit";
 import { CommitData } from "./types";
 
 // Retrieve an Octokit instance authenticated as PyTorchBot's installation on

--- a/torchci/lib/jobUtils.ts
+++ b/torchci/lib/jobUtils.ts
@@ -1,18 +1,17 @@
-import _ from "lodash";
 import dayjs from "dayjs";
-import TrieSearch from "trie-search";
-import getRocksetClient from "./rockset";
-import rocksetVersions from "rockset/prodVersions.json";
-import { isEqual } from "lodash";
+import { jaroWinkler } from "jaro-winkler-typescript";
+import { getAuthors } from "lib/getAuthors";
 import {
-  RecentWorkflowsData,
-  JobData,
   BasicJobData,
   IssueData,
+  JobData,
   PRandJobs,
+  RecentWorkflowsData,
 } from "lib/types";
-import { getAuthors } from "lib/getAuthors";
-import { jaroWinkler } from "jaro-winkler-typescript";
+import _, { isEqual } from "lodash";
+import rocksetVersions from "rockset/prodVersions.json";
+import TrieSearch from "trie-search";
+import getRocksetClient from "./rockset";
 
 export const REMOVE_JOB_NAME_SUFFIX_REGEX = new RegExp(
   ", [0-9]+, [0-9]+, .+\\)"

--- a/torchci/lib/metricUtils.ts
+++ b/torchci/lib/metricUtils.ts
@@ -1,4 +1,4 @@
-import { JobsPerCommitData, JobAnnotation } from "lib/types";
+import { JobAnnotation, JobsPerCommitData } from "lib/types";
 
 // When N consecutive failures of the same type happen, the failures are counted as
 // broken trunk failures (approximately)

--- a/torchci/lib/searchUtils.ts
+++ b/torchci/lib/searchUtils.ts
@@ -1,7 +1,7 @@
 import { Client } from "@opensearch-project/opensearch";
+import dayjs from "dayjs";
 import { JobData } from "lib/types";
 import { getOpenSearchClient } from "./opensearch";
-import dayjs from "dayjs";
 // Import itself to ensure that mocks can be applied, see
 // https://stackoverflow.com/questions/51900413/jest-mock-function-doesnt-work-while-it-was-called-in-the-other-function
 // https://stackoverflow.com/questions/45111198/how-to-mock-functions-in-the-same-module-using-jest

--- a/torchci/lib/useTableFilter.ts
+++ b/torchci/lib/useTableFilter.ts
@@ -1,7 +1,7 @@
 import { useRouter } from "next/router";
 import { useCallback, useContext, useEffect, useState } from "react";
-import { formatHudUrlForRoute, HudParams } from "./types";
 import { PinnedTooltipContext } from "../pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]]";
+import { formatHudUrlForRoute, HudParams } from "./types";
 
 export default function useTableFilter(params: HudParams) {
   const router = useRouter();

--- a/torchci/package.json
+++ b/torchci/package.json
@@ -80,6 +80,7 @@
     "monaco-editor": "^0.33.0",
     "nock": "^13.2.6",
     "prettier": "2.6.2",
+    "prettier-plugin-organize-imports": "^3.2.4",
     "typescript": "4.6.3"
   }
 }

--- a/torchci/pages/[repoOwner]/[repoName]/pull/[prNumber].tsx
+++ b/torchci/pages/[repoOwner]/[repoName]/pull/[prNumber].tsx
@@ -1,9 +1,9 @@
 import CommitStatus from "components/CommitStatus";
-import ErrorBoundary from "components/ErrorBoundary";
 import { useSetTitle } from "components/DynamicTitle";
+import ErrorBoundary from "components/ErrorBoundary";
 import { PRData } from "lib/types";
 import { useRouter } from "next/router";
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import useSWR from "swr";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());

--- a/torchci/pages/_app.tsx
+++ b/torchci/pages/_app.tsx
@@ -1,14 +1,14 @@
 import AnnouncementBanner from "components/AnnouncementBanner";
+import TitleProvider from "components/DynamicTitle";
 import NavBar from "components/NavBar";
 import SevReport from "components/SevReport";
-import TitleProvider from "components/DynamicTitle";
 import { track } from "lib/track";
 import { SessionProvider } from "next-auth/react";
 import type { AppProps } from "next/app";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
-import "styles/globals.css";
 import ReactGA from "react-ga4";
+import "styles/globals.css";
 
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();

--- a/torchci/pages/_githubrunnersutilization.tsx
+++ b/torchci/pages/_githubrunnersutilization.tsx
@@ -1,18 +1,18 @@
-import TimeSeriesPanel from "components/metrics/panels/TimeSeriesPanel";
-import { RocksetParam } from "lib/rockset";
-import { durationDisplay } from "components/TimeUtils";
-import { TimeRangePicker } from "./metrics";
-import { useState } from "react";
-import dayjs from "dayjs";
 import {
-  Grid,
-  Stack,
-  Select,
-  MenuItem,
   FormControl,
+  Grid,
   InputLabel,
+  MenuItem,
+  Select,
   SelectChangeEvent,
+  Stack,
 } from "@mui/material";
+import TimeSeriesPanel from "components/metrics/panels/TimeSeriesPanel";
+import { durationDisplay } from "components/TimeUtils";
+import dayjs from "dayjs";
+import { RocksetParam } from "lib/rockset";
+import { useState } from "react";
+import { TimeRangePicker } from "./metrics";
 
 const ROW_HEIGHT = 340;
 

--- a/torchci/pages/api/[repoOwner]/[repoName]/commit/[sha].ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/commit/[sha].ts
@@ -1,6 +1,6 @@
-import type { NextApiRequest, NextApiResponse } from "next";
 import fetchCommit from "lib/fetchCommit";
 import { CommitData, JobData } from "lib/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(
   req: NextApiRequest,

--- a/torchci/pages/api/[repoOwner]/[repoName]/pull/[prNumber].ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/pull/[prNumber].ts
@@ -1,7 +1,7 @@
-import { getOctokit } from "lib/github";
-import type { NextApiRequest, NextApiResponse } from "next";
 import fetchPR from "lib/fetchPR";
+import { getOctokit } from "lib/github";
 import { PRData } from "lib/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<PRData>

--- a/torchci/pages/api/corresponding_workflow_id.ts
+++ b/torchci/pages/api/corresponding_workflow_id.ts
@@ -3,8 +3,8 @@
 // the trunk workflow, then this will return the workflow id for the trunk
 // workflow on the provided sha
 
-import type { NextApiRequest, NextApiResponse } from "next";
 import getRocksetClient, { RocksetParam } from "lib/rockset";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 async function getCorrespondingWorkflowID(sha: string, workflowId: string) {
   const parameters: RocksetParam[] = [

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -1,45 +1,45 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-import { getOctokit } from "lib/github";
-import {
-  fetchRecentWorkflows,
-  fetchFailedJobsFromCommits,
-} from "lib/fetchRecentWorkflows";
-import { RecentWorkflowsData, IssueData, PRandJobs } from "lib/types";
-import {
-  NUM_MINUTES,
-  formDrciComment,
-  OWNER,
-  getDrciComment,
-  getActiveSEVs,
-  formDrciSevBody,
-  FLAKY_RULES_JSON,
-  HUD_URL,
-  hasSimilarFailures,
-  isInfraFlakyJob,
-  isLogClassifierFailed,
-  fetchIssueLabels,
-  getSuppressedLabels,
-  isExcludedFromFlakiness,
-} from "lib/drciUtils";
-import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
-import { Octokit } from "octokit";
 import { fetchJSON } from "lib/bot/utils";
 import {
-  removeJobNameSuffix,
-  isSameFailure,
-  removeCancelledJobAfterRetry,
+  fetchIssueLabels,
+  FLAKY_RULES_JSON,
+  formDrciComment,
+  formDrciSevBody,
+  getActiveSEVs,
+  getDrciComment,
+  getSuppressedLabels,
+  hasSimilarFailures,
+  HUD_URL,
+  isExcludedFromFlakiness,
+  isInfraFlakyJob,
+  isLogClassifierFailed,
+  NUM_MINUTES,
+  OWNER,
+} from "lib/drciUtils";
+import { fetchCommitTimestamp } from "lib/fetchCommit";
+import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
+import fetchPR from "lib/fetchPR";
+import {
+  fetchFailedJobsFromCommits,
+  fetchRecentWorkflows,
+} from "lib/fetchRecentWorkflows";
+import { getOctokit } from "lib/github";
+import {
   backfillMissingLog,
-  isUnstableJob,
-  getOpenUnstableIssues,
   getDisabledTestIssues,
-  isRecentlyCloseDisabledTest,
+  getOpenUnstableIssues,
   isDisabledTest,
   isDisabledTestMentionedInPR,
+  isRecentlyCloseDisabledTest,
+  isSameFailure,
+  isUnstableJob,
+  removeCancelledJobAfterRetry,
+  removeJobNameSuffix,
 } from "lib/jobUtils";
 import getRocksetClient from "lib/rockset";
+import { IssueData, PRandJobs, RecentWorkflowsData } from "lib/types";
 import _ from "lodash";
-import { fetchCommitTimestamp } from "lib/fetchCommit";
-import fetchPR from "lib/fetchPR";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { Octokit } from "octokit";
 
 export interface FlakyRule {
   name: string;

--- a/torchci/pages/api/failure.ts
+++ b/torchci/pages/api/failure.ts
@@ -1,8 +1,7 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-import { NEWEST_FIRST, querySimilarFailures } from "lib/searchUtils";
 import dayjs from "dayjs";
-import _ from "lodash";
-import { isEqual } from "lodash";
+import { NEWEST_FIRST, querySimilarFailures } from "lib/searchUtils";
+import _, { isEqual } from "lodash";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 interface Data {}
 

--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -1,19 +1,19 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-import { getOctokit } from "lib/github";
-import fetchFlakyTests, {
-  fetchFlakyTestsAcrossFileReruns,
-} from "lib/fetchFlakyTests";
-import fetchDisabledNonFlakyTests from "lib/fetchDisabledNonFlakyTests";
-import { FlakyTestData, IssueData, DisabledNonFlakyTestData } from "lib/types";
+import dayjs from "dayjs";
+import { retryRequest } from "lib/bot/utils";
 import {
   parseBody,
   supportedPlatforms,
 } from "lib/bot/verifyDisableTestIssueBot";
+import fetchDisabledNonFlakyTests from "lib/fetchDisabledNonFlakyTests";
+import fetchFlakyTests, {
+  fetchFlakyTestsAcrossFileReruns,
+} from "lib/fetchFlakyTests";
 import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
-import { retryRequest } from "lib/bot/utils";
-import { Octokit } from "octokit";
-import dayjs from "dayjs";
+import { getOctokit } from "lib/github";
+import { DisabledNonFlakyTestData, FlakyTestData, IssueData } from "lib/types";
 import _ from "lodash";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { Octokit } from "octokit";
 
 const NUM_HOURS = 3;
 const NUM_HOURS_ACROSS_JOBS = 72;

--- a/torchci/pages/api/flaky-tests/flakytest.ts
+++ b/torchci/pages/api/flaky-tests/flakytest.ts
@@ -1,7 +1,7 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-import { JobData } from "lib/types";
 import getRocksetClient from "lib/rockset";
+import { JobData } from "lib/types";
 import _ from "lodash";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(
   req: NextApiRequest,

--- a/torchci/pages/api/github/dispatch/[repoOwner]/[repoName]/[workflow]/[sha].ts
+++ b/torchci/pages/api/github/dispatch/[repoOwner]/[repoName]/[workflow]/[sha].ts
@@ -1,6 +1,6 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-import { getOctokit, getOctokitWithUserToken } from "lib/github";
 import { hasWritePermissionsUsingOctokit } from "lib/bot/utils";
+import { getOctokit, getOctokitWithUserToken } from "lib/github";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(
   req: NextApiRequest,

--- a/torchci/pages/api/github/webhooks.ts
+++ b/torchci/pages/api/github/webhooks.ts
@@ -1,5 +1,5 @@
-import { createNodeMiddleware, createProbot } from "probot";
 import bot from "lib/bot";
+import { createNodeMiddleware, createProbot } from "probot";
 
 export default createNodeMiddleware(bot, {
   probot: createProbot(),

--- a/torchci/pages/api/hud/[repoOwner]/[repoName]/[branch]/[page].ts
+++ b/torchci/pages/api/hud/[repoOwner]/[repoName]/[branch]/[page].ts
@@ -1,8 +1,7 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-import zlib from "zlib";
-
 import fetchHud from "lib/fetchHud";
 import { packHudParams } from "lib/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+import zlib from "zlib";
 
 export default async function handler(
   req: NextApiRequest,

--- a/torchci/pages/api/issue/[label].ts
+++ b/torchci/pages/api/issue/[label].ts
@@ -1,7 +1,6 @@
-import { NextApiRequest, NextApiResponse } from "next";
-
-import { IssueData } from "lib/types";
 import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
+import { IssueData } from "lib/types";
+import { NextApiRequest, NextApiResponse } from "next";
 
 interface Data {
   issues: IssueData[];

--- a/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/[annotation].ts
+++ b/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/[annotation].ts
@@ -1,8 +1,8 @@
-import { NextApiRequest, NextApiResponse } from "next";
 import { getDynamoClient } from "lib/dynamo";
+import { getOctokit } from "lib/github";
+import { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth";
 import { authOptions } from "pages/api/auth/[...nextauth]";
-import { getOctokit } from "lib/github";
 
 // Team ID query from https://api.github.com/orgs/pytorch/teams/pytorch-dev-infra
 export const pytorchDevInfra = "pytorch-dev-infra";

--- a/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/failures/[queryParams].ts
+++ b/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/failures/[queryParams].ts
@@ -1,8 +1,7 @@
 import { getDynamoClient } from "lib/dynamo";
+import getRocksetClient, { RocksetParam } from "lib/rockset";
 import { JobData } from "lib/types";
 import { NextApiRequest, NextApiResponse } from "next";
-import getRocksetClient from "lib/rockset";
-import { RocksetParam } from "lib/rockset";
 import rocksetVersions from "rockset/prodVersions.json";
 
 async function fetchFailureJobs(

--- a/torchci/pages/api/log_annotation/[repoOwner]/[repoName]/[annotation].ts
+++ b/torchci/pages/api/log_annotation/[repoOwner]/[repoName]/[annotation].ts
@@ -1,9 +1,9 @@
-import { NextApiRequest, NextApiResponse } from "next";
+import { hasWritePermissionsUsingOctokit } from "lib/bot/utils";
 import { getDynamoClient } from "lib/dynamo";
+import { getOctokit } from "lib/github";
+import { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth";
 import { authOptions } from "pages/api/auth/[...nextauth]";
-import { getOctokit } from "lib/github";
-import { hasWritePermissionsUsingOctokit } from "lib/bot/utils";
 
 export default async function handler(
   req: NextApiRequest,

--- a/torchci/pages/api/query/[collection]/[lambdaName].ts
+++ b/torchci/pages/api/query/[collection]/[lambdaName].ts
@@ -1,6 +1,5 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-
 import getRocksetClient, { RocksetParam } from "lib/rockset";
+import type { NextApiRequest, NextApiResponse } from "next";
 import rocksetVersions from "rockset/prodVersions.json";
 
 export const config = {

--- a/torchci/pages/api/search.ts
+++ b/torchci/pages/api/search.ts
@@ -1,11 +1,11 @@
-import type { NextApiRequest, NextApiResponse } from "next";
 import { getOpenSearchClient } from "lib/opensearch";
-import { JobData } from "lib/types";
 import {
+  MIN_SCORE,
   searchSimilarFailures,
   WORKFLOW_JOB_INDEX,
-  MIN_SCORE,
 } from "lib/searchUtils";
+import { JobData } from "lib/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(
   req: NextApiRequest,

--- a/torchci/pages/api/usage-log-aggregator/lambda.ts
+++ b/torchci/pages/api/usage-log-aggregator/lambda.ts
@@ -1,5 +1,5 @@
-import * as restc from "typed-rest-client/RestClient";
 import { NextApiRequest, NextApiResponse } from "next";
+import * as restc from "typed-rest-client/RestClient";
 
 // TODO: Create a hostname and secure this API
 const USAGE_LOG_AGGREGATOR_API =

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -1,31 +1,29 @@
-import dayjs from "dayjs";
-import useSWR from "swr";
-import { Grid, Skeleton, Stack, Typography, Divider } from "@mui/material";
-import { useRouter } from "next/router";
-import React from "react";
-import { useState, useEffect } from "react";
-import { RocksetParam } from "lib/rockset";
-import { fetcher } from "lib/GeneralUtils";
-import { Granularity } from "components/metrics/panels/TimeSeriesPanel";
-import GranularityPicker from "components/GranularityPicker";
-import { TimeRangePicker } from "../../../metrics";
-import { CompilerPerformanceData } from "lib/types";
-import CopyLink from "components/CopyLink";
+import { Divider, Grid, Skeleton, Stack, Typography } from "@mui/material";
 import { BranchAndCommitPicker } from "components/benchmark/BranchAndCommitPicker";
-import { MAIN_BRANCH, LAST_N_DAYS } from "components/benchmark/common";
+import { CommitPanel } from "components/benchmark/CommitPanel";
+import { LAST_N_DAYS, MAIN_BRANCH } from "components/benchmark/common";
+import { BenchmarkLogs } from "components/benchmark/compilers/BenchmarkLogs";
+import { COMPILER_NAMES_TO_DISPLAY_NAMES } from "components/benchmark/compilers/common";
+import { GraphPanel } from "components/benchmark/compilers/ModelGraphPanel";
+import { ModelPanel } from "components/benchmark/compilers/ModelPanel";
 import {
   DEFAULT_MODE,
-  MODES,
-  ModePicker,
   DTypePicker,
+  ModePicker,
+  MODES,
 } from "components/benchmark/ModeAndDTypePicker";
+import CopyLink from "components/CopyLink";
+import GranularityPicker from "components/GranularityPicker";
+import { Granularity } from "components/metrics/panels/TimeSeriesPanel";
+import dayjs from "dayjs";
 import { augmentData } from "lib/benchmark/compilerUtils";
-import { COMPILER_NAMES_TO_DISPLAY_NAMES } from "components/benchmark/compilers/common";
-import { ModelPanel } from "components/benchmark/compilers/ModelPanel";
-import { GraphPanel } from "components/benchmark/compilers/ModelGraphPanel";
-import { BranchAndCommit } from "lib/types";
-import { CommitPanel } from "components/benchmark/CommitPanel";
-import { BenchmarkLogs } from "components/benchmark/compilers/BenchmarkLogs";
+import { fetcher } from "lib/GeneralUtils";
+import { RocksetParam } from "lib/rockset";
+import { BranchAndCommit, CompilerPerformanceData } from "lib/types";
+import { useRouter } from "next/router";
+import React, { useEffect, useState } from "react";
+import useSWR from "swr";
+import { TimeRangePicker } from "../../../metrics";
 
 function Report({
   queryParams,

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -1,33 +1,32 @@
-import dayjs from "dayjs";
-import useSWR from "swr";
-import { Skeleton, Stack, Typography, Divider } from "@mui/material";
-import React from "react";
-import { useState, useEffect } from "react";
-import { RocksetParam } from "lib/rockset";
-import { fetcher } from "lib/GeneralUtils";
-import GranularityPicker from "components/GranularityPicker";
-import { TimeRangePicker } from "../metrics";
-import { BranchAndCommit } from "lib/types";
-import { useRouter } from "next/router";
-import CopyLink from "components/CopyLink";
+import { Divider, Skeleton, Stack, Typography } from "@mui/material";
 import { BranchAndCommitPicker } from "components/benchmark/BranchAndCommitPicker";
 import { CommitPanel } from "components/benchmark/CommitPanel";
-import { MAIN_BRANCH, LAST_N_DAYS } from "components/benchmark/common";
+import { LAST_N_DAYS, MAIN_BRANCH } from "components/benchmark/common";
+import { BenchmarkLogs } from "components/benchmark/compilers/BenchmarkLogs";
 import {
-  SUITES,
   SuitePicker,
+  SUITES,
 } from "components/benchmark/compilers/SuitePicker";
+import { GraphPanel } from "components/benchmark/compilers/SummaryGraphPanel";
+import { SummaryPanel } from "components/benchmark/compilers/SummaryPanel";
 import {
   DEFAULT_MODE,
-  MODES,
-  ModePicker,
   DTypePicker,
+  ModePicker,
+  MODES,
 } from "components/benchmark/ModeAndDTypePicker";
-import { BenchmarkLogs } from "components/benchmark/compilers/BenchmarkLogs";
-import { SummaryPanel } from "components/benchmark/compilers/SummaryPanel";
-import { GraphPanel } from "components/benchmark/compilers/SummaryGraphPanel";
+import CopyLink from "components/CopyLink";
+import GranularityPicker from "components/GranularityPicker";
 import { Granularity } from "components/metrics/panels/TimeSeriesPanel";
+import dayjs from "dayjs";
 import { augmentData } from "lib/benchmark/compilerUtils";
+import { fetcher } from "lib/GeneralUtils";
+import { RocksetParam } from "lib/rockset";
+import { BranchAndCommit } from "lib/types";
+import { useRouter } from "next/router";
+import React, { useEffect, useState } from "react";
+import useSWR from "swr";
+import { TimeRangePicker } from "../metrics";
 
 function Report({
   queryParams,

--- a/torchci/pages/correlation.tsx
+++ b/torchci/pages/correlation.tsx
@@ -1,5 +1,5 @@
-import ReactECharts from "echarts-for-react";
 import { EChartsOption } from "echarts";
+import ReactECharts from "echarts-for-react";
 import correlationMatrix from "lib/correlation_matrix.json";
 
 export default function Page() {

--- a/torchci/pages/failedjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/failedjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -1,18 +1,18 @@
-import useSWR from "swr";
-import _ from "lodash";
 import { Skeleton, Stack, Typography } from "@mui/material";
-import { useRouter } from "next/router";
-import { RocksetParam } from "lib/rockset";
-import { fetcher } from "lib/GeneralUtils";
-import React, { useState } from "react";
-import JobSummary from "components/JobSummary";
-import JobLinks from "components/JobLinks";
-import LogViewer from "components/LogViewer";
 import JobAnnotationToggle from "components/JobAnnotationToggle";
-import { JobData, JobAnnotation } from "lib/types";
-import { TimeRangePicker } from "pages/metrics";
+import JobLinks from "components/JobLinks";
+import JobSummary from "components/JobSummary";
+import LogViewer from "components/LogViewer";
 import dayjs from "dayjs";
+import { fetcher } from "lib/GeneralUtils";
 import { isRerunDisabledTestsJob, isUnstableJob } from "lib/jobUtils";
+import { RocksetParam } from "lib/rockset";
+import { JobAnnotation, JobData } from "lib/types";
+import _ from "lodash";
+import { useRouter } from "next/router";
+import { TimeRangePicker } from "pages/metrics";
+import React, { useState } from "react";
+import useSWR from "swr";
 
 function SimilarFailedJobs({
   job,

--- a/torchci/pages/failure.tsx
+++ b/torchci/pages/failure.tsx
@@ -1,18 +1,16 @@
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-dayjs.extend(utc);
-
-import { CSSProperties, useEffect, useState } from "react";
-import { useRouter } from "next/router";
-import useSWR from "swr";
-import { BarChart, Bar, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
-
-import { JobData } from "lib/types";
+import JobLinks from "components/JobLinks";
 import JobSummary from "components/JobSummary";
 import LogViewer from "components/LogViewer";
-import JobLinks from "components/JobLinks";
-import { usePreference } from "lib/useGroupingPreference";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import { ParamSelector } from "lib/ParamSelector";
+import { JobData } from "lib/types";
+import { usePreference } from "lib/useGroupingPreference";
+import { useRouter } from "next/router";
+import { CSSProperties, useEffect, useState } from "react";
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
+import useSWR from "swr";
+dayjs.extend(utc);
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 

--- a/torchci/pages/flakytest.tsx
+++ b/torchci/pages/flakytest.tsx
@@ -1,10 +1,10 @@
-import { useRouter } from "next/router";
-import useSWR from "swr";
-import LogViewer from "components/LogViewer";
-import { FlakyTestInfoHUD } from "./api/flaky-tests/flakytest";
 import JobLinks from "components/JobLinks";
 import JobSummary from "components/JobSummary";
+import LogViewer from "components/LogViewer";
 import { ParamSelector } from "lib/ParamSelector";
+import { useRouter } from "next/router";
+import useSWR from "swr";
+import { FlakyTestInfoHUD } from "./api/flaky-tests/flakytest";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -1,3 +1,4 @@
+import CopyLink from "components/CopyLink";
 import {
   GroupHudTableColumns,
   GroupHudTableHeader,
@@ -7,45 +8,44 @@ import styles from "components/hud.module.css";
 import JobConclusion from "components/JobConclusion";
 import JobFilterInput from "components/JobFilterInput";
 import JobTooltip from "components/JobTooltip";
+import PageSelector from "components/PageSelector";
 import { LocalTimeHuman } from "components/TimeUtils";
 import TooltipTarget from "components/TooltipTarget";
+import { fetcher } from "lib/GeneralUtils";
 import {
   getGroupingData,
   groups,
-  sortGroupNamesForHUD,
   isUnstableGroup,
+  sortGroupNamesForHUD,
 } from "lib/JobClassifierUtil";
-import {
-  formatHudUrlForRoute,
-  Highlight,
-  HudData,
-  HudParams,
-  JobData,
-  packHudParams,
-  RowData,
-  IssueData,
-} from "lib/types";
-import useHudData from "lib/useHudData";
-import useTableFilter from "lib/useTableFilter";
-import Head from "next/head";
-import { useRouter } from "next/router";
-import React, { createContext, useContext, useEffect, useState } from "react";
-import PageSelector from "components/PageSelector";
 import {
   isFailedJob,
   isRerunDisabledTestsJob,
   isUnstableJob,
 } from "lib/jobUtils";
+import { ParamSelector } from "lib/ParamSelector";
+import { track } from "lib/track";
+import {
+  formatHudUrlForRoute,
+  Highlight,
+  HudData,
+  HudParams,
+  IssueData,
+  JobData,
+  packHudParams,
+  RowData,
+} from "lib/types";
 import {
   useGroupingPreference,
-  usePreference,
   useMonsterFailuresPreference,
+  usePreference,
 } from "lib/useGroupingPreference";
-import { track } from "lib/track";
+import useHudData from "lib/useHudData";
+import useTableFilter from "lib/useTableFilter";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import React, { createContext, useContext, useEffect, useState } from "react";
 import useSWR from "swr";
-import { fetcher } from "lib/GeneralUtils";
-import { ParamSelector } from "lib/ParamSelector";
-import CopyLink from "components/CopyLink";
 
 export function JobCell({
   sha,

--- a/torchci/pages/login_test.tsx
+++ b/torchci/pages/login_test.tsx
@@ -1,5 +1,5 @@
+import { signIn, signOut, useSession } from "next-auth/react";
 import React from "react";
-import { useSession, signIn, signOut } from "next-auth/react";
 
 export default function MePage() {
   const session = useSession();

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -1,37 +1,35 @@
-import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
-import dayjs from "dayjs";
-import ReactECharts from "echarts-for-react";
-import { EChartsOption } from "echarts";
+import {
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  SelectChangeEvent,
+  Skeleton,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
 import {
   GridRenderCellParams,
   GridValueFormatterParams,
 } from "@mui/x-data-grid";
-import useSWR from "swr";
-import {
-  Grid,
-  Paper,
-  TextField,
-  Typography,
-  Stack,
-  Skeleton,
-  Select,
-  MenuItem,
-  FormControl,
-  InputLabel,
-  SelectChangeEvent,
-} from "@mui/material";
-import { LocalizationProvider, DateTimePicker } from "@mui/x-date-pickers";
-
-import { useEffect, useState } from "react";
-
-import { RocksetParam } from "lib/rockset";
-import { fetcher } from "lib/GeneralUtils";
+import { DateTimePicker, LocalizationProvider } from "@mui/x-date-pickers";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import ScalarPanel, {
   ScalarPanelWithValue,
 } from "components/metrics/panels/ScalarPanel";
 import TablePanel from "components/metrics/panels/TablePanel";
 import TimeSeriesPanel from "components/metrics/panels/TimeSeriesPanel";
 import { durationDisplay } from "components/TimeUtils";
+import dayjs from "dayjs";
+import { EChartsOption } from "echarts";
+import ReactECharts from "echarts-for-react";
+import { fetcher } from "lib/GeneralUtils";
+import { RocksetParam } from "lib/rockset";
+import { useEffect, useState } from "react";
+import useSWR from "swr";
 
 function MasterCommitRedPanel({ params }: { params: RocksetParam[] }) {
   const url = `/api/query/metrics/master_commit_red?parameters=${encodeURIComponent(

--- a/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -1,4 +1,5 @@
 import CopyLink from "components/CopyLink";
+import JobAnnotationToggle from "components/JobAnnotationToggle";
 import JobConclusion from "components/JobConclusion";
 import JobFilterInput from "components/JobFilterInput";
 import JobLinks from "components/JobLinks";
@@ -7,19 +8,19 @@ import styles from "components/minihud.module.css";
 import PageSelector from "components/PageSelector";
 import { durationHuman, LocalTimeHuman } from "components/TimeUtils";
 import { isFailedJob } from "lib/jobUtils";
+import { RevertModal } from "lib/RevertModal";
 import {
   HudParams,
+  JobAnnotation,
   JobData,
   packHudParams,
   RowData,
   TTSChange,
-  JobAnnotation,
 } from "lib/types";
 import useHudData from "lib/useHudData";
 import useScrollTo from "lib/useScrollTo";
 import _ from "lodash";
 import { useRouter } from "next/router";
-import { RevertModal } from "lib/RevertModal";
 import {
   createContext,
   CSSProperties,
@@ -29,7 +30,6 @@ import {
   useState,
 } from "react";
 import { SWRConfig } from "swr";
-import JobAnnotationToggle from "components/JobAnnotationToggle";
 
 function includesCaseInsensitive(value: string, pattern: string): boolean {
   if (pattern === "") {

--- a/torchci/pages/nightlies.tsx
+++ b/torchci/pages/nightlies.tsx
@@ -1,15 +1,13 @@
-import dayjs from "dayjs";
-import ReactECharts from "echarts-for-react";
-import { EChartsOption } from "echarts";
-import useSWR from "swr";
-import { Grid, Paper, Typography, Stack, Skeleton } from "@mui/material";
-
-import { useState } from "react";
-import { RocksetParam } from "lib/rockset";
-import { fetcher } from "lib/GeneralUtils";
-
+import { Grid, Paper, Skeleton, Stack, Typography } from "@mui/material";
 import TablePanel from "components/metrics/panels/TablePanel";
+import dayjs from "dayjs";
+import { EChartsOption } from "echarts";
+import ReactECharts from "echarts-for-react";
+import { fetcher } from "lib/GeneralUtils";
+import { RocksetParam } from "lib/rockset";
 import { TimeRangePicker } from "pages/metrics";
+import { useState } from "react";
+import useSWR from "swr";
 
 function NightlyJobsRedPanel({
   params,

--- a/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
+++ b/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
@@ -1,29 +1,28 @@
-import dayjs from "dayjs";
-import ReactECharts from "echarts-for-react";
-import { EChartsOption } from "echarts";
-import useSWR from "swr";
 import { Grid, Paper, Skeleton, Stack, Typography } from "@mui/material";
-import { useRouter } from "next/router";
-import { useCallback, useState } from "react";
-import { RocksetParam } from "lib/rockset";
-import { fetcher } from "lib/GeneralUtils";
 import {
-  Granularity,
-  getTooltipMarker,
-  seriesWithInterpolatedTimes,
-} from "components/metrics/panels/TimeSeriesPanel";
-import React from "react";
-import { TimeRangePicker } from "../../../metrics";
-import { TablePanelWithData } from "components/metrics/panels/TablePanel";
-import GranularityPicker from "components/GranularityPicker";
-import {
-  GridRenderCellParams,
   GridCellParams,
+  GridRenderCellParams,
   GridValueFormatterParams,
 } from "@mui/x-data-grid";
+import GranularityPicker from "components/GranularityPicker";
 import styles from "components/hud.module.css";
+import { TablePanelWithData } from "components/metrics/panels/TablePanel";
+import {
+  getTooltipMarker,
+  Granularity,
+  seriesWithInterpolatedTimes,
+} from "components/metrics/panels/TimeSeriesPanel";
+import dayjs from "dayjs";
+import { EChartsOption } from "echarts";
+import ReactECharts from "echarts-for-react";
+import { fetcher } from "lib/GeneralUtils";
 import { approximateFailureByTypePercent } from "lib/metricUtils";
+import { RocksetParam } from "lib/rockset";
 import { JobAnnotation } from "lib/types";
+import { useRouter } from "next/router";
+import React, { useCallback, useState } from "react";
+import useSWR from "swr";
+import { TimeRangePicker } from "../../../metrics";
 
 const PRIMARY_WORKFLOWS = ["lint", "pull", "trunk"];
 const SECONDARY_WORKFLOWS = ["periodic", "inductor"];

--- a/torchci/pages/sli.tsx
+++ b/torchci/pages/sli.tsx
@@ -1,7 +1,3 @@
-import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
-import dayjs from "dayjs";
-import useSWR from "swr";
-import { useEffect, useState } from "react";
 import {
   Autocomplete,
   FormControl,
@@ -15,11 +11,15 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import { RocksetParam } from "lib/rockset";
-import { LocalizationProvider, DateTimePicker } from "@mui/x-date-pickers";
+import { DateTimePicker, LocalizationProvider } from "@mui/x-date-pickers";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import TimeSeriesPanel from "components/metrics/panels/TimeSeriesPanel";
 import { durationDisplay } from "components/TimeUtils";
+import dayjs from "dayjs";
 import { fetcher } from "lib/GeneralUtils";
+import { RocksetParam } from "lib/rockset";
+import { useEffect, useState } from "react";
+import useSWR from "swr";
 
 const ROW_HEIGHT = 600;
 

--- a/torchci/pages/test/insights.tsx
+++ b/torchci/pages/test/insights.tsx
@@ -1,11 +1,11 @@
-import dayjs from "dayjs";
 import { Grid, Stack, Typography } from "@mui/material";
-import { useRouter } from "next/router";
-import { RocksetParam } from "lib/rockset";
-import { fetcher } from "lib/GeneralUtils";
-import useSWR from "swr";
-import { useState } from "react";
 import { TimeSeriesPanelWithData } from "components/metrics/panels/TimeSeriesPanel";
+import dayjs from "dayjs";
+import { fetcher } from "lib/GeneralUtils";
+import { RocksetParam } from "lib/rockset";
+import { useRouter } from "next/router";
+import { useState } from "react";
+import useSWR from "swr";
 
 const LASTEST_N_RUNS = 50;
 const ROW_HEIGHT = 240;

--- a/torchci/pages/testing_overhead/insights.tsx
+++ b/torchci/pages/testing_overhead/insights.tsx
@@ -1,10 +1,10 @@
-import dayjs from "dayjs";
 import { Grid, Stack, Typography } from "@mui/material";
+import dayjs from "dayjs";
+import { useRouter } from "next/router";
 import { TimeRangePicker } from "pages/metrics";
-
 import { useState } from "react";
 import GenerateTestInsightsOverviewTable from "../../components/metrics/panels/GenerateTestInsightsOverviewTable";
-import { useRouter } from "next/router";
+
 const THRESHOLD_IN_SECOND = 60;
 
 export default function IndividualTestInsights() {

--- a/torchci/pages/testing_overhead/oncall_insights.tsx
+++ b/torchci/pages/testing_overhead/oncall_insights.tsx
@@ -1,19 +1,19 @@
 import { Grid } from "@mui/material";
-import TimeSeriesPanel from "components/metrics/panels/TimeSeriesPanel";
-import dayjs from "dayjs";
-import { RocksetParam } from "lib/rockset";
-import { useState } from "react";
-import { useRouter } from "next/router";
-import TablePanel from "components/metrics/panels/TablePanel";
-import { durationDisplay } from "components/TimeUtils";
 import {
   GridRenderCellParams,
   GridValueFormatterParams,
 } from "@mui/x-data-grid";
 import GenerateIndividualTestsLeaderboard from "components/metrics/panels/GenerateIndividualTestsLeaderboard";
+import TablePanel from "components/metrics/panels/TablePanel";
+import TimeSeriesPanel from "components/metrics/panels/TimeSeriesPanel";
 import WorkflowPicker, {
   WORKFLOWS,
 } from "components/metrics/panels/WorkflowPicker";
+import { durationDisplay } from "components/TimeUtils";
+import dayjs from "dayjs";
+import { RocksetParam } from "lib/rockset";
+import { useRouter } from "next/router";
+import { useState } from "react";
 
 const ROW_HEIGHT = 500;
 const THRESHOLD_IN_SECOND = 60;

--- a/torchci/pages/tests.tsx
+++ b/torchci/pages/tests.tsx
@@ -1,8 +1,8 @@
-import dayjs from "dayjs";
 import { Grid, Stack, Typography } from "@mui/material";
-import { TimeRangePicker } from "./metrics";
+import dayjs from "dayjs";
 import { useState } from "react";
 import GenerateTestInsightsOverviewTable from "../components/metrics/panels/GenerateTestInsightsOverviewTable";
+import { TimeRangePicker } from "./metrics";
 
 const THRESHOLD_IN_SECOND = 60;
 

--- a/torchci/pages/torchbench/userbenchmark.tsx
+++ b/torchci/pages/torchbench/userbenchmark.tsx
@@ -1,22 +1,22 @@
-import dayjs from "dayjs";
-import useSWR from "swr";
-import { fetcher } from "lib/GeneralUtils";
-import React, { useState, useEffect } from "react";
-import { RocksetParam } from "lib/rockset";
 import {
+  Divider,
+  FormControl,
   Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
   Skeleton,
   Stack,
   Typography,
-  Select,
-  MenuItem,
-  FormControl,
-  Divider,
-  InputLabel,
-  SelectChangeEvent,
 } from "@mui/material";
+import { GridCellParams, GridRenderCellParams } from "@mui/x-data-grid";
 import { TablePanelWithData } from "components/metrics/panels/TablePanel";
-import { GridRenderCellParams, GridCellParams } from "@mui/x-data-grid";
+import dayjs from "dayjs";
+import { fetcher } from "lib/GeneralUtils";
+import { RocksetParam } from "lib/rockset";
+import React, { useEffect, useState } from "react";
+import useSWR from "swr";
 
 const queryCollection = "torchbench";
 const ROW_GAP = 30;

--- a/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -1,22 +1,21 @@
-import dayjs from "dayjs";
-import ReactECharts from "echarts-for-react";
-import { EChartsOption } from "echarts";
-import useSWR from "swr";
 import { Grid, Paper, Skeleton, Stack, Typography } from "@mui/material";
-import { useRouter } from "next/router";
-import { useCallback, useState } from "react";
-import { RocksetParam } from "lib/rockset";
-import { fetcher } from "lib/GeneralUtils";
+import GranularityPicker from "components/GranularityPicker";
+import styles from "components/hud.module.css";
 import {
-  Granularity,
   getTooltipMarker,
+  Granularity,
   seriesWithInterpolatedTimes,
 } from "components/metrics/panels/TimeSeriesPanel";
 import { durationDisplay } from "components/TimeUtils";
-import GranularityPicker from "components/GranularityPicker";
-import React from "react";
+import dayjs from "dayjs";
+import { EChartsOption } from "echarts";
+import ReactECharts from "echarts-for-react";
+import { fetcher } from "lib/GeneralUtils";
+import { RocksetParam } from "lib/rockset";
+import { useRouter } from "next/router";
+import React, { useCallback, useState } from "react";
+import useSWR from "swr";
 import { TimeRangePicker, TtsPercentilePicker } from "../../../../metrics";
-import styles from "components/hud.module.css";
 
 const SUPPORTED_WORKFLOWS = [
   "pull",

--- a/torchci/scripts/backfillJobs.mjs
+++ b/torchci/scripts/backfillJobs.mjs
@@ -4,9 +4,9 @@
 
 import { DynamoDB } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
-import { Octokit, App } from "octokit";
 import { createAppAuth } from "@octokit/auth-app";
 import rockset from "@rockset/client";
+import { App, Octokit } from "octokit";
 import { request } from "urllib";
 
 function getDynamoClient() {

--- a/torchci/scripts/checkRockset.mjs
+++ b/torchci/scripts/checkRockset.mjs
@@ -1,7 +1,7 @@
 import rockset from "@rockset/client";
-import { promises as fs } from "fs";
-import { diffLines } from "diff";
 import "colors";
+import { diffLines } from "diff";
+import { promises as fs } from "fs";
 
 async function readJSON(path) {
   const rawData = await fs.readFile(path);

--- a/torchci/scripts/downloadQueryLambda.mjs
+++ b/torchci/scripts/downloadQueryLambda.mjs
@@ -1,7 +1,7 @@
 import rockset from "@rockset/client";
 import { ArgumentParser } from "argparse";
-import { promises as fs, existsSync } from "fs";
 import dotenv from "dotenv";
+import { existsSync, promises as fs } from "fs";
 import path from "path";
 import { exit } from "process";
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });

--- a/torchci/scripts/updateSlowTests.mjs
+++ b/torchci/scripts/updateSlowTests.mjs
@@ -1,6 +1,6 @@
 import rockset from "@rockset/client";
-import { promises as fs } from "fs";
 import dotenv from "dotenv";
+import { promises as fs } from "fs";
 import path from "path";
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
 

--- a/torchci/scripts/uploadQueryLambda.mjs
+++ b/torchci/scripts/uploadQueryLambda.mjs
@@ -1,6 +1,6 @@
 import rockset from "@rockset/client";
-import { promises as fs } from "fs";
 import dotenv from "dotenv";
+import { promises as fs } from "fs";
 import path from "path";
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
 

--- a/torchci/test/autoCcBot.test.ts
+++ b/torchci/test/autoCcBot.test.ts
@@ -1,8 +1,8 @@
 import nock from "nock";
-import * as utils from "./utils";
+import { Probot } from "probot";
 import myProbotApp from "../lib/bot/autoCcBot";
 import { nockTracker } from "./common";
-import { Probot } from "probot";
+import * as utils from "./utils";
 
 nock.disableNetConnect();
 

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -1,9 +1,9 @@
+import * as botUtils from "lib/bot/utils";
 import nock from "nock";
 import { Probot } from "probot";
-import * as utils from "./utils";
-import { handleScope, requireDeepCopy } from "./common";
 import myProbotApp from "../lib/bot/autoLabelBot";
-import * as botUtils from "lib/bot/utils";
+import { handleScope, requireDeepCopy } from "./common";
+import * as utils from "./utils";
 
 nock.disableNetConnect();
 

--- a/torchci/test/closeCommands.test.ts
+++ b/torchci/test/closeCommands.test.ts
@@ -1,8 +1,8 @@
+import pytorchBot from "lib/bot/pytorchBot";
 import nock from "nock";
 import * as probot from "probot";
-import * as utils from "./utils";
-import pytorchBot from "lib/bot/pytorchBot";
 import { handleScope } from "./common";
+import * as utils from "./utils";
 
 nock.disableNetConnect();
 

--- a/torchci/test/codevNoWritePermBot.test.ts
+++ b/torchci/test/codevNoWritePermBot.test.ts
@@ -1,9 +1,9 @@
+import * as botUtils from "lib/bot/utils";
 import nock from "nock";
-import * as utils from "./utils";
+import { Probot } from "probot";
 import myProbotApp from "../lib/bot/codevNoWritePermBot";
 import { handleScope, requireDeepCopy } from "./common";
-import { Probot } from "probot";
-import * as botUtils from "lib/bot/utils";
+import * as utils from "./utils";
 
 nock.disableNetConnect();
 

--- a/torchci/test/disableFlakyBot.test.ts
+++ b/torchci/test/disableFlakyBot.test.ts
@@ -1,10 +1,10 @@
-import nock from "nock";
-import * as utils from "./utils";
-import * as disableFlakyTestBot from "../pages/api/flaky-tests/disable";
 import dayjs from "dayjs";
-import { deepCopy, handleScope } from "./common";
-import { IssueData } from "lib/types";
 import { parseBody } from "lib/bot/verifyDisableTestIssueBot";
+import { IssueData } from "lib/types";
+import nock from "nock";
+import * as disableFlakyTestBot from "../pages/api/flaky-tests/disable";
+import { deepCopy, handleScope } from "./common";
+import * as utils from "./utils";
 
 nock.disableNetConnect();
 

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -1,23 +1,22 @@
-import nock from "nock";
-import * as updateDrciBot from "../pages/api/drci/drci";
+import dayjs from "dayjs";
+import * as drciUtils from "lib/drciUtils";
 import {
-  OH_URL,
   DOCS_URL,
   DRCI_COMMENT_START,
   formDrciComment,
   formDrciHeader,
-  getActiveSEVs,
   formDrciSevBody,
-  isInfraFlakyJob,
+  getActiveSEVs,
   HUD_URL,
+  OH_URL,
 } from "lib/drciUtils";
-import { IssueData, RecentWorkflowsData } from "lib/types";
-import dayjs from "dayjs";
-import { removeJobNameSuffix } from "lib/jobUtils";
-import * as fetchRecentWorkflows from "lib/fetchRecentWorkflows";
-import * as drciUtils from "lib/drciUtils";
-import * as jobUtils from "lib/jobUtils";
 import * as fetchPR from "lib/fetchPR";
+import * as fetchRecentWorkflows from "lib/fetchRecentWorkflows";
+import * as jobUtils from "lib/jobUtils";
+import { removeJobNameSuffix } from "lib/jobUtils";
+import { IssueData, RecentWorkflowsData } from "lib/types";
+import nock from "nock";
+import * as updateDrciBot from "../pages/api/drci/drci";
 
 nock.disableNetConnect();
 

--- a/torchci/test/drciBot.test.ts
+++ b/torchci/test/drciBot.test.ts
@@ -1,13 +1,12 @@
-import _ from "lodash";
-import { Probot } from "probot";
-import * as utils from "./utils";
-import nock from "nock";
-import myProbotApp from "../lib/bot/drciBot";
-import pytorchBot from "../lib/bot/pytorchBot";
 import * as drciUtils from "lib/drciUtils";
 import { OWNER, REPO } from "lib/drciUtils";
+import nock from "nock";
+import { Probot } from "probot";
+import myProbotApp from "../lib/bot/drciBot";
+import pytorchBot from "../lib/bot/pytorchBot";
 import { handleScope } from "./common";
 import { successfulA } from "./drci.test";
+import * as utils from "./utils";
 
 nock.disableNetConnect();
 

--- a/torchci/test/drciUtils.test.ts
+++ b/torchci/test/drciUtils.test.ts
@@ -1,17 +1,17 @@
-import {
-  hasSimilarFailures,
-  isInfraFlakyJob,
-  isExcludedFromFlakiness,
-  isLogClassifierFailed,
-  getSuppressedLabels,
-  MAX_SEARCH_HOURS_FOR_QUERYING_SIMILAR_FAILURES,
-} from "../lib/drciUtils";
-import * as searchUtils from "../lib/searchUtils";
-import * as jobUtils from "../lib/jobUtils";
+import { Client } from "@opensearch-project/opensearch";
+import dayjs from "dayjs";
 import { JobData, RecentWorkflowsData } from "lib/types";
 import nock from "nock";
-import dayjs from "dayjs";
-import { Client } from "@opensearch-project/opensearch";
+import {
+  getSuppressedLabels,
+  hasSimilarFailures,
+  isExcludedFromFlakiness,
+  isInfraFlakyJob,
+  isLogClassifierFailed,
+  MAX_SEARCH_HOURS_FOR_QUERYING_SIMILAR_FAILURES,
+} from "../lib/drciUtils";
+import * as jobUtils from "../lib/jobUtils";
+import * as searchUtils from "../lib/searchUtils";
 
 nock.disableNetConnect();
 

--- a/torchci/test/jobUtils.test.ts
+++ b/torchci/test/jobUtils.test.ts
@@ -1,25 +1,23 @@
 import {
-  removeJobNameSuffix,
-  isSameFailure,
-  isSameAuthor,
-  isSameContext,
-  removeCancelledJobAfterRetry,
-  isFailureFromPrevMergeCommit,
-  getDisabledTestIssues,
-  isRecentlyCloseDisabledTest,
-  isDisabledTest,
-  isDisabledTestMentionedInPR,
-} from "../lib/jobUtils";
-import {
-  JobData,
-  RecentWorkflowsData,
   BasicJobData,
   IssueData,
   PRandJobs,
+  RecentWorkflowsData,
 } from "lib/types";
 import nock from "nock";
-import dayjs from "dayjs";
 import * as getAuthors from "../lib/getAuthors";
+import {
+  getDisabledTestIssues,
+  isDisabledTest,
+  isDisabledTestMentionedInPR,
+  isFailureFromPrevMergeCommit,
+  isRecentlyCloseDisabledTest,
+  isSameAuthor,
+  isSameContext,
+  isSameFailure,
+  removeCancelledJobAfterRetry,
+  removeJobNameSuffix,
+} from "../lib/jobUtils";
 
 nock.disableNetConnect();
 

--- a/torchci/test/labelCommands.test.ts
+++ b/torchci/test/labelCommands.test.ts
@@ -1,8 +1,8 @@
+import pytorchBot from "lib/bot/pytorchBot";
 import nock from "nock";
 import * as probot from "probot";
-import * as utils from "./utils";
-import pytorchBot from "lib/bot/pytorchBot";
 import { handleScope } from "./common";
+import * as utils from "./utils";
 
 nock.disableNetConnect();
 

--- a/torchci/test/mergeCommands.test.ts
+++ b/torchci/test/mergeCommands.test.ts
@@ -1,9 +1,9 @@
+import { getFailureMessage, getMessage } from "lib/GeneralUtils";
 import nock from "nock";
 import * as probot from "probot";
-import * as utils from "./utils";
 import pytorchBot from "../lib/bot/pytorchBot";
 import { handleScope, requireDeepCopy } from "./common";
-import { getFailureMessage, getMessage } from "lib/GeneralUtils";
+import * as utils from "./utils";
 
 nock.disableNetConnect();
 

--- a/torchci/test/metricUtils.test.ts
+++ b/torchci/test/metricUtils.test.ts
@@ -1,9 +1,9 @@
+import { JobAnnotation, JobsPerCommitData } from "lib/types";
 import {
   approximateFailureByType,
   approximateFailureByTypePercent,
   BROKEN_TRUNK_THRESHOLD,
 } from "../lib/metricUtils";
-import { JobsPerCommitData, JobAnnotation } from "lib/types";
 
 describe("Approximate failures by its categories", () => {
   test("no data", () => {

--- a/torchci/test/retryBot.test.ts
+++ b/torchci/test/retryBot.test.ts
@@ -1,8 +1,8 @@
 import nock from "nock";
-import * as utils from "./utils";
+import { Probot } from "probot";
 import myProbotApp from "../lib/bot/retryBot";
 import { handleScope, requireDeepCopy } from "./common";
-import { Probot } from "probot";
+import * as utils from "./utils";
 
 nock.disableNetConnect();
 

--- a/torchci/test/searchUtils.test.ts
+++ b/torchci/test/searchUtils.test.ts
@@ -1,8 +1,8 @@
-import * as searchUtils from "../lib/searchUtils";
+import { Client } from "@opensearch-project/opensearch";
+import dayjs from "dayjs";
 import { JobData } from "lib/types";
 import nock from "nock";
-import dayjs from "dayjs";
-import { Client } from "@opensearch-project/opensearch";
+import * as searchUtils from "../lib/searchUtils";
 
 nock.disableNetConnect();
 

--- a/torchci/test/triggerCircleCIWorkflows.test.ts
+++ b/torchci/test/triggerCircleCIWorkflows.test.ts
@@ -1,9 +1,8 @@
 import { promises as fs } from "fs";
 import nock from "nock";
 import { Probot } from "probot";
-
-import * as utils from "./utils";
 import * as triggerCircleBot from "../lib/bot/triggerCircleCIWorkflows";
+import * as utils from "./utils";
 
 nock.disableNetConnect();
 

--- a/torchci/test/utils.ts
+++ b/torchci/test/utils.ts
@@ -1,4 +1,3 @@
-import { createAppAuth } from "@octokit/auth-app";
 import nock from "nock";
 import { Octokit } from "octokit";
 import { Probot, ProbotOctokit } from "probot";

--- a/torchci/test/verifyDisableTestIssue.test.ts
+++ b/torchci/test/verifyDisableTestIssue.test.ts
@@ -1,14 +1,14 @@
-import { Probot } from "probot";
-import * as utils from "./utils";
-import myProbotApp, * as bot from "../lib/bot/verifyDisableTestIssueBot";
+import _ from "lodash";
 import nock from "nock";
-import { requireDeepCopy, handleScope } from "./common";
-import {
-  pytorchBotId,
+import { Probot } from "probot";
+import * as bot from "../lib/bot/verifyDisableTestIssueBot";
+import myProbotApp, {
   disabledKey,
+  pytorchBotId,
   unstableKey,
 } from "../lib/bot/verifyDisableTestIssueBot";
-import _ from "lodash";
+import { handleScope, requireDeepCopy } from "./common";
+import * as utils from "./utils";
 
 nock.disableNetConnect();
 

--- a/torchci/yarn.lock
+++ b/torchci/yarn.lock
@@ -7205,6 +7205,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier-plugin-organize-imports@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.4.tgz#77967f69d335e9c8e6e5d224074609309c62845e"
+  integrity sha512-6m8WBhIp0dfwu0SkgfOxJqh+HpdyfqSSLfKKRZSFbDuEQXDDndb8fTpRWkUrX/uBenkex3MgnVk0J3b3Y5byog==
+
 prettier@2.6.2:
   version "2.6.2"
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz"


### PR DESCRIPTION
https://www.npmjs.com/package/prettier-plugin-organize-imports

Organize imports and automatically remove unused imports when running `yarn format`.  Sort of a follow up to https://github.com/pytorch/test-infra/pull/5256

Not entirely sure this is a good idea

First commit is changes to add the dep, second commit is running `yarn format`