### PR TITLE
Add ROCm device to PT2 inductor dashboard

### DIFF
--- a/torchci/components/benchmark/compilers/common.tsx
+++ b/torchci/components/benchmark/compilers/common.tsx
@@ -65,6 +65,7 @@ export const DISPLAY_NAMES_TO_DEVICE_NAMES: { [k: string]: string } = {
   "cuda (a10g)": "cuda_a10g",
   "cpu (x86)": "cpu_x86",
   "cpu (aarch64)": "cpu_aarch64",
+  rocm: "rocm",
   mps: "mps",
 };
 export const DISPLAY_NAMES_TO_WORKFLOW_NAMES: { [k: string]: string } = {
@@ -72,5 +73,6 @@ export const DISPLAY_NAMES_TO_WORKFLOW_NAMES: { [k: string]: string } = {
   "cuda (a10g)": "inductor-perf-nightly-A10g",
   "cpu (x86)": "inductor-perf-nightly-x86",
   "cpu (aarch64)": "inductor-perf-nightly-aarch64",
+  rocm: "inductor-perf-nightly-rocm",
   mps: "inductor-perf-nightly-macos",
 };


### PR DESCRIPTION
This is to support ROCm benchmark at https://github.com/pytorch/pytorch/pull/144594

### Testing

https://torchci-git-fork-huydhn-add-rocm-device-fbopensource.vercel.app/benchmark/compilers?dashboard=torchinductor&startTime=Mon%2C%2020%20Jan%202025%2019%3A06%3A47%20GMT&stopTime=Mon%2C%2027%20Jan%202025%2019%3A06%3A47%20GMT&granularity=hour&mode=inference&dtype=bfloat16&deviceName=rocm&lBranch=144594&lCommit=9f5cb037965aa2990b2e4593610bca92526ebb3b&rBranch=144594&rCommit=9f5cb037965aa2990b2e4593610bca92526ebb3b

cc @jeffdaily @BLOrange-AMD 

