### PR TITLE
[HUD] Flaky tests page: Require more specific search, include rerun disabled tests jobs

### DIFF
--- a/torchci/pages/api/flaky-tests/flakytest.ts
+++ b/torchci/pages/api/flaky-tests/flakytest.ts
@@ -53,13 +53,26 @@ where
   t.name like :name
   and t.classname like :suite
   and t.file like :file
-  and j.name not like '%rerun_disabled_tests%'
+group by
+  t.name,
+  t.classname,
+  t.file,
+  t.invoking_file,
+  j.conclusion,
+  j.id,
+  j.name,
+  j.html_url,
+  j.started_at,
+  j.torchci_classification.line,
+  j.torchci_classification.line_num,
+  j.torchci_classification.captures,
+  w.head_branch,
+  j.head_sha
 order by
   PARSE_TIMESTAMP_ISO8601(j.started_at) desc
 limit
   :limit
-
-  `;
+`;
   const rocksetClient = getRocksetClient();
   const flakyTestQuery = await rocksetClient.queries.query({
     sql: {

--- a/torchci/pages/flakytest.tsx
+++ b/torchci/pages/flakytest.tsx
@@ -5,6 +5,7 @@ import { ParamSelector } from "lib/ParamSelector";
 import { useRouter } from "next/router";
 import useSWR from "swr";
 import { FlakyTestInfoHUD } from "./api/flaky-tests/flakytest";
+import { useEffect, useState } from "react";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
@@ -22,6 +23,16 @@ export default function Page() {
   const suite = (router.query.suite || "%") as string;
   const file = (router.query.file || "%") as string;
   const limit = (router.query.limit || "100") as string;
+  const [hasSearch, setHasSearch] = useState(true);
+  useEffect(() => {
+    console.log(name, suite, file);
+    if (name === "%" && suite === "%" && file === "%") {
+      setHasSearch(false);
+    } else {
+      setHasSearch(true);
+    }
+    console.log(hasSearch);
+  }, [name, suite, file]);
 
   // `useSWR` to avoid sending a garbage request to the server.
   const swrKey = `/api/flaky-tests/flakytest?name=${encodeURIComponent(
@@ -29,7 +40,7 @@ export default function Page() {
   )}&suite=${encodeURIComponent(suite)}&file=${encodeURIComponent(
     file
   )}&limit=${encodeURIComponent(limit)}`;
-  const { data } = useSWR(swrKey, fetcher);
+  const { data } = useSWR(hasSearch && swrKey, fetcher);
 
   return (
     <div>
@@ -59,7 +70,9 @@ export default function Page() {
           handleSubmit={(s) => setURL(name, suite, s, limit)}
         />
       </h3>
-      {data === undefined ? (
+      {!hasSearch ? (
+        <div>Please search for something more specific</div>
+      ) : data === undefined ? (
         <div>Loading...</div>
       ) : (
         (data as FlakyTestInfoHUD[]).map((test) => {

--- a/torchci/pages/flakytest.tsx
+++ b/torchci/pages/flakytest.tsx
@@ -72,7 +72,7 @@ export default function Page() {
       </h3>
       {!hasSearch ? (
         <div>
-          Please click the blue boxes with '%' and enter a test name/class/file
+          Please click the blue boxes with `%` and enter a test name/class/file
           to search for a specific test.
         </div>
       ) : data === undefined ? (

--- a/torchci/pages/flakytest.tsx
+++ b/torchci/pages/flakytest.tsx
@@ -3,9 +3,9 @@ import JobSummary from "components/JobSummary";
 import LogViewer from "components/LogViewer";
 import { ParamSelector } from "lib/ParamSelector";
 import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
 import useSWR from "swr";
 import { FlakyTestInfoHUD } from "./api/flaky-tests/flakytest";
-import { useEffect, useState } from "react";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 

--- a/torchci/pages/flakytest.tsx
+++ b/torchci/pages/flakytest.tsx
@@ -71,7 +71,10 @@ export default function Page() {
         />
       </h3>
       {!hasSearch ? (
-        <div>Please search for something more specific</div>
+        <div>
+          Please click the blue boxes with '%' and enter a test name/class/file
+          to search for a specific test.
+        </div>
       ) : data === undefined ? (
         <div>Loading...</div>
       ) : (


### PR DESCRIPTION
* Requires a more specific search ( cannot do empty name, classname, and file) -  querying for non specific takes a long time
* Includes rerun disabled jobs in results

Mostly looks the same, the content will be different though.  

Normal page with test: https://torchci-git-csl-flakytestspageshowrerundisa-7ca490-fbopensource.vercel.app/flakytest?name=test_aot_module_simplified_fake_tensor_gm_raises&suite=TestAOTModuleSimplified&limit=100

New page with nothing set https://torchci-git-csl-flakytestspageshowrerundisa-7ca490-fbopensource.vercel.app//flakytest?name=%25&suite=&file=%25&limit=100
Old one took forever to load and if it did load, it would look kind of like the previous link