### PR TITLE
Set min_runners for linux.2xlarge to 0

### DIFF
--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -96,6 +96,7 @@ runner_types:
   lf.c.linux.2xlarge:
     disk_size: 150
     instance_type: c5.2xlarge
+    min_available: 0
     is_ephemeral: false
     os: linux
     ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -96,6 +96,7 @@ runner_types:
   lf.linux.2xlarge:
     disk_size: 150
     instance_type: c5.2xlarge
+    min_available: 0
     is_ephemeral: false
     os: linux
     ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -92,6 +92,7 @@ runner_types:
   linux.2xlarge:
     disk_size: 150
     instance_type: c5.2xlarge
+    min_available: 0
     is_ephemeral: false
     os: linux
     ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64


### PR DESCRIPTION
This runner type is very actively so is always being spun up an down by the system so should not be necessary to have idle runners of this type sitting around.

Issue: pytorch/pytorch#138476