### PR TITLE
Correctly return 200 in api/flaky-tests/disable

### DIFF
--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -29,8 +29,7 @@ export default async function handler(
   if (authorization === process.env.FLAKY_TEST_BOT_KEY) {
     await disableFlakyTestsAndReenableNonFlakyTests();
     res.status(200).end();
-  }
-  else {
+  } else {
     res.status(403).end();
   }
 }

--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -30,7 +30,9 @@ export default async function handler(
     await disableFlakyTestsAndReenableNonFlakyTests();
     res.status(200).end();
   }
-  res.status(403).end();
+  else {
+    res.status(403).end();
+  }
 }
 
 async function disableFlakyTestsAndReenableNonFlakyTests() {


### PR DESCRIPTION
When investigating https://github.com/pytorch/pytorch/issues/144964, I notice that `api/flaky-tests/disable` returns 403 error code even when I use the correct credential.  Same goes on 
https://vercel.com/fbopensource/torchci/logs?requestPaths=%2Fapi%2Fflaky-tests%2Fdisable&selectedLogId=cv6z2-1736966788286-ab32c5324f42&timeline=maximum&page=2