### PR TITLE
[HUD][ez] Fix title element having multiple children warning

### DIFF
--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -472,14 +472,14 @@ export default function Hud() {
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, []);
-  const title =
+  const titleRepoInfo =
     params.repoOwner != null && params.repoName != null && params.branch != null
       ? ` (${params.repoOwner}/${params.repoName}: ${params.branch})`
       : "";
   return (
     <>
       <Head>
-        <title>HUD {title}</title>
+        <title>{`HUD ${titleRepoInfo}`}</title>
       </Head>
       <PinnedTooltipContext.Provider value={[pinnedTooltip, setPinnedTooltip]}>
         <MonsterFailuresProvider>


### PR DESCRIPTION
Fixes errors like
```
Warning: A title element received an array with more than 1 element as children. In browsers title Elements can only have Text Nodes as children. If the children being rendered output more than a single text node in aggregate the browser will display markup and comments as text in the title and hydration will likely fail and fall back to client rendering
```

See https://github.com/vercel/next.js/discussions/38256