### PR TITLE
Update linux_job_v2.yml

### DIFF
--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -278,21 +278,6 @@ jobs:
           path: ${{ env.RUNNER_TEST_RESULTS_DIR }}
           fail-on-empty: false
 
-      - name: configure aws credentials
-        id: aws_creds
-        if: ${{ inputs.gpu-arch-type == 'rocm' }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
-          aws-region: us-east-1
-          role-duration-seconds: 18000
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        if: ${{ inputs.gpu-arch-type == 'rocm' }}
-        continue-on-error: true
-        uses: aws-actions/amazon-ecr-login@v2
-
       - name: Chown repository directory
         if: ${{ inputs.gpu-arch-type != 'rocm' }}
         uses: ./test-infra/.github/actions/chown-directory


### PR DESCRIPTION
This removes the aws credentialing since we don't need the alpine image for the 'chown' workflow step.