### PR TITLE
Login to docker.io

### DIFF
--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -30,12 +30,6 @@ inputs:
     description: If set to true, always push the image to ECR even if it exists.
     required: false
     default: false
-  docker-hub-username:
-    description: An optional username to login to Docker Hub
-    required: false
-  docker-hub-password:
-    description: An optional password to login to Docker Hub
-    required: false
 
 outputs:
   docker-image:
@@ -164,11 +158,12 @@ runs:
         retry login "${DOCKER_REGISTRY}"
 
     - name: Login to Docker Hub
-      if: ${{ inputs.docker-hub-username != '' && inputs.docker-hub-password != '' }}
-      uses: docker/login-action@v3
-      with:
-        username: ${{ inputs.docker-hub-username }}
-        password: ${{ inputs.docker-hub-password }}
+      shell: bash
+      # It's ok if this steps fails, it would then be an anonymous user like what we used to have
+      continue-on-error: true
+      run: |
+        set -eux
+        aws secretsmanager get-secret-value --secret-id docker_hub_readonly_token | jq --raw-output '.SecretString' | jq -r .docker_hub_readonly_token | docker login --username pytorchbot --password-stdin
 
     - name: Build docker image
       if: ${{ steps.calculate-image.outputs.skip != 'true' && (inputs.always-rebuild || steps.check-image.outputs.rebuild) }}

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -30,6 +30,12 @@ inputs:
     description: If set to true, always push the image to ECR even if it exists.
     required: false
     default: false
+  docker-hub-username:
+    description: An optional username to login to Docker Hub
+    required: false
+  docker-hub-password:
+    description: An optional password to login to Docker Hub
+    required: false
 
 outputs:
   docker-image:
@@ -156,6 +162,13 @@ runs:
         }
 
         retry login "${DOCKER_REGISTRY}"
+
+    - name: Login to Docker Hub
+      if: ${{ inputs.docker-hub-username != '' && inputs.docker-hub-password != '' }}
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.docker-hub-username }}
+        password: ${{ inputs.docker-hub-password }}
 
     - name: Build docker image
       if: ${{ steps.calculate-image.outputs.skip != 'true' && (inputs.always-rebuild || steps.check-image.outputs.rebuild) }}

--- a/torchci/next-env.d.ts
+++ b/torchci/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/torchci/next-env.d.ts
+++ b/torchci/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
This is an attempt to mitigate the rate limit issue we are seeing when pulling the base image from docker.io https://docs.docker.com/docker-hub/download-rate-limit/#rate-limit.

Here is the summary of my support ticket to GitHub about the issue:

1. This behavior is from Docker Hub itself and isn't something GitHub can directly control.  You might consider a paid subscription to Docker Hub which increases the rate limit. You would need to pre-authenticate to Docker Hub on these runners before the job starts as GitHub builds the Docker containers before the first explicit step on the job.
2. Alternatively, we could move the images to https://ghcr.io which does not have such rate limits. 
3. GitHub has an agreement with Docker so that the rate limits do not apply for publicly accessible images downloaded through a GitHub-hosted runner but this does not apply to self-hosted runners.
 
This is basically the first approach.  We could try it out and see if it helps.  The worst thing that could happen is to be rate limited again.

This goes together with https://github.com/pytorch-labs/pytorch-gha-infra/pull/544