### PR TITLE
[BE] Add `fail-silently` option to setup-ssh

### DIFF
--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -21,6 +21,10 @@ inputs:
   instructions:
     required: false
     description: 'Additional instructions on what to do next'
+  fail-silently:
+    required: true
+    description: 'If set to true, action will always succeed even if it failed to fetch the keys or determine hosts IP address'
+    default: true
 
 runs:
   using: 'node16'

--- a/.github/actions/setup-ssh/index.js
+++ b/.github/actions/setup-ssh/index.js
@@ -16902,6 +16902,7 @@ const node_fetch_1 = __importDefault(__nccwpck_require__(467));
 (0, source_map_support_1.install)();
 async function run() {
     var _a;
+    let failSilently = false;
     try {
         core.info('Please see https://github.com/pytorch/pytorch/wiki/Debugging-using-with-ssh-for-Github-Actions for more info.');
         const activateWithLabel = core.getBooleanInput('activate-with-label');
@@ -16909,6 +16910,7 @@ async function run() {
         const github_token = core.getInput('github-secret');
         const instructions = core.getInput('instructions');
         const removeExistingKeys = core.getBooleanInput('remove-existing-keys');
+        failSilently = core.getBooleanInput('fail-silently');
         let prNumber = (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.number;
         if (github.context.eventName !== 'pull_request') {
             prNumber = (0, github_utils_1.extractCiFlowPrNumber)(github.context.ref);
@@ -16975,11 +16977,12 @@ async function run() {
         }
     }
     catch (error) {
+        const errFunc = failSilently ? core.warning : core.setFailed;
         if (error instanceof Error) {
-            core.setFailed(error.message);
+            errFunc(error.message);
         }
         else {
-            core.setFailed(`Failed due to unexpected error ${error}`);
+            errFunc(`Failed due to unexpected error ${error}`);
         }
     }
 }

--- a/setup-ssh/src/main.ts
+++ b/setup-ssh/src/main.ts
@@ -14,6 +14,7 @@ import fetch from 'node-fetch'
 install()
 
 async function run(): Promise<void> {
+  let failSilently = false
   try {
     core.info(
       'Please see https://github.com/pytorch/pytorch/wiki/Debugging-using-with-ssh-for-Github-Actions for more info.'
@@ -27,6 +28,7 @@ async function run(): Promise<void> {
     const removeExistingKeys: boolean = core.getBooleanInput(
       'remove-existing-keys'
     )
+    failSilently = core.getBooleanInput('fail-silently')
     let prNumber = github.context.payload.pull_request?.number as number
     if (github.context.eventName !== 'pull_request') {
       prNumber = extractCiFlowPrNumber(github.context.ref)
@@ -103,10 +105,11 @@ async function run(): Promise<void> {
       return
     }
   } catch (error) {
+    const errFunc = failSilently ? core.warning : core.setFailed
     if (error instanceof Error) {
-      core.setFailed(error.message)
+      errFunc(error.message)
     } else {
-      core.setFailed(`Failed due to unexpected error ${error}`)
+      errFunc(`Failed due to unexpected error ${error}`)
     }
   }
 }


### PR DESCRIPTION
And set it to true by default. This will prevent workflow failures due to the network outages