### PR TITLE
Apply $CONDA_ENV fix for smoke tests

### DIFF
--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -156,6 +156,13 @@ jobs:
         with:
           repository: ${{ inputs.repository  }}
           script: ${{ inputs.post-script }}
+      # NB: Upload GitHub. In case we need to debug the build
+      - name: Upload artifact to GitHub
+        continue-on-error: true
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ inputs.repository }}/distr/
       - name: Smoke Test
         env:
           PACKAGE_NAME: ${{ inputs.package-name }}
@@ -168,6 +175,13 @@ jobs:
           # shellcheck disable=SC1090
           source "${BUILD_ENV_FILE}"
           CONDA_LOCAL_CHANNEL="file://$(readlink -f ${{ inputs.repository }}/distr)"
+
+          # Please note these are required changes to make sure our conda environment take precedence before
+          # any other environments https://github.com/conda-incubator/setup-miniconda#conda-incubatorsetup-miniconda
+          # such as test environment created by default.
+          export PATH=$CONDA_ENV/bin:$CONDA_ENV:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH
+          export Python3_ROOT_DIR=${CONDA_ENV}
+          export Python3_EXECUTABLE="${CONDA_ENV}"
 
           export CONDA_ENV_SMOKE="${RUNNER_TEMP}/pytorch_pkg_helpers_${GITHUB_RUN_ID}_smoke"
           conda create --yes --quiet --prefix "${CONDA_ENV_SMOKE}" python="${PYTHON_VERSION}"
@@ -211,13 +225,6 @@ jobs:
             ${CONDA_RUN_SMOKE} python "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT}"
           fi
           conda env remove -p "${CONDA_ENV_SMOKE}"
-      # NB: Only upload to GitHub after passing smoke tests
-      - name: Upload artifact to GitHub
-        continue-on-error: true
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: ${{ inputs.repository }}/distr/
 
   upload:
     needs: build

--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -218,7 +218,7 @@ jobs:
             ${CONDA_RUN_SMOKE} python "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT}"
           fi
           conda env remove -p "${CONDA_ENV_SMOKE}"
-      # NB: Upload GitHub. In case we need to debug the build
+      # NB: Only upload to GitHub after passing smoke tests
       - name: Upload artifact to GitHub
         continue-on-error: true
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -156,13 +156,6 @@ jobs:
         with:
           repository: ${{ inputs.repository  }}
           script: ${{ inputs.post-script }}
-      # NB: Upload GitHub. In case we need to debug the build
-      - name: Upload artifact to GitHub
-        continue-on-error: true
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: ${{ inputs.repository }}/distr/
       - name: Smoke Test
         env:
           PACKAGE_NAME: ${{ inputs.package-name }}
@@ -225,6 +218,13 @@ jobs:
             ${CONDA_RUN_SMOKE} python "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT}"
           fi
           conda env remove -p "${CONDA_ENV_SMOKE}"
+      # NB: Upload GitHub. In case we need to debug the build
+      - name: Upload artifact to GitHub
+        continue-on-error: true
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ inputs.repository }}/distr/
 
   upload:
     needs: build


### PR DESCRIPTION
Same fix already applied in conda-build step above: https://github.com/pytorch/test-infra/pull/5527/files#diff-a830234c1ab7788cbd304fa713940ab2393c8da8f7338ff31c0c08c86d9900aeR140

Fixes issue with conda picking up default test env created by:
https://github.com/conda-incubator/setup-miniconda#conda-incubatorsetup-miniconda

Test PR:  https://github.com/pytorch/vision/pull/8562

Failure running conda info before install (2 yrs old conda version 4.12):
```
+ export 'CONDA_RUN_SMOKE=conda run -p /__w/_temp/pytorch_pkg_helpers_10168573792_smoke'
+ CONDA_RUN_SMOKE='conda run -p /__w/_temp/pytorch_pkg_helpers_10168573792_smoke'
+ [[ cpu = \c\u\d\a ]]
+ CONSTRAINTS=cpuonly
+ CONSTRAINT_BUILD=
+ [[ nightly = \t\e\s\t ]]
+ conda run -p /__w/_temp/pytorch_pkg_helpers_10168573792_smoke conda info

     active environment : /__w/_temp/pytorch_pkg_helpers_10168573792_smoke
    active env location : /__w/_temp/pytorch_pkg_helpers_10168573792_smoke
            shell level : 2
       user config file : /github/home/.condarc
 populated config files : /github/home/.condarc
          conda version : 4.12.0
    conda-build version : not installed
         python version : 3.9.12.final.0
       virtual packages : __linux=4.14.336=0
                          __glibc=2.17=0
                          __unix=0=0
                          __archspec=1=x86_64
       base environment : /__w/vision/vision/3  (writable)
      conda av data dir : /__w/vision/vision/3/etc/conda
  conda av metadata url : None
           channel URLs : https://repo.anaconda.com/pkgs/main/linux-64
                          https://repo.anaconda.com/pkgs/main/noarch
                          https://repo.anaconda.com/pkgs/r/linux-64
                          https://repo.anaconda.com/pkgs/r/noarch
          package cache : /github/home/conda_pkgs_dir
       envs directories : /__w/vision/vision/3/envs
                          /github/home/.conda/envs
               platform : linux-64
             user-agent : conda/4.12.0 requests/2.27.1 CPython/3.9.12 Linux/4.14.336-257.562.amzn2.x86_64 centos/7.9.[200](https://github.com/pytorch/vision/actions/runs/10168573792/job/28127797690?pr=8562#step:14:201)9 glibc/2.17
                UID:GID : 0:0
             netrc file : None
           offline mode : False
```
Fail run: https://github.com/pytorch/vision/actions/runs/10168573792/job/28127797690?pr=8562

Success:
```
Executing transaction: ...working... done
+ export 'CONDA_RUN_SMOKE=conda run -p /__w/_temp/pytorch_pkg_helpers_10168573792_smoke'
+ CONDA_RUN_SMOKE='conda run -p /__w/_temp/pytorch_pkg_helpers_10168573792_smoke'
+ [[ cpu = \c\u\d\a ]]
+ CONSTRAINTS=cpuonly
+ CONSTRAINT_BUILD=
+ [[ nightly = \t\e\s\t ]]
+ conda run -p /__w/_temp/pytorch_pkg_helpers_10168573792_smoke conda info

     active environment : /__w/_temp/pytorch_pkg_helpers_10168573792_smoke
    active env location : /__w/_temp/pytorch_pkg_helpers_10168573792_smoke
            shell level : 2
       user config file : /github/home/.condarc
 populated config files : /github/home/.condarc
          conda version : 24.4.0
    conda-build version : 24.3.0
         python version : 3.9.19.final.0
                 solver : libmamba (default)
       virtual packages : __archspec=1=skylake_avx512
                          __conda=24.4.0=0
                          __glibc=2.17=0
                          __linux=4.14.336=0
                          __unix=0=0
       base environment : /__w/_temp/conda_environment_10168573792  (writable)
      conda av data dir : /__w/_temp/conda_environment_10168573792/etc/conda
  conda av metadata url : None
           channel URLs : https://repo.anaconda.com/pkgs/main/linux-64
                          https://repo.anaconda.com/pkgs/main/noarch
                          https://repo.anaconda.com/pkgs/r/linux-64
                          https://repo.anaconda.com/pkgs/r/noarch
          package cache : /github/home/conda_pkgs_dir
       envs directories : /__w/_temp/conda_environment_10168573792/envs
                          /github/home/.conda/envs
               platform : linux-64
             user-agent : conda/24.4.0 requests/2.32.3 CPython/3.9.19 Linux/4.14.336-257.562.amzn2.x86_64 centos/7.9.2009 glibc/2.17 solver/libmamba conda-libmamba-solver/24.7.0 libmambapy/1.5.8
                UID:GID : 0:0
             netrc file : None
           offline mode : False
```
Success run: https://github.com/pytorch/vision/actions/runs/10168573792/job/28128479597?pr=8562