### PR TITLE
Use g5.4xlarge with 128GB volume to build windows AMI

### DIFF
--- a/aws/ami/windows/windows.pkr.hcl
+++ b/aws/ami/windows/windows.pkr.hcl
@@ -17,11 +17,11 @@ source "amazon-ebs" "windows_ebs_builder" {
   ami_name                    = "Windows 2019 GHA CI - ${local.timestamp}"
   associate_public_ip_address = true
   communicator                = "winrm"
-  instance_type               = "p3.2xlarge"
+  instance_type               = "g5.4xlarge"
   launch_block_device_mappings {
     delete_on_termination = true
     device_name           = "/dev/sda1"
-    volume_size           = 64
+    volume_size           = 128
   }
   source_ami      = "${data.amazon-ami.windows_root_ami.id}"
   region          = "us-east-1"


### PR DESCRIPTION
Using more available g5.4xlarge machine with larger volume

I see following errors during cuda 12.8 installation:
```
ERROR: [NVI2.NVDiskSpaceConstraint] 1206@CNVDiskSpaceConstraint::InvokeCheck : Extra space required on system for packages: "3121.46 MB on Disk (C:)".
  amazon-ebs.windows_ebs_builder:   15.000 |   INFO: [NVI2.NVDiskSpaceConstraint] 1212@CNVDiskSpaceConstraint::InvokeCheck : Disk space check complete.
...
amazon-ebs.windows_ebs_builder:     + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
```

Failure here: https://github.com/pytorch/test-infra/actions/runs/13184202890/job/36802279658