### PR TITLE
[CH][HUD] Set query_id parameter for ClickHouse queries

### DIFF
--- a/torchci/lib/clickhouse.ts
+++ b/torchci/lib/clickhouse.ts
@@ -4,6 +4,7 @@
 // deploy.
 import { createClient } from "@clickhouse/client";
 import { readFileSync } from "fs";
+import { v4 as uuidv4 } from "uuid";
 // Import itself to ensure that mocks can be applied, see
 // https://stackoverflow.com/questions/51900413/jest-mock-function-doesnt-work-while-it-was-called-in-the-other-function
 // https://stackoverflow.com/questions/45111198/how-to-mock-functions-in-the-same-module-using-jest
@@ -27,8 +28,14 @@ export function getClickhouseClientWritable() {
 
 export async function queryClickhouse(
   query: string,
-  params: Record<string, unknown>
+  params: Record<string, unknown>,
+  query_id?: string
 ): Promise<any[]> {
+  if (query_id === undefined) {
+    query_id = "adhoc";
+  }
+  // This needs to be unique for each query
+  query_id = `${query_id}-${uuidv4()}`;
   /**
    * queryClickhouse
    * @param query: string, the sql query
@@ -43,6 +50,7 @@ export async function queryClickhouse(
       output_format_json_quote_64bit_integers: 0,
       date_time_output_format: "iso",
     },
+    query_id,
   });
 
   return (await res.json()) as any[];
@@ -75,7 +83,8 @@ export async function queryClickhouseSaved(
   );
   return await thisModule.queryClickhouse(
     query,
-    Object.fromEntries(queryParams)
+    Object.fromEntries(queryParams),
+    queryName
   );
 }
 


### PR DESCRIPTION
Set the query_id to be `query_name-uuid` for named queries or `adhoc-uuid` in the case of adhoc queries. 

This is helpful for getting average time and memory usage for queries and mapping them back to the original query.  The system.query_log table can be used to find this information (https://clickhouse.com/docs/knowledgebase/find-expensive-queries) but when using the ClickHouse javascript package, the query column there is a parsed version of the query which is hard to map back to the original query text.  

The query_id needs to be unique for every query and the docs suggest using a uuid
https://clickhouse.com/docs/en/integrations/javascript#query-id

