### PR TITLE
Fix binary upload logic after #5983

### DIFF
--- a/.github/workflows/_binary_upload.yml
+++ b/.github/workflows/_binary_upload.yml
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: 30
     name: ${{ matrix.build_name }}
     env:
-      IS_MANYLINUX2_28: ${{ contains(matrix.container_image, '2_28') || contains(matrix.container_image, 'manylinuxaarch64-builder:cuda') }}
+      DO_UPLOAD: ${{ contains(matrix.validation_runner, 'windows') || contains(matrix.validation_runner, 'macos') || contains(matrix.container_image, '2_28') || contains(matrix.container_image, 'manylinuxaarch64-builder:cuda') }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -72,7 +72,7 @@ jobs:
           upload-to-base-bucket: ${{ matrix.upload_to_base_bucket }}
 
       - name: Download the artifact
-        if: ${{ env.IS_MANYLINUX2_28 == 'true' }}
+        if: ${{ env.DO_UPLOAD == 'true' }}
         uses: actions/download-artifact@v3
         with:
           name: ${{ env.ARTIFACT_NAME }}
@@ -100,7 +100,7 @@ jobs:
           echo "NIGHTLY_OR_TEST=1" >> "${GITHUB_ENV}"
 
       - name: Upload package to pytorch.org
-        if: ${{ env.IS_MANYLINUX2_28 == 'true' }}
+        if: ${{ env.DO_UPLOAD == 'true' }}
         shell: bash
         working-directory: ${{ inputs.repository }}
         run: |
@@ -121,7 +121,7 @@ jobs:
           done
 
       - name: Upload package to pypi
-        if: ${{ env.IS_MANYLINUX2_28 == 'true' && env.NIGHTLY_OR_TEST == '1' && contains(inputs.upload-to-pypi, matrix.desired_cuda) }}
+        if: ${{ env.DO_UPLOAD == 'true' && env.NIGHTLY_OR_TEST == '1' && contains(inputs.upload-to-pypi, matrix.desired_cuda) }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__


### PR DESCRIPTION
The PR https://github.com/pytorch/test-infra/pull/5983 fixed binary upload for Linux job, however MacOS and Windows needs to be added to the fix as well.