### PR TITLE
Workaround for Windows AMI conda install step failing

### DIFF
--- a/aws/ami/windows/windows.pkr.hcl
+++ b/aws/ami/windows/windows.pkr.hcl
@@ -42,7 +42,6 @@ build {
 
   # Install conda, it needs to be installed under SYSTEM to avoid this broken
   # installation https://github.com/ContinuumIO/anaconda-issues/issues/11799.
-  # CondaHTTPError: HTTP 000 CONNECTION FAILED when connecting to conda (?)
   provisioner "powershell" {
     elevated_user     = "SYSTEM"
     elevated_password = ""

--- a/aws/ami/windows/windows.pkr.hcl
+++ b/aws/ami/windows/windows.pkr.hcl
@@ -40,6 +40,20 @@ source "amazon-ebs" "windows_ebs_builder" {
 build {
   sources = ["source.amazon-ebs.windows_ebs_builder"]
 
+  # Install conda, it needs to be installed under SYSTEM to avoid this broken
+  # installation https://github.com/ContinuumIO/anaconda-issues/issues/11799.
+  # Also this needs to come after all the tools are installed to avoid error
+  # CondaHTTPError: HTTP 000 CONNECTION FAILED when connecting to conda (?)
+  provisioner "powershell" {
+    elevated_user     = "SYSTEM"
+    elevated_password = ""
+    scripts = [
+      "${path.root}/scripts/Installers/Install-Miniconda3.ps1",
+      "${path.root}/scripts/Installers/Install-Conda-Dependencies.ps1",
+      "${path.root}/scripts/Installers/Install-Pip-Dependencies.ps1",
+    ]
+  }
+
   # Install sshd_config
   provisioner "file" {
     source      = "${path.root}/configs/sshd_config"
@@ -80,20 +94,6 @@ build {
       "${path.root}/scripts/Helpers/Reset-UserData.ps1",
       "${path.root}/scripts/Installers/Install-Choco.ps1",
       "${path.root}/scripts/Installers/Install-Tools.ps1",
-    ]
-  }
-
-  # Install conda, it needs to be installed under SYSTEM to avoid this broken
-  # installation https://github.com/ContinuumIO/anaconda-issues/issues/11799.
-  # Also this needs to come after all the tools are installed to avoid error
-  # CondaHTTPError: HTTP 000 CONNECTION FAILED when connecting to conda (?)
-  provisioner "powershell" {
-    elevated_user     = "SYSTEM"
-    elevated_password = ""
-    scripts = [
-      "${path.root}/scripts/Installers/Install-Miniconda3.ps1",
-      "${path.root}/scripts/Installers/Install-Conda-Dependencies.ps1",
-      "${path.root}/scripts/Installers/Install-Pip-Dependencies.ps1",
     ]
   }
 

--- a/aws/ami/windows/windows.pkr.hcl
+++ b/aws/ami/windows/windows.pkr.hcl
@@ -42,7 +42,6 @@ build {
 
   # Install conda, it needs to be installed under SYSTEM to avoid this broken
   # installation https://github.com/ContinuumIO/anaconda-issues/issues/11799.
-  # Also this needs to come after all the tools are installed to avoid error
   # CondaHTTPError: HTTP 000 CONNECTION FAILED when connecting to conda (?)
   provisioner "powershell" {
     elevated_user     = "SYSTEM"


### PR DESCRIPTION
We get a failure during this step:
https://github.com/pytorch/test-infra/blob/main/aws/ami/windows/scripts/Installers/Install-Miniconda3.ps1#L31
``
Miniconda installation failed, no hook found
``
Workaround it to install Miniconda first to get past this error and continue installing everything else.