### PR TITLE
Runner variants to be aware of the lf. and lf.c. prefixes, to facilitate migrations

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.test.ts
@@ -682,7 +682,25 @@ runner_types:
         largedisk:
           disk_size: 300
         ami123:
-          ami: ami-123`;
+          ami: ami-123
+    lf.linux.4xlarge:
+      instance_type: c5.2xlarge
+      os: linux
+      max_available: 1
+      disk_size: 150
+      is_ephemeral: false
+      variants:
+        ephemeral:
+          is_ephemeral: true
+    lf.c.linux.4xlarge:
+      instance_type: c5.2xlarge
+      os: linux
+      max_available: 1
+      disk_size: 150
+      is_ephemeral: false
+      variants:
+        ephemeral:
+          is_ephemeral: true`;
 
   const getRunnerTypeResponse = new Map([
     [
@@ -739,6 +757,50 @@ runner_types:
         disk_size: 150,
         is_ephemeral: false,
         ami: 'ami-123',
+      },
+    ],
+    [
+      'lf.linux.4xlarge',
+      {
+        runnerTypeName: 'lf.linux.4xlarge',
+        instance_type: 'c5.2xlarge',
+        os: 'linux',
+        max_available: 1,
+        disk_size: 150,
+        is_ephemeral: false,
+      },
+    ],
+    [
+      'lf.ephemeral.linux.4xlarge',
+      {
+        runnerTypeName: 'lf.ephemeral.linux.4xlarge',
+        instance_type: 'c5.2xlarge',
+        os: 'linux',
+        max_available: 1,
+        disk_size: 150,
+        is_ephemeral: true,
+      },
+    ],
+    [
+      'lf.c.linux.4xlarge',
+      {
+        runnerTypeName: 'lf.c.linux.4xlarge',
+        instance_type: 'c5.2xlarge',
+        os: 'linux',
+        max_available: 1,
+        disk_size: 150,
+        is_ephemeral: false,
+      },
+    ],
+    [
+      'lf.c.ephemeral.linux.4xlarge',
+      {
+        runnerTypeName: 'lf.c.ephemeral.linux.4xlarge',
+        instance_type: 'c5.2xlarge',
+        os: 'linux',
+        max_available: 1,
+        disk_size: 150,
+        is_ephemeral: true,
       },
     ],
   ]);

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
@@ -376,7 +376,16 @@ export async function getRunnerTypes(
               return;
             }
 
-            result.set(`${variant}.${key}`, { ...runnerType, ...variantType, runnerTypeName: `${variant}.${key}` });
+            let variantRunnTypeName: string;
+            if (key.startsWith('lf.c.')) {
+              variantRunnTypeName = `lf.c.${variant}.${key.slice(5)}`;
+            } else if (key.startsWith('lf.')) {
+              variantRunnTypeName = `lf.${variant}.${key.slice(3)}`;
+            } else {
+              variantRunnTypeName = `${variant}.${key}`;
+            }
+
+            result.set(variantRunnTypeName, { ...runnerType, ...variantType, runnerTypeName: variantRunnTypeName });
           });
         }
       });


### PR DESCRIPTION
tests explain it by itself

Just runner variants are aware of lf. and lf.c. prefixes, and are introduced after them, so we don't need to make a big effort towards migrating it.