### PR TITLE
Remove workaround to install kernel-devel

### DIFF
--- a/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
@@ -108,13 +108,6 @@ ${install_config_runner}
 retry sudo $PKG_MANAGER groupinstall -y 'Development Tools'
 retry sudo $PKG_MANAGER install -y "kernel-devel-uname-r == $(uname -r)" || true
 
-# Needed since kernel 4.14.336-257.562 is not currently available in package managers
-(
-  pushd /usr/src/kernels/
-  aws s3 cp s3://ossci-linux/4.14.336-257.562.amzn2.x86_64.tar.gz .
-  tar xzf 4.14.336-257.562.amzn2.x86_64.tar.gz
-)
-
 echo Checking if nvidia install required ${nvidia_driver_install}
 %{ if nvidia_driver_install ~}
 echo "NVIDIA driver install required"


### PR DESCRIPTION
This workaround might not be necessary any longer as kernel-devel appears to be available again in package managers. This also fixes the LF ALI runners as they are failing to fetch from the s3://ossci-linux bucket due to no permissions.

I verified by doing a `yum install kernel-devel` on one of the EC2 instances that was stuck and saw that it returned a newer kernel-devel package.

Relates to pytorch/pytorch#129880 and pytorch/ci-infra#244.