### PR TITLE
Improves SLI page by adding sharable stateful link and sets 'pet, ephemeral, nonephemeral' as default options

### DIFF
--- a/torchci/pages/sli.tsx
+++ b/torchci/pages/sli.tsx
@@ -13,10 +13,12 @@ import {
 } from "@mui/material";
 import { DateTimePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import CopyLink from "components/CopyLink";
 import TimeSeriesPanel from "components/metrics/panels/TimeSeriesPanel";
 import { durationDisplay } from "components/TimeUtils";
 import dayjs from "dayjs";
 import { fetcher } from "lib/GeneralUtils";
+import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import useSWR from "swr";
 
@@ -130,8 +132,9 @@ export function TimeRangePicker({
           <MenuItem value={7}>Last 7 Days</MenuItem>
           <MenuItem value={14}>Last 14 Days</MenuItem>
           <MenuItem value={30}>Last Month</MenuItem>
-          <MenuItem value={90}>Last Quarter</MenuItem>
-          <MenuItem value={180}>Last Half</MenuItem>
+          <MenuItem value={60}>Last 2 Months</MenuItem>
+          <MenuItem value={90}>Last 3 Months</MenuItem>
+          <MenuItem value={180}>Last 6 Months</MenuItem>
           <MenuItem value={365}>Last Year</MenuItem>
           <MenuItem value={-1}>Custom</MenuItem>
         </Select>
@@ -169,7 +172,7 @@ function WorkerTypePicker({
     JSON.stringify(queryParams)
   )}`;
 
-  let { data, error } = useSWR(url, fetcher, {
+  let { data, error, isLoading } = useSWR(url, fetcher, {
     refreshInterval: 20 * 60 * 1000, // refresh 20 minutes
   });
 
@@ -182,7 +185,7 @@ function WorkerTypePicker({
     );
   }
 
-  if (data === undefined || data.length === 0) {
+  if (data === undefined || data.length === 0 || isLoading) {
     return <Skeleton variant={"rectangular"} height={"100%"} />;
   }
 
@@ -218,67 +221,153 @@ function WorkerTypePicker({
 }
 
 export default function Page() {
-  const [startTime, setStartTime] = useState(dayjs().subtract(1, "week"));
-  const [stopTime, setStopTime] = useState(dayjs());
-  const [timeRange, setTimeRange] = useState<number>(7);
-  const [workerTypes, setWorkerTypes] = useState<string[]>(["all"]);
+  const router = useRouter();
 
-  const timeParams: { [key: string]: any } = {
-    startTime: startTime.utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
-    stopTime: stopTime.utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
-  };
+  const { query } = router;
 
-  const [ttsPercentile, setTtsPercentile] = useState<string>("p95");
+  const initialStopTime = query.stopTime
+    ? dayjs(query.stopTime as string)
+    : dayjs();
+  const initialTimeRange = query.timeRange
+    ? parseInt(query.timeRange as string)
+    : 7;
+  const initialStartTime = query.startTime
+    ? dayjs(query.startTime as string)
+    : initialStopTime.subtract(initialTimeRange, "day");
+  const initialWorkerTypes = query.workerTypes
+    ? (query.workerTypes as string).split(",")
+    : ["pet", "ephemeral", "nonephemeral"];
+  const initialTtsPercentile = query.ttsPercentile
+    ? (query.ttsPercentile as string)
+    : "p80";
+
+  const [startTime, setStartTime] = useState(initialStartTime);
+  const [stopTime, setStopTime] = useState(initialStopTime);
+  const [timeRange, setTimeRange] = useState(initialTimeRange);
+  const [workerTypes, setWorkerTypes] = useState(initialWorkerTypes);
+  const [ttsPercentile, setTtsPercentile] = useState(initialTtsPercentile);
+  const [routerReady, setRouterReady] = useState(false);
+
+  if (!routerReady && router.isReady) {
+    setRouterReady(true);
+    setStartTime(initialStartTime);
+    setStopTime(initialStopTime);
+    setTimeRange(initialTimeRange);
+    setWorkerTypes(initialWorkerTypes);
+    setTtsPercentile(initialTtsPercentile);
+  }
+
+  const fullUrl = routerReady
+    ? `${window.location.origin}${router.asPath}`
+    : "";
+
+  useEffect(() => {
+    if (!router.isReady) return;
+
+    const params = new URLSearchParams();
+
+    if (timeRange !== -1) {
+      params.set("timeRange", timeRange.toString());
+    } else if (startTime && stopTime) {
+      params.set("startTime", startTime.utc().format("YYYY-MM-DD"));
+      params.set("stopTime", stopTime.utc().format("YYYY-MM-DD"));
+    } else {
+      params.set("timeRange", "7");
+    }
+
+    if (workerTypes) {
+      params.set("workerTypes", workerTypes.join(","));
+    } else {
+      params.set("workerTypes", initialWorkerTypes.join(","));
+    }
+    if (ttsPercentile) {
+      params.set("ttsPercentile", ttsPercentile);
+    } else {
+      params.set("ttsPercentile", initialTtsPercentile);
+    }
+
+    router.push({
+      pathname: router.pathname,
+      query: params.toString(),
+    });
+  }, [
+    initialTtsPercentile,
+    initialWorkerTypes,
+    router,
+    startTime,
+    stopTime,
+    timeRange,
+    ttsPercentile,
+    workerTypes,
+  ]);
 
   return (
     <div>
-      <Stack direction="row" spacing={2} sx={{ mb: 1 }}>
-        <Typography
-          fontSize={"2rem"}
-          fontWeight={"bold"}
-          sx={{ mb: 1, minWidth: 280 }}
-        >
-          GHA Workers SLI
-        </Typography>
-        <TimeRangePicker
-          startTime={startTime}
-          setStartTime={setStartTime}
-          stopTime={stopTime}
-          setStopTime={setStopTime}
-          timeRange={timeRange}
-          setTimeRange={setTimeRange}
-        />
-        <TtsPercentilePicker
-          ttsPercentile={ttsPercentile}
-          setTtsPercentile={setTtsPercentile}
-        />
-        <WorkerTypePicker
-          workerTypes={workerTypes}
-          setWorkerTypes={setWorkerTypes}
-          queryParams={{
-            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-            ...timeParams,
-          }}
-        />
-      </Stack>
-
-      <Grid2 size={{ xs: 6 }} height={ROW_HEIGHT}>
-        <TimeSeriesPanel
-          title={"GHA Worker Queue Time"}
-          queryName={"queue_times_historical_pct"}
-          queryParams={{
-            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-            pctile: ttsPercentile,
-            workersTypes: workerTypes,
-            ...timeParams,
-          }}
-          granularity={"hour"}
-          groupByFieldName={"machine_type"}
-          timeFieldName={"granularity_bucket"}
-          yAxisFieldName={`queue_s_${ttsPercentile}`}
-          yAxisRenderer={durationDisplay}
-        />
-      </Grid2>
+      {routerReady && (
+        <Stack direction="row" spacing={2} sx={{ mb: 1 }}>
+          <Typography
+            fontSize={"2rem"}
+            fontWeight={"bold"}
+            sx={{ mb: 1, minWidth: 280 }}
+          >
+            GHA Workers SLI
+          </Typography>
+          <CopyLink
+            textToCopy={fullUrl}
+            link={true}
+            compressed={false}
+            style={{
+              fontSize: "1rem",
+              borderRadius: 10,
+            }}
+          />
+        </Stack>
+      )}
+      {routerReady && (
+        <Stack direction="row" spacing={2} sx={{ mb: 1 }}>
+          <TimeRangePicker
+            startTime={startTime}
+            setStartTime={setStartTime}
+            stopTime={stopTime}
+            setStopTime={setStopTime}
+            timeRange={timeRange}
+            setTimeRange={setTimeRange}
+          />
+          <TtsPercentilePicker
+            ttsPercentile={ttsPercentile}
+            setTtsPercentile={setTtsPercentile}
+          />
+          <WorkerTypePicker
+            workerTypes={workerTypes}
+            setWorkerTypes={setWorkerTypes}
+            queryParams={{
+              timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+              startTime: startTime.utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
+              stopTime: stopTime.utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
+            }}
+          />
+        </Stack>
+      )}
+      {routerReady && (
+        <Grid2 size={{ xs: 6 }} height={ROW_HEIGHT}>
+          <TimeSeriesPanel
+            title={"GHA Worker Queue Time"}
+            queryName={"queue_times_historical_pct"}
+            queryParams={{
+              timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+              pctile: ttsPercentile,
+              workersTypes: workerTypes,
+              startTime: startTime.utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
+              stopTime: stopTime.utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
+            }}
+            granularity={"hour"}
+            groupByFieldName={"machine_type"}
+            timeFieldName={"granularity_bucket"}
+            yAxisFieldName={`queue_s_${ttsPercentile}`}
+            yAxisRenderer={durationDisplay}
+          />
+        </Grid2>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Adding a sharable link is a useful thing for when we want to share and discuss things inside the team (easier than sharing print screens most of the time).

All is not that useful of a metric for us, it include 3rd party provided runners and github runners. This makes the information noisy and non-actionable. To focus on what we manage and provide some useful breakdown I opted to have the following breakdowns by default:

- "pet" - include all our pet instances, macos and the shared instances with A100 and H100;
- "ephemeral" - are all instances that are dynamically scaled both by Meta and LF, that are ephemeral. They are very fragile to stockouts;
- "nonephemeral" - are all instances that are dynamically scaled both by Meta and LF, that are non-ephemeral. They are somewhat resilient to stockouts;

Other breakdowns are more useful as troubleshoot. More details can be found checking the code: https://github.com/pytorch-labs/pytorch-gha-infra/pull/590/files#diff-9837b2a66265c20a3b89d979d8c446108a824c8af3f997f535d62f644089e82cR148