### PR TITLE
[EZ] Slightly less ugly metrics page

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -370,7 +370,7 @@ function WorkflowDuration({
 
   let title: string = `p${ttsPercentile * 100} ${workflowNames.join(
     ", "
-  )} workflows duration`;
+  )} TTS`;
   let queryName: string = "workflow_duration_percentile";
 
   // -1 is the specical case where we will show the avg instead

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -368,9 +368,7 @@ function WorkflowDuration({
 }) {
   const ttsPercentile = percentileParam.value;
 
-  let title: string = `p${ttsPercentile * 100} ${workflowNames.join(
-    ", "
-  )} TTS`;
+  let title: string = `p${ttsPercentile * 100} ${workflowNames.join(", ")} TTS`;
   let queryName: string = "workflow_duration_percentile";
 
   // -1 is the specical case where we will show the avg instead


### PR DESCRIPTION
Shrink the title name of the `p50 pull, trunk workflows duration` box to make the box align with the other boxes in the row

An OCD fix

Before:
<img width="489" alt="image" src="https://github.com/user-attachments/assets/6466d076-46a8-4b99-9038-af9e3500b9db">

After:
<img width="484" alt="image" src="https://github.com/user-attachments/assets/24868548-b1b8-4a60-a5d3-0badbec2a707">
