### PR TITLE
[EZ] Use curl --fail to correctly fail the job when the link is invalid

### DIFF
--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -163,6 +163,7 @@ jobs:
           if [[ "${IPA_ARCHIVE}" == http* ]]; then
             IPA_ARCHIVE_OUTPUT="ci.ipa"
 
+            # shellcheck disable=SC2086
             curl ${CURL_PARAMS} "${IPA_ARCHIVE}" -o "${IPA_ARCHIVE_OUTPUT}"
             ls -lah "${IPA_ARCHIVE_OUTPUT}"
           else
@@ -174,6 +175,7 @@ jobs:
           if [[ "${XCTESTRUN_ZIP}" == http* ]]; then
             XCTESTRUN_ZIP_OUTPUT="ci.xctestrun.zip"
 
+            # shellcheck disable=SC2086
             curl ${CURL_PARAMS} "${XCTESTRUN_ZIP}" -o "${XCTESTRUN_ZIP_OUTPUT}"
             ls -lah "${XCTESTRUN_ZIP_OUTPUT}"
           else
@@ -201,6 +203,7 @@ jobs:
           if [[ "${APP_ARCHIVE}" == http* ]]; then
             APP_ARCHIVE_OUTPUT="ci.apk"
 
+            # shellcheck disable=SC2086
             curl ${CURL_PARAMS} "${APP_ARCHIVE}" -o "${APP_ARCHIVE_OUTPUT}"
             ls -lah "${APP_ARCHIVE_OUTPUT}"
           else
@@ -212,6 +215,7 @@ jobs:
           if [[ "${TEST_ARCHIVE}" == http* ]]; then
             TEST_ARCHIVE_OUTPUT="ci.test.apk"
 
+            # shellcheck disable=SC2086
             curl ${CURL_PARAMS} "${TEST_ARCHIVE}" -o "${TEST_ARCHIVE_OUTPUT}"
             ls -lah "${TEST_ARCHIVE_OUTPUT}"
           else
@@ -232,6 +236,7 @@ jobs:
           if [[ "${TEST_SPEC}" == http* ]]; then
             TEST_SPEC_OUTPUT="ci.yml"
 
+            # shellcheck disable=SC2086
             curl ${CURL_PARAMS} "${TEST_SPEC}" -o "${TEST_SPEC_OUTPUT}"
             cat "${TEST_SPEC_OUTPUT}"
           else
@@ -253,6 +258,7 @@ jobs:
             if [[ "${EXTRA_DATA}" == http* ]]; then
               EXTRA_DATA_OUTPUT="extra-data.zip"
 
+              # shellcheck disable=SC2086
               curl ${CURL_PARAMS} "${EXTRA_DATA}" -o "${EXTRA_DATA_OUTPUT}"
               ls -lah "${EXTRA_DATA_OUTPUT}"
             else

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -161,7 +161,7 @@ jobs:
           if [[ "${IPA_ARCHIVE}" == http* ]]; then
             IPA_ARCHIVE_OUTPUT="ci.ipa"
 
-            curl -s "${IPA_ARCHIVE}" -o "${IPA_ARCHIVE_OUTPUT}"
+            curl -s "${IPA_ARCHIVE}" -o "${IPA_ARCHIVE_OUTPUT}" --fail
             ls -lah "${IPA_ARCHIVE_OUTPUT}"
           else
             IPA_ARCHIVE_OUTPUT="${IPA_ARCHIVE}"
@@ -172,7 +172,7 @@ jobs:
           if [[ "${XCTESTRUN_ZIP}" == http* ]]; then
             XCTESTRUN_ZIP_OUTPUT="ci.xctestrun.zip"
 
-            curl -s "${XCTESTRUN_ZIP}" -o "${XCTESTRUN_ZIP_OUTPUT}"
+            curl -s "${XCTESTRUN_ZIP}" -o "${XCTESTRUN_ZIP_OUTPUT}" --fail
             ls -lah "${XCTESTRUN_ZIP_OUTPUT}"
           else
             XCTESTRUN_ZIP_OUTPUT="${XCTESTRUN_ZIP}"
@@ -199,7 +199,7 @@ jobs:
           if [[ "${APP_ARCHIVE}" == http* ]]; then
             APP_ARCHIVE_OUTPUT="ci.apk"
 
-            curl -s "${APP_ARCHIVE}" -o "${APP_ARCHIVE_OUTPUT}"
+            curl -s "${APP_ARCHIVE}" -o "${APP_ARCHIVE_OUTPUT}" --fail
             ls -lah "${APP_ARCHIVE_OUTPUT}"
           else
             APP_ARCHIVE_OUTPUT="${APP_ARCHIVE}"
@@ -210,7 +210,7 @@ jobs:
           if [[ "${TEST_ARCHIVE}" == http* ]]; then
             TEST_ARCHIVE_OUTPUT="ci.test.apk"
 
-            curl -s "${TEST_ARCHIVE}" -o "${TEST_ARCHIVE_OUTPUT}"
+            curl -s "${TEST_ARCHIVE}" -o "${TEST_ARCHIVE_OUTPUT}" --fail
             ls -lah "${TEST_ARCHIVE_OUTPUT}"
           else
             TEST_ARCHIVE_OUTPUT="${TEST_ARCHIVE}"
@@ -230,7 +230,7 @@ jobs:
           if [[ "${TEST_SPEC}" == http* ]]; then
             TEST_SPEC_OUTPUT="ci.yml"
 
-            curl -s "${TEST_SPEC}" -o "${TEST_SPEC_OUTPUT}"
+            curl -s "${TEST_SPEC}" -o "${TEST_SPEC_OUTPUT}" --fail
             cat "${TEST_SPEC_OUTPUT}"
           else
             TEST_SPEC_OUTPUT="${TEST_SPEC}"
@@ -251,7 +251,7 @@ jobs:
             if [[ "${EXTRA_DATA}" == http* ]]; then
               EXTRA_DATA_OUTPUT="extra-data.zip"
 
-              curl -s "${EXTRA_DATA}" -o "${EXTRA_DATA_OUTPUT}"
+              curl -s "${EXTRA_DATA}" -o "${EXTRA_DATA_OUTPUT}" --fail
               ls -lah "${EXTRA_DATA_OUTPUT}"
             else
               EXTRA_DATA_OUTPUT="${EXTRA_DATA}"

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -108,6 +108,8 @@ jobs:
       contents: read
     outputs:
       artifacts: ${{ inputs.device-type == 'ios' && steps.ios-test.outputs.artifacts || inputs.device-type == 'android' && steps.android-test.outputs.artifacts || '[]' }}
+    env:
+      CURL_PARAMS: -s --fail
     steps:
       - name: Clean workspace
         run: |
@@ -161,7 +163,7 @@ jobs:
           if [[ "${IPA_ARCHIVE}" == http* ]]; then
             IPA_ARCHIVE_OUTPUT="ci.ipa"
 
-            curl -s "${IPA_ARCHIVE}" -o "${IPA_ARCHIVE_OUTPUT}" --fail
+            curl ${CURL_PARAMS} "${IPA_ARCHIVE}" -o "${IPA_ARCHIVE_OUTPUT}"
             ls -lah "${IPA_ARCHIVE_OUTPUT}"
           else
             IPA_ARCHIVE_OUTPUT="${IPA_ARCHIVE}"
@@ -172,7 +174,7 @@ jobs:
           if [[ "${XCTESTRUN_ZIP}" == http* ]]; then
             XCTESTRUN_ZIP_OUTPUT="ci.xctestrun.zip"
 
-            curl -s "${XCTESTRUN_ZIP}" -o "${XCTESTRUN_ZIP_OUTPUT}" --fail
+            curl ${CURL_PARAMS} "${XCTESTRUN_ZIP}" -o "${XCTESTRUN_ZIP_OUTPUT}"
             ls -lah "${XCTESTRUN_ZIP_OUTPUT}"
           else
             XCTESTRUN_ZIP_OUTPUT="${XCTESTRUN_ZIP}"
@@ -199,7 +201,7 @@ jobs:
           if [[ "${APP_ARCHIVE}" == http* ]]; then
             APP_ARCHIVE_OUTPUT="ci.apk"
 
-            curl -s "${APP_ARCHIVE}" -o "${APP_ARCHIVE_OUTPUT}" --fail
+            curl ${CURL_PARAMS} "${APP_ARCHIVE}" -o "${APP_ARCHIVE_OUTPUT}"
             ls -lah "${APP_ARCHIVE_OUTPUT}"
           else
             APP_ARCHIVE_OUTPUT="${APP_ARCHIVE}"
@@ -210,7 +212,7 @@ jobs:
           if [[ "${TEST_ARCHIVE}" == http* ]]; then
             TEST_ARCHIVE_OUTPUT="ci.test.apk"
 
-            curl -s "${TEST_ARCHIVE}" -o "${TEST_ARCHIVE_OUTPUT}" --fail
+            curl ${CURL_PARAMS} "${TEST_ARCHIVE}" -o "${TEST_ARCHIVE_OUTPUT}"
             ls -lah "${TEST_ARCHIVE_OUTPUT}"
           else
             TEST_ARCHIVE_OUTPUT="${TEST_ARCHIVE}"
@@ -230,7 +232,7 @@ jobs:
           if [[ "${TEST_SPEC}" == http* ]]; then
             TEST_SPEC_OUTPUT="ci.yml"
 
-            curl -s "${TEST_SPEC}" -o "${TEST_SPEC_OUTPUT}" --fail
+            curl ${CURL_PARAMS} "${TEST_SPEC}" -o "${TEST_SPEC_OUTPUT}"
             cat "${TEST_SPEC_OUTPUT}"
           else
             TEST_SPEC_OUTPUT="${TEST_SPEC}"
@@ -251,7 +253,7 @@ jobs:
             if [[ "${EXTRA_DATA}" == http* ]]; then
               EXTRA_DATA_OUTPUT="extra-data.zip"
 
-              curl -s "${EXTRA_DATA}" -o "${EXTRA_DATA_OUTPUT}" --fail
+              curl ${CURL_PARAMS} "${EXTRA_DATA}" -o "${EXTRA_DATA_OUTPUT}"
               ls -lah "${EXTRA_DATA_OUTPUT}"
             else
               EXTRA_DATA_OUTPUT="${EXTRA_DATA}"


### PR DESCRIPTION
As the job downloads the link and store the content in a file before continuing, it makes sense to fail it when the link is invalid, i.e. https://gha-artifacts.s3.amazonaws.com/pytorch/executorch/12021308640/artifacts/stories110M_xnnpack/model.zip.  Otherwise, the subsequent test step would fail anyway, but we waste sometimes spinning up those mobile devices