### PR TITLE
Excpect scale-configs to all live in test-infra now

### DIFF
--- a/.github/scripts/validate_scale_config.py
+++ b/.github/scripts/validate_scale_config.py
@@ -9,10 +9,9 @@ import argparse
 import copy
 import json
 import os
-import tempfile
-from pathlib import Path
 
 import urllib.request
+from pathlib import Path
 
 from typing import Any, cast, Dict, List, NamedTuple
 
@@ -141,7 +140,7 @@ def runner_types_are_equivalent(
 
 
 def is_config_valid_internally(runner_types: Dict[str, Dict[str, str]]) -> bool:
-    f"""
+    """
     Ensure that for every linux runner type in the config:
 
     1 - they match RunnerTypeScaleConfig https://github.com/pytorch/test-infra/blob/f3c58fea68ec149391570d15a4d0a03bc26fbe4f/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts#L50

--- a/.github/scripts/validate_scale_config.py
+++ b/.github/scripts/validate_scale_config.py
@@ -290,7 +290,9 @@ def main() -> None:
     source_scale_config = load_yaml_file(source_scale_config_info.path)
     validation_success = True
 
-    validation_success = is_config_valid_internally(source_scale_config[RUNNER_TYPE_CONFIG_KEY])
+    validation_success = is_config_valid_internally(
+        source_scale_config[RUNNER_TYPE_CONFIG_KEY]
+    )
     print(f"scaled-config.yml is {'valid' if validation_success else 'invalid'}\n")
 
     def validate_config(generated_config_info: ScaleConfigInfo) -> bool:
@@ -302,8 +304,6 @@ def main() -> None:
                 generated_config_info.path,
                 generated_config_info.prefix,
             )
-
-            print(f"Generated updated scale config file at {generated_config_info.path}\n")
 
         cloned_scale_config = load_yaml_file(generated_config_info.path)
 

--- a/.github/scripts/validate_scale_config.py
+++ b/.github/scripts/validate_scale_config.py
@@ -1,10 +1,9 @@
 # Takes the scale-config.yml file in test-infra/.github/scale-config.yml and runs the following
 # validations against it:
-# 1. Internal validation: Ensure that every linux runner type listed has the corresponding Amazon 2023 variant
+# 1. Internal validation: Runs a custom set of sanity checks against the runner types defined in the file
 # 2. External validation: Ensure that every runner type listed (linux & windows) have corresponding runner types in
-#    pytorch/pytorch's .github/lf-scale-config.yml and .github/lf-canary-scale-config.yml that have the "lf."
-#    "lf.c." prefixes added correspondingly
-# This script assumes that it is being run from the root of the test-infra repository
+#    the Linux Foundation fleet's scale config files (.github/lf-scale-config.yml and .github/lf-canary-scale-config.yml).
+#    Those files are expected to have the "lf." and "lf.c." prefixes added to each runner type
 
 import argparse
 import copy


### PR DESCRIPTION
Part of the workflow to move the LF scale-config.yml files from pytorch/pytorch to test-infra (details in https://github.com/pytorch/test-infra/pull/5767)

This updates the validation script to no longer expect to update the pytorch/pytorch version of these scale configs.  It resulted in many other aspects of that file becoming simpler as well.