### PR TITLE
[Nova] Honor with-cuda flag when building aarch64 wheel

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -129,7 +129,7 @@ jobs:
     environment: ${{(inputs.trigger-event == 'schedule' || (inputs.trigger-event == 'push' && (startsWith(github.event.ref, 'refs/heads/nightly') || startsWith(github.event.ref, 'refs/tags/v')))) && 'pytorchbot-env' || ''}}
     container:
       image: ${{ matrix.container_image }}
-      options: ${{ matrix.gpu_arch_type == 'cuda' && '--gpus all' || ' ' }}
+      options: ${{ (matrix.gpu_arch_type == 'cuda' || matrix.gpu_arch_type == 'cuda-aarch64') && '--gpus all' || ' ' }}
     timeout-minutes: ${{ inputs.timeout }}
     steps:
       - name: Clean workspace

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -449,9 +449,10 @@ def generate_wheels_matrix(
             arches += [CPU]
 
         if os == LINUX_AARCH64:
-            # Only want the one arch as the CPU type is different and
-            # uses different build/test scripts
-            arches = [CPU_AARCH64, CUDA_AARCH64]
+            if with_cuda == ENABLE:
+                arches = [CPU_AARCH64, CUDA_AARCH64]
+            else:
+                arches = [CPU_AARCH64]
 
         if with_cuda == ENABLE:
             upload_to_base_bucket = "no"


### PR DESCRIPTION
I discover this issue when debugging FBGEMM aarch64 build in which the build picks up both CPU and CUDA builds even then `with-cuda` is set to false there https://github.com/pytorch/FBGEMM/pull/3528#issuecomment-2561647469.

Another note is that I don't think we have an arm runner with GPU at the moment (correct me if I'm wrong). So, Nova CUDA aarch64 build would never be able to run smoke test (on the same runner) because there is no GPU.  We would probably need to:

* Add arm runner with GPU
* and maybe separate Nova wheel build and smoke test steps.

cc @q10 