### PR TITLE
Add a page to navigate disabled issues on HUD

### DIFF
--- a/torchci/components/NavBar.tsx
+++ b/torchci/components/NavBar.tsx
@@ -64,6 +64,10 @@ function NavBar() {
       name: "TorchBench",
       href: "/torchbench/userbenchmark",
     },
+    {
+      name: "Disabled Tests",
+      href: "/disabled",
+    },
     // uncomment after some eyeballs are on this
     // {
     //   name: "Testing Overhead",

--- a/torchci/components/ValuePicker.tsx
+++ b/torchci/components/ValuePicker.tsx
@@ -1,0 +1,44 @@
+import {
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+} from "@mui/material";
+
+export default function ValuePicker({
+  value,
+  setValue,
+  values,
+  label,
+}: {
+  value: string;
+  setValue: any;
+  values: string[];
+  label: string;
+}) {
+  function handleChange(e: SelectChangeEvent<string>) {
+    setValue(e.target.value);
+  }
+
+  return (
+    <>
+      <FormControl>
+        <InputLabel id="value-picker-input-label">{label}</InputLabel>
+        <Select
+          value={value}
+          label={label}
+          labelId={`value-picker-select-label-${label}`}
+          onChange={handleChange}
+          id={`value-picker-select-${label}`}
+        >
+          {values.map((value) => (
+            <MenuItem key={value} value={value}>
+              {value}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </>
+  );
+}

--- a/torchci/pages/disabled.tsx
+++ b/torchci/pages/disabled.tsx
@@ -228,6 +228,7 @@ function DisabledTestsPanel({ queryParams }: { queryParams: RocksetParam[] }) {
             },
           ]}
           dataGridProps={{ getRowId: (el: any) => el.metadata.number }}
+          showFooter={true}
         />
       </Grid>
     </Grid>

--- a/torchci/pages/disabled.tsx
+++ b/torchci/pages/disabled.tsx
@@ -1,0 +1,397 @@
+import { Grid, Stack, Typography } from "@mui/material";
+import { GridCellParams, GridRenderCellParams } from "@mui/x-data-grid";
+import CopyLink from "components/CopyLink";
+import GranularityPicker from "components/GranularityPicker";
+import styles from "components/metrics.module.css";
+import { TablePanelWithData } from "components/metrics/panels/TablePanel";
+import TimeSeriesPanel, {
+  Granularity,
+} from "components/metrics/panels/TimeSeriesPanel";
+import ValuePicker from "components/ValuePicker";
+import dayjs from "dayjs";
+import { fetcher } from "lib/GeneralUtils";
+import { RocksetParam } from "lib/rockset";
+import _ from "lodash";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import useSWR from "swr";
+import { TimeRangePicker } from "./metrics";
+
+const MIN_ENTRIES = 10;
+const ROW_GAP = 30;
+const TABLE_ROW_HEIGHT = 48;
+const GRAPH_ROW_HEIGHT = 240;
+const DEFAULT_ISSUE_STATE = "open";
+const ISSUE_STATES = [DEFAULT_ISSUE_STATE, "closed"];
+const DEFAULT_PLATFORM = "All platforms";
+// Maybe figure out a better way to not hardcode this list here
+// https://github.com/pytorch/pytorch/blob/main/torch/testing/_internal/common_utils.py#L2266
+const PLATFORMS = [
+  DEFAULT_PLATFORM,
+  "asan",
+  "dynamo",
+  "inductor",
+  "linux",
+  "mac",
+  "rocm",
+  "slow",
+  "win",
+  "xpu",
+];
+const DEFAULT_LABEL = "All labels";
+const SKIPPED_LABEL = "skipped";
+const TRIAGED_LABEL = "triaged";
+const HIGH_PRIORITY_LABEL = "high priority";
+const ACCEPTED_LABELS_REGEX = new RegExp(
+  "^((module:s*.*)|(oncall:s*.*)|skipped)$"
+);
+const DEFAULT_TRIAGED_STATE = "both";
+const TRIAGED_STATES = [DEFAULT_TRIAGED_STATE, "yes", "no"];
+
+function getLabels(data: any) {
+  const acceptedLabels: string[] = [];
+  data.forEach((r: any) => {
+    if (r.label.match(ACCEPTED_LABELS_REGEX)) {
+      acceptedLabels.push(r.label !== SKIPPED_LABEL ? r.label : DEFAULT_LABEL);
+    }
+  });
+
+  return _.sortBy(_.uniq(acceptedLabels));
+}
+
+function generateDisabledTestsTable(data: any) {
+  const disabledTests: any = [];
+  data.forEach((r: any) => {
+    disabledTests.push({
+      metadata: {
+        number: r.number,
+        url: r.html_url,
+        triaged: r.labels.some((label: string) => label === TRIAGED_LABEL),
+        hiprio: r.labels.some((label: string) => label === HIGH_PRIORITY_LABEL),
+      },
+      title: r.title,
+      assignee: r.assignee,
+      timestamp: r.updated_at,
+    });
+  });
+  return _.sortBy(disabledTests, (r) => !r.metadata.hiprio);
+}
+
+function GraphPanel({ queryParams }: { queryParams: RocksetParam[] }) {
+  return (
+    <Grid item xs={12} lg={6} height={GRAPH_ROW_HEIGHT}>
+      <TimeSeriesPanel
+        title={"Total number of open disabled tests"}
+        queryName={"disabled_test_historical"}
+        queryCollection={"metrics"}
+        queryParams={[...queryParams]}
+        granularity={"day"}
+        timeFieldName={"granularity_bucket"}
+        yAxisFieldName={"number_of_open_disabled_tests"}
+        yAxisRenderer={(duration) => duration}
+      />
+    </Grid>
+  );
+}
+
+function DisabledTestsPanel({ queryParams }: { queryParams: RocksetParam[] }) {
+  const queryCollection = "commons";
+  const queryName = "disabled_tests";
+  const url = `/api/query/${queryCollection}/${queryName}?parameters=${encodeURIComponent(
+    JSON.stringify(queryParams)
+  )}`;
+
+  let { data, error } = useSWR(url, fetcher, {
+    refreshInterval: 60 * 60 * 1000, // refresh every hour
+  });
+
+  if (error) {
+    return (
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <Typography fontSize={"1rem"} fontStyle={"italic"}>
+          Failed to load disabled tests
+        </Typography>
+      </Stack>
+    );
+  }
+
+  if (data === undefined || data.length === 0) {
+    return (
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <Typography fontSize={"1rem"} fontStyle={"italic"}>
+          Loading disabled tests...
+        </Typography>
+      </Stack>
+    );
+  }
+
+  const disabledTests = generateDisabledTestsTable(data);
+  const minEntries =
+    disabledTests.length > MIN_ENTRIES ? data.length : MIN_ENTRIES;
+  return (
+    <Grid container spacing={2} style={{ height: "100%" }}>
+      <Grid
+        item
+        xs={12}
+        lg={12}
+        height={minEntries * TABLE_ROW_HEIGHT + ROW_GAP}
+      >
+        <TablePanelWithData
+          title={`Disabled tests (${disabledTests.length})`}
+          data={disabledTests}
+          columns={[
+            {
+              field: "metadata",
+              headerName: "GitHub Issue (⚠ ~ high priority)",
+              flex: 1,
+              cellClassName: (params: GridCellParams<any>) => {
+                return params.value.hiprio ? styles.warning : "";
+              },
+              renderCell: (params: GridRenderCellParams<any>) => {
+                const number = params.value.number;
+                const url = params.value.url;
+                const hiprio = params.value.hiprio ? "⚠" : "";
+
+                return (
+                  <>
+                    <a href={url}>
+                      <b>
+                        {hiprio} #{number}
+                      </b>
+                    </a>
+                  </>
+                );
+              },
+            },
+            {
+              field: "title",
+              headerName: "Disabled Test",
+              flex: 1,
+              renderCell: (params: GridRenderCellParams<any>) => {
+                return params.value.substring("DISABLED ".length);
+              },
+            },
+            {
+              field: "assignee",
+              headerName: "Assignee",
+              flex: 1,
+              renderCell: (params: GridRenderCellParams<any>) => {
+                return params.value !== null ? params.value : "";
+              },
+            },
+            {
+              field: "timestamp",
+              headerName: "Last Updated",
+              flex: 1,
+              renderCell: (params: GridRenderCellParams<any>) => {
+                return dayjs(params.value).toString();
+              },
+            },
+          ]}
+          dataGridProps={{ getRowId: (el: any) => el.metadata.number }}
+        />
+      </Grid>
+    </Grid>
+  );
+
+  return <></>;
+}
+
+export default function Page() {
+  const router = useRouter();
+
+  const defaultStartTime = dayjs().subtract(6, "month");
+  const [startTime, setStartTime] = useState(defaultStartTime);
+  const defaultStopTime = dayjs();
+  const [stopTime, setStopTime] = useState(defaultStopTime);
+  const [timeRange, setTimeRange] = useState<number>(180);
+  const [granularity, setGranularity] = useState<Granularity>("day");
+  const [baseUrl, setBaseUrl] = useState<string>("");
+
+  const [state, setState] = useState<string>(DEFAULT_ISSUE_STATE);
+  const [platform, setPlatform] = useState<string>(DEFAULT_PLATFORM);
+  const [label, setLabel] = useState<string>(DEFAULT_LABEL);
+  const [triaged, setTriaged] = useState<string>(DEFAULT_TRIAGED_STATE);
+
+  // Set the dropdown value what is in the param
+  useEffect(() => {
+    const startTime: string = (router.query.startTime as string) ?? undefined;
+    if (startTime !== undefined) {
+      setStartTime(dayjs(startTime));
+
+      if (dayjs(startTime).valueOf() !== defaultStartTime.valueOf()) {
+        setTimeRange(-1);
+      }
+    }
+
+    const stopTime: string = (router.query.stopTime as string) ?? undefined;
+    if (stopTime !== undefined) {
+      setStopTime(dayjs(stopTime));
+
+      if (dayjs(stopTime).valueOf() !== defaultStopTime.valueOf()) {
+        setTimeRange(-1);
+      }
+    }
+
+    const granularity: Granularity =
+      (router.query.granularity as Granularity) ?? undefined;
+    if (granularity !== undefined) {
+      setGranularity(granularity);
+    }
+
+    const state: string = (router.query.state as string) ?? undefined;
+    if (state !== undefined) {
+      setState(state);
+    }
+
+    const platform: string = (router.query.platform as string) ?? undefined;
+    if (platform !== undefined) {
+      setPlatform(platform);
+    }
+
+    const label: string = (router.query.label as string) ?? undefined;
+    if (label !== undefined) {
+      setLabel(label);
+    }
+
+    const triaged: string = (router.query.triaged as string) ?? undefined;
+    if (triaged !== undefined) {
+      setTriaged(triaged);
+    }
+
+    setBaseUrl(
+      `${window.location.protocol}//${
+        window.location.host
+      }${router.asPath.replace(/\?.+/, "")}`
+    );
+  }, [router.query]);
+
+  const queryParams: RocksetParam[] = [
+    {
+      name: "timezone",
+      type: "string",
+      value: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    },
+    {
+      name: "startTime",
+      type: "string",
+      value: startTime,
+    },
+    {
+      name: "stopTime",
+      type: "string",
+      value: stopTime,
+    },
+    {
+      name: "state",
+      type: "string",
+      value: state,
+    },
+    {
+      name: "platform",
+      type: "string",
+      value: platform !== DEFAULT_PLATFORM ? platform : "",
+    },
+    {
+      name: "label",
+      type: "string",
+      value: label !== DEFAULT_LABEL ? label : "skipped",
+    },
+    {
+      name: "triaged",
+      type: "string",
+      value: triaged !== DEFAULT_TRIAGED_STATE ? triaged : "",
+    },
+  ];
+
+  const queryCollection = "commons";
+  const queryName = "disabled_test_labels";
+  const url = `/api/query/${queryCollection}/${queryName}?parameters=${encodeURIComponent(
+    JSON.stringify(queryParams)
+  )}`;
+
+  let { data, error } = useSWR(url, fetcher, {
+    refreshInterval: 60 * 60 * 1000, // refresh every hour
+  });
+
+  if (error) {
+    return (
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <Typography fontSize={"1rem"} fontStyle={"italic"}>
+          Failed to load disabled test labels
+        </Typography>
+      </Stack>
+    );
+  }
+
+  if (data === undefined || data.length === 0) {
+    return (
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <Typography fontSize={"1rem"} fontStyle={"italic"}>
+          Loading disabled test labels...
+        </Typography>
+      </Stack>
+    );
+  }
+
+  // Get the list of labels from these disabled issues
+  const acceptLabels = getLabels(data);
+
+  return (
+    <div>
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <Typography fontSize={"2rem"} fontWeight={"bold"}>
+          PyTorch Disabled Tests DashBoard
+        </Typography>
+        <CopyLink
+          textToCopy={`${baseUrl}?startTime=${encodeURIComponent(
+            startTime.toString()
+          )}&stopTime=${encodeURIComponent(
+            stopTime.toString()
+          )}&granularity=${granularity}&state=${state}`}
+        />
+      </Stack>
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <TimeRangePicker
+          startTime={startTime}
+          setStartTime={setStartTime}
+          stopTime={stopTime}
+          setStopTime={setStopTime}
+          timeRange={timeRange}
+          setTimeRange={setTimeRange}
+          setGranularity={setGranularity}
+        />
+        <GranularityPicker
+          granularity={granularity}
+          setGranularity={setGranularity}
+        />
+        <ValuePicker
+          value={state}
+          setValue={setState}
+          values={ISSUE_STATES}
+          label={"State"}
+        />
+        <ValuePicker
+          value={platform}
+          setValue={setPlatform}
+          values={PLATFORMS}
+          label={"Platform"}
+        />
+        <ValuePicker
+          value={label}
+          setValue={setLabel}
+          values={acceptLabels}
+          label={"Label"}
+        />
+        <ValuePicker
+          value={triaged}
+          setValue={setTriaged}
+          values={TRIAGED_STATES}
+          label={"Triaged?"}
+        />
+      </Stack>
+      <GraphPanel queryParams={queryParams} />
+      <DisabledTestsPanel queryParams={queryParams} />
+    </div>
+  );
+}

--- a/torchci/pages/disabled.tsx
+++ b/torchci/pages/disabled.tsx
@@ -388,7 +388,9 @@ export default function Page() {
             startTime.toString()
           )}&stopTime=${encodeURIComponent(
             stopTime.toString()
-          )}&granularity=${granularity}&state=${state}&platform=${platform}&label=${label}&triaged=${triaged}`}
+          )}&granularity=${granularity}&state=${state}&platform=${platform}&label=${encodeURIComponent(
+            label
+          )}&triaged=${triaged}`}
         />
       </Stack>
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>

--- a/torchci/pages/disabled.tsx
+++ b/torchci/pages/disabled.tsx
@@ -95,7 +95,7 @@ function GraphPanel({ queryParams }: { queryParams: RocksetParam[] }) {
   return (
     <Grid item xs={12} lg={6} height={GRAPH_ROW_HEIGHT}>
       <TimeSeriesPanel
-        title={"Total number of open disabled tests"}
+        title={"Number of open disabled tests"}
         queryName={"disabled_test_historical"}
         queryCollection={"metrics"}
         queryParams={[...queryParams]}

--- a/torchci/rockset/commons/__sql/disabled_test_labels.sql
+++ b/torchci/rockset/commons/__sql/disabled_test_labels.sql
@@ -1,0 +1,22 @@
+--- This query returns the list of DISABLED tests labels.  This powers
+--- the disabled tests dashboard label dropdown list
+SELECT
+  DISTINCT labels.value.name AS label,
+FROM
+  commons.issues i,
+  UNNEST (i.labels AS value) AS labels
+WHERE
+  (
+    ARRAY_CONTAINS(
+      SPLIT(: states, ','),
+      i.state
+    )
+    OR : states = ''
+  )
+  AND i.repository_url = CONCAT(
+    'https://api.github.com/repos/',
+    : repo
+  )
+  AND i.title LIKE '%DISABLED%'
+ORDER BY
+  label ASC

--- a/torchci/rockset/commons/__sql/disabled_tests.sql
+++ b/torchci/rockset/commons/__sql/disabled_tests.sql
@@ -1,0 +1,68 @@
+--- This query returns the list of DISABLED tests together with their labels.  This powers
+--- the disabled tests dashboard, contributing them to their owners.
+WITH issues_with_labels AS (
+  SELECT
+    i.number,
+    i.title,
+    i.body,
+    ARRAY_AGG(labels.value.name) AS labels,
+    i.assignee.login AS assignee,
+    i.html_url,
+    i.updated_at,
+  FROM
+    commons.issues i,
+    UNNEST (i.labels AS value) AS labels
+  WHERE
+    (
+      i.state = : state
+      OR : state = ''
+    )
+    AND i.repository_url = CONCAT(
+      'https://api.github.com/repos/',
+      : repo
+    )
+    AND i.title LIKE '%DISABLED%'
+    AND (
+      : platform = ''
+      OR i.body LIKE CONCAT('%', : platform, '%')
+      OR (NOT i.body LIKE '%Platforms: %')
+    )
+  GROUP BY
+    i.number,
+    i.title,
+    i.body,
+    i.assignee.login,
+    i.html_url,
+    i.updated_at
+)
+SELECT
+  *
+FROM
+  issues_with_labels
+WHERE
+  ARRAY_CONTAINS(
+    issues_with_labels.labels, 'skipped'
+  )
+  AND (
+    : label = ''
+    OR ARRAY_CONTAINS(
+      issues_with_labels.labels, : label
+    )
+  )
+  AND (
+    : triaged = ''
+    OR (
+      : triaged = 'yes'
+      AND ARRAY_CONTAINS(
+        issues_with_labels.labels, 'triaged'
+      )
+    )
+    OR (
+      : triaged = 'no'
+      AND NOT ARRAY_CONTAINS(
+        issues_with_labels.labels, 'triaged'
+      )
+    )
+  )
+ORDER BY
+  issues_with_labels.updated_at DESC

--- a/torchci/rockset/commons/disabled_test_labels.lambda.json
+++ b/torchci/rockset/commons/disabled_test_labels.lambda.json
@@ -1,0 +1,16 @@
+{
+  "sql_path": "__sql/disabled_test_labels.sql",
+  "default_parameters": [
+    {
+      "name": "repo",
+      "type": "string",
+      "value": "pytorch/pytorch"
+    },
+    {
+      "name": "states",
+      "type": "string",
+      "value": "open"
+    }
+  ],
+  "description": "Query the list of DISABLED tests labels"
+}

--- a/torchci/rockset/commons/disabled_tests.lambda.json
+++ b/torchci/rockset/commons/disabled_tests.lambda.json
@@ -1,0 +1,31 @@
+{
+  "sql_path": "__sql/disabled_tests.sql",
+  "default_parameters": [
+    {
+      "name": "label",
+      "type": "string",
+      "value": ""
+    },
+    {
+      "name": "platform",
+      "type": "string",
+      "value": ""
+    },
+    {
+      "name": "repo",
+      "type": "string",
+      "value": "pytorch/pytorch"
+    },
+    {
+      "name": "state",
+      "type": "string",
+      "value": "open"
+    },
+    {
+      "name": "triaged",
+      "type": "string",
+      "value": ""
+    }
+  ],
+  "description": "Returns the list of DISABLED tests together with their labels"
+}

--- a/torchci/rockset/metrics/disabled_test_historical.lambda.json
+++ b/torchci/rockset/metrics/disabled_test_historical.lambda.json
@@ -7,6 +7,21 @@
       "value": "day"
     },
     {
+      "name": "label",
+      "type": "string",
+      "value": ""
+    },
+    {
+      "name": "platform",
+      "type": "string",
+      "value": ""
+    },
+    {
+      "name": "repo",
+      "type": "string",
+      "value": "pytorch/pytorch"
+    },
+    {
       "name": "startTime",
       "type": "string",
       "value": "2023-07-01T00:00:00.000Z"
@@ -25,6 +40,11 @@
       "name": "timezone",
       "type": "string",
       "value": "America/Los_Angeles"
+    },
+    {
+      "name": "triaged",
+      "type": "string",
+      "value": ""
     }
   ],
   "description": "Count the number of open disabled tests over time"

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -49,7 +49,7 @@
   },
   "metrics": {
     "correlation_matrix": "35c05e04047123f0",
-    "disabled_test_historical": "27c9ab055ba7a5ad",
+    "disabled_test_historical": "5f8764703b63d0c2",
     "disabled_test_total": "da5f834a6501fc63",
     "external_contribution_stats": "d98863128f502cdb",
     "job_duration_avg": "10a88ea2ebb80647",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -32,7 +32,9 @@
     "weekly_force_merge_stats": "d2264131599bcf6e",
     "pr_commits": "cc14c0d3a5091636",
     "test_time_per_class": "630fa1ba72a3222b",
-    "test_time_per_class_periodic_jobs": "c91054c7a10b377e"
+    "test_time_per_class_periodic_jobs": "c91054c7a10b377e",
+    "disabled_tests": "96202f2d01403a94",
+    "disabled_test_labels": "91098effa428d64a"
   },
   "pytorch_dev_infra_kpis": {
     "monthly_contribution_stats": "c1a8751a22f6b6ce",


### PR DESCRIPTION
This page displays the total number of active disabled tests and their break down by platforms, labels, and their triaged status.  By default, the table is sorted by high priority status and the issue last updated.  Hopefully, this will allow the test owners to better keep track of active disabled tests assigned to their teams.

The preview is at https://torchci-git-fork-huydhn-add-break-down-disa-507a79-fbopensource.vercel.app/disabled