### PR TITLE
[ch] Revert printer

### DIFF
--- a/tools/torchci/reverts.py
+++ b/tools/torchci/reverts.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from rockset import RocksetClient  # type: ignore[import]
+from torchci.clickhouse import query_clickhouse
 from torchci.github_analyze import GitCommit, GitRepo  # type: ignore[import]
 
 # Should match the contents produced by trymerge on revert
@@ -24,20 +24,20 @@ CLASSIFICATIONS = {
     "manual": "Not through pytorchbot",
 }
 
-ROCKSET_REVERT_QUERY = """
+DB_REVERT_QUERY = """
 SELECT
     ic.user.login as reverter,
     ic.body,
     ic.html_url as comment_url
 FROM
-    commons.issue_comment AS ic
+    default.issue_comment AS ic final
 WHERE
-    REGEXP_LIKE(
+    match(
         ic.body,
         '@pytorch(merge|)bot +revert'
     )
-    AND ic.created >= PARSE_TIMESTAMP_ISO8601(:startTime)
-    AND ic.created < PARSE_TIMESTAMP_ISO8601(:stopTime)
+    AND ic.created_at >= {startTime: DateTime64}
+    AND ic.created_at < {stopTime: DateTime64}
     AND ic.user.login != 'pytorch-bot[bot]'
 """
 
@@ -75,15 +75,15 @@ def parse_body(revert: Dict[str, str]) -> None:
 
 
 def format_string_for_markdown_long(
-    commit: Optional[GitCommit], rockset_result: Optional[Dict[str, str]] = None
+    commit: Optional[GitCommit], db_result: Optional[Dict[str, str]] = None
 ) -> str:
     s = ""
     if commit is None:
         s += "- cannot find commit corresponding to @pytorchbot revert comment"
     else:
         s = f"- [{commit.title}](https://github.com/pytorch/pytorch/commit/{commit.commit_hash})"
-    if rockset_result is not None:
-        s += f'\n  - {rockset_result["message"]} ([comment]({rockset_result["comment_url"]}))'
+    if db_result is not None:
+        s += f'\n  - {db_result["message"]} ([comment]({db_result["comment_url"]}))'
     s += "\n"
     return s
 
@@ -97,22 +97,12 @@ def get_start_stop_times() -> Tuple[str, str]:
     return start_time, end_time
 
 
-def get_rockset_reverts(start_time: str, end_time: str) -> Dict[str, Dict[str, str]]:
+def get_db_reverts(start_time: str, end_time: str) -> Dict[str, Dict[str, str]]:
     params = {
-        "startTime": start_time,
-        "stopTime": end_time,
+        "startTime": start_time[:-1],  # Remove Z
+        "stopTime": end_time[:-1],
     }
-    ROCKSET_API_KEY = os.environ.get("ROCKSET_API_KEY")
-    if ROCKSET_API_KEY is None:
-        raise RuntimeError("ROCKSET_API_KEY not set")
-
-    client = RocksetClient(
-        api_key=ROCKSET_API_KEY,
-        host="https://api.usw2a1.rockset.com",
-    )
-    response = client.sql(ROCKSET_REVERT_QUERY, params=params)
-    res: List[Dict[str, str]] = response.results
-
+    res: List[Dict[str, str]] = query_clickhouse(DB_REVERT_QUERY, params)
     return {revert["comment_url"]: revert for revert in res}
 
 
@@ -133,9 +123,9 @@ def get_gitlog_reverts(start_time: str, end_time: str) -> List[GitCommit]:
 
 def main() -> None:
     start_time, end_time = get_start_stop_times()
-    rockset_reverts = get_rockset_reverts(start_time, end_time)
+    db_reverts = get_db_reverts(start_time, end_time)
     gitlog_reverts = get_gitlog_reverts(start_time, end_time)
-    # map classification type -> list of (commit, rockset result)
+    # map classification type -> list of (commit, db result)
     classification_dict: Dict[
         str, List[Tuple[Optional[str], Optional[Dict[str, str]]]]
     ] = defaultdict(lambda: [])
@@ -149,10 +139,10 @@ def main() -> None:
             classification_dict["manual"].append((gitlog_revert, None))
             continue
         comment_url = comment_match[1]
-        rockset_revert = rockset_reverts[comment_url]
-        parse_body(rockset_revert)
-        classification_dict[rockset_revert["code"]].append(
-            (gitlog_revert, rockset_revert)
+        db_revert = db_reverts[comment_url]
+        parse_body(db_revert)
+        classification_dict[db_revert["code"]].append(
+            (gitlog_revert, db_revert)
         )
 
     assert sum(len(code) for code in classification_dict.values()) == len(
@@ -169,8 +159,8 @@ def main() -> None:
             classification_dict.items(), key=lambda x: x[0]
         ):
             f.write(f"\n### {CLASSIFICATIONS[classification]} ({len(reverts)})\n\n")
-            for commit, rockset_result in reverts:
-                f.write(format_string_for_markdown_long(commit, rockset_result))
+            for commit, db_result in reverts:
+                f.write(format_string_for_markdown_long(commit, db_result))
 
     # Probably not a great idea but at least this way I never have to worry
     # about print to stdout vs stderr

--- a/tools/torchci/reverts.py
+++ b/tools/torchci/reverts.py
@@ -141,9 +141,7 @@ def main() -> None:
         comment_url = comment_match[1]
         db_revert = db_reverts[comment_url]
         parse_body(db_revert)
-        classification_dict[db_revert["code"]].append(
-            (gitlog_revert, db_revert)
-        )
+        classification_dict[db_revert["code"]].append((gitlog_revert, db_revert))
 
     assert sum(len(code) for code in classification_dict.values()) == len(
         gitlog_reverts


### PR DESCRIPTION
* Migrate query to CH syntax
* Use CH only
* Bunch of renames like rockset_result -> db_result 

Tested by running on base and head, got the same results for this week