### PR TITLE
Revert min-available from AMX runners

### DIFF
--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -35,7 +35,6 @@ runner_types:
   lf.c.linux.8xlarge.amx:
     disk_size: 200
     instance_type: m7i-flex.8xlarge
-    min_available: 0
     is_ephemeral: false
     os: linux
     ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -35,7 +35,6 @@ runner_types:
   lf.linux.8xlarge.amx:
     disk_size: 200
     instance_type: m7i-flex.8xlarge
-    min_available: 0
     is_ephemeral: false
     os: linux
     ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -31,7 +31,6 @@ runner_types:
   linux.8xlarge.amx:
     disk_size: 200
     instance_type: m7i-flex.8xlarge
-    min_available: 0
     is_ephemeral: false
     os: linux
     ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64


### PR DESCRIPTION
This was added when we added the m7i-flex.8xlarge instance type via #5874