### PR TITLE
Add check for bad checksum for multipart upload for s3 html index

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -540,7 +540,12 @@ class S3Index:
                 if obj.size is None
             }.items():
                 response = future.result()
-                sha256 = (_b64 := response.get("ChecksumSHA256")) and base64.b64decode(_b64).hex()
+                raw = response.get("ChecksumSHA256")
+                if len(raw) != 44:
+                    # Possibly part of a multipart upload, making the checksum incorrect
+                    print(f"WARNING: {self.objects[idx].orig_key} has incorrect checksum")
+                    raw = None
+                sha256 = raw and base64.b64decode(raw).hex()
                 # For older files, rely on checksum-sha256 metadata that can be added to the file later
                 if sha256 is None:
                     sha256 = response.get("Metadata", {}).get("checksum-sha256")

--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -541,7 +541,7 @@ class S3Index:
             }.items():
                 response = future.result()
                 raw = response.get("ChecksumSHA256")
-                if raw and len(raw) != 44:
+                if raw and raw.match("^[A-Za-z0-9+/=]+=-[0-9]+$") is None:
                     # Possibly part of a multipart upload, making the checksum incorrect
                     print(f"WARNING: {self.objects[idx].orig_key} has incorrect checksum")
                     raw = None

--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -541,7 +541,7 @@ class S3Index:
             }.items():
                 response = future.result()
                 raw = response.get("ChecksumSHA256")
-                if len(raw) != 44:
+                if raw and len(raw) != 44:
                     # Possibly part of a multipart upload, making the checksum incorrect
                     print(f"WARNING: {self.objects[idx].orig_key} has incorrect checksum")
                     raw = None


### PR DESCRIPTION
I think the reason the checksum is wrong is because the whl gets uploaded as a multipart upload since it is large.

Multipart upload checksums can be identified with the `-<number of parts>` at the end of the checksum

I want to use the workflow to collect all instances where this is true since running locally takes a long time

Tested locally by putting a very restrictive prefix filter