### PR TITLE
Add pti env due to kineto xpu enabled

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -194,6 +194,7 @@ jobs:
         run: |
           echo "set +u" >> "${BUILD_ENV_FILE}"
           echo "source /opt/intel/oneapi/pytorch-gpu-dev-0.5/oneapi-vars.sh" >> "${BUILD_ENV_FILE}"
+          echo "source /opt/intel/oneapi/pti/latest/env/vars.sh" >> "${BUILD_ENV_FILE}"
       - name: Install torch dependency
         run: |
           set -euxo pipefail


### PR DESCRIPTION
After this change land, we can re-enable xpu nightly wheel build with USE_KINETO. Refer [PyTorch Prerequisites for Intel GPUs](https://www.intel.com/content/www/us/en/developer/articles/tool/pytorch-prerequisites-for-intel-gpus.html). Works for https://github.com/pytorch/pytorch/issues/114850