### PR TITLE
[ez][HUD] Main page permalink to use sha from page one

### DIFF
--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -531,7 +531,7 @@ export default function Hud() {
 }
 
 function useLatestCommitSha(params: HudParams) {
-  const data = useHudData(params);
+  const data = useHudData({ ...params, page: 1, per_page: 1 });
   if (data === undefined) {
     return null;
   }


### PR DESCRIPTION
Currently, if you click the permalink button on the second page of HUD https://hud.pytorch.org/hud/pytorch/pytorch/main/2?per_page=100
<img width="738" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/2c1a5988-19fe-4473-8457-6e991ebce2bc">

Then the result is https://hud.pytorch.org/hud/pytorch/pytorch/c9dc9887db0deff3ccbebf9b59dcbe79c3bd8a4f/2?per_page=100

<img width="947" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/87c1548f-6a75-47b4-bae3-5b0dc05660ee">


Note the difference in first sha shown on the page.  This is because the permalink uses the latest commit sha present on the page (c9dc988), but uses the page param (2 in this example).  

This PR changes it to use the latest commit sha of the branch on page one, so the new permalink is https://torchci-git-csl-permalinkpage1-fbopensource.vercel.app/hud/pytorch/pytorch/29c68df600e6cb8eb61ccfea57d6aa3685b0a30f/2?per_page=100.

The sha is doesn't show up on the original page that we clicked the permalink button on, it's the sha on page 1.  The page param is still 2, allowing us to use the prev button.

An alternate solution would to keep the sha the same (the sha on page 2) but change the page param to be 1, but then you would lose use of the prev button

<img width="920" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/e7d3d4b1-ab22-4664-a6d2-c01cd06c65d3">
