### PR TITLE
Release 2.6 pypi prep changes

### DIFF
--- a/release/pypi/promote_pypi_to_staging.sh
+++ b/release/pypi/promote_pypi_to_staging.sh
@@ -27,7 +27,7 @@ MACOS_X86_64="macosx_.*_x86_64"
 MACOS_ARM64="macosx_.*_arm64"
 
 PLATFORM="linux_x86_64"          VERSION_SUFFIX="${LINUX_VERSION_SUFFIX}" ARCH="cu124" upload_pypi_to_staging torch "${PYTORCH_VERSION}"
-PLATFORM="manylinux2014_aarch64" VERSION_SUFFIX=""                                     upload_pypi_to_staging torch "${PYTORCH_VERSION}"
+PLATFORM="manylinux_2_28_aarch64" VERSION_SUFFIX="${CPU_VERSION_SUFFIX}"               upload_pypi_to_staging torch "${PYTORCH_VERSION}"
 PLATFORM="win_amd64"             VERSION_SUFFIX="${CPU_VERSION_SUFFIX}"                upload_pypi_to_staging torch "${PYTORCH_VERSION}"
 PLATFORM="${MACOS_ARM64}"        VERSION_SUFFIX=""                                     upload_pypi_to_staging torch "${PYTORCH_VERSION}"
 

--- a/release/pypi/upload_pypi_to_staging.sh
+++ b/release/pypi/upload_pypi_to_staging.sh
@@ -19,7 +19,7 @@ VERSION_SUFFIX=${VERSION_SUFFIX:-}
 PLATFORM=${PLATFORM:-}
 # Refers to the specific architecture we'd like to promote
 # i.e. cpu, cu121, cu124
-ARCH==${ARCH:-cpu}
+ARCH=${ARCH:-cpu}
 
 pkgs_to_promote=$(\
     curl -fsSL "https://download.pytorch.org/whl/test/${ARCH}/${PACKAGE_NAME}/index.html" \
@@ -47,12 +47,9 @@ for pkg in ${pkgs_to_promote}; do
     if [[ "${pkg}" != *aarch64* && "${pkg}" != *torchao* ]]; then
         # sub out linux for manylinux1
         pkg_basename="$(basename "${pkg//linux/manylinux1}")"
-    elif [[ "${pkg}" == *manylinux_2_17_aarch64* ]]; then
-        # strip manylinux_2_17 from core filename
-        pkg_basename="$(basename "${pkg//manylinux_2_17_aarch64./}")"
     elif [[ "${pkg}" == *linux_aarch64* ]]; then
-        # domains change linux_aarch64 to manylinux2014_aarch64
-        pkg_basename="$(basename "${pkg//linux_aarch64/manylinux2014_aarch64}")"
+        # domains change linux_aarch64 to manylinux_2_28_aarch64
+        pkg_basename="$(basename "${pkg//linux_aarch64/manylinux_2_28_aarch64}")"
     fi
 
     orig_pkg="${tmp_dir}/${pkg_basename}"


### PR DESCRIPTION
Changes the pypi prep scripts ahead of PyTorch release 2.6.
Main change: Aarch64 wheels are build using manylinux_2_28 Docker now.