### PR TITLE
[HUD] Do not rerender (?) on switching tabs

### DIFF
--- a/torchci/components/CommitStatus.tsx
+++ b/torchci/components/CommitStatus.tsx
@@ -116,9 +116,6 @@ export default function CommitStatus({
   isCommitPage: boolean;
   unstableIssues: IssueData[];
 }) {
-  const session = useSession();
-  const isAuthenticated = session.status === "authenticated";
-
   // Populate the repo field if it's not yet set in the job data
   jobs.forEach((job) => {
     job.repo = job.repo ?? `${repoOwner}/${repoName}`;
@@ -174,13 +171,12 @@ export default function CommitStatus({
         unstableIssues={unstableIssues}
         repoFullName={`${repoOwner}/${repoName}`}
       />
-      {isAuthenticated && isCommitPage && (
+      {isCommitPage && (
         <WorkflowDispatcher
           repoOwner={repoOwner}
           repoName={repoName}
           commit={commit}
           jobs={jobs}
-          session={session.data}
         />
       )}
     </>

--- a/torchci/components/WorkflowDispatcher.tsx
+++ b/torchci/components/WorkflowDispatcher.tsx
@@ -102,18 +102,18 @@ export default function WorkflowDispatcher({
   repoName,
   commit,
   jobs,
-  session,
 }: {
   repoOwner: string;
   repoName: string;
   commit: CommitData;
   jobs: JobData[];
-  session: any;
 }) {
+  const session = useSession();
   if (
     session === undefined ||
-    session["accessToken"] === undefined ||
-    session["user"] == undefined
+    session.data === null ||
+    session.data["accessToken"] === undefined ||
+    session.data["user"] == undefined
   ) {
     return <></>;
   }
@@ -124,7 +124,7 @@ export default function WorkflowDispatcher({
   }
 
   const supportedWorkflows = SUPPORTED_WORKFLOWS[repo];
-  const accessToken = session["accessToken"];
+  const accessToken = session.data["accessToken"];
 
   return (
     <div>


### PR DESCRIPTION
Move the `useSession` call from in the `CommitStatus` component to when it is actually used (in the workflow dispatcher)

