### PR TITLE
Move meta canary scale-config.yml file to this repository

### DIFF
--- a/.github/scripts/validate_scale_config.py
+++ b/.github/scripts/validate_scale_config.py
@@ -21,12 +21,14 @@ MAX_AVAILABLE_MINIMUM = 50
 
 # Paths relative to their respective repositories
 META_SCALE_CONFIG_PATH = ".github/scale-config.yml"
+META_CANARY_SCALE_CONFIG_PATH = ".github/canary-scale-config.yml"
 LF_SCALE_CONFIG_PATH = ".github/lf-scale-config.yml"
 LF_CANARY_SCALE_CONFIG_PATH = ".github/lf-canary-scale-config.yml"
 
 RUNNER_TYPE_CONFIG_KEY = "runner_types"
 
 PREFIX_META = ""
+PREFIX_META_CANARY = "c."
 PREFIX_LF = "lf."
 PREFIX_LF_CANARY = "lf.c."
 
@@ -294,6 +296,10 @@ def main() -> None:
 
     # Contains scale configs that are generated from the source scale config
     generated_scale_config_infos: List[ScaleConfigInfo] = [
+        ScaleConfigInfo(
+            path=repo_root / META_CANARY_SCALE_CONFIG_PATH,
+            prefix=PREFIX_META_CANARY,
+        ),
         ScaleConfigInfo(
             path=repo_root / LF_SCALE_CONFIG_PATH,
             prefix=PREFIX_LF,

--- a/torchci/clickhouse_queries/lf_rollover_health/query.sql
+++ b/torchci/clickhouse_queries/lf_rollover_health/query.sql
@@ -30,7 +30,8 @@ normalized_jobs AS (
     AND j.status = 'completed'
     AND l != 'self-hosted'
     AND l NOT LIKE 'lf.c.%'
-    AND l NOT LIKE '%canary%'
+    AND l NOT LIKE '%.canary'
+    AND l NOT LIKE 'c.%'
 ),
 lf_jobs AS (
   SELECT DISTINCT

--- a/torchci/clickhouse_queries/lf_rollover_percentage/query.sql
+++ b/torchci/clickhouse_queries/lf_rollover_percentage/query.sql
@@ -23,7 +23,8 @@ WITH
             AND j.status = 'completed'
             AND l != 'self-hosted'
             AND l NOT LIKE 'lf.c.%'
-            AND l NOT LIKE '%canary%'
+            AND l NOT LIKE '%.canary'
+            AND l NOT LIKE 'c.%'
     ),
     lf_jobs AS (
         SELECT


### PR DESCRIPTION
Added `.github/canary-scale-config.yml` file. This file should be the one used by Pytorch Canary on Meta's environment.

Its been painful to develop/test things using pytorch/pytorch-canary on meta's fleet. The main reason for this is the need to add/update the scale-config.yml file every time a test needs to be executed. This always generates merge conflicts with pytorch/pytorch and requires a substantial manual work.

The other advantage of having this file here is the clarity of where all the configuration is, so it is central in a single place for all 4 environments that we have.

Finally, the validation scripts should then ensure the quality of the code and that all 4 scale-config files are in sync.