### PR TITLE
[ch][hud][ez] Fix artifacts under each job

### DIFF
--- a/torchci/components/WorkflowBox.tsx
+++ b/torchci/components/WorkflowBox.tsx
@@ -222,7 +222,7 @@ export default function WorkflowBox({
           <div key={job.id} id={`${job.id}-box`}>
             <WorkflowJobSummary
               job={job}
-              artifacts={groupedArtifacts?.get(job.id)}
+              artifacts={groupedArtifacts?.get(job.id?.toString())}
               artifactsToShow={artifactsToShow}
               setArtifactsToShow={setArtifactsToShow}
               unstableIssues={unstableIssues}
@@ -264,7 +264,7 @@ function useArtifacts(workflowId: string | undefined): {
 
 function groupArtifacts(jobs: JobData[], artifacts: Artifact[]) {
   // Group artifacts by job id if possible
-  const jobIds = jobs.map((job) => job.id);
+  const jobIds = jobs.map((job) => job.id?.toString());
   const grouping = new Map<string | undefined, Artifact[]>();
   for (const artifact of artifacts) {
     let key = "none";


### PR DESCRIPTION
CH returns job id as a number, not a string, but string is expected in some places

Previously, when using CH, the show artifacts button wouldn't show up, but now it does
<img width="563" alt="image" src="https://github.com/user-attachments/assets/9a6a1b5f-990d-42e4-9e19-60d730592c53">
