### PR TITLE
Create Makefiles for test-infra ALI lambdas

### DIFF
--- a/.github/workflows/lambda-runner-binaries-syncer.yml
+++ b/.github/workflows/lambda-runner-binaries-syncer.yml
@@ -19,16 +19,5 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Install dependencies
-        run: yarn install
-      - name: Run linter
-        run: yarn lint
-      - name: Format Check
-        run: yarn format-check
-      # TODO: Fix broken tests.
-      # - name: Run tests
-      #   run: yarn test
-      - name: Build distribution
-        run: yarn build
-        env:
-          NODE_OPTIONS: "--openssl-legacy-provider"
+      - name: Build, Lint, and Test
+        run: make build

--- a/.github/workflows/lambda-runners.yml
+++ b/.github/workflows/lambda-runners.yml
@@ -19,13 +19,5 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Install dependencies
-        run: yarn install
-      - name: Run linter
-        run: yarn lint
-      - name: Format Check
-        run: yarn format-check
-      - name: Run tests
-        run: yarn test
-      - name: Build distribution
-        run: yarn build
+      - name: Build, Lint, and Test
+        run: make build

--- a/.github/workflows/lambda-webhook.yml
+++ b/.github/workflows/lambda-webhook.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    name: "Run tests for webhook lambda"
     runs-on: ubuntu-latest
     container: node:20
     defaults:
@@ -18,15 +19,5 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Install dependencies
-        run: yarn install
-      - name: Run linter
-        run: yarn lint
-      - name: Format Check
-        run: yarn format-check
-      - name: Run tests
-        run: yarn test
-      - name: Build distribution
-        run: yarn build
-        env:
-          NODE_OPTIONS: "--openssl-legacy-provider"
+      - name: Build, Lint, and Test
+        run: make build

--- a/terraform-aws-github-runner/modules/runner-binaries-syncer/lambdas/runner-binaries-syncer/Makefile
+++ b/terraform-aws-github-runner/modules/runner-binaries-syncer/lambdas/runner-binaries-syncer/Makefile
@@ -1,0 +1,20 @@
+SHELL=/bin/bash -o pipefail
+
+.PHONY: clean
+clean:
+	rm -rf dist node_modules
+	rm runner-binaries-syncer.zip
+
+.PHONY: build
+build:
+	yarn install
+	yarn lint
+	yarn format-check
+	NODE_OPTIONS="--openssl-legacy-provider" yarn build
+	# TODO: Fix broken tests.
+	# yarn test
+
+.PHONY: dist
+dist:
+	yarn install
+	NODE_OPTIONS="--openssl-legacy-provider" yarn dist

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/Makefile
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/Makefile
@@ -1,0 +1,19 @@
+SHELL=/bin/bash -o pipefail
+
+.PHONY: clean
+clean:
+	rm -rf dist node_modules
+	rm runners.zip
+
+.PHONY: build
+build:
+	yarn install
+	yarn lint
+	yarn format-check
+	NODE_OPTIONS="--openssl-legacy-provider" yarn build
+	yarn test
+
+.PHONY: dist
+dist:
+	yarn install
+	NODE_OPTIONS="--openssl-legacy-provider" yarn dist

--- a/terraform-aws-github-runner/modules/webhook/lambdas/webhook/Makefile
+++ b/terraform-aws-github-runner/modules/webhook/lambdas/webhook/Makefile
@@ -1,0 +1,19 @@
+SHELL=/bin/bash -o pipefail
+
+.PHONY: clean
+clean:
+	rm -rf dist node_modules
+	rm webhook.zip
+
+.PHONY: build
+build:
+	yarn install
+	yarn lint
+	yarn format-check
+	NODE_OPTIONS="--openssl-legacy-provider" yarn build
+	yarn test
+
+.PHONY: dist
+dist:
+	yarn install
+	NODE_OPTIONS="--openssl-legacy-provider" yarn dist


### PR DESCRIPTION
Create Makefiles for the ALI lambda functions so that we can make sure that CI and Local dev use the same commands to build and test.

Issue: pytorch/ci-infra#274