### PR TITLE
Set the correct repo link in mark unstable job button in commit and PR pages

### DIFF
--- a/torchci/components/CommitStatus.tsx
+++ b/torchci/components/CommitStatus.tsx
@@ -119,6 +119,11 @@ export default function CommitStatus({
   const session = useSession();
   const isAuthenticated = session.status === "authenticated";
 
+  // Populate the repo field if it's not yet set in the job data
+  jobs.forEach((job) => {
+    job.repo = job.repo ?? `${repoOwner}/${repoName}`;
+  });
+
   return (
     <>
       <VersionControlLinks


### PR DESCRIPTION
This is a miss from https://github.com/pytorch/test-infra/pull/5122 where I failed to check that the repo field in JobData is optional and wasn't set in HUD commit and PR pages.  So, marking an unstable job link works correctly in main HUD page like https://hud.pytorch.org/hud/pytorch/executorch/main where the data comes from `fetchHud`, but it uses the default link pointing to `pytorch/pytorch` in:

* Commit page https://hud.pytorch.org/pytorch/executorch/commit/7c0f4c2b6f87369ee20544aada33dc55078c6bc6
* and PR page https://hud.pytorch.org/pr/pytorch/executorch/3972

The fix here is to populate the repo field if it's not there

### Testing

Verify this locally (need to login to HUD)

* http://localhost:3000/pytorch/executorch/commit/7c0f4c2b6f87369ee20544aada33dc55078c6bc6
* http://localhost:3000/pr/pytorch/executorch/3972
