### PR TITLE
[disablebot] Allow reading of disable issue for multiple tests

### DIFF
--- a/.github/scripts/test_update_disabled_issues.py
+++ b/.github/scripts/test_update_disabled_issues.py
@@ -3,8 +3,8 @@ from unittest import main, mock, TestCase
 from update_disabled_issues import (
     condense_disable_jobs,
     filter_disable_issues,
-    get_disabled_tests,
     get_disable_issues,
+    get_disabled_tests,
     OWNER,
     REPO,
     UNSTABLE_PREFIX,

--- a/.github/scripts/test_update_disabled_issues.py
+++ b/.github/scripts/test_update_disabled_issues.py
@@ -2,8 +2,8 @@ from unittest import main, mock, TestCase
 
 from update_disabled_issues import (
     condense_disable_jobs,
-    condense_disable_tests,
     filter_disable_issues,
+    get_disabled_tests,
     get_disable_issues,
     OWNER,
     REPO,
@@ -98,13 +98,13 @@ class TestUpdateDisabledIssues(TestCase):
             [item["number"] for item in disabled_jobs], [32132, 42345, 94861]
         )
 
-    def test_condense_disable_tests(self, mock_get_disable_issues):
+    def test_get_disable_tests(self, mock_get_disable_issues):
         mock_get_disable_issues.return_value = MOCK_DATA
 
         disabled_issues = get_disable_issues("dummy token")
 
         disabled_tests, _ = filter_disable_issues(disabled_issues)
-        results = condense_disable_tests(disabled_tests)
+        results = get_disabled_tests(disabled_tests)
 
         self.assertDictEqual(
             {
@@ -123,6 +123,83 @@ class TestUpdateDisabledIssues(TestCase):
                 ),
             },
             results,
+        )
+
+    def test_get_disable_tests_aggregate_issue(self, mock_get_disable_issues):
+        self.maxDiff = None
+        mock_data = [
+            {
+                "url": "https://github.com/pytorch/pytorch/issues/32644",
+                "number": 32644,
+                "title": "DISABLED MULTIPLE dummy test",
+                "body": "disable the following tests:\n```\ntest_quantized_nn (test_quantization.PostTrainingDynamicQuantTest): mac, win\ntest_zero_redundancy_optimizer (__main__.TestZeroRedundancyOptimizerDistributed)\n```",
+            }
+        ]
+        disabled_tests = get_disabled_tests(mock_data)
+        self.assertDictEqual(
+            {
+                "test_quantized_nn (test_quantization.PostTrainingDynamicQuantTest)": (
+                    str(mock_data[0]["number"]),
+                    mock_data[0]["url"],
+                    ["mac", "win"],
+                ),
+                "test_zero_redundancy_optimizer (__main__.TestZeroRedundancyOptimizerDistributed)": (
+                    str(mock_data[0]["number"]),
+                    mock_data[0]["url"],
+                    [],
+                ),
+            },
+            disabled_tests,
+        )
+
+    def test_get_disable_tests_merge_issues(self, mock_get_disable_issues):
+        self.maxDiff = None
+        mock_data = [
+            {
+                "url": "https://github.com/pytorch/pytorch/issues/32644",
+                "number": 32644,
+                "title": "DISABLED MULTIPLE dummy test",
+                "body": "disable the following tests:\n```\ntest_2 (abc.ABC): mac, win\ntest_3 (DEF)\n```",
+            },
+            {
+                "url": "https://github.com/pytorch/pytorch/issues/32645",
+                "number": 32645,
+                "title": "DISABLED MULTIPLE dummy test",
+                "body": "disable the following tests:\n```\ntest_2 (abc.ABC): mac, win, linux\ntest_3 (DEF): mac\n```",
+            },
+            {
+                "url": "https://github.com/pytorch/pytorch/issues/32646",
+                "number": 32646,
+                "title": "DISABLED test_1 (__main__.Test1)",
+                "body": "platforms: linux",
+            },
+            {
+                "url": "https://github.com/pytorch/pytorch/issues/32647",
+                "number": 32647,
+                "title": "DISABLED test_2 (abc.ABC)",
+                "body": "platforms: dynamo",
+            },
+        ]
+        disabled_tests = get_disabled_tests(mock_data)
+        self.assertDictEqual(
+            {
+                "test_2 (abc.ABC)": (
+                    str(mock_data[3]["number"]),
+                    mock_data[3]["url"],
+                    ["dynamo", "linux", "mac", "win"],
+                ),
+                "test_3 (DEF)": (
+                    str(mock_data[1]["number"]),
+                    mock_data[1]["url"],
+                    [],
+                ),
+                "test_1 (__main__.Test1)": (
+                    str(mock_data[2]["number"]),
+                    mock_data[2]["url"],
+                    ["linux"],
+                ),
+            },
+            disabled_tests,
         )
 
     def test_condense_disable_jobs(self, mock_get_disable_issues):

--- a/.github/scripts/test_update_disabled_issues.py
+++ b/.github/scripts/test_update_disabled_issues.py
@@ -126,6 +126,7 @@ class TestUpdateDisabledIssues(TestCase):
         )
 
     def test_get_disable_tests_aggregate_issue(self, mock_get_disable_issues):
+        # Test that the function can read aggregate issues
         self.maxDiff = None
         mock_data = [
             {
@@ -153,6 +154,8 @@ class TestUpdateDisabledIssues(TestCase):
         )
 
     def test_get_disable_tests_merge_issues(self, mock_get_disable_issues):
+        # Test that the function can merge multiple issues with the same test
+        # name
         self.maxDiff = None
         mock_data = [
             {

--- a/.github/scripts/update_disabled_issues.py
+++ b/.github/scripts/update_disabled_issues.py
@@ -156,10 +156,15 @@ def get_disabled_tests(issues: List[Dict[str, Any]]) -> Dict[str, Tuple]:
         if key not in disabled_tests:
             disabled_tests[key] = (number, url, platforms_to_skip)
         else:
+            original_platforms = disabled_tests[key][2]
+            if len(original_platforms) == 0 or len(platforms_to_skip) == 0:
+                platforms = []
+            else:
+                platforms = sorted(set(original_platforms + platforms_to_skip))
             disabled_tests[key] = (
                 number,
                 url,
-                list(set(disabled_tests[key][2] + platforms_to_skip)),
+                platforms,
             )
 
     test_name_regex = re.compile(r"(test_[a-zA-Z0-9-_\.]+)\s+\(([a-zA-Z0-9-_\.]+)\)")
@@ -196,8 +201,7 @@ def get_disabled_tests(issues: List[Dict[str, Any]]) -> Dict[str, Tuple]:
                     if "```" in line:
                         break
                     split_by_colon = line.split(":")
-                    if len(split_by_colon) != 2:
-                        continue
+
                     test_name = parse_test_name(split_by_colon[0].strip())
                     if test_name is None:
                         continue
@@ -205,7 +209,12 @@ def get_disabled_tests(issues: List[Dict[str, Any]]) -> Dict[str, Tuple]:
                         test_name,
                         number,
                         url,
-                        get_platforms_to_skip(split_by_colon[1].strip(), ""),
+                        get_platforms_to_skip(
+                            split_by_colon[1].strip()
+                            if len(split_by_colon) > 1
+                            else "",
+                            "",
+                        ),
                     )
             else:
                 print(f"Unknown disable issue type: {title}")

--- a/.github/scripts/update_disabled_issues.py
+++ b/.github/scripts/update_disabled_issues.py
@@ -19,7 +19,7 @@ from urllib.request import Request, urlopen
 DISABLED_PREFIX = "DISABLED"
 UNSTABLE_PREFIX = "UNSTABLE"
 DISABLED_TEST_ISSUE_TITLE = re.compile(r"DISABLED\s*test_.+\s*\(.+\)")
-DISABLED_TEST_MULTI_ISSUE_TITLE = re.compile(r"DISABLED AGGREGATE")
+DISABLED_TEST_MULTI_ISSUE_TITLE = re.compile(r"DISABLED MULTIPLE")
 JOB_NAME_MAXSPLIT = 2
 
 OWNER = "pytorch"
@@ -186,7 +186,7 @@ def get_disabled_tests(issues: List[Dict[str, Any]]) -> Dict[str, Tuple]:
                 # This is a multi-test issue
                 start = body.lower().find("disable the following tests:")
                 # Format for disabling tests:
-                # Title: DISABLED AGGREGATE <whatever>
+                # Title: DISABLED MULTIPLE anything
                 # disable the following tests:
                 # ```
                 # test_name1 (test_suite1): mac, windows


### PR DESCRIPTION
The expected format of a disable issue for multiple tests is
Title: DISABLED MULTIPLE <can be anything here>

Body:
additional info
disable the following tests:
```
test_name (test_suite): platforms, mac
test_name2 (test_suite):
```
additional info

For example

<img width="841" alt="image" src="https://github.com/user-attachments/assets/63200bc7-5321-4f80-a468-ef1bfdae3a53" />

---

Tested by running old version and new version and diffing the files.  There was no change

