### PR TITLE
add sm_100 and sm_120 to cuda 12.8 domain builds

### DIFF
--- a/tools/pkg-helpers/pytorch_pkg_helpers/cuda.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/cuda.py
@@ -8,8 +8,11 @@ WINDOWS_PATH_PREFIX = "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v"
 
 
 def get_cuda_arch_list(sanitized_version: str) -> str:
+    base_arch_list = "5.0+PTX;6.0;7.0;7.5;8.0;8.6;9.0"
     if float(sanitized_version) >= 12.0:
-        return "5.0+PTX;6.0;7.0;7.5;8.0;8.6;9.0;10.0;12.0"
+        if sanitized_version == "12.8":
+            return base_arch_list + ";10.0;12.0"
+        return base_arch_list
     if float(sanitized_version) > 11.3:
         return "3.5;5.0+PTX;6.0;7.0;7.5;8.0;8.6"
     # mainly for cuda 10.2

--- a/tools/pkg-helpers/pytorch_pkg_helpers/cuda.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/cuda.py
@@ -9,7 +9,7 @@ WINDOWS_PATH_PREFIX = "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v"
 
 def get_cuda_arch_list(sanitized_version: str) -> str:
     if float(sanitized_version) >= 12.0:
-        return "5.0+PTX;6.0;7.0;7.5;8.0;8.6;9.0"
+        return "5.0+PTX;6.0;7.0;7.5;8.0;8.6;9.0;10.0;12.0"
     if float(sanitized_version) > 11.3:
         return "3.5;5.0+PTX;6.0;7.0;7.5;8.0;8.6"
     # mainly for cuda 10.2


### PR DESCRIPTION
current torchvision/audio builds missing sm_100 and sm_120

adding to cu128 builds

`cuobjdump -ptx /usr/local/lib/python3.12/dist-packages/torchvision/_C.so | grep "arch = sm_" | sort --unique
arch = sm_50
arch = sm_60
arch = sm_70
arch = sm_75
arch = sm_80
arch = sm_86
arch = sm_90`

cc @atalman @ptrblck @nWEIdia 