### PR TITLE
[HUD] Do not set use grouping preference when using filter

### DIFF
--- a/torchci/lib/useGroupingPreference.tsx
+++ b/torchci/lib/useGroupingPreference.tsx
@@ -10,7 +10,7 @@ export function usePreference(
   name: string,
   override: boolean | undefined = undefined,
   defaultValue: boolean = true
-): [boolean, (_grouping: boolean) => void] {
+): [boolean, (_grouping: boolean) => void, (_grouping: boolean) => void] {
   const settingFromStorage =
     typeof window === "undefined"
       ? String(defaultValue)
@@ -29,24 +29,37 @@ export function usePreference(
     setState(initialVal);
   }, [initialVal]);
 
-  return [state, setStatePersist];
+  return [state, setStatePersist, setState];
 }
 
 export function useGroupingPreference(
-  hasParams: boolean
+  nameFilter: string | undefined | null
 ): [boolean, (_grouping: boolean) => void] {
-  const override = hasParams ? false : undefined;
+  const hasNameFilter =
+    nameFilter !== "" && nameFilter !== null && nameFilter !== undefined;
+  const override = hasNameFilter ? false : undefined;
+  const [state, setState, setStateTemp] = usePreference(
+    "useGrouping",
+    override
+  );
+  useEffect(() => {
+    if (hasNameFilter) {
+      // Set grouping to be false if there is a name filter.
+      setStateTemp(false);
+    }
+  }, [nameFilter]);
 
-  return usePreference("useGrouping", override);
+  return [state, setState];
 }
 
 export function useMonsterFailuresPreference(): [
   boolean,
   (_useMonsterFailuresValue: boolean) => void
 ] {
-  return usePreference(
+  const [state, setState] = usePreference(
     "useMonsterFailures",
     /*override*/ undefined,
     /*default*/ false
   );
+  return [state, setState];
 }

--- a/torchci/lib/useGroupingPreference.tsx
+++ b/torchci/lib/useGroupingPreference.tsx
@@ -44,7 +44,9 @@ export function useGroupingPreference(
   );
   useEffect(() => {
     if (hasNameFilter) {
-      // Set grouping to be false if there is a name filter.
+      // Manually set grouping to be false if there is a name filter.  Without this
+      // setState, if you enter a filter, check use grouping, then enter another
+      // filter, it will still be grouped
       setStateTemp(false);
     }
   }, [nameFilter]);

--- a/torchci/lib/useGroupingPreference.tsx
+++ b/torchci/lib/useGroupingPreference.tsx
@@ -44,9 +44,9 @@ export function useGroupingPreference(
   );
   useEffect(() => {
     if (hasNameFilter) {
-      // Manually set grouping to be false if there is a name filter.  Without this
-      // setState, if you enter a filter, check use grouping, then enter another
-      // filter, it will still be grouped
+      // Manually set grouping to be false if there is a name filter on first
+      // load.  Without this setState, if you enter a filter, check use
+      // grouping, then enter another filter, it will still be grouped
       setStateTemp(false);
     }
   }, [nameFilter]);

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -298,10 +298,7 @@ function GroupFilterableHudTable({
   const [mergeLF, setMergeLF] = useContext(MergeLFContext);
   return (
     <>
-      <JobFilterInput
-        currentFilter={jobFilter}
-        handleSubmit={handleSubmit}
-      />
+      <JobFilterInput currentFilter={jobFilter} handleSubmit={handleSubmit} />
       <CheckBoxSelector
         value={useGrouping}
         setValue={(value) => setUseGrouping(value)}

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -551,7 +551,7 @@ function GroupedHudTable({
 
   const [hideUnstable, setHideUnstable] = usePreference("hideUnstable");
   const [useGrouping, setUseGrouping] = useGroupingPreference(
-    params.nameFilter != null && params.nameFilter !== ""
+    params.nameFilter
   );
 
   const { shaGrid, groupNameMapping } = getGroupingData(

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -301,9 +301,6 @@ function GroupFilterableHudTable({
       <JobFilterInput
         currentFilter={jobFilter}
         handleSubmit={handleSubmit}
-        handleFocus={() => {
-          setUseGrouping(false);
-        }}
       />
       <CheckBoxSelector
         value={useGrouping}


### PR DESCRIPTION
Previously if you clicked the filter search box, it would change HUD to not use groupings.  
This made sense since the filtering was as you type, but it was changed recently to only take place after you hit enter.
Also, afterwards, if you reload the page, it would still not use groupings, even if no filter was applied, which is odd.

Now, if you click the filter, it does not change to use groupings immediately.  It now changes to not use the grouping after you hit enter and the filtering is performed.  When you reload the page, it uses the preference you set before clicking the filter


--

Old old (commit prior to this PRs base commit)
click filter -> turn off use grouping
type -> filter happens as you type, all groups are expanded
reload page with no filter -> grouping preference is to use expanded

Old (this PRs base commit)
click filter -> turn off use grouping
type -> nothing.  Hit enter -> filter, all groups are expanded
reload page with no filter -> grouping preference is to use expanded

New
click filter -> nothing happens
type -> nothing.  Hit enter -> filter + all groups are expanded
reload page with no filter -> grouping preference is to use whatever you had previously

