### PR TITLE
Remove setup-ssh from dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,5 @@
 version: 2
 updates:
-  # Enable version updates for npm
-  - package-ecosystem: 'npm'
-    # Look for `package.json` and `lock` files in the `root` directory
-    directory: '/setup-ssh'
-    # Check the npm registry for updates every day (weekdays)
-    schedule:
-      interval: 'weekly'
-
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
It creates a bunch of PRs that we never merge.  I don't know how to test this action and I assume that others are also unsure so they don't merge them either