### PR TITLE
Fix perf dashboard querying for individual suite

### DIFF
--- a/torchci/clickhouse_queries/compilers_benchmark_performance/query.sql
+++ b/torchci/clickhouse_queries/compilers_benchmark_performance/query.sql
@@ -94,7 +94,7 @@ results AS (
             WHEN accuracy_results.replaced_filename LIKE '%_torchbench' THEN 'torchbench'
             WHEN accuracy_results.replaced_filename LIKE '%_timm_models' THEN 'timm_models'
             WHEN accuracy_results.replaced_filename LIKE '%_huggingface' THEN 'huggingface'
-            ELSE NULL
+            ELSE ''
         END AS suite,
         CASE
             WHEN accuracy_results.replaced_filename LIKE '%_torchbench' THEN REPLACE(
@@ -112,7 +112,7 @@ results AS (
                 '_huggingface',
                 ''
             )
-            ELSE NULL
+            ELSE ''
         END AS compiler,
         accuracy_results.name,
         IF(speedup != '', toFloat32(speedup), 0.0) AS speedup,
@@ -166,7 +166,10 @@ FROM
     results
     LEFT JOIN default .workflow_run w FINAL ON results.workflow_id = w.id
 WHERE
-    has({suites: Array(String) }, lower(results.suite))
+    (
+        has({suites: Array(String) }, lower(results.suite))
+        OR empty({suites: Array(String) })
+    )
     AND (
         has(
             {compilers: Array(String) },

--- a/torchci/package.json
+++ b/torchci/package.json
@@ -39,7 +39,7 @@
     "axios": "^0.28.0",
     "dayjs": "^1.11.3",
     "dayjs-plugin-utc": "^0.1.2",
-    "echarts": "^5.3.2",
+    "echarts": "^5.5.1",
     "echarts-for-react": "^3.0.2",
     "eslint-plugin-unused-imports": "^3.2.0",
     "jaro-winkler-typescript": "^1.0.1",

--- a/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
+++ b/torchci/pages/benchmark/[suite]/[compiler]/[[...page]].tsx
@@ -274,7 +274,7 @@ export default function Page() {
     mode: mode,
     startTime: dayjs(startTime).utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
     stopTime: dayjs(stopTime).utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
-    suites: [suite],
+    suites: [],
     workflowId: 0,
   };
 

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -257,7 +257,6 @@ export default function Page() {
     suites: Object.keys(SUITES),
     workflowId: 0,
   };
-  console.log("DEBUG");
 
   return (
     <div>

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -257,6 +257,7 @@ export default function Page() {
     suites: Object.keys(SUITES),
     workflowId: 0,
   };
+  console.log(window);
 
   return (
     <div>

--- a/torchci/pages/benchmark/compilers.tsx
+++ b/torchci/pages/benchmark/compilers.tsx
@@ -257,7 +257,7 @@ export default function Page() {
     suites: Object.keys(SUITES),
     workflowId: 0,
   };
-  console.log(window);
+  console.log("DEBUG");
 
   return (
     <div>

--- a/torchci/yarn.lock
+++ b/torchci/yarn.lock
@@ -4183,13 +4183,13 @@ echarts-for-react@^3.0.2:
     fast-deep-equal "^3.1.3"
     size-sensor "^1.0.1"
 
-echarts@^5.3.2:
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/echarts/-/echarts-5.3.2.tgz"
-  integrity sha512-LWCt7ohOKdJqyiBJ0OGBmE9szLdfA9sGcsMEi+GGoc6+Xo75C+BkcT/6NNGRHAWtnQl2fNow05AQjznpap28TQ==
+echarts@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.5.1.tgz#8dc9c68d0c548934bedcb5f633db07ed1dd2101c"
+  integrity sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==
   dependencies:
     tslib "2.3.0"
-    zrender "5.3.1"
+    zrender "5.6.0"
 
 ee-first@1.1.1, ee-first@~1.1.1:
   version "1.1.1"
@@ -8740,9 +8740,9 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zrender@5.3.1:
-  version "5.3.1"
-  resolved "https://registry.npmjs.org/zrender/-/zrender-5.3.1.tgz"
-  integrity sha512-7olqIjy0gWfznKr6vgfnGBk7y4UtdMvdwFmK92vVQsQeDPyzkHW1OlrLEKg6GHz1W5ePf0FeN1q2vkl/HFqhXw==
+zrender@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.6.0.tgz#01325b0bb38332dd5e87a8dbee7336cafc0f4a5b"
+  integrity sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==
   dependencies:
     tslib "2.3.0"


### PR DESCRIPTION
This is reported by @yf225 and @ezyang  that when selecting dynamic or blueberries suites on the perf dashboard, an empty page is returned, for example https://hud.pytorch.org/benchmark/dynamic/inductor_aot_inductor?dashboard=torchinductor&startTime=Fri,%2015%20Nov%202024%2021:57:42%20GMT&stopTime=Fri,%2022%20Nov%202024%2021:57:42%20GMT&granularity=hour&mode=inference&dtype=bfloat16&deviceName=cuda%20(a100)&lBranch=main&lCommit=d65f194ab91055d1a104163dce93d5580fec2d28&rBranch=main&rCommit=2b39a8db7741b816b03677a9c6fec1af05640dee

This is a regression bug coming from https://github.com/pytorch/test-infra/pull/5769 where I set the suite parameter incorrectly:

* Rockset set the default of this parameter to query everything.  The CH query missed that.
* The old code didn't set any suite and relied on the above default behavior.

I also update echarts package to fix the window not defined error when the page is rendered on the server-side.

### Testing

Selecting individual suite is displayed correctly now https://torchci-git-fork-huydhn-fix-dashboard-augmentdata-fbopensource.vercel.app/benchmark/dynamic/inductor_with_cudagraphs_freezing?dashboard=torchinductor&startTime=Fri,%2015%20Nov%202024%2022:02:08%20GMT&stopTime=Fri,%2022%20Nov%202024%2022:02:08%20GMT&granularity=hour&mode=inference&dtype=bfloat16&deviceName=cuda%20(a100)&lBranch=main&lCommit=d65f194ab91055d1a104163dce93d5580fec2d28&rBranch=main&rCommit=2b39a8db7741b816b03677a9c6fec1af05640dee
