### PR TITLE
Add torchcodec to the list of nightly dispatch options

### DIFF
--- a/.github/workflows/trigger_nightly.yml
+++ b/.github/workflows/trigger_nightly.yml
@@ -21,6 +21,7 @@ on:
           - fbgemm
           - executorch
           - torchtune
+          - torchcodec
           - all
 jobs:
   trigger:


### PR DESCRIPTION
My miss in reviewing https://github.com/pytorch/test-infra/pull/5814, having torchcodec in the list of options will allow folks to test the nightly build manually. 