### PR TITLE
Revert "s3 binary upload with sha256 as metadata"

### DIFF
--- a/.github/workflows/_binary_upload.yml
+++ b/.github/workflows/_binary_upload.yml
@@ -117,9 +117,7 @@ jobs:
           fi
 
           for pkg in dist/*; do
-            shm_id=$(sha256sum "${pkg}" | awk '{print $1}')
-            ${AWS_CMD} "$pkg" "${PYTORCH_S3_BUCKET_PATH}" --acl public-read \
-              --metadata "checksum-sha256=${shm_id}"
+            ${AWS_CMD} "$pkg" "${PYTORCH_S3_BUCKET_PATH}" --acl public-read
           done
 
       - name: Upload package to pypi


### PR DESCRIPTION
Reverts pytorch/test-infra#6247 
Torchao users complaining they are seeing trainsient metadata issues:
https://github.com/pytorch/ao/actions/runs/13169233152/job/36756350554