### PR TITLE
Update aarch64 jobs to use manylinux2_28_aarch64-builder

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -161,7 +161,8 @@ def initialize_globals(channel: str, build_python_only: bool) -> None:
         },
         CPU: "pytorch/manylinux2_28-builder:cpu",
         XPU: "pytorch/manylinux2_28-builder:xpu",
-        CPU_AARCH64: "pytorch/manylinuxaarch64-builder:cpu-aarch64",
+        # TODO: Migrate CUDA_AARCH64 image to manylinux2_28_aarch64-builder:cuda12.4
+        CPU_AARCH64: "pytorch/manylinux2_28_aarch64-builder:cpu-aarch64",
         CUDA_AARCH64: "pytorch/manylinuxaarch64-builder:cuda12.4",
     }
     CONDA_CONTAINER_IMAGES = {


### PR DESCRIPTION
Accompanying PyTorch PR: https://github.com/pytorch/pytorch/pull/140743

Aarch64 jobs are passing: https://github.com/pytorch/test-infra/actions/runs/11844478690/job/33007802789?pr=5919