### PR TITLE
Enable mac wheel building to setup miniconda

### DIFF
--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -74,6 +74,11 @@ on:
         required: false
         type: string
         default: recursive
+      setup-miniconda:
+        description: Set to true if setup-miniconda is needed
+        required: false
+        type: boolean
+        default: false
       delocate-wheel:
         description: "Whether to run delocate-wheel after building."
         required: false
@@ -130,7 +135,7 @@ jobs:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
           submodules: ${{ inputs.submodules }}
-          setup-miniconda: false
+          setup-miniconda: ${{ inputs.setup-miniconda }}
           python-version: ${{ env.PYTHON_VERSION }}
           cuda-version: ${{ env.CU_VERSION }}
           arch: ${{ env.ARCH }}


### PR DESCRIPTION
Currently, building Mac wheels has setting up miniconda for binary builds hard-coded to false. I believe this prevents us from doing wheel building on ephemeral runners. When trying to build Mac wheels on ephemeral runners, we run into a [`conda command not found`](https://github.com/pytorch/torchcodec/actions/runs/11580808748/job/32240163090?pr=320) error. Conda is not found because it's not installed. I assume that on our stable runners, it's already there.

This PR adds setting up miniconda as an option. It defaults to `false` because currently everyone is already working without setting it up, so it seems safest to disable it by default. This change mirrors what is currently in building wheels for Linux: https://github.com/pytorch/test-infra/blob/29912dec4567529a8aa7d124b7610c06b1648acb/.github/workflows/build_wheels_linux.yml#L68-L72