### PR TITLE
Update generate_binary_build_matrix.py - Restore CUDA 12.1 wheel image

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -149,6 +149,7 @@ def initialize_globals(channel: str, build_python_only: bool) -> None:
         PYTHON_ARCHES = PYTHON_ARCHES_DICT[channel]
     WHEEL_CONTAINER_IMAGES = {
        "11.8": "pytorch/manylinux-builder:cuda11.8",
+       "12.1": "pytorch/manylinux-builder:cuda12.1",
        "12.4": "pytorch/manylinux-builder:cuda12.4",
        "12.6": "pytorch/manylinux2_28-builder:cuda12.6",
         **{


### PR DESCRIPTION
Fix issue with torchao release: https://github.com/pytorch/ao/actions/runs/12123438304/job/33798926358
