### PR TITLE
Add textx depdendency when python < 3.10

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -90,6 +90,7 @@ PACKAGE_ALLOW_LIST = {
     "pytz",
     "textx",
     "tzdata",
+    "importlib_metadata",
     # ----
     "Pillow",
     "certifi",

--- a/s3_management/update_dependencies.py
+++ b/s3_management/update_dependencies.py
@@ -38,6 +38,7 @@ PACKAGES_PER_PROJECT = {
         "pytz",
         "textX",
         "tzdata",
+        "importlib-metadata",
     ],
     "torchtune": [
         "aiohttp",


### PR DESCRIPTION
Additional dependency:
``importlib-metadata``