### PR TITLE
Add memory intensive R5 instances

### DIFF
--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -224,3 +224,27 @@ runner_types:
     instance_type: g5.4xlarge
     is_ephemeral: false
     os: windows
+  lf.c.linux.2xlarge.memory:
+    disk_size: 200
+    instance_type: r5.2xlarge
+    is_ephemeral: false
+    os: linux
+    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64
+  lf.c.linux.4xlarge.memory:
+    disk_size: 300
+    instance_type: r5.4xlarge
+    is_ephemeral: false
+    os: linux
+    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64
+  lf.c.linux.8xlarge.memory:
+    disk_size: 400
+    instance_type: r5.8xlarge
+    is_ephemeral: false
+    os: linux
+    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64
+  lf.c.linux.12xlarge.memory:
+    disk_size: 600
+    instance_type: r5.12xlarge
+    is_ephemeral: false
+    os: linux
+    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -224,3 +224,27 @@ runner_types:
     instance_type: g5.4xlarge
     is_ephemeral: false
     os: windows
+  lf.linux.2xlarge.memory:
+    disk_size: 200
+    instance_type: r5.2xlarge
+    is_ephemeral: false
+    os: linux
+    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64
+  lf.linux.4xlarge.memory:
+    disk_size: 300
+    instance_type: r5.4xlarge
+    is_ephemeral: false
+    os: linux
+    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64
+  lf.linux.8xlarge.memory:
+    disk_size: 400
+    instance_type: r5.8xlarge
+    is_ephemeral: false
+    os: linux
+    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64
+  lf.linux.12xlarge.memory:
+    disk_size: 600
+    instance_type: r5.12xlarge
+    is_ephemeral: false
+    os: linux
+    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -220,3 +220,27 @@ runner_types:
     instance_type: g5.4xlarge
     is_ephemeral: false
     os: windows
+  linux.2xlarge.memory:
+    disk_size: 200
+    instance_type: r5.2xlarge
+    is_ephemeral: false
+    os: linux
+    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64
+  linux.4xlarge.memory:
+    disk_size: 300
+    instance_type: r5.4xlarge
+    is_ephemeral: false
+    os: linux
+    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64
+  linux.8xlarge.memory:
+    disk_size: 400
+    instance_type: r5.8xlarge
+    is_ephemeral: false
+    os: linux
+    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64
+  linux.12xlarge.memory:
+    disk_size: 600
+    instance_type: r5.12xlarge
+    is_ephemeral: false
+    os: linux
+    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64


### PR DESCRIPTION
ExecuTorch is requesting memory intensive R5 instances because they uses lots of memory to export the model while CPU cores stay idle.  Atm, they need to jump from `2xlarge` to `4xlarge` or `12xlarge` (or even `24xlarge`) to get the necessary amount of memory, which is a waste.

I also allocate more disk space to there instances, enough that they could dump the whole memory without running out of space.

cc @guangy10 @dvorjackz 