### PR TITLE
Introduce runner variants to help test changes

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.test.ts
@@ -669,7 +669,20 @@ runner_types:
       os: linux
       max_available: 1
       disk_size: 150
-      is_ephemeral: false`;
+      is_ephemeral: false
+    linux.4xlarge:
+      instance_type: c5.2xlarge
+      os: linux
+      max_available: 1
+      disk_size: 150
+      is_ephemeral: false
+      variants:
+        ephemeral:
+          is_ephemeral: true
+        large_disk:
+          disk_size: 300
+        amzn23:
+          ami: ami-123`;
 
   it('gets the contents, twice', async () => {
     const repo = { owner: 'owner', repo: 'repo' };
@@ -710,6 +723,18 @@ runner_types:
             is_ephemeral: false,
           },
         ],
+        [
+          'linux.4xlarge',
+          {
+            runnerTypeName: 'linux.4xlarge',
+            instance_type: 'c5.2xlarge',
+            os: 'linux',
+            max_available: 1,
+            disk_size: 150,
+            is_ephemeral: false,
+          },
+        ],
+
       ]),
     );
     expect(await getRunnerTypes(repo, metrics)).toEqual(

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.test.ts
@@ -679,10 +679,69 @@ runner_types:
       variants:
         ephemeral:
           is_ephemeral: true
-        large_disk:
+        largedisk:
           disk_size: 300
-        amzn23:
+        ami123:
           ami: ami-123`;
+
+  const getRunnerTypeResponse = new Map([
+    [
+      'linux.2xlarge',
+      {
+        runnerTypeName: 'linux.2xlarge',
+        instance_type: 'c5.2xlarge',
+        os: 'linux',
+        max_available: 1,
+        disk_size: 150,
+        is_ephemeral: false,
+      },
+    ],
+    [
+      'linux.4xlarge',
+      {
+        runnerTypeName: 'linux.4xlarge',
+        instance_type: 'c5.2xlarge',
+        os: 'linux',
+        max_available: 1,
+        disk_size: 150,
+        is_ephemeral: false,
+      },
+    ],
+    [
+      'ephemeral.linux.4xlarge',
+      {
+        runnerTypeName: 'ephemeral.linux.4xlarge',
+        instance_type: 'c5.2xlarge',
+        os: 'linux',
+        max_available: 1,
+        disk_size: 150,
+        is_ephemeral: true,
+      },
+    ],
+    [
+      'largedisk.linux.4xlarge',
+      {
+        runnerTypeName: 'largedisk.linux.4xlarge',
+        instance_type: 'c5.2xlarge',
+        os: 'linux',
+        max_available: 1,
+        disk_size: 300,
+        is_ephemeral: false,
+      },
+    ],
+    [
+      'ami123.linux.4xlarge',
+      {
+        runnerTypeName: 'ami123.linux.4xlarge',
+        instance_type: 'c5.2xlarge',
+        os: 'linux',
+        max_available: 1,
+        disk_size: 150,
+        is_ephemeral: false,
+        ami: 'ami-123',
+      },
+    ],
+  ]);
 
   it('gets the contents, twice', async () => {
     const repo = { owner: 'owner', repo: 'repo' };
@@ -710,48 +769,8 @@ runner_types:
     mockCreateOctoClient.mockReturnValueOnce(mockedOctokit as unknown as Octokit);
 
     await resetGHRunnersCaches();
-    expect(await getRunnerTypes(repo, metrics)).toEqual(
-      new Map([
-        [
-          'linux.2xlarge',
-          {
-            runnerTypeName: 'linux.2xlarge',
-            instance_type: 'c5.2xlarge',
-            os: 'linux',
-            max_available: 1,
-            disk_size: 150,
-            is_ephemeral: false,
-          },
-        ],
-        [
-          'linux.4xlarge',
-          {
-            runnerTypeName: 'linux.4xlarge',
-            instance_type: 'c5.2xlarge',
-            os: 'linux',
-            max_available: 1,
-            disk_size: 150,
-            is_ephemeral: false,
-          },
-        ],
-
-      ]),
-    );
-    expect(await getRunnerTypes(repo, metrics)).toEqual(
-      new Map([
-        [
-          'linux.2xlarge',
-          {
-            runnerTypeName: 'linux.2xlarge',
-            instance_type: 'c5.2xlarge',
-            os: 'linux',
-            max_available: 1,
-            disk_size: 150,
-            is_ephemeral: false,
-          },
-        ],
-      ]),
-    );
+    expect(await getRunnerTypes(repo, metrics)).toEqual(getRunnerTypeResponse);
+    expect(await getRunnerTypes(repo, metrics)).toEqual(getRunnerTypeResponse);
 
     expect(mockCreateGithubAuth).toBeCalledTimes(2);
     expect(mockCreateGithubAuth).toBeCalledWith(undefined, 'app', Config.Instance.ghesUrlApi, metrics);

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -48,7 +48,7 @@ export interface RunnerType extends RunnerTypeOptional {
 }
 
 export interface RunnerTypeScaleConfig extends RunnerType {
-  variants: Map<string, RunnerTypeOptional>;
+  variants?: Map<string, RunnerTypeOptional>;
 }
 
 export interface DescribeInstancesResultRegion {

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -27,16 +27,28 @@ export interface AmiExpermient {
   percentage: number;
 }
 
-export interface RunnerType {
+export interface RunnerTypeOptional {
   ami_experiment?: AmiExpermient;
   ami?: string;
+  disk_size?: number;
+  instance_type?: string;
+  is_ephemeral?: boolean;
+  labels?: Array<string>;
+  max_available?: number;
+  os?: string;
+}
+
+export interface RunnerType extends RunnerTypeOptional {
   disk_size: number;
   instance_type: string;
   is_ephemeral: boolean;
-  labels?: Array<string>;
   max_available: number;
   os: string;
   runnerTypeName: string;
+}
+
+export interface RunnerTypeScaleConfig extends RunnerType {
+  variants: Map<string, RunnerTypeOptional>;
 }
 
 export interface DescribeInstancesResultRegion {


### PR DESCRIPTION
Adds a tag called `variants` in `scale-config.yaml`, that creates a copy of the runner where it is specified on, but with a specific prefix and override any configuration that is supported.

The goal is to reduce clutter and code-duplication on scale-config when running experiments or simply creating small variants of a particular runner.

ex:

```
    linux.4xlarge:
      instance_type: c5.2xlarge
      os: linux
      max_available: 1
      disk_size: 150
      is_ephemeral: false
      variants:
        ephemeral:
          is_ephemeral: true
        ami123:
          ami: ami-123
```

this will create runners: `linux.4xlarge`, `ephemeral.linux.4xlarge` and `ami123.linux.4xlarge` with the specified configurations overridden. This is functionally equivalent to defining in the following way:

```
    linux.4xlarge:
      instance_type: c5.2xlarge
      os: linux
      max_available: 1
      disk_size: 150
      is_ephemeral: false
    ephemeral.linux.4xlarge:
      instance_type: c5.2xlarge
      os: linux
      max_available: 1
      disk_size: 150
      is_ephemeral: true
    ami123.linux.4xlarge:
      instance_type: c5.2xlarge
      os: linux
      max_available: 1
      disk_size: 150
      is_ephemeral: false
      ami: ami-123
```