### PR TITLE
[drci][ez] Reduce drci check run update size

### DIFF
--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -67,7 +67,7 @@ export default async function handler(
 ) {
   const authorization = req.headers.authorization;
 
-  if (authorization === process.env.DRCI_BOT_KEY) {
+  if (true || authorization === process.env.DRCI_BOT_KEY) {
     const { prNumber } = req.query;
     const { repo }: UpdateCommentBody = req.body;
     const octokit = await getOctokit(OWNER, repo);
@@ -200,7 +200,7 @@ export async function updateDrciComments(
 
       // The comment is there and remains unchanged, so there is no need to do anything
       if (body === comment) {
-        return;
+        // return;
       }
 
       // If the id is 0, it means that the bot has failed to create the comment, so we
@@ -262,9 +262,9 @@ function removeFailureContext(failure: {
 }) {
   const result = { ...failure };
   for (const cat in result) {
-    for (const job of result[cat]) {
-      job.failure_context = [];
-    }
+    result[cat] = result[cat].map((job) => {
+      return { ...job, failure_context: [] };
+    });
   }
   return result;
 }

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -236,7 +236,9 @@ export async function updateDrciComments(
           title: "Dr.CI classification results",
           // NB: the summary contains the classification result from Dr.CI,
           // so that it can be queried elsewhere
-          summary: JSON.stringify(failures[pr_info.pr_number]),
+          summary: JSON.stringify(
+            removeFailureContext(failures[pr_info.pr_number])
+          ),
         },
       });
     },
@@ -246,6 +248,25 @@ export async function updateDrciComments(
   );
 
   return failures;
+}
+
+/**
+ * Changes the failure context of each job to an empty array. This is done to
+ * reduce the size of the payload, which can some times exceed the maximum size
+ * allowed by GitHub
+ * @param failure
+ * @returns
+ */
+function removeFailureContext(failure: {
+  [cat: string]: RecentWorkflowsData[];
+}) {
+  const result = { ...failure };
+  for (const cat in result) {
+    for (const job of result[cat]) {
+      job.failure_context = [];
+    }
+  }
+  return result;
 }
 
 /**

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -67,7 +67,7 @@ export default async function handler(
 ) {
   const authorization = req.headers.authorization;
 
-  if (true || authorization === process.env.DRCI_BOT_KEY) {
+  if (authorization === process.env.DRCI_BOT_KEY) {
     const { prNumber } = req.query;
     const { repo }: UpdateCommentBody = req.body;
     const octokit = await getOctokit(OWNER, repo);
@@ -200,7 +200,7 @@ export async function updateDrciComments(
 
       // The comment is there and remains unchanged, so there is no need to do anything
       if (body === comment) {
-        // return;
+        return;
       }
 
       // If the id is 0, it means that the bot has failed to create the comment, so we


### PR DESCRIPTION
Remove the failure context when updating check run in Dr. CI because it is really big

before
```
{"FAILED":[{"workflowId":11689744970,"workflowUniqueId":16521569,"id":32555466376,"runnerName":"i-0392431e49f4740e6","authorEmail":"[csl@fb.com](mailto:csl@fb.com)","name":"pull / linux-focal-cuda12.1-py3.10-gcc9-sm86 / test (default, 3, 5, lf.linux.g5.4xlarge.nvidia.gpu)","jobName":"linux-focal-cuda12.1-py3.10-gcc9-sm86 / test (default, 3, 5, lf.linux.g5.4xlarge.nvidia.gpu)","conclusion":"failure","completed_at":"2024-11-05T21:02:34.000000000Z","html_url":"https://github.com/pytorch/pytorch/actions/runs/11689744970/job/32555466376","head_branch":"csl/always_produce_xml","pr_number":138513,"head_sha":"7fe36acfe3dbdde66a273d5b8b66134ddc18b44f","head_sha_timestamp":"2024-11-05T17:49:16.000000000Z","failure_captures":["'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocation::test_view_outputs_cpu_with_stack_allocation', 'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_misc_1_max_autotune_False_cpu_with_stack_allocation_and_minimal_arrayref_interface'"],"failure_lines":["The following tests failed consistently: ['test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocation::test_view_outputs_cpu_with_stack_allocation', 'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_misc_1_max_autotune_False_cpu_with_stack_allocation_and_minimal_arrayref_interface']"],"failure_context":["+ python test/run_test.py --exclude-jit-executor --exclude-distributed-tests --shard 3 5 --verbose","+ [[ -z 5 ]]","+ test_python_shard 3","+ '[' -n '' ']'","+ pip install --progress-bar off --no-use-pep517 --user git+https://github.com/pytorch/vision.git@d23a6e1664d20707c11781299611436e1f0c104f","+ pip_install --no-use-pep517 --user git+https://github.com/pytorch/vision.git@d23a6e1664d20707c11781299611436e1f0c104f","+ '[' -n '' ']'","+ orig_preload=","+ commit=d23a6e1664d20707c11781299611436e1f0c104f","++ cat .github/ci_commit_pins/vision.txt","++ get_pinned_commit vision","+ local commit"],"time":"2024-11-05T18:37:23.000000000Z"},{"workflowId":11689744970,"workflowUniqueId":16521569,"id":32555466721,"runnerName":"i-050db2b886bfb46c6","authorEmail":"[csl@fb.com](mailto:csl@fb.com)","name":"pull / linux-focal-cuda12.1-py3.10-gcc9-sm86 / test (default, 4, 5, lf.linux.g5.4xlarge.nvidia.gpu)","jobName":"linux-focal-cuda12.1-py3.10-gcc9-sm86 / test (default, 4, 5, lf.linux.g5.4xlarge.nvidia.gpu)","conclusion":"failure","completed_at":"2024-11-05T21:11:27.000000000Z","html_url":"https://github.com/pytorch/pytorch/actions/runs/11689744970/job/32555466721","head_branch":"csl/always_produce_xml","pr_number":138513,"head_sha":"7fe36acfe3dbdde66a273d5b8b66134ddc18b44f","head_sha_timestamp":"2024-11-05T17:49:16.000000000Z","failure_captures":["'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_misc_1_max_autotune_True_cpu_with_stack_allocation_and_minimal_arrayref_interface', 'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_return_view_constant_cpu_with_stack_allocation_and_minimal_arrayref_interface', 'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_sdpa_2_cpu_with_stack_allocation_and_minimal_arrayref_interface', 'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_sdpa_cpu_with_stack_allocation_and_minimal_arrayref_interface'"],"failure_lines":["The following tests failed consistently: ['test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_misc_1_max_autotune_True_cpu_with_stack_allocation_and_minimal_arrayref_interface', 'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_return_view_constant_cpu_with_stack_allocation_and_minimal_arrayref_interface', 'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_sdpa_2_cpu_with_stack_allocation_and_minimal_arrayref_interface', 'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_sdpa_cpu_with_stack_allocation_and_minimal_arrayref_interface']"],"failure_context":["+ python test/run_test.py --exclude-jit-executor --exclude-distributed-tests --shard 4 5 --verbose","+ [[ -z 5 ]]","+ test_python_shard 4","+ '[' -n '' ']'","+ pip install --progress-bar off --no-use-pep517 --user git+https://github.com/pytorch/vision.git@d23a6e1664d20707c11781299611436e1f0c104f","+ pip_install --no-use-pep517 --user git+https://github.com/pytorch/vision.git@d23a6e1664d20707c11781299611436e1f0c104f","+ '[' -n '' ']'","+ orig_preload=","+ commit=d23a6e1664d20707c11781299611436e1f0c104f","++ cat .github/ci_commit_pins/vision.txt","++ get_pinned_commit vision","+ local commit"],"time":"2024-11-05T18:37:24.000000000Z"},{"workflowId":11689744970,"workflowUniqueId":16521569,"id":32554408818,"runnerName":"i-048dbed49b5c08b4e","authorEmail":"[csl@fb.com](mailto:csl@fb.com)","name":"pull / linux-jammy-py3.10-clang15-asan / test (default, 2, 6, lf.linux.4xlarge)","jobName":"linux-jammy-py3.10-clang15-asan / test (default, 2, 6, lf.linux.4xlarge)","conclusion":"failure","completed_at":"2024-11-05T21:53:02.000000000Z","html_url":"https://github.com/pytorch/pytorch/actions/runs/11689744970/job/32554408818","head_branch":"csl/always_produce_xml","pr_number":138513,"head_sha":"7fe36acfe3dbdde66a273d5b8b66134ddc18b44f","head_sha_timestamp":"2024-11-05T17:49:16.000000000Z","failure_captures":["'Test' "],"failure_lines":["##[error]The action 'Test' has timed out after 210 minutes."],"failure_context":["+ sudo chown -R 1000 /var/lib/jenkins/workspace","+ echo 'For more details refer to https://github.com/https://github.com/sudo-project/sudo/issues/42'","+ echo ' sudo: setrlimit(RLIMIT_STACK): Operation not permitted'","+ echo 'sudo may print the following warning message that can be ignored. The chown command will still run.'","+ cleanup_workspace","+ [[ -n '' ]]","+ git_status=","++ true","++ grep -v '?? third_party'","++ git status --porcelain","+ [[ linux-jammy-py3.10-clang15-asan != xla ]]","+ [[ linux-jammy-py3.10-clang15-asan != rocm ]]"],"time":"2024-11-05T18:14:59.000000000Z"},{"workflowId":11689744970,"workflowUniqueId":16521569,"id":32554280491,"runnerName":"i-062ca18ae0c19ca4a","authorEmail":"[csl@fb.com](mailto:csl@fb.com)","name":"pull / linux-jammy-py3-clang12-executorch / test (executorch, 1, 1, lf.linux.2xlarge)","jobName":"linux-jammy-py3-clang12-executorch / test (executorch, 1, 1, lf.linux.2xlarge)","conclusion":"failure","completed_at":"2024-11-05T18:29:31.000000000Z","html_url":"https://github.com/pytorch/pytorch/actions/runs/11689744970/job/32554280491","head_branch":"csl/always_produce_xml","pr_number":138513,"head_sha":"7fe36acfe3dbdde66a273d5b8b66134ddc18b44f","head_sha_timestamp":"2024-11-05T17:49:16.000000000Z","failure_captures":["ModuleNotFoundError: No module named 'boto3'"],"failure_lines":["ModuleNotFoundError: No module named 'boto3'"],"failure_context":["+ python3 /home/ec2-user/actions-runner/_work/pytorch/pytorch/./.github/actions/filter-test-configs/../../scripts/parse_ref.py","+ python3 -m pip install requests==2.27.1 pyyaml==6.0.1","+ python3 .github/scripts/get_workflow_job_id.py 11689744970 i-062ca18ae0c19ca4a","+ docker pull 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-jammy-py3-clang12-executorch:4f63d69654059ea7612556eac86368e69e3b0dfa","+ retry docker pull 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-jammy-py3-clang12-executorch:4f63d69654059ea7612556eac86368e69e3b0dfa","+ docker inspect --type=image 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-jammy-py3-clang12-executorch:4f63d69654059ea7612556eac86368e69e3b0dfa","+ set -e","+ docker login -u AWS --password-stdin 308535385114.dkr.ecr.us-east-1.amazonaws.com","+ aws ecr get-login-password --region us-east-1","+ login 308535385114.dkr.ecr.us-east-1.amazonaws.com","+ retry login 308535385114.dkr.ecr.us-east-1.amazonaws.com","+ set +e"],"time":"2024-11-05T18:12:13.000000000Z"}],"FLAKY":[],"BROKEN_TRUNK":[],"UNSTABLE":[]}
```
after
```
{"FAILED":[{"workflowId":11689744970,"workflowUniqueId":16521569,"id":32555466376,"runnerName":"i-0392431e49f4740e6","authorEmail":"[csl@fb.com](mailto:csl@fb.com)","name":"pull / linux-focal-cuda12.1-py3.10-gcc9-sm86 / test (default, 3, 5, lf.linux.g5.4xlarge.nvidia.gpu)","jobName":"linux-focal-cuda12.1-py3.10-gcc9-sm86 / test (default, 3, 5, lf.linux.g5.4xlarge.nvidia.gpu)","conclusion":"failure","completed_at":"2024-11-05T21:02:34.000000000Z","html_url":"https://github.com/pytorch/pytorch/actions/runs/11689744970/job/32555466376","head_branch":"csl/always_produce_xml","pr_number":138513,"head_sha":"7fe36acfe3dbdde66a273d5b8b66134ddc18b44f","head_sha_timestamp":"2024-11-05T17:49:16.000000000Z","failure_captures":["'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocation::test_view_outputs_cpu_with_stack_allocation', 'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_misc_1_max_autotune_False_cpu_with_stack_allocation_and_minimal_arrayref_interface'"],"failure_lines":["The following tests failed consistently: ['test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocation::test_view_outputs_cpu_with_stack_allocation', 'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_misc_1_max_autotune_False_cpu_with_stack_allocation_and_minimal_arrayref_interface']"],"failure_context":[],"time":"2024-11-05T18:37:23.000000000Z"},{"workflowId":11689744970,"workflowUniqueId":16521569,"id":32555466721,"runnerName":"i-050db2b886bfb46c6","authorEmail":"[csl@fb.com](mailto:csl@fb.com)","name":"pull / linux-focal-cuda12.1-py3.10-gcc9-sm86 / test (default, 4, 5, lf.linux.g5.4xlarge.nvidia.gpu)","jobName":"linux-focal-cuda12.1-py3.10-gcc9-sm86 / test (default, 4, 5, lf.linux.g5.4xlarge.nvidia.gpu)","conclusion":"failure","completed_at":"2024-11-05T21:11:27.000000000Z","html_url":"https://github.com/pytorch/pytorch/actions/runs/11689744970/job/32555466721","head_branch":"csl/always_produce_xml","pr_number":138513,"head_sha":"7fe36acfe3dbdde66a273d5b8b66134ddc18b44f","head_sha_timestamp":"2024-11-05T17:49:16.000000000Z","failure_captures":["'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_misc_1_max_autotune_True_cpu_with_stack_allocation_and_minimal_arrayref_interface', 'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_return_view_constant_cpu_with_stack_allocation_and_minimal_arrayref_interface', 'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_sdpa_2_cpu_with_stack_allocation_and_minimal_arrayref_interface', 'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_sdpa_cpu_with_stack_allocation_and_minimal_arrayref_interface'"],"failure_lines":["The following tests failed consistently: ['test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_misc_1_max_autotune_True_cpu_with_stack_allocation_and_minimal_arrayref_interface', 'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_return_view_constant_cpu_with_stack_allocation_and_minimal_arrayref_interface', 'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_sdpa_2_cpu_with_stack_allocation_and_minimal_arrayref_interface', 'test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface::test_sdpa_cpu_with_stack_allocation_and_minimal_arrayref_interface']"],"failure_context":[],"time":"2024-11-05T18:37:24.000000000Z"},{"workflowId":11689744970,"workflowUniqueId":16521569,"id":32554408818,"runnerName":"i-048dbed49b5c08b4e","authorEmail":"[csl@fb.com](mailto:csl@fb.com)","name":"pull / linux-jammy-py3.10-clang15-asan / test (default, 2, 6, lf.linux.4xlarge)","jobName":"linux-jammy-py3.10-clang15-asan / test (default, 2, 6, lf.linux.4xlarge)","conclusion":"failure","completed_at":"2024-11-05T21:53:02.000000000Z","html_url":"https://github.com/pytorch/pytorch/actions/runs/11689744970/job/32554408818","head_branch":"csl/always_produce_xml","pr_number":138513,"head_sha":"7fe36acfe3dbdde66a273d5b8b66134ddc18b44f","head_sha_timestamp":"2024-11-05T17:49:16.000000000Z","failure_captures":["'Test' "],"failure_lines":["##[error]The action 'Test' has timed out after 210 minutes."],"failure_context":[],"time":"2024-11-05T18:14:59.000000000Z"},{"workflowId":11689744970,"workflowUniqueId":16521569,"id":32554280491,"runnerName":"i-062ca18ae0c19ca4a","authorEmail":"[csl@fb.com](mailto:csl@fb.com)","name":"pull / linux-jammy-py3-clang12-executorch / test (executorch, 1, 1, lf.linux.2xlarge)","jobName":"linux-jammy-py3-clang12-executorch / test (executorch, 1, 1, lf.linux.2xlarge)","conclusion":"failure","completed_at":"2024-11-05T18:29:31.000000000Z","html_url":"https://github.com/pytorch/pytorch/actions/runs/11689744970/job/32554280491","head_branch":"csl/always_produce_xml","pr_number":138513,"head_sha":"7fe36acfe3dbdde66a273d5b8b66134ddc18b44f","head_sha_timestamp":"2024-11-05T17:49:16.000000000Z","failure_captures":["ModuleNotFoundError: No module named 'boto3'"],"failure_lines":["ModuleNotFoundError: No module named 'boto3'"],"failure_context":[],"time":"2024-11-05T18:12:13.000000000Z"}],"FLAKY":[],"BROKEN_TRUNK":[],"UNSTABLE":[]}
```