### PR TITLE
Use Manylinux Docker image for linux job

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -215,7 +215,6 @@ jobs:
             echo "#!/usr/bin/env bash";
             echo "set -eou pipefail";
             # shellcheck disable=SC2016
-            echo 'export PATH=/opt/conda/bin:$PATH';
             echo 'eval "$(conda shell.bash hook)"';
             echo "set -x";
             echo "${SCRIPT}";

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -60,7 +60,7 @@ on:
         type: string
       docker-image:
         description: Identifies the Docker image by name.
-        default: "pytorch/conda-builder"
+        default: "pytorch/manylinux-builder"
         type: string
       docker-build-dir:
         description: |
@@ -109,7 +109,7 @@ jobs:
     name: ${{ inputs.job-name }}
     env:
       DOCKER_IMAGE: >-
-        ${{ inputs.docker-image == 'pytorch/conda-builder' && format('pytorch/conda-builder:{0}{1}',
+        ${{ inputs.docker-image == 'pytorch/manylinux-builder' && format('pytorch/manylinux-builder:{0}{1}',
                                                                       inputs.gpu-arch-type,
                                                                       inputs.gpu-arch-version)
                                                            || inputs.docker-image }}
@@ -215,6 +215,7 @@ jobs:
             echo "#!/usr/bin/env bash";
             echo "set -eou pipefail";
             # shellcheck disable=SC2016
+            echo 'export PATH=/opt/conda/bin:$PATH';
             echo 'eval "$(conda shell.bash hook)"';
             echo "set -x";
             echo "${SCRIPT}";

--- a/.github/workflows/test_linux_job.yml
+++ b/.github/workflows/test_linux_job.yml
@@ -72,9 +72,9 @@ jobs:
         # Can import pytorch, cuda is available
         python3 -c 'import torch;cuda_avail = torch.cuda.is_available();print("CUDA available: " + str(cuda_avail));assert(cuda_avail)'
         python3 -c 'import torch;t = torch.ones([2,2], device="cuda:0");print(t);print("tensor device:" + str(t.device))'
+        python3 -c 'import torch;assert(torch.version.cuda == "12.1")'
         nvidia-smi
         nvcc --version | grep "cuda_12.1"
-        [[ "${CUDA_HOME}" == "/usr/local/cuda-12.1" ]] || exit 1
   test-docker-image:
     uses: ./.github/workflows/linux_job.yml
     with:


### PR DESCRIPTION
Use ``pytorch/manylinux-builder`` as default image.

I believe the two secrets failures are expected on PR. Here is another example: https://github.com/pytorch/test-infra/actions/runs/11408487659/job/31746765207?pr=5786