### PR TITLE
Small improvements designed to increase the resiliency of ephemeral instances

### DIFF
--- a/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
@@ -217,7 +217,7 @@ fallback_to_node16
 ${arm_patch}
 
 echo wait for configuration
-RETRY_LEFT=600
+RETRY_LEFT=1200  # 20 minutes
 while [[ $(aws ssm get-parameters --names ${environment}-$INSTANCE_ID --with-decryption --region $REGION | jq -r ".Parameters | .[0] | .Value") == null ]]; do
     echo Waiting for configuration ...
     sleep 1

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/config.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/config.test.ts
@@ -189,7 +189,7 @@ describe('Config', () => {
     expect(Config.Instance.launchTemplateVersionLinuxNvidia).toBe('LAUNCH_TEMPLATE_VERSION_LINUX_NVIDIA');
     expect(Config.Instance.launchTemplateVersionWindows).toBe('LAUNCH_TEMPLATE_VERSION_WINDOWS');
     expect(Config.Instance.minAvailableRunners).toBe(10);
-    expect(Config.Instance.minimumRunningTimeInMinutes).toBe(10);
+    expect(Config.Instance.minimumRunningTimeInMinutes).toBe(60);
     expect(Config.Instance.mustHaveIssuesLabels).toEqual([]);
     expect(Config.Instance.runnerGroupName).toBeUndefined();
     expect(Config.Instance.runnersExtraLabels).toBeUndefined();

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/config.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/config.ts
@@ -78,7 +78,7 @@ export class Config {
     /* istanbul ignore next */
     this.minAvailableRunners = mnAvalRuns > 0 ? mnAvalRuns : 1;
     /* istanbul ignore next */
-    const mnRunMin = Number(process.env.MINIMUM_RUNNING_TIME_IN_MINUTES || '10');
+    const mnRunMin = Number(process.env.MINIMUM_RUNNING_TIME_IN_MINUTES || '60');
     /* istanbul ignore next */
     this.minimumRunningTimeInMinutes = mnRunMin > 0 ? mnRunMin : 1;
     /* istanbul ignore next */

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -240,8 +240,8 @@ async function allRunnersBusy(
     console.info(`Available (${availableCount}) runners is bellow minimum ${Config.Instance.minAvailableRunners}`);
     // It is impossible to accumulate runners if we know that the one we're creating will be terminated.
     if (isEphemeral) {
-      const ratio: number = availableCount / (Config.Instance.minAvailableRunners * 1.3);
-      return Math.random() < ratio ? 2 : 1;
+      const ratio: number = availableCount / (Config.Instance.minAvailableRunners * 1.5);
+      return Math.random() < ratio ? 3 : 1;
     } else {
       return 1;
     }


### PR DESCRIPTION
1 - increase the time out for instances to be cleaned up if not used from 10 to 60 minutes
2 - increase the timeout to give up if user-data fails from 10 to 20 minutes
3 - Deploy a higher percentage of instances when they are ephemeral.  From up to ~30% minAvailable to ~50% 