### PR TITLE
[xpu] Add the torch xpu runtime dependencies pypi packages

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -102,6 +102,17 @@ PACKAGE_ALLOW_LIST = {x.lower() for x in [
     "importlib_metadata",
     "importlib_resources",
     "zipp",
+    # ---- torch xpu additional packages ----
+    "dpcpp-cpp-rt",
+    "intel-cmplr-lib-rt",
+    "intel-cmplr-lib-ur",
+    "intel-cmplr-lic-rt",
+    "intel-opencl-rt",
+    "intel-sycl-rt",
+    "intel-openmp",
+    "tcmlib",
+    "umf",
+    "intel-pti",
     # ----
     "Pillow",
     "certifi",

--- a/s3_management/update_dependencies.py
+++ b/s3_management/update_dependencies.py
@@ -79,7 +79,7 @@ PACKAGES_PER_PROJECT = {
         "xxhash",
         "yarl",
     ]
-    "troch_xpu": [
+    "torch_xpu": [
         "dpcpp-cpp-rt",
         "intel-cmplr-lib-rt",
         "intel-cmplr-lib-ur",

--- a/s3_management/update_dependencies.py
+++ b/s3_management/update_dependencies.py
@@ -79,6 +79,19 @@ PACKAGES_PER_PROJECT = {
         "xxhash",
         "yarl",
     ]
+    "troch_xpu": [
+        "dpcpp-cpp-rt",
+        "intel-cmplr-lib-rt",
+        "intel-cmplr-lib-ur",
+        "intel-cmplr-lic-rt",
+        "intel-opencl-rt",
+        "intel-sycl-rt",
+        "intel-openmp",
+        "tcmlib",
+        "umf",
+        "intel-pti",
+        "tbb",
+    ]
 }
 
 


### PR DESCRIPTION
Add torch xpu runtime dependencies pypi packages into S3 manage
Works for https://github.com/pytorch/pytorch/issues/139722 and https://github.com/pytorch/pytorch/issues/114850