### PR TITLE
[inductor] add bot to trigger inductor workflows

### DIFF
--- a/torchci/lib/bot/triggerInductorTestsBot.ts
+++ b/torchci/lib/bot/triggerInductorTestsBot.ts
@@ -1,0 +1,32 @@
+import { Context, Probot } from "probot";
+
+export default function triggerInductorTestsBot(app: Probot): void {
+  const preapprovedUsers = ["pytorchbot", "PaliC"]; // List of preapproved users
+  const preapprovedRepos = ["malfet/deleteme"]; // List of preapproved orgs/repos
+
+  app.on(
+    ["issue_comment.created"],
+    async (ctx: Context<"issue_comment.created">) => {
+      const commentBody = ctx.payload.comment.body.toLowerCase();
+      const commenter = ctx.payload.comment.user.login;
+      const orgRepo = `${ctx.payload.repository.owner.login}/${ctx.payload.repository.name}`;
+
+      if (
+        commentBody.includes("trigger inductor tests") &&
+        preapprovedUsers.includes(commenter) &&
+        preapprovedRepos.includes(orgRepo)
+      ) {
+        const owner = ctx.payload.repository.owner.login;
+        const repo = ctx.payload.repository.name;
+        const issue_number = ctx.payload.issue.number;
+
+        await ctx.octokit.issues.createComment({
+          owner,
+          repo,
+          issue_number,
+          body: "Inductor tests triggered",
+        });
+      }
+    }
+  );
+}

--- a/torchci/lib/bot/triggerInductorTestsBot.ts
+++ b/torchci/lib/bot/triggerInductorTestsBot.ts
@@ -2,7 +2,10 @@ import { Context, Probot } from "probot";
 
 export default function triggerInductorTestsBot(app: Probot): void {
   const preapprovedUsers = ["pytorchbot", "PaliC"]; // List of preapproved users
-  const preapprovedRepos = ["malfet/deleteme"]; // List of preapproved orgs/repos
+  //   const tritonRepo = "triton-lang/triton"; // uncomment once this is good enough for triton
+  const tritonRepo = "triton-lang-test/triton"; // delete once this is good enough for triton
+  const preapprovedRepos = ["malfet/deleteme", tritonRepo]; // List of preapproved orgs/repos
+  //   const preapprovedRepos = ["malfet/deleteme", "triton-lang/triton"];// uncomment once this is good enough for triton and delete line above
 
   app.on(
     ["issue_comment.created"],
@@ -10,22 +13,46 @@ export default function triggerInductorTestsBot(app: Probot): void {
       const commentBody = ctx.payload.comment.body.toLowerCase();
       const commenter = ctx.payload.comment.user.login;
       const orgRepo = `${ctx.payload.repository.owner.login}/${ctx.payload.repository.name}`;
-
+      const tritonCommit = "main";
+      if (orgRepo === tritonRepo) {
+        // get commit of pr
+      }
       if (
         commentBody.includes("trigger inductor tests") &&
         preapprovedUsers.includes(commenter) &&
         preapprovedRepos.includes(orgRepo)
       ) {
-        const owner = ctx.payload.repository.owner.login;
-        const repo = ctx.payload.repository.name;
-        const issue_number = ctx.payload.issue.number;
+        const workflow_owner = "pytorch";
+        const workflow_repo = "pytorch-integration-testing";
+        const workflow_id = "triton-inductor.yml";
 
-        await ctx.octokit.issues.createComment({
-          owner,
-          repo,
-          issue_number,
-          body: "Inductor tests triggered",
-        });
+        try {
+          await ctx.octokit.actions.createWorkflowDispatch({
+            owner: workflow_owner,
+            repo: workflow_repo,
+            workflow_id,
+            ref: "main",
+            inputs: {
+              triton_commit: "main",
+              pytorch_commit: "viable/strict",
+            },
+          });
+
+          await ctx.octokit.issues.createComment({
+            owner: ctx.payload.repository.owner.login,
+            repo: ctx.payload.repository.name,
+            issue_number: ctx.payload.issue.number,
+            body: "Inductor tests triggered successfully",
+          });
+        } catch (error) {
+          console.error("Error triggering workflow:", error);
+          await ctx.octokit.issues.createComment({
+            owner: ctx.payload.repository.owner.login,
+            repo: ctx.payload.repository.name,
+            issue_number: ctx.payload.issue.number,
+            body: "Failed to trigger Inductor tests. Please check the logs.",
+          });
+        }
       }
     }
   );

--- a/torchci/lib/bot/triggerInductorTestsBot.ts
+++ b/torchci/lib/bot/triggerInductorTestsBot.ts
@@ -14,13 +14,14 @@ export default function triggerInductorTestsBot(app: Probot): void {
       const commenter = ctx.payload.comment.user.login;
       const orgRepo = `${ctx.payload.repository.owner.login}/${ctx.payload.repository.name}`;
       if (
-        commentBody.includes("trigger inductor tests") &&
+        commentBody.includes("@pytorchbot run pytorch tests") &&
         preapprovedUsers.includes(commenter) &&
         preapprovedRepos.includes(orgRepo)
       ) {
         const workflow_owner = "pytorch";
         const workflow_repo = "pytorch-integration-testing";
         const workflow_id = "triton-inductor.yml";
+        const pytorchCommit = "viable/strict";
 
         let tritonCommit = "main";
         // if on the triton repo, get the commit of the pr
@@ -41,7 +42,7 @@ export default function triggerInductorTestsBot(app: Probot): void {
             ref: "main",
             inputs: {
               triton_commit: tritonCommit,
-              pytorch_commit: "viable/strict",
+              pytorch_commit: pytorchCommit,
             },
           });
 
@@ -49,7 +50,7 @@ export default function triggerInductorTestsBot(app: Probot): void {
             owner: ctx.payload.repository.owner.login,
             repo: ctx.payload.repository.name,
             issue_number: ctx.payload.issue.number,
-            body: "Inductor tests triggered successfully",
+            body: `Inductor tests triggered successfully with pytorch commit: ${pytorchCommit} and triton commit: ${tritonCommit}`,
           });
         } catch (error) {
           console.error("Error triggering workflow:", error);

--- a/torchci/test/triggerInductorTestsBot.test.ts
+++ b/torchci/test/triggerInductorTestsBot.test.ts
@@ -1,0 +1,82 @@
+import nock from "nock";
+import { Probot } from "probot";
+import triggerInductorTestsBot from "../lib/bot/triggerInductorTestsBot";
+import { requireDeepCopy } from "./common";
+import * as utils from "./utils";
+
+nock.disableNetConnect();
+
+describe("trigger-inductor-tests-bot", () => {
+  let probot: Probot;
+
+  beforeEach(() => {
+    probot = utils.testProbot();
+    probot.load(triggerInductorTestsBot);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    jest.restoreAllMocks();
+  });
+
+  test("triggers inductor tests for preapproved user and repo", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
+    event.payload.comment.body = "trigger inductor tests";
+    event.payload.comment.user.login = "pytorchbot";
+    event.payload.repository.owner.login = "malfet";
+    event.payload.repository.name = "deleteme";
+
+    const scope = nock("https://api.github.com")
+      .post("/repos/malfet/deleteme/issues/31/comments", (body) => {
+        expect(body.body).toBe("Inductor tests triggered");
+        return true;
+      })
+      .reply(200);
+
+    await probot.receive(event);
+
+    scope.done();
+  });
+
+  test("does not trigger for non-preapproved user", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
+    event.payload.comment.body = "trigger inductor tests";
+    event.payload.comment.user.login = "nonApprovedUser";
+    event.payload.repository.owner.login = "malfet";
+    event.payload.repository.name = "deleteme";
+
+    const scope = nock("https://api.github.com");
+
+    await probot.receive(event);
+
+    scope.done();
+  });
+
+  test("does not trigger for non-preapproved repo", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
+    event.payload.comment.body = "trigger inductor tests";
+    event.payload.comment.user.login = "pytorchbot";
+    event.payload.repository.owner.login = "fakeorg";
+    event.payload.repository.name = "fakerepo";
+
+    const scope = nock("https://api.github.com");
+
+    await probot.receive(event);
+
+    scope.done();
+  });
+
+  test("does not trigger for irrelevant comment", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
+    event.payload.comment.body = "random comment";
+    event.payload.comment.user.login = "pytorchbot";
+    event.payload.repository.owner.login = "malfet";
+    event.payload.repository.name = "deleteme";
+
+    const scope = nock("https://api.github.com");
+
+    await probot.receive(event);
+
+    scope.done();
+  });
+});

--- a/torchci/test/triggerInductorTestsBot.test.ts
+++ b/torchci/test/triggerInductorTestsBot.test.ts
@@ -27,8 +27,18 @@ describe("trigger-inductor-tests-bot", () => {
     event.payload.repository.name = "deleteme";
 
     const scope = nock("https://api.github.com")
+      .post(
+        "/repos/pytorch/pytorch-integration-testing/actions/workflows/triton-inductor.yml/dispatches",
+        (body) => {
+          expect(JSON.stringify(body)).toContain(
+            `{"ref":"main","inputs\":{"triton_commit":"main","pytorch_commit":"viable/strict"}}`
+          );
+          return true;
+        }
+      )
+      .reply(200, {})
       .post("/repos/malfet/deleteme/issues/31/comments", (body) => {
-        expect(body.body).toBe("Inductor tests triggered");
+        expect(body.body).toBe("Inductor tests triggered successfully");
         return true;
       })
       .reply(200);

--- a/torchci/test/triggerInductorTestsBot.test.ts
+++ b/torchci/test/triggerInductorTestsBot.test.ts
@@ -21,7 +21,7 @@ describe("trigger-inductor-tests-bot", () => {
 
   test("triggers inductor tests for preapproved user and repo", async () => {
     const event = requireDeepCopy("./fixtures/pull_request_comment.json");
-    event.payload.comment.body = "trigger inductor tests";
+    event.payload.comment.body = "@pytorchbot run pytorch tests";
     event.payload.comment.user.login = "pytorchbot";
     event.payload.repository.owner.login = "malfet";
     event.payload.repository.name = "deleteme";
@@ -38,7 +38,9 @@ describe("trigger-inductor-tests-bot", () => {
       )
       .reply(200, {})
       .post("/repos/malfet/deleteme/issues/31/comments", (body) => {
-        expect(body.body).toBe("Inductor tests triggered successfully");
+        expect(body.body).toBe(
+          `Inductor tests triggered successfully with pytorch commit: viable/strict and triton commit: main`
+        );
         return true;
       })
       .reply(200);
@@ -50,7 +52,7 @@ describe("trigger-inductor-tests-bot", () => {
 
   test("triggers inductor tests for triton repo", async () => {
     const event = requireDeepCopy("./fixtures/pull_request_comment.json");
-    event.payload.comment.body = "trigger inductor tests";
+    event.payload.comment.body = "@pytorchbot run pytorch tests";
     event.payload.comment.user.login = "pytorchbot";
     event.payload.repository.owner.login = "triton-lang-test";
     event.payload.repository.name = "triton";
@@ -73,7 +75,9 @@ describe("trigger-inductor-tests-bot", () => {
       )
       .reply(200, {})
       .post("/repos/triton-lang-test/triton/issues/31/comments", (body) => {
-        expect(body.body).toBe("Inductor tests triggered successfully");
+        expect(body.body).toBe(
+          `Inductor tests triggered successfully with pytorch commit: viable/strict and triton commit: custom_triton_sha`
+        );
         return true;
       })
       .reply(200);
@@ -85,7 +89,7 @@ describe("trigger-inductor-tests-bot", () => {
 
   test("does not trigger for non-preapproved user", async () => {
     const event = requireDeepCopy("./fixtures/pull_request_comment.json");
-    event.payload.comment.body = "trigger inductor tests";
+    event.payload.comment.body = "@pytorchbot run pytorch tests";
     event.payload.comment.user.login = "nonApprovedUser";
     event.payload.repository.owner.login = "malfet";
     event.payload.repository.name = "deleteme";
@@ -99,7 +103,7 @@ describe("trigger-inductor-tests-bot", () => {
 
   test("does not trigger for non-preapproved repo", async () => {
     const event = requireDeepCopy("./fixtures/pull_request_comment.json");
-    event.payload.comment.body = "trigger inductor tests";
+    event.payload.comment.body = "@pytorchbot run pytorch tests";
     event.payload.comment.user.login = "pytorchbot";
     event.payload.repository.owner.login = "fakeorg";
     event.payload.repository.name = "fakerepo";


### PR DESCRIPTION
This pr is the first in a set of PRs to enable inductor testing on the triton-lang/triton repo using pytorch resources. Specially we trigger a workflow in the pytorch repo which runs inductor tests on a specific triton hash against pytorch viable/strict.

Once this pr is merged. I will test it on malfet/deleteme to make sure it works. 