### PR TITLE
Fix the wrong compilation time highlight on LLMs benchmark dashboard

### DIFF
--- a/torchci/components/benchmark/llms/SummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/SummaryPanel.tsx
@@ -2,6 +2,7 @@ import { Grid } from "@mui/material";
 import { GridCellParams, GridRenderCellParams } from "@mui/x-data-grid";
 import {
   BranchAndCommitPerfData,
+  IS_INCREASING_METRIC_VALUE_GOOD,
   METRIC_DISPLAY_HEADERS,
   RELATIVE_THRESHOLD,
 } from "components/benchmark/llms/common";
@@ -132,14 +133,18 @@ export function SummaryPanel({
                       return styles.error;
                     }
 
-                    // Higher TPS
+                    // Higher value
                     if (r - l > RELATIVE_THRESHOLD * l) {
-                      return styles.ok;
+                      return IS_INCREASING_METRIC_VALUE_GOOD[metric]
+                        ? styles.ok
+                        : styles.error;
                     }
 
-                    // Lower TPS
+                    // Lower value
                     if (l - r > RELATIVE_THRESHOLD * r) {
-                      return styles.error;
+                      return IS_INCREASING_METRIC_VALUE_GOOD[metric]
+                        ? styles.error
+                        : styles.ok;
                     }
                   }
 

--- a/torchci/components/benchmark/llms/common.tsx
+++ b/torchci/components/benchmark/llms/common.tsx
@@ -9,6 +9,15 @@ export const METRIC_DISPLAY_HEADERS: { [k: string]: string } = {
   flops_utilization: "FLOPs utilization",
   "compilation_time(s)": "Compilation Time (s)",
 };
+// The variable name is a bit dumb, but it tells if a higher metric value
+// is good or bad so that we can highlight it on the dashboard accordingly.
+// For example, higher TPS is good while higher compilation time isn't
+export const IS_INCREASING_METRIC_VALUE_GOOD: { [k: string]: boolean } = {
+  "memory_bandwidth(GB/s)": true,
+  token_per_sec: true,
+  flops_utilization: true,
+  "compilation_time(s)": false,
+};
 export const METRIC_DISPLAY_SHORT_HEADERS: { [k: string]: string } = {
   "memory_bandwidth(GB/s)": "Bandwidth",
   token_per_sec: "TPS",


### PR DESCRIPTION
A quick fix to address the wrong compilation time highlight on LLMs benchmark dashboard.  We need a way to tell if a higher metric value is good or bad so that we can highlight it on the dashboard accordingly.  For example, higher TPS is good while higher compilation time isn't.