### PR TITLE
[ez] Revert printer - throw exception on unrecognized arguments in comment

### DIFF
--- a/tools/torchci/reverts.py
+++ b/tools/torchci/reverts.py
@@ -44,7 +44,8 @@ WHERE
 
 class ErrorRaisingArgumentParser(argparse.ArgumentParser):
     """
-    Raises an error on unrecognized arguments since the normal one simply exits.
+    Raises an exception on unrecognized arguments that can be caught.  The
+    normal argument parser simply exits.
     Reference: https://stackoverflow.com/questions/73441232/raise-exception-if-argumentparser-encounters-unknown-argument
     """
     def error(self, message):

--- a/tools/torchci/reverts.py
+++ b/tools/torchci/reverts.py
@@ -45,7 +45,7 @@ WHERE
 class ErrorRaisingArgumentParser(argparse.ArgumentParser):
     """
     Raises an exception on unrecognized arguments that can be caught.  The
-    normal argument parser simply exits.
+    normal argument parser exits.
     Reference: https://stackoverflow.com/questions/73441232/raise-exception-if-argumentparser-encounters-unknown-argument
     """
     def error(self, message):

--- a/tools/torchci/reverts.py
+++ b/tools/torchci/reverts.py
@@ -48,6 +48,7 @@ class ErrorRaisingArgumentParser(argparse.ArgumentParser):
     default argument parser exits.
     Reference: https://stackoverflow.com/questions/73441232/raise-exception-if-argumentparser-encounters-unknown-argument
     """
+
     def error(self, message):
         raise ValueError(message)
 

--- a/tools/torchci/reverts.py
+++ b/tools/torchci/reverts.py
@@ -42,8 +42,17 @@ WHERE
 """
 
 
+class ErrorRaisingArgumentParser(argparse.ArgumentParser):
+    """
+    Raises an error on unrecognized arguments since the normal one simply exits.
+    Reference: https://stackoverflow.com/questions/73441232/raise-exception-if-argumentparser-encounters-unknown-argument
+    """
+    def error(self, message):
+        raise ValueError(message)
+
+
 def parse_body(revert: Dict[str, str]) -> None:
-    parser = argparse.ArgumentParser()
+    parser = ErrorRaisingArgumentParser()
     subparser = parser.add_subparsers()
     group = subparser.add_parser("revert")
 

--- a/tools/torchci/reverts.py
+++ b/tools/torchci/reverts.py
@@ -45,7 +45,7 @@ WHERE
 class ErrorRaisingArgumentParser(argparse.ArgumentParser):
     """
     Raises an exception on unrecognized arguments that can be caught.  The
-    normal argument parser exits.
+    default argument parser exits.
     Reference: https://stackoverflow.com/questions/73441232/raise-exception-if-argumentparser-encounters-unknown-argument
     """
     def error(self, message):


### PR DESCRIPTION
Raises an error on unrecognized arguments when parsing the comment body since the default argument parser exits immediately.

This makes it easier to debug what failed as the later try catch in parse_body will print the comment link

Example failure: https://github.com/pytorch/test-infra/actions/runs/10886791088/job/30207637435

The comment it failed on was https://togithub.com/pytorch/pytorch/pull/134968#issuecomment-2348837553
It was edited after the revert to not match the expected revert command.  I edited the comment to make it match again and the revert printer succeeded 