### PR TITLE
Move Validation Framework workflows to test-infra

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -1,0 +1,121 @@
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+if [[ ${MATRIX_PACKAGE_TYPE} == "libtorch" ]]; then
+    curl ${MATRIX_INSTALLATION} -o libtorch.zip
+    unzip libtorch.zip
+else
+
+    export PYTHON_RUN="python3"
+    if [[ ${TARGET_OS} == 'windows' ]]; then
+        export PYTHON_RUN="python"
+        # Currently xpu env need a helper script to activate
+        if [[ ${MATRIX_GPU_ARCH_TYPE} == "xpu" ]]; then
+            export PYTHON_RUN="${SCRIPT_DIR}/xpu_env_helper.bat python"
+        fi
+    fi
+
+    if [[ ${TARGET_OS} == 'macos-arm64' ]]; then
+        conda update -y -n base -c defaults conda
+    elif [[ ${TARGET_OS} != 'linux-aarch64' ]]; then
+        # Conda pinned see issue: https://github.com/ContinuumIO/anaconda-issues/issues/13350
+        conda install -y conda=23.11.0
+    fi
+    # Please note ffmpeg is required for torchaudio, see https://github.com/pytorch/pytorch/issues/96159
+    conda create -y -n ${ENV_NAME} python=${MATRIX_PYTHON_VERSION} numpy ffmpeg
+    conda activate ${ENV_NAME}
+
+    # Remove when https://github.com/pytorch/builder/issues/1985 is fixed
+    if [[ ${MATRIX_GPU_ARCH_TYPE} == 'cuda-aarch64' ]]; then
+        pip3 install numpy --force-reinstall
+    fi
+
+    INSTALLATION=${MATRIX_INSTALLATION/"conda install"/"conda install -y"}
+    TEST_SUFFIX=""
+
+    # force-reinstall: latest version of packages are reinstalled
+    if [[ ${USE_FORCE_REINSTALL} == 'true' ]]; then
+        INSTALLATION=${INSTALLATION/"pip3 install"/"pip3 install --force-reinstall"}
+    fi
+    # extra-index-url: extra dependencies are downloaded from pypi
+    if [[ ${USE_EXTRA_INDEX_URL} == 'true' ]]; then
+        INSTALLATION=${INSTALLATION/"--index-url"/"--extra-index-url"}
+    fi
+
+    # use-meta-cdn: use meta cdn for pypi download
+    if [[ ${USE_META_CDN} == 'true' ]]; then
+        INSTALLATION=${INSTALLATION/"download.pytorch.org"/"d3kup0pazkvub8.cloudfront.net"}
+    fi
+
+
+    if [[ ${TORCH_ONLY} == 'true' ]]; then
+        INSTALLATION=${INSTALLATION/"torchvision torchaudio"/""}
+        TEST_SUFFIX=" --package torchonly"
+    fi
+
+    # if RELESE version is passed as parameter - install speific version
+    if [[ ! -z ${RELEASE_VERSION} ]]; then
+          INSTALLATION=${INSTALLATION/"torch "/"torch==${RELEASE_VERSION} "}
+          INSTALLATION=${INSTALLATION/"-y pytorch "/"-y pytorch==${RELEASE_VERSION} "}
+          INSTALLATION=${INSTALLATION/"::pytorch "/"::pytorch==${RELEASE_VERSION} "}
+
+        if [[ ${USE_VERSION_SET} == 'true' ]]; then
+          INSTALLATION=${INSTALLATION/"torchvision "/"torchvision==${VISION_RELEASE_VERSION} "}
+          INSTALLATION=${INSTALLATION/"torchaudio "/"torchaudio==${AUDIO_RELEASE_VERSION} "}
+        fi
+    fi
+
+    export OLD_PATH=${PATH}
+    # Workaround macos-arm64 runners. Issue: https://github.com/pytorch/test-infra/issues/4342
+    if [[ ${TARGET_OS} == 'macos-arm64' ]]; then
+        export PATH="${CONDA_PREFIX}/bin:${PATH}"
+    fi
+
+    # Make sure we remove previous installation if it exists
+    if [[ ${MATRIX_PACKAGE_TYPE} == 'wheel' ]]; then
+        pip3 uninstall -y torch torchaudio torchvision
+    fi
+    eval $INSTALLATION
+
+    pushd ${PWD}/.ci/pytorch/
+
+    if [[ ${MATRIX_GPU_ARCH_VERSION} == "12.6" ]]; then
+        export DESIRED_DEVTOOLSET="cxx11-abi"
+    fi
+
+    if [[ ${TARGET_OS} == 'linux' ]]; then
+        export CONDA_LIBRARY_PATH="$(dirname $(which python))/../lib"
+        export LD_LIBRARY_PATH=$CONDA_LIBRARY_PATH:$LD_LIBRARY_PATH
+        source ./check_binary.sh
+    fi
+
+     # We are only interested in CUDA tests and Python 3.9-3.11. Not all requirement libraries are available for 3.12 yet.
+    if [[ ${INCLUDE_TEST_OPS:-} == 'true' &&  ${MATRIX_GPU_ARCH_TYPE} == 'cuda' && ${MATRIX_PYTHON_VERSION} != "3.13" ]]; then
+        source ${SCRIPT_DIR}/validate_test_ops.sh
+    fi
+
+    # Regular smoke test
+    ${PYTHON_RUN}  ./smoke_test/smoke_test.py ${TEST_SUFFIX}
+    # For pip install also test with numpy 2.0.0 for python 3.8 or above
+    if [[ ${MATRIX_PACKAGE_TYPE} == 'wheel' ]]; then
+        pip3 install numpy==2.0.0 --force-reinstall
+        ${PYTHON_RUN}  ./smoke_test/smoke_test.py ${TEST_SUFFIX}
+    fi
+
+
+    if [[ ${TARGET_OS} == 'macos-arm64' ]]; then
+        export PATH=${OLD_PATH}
+    fi
+
+    # Use case CUDA_VISIBLE_DEVICES: https://github.com/pytorch/pytorch/issues/128819
+    if [[ ${MATRIX_GPU_ARCH_TYPE} == 'cuda' ]]; then
+        python -c "import torch;import os;print(torch.cuda.device_count(), torch.__version__);os.environ['CUDA_VISIBLE_DEVICES']='0';print(torch.empty(2, device='cuda'))"
+    fi
+
+    # this is optional step
+    if [[ ${TARGET_OS} != linux*  ]]; then
+        conda deactivate
+        conda env remove -n ${ENV_NAME}
+    fi
+    popd
+
+fi

--- a/.github/scripts/validate_pipy.sh
+++ b/.github/scripts/validate_pipy.sh
@@ -1,0 +1,20 @@
+conda create -yn ${ENV_NAME}_pypi python=${MATRIX_PYTHON_VERSION} numpy ffmpeg
+conda activate ${ENV_NAME}_pypi
+
+TEST_SUFFIX=""
+RELEASE_SUFFIX=""
+# if RELESE version is passed as parameter - install speific version
+if [[ ! -z ${RELEASE_VERSION} ]]; then
+    RELEASE_SUFFIX="==${RELEASE_VERSION}"
+fi
+
+if [[ ${TORCH_ONLY} == 'true' ]]; then
+    TEST_SUFFIX=" --package torchonly"
+    pip3 install torch${RELEASE_SUFFIX}
+else
+    pip3 install torch${RELEASE_SUFFIX} torchvision torchaudio
+fi
+
+python ./test/smoke_test/smoke_test.py ${TEST_SUFFIX} --runtime-error-check disabled
+conda deactivate
+conda env remove -p ${ENV_NAME}_pypi

--- a/.github/scripts/validate_poetry.sh
+++ b/.github/scripts/validate_poetry.sh
@@ -1,0 +1,31 @@
+
+conda create -y -n ${ENV_NAME}_poetry python=${MATRIX_PYTHON_VERSION} numpy ffmpeg
+conda activate ${ENV_NAME}_poetry
+curl -sSL https://install.python-poetry.org | python3 - --git https://github.com/python-poetry/poetry.git@master
+export PATH="/root/.local/bin:$PATH"
+
+poetry --version
+poetry new test_poetry
+cd test_poetry
+
+TEST_SUFFIX=""
+if [[ ${TORCH_ONLY} == 'true' ]]; then
+    TEST_SUFFIX=" --package torchonly"
+fi
+
+RELEASE_SUFFIX=""
+# if RELESE version is passed as parameter - install speific version
+if [[ ! -z ${RELEASE_VERSION} ]]; then
+    RELEASE_SUFFIX="@${RELEASE_VERSION}"
+fi
+
+if [[ ${TORCH_ONLY} == 'true' ]]; then
+    poetry --quiet add torch${RELEASE_SUFFIX}
+else
+    poetry --quiet add torch${RELEASE_SUFFIX} torchaudio torchvision
+fi
+
+python ../test/smoke_test/smoke_test.py ${TEST_SUFFIX} --runtime-error-check disabled
+conda deactivate
+conda env remove -p ${ENV_NAME}_poetry
+cd ..

--- a/.github/scripts/validate_test_ops.sh
+++ b/.github/scripts/validate_test_ops.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+retry () {
+    $*  || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
+}
+
+BRANCH=""
+if [[ ${MATRIX_CHANNEL} == "test" || ${MATRIX_CHANNEL} == "release" ]]; then
+    SHORT_VERSION=${MATRIX_STABLE_VERSION%.*}
+    BRANCH="--branch release/${SHORT_VERSION}"
+fi
+
+
+# Clone the Pytorch branch
+retry git clone ${BRANCH} --depth 1 https://github.com/pytorch/pytorch.git
+retry git submodule update --init --recursive
+pushd pytorch
+
+pip install expecttest numpy pyyaml jinja2 packaging hypothesis unittest-xml-reporting scipy
+
+# Run pytorch cuda wheels validation
+# Detect ReduceLogicKernel (ReduceOp and kernel) IMA
+python test/test_ops.py -k test_dtypes_all_cuda
+# Detect BinaryMulKernel (elementwise binary functor internal mul) IMA
+python test/test_torch.py -k test_index_reduce_reduce_prod_cuda_int32
+# Detect BinaryBitwiseOpsKernels (at::native::BitwiseAndFunctor) IMA
+python test/test_binary_ufuncs.py -k test_contig_vs_every_other___rand___cuda_int32
+# Detect MaxMinElementwiseKernel (maximum) IMA
+python test/test_schema_check.py -k test_schema_correctness_clamp_cuda_int8
+
+pushd /tmp
+# Detect StepKernel (nextafter) IMA
+python -c "import torch; print(torch.nextafter(torch.tensor([-4.5149, -5.9053, -0.9516, -2.3615,  1.5591], device='cuda:0'), torch.tensor(3.8075, device='cuda:0')))"
+# Detect BinaryGeometricKernels (atan2) IMA
+python -c "import torch; x = (torch.randn((2,1,1), dtype=torch.float, device='cuda')*5).to(torch.float32); y=(torch.randn((), dtype=torch.float, device='cuda')*5).to(torch.float32); print(torch.atan2(x,y))"
+popd

--- a/.github/scripts/xpu_env_helper.bat
+++ b/.github/scripts/xpu_env_helper.bat
@@ -1,0 +1,17 @@
+call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+
+set args=%1
+shift
+:start
+if [%1] == [] goto done
+set args=%args% %1
+shift
+goto start
+
+:done
+if "%args%" == "" (
+    echo Usage: xpu_env_helper.bat [command] [args]
+    echo e.g. xpu_env_helper.bat icpx --version
+)
+
+%args% || exit /b 1

--- a/.github/workflows/generate_binary_build_matrix.yml
+++ b/.github/workflows/generate_binary_build_matrix.yml
@@ -41,8 +41,8 @@ on:
         type: string
       use-only-dl-pytorch-org:
         description: "Use only download.pytorch.org when generating wheel install command?"
-        default: "false"
-        type: string
+        default: false
+        type: boolean
       build-python-only:
         description: "Generate binary build matrix for a python only package (i.e. only one python version)"
         default: "disable"

--- a/.github/workflows/generate_binary_build_matrix.yml
+++ b/.github/workflows/generate_binary_build_matrix.yml
@@ -41,8 +41,9 @@ on:
         type: string
       use-only-dl-pytorch-org:
         description: "Use only download.pytorch.org when generating wheel install command?"
-        default: false
-        type: boolean
+        default: "false"
+        required: false
+        type: string
       build-python-only:
         description: "Generate binary build matrix for a python only package (i.e. only one python version)"
         default: "disable"

--- a/.github/workflows/generate_docker_release_matrix.yml
+++ b/.github/workflows/generate_docker_release_matrix.yml
@@ -18,6 +18,7 @@ on:
       generate_dockerhub_images:
         description: "Whether to generate Docker Hub images"
         default: false
+        required: false
         type: boolean
     outputs:
       matrix:

--- a/.github/workflows/generate_docker_release_matrix.yml
+++ b/.github/workflows/generate_docker_release_matrix.yml
@@ -17,9 +17,9 @@ on:
         type: string
       generate_dockerhub_images:
         description: "Whether to generate Docker Hub images"
-        default: false
+        default: "false"
         required: false
-        type: boolean
+        type: string
     outputs:
       matrix:
         description: "Generated build matrix"

--- a/.github/workflows/generate_docker_release_matrix.yml
+++ b/.github/workflows/generate_docker_release_matrix.yml
@@ -15,10 +15,10 @@ on:
         description: "Test infra reference to use"
         default: "main"
         type: string
-      generate_dockerhub_images: 
+      generate_dockerhub_images:
         description: "Whether to generate Docker Hub images"
         default: "false"
-        type: string
+        type: boolean
     outputs:
       matrix:
         description: "Generated build matrix"

--- a/.github/workflows/generate_docker_release_matrix.yml
+++ b/.github/workflows/generate_docker_release_matrix.yml
@@ -17,7 +17,7 @@ on:
         type: string
       generate_dockerhub_images:
         description: "Whether to generate Docker Hub images"
-        default: "false"
+        default: false
         type: boolean
     outputs:
       matrix:

--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -29,9 +29,9 @@ on:
         type: string
       use-only-dl-pytorch-org:
         description: 'Use only download.pytorch.org when generating wheel install command'
-        default: false
+        default: "false"
         required: false
-        type: boolean
+        type: string
       use-meta-cdn:
         description: 'Use meta cdn for installing pip binaries'
         default: false
@@ -70,9 +70,9 @@ on:
         type: string
       use-only-dl-pytorch-org:
         description: 'Use only download.pytorch.org when generating wheel install command'
-        default: false
+        default: "false"
         required: false
-        type: boolean
+        type: string
       use-meta-cdn:
         description: 'Use meta cdn for installing pip binaries'
         default: false

--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -1,0 +1,157 @@
+name: Validate Aarch64 linux binaries
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: "Channel to use (nightly, test, release, all)"
+        required: true
+        type: string
+      torchonly:
+        description: 'Validate torchonly'
+        default: false
+        required: false
+        type: boolean
+      version:
+        description: 'Version to validate - optional'
+        default: ""
+        required: false
+        type: string
+      use-version-set:
+        description: 'Applies when version is used, use version for each domain'
+        default: false
+        required: false
+        type: boolean
+      release-matrix:
+        description: 'Release matrix - optional'
+        default: ""
+        required: false
+        type: string
+      use-only-dl-pytorch-org:
+        description: 'Use only download.pytorch.org when generating wheel install command'
+        default: false
+        required: false
+        type: boolean
+      use-meta-cdn:
+        description: 'Use meta cdn for installing pip binaries'
+        default: false
+        required: false
+        type: boolean
+      use-extra-index-url:
+        description: 'Use extra-index url for pip tests'
+        default: false
+        required: false
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Channel to use (nightly, test, release, all)"
+        required: true
+        type: choice
+        options:
+          - release
+          - nightly
+          - test
+          - all
+      torchonly:
+        description: 'Validate torchonly'
+        default: false
+        required: false
+        type: boolean
+      version:
+        description: 'Version to validate - optional'
+        default: ""
+        required: false
+        type: string
+      release-matrix:
+        description: 'Release matrix - optional'
+        default: ""
+        required: false
+        type: string
+      use-only-dl-pytorch-org:
+        description: 'Use only download.pytorch.org when generating wheel install command'
+        default: false
+        required: false
+        type: boolean
+      use-meta-cdn:
+        description: 'Use meta cdn for installing pip binaries'
+        default: false
+        required: false
+        type: boolean
+      use-extra-index-url:
+        description: 'Use extra-index url for pip tests'
+        default: false
+        required: false
+        type: boolean
+      use-version-set:
+        description: 'Applies when version is used, use version for each domain'
+        default: false
+        required: false
+        type: boolean
+
+jobs:
+  generate-aarch64-linux-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: wheel
+      os: linux-aarch64
+      channel: ${{ inputs.channel }}
+      with-cuda: disable
+      use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
+
+  linux-aarch64:
+    needs: generate-aarch64-linux-matrix
+    strategy:
+      matrix: ${{ fromJson(needs.generate-aarch64-linux-matrix.outputs.matrix) }}
+      fail-fast: false
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    name: ${{ matrix.build_name }}
+    with:
+      runner: ${{ matrix.validation_runner }}
+      repository: "pytorch/pytorch"
+      ref: main
+      job-name: ${{ matrix.build_name }}
+      docker-image: ${{ matrix.container_image }}
+      binary-matrix: ${{ toJSON(matrix) }}
+      no-sudo: true
+      script: |
+        set -ex
+        export DESIRED_PYTHON=${{ matrix.python_version }}
+        echo "/opt/conda/bin" >> $GITHUB_PATH
+        ###############################################################################
+        # Install conda
+        # disable SSL_verify due to getting "Could not find a suitable TLS CA certificate bundle, invalid path"
+        # when using Python version, less than the conda latest
+        ###############################################################################
+        echo 'Installing conda-forge'
+        curl -L -o /mambaforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh
+        chmod +x /mambaforge.sh
+        /mambaforge.sh -b -p /opt/conda
+        rm /mambaforge.sh
+        source /opt/conda/etc/profile.d/conda.sh
+        conda config --set ssl_verify False
+
+        export ENV_NAME="conda-env-${{ github.run_id }}"
+        export TARGET_OS="linux-aarch64"
+        export TORCH_ONLY=${{ inputs.torchonly }}
+        export RELEASE_VERSION=${{ inputs.version }}
+        export USE_FORCE_REINSTALL="true"
+        export USE_EXTRA_INDEX_URL=${{ inputs.use-extra-index-url }}
+        export USE_META_CDN=${{ inputs.use-meta-cdn }}
+        export USE_VERSION_SET=${{ inputs.use-version-set }}
+        if [[ ${USE_VERSION_SET} == 'true' ]]; then
+          export VISION_RELEASE_VERSION=${{ fromJson(inputs.release-matrix).torchvision }}
+          export AUDIO_RELEASE_VERSION=${{ fromJson(inputs.release-matrix).torchaudio }}
+        fi
+
+        printf '%s\n' ${{ toJson(inputs.release-matrix) }} > release_matrix.json
+        eval "$(conda shell.bash hook)"
+
+        # NB: The latest conda 23.11.0 pulls in some dependencies of conda-libmamba-solver that
+        # require GLIBC_2.25, which is not available in the current aarch64 image causing the
+        # subsequence git command to fail. Basically, they don't work with CentOS 7 which AML 2
+        # is based on https://github.com/ContinuumIO/anaconda-issues/issues/12822
+        unset LD_LIBRARY_PATH
+
+        # Standard case: Validate binaries
+        source ../../.github/scripts/validate_binaries.sh

--- a/.github/workflows/validate-binaries.yml
+++ b/.github/workflows/validate-binaries.yml
@@ -34,9 +34,9 @@ on:
         type: boolean
       use-only-dl-pytorch-org:
         description: 'Use only download.pytorch.org when generating wheel install command'
-        default: false
+        default: "false"
         required: false
-        type: boolean
+        type: string
       use-meta-cdn:
         description: 'Use meta cdn for installing pip binaries'
         default: false
@@ -93,9 +93,9 @@ on:
         type: boolean
       use-only-dl-pytorch-org:
         description: 'Use only download.pytorch.org when generating wheel install command'
-        default: false
+        default: "false"
         required: false
-        type: boolean
+        type: string
       use-meta-cdn:
         description: 'Use meta cdn for installing pip binaries'
         default: false

--- a/.github/workflows/validate-binaries.yml
+++ b/.github/workflows/validate-binaries.yml
@@ -1,0 +1,174 @@
+name: Validate binaries
+
+# A reusable workflow that triggers a set of jobs that perform a smoke test / validation of pytorch binaries.
+# Optionally restricts validation to the specified OS and channel.
+# For the details about parameter values, see:
+#   pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+# For an example of the `workflow_call` usage see:
+#   https://github.com/pytorch/builder/pull/1144
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: "Operating system to generate for (linux, windows, macos, macos-arm64)"
+        required: true
+        type: string
+      channel:
+        description: "Channel to use (nightly, test, release, all)"
+        required: true
+        type: string
+      torchonly:
+        description: 'Validate torchonly'
+        default: false
+        required: false
+        type: boolean
+      include-test-ops:
+        description: 'Include Test Ops tests (only Linux)'
+        default: false
+        required: false
+        type: boolean
+      use-version-set:
+        description: 'Use version for each domain'
+        default: false
+        required: false
+        type: boolean
+      use-only-dl-pytorch-org:
+        description: 'Use only download.pytorch.org when generating wheel install command'
+        default: false
+        required: false
+        type: boolean
+      use-meta-cdn:
+        description: 'Use meta cdn for installing pip binaries'
+        default: false
+        required: false
+        type: boolean
+      use_split_build:
+        description: |
+          [Experimental] Use Split Build
+        required: false
+        type: boolean
+        default: false
+      use-extra-index-url:
+        description: 'Use extra-index url for pip tests'
+        default: false
+        required: false
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      os:
+        description: "Operating system to generate for (linux, windows, macos, macos-arm64)"
+        required: true
+        type: choice
+        default: all
+        options:
+          - windows
+          - linux
+          - linux-aarch64
+          - macos
+          - all
+      channel:
+        description: "Channel to use (nightly, test, release, all)"
+        required: true
+        type: choice
+        default: test
+        options:
+          - release
+          - nightly
+          - test
+          - all
+      torchonly:
+        description: 'Validate torchonly'
+        default: false
+        required: false
+        type: boolean
+      version:
+        description: 'Version to validate'
+        default: ""
+        required: false
+        type: string
+      include-test-ops:
+        description: 'Include Test Ops tests (only Linux)'
+        default: false
+        required: false
+        type: boolean
+      use-only-dl-pytorch-org:
+        description: 'Use only download.pytorch.org when generating wheel install command'
+        default: false
+        required: false
+        type: boolean
+      use-meta-cdn:
+        description: 'Use meta cdn for installing pip binaries'
+        default: false
+        required: false
+        type: boolean
+      use_split_build:
+        description: |
+          [Experimental] Use Split Build
+        required: false
+        type: boolean
+        default: false
+      use-extra-index-url:
+        description: 'Use extra-index url for pip tests'
+        default: false
+        required: false
+        type: boolean
+
+jobs:
+  generate-release-matrix:
+    uses: ./.github/workflows/generate_release_matrix.yml
+    with:
+      version: ${{ inputs.version }}
+
+  win:
+    if:  inputs.os == 'windows' || inputs.os == 'all'
+    needs: generate-release-matrix
+    uses: ./.github/workflows/validate-windows-binaries.yml
+    with:
+      channel: ${{ inputs.channel }}
+      torchonly: ${{ inputs.torchonly }}
+      version: ${{ inputs.version }}
+      release-matrix: ${{ needs.generate-release-matrix.outputs.matrix }}
+      use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
+      use-extra-index-url: ${{ inputs.use-extra-index-url }}
+      use-meta-cdn: ${{ inputs.use-meta-cdn }}
+
+  linux:
+    if:  inputs.os == 'linux' || inputs.os == 'all'
+    needs: generate-release-matrix
+    uses: ./.github/workflows/validate-linux-binaries.yml
+    with:
+      channel: ${{ inputs.channel }}
+      torchonly: ${{ inputs.torchonly }}
+      version: ${{ inputs.version }}
+      release-matrix: ${{ needs.generate-release-matrix.outputs.matrix }}
+      include-test-ops: ${{ inputs.include-test-ops }}
+      use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
+      use_split_build: ${{ inputs.use_split_build }}
+      use-extra-index-url: ${{ inputs.use-extra-index-url }}
+      use-meta-cdn: ${{ inputs.use-meta-cdn }}
+
+  linux-aarch64:
+    if:  inputs.os == 'linux-aarch64' || inputs.os == 'all'
+    needs: generate-release-matrix
+    uses: ./.github/workflows/validate-aarch64-linux-binaries.yml
+    with:
+      channel: ${{ inputs.channel }}
+      torchonly: ${{ inputs.torchonly }}
+      version: ${{ inputs.version }}
+      release-matrix: ${{ needs.generate-release-matrix.outputs.matrix }}
+      use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
+      use-extra-index-url: ${{ inputs.use-extra-index-url }}
+      use-meta-cdn: ${{ inputs.use-meta-cdn }}
+
+  mac-arm64:
+    if:  inputs.os == 'macos' || inputs.os == 'all'
+    needs: generate-release-matrix
+    uses: ./.github/workflows/validate-macos-arm64-binaries.yml
+    with:
+      channel: ${{ inputs.channel }}
+      torchonly: ${{ inputs.torchonly }}
+      version: ${{ inputs.version }}
+      release-matrix: ${{ needs.generate-release-matrix.outputs.matrix }}
+      use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
+      use-extra-index-url: ${{ inputs.use-extra-index-url }}
+      use-meta-cdn: ${{ inputs.use-meta-cdn }}

--- a/.github/workflows/validate-docker-images.yml
+++ b/.github/workflows/validate-docker-images.yml
@@ -47,6 +47,7 @@ jobs:
     uses: ./.github/workflows/generate_docker_release_matrix.yml
     with:
       channel: ${{ inputs.channel }}
+      generate_dockerhub_images: ${{ inputs.generate_dockerhub_images }}
     secrets: inherit
   run-gpu-tests:
     needs: generate-matrix

--- a/.github/workflows/validate-docker-images.yml
+++ b/.github/workflows/validate-docker-images.yml
@@ -12,9 +12,9 @@ on:
         default: 'nightly'
       generate_dockerhub_images:
         description: 'Generate Docker Hub images (strip ghcr.io/ prefix for release)'
-        default: false
+        default: "false"
         required: false
-        type: boolean
+        type: string
       ref:
         description: 'Reference to checkout, defaults to empty'
         default: ""
@@ -33,9 +33,9 @@ on:
           - 'release'
       generate_dockerhub_images:
         description: 'Generate Docker Hub images (strip ghcr.io/ prefix for release)'
-        default: false
+        default: "false"
         required: false
-        type: boolean
+        type: string
       ref:
         description: 'Reference to checkout, defaults to empty'
         default: ""

--- a/.github/workflows/validate-docker-images.yml
+++ b/.github/workflows/validate-docker-images.yml
@@ -1,0 +1,81 @@
+name: Validate Nightly Docker Images
+on:
+  pull_request:
+    paths:
+      - .github/workflows/validate-docker-images.yml
+  workflow_call:
+    inputs:
+      channel:
+        description: 'PyTorch channel to use (nightly, test, release, all)'
+        required: false
+        type: string
+        default: 'nightly'
+      generate_dockerhub_images:
+        description: 'Generate Docker Hub images (strip ghcr.io/ prefix for release)'
+        default: false
+        required: false
+        type: boolean
+      ref:
+        description: 'Reference to checkout, defaults to empty'
+        default: ""
+        required: false
+        type: string
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: 'PyTorch channel to use (nightly, test, release, all)'
+        required: false
+        type: choice
+        default: 'nightly'
+        options:
+          - 'nightly'
+          - 'test'
+          - 'release'
+      generate_dockerhub_images:
+        description: 'Generate Docker Hub images (strip ghcr.io/ prefix for release)'
+        default: false
+        required: false
+        type: boolean
+      ref:
+        description: 'Reference to checkout, defaults to empty'
+        default: ""
+        required: false
+        type: string
+
+jobs:
+  generate-matrix:
+    uses: ./.github/workflows/generate_docker_release_matrix.yml
+    with:
+      channel: ${{ inputs.channel }}
+      generate_dockerhub_images : ${{ inputs.generate_dockerhub_images }}
+    secrets: inherit
+  run-gpu-tests:
+    needs: generate-matrix
+    name: cuda${{ matrix.cuda }}-cudnn${{ matrix.cudnn_version }}-${{ matrix.image_type }}
+    strategy:
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+      fail-fast: false
+    uses: ./.github/workflows/linux_job.yml
+    with:
+      runner: ${{ matrix.validation_runner }}
+      repository: "pytorch/pytorch"
+      ref: main
+      job-name: cuda${{ matrix.cuda }}-cudnn${{ matrix.cudnn_version }}-${{ matrix.image_type }}
+      binary-matrix: ${{ toJSON(matrix) }}
+      docker-image: ${{matrix.docker}}
+      timeout: 180
+      script: |
+        set -ex
+
+        export MATRIX_GPU_ARCH_VERSION="${{ matrix.cuda }}"
+        export MATRIX_IMAGE_TYPE="${{ matrix.image_type }}"
+        export TARGET_OS="linux"
+        TORCH_COMPILE_CHECK="--torch-compile-check enabled"
+        if [[ ${MATRIX_IMAGE_TYPE} == "runtime" ]]; then
+          TORCH_COMPILE_CHECK="--torch-compile-check disabled"
+        fi
+        export MATRIX_GPU_ARCH_TYPE="cuda"
+        if [[ ${MATRIX_GPU_ARCH_VERSION} == "cpu" ]]; then
+          export MATRIX_GPU_ARCH_TYPE="cpu"
+        fi
+        python ./.ci/pytorch/smoke_test/smoke_test.py --package torchonly --runtime-error-check disabled ${TORCH_COMPILE_CHECK}

--- a/.github/workflows/validate-docker-images.yml
+++ b/.github/workflows/validate-docker-images.yml
@@ -47,7 +47,6 @@ jobs:
     uses: ./.github/workflows/generate_docker_release_matrix.yml
     with:
       channel: ${{ inputs.channel }}
-      generate_dockerhub_images: ${{ inputs.generate_dockerhub_images }}
     secrets: inherit
   run-gpu-tests:
     needs: generate-matrix

--- a/.github/workflows/validate-docker-images.yml
+++ b/.github/workflows/validate-docker-images.yml
@@ -47,7 +47,7 @@ jobs:
     uses: ./.github/workflows/generate_docker_release_matrix.yml
     with:
       channel: ${{ inputs.channel }}
-      generate_dockerhub_images : ${{ inputs.generate_dockerhub_images }}
+      generate_dockerhub_images: ${{ inputs.generate_dockerhub_images }}
     secrets: inherit
   run-gpu-tests:
     needs: generate-matrix

--- a/.github/workflows/validate-docker-images.yml
+++ b/.github/workflows/validate-docker-images.yml
@@ -62,6 +62,7 @@ jobs:
       job-name: cuda${{ matrix.cuda }}-cudnn${{ matrix.cudnn_version }}-${{ matrix.image_type }}
       binary-matrix: ${{ toJSON(matrix) }}
       docker-image: ${{matrix.docker}}
+      docker-build-dir: "skip-docker-build"
       timeout: 180
       script: |
         set -ex

--- a/.github/workflows/validate-docker-images.yml
+++ b/.github/workflows/validate-docker-images.yml
@@ -67,7 +67,6 @@ jobs:
       timeout: 180
       script: |
         set -ex
-
         export MATRIX_GPU_ARCH_VERSION="${{ matrix.cuda }}"
         export MATRIX_IMAGE_TYPE="${{ matrix.image_type }}"
         export TARGET_OS="linux"

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -34,9 +34,9 @@ on:
         type: boolean
       use-only-dl-pytorch-org:
         description: 'Use only download.pytorch.org when generating wheel install command'
-        default: false
+        default: "false"
         required: false
-        type: boolean
+        type: string
       use-meta-cdn:
         description: 'Use meta cdn for installing pip binaries'
         default: false
@@ -86,9 +86,9 @@ on:
         type: boolean
       use-only-dl-pytorch-org:
         description: 'Use only download.pytorch.org when generating wheel install command'
-        default: false
+        default: "false"
         required: false
-        type: boolean
+        type: string
       use-meta-cdn:
         description: 'Use meta cdn for installing pip binaries'
         default: false

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -1,0 +1,175 @@
+name: Validate linux binaries
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: "Channel to use (nightly, test, release, all)"
+        required: true
+        type: string
+      torchonly:
+        description: 'Validate torchonly'
+        default: false
+        required: false
+        type: boolean
+      version:
+        description: 'Version to validate - optional'
+        default: ""
+        required: false
+        type: string
+      use-version-set:
+        description: 'Applies when version is used, use version for each domain'
+        default: false
+        required: false
+        type: boolean
+      release-matrix:
+        description: 'Release matrix - optional'
+        default: ""
+        required: false
+        type: string
+      include-test-ops:
+        description: 'Include Test Ops tests (only Linux)'
+        default: false
+        required: false
+        type: boolean
+      use-only-dl-pytorch-org:
+        description: 'Use only download.pytorch.org when generating wheel install command'
+        default: false
+        required: false
+        type: boolean
+      use-meta-cdn:
+        description: 'Use meta cdn for installing pip binaries'
+        default: false
+        required: false
+        type: boolean
+      use_split_build:
+        description: |
+          [Experimental] Use split build
+        required: false
+        type: boolean
+        default: false
+      use-extra-index-url:
+        description: 'Use extra-index url for pip tests'
+        default: false
+        required: false
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Channel to use (nightly, test, release, all)"
+        required: true
+        type: choice
+        options:
+          - release
+          - nightly
+          - test
+          - all
+      torchonly:
+        description: 'Validate torchonly'
+        default: false
+        required: false
+        type: boolean
+      version:
+        description: 'Version to validate - optional'
+        default: ""
+        required: false
+        type: string
+      release-matrix:
+        description: 'Release matrix - optional'
+        default: ""
+        required: false
+        type: string
+      include-test-ops:
+        description: 'Include Test Ops tests (only Linux)'
+        default: false
+        required: false
+        type: boolean
+      use-only-dl-pytorch-org:
+        description: 'Use only download.pytorch.org when generating wheel install command'
+        default: false
+        required: false
+        type: boolean
+      use-meta-cdn:
+        description: 'Use meta cdn for installing pip binaries'
+        default: false
+        required: false
+        type: boolean
+      use_split_build:
+        description: |
+          [Experimental] Use split build
+        required: false
+        type: boolean
+        default: false
+      use-extra-index-url:
+        description: 'Use extra-index url for pip tests'
+        default: false
+        required: false
+        type: boolean
+      use-version-set:
+        description: 'Applies when version is used, use version for each domain'
+        default: false
+        required: false
+        type: boolean
+
+jobs:
+  generate-linux-matrix:
+    uses: ./.github/workflows/generate_binary_build_matrix.yml
+    with:
+      package-type: wheel,libtorch
+      os: linux
+      channel: ${{ inputs.channel }}
+      use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
+      use_split_build: ${{ inputs.use_split_build }}
+      with-xpu: enable
+
+  linux:
+    needs: generate-linux-matrix
+    strategy:
+      matrix: ${{ fromJson(needs.generate-linux-matrix.outputs.matrix) }}
+      fail-fast: false
+    uses: ./.github/workflows/linux_job.yml
+    name: ${{ matrix.build_name }}
+    with:
+      runner: ${{ matrix.validation_runner }}
+      repository: "pytorch/pytorch"
+      ref: main
+      job-name: ${{ matrix.build_name }}
+      docker-image: ${{ (matrix.gpu_arch_type == 'xpu' && matrix.container_image) || (matrix.gpu_arch_version == '12.6' && 'pytorch/almalinux-builder:cpu-main') || 'pytorch/conda-builder' }}
+      binary-matrix: ${{ toJSON(matrix) }}
+      docker-build-dir: "skip-docker-build"
+      timeout: 180
+      script: |
+        set -ex
+        export ENV_NAME="conda-env-${{ github.run_id }}"
+        export TORCH_ONLY=${{ inputs.torchonly }}
+        export INCLUDE_TEST_OPS=${{ inputs.include-test-ops }}
+        export USE_ONLY_DL_PYTORCH_ORG=${{ inputs.use-only-dl-pytorch-org }}
+        export USE_EXTRA_INDEX_URL=${{ inputs.use-extra-index-url }}
+        export USE_META_CDN=${{ inputs.use-meta-cdn }}
+        export RELEASE_VERSION=${{ inputs.version }}
+        export USE_VERSION_SET=${{ inputs.use-version-set }}
+        if [[ ${USE_VERSION_SET} == 'true' ]]; then
+          export VISION_RELEASE_VERSION=${{ fromJson(inputs.release-matrix).torchvision }}
+          export AUDIO_RELEASE_VERSION=${{ fromJson(inputs.release-matrix).torchaudio }}
+        fi
+
+        export USE_FORCE_REINSTALL="true"
+        export TARGET_OS="linux"
+        # Due to xpu doesn't use pytorch/conda-builder image, need to install conda firstly
+        if [[ ${{ matrix.gpu_arch_type }} == 'xpu' ]]; then
+          source /.ci/docker/common/install_conda.sh
+        fi
+        eval "$(conda shell.bash hook)"
+        printf '%s\n' ${{ toJson(inputs.release-matrix) }} > release_matrix.json
+
+        # Special case PyPi installation package. And Install of PyPi package via poetry
+        if [[ ${MATRIX_PACKAGE_TYPE} == "manywheel" && \
+              ${MATRIX_GPU_ARCH_VERSION} == "12.4" && \
+              ${MATRIX_CHANNEL} == "release" && \
+              ${USE_ONLY_DL_PYTORCH_ORG} == "false" ]]; then
+          source ../../test-infra/.github/scripts/validate_pipy.sh
+          source ../../test-infra/.github/scripts/validate_poetry.sh
+        fi
+
+        # Validate binaries
+        source ../../test-infra/.github/scripts/validate_binaries.sh

--- a/.github/workflows/validate-macos-arm64-binaries.yml
+++ b/.github/workflows/validate-macos-arm64-binaries.yml
@@ -1,0 +1,135 @@
+name: Validate MacOS ARM64 Binaries
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: "Channel to use (nightly, test, release, all)"
+        required: true
+        type: string
+      torchonly:
+        description: 'Validate torchonly'
+        default: false
+        required: false
+        type: boolean
+      version:
+        description: 'Version to validate - optional'
+        default: ""
+        required: false
+        type: string
+      use-version-set:
+        description: 'Applies when version is used, use version for each domain'
+        default: false
+        required: false
+        type: boolean
+      release-matrix:
+        description: 'Release matrix - optional'
+        default: ""
+        required: false
+        type: string
+      use-only-dl-pytorch-org:
+        description: 'Use only download.pytorch.org when generating wheel install command'
+        default: false
+        required: false
+        type: boolean
+      use-meta-cdn:
+        description: 'Use meta cdn for installing pip binaries'
+        default: false
+        required: false
+        type: boolean
+      use-extra-index-url:
+        description: 'Use extra-index url for pip tests'
+        default: false
+        required: false
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Channel to use (nightly, test, release, all)"
+        required: true
+        type: choice
+        options:
+          - release
+          - nightly
+          - test
+          - all
+      torchonly:
+        description: 'Validate torchonly'
+        default: false
+        required: false
+        type: boolean
+      version:
+        description: 'Version to validate - optional'
+        default: ""
+        required: false
+        type: string
+      release-matrix:
+        description: 'Release matrix - optional'
+        default: ""
+        required: false
+        type: string
+      use-only-dl-pytorch-org:
+        description: 'Use only download.pytorch.org when generating wheel install command'
+        default: false
+        required: false
+        type: boolean
+      use-meta-cdn:
+        description: 'Use meta cdn for installing pip binaries'
+        default: false
+        required: false
+        type: boolean
+      use-extra-index-url:
+        description: 'Use extra-index url for pip tests'
+        default: false
+        required: false
+        type: boolean
+      use-version-set:
+        description: 'Applies when version is used, use version for each domain'
+        default: false
+        required: false
+        type: boolean
+
+jobs:
+  generate-macos-arm64-matrix:
+    uses: ./.github/workflows/generate_binary_build_matrix.yml
+    with:
+      package-type: wheel,libtorch #  We stopped producing conda nightlies
+      os: macos-arm64
+      channel: ${{ inputs.channel }}
+      use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
+
+  macos-arm64:
+    needs: generate-macos-arm64-matrix
+    strategy:
+      matrix: ${{ fromJson(needs.generate-macos-arm64-matrix.outputs.matrix) }}
+      fail-fast: false
+    uses: ./.github/workflows/macos_job.yml
+    name: ${{ matrix.build_name }}
+    with:
+      runner: ${{ matrix.validation_runner }}
+      repository: "pytorch/pytorch"
+      ref: main
+      job-name: ${{ matrix.build_name }}
+      binary-matrix: ${{ toJSON(matrix) }}
+      script: |
+        set -ex
+        export ENV_NAME="conda-env-${{ github.run_id }}"
+        export TARGET_OS="macos-arm64"
+        export TORCH_ONLY=${{ inputs.torchonly }}
+        export RELEASE_VERSION=${{ inputs.version }}
+        export USE_FORCE_REINSTALL="true"
+        export USE_EXTRA_INDEX_URL=${{ inputs.use-extra-index-url }}
+        export USE_META_CDN=${{ inputs.use-meta-cdn }}
+        export USE_VERSION_SET=${{ inputs.use-version-set }}
+
+        if [[ ${{ matrix.package_type }} == "conda" ]]; then
+          export IS_M1_CONDA_BUILD_JOB=1
+        fi
+
+        if [[ ${USE_VERSION_SET} == 'true' ]]; then
+          export VISION_RELEASE_VERSION=${{ fromJson(inputs.release-matrix).torchvision }}
+          export AUDIO_RELEASE_VERSION=${{ fromJson(inputs.release-matrix).torchaudio }}
+        fi
+
+        printf '%s\n' ${{ toJson(inputs.release-matrix) }} > release_matrix.json
+        source ../../test-infra/.github/scripts/validate_binaries.sh

--- a/.github/workflows/validate-macos-arm64-binaries.yml
+++ b/.github/workflows/validate-macos-arm64-binaries.yml
@@ -29,9 +29,9 @@ on:
         type: string
       use-only-dl-pytorch-org:
         description: 'Use only download.pytorch.org when generating wheel install command'
-        default: false
+        default: "false"
         required: false
-        type: boolean
+        type: string
       use-meta-cdn:
         description: 'Use meta cdn for installing pip binaries'
         default: false
@@ -70,9 +70,9 @@ on:
         type: string
       use-only-dl-pytorch-org:
         description: 'Use only download.pytorch.org when generating wheel install command'
-        default: false
+        default: "false"
         required: false
-        type: boolean
+        type: string
       use-meta-cdn:
         description: 'Use meta cdn for installing pip binaries'
         default: false

--- a/.github/workflows/validate-nightly-binaries.yml
+++ b/.github/workflows/validate-nightly-binaries.yml
@@ -1,0 +1,34 @@
+# Scheduled validation of the nightly binaries
+name: Nightly Binaries Validations
+
+on:
+  schedule:
+    # At 3:30 pm UTC (8:30 am PDT)
+    - cron: "30 15 * * *"
+  # Have the ability to trigger this job manually through the API
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/validate-nightly-binaries.yml
+      - .github/workflows/validate-linux-binaries.yml
+      - .github/workflows/validate-windows-binaries.yml
+      - .github/workflows/validate-macos-arm64-binaries.yml
+      - test/smoke_test/*
+  pull_request:
+    paths:
+      - .github/workflows/validate-nightly-binaries.yml
+      - .github/workflows/validate-linux-binaries.yml
+      - .github/workflows/validate-windows-binaries.yml
+      - .github/workflows/validate-macos-arm64-binaries.yml
+      - .github/scripts/validate_binaries.sh
+      - test/smoke_test/*
+
+jobs:
+  nightly:
+    uses: ./.github/workflows/validate-binaries.yml
+    with:
+      channel: nightly
+      os: all
+      use-meta-cdn: false

--- a/.github/workflows/validate-nightly-pypi-wheel-binary-size.yml
+++ b/.github/workflows/validate-nightly-pypi-wheel-binary-size.yml
@@ -1,0 +1,26 @@
+name: Validate Nightly PyPI Wheel Binary Size
+on:
+  pull_request:
+    paths:
+      - .github/workflows/validate-nightly-pypi-wheel-binary-size.yml
+  workflow_dispatch:
+  schedule:
+    # At 2:30 pm UTC (7:30 am PDT)
+    - cron: "30 14 * * *"
+
+jobs:
+  nightly-pypi-binary-size-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: pytorch/test-infra
+      - name: Install requirements
+        run: |
+          pip3 install -r tools/binary_size_validation/requirements.txt
+      - name: Run validation
+        run: |
+          python tools/binary_size_validation/binary_size_validation.py \
+              --url https://download.pytorch.org/whl/nightly/cu121/torch/ \
+              --include "linux" --only-latest-version --threshold 750

--- a/.github/workflows/validate-release-binaries.yml
+++ b/.github/workflows/validate-release-binaries.yml
@@ -1,0 +1,16 @@
+# Scheduled validation of the release binaries
+name: Release Binaries Validations
+
+on:
+  schedule:
+    # At 3 am UTC (7 am PDT)
+    - cron: "0 3 * * *"
+  # Have the ability to trigger this job manually through the API
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: ./.github/workflows/validate-binaries.yml
+    with:
+      channel: release
+      os: all

--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -1,0 +1,139 @@
+name: Validate Windows binary images
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: "Channel to use (nightly, test, release, all)"
+        required: true
+        type: string
+      torchonly:
+        description: 'Validate torchonly'
+        default: false
+        required: false
+        type: boolean
+      version:
+        description: 'Version to validate - optional'
+        default: ""
+        required: false
+        type: string
+      use-version-set:
+        description: 'Applies when version is used, use version for each domain'
+        default: false
+        required: false
+        type: boolean
+      release-matrix:
+        description: 'Release matrix - optional'
+        default: ""
+        required: false
+        type: string
+      use-only-dl-pytorch-org:
+        description: 'Use only download.pytorch.org when generating wheel install command'
+        default: false
+        required: false
+        type: boolean
+      use-meta-cdn:
+        description: 'Use meta cdn for installing pip binaries'
+        default: false
+        required: false
+        type: boolean
+      use-extra-index-url:
+        description: 'Use extra-index url for pip tests'
+        default: false
+        required: false
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Channel to use (nightly, test, release, all)"
+        required: true
+        type: choice
+        options:
+          - release
+          - nightly
+          - test
+          - all
+      torchonly:
+        description: 'Validate torchonly'
+        default: false
+        required: false
+        type: boolean
+      version:
+        description: 'Version to validate - optional'
+        default: ""
+        required: false
+        type: string
+      release-matrix:
+        description: 'Release matrix - optional'
+        default: ""
+        required: false
+        type: string
+      use-only-dl-pytorch-org:
+        description: 'Use only download.pytorch.org when generating wheel install command'
+        default: false
+        required: false
+        type: boolean
+      use-meta-cdn:
+        description: 'Use meta cdn for installing pip binaries'
+        default: false
+        required: false
+        type: boolean
+      use-extra-index-url:
+        description: 'Use extra-index url for pip tests'
+        default: false
+        required: false
+        type: boolean
+      use-version-set:
+        description: 'Applies when version is used, use version for each domain'
+        default: false
+        required: false
+        type: boolean
+
+jobs:
+  generate-windows-matrix:
+    uses: ./.github/workflows/generate_binary_build_matrix.yml
+    with:
+      package-type: wheel,libtorch #  We stopped producing conda nightlies
+      os: windows
+      channel: ${{ inputs.channel }}
+      use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
+      with-xpu: enable
+
+  win:
+    needs: generate-windows-matrix
+    strategy:
+      matrix: ${{ fromJson(needs.generate-windows-matrix.outputs.matrix) }}
+      fail-fast: false
+    uses: ./.github/workflows/windows_job.yml
+    name: ${{ matrix.build_name }}
+    with:
+      runner: ${{ matrix.package_type == 'libtorch' && 'windows.4xlarge' || matrix.validation_runner }}
+      repository: "pytorch/pytorch"
+      ref: main
+      job-name: ${{ matrix.build_name }}
+      binary-matrix: ${{ toJSON(matrix) }}
+      timeout: 60
+      script: |
+        set -ex
+        export ENV_NAME="conda-env-${{ github.run_id }}"
+        export TARGET_OS="windows"
+        export TORCH_ONLY=${{ inputs.torchonly }}
+        export RELEASE_VERSION=${{ inputs.version }}
+        export USE_FORCE_REINSTALL="true"
+        export USE_EXTRA_INDEX_URL=${{ inputs.use-extra-index-url }}
+        export USE_META_CDN=${{ inputs.use-meta-cdn }}
+        export USE_VERSION_SET=${{ inputs.use-version-set }}
+        if [[ ${USE_VERSION_SET} == 'true' ]]; then
+          export VISION_RELEASE_VERSION=${{ fromJson(inputs.release-matrix).torchvision }}
+          export AUDIO_RELEASE_VERSION=${{ fromJson(inputs.release-matrix).torchaudio }}
+        fi
+
+        printf '%s\n' ${{ toJson(inputs.release-matrix) }} > release_matrix.json
+        source /c/Jenkins/Miniconda3/etc/profile.d/conda.sh
+        if [[ ${MATRIX_GPU_ARCH_TYPE} == "cuda" ]]; then
+          ./.ci/pytorch/windows/internal/driver_update.bat
+        elif [[ ${MATRIX_GPU_ARCH_TYPE} == "xpu" ]]; then
+          export CUDA_VERSION=xpu
+          ./.ci/pytorch/windows/internal/xpu_install.bat
+        fi
+        source ../../test-infra/.github/scripts/validate_binaries.sh

--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -29,9 +29,9 @@ on:
         type: string
       use-only-dl-pytorch-org:
         description: 'Use only download.pytorch.org when generating wheel install command'
-        default: false
+        default: "false"
         required: false
-        type: boolean
+        type: string
       use-meta-cdn:
         description: 'Use meta cdn for installing pip binaries'
         default: false
@@ -70,9 +70,9 @@ on:
         type: string
       use-only-dl-pytorch-org:
         description: 'Use only download.pytorch.org when generating wheel install command'
-        default: false
+        default: "false"
         required: false
-        type: boolean
+        type: string
       use-meta-cdn:
         description: 'Use meta cdn for installing pip binaries'
         default: false


### PR DESCRIPTION
Moves all the worklfows from builder Validation framework except:
https://github.com/pytorch/builder/blob/main/.github/workflows/validate-repackaged-binary-sizes.yml

Part of https://github.com/pytorch/builder/issues/2054

It needs to be rewritten, followup PR required.