### PR TITLE
Add errors="backslashreplace" to run_with_env_secrets.py

### DIFF
--- a/.github/scripts/run_with_env_secrets.py
+++ b/.github/scripts/run_with_env_secrets.py
@@ -15,6 +15,7 @@ def run_cmd_or_die(cmd):
         stderr=subprocess.STDOUT,
         bufsize=1,
         universal_newlines=True,
+        errors="backslashreplace",
     )
     p.stdin.write("set -e\n")
     p.stdin.write(cmd)


### PR DESCRIPTION
See: https://fb.workplace.com/groups/4571909969591489/permalink/7818394354943018/

ExecuTorch CI was running into an issue where non-utf8 print output caused tests to crash. This was resolved by removing the printing in https://github.com/pytorch/executorch/pull/4268. 

This PR updates the error handling to use `backslashreplace`, which should still show us the error/printing, but without crashing the test.

From https://docs.python.org/3.9/library/io.html#io.TextIOWrapper:
```
'backslashreplace' causes malformed data to be replaced by a backslashed escape sequence. 
```
From https://docs.python.org/3/library/subprocess.html#frequently-used-arguments:

If encoding or errors are specified, or text (also known as universal_newlines) is true, the file objects stdin, stdout and stderr will be opened in text mode using the encoding and errors specified in the call or the defaults for [io.TextIOWrapper](https://docs.python.org/3/library/io.html#io.TextIOWrapper).

