### PR TITLE
[bots] Testing utilities: Partial type, some helper functions for flakybot

### DIFF
--- a/torchci/test/disableFlakyBot.test.ts
+++ b/torchci/test/disableFlakyBot.test.ts
@@ -568,10 +568,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
     expect(additionalErrMessage).toEqual(undefined);
     expect(labels).toEqual(["module: fft", "module: windows", "triaged"]);
 
-    if (!scope.isDone()) {
-      console.error("pending mocks: %j", scope.pendingMocks());
-    }
-    scope.done();
+    handleScope(scope);
   });
 
   test("getTestOwnerLabels: owned test file should route to oncall and NOT be triaged", async () => {
@@ -587,10 +584,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
       "triaged",
     ]);
 
-    if (!scope.isDone()) {
-      console.error("pending mocks: %j", scope.pendingMocks());
-    }
-    scope.done();
+    handleScope(scope);
   });
 
   test("getTestOwnerLabels: un-owned test file should return module: unknown", async () => {
@@ -604,10 +598,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
     expect(labels).toEqual(["module: unknown", "module: windows", "triaged"]);
     expect(additionalErrMessage).toEqual(undefined);
 
-    if (!scope.isDone()) {
-      console.error("pending mocks: %j", scope.pendingMocks());
-    }
-    scope.done();
+    handleScope(scope);
   });
 
   test("getTestOwnerLabels: ill-formatted file should return module: unknown", async () => {
@@ -621,10 +612,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
     expect(labels).toEqual(["module: windows", "triaged"]);
     expect(additionalErrMessage).toEqual(undefined);
 
-    if (!scope.isDone()) {
-      console.error("pending mocks: %j", scope.pendingMocks());
-    }
-    scope.done();
+    handleScope(scope);
   });
 
   test("getTestOwnerLabels: retry getting file fails all times", async () => {
@@ -653,10 +641,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
       "Error: Error retrieving file_a.py: 404, file_a: 404"
     );
 
-    if (!scope.isDone()) {
-      console.error("pending mocks: %j", scope.pendingMocks());
-    }
-    scope.done();
+    handleScope(scope);
   });
 
   test("getTestOwnerLabels: retry getting file", async () => {
@@ -673,10 +658,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
     expect(labels).toEqual(["module: fft", "module: windows", "triaged"]);
     expect(additionalErrMessage).toEqual(undefined);
 
-    if (!scope.isDone()) {
-      console.error("pending mocks: %j", scope.pendingMocks());
-    }
-    scope.done();
+    handleScope(scope);
   });
 
   test("getTestOwnerLabels: fallback to invoking file when retrieving file", async () => {
@@ -699,10 +681,7 @@ describe("Disable Flaky Test Bot Unit Tests", () => {
     expect(labels).toEqual(["module: fft", "module: rocm", "triaged"]);
     expect(additionalErrMessage).toEqual(undefined);
 
-    if (!scope.isDone()) {
-      console.error("pending mocks: %j", scope.pendingMocks());
-    }
-    scope.done();
+    handleScope(scope);
   });
 
   test("getTestOwnerLabels: give dynamo and inductor oncall: pt2 label", async () => {

--- a/torchci/test/disableFlakyBot.test.ts
+++ b/torchci/test/disableFlakyBot.test.ts
@@ -122,7 +122,7 @@ describe("Disable Flaky Test Bot Across Jobs", () => {
       flakyTestAcrossJobA.file,
       `# Owner(s): ["module: fft"]\nimport blah;\nrest of file`
     );
-    const scope2 = utils.mockCreatePR(
+    const scope2 = utils.mockCreateIssue(
       "pytorch/pytorch",
       "DISABLED test_conv1d_vs_scipy_mode_same_cuda_complex64 (__main__.TestConvolutionNNDeviceTypeCUDA)",
       ["Platforms: "],
@@ -270,7 +270,7 @@ describe("Disable Flaky Test Bot Integration Tests", () => {
       flakyTestA.file,
       `# Owner(s): ["module: fft"]\nimport blah;\nrest of file`
     );
-    const scope2 = utils.mockCreatePR(
+    const scope2 = utils.mockCreateIssue(
       "pytorch/pytorch",
       "DISABLED test_a (__main__.suite_a)",
       ["Platforms: "],
@@ -294,7 +294,7 @@ describe("Disable Flaky Test Bot Integration Tests", () => {
       flakyTestB.file,
       `# Owner(s): ["module: fft"]\nimport blah;\nrest of file`
     );
-    const scope2 = utils.mockCreatePR(
+    const scope2 = utils.mockCreateIssue(
       "pytorch/pytorch",
       "DISABLED test_b (__main__.suite_b)",
       ["Platforms:"],

--- a/torchci/test/utils.ts
+++ b/torchci/test/utils.ts
@@ -89,7 +89,7 @@ export function mockGetPR(repoFullName: string, prNumber: number, body: any) {
     .reply(200, body);
 }
 
-export function mockCreatePR(
+export function mockCreateIssue(
   repoFullName: string,
   title: string,
   bodyContains: string[],

--- a/torchci/test/utils.ts
+++ b/torchci/test/utils.ts
@@ -89,6 +89,25 @@ export function mockGetPR(repoFullName: string, prNumber: number, body: any) {
     .reply(200, body);
 }
 
+export function mockCreatePR(
+  repoFullName: string,
+  title: string,
+  bodyContains: string[],
+  labels: string[]
+) {
+  return nock("https://api.github.com")
+    .post(`/repos/${repoFullName}/issues`, (body) => {
+      expect(body.title).toEqual(title);
+      expect(body.labels.sort()).toEqual(labels.sort());
+      const bodyString = JSON.stringify(body.body);
+      for (const containedString of bodyContains) {
+        expect(bodyString).toContain(containedString);
+      }
+      return true;
+    })
+    .reply(200, {});
+}
+
 export function mockPostComment(
   repoFullName: string,
   prNumber: number,
@@ -131,18 +150,7 @@ export function mockHasApprovedWorkflowRun(repoFullName: string) {
     });
 }
 
-export function genIssueData(
-  nonDefaultInputs: {
-    number?: number;
-    title?: string;
-    html_url?: string;
-    state?: "open" | "closed";
-    body?: string;
-    updated_at?: string;
-    author_association?: string;
-    labels?: string[];
-  } = {}
-): IssueData {
+export function genIssueData(nonDefaultInputs: Partial<IssueData>): IssueData {
   return {
     number: 1,
     title: "test issue",
@@ -156,7 +164,9 @@ export function genIssueData(
   };
 }
 
-export function getDummyJob(nonDefaultInputs: any = {}): RecentWorkflowsData {
+export function getDummyJob(
+  nonDefaultInputs: Partial<RecentWorkflowsData>
+): RecentWorkflowsData {
   // Use this function to create a dummy job with default values
   if (
     (nonDefaultInputs.conclusion == "failure" ||


### PR DESCRIPTION
A few testing utilities to hopefully making writing bot tests easier
* Use Partial type for testing helper functions that generate dummy data https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype
* Add mockCreateIssue to mock creating an issue on Github, and use it in flakybot
* Add mockGetRawTestFile for flakybot for mocking retrieving the raw test file for oncall labels
* Use handleScope in flakybot tests