### PR TITLE
[CH] Handle upload for torchao edge case where keys have //

### DIFF
--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -396,6 +396,7 @@ def torchao_perf_stats_adapter(table, bucket, key) -> None:
     except Exception as e:
         log_failure_to_clickhouse(table, bucket, key, e)
 
+
 def torchbench_userbenchmark_adapter(table, bucket, key):
     schema = """
     `environ` String,

--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -306,8 +306,7 @@ def general_adapter(table, bucket, key, schema, compressions, format) -> None:
             f"Failed to insert into {table} with {[str(x) for x in exceptions]}"
         )
     except Exception as e:
-        print(f"Failed to insert into {table} {key}: {e}")
-        # log_failure_to_clickhouse(table, bucket, key, e)
+        log_failure_to_clickhouse(table, bucket, key, e)
 
 
 def external_aggregated_test_metrics_adapter(table, bucket, key) -> None:
@@ -395,7 +394,7 @@ def torchao_perf_stats_adapter(table, bucket, key) -> None:
     try:
         get_clickhouse_client().query(insert_query)
     except Exception as e:
-        print(f"Failed to insert into {table} {key}: {e}")
+        log_failure_to_clickhouse(table, bucket, key, e)
 
 def torchbench_userbenchmark_adapter(table, bucket, key):
     schema = """

--- a/t.json
+++ b/t.json
@@ -1,0 +1,1 @@
+{"exclusive_start_key": "torchbench-csv/torchao/9421931167/1/torchao_noquant_timm_models_bfloat16_inference_cuda_performance_compilation_metrics.csv", "items_scanned": 1304, "total_items": 0}

--- a/t.json
+++ b/t.json
@@ -1,1 +1,0 @@
-{"exclusive_start_key": "torchbench-csv/torchao/9421931167/1/torchao_noquant_timm_models_bfloat16_inference_cuda_performance_compilation_metrics.csv", "items_scanned": 1304, "total_items": 0}


### PR DESCRIPTION
the s3 function cannot handle keys that have multiple slashes (/) in a row, but the url function can.


Tested by running s32ch locally