### PR TITLE
Differentiate between cuda (a100) and cuda (a10g) commits on perf dashboard

### DIFF
--- a/torchci/rockset/inductor/__sql/compilers_benchmark_performance.sql
+++ b/torchci/rockset/inductor/__sql/compilers_benchmark_performance.sql
@@ -21,10 +21,9 @@ WITH performance_results AS (
   FROM
     inductor.torch_dynamo_perf_stats_v2
   WHERE
-    filename LIKE '%_performance'
-    AND filename LIKE CONCAT(
+    filename LIKE CONCAT(
       '%_', : dtypes, '_', : mode, '_', : device,
-      '_%'
+      '_performance%'
     )
     AND TIMESTAMP_MILLIS(timestamp) >= PARSE_DATETIME_ISO8601(:startTime)
     AND TIMESTAMP_MILLIS(timestamp) < PARSE_DATETIME_ISO8601(:stopTime)
@@ -46,10 +45,9 @@ accuracy_results AS (
   FROM
     inductor.torch_dynamo_perf_stats_v2
   WHERE
-    filename LIKE '%_accuracy'
-    AND filename LIKE CONCAT(
+    filename LIKE CONCAT(
       '%_', : dtypes, '_', : mode, '_', : device,
-      '_%'
+      '_accuracy%'
     )
     AND TIMESTAMP_MILLIS(timestamp) >= PARSE_DATETIME_ISO8601(:startTime)
     AND TIMESTAMP_MILLIS(timestamp) < PARSE_DATETIME_ISO8601(:stopTime)

--- a/torchci/rockset/inductor/__sql/compilers_benchmark_performance_branches.sql
+++ b/torchci/rockset/inductor/__sql/compilers_benchmark_performance_branches.sql
@@ -13,10 +13,9 @@ FROM
 WHERE
   TIMESTAMP_MILLIS(p.timestamp) >= PARSE_DATETIME_ISO8601(: startTime)
   AND TIMESTAMP_MILLIS(p.timestamp) < PARSE_DATETIME_ISO8601(: stopTime)
-  AND p.filename LIKE '%_performance'
   AND p.filename LIKE CONCAT(
     '%_', : dtypes, '_', : mode, '_', : device,
-    '_%'
+    '_performance%'
   )
 ORDER BY
   w.head_branch,

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -82,8 +82,8 @@
     "queue_times_historical_pct": "f815ad1732928bb6"
   },
   "inductor": {
-    "compilers_benchmark_performance": "948afbaf5797a1eb",
-    "compilers_benchmark_performance_branches": "7523024a30c6b32f",
+    "compilers_benchmark_performance": "442c41fbbc0eb758",
+    "compilers_benchmark_performance_branches": "a07ce298be770d63",
     "torchao_query": "89dd8524b4784c7b",
     "torchao_query_branches": "dae2141eab66e839"
   },


### PR DESCRIPTION
Fixes https://github.com/pytorch/test-infra/issues/5520

cuda (a100) uses the original cuda device name while cuda (a10g) uses `cuda_a10g` as its device name. The issue here is that both of them has `cuda` prefix, so the current query for cuda (a100) would wrongly fetch the result for both.  The error observed by the dashboard users is a blank page when the selected device is cuda (a100) and the selected commit is cuda (a10g), a mismatch.

Selecting other devices, cuda (a10g) or cpu (x86), is working fine because their names are unambiguous.

### Testing

* cuda (a100) https://torchci-git-fork-huydhn-fix-wrong-commits-s-4891ea-fbopensource.vercel.app/benchmark/compilers
* cuda (a10g) https://torchci-git-fork-huydhn-fix-wrong-commits-s-4891ea-fbopensource.vercel.app/benchmark/compilers?dashboard=torchinductor&startTime=Tue%2C%2023%20Jul%202024%2020%3A29%3A42%20GMT&stopTime=Tue%2C%2030%20Jul%202024%2020%3A29%3A42%20GMT&granularity=hour&suite=torchbench&mode=inference&dtype=bfloat16&deviceName=cuda%20(a10g)&lBranch=main&lCommit=54d4f6bbcac985e587e51d43d9bfb3d7e116a7cf&rBranch=main&rCommit=9440a4824dee84ddbdd56437e4f022bbbe0eaa6f
* cpu (x86) https://torchci-git-fork-huydhn-fix-wrong-commits-s-4891ea-fbopensource.vercel.app/benchmark/compilers?dashboard=torchinductor&startTime=Tue%2C%2023%20Jul%202024%2020%3A29%3A42%20GMT&stopTime=Tue%2C%2030%20Jul%202024%2020%3A29%3A42%20GMT&granularity=hour&suite=torchbench&mode=inference&dtype=bfloat16&deviceName=cpu%20(x86)&lBranch=main&lCommit=54d4f6bbcac985e587e51d43d9bfb3d7e116a7cf&rBranch=main&rCommit=8aff6caf67472ea0281a75eae40b89d9c433c63b