### PR TITLE
Pin nvidia-container-toolkit to version 1.16.2

### DIFF
--- a/.github/actions/setup-nvidia/action.yml
+++ b/.github/actions/setup-nvidia/action.yml
@@ -40,7 +40,7 @@ runs:
                   fi
 
                   sudo yum-config-manager --add-repo "${YUM_REPO_URL}"
-                  sudo yum install -y nvidia-docker2
+                  sudo yum install -y nvidia-docker2 nvidia-container-toolkit-1.16.2
                   sudo systemctl restart docker
               )
           }
@@ -51,7 +51,7 @@ runs:
                   # Install nvidia-driver package if not installed
                   status="$(dpkg-query -W --showformat='${db:Status-Status}' nvidia-docker2 2>&1)"
                   if [ ! $? = 0 ] || [ ! "$status" = installed ]; then
-                    sudo apt-get install -y nvidia-docker2
+                    sudo apt-get install -y nvidia-docker2 nvidia-container-toolkit-1.16.2
                     sudo systemctl restart docker
                   fi
               )


### PR DESCRIPTION
Yesterday's nvidia-container-toolkit v1.17.0 [release](https://github.com/NVIDIA/nvidia-container-toolkit/releases/tag/v1.17.0) seems to have broken some of our domain images, causing `docker run --gpus all [image]" to fail with the error:

```
$ docker run --gpus all [IMAGE]
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error running hook #0: error running hook: exit status 1, stdout: , stderr: Auto-detected mode as 'legacy'
nvidia-container-cli: error parsing IMEX info: unsupported IMEX channel value: all: unknown.
ERRO[0000] error waiting for container: context canceled 
```

Pinning the toolkit to the previous version to mitigate the failure for now

Testing:
- Validated locally
- TBD: Currently testing on a domain repo 