### PR TITLE
Set min_runners for linux.4xlarge to 0 (#5958)

### DIFF
--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -103,6 +103,7 @@ runner_types:
   lf.c.linux.4xlarge:
     disk_size: 150
     instance_type: c5.4xlarge
+    min_available: 0
     is_ephemeral: false
     os: linux
     ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -103,6 +103,7 @@ runner_types:
   lf.linux.4xlarge:
     disk_size: 150
     instance_type: c5.4xlarge
+    min_available: 0
     is_ephemeral: false
     os: linux
     ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -99,6 +99,7 @@ runner_types:
   linux.4xlarge:
     disk_size: 150
     instance_type: c5.4xlarge
+    min_available: 0
     is_ephemeral: false
     os: linux
     ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64


### PR DESCRIPTION
This runner type is very actively so is always being spun up an down by the system so should not be necessary to have idle runners of this type sitting around. This uses the new `min-available` feature that was recently added via pytorch/test-infra#5713.

Issue: pytorch/pytorch#138476