### PR TITLE
[Tooling][Hud ]Add Performance Render Profiler wrapper

### DIFF
--- a/torchci/lib/tools/MeasureRenderTimeProfiler.tsx
+++ b/torchci/lib/tools/MeasureRenderTimeProfiler.tsx
@@ -1,0 +1,50 @@
+import React, { Profiler } from "react";
+/**
+ * Profiler Wrapper to estimate the render time of a component. Notice this is not only log the parent component,
+ * but also all children comp's render time.
+ * See more details on https://react.dev/reference/react/Profiler.
+ *
+ * Usage:
+ * const MyComponent()=>{
+ *   reutrn (
+ *      <>
+ *         <MeasureRenderTimeProfiler id="My Component">
+ *              <ChildComponentICare />
+ *         </MeasureRenderTimeProfiler>
+ *      </>
+ *    )
+ * }
+ */
+const MeasureRenderTimeProfiler = ({
+  children,
+  id = "Component",
+}: {
+  children: React.ReactNode;
+  id: string;
+}) => {
+  const onRenderCallback = (
+    id: string, // The "id" prop of the Profiler tree that has just committed
+    phase: "mount" | "update", // Either "mount" (for initial render) or "update" (for re-renders)
+    actualDuration: number, // Time spent rendering the committed update
+    baseDuration: number, // Estimated time to render the entire subtree without memoization
+    startTime: number, // When React began rendering this update
+    commitTime: number // When React committed this update
+  ) => {
+    const loggingObject = {
+      "Profiler ID": id,
+      Phase: phase,
+      "Actual Duration": `${actualDuration.toFixed(2)} ms`,
+      "Base Duration": `${baseDuration.toFixed(2)} ms`,
+      "Start Time": `${startTime.toFixed(2)} ms`,
+      "Commit Time": `${commitTime.toFixed(2)} ms`,
+    };
+    console.log(JSON.stringify(loggingObject, null, 2));
+  };
+  return (
+    <Profiler id={id} onRender={onRenderCallback}>
+      {children}
+    </Profiler>
+  );
+};
+
+export default MeasureRenderTimeProfiler;

--- a/torchci/lib/tools/MeasureRenderTimeProfiler.tsx
+++ b/torchci/lib/tools/MeasureRenderTimeProfiler.tsx
@@ -2,7 +2,10 @@ import React, { Profiler } from "react";
 /**
  * Profiler Wrapper to estimate the render time of a component. Notice this is not only log the parent component,
  * but also all children comp's render time.
+ *
  * See more details on https://react.dev/reference/react/Profiler.
+ * Do not use it in prod, as each use adds some CPU and memory overhead to an application.
+ * Only use it for local development to collect metrics.
  *
  * Usage:
  * const MyComponent()=>{

--- a/torchci/lib/tools/MeasureRenderTimeProfiler.tsx
+++ b/torchci/lib/tools/MeasureRenderTimeProfiler.tsx
@@ -34,7 +34,7 @@ const MeasureRenderTimeProfiler = ({
   ) => {
     const loggingObject = {
       "Profiler ID": id,
-      "Phase": phase,
+      Phase: phase,
       "Actual Duration": `${actualDuration.toFixed(2)} ms`,
       "Base Duration": `${baseDuration.toFixed(2)} ms`,
       "Start Time": `${startTime.toFixed(2)} ms`,

--- a/torchci/lib/tools/MeasureRenderTimeProfiler.tsx
+++ b/torchci/lib/tools/MeasureRenderTimeProfiler.tsx
@@ -1,7 +1,6 @@
 import React, { Profiler } from "react";
 /**
- * Profiler Wrapper to estimate the render time of a component. Notice this is not only log the parent component,
- * but also all children comp's render time.
+ * Profiler Wrapper to estimate the render time of a component.
  *
  * See more details on https://react.dev/reference/react/Profiler.
  * Do not use it in prod, as each use adds some CPU and memory overhead to an application.
@@ -35,7 +34,7 @@ const MeasureRenderTimeProfiler = ({
   ) => {
     const loggingObject = {
       "Profiler ID": id,
-      Phase: phase,
+      "Phase": phase,
       "Actual Duration": `${actualDuration.toFixed(2)} ms`,
       "Base Duration": `${baseDuration.toFixed(2)} ms`,
       "Start Time": `${startTime.toFixed(2)} ms`,


### PR DESCRIPTION
# Overview
We want to investigate the performance of components in HUD, [react-profiler](https://react.dev/reference/react/Profiler) is a good tool to give us the render time feedback.

# Altenative
You can def choose the profile tool in Chrome Extension: React Dev Tools, for me this is easy to target.

# Notice
Only use it during local development. Though react profiler is light-weight, it is still takes memories on application.

# Screenshot logging demo
Tracking render time for HudTable's  and its children's.
![Nov-12-2024 16-51-44](https://github.com/user-attachments/assets/93d8ec53-be8f-45d3-8431-4e3a98b669e6)



