### PR TITLE
Add cuda (a10g) device to TorchInductor dashboard

### DIFF
--- a/torchci/components/benchmark/compilers/common.tsx
+++ b/torchci/components/benchmark/compilers/common.tsx
@@ -58,11 +58,13 @@ export const DEFAULT_DEVICE_NAME = "cuda (a100)";
 // the LLM micro-benchmark page is implemented
 export const DISPLAY_NAMES_TO_DEVICE_NAMES: { [k: string]: string } = {
   "cuda (a100)": "cuda",
+  "cuda (a10g)": "cuda_a10g",
   "cpu (x86)": "cpu_x86",
   "cpu (aarch64)": "cpu_aarch64",
 };
 export const DISPLAY_NAMES_TO_WORKFLOW_NAMES: { [k: string]: string } = {
   "cuda (a100)": "inductor-A100-perf-nightly",
+  "cuda (a10g)": "inductor-perf-nightly-A10g",
   "cpu (x86)": "inductor-perf-nightly-x86",
   "cpu (aarch64)": "inductor-perf-nightly-aarch64",
 };


### PR DESCRIPTION
The corresponding UX update to show cuda (a10g) device after https://github.com/pytorch/pytorch/pull/131816

### Testing

https://torchci-git-fork-huydhn-perf-dashboard-add-30bec4-fbopensource.vercel.app/benchmark/compilers