### PR TITLE
Revert "Use python3 instead of python for macos wheels build"

### DIFF
--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -47,7 +47,7 @@ on:
       build-command:
         description: The build command to use if build-platform is python-build-package
         required: false
-        default: "python3 -m build --wheel"
+        default: "python -m build --wheel"
         type: string
       env-var-script:
         description: "Script that sets Domain-Specific Environment Variables"
@@ -181,7 +181,7 @@ jobs:
           PYTORCH_VERSION="$(${CONDA_RUN} pip show torch | grep ^Version: | sed 's/Version:  *//')"
           export PYTORCH_VERSION
 
-          ${CONDA_RUN} python3 -m pip install build
+          ${CONDA_RUN} python -m pip install build
           echo "Successfully installed Python build package"
 
           ${CONDA_RUN} ${{ inputs.build-command }}


### PR DESCRIPTION
Reverts pytorch/test-infra#5737

This causes issue: https://github.com/pytorch/torchcodec/actions/runs/11155431850/job/31006353091?pr=230

During build, different Python verison is getting picked up, required 3.9 - version used 3.10:

```
+ __conda_exe run -p /Users/ec2-user/runner/_work/_temp/conda_environment_11155431850 python3 -m pip install build
+ /opt/homebrew/Caskroom/miniconda/base/bin/conda run -p /Users/ec2-user/runner/_work/_temp/conda_environment_11155431850 python3 -m pip install build
  WARNING: The script pyproject-build is installed in '/Library/Frameworks/Python.framework/Versions/3.10/bin' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.

Notice:  A new release of pip is available: 23.0.1 -> 24.2
Notice:  To update, run: python3 -m pip install --upgrade pip

```