### PR TITLE
Add default package hash to cache key

### DIFF
--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -40,7 +40,7 @@ runs:
         shell: bash
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')d" >> "${GITHUB_OUTPUT}"
-          echo "default_packages_checksum=$(echo -n ${{ inputs.default-packages | md5sum | awk '{print $1}' }})" >> "${GITHUB_OUTPUT}"
+          echo "default_packages_checksum=$(echo -n ${{ inputs.default-packages }} | md5sum | awk '{print $1}' )" >> "${GITHUB_OUTPUT}"
 
       - name: Setup miniconda cache
         id: miniconda-cache

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -40,13 +40,14 @@ runs:
         shell: bash
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')d" >> "${GITHUB_OUTPUT}"
+          echo "package_hash=$(echo ${{ input.default-packages }} | md5sum | awk "{print $1}) >> "${GITHUB_OUTPUT}"
 
       - name: Setup miniconda cache
         id: miniconda-cache
         uses: actions/cache@v3
         with:
           path: ${{ runner.temp }}/miniconda
-          key: miniconda-${{ inputs.miniconda-version }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}
+          key: miniconda-${{ inputs.miniconda-version }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}-${{ inputs.default-packages }}
 
       - name: Install miniconda (${{ inputs.miniconda-version }})
         if: steps.miniconda-cache.outputs.cache-hit != 'true'

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -40,7 +40,7 @@ runs:
         shell: bash
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')d" >> "${GITHUB_OUTPUT}"
-          echo "package_hash=$(echo ${{ inputs.default-packages }} | md5sum | awk "{print $1}) >> "${GITHUB_OUTPUT}"
+          echo "package_hash=$(echo ${{ inputs.default-packages }} | md5sum | awk "{print $1})" >> "${GITHUB_OUTPUT}"
 
       - name: Setup miniconda cache
         id: miniconda-cache

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -40,14 +40,14 @@ runs:
         shell: bash
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')d" >> "${GITHUB_OUTPUT}"
-          echo "package_hash=$(echo ${{ inputs.default-packages }} | md5sum | awk '{print $1}' )" >> "${GITHUB_OUTPUT}"
+          echo "default_packages_checksum=$(echo -n ${{ input.default-packages | md5sum | awk '{print $1}' }})" >> "${GITHUB_OUTPUT}"
 
       - name: Setup miniconda cache
         id: miniconda-cache
         uses: actions/cache@v3
         with:
           path: ${{ runner.temp }}/miniconda
-          key: miniconda-${{ inputs.miniconda-version }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}-${{ inputs.default-packages }}
+          key: miniconda-${{ inputs.miniconda-version }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}-${{ steps.get-date.outputs.default_packages_checksum }}
 
       - name: Install miniconda (${{ inputs.miniconda-version }})
         if: steps.miniconda-cache.outputs.cache-hit != 'true'

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -40,7 +40,7 @@ runs:
         shell: bash
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')d" >> "${GITHUB_OUTPUT}"
-          echo "default_packages_checksum=$(echo -n ${{ input.default-packages | md5sum | awk '{print $1}' }})" >> "${GITHUB_OUTPUT}"
+          echo "default_packages_checksum=$(echo -n ${{ inputs.default-packages | md5sum | awk '{print $1}' }})" >> "${GITHUB_OUTPUT}"
 
       - name: Setup miniconda cache
         id: miniconda-cache

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -40,7 +40,7 @@ runs:
         shell: bash
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')d" >> "${GITHUB_OUTPUT}"
-          echo "package_hash=$(echo ${{ input.default-packages }} | md5sum | awk "{print $1}) >> "${GITHUB_OUTPUT}"
+          echo "package_hash=$(echo ${{ inputs.default-packages }} | md5sum | awk "{print $1}) >> "${GITHUB_OUTPUT}"
 
       - name: Setup miniconda cache
         id: miniconda-cache

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -47,7 +47,7 @@ runs:
         uses: actions/cache@v3
         with:
           path: ${{ runner.temp }}/miniconda
-          key: miniconda-${{ inputs.miniconda-version }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}-${{ steps.get-date.outputs.default_packages_checksum }}
+          key: miniconda-${{ inputs.miniconda-version }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.default_packages_checksum }}-${{ steps.get-date.outputs.today }}
 
       - name: Install miniconda (${{ inputs.miniconda-version }})
         if: steps.miniconda-cache.outputs.cache-hit != 'true'
@@ -105,7 +105,7 @@ runs:
         uses: actions/cache@v3
         with:
           path: ${{ runner.temp }}/conda-python-${{ inputs.python-version }}
-          key: miniconda-env-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.today }}-${{ hashFiles(inputs.environment-file) }}-${{ hashFiles(inputs.pip-requirements-file) }}
+          key: miniconda-env-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.default_packages_checksum }}-${{ steps.get-date.outputs.today }}-${{ hashFiles(inputs.environment-file) }}-${{ hashFiles(inputs.pip-requirements-file) }}
 
       - name: Setup conda environment with python (v${{ inputs.python-version }})
         if: steps.miniconda-env-cache.outcome == 'success' && steps.miniconda-env-cache.outputs.cache-hit != 'true'

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -40,7 +40,7 @@ runs:
         shell: bash
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')d" >> "${GITHUB_OUTPUT}"
-          echo "package_hash=$(echo ${{ inputs.default-packages }} | md5sum | awk "{print $1})" >> "${GITHUB_OUTPUT}"
+          echo "package_hash=$(echo ${{ inputs.default-packages }} | md5sum | awk '{print $1}' )" >> "${GITHUB_OUTPUT}"
 
       - name: Setup miniconda cache
         id: miniconda-cache


### PR DESCRIPTION
Without this there would be cache collisions of different default-packages. i.e. the symptom I was seeing was the cache 
would restore my conda environment but without the packages.

I tested it here with torchcodec https://github.com/pytorch/torchcodec/pull/298

https://github.com/pytorch/torchcodec/actions/runs/11523232397/job/32081186451?pr=298

And it seems to be working fine.

Example the cache key contains the package hashes:

<img width="1193" alt="image" src="https://github.com/user-attachments/assets/f04d6ac9-ff72-4f07-b5ef-831b6d3fd09f">
