### PR TITLE
[disablebot] Stop bot on some inductor mac tests

### DIFF
--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -86,7 +86,11 @@ export function filterThreshold(
   return tests.filter(
     (test) =>
       new Set(test.jobIds).size > threshold &&
-      test.suite != "TestSDPACudaOnlyCUDA" // TODO: Get rid of this when driss fixes the flakiness
+      test.suite != "TestSDPACudaOnlyCUDA" && // TODO: Get rid of this when driss fixes the flakiness
+      !(
+        test.suite == "TestInductorOpInfoCPU" &&
+        test.jobNames.every((name) => name.includes("mac"))
+      ) // See https://github.com/pytorch/pytorch/issues/135885
   );
 }
 


### PR DESCRIPTION
Made a ton of issues

I'll put in a rate limiter thing in a later PR?  or make the bot create an issue instead of mass disabling