### PR TITLE
[HUD] Better similar failure search UI

### DIFF
--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -49,7 +49,9 @@ export default function JobLinks({
         )}&jobName=${encodeURIComponent(
           job.jobName as string
         )}&failureCaptures=${encodeURIComponent(
-          JSON.stringify(job.failureCaptures)
+          job.failureCaptures.length == 1
+            ? (job.failureCaptures[0] as string)
+            : JSON.stringify(job.failureCaptures)
         )}`}
       >
         more like this

--- a/torchci/pages/api/failure.ts
+++ b/torchci/pages/api/failure.ts
@@ -2,7 +2,6 @@ import dayjs from "dayjs";
 import { NEWEST_FIRST, querySimilarFailures } from "lib/searchUtils";
 import _, { isEqual } from "lodash";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { formatFailureCaptures } from "pages/failure";
 
 interface Data {}
 
@@ -16,9 +15,9 @@ export default async function handler(
 ) {
   const name = req.query.name as string;
   const jobName = req.query.jobName as string;
-  const failureCaptures = formatFailureCaptures(
+  const failureCaptures = JSON.parse(
     req.query.failureCaptures as string
-  );
+  ) as string[];
   const useFuzzySearch = req.query.useFuzzySearch as string;
 
   // The current HUD page shows the last 14 days. Newer results are preferred

--- a/torchci/pages/api/failure.ts
+++ b/torchci/pages/api/failure.ts
@@ -2,6 +2,7 @@ import dayjs from "dayjs";
 import { NEWEST_FIRST, querySimilarFailures } from "lib/searchUtils";
 import _, { isEqual } from "lodash";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { formatFailureCaptures } from "pages/failure";
 
 interface Data {}
 
@@ -15,7 +16,9 @@ export default async function handler(
 ) {
   const name = req.query.name as string;
   const jobName = req.query.jobName as string;
-  const failureCaptures = JSON.parse(req.query.failureCaptures as string);
+  const failureCaptures = formatFailureCaptures(
+    req.query.failureCaptures as string
+  );
   const useFuzzySearch = req.query.useFuzzySearch as string;
 
   // The current HUD page shows the last 14 days. Newer results are preferred

--- a/torchci/pages/failure.tsx
+++ b/torchci/pages/failure.tsx
@@ -20,16 +20,16 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
 export function formatFailureCaptures(failureCaptures: string) {
   // Format the failure captures to be string[] for the API
-  let captures: any = [];
   try {
-    captures = JSON.parse(failureCaptures);
+    let captures = JSON.parse(failureCaptures);
+    if (captures instanceof Array) {
+      return captures;
+    } else {
+      return [failureCaptures as string];
+    }
   } catch (e) {
-    captures = failureCaptures as string;
+    return [failureCaptures as string];
   }
-  if (!Array.isArray(captures)) {
-    captures = [captures];
-  }
-  return captures as string[];
 }
 
 function FuzzySearchCheckBox({
@@ -277,7 +277,7 @@ function FailureInfo({
 }
 
 function getTestInfo(failureCapture: string) {
-  const pytestFailureRe = /.*.py::(.*)::(test_\S*)/;
+  const pytestFailureRe = /.*.py::(.*)::(test_\w*)/;
   const match = failureCapture.match(pytestFailureRe);
   if (match == null) {
     return null;

--- a/torchci/pages/failure.tsx
+++ b/torchci/pages/failure.tsx
@@ -18,7 +18,7 @@ dayjs.extend(utc);
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
-export function formatFailureCaptures(failureCaptures: string) {
+function formatFailureCaptures(failureCaptures: string) {
   // Format the failure captures to be string[] for the API
   try {
     let captures = JSON.parse(failureCaptures);
@@ -314,7 +314,9 @@ export default function Page() {
       ? `/api/failure?${encodeParams({
           name,
           jobName,
-          failureCaptures,
+          failureCaptures: JSON.stringify(
+            formatFailureCaptures(failureCaptures)
+          ),
           useFuzzySearch: useFuzzySearch.toString(),
         })}`
       : null;

--- a/torchci/pages/failure.tsx
+++ b/torchci/pages/failure.tsx
@@ -353,7 +353,12 @@ export default function Page() {
         <Stack spacing={1}>
           <TextField label="Job" defaultValue={name} />
           <TextField label="Failure Captures" defaultValue={failureCaptures} />
-          <Button variant="contained" color="primary" type="submit">
+          <Button
+            variant="contained"
+            color="primary"
+            type="submit"
+            style={{ width: "max-content" }}
+          >
             Search
           </Button>
         </Stack>


### PR DESCRIPTION
hud.pytorch.org/failure easier to search by doing some parsing into the expected format and putting a search button so it's clearer that you can search.

Search will still work without the [""], which didn't work before.

The `more like this` link will get rid of the [""] if possible to reduce confusion

I don't know what job name actually does so I didn't touch that functionality so there's probably still more parsing that needs to be done there

https://torchci-git-csl-similarfailureeasiersearch-fbopensource.vercel.app//failure?name=pull%20%2F%20linux-focal-cuda12.4-py3.10-gcc9%20%2F%20test%20(default%2C%204%2C%205%2C%20linux.4xlarge.nvidia.gpu)&jobName=undefined&failureCaptures=functorch%2Ftest_ops.py%3A%3ATestOperatorsCUDA%3A%3Atest_jvp_nn_functional_multi_head_attention_forward_cuda_float32

Old:
<img width="980" alt="image" src="https://github.com/user-attachments/assets/f919b818-7628-4fde-86fa-2c6b0d3336d8" />

New:
<img width="1099" alt="image" src="https://github.com/user-attachments/assets/e1f12391-38a6-4253-b7e1-3267c2bb202a" />
