### PR TITLE
[CI] Add SHA256 checksum for binary uploads to S3

### DIFF
--- a/.github/actions/binary-upload/action.yml
+++ b/.github/actions/binary-upload/action.yml
@@ -29,7 +29,7 @@ runs:
         # shellcheck disable=SC1090
         source "${BUILD_ENV_FILE}"
 
-        pip install awscli==1.32.18
+        pip install awscli==1.37.0
         yum install -y jq
 
         export AWS_ROLE_ARN="arn:aws:iam::749337293305:role/gha_workflow_nightly_build_wheels"
@@ -43,5 +43,5 @@ runs:
           | jq -r '.value' > "${AWS_WEB_IDENTITY_TOKEN_FILE}"
 
         for pkg in dist/*; do
-          aws s3 cp "$pkg" "${PYTORCH_S3_BUCKET_PATH}" --acl public-read
+          aws s3 cp "$pkg" "${PYTORCH_S3_BUCKET_PATH}" --acl public-read --checksum-algorithm SHA256
         done

--- a/.github/workflows/_binary_upload.yml
+++ b/.github/workflows/_binary_upload.yml
@@ -109,7 +109,7 @@ jobs:
           # shellcheck disable=SC1090
           source "${BUILD_ENV_FILE}"
 
-          pip install awscli==1.32.18
+          pip install awscli==1.37.0
 
           AWS_CMD="aws s3 cp --dryrun"
           if [[ "${NIGHTLY_OR_TEST:-0}" == "1" ]]; then
@@ -117,7 +117,7 @@ jobs:
           fi
 
           for pkg in dist/*; do
-            ${AWS_CMD} "$pkg" "${PYTORCH_S3_BUCKET_PATH}" --acl public-read
+            ${AWS_CMD} "$pkg" "${PYTORCH_S3_BUCKET_PATH}" --acl public-read --checksum-algorithm SHA256
           done
 
       - name: Upload package to pypi

--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Upload files to s3
         if: github.event_name != 'pull_request'
         run: |
-          python3 -mpip install awscli==1.27.69
+          python3 -mpip install awscli==1.37.0
 
           aws s3 cp disabled-tests-condensed.json s3://ossci-metrics/disabled-tests-condensed.json
           aws s3 cp disabled-jobs.json s3://ossci-metrics/disabled-jobs.json


### PR DESCRIPTION
This ensures binary uploads to S3 attaches a SHA256 checksum.

I am not familiar with this code base, but from what I can gather the S3 uploads seem to be missing SHA256 for various wheel file URLs. This seem to lead to missing wheel hashes at https://download.pytorch.org/.  My guess is that the checksum is not available when it is retrieved [when the html is generated](https://github.com/pytorch/test-infra/blame/a797a36aab02198636cb2d032f24b894d668cefe/s3_management/manage.py#L535).

With this change, it should ensure that the checksum is calculated before upload and attached to the object.

Relates-to: https://github.com/pytorch/pytorch/issues/76557