### PR TITLE
Fix pt2 dashboard passrate calculation regression

### DIFF
--- a/torchci/clickhouse_queries/compilers_benchmark_performance/query.sql
+++ b/torchci/clickhouse_queries/compilers_benchmark_performance/query.sql
@@ -83,8 +83,6 @@ accuracy_results AS (
             workflow_id = { workflowId: Int64 }
             OR { workflowId: Int64 } = 0
         )
-        AND accuracy != 'model_fail_to_load'
-        AND accuracy != 'eager_fail_to_run'
 ),
 results AS (
     SELECT
@@ -144,6 +142,9 @@ results AS (
         LEFT JOIN accuracy_results ON performance_results.name = accuracy_results.name
         AND performance_results.replaced_filename = accuracy_results.replaced_filename
         AND performance_results.workflow_id = accuracy_results.workflow_id
+    WHERE
+        accuracy != 'model_fail_to_load'
+        AND accuracy != 'eager_fail_to_run'
 )
 SELECT
     DISTINCT results.workflow_id,


### PR DESCRIPTION
The regression comes from https://github.com/pytorch/test-infra/pull/6006 where I changed `accuracy_results LEFT JOIN performance_results` to `performance_results LEFT JOIN accuracy_results` to accommodate Apple MPS eager benchmark.  The swapped join wrongly returned `model_fail_to_load` and `eager_fail_to_run` models that shouldn't be included in the pass rate calculation because they are not something wrong with pt2.

### Testing

https://torchci-git-fork-huydhn-fix-pt2-dashboard-p-e92d66-fbopensource.vercel.app/benchmark/compilers?dashboard=torchinductor&startTime=Fri%2C%2019%20Jul%202024%2000%3A29%3A48%20GMT&stopTime=Wed%2C%2015%20Jan%202025%2001%3A29%3A48%20GMT&granularity=week&mode=inference&dtype=bfloat16&deviceName=cuda%20(a100)&lBranch=main&lCommit=1dab79470dbecef79ba4c7d4308d8a181091e58e&rBranch=main&rCommit=b732b52f1e4378f8486ceb5e7026be3321c2651c

* Before https://hud.pytorch.org/benchmark/torchbench/inductor_with_cudagraphs?dashboard=torchinductor&startTime=Thu%2C%2018%20Jul%202024%2023%3A36%3A11%20GMT&stopTime=Wed%2C%2015%20Jan%202025%2000%3A36%3A11%20GMT&granularity=week&mode=inference&dtype=bfloat16&deviceName=cuda%20(a100)&lBranch=main&lCommit=b732b52f1e4378f8486ceb5e7026be3321c2651c&rBranch=main&rCommit=b732b52f1e4378f8486ceb5e7026be3321c2651c

* After https://torchci-git-fork-huydhn-fix-pt2-dashboard-p-e92d66-fbopensource.vercel.app/benchmark/torchbench/inductor_with_cudagraphs?dashboard=torchinductor&startTime=Thu%2C%2018%20Jul%202024%2023%3A36%3A11%20GMT&stopTime=Wed%2C%2015%20Jan%202025%2000%3A36%3A11%20GMT&granularity=week&mode=inference&dtype=bfloat16&deviceName=cuda%20(a100)&lBranch=main&lCommit=b732b52f1e4378f8486ceb5e7026be3321c2651c&rBranch=main&rCommit=b732b52f1e4378f8486ceb5e7026be3321c2651chttps%3A%2F%2Ftorchci-git-fork-huydhn-fix-pt2-dashboard-p-e92d66-fbopensource.vercel.app%2F

