### PR TITLE
[ch][kpis] TTS chart

### DIFF
--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -1,8 +1,10 @@
 import { Grid } from "@mui/material";
 import TimeSeriesPanel from "components/metrics/panels/TimeSeriesPanel";
+import { useCHContext } from "components/UseClickhouseProvider";
 import dayjs from "dayjs";
 import { RocksetParam } from "lib/rockset";
 import { useState } from "react";
+import { RStoCHTimeParams } from "./metrics";
 
 const ROW_HEIGHT = 240;
 
@@ -23,6 +25,9 @@ export default function Kpis() {
       value: stopTime,
     },
   ];
+
+  const clickhouseTimeParams = RStoCHTimeParams(timeParams);
+  const useCH = useCHContext().useCH;
 
   // deprecate this in Q3 2023
   const contributionTimeParams: RocksetParam[] = [
@@ -104,20 +109,14 @@ export default function Kpis() {
           title={"Avg time-to-signal - E2E (Weekly)"}
           queryName={"time_to_signal"}
           queryCollection={"pytorch_dev_infra_kpis"}
-          queryParams={[
-            {
-              name: "buildOrAll",
-              type: "string",
-              value: "all",
-            },
-            ...timeParams,
-          ]}
+          queryParams={useCH ? clickhouseTimeParams : timeParams}
           granularity={"week"}
           timeFieldName={"week_bucket"}
           yAxisFieldName={"avg_tts"}
           yAxisLabel={"Hours"}
           yAxisRenderer={(unit) => `${unit}`}
           groupByFieldName="branch"
+          useClickHouse={useCH}
         />
       </Grid>
 

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -467,7 +467,7 @@ function JobsDuration({
 
 const ROW_HEIGHT = 375;
 
-function RStoCHTimeParams(params: RocksetParam[]) {
+export function RStoCHTimeParams(params: RocksetParam[]) {
   return {
     startTime: params
       .find((p) => p.name === "startTime")


### PR DESCRIPTION
* Add CH query for TTS chart, works with rs/ch toggle button
* CH date_trunc('week') truncates to monday, but toStartOfWeek can let you choose which day to truncate to.  The second keeps the results the same, but date_trunc lets you choose granularities better.  For parity with RS, I am putting this query to trunc to sunday, but we might want to change this later