### PR TITLE
[ch] New preference name for useClickhouse

### DIFF
--- a/torchci/components/UseClickhouseProvider.tsx
+++ b/torchci/components/UseClickhouseProvider.tsx
@@ -21,7 +21,7 @@ export function UseCHContextProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const [useCH, setUseCH] = usePreference("useClickHouse", undefined, true);
+  const [useCH, setUseCH] = usePreference("useClickHouse2", undefined, true);
   return (
     <UseCHContext.Provider
       value={{


### PR DESCRIPTION
<img width="1142" alt="image" src="https://github.com/user-attachments/assets/11351e66-3064-43f5-8289-25e482643f3d">

After https://github.com/pytorch/test-infra/pull/5778, the amount of queries to Rockset for things like hud_query decreased significantly, but there are still a few stragglers, so this is an effort to force people to re click the toggle to use Rockset explicitly 

One possible cause of this is people toggling to test Rockset queries but I figure this is can be done as well just in case