### PR TITLE
[BE] [PyTorchBot] More understandable error  message when labels cannot be added

### DIFF
--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -193,8 +193,8 @@ async function handleLabelEvent(
     }
   }
   if (!has_ci_approved) {
-    let body = "To add the ciflow label `" + label + "` to PR please first approve the workflows " +
-    "awaiting approval.\n\n" +
+    let body = "To add the ciflow label `" + label + "` please first approve the workflows " +
+    "that are awaiting approval (scroll to the bottom of this page).\n\n" +
     "This helps ensure we don't trigger CI on this PR until it is actually authorized to do so. " +
     "Please ping one of the reviewers if you do not have access to approve and run workflows.";
     await context.octokit.issues.createComment(

--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -193,10 +193,13 @@ async function handleLabelEvent(
     }
   }
   if (!has_ci_approved) {
-    let body = "To add the ciflow label `" + label + "` please first approve the workflows " +
-    "that are awaiting approval (scroll to the bottom of this page).\n\n" +
-    "This helps ensure we don't trigger CI on this PR until it is actually authorized to do so. " +
-    "Please ping one of the reviewers if you do not have access to approve and run workflows.";
+    let body =
+      "To add the ciflow label `" +
+      label +
+      "` please first approve the workflows " +
+      "that are awaiting approval (scroll to the bottom of this page).\n\n" +
+      "This helps ensure we don't trigger CI on this PR until it is actually authorized to do so. " +
+      "Please ping one of the reviewers if you do not have access to approve and run workflows.";
     await context.octokit.issues.createComment(
       context.repo({
         body,

--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -193,7 +193,10 @@ async function handleLabelEvent(
     }
   }
   if (!has_ci_approved) {
-    let body = `Please seek CI approval before scheduling CIFlow labels`;
+    let body = "To add the ciflow label `" + label + "` to PR please first approve the workflows " +
+    "awaiting approval.\n\n" +
+    "This helps ensure we don't trigger CI on this PR until it is actually authorized to do so. " +
+    "Please ping one of the reviewers if you do not have access to approve and run workflows.";
     await context.octokit.issues.createComment(
       context.repo({
         body,

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -481,7 +481,7 @@ The explanation needs to be clear on why this is needed. Here are some good exam
       ))
     ) {
       return await this.addComment(
-        "Can't add following labels to PR: " +
+        "Can't add following labels to PR until the workflows awaiting approval are approved first: " +
           ciflowLabels.join(", ") +
           ". Please ping one of the reviewers for help."
       );

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -481,8 +481,8 @@ The explanation needs to be clear on why this is needed. Here are some good exam
       ))
     ) {
       return await this.addComment(
-        "Please ensure the workflows awaiting approval are approved first before trying to add any of " +
-        "the following labels: " + ciflowLabels.join(", ") + ".\n\n" +
+        "To add these label(s) (" + ciflowLabels.join(", ") + ") to the PR, please first approve the " +
+        "workflows that are awaiting approval (scroll to the bottom of this page).\n\n" +
         "This helps ensure we don't trigger CI on this PR until it is actually authorized to do so. " +
         "Please ping one of the reviewers if you do not have access to approve and run workflows."
       );

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -481,10 +481,12 @@ The explanation needs to be clear on why this is needed. Here are some good exam
       ))
     ) {
       return await this.addComment(
-        "To add these label(s) (" + ciflowLabels.join(", ") + ") to the PR, please first approve the " +
-        "workflows that are awaiting approval (scroll to the bottom of this page).\n\n" +
-        "This helps ensure we don't trigger CI on this PR until it is actually authorized to do so. " +
-        "Please ping one of the reviewers if you do not have access to approve and run workflows."
+        "To add these label(s) (" +
+          ciflowLabels.join(", ") +
+          ") to the PR, please first approve the " +
+          "workflows that are awaiting approval (scroll to the bottom of this page).\n\n" +
+          "This helps ensure we don't trigger CI on this PR until it is actually authorized to do so. " +
+          "Please ping one of the reviewers if you do not have access to approve and run workflows."
       );
     }
     if (invalidLabels.length > 0) {

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -481,9 +481,10 @@ The explanation needs to be clear on why this is needed. Here are some good exam
       ))
     ) {
       return await this.addComment(
-        "Can't add following labels to PR until the workflows awaiting approval are approved first: " +
-          ciflowLabels.join(", ") +
-          ". Please ping one of the reviewers for help."
+        "Please ensure the workflows awaiting approval are approved first before trying to add any of " +
+        "the following labels: " + ciflowLabels.join(", ") + ".\n\n" +
+        "This helps ensure we don't trigger CI on this PR until it is actually authorized to do so. " +
+        "Please ping one of the reviewers if you do not have access to approve and run workflows."
       );
     }
     if (invalidLabels.length > 0) {

--- a/torchci/test/labelCommands.test.ts
+++ b/torchci/test/labelCommands.test.ts
@@ -162,7 +162,7 @@ describe("label-bot", () => {
       .reply(200, existingRepoLabelsResponse)
       .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
         expect(JSON.stringify(body)).toContain(
-          `{"body":"Can't add following labels to PR: ciflow/trunk`
+          `{"body":"To add these label(s) (ciflow/trunk`
         );
         return true;
       })


### PR DESCRIPTION
Fixes https://github.com/pytorch/test-infra/issues/5900

When a `ciflow` label is added to a PR, we normally trigger workflows against it. However, if the PR has not yet been authorized to actually run workflows then we do not allow the label to be added. (This feature was added by https://github.com/pytorch/test-infra/pull/4892)

This change improves the reasoning given by the error messages, making it easier for the reviewer to understand why a label was not added to the PR and the steps they need to take to actually add the desired label.