### PR TITLE
[CH] Migrate failure annotation page

### DIFF
--- a/torchci/clickhouse_queries/failed_workflow_jobs/params.json
+++ b/torchci/clickhouse_queries/failed_workflow_jobs/params.json
@@ -1,6 +1,5 @@
 {
   "branch": "String",
-  "count": "Int64",
   "repo": "String",
   "startTime": "DateTime64(3)",
   "stopTime": "DateTime64(3)"

--- a/torchci/clickhouse_queries/failed_workflow_jobs/query.sql
+++ b/torchci/clickhouse_queries/failed_workflow_jobs/query.sql
@@ -1,60 +1,26 @@
--- !!! Query is not converted to CH syntax yet.  Delete this line when it gets converted
-WITH repeats AS (
-  SELECT
-    array_agg(j.id) AS ids
-  FROM
-    workflow_run w
-    JOIN workflow_job j ON w.id = j.run_id HINT(join_strategy = lookup)
-  WHERE
-    j._event_time >= PARSE_DATETIME_ISO8601(: startTime)
-    AND j._event_time < PARSE_DATETIME_ISO8601(: stopTime)
-    AND w.head_repository.full_name = : repo
-    AND w.head_branch = : branch
+-- This query is used to annotate job on HUD
+SELECT DISTINCT
+    j.head_sha AS sha,
+    CONCAT(w.name, ' / ', j.name) AS jobName,
+    j.id,
+    j.conclusion,
+    j.html_url AS htmlUrl,
+    CONCAT(
+        'https://ossci-raw-job-status.s3.amazonaws.com/log/',
+        j.id
+    ) AS logUrl,
+    DATE_DIFF('SECOND', j.started_at, j.completed_at) AS durationS,
+    array(j.torchci_classification. 'line') AS failureLines,
+    j.torchci_classification. 'captures' AS failureCaptures,
+    array(j.torchci_classification. 'line_num') AS failureLineNumbers
+FROM
+    workflow_job j FINAL
+    JOIN workflow_run w FINAL on w.id = j.run_id
+WHERE
+    j.created_at >= {startTime: DateTime64(3) }
+    AND j.created_at < {stopTime: DateTime64(3) }
+    AND w.head_repository. 'full_name' = {repo: String }
+    AND w.head_branch = {branch: String }
     AND w.event != 'workflow_run'
     AND w.event != 'repository_dispatch'
-  GROUP BY
-    j.head_sha,
-    j.name,
-    w.name
-  HAVING
-    count(*) > : count
-    AND bool_or(
-      j.conclusion IN (
-        'failure', 'cancelled', 'time_out'
-      )
-    )
-),
-ids AS (
-  SELECT
-    ids.id
-  FROM
-    repeats,
-    UNNEST(repeats.ids AS id) AS ids
-)
-SELECT
-  job.head_sha AS sha,
-  CONCAT(w.name, ' / ', job.name) AS jobName,
-  job.id,
-  job.conclusion,
-  job.html_url AS htmlUrl,
-  CONCAT(
-    'https://ossci-raw-job-status.s3.amazonaws.com/log/',
-    CAST(job.id AS string)
-  ) AS logUrl,
-  DATE_DIFF(
-    'SECOND',
-    PARSE_TIMESTAMP_ISO8601(job.started_at),
-    PARSE_TIMESTAMP_ISO8601(job.completed_at)
-  ) AS durationS,
-  w.repository.full_name AS repo,
-  ARRAY_CREATE(job.torchci_classification.line) AS failureLines,
-  job.torchci_classification.captures AS failureCaptures,
-  ARRAY_CREATE(job.torchci_classification.line_num) AS failureLineNumbers,
-FROM
-  ids
-  JOIN workflow_job job on job.id = ids.id
-  INNER JOIN workflow_run w on w.id = job.run_id
-WHERE
-  job.conclusion IN (
-    'failure', 'cancelled', 'time_out'
-  )
+    AND j.conclusion IN ('failure', 'cancelled', 'time_out')

--- a/torchci/components/JobAnnotationToggle.tsx
+++ b/torchci/components/JobAnnotationToggle.tsx
@@ -1,4 +1,5 @@
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
+import _ from "lodash";
 import { useSession } from "next-auth/react";
 import React from "react";
 import { JobAnnotation, JobData } from "../lib/types";
@@ -15,7 +16,10 @@ export default function JobAnnotationToggle({
   repo?: string | null;
 }) {
   const allJobs = similarJobs ?? [];
-  allJobs.push(job);
+  // Double check if the job exists before adding it
+  if (!_.find(allJobs, (j: JobData) => j.id === job.id)) {
+    allJobs.push(job);
+  }
 
   const [state, setState] = React.useState<JobAnnotation>(
     (annotation ?? "null") as JobAnnotation

--- a/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/failures/[queryParams].ts
+++ b/torchci/pages/api/job_annotation/[repoOwner]/[repoName]/failures/[queryParams].ts
@@ -1,22 +1,12 @@
+import { queryClickhouseSaved } from "lib/clickhouse";
 import { getDynamoClient } from "lib/dynamo";
-import getRocksetClient, { RocksetParam } from "lib/rockset";
 import { JobData } from "lib/types";
 import { NextApiRequest, NextApiResponse } from "next";
-import rocksetVersions from "rockset/prodVersions.json";
 
-async function fetchFailureJobs(
-  queryParams: RocksetParam[]
-): Promise<JobData[]> {
-  const rocksetClient = getRocksetClient();
-  const failedJobs = await rocksetClient.queryLambdas.executeQueryLambda(
-    "commons",
-    "failed_workflow_jobs",
-    rocksetVersions.commons.failed_workflow_jobs,
-    {
-      parameters: queryParams,
-    }
-  );
-  return failedJobs.results ?? [];
+async function fetchFailureJobs(queryParams: {
+  [key: string]: any;
+}): Promise<JobData[]> {
+  return await queryClickhouseSaved("failed_workflow_jobs", queryParams);
 }
 
 export default async function handler(

--- a/torchci/pages/failedjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/failedjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -99,13 +99,12 @@ function FailedJob({
 }
 
 function FailedJobsByFailure({
-  jobsBySha,
+  jobs,
   annotations,
 }: {
-  jobsBySha: { [sha: string]: JobData };
+  jobs: { [sha: string]: JobData };
   annotations: { [id: string]: { [key: string]: any } };
 }) {
-  const jobs: JobData[] = _.map(jobsBySha);
   // Select a random representative job in the group of similar jobs. Once
   // this job is classified, the rest will be put into the same category
   const job: JobData | undefined = _.sample(jobs);
@@ -159,7 +158,7 @@ function FailedJobs({
   // Grouped by annotation then by job name
   const groupedJobs: {
     [annotation: string]: {
-      [name: string]: { [sha: string]: JobData };
+      [name: string]: JobData[];
     };
   } = {};
 
@@ -186,13 +185,10 @@ function FailedJobs({
 
     const failure = jobName + workflowName + failureCaptures;
     if (!(failure in groupedJobs[annotation])) {
-      groupedJobs[annotation][failure] = {};
+      groupedJobs[annotation][failure] = [];
     }
 
-    const sha = job.sha;
-    if (!(sha in groupedJobs[annotation][failure])) {
-      groupedJobs[annotation][failure][sha] = job;
-    }
+    groupedJobs[annotation][failure].push(job);
   });
 
   return (
@@ -211,17 +207,17 @@ function FailedJobs({
             {_.reduce(
               groupedJobsByFailure,
               (s, v) => {
-                return s + Object.keys(v).length;
+                return s + v.length;
               },
               0
             )}
             )
           </summary>
           <ul>
-            {_.map(groupedJobsByFailure, (jobsBySha, failure) => (
+            {_.map(groupedJobsByFailure, (jobs, failure) => (
               <FailedJobsByFailure
                 key={failure}
-                jobsBySha={jobsBySha}
+                jobs={jobs}
                 annotations={annotations}
               />
             ))}

--- a/torchci/pages/failedjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/failedjobs/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -102,7 +102,7 @@ function FailedJobsByFailure({
   jobs,
   annotations,
 }: {
-  jobs: { [sha: string]: JobData };
+  jobs: JobData[];
   annotations: { [id: string]: { [key: string]: any } };
 }) {
   // Select a random representative job in the group of similar jobs. Once


### PR DESCRIPTION
This is more like a refactoring, not a migration, but it's needed to make the query works.

* `failed_workflow_jobs` runs OOM on ClickHouse trying to load all failed jobs from commits that are having more than N failures.  I rewrite the logic to get rid of N because we only set it to 0 anyway.  The simplified logic can be then be run
* https://hud.pytorch.org/failedjobs/pytorch/pytorch/main has duplicated entries.  This is a subtle bug from `torchci/components/JobAnnotationToggle.tsx` that took me way too long to figure out.
* There are several React warnings on the page, so I fix them too

### Testing

https://torchci-git-fork-huydhn-ch-migrate-job-anno-45acb4-fbopensource.vercel.app/failedjobs/pytorch/pytorch/main