### PR TITLE
cost dashboard: remove timestamp, add UTC label for tooltip

### DIFF
--- a/torchci/pages/cost_analysis.tsx
+++ b/torchci/pages/cost_analysis.tsx
@@ -377,6 +377,7 @@ export default function Page() {
             smooth={false}
             chartType={chartType}
             filter={searchFilter}
+            timeFieldDisplayFormat="M/D (UTC)"
             sort_by="total"
             auto_refresh={false}
             max_items_in_series={30}


### PR DESCRIPTION
to clarify that all is in UTC