### PR TITLE
Add psutil to torchtune dependencies for v0.3.1 release

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -64,6 +64,7 @@ PACKAGE_ALLOW_LIST = {
     "multiprocess",
     "omegaconf",
     "pandas",
+    "psutil",
     "pyarrow",
     "pyarrow_hotfix",
     "pycryptodomex",


### PR DESCRIPTION
torchtune's 0.3.1 release added psutil as a dependency: https://github.com/pytorch/torchtune/blob/main/pyproject.toml#L28

We add it to the list of additional packages for torchtune in `s3_management/manage.py` here.