### PR TITLE
Adjust index page `Cache-Control` headers

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -613,7 +613,7 @@ class S3Index:
                 print(f"INFO Uploading {subdir}/{self.html_name} to {bucket.name}")
                 bucket.Object(key=f"{subdir}/{self.html_name}").put(
                     ACL="public-read",
-                    CacheControl="no-cache,no-store,must-revalidate",
+                    CacheControl="max-age=600, public",
                     ContentType="text/html",
                     Body=index_html,
                 )
@@ -626,7 +626,7 @@ class S3Index:
                 print(f"INFO Uploading {subdir}/index.html to {bucket.name}")
                 bucket.Object(key=f"{subdir}/index.html").put(
                     ACL="public-read",
-                    CacheControl="no-cache,no-store,must-revalidate",
+                    CacheControl="max-age=600, public",
                     ContentType="text/html",
                     Body=index_html,
                 )
@@ -641,7 +641,7 @@ class S3Index:
                     )
                     bucket.Object(key=f"{subdir}/{compat_pkg_name}/index.html").put(
                         ACL="public-read",
-                        CacheControl="no-cache,no-store,must-revalidate",
+                        CacheControl="max-age=600, public",
                         ContentType="text/html",
                         Body=index_html,
                     )


### PR DESCRIPTION
This changes the `Cache-Control` value for index pages from:
`no-cache,no-store,must-revalidate`

...to:
`max-age=600, public`

In order to allow the pages to be cached for up to 10 minutes.

The new value was chosen so that it matches that returned for PyPI index pages:

```
$ curl -sSI https://pypi.org/simple/ | rg cache-control
cache-control: max-age=600, public
```

For explanations of the directives, see:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#response_directives

Fixes pytorch/pytorch#130571.