### PR TITLE
[CH] Update queue times script and queue alert script to use api/clickhouse

### DIFF
--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -55,7 +55,6 @@ jobs:
   update-queue-alert:
     env:
       DRY_RUN: ${{ github.event_name == 'pull_request' }}
-      ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
     runs-on: ubuntu-22.04
     permissions:
       issues: write
@@ -63,7 +62,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Dependencies
-        run: pip3 install requests setuptools==61.2.0 rockset==1.0.3
+        run: pip3 install requests setuptools==61.2.0
       - name: Check for alerts and creates issue
         run: |
           cd tools

--- a/.github/workflows/update-queue-times.yml
+++ b/.github/workflows/update-queue-times.yml
@@ -24,5 +24,3 @@ jobs:
           role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_update_queue_times
           aws-region: us-east-1
       - run: yarn node scripts/updateQueueTimes.mjs
-        env:
-          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}

--- a/tools/torchci/queue_alert.py
+++ b/tools/torchci/queue_alert.py
@@ -89,7 +89,9 @@ def filter_long_queues(db_result: List[Dict[str, Any]]) -> List[QueueInfo]:
 
 def queuing_alert(dry_run: bool) -> None:
     # %7B%7D = encoded {}
-    url = "https://hud.pytorch.org/api/clickhouse/queued_jobs_by_label?parameters=%7B%7D"
+    url = (
+        "https://hud.pytorch.org/api/clickhouse/queued_jobs_by_label?parameters=%7B%7D"
+    )
     response = requests.get(url).json()
 
     large_queue = filter_long_queues(response)
@@ -118,7 +120,7 @@ def queuing_alert(dry_run: bool) -> None:
         new_issue = gen_issue(large_queue)
         update_issue(new_issue, existing_issue, update_comment, dry_run=dry_run)
     else:
-        print(f"No new change for queuing alert")
+        print("No new change for queuing alert")
 
 
 def parse_args() -> argparse.Namespace:

--- a/tools/torchci/queue_alert.py
+++ b/tools/torchci/queue_alert.py
@@ -88,8 +88,8 @@ def filter_long_queues(db_result: List[Dict[str, Any]]) -> List[QueueInfo]:
 
 
 def queuing_alert(dry_run: bool) -> None:
-    url = "https://hud.pytorch.org/api/clickhouse/queued_jobs_by_label?parameters=%7B%7D%0A"
-    # %7B%7D%0A = encoded {}
+    # %7B%7D = encoded {}
+    url = "https://hud.pytorch.org/api/clickhouse/queued_jobs_by_label?parameters=%7B%7D"
     response = requests.get(url).json()
 
     large_queue = filter_long_queues(response)

--- a/torchci/scripts/updateQueueTimes.mjs
+++ b/torchci/scripts/updateQueueTimes.mjs
@@ -3,8 +3,6 @@
 // give us historical data, so write our snapshot regularly to s3 so we can get
 // a view of the queue over time.
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
-import rockset from "@rockset/client";
-import { promises as fs } from "fs";
 
 export function getS3Client() {
   return new S3Client({
@@ -14,21 +12,11 @@ export function getS3Client() {
 
 const s3client = getS3Client();
 
-async function readJSON(path) {
-  const rawData = await fs.readFile(path);
-  return JSON.parse(rawData);
-}
-const prodVersions = await readJSON("./rockset/prodVersions.json");
-const client = rockset.default(process.env.ROCKSET_API_KEY);
-
-const response = await client.queryLambdas.executeQueryLambda(
-  "metrics",
-  "queued_jobs_by_label",
-  prodVersions.metrics.queued_jobs_by_label,
-  {}
-);
-
-for (const r of response.results) {
+// %7B%7D%0A = encoded {}
+const response = await fetch(
+  "https://hud.pytorch.org/api/clickhouse/queued_jobs_by_label?parameters=%7B%7D%0A"
+).then((r) => r.json());
+for (const r of response) {
   const unixTime = parseInt((new Date(r.time).getTime() / 1000).toFixed(0));
   s3client.send(
     new PutObjectCommand({

--- a/torchci/scripts/updateQueueTimes.mjs
+++ b/torchci/scripts/updateQueueTimes.mjs
@@ -12,9 +12,9 @@ export function getS3Client() {
 
 const s3client = getS3Client();
 
-// %7B%7D%0A = encoded {}
+// %7B%7D = encoded {}
 const response = await fetch(
-  "https://hud.pytorch.org/api/clickhouse/queued_jobs_by_label?parameters=%7B%7D%0A"
+  "https://hud.pytorch.org/api/clickhouse/queued_jobs_by_label?parameters=%7B%7D"
 ).then((r) => r.json());
 for (const r of response) {
   const unixTime = parseInt((new Date(r.time).getTime() / 1000).toFixed(0));


### PR DESCRIPTION
Change the queue times script (which populates the historical queue times table), and the queue alert script (which makes issues about long queues) to ask hud.pytorch.org/api/clickhouse instead of directly asking rockset or clickhouse.

This is how the HUD alert also works already
