### PR TITLE
[HUD] Upgrade typescript 4.6.3 -> 5.7.2

### DIFF
--- a/torchci/components/LoadingPage.tsx
+++ b/torchci/components/LoadingPage.tsx
@@ -1,5 +1,4 @@
 import { CircularProgress, styled } from "@mui/material";
-import React from "react";
 
 const LoadingContainer = styled("div")(({}) => ({
   display: "flex",

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -6,10 +6,10 @@ import { getHelp, getParser } from "./cliParser";
 import { cherryPickClassifications } from "./Constants";
 import PytorchBotLogger from "./pytorchbotLogger";
 import {
+  hasWritePermissions as _hasWP,
   addLabels,
   CachedConfigTracker,
   hasApprovedPullRuns,
-  hasWritePermissions as _hasWP,
   isFirstTimeContributor,
   isPyTorchOrg,
   isPyTorchPyTorch,

--- a/torchci/lib/bot/utils.ts
+++ b/torchci/lib/bot/utils.ts
@@ -12,7 +12,7 @@ export function isTime0(time: string): boolean {
 export const TIME_0 = "1970-01-01 00:00:00.000000000";
 
 export function repoKey(
-  context: Context | Context<"pull_request.labeled">
+  context: Context
 ): string {
   const repo = context.repo();
   return `${repo.owner}/${repo.repo}`;
@@ -60,7 +60,7 @@ export class CachedConfigTracker {
   }
 
   async loadConfig(
-    context: Context | Context<"pull_request.labeled">,
+    context: Context,
     force = false
   ): Promise<object> {
     const key = repoKey(context);

--- a/torchci/lib/bot/utils.ts
+++ b/torchci/lib/bot/utils.ts
@@ -11,9 +11,7 @@ export function isTime0(time: string): boolean {
 
 export const TIME_0 = "1970-01-01 00:00:00.000000000";
 
-export function repoKey(
-  context: Context
-): string {
+export function repoKey(context: Context): string {
   const repo = context.repo();
   return `${repo.owner}/${repo.repo}`;
 }
@@ -59,10 +57,7 @@ export class CachedConfigTracker {
     });
   }
 
-  async loadConfig(
-    context: Context,
-    force = false
-  ): Promise<object> {
+  async loadConfig(context: Context, force = false): Promise<object> {
     const key = repoKey(context);
     if (!(key in this.repoConfigs) || force) {
       context.log({ key }, "loadConfig");

--- a/torchci/package.json
+++ b/torchci/package.json
@@ -88,7 +88,7 @@
     "prettier": "2.6.2",
     "prettier-plugin-organize-imports": "^3.2.4",
     "ts-jest": "^29.2.5",
-    "typescript": "4.6.3"
+    "typescript": "^5.7.2"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/torchci/pages/[repoOwner]/[repoName]/commit/[sha].tsx
+++ b/torchci/pages/[repoOwner]/[repoName]/commit/[sha].tsx
@@ -2,8 +2,8 @@ import CommitStatus from "components/CommitStatus";
 import { useSetTitle } from "components/DynamicTitle";
 import { fetcher } from "lib/GeneralUtils";
 import { useRouter } from "next/router";
-import { IssueLabelApiResponse } from "pages/api/issue/[label]";
 import { CommitApiResponse } from "pages/api/[repoOwner]/[repoName]/commit/[sha]";
+import { IssueLabelApiResponse } from "pages/api/issue/[label]";
 import useSWR from "swr";
 
 export function CommitInfo({

--- a/torchci/pages/[repoOwner]/[repoName]/pull/[prNumber].tsx
+++ b/torchci/pages/[repoOwner]/[repoName]/pull/[prNumber].tsx
@@ -6,8 +6,8 @@ import ErrorBoundary from "components/ErrorBoundary";
 import { useCHContext } from "components/UseClickhouseProvider";
 import { PRData } from "lib/types";
 import { useRouter } from "next/router";
-import { IssueLabelApiResponse } from "pages/api/issue/[label]";
 import { CommitApiResponse } from "pages/api/[repoOwner]/[repoName]/commit/[sha]";
+import { IssueLabelApiResponse } from "pages/api/issue/[label]";
 import { useEffect, useState } from "react";
 import useSWR from "swr";
 

--- a/torchci/yarn.lock
+++ b/torchci/yarn.lock
@@ -8282,10 +8282,10 @@ typed-rest-client@^1.8.9:
     tunnel "0.0.6"
     underscore "^1.12.1"
 
-typescript@4.6.3:
-  version "4.6.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz"
-  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
+typescript@^5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
+  integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
 
 uglify-js@^3.1.4:
   version "3.17.3"


### PR DESCRIPTION
This results in a lot of "union too complex to represent" errors, which I solved by separating the context, which was previously typed `Context<webhook type>` to just `Context`, and the payload (if it is used), which is now typed `Context<webhook type>["payload"]`

so functions taking in
`context: Context<"pull_request">`
now take in
`context: Context, payload: Context<"pull_request">["payload"]`
and anything that previously used `context.payload` now just uses `payload`

Some disccusion on this can be found here:
https://github.com/probot/probot/discussions/1966
https://togithub.com/ubiquity-os/ubiquity-os-kernel/issues/31
https://togithub.com/probot/probot/issues/1968

I'm not sure why the import order formatter changed it's mind about what order things should be in, but it seems to still have opinions which I think is the main thing to check