### PR TITLE
Allow Nova callers to choose Python version to build

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -238,7 +238,7 @@ jobs:
           set -euxo pipefail
           source "${BUILD_ENV_FILE}"
           export PYTORCH_VERSION="$(${CONDA_RUN} pip show torch | grep ^Version: | sed 's/Version: *//' | sed 's/+.\+//')"
-          ${CONDA_RUN} python -m pip install build
+          ${CONDA_RUN} python -m pip install build==1.2.2
           echo "Successfully installed Python build package"
           ${CONDA_RUN} ${{ inputs.build-command }}
       - name: Build the wheel (setup-py)

--- a/.github/workflows/generate_binary_build_matrix.yml
+++ b/.github/workflows/generate_binary_build_matrix.yml
@@ -47,6 +47,10 @@ on:
         description: "Generate binary build matrix for a python only package (i.e. only one python version)"
         default: "disable"
         type: string
+      python-versions:
+        description: "A JSON-encoded list of python versions to build. An empty list means building all supported versions"
+        default: "[]"
+        type: string
       use_split_build:
         description: |
           [Experimental] Build a libtorch only wheel and build pytorch such that
@@ -93,6 +97,7 @@ jobs:
           USE_ONLY_DL_PYTORCH_ORG: ${{ inputs.use-only-dl-pytorch-org }}
           BUILD_PYTHON_ONLY: ${{ inputs.build-python-only }}
           USE_SPLIT_BUILD: ${{ inputs.use_split_build }}
+          PYTHON_VERSIONS: ${{ inputs.python-versions }}
         run: |
           set -eou pipefail
           MATRIX_BLOB="$(python3 tools/scripts/generate_binary_build_matrix.py)"

--- a/.github/workflows/test_build_wheels_linux_python_versions.yml
+++ b/.github/workflows/test_build_wheels_linux_python_versions.yml
@@ -45,7 +45,6 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      submodules: "true"
       env-var-script: build/packaging/env_var_script_linux.sh
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}

--- a/.github/workflows/test_build_wheels_linux_python_versions.yml
+++ b/.github/workflows/test_build_wheels_linux_python_versions.yml
@@ -45,7 +45,7 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      submodules: true
+      submodules: 'true'
       env-var-script: build/packaging/env_var_script_linux.sh
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}

--- a/.github/workflows/test_build_wheels_linux_python_versions.yml
+++ b/.github/workflows/test_build_wheels_linux_python_versions.yml
@@ -1,0 +1,47 @@
+name: Test Build Linux Wheels on only selected python versions
+
+on:
+  pull_request:
+    paths:
+      - .github/actions/setup-binary-builds/action.yml
+      - .github/workflows/test_build_wheels_linux_python_versions.yml
+      - .github/workflows/build_wheels_linux.yml
+      - .github/workflows/generate_binary_build_matrix.yml
+      - tools/scripts/generate_binary_build_matrix.py
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  generate-matrix:
+    uses: ./.github/workflows/generate_binary_build_matrix.yml
+    with:
+      package-type: wheel
+      os: linux
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      with-cuda: disable
+      with-rocm: disable
+      build-python-only: enable
+      python-versions: '["3.10", "3.11"]'
+  test:
+    needs: generate-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repository: pytorch/torchtune
+            package-name: torchtune
+    uses: ./.github/workflows/build_wheels_linux.yml
+    name: ${{ matrix.repository }}
+    with:
+      repository: ${{ matrix.repository }}
+      ref: nightly
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      package-name: ${{ matrix.package-name }}
+      trigger-event: "${{ github.event_name }}"
+      build-platform: 'python-build-package'

--- a/.github/workflows/test_build_wheels_linux_python_versions.yml
+++ b/.github/workflows/test_build_wheels_linux_python_versions.yml
@@ -45,7 +45,7 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      submodules: 'true'
+      submodules: "true"
       env-var-script: build/packaging/env_var_script_linux.sh
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}

--- a/.github/workflows/test_build_wheels_linux_python_versions.yml
+++ b/.github/workflows/test_build_wheels_linux_python_versions.yml
@@ -32,8 +32,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - repository: pytorch/torchtune
-            package-name: torchtune
+          - repository: pytorch/executorch
+            pre-script: build/packaging/pre_build_script.sh
+            post-script: build/packaging/post_build_script.sh
+            smoke-test-script: build/packaging/smoke_test.py
+            package-name: executorch
     uses: ./.github/workflows/build_wheels_linux.yml
     name: ${{ matrix.repository }}
     with:
@@ -42,6 +45,10 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      submodules: true
+      env-var-script: build/packaging/env_var_script_linux.sh
+      pre-script: ${{ matrix.pre-script }}
+      post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}
-      trigger-event: "${{ github.event_name }}"
-      build-platform: 'python-build-package'
+      smoke-test-script: ${{ matrix.smoke-test-script }}
+      trigger-event: ${{ github.event_name }}

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -425,7 +425,7 @@ def generate_wheels_matrix(
 ) -> List[Dict[str, str]]:
     package_type = "wheel"
 
-    if python_versions is None:
+    if not python_versions:
         # Define default python version
         python_versions = list(PYTHON_ARCHES)
 


### PR DESCRIPTION
This is a simple tweak to add `python-versions` to `.github/workflows/generate_binary_build_matrix.yml` so that Nova caller can narrow down the python version they want to build.  While PyTorch supports all Python versions from 3.9 to 3.13, not all domain libraries can do so.  So, unsupported Python versions always show up on their nightly branches, for example https://hud.pytorch.org/hud/pytorch/executorch/nightly/1?per_page=50&mergeLF=true.

The rest of the changes are lint fixes.

### Testing

* https://github.com/pytorch/test-infra/actions/runs/12019554633
* https://github.com/pytorch/executorch/actions/runs/12019498604