### PR TITLE
[Rockset migration] Switch to oss_ci_benchmark_v2 powered by dynamoDB

### DIFF
--- a/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_branches.sql
+++ b/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_branches.sql
@@ -5,15 +5,15 @@ SELECT
   w.head_sha,
   w.id,
   FORMAT_ISO8601(
-    DATE_TRUNC(: granularity, o._event_time)
+    DATE_TRUNC(: granularity, TIMESTAMP_MILLIS(o.timestamp))
   ) AS event_time,
   o.filename
 FROM
   benchmarks.oss_ci_benchmark_v2 o
   LEFT JOIN commons.workflow_run w ON o.workflow_id = w.id
 WHERE
-  o._event_time >= PARSE_DATETIME_ISO8601(: startTime)
-  AND o._event_time < PARSE_DATETIME_ISO8601(: stopTime)
+  TIMESTAMP_MILLIS(o.timestamp) >= PARSE_DATETIME_ISO8601(: startTime)
+  AND TIMESTAMP_MILLIS(o.timestamp) < PARSE_DATETIME_ISO8601(: stopTime)
   AND (
     ARRAY_CONTAINS(
       SPLIT(: filenames, ','),

--- a/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_branches.sql
+++ b/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_branches.sql
@@ -9,7 +9,7 @@ SELECT
   ) AS event_time,
   o.filename
 FROM
-  benchmarks.oss_ci_benchmark o
+  benchmarks.oss_ci_benchmark_v2 o
   LEFT JOIN commons.workflow_run w ON o.workflow_id = w.id
 WHERE
   o._event_time >= PARSE_DATETIME_ISO8601(: startTime)

--- a/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_llms.sql
+++ b/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_llms.sql
@@ -21,7 +21,7 @@ SELECT
   o.dtype,
   o.device,
 FROM
-  benchmarks.oss_ci_benchmark o
+  benchmarks.oss_ci_benchmark_v2 o
   LEFT JOIN commons.workflow_run w ON o.workflow_id = w.id
 WHERE
   (

--- a/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_llms.sql
+++ b/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_llms.sql
@@ -16,7 +16,7 @@ SELECT
     CAST(o.target AS FLOAT), 0.0
   ) AS target,
   FORMAT_ISO8601(
-    DATE_TRUNC(: granularity, w._event_time)
+    DATE_TRUNC(: granularity,TIMESTAMP_MILLIS(o.timestamp))
   ) AS granularity_bucket,
   o.dtype,
   o.device,
@@ -24,7 +24,9 @@ FROM
   benchmarks.oss_ci_benchmark_v2 o
   LEFT JOIN commons.workflow_run w ON o.workflow_id = w.id
 WHERE
-  (
+  TIMESTAMP_MILLIS(o.timestamp) >= PARSE_DATETIME_ISO8601(: startTime)
+  AND TIMESTAMP_MILLIS(o.timestamp) < PARSE_DATETIME_ISO8601(: stopTime)
+  AND (
     ARRAY_CONTAINS(
       SPLIT(: branches, ','),
       w.head_branch

--- a/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_names.sql
+++ b/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_names.sql
@@ -6,7 +6,7 @@ SELECT DISTINCT
   o.dtype,
   o.device,
 FROM
-  benchmarks.oss_ci_benchmark o
+  benchmarks.oss_ci_benchmark_v2 o
   LEFT JOIN commons.workflow_run w ON o.workflow_id = w.id
 WHERE
   o._event_time >= PARSE_DATETIME_ISO8601(: startTime)

--- a/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_names.sql
+++ b/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_names.sql
@@ -9,8 +9,8 @@ FROM
   benchmarks.oss_ci_benchmark_v2 o
   LEFT JOIN commons.workflow_run w ON o.workflow_id = w.id
 WHERE
-  o._event_time >= PARSE_DATETIME_ISO8601(: startTime)
-  AND o._event_time < PARSE_DATETIME_ISO8601(: stopTime)
+  TIMESTAMP_MILLIS(o.timestamp) >= PARSE_DATETIME_ISO8601(: startTime)
+  AND TIMESTAMP_MILLIS(o.timestamp) < PARSE_DATETIME_ISO8601(: stopTime)
   AND (
     ARRAY_CONTAINS(
       SPLIT(: filenames, ','),

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -108,8 +108,8 @@
     "validation_jobs_red_past_day": "aecb798a574ba2ff"
   },
   "benchmarks": {
-    "oss_ci_benchmark_llms": "656fe095f7e9a3ab",
-    "oss_ci_benchmark_branches": "76446d877defb748",
-    "oss_ci_benchmark_names": "98a212e928df968b"
+    "oss_ci_benchmark_llms": "3aa20b17f4627823",
+    "oss_ci_benchmark_branches": "0077d50647fa005c",
+    "oss_ci_benchmark_names": "aae4d31197103b8a"
   }
 }

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -108,8 +108,8 @@
     "validation_jobs_red_past_day": "aecb798a574ba2ff"
   },
   "benchmarks": {
-    "oss_ci_benchmark_llms": "3aa20b17f4627823",
-    "oss_ci_benchmark_branches": "0077d50647fa005c",
-    "oss_ci_benchmark_names": "aae4d31197103b8a"
+    "oss_ci_benchmark_llms": "05d3fff964c653ac",
+    "oss_ci_benchmark_branches": "3514932f2b980b56",
+    "oss_ci_benchmark_names": "f2c65d404a4262ab"
   }
 }


### PR DESCRIPTION
`oss_ci_benchmark_v2` is a copy of `oss_ci_benchmark` but it's backed by dynamoDB.  This is not yet out of Rockset, but at least we now have a copy of the database on dynamoDB.

1. I import `oss_ci_benchmark` to dynamo using the script in https://github.com/pytorch/test-infra/pull/5408
2. Then I create a new Rockset called `oss_ci_benchmark_v2` from the new dynamoDB table from the previous step

This also gets rid of the use of the transient `_event_time` field from Rockset.

### Testing

No change to the HUD page https://torchci-git-fork-huydhn-ossci-queries-to-v2-fbopensource.vercel.app/benchmark/llms