### PR TITLE
[drci] Update comments that say pending

### DIFF
--- a/torchci/clickhouse_queries/recent_pr_workflows_query/params.json
+++ b/torchci/clickhouse_queries/recent_pr_workflows_query/params.json
@@ -1,5 +1,5 @@
 {
   "numMinutes": "Int64",
-  "prNumber": "Int64",
+  "prNumbers": "Array(Int64)",
   "repo": "String"
 }

--- a/torchci/clickhouse_queries/recent_pr_workflows_query/query.sql
+++ b/torchci/clickhouse_queries/recent_pr_workflows_query/query.sql
@@ -4,11 +4,11 @@ WITH relevant_shas as (
   select head_sha
   from materialized_views.workflow_job_by_completed_at
   where completed_at > now() - Interval {numMinutes: Int64} MINUTES
-  and {prNumber: Int64} = 0
+  and LENGTH({prNumbers: Array(Int64)}) = 0
   union all
   select pr.head.'sha' as head_sha
   from default.pull_request pr final
-  where pr.number = {prNumber: Int64}
+  where pr.number in {prNumbers: Array(Int64)}
 ),
 relevant_pushes as (
   -- optimization because push is currently ordered by timestamp

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -503,7 +503,7 @@ The explanation needs to be clear on why this is needed. Here are some good exam
     const { ctx, prNum, repo } = this;
 
     await this.ackComment();
-    await updateDrciComments(ctx.octokit, repo, prNum.toString());
+    await updateDrciComments(ctx.octokit, repo, [prNum]);
   }
 
   async handleCherryPick(

--- a/torchci/lib/fetchRecentWorkflows.ts
+++ b/torchci/lib/fetchRecentWorkflows.ts
@@ -3,12 +3,12 @@ import { RecentWorkflowsData } from "./types";
 
 export async function fetchRecentWorkflows(
   repo: string = "pytorch/pytorch",
-  prNumber: string = "0",
+  prNumbers: Array<number> = [],
   numMinutes: string = "30"
 ): Promise<RecentWorkflowsData[]> {
   return await queryClickhouseSaved("recent_pr_workflows_query", {
     numMinutes,
-    prNumber,
+    prNumbers,
     repo,
   });
 }


### PR DESCRIPTION
Dr. CI updates comments every 15 minutes (done via GHA) and queries for the last 30 minutes of completed jobs in order to account for small errors like Dr. CI not actually running due to GHA not scheduling in time.

However, if Dr. CI fails to run multiple times in a row or webhooks are sent late (ex there was an outage), we can get cases where the job completes but Dr. CI never picks it up, so the comment always says that there is something pending.

One way to solve this (implemented here) is to also query for comments that say there are jobs pending and update those too.

Currently, it searches for any comments that say there are things pending in the last month (do we want to make this interval smaller?) and Dr. CI will update those as well.

Drawbacks:
* additional CH queries
* probably a lot of overlap between jobs that finished in the last 30 minutes and comments that say pending
