### PR TITLE
[EZ] Tweak queued_jobs_aggregate query columns

### DIFF
--- a/torchci/clickhouse_queries/queued_jobs_aggregate/query.sql
+++ b/torchci/clickhouse_queries/queued_jobs_aggregate/query.sql
@@ -28,6 +28,7 @@ with possible_queued_jobs as (
         CURRENT_TIMESTAMP()
     ) AS queue_m,
     workflow.repository.owner.login as org,
+    workflow.repository.name as repo,
     workflow.repository.full_name as full_repo,
     CONCAT(workflow.name, ' / ', job.name) AS name,
     job.html_url,
@@ -61,11 +62,12 @@ with possible_queued_jobs as (
 select
   runner_label,
   org,
+  repo,
   full_repo,
   count(*) as num_queued_jobs,
-  min(queue_m) as min_queue_time_min,
-  max(queue_m) as max_queue_time_min
+  min(queue_m) as min_queue_time_minutes,
+  max(queue_m) as max_queue_time_minutes
 from queued_jobs
-group by runner_label, org, full_repo
+group by runner_label, org, repo, full_repo
 order by max_queue_time_min desc
 settings allow_experimental_analyzer = 1;

--- a/torchci/clickhouse_queries/queued_jobs_aggregate/query.sql
+++ b/torchci/clickhouse_queries/queued_jobs_aggregate/query.sql
@@ -2,7 +2,7 @@
 --- have had jobs waiting for them for a significant period of time.
 ---
 --- This query returns the number of jobs per runner type that have been
---- queued for too long, which the autoscalers use to determin how many
+--- queued for too long, which the autoscalers use to determine how many
 --- additional runners to spin up.
 
 with possible_queued_jobs as (
@@ -29,7 +29,6 @@ with possible_queued_jobs as (
     ) AS queue_m,
     workflow.repository.owner.login as org,
     workflow.repository.name as repo,
-    workflow.repository.full_name as full_repo,
     CONCAT(workflow.name, ' / ', job.name) AS name,
     job.html_url,
     IF(
@@ -63,11 +62,10 @@ select
   runner_label,
   org,
   repo,
-  full_repo,
   count(*) as num_queued_jobs,
   min(queue_m) as min_queue_time_minutes,
   max(queue_m) as max_queue_time_minutes
 from queued_jobs
-group by runner_label, org, repo, full_repo
-order by max_queue_time_min desc
+group by runner_label, org, repo
+order by max_queue_time_minutes desc
 settings allow_experimental_analyzer = 1;


### PR DESCRIPTION
Changes:
- Rename two columns to make them less confusing
- Replace the full repo name column with one that just has the repo name (without the org) to make just the repo name easier to parse out

This query isn't used anywhere yet so these changes are still safe to make