### PR TITLE
Improve master_commit_red query performance

### DIFF
--- a/torchci/clickhouse_queries/master_commit_red/query.sql
+++ b/torchci/clickhouse_queries/master_commit_red/query.sql
@@ -43,7 +43,7 @@ all_jobs AS (
     END as conclusion,
     workflow_run.sha AS sha
   FROM
-    all_runs workflow_run join default.workflow_job job final on workflow_run.id = workflow_job.run_id
+    default.workflow_job job final join all_runs workflow_run on workflow_run.id = workflow_job.run_id
   WHERE
     job.name != 'ciflow_should_run'
     AND job.name != 'generate-test-matrix'

--- a/torchci/clickhouse_queries/master_commit_red/query.sql
+++ b/torchci/clickhouse_queries/master_commit_red/query.sql
@@ -1,5 +1,6 @@
 --- This query is used to show the histogram of trunk red commits on HUD metrics page
 --- during a period of time
+-- Split up the query into multiple CTEs to make it faster.
 with commits as (
   select
     push.head_commit.'timestamp' as time,

--- a/torchci/clickhouse_queries/master_commit_red/query.sql
+++ b/torchci/clickhouse_queries/master_commit_red/query.sql
@@ -43,7 +43,7 @@ all_jobs AS (
     END as conclusion,
     workflow_run.sha AS sha
   FROM
-    all_runs workflow_run join default.workflow_job job on workflow_run.id = workflow_job.run_id
+    all_runs workflow_run join default.workflow_job job final on workflow_run.id = workflow_job.run_id
   WHERE
     job.name != 'ciflow_should_run'
     AND job.name != 'generate-test-matrix'

--- a/torchci/clickhouse_queries/master_commit_red/query.sql
+++ b/torchci/clickhouse_queries/master_commit_red/query.sql
@@ -6,7 +6,8 @@ with commits as (
     push.head_commit.'timestamp' as time,
     push.head_commit.'id' as sha
   from
-    push final
+    -- Not using final since push table doesn't really get updated
+    push
   where
     push.ref in ('refs/heads/master', 'refs/heads/main')
     and push.repository.'owner'.'name' = 'pytorch'
@@ -34,7 +35,7 @@ all_runs as (
 ),
 all_jobs AS (
   SELECT
-    workflow_run.time AS time,
+    all_runs.time AS time,
     CASE
       WHEN job.conclusion = 'failure' THEN 'red'
       WHEN job.conclusion = 'timed_out' THEN 'red'
@@ -42,9 +43,9 @@ all_jobs AS (
       WHEN job.conclusion = '' THEN 'pending'
       ELSE 'green'
     END as conclusion,
-    workflow_run.sha AS sha
+    all_runs.sha AS sha
   FROM
-    default.workflow_job job final join all_runs workflow_run on workflow_run.id = workflow_job.run_id
+    default.workflow_job job final join all_runs all_runs on all_runs.id = workflow_job.run_id
   WHERE
     job.name != 'ciflow_should_run'
     AND job.name != 'generate-test-matrix'


### PR DESCRIPTION
Pre filter the commits so we can filter the workflow job and workflow run tables on it later

This improves speed for all time ranges up to 1 year.  I did not check beyond that
I believe the memory used is about the same, but it scans more rows for some reason

This is the query behind this chart
<img width="1266" alt="image" src="https://github.com/user-attachments/assets/e00c18dc-a87a-4648-99cd-9c35295baabf" />
on the metrics page

Tentative wins, sample size 3
```
+------+----------+-----------+-------------+---------------+--------------+---------------+----------------+--------------+
| Test | Avg Time | Base Time | Time Change | % Time Change |   Avg Mem    |    Base Mem   |   Mem Change   | % Mem Change |
+------+----------+-----------+-------------+---------------+--------------+---------------+----------------+--------------+
|  0   |   1163   |   23117   |    -21954   |      -95      | 157241294.6  | 1539051189.75 | -1381809895.15 |     -90      |
|  1   |   1281   |   14509   |    -13228   |      -91      |  350569557   |  1585082143.8 | -1234512586.8  |     -78      |
|  2   |   8704   |   22954   |    -14250   |      -62      | 1774302065.6 |   3929546293  | -2155244227.4  |     -55      |
+------+----------+-----------+-------------+---------------+--------------+---------------+----------------+--------------+
```