### PR TITLE
Do not show upload test stats while running job on HUD

### DIFF
--- a/torchci/clickhouse_queries/commit_jobs_query/query.sql
+++ b/torchci/clickhouse_queries/commit_jobs_query/query.sql
@@ -60,6 +60,7 @@ WITH job AS (
         AND workflow.id in (select id from materialized_views.workflow_run_by_head_sha where head_sha = {sha: String})
         AND job.id in (select id from materialized_views.workflow_job_by_head_sha where head_sha = {sha: String})
         AND workflow.repository. 'full_name' = {repo: String } --         UNION
+        AND workflow.name != 'Upload test stats while running' -- Continuously running cron job that cancels itself to avoid running concurrently
     UNION ALL
     SELECT
         workflow.created_at AS time,
@@ -96,6 +97,7 @@ WITH job AS (
         AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
         AND workflow.id in (select id from materialized_views.workflow_run_by_head_sha where head_sha = {sha: String})
         AND workflow.repository.full_name = {repo: String }
+        AND workflow.name != 'Upload test stats while running' -- Continuously running cron job that cancels itself to avoid running concurrently
 )
 SELECT
     sha,

--- a/torchci/clickhouse_queries/hud_query/query.sql
+++ b/torchci/clickhouse_queries/hud_query/query.sql
@@ -42,6 +42,7 @@ WITH job AS (
         AND job.id in (select id from materialized_views.workflow_job_by_head_sha where head_sha in {shas: Array(String)})
         AND workflow.id in (select id from materialized_views.workflow_run_by_head_sha where head_sha in {shas: Array(String)})
         AND workflow.repository.'full_name' = {repo: String}
+        AND workflow.name != 'Upload test stats while running' -- Continuously running cron job that cancels itself to avoid running concurrently
     -- Removed CircleCI query
 )
 SELECT


### PR DESCRIPTION
Companion to https://github.com/pytorch/pytorch/pull/140453

Exclude this job from HUD to reduce confusion, as it is always going to be red