### PR TITLE
Remove id-token:write in linux_job_v2

### DIFF
--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -105,9 +105,6 @@ on:
         default: false
         type: boolean
 
-permissions:
-  id-token: write
-
 jobs:
   job:
     strategy:


### PR DESCRIPTION
This should have been removed in https://github.com/pytorch/test-infra/pull/6250.  We don't need this anymore when there is no OIDC.

AI: Write a lint job to prevent people from changing the permission in linux job sounds like a good idea because doing so requires updating all the callers.