### PR TITLE
Migrate master_commit_red query and add a ClickHouse toggle on metrics page

### DIFF
--- a/torchci/clickhouse_queries/master_commit_red/params.json
+++ b/torchci/clickhouse_queries/master_commit_red/params.json
@@ -1,0 +1,5 @@
+{
+    "startTime": "DateTime('UTC')",
+    "stopTime": "DateTime('UTC')",
+    "timezone": "String"
+}

--- a/torchci/clickhouse_queries/master_commit_red/params.json
+++ b/torchci/clickhouse_queries/master_commit_red/params.json
@@ -1,5 +1,5 @@
 {
-    "startTime": "DateTime('UTC')",
-    "stopTime": "DateTime('UTC')",
+    "startTime": "DateTime64(3)",
+    "stopTime": "DateTime64(3)",
     "timezone": "String"
 }

--- a/torchci/clickhouse_queries/master_commit_red/query.sql
+++ b/torchci/clickhouse_queries/master_commit_red/query.sql
@@ -7,7 +7,7 @@ WITH all_jobs AS (
       WHEN job.conclusion = 'failure' THEN 'red'
       WHEN job.conclusion = 'timed_out' THEN 'red'
       WHEN job.conclusion = 'cancelled' THEN 'red'
-      WHEN job.conclusion IS NULL THEN 'pending'
+      WHEN job.conclusion = '' THEN 'pending'
       ELSE 'green'
     END as conclusion,
     push.head_commit.'id' AS sha

--- a/torchci/clickhouse_queries/master_commit_red/query.sql
+++ b/torchci/clickhouse_queries/master_commit_red/query.sql
@@ -1,4 +1,4 @@
---- This query is used to show the percentage of trunk red commits on HUD metrics page
+--- This query is used to show the histogram of trunk red commits on HUD metrics page
 --- during a period of time
 WITH all_jobs AS (
   SELECT
@@ -31,8 +31,8 @@ WITH all_jobs AS (
     )
     AND push.repository.'owner'.'name' = 'pytorch'
     AND push.repository.'name' = 'pytorch'
-    AND push.head_commit.'timestamp' >= {startTime: DateTime('UTC')}
-    AND push.head_commit.'timestamp' < {stopTime: DateTime('UTC')}
+    AND push.head_commit.'timestamp' >= {startTime: DateTime64(3)}
+    AND push.head_commit.'timestamp' < {stopTime: DateTime64(3)}
 ),
 commit_overall_conclusion AS (
   SELECT

--- a/torchci/clickhouse_queries/master_commit_red/query.sql
+++ b/torchci/clickhouse_queries/master_commit_red/query.sql
@@ -1,0 +1,70 @@
+--- This query is used to show the percentage of trunk red commits on HUD metrics page
+--- during a period of time
+WITH all_jobs AS (
+  SELECT
+    push.head_commit.'timestamp' AS time,
+    CASE
+      WHEN job.conclusion = 'failure' THEN 'red'
+      WHEN job.conclusion = 'timed_out' THEN 'red'
+      WHEN job.conclusion = 'cancelled' THEN 'red'
+      WHEN job.conclusion IS NULL THEN 'pending'
+      ELSE 'green'
+    END as conclusion,
+    push.head_commit.'id' AS sha
+  FROM
+    workflow_job job FINAL
+    JOIN workflow_run FINAL ON workflow_run.id = workflow_job.run_id
+    JOIN push FINAL ON workflow_run.head_commit.'id' = push.head_commit.'id'
+  WHERE
+    job.name != 'ciflow_should_run'
+    AND job.name != 'generate-test-matrix'
+    AND (
+      -- Limit it to workflows which block viable/strict upgrades
+      workflow_run.name in ('Lint', 'pull', 'trunk')
+      OR workflow_run.name like 'linux-binary%'
+    )
+    AND job.name NOT LIKE '%rerun_disabled_tests%'
+    AND job.name NOT LIKE '%unstable%'
+    AND workflow_run.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
+    AND push.ref IN (
+      'refs/heads/master', 'refs/heads/main'
+    )
+    AND push.repository.'owner'.'name' = 'pytorch'
+    AND push.repository.'name' = 'pytorch'
+    AND push.head_commit.'timestamp' >= {startTime: DateTime('UTC')}
+    AND push.head_commit.'timestamp' < {stopTime: DateTime('UTC')}
+),
+commit_overall_conclusion AS (
+  SELECT
+    time,
+    sha,
+    CASE
+      WHEN countIf(conclusion = 'red') > 0 THEN 'red'
+      WHEN countIf(conclusion = 'pending') > 0 THEN 'pending'
+      ELSE 'green'
+    END AS overall_conclusion
+  FROM
+    all_jobs
+  GROUP BY
+    time,
+    sha
+  HAVING
+    COUNT(*) > 10 -- Filter out jobs that didn't run anything.
+  ORDER BY
+    time DESC
+)
+SELECT
+  toDate(
+    date_trunc('hour', time),
+    {timezone: String}
+  ) AS granularity_bucket,
+  countIf(overall_conclusion = 'red') AS red,
+  countIf(overall_conclusion = 'pending') AS pending,
+  countIf(overall_conclusion = 'green') AS green,
+  COUNT(*) as total
+FROM
+  commit_overall_conclusion
+GROUP BY
+  granularity_bucket
+ORDER BY
+  granularity_bucket ASC

--- a/torchci/components/ClickHouseCheckBox.tsx
+++ b/torchci/components/ClickHouseCheckBox.tsx
@@ -1,0 +1,27 @@
+export function ClickHouseCheckBox({
+  useClickHouse,
+  setUseClickHouse,
+}: {
+  useClickHouse: boolean;
+  setUseClickHouse: any;
+}) {
+  return (
+    <>
+      <div>
+        <span
+          onClick={() => {
+            setUseClickHouse(!useClickHouse);
+          }}
+        >
+          <input
+            type="checkbox"
+            name="useClickHouse"
+            checked={useClickHouse}
+            onChange={() => {}}
+          />
+          <label htmlFor="useClickHouse"> Use ClickHouse</label>
+        </span>
+      </div>
+    </>
+  );
+}

--- a/torchci/pages/api/clickhouse/[queryName].ts
+++ b/torchci/pages/api/clickhouse/[queryName].ts
@@ -6,8 +6,9 @@ export default async function handler(
   res: NextApiResponse
 ) {
   const queryName = req.query.queryName as string;
-
-  const response = await queryClickhouseSaved(queryName, req.query);
-
+  const response = await queryClickhouseSaved(
+    queryName,
+    JSON.parse(req.query.parameters as string)
+  );
   res.status(200).json(response);
 }

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -449,6 +449,8 @@ export default function Page() {
   const [startTime, setStartTime] = useState(dayjs().subtract(1, "week"));
   const [stopTime, setStopTime] = useState(dayjs());
   const [timeRange, setTimeRange] = useState<number>(7);
+
+  // TODO (huydhn): Clean this up once ClickHouse migration finishes
   const [useClickHouse, setUseClickHouse] = usePreference(
     "useClickHouse",
     false

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -41,7 +41,7 @@ function MasterCommitRedPanel({
   useClickHouse: boolean;
 }) {
   const url = useClickHouse
-    ? `/api/clickhouse/master_commit_red?query=${encodeURIComponent(
+    ? `/api/clickhouse/master_commit_red?parameters=${encodeURIComponent(
         JSON.stringify({
           ...params,
           timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -49,7 +49,7 @@ function MasterCommitRedPanel({
       )}`
     : `/api/query/metrics/master_commit_red?parameters=${encodeURIComponent(
         JSON.stringify([
-          ...params,
+          ...(params as RocksetParam[]),
           {
             name: "timezone",
             type: "string",
@@ -467,8 +467,8 @@ export default function Page() {
     },
   ];
   const timeParamsClickHouse = {
-    startTime: startTime.utc().format("YYYY-MM-DD HH:mm:ss"),
-    stopTime: stopTime.utc().format("YYYY-MM-DD HH:mm:ss"),
+    startTime: startTime.utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
+    stopTime: stopTime.utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
   };
 
   const [ttsPercentile, setTtsPercentile] = useState<number>(0.5);

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -17,6 +17,7 @@ import {
 } from "@mui/x-data-grid";
 import { DateTimePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { ClickHouseCheckBox } from "components/ClickHouseCheckBox";
 import ScalarPanel, {
   ScalarPanelWithValue,
 } from "components/metrics/panels/ScalarPanel";
@@ -28,20 +29,34 @@ import { EChartsOption } from "echarts";
 import ReactECharts from "echarts-for-react";
 import { fetcher } from "lib/GeneralUtils";
 import { RocksetParam } from "lib/rockset";
+import { usePreference } from "lib/useGroupingPreference";
 import { useEffect, useState } from "react";
 import useSWR from "swr";
 
-function MasterCommitRedPanel({ params }: { params: RocksetParam[] }) {
-  const url = `/api/query/metrics/master_commit_red?parameters=${encodeURIComponent(
-    JSON.stringify([
-      ...params,
-      {
-        name: "timezone",
-        type: "string",
-        value: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      },
-    ])
-  )}`;
+function MasterCommitRedPanel({
+  params,
+  useClickHouse,
+}: {
+  params: RocksetParam[] | {};
+  useClickHouse: boolean;
+}) {
+  const url = useClickHouse
+    ? `/api/clickhouse/master_commit_red?query=${encodeURIComponent(
+        JSON.stringify({
+          ...params,
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        })
+      )}`
+    : `/api/query/metrics/master_commit_red?parameters=${encodeURIComponent(
+        JSON.stringify([
+          ...params,
+          {
+            name: "timezone",
+            type: "string",
+            value: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          },
+        ])
+      )}`;
 
   const { data } = useSWR(url, fetcher, {
     refreshInterval: 5 * 60 * 1000, // refresh every 5 minutes
@@ -434,6 +449,10 @@ export default function Page() {
   const [startTime, setStartTime] = useState(dayjs().subtract(1, "week"));
   const [stopTime, setStopTime] = useState(dayjs());
   const [timeRange, setTimeRange] = useState<number>(7);
+  const [useClickHouse, setUseClickHouse] = usePreference(
+    "useClickHouse",
+    false
+  );
 
   const timeParams: RocksetParam[] = [
     {
@@ -447,6 +466,10 @@ export default function Page() {
       value: stopTime,
     },
   ];
+  const timeParamsClickHouse = {
+    startTime: startTime.utc().format("YYYY-MM-DD HH:mm:ss"),
+    stopTime: stopTime.utc().format("YYYY-MM-DD HH:mm:ss"),
+  };
 
   const [ttsPercentile, setTtsPercentile] = useState<number>(0.5);
 
@@ -497,9 +520,19 @@ export default function Page() {
         />
       </Stack>
 
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <ClickHouseCheckBox
+          useClickHouse={useClickHouse}
+          setUseClickHouse={setUseClickHouse}
+        />
+      </Stack>
+
       <Grid container spacing={2}>
         <Grid item md={6} xs={12} height={ROW_HEIGHT}>
-          <MasterCommitRedPanel params={timeParams} />
+          <MasterCommitRedPanel
+            params={useClickHouse ? timeParamsClickHouse : timeParams}
+            useClickHouse={useClickHouse}
+          />
         </Grid>
 
         <Grid container item lg={2} md={3} xs={6} justifyContent={"stretch"}>


### PR DESCRIPTION
This PR:

* Fixes a bug in `torchci/pages/api/clickhouse/[queryName].ts` where the function doesn't parse the JSON parameters (missed in https://github.com/pytorch/test-infra/pull/5563)
* Adds a toggle on HUD metrics page to gradually migrate everything there to ClickHouse
* Migrates an example `master_commit_red` query that is used to generate the red commit histogram on HUD metrics page

### Testing

https://torchci-git-fork-huydhn-add-api-endpoint-to-8b08ac-fbopensource.vercel.app/metrics