### PR TITLE
Remove macos from lintrunner_ci.yml

### DIFF
--- a/.github/workflows/lintrunner_ci.yml
+++ b/.github/workflows/lintrunner_ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest] # TODO: add back macos-latest
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Lintrunner CI / test (macos-latest) has broken for weeks in the "Install and initialize sapling on macos" step. Removing macos to make CI green again.