### PR TITLE
fixes #6038 the -h command not always taken into account

### DIFF
--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -532,9 +532,13 @@ The explanation needs to be clear on why this is needed. Here are some good exam
     is_pr_comment: boolean = true
   ) {
     let args;
+    let split_args: string[] = [];
+
     try {
       const parser = getParser();
-      args = parser.parse_args(shlex.split(inputArgs));
+
+      split_args = shlex.split(inputArgs);
+      args = parser.parse_args(split_args);
     } catch (err: any) {
       // If the args are invalid, comment with the error + some help.
       await this.addComment(
@@ -546,7 +550,12 @@ The explanation needs to be clear on why this is needed. Here are some good exam
       return;
     }
 
-    if (args.help) {
+    // if help is present as an option on the main command, or -h or --help is in any location in the args (parseargs fails to get -h at the start of the args)
+    if (
+      args.help ||
+      split_args.includes("-h") ||
+      split_args.includes("--help")
+    ) {
       return await this.addComment(getHelp());
     }
 

--- a/torchci/test/mergeCommands.test.ts
+++ b/torchci/test/mergeCommands.test.ts
@@ -1562,6 +1562,56 @@ some other text lol
 
     handleScope(scope);
   });
+
+  test("pytorchmergebot -h rebase command on pull request prints help message and does not execute rebase", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
+
+    event.payload.comment.body = "@pytorchmergebot -h rebase";
+    event.payload.comment.user.login = "wdvr";
+    event.payload.issue.user.login = "random";
+
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    const pr_number = event.payload.issue.number;
+    const comment_number = event.payload.comment.id;
+    const scope = nock("https://api.github.com")
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          "Rebase a PR. Rebasing defaults to the stable viable/strict branch of pytorch."
+        );
+        return true;
+      })
+      .reply(200, {});
+
+    await probot.receive(event);
+
+    handleScope(scope);
+  });
+
+  test("pytorchmergebot rebase -h command on pull request prints help message and does not execute rebase", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request_comment.json");
+
+    event.payload.comment.body = "@pytorchmergebot rebase -h";
+    event.payload.comment.user.login = "wdvr";
+    event.payload.issue.user.login = "random";
+
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    const pr_number = event.payload.issue.number;
+    const comment_number = event.payload.comment.id;
+    const scope = nock("https://api.github.com")
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
+        expect(JSON.stringify(body)).toContain(
+          "Rebase a PR. Rebasing defaults to the stable viable/strict branch of pytorch."
+        );
+        return true;
+      })
+      .reply(200, {});
+
+    await probot.receive(event);
+
+    handleScope(scope);
+  });
 });
 
 describe("merge-bot not supported repo", () => {


### PR DESCRIPTION
fixes #6038 

the -h command is not always taken into account

the argparse library does not always capture the -h flag in all positions. Added 2 tests and an explicit check for the help flag.