### PR TITLE
[HUD][ez] Fix disable test button

### DIFF
--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -188,7 +188,7 @@ function DisableTest({ job, label }: { job: JobData; label: string }) {
 
   // At this point, we should show something. Search the existing disable issues
   // for a matching one.
-  const issueTitle = `DISABLED ${testName}`;
+  const issueTitle = `DISABLED ${testName.testName} (__main__.${testName.suite})`;
   const issueBody = formatDisableTestBody(job);
 
   const issues: IssueData[] = data.issues;


### PR DESCRIPTION
Missed this in #5510

Old: makes an issue titled DISABLE [object Object]
New: makes an issue titled DISABLED test_correct_module_names (__main__.TestPublicBindings)