### PR TITLE
[drci][ez] Fix update pending

### DIFF
--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -261,10 +261,10 @@ async function getPRsWithPendingJobInComment(repo: String): Promise<number[]> {
 select
     issue_url
 from
-    issue_comment final
+    default.issue_comment final
 where
     body like '<!-- drci-comment-start -->%'
-    and body like '%hourglass_flowing_sand%'
+    and body like '% Pending%'
     and issue_comment.updated_at > now() - interval 1 month
     and issue_url like {repo: String}`;
   const results = await queryClickhouse(query, { repo: `%${repo}%` });

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -264,7 +264,7 @@ from
     default.issue_comment final
 where
     body like '<!-- drci-comment-start -->%'
-    and body like '% Pending%'
+    and match(body, '\\d Pending')
     and issue_comment.updated_at > now() - interval 1 month
     and issue_url like {repo: String}`;
   const results = await queryClickhouse(query, { repo: `%${repo}%` });


### PR DESCRIPTION
I forgot that you can have failing jobs and pending jobs at the same time, and the failing jobs icon will take precedence.  Tested by editing one of my PRs to it's old, pending and failed status and saw that it updated
