### PR TITLE
tools: Add script to run clickhouse formatter

### DIFF
--- a/.github/scripts/run_clickhouse_format.sh
+++ b/.github/scripts/run_clickhouse_format.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+# Should return the top directory for our git repository
+TOP_DIR=$(git rev-parse --show-toplevel)
+TEMP_LINT_DIR=${TOP_DIR}/.linttemp
+
+rm -rf "${TEMP_LINT_DIR}"
+mkdir -p "${TEMP_LINT_DIR}"
+
+# We can optionally specify a separate clickhouse binary here
+CLICKHOUSE_BINARY=${CLICKHOUSE_BINARY:-clickhouse}
+CLICKHOUSE_QUERIES_DIR=${CLICKHOUSE_QUERIES_DIR:-${TOP_DIR}/torchci/clickhouse_queries}
+
+# Check if clickhouse binary is actually installed
+if ! ${CLICKHOUSE_BINARY} --version >/dev/null 2>/dev/null; then
+  echo "ERROR: clickhouse binary '${CLICKHOUSE_BINARY}' not installed"
+  echo "       Refer to docs on how to install clickhouse, https://clickhouse.com/docs/en/install"
+  echo "       exiting..."
+  exit 1
+fi
+
+while read -r file; do
+  # Get the relative path since we don't want to copy over all of our filesystem structure
+  rel_path=${file#${TOP_DIR}/}
+  # Make the directory just in case it doesn't exist
+  mkdir -p $(dirname "${TEMP_LINT_DIR}/${rel_path}")
+  # Do the formatting, output it to a temporary directory first
+  ${CLICKHOUSE_BINARY} format < "${rel_path}" > "${TEMP_LINT_DIR}/${rel_path}"
+  # Replace the local copy that we have with the one that's been formatted
+  mv "${TEMP_LINT_DIR}/${rel_path}" "${rel_path}"
+done < <(find ${CLICKHOUSE_QUERIES_DIR} -name "*.sql")
+
+# Check if there's any changes in our queries directory
+CHANGES=$(git status --porcelain "${CLICKHOUSE_QUERIES_DIR}")
+
+if [[ -n ${CHANGES} ]]; then
+  echo "INFO: The following files have been modified:"
+  echo "${CHANGES}"
+  exit 2
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .venv
 .idea
 .lintbin
+.linttemp
 
 *.env
 *.zip


### PR DESCRIPTION
Adds a script to run the clickhouse formatter on all of our clickhouse queries, in an ideal state this script should run `clickhouse format` on all of our queries (suffixed with `.sql`) in `torchci/clickhouse_queries` and then replace them in place with formatted versions of themselves.

NOTE: This does not install the clickhouse binary for you and will need to install it on their own.

Usage:

```
bash .github/scripts/run_clickhouse_format.sh
```

Example:

```
$ bash .github/scripts/run_clickhouse_format.sh
INFO: The following files have been modified:
 M torchci/clickhouse_queries/commit_jobs_query/query.sql
```

> **TODO**: This definitely needs a follow up to automate this into a github actions workflow but don't have the bandwidth to do that right now

## Questions you might have:
* Why are you using a temporary directory:
  * The `clickhouse format` tool only accepts `stdin` and `stdout` as input and output
* Why don't you install the clickhouse binary as part of the setup process?
  * Clickhouse client installation is actually a bit non-trivial, ideally we should download static binaries instead of relying on the `curl | sh` command that clickhouse provides but did not have enough time to explore the static binaries enough. (I also think they only work on linux)
* Why did you write this in shell instead of python?
  * My brain thinks in bash and I'm able to get it done quickly, python is probably the correct long term answer here.