### PR TITLE
[disablebot] Fix workflow when run on PR

### DIFF
--- a/.github/scripts/update_disabled_issues.py
+++ b/.github/scripts/update_disabled_issues.py
@@ -306,9 +306,9 @@ def main() -> None:
         help="Set the repo to query the issues from",
     )
     args = parser.parse_args()
-    token = os.getenv("GH_PYTORCHBOT_TOKEN")
+    token = os.getenv("GITHUB_TOKEN")
     if not token:
-        raise RuntimeError("The GH_PYTORCHBOT_TOKEN environment variable is required")
+        raise RuntimeError("The GITHUB_TOKEN environment variable is required")
 
     # Get the list of disabled issues and sort them
     disable_issues = get_disable_issues(token)

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   update-disabled-tests:
     runs-on: ubuntu-latest
-    environment: trigger-nightly
+    environment: ${{ github.ref == 'refs/heads/main' && 'trigger-nightly' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,8 +27,10 @@ jobs:
           # The token is used to confirm issue creator's write permission before
           # allowing them to disable jobs. Note that the token needs to have access
           # to the target repo, i.e. pytorch/pytorch instead of test-infra. Using
-          # PyTorch bot token is the most obvious choice.
-          GH_PYTORCHBOT_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+          # PyTorch bot token is the most obvious choice.  Outside of the
+          # environment, we do not have access to this token so fall back to the
+          # GITHUB_TOKEN.
+          GITHUB_TOKEN: ${{ github.ref == 'refs/heads/main' && secrets.GH_MERGEBOT_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           python3 .github/scripts/update_disabled_issues.py
 


### PR DESCRIPTION
We don't have access to the environment at PR time, so we don't have the GH_PYTORCHBOT_TOKEN.  Instead we can fallback to GITHUB_TOKEN, but this doesn't have the necessary permissions for getting the correct unstable + disable jobs.  However, being able to test the overall workflow on PR and the disable tests generator is better than nothing
