### PR TITLE
CI: Migrate malfet/checkout to test-infra

### DIFF
--- a/.github/actions/bc-lint/action.yml
+++ b/.github/actions/bc-lint/action.yml
@@ -29,12 +29,12 @@ runs:
         path: _test-infra
 
     - name: Checkout ${{ inputs.repo }}
-      uses: malfet/checkout@silent-checkout
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.head_sha }}
         fetch-depth: -1
         submodules: false
-        quiet-checkout: true
+        show-progress: false
         path: _repo
 
     - name: Merge PR changes onto base

--- a/.github/workflows/pr-dependencies-check.yml
+++ b/.github/workflows/pr-dependencies-check.yml
@@ -46,12 +46,12 @@ jobs:
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Pytorch repository
-        uses: malfet/checkout@silent-checkout
+        uses: actions/checkout@v4
         with:
           repository: pytorch/pytorch
           fetch-depth: -1
           submodules: false
-          quiet-checkout: true
+          show-progress: false
 
       - name: Set up Git
         shell: bash


### PR DESCRIPTION
We are migrating this action "malfet/checkout@silent-checkout" into test-infra to have all the code hosted in our public repos.