### PR TITLE
Handle cancelled timeout step on Dr.CI

### DIFF
--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -53,6 +53,9 @@ export const SUPPRESSED_JOB_BY_LABELS: { [job: string]: string[] } = {
 export const EXCLUDED_FROM_SIMILARITY_POST_PROCESSING = [
   new RegExp("Process completed with exit code \\d+"),
 ];
+// This error is returned when a step in the job timeout and is cancelled
+export const CANCELLED_STEP_ERROR: string =
+  "##[error]The operation was canceled.";
 
 export function formDrciHeader(
   owner: string,

--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -54,8 +54,7 @@ export const EXCLUDED_FROM_SIMILARITY_POST_PROCESSING = [
   new RegExp("Process completed with exit code \\d+"),
 ];
 // This error is returned when a step in the job timeout and is cancelled
-export const CANCELLED_STEP_ERROR: string =
-  "##[error]The operation was canceled.";
+export const CANCELLED_STEP_ERROR = "##[error]The operation was canceled.";
 
 export function formDrciHeader(
   owner: string,

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -1,5 +1,6 @@
 import { fetchJSON } from "lib/bot/utils";
 import {
+  CANCELLED_STEP_ERROR,
   fetchIssueLabels,
   FLAKY_RULES_JSON,
   formDrciComment,
@@ -548,10 +549,14 @@ export function constructResultsComment(
   const unrelatedFailureCount =
     flakyJobs.length + brokenTrunkJobs.length + unstableJobs.length;
   const newFailedJobs: RecentWorkflowsData[] = failedJobs.filter(
-    (job) => job.conclusion !== "cancelled"
+    (job) =>
+      job.conclusion !== "cancelled" &&
+      !job.failure_captures.includes(CANCELLED_STEP_ERROR)
   );
   const cancelledJobs: RecentWorkflowsData[] = failedJobs.filter(
-    (job) => job.conclusion === "cancelled"
+    (job) =>
+      job.conclusion === "cancelled" ||
+      job.failure_captures.includes(CANCELLED_STEP_ERROR)
   );
   const failing =
     failedJobs.length +


### PR DESCRIPTION
A minor fix on Dr.CI to correctly group cancelled timeout step into cancelled group.

### Testing

https://github.com/pytorch/pytorch/pull/128801

BEFORE

## :x: 1 New Failure, 1 Unrelated Failure
As of commit 3a7846bb10be264306c1b30d43db62f96dfd4788 with merge base f9dae86222aaf15ea085c7774da70781bae46ff9 (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1718581874?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details open><summary><b>NEW FAILURE</b> - The following job has failed:</summary><p>

* [trunk / macos-py3-arm64 / build](https://hud.pytorch.org/pr/pytorch/pytorch/128801#26309349897) ([gh](https://github.com/pytorch/pytorch/actions/runs/9542158142/job/26309349897))
    `##[error]The operation was canceled.`
</p></details>
<details ><summary><b>FLAKY</b> - The following job failed but was likely due to flakiness present on trunk:</summary><p>

* [pull / linux-jammy-py3.8-gcc11 / test (distributed, 1, 2, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/128801#26294298713) ([gh](https://github.com/pytorch/pytorch/actions/runs/9541160400/job/26294298713)) ([similar failure](https://hud.pytorch.org/pytorch/pytorch/commit/9f076b4f2c96b2d50e468a0557802b99b2954e0c#26277268726))
    `Process completed with exit code 1.`
</p></details>

AFTER

## :x: 1 Cancelled Job, 1 Unrelated Failure
As of commit 3a7846bb10be264306c1b30d43db62f96dfd4788 with merge base f9dae86222aaf15ea085c7774da70781bae46ff9 (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1718581874?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details ><summary><b>CANCELLED JOB</b> - The following job was cancelled. Please retry:</summary><p>

* [trunk / macos-py3-arm64 / build](https://hud.pytorch.org/pr/pytorch/pytorch/128801#26309349897) ([gh](https://github.com/pytorch/pytorch/actions/runs/9542158142/job/26309349897))
    `##[error]The operation was canceled.`
</p></details>
<details ><summary><b>FLAKY</b> - The following job failed but was likely due to flakiness present on trunk:</summary><p>

* [pull / linux-jammy-py3.8-gcc11 / test (distributed, 1, 2, linux.2xlarge)](https://hud.pytorch.org/pr/pytorch/pytorch/128801#26294298713) ([gh](https://github.com/pytorch/pytorch/actions/runs/9541160400/job/26294298713)) ([similar failure](https://hud.pytorch.org/pytorch/pytorch/commit/9f076b4f2c96b2d50e468a0557802b99b2954e0c#26277268726))
    `Process completed with exit code 1.`
</p></details>