### PR TITLE
Add pep658 metadata sha to index html

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -16,6 +16,7 @@ from re import sub, match, search
 from packaging.version import parse as _parse_version, Version, InvalidVersion
 
 import boto3
+import botocore
 
 
 S3 = boto3.resource('s3')
@@ -217,6 +218,7 @@ class S3Object:
     orig_key: str
     checksum: Optional[str]
     size: Optional[int]
+    pep658: Optional[str]
 
     def __hash__(self):
         return hash(self.key)
@@ -380,7 +382,16 @@ class S3Index:
         out.append('    <h1>Links for {}</h1>'.format(package_name.lower().replace("_", "-")))
         for obj in sorted(self.gen_file_list(subdir, package_name)):
             maybe_fragment = f"#sha256={obj.checksum}" if obj.checksum else ""
-            out.append(f'    <a href="/{obj.key}{maybe_fragment}">{path.basename(obj.key).replace("%2B","+")}</a><br/>')
+            pep658_attribute = ""
+            if obj.pep658:
+                pep658_sha = f"sha256={obj.pep658}"
+                # pep714 renames the attribute to data-core-metadata
+                pep658_attribute = (
+                    f' data-dist-info-metadata="{pep658_sha}" data-core-metadata="{pep658_sha}"'
+                )
+            out.append(
+                f'    <a href="/{obj.key}{maybe_fragment}"{pep658_attribute}>{path.basename(obj.key).replace("%2B","+")}</a><br/>'
+            )
         # Adding html footer
         out.append('  </body>')
         out.append('</html>')
@@ -529,6 +540,32 @@ class S3Index:
                 if size := response.get("ContentLength"):
                     self.objects[idx].size = int(size)
 
+    def fetch_pep658(self: S3IndexType) -> None:
+        def _fetch_metadata(key: str) -> str:
+            try:
+                response = CLIENT.head_object(
+                    Bucket=BUCKET.name, Key=f"{key}.metadata", ChecksumMode="Enabled"
+                )
+                sha256 = base64.b64decode(response.get("ChecksumSHA256")).hex()
+                return sha256
+            except botocore.exceptions.ClientError as e:
+                if e.response["Error"]["Code"] == "404":
+                    return None
+                raise
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=6) as executor:
+            metadata_futures = {
+                idx: executor.submit(
+                    _fetch_metadata,
+                    obj.orig_key,
+                )
+                for (idx, obj) in enumerate(self.objects)
+            }
+            for idx, future in metadata_futures.items():
+                response = future.result()
+                if response is not None:
+                    self.objects[idx].pep658 = response
+
     @classmethod
     def from_S3(cls: Type[S3IndexType], prefix: str, with_metadata: bool = True) -> S3IndexType:
         prefix = prefix.rstrip("/")
@@ -545,6 +582,7 @@ class S3Index:
             rc.objects = rc.nightly_packages_to_show()
         if with_metadata:
             rc.fetch_metadata()
+            rc.fetch_pep658()
         return rc
 
     @classmethod

--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -577,7 +577,8 @@ class S3Index:
         rc = cls([S3Object(key=sanitize_key(key),
                            orig_key=key,
                            checksum=None,
-                           size=None) for key in obj_names], prefix)
+                           size=None,
+                           pep658=None) for key in obj_names], prefix)
         if prefix == "whl/nightly":
             rc.objects = rc.nightly_packages_to_show()
         if with_metadata:


### PR DESCRIPTION
Corresponds to https://github.com/pytorch/pytorch/pull/143677

Add support for pep658 and pep714
https://peps.python.org/pep-0658/
https://peps.python.org/pep-0714/

Some of the shas are the same, but this also happens on pypi so I guess the metadata file is just the same for those

Snippet of what the index html looks like:
```
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250102%2Bcu126-cp313-cp313-win_amd64.whl">torch-2.6.0.dev20250102+cu126-cp313-cp313-win_amd64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250102%2Bcu126-cp313-cp313t-manylinux_2_28_x86_64.whl">torch-2.6.0.dev20250102+cu126-cp313-cp313t-manylinux_2_28_x86_64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250102%2Bcu126-cp39-cp39-linux_aarch64.whl">torch-2.6.0.dev20250102+cu126-cp39-cp39-linux_aarch64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250102%2Bcu126-cp39-cp39-manylinux_2_28_x86_64.whl">torch-2.6.0.dev20250102+cu126-cp39-cp39-manylinux_2_28_x86_64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250102%2Bcu126-cp39-cp39-win_amd64.whl">torch-2.6.0.dev20250102+cu126-cp39-cp39-win_amd64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250103%2Bcu126-cp310-cp310-linux_aarch64.whl" data-dist-info-metadata="sha256=3217e3132055e58b637de9707757c7cc46317d928264f38baf9187c063f1fb34" data-core-metadata="sha256=3217e3132055e58b637de9707757c7cc46317d928264f38baf9187c063f1fb34">torch-2.6.0.dev20250103+cu126-cp310-cp310-linux_aarch64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250103%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl" data-dist-info-metadata="sha256=b69536f947ca5a470fcba3279faa6373780daff1837f1d26c7b32cc81dc653ee" data-core-metadata="sha256=b69536f947ca5a470fcba3279faa6373780daff1837f1d26c7b32cc81dc653ee">torch-2.6.0.dev20250103+cu126-cp310-cp310-manylinux_2_28_x86_64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250103%2Bcu126-cp310-cp310-win_amd64.whl" data-dist-info-metadata="sha256=a06eb2d819dc1c4e66a04a3e4c86b30268b244e933231e47b0ba824314ade85b" data-core-metadata="sha256=a06eb2d819dc1c4e66a04a3e4c86b30268b244e933231e47b0ba824314ade85b">torch-2.6.0.dev20250103+cu126-cp310-cp310-win_amd64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250103%2Bcu126-cp311-cp311-linux_aarch64.whl" data-dist-info-metadata="sha256=3217e3132055e58b637de9707757c7cc46317d928264f38baf9187c063f1fb34" data-core-metadata="sha256=3217e3132055e58b637de9707757c7cc46317d928264f38baf9187c063f1fb34">torch-2.6.0.dev20250103+cu126-cp311-cp311-linux_aarch64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250103%2Bcu126-cp311-cp311-manylinux_2_28_x86_64.whl" data-dist-info-metadata="sha256=b69536f947ca5a470fcba3279faa6373780daff1837f1d26c7b32cc81dc653ee" data-core-metadata="sha256=b69536f947ca5a470fcba3279faa6373780daff1837f1d26c7b32cc81dc653ee">torch-2.6.0.dev20250103+cu126-cp311-cp311-manylinux_2_28_x86_64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250103%2Bcu126-cp311-cp311-win_amd64.whl" data-dist-info-metadata="sha256=a06eb2d819dc1c4e66a04a3e4c86b30268b244e933231e47b0ba824314ade85b" data-core-metadata="sha256=a06eb2d819dc1c4e66a04a3e4c86b30268b244e933231e47b0ba824314ade85b">torch-2.6.0.dev20250103+cu126-cp311-cp311-win_amd64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250103%2Bcu126-cp312-cp312-linux_aarch64.whl" data-dist-info-metadata="sha256=3217e3132055e58b637de9707757c7cc46317d928264f38baf9187c063f1fb34" data-core-metadata="sha256=3217e3132055e58b637de9707757c7cc46317d928264f38baf9187c063f1fb34">torch-2.6.0.dev20250103+cu126-cp312-cp312-linux_aarch64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250103%2Bcu126-cp312-cp312-manylinux_2_28_x86_64.whl" data-dist-info-metadata="sha256=b69536f947ca5a470fcba3279faa6373780daff1837f1d26c7b32cc81dc653ee" data-core-metadata="sha256=b69536f947ca5a470fcba3279faa6373780daff1837f1d26c7b32cc81dc653ee">torch-2.6.0.dev20250103+cu126-cp312-cp312-manylinux_2_28_x86_64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250103%2Bcu126-cp312-cp312-win_amd64.whl" data-dist-info-metadata="sha256=a06eb2d819dc1c4e66a04a3e4c86b30268b244e933231e47b0ba824314ade85b" data-core-metadata="sha256=a06eb2d819dc1c4e66a04a3e4c86b30268b244e933231e47b0ba824314ade85b">torch-2.6.0.dev20250103+cu126-cp312-cp312-win_amd64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250103%2Bcu126-cp313-cp313-linux_aarch64.whl" data-dist-info-metadata="sha256=66e76168374efe8be52f14f0338887c060e18860e6d732216b0e136b49d43e15" data-core-metadata="sha256=66e76168374efe8be52f14f0338887c060e18860e6d732216b0e136b49d43e15">torch-2.6.0.dev20250103+cu126-cp313-cp313-linux_aarch64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250103%2Bcu126-cp313-cp313-manylinux_2_28_x86_64.whl" data-dist-info-metadata="sha256=89dc22f0edddfefd1e9a2979ce4a9f9b3b350911d7af1c12907f5bed4e950b3c" data-core-metadata="sha256=89dc22f0edddfefd1e9a2979ce4a9f9b3b350911d7af1c12907f5bed4e950b3c">torch-2.6.0.dev20250103+cu126-cp313-cp313-manylinux_2_28_x86_64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250103%2Bcu126-cp313-cp313-win_amd64.whl" data-dist-info-metadata="sha256=bc499a1079eeebf19c2e224f979254955b9329540b691f2bd5c76567b922b0e6" data-core-metadata="sha256=bc499a1079eeebf19c2e224f979254955b9329540b691f2bd5c76567b922b0e6">torch-2.6.0.dev20250103+cu126-cp313-cp313-win_amd64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250103%2Bcu126-cp313-cp313t-manylinux_2_28_x86_64.whl" data-dist-info-metadata="sha256=89dc22f0edddfefd1e9a2979ce4a9f9b3b350911d7af1c12907f5bed4e950b3c" data-core-metadata="sha256=89dc22f0edddfefd1e9a2979ce4a9f9b3b350911d7af1c12907f5bed4e950b3c">torch-2.6.0.dev20250103+cu126-cp313-cp313t-manylinux_2_28_x86_64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250103%2Bcu126-cp39-cp39-linux_aarch64.whl" data-dist-info-metadata="sha256=3217e3132055e58b637de9707757c7cc46317d928264f38baf9187c063f1fb34" data-core-metadata="sha256=3217e3132055e58b637de9707757c7cc46317d928264f38baf9187c063f1fb34">torch-2.6.0.dev20250103+cu126-cp39-cp39-linux_aarch64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250103%2Bcu126-cp39-cp39-manylinux_2_28_x86_64.whl" data-dist-info-metadata="sha256=b69536f947ca5a470fcba3279faa6373780daff1837f1d26c7b32cc81dc653ee" data-core-metadata="sha256=b69536f947ca5a470fcba3279faa6373780daff1837f1d26c7b32cc81dc653ee">torch-2.6.0.dev20250103+cu126-cp39-cp39-manylinux_2_28_x86_64.whl</a><br/>
    <a href="/whl/nightly/cu126/torch-2.6.0.dev20250103%2Bcu126-cp39-cp39-win_amd64.whl" data-dist-info-metadata="sha256=a06eb2d819dc1c4e66a04a3e4c86b30268b244e933231e47b0ba824314ade85b" data-core-metadata="sha256=a06eb2d819dc1c4e66a04a3e4c86b30268b244e933231e47b0ba824314ade85b">torch-2.6.0.dev20250103+cu126-cp39-cp39-win_amd64.whl</a><br/>
  </body>
</html>
```
