### PR TITLE
[CH] Migrate https://hud.pytorch.org/tts

### DIFF
--- a/torchci/clickhouse_queries/tts_duration_historical/params.json
+++ b/torchci/clickhouse_queries/tts_duration_historical/params.json
@@ -1,7 +1,8 @@
 {
+  "branch": "String",
   "granularity": "String",
+  "repo": "String",
   "startTime": "DateTime64(3)",
   "stopTime": "DateTime64(3)",
-  "timezone": "String",
-  "workflowNames": "String"
+  "workflowNames": "Array(String)"
 }

--- a/torchci/clickhouse_queries/tts_duration_historical/query.sql
+++ b/torchci/clickhouse_queries/tts_duration_historical/query.sql
@@ -1,31 +1,28 @@
--- !!! Query is not converted to CH syntax yet.  Delete this line when it gets converted
+-- This query powers https://hud.pytorch.org/tts
 SELECT
-    FORMAT_ISO8601(
-        DATE_TRUNC(
-            :granularity,
-            job._event_time AT TIME ZONE :timezone
-        )
-    ) AS granularity_bucket,
-    AVG(DATE_DIFF(
-        'second',
-        PARSE_TIMESTAMP_ISO8601(workflow.created_at) AT TIME ZONE :timezone,
-        PARSE_TIMESTAMP_ISO8601(job.completed_at) AT TIME ZONE :timezone
-    )) as tts_avg_sec,
-    AVG(DATE_DIFF(
-        'second',
-        PARSE_TIMESTAMP_ISO8601(job.started_at) AT TIME ZONE :timezone,
-        PARSE_TIMESTAMP_ISO8601(job.completed_at) AT TIME ZONE :timezone
-    )) as duration_avg_sec,
-    CONCAT(workflow.name, ' / ', job.name) as full_name,
+    DATE_TRUNC({granularity: String }, job.created_at) AS granularity_bucket,
+    AVG(
+        DATE_DIFF('second', workflow.created_at, job.completed_at)
+    ) AS tts_avg_sec,
+    AVG(
+        DATE_DIFF('second', job.started_at, job.completed_at)
+    ) AS duration_avg_sec,
+    CONCAT(workflow.name, ' / ', job.name) AS full_name
 FROM
-    commons.workflow_job job
-    JOIN commons.workflow_run workflow on workflow.id = job.run_id
+    default .workflow_job job FINAL
+    JOIN default .workflow_run workflow FINAL on workflow.id = job.run_id
 WHERE
-    job._event_time >= PARSE_DATETIME_ISO8601(:startTime)
-    AND job._event_time < PARSE_DATETIME_ISO8601(:stopTime)
-    AND ARRAY_CONTAINS(SPLIT(:workflowNames, ','), workflow.name)
-	AND workflow.head_branch LIKE 'main'
+    job.created_at >= {startTime: DateTime64(3) }
+    AND job.created_at < {stopTime: DateTime64(3) }
+    AND has({workflowNames: Array(String) }, workflow.name)
+    AND workflow.head_branch LIKE {branch: String }
     AND workflow.run_attempt = 1
+    AND workflow.repository. 'full_name' = {repo: String }
+    AND job.name NOT LIKE '%before-test%'
+    AND job.name NOT LIKE '%determinator%'
+    AND job.name NOT LIKE '%mem_leak_check%'
+    AND job.name NOT LIKE '%rerun_disabled_tests%'
+    AND toUnixTimestamp(job.completed_at) != 0 -- To remove jobs that are still running
 GROUP BY
     granularity_bucket,
     full_name

--- a/torchci/clickhouse_queries/tts_duration_historical_percentile/params.json
+++ b/torchci/clickhouse_queries/tts_duration_historical_percentile/params.json
@@ -1,9 +1,9 @@
 {
   "branch": "String",
   "granularity": "String",
-  "percentile": "Float64",
+  "percentile": "Float32",
+  "repo": "String",
   "startTime": "DateTime64(3)",
   "stopTime": "DateTime64(3)",
-  "timezone": "String",
-  "workflowNames": "String"
+  "workflowNames": "Array(String)"
 }

--- a/torchci/clickhouse_queries/tts_duration_historical_percentile/query.sql
+++ b/torchci/clickhouse_queries/tts_duration_historical_percentile/query.sql
@@ -1,49 +1,73 @@
--- !!! Query is not converted to CH syntax yet.  Delete this line when it gets converted
+-- This query powers https://hud.pytorch.org/tts
+WITH tts_duration AS (
+    SELECT
+        DATE_TRUNC({granularity: String }, job.created_at) AS granularity_bucket,
+        DATE_DIFF('second', workflow.created_at, job.completed_at) AS tts_sec,
+        DATE_DIFF('second', job.started_at, job.completed_at) AS duration_sec,
+        CONCAT(workflow.name, ' / ', job.name) AS full_name
+    FROM
+        default .workflow_job job FINAL
+        JOIN default .workflow_run workflow FINAL ON workflow.id = job.run_id
+    WHERE
+        job.created_at >= {startTime: DateTime64(3) }
+        AND job.created_at < {stopTime: DateTime64(3) }
+        AND has({workflowNames: Array(String) }, workflow.name)
+        AND workflow.head_branch LIKE {branch: String }
+        AND workflow.run_attempt = 1
+        AND workflow.repository. 'full_name' = {repo: String }
+        AND job.name NOT LIKE '%before-test%'
+        AND job.name NOT LIKE '%determinator%'
+        AND job.name NOT LIKE '%mem_leak_check%'
+        AND job.name NOT LIKE '%rerun_disabled_tests%'
+        AND toUnixTimestamp(job.completed_at) != 0 -- To remove jobs that are still running
+),
+p AS (
+    SELECT
+        granularity_bucket,
+        tts_sec,
+        -- Switch this to percent_rank once it's available on ClickHouse Cloud https://github.com/ClickHouse/ClickHouse/issues/46300
+        ifNull(
+            (
+                rank() OVER(
+                    PARTITION BY full_name
+                    ORDER BY
+                        tts_sec DESC
+                ) - 1
+            ) / nullif(count(1) OVER(PARTITION BY full_name) -1, 0),
+            0
+        ) AS tts_percentile,
+        duration_sec,
+        -- Switch this to percent_rank once it's available on ClickHouse Cloud https://github.com/ClickHouse/ClickHouse/issues/46300
+        ifNull(
+            (
+                rank() OVER(
+                    PARTITION BY full_name
+                    ORDER BY
+                        duration_sec DESC
+                ) - 1
+            ) / nullif(count(1) OVER(PARTITION BY full_name) -1, 0),
+            0
+        ) AS duration_percentile,
+        full_name,
+    FROM
+        tts_duration
+),
+filtered_p AS (
+    SELECT
+        *
+    FROM
+        p
+    WHERE
+        p.tts_percentile >= (1.0 - {percentile: Float32})
+        OR p.duration_percentile >= (1.0 - {percentile: Float32})
+)
 SELECT
     granularity_bucket,
     MAX(tts_sec) AS tts_percentile_sec,
     MAX(duration_sec) AS duration_percentile_sec,
     full_name
-FROM (
-    SELECT
-        granularity_bucket,
-        tts_sec,
-        PERCENT_RANK() OVER (PARTITION BY full_name ORDER BY tts_sec DESC) AS tts_percentile,
-        duration_sec,
-        PERCENT_RANK() OVER (PARTITION BY full_name ORDER BY duration_sec DESC) AS duration_percentile,
-        full_name,
-    FROM (
-        SELECT
-            FORMAT_ISO8601(
-                DATE_TRUNC(
-                    :granularity,
-                    job._event_time AT TIME ZONE :timezone
-                )
-            ) AS granularity_bucket,
-            DATE_DIFF(
-                'second',
-                PARSE_TIMESTAMP_ISO8601(workflow.created_at) AT TIME ZONE :timezone,
-                PARSE_TIMESTAMP_ISO8601(job.completed_at) AT TIME ZONE :timezone
-            ) AS tts_sec,
-            DATE_DIFF(
-                'second',
-                PARSE_TIMESTAMP_ISO8601(job.started_at) AT TIME ZONE :timezone,
-                PARSE_TIMESTAMP_ISO8601(job.completed_at) AT TIME ZONE :timezone
-            ) AS duration_sec,
-            CONCAT(workflow.name, ' / ', job.name) as full_name
-        FROM
-            commons.workflow_job job
-            JOIN commons.workflow_run workflow on workflow.id = job.run_id
-        WHERE
-            job._event_time >= PARSE_DATETIME_ISO8601(:startTime)
-            AND job._event_time < PARSE_DATETIME_ISO8601(:stopTime)
-            AND ARRAY_CONTAINS(SPLIT(:workflowNames, ','), workflow.name)
-            AND workflow.head_branch LIKE :branch
-            AND workflow.run_attempt = 1
-    ) AS tts_duration
-) AS p
-WHERE
-    (SELECT p.tts_percentile >= (1.0 - :percentile) OR p.duration_percentile >= (1.0 - :percentile))
+FROM
+    filtered_p
 GROUP BY
     granularity_bucket,
     full_name

--- a/torchci/clickhouse_queries/tts_duration_historical_percentile/query.sql
+++ b/torchci/clickhouse_queries/tts_duration_historical_percentile/query.sql
@@ -20,54 +20,14 @@ WITH tts_duration AS (
         AND job.name NOT LIKE '%mem_leak_check%'
         AND job.name NOT LIKE '%rerun_disabled_tests%'
         AND toUnixTimestamp(job.completed_at) != 0 -- To remove jobs that are still running
-),
-p AS (
-    SELECT
-        granularity_bucket,
-        tts_sec,
-        -- Switch this to percent_rank once it's available on ClickHouse Cloud https://github.com/ClickHouse/ClickHouse/issues/46300
-        ifNull(
-            (
-                rank() OVER(
-                    PARTITION BY full_name
-                    ORDER BY
-                        tts_sec DESC
-                ) - 1
-            ) / nullif(count(1) OVER(PARTITION BY full_name) -1, 0),
-            0
-        ) AS tts_percentile,
-        duration_sec,
-        -- Switch this to percent_rank once it's available on ClickHouse Cloud https://github.com/ClickHouse/ClickHouse/issues/46300
-        ifNull(
-            (
-                rank() OVER(
-                    PARTITION BY full_name
-                    ORDER BY
-                        duration_sec DESC
-                ) - 1
-            ) / nullif(count(1) OVER(PARTITION BY full_name) -1, 0),
-            0
-        ) AS duration_percentile,
-        full_name,
-    FROM
-        tts_duration
-),
-filtered_p AS (
-    SELECT
-        *
-    FROM
-        p
-    WHERE
-        p.tts_percentile >= (1.0 - {percentile: Float32})
-        OR p.duration_percentile >= (1.0 - {percentile: Float32})
 )
 SELECT
     granularity_bucket,
-    MAX(tts_sec) AS tts_percentile_sec,
-    MAX(duration_sec) AS duration_percentile_sec,
+    quantile({percentile: Float32})(tts_sec) AS tts_percentile_sec,
+    quantile({percentile: Float32})(duration_sec) AS duration_percentile_sec,
     full_name
 FROM
-    filtered_p
+    tts_duration
 GROUP BY
     granularity_bucket,
     full_name

--- a/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -11,7 +11,6 @@ import dayjs from "dayjs";
 import { EChartsOption } from "echarts";
 import ReactECharts from "echarts-for-react";
 import { fetcher } from "lib/GeneralUtils";
-import { RocksetParam } from "lib/rockset";
 import { useRouter } from "next/router";
 import { useCallback, useState } from "react";
 import useSWR from "swr";
@@ -84,7 +83,7 @@ function Graphs({
   filter,
   toggleFilter,
 }: {
-  queryParams: RocksetParam[];
+  queryParams: { [key: string]: any };
   granularity: Granularity;
   ttsPercentile: number;
   checkboxRef: any;
@@ -107,7 +106,7 @@ function Graphs({
 
   const timeFieldName = "granularity_bucket";
   const groupByFieldName = "full_name";
-  const url = `/api/query/metrics/${queryName}?parameters=${encodeURIComponent(
+  const url = `/api/clickhouse/${queryName}?parameters=${encodeURIComponent(
     JSON.stringify(queryParams)
   )}`;
 
@@ -130,13 +129,10 @@ function Graphs({
     return <Skeleton variant={"rectangular"} height={"100%"} />;
   }
 
-  let startTime = queryParams.find((p) => p.name === "startTime")?.value;
-  let stopTime = queryParams.find((p) => p.name === "stopTime")?.value;
-
   // Clamp to the nearest granularity (e.g. nearest hour) so that the times will
-  // align with the data we get from Rockset
-  startTime = dayjs(startTime).startOf(granularity);
-  stopTime = dayjs(stopTime).endOf(granularity);
+  // align with the data we get from the database
+  const startTime = dayjs(queryParams["startTime"]).startOf(granularity);
+  const stopTime = dayjs(queryParams["stopTime"]).startOf(granularity);
 
   const tts_true_series = seriesWithInterpolatedTimes(
     data,
@@ -163,8 +159,9 @@ function Graphs({
     filter.has(item["name"])
   );
 
+  const repo = queryParams["repo"];
   const encodedBranchName = encodeURIComponent(branchName);
-  const jobUrlPrefix = `/tts/pytorch/pytorch/${encodedBranchName}?jobName=`;
+  const jobUrlPrefix = `/tts/${repo}/${encodedBranchName}?jobName=`;
 
   return (
     <Grid container spacing={2}>
@@ -207,7 +204,9 @@ function Graphs({
 
 export default function Page() {
   const router = useRouter();
-  const branch: string = (router.query.branch as string) ?? "master";
+  const repoOwner: string = (router.query.repoOwner as string) ?? "pytorch";
+  const repoName: string = (router.query.repoName as string) ?? "pytorch";
+  const branch: string = (router.query.branch as string) ?? "main";
   const jobName: string = (router.query.jobName as string) ?? "none";
   const percentile: number =
     router.query.percentile === undefined
@@ -232,43 +231,15 @@ export default function Page() {
     setFilter(next);
   }
 
-  const queryParams: RocksetParam[] = [
-    {
-      name: "timezone",
-      type: "string",
-      value: Intl.DateTimeFormat().resolvedOptions().timeZone,
-    },
-    {
-      name: "startTime",
-      type: "string",
-      value: startTime,
-    },
-    {
-      name: "stopTime",
-      type: "string",
-      value: stopTime,
-    },
-    {
-      name: "granularity",
-      type: "string",
-      value: granularity,
-    },
-    {
-      name: "percentile",
-      type: "float",
-      value: ttsPercentile,
-    },
-    {
-      name: "branch",
-      type: "string",
-      value: branch,
-    },
-    {
-      name: "workflowNames",
-      type: "string",
-      value: SUPPORTED_WORKFLOWS.join(","),
-    },
-  ];
+  const queryParams: { [key: string]: any } = {
+    branch: branch,
+    granularity: granularity,
+    percentile: ttsPercentile,
+    repo: `${repoOwner}/${repoName}`,
+    startTime: dayjs(startTime).utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
+    stopTime: dayjs(stopTime).utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
+    workflowNames: SUPPORTED_WORKFLOWS,
+  };
 
   const checkboxRef = useCallback(() => {
     const selectedJob = document.getElementById(jobName);


### PR DESCRIPTION
I need to rewrite parts of the queries to make the page works.  I guess we don't use this as often anymore.

* Add `repo` name to the query to filter jobs from other repos, i.e. ExecuTorch
* Remove some jobs that we don't care about their TTS, i.e. `mem_leak_check`
* Rewrite `percent_rank` with `rank` because the former is not yet available in the current CH Cloud we are using https://github.com/ClickHouse/ClickHouse/issues/46300

### Testing
https://torchci-git-fork-huydhn-migrate-ttsduration-ec63fe-fbopensource.vercel.app/tts