### PR TITLE
Switch to ${{ runner.temp }}

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -258,7 +258,7 @@ jobs:
         if: always()
         uses: ./test-infra/.github/actions/chown-directory
         with:
-          directory: ${{ env.RUNNER_TEMP }}
+          directory: ${{ runner.temp }}
           ALPINE_IMAGE: ${{ inputs.runner == 'linux.arm64.2xlarge' && 'arm64v8/alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
 
       - name: Prepare artifacts for upload


### PR DESCRIPTION
This seems to work while `{{ env.RUNNER_TEMP }}` is not https://github.com/pytorch/test-infra/actions/runs/9492075721/job/26158612745?pr=5327#step:16:29