### PR TITLE
[HUD] Compress api/issues/[label]

### DIFF
--- a/torchci/pages/api/issue/[label].ts
+++ b/torchci/pages/api/issue/[label].ts
@@ -1,15 +1,21 @@
 import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
 import { IssueData } from "lib/types";
 import { NextApiRequest, NextApiResponse } from "next";
+import zlib from "zlib";
 
 export type IssueLabelApiResponse = IssueData[];
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<IssueLabelApiResponse>
+  res: NextApiResponse
 ) {
   return res
     .status(200)
     .setHeader("Cache-Control", "s-maxage=60")
-    .json(await fetchIssuesByLabel(req.query.label as string));
+    .setHeader("Content-Encoding", "gzip")
+    .send(
+      zlib.gzipSync(
+        JSON.stringify(await fetchIssuesByLabel(req.query.label as string))
+      )
+    );
 }


### PR DESCRIPTION
To reduce warnings about `API response for /api/issue/skipped exceeds 4MB. API Routes are meant to respond quickly. https://nextjs.org/docs/messages/api-routes-response-size-limit`

Realistically most of these calls don't need the entire body, which is probably most of the size, but going through and finding all references is a task for another day

Checked that main HUD page still has buttons for "test is disabled" and "disable test"