### PR TITLE
Fix scaleUp not waiting for rateLimit response and improved testing

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
@@ -2,6 +2,7 @@ import { createRunner } from './runners';
 import {
   createRegistrationTokenOrg,
   createRegistrationTokenRepo,
+  getGitHubRateLimit,
   getRunnerTypes,
   listGithubRunnersOrg,
   listGithubRunnersRepo,
@@ -23,6 +24,8 @@ beforeEach(() => {
   jest.clearAllMocks();
   jest.restoreAllMocks();
   nock.disableNetConnect();
+
+  mocked(getGitHubRateLimit).mockResolvedValue({ limit: 5000, remaining: 4999, used: 1 });
 });
 
 const baseCfg = {

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -55,7 +55,13 @@ export async function scaleUp(
   metrics.runRepo(repo);
   metrics.run();
 
-  getGitHubRateLimit(repo, Number(payload.installationId), metrics);
+  try {
+    const ghLimitInfo = await getGitHubRateLimit(repo, metrics);
+    metrics.gitHubRateLimitStats(ghLimitInfo.limit, ghLimitInfo.remaining, ghLimitInfo.used);
+  } catch (e) {
+    /* istanbul ignore next */
+    console.error(`Error getting GitHub rate limit: ${e}`);
+  }
 
   const scaleConfigRepo = {
     owner: repo.owner,


### PR DESCRIPTION
Fix `scaleUp` not waiting for `getGitHubRateLimit`, plus some other fixes/improvements:

* Used global redis cache over local cache to reduce request frequency;
* Added testing coverage for the function;
* Improved test coverage for other sections so it is above 80%;
* `getGitHubRateLimit` should return the statistics, instead of simply sending them from inside, It is not a problem to send this data more frequently to CW, and it makes to a more clear, understandable and reusable code IMO.