### PR TITLE
[ez] Exclude Check labels job from flakiness (attempt 2)

### DIFF
--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -40,7 +40,7 @@ export const EXCLUDED_FROM_FLAKINESS = [
   "pr-sanity-checks",
   // TODO (huydhn): Figure out a way to do flaky check accurately for build jobs
   "/ build",
-  "check-labels",
+  "Check labels",
 ];
 // If the base commit is too old, don't query for similar failures because
 // it increases the risk of getting misclassification. This guardrail can


### PR DESCRIPTION
Related to #5611 

apparently flakiness exclusions use job name instead of id