### PR TITLE
Trigger nightly build of torchvision-extra-decoders repo

### DIFF
--- a/.github/workflows/trigger_nightly.yml
+++ b/.github/workflows/trigger_nightly.yml
@@ -110,3 +110,12 @@ jobs:
           repository: pytorch/torchcodec
           token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
           path: torchcodec
+      - name: Trigger nightly torchvision-extra-decoders build
+        if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'torchvision-extra-decoders' || inputs.domain == 'all' }}
+        uses: ./.github/actions/trigger-nightly
+        with:
+          ref: main
+          repository: pytorch-labs/torchvision-extra-decoders
+          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+          path: torchvision-extra-decoders
+

--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -171,6 +171,7 @@ PACKAGE_ALLOW_LIST = {x.lower() for x in [
     "torchtext",
     "torchtune",
     "torchvision",
+    "torchvision-extra-decoders",
     "triton",
     "tqdm",
     "typing_extensions",


### PR DESCRIPTION
This PR lets nightly builds be triggered for https://github.com/pytorch-labs/torchvision-extra-decoders

I based this PR on what was recently done for TorchCodec: https://github.com/pytorch/test-infra/pull/5814 and https://github.com/pytorch/test-infra/pull/5815.