### PR TITLE
Slow down queries to docker.io

### DIFF
--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -157,6 +157,19 @@ runs:
 
         retry login "${DOCKER_REGISTRY}"
 
+    - name: Slow down the incoming requests to avoid Docker rate limit
+      shell: bash
+      continue-on-error: true
+      env:
+        MAX_WAIT_TIME_IN_SECONDS: 120
+      run: |
+        set -ex
+
+        # NB: Docker imposes a rate limit somewhere on the number of requests
+        # we can submit to them. Let's just slow down a bit here
+        WAIT_TIME_IN_SECONDS=$((RANDOM % MAX_WAIT_TIME_IN_SECONDS))
+        sleep "${WAIT_TIME_IN_SECONDS}"
+
     - name: Build docker image
       if: ${{ steps.calculate-image.outputs.skip != 'true' && (inputs.always-rebuild || steps.check-image.outputs.rebuild) }}
       env:


### PR DESCRIPTION
We are rate limit by docker.io when trying to fetch the base image `docker.io/library/ubuntu:20.04`.  This happens because our docker build jobs are spawn in one go whenever there are changes to the dir causing a burst of requests at the same time to docker.io:

* https://github.com/pytorch/pytorch/actions/runs/11808117116/job/32896118382
* The issue is also reported by ExecuTorch, for example https://github.com/pytorch/executorch/actions/runs/11807697251/job/32894904332?pr=6796 (cc @kirklandsign @cccclai)

A easy workaround is to introduce a small random delay.  I'm using the same trick when connecting to AWS Device Farm https://github.com/pytorch/test-infra/blob/main/.github/workflows/mobile_job.yml#L273

Appreciate if there is a better suggestion.  It seems that we can login to docker.io to get a higher rate limit, but it's probably more work.