### PR TITLE
Upload sha256 for wheels in lambda

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -264,9 +264,17 @@ init_command = [
 code = 'PYFMT'
 include_patterns = [
     '**/*.py',
+    'aws/lambda/whl_metadata_upload_pep658/**/*.py',
 ]
 exclude_patterns = [
-    'aws/lambda/**',
+    # 'aws/lambda/**',
+    'aws/lambda/usage-log-aggregator/**',
+    'aws/lambda/servicelab-ingestor/**',
+    'aws/lambda/log-classifier/**',
+    'aws/lambda/github-status-test/**',
+    'aws/lambda/gha-artifacts/**',
+    'aws/lambda/clickhouse-replicator-s3/**',
+    'aws/lambda/clickhouse-replicator-dynamo/**',
     's3_management/**',
 ]
 command = [

--- a/aws/lambda/whl_metadata_upload_pep658/README.md
+++ b/aws/lambda/whl_metadata_upload_pep658/README.md
@@ -1,6 +1,10 @@
-This lambda is used on the pytorch AWS account to upload metadata files from whl
-to be used in [pep658].  They are then added to the index by
-[s3_management/manage.py][managepy].
+This lambda is used on the pytorch AWS account to upload the sha256 of binaries
+for [pep503] and metadata files from whl to be used in [pep658].  They are then
+added to the index by [s3_management/manage.py][managepy].
+
+If a binary does not have a sha256, the lambda reuploads the binary with the
+sha256 as metadata. If a binary does have a sha256, the lambda extracts the
+metatdata file and uploads it to s3.
 
 This account does not use terraform, so this is the source of truth for the
 code, and the configuration should be:
@@ -21,3 +25,4 @@ Please see `test_lambda_function.py`.
 
 [pep658]: https://peps.python.org/pep-0658/
 [managepy]: https://github.com/pytorch/test-infra/blob/73eea9088162354f937230cb518f19f50f557062/s3_management/manage.py
+[pep503]: https://peps.python.org/pep-0503/

--- a/aws/lambda/whl_metadata_upload_pep658/lambda_function.py
+++ b/aws/lambda/whl_metadata_upload_pep658/lambda_function.py
@@ -40,6 +40,14 @@ def reupload_s3(bucket: str, key: str, dry_run: bool) -> None:
         )
 
 
+def is_public(bucket: str, key: str) -> bool:
+    try:
+        get_client(True).head_object(Bucket=bucket, Key=key)
+        return True
+    except Exception:
+        return False
+
+
 def lambda_handler(event: Any, context: Any, dry_run: bool = False) -> None:
     zip_location = "/tmp/wheel.zip"
     metadata_location = "/tmp/METADATA"
@@ -49,6 +57,11 @@ def lambda_handler(event: Any, context: Any, dry_run: bool = False) -> None:
         if not key.endswith(".whl"):
             print(f"Skipping {bucket}/{key} as it is not a wheel")
             continue
+
+        if not is_public(bucket, key):
+            print(f"Skipping {bucket}/{key} as it is not public")
+            continue
+
         print(f"Processing {bucket}/{key}")
 
         if os.path.exists(zip_location):

--- a/aws/lambda/whl_metadata_upload_pep658/test_lambda_function.py
+++ b/aws/lambda/whl_metadata_upload_pep658/test_lambda_function.py
@@ -6,6 +6,7 @@ from typing import Generator
 
 from lambda_function import get_client, lambda_handler
 
+
 GENERATE_EVENT_HELP_TEXT = """
 Generate an test_event.json for all files in this s3 path and test the lambda
 function with this new test_event.json. The test_event.json does not have


### PR DESCRIPTION
If a whl doesn't have the sha256 as metadata, the lambda will reupload the whl with the sha256

Also do not do anything if the object is not public

A previous attempt of this was using the --checksum argument with the cli, but it ended up with incorrect checksums. My guess is that multi part uploads mess with the checksum
Other ways to do this:
* call manage.py with --compute-sha256 before updating the index
* when uploading the binary, either make sure it doesn't use a multi part upload (I am not sure how to do this), upload with a manually calculated checksum, do another copy after uploading to get the correct checksum (not sure if this works in the cli)

Tested locally by running test_lambda_function 