### PR TITLE
[ez][hud][ch] Fix numbers being converted to strings

### DIFF
--- a/torchci/lib/clickhouse.ts
+++ b/torchci/lib/clickhouse.ts
@@ -23,6 +23,7 @@ export async function queryClickhouse(
     query,
     format: "JSONEachRow",
     query_params: params,
+    clickhouse_settings: { output_format_json_quote_64bit_integers: 0 },
   });
 
   return (await res.json()) as any[];


### PR DESCRIPTION
Fixes the issue discussed here https://github.com/pytorch/test-infra/pull/5566#discussion_r1722707100 (ints being converted to string by json)

The behavior is documented here: https://clickhouse.com/docs/en/integrations/language-clients/javascript#integral-types-int64-int128-int256-uint64-uint128-uint256

It is to protect against some datatypes being larger than Number.MAX_SAFE_INTEGER, but this value is 9007199254740991 (2^53 - 1) which is pretty large

Testing out ghstack --direct again