### PR TITLE
Fix linux.arm64 GPU validations

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -252,14 +252,14 @@ jobs:
         uses: ./test-infra/.github/actions/chown-directory
         with:
           directory: ${{ github.workspace }}/${{ env.repository }}
-          ALPINE_IMAGE: ${{ inputs.runner == 'linux.arm64.2xlarge' && 'arm64v8/alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
+          ALPINE_IMAGE: ${{ startsWith(inputs.runner, 'linux.arm64') && 'arm64v8/alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
 
       - name: Chown runner temp
         if: always()
         uses: ./test-infra/.github/actions/chown-directory
         with:
           directory: ${{ runner.temp }}
-          ALPINE_IMAGE: ${{ inputs.runner == 'linux.arm64.2xlarge' && 'arm64v8/alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
+          ALPINE_IMAGE: ${{ startsWith(inputs.runner, 'linux.arm64') && 'arm64v8/alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
 
       - name: Prepare artifacts for upload
         if: always()


### PR DESCRIPTION
This is currently failing: https://github.com/pytorch/builder/actions/runs/10062669199/job/27817964549
Since we use:
``linux.arm64.m7g.4xlarge``
instead of 
``linux.arm64.2xlarge``