### PR TITLE
[ez] Exclude check-labels job from flakiness

### DIFF
--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -40,6 +40,7 @@ export const EXCLUDED_FROM_FLAKINESS = [
   "pr-sanity-checks",
   // TODO (huydhn): Figure out a way to do flaky check accurately for build jobs
   "/ build",
+  "check-labels",
 ];
 // If the base commit is too old, don't query for similar failures because
 // it increases the risk of getting misclassification. This guardrail can


### PR DESCRIPTION
Currently Dr.CI marks this signal as flaky ([example](https://github.com/pytorch/pytorch/pull/133896#issuecomment-2297445921)).