### PR TITLE
fix: TFLint error for duplicate output declaration

### DIFF
--- a/terraform-aws-github-runner/outputs.tf
+++ b/terraform-aws-github-runner/outputs.tf
@@ -11,7 +11,6 @@ output "runners" {
     role_runner                     = module.runners_instances.role_runner
     role_scale_up                   = module.runners.role_scale_up
     role_scale_down                 = module.runners.role_scale_down
-    role_scale_down                 = module.runners.role_scale_down
     iam_profile_name_runner         = module.runners_instances.iam_profile_name_runner
   }
 }


### PR DESCRIPTION
The output here is duplicated and is causing TFLint to throw an error.