### PR TITLE
Add `-` to alphaNum character set

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
@@ -306,7 +306,7 @@ export async function getRunnerTypes(
   metrics: Metrics,
   filepath = Config.Instance.scaleConfigRepoPath,
 ): Promise<Map<string, RunnerType>> {
-  const alphaNumericStr = /^[a-zA-Z0-9.\-]+$/;
+  const alphaNumericStr = /^[a-zA-Z0-9.-]+$/;
 
   return await redisCached('ghRunners', `getRunnerTypes-${repo.owner}.${repo.repo}`, 10 * 60, 0.5, async () => {
     let status = 'noRun';

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
@@ -306,7 +306,7 @@ export async function getRunnerTypes(
   metrics: Metrics,
   filepath = Config.Instance.scaleConfigRepoPath,
 ): Promise<Map<string, RunnerType>> {
-  const alphaNumericStr = /^[a-zA-Z0-9.]+$/;
+  const alphaNumericStr = /^[a-zA-Z0-9.\-]+$/;
 
   return await redisCached('ghRunners', `getRunnerTypes-${repo.owner}.${repo.repo}`, 10 * 60, 0.5, async () => {
     let status = 'noRun';


### PR DESCRIPTION
So that runner labels like `foo-metal` will be valid again Test plan:
```
 % /opt/homebrew/bin/node
Welcome to Node.js v22.2.0.
Type ".help" for more information.
> const alphaNumericStr = /^[a-zA-Z0-9.\-]+$/;
undefined
> const alphaNumericStr = /^[a-zA-Z0-9.\-]+$/;
> alphaNumericStr.test("foo-bar")
true
> alphaNumericStr.test("foo.bar")
true
> const alphaNumericStrPrev = /^[a-zA-Z0-9.]+$/;
undefined
> alphaNumericStrPrev.test("foo.bar")
true
> alphaNumericStrPrev.test("foo-bar")
false
```