### PR TITLE
Migrate queue_times_historical to Clickhouse

### DIFF
--- a/torchci/clickhouse_queries/queue_times_historical/params.json
+++ b/torchci/clickhouse_queries/queue_times_historical/params.json
@@ -1,0 +1,5 @@
+{
+    "granularity": "String",
+    "startTime": "String",
+    "stopTime": "String"
+}

--- a/torchci/clickhouse_queries/queue_times_historical/query.sql
+++ b/torchci/clickhouse_queries/queue_times_historical/query.sql
@@ -1,0 +1,28 @@
+SELECT
+    formatDateTime(
+            CASE
+                WHEN {granularity:String} = 'minute' THEN toStartOfMinute(q.time)
+                WHEN {granularity:String} = 'hour' THEN toStartOfHour(q.time)
+                WHEN {granularity:String} = 'day' THEN toStartOfDay(q.time)
+                WHEN {granularity:String} = 'week' THEN toStartOfWeek(q.time)
+                WHEN {granularity:String} = 'month' THEN toStartOfMonth(q.time)
+                WHEN {granularity:String} = 'year' THEN toStartOfYear(q.time)
+                ELSE toStartOfDay(q.time)  -- Default to day if granularity is not recognized
+                END,
+            '%Y-%m-%dT%H:%i:%s'
+    ) AS granularity_bucket,
+    /* misnomer, this is the max queue time, not the avg queue time */
+    avg(q.avg_queue_s) as avg_queue_s,
+    q.machine_type
+FROM
+    queue_times_historical q
+WHERE
+    q.time >= parseDateTimeBestEffort({startTime:String}) AND q.time < parseDateTimeBestEffort({stopTime:String})
+GROUP BY
+    granularity_bucket,
+    q.machine_type
+HAVING
+    /* filter out weird GH API bugs */
+    avg(q.count) > 5
+ORDER BY
+    granularity_bucket ASC

--- a/torchci/components/metrics/panels/TimeSeriesPanel.tsx
+++ b/torchci/components/metrics/panels/TimeSeriesPanel.tsx
@@ -222,6 +222,7 @@ export default function TimeSeriesPanel({
   yAxisLabel,
   // Additional EChartsOption (ex max y value)
   additionalOptions,
+  useClickhouse,
 }: {
   title: string;
   queryCollection?: string;
@@ -235,16 +236,24 @@ export default function TimeSeriesPanel({
   yAxisRenderer: (_value: any) => string;
   yAxisLabel?: string;
   additionalOptions?: EChartsOption;
+  useClickhouse?: boolean;
 }) {
   // - Granularity
   // - Group by
   // - Time field
-  const url = `/api/query/${queryCollection}/${queryName}?parameters=${encodeURIComponent(
-    JSON.stringify([
-      ...queryParams,
-      { name: "granularity", type: "string", value: granularity },
-    ])
-  )}`;
+  const url = !useClickhouse
+    ? `/api/query/${queryCollection}/${queryName}?parameters=${encodeURIComponent(
+        JSON.stringify([
+          ...queryParams,
+          { name: "granularity", type: "string", value: granularity },
+        ])
+      )}`
+    : `/api/clickhouse/${queryName}?parameters=${encodeURIComponent(
+        JSON.stringify([
+          ...queryParams,
+          { name: "granularity", type: "string", value: granularity },
+        ])
+      )}`;
 
   const { data } = useSWR(url, fetcher, {
     refreshInterval: 5 * 60 * 1000, // refresh every 5 minutes

--- a/torchci/pages/api/clickhouse/[queryName].ts
+++ b/torchci/pages/api/clickhouse/[queryName].ts
@@ -6,9 +6,25 @@ export default async function handler(
   res: NextApiResponse
 ) {
   const queryName = req.query.queryName as string;
-  const response = await queryClickhouseSaved(
-    queryName,
-    JSON.parse(req.query.parameters as string)
-  );
+
+  // detect if parameters are in the legacy Rockset lambda format
+  // (if they all contain "name", "type", and "value" keys)
+  // and convert them to the new format if so
+  let parameters = JSON.parse(req.query.parameters as string);
+
+  if (
+    Array.isArray(parameters) &&
+    parameters.every(
+      (param: any) => "name" in param && "type" in param && "value" in param
+    )
+  ) {
+    const newParams: Record<string, any> = {};
+    for (const param of parameters) {
+      newParams[param.name] = param.value;
+    }
+    parameters = newParams;
+  }
+
+  const response = await queryClickhouseSaved(queryName, parameters);
   res.status(200).json(response);
 }

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -879,6 +879,7 @@ export default function Page() {
             timeFieldName={"granularity_bucket"}
             yAxisFieldName={"avg_queue_s"}
             yAxisRenderer={durationDisplay}
+            useClickhouse={useClickHouse}
           />
         </Grid>
 


### PR DESCRIPTION
Two changes:
* migrate queue_times_historical to Clickhouse
* api/clickhouse supports legacy Rockset Lambda params format

Tested in Hud locally (not sure how to change granularity though).