### PR TITLE
ci: Switch env variable to context for runner.temp

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -258,7 +258,7 @@ jobs:
         if: always()
         uses: ./test-infra/.github/actions/chown-directory
         with:
-          directory: ${{ env.RUNNER_TEMP }}
+          directory: ${{ runner.temp }}
           ALPINE_IMAGE: ${{ inputs.runner == 'linux.arm64.2xlarge' && 'arm64v8/alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
 
       - name: Prepare artifacts for upload


### PR DESCRIPTION
There can be cases where RUNNER_TEMP may not be available by using `${{ env.RUNNER_TEMP }}` so let's just use the context since that seems to be the safer better in the long run