### PR TITLE
Add a rule for pr_time_benchmarks REGRESSION

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -217,6 +217,10 @@ name = 'Python flaky unittest - errored'
 pattern = '^\s*(test.*) errored - num_retries_left:'
 
 [[rule]]
+name = 'pr_time_benchmarks regression'
+pattern = '^REGRESSION: benchmark.*'
+
+[[rule]]
 name = 'Python RuntimeError'
 pattern = '^RuntimeError: .*'
 


### PR DESCRIPTION
Here is an example misclassification from https://github.com/pytorch/pytorch/pull/139323

<!-- drci-comment-start -->

## :link: Helpful Links
### :test_tube: See artifacts and rendered test results at [hud.pytorch.org/pr/139323](https://hud.pytorch.org/pr/139323)
* :page_facing_up: Preview [Python docs built from this PR](https://docs-preview.pytorch.org/pytorch/pytorch/139323/index.html)
* :page_facing_up: Preview [C++ docs built from this PR](https://docs-preview.pytorch.org/pytorch/pytorch/139323/cppdocs/index.html)
* :question: Need help or want to give feedback on the CI? Visit the [bot commands wiki](https://github.com/pytorch/pytorch/wiki/Bot-commands) or our [office hours](https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours)

Note: Links to docs will display an error until the docs builds have been completed.


## :white_check_mark: You can merge normally! (1 Unrelated Failure)
As of commit c185cfdfb26bb455800c8613be5fbacba971acb1 with merge base fef5e94657556f6617cb21eeeb494389d297b7d8 (<sub><sub><img alt="image" width=70 src="https://img.shields.io/date/1730324799?label=&color=FFFFFF&style=flat-square"></sub></sub>):
<details ><summary><b>FLAKY</b> - The following job failed but was likely due to flakiness present on trunk:</summary><p>

* [pull / cuda12.1-py3.10-gcc9-sm75 / test (pr_time_benchmarks, 1, 1, linux.g4dn.metal.nvidia.gpu)](https://hud.pytorch.org/pr/pytorch/pytorch/139323#32308570266) ([gh](https://github.com/pytorch/pytorch/actions/runs/11602467041/job/32308570266)) ([similar failure](https://hud.pytorch.org/pytorch/pytorch/commit/04eb15da441fec30353b7e1700feba5b22f62b7d#32291887289))
    `ModuleNotFoundError: No module named 'boto3'`
</p></details>


This comment was automatically generated by Dr. CI and updates every 15 minutes.
<!-- drci-comment-end -->

### Testing

https://hud.pytorch.org/pr/139323