### PR TITLE
[ez] Make a query in the backfill script faster

### DIFF
--- a/torchci/scripts/backfillJobs.mjs
+++ b/torchci/scripts/backfillJobs.mjs
@@ -106,7 +106,7 @@ async function backfillWorkflowJob(
     console.log(`Querying dynamo entry for job id ${id}`);
 
     let rows = await queryClickhouse(
-      `SELECT * FROM workflow_job j final WHERE j.dynamoKey = '${dynamo_key}'`,
+      `SELECT * FROM workflow_job j final WHERE j.dynamoKey = '${dynamo_key}' and j.id = ${id}`,
       {}
     );
 


### PR DESCRIPTION
The primary key has id first and dynamoKey last, so adding j.id = ${id} makes it go faster.

No need for quotes because it's a number and not a string

This is a very rarely used branch in the logic