### PR TITLE
Convert num_reverts query to clickhouse

### DIFF
--- a/torchci/clickhouse_queries/num_reverts/params.json
+++ b/torchci/clickhouse_queries/num_reverts/params.json
@@ -1,5 +1,4 @@
 {
-  "granularity": "String",
   "startTime": "DateTime64(3)",
   "stopTime": "DateTime64(3)"
 }

--- a/torchci/clickhouse_queries/num_reverts/query.sql
+++ b/torchci/clickhouse_queries/num_reverts/query.sql
@@ -13,7 +13,7 @@ WITH coded_reverts AS (
             issue_comment.issue_url,
             MAX(issue_comment.created_at) AS created
         FROM
-            default.issue_comment
+            default.issue_comment FINAL
         WHERE
             match(issue_comment.body, '@pytorch(merge|)bot revert')
         GROUP BY

--- a/torchci/clickhouse_queries/num_reverts/query.sql
+++ b/torchci/clickhouse_queries/num_reverts/query.sql
@@ -1,108 +1,80 @@
--- !!! Query is not converted to CH syntax yet.  Delete this line when it gets converted
-WITH
-    coded_reverts as (
+-- Take this query run against rockset and convert it to be clickhouse compatible: WITH     coded_reverts as (         SELECT             FORMAT_TIMESTAMP(                 '%Y-%m-%d',                 DATE_TRUNC(:granularity, ic.created)             ) AS bucket,             REGEXP_EXTRACT(                 ic.body,                 '(-c|--classification)[\s =]+["'']?(\w+)["'']?',                 2             ) AS code,             COUNT(*) AS num         FROM             commons.issue_comment AS ic             INNER JOIN (                 SELECT                     issue_comment.issue_url,                     MAX(issue_comment.created) AS created -- Use the max for when invalid revert commands are tried first                 FROM                     commons.issue_comment                 WHERE                     REGEXP_LIKE(                         issue_comment.body,                         ' *@pytorch(merge|)bot revert'                     )                 GROUP BY                     issue_comment.issue_url             ) AS rc ON ic.issue_url = rc.issue_url         WHERE             ic.created = rc.created             AND ic.created >= PARSE_DATETIME_ISO8601(:startTime)             AND ic.created <= PARSE_DATETIME_ISO8601(:stopTime)             AND ic.user.login != 'pytorch-bot[bot]'             AND REGEXP_EXTRACT(                 ic.body,                 '(-c|--classification)[\s =]+["'']?(\w+)["'']?',                 2             ) IS NOT NULL         GROUP BY             code,             bucket     ),     weekly_results as (         (             SELECT                 FORMAT_TIMESTAMP(                     '%Y-%m-%d',                     DATE_TRUNC(:granularity, push._event_time)                 ) AS bucket,                 'total' AS code,                 COUNT(*) AS num             FROM                 push             WHERE                 push.ref IN ('refs/heads/master', 'refs/heads/main')                 AND push.repository.owner.name = 'pytorch'                 AND push.repository.name = 'pytorch'                 AND (                     push.head_commit.message LIKE 'Revert %'                     OR push.head_commit.message LIKE 'Back out%'                 )                 AND push._event_time >= PARSE_DATETIME_ISO8601(:startTime)                 AND push._event_time <= PARSE_DATETIME_ISO8601(:stopTime)             GROUP BY                 bucket             ORDER BY                 bucket         )         UNION         (             SELECT                 bucket,                 code,                 num             FROM                 coded_reverts         )         UNION         (             SELECT                 bucket,                 'non-ghfirst-total' AS code,                 SUM(num)             FROM                 coded_reverts             WHERE                 code != 'ghfirst'             GROUP BY                 bucket         )     ) SELECT     bucket,     -- 2 week rolling average     (         SUM(num) OVER(             PARTITION BY code             ORDER BY                 bucket ROWS 1 PRECEDING         )     ) / 2.0 AS num,     code, FROM     weekly_results ORDER BY     bucket DESC, code
+WITH coded_reverts AS (
+    SELECT
+        formatDateTime(toStartOfInterval(ic.created_at, interval 1 WEEK), '%Y-%m-%d') AS bucket,
+        extract(ic.body, '(?:-c|--classification)[\s =]+["\']?(\w+)["\']?') AS code,
+        COUNT(*) AS num
+    FROM
+        default.issue_comment AS ic
+    INNER JOIN (
         SELECT
-            FORMAT_TIMESTAMP(
-                '%Y-%m-%d',
-                DATE_TRUNC(:granularity, ic.created)
-            ) AS bucket,
-            REGEXP_EXTRACT(
-                ic.body,
-                '(-c|--classification)[\s =]+["'']?(\w+)["'']?',
-                2
-            ) AS code,
-            COUNT(*) AS num
+            issue_comment.issue_url,
+            MAX(issue_comment.created_at) AS created
         FROM
-            commons.issue_comment AS ic
-            INNER JOIN (
-                SELECT
-                    issue_comment.issue_url,
-                    MAX(issue_comment.created) AS created -- Use the max for when invalid revert commands are tried first
-                FROM
-                    commons.issue_comment
-                WHERE
-                    REGEXP_LIKE(
-                        issue_comment.body,
-                        ' *@pytorch(merge|)bot revert'
-                    )
-                GROUP BY
-                    issue_comment.issue_url
-            ) AS rc ON ic.issue_url = rc.issue_url
+            default.issue_comment
         WHERE
-            ic.created = rc.created
-            AND ic.created >= PARSE_DATETIME_ISO8601(:startTime)
-            AND ic.created <= PARSE_DATETIME_ISO8601(:stopTime)
-            AND ic.user.login != 'pytorch-bot[bot]'
-            AND REGEXP_EXTRACT(
-                ic.body,
-                '(-c|--classification)[\s =]+["'']?(\w+)["'']?',
-                2
-            ) IS NOT NULL
+            match(issue_comment.body, '@pytorch(merge|)bot revert')
         GROUP BY
-            code,
-            bucket
-    ),
-    weekly_results as (
-        (
-            SELECT
-                FORMAT_TIMESTAMP(
-                    '%Y-%m-%d',
-                    DATE_TRUNC(:granularity, push._event_time)
-                ) AS bucket,
-                'total' AS code,
-                COUNT(*) AS num
-            FROM
-                push
-            WHERE
-                push.ref IN ('refs/heads/master', 'refs/heads/main')
-                AND push.repository.owner.name = 'pytorch'
-                AND push.repository.name = 'pytorch'
-                AND (
-                    push.head_commit.message LIKE 'Revert %'
-                    OR push.head_commit.message LIKE 'Back out%'
-                )
-                AND push._event_time >= PARSE_DATETIME_ISO8601(:startTime)
-                AND push._event_time <= PARSE_DATETIME_ISO8601(:stopTime)
-            GROUP BY
-                bucket
-            ORDER BY
-                bucket
+            issue_comment.issue_url
+        ) AS rc ON ic.issue_url = rc.issue_url
+    WHERE
+        ic.created_at = rc.created
+        AND ic.created_at >= {startTime: DateTime64(3)}
+        AND ic.created_at <= {stopTime: DateTime64(3)}
+        AND ic.user.login != 'pytorch-bot[bot]'
+        AND extract(ic.body, '(?:-c|--classification)[\s =]+["\']?(\w+)["\']?') IS NOT NULL
+    GROUP BY
+        code,
+        bucket
+),
+weekly_results AS (
+    SELECT
+        formatDateTime(toStartOfInterval(push.head_commit.timestamp, interval 1 WEEK), '%Y-%m-%d') AS bucket,
+        'total' AS code,
+        COUNT(*) AS num
+    FROM
+        push
+    WHERE
+        push.ref IN ('refs/heads/master', 'refs/heads/main')
+        AND push.repository.owner.login = 'pytorch'
+        AND push.repository.name = 'pytorch'
+        AND (
+            push.head_commit.message LIKE 'Revert %'
+            OR push.head_commit.message LIKE 'Back out%'
         )
-        UNION
-        (
-            SELECT
-                bucket,
-                code,
-                num
-            FROM
-                coded_reverts
-        )
-        UNION
-        (
-            SELECT
-                bucket,
-                'non-ghfirst-total' AS code,
-                SUM(num)
-            FROM
-                coded_reverts
-            WHERE
-                code != 'ghfirst'
-            GROUP BY
-                bucket
-        )
-    )
+        AND push.head_commit.timestamp >= {startTime: DateTime64(3)}
+        AND push.head_commit.timestamp <= {stopTime: DateTime64(3)}
+    GROUP BY
+        bucket
+    UNION ALL
+    SELECT
+        bucket,
+        code,
+        num
+    FROM
+        coded_reverts
+    UNION ALL
+    SELECT
+        bucket,
+        'non-ghfirst-total' AS code,
+        SUM(num)
+    FROM
+        coded_reverts
+    WHERE
+        code != 'ghfirst'
+    GROUP BY
+        bucket
+)
 SELECT
     bucket,
-    -- 2 week rolling average
-    (
-        SUM(num) OVER(
-            PARTITION BY code
-            ORDER BY
-                bucket ROWS 1 PRECEDING
-        )
+    SUM(num) OVER (
+        PARTITION BY code
+        ORDER BY
+            bucket ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
     ) / 2.0 AS num,
-    code,
+    code
 FROM
     weekly_results
 ORDER BY
-    bucket DESC, code
+    bucket DESC,
+    code

--- a/torchci/clickhouse_queries/num_reverts/query.sql
+++ b/torchci/clickhouse_queries/num_reverts/query.sql
@@ -35,7 +35,7 @@ weekly_results AS (
         'total' AS code,
         COUNT(*) AS num
     FROM
-        push
+        push FINAL
     WHERE
         push.ref IN ('refs/heads/master', 'refs/heads/main')
         AND push.repository.owner.login = 'pytorch'

--- a/torchci/clickhouse_queries/num_reverts/query.sql
+++ b/torchci/clickhouse_queries/num_reverts/query.sql
@@ -1,7 +1,9 @@
--- Take this query run against rockset and convert it to be clickhouse compatible: WITH     coded_reverts as (         SELECT             FORMAT_TIMESTAMP(                 '%Y-%m-%d',                 DATE_TRUNC(:granularity, ic.created)             ) AS bucket,             REGEXP_EXTRACT(                 ic.body,                 '(-c|--classification)[\s =]+["'']?(\w+)["'']?',                 2             ) AS code,             COUNT(*) AS num         FROM             commons.issue_comment AS ic             INNER JOIN (                 SELECT                     issue_comment.issue_url,                     MAX(issue_comment.created) AS created -- Use the max for when invalid revert commands are tried first                 FROM                     commons.issue_comment                 WHERE                     REGEXP_LIKE(                         issue_comment.body,                         ' *@pytorch(merge|)bot revert'                     )                 GROUP BY                     issue_comment.issue_url             ) AS rc ON ic.issue_url = rc.issue_url         WHERE             ic.created = rc.created             AND ic.created >= PARSE_DATETIME_ISO8601(:startTime)             AND ic.created <= PARSE_DATETIME_ISO8601(:stopTime)             AND ic.user.login != 'pytorch-bot[bot]'             AND REGEXP_EXTRACT(                 ic.body,                 '(-c|--classification)[\s =]+["'']?(\w+)["'']?',                 2             ) IS NOT NULL         GROUP BY             code,             bucket     ),     weekly_results as (         (             SELECT                 FORMAT_TIMESTAMP(                     '%Y-%m-%d',                     DATE_TRUNC(:granularity, push._event_time)                 ) AS bucket,                 'total' AS code,                 COUNT(*) AS num             FROM                 push             WHERE                 push.ref IN ('refs/heads/master', 'refs/heads/main')                 AND push.repository.owner.name = 'pytorch'                 AND push.repository.name = 'pytorch'                 AND (                     push.head_commit.message LIKE 'Revert %'                     OR push.head_commit.message LIKE 'Back out%'                 )                 AND push._event_time >= PARSE_DATETIME_ISO8601(:startTime)                 AND push._event_time <= PARSE_DATETIME_ISO8601(:stopTime)             GROUP BY                 bucket             ORDER BY                 bucket         )         UNION         (             SELECT                 bucket,                 code,                 num             FROM                 coded_reverts         )         UNION         (             SELECT                 bucket,                 'non-ghfirst-total' AS code,                 SUM(num)             FROM                 coded_reverts             WHERE                 code != 'ghfirst'             GROUP BY                 bucket         )     ) SELECT     bucket,     -- 2 week rolling average     (         SUM(num) OVER(             PARTITION BY code             ORDER BY                 bucket ROWS 1 PRECEDING         )     ) / 2.0 AS num,     code, FROM     weekly_results ORDER BY     bucket DESC, code
+-- This query is used on the kpi page to break down the types
+-- of reverts that have occurred in the pytorch/pytorch repo over time.
+
 WITH coded_reverts AS (
     SELECT
-        formatDateTime(toStartOfInterval(ic.created_at, interval 1 WEEK), '%Y-%m-%d') AS bucket,
+        formatDateTime(toStartOfWeek(ic.created_at), '%Y-%m-%d') AS bucket,
         extract(ic.body, '(?:-c|--classification)[\s =]+["\']?(\w+)["\']?') AS code,
         COUNT(*) AS num
     FROM
@@ -29,7 +31,7 @@ WITH coded_reverts AS (
 ),
 weekly_results AS (
     SELECT
-        formatDateTime(toStartOfInterval(push.head_commit.timestamp, interval 1 WEEK), '%Y-%m-%d') AS bucket,
+        formatDateTime(toStartOfWeek(push.head_commit.timestamp), '%Y-%m-%d') AS bucket,
         'total' AS code,
         COUNT(*) AS num
     FROM
@@ -55,15 +57,15 @@ weekly_results AS (
         coded_reverts
     UNION ALL
     SELECT
-        bucket,
+        cr.bucket,
         'non-ghfirst-total' AS code,
-        SUM(num) AS num
+        SUM(cr.num) AS num
     FROM
-        coded_reverts
+        coded_reverts as cr
     WHERE
-        code != 'ghfirst'
+        cr.code != 'ghfirst'
     GROUP BY
-        bucket
+        cr.bucket
 )
 SELECT
     bucket,

--- a/torchci/clickhouse_queries/num_reverts/query.sql
+++ b/torchci/clickhouse_queries/num_reverts/query.sql
@@ -7,7 +7,7 @@ WITH coded_reverts AS (
         extract(ic.body, '(?:-c|--classification)[\s =]+["\']?(\w+)["\']?') AS code,
         COUNT(*) AS num
     FROM
-        default.issue_comment AS ic
+        default.issue_comment AS ic FINAL
     INNER JOIN (
         SELECT
             issue_comment.issue_url,

--- a/torchci/clickhouse_queries/num_reverts/query.sql
+++ b/torchci/clickhouse_queries/num_reverts/query.sql
@@ -57,7 +57,7 @@ weekly_results AS (
     SELECT
         bucket,
         'non-ghfirst-total' AS code,
-        SUM(num)
+        SUM(num) AS num
     FROM
         coded_reverts
     WHERE

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -125,12 +125,13 @@ export default function Kpis() {
           title={"# of reverts (2 week moving avg)"}
           queryName={"num_reverts"}
           queryCollection={"pytorch_dev_infra_kpis"}
-          queryParams={[...timeParams]}
+          queryParams={useCH ? clickhouseTimeParams : timeParams}
           granularity={"week"}
           timeFieldName={"bucket"}
           yAxisFieldName={"num"}
           yAxisRenderer={(unit) => `${unit}`}
           groupByFieldName={"code"}
+          useClickHouse={useCH}
         />
       </Grid>
 


### PR DESCRIPTION
Switch the # of reverts KPI query & chart to use ClickHouse

Testing: 
- Verified that the CH version of the chart shows the same data as the Rockset version.
- Ensured that the CH query is being run by modifying it and validating that the chart changed

https://torchci-git-zainr-clickhouses-num-reverts-fbopensource.vercel.app/kpis