### PR TITLE
Set the AWS credential duration in mobile job

### DIFF
--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -108,10 +108,23 @@ jobs:
           mkdir -p "${GITHUB_WORKSPACE}"
           echo "::endgroup::"
 
+      - name: Calculate the role duration (seconds)
+        id: calculate-role-duration
+        env:
+          TIMEOUT_IN_MINUTES: ${{ inputs.timeout }}
+        shell: bash
+        run: |
+          set -ex
+
+          TIMEOUT_IN_SECONDS=$(( TIMEOUT_IN_MINUTES * 60 ))
+          echo "timeout-seconds=${TIMEOUT_IN_SECONDS}" >> "${GITHUB_OUTPUT}"
+
       - name: Authenticate with AWS
         uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_mobile_job
+          # This could go up to 18000, the max duration enforced by the server side
+          role-duration-seconds: ${{ steps.calculate-role-duration.outputs.timeout-seconds }}
           aws-region: us-east-1
 
       - name: Checkout repository (${{ inputs.test-infra-repository }}@${{ inputs.test-infra-ref }})

--- a/.github/workflows/test_mobile_job.yml
+++ b/.github/workflows/test_mobile_job.yml
@@ -32,6 +32,7 @@ jobs:
     with:
       device-type: android
       runner: ubuntu-latest
+      timeout: 120
       # There values are prepared beforehand for the test
       project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:02a2cf0f-6d9b-45ee-ba1a-a086587469e6
       device-pool-arn: arn:aws:devicefarm:us-west-2:308535385114:devicepool:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/e59f866a-30aa-4aa1-87b7-4510e5820dfa


### PR DESCRIPTION
As reported by @guangy10 in https://github.com/pytorch/executorch/pull/5441#issuecomment-2357004155, it turns out that the job timeout can be set to a higher value (120 minutes), but the AWS credential still expires after 1 hour https://github.com/aws-actions/configure-aws-credentials.

The fix here is to set the role duration correctly.  However, the max that it can go is 18000 seconds.  I believe that's plenty of room already, but if a higher is needed, we will need to update the server side https://github.com/pytorch-labs/pytorch-gha-infra/blob/main/runners/gha_roles.tf#L1425