### PR TITLE
mandate IMDSv2 on all new ec2 runners

### DIFF
--- a/terraform-aws-github-runner/modules/runners-instances/launch-template.tf
+++ b/terraform-aws-github-runner/modules/runners-instances/launch-template.tf
@@ -109,7 +109,7 @@ resource "aws_launch_template" "linux_runner" {
 
   metadata_options {
     http_endpoint               = "enabled"
-    http_tokens                 = "optional"
+    http_tokens                 = "required"
     http_put_response_hop_limit = 3
     instance_metadata_tags      = "enabled"
   }
@@ -165,7 +165,7 @@ resource "aws_launch_template" "linux_runner_nvidia" {
 
   metadata_options {
     http_endpoint               = "enabled"
-    http_tokens                 = "optional"
+    http_tokens                 = "required"
     http_put_response_hop_limit = 3
     instance_metadata_tags      = "enabled"
   }
@@ -221,7 +221,7 @@ resource "aws_launch_template" "linux_arm64_runner" {
 
   metadata_options {
     http_endpoint               = "enabled"
-    http_tokens                 = "optional"
+    http_tokens                 = "required"
     http_put_response_hop_limit = 3
     instance_metadata_tags      = "enabled"
   }
@@ -292,7 +292,7 @@ resource "aws_launch_template" "windows_runner" {
 
     metadata_options {
     http_endpoint               = "enabled"
-    http_tokens                 = "optional"
+    http_tokens                 = "required"
     http_put_response_hop_limit = 3
     instance_metadata_tags      = "enabled"
   }


### PR DESCRIPTION
This follows the removal of all IMDSv1 calls weeks ago, as well as the upgrade of sccache on all repos that use it.

test plan: 

We'll monitor impact, but current IMDSv1 calls are close to 0, with those left being ones based of a main older than a few weeks.

mitigation in case of failure:
- revert this
- **https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-IMDS-existing-instances.html#modify-restore-IMDSv1** for existing runners