### PR TITLE
Add importlib-resources

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -91,6 +91,7 @@ PACKAGE_ALLOW_LIST = {
     "textx",
     "tzdata",
     "importlib_metadata",
+    "importlib_resources",
     # ----
     "Pillow",
     "certifi",

--- a/s3_management/update_dependencies.py
+++ b/s3_management/update_dependencies.py
@@ -39,6 +39,7 @@ PACKAGES_PER_PROJECT = {
         "textX",
         "tzdata",
         "importlib-metadata",
+        "importlib-resources",
     ],
     "torchtune": [
         "aiohttp",


### PR DESCRIPTION
Follow up after https://github.com/pytorch/test-infra/pull/5315
metplotlib has : ```Requires-Dist: importlib-resources>=3.2.0; python_version < "3.10"```