### PR TITLE
Enable setup minimum available runners for scale infra

### DIFF
--- a/terraform-aws-github-runner/main.tf
+++ b/terraform-aws-github-runner/main.tf
@@ -127,6 +127,7 @@ module "runners" {
   runner_extra_labels             = var.runner_extra_labels
   idle_config                     = var.idle_config
   secretsmanager_secrets_id       = var.secretsmanager_secrets_id
+  min_available_runners           = var.min_available_runners
 
   lambda_zip                = var.runners_lambda_zip
   lambda_timeout_scale_up   = var.runners_scale_up_lambda_timeout

--- a/terraform-aws-github-runner/modules/runners/scale-down.tf
+++ b/terraform-aws-github-runner/modules/runners/scale-down.tf
@@ -39,13 +39,14 @@ resource "aws_lambda_function" "scale_down" {
       GITHUB_APP_KEY_BASE64           = var.github_app_key_base64
       KMS_KEY_ID                      = var.encryption.kms_key_id
       LAMBDA_TIMEOUT                  = var.lambda_timeout_scale_down
+      MIN_AVAILABLE_RUNNERS           = var.min_available_runners
       MINIMUM_RUNNING_TIME_IN_MINUTES = var.minimum_running_time_in_minutes
       REDIS_ENDPOINT                  = var.redis_endpoint
       REDIS_LOGIN                     = var.redis_login
-      SCALE_DOWN_CONFIG               = jsonencode(var.idle_config)
-      SECRETSMANAGER_SECRETS_ID       = var.secretsmanager_secrets_id
       SCALE_CONFIG_REPO               = var.scale_config_repo
       SCALE_CONFIG_REPO_PATH          = var.scale_config_repo_path
+      SCALE_DOWN_CONFIG               = jsonencode(var.idle_config)
+      SECRETSMANAGER_SECRETS_ID       = var.secretsmanager_secrets_id
       AWS_REGIONS_TO_VPC_IDS = join(
         ",",
         sort(distinct([

--- a/terraform-aws-github-runner/modules/runners/scale-up.tf
+++ b/terraform-aws-github-runner/modules/runners/scale-up.tf
@@ -41,14 +41,15 @@ resource "aws_lambda_function" "scale_up" {
       KMS_KEY_ID                           = var.encryption.kms_key_id
       LAMBDA_TIMEOUT                       = var.lambda_timeout_scale_up
       LAUNCH_TEMPLATE_NAME_LINUX           = var.launch_template_name_linux
-      LAUNCH_TEMPLATE_NAME_LINUX_NVIDIA    = var.launch_template_name_linux_nvidia
       LAUNCH_TEMPLATE_NAME_LINUX_ARM64     = var.launch_template_name_linux_arm64
+      LAUNCH_TEMPLATE_NAME_LINUX_NVIDIA    = var.launch_template_name_linux_nvidia
       LAUNCH_TEMPLATE_NAME_WINDOWS         = var.launch_template_name_windows
       LAUNCH_TEMPLATE_VERSION_LINUX        = var.launch_template_version_linux
-      LAUNCH_TEMPLATE_VERSION_LINUX_NVIDIA = var.launch_template_version_linux_nvidia
       LAUNCH_TEMPLATE_VERSION_LINUX_ARM64  = var.launch_template_version_linux_arm64
+      LAUNCH_TEMPLATE_VERSION_LINUX_NVIDIA = var.launch_template_version_linux_nvidia
       LAUNCH_TEMPLATE_VERSION_WINDOWS      = var.launch_template_version_windows
       MAX_RETRY_SCALEUP_RECORD             = "10"
+      MIN_AVAILABLE_RUNNERS                = var.min_available_runners
       MUST_HAVE_ISSUES_LABELS              = join(",", var.must_have_issues_labels)
       REDIS_ENDPOINT                       = var.redis_endpoint
       REDIS_LOGIN                          = var.redis_login
@@ -56,9 +57,9 @@ resource "aws_lambda_function" "scale_up" {
       RETRY_SCALE_UP_RECORD_JITTER_PCT     = "0.5"
       RETRY_SCALE_UP_RECORD_QUEUE_URL      = var.sqs_build_queue_retry.url
       RUNNER_EXTRA_LABELS                  = var.runner_extra_labels
-      SECRETSMANAGER_SECRETS_ID            = var.secretsmanager_secrets_id
       SCALE_CONFIG_REPO                    = var.scale_config_repo
       SCALE_CONFIG_REPO_PATH               = var.scale_config_repo_path
+      SECRETSMANAGER_SECRETS_ID            = var.secretsmanager_secrets_id
 
       AWS_REGIONS_TO_VPC_IDS = join(
         ",",

--- a/terraform-aws-github-runner/modules/runners/variables.tf
+++ b/terraform-aws-github-runner/modules/runners/variables.tf
@@ -296,3 +296,8 @@ variable "scale_config_repo_path" {
   default     = ""
   type        = string
 }
+
+variable "min_available_runners" {
+  description = "Minimum number of runners to keep available."
+  type        = number
+}

--- a/terraform-aws-github-runner/variables.tf
+++ b/terraform-aws-github-runner/variables.tf
@@ -356,3 +356,9 @@ variable "scale_config_repo_path" {
   default     = "" # Internally defaults to '.github/scale-config.yml'
   type        = string
 }
+
+variable "min_available_runners" {
+  description = "Minimum number of runners to keep available."
+  type        = number
+  default     = 10
+}


### PR DESCRIPTION
adds `min_available_runners` terraform config to setup environment variable `MIN_AVAILABLE_RUNNERS` on scale lambdas