### PR TITLE
Fix wrong query parameters to TorchInductor summary charts

### DIFF
--- a/torchci/components/benchmark/compilers/SummaryGraphPanel.tsx
+++ b/torchci/components/benchmark/compilers/SummaryGraphPanel.tsx
@@ -73,9 +73,9 @@ function SuiteGraphPanel({
   const queryCollection = "inductor";
 
   const queryParamsWithSuite: { [key: string]: any } = {
+    ...queryParams,
     branches: [branch],
     suites: [suite],
-    ...queryParams,
   };
   // NB: Querying data for all the suites blows up the response from the database
   // over the lambda reponse body limit of 6MB. So I need to split up the query


### PR DESCRIPTION
Discovered by @yangw-dev.  The default list of suites overwrote the selected value on https://hud.pytorch.org/benchmark/compilers, so the charts weren't updated even when a different suite was selected.


### Testing

https://torchci-git-fork-huydhn-fix-wrong-params-su-ebff9e-fbopensource.vercel.app/benchmark/compilers