### PR TITLE
Correctly use rocm (mi300x) for ROCm device

### DIFF
--- a/torchci/components/benchmark/compilers/common.tsx
+++ b/torchci/components/benchmark/compilers/common.tsx
@@ -65,7 +65,7 @@ export const DISPLAY_NAMES_TO_DEVICE_NAMES: { [k: string]: string } = {
   "cuda (a10g)": "cuda_a10g",
   "cpu (x86)": "cpu_x86",
   "cpu (aarch64)": "cpu_aarch64",
-  rocm: "rocm",
+  "rocm (mi300x)": "rocm",
   mps: "mps",
 };
 export const DISPLAY_NAMES_TO_WORKFLOW_NAMES: { [k: string]: string } = {


### PR DESCRIPTION
This was called out by AMD team that the device should be called `rocm (mi300x)` so that we could have different AMD devices in the future.  This is also the same convention used by cuda on the dashboard.