### PR TITLE
[HUD][CH migration] Functioning commit_jobs_query

### DIFF
--- a/torchci/clickhouse_queries/commit_jobs_query/query.sql
+++ b/torchci/clickhouse_queries/commit_jobs_query/query.sql
@@ -1,5 +1,7 @@
 -- This query is used by HUD commit and pull request pages to get all jobs belong
 -- to specific commit hash. They can then be displayed on those pages.
+-- Based off of https://github.com/pytorch/test-infra/blob/c84f2b91cd104d3bbff5d99c4459059119050b95/torchci/rockset/commons/__sql/commit_jobs_query.sql#L1
+-- CircleCI has been removed
 WITH job AS (
     SELECT
         job.started_at AS time,
@@ -51,55 +53,6 @@ WITH job AS (
         AND workflow.head_sha = {sha: String }
         AND job.head_sha = {sha: String }
         AND workflow.repository. 'full_name' = {repo: String } --         UNION
-        --         -- Handle CircleCI
-        --         -- IMPORTANT: this needs to have the same order AS the query above
-        --         SELECT
-        --             job._event_time AS time,
-        --             job.pipeline.vcs.revision AS sha,
-        --             -- Swap workflow and job name for consistency with GHA naming style.
-        --             job.workflow.name AS job_name,
-        --             job.job.name AS workflow_name,
-        --             job.job.number AS id,
-        --             null AS workflow_id,
-        --             null AS github_artifact_id,
-        --             CASE
-        --                 WHEN job.job.status = 'failed' THEN 'failure'
-        --                 WHEN job.job.status = 'canceled' THEN 'cancelled'
-        --                 ELSE job.job.status
-        --             END AS conclusion,
-        --             -- cirleci doesn't provide a url, piece one together out of the info we have
-        --             CONCAT(
-        --                 'https://app.circleci.com/pipelines/github/',
-        -- : repo,
-        --                 '/',
-        --                 CAST(job.pipeline.number AS string),
-        --                 '/workflows/',
-        --                 job.workflow.id,
-        --                 '/jobs/',
-        --                 CAST(job.job.number AS string)
-        --             ) AS html_url,
-        --             -- logs aren't downloaded currently, just reuse html_url
-        --             html_url AS log_url,
-        --             null AS queue_time_s,
-        --             -- for circle ci, the event time comes after the end time, so its not reliable for queueing
-        --             DATE_DIFF(
-        --                 'SECOND',
-        --                 PARSE_TIMESTAMP_ISO8601(job.job.started_at),
-        --                 PARSE_TIMESTAMP_ISO8601(job.job.stopped_at)
-        --             ) AS duration_s,
-        --             -- Classifications not yet supported
-        --             null,
-        --             null,
-        --             null,
-        --             null,
-        --             -- Don't care about runner name from CircleCI
-        --             null AS runner_name,
-        --             null AS authorEmail,
-        --         FROM
-        --             circleci.job job
-        --         WHERE
-        --             job.pipeline.vcs.revision =: sha
-        --             AND CONCAT(job.organization.name, '/', job.project.name) =: repo
     UNION ALL
     SELECT
         workflow.created_at AS time,

--- a/torchci/clickhouse_queries/commit_jobs_query/query.sql
+++ b/torchci/clickhouse_queries/commit_jobs_query/query.sql
@@ -1,158 +1,164 @@
 -- This query is used by HUD commit and pull request pages to get all jobs belong
 -- to specific commit hash. They can then be displayed on those pages.
 WITH job AS (
-  SELECT
-    job.started_at AS time,
-    workflow.head_sha AS sha,
-    job.name AS job_name,
-    workflow.name AS workflow_name,
-    job.id,
-    workflow.id AS workflow_id,
-    workflow.artifacts_url AS github_artifact_url,
-    job.conclusion,
-    job.html_url,
-    IF(
-      {repo : String} = 'pytorch/pytorch',
-      CONCAT(
-        'https://ossci-raw-job-status.s3.amazonaws.com/log/',
-        job.id :: String
-      ),
-      CONCAT(
-        'https://ossci-raw-job-status.s3.amazonaws.com/log/',
-        {repo : String}, '/', job.id :: String
-      )
-    ) AS log_url,
-    DATE_DIFF(
-      'SECOND', job.created_at, job.started_at
-    ) AS queue_time_s,
-    DATE_DIFF(
-      'SECOND', job.started_at, job.completed_at
-    ) AS duration_s,
-    job.torchci_classification.line as line,
-    job.torchci_classification.captures as captures,
-    job.torchci_classification.line_num as line_num,
-    job.torchci_classification.context as context,
-    job.runner_name AS runner_name,
-    workflow.head_commit.'author'.'email' AS authorEmail
-  FROM
-    workflow_job job final
-    INNER JOIN workflow_run workflow final ON workflow.id = job.run_id
-  WHERE
-    job.name != 'ciflow_should_run'
-    AND job.name != 'generate-test-matrix'
-    AND workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
-    AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
-    AND workflow.head_sha = {sha : String}
-    AND job.head_sha = {sha : String}
-    AND workflow.repository.'full_name' = {repo : String} --         UNION
-    --         -- Handle CircleCI
-    --         -- IMPORTANT: this needs to have the same order AS the query above
-    --         SELECT
-    --             job._event_time AS time,
-    --             job.pipeline.vcs.revision AS sha,
-    --             -- Swap workflow and job name for consistency with GHA naming style.
-    --             job.workflow.name AS job_name,
-    --             job.job.name AS workflow_name,
-    --             job.job.number AS id,
-    --             null AS workflow_id,
-    --             null AS github_artifact_id,
-    --             CASE
-    --                 WHEN job.job.status = 'failed' THEN 'failure'
-    --                 WHEN job.job.status = 'canceled' THEN 'cancelled'
-    --                 ELSE job.job.status
-    --             END AS conclusion,
-    --             -- cirleci doesn't provide a url, piece one together out of the info we have
-    --             CONCAT(
-    --                 'https://app.circleci.com/pipelines/github/',
-    -- : repo,
-    --                 '/',
-    --                 CAST(job.pipeline.number AS string),
-    --                 '/workflows/',
-    --                 job.workflow.id,
-    --                 '/jobs/',
-    --                 CAST(job.job.number AS string)
-    --             ) AS html_url,
-    --             -- logs aren't downloaded currently, just reuse html_url
-    --             html_url AS log_url,
-    --             null AS queue_time_s,
-    --             -- for circle ci, the event time comes after the end time, so its not reliable for queueing
-    --             DATE_DIFF(
-    --                 'SECOND',
-    --                 PARSE_TIMESTAMP_ISO8601(job.job.started_at),
-    --                 PARSE_TIMESTAMP_ISO8601(job.job.stopped_at)
-    --             ) AS duration_s,
-    --             -- Classifications not yet supported
-    --             null,
-    --             null,
-    --             null,
-    --             null,
-    --             -- Don't care about runner name from CircleCI
-    --             null AS runner_name,
-    --             null AS authorEmail,
-    --         FROM
-    --             circleci.job job
-    --         WHERE
-    --             job.pipeline.vcs.revision =: sha
-    --             AND CONCAT(job.organization.name, '/', job.project.name) =: repo
-  UNION ALL
-  SELECT
-    workflow.created_at AS time,
-    workflow.head_sha AS sha,
-    workflow.name AS job_name,
-    'Workflow Startup Failure' AS workflow_name,
-    workflow.id,
-    0 AS workflow_id,
-    workflow.artifacts_url AS github_artifact_url,
-    if(
-      workflow.conclusion = ''
-      and workflow.status = 'queued',
-      'failure',
-      workflow.conclusion
-    ) as conclusion,
-    workflow.html_url,
-    '' AS log_url,
-    DATE_DIFF(
-      'SECOND', workflow.created_at, workflow.run_started_at
-    ) AS queue_time_s,
-    0 AS duration_s,
-    '' as line,
-    [] as captures,
-    0 as line_num,
-    [] as context,
-    '' AS runner_name,
-    workflow.head_commit.author.email AS authorEmail
-  FROM
-    workflow_run workflow final
-  WHERE
-    workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
-    AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
-    AND workflow.head_sha = {sha : String}
-    AND workflow.repository.full_name = {repo : String}
+    SELECT
+        job.started_at AS time,
+        workflow.head_sha AS sha,
+        job.name AS job_name,
+        workflow.name AS workflow_name,
+        job.id,
+        workflow.id AS workflow_id,
+        workflow.artifacts_url AS github_artifact_url,
+        job.conclusion,
+        job.html_url,
+        IF(
+            {repo: String } = 'pytorch/pytorch',
+            CONCAT(
+                'https://ossci-raw-job-status.s3.amazonaws.com/log/',
+                job.id:: String
+            ),
+            CONCAT(
+                'https://ossci-raw-job-status.s3.amazonaws.com/log/',
+                {repo: String },
+                '/',
+                job.id:: String
+            )
+        ) AS log_url,
+        if(
+            job.started_at = 0,
+            0,
+            DATE_DIFF('SECOND', job.created_at, job.started_at)
+        ) AS queue_time_s,
+        if(
+            job.completed_at = 0,
+            0,
+            DATE_DIFF('SECOND', job.started_at, job.completed_at)
+        ) AS duration_s,
+        job.torchci_classification.line as line,
+        job.torchci_classification.captures as captures,
+        job.torchci_classification.line_num as line_num,
+        job.torchci_classification.context as context,
+        job.runner_name AS runner_name,
+        workflow.head_commit. 'author'.'email' AS authorEmail
+    FROM
+        workflow_job job final
+        INNER JOIN workflow_run workflow final ON workflow.id = job.run_id
+    WHERE
+        job.name != 'ciflow_should_run'
+        AND job.name != 'generate-test-matrix'
+        AND workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
+        AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
+        AND workflow.head_sha = {sha: String }
+        AND job.head_sha = {sha: String }
+        AND workflow.repository. 'full_name' = {repo: String } --         UNION
+        --         -- Handle CircleCI
+        --         -- IMPORTANT: this needs to have the same order AS the query above
+        --         SELECT
+        --             job._event_time AS time,
+        --             job.pipeline.vcs.revision AS sha,
+        --             -- Swap workflow and job name for consistency with GHA naming style.
+        --             job.workflow.name AS job_name,
+        --             job.job.name AS workflow_name,
+        --             job.job.number AS id,
+        --             null AS workflow_id,
+        --             null AS github_artifact_id,
+        --             CASE
+        --                 WHEN job.job.status = 'failed' THEN 'failure'
+        --                 WHEN job.job.status = 'canceled' THEN 'cancelled'
+        --                 ELSE job.job.status
+        --             END AS conclusion,
+        --             -- cirleci doesn't provide a url, piece one together out of the info we have
+        --             CONCAT(
+        --                 'https://app.circleci.com/pipelines/github/',
+        -- : repo,
+        --                 '/',
+        --                 CAST(job.pipeline.number AS string),
+        --                 '/workflows/',
+        --                 job.workflow.id,
+        --                 '/jobs/',
+        --                 CAST(job.job.number AS string)
+        --             ) AS html_url,
+        --             -- logs aren't downloaded currently, just reuse html_url
+        --             html_url AS log_url,
+        --             null AS queue_time_s,
+        --             -- for circle ci, the event time comes after the end time, so its not reliable for queueing
+        --             DATE_DIFF(
+        --                 'SECOND',
+        --                 PARSE_TIMESTAMP_ISO8601(job.job.started_at),
+        --                 PARSE_TIMESTAMP_ISO8601(job.job.stopped_at)
+        --             ) AS duration_s,
+        --             -- Classifications not yet supported
+        --             null,
+        --             null,
+        --             null,
+        --             null,
+        --             -- Don't care about runner name from CircleCI
+        --             null AS runner_name,
+        --             null AS authorEmail,
+        --         FROM
+        --             circleci.job job
+        --         WHERE
+        --             job.pipeline.vcs.revision =: sha
+        --             AND CONCAT(job.organization.name, '/', job.project.name) =: repo
+    UNION ALL
+    SELECT
+        workflow.created_at AS time,
+        workflow.head_sha AS sha,
+        workflow.name AS job_name,
+        'Workflow Startup Failure' AS workflow_name,
+        workflow.id,
+        0 AS workflow_id,
+        workflow.artifacts_url AS github_artifact_url,
+        if(
+            workflow.conclusion = ''
+            and workflow.status = 'queued',
+            'failure',
+            workflow.conclusion
+        ) as conclusion,
+        workflow.html_url,
+        '' AS log_url,
+        DATE_DIFF(
+            'SECOND',
+            workflow.created_at,
+            workflow.run_started_at
+        ) AS queue_time_s,
+        0 AS duration_s,
+        '' as line,
+        [ ] as captures,
+        0 as line_num,
+        [ ] as context,
+        '' AS runner_name,
+        workflow.head_commit.author.email AS authorEmail
+    FROM
+        workflow_run workflow final
+    WHERE
+        workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
+        AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
+        AND workflow.head_sha = {sha: String }
+        AND workflow.repository.full_name = {repo: String }
 )
 SELECT
-  sha,
-  workflow_name AS workflowName,
-  job_name AS jobName,
-  CONCAT(workflow_name, ' / ', job_name) AS name,
-  id AS id,
-  workflow_id AS workflowId,
-  github_artifact_url AS githubArtifactUrl,
-  if(
-    conclusion = '', 'pending', conclusion
-  ) as conclusion,
-  html_url AS htmlUrl,
-  log_url AS logUrl,
-  duration_s AS durationS,
-  queue_time_s AS queueTimeS,
-  line AS failureLines,
-  line_num AS failureLineNumbers,
-  captures AS failureCaptures,
-  context AS failureContext,
-  runner_name AS runnerName,
-  authorEmail,
-  time,
+    sha,
+    workflow_name AS workflowName,
+    job_name AS jobName,
+    CONCAT(workflow_name, ' / ', job_name) AS name,
+    id AS id,
+    workflow_id AS workflowId,
+    github_artifact_url AS githubArtifactUrl,
+    if(conclusion = '', 'pending', conclusion) as conclusion,
+    html_url AS htmlUrl,
+    log_url AS logUrl,
+    duration_s AS durationS,
+    queue_time_s AS queueTimeS,
+    if(line = '', [ ], [ line ]) AS failureLines,
+    if(line_num = 0, [ ], [ line_num ]) AS failureLineNumbers,
+    captures AS failureCaptures,
+    context AS failureContext,
+    runner_name AS runnerName,
+    authorEmail,
+    time,
 FROM
-  job
+    job
 ORDER BY
-  name,
-  time DESC
+    name,
+    time DESC

--- a/torchci/clickhouse_queries/commit_jobs_query/query.sql
+++ b/torchci/clickhouse_queries/commit_jobs_query/query.sql
@@ -103,6 +103,7 @@ SELECT
     log_url AS logUrl,
     duration_s AS durationS,
     queue_time_s AS queueTimeS,
+    -- Convert to arrays
     if(line = '', [ ], [ line ]) AS failureLines,
     if(line_num = 0, [ ], [ line_num ]) AS failureLineNumbers,
     captures AS failureCaptures,

--- a/torchci/clickhouse_queries/commit_jobs_query/query.sql
+++ b/torchci/clickhouse_queries/commit_jobs_query/query.sql
@@ -35,8 +35,8 @@ WITH job AS (
     job.runner_name AS runner_name,
     workflow.head_commit.'author'.'email' AS authorEmail
   FROM
-    workflow_job job
-    INNER JOIN workflow_run workflow ON workflow.id = job.run_id
+    workflow_job job final
+    INNER JOIN workflow_run workflow final ON workflow.id = job.run_id
   WHERE
     job.name != 'ciflow_should_run'
     AND job.name != 'generate-test-matrix'
@@ -122,7 +122,7 @@ WITH job AS (
     '' AS runner_name,
     workflow.head_commit.author.email AS authorEmail
   FROM
-    workflow_run workflow
+    workflow_run workflow final
   WHERE
     workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
     AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
@@ -139,7 +139,7 @@ SELECT
   github_artifact_url AS githubArtifactUrl,
   if(
     conclusion = '', 'pending', conclusion
-  ),
+  ) as conclusion,
   html_url AS htmlUrl,
   log_url AS logUrl,
   duration_s AS durationS,

--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -40,7 +40,7 @@ export default function JobLinks({
     );
   }
 
-  if (job.failureCaptures != null) {
+  if (job.failureCaptures != null && job.failureLines?.length != 0) {
     subInfo.push(
       <a
         target="_blank"
@@ -156,6 +156,7 @@ This test was disabled because it is failing on main branch ([recent examples]($
 }
 
 function DisableTest({ job, label }: { job: JobData; label: string }) {
+  console.log(job.failureLines)
   const hasFailureClassification =
     job.failureLines != null && job.failureLines.every((line) => line !== null);
   const swrKey = hasFailureClassification ? `/api/issue/${label}` : null;

--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -156,7 +156,7 @@ This test was disabled because it is failing on main branch ([recent examples]($
 }
 
 function DisableTest({ job, label }: { job: JobData; label: string }) {
-  console.log(job.failureLines)
+  console.log(job.failureLines);
   const hasFailureClassification =
     job.failureLines != null && job.failureLines.every((line) => line !== null);
   const swrKey = hasFailureClassification ? `/api/issue/${label}` : null;

--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -156,7 +156,6 @@ This test was disabled because it is failing on main branch ([recent examples]($
 }
 
 function DisableTest({ job, label }: { job: JobData; label: string }) {
-  console.log(job.failureLines);
   const hasFailureClassification =
     job.failureLines != null && job.failureLines.every((line) => line !== null);
   const swrKey = hasFailureClassification ? `/api/issue/${label}` : null;

--- a/torchci/components/LogViewer.tsx
+++ b/torchci/components/LogViewer.tsx
@@ -274,6 +274,9 @@ function LogWithLineSelector({
   });
   // undefined means that no line is selected, so the log viewer is closed
   const [currentLine, setCurrentLine] = useState<number | undefined>(undefined);
+  // TODO: Remove this. This is a hack to make sure that that the log viewer
+  // will always show up. It gets around some differences in output between
+  // rockset and clickhouse
   if (lineNumbers.length === 0) {
     lineNumbers = [0];
   }

--- a/torchci/components/LogViewer.tsx
+++ b/torchci/components/LogViewer.tsx
@@ -274,6 +274,9 @@ function LogWithLineSelector({
   });
   // undefined means that no line is selected, so the log viewer is closed
   const [currentLine, setCurrentLine] = useState<number | undefined>(undefined);
+  if (lineNumbers.length === 0) {
+    lineNumbers = [0];
+  }
   return (
     <>
       {lineNumbers.map((line, index) => (

--- a/torchci/lib/clickhouse.ts
+++ b/torchci/lib/clickhouse.ts
@@ -56,29 +56,3 @@ export function enableClickhouse() {
   // Use this to quickly toggle between clickhouse and rockset
   return process.env.USE_CLICKHOUSE == "true";
 }
-
-export function coerceBoolNum(data: any[]) {
-  // Coerces the types of an output from clickhouse to bool or number if
-  // possible since clickhouse returns strings.  Does not yet handle nested
-  // objects/tuples.
-  for (const row of data) {
-    for (const key in row) {
-      if (row[key] === "true") {
-        row[key] = true;
-      } else if (row[key] === "false") {
-        row[key] = false;
-      } else if (!isNaN(row[key])) {
-        row[key] = Number(row[key]);
-      }
-    }
-  }
-  return data;
-}
-
-export function numToNullableStr(val: number) {
-  // Some code expects nullable strings for values that are usually numbers
-  if (val === 0) {
-    return null;
-  }
-  return val.toString();
-}

--- a/torchci/lib/clickhouse.ts
+++ b/torchci/lib/clickhouse.ts
@@ -12,7 +12,7 @@ export function getClickhouseClient() {
 export async function queryClickhouse(
   query: string,
   params: Record<string, unknown>
-) {
+): Promise<any[]> {
   /**
    * queryClickhouse
    * @param query: string, the sql query
@@ -25,7 +25,7 @@ export async function queryClickhouse(
     query_params: params,
   });
 
-  return await res.json();
+  return (await res.json()) as any[];
 }
 
 export async function queryClickhouseSaved(
@@ -55,4 +55,30 @@ export async function queryClickhouseSaved(
 export function enableClickhouse() {
   // Use this to quickly toggle between clickhouse and rockset
   return process.env.USE_CLICKHOUSE == "true";
+}
+
+export function coerceBoolNum(data: any[]) {
+  // Coerces the types of an output from clickhouse to bool or number if
+  // possible since clickhouse returns strings.  Does not yet handle nested
+  // objects/tuples.
+  for (const row of data) {
+    for (const key in row) {
+      if (row[key] === "true") {
+        row[key] = true;
+      } else if (row[key] === "false") {
+        row[key] = false;
+      } else if (!isNaN(row[key])) {
+        row[key] = Number(row[key]);
+      }
+    }
+  }
+  return data;
+}
+
+export function numToNullableStr(val: number) {
+  // Some code expects nullable strings for values that are usually numbers
+  if (val === 0) {
+    return null;
+  }
+  return val.toString();
 }

--- a/torchci/lib/fetchCommit.ts
+++ b/torchci/lib/fetchCommit.ts
@@ -61,7 +61,6 @@ export default async function fetchCommit(
   ]);
 
   let jobs = response as any[];
-  console.log(response);
 
   // Subtle: we need to unique jobs by name, taking the most recent job. This is
   // because there might be many periodic jobs with the same name, and we want

--- a/torchci/lib/fetchCommit.ts
+++ b/torchci/lib/fetchCommit.ts
@@ -1,10 +1,7 @@
 import _ from "lodash";
 import { Octokit } from "octokit";
 import rocksetVersions from "rockset/prodVersions.json";
-import {
-  enableClickhouse,
-  queryClickhouseSaved,
-} from "./clickhouse";
+import { enableClickhouse, queryClickhouseSaved } from "./clickhouse";
 import { commitDataFromResponse, getOctokit } from "./github";
 import { removeCancelledJobAfterRetry } from "./jobUtils";
 import getRocksetClient from "./rockset";
@@ -22,7 +19,7 @@ async function fetchDatabaseInfo(owner: string, repo: string, sha: string) {
       row.workflowId = row.workflowId == 0 ? null : row.workflowId;
       row.durationS = parseInt(row.durationS);
       row.queueTimeS = parseInt(row.queueTimeS);
-      row.time = row.time + 'Z'
+      row.time = row.time + "Z";
     }
     return response;
   } else {
@@ -64,7 +61,7 @@ export default async function fetchCommit(
   ]);
 
   let jobs = response as any[];
-  console.log(response)
+  console.log(response);
 
   // Subtle: we need to unique jobs by name, taking the most recent job. This is
   // because there might be many periodic jobs with the same name, and we want


### PR DESCRIPTION
There's a lot of type casting/changes here because rockset returns slightly different types.

TODO when we switch: get rid of the type changes and just change the code to use the ClickHouse types

The query didn't actually change that much, most of it is formatting

https://torchci-git-csl-workingcommithudquery-fbopensource.vercel.app/pytorch/pytorch/commit/773a782249ebe982996f18988ce6b26c4a786aa3
