### PR TITLE
Fix wrong commit date on benchmark dashboards

### DIFF
--- a/torchci/components/benchmark/CommitPanel.tsx
+++ b/torchci/components/benchmark/CommitPanel.tsx
@@ -1,6 +1,5 @@
 import { Stack, Typography } from "@mui/material";
 import { SHA_DISPLAY_LENGTH } from "components/benchmark/common";
-import dayjs from "dayjs";
 import { BranchAndCommit } from "lib/types";
 import { ReactNode } from "react";
 
@@ -27,8 +26,7 @@ export function CommitPanel({
         >
           {lBranchAndCommit.commit.substring(0, SHA_DISPLAY_LENGTH)}
         </a>{" "}
-        on {dayjs(lBranchAndCommit.date).format("YYYY/MM/DD")} comparing with{" "}
-        {rBranchAndCommit.branch} branch at commit{" "}
+        comparing with {rBranchAndCommit.branch} branch at commit{" "}
         <a
           href={`/${repoName}/commit/${rBranchAndCommit.commit}#${workflowName}`}
         >

--- a/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_branches.sql
+++ b/torchci/rockset/benchmarks/__sql/oss_ci_benchmark_branches.sql
@@ -5,7 +5,7 @@ SELECT
   w.head_sha,
   w.id,
   FORMAT_ISO8601(
-    DATE_TRUNC(: granularity, TIMESTAMP_MILLIS(o.timestamp))
+    DATE_TRUNC('day', TIMESTAMP_MILLIS(o.timestamp))
   ) AS event_time,
   o.filename
 FROM

--- a/torchci/rockset/benchmarks/oss_ci_benchmark_branches.lambda.json
+++ b/torchci/rockset/benchmarks/oss_ci_benchmark_branches.lambda.json
@@ -12,11 +12,6 @@
       "value": ""
     },
     {
-      "name": "granularity",
-      "type": "string",
-      "value": "day"
-    },
-    {
       "name": "repo",
       "type": "string",
       "value": "pytorch/pytorch"

--- a/torchci/rockset/inductor/__sql/compilers_benchmark_performance_branches.sql
+++ b/torchci/rockset/inductor/__sql/compilers_benchmark_performance_branches.sql
@@ -4,7 +4,7 @@ SELECT
   w.id,
   FORMAT_ISO8601(
     DATE_TRUNC(
-      : granularity, TIMESTAMP_MILLIS(p.timestamp)
+      'day', TIMESTAMP_MILLIS(p.timestamp)
     )
   ) AS event_time,
 FROM

--- a/torchci/rockset/inductor/compilers_benchmark_performance_branches.lambda.json
+++ b/torchci/rockset/inductor/compilers_benchmark_performance_branches.lambda.json
@@ -12,11 +12,6 @@
       "value": "amp"
     },
     {
-      "name": "granularity",
-      "type": "string",
-      "value": "day"
-    },
-    {
       "name": "mode",
       "type": "string",
       "value": "training"

--- a/torchci/rockset/prodVersions.json
+++ b/torchci/rockset/prodVersions.json
@@ -84,7 +84,7 @@
   },
   "inductor": {
     "compilers_benchmark_performance": "442c41fbbc0eb758",
-    "compilers_benchmark_performance_branches": "a07ce298be770d63",
+    "compilers_benchmark_performance_branches": "2d47c0ef6d04d7f1",
     "torchao_query": "89dd8524b4784c7b",
     "torchao_query_branches": "dae2141eab66e839"
   },
@@ -110,7 +110,7 @@
   },
   "benchmarks": {
     "oss_ci_benchmark_llms": "ec0dd4a03918ba0f",
-    "oss_ci_benchmark_branches": "c23c2d736b13edd4",
+    "oss_ci_benchmark_branches": "80fdbef4cf5b8360",
     "oss_ci_benchmark_names": "80824879afbc1c5b"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/pytorch/test-infra/issues/5696

I discover two issues with the current query to get the commits and their date:

* The query inherits the granularity parameter, so when the granularity is set to week, for example, all commit's dates are truncated to the beginning of the week.  This is the root cause of https://github.com/pytorch/test-infra/issues/5696.  For more context, switching to weekly granularity is a hack I have at the moment to be able to reduce the payload side and be able to load last quarter data (https://github.com/pytorch/test-infra/issues/4123).  So the issue only manifests when a time range from last quarter or more is selected.  The fix then is just to truncate commit's dates by day because that's the format displayed in the dashboard (YYYY/MM/DD)
* Truncating the commit's date by day also fixes an off-by-one-day mismatch in the dashboard.  For example, [77fba0c407](https://hud.pytorch.org/pytorch/pytorch/commit/77fba0c407c10e3e2b5182578aa8affae6abc398#inductor-A100-perf-nightly)'s date is 2024/09/26, which is actually a day later than the actual date https://github.com/pytorch/pytorch/commit/77fba0c407c10e3e2b5182578aa8affae6abc398 (2024/09/25)

### Testing

* Selecting last quarter with weekly granularity doesn't screw up the commit's dates now https://torchci-git-fork-huydhn-fix-wrong-commit-da-ccea24-fbopensource.vercel.app/benchmark/compilers?dashboard=torchinductor&startTime=Sat%2C%2029%20Jun%202024%2005%3A17%3A28%20GMT&stopTime=Fri%2C%2027%20Sep%202024%2005%3A17%3A28%20GMT&granularity=week&suite=torchbench&mode=inference&dtype=bfloat16&deviceName=cuda%20(a100)&lBranch=main&lCommit=77fba0c407c10e3e2b5182578aa8affae6abc398&rBranch=main&rCommit=a676b7c5f3cf05690afbce3c99575916b3b468aa
* Regular view https://torchci-git-fork-huydhn-fix-wrong-commit-da-ccea24-fbopensource.vercel.app/benchmark/compilers shows the correct commit's dates.
* Other benchmark dashboards also looks correct:
    * https://torchci-git-fork-huydhn-fix-wrong-commit-da-ccea24-fbopensource.vercel.app/benchmark/llms