### PR TITLE
Add arch to the device type on LLMs benchmark dashboard

### DIFF
--- a/torchci/components/benchmark/llms/ModelGraphPanel.tsx
+++ b/torchci/components/benchmark/llms/ModelGraphPanel.tsx
@@ -93,7 +93,7 @@ export function GraphPanel({
         return (
           record.name === modelName &&
           (record.dtype === dtypeName || dtypeName === DEFAULT_DTYPE_NAME) &&
-          (record.device === deviceName ||
+          (`${record.device} (${record.arch})` === deviceName ||
             deviceName === DEFAULT_DEVICE_NAME) &&
           record.metric === metric
         );
@@ -102,7 +102,8 @@ export function GraphPanel({
         const id = record.workflow_id;
         return (
           (id >= lWorkflowId && id <= rWorkflowId) ||
-          (id <= lWorkflowId && id >= rWorkflowId)
+          (id <= lWorkflowId && id >= rWorkflowId) ||
+          (lWorkflowId === undefined && rWorkflowId === undefined)
         );
       })
       .map((record: LLMsBenchmarkData) => {

--- a/torchci/components/benchmark/llms/SummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/SummaryPanel.tsx
@@ -2,7 +2,6 @@ import { Grid } from "@mui/material";
 import { GridCellParams, GridRenderCellParams } from "@mui/x-data-grid";
 import {
   BranchAndCommitPerfData,
-  IS_INCREASING_METRIC_VALUE_GOOD,
   METRIC_DISPLAY_HEADERS,
   RELATIVE_THRESHOLD,
 } from "components/benchmark/llms/common";
@@ -137,18 +136,14 @@ export function SummaryPanel({
                       return styles.error;
                     }
 
-                    // Higher value
+                    // Higher TPS
                     if (r - l > RELATIVE_THRESHOLD * l) {
-                      return IS_INCREASING_METRIC_VALUE_GOOD[metric]
-                        ? styles.ok
-                        : styles.error;
+                      styles.ok;
                     }
 
-                    // Lower value
+                    // Lower TPS
                     if (l - r > RELATIVE_THRESHOLD * r) {
-                      return IS_INCREASING_METRIC_VALUE_GOOD[metric]
-                        ? styles.error
-                        : styles.ok;
+                      styles.error;
                     }
                   }
 

--- a/torchci/components/benchmark/llms/SummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/SummaryPanel.tsx
@@ -138,12 +138,12 @@ export function SummaryPanel({
 
                     // Higher TPS
                     if (r - l > RELATIVE_THRESHOLD * l) {
-                      styles.ok;
+                      return styles.ok;
                     }
 
                     // Lower TPS
                     if (l - r > RELATIVE_THRESHOLD * r) {
-                      styles.error;
+                      return styles.error;
                     }
                   }
 

--- a/torchci/components/benchmark/llms/common.tsx
+++ b/torchci/components/benchmark/llms/common.tsx
@@ -9,6 +9,15 @@ export const METRIC_DISPLAY_HEADERS: { [k: string]: string } = {
   flops_utilization: "FLOPs utilization",
   "compilation_time(s)": "Compilation Time (s)",
 };
+// The variable name is a bit dumb, but it tells if a higher metric value
+// is good or bad so that we can highlight it on the dashboard accordingly.
+// For example, higher TPS is good while higher compilation time isn't
+export const IS_INCREASING_METRIC_VALUE_GOOD: { [k: string]: boolean } = {
+  "memory_bandwidth(GB/s)": true,
+  token_per_sec: true,
+  flops_utilization: true,
+  "compilation_time(s)": false,
+};
 export const METRIC_DISPLAY_SHORT_HEADERS: { [k: string]: string } = {
   "memory_bandwidth(GB/s)": "Bandwidth",
   token_per_sec: "TPS",
@@ -31,6 +40,7 @@ export interface LLMsBenchmarkData {
   target: number;
   dtype: string;
   device: string;
+  arch: string;
   display?: string;
 }
 

--- a/torchci/components/benchmark/llms/common.tsx
+++ b/torchci/components/benchmark/llms/common.tsx
@@ -9,15 +9,6 @@ export const METRIC_DISPLAY_HEADERS: { [k: string]: string } = {
   flops_utilization: "FLOPs utilization",
   "compilation_time(s)": "Compilation Time (s)",
 };
-// The variable name is a bit dumb, but it tells if a higher metric value
-// is good or bad so that we can highlight it on the dashboard accordingly.
-// For example, higher TPS is good while higher compilation time isn't
-export const IS_INCREASING_METRIC_VALUE_GOOD: { [k: string]: boolean } = {
-  "memory_bandwidth(GB/s)": true,
-  token_per_sec: true,
-  flops_utilization: true,
-  "compilation_time(s)": false,
-};
 export const METRIC_DISPLAY_SHORT_HEADERS: { [k: string]: string } = {
   "memory_bandwidth(GB/s)": "Bandwidth",
   token_per_sec: "TPS",

--- a/torchci/pages/benchmark/llms.tsx
+++ b/torchci/pages/benchmark/llms.tsx
@@ -262,6 +262,11 @@ export default function Page() {
       type: "string",
       value: repoName,
     },
+    {
+      name: "deviceArch",
+      type: "string",
+      value: deviceName === DEFAULT_DEVICE_NAME ? "" : deviceName,
+    },
   ];
 
   const url = `/api/query/${queryCollection}/${queryName}?parameters=${encodeURIComponent(
@@ -281,7 +286,7 @@ export default function Page() {
   ];
   const deviceNames: string[] = [
     DEFAULT_DEVICE_NAME,
-    ...(_.uniq(data.map((r: any) => r.device)) as string[]),
+    ...(_.uniq(data.map((r: any) => `${r.device} (${r.arch})`)) as string[]),
   ];
   const dtypeNames: string[] = [
     DEFAULT_DTYPE_NAME,

--- a/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_branches.sql
+++ b/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_branches.sql
@@ -21,6 +21,18 @@ WHERE
     )
     OR : filenames = ''
   )
+  -- NB: DEVICE (ARCH) is the display format used by HUD when grouping together these two fields
+  AND (
+    FORMAT(
+      '{} ({})',
+      o.device,
+      IF(
+        o.arch IS NULL, 'NVIDIA A100-SXM4-40GB',
+        o.arch
+      )
+    ) = : deviceArch
+    OR : deviceArch = ''
+  )
   AND o.metric IS NOT NULL
   AND w.html_url LIKE CONCAT('%', : repo, '%')
   AND o.dtype IS NOT NULL

--- a/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_names.sql
+++ b/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_names.sql
@@ -5,6 +5,8 @@ SELECT DISTINCT
   o.metric,
   o.dtype,
   o.device,
+  -- NB: Default to NVIDIA A100-SXM4-40GB for old records without arch column
+  IF(o.arch IS NULL, 'NVIDIA A100-SXM4-40GB', o.arch) as arch,
 FROM
   benchmarks.oss_ci_benchmark_v2 o
   LEFT JOIN commons.workflow_run w ON o.workflow_id = w.id

--- a/torchci/rockset/benchmarks/oss_ci_benchmark_branches.lambda.json
+++ b/torchci/rockset/benchmarks/oss_ci_benchmark_branches.lambda.json
@@ -2,6 +2,11 @@
   "sql_path": "__sql/oss_ci_benchmark_branches.sql",
   "default_parameters": [
     {
+      "name": "deviceArch",
+      "type": "string",
+      "value": ""
+    },
+    {
       "name": "filenames",
       "type": "string",
       "value": ""

--- a/torchci/rockset/benchmarks/oss_ci_benchmark_llms.lambda.json
+++ b/torchci/rockset/benchmarks/oss_ci_benchmark_llms.lambda.json
@@ -12,7 +12,7 @@
       "value": ""
     },
     {
-      "name": "devices",
+      "name": "deviceArch",
       "type": "string",
       "value": ""
     },

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -108,8 +108,8 @@
     "validation_jobs_red_past_day": "aecb798a574ba2ff"
   },
   "benchmarks": {
-    "oss_ci_benchmark_llms": "05d3fff964c653ac",
-    "oss_ci_benchmark_branches": "3514932f2b980b56",
-    "oss_ci_benchmark_names": "f2c65d404a4262ab"
+    "oss_ci_benchmark_llms": "ec0dd4a03918ba0f",
+    "oss_ci_benchmark_branches": "c23c2d736b13edd4",
+    "oss_ci_benchmark_names": "80824879afbc1c5b"
   }
 }


### PR DESCRIPTION
With https://github.com/pytorch/pytorch/pull/135042, there is now information about the device arch from the benchmark to separate different CUDA or CPU types.  Instead of showing device like CUDA, we need to be more specific, for example:

* cpu (x86_64)
* cpu (arm64)
* cuda (NVIDIA A100-SXM4-40GB)

### Testing

https://torchci-git-fork-huydhn-add-cpu-device-llm-a5f029-fbopensource.vercel.app/benchmark/llms shows different devices and their archs.

