### PR TITLE
Add support for benchmark configs on ExecuTorch dashboard

### DIFF
--- a/torchci/clickhouse_queries/oss_ci_benchmark_branches/query.sql
+++ b/torchci/clickhouse_queries/oss_ci_benchmark_branches/query.sql
@@ -15,6 +15,7 @@ WITH benchmarks AS (
             tupleElement(o.benchmark, 'extra_info') [ 'arch' ],
             tupleElement(o.runners [ 1 ], 'type')
         ) AS arch,
+        o.timestamp AS timestamp,
         toStartOfDay(fromUnixTimestamp(o.timestamp)) AS event_time
     FROM
         benchmark.oss_ci_benchmark_v3 o
@@ -43,7 +44,6 @@ WITH benchmarks AS (
             OR empty({excludedMetrics: Array(String) })
         )
         AND notEmpty(o.metric.name)
-        AND notEmpty(o.benchmark.dtype)
 )
 SELECT
     DISTINCT replaceOne(head_branch, 'refs/heads/', '') AS head_branch,
@@ -66,4 +66,4 @@ WHERE
     AND notEmpty(device)
 ORDER BY
     head_branch,
-    event_time DESC
+    timestamp DESC

--- a/torchci/clickhouse_queries/oss_ci_benchmark_llms/query.sql
+++ b/torchci/clickhouse_queries/oss_ci_benchmark_llms/query.sql
@@ -57,7 +57,6 @@ WITH benchmarks AS (
             OR empty({excludedMetrics: Array(String) })
         )
         AND notEmpty(o.metric.name)
-        AND notEmpty(o.benchmark.dtype)
 )
 SELECT
     DISTINCT workflow_id,

--- a/torchci/clickhouse_queries/oss_ci_benchmark_names/query.sql
+++ b/torchci/clickhouse_queries/oss_ci_benchmark_names/query.sql
@@ -43,7 +43,6 @@ WITH benchmarks AS (
             OR empty({excludedMetrics: Array(String) })
         )
         AND notEmpty(o.metric.name)
-        AND notEmpty(o.benchmark.dtype)
 )
 SELECT
     DISTINCT benchmark,

--- a/torchci/pages/benchmark/llms.tsx
+++ b/torchci/pages/benchmark/llms.tsx
@@ -252,11 +252,9 @@ export default function Page() {
     JSON.stringify(queryParams)
   )}`;
 
-  console.log(queryParams);
   const { data } = useSWR(url, fetcher, {
     refreshInterval: 60 * 60 * 1000, // refresh every hour
   });
-  console.log(data);
 
   if (data === undefined || data.length === 0) {
     return <>Loading {REPO_TO_BENCHMARKS[repoName].join(", ")}...</>;
@@ -274,10 +272,10 @@ export default function Page() {
     DEFAULT_DEVICE_NAME,
     ...(_.uniq(data.map((r: any) => `${r.device} (${r.arch})`)) as string[]),
   ];
-  const dtypeNames: string[] = [
+  const dtypeNames: string[] = _.compact([
     DEFAULT_DTYPE_NAME,
     ...(_.uniq(data.map((r: any) => r.dtype)) as string[]),
-  ];
+  ]);
   const metricNames: string[] = _.uniq(data.map((r: any) => r.metric));
 
   return (
@@ -330,12 +328,14 @@ export default function Page() {
             label={"Backend"}
           />
         )}
-        <DTypePicker
-          dtype={dtypeName}
-          setDType={setDTypeName}
-          dtypes={dtypeNames}
-          label={"DType"}
-        />
+        {dtypeNames.length > 1 && (
+          <DTypePicker
+            dtype={dtypeName}
+            setDType={setDTypeName}
+            dtypes={dtypeNames}
+            label={"DType"}
+          />
+        )}
         <DTypePicker
           dtype={deviceName}
           setDType={setDeviceName}


### PR DESCRIPTION
ExecuTorch has replaced the backend field with a more generic benchmark configs concept, so the dashboard will display it instead.

* https://github.com/pytorch/executorch/pull/7349
* https://github.com/pytorch/executorch/pull/7433

### Testing

https://torchci-git-fork-huydhn-add-executorch-backend-fbopensource.vercel.app/benchmark/llms?startTime=Tue%2C%2017%20Dec%202024%2019%3A05%3A31%20GMT&stopTime=Tue%2C%2024%20Dec%202024%2019%3A05%3A31%20GMT&granularity=hour&lBranch=handle-benchmark-config-dashboard&lCommit=c48da2bd2c9a32705db9b1adf638344474c275a4&rBranch=handle-benchmark-config-dashboard&rCommit=c33f815eff17c8890f2c8527dc0f0dbca50b4397&repoName=pytorch%2Fexecutorch&modelName=All%20Models&backendName=All%20Backends&dtypeName=All%20DType&deviceName=All%20Devices