### PR TITLE
Switch to ${{ runner.temp }} (#5327)

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -258,7 +258,7 @@ jobs:
         if: always()
         uses: ./test-infra/.github/actions/chown-directory
         with:
-          directory: ${{ env.RUNNER_TEMP }}
+          directory: ${{ runner.temp }}
           ALPINE_IMAGE: ${{ inputs.runner == 'linux.arm64.2xlarge' && 'arm64v8/alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
 
       - name: Prepare artifacts for upload


### PR DESCRIPTION



Cherry pick #5327 onto release branch to fix executorch release CI problems https://github.com/pytorch/executorch/actions/runs/9555791712/job/26339725286?pr=3994
