### PR TITLE
Bump max runners for linux.24xlarge to 500

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -102,7 +102,7 @@ runner_types:
     disk_size: 150
     instance_type: c5.24xlarge
     is_ephemeral: false
-    max_available: 250
+    max_available: 500
     os: linux
     variants:
       amz2023:


### PR DESCRIPTION
related pytorch PR: https://github.com/pytorch/pytorch/pull/133569