### PR TITLE
Add rule to handle missing docs for a new module

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -311,4 +311,4 @@ pattern = '^##\[error\](.*)'
 
 [[rule]]
 name = 'New modules are not documented correctly'
-pattern = 'You added the following module(s) to the PyTorch namespace .* but they'
+pattern = 'You added the following module\(s\) to the PyTorch namespace .* but they'

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -308,3 +308,7 @@ pattern = '^Mergeability Error: .*'
 [[rule]]
 name = 'GHA error'
 pattern = '^##\[error\](.*)'
+
+[[rule]]
+name = 'New modules are not documented correctly'
+pattern = 'You added the following module(s) to the PyTorch namespace .* but they'


### PR DESCRIPTION
Mitigates https://github.com/pytorch/test-infra/issues/5975

A better (but more involved) fix will be to update the AI part of log classifier to better notice that this line was the real failure