### PR TITLE
[ez][HUD] More flexible regex matching for log line display (mainly affects the disable test button)

### DIFF
--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -125,7 +125,7 @@ export default function JobLinks({
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 const unittestFailureRe = /^(?:FAIL|ERROR) \[.*\]: (test_.*) \(.*(Test.*)\)/;
-const pytestFailureRe = /^(?:FAILED|ERROR).* ([^ ]+\.py)::(.*)::(test_\S*)/;
+const pytestFailureRe = /([\w\\\/]+\.py)::(.*)::(test_\w*)/;
 export function getTestName(failureLine: string) {
   const unittestMatch = failureLine.match(unittestFailureRe);
   if (unittestMatch !== null) {


### PR DESCRIPTION
Allows it to match things like
```
2024-08-14T20:46:39.3465365Z The following tests failed consistently: ['test/profiler/test_cpp_thread.py::CppThreadTest::test_with_enable_profiler_in_child_thread']
```

Previously it only looked for things like
```
2024-08-14T19:39:57.2636076Z FAILED [0.0058s] test_transformers.py::TestSDPACudaOnlyCUDA::test_mem_efficient_attention_attn_mask_vs_math_ref_grads_batch_size_1_seq_len_q_152_seq_len_k_37_head_dim_16_is_causal_False_dropout_p_0_0_float16_scale_l1_cuda_float16 - ValueError: grad_key Test error 0.23132219910621643 is greater than threshold 0.0013792295940220356!
```

Note that this does not change the log classifier rules, it mainly affects the HUD disable test button and revert info button

Old:
<img width="841" alt="image" src="https://github.com/user-attachments/assets/fbedd6ea-e416-4c29-92f3-c2942efa4364">

New:
<img width="840" alt="image" src="https://github.com/user-attachments/assets/98358bfc-321f-463a-acd2-611246aed542">

The disable test button would generate an issue with the title `DISABLED test_with_enable_profiler_in_child_thread (__main__.CppThreadTest)`
