### PR TITLE
Pass submodules option to custom checkout

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -70,6 +70,7 @@ runs:
         with:
           repository: ${{ inputs.repository }}
           path: ${{ inputs.repository }}
+          submodules: ${{ inputs.submodules }}
           ref: ${{ inputs.ref }}
 
       - name: Log Available Webhook Fields

--- a/.github/workflows/test_build_wheels_linux_python_versions.yml
+++ b/.github/workflows/test_build_wheels_linux_python_versions.yml
@@ -41,10 +41,11 @@ jobs:
     name: ${{ matrix.repository }}
     with:
       repository: ${{ matrix.repository }}
-      ref: nightly
+      ref: ""
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      submodules: true
       env-var-script: build/packaging/env_var_script_linux.sh
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}

--- a/.github/workflows/test_build_wheels_linux_python_versions.yml
+++ b/.github/workflows/test_build_wheels_linux_python_versions.yml
@@ -41,11 +41,11 @@ jobs:
     name: ${{ matrix.repository }}
     with:
       repository: ${{ matrix.repository }}
-      ref: ""
+      ref: main
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      submodules: true
+      submodules: recursive
       env-var-script: build/packaging/env_var_script_linux.sh
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}


### PR DESCRIPTION
Without this option, all the submodule won't be initialized correctly, which leads to build failures like https://github.com/pytorch/executorch/actions/runs/12084054206/job/33698428919