### PR TITLE
Wait for docker build

### DIFF
--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -122,7 +122,7 @@ runs:
         shell: bash
         timeout_minutes: 90
         max_attempts: 3
-        # NB: Wait for half an hour before retrying, this is used as a polling mechanism to wait
+        # NB: Wait for half an hour before retrying, this is used as a pooling mechanism to wait
         # for the docker build workflow to finish
         retry_wait_seconds: 1800
         command: |

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -106,7 +106,7 @@ runs:
 
     - name: Check if image exists and build it if it doesnt
       id: check-and-build-image
-      if: ${{ steps.calculate-image.outputs.skip != 'true' && inputs.always-rebuild }}
+      if: ${{ steps.calculate-image.outputs.skip != 'true' }}
       env:
         REPO_NAME: ${{ github.event.repository.name }}
         BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
@@ -115,6 +115,7 @@ runs:
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
         DOCKER_TAG: ${{ steps.calculate-image.outputs.docker-tag }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
+        ALWAYS_REBUILD: ${{ inputs.always-rebuild }}
       # NB: Retry here as this step frequently fails with network error downloading various stuffs
       uses: nick-fields/retry@v3.0.0
       with:
@@ -143,42 +144,50 @@ runs:
             exit 0
           }
 
-          pushd "${WORKING_DIRECTORY}"
+          check_if_image_exists_and_build_it_if_not() {
+            pushd "${WORKING_DIRECTORY}"
 
-          # Check if image already exists, if it does then skip building it
-          if docker manifest inspect "${DOCKER_IMAGE}"; then
-            exit 0
-          fi
+            # Check if image already exists, if it does then skip building it
+            if docker manifest inspect "${DOCKER_IMAGE}"; then
+              exit 0
+            fi
 
-          # NB: This part requires a full checkout. Otherwise, the merge base will
-          # be empty.  The default action would be to continue rebuild the image
-          if [[ "$BASE_REVISION" = "$(git rev-parse HEAD)" ]]; then
-            # if we're on the base branch then use the parent commit
-            MERGE_BASE=$(git rev-parse HEAD~)
-          else
-            # otherwise we're on a PR, so use the most recent base commit
-            MERGE_BASE=$(git merge-base HEAD "$BASE_REVISION")
-          fi
+            # NB: This part requires a full checkout. Otherwise, the merge base will
+            # be empty.  The default action would be to continue rebuild the image
+            if [[ "$BASE_REVISION" = "$(git rev-parse HEAD)" ]]; then
+              # if we're on the base branch then use the parent commit
+              MERGE_BASE=$(git rev-parse HEAD~)
+            else
+              # otherwise we're on a PR, so use the most recent base commit
+              MERGE_BASE=$(git merge-base HEAD "$BASE_REVISION")
+            fi
 
-          if [[ -z "${MERGE_BASE}" ]]; then
-            echo "Finding merge base only works with full checkout, please set fetch-depth to 0, continuing ..."
+            if [[ -z "${MERGE_BASE}" ]]; then
+              echo "Finding merge base only works with full checkout, please set fetch-depth to 0, continuing ..."
+              build_image
+            fi
+
+            if ! git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}"; then
+              echo "Directory '${DOCKER_BUILD_DIR}' not found in commit $MERGE_BASE, you should rebase onto a more recent commit"
+              exit 1
+            fi
+
+            PREVIOUS_DOCKER_TAG=$(git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}")
+            # If no image exists but the hash is the same as the previous hash then we should error out here
+            if [[ "${PREVIOUS_DOCKER_TAG}" == "${DOCKER_TAG}" ]]; then
+              echo "WARNING: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
+              echo "         Will re-build docker image to store in local cache, TTS may be longer"
+            fi
             build_image
-          fi
 
-          if ! git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}"; then
-            echo "Directory '${DOCKER_BUILD_DIR}' not found in commit $MERGE_BASE, you should rebase onto a more recent commit"
-            exit 1
-          fi
+            popd
+          }
 
-          PREVIOUS_DOCKER_TAG=$(git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}")
-          # If no image exists but the hash is the same as the previous hash then we should error out here
-          if [[ "${PREVIOUS_DOCKER_TAG}" == "${DOCKER_TAG}" ]]; then
-            echo "WARNING: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
-            echo "         Will re-build docker image to store in local cache, TTS may be longer"
+          if [ "${ALWAYS_REBUILD:-false}" == "true" ]; then
+            build_image
+          else
+            check_if_image_exists_and_build_it_if_not
           fi
-          build_image
-
-          popd
 
     - name: Push to ECR
       if: ${{ steps.calculate-image.outputs.skip != 'true' && (inputs.always-rebuild || steps.check-and-build-image.outputs.rebuild) }}

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -122,7 +122,7 @@ runs:
         shell: bash
         timeout_minutes: 90
         max_attempts: 3
-        # NB: Wait for half an hour before retrying, this is used as a pooling mechanism to wait
+        # NB: Wait for half an hour before retrying, this is used as a polling mechanism to wait
         # for the docker build workflow to finish
         retry_wait_seconds: 1800
         command: |

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -76,67 +76,6 @@ runs:
           echo "docker-image=${DOCKER_REGISTRY}/${REPO_NAME}/${DOCKER_IMAGE_NAME}:${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
         fi
 
-    - name: Check if image should be built
-      id: check-image
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-      if: ${{ steps.calculate-image.outputs.skip != 'true' && !inputs.always-rebuild }}
-      env:
-        DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
-        BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
-        DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
-        DOCKER_TAG: ${{ steps.calculate-image.outputs.docker-tag }}
-        DOCKER_REGISTRY: ${{ inputs.docker-registry }}
-      run: |
-        set +e
-        set -x
-
-        login() {
-          aws ecr get-login-password --region us-east-1 | docker login -u AWS --password-stdin "$1"
-        }
-
-        retry () {
-          $*  || (sleep 1 && $*) || (sleep 2 && $*)
-        }
-
-        retry login "${DOCKER_REGISTRY}"
-
-        # Check if image already exists, if it does then skip building it
-        if docker manifest inspect "${DOCKER_IMAGE}"; then
-          exit 0
-        fi
-
-        # NB: This part requires a full checkout. Otherwise, the merge base will
-        # be empty.  The default action would be to continue rebuild the image
-        if [[ "$BASE_REVISION" = "$(git rev-parse HEAD)" ]]; then
-          # if we're on the base branch then use the parent commit
-          MERGE_BASE=$(git rev-parse HEAD~)
-        else
-          # otherwise we're on a PR, so use the most recent base commit
-          MERGE_BASE=$(git merge-base HEAD "$BASE_REVISION")
-        fi
-
-        if [[ -z "${MERGE_BASE}" ]]; then
-          echo "rebuild=true" >> "${GITHUB_OUTPUT}"
-
-          echo "Finding merge base only works with full checkout, please set fetch-depth to 0, continuing ..."
-          exit 0
-        fi
-
-        if ! git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}"; then
-          echo "Directory '${DOCKER_BUILD_DIR}' not found in commit $MERGE_BASE, you should rebase onto a more recent commit"
-          exit 1
-        fi
-
-        PREVIOUS_DOCKER_TAG=$(git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}")
-        # If no image exists but the hash is the same as the previous hash then we should error out here
-        if [[ "${PREVIOUS_DOCKER_TAG}" == "${DOCKER_TAG}" ]]; then
-          echo "WARNING: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
-          echo "         Will re-build docker image to store in local cache, TTS may be longer"
-        fi
-
-        echo "rebuild=true" >> "${GITHUB_OUTPUT}"
-
     - name: Login to ECR
       if: ${{ steps.calculate-image.outputs.skip != 'true' && (inputs.always-rebuild || steps.check-image.outputs.rebuild) }}
       shell: bash
@@ -165,34 +104,84 @@ runs:
         set -eux
         aws secretsmanager get-secret-value --secret-id docker_hub_readonly_token | jq --raw-output '.SecretString' | jq -r .docker_hub_readonly_token | docker login --username pytorchbot --password-stdin
 
-    - name: Build docker image
-      if: ${{ steps.calculate-image.outputs.skip != 'true' && (inputs.always-rebuild || steps.check-image.outputs.rebuild) }}
+    - name: Check if image exists and build it if it doesnt
+      id: check-and-build-image
+      if: ${{ steps.calculate-image.outputs.skip != 'true' && inputs.always-rebuild }}
       env:
         REPO_NAME: ${{ github.event.repository.name }}
+        BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
+        DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
+        DOCKER_TAG: ${{ steps.calculate-image.outputs.docker-tag }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
-        WORKING_DIRECTORY: ${{ inputs.working-directory }}/${{ inputs.docker-build-dir }}
       # NB: Retry here as this step frequently fails with network error downloading various stuffs
       uses: nick-fields/retry@v3.0.0
       with:
         shell: bash
         timeout_minutes: 90
         max_attempts: 3
-        retry_wait_seconds: 90
+        # NB: Wait for half an hour before retrying, this is used as a pooling mechanism to wait
+        # for the docker build workflow to finish
+        retry_wait_seconds: 1800
         command: |
           set -ex
 
-          # NB: Setting working directory on the step doesn't work with nick-fields/retry https://github.com/nick-fields/retry/issues/89
+          build_image() {
+            # NB: Setting working directory on the step doesn't work with nick-fields/retry https://github.com/nick-fields/retry/issues/89
+            pushd "${WORKING_DIRECTORY}/${DOCKER_BUILD_DIR}"
+
+            IMAGE_NAME=$(echo ${DOCKER_IMAGE#"${DOCKER_REGISTRY}/${REPO_NAME}/"} | awk -F '[:,]' '{print $1}')
+            # Build new image
+            ./build.sh "${IMAGE_NAME}" -t "${DOCKER_IMAGE}"
+
+            popd
+
+            echo "rebuild=true" >> "${GITHUB_OUTPUT}"
+            # Reaching this part means that the image has been built successfully
+            # so we can just exit from here
+            exit 0
+          }
+
           pushd "${WORKING_DIRECTORY}"
 
-          IMAGE_NAME=$(echo ${DOCKER_IMAGE#"${DOCKER_REGISTRY}/${REPO_NAME}/"} | awk -F '[:,]' '{print $1}')
-          # Build new image
-          ./build.sh "${IMAGE_NAME}" -t "${DOCKER_IMAGE}"
+          # Check if image already exists, if it does then skip building it
+          if docker manifest inspect "${DOCKER_IMAGE}"; then
+            exit 0
+          fi
+
+          # NB: This part requires a full checkout. Otherwise, the merge base will
+          # be empty.  The default action would be to continue rebuild the image
+          if [[ "$BASE_REVISION" = "$(git rev-parse HEAD)" ]]; then
+            # if we're on the base branch then use the parent commit
+            MERGE_BASE=$(git rev-parse HEAD~)
+          else
+            # otherwise we're on a PR, so use the most recent base commit
+            MERGE_BASE=$(git merge-base HEAD "$BASE_REVISION")
+          fi
+
+          if [[ -z "${MERGE_BASE}" ]]; then
+            echo "Finding merge base only works with full checkout, please set fetch-depth to 0, continuing ..."
+            build_image
+          fi
+
+          if ! git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}"; then
+            echo "Directory '${DOCKER_BUILD_DIR}' not found in commit $MERGE_BASE, you should rebase onto a more recent commit"
+            exit 1
+          fi
+
+          PREVIOUS_DOCKER_TAG=$(git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}")
+          # If no image exists but the hash is the same as the previous hash then we should error out here
+          if [[ "${PREVIOUS_DOCKER_TAG}" == "${DOCKER_TAG}" ]]; then
+            echo "WARNING: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
+            echo "         Will re-build docker image to store in local cache, TTS may be longer"
+          fi
+          build_image
 
           popd
 
     - name: Push to ECR
-      if: ${{ steps.calculate-image.outputs.skip != 'true' && (inputs.always-rebuild || steps.check-image.outputs.rebuild) }}
+      if: ${{ steps.calculate-image.outputs.skip != 'true' && (inputs.always-rebuild || steps.check-and-build-image.outputs.rebuild) }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}/${{ inputs.docker-build-dir }}
       env:

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -106,7 +106,7 @@ runs:
 
     - name: Check if image exists and build it if it doesnt
       id: check-and-build-image
-      if: ${{ steps.calculate-image.outputs.skip != 'true' }}
+      if: ${{ steps.calculate-image.outputs.skip != 'true' && inputs.always-rebuild }}
       env:
         REPO_NAME: ${{ github.event.repository.name }}
         BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
@@ -115,7 +115,6 @@ runs:
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
         DOCKER_TAG: ${{ steps.calculate-image.outputs.docker-tag }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
-        ALWAYS_REBUILD: ${{ inputs.always-rebuild }}
       # NB: Retry here as this step frequently fails with network error downloading various stuffs
       uses: nick-fields/retry@v3.0.0
       with:
@@ -144,50 +143,42 @@ runs:
             exit 0
           }
 
-          check_if_image_exists_and_build_it_if_not() {
-            pushd "${WORKING_DIRECTORY}"
+          pushd "${WORKING_DIRECTORY}"
 
-            # Check if image already exists, if it does then skip building it
-            if docker manifest inspect "${DOCKER_IMAGE}"; then
-              exit 0
-            fi
-
-            # NB: This part requires a full checkout. Otherwise, the merge base will
-            # be empty.  The default action would be to continue rebuild the image
-            if [[ "$BASE_REVISION" = "$(git rev-parse HEAD)" ]]; then
-              # if we're on the base branch then use the parent commit
-              MERGE_BASE=$(git rev-parse HEAD~)
-            else
-              # otherwise we're on a PR, so use the most recent base commit
-              MERGE_BASE=$(git merge-base HEAD "$BASE_REVISION")
-            fi
-
-            if [[ -z "${MERGE_BASE}" ]]; then
-              echo "Finding merge base only works with full checkout, please set fetch-depth to 0, continuing ..."
-              build_image
-            fi
-
-            if ! git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}"; then
-              echo "Directory '${DOCKER_BUILD_DIR}' not found in commit $MERGE_BASE, you should rebase onto a more recent commit"
-              exit 1
-            fi
-
-            PREVIOUS_DOCKER_TAG=$(git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}")
-            # If no image exists but the hash is the same as the previous hash then we should error out here
-            if [[ "${PREVIOUS_DOCKER_TAG}" == "${DOCKER_TAG}" ]]; then
-              echo "WARNING: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
-              echo "         Will re-build docker image to store in local cache, TTS may be longer"
-            fi
-            build_image
-
-            popd
-          }
-
-          if [ "${ALWAYS_REBUILD:-false}" == "true" ]; then
-            build_image
-          else
-            check_if_image_exists_and_build_it_if_not
+          # Check if image already exists, if it does then skip building it
+          if docker manifest inspect "${DOCKER_IMAGE}"; then
+            exit 0
           fi
+
+          # NB: This part requires a full checkout. Otherwise, the merge base will
+          # be empty.  The default action would be to continue rebuild the image
+          if [[ "$BASE_REVISION" = "$(git rev-parse HEAD)" ]]; then
+            # if we're on the base branch then use the parent commit
+            MERGE_BASE=$(git rev-parse HEAD~)
+          else
+            # otherwise we're on a PR, so use the most recent base commit
+            MERGE_BASE=$(git merge-base HEAD "$BASE_REVISION")
+          fi
+
+          if [[ -z "${MERGE_BASE}" ]]; then
+            echo "Finding merge base only works with full checkout, please set fetch-depth to 0, continuing ..."
+            build_image
+          fi
+
+          if ! git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}"; then
+            echo "Directory '${DOCKER_BUILD_DIR}' not found in commit $MERGE_BASE, you should rebase onto a more recent commit"
+            exit 1
+          fi
+
+          PREVIOUS_DOCKER_TAG=$(git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}")
+          # If no image exists but the hash is the same as the previous hash then we should error out here
+          if [[ "${PREVIOUS_DOCKER_TAG}" == "${DOCKER_TAG}" ]]; then
+            echo "WARNING: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
+            echo "         Will re-build docker image to store in local cache, TTS may be longer"
+          fi
+          build_image
+
+          popd
 
     - name: Push to ECR
       if: ${{ steps.calculate-image.outputs.skip != 'true' && (inputs.always-rebuild || steps.check-and-build-image.outputs.rebuild) }}

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -87,6 +87,7 @@ runs:
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
         DOCKER_TAG: ${{ steps.calculate-image.outputs.docker-tag }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
+        DOCKER_PUSH: ${{ inputs.push }}
       run: |
         set +e
         set -x
@@ -101,10 +102,26 @@ runs:
 
         retry login "${DOCKER_REGISTRY}"
 
-        # Check if image already exists, if it does then skip building it
-        if docker manifest inspect "${DOCKER_IMAGE}"; then
-          exit 0
-        fi
+        START_TIME=$(date +%s)
+        # Wait up to 90 minutes
+        while [[ $(( $(date +%s) - 5400 )) -lt $START_TIME ]]; do
+        do
+          # Check if image already exists, if it does then skip building it
+          if docker manifest inspect "${DOCKER_IMAGE}"; then
+            exit 0
+          fi
+
+          # NB: This flag is used by Docker build workflow to push the image to ECR, so we can
+          # use this to differentiate between the Docker build and regular build jobs. For the
+          # latter, it will wait for the Docker images to become available before continuing
+          if [ "${DOCKER_PUSH:-false}" == "true" ]; then
+            # It's a Docker build job, let's build the image
+            break
+          else
+            # It's a regular build job, wait for the image to become available
+            sleep 300
+          fi
+        done
 
         # NB: This part requires a full checkout. Otherwise, the merge base will
         # be empty.  The default action would be to continue rebuild the image

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -105,7 +105,6 @@ runs:
         START_TIME=$(date +%s)
         # Wait up to 90 minutes
         while [[ $(( $(date +%s) - 5400 )) -lt $START_TIME ]]; do
-        do
           # Check if image already exists, if it does then skip building it
           if docker manifest inspect "${DOCKER_IMAGE}"; then
             exit 0

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -76,6 +76,67 @@ runs:
           echo "docker-image=${DOCKER_REGISTRY}/${REPO_NAME}/${DOCKER_IMAGE_NAME}:${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
         fi
 
+    - name: Check if image should be built
+      id: check-image
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      if: ${{ steps.calculate-image.outputs.skip != 'true' && !inputs.always-rebuild }}
+      env:
+        DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
+        BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
+        DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
+        DOCKER_TAG: ${{ steps.calculate-image.outputs.docker-tag }}
+        DOCKER_REGISTRY: ${{ inputs.docker-registry }}
+      run: |
+        set +e
+        set -x
+
+        login() {
+          aws ecr get-login-password --region us-east-1 | docker login -u AWS --password-stdin "$1"
+        }
+
+        retry () {
+          $*  || (sleep 1 && $*) || (sleep 2 && $*)
+        }
+
+        retry login "${DOCKER_REGISTRY}"
+
+        # Check if image already exists, if it does then skip building it
+        if docker manifest inspect "${DOCKER_IMAGE}"; then
+          exit 0
+        fi
+
+        # NB: This part requires a full checkout. Otherwise, the merge base will
+        # be empty.  The default action would be to continue rebuild the image
+        if [[ "$BASE_REVISION" = "$(git rev-parse HEAD)" ]]; then
+          # if we're on the base branch then use the parent commit
+          MERGE_BASE=$(git rev-parse HEAD~)
+        else
+          # otherwise we're on a PR, so use the most recent base commit
+          MERGE_BASE=$(git merge-base HEAD "$BASE_REVISION")
+        fi
+
+        if [[ -z "${MERGE_BASE}" ]]; then
+          echo "rebuild=true" >> "${GITHUB_OUTPUT}"
+
+          echo "Finding merge base only works with full checkout, please set fetch-depth to 0, continuing ..."
+          exit 0
+        fi
+
+        if ! git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}"; then
+          echo "Directory '${DOCKER_BUILD_DIR}' not found in commit $MERGE_BASE, you should rebase onto a more recent commit"
+          exit 1
+        fi
+
+        PREVIOUS_DOCKER_TAG=$(git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}")
+        # If no image exists but the hash is the same as the previous hash then we should error out here
+        if [[ "${PREVIOUS_DOCKER_TAG}" == "${DOCKER_TAG}" ]]; then
+          echo "WARNING: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
+          echo "         Will re-build docker image to store in local cache, TTS may be longer"
+        fi
+
+        echo "rebuild=true" >> "${GITHUB_OUTPUT}"
+
     - name: Login to ECR
       if: ${{ steps.calculate-image.outputs.skip != 'true' && (inputs.always-rebuild || steps.check-image.outputs.rebuild) }}
       shell: bash
@@ -104,84 +165,34 @@ runs:
         set -eux
         aws secretsmanager get-secret-value --secret-id docker_hub_readonly_token | jq --raw-output '.SecretString' | jq -r .docker_hub_readonly_token | docker login --username pytorchbot --password-stdin
 
-    - name: Check if image exists and build it if it doesnt
-      id: check-and-build-image
-      if: ${{ steps.calculate-image.outputs.skip != 'true' && inputs.always-rebuild }}
+    - name: Build docker image
+      if: ${{ steps.calculate-image.outputs.skip != 'true' && (inputs.always-rebuild || steps.check-image.outputs.rebuild) }}
       env:
         REPO_NAME: ${{ github.event.repository.name }}
-        BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
-        DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
-        WORKING_DIRECTORY: ${{ inputs.working-directory }}
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
-        DOCKER_TAG: ${{ steps.calculate-image.outputs.docker-tag }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}/${{ inputs.docker-build-dir }}
       # NB: Retry here as this step frequently fails with network error downloading various stuffs
       uses: nick-fields/retry@v3.0.0
       with:
         shell: bash
         timeout_minutes: 90
         max_attempts: 3
-        # NB: Wait for half an hour before retrying, this is used as a pooling mechanism to wait
-        # for the docker build workflow to finish
-        retry_wait_seconds: 1800
+        retry_wait_seconds: 90
         command: |
           set -ex
 
-          build_image() {
-            # NB: Setting working directory on the step doesn't work with nick-fields/retry https://github.com/nick-fields/retry/issues/89
-            pushd "${WORKING_DIRECTORY}/${DOCKER_BUILD_DIR}"
-
-            IMAGE_NAME=$(echo ${DOCKER_IMAGE#"${DOCKER_REGISTRY}/${REPO_NAME}/"} | awk -F '[:,]' '{print $1}')
-            # Build new image
-            ./build.sh "${IMAGE_NAME}" -t "${DOCKER_IMAGE}"
-
-            popd
-
-            echo "rebuild=true" >> "${GITHUB_OUTPUT}"
-            # Reaching this part means that the image has been built successfully
-            # so we can just exit from here
-            exit 0
-          }
-
+          # NB: Setting working directory on the step doesn't work with nick-fields/retry https://github.com/nick-fields/retry/issues/89
           pushd "${WORKING_DIRECTORY}"
 
-          # Check if image already exists, if it does then skip building it
-          if docker manifest inspect "${DOCKER_IMAGE}"; then
-            exit 0
-          fi
-
-          # NB: This part requires a full checkout. Otherwise, the merge base will
-          # be empty.  The default action would be to continue rebuild the image
-          if [[ "$BASE_REVISION" = "$(git rev-parse HEAD)" ]]; then
-            # if we're on the base branch then use the parent commit
-            MERGE_BASE=$(git rev-parse HEAD~)
-          else
-            # otherwise we're on a PR, so use the most recent base commit
-            MERGE_BASE=$(git merge-base HEAD "$BASE_REVISION")
-          fi
-
-          if [[ -z "${MERGE_BASE}" ]]; then
-            echo "Finding merge base only works with full checkout, please set fetch-depth to 0, continuing ..."
-            build_image
-          fi
-
-          if ! git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}"; then
-            echo "Directory '${DOCKER_BUILD_DIR}' not found in commit $MERGE_BASE, you should rebase onto a more recent commit"
-            exit 1
-          fi
-
-          PREVIOUS_DOCKER_TAG=$(git rev-parse "${MERGE_BASE}:${DOCKER_BUILD_DIR}")
-          # If no image exists but the hash is the same as the previous hash then we should error out here
-          if [[ "${PREVIOUS_DOCKER_TAG}" == "${DOCKER_TAG}" ]]; then
-            echo "WARNING: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
-            echo "         Will re-build docker image to store in local cache, TTS may be longer"
-          fi
-          build_image
+          IMAGE_NAME=$(echo ${DOCKER_IMAGE#"${DOCKER_REGISTRY}/${REPO_NAME}/"} | awk -F '[:,]' '{print $1}')
+          # Build new image
+          ./build.sh "${IMAGE_NAME}" -t "${DOCKER_IMAGE}"
 
           popd
 
     - name: Push to ECR
-      if: ${{ steps.calculate-image.outputs.skip != 'true' && (inputs.always-rebuild || steps.check-and-build-image.outputs.rebuild) }}
+      if: ${{ steps.calculate-image.outputs.skip != 'true' && (inputs.always-rebuild || steps.check-image.outputs.rebuild) }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}/${{ inputs.docker-build-dir }}
       env:

--- a/torchci/components/benchmark/compilers/SummaryGraphPanel.tsx
+++ b/torchci/components/benchmark/compilers/SummaryGraphPanel.tsx
@@ -73,9 +73,9 @@ function SuiteGraphPanel({
   const queryCollection = "inductor";
 
   const queryParamsWithSuite: { [key: string]: any } = {
-    ...queryParams,
     branches: [branch],
     suites: [suite],
+    ...queryParams,
   };
   // NB: Querying data for all the suites blows up the response from the database
   // over the lambda reponse body limit of 6MB. So I need to split up the query

--- a/torchci/components/benchmark/compilers/SummaryGraphPanel.tsx
+++ b/torchci/components/benchmark/compilers/SummaryGraphPanel.tsx
@@ -73,9 +73,9 @@ function SuiteGraphPanel({
   const queryCollection = "inductor";
 
   const queryParamsWithSuite: { [key: string]: any } = {
+    ...queryParams,
     branches: [branch],
     suites: [suite],
-    ...queryParams,
   };
   // NB: Querying data for all the suites blows up the response from the database
   // over the lambda reponse body limit of 6MB. So I need to split up the query


### PR DESCRIPTION
This is a short-term mitigation for https://github.com/pytorch/pytorch/issues/141885 in which any changes touching `.ci/docker` would cause all the builds to fail until docker build workflow finishes building the images.

At the moment, we don't have a good way to tell the build workflow to wait for the new docker image, so my fix here attempts to inject a delay when the action is called by `_linux_build`.  It will wait up to 90 minutes for the Docker build to finish

### Testing 

https://github.com/pytorch/pytorch/pull/142177