### PR TITLE
add dynamo tables to terraform (prep for backup)

### DIFF
--- a/terraform-aws-github-runner/dynamodb.tf
+++ b/terraform-aws-github-runner/dynamodb.tf
@@ -1,0 +1,183 @@
+resource "aws_dynamodb_table" "pytorchbot-logs" {
+    name           = "pytorchbot-logs"
+    hash_key = "dynamoKey"
+    billing_mode   = "PROVISIONED"
+    read_capacity = 1
+    write_capacity = 1
+    stream_enabled = true
+    stream_view_type = "NEW_AND_OLD_IMAGES"
+    attribute {
+        name = "dynamoKey"
+        type = "S"
+    }
+}
+
+resource "aws_dynamodb_table" "torchci-dynamo-perf-stats" {
+    name           = "torchci-dynamo-perf-stats"
+    hash_key = "dynamoKey"
+    billing_mode   = "PAY_PER_REQUEST"
+    stream_enabled = true
+    stream_view_type = "NEW_AND_OLD_IMAGES"
+    attribute {
+        name = "dynamoKey"
+        type = "S"
+    }
+}
+
+resource "aws_dynamodb_table" "torchci-issue-comment" {
+    name           = "torchci-issue-comment"
+    hash_key = "dynamoKey"
+    billing_mode   = "PAY_PER_REQUEST"
+    stream_enabled = true
+    stream_view_type = "NEW_AND_OLD_IMAGES"
+    attribute {
+        name = "dynamoKey"
+        type = "S"
+    }
+}
+
+resource "aws_dynamodb_table" "torchci-issues" {
+    name           = "torchci-issues"
+    hash_key = "dynamoKey"
+    billing_mode   = "PAY_PER_REQUEST"
+    stream_enabled = true
+    stream_view_type = "NEW_AND_OLD_IMAGES"
+    attribute {
+        name = "dynamoKey"
+        type = "S"
+    }
+}
+
+resource "aws_dynamodb_table" "torchci-job-annotation" {
+    name           = "torchci-job-annotation"
+    hash_key = "dynamoKey"
+    billing_mode   = "PAY_PER_REQUEST"
+    stream_enabled = true
+    stream_view_type = "NEW_AND_OLD_IMAGES"
+    attribute {
+        name = "dynamoKey"
+        type = "S"
+    }
+}
+
+resource "aws_dynamodb_table" "torchci-metrics" {
+    name           = "torchci-metrics"
+    hash_key = "dynamo_key"
+    range_key = "metrics_name"
+    billing_mode   = "PAY_PER_REQUEST"
+    stream_enabled = true
+    stream_view_type = "NEW_AND_OLD_IMAGES"
+    attribute {
+        name = "dynamo_key"
+        type = "S"
+    }
+    attribute {
+        name = "metrics_name"
+        type = "S"
+    }
+}
+
+resource "aws_dynamodb_table" "torchci-metrics-ci-wait-time" {
+    name           = "torchci-metrics-ci-wait-time"
+    hash_key = "dynamoKey"
+    billing_mode   = "PROVISIONED"
+    read_capacity = 1
+    write_capacity = 1
+    stream_enabled = true
+    stream_view_type = "NEW_AND_OLD_IMAGES"
+    attribute {
+        name = "dynamoKey"
+        type = "S"
+    }
+}
+
+resource "aws_dynamodb_table" "torchci-oss-ci-benchmark" {
+    name           = "torchci-oss-ci-benchmark"
+    hash_key = "dynamoKey"
+    billing_mode   = "PAY_PER_REQUEST"
+    stream_enabled = true
+    stream_view_type = "NEW_AND_OLD_IMAGES"
+    attribute {
+        name = "dynamoKey"
+        type = "S"
+    }
+}
+
+resource "aws_dynamodb_table" "torchci-pull-request" {
+    name           = "torchci-pull-request"
+    hash_key = "dynamoKey"
+    billing_mode   = "PAY_PER_REQUEST"
+    stream_enabled = true
+    stream_view_type = "NEW_AND_OLD_IMAGES"
+    attribute {
+        name = "dynamoKey"
+        type = "S"
+    }
+}
+
+resource "aws_dynamodb_table" "torchci-pull-request-review" {
+    name           = "torchci-pull-request-review"
+    hash_key = "dynamoKey"
+    billing_mode   = "PAY_PER_REQUEST"
+    stream_enabled = true
+    stream_view_type = "NEW_AND_OLD_IMAGES"
+    attribute {
+        name = "dynamoKey"
+        type = "S"
+    }
+}
+
+resource "aws_dynamodb_table" "torchci-pull-request-review-comment" {
+    name           = "torchci-pull-request-review-comment"
+    hash_key = "dynamoKey"
+    billing_mode   = "PAY_PER_REQUEST"
+    stream_enabled = true
+    stream_view_type = "NEW_AND_OLD_IMAGES"
+    attribute {
+        name = "dynamoKey"
+        type = "S"
+    }
+}
+
+resource "aws_dynamodb_table" "torchci-push" {
+    name           = "torchci-push"
+    hash_key = "dynamoKey"
+    billing_mode   = "PAY_PER_REQUEST"
+    stream_enabled = true
+    stream_view_type = "NEW_AND_OLD_IMAGES"
+    attribute {
+        name = "dynamoKey"
+        type = "S"
+    }
+}
+
+resource "aws_dynamodb_table" "torchci-retry-bot" {
+    name           = "torchci-retry-bot"
+    hash_key = "dynamoKey"
+    billing_mode   = "PAY_PER_REQUEST"
+    stream_enabled = true
+    stream_view_type = "NEW_AND_OLD_IMAGES"
+    attribute {
+        name = "dynamoKey"
+        type = "S"
+    }
+}
+
+resource "aws_dynamodb_table" "torchci-tutorial-filenames" {
+    name           = "torchci-tutorial-filenames"
+    hash_key = "commit_id"
+    range_key = "filename"
+    billing_mode   = "PROVISIONED"
+    read_capacity = 10
+    write_capacity = 10
+    stream_enabled = true
+    stream_view_type = "NEW_AND_OLD_IMAGES"
+    attribute {
+        name = "commit_id"
+        type = "S"
+    }
+    attribute {
+        name = "filename"
+        type = "S"
+    }
+}

--- a/terraform-aws-github-runner/dynamodb.tf
+++ b/terraform-aws-github-runner/dynamodb.tf
@@ -181,3 +181,80 @@ resource "aws_dynamodb_table" "torchci-tutorial-filenames" {
         type = "S"
     }
 }
+
+resource "aws_dynamodb_table" "torchci-tutorial-metadata" {
+    name           = "torchci-tutorial-metadata"
+    hash_key = "commit_id"
+    range_key = "date"
+    billing_mode   = "PROVISIONED"
+    read_capacity = 10
+    write_capacity = 10
+    stream_enabled = true
+    stream_view_type = "NEW_AND_OLD_IMAGES"
+    attribute {
+        name = "commit_id"
+        type = "S"
+    }
+    attribute {
+        name = "date"
+        type = "S"
+    }
+}
+
+resource "aws_dynamodb_table" "torchci-workflow-job" {
+    name           = "torchci-workflow-job"
+    hash_key = "dynamoKey"
+    billing_mode   = "PAY_PER_REQUEST"
+    stream_enabled = true
+    stream_view_type = "NEW_AND_OLD_IMAGES"
+    attribute {
+        name = "dynamoKey"
+        type = "S"
+    }
+}
+
+resource "aws_dynamodb_table" "torchci-workflow-run" {
+    name           = "torchci-workflow-run"
+    hash_key = "dynamoKey"
+    billing_mode   = "PAY_PER_REQUEST"
+    stream_enabled = true
+    stream_view_type = "NEW_AND_OLD_IMAGES"
+    attribute {
+        name = "dynamoKey"
+        type = "S"
+    }
+}
+
+resource "aws_dynamodb_table" "trymerge_event" {
+    name           = "trymerge_event"
+    hash_key = "dynamoKey"
+    range_key = "timestamp"
+    billing_mode   = "PAY_PER_REQUEST"
+    stream_enabled = true
+    stream_view_type = "NEW_AND_OLD_IMAGES"
+    attribute {
+        name = "dynamoKey"
+        type = "S"
+    }
+    attribute {
+        name = "timestamp"
+        type = "N"
+    }
+}
+
+resource "aws_dynamodb_table" "trymerge_event_comment" {
+    name           = "trymerge_event_comment"
+    hash_key = "dynamoKey"
+    range_key = "timestamp"
+    billing_mode   = "PAY_PER_REQUEST"
+    stream_enabled = true
+    stream_view_type = "NEW_AND_OLD_IMAGES"
+    attribute {
+        name = "dynamoKey"
+        type = "S"
+    }
+    attribute {
+        name = "timestamp"
+        type = "N"
+    }
+}


### PR DESCRIPTION
Goal is to have the tables in terraform, but also enable backups (Point-in-time recovery (PITR)) for all tables in a next commit

need to import:

```
#!/bin/bash
# Set the AWS region and account ID
REGION=us-east-1
ACCOUNT_ID=308535385114
# Get the list of ARNs for DynamoDB tables in the account and region
TABLE_NAMES=$(aws dynamodb list-tables --region $REGION  --output text)
# Loop over the ARN list and import each table
while IFS= read -r line || [[ -n "$line" ]]; do

    echo $line
    ARN=$(echo "$line" | sed -E "s/^TABLENAMES[[:blank:]]+(.*)/arn:aws:dynamodb:$REGION:$ACCOUNT_ID:table\/\1\n/")

    TABLE_NAME=$(echo $ARN | cut -d '/' -f 2)
    # if line contains terraform-state, skip it
    if [[ $TABLE_NAME == *"terraform-state"* ]]; then
        echo "Skipping $TABLE_NAME"
        continue
    fi
    echo "Importing $TABLE_NAME with ARN $ARN"

    terraform import aws_dynamodb_table.$TABLE_NAME $ARN

    exit 0
done <<< "$TABLE_NAMES"

```