### PR TITLE
[drci] Fix when calling for single PR

### DIFF
--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -67,7 +67,7 @@ export default async function handler(
 ) {
   const authorization = req.headers.authorization;
 
-  if (true || authorization === process.env.DRCI_BOT_KEY) {
+  if (authorization === process.env.DRCI_BOT_KEY) {
     const { prNumber } = req.query;
     const { repo }: UpdateCommentBody = req.body;
     const octokit = await getOctokit(OWNER, repo);
@@ -88,10 +88,9 @@ export async function updateDrciComments(
   repo: string = "pytorch",
   prNumbers: number[]
 ): Promise<{ [pr: number]: { [cat: string]: RecentWorkflowsData[] } }> {
-  console.log(prNumbers)
+  // Fetch in two separate queries because combining into one query took much
+  // longer to run on CH
   const [recentWorkflows, workflowsFromPendingComments] = await Promise.all([
-    // Fetch in two separate queries because combinidng into one query took much
-    // longer to run on CH
     fetchRecentWorkflows(`${OWNER}/${repo}`, prNumbers, NUM_MINUTES + ""),
     // Only fetch if we are not updating a specific PR
     prNumbers.length != 0

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -67,7 +67,7 @@ export default async function handler(
 ) {
   const authorization = req.headers.authorization;
 
-  if (authorization === process.env.DRCI_BOT_KEY) {
+  if (true || authorization === process.env.DRCI_BOT_KEY) {
     const { prNumber } = req.query;
     const { repo }: UpdateCommentBody = req.body;
     const octokit = await getOctokit(OWNER, repo);
@@ -75,7 +75,7 @@ export default async function handler(
     const failures = await updateDrciComments(
       octokit,
       repo,
-      prNumber ? [prNumber as unknown as number] : []
+      prNumber ? [parseInt(prNumber as string)] : []
     );
     res.status(200).json(failures);
   }
@@ -88,18 +88,19 @@ export async function updateDrciComments(
   repo: string = "pytorch",
   prNumbers: number[]
 ): Promise<{ [pr: number]: { [cat: string]: RecentWorkflowsData[] } }> {
+  console.log(prNumbers)
   const [recentWorkflows, workflowsFromPendingComments] = await Promise.all([
     // Fetch in two separate queries because combinidng into one query took much
     // longer to run on CH
     fetchRecentWorkflows(`${OWNER}/${repo}`, prNumbers, NUM_MINUTES + ""),
-    fetchRecentWorkflows(
-      `${OWNER}/${repo}`,
-      // Only fetch if we are not updating a specific PR
-      prNumbers.length == 0
-        ? await getPRsWithPendingJobInComment(`${OWNER}/${repo}`)
-        : [],
-      NUM_MINUTES + ""
-    ),
+    // Only fetch if we are not updating a specific PR
+    prNumbers.length != 0
+      ? []
+      : fetchRecentWorkflows(
+          `${OWNER}/${repo}`,
+          await getPRsWithPendingJobInComment(`${OWNER}/${repo}`),
+          NUM_MINUTES + ""
+        ),
   ]);
 
   const workflowsByPR = await reorganizeWorkflows(


### PR DESCRIPTION
I dunno how I missed this when I originally made this change

Tested by calling 
`curl "http://localhost:3000/api/drci/drci?prNumber=138513"  --data 'repo=pytorch'`
and
`curl "http://localhost:3000/api/drci/drci"  --data 'repo=pytorch'`
but only verified that clickhouse returned results