### PR TITLE
Dependabot for GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,8 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: 'weekly'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
I followed https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot but I'm not sure this works since this file only has /setup-ssh for npm and we definitely get dependabot PRs for stuff outside of setup-ssh

After looking at the dependabot config, I think the non setup-ssh updates might come from security updates, not version updates