### PR TITLE
Revert #5397 now that AL2023/Node 20 rollout is done

### DIFF
--- a/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
@@ -186,14 +186,6 @@ EOF
   popd
 }
 
-# TODO (huydhn): Remove this after moving to AmazonLinux2023
-fallback_to_node16() {
-  # https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
-  FALLBACK_TO_NODE16="ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true"
-  export $FALLBACK_TO_NODE16
-  echo $FALLBACK_TO_NODE16 >> $RUNNER_ENV
-}
-
 get_labels_from_config() {
   while [[ "$#" -gt 0 ]]; do
     case $1 in
@@ -212,7 +204,6 @@ tar xzf ./actions-runner.tar.gz
 rm -rf actions-runner.tar.gz
 
 install_hooks
-fallback_to_node16
 
 ${arm_patch}
 


### PR DESCRIPTION
This is the fallback we have been using for a while to avoid the upgrade.