### PR TITLE
[HUD][CH] Move TablePanel to only use CH

### DIFF
--- a/torchci/components/metrics/panels/TablePanelRS.tsx
+++ b/torchci/components/metrics/panels/TablePanelRS.tsx
@@ -1,7 +1,13 @@
+/*
+This file is an exact copy of TablePanel.tsx prior to moving it to only use
+ClickHouse.  After Jan 1 2025, this file will be deleted and all pages depending
+on it will be broken.
+*/
 import HelpIcon from "@mui/icons-material/Help";
 import { Skeleton, Typography } from "@mui/material";
 import IconButton from "@mui/material/IconButton";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import { RocksetParam } from "lib/rockset";
 import useSWR from "swr";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
@@ -9,9 +15,11 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json());
 export default function TablePanel({
   // Human-readable title for this panel.
   title,
-  // Query name
+  // Query lambda collection in Rockset.
+  queryCollection = "metrics",
+  // Query lambda name in Rockset, ("metrics" collection is assumed).
   queryName,
-  // Params to pass to the query.
+  // Params to pass to the Rockset query.
   queryParams,
   // Column definitions for the data grid.
   columns,
@@ -21,18 +29,25 @@ export default function TablePanel({
   helpLink,
   // An optional flag to show the table footer
   showFooter,
+  useClickHouse = false,
 }: {
   title: string;
+  queryCollection?: string;
   queryName: string;
-  queryParams: { [key: string]: any };
+  queryParams: RocksetParam[] | {};
   columns: GridColDef[];
   dataGridProps: any;
   helpLink?: string;
   showFooter?: boolean;
+  useClickHouse?: boolean;
 }) {
-  const url = `/api/clickhouse/${queryName}?parameters=${encodeURIComponent(
-    JSON.stringify(queryParams)
-  )}`;
+  const url = useClickHouse
+    ? `/api/clickhouse/${queryName}?parameters=${encodeURIComponent(
+        JSON.stringify(queryParams)
+      )}`
+    : `/api/query/${queryCollection}/${queryName}?parameters=${encodeURIComponent(
+        JSON.stringify(queryParams)
+      )}`;
 
   const { data } = useSWR(url, fetcher, {
     refreshInterval: 5 * 60 * 1000, // refresh every 5 minutes

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -186,7 +186,6 @@ function TTSPanel({
         },
       ]}
       dataGridProps={{ getRowId: (el: any) => el.name }}
-      useClickHouse={useClickHouse}
     />
   );
 }
@@ -779,7 +778,7 @@ export default function Page() {
           <TablePanel
             title={"Queued Jobs by Machine Type"}
             queryName={"queued_jobs_by_label"}
-            queryParams={[]}
+            queryParams={{}}
             columns={[
               { field: "count", headerName: "Count", flex: 1 },
               {
@@ -792,7 +791,6 @@ export default function Page() {
               { field: "machine_type", headerName: "Machine Type", flex: 4 },
             ]}
             dataGridProps={{ getRowId: (el: any) => el.machine_type }}
-            useClickHouse={useClickHouse}
           />
         </Grid>
 
@@ -800,7 +798,7 @@ export default function Page() {
           <TablePanel
             title={"Jobs in Queue"}
             queryName={"queued_jobs"}
-            queryParams={[]}
+            queryParams={{}}
             columns={[
               {
                 field: "queue_s",
@@ -827,7 +825,6 @@ export default function Page() {
               },
               getRowId: (el: any) => el.html_url,
             }}
-            useClickHouse={useClickHouse}
           />
         </Grid>
 
@@ -934,8 +931,7 @@ export default function Page() {
           <TablePanel
             title={"Failed Jobs Log Classifications"}
             queryName={"log_captures_count"}
-            queryCollection={"metrics"}
-            queryParams={useClickHouse ? timeParamsClickHouse : [...timeParams]}
+            queryParams={timeParamsClickHouse}
             columns={[
               { field: "num", headerName: "Count", flex: 1 },
               { field: "example", headerName: "Example", flex: 4 },
@@ -957,7 +953,6 @@ export default function Page() {
               getRowId: (el: any) =>
                 el.captures ? JSON.stringify(el.captures) : "null",
             }}
-            useClickHouse={useClickHouse}
           />
         </Grid>
 

--- a/torchci/pages/nightlies.tsx
+++ b/torchci/pages/nightlies.tsx
@@ -1,5 +1,5 @@
 import { Grid, Paper, Skeleton, Stack, Typography } from "@mui/material";
-import TablePanel from "components/metrics/panels/TablePanel";
+import TablePanel from "components/metrics/panels/TablePanelRS";
 import dayjs from "dayjs";
 import { EChartsOption } from "echarts";
 import ReactECharts from "echarts-for-react";


### PR DESCRIPTION
Similar to https://github.com/pytorch/test-infra/pull/6032 but for TablePanel

Only page to still use it and is not migrated is torchci/pages/nightlies.tsx