### PR TITLE
Fix a bug when swapfile doesn't exist

### DIFF
--- a/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
@@ -138,9 +138,11 @@ fi
 
 ${post_install}
 
-# Cleanup any existing swapfile just to be sure
-sudo swapoff /swapfile
-sudo rm /swapfile
+if [[ -f /swapfile ]]; then
+  # Cleanup any existing swapfile just to be sure
+  sudo swapoff /swapfile
+  sudo rm /swapfile
+fi
 # before allocating a new one
 sudo fallocate -l 3G /swapfile
 sudo chmod 600 /swapfile


### PR DESCRIPTION
I made a mistake in https://github.com/pytorch/test-infra/pull/6066 and should have checked if the file exists first.