### PR TITLE
Increase max docker build wait time to 120 minutes

### DIFF
--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -103,8 +103,8 @@ runs:
         retry login "${DOCKER_REGISTRY}"
 
         START_TIME=$(date +%s)
-        # Wait up to 90 minutes
-        while [[ $(( $(date +%s) - 5400 )) -lt $START_TIME ]]; do
+        # Wait up to 120 minutes
+        while [[ $(( $(date +%s) - 7200 )) -lt $START_TIME ]]; do
           # Check if image already exists, if it does then skip building it
           if docker manifest inspect "${DOCKER_IMAGE}"; then
             exit 0


### PR DESCRIPTION
Reported by @jeffdaily that the build job for ROCm Docker image now takes close to 90 minutes to finish, for example https://github.com/pytorch/pytorch/actions/runs/12998049606/job/36250394659.  So, setting the max waiting time to 90 minute is not sufficient anymore.