### PR TITLE
Enable certain labels to only be added by a select group of people

### DIFF
--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -456,13 +456,17 @@ The explanation needs to be clear on why this is needed. Here are some good exam
     }
 
     // Labels only people with write access to the repo should be able to add
-    const labels_requiring_write_access: string[] = ["skip-pr-sanity-check"]
+    const labels_requiring_write_access: string[] = ["skip-pr-sanity-check"];
     const write_required_labels = labelsToAdd.filter((l: string) =>
-      labels_requiring_write_access.some((write_required_label) => write_required_label === l))
+      labels_requiring_write_access.some(
+        (write_required_label) => write_required_label === l
+      )
+    );
 
-    if (write_required_labels.length > 0 &&
-       !(await this.hasWritePermissions(ctx.payload?.comment?.user?.login)))
-     {
+    if (
+      write_required_labels.length > 0 &&
+      !(await this.hasWritePermissions(ctx.payload?.comment?.user?.login))
+    ) {
       return await this.addComment(
         "Only people with write access to the repo can add these labels: " +
           write_required_labels.join(", ") +

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -454,6 +454,22 @@ The explanation needs to be clear on why this is needed. Here are some good exam
         "Can't add ciflow labels to an Issue."
       );
     }
+
+    // Labels only people with write access to the repo should be able to add
+    const labels_requiring_write_access: string[] = ["skip-pr-sanity-check"]
+    const write_required_labels = labelsToAdd.filter((l: string) =>
+      labels_requiring_write_access.some((write_required_label) => write_required_label === l))
+
+    if (write_required_labels.length > 0 &&
+       !(await this.hasWritePermissions(ctx.payload?.comment?.user?.login)))
+     {
+      return await this.addComment(
+        "Only people with write access to the repo can add these labels: " +
+          write_required_labels.join(", ") +
+          ". Please ping one of the reviewers for help."
+      );
+    }
+
     if (
       ciflowLabels.length > 0 &&
       !(await this.hasWorkflowRunningPermissions(

--- a/torchci/test/fixtures/known_labels.json
+++ b/torchci/test/fixtures/known_labels.json
@@ -26,5 +26,14 @@
     "color": "574CBB",
     "default": false,
     "description": "Trigger trunk jobs on your pull request"
+  },
+  {
+    "id": 1663721063,
+    "node_id": "LA_AAAAA-j9z87aX_Jl",
+    "url": "https://api.github.com/repos/pytorch/pytorch/labels/skip-pr-sanity-check",
+    "name": "skip-pr-sanity-check",
+    "color": "574CBB",
+    "default": false,
+    "description": "Skips PR size check"
   }
 ]

--- a/torchci/test/labelCommands.test.ts
+++ b/torchci/test/labelCommands.test.ts
@@ -284,7 +284,9 @@ describe("label-bot", () => {
       )
       .reply(200, {})
       .post(`/repos/${owner}/${repo}/issues/${pr_number}/labels`, (body) => {
-        expect(JSON.stringify(body)).toContain(`{"labels":["skip-pr-sanity-check"]}`);
+        expect(JSON.stringify(body)).toContain(
+          `{"labels":["skip-pr-sanity-check"]}`
+        );
         return true;
       })
       .reply(200, {});

--- a/torchci/test/labelCommands.test.ts
+++ b/torchci/test/labelCommands.test.ts
@@ -228,6 +228,71 @@ describe("label-bot", () => {
     handleScope(additionalScopes);
   });
 
+  test("label requiring write access with bad permissions", async () => {
+    const event = require("./fixtures/pull_request_comment.json");
+
+    event.payload.comment.body = "@pytorchbot label 'skip-pr-sanity-check'";
+
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    const pr_number = event.payload.issue.number;
+    const user = event.payload.comment.user.login;
+
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${owner}/${repo}/labels`)
+      .reply(200, existingRepoLabelsResponse)
+      .get(`/repos/${owner}/${repo}/collaborators/${user}/permission`)
+      .reply(200, {
+        permission: "read",
+      })
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          `{"body":"Only people with write access to the repo can add these labels`
+        );
+        return true;
+      })
+      .reply(200, {});
+
+    await probot.receive(event);
+    handleScope(scope);
+  });
+
+  test("label requiring write access with good permissions", async () => {
+    const event = require("./fixtures/pull_request_comment.json");
+
+    event.payload.comment.body = "@pytorchbot label 'skip-pr-sanity-check'";
+
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    const pr_number = event.payload.issue.number;
+    const comment_number = event.payload.comment.id;
+    const user = event.payload.comment.user.login;
+
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${owner}/${repo}/labels`)
+      .reply(200, existingRepoLabelsResponse)
+      .get(`/repos/${owner}/${repo}/collaborators/${user}/permission`)
+      .reply(200, {
+        permission: "write",
+      })
+      .post(
+        `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
+        (body) => {
+          expect(JSON.stringify(body)).toContain('{"content":"+1"}');
+          return true;
+        }
+      )
+      .reply(200, {})
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/labels`, (body) => {
+        expect(JSON.stringify(body)).toContain(`{"labels":["skip-pr-sanity-check"]}`);
+        return true;
+      })
+      .reply(200, {});
+
+    await probot.receive(event);
+    handleScope(scope);
+  });
+
   test("label with ciflow on issue should have no event", async () => {
     const event = require("./fixtures/issue_comment.json");
     event.payload.comment.body = "@pytorchbot label 'ciflow/trunk'";


### PR DESCRIPTION
The `skip-pr-sanity-check` label is meant to skip PR size checks when needed, but it's easy to accidentally abuse it.

Limiting the scope of who can add it to a PR to those with write access