### PR TITLE
[RS migration][drci] upload merge bases to s3, fix changed files query

### DIFF
--- a/torchci/lib/s3.ts
+++ b/torchci/lib/s3.ts
@@ -1,0 +1,11 @@
+import { S3Client } from "@aws-sdk/client-s3";
+
+const s3client = new S3Client({
+  region: "us-east-1",
+  credentials: {
+    accessKeyId: process.env.OUR_AWS_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.OUR_AWS_SECRET_ACCESS_KEY!,
+  },
+});
+
+export default s3client;

--- a/torchci/lib/s3.ts
+++ b/torchci/lib/s3.ts
@@ -1,11 +1,11 @@
 import { S3Client } from "@aws-sdk/client-s3";
 
-const s3client = new S3Client({
-  region: "us-east-1",
-  credentials: {
-    accessKeyId: process.env.OUR_AWS_ACCESS_KEY_ID!,
-    secretAccessKey: process.env.OUR_AWS_SECRET_ACCESS_KEY!,
-  },
-});
-
-export default s3client;
+export function getS3Client() {
+  return new S3Client({
+    region: "us-east-1",
+    credentials: {
+      accessKeyId: process.env.OUR_AWS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.OUR_AWS_SECRET_ACCESS_KEY!,
+    },
+  });
+}

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -1,3 +1,4 @@
+import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { fetchJSON } from "lib/bot/utils";
 import {
   CANCELLED_STEP_ERROR,
@@ -40,6 +41,7 @@ import {
   removeJobNameSuffix,
 } from "lib/jobUtils";
 import getRocksetClient from "lib/rockset";
+import s3client from "lib/s3";
 import { IssueData, PRandJobs, RecentWorkflowsData } from "lib/types";
 import _ from "lodash";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -297,7 +299,6 @@ where
       })
     ).results?.map((v) => [v.head_sha, v])
   );
-  const newData: any[] = [];
 
   await forAllPRs(
     workflowsByPR,
@@ -315,13 +316,25 @@ where
         pr_info.merge_base_date =
           diff.data.merge_base_commit.commit.committer?.date ?? "";
 
-        newData.push({
-          sha: pr_info.head_sha,
-          merge_base: pr_info.merge_base,
-          changed_files: diff.data.files?.map((e) => e.filename),
-          merge_base_commit_date: pr_info.merge_base_date ?? "",
-          repo: `${OWNER}/${repo}`,
-        });
+        try {
+          const data = {
+            sha: pr_info.head_sha,
+            merge_base: pr_info.merge_base,
+            changed_files: diff.data.files?.map((e) => e.filename),
+            merge_base_commit_date: pr_info.merge_base_date ?? "",
+            repo: `${OWNER}/${repo}`,
+            _id: `${OWNER}-${repo}-${pr_info.head_sha}`,
+          };
+          s3client.send(
+            new PutObjectCommand({
+              Bucket: "ossci-raw-job-status",
+              Key: `merge_bases/${OWNER}/${repo}/${pr_info.head_sha}`,
+              Body: JSON.stringify(data),
+            })
+          );
+        } catch (e) {
+          console.error("Failed to upload to S3", e);
+        }
       } else {
         pr_info.merge_base = rocksetMergeBase.merge_base;
         pr_info.merge_base_date = rocksetMergeBase.merge_base_commit_date;
@@ -339,9 +352,6 @@ where
       pr_info.merge_base_date = "";
     }
   );
-  rocksetClient.documents.addDocuments("commons", "merge_bases", {
-    data: newData,
-  });
 }
 
 export async function getBaseCommitJobs(

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -338,6 +338,7 @@ where
               Bucket: "ossci-raw-job-status",
               Key: `merge_bases/${OWNER}/${repo}/${pr_info.head_sha}`,
               Body: JSON.stringify(data),
+              ContentType: "application/json",
             })
           );
         } catch (e) {

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -317,11 +317,18 @@ where
         pr_info.merge_base_date =
           diff.data.merge_base_commit.commit.committer?.date ?? "";
 
+        const diffWithMergeBase = await octokit.rest.repos.compareCommits({
+          owner: OWNER,
+          repo: repo,
+          base: pr_info.merge_base,
+          head: pr_info.head_sha,
+        });
+
         try {
           const data = {
             sha: pr_info.head_sha,
             merge_base: pr_info.merge_base,
-            changed_files: diff.data.files?.map((e) => e.filename),
+            changed_files: diffWithMergeBase.data.files?.map((e) => e.filename),
             merge_base_commit_date: pr_info.merge_base_date ?? "",
             repo: `${OWNER}/${repo}`,
             _id: `${OWNER}-${repo}-${pr_info.head_sha}`,

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -41,7 +41,7 @@ import {
   removeJobNameSuffix,
 } from "lib/jobUtils";
 import getRocksetClient from "lib/rockset";
-import s3client from "lib/s3";
+import { getS3Client } from "lib/s3";
 import { IssueData, PRandJobs, RecentWorkflowsData } from "lib/types";
 import _ from "lodash";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -275,6 +275,7 @@ where
     and repo = :repo
   `;
   const rocksetClient = getRocksetClient();
+  const s3client = getS3Client();
 
   const rocksetMergeBases = new Map(
     (

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -336,7 +336,7 @@ where
           s3client.send(
             new PutObjectCommand({
               Bucket: "ossci-raw-job-status",
-              Key: `merge_bases/${OWNER}/${repo}/${pr_info.head_sha}`,
+              Key: `merge_bases/${OWNER}/${repo}/${pr_info.head_sha}.gzip`,
               Body: JSON.stringify(data),
               ContentType: "application/json",
             })

--- a/torchci/test/drciBot.test.ts
+++ b/torchci/test/drciBot.test.ts
@@ -1,5 +1,7 @@
+import { S3Client } from "@aws-sdk/client-s3";
 import * as drciUtils from "lib/drciUtils";
 import { OWNER, REPO } from "lib/drciUtils";
+import * as getS3Client from "lib/s3";
 import nock from "nock";
 import { Probot } from "probot";
 import myProbotApp from "../lib/bot/drciBot";
@@ -23,6 +25,15 @@ describe("verify-drci-functionality", () => {
     nock("https://raw.githubusercontent.com")
       .get((url) => url.includes("rules.json"))
       .reply(200, []);
+
+    const mockS3 = {
+      send: jest.fn(),
+    };
+    jest.mock("aws-sdk", () => ({
+      S3: jest.fn().mockImplementation(() => mockS3),
+    }));
+    const mockS3Client = jest.spyOn(getS3Client, "getS3Client");
+    mockS3Client.mockImplementation(() => mockS3 as unknown as S3Client);
   });
 
   afterEach(() => {

--- a/torchci/test/drciBot.test.ts
+++ b/torchci/test/drciBot.test.ts
@@ -187,8 +187,6 @@ describe("verify-drci-functionality", () => {
         (body) => JSON.stringify(body).includes("merge_commit_sha")
       )
       .reply(200, { results: [] }) // query to get the previous merge commit sha
-      .post((url) => url.includes("merge_bases"))
-      .reply(200, { results: [] }) // query to insert back to rockset
       .post(
         (url) => url.includes("self/queries"),
         (body) => JSON.stringify(body).includes("issue_comment")


### PR DESCRIPTION
Upload the merge bases to s3 instead of rockset.  Tested locally by running `curl "http://localhost:3000/api/drci/drci?prNumber=130387" --data 'repo=pytorch'` with the part to query rockset commented out and checked that something got put to s3.

Also sanity checked that the bucket could be ingested by rockset

Fixed changed files query (previously it was taking the diff between the PR head and the main branch head, now it does another query for the files between the merge base and the PR head.  I don't know how I didn't miss this before)


* Companion to https://github.com/pytorch/test-infra/pull/5377