### PR TITLE
Fixing package name kernel-devel-uname-r on user-data.sh + fix shell expansion

### DIFF
--- a/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
@@ -76,7 +76,7 @@ USER_NAME=ec2-user
 ${install_config_runner}
 
 retry sudo $PKG_MANAGER groupinstall -y 'Development Tools'
-retry sudo $PKG_MANAGER install -y "kernel-devel == $(uname -r)" || true
+retry sudo $PKG_MANAGER install -y "kernel-devel-uname-r == $(uname -r)" || true
 
 # Needed since kernel 4.14.336-257.562 is not currently available in package managers
 (

--- a/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 function retry {
   local retries=7
   local count=0
-  until $@; do
+  until "$@"; do
     exit=$?
     wait=$((2 ** $count))
     count=$(($count + 1))

--- a/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
@@ -82,7 +82,7 @@ retry sudo $PKG_MANAGER install -y "kernel-devel-uname-r == $(uname -r)" || true
 (
   pushd /usr/src/kernels/
   aws s3 cp s3://ossci-linux/4.14.336-257.562.amzn2.x86_64.tar.gz .
-  tar xvzf 4.14.336-257.562.amzn2.x86_64.tar.gz
+  tar xzf 4.14.336-257.562.amzn2.x86_64.tar.gz
 )
 
 


### PR DESCRIPTION
During firefight we changed the package name. But after careful investigation, it seems that the package name is not the issue given its presence is over 2 years old.

So I am returning the package, otherwise next kernel upgrade could cause a big breakage again.

Seems that the main isue is that `$@` and `"$@"` expands differently. Being the 2nd one what we want, as it expands to: `"$1" "$2" "$3" ...` over `$1 $2 $3`. This was causing some parameters to be splitted by space.