### PR TITLE
[BE][EZ] Reduce unnecessary windows AMI uploading

### DIFF
--- a/aws/ami/windows/windows.pkr.hcl
+++ b/aws/ami/windows/windows.pkr.hcl
@@ -25,7 +25,7 @@ source "amazon-ebs" "windows_ebs_builder" {
   }
   source_ami      = "${data.amazon-ami.windows_root_ami.id}"
   region          = "us-east-1"
-  ami_regions     = ["us-east-1", "us-east-2"]
+  ami_regions     = ["us-east-1"]
   user_data_file  = "user-data-scripts/bootstrap-winrm.ps1"
   winrm_insecure  = true
   winrm_use_ssl   = true


### PR DESCRIPTION
We only have runners in us-east-1, so there's no reason to upload our AMI to us-east-2 as well.