### PR TITLE
Update clickhouse connect to 0.8.14

### DIFF
--- a/.github/actions/update-viablestrict/action.yml
+++ b/.github/actions/update-viablestrict/action.yml
@@ -75,7 +75,7 @@ runs:
     - name: Install Python Packages
       shell: bash
       run: |
-        pip install clickhouse-connect==0.7.16 boto3==1.19.12
+        pip install clickhouse-connect==0.8.14 boto3==1.19.12
 
     - name: Get latest viable commit
       id: get-latest-commit

--- a/.github/workflows/revert-tracker.yml
+++ b/.github/workflows/revert-tracker.yml
@@ -25,7 +25,7 @@ jobs:
       - id: generate-reverts-file
         run: |
           cd test-infra/tools
-          python3 -m pip install clickhouse-connect==0.7.16
+          python3 -m pip install clickhouse-connect==0.8.14
           python3 -m torchci.reverts
           echo "revert_file=$(cat revert_file_name.txt)" >> "${GITHUB_OUTPUT}"
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
         echo ::group::setup Python environment
         python -m venv .venv/
         source .venv/bin/activate
-        pip install pip==23.0.1 pytest==7.2.0 jsonschema==4.17.3 clickhouse-connect==0.7.16
+        pip install pip==23.0.1 pytest==7.2.0 jsonschema==4.17.3 clickhouse-connect==0.8.14
         echo ::endgroup::
 
         # Test tools
@@ -53,7 +53,7 @@ jobs:
         source .venv/bin/activate
         pip install pip==23.0.1 pytest==7.2.0 \
           jsonschema==4.17.3 numpy==1.24.1 pandas==2.1.4 boto3==1.19.12 \
-          clickhouse-connect==0.7.16
+          clickhouse-connect==0.8.14
         echo ::endgroup::
 
         # Test tools

--- a/.github/workflows/update-test-times.yml
+++ b/.github/workflows/update-test-times.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install Dependencies
-        run: python -m pip install boto3==1.19.12 clickhouse-connect==0.7.16 requests==2.26.0
+        run: python -m pip install boto3==1.19.12 clickhouse-connect==0.8.14 requests==2.26.0
 
       - name: Update test times
         run: |

--- a/.github/workflows/update_test_file_ratings.yml
+++ b/.github/workflows/update_test_file_ratings.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pip3 install --upgrade pip
-          pip3 install boto3==1.19.12 clickhouse-connect==0.7.16
+          pip3 install boto3==1.19.12 clickhouse-connect==0.8.14
           cd test-infra/tools/torchci
           pip3 install -e .
 

--- a/aws/lambda/clickhouse-replicator-dynamo/requirements.txt
+++ b/aws/lambda/clickhouse-replicator-dynamo/requirements.txt
@@ -1,2 +1,2 @@
-clickhouse-connect==0.7.16
+clickhouse-connect==0.8.14
 pytest==7.4.0

--- a/aws/lambda/clickhouse-replicator-s3/requirements.txt
+++ b/aws/lambda/clickhouse-replicator-s3/requirements.txt
@@ -1,2 +1,2 @@
-clickhouse-connect==0.7.16
+clickhouse-connect==0.8.14
 pytest==7.4.0

--- a/aws/lambda/servicelab-ingestor/requirements.txt
+++ b/aws/lambda/servicelab-ingestor/requirements.txt
@@ -1,3 +1,3 @@
 boto3==1.28.24
-clickhouse-connect==0.7.16
+clickhouse-connect==0.8.14
 pytest==7.4.0

--- a/tools/torchci/requirements.txt
+++ b/tools/torchci/requirements.txt
@@ -2,4 +2,4 @@ setuptools==70.0.0
 requests
 boto3==1.19.12
 pytest==7.2.0
-clickhouse-connect==0.7.16
+clickhouse-connect==0.8.14


### PR DESCRIPTION
Did some verification for the easier python scripts like the revert tracker and the test time generator

Ran the dynamo replicator on a bit of workflow_job 
Ran the s3 replicator on a bit of merge_bases
Both seemed fine, but we should still monitor just in case

Do not merge until we are awake and able to revert quickly