### PR TITLE
Update build_wheels_linux.yml - set environment

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -126,6 +126,7 @@ jobs:
       IS_MANYLINUX2_28: ${{ contains(matrix.container_image, '2_28') }}
     name: ${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
+    environment: ${{(inputs.trigger-event == 'schedule' || (inputs.trigger-event == 'push' && (startsWith(github.event.ref, 'refs/heads/nightly') || startsWith(github.event.ref, 'refs/tags/v')))) && 'pytorchbot-env' || ''}}
     container:
       image: ${{ matrix.container_image }}
       options: ${{ matrix.gpu_arch_type == 'cuda' && '--gpus all' || ' ' }}


### PR DESCRIPTION
Set Environment for OIDC upload.
Same as in: https://github.com/pytorch/test-infra/blob/main/.github/workflows/_binary_upload.yml#L47
This should allow us to upload when running under Manylinux1: https://github.com/pytorch/test-infra/blob/main/.github/actions/binary-upload/action.yml#L66