### PR TITLE
Update pep503_whl_redirect to accomodate for rocm maj.min.patch version

### DIFF
--- a/aws/websites/download.pytorch.org/pep503_whl_redirect.js
+++ b/aws/websites/download.pytorch.org/pep503_whl_redirect.js
@@ -3,19 +3,17 @@ function handler(event) {
     var uri = request.uri;
     var uri_parts = uri.split('/')
     var last_uri_part = uri_parts[uri_parts.length -1]
-    var rocm_pattern = /^rocm[0-9]+\.[0-9]+$/
-    var rocm_extended = /^rocm[0-9]+\.[0-9]+\.[0-9]+$/
+    var rocm_pattern = /^rocm[0-9]+\.[0-9]+(\.[0-9]+)*$/
     
     if (uri.startsWith('/whl')) {
         // Check whether the URI is missing a file name.
         if (uri.endsWith('/')) {
             request.uri += 'index.html';
         // Check whether the URI is folder like
-        // I.e. does not have dots in path or rocm\d.\d or 1.8 (for lts)
+        // I.e. does not have dots in path or rocm\d.\d or rocm\d.\d.\d or 1.8 (for lts)
         // For example /whl/cpu/torch
         } else if (last_uri_part.indexOf('.') == -1
                 || last_uri_part.match(rocm_pattern)
-                || last_uri_part.match(rocm_extended)
                 || uri == "/whl/lts/1.8") {
             request.uri += '/index.html';
         }

--- a/aws/websites/download.pytorch.org/pep503_whl_redirect.js
+++ b/aws/websites/download.pytorch.org/pep503_whl_redirect.js
@@ -4,6 +4,7 @@ function handler(event) {
     var uri_parts = uri.split('/')
     var last_uri_part = uri_parts[uri_parts.length -1]
     var rocm_pattern = /^rocm[0-9]+\.[0-9]+$/
+    var rocm_extended = /^rocm[0-9]+\.[0-9]+\.[0-9]+$/
     
     if (uri.startsWith('/whl')) {
         // Check whether the URI is missing a file name.
@@ -14,6 +15,7 @@ function handler(event) {
         // For example /whl/cpu/torch
         } else if (last_uri_part.indexOf('.') == -1
                 || last_uri_part.match(rocm_pattern)
+                || last_uri_part.match(rocm_extended)
                 || uri == "/whl/lts/1.8") {
             request.uri += '/index.html';
         }

--- a/aws/websites/download.pytorch.org/pep503_whl_redirect.js
+++ b/aws/websites/download.pytorch.org/pep503_whl_redirect.js
@@ -3,7 +3,7 @@ function handler(event) {
     var uri = request.uri;
     var uri_parts = uri.split('/')
     var last_uri_part = uri_parts[uri_parts.length -1]
-    var rocm_pattern = /^rocm[0-9]+\.[0-9]+(\.[0-9]+)*$/
+    var rocm_pattern = /^rocm[0-9]+(\.[0-9]+)*$/
     
     if (uri.startsWith('/whl')) {
         // Check whether the URI is missing a file name.


### PR DESCRIPTION
I am seeing validation error here:
https://github.com/pytorch/test-infra/actions/runs/12357596722/job/34504501590#step:14:2563
Executing:
```pip3 install --force-reinstall torch --index-url https://download.pytorch.org/whl/test/rocm6.2.4```
does not work, accessing https://download.pytorch.org/whl/test/6.2.4 does not work either