### PR TITLE
allow to group by gpu/non-gpu

### DIFF
--- a/torchci/clickhouse_queries/cost_job_per_gpu/params.json
+++ b/torchci/clickhouse_queries/cost_job_per_gpu/params.json
@@ -1,0 +1,10 @@
+{
+  "granularity": "String",
+  "startTime": "DateTime64(9)",
+  "stopTime": "DateTime64(9)",
+  "selectedRepos": "Array(String)",
+  "selectedGPU": "Array(UInt8)",
+  "selectedPlatforms": "Array(String)",
+  "selectedProviders": "Array(String)",
+  "selectedOwners": "Array(String)"
+}

--- a/torchci/clickhouse_queries/cost_job_per_gpu/query.sql
+++ b/torchci/clickhouse_queries/cost_job_per_gpu/query.sql
@@ -1,0 +1,24 @@
+select
+    DATE_TRUNC(
+        {granularity: String},
+        rc.date
+    ) as granularity_bucket,
+    rc.gpu as gpu,
+    sum(rc.cost) as total_cost
+from
+    misc.runner_cost rc final
+where
+    rc.date > {startTime: DateTime64(9)}
+    and rc.date < {stopTime: DateTime64(9)}
+    and rc.cost > 0
+    and rc.group_repo in {selectedRepos: Array(String)}
+    and rc.gpu in {selectedGPU: Array(UInt8)}
+    and rc.os in {selectedPlatforms: Array(String)}
+    and rc.provider in {selectedProviders: Array(String)}
+    and rc.owning_account in {selectedOwners: Array(String)}
+group by
+    granularity_bucket,
+    gpu
+order by
+    granularity_bucket asc
+

--- a/torchci/clickhouse_queries/duration_job_per_gpu/params.json
+++ b/torchci/clickhouse_queries/duration_job_per_gpu/params.json
@@ -1,0 +1,10 @@
+{
+  "granularity": "String",
+  "startTime": "DateTime64(9)",
+  "stopTime": "DateTime64(9)",
+  "selectedRepos": "Array(String)",
+  "selectedGPU": "Array(UInt8)",
+  "selectedPlatforms": "Array(String)",
+  "selectedProviders": "Array(String)",
+  "selectedOwners": "Array(String)"
+}

--- a/torchci/clickhouse_queries/duration_job_per_gpu/query.sql
+++ b/torchci/clickhouse_queries/duration_job_per_gpu/query.sql
@@ -1,0 +1,24 @@
+select
+    DATE_TRUNC(
+        {granularity: String},
+        rc.date
+    ) as granularity_bucket,
+    rc.gpu as gpu,
+    sum(rc.duration) as total_duration
+from
+    misc.runner_cost rc final
+where
+    rc.date > {startTime: DateTime64(9)}
+    and rc.date < {stopTime: DateTime64(9)}
+    and rc.duration > 0
+    and rc.group_repo in {selectedRepos: Array(String)}
+    and rc.gpu in {selectedGPU: Array(UInt8)}
+    and rc.os in {selectedPlatforms: Array(String)}
+    and rc.provider in {selectedProviders: Array(String)}
+    and rc.owning_account in {selectedOwners: Array(String)}
+group by
+    granularity_bucket,
+    gpu
+order by
+    granularity_bucket asc
+

--- a/torchci/pages/cost_analysis.tsx
+++ b/torchci/pages/cost_analysis.tsx
@@ -456,6 +456,7 @@ export default function Page() {
               <MenuItem value={"platform"}>Platform</MenuItem>
               <MenuItem value={"provider"}>Provider</MenuItem>
               <MenuItem value={"owning_account"}>Owning Account</MenuItem>
+              <MenuItem value={"gpu"}>GPU/Non-GPU</MenuItem>
             </Select>
           </FormControl>
         </Grid>


### PR DESCRIPTION
This allows the cost analysis to group by gpu/non-gpu:

[https://torchci-git-wdvr-gpu-nongpu-cost-fbopensource.vercel.app/cost_analysis?dateRange=7&granularity=day&**groupby=gpu**&chartType=line&yAxis=cost](https://torchci-git-wdvr-gpu-nongpu-cost-fbopensource.vercel.app/cost_analysis?dateRange=7&granularity=day&groupby=gpu&chartType=line&yAxis=cost)

See on the right 'group by' -> 'GPU'
