### PR TITLE
Decode branch name before passing to Octokit

### DIFF
--- a/torchci/lib/fetchHud.ts
+++ b/torchci/lib/fetchHud.ts
@@ -58,7 +58,7 @@ export default async function fetchHud(params: HudParams): Promise<{
   const branch = await octokit.rest.repos.listCommits({
     owner: params.repoOwner,
     repo: params.repoName,
-    sha: params.branch,
+    sha: decodeURIComponent(params.branch),
     per_page: params.per_page,
     page: params.page,
   });


### PR DESCRIPTION
According to Vercel log, the GH API link looks wrong with double encoding `https://api.github.com/repos/pytorch/pytorch/commits?sha=viable%252Fstrict&per_page=50&page=1` where it should just be `https://api.github.com/repos/pytorch/pytorch/commits?sha=viable%2Fstrict&per_page=50&page=1` instead.

I suspect that this might be related to Octokit version, or one of its dependencies https://www.npmjs.com/package/octokit?activeTab=versions, as the error is not manifested locally.

### Testing 

https://torchci-git-fix-wrong-branch-name-hud-fbopensource.vercel.app/hud/pytorch/pytorch/viable%2Fstrict/1?per_page=50

https://torchci-git-fix-wrong-branch-name-hud-fbopensource.vercel.app/hud/pytorch/executorch/release%2F0.4/1?per_page=50