### PR TITLE
[queue times] Actually use correct env vars

### DIFF
--- a/.github/workflows/update-queue-times.yml
+++ b/.github/workflows/update-queue-times.yml
@@ -5,7 +5,6 @@ on:
     # Run every 15 minutes
     - cron: "*/15 * * * *"
   workflow_dispatch:
-  push:
 
 defaults:
   run:

--- a/.github/workflows/update-queue-times.yml
+++ b/.github/workflows/update-queue-times.yml
@@ -5,7 +5,7 @@ on:
     # Run every 15 minutes
     - cron: "*/15 * * * *"
   workflow_dispatch:
-  pull_request:
+  push:
 
 defaults:
   run:

--- a/.github/workflows/update-queue-times.yml
+++ b/.github/workflows/update-queue-times.yml
@@ -26,6 +26,4 @@ jobs:
           aws-region: us-east-1
       - run: yarn node scripts/updateQueueTimes.mjs
         env:
-          OUR_AWS_ACCESS_KEY_ID: ${{ steps.aws_creds.outputs.aws-access-key-id }}
-          OUR_AWS_SECRET_ACCESS_KEY: ${{ steps.aws_creds.outputs.aws-secret-access-key }}
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}

--- a/.github/workflows/update-queue-times.yml
+++ b/.github/workflows/update-queue-times.yml
@@ -5,6 +5,7 @@ on:
     # Run every 15 minutes
     - cron: "*/15 * * * *"
   workflow_dispatch:
+  pull_request:
 
 defaults:
   run:
@@ -19,7 +20,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - name: configure aws credentials
         id: aws_creds
-        uses: aws-actions/configure-aws-credentials@v1.7.0
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_update_queue_times
           aws-region: us-east-1

--- a/torchci/scripts/updateQueueTimes.mjs
+++ b/torchci/scripts/updateQueueTimes.mjs
@@ -9,10 +9,6 @@ import { promises as fs } from "fs";
 export function getS3Client() {
   return new S3Client({
     region: "us-east-1",
-    credentials: {
-      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-    },
   });
 }
 


### PR DESCRIPTION
* Follow up to https://github.com/pytorch/test-infra/pull/5417

I think the env var I was missing is the session token, which is needed for temporary credentials.  Instead of specifying that, I choose to not explicitly set the credentials information and the `new S3Client` will know to look for the env vars it needs on its own.  This makes it slightly easier to run locally if you have tokens already

A succeeding run is https://github.com/pytorch/test-infra/actions/runs/9877586518/job/27279561554?pr=5418.  I got this by temporarily adding my branch to the iam trust relationship policy and setting the workflow to run on push trigger. 

I forgot that I could just add my branch there and test on a PR instead of needing to test on the main branch

I don't think the upgrade to v3 is necessary but I decided to bundle that in anyways
