### PR TITLE
[HUD] Slightly improved repro copy paste for failure, do not require authentication to see copy paste link

### DIFF
--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -94,7 +94,7 @@ export default function JobLinks({
     }
   }
 
-  if (authenticated && job.failureLines) {
+  if (job.failureLines) {
     const reproComamnd = ReproductionCommand({
       job: job,
       separator: "",
@@ -119,7 +119,7 @@ export default function JobLinks({
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 const unittestFailureRe = /^(?:FAIL|ERROR) \[.*\]: (test_.* \(.*Test.*\))/;
-const pytestFailureRe = /^FAILED .*.py::(.*)::(test_\S*)/;
+const pytestFailureRe = /^FAILED.* ([^ ]+\.py)::(.*)::(test_\S*)/;
 function getTestName(failureCapture: string, reproduction: boolean = false) {
   const unittestMatch = failureCapture.match(unittestFailureRe);
   if (unittestMatch !== null) {
@@ -128,9 +128,9 @@ function getTestName(failureCapture: string, reproduction: boolean = false) {
   const pytestMatch = failureCapture.match(pytestFailureRe);
   if (pytestMatch !== null) {
     if (reproduction) {
-      return `python ${pytestMatch[0]}.py ${pytestMatch[1]}.${pytestMatch[2]}`;
+      return `python ${pytestMatch[1]}.py -k ${pytestMatch[1]}::${pytestMatch[2]}::${pytestMatch[3]}`;
     }
-    return `${pytestMatch[2]} (__main__.${pytestMatch[1]})`;
+    return `${pytestMatch[3]} (__main__.${pytestMatch[2]})`;
   }
   return null;
 }


### PR DESCRIPTION
I don't know why it required authentication so I got rid of it

Doesn't include env vars but it is better than what existed previously

Old
`python FAILED [5.4733s] inductor/test_torchinductor_dynamic_shapes.py::DynamicShapesCpuTests::test_upsample_bicubic2d_dynamic_shapes_cpu.py DynamicShapesCpuTests.test_upsample_bicubic2d_dynamic_shapes_cpu`

New
`python inductor/test_torchinductor_dynamic_shapes.py.py -k inductor/test_torchinductor_dynamic_shapes.py::DynamicShapesCpuTests::test_upsample_bicubic2d_dynamic_shapes_cpu`



Old not authenticated:
<img width="870" alt="image" src="https://github.com/user-attachments/assets/705cd0df-5a4a-46ad-aed1-b321998d7614">

New not authenticated:
<img width="1011" alt="image" src="https://github.com/user-attachments/assets/ff7cecb6-85f2-4de8-a4c4-25dd51165812">


https://torchci-git-csl-fixpytestreprocommand-fbopensource.vercel.app//pytorch/pytorch/commit/8fcb156e8b5697a8f292db6db2a1803c5f4ce2d7