### PR TITLE
Remove dependency on legacy ssl

### DIFF
--- a/.github/workflows/lambda-runners.yml
+++ b/.github/workflows/lambda-runners.yml
@@ -29,5 +29,3 @@ jobs:
         run: yarn test
       - name: Build distribution
         run: yarn build
-        env:
-          NODE_OPTIONS: "--openssl-legacy-provider"

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/package.json
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/package.json
@@ -21,7 +21,7 @@
     "@types/jest": "^26.0.20",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
-    "@vercel/ncc": "^0.27.0",
+    "@vercel/ncc": "^0.38.1",
     "eslint": "^8.19.0",
     "jest": "^26.6.3",
     "jest-mock-extended": "^1.0.13",

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/yarn.lock
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/yarn.lock
@@ -1197,10 +1197,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@vercel/ncc@^0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.27.0.tgz#c0cfeebb0bebb56052719efa4a0ecc090a932c76"
-  integrity sha512-DllIJQapnU2YwewIhh/4dYesmMQw3h2cFtabECc/zSJHqUbNa0eJuEkRa6DXbZvh1YPWBtYQoPV17NlDpBw1Vw==
+"@vercel/ncc@^0.38.1":
+  version "0.38.1"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.38.1.tgz#13f08738111e1d9e8a22fd6141f3590e54d9a60e"
+  integrity sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==
 
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.6"


### PR DESCRIPTION
Upgrade from the version of @vercel/ncc which used the legacy ssl provider and required and extra parameter to be passed in.

Requiring this extra parameter to be passed in had broken pytorch/ci-infra's `make link-test-infra-canary` command since that wasn't passing in this new parameter (not to mention it used a less secure form of ssl)