### PR TITLE
[CH] Historical file failure correlation query

### DIFF
--- a/tools/torchci/td/historical_file_failure_correlation.py
+++ b/tools/torchci/td/historical_file_failure_correlation.py
@@ -1,7 +1,7 @@
 import json
 from collections import defaultdict
 
-from torchci.rockset_utils import query_rockset
+from torchci.clickhouse import query_clickhouse
 
 from torchci.td.utils import (
     calculate_generic_test_ratings,
@@ -12,13 +12,13 @@ from torchci.td.utils import (
 FAILED_TESTS_QUERY = """
 select
     w.head_sha,
-    t.failure,
+    JSONExtractString(t.info, 'failure')
 from
-    workflow_run w
-    join metrics.metrics t on t.run_id = w.id
+    default.workflow_run w
+    join misc.ossci_uploaded_metrics t on t.run_id = w.id
 where
     t.metric_name = 'td_test_failure_stats_v2'
-    and t._event_time > CURRENT_TIMESTAMP() - DAYS(90)
+    and t.timestamp > CURRENT_TIMESTAMP() - interval 30 day
 """
 
 
@@ -49,9 +49,9 @@ def filter_tests(failed_tests, merge_bases):
 
 
 def main() -> None:
-    failed_tests = query_rockset(FAILED_TESTS_QUERY)
+    failed_tests = query_clickhouse(FAILED_TESTS_QUERY, {})
     merge_bases = get_merge_bases_dict()
-    print("done querying rockset", flush=True)
+    print("done querying", flush=True)
 
     filtered_tests = filter_tests(failed_tests, merge_bases)
 

--- a/tools/torchci/td/historical_file_failure_correlation.py
+++ b/tools/torchci/td/historical_file_failure_correlation.py
@@ -18,7 +18,7 @@ from
     join misc.ossci_uploaded_metrics t on t.run_id = w.id
 where
     t.metric_name = 'td_test_failure_stats_v2'
-    and t.timestamp > CURRENT_TIMESTAMP() - interval 30 day
+    and t.timestamp > CURRENT_TIMESTAMP() - interval 90 day
 """
 
 

--- a/tools/torchci/td/historical_file_failure_correlation.py
+++ b/tools/torchci/td/historical_file_failure_correlation.py
@@ -12,7 +12,7 @@ from torchci.td.utils import (
 FAILED_TESTS_QUERY = """
 select
     w.head_sha,
-    JSONExtractString(t.info, 'failure')
+    JSONExtractString(t.info, 'failure') as failure
 from
     default.workflow_run w
     join misc.ossci_uploaded_metrics t on t.run_id = w.id


### PR DESCRIPTION
Move query for getting historical file failure correlations for TD to ClickHouse

Checked by running the script and seeing that it outputted a file.  Unfortunately the data is not comparable to Rockset because the data on Rockset is outdated and incomplete