### PR TITLE
[ch] tts_duration_historical (not gated)

### DIFF
--- a/torchci/clickhouse_queries/tts_duration_historical/params.json
+++ b/torchci/clickhouse_queries/tts_duration_historical/params.json
@@ -2,6 +2,5 @@
   "granularity": "String",
   "startTime": "DateTime64(3)",
   "stopTime": "DateTime64(3)",
-  "timezone": "String",
   "workflowNames": "String"
 }

--- a/torchci/clickhouse_queries/tts_duration_historical/query.sql
+++ b/torchci/clickhouse_queries/tts_duration_historical/query.sql
@@ -1,29 +1,39 @@
--- !!! Query is not converted to CH syntax yet.  Delete this line when it gets converted
-SELECT
-    FORMAT_ISO8601(
-        DATE_TRUNC(
-            :granularity,
-            job._event_time AT TIME ZONE :timezone
+with jobs as (
+    select
+        run_id,
+        created_at,
+        completed_at,
+        started_at,
+        name
+    from default.workflow_job
+    where
+        id in (
+            select id from materialized_views.workflow_job_by_created_at
+            where created_at >= {startTime: String} and created_at < {stopTime: String}
         )
+)
+SELECT
+    DATE_TRUNC(
+        {granularity: String},
+        job.created_at,
     ) AS granularity_bucket,
     AVG(DATE_DIFF(
         'second',
-        PARSE_TIMESTAMP_ISO8601(workflow.created_at) AT TIME ZONE :timezone,
-        PARSE_TIMESTAMP_ISO8601(job.completed_at) AT TIME ZONE :timezone
+        workflow.created_at,
+        job.completed_at
     )) as tts_avg_sec,
     AVG(DATE_DIFF(
         'second',
-        PARSE_TIMESTAMP_ISO8601(job.started_at) AT TIME ZONE :timezone,
-        PARSE_TIMESTAMP_ISO8601(job.completed_at) AT TIME ZONE :timezone
+        job.started_at,
+        job.completed_at
     )) as duration_avg_sec,
-    CONCAT(workflow.name, ' / ', job.name) as full_name,
+    CONCAT(workflow.name, ' / ', job.name) as full_name
 FROM
-    commons.workflow_job job
-    JOIN commons.workflow_run workflow on workflow.id = job.run_id
+    jobs job
+    JOIN default.workflow_run workflow final on workflow.id = job.run_id
 WHERE
-    job._event_time >= PARSE_DATETIME_ISO8601(:startTime)
-    AND job._event_time < PARSE_DATETIME_ISO8601(:stopTime)
-    AND ARRAY_CONTAINS(SPLIT(:workflowNames, ','), workflow.name)
+    workflow.id in (select run_id from jobs)
+    and workflow.name in {workflowNames: Array(String)}
 	AND workflow.head_branch LIKE 'main'
     AND workflow.run_attempt = 1
 GROUP BY

--- a/torchci/clickhouse_queries/tts_duration_historical/query.sql
+++ b/torchci/clickhouse_queries/tts_duration_historical/query.sql
@@ -15,7 +15,7 @@ with jobs as (
 SELECT
     DATE_TRUNC(
         {granularity: String},
-        job.created_at,
+        job.created_at
     ) AS granularity_bucket,
     AVG(DATE_DIFF(
         'second',

--- a/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -83,7 +83,7 @@ function Graphs({
   filter,
   toggleFilter,
 }: {
-  queryParams: {};
+  queryParams: { [k: string]: any };
   granularity: Granularity;
   ttsPercentile: number;
   checkboxRef: any;
@@ -129,8 +129,8 @@ function Graphs({
     return <Skeleton variant={"rectangular"} height={"100%"} />;
   }
 
-  let startTime = (queryParams as any)["startTime"];
-  let stopTime = (queryParams as any)["stopTime"];
+  let startTime = queryParams["startTime"];
+  let stopTime = queryParams["stopTime"];
 
   // Clamp to the nearest granularity (e.g. nearest hour) so that the times will
   // align with the data we get from Rockset


### PR DESCRIPTION
Migrate tts_duration_historical to CH.  Use CH always

Breaks the page because this is only 1 query (select avg on the page) of 2 (the other is percentiles) 

Remove timezone option: imo too confusing when comparing pages with other people due to the group by value changing

There are small differences in graph with original query that I assume is just due to _event_time vs created_at

https://hud.pytorch.org/tts