### PR TITLE
[HUD][CH] Everything on metrics page to use ClickHouse only and remove migration related code

### DIFF
--- a/torchci/pages/_githubrunnersutilization.tsx
+++ b/torchci/pages/_githubrunnersutilization.tsx
@@ -7,7 +7,7 @@ import {
   SelectChangeEvent,
   Stack,
 } from "@mui/material";
-import TimeSeriesPanel from "components/metrics/panels/TimeSeriesPanel";
+import TimeSeriesPanel from "components/metrics/panels/TimeSeriesPanelRS";
 import { durationDisplay } from "components/TimeUtils";
 import dayjs from "dayjs";
 import { RocksetParam } from "lib/rockset";

--- a/torchci/pages/cost_analysis.tsx
+++ b/torchci/pages/cost_analysis.tsx
@@ -373,7 +373,6 @@ export default function Page() {
             timeFieldName={"granularity_bucket"}
             yAxisFieldName={`total_${yAxis}`}
             yAxisRenderer={yAxis === "cost" ? costDisplay : hourDisplay}
-            useClickHouse={true}
             smooth={false}
             chartType={chartType}
             filter={searchFilter}

--- a/torchci/pages/disabled.tsx
+++ b/torchci/pages/disabled.tsx
@@ -96,13 +96,11 @@ function GraphPanel({ queryParams }: { queryParams: { [key: string]: any } }) {
       <TimeSeriesPanel
         title={"Number of open disabled tests"}
         queryName={"disabled_test_historical"}
-        queryCollection={"metrics"}
         queryParams={queryParams}
         granularity={"day"}
         timeFieldName={"granularity_bucket"}
         yAxisFieldName={"number_of_open_disabled_tests"}
         yAxisRenderer={(duration) => duration}
-        useClickHouse={true}
       />
     </Grid>
   );

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -10,7 +10,7 @@ export default function Kpis() {
   const [startTime, _setStartTime] = useState(dayjs().subtract(6, "month"));
   const [stopTime, _setStopTime] = useState(dayjs());
 
-  const clickhouseTimeParams = {
+  const timeParams = {
     startTime: startTime.utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
     stopTime: stopTime.utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
   };
@@ -22,7 +22,7 @@ export default function Kpis() {
           title={"% of commits red on trunk (Weekly)"}
           queryName={"master_commit_red_percent"}
           queryParams={{
-            ...clickhouseTimeParams,
+            ...timeParams,
             granularity: "week",
             workflowNames: ["lint", "pull", "trunk"],
           }}
@@ -40,7 +40,7 @@ export default function Kpis() {
         <TimeSeriesPanel
           title={"# of force merges (Weekly)"}
           queryName={"number_of_force_pushes_historical"}
-          queryParams={clickhouseTimeParams}
+          queryParams={timeParams}
           granularity={"week"}
           timeFieldName={"bucket"}
           yAxisFieldName={"count"}
@@ -53,7 +53,7 @@ export default function Kpis() {
           title={"Time to Red Signal - (Weekly, pull workflow)"}
           queryName={"ttrs_percentiles"}
           queryParams={{
-            ...clickhouseTimeParams,
+            ...timeParams,
             one_bucket: false,
             percentile_to_get: 0,
             workflow: "pull",
@@ -88,7 +88,7 @@ export default function Kpis() {
           title={"% of force merges (Weekly, 2 week rolling avg)"}
           queryName={"weekly_force_merge_stats"}
           queryParams={{
-            ...clickhouseTimeParams,
+            ...timeParams,
             one_bucket: false,
             merge_type: "",
             granularity: "week",
@@ -107,7 +107,7 @@ export default function Kpis() {
         <TimeSeriesPanel
           title={"Avg time-to-signal - E2E (Weekly)"}
           queryName={"time_to_signal"}
-          queryParams={clickhouseTimeParams}
+          queryParams={timeParams}
           granularity={"week"}
           timeFieldName={"week_bucket"}
           yAxisFieldName={"avg_tts"}
@@ -121,7 +121,7 @@ export default function Kpis() {
         <TimeSeriesPanel
           title={"# of reverts (2 week moving avg)"}
           queryName={"num_reverts"}
-          queryParams={clickhouseTimeParams}
+          queryParams={timeParams}
           granularity={"week"}
           timeFieldName={"bucket"}
           yAxisFieldName={"num"}
@@ -135,7 +135,7 @@ export default function Kpis() {
           title={"viable/strict lag (Daily)"}
           queryName={"strict_lag_historical"}
           queryParams={{
-            ...clickhouseTimeParams,
+            ...timeParams,
             // Missing data prior to 2024-10-01 due to migration to ClickHouse
             ...(startTime < dayjs("2024-10-01") && {
               startTime: dayjs("2024-10-01")
@@ -158,7 +158,7 @@ export default function Kpis() {
         <TimeSeriesPanel
           title={"Weekly external PR count (4 week moving average)"}
           queryName={"external_contribution_stats"}
-          queryParams={clickhouseTimeParams}
+          queryParams={timeParams}
           granularity={"week"}
           timeFieldName={"granularity_bucket"}
           yAxisFieldName={"pr_count"}
@@ -171,7 +171,7 @@ export default function Kpis() {
         <TimeSeriesPanel
           title={"Monthly external PR count"}
           queryName={"monthly_contribution_stats"}
-          queryParams={clickhouseTimeParams}
+          queryParams={timeParams}
           granularity={"month"}
           timeFieldName={"year_and_month"}
           timeFieldDisplayFormat={"MMMM YYYY"}
@@ -185,7 +185,7 @@ export default function Kpis() {
         <TimeSeriesPanel
           title={"Total number of open disabled tests (Daily)"}
           queryName={"disabled_test_historical"}
-          queryParams={{ ...clickhouseTimeParams, repo: "pytorch/pytorch" }}
+          queryParams={{ ...timeParams, repo: "pytorch/pytorch" }}
           granularity={"day"}
           timeFieldName={"granularity_bucket"}
           yAxisFieldName={"number_of_open_disabled_tests"}

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -813,27 +813,15 @@ export default function Page() {
           <TimeSeriesPanel
             title={"Queue times historical"}
             queryName={"queue_times_historical"}
-            queryParams={
-              useClickHouse
-                ? {
-                    ...timeParamsClickHouse,
-                    granlarity: "hour",
-                  }
-                : [
-                    {
-                      name: "timezone",
-                      type: "string",
-                      value: Intl.DateTimeFormat().resolvedOptions().timeZone,
-                    },
-                    ...timeParams,
-                  ]
-            }
+            queryParams={{
+              ...timeParamsClickHouse,
+              granlarity: "hour",
+            }}
             granularity={"hour"}
             groupByFieldName={"machine_type"}
             timeFieldName={"granularity_bucket"}
             yAxisFieldName={"avg_queue_s"}
             yAxisRenderer={durationDisplay}
-            useClickHouse={useClickHouse}
           />
         </Grid>
 
@@ -841,30 +829,13 @@ export default function Page() {
           <TimeSeriesPanel
             title={"Workflow load per Day"}
             queryName={"workflow_load"}
-            queryParams={
-              useClickHouse
-                ? { ...timeParamsClickHouse, repo: "pytorch/pytorch" }
-                : [
-                    {
-                      name: "timezone",
-                      type: "string",
-                      value: Intl.DateTimeFormat().resolvedOptions().timeZone,
-                    },
-                    {
-                      name: "repo",
-                      type: "string",
-                      value: "pytorch/pytorch",
-                    },
-                    ...timeParams,
-                  ]
-            }
+            queryParams={{ ...timeParamsClickHouse, repo: "pytorch/pytorch" }}
             granularity={"hour"}
             groupByFieldName={"name"}
             timeFieldName={"granularity_bucket"}
             yAxisFieldName={"count"}
             yAxisLabel={"workflows started"}
             yAxisRenderer={(value) => value}
-            useClickHouse={useClickHouse}
           />
         </Grid>
 
@@ -941,29 +912,12 @@ export default function Page() {
           <TimeSeriesPanel
             title={"Number of new disabled tests"}
             queryName={"disabled_test_historical"}
-            queryParams={
-              useClickHouse
-                ? { ...timeParamsClickHouse, repo: "pytorch/pytorch" }
-                : [
-                    {
-                      name: "timezone",
-                      type: "string",
-                      value: Intl.DateTimeFormat().resolvedOptions().timeZone,
-                    },
-                    {
-                      name: "repo",
-                      type: "string",
-                      value: "pytorch/pytorch",
-                    },
-                    ...timeParams,
-                  ]
-            }
+            queryParams={{ ...timeParamsClickHouse, repo: "pytorch/pytorch" }}
             granularity={"day"}
             timeFieldName={"granularity_bucket"}
             yAxisFieldName={"number_of_new_disabled_tests"}
             yAxisRenderer={(value) => value}
             additionalOptions={{ yAxis: { scale: true } }}
-            useClickHouse={useClickHouse}
           />
         </Grid>
 
@@ -983,25 +937,13 @@ export default function Page() {
           <TimeSeriesPanel
             title={"LF vs Meta: Success rate delta"}
             queryName={"lf_rollover_health"}
-            queryCollection={"metrics"}
-            queryParams={
-              useClickHouse
-                ? { ...timeParamsClickHouse, days_ago: timeRange }
-                : [
-                    {
-                      name: "days_ago",
-                      type: "int",
-                      value: timeRange,
-                    },
-                  ]
-            }
+            queryParams={{ ...timeParamsClickHouse, days_ago: timeRange }}
             granularity={"day"}
             timeFieldName={"bucket"}
             yAxisLabel={"rate delta"}
             yAxisFieldName={"success_rate_delta"}
             yAxisRenderer={(value) => value}
             groupByFieldName={"job_name"}
-            useClickHouse={useClickHouse}
           />
         </Grid>
 
@@ -1009,25 +951,13 @@ export default function Page() {
           <TimeSeriesPanel
             title={"LF vs Meta: Cancelled rate delta"}
             queryName={"lf_rollover_health"}
-            queryCollection={"metrics"}
-            queryParams={
-              useClickHouse
-                ? { ...timeParamsClickHouse, days_ago: timeRange }
-                : [
-                    {
-                      name: "days_ago",
-                      type: "int",
-                      value: timeRange,
-                    },
-                  ]
-            }
+            queryParams={{ ...timeParamsClickHouse, days_ago: timeRange }}
             granularity={"day"}
             timeFieldName={"bucket"}
             yAxisLabel={"rate delta"}
             yAxisFieldName={"cancelled_rate_delta"}
             yAxisRenderer={(value) => value}
             groupByFieldName={"job_name"}
-            useClickHouse={useClickHouse}
           />
         </Grid>
 
@@ -1035,49 +965,25 @@ export default function Page() {
           <TimeSeriesPanel
             title={"LF vs Meta: Duration increase ratio"}
             queryName={"lf_rollover_health"}
-            queryCollection={"metrics"}
-            queryParams={
-              useClickHouse
-                ? { ...timeParamsClickHouse, days_ago: timeRange }
-                : [
-                    {
-                      name: "days_ago",
-                      type: "int",
-                      value: timeRange,
-                    },
-                  ]
-            }
+            queryParams={{ ...timeParamsClickHouse, days_ago: timeRange }}
             granularity={"day"}
             timeFieldName={"bucket"}
             yAxisLabel="increase ratio"
             yAxisFieldName={"success_duration_increase_ratio"}
             yAxisRenderer={(value) => value}
             groupByFieldName={"job_name"}
-            useClickHouse={useClickHouse}
           />
         </Grid>
         <Grid item xs={12} height={ROW_HEIGHT}>
           <TimeSeriesPanel
             title={"Percentage of jobs rolled over to Linux Foundation"}
             queryName={"lf_rollover_percentage"}
-            queryCollection={"metrics"}
-            queryParams={
-              useClickHouse
-                ? { ...timeParamsClickHouse, days_ago: timeRange }
-                : [
-                    {
-                      name: "days_ago",
-                      type: "int",
-                      value: timeRange,
-                    },
-                  ]
-            }
+            queryParams={{ ...timeParamsClickHouse, days_ago: timeRange }}
             granularity={"hour"}
             timeFieldName={"bucket"}
             yAxisFieldName={"percentage"}
             groupByFieldName={"fleet"}
             yAxisRenderer={(value) => value.toFixed(2).toString() + "%"}
-            useClickHouse={useClickHouse}
           />
         </Grid>
       </Grid>

--- a/torchci/pages/sli.tsx
+++ b/torchci/pages/sli.tsx
@@ -267,7 +267,6 @@ export default function Page() {
         <TimeSeriesPanel
           title={"GHA Worker Queue Time"}
           queryName={"queue_times_historical_pct"}
-          useClickHouse={true}
           queryParams={{
             timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
             pctile: ttsPercentile,


### PR DESCRIPTION
As in title.

Most things were already switched by previous, similar PRs for components