### PR TITLE
Use devtoolset x11-abi for XPU builds validations. 

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -78,7 +78,7 @@ else
 
     pushd ${PWD}/.ci/pytorch/
 
-    if [[ ${MATRIX_GPU_ARCH_VERSION} == "12.6" ]]; then
+    if [[ ${MATRIX_GPU_ARCH_VERSION} == "12.6" || ${MATRIX_GPU_ARCH_TYPE} == "xpu" ]]; then
         export DESIRED_DEVTOOLSET="cxx11-abi"
     fi
 


### PR DESCRIPTION
XPU are compiled with cxx11-abi hence set the correct flag before running the validations.

Test failures are fixed by: https://github.com/pytorch/test-infra/pull/6079