### PR TITLE
[queue times] Use correct env vars

### DIFF
--- a/torchci/scripts/updateQueueTimes.mjs
+++ b/torchci/scripts/updateQueueTimes.mjs
@@ -10,8 +10,8 @@ export function getS3Client() {
   return new S3Client({
     region: "us-east-1",
     credentials: {
-      accessKeyId: process.env.OUR_AWS_ACCESS_KEY_ID,
-      secretAccessKey: process.env.OUR_AWS_SECRET_ACCESS_KEY,
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
     },
   });
 }


### PR DESCRIPTION
Follow up to https://github.com/pytorch/test-infra/pull/5412

I'm not sure why the env var is not being set https://github.com/pytorch/test-infra/actions/runs/9867482380/job/27247927172#step:5:10 but the other ones are so we can just use those for now