### PR TITLE
[ez][HUD] Remove rockset pip installs + some variable names

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
         echo ::group::setup Python environment
         python -m venv .venv/
         source .venv/bin/activate
-        pip install pip==23.0.1 pytest==7.2.0 rockset==1.0.3 jsonschema==4.17.3 clickhouse-connect==0.7.16
+        pip install pip==23.0.1 pytest==7.2.0 jsonschema==4.17.3 clickhouse-connect==0.7.16
         echo ::endgroup::
 
         # Test tools
@@ -51,7 +51,7 @@ jobs:
         echo ::group::setup Python environment
         python -m venv .venv/
         source .venv/bin/activate
-        pip install pip==23.0.1 pytest==7.2.0 rockset==1.0.3 \
+        pip install pip==23.0.1 pytest==7.2.0 \
           jsonschema==4.17.3 numpy==1.24.1 pandas==2.1.4 boto3==1.19.12 \
           clickhouse-connect==0.7.16
         echo ::endgroup::

--- a/.github/workflows/update-test-times.yml
+++ b/.github/workflows/update-test-times.yml
@@ -35,7 +35,6 @@ jobs:
         run: |
           python -m torchci.update_test_times
         env:
-          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
           CLICKHOUSE_ENDPOINT: ${{ secrets.CLICKHOUSE_HUD_USER_URL }}
           CLICKHOUSE_USERNAME: ${{ secrets.CLICKHOUSE_HUD_USER_USERNAME }}
           CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_HUD_USER_PASSWORD }}

--- a/.github/workflows/update_test_file_ratings.yml
+++ b/.github/workflows/update_test_file_ratings.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pip3 install --upgrade pip
-          pip3 install boto3==1.19.12 rockset==1.0.3 clickhouse-connect==0.7.16
+          pip3 install boto3==1.19.12 clickhouse-connect==0.7.16
           cd test-infra/tools/torchci
           pip3 install -e .
 
@@ -59,7 +59,6 @@ jobs:
           # python3 test-infra/tools/torchci/td/td_heuristic_profiling.py
 
         env:
-          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
           CLICKHOUSE_ENDPOINT: ${{ secrets.CLICKHOUSE_HUD_USER_URL }}
           CLICKHOUSE_USERNAME: ${{ secrets.CLICKHOUSE_HUD_USER_USERNAME }}
           CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_HUD_USER_PASSWORD }}

--- a/aws/ami/windows/scripts/Installers/Install-Pip-Dependencies.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-Pip-Dependencies.ps1
@@ -13,4 +13,4 @@ if (-Not (Test-Path -Path $condaHook -PathType Leaf)) {
 conda activate base
 
 # Some dependencies are installed by pip before testing, pin all of them
-pip install "ninja==1.10.0.post1" "future==0.18.2" "hypothesis==5.35.1" "expecttest==0.1.3" "librosa>=0.6.2" "scipy==1.6.3" "psutil==5.9.1" "pynvml==11.4.1" "pillow==9.2.0" "unittest-xml-reporting<=3.2.0,>=2.0.0" "pytest==7.1.3" "pytest-xdist==2.5.0" "pytest-flakefinder==1.1.0" "pytest-rerunfailures==10.2" "pytest-shard==0.1.2" "sympy==1.11.1" "xdoctest==1.0.2" "pygments==2.12.0" "opt-einsum>=3.3" "networkx==2.8.8" "mpmath==1.2.1" "pytest-rerunfailures==10.2" "pytest-cpp==2.3.0" "rockset==1.0.3"
+pip install "ninja==1.10.0.post1" "future==0.18.2" "hypothesis==5.35.1" "expecttest==0.1.3" "librosa>=0.6.2" "scipy==1.6.3" "psutil==5.9.1" "pynvml==11.4.1" "pillow==9.2.0" "unittest-xml-reporting<=3.2.0,>=2.0.0" "pytest==7.1.3" "pytest-xdist==2.5.0" "pytest-flakefinder==1.1.0" "pytest-rerunfailures==10.2" "pytest-shard==0.1.2" "sympy==1.11.1" "xdoctest==1.0.2" "pygments==2.12.0" "opt-einsum>=3.3" "networkx==2.8.8" "mpmath==1.2.1" "pytest-rerunfailures==10.2" "pytest-cpp==2.3.0"

--- a/tools/torchci/queue_alert.py
+++ b/tools/torchci/queue_alert.py
@@ -11,8 +11,6 @@ from torchci.check_alerts import clear_alerts, create_issue, fetch_alerts, updat
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
-PROD_VERSIONS_FILE = REPO_ROOT / "torchci" / "rockset" / "prodVersions.json"
-
 QUEUE_ALERT_LABEL = "queue-alert"
 
 MAX_HOURS = 4

--- a/tools/torchci/tests/test_queue_alert.py
+++ b/tools/torchci/tests/test_queue_alert.py
@@ -5,15 +5,15 @@ from torchci.queue_alert import filter_long_queues, gen_update_comment, QueueInf
 
 class TestGitHubPR(TestCase):
     def test_filter_long_queues(self):
-        rockset_results = [
+        db_results = [
             {"count": 30, "avg_queue_s": 0, "machine_type": "linux.gcp.a100.large"},
             {"count": 100, "avg_queue_s": 0, "machine_type": "machine1"},
             {"count": 30, "avg_queue_s": 3600 * 5, "machine_type": "machine2"},
         ]
-        long_queues = filter_long_queues(rockset_results)
+        long_queues = filter_long_queues(db_results)
         self.assertEqual(len(long_queues), 3)
 
-        rockset_results = [
+        db_results = [
             {
                 "count": 0,
                 "avg_queue_s": 3600 * 30,
@@ -22,7 +22,7 @@ class TestGitHubPR(TestCase):
             {"count": 10, "avg_queue_s": 0, "machine_type": "machine1"},
             {"count": 10, "avg_queue_s": 3600 * 1, "machine_type": "machine2"},
         ]
-        long_queues = filter_long_queues(rockset_results)
+        long_queues = filter_long_queues(db_results)
         self.assertEqual(len(long_queues), 1)
         self.assertEqual(long_queues[0].machine, "linux.gcp.a100.large")
 


### PR DESCRIPTION
Remove rockset pip installs + some mentions in variable names

This changes the windows ami scripts.  I'm down to try updating the AMI, but I'm also ok with this change being bundled into the next time the AMI gets changed