### PR TITLE
[RS migration] merge_bases generation script to upload to s3 instead of rockset

### DIFF
--- a/.github/workflows/update_test_file_ratings.yml
+++ b/.github/workflows/update_test_file_ratings.yml
@@ -1,10 +1,6 @@
 name: Update test file ratings for TD Heuristics
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/update_test_file_ratings.yml"
-      - "tools/torchci/td"
   schedule:
     - cron: 5 11 * * *  # At 11:05 UTC every day or about 4am PT
 
@@ -14,6 +10,7 @@ concurrency:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   update-test-file-ratings:
@@ -37,6 +34,12 @@ jobs:
           pip3 install boto3==1.19.12 rockset==1.0.3
           cd test-infra/tools/torchci
           pip3 install -e .
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/upload_to_ossci_raw_job_status
+          aws-region: us-east-1
 
       - name: Get merge base info
         run: |

--- a/.github/workflows/update_test_file_ratings.yml
+++ b/.github/workflows/update_test_file_ratings.yml
@@ -3,7 +3,6 @@ name: Update test file ratings for TD Heuristics
 on:
   schedule:
     - cron: 5 11 * * *  # At 11:05 UTC every day or about 4am PT
-  push:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
@@ -48,56 +47,56 @@ jobs:
         env:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
 
-      # - name: Generate file test ratings
-      #   run: |
-      #     set -ex
-      #     python3 test-infra/tools/torchci/td/historical_file_failure_correlation.py
-      #     python3 test-infra/tools/torchci/td/historical_class_failure_correlation.py
-      #     python3 test-infra/tools/torchci/td/td_heuristic_historical_edited_files.py
-      #     # Do not run this one, it won't change
-      #     # python3 test-infra/tools/torchci/td/td_heuristic_profiling.py
+      - name: Generate file test ratings
+        run: |
+          set -ex
+          python3 test-infra/tools/torchci/td/historical_file_failure_correlation.py
+          python3 test-infra/tools/torchci/td/historical_class_failure_correlation.py
+          python3 test-infra/tools/torchci/td/td_heuristic_historical_edited_files.py
+          # Do not run this one, it won't change
+          # python3 test-infra/tools/torchci/td/td_heuristic_profiling.py
 
-      #   env:
-      #     ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
+        env:
+          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
 
-      # - name: Push file to test file correlations to test-infra repository
-      #   if: github.event_name != 'pull_request'
-      #   uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
-      #   env:
-      #     API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     source_file: "file_test_rating.json"
-      #     destination_repo: "pytorch/test-infra"
-      #     destination_folder: "stats"
-      #     destination_branch: generated-stats
-      #     user_email: "test-infra@pytorch.org"
-      #     user_name: "Pytorch Test Infra"
-      #     commit_message: "Updating file to test file correlations"
+      - name: Push file to test file correlations to test-infra repository
+        if: github.event_name != 'pull_request'
+        uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          source_file: "file_test_rating.json"
+          destination_repo: "pytorch/test-infra"
+          destination_folder: "stats"
+          destination_branch: generated-stats
+          user_email: "test-infra@pytorch.org"
+          user_name: "Pytorch Test Infra"
+          commit_message: "Updating file to test file correlations"
 
-      # - name: Push file to test class correlations to test-infra repository
-      #   if: github.event_name != 'pull_request'
-      #   uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
-      #   env:
-      #     API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     source_file: "file_test_class_rating.json"
-      #     destination_repo: "pytorch/test-infra"
-      #     destination_folder: "stats"
-      #     destination_branch: generated-stats
-      #     user_email: "test-infra@pytorch.org"
-      #     user_name: "Pytorch Test Infra"
-      #     commit_message: "Updating file to test class correlations"
+      - name: Push file to test class correlations to test-infra repository
+        if: github.event_name != 'pull_request'
+        uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          source_file: "file_test_class_rating.json"
+          destination_repo: "pytorch/test-infra"
+          destination_folder: "stats"
+          destination_branch: generated-stats
+          user_email: "test-infra@pytorch.org"
+          user_name: "Pytorch Test Infra"
+          commit_message: "Updating file to test class correlations"
 
-      # - name: Push historical edited files heuristic to test-infra repository
-      #   if: github.event_name != 'pull_request'
-      #   uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
-      #   env:
-      #     API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     source_file: "td_heuristic_historical_edited_files.json"
-      #     destination_repo: "pytorch/test-infra"
-      #     destination_folder: "stats"
-      #     destination_branch: generated-stats
-      #     user_email: "test-infra@pytorch.org"
-      #     user_name: "Pytorch Test Infra"
-      #     commit_message: "Updating TD heuristic: historical edited files"
+      - name: Push historical edited files heuristic to test-infra repository
+        if: github.event_name != 'pull_request'
+        uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          source_file: "td_heuristic_historical_edited_files.json"
+          destination_repo: "pytorch/test-infra"
+          destination_folder: "stats"
+          destination_branch: generated-stats
+          user_email: "test-infra@pytorch.org"
+          user_name: "Pytorch Test Infra"
+          commit_message: "Updating TD heuristic: historical edited files"

--- a/.github/workflows/update_test_file_ratings.yml
+++ b/.github/workflows/update_test_file_ratings.yml
@@ -3,6 +3,7 @@ name: Update test file ratings for TD Heuristics
 on:
   schedule:
     - cron: 5 11 * * *  # At 11:05 UTC every day or about 4am PT
+  push:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
@@ -47,56 +48,56 @@ jobs:
         env:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
 
-      - name: Generate file test ratings
-        run: |
-          set -ex
-          python3 test-infra/tools/torchci/td/historical_file_failure_correlation.py
-          python3 test-infra/tools/torchci/td/historical_class_failure_correlation.py
-          python3 test-infra/tools/torchci/td/td_heuristic_historical_edited_files.py
-          # Do not run this one, it won't change
-          # python3 test-infra/tools/torchci/td/td_heuristic_profiling.py
+      # - name: Generate file test ratings
+      #   run: |
+      #     set -ex
+      #     python3 test-infra/tools/torchci/td/historical_file_failure_correlation.py
+      #     python3 test-infra/tools/torchci/td/historical_class_failure_correlation.py
+      #     python3 test-infra/tools/torchci/td/td_heuristic_historical_edited_files.py
+      #     # Do not run this one, it won't change
+      #     # python3 test-infra/tools/torchci/td/td_heuristic_profiling.py
 
-        env:
-          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
+      #   env:
+      #     ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
 
-      - name: Push file to test file correlations to test-infra repository
-        if: github.event_name != 'pull_request'
-        uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          source_file: "file_test_rating.json"
-          destination_repo: "pytorch/test-infra"
-          destination_folder: "stats"
-          destination_branch: generated-stats
-          user_email: "test-infra@pytorch.org"
-          user_name: "Pytorch Test Infra"
-          commit_message: "Updating file to test file correlations"
+      # - name: Push file to test file correlations to test-infra repository
+      #   if: github.event_name != 'pull_request'
+      #   uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
+      #   env:
+      #     API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     source_file: "file_test_rating.json"
+      #     destination_repo: "pytorch/test-infra"
+      #     destination_folder: "stats"
+      #     destination_branch: generated-stats
+      #     user_email: "test-infra@pytorch.org"
+      #     user_name: "Pytorch Test Infra"
+      #     commit_message: "Updating file to test file correlations"
 
-      - name: Push file to test class correlations to test-infra repository
-        if: github.event_name != 'pull_request'
-        uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          source_file: "file_test_class_rating.json"
-          destination_repo: "pytorch/test-infra"
-          destination_folder: "stats"
-          destination_branch: generated-stats
-          user_email: "test-infra@pytorch.org"
-          user_name: "Pytorch Test Infra"
-          commit_message: "Updating file to test class correlations"
+      # - name: Push file to test class correlations to test-infra repository
+      #   if: github.event_name != 'pull_request'
+      #   uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
+      #   env:
+      #     API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     source_file: "file_test_class_rating.json"
+      #     destination_repo: "pytorch/test-infra"
+      #     destination_folder: "stats"
+      #     destination_branch: generated-stats
+      #     user_email: "test-infra@pytorch.org"
+      #     user_name: "Pytorch Test Infra"
+      #     commit_message: "Updating file to test class correlations"
 
-      - name: Push historical edited files heuristic to test-infra repository
-        if: github.event_name != 'pull_request'
-        uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          source_file: "td_heuristic_historical_edited_files.json"
-          destination_repo: "pytorch/test-infra"
-          destination_folder: "stats"
-          destination_branch: generated-stats
-          user_email: "test-infra@pytorch.org"
-          user_name: "Pytorch Test Infra"
-          commit_message: "Updating TD heuristic: historical edited files"
+      # - name: Push historical edited files heuristic to test-infra repository
+      #   if: github.event_name != 'pull_request'
+      #   uses: dmnemec/copy_file_to_another_repo_action@eebb594efdf52bc12e1b461988d7254322dac131
+      #   env:
+      #     API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     source_file: "td_heuristic_historical_edited_files.json"
+      #     destination_repo: "pytorch/test-infra"
+      #     destination_folder: "stats"
+      #     destination_branch: generated-stats
+      #     user_email: "test-infra@pytorch.org"
+      #     user_name: "Pytorch Test Infra"
+      #     commit_message: "Updating TD heuristic: historical edited files"

--- a/tools/torchci/rockset_utils.py
+++ b/tools/torchci/rockset_utils.py
@@ -24,26 +24,3 @@ def query_rockset(
         return get_rockset_client().sql(query, params=params).results
 
     return cache_query_rockset(query, params)
-
-
-def upload_to_rockset(
-    collection: str, docs: List[Any], workspace: str = "commons"
-) -> None:
-    client = get_rockset_client()
-    client.Documents.add_documents(
-        collection=collection,
-        data=docs,
-        workspace=workspace,
-    )
-
-
-def remove_from_rockset(
-    collection: str, ids: List[str], workspace: str = "commons"
-) -> None:
-    client = get_rockset_client()
-    ids_to_map = [{"id": id} for id in ids]
-    client.Documents.delete_documents(
-        collection=collection,
-        data=ids_to_map,
-        workspace=workspace,
-    )

--- a/tools/torchci/td/get_merge_base_info.py
+++ b/tools/torchci/td/get_merge_base_info.py
@@ -5,6 +5,7 @@ import subprocess
 from datetime import datetime
 from pathlib import Path
 from typing import List
+
 import boto3  # type: ignore
 from torchci.rockset_utils import query_rockset
 from torchci.td.utils import list_past_year_shas, run_command

--- a/tools/torchci/td/get_merge_base_info.py
+++ b/tools/torchci/td/get_merge_base_info.py
@@ -99,7 +99,6 @@ def upload_merge_base_info(shas: List[str]) -> None:
                 ContentEncoding="gzip",
                 ContentType="application/json",
             )
-            print("uploaded")
         except Exception as e:
             return e
 

--- a/tools/torchci/td/get_merge_base_info.py
+++ b/tools/torchci/td/get_merge_base_info.py
@@ -32,6 +32,9 @@ select
 from
     unnest(SPLIT(:shas, ',') as sha) as shas
     left outer join commons.merge_bases mb on mb.sha = shas.sha
+where
+    mb.sha is null
+    or mb.repo is null
 """
 
 DUP_MERGE_BASE_INFO = """
@@ -121,6 +124,6 @@ if __name__ == "__main__":
                 NOT_IN_MERGE_BASES_TABLE,
                 {"shas": ",".join(main_branch_shas[i : i + interval])},
             )
-        ][:50]
+        ]
         upload_merge_base_info(shas)
         print(f"{i} to {i + interval} done")

--- a/tools/torchci/td/get_merge_base_info.py
+++ b/tools/torchci/td/get_merge_base_info.py
@@ -1,13 +1,18 @@
+import gzip
+import io
+import json
 import subprocess
 from datetime import datetime
 from pathlib import Path
 from typing import List
-
-from torchci.rockset_utils import query_rockset, remove_from_rockset, upload_to_rockset
+import boto3  # type: ignore
+from torchci.rockset_utils import query_rockset
 from torchci.td.utils import list_past_year_shas, run_command
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+S3_RESOURCE = boto3.resource("s3")
 
 FAILED_TEST_SHAS_QUERY = """
 SELECT
@@ -43,17 +48,6 @@ having
 """
 
 
-def dedup_merge_base_info() -> None:
-    ids = []
-    for item in query_rockset(DUP_MERGE_BASE_INFO):
-        for val in item.values():
-            ids.extend(val)
-    interval = 500
-
-    for i in range(0, len(ids), interval):
-        remove_from_rockset("merge_bases", ids[i : i + interval])
-
-
 def run_command(command: str) -> str:
     cwd = REPO_ROOT / ".." / "pytorch"
     return (
@@ -87,24 +81,30 @@ def upload_merge_base_info(shas: List[str]) -> None:
                 f"git show --no-patch --format=%ct {merge_base}"
             )
             timestamp = datetime.utcfromtimestamp(int(unix_timestamp)).isoformat() + "Z"
-            docs.append(
-                {
-                    "sha": sha,
-                    "merge_base": merge_base,
-                    "changed_files": changed_files.splitlines(),
-                    "merge_base_commit_date": timestamp,
-                    "repo": "pytorch/pytorch",
-                }
+            data = {
+                "sha": sha,
+                "merge_base": merge_base,
+                "changed_files": changed_files.splitlines(),
+                "merge_base_commit_date": timestamp,
+                "repo": "pytorch/pytorch",
+                "_id": f"pytorch-pytorch-{sha}",
+            }
+            body = io.StringIO()
+            json.dump(data, body)
+            S3_RESOURCE.Object(
+                f"ossci-raw-job-status",
+                f"merge_bases/pytorch/pytorch/{sha}",
+            ).put(
+                Body=gzip.compress(body.getvalue().encode()),
+                ContentEncoding="gzip",
+                ContentType="application/json",
             )
+            print("uploaded")
         except Exception as e:
             return e
 
-    upload_to_rockset(collection="merge_bases", docs=docs, workspace="commons")
-
 
 if __name__ == "__main__":
-    dedup_merge_base_info()
-
     failed_test_shas = [x["head_sha"] for x in query_rockset(FAILED_TEST_SHAS_QUERY)]
     interval = 100
     print(

--- a/tools/torchci/td/get_merge_base_info.py
+++ b/tools/torchci/td/get_merge_base_info.py
@@ -94,7 +94,7 @@ def upload_merge_base_info(shas: List[str]) -> None:
             json.dump(data, body)
             S3_RESOURCE.Object(
                 f"ossci-raw-job-status",
-                f"merge_bases/pytorch/pytorch/{sha}",
+                f"merge_bases/pytorch/pytorch/{sha}.gzip",
             ).put(
                 Body=gzip.compress(body.getvalue().encode()),
                 ContentEncoding="gzip",

--- a/tools/torchci/td/get_merge_base_info.py
+++ b/tools/torchci/td/get_merge_base_info.py
@@ -32,9 +32,6 @@ select
 from
     unnest(SPLIT(:shas, ',') as sha) as shas
     left outer join commons.merge_bases mb on mb.sha = shas.sha
-where
-    mb.sha is null
-    or mb.repo is null
 """
 
 DUP_MERGE_BASE_INFO = """
@@ -124,6 +121,6 @@ if __name__ == "__main__":
                 NOT_IN_MERGE_BASES_TABLE,
                 {"shas": ",".join(main_branch_shas[i : i + interval])},
             )
-        ]
+        ][:50]
         upload_merge_base_info(shas)
         print(f"{i} to {i + interval} done")


### PR DESCRIPTION
Removes ability to run the update_test_file_ratings on pull request because I don't want to give permissions to write to the bucket to branches

Role defintion in https://github.com/pytorch-labs/pytorch-gha-infra/pull/426

* Companion to https://github.com/pytorch/test-infra/pull/5375
