### PR TITLE
Correctly set the ref (branch) when using workflow dispatch

### DIFF
--- a/.github/actions/upload-benchmark-results/action.yml
+++ b/.github/actions/upload-benchmark-results/action.yml
@@ -47,7 +47,7 @@ runs:
       env:
         SCHEMA_VERSION: ${{ inputs.schema-version }}
         REPO: ${{ github.repository }}
-        HEAD_BRANCH: ${{ github.head_ref }}
+        HEAD_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
         HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         WORKFLOW_RUN_ID: ${{ github.run_id }}
         RUN_ATTEMPT: ${{ github.run_attempt }}


### PR DESCRIPTION
`github.head_ref` is empty when using workflow dispatch to trigger the workflow.  According to https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context, `github.head_ref is only available when the event that triggers a workflow run is either `pull_request` or `pull_request_target`.

The fix is to do the same as SHA by checking for the event name and set the branch accordingly.

### Testing

https://github.com/pytorch/pytorch/actions/workflows/inductor-perf-test-nightly-macos.yml