### PR TITLE
Make Nova build job timeout parameter configurable

### DIFF
--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -59,6 +59,10 @@ on:
         description: "The key created when saving a cache and the key used to search for a cache."
         default: ""
         type: string
+      timeout:
+        description: 'Timeout for the job (in minutes)'
+        default: 60
+        type: number
     secrets:
       CONDA_PYTORCHBOT_TOKEN:
         description: "Access Token needed to upload binaries to anaconda nightly channel"
@@ -86,7 +90,7 @@ jobs:
       options: ${{ matrix.gpu_arch_type == 'cuda' && '--gpus all' || ' ' }}
     # If a build is taking longer than 60 minutes on these runners we need
     # to have a conversation
-    timeout-minutes: 60
+    timeout-minutes: ${{ inputs.timeout }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -63,6 +63,10 @@ on:
         description: "The key created when saving a cache and the key used to search for a cache."
         default: ""
         type: string
+      timeout:
+        description: 'Timeout for the job (in minutes)'
+        default: 60
+        type: number
     secrets:
       CONDA_PYTORCHBOT_TOKEN:
         description: "Access Token needed to upload binaries to anaconda nightly channel"
@@ -87,7 +91,7 @@ jobs:
     runs-on: ${{ inputs.runner-type }}
     # If a build is taking longer than 60 minutes on these runners we need
     # to have a conversation
-    timeout-minutes: 60
+    timeout-minutes: ${{ inputs.timeout }}
     steps:
       - name: Clean workspace
         run: |

--- a/.github/workflows/build_conda_windows.yml
+++ b/.github/workflows/build_conda_windows.yml
@@ -59,6 +59,10 @@ on:
         description: "The key created when saving a cache and the key used to search for a cache."
         default: ""
         type: string
+      timeout:
+        description: 'Timeout for the job (in minutes)'
+        default: 60
+        type: number
     secrets:
       CONDA_PYTORCHBOT_TOKEN:
         description: "Access Token needed to upload binaries to anaconda nightly channel"
@@ -86,7 +90,7 @@ jobs:
         shell: bash -l {0}
     # If a build is taking longer than 60 minutes on these runners we need
     # to have a conversation
-    timeout-minutes: 60
+    timeout-minutes: ${{ inputs.timeout }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -97,6 +97,10 @@ on:
         required: false
         default: ""
         type: string
+      timeout:
+        description: 'Timeout for the job (in minutes)'
+        default: 120
+        type: number
     secrets:
       PYPI_API_TOKEN:
         description: An optional token to upload to pypi
@@ -124,9 +128,7 @@ jobs:
     container:
       image: ${{ matrix.container_image }}
       options: ${{ matrix.gpu_arch_type == 'cuda' && '--gpus all' || ' ' }}
-    # If a build is taking longer than 60 minutes on these runners we need
-    # to have a conversation
-    timeout-minutes: 120
+    timeout-minutes: ${{ inputs.timeout }}
     steps:
       - name: Clean workspace
         shell: bash -l {0}

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -69,6 +69,10 @@ on:
         required: false
         type: boolean
         default: true
+      timeout:
+        description: 'Timeout for the job (in minutes)'
+        default: 60
+        type: number
 
 permissions:
   id-token: write
@@ -89,7 +93,7 @@ jobs:
     runs-on: ${{ inputs.runner-type }}
     # If a build is taking longer than 60 minutes on these runners we need
     # to have a conversation
-    timeout-minutes: 60
+    timeout-minutes: ${{ inputs.timeout }}
     steps:
       - name: Clean workspace
         run: |

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -64,6 +64,10 @@ on:
         required: false
         type: string
         default: recursive
+      timeout:
+        description: 'Timeout for the job (in minutes)'
+        default: 60
+        type: number
 
 permissions:
   id-token: write
@@ -88,7 +92,7 @@ jobs:
         shell: bash -l {0}
     # If a build is taking longer than 60 minutes on these runners we need
     # to have a conversation
-    timeout-minutes: 60
+    timeout-minutes: ${{ inputs.timeout }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
TSIA.  This is a request from fbgemm in which their Linux CUDA build jobs is too close to the 120 minutes threshold and frequently timeout, i.e. https://github.com/pytorch/FBGEMM/actions/runs/10772363019/job/29869849673