### PR TITLE
Add montoring for Linux Foundation fleet rollover

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -42,21 +42,21 @@ function MasterCommitRedPanel({
 }) {
   const url = useClickHouse
     ? `/api/clickhouse/master_commit_red?parameters=${encodeURIComponent(
-        JSON.stringify({
-          ...params,
-          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-        })
-      )}`
+      JSON.stringify({
+        ...params,
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      })
+    )}`
     : `/api/query/metrics/master_commit_red?parameters=${encodeURIComponent(
-        JSON.stringify([
-          ...(params as RocksetParam[]),
-          {
-            name: "timezone",
-            type: "string",
-            value: Intl.DateTimeFormat().resolvedOptions().timeZone,
-          },
-        ])
-      )}`;
+      JSON.stringify([
+        ...(params as RocksetParam[]),
+        {
+          name: "timezone",
+          type: "string",
+          value: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        },
+      ])
+    )}`;
 
   const { data } = useSWR(url, fetcher, {
     refreshInterval: 5 * 60 * 1000, // refresh every 5 minutes
@@ -489,15 +489,15 @@ export default function Page() {
   // save CPU usage. This query is quite expensive to run
   const url = useClickHouse
     ? `/api/clickhouse/${queryName}?parameters=${encodeURIComponent(
-        JSON.stringify({
-          ...timeParamsClickHouse,
-          // TODO (huydhn): Figure out a way to have default parameters for ClickHouse queries
-          workflowNames: ["lint", "pull", "trunk"],
-        })
-      )}`
+      JSON.stringify({
+        ...timeParamsClickHouse,
+        // TODO (huydhn): Figure out a way to have default parameters for ClickHouse queries
+        workflowNames: ["lint", "pull", "trunk"],
+      })
+    )}`
     : `/api/query/${queryCollection}/${queryName}?parameters=${encodeURIComponent(
-        JSON.stringify(timeParams)
-      )}`;
+      JSON.stringify(timeParams)
+    )}`;
 
   const { data } = useSWR(url, fetcher, {
     refreshInterval: 5 * 60 * 1000, // refresh every 5 minutes
@@ -915,6 +915,7 @@ export default function Page() {
             yAxisRenderer={(value) => value}
           />
         </Grid>
+
         <JobsDuration
           title={"Job time-to-signal, all branches"}
           branchName={"%"}
@@ -967,8 +968,8 @@ export default function Page() {
                 renderCell: (params: GridRenderCellParams<string>) => {
                   const url = params.value
                     ? `failure?failureCaptures=${encodeURIComponent(
-                        JSON.stringify(params.row.captures)
-                      )}`
+                      JSON.stringify(params.row.captures)
+                    )}`
                     : "failure";
                   return <a href={url}>{params.value}</a>;
                 },
@@ -990,6 +991,78 @@ export default function Page() {
             yAxisFieldName={"number_of_new_disabled_tests"}
             yAxisRenderer={(value) => value}
             additionalOptions={{ yAxis: { scale: true } }}
+          />
+        </Grid>
+
+        <Grid item xs={12}>
+          <br /><br />
+          <Typography variant="h3" gutterBottom>
+            Linux Foundation vs Meta Fleets
+          </Typography>
+          <p>
+            These panels show the <b>delta</b> between states of the same job run on the Linux Foundation and Meta fleets.
+          </p>
+        </Grid>
+
+        <Grid item xs={12} height={ROW_HEIGHT}>
+          <TimeSeriesPanel
+            title={"LF vs Meta: Success rate delta"}
+            queryName={"lf_rollover_health"}
+            queryCollection={"metrics"}
+            queryParams={[]}
+            granularity={"day"}
+            timeFieldName={"bucket"}
+            yAxisLabel={"rate delta"}
+            yAxisFieldName={"success_rate_delta"}
+            yAxisRenderer={(value) => value}
+            groupByFieldName={"job_name"}
+          />
+        </Grid>
+
+        <Grid item xs={12} height={ROW_HEIGHT}>
+          <TimeSeriesPanel
+            title={"LF vs Meta: Failure rate delta"}
+            queryName={"lf_rollover_health"}
+            queryCollection={"metrics"}
+            queryParams={[]}
+            granularity={"day"}
+            timeFieldName={"bucket"}
+            yAxisLabel="rate delta"
+            yAxisFieldName={"failure_rate_delta"}
+            yAxisRenderer={(value) => value}
+            groupByFieldName={"job_name"}
+          />
+        </Grid>
+
+        <Grid item xs={12} height={ROW_HEIGHT}>
+          <TimeSeriesPanel
+            title={"LF vs Meta: Cancelled rate delta"}
+            queryName={"lf_rollover_health"}
+            queryCollection={"metrics"}
+            queryParams={[]}
+            granularity={"day"}
+            timeFieldName={"bucket"}
+            yAxisLabel={"rate delta"}
+            yAxisFieldName={"cancelled_rate_delta"}
+            yAxisRenderer={(value) => value}
+            groupByFieldName={"job_name"}
+          />
+        </Grid>
+
+
+
+        <Grid item xs={12} height={ROW_HEIGHT}>
+          <TimeSeriesPanel
+            title={"LF vs Meta: Duration increase ratio"}
+            queryName={"lf_rollover_health"}
+            queryCollection={"metrics"}
+            queryParams={[]}
+            granularity={"day"}
+            timeFieldName={"bucket"}
+            yAxisLabel="increase ratio"
+            yAxisFieldName={"success_duration_increase_ratio"}
+            yAxisRenderer={(value) => value}
+            groupByFieldName={"job_name"}
           />
         </Grid>
       </Grid>

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -42,21 +42,21 @@ function MasterCommitRedPanel({
 }) {
   const url = useClickHouse
     ? `/api/clickhouse/master_commit_red?parameters=${encodeURIComponent(
-      JSON.stringify({
-        ...params,
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      })
-    )}`
+        JSON.stringify({
+          ...params,
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        })
+      )}`
     : `/api/query/metrics/master_commit_red?parameters=${encodeURIComponent(
-      JSON.stringify([
-        ...(params as RocksetParam[]),
-        {
-          name: "timezone",
-          type: "string",
-          value: Intl.DateTimeFormat().resolvedOptions().timeZone,
-        },
-      ])
-    )}`;
+        JSON.stringify([
+          ...(params as RocksetParam[]),
+          {
+            name: "timezone",
+            type: "string",
+            value: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          },
+        ])
+      )}`;
 
   const { data } = useSWR(url, fetcher, {
     refreshInterval: 5 * 60 * 1000, // refresh every 5 minutes
@@ -489,15 +489,15 @@ export default function Page() {
   // save CPU usage. This query is quite expensive to run
   const url = useClickHouse
     ? `/api/clickhouse/${queryName}?parameters=${encodeURIComponent(
-      JSON.stringify({
-        ...timeParamsClickHouse,
-        // TODO (huydhn): Figure out a way to have default parameters for ClickHouse queries
-        workflowNames: ["lint", "pull", "trunk"],
-      })
-    )}`
+        JSON.stringify({
+          ...timeParamsClickHouse,
+          // TODO (huydhn): Figure out a way to have default parameters for ClickHouse queries
+          workflowNames: ["lint", "pull", "trunk"],
+        })
+      )}`
     : `/api/query/${queryCollection}/${queryName}?parameters=${encodeURIComponent(
-      JSON.stringify(timeParams)
-    )}`;
+        JSON.stringify(timeParams)
+      )}`;
 
   const { data } = useSWR(url, fetcher, {
     refreshInterval: 5 * 60 * 1000, // refresh every 5 minutes
@@ -968,8 +968,8 @@ export default function Page() {
                 renderCell: (params: GridRenderCellParams<string>) => {
                   const url = params.value
                     ? `failure?failureCaptures=${encodeURIComponent(
-                      JSON.stringify(params.row.captures)
-                    )}`
+                        JSON.stringify(params.row.captures)
+                      )}`
                     : "failure";
                   return <a href={url}>{params.value}</a>;
                 },
@@ -995,12 +995,14 @@ export default function Page() {
         </Grid>
 
         <Grid item xs={12}>
-          <br /><br />
+          <br />
+          <br />
           <Typography variant="h3" gutterBottom>
             Linux Foundation vs Meta Fleets
           </Typography>
           <p>
-            These panels show the <b>delta</b> between states of the same job run on the Linux Foundation and Meta fleets.
+            These panels show the <b>delta</b> between states of the same job
+            run on the Linux Foundation and Meta fleets.
           </p>
         </Grid>
 
@@ -1048,8 +1050,6 @@ export default function Page() {
             groupByFieldName={"job_name"}
           />
         </Grid>
-
-
 
         <Grid item xs={12} height={ROW_HEIGHT}>
           <TimeSeriesPanel

--- a/torchci/rockset/metrics/__sql/lf_rollover_health.sql
+++ b/torchci/rockset/metrics/__sql/lf_rollover_health.sql
@@ -1,0 +1,143 @@
+
+WITH normalized_jobs AS (
+  SELECT
+    j.started_at,
+    ROUND(DATE_DIFF('MINUTE', PARSE_TIMESTAMP_ISO8601(j.started_at), PARSE_TIMESTAMP_ISO8601(j.completed_at)), 1) as duration_min,
+    if(
+        strpos(l.label, 'amz2023.') = 0,
+        l.label,
+        CONCAT(
+            substr(l.label, 1, strpos(l.label, 'amz2023.') - 1),
+            substr(l.label, length('amz2023.') + strpos(l.label, 'amz2023.'))
+        )
+    ) as label,
+    REGEXP_EXTRACT(j.name, '([^,]*),?', 1) as job_name, -- remove shard number and label from job names
+    j.workflow_name,
+    j.conclusion,
+      DATE_TRUNC(:granularity, PARSE_TIMESTAMP_ISO8601(j.started_at))
+    AS bucket,
+  FROM
+      commons.workflow_job j
+      CROSS JOIN UNNEST(j.labels as label) as l
+  WHERE 1=1
+    AND j.labels is not NULL
+    AND j._event_time > CURRENT_DATETIME() - DAYS(:days_ago)
+    AND j.status = 'completed'
+    AND l.label != 'self-hosted'
+    AND l.label not like 'lf.c.%'
+    AND l.label not like '%canary%'
+
+), migrated_jobs AS (
+  SELECT DISTINCT
+    j.job_name
+  FROM
+      normalized_jobs j
+  WHERE 1=1
+    AND j.label like 'lf%'
+), comparable_jobs AS (
+      SELECT
+        -- count(*)
+        j.bucket,
+        j.started_at,
+        j.duration_min,-- -- j.completed_at,
+        j.label,
+        j.job_name, -- remove shard number and label from job names
+        j.workflow_name,
+        j.conclusion,
+      FROM
+        normalized_jobs j
+        CROSS JOIN migrated_jobs mj
+      WHERE 1 = 1
+        AND j.job_name = mj.job_name
+        -- AND STRPOS(j.name, mj.job_clean) > 0
+
+), success_stats AS (
+  SELECT
+    bucket,
+    count(*) as group_size,
+    job_name,
+    workflow_name,
+    label,
+    IF(SUBSTR(label, 1, 3) = 'lf.', True, False ) as lf_fleet,
+    SUM(
+        CASE
+            WHEN conclusion = 'success' THEN 1
+            ELSE 0
+        END
+    ) * 100 / (COUNT_IF(conclusion != 'cancelled') + 1) as success_rate, -- plus one is to handle divide by zero errors
+    SUM(
+        CASE
+            WHEN conclusion = 'failure' THEN 1
+            ELSE 0
+        END
+    ) * 100 / (COUNT_IF(conclusion != 'cancelled') + 1) as failure_rate,
+    SUM(
+        CASE
+            WHEN conclusion = 'cancelled' THEN 1
+            ELSE 0
+        END
+    ) * 100 / COUNT(*) as cancelled_rate, -- cancelled rate is calculated over all jobs
+    SUM(
+        CASE
+            WHEN conclusion = 'success' THEN 1
+            ELSE 0
+        END
+    ) as success_count,
+    SUM(
+        CASE
+            WHEN conclusion = 'failure' THEN 1
+            ELSE 0
+        END
+    ) as failure_count,
+    SUM(
+        CASE
+            WHEN conclusion = 'cancelled' THEN 1
+            ELSE 0
+        END
+    ) as cancelled_count,
+    COUNT(*) as total_count,
+    SUM(
+        CASE
+            WHEN conclusion = 'success' THEN duration_min
+            ELSE 0
+        END
+    ) / COUNT(*) as success_avg_duration,
+    SUM(
+        CASE
+            WHEN conclusion = 'failure' THEN duration_min
+            ELSE 0
+        END
+    ) / COUNT(*) as failure_avg_duration,
+    SUM(
+        CASE
+            WHEN conclusion = 'cancelled' THEN duration_min
+            ELSE 0
+        END
+    ) / COUNT(*) as cancelled_avg_duration,
+
+  FROM comparable_jobs
+  GROUP BY
+    bucket, job_name, workflow_name, label
+), comparison_stats AS (
+    SELECT
+        lf.bucket,
+        lf.workflow_name,
+        lf.job_name,
+        lf.group_size as sample_size_lf,
+        m.group_size as sample_size_meta,
+        lf.success_rate - m.success_rate as success_rate_delta,
+        lf.failure_rate - m.failure_rate as failure_rate_delta,
+        lf.cancelled_rate - m.cancelled_rate as cancelled_rate_delta,
+        IF(m.success_avg_duration = 0, 1, ROUND(lf.success_avg_duration * 1.0 / m.success_avg_duration, 2)) as success_duration_increase_ratio,
+    FROM success_stats lf
+    INNER JOIN success_stats m on lf.bucket = m.bucket
+    WHERE 1 = 1
+        AND lf.job_name = m.job_name
+        AND lf.workflow_name = m.workflow_name
+        AND lf.lf_fleet = True
+        AND m.lf_fleet = False
+        AND lf.group_size > 3
+        AND m.group_size > 3
+)
+SELECT * from comparison_stats
+ORDER by bucket desc, job_name desc, success_rate_delta, workflow_name

--- a/torchci/rockset/metrics/lf_rollover_health.lambda.json
+++ b/torchci/rockset/metrics/lf_rollover_health.lambda.json
@@ -1,0 +1,16 @@
+{
+  "sql_path": "__sql/lf_rollover_health.sql",
+  "default_parameters": [
+    {
+      "name": "days_ago",
+      "type": "int",
+      "value": "14"
+    },
+    {
+      "name": "granularity",
+      "type": "string",
+      "value": "day"
+    }
+  ],
+  "description": ""
+}

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -79,7 +79,8 @@
     "workflow_load": "52a630d4c9bacdb1",
     "completed_pr_jobs_aggregate": "7b6b27eeca4dfc6f",
     "get_workers_on_period": "ae5cf853350477c7",
-    "queue_times_historical_pct": "f815ad1732928bb6"
+    "queue_times_historical_pct": "f815ad1732928bb6",
+    "lf_rollover_health": "b3eb4ffc761a224a"
   },
   "inductor": {
     "compilers_benchmark_performance": "442c41fbbc0eb758",


### PR DESCRIPTION
Adds charts that compare stats on jobs when they're run in the Linux Foundation runner fleet vs the Meta runner fleet.

The charts specifically show the difference between the two fleets, not showing absolute values. 

Looking at the charts right now there's a lot of variability in the jobs, both up and down, but mousing over the individual jobs tends to show that the dips in the chart so far tend to be noise that doesn't persist from day to day.

(Unfortunate that the chart runs off over onto the legend.  Seems like there's just a fixed width space for legends and if the legend contains items that are too long then the legend's canvas starts to overlap with the graph canvas)  