### PR TITLE
Add m7i-flex.8xlarge instance type

### DIFF
--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -24,12 +24,21 @@
 #   runner_label:
 #     instance_type: m4.large
 #     os: linux
+#     # min_available defaults to the global cfg in the ALI Terraform
+#     min_available: undefined
 #     # when max_available value is not defined, no max runners is enforced
 #     max_available: undefined
 #     disk_size: 50
 #     is_ephemeral: true
 
 runner_types:
+  lf.c.linux.8xlarge.amx:
+    disk_size: 200
+    instance_type: m7i-flex.8xlarge
+    min_available: 0
+    is_ephemeral: false
+    os: linux
+    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64
   lf.c.linux.12xlarge:
     disk_size: 200
     instance_type: c5.12xlarge

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -24,12 +24,21 @@
 #   runner_label:
 #     instance_type: m4.large
 #     os: linux
+#     # min_available defaults to the global cfg in the ALI Terraform
+#     min_available: undefined
 #     # when max_available value is not defined, no max runners is enforced
 #     max_available: undefined
 #     disk_size: 50
 #     is_ephemeral: true
 
 runner_types:
+  lf.linux.8xlarge.amx:
+    disk_size: 200
+    instance_type: m7i-flex.8xlarge
+    min_available: 0
+    is_ephemeral: false
+    os: linux
+    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64
   lf.linux.12xlarge:
     disk_size: 200
     instance_type: c5.12xlarge

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -20,12 +20,21 @@
 #   runner_label:
 #     instance_type: m4.large
 #     os: linux
+#     # min_available defaults to the global cfg in the ALI Terraform
+#     min_available: undefined
 #     # when max_available value is not defined, no max runners is enforced
 #     max_available: undefined
 #     disk_size: 50
 #     is_ephemeral: true
 
 runner_types:
+  linux.8xlarge.amx:
+    disk_size: 200
+    instance_type: m7i-flex.8xlarge
+    min_available: 0
+    is_ephemeral: false
+    os: linux
+    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64
   linux.12xlarge:
     disk_size: 200
     instance_type: c5.12xlarge

--- a/.github/scripts/validate_scale_config.py
+++ b/.github/scripts/validate_scale_config.py
@@ -42,6 +42,7 @@ _RUNNER_BASE_JSCHEMA = {
         "instance_type": {"type": "string"},
         "is_ephemeral": {"type": "boolean"},
         "labels": {"type": "array", "items": {"type": "string"}},
+        "min_available": {"type": "number"},
         "max_available": {"type": "number"},
         "os": {"type": "string", "enum": ["linux", "windows"]},
     },


### PR DESCRIPTION
Add the m7i-flex.8xlarge instance type for Intel test suite to move off of from the c5.12xlarge instance type in use today.

Related: pytorch/pytorch#138476