### PR TITLE
Add a lambda to replicate dynamo CDC stream to ClickHouse

### DIFF
--- a/aws/lambda/dynamo-clickhouse-replicator/Makefile
+++ b/aws/lambda/dynamo-clickhouse-replicator/Makefile
@@ -1,0 +1,11 @@
+prepare: clean
+	mkdir -p ./packages
+	pip3 install --target ./packages -r requirements.txt
+	cd packages && zip -r ../dynamo-clickhouse-replicator-deployment.zip .
+	zip -g dynamo-clickhouse-replicator-deployment.zip lambda_function.py
+
+deploy: prepare
+	aws lambda update-function-code --function-name dynamo-clickhouse-replicator --zip-file fileb://dynamo-clickhouse-replicator-deployment.zip
+
+clean:
+	rm -rf dynamo-clickhouse-replicator-deployment.zip packages

--- a/aws/lambda/dynamo-clickhouse-replicator/README.md
+++ b/aws/lambda/dynamo-clickhouse-replicator/README.md
@@ -1,0 +1,15 @@
+This lambda is used to replicate the change data capture (CDC) records
+from our DynamoDB tables to their corresponding ClickHouse ones. This
+is done by listening to the stream of `INSERT`, `MODIFY`, and `REMOVE`
+events coming to the DynamoDB tables, extracting the documents, and upsert
+them into ClickHouse
+
+Because the JSON structure of a DynamoDB event includes some simple
+datatype annotation ([link](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_AttributeValue.html)).
+The lambda performs some transformation to convert it back to a regular
+JSON data structure.
+
+### Deployment
+
+A new version of the lambda can be deployed using `make deploy` and it
+is done so automatically as part of the CI.

--- a/aws/lambda/dynamo-clickhouse-replicator/lambda_function.py
+++ b/aws/lambda/dynamo-clickhouse-replicator/lambda_function.py
@@ -1,0 +1,165 @@
+import json
+import os
+import re
+from collections import defaultdict
+from enum import Enum
+from typing import Any, Dict, Optional, Union
+from warnings import warn
+
+import clickhouse_connect
+
+
+DYNAMODB_TABLE_REGEX = re.compile(
+    "arn:aws:dynamodb:.*?:.*?:table/(?P<table>[0-9a-zA-Z_-]+)/.+"
+)
+CLICKHOUSE_ENDPOINT = os.getenv("CLICKHOUSE_ENDPOINT", "")
+CLICKHOUSE_USERNAME = os.getenv("CLICKHOUSE_USERNAME", "default")
+CLICKHOUSE_PASSWORD = os.getenv("CLICKHOUSE_PASSWORD", "")
+
+
+class EventType(Enum):
+    INSERT = "INSERT"
+    REMOVE = "REMOVE"
+    MODIFY = "MODIFY"
+
+
+def lambda_handler(event: Any, context: Any) -> None:
+    # https://clickhouse.com/docs/en/integrations/python
+    clickhouse_client = clickhouse_connect.get_client(
+        host=CLICKHOUSE_ENDPOINT,
+        user=CLICKHOUSE_USERNAME,
+        password=CLICKHOUSE_PASSWORD,
+        secure=True,
+    )
+
+    counts = defaultdict(int)
+    for record in event["Records"]:
+        event_name = record.get("eventName", "")
+        try:
+            if (
+                event_name == EventType.INSERT.value
+                or event_name == EventType.MODIFY.value
+            ):
+                upsert_document(clickhouse_client, record)
+            elif event_name == EventType.REMOVE.value:
+                remove_document(clickhouse_client, record)
+            else:
+                warn(f"Unrecognized event type {event_name} in {json.dumps(record)}")
+
+            counts[event_name] += 1
+        except Exception as error:
+            warn(f"Failed to process {json.dumps(record)}: {error}")
+
+    print(f"Finish processing {json.dumps(counts)}")
+
+
+def extract_dynamodb_table(record: Any) -> Optional[str]:
+    """
+    Extract the DynamoDB table name from the source ARN. This will be used later as
+    the index name
+    """
+    table = record.get("tableName", "")
+    # In the case of a Kinesis stream, the table name has already been provided
+    if table:
+        return table
+
+    s = record.get("eventSourceARN", "")
+    m = DYNAMODB_TABLE_REGEX.match(s)
+    if not m:
+        warn(f"Invalid value {s}, expecting a DynamoDB table")
+        return
+
+    return m.group("table").lower()
+
+
+def extract_dynamodb_key(record: Any) -> Optional[str]:
+    keys = unmarshal({"M": record.get("dynamodb", {}).get("Keys", {})})
+    if not keys:
+        return
+    return "|".join(keys.values())
+
+
+def to_number(s: str) -> Union[int, float]:
+    try:
+        return int(s)
+    except ValueError:
+        return float(s)
+
+
+def unmarshal(doc: Dict[Any, Any]) -> Any:
+    """
+    Convert the DynamoDB stream record into a regular JSON document. This is done recursively.
+    At the top level, it will be a dictionary of type M (Map). Here is the list of DynamoDB
+    attributes to handle:
+
+    https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_AttributeValue.html
+    """
+    for k, v in list(doc.items()):
+        if k == "NULL":
+            return
+
+        if k == "S" or k == "BOOL":
+            return v
+
+        if k == "N":
+            return to_number(v)
+
+        if k == "M":
+            return {sk: unmarshal(sv) for sk, sv in v.items()}
+
+        if k == "BS" or k == "L":
+            return [unmarshal(item) for item in v]
+
+        if k == "SS":
+            return v.copy()
+
+        if k == "NS":
+            return [to_number(item) for item in v]
+
+
+def upsert_document(client: Any, record: Any) -> None:
+    """
+    Insert a new doc or modify an existing document. Note that ClickHouse doesn't really
+    update the document in place, but rather adding a new record for the update
+    """
+    table = extract_dynamodb_table(record)
+    if not table:
+        return
+
+    body = unmarshal({"M": record.get("dynamodb", {}).get("NewImage", {})})
+    if not body:
+        return
+
+    id = extract_dynamodb_key(record)
+    if not id:
+        return
+
+    # TODO (huydhn) Inserting individual record is not efficient according
+    # to ClickHouse doc, but we can try to improve this later. See more at
+    # https://clickhouse.com/docs/en/optimize/bulk-inserts
+    print(f"UPSERTING {id} INTO {table}")
+    # Checkout https://clickhouse.com/videos/how-to-upsert-rows-into-clickhouse
+    # to understand how to upsert works in ClickHouse and how to get the latest
+    # records. A generic way is to use the FINAL keyword but their doc mentions
+    # that it's slower https://clickhouse.com/docs/en/sql-reference/statements/select/from
+    client.query(f"INSERT INTO `{table}` FORMAT JSONEachRow {json.dumps(body)}")
+
+
+def remove_document(client: Any, record: Any) -> None:
+    """
+    Remove a document. This is here for completeness as we don't remove records like ever
+    """
+    table = extract_dynamodb_table(record)
+    if not table:
+        return
+
+    id = extract_dynamodb_key(record)
+    if not id:
+        return
+
+    print(f"DELETING {id} FROM {table}")
+
+    parameters = {"id": id}
+    client.query(
+        f"DELETE FROM `{table}` WHERE dynamoKey = %(id)s", parameters=parameters
+    )

--- a/aws/lambda/dynamo-clickhouse-replicator/requirements.txt
+++ b/aws/lambda/dynamo-clickhouse-replicator/requirements.txt
@@ -1,0 +1,3 @@
+boto3==1.28.24
+clickhouse-connect==0.7.16
+pytest==7.4.0

--- a/tools/rockset_migration/dynamodb2s3.py
+++ b/tools/rockset_migration/dynamodb2s3.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+
+import gzip
+import io
+import json
+import uuid
+from argparse import ArgumentParser
+from typing import Any, Dict, List, Union
+
+import boto3
+
+S3_RESOURCE = boto3.resource("s3")
+BATCH_SIZE = 1000
+
+
+def parse_args() -> Any:
+    parser = ArgumentParser("Copy dynamoDB table to ClickHouse")
+    parser.add_argument(
+        "--s3-bucket",
+        type=str,
+        required=True,
+        help="the name of the S3 bucket",
+    )
+    parser.add_argument(
+        "--s3-path",
+        type=str,
+        required=True,
+        help="the name of the destination S3 path on the bucket",
+    )
+    parser.add_argument(
+        "--dynamodb-table",
+        type=str,
+        required=True,
+        help="the name of the source dynamoDB table",
+    )
+    return parser.parse_args()
+
+
+def scan_dynamodb_table(dynamo_client: Any, table: str):
+    """
+    Generates all the items in a DynamoDB table
+    """
+    paginator = dynamo_client.get_paginator("scan")
+
+    for page in paginator.paginate(TableName=table):
+        yield from page["Items"]
+
+
+def to_number(s: str) -> Union[int, float]:
+    try:
+        return int(s)
+    except ValueError:
+        return float(s)
+
+
+def unmarshal(doc: Dict[Any, Any]) -> Any:
+    """
+    Convert the DynamoDB stream record into a regular JSON document. This is done recursively.
+    At the top level, it will be a dictionary of type M (Map). Here is the list of DynamoDB
+    attributes to handle:
+
+    https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_AttributeValue.html
+    """
+    for k, v in list(doc.items()):
+        if k == "NULL":
+            return
+
+        if k == "S" or k == "BOOL":
+            return v
+
+        if k == "N":
+            return to_number(v)
+
+        if k == "M":
+            return {sk: unmarshal(sv) for sk, sv in v.items()}
+
+        if k == "BS" or k == "L":
+            return [unmarshal(item) for item in v]
+
+        if k == "SS":
+            return v.copy()
+
+        if k == "NS":
+            return [to_number(item) for item in v]
+
+
+def upload_to_s3(
+    s3_bucket: str,
+    s3_path: str,
+    records: List[Dict[str, Any]],
+) -> None:
+    print(f"Writing {len(records)} documents to S3")
+    body = io.StringIO()
+    for r in records:
+        json.dump(r, body)
+        body.write("\n")
+
+    filename = f"{uuid.uuid4()}.json"
+    S3_RESOURCE.Object(
+        f"{s3_bucket}",
+        f"{s3_path}/{filename}",
+    ).put(
+        Body=body.getvalue().encode(),
+        ContentType="application/json",
+    )
+
+
+def copy(dynamodb_table: str, s3_bucket: str, s3_path: str):
+    """
+    Copy everything from a dynamo table to ClickHouse
+    """
+    count = 0
+    records = []
+
+    dynamo_client = boto3.client("dynamodb")
+    for item in scan_dynamodb_table(dynamo_client, table=dynamodb_table):
+        count += 1
+        records.append(unmarshal({"M": item}))
+
+        if count == BATCH_SIZE:
+            upload_to_s3(s3_bucket, s3_path, records)
+
+            count = 0
+            records = []
+
+    if records:
+        upload_to_s3(s3_bucket, s3_path, records)
+
+
+def main() -> None:
+    args = parse_args()
+    copy(args.dynamodb_table, args.s3_bucket, args.s3_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Here is the working ingestion strategy that I have:

1. Bulk transfer all records from a dynamoDB table to a ClickHouse one:
    1. Use `tools/rockset_migration/dynamodb2s3.py` to dump the content of a dynamoDB table to an S3 bucket in JSON format, for example, I test it with `python dynamodb_2_s3.py --dynamodb-table torchci-issues --s3-bucket ossci-raw-job-status --s3-path debug-clickhouse-ingest/Manual/`
    2. Use S3 ClickPipe to ingest the data, for example  `s3://ossci-raw-job-status/debug-clickhouse-ingest/Manual/*.json` **remember** to use `dynamoKey` as the sort key and `ReplacingMergeTree` as the table engine.  They supports the way we mutate GitHub records.  The main reason I use S3 ClickPipe here is that it automatically creates the table for me from the JSON structure.
2. After the import, the lambda `dynamo-clickhouse-replicator` will sync all future changes to the corresponding ClickHouse table.

I could add a deployment workflow later if we decide to go this route. 

Failed attempts that didn't work out well:
1. I tried to use ClickHouse JSON object but it has been deprecated https://clickhouse.com/docs/en/sql-reference/data-types/object-data-type.  There is an open issue to address this gap https://github.com/ClickHouse/ClickHouse/issues/54864
2. I tried to create the table manually with CREATE TABLE but it's very tedious given the complex structure of the GitHub webhook payload. For simpler use cases, i.e. `merges`, this is still feasible
4. I tried DynamoDB to S3 auto-export route https://docs.aws.amazon.com/prescriptive-guidance/latest/dynamodb-full-table-copy-options/amazon-s3.html but the format is in dynamo JSON format and this confuses ClickHouse.  The above script `dynamodb2s3.py` and lambda address this by un-marshaling the records before inserting them into ClickHouse.

Ref
---
* https://clickhouse.com/videos/how-to-upsert-rows-into-clickhouse, updates to ClickHouse is done by inserting a new record.  For example, when the issue https://github.com/pytorch/pytorch/issues/130498 was closed, there are 2 records with the same `dynamoKey` of `pytorch/pytorch/130498`

```
SELECT dynamoKey, state, labels FROM `torchci-issues` WHERE dynamoKey = 'pytorch/pytorch/130498'
pytorch/pytorch/130498	closed	[{"color":"f7e101","default":false,"description":"Related to continuous integration","id":"1300896147","name":"module: ci","node_id":"MDU6TGFiZWwxMzAwODk2MTQ3","url":"https://api.github.com/repos/pytorch/pytorch/labels/module:%20ci"},{"color":"AA5D26","default":false,"description":"","id":"5626213550","name":"unstable","node_id":"LA_kwDOA-j9z88AAAABT1k0rg","url":"https://api.github.com/repos/pytorch/pytorch/labels/unstable"}]
pytorch/pytorch/130498	open	[]
```

Using the FINAL keyword returns the latest one https://clickhouse.com/docs/en/sql-reference/statements/select/from

```
SELECT dynamoKey, state, labels FROM `torchci-issues` FINAL WHERE dynamoKey = 'pytorch/pytorch/130498'
pytorch/pytorch/130498	closed	[{"color":"f7e101","default":false,"description":"Related to continuous integration","id":"1300896147","name":"module: ci","node_id":"MDU6TGFiZWwxMzAwODk2MTQ3","url":"https://api.github.com/repos/pytorch/pytorch/labels/module:%20ci"},{"color":"AA5D26","default":false,"description":"","id":"5626213550","name":"unstable","node_id":"LA_kwDOA-j9z88AAAABT1k0rg","url":"https://api.github.com/repos/pytorch/pytorch/labels/unstable"}]
```