### PR TITLE
[CH] Remove various mentions of Rockset in comments and variable names

### DIFF
--- a/.github/workflows/update-drci-comments.yml
+++ b/.github/workflows/update-drci-comments.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Retrieve rockset query results and update Dr. CI comments
+      - name: Retrieve query results and update Dr. CI comments
         run: |
           curl --request POST \
             --url 'https://www.torch-ci.com/api/drci/drci' \

--- a/.github/workflows/update-queue-times.yml
+++ b/.github/workflows/update-queue-times.yml
@@ -10,7 +10,7 @@ defaults:
   run:
     working-directory: torchci
 jobs:
-  update-queue-rockset:
+  update-queue-times:
     runs-on: ubuntu-20.04
     permissions:
       id-token: write

--- a/aws/lambda/log-classifier/src/rule_match.rs
+++ b/aws/lambda/log-classifier/src/rule_match.rs
@@ -12,7 +12,7 @@ pub struct Match {
     pub captures: Vec<String>,
 }
 
-/// The actual format that we insert to Rockset.
+/// The actual format that we insert to our database.
 #[derive(Debug, Serialize, Default)]
 pub struct SerializedMatch {
     pub rule: String,

--- a/aws/lambda/usage-log-aggregator/lambda_function.py
+++ b/aws/lambda/usage-log-aggregator/lambda_function.py
@@ -219,7 +219,7 @@ async def aggregate(body: str, context: Any) -> str:
         return json.dumps({"error": "Failed to read from S3"})
 
     # Tne params should contain a list of workflow ids and job ids of the same length. Normally, they come from
-    # Rockset query test_insights_latest_runs
+    # the query test_insights_latest_runs
     workflow_ids = params.get("workflowIds", [])
     jobs_ids = params.get("jobIds", [])
 

--- a/tools/torchci/check_alerts.py
+++ b/tools/torchci/check_alerts.py
@@ -375,7 +375,7 @@ def fetch_hud_data(repo: str, branch: str) -> Any:
     return (hud_data["jobNames"], hud_data["shaGrid"])
 
 
-# TODO: Do something about these flaky jobs, save them in rockset or something
+# TODO: Do something about these flaky jobs, save them or something
 def record_flaky_jobs(flaky_jobs: List[Any]) -> None:
     return
 

--- a/tools/torchci/td/historical_class_failure_correlation.py
+++ b/tools/torchci/td/historical_class_failure_correlation.py
@@ -34,7 +34,7 @@ def extract_test_class_name(test_row):
 
 def main() -> None:
     failed_tests = query_clickhouse(FAILED_TESTS_QUERY, {})
-    print("done querying rockset", flush=True)
+    print("done querying", flush=True)
 
     merge_bases = get_merge_bases_dict()
     filtered_tests = filter_tests(failed_tests, merge_bases)

--- a/tools/torchci/td/historical_file_failure_correlation.py
+++ b/tools/torchci/td/historical_file_failure_correlation.py
@@ -34,7 +34,7 @@ def filter_tests(failed_tests, merge_bases):
     for test in failed_tests:
         sha = test["head_sha"]
         if sha not in merge_bases:
-            # Should only happen if rockset table is unfilled, or if the sha
+            # Should only happen if the table is unfilled, or if the sha
             # doesn't exist somehow
             continue
         merge_base = merge_bases[sha]["merge_base"]

--- a/tools/torchci/td/td_heuristic_historical_edited_files.py
+++ b/tools/torchci/td/td_heuristic_historical_edited_files.py
@@ -44,8 +44,8 @@ def gen_correlation_dict() -> Dict[str, Dict[str, float]]:
     for commit in commits:
         changed_files = commit["changed_files"]
         # Fullname of test files look like test/<file>.py, but invoking files
-        # from rockset don't include the test/ or the .py extension, so remove
-        # those
+        # from the database don't include the test/ or the .py extension, so
+        # remove those
         test_files = [x[5:-3] for x in changed_files if x[5:-3] in invoking_files]
         for test_file in test_files:
             for file in changed_files:

--- a/tools/torchci/td/utils.py
+++ b/tools/torchci/td/utils.py
@@ -49,7 +49,7 @@ def filter_tests(failed_tests, merge_bases):
     for test in failed_tests:
         sha = test["head_sha"]
         if sha not in merge_bases:
-            # Should only happen if rockset table is unfilled, or if the sha
+            # Should only happen if the table is unfilled, or if the sha
             # doesn't exist somehow
             continue
         merge_base = merge_bases[sha]["merge_base"]

--- a/tools/torchci/tests/test_update_test_times.py
+++ b/tools/torchci/tests/test_update_test_times.py
@@ -4,14 +4,14 @@ from torchci.update_test_times import gen_test_class_times, gen_test_file_times
 
 
 class TestUpdateTestTimesFile(unittest.TestCase):
-    def make_rockset_row(self, job: str, config: str, file: str, time: float):
+    def make_db_row(self, job: str, config: str, file: str, time: float):
         return {"base_name": job, "test_config": config, "file": file, "time": time}
 
     def test_gen_test_file_times_create_default(self) -> None:
         data = [
-            self.make_rockset_row("job", "config", "a", 1),
-            self.make_rockset_row("job", "config", "b", 1),
-            self.make_rockset_row("job", "config", "c", 1),
+            self.make_db_row("job", "config", "a", 1),
+            self.make_db_row("job", "config", "b", 1),
+            self.make_db_row("job", "config", "c", 1),
         ]
         res = gen_test_file_times(data, {})
         expected = {
@@ -25,9 +25,9 @@ class TestUpdateTestTimesFile(unittest.TestCase):
 
     def test_gen_test_file_times_defaults_average(self) -> None:
         data = [
-            self.make_rockset_row("job", "config", "a", 1),
-            self.make_rockset_row("job", "config2", "a", 6),
-            self.make_rockset_row("job2", "config", "a", 5),
+            self.make_db_row("job", "config", "a", 1),
+            self.make_db_row("job", "config2", "a", 6),
+            self.make_db_row("job2", "config", "a", 5),
         ]
         res = gen_test_file_times(data, {})
         expected = {
@@ -44,9 +44,9 @@ class TestUpdateTestTimesFile(unittest.TestCase):
 
     def test_gen_test_file_times_override_default(self) -> None:
         data = [
-            self.make_rockset_row("default", "config", "a", 1),
-            self.make_rockset_row("job", "config", "a", 6),
-            self.make_rockset_row("default", "default", "a", 5),
+            self.make_db_row("default", "config", "a", 1),
+            self.make_db_row("job", "config", "a", 6),
+            self.make_db_row("default", "default", "a", 5),
         ]
         res = gen_test_file_times(data, {})
         expected = {
@@ -57,9 +57,9 @@ class TestUpdateTestTimesFile(unittest.TestCase):
 
     def test_gen_test_file_times_override_old_default(self) -> None:
         data = [
-            self.make_rockset_row("default", "config", "a", 1),
-            self.make_rockset_row("job", "config", "a", 6),
-            self.make_rockset_row("default", "default", "a", 5),
+            self.make_db_row("default", "config", "a", 1),
+            self.make_db_row("job", "config", "a", 6),
+            self.make_db_row("default", "default", "a", 5),
         ]
         res = gen_test_file_times(data, {"default": {"config": {"a": 57}}})
         expected = {
@@ -69,7 +69,7 @@ class TestUpdateTestTimesFile(unittest.TestCase):
         self.assertDictEqual(res, expected)
 
         data = [
-            self.make_rockset_row("env", "config", "a", 1),
+            self.make_db_row("env", "config", "a", 1),
         ]
         res = gen_test_file_times(
             data, {"default": {"config": {"a": 57}, "default": {"a": 100}}}
@@ -82,7 +82,7 @@ class TestUpdateTestTimesFile(unittest.TestCase):
 
     def test_gen_test_file_times_old_values_still_present(self) -> None:
         data = [
-            self.make_rockset_row("env", "config", "a", 5),
+            self.make_db_row("env", "config", "a", 5),
         ]
         res = gen_test_file_times(data, {"env": {"config": {"b": 57}}})
         expected = {
@@ -93,7 +93,7 @@ class TestUpdateTestTimesFile(unittest.TestCase):
 
 
 class TestUpdateTestTimesClass(unittest.TestCase):
-    def make_rockset_row(
+    def make_db_row(
         self, job: str, config: str, file: str, classname: str, time: float
     ):
         return {
@@ -106,9 +106,9 @@ class TestUpdateTestTimesClass(unittest.TestCase):
 
     def test_gen_test_class_times_create_default(self) -> None:
         data = [
-            self.make_rockset_row("job", "config", "a", "classa", 1),
-            self.make_rockset_row("job", "config", "a", "classb", 1),
-            self.make_rockset_row("job", "config", "c", "classc", 1),
+            self.make_db_row("job", "config", "a", "classa", 1),
+            self.make_db_row("job", "config", "a", "classb", 1),
+            self.make_db_row("job", "config", "c", "classc", 1),
         ]
         res = gen_test_class_times(data, {})
         expected = {
@@ -123,9 +123,9 @@ class TestUpdateTestTimesClass(unittest.TestCase):
     def test_gen_test_class_times_defaults_average(self) -> None:
         self.maxDiff = None
         data = [
-            self.make_rockset_row("job", "config", "a", "classa", 1),
-            self.make_rockset_row("job", "config2", "a", "classa", 6),
-            self.make_rockset_row("job2", "config", "a", "classa", 5),
+            self.make_db_row("job", "config", "a", "classa", 1),
+            self.make_db_row("job", "config2", "a", "classa", 6),
+            self.make_db_row("job2", "config", "a", "classa", 5),
         ]
         res = gen_test_class_times(data, {})
         expected = {
@@ -142,9 +142,9 @@ class TestUpdateTestTimesClass(unittest.TestCase):
 
     def test_gen_test_class_times_override_default(self) -> None:
         data = [
-            self.make_rockset_row("default", "config", "a", "classa", 1),
-            self.make_rockset_row("job", "config", "a", "classa", 6),
-            self.make_rockset_row("default", "default", "a", "classa", 5),
+            self.make_db_row("default", "config", "a", "classa", 1),
+            self.make_db_row("job", "config", "a", "classa", 6),
+            self.make_db_row("default", "default", "a", "classa", 5),
         ]
         res = gen_test_class_times(data, {})
         expected = {
@@ -159,9 +159,9 @@ class TestUpdateTestTimesClass(unittest.TestCase):
     def test_gen_test_class_times_override_old_default(self) -> None:
         self.maxDiff = None
         data = [
-            self.make_rockset_row("default", "config", "a", "classa", 1),
-            self.make_rockset_row("job", "config", "a", "classa", 6),
-            self.make_rockset_row("default", "default", "a", "classa", 5),
+            self.make_db_row("default", "config", "a", "classa", 1),
+            self.make_db_row("job", "config", "a", "classa", 6),
+            self.make_db_row("default", "default", "a", "classa", 5),
         ]
         res = gen_test_class_times(data, {"default": {"config": {"a": {"classa": 57}}}})
         expected = {
@@ -174,7 +174,7 @@ class TestUpdateTestTimesClass(unittest.TestCase):
         self.assertDictEqual(res, expected)
 
         data = [
-            self.make_rockset_row("env", "config", "a", "classa", 1),
+            self.make_db_row("env", "config", "a", "classa", 1),
         ]
         res = gen_test_class_times(
             data,
@@ -196,7 +196,7 @@ class TestUpdateTestTimesClass(unittest.TestCase):
 
     def test_gen_test_class_times_old_values_still_present(self) -> None:
         data = [
-            self.make_rockset_row("env", "config", "a", "classa", 5),
+            self.make_db_row("env", "config", "a", "classa", 5),
         ]
         res = gen_test_class_times(data, {"env": {"config": {"b": {"classb": 57}}}})
         expected = {


### PR DESCRIPTION
Remove rockset from variable names, workflow names, and comments.

This is non exhaustive, but it helps reduce the results when I search for Rockset in the codebase