### PR TITLE
Add a new section on Dr.CI for canncelled jobs

### DIFF
--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -603,20 +603,51 @@ export function constructResultsComment(
   if (!hasAnyFailing) {
     output += `\n:green_heart: Looks good so far! There are no failures yet. :green_heart:`;
   }
-  output += constructResultsJobsSections(
-    hudBaseUrl,
-    owner,
-    repo,
-    prNumber,
-    `NEW ${pluralize("FAILURE", failedJobs.length).toLocaleUpperCase()}`,
-    `The following ${failedJobs.length > 1 ? "jobs have" : "job has"} failed`,
-    failedJobs,
-    "",
-    false,
-    relatedJobs,
-    relatedIssues,
-    relatedInfo
+
+  const newFailedJobs: RecentWorkflowsData[] = failedJobs.filter(
+    (job) => job.conclusion !== "cancelled"
   );
+  if (newFailedJobs.length) {
+    output += constructResultsJobsSections(
+      hudBaseUrl,
+      owner,
+      repo,
+      prNumber,
+      `NEW ${pluralize("FAILURE", newFailedJobs.length).toLocaleUpperCase()}`,
+      `The following ${
+        newFailedJobs.length > 1 ? "jobs have" : "job has"
+      } failed`,
+      newFailedJobs,
+      "",
+      false,
+      relatedJobs,
+      relatedIssues,
+      relatedInfo
+    );
+  }
+
+  const cancelledJobs: RecentWorkflowsData[] = failedJobs.filter(
+    (job) => job.conclusion === "cancelled"
+  );
+  if (cancelledJobs.length) {
+    output += constructResultsJobsSections(
+      hudBaseUrl,
+      owner,
+      repo,
+      prNumber,
+      `CANCELLED ${pluralize("JOB", cancelledJobs.length).toLocaleUpperCase()}`,
+      `The following ${
+        cancelledJobs.length > 1 ? "jobs were" : "job was"
+      } cancelled. Please retry`,
+      cancelledJobs,
+      "",
+      true,
+      relatedJobs,
+      relatedIssues,
+      relatedInfo
+    );
+  }
+
   output += constructResultsJobsSections(
     hudBaseUrl,
     owner,


### PR DESCRIPTION
This groups all cancelled jobs on Dr.CI into a separate collapsible section to avoid clutter the view.  Cancelled jobs are still treated as new failures from mergebot point-of-view.

### Testing

https://github.com/pytorch/pytorch/pull/126717

## :x: 1 Cancelled Job, 1 Unrelated Failure
As of commit 1509f7c2cc07e9d921d0e9dd66c7435b3f01be52 with merge base a7c596870d92f15cf723f53139bf1a63ac6da4a2 (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1717624429?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details ><summary><b>CANCELLED JOB</b> - The following job was cancelled. Please retry:</summary><p>

* [inductor / cuda12.1-py3.10-gcc9-sm80 / test (inductor_torchbench_smoketest_perf, 1, 1, linux.gcp.a100)](https://hud.pytorch.org/pr/pytorch/pytorch/126717#25866261671) ([gh](https://github.com/pytorch/pytorch/actions/runs/9391917998/job/25866261671))
</p></details>
<details ><summary><b>UNSTABLE</b> - The following job failed but was likely due to flakiness present on trunk and has been marked as unstable:</summary><p>

* [inductor / cuda12.1-py3.10-gcc9-sm86 / test (dynamic_inductor_timm, 2, 2, linux.g5.4xlarge.nvidia.gpu, unstable)](https://hud.pytorch.org/pr/pytorch/pytorch/126717#25866260212) ([gh](https://github.com/pytorch/pytorch/actions/runs/9391917998/job/25866260212)) ()
    `sebotnet33ts_256`
</p></details>

https://github.com/pytorch/pytorch/pull/127232

## :x: 1 New Failure, 85 Cancelled Jobs, 5 Unrelated Failures
As of commit 1bad649fdb1ae7e502c19b81810a5dec53f6cac3 with merge base 2dd269986027ea25c092f769ef8e9524920aaef6 (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1716370385?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details open><summary><b>NEW FAILURE</b> - The following job has failed:</summary><p>

* [trunk / macos-13-py3-arm64 / build](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25901568357) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909439/job/25901568357))
    `/Users/ec2-user/runner/_work/pytorch/pytorch/c10/util/StringUtil.cpp:45:8: error: 'wstring_convert<std::codecvt_utf8_utf16<wchar_t>>' is deprecated [-Werror,-Wdeprecated-declarations]`
</p></details>
<details ><summary><b>CANCELLED JOBS</b> - The following jobs were cancelled. Please retry:</summary><p>

* [inductor / cuda12.1-py3.10-gcc9-sm86](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902984020) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909746/job/25902984020))
* [inductor / cuda12.1-py3.10-gcc9-sm86 / build](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25901569488) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909746/job/25901569488))
    `##[error]The operation was canceled.`
* [inductor / cuda12.1-py3.12-gcc9-sm86 / build](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25901569828) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909746/job/25901569828))
    `##[error]The operation was canceled.`
* [inductor / linux-jammy-cpu-py3.8-gcc11-inductor / test (cpu_inductor_huggingface, 1, 1, linux.12xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902380967) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909746/job/25902380967))
    `##[error]The operation was canceled.`
* [inductor / linux-jammy-cpu-py3.8-gcc11-inductor / test (cpu_inductor_timm, 1, 2, linux.12xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902381342) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909746/job/25902381342))
    `##[error]The operation was canceled.`
* [inductor / linux-jammy-cpu-py3.8-gcc11-inductor / test (cpu_inductor_timm, 2, 2, linux.12xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902381658) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909746/job/25902381658))
    `##[error]The operation was canceled.`
* [inductor / linux-jammy-cpu-py3.8-gcc11-inductor / test (cpu_inductor_torchbench, 1, 2, linux.12xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902382136) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909746/job/25902382136))
    `##[error]The operation was canceled.`
* [inductor / linux-jammy-cpu-py3.8-gcc11-inductor / test (cpu_inductor_torchbench, 2, 2, linux.12xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902382572) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909746/job/25902382572))
    `##[error]The operation was canceled.`
* [inductor / linux-jammy-cpu-py3.8-gcc11-inductor / test (dynamic_cpu_inductor_huggingface, 1, 1, linux.12xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902382871) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909746/job/25902382871))
    `##[error]The operation was canceled.`
* [inductor / linux-jammy-cpu-py3.8-gcc11-inductor / test (dynamic_cpu_inductor_timm, 1, 2, linux.12xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902383214) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909746/job/25902383214))
    `##[error]The operation was canceled.`
* [inductor / linux-jammy-cpu-py3.8-gcc11-inductor / test (dynamic_cpu_inductor_timm, 2, 2, linux.12xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902383528) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909746/job/25902383528))
    `##[error]The operation was canceled.`
* [inductor / linux-jammy-cpu-py3.8-gcc11-inductor / test (dynamic_cpu_inductor_torchbench, 1, 2, linux.12xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902383915) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909746/job/25902383915))
    `##[error]The operation was canceled.`
* [inductor / linux-jammy-cpu-py3.8-gcc11-inductor / test (dynamic_cpu_inductor_torchbench, 2, 2, linux.12xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902384232) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909746/job/25902384232))
    `##[error]The operation was canceled.`
* [inductor / rocm6.1-py3.8-inductor](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902989004) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909746/job/25902989004))
* [inductor / rocm6.1-py3.8-inductor / build](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25901568701) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909746/job/25901568701))
    `##[error]The operation was canceled.`
* [inductor-periodic / cuda12.1-py3.10-gcc9-sm86-periodic-dynamo-benchmarks / build](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25901568286) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909744/job/25901568286))
    `##[error]The operation was canceled.`
* [linux-binary-libtorch-cxx11-abi / libtorch-cpu-shared-with-deps-cxx11-abi-build / build](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25901566650) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909408/job/25901566650))
    `##[error]The operation was canceled.`
* [linux-binary-libtorch-cxx11-abi / libtorch-cpu-shared-with-deps-cxx11-abi-test](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902985021) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909408/job/25902985021))
* [linux-binary-libtorch-pre-cxx11 / libtorch-cpu-shared-with-deps-pre-cxx11-build / build](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25901566588) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909418/job/25901566588))
    `##[error]The operation was canceled.`
* [linux-binary-libtorch-pre-cxx11 / libtorch-cpu-shared-with-deps-pre-cxx11-test](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902993274) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909418/job/25902993274))
* [linux-binary-manywheel / manywheel-py3_8-cuda11_8-build / build](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25901567016) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909414/job/25901567016))
    `##[error]The operation was canceled.`
* [linux-binary-manywheel / manywheel-py3_8-cuda11_8-test](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902993339) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909414/job/25902993339))
* [linux-binary-manywheel / manywheel-py3_8-cuda12_1-build / build](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25901566622) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909414/job/25901566622))
    `##[error]The operation was canceled.`
* [linux-binary-manywheel / manywheel-py3_8-cuda12_1-test](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902994949) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909414/job/25902994949))
* [pull / linux-docs / build-docs-python-false](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902371984) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902371984))
    `##[error]The operation was canceled.`
* [pull / linux-focal-cpu-py3.10-gcc9-bazel-test / build-and-test (default, 1, 1, linux.4xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25901587810) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25901587810))
    `##[error]The operation was canceled.`
* [pull / linux-focal-cuda11.8-py3.10-gcc9 / test (distributed, 1, 3, linux.8xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902954918) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902954918))
    `##[error]The operation was canceled.`
* [pull / linux-focal-cuda11.8-py3.10-gcc9 / test (distributed, 2, 3, linux.8xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902955275) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902955275))
    `##[error]The operation was canceled.`
* [pull / linux-focal-cuda11.8-py3.10-gcc9 / test (distributed, 3, 3, linux.8xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902955583) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902955583))
    `##[error]The operation was canceled.`
* [pull / linux-focal-cuda12.1-py3.10-gcc9 / test (default, 1, 5, linux.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902893816) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902893816))
* [pull / linux-focal-cuda12.1-py3.10-gcc9 / test (default, 2, 5, linux.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902894347) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902894347))
* [pull / linux-focal-cuda12.1-py3.10-gcc9 / test (default, 3, 5, linux.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902894804) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902894804))
* [pull / linux-focal-cuda12.1-py3.10-gcc9 / test (default, 4, 5, linux.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902895264) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902895264))
* [pull / linux-focal-cuda12.1-py3.10-gcc9 / test (default, 5, 5, linux.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902895819) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902895819))
* [pull / linux-focal-cuda12.1-py3.10-gcc9 / test (deploy, 1, 1, linux.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902896172) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902896172))
* [pull / linux-focal-cuda12.1-py3.10-gcc9-bazel-test / build-and-test (default, 1, 1, linux.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25901587421) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25901587421))
    `##[error]The operation was canceled.`
* [pull / linux-focal-cuda12.1-py3.10-gcc9-sm86](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902985566) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902985566))
* [pull / linux-focal-cuda12.1-py3.10-gcc9-sm86 / build](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25901569517) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25901569517))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3_8-clang9-xla / test (xla, 1, 1, linux.12xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902810843) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902810843))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3-clang9-android-ndk-r21e-gradle-custom-build-single-full-jit / build-and-test (default, 1, 1, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25901589375) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25901589375))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.11-clang10 / test (crossref, 1, 2, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902298336) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902298336))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.11-clang10 / test (crossref, 2, 2, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902298792) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902298792))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.11-clang10 / test (default, 1, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902297163) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902297163))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.11-clang10 / test (default, 2, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902297564) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902297564))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.11-clang10 / test (default, 3, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902297957) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902297957))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.11-clang10 / test (dynamo, 1, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902299171) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902299171))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.11-clang10 / test (dynamo, 2, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902299492) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902299492))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.11-clang10 / test (dynamo, 3, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902299863) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902299863))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.12-clang10 / test (default, 1, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902256347) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902256347))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.12-clang10 / test (default, 2, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902256630) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902256630))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.12-clang10 / test (default, 3, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902256911) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902256911))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.12-clang10 / test (dynamo, 1, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902257220) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902257220))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.12-clang10 / test (dynamo, 2, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902257484) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902257484))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.12-clang10 / test (dynamo, 3, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902257721) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902257721))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.8-clang10 / test (crossref, 1, 2, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902280736) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902280736))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.8-clang10 / test (crossref, 2, 2, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902281138) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902281138))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.8-clang10 / test (default, 1, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902279565) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902279565))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.8-clang10 / test (default, 2, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902279987) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902279987))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.8-clang10 / test (default, 3, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902280346) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902280346))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.8-clang10 / test (dynamo, 1, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902281542) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902281542))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.8-clang10 / test (dynamo, 2, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902281891) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902281891))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.8-clang10 / test (dynamo, 3, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902282229) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902282229))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.8-clang10-onnx / test (default, 1, 2, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902252563) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902252563))
    `##[error]The operation was canceled.`
* [pull / linux-focal-py3.8-clang10-onnx / test (default, 2, 2, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902252944) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902252944))
    `##[error]The operation was canceled.`
* [pull / linux-focal-rocm6.1-py3.8 / build](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25901572196) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25901572196))
    `##[error]The operation was canceled.`
* [pull / linux-jammy-cuda11.8-cudnn8-py3.8-clang12 / build](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25901567566) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25901567566))
    `##[error]The operation was canceled.`
* [pull / linux-jammy-py3-clang12-executorch / test (executorch, 1, 1, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902411462) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902411462))
    `##[error]The operation was canceled.`
* [pull / linux-jammy-py3.10-clang15-asan / test (default, 1, 6, linux.4xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902324496) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902324496))
    `##[error]The operation was canceled.`
* [pull / linux-jammy-py3.10-clang15-asan / test (default, 2, 6, linux.4xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902324991) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902324991))
    `##[error]The operation was canceled.`
* [pull / linux-jammy-py3.10-clang15-asan / test (default, 3, 6, linux.4xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902325508) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902325508))
    `##[error]The operation was canceled.`
* [pull / linux-jammy-py3.10-clang15-asan / test (default, 4, 6, linux.4xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902326015) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902326015))
    `##[error]The operation was canceled.`
* [pull / linux-jammy-py3.10-clang15-asan / test (default, 5, 6, linux.4xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902326477) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902326477))
    `##[error]The operation was canceled.`
* [pull / linux-jammy-py3.10-clang15-asan / test (default, 6, 6, linux.4xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902326946) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902326946))
    `##[error]The operation was canceled.`
* [pull / linux-jammy-py3.8-gcc11 / test (backwards_compat, 1, 1, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902373740) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902373740))
    `##[error]The operation was canceled.`
* [pull / linux-jammy-py3.8-gcc11 / test (default, 1, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902370168) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902370168))
    `##[error]The operation was canceled.`
* [pull / linux-jammy-py3.8-gcc11 / test (default, 2, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902370617) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902370617))
    `##[error]The operation was canceled.`
* [pull / linux-jammy-py3.8-gcc11 / test (default, 3, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902371491) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902371491))
    `##[error]The operation was canceled.`
* [pull / linux-jammy-py3.8-gcc11 / test (distributed, 1, 2, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902374098) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902374098))
    `##[error]The operation was canceled.`
* [pull / linux-jammy-py3.8-gcc11 / test (distributed, 2, 2, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902374661) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403908109/job/25902374661))
    `##[error]The operation was canceled.`
* [trunk / libtorch-linux-focal-cuda12.1-py3.7-gcc9-debug / build](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25901567550) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909439/job/25901567550))
    `##[error]The operation was canceled.`
* [trunk / linux-focal-cuda12.1-py3.10-gcc9 / test (jit_legacy, 1, 1, linux.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902869371) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909439/job/25902869371))
* [trunk / linux-focal-cuda12.1-py3.10-gcc9 / test (nogpu_AVX512, 1, 1, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902868725) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909439/job/25902868725))
    `##[error]The operation was canceled.`
* [trunk / linux-focal-cuda12.1-py3.10-gcc9 / test (nogpu_NO_AVX2, 1, 1, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902869026) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909439/job/25902869026))
    `##[error]The operation was canceled.`
* [trunk / linux-focal-rocm6.1-py3.8 / build](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25901567076) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909439/job/25901567076))
    `##[error]The operation was canceled.`
* [trunk / pytorch-linux-focal-py3-clang9-android-ndk-r21e-build / build (default, 1, 1, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25901588077) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909439/job/25901588077))
    `##[error]The operation was canceled.`
</p></details>
<details ><summary><b>FLAKY</b> - The following jobs failed but were likely due to flakiness present on trunk:</summary><p>

* [trunk / win-vs2019-cpu-py3 / test (default, 1, 3, windows.4xlarge.nonephemeral)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902748235) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909439/job/25902748235)) (matched **win** rule in [flaky-rules.json](https://github.com/pytorch/test-infra/blob/generated-stats/stats/flaky-rules.json))
    `##[error]The operation was canceled.`
* [trunk / win-vs2019-cpu-py3 / test (default, 2, 3, windows.4xlarge.nonephemeral)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902748571) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909439/job/25902748571)) (matched **win** rule in [flaky-rules.json](https://github.com/pytorch/test-infra/blob/generated-stats/stats/flaky-rules.json))
    `##[error]The operation was canceled.`
* [trunk / win-vs2019-cpu-py3 / test (default, 3, 3, windows.4xlarge.nonephemeral)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902748845) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909439/job/25902748845)) (matched **win** rule in [flaky-rules.json](https://github.com/pytorch/test-infra/blob/generated-stats/stats/flaky-rules.json))
    `##[error]The operation was canceled.`
* [trunk / win-vs2019-cuda11.8-py3 / build](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25901569184) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909439/job/25901569184)) (matched **win** rule in [flaky-rules.json](https://github.com/pytorch/test-infra/blob/generated-stats/stats/flaky-rules.json))
    `##[error]The operation was canceled.`
</p></details>
<details ><summary><b>UNSTABLE</b> - The following job failed but was likely due to flakiness present on trunk and has been marked as unstable:</summary><p>

* [inductor / linux-jammy-cpu-py3.8-gcc11-inductor / test (inductor_torchbench_cpu_smoketest_perf, 1, 1, linux.24xl.spr-metal, unstable)](https://hud.pytorch.org/pr/pytorch/pytorch/127232#25902384532) ([gh](https://github.com/pytorch/pytorch/actions/runs/9403909746/job/25902384532)) ([#126993](https://hud.pytorch.org/pytorch/pytorch/issues/126993))
    `##[error]The operation was canceled.`
</p></details>