### PR TITLE
viable strict update: fix multiline output 

### DIFF
--- a/.github/actions/update-viablestrict/action.yml
+++ b/.github/actions/update-viablestrict/action.yml
@@ -105,6 +105,10 @@ runs:
         # Pushing an older green commit here will fail because it's non-fast-forward, which is ok
         # to ignore because we already have the later green commit in visable/strict
         push_result=$(git push origin "${LATEST_VIABLE_SHA}:${STABLE_BRANCH}" 2>&1 || true)
-        echo "push_result=$push_result" >> "${GITHUB_OUTPUT}"
+        {
+          echo 'push_result<<EOF'
+          echo $push_result
+          echo EOF
+        } >> "${GITHUB_OUTPUT}"
         echo "${push_result}"
         echo "time=$(date +%s)" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
Fixes output not writing correctly due to multiline string

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings


Example 
https://github.com/pytorch/pytorch/actions/runs/11091486634/job/30815281180#step:2:8268
```

+ output=156ca01e51f766b1b069c5c6f3d57112a5c8f9ff
+ echo latest_viable_sha=156ca01e51f766b1b069c5c6f3d57112a5c8f9ff
Run git config --global user.email "pytorchmergebot@users.noreply.github.com"
  git config --global user.email "pytorchmergebot@users.noreply.github.com"
  git config --global user.name "PyTorch MergeBot"
  
  echo "Set the latest sha variable to be ${LATEST_VIABLE_SHA}"
  # Pushing an older green commit here will fail because it's non-fast-forward, which is ok
  # to ignore because we already have the later green commit in visable/strict
  push_result=$(git push origin "${LATEST_VIABLE_SHA}:${STABLE_BRANCH}" 2>&1 || true)
  echo "push_result=$push_result" >> "${GITHUB_OUTPUT}"
  echo "${push_result}"
  echo "time=$(date +%s)" >> "${GITHUB_OUTPUT}"
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.11.10/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.10/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.10/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.10/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.10/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.10/x64/lib
    GITHUB_TOKEN: ***
    STABLE_BRANCH: viable/strict
    LATEST_VIABLE_SHA: 156ca01e51f766b1b069c5c6f3d57112a5c8f9ff
Set the latest sha variable to be 156ca01e51f766b1b069c5c6f3d57112a5c8f9ff
remote: 
remote: GitHub found 5 vulnerabilities on pytorch/pytorch's default branch (3 high, 1 moderate, 1 low). To find out more, visit:        
remote:      https://github.com/pytorch/pytorch/security/dependabot        
remote: 
To https://github.com/pytorch/pytorch
   1d6e0412f5..156ca01e51  156ca01e51f766b1b069c5c6f3d57112a5c8f9ff -> viable/strict
Error: Unable to process file command 'output' successfully.
Error: Invalid format 'remote: GitHub found 5 vulnerabilities on pytorch/pytorch's default branch (3 high, 1 moderate, 1 low). To find out more, visit:        '

```