### PR TITLE
Remove am2 variant

### DIFF
--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -64,9 +64,6 @@ runner_types:
     max_available: 50
     os: linux
     ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64
-    variants:
-      am2:
-        ami: amzn2-ami-hvm-2.0.20240306.2-x86_64-ebs
   lf.c.linux.12xlarge.ephemeral:
     disk_size: 200
     instance_type: c5.12xlarge

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -64,9 +64,6 @@ runner_types:
     max_available: 50
     os: linux
     ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64
-    variants:
-      am2:
-        ami: amzn2-ami-hvm-2.0.20240306.2-x86_64-ebs
   lf.linux.12xlarge.ephemeral:
     disk_size: 200
     instance_type: c5.12xlarge

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -60,9 +60,6 @@ runner_types:
     max_available: 50
     os: linux
     ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64
-    variants:
-      am2:
-        ami: amzn2-ami-hvm-2.0.20240306.2-x86_64-ebs
   linux.12xlarge.ephemeral:
     disk_size: 200
     instance_type: c5.12xlarge


### PR DESCRIPTION
Removing the last am2 variant, which allowed the usage of Amazon Linux 2 amis.

This is needed since github runners are no longer officially supported on those machines and could break at any time.

Note: The am2.linux.9xlarge.ephemeral runner type is still referenced by the release/2.5 branch. This means that when we're releasing 2.5.1 we’ll want to cherry pick in the fix to remove the am2 reference from those workflows to let them actually build

Companion PR, which should be merged first: https://github.com/pytorch/pytorch/pull/138358