### PR TITLE
Increase default timeout value for Nova jobs

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -9,7 +9,7 @@ on:
         type: string
       timeout:
         description: 'Timeout for the job (in minutes)'
-        default: 90
+        default: 120
         type: number
       runner:
         description: 'Runner type to utilize'

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -9,7 +9,7 @@ on:
         type: string
       timeout:
         description: 'Timeout for the job (in minutes)'
-        default: 30
+        default: 90
         type: number
       runner:
         description: 'Runner type to utilize'

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -9,7 +9,7 @@ on:
         type: string
       timeout:
         description: 'Timeout for the job (in minutes)'
-        default: 30
+        default: 60
         type: number
       runner:
         description: 'Runner type to utilize'

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -9,7 +9,7 @@ on:
         type: string
       timeout:
         description: 'Timeout for the job (in minutes)'
-        default: 30
+        default: 60
         type: number
       runner:
         description: 'Runner type to utilize'


### PR DESCRIPTION
The default value of 30 minutes feels too short now and I find myself frequently setting a higher value. So, the proposal here is to increase the default value for Nova jobs to a higher value across the board.  The increases are:

* 120 minutes for Linux job. This is due to the recent change in `calculate-docker-image` to wait up to 120 minutes for the Docker image to be ready https://github.com/pytorch/test-infra/pull/6227.
* 60 minutes for both MacOS and Windows jobs to give it enough time to at least build PyTorch from source, which usually takes around 30 minutes.  This is a common step that people need to do to test against PyTorch main branch.  Having a 30 minutes timeout frequently cancels the job prematurely, i.e. https://github.com/pytorch/executorch/actions/runs/13193195265/job/36829784707