### PR TITLE
[EZ] Remove remaining amz2023 runner variant references

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -32,9 +32,6 @@ runner_types:
     max_available: 1000
     os: linux
     ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-    variants:
-      amz2023:
-        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.10xlarge.avx2:
     disk_size: 200
     instance_type: m4.10xlarge
@@ -108,9 +105,6 @@ runner_types:
     max_available: 1000
     os: linux
     ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-    variants:
-      amz2023:
-        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.4xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g3.4xlarge
@@ -125,9 +119,6 @@ runner_types:
     max_available: 400
     os: linux
     ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-    variants:
-      amz2023:
-        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.g4dn.12xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g4dn.12xlarge
@@ -170,9 +161,6 @@ runner_types:
     max_available: 50
     os: linux
     ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
-    variants:
-      amz2023:
-        ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
   linux.large:
     max_available: 1200
     disk_size: 15


### PR DESCRIPTION
Validated no jobs use the amz2023 runner variant anymore ([proof](https://github.com/search?type=code&q=org%3Apytorch+%2F%5Cbamz2023%5Cb%2F+&p=1)) so removing all references to it

Note: The Scale Config Validator job will only pass after https://github.com/pytorch/pytorch/pull/136540 is merged