### PR TITLE
Fix alert for no new flaky tests spamming

### DIFF
--- a/tools/torchci/check_alerts.py
+++ b/tools/torchci/check_alerts.py
@@ -497,7 +497,9 @@ def classify_jobs(
     return jobs_to_alert_on, flaky_jobs
 
 
-def handle_flaky_tests_alert(existing_alerts: List[Dict]) -> Dict:
+def handle_flaky_tests_alert(
+    existing_alerts: List[Dict], dry_run: bool = False
+) -> Dict:
     if not existing_alerts:
         from_date = (
             datetime.today() - timedelta(days=FLAKY_TESTS_SEARCH_PERIOD_DAYS)
@@ -510,7 +512,7 @@ def handle_flaky_tests_alert(existing_alerts: List[Dict]) -> Dict:
             num_issues_with_flaky_tests_lables,
         )
         if num_issues_with_flaky_tests_lables == 0:
-            return create_issue(generate_no_flaky_tests_issue(), False)
+            return create_issue(generate_no_flaky_tests_issue(), dry_run=dry_run)
 
     print("No new alert for flaky tests bots.")
     return None

--- a/tools/torchci/check_alerts.py
+++ b/tools/torchci/check_alerts.py
@@ -6,7 +6,7 @@ import os
 import re
 import urllib.parse
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from difflib import SequenceMatcher
 from typing import Any, Dict, List, Set, Tuple
 
@@ -498,13 +498,7 @@ def classify_jobs(
 
 
 def handle_flaky_tests_alert(existing_alerts: List[Dict]) -> Dict:
-    if (
-        not existing_alerts
-        or datetime.fromisoformat(
-            existing_alerts[0]["createdAt"].replace("Z", "+00:00")
-        ).date()
-        != datetime.today().date()
-    ):
+    if not existing_alerts:
         from_date = (
             datetime.today() - timedelta(days=FLAKY_TESTS_SEARCH_PERIOD_DAYS)
         ).strftime("%Y-%m-%d")
@@ -598,7 +592,17 @@ def check_for_no_flaky_tests_alert(repo: str, branch: str):
     existing_no_flaky_tests_alerts = fetch_alerts(
         labels=[NO_FLAKY_TESTS_LABEL],
     )
-    handle_flaky_tests_alert(existing_no_flaky_tests_alerts)
+    open_alerts = [
+        alert for alert in existing_no_flaky_tests_alerts if not alert["closed"]
+    ]
+    recent_open_alerts = [
+        existing_alert
+        for existing_alert in open_alerts
+        if datetime.now(timezone.utc)
+        - datetime.fromisoformat(existing_alert["createdAt"].replace("Z", "+00:00"))
+        < timedelta(days=7)
+    ]
+    handle_flaky_tests_alert(recent_open_alerts)
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2b81448d-32f3-4a54-909b-40cf2f9a9dcc)
Made a ton of issues for some reason

This change checks for an open issue made in the last 7 days.  If it sees one, it doesn't make a new one
