### PR TITLE
Add the list of devices on PT2 inductor perf dashboard

### DIFF
--- a/torchci/components/benchmark/ModeAndDTypePicker.tsx
+++ b/torchci/components/benchmark/ModeAndDTypePicker.tsx
@@ -6,7 +6,7 @@ import {
   SelectChangeEvent,
 } from "@mui/material";
 
-export const DEFAULT_MODE = "training";
+export const DEFAULT_MODE = "inference";
 // The value is the default dtype for that mode
 export const MODES: { [k: string]: string } = {
   training: "amp",

--- a/torchci/components/benchmark/compilers/ModelPanel.tsx
+++ b/torchci/components/benchmark/compilers/ModelPanel.tsx
@@ -39,6 +39,7 @@ export function ModelPanel({
   suite,
   mode,
   dtype,
+  deviceName,
   compiler,
   model,
   lPerfData,
@@ -51,6 +52,7 @@ export function ModelPanel({
   suite: string;
   mode: string;
   dtype: string;
+  deviceName: string;
   compiler: string;
   model: string;
   lPerfData: BranchAndCommitPerfData;
@@ -176,7 +178,9 @@ export function ModelPanel({
                     : undefined;
 
                 const encodedName = encodeURIComponent(name);
-                const url = `/benchmark/${suite}/${compiler}?dashboard=${dashboard}&startTime=${startTime}&stopTime=${stopTime}&granularity=${granularity}&mode=${mode}&model=${encodedName}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
+                const url = `/benchmark/${suite}/${compiler}?dashboard=${dashboard}&startTime=${startTime}&stopTime=${stopTime}&granularity=${granularity}&mode=${mode}&model=${encodedName}&dtype=${dtype}&deviceName=${encodeURIComponent(
+                  deviceName
+                )}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
 
                 if (lLog === undefined) {
                   return (

--- a/torchci/components/benchmark/compilers/SummaryPanel.tsx
+++ b/torchci/components/benchmark/compilers/SummaryPanel.tsx
@@ -134,6 +134,7 @@ export function SummaryPanel({
   granularity,
   mode,
   dtype,
+  deviceName,
   lPerfData,
   rPerfData,
   all_suites,
@@ -144,6 +145,7 @@ export function SummaryPanel({
   granularity: Granularity;
   mode: string;
   dtype: string;
+  deviceName: string;
   lPerfData: BranchAndCommitPerfData;
   rPerfData: BranchAndCommitPerfData;
   all_suites: { [key: string]: string };
@@ -244,7 +246,9 @@ export function SummaryPanel({
                     const url = `/benchmark/${suite}/${
                       DISPLAY_NAMES_TO_COMPILER_NAMES[params.row.compiler] ??
                       params.row.compiler
-                    }?dashboard=${dashboard}&startTime=${startTime}&stopTime=${stopTime}&granularity=${granularity}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
+                    }?dashboard=${dashboard}&startTime=${startTime}&stopTime=${stopTime}&granularity=${granularity}&mode=${mode}&dtype=${dtype}&deviceName=${encodeURIComponent(
+                      deviceName
+                    )}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
 
                     const l = extractPercentage(v.l);
                     const r = extractPercentage(v.r);
@@ -334,7 +338,9 @@ export function SummaryPanel({
                     const url = `/benchmark/${suite}/${
                       DISPLAY_NAMES_TO_COMPILER_NAMES[params.row.compiler] ??
                       params.row.compiler
-                    }?dashboard=${dashboard}&startTime=${startTime}&stopTime=${stopTime}&granularity=${granularity}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
+                    }?dashboard=${dashboard}&startTime=${startTime}&stopTime=${stopTime}&granularity=${granularity}&mode=${mode}&dtype=${dtype}&deviceName=${encodeURIComponent(
+                      deviceName
+                    )}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
 
                     const l = Number(v.l).toFixed(SCALE);
                     const r = Number(v.r).toFixed(SCALE);
@@ -427,7 +433,9 @@ export function SummaryPanel({
                     const url = `/benchmark/${suite}/${
                       DISPLAY_NAMES_TO_COMPILER_NAMES[params.row.compiler] ??
                       params.row.compiler
-                    }?dashboard=${dashboard}&startTime=${startTime}&stopTime=${stopTime}&granularity=${granularity}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
+                    }?dashboard=${dashboard}&startTime=${startTime}&stopTime=${stopTime}&granularity=${granularity}&mode=${mode}&dtype=${dtype}&deviceName=${encodeURIComponent(
+                      deviceName
+                    )}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
 
                     const l = Number(v.l).toFixed(0);
                     const r = Number(v.r).toFixed(0);
@@ -516,7 +524,9 @@ export function SummaryPanel({
                     const url = `/benchmark/${suite}/${
                       DISPLAY_NAMES_TO_COMPILER_NAMES[params.row.compiler] ??
                       params.row.compiler
-                    }?dashboard=${dashboard}&startTime=${startTime}&stopTime=${stopTime}&granularity=${granularity}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
+                    }?dashboard=${dashboard}&startTime=${startTime}&stopTime=${stopTime}&granularity=${granularity}&mode=${mode}&dtype=${dtype}&deviceName=${encodeURIComponent(
+                      deviceName
+                    )}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`;
 
                     const l = Number(v.l).toFixed(SCALE);
                     const r = Number(v.r).toFixed(SCALE);

--- a/torchci/components/benchmark/compilers/common.tsx
+++ b/torchci/components/benchmark/compilers/common.tsx
@@ -52,3 +52,8 @@ export const HELP_LINK =
   "https://pytorch.org/docs/main/torch.compiler_performance_dashboard.html";
 
 export const DTYPES = ["amp", "float16", "bfloat16", "quant"];
+
+export const DEFAULT_DEVICE_NAME = "cuda";
+// TODO (huydhn): there is a way to avoid hard-coding dtypes and devices like how
+// the LLM micro-benchmark page is implemented
+export const DEVICES = ["cuda", "cpu-x86"];

--- a/torchci/components/benchmark/compilers/common.tsx
+++ b/torchci/components/benchmark/compilers/common.tsx
@@ -53,7 +53,16 @@ export const HELP_LINK =
 
 export const DTYPES = ["amp", "float16", "bfloat16", "quant"];
 
-export const DEFAULT_DEVICE_NAME = "cuda";
+export const DEFAULT_DEVICE_NAME = "cuda (a100)";
 // TODO (huydhn): there is a way to avoid hard-coding dtypes and devices like how
 // the LLM micro-benchmark page is implemented
-export const DEVICES = ["cuda", "cpu-x86"];
+export const DISPLAY_NAMES_TO_DEVICE_NAMES: { [k: string]: string } = {
+  "cuda (a100)": "cuda",
+  "cpu (x86)": "cpu_x86",
+  "cpu (aarch64)": "cpu_aarch64",
+};
+export const DISPLAY_NAMES_TO_WORKFLOW_NAMES: { [k: string]: string } = {
+  "cuda (a100)": "inductor-A100-perf-nightly",
+  "cpu (x86)": "inductor-perf-nightly-x86",
+  "cpu (aarch64)": "inductor-perf-nightly-aarch64",
+};

--- a/torchci/components/benchmark/torchao/common.tsx
+++ b/torchci/components/benchmark/torchao/common.tsx
@@ -1,3 +1,10 @@
 export const DEFAULT_REPO_NAME = "pytorch/ao";
 export const DTYPES = ["amp", "bfloat16"];
 export const DEFAULT_MODE = "inference";
+
+export const DEFAULT_DEVICE_NAME = "cuda (a100)";
+// TODO (huydhn): there is a way to avoid hard-coding dtypes and devices like how
+// the LLM micro-benchmark page is implemented
+export const DISPLAY_NAMES_TO_DEVICE_NAMES: { [k: string]: string } = {
+  "cuda (a100)": "cuda",
+};

--- a/torchci/lib/benchmark/compilerUtils.ts
+++ b/torchci/lib/benchmark/compilerUtils.ts
@@ -273,10 +273,12 @@ export function computeCompilationTime(
           (compiler: string) => {
             const l = compTime[bucket][workflowId][suite][compiler].length;
             const m =
-              compTime[bucket][workflowId][suite][compiler].reduce(
-                (total: number, v: number) => total + v,
-                0
-              ) / l;
+              l !== 0
+                ? compTime[bucket][workflowId][suite][compiler].reduce(
+                    (total: number, v: number) => total + v,
+                    0
+                  ) / l
+                : 0;
 
             returnedCompTime.push({
               granularity_bucket: bucket,
@@ -346,10 +348,12 @@ export function computeMemoryCompressionRatio(
           (compiler: string) => {
             const l = memory[bucket][workflowId][suite][compiler].length;
             const m =
-              memory[bucket][workflowId][suite][compiler].reduce(
-                (total: number, v: number) => total + v,
-                0
-              ) / l;
+              l !== 0
+                ? memory[bucket][workflowId][suite][compiler].reduce(
+                    (total: number, v: number) => total + v,
+                    0
+                  ) / l
+                : 0;
 
             returnedMemory.push({
               granularity_bucket: bucket,

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -11,6 +11,8 @@ import {
 import { BenchmarkLogs } from "components/benchmark/compilers/BenchmarkLogs";
 import {
   COMPILER_NAMES_TO_DISPLAY_NAMES,
+  DEFAULT_DEVICE_NAME,
+  DEVICES,
   DTYPES,
 } from "components/benchmark/compilers/common";
 import { GraphPanel } from "components/benchmark/compilers/ModelGraphPanel";
@@ -208,6 +210,7 @@ export default function Page() {
   const [rBranch, setRBranch] = useState<string>(MAIN_BRANCH);
   const [rCommit, setRCommit] = useState<string>("");
   const [baseUrl, setBaseUrl] = useState<string>("");
+  const [deviceName, setDeviceName] = useState<string>(DEFAULT_DEVICE_NAME);
 
   // Set the dropdown value what is in the param
   useEffect(() => {
@@ -243,6 +246,11 @@ export default function Page() {
     const dtype: string = (router.query.dtype as string) ?? undefined;
     if (dtype !== undefined) {
       setDType(dtype);
+    }
+
+    const deviceName: string = (router.query.deviceName as string) ?? undefined;
+    if (deviceName !== undefined) {
+      setDeviceName(deviceName);
     }
 
     const lBranch: string = (router.query.lBranch as string) ?? undefined;
@@ -312,6 +320,11 @@ export default function Page() {
       type: "string",
       value: dtype,
     },
+    {
+      name: "device",
+      type: "string",
+      value: deviceName,
+    },
   ];
 
   return (
@@ -327,7 +340,9 @@ export default function Page() {
               startTime.toString()
             )}&stopTime=${encodeURIComponent(
               stopTime.toString()
-            )}&granularity=${granularity}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}` +
+            )}&granularity=${granularity}&mode=${mode}&dtype=${dtype}&deviceName=${encodeURIComponent(
+              deviceName
+            )}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}` +
             (model === undefined ? "" : `&model=${model}`)
           }
         />
@@ -352,6 +367,12 @@ export default function Page() {
           setDType={setDType}
           dtypes={DTYPES}
           label={"Precision"}
+        />
+        <DTypePicker
+          dtype={deviceName}
+          setDType={setDeviceName}
+          dtypes={DEVICES}
+          label={"Device"}
         />
         <BranchAndCommitPicker
           queryName={branchQueryName}

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -12,7 +12,8 @@ import { BenchmarkLogs } from "components/benchmark/compilers/BenchmarkLogs";
 import {
   COMPILER_NAMES_TO_DISPLAY_NAMES,
   DEFAULT_DEVICE_NAME,
-  DEVICES,
+  DISPLAY_NAMES_TO_DEVICE_NAMES,
+  DISPLAY_NAMES_TO_WORKFLOW_NAMES,
   DTYPES,
 } from "components/benchmark/compilers/common";
 import { GraphPanel } from "components/benchmark/compilers/ModelGraphPanel";
@@ -46,6 +47,7 @@ function Report({
   suite,
   mode,
   dtype,
+  deviceName,
   compiler,
   model,
   lBranchAndCommit,
@@ -60,6 +62,7 @@ function Report({
   suite: string;
   mode: string;
   dtype: string;
+  deviceName: string;
   compiler: string;
   model: string;
   lBranchAndCommit: BranchAndCommit;
@@ -146,7 +149,10 @@ function Report({
               ? rData[0].granularity_bucket
               : undefined,
         }}
-        workflowName={"inductor-a100-perf-nightly"}
+        workflowName={
+          DISPLAY_NAMES_TO_WORKFLOW_NAMES[deviceName] ??
+          "inductor-a100-perf-nightly"
+        }
       >
         <BenchmarkLogs workflowId={lData[0].workflow_id} />
       </CommitPanel>
@@ -168,6 +174,7 @@ function Report({
         suite={suite}
         mode={mode}
         dtype={dtype}
+        deviceName={deviceName}
         compiler={compiler}
         model={model}
         lPerfData={{
@@ -323,7 +330,7 @@ export default function Page() {
     {
       name: "device",
       type: "string",
-      value: deviceName,
+      value: DISPLAY_NAMES_TO_DEVICE_NAMES[deviceName],
     },
   ];
 
@@ -371,7 +378,7 @@ export default function Page() {
         <DTypePicker
           dtype={deviceName}
           setDType={setDeviceName}
-          dtypes={DEVICES}
+          dtypes={Object.keys(DISPLAY_NAMES_TO_DEVICE_NAMES)}
           label={"Device"}
         />
         <BranchAndCommitPicker
@@ -414,6 +421,7 @@ export default function Page() {
           suite={suite}
           mode={mode}
           dtype={dtype}
+          deviceName={deviceName}
           compiler={compiler}
           model={model}
           lBranchAndCommit={{ branch: lBranch, commit: lCommit }}

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -9,7 +9,8 @@ import {
 import { BenchmarkLogs } from "components/benchmark/compilers/BenchmarkLogs";
 import {
   DEFAULT_DEVICE_NAME,
-  DEVICES,
+  DISPLAY_NAMES_TO_DEVICE_NAMES,
+  DISPLAY_NAMES_TO_WORKFLOW_NAMES,
   DTYPES,
 } from "components/benchmark/compilers/common";
 import {
@@ -45,6 +46,7 @@ function Report({
   suite,
   mode,
   dtype,
+  deviceName,
   lBranchAndCommit,
   rBranchAndCommit,
 }: {
@@ -55,6 +57,7 @@ function Report({
   suite: string;
   mode: string;
   dtype: string;
+  deviceName: string;
   lBranchAndCommit: BranchAndCommit;
   rBranchAndCommit: BranchAndCommit;
 }) {
@@ -134,7 +137,10 @@ function Report({
               ? rData[0].granularity_bucket
               : undefined,
         }}
-        workflowName={"inductor-a100-perf-nightly"}
+        workflowName={
+          DISPLAY_NAMES_TO_WORKFLOW_NAMES[deviceName] ??
+          "inductor-a100-perf-nightly"
+        }
       >
         <BenchmarkLogs workflowId={lData[0].workflow_id} />
       </CommitPanel>
@@ -145,6 +151,7 @@ function Report({
         granularity={granularity}
         mode={mode}
         dtype={dtype}
+        deviceName={deviceName}
         lPerfData={{
           ...lBranchAndCommit,
           data: lData,
@@ -295,7 +302,7 @@ export default function Page() {
     {
       name: "device",
       type: "string",
-      value: deviceName,
+      value: DISPLAY_NAMES_TO_DEVICE_NAMES[deviceName],
     },
   ];
 
@@ -340,7 +347,7 @@ export default function Page() {
         <DTypePicker
           dtype={deviceName}
           setDType={setDeviceName}
-          dtypes={DEVICES}
+          dtypes={Object.keys(DISPLAY_NAMES_TO_DEVICE_NAMES)}
           label={"Device"}
         />
         <BranchAndCommitPicker
@@ -380,6 +387,7 @@ export default function Page() {
         suite={suite}
         mode={mode}
         dtype={dtype}
+        deviceName={deviceName}
         lBranchAndCommit={{ branch: lBranch, commit: lCommit }}
         rBranchAndCommit={{ branch: rBranch, commit: rCommit }}
       />

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -7,7 +7,11 @@ import {
   MAIN_BRANCH,
 } from "components/benchmark/common";
 import { BenchmarkLogs } from "components/benchmark/compilers/BenchmarkLogs";
-import { DTYPES } from "components/benchmark/compilers/common";
+import {
+  DEFAULT_DEVICE_NAME,
+  DEVICES,
+  DTYPES,
+} from "components/benchmark/compilers/common";
 import {
   SuitePicker,
   SUITES,
@@ -182,6 +186,7 @@ export default function Page() {
   const [rBranch, setRBranch] = useState<string>(MAIN_BRANCH);
   const [rCommit, setRCommit] = useState<string>("");
   const [baseUrl, setBaseUrl] = useState<string>("");
+  const [deviceName, setDeviceName] = useState<string>(DEFAULT_DEVICE_NAME);
 
   // Set the dropdown value what is in the param
   useEffect(() => {
@@ -222,6 +227,11 @@ export default function Page() {
     const dtype: string = (router.query.dtype as string) ?? undefined;
     if (dtype !== undefined) {
       setDType(dtype);
+    }
+
+    const deviceName: string = (router.query.deviceName as string) ?? undefined;
+    if (deviceName !== undefined) {
+      setDeviceName(deviceName);
     }
 
     const lBranch: string = (router.query.lBranch as string) ?? undefined;
@@ -282,6 +292,11 @@ export default function Page() {
       type: "string",
       value: dtype,
     },
+    {
+      name: "device",
+      type: "string",
+      value: deviceName,
+    },
   ];
 
   return (
@@ -295,7 +310,9 @@ export default function Page() {
             startTime.toString()
           )}&stopTime=${encodeURIComponent(
             stopTime.toString()
-          )}&granularity=${granularity}&suite=${suite}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`}
+          )}&granularity=${granularity}&suite=${suite}&mode=${mode}&dtype=${dtype}&deviceName=${encodeURIComponent(
+            deviceName
+          )}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`}
         />
       </Stack>
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
@@ -319,6 +336,12 @@ export default function Page() {
           setDType={setDType}
           dtypes={DTYPES}
           label={"Precision"}
+        />
+        <DTypePicker
+          dtype={deviceName}
+          setDType={setDeviceName}
+          dtypes={DEVICES}
+          label={"Device"}
         />
         <BranchAndCommitPicker
           queryName={"compilers_benchmark_performance_branches"}

--- a/torchci/pages/benchmark/torchao.tsx
+++ b/torchci/pages/benchmark/torchao.tsx
@@ -11,8 +11,10 @@ import {
   MODES,
 } from "components/benchmark/ModeAndDTypePicker";
 import {
+  DEFAULT_DEVICE_NAME,
   DEFAULT_MODE,
   DEFAULT_REPO_NAME,
+  DISPLAY_NAMES_TO_DEVICE_NAMES,
   DTYPES,
 } from "components/benchmark/torchao/common";
 import { SuitePicker, SUITES } from "components/benchmark/torchao/SuitePicker";
@@ -37,6 +39,7 @@ function Report({
   suite,
   mode,
   dtype,
+  deviceName,
   lBranchAndCommit,
   rBranchAndCommit,
 }: {
@@ -47,6 +50,7 @@ function Report({
   suite: string;
   mode: string;
   dtype: string;
+  deviceName: string;
   lBranchAndCommit: BranchAndCommit;
   rBranchAndCommit: BranchAndCommit;
 }) {
@@ -137,6 +141,7 @@ function Report({
         granularity={granularity}
         mode={mode}
         dtype={dtype}
+        deviceName={deviceName}
         lPerfData={{
           ...lBranchAndCommit,
           data: lData,
@@ -178,6 +183,7 @@ export default function Page() {
   const [rBranch, setRBranch] = useState<string>(MAIN_BRANCH);
   const [rCommit, setRCommit] = useState<string>("");
   const [baseUrl, setBaseUrl] = useState<string>("");
+  const [deviceName, setDeviceName] = useState<string>(DEFAULT_DEVICE_NAME);
 
   // Set the dropdown value what is in the param
   useEffect(() => {
@@ -218,6 +224,11 @@ export default function Page() {
     const dtype: string = (router.query.dtype as string) ?? undefined;
     if (dtype !== undefined) {
       setDType(dtype);
+    }
+
+    const deviceName: string = (router.query.deviceName as string) ?? undefined;
+    if (deviceName !== undefined) {
+      setDeviceName(deviceName);
     }
 
     const lBranch: string = (router.query.lBranch as string) ?? undefined;
@@ -278,6 +289,11 @@ export default function Page() {
       type: "string",
       value: dtype,
     },
+    {
+      name: "device",
+      type: "string",
+      value: DISPLAY_NAMES_TO_DEVICE_NAMES[deviceName],
+    },
   ];
 
   return (
@@ -291,7 +307,9 @@ export default function Page() {
             startTime.toString()
           )}&stopTime=${encodeURIComponent(
             stopTime.toString()
-          )}&granularity=${granularity}&suite=${suite}&mode=${mode}&dtype=${dtype}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`}
+          )}&granularity=${granularity}&suite=${suite}&mode=${mode}&dtype=${dtype}&deviceName=${encodeURIComponent(
+            deviceName
+          )}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}`}
         />
       </Stack>
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
@@ -315,6 +333,12 @@ export default function Page() {
           setDType={setDType}
           dtypes={DTYPES}
           label={"Precision"}
+        />
+        <DTypePicker
+          dtype={deviceName}
+          setDType={setDeviceName}
+          dtypes={Object.keys(DISPLAY_NAMES_TO_DEVICE_NAMES)}
+          label={"Device"}
         />
         <BranchAndCommitPicker
           queryName={"torchao_query_branches"}
@@ -353,6 +377,7 @@ export default function Page() {
         suite={suite}
         mode={mode}
         dtype={dtype}
+        deviceName={deviceName}
         lBranchAndCommit={{ branch: lBranch, commit: lCommit }}
         rBranchAndCommit={{ branch: rBranch, commit: rCommit }}
       />


### PR DESCRIPTION
After https://github.com/pytorch/pytorch/pull/131369 lands, we will need this change to surface the the benchmark results from `cpu-x86` device.  This is one of the parameter that I didn't surface before on the dashboard because there is only one device `cuda`.

# Testing

Selecting `cpu-x86` would show nothing now, but we can wait for https://github.com/pytorch/pytorch/pull/131369 to land and run a few more days to test the UX before landing this change.

https://torchci-git-fork-huydhn-add-cpu-device-pt2-96f356-fbopensource.vercel.app/benchmark/compilers