### PR TITLE
[HUD] Merge LF and non LF columns

### DIFF
--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -321,7 +321,7 @@ export function getGroupingData(
     for (const groupName of groupNamesArray) {
       groupedJobs.set(groupName, { groupName, jobs: [] });
     }
-    for (const job of row.jobs) {
+    for (const job of row.nameToJobs!.values()) {
       const groupName = jobToGroupName.get(job.name!)!;
       groupedJobs.get(groupName)!.jobs.push(job);
     }
@@ -343,4 +343,9 @@ export function isUnstableGroup(name: string, unstableIssues?: IssueData[]) {
     name.toLocaleLowerCase().includes("unstable") ||
     (openUnstableIssues !== undefined && openUnstableIssues.length !== 0)
   );
+}
+
+export function getNameWithoutLF(name: string) {
+  const lfRegex = /, lf\.(linux|windows)/g;
+  return name.replace(lfRegex, ", $1");
 }

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -117,6 +117,7 @@ export interface HudParams {
   filter_reruns: boolean;
   filter_unstable: boolean;
   use_ch: boolean;
+  mergeLF?: boolean;
 }
 
 export interface PRData {
@@ -230,6 +231,7 @@ export function packHudParams(input: any) {
     filter_reruns: input.filter_reruns ?? (false as boolean),
     filter_unstable: input.filter_unstable ?? (false as boolean),
     use_ch: input.use_ch === "true",
+    mergeLF: input.mergeLF as boolean,
   };
 }
 
@@ -273,5 +275,10 @@ function formatHudURL(
   if (params.use_ch) {
     base += `&use_ch=true`;
   }
+
+  if (params.mergeLF) {
+    base += `&mergeLF=true`;
+  }
+
   return base;
 }

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -298,6 +298,7 @@ function GroupFilterableHudTable({
   const { jobFilter, handleSubmit, handleInput, normalizedJobFilter } =
     useTableFilter(params);
   const headerNames = groupNames;
+  const [mergeLF, setMergeLF] = useContext(MergeLFContext);
   return (
     <>
       <JobFilterInput
@@ -319,6 +320,12 @@ function GroupFilterableHudTable({
         setValue={(value) => setHideUnstable(value)}
         checkBoxName="hideUnstable"
         labelText={"Hide unstable jobs"}
+      />
+      <CheckBoxSelector
+        value={mergeLF}
+        setValue={setMergeLF}
+        checkBoxName="mergeLF"
+        labelText={"Condense LF jobs"}
       />
       <MonsterFailuresCheckbox />
       <table className={styles.hudTable}>
@@ -409,9 +416,15 @@ export const PinnedTooltipContext = createContext<[Highlight, any]>([
   null,
 ]);
 
+export const MergeLFContext = createContext<[boolean, (val: boolean) => void]>([
+  false,
+  (_) => {},
+]);
+
 export default function Hud() {
   const router = useRouter();
-  const params = packHudParams(router.query);
+  const [mergeLF, setMergeLF] = usePreference("mergeLF");
+  const params = packHudParams({ ...router.query, mergeLF: mergeLF });
 
   // Logic to handle tooltip pinning. The behavior we want is:
   // - If the user clicks on a tooltip, it should be pinned.
@@ -447,23 +460,25 @@ export default function Hud() {
       </Head>
       <PinnedTooltipContext.Provider value={[pinnedTooltip, setPinnedTooltip]}>
         <MonsterFailuresProvider>
-          {params.branch !== undefined && (
-            <div onClick={handleClick}>
-              <div style={{ display: "flex", alignItems: "flex-end" }}>
-                <HudHeader params={params} />
-                <CopyPermanentLink
-                  params={params}
-                  style={{ marginLeft: "10px" }}
-                />
+          <MergeLFContext.Provider value={[mergeLF, setMergeLF]}>
+            {params.branch !== undefined && (
+              <div onClick={handleClick}>
+                <div style={{ display: "flex", alignItems: "flex-end" }}>
+                  <HudHeader params={params} />
+                  <CopyPermanentLink
+                    params={params}
+                    style={{ marginLeft: "10px" }}
+                  />
+                </div>
+                <HudTable params={params} />
+                <PageSelector params={params} baseUrl="hud" />
+                <br />
+                <div>
+                  <em>This page automatically updates.</em>
+                </div>
               </div>
-              <HudTable params={params} />
-              <PageSelector params={params} baseUrl="hud" />
-              <br />
-              <div>
-                <em>This page automatically updates.</em>
-              </div>
-            </div>
-          )}
+            )}
+          </MergeLFContext.Provider>
         </MonsterFailuresProvider>
       </PinnedTooltipContext.Provider>
     </>


### PR DESCRIPTION
The logic here in HUD is pretty bad...

Merges LF and non LF columns into one column on the man page of HUD to reduce the size of HUD.  Using it is controlled through checkbox like most other settings

This desperately needs a second pair of eyes

