### PR TITLE
Fix missing ClickHouse SQL queries on Vercel

### DIFF
--- a/torchci/lib/clickhouse.ts
+++ b/torchci/lib/clickhouse.ts
@@ -40,7 +40,8 @@ export async function queryClickhouseSaved(
    * This function will filter the inputParams to only include the parameters that are in the query params json file
    */
   const query = readFileSync(
-    `clickhouse_queries/${queryName}/query.sql`,
+    // https://stackoverflow.com/questions/74924100/vercel-error-enoent-no-such-file-or-directory
+    `${process.cwd()}/clickhouse_queries/${queryName}/query.sql`,
     "utf8"
   );
   const paramsText = require(`clickhouse_queries/${queryName}/params.json`);


### PR DESCRIPTION
This fixes the missing SQL files error when running ClickHouse queries on Vercel, i.e. https://vercel.com/fbopensource/torchci/logs?slug=app-future&slug=en-US&slug=fbopensource&slug=torchci&slug=logs&page=1&timeline=past30Minutes&startDate=1724086676515&endDate=1724088476515&levels=error&selectedLogId=1724088099571809957129200000&selectedLogTimestamp=1724088099571&forceEndDate=1724088255973

### Testing 

Using the preview from https://github.com/pytorch/test-infra/pull/5393 https://vercel.live/open-feedback/torchci-git-fork-huydhn-switch-merges-to-cl-55041f-fbopensource.vercel.app?via=pr-comment-visit-preview-link&passThrough=1.  I have set `USE_CLICKHOUSE` to true for preview and dev environments on https://vercel.com/fbopensource/torchci/settings/environment-variables