### PR TITLE
[BE] Update action versions

### DIFF
--- a/.github/actions/bc-lint/action.yml
+++ b/.github/actions/bc-lint/action.yml
@@ -23,7 +23,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout pytorch/test-infra repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: pytorch/test-infra
         path: _test-infra

--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -51,7 +51,7 @@ runs:
         run: |
           set -euxo pipefail
           rm -rf "${REPOSITORY}"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}

--- a/.github/actions/setup-binary-upload/action.yml
+++ b/.github/actions/setup-binary-upload/action.yml
@@ -33,7 +33,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
         cache: pip
@@ -54,7 +54,7 @@ runs:
         echo "ARTIFACT_NAME=${REPOSITORY/\//_}_${REF}_${PYTHON_VERSION}_${CU_VERSION}_${ARCH}" >> "${GITHUB_ENV}"
 
     # Need to checkout the target repository to run pkg-helpers
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}

--- a/.github/actions/setup-build-test/action.yml
+++ b/.github/actions/setup-build-test/action.yml
@@ -33,7 +33,7 @@ runs:
           REPOSITORY: ${{ inputs.repository || github.repository }}
         run: |
           rm -rf "${REPOSITORY}"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.ref }}

--- a/.github/actions/trigger-nightly/action.yml
+++ b/.github/actions/trigger-nightly/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
         repository: ${{ inputs.repository }}

--- a/.github/actions/update-commit-hash/action.yml
+++ b/.github/actions/update-commit-hash/action.yml
@@ -42,14 +42,14 @@ runs:
   using: composite
   steps:
     - name: Checkout the source repo with the pinned commit file
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: 'main'
         submodules: true
         token: ${{ inputs.updatebot-token }}
 
     - name: Checkout test-infra for the update_commit_hashes scripts
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{ inputs.test-infra-repository }}
         ref: ${{ inputs.test-infra-ref }}
@@ -60,7 +60,7 @@ runs:
       run: |
         git clone https://github.com/${{ inputs.repo-owner }}/${{ inputs.repo-name }}.git --quiet
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
         cache: pip

--- a/.github/actions/update-viablestrict/action.yml
+++ b/.github/actions/update-viablestrict/action.yml
@@ -59,11 +59,11 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: ${{ inputs.repository }}
         token: ${{ inputs.secret-bot-token }}

--- a/.github/workflows/_binary_conda_upload.yml
+++ b/.github/workflows/_binary_conda_upload.yml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 30
     name: ${{ matrix.build_name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: ${{ inputs.test-infra-repository }}
           ref: ${{ inputs.test-infra-ref }}

--- a/.github/workflows/_binary_upload.yml
+++ b/.github/workflows/_binary_upload.yml
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: 30
     name: ${{ matrix.build_name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: ${{ inputs.test-infra-repository }}
           ref: ${{ inputs.test-infra-ref }}

--- a/.github/workflows/_prune-anaconda-packages.yml
+++ b/.github/workflows/_prune-anaconda-packages.yml
@@ -23,7 +23,7 @@ jobs:
       image: continuumio/miniconda3:4.12.0
     steps:
       - name: Checkout repository test-infra
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: pytorch/test-infra
           ref: ${{ github.ref }}

--- a/.github/workflows/_upload_docs.yml
+++ b/.github/workflows/_upload_docs.yml
@@ -26,7 +26,7 @@ jobs:
     if: github.repository == ${{ inputs.repository }} && github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.docs-branch }}
           persist-credentials: true

--- a/.github/workflows/backfill-workflow-job.yml
+++ b/.github/workflows/backfill-workflow-job.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_backfill-workflow-job
           aws-region: us-east-1
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: yarn install --frozen-lockfile
       - run: yarn node scripts/backfillJobs.mjs
         env:

--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -92,7 +92,7 @@ jobs:
     # to have a conversation
     timeout-minutes: ${{ inputs.timeout }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ inputs.test-infra-repository }}

--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -100,7 +100,7 @@ jobs:
           rm -rfv "${GITHUB_WORKSPACE}"
           mkdir -p "${GITHUB_WORKSPACE}"
           echo "::endgroup::"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ inputs.test-infra-repository }}

--- a/.github/workflows/build_conda_windows.yml
+++ b/.github/workflows/build_conda_windows.yml
@@ -92,7 +92,7 @@ jobs:
     # to have a conversation
     timeout-minutes: ${{ inputs.timeout }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ inputs.test-infra-repository }}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -143,7 +143,7 @@ jobs:
           fi
 
           echo "::endgroup::"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ inputs.test-infra-repository }}

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -117,7 +117,7 @@ jobs:
           rm -rfv "${GITHUB_WORKSPACE}"
           mkdir -p "${GITHUB_WORKSPACE}"
           echo "::endgroup::"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ inputs.test-infra-repository }}

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -94,7 +94,7 @@ jobs:
     # to have a conversation
     timeout-minutes: ${{ inputs.timeout }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ inputs.test-infra-repository }}

--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -41,7 +41,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Dependencies
         run: pip3 install requests setuptools==61.2.0
       - name: Check for alerts and creates issue
@@ -61,7 +61,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Dependencies
         run: pip3 install requests setuptools==61.2.0 rockset==1.0.3
       - name: Check for alerts and creates issue

--- a/.github/workflows/clang-tidy-linux.yml
+++ b/.github/workflows/clang-tidy-linux.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: linux.12xlarge
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build docker image
         run: |
           set -ex

--- a/.github/workflows/clang-tidy-macos.yml
+++ b/.github/workflows/clang-tidy-macos.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: macos-12-xl
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           brew install ninja
@@ -64,7 +64,7 @@ jobs:
     runs-on: macos-m1-stable
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           brew install ninja cmake

--- a/.github/workflows/clickhouse-replicator-dynamo-lambda.yml
+++ b/.github/workflows/clickhouse-replicator-dynamo-lambda.yml
@@ -19,8 +19,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: pip

--- a/.github/workflows/clickhouse-replicator-s3-lambda.yml
+++ b/.github/workflows/clickhouse-replicator-s3-lambda.yml
@@ -19,8 +19,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: pip

--- a/.github/workflows/generate_binary_build_matrix.yml
+++ b/.github/workflows/generate_binary_build_matrix.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Checkout test-infra repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ inputs.test-infra-repository }}
           ref: ${{ inputs.test-infra-ref }}

--- a/.github/workflows/generate_binary_build_matrix.yml
+++ b/.github/workflows/generate_binary_build_matrix.yml
@@ -66,7 +66,7 @@ jobs:
       matrix: ${{ steps.generate.outputs.matrix }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Checkout test-infra repository

--- a/.github/workflows/generate_docker_release_matrix.yml
+++ b/.github/workflows/generate_docker_release_matrix.yml
@@ -30,11 +30,11 @@ jobs:
       matrix: ${{ steps.generate.outputs.matrix }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Checkout test-infra repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ inputs.test-infra-repository }}
           ref: ${{ inputs.test-infra-ref }}

--- a/.github/workflows/generate_release_matrix.yml
+++ b/.github/workflows/generate_release_matrix.yml
@@ -26,11 +26,11 @@ jobs:
       matrix: ${{ steps.generate.outputs.matrix }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Checkout test-infra repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ inputs.test-infra-repository }}
           ref: ${{ inputs.test-infra-ref }}

--- a/.github/workflows/gha-artifacts-lambda.yml
+++ b/.github/workflows/gha-artifacts-lambda.yml
@@ -24,8 +24,8 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: pip
@@ -36,8 +36,8 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: pip

--- a/.github/workflows/github-status-test-lambda.yml
+++ b/.github/workflows/github-status-test-lambda.yml
@@ -31,10 +31,10 @@ jobs:
           aws-region: us-east-1
 
       - name: Check out test infra
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
 
       - uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
         name: Setup dependencies

--- a/.github/workflows/lambda-do-release-runners.yml
+++ b/.github/workflows/lambda-do-release-runners.yml
@@ -19,7 +19,7 @@ jobs:
       REF: ${{ inputs.tag }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag }}
 

--- a/.github/workflows/lambda-release-tag-runners.yml
+++ b/.github/workflows/lambda-release-tag-runners.yml
@@ -17,7 +17,7 @@ jobs:
       date: ${{ steps.date.outputs.date }}
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get current date
         id: date

--- a/.github/workflows/lambda-runner-binaries-syncer.yml
+++ b/.github/workflows/lambda-runner-binaries-syncer.yml
@@ -18,6 +18,6 @@ jobs:
         working-directory: terraform-aws-github-runner/modules/runner-binaries-syncer/lambdas/runner-binaries-syncer
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build, Lint, and Test
         run: make build

--- a/.github/workflows/lambda-runners.yml
+++ b/.github/workflows/lambda-runners.yml
@@ -18,6 +18,6 @@ jobs:
         working-directory: terraform-aws-github-runner/modules/runners/lambdas/runners
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build, Lint, and Test
         run: make build

--- a/.github/workflows/lambda-webhook.yml
+++ b/.github/workflows/lambda-webhook.yml
@@ -18,6 +18,6 @@ jobs:
         working-directory: terraform-aws-github-runner/modules/webhook/lambdas/webhook
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build, Lint, and Test
         run: make build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Upload SARIF file
         if: always() && matrix.os == 'ubuntu-latest'
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: lintrunner.sarif

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,9 +23,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
 

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -143,7 +143,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository (${{ inputs.test-infra-repository }}@${{ inputs.test-infra-ref }})
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ inputs.test-infra-repository }}
@@ -167,7 +167,7 @@ jobs:
                docker exec -it $(docker container ps --format '{{.ID}}') bash
 
       - name: Checkout repository (${{ inputs.repository || github.repository }}@${{ inputs.ref }})
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ inputs.repository || github.repository }}

--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -143,7 +143,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository (${{ inputs.test-infra-repository }}@${{ inputs.test-infra-ref }})
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ inputs.test-infra-repository }}
@@ -167,7 +167,7 @@ jobs:
                docker exec -it $(docker container ps --format '{{.ID}}') bash
 
       - name: Checkout repository (${{ inputs.repository || github.repository }}@${{ inputs.ref }})
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ inputs.repository || github.repository }}

--- a/.github/workflows/log-classifier-lambda.yml
+++ b/.github/workflows/log-classifier-lambda.yml
@@ -19,7 +19,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: cargo test
 
   deploy:
@@ -30,8 +30,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v1.7.0
         with:

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -98,7 +98,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository (${{ inputs.test-infra-repository }}@${{ inputs.test-infra-ref }})
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ inputs.test-infra-repository }}
@@ -111,7 +111,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
 
       - name: Checkout repository (${{ inputs.repository || github.repository }}@${{ inputs.ref }})
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ inputs.repository || github.repository }}

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -125,7 +125,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Checkout repository (${{ inputs.test-infra-repository }}@${{ inputs.test-infra-ref }})
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ inputs.test-infra-repository }}
           ref: ${{ inputs.test-infra-ref }}

--- a/.github/workflows/opensearch-gha-jobs-lambda.yml
+++ b/.github/workflows/opensearch-gha-jobs-lambda.yml
@@ -19,8 +19,8 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: pip
@@ -35,8 +35,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: pip

--- a/.github/workflows/push-rockset-query-lambda-tags.yml
+++ b/.github/workflows/push-rockset-query-lambda-tags.yml
@@ -15,7 +15,7 @@ jobs:
   push-rockset-tags:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: yarn install --frozen-lockfile
       - run: yarn node scripts/pushRocksetTags.mjs
         env:

--- a/.github/workflows/revert-tracker.yml
+++ b/.github/workflows/revert-tracker.yml
@@ -13,11 +13,11 @@ jobs:
       contents: write
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: test-infra
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: pytorch/pytorch
           path: pytorch

--- a/.github/workflows/rockset_autoscale.yml
+++ b/.github/workflows/rockset_autoscale.yml
@@ -17,10 +17,10 @@ jobs:
     if: ${{ github.repository == 'pytorch/test-infra' }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
           architecture: x64

--- a/.github/workflows/rockset_delete_old_lambda_versions.yml
+++ b/.github/workflows/rockset_delete_old_lambda_versions.yml
@@ -14,7 +14,7 @@ jobs:
   delete-old-query-lambda-versions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: yarn install --frozen-lockfile
       - run: yarn node scripts/deleteOldQueryLambdaVersions.mjs
         env:

--- a/.github/workflows/scale_config_validation.yml
+++ b/.github/workflows/scale_config_validation.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
 

--- a/.github/workflows/servicelab-ingestor-lambda.yml
+++ b/.github/workflows/servicelab-ingestor-lambda.yml
@@ -19,8 +19,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: pip

--- a/.github/workflows/sync_pytorch_canary.yml
+++ b/.github/workflows/sync_pytorch_canary.yml
@@ -25,7 +25,7 @@ jobs:
           echo "$PYTORCH_CANARY_SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
       - name: Clone pytorch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'pytorch/pytorch'
           ref: ${{ matrix.ref }}

--- a/.github/workflows/test-binary-size-validation.yml
+++ b/.github/workflows/test-binary-size-validation.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install requirements
         run: |
           pip3 install -r tools/binary_size_validation/requirements.txt

--- a/.github/workflows/test-setup-miniconda.yml
+++ b/.github/workflows/test-setup-miniconda.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get disk space usage and throw an error for low disk space
         uses: ./.github/actions/check-disk-space

--- a/.github/workflows/test-setup-nvidia.yml
+++ b/.github/workflows/test-setup-nvidia.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.runner-type }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Test that setup-nvidia works
         uses: ./.github/actions/setup-nvidia

--- a/.github/workflows/test-setup-ssh.yml
+++ b/.github/workflows/test-setup-ssh.yml
@@ -12,7 +12,7 @@ jobs:
   build: # make sure build/ci work properly
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: |
           cd setup-ssh
           yarn install
@@ -22,7 +22,7 @@ jobs:
   test-linux: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-ssh
         name: Check if can write keys
         with:
@@ -50,7 +50,7 @@ jobs:
   test-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-ssh
         name: Check if can write keys
         with:

--- a/.github/workflows/test_upload_benchmark_results.yml
+++ b/.github/workflows/test_upload_benchmark_results.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: linux.2xlarge
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Test upload the benchmark results (v2)
         uses: ./.github/actions/upload-benchmark-results

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -15,7 +15,7 @@ jobs:
     container: node:20
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Checkout source code
 
     - uses: terraform-linters/setup-tflint@v4

--- a/.github/workflows/torchci.yml
+++ b/.github/workflows/torchci.yml
@@ -16,7 +16,7 @@ jobs:
       run:
         working-directory: torchci
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: yarn install --frozen-lockfile
       - run: yarn lint
       - name: yarn prettier --check .
@@ -34,7 +34,7 @@ jobs:
       run:
         working-directory: tools/torchci
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: |
           pip3 install --upgrade pip
           pip3 install -r requirements.txt

--- a/.github/workflows/trigger_nightly.yml
+++ b/.github/workflows/trigger_nightly.yml
@@ -29,7 +29,7 @@ jobs:
     environment: trigger-nightly
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Trigger nightly audio build
         if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'audio' || inputs.domain == 'all' }}
         uses: ./.github/actions/trigger-nightly

--- a/.github/workflows/trigger_nightly_core.yml
+++ b/.github/workflows/trigger_nightly_core.yml
@@ -12,7 +12,7 @@ jobs:
     environment: trigger-nightly
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Trigger nightly core build
         uses: ./.github/actions/trigger-nightly
         with:

--- a/.github/workflows/update-drci-comments.yml
+++ b/.github/workflows/update-drci-comments.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Retrieve rockset query results and update Dr. CI comments for the PyTorch repo
         run: |

--- a/.github/workflows/update-queue-times.yml
+++ b/.github/workflows/update-queue-times.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: yarn install --frozen-lockfile
       - name: configure aws credentials
         id: aws_creds

--- a/.github/workflows/update-s3-html.yml
+++ b/.github/workflows/update-s3-html.yml
@@ -28,7 +28,7 @@ jobs:
           role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_s3_update
           aws-region: us-east-1
       - name: Checkout repository test-infra
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: pytorch/test-infra
           ref: ${{ github.ref }}

--- a/.github/workflows/update-test-times.yml
+++ b/.github/workflows/update-test-times.yml
@@ -21,7 +21,7 @@ jobs:
   update-test-time-stats:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up python 3.10
         uses: actions/setup-python@v5

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -20,7 +20,7 @@ jobs:
     environment: trigger-nightly
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Generate new disabled tests and jobs jsons
         env:

--- a/.github/workflows/update_test_file_ratings.yml
+++ b/.github/workflows/update_test_file_ratings.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout pytorch/test-infra
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: test-infra
 
       - name: Checkout pytorch/pytorch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: pytorch/pytorch
           path: pytorch

--- a/.github/workflows/upload-tutorials-stats.yml
+++ b/.github/workflows/upload-tutorials-stats.yml
@@ -26,14 +26,14 @@ jobs:
           aws-region: us-east-1
 
       - name: Checkout the tutorials repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'pytorch/tutorials'
           path: './tutorials'
           fetch-depth: 0
 
       - name: Checkout the test-infra repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: test-infra
 

--- a/.github/workflows/usage-log-aggregator-lambda.yml
+++ b/.github/workflows/usage-log-aggregator-lambda.yml
@@ -20,8 +20,8 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: pip
@@ -36,8 +36,8 @@ jobs:
       contents: read
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: pip

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -98,7 +98,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository (${{ inputs.test-infra-repository }}@${{ inputs.test-infra-ref }})
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ inputs.test-infra-repository }}
@@ -114,7 +114,7 @@ jobs:
           github-secret: ${{ github.token }}
 
       - name: Checkout repository (${{ inputs.repository || github.repository }}@${{ inputs.ref }})
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ inputs.repository || github.repository }}


### PR DESCRIPTION
I.e. :
- `actions/checkout@v3` -> `actions/checkout@v4`
- `actions/setup-python@v4` -> `actions/setup-python@v5`
- `github/codeql-action/upload-sarif@v2` -> `github/codeql-action/upload-sarif@v3`
To get rid of node-16 deprecated warning, for example see
```
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/setup-python@v4, actions/checkout@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```
