### PR TITLE
Update get-workflow-job-id to use relative path to its script

### DIFF
--- a/.github/actions/get-workflow-job-id/action.yml
+++ b/.github/actions/get-workflow-job-id/action.yml
@@ -28,6 +28,6 @@ runs:
       run: |
         set -eux
 
-        python3 .github/scripts/get_workflow_job_id.py "${GITHUB_RUN_ID}" "${RUNNER_NAME}"
+        python3 "${GITHUB_ACTION_PATH}/../../scripts/get_workflow_job_id.py" "${GITHUB_RUN_ID}" "${RUNNER_NAME}"
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/.github/actions/upload-benchmark-results/action.yml
+++ b/.github/actions/upload-benchmark-results/action.yml
@@ -37,7 +37,8 @@ runs:
     - name: Get workflow job id
       if: ${{ inputs.github-token != '' }}
       id: get-job-id
-      uses: pytorch/test-infra/.github/actions/get-workflow-job-id@main
+      # TESTING: TO BE REVERTED BEFORE LANDING
+      uses: pytorch/test-infra/.github/actions/get-workflow-job-id@fix-get-job-id
       with:
         github-token: ${{ inputs.github-token }}
 

--- a/.github/actions/upload-benchmark-results/action.yml
+++ b/.github/actions/upload-benchmark-results/action.yml
@@ -37,8 +37,7 @@ runs:
     - name: Get workflow job id
       if: ${{ inputs.github-token != '' }}
       id: get-job-id
-      # TESTING: TO BE REVERTED BEFORE LANDING
-      uses: pytorch/test-infra/.github/actions/get-workflow-job-id@fix-get-job-id
+      uses: pytorch/test-infra/.github/actions/get-workflow-job-id@main
       with:
         github-token: ${{ inputs.github-token }}
 


### PR DESCRIPTION
It's a silly mistake and I should have used the relative path to the `get_workflow_job_id.py` script here.  Otherwise, this GH action will fail, for example https://github.com/pytorch/executorch/actions/runs/12060055309/job/33630870653.

It works in PyTorch because there is a script with the same name there.  I have done a similar fix before in https://github.com/pytorch/test-infra/blob/main/.github/actions/upload-benchmark-results/action.yml#L59