### PR TITLE
Run nvidia-persistenced to avoid timeout error when initializing Docker containers

### DIFF
--- a/.github/actions/setup-nvidia/action.yml
+++ b/.github/actions/setup-nvidia/action.yml
@@ -246,7 +246,9 @@ runs:
           echo "GPU_FLAG=--gpus all -e NVIDIA_DRIVER_CAPABILITIES=all" >> "${GITHUB_ENV}"
 
           # Fix https://github.com/NVIDIA/nvidia-docker/issues/1648 on runners with
-          # more than one GPUs. This just needs to be run once
+          # more than one GPUs. This just needs to be run once. The command fails
+          # on subsequent runs and complains that the mode is already on, but that's
+          # ok
           sudo nvidia-persistenced || true
           # This should show persistence mode ON
           nvidia-smi

--- a/.github/actions/setup-nvidia/action.yml
+++ b/.github/actions/setup-nvidia/action.yml
@@ -244,3 +244,9 @@ runs:
                   ;;
           esac
           echo "GPU_FLAG=--gpus all -e NVIDIA_DRIVER_CAPABILITIES=all" >> "${GITHUB_ENV}"
+
+          # Fix https://github.com/NVIDIA/nvidia-docker/issues/1648 on runners with
+          # more than one GPUs. This just needs to be run once
+          sudo nvidia-persistenced || true
+          # This should show persistence mode ON
+          nvidia-smi

--- a/aws/lambda/log-classifier/src/bedrock.rs
+++ b/aws/lambda/log-classifier/src/bedrock.rs
@@ -194,8 +194,8 @@ async fn make_bedrock_call(
 #[cfg(test)]
 mod test {
     use super::*;
-    use insta::assert_snapshot;
     use crate::log::Log;
+    use insta::assert_snapshot;
     use std::fs;
 
     #[test]
@@ -258,7 +258,6 @@ mod test {
         // Assert is validation_log_partial_tag2 is None
         assert_eq!(validation_log_partial_tag2, None);
     }
-
 
     // // Actually use the llm. Uncomment and you should hopefully see a reasonable output.
     // #[tokio::test]


### PR DESCRIPTION
As reported by @wconstab https://fb.workplace.com/groups/4571909969591489/permalink/7817935518322235