### PR TITLE
[log classifier] More test failure rules

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -90,7 +90,7 @@ pattern = 'XPASS(?: \[.*\])?: (test.*) \((?:__main__\.)?(.*)\)'
 
 [[rule]]
 name = 'pytest failure'
-pattern = '^FAILED (?:\[.*s\] )?(\S*.py::\S*::test_\S*)'
+pattern = '^(FAILED|SUBFAIL) (?:\[.*s\] )?(\S*.py::\S*::test_\S*)'
 
 [[rule]]
 name = 'Python unittest error'
@@ -99,6 +99,10 @@ pattern = 'ERROR(?: \[.*\])?: (test.*) \((?:__main__\.)?(.*)\)'
 [[rule]]
 name = 'pytest test error'
 pattern = '^ERROR (?:\[.*s\] )?(\S*.py::\S*::test_\S*)'
+
+[[rule]]
+name = 'Fallback for other test failure rules'
+pattern = '^The following tests failed consistently: \[(.*)\]$'
 
 [[rule]]
 name = 'xla cpp test failure'
@@ -190,7 +194,7 @@ pattern = '!+ KeyboardInterrupt !+'
 
 [[rule]]
 name = 'Python Test File RuntimeError'
-pattern = '^RuntimeError: .*test.* failed'
+pattern = '(?:RuntimeError: )?.*test.* failed!'
 
 [[rule]]
 name = 'CUDA out of memory error'


### PR DESCRIPTION
* `SUBFAIL` is a new string I saw
* `The following tests failed consistently: ` is printed by run_test when tests fail consistently (mostly a fallback, I don't expect this to match often since the other rules for tests should match instead)
* `Runtime error` is not guaranteed to be raised, but `something/test_something failed! (maybe signal info here)` should still be printed

Example log that got match to the very generic `##[error]Process completed with exit code 1.` that any of the above changes should be able to handle
https://github.com/pytorch/pytorch/actions/runs/9352291906/job/25742364204
```
2024-06-03T15:38:03.2015505Z SUBFAIL [0.0000s] onnx/test_fx_op_consistency.py::TestOnnxModelOutputConsistency_opset_version_18_model_type_TorchModelType.TORCH_NN_MODULECPU::test_output_match__unsafe_masked_index_put_accumulate_cpu_float32 - onnxruntime.capi.onnxruntime_pybind11_state.InvalidArgument: [ONNXRuntimeError] : 2 : INVALID_ARGUMENT : Non-zero status code returned while running ScatterND node. Name:'_inlfunc_aten_index_put_n7_n0' Status Message: updates tensor should have shape equal to indices.shape[:-1] + data.shape[indices.shape[-1]:]. updates shape: {10,9,11}, indices shape: {10,1,1,1}, data shape: {5,5,5}
2024-06-03T15:38:03.2018945Z !!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 6 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
2024-06-03T15:38:03.2019575Z ================== 6 failed, 1 passed, 1 deselected in 2.55s ===================
2024-06-03T15:38:03.2020105Z Got exit code 1
2024-06-03T15:38:03.2020421Z Stopping at first consistent failure
2024-06-03T15:38:03.2022146Z The following tests failed consistently: ['test/onnx/test_fx_op_consistency.py::TestOnnxModelOutputConsistency_opset_version_18_model_type_TorchModelType.TORCH_NN_MODULECPU::test_output_match__unsafe_masked_index_put_accumulate_cpu_float32']
2024-06-03T15:38:03.2023516Z 
2024-06-03T15:38:03.2024283Z FINISHED PRINTING LOG FILE of onnx/test_fx_op_consistency 4/15 (test/test-reports/onnx.test_fx_op_consistency_4.15_8f420556de5f0fb1_.log)
2024-06-03T15:38:03.2025117Z 
2024-06-03T15:38:03.2025260Z onnx/test_fx_op_consistency 4/15 failed!
2024-06-03T15:38:03.2025683Z Emiting td_test_failure_stats_v2
2024-06-03T15:38:04.0704841Z onnx/test_fx_op_consistency 4/15 failed!
```