### PR TITLE
Improve autoscale lambda release documentation and ease of use

### DIFF
--- a/.github/workflows/lambda-release-tag-runners.yml
+++ b/.github/workflows/lambda-release-tag-runners.yml
@@ -1,7 +1,12 @@
+name: Create Release Tag
+
 on:
   workflow_dispatch: {}
-
-name: Create Release Tag
+  push: # Automatically tag as release eligible changes to autoscaler lambdas once merged to main
+    branches:
+      - main
+    paths:
+      - 'terraform-aws-github-runnerr/**'
 
 jobs:
   tag:

--- a/terraform-aws-github-runner/README.md
+++ b/terraform-aws-github-runner/README.md
@@ -3,7 +3,7 @@
 This is a terraform module that sets up self hosted github runners on AWS along with the infra needed to autoscale them
 
 # Release
-Terraform code that uses this module refer to the specific that they use via a file called `Terrafile`.  We need to create a new tag for any changes here that we want to deploy and update the `Terrafile` to refer to that tag:
+Terraform code that uses this module specify the tag (version of test-infra) that they use via a file called `Terrafile`.  We need to create a new tag for any changes here that we want to deploy and update the `Terrafile` to refer to that tag:
 
 1. Merge the PR to `main` and wait for the `Create Release Tag` workflow to run (or trigger it manually). This will give your commit a unique release tag.
 1. In the terraform script that consumes this module, go to the `Terrafile` file and modify the `tag` for `terraform-aws-github-runner` to point to the new release tag.

--- a/terraform-aws-github-runner/README.md
+++ b/terraform-aws-github-runner/README.md
@@ -6,6 +6,7 @@ This is a terraform module that sets up self hosted github runners on AWS along 
 To use the changes made to these files:
 1. Merge the PR to `main` and wait for the `Create Release Tag` workflow to run (or trigger it manually). This will give your commit a unique release tag.
 1. In the terraform script that consumes this module, go to the `Terrafile` file and modify the `tag` for `terraform-aws-github-runner` to point to the new release tag.
+1. Now when you apply the terraform code that uses this module, it'll pull in your changes (for PyTorch CI, there are workflows you trigger in pytorch-gha-infra and ci-infra for this step).
 
 # Directories
 

--- a/terraform-aws-github-runner/README.md
+++ b/terraform-aws-github-runner/README.md
@@ -3,7 +3,8 @@
 This is a terraform module that sets up self hosted github runners on AWS along with the infra needed to autoscale them
 
 # Release
-To use the changes made to these files:
+Terraform code that uses this module refer to the specific that they use via a file called `Terrafile`.  We need to create a new tag for any changes here that we want to deploy and update the `Terrafile` to refer to that tag:
+
 1. Merge the PR to `main` and wait for the `Create Release Tag` workflow to run (or trigger it manually). This will give your commit a unique release tag.
 1. In the terraform script that consumes this module, go to the `Terrafile` file and modify the `tag` for `terraform-aws-github-runner` to point to the new release tag.
 1. Now when you apply the terraform code that uses this module, it'll pull in your changes (for PyTorch CI, there are workflows you trigger in pytorch-gha-infra and ci-infra for this step).

--- a/terraform-aws-github-runner/README.md
+++ b/terraform-aws-github-runner/README.md
@@ -5,7 +5,7 @@ This is a terraform module that sets up self hosted github runners on AWS along 
 # Release
 Terraform code that uses this module specify the tag (version of test-infra) that they use via a file called `Terrafile`.  We need to create a new tag for any changes here that we want to deploy and update the `Terrafile` to refer to that tag:
 
-1. Merge the PR to `main` and wait for the `Create Release Tag` workflow to run (or trigger it manually). This will give your commit a unique release tag.
+1. Merge any changes to this folder to `main` and wait for the `Create Release Tag` workflow to run (or trigger it manually). This will give your commit a unique release tag.
 1. In the terraform script that consumes this module, go to the `Terrafile` file and modify the `tag` for `terraform-aws-github-runner` to point to the new release tag.
 1. Now when you apply the terraform code that uses this module, it'll pull in your changes (for PyTorch CI, there are workflows you trigger in pytorch-gha-infra and ci-infra for this step).
 

--- a/terraform-aws-github-runner/README.md
+++ b/terraform-aws-github-runner/README.md
@@ -2,6 +2,11 @@
 
 This is a terraform module that sets up self hosted github runners on AWS along with the infra needed to autoscale them
 
+# Release
+To use the changes made to these files:
+1. Merge the PR to `main` and wait for the `Create Release Tag` workflow to run (or trigger it manually). This will give your commit a unique release tag.
+1. In the terraform script that consumes this module, go to the `Terrafile` file and modify the `tag` for `terraform-aws-github-runner` to point to the new release tag.
+
 # Directories
 
 ```


### PR DESCRIPTION
Document and automate the step of tagging updates to the autoscale lambdas in order to actually use them.

The lambdas are what scales our runners up and down. This folder contains code to define those lambdas and a terraform module that provisions them