### PR TITLE
Improves visibility for AMI experiments

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
@@ -535,7 +535,7 @@ describe('createRunner', () => {
       expect(mockEC2.runInstances).toHaveBeenCalledTimes(1);
       expect(mockEC2.runInstances).toBeCalledWith(createExpectedRunInstancesLinux(runnerParameters, 0));
       expect(runnerConfigFn).toBeCalledTimes(1);
-      expect(runnerConfigFn).toBeCalledWith(config.awsRegion);
+      expect(runnerConfigFn).toBeCalledWith(config.awsRegion, false);
     });
 
     it('calls run instances with the correct config for repo && linux && organization', async () => {
@@ -559,7 +559,7 @@ describe('createRunner', () => {
       expect(mockEC2.runInstances).toHaveBeenCalledTimes(1);
       expect(mockEC2.runInstances).toBeCalledWith(createExpectedRunInstancesLinux(runnerParameters, 0, true));
       expect(runnerConfigFn).toBeCalledTimes(1);
-      expect(runnerConfigFn).toBeCalledWith(config.awsRegion);
+      expect(runnerConfigFn).toBeCalledWith(config.awsRegion, false);
     });
 
     it('calls run instances with the correct config for repo && windows', async () => {
@@ -581,7 +581,7 @@ describe('createRunner', () => {
       await createRunner(runnerParameters, metrics);
 
       expect(runnerConfigFn).toBeCalledTimes(1);
-      expect(runnerConfigFn).toBeCalledWith(config.awsRegion);
+      expect(runnerConfigFn).toBeCalledWith(config.awsRegion, false);
       expect(mockEC2.runInstances).toHaveBeenCalledTimes(1);
       const secGroup = Config.Instance.vpcIdToSecurityGroupIds.get('vpc-agdgaduwg113') || [];
       expect(mockEC2.runInstances).toBeCalledWith({
@@ -647,7 +647,7 @@ describe('createRunner', () => {
         metrics,
       );
       expect(runnerConfigFn).toBeCalledTimes(1);
-      expect(runnerConfigFn).toBeCalledWith(config.awsRegion);
+      expect(runnerConfigFn).toBeCalledWith(config.awsRegion, false);
       expect(mockSSM.putParameter).toBeCalledTimes(1);
       expect(mockSSM.putParameter).toBeCalledWith({
         Name: 'unit-test-env-i-1234',
@@ -903,7 +903,7 @@ describe('createRunner', () => {
       expect(mockEC2.runInstances).toHaveBeenCalledTimes(1);
       expect(mockEC2.runInstances).toBeCalledWith(createExpectedRunInstancesLinux(runnerParameters, 2));
       expect(runnerConfigFn).toBeCalledTimes(1);
-      expect(runnerConfigFn).toBeCalledWith(config.shuffledAwsRegionInstances[0]);
+      expect(runnerConfigFn).toBeCalledWith(config.shuffledAwsRegionInstances[0], false);
     });
 
     it('succeed, 2nd subnet and 1st region', async () => {
@@ -935,7 +935,7 @@ describe('createRunner', () => {
         createExpectedRunInstancesLinux(runnerParameters, 4, false, 'vpc-agdgaduwg113-12'),
       );
       expect(runnerConfigFn).toBeCalledTimes(1);
-      expect(runnerConfigFn).toBeCalledWith(config.shuffledAwsRegionInstances[0]);
+      expect(runnerConfigFn).toBeCalledWith(config.shuffledAwsRegionInstances[0], false);
     });
 
     it('succeed, 1nd subnet and 2nd region', async () => {
@@ -983,7 +983,7 @@ describe('createRunner', () => {
         ),
       );
       expect(runnerConfigFn).toBeCalledTimes(1);
-      expect(runnerConfigFn).toBeCalledWith(config.shuffledAwsRegionInstances[1]);
+      expect(runnerConfigFn).toBeCalledWith(config.shuffledAwsRegionInstances[1], false);
     });
 
     it('fails, everywere', async () => {

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -15,7 +15,7 @@ export interface ListRunnerFilters {
 }
 
 export interface RunnerInputParameters {
-  runnerConfig: (awsRegion: string) => Promise<string>;
+  runnerConfig: (awsRegion: string, experimentalRunner: boolean) => Promise<string>;
   environment: string;
   repoName?: string;
   orgName?: string;
@@ -319,7 +319,7 @@ async function addSSMParameterRunnerConfig(
     return;
   }
 
-  let runnerConfig = await runnerParameters.runnerConfig(awsRegion);
+  let runnerConfig = await runnerParameters.runnerConfig(awsRegion, customAmiExperiment);
   if (customAmiExperiment) {
     runnerConfig = `${runnerConfig} #ON_AMI_EXPERIMENT`;
   }

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
@@ -275,11 +275,15 @@ describe('scaleUp', () => {
       metrics,
     );
 
-    expect(await mockedCreateRunner.mock.calls[0][0].runnerConfig(config.awsRegion)).toEqual(
+    expect(await mockedCreateRunner.mock.calls[0][0].runnerConfig(config.awsRegion, false)).toEqual(
       `--url ${config.ghesUrlHost}/owner --token ${token} --labels AWS:${config.awsRegion},linux.2xlarge,` +
         `extra-label  --runnergroup group_one`,
     );
-    expect(mockedCreateRegistrationTokenForOrg).toBeCalledTimes(1);
+    expect(await mockedCreateRunner.mock.calls[0][0].runnerConfig(config.awsRegion, true)).toEqual(
+      `--url ${config.ghesUrlHost}/owner --token ${token} --labels AWS:${config.awsRegion},linux.2xlarge,` +
+        `experimental.ami,extra-label --ephemeral --runnergroup group_one`,
+    );
+    expect(mockedCreateRegistrationTokenForOrg).toBeCalledTimes(2);
     expect(mockedCreateRegistrationTokenForOrg).toBeCalledWith(repo.owner, metrics, 2);
   });
 
@@ -357,11 +361,15 @@ describe('scaleUp', () => {
       metrics,
     );
 
-    expect(await mockedCreateRunner.mock.calls[0][0].runnerConfig(config.awsRegion)).toEqual(
+    expect(await mockedCreateRunner.mock.calls[0][0].runnerConfig(config.awsRegion, false)).toEqual(
       `--url ${config.ghesUrlHost}/owner/repo --token ${token} --labels AWS:${config.awsRegion},linux.2xlarge,` +
         `extra-label `,
     );
-    expect(mockedCreateRegistrationTokenForRepo).toBeCalledTimes(1);
+    expect(await mockedCreateRunner.mock.calls[0][0].runnerConfig(config.awsRegion, true)).toEqual(
+      `--url ${config.ghesUrlHost}/owner/repo --token ${token} --labels AWS:${config.awsRegion},linux.2xlarge,` +
+        `experimental.ami,extra-label --ephemeral`,
+    );
+    expect(mockedCreateRegistrationTokenForRepo).toBeCalledTimes(2);
     expect(mockedCreateRegistrationTokenForRepo).toBeCalledWith(repo, metrics, 2);
   });
 
@@ -439,11 +447,15 @@ describe('scaleUp', () => {
       metrics,
     );
 
-    expect(await mockedCreateRunner.mock.calls[0][0].runnerConfig(config.awsRegion)).toEqual(
+    expect(await mockedCreateRunner.mock.calls[0][0].runnerConfig(config.awsRegion, false)).toEqual(
       `--url ${config.ghesUrlHost}/owner/repo --token ${token} --labels AWS:${config.awsRegion},linux.2xlarge,` +
         `extra-label `,
     );
-    expect(mockedCreateRegistrationTokenForRepo).toBeCalledTimes(1);
+    expect(await mockedCreateRunner.mock.calls[0][0].runnerConfig(config.awsRegion, true)).toEqual(
+      `--url ${config.ghesUrlHost}/owner/repo --token ${token} --labels AWS:${config.awsRegion},linux.2xlarge,` +
+        `experimental.ami,extra-label --ephemeral`,
+    );
+    expect(mockedCreateRegistrationTokenForRepo).toBeCalledTimes(2);
     expect(mockedCreateRegistrationTokenForRepo).toBeCalledWith(repo, metrics, 0);
   });
 
@@ -521,11 +533,15 @@ describe('scaleUp', () => {
       metrics,
     );
 
-    expect(await mockedCreateRunner.mock.calls[0][0].runnerConfig(config.awsRegion)).toEqual(
+    expect(await mockedCreateRunner.mock.calls[0][0].runnerConfig(config.awsRegion, false)).toEqual(
       `--url ${config.ghesUrlHost}/owner/repo --token ${token} --labels AWS:${config.awsRegion},linux.2xlarge,` +
         `extra-label `,
     );
-    expect(mockedCreateRegistrationTokenForRepo).toBeCalledTimes(1);
+    expect(await mockedCreateRunner.mock.calls[0][0].runnerConfig(config.awsRegion, true)).toEqual(
+      `--url ${config.ghesUrlHost}/owner/repo --token ${token} --labels AWS:${config.awsRegion},linux.2xlarge,` +
+        `experimental.ami,extra-label --ephemeral`,
+    );
+    expect(mockedCreateRegistrationTokenForRepo).toBeCalledTimes(2);
     expect(mockedCreateRegistrationTokenForRepo).toBeCalledWith(repo, metrics, undefined);
   });
 
@@ -636,9 +652,13 @@ describe('scaleUp', () => {
       metrics,
     );
 
-    expect(await mockedCreateRunner.mock.calls[0][0].runnerConfig(config.awsRegion)).toEqual(
+    expect(await mockedCreateRunner.mock.calls[0][0].runnerConfig(config.awsRegion, false)).toEqual(
       `--url ${config.ghesUrlHost}/owner/repo --token ${token} --labels AWS:${config.awsRegion},linux.2xlarge` +
         ` --ephemeral`,
+    );
+    expect(await mockedCreateRunner.mock.calls[0][0].runnerConfig(config.awsRegion, true)).toEqual(
+      `--url ${config.ghesUrlHost}/owner/repo --token ${token} --labels AWS:${config.awsRegion},linux.2xlarge,` +
+        `experimental.ami --ephemeral`,
     );
   });
 

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -145,7 +145,7 @@ async function createRunnerConfigArgument(
   const labelsArgument = [
     `AWS:${awsRegion}`,
     `${runnerType.runnerTypeName}`,
-    ...(experimentalRunner ? ['experimentalAMI'] : []),
+    ...(experimentalRunner ? ['experimental.ami'] : []),
     ...(Config.Instance.runnersExtraLabels ? Config.Instance.runnersExtraLabels.split(',') : []),
     ...(runnerType.labels ?? []),
   ].join(',');

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -83,8 +83,15 @@ export async function scaleUp(
       try {
         const createRunnerParams: RunnerInputParameters = {
           environment: Config.Instance.environment,
-          runnerConfig: (awsRegion: string) => {
-            return createRunnerConfigArgument(runnerType, repo, payload.installationId, metrics, awsRegion);
+          runnerConfig: (awsRegion: string, experimentalRunner: boolean) => {
+            return createRunnerConfigArgument(
+              runnerType,
+              repo,
+              payload.installationId,
+              metrics,
+              awsRegion,
+              experimentalRunner,
+            );
           },
           runnerType: runnerType,
         };
@@ -132,11 +139,13 @@ async function createRunnerConfigArgument(
   installationId: number | undefined,
   metrics: Metrics,
   awsRegion: string,
+  experimentalRunner: boolean,
 ): Promise<string> {
-  const ephemeralArgument = runnerType.is_ephemeral ? '--ephemeral' : '';
+  const ephemeralArgument = runnerType.is_ephemeral || experimentalRunner ? '--ephemeral' : '';
   const labelsArgument = [
     `AWS:${awsRegion}`,
     `${runnerType.runnerTypeName}`,
+    ...(experimentalRunner ? ['experimentalAMI'] : []),
     ...(Config.Instance.runnersExtraLabels ? Config.Instance.runnersExtraLabels.split(',') : []),
     ...(runnerType.labels ?? []),
   ].join(',');


### PR DESCRIPTION
After a few experiments and practical uses I identified a few shortcomings for the new AMI experiment feature, the goal of this PR is to address them:

1 - Metrics are not broken down by runner label + experiment or not. What makes it very hard to detect and understand issues in the experiment instances. New metrics now should include this breakdown;
2 - The failure rate for jobs is >60%, this makes it pointless to make an effort to keep the runner live when it succeed and remove when it fails. It makes more sense to be safe from the start and run the instances in the experiment as ephemeral instances;
