### PR TITLE
Uses variants on scale-config and update validate_scale_config to be fully compliant with autoscaler

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -61,7 +61,7 @@ runner_types:
     disk_size: 200
     instance_type: c5.9xlarge
     is_ephemeral: true
-    max_available: 20
+    max_available: 50
     os: linux
     variants:
       amz2023:
@@ -178,7 +178,7 @@ runner_types:
     disk_size: 150
     instance_type: g6.4xlarge
     is_ephemeral: false
-    max_available: 30
+    max_available: 50
     os: linux
     variants:
       amz2023:

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -200,7 +200,7 @@ runner_types:
     os: linux
     variants:
       amz2023:
-        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
   linux.arm64.m7g.4xlarge:
     disk_size: 256
     instance_type: m7g.4xlarge
@@ -209,7 +209,7 @@ runner_types:
     os: linux
     variants:
       amz2023:
-        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
   linux.arm64.m7g.metal:
     disk_size: 256
     instance_type: m7g.metal
@@ -218,7 +218,7 @@ runner_types:
     os: linux
     variants:
       amz2023:
-        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
   windows.4xlarge:
     disk_size: 256
     instance_type: c5d.4xlarge

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -27,132 +27,198 @@ runner_types:
     is_ephemeral: false
     max_available: 1000
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.10xlarge.avx2:
     disk_size: 200
     instance_type: m4.10xlarge
     is_ephemeral: false
     max_available: 450
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.24xl.spr-metal:
     disk_size: 200
     instance_type: c7i.metal-24xl
     is_ephemeral: false
     max_available: 150
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.16xlarge.spr:
     disk_size: 200
     instance_type: c7i.16xlarge
     is_ephemeral: false
     max_available: 150
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.9xlarge.ephemeral:
     disk_size: 200
     instance_type: c5.9xlarge
     is_ephemeral: true
     max_available: 20
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.12xlarge.ephemeral:
     disk_size: 200
     instance_type: c5.12xlarge
     is_ephemeral: true
     max_available: 300
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.16xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g3.16xlarge
     is_ephemeral: false
     max_available: 150
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.24xlarge:
     disk_size: 150
     instance_type: c5.24xlarge
     is_ephemeral: false
     max_available: 250
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.2xlarge:
     disk_size: 150
     instance_type: c5.2xlarge
     is_ephemeral: false
     max_available: 3120
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.4xlarge:
     disk_size: 150
     instance_type: c5.4xlarge
     is_ephemeral: false
     max_available: 1000
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.4xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g3.4xlarge
     is_ephemeral: false
     max_available: 1000
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.8xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g3.8xlarge
     is_ephemeral: false
     max_available: 400
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.g4dn.12xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g4dn.12xlarge
     is_ephemeral: false
     max_available: 250
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.g4dn.metal.nvidia.gpu:
     disk_size: 150
     instance_type: g4dn.metal
     is_ephemeral: false
     max_available: 300
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.g5.48xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g5.48xlarge
     is_ephemeral: false
     max_available: 200
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.g5.12xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g5.12xlarge
     is_ephemeral: false
     max_available: 150
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.g5.4xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g5.4xlarge
     is_ephemeral: false
     max_available: 2400
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.g6.4xlarge.experimental.nvidia.gpu:
     disk_size: 150
     instance_type: g6.4xlarge
     is_ephemeral: false
     max_available: 30
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.large:
     max_available: 1200
     disk_size: 15
     instance_type: c5.large
     is_ephemeral: false
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.arm64.2xlarge:
     disk_size: 256
     instance_type: t4g.2xlarge
     is_ephemeral: false
     max_available: 200
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.arm64.m7g.4xlarge:
     disk_size: 256
     instance_type: m7g.4xlarge
     is_ephemeral: false
     max_available: 200
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.arm64.m7g.metal:
     disk_size: 256
     instance_type: m7g.metal
     is_ephemeral: false
     max_available: 100
     os: linux
+    variants:
+      amz2023:
+        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   windows.4xlarge:
     disk_size: 256
     instance_type: c5d.4xlarge
@@ -183,159 +249,3 @@ runner_types:
     is_ephemeral: false
     max_available: 250
     os: windows
-
-  ### Setup runner types to test the Amazon Linux 2023 AMI
-  amz2023.linux.12xlarge:
-    disk_size: 200
-    instance_type: c5.12xlarge
-    is_ephemeral: false
-    max_available: 1000
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-  amz2023.linux.10xlarge.avx2:
-    disk_size: 200
-    instance_type: m4.10xlarge
-    is_ephemeral: false
-    max_available: 450
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-  amz2023.linux.24xl.spr-metal:
-    disk_size: 200
-    instance_type: c7i.metal-24xl
-    is_ephemeral: false
-    max_available: 150
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-  amz2023.linux.16xlarge.spr:
-    disk_size: 200
-    instance_type: c7i.16xlarge
-    is_ephemeral: false
-    max_available: 150
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-  amz2023.linux.9xlarge.ephemeral:
-    disk_size: 200
-    instance_type: c5.9xlarge
-    is_ephemeral: true
-    max_available: 20
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-  amz2023.linux.12xlarge.ephemeral:
-    disk_size: 200
-    instance_type: c5.12xlarge
-    is_ephemeral: true
-    max_available: 300
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-  amz2023.linux.16xlarge.nvidia.gpu:
-    disk_size: 150
-    instance_type: g3.16xlarge
-    is_ephemeral: false
-    max_available: 150
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-  amz2023.linux.24xlarge:
-    disk_size: 150
-    instance_type: c5.24xlarge
-    is_ephemeral: false
-    max_available: 250
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-  amz2023.linux.2xlarge:
-    disk_size: 150
-    instance_type: c5.2xlarge
-    is_ephemeral: false
-    max_available: 3120
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-  amz2023.linux.4xlarge:
-    disk_size: 150
-    instance_type: c5.4xlarge
-    is_ephemeral: false
-    max_available: 1000
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-  amz2023.linux.4xlarge.nvidia.gpu:
-    disk_size: 150
-    instance_type: g3.4xlarge
-    is_ephemeral: false
-    max_available: 1000
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-  amz2023.linux.8xlarge.nvidia.gpu:
-    disk_size: 150
-    instance_type: g3.8xlarge
-    is_ephemeral: false
-    max_available: 400
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-  amz2023.linux.g4dn.12xlarge.nvidia.gpu:
-    disk_size: 150
-    instance_type: g4dn.12xlarge
-    is_ephemeral: false
-    max_available: 250
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-  amz2023.linux.g4dn.metal.nvidia.gpu:
-    disk_size: 150
-    instance_type: g4dn.metal
-    is_ephemeral: false
-    max_available: 300
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-  amz2023.linux.g5.48xlarge.nvidia.gpu:
-    disk_size: 150
-    instance_type: g5.48xlarge
-    is_ephemeral: false
-    max_available: 200
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-  amz2023.linux.g5.12xlarge.nvidia.gpu:
-    disk_size: 150
-    instance_type: g5.12xlarge
-    is_ephemeral: false
-    max_available: 150
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-  amz2023.linux.g5.4xlarge.nvidia.gpu:
-    disk_size: 150
-    instance_type: g5.4xlarge
-    is_ephemeral: false
-    max_available: 2400
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-  amz2023.linux.g6.4xlarge.experimental.nvidia.gpu:
-    disk_size: 150
-    instance_type: g6.4xlarge
-    is_ephemeral: false
-    max_available: 30
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-  amz2023.linux.large:
-    max_available: 1200
-    disk_size: 15
-    instance_type: c5.large
-    is_ephemeral: false
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-  amz2023.linux.arm64.2xlarge:
-    disk_size: 256
-    instance_type: t4g.2xlarge
-    is_ephemeral: false
-    max_available: 200
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
-  amz2023.linux.arm64.m7g.4xlarge:
-    disk_size: 256
-    instance_type: m7g.4xlarge
-    is_ephemeral: false
-    max_available: 200
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
-  amz2023.linux.arm64.m7g.metal:
-    disk_size: 256
-    instance_type: m7g.metal
-    is_ephemeral: false
-    max_available: 100
-    os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64

--- a/.github/scripts/validate_scale_config.py
+++ b/.github/scripts/validate_scale_config.py
@@ -1,7 +1,6 @@
 # Takes the scale-config.yml file in test-infra/.github/scale-config.yml and runs the following
 # validations against it:
-# 1. Internal validation: Ensure that every linux runner type listed has a corresponding runner type with the
-#    prefix "amz2023." that contains all the same settings except for the ami
+# 1. Internal validation: Ensure that every linux runner type listed has the corresponding Amazon 2023 variant
 # 2. External validation: Ensure that every runner type listed (linux & windows) have corresponding runner types in
 #    pytorch/pytorch's .github/lf-scale-config.yml and .github/lf-canary-scale-config.yml that have the "lf."
 #    "lf.c." prefixes added correspondingly
@@ -120,9 +119,9 @@ def runner_types_are_equivalent(
 
         elif key in {"variants", "ami_experiment"}:
             # These are dictionaries, so we need to compare them as JSON strings
-            if json.dumps(runner1_config[key], sort_keys=True) == json.dumps(runner2_config[key], sort_keys=True):
+            if json.dumps(runner1_config[key], sort_keys=True) != json.dumps(runner2_config[key], sort_keys=True):
                 print(
-                    f"Runner type {runner1_type} and {runner2_type} have different {key} "
+                    f"Runner type {runner1_type} and {runner2_type} have different '{key}' "
                     f"{runner1_config[key]} vs {runner2_config[key]}"
                 )
                 are_same = False
@@ -352,6 +351,8 @@ def main() -> None:
     if not is_config_consistent_internally(scale_config[RUNNER_TYPE_CONFIG_KEY]):
         validation_success = False
         print("scale-config.yml is not internally consistent\n")
+    else:
+        print("scale-config.yml is internally consistent\n")
 
     if generate_files:
         generate_repo_scale_config(
@@ -375,6 +376,8 @@ def main() -> None:
             f"Consistency validation failed between {scale_config_path} and {pt_lf_scale_config_path}\n"
         )
         validation_success = False
+    else:
+        print("scale-config.yml is consistent with pytorch/pytorch scale config\n")
 
     if not is_consistent_across_configs(
         scale_config[RUNNER_TYPE_CONFIG_KEY],
@@ -385,6 +388,8 @@ def main() -> None:
             f"Consistency validation failed between {scale_config_path} and {pt_lf_canary_scale_config_path}\n"
         )
         validation_success = False
+    else:
+        print("scale-config.yml is consistent with pytorch/pytorch canary scale config\n")
 
     # # Delete the temp dir, if it was created
     # if temp_dir and os.path.exists(temp_dir):
@@ -401,6 +406,8 @@ def main() -> None:
             " relevant changes, you can merge that pytorch/pytorch PR first to make this job pass."
         )
         exit(1)
+    else:
+        print("All validations successful")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/validate_scale_config.py
+++ b/.github/scripts/validate_scale_config.py
@@ -21,6 +21,7 @@ import yaml
 
 AMAZON_2023_PREFIX = "amz2023"
 AMAZON_2023_AMI_PREFIX = "al2023-ami-2023"
+MAX_AVAILABLE_MINIMUM = 50
 
 # Paths relative to their respective repositories
 SCALE_CONFIG_PATH = ".github/scale-config.yml"
@@ -140,7 +141,7 @@ def is_config_consistent_internally(runner_types: Dict[str, Dict[str, str]]) -> 
     f"""
     Ensure that for every linux runner type in the config:
 
-    1 - they match RunnerTypeScaleConfig https://github.com/pytorch/test-infra/blob/main/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts#L50
+    1 - they match RunnerTypeScaleConfig https://github.com/pytorch/test-infra/blob/f3c58fea68ec149391570d15a4d0a03bc26fbe4f/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts#L50
     2 - they have a max_available of at least 50
     3 - they have a valid {AMAZON_2023_PREFIX} variant, that overrides only the ami
     """
@@ -156,18 +157,18 @@ def is_config_consistent_internally(runner_types: Dict[str, Dict[str, str]]) -> 
             # so the next part of the code might break
             continue
 
-        # Ensure that the max_available is at least 50
-        # this is a requirement as scale-up always keeps at minimum some spare runners live, and less than 50
+        # Ensure that the max_available is at least MAX_AVAILABLE_MINIMUM
+        # this is a requirement as scale-up always keeps at minimum some spare runners live, and less than MAX_AVAILABLE_MINIMUM
         # will very easily trigger alerts of not enough runners
-        if runner_config["max_available"] < 50:
+        if runner_config["max_available"] < MAX_AVAILABLE_MINIMUM:
             print(
                 f"Runner type {runner_type} has max_available set to {runner_config['max_available']}, "
-                f"which is less than the minimum required value of 50"
+                f"which is less than the minimum required value of {MAX_AVAILABLE_MINIMUM}"
             )
             errors_found = True
 
         # Next validations are for linux runners only
-        if runner_config.get("os").lower() == "windows":
+        if runner_config.get("os").lower() != "linux":
             continue
 
         # Validations now are to guarantee that Amazon 2023 is a variant of the runner type

--- a/.github/scripts/validate_scale_config.py
+++ b/.github/scripts/validate_scale_config.py
@@ -9,13 +9,14 @@
 import argparse
 import copy
 import json
-import jsonschema
 import os
 import tempfile
 
 import urllib.request
 
 from typing import Any, cast, Dict
+
+import jsonschema
 
 import yaml
 
@@ -47,7 +48,7 @@ _RUNNER_BASE_JSCHEMA = {
         "labels": {"type": "array", "items": {"type": "string"}},
         "max_available": {"type": "number"},
         "os": {"type": "string", "enum": ["linux", "windows"]},
-    }
+    },
 }
 
 RUNNER_JSCHEMA = copy.deepcopy(_RUNNER_BASE_JSCHEMA)
@@ -58,7 +59,14 @@ RUNNER_JSCHEMA["properties"]["variants"] = {
     },
     "additionalProperties": False,
 }
-RUNNER_JSCHEMA["required"] = ["disk_size", "instance_type", "is_ephemeral", "max_available", "os"]
+RUNNER_JSCHEMA["required"] = [
+    "disk_size",
+    "instance_type",
+    "is_ephemeral",
+    "max_available",
+    "os",
+]
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Validate scale-config.yml file")
@@ -120,7 +128,9 @@ def runner_types_are_equivalent(
 
         elif key in {"variants", "ami_experiment"}:
             # These are dictionaries, so we need to compare them as JSON strings
-            if json.dumps(runner1_config[key], sort_keys=True) != json.dumps(runner2_config[key], sort_keys=True):
+            if json.dumps(runner1_config[key], sort_keys=True) != json.dumps(
+                runner2_config[key], sort_keys=True
+            ):
                 print(
                     f"Runner type {runner1_type} and {runner2_type} have different '{key}' "
                     f"{runner1_config[key]} vs {runner2_config[key]}"
@@ -390,7 +400,9 @@ def main() -> None:
         )
         validation_success = False
     else:
-        print("scale-config.yml is consistent with pytorch/pytorch canary scale config\n")
+        print(
+            "scale-config.yml is consistent with pytorch/pytorch canary scale config\n"
+        )
 
     # # Delete the temp dir, if it was created
     # if temp_dir and os.path.exists(temp_dir):

--- a/.github/workflows/scale_config_validation.yml
+++ b/.github/workflows/scale_config_validation.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          pip install pyyaml==6.0.1
+          pip install pyyaml==6.0.1 jsonschema=4.23.0
 
       - name: Validate Scale Config
         run: |

--- a/.github/workflows/scale_config_validation.yml
+++ b/.github/workflows/scale_config_validation.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          pip install pyyaml==6.0.1 jsonschema=4.23.0
+          pip install pyyaml==6.0.1 jsonschema==4.23.0
 
       - name: Validate Scale Config
         run: |


### PR DESCRIPTION
- Makes validate_scale_config to be fully compliant with all the rules of the `scale-config.yaml` configuration file;
- Adds support for runner variants on validate_scale_config;
- Replaces duplicated configuration on `scale-config.yaml` with runner variants

depends on https://github.com/pytorch/pytorch/pull/132918 && https://github.com/pytorch/test-infra/pull/5541

Test for this changes are in this PR: https://github.com/pytorch/test-infra/pull/5542