### PR TITLE
[BE] Add vercel analytics to track user visit

### DIFF
--- a/torchci/package.json
+++ b/torchci/package.json
@@ -34,6 +34,7 @@
     "@opensearch-project/opensearch": "^2.3.1",
     "@rockset/client": "^0.8.9",
     "@types/minimist": "^1.2.2",
+    "@vercel/analytics": "^1.3.2",
     "ansicolor": "^1.1.100",
     "axios": "^0.28.0",
     "dayjs": "^1.11.3",

--- a/torchci/pages/_app.tsx
+++ b/torchci/pages/_app.tsx
@@ -1,3 +1,4 @@
+import { Analytics } from "@vercel/analytics/react";
 import AnnouncementBanner from "components/AnnouncementBanner";
 import TitleProvider from "components/DynamicTitle";
 import NavBar from "components/NavBar";
@@ -10,7 +11,6 @@ import { useRouter } from "next/router";
 import { useEffect } from "react";
 import ReactGA from "react-ga4";
 import "styles/globals.css";
-import { Analytics } from '@vercel/analytics/react';
 
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();

--- a/torchci/pages/_app.tsx
+++ b/torchci/pages/_app.tsx
@@ -10,6 +10,7 @@ import { useRouter } from "next/router";
 import { useEffect } from "react";
 import ReactGA from "react-ga4";
 import "styles/globals.css";
+import { Analytics } from '@vercel/analytics/react';
 
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
@@ -30,6 +31,7 @@ function MyApp({ Component, pageProps }: AppProps) {
             <SevReport />
             <div style={{ margin: "20px" }}>
               <Component {...pageProps} />
+              <Analytics />
             </div>
           </TitleProvider>
         </UseCHContextProvider>

--- a/torchci/yarn.lock
+++ b/torchci/yarn.lock
@@ -3167,6 +3167,13 @@
     "@typescript-eslint/types" "5.10.1"
     eslint-visitor-keys "^3.0.0"
 
+"@vercel/analytics@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@vercel/analytics/-/analytics-1.3.2.tgz#e7a8e22c83a7945e069960bab172308498b12b4e"
+  integrity sha512-n/Ws7skBbW+fUBMeg+jrT30+GP00jTHvCcL4fuVrShuML0uveEV/4vVUdvqEVnDgXIGfLm0GXW5EID2mCcRXhg==
+  dependencies:
+    server-only "^0.0.1"
+
 accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz"
@@ -7764,6 +7771,11 @@ serve-static@1.16.2:
     escape-html "~1.0.3"
     parseurl "~1.3.3"
     send "0.19.0"
+
+server-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/server-only/-/server-only-0.0.1.tgz#0f366bb6afb618c37c9255a314535dc412cd1c9e"
+  integrity sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==
 
 set-function-length@^1.2.1:
   version "1.2.2"


### PR DESCRIPTION
# Overview
Add existing Vercel analytics to track user visit. 

# Background: Another tracking
Currently our team has a setting up using google analytics general tracking, but the visit tracking is not very accurate , we found that Vercel has it's own tracking dashboard, but our team does not enable it. this pr add it to our website to see if it can gather some more accurate info.

See official Doc:
https://vercel.com/docs/analytics
