### PR TITLE
Use amzn2 for linux.9xlarge.ephemeral

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -75,7 +75,7 @@ runner_types:
     is_ephemeral: true
     max_available: 50
     os: linux
-    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
+    ami: amzn2-ami-hvm-2.0.20240306.2-x86_64-ebs
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64


### PR DESCRIPTION
Temporary use amzon linux 2 as default for these runners.
See: https://github.com/pytorch/pytorch/pull/132202#issuecomment-2302193247