### PR TITLE
[bots] PR gets ciflow/trunk on import

### DIFF
--- a/torchci/lib/bot/autoLabelCodevTrunk.ts
+++ b/torchci/lib/bot/autoLabelCodevTrunk.ts
@@ -62,7 +62,8 @@ function myBot(app: Probot): void {
     // Apply `ciflow/trunk` to PRs that have just been imported
     if (
       context.payload.comment.user.login == "facebook-github-bot" &&
-      context.payload.comment.body.match("has imported this pull request")
+      context.payload.comment.body.match("has imported this pull request") &&
+      context.payload.issue.pull_request
     ) {
       const owner = context.payload.repository.owner.login;
       const repo = context.payload.repository.name;

--- a/torchci/lib/bot/autoLabelCodevTrunk.ts
+++ b/torchci/lib/bot/autoLabelCodevTrunk.ts
@@ -62,9 +62,7 @@ function myBot(app: Probot): void {
     // Apply `ciflow/trunk` to PRs that have just been imported
     if (
       context.payload.comment.user.login == "facebook-github-bot" &&
-      context.payload.comment.body.match(
-        "has imported this pull request. If you are a Meta employee, you can view this diff"
-      )
+      context.payload.comment.body.match("has imported this pull request")
     ) {
       const owner = context.payload.repository.owner.login;
       const repo = context.payload.repository.name;

--- a/torchci/test/autoLabelCodevTrunk.test.ts
+++ b/torchci/test/autoLabelCodevTrunk.test.ts
@@ -272,4 +272,18 @@ describe("autoLabelCodevTrunkBot", () => {
 
     handleScope(scope);
   });
+
+  test("Does not add ciflow/trunk label on comment if not a PR", async () => {
+    const event = requireDeepCopy("./fixtures/issue_comment.json");
+    event.payload.comment.body =
+      "@clee2000 has imported this pull request. If you are a Meta employee, you can view this diff [on Phabricator](https://www.internalfb.com/diff/D64475068).";
+    event.payload.comment.user.login = "facebook-github-bot";
+    delete event.payload.issue.pull_request;
+    event.payload.comment.body = "@zhouzhuojie has imported this pull request.";
+
+    const scope = nock("https://api.github.com");
+    await probot.receive(event);
+
+    scope.done();
+  });
 });

--- a/torchci/test/autoLabelCodevTrunk.test.ts
+++ b/torchci/test/autoLabelCodevTrunk.test.ts
@@ -175,4 +175,101 @@ describe("autoLabelCodevTrunkBot", () => {
 
     scope.done();
   });
+
+  test("PR does not add ciflow/trunk on random comment (wrong content)", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
+    event.payload.body = "random";
+    event.payload.comment.user.login = "facebook-github-bot";
+
+    nock("https://api.github.com")
+      .post("/app/installations/2/access_tokens")
+      .reply(200, { token: "test" });
+
+    const scope = nock("https://api.github.com");
+    await probot.receive(event);
+
+    scope.done();
+  });
+
+  test("PR does not add ciflow/trunk on random comment (wrong user)", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
+    event.payload.comment.body =
+      "@clee2000 has imported this pull request. If you are a Meta employee, you can view this diff [on Phabricator](https://www.internalfb.com/diff/D64475068).";
+    event.payload.comment.user.login = "random user";
+
+    nock("https://api.github.com")
+      .post("/app/installations/2/access_tokens")
+      .reply(200, { token: "test" });
+
+    const scope = nock("https://api.github.com");
+    await probot.receive(event);
+
+    scope.done();
+  });
+
+  test("PR does not add ciflow/trunk on comment (no permissions)", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
+    event.payload.comment.body =
+      "@clee2000 has imported this pull request. If you are a Meta employee, you can view this diff [on Phabricator](https://www.internalfb.com/diff/D64475068).";
+    event.payload.comment.user.login = "facebook-github-bot";
+    const owner = "clee2000";
+    const repo = "random-testing";
+    event.payload.repository.owner.login = owner;
+    event.payload.repository.name = repo;
+    const repoFullName = `${owner}/${repo}`;
+    const author = event.payload.issue.user.login;
+    const headSha = "random";
+
+    nock("https://api.github.com")
+      .post("/app/installations/2/access_tokens")
+      .reply(200, { token: "test" });
+
+    const scope = [
+      utils.mockGetPR(repoFullName, event.payload.issue.number, {
+        user: { login: author },
+        head: { sha: headSha },
+        base: { repo: { name: repo, owner: { login: owner } } },
+      }),
+      utils.mockPermissions(repoFullName, author, "read"),
+      utils.mockApprovedWorkflowRuns(repoFullName, headSha, false),
+    ];
+    await probot.receive(event);
+
+    handleScope(scope);
+  });
+
+  test("PR adds ciflow/trunk on comment", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
+    event.payload.comment.body =
+      "@clee2000 has imported this pull request. If you are a Meta employee, you can view this diff [on Phabricator](https://www.internalfb.com/diff/D64475068).";
+    event.payload.comment.user.login = "facebook-github-bot";
+    const owner = "clee2000";
+    const repo = "random-testing";
+    event.payload.repository.owner.login = owner;
+    event.payload.repository.name = repo;
+    const repoFullName = `${owner}/${repo}`;
+    const author = event.payload.issue.user.login;
+    const headSha = "random";
+
+    nock("https://api.github.com")
+      .post("/app/installations/2/access_tokens")
+      .reply(200, { token: "test" });
+
+    const scope = [
+      utils.mockGetPR(repoFullName, event.payload.issue.number, {
+        user: { login: author },
+        head: { sha: headSha },
+        base: { repo: { name: repo, owner: { login: owner } } },
+      }),
+      utils.mockApprovedWorkflowRuns(repoFullName, headSha, true),
+      utils.mockAddLabels(
+        ["ciflow/trunk"],
+        repoFullName,
+        event.payload.issue.number
+      ),
+    ];
+    await probot.receive(event);
+
+    handleScope(scope);
+  });
 });


### PR DESCRIPTION
Continuation of https://github.com/pytorch/test-infra/pull/5795

There was a case where the pr body didn't get edited when the PR was imported, so we should also handle this case, which I identify by seeing if the comment got added

I think the rule is :
* ghimport -> pr body gets edited
* normal import using button -> pr body doesn't get edited

Random but I think ghimport uses 2 spaces after the period, but the facebook-github-bot uses 1