### PR TITLE
Bugfix: Overprovision scaleups on ephemeral instances & extend runner scale up code to enable larger scale ups

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
@@ -1052,32 +1052,44 @@ describe('_calculateScaleUpAmount', () => {
       }
     });
 
-    it(
-      'When avail runners are high enough to handle request but will dip below min, ' + 'Scale ups partway to min',
-      () => {
-        const requestedCount = 4;
-        const availableCount = 5;
-        const minRunners = 4;
+    it('No runners are available and below min, scales up', () => {
+      const requestedCount = 1;
+      const availableCount = 2;
+      const minRunners = 10;
+      const isEphemeral = false;
 
-        for (const isEphemeral of [false, true]) {
-          const scaleUpAmount = _calculateScaleUpAmount(
-            requestedCount,
-            isEphemeral,
-            minRunners,
-            maxScaleUp,
-            availableCount,
-          );
+      const scaleUpAmount = _calculateScaleUpAmount(
+        requestedCount,
+        isEphemeral,
+        minRunners,
+        maxScaleUp,
+        availableCount,
+      );
 
-          const availAfterHandinglingRequest = availableCount - requestedCount;
-          const amtBelowMin = minRunners - availAfterHandinglingRequest;
+      expect(scaleUpAmount).toBe(1);
+    });
 
-          // Not being exactly prescriptive with a value in this test so that we can tweak the results later without
-          // needing to update the test.
-          expect(scaleUpAmount).toBeGreaterThan(0); // Ensure we're adding some extra instances
-          expect(scaleUpAmount).toBeLessThanOrEqual(amtBelowMin);
-        }
-      },
-    );
+    it('When avail runners are high enough to handle request but will dip below min, scale ups partway to min', () => {
+      const requestedCount = 4;
+      const availableCount = 5;
+      const minRunners = 4;
+
+      for (const isEphemeral of [false, true]) {
+        const scaleUpAmount = _calculateScaleUpAmount(
+          requestedCount,
+          isEphemeral,
+          minRunners,
+          maxScaleUp,
+          availableCount,
+        );
+
+        const availAfterHandinglingRequest = availableCount - requestedCount;
+        const amtBelowMin = minRunners - availAfterHandinglingRequest;
+
+        // We were above min runners before, and we should scale up enough to not dip below min runners
+        expect(scaleUpAmount).toEqual(3);
+      }
+    });
 
     it(
       'When avail runners are insuffiicent to handle request, ' +

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
@@ -12,7 +12,7 @@ import { Config } from './config';
 import { getRepoIssuesWithLabel, GhIssues } from './gh-issues';
 import { mocked } from 'ts-jest/utils';
 import nock from 'nock';
-import { scaleUp } from './scale-up';
+import { scaleUp, _calculateScaleUpAmount } from './scale-up';
 import * as MetricsModule from './metrics';
 
 jest.mock('./runners');
@@ -1027,5 +1027,141 @@ describe('scaleUp', () => {
     expect(mockedGetRepoIssuesWithLabel).toBeCalledTimes(2);
     expect(mockedGetRepoIssuesWithLabel).toBeCalledWith(repo, config.cantHaveIssuesLabels[0], metrics);
     expect(mockedGetRepoIssuesWithLabel).toBeCalledWith(repo, config.cantHaveIssuesLabels[1], metrics);
+  });
+});
+
+describe('_calculateScaleUpAmount', () => {
+
+  describe('When we are sufficently below the max scale up limit', () => {
+    const maxScaleUp = Number.MAX_SAFE_INTEGER;
+
+    it('When avail runners are high enough to handle request and stay above min, does not scale up', () => {
+      const requestedCount = 4;
+      const availableCount = 7;
+      const minRunners = 2;
+
+      for (const isEphemeral of [false, true]) {
+        const scaleUpAmount = _calculateScaleUpAmount(
+          requestedCount,
+          isEphemeral,
+          minRunners,
+          maxScaleUp,
+          availableCount);
+
+        expect(scaleUpAmount).toBe(0);
+      }
+    });
+
+    it('When avail runners are high enough to handle request but will dip below min, ' +
+       'Scale ups partway to min', () => {
+      const requestedCount = 4;
+      const availableCount = 5;
+      const minRunners = 4;
+
+      for (const isEphemeral of [false, true]) {
+        const scaleUpAmount = _calculateScaleUpAmount(
+          requestedCount,
+          isEphemeral,
+          minRunners,
+          maxScaleUp,
+          availableCount);
+
+        const availAfterHandinglingRequest = availableCount - requestedCount;
+        const amtBelowMin = minRunners - availAfterHandinglingRequest;
+
+        // Not being exactly prescriptive with a value in this test so that we can tweak the results later without
+        // needing to update the test.
+        expect(scaleUpAmount).toBeGreaterThan(0); // Ensure we're adding some extra instances
+        expect(scaleUpAmount).toBeLessThanOrEqual(amtBelowMin);
+      }
+    });
+
+    it('When avail runners are insuffiicent to handle request, ' +
+       'provisions enough to handle request and also scale up partway to min', () => {
+      const requestedCount = 6;
+      const availableCount = 5;
+      const minRunners = 4;
+
+      for (const isEphemeral of [false, true]) {
+        const scaleUpAmount = _calculateScaleUpAmount(
+          requestedCount,
+          isEphemeral,
+          minRunners,
+          maxScaleUp,
+          availableCount);
+
+        const reqRemainingAfterUsingAvailableRuners = requestedCount - availableCount;
+
+        // Not being exactly prescriptive with a value in this test so that we can tweak the results later without
+        // needing to update the test.
+        expect(scaleUpAmount).toBeGreaterThan(reqRemainingAfterUsingAvailableRuners); // Ensure we get extra instances
+        expect(scaleUpAmount).toBeLessThanOrEqual(minRunners + reqRemainingAfterUsingAvailableRuners);
+      }
+    });
+  });
+
+  describe('When we are near the max scale up limit', () => {
+
+    it('When there is no additional capacity to scale up, does not scale up', () => {
+      const requestedCount = 4;
+      const availableCount = 2;
+      const minRunners = 2;
+      const maxScaleUp = 0;
+
+      for (const isEphemeral of [false, true]) {
+        const scaleUpAmount = _calculateScaleUpAmount(
+          requestedCount,
+          isEphemeral,
+          minRunners,
+          maxScaleUp,
+          availableCount);
+
+        expect(scaleUpAmount).toBe(0);
+      }
+    });
+
+    it('When avail runners are high enough to handle request but will dip below min, ' +
+       'Scale ups partway to min while staying below the max limit', () => {
+      const requestedCount = 4;
+      const availableCount = 2;
+      const minRunners = 10;
+      const maxScaleUp = 3;
+
+
+      for (const isEphemeral of [false, true]) {
+        const scaleUpAmount = _calculateScaleUpAmount(
+          requestedCount,
+          isEphemeral,
+          minRunners,
+          maxScaleUp,
+          availableCount);
+
+        // Not being exactly prescriptive with all values in this test so that we can tweak the results later without
+        // needing to update the test.
+        expect(scaleUpAmount).toBeGreaterThan(requestedCount - availableCount); // Ensure we're getting extra instances
+        expect(scaleUpAmount).toBeLessThanOrEqual(minRunners);
+        expect(scaleUpAmount).toBeLessThanOrEqual(maxScaleUp);
+      }
+    });
+
+    it('When avail runners are insuffiicent to handle request, ' +
+       'provisions enough to handle request from what is available', () => {
+      const requestedCount = 6;
+      const availableCount = 2;
+      const minRunners = 4;
+      const maxScaleUp = 3;
+
+
+      for (const isEphemeral of [false, true]) {
+        const scaleUpAmount = _calculateScaleUpAmount(
+          requestedCount,
+          isEphemeral,
+          minRunners,
+          maxScaleUp,
+          availableCount);
+
+        expect(scaleUpAmount).toEqual(maxScaleUp);
+      }
+    });
   });
 });

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
@@ -1031,7 +1031,6 @@ describe('scaleUp', () => {
 });
 
 describe('_calculateScaleUpAmount', () => {
-
   describe('When we are sufficently below the max scale up limit', () => {
     const maxScaleUp = Number.MAX_SAFE_INTEGER;
 
@@ -1046,62 +1045,69 @@ describe('_calculateScaleUpAmount', () => {
           isEphemeral,
           minRunners,
           maxScaleUp,
-          availableCount);
+          availableCount,
+        );
 
         expect(scaleUpAmount).toBe(0);
       }
     });
 
-    it('When avail runners are high enough to handle request but will dip below min, ' +
-       'Scale ups partway to min', () => {
-      const requestedCount = 4;
-      const availableCount = 5;
-      const minRunners = 4;
+    it(
+      'When avail runners are high enough to handle request but will dip below min, ' + 'Scale ups partway to min',
+      () => {
+        const requestedCount = 4;
+        const availableCount = 5;
+        const minRunners = 4;
 
-      for (const isEphemeral of [false, true]) {
-        const scaleUpAmount = _calculateScaleUpAmount(
-          requestedCount,
-          isEphemeral,
-          minRunners,
-          maxScaleUp,
-          availableCount);
+        for (const isEphemeral of [false, true]) {
+          const scaleUpAmount = _calculateScaleUpAmount(
+            requestedCount,
+            isEphemeral,
+            minRunners,
+            maxScaleUp,
+            availableCount,
+          );
 
-        const availAfterHandinglingRequest = availableCount - requestedCount;
-        const amtBelowMin = minRunners - availAfterHandinglingRequest;
+          const availAfterHandinglingRequest = availableCount - requestedCount;
+          const amtBelowMin = minRunners - availAfterHandinglingRequest;
 
-        // Not being exactly prescriptive with a value in this test so that we can tweak the results later without
-        // needing to update the test.
-        expect(scaleUpAmount).toBeGreaterThan(0); // Ensure we're adding some extra instances
-        expect(scaleUpAmount).toBeLessThanOrEqual(amtBelowMin);
-      }
-    });
+          // Not being exactly prescriptive with a value in this test so that we can tweak the results later without
+          // needing to update the test.
+          expect(scaleUpAmount).toBeGreaterThan(0); // Ensure we're adding some extra instances
+          expect(scaleUpAmount).toBeLessThanOrEqual(amtBelowMin);
+        }
+      },
+    );
 
-    it('When avail runners are insuffiicent to handle request, ' +
-       'provisions enough to handle request and also scale up partway to min', () => {
-      const requestedCount = 6;
-      const availableCount = 5;
-      const minRunners = 4;
+    it(
+      'When avail runners are insuffiicent to handle request, ' +
+        'provisions enough to handle request and also scale up partway to min',
+      () => {
+        const requestedCount = 6;
+        const availableCount = 5;
+        const minRunners = 4;
 
-      for (const isEphemeral of [false, true]) {
-        const scaleUpAmount = _calculateScaleUpAmount(
-          requestedCount,
-          isEphemeral,
-          minRunners,
-          maxScaleUp,
-          availableCount);
+        for (const isEphemeral of [false, true]) {
+          const scaleUpAmount = _calculateScaleUpAmount(
+            requestedCount,
+            isEphemeral,
+            minRunners,
+            maxScaleUp,
+            availableCount,
+          );
 
-        const reqRemainingAfterUsingAvailableRuners = requestedCount - availableCount;
+          const reqRemainingAfterUsingAvailableRuners = requestedCount - availableCount;
 
-        // Not being exactly prescriptive with a value in this test so that we can tweak the results later without
-        // needing to update the test.
-        expect(scaleUpAmount).toBeGreaterThan(reqRemainingAfterUsingAvailableRuners); // Ensure we get extra instances
-        expect(scaleUpAmount).toBeLessThanOrEqual(minRunners + reqRemainingAfterUsingAvailableRuners);
-      }
-    });
+          // Not being exactly prescriptive with a value in this test so that we can tweak the results later without
+          // needing to update the test.
+          expect(scaleUpAmount).toBeGreaterThan(reqRemainingAfterUsingAvailableRuners); // Ensure we get extra instances
+          expect(scaleUpAmount).toBeLessThanOrEqual(minRunners + reqRemainingAfterUsingAvailableRuners);
+        }
+      },
+    );
   });
 
   describe('When we are near the max scale up limit', () => {
-
     it('When there is no additional capacity to scale up, does not scale up', () => {
       const requestedCount = 4;
       const availableCount = 2;
@@ -1114,54 +1120,61 @@ describe('_calculateScaleUpAmount', () => {
           isEphemeral,
           minRunners,
           maxScaleUp,
-          availableCount);
+          availableCount,
+        );
 
         expect(scaleUpAmount).toBe(0);
       }
     });
 
-    it('When avail runners are high enough to handle request but will dip below min, ' +
-       'Scale ups partway to min while staying below the max limit', () => {
-      const requestedCount = 4;
-      const availableCount = 2;
-      const minRunners = 10;
-      const maxScaleUp = 3;
+    it(
+      'When avail runners are high enough to handle request but will dip below min, ' +
+        'Scale ups partway to min while staying below the max limit',
+      () => {
+        const requestedCount = 4;
+        const availableCount = 2;
+        const minRunners = 10;
+        const maxScaleUp = 3;
 
+        for (const isEphemeral of [false, true]) {
+          const scaleUpAmount = _calculateScaleUpAmount(
+            requestedCount,
+            isEphemeral,
+            minRunners,
+            maxScaleUp,
+            availableCount,
+          );
 
-      for (const isEphemeral of [false, true]) {
-        const scaleUpAmount = _calculateScaleUpAmount(
-          requestedCount,
-          isEphemeral,
-          minRunners,
-          maxScaleUp,
-          availableCount);
+          // Not being exactly prescriptive with all values in this test so that we can tweak the results later without
+          // needing to update the test.
+          expect(scaleUpAmount).toBeGreaterThan(requestedCount - availableCount); // Ensure we're getting extra instances
+          expect(scaleUpAmount).toBeLessThanOrEqual(minRunners);
+          expect(scaleUpAmount).toBeLessThanOrEqual(maxScaleUp);
+        }
+      },
+    );
 
-        // Not being exactly prescriptive with all values in this test so that we can tweak the results later without
-        // needing to update the test.
-        expect(scaleUpAmount).toBeGreaterThan(requestedCount - availableCount); // Ensure we're getting extra instances
-        expect(scaleUpAmount).toBeLessThanOrEqual(minRunners);
-        expect(scaleUpAmount).toBeLessThanOrEqual(maxScaleUp);
-      }
-    });
+    it(
+      'When avail runners are insuffiicent to handle request, ' +
+        'provisions enough to handle request from what is available',
+      () => {
+        const requestedCount = 6;
+        const availableCount = 2;
+        const minRunners = 4;
+        const maxScaleUp = 3;
 
-    it('When avail runners are insuffiicent to handle request, ' +
-       'provisions enough to handle request from what is available', () => {
-      const requestedCount = 6;
-      const availableCount = 2;
-      const minRunners = 4;
-      const maxScaleUp = 3;
+        for (const isEphemeral of [false, true]) {
+          const scaleUpAmount = _calculateScaleUpAmount(
+            requestedCount,
+            isEphemeral,
+            minRunners,
+            maxScaleUp,
+            availableCount,
+          );
 
-
-      for (const isEphemeral of [false, true]) {
-        const scaleUpAmount = _calculateScaleUpAmount(
-          requestedCount,
-          isEphemeral,
-          minRunners,
-          maxScaleUp,
-          availableCount);
-
-        expect(scaleUpAmount).toEqual(maxScaleUp);
-      }
-    });
+          expect(scaleUpAmount).toEqual(maxScaleUp);
+        }
+      },
+    );
   });
 });

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
@@ -1147,7 +1147,7 @@ describe('_calculateScaleUpAmount', () => {
 
           // Not being exactly prescriptive with all values in this test so that we can tweak the results later without
           // needing to update the test.
-          expect(scaleUpAmount).toBeGreaterThan(requestedCount - availableCount); // Ensure we're getting extra instances
+          expect(scaleUpAmount).toBeGreaterThan(requestedCount - availableCount); // Ensure we're get extra instances
           expect(scaleUpAmount).toBeLessThanOrEqual(minRunners);
           expect(scaleUpAmount).toBeLessThanOrEqual(maxScaleUp);
         }

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -307,14 +307,13 @@ export function _calculateScaleUpAmount(
   isEphemeral: boolean,
   minRunners: number, // Minimum number of runners that should be available
   maxScaleUp: number,
-  availableCount: number // Number of runners that are currently available to run jobs
+  availableCount: number, // Number of runners that are currently available to run jobs
 ): number {
   const availableAfterAcceptingRequests = Math.max(availableCount - requestedCount, 0);
   const extraNeededToAcceptRequests = Math.max(requestedCount - availableCount, 0);
 
   // Tracks how many runners should be provisioned to bring us up to the minimum limit
   const minRunnersUnderprovisionCount = minRunners - availableAfterAcceptingRequests;
-
 
   let extraScaleUp = 0;
   if (minRunnersUnderprovisionCount > 0) {
@@ -339,8 +338,9 @@ export function _calculateScaleUpAmount(
     // Never proactively scale up above the minimum limit
     extraScaleUp = Math.min(extraScaleUp, minRunnersUnderprovisionCount);
 
-    console.info(`Available (${availableCount}) runners will be below minimum ${minRunners}. ` +
-      `Will provision ${extraScaleUp} extra runners`
+    console.info(
+      `Available (${availableCount}) runners will be below minimum ${minRunners}. ` +
+        `Will provision ${extraScaleUp} extra runners`,
     );
   }
 
@@ -350,8 +350,6 @@ export function _calculateScaleUpAmount(
       `Desired count ${scaleUpAmount} is higher than max allowed scale up ${maxScaleUp}, ` +
         `will scale up ${maxScaleUp} instead`,
     );
-
-
 
     scaleUpAmount = maxScaleUp;
   }

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -319,8 +319,19 @@ export function _calculateScaleUpAmount(
   if (minRunnersUnderprovisionCount > 0) {
     // Scale up by a bit extra to bring us closer to the minimum limit
 
-    // Keep the overprovisioning to a small % when we have a large number of runners requested
-    extraScaleUp = Math.ceil(minRunnersUnderprovisionCount * 0.05);
+    // Keep the overprovisioning to a small % when we have a large number of runners requested.
+    // However, in the normal case (non-ephemeral, where only a single runner is requested) we
+    //   won't overprovision since that would risk overprovisioning runners by too much.
+    // How? Imagine 100 jobs have started on GitHub and we get 100 parallel webhooks requests to
+    //   provision one runners.  Each of those running in parallel is unlikely to see the other
+    //   requests and will provision not only the 100 runners they need, but also an additional 100
+    //   as "extraScaleUp".
+    // The requests that ask for more than one runner are less likely to run in parallel and so
+    //   are less likely to overprovision so drastically.
+    // Note: Since Ephemeral runners are short lived we can still overprovision them more aggressively
+    if (requestedCount > 1) {
+      extraScaleUp = Math.ceil(minRunnersUnderprovisionCount * 0.1);
+    }
 
     if (isEphemeral) {
       // We randomly overprovision ephemeral runners to handle extra incoming requests.

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -336,6 +336,7 @@ export function _calculateScaleUpAmount(
   if (minRunnersUnderprovisionCount > 0) {
     // Scale up by a bit extra to bring us closer to the minimum limit
 
+    // Keep the overprovisioning to a small % when we have a large number of runners requested
     extraScaleUp = Math.ceil(minRunnersUnderprovisionCount * 0.05);
 
     if (isEphemeral) {

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -328,7 +328,7 @@ export function _calculateScaleUpAmount(
       // This is to compensate for requests that fail to provision runners for unknown reasons.
       // We're more aggressive here since these runners are short lived and cannot be reused.
 
-      const overprovisionFrequency = 0.5; // Overprivision 50% of the time
+      const overprovisionFrequency = 0.5; // Overprovision 50% of the time
       const overprovisionAmount = 2; // Additional runners to add when overprovisioning
 
       if (Math.random() < overprovisionFrequency) {

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -82,11 +82,13 @@ export async function scaleUp(
       );
       continue;
     }
-    const runnersToCreate = await allRunnersBusy(
+    let runnersRequested = 1;
+    const runnersToCreate = await getCreatableRunnerCount(
       runnerType.runnerTypeName,
       repo,
       runnerType.is_ephemeral,
       runnerType.max_available,
+      runnersRequested,
       metrics,
     );
     for (let i = 0; i < runnersToCreate; i++) {
@@ -206,11 +208,51 @@ async function shouldSkipForRepo(repo: Repo, metrics: Metrics): Promise<boolean>
   return false;
 }
 
-async function allRunnersBusy(
+/**
+ * Returns the maximum number of runners that can be created for the given runner type
+ */
+function getMaximumAllowedScaleUpSize(
+  maxAllowed: number | undefined,
+  provisioned: number,
+  isEphemeral: boolean,
+): number {
+  const NO_LIMIT = Number.MAX_SAFE_INTEGER;
+
+  if (isEphemeral) {
+    // Ephemeral runners are not limited by maxAllowed
+    return NO_LIMIT;
+  }
+
+  if (maxAllowed === undefined || maxAllowed <= 0) {
+    return NO_LIMIT;
+  }
+
+  return maxAllowed - provisioned;
+}
+
+function getOverprovisionedCountForEphemeralRunner(requested: number): number {
+  // We randomly overprovision ephemeral runners to handle extra incoming requests.
+  // This is to compensate for requests that fail to provision runners for unknown reasons.
+  // Non-ephemeral runners are not overprovisioned since they are long-lived and can be reused.
+  const overprovisionRate = 0.5; // Overprivision 50% of the time
+  const overprovisionAmount = 2; // Overprovision by 2 runners
+
+  if (Math.random() < overprovisionRate) {
+    return requested + overprovisionAmount;
+  }
+
+  return requested;
+}
+
+/**
+ *  Returns the number of runners that should be created to process the given request
+ */
+async function getCreatableRunnerCount(
   runnerType: string,
   repo: Repo,
   isEphemeral: boolean,
   maxAvailable: number | undefined,
+  requestedCount: number,
   metrics: ScaleUpMetrics,
 ): Promise<number> {
   const ghRunners = Config.Instance.enableOrganizationRunners
@@ -232,8 +274,9 @@ async function allRunnersBusy(
     metrics.ghRunnersRepoStats(repo, runnerType, runnersWithLabel.length, runnersWithLabel.length, busyCount);
   }
 
-  // If a runner isn't ephemeral then maxAvailable should be applied
-  if (!isEphemeral && maxAvailable !== undefined && maxAvailable >= 0 && runnersWithLabel.length >= maxAvailable) {
+  const maxAllowedScaleUp = getMaximumAllowedScaleUpSize(maxAvailable, runnersWithLabel.length, isEphemeral);
+
+  if (maxAllowedScaleUp <= 0) {
     /* istanbul ignore next */
     if (Config.Instance.enableOrganizationRunners) {
       metrics.ghRunnersOrgMaxHit(repo.owner, runnerType);
@@ -248,20 +291,41 @@ async function allRunnersBusy(
     return 0;
   }
 
-  // Have a fail safe just in case we're likely to need more runners
-  const availableCount = runnersWithLabel.length - busyCount;
-  // Min runners for scale-up must be at least 1 otherwise scale-up won't ever increase runners
-  const minRunners = Config.Instance.minAvailableRunners > 0 ? Config.Instance.minAvailableRunners : 1;
-  if (availableCount < minRunners) {
-    console.info(`Available (${availableCount}) runners is below minimum ${minRunners}`);
-    // It is impossible to accumulate runners if we know that the one we're creating will be terminated.
-    if (isEphemeral) {
-      const ratio: number = availableCount / (minRunners * 1.5);
-      return Math.random() < ratio ? 3 : 1;
-    } else {
-      return 1;
-    }
+  if (requestedCount > maxAllowedScaleUp) {
+    console.info(
+      `Requested count ${requestedCount} is higher than max allowed scale up ${maxAllowedScaleUp}, ` +
+        `will scale up ${maxAllowedScaleUp} instead`,
+    );
+    requestedCount = maxAllowedScaleUp;
   }
 
-  return 0;
+  const availableCount = runnersWithLabel.length - busyCount;
+  let additionalNeeded = requestedCount - availableCount;
+
+  if (additionalNeeded > 0) {
+    // We need to scale up to process the request
+    // TODO: See if we should scale up extra runners for ephemerals
+    if (isEphemeral) {
+      additionalNeeded = getOverprovisionedCountForEphemeralRunner(additionalNeeded);
+    }
+
+    return additionalNeeded;
+  }
+
+  // Fail-safe: If we're below the minimum available limit, we scale up an extra runner
+  //            to handle potential additional incoming traffic
+  const minRunners = Config.Instance.minAvailableRunners > 0 ? Config.Instance.minAvailableRunners : 1;
+
+  if (availableCount > minRunners) {
+    // We already have enough backup runners. No need to scale up.
+    return 0;
+  }
+
+  console.info(`Available (${availableCount}) runners is below minimum ${minRunners}`);
+  let provisionCount = 1
+  if (isEphemeral) {
+    // It is impossible to accumulate runners if we know that the one we're creating will be terminated.
+    provisionCount = getOverprovisionedCountForEphemeralRunner(provisionCount);
+  }
+  return provisionCount;
 }


### PR DESCRIPTION
Part of https://github.com/pytorch/test-infra/issues/5798

### Changes included
- Fix a big bug with how we provisioned instances for ephemeral instances. In the old code, the fewer ephemeral runners we had available, the _less_ likely we were to overprovision them, which sounds like the opposite of what we actually want to do. Changed that logic to more explicitly give ephemeral runners a 50% chance of overprovisioning the incoming request by two instances, which is what I think [this PR](https://github.com/pytorch/test-infra/pull/5501) was intending to do (we can tweak these numbers as desired).  This fix might handle most of our ephemeral runner woes by itself...
- Extend the allRunnersBusy function to enable it to handle scale up requests of more than a single instance (which will be leveraged in a future PR)
- Renames allRUnnersBusy to something more accurate name
