### PR TITLE
Add torchcodec to manage.py for nightly wheel upload

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -162,6 +162,7 @@ PACKAGE_ALLOW_LIST = {
     "torch_tensorrt",
     "torcharrow",
     "torchaudio",
+    "torchcodec",
     "torchcsprng",
     "torchdata",
     "torchdistx",


### PR DESCRIPTION
https://github.com/pytorch/test-infra/pull/5814 adds torchcodec nightly wheel upload to test-infra.

This PR adds it to the index.