### PR TITLE
Set the AWS credential duration in mobile job

### DIFF
--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -108,23 +108,12 @@ jobs:
           mkdir -p "${GITHUB_WORKSPACE}"
           echo "::endgroup::"
 
-      - name: Calculate the role duration (seconds)
-        id: calculate-role-duration
-        env:
-          TIMEOUT_IN_MINUTES: ${{ inputs.timeout }}
-        shell: bash
-        run: |
-          set -ex
-
-          TIMEOUT_IN_SECONDS=$(( TIMEOUT_IN_MINUTES * 60 ))
-          echo "timeout-seconds=${TIMEOUT_IN_SECONDS}" >> "${GITHUB_OUTPUT}"
-
       - name: Authenticate with AWS
         uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_mobile_job
           # This could go up to 18000, the max duration enforced by the server side
-          role-duration-seconds: ${{ steps.calculate-role-duration.outputs.timeout-seconds }}
+          role-duration-seconds: 18000
           aws-region: us-east-1
 
       - name: Checkout repository (${{ inputs.test-infra-repository }}@${{ inputs.test-infra-ref }})

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -108,10 +108,23 @@ jobs:
           mkdir -p "${GITHUB_WORKSPACE}"
           echo "::endgroup::"
 
+      - name: Calculate the role duration (seconds)
+        id: calculate-role-duration
+        env:
+          TIMEOUT_IN_MINUTES: ${{ inputs.timeout }}
+        shell: bash
+        run: |
+          set -ex
+
+          TIMEOUT_IN_SECONDS=$(( TIMEOUT_IN_MINUTES * 60 ))
+          echo "timeout-seconds=${TIMEOUT_IN_SECONDS}" >> "${GITHUB_OUTPUT}"
+
       - name: Authenticate with AWS
         uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_mobile_job
+          # This could go up to 18000, the max duration enforced by the server side
+          role-duration-seconds: ${{ steps.calculate-role-duration.outputs.timeout-seconds }}
           aws-region: us-east-1
 
       - name: Checkout repository (${{ inputs.test-infra-repository }}@${{ inputs.test-infra-ref }})

--- a/.github/workflows/test_mobile_job.yml
+++ b/.github/workflows/test_mobile_job.yml
@@ -19,10 +19,10 @@ jobs:
       # For iOS testing, the runner just needs to call AWS Device Farm, so there is no need to run this on macOS
       runner: ubuntu-latest
       # There values are prepared beforehand for the test
-      project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:02a2cf0f-6d9b-45ee-ba1a-a086587469e6
-      ios-ipa-archive: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/56b109f3-64b4-48c0-b1c8-b19dafc80647
-      ios-xctestrun-zip: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/8aeaf73f-3a42-4304-8eda-7a8d6b5a770c
-      test-spec: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/68677456-2999-47ec-a3a1-722db2b69b69
+      project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:b531574a-fb82-40ae-b687-8f0b81341ae0
+      ios-ipa-archive: https://ossci-assets.s3.amazonaws.com/DeviceFarm.ipa
+      ios-xctestrun-zip: https://ossci-assets.s3.amazonaws.com/MobileNetClassifierTest_MobileNetClassifierTest_iphoneos17.4-arm64.xctestrun.zip
+      test-spec: https://ossci-assets.s3.amazonaws.com/default-ios-device-farm-appium-test-spec.yml
 
   test-android-llama2-job:
     permissions:
@@ -34,9 +34,9 @@ jobs:
       runner: ubuntu-latest
       timeout: 120
       # There values are prepared beforehand for the test
-      project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:02a2cf0f-6d9b-45ee-ba1a-a086587469e6
+      project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:b531574a-fb82-40ae-b687-8f0b81341ae0
       device-pool-arn: arn:aws:devicefarm:us-west-2:308535385114:devicepool:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/e59f866a-30aa-4aa1-87b7-4510e5820dfa
-      android-app-archive: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/8a7276b7-03ac-4053-8b09-1305c429f59d
-      android-test-archive: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/528113d6-2003-420b-aedb-4242b6d14254
-      test-spec: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/414cb54d-4d83-4576-8317-93244e4dc50e
-      extra-data: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/bd15825b-ddab-4e47-9fef-a9c8935778dd
+      android-app-archive: https://ossci-assets.s3.amazonaws.com/app-debug.apk
+      android-test-archive: https://ossci-assets.s3.amazonaws.com/app-debug-androidTest.apk
+      test-spec: https://ossci-assets.s3.amazonaws.com/android-llm-device-farm-test-spec.yml
+      extra-data: https://ossci-assets.s3.amazonaws.com/executorch-android-llama2-7b-0717.zip

--- a/.github/workflows/test_mobile_job.yml
+++ b/.github/workflows/test_mobile_job.yml
@@ -20,6 +20,7 @@ jobs:
       runner: ubuntu-latest
       # There values are prepared beforehand for the test
       project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:b531574a-fb82-40ae-b687-8f0b81341ae0
+      device-pool-arn: arn:aws:devicefarm:us-west-2:308535385114:devicepool:b531574a-fb82-40ae-b687-8f0b81341ae0/da5d902d-45db-477b-ae0a-766e06ef3845
       ios-ipa-archive: https://ossci-assets.s3.amazonaws.com/DeviceFarm.ipa
       ios-xctestrun-zip: https://ossci-assets.s3.amazonaws.com/MobileNetClassifierTest_MobileNetClassifierTest_iphoneos17.4-arm64.xctestrun.zip
       test-spec: https://ossci-assets.s3.amazonaws.com/default-ios-device-farm-appium-test-spec.yml
@@ -35,7 +36,7 @@ jobs:
       timeout: 120
       # There values are prepared beforehand for the test
       project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:b531574a-fb82-40ae-b687-8f0b81341ae0
-      device-pool-arn: arn:aws:devicefarm:us-west-2:308535385114:devicepool:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/e59f866a-30aa-4aa1-87b7-4510e5820dfa
+      device-pool-arn: arn:aws:devicefarm:us-west-2:308535385114:devicepool:b531574a-fb82-40ae-b687-8f0b81341ae0/bd86eb80-74a6-4511-8183-09aa66e3ccc4
       android-app-archive: https://ossci-assets.s3.amazonaws.com/app-debug.apk
       android-test-archive: https://ossci-assets.s3.amazonaws.com/app-debug-androidTest.apk
       test-spec: https://ossci-assets.s3.amazonaws.com/android-llm-device-farm-test-spec.yml

--- a/.github/workflows/test_mobile_job.yml
+++ b/.github/workflows/test_mobile_job.yml
@@ -32,6 +32,7 @@ jobs:
     with:
       device-type: android
       runner: ubuntu-latest
+      timeout: 120
       # There values are prepared beforehand for the test
       project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:02a2cf0f-6d9b-45ee-ba1a-a086587469e6
       device-pool-arn: arn:aws:devicefarm:us-west-2:308535385114:devicepool:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/e59f866a-30aa-4aa1-87b7-4510e5820dfa


### PR DESCRIPTION
As reported by @guangy10 in https://github.com/pytorch/executorch/pull/5441#issuecomment-2357004155, it turns out that the job timeout can be set to a higher value (120 minutes), but the AWS credential still expires after 1 hour https://github.com/aws-actions/configure-aws-credentials.

The fix here is to set the role duration correctly.  However, the max that it can go is 18000 seconds.  I believe that's plenty of room already, but if a higher is needed, we will need to update the server side https://github.com/pytorch-labs/pytorch-gha-infra/blob/main/runners/gha_roles.tf#L1425

### Testing

The role duration is set correctly to 7200 seconds (2 hours) https://github.com/pytorch/test-infra/actions/runs/10916800466/job/30298898748#step:4:4