### PR TITLE
Add g6.4xlarge runner type

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -117,6 +117,12 @@ runner_types:
     is_ephemeral: false
     max_available: 1200
     os: linux
+  linux.g6.4xlarge.nvidia.gpu:
+    disk_size: 150
+    instance_type: g6.4xlarge
+    is_ephemeral: false
+    max_available: 30
+    os: linux    
   linux.large:
     max_available: 1200
     disk_size: 15


### PR DESCRIPTION
Which enables one to test float8 dtypes supported by https://www.nvidia.com/en-us/data-center/l4/ GPUs , see https://aws.amazon.com/ec2/instance-types/g6/