### PR TITLE
[TD] Update test file ratings: error handling for pulling shas

### DIFF
--- a/tools/torchci/td/get_merge_base_info.py
+++ b/tools/torchci/td/get_merge_base_info.py
@@ -120,18 +120,18 @@ if __name__ == "__main__":
     )
     for i in range(0, len(failed_test_shas), interval):
         pull_shas(failed_test_shas[i : i + interval])
-        # upload_merge_base_info(failed_test_shas[i : i + interval])
+        upload_merge_base_info(failed_test_shas[i : i + interval])
 
-    # interval = 500
-    # main_branch_shas = list_past_year_shas()
-    # print(f"There are {len(main_branch_shas)} shas, uploading in batches of {interval}")
-    # for i in range(0, len(main_branch_shas), interval):
-    #     shas = [
-    #         x["head_sha"]
-    #         for x in query_rockset(
-    #             NOT_IN_MERGE_BASES_TABLE,
-    #             {"shas": ",".join(main_branch_shas[i : i + interval])},
-    #         )
-    #     ]
-    #     upload_merge_base_info(shas)
-    #     print(f"{i} to {i + interval} done")
+    interval = 500
+    main_branch_shas = list_past_year_shas()
+    print(f"There are {len(main_branch_shas)} shas, uploading in batches of {interval}")
+    for i in range(0, len(main_branch_shas), interval):
+        shas = [
+            x["head_sha"]
+            for x in query_rockset(
+                NOT_IN_MERGE_BASES_TABLE,
+                {"shas": ",".join(main_branch_shas[i : i + interval])},
+            )
+        ]
+        upload_merge_base_info(shas)
+        print(f"{i} to {i + interval} done")

--- a/tools/torchci/td/get_merge_base_info.py
+++ b/tools/torchci/td/get_merge_base_info.py
@@ -111,8 +111,11 @@ if __name__ == "__main__":
         f"There are {len(failed_test_shas)} shas, uploading in intervals of {interval}"
     )
     for i in range(0, len(failed_test_shas), interval):
-        pull_shas(failed_test_shas[i : i + interval])
-        upload_merge_base_info(failed_test_shas[i : i + interval])
+        try:
+            pull_shas(failed_test_shas[i : i + interval])
+            upload_merge_base_info(failed_test_shas[i : i + interval])
+        except Exception as e:
+            print(e)
 
     interval = 500
     main_branch_shas = list_past_year_shas()


### PR DESCRIPTION
Example failure https://github.com/pytorch/test-infra/actions/runs/10179085213/job/28154073097

The commit 0df18019c641da816fa16d1cf3111272ae7ad756 doesn't exist anymore, even though rockset claims there were workflows run on it and it is present in the push table

Simple workaround is to add a try catch and then try to pull them individually