### PR TITLE
[HUD] Simplify grouping/header logic

### DIFF
--- a/torchci/components/GroupHudTableHeaders.tsx
+++ b/torchci/components/GroupHudTableHeaders.tsx
@@ -1,6 +1,9 @@
 import styles from "components/hud.module.css";
 import { includesCaseInsensitive } from "lib/GeneralUtils";
-import { PinnedTooltipContext } from "pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]]";
+import {
+  GroupingContext,
+  PinnedTooltipContext,
+} from "pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]]";
 import React, { useContext } from "react";
 import { BsFillCaretDownFill, BsFillCaretRightFill } from "react-icons/bs";
 
@@ -13,7 +16,7 @@ function groupingIncludesJobFilter(jobNames: string[], filter: string) {
   return false;
 }
 
-function passesGroupFilter(
+export function passesGroupFilter(
   filter: string | null,
   name: string,
   groupNameMapping: Map<string, string[]>
@@ -25,15 +28,7 @@ function passesGroupFilter(
   );
 }
 
-export function GroupHudTableColumns({
-  names,
-  filter,
-  groupNameMapping,
-}: {
-  names: string[];
-  filter: string | null;
-  groupNameMapping: Map<string, string[]>;
-}) {
+export function GroupHudTableColumns({ names }: { names: string[] }) {
   return (
     <colgroup>
       <col className={styles.colTime} />
@@ -42,30 +37,16 @@ export function GroupHudTableColumns({
       <col className={styles.colPr} />
       <col className={styles.colAuthor} />
       {names.map((name: string) => {
-        const style = passesGroupFilter(filter, name, groupNameMapping)
-          ? {}
-          : { visibility: "collapse" as any };
-
-        return <col className={styles.colJob} key={name} style={style} />;
+        return <col className={styles.colJob} key={name} />;
       })}
     </colgroup>
   );
 }
 
-export function GroupHudTableHeader({
-  names,
-  filter,
-  expandedGroups,
-  setExpandedGroups,
-  groupNameMapping,
-}: {
-  names: string[];
-  filter: string | null;
-  expandedGroups: Set<string>;
-  setExpandedGroups: React.Dispatch<React.SetStateAction<Set<string>>>;
-  groupNameMapping: Map<string, string[]>;
-}) {
+export function GroupHudTableHeader({ names }: { names: string[] }) {
   const [pinnedId, setPinnedId] = useContext(PinnedTooltipContext);
+  const { groupNameMapping, expandedGroups, setExpandedGroups } =
+    useContext(GroupingContext);
 
   const groupNames = new Set(groupNameMapping.keys());
   return (
@@ -79,16 +60,13 @@ export function GroupHudTableHeader({
         {names.map((name) => {
           const isGroup = groupNames.has(name);
           const pinnedStyle = pinnedId.name == name ? styles.highlight : "";
-          const style = passesGroupFilter(filter, name, groupNameMapping)
-            ? {}
-            : { visibility: "collapse" as any };
           const jobStyle = isGroup ? { cursor: "pointer" } : {};
           const headerStyle = isGroup ? { fontWeight: "bold" } : {};
           return (
             <th
               className={styles.jobHeader}
               key={name}
-              style={{ ...style, ...jobStyle }}
+              style={{ ...jobStyle }}
               onClick={(e: React.MouseEvent) => {
                 if (pinnedId.name !== undefined || pinnedId.sha !== undefined) {
                   return;

--- a/torchci/components/GroupJobConclusion.tsx
+++ b/torchci/components/GroupJobConclusion.tsx
@@ -5,7 +5,7 @@ import {
   isRerunDisabledTestsJob,
   isUnstableJob,
 } from "lib/jobUtils";
-import { GroupData, IssueData, JobData } from "lib/types";
+import { IssueData, JobData } from "lib/types";
 import { PinnedTooltipContext } from "pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]]";
 import { useContext } from "react";
 import hudStyles from "./hud.module.css";
@@ -36,21 +36,23 @@ export enum GroupedJobStatus {
 
 export default function HudGroupedCell({
   sha,
-  groupData,
+  groupName,
+  jobs,
   isExpanded,
   toggleExpanded,
   isClassified,
   unstableIssues,
 }: {
   sha: string;
-  groupData: GroupData;
+  groupName: string;
+  jobs: JobData[];
   isExpanded: boolean;
   toggleExpanded: () => void;
   isClassified: boolean;
   unstableIssues: IssueData[];
 }) {
   const [pinnedId, setPinnedId] = useContext(PinnedTooltipContext);
-  const style = pinnedId.name == groupData.groupName ? hudStyles.highlight : "";
+  const style = pinnedId.name == groupName ? hudStyles.highlight : "";
 
   const erroredJobs = [];
   const warningOnlyJobs = [];
@@ -58,7 +60,7 @@ export default function HudGroupedCell({
   const pendingJobs = [];
   const noStatusJobs = [];
   const failedPreviousRunJobs = [];
-  for (const job of groupData.jobs) {
+  for (const job of jobs) {
     if (isFailedJob(job)) {
       if (isRerunDisabledTestsJob(job) || isUnstableJob(job, unstableIssues)) {
         warningOnlyJobs.push(job);
@@ -87,7 +89,7 @@ export default function HudGroupedCell({
     conclusion = GroupedJobStatus.WarningOnly;
   } else if (!(queuedJobs.length === 0)) {
     conclusion = GroupedJobStatus.Queued;
-  } else if (noStatusJobs.length === groupData.jobs.length) {
+  } else if (noStatusJobs.length === jobs.length) {
     conclusion = GroupedJobStatus.AllNull;
   }
 
@@ -96,13 +98,13 @@ export default function HudGroupedCell({
       <td className={style}>
         <TooltipTarget
           sha={sha}
-          name={groupData.groupName}
+          name={groupName}
           pinnedId={pinnedId}
           setPinnedId={setPinnedId}
           tooltipContent={
             <GroupTooltip
               conclusion={conclusion}
-              groupName={groupData.groupName}
+              groupName={groupName}
               erroredJobs={erroredJobs}
               pendingJobs={pendingJobs}
               queuedJobs={queuedJobs}

--- a/torchci/components/JobFilterInput.tsx
+++ b/torchci/components/JobFilterInput.tsx
@@ -1,33 +1,37 @@
+import { useEffect, useState } from "react";
+
 export default function JobFilterInput({
   currentFilter,
   handleSubmit,
-  handleInput,
   width,
   handleFocus,
 }: {
   currentFilter: string | null;
-  handleSubmit: () => void;
-  handleInput: (_value: string) => void;
+  handleSubmit: (f: any) => void;
   handleFocus?: () => void;
   width?: string;
 }) {
+  const [currVal, setCurrVal] = useState<string>(currentFilter ?? "");
+  useEffect(() => {
+    // something about hydration and states is making it so that currVal remains
+    // as "" when currentFilter changes
+    setCurrVal(currentFilter ?? "");
+  }, [currentFilter]);
   return (
     <div>
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          handleSubmit();
+          handleSubmit(currVal);
         }}
       >
         <label htmlFor="name_filter">Job filter: </label>
         <input
           style={{ width: width }}
-          onChange={(e) => {
-            handleInput(e.currentTarget.value);
-          }}
-          type="search"
+          type="text"
           name="name_filter"
-          value={currentFilter || ""}
+          value={currVal}
+          onChange={(e) => setCurrVal(e.target.value)}
           onFocus={handleFocus}
         />
         <input type="submit" value="Go" />

--- a/torchci/lib/GeneralUtils.ts
+++ b/torchci/lib/GeneralUtils.ts
@@ -29,8 +29,9 @@ export function getFailureMessage(
   if (commitData == null || jobData == null) {
     return "";
   }
-  const failedJobs = jobData.filter((job) => isFailure(job.conclusion));
-  const failedJobsString = failedJobs
+  const failedJobsString = jobData
+
+    .filter((job) => isFailure(job.conclusion))
     .map((failedJob) => `- [${failedJob.name}](${failedJob.htmlUrl})`)
     .join("\n");
   const hudLink = `https://hud.pytorch.org/pytorch/pytorch/commit/${commitData.sha}`;

--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -1,6 +1,6 @@
 import { GroupedJobStatus, JobStatus } from "components/GroupJobConclusion";
 import { getOpenUnstableIssues } from "lib/jobUtils";
-import { GroupData, IssueData, RowData } from "./types";
+import { IssueData, RowData } from "./types";
 
 const GROUP_MEMORY_LEAK_CHECK = "Memory Leak Check";
 const GROUP_RERUN_DISABLED_TESTS = "Rerun Disabled Tests";
@@ -324,33 +324,17 @@ export function getConclusionSeverityForSorting(conclusion?: string): number {
 
 export function getGroupingData(
   shaGrid: RowData[],
-  jobNames: string[],
+  jobNames: Set<string>,
   showUnstableGroup: boolean,
   unstableIssues?: IssueData[]
 ) {
   // Construct Job Groupping Mapping
-  const groupNameMapping = new Map<string, Array<string>>(); // group -> [jobs]
-  const jobToGroupName = new Map<string, string>(); // job -> group
+  const groupNameMapping = new Map<string, Array<string>>(); // group -> [job names]
   for (const name of jobNames) {
     const groupName = classifyGroup(name, showUnstableGroup, unstableIssues);
     const jobsInGroup = groupNameMapping.get(groupName) ?? [];
     jobsInGroup.push(name);
     groupNameMapping.set(groupName, jobsInGroup);
-    jobToGroupName.set(name, groupName);
-  }
-  const groupNamesArray = Array.from(groupNameMapping.keys());
-
-  // Group Jobs per Row
-  for (const row of shaGrid) {
-    const groupedJobs = new Map<string, GroupData>();
-    for (const groupName of groupNamesArray) {
-      groupedJobs.set(groupName, { groupName, jobs: [] });
-    }
-    for (const job of row.nameToJobs!.values()) {
-      const groupName = jobToGroupName.get(job.name!)!;
-      groupedJobs.get(groupName)!.jobs.push(job);
-    }
-    row.groupedJobs = groupedJobs;
   }
   return { shaGrid, groupNameMapping };
 }

--- a/torchci/lib/RevertModal.tsx
+++ b/torchci/lib/RevertModal.tsx
@@ -69,7 +69,7 @@ export default function Revert({ row }: { row: RowData }) {
   const msg = getMessage(
     message,
     classification,
-    getFailureMessage(row, row.jobs)
+    getFailureMessage(row, Array.from(row.nameToJobs.values()))
   );
 
   if (session.status == "loading" || session.status == "unauthenticated") {

--- a/torchci/lib/fetchHud.ts
+++ b/torchci/lib/fetchHud.ts
@@ -6,7 +6,12 @@ import { commitDataFromResponse, getOctokit } from "./github";
 import { getNameWithoutLF, isFailure } from "./JobClassifierUtil";
 import { isRerunDisabledTestsJob, isUnstableJob } from "./jobUtils";
 import getRocksetClient from "./rockset";
-import { HudParams, JobData, RowData } from "./types";
+import {
+  HudDataAPIResponse,
+  HudParams,
+  JobData,
+  RowDataAPIResponse,
+} from "./types";
 
 async function fetchDatabaseInfo(
   owner: string,
@@ -54,10 +59,9 @@ async function fetchDatabaseInfo(
   }
 }
 
-export default async function fetchHud(params: HudParams): Promise<{
-  shaGrid: RowData[];
-  jobNames: string[];
-}> {
+export default async function fetchHud(
+  params: HudParams
+): Promise<HudDataAPIResponse> {
   // Retrieve commit data from GitHub
   const octokit = await getOctokit(params.repoOwner, params.repoName);
   const branch = await octokit.rest.repos.listCommits({
@@ -184,7 +188,7 @@ export default async function fetchHud(params: HudParams): Promise<{
   });
   const names = Array.from(namesSet).sort();
 
-  const shaGrid: RowData[] = [];
+  const shaGrid: RowDataAPIResponse[] = [];
 
   _.forEach(commitsBySha, (commit, sha) => {
     const jobs: JobData[] = [];
@@ -204,7 +208,7 @@ export default async function fetchHud(params: HudParams): Promise<{
       }
     }
 
-    const row: RowData = {
+    const row = {
       ...commit,
       jobs: jobs,
       isForcedMerge: forcedMergeShas.has(commit.sha),

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -85,16 +85,21 @@ export interface Highlight {
   name?: string;
 }
 
-export interface RowData extends CommitData {
-  jobs: JobData[];
-  groupedJobs?: Map<string, GroupData>;
+interface RowDataBase extends CommitData {
   isForcedMerge: boolean | false;
   isForcedMergeWithFailures: boolean | false;
-  nameToJobs?: Map<string, JobData>;
 }
 
-export interface HudData {
-  shaGrid: RowData[];
+export interface RowData extends RowDataBase {
+  nameToJobs: Map<string, JobData>;
+}
+
+export interface RowDataAPIResponse extends RowDataBase {
+  jobs: JobData[];
+}
+
+export interface HudDataAPIResponse {
+  shaGrid: RowDataAPIResponse[];
   jobNames: string[];
 }
 

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -94,6 +94,8 @@ export interface RowData extends RowDataBase {
   nameToJobs: Map<string, JobData>;
 }
 
+// Returned by the API instead of the above type because it results in a smaller
+// response size
 export interface RowDataAPIResponse extends RowDataBase {
   jobs: JobData[];
 }

--- a/torchci/lib/useTableFilter.ts
+++ b/torchci/lib/useTableFilter.ts
@@ -31,7 +31,7 @@ export default function useTableFilter(params: HudParams) {
       };
     }
   }, [router, params, pinnedId.sha]);
-  const handleInput = useCallback(
+  const handleSubmit = useCallback(
     (f: any) => {
       setJobFilter(f);
       router.push(
@@ -47,7 +47,6 @@ export default function useTableFilter(params: HudParams) {
     },
     [params, router]
   );
-  const handleSubmit = () => {};
 
   // We have to use an effect hook here because query params are undefined at
   // static generation time; they only become available after hydration.
@@ -56,5 +55,5 @@ export default function useTableFilter(params: HudParams) {
     setJobFilter(filterValue);
   }, [router.query.name_filter]);
 
-  return { jobFilter, handleSubmit, handleInput, normalizedJobFilter };
+  return { jobFilter, handleSubmit, normalizedJobFilter };
 }

--- a/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/minihud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -438,14 +438,15 @@ function CommitSummary({
   const [showDurationInfo] = useContext(ShowDurationContext);
   const [highlighted, setHighlighted] = useState(false);
 
-  const existingJobs = row.jobs.filter((job) => job.conclusion !== undefined);
+  const existingJobs = Array.from(row.nameToJobs.values()).filter(
+    (job) => job.conclusion !== undefined
+  );
   const jobs =
     jobFilter === null
       ? existingJobs
       : existingJobs.filter((job) =>
           includesCaseInsensitive(job.name!, jobFilter)
         );
-
   const failedJobs = jobs.filter(isFailedJob);
   const classifiedJobs = jobs.filter((job) => job.failureAnnotation != null);
   const pendingJobs = jobs.filter(
@@ -476,8 +477,8 @@ function CommitSummary({
     jobs,
     // also filter the previous jobs
     jobFilter === null
-      ? prevRow?.jobs
-      : prevRow?.jobs.filter((job) =>
+      ? Array.from(prevRow?.nameToJobs.values() ?? [])
+      : Array.from(prevRow?.nameToJobs.values() ?? []).filter((job) =>
           includesCaseInsensitive(job.name!, jobFilter)
         )
   );
@@ -556,7 +557,7 @@ function MiniHud({ params }: { params: HudParams }) {
     return <div>Loading...</div>;
   }
 
-  const { shaGrid } = data;
+  const shaGrid = data;
 
   return (
     <>
@@ -580,8 +581,8 @@ function MiniHud({ params }: { params: HudParams }) {
         <CommitSummary
           row={row}
           prevRow={
-            index + 1 >= array.length
-              ? extraRow?.shaGrid[0]
+            index + 1 >= array.length && extraRow
+              ? extraRow[0]
               : array.at(index + 1)
           }
           key={row.sha}
@@ -645,7 +646,6 @@ export default function Page() {
         width="50%"
         currentFilter={jobFilter}
         handleSubmit={handleSubmit}
-        handleInput={setJobFilter}
       />
 
       <JobFilterContext.Provider value={[jobFilter, setJobFilter]}>


### PR DESCRIPTION
Changes filter input to not update as typing, only updates after hitting enter

Changing this code in the past was really annoying, so I'm hoping that this makes it easier

Now the names array is all the jobs that we want to show, instead of everything or the groupNames.  This also simplifies some of the data passed around by HUD, like getting rid of old job array (data is dup with nameToJobs map), removing groupData (which can be reconstructed from nameToJob, groupNameMapping, and names)

This change made it easier to only render columns that actually pass the filter instead of setting the style to {visibility: "collapse"}, which I think reduces the number of DOM elements
 
I also added new context for group related data since we sometimes are just passing it from parent to child 
