### PR TITLE
Add dtype and device columns

### DIFF
--- a/torchci/components/benchmark/llms/SummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/SummaryPanel.tsx
@@ -2,7 +2,6 @@ import { Grid } from "@mui/material";
 import { GridCellParams, GridRenderCellParams } from "@mui/x-data-grid";
 import {
   BranchAndCommitPerfData,
-  LLMsBenchmarkData,
   METRIC_DISPLAY_HEADERS,
   RELATIVE_THRESHOLD,
 } from "components/benchmark/llms/common";
@@ -10,6 +9,7 @@ import styles from "components/metrics.module.css";
 import { TablePanelWithData } from "components/metrics/panels/TablePanel";
 import { Granularity } from "components/metrics/panels/TimeSeriesPanel";
 import dayjs from "dayjs";
+import { combineLeftAndRight } from "lib/benchmark/llmUtils";
 
 const ROW_GAP = 100;
 const ROW_HEIGHT = 38;
@@ -40,108 +40,7 @@ export function SummaryPanel({
   const rCommit = rPerfData.commit;
   const rData = rPerfData.data;
 
-  const dataGroupedByModel: { [k: string]: any } = {};
-  rData.forEach((record: LLMsBenchmarkData) => {
-    const name = record.name;
-    const dtype = record.dtype;
-    const device = record.device;
-    const metric = record.metric;
-
-    if (!(name in dataGroupedByModel)) {
-      dataGroupedByModel[name] = {};
-    }
-
-    if (!(dtype in dataGroupedByModel[name])) {
-      dataGroupedByModel[name][dtype] = {};
-    }
-
-    if (!(device in dataGroupedByModel[name][dtype])) {
-      dataGroupedByModel[name][dtype][device] = {};
-    }
-
-    dataGroupedByModel[name][dtype][device][metric] = {
-      r: record,
-    };
-  });
-
-  // Combine with left (base) data
-  if (lCommit !== rCommit && lData !== undefined) {
-    lData.forEach((record: LLMsBenchmarkData) => {
-      const name = record.name;
-      const dtype = record.dtype;
-      const device = record.device;
-      const metric = record.metric;
-
-      if (!(name in dataGroupedByModel)) {
-        dataGroupedByModel[name] = {};
-      }
-
-      if (!(dtype in dataGroupedByModel[name])) {
-        dataGroupedByModel[name][dtype] = {};
-      }
-
-      if (!(device in dataGroupedByModel[name][dtype])) {
-        dataGroupedByModel[name][dtype][device] = {};
-      }
-
-      if (!(metric in dataGroupedByModel[name][dtype][device])) {
-        dataGroupedByModel[name][dtype][device][metric] = {};
-      }
-
-      dataGroupedByModel[name][dtype][device][metric]["l"] = record;
-    });
-  }
-
-  // Transform the data into a displayable format
-  const data: { [k: string]: any }[] = [];
-  Object.keys(dataGroupedByModel).forEach((name: string) => {
-    Object.keys(dataGroupedByModel[name]).forEach((dtype: string) => {
-      Object.keys(dataGroupedByModel[name][dtype]).forEach((device: string) => {
-        const row: { [k: string]: any } = {
-          // Keep the name as as the row ID as DataGrid requires it
-          name: `${name} (${dtype} / ${device})`,
-        };
-
-        for (const metric in dataGroupedByModel[name][dtype][device]) {
-          const record = dataGroupedByModel[name][dtype][device][metric];
-          const hasL = "l" in record;
-          const hasR = "r" in record;
-
-          row["metadata"] = {
-            name: name,
-            dtype: dtype,
-            device: device,
-            l: hasL ? record["l"]["job_id"] : undefined,
-            r: hasR ? record["r"]["job_id"] : undefined,
-          };
-
-          row[metric] = {
-            l: hasL
-              ? {
-                  actual: record["l"].actual,
-                  target: record["l"].target,
-                }
-              : {
-                  actual: 0,
-                  target: 0,
-                },
-            r: hasR
-              ? {
-                  actual: record["r"].actual,
-                  target: record["r"].target,
-                }
-              : {
-                  actual: 0,
-                  target: 0,
-                },
-          };
-        }
-
-        data.push(row);
-      });
-    });
-  });
-
+  const data = combineLeftAndRight(lPerfData, rPerfData);
   return (
     <Grid container spacing={2} style={{ height: "100%" }}>
       <Grid item xs={12} lg={12} height={data.length * ROW_HEIGHT + ROW_GAP}>
@@ -179,7 +78,10 @@ export function SummaryPanel({
                 )}&dtypeName=${encodeURIComponent(
                   dtype
                 )}&deviceName=${encodeURIComponent(device)}`;
-                const isNewModel = params.value.l === undefined ? "✅" : "";
+                const isNewModel =
+                  params.value.l === undefined && lCommit !== rCommit
+                    ? "(NEW!) "
+                    : "";
                 const isModelStopRunning =
                   params.value.r === undefined ? "❌" : "";
 
@@ -260,11 +162,12 @@ export function SummaryPanel({
                   const rPercent = target
                     ? `(${Number((r * 100) / target).toFixed(0)}%)`
                     : "";
+                  const isNewModel = l === 0 ? "(NEW!)" : "";
 
-                  if (lCommit === rCommit || l === r || v.l === 0) {
+                  if (lCommit === rCommit || l === r) {
                     return `${r} ${rPercent} [target = ${target}]`;
                   } else {
-                    return `${l} ${lPercent} → ${r} ${rPercent} [target = ${target}]`;
+                    return `${l} ${lPercent} → ${r} ${rPercent} [target = ${target}] ${isNewModel} `;
                   }
                 },
               };

--- a/torchci/components/benchmark/llms/SummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/SummaryPanel.tsx
@@ -42,11 +42,24 @@ export function SummaryPanel({
 
   const dataGroupedByModel: { [k: string]: any } = {};
   rData.forEach((record: LLMsBenchmarkData) => {
-    if (!(record.name in dataGroupedByModel)) {
-      dataGroupedByModel[record.name] = {};
+    const name = record.name;
+    const dtype = record.dtype;
+    const device = record.device;
+    const metric = record.metric;
+
+    if (!(name in dataGroupedByModel)) {
+      dataGroupedByModel[name] = {};
     }
 
-    dataGroupedByModel[record.name][record.metric] = {
+    if (!(dtype in dataGroupedByModel[name])) {
+      dataGroupedByModel[name][dtype] = {};
+    }
+
+    if (!(device in dataGroupedByModel[name][dtype])) {
+      dataGroupedByModel[name][dtype][device] = {};
+    }
+
+    dataGroupedByModel[name][dtype][device][metric] = {
       r: record,
     };
   });
@@ -54,59 +67,79 @@ export function SummaryPanel({
   // Combine with left (base) data
   if (lCommit !== rCommit && lData !== undefined) {
     lData.forEach((record: LLMsBenchmarkData) => {
-      if (!(record.name in dataGroupedByModel)) {
-        dataGroupedByModel[record.name] = {};
+      const name = record.name;
+      const dtype = record.dtype;
+      const device = record.device;
+      const metric = record.metric;
+
+      if (!(name in dataGroupedByModel)) {
+        dataGroupedByModel[name] = {};
       }
 
-      if (!(record.metric in dataGroupedByModel[record.name])) {
-        dataGroupedByModel[record.name][record.metric] = {};
+      if (!(dtype in dataGroupedByModel[name])) {
+        dataGroupedByModel[name][dtype] = {};
       }
 
-      dataGroupedByModel[record.name][record.metric]["l"] = record;
+      if (!(device in dataGroupedByModel[name][dtype])) {
+        dataGroupedByModel[name][dtype][device] = {};
+      }
+
+      if (!(metric in dataGroupedByModel[name][dtype][device])) {
+        dataGroupedByModel[name][dtype][device][metric] = {};
+      }
+
+      dataGroupedByModel[name][dtype][device][metric]["l"] = record;
     });
   }
 
   // Transform the data into a displayable format
-  const data = Object.keys(dataGroupedByModel).map((name: string) => {
-    const row: { [k: string]: any } = {
-      // Keep the name as as the row ID as DataGrid requires it
-      name: name,
-    };
+  const data: { [k: string]: any }[] = [];
+  Object.keys(dataGroupedByModel).forEach((name: string) => {
+    Object.keys(dataGroupedByModel[name]).forEach((dtype: string) => {
+      Object.keys(dataGroupedByModel[name][dtype]).forEach((device: string) => {
+        const row: { [k: string]: any } = {
+          // Keep the name as as the row ID as DataGrid requires it
+          name: `${name} (${dtype} / ${device})`,
+        };
 
-    for (const metric in dataGroupedByModel[name]) {
-      const record = dataGroupedByModel[name][metric];
-      const hasL = "l" in record;
-      const hasR = "r" in record;
+        for (const metric in dataGroupedByModel[name][dtype][device]) {
+          const record = dataGroupedByModel[name][dtype][device][metric];
+          const hasL = "l" in record;
+          const hasR = "r" in record;
 
-      row["metadata"] = {
-        name: name,
-        l: hasL ? record["l"]["job_id"] : undefined,
-        r: hasR ? record["r"]["job_id"] : undefined,
-      };
+          row["metadata"] = {
+            name: name,
+            dtype: dtype,
+            device: device,
+            l: hasL ? record["l"]["job_id"] : undefined,
+            r: hasR ? record["r"]["job_id"] : undefined,
+          };
 
-      row[metric] = {
-        l: hasL
-          ? {
-              actual: record["l"].actual,
-              target: record["l"].target,
-            }
-          : {
-              actual: 0,
-              target: 0,
-            },
-        r: hasR
-          ? {
-              actual: record["r"].actual,
-              target: record["r"].target,
-            }
-          : {
-              actual: 0,
-              target: 0,
-            },
-      };
-    }
+          row[metric] = {
+            l: hasL
+              ? {
+                  actual: record["l"].actual,
+                  target: record["l"].target,
+                }
+              : {
+                  actual: 0,
+                  target: 0,
+                },
+            r: hasR
+              ? {
+                  actual: record["r"].actual,
+                  target: record["r"].target,
+                }
+              : {
+                  actual: 0,
+                  target: 0,
+                },
+          };
+        }
 
-    return row;
+        data.push(row);
+      });
+    });
   });
 
   return (
@@ -132,90 +165,110 @@ export function SummaryPanel({
               },
               renderCell: (params: GridRenderCellParams<any>) => {
                 const name = params.value.name;
+                const dtype = params.value.dtype;
+                const device = params.value.device;
                 if (name === undefined) {
-                  return `Invalid model name ${name}`;
+                  return `Invalid model name`;
+                }
+                if (dtype === undefined) {
+                  return `Invalid dtype for model ${name}`;
                 }
 
-                const encodedName = encodeURIComponent(name);
-                const url = `/benchmark/llms?startTime=${startTime}&stopTime=${stopTime}&granularity=${granularity}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}&modelName=${encodedName}`;
+                const url = `/benchmark/llms?startTime=${startTime}&stopTime=${stopTime}&granularity=${granularity}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}&modelName=${encodeURIComponent(
+                  name
+                )}&dtypeName=${encodeURIComponent(
+                  dtype
+                )}&deviceName=${encodeURIComponent(device)}`;
+                const isNewModel = params.value.l === undefined ? "✅" : "";
+                const isModelStopRunning =
+                  params.value.r === undefined ? "❌" : "";
+
+                const displayName = name.includes(dtype)
+                  ? name.includes(device)
+                    ? name
+                    : `${name} (${device})`
+                  : name.includes(device)
+                  ? `${name} (${dtype})`
+                  : `${name} (${dtype} / ${device})`;
 
                 return (
                   <a href={url}>
-                    <b>{name}</b>
+                    {isNewModel}
+                    {isModelStopRunning}&nbsp;<b>{displayName}</b>
                   </a>
                 );
               },
             },
-            ...metricNames
-              .filter(
-                (metric: string) => data.length !== 0 && metric in data[0]
-              )
-              .map((metric: string) => {
-                return {
-                  field: metric,
-                  headerName:
-                    metric in METRIC_DISPLAY_HEADERS
-                      ? METRIC_DISPLAY_HEADERS[metric]
-                      : metric,
-                  flex: 1,
-                  cellClassName: (params: GridCellParams<any>) => {
-                    const v = params.value;
-                    if (v === undefined || v.l.actual === 0) {
-                      return "";
-                    }
-
-                    // l is the old (base) value, r is the new value
-                    const l = v.l.actual;
-                    const r = v.r.actual;
-
-                    if (lCommit === rCommit) {
-                      return "";
-                    } else {
-                      if (l === r) {
-                        // 0 means the model isn't run at all
-                        return "";
-                      }
-
-                      // It didn't error in the past, but now it does error
-                      if (r === 0) {
-                        return styles.error;
-                      }
-
-                      // Higher TPS
-                      if (r - l > RELATIVE_THRESHOLD * l) {
-                        return styles.ok;
-                      }
-
-                      // Lower TPS
-                      if (l - r > RELATIVE_THRESHOLD * r) {
-                        return styles.error;
-                      }
-                    }
-
+            ...metricNames.map((metric: string) => {
+              return {
+                field: metric,
+                headerName:
+                  metric in METRIC_DISPLAY_HEADERS
+                    ? METRIC_DISPLAY_HEADERS[metric]
+                    : metric,
+                flex: 1,
+                cellClassName: (params: GridCellParams<any>) => {
+                  const v = params.value;
+                  if (v === undefined || v.l.actual === 0) {
                     return "";
-                  },
-                  renderCell: (params: GridRenderCellParams<any>) => {
-                    const v = params.value;
-                    if (v === undefined) {
+                  }
+
+                  // l is the old (base) value, r is the new value
+                  const l = v.l.actual;
+                  const r = v.r.actual;
+
+                  if (lCommit === rCommit) {
+                    return "";
+                  } else {
+                    if (l === r) {
+                      // 0 means the model isn't run at all
                       return "";
                     }
 
-                    const l = v.l.actual;
-                    const r = v.r.actual;
-
-                    // Compute the percentage
-                    const target = v.r.target;
-                    const lPercent = Number((l * 100) / target).toFixed(0);
-                    const rPercent = Number((r * 100) / target).toFixed(0);
-
-                    if (lCommit === rCommit || l === r || v.l === 0) {
-                      return `${r} (${rPercent}%) [target = ${target}]`;
-                    } else {
-                      return `${l} (${lPercent}%) → ${r} (${rPercent}%) [target = ${target}]`;
+                    // It didn't error in the past, but now it does error
+                    if (r === 0) {
+                      return styles.error;
                     }
-                  },
-                };
-              }),
+
+                    // Higher TPS
+                    if (r - l > RELATIVE_THRESHOLD * l) {
+                      return styles.ok;
+                    }
+
+                    // Lower TPS
+                    if (l - r > RELATIVE_THRESHOLD * r) {
+                      return styles.error;
+                    }
+                  }
+
+                  return "";
+                },
+                renderCell: (params: GridRenderCellParams<any>) => {
+                  const v = params.value;
+                  if (v === undefined) {
+                    return "";
+                  }
+
+                  const l = v.l.actual;
+                  const r = v.r.actual;
+
+                  // Compute the percentage
+                  const target = v.r.target;
+                  const lPercent = target
+                    ? `(${Number((l * 100) / target).toFixed(0)}%)`
+                    : "";
+                  const rPercent = target
+                    ? `(${Number((r * 100) / target).toFixed(0)}%)`
+                    : "";
+
+                  if (lCommit === rCommit || l === r || v.l === 0) {
+                    return `${r} ${rPercent} [target = ${target}]`;
+                  } else {
+                    return `${l} ${lPercent} → ${r} ${rPercent} [target = ${target}]`;
+                  }
+                },
+              };
+            }),
           ]}
           dataGridProps={{ getRowId: (el: any) => el.name }}
         />

--- a/torchci/components/benchmark/llms/common.tsx
+++ b/torchci/components/benchmark/llms/common.tsx
@@ -7,11 +7,13 @@ export const METRIC_DISPLAY_HEADERS: { [k: string]: string } = {
   "memory_bandwidth(GB/s)": "Memory bandwidth (GB/s)",
   token_per_sec: "Token per second",
   flops_utilization: "FLOPs utilization",
+  "compilation_time(s)": "Compilation Time (s)",
 };
 export const METRIC_DISPLAY_SHORT_HEADERS: { [k: string]: string } = {
   "memory_bandwidth(GB/s)": "Bandwidth",
   token_per_sec: "TPS",
   flops_utilization: "FLOPs",
+  "compilation_time(s)": "CompTime",
 };
 export const DEFAULT_DEVICE_NAME = "All Devices";
 export const DEFAULT_DTYPE_NAME = "All DType";

--- a/torchci/components/benchmark/llms/common.tsx
+++ b/torchci/components/benchmark/llms/common.tsx
@@ -6,12 +6,15 @@ export const SCALE = 2;
 export const METRIC_DISPLAY_HEADERS: { [k: string]: string } = {
   "memory_bandwidth(GB/s)": "Memory bandwidth (GB/s)",
   token_per_sec: "Token per second",
+  flops_utilization: "FLOPs utilization",
 };
 export const METRIC_DISPLAY_SHORT_HEADERS: { [k: string]: string } = {
   "memory_bandwidth(GB/s)": "Bandwidth",
   token_per_sec: "TPS",
+  flops_utilization: "FLOPs",
 };
 export const DEFAULT_DEVICE_NAME = "All Devices";
+export const DEFAULT_DTYPE_NAME = "All DType";
 
 // Relative thresholds
 export const RELATIVE_THRESHOLD = 0.05;
@@ -24,6 +27,9 @@ export interface LLMsBenchmarkData {
   metric: string;
   actual: number;
   target: number;
+  dtype: string;
+  device: string;
+  display?: string;
 }
 
 export interface BranchAndCommitPerfData extends BranchAndCommit {

--- a/torchci/lib/benchmark/llmUtils.ts
+++ b/torchci/lib/benchmark/llmUtils.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_DEVICE_NAME,
+  DEFAULT_DTYPE_NAME,
   DEFAULT_MODEL_NAME,
 } from "components/benchmark/llms/common";
 import { fetcher } from "lib/GeneralUtils";
@@ -10,6 +11,7 @@ import useSWR from "swr";
 export function useBenchmark(
   queryParams: RocksetParam[],
   modelName: string,
+  dtypeName: string,
   deviceName: string,
   branchAndCommit: BranchAndCommit,
   getJobId: boolean = false
@@ -22,6 +24,11 @@ export function useBenchmark(
       name: "names",
       type: "string",
       value: modelName === DEFAULT_MODEL_NAME ? "" : modelName,
+    },
+    {
+      name: "dtypes",
+      type: "string",
+      value: dtypeName === DEFAULT_DTYPE_NAME ? "" : dtypeName,
     },
     {
       name: "devices",

--- a/torchci/lib/benchmark/llmUtils.ts
+++ b/torchci/lib/benchmark/llmUtils.ts
@@ -1,7 +1,9 @@
 import {
+  BranchAndCommitPerfData,
   DEFAULT_DEVICE_NAME,
   DEFAULT_DTYPE_NAME,
   DEFAULT_MODEL_NAME,
+  LLMsBenchmarkData,
 } from "components/benchmark/llms/common";
 import { fetcher } from "lib/GeneralUtils";
 import { RocksetParam } from "lib/rockset";
@@ -66,4 +68,131 @@ export function useBenchmark(
   return useSWR(lUrl, fetcher, {
     refreshInterval: 60 * 60 * 1000, // refresh every hour
   });
+}
+
+export function combineLeftAndRight(
+  lPerfData: BranchAndCommitPerfData,
+  rPerfData: BranchAndCommitPerfData
+): { [k: string]: any }[] {
+  // The left (base commit)
+  const lBranch = lPerfData.branch;
+  const lCommit = lPerfData.commit;
+  const lData = lPerfData.data;
+  // and the right (new commit)
+  const rBranch = rPerfData.branch;
+  const rCommit = rPerfData.commit;
+  const rData = rPerfData.data;
+
+  const dataGroupedByModel: { [k: string]: any } = {};
+  rData.forEach((record: LLMsBenchmarkData) => {
+    const name = record.name;
+    const dtype = record.dtype;
+    const device = record.device;
+    const metric = record.metric;
+
+    if (!(name in dataGroupedByModel)) {
+      dataGroupedByModel[name] = {};
+    }
+
+    if (!(dtype in dataGroupedByModel[name])) {
+      dataGroupedByModel[name][dtype] = {};
+    }
+
+    if (!(device in dataGroupedByModel[name][dtype])) {
+      dataGroupedByModel[name][dtype][device] = {};
+    }
+
+    dataGroupedByModel[name][dtype][device][metric] = {
+      r: record,
+    };
+  });
+
+  // Combine with left (base) data
+  if (lCommit !== rCommit && lData !== undefined) {
+    lData.forEach((record: LLMsBenchmarkData) => {
+      const name = record.name;
+      const dtype = record.dtype;
+      const device = record.device;
+      const metric = record.metric;
+
+      if (!(name in dataGroupedByModel)) {
+        dataGroupedByModel[name] = {};
+      }
+
+      if (!(dtype in dataGroupedByModel[name])) {
+        dataGroupedByModel[name][dtype] = {};
+      }
+
+      if (!(device in dataGroupedByModel[name][dtype])) {
+        dataGroupedByModel[name][dtype][device] = {};
+      }
+
+      if (!(metric in dataGroupedByModel[name][dtype][device])) {
+        dataGroupedByModel[name][dtype][device][metric] = {};
+      }
+
+      dataGroupedByModel[name][dtype][device][metric]["l"] = record;
+    });
+  }
+
+  // Transform the data into a displayable format
+  const data: { [k: string]: any }[] = [];
+  Object.keys(dataGroupedByModel).forEach((name: string) => {
+    Object.keys(dataGroupedByModel[name]).forEach((dtype: string) => {
+      Object.keys(dataGroupedByModel[name][dtype]).forEach((device: string) => {
+        const row: { [k: string]: any } = {
+          // Keep the name as as the row ID as DataGrid requires it
+          name: `${name} (${dtype} / ${device})`,
+        };
+
+        for (const metric in dataGroupedByModel[name][dtype][device]) {
+          const record = dataGroupedByModel[name][dtype][device][metric];
+          const hasL = "l" in record;
+          const hasR = "r" in record;
+
+          if (!("metadata" in row)) {
+            row["metadata"] = {
+              name: name,
+              dtype: dtype,
+              device: device,
+              l: hasL ? record["l"]["job_id"] : undefined,
+              r: hasR ? record["r"]["job_id"] : undefined,
+            };
+          } else {
+            row["metadata"]["l"] =
+              row["metadata"]["l"] ??
+              (hasL ? record["l"]["job_id"] : undefined);
+            row["metadata"]["r"] =
+              row["metadata"]["r"] ??
+              (hasR ? record["r"]["job_id"] : undefined);
+          }
+
+          row[metric] = {
+            l: hasL
+              ? {
+                  actual: record["l"].actual,
+                  target: record["l"].target,
+                }
+              : {
+                  actual: 0,
+                  target: 0,
+                },
+            r: hasR
+              ? {
+                  actual: record["r"].actual,
+                  target: record["r"].target,
+                }
+              : {
+                  actual: 0,
+                  target: 0,
+                },
+          };
+        }
+
+        data.push(row);
+      });
+    });
+  });
+
+  return data;
 }

--- a/torchci/pages/benchmark/llms.tsx
+++ b/torchci/pages/benchmark/llms.tsx
@@ -9,6 +9,7 @@ import {
 import {
   BENCHMARKS,
   DEFAULT_DEVICE_NAME,
+  DEFAULT_DTYPE_NAME,
   DEFAULT_MODEL_NAME,
 } from "components/benchmark/llms/common";
 import { GraphPanel } from "components/benchmark/llms/ModelGraphPanel";
@@ -35,6 +36,7 @@ function Report({
   granularity,
   repoName,
   modelName,
+  dtypeName,
   deviceName,
   metricNames,
   lBranchAndCommit,
@@ -46,6 +48,7 @@ function Report({
   granularity: Granularity;
   repoName: string;
   modelName: string;
+  dtypeName: string;
   deviceName: string;
   metricNames: string[];
   lBranchAndCommit: BranchAndCommit;
@@ -54,6 +57,7 @@ function Report({
   const { data: lData, error: _lError } = useBenchmark(
     queryParams,
     modelName,
+    dtypeName,
     deviceName,
     lBranchAndCommit,
     true
@@ -61,6 +65,7 @@ function Report({
   const { data: rData, error: _rError } = useBenchmark(
     queryParams,
     modelName,
+    dtypeName,
     deviceName,
     rBranchAndCommit,
     true
@@ -107,6 +112,7 @@ function Report({
         queryParams={queryParams}
         granularity={granularity}
         modelName={modelName}
+        dtypeName={dtypeName}
         deviceName={deviceName}
         metricNames={metricNames}
         lBranchAndCommit={lBranchAndCommit}
@@ -147,6 +153,7 @@ export default function Page() {
   const [baseUrl, setBaseUrl] = useState<string>("");
   const [repoName, setRepoName] = useState<string>(DEFAULT_REPO_NAME);
   const [modelName, setModelName] = useState<string>(DEFAULT_MODEL_NAME);
+  const [dtypeName, setDTypeName] = useState<string>(DEFAULT_DTYPE_NAME);
   const [deviceName, setDeviceName] = useState<string>(DEFAULT_DEVICE_NAME);
 
   // Set the dropdown value what is in the param
@@ -183,6 +190,11 @@ export default function Page() {
     const modelName: string = (router.query.modelName as string) ?? undefined;
     if (modelName !== undefined) {
       setModelName(modelName);
+    }
+
+    const dtypeName: string = (router.query.dtypeName as string) ?? undefined;
+    if (dtypeName !== undefined) {
+      setDTypeName(dtypeName);
     }
 
     const deviceName: string = (router.query.deviceName as string) ?? undefined;
@@ -267,6 +279,14 @@ export default function Page() {
     DEFAULT_MODEL_NAME,
     ...(_.uniq(data.map((r: any) => r.name)) as string[]),
   ];
+  const deviceNames: string[] = [
+    DEFAULT_DEVICE_NAME,
+    ...(_.uniq(data.map((r: any) => r.device)) as string[]),
+  ];
+  const dtypeNames: string[] = [
+    DEFAULT_DTYPE_NAME,
+    ...(_.uniq(data.map((r: any) => r.dtype)) as string[]),
+  ];
   const metricNames: string[] = _.uniq(data.map((r: any) => r.metric));
 
   return (
@@ -284,6 +304,8 @@ export default function Page() {
             repoName
           )}&modelName=${encodeURIComponent(
             modelName
+          )}&dtypeName=${encodeURIComponent(
+            dtypeName
           )}&deviceName=${encodeURIComponent(deviceName)}`}
         />
       </Stack>
@@ -308,9 +330,15 @@ export default function Page() {
           label={"Model"}
         />
         <DTypePicker
+          dtype={dtypeName}
+          setDType={setDTypeName}
+          dtypes={dtypeNames}
+          label={"DType"}
+        />
+        <DTypePicker
           dtype={deviceName}
           setDType={setDeviceName}
-          dtypes={[DEFAULT_DEVICE_NAME]}
+          dtypes={deviceNames}
           label={"Device"}
         />
         <BranchAndCommitPicker
@@ -349,6 +377,7 @@ export default function Page() {
         granularity={granularity}
         repoName={repoName}
         modelName={modelName}
+        dtypeName={dtypeName}
         deviceName={deviceName}
         metricNames={metricNames}
         lBranchAndCommit={{ branch: lBranch, commit: lCommit }}

--- a/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_branches.sql
+++ b/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_branches.sql
@@ -23,6 +23,8 @@ WHERE
   )
   AND o.metric IS NOT NULL
   AND w.html_url LIKE CONCAT('%', : repo, '%')
+  AND o.dtype IS NOT NULL
+  AND o.device IS NOT NULL
 ORDER BY
   w.head_branch,
   event_time DESC

--- a/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_llms.sql
+++ b/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_llms.sql
@@ -67,8 +67,12 @@ WHERE
     OR : dtypes = ''
   )
   AND o.metric IS NOT NULL
+  AND o.dtype IS NOT NULL
+  AND o.device IS NOT NULL
   AND w.html_url LIKE CONCAT('%', : repo, '%')
 ORDER BY
   granularity_bucket DESC,
   workflow_id DESC,
-  name ASC
+  name,
+  dtype,
+  device

--- a/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_llms.sql
+++ b/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_llms.sql
@@ -18,6 +18,8 @@ SELECT
   FORMAT_ISO8601(
     DATE_TRUNC(: granularity, w._event_time)
   ) AS granularity_bucket,
+  o.dtype,
+  o.device,
 FROM
   benchmarks.oss_ci_benchmark o
   LEFT JOIN commons.workflow_run w ON o.workflow_id = w.id
@@ -49,6 +51,20 @@ WHERE
       o.name
     )
     OR : names = ''
+  )
+  AND (
+    ARRAY_CONTAINS(
+      SPLIT(: devices, ','),
+      o.device
+    )
+    OR : devices = ''
+  )
+  AND (
+    ARRAY_CONTAINS(
+      SPLIT(: dtypes, ','),
+      o.dtype
+    )
+    OR : dtypes = ''
   )
   AND o.metric IS NOT NULL
   AND w.html_url LIKE CONCAT('%', : repo, '%')

--- a/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_names.sql
+++ b/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_names.sql
@@ -25,4 +25,6 @@ WHERE
 ORDER BY
   o.filename,  
   o.name,
-  o.metric
+  o.metric,
+  o.dtype,
+  o.device

--- a/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_names.sql
+++ b/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_names.sql
@@ -3,6 +3,8 @@ SELECT DISTINCT
   o.filename,  
   o.name,  
   o.metric,
+  o.dtype,
+  o.device,
 FROM
   benchmarks.oss_ci_benchmark o
   LEFT JOIN commons.workflow_run w ON o.workflow_id = w.id
@@ -18,6 +20,8 @@ WHERE
   )
   AND o.metric IS NOT NULL
   AND w.html_url LIKE CONCAT('%', : repo, '%')
+  AND o.dtype IS NOT NULL
+  AND o.device IS NOT NULL
 ORDER BY
   o.filename,  
   o.name,

--- a/torchci/rockset/benchmarks/oss_ci_benchmark_llms.lambda.json
+++ b/torchci/rockset/benchmarks/oss_ci_benchmark_llms.lambda.json
@@ -17,6 +17,11 @@
       "value": ""
     },
     {
+      "name": "dtypes",
+      "type": "string",
+      "value": ""
+    },
+    {
       "name": "filenames",
       "type": "string",
       "value": ""

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -110,6 +110,6 @@
   "benchmarks": {
     "oss_ci_benchmark_llms": "a2cb598ac5b13d5a",
     "oss_ci_benchmark_branches": "76446d877defb748",
-    "oss_ci_benchmark_names": "92e166a6605bc812"
+    "oss_ci_benchmark_names": "98a212e928df968b"
   }
 }

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -108,8 +108,8 @@
     "validation_jobs_red_past_day": "aecb798a574ba2ff"
   },
   "benchmarks": {
-    "oss_ci_benchmark_llms": "3fdf5ff69268b022",
-    "oss_ci_benchmark_branches": "a8a2b565346c7fef",
-    "oss_ci_benchmark_names": "4eb39053cbdb479a"
+    "oss_ci_benchmark_llms": "a2cb598ac5b13d5a",
+    "oss_ci_benchmark_branches": "76446d877defb748",
+    "oss_ci_benchmark_names": "92e166a6605bc812"
   }
 }

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -108,7 +108,7 @@
     "validation_jobs_red_past_day": "aecb798a574ba2ff"
   },
   "benchmarks": {
-    "oss_ci_benchmark_llms": "a2cb598ac5b13d5a",
+    "oss_ci_benchmark_llms": "656fe095f7e9a3ab",
     "oss_ci_benchmark_branches": "76446d877defb748",
     "oss_ci_benchmark_names": "98a212e928df968b"
   }


### PR DESCRIPTION
After https://github.com/pytorch/pytorch/pull/128091, we now have dtype and device columns on the dashboard.  This also fixes the ugly view on https://hud.pytorch.org/benchmark/llms where some older records show up without these two columns.

### Testing

https://torchci-git-fork-huydhn-update-llms-benchmark-fbopensource.vercel.app/benchmark/llms