### PR TITLE
[viable strict] Add some outputs for tracking metrics

### DIFF
--- a/.github/actions/update-viablestrict/action.yml
+++ b/.github/actions/update-viablestrict/action.yml
@@ -37,6 +37,16 @@ inputs:
     description: Test infra reference to use
     default: ''
     type: string
+outputs:
+  latest_viable_sha:
+    description: The latest viable sha that passed all the required jobs
+    value: ${{ steps.get-latest-commit.outputs.latest_viable_sha }}
+  push_result:
+    description: The result of the push to the stable branch
+    value: ${{ steps.push-to-stable.outputs.push_result }}
+  time:
+    description: The time when the push was made
+    value: ${{ steps.push-to-stable.outputs.time }}
 
 runs:
   using: composite
@@ -81,6 +91,7 @@ runs:
     - name: Push SHA to viable/strict branch
       if: steps.get-latest-commit.outputs.latest_viable_sha != 'None'
       working-directory: ${{ inputs.repository }}
+      id: push-to-stable
       env:
         GITHUB_TOKEN: ${{ inputs.secret-bot-token }}
         STABLE_BRANCH: ${{ inputs.stable-branch }}
@@ -93,4 +104,7 @@ runs:
         echo "Set the latest sha variable to be ${LATEST_VIABLE_SHA}"
         # Pushing an older green commit here will fail because it's non-fast-forward, which is ok
         # to ignore because we already have the later green commit in visable/strict
-        git push origin "${LATEST_VIABLE_SHA}":"${STABLE_BRANCH}" || true
+        push_result=$(git push origin "${LATEST_VIABLE_SHA}:${STABLE_BRANCH}" 2>&1 || true)
+        echo "push_result=$push_result" >> "${GITHUB_OUTPUT}"
+        echo "${push_result}"
+        echo "time=$(date +%s)" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
Adds the following outputs:
* time: when the push command finished, in seconds from epoch 
* latest_viable_sha: the latest sha that works
* push_result: stdout and stderr of the push

To be used in https://github.com/pytorch/pytorch/pull/136470