### PR TITLE
[HUD] Reduce number of clicks for expanding grouping

### DIFF
--- a/torchci/components/GroupHudTableHeaders.tsx
+++ b/torchci/components/GroupHudTableHeaders.tsx
@@ -68,9 +68,6 @@ export function GroupHudTableHeader({ names }: { names: string[] }) {
               key={name}
               style={{ ...jobStyle }}
               onClick={(e: React.MouseEvent) => {
-                if (pinnedId.name !== undefined || pinnedId.sha !== undefined) {
-                  return;
-                }
                 if (expandedGroups.has(name)) {
                   expandedGroups.delete(name);
                   setExpandedGroups(new Set(expandedGroups));


### PR DESCRIPTION
Reduce the number of clicks needed to expand/collapse a group by removing the part of the code that ensures that the first click only removes the highlighted component for job names/headers.  This only changes the flow for clicking the headers, clicking jobs or commits still has the same behavior

Example:
Click on group -> group gets highlighted, and group expands
Current behavior:
Click on group again -> group gets unhighlighted
Click on group again -> group gets collapsed
This PR:
Click on group again -> group gets highlighted, and group collapses

This also means if something is highlighted, ex you have a job tooltip open, clicking on a group will highlight and expand that group immediately, while previously it would unhighlight and you would have to click again to expand

Example:
Click on job -> job gets highlighted
Current behavior:
Click on group -> job gets unhighlighted
Click on group again -> group gets expanded
This PR:
Click on group -> job gets unhighlighted + group gets expanded

Please click around on the HUD main page to see if you like this flow