### PR TITLE
Revert "Add g6.4xlarge runner type"

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -117,12 +117,6 @@ runner_types:
     is_ephemeral: false
     max_available: 1200
     os: linux
-  linux.g6.4xlarge.nvidia.gpu:
-    disk_size: 150
-    instance_type: g6.4xlarge
-    is_ephemeral: false
-    max_available: 30
-    os: linux    
   linux.large:
     max_available: 1200
     disk_size: 15


### PR DESCRIPTION
After reaching out to @malfet we agreed to disable this runner by reverting this commit until we evaluate a more reasonable number for max_runners.