### PR TITLE
[HUD] Main page: better grouping in full view for jobs that are unstable and mem leak check/rerun disabled tests

### DIFF
--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -182,21 +182,31 @@ export function sortGroupNamesForHUD(groupNames: string[]): string[] {
 
 export function classifyGroup(
   jobName: string,
+  showUnstableGroup: boolean,
   unstableIssues?: IssueData[]
 ): string {
   const openUnstableIssues = getOpenUnstableIssues(jobName, unstableIssues);
-  // Double check first if the job has been marked as unstable but doesn't include
-  // the unstable keyword
+  let assignedGroup = undefined;
+  for (const group of groups) {
+    if (jobName.match(group.regex)) {
+      assignedGroup = group;
+      break;
+    }
+  }
+
+  // Check if the job has been marked as unstable but doesn't include the
+  // unstable keyword.
+  if (assignedGroup?.persistent && !showUnstableGroup) {
+    // Persistent groups (mem leak check, rerun disabled tests) should not be
+    // overwritten unless you are hiding the unstable jobs
+    return assignedGroup.name;
+  }
+
   if (openUnstableIssues !== undefined && openUnstableIssues.length !== 0) {
     return GROUP_UNSTABLE;
   }
 
-  for (const group of groups) {
-    if (jobName.match(group.regex)) {
-      return group.name;
-    }
-  }
-  return GROUP_OTHER;
+  return assignedGroup === undefined ? GROUP_OTHER : assignedGroup.name;
 }
 
 export function getGroupConclusionChar(conclusion?: GroupedJobStatus): string {
@@ -290,13 +300,14 @@ export function getConclusionSeverityForSorting(conclusion?: string): number {
 export function getGroupingData(
   shaGrid: RowData[],
   jobNames: string[],
+  showUnstableGroup: boolean,
   unstableIssues?: IssueData[]
 ) {
   // Construct Job Groupping Mapping
   const groupNameMapping = new Map<string, Array<string>>(); // group -> [jobs]
   const jobToGroupName = new Map<string, string>(); // job -> group
   for (const name of jobNames) {
-    const groupName = classifyGroup(name, unstableIssues);
+    const groupName = classifyGroup(name, showUnstableGroup, unstableIssues);
     const jobsInGroup = groupNameMapping.get(groupName) ?? [];
     jobsInGroup.push(name);
     groupNameMapping.set(groupName, jobsInGroup);

--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -196,9 +196,9 @@ export function classifyGroup(
 
   // Check if the job has been marked as unstable but doesn't include the
   // unstable keyword.
-  if (assignedGroup?.persistent && !showUnstableGroup) {
-    // Persistent groups (mem leak check, rerun disabled tests) should not be
-    // overwritten unless you are hiding the unstable jobs
+  if (!showUnstableGroup && assignedGroup?.persistent) {
+    // If the unstable group is not being shown, then persistent groups (mem
+    // leak check, rerun disabled tests) should not be overwritten
     return assignedGroup.name;
   }
 

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -587,16 +587,19 @@ function GroupedHudTable({
     refreshInterval: 300 * 1000, // refresh every 5 minutes
   });
 
-  const { shaGrid, groupNameMapping } = getGroupingData(
-    data.shaGrid,
-    data.jobNames,
-    unstableIssuesData ? unstableIssuesData.issues : []
-  );
-  const [expandedGroups, setExpandedGroups] = useState(new Set<string>());
-
+  const [hideUnstable, setHideUnstable] = usePreference("hideUnstable");
   const [useGrouping, setUseGrouping] = useGroupingPreference(
     params.nameFilter != null && params.nameFilter !== ""
   );
+
+  const { shaGrid, groupNameMapping } = getGroupingData(
+    data.shaGrid,
+    data.jobNames,
+    (!useGrouping && hideUnstable) || (useGrouping && !hideUnstable),
+    unstableIssuesData ? unstableIssuesData.issues : []
+  );
+
+  const [expandedGroups, setExpandedGroups] = useState(new Set<string>());
 
   const router = useRouter();
   useEffect(() => {
@@ -604,8 +607,6 @@ function GroupedHudTable({
     // the value in local storage
     track(router, "groupingPreference", { useGrouping: useGrouping });
   }, [router, useGrouping]);
-
-  const [hideUnstable, setHideUnstable] = usePreference("hideUnstable");
 
   const groupNames = Array.from(groupNameMapping.keys());
   let names = sortGroupNamesForHUD(groupNames);


### PR DESCRIPTION
This is a change to how the unstable & mem leak/rerun disable tests jobs works with the full view.  Previously, if the job was both unstable and mem leak, then it would show up in the main area since unstable jobs show up in the main area and the unstable categorization would take precedence over the mem leak check categorization.  This changes it so that if the unstable group exists, the unstable jobs get put into that group.  However, if it doesn't, then the job goes into the mem leak check group.

### When using full view + showing unstable jobs, unstable jobs that are mem leak or rerun disable tests get:
Old:
Put under the general area
<img width="1876" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/5a768cce-8347-4577-8d3d-cbf5b266e7fb">

New:
Put into the mem leak or rerun disable tests group
<img width="1866" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/3c4333a1-1fe6-4275-b959-d0764138f51c">

### When using full view + hiding unstable jobs:
There is no change.  The unstable jobs get put into the unstable jobs group
<img width="1815" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/eac44410-40dc-4256-9e07-900096af7c9b">


### When using the grouped view + not hiding unstable jobs:

There is no change.  The unstable jobs get put into the unstable jobs group
<img width="1638" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/64627ebb-cd82-4e64-a00a-f79a0d30378a">

### When using the grouped view + hiding unstable jobs:
There is no change.  The unstable jobs group disappears, along with all the unstable jobs
<img width="1221" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/4d5e7795-193f-4740-8710-7136b60c21e5">


