### PR TITLE
Add metric for GitHub API Rate Limit

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
@@ -514,3 +514,13 @@ export async function createRegistrationTokenOrg(
     throw e;
   }
 }
+
+export async function getGitHubRateLimit(installationId: number, metrics: Metrics): Promise<void> {
+  const ghAuth = await createGithubAuth(installationId, 'installation', Config.Instance.ghesUrlApi, metrics);
+  const githubInstallationClient = await createOctoClient(ghAuth, Config.Instance.ghesUrl);
+  const rateLimit = await githubInstallationClient.rateLimit.get();
+  const limit = Number(rateLimit.headers['x-ratelimit-limit']);
+  const remaining = Number(rateLimit.headers['x-ratelimit-remaining']);
+  const used = Number(rateLimit.headers['x-ratelimit-used']);
+  metrics.getGitHubRateLimit(limit, remaining, used);
+}

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/metrics.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/metrics.ts
@@ -242,8 +242,23 @@ export class Metrics {
 
   // GitHub API CALLS
   /* istanbul ignore next */
-  getGitHubRateLimit(limit: number, remaining: number, used: number) {
+  getGitHubRateLimitSuccess(ms: number) {
     this.countEntry(`gh.calls.total`, 1);
+    this.countEntry(`gh.calls.getGitHubRateLimit.count`, 1);
+    this.countEntry(`gh.calls.getGitHubRateLimit.success`, 1);
+    this.countEntry(`gh.calls.getGitHubRateLimit.wallclock`, ms);
+  }
+
+  /* istanbul ignore next */
+  getGitHubRateLimitFailure(ms: number) {
+    this.countEntry(`gh.calls.total`, 1);
+    this.countEntry(`gh.calls.getGitHubRateLimit.count`, 1);
+    this.countEntry(`gh.calls.getGitHubRateLimit.failure`, 1);
+    this.countEntry(`gh.calls.getGitHubRateLimit.wallclock`, ms);
+  }
+
+  /* istanbul ignore next */
+  gitHubRateLimitStats(limit: number, remaining: number, used: number) {
     this.addEntry(`gh.calls.ratelimit.limit`, limit);
     this.addEntry(`gh.calls.ratelimit.remaining`, remaining);
     this.addEntry(`gh.calls.ratelimit.used`, used);

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/metrics.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/metrics.ts
@@ -242,6 +242,14 @@ export class Metrics {
 
   // GitHub API CALLS
   /* istanbul ignore next */
+  getGitHubRateLimit(limit: number, remaining: number, used: number) {
+    this.countEntry(`gh.calls.total`, 1);
+    this.addEntry(`gh.calls.ratelimit.limit`, limit);
+    this.addEntry(`gh.calls.ratelimit.remaining`, remaining);
+    this.addEntry(`gh.calls.ratelimit.used`, used);
+  }
+
+  /* istanbul ignore next */
   createAppAuthGHCallSuccess(ms: number) {
     this.countEntry(`gh.calls.total`, 1);
     this.countEntry(`gh.calls.createAppAuth.count`, 1);

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -54,7 +54,8 @@ export async function scaleUp(
 
   metrics.runRepo(repo);
   metrics.run();
-  getGitHubRateLimit(Number(payload.installationId), metrics);
+
+  getGitHubRateLimit(repo, Number(payload.installationId), metrics);
 
   const runnerTypes = await getRunnerTypes(
     {

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -7,6 +7,7 @@ import {
   getRunnerTypes,
   listGithubRunnersOrg,
   listGithubRunnersRepo,
+  getGitHubRateLimit,
 } from './gh-runners';
 
 import { Config } from './config';
@@ -53,6 +54,7 @@ export async function scaleUp(
 
   metrics.runRepo(repo);
   metrics.run();
+  getGitHubRateLimit(Number(payload.installationId), metrics);
 
   const runnerTypes = await getRunnerTypes(
     {


### PR DESCRIPTION
This captures the rate limit values from GitHub for the ALI account user/process. We can use this to graph and track how much of the API rate limit is used by the CI infrastructure and flag when we are getting too close to the overall limit.

Closes: pytorch/ci-infra#273