### PR TITLE
[dashboard] Update the export display

### DIFF
--- a/torchci/components/benchmark/compilers/common.tsx
+++ b/torchci/components/benchmark/compilers/common.tsx
@@ -26,6 +26,7 @@ export const COMPILER_NAMES_TO_DISPLAY_NAMES: { [k: string]: string } = {
   inductor_aot_inductor: "aot_inductor",
   inductor_with_cudagraphs_freezing: "cudagraphs_freezing",
   inductor_cudagraphs_low_precision: "cudagraphs_low_precision",
+  inductor_export: "export",
 };
 export const DISPLAY_NAMES_TO_COMPILER_NAMES: { [k: string]: string } = {
   inductor_default: "inductor_no_cudagraphs",
@@ -36,6 +37,7 @@ export const DISPLAY_NAMES_TO_COMPILER_NAMES: { [k: string]: string } = {
   aot_inductor: "inductor_aot_inductor",
   cudagraphs_freezing: "inductor_with_cudagraphs_freezing",
   cudagraphs_low_precision: "inductor_cudagraphs_low_precision",
+  export: "inductor_export",
 };
 export const BLOCKLIST_COMPILERS = ["aot_eager", "eager"];
 export const PASSING_ACCURACY = ["pass", "pass_due_to_skip", "eager_variation"];

--- a/torchci/lib/benchmark/compilerUtils.ts
+++ b/torchci/lib/benchmark/compilerUtils.ts
@@ -102,10 +102,11 @@ export function computePassrate(
 
     // If the model pass accuracy check but fails the performance benchmark with an
     // 0 speedup, it should be counted as a failure. However, `pass_due_to_skip` is
-    // an exception and it's ok to have 0 speedup there
+    // an exception and it's ok to have 0 speedup there, also `export` is an exception
+    // because we only measure its pass rate but not speedup.
     if (
       (isPass(bucket, workflowId, suite, compiler, model, passingModels) &&
-        record.speedup !== 0.0) ||
+        (record.speedup !== 0.0 || compiler === "inductor_export")) ||
       accuracy === "pass_due_to_skip"
     ) {
       passCount[bucket][workflowId][suite][compiler] += 1;


### PR DESCRIPTION
Summary: https://github.com/pytorch/pytorch/pull/134076 adds a dashboard run to collect the pass rate only for torch.export. Update its displayed name here, and also igore the speedup number when counting its pass rate.