### PR TITLE
[HUD] Better test info pages

### DIFF
--- a/torchci/clickhouse_queries/testStats3d/params.json
+++ b/torchci/clickhouse_queries/testStats3d/params.json
@@ -1,0 +1,6 @@
+{
+    "name": "String",
+    "suite": "String",
+    "file": "String",
+    "jobFilter": "String"
+}

--- a/torchci/clickhouse_queries/testStats3d/query.sql
+++ b/torchci/clickhouse_queries/testStats3d/query.sql
@@ -1,0 +1,56 @@
+with test_info as (
+    select
+        t.invoking_file,
+        t.job_id,
+        t.time,
+        t.failure,
+        t.error,
+        t.skipped,
+        t.rerun
+    from
+        default .test_run_s3 t
+    where
+        t.name = {name: String }
+        and t.classname = {suite: String }
+        and t.file = {file: String }
+        and t.time_inserted > now() - interval 3 day
+),
+per_job as (
+    select
+        t.invoking_file,
+        j.id,
+        avg(t.time) as time,
+        multiIf(
+            sum(length(t.failure)) + sum(length(t.error)) = count(*),
+            'failed',
+            sum(length(t.failure)) + sum(length(t.error)) + sum(length(t.rerun)) > 0,
+            'flaky',
+            sum(length(t.skipped)) = count(*),
+            'skipped',
+            'success'
+        ) as conclusion,
+        j.name as job_name,
+        any(j.created_at) as job_created_at
+    from
+        test_info t
+        join default .workflow_job j on t.job_id = j.id
+    where
+        j.id in (
+            select
+                t.job_id
+            from
+                test_info t
+        )
+        and j.name like {jobFilter: String}
+    group by
+        j.id,
+        j.name,
+        t.invoking_file
+)
+select
+    DATE_TRUNC('hour', job_created_at) as hour,
+    groupArray(conclusion) as conclusions
+from
+    per_job
+group by
+    hour

--- a/torchci/clickhouse_queries/testStatsDistinctCount/params.json
+++ b/torchci/clickhouse_queries/testStatsDistinctCount/params.json
@@ -1,0 +1,5 @@
+{
+    "name": "String",
+    "suite": "String",
+    "file": "String"
+}

--- a/torchci/clickhouse_queries/testStatsDistinctCount/query.sql
+++ b/torchci/clickhouse_queries/testStatsDistinctCount/query.sql
@@ -1,0 +1,8 @@
+select
+  count(distinct *) as count
+from
+  tests.distinct_names t
+where
+  t.name like {name: String}
+  and t.classname like {suite: String}
+  and t.file like {file: String}

--- a/torchci/clickhouse_queries/testStatsSearch/params.json
+++ b/torchci/clickhouse_queries/testStatsSearch/params.json
@@ -1,0 +1,7 @@
+{
+    "name": "String",
+    "suite": "String",
+    "file": "String",
+    "per_page": "Int",
+    "offset": "Int"
+}

--- a/torchci/clickhouse_queries/testStatsSearch/query.sql
+++ b/torchci/clickhouse_queries/testStatsSearch/query.sql
@@ -1,0 +1,23 @@
+select
+  t.name,
+  t.classname,
+  t.file,
+  t.invoking_file,
+  maxMerge(t.last_run) as last_run
+from
+  tests.distinct_names t
+where
+  t.name like {name: String}
+  and t.classname like {suite: String}
+  and t.file like {file: String}
+group by
+  t.name,
+  t.classname,
+  t.file,
+  t.invoking_file
+order by
+  t.name, t.classname, t.file, t.invoking_file
+limit
+  {per_page: Int}
+offset
+  {offset: Int}

--- a/torchci/components/tests/TestSearchForm.tsx
+++ b/torchci/components/tests/TestSearchForm.tsx
@@ -1,11 +1,12 @@
 import { Box, Button, TextField } from "@mui/material";
+import { encodeParams } from "pages/tests/search";
 
-function setURL(name: string, suite: string, file: string, limit: string) {
-  window.location.href = `/flakytest?name=${encodeURIComponent(
-    name
-  )}&suite=${encodeURIComponent(suite)}&file=${encodeURIComponent(
-    file
-  )}&limit=${encodeURIComponent(limit)}`;
+function setURL(name: string, suite: string, file: string) {
+  window.location.href = `/tests/search?${encodeParams({
+    name,
+    suite,
+    file,
+  })}`;
 }
 
 export default function TestSearchForm({

--- a/torchci/components/tests/TestSearchForm.tsx
+++ b/torchci/components/tests/TestSearchForm.tsx
@@ -1,0 +1,43 @@
+import { Box, Button, TextField } from "@mui/material";
+
+function setURL(name: string, suite: string, file: string, limit: string) {
+  window.location.href = `/flakytest?name=${encodeURIComponent(
+    name
+  )}&suite=${encodeURIComponent(suite)}&file=${encodeURIComponent(
+    file
+  )}&limit=${encodeURIComponent(limit)}`;
+}
+
+export default function TestSearchForm({
+  name,
+  suite,
+  file,
+}: {
+  name: string;
+  suite: string;
+  file: string;
+}) {
+  return (
+    <Box
+      component="form"
+      noValidate
+      autoComplete="off"
+      sx={{
+        "& .MuiTextField-root": { m: 1, width: "25ch" },
+        "& .MuiButton-root": { m: 2 },
+      }}
+      onSubmit={(e) => {
+        e.preventDefault();
+        // @ts-ignore
+        setURL(e.target[0].value, e.target[2].value, e.target[4].value);
+      }}
+    >
+      <TextField label="Test Name" defaultValue={name} />
+      <TextField label="Test Suite/Class" defaultValue={suite} />
+      <TextField label="Test File" defaultValue={file} />
+      <Button variant="contained" color="primary" type="submit">
+        Search
+      </Button>
+    </Box>
+  );
+}

--- a/torchci/package.json
+++ b/torchci/package.json
@@ -28,6 +28,7 @@
     "@mui/lab": "^6.0.0-beta.20",
     "@mui/material": "^6.2.1",
     "@mui/system": "^6.2.1",
+    "@mui/x-charts": "^7.24.0",
     "@mui/x-data-grid": "^7.23.3",
     "@mui/x-date-pickers": "^7.23.3",
     "@octokit/webhooks": "^13.3.0",

--- a/torchci/pages/api/flaky-tests/3dStats.ts
+++ b/torchci/pages/api/flaky-tests/3dStats.ts
@@ -1,0 +1,93 @@
+import { queryClickhouse } from "lib/clickhouse";
+import _ from "lodash";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<TestInfoAPIResponse>
+) {
+  const name = req.query.name as string;
+  const suite = req.query.suite as string;
+  const file = req.query.file as string;
+  const jobFilter = req.query.jobFilter as string;
+  res.status(200).json(await getTest(name, suite, file, jobFilter));
+}
+
+async function getTest(
+  name: string,
+  suite: string,
+  file: string,
+  jobFilter: string
+): Promise<TestInfoAPIResponse> {
+  jobFilter = `%${jobFilter}%`;
+  const query = `
+with test_info as (
+    select
+        t.invoking_file,
+        t.job_id,
+        t.time,
+        t.failure,
+        t.error,
+        t.skipped,
+        t.rerun
+    from
+        default .test_run_s3 t
+    where
+        t.name = {name: String }
+        and t.classname = {suite: String }
+        and t.file = {file: String }
+        and t.time_inserted > now() - interval 3 day
+),
+per_job as (
+    select
+        t.invoking_file,
+        j.id,
+        avg(t.time) as time,
+        multiIf(
+            sum(length(t.failure)) + sum(length(t.error)) = count(*),
+            'failed',
+            sum(length(t.failure)) + sum(length(t.error)) + sum(length(t.rerun)) > 0,
+            'flaky',
+            sum(length(t.skipped)) = count(*),
+            'skipped',
+            'success'
+        ) as conclusion,
+        j.name as job_name,
+        any(j.created_at) as job_created_at
+    from
+        test_info t
+        join default .workflow_job j on t.job_id = j.id
+    where
+        j.id in (
+            select
+                t.job_id
+            from
+                test_info t
+        )
+        and j.name like {jobFilter: String}
+    group by
+        j.id,
+        j.name,
+        t.invoking_file
+)
+select
+    DATE_TRUNC('hour', job_created_at) as hour,
+    groupArray(conclusion) as conclusions
+from
+    per_job
+group by
+    hour
+`;
+
+  const res = await queryClickhouse(query, { name, suite, file, jobFilter });
+
+  for (const row of res) {
+    row.conclusions = _.countBy(row.conclusions);
+  }
+  return res;
+}
+
+export type TestInfoAPIResponse = {
+  hour: string;
+  conclusions: { [key: string]: number };
+}[];

--- a/torchci/pages/api/flaky-tests/3dStats.ts
+++ b/torchci/pages/api/flaky-tests/3dStats.ts
@@ -1,4 +1,4 @@
-import { queryClickhouse } from "lib/clickhouse";
+import { queryClickhouseSaved } from "lib/clickhouse";
 import _ from "lodash";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -20,66 +20,13 @@ async function getTest(
   jobFilter: string
 ): Promise<TestInfoAPIResponse> {
   jobFilter = `%${jobFilter}%`;
-  const query = `
-with test_info as (
-    select
-        t.invoking_file,
-        t.job_id,
-        t.time,
-        t.failure,
-        t.error,
-        t.skipped,
-        t.rerun
-    from
-        default .test_run_s3 t
-    where
-        t.name = {name: String }
-        and t.classname = {suite: String }
-        and t.file = {file: String }
-        and t.time_inserted > now() - interval 3 day
-),
-per_job as (
-    select
-        t.invoking_file,
-        j.id,
-        avg(t.time) as time,
-        multiIf(
-            sum(length(t.failure)) + sum(length(t.error)) = count(*),
-            'failed',
-            sum(length(t.failure)) + sum(length(t.error)) + sum(length(t.rerun)) > 0,
-            'flaky',
-            sum(length(t.skipped)) = count(*),
-            'skipped',
-            'success'
-        ) as conclusion,
-        j.name as job_name,
-        any(j.created_at) as job_created_at
-    from
-        test_info t
-        join default .workflow_job j on t.job_id = j.id
-    where
-        j.id in (
-            select
-                t.job_id
-            from
-                test_info t
-        )
-        and j.name like {jobFilter: String}
-    group by
-        j.id,
-        j.name,
-        t.invoking_file
-)
-select
-    DATE_TRUNC('hour', job_created_at) as hour,
-    groupArray(conclusion) as conclusions
-from
-    per_job
-group by
-    hour
-`;
 
-  const res = await queryClickhouse(query, { name, suite, file, jobFilter });
+  const res = await queryClickhouseSaved("testStats3d", {
+    name,
+    suite,
+    file,
+    jobFilter,
+  });
 
   for (const row of res) {
     row.conclusions = _.countBy(row.conclusions);

--- a/torchci/pages/api/flaky-tests/search.ts
+++ b/torchci/pages/api/flaky-tests/search.ts
@@ -1,0 +1,90 @@
+import { queryClickhouse } from "lib/clickhouse";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ListTestInfoAPIResponse>
+) {
+  const name = req.query.name as string;
+  const suite = req.query.suite as string;
+  const file = req.query.file as string;
+  const per_page = parseInt(req.query.per_page as string) || 100;
+  const page = parseInt(req.query.page as string) || 1;
+
+  res.status(200).json(await listTests(name, suite, file, per_page, page));
+}
+
+async function listTests(
+  name: string,
+  suite: string,
+  file: string,
+  per_page: number,
+  page: number
+): Promise<ListTestInfoAPIResponse> {
+  const query = `
+select
+  t.name,
+  t.classname,
+  t.file,
+  t.invoking_file,
+  maxMerge(t.last_run) as last_run
+from
+  tests.distinct_names t
+where
+  t.name like {name: String}
+  and t.classname like {suite: String}
+  and t.file like {file: String}
+group by
+  t.name,
+  t.classname,
+  t.file,
+  t.invoking_file
+order by
+  t.name, t.classname, t.file, t.invoking_file
+limit
+  {per_page: Int}
+offset
+  {offset: Int}
+`;
+
+  const count = await queryClickhouse(
+    `
+select
+  count(distinct *) as count
+from
+  tests.distinct_names t
+where
+  t.name like {name: String}
+  and t.classname like {suite: String}
+  and t.file like {file: String}
+`,
+    {
+      name: `%${name}%`,
+      suite: `%${suite}%`,
+      file: `%${file}%`,
+    }
+  );
+
+  const result = await queryClickhouse(query, {
+    name: `%${name}%`,
+    suite: `%${suite}%`,
+    file: `%${file}%`,
+    per_page,
+    offset: (page - 1) * per_page,
+  });
+  return {
+    count: count[0].count,
+    tests: result,
+  };
+}
+
+export interface ListTestInfoAPIResponse {
+  count: number;
+  tests: {
+    name: string;
+    classname: string;
+    file: string;
+    invoking_file: string;
+    last_run: string;
+  }[];
+}

--- a/torchci/pages/api/flaky-tests/search.ts
+++ b/torchci/pages/api/flaky-tests/search.ts
@@ -1,4 +1,4 @@
-import { queryClickhouse } from "lib/clickhouse";
+import { queryClickhouseSaved } from "lib/clickhouse";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(
@@ -21,60 +21,23 @@ async function listTests(
   per_page: number,
   page: number
 ): Promise<ListTestInfoAPIResponse> {
-  const query = `
-select
-  t.name,
-  t.classname,
-  t.file,
-  t.invoking_file,
-  maxMerge(t.last_run) as last_run
-from
-  tests.distinct_names t
-where
-  t.name like {name: String}
-  and t.classname like {suite: String}
-  and t.file like {file: String}
-group by
-  t.name,
-  t.classname,
-  t.file,
-  t.invoking_file
-order by
-  t.name, t.classname, t.file, t.invoking_file
-limit
-  {per_page: Int}
-offset
-  {offset: Int}
-`;
+  const count = queryClickhouseSaved("testStatsDistinctCount", {
+    name: `%${name}%`,
+    suite: `%${suite}%`,
+    file: `%${file}%`,
+  });
 
-  const count = await queryClickhouse(
-    `
-select
-  count(distinct *) as count
-from
-  tests.distinct_names t
-where
-  t.name like {name: String}
-  and t.classname like {suite: String}
-  and t.file like {file: String}
-`,
-    {
-      name: `%${name}%`,
-      suite: `%${suite}%`,
-      file: `%${file}%`,
-    }
-  );
-
-  const result = await queryClickhouse(query, {
+  const result = queryClickhouseSaved("testStatsSearch", {
     name: `%${name}%`,
     suite: `%${suite}%`,
     file: `%${file}%`,
     per_page,
     offset: (page - 1) * per_page,
   });
+
   return {
-    count: count[0].count,
-    tests: result,
+    count: (await count)[0].count,
+    tests: await result,
   };
 }
 

--- a/torchci/pages/failure.tsx
+++ b/torchci/pages/failure.tsx
@@ -11,6 +11,7 @@ import { useRouter } from "next/router";
 import { CSSProperties, useEffect, useState } from "react";
 import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
 import useSWR from "swr";
+import { encodeParams } from "./tests/search";
 dayjs.extend(utc);
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
@@ -329,9 +330,10 @@ export default function Page() {
       {testInfo && (
         <div>
           <a
-            href={`/flakytest?name=${encodeURIComponent(
-              testInfo.testName
-            )}&suite=${encodeURIComponent(testInfo.moduleName)}&limit=100`}
+            href={`/tests/search?${encodeParams({
+              name: testInfo.testName,
+              suite: testInfo.moduleName,
+            })}`}
           >
             More Failures Page for {testInfo.testName}
           </a>

--- a/torchci/pages/flakytest.tsx
+++ b/torchci/pages/flakytest.tsx
@@ -1,106 +1,21 @@
-import { Pagination, Stack, Tooltip } from "@mui/material";
-import { DataGrid, GridColDef } from "@mui/x-data-grid";
-import LoadingPage from "components/LoadingPage";
-import TestSearchForm from "components/tests/TestSearchForm";
 import { useRouter } from "next/router";
-import { ListTestInfoAPIResponse } from "pages/api/flaky-tests/search";
-import { useEffect, useState } from "react";
-import useSWR from "swr";
-
-const fetcher = (url: string) => fetch(url).then((res) => res.json());
-
-export function encodeParams(params: { [key: string]: string }) {
-  return Object.keys(params)
-    .map((key) => `${key}=${encodeURIComponent(params[key])}`)
-    .join("&");
-}
+import { useEffect } from "react";
+import { encodeParams } from "./tests/search";
 
 export default function Page() {
   const router = useRouter();
   const name = (router.query.name || "") as string;
   const suite = (router.query.suite || "") as string;
   const file = (router.query.file || "") as string;
-  const [page, setPage] = useState(1);
-  const [count, setCount] = useState(1);
-  const { data, isLoading } = useSWR<ListTestInfoAPIResponse>(
-    `/api/flaky-tests/search?${encodeParams({
-      name,
-      suite,
-      file,
-      per_page: "100",
-      page: page.toString(),
-    })}`,
-    fetcher
-  );
-
-  const columns: GridColDef[] = [
-    {
-      field: "name",
-      headerName: "Name",
-      flex: 2,
-      renderCell: (params) => {
-        return (
-          <Tooltip title={params.value}>
-            <span>{params.value}</span>
-          </Tooltip>
-        );
-      },
-    },
-    { field: "classname", headerName: "Classname", flex: 1 },
-    { field: "file", headerName: "File", flex: 1 },
-    { field: "invoking_file", headerName: "Invoking File", flex: 1 },
-    { field: "last_run", headerName: "Last Run", flex: 1 },
-  ];
 
   useEffect(() => {
-    if (data) {
-      setCount(Math.ceil(data.count / 100));
+    if (router.isReady) {
+      window.location.href = `/tests/search?${encodeParams({
+        name,
+        suite,
+        file,
+      })}`;
     }
-  }, [data]);
-
-  if (!router.isReady) {
-    // router.query is not set on the initial render, so I return this in order
-    // to force the entire component to re-render once the query is set.  This
-    // gets around the TextField defaultValue getting set to "" and then not
-    // changing when the router changes.  Another option could be setting state
-    // but that is a lot of variables to set
-    return <LoadingPage />;
-  }
-
-  return (
-    <Stack spacing={{ xs: 1 }}>
-      <h1>Test Search</h1>
-      <TestSearchForm name={name} suite={suite} file={file} />
-      <div>Double click a row to see individual stats</div>
-      <Pagination
-        count={count}
-        page={page}
-        onChange={(_e, value) => setPage(value)}
-      />
-      <div style={{ height: "600px", width: "100%" }}>
-        {isLoading ? (
-          <LoadingPage />
-        ) : (
-          <DataGrid
-            sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
-            rows={data?.tests || []}
-            columns={columns}
-            density={"compact"}
-            hideFooter={true}
-            getRowId={(row) =>
-              `${row.name}-${row.classname}-${row.file}-${row.invoking_file}`
-            }
-            pagination={undefined}
-            onRowDoubleClick={(e) => {
-              window.location.href = `/tests/testInfo?${encodeParams({
-                name: e.row.name,
-                suite: e.row.classname,
-                file: e.row.file,
-              })}`;
-            }}
-          />
-        )}
-      </div>
-    </Stack>
-  );
+  }, [router.isReady]);
+  return <div></div>;
 }

--- a/torchci/pages/flakytest.tsx
+++ b/torchci/pages/flakytest.tsx
@@ -1,112 +1,106 @@
-import JobLinks from "components/JobLinks";
-import JobSummary from "components/JobSummary";
-import LogViewer from "components/LogViewer";
-import { ParamSelector } from "lib/ParamSelector";
+import { Pagination, Stack, Tooltip } from "@mui/material";
+import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import LoadingPage from "components/LoadingPage";
+import TestSearchForm from "components/tests/TestSearchForm";
 import { useRouter } from "next/router";
+import { ListTestInfoAPIResponse } from "pages/api/flaky-tests/search";
 import { useEffect, useState } from "react";
 import useSWR from "swr";
-import { FlakyTestInfoHUD } from "./api/flaky-tests/flakytest";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
-function setURL(name: string, suite: string, file: string, limit: string) {
-  window.location.href = `/flakytest?name=${encodeURIComponent(
-    name
-  )}&suite=${encodeURIComponent(suite)}&file=${encodeURIComponent(
-    file
-  )}&limit=${encodeURIComponent(limit)}`;
+export function encodeParams(params: { [key: string]: string }) {
+  return Object.keys(params)
+    .map((key) => `${key}=${encodeURIComponent(params[key])}`)
+    .join("&");
 }
 
 export default function Page() {
   const router = useRouter();
-  const name = (router.query.name || "%") as string;
-  const suite = (router.query.suite || "%") as string;
-  const file = (router.query.file || "%") as string;
-  const limit = (router.query.limit || "100") as string;
-  const [hasSearch, setHasSearch] = useState(true);
-  useEffect(() => {
-    console.log(name, suite, file);
-    if (name === "%" && suite === "%" && file === "%") {
-      setHasSearch(false);
-    } else {
-      setHasSearch(true);
-    }
-    console.log(hasSearch);
-  }, [name, suite, file]);
+  const name = (router.query.name || "") as string;
+  const suite = (router.query.suite || "") as string;
+  const file = (router.query.file || "") as string;
+  const [page, setPage] = useState(1);
+  const [count, setCount] = useState(1);
+  const { data, isLoading } = useSWR<ListTestInfoAPIResponse>(
+    `/api/flaky-tests/search?${encodeParams({
+      name,
+      suite,
+      file,
+      per_page: "100",
+      page: page.toString(),
+    })}`,
+    fetcher
+  );
 
-  // `useSWR` to avoid sending a garbage request to the server.
-  const swrKey = `/api/flaky-tests/flakytest?name=${encodeURIComponent(
-    name
-  )}&suite=${encodeURIComponent(suite)}&file=${encodeURIComponent(
-    file
-  )}&limit=${encodeURIComponent(limit)}`;
-  const { data } = useSWR(hasSearch && swrKey, fetcher);
+  const columns: GridColDef[] = [
+    {
+      field: "name",
+      headerName: "Name",
+      flex: 2,
+      renderCell: (params) => {
+        return (
+          <Tooltip title={params.value}>
+            <span>{params.value}</span>
+          </Tooltip>
+        );
+      },
+    },
+    { field: "classname", headerName: "Classname", flex: 1 },
+    { field: "file", headerName: "File", flex: 1 },
+    { field: "invoking_file", headerName: "Invoking File", flex: 1 },
+    { field: "last_run", headerName: "Last Run", flex: 1 },
+  ];
+
+  useEffect(() => {
+    if (data) {
+      setCount(Math.ceil(data.count / 100));
+    }
+  }, [data]);
+
+  if (!router.isReady) {
+    // router.query is not set on the initial render, so I return this in order
+    // to force the entire component to re-render once the query is set.  This
+    // gets around the TextField defaultValue getting set to "" and then not
+    // changing when the router changes.  Another option could be setting state
+    // but that is a lot of variables to set
+    return <LoadingPage />;
+  }
 
   return (
-    <div>
-      <h1>PyTorch CI Test Failures and Flaky Tests</h1>
-      <div>
-        {/* The March 22 date refers to https://github.com/pytorch/pytorch/pull/97304 */}
-        This shows the most recent failures in CI from after March 22nd, 2023
-        (100 by default). Data prior to this date still exists, but can only be
-        obtained by parsing test report xmls. If the job was successful, it
-        might have succeeded on retry. Search through the logs for the test
-        name.
+    <Stack spacing={{ xs: 1 }}>
+      <h1>Test Search</h1>
+      <TestSearchForm name={name} suite={suite} file={file} />
+      <div>Double click a row to see individual stats</div>
+      <Pagination
+        count={count}
+        page={page}
+        onChange={(_e, value) => setPage(value)}
+      />
+      <div style={{ height: "600px", width: "100%" }}>
+        {isLoading ? (
+          <LoadingPage />
+        ) : (
+          <DataGrid
+            sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+            rows={data?.tests || []}
+            columns={columns}
+            density={"compact"}
+            hideFooter={true}
+            getRowId={(row) =>
+              `${row.name}-${row.classname}-${row.file}-${row.invoking_file}`
+            }
+            pagination={undefined}
+            onRowDoubleClick={(e) => {
+              window.location.href = `/tests/testInfo?${encodeParams({
+                name: e.row.name,
+                suite: e.row.classname,
+                file: e.row.file,
+              })}`;
+            }}
+          />
+        )}
       </div>
-      <h3>
-        Test Name Filter:{" "}
-        <ParamSelector
-          value={name}
-          handleSubmit={(e) => setURL(e, suite, file, limit)}
-        />{" "}
-        | Test Suite Filter:{" "}
-        <ParamSelector
-          value={suite}
-          handleSubmit={(s) => setURL(name, s, file, limit)}
-        />{" "}
-        | Test File Filter:{" "}
-        <ParamSelector
-          value={file}
-          handleSubmit={(s) => setURL(name, suite, s, limit)}
-        />
-      </h3>
-      {!hasSearch ? (
-        <div>
-          Please click the blue boxes with `%` and enter a test name/class/file
-          to search for a specific test.
-        </div>
-      ) : data === undefined ? (
-        <div>Loading...</div>
-      ) : (
-        (data as FlakyTestInfoHUD[]).map((test) => {
-          return (
-            <div key={`${test.name} ${test.classname} ${test.file}`}>
-              <h1>
-                <code>{`${test.name}, ${test.classname}`}</code>
-              </h1>
-              from file <code>{`${test.invoking_file}`}</code>
-              <div>Jobs ({test.jobs.length} matches):</div>
-              <ul>
-                {test.jobs.map((job) => {
-                  return (
-                    <li key={job.id} id={job.id}>
-                      <JobSummary
-                        job={job}
-                        highlight={job.branch == "main"}
-                        unstableIssues={[]}
-                      />
-                      <div>
-                        <JobLinks job={job} showCommitLink={true} />
-                      </div>
-                      <LogViewer job={job} />
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
-          );
-        })
-      )}
-    </div>
+    </Stack>
   );
 }

--- a/torchci/pages/tests/search.tsx
+++ b/torchci/pages/tests/search.tsx
@@ -1,0 +1,106 @@
+import { Pagination, Stack, Tooltip } from "@mui/material";
+import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import LoadingPage from "components/LoadingPage";
+import TestSearchForm from "components/tests/TestSearchForm";
+import { useRouter } from "next/router";
+import { ListTestInfoAPIResponse } from "pages/api/flaky-tests/search";
+import { useEffect, useState } from "react";
+import useSWR from "swr";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export function encodeParams(params: { [key: string]: string }) {
+  return Object.keys(params)
+    .map((key) => `${key}=${encodeURIComponent(params[key])}`)
+    .join("&");
+}
+
+export default function Page() {
+  const router = useRouter();
+  const name = (router.query.name || "") as string;
+  const suite = (router.query.suite || "") as string;
+  const file = (router.query.file || "") as string;
+  const [page, setPage] = useState(1);
+  const [count, setCount] = useState(1);
+  const { data, isLoading } = useSWR<ListTestInfoAPIResponse>(
+    `/api/flaky-tests/search?${encodeParams({
+      name,
+      suite,
+      file,
+      per_page: "100",
+      page: page.toString(),
+    })}`,
+    fetcher
+  );
+
+  const columns: GridColDef[] = [
+    {
+      field: "name",
+      headerName: "Name",
+      flex: 2,
+      renderCell: (params) => {
+        return (
+          <Tooltip title={params.value}>
+            <span>{params.value}</span>
+          </Tooltip>
+        );
+      },
+    },
+    { field: "classname", headerName: "Classname", flex: 1 },
+    { field: "file", headerName: "File", flex: 1 },
+    { field: "invoking_file", headerName: "Invoking File", flex: 1 },
+    { field: "last_run", headerName: "Last Run", flex: 1 },
+  ];
+
+  useEffect(() => {
+    if (data) {
+      setCount(Math.ceil(data.count / 100));
+    }
+  }, [data]);
+
+  if (!router.isReady) {
+    // router.query is not set on the initial render, so I return this in order
+    // to force the entire component to re-render once the query is set.  This
+    // gets around the TextField defaultValue getting set to "" and then not
+    // changing when the router changes.  Another option could be setting state
+    // but that is a lot of variables to set
+    return <LoadingPage />;
+  }
+
+  return (
+    <Stack spacing={{ xs: 1 }}>
+      <h1>Test Search</h1>
+      <TestSearchForm name={name} suite={suite} file={file} />
+      <div>Double click a row to see individual stats</div>
+      <Pagination
+        count={count}
+        page={page}
+        onChange={(_e, value) => setPage(value)}
+      />
+      <div style={{ height: "600px", width: "100%" }}>
+        {isLoading ? (
+          <LoadingPage />
+        ) : (
+          <DataGrid
+            sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+            rows={data?.tests || []}
+            columns={columns}
+            density={"compact"}
+            hideFooter={true}
+            getRowId={(row) =>
+              `${row.name}-${row.classname}-${row.file}-${row.invoking_file}`
+            }
+            pagination={undefined}
+            onRowDoubleClick={(e) => {
+              window.location.href = `/tests/testInfo?${encodeParams({
+                name: e.row.name,
+                suite: e.row.classname,
+                file: e.row.file,
+              })}`;
+            }}
+          />
+        )}
+      </div>
+    </Stack>
+  );
+}

--- a/torchci/pages/tests/search.tsx
+++ b/torchci/pages/tests/search.tsx
@@ -41,7 +41,15 @@ export default function Page() {
       renderCell: (params) => {
         return (
           <Tooltip title={params.value}>
-            <span>{params.value}</span>
+            <a
+              href={`/tests/testInfo?${encodeParams({
+                name: params.value,
+                suite: params.row.classname,
+                file: params.row.file,
+              })}`}
+            >
+              {params.value}
+            </a>
           </Tooltip>
         );
       },
@@ -71,7 +79,6 @@ export default function Page() {
     <Stack spacing={{ xs: 1 }}>
       <h1>Test Search</h1>
       <TestSearchForm name={name} suite={suite} file={file} />
-      <div>Double click a row to see individual stats</div>
       <Pagination
         count={count}
         page={page}
@@ -91,13 +98,6 @@ export default function Page() {
               `${row.name}-${row.classname}-${row.file}-${row.invoking_file}`
             }
             pagination={undefined}
-            onRowDoubleClick={(e) => {
-              window.location.href = `/tests/testInfo?${encodeParams({
-                name: e.row.name,
-                suite: e.row.classname,
-                file: e.row.file,
-              })}`;
-            }}
           />
         )}
       </div>

--- a/torchci/pages/tests/testInfo.tsx
+++ b/torchci/pages/tests/testInfo.tsx
@@ -93,7 +93,7 @@ export default function Page() {
     <Stack spacing={{ xs: 1 }}>
       <h1>Test Info</h1>
       <TestSearchForm name={name} suite={suite} file={file} />
-      <h2>Last 3 Days</h2>
+      <h2>Last 3 Days on main Branch</h2>
       <Box
         component="form"
         noValidate
@@ -108,9 +108,9 @@ export default function Page() {
           setJobFilter(e.target[0].value);
         }}
       >
-        <TextField label="Job Filter" defaultValue={jobFilter} />
+        <TextField label="Chart Job Filter" defaultValue={jobFilter} />
         <Button variant="contained" color="primary" type="submit">
-          Search
+          Filter
         </Button>
       </Box>
 
@@ -124,7 +124,7 @@ export default function Page() {
         />
       )}
 
-      <h2>Failures and Reruns</h2>
+      <h2>Failures and Reruns on All Branches</h2>
       {failureInfoIsLoading ? (
         <LoadingPage />
       ) : (

--- a/torchci/pages/tests/testInfo.tsx
+++ b/torchci/pages/tests/testInfo.tsx
@@ -1,0 +1,152 @@
+import { Box, Button, Stack, TextField } from "@mui/material";
+import { BarChart } from "@mui/x-charts";
+import JobLinks from "components/JobLinks";
+import JobSummary from "components/JobSummary";
+import LoadingPage from "components/LoadingPage";
+import LogViewer from "components/LogViewer";
+import TestSearchForm from "components/tests/TestSearchForm";
+import dayjs from "dayjs";
+import { fetcher } from "lib/GeneralUtils";
+import { JobData } from "lib/types";
+import _ from "lodash";
+import { useRouter } from "next/router";
+import { TestInfoAPIResponse } from "pages/api/flaky-tests/3dStats";
+import { encodeParams } from "pages/flakytest";
+import { useState } from "react";
+import useSWRImmutable from "swr/immutable";
+
+function convertToSeries(data: TestInfoAPIResponse) {
+  data = data.sort((a, b) => dayjs(a.hour).unix() - dayjs(b.hour).unix());
+  const xAxis = [
+    {
+      data: data.map((d) => dayjs(d.hour).format("YYYY-MM-DD HH:mm")),
+      scaleType: "band",
+    },
+  ];
+  const allConclusions = _.uniq(
+    _.flatten(data.map((d) => Object.keys(d.conclusions)))
+  );
+
+  function getColorForConclusion(conclusion: string) {
+    switch (conclusion) {
+      case "failed":
+        return "#e15759";
+      case "flaky":
+        return "#f28e2c";
+      case "skipped":
+        return "#bab0ab";
+      case "success":
+        return "#59a14f";
+      default:
+        return "black";
+    }
+  }
+
+  const series = allConclusions.map((conclusion) => {
+    return {
+      label: conclusion,
+      stack: "total",
+      data: data.map((d) => d.conclusions[conclusion] ?? 0),
+      color: getColorForConclusion(conclusion),
+    };
+  });
+
+  return { xAxis, series };
+}
+
+export default function Page() {
+  const router = useRouter();
+  const name = (router.query.name || "%") as string;
+  const suite = (router.query.suite || "%") as string;
+  const file = (router.query.file || "%") as string;
+  const [jobFilter, setJobFilter] = useState<string>("");
+
+  const swrKey = `/api/flaky-tests/3dStats?${encodeParams({
+    name,
+    suite,
+    file,
+    jobFilter,
+  })}`;
+  const { data: last3dStats, isLoading } = useSWRImmutable<TestInfoAPIResponse>(
+    swrKey,
+    fetcher
+  );
+  const { data: failureInfo, isLoading: failureInfoIsLoading } =
+    useSWRImmutable<JobData[]>(
+      `/api/flaky-tests/failures?${encodeParams({
+        name,
+        suite,
+        file,
+        limit: "100",
+      })}`,
+      fetcher
+    );
+
+  if (!router.isReady) {
+    return <LoadingPage />;
+  }
+
+  const { series: last3dStatsSeries, xAxis: last3dStatsxAxis } =
+    convertToSeries(last3dStats ?? []);
+
+  return (
+    <Stack spacing={{ xs: 1 }}>
+      <h1>Test Info</h1>
+      <TestSearchForm name={name} suite={suite} file={file} />
+      <h2>Last 3 Days</h2>
+      <Box
+        component="form"
+        noValidate
+        autoComplete="off"
+        sx={{
+          "& .MuiTextField-root": { m: 1, width: "25ch" },
+          "& .MuiButton-root": { m: 2 },
+        }}
+        onSubmit={(e) => {
+          e.preventDefault();
+          // @ts-ignore
+          setJobFilter(e.target[0].value);
+        }}
+      >
+        <TextField label="Job Filter" defaultValue={jobFilter} />
+        <Button variant="contained" color="primary" type="submit">
+          Search
+        </Button>
+      </Box>
+
+      {isLoading ? (
+        <LoadingPage />
+      ) : (
+        <BarChart
+          height={400}
+          series={last3dStatsSeries}
+          xAxis={last3dStatsxAxis as any}
+        />
+      )}
+
+      <h2>Failures and Reruns</h2>
+      {failureInfoIsLoading ? (
+        <LoadingPage />
+      ) : (
+        <>
+          <div>Showing {(failureInfo ?? []).length} results</div>
+          <ul>
+            {(failureInfo ?? []).map((job) => (
+              <li key={job.id} id={job.id}>
+                <JobSummary
+                  job={job}
+                  highlight={job.branch == "main"}
+                  unstableIssues={[]}
+                />
+                <div>
+                  <JobLinks job={job} showCommitLink={true} />
+                </div>
+                <LogViewer job={job} />
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </Stack>
+  );
+}

--- a/torchci/pages/tests/testInfo.tsx
+++ b/torchci/pages/tests/testInfo.tsx
@@ -11,7 +11,7 @@ import { JobData } from "lib/types";
 import _ from "lodash";
 import { useRouter } from "next/router";
 import { TestInfoAPIResponse } from "pages/api/flaky-tests/3dStats";
-import { encodeParams } from "pages/flakytest";
+import { encodeParams } from "pages/tests/search";
 import { useState } from "react";
 import useSWRImmutable from "swr/immutable";
 

--- a/torchci/yarn.lock
+++ b/torchci/yarn.lock
@@ -2052,6 +2052,41 @@
     prop-types "^15.8.1"
     react-is "^19.0.0"
 
+"@mui/x-charts-vendor@7.20.0":
+  version "7.20.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-charts-vendor/-/x-charts-vendor-7.20.0.tgz#b5858b91da0bde4f9c31f5360d05ade0b6eb5e31"
+  integrity sha512-pzlh7z/7KKs5o0Kk0oPcB+sY0+Dg7Q7RzqQowDQjpy5Slz6qqGsgOB5YUzn0L+2yRmvASc4Pe0914Ao3tMBogg==
+  dependencies:
+    "@babel/runtime" "^7.25.7"
+    "@types/d3-color" "^3.1.3"
+    "@types/d3-delaunay" "^6.0.4"
+    "@types/d3-interpolate" "^3.0.4"
+    "@types/d3-scale" "^4.0.8"
+    "@types/d3-shape" "^3.1.6"
+    "@types/d3-time" "^3.0.3"
+    d3-color "^3.1.0"
+    d3-delaunay "^6.0.4"
+    d3-interpolate "^3.0.1"
+    d3-scale "^4.0.2"
+    d3-shape "^3.2.0"
+    d3-time "^3.1.0"
+    delaunator "^5.0.1"
+    robust-predicates "^3.0.2"
+
+"@mui/x-charts@^7.24.0":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-charts/-/x-charts-7.24.0.tgz#1269177a31e937989059341d3edb1923df300766"
+  integrity sha512-X/zN0GxPHJC24QckFrtEbIK0HYoGwZgpNC5CV9cvRGvHphDFuNZk9xg9fJwIg1i3PPZHXRO3E+L/ee6fJ9ufhw==
+  dependencies:
+    "@babel/runtime" "^7.25.7"
+    "@mui/utils" "^5.16.6 || ^6.0.0"
+    "@mui/x-charts-vendor" "7.20.0"
+    "@mui/x-internals" "7.24.0"
+    "@react-spring/rafz" "^9.7.5"
+    "@react-spring/web" "^9.7.5"
+    clsx "^2.1.1"
+    prop-types "^15.8.1"
+
 "@mui/x-data-grid@^7.23.3":
   version "7.23.3"
   resolved "https://registry.yarnpkg.com/@mui/x-data-grid/-/x-data-grid-7.23.3.tgz#35b30c8aaf2afee43aaa9cd6273e8478dad2c863"
@@ -2081,6 +2116,14 @@
   version "7.23.0"
   resolved "https://registry.yarnpkg.com/@mui/x-internals/-/x-internals-7.23.0.tgz#3b1d0e47f1504cbd74c60b6a514eb18c108cc6dd"
   integrity sha512-bPclKpqUiJYIHqmTxSzMVZi6MH51cQsn5U+8jskaTlo3J4QiMeCYJn/gn7YbeR9GOZFp8hetyHjoQoVHKRXCig==
+  dependencies:
+    "@babel/runtime" "^7.25.7"
+    "@mui/utils" "^5.16.6 || ^6.0.0"
+
+"@mui/x-internals@7.24.0":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-internals/-/x-internals-7.24.0.tgz#5d09d3d5d113e2be6ec2af49192024859951d348"
+  integrity sha512-lYa/XLltxNMY8YAFDopIHrXda2EAoqMCilyGMuPMz+WTG+b+StlUKqtj8cgFPQ/sa5dQ2fR7R3KJdjLREKUrlQ==
   dependencies:
     "@babel/runtime" "^7.25.7"
     "@mui/utils" "^5.16.6 || ^6.0.0"
@@ -2637,6 +2680,51 @@
     readable-stream "^3.6.0"
     split2 "^4.0.0"
 
+"@react-spring/animated@~9.7.5":
+  version "9.7.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.7.5.tgz#eb0373aaf99b879736b380c2829312dae3b05f28"
+  integrity sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==
+  dependencies:
+    "@react-spring/shared" "~9.7.5"
+    "@react-spring/types" "~9.7.5"
+
+"@react-spring/core@~9.7.5":
+  version "9.7.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.7.5.tgz#72159079f52c1c12813d78b52d4f17c0bf6411f7"
+  integrity sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==
+  dependencies:
+    "@react-spring/animated" "~9.7.5"
+    "@react-spring/shared" "~9.7.5"
+    "@react-spring/types" "~9.7.5"
+
+"@react-spring/rafz@^9.7.5", "@react-spring/rafz@~9.7.5":
+  version "9.7.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/rafz/-/rafz-9.7.5.tgz#ee7959676e7b5d6a3813e8c17d5e50df98b95df9"
+  integrity sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==
+
+"@react-spring/shared@~9.7.5":
+  version "9.7.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.7.5.tgz#6d513622df6ad750bbbd4dedb4ca0a653ec92073"
+  integrity sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==
+  dependencies:
+    "@react-spring/rafz" "~9.7.5"
+    "@react-spring/types" "~9.7.5"
+
+"@react-spring/types@~9.7.5":
+  version "9.7.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.7.5.tgz#e5dd180f3ed985b44fd2cd2f32aa9203752ef3e8"
+  integrity sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==
+
+"@react-spring/web@^9.7.5":
+  version "9.7.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.7.5.tgz#7d7782560b3a6fb9066b52824690da738605de80"
+  integrity sha512-lmvqGwpe+CSttsWNZVr+Dg62adtKhauGwLyGE/RRyZ8AAMLgb9x3NDMA5RMElXo+IMyTkPp7nxTB8ZQlmhb6JQ==
+  dependencies:
+    "@react-spring/animated" "~9.7.5"
+    "@react-spring/core" "~9.7.5"
+    "@react-spring/shared" "~9.7.5"
+    "@react-spring/types" "~9.7.5"
+
 "@remix-run/router@1.19.2":
   version "1.19.2"
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.19.2.tgz#0c896535473291cb41f152c180bedd5680a3b273"
@@ -2823,6 +2911,16 @@
   resolved "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz"
   integrity sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==
 
+"@types/d3-color@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.1.3.tgz#368c961a18de721da8200e80bf3943fb53136af2"
+  integrity sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==
+
+"@types/d3-delaunay@^6.0.4":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz#185c1a80cc807fdda2a3fe960f7c11c4a27952e1"
+  integrity sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==
+
 "@types/d3-ease@^3.0.0":
   version "3.0.0"
   resolved "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.0.tgz"
@@ -2832,6 +2930,13 @@
   version "3.0.1"
   resolved "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz"
   integrity sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==
+  dependencies:
+    "@types/d3-color" "*"
+
+"@types/d3-interpolate@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz#412b90e84870285f2ff8a846c6eb60344f12a41c"
+  integrity sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==
   dependencies:
     "@types/d3-color" "*"
 
@@ -2847,6 +2952,13 @@
   dependencies:
     "@types/d3-time" "*"
 
+"@types/d3-scale@^4.0.8":
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.8.tgz#d409b5f9dcf63074464bf8ddfb8ee5a1f95945bb"
+  integrity sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==
+  dependencies:
+    "@types/d3-time" "*"
+
 "@types/d3-shape@^3.1.0":
   version "3.1.1"
   resolved "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.1.tgz"
@@ -2854,10 +2966,22 @@
   dependencies:
     "@types/d3-path" "*"
 
+"@types/d3-shape@^3.1.6":
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-3.1.7.tgz#2b7b423dc2dfe69c8c93596e673e37443348c555"
+  integrity sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==
+  dependencies:
+    "@types/d3-path" "*"
+
 "@types/d3-time@*", "@types/d3-time@^3.0.0":
   version "3.0.0"
   resolved "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz"
   integrity sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==
+
+"@types/d3-time@^3.0.3":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.4.tgz#8472feecd639691450dd8000eb33edd444e1323f"
+  integrity sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==
 
 "@types/d3-timer@^3.0.0":
   version "3.0.0"
@@ -3954,10 +4078,17 @@ csstype@^3.1.3:
   dependencies:
     internmap "1 - 2"
 
-"d3-color@1 - 3":
+"d3-color@1 - 3", d3-color@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz"
   integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+
+d3-delaunay@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-6.0.4.tgz#98169038733a0a5babbeda55054f795bb9e4a58b"
+  integrity sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==
+  dependencies:
+    delaunator "5"
 
 d3-ease@^3.0.1:
   version "3.0.1"
@@ -3992,7 +4123,7 @@ d3-scale@^4.0.2:
     d3-time "2.1.1 - 3"
     d3-time-format "2 - 4"
 
-d3-shape@^3.1.0:
+d3-shape@^3.1.0, d3-shape@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz"
   integrity sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==
@@ -4006,7 +4137,7 @@ d3-shape@^3.1.0:
   dependencies:
     d3-time "1 - 3"
 
-"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@^3.0.0:
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@^3.0.0, d3-time@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz"
   integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
@@ -4109,6 +4240,13 @@ define-properties@^1.1.3, define-properties@^1.1.4:
   dependencies:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delaunator@5, delaunator@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-5.0.1.tgz#39032b08053923e924d6094fe2cde1a99cc51278"
+  integrity sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==
+  dependencies:
+    robust-predicates "^3.0.2"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -7651,6 +7789,11 @@ rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+robust-predicates@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-3.0.2.tgz#d5b28528c4824d20fc48df1928d41d9efa1ad771"
+  integrity sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==
 
 run-parallel@^1.1.9:
   version "1.2.0"


### PR DESCRIPTION
https://hud.pytorch.org/flakytest?name=test_mm_plus_mm&suite=TestPatternMatcher&limit=100

Changes the flakytest page to redirect to a search page.  Double clicking on a row brings you to a page about the individual test.  The individual test page has a bar chart of runs from the past 3 days, and the info that used to be on the flakytest page (list of jobs the test failed or was rerun)


Old:
<img width="784" alt="image" src="https://github.com/user-attachments/assets/6ac75367-503b-4b4f-9067-0a04edc34503" />
New:
https://torchci-git-csl-testx-fbopensource.vercel.app/flakytest?name=test_mm_plus_mm&suite=TestPatternMatcher&limit=100
<img width="790" alt="image" src="https://github.com/user-attachments/assets/a65fbc17-d4bb-456a-a3a2-73b3ca2da758" />
Double clicking on the row brings you to
https://torchci-git-csl-testx-fbopensource.vercel.app/tests/testInfo?name=test_mm_plus_mm&suite=TestPatternMatcher&file=inductor%2Ftest_pattern_matcher.py
which looks like this after loading
<img width="786" alt="image" src="https://github.com/user-attachments/assets/be18bcaa-8361-418f-8346-6840b6ddbe33" />
