### PR TITLE
[flaky tests] don't disable tests with an overly generic error

### DIFF
--- a/torchci/pages/api/constants.ts
+++ b/torchci/pages/api/constants.ts
@@ -1,0 +1,4 @@
+export const ErrorsToNotDisable: RegExp[] = [
+  /^##\[error\]The operation was canceled\.$/,
+  // Add more regex patterns as needed
+];

--- a/torchci/test/disableFlakyBot.test.ts
+++ b/torchci/test/disableFlakyBot.test.ts
@@ -26,6 +26,11 @@ const flakyTestA = {
   branches: ["master", "master", "master"],
 };
 
+const flakyTestAwithGenericError = {
+  ...flakyTestA,
+  sampleTraceback: "##[error]The operation was canceled.",
+};
+
 const flakyTestB = {
   file: "file_b.py",
   invoking_file: "file_b",
@@ -531,6 +536,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
         branches: ["quick-fix", "ciflow/scheduled/22222"],
       },
       flakyTestE,
+      flakyTestAwithGenericError,
     ];
     const expectedFlakyTestsOnTrunk = [
       flakyTestA,


### PR DESCRIPTION
This should deal with https://github.com/pytorch/test-infra/issues/4927