### PR TITLE
Fix logic in validate aarch64 and xpu linux binaries

### DIFF
--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -155,4 +155,4 @@ jobs:
         unset LD_LIBRARY_PATH
 
         # Standard case: Validate binaries
-        source ../../.github/scripts/validate_binaries.sh
+        source ../../test-infra/.github/scripts/validate_binaries.sh

--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -113,6 +113,7 @@ jobs:
       job-name: ${{ matrix.build_name }}
       docker-image: ${{ matrix.container_image }}
       binary-matrix: ${{ toJSON(matrix) }}
+      docker-build-dir: "skip-docker-build"
       no-sudo: true
       script: |
         set -ex

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -157,7 +157,7 @@ jobs:
         export TARGET_OS="linux"
         # Due to xpu doesn't use pytorch/conda-builder image, need to install conda firstly
         if [[ ${{ matrix.gpu_arch_type }} == 'xpu' ]]; then
-          source /.ci/docker/common/install_conda.sh
+          source ${PWD}/.ci/docker/common/install_conda.sh
         fi
         eval "$(conda shell.bash hook)"
         printf '%s\n' ${{ toJson(inputs.release-matrix) }} > release_matrix.json

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -157,6 +157,7 @@ jobs:
         export TARGET_OS="linux"
         # Due to xpu doesn't use pytorch/conda-builder image, need to install conda firstly
         if [[ ${{ matrix.gpu_arch_type }} == 'xpu' ]]; then
+          ANACONDA_PYTHON_VERSION="${MATRIX_PYTHON_VERSION}"
           source ${PWD}/.ci/docker/common/install_conda.sh
         fi
         eval "$(conda shell.bash hook)"

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -158,6 +158,7 @@ jobs:
         # Due to xpu doesn't use pytorch/conda-builder image, need to install conda firstly
         if [[ ${{ matrix.gpu_arch_type }} == 'xpu' ]]; then
           ANACONDA_PYTHON_VERSION="${MATRIX_PYTHON_VERSION}"
+          BUILD_ENVIRONMENT="xpu"
           source ${PWD}/.ci/docker/common/install_conda.sh
         fi
         eval "$(conda shell.bash hook)"

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -155,14 +155,6 @@ jobs:
 
         export USE_FORCE_REINSTALL="true"
         export TARGET_OS="linux"
-        # Due to xpu doesn't use pytorch/conda-builder image, need to install conda firstly
-        if [[ ${{ matrix.gpu_arch_type }} == 'xpu' ]]; then
-          MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-py311_23.5.2-0-Linux-x86_64.sh
-          wget -q $MINICONDA_URL
-          bash $(basename "$MINICONDA_URL") -b -p /opt/conda
-          rm $(basename "$MINICONDA_URL")
-          export PATH=/opt/conda/bin:$PATH
-        fi
         eval "$(conda shell.bash hook)"
         printf '%s\n' ${{ toJson(inputs.release-matrix) }} > release_matrix.json
 

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -157,9 +157,11 @@ jobs:
         export TARGET_OS="linux"
         # Due to xpu doesn't use pytorch/conda-builder image, need to install conda firstly
         if [[ ${{ matrix.gpu_arch_type }} == 'xpu' ]]; then
-          ANACONDA_PYTHON_VERSION="${MATRIX_PYTHON_VERSION}"
-          BUILD_ENVIRONMENT="xpu"
-          source ${PWD}/.ci/docker/common/install_conda.sh
+          MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-py311_23.5.2-0-Linux-x86_64.sh
+          wget -q $MINICONDA_URL
+          bash $(basename "$MINICONDA_URL") -b -p /opt/conda
+          rm $(basename "$MINICONDA_URL")
+          export PATH=/opt/conda/bin:$PATH
         fi
         eval "$(conda shell.bash hook)"
         printf '%s\n' ${{ toJson(inputs.release-matrix) }} > release_matrix.json

--- a/.github/workflows/validate-nightly-binaries.yml
+++ b/.github/workflows/validate-nightly-binaries.yml
@@ -15,6 +15,7 @@ on:
       - .github/workflows/validate-linux-binaries.yml
       - .github/workflows/validate-windows-binaries.yml
       - .github/workflows/validate-macos-arm64-binaries.yml
+      - .github/workflows/validate-aarch64-linux-binaries.yml
       - test/smoke_test/*
   pull_request:
     paths:
@@ -22,6 +23,7 @@ on:
       - .github/workflows/validate-linux-binaries.yml
       - .github/workflows/validate-windows-binaries.yml
       - .github/workflows/validate-macos-arm64-binaries.yml
+      - .github/workflows/validate-aarch64-linux-binaries.yml
       - .github/scripts/validate_binaries.sh
       - test/smoke_test/*
 


### PR DESCRIPTION
1. Aarch64: Skip docker builds same as here: https://github.com/pytorch/test-infra/blob/main/.github/workflows/validate-linux-binaries.yml#L139
2. Aarch64: Fix script path
3. Aarch64: Add tests to nightly validation trigger
4. XPU: conda install path fix
