### PR TITLE
Make last_successful_jobs query faster

### DIFF
--- a/torchci/clickhouse_queries/last_successful_jobs/query.sql
+++ b/torchci/clickhouse_queries/last_successful_jobs/query.sql
@@ -1,39 +1,19 @@
-with successful_jobs as (
-    select
-        DATE_DIFF(
-            'second',
-            job.created_at,
-            CURRENT_TIMESTAMP()
-        ) as last_success_seconds_ago,
-        job.head_sha as head_sha,
-        job.name as name
-    from
-        default.workflow_job job final
-        JOIN default.workflow_run workflow final on workflow.id = job.run_id
-    where
-        workflow.repository.'full_name' = 'pytorch/pytorch'
-        AND workflow.head_branch IN ('master', 'main')
-        AND job.conclusion = 'success'
-        AND job.name in {jobNames: Array(String)}
-    order by
-        job.created_at DESC
-),
-successful_commits as (
-    select
-        min(last_success_seconds_ago) seconds_ago,
-        count(DISTINCT name) distinct_names,
-        head_sha
-    from
-        successful_jobs
-    group by
-        head_sha
-)
 select
-    seconds_ago as last_success_seconds_ago
+    min(
+        DATE_DIFF('second', job.created_at, CURRENT_TIMESTAMP())
+    ) as seconds_ago
 from
-    successful_commits
+    -- No final because info is unlikely to change after conclusion gets set
+    default .workflow_job job
 where
-    distinct_names >= LENGTH({jobNames: Array(String)})
+    job.name in {jobNames: Array(String) }
+    and job.conclusion = 'success'
+    and job.head_branch = 'main'
+    and job.html_url like '%/pytorch/pytorch/%' -- proxy for workflow.repository.'full_name' = 'pytorch/pytorch'
+group by
+    job.head_sha
+having
+    count(distinct job.name) >= LENGTH({jobNames: Array(String) })
 order by
     seconds_ago
 limit


### PR DESCRIPTION
Some slight differences but should return same result.  Please see comments for changes

With input: [     'docs push / build-docs-python-true',     'docs push / build-docs-cpp-true',     'docs push / build-docs-functorch-true' ]  (this is the input used on the metrics page)

Original: 
Elapsed: 7.157s
Read: 50,661,037 rows (27.19 GB)

New:
Elapsed: 1.079s
Read: 45,233,361 rows (4.22 GB)