### PR TITLE
[HUD] All and inverse buttons for chart legends

### DIFF
--- a/torchci/components/metrics/panels/TimeSeriesPanel.tsx
+++ b/torchci/components/metrics/panels/TimeSeriesPanel.tsx
@@ -158,6 +158,16 @@ export function TimeSeriesPanelWithData({
         right: 10,
         top: "center",
         type: "scroll",
+        selector: [
+          {
+            type: "all",
+            title: "All",
+          },
+          {
+            type: "inverse",
+            title: "Inv",
+          },
+        ],
       },
       // @ts-ignore
       tooltip: {
@@ -173,6 +183,7 @@ export function TimeSeriesPanelWithData({
     },
     additionalOptions
   );
+  console.log(options);
 
   return (
     <Paper sx={{ p: 2, height: "100%" }} elevation={3}>

--- a/torchci/components/metrics/panels/TimeSeriesPanel.tsx
+++ b/torchci/components/metrics/panels/TimeSeriesPanel.tsx
@@ -183,7 +183,6 @@ export function TimeSeriesPanelWithData({
     },
     additionalOptions
   );
-  console.log(options);
 
   return (
     <Paper sx={{ p: 2, height: "100%" }} elevation={3}>

--- a/torchci/components/metrics/panels/TimeSeriesPanel.tsx
+++ b/torchci/components/metrics/panels/TimeSeriesPanel.tsx
@@ -158,16 +158,18 @@ export function TimeSeriesPanelWithData({
         right: 10,
         top: "center",
         type: "scroll",
-        selector: [
-          {
-            type: "all",
-            title: "All",
-          },
-          {
-            type: "inverse",
-            title: "Inv",
-          },
-        ],
+        ...(groupByFieldName !== undefined && {
+          selector: [
+            {
+              type: "all",
+              title: "All",
+            },
+            {
+              type: "inverse",
+              title: "Inv",
+            },
+          ],
+        }),
       },
       // @ts-ignore
       tooltip: {


### PR DESCRIPTION
Save my life by letting me quickly deselect everything in the historical queue times chart except the g5 runners

Adds all and inverse buttons for selecting the lines in the charts

Useful for charts that have tons of lines and you only care about one.

Most visibly prominent on the kpis page, but this should affect all charts

Ex queue times
<img width="855" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/2c4abea6-06c5-45ac-a93d-9032bd316e0a">


https://echarts.apache.org/en/option.html#legend.selector
Can't just use true for some reason, the buttons disappear (on rerender? not sure)