### PR TITLE
[drci] don't mark jobs with an overly generic error as flaky

### DIFF
--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -257,6 +257,14 @@ export async function hasSimilarFailures(
     return;
   }
 
+  if (
+    job.failure_captures.some((capture) =>
+      ErrorsToNotDisable.some((error) => error.test(capture))
+    )
+  ) {
+    return;
+  }
+
   // NB: Using the job completed_at timestamp has many false positives, so it's
   // better that we only enable this feature when the head commit timestamp is
   // available and use it as the end date
@@ -327,13 +335,6 @@ export async function hasSimilarFailures(
       failure.head_sha
     );
     if (!isEligibleCommit) {
-      continue;
-    }
-    if (
-      failure.failure_captures.some((capture) =>
-        ErrorsToNotDisable.some((error) => error.test(capture))
-      )
-    ) {
       continue;
     }
 

--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -53,6 +53,12 @@ export const EXCLUDED_FROM_FLAKINESS = [
 // it increases the risk of getting misclassification. This guardrail can
 // be relaxed once we achieve better accuracy from the log classifier. This
 // sets the limit to 7 days
+
+export const ErrorsToNotDisable: RegExp[] = [
+  /^##\[error\]The operation was canceled\.$/,
+  // Add more regex patterns as needed
+];
+
 export const MAX_SEARCH_HOURS_FOR_QUERYING_SIMILAR_FAILURES = 7 * 24;
 // Mapping the job to the list of suppressed labels
 export const SUPPRESSED_JOB_BY_LABELS: { [job: string]: string[] } = {
@@ -321,6 +327,13 @@ export async function hasSimilarFailures(
       failure.head_sha
     );
     if (!isEligibleCommit) {
+      continue;
+    }
+    if (
+      failure.failure_captures.some((capture) =>
+        ErrorsToNotDisable.some((error) => error.test(capture))
+      )
+    ) {
       continue;
     }
 

--- a/torchci/test/drciUtils.test.ts
+++ b/torchci/test/drciUtils.test.ts
@@ -45,6 +45,10 @@ describe("Test various utils used by Dr.CI", () => {
       completed_at: mockHeadShaDate.format("YYYY-MM-DD HH:mm:ss"),
       head_branch: "whatever",
     });
+    const jobWithGenericError: RecentWorkflowsData = {
+      ...job,
+      failure_captures: ["##[error]The operation was canceled."],
+    };
 
     const mock = jest.spyOn(searchUtils, "searchSimilarFailures");
     mock.mockImplementation(() => Promise.resolve({ jobs: [] }));
@@ -301,6 +305,17 @@ describe("Test various utils used by Dr.CI", () => {
     expect(
       await hasSimilarFailures(
         job,
+        emptyBaseCommitDate,
+        [],
+        lookbackPeriodInHours,
+        "TESTING" as unknown as Client
+      )
+    ).toEqual(undefined);
+
+    // Found a match but it has a generic error
+    expect(
+      await hasSimilarFailures(
+        jobWithGenericError,
         emptyBaseCommitDate,
         [],
         lookbackPeriodInHours,


### PR DESCRIPTION
This should deal with https://github.com/pytorch/test-infra/issues/4927