### PR TITLE
Rockset migration - update queue times- explicitly use the new time field instead of _event_time and fix env variables in update queue times workflow

### DIFF
--- a/.github/workflows/update-queue-times.yml
+++ b/.github/workflows/update-queue-times.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # Run every 15 minutes
     - cron: "*/15 * * * *"
+  workflow_dispatch:
 
 defaults:
   run:
@@ -16,4 +17,6 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn node scripts/updateQueueTimes.mjs
         env:
+          OUR_AWS_ACCESS_KEY_ID: ${{ steps.aws_creds.outputs.aws-access-key-id }}
+          OUR_AWS_SECRET_ACCESS_KEY: ${{ steps.aws_creds.outputs.aws-secret-access-key }}
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}

--- a/torchci/rockset/metrics/__sql/queue_times_historical.sql
+++ b/torchci/rockset/metrics/__sql/queue_times_historical.sql
@@ -9,7 +9,7 @@ SELECT
     AVG(q.avg_queue_s) as avg_queue_s,
     q.machine_type,
 FROM
-    commons.queue_times_test q
+    metrics.queeu_times_historical q
 WHERE
     q.time >= PARSE_DATETIME_ISO8601(:startTime) AT TIME ZONE :timezone
     AND q.time < PARSE_DATETIME_ISO8601(:stopTime) AT TIME ZONE :timezone

--- a/torchci/rockset/metrics/__sql/queue_times_historical.sql
+++ b/torchci/rockset/metrics/__sql/queue_times_historical.sql
@@ -9,7 +9,7 @@ SELECT
     AVG(q.avg_queue_s) as avg_queue_s,
     q.machine_type,
 FROM
-    metrics.queeu_times_historical q
+    metrics.queue_times_historical q
 WHERE
     q.time >= PARSE_DATETIME_ISO8601(:startTime) AT TIME ZONE :timezone
     AND q.time < PARSE_DATETIME_ISO8601(:stopTime) AT TIME ZONE :timezone

--- a/torchci/rockset/metrics/__sql/queue_times_historical.sql
+++ b/torchci/rockset/metrics/__sql/queue_times_historical.sql
@@ -2,17 +2,17 @@ SELECT
     FORMAT_ISO8601(
         DATE_TRUNC(
             :granularity,
-            q._event_time AT TIME ZONE :timezone
+            q.time AT TIME ZONE :timezone
         )
     ) AS granularity_bucket,
     /* misnomer, this is the max queue time, not the avg queue time */
     AVG(q.avg_queue_s) as avg_queue_s,
     q.machine_type,
 FROM
-    metrics.queue_times_historical q
+    commons.queue_times_test q
 WHERE
-    q._event_time >= PARSE_DATETIME_ISO8601(:startTime) AT TIME ZONE :timezone
-    AND q._event_time < PARSE_DATETIME_ISO8601(:stopTime) AT TIME ZONE :timezone
+    q.time >= PARSE_DATETIME_ISO8601(:startTime) AT TIME ZONE :timezone
+    AND q.time < PARSE_DATETIME_ISO8601(:stopTime) AT TIME ZONE :timezone
 GROUP BY
     granularity_bucket,
     q.machine_type

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -73,7 +73,7 @@
     "tts_duration_historical": "88c02c6e25d59854",
     "tts_duration_historical_percentile": "f6824cbe03e1b6d8",
     "strict_lag_sec": "e0ab723990d6f2a2",
-    "queue_times_historical": "0e124a5876a9316d",
+    "queue_times_historical": "2069a7304a266f6c",
     "workflow_duration_avg": "7bae00900097a486",
     "workflow_duration_percentile": "0b28cf65de7cfe07",
     "workflow_load": "c4e5806c20e64d01",

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -73,7 +73,7 @@
     "tts_duration_historical": "88c02c6e25d59854",
     "tts_duration_historical_percentile": "f6824cbe03e1b6d8",
     "strict_lag_sec": "e0ab723990d6f2a2",
-    "queue_times_historical": "f4a5f7cab1f00b24",
+    "queue_times_historical": "0e124a5876a9316d",
     "workflow_duration_avg": "7bae00900097a486",
     "workflow_duration_percentile": "0b28cf65de7cfe07",
     "workflow_load": "c4e5806c20e64d01",


### PR DESCRIPTION
Related to https://github.com/pytorch/test-infra/pull/5398

Change historical queue times query for HUD metrics page

Looks good
<img width="847" alt="image" src="https://github.com/pytorch/test-infra/assets/44682903/3376331c-01f6-45e9-a22c-da359ce6df89">

Also change the workflow so we can use workflow dispatch and so that it has the env vars
