### PR TITLE
Add CPU m4.10xlarge instance type for Inductor CPU FP32 accuracy test with AVX2

### DIFF
--- a/.github/arc-node-config.yaml
+++ b/.github/arc-node-config.yaml
@@ -50,6 +50,23 @@ nodeConfig:
       - key: "karpenter.sh/capacity-type"
         operator: In
         values: ["on-demand"]
+  - nodeType: compute-amd64-avx2
+    requirements:
+      - key: "karpenter.k8s.aws/instance-category"
+        operator: In
+        values: ["m4"]
+      - key: "karpenter.k8s.aws/instance-cpu"
+        operator: In
+        values: ["40"]
+      - key: "kubernetes.io/arch"
+        operator: In
+        values: ["amd64"]
+      - key: kubernetes.io/os
+        operator: In
+        values: ["linux"]
+      - key: "karpenter.sh/capacity-type"
+        operator: In
+        values: ["on-demand"]
   - nodeType: compute-amd64-avx512
     requirements:
       - key: "karpenter.k8s.aws/instance-category"

--- a/.github/arc-runner-config.yaml
+++ b/.github/arc-runner-config.yaml
@@ -15,6 +15,14 @@ runnerConfig:
     runnerLabel: linux.2xlarge
     containerMode: dind-rootless
     workingDiskSpace: 150Gi
+  - cpu: 20.0
+    maxRunners: 100
+    memory: 80Gi
+    minRunners: 0
+    nodeType: compute-amd64-avx2
+    runnerLabel: linux.10xlarge.avx2
+    containerMode: dind-rootless
+    workingDiskSpace: 200Gi
   - cpu: 16.0
     maxRunners: 100
     memory: 16Gi

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -27,11 +27,11 @@ runner_types:
     is_ephemeral: false
     max_available: 1000
     os: linux
-  linux.10xlarge:
+  linux.10xlarge.avx2:
     disk_size: 160
     instance_type: m4.10xlarge
     is_ephemeral: false
-    max_available: 30
+    max_available: 60
     os: linux
   linux.24xl.spr-metal:
     disk_size: 200

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -28,7 +28,7 @@ runner_types:
     max_available: 1000
     os: linux
   linux.10xlarge.avx2:
-    disk_size: 160
+    disk_size: 200
     instance_type: m4.10xlarge
     is_ephemeral: false
     max_available: 60

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -27,6 +27,12 @@ runner_types:
     is_ephemeral: false
     max_available: 1000
     os: linux
+  linux.10xlarge:
+    disk_size: 160
+    instance_type: m4.10xlarge
+    is_ephemeral: false
+    max_available: 30
+    os: linux
   linux.24xl.spr-metal:
     disk_size: 200
     instance_type: c7i.metal-24xl


### PR DESCRIPTION
Due to issue [#123224](https://github.com/pytorch/pytorch/issues/123224), we plan to add m4.10xlarge instance for testing inductor CPU FP32 accuracy with AVX2 ISA in Pytorch CI. We collected the time cost for running FP32 accuracy test on both m4.10xlarge and c5.12xlarge, and here is the results.
</head>
<body link=blue vlink=purple>

Config | Runner | Instance type | ISA | Price $/h | TB Acc /h | HF Acc /h | TIMM Acc /h | Total Time /h
-- | -- | -- | -- | -- | -- | -- | -- | -- 
1 | add in this PR | m4.10xlarge | AVX2 | 2 | 1.5 | 0.8 | 1.2 | 3.5
2 | linux.12xlarge | c5.12xlarge | AVX512, AVX2 | 2.04 | 1.5 | 0.5 | 0.6 | 2.6

</body>
</html>

Config 2 depends on PR [#123514](https://github.com/pytorch/pytorch/pull/123514) land, and if the inductor generates code which call oneDNN kernels, those kernels may not run with AVX2. So for AVX2 inductor tests, we prefer to add AVX2 only instance as new runner type. 

As we mentioned in PR #5089,  the average launch times/day of inductor cpu test is 174, and we can assume 70% ~ 100% tests can be completed. The base pricing of m4.10xlarge is **2 USD per hour**, so the average base cost of accuracy test running on m4.10xlarge is **852.6 ~ 1218**(174 * 3.5 * 2) USD per day