### PR TITLE
[CH] Move viable/strict historical lag query to ClickHouse

### DIFF
--- a/torchci/clickhouse_queries/strict_lag_historical/params.json
+++ b/torchci/clickhouse_queries/strict_lag_historical/params.json
@@ -1,5 +1,6 @@
 {
   "granularity": "String",
   "startTime": "DateTime64(3)",
-  "stopTime": "DateTime64(3)"
+  "stopTime": "DateTime64(3)",
+  "repoFullName": "String"
 }

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -144,7 +144,6 @@ export default function Kpis() {
                 .utc()
                 .format("YYYY-MM-DDTHH:mm:ss.SSS"),
             }),
-            granularity: "week",
             repoFullName: "pytorch/pytorch",
           }}
           granularity={"day"}

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -136,14 +136,25 @@ export default function Kpis() {
           title={"viable/strict lag (Daily)"}
           queryName={"strict_lag_historical"}
           queryCollection={"pytorch_dev_infra_kpis"}
-          queryParams={[...timeParams]}
+          queryParams={{
+            ...clickhouseTimeParams,
+            // Missing data prior to 2024-10-01 due to migration to ClickHouse
+            ...(startTime < dayjs("2024-10-01") && {
+              startTime: dayjs("2024-10-01")
+                .utc()
+                .format("YYYY-MM-DDTHH:mm:ss.SSS"),
+            }),
+            granularity: "week",
+            repoFullName: "pytorch/pytorch",
+          }}
           granularity={"day"}
           timeFieldName={"push_time"}
           yAxisFieldName={"diff_hr"}
           yAxisLabel={"Hours"}
           yAxisRenderer={(unit) => `${unit}`}
           // the data is very variable, so set the y axis to be something that makes this chart a bit easier to read
-          additionalOptions={{ yAxis: { max: 7 } }}
+          additionalOptions={{ yAxis: { max: 10 } }}
+          useClickHouse={true}
         />
       </Grid>
 


### PR DESCRIPTION
Switch entirely

We lack data prior to 2024-10-01 due to the old query relying on _event_time, which is not available, so instead I had to make a new table and log data specifically about when viable/strict was updated

Data looks slightly different, my guess would be a combo of date trunc truncating to monday instead of sunday

Uses data from https://github.com/pytorch/pytorch/pull/136470