### PR TITLE
[ch] Set up ingestion for benchmarks tables and aggregated_test_metrics

### DIFF
--- a/aws/lambda/clickhouse-replicator-dynamo/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-dynamo/lambda_function.py
@@ -27,6 +27,8 @@ SUPPORTED_TABLES = {
     "torchci-pull-request-review": "default.pull_request_review",
     "torchci-pull-request-review-comment": "default.pull_request_review_comment",
     "torchci-metrics-ci-wait-time": "misc.metrics_ci_wait_time",
+    "torchci-dynamo-perf-stats": "benchmark.inductor_torch_dynamo_perf_stats",
+    "torchci-oss-ci-benchmark": "benchmark.oss_ci_benchmark_v2",
 }
 
 

--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -544,21 +544,3 @@ def remove_document(record: Any) -> None:
     # get_clickhouse_client().query(
     #     f"DELETE FROM `{table}` WHERE dynamoKey = %(id)s", parameters=parameters
     # )
-
-
-if __name__ == "__main__":
-    lambda_handler({
-        "Records": [
-            {
-                "eventName": "ObjectCreated",
-                "s3": {
-                    "bucket": {
-                        "name": "torchci-aggregated-stats",
-                    },
-                    "object": {
-                        "key": "test_data_aggregates/2024-09-25",
-                    },
-                },
-            },
-        ],
-    }, None)

--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -351,7 +351,7 @@ def external_contribution_stats_adapter(table, bucket, key) -> None:
         get_clickhouse_client().query(get_insert_query("gzip"))
     except Exception as e:
         get_clickhouse_client().query(
-            f"insert into errors.gen_errors ('{table}', '{bucket}', '{key}', '{json.dumps(str(e))}')"
+            f"insert into errors.gen_errors VALUES ('{table}', '{bucket}', '{key}', '{json.dumps(str(e))}')"
         )
 
 


### PR DESCRIPTION
s3 tested by running locally and seeing if it got inserted
dynamo only checked `python aws/lambda/clickhouse-replicator-dynamo/test_lambda_function.py` to make sure other ingestions didn't break

Also small fix for external_contribution_stats error handler

