### PR TITLE
Increase max runners available for m4.10xlarge

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -31,7 +31,7 @@ runner_types:
     disk_size: 200
     instance_type: m4.10xlarge
     is_ephemeral: false
-    max_available: 60
+    max_available: 450
     os: linux
   linux.24xl.spr-metal:
     disk_size: 200


### PR DESCRIPTION
We can estimate the maximum number of m4.10xlarge runners based on the max runner number for linux.16xlarge.spr. 

Per our statistic, in one round of CI inductor test, dynamo suites freezing accuracy test and inductor UT test run on m4.10xlarge, they cost ~9h. dynamo suites freezing accuracy test also runs on linux.16xlarge.spr, it cost ~3h. 

Based on the time cost ratio (9/3) and the max runner number for linux.16xlarge.spr (150), 450 should be enough for the maximum number of m4.10xlarge.