### PR TITLE
Change default runner's AMI to Amazon 2023 - Part 2

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -27,6 +27,7 @@ runner_types:
     is_ephemeral: false
     max_available: 1000
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -38,6 +39,7 @@ runner_types:
     is_ephemeral: false
     max_available: 450
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -49,6 +51,7 @@ runner_types:
     is_ephemeral: false
     max_available: 150
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -60,6 +63,7 @@ runner_types:
     is_ephemeral: false
     max_available: 150
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -71,6 +75,7 @@ runner_types:
     is_ephemeral: true
     max_available: 50
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -82,6 +87,7 @@ runner_types:
     is_ephemeral: true
     max_available: 300
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -93,6 +99,7 @@ runner_types:
     is_ephemeral: false
     max_available: 150
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -104,6 +111,7 @@ runner_types:
     is_ephemeral: false
     max_available: 500
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -115,6 +123,7 @@ runner_types:
     is_ephemeral: false
     max_available: 3120
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -126,6 +135,7 @@ runner_types:
     is_ephemeral: false
     max_available: 1000
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -137,6 +147,7 @@ runner_types:
     is_ephemeral: false
     max_available: 1000
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -148,6 +159,7 @@ runner_types:
     is_ephemeral: false
     max_available: 400
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -159,6 +171,7 @@ runner_types:
     is_ephemeral: false
     max_available: 250
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -170,6 +183,7 @@ runner_types:
     is_ephemeral: false
     max_available: 300
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -181,6 +195,7 @@ runner_types:
     is_ephemeral: false
     max_available: 200
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -192,6 +207,7 @@ runner_types:
     is_ephemeral: false
     max_available: 150
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -203,6 +219,7 @@ runner_types:
     is_ephemeral: false
     max_available: 2400
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -214,6 +231,7 @@ runner_types:
     is_ephemeral: false
     max_available: 50
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -225,6 +243,7 @@ runner_types:
     instance_type: c5.large
     is_ephemeral: false
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -236,6 +255,7 @@ runner_types:
     is_ephemeral: false
     max_available: 200
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
@@ -247,6 +267,7 @@ runner_types:
     is_ephemeral: false
     max_available: 200
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
@@ -258,6 +279,7 @@ runner_types:
     is_ephemeral: false
     max_available: 100
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64

--- a/.github/scripts/validate_scale_config.py
+++ b/.github/scripts/validate_scale_config.py
@@ -205,13 +205,6 @@ def is_config_consistent_internally(runner_types: Dict[str, Dict[str, str]]) -> 
             errors_found = True
             continue
 
-        if "ami" in runner_config and amzn_variant["ami"] == runner_config["ami"]:
-            print(
-                f"Runner type {runner_type} variant {AMAZON_2023_PREFIX} has the same ami as the runner type"
-            )
-            errors_found = True
-            continue
-
         if not amzn_variant["ami"].startswith(AMAZON_2023_AMI_PREFIX):
             print(
                 f"Runner type {runner_type} variant {AMAZON_2023_PREFIX} ami does not start with {AMAZON_2023_AMI_PREFIX}"


### PR DESCRIPTION
Upgrades the LF scale configs to change the default AMI in accordance with the Amazon 2023 rollout plan.

This PR will be merged on Monday Aug 19 in the morning, and over the next 2-3 days as new linux runners are spun up (and old ones spun down) they'll start using this new AMI

This PR will be paired with https://github.com/pytorch/pytorch/pull/133641, which will be merged first

Note: I had to remove a check that validated that the variant's AMI is different from the base runner type's AMI because we want them to be the same during this rollout

**Rollout steps:**
1. Merge PR1 & PR2 early Monday morning, before folks start using the CI heavily 
2. (To roll out faster) Manually trigger a rollout in gha-labs-infra and ci-infra. This will accelerate the rollout by causing the runner instances to be cycled faster than otherwise. Most of the fleet will have the new runners quickly within the day, but we can still expect it to take up to 3 days for some stragglers to be cycled.
   - In pytorch-gha-infra, run the action [Runners Do Terraform Release (apply)](https://github.com/pytorch-labs/pytorch-gha-infra/actions/workflows/runners-on-dispatch-release.yml). 
   - In ci-infra, run the action [Terraform Apply / Runners / Production - ALI](https://github.com/pytorch/ci-infra/actions/workflows/ali-deploy-prod.yml) 
   
**Revert steps (if needed):**
1. Revert PR1 & PR 2
4. (To revert faster) Manually trigger a rollout in gha-labs-infra and ci-infra. This will accelerate the rollback by marking all current runners as stale and will cause the instances to be cycled faster than otherwise. Most of the fleet will have the new runners quickly within the day, but we can still expect it to take up to 3 days for some stragglers to be cycled.
   - In pytorch-gha-infra, run the action [Runners Do Terraform Release (apply)](https://github.com/pytorch-labs/pytorch-gha-infra/actions/workflows/runners-on-dispatch-release.yml). 
   - In ci-infra, run the action [Terraform Apply / Runners / Production - ALI](https://github.com/pytorch/ci-infra/actions/workflows/ali-deploy-prod.yml) 
5. (If we need to revert even faster in the case of a major outage) To go the EC2 instances in AWS and manually terminate the relevant instances. Note that this will cancel any jobs running on them. The scale up script will then provision instances with the new configs as fresh jobs are requested.

GHA Infra Runbook, in case something goes wrong when attempting the acceleration rollbacks: https://fburl.com/gdoc/jsvpqrav