### PR TITLE
[Split Build] Add split build to binary build generation

### DIFF
--- a/.github/workflows/generate_binary_build_matrix.yml
+++ b/.github/workflows/generate_binary_build_matrix.yml
@@ -43,6 +43,14 @@ on:
         description: "Generate binary build matrix for a python only package (i.e. only one python version)"
         default: "disable"
         type: string
+      use_split_build:
+        description: |
+          [Experimental] Build a libtorch only wheel and build pytorch such that
+          are built from the libtorch wheel.
+        required: false
+        type: boolean
+        default: false
+
     outputs:
       matrix:
         description: "Generated build matrix"
@@ -79,6 +87,7 @@ jobs:
           # In cases when pipy binaries are not published yet.
           USE_ONLY_DL_PYTORCH_ORG: ${{ inputs.use-only-dl-pytorch-org }}
           BUILD_PYTHON_ONLY: ${{ inputs.build-python-only }}
+          USE_SPLIT_BUILD: ${{ inputs.use_split_build }}
         run: |
           set -eou pipefail
           MATRIX_BLOB="$(python3 tools/scripts/generate_binary_build_matrix.py)"


### PR DESCRIPTION

Adds split build to binary generation script. The outputs of the json is as follows. We will need to also add it to testing proper.

```
sahanp@sahanp-mbp ~/test-infra> python tools/scripts/generate_binary_build_matrix.py                                                                                                                                                                                    (pytorch)
{
  "include": [
    {
      "python_version": "3.8",
      "gpu_arch_type": "cpu",
      "gpu_arch_version": "",
      "desired_cuda": "cpu",
      "container_image": "pytorch/manylinux-builder:cpu",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-cpu",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.3.1",
      "use_split_build": false
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "cuda",
      "gpu_arch_version": "11.8",
      "desired_cuda": "cu118",
      "container_image": "pytorch/manylinux-builder:cuda11.8",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-cuda11_8",
      "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.3.1",
      "use_split_build": false
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "cuda",
      "gpu_arch_version": "12.1",
      "desired_cuda": "cu121",
      "container_image": "pytorch/manylinux-builder:cuda12.1",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-cuda12_1",
      "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu121",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.3.1",
      "use_split_build": false
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "cuda",
      "gpu_arch_version": "12.4",
      "desired_cuda": "cu124",
      "container_image": "pytorch/manylinux-builder:cuda12.4",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-cuda12_4",
      "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu124",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.3.1",
      "use_split_build": false
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "rocm",
      "gpu_arch_version": "6.0",
      "desired_cuda": "rocm6.0",
      "container_image": "pytorch/manylinux-builder:rocm6.0",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-rocm6_0",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.0",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.3.1",
      "use_split_build": false
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "rocm",
      "gpu_arch_version": "6.1",
      "desired_cuda": "rocm6.1",
      "container_image": "pytorch/manylinux-builder:rocm6.1",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-rocm6_1",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.1",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.3.1",
      "use_split_build": false
    }
  ]
}
sahanp@sahanp-mbp ~/test-infra> python tools/scripts/generate_binary_build_matrix.py --use-split-build true                                                                                                                                                             (pytorch)
{
  "include": [
    {
      "python_version": "3.8",
      "gpu_arch_type": "cpu",
      "gpu_arch_version": "",
      "desired_cuda": "cpu",
      "container_image": "pytorch/manylinux-builder:cpu",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-cpu",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.3.1",
      "use_split_build": false
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "cpu",
      "gpu_arch_version": "",
      "desired_cuda": "cpu",
      "container_image": "pytorch/manylinux-builder:cpu",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-cpu-split",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.3.1",
      "use_split_build": true
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "cuda",
      "gpu_arch_version": "11.8",
      "desired_cuda": "cu118",
      "container_image": "pytorch/manylinux-builder:cuda11.8",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-cuda11_8",
      "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.3.1",
      "use_split_build": false
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "cuda",
      "gpu_arch_version": "11.8",
      "desired_cuda": "cu118",
      "container_image": "pytorch/manylinux-builder:cuda11.8",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-cuda11_8-split",
      "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.3.1",
      "use_split_build": true
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "cuda",
      "gpu_arch_version": "12.1",
      "desired_cuda": "cu121",
      "container_image": "pytorch/manylinux-builder:cuda12.1",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-cuda12_1",
      "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu121",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.3.1",
      "use_split_build": false
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "cuda",
      "gpu_arch_version": "12.1",
      "desired_cuda": "cu121",
      "container_image": "pytorch/manylinux-builder:cuda12.1",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-cuda12_1-split",
      "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu121",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.3.1",
      "use_split_build": true
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "cuda",
      "gpu_arch_version": "12.4",
      "desired_cuda": "cu124",
      "container_image": "pytorch/manylinux-builder:cuda12.4",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-cuda12_4",
      "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu124",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.3.1",
      "use_split_build": false
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "cuda",
      "gpu_arch_version": "12.4",
      "desired_cuda": "cu124",
      "container_image": "pytorch/manylinux-builder:cuda12.4",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-cuda12_4-split",
      "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu124",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.3.1",
      "use_split_build": true
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "rocm",
      "gpu_arch_version": "6.0",
      "desired_cuda": "rocm6.0",
      "container_image": "pytorch/manylinux-builder:rocm6.0",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-rocm6_0",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.0",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.3.1",
      "use_split_build": false
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "rocm",
      "gpu_arch_version": "6.0",
      "desired_cuda": "rocm6.0",
      "container_image": "pytorch/manylinux-builder:rocm6.0",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-rocm6_0-split",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.0",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.3.1",
      "use_split_build": true
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "rocm",
      "gpu_arch_version": "6.1",
      "desired_cuda": "rocm6.1",
      "container_image": "pytorch/manylinux-builder:rocm6.1",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-rocm6_1",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.1",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.3.1",
      "use_split_build": false
    },
    {
      "python_version": "3.8",
      "gpu_arch_type": "rocm",
      "gpu_arch_version": "6.1",
      "desired_cuda": "rocm6.1",
      "container_image": "pytorch/manylinux-builder:rocm6.1",
      "package_type": "manywheel",
      "build_name": "manywheel-py3_8-rocm6_1-split",
      "validation_runner": "linux.2xlarge",
      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.1",
      "channel": "nightly",
      "upload_to_base_bucket": "no",
      "stable_version": "2.3.1",
      "use_split_build": true
    }
  ]
}
```
