### PR TITLE
Emit Runner info at the start of every job on self hosted linux runners  

### DIFF
--- a/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
@@ -66,15 +66,15 @@ EOF
 
 sudo chown -R $USER_NAME:$USER_NAME /home/$USER_NAME/actions-runner
 
-# See all meta
-echo "Instance Type: $(curl http://169.254.169.254/latest/meta-data/instance-type)"
-echo "AMI Type: $(curl http://169.254.169.254/latest/meta-data/ami-id)"
+instance_id=\$(curl http://169.254.169.254/latest/meta-data/instance-id)
+region=\$(curl http://169.254.169.254/latest/meta-data/placement/region)
+runner_type=\$(aws ec2 describe-tags --filters "Name=resource-id,Values=\$instance_id" "Name=key,Values=RunnerType" --query 'Tags[0].Value' --output text --region \$region)
+instance_type=\$(curl http://169.254.169.254/latest/meta-data/instance-type)
+ami_id=$(curl http://169.254.169.254/latest/meta-data/ami-id)"
 
-# The second line contains the runner type. Ugly, but this is currently the most reliable way to get it.
-echo "Runner Type: \$(sed -n '2p' /home/$USER_NAME/runner-labels)"
-
-# Print everything but the second line (runner type), comma separated
-echo "Additional Runner Labels: \$(sed -n -e '1p' -e '3,\$p' /home/$USER_NAME/runner-labels | paste -sd ',' -)"
+echo "Runner Type: \$runner_type"
+echo "Instance Type: \$instance_type"
+echo "AMI ID: \$ami_id"
 
 metric_report "runner_scripts.before_job" 1
 EOF

--- a/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
@@ -67,7 +67,7 @@ EOF
 sudo chown -R $USER_NAME:$USER_NAME /home/$USER_NAME/actions-runner
 
 # Use the IDMS v2 token
-token=\$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" -s)
+token=\$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 600" -s)
 
 # Use the token to fetch instance metadata
 instance_id=\$(curl -H "X-aws-ec2-metadata-token: \$token" -s http://169.254.169.254/latest/meta-data/instance-id)

--- a/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
@@ -70,11 +70,11 @@ sudo chown -R $USER_NAME:$USER_NAME /home/$USER_NAME/actions-runner
 echo "Instance Type: $(curl http://169.254.169.254/latest/meta-data/instance-type)"
 echo "AMI Type: $(curl http://169.254.169.254/latest/meta-data/ami-id)"
 
-# The second line contains the runner type
-echo "Runner Type: $(sed -n '2p' /home/ec2-user/runner-labels)"
+# The second line contains the runner type. Ugly, but this is currently the most reliable way to get it.
+echo "Runner Type: \$(sed -n '2p' /home/$USER_NAME/runner-labels)"
 
 # Print everything but the second line (runner type), comma separated
-echo "Other Labels: $(sed -n -e '1p' -e '3,$p' /home/ec2-user/runner-labels | paste -sd ',' -)"
+echo "Additional Runner Labels: \$(sed -n -e '1p' -e '3,\$p' /home/$USER_NAME/runner-labels | paste -sd ',' -)"
 
 metric_report "runner_scripts.before_job" 1
 EOF

--- a/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
@@ -65,6 +65,17 @@ EOF
 . /home/$USER_NAME/runner-scripts/utils.sh
 
 sudo chown -R $USER_NAME:$USER_NAME /home/$USER_NAME/actions-runner
+
+# See all meta
+echo "Instance Type: $(curl http://169.254.169.254/latest/meta-data/instance-type)"
+echo "AMI Type: $(curl http://169.254.169.254/latest/meta-data/ami-id)"
+
+# The second line contains the runner type
+echo "Runner Type: $(sed -n '2p' /home/ec2-user/runner-labels)"
+
+# Print everything but the second line (runner type), comma separated
+echo "Other Labels: $(sed -n -e '1p' -e '3,$p' /home/ec2-user/runner-labels | paste -sd ',' -)"
+
 metric_report "runner_scripts.before_job" 1
 EOF
   chmod 755 $BEFORE_JOB_SCRIPT

--- a/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
@@ -66,14 +66,21 @@ EOF
 
 sudo chown -R $USER_NAME:$USER_NAME /home/$USER_NAME/actions-runner
 
-instance_id=\$(curl http://169.254.169.254/latest/meta-data/instance-id)
-region=\$(curl http://169.254.169.254/latest/meta-data/placement/region)
+instance_id=\$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+region=\$(curl -s http://169.254.169.254/latest/meta-data/placement/region)
 runner_type=\$(aws ec2 describe-tags --filters "Name=resource-id,Values=\$instance_id" "Name=key,Values=RunnerType" --query 'Tags[0].Value' --output text --region \$region)
-instance_type=\$(curl http://169.254.169.254/latest/meta-data/instance-type)
-ami_id=$(curl http://169.254.169.254/latest/meta-data/ami-id)"
+instance_type=\$(curl -s http://169.254.169.254/latest/meta-data/instance-type)
+ami_id=\$(curl -s http://169.254.169.254/latest/meta-data/ami-id)
 
 echo "Runner Type: \$runner_type"
 echo "Instance Type: \$instance_type"
+
+case \$ami_id in
+  ami-0ce0c36d7a00b20e2) echo "AMI Name: amzn2-ami-hvm-2.0.20240306.2-x86_64-ebs";;
+  ami-06c68f701d8090592) echo "AMI Name: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64";;
+  *) echo "AMI Name: unknown";;
+esac
+
 echo "AMI ID: \$ami_id"
 
 metric_report "runner_scripts.before_job" 1

--- a/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
@@ -74,7 +74,7 @@ instance_id=\$(curl -H "X-aws-ec2-metadata-token: \$token" -s http://169.254.169
 region=\$(curl -H "X-aws-ec2-metadata-token: \$token" -s http://169.254.169.254/latest/meta-data/placement/region)
 runner_type=\$(aws ec2 describe-tags --filters "Name=resource-id,Values=\$instance_id" "Name=key,Values=RunnerType" --query 'Tags[0].Value' --output text --region \$region)
 instance_type=\$(curl -H "X-aws-ec2-metadata-token: \$token" -s http://169.254.169.254/latest/meta-data/instance-type)
-ami_id=$\(curl -H "X-aws-ec2-metadata-token: \$token" -s http://169.254.169.254/latest/meta-data/ami-id)
+ami_id=\$(curl -H "X-aws-ec2-metadata-token: \$token" -s http://169.254.169.254/latest/meta-data/ami-id)
 
 echo "Runner Type: \$runner_type"
 echo "Instance Type: \$instance_type"


### PR DESCRIPTION
Emits:
- Runner type
- Instance Type
- AMI ID
- AMI Name (if known)

Note: Hard coding the ami id->name mapping isn't ideal, we should get the name dynamically. However, that requires granting the runners extra permissions to read the AMI name so will add that as a follow up.

Sample output:
<img width="725" alt="image" src="https://github.com/user-attachments/assets/d0933907-2f6c-4ade-aeb4-44fe5fe139b6">

Testing: https://github.com/pytorch/pytorch-canary/actions/runs/10012762937/job/27679499479?pr=227