### PR TITLE
Fix incorrect path to runner-binaries-syncer

### DIFF
--- a/.github/workflows/lambda-do-release-runners.yml
+++ b/.github/workflows/lambda-do-release-runners.yml
@@ -32,7 +32,7 @@ jobs:
           NODE_OPTIONS: "--openssl-legacy-provider"
         working-directory: terraform-aws-github-runner/modules/runner-binaries-syncer/lambdas/runner-binaries-syncer
       - name: Copy js to root - Runner Binaries Syncer
-        run: cp terraform-aws-github-runner/modules/runners/lambdas/runners/dist/index.js .
+        run: cp terraform-aws-github-runner/modules/runner-binaries-syncer/lambdas/runner-binaries-syncer/dist/index.js .
       - name: create lambda zip - Runner Binaries Syncer
         uses: montudor/action-zip@v1
         with:


### PR DESCRIPTION
Change #5615 had an incorrect path for the runner-binaries-syncer index.js file. This change fixes the pathing issue.