### PR TITLE
Cleanup Rockset on ET benchmark dashboards

### DIFF
--- a/torchci/components/benchmark/llms/ModelGraphPanel.tsx
+++ b/torchci/components/benchmark/llms/ModelGraphPanel.tsx
@@ -19,7 +19,6 @@ import {
 } from "components/metrics/panels/TimeSeriesPanel";
 import dayjs from "dayjs";
 import { useBenchmark } from "lib/benchmark/llmUtils";
-import { RocksetParam } from "lib/rockset";
 import { BranchAndCommit } from "lib/types";
 
 const GRAPH_ROW_HEIGHT = 245;
@@ -34,7 +33,7 @@ export function GraphPanel({
   lBranchAndCommit,
   rBranchAndCommit,
 }: {
-  queryParams: RocksetParam[] | {};
+  queryParams: { [key: string]: any };
   granularity: Granularity;
   modelName: string;
   dtypeName: string;

--- a/torchci/components/benchmark/llms/ModelGraphPanel.tsx
+++ b/torchci/components/benchmark/llms/ModelGraphPanel.tsx
@@ -33,7 +33,6 @@ export function GraphPanel({
   metricNames,
   lBranchAndCommit,
   rBranchAndCommit,
-  useClickHouse,
 }: {
   queryParams: RocksetParam[] | {};
   granularity: Granularity;
@@ -43,7 +42,6 @@ export function GraphPanel({
   metricNames: string[];
   lBranchAndCommit: BranchAndCommit;
   rBranchAndCommit: BranchAndCommit;
-  useClickHouse: boolean;
 }) {
   // Do not set the commit here to query all the records in the time range to
   // draw a chart
@@ -55,8 +53,7 @@ export function GraphPanel({
     {
       branch: rBranchAndCommit.branch,
       commit: "",
-    },
-    useClickHouse
+    }
   );
 
   if (data === undefined || data.length === 0) {
@@ -75,22 +72,12 @@ export function GraphPanel({
 
   // Clamp to the nearest granularity (e.g. nearest hour) so that the times will
   // align with the data we get from the database
-  const startTime = useClickHouse
-    ? dayjs((queryParams as { [key: string]: any })["startTime"]).startOf(
-        granularity
-      )
-    : dayjs(
-        (queryParams as RocksetParam[]).find((p) => p.name === "startTime")
-          ?.value
-      ).startOf(granularity);
-  const stopTime = useClickHouse
-    ? dayjs((queryParams as { [key: string]: any })["stopTime"]).startOf(
-        granularity
-      )
-    : dayjs(
-        (queryParams as RocksetParam[]).find((p) => p.name === "stopTime")
-          ?.value
-      ).startOf(granularity);
+  const startTime = dayjs(
+    (queryParams as { [key: string]: any })["startTime"]
+  ).startOf(granularity);
+  const stopTime = dayjs(
+    (queryParams as { [key: string]: any })["stopTime"]
+  ).startOf(granularity);
 
   // Only show records between these twos
   const lWorkflowId = COMMIT_TO_WORKFLOW_ID[lBranchAndCommit.commit];

--- a/torchci/pages/benchmark/llms.tsx
+++ b/torchci/pages/benchmark/llms.tsx
@@ -22,7 +22,6 @@ import { Granularity } from "components/metrics/panels/TimeSeriesPanel";
 import dayjs from "dayjs";
 import { useBenchmark } from "lib/benchmark/llmUtils";
 import { fetcher } from "lib/GeneralUtils";
-import { RocksetParam } from "lib/rockset";
 import { BranchAndCommit } from "lib/types";
 import _ from "lodash";
 import { useRouter } from "next/router";
@@ -43,7 +42,7 @@ function Report({
   lBranchAndCommit,
   rBranchAndCommit,
 }: {
-  queryParams: RocksetParam[] | {};
+  queryParams: { [key: string]: any };
   startTime: dayjs.Dayjs;
   stopTime: dayjs.Dayjs;
   granularity: Granularity;

--- a/torchci/pages/benchmark/llms.tsx
+++ b/torchci/pages/benchmark/llms.tsx
@@ -19,7 +19,6 @@ import { DTypePicker } from "components/benchmark/ModeAndDTypePicker";
 import CopyLink from "components/CopyLink";
 import GranularityPicker from "components/GranularityPicker";
 import { Granularity } from "components/metrics/panels/TimeSeriesPanel";
-import { useCHContext } from "components/UseClickhouseProvider";
 import dayjs from "dayjs";
 import { useBenchmark } from "lib/benchmark/llmUtils";
 import { fetcher } from "lib/GeneralUtils";
@@ -29,7 +28,7 @@ import _ from "lodash";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import useSWR from "swr";
-import { RStoCHTimeParams, TimeRangePicker } from "../metrics";
+import { TimeRangePicker } from "../metrics";
 
 function Report({
   queryParams,
@@ -43,7 +42,6 @@ function Report({
   metricNames,
   lBranchAndCommit,
   rBranchAndCommit,
-  useClickHouse,
 }: {
   queryParams: RocksetParam[] | {};
   startTime: dayjs.Dayjs;
@@ -56,7 +54,6 @@ function Report({
   metricNames: string[];
   lBranchAndCommit: BranchAndCommit;
   rBranchAndCommit: BranchAndCommit;
-  useClickHouse: boolean;
 }) {
   const { data: lData, error: _lError } = useBenchmark(
     queryParams,
@@ -64,7 +61,6 @@ function Report({
     dtypeName,
     deviceName,
     lBranchAndCommit,
-    useClickHouse,
     true
   );
   const { data: rData, error: _rError } = useBenchmark(
@@ -73,7 +69,6 @@ function Report({
     dtypeName,
     deviceName,
     rBranchAndCommit,
-    useClickHouse,
     true
   );
 
@@ -123,7 +118,6 @@ function Report({
         metricNames={metricNames}
         lBranchAndCommit={lBranchAndCommit}
         rBranchAndCommit={rBranchAndCommit}
-        useClickHouse={useClickHouse}
       />
       <SummaryPanel
         startTime={startTime}
@@ -163,9 +157,6 @@ export default function Page() {
   const [modelName, setModelName] = useState<string>(DEFAULT_MODEL_NAME);
   const [dtypeName, setDTypeName] = useState<string>(DEFAULT_DTYPE_NAME);
   const [deviceName, setDeviceName] = useState<string>(DEFAULT_DEVICE_NAME);
-
-  // TODO (huydhn): Clean this up once ClickHouse migration finishes
-  const { useCH: useClickHouse } = useCHContext();
 
   // Set the dropdown value what is in the param
   useEffect(() => {
@@ -242,60 +233,7 @@ export default function Page() {
 
   const queryCollection = "benchmarks";
   const queryName = "oss_ci_benchmark_names";
-
-  const timeParams: RocksetParam[] = [
-    {
-      name: "startTime",
-      type: "string",
-      value: startTime,
-    },
-    {
-      name: "stopTime",
-      type: "string",
-      value: stopTime,
-    },
-  ];
-  const timeParamsClickHouse = RStoCHTimeParams(timeParams);
-
-  const queryParams: RocksetParam[] = [
-    {
-      name: "deviceArch",
-      type: "string",
-      value: deviceName === DEFAULT_DEVICE_NAME ? "" : deviceName,
-    },
-    {
-      name: "dtypes",
-      type: "string",
-      value: dtypeName === DEFAULT_DTYPE_NAME ? "" : dtypeName,
-    },
-    {
-      name: "excludedMetrics",
-      type: "string",
-      value: EXCLUDED_METRICS.join(","),
-    },
-    {
-      name: "filenames",
-      type: "string",
-      value: REPO_TO_BENCHMARKS[repoName].join(","),
-    },
-    {
-      name: "granularity",
-      type: "string",
-      value: granularity,
-    },
-    {
-      name: "names",
-      type: "string",
-      value: modelName === DEFAULT_MODEL_NAME ? "" : modelName,
-    },
-    {
-      name: "repo",
-      type: "string",
-      value: repoName,
-    },
-    ...timeParams,
-  ];
-  const queryParamsClickHouse = {
+  const queryParams = {
     deviceArch: deviceName === DEFAULT_DEVICE_NAME ? "" : deviceName,
     dtypes: dtypeName === DEFAULT_DTYPE_NAME ? [] : [dtypeName],
     excludedMetrics: EXCLUDED_METRICS,
@@ -303,16 +241,13 @@ export default function Page() {
     granularity: granularity,
     names: modelName === DEFAULT_MODEL_NAME ? [] : [modelName],
     repo: repoName,
-    ...timeParamsClickHouse,
+    startTime: dayjs(startTime).utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
+    stopTime: dayjs(stopTime).utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
   };
 
-  const url = useClickHouse
-    ? `/api/clickhouse/${queryName}?parameters=${encodeURIComponent(
-        JSON.stringify(queryParamsClickHouse)
-      )}`
-    : `/api/query/${queryCollection}/${queryName}?parameters=${encodeURIComponent(
-        JSON.stringify(queryParams)
-      )}`;
+  const url = `/api/clickhouse/${queryName}?parameters=${encodeURIComponent(
+    JSON.stringify(queryParams)
+  )}`;
 
   const { data } = useSWR(url, fetcher, {
     refreshInterval: 60 * 60 * 1000, // refresh every hour
@@ -391,7 +326,7 @@ export default function Page() {
         <BranchAndCommitPicker
           queryName={"oss_ci_benchmark_branches"}
           queryCollection={"benchmarks"}
-          queryParams={useClickHouse ? queryParamsClickHouse : queryParams}
+          queryParams={queryParams}
           branch={lBranch}
           setBranch={setLBranch}
           commit={lCommit}
@@ -399,7 +334,7 @@ export default function Page() {
           titlePrefix={"Base"}
           fallbackIndex={1} // Default to previous commit
           timeRange={timeRange}
-          useClickHouse={useClickHouse}
+          useClickHouse={true}
         />
         <Divider orientation="vertical" flexItem>
           &mdash;Diff→
@@ -407,7 +342,7 @@ export default function Page() {
         <BranchAndCommitPicker
           queryName={"oss_ci_benchmark_branches"}
           queryCollection={"benchmarks"}
-          queryParams={useClickHouse ? queryParamsClickHouse : queryParams}
+          queryParams={queryParams}
           branch={rBranch}
           setBranch={setRBranch}
           commit={rCommit}
@@ -415,12 +350,12 @@ export default function Page() {
           titlePrefix={"New"}
           fallbackIndex={0} // Default to the latest commit
           timeRange={timeRange}
-          useClickHouse={useClickHouse}
+          useClickHouse={true}
         />
       </Stack>
 
       <Report
-        queryParams={useClickHouse ? queryParamsClickHouse : queryParams}
+        queryParams={queryParams}
         startTime={startTime}
         stopTime={stopTime}
         granularity={granularity}
@@ -431,7 +366,6 @@ export default function Page() {
         metricNames={metricNames}
         lBranchAndCommit={{ branch: lBranch, commit: lCommit }}
         rBranchAndCommit={{ branch: rBranch, commit: rCommit }}
-        useClickHouse={useClickHouse}
       />
     </div>
   );


### PR DESCRIPTION
This is a follow-up of https://github.com/pytorch/test-infra/pull/5758, let's just keep ClickHouse route going forward as it's tedious to update both ClickHouse and Rockset queries

### Testing

https://torchci-git-fork-huydhn-cleanup-rockset-llm-e8a0f2-fbopensource.vercel.app/benchmark/llms?repoName=pytorch%2Fexecutorch

and 

https://torchci-git-fork-huydhn-cleanup-rockset-llm-e8a0f2-fbopensource.vercel.app/benchmark/llms?repoName=pytorch%2Fpytorch