### PR TITLE
Add TorchAO aggregated geomean speedup metric

### DIFF
--- a/torchci/components/benchmark/llms/ModelGraphPanel.tsx
+++ b/torchci/components/benchmark/llms/ModelGraphPanel.tsx
@@ -89,10 +89,24 @@ export function GraphPanel({
     const geomean = computeGeomean(dataWithSpeedup, metric);
     chartData[metric] =
       modelName === DEFAULT_MODEL_NAME
-        ? geomean.map((record: LLMsBenchmarkData) => {
-            record.display = `${record.device} (${record.arch})`;
-            return record;
-          })
+        ? geomean
+            .filter((record: LLMsBenchmarkData) => {
+              const id = record.workflow_id;
+              return (
+                (id >= lWorkflowId && id <= rWorkflowId) ||
+                (id <= lWorkflowId && id >= rWorkflowId) ||
+                (lWorkflowId === undefined && rWorkflowId === undefined) ||
+                // This is a hack to handle the mock workflow ID coming from running TorchAO benchmark locally
+                // In such caase, the workflow ID is actually the epoch timestamp and the value is completely
+                // different than the regular GitHub workflow ID
+                0.5 > rWorkflowId / lWorkflowId ||
+                rWorkflowId / lWorkflowId > 2
+              );
+            })
+            .map((record: LLMsBenchmarkData) => {
+              record.display = `${record.device} (${record.arch})`;
+              return record;
+            })
         : dataWithSpeedup
             .filter((record: LLMsBenchmarkData) => {
               return (

--- a/torchci/components/benchmark/llms/ModelGraphPanel.tsx
+++ b/torchci/components/benchmark/llms/ModelGraphPanel.tsx
@@ -19,7 +19,7 @@ import {
 } from "components/metrics/panels/TimeSeriesPanel";
 import dayjs from "dayjs";
 import { computeSpeedup } from "lib/benchmark/aoUtils";
-import { useBenchmark } from "lib/benchmark/llmUtils";
+import { computeGeomean, useBenchmark } from "lib/benchmark/llmUtils";
 import { BranchAndCommit } from "lib/types";
 
 const GRAPH_ROW_HEIGHT = 245;
@@ -64,10 +64,6 @@ export function GraphPanel({
     );
   }
 
-  if (modelName === DEFAULT_MODEL_NAME) {
-    return <></>;
-  }
-
   const dataWithSpeedup = computeSpeedup(repoName, data);
 
   // Clamp to the nearest granularity (e.g. nearest hour) so that the times will
@@ -84,39 +80,53 @@ export function GraphPanel({
   const chartData: { [k: string]: any } = {};
   const graphSeries: { [k: string]: any } = {};
   metricNames.forEach((metric: string) => {
-    chartData[metric] = dataWithSpeedup
-      .filter((record: LLMsBenchmarkData) => {
-        return (
-          record.model === modelName &&
-          (record.dtype === dtypeName || dtypeName === DEFAULT_DTYPE_NAME) &&
-          (`${record.device} (${record.arch})` === deviceName ||
-            deviceName === DEFAULT_DEVICE_NAME) &&
-          record.metric === metric
-        );
-      })
-      .filter((record: LLMsBenchmarkData) => {
-        const id = record.workflow_id;
-        return (
-          (id >= lWorkflowId && id <= rWorkflowId) ||
-          (id <= lWorkflowId && id >= rWorkflowId) ||
-          (lWorkflowId === undefined && rWorkflowId === undefined)
-        );
-      })
-      .map((record: LLMsBenchmarkData) => {
-        const model = record.model;
-        const dtype = record.dtype;
-        const device = record.device;
+    // TODO (huydhn): Only display aggregated speedup metric for now
+    if (modelName === DEFAULT_MODEL_NAME && metric !== "speedup") {
+      chartData[metric] = [];
+      return;
+    }
 
-        record.display = model.includes(dtype)
-          ? model.includes(device)
-            ? model
-            : `${model} (${device})`
-          : model.includes(device)
-          ? `${model} (${dtype})`
-          : `${model} (${dtype} / ${device})`;
+    const geomean = computeGeomean(dataWithSpeedup, metric);
+    chartData[metric] =
+      modelName === DEFAULT_MODEL_NAME
+        ? geomean.map((record: LLMsBenchmarkData) => {
+            record.display = `${record.device} (${record.arch})`;
+            return record;
+          })
+        : dataWithSpeedup
+            .filter((record: LLMsBenchmarkData) => {
+              return (
+                record.model === modelName &&
+                (record.dtype === dtypeName ||
+                  dtypeName === DEFAULT_DTYPE_NAME) &&
+                (`${record.device} (${record.arch})` === deviceName ||
+                  deviceName === DEFAULT_DEVICE_NAME) &&
+                record.metric === metric
+              );
+            })
+            .filter((record: LLMsBenchmarkData) => {
+              const id = record.workflow_id;
+              return (
+                (id >= lWorkflowId && id <= rWorkflowId) ||
+                (id <= lWorkflowId && id >= rWorkflowId) ||
+                (lWorkflowId === undefined && rWorkflowId === undefined)
+              );
+            })
+            .map((record: LLMsBenchmarkData) => {
+              const model = record.model;
+              const dtype = record.dtype;
+              const device = record.device;
 
-        return record;
-      });
+              record.display = model.includes(dtype)
+                ? model.includes(device)
+                  ? model
+                  : `${model} (${device})`
+                : model.includes(device)
+                ? `${model} (${dtype})`
+                : `${model} (${dtype} / ${device})`;
+
+              return record;
+            });
 
     graphSeries[metric] = seriesWithInterpolatedTimes(
       chartData[metric],
@@ -141,7 +151,13 @@ export function GraphPanel({
           {metricNames
             .filter((metric) => chartData[metric].length !== 0)
             .map((metric: string) => (
-              <Grid item xs={12} lg={4} height={GRAPH_ROW_HEIGHT} key={metric}>
+              <Grid
+                item
+                xs={12}
+                lg={modelName === DEFAULT_MODEL_NAME ? 12 : 4}
+                height={GRAPH_ROW_HEIGHT}
+                key={metric}
+              >
                 <TimeSeriesPanelWithData
                   data={chartData[metric]}
                   series={graphSeries[metric]}
@@ -169,54 +185,56 @@ export function GraphPanel({
             ))}
         </Grid>
       </div>
-      <div>
-        <table>
-          <thead>
-            <tr>
-              <th>Date</th>
-              <th>Commit</th>
-              {metricNames.map((metric: string) => (
-                <th key={metric}>
-                  {chartData[metric].length !== 0
-                    ? metric in METRIC_DISPLAY_SHORT_HEADERS
-                      ? METRIC_DISPLAY_SHORT_HEADERS[metric]
-                      : metric
-                    : ""}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {chartData[availableMetric].map((entry: any, index: number) => {
-              let commit = WORKFLOW_ID_TO_COMMIT[entry.workflow_id];
-              return (
-                <tr key={index}>
-                  <td>{entry.granularity_bucket}</td>
-                  <td>
-                    <code>
-                      <a
-                        onClick={() => navigator.clipboard.writeText(commit)}
-                        className="animate-on-click"
-                      >
-                        {commit}
-                      </a>
-                    </code>
-                  </td>
-                  {metricNames
-                    .filter((metric) => chartData[metric].length !== 0)
-                    .map((metric: string) => (
-                      <td key={`${metric}-${index}`}>
-                        {chartData[metric][index] !== undefined
-                          ? chartData[metric][index].actual
-                          : ""}
-                      </td>
-                    ))}
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
+      {modelName !== DEFAULT_MODEL_NAME && (
+        <div>
+          <table>
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Commit</th>
+                {metricNames.map((metric: string) => (
+                  <th key={metric}>
+                    {chartData[metric].length !== 0
+                      ? metric in METRIC_DISPLAY_SHORT_HEADERS
+                        ? METRIC_DISPLAY_SHORT_HEADERS[metric]
+                        : metric
+                      : ""}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {chartData[availableMetric].map((entry: any, index: number) => {
+                let commit = WORKFLOW_ID_TO_COMMIT[entry.workflow_id];
+                return (
+                  <tr key={index}>
+                    <td>{entry.granularity_bucket}</td>
+                    <td>
+                      <code>
+                        <a
+                          onClick={() => navigator.clipboard.writeText(commit)}
+                          className="animate-on-click"
+                        >
+                          {commit}
+                        </a>
+                      </code>
+                    </td>
+                    {metricNames
+                      .filter((metric) => chartData[metric].length !== 0)
+                      .map((metric: string) => (
+                        <td key={`${metric}-${index}`}>
+                          {chartData[metric][index] !== undefined
+                            ? chartData[metric][index].actual
+                            : ""}
+                        </td>
+                      ))}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
     </>
   );
 }

--- a/torchci/components/benchmark/llms/SummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/SummaryPanel.tsx
@@ -83,13 +83,9 @@ export function SummaryPanel({
           model
         )}${backend}${dtype}&deviceName=${encodeURIComponent(deviceArch)}`;
 
-        const isNewModel = params.value.l === undefined ? "(NEW!) " : "";
-        const isModelStopRunning = params.value.r === undefined ? "❌" : "";
-
         return (
           <a href={url}>
-            {isNewModel}
-            {isModelStopRunning}&nbsp;<b>{model}</b>
+            <b>{model}</b>
           </a>
         );
       },

--- a/torchci/components/benchmark/llms/common.tsx
+++ b/torchci/components/benchmark/llms/common.tsx
@@ -14,6 +14,7 @@ export const METRIC_DISPLAY_HEADERS: { [k: string]: string } = {
   token_per_sec: "Token per second",
   flops_utilization: "FLOPs utilization",
   "compilation_time(s)": "Compilation Time (s)",
+  speedup: "Speedup",
 };
 // The variable name is a bit dumb, but it tells if a higher metric value
 // is good or bad so that we can highlight it on the dashboard accordingly.

--- a/torchci/pages/benchmark/llms.tsx
+++ b/torchci/pages/benchmark/llms.tsx
@@ -152,7 +152,7 @@ export default function Page() {
   const defaultStopTime = dayjs();
   const [stopTime, setStopTime] = useState(defaultStopTime);
   const [timeRange, setTimeRange] = useState<number>(LAST_N_DAYS);
-  const [granularity, setGranularity] = useState<Granularity>("hour");
+  const [granularity, setGranularity] = useState<Granularity>("day");
   const [lBranch, setLBranch] = useState<string>(MAIN_BRANCH);
   const [lCommit, setLCommit] = useState<string>("");
   const [rBranch, setRBranch] = useState<string>(MAIN_BRANCH);


### PR DESCRIPTION
This is the follow-up of https://github.com/pytorch/test-infra/pull/6118 to add an aggregated geomean speedup metric for all models grouped by devices.

I limit this change to TorchAO `speedup` metric for now until I have time to polish the rest of the metrics (or if there is a need to add them at all)

### Testing

https://torchci-git-fork-huydhn-add-benchmark-summary-fbopensource.vercel.app/benchmark/llms?repoName=pytorch%2Fao