### PR TITLE
s3 binary upload with sha256 as metadata

### DIFF
--- a/.github/workflows/_binary_upload.yml
+++ b/.github/workflows/_binary_upload.yml
@@ -117,7 +117,9 @@ jobs:
           fi
 
           for pkg in dist/*; do
-            ${AWS_CMD} "$pkg" "${PYTORCH_S3_BUCKET_PATH}" --acl public-read
+            shm_id=$(sha256sum "${pkg}" | awk '{print $1}')
+            ${AWS_CMD} "$pkg" "${PYTORCH_S3_BUCKET_PATH}" --acl public-read \
+              --metadata "checksum-sha256=${shm_id}"
           done
 
       - name: Upload package to pypi


### PR DESCRIPTION
Equivalent of https://github.com/pytorch/pytorch/pull/144887 for domains

To be used in https://github.com/pytorch/test-infra/pull/6241