### PR TITLE
[HUD] Add button for copying common revert message info/links

### DIFF
--- a/torchci/components/CopyLink.tsx
+++ b/torchci/components/CopyLink.tsx
@@ -1,16 +1,18 @@
 import React, { useState } from "react";
+import { FaCheck, FaLink, FaRegCopy } from "react-icons/fa";
 import useCopyClipboard from "react-use-clipboard";
-import Emoji from "./SmallerEmoji";
 
 export default function CopyLink({
   textToCopy,
   style,
   copyPrompt = "Permalink",
+  link = true, // Whether this is a link or not, controls the icon shown
   compressed = true, // Whether a small or large button should be used
 }: {
   textToCopy: string;
   style?: React.CSSProperties;
   copyPrompt?: string;
+  link?: boolean;
   compressed?: boolean;
 }) {
   const [isCopied, setCopied] = useCopyClipboard(textToCopy);
@@ -43,13 +45,21 @@ export default function CopyLink({
     >
       {showCopied ? (
         <>
-          <Emoji emoji="✅" /> {getButtonText(copyAck)}
+          <SmallIcon>
+            <FaCheck />
+          </SmallIcon>{" "}
+          {getButtonText(copyAck)}
         </>
       ) : (
         <>
-          <Emoji emoji="🔗" /> {getButtonText(copyPrompt)}
+          <SmallIcon>{link ? <FaLink /> : <FaRegCopy />}</SmallIcon>{" "}
+          {getButtonText(copyPrompt)}
         </>
       )}
     </button>
   );
+}
+
+function SmallIcon({ children }: { children: React.ReactNode }) {
+  return <span style={{ fontSize: "80%" }}>{children}</span>;
 }

--- a/torchci/components/CopyLink.tsx
+++ b/torchci/components/CopyLink.tsx
@@ -1,13 +1,16 @@
 import React, { useState } from "react";
 import useCopyClipboard from "react-use-clipboard";
+import Emoji from "./SmallerEmoji";
 
 export default function CopyLink({
   textToCopy,
   style,
+  copyPrompt = "Permalink",
   compressed = true, // Whether a small or large button should be used
 }: {
   textToCopy: string;
   style?: React.CSSProperties;
+  copyPrompt?: string;
   compressed?: boolean;
 }) {
   const [isCopied, setCopied] = useCopyClipboard(textToCopy);
@@ -21,14 +24,11 @@ export default function CopyLink({
     }, 3000);
   };
 
-  const copy_prompt = "Permalink";
-  const copy_ack = "Copied";
+  const copyAck = "Copied";
 
-  function getButtonText(baseIcon: string, elaboration: string) {
-    if (compressed) {
-      return baseIcon;
-    } else {
-      return `${baseIcon} ${elaboration}`;
+  function getButtonText(elaboration: string) {
+    if (!compressed) {
+      return elaboration;
     }
   }
 
@@ -38,12 +38,18 @@ export default function CopyLink({
   return (
     <button
       style={css_style}
-      title={isCopied ? copy_ack : copy_prompt}
+      title={isCopied ? copyAck : copyPrompt}
       onClick={onClick}
     >
-      {showCopied
-        ? getButtonText("✅", copy_ack)
-        : getButtonText("🔗", copy_prompt)}
+      {showCopied ? (
+        <>
+          <Emoji emoji="✅" /> {getButtonText(copyAck)}
+        </>
+      ) : (
+        <>
+          <Emoji emoji="🔗" /> {getButtonText(copyPrompt)}
+        </>
+      )}
     </button>
   );
 }

--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -328,7 +328,9 @@ function RevertInfoCopy({ job }: { job: JobData }) {
     info.push(testName);
   }
   info.push(`[GH job link](${job.htmlUrl})`);
-  info.push(`[HUD commit link](https://hud.pytorch.org/${job.repo}/commit/${job.sha})`);
+  info.push(
+    `[HUD commit link](https://hud.pytorch.org/${job.repo}/commit/${job.sha})`
+  );
   return CopyLink({
     textToCopy: info.join(" "),
     copyPrompt: "Revert Info",

--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -326,7 +326,7 @@ function RevertInfoCopy({ job }: { job: JobData }) {
     info.push(testName);
   }
   info.push(job.htmlUrl);
-  info.push(`${location.host}/${job.repo}/commit/${job.sha}`);
+  info.push(`https://hud.pytorch.org/${job.repo}/commit/${job.sha}`);
   return CopyLink({
     textToCopy: info.join(" "),
     copyPrompt: "Revert Info",

--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -3,7 +3,7 @@ import { useSession } from "next-auth/react";
 import React from "react";
 import useSWR from "swr";
 import { isFailure } from "../lib/JobClassifierUtil";
-import { transformJobName } from "../lib/jobUtils";
+import { isFailedJob, transformJobName } from "../lib/jobUtils";
 import { IssueData, JobData } from "../lib/types";
 import CopyLink from "./CopyLink";
 import styles from "./JobLinks.module.css";
@@ -82,9 +82,11 @@ export default function JobLinks({
     subInfo.push(testInsightsLink);
   }
 
-  const revertInfoCopy = RevertInfoCopy({ job: job });
-  if (revertInfoCopy != null) {
-    subInfo.push(revertInfoCopy);
+  if (isFailedJob(job)) {
+    const revertInfoCopy = RevertInfoCopy({ job: job });
+    if (revertInfoCopy != null) {
+      subInfo.push(revertInfoCopy);
+    }
   }
 
   const disableTestButton = DisableTest({ job: job, label: "skipped" });
@@ -331,5 +333,6 @@ function RevertInfoCopy({ job }: { job: JobData }) {
     textToCopy: info.join(" "),
     copyPrompt: "Revert Info",
     compressed: false,
+    link: false,
   });
 }

--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -327,8 +327,8 @@ function RevertInfoCopy({ job }: { job: JobData }) {
   if (testName !== null) {
     info.push(testName);
   }
-  info.push(job.htmlUrl);
-  info.push(`https://hud.pytorch.org/${job.repo}/commit/${job.sha}`);
+  info.push(`[GH job link](${job.htmlUrl})`);
+  info.push(`[HUD commit link](https://hud.pytorch.org/${job.repo}/commit/${job.sha})`);
   return CopyLink({
     textToCopy: info.join(" "),
     copyPrompt: "Revert Info",

--- a/torchci/components/SmallerEmoji.tsx
+++ b/torchci/components/SmallerEmoji.tsx
@@ -1,0 +1,3 @@
+export default function Emoji({ emoji }: { emoji: string }) {
+  return <span style={{ fontSize: "70%" }}>{emoji}</span>;
+}

--- a/torchci/components/SmallerEmoji.tsx
+++ b/torchci/components/SmallerEmoji.tsx
@@ -1,3 +1,0 @@
-export default function Emoji({ emoji }: { emoji: string }) {
-  return <span style={{ fontSize: "70%" }}>{emoji}</span>;
-}


### PR DESCRIPTION
Add a button to copy info so you can paste into revert message

Relies on https://github.com/pytorch/test-infra/pull/5432

**Caveat: Changes the icons for other things too** Not sure if this is something we're willing to have
Link:
Old 
<img width="107" alt="image" src="https://github.com/user-attachments/assets/122abe8b-402d-4d66-888d-1c47c27bfc36">

new
<img width="81" alt="image" src="https://github.com/user-attachments/assets/b714ae5c-52e6-4a78-a926-fb4418ca584d">

Copied checkmark:
old
<img width="74" alt="image" src="https://github.com/user-attachments/assets/3cd50361-8e37-4d8c-b9c3-862c8991267d">
new
<img width="79" alt="image" src="https://github.com/user-attachments/assets/3a51ba01-4579-42d4-b938-bd8b12663a92">


Info includes:
if test, testname
GH job link
HUD commit link

ex 
<img width="943" alt="image" src="https://github.com/user-attachments/assets/2651873a-7994-4d41-b05c-83eab4445d0a">
export/test_torchbind.py::TestExportTorchbind::test_export_inplace_custom_op [GH job link](https://github.com/pytorch/pytorch/actions/runs/10077811381/job/27862620615) [HUD commit link](https://hud.pytorch.org/pytorch/pytorch/commit/6415c45da5aee538624355fdf5aab8059bf5f98b)

or 
[GH job link](https://github.com/pytorch/pytorch/actions/runs/10074672842/job/27851322465) [HUD commit link](https://hud.pytorch.org/pytorch/pytorch/commit/62e566b3455785569c923be304b0701a2cbaa4ac)

Also visible on the commit/PR page
<img width="1150" alt="image" src="https://github.com/user-attachments/assets/ce0efa2d-c721-4d04-a768-a70822dc2b82">



