### PR TITLE
Fix labels race condition

### DIFF
--- a/torchci/lib/bot/verifyDisableTestIssueBot.ts
+++ b/torchci/lib/bot/verifyDisableTestIssueBot.ts
@@ -290,7 +290,7 @@ export default function verifyDisableTestIssueBot(app: Probot): void {
       // check labels, add labels as needed
       let expectedLabels = getExpectedLabels(platformsToSkip, labels);
       if (!_.isEqual(new Set(expectedLabels), new Set(labels))) {
-        await context.octokit.issues.setLabels({
+        await context.octokit.issues.addLabels({
           owner,
           repo,
           issue_number: number,

--- a/torchci/lib/bot/verifyDisableTestIssueBot.ts
+++ b/torchci/lib/bot/verifyDisableTestIssueBot.ts
@@ -45,16 +45,22 @@ async function getValidationComment(
   return [0, ""];
 }
 
-export function getExpectedLabels(
+// Returns the platform labels that are expected, and invalid labels that we do not expect to be there
+export function getExpectedPlatformLabels(
   platforms: string[],
   labels: string[]
-): string[] {
+): [string[], string[]] {
   let supportedPlatformLabels = Array.from(supportedPlatforms.values()).flat();
-  let nonIssuePlatformLabels = labels.filter(
-    (label) => !supportedPlatformLabels.includes(label)
+  let existingPlatformLabels = labels.filter((label) =>
+    supportedPlatformLabels.includes(label)
   );
   let expectedPlatformLabels = getPlatformLabels(platforms);
-  return nonIssuePlatformLabels.concat(expectedPlatformLabels);
+  // everything in labels that's not in expectedLabels is invalid
+  let invalidPlatformLabels = _.difference(
+    existingPlatformLabels,
+    expectedPlatformLabels
+  );
+  return [expectedPlatformLabels, invalidPlatformLabels];
 }
 
 export function parseBody(body: string) {
@@ -103,7 +109,6 @@ export function parseTitle(title: string, prefix: string): string {
 
 function testNameIsExpected(testName: string): boolean {
   const split = testName.split(/\s+/);
-  console.log(split);
   if (split.length !== 2) {
     return false;
   }
@@ -288,13 +293,23 @@ export default function verifyDisableTestIssueBot(app: Probot): void {
       });
     } else {
       // check labels, add labels as needed
-      let expectedLabels = getExpectedLabels(platformsToSkip, labels);
-      if (!_.isEqual(new Set(expectedLabels), new Set(labels))) {
+      let [expectedPlatformLabels, invalidPlatformLabels] =
+        getExpectedPlatformLabels(platformsToSkip, labels);
+      let labelsSet = new Set(labels);
+      if (!expectedPlatformLabels.every((label) => labelsSet.has(label))) {
         await context.octokit.issues.addLabels({
           owner,
           repo,
           issue_number: number,
-          labels: expectedLabels,
+          labels: expectedPlatformLabels,
+        });
+      }
+      for (const invalidLabel of invalidPlatformLabels) {
+        await context.octokit.issues.removeLabel({
+          owner,
+          repo,
+          issue_number: number,
+          name: invalidLabel,
         });
       }
     }

--- a/torchci/test/verifyDisableTestIssue.test.ts
+++ b/torchci/test/verifyDisableTestIssue.test.ts
@@ -318,28 +318,31 @@ describe("verify-disable-test-issue", () => {
   });
 
   test("various getExpectedLabels tests", async () => {
-    expect(await bot.getExpectedLabels(["linux"], ["random"])).toEqual([
-      "random",
-    ]);
-    expect(await bot.getExpectedLabels(["inductor"], ["random"])).toEqual([
-      "random",
-      "oncall: pt2",
+    expect(await bot.getExpectedPlatformLabels(["linux"], ["random"])).toEqual([
+      [],
+      [],
     ]);
     expect(
-      await bot.getExpectedLabels(["linux"], ["random", "module: rocm"])
-    ).toEqual(["random"]);
+      await bot.getExpectedPlatformLabels(["inductor"], ["random"])
+    ).toEqual([["oncall: pt2"], []]);
     expect(
-      await bot.getExpectedLabels(["rocm"], ["random", "module: rocm"])
-    ).toEqual(["random", "module: rocm"]);
+      await bot.getExpectedPlatformLabels(["linux"], ["random", "module: rocm"])
+    ).toEqual([[], ["module: rocm"]]);
     expect(
-      await bot.getExpectedLabels(
+      await bot.getExpectedPlatformLabels(["rocm"], ["random", "module: rocm"])
+    ).toEqual([["module: rocm"], []]);
+    expect(
+      await bot.getExpectedPlatformLabels(
         ["dynamo", "inductor"],
         ["random", "module: rocm"]
       )
-    ).toEqual(["random", "oncall: pt2"]);
+    ).toEqual([["oncall: pt2"], ["module: rocm"]]);
     expect(
-      await bot.getExpectedLabels(["linux", "rocm"], ["random", "module: rocm"])
-    ).toEqual(["random"]);
+      await bot.getExpectedPlatformLabels(
+        ["linux", "rocm"],
+        ["random", "module: rocm"]
+      )
+    ).toEqual([[], ["module: rocm"]]);
   });
 });
 
@@ -464,7 +467,11 @@ describe("verify-disable-test-issue-bot", () => {
       )
       .reply(200)
       .post(`/repos/${owner}/${repo}/issues/${number}/labels`, (body) =>
-        _.isEqual(body.labels, ["random label", "module: rocm"])
+        _.isEqual(body.labels, ["module: rocm"])
+      )
+      .reply(200, [])
+      .delete(
+        `/repos/${owner}/${repo}/issues/${number}/labels/module%3A%20windows`
       )
       .reply(200, []);
 

--- a/torchci/test/verifyDisableTestIssue.test.ts
+++ b/torchci/test/verifyDisableTestIssue.test.ts
@@ -428,7 +428,7 @@ describe("verify-disable-test-issue-bot", () => {
         (body) => !body.body.includes("don't have permission")
       )
       .reply(200)
-      .put(`/repos/${owner}/${repo}/issues/${number}/labels`, (body) =>
+      .post(`/repos/${owner}/${repo}/issues/${number}/labels`, (body) =>
         _.isEqual(body.labels, ["module: rocm"])
       )
       .reply(200, []);
@@ -463,7 +463,7 @@ describe("verify-disable-test-issue-bot", () => {
         (body) => !body.body.includes("don't have permission")
       )
       .reply(200)
-      .put(`/repos/${owner}/${repo}/issues/${number}/labels`, (body) =>
+      .post(`/repos/${owner}/${repo}/issues/${number}/labels`, (body) =>
         _.isEqual(body.labels, ["random label", "module: rocm"])
       )
       .reply(200, []);

--- a/torchci/test/verifyDisableTestIssue.test.ts
+++ b/torchci/test/verifyDisableTestIssue.test.ts
@@ -317,7 +317,7 @@ describe("verify-disable-test-issue", () => {
     expect(comment.includes("ERROR")).toBeFalsy();
   });
 
-  test("various getExpectedLabels tests", async () => {
+  test("various getExpectedPlatformLabels tests", async () => {
     expect(await bot.getExpectedPlatformLabels(["linux"], ["random"])).toEqual([
       [],
       [],


### PR DESCRIPTION
Fixes https://github.com/pytorch/test-infra/issues/5220

The getExpectedLabels test would return all labels that were expected to be on the issue, risking race conditions.

Now it instead returns:
1. The platform labels that are expected to be on the issue
2. Any platform labels that are erroneously on the issue and should be removed