### PR TITLE
[ch] set up ingestion for metrics and stable pushes tables

### DIFF
--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -476,7 +476,7 @@ def ossci_uploaded_metrics_adapter(table, bucket, key):
     `timestamp` DateTime64(9),
     `info` String
     """
-    general_adapter(table, bucket, key, schema, "none", "JSONEachRow")
+    general_adapter(table, bucket, key, schema, "gzip", "JSONEachRow")
 
 
 SUPPORTED_PATHS = {

--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -456,6 +456,29 @@ def torchbench_userbenchmark_adapter(table, bucket, key):
     general_adapter(table, bucket, key, schema, "none", "JSONEachRow")
 
 
+def ossci_uploaded_metrics_adapter(table, bucket, key):
+    schema = """
+    `repo` String,
+    `workflow` String,
+    `build_environment` String,
+    `job` String,
+    `test_config` String,
+    `pr_number` Int64,
+    `run_id` Int64,
+    `run_number` Int64,
+    `run_attempt` Int64,
+    `job_id` Int64,
+    `job_name` String,
+    `metric_name` String,
+    `calling_file` String,
+    `calling_module` String,
+    `calling_function` String,
+    `timestamp` DateTime64(9),
+    `info` String
+    """
+    general_adapter(table, bucket, key, schema, "none", "JSONEachRow")
+
+
 SUPPORTED_PATHS = {
     "merges": "default.merges",
     "queue_times_historical": "default.queue_times_historical",
@@ -468,6 +491,7 @@ SUPPORTED_PATHS = {
     "test_data_aggregates": "misc.aggregated_test_metrics",
     "torchbench-csv/torchao": "benchmark.inductor_torchao_perf_stats",
     "torchbench-userbenchmark": "benchmark.torchbench_userbenchmark",
+    "ossci_uploaded_metrics": "misc.ossci_uploaded_metrics",
 }
 
 OBJECT_CONVERTER = {
@@ -482,6 +506,7 @@ OBJECT_CONVERTER = {
     "misc.aggregated_test_metrics": external_aggregated_test_metrics_adapter,
     "benchmark.inductor_torchao_perf_stats": torchao_perf_stats_adapter,
     "benchmark.torchbench_userbenchmark": torchbench_userbenchmark_adapter,
+    "misc.ossci_uploaded_metrics": ossci_uploaded_metrics_adapter,
 }
 
 

--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -479,6 +479,15 @@ def ossci_uploaded_metrics_adapter(table, bucket, key):
     general_adapter(table, bucket, key, schema, "gzip", "JSONEachRow")
 
 
+def stable_pushes_adapter(table, bucket, key):
+    schema = """
+    `sha` String,
+    `repository` String,
+    `timestamp` DateTime
+    """
+    general_adapter(table, bucket, key, schema, "none", "JSONEachRow")
+
+
 SUPPORTED_PATHS = {
     "merges": "default.merges",
     "queue_times_historical": "default.queue_times_historical",
@@ -492,6 +501,7 @@ SUPPORTED_PATHS = {
     "torchbench-csv/torchao": "benchmark.inductor_torchao_perf_stats",
     "torchbench-userbenchmark": "benchmark.torchbench_userbenchmark",
     "ossci_uploaded_metrics": "misc.ossci_uploaded_metrics",
+    "stable_pushes": "misc.stable_pushes",
 }
 
 OBJECT_CONVERTER = {
@@ -507,6 +517,7 @@ OBJECT_CONVERTER = {
     "benchmark.inductor_torchao_perf_stats": torchao_perf_stats_adapter,
     "benchmark.torchbench_userbenchmark": torchbench_userbenchmark_adapter,
     "misc.ossci_uploaded_metrics": ossci_uploaded_metrics_adapter,
+    "misc.stable_pushes": stable_pushes_adapter,
 }
 
 
@@ -569,3 +580,21 @@ def remove_document(record: Any) -> None:
     # get_clickhouse_client().query(
     #     f"DELETE FROM `{table}` WHERE dynamoKey = %(id)s", parameters=parameters
     # )
+
+
+lambda_handler(
+    {
+        "Records": [
+            {
+                "eventName": "ObjectCreated:Put",
+                "s3": {
+                    "bucket": {"name": "ossci-raw-job-status"},
+                    "object": {
+                        "key": "stable_pushes/pytorch/pytorch/0788d016d61a683f2348190bf9314b3c1b9265b4.json"
+                    },
+                },
+            }
+        ]
+    },
+    None,
+)

--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -580,21 +580,3 @@ def remove_document(record: Any) -> None:
     # get_clickhouse_client().query(
     #     f"DELETE FROM `{table}` WHERE dynamoKey = %(id)s", parameters=parameters
     # )
-
-
-lambda_handler(
-    {
-        "Records": [
-            {
-                "eventName": "ObjectCreated:Put",
-                "s3": {
-                    "bucket": {"name": "ossci-raw-job-status"},
-                    "object": {
-                        "key": "stable_pushes/pytorch/pytorch/0788d016d61a683f2348190bf9314b3c1b9265b4.json"
-                    },
-                },
-            }
-        ]
-    },
-    None,
-)


### PR DESCRIPTION
* Renamed metrics table to ossci_uploaded_metrics
* Relevant PR for metrics table: https://github.com/pytorch/pytorch/pull/136799 
* Relevant info for stable pushes table: https://github.com/pytorch/pytorch/pull/136470

---

Tested by running the lambda handler on some docs currently in those bucket/paths