### PR TITLE
[BOT] Add ci-no-td to reland PRs

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -311,11 +311,11 @@ function getLabelsToAddFromPrTitle(
 function getLabelsToAdd(
   title: string,
   labelFilter: RegExp = /.*/,
-  RegexToTableList: [RegExp, string][]
+  regexToLabelList: [RegExp, string][]
 ): string[] {
   const labelsToAdd: string[] = [];
 
-  for (const [regex, label] of RegexToTableList) {
+  for (const [regex, label] of regexToLabelList) {
     if (title.match(regex) && label.match(labelFilter)) {
       labelsToAdd.push(label);
     }

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -15,14 +15,13 @@ import {
 // List of regex patterns for assigning labels to both Pull Requests and Issues
 const IssueAndPRRegexToLabel: [RegExp, string][] = [
   [/rocm/gi, "module: rocm"],
-  [/rocm/gi, "ciflow/rocm"],
   [/vulkan/gi, "module: vulkan"],
-  [/DISABLED\s+test.*\(.*\)/g, "skipped"],
 ];
 
 // List of regex patterns for assigning labels to Pull Requests
 const PrTitleRegexToLabel: [RegExp, string][] = [
   [/reland/gi, "ci-no-td"],
+  [/rocm/gi, "ciflow/rocm"],
   ...IssueAndPRRegexToLabel,
 ];
 
@@ -30,6 +29,7 @@ const PrTitleRegexToLabel: [RegExp, string][] = [
 const IssueTitleRegexToLabel: [RegExp, string][] = [
   [/UNSTABLE\s+.*\s+\/\s+.*/g, "unstable"],
   [/UNSTABLE\s+.*\s+\/\s+.*/g, "module: ci"],
+  [/DISABLED\s+test.*\(.*\)/g, "skipped"],
   ...IssueAndPRRegexToLabel,
 ];
 

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -298,24 +298,24 @@ function getLabelsToAddFromIssueTitle(
   title: string,
   labelFilter: RegExp = /.*/
 ): string[] {
-  const labelsToAdd: string[] = [];
-
-  for (const [regex, label] of IssueTitleRegexToLabel) {
-    if (title.match(regex) && label.match(labelFilter)) {
-      labelsToAdd.push(label);
-    }
-  }
-
-  return labelsToAdd;
+  return getLabelsToAdd(title,labelFilter ,IssueTitleRegexToLabel)
 }
 
 function getLabelsToAddFromPrTitle(
   title: string,
   labelFilter: RegExp = /.*/
 ): string[] {
+  return getLabelsToAdd(title,labelFilter ,PrTitleRegexToLabel)
+}
+
+function getLabelsToAdd(
+  title: string,
+  labelFilter: RegExp = /.*/,
+  RegexToTableList: [RegExp, string][]
+): string[] {
   const labelsToAdd: string[] = [];
 
-  for (const [regex, label] of PrTitleRegexToLabel) {
+  for (const [regex, label] of RegexToTableList) {
     if (title.match(regex) && label.match(labelFilter)) {
       labelsToAdd.push(label);
     }
@@ -323,6 +323,7 @@ function getLabelsToAddFromPrTitle(
 
   return labelsToAdd;
 }
+
 
 // https://github.com/pytorch/pytorch/blob/master/scripts/release_notes/commitlist.py#L90
 function getReleaseNotesCategoryAndTopic(

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -12,10 +12,9 @@ import {
   LabelToLabelConfigTracker,
 } from "./utils";
 
-
 // list of regex to assign labels to pull requests
 const PrTitleRegexToLabel: [RegExp, string][] = [
-  [/reland/gi,"ci-no-td"],
+  [/reland/gi, "ci-no-td"],
   [/rocm/gi, "module: rocm"],
   [/rocm/gi, "ciflow/rocm"],
   [/vulkan/gi, "module: vulkan"],
@@ -299,7 +298,7 @@ function isNotUserFacing(filesChanged: string[]): boolean {
 
 function getLabelsToAddFromIssueTitle(
   title: string,
-  labelFilter: RegExp = /.*/,
+  labelFilter: RegExp = /.*/
 ): string[] {
   const labelsToAdd: string[] = [];
 
@@ -314,7 +313,7 @@ function getLabelsToAddFromIssueTitle(
 
 function getLabelsToAddFromPrTitle(
   title: string,
-  labelFilter: RegExp = /.*/,
+  labelFilter: RegExp = /.*/
 ): string[] {
   const labelsToAdd: string[] = [];
 
@@ -481,7 +480,10 @@ function myBot(app: Probot): void {
     const title = context.payload["issue"]["title"];
     context.log({ existingLabels, title });
 
-    const labelsToAdd = getLabelsToAddFromIssueTitle(title, /^(?!ciflow\/.*).*/);
+    const labelsToAdd = getLabelsToAddFromIssueTitle(
+      title,
+      /^(?!ciflow\/.*).*/
+    );
     await addNewLabels(existingLabels, labelsToAdd, context);
   });
 

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -294,29 +294,22 @@ function isNotUserFacing(filesChanged: string[]): boolean {
   );
 }
 
-function getLabelsToAddFromIssueTitle(
-  title: string,
-  labelFilter: RegExp = /.*/
-): string[] {
-  return getLabelsToAdd(title, labelFilter, IssueTitleRegexToLabel);
+function getLabelsToAddFromIssueTitle(title: string): string[] {
+  return getLabelsToAdd(title, IssueTitleRegexToLabel);
 }
 
-function getLabelsToAddFromPrTitle(
-  title: string,
-  labelFilter: RegExp = /.*/
-): string[] {
-  return getLabelsToAdd(title, labelFilter, PrTitleRegexToLabel);
+function getLabelsToAddFromPrTitle(title: string): string[] {
+  return getLabelsToAdd(title, PrTitleRegexToLabel);
 }
 
 function getLabelsToAdd(
   title: string,
-  labelFilter: RegExp = /.*/,
   regexToLabelList: [RegExp, string][]
 ): string[] {
   const labelsToAdd: string[] = [];
 
   for (const [regex, label] of regexToLabelList) {
-    if (title.match(regex) && label.match(labelFilter)) {
+    if (title.match(regex)) {
       labelsToAdd.push(label);
     }
   }
@@ -478,10 +471,7 @@ function myBot(app: Probot): void {
     const title = context.payload["issue"]["title"];
     context.log({ existingLabels, title });
 
-    const labelsToAdd = getLabelsToAddFromIssueTitle(
-      title,
-      /^(?!ciflow\/.*).*/
-    );
+    const labelsToAdd = getLabelsToAddFromIssueTitle(title);
     await addNewLabels(existingLabels, labelsToAdd, context);
   });
 

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -12,7 +12,7 @@ import {
   LabelToLabelConfigTracker,
 } from "./utils";
 
-// List of Regex Patterns For Assigning Labels to Pull Requests
+// List of regex patterns for assigning labels to Pull Requests
 const PrTitleRegexToLabel: [RegExp, string][] = [
   [/reland/gi, "ci-no-td"],
   [/rocm/gi, "module: rocm"],
@@ -24,7 +24,7 @@ const PrTitleRegexToLabel: [RegExp, string][] = [
   [/UNSTABLE\s+.*\s+\/\s+.*/g, "module: ci"],
 ];
 
-// List of Regex Patterns For Assigning Labels to Issues
+// List of regex patterns for assigning labels to Issues
 const IssueTitleRegexToLabel: [RegExp, string][] = [
   [/rocm/gi, "module: rocm"],
   [/rocm/gi, "ciflow/rocm"],

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -12,7 +12,7 @@ import {
   LabelToLabelConfigTracker,
 } from "./utils";
 
-// List of Regex Patterns for Assigning Labels to Pull Requests
+// List of Regex Patterns For Assigning Labels to Pull Requests
 const PrTitleRegexToLabel: [RegExp, string][] = [
   [/reland/gi, "ci-no-td"],
   [/rocm/gi, "module: rocm"],
@@ -24,7 +24,7 @@ const PrTitleRegexToLabel: [RegExp, string][] = [
   [/UNSTABLE\s+.*\s+\/\s+.*/g, "module: ci"],
 ];
 
-//List of Regex Patterns for Assigning Labels to Issues
+// List of Regex Patterns For Assigning Labels to Issues
 const IssueTitleRegexToLabel: [RegExp, string][] = [
   [/rocm/gi, "module: rocm"],
   [/rocm/gi, "ciflow/rocm"],

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -13,24 +13,24 @@ import {
 } from "./utils";
 
 // List of regex patterns for assigning labels to both Pull Requests and Issues
-const IssueAndPRRegexToLabel:[RegExp, string][] =[
+const IssueAndPRRegexToLabel: [RegExp, string][] = [
   [/rocm/gi, "module: rocm"],
   [/rocm/gi, "ciflow/rocm"],
   [/vulkan/gi, "module: vulkan"],
   [/DISABLED\s+test.*\(.*\)/g, "skipped"],
-]
+];
 
 // List of regex patterns for assigning labels to Pull Requests
 const PrTitleRegexToLabel: [RegExp, string][] = [
   [/reland/gi, "ci-no-td"],
-  ... IssueAndPRRegexToLabel
+  ...IssueAndPRRegexToLabel,
 ];
 
 // List of regex patterns for assigning labels to Issues
 const IssueTitleRegexToLabel: [RegExp, string][] = [
   [/UNSTABLE\s+.*\s+\/\s+.*/g, "unstable"],
   [/UNSTABLE\s+.*\s+\/\s+.*/g, "module: ci"],
-  ... IssueAndPRRegexToLabel
+  ...IssueAndPRRegexToLabel,
 ];
 
 const filenameRegexToReleaseCategory: [RegExp, string][] = [

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -12,7 +12,7 @@ import {
   LabelToLabelConfigTracker,
 } from "./utils";
 
-// list of regex to assign labels to pull requests
+// List of Regex Patterns for Assigning Labels to Pull Requests
 const PrTitleRegexToLabel: [RegExp, string][] = [
   [/reland/gi, "ci-no-td"],
   [/rocm/gi, "module: rocm"],
@@ -24,7 +24,7 @@ const PrTitleRegexToLabel: [RegExp, string][] = [
   [/UNSTABLE\s+.*\s+\/\s+.*/g, "module: ci"],
 ];
 
-// list of regex to assign labels to issues
+//List of Regex Patterns for Assigning Labels to Issues
 const IssueTitleRegexToLabel: [RegExp, string][] = [
   [/rocm/gi, "module: rocm"],
   [/rocm/gi, "ciflow/rocm"],

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -298,14 +298,14 @@ function getLabelsToAddFromIssueTitle(
   title: string,
   labelFilter: RegExp = /.*/
 ): string[] {
-  return getLabelsToAdd(title,labelFilter ,IssueTitleRegexToLabel)
+  return getLabelsToAdd(title, labelFilter, IssueTitleRegexToLabel);
 }
 
 function getLabelsToAddFromPrTitle(
   title: string,
   labelFilter: RegExp = /.*/
 ): string[] {
-  return getLabelsToAdd(title,labelFilter ,PrTitleRegexToLabel)
+  return getLabelsToAdd(title, labelFilter, PrTitleRegexToLabel);
 }
 
 function getLabelsToAdd(
@@ -323,7 +323,6 @@ function getLabelsToAdd(
 
   return labelsToAdd;
 }
-
 
 // https://github.com/pytorch/pytorch/blob/master/scripts/release_notes/commitlist.py#L90
 function getReleaseNotesCategoryAndTopic(

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -12,27 +12,25 @@ import {
   LabelToLabelConfigTracker,
 } from "./utils";
 
-// List of regex patterns for assigning labels to Pull Requests
-const PrTitleRegexToLabel: [RegExp, string][] = [
-  [/reland/gi, "ci-no-td"],
+// List of regex patterns for assigning labels to both Pull Requests and Issues
+const IssueAndPRRegexToLabel:[RegExp, string][] =[
   [/rocm/gi, "module: rocm"],
   [/rocm/gi, "ciflow/rocm"],
   [/vulkan/gi, "module: vulkan"],
-  [/vulkan/gi, "ciflow/periodic"], // Vulkan tests are run periodically
   [/DISABLED\s+test.*\(.*\)/g, "skipped"],
-  [/UNSTABLE\s+.*\s+\/\s+.*/g, "unstable"],
-  [/UNSTABLE\s+.*\s+\/\s+.*/g, "module: ci"],
+]
+
+// List of regex patterns for assigning labels to Pull Requests
+const PrTitleRegexToLabel: [RegExp, string][] = [
+  [/reland/gi, "ci-no-td"],
+  ... IssueAndPRRegexToLabel
 ];
 
 // List of regex patterns for assigning labels to Issues
 const IssueTitleRegexToLabel: [RegExp, string][] = [
-  [/rocm/gi, "module: rocm"],
-  [/rocm/gi, "ciflow/rocm"],
-  [/vulkan/gi, "module: vulkan"],
-  [/vulkan/gi, "ciflow/periodic"], // Vulkan tests are run periodically
-  [/DISABLED\s+test.*\(.*\)/g, "skipped"],
   [/UNSTABLE\s+.*\s+\/\s+.*/g, "unstable"],
   [/UNSTABLE\s+.*\s+\/\s+.*/g, "module: ci"],
+  ... IssueAndPRRegexToLabel
 ];
 
 const filenameRegexToReleaseCategory: [RegExp, string][] = [

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -104,6 +104,80 @@ describe("auto-label-bot", () => {
     scope.done();
   });
 
+
+  test("add ci-no-td label when PR title contains Reland", async () => {
+    nock("https://api.github.com")
+      .post("/app/installations/2/access_tokens")
+      .reply(200, { token: "test" });
+
+    const payload = requireDeepCopy("./fixtures/pull_request.opened")[
+      "payload"
+    ];
+    payload["pull_request"]["title"] = "Failed test [Reland]";
+    payload["pull_request"]["labels"] = [];
+
+    const scope = nock("https://api.github.com")
+      .get("/repos/zhouzhuojie/gha-ci-playground/pulls/31/files?per_page=100")
+      .reply(200)
+      .post("/repos/zhouzhuojie/gha-ci-playground/issues/31/labels", (body) => {
+        expect(body).toMatchObject({ labels: ["ci-no-td"] });
+        return true;
+      }).reply(200)
+    await probot.receive({ name: "pull_request", payload: payload, id: "2" });
+
+    scope.done();
+  });
+
+  test("add ci-no-td label when PR title contains reLanD", async () => {
+    nock("https://api.github.com")
+      .post("/app/installations/2/access_tokens")
+      .reply(200, { token: "test" });
+
+    const payload = requireDeepCopy("./fixtures/pull_request.opened")[
+      "payload"
+    ];
+    payload["pull_request"]["title"] = "Failed test [reLanD]";
+    payload["pull_request"]["labels"] = [];
+
+    const scope = nock("https://api.github.com")
+      .get("/repos/zhouzhuojie/gha-ci-playground/pulls/31/files?per_page=100")
+      .reply(200)
+      .post("/repos/zhouzhuojie/gha-ci-playground/issues/31/labels", (body) => {
+        expect(body).toMatchObject({ labels: ["ci-no-td"] });
+        return true;
+      }).reply(200)
+    await probot.receive({ name: "pull_request", payload: payload, id: "2" });
+
+    scope.done();
+  });
+
+  test("add reland label when issue title contains ROCm", async () => {
+    nock("https://api.github.com")
+      .post("/app/installations/2/access_tokens")
+      .reply(200, { token: "test" });
+
+    const payload = requireDeepCopy("./fixtures/issues.opened");
+    payload["issue"]["title"] = "Issue is Reland";
+    payload["issue"]["labels"] = [{name:"test"}];
+
+    const scope = nock("https://api.github.com")
+      .post(
+        "/repos/ezyang/testing-ideal-computing-machine/issues/5/labels",
+        (body) => {
+          expect(body).toMatchObject({
+            labels: ["ROCm"],
+          });
+          return true;
+        }
+      )
+      .reply(200);
+
+    await probot.receive({ name: "issues", payload: payload, id: "2" });
+
+    // the api never been called.
+    expect(scope.isDone()).toBe(false);
+  });
+
   test("add skipped label when issue title contains DISABLED test", async () => {
     nock("https://api.github.com")
       .post("/app/installations/2/access_tokens")

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -104,7 +104,6 @@ describe("auto-label-bot", () => {
     scope.done();
   });
 
-
   test("add ci-no-td label when PR title contains Reland", async () => {
     nock("https://api.github.com")
       .post("/app/installations/2/access_tokens")
@@ -122,7 +121,8 @@ describe("auto-label-bot", () => {
       .post("/repos/zhouzhuojie/gha-ci-playground/issues/31/labels", (body) => {
         expect(body).toMatchObject({ labels: ["ci-no-td"] });
         return true;
-      }).reply(200)
+      })
+      .reply(200);
     await probot.receive({ name: "pull_request", payload: payload, id: "2" });
 
     scope.done();
@@ -145,7 +145,8 @@ describe("auto-label-bot", () => {
       .post("/repos/zhouzhuojie/gha-ci-playground/issues/31/labels", (body) => {
         expect(body).toMatchObject({ labels: ["ci-no-td"] });
         return true;
-      }).reply(200)
+      })
+      .reply(200);
     await probot.receive({ name: "pull_request", payload: payload, id: "2" });
 
     scope.done();
@@ -158,7 +159,7 @@ describe("auto-label-bot", () => {
 
     const payload = requireDeepCopy("./fixtures/issues.opened");
     payload["issue"]["title"] = "Issue is Reland";
-    payload["issue"]["labels"] = [{name:"test"}];
+    payload["issue"]["labels"] = [{ name: "test" }];
 
     const scope = nock("https://api.github.com")
       .post(

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -136,7 +136,7 @@ describe("auto-label-bot", () => {
     const payload = requireDeepCopy("./fixtures/pull_request.opened")[
       "payload"
     ];
-    payload["pull_request"]["title"] = "Failed test [reLanD]";
+    payload["pull_request"]["title"] = "[reLanD] detect failure";
     payload["pull_request"]["labels"] = [];
 
     const scope = nock("https://api.github.com")

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -128,7 +128,7 @@ describe("auto-label-bot", () => {
     scope.done();
   });
 
-  test("add ci-no-td label when PR title contains reLanD", async () => {
+  test("add ci-no-td label when PR title contains mixed cases reLanD", async () => {
     nock("https://api.github.com")
       .post("/app/installations/2/access_tokens")
       .reply(200, { token: "test" });
@@ -152,13 +152,13 @@ describe("auto-label-bot", () => {
     scope.done();
   });
 
-  test("add reland label when issue title contains ROCm", async () => {
+  test("no reland label added when issue title contains reland", async () => {
     nock("https://api.github.com")
       .post("/app/installations/2/access_tokens")
       .reply(200, { token: "test" });
 
     const payload = requireDeepCopy("./fixtures/issues.opened");
-    payload["issue"]["title"] = "Issue is Reland";
+    payload["issue"]["title"] = "Issue Reland Does not work";
     payload["issue"]["labels"] = [{ name: "test" }];
 
     const scope = nock("https://api.github.com")

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -94,14 +94,13 @@ describe("auto-label-bot", () => {
       .get("/repos/zhouzhuojie/gha-ci-playground/pulls/31/files?per_page=100")
       .reply(200)
       .post("/repos/zhouzhuojie/gha-ci-playground/issues/31/labels", (body) => {
-        expect(body).toMatchObject({ labels: ["ciflow/rocm","module: rocm"] });
+        expect(body).toMatchObject({ labels: ["ciflow/rocm", "module: rocm"] });
         return true;
       })
       .reply(200);
 
     await probot.receive({ name: "pull_request", payload: payload, id: "2" });
 
-    // the api never been called.
     scope.done();
   });
 

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -94,13 +94,14 @@ describe("auto-label-bot", () => {
       .get("/repos/zhouzhuojie/gha-ci-playground/pulls/31/files?per_page=100")
       .reply(200)
       .post("/repos/zhouzhuojie/gha-ci-playground/issues/31/labels", (body) => {
-        expect(body).toMatchObject({ labels: ["module: rocm", "ciflow/rocm"] });
+        expect(body).toMatchObject({ labels: ["ciflow/rocm","module: rocm"] });
         return true;
       })
       .reply(200);
 
     await probot.receive({ name: "pull_request", payload: payload, id: "2" });
 
+    // the api never been called.
     scope.done();
   });
 
@@ -203,7 +204,7 @@ describe("auto-label-bot", () => {
     scope.done();
   });
 
-  test("add skipped label when PR title contains DISABLED test", async () => {
+  test("no skipped label added when PR title contains DISABLED test", async () => {
     nock("https://api.github.com")
       .post("/app/installations/2/access_tokens")
       .reply(200, { token: "test" });
@@ -226,7 +227,8 @@ describe("auto-label-bot", () => {
 
     await probot.receive({ name: "pull_request", payload: payload, id: "2" });
 
-    scope.done();
+    // the api never been called.
+    expect(scope.isDone()).toBe(false);
   });
 
   test("non pytorch/pytorch repo do NOT add any release notes category labels", async () => {


### PR DESCRIPTION
Issue: https://github.com/pytorch/pytorch/issues/139492

# Overview
Add label `ci-no-td` to reland PullRequest.

# Notice
I split the list for pr and issue regex, this makes us to hand labels in different situations.
