### PR TITLE
[Temp] Use Meta CDN for building domain binaries

### DIFF
--- a/tools/pkg-helpers/pytorch_pkg_helpers/wheel.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/wheel.py
@@ -18,12 +18,15 @@ def get_pytorch_pip_install_command(
     channel: str,
 ) -> List[str]:
     torch_pkg = "torch"
+    download_pytorch_org = "download.pytorch.org"
     if pytorch_version != "":
         torch_pkg += f"=={pytorch_version}"
     pip_install = f"pip install {torch_pkg}"
     if channel == "nightly":
         pip_install += " --pre"
-    extra_index = f"https://download.pytorch.org/whl/{channel}/{gpu_arch_version}"
+        # Use Meta CDN for nightly builds
+        download_pytorch_org = "d3kup0pazkvub8.cloudfront.net"
+    extra_index = f"https://{download_pytorch_org}/whl/{channel}/{gpu_arch_version}"
     return [f"export PIP_INSTALL_TORCH='{pip_install} --index-url {extra_index}'"]
 
 


### PR DESCRIPTION
We already use Meta CDN in builder validation as an option:
https://github.com/pytorch/builder/pull/1999

Here is the log from builder:
```
+++ pip3 install --pre torch torchvision torchaudio --index-url https://d3kup0pazkvub8.cloudfront.net/whl/nightly/cu121
Looking in indexes: https://d3kup0pazkvub8.cloudfront.net/whl/nightly/cu121
Collecting torch
  Downloading https://d3kup0pazkvub8.cloudfront.net/whl/nightly/cu121/torch-2.6.0.dev20241003%2Bcu121-cp310-cp310-win_amd64.whl (2451.6 MB)
     ---------------------------------------- 2.5/2.5 GB 45.6 MB/s eta 0:00:00
Collecting torchvision
  Downloading https://d3kup0pazkvub8.cloudfront.net/whl/nightly/cu121/torchvision-0.20.0.dev20241003%2Bcu121-cp310-cp310-win_amd64.whl (6.2 MB)
     ---------------------------------------- 6.2/6.2 MB 31.5 MB/s eta 0:00:00
Collecting torchaudio
  Downloading https://d3kup0pazkvub8.cloudfront.net/whl/nightly/cu121/torchaudio-2.5.0.dev20241003%2Bcu121-cp310-cp310-win_amd64.whl (4.2 MB)
     ---------------------------------------- 4.2/4.2 MB 31.1 MB/s eta 0:00:00
Collecting filelock (from torch)
  Downloading https://d3kup0pazkvub8.cloudfront.net/whl/nightly/filelock-3.13.1-py3-none-any.whl (11 kB)
Collecting typing-extensions>=4.8.0 (from torch)
  Downloading https://d3kup0pazkvub8.cloudfront.net/whl/nightly/typing_extensions-4.12.2-py3-none-any.whl (37 kB)
Collecting networkx (from torch)
  Downloading https://d3kup0pazkvub8.cloudfront.net/whl/nightly/networkx-3.3-py3-none-any.whl (1.7 MB)
     ---------------------------------------- 1.7/1.7 MB 31.3 MB/s eta 0:00:00
Collecting jinja2 (from torch)
  Downloading https://d3kup0pazkvub8.cloudfront.net/whl/nightly/Jinja2-3.1.4-py3-none-any.whl (133 kB)
Collecting fsspec (from torch)
  Downloading https://d3kup0pazkvub8.cloudfront.net/whl/nightly/fsspec-2024.6.1-py3-none-any.whl (177 kB)
Collecting sympy==1.13.1 (from torch)
  Downloading https://d3kup0pazkvub8.cloudfront.net/whl/nightly/sympy-1.13.1-py3-none-any.whl (6.2 MB)
     ---------------------------------------- 6.2/6.2 MB 53.9 MB/s eta 0:00:00
Collecting mpmath<1.4,>=1.1.0 (from sympy==1.13.1->torch)
  Downloading https://d3kup0pazkvub8.cloudfront.net/whl/nightly/mpmath-1.3.0-py3-none-any.whl (536 kB)
     ------------------------------------- 536.2/536.2 kB 17.1 MB/s eta 0:00:00
Requirement already satisfied: numpy in c:\jenkins\miniconda3\envs\conda-env-11165033321\lib\site-packages (from torchvision) (2.0.1)
Collecting pillow!=8.3.*,>=5.3.0 (from torchvision)
  Downloading https://d3kup0pazkvub8.cloudfront.net/whl/nightly/Pillow-9.3.0-cp310-cp310-win_amd64.whl (2.5 MB)
     ---------------------------------------- 2.5/2.5 MB 146.9 MB/s eta 0:00:00
Collecting MarkupSafe>=2.0 (from jinja2->torch)
  Downloading https://d3kup0pazkvub8.cloudfront.net/whl/nightly/MarkupSafe-2.1.5-cp310-cp310-win_amd64.whl (17 kB)
Installing collected packages: mpmath, typing-extensions, sympy, pillow, networkx, MarkupSafe, fsspec, filelock, jinja2, torch, torchvision, torchaudio```