### PR TITLE
[flakybot] Instructions to re-enable test in validation comment

### DIFF
--- a/torchci/lib/bot/verifyDisableTestIssueBot.ts
+++ b/torchci/lib/bot/verifyDisableTestIssueBot.ts
@@ -125,7 +125,8 @@ export function formValidationComment(
   authorized: boolean,
   testName: string,
   platformsToSkip: string[],
-  invalidPlatforms: string[]
+  invalidPlatforms: string[],
+  issueNumber: number
 ): string {
   const platformMsg =
     platformsToSkip.length === 0
@@ -184,8 +185,14 @@ export function formValidationComment(
     "```\nPlatforms: case-insensitive, list, of, platforms\n```\nWe currently support the following platforms: ";
   body += `${Array.from(supportedPlatforms.keys())
     .sort((a, b) => a.localeCompare(b))
-    .join(", ")}.</body>`;
+    .join(", ")}.\n\n`;
 
+  body += `
+### How to re-enable a test
+To re-enable the test globally, close the issue. If you wish to re-enable a test for only a subset of platforms, remove the platforms from the list in the issue body. This may take some time to propagate. If you wish to re-enable a test only for a PR, put \`Fixes #${issueNumber}\` in the PR body and rerun the test jobs. Note that if a test is flaky, it maybe be difficult to tell if the test is still flaky on the PR.
+`;
+
+  body += "</body>";
   return validationCommentStart + body + validationCommentEnd;
 }
 
@@ -259,7 +266,8 @@ export default function verifyDisableTestIssueBot(app: Probot): void {
           authorized,
           target,
           platformsToSkip,
-          invalidPlatforms
+          invalidPlatforms,
+          number
         )
       : formJobValidationComment(username, authorized, target, prefix);
 

--- a/torchci/lib/bot/verifyDisableTestIssueBot.ts
+++ b/torchci/lib/bot/verifyDisableTestIssueBot.ts
@@ -189,7 +189,7 @@ export function formValidationComment(
 
   body += `
 ### How to re-enable a test
-To re-enable the test globally, close the issue. If you wish to re-enable a test for only a subset of platforms, remove the platforms from the list in the issue body. This may take some time to propagate. If you wish to re-enable a test only for a PR, put \`Fixes #${issueNumber}\` in the PR body and rerun the test jobs. Note that if a test is flaky, it maybe be difficult to tell if the test is still flaky on the PR.
+To re-enable the test globally, close the issue. To re-enable a test for only a subset of platforms, remove the platforms from the list in the issue body. This may take some time to propagate. To re-enable a test only for a PR, put \`Fixes #${issueNumber}\` in the PR body and rerun the test jobs. Note that if a test is flaky, it maybe be difficult to tell if the test is still flaky on the PR.
 `;
 
   body += "</body>";

--- a/torchci/test/verifyDisableTestIssue.test.ts
+++ b/torchci/test/verifyDisableTestIssue.test.ts
@@ -47,7 +47,8 @@ describe("verify-disable-test-issue", () => {
       false,
       testName,
       platformsToSkip,
-      invalidPlatforms
+      invalidPlatforms,
+      0
     );
 
     expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
@@ -72,7 +73,8 @@ describe("verify-disable-test-issue", () => {
       true,
       testName,
       platformsToSkip,
-      invalidPlatforms
+      invalidPlatforms,
+      0
     );
     expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
     expect(
@@ -100,7 +102,8 @@ describe("verify-disable-test-issue", () => {
       true,
       testName,
       platformsToSkip,
-      invalidPlatforms
+      invalidPlatforms,
+      0
     );
     expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
     expect(
@@ -130,7 +133,8 @@ describe("verify-disable-test-issue", () => {
       true,
       testName,
       platformsToSkip,
-      invalidPlatforms
+      invalidPlatforms,
+      0
     );
     expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
     expect(
@@ -158,7 +162,8 @@ describe("verify-disable-test-issue", () => {
       true,
       testName,
       platformsToSkip,
-      invalidPlatforms
+      invalidPlatforms,
+      0
     );
     expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
     expect(
@@ -194,7 +199,8 @@ describe("verify-disable-test-issue", () => {
       true,
       testName,
       platformsToSkip,
-      invalidPlatforms
+      invalidPlatforms,
+      0
     );
     expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
     expect(comment.includes("~15 minutes")).toBeTruthy();
@@ -217,7 +223,8 @@ describe("verify-disable-test-issue", () => {
       true,
       testName,
       platformsToSkip,
-      invalidPlatforms
+      invalidPlatforms,
+      0
     );
     expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
     expect(comment.includes("~15 minutes")).toBeFalsy();
@@ -240,7 +247,8 @@ describe("verify-disable-test-issue", () => {
       true,
       testName,
       platformsToSkip,
-      invalidPlatforms
+      invalidPlatforms,
+      0
     );
     expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
     expect(comment.includes("~15 minutes")).toBeFalsy();


### PR DESCRIPTION
Adds instructions on how to re enable the test in the validation comment (the comment that gets made after a disable issue gets made) so that manually created disable issues also have instructions

Example:
<img width="784" alt="image" src="https://github.com/user-attachments/assets/df4bd7c7-5cb0-44bf-9587-c5366550a126">
