### PR TITLE
Allow full control on `python -m build` command

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -79,10 +79,10 @@ on:
         description: The comma-separated list of CUDA arch to be uploaded to pypi
         default: ""
         type: string
-      wheel-build-extra-args:
-        description: Extra arguments to pass to the python build wheel command
+      wheel-build-args:
+        description: Arguments to pass to the `python -m build` command
         required: false
-        default: ""
+        default: "--wheel"
         type: string
       pip-install-torch-extra-args:
         # NOTE: Why does this exist?
@@ -219,7 +219,7 @@ jobs:
           export PYTORCH_VERSION="$(${CONDA_RUN} pip show torch | grep ^Version: | sed 's/Version: *//' | sed 's/+.\+//')"
           ${CONDA_RUN} python -m pip install build
           echo "Successfully installed Python build package"
-          ${CONDA_RUN} python -m build --wheel ${{ inputs.wheel-build-extra-args }}
+          ${CONDA_RUN} python -m build ${{ inputs.wheel-build-args }}
       - name: Build the wheel (setup-py)
         if: ${{ inputs.build-platform == 'setup-py' }}
         working-directory: ${{ inputs.repository }}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -79,10 +79,10 @@ on:
         description: The comma-separated list of CUDA arch to be uploaded to pypi
         default: ""
         type: string
-      wheel-build-args:
-        description: Arguments to pass to the `python -m build` command
+      build-command:
+        description: The build command to use if build-platform is python-build-package
         required: false
-        default: "--wheel"
+        default: "python -m build --wheel"
         type: string
       pip-install-torch-extra-args:
         # NOTE: Why does this exist?
@@ -219,7 +219,7 @@ jobs:
           export PYTORCH_VERSION="$(${CONDA_RUN} pip show torch | grep ^Version: | sed 's/Version: *//' | sed 's/+.\+//')"
           ${CONDA_RUN} python -m pip install build
           echo "Successfully installed Python build package"
-          ${CONDA_RUN} python -m build ${{ inputs.wheel-build-args }}
+          ${CONDA_RUN} ${{ inputs.build-command }}
       - name: Build the wheel (setup-py)
         if: ${{ inputs.build-platform == 'setup-py' }}
         working-directory: ${{ inputs.repository }}


### PR DESCRIPTION
This PR allows users to override the `python -m build` command when building linux wheels.

I need this for torchcodec for 2 reasons.

1.  We want the build command to be:

```
python -m build
```

instead of the currently hardcoded:

```
python -m build --wheel
```

From the `build` docs, the default behavior is to *not* pass `--wheel`, so that the wheel is built *from* the sdist. This is slightly safer as it ensures that a sdist can indeed be built.


2. We want to pass an environment variable, i.e. we want to write


```
SOME_ENV_VAR=123 python -m build ...
```

I realize this can be done with `env-var-script`. But using `env_var_script` leads to a decentralized build command, and it's more difficult to really understand what command is being used for building. It would be simpler and easier to grasp if we could write the whole command as a one-liner like above.