### PR TITLE
Handle invalid benchmark results directory

### DIFF
--- a/.github/actions/upload-benchmark-results/action.yml
+++ b/.github/actions/upload-benchmark-results/action.yml
@@ -96,6 +96,12 @@ runs:
       run: |
         set -eux
 
+        if [[ ! -d "${BENCHMARK_RESULTS_DIR}" ]]; then
+          echo "${BENCHMARK_RESULTS_DIR} does not exist, skipping"
+          # We don't want the job to fail if the directory doesn't exist
+          exit 0
+        fi
+
         if [[ "${DRY_RUN}" == "true" ]]; then
           python3 "${GITHUB_ACTION_PATH}/../../scripts/upload_benchmark_results.py" \
             --benchmark-results-dir "${BENCHMARK_RESULTS_DIR}" \


### PR DESCRIPTION
It's ok if the benchmark results directory doesn't exists, for example, on non-benchmark job like `doc_test` https://github.com/pytorch/pytorch/actions/runs/11925173700/job/33237580806.  I missed this after landing https://github.com/pytorch/pytorch/pull/140493