### PR TITLE
[HUD] Fix docs push panel when using CH, ttrs kpi to use CH

### DIFF
--- a/torchci/clickhouse_queries/last_successful_jobs/query.sql
+++ b/torchci/clickhouse_queries/last_successful_jobs/query.sql
@@ -1,7 +1,7 @@
 select
     min(
         DATE_DIFF('second', job.created_at, CURRENT_TIMESTAMP())
-    ) as seconds_ago
+    ) as last_success_seconds_ago
 from
     -- No final because info is unlikely to change after conclusion gets set
     default .workflow_job job
@@ -15,6 +15,6 @@ group by
 having
     count(distinct job.name) >= LENGTH({jobNames: Array(String) })
 order by
-    seconds_ago
+    last_success_seconds_ago
 limit
     1

--- a/torchci/components/metrics/panels/TimeSeriesPanel.tsx
+++ b/torchci/components/metrics/panels/TimeSeriesPanel.tsx
@@ -286,6 +286,8 @@ export default function TimeSeriesPanel({
   max_items_in_series = 0,
   filter = undefined,
   auto_refresh = true,
+  // Additional function to process the data after querying
+  dataReader = undefined,
 }: {
   title: string;
   queryCollection?: string;
@@ -306,6 +308,7 @@ export default function TimeSeriesPanel({
   max_items_in_series?: number;
   filter?: string;
   auto_refresh?: boolean;
+  dataReader?: (_data: { [k: string]: any }[]) => { [k: string]: any }[];
 }) {
   // - Granularity
   // - Group by
@@ -324,13 +327,14 @@ export default function TimeSeriesPanel({
         ])
       )}`;
 
-  const { data } = useSWR(url, fetcher, {
+  const { data: rawData } = useSWR(url, fetcher, {
     refreshInterval: auto_refresh ? 5 * 60 * 1000 : 0,
   });
 
-  if (data === undefined) {
+  if (rawData === undefined) {
     return <Skeleton variant={"rectangular"} height={"100%"} />;
   }
+  const data = dataReader ? dataReader(rawData) : rawData;
 
   let startTime, stopTime;
   if (useClickHouse) {

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -72,15 +72,34 @@ export default function Kpis() {
 
       <Grid item xs={12} lg={6} height={ROW_HEIGHT}>
         <TimeSeriesPanel
-          title={"Time to Red Signal - (Weekly)"}
+          title={"Time to Red Signal - (Weekly, pull workflow)"}
           queryName={"ttrs_percentiles"}
-          queryCollection={"pytorch_dev_infra_kpis"}
-          queryParams={[...timeParams]}
+          queryParams={{
+            ...clickhouseTimeParams,
+            one_bucket: false,
+            percentile_to_get: 0,
+            workflow: "pull",
+          }}
           granularity={"week"}
           timeFieldName={"bucket"}
           yAxisFieldName={"ttrs_mins"}
           yAxisRenderer={(duration) => duration}
-          groupByFieldName={"percentile"}
+          useClickHouse={true}
+          groupByFieldName="percentile"
+          // Format data so that we can display all percentiles in the same
+          // chart
+          dataReader={(data) => {
+            const percentiles = ["p25", "p50", "p75", "p90"];
+            return data.map((d) =>
+              percentiles.map((p) => {
+                return {
+                  ...d,
+                  percentile: p,
+                  ttrs_mins: d[p],
+                };
+              })
+            ).flat();
+          }}
         />
       </Grid>
 

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -87,18 +87,21 @@ export default function Kpis() {
           useClickHouse={true}
           groupByFieldName="percentile"
           // Format data so that we can display all percentiles in the same
-          // chart
+          // chart. Goes from 1 row per timestamp with all percentiles in the
+          // row to 4 rows per timestamp with one percentile in each row.
           dataReader={(data) => {
             const percentiles = ["p25", "p50", "p75", "p90"];
-            return data.map((d) =>
-              percentiles.map((p) => {
-                return {
-                  ...d,
-                  percentile: p,
-                  ttrs_mins: d[p],
-                };
-              })
-            ).flat();
+            return data
+              .map((d) =>
+                percentiles.map((p) => {
+                  return {
+                    ...d,
+                    percentile: p,
+                    ttrs_mins: d[p],
+                  };
+                })
+              )
+              .flat();
           }}
         />
       </Grid>


### PR DESCRIPTION
Fixes 2 charts when using ClickHouse
metrics page: last successful docs push had wrong return value names
kpis page: time to red signal chart to use ClickHouse, also needs some slight changes in formatting of the data to be able to display, as the current panel expects each percentile to be in a different row, but the query returns 1 row for a timestamp with all percentiles in the row