### PR TITLE
Allow setting minimum available runners to 0

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/config.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/config.ts
@@ -78,7 +78,7 @@ export class Config {
     /* istanbul ignore next */
     const mnAvalRuns = Number(process.env.MIN_AVAILABLE_RUNNERS || '10');
     /* istanbul ignore next */
-    this.minAvailableRunners = mnAvalRuns > 0 ? mnAvalRuns : 1;
+    this.minAvailableRunners = mnAvalRuns >= 0 ? mnAvalRuns : 0;
     /* istanbul ignore next */
     const mnRunMin = Number(process.env.MINIMUM_RUNNING_TIME_IN_MINUTES || '60');
     /* istanbul ignore next */

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -236,11 +236,13 @@ async function allRunnersBusy(
 
   // Have a fail safe just in case we're likely to need more runners
   const availableCount = runnersWithLabel.length - busyCount;
-  if (availableCount < Config.Instance.minAvailableRunners) {
-    console.info(`Available (${availableCount}) runners is bellow minimum ${Config.Instance.minAvailableRunners}`);
+  // Min runners for scale-up must be at least 1 otherwise scale-up won't ever increase runners
+  const minRunners = Config.Instance.minAvailableRunners > 0 ? Config.Instance.minAvailableRunners : 1;
+  if (availableCount < minRunners) {
+    console.info(`Available (${availableCount}) runners is below minimum ${minRunners}`);
     // It is impossible to accumulate runners if we know that the one we're creating will be terminated.
     if (isEphemeral) {
-      const ratio: number = availableCount / (Config.Instance.minAvailableRunners * 1.5);
+      const ratio: number = availableCount / (minRunners * 1.5);
       return Math.random() < ratio ? 3 : 1;
     } else {
       return 1;


### PR DESCRIPTION
This change modifies the check to allow the minimum available runners setting to be 0 while keeping the default value to 10. The sanity check to ensure that at least a positive number is used remains. If an invalid number is passed then the setting is assumed to be 0.

Scale-up function however requires a minimum of at least 1 to be able
to do its calculations on how many runners to scale up. A value of 0
here breaks the logic and causes the function to never create any runners.
So logic is added here to ensure that scale-up's min value is 1.

Issue: https://lf-pytorch.atlassian.net/browse/PC-33