### PR TITLE
[mergebot] Set mergebot to be configured via config

### DIFF
--- a/torchci/lib/bot/pytorchBot.ts
+++ b/torchci/lib/bot/pytorchBot.ts
@@ -1,8 +1,11 @@
 import { Probot } from "probot";
 import { getInputArgs } from "./cliParser";
 import PytorchBotHandler from "./pytorchBotHandler";
+import { CachedConfigTracker } from "./utils";
 
 function pytorchBot(app: Probot): void {
+  const cachedConfigTracker = new CachedConfigTracker(app);
+
   app.on("issue_comment.created", async (ctx) => {
     const commentBody = ctx.payload.comment.body;
     const owner = ctx.payload.repository.owner.login;
@@ -20,6 +23,7 @@ function pytorchBot(app: Probot): void {
       commentId,
       commentBody,
       useReactions: true,
+      cachedConfigTracker,
     });
     const is_pr_comment = ctx.payload.issue.pull_request != null;
     const skipUsers = [
@@ -57,6 +61,7 @@ function pytorchBot(app: Probot): void {
         commentId,
         commentBody: reviewBody ?? "",
         useReactions: false,
+        cachedConfigTracker,
       });
       if (reviewBody == null) {
         return;

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -248,7 +248,7 @@ The explanation needs to be clear on why this is needed. Here are some good exam
     ic: boolean
   ) {
     const config: any = await this.cachedConfigTracker.loadConfig(this.ctx);
-    if (config == null || config["mergebot"] == null) {
+    if (config == null || !config["mergebot"]) {
       await this.handleConfused(
         true,
         "Mergebot is not configured for this repository. Please use the merge button provided by GitHub."

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -7,6 +7,7 @@ import { cherryPickClassifications } from "./Constants";
 import PytorchBotLogger from "./pytorchbotLogger";
 import {
   addLabels,
+  CachedConfigTracker,
   hasApprovedPullRuns,
   hasWritePermissions as _hasWP,
   isFirstTimeContributor,
@@ -27,6 +28,7 @@ export interface PytorchbotParams {
   commentId: number;
   commentBody: string;
   useReactions: boolean;
+  cachedConfigTracker: CachedConfigTracker;
 }
 
 const PR_COMMENTED = "commented";
@@ -45,6 +47,7 @@ class PytorchBotHandler {
   login: string;
   commentBody: string;
   headSha: string | undefined;
+  cachedConfigTracker: CachedConfigTracker;
 
   forceMergeMessagePat = new RegExp("^\\s*\\S+\\s+\\S+.*");
 
@@ -60,6 +63,7 @@ class PytorchBotHandler {
     this.commentId = params.commentId;
     this.commentBody = params.commentBody;
     this.useReactions = params.useReactions;
+    this.cachedConfigTracker = params.cachedConfigTracker;
 
     this.logger = new PytorchBotLogger(params);
   }
@@ -243,6 +247,15 @@ The explanation needs to be clear on why this is needed. Here are some good exam
     rebase: string | boolean,
     ic: boolean
   ) {
+    const config: any = await this.cachedConfigTracker.loadConfig(this.ctx);
+    if (config == null || config["mergebot"] == null) {
+      await this.handleConfused(
+        true,
+        "Mergebot is not configured for this repository. Please use the merge button provided by GitHub."
+      );
+      return;
+    }
+
     const extra_data = {
       forceMessage,
       rebase,

--- a/torchci/test/mergeCommands.test.ts
+++ b/torchci/test/mergeCommands.test.ts
@@ -1592,7 +1592,11 @@ describe("merge-bot not supported repo", () => {
     const repo = event.payload.repository.name;
     const pr_number = event.payload.issue.number;
     const comment_number = event.payload.comment.id;
-    utils.mockConfig("pytorch-probot.yml", "mergebot: False", `${owner}/${repo}`);
+    utils.mockConfig(
+      "pytorch-probot.yml",
+      "mergebot: False",
+      `${owner}/${repo}`
+    );
     const scopes = [
       nock("https://api.github.com")
         .post(

--- a/torchci/test/utils.ts
+++ b/torchci/test/utils.ts
@@ -25,7 +25,7 @@ export function testOctokit(): Octokit {
 export function mockConfig(
   fileName: string,
   content: string,
-  repoKey: string
+  repoKey: string | RegExp = ".*"
 ): void {
   const configPayload = require("./fixtures/config.json");
   configPayload["content"] = Buffer.from(content).toString("base64");
@@ -33,7 +33,14 @@ export function mockConfig(
   configPayload["path"] = `.github/${fileName}`;
   nock("https://api.github.com")
     .get(
-      `/repos/${repoKey}/contents/${encodeURIComponent(`.github/${fileName}`)}`
+      // The use of regex here means that if the repokey or the filename contain
+      // regex special characters, they will be viewed as regex.  The main one
+      // to worry about is `.` but I think it will cause minimal problems
+      RegExp(
+        `/repos/${repoKey}/contents/${encodeURIComponent(
+          `.github/${fileName}`
+        )}`
+      )
     )
     .times(2)
     .reply(200, content);


### PR DESCRIPTION
For repos that want to merge via `@pytorchbot merge`, the repo should put `mergebot: True` in their `pytorch-probot.yml`

In preparation for letting torchao trigger their own merges through bot

Risks: 
If we can't query for the config for some reason, it will not merge

todo before this gets merged:
Add `mergebot: True` in pytorch's config file
