### PR TITLE
Add linux aarch64 Python 3.13 builds for domains

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -495,7 +495,7 @@ def generate_wheels_matrix(
     if os == LINUX:
         # NOTE: We only build manywheel packages for linux
         package_type = "manywheel"
-    if channel == NIGHTLY and (os == LINUX or os == MACOS_ARM64):
+    if channel == NIGHTLY and (os == LINUX or os == MACOS_ARM64 or os == LINUX_AARCH64):
         python_versions += ["3.13"]
 
     upload_to_base_bucket = "yes"


### PR DESCRIPTION
We have 3.13 Aarch64 builds in core for couple of days now : https://hud2.pytorch.org/hud/pytorch/pytorch/nightly/1?per_page=50&name_filter=3_13&mergeLF=true
Hence enabling for domains.