### PR TITLE
[CH] Migrate flaky_workflows_jobs and retry bot

### DIFF
--- a/torchci/clickhouse_queries/flaky_workflows_jobs/params.json
+++ b/torchci/clickhouse_queries/flaky_workflows_jobs/params.json
@@ -1,9 +1,9 @@
 {
-  "branches": "String",
+  "branches": "Array(String)",
   "maxAttempt": "Int64",
   "nextWorkflowId": "Int64",
   "numHours": "Int64",
   "repo": "String",
   "workflowId": "Int64",
-  "workflowNames": "String"
+  "workflowNames": "Array(String)"
 }

--- a/torchci/clickhouse_queries/flaky_workflows_jobs/query.sql
+++ b/torchci/clickhouse_queries/flaky_workflows_jobs/query.sql
@@ -114,7 +114,7 @@ SELECT
     annotation.annotation
 FROM
     flaky_jobs
-    LEFT JOIN default .job_annotation annotation on annotation.jobID = flaky_jobs.job_id
+    LEFT JOIN default .job_annotation annotation FINAL on annotation.jobID = flaky_jobs.job_id
 WHERE
     (
         (

--- a/torchci/clickhouse_queries/flaky_workflows_jobs/query.sql
+++ b/torchci/clickhouse_queries/flaky_workflows_jobs/query.sql
@@ -1,138 +1,133 @@
--- !!! Query is not converted to CH syntax yet.  Delete this line when it gets converted
 -- This query is used to get flaky job on trunk so that they can be retried. A flaky job is the
 -- one that has the green / red / green pattern. The failure in the middle is considered flaky
 -- and can be retried
 WITH dedups AS (
-  -- Note that there can be more than one commit with the same ID with the actual author and pytorchmergebot.
-  -- This mess up the results in some cases, so this removes all redundant information and only keeps what is
-  -- needed for the later query
-  SELECT
-    DISTINCT CONCAT(w.name, ' / ', job.name) AS fullname,
-    w.name AS workflow_name,
-    w.id AS workflow_id,
-    job.name AS job_name,
-    job.id AS job_id,
-    job.conclusion AS conclusion,
-    push.head_commit.id AS head_commit,
-    push.head_commit.timestamp AS head_commit_timestamp,
-    job.run_attempt AS run_attempt,
-    ROW_NUMBER() OVER(
-      PARTITION BY w.id,
-      w.name,
-      job.name
-      ORDER BY
-        job.run_attempt DESC
-    ) AS row_num,
-  FROM
-    commons.workflow_run w
-    JOIN commons.workflow_job job ON w.id = job.run_id HINT(join_strategy = lookup)
-    JOIN push ON push.head_commit.id = w.head_commit.id
-  WHERE
-    (
-      job._event_time >= CURRENT_DATE() - HOURS(: numHours)
-      OR : numHours = 0
-    )
-    AND w.head_repository.full_name = : repo
-    AND ARRAY_CONTAINS(
-      SPLIT(: branches, ','),
-      w.head_branch
-    )
-    AND ARRAY_CONTAINS(
-      SPLIT(: workflowNames, ','),
-      w.name
-    )
-    AND job.name NOT LIKE '%mem_leak_check%'
-    AND job.name NOT LIKE '%rerun_disabled_tests%'
-    AND job.name NOT LIKE '%unstable%'
+    -- Note that there can be more than one commit with the same ID with the actual author and pytorchmergebot.
+    -- This mess up the results in some cases, so this removes all redundant information and only keeps what is
+    -- needed for the later query
+    SELECT
+        DISTINCT CONCAT(w.name, ' / ', j.name) AS fullname,
+        w.name AS workflow_name,
+        w.id AS workflow_id,
+        j.name AS job_name,
+        j.id AS job_id,
+        j.conclusion AS conclusion,
+        push.head_commit. 'id' AS head_commit,
+        push.head_commit. 'timestamp' AS head_commit_timestamp,
+        j.run_attempt AS run_attempt,
+        ROW_NUMBER() OVER(
+            PARTITION BY w.id,
+            w.name,
+            j.name
+            ORDER BY
+                j.run_attempt DESC
+        ) AS row_num
+    FROM
+        default .workflow_run w FINAL
+        JOIN default .workflow_job j FINAL ON w.id = j.run_id
+        JOIN default .push FINAL ON push.head_commit. 'id' = w.head_commit. 'id'
+    WHERE
+        (
+            j.created_at >= dateSub(hour, { numHours: Int64 }, CURRENT_DATE())
+            OR { numHours: Int64 } = 0
+        )
+        AND w.head_repository. 'full_name' = { repo: String }
+        AND has({branches: Array(String) }, w.head_branch)
+        AND has({workflowNames: Array(String) }, w.name)
+        AND j.name NOT LIKE '%mem_leak_check%'
+        AND j.name NOT LIKE '%rerun_disabled_tests%'
+        AND j.name NOT LIKE '%unstable%'
 ),
 latest_attempts AS (
-  -- Keep the latest run attempt to know if the job has already been retried
-  SELECT
-    *
-  FROM
-    dedups
-  WHERE
-    row_num = 1
+    -- Keep the latest run attempt to know if the job has already been retried
+    SELECT
+        *
+    FROM
+        dedups
+    WHERE
+        row_num = 1
 ),
 flaky_jobs AS (
-  SELECT
-    workflow_name,
-    job_name,
-    -- Next commit
-    workflow_id AS next_workflow_id,
-    job_id AS next_job_id,
-    -- The flaky status of the job
-    FIRST_VALUE(conclusion) OVER(
-      PARTITION BY fullname
-      ORDER BY
-        head_commit_timestamp DESC ROWS BETWEEN CURRENT ROW
-        AND 2 FOLLOWING
-    ) = 'success'
-    AND NTH_VALUE(conclusion, 2) OVER(
-      PARTITION BY fullname
-      ORDER BY
-        head_commit_timestamp DESC ROWS BETWEEN CURRENT ROW
-        AND 2 FOLLOWING
-    ) = 'failure'
-    AND LAST_VALUE(conclusion) OVER(
-      PARTITION BY fullname
-      ORDER BY
-        head_commit_timestamp DESC ROWS BETWEEN CURRENT ROW
-        AND 2 FOLLOWING
-    ) = 'success' AS flaky,
-    -- The current commit
-    NTH_VALUE(workflow_id, 2) OVER(
-      PARTITION BY fullname
-      ORDER BY
-        head_commit_timestamp DESC ROWS BETWEEN CURRENT ROW
-        AND 2 FOLLOWING
-    ) AS workflow_id,
-    NTH_VALUE(job_id, 2) OVER(
-      PARTITION BY fullname
-      ORDER BY
-        head_commit_timestamp DESC ROWS BETWEEN CURRENT ROW
-        AND 2 FOLLOWING
-    ) AS job_id,
-    NTH_VALUE(run_attempt, 2) OVER(
-      PARTITION BY fullname
-      ORDER BY
-        head_commit_timestamp DESC ROWS BETWEEN CURRENT ROW
-        AND 2 FOLLOWING
-    ) AS run_attempt,
-  FROM
-    latest_attempts
-  WHERE
-    (
-      latest_attempts.run_attempt <= : maxAttempt
-      OR : maxAttempt = 0
-    )
+    SELECT
+        workflow_name,
+        job_name,
+        -- The flaky status of the job
+        FIRST_VALUE(conclusion) OVER(
+            PARTITION BY fullname
+            ORDER BY
+                head_commit_timestamp DESC ROWS BETWEEN CURRENT ROW
+                AND 2 FOLLOWING
+        ) = 'success'
+        AND NTH_VALUE(conclusion, 2) OVER(
+            PARTITION BY fullname
+            ORDER BY
+                head_commit_timestamp DESC ROWS BETWEEN CURRENT ROW
+                AND 2 FOLLOWING
+        ) = 'failure'
+        AND LAST_VALUE(conclusion) OVER(
+            PARTITION BY fullname
+            ORDER BY
+                head_commit_timestamp DESC ROWS BETWEEN CURRENT ROW
+                AND 2 FOLLOWING
+        ) = 'success' AS flaky,
+        -- The current commit
+        NTH_VALUE(workflow_id, 2) OVER(
+            PARTITION BY fullname
+            ORDER BY
+                head_commit_timestamp DESC ROWS BETWEEN CURRENT ROW
+                AND 2 FOLLOWING
+        ) AS workflow_id,
+        NTH_VALUE(job_id, 2) OVER(
+            PARTITION BY fullname
+            ORDER BY
+                head_commit_timestamp DESC ROWS BETWEEN CURRENT ROW
+                AND 2 FOLLOWING
+        ) AS job_id,
+        NTH_VALUE(run_attempt, 2) OVER(
+            PARTITION BY fullname
+            ORDER BY
+                head_commit_timestamp DESC ROWS BETWEEN CURRENT ROW
+                AND 2 FOLLOWING
+        ) AS run_attempt,
+        -- Next commit, this needs to come after the nth_value window functions
+        -- above, otherwise, CH query planner croaks about nested the illegal
+        -- use of nested window functions
+        workflow_id AS next_workflow_id,
+        job_id AS next_job_id
+    FROM
+        latest_attempts
+    WHERE
+        (
+            latest_attempts.run_attempt <= {maxAttempt: Int64}
+            OR {maxAttempt: Int64} = 0
+        )
 )
 SELECT
-  DISTINCT flaky_jobs.workflow_name,
-  flaky_jobs.workflow_id,
-  flaky_jobs.job_name,
-  flaky_jobs.job_id,
-  flaky_jobs.flaky,
-  flaky_jobs.run_attempt,
-  flaky_jobs.next_workflow_id,
-  flaky_jobs.next_job_id,
-  annotation.annotation,
+    DISTINCT flaky_jobs.workflow_name,
+    flaky_jobs.workflow_id,
+    flaky_jobs.job_name,
+    flaky_jobs.job_id,
+    flaky_jobs.flaky,
+    flaky_jobs.run_attempt,
+    flaky_jobs.next_workflow_id,
+    flaky_jobs.next_job_id,
+    annotation.annotation
 FROM
-  flaky_jobs
-  LEFT JOIN commons.job_annotation annotation on annotation.jobID = flaky_jobs.job_id
+    flaky_jobs
+    LEFT JOIN default .job_annotation annotation on annotation.jobID = flaky_jobs.job_id
 WHERE
-  (
     (
-      flaky_jobs.flaky
-      AND annotation.annotation IS NULL
+        (
+            flaky_jobs.flaky = 1
+            AND annotation.annotation = ''
+        )
+        OR annotation.annotation = 'TEST_FLAKE'
     )
-    OR annotation.annotation = 'TEST_FLAKE'
-  )
-  AND (
-    flaky_jobs.workflow_id = : workflowId
-    OR : workflowId = 0
-  )
-  AND (
-    flaky_jobs.next_workflow_id = : nextWorkflowId
-    OR : nextWorkflowId = 0
-  )
+    AND (
+        flaky_jobs.workflow_id = {workflowId: Int64}
+        OR {workflowId: Int64} = 0
+    )
+    AND (
+        flaky_jobs.next_workflow_id = {nextWorkflowId: Int64}
+        OR {nextWorkflowId: Int64} = 0
+    )

--- a/torchci/lib/bot/retryBot.ts
+++ b/torchci/lib/bot/retryBot.ts
@@ -1,4 +1,4 @@
-import { queryClickhouseSaved } from "lib/clickhouse";
+import { queryClickhouseSaved } from "../clickhouse";
 import { Probot } from "probot";
 import { CachedConfigTracker } from "./utils";
 

--- a/torchci/lib/bot/retryBot.ts
+++ b/torchci/lib/bot/retryBot.ts
@@ -21,8 +21,6 @@ async function retryPreviousWorkflow(
     workflowId
   );
 
-  console.log(flakyJobs);
-
   if (flakyJobs === undefined || flakyJobs.length === 0) {
     return;
   }

--- a/torchci/lib/bot/retryBot.ts
+++ b/torchci/lib/bot/retryBot.ts
@@ -1,5 +1,5 @@
-import { queryClickhouseSaved } from "../clickhouse";
 import { Probot } from "probot";
+import { queryClickhouseSaved } from "../clickhouse";
 import { CachedConfigTracker } from "./utils";
 
 const SUCCESS_CONCLUSIONS = ["success"];

--- a/torchci/lib/bot/retryBot.ts
+++ b/torchci/lib/bot/retryBot.ts
@@ -1,9 +1,34 @@
+import { queryClickhouseSaved } from "lib/clickhouse";
 import { Probot } from "probot";
-import { getFlakyJobsFromPreviousWorkflow } from "../jobUtils";
 import { CachedConfigTracker } from "./utils";
 
 const SUCCESS_CONCLUSIONS = ["success"];
 const FAILURE_CONCLUSIONS = ["failure", "cancelled", "timed_out"];
+
+async function getFlakyJobsFromPreviousWorkflow(
+  owner: string,
+  repo: string,
+  branch: string,
+  workflowName: string,
+  workflowId: number
+): Promise<any> {
+  const flakyJobs = await queryClickhouseSaved("flaky_workflows_jobs", {
+    branches: [branch],
+    maxAttempt: 1, // If the job was retried and still failed, it wasn't flaky
+    nextWorkflowId: `${workflowId}`, // Query the flaky status of jobs from the previous workflow
+    numHours: 24, // The default value
+    repo: `${owner}/${repo}`,
+    workflowId: 0,
+    workflowNames: [workflowName],
+  });
+
+  if (flakyJobs === undefined || flakyJobs.length === 0) {
+    return [];
+  }
+
+  // The query returns all the flaky jobs from the previous workflow
+  return flakyJobs;
+}
 
 async function retryPreviousWorkflow(
   ctx: any,

--- a/torchci/lib/bot/retryBot.ts
+++ b/torchci/lib/bot/retryBot.ts
@@ -21,6 +21,8 @@ async function retryPreviousWorkflow(
     workflowId
   );
 
+  console.log(flakyJobs);
+
   if (flakyJobs === undefined || flakyJobs.length === 0) {
     return;
   }

--- a/torchci/lib/bot/retryBot.ts
+++ b/torchci/lib/bot/retryBot.ts
@@ -15,7 +15,7 @@ async function getFlakyJobsFromPreviousWorkflow(
   const flakyJobs = await queryClickhouseSaved("flaky_workflows_jobs", {
     branches: [branch],
     maxAttempt: 1, // If the job was retried and still failed, it wasn't flaky
-    nextWorkflowId: `${workflowId}`, // Query the flaky status of jobs from the previous workflow
+    nextWorkflowId: workflowId, // Query the flaky status of jobs from the previous workflow
     numHours: 24, // The default value
     repo: `${owner}/${repo}`,
     workflowId: 0,

--- a/torchci/lib/jobUtils.ts
+++ b/torchci/lib/jobUtils.ts
@@ -9,7 +9,6 @@ import {
 } from "lib/types";
 import _, { isEqual } from "lodash";
 import TrieSearch from "trie-search";
-import { queryClickhouseSaved } from "./clickhouse";
 
 export const REMOVE_JOB_NAME_SUFFIX_REGEX = new RegExp(
   ", [0-9]+, [0-9]+, .+\\)"
@@ -211,31 +210,6 @@ export function getDisabledTestIssues(
   }
 
   return matchingIssues;
-}
-
-export async function getFlakyJobsFromPreviousWorkflow(
-  owner: string,
-  repo: string,
-  branch: string,
-  workflowName: string,
-  workflowId: number
-): Promise<any> {
-  const flakyJobs = await queryClickhouseSaved("flaky_workflows_jobs", {
-    branches: [branch],
-    maxAttempt: 1, // If the job was retried and still failed, it wasn't flaky
-    nextWorkflowId: `${workflowId}`, // Query the flaky status of jobs from the previous workflow
-    numHours: 24, // The default value
-    repo: `${owner}/${repo}`,
-    workflowId: 0,
-    workflowNames: [workflowName],
-  });
-
-  if (flakyJobs === undefined || flakyJobs.length === 0) {
-    return [];
-  }
-
-  // The query returns all the flaky jobs from the previous workflow
-  return flakyJobs;
 }
 
 export function removeJobNameSuffix(

--- a/torchci/test/retryBot.test.ts
+++ b/torchci/test/retryBot.test.ts
@@ -1,7 +1,7 @@
-import * as clickhouse from "../lib/clickhouse";
 import nock from "nock";
 import { Probot } from "probot";
 import myProbotApp from "../lib/bot/retryBot";
+import * as clickhouse from "../lib/clickhouse";
 import { handleScope, requireDeepCopy } from "./common";
 import * as utils from "./utils";
 

--- a/torchci/test/retryBot.test.ts
+++ b/torchci/test/retryBot.test.ts
@@ -1,4 +1,4 @@
-import * as clickhouse from "lib/clickhouse";
+import * as clickhouse from "../lib/clickhouse";
 import nock from "nock";
 import { Probot } from "probot";
 import myProbotApp from "../lib/bot/retryBot";


### PR DESCRIPTION
This query is used to get flaky jobs in the past 24 hours, which is then used by retry bot.  As part of this, I also need to move `getFlakyJobsFromPreviousWorkflow` from `jobUtils` to the bot itself because `queryClickhouseSaved` can only be used on the server side.