### PR TITLE
Apply isFailureFromPrevMergeCommit logic to all similar failures

### DIFF
--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -2,7 +2,6 @@ import { Client } from "@opensearch-project/opensearch";
 import dayjs from "dayjs";
 import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
 import {
-  getPRMergeCommits,
   hasS3Log,
   isFailureFromPrevMergeCommit,
   isSameAuthor,
@@ -233,6 +232,7 @@ export async function upsertDrCiComment(
 export async function hasSimilarFailures(
   job: RecentWorkflowsData,
   baseCommitDate: string,
+  mergeCommits: string[],
   lookbackPeriodInHours: number = 24,
   client?: Client
 ): Promise<RecentWorkflowsData | undefined> {
@@ -290,9 +290,7 @@ export async function hasSimilarFailures(
     return;
   }
 
-  // Find the merge commits of the PR if it has already been merged before
-  const mergeCommits = await getPRMergeCommits(job);
-
+  let foundSimilarFailure;
   for (const record of records) {
     // Convert the result in JobData to RecentWorkflowsData used by Dr.CI
     const failure: RecentWorkflowsData = {
@@ -335,13 +333,17 @@ export async function hasSimilarFailures(
       isSameFailure(job, failure) &&
       // Run this check last because it costs one query to query for the commit
       // author of the failure
-      !(await isSameAuthor(job, failure))
+      !(await isSameAuthor(job, failure)) &&
+      foundSimilarFailure === undefined
     ) {
-      return failure;
+      // Save the first similar failure (the one with the highest score) and continue
+      // instead of returning right away to make sure that the previous logic from
+      // isFailureFromPrevMergeCommit is applied to all matches
+      foundSimilarFailure = failure;
     }
   }
 
-  return;
+  return foundSimilarFailure;
 }
 
 export function isInfraFlakyJob(job: RecentWorkflowsData): boolean {

--- a/torchci/test/drciBot.test.ts
+++ b/torchci/test/drciBot.test.ts
@@ -182,6 +182,11 @@ describe("verify-drci-functionality", () => {
         (body) => JSON.stringify(body).includes("merge_base_commit_date")
       )
       .reply(200, { results: [] }) // query to get merge bases
+      .post(
+        (url) => url.includes("self/queries"),
+        (body) => JSON.stringify(body).includes("merge_commit_sha")
+      )
+      .reply(200, { results: [] }) // query to get the previous merge commit sha
       .post((url) => url.includes("merge_bases"))
       .reply(200, { results: [] }) // query to insert back to rockset
       .post(

--- a/torchci/test/drciUtils.test.ts
+++ b/torchci/test/drciUtils.test.ts
@@ -52,6 +52,7 @@ describe("Test various utils used by Dr.CI", () => {
       await hasSimilarFailures(
         job,
         emptyBaseCommitDate,
+        [],
         lookbackPeriodInHours,
         "TESTING" as unknown as Client
       )
@@ -81,6 +82,7 @@ describe("Test various utils used by Dr.CI", () => {
       await hasSimilarFailures(
         job,
         emptyBaseCommitDate,
+        [],
         lookbackPeriodInHours,
         "TESTING" as unknown as Client
       )
@@ -122,6 +124,7 @@ describe("Test various utils used by Dr.CI", () => {
       await hasSimilarFailures(
         { ...job, head_branch: headBranch },
         emptyBaseCommitDate,
+        [],
         lookbackPeriodInHours,
         "TESTING" as unknown as Client
       )
@@ -135,6 +138,7 @@ describe("Test various utils used by Dr.CI", () => {
           name: "android-emulator-build-test / build-and-test (default, 1, 1, ubuntu-20.04-16x)",
         },
         emptyBaseCommitDate,
+        [],
         lookbackPeriodInHours,
         "TESTING" as unknown as Client
       )
@@ -145,6 +149,7 @@ describe("Test various utils used by Dr.CI", () => {
       await hasSimilarFailures(
         { ...job, id: mockJobData.id! },
         emptyBaseCommitDate,
+        [],
         lookbackPeriodInHours,
         "TESTING" as unknown as Client
       )
@@ -155,6 +160,7 @@ describe("Test various utils used by Dr.CI", () => {
       await hasSimilarFailures(
         { ...job, failure_captures: ["NOT THE SAME ERROR"] },
         emptyBaseCommitDate,
+        [],
         lookbackPeriodInHours,
         "TESTING" as unknown as Client
       )
@@ -165,6 +171,7 @@ describe("Test various utils used by Dr.CI", () => {
       await hasSimilarFailures(
         { ...job, conclusion: "neutral" },
         emptyBaseCommitDate,
+        [],
         lookbackPeriodInHours,
         "TESTING" as unknown as Client
       )
@@ -178,6 +185,7 @@ describe("Test various utils used by Dr.CI", () => {
         head_sha_timestamp: mockHeadShaDate.subtract(1, "hour").toISOString(),
       },
       emptyBaseCommitDate,
+      [],
       lookbackPeriodInHours,
       "TESTING" as unknown as Client
     );
@@ -206,6 +214,7 @@ describe("Test various utils used by Dr.CI", () => {
         head_sha_timestamp: mockHeadShaDate.subtract(1, "hour").toISOString(),
       },
       mockHeadShaDate.subtract(20, "hour").toISOString(),
+      [],
       lookbackPeriodInHours,
       "TESTING" as unknown as Client
     );
@@ -239,6 +248,7 @@ describe("Test various utils used by Dr.CI", () => {
             "hour"
           )
           .toISOString(),
+        [],
         lookbackPeriodInHours,
         "TESTING" as unknown as Client
       )
@@ -251,6 +261,7 @@ describe("Test various utils used by Dr.CI", () => {
       await hasSimilarFailures(
         { ...job, head_sha_timestamp: "" },
         emptyBaseCommitDate,
+        [],
         lookbackPeriodInHours,
         "TESTING" as unknown as Client
       )

--- a/torchci/test/drciUtils.test.ts
+++ b/torchci/test/drciUtils.test.ts
@@ -26,7 +26,7 @@ describe("Test various utils used by Dr.CI", () => {
   });
 
   test("test hasSimilarFailures", async () => {
-    const headBranch = "mock-branch";
+    const headBranch = "main";
     const emptyBaseCommitDate = "";
     const lookbackPeriodInHours = 24;
     const mockHeadShaDate = dayjs("2023-08-01T00:00:00Z");
@@ -117,6 +117,18 @@ describe("Test various utils used by Dr.CI", () => {
         ],
       ])
     );
+
+    // Found a match, but it belongs to the merge commits of the same PR, so it
+    // will be ignored to avoid misclassification after the PR is reverted
+    expect(
+      await hasSimilarFailures(
+        { ...job, head_branch: "main" },
+        emptyBaseCommitDate,
+        ["ABCD"],
+        lookbackPeriodInHours,
+        "TESTING" as unknown as Client
+      )
+    ).toEqual(undefined);
 
     // Found a match, but it belongs to the same branch, thus from the same PR,
     // so it will be ignored


### PR DESCRIPTION
Fixes https://github.com/pytorch/test-infra/issues/5188

This is to address the mismatch reported in https://github.com/pytorch/test-infra/issues/5188 where some legit failures from the previous merge commit are marked as flaky.  We already have the logic to gate against this in `isFailureFromPrevMergeCommit`.  The bug here is that if a match from a subsequent broken trunk commit was found before `isFailureFromPrevMergeCommit` was applied, the match was returned right away.

There are 2 fixes here:

* Correctly apply `isFailureFromPrevMergeCommit` to all potential matches. Even if one failure shows up from the previous merge commit, the failure will be treated as a new failure.
* I also move the `getPRMergeCommits` function call out of `hasSimilarFailures` because this is the same for all failures in the PR, so we don't need to call it multiple times for each failures.

### Testing

https://github.com/pytorch/pytorch/pull/124045

BEFORE

## :x: 9 New Failures, 3 Unrelated Failures
As of commit 0b8801e63882c96a3d8650d3076ffbc96cad37c6 with merge base c59a2369bec99dbbc088ac5477efe1ab6adc7ec8 (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1715230941?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details open><summary><b>NEW FAILURES</b> - The following jobs have failed:</summary><p>

* [pull / linux-focal-cuda12.1-py3.10-gcc9 / test (default, 3, 5, linux.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788837018) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021176052/job/24788837018))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
* [pull / linux-focal-cuda12.1-py3.10-gcc9-sm86 / test (default, 2, 5, linux.g5.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24789401094) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021176052/job/24789401094))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
* [pull / linux-focal-py3.11-clang10 / test (default, 2, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788472937) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021176052/job/24788472937))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
* [pull / linux-focal-py3.12-clang10 / test (default, 2, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788399029) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021176052/job/24788399029))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
* [pull / linux-focal-py3.8-clang10 / test (default, 1, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788466265) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021176052/job/24788466265))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
* [pull / linux-jammy-py3.10-clang15-asan / test (default, 3, 6, linux.4xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788469024) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021176052/job/24788469024))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
* [pull / linux-jammy-py3.8-gcc11 / test (default, 2, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788510073) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021176052/job/24788510073))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
* [trunk / linux-focal-cuda12.1-py3.10-gcc9 / test (nogpu_AVX512, 1, 1, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788892217) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021177901/job/24788892217))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
* [trunk / linux-focal-cuda12.1-py3.10-gcc9 / test (nogpu_NO_AVX2, 1, 1, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788892453) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021177901/job/24788892453))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
</p></details>
<details ><summary><b>FLAKY</b> - The following jobs failed but were likely due to flakiness present on trunk:</summary><p>

* [pull / linux-focal-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24789400741) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021176052/job/24789400741)) ([similar failure](https://hud.pytorch.org/pytorch/pytorch/commit/8bd55a581a0f6b8e639f1eb134d3a6875ba8710b#24734539091))
    `inductor/test_max_autotune.py::TestMaxAutotune::test_max_autotune_remote_caching_dynamic_False`
* [trunk / macos-12-py3-arm64 / test (default, 2, 3, macos-m1-stable)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788213926) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021177901/job/24788213926)) ([similar failure](https://hud.pytorch.org/pytorch/pytorch/commit/0542fd485fd72bea21ccd72ae7642502b4f89efd#24716851442))
    `inductor/test_torchinductor.py::CpuTests::test_AllenaiLongformerBase_repro_cpu`
* [trunk / macos-12-py3-arm64 / test (default, 3, 3, macos-m1-stable)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788214168) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021177901/job/24788214168)) ([similar failure](https://hud.pytorch.org/pytorch/pytorch/commit/15a977022567edb9a143483c2e8d790604267685#24717276733))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
</p></details>

AFTER

## :x: 12 New Failures
As of commit 0b8801e63882c96a3d8650d3076ffbc96cad37c6 with merge base c59a2369bec99dbbc088ac5477efe1ab6adc7ec8 (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1715230941?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details open><summary><b>NEW FAILURES</b> - The following jobs have failed:</summary><p>

* [pull / linux-focal-cuda12.1-py3.10-gcc9 / test (default, 3, 5, linux.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788837018) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021176052/job/24788837018))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
* [pull / linux-focal-cuda12.1-py3.10-gcc9-sm86 / test (default, 1, 5, linux.g5.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24789400741) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021176052/job/24789400741))
    `inductor/test_max_autotune.py::TestMaxAutotune::test_max_autotune_remote_caching_dynamic_False`
* [pull / linux-focal-cuda12.1-py3.10-gcc9-sm86 / test (default, 2, 5, linux.g5.4xlarge.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24789401094) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021176052/job/24789401094))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
* [pull / linux-focal-py3.11-clang10 / test (default, 2, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788472937) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021176052/job/24788472937))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
* [pull / linux-focal-py3.12-clang10 / test (default, 2, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788399029) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021176052/job/24788399029))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
* [pull / linux-focal-py3.8-clang10 / test (default, 1, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788466265) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021176052/job/24788466265))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
* [pull / linux-jammy-py3.10-clang15-asan / test (default, 3, 6, linux.4xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788469024) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021176052/job/24788469024))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
* [pull / linux-jammy-py3.8-gcc11 / test (default, 2, 3, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788510073) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021176052/job/24788510073))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
* [trunk / linux-focal-cuda12.1-py3.10-gcc9 / test (nogpu_AVX512, 1, 1, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788892217) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021177901/job/24788892217))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
* [trunk / linux-focal-cuda12.1-py3.10-gcc9 / test (nogpu_NO_AVX2, 1, 1, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788892453) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021177901/job/24788892453))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
* [trunk / macos-12-py3-arm64 / test (default, 2, 3, macos-m1-stable)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788213926) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021177901/job/24788213926))
    `inductor/test_torchinductor.py::CpuTests::test_AllenaiLongformerBase_repro_cpu`
* [trunk / macos-12-py3-arm64 / test (default, 3, 3, macos-m1-stable)](https://hud.pytorch.org/pr/pytorch/pytorch/124045#24788214168) ([gh](https://github.com/pytorch/pytorch/actions/runs/9021177901/job/24788214168))
    `inductor/test_codecache.py::TestUtils::test_fresh_inductor_cache`
</p></details>

https://github.com/pytorch/pytorch/pull/128464

BEFORE

## :x: 1 New Failure, 2 Unrelated Failures
As of commit b245737edbb1a5372b3b63df870aed9746e94958 with merge base 5d8c7f39d46699d8f8e92512309ea3499a29c08a (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1718148968?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details open><summary><b>NEW FAILURE</b> - The following job has failed:</summary><p>

* [Lint / lintrunner-clang / linux-job](https://hud.pytorch.org/pr/pytorch/pytorch/128464#26103384439) ([gh](https://github.com/pytorch/pytorch/actions/runs/9474224325/job/26103384439))
    `>>> Lint for torch/csrc/autograd/profiler_kineto.cpp:`
</p></details>
<details ><summary><b>FLAKY</b> - The following jobs failed but were likely due to flakiness present on trunk:</summary><p>

* [pull / linux-focal-py3_8-clang9-xla / test (xla, 1, 1, linux.12xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/128464#26103802338) ([gh](https://github.com/pytorch/pytorch/actions/runs/9474224262/job/26103802338)) ([similar failure](https://hud.pytorch.org/pytorch/pytorch/commit/d346c5ee8a2e2e5b4457e2e7d5617e146f231c2e#26051372274))
    `test_all_reduce_no_op_with_one_replica`
* [pull / linux-jammy-py3.8-gcc11 / test (distributed, 1, 2, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/128464#26103734814) ([gh](https://github.com/pytorch/pytorch/actions/runs/9474224262/job/26103734814)) ([similar failure](https://hud.pytorch.org/pytorch/pytorch/commit/09ce15743673dc6f0085a239613f5e86a0d965ea#26050704066))
    `Process completed with exit code 1.`
</p></details>

AFTER

## :x: 1 New Failure, 2 Unrelated Failures
As of commit b245737edbb1a5372b3b63df870aed9746e94958 with merge base 5d8c7f39d46699d8f8e92512309ea3499a29c08a (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1718148968?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details open><summary><b>NEW FAILURE</b> - The following job has failed:</summary><p>

* [Lint / lintrunner-clang / linux-job](https://hud.pytorch.org/pr/pytorch/pytorch/128464#26103384439) ([gh](https://github.com/pytorch/pytorch/actions/runs/9474224325/job/26103384439))
    `>>> Lint for torch/csrc/autograd/profiler_kineto.cpp:`
</p></details>
<details ><summary><b>FLAKY</b> - The following jobs failed but were likely due to flakiness present on trunk:</summary><p>

* [pull / linux-focal-py3_8-clang9-xla / test (xla, 1, 1, linux.12xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/128464#26103802338) ([gh](https://github.com/pytorch/pytorch/actions/runs/9474224262/job/26103802338)) ([similar failure](https://hud.pytorch.org/pytorch/pytorch/commit/d346c5ee8a2e2e5b4457e2e7d5617e146f231c2e#26051372274))
    `test_all_reduce_no_op_with_one_replica`
* [pull / linux-jammy-py3.8-gcc11 / test (distributed, 1, 2, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/128464#26103734814) ([gh](https://github.com/pytorch/pytorch/actions/runs/9474224262/job/26103734814)) ([similar failure](https://hud.pytorch.org/pytorch/pytorch/commit/09ce15743673dc6f0085a239613f5e86a0d965ea#26050704066))
    `Process completed with exit code 1.`
</p></details>