### PR TITLE
Add a chart to show the total the number of models

### DIFF
--- a/torchci/components/benchmark/compilers/SummaryGraphPanel.tsx
+++ b/torchci/components/benchmark/compilers/SummaryGraphPanel.tsx
@@ -275,6 +275,7 @@ function SuiteGraphPanel({
               },
             },
           }}
+          legendPadding={310}
         />
       </Grid2>
 
@@ -299,6 +300,7 @@ function SuiteGraphPanel({
               },
             },
           }}
+          legendPadding={310}
         />
       </Grid2>
 
@@ -324,6 +326,7 @@ function SuiteGraphPanel({
               },
             },
           }}
+          legendPadding={310}
         />
       </Grid2>
 
@@ -349,6 +352,7 @@ function SuiteGraphPanel({
               },
             },
           }}
+          legendPadding={310}
         />
       </Grid2>
 
@@ -373,6 +377,7 @@ function SuiteGraphPanel({
               },
             },
           }}
+          legendPadding={310}
         />
       </Grid2>
 
@@ -398,6 +403,7 @@ function SuiteGraphPanel({
               },
             },
           }}
+          legendPadding={310}
         />
       </Grid2>
 
@@ -423,6 +429,7 @@ function SuiteGraphPanel({
               },
             },
           }}
+          legendPadding={310}
         />
       </Grid2>
     </Grid2>

--- a/torchci/components/benchmark/compilers/SummaryGraphPanel.tsx
+++ b/torchci/components/benchmark/compilers/SummaryGraphPanel.tsx
@@ -143,6 +143,16 @@ function SuiteGraphPanel({
     "passrate",
     false
   );
+  const totalModelCountSeries = seriesWithInterpolatedTimes(
+    passrate,
+    startTime,
+    stopTime,
+    granularity,
+    groupByFieldName,
+    TIME_FIELD_NAME,
+    "total_count",
+    false
+  );
 
   // Geomean speedup
   const geomean = computeGeomean(data, models).filter((r: any) => {
@@ -262,6 +272,30 @@ function SuiteGraphPanel({
               align: "left",
               formatter: (r: any) => {
                 return (r.value[1] * 100).toFixed(0);
+              },
+            },
+          }}
+        />
+      </Grid2>
+
+      <Grid2 size={{ xs: 12, lg: 6 }} height={GRAPH_ROW_HEIGHT}>
+        <TimeSeriesPanelWithData
+          data={passrate}
+          series={totalModelCountSeries}
+          title={`Number of Models / ${SUITES[suite]}`}
+          groupByFieldName={groupByFieldName}
+          yAxisRenderer={(unit) => {
+            return `${unit}`;
+          }}
+          additionalOptions={{
+            yAxis: {
+              scale: true,
+            },
+            label: {
+              show: true,
+              align: "left",
+              formatter: (r: any) => {
+                return r.value[1];
               },
             },
           }}


### PR DESCRIPTION
Per the char with @zou3519 and @shunting314, I'm adding another chart to show the total number of models covered in the benchmark run.  This is the denominator used to compute the pass rate.  I'm showing this in a separate chart because there is no easy way to include this information in the current pass rate chart given the current implementation.

I also increase the legend padding a bit to make the chart easier to view.

### Testing

https://torchci-git-fork-huydhn-show-inductor-passr-b83539-fbopensource.vercel.app/benchmark/compilers?dashboard=torchinductor&startTime=Thu%2C%2018%20Jul%202024%2022%3A52%3A52%20GMT&stopTime=Tue%2C%2014%20Jan%202025%2023%3A52%3A52%20GMT&granularity=week&mode=inference&dtype=bfloat16&deviceName=cuda%20(a100)&lBranch=main&lCommit=1dab79470dbecef79ba4c7d4308d8a181091e58e&rBranch=main&rCommit=b732b52f1e4378f8486ceb5e7026be3321c2651c