### PR TITLE
[aarch64] Add aarch64 cuda 12.8 domain builds

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -46,7 +46,7 @@ CUDA_CUDNN_VERSIONS = {
 
 CUDA_AARCH64_ARCHES = ["12.6-aarch64", "12.8-aarch64"]
 
-PACKAGE_TYPES = ["wheel", "libtorch"]
+PACKAGE_TYPES = ["wheel", "conda", "libtorch"]
 PRE_CXX11_ABI = "pre-cxx11"
 CXX11_ABI = "cxx11-abi"
 RELEASE = "release"
@@ -308,6 +308,23 @@ def get_wheel_install_command(
         return f"{whl_install_command} --index-url {get_base_download_url_for_repo('whl', channel, gpu_arch_type, desired_cuda)}"  # noqa: E501
 
 
+def generate_conda_matrix(
+    os: str,
+    channel: str,
+    with_cuda: str,
+    with_rocm: str,
+    with_cpu: str,
+    with_xpu: str,
+    limit_pr_builds: bool,
+    use_only_dl_pytorch_org: bool,
+    use_split_build: bool = False,
+    python_versions: Optional[List[str]] = None,
+) -> List[Dict[str, str]]:
+    ret: List[Dict[str, str]] = []
+    # return empty list. Conda builds are deprecated, see https://github.com/pytorch/pytorch/issues/138506
+    return ret
+
+
 def generate_libtorch_matrix(
     os: str,
     channel: str,
@@ -515,6 +532,7 @@ def generate_wheels_matrix(
 
 GENERATING_FUNCTIONS_BY_PACKAGE_TYPE: Dict[str, Callable[..., List[Dict[str, str]]]] = {
     "wheel": generate_wheels_matrix,
+    "conda": generate_conda_matrix,
     "libtorch": generate_libtorch_matrix,
 }
 

--- a/tools/tests/test_generate_binary_build_matrix.py
+++ b/tools/tests/test_generate_binary_build_matrix.py
@@ -60,17 +60,6 @@ class GenerateBuildMatrixTest(TestCase):
             reference_output_file="build_matrix_linux_wheel_cuda.json",
         )
 
-    def test_linux_conda_cuda(self):
-        self.matrix_compare_helper(
-            package_type="conda",
-            operating_system="linux",
-            cuda=True,
-            rocm=True,
-            cpu=True,
-            xpu=False,
-            reference_output_file="build_matrix_linux_conda_cuda.json",
-        )
-
     def test_macos_wheel(self):
         self.matrix_compare_helper(
             package_type="wheel",
@@ -82,17 +71,6 @@ class GenerateBuildMatrixTest(TestCase):
             reference_output_file="build_matrix_macos_wheel.json",
         )
 
-    def test_macos_conda(self):
-        self.matrix_compare_helper(
-            package_type="conda",
-            operating_system="macos",
-            cuda=False,
-            rocm=False,
-            cpu=True,
-            xpu=False,
-            reference_output_file="build_matrix_macos_conda.json",
-        )
-
     def test_windows_wheel_cuda(self):
         self.matrix_compare_helper(
             package_type="wheel",
@@ -102,17 +80,6 @@ class GenerateBuildMatrixTest(TestCase):
             cpu=True,
             xpu=True,
             reference_output_file="build_matrix_windows_wheel_cuda.json",
-        )
-
-    def test_windows_conda_cuda(self):
-        self.matrix_compare_helper(
-            package_type="conda",
-            operating_system="windows",
-            cuda=True,
-            rocm=True,
-            cpu=True,
-            xpu=True,
-            reference_output_file="build_matrix_windows_conda_cuda.json",
         )
 
     def test_windows_wheel_xpu(self):

--- a/tools/tests/test_generate_binary_build_matrix.py
+++ b/tools/tests/test_generate_binary_build_matrix.py
@@ -60,6 +60,17 @@ class GenerateBuildMatrixTest(TestCase):
             reference_output_file="build_matrix_linux_wheel_cuda.json",
         )
 
+    def test_linux_conda_cuda(self):
+        self.matrix_compare_helper(
+            package_type="conda",
+            operating_system="linux",
+            cuda=True,
+            rocm=True,
+            cpu=True,
+            xpu=False,
+            reference_output_file="build_matrix_linux_conda_cuda.json",
+        )
+
     def test_macos_wheel(self):
         self.matrix_compare_helper(
             package_type="wheel",
@@ -71,6 +82,17 @@ class GenerateBuildMatrixTest(TestCase):
             reference_output_file="build_matrix_macos_wheel.json",
         )
 
+    def test_macos_conda(self):
+        self.matrix_compare_helper(
+            package_type="conda",
+            operating_system="macos",
+            cuda=False,
+            rocm=False,
+            cpu=True,
+            xpu=False,
+            reference_output_file="build_matrix_macos_conda.json",
+        )
+
     def test_windows_wheel_cuda(self):
         self.matrix_compare_helper(
             package_type="wheel",
@@ -80,6 +102,17 @@ class GenerateBuildMatrixTest(TestCase):
             cpu=True,
             xpu=True,
             reference_output_file="build_matrix_windows_wheel_cuda.json",
+        )
+
+    def test_windows_conda_cuda(self):
+        self.matrix_compare_helper(
+            package_type="conda",
+            operating_system="windows",
+            cuda=True,
+            rocm=True,
+            cpu=True,
+            xpu=True,
+            reference_output_file="build_matrix_windows_conda_cuda.json",
         )
 
     def test_windows_wheel_xpu(self):


### PR DESCRIPTION
https://github.com/pytorch/pytorch/issues/145570

Deprecate conda functions meanwhile, as conda builds are gone https://github.com/pytorch/pytorch/issues/138506

cc @atalman @ptrblck @nWEIdia 