### PR TITLE
[ch] Refactor/unify s3 lambda, improve s3 backfill script

### DIFF
--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -302,7 +302,9 @@ def general_adapter(table, bucket, key, schema, compressions, format) -> None:
                 return
             except Exception as e:
                 exceptions.append(e)
-        raise Exception(f"Failed to insert into {table} with {exceptions}")
+        raise Exception(
+            f"Failed to insert into {table} with {[str(x) for x in exceptions]}"
+        )
     except Exception as e:
         log_failure_to_clickhouse(table, bucket, key, e)
 
@@ -389,7 +391,7 @@ def torchbench_userbenchmark_adapter(table, bucket, key):
 SUPPORTED_PATHS = {
     "merges": "default.merges",
     "queue_times_historical": "default.queue_times_historical",
-    "test_run": "default.test_run_s3",
+    "test_run": "fortesting.test_run_s3",
     "test_run_summary": "default.test_run_summary",
     "merge_bases": "default.merge_bases",
     "failed_test_runs": "default.failed_test_runs",
@@ -402,7 +404,7 @@ SUPPORTED_PATHS = {
 
 OBJECT_CONVERTER = {
     "default.merges": merges_adapter,
-    "default.test_run_s3": handle_test_run_s3,
+    "fortesting.test_run_s3": handle_test_run_s3,
     "default.failed_test_runs": handle_test_run_s3,
     "default.test_run_summary": handle_test_run_summary,
     "default.merge_bases": merge_bases_adapter,

--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -391,7 +391,7 @@ def torchbench_userbenchmark_adapter(table, bucket, key):
 SUPPORTED_PATHS = {
     "merges": "default.merges",
     "queue_times_historical": "default.queue_times_historical",
-    "test_run": "fortesting.test_run_s3",
+    "test_run": "default.test_run_s3",
     "test_run_summary": "default.test_run_summary",
     "merge_bases": "default.merge_bases",
     "failed_test_runs": "default.failed_test_runs",
@@ -404,7 +404,7 @@ SUPPORTED_PATHS = {
 
 OBJECT_CONVERTER = {
     "default.merges": merges_adapter,
-    "fortesting.test_run_s3": handle_test_run_s3,
+    "default.test_run_s3": handle_test_run_s3,
     "default.failed_test_runs": handle_test_run_s3,
     "default.test_run_summary": handle_test_run_summary,
     "default.merge_bases": merge_bases_adapter,

--- a/tools/rockset_migration/dynamo2ch.py
+++ b/tools/rockset_migration/dynamo2ch.py
@@ -160,7 +160,7 @@ def upload_to_clickhouse(records, table):
     # Async insert to maybe make insertions more efficient on the ClickHouse side
     # https://clickhouse.com/docs/en/cloud/bestpractices/asynchronous-inserts
     get_clickhouse_client().query(
-        f"INSERT INTO `{table}`  SETTINGS async_insert=1, wait_for_async_insert=1  FORMAT JSONEachRow {body}"
+        f"INSERT INTO {table}  SETTINGS async_insert=1, wait_for_async_insert=1  FORMAT JSONEachRow {body}"
     )
 
 

--- a/tools/rockset_migration/s32ch.py
+++ b/tools/rockset_migration/s32ch.py
@@ -25,7 +25,9 @@ from prefetch_generator import BackgroundGenerator
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.append(str(REPO_ROOT))
-lambda_function = importlib.import_module("aws.lambda.clickhouse-replicator-s3.lambda_function")
+lambda_function = importlib.import_module(
+    "aws.lambda.clickhouse-replicator-s3.lambda_function"
+)
 sys.path.pop()
 
 
@@ -107,6 +109,8 @@ def scan_s3_bucket(bucket: str, prefix: str, last_evaluated_key: Optional[str] =
 
 
 ADAPTERS = lambda_function.OBJECT_CONVERTER
+
+
 def wait_for_async_and_save(
     async_res, stored_data_file, last_evaluated_key, item_count, stored_data
 ) -> None:


### PR DESCRIPTION
Refactor the s3 replicator lambda to reduce dup code and have better error handling (upload to same database so we don't have to create a new one each time)

Tested via:
* randomly selecting a key for merges, merge_bases, rerun_disabled_tests, external_contribution_stats and checking that it could be uploaded
* backfilled inductor_torchao_perf_stats and torchbench_userbenchmark
* rebackfilled queue_times_historical and removed dups
* raise an exception to see if the error handler wrote to the database (it did)

Reused logic from lambda replicator in s3 backfill script