### PR TITLE
Add a util script to copy Rockset collections to dynamoDB tables

### DIFF
--- a/tools/rockset_migration/rockset_2_dynamodb.py
+++ b/tools/rockset_migration/rockset_2_dynamodb.py
@@ -1,22 +1,18 @@
 #!/usr/bin/env python3
 
-import logging
-import pickle
 import hashlib
 import json
+import logging
 import os
 import time
 from argparse import ArgumentParser
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import boto3
 
-import rockset  # type: ignore[import]
 from dateutil import parser  # type: ignore[import]
-from rockset import QueryPaginator, RocksetClient
-
-
-PAGE_SIZE = 1000
+from rockset import RocksetClient  # type: ignore[import]
+from rockset.models import QueryParameter, QueryRequestSql  # type: ignore[import]
 
 
 def parse_args() -> Any:
@@ -52,10 +48,8 @@ def generate_partition_key(repo: str, doc: Dict[str, Any]) -> str:
     """
     Generate an unique partition key for the document on DynamoDB
     """
-    workflow_id = doc.get("workflow_id", "")
-    if workflow_id:
-        doc["workflow_id"] = int(workflow_id)
-    job_id = doc.get("job_id", "")
+    workflow_id = int(doc.get("workflow_id", 0))
+    job_id = int(doc.get("job_id", 0))
     test_name = doc.get("test_name", "")
     filename = doc.get("filename", "")
 
@@ -63,35 +57,60 @@ def generate_partition_key(repo: str, doc: Dict[str, Any]) -> str:
     return f"{repo}/{workflow_id}/{job_id}/{test_name}/{filename}/{hash_content}"
 
 
-def copy(
+def get_workflow_ids(
+    rs_client: RocksetClient, workspace: str, collection: str
+) -> List[int]:
+    """
+    Attempt to query the whole 3M+ records from some table fails with Rockset returns
+    gibberish, so we need to make the query smaller by processing each workflow id
+    sequentially
+    """
+    query = f"SELECT DISTINCT workflow_id FROM {workspace}.{collection} GROUP BY workflow_id"
+    docs = rs_client.sql(query=query)
+    return [int(doc["workflow_id"]) for doc in docs["results"]]
+
+
+def copy_perf_stats(
     workspace: str, collection: str, dynamodb_table: str, repo: str = "pytorch/pytorch"
 ) -> None:
     rs = RocksetClient(
         host="api.usw2a1.rockset.com", api_key=os.environ["ROCKSET_API_KEY"]
     )
 
+    # Break down by workflow ID, issuing a select all statement to Rockset returns gibberish
+    # data in some fields
+    workflow_ids = get_workflow_ids(rs, workspace, collection)
+
     count = 0
-    query = f"SELECT * FROM {workspace}.{collection}"
-    for docs in QueryPaginator(
-        rs,
-        rs.Queries.query(
-            sql=rockset.models.QueryRequestSql(
+    query = f"SELECT * FROM {workspace}.{collection} WHERE workflow_id = : workflow_id"
+
+    for workflow_id in workflow_ids:
+        print(f"Processing {workflow_id}")
+        docs = rs.Queries.query(
+            sql=QueryRequestSql(
+                parameters=[
+                    QueryParameter(
+                        name="workflow_id",
+                        type="int",
+                        value=str(workflow_id),
+                    ),
+                ],
                 query=query,
-                paginate=True,
-                initial_paginate_response_doc_count=PAGE_SIZE,
             )
-        ),
-    ):
+        )["results"]
+
         dedup = set()
         count += len(docs)
-        failures = []
+        failures = 0
         print(f"Writing {len(docs)} ({count}) documents to DynamoDB {dynamodb_table}")
         # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/dynamodb.html#batch-writing
         with boto3.resource("dynamodb").Table(dynamodb_table).batch_writer() as batch:
             for doc in docs:
                 event_time = doc.get("_event_time", None)
                 if event_time:
-                    timestamp = int(round(parser.parse(str(event_time)).timestamp() * 1000))
+                    timestamp = int(
+                        round(parser.parse(str(event_time)).timestamp() * 1000)
+                    )
                 else:
                     timestamp = int(round(time.time() * 1000))
 
@@ -107,9 +126,9 @@ def copy(
                             continue
                         dedup.add(doc["dynamoKey"])
                 except TypeError:
-                    failures.append(doc)
+                    failures += 1
                     # Record and ignore broken records
-                    logging.warning("...%s failures", len(failures))
+                    logging.warning("...%s failures", failures)
                     continue
 
                 # This is to move away the _event_time field from Rockset, which we cannot use when
@@ -117,21 +136,19 @@ def copy(
                 doc["timestamp"] = timestamp
 
                 try:
+                    # https://ruan.dev/blog/2019/02/05/convert-float-to-decimal-data-types-for-boto3-dynamodb-using-python
+                    # doc = json.loads(json.dumps(doc, default=str), parse_float=Decimal)
                     batch.put_item(Item=doc)
                 except TypeError:
-                    failures.append(doc)
+                    failures += 1
                     # Record and ignore broken records
-                    logging.warning("...%s failures", len(failures))
+                    logging.warning("...%s failures", failures)
                     continue
-
-        if failures:
-            with open("failures.dump", "wb") as f:
-                pickle.dump(failures, f)
 
 
 def main() -> None:
     args = parse_args()
-    copy(
+    copy_perf_stats(
         args.rockset_workspace, args.rockset_collection, args.dynamodb_table, args.repo
     )
 

--- a/tools/rockset_migration/rockset_2_dynamodb.py
+++ b/tools/rockset_migration/rockset_2_dynamodb.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+import hashlib
+import json
+import os
+import time
+from argparse import ArgumentParser
+from typing import Any, Dict
+
+import boto3
+
+import rockset  # type: ignore[import]
+from dateutil import parser  # type: ignore[import]
+from rockset import QueryPaginator, RocksetClient
+
+
+PAGE_SIZE = 1000
+
+
+def parse_args() -> Any:
+    parser = ArgumentParser("Copy Rockset collection to dynamoDB")
+    parser.add_argument(
+        "--rockset-workspace",
+        type=str,
+        required=True,
+        help="the name of the Rockset workspace with the collection",
+    )
+    parser.add_argument(
+        "--rockset-collection",
+        type=str,
+        required=True,
+        help="the name of the Rockset collection to copy",
+    )
+    parser.add_argument(
+        "--dynamodb-table",
+        type=str,
+        required=True,
+        help="the name of the destination dynamoDB table",
+    )
+    parser.add_argument(
+        "--repo",
+        type=str,
+        default="pytorch/pytorch",
+        help="this is used as part of dynamoDB key",
+    )
+    return parser.parse_args()
+
+
+def generate_partition_key(repo: str, doc: Dict[str, Any]) -> str:
+    """
+    Generate an unique partition key for the document on DynamoDB
+    """
+    workflow_id = doc.get("workflow_id", "")
+    job_id = doc.get("job_id", "")
+    test_name = doc.get("test_name", "")
+    filename = doc.get("filename", "")
+
+    hash_content = hashlib.md5(json.dumps(doc).encode("utf-8")).hexdigest()
+    return f"{repo}/{workflow_id}/{job_id}/{test_name}/{filename}/{hash_content}"
+
+
+def copy(
+    workspace: str, collection: str, dynamodb_table: str, repo: str = "pytorch/pytorch"
+) -> None:
+    rs = RocksetClient(
+        host="api.usw2a1.rockset.com", api_key=os.environ["ROCKSET_API_KEY"]
+    )
+
+    count = 0
+    query = f"SELECT * FROM {workspace}.{collection}"
+    for docs in QueryPaginator(
+        rs,
+        rs.Queries.query(
+            sql=rockset.models.QueryRequestSql(
+                query=query,
+                paginate=True,
+                initial_paginate_response_doc_count=PAGE_SIZE,
+            )
+        ),
+    ):
+        dedup = set()
+        count += len(docs)
+        print(f"Writing {len(docs)} ({count}) documents to DynamoDB {dynamodb_table}")
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/dynamodb.html#batch-writing
+        with boto3.resource("dynamodb").Table(dynamodb_table).batch_writer() as batch:
+            for doc in docs:
+                event_time = doc.get("_event_time", None)
+                if event_time:
+                    timestamp = int(round(parser.parse(event_time).timestamp() * 1000))
+                else:
+                    timestamp = int(round(time.time() * 1000))
+
+                # We don't need these fields from Rockset
+                del doc["_event_time"]
+                del doc["_id"]
+                del doc["_meta"]
+
+                if generate_partition_key:
+                    doc["dynamoKey"] = generate_partition_key(repo, doc)
+                    if doc["dynamoKey"] in dedup:
+                        continue
+                    dedup.add(doc["dynamoKey"])
+
+                # This is to move away the _event_time field from Rockset, which we cannot use when
+                # reimport the data
+                doc["timestamp"] = timestamp
+                batch.put_item(Item=doc)
+
+
+def main() -> None:
+    args = parse_args()
+    copy(
+        args.rockset_workspace, args.rockset_collection, args.dynamodb_table, args.repo
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I use this script to copy the following Rockset collections to dynamoDB tables, so it's a good idea to keep this here for future usage:

* `python rockset_2_dynamodb.py --rockset-workspace benchmarks --rockset-collection oss_ci_benchmark --dynamodb-table torchci-oss-ci-benchmark` (599 records deduped and copied)
* `python rockset_2_dynamodb.py --rockset-workspace inductor --rockset-collection torch_dynamo_perf_stats --dynamodb-table torchci-dynamo-perf-stats` (3.5M+ records)

For some reason, a query like `SELECT * FROM torch_dynamo_perf_stats` returns gibberish in some fields despite my attempt to paginate the results.  So, I need to copy data sequentially by each workflow instead.