### PR TITLE
Reland "[ch] replicator lambdas: external contribution stats (s3), wait time/pr_stats (dynamo)"

### DIFF
--- a/aws/lambda/clickhouse-replicator-dynamo/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-dynamo/lambda_function.py
@@ -184,7 +184,7 @@ def upsert_documents(table: str, documents: List[Any]) -> None:
 
     print(f"UPSERTING {len(documents)} INTO {table}")
     res = get_clickhouse_client().query(
-        f"INSERT INTO `{table}` SETTINGS async_insert=1, wait_for_async_insert=1 FORMAT JSONEachRow {body}"
+        f"INSERT INTO {table} SETTINGS async_insert=1, wait_for_async_insert=1 FORMAT JSONEachRow {body}"
     )
     print(res)
 
@@ -205,5 +205,5 @@ def remove_document(record: Any) -> None:
 
     parameters = {"id": id}
     get_clickhouse_client().query(
-        f"DELETE FROM `{table}` WHERE dynamoKey = %(id)s", parameters=parameters
+        f"DELETE FROM {table} WHERE dynamoKey = %(id)s", parameters=parameters
     )

--- a/aws/lambda/clickhouse-replicator-dynamo/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-dynamo/lambda_function.py
@@ -17,15 +17,16 @@ CLICKHOUSE_ENDPOINT = os.getenv("CLICKHOUSE_ENDPOINT", "")
 CLICKHOUSE_USERNAME = os.getenv("CLICKHOUSE_USERNAME", "default")
 CLICKHOUSE_PASSWORD = os.getenv("CLICKHOUSE_PASSWORD", "")
 SUPPORTED_TABLES = {
-    "torchci-workflow-job": "workflow_job",
-    "torchci-workflow-run": "workflow_run",
-    "torchci-push": "push",
-    "torchci-pull-request": "pull_request",
-    "torchci-issues": "issues",
-    "torchci-issue-comment": "issue_comment",
-    "torchci-job-annotation": "job_annotation",
-    "torchci-pull-request-review": "pull_request_review",
-    "torchci-pull-request-review-comment": "pull_request_review_comment",
+    "torchci-workflow-job": "default.workflow_job",
+    "torchci-workflow-run": "default.workflow_run",
+    "torchci-push": "default.push",
+    "torchci-pull-request": "default.pull_request",
+    "torchci-issues": "default.issues",
+    "torchci-issue-comment": "default.issue_comment",
+    "torchci-job-annotation": "default.job_annotation",
+    "torchci-pull-request-review": "default.pull_request_review",
+    "torchci-pull-request-review-comment": "default.pull_request_review_comment",
+    "torchci-metrics-ci-wait-time": "misc.metrics_ci_wait_time",
 }
 
 
@@ -183,7 +184,7 @@ def upsert_documents(table: str, documents: List[Any]) -> None:
 
     print(f"UPSERTING {len(documents)} INTO {table}")
     res = get_clickhouse_client().query(
-        f"INSERT INTO default.`{table}` SETTINGS async_insert=1, wait_for_async_insert=1 FORMAT JSONEachRow {body}"
+        f"INSERT INTO `{table}` SETTINGS async_insert=1, wait_for_async_insert=1 FORMAT JSONEachRow {body}"
     )
     print(res)
 

--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -104,17 +104,17 @@ def handle_test_run_s3(table, bucket, key) -> List[Dict[str, Any]]:
     select
         classname,
         duration,
-        {get_skipped_failure_parser_helper('error', 'Tuple(type String, message String, text String)', 'type')},
-        {get_skipped_failure_parser_helper('failure', 'Tuple(type String, message String, text String)', 'type')},
+        {get_skipped_failure_parser_helper('error', 'Tuple(type String, message String, text String)', 'message')},
+        {get_skipped_failure_parser_helper('failure', 'Tuple(type String, message String, text String)', 'message')},
         file,
         invoking_file,
         job_id,
         line::Int64,
         name,
         properties,
-        {get_skipped_failure_parser_helper('rerun', 'Tuple(message String, text String)', 'type')},
+        {get_skipped_failure_parser_helper('rerun', 'Tuple(message String, text String)', 'message')},
         result,
-        {get_skipped_failure_parser_helper('skipped', 'Tuple(type String, message String, text String)', 'type')},
+        {get_skipped_failure_parser_helper('skipped', 'Tuple(type String, message String, text String)', 'message')},
         status,
         {get_sys_err_out_parser('system-err')},
         {get_sys_err_out_parser('system-out')},
@@ -327,24 +327,54 @@ def queue_times_historical_adapter(table, bucket, key) -> None:
         get_clickhouse_client().query(get_insert_query("none"))
 
 
+def external_contribution_stats_adapter(table, bucket, key) -> None:
+    schema = """
+    `date` String,
+    `pr_count` Int64,
+    `user_count` Int64,
+    `users` Array(String)
+    """
+    url = f"https://{bucket}.s3.amazonaws.com/{encode_url_component(key)}"
+
+    def get_insert_query(compression):
+        return f"""
+        insert into {table}
+        select *, ('{bucket}', '{key}')
+        from s3('{url}', 'JSONEachRow', '{schema}', '{compression}',
+            extra_credentials(
+                role_arn = 'arn:aws:iam::308535385114:role/clickhouse_role'
+            )
+        )
+        """
+
+    try:
+        get_clickhouse_client().query(get_insert_query("gzip"))
+    except Exception as e:
+        get_clickhouse_client().query(
+            f"insert into errors.gen_errors ('{table}', '{bucket}', '{key}', '{json.dumps(str(e))}')"
+        )
+
+
 SUPPORTED_PATHS = {
-    "merges": "merges",
-    "queue_times_historical": "queue_times_historical",
-    "test_run": "test_run_s3",
-    "test_run_summary": "test_run_summary",
-    "merge_bases": "merge_bases",
-    "failed_test_runs": "failed_test_runs",
-    "rerun_disabled_tests": "rerun_disabled_tests",
+    "merges": "default.merges",
+    "queue_times_historical": "default.queue_times_historical",
+    "test_run": "default.test_run_s3",
+    "test_run_summary": "default.test_run_summary",
+    "merge_bases": "default.merge_bases",
+    "failed_test_runs": "default.failed_test_runs",
+    "rerun_disabled_tests": "default.rerun_disabled_tests",
+    "external_contribution_counts": "misc.external_contribution_stats",
 }
 
 OBJECT_CONVERTER = {
-    "merges": merges_adapter,
-    "test_run_s3": handle_test_run_s3,
-    "failed_test_runs": handle_test_run_s3,
-    "test_run_summary": handle_test_run_summary,
-    "merge_bases": merge_bases_adapter,
-    "rerun_disabled_tests": rerun_disabled_tests_adapter,
-    "queue_times_historical": queue_times_historical_adapter,
+    "default.merges": merges_adapter,
+    "default.test_run_s3": handle_test_run_s3,
+    "default.failed_test_runs": handle_test_run_s3,
+    "default.test_run_summary": handle_test_run_summary,
+    "default.merge_bases": merge_bases_adapter,
+    "default.rerun_disabled_tests": rerun_disabled_tests_adapter,
+    "default.queue_times_historical": queue_times_historical_adapter,
+    "misc.external_contribution_stats": external_contribution_stats_adapter,
 }
 
 


### PR DESCRIPTION
Reverts pytorch/test-infra#5709 with correct code

See most recent commit for change (the quotations was wrong)

Testing here: https://github.com/pytorch/test-infra/pull/5711