### PR TITLE
Add speedup metric for TorchAO

### DIFF
--- a/torchci/components/benchmark/llms/ModelGraphPanel.tsx
+++ b/torchci/components/benchmark/llms/ModelGraphPanel.tsx
@@ -18,6 +18,7 @@ import {
   TimeSeriesPanelWithData,
 } from "components/metrics/panels/TimeSeriesPanel";
 import dayjs from "dayjs";
+import { computeSpeedup } from "lib/benchmark/aoUtils";
 import { useBenchmark } from "lib/benchmark/llmUtils";
 import { BranchAndCommit } from "lib/types";
 
@@ -26,6 +27,7 @@ const GRAPH_ROW_HEIGHT = 245;
 export function GraphPanel({
   queryParams,
   granularity,
+  repoName,
   modelName,
   backendName,
   dtypeName,
@@ -36,6 +38,7 @@ export function GraphPanel({
 }: {
   queryParams: { [key: string]: any };
   granularity: Granularity;
+  repoName: string;
   modelName: string;
   backendName: string;
   dtypeName: string;
@@ -65,6 +68,8 @@ export function GraphPanel({
     return <></>;
   }
 
+  const dataWithSpeedup = computeSpeedup(repoName, data);
+
   // Clamp to the nearest granularity (e.g. nearest hour) so that the times will
   // align with the data we get from the database
   const startTime = dayjs(queryParams["startTime"]).startOf(granularity);
@@ -79,7 +84,7 @@ export function GraphPanel({
   const chartData: { [k: string]: any } = {};
   const graphSeries: { [k: string]: any } = {};
   metricNames.forEach((metric: string) => {
-    chartData[metric] = data
+    chartData[metric] = dataWithSpeedup
       .filter((record: LLMsBenchmarkData) => {
         return (
           record.model === modelName &&

--- a/torchci/components/benchmark/llms/SummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/SummaryPanel.tsx
@@ -163,18 +163,23 @@ export function SummaryPanel({
                 return styles.error;
               }
 
-              // Higher value
-              if (r - l > RELATIVE_THRESHOLD * l) {
-                return IS_INCREASING_METRIC_VALUE_GOOD[metric]
-                  ? styles.ok
-                  : styles.error;
-              }
+              if (metric in IS_INCREASING_METRIC_VALUE_GOOD) {
+                // Higher value
+                if (r - l > RELATIVE_THRESHOLD * l) {
+                  return IS_INCREASING_METRIC_VALUE_GOOD[metric]
+                    ? styles.ok
+                    : styles.error;
+                }
 
-              // Lower value
-              if (l - r > RELATIVE_THRESHOLD * r) {
-                return IS_INCREASING_METRIC_VALUE_GOOD[metric]
-                  ? styles.error
-                  : styles.ok;
+                // Lower value
+                if (l - r > RELATIVE_THRESHOLD * r) {
+                  return IS_INCREASING_METRIC_VALUE_GOOD[metric]
+                    ? styles.error
+                    : styles.ok;
+                }
+              } else {
+                // No data
+                return "";
               }
             }
 

--- a/torchci/components/benchmark/llms/SummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/SummaryPanel.tsx
@@ -63,42 +63,50 @@ export function SummaryPanel({
       },
       renderCell: (params: GridRenderCellParams<any>) => {
         const model = params.value.model;
-        const dtype = params.value.dtype;
-        const deviceArch = `${params.value.device} (${params.value.arch})`;
         if (model === undefined) {
           return `Invalid model name`;
         }
-        if (dtype === undefined) {
-          return `Invalid dtype for model ${model}`;
-        }
 
+        const dtype =
+          params.value.dtype !== undefined
+            ? `&dtypeName=${encodeURIComponent(params.value.dtype)}`
+            : "";
         const backend =
           params.value.backend !== undefined
-            ? `&${encodeURIComponent(params.value.backend)}`
+            ? `&backendName=${encodeURIComponent(params.value.backend)}`
             : "";
+        const deviceArch = `${params.value.device} (${params.value.arch})`;
+
         const url = `/benchmark/llms?startTime=${startTime}&stopTime=${stopTime}&granularity=${granularity}&repoName=${encodeURIComponent(
           repoName
         )}&modelName=${encodeURIComponent(
           model
-        )}${backend}&dtypeName=${encodeURIComponent(
-          dtype
-        )}&deviceName=${encodeURIComponent(deviceArch)}`;
+        )}${backend}${dtype}&deviceName=${encodeURIComponent(deviceArch)}`;
 
         const isNewModel = params.value.l === undefined ? "(NEW!) " : "";
         const isModelStopRunning = params.value.r === undefined ? "❌" : "";
 
-        const displayName = model.includes(dtype)
-          ? model
-          : `${model} (${dtype})`;
         return (
           <a href={url}>
             {isNewModel}
-            {isModelStopRunning}&nbsp;<b>{displayName}</b>
+            {isModelStopRunning}&nbsp;<b>{model}</b>
           </a>
         );
       },
     },
   ];
+
+  const hasDtype = data.length > 0 && "dtype" in data[0] ? true : false;
+  if (hasDtype) {
+    columns.push({
+      field: "dtype",
+      headerName: "Quantization",
+      flex: 1,
+      renderCell: (params: GridRenderCellParams<any>) => {
+        return `${params.value}`;
+      },
+    });
+  }
 
   const hasBackend = data.length > 0 && "backend" in data[0] ? true : false;
   if (hasBackend) {

--- a/torchci/components/benchmark/llms/common.tsx
+++ b/torchci/components/benchmark/llms/common.tsx
@@ -1,6 +1,6 @@
 import { BranchAndCommit } from "lib/types";
 
-export const REPOS = ["pytorch/pytorch", "pytorch/executorch"];
+export const REPOS = ["pytorch/pytorch", "pytorch/executorch", "pytorch/ao"];
 export const REPO_TO_BENCHMARKS: { [k: string]: string[] } = {
   "pytorch/pytorch": ["PyTorch gpt-fast benchmark"],
   "pytorch/executorch": ["ExecuTorch"],
@@ -40,9 +40,9 @@ export const RELATIVE_THRESHOLD = 0.05;
 export interface LLMsBenchmarkData {
   granularity_bucket: string;
   model: string;
-  backend?: string;
+  backend: string;
   workflow_id: number;
-  job_id?: number;
+  job_id: number;
   metric: string;
   actual: number;
   target: number;

--- a/torchci/components/benchmark/llms/common.tsx
+++ b/torchci/components/benchmark/llms/common.tsx
@@ -23,6 +23,7 @@ export const IS_INCREASING_METRIC_VALUE_GOOD: { [k: string]: boolean } = {
   token_per_sec: true,
   flops_utilization: true,
   "compilation_time(s)": false,
+  speedup: true,
 };
 export const METRIC_DISPLAY_SHORT_HEADERS: { [k: string]: string } = {
   "memory_bandwidth(GB/s)": "Bandwidth",

--- a/torchci/lib/benchmark/aoUtils.ts
+++ b/torchci/lib/benchmark/aoUtils.ts
@@ -77,11 +77,19 @@ export function computeSpeedup(repoName: string, data: LLMsBenchmarkData[]) {
 
     if (SPEEDUP_METRICS.includes(r.metric)) {
       const k = `${r.workflow_id} ${r.job_id} ${r.model} ${r.metric} ${r.device} ${r.arch}`;
-      if (k in baselineMetrics && baselineMetrics[k].actual !== 0) {
+      if (
+        k in baselineMetrics &&
+        baselineMetrics[k].actual !== 0 &&
+        r.actual !== 0
+      ) {
+        const speedup = r.metric.includes("time")
+          ? baselineMetrics[k].actual / r.actual
+          : r.actual / baselineMetrics[k].actual;
+
         withSpeedup.push({
           ...r,
           metric: "speedup",
-          actual: Number((r.actual / baselineMetrics[k].actual).toFixed(4)),
+          actual: Number(speedup.toFixed(4)),
           target: 0,
         });
       }

--- a/torchci/lib/benchmark/aoUtils.ts
+++ b/torchci/lib/benchmark/aoUtils.ts
@@ -56,7 +56,7 @@ export function convertToCompilerPerformanceData(data: BenchmarkData[]) {
 
 export function computeSpeedup(repoName: string, data: LLMsBenchmarkData[]) {
   if (repoName !== TORCHAO_REPO) {
-    return [];
+    return data;
   }
 
   const baselineMetrics: { [key: string]: LLMsBenchmarkData } = {};

--- a/torchci/lib/benchmark/aoUtils.ts
+++ b/torchci/lib/benchmark/aoUtils.ts
@@ -54,18 +54,14 @@ export function convertToCompilerPerformanceData(data: BenchmarkData[]) {
   return Object.values(convertData);
 }
 
-export function computeSpeedup(
-  repoName: string,
-  baseline: string,
-  data: LLMsBenchmarkData[]
-) {
+export function computeSpeedup(repoName: string, data: LLMsBenchmarkData[]) {
   if (repoName !== TORCHAO_REPO) {
     return [];
   }
 
   const baselineMetrics: { [key: string]: LLMsBenchmarkData } = {};
   data.forEach((r: LLMsBenchmarkData) => {
-    if (r.dtype !== baseline) {
+    if (r.dtype !== TORCHAO_BASELINE) {
       return;
     }
 
@@ -75,7 +71,7 @@ export function computeSpeedup(
 
   const withSpeedup: LLMsBenchmarkData[] = [];
   data.forEach((r: LLMsBenchmarkData) => {
-    if (r.dtype === baseline) {
+    if (r.dtype === TORCHAO_BASELINE) {
       return;
     }
 

--- a/torchci/lib/benchmark/llmUtils.ts
+++ b/torchci/lib/benchmark/llmUtils.ts
@@ -118,6 +118,10 @@ export function combineLeftAndRight(
           row["metadata"]["r"] ?? (hasR ? record["r"]["job_id"] : undefined);
       }
 
+      if (dtype !== "") {
+        row["dtype"] = dtype;
+      }
+
       if (backend !== "") {
         row["backend"] = backend;
       }

--- a/torchci/pages/benchmark/llms.tsx
+++ b/torchci/pages/benchmark/llms.tsx
@@ -85,10 +85,7 @@ function Report({
   const lDataWithSpeedup = computeSpeedup(repoName, lData);
   const rDataWithSpeedup = computeSpeedup(repoName, rData);
 
-  if (
-    lDataWithSpeedup.length !== lData.length ||
-    rDataWithSpeedup.length !== rData.length
-  ) {
+  if (repoName === "pytorch/ao") {
     metricNames = ["speedup", ...metricNames];
   }
 

--- a/torchci/pages/benchmark/llms.tsx
+++ b/torchci/pages/benchmark/llms.tsx
@@ -82,8 +82,8 @@ function Report({
     );
   }
 
-  const lDataWithSpeedup = computeSpeedup(repoName, TORCHAO_BASELINE, lData);
-  const rDataWithSpeedup = computeSpeedup(repoName, TORCHAO_BASELINE, rData);
+  const lDataWithSpeedup = computeSpeedup(repoName, lData);
+  const rDataWithSpeedup = computeSpeedup(repoName, rData);
 
   if (
     lDataWithSpeedup.length !== lData.length ||
@@ -117,6 +117,7 @@ function Report({
       <GraphPanel
         queryParams={queryParams}
         granularity={granularity}
+        repoName={repoName}
         modelName={modelName}
         backendName={backendName}
         dtypeName={dtypeName}


### PR DESCRIPTION
This is my initial attempt to add the speedup metric for TorchAO. This is done by comparing the gain of `autoquant` v.s. `noquant`.  This is by no means the best approach because it requires custom logic for TorchAO on the dashboard.  On the other hand, it's easy to implement and I think it's better to have the UX done first to gather early feedbacks from @jerryzh168 and the rest of ao team first.

IMO, better approaches would be to either 1) set the speedup metric on TorchAO side or 2) compute the speed up metric on ClickHouse.  Both are more involved and requires further design discussion.

### Testing

https://torchci-git-fork-huydhn-add-speedup-llm-dashboard-fbopensource.vercel.app/benchmark/llms?repoName=pytorch%2Fao