### PR TITLE
Update manage.py - add build time dependencies

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -141,6 +141,8 @@ PACKAGE_ALLOW_LIST = {
     "urllib3",
     "xformers",
     "executorch",
+    "setuptools",
+    "wheel"
 }
 
 # Should match torch-2.0.0.dev20221221+cu118-cp310-cp310-linux_x86_64.whl as:


### PR DESCRIPTION
This allows 2 build time dependencies in download.pytorch.org, so we can potentially use our index only during the build:
https://github.com/pytorch/vision/blob/main/pyproject.toml#L18