### PR TITLE
Update TimeSeriesPanel.tsx

### DIFF
--- a/torchci/components/metrics/panels/TimeSeriesPanel.tsx
+++ b/torchci/components/metrics/panels/TimeSeriesPanel.tsx
@@ -247,6 +247,7 @@ export function TimeSeriesPanelWithData({
       <ReactECharts
         style={{ height: "100%", width: "100%" }}
         option={options}
+        notMerge={true}
       />
     </Paper>
   );


### PR DESCRIPTION
adding notMerge=true rerenders the whole series on data change, which is needed for the search of cost analysis. It has seemingly no impact on other graphs, and I don't see any performance impact