### PR TITLE
Make llm benchmarks query faster

### DIFF
--- a/tools/torchci/clickhouse_query_perf.py
+++ b/tools/torchci/clickhouse_query_perf.py
@@ -173,6 +173,9 @@ def results_compare(args: argparse.Namespace) -> None:
         return
     query, tests = get_query(args.query, args.head)
     base_query, _ = get_query(args.query, args.base)
+    results_folder = REPO_ROOT / "_logs" / "query_results"
+    if not results_folder.exists():
+        results_folder.mkdir(parents=True)
     print(
         f"Comparing results for query: {args.query}\nNum tests: {len(tests)}\nHead: {args.head} Base: {args.base}"
     )
@@ -189,8 +192,11 @@ def results_compare(args: argparse.Namespace) -> None:
         if new_results != base_results:
             print(f"Results for test {i} differ")
             print(f"Test: {json.dumps(test, indent=2)}")
-            print(f"New: {new_results}")
-            print(f"Base: {base_results}")
+            with open(results_folder / f"{args.query}_{i}_new.json", "w") as f:
+                json.dump(new_results, f, indent=2)
+            with open(results_folder / f"{args.query}_{i}_base.json", "w") as f:
+                json.dump(base_results, f, indent=2)
+            print("Results can be found in the _logs/query_results folder")
             print()
         else:
             print(f"Results for test {i} match")

--- a/torchci/clickhouse_queries/oss_ci_benchmark_llms/params.json
+++ b/torchci/clickhouse_queries/oss_ci_benchmark_llms/params.json
@@ -14,5 +14,21 @@
     "startTime": "DateTime64(3)",
     "stopTime": "DateTime64(3)"
   },
-  "tests": []
+  "tests": [
+    {
+      "arch": "",
+      "branches": ["main"],
+      "commits": ["bb4bd5f00b35eaaecb47d17caddfbd69e1f733df"],
+      "device": "",
+      "dtypes": [],
+      "excludedMetrics": [],
+      "benchmarks": ["PyTorch gpt-fast benchmark"],
+      "granularity": "day",
+      "models": [],
+      "backends": [],
+      "repo": "pytorch/pytorch",
+      "startTime": "2025-01-28T22:46:18.214",
+      "stopTime": "2025-02-04T22:46:18.214"
+    }
+  ]
 }

--- a/torchci/clickhouse_queries/oss_ci_benchmark_llms/query.sql
+++ b/torchci/clickhouse_queries/oss_ci_benchmark_llms/query.sql
@@ -6,13 +6,13 @@ WITH benchmarks AS (
         replaceOne(o.head_branch, 'refs/heads/', '') AS head_branch,
         o.workflow_id AS workflow_id,
         o.job_id AS job_id,
-        o.model.name AS model,
-        o.model.backend AS backend,
-        o.model.origins AS origins,
-        o.metric.name AS metric,
-        floor(arrayAvg(o.metric.benchmark_values), 2) AS actual,
-        floor(toFloat64(o.metric.target_value), 2) AS target,
-        o.benchmark.dtype AS dtype,
+        o.model.'name' AS model,
+        o.model.'backend' AS backend,
+        o.model.'origins' AS origins,
+        o.metric.'name' AS metric,
+        floor(arrayAvg(o.metric.'benchmark_values'), 2) AS actual,
+        floor(toFloat64(o.metric.'target_value'), 2) AS target,
+        o.benchmark.'dtype' AS dtype,
         IF(
             empty(o.runners),
             tupleElement(o.benchmark, 'extra_info')['device'],
@@ -43,26 +43,26 @@ WITH benchmarks AS (
             OR empty({commits: Array(String) })
         )
         AND (
-            has({benchmarks: Array(String) }, o.benchmark.name)
+            o.benchmark.'name' in {benchmarks: Array(String) }
             OR empty({benchmarks: Array(String) })
         )
         AND (
-            has({models: Array(String) }, o.model.name)
+            has({models: Array(String) }, o.model.'name')
             OR empty({models: Array(String) })
         )
         AND (
-            has({backends: Array(String) }, o.model.backend)
+            has({backends: Array(String) }, o.model.'backend')
             OR empty({backends: Array(String) })
         )
         AND (
-            has({dtypes: Array(String) }, o.benchmark.dtype)
+            has({dtypes: Array(String) }, o.benchmark.'dtype')
             OR empty({dtypes: Array(String) })
         )
         AND (
-            NOT has({excludedMetrics: Array(String) }, o.metric.name)
+            NOT has({excludedMetrics: Array(String) }, o.metric.'name')
             OR empty({excludedMetrics: Array(String) })
         )
-        AND notEmpty(o.metric.name)
+        AND notEmpty(o.metric.'name')
 )
 
 SELECT DISTINCT


### PR DESCRIPTION
Make faster by adding a projection to the table 
```
PROJECTION benchmark_name_projection
    (
        SELECT *
        ORDER BY 
            repo,
            tupleElement(benchmark, 'name'),
            tupleElement(model, 'name'),
            tupleElement(metric, 'name'),
            timestamp,
            head_branch,
            head_sha,
            workflow_id,
            job_id,
            servicelab_experiment_id,
            servicelab_trial_id
    ),
```
For some reason, ClickHouse won't use the projection unless t uses `has` instead of `in` and all the other tuple elements are in quotation marks 

We should consider changing the order by key to be this instead since I can't imagine anyone not filtering by benchmark name

Perf results:
```
+------+----------+-----------+-------------+---------------+----------+-----------+------------+--------------+
| Test | Avg Time | Base Time | Time Change | % Time Change | Avg Mem  |  Base Mem | Mem Change | % Mem Change |
+------+----------+-----------+-------------+---------------+----------+-----------+------------+--------------+
|  0   |   131    |   33300   |    -33169   |      -100     | 57215999 | 335780375 | -278564376 |     -83      |
+------+----------+-----------+-------------+---------------+----------+-----------+------------+--------------+
```

Also added a test

Checked results were the same after sorting

Also a change to the script to compare queries that makes it easier to compare results that are different by piping them to files that can be diffed later


