### PR TITLE
Add ExecuTorch benchmark dashboard

### DIFF
--- a/torchci/clickhouse_queries/oss_ci_benchmark_branches/params.json
+++ b/torchci/clickhouse_queries/oss_ci_benchmark_branches/params.json
@@ -1,7 +1,10 @@
 {
-  "filenames": "Array(String)",
-  "repo": "String",
   "deviceArch": "String",
+  "dtypes": "Array(String)",
+  "excludedMetrics": "Array(String)",
+  "filenames": "Array(String)",
+  "names": "Array(String)",
+  "repo": "String",
   "startTime": "DateTime64(3)",
   "stopTime": "DateTime64(3)"
 }

--- a/torchci/clickhouse_queries/oss_ci_benchmark_branches/query.sql
+++ b/torchci/clickhouse_queries/oss_ci_benchmark_branches/query.sql
@@ -16,6 +16,10 @@ WHERE
         has({filenames: Array(String) }, o.filename)
         OR empty({filenames: Array(String) })
     )
+    AND (
+        has({names: Array(String) }, o.name)
+        OR empty({names: Array(String) })
+    )
     -- NB: DEVICE (ARCH) is the display format used by HUD when grouping together these two fields
     AND (
         CONCAT(
@@ -25,6 +29,14 @@ WHERE
             ')'
         ) = {deviceArch: String }
         OR {deviceArch: String } = ''
+    )
+    AND (
+        has({dtypes: Array(String) }, o.dtype)
+        OR empty({dtypes: Array(String) })
+    )
+    AND (
+        NOT has({excludedMetrics: Array(String) }, o.metric)
+        OR empty({excludedMetrics: Array(String) })
     )
     AND notEmpty(o.metric)
     AND w.html_url LIKE CONCAT('%', {repo: String }, '%')

--- a/torchci/clickhouse_queries/oss_ci_benchmark_llms/params.json
+++ b/torchci/clickhouse_queries/oss_ci_benchmark_llms/params.json
@@ -3,6 +3,7 @@
   "commits": "Array(String)",
   "deviceArch": "String",
   "dtypes": "Array(String)",
+  "excludedMetrics": "Array(String)",
   "filenames": "Array(String)",
   "getJobId": "Bool",
   "granularity": "String",

--- a/torchci/clickhouse_queries/oss_ci_benchmark_llms/query.sql
+++ b/torchci/clickhouse_queries/oss_ci_benchmark_llms/query.sql
@@ -7,8 +7,8 @@ SELECT
     IF({getJobId: Bool}, o.job_id, '') AS job_id,
     o.name,
     o.metric,
-    o.actual AS actual,
-    o.target AS target,
+    floor(toFloat64(o.actual), 2) AS actual,
+    floor(toFloat64(o.target), 2) AS target,
     DATE_TRUNC(
         {granularity: String },
         fromUnixTimestamp64Milli(o.timestamp)
@@ -52,6 +52,10 @@ WHERE
     AND (
         has({dtypes: Array(String) }, o.dtype)
         OR empty({dtypes: Array(String) })
+    )
+    AND (
+        NOT has({excludedMetrics: Array(String) }, o.metric)
+        OR empty({excludedMetrics: Array(String) })
     )
     AND notEmpty(o.metric)
     AND notEmpty(o.dtype)

--- a/torchci/clickhouse_queries/oss_ci_benchmark_names/params.json
+++ b/torchci/clickhouse_queries/oss_ci_benchmark_names/params.json
@@ -1,5 +1,9 @@
 {
+  "deviceArch": "String",
+  "dtypes": "Array(String)",
+  "excludedMetrics": "Array(String)",
   "filenames": "Array(String)",
+  "names": "Array(String)",
   "repo": "String",
   "startTime": "DateTime64(3)",
   "stopTime": "DateTime64(3)"

--- a/torchci/clickhouse_queries/oss_ci_benchmark_names/query.sql
+++ b/torchci/clickhouse_queries/oss_ci_benchmark_names/query.sql
@@ -17,6 +17,28 @@ WHERE
         has({filenames: Array(String) }, o.filename)
         OR empty({filenames: Array(String) })
     )
+    AND (
+        has({names: Array(String) }, o.name)
+        OR empty({names: Array(String) })
+    )
+    -- NB: DEVICE (ARCH) is the display format used by HUD when grouping together these two fields
+    AND (
+        CONCAT(
+            o.device,
+            ' (',
+            IF(empty(o.arch), 'NVIDIA A100-SXM4-40GB', o.arch),
+            ')'
+        ) = {deviceArch: String }
+        OR {deviceArch: String } = ''
+    )
+    AND (
+        has({dtypes: Array(String) }, o.dtype)
+        OR empty({dtypes: Array(String) })
+    )
+    AND (
+        NOT has({excludedMetrics: Array(String) }, o.metric)
+        OR empty({excludedMetrics: Array(String) })
+    )
     AND notEmpty(o.metric)
     AND w.html_url LIKE CONCAT('%', {repo: String }, '%')
     AND notEmpty(o.dtype)

--- a/torchci/components/NavBar.tsx
+++ b/torchci/components/NavBar.tsx
@@ -51,7 +51,11 @@ function NavBar() {
     },
     {
       name: "LLMs",
-      href: "/benchmark/llms",
+      href: "/benchmark/llms?repoName=pytorch%2Fpytorch",
+    },
+    {
+      name: "ExecuTorch",
+      href: "/benchmark/llms?repoName=pytorch%2Fexecutorch",
     },
   ];
 

--- a/torchci/components/benchmark/llms/ModelGraphPanel.tsx
+++ b/torchci/components/benchmark/llms/ModelGraphPanel.tsx
@@ -76,13 +76,17 @@ export function GraphPanel({
   // Clamp to the nearest granularity (e.g. nearest hour) so that the times will
   // align with the data we get from the database
   const startTime = useClickHouse
-    ? (queryParams as { [key: string]: any })["startTime"].startOf(granularity)
+    ? dayjs((queryParams as { [key: string]: any })["startTime"]).startOf(
+        granularity
+      )
     : dayjs(
         (queryParams as RocksetParam[]).find((p) => p.name === "startTime")
           ?.value
       ).startOf(granularity);
   const stopTime = useClickHouse
-    ? (queryParams as { [key: string]: any })["stopTime"].startOf(granularity)
+    ? dayjs((queryParams as { [key: string]: any })["stopTime"]).startOf(
+        granularity
+      )
     : dayjs(
         (queryParams as RocksetParam[]).find((p) => p.name === "stopTime")
           ?.value

--- a/torchci/components/benchmark/llms/SummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/SummaryPanel.tsx
@@ -19,6 +19,7 @@ export function SummaryPanel({
   startTime,
   stopTime,
   granularity,
+  repoName,
   modelName,
   metricNames,
   lPerfData,
@@ -27,6 +28,7 @@ export function SummaryPanel({
   startTime: dayjs.Dayjs;
   stopTime: dayjs.Dayjs;
   granularity: Granularity;
+  repoName: string;
   modelName: string;
   metricNames: string[];
   lPerfData: BranchAndCommitPerfData;
@@ -74,7 +76,9 @@ export function SummaryPanel({
                   return `Invalid dtype for model ${name}`;
                 }
 
-                const url = `/benchmark/llms?startTime=${startTime}&stopTime=${stopTime}&granularity=${granularity}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}&modelName=${encodeURIComponent(
+                const url = `/benchmark/llms?startTime=${startTime}&stopTime=${stopTime}&granularity=${granularity}&lBranch=${lBranch}&lCommit=${lCommit}&rBranch=${rBranch}&rCommit=${rCommit}&repoName=${encodeURIComponent(
+                  repoName
+                )}&modelName=${encodeURIComponent(
                   name
                 )}&dtypeName=${encodeURIComponent(
                   dtype
@@ -165,18 +169,24 @@ export function SummaryPanel({
 
                   // Compute the percentage
                   const target = v.r.target;
-                  const lPercent = target
-                    ? `(${Number((l * 100) / target).toFixed(0)}%)`
-                    : "";
-                  const rPercent = target
-                    ? `(${Number((r * 100) / target).toFixed(0)}%)`
-                    : "";
+                  const lPercent =
+                    target && target != 0
+                      ? `(${Number((l * 100) / target).toFixed(0)}%)`
+                      : "";
+                  const rPercent =
+                    target && target != 0
+                      ? `(${Number((r * 100) / target).toFixed(0)}%)`
+                      : "";
+                  const showTarget =
+                    target && target != 0 ? `[target = ${target}]` : "";
                   const isNewModel = l === 0 ? "(NEW!)" : "";
 
                   if (lCommit === rCommit || l === r) {
-                    return `${r} ${rPercent} [target = ${target}]`;
+                    return `${Number(r).toFixed(2)} ${rPercent} ${showTarget}`;
                   } else {
-                    return `${l} ${lPercent} → ${r} ${rPercent} [target = ${target}] ${isNewModel} `;
+                    return `${Number(l).toFixed(2)} ${lPercent} → ${Number(
+                      r
+                    ).toFixed(2)} ${rPercent} ${showTarget} ${isNewModel} `;
                   }
                 },
               };

--- a/torchci/components/benchmark/llms/SummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/SummaryPanel.tsx
@@ -182,11 +182,9 @@ export function SummaryPanel({
                   const isNewModel = l === 0 ? "(NEW!)" : "";
 
                   if (lCommit === rCommit || l === r) {
-                    return `${Number(r).toFixed(2)} ${rPercent} ${showTarget}`;
+                    return `${r} ${rPercent} ${showTarget}`;
                   } else {
-                    return `${Number(l).toFixed(2)} ${lPercent} → ${Number(
-                      r
-                    ).toFixed(2)} ${rPercent} ${showTarget} ${isNewModel} `;
+                    return `${l} ${lPercent} → ${r} ${rPercent} ${showTarget} ${isNewModel} `;
                   }
                 },
               };

--- a/torchci/components/benchmark/llms/common.tsx
+++ b/torchci/components/benchmark/llms/common.tsx
@@ -1,6 +1,11 @@
 import { BranchAndCommit } from "lib/types";
 
-export const BENCHMARKS = ["gpt_fast_benchmark"];
+export const REPOS = ["pytorch/pytorch", "pytorch/executorch"];
+export const REPO_TO_BENCHMARKS: { [k: string]: string[] } = {
+  "pytorch/pytorch": ["gpt_fast_benchmark"],
+  "pytorch/executorch": ["android-perf", "apple-perf"],
+};
+export const EXCLUDED_METRICS: string[] = ["load_status"];
 export const DEFAULT_MODEL_NAME = "All Models";
 export const SCALE = 2;
 export const METRIC_DISPLAY_HEADERS: { [k: string]: string } = {

--- a/torchci/lib/benchmark/llmUtils.ts
+++ b/torchci/lib/benchmark/llmUtils.ts
@@ -1,7 +1,5 @@
 import {
   BranchAndCommitPerfData,
-  DEFAULT_DTYPE_NAME,
-  DEFAULT_MODEL_NAME,
   LLMsBenchmarkData,
 } from "components/benchmark/llms/common";
 import { fetcher } from "lib/GeneralUtils";
@@ -25,22 +23,10 @@ export function useBenchmark(
     | RocksetParam[]
     | { [key: string]: any } = useClickHouse
     ? {
-        names: modelName === DEFAULT_MODEL_NAME ? [] : [modelName],
-        dtypes: dtypeName === DEFAULT_DTYPE_NAME ? [] : [dtypeName],
         getJobId: getJobId,
         ...queryParams,
       }
     : [
-        {
-          name: "names",
-          type: "string",
-          value: modelName === DEFAULT_MODEL_NAME ? "" : modelName,
-        },
-        {
-          name: "dtypes",
-          type: "string",
-          value: dtypeName === DEFAULT_DTYPE_NAME ? "" : dtypeName,
-        },
         {
           name: "getJobId",
           type: "bool",

--- a/torchci/pages/benchmark/llms.tsx
+++ b/torchci/pages/benchmark/llms.tsx
@@ -397,7 +397,7 @@ export default function Page() {
           commit={lCommit}
           setCommit={setLCommit}
           titlePrefix={"Base"}
-          fallbackIndex={1} // Default to the next to latest in the window
+          fallbackIndex={1} // Default to previous commit
           timeRange={timeRange}
           useClickHouse={useClickHouse}
         />

--- a/torchci/pages/benchmark/llms.tsx
+++ b/torchci/pages/benchmark/llms.tsx
@@ -7,10 +7,11 @@ import {
   MAIN_BRANCH,
 } from "components/benchmark/common";
 import {
-  BENCHMARKS,
   DEFAULT_DEVICE_NAME,
   DEFAULT_DTYPE_NAME,
   DEFAULT_MODEL_NAME,
+  EXCLUDED_METRICS,
+  REPO_TO_BENCHMARKS,
 } from "components/benchmark/llms/common";
 import { GraphPanel } from "components/benchmark/llms/ModelGraphPanel";
 import { SummaryPanel } from "components/benchmark/llms/SummaryPanel";
@@ -128,6 +129,7 @@ function Report({
         startTime={startTime}
         stopTime={stopTime}
         granularity={granularity}
+        repoName={repoName}
         modelName={modelName}
         metricNames={metricNames}
         lPerfData={{
@@ -257,32 +259,50 @@ export default function Page() {
 
   const queryParams: RocksetParam[] = [
     {
+      name: "deviceArch",
+      type: "string",
+      value: deviceName === DEFAULT_DEVICE_NAME ? "" : deviceName,
+    },
+    {
+      name: "dtypes",
+      type: "string",
+      value: dtypeName === DEFAULT_DTYPE_NAME ? "" : dtypeName,
+    },
+    {
+      name: "excludedMetrics",
+      type: "string",
+      value: EXCLUDED_METRICS.join(","),
+    },
+    {
+      name: "filenames",
+      type: "string",
+      value: REPO_TO_BENCHMARKS[repoName].join(","),
+    },
+    {
       name: "granularity",
       type: "string",
       value: granularity,
     },
     {
-      name: "filenames",
+      name: "names",
       type: "string",
-      value: BENCHMARKS.join(","),
+      value: modelName === DEFAULT_MODEL_NAME ? "" : modelName,
     },
     {
       name: "repo",
       type: "string",
       value: repoName,
     },
-    {
-      name: "deviceArch",
-      type: "string",
-      value: deviceName === DEFAULT_DEVICE_NAME ? "" : deviceName,
-    },
     ...timeParams,
   ];
   const queryParamsClickHouse = {
-    granularity: granularity,
-    filenames: BENCHMARKS,
-    repo: repoName,
     deviceArch: deviceName === DEFAULT_DEVICE_NAME ? "" : deviceName,
+    dtypes: dtypeName === DEFAULT_DTYPE_NAME ? [] : [dtypeName],
+    excludedMetrics: EXCLUDED_METRICS,
+    filenames: REPO_TO_BENCHMARKS[repoName],
+    granularity: granularity,
+    names: modelName === DEFAULT_MODEL_NAME ? [] : [modelName],
+    repo: repoName,
     ...timeParamsClickHouse,
   };
 
@@ -299,7 +319,7 @@ export default function Page() {
   });
 
   if (data === undefined || data.length === 0) {
-    return <>Loading {BENCHMARKS.join(", ")}...</>;
+    return <>Loading {REPO_TO_BENCHMARKS[repoName].join(", ")}...</>;
   }
 
   const modelNames: string[] = [
@@ -320,7 +340,7 @@ export default function Page() {
     <div>
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
         <Typography fontSize={"2rem"} fontWeight={"bold"}>
-          LLMs Benchmark DashBoard
+          Benchmark DashBoard
         </Typography>
         <CopyLink
           textToCopy={`${baseUrl}?startTime=${encodeURIComponent(
@@ -377,7 +397,7 @@ export default function Page() {
           commit={lCommit}
           setCommit={setLCommit}
           titlePrefix={"Base"}
-          fallbackIndex={-1} // Default to the next to latest in the window
+          fallbackIndex={1} // Default to the next to latest in the window
           timeRange={timeRange}
           useClickHouse={useClickHouse}
         />


### PR DESCRIPTION
This bases on the current benchmark dashboard on PyTorch with only a different repo name `pytorch/executorch`.  The dashboard is still using `benchmark.oss_ci_benchmark_v2` as I'm setting up the initial version of the dashboard first before looking into consolidating the database schema.

### Testing

https://torchci-git-fork-huydhn-executorch-benchmark-fbopensource.vercel.app/benchmark/llms?repoName=pytorch%2Fexecutorch 

**Please switch to ClickHouse for testing as it has the latest queries, I will submit a PR to clean up Rockset to avoid further discrepancy**