### PR TITLE
[CH] Move external contrib queries on KPIs page to ClickHouse

### DIFF
--- a/torchci/clickhouse_queries/external_contribution_stats/query.sql
+++ b/torchci/clickhouse_queries/external_contribution_stats/query.sql
@@ -1,26 +1,46 @@
--- !!! Query is not converted to CH syntax yet.  Delete this line when it gets converted
 WITH rolling_average_table as (
-  SELECT
-    FORMAT_ISO8601(
-        CAST(date as date)
-    ) AS granularity_bucket,
-    -- weekly granularity with a 4 week rolling average
-    TRUNC(SUM(pr_count)
-           OVER(ORDER BY date ROWS 27 PRECEDING),1)/4
-           AS weekly_pr_count_rolling_average,
-  TRUNC(LENGTH(ARRAY_DISTINCT(ARRAY_FLATTEN(ARRAY_AGG(users)
-  OVER(ORDER BY date ROWS 27 PRECEDING)))),1)/4 as weekly_user_count_rolling_average,
-FROM
-    metrics.external_contribution_stats
-    WHERE CAST(date as date) >= PARSE_DATETIME_ISO8601(:startTime) - DAYS(28)
-    AND CAST(date as date) < PARSE_DATETIME_ISO8601(:stopTime)
+    SELECT
+        date AS granularity_bucket,
+        -- weekly granularity with a 4 week rolling average
+        TRUNC(
+            SUM(pr_count) OVER(
+                ORDER BY
+                    date ROWS 27 PRECEDING
+            ),
+            1
+        ) / 4 AS weekly_pr_count_rolling_average,
+        TRUNC(
+            LENGTH(
+                arrayDistinct(
+                    arrayFlatten(
+                        ARRAY_AGG(users) OVER(
+                            ORDER BY
+                                date ROWS 27 PRECEDING
+                        )
+                    )
+                )
+            ),
+            1
+        ) / 4 as weekly_user_count_rolling_average
+    FROM
+        misc.external_contribution_stats
+    WHERE
+        date >= {startTime: DateTime64(9) } - interval 28 day
+        AND date < {stopTime: DateTime64(9) }
 )
 SELECT
-granularity_bucket,
-weekly_pr_count_rolling_average AS pr_count,
-weekly_user_count_rolling_average AS user_count,
+    granularity_bucket,
+    weekly_pr_count_rolling_average AS pr_count,
+    weekly_user_count_rolling_average AS user_count
 FROM
-rolling_average_table
-WHERE CAST(granularity_bucket as date) >= PARSE_DATETIME_ISO8601(:startTime)
-    AND CAST(granularity_bucket as date) < PARSE_DATETIME_ISO8601(:stopTime)
-    AND (DATE_DIFF('DAY', CAST(granularity_bucket as date), CAST(PARSE_DATETIME_ISO8601(:startTime) as date)) % 7) = 0
+    rolling_average_table
+WHERE
+    granularity_bucket >= {startTime: DateTime64(9) }
+    AND granularity_bucket < {stopTime: DateTime64(9) }
+    AND (
+        DATE_DIFF(
+            'DAY',
+            granularity_bucket,
+            {startTime: DateTime64(9) }
+        ) % 7
+    ) = 0

--- a/torchci/clickhouse_queries/monthly_contribution_stats/query.sql
+++ b/torchci/clickhouse_queries/monthly_contribution_stats/query.sql
@@ -1,25 +1,25 @@
--- !!! Query is not converted to CH syntax yet.  Delete this line when it gets converted
 WITH average_table as (
-  SELECT
-    DATE_TRUNC('MONTH', DATE (CAST(date as date))) AS granularity_bucket,
-    SUM(pr_count)
-           AS pr_count_sum,
-    ARRAY_AGG(users) as users_agg
-  FROM
-      metrics.external_contribution_stats
-      WHERE CAST(date as date) >= PARSE_DATETIME_ISO8601(:startTime)
-      AND CAST(date as date) < PARSE_DATETIME_ISO8601(:stopTime)
-  GROUP BY
-      DATE_TRUNC('MONTH', DATE (CAST(date as date)))
+    SELECT
+        DATE_TRUNC('MONTH', date) AS granularity_bucket,
+        SUM(pr_count) AS pr_count_sum,
+        ARRAY_AGG(users) as users_agg
+    FROM
+        misc.external_contribution_stats
+    WHERE
+        date >= {startTime: DateTime64(9) }
+        AND date < {stopTime: DateTime64(9) }
+    GROUP BY
+        granularity_bucket
 )
 SELECT
--- the day will always be 01
-FORMAT_ISO8601(CAST(granularity_bucket as date)) as year_and_month,
-pr_count_sum as pr_count,
-LENGTH(ARRAY_DISTINCT(ARRAY_FLATTEN(users_agg))) as user_count,
+    -- the day will always be 01
+    granularity_bucket as year_and_month,
+    pr_count_sum as pr_count,
+    LENGTH(arrayDistinct(arrayFlatten(users_agg))) as user_count
 FROM
-average_table
-WHERE CAST(granularity_bucket as date) >= PARSE_DATETIME_ISO8601(:startTime)
-    AND CAST(granularity_bucket as date) < PARSE_DATETIME_ISO8601(:stopTime)
+    average_table
+WHERE
+    granularity_bucket >= {startTime: DateTime64(9) }
+    AND granularity_bucket < {stopTime: DateTime64(9) }
 ORDER BY
-granularity_bucket DESC
+    granularity_bucket DESC

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -29,20 +29,6 @@ export default function Kpis() {
   const clickhouseTimeParams = RStoCHTimeParams(timeParams);
   const useCH = useCHContext().useCH;
 
-  // deprecate this in Q3 2023
-  const contributionTimeParams: RocksetParam[] = [
-    {
-      name: "startTime",
-      type: "string",
-      value: "2022-07-03T00:00:00.000Z",
-    },
-    {
-      name: "stopTime",
-      type: "string",
-      value: stopTime,
-    },
-  ];
-
   return (
     <Grid container spacing={2}>
       <Grid item xs={12} lg={6} height={ROW_HEIGHT}>
@@ -164,13 +150,14 @@ export default function Kpis() {
         <TimeSeriesPanel
           title={"Weekly external PR count (4 week moving average)"}
           queryName={"external_contribution_stats"}
-          queryParams={[...contributionTimeParams]}
+          queryParams={clickhouseTimeParams}
           queryCollection={"metrics"}
           granularity={"week"}
           timeFieldName={"granularity_bucket"}
           yAxisFieldName={"pr_count"}
           yAxisRenderer={(value) => value}
           additionalOptions={{ yAxis: { scale: true } }}
+          useClickHouse={true}
         />
       </Grid>
 
@@ -179,13 +166,14 @@ export default function Kpis() {
           title={"Monthly external PR count"}
           queryName={"monthly_contribution_stats"}
           queryCollection={"pytorch_dev_infra_kpis"}
-          queryParams={[...contributionTimeParams]}
+          queryParams={clickhouseTimeParams}
           granularity={"month"}
           timeFieldName={"year_and_month"}
           timeFieldDisplayFormat={"MMMM YYYY"}
           yAxisFieldName={"pr_count"}
           yAxisRenderer={(value) => value}
           additionalOptions={{ yAxis: { scale: true } }}
+          useClickHouse={true}
         />
       </Grid>
 


### PR DESCRIPTION
The returned data looks different between CH and RS because there are some errors in the RS table (dup rows) that I removed in CH.  This is also why I'm switching entirely to CH

Also removes old time params for the query since it says to remove them (I believe it's because contrb stats were only available after that time)