### PR TITLE
[Utilizaiton] Add RankTable View

### DIFF
--- a/torchci/components/utilization/UtilizationPage.tsx
+++ b/torchci/components/utilization/UtilizationPage.tsx
@@ -12,7 +12,7 @@ import { getIgnoredSegmentName, processStatsData } from "./helper";
 import { Divider, MainPage, Section } from "./styles";
 import { StatsInfo } from "./types";
 
-const lineFilters: PickerConfig[] = [
+export const lineFilters: PickerConfig[] = [
   { category: "all", types: [{ name: "all", tags: ["|"] }] },
   {
     category: "gpu",

--- a/torchci/components/utilization/components/TestSectionView/RankTestView/RankBar.tsx
+++ b/torchci/components/utilization/components/TestSectionView/RankTestView/RankBar.tsx
@@ -1,0 +1,118 @@
+import * as echarts from "echarts";
+import { useEffect, useRef, useState } from "react";
+
+export function RankBar({
+  onRankClick = () => {},
+  data,
+  resourceName,
+  statType,
+}: {
+  onRankClick?: (rank: string) => void;
+  data: { name: string; resourceName: string; [key: string]: any }[];
+  resourceName: string;
+  statType: string;
+}) {
+  const chartRef = useRef(null); // Create a ref for the chart container
+  const baseHeight = 10; // Height per item
+  const minHeight = 300; // Minimum height for small datasets
+  const maxHeight = 600; // Maximum height for very large datasets
+
+  const [chartInstance, setChartInstance] = useState<any>(null);
+
+  useEffect(() => {
+    let instance = chartInstance;
+    if (!instance) {
+      instance = echarts.init(chartRef.current);
+      setChartInstance(chartInstance);
+    }
+
+    let echartData: any[][] = [];
+    let validItems = data
+      .filter((item) => {
+        return item.resourceName === resourceName;
+      })
+      .sort((a, b) => {
+        return a[statType] - b[statType];
+      });
+
+    validItems.map((item) => {
+      echartData.push([item[statType], item[statType], item.name]);
+    });
+
+    const options: echarts.EChartOption = getOptions(echartData);
+    const handleClick = (params: any) => {
+      if (params.componentType === "yAxis") {
+        onRankClick(params.value);
+        console.log(params);
+        const selectedIndex = params.dataIndex;
+        instance.setOption({
+          yAxis: {
+            axisLabel: {
+              color: function (value: any, index: any) {
+                return index === selectedIndex ? "red" : "#333"; // Highlight only clicked item
+              },
+            },
+          },
+        });
+      }
+    };
+
+    instance.setOption(options, { notMerge: true });
+    instance.on("click", handleClick);
+    return () => {
+      instance.dispose();
+    };
+  }, [resourceName, statType, data]);
+
+  return (
+    <div
+      ref={chartRef}
+      style={{
+        height: Math.min(
+          maxHeight,
+          Math.max(minHeight, data.length * baseHeight)
+        ),
+      }}
+    />
+  );
+}
+
+const getOptions = (data: any[]): any => {
+  return {
+    dataset: {
+      source: [["score", "percent", "test"], ...data],
+    },
+    grid: { containLabel: true },
+    xAxis: { name: "percent" },
+    yAxis: {
+      type: "category",
+      triggerEvent: true,
+      axisLabel: {
+        interval: 0,
+        color: "#333",
+      },
+    },
+    visualMap: {
+      type: "continuous",
+      orient: "horizontal",
+      left: "center",
+      min: 0,
+      max: 100,
+      text: ["High Score", "Low Score"],
+      // Map the score column to color
+      dimension: 0,
+      inRange: {
+        color: ["#65B581", "#FFCE34", "#FD665F"],
+      },
+    },
+    series: [
+      {
+        type: "bar",
+        encode: {
+          x: "percent",
+          y: "test",
+        },
+      },
+    ],
+  };
+};

--- a/torchci/components/utilization/components/TestSectionView/RankTestView/RankBar.tsx
+++ b/torchci/components/utilization/components/TestSectionView/RankTestView/RankBar.tsx
@@ -129,7 +129,7 @@ const getOptions = (data: any[], selectedId: any): any => {
       left: "center",
       min: 0,
       max: 100,
-      text: ["High Score", "Low Score"],
+      text: ["High Usage", "Low Usage"],
       // Map the score column to color
       dimension: 0,
       inRange: {

--- a/torchci/components/utilization/components/TestSectionView/RankTestView/RankBar.tsx
+++ b/torchci/components/utilization/components/TestSectionView/RankTestView/RankBar.tsx
@@ -91,6 +91,7 @@ export function RankBar({
 
 const getOptions = (data: any[], selectedId: any): any => {
   return {
+    animation: false,
     dataset: {
       source: [["score", "percent", "test"], ...data],
     },

--- a/torchci/components/utilization/components/TestSectionView/RankTestView/RankBar.tsx
+++ b/torchci/components/utilization/components/TestSectionView/RankTestView/RankBar.tsx
@@ -82,7 +82,7 @@ const getOptions = (data: any[], selectedId: any): any => {
         interval: 0,
         color: function (value: any, index: any) {
           if (value === selectedId) {
-            return "red"; // Highlight only clicked item
+            return "blue"; // Highlight only clicked item
           }
           return "#333"; // Default color for other items
         },

--- a/torchci/components/utilization/components/TestSectionView/RankTestView/RankBar.tsx
+++ b/torchci/components/utilization/components/TestSectionView/RankTestView/RankBar.tsx
@@ -1,4 +1,5 @@
 import * as echarts from "echarts";
+import { truncate } from "lodash";
 import { useEffect, useRef, useState } from "react";
 
 export function RankBar({
@@ -41,6 +42,11 @@ export function RankBar({
       echartData.push([item[statType], item[statType], item.name]);
     });
 
+    if (echartData.length === 0) {
+      console.log("No data for " + resourceName + " " + statType);
+      return;
+    }
+
     const options: echarts.EChartOption = getOptions(echartData, selectedId);
     const handleClick = (params: any) => {
       if (params.componentType === "yAxis") {
@@ -74,6 +80,13 @@ const getOptions = (data: any[], selectedId: any): any => {
       source: [["score", "percent", "test"], ...data],
     },
     grid: { containLabel: true },
+    tooltip: {
+      trigger: "axis", // Show tooltip when hovering on the axis
+      formatter: function (params: any) {
+        let yValue = params[0].value; // Get full Y-axis value
+        return `${yValue[2]}:<br> ${yValue[0]}%`; // Show full value in tooltip
+      },
+    },
     xAxis: { name: "percent" },
     yAxis: {
       type: "category",
@@ -85,6 +98,12 @@ const getOptions = (data: any[], selectedId: any): any => {
             return "blue"; // Highlight only clicked item
           }
           return "#333"; // Default color for other items
+        },
+        formatter: function (value: any, index: any) {
+          if (value.length > 100) {
+            return truncate(value, { length: 100 }) + "..."; // Truncate long strings
+          }
+          return value;
         },
       },
     },
@@ -103,6 +122,14 @@ const getOptions = (data: any[], selectedId: any): any => {
     },
     series: [
       {
+        label: {
+          show: true,
+          position: "inside",
+          color: "black",
+          formatter: function (params: any) {
+            return params.value[0] + "%";
+          },
+        },
         type: "bar",
         encode: {
           x: "percent",

--- a/torchci/components/utilization/components/TestSectionView/RankTestView/RankBar.tsx
+++ b/torchci/components/utilization/components/TestSectionView/RankTestView/RankBar.tsx
@@ -50,7 +50,7 @@ export function RankBar({
     });
 
     setChartData(echartData);
-  }, [data]);
+  }, [data, statType, resourceName]);
 
   useEffect(() => {
     if (chartData.length == 0) {
@@ -75,7 +75,6 @@ export function RankBar({
   if (chartData.length == 0) {
     return <div></div>;
   }
-
 
   return (
     <div
@@ -143,6 +142,9 @@ const getOptions = (data: any[], selectedId: any): any => {
           position: "inside",
           color: "black",
           formatter: function (params: any) {
+            if (params.value[0] <= 1) {
+              return ""; // Hide labels for small values
+            }
             return params.value[0] + "%";
           },
         },

--- a/torchci/components/utilization/components/TestSectionView/RankTestView/RankBar.tsx
+++ b/torchci/components/utilization/components/TestSectionView/RankTestView/RankBar.tsx
@@ -16,17 +16,24 @@ export function RankBar({
   statType: string;
 }) {
   const chartRef = useRef(null); // Create a ref for the chart container
-  const baseHeight = 10; // Height per item
+  const baseHeight = 20; // Height per item
   const minHeight = 300; // Minimum height for small datasets
   const maxHeight = 600; // Maximum height for very large datasets
 
   const [chartInstance, setChartInstance] = useState<any>(null);
+  const [chartData, setChartData] = useState<any[]>([]);
+
+  const handleClick = (params: any) => {
+    if (params.componentType === "yAxis") {
+      onRankClick(params.value);
+    } else if (params.componentType == "series") {
+      onRankClick(params.value[2]);
+    }
+  };
 
   useEffect(() => {
-    let instance = chartInstance;
-    if (!instance) {
-      instance = echarts.init(chartRef.current);
-      setChartInstance(chartInstance);
+    if (data.length == 0) {
+      return;
     }
 
     let echartData: any[][] = [];
@@ -42,24 +49,33 @@ export function RankBar({
       echartData.push([item[statType], item[statType], item.name]);
     });
 
-    if (echartData.length === 0) {
-      console.log("No data for " + resourceName + " " + statType);
+    setChartData(echartData);
+  }, [data]);
+
+  useEffect(() => {
+    if (chartData.length == 0) {
       return;
     }
 
-    const options: echarts.EChartOption = getOptions(echartData, selectedId);
-    const handleClick = (params: any) => {
-      if (params.componentType === "yAxis") {
-        onRankClick(params.value);
-      }
-    };
+    let instance = chartInstance;
+    if (!instance) {
+      instance = echarts.init(chartRef.current);
+      setChartInstance(chartInstance);
+    }
+
+    const options: echarts.EChartOption = getOptions(chartData, selectedId);
 
     instance.setOption(options, { notMerge: true });
     instance.on("click", handleClick);
     return () => {
       instance.dispose();
     };
-  }, [resourceName, statType, data, selectedId]);
+  }, [chartData, selectedId]);
+
+  if (chartData.length == 0) {
+    return <div></div>;
+  }
+
 
   return (
     <div
@@ -67,7 +83,7 @@ export function RankBar({
       style={{
         height: Math.min(
           maxHeight,
-          Math.max(minHeight, data.length * baseHeight)
+          Math.max(minHeight, chartData.length * baseHeight)
         ),
       }}
     />

--- a/torchci/components/utilization/components/TestSectionView/RankTestView/RankBar.tsx
+++ b/torchci/components/utilization/components/TestSectionView/RankTestView/RankBar.tsx
@@ -1,5 +1,4 @@
 import * as echarts from "echarts";
-import { set } from "lodash";
 import { useEffect, useRef, useState } from "react";
 
 export function RankBar({
@@ -10,7 +9,7 @@ export function RankBar({
   statType,
 }: {
   onRankClick?: (rank: string) => void;
-  selectedId?: string|null;
+  selectedId?: string | null;
   data: { name: string; resourceName: string; [key: string]: any }[];
   resourceName: string;
   statType: string;
@@ -21,7 +20,6 @@ export function RankBar({
   const maxHeight = 600; // Maximum height for very large datasets
 
   const [chartInstance, setChartInstance] = useState<any>(null);
-  const [selectedName, setSelectedName] = useState<any>(null);
 
   useEffect(() => {
     let instance = chartInstance;
@@ -43,13 +41,10 @@ export function RankBar({
       echartData.push([item[statType], item[statType], item.name]);
     });
 
-    setSelectedName(selectedId);
-
     const options: echarts.EChartOption = getOptions(echartData, selectedId);
     const handleClick = (params: any) => {
       if (params.componentType === "yAxis") {
         onRankClick(params.value);
-        setSelectedName(params.value);
       }
     };
 
@@ -58,7 +53,7 @@ export function RankBar({
     return () => {
       instance.dispose();
     };
-  }, [resourceName, statType, data,selectedId]);
+  }, [resourceName, statType, data, selectedId]);
 
   return (
     <div
@@ -73,7 +68,7 @@ export function RankBar({
   );
 }
 
-const getOptions = (data: any[],selectedId:any): any => {
+const getOptions = (data: any[], selectedId: any): any => {
   return {
     dataset: {
       source: [["score", "percent", "test"], ...data],

--- a/torchci/components/utilization/components/TestSectionView/RankTestView/RankBar.tsx
+++ b/torchci/components/utilization/components/TestSectionView/RankTestView/RankBar.tsx
@@ -1,13 +1,16 @@
 import * as echarts from "echarts";
+import { set } from "lodash";
 import { useEffect, useRef, useState } from "react";
 
 export function RankBar({
   onRankClick = () => {},
+  selectedId,
   data,
   resourceName,
   statType,
 }: {
   onRankClick?: (rank: string) => void;
+  selectedId?: string|null;
   data: { name: string; resourceName: string; [key: string]: any }[];
   resourceName: string;
   statType: string;
@@ -18,6 +21,7 @@ export function RankBar({
   const maxHeight = 600; // Maximum height for very large datasets
 
   const [chartInstance, setChartInstance] = useState<any>(null);
+  const [selectedName, setSelectedName] = useState<any>(null);
 
   useEffect(() => {
     let instance = chartInstance;
@@ -39,21 +43,13 @@ export function RankBar({
       echartData.push([item[statType], item[statType], item.name]);
     });
 
-    const options: echarts.EChartOption = getOptions(echartData);
+    setSelectedName(selectedId);
+
+    const options: echarts.EChartOption = getOptions(echartData, selectedId);
     const handleClick = (params: any) => {
       if (params.componentType === "yAxis") {
         onRankClick(params.value);
-        console.log(params);
-        const selectedIndex = params.dataIndex;
-        instance.setOption({
-          yAxis: {
-            axisLabel: {
-              color: function (value: any, index: any) {
-                return index === selectedIndex ? "red" : "#333"; // Highlight only clicked item
-              },
-            },
-          },
-        });
+        setSelectedName(params.value);
       }
     };
 
@@ -62,7 +58,7 @@ export function RankBar({
     return () => {
       instance.dispose();
     };
-  }, [resourceName, statType, data]);
+  }, [resourceName, statType, data,selectedId]);
 
   return (
     <div
@@ -77,7 +73,7 @@ export function RankBar({
   );
 }
 
-const getOptions = (data: any[]): any => {
+const getOptions = (data: any[],selectedId:any): any => {
   return {
     dataset: {
       source: [["score", "percent", "test"], ...data],
@@ -89,7 +85,12 @@ const getOptions = (data: any[]): any => {
       triggerEvent: true,
       axisLabel: {
         interval: 0,
-        color: "#333",
+        color: function (value: any, index: any) {
+          if (value === selectedId) {
+            return "red"; // Highlight only clicked item
+          }
+          return "#333"; // Default color for other items
+        },
       },
     },
     visualMap: {

--- a/torchci/components/utilization/components/TestSectionView/RankTestView/RankTestView.tsx
+++ b/torchci/components/utilization/components/TestSectionView/RankTestView/RankTestView.tsx
@@ -38,10 +38,12 @@ const reousrceNames = [
 
 export const RankTestView = ({
   onRankClick = (id: string) => {},
+  selectedId = "",
   timeSeriesList,
   segments,
 }: {
   onRankClick?: (id: string) => void;
+  selectedId?: string|null;
   timeSeriesList: TimeSeriesWrapper[];
   segments: Segment[];
 }) => {
@@ -85,6 +87,7 @@ export const RankTestView = ({
           resourceName={selectResource}
           statType={selectStat}
           onRankClick={onRankClick}
+          selectedId={selectedId}
         />
       </div>
     </div>

--- a/torchci/components/utilization/components/TestSectionView/RankTestView/RankTestView.tsx
+++ b/torchci/components/utilization/components/TestSectionView/RankTestView/RankTestView.tsx
@@ -66,6 +66,11 @@ export const RankTestView = ({
 
     setRankData(rankData);
     setResourceNames(names);
+
+    if (names.length === 0 || statsNames.length == 0) {
+      return;
+    }
+
     setSelectResource(names[0].value);
     setSelectStat(statsNames[0].value);
   }, [segments, timeSeriesList]);

--- a/torchci/components/utilization/components/TestSectionView/RankTestView/RankTestView.tsx
+++ b/torchci/components/utilization/components/TestSectionView/RankTestView/RankTestView.tsx
@@ -1,0 +1,123 @@
+import DropDownList from "components/common/DropDownList";
+import { getSegmentStatsAndTimeSeries } from "components/utilization/helper";
+import { FlexSection } from "components/utilization/styles";
+import { StatType } from "components/utilization/types";
+import { Segment, TimeSeriesWrapper } from "lib/utilization/types";
+import { useEffect, useState } from "react";
+import { RankBar } from "./RankBar";
+
+const statsNames = [
+  {
+    name: "avg",
+    value: StatType.Average,
+  },
+  {
+    name: "max",
+    value: StatType.Max,
+  },
+];
+
+const reousrceNames = [
+  {
+    name: "cpu",
+    value: "cpu",
+  },
+  {
+    name: "memory",
+    value: "memory",
+  },
+  {
+    name: "all gpus utils",
+    value: "gpus_util_all",
+  },
+  {
+    name: "all gpu memory",
+    value: "gpu_mem_all",
+  },
+];
+
+export const RankTestView = ({
+  onRankClick = (id: string) => {},
+  timeSeriesList,
+  segments,
+}: {
+  onRankClick?: (id: string) => void;
+  timeSeriesList: TimeSeriesWrapper[];
+  segments: Segment[];
+}) => {
+  const [rankData, setRankData] = useState<any[]>([]);
+  const [selectResource, setSelectResource] = useState<string>("");
+  const [selectStat, setSelectStat] = useState<string>("");
+
+  useEffect(() => {
+    const rankData = processRankData(segments, timeSeriesList);
+    const reousrceNames = timeSeriesList.map((ts) => {
+      return { name: ts.name, value: ts.name };
+    });
+    setRankData(rankData);
+    setSelectResource(reousrceNames[0].value);
+    setSelectStat(statsNames[0].value);
+  }, [segments, timeSeriesList]);
+
+  return (
+    <div>
+      <div>Rank Test View</div>
+      <div>select resource and stats to pick the test you want to view</div>
+      <FlexSection>
+        <DropDownList
+          onChange={function (value: string): void {
+            setSelectResource(value);
+          }}
+          defaultValue={reousrceNames[0].value}
+          options={reousrceNames}
+        />
+        <DropDownList
+          onChange={function (value: string): void {
+            setSelectStat(value);
+          }}
+          defaultValue={statsNames[0].value}
+          options={statsNames}
+        />
+      </FlexSection>
+      <div>
+        <RankBar
+          data={rankData}
+          resourceName={selectResource}
+          statType={selectStat}
+          onRankClick={onRankClick}
+        />
+      </div>
+    </div>
+  );
+};
+
+function processRankData(
+  segments: Segment[],
+  timeSeriesList: TimeSeriesWrapper[]
+) {
+  let allData: any[] = [];
+  for (const segment of segments) {
+    const data = getSegmentStatsAndTimeSeries(segment, timeSeriesList);
+    if (!data) {
+      console.log(
+        `unable to get stats and time series data for ${segment.name}, something is wrong`
+      );
+      continue;
+    }
+    // flatten data for each test segment
+    // {resourceName:"cpu", columns:[{type:"avg", value:0.1}, {type:"max", value:0.2}]} to {resourceName:"cpu", avg:0.1, max:0.2}
+    const flattenedData = data.stats.map((s) => {
+      const obj = s.columns.reduce(
+        (acc, item) => ({ ...acc, [item.type]: item.value }),
+        {}
+      );
+      return {
+        name: segment.name,
+        resourceName: s.name,
+        ...obj,
+      };
+    });
+    allData = [...allData, ...flattenedData];
+  }
+  return allData;
+}

--- a/torchci/components/utilization/components/TestSectionView/RankTestView/RankTestView.tsx
+++ b/torchci/components/utilization/components/TestSectionView/RankTestView/RankTestView.tsx
@@ -3,6 +3,7 @@ import { getSegmentStatsAndTimeSeries } from "components/utilization/helper";
 import { FlexSection } from "components/utilization/styles";
 import { StatType } from "components/utilization/types";
 import { Segment, TimeSeriesWrapper } from "lib/utilization/types";
+import { cloneDeep } from "lodash";
 import { useEffect, useState } from "react";
 import { RankBar } from "./RankBar";
 
@@ -17,7 +18,7 @@ const statsNames = [
   },
 ];
 
-const reousrceNames = [
+const DefaultResourceNames = [
   {
     name: "cpu",
     value: "cpu",
@@ -26,6 +27,9 @@ const reousrceNames = [
     name: "memory",
     value: "memory",
   },
+];
+
+const DefaultGpuResourceValue = [
   {
     name: "all gpus utils",
     value: "gpus_util_all",
@@ -50,14 +54,19 @@ export const RankTestView = ({
   const [rankData, setRankData] = useState<any[]>([]);
   const [selectResource, setSelectResource] = useState<string>("");
   const [selectStat, setSelectStat] = useState<string>("");
+  const [resourceNames, setResourceNames] = useState<any[]>([]);
 
   useEffect(() => {
     const rankData = processRankData(segments, timeSeriesList);
-    const reousrceNames = timeSeriesList.map((ts) => {
-      return { name: ts.name, value: ts.name };
-    });
+    let names = cloneDeep(DefaultResourceNames);
+
+    if (rankData.find((d) => d.resourceName.includes("gpu"))) {
+      names = [...names, ...DefaultGpuResourceValue];
+    }
+
     setRankData(rankData);
-    setSelectResource(reousrceNames[0].value);
+    setResourceNames(names);
+    setSelectResource(names[0].value);
     setSelectStat(statsNames[0].value);
   }, [segments, timeSeriesList]);
 
@@ -70,14 +79,14 @@ export const RankTestView = ({
           onChange={function (value: string): void {
             setSelectResource(value);
           }}
-          defaultValue={reousrceNames[0].value}
-          options={reousrceNames}
+          defaultValue={"cpu"}
+          options={resourceNames}
         />
         <DropDownList
           onChange={function (value: string): void {
             setSelectStat(value);
           }}
-          defaultValue={statsNames[0].value}
+          defaultValue={StatType.Average}
           options={statsNames}
         />
       </FlexSection>

--- a/torchci/components/utilization/components/TestSectionView/RankTestView/RankTestView.tsx
+++ b/torchci/components/utilization/components/TestSectionView/RankTestView/RankTestView.tsx
@@ -43,7 +43,7 @@ export const RankTestView = ({
   segments,
 }: {
   onRankClick?: (id: string) => void;
-  selectedId?: string|null;
+  selectedId?: string | null;
   timeSeriesList: TimeSeriesWrapper[];
   segments: Segment[];
 }) => {

--- a/torchci/components/utilization/components/TestSectionView/SingleTestView.tsx
+++ b/torchci/components/utilization/components/TestSectionView/SingleTestView.tsx
@@ -10,12 +10,13 @@ import {
   InfoSection,
   InfoTitle,
 } from "components/utilization/styles";
+import { lineFilters } from "components/utilization/UtilizationPage";
 import { Segment, TimeSeriesWrapper } from "lib/utilization/types";
 import { useEffect, useState } from "react";
 import UtilizationJobMetricsTable from "../UtilizationStatsTable";
 
 const StatsTable = styled("div")({
-  width: "1200px",
+  maxWidth: "1400px",
   margin: "10px",
 });
 
@@ -26,6 +27,8 @@ const GraphGroupSection = styled("div")({
 
 const SingleGraphSection = styled("div")({
   margin: "5px",
+  padding: "10px",
+  border: "1px solid #ccc",
 });
 
 export const SingleTestView = ({
@@ -105,6 +108,7 @@ export const SingleTestView = ({
               chartWidth={1200}
               disableLineTooltip={false}
               disableRect={true}
+              lineFilterConfig={lineFilters}
             ></LineRectChart>
           )}
         </SingleGraphSection>
@@ -135,6 +139,5 @@ function getGithubSearchLink(testName: string) {
   const repo = `${testName}`;
   const encodedString = encodeURIComponent(repo);
   const url = head + `"` + encodedString + `"&type=code`;
-  console.log(url);
   return url;
 }

--- a/torchci/components/utilization/components/TestSectionView/TestSectionView.tsx
+++ b/torchci/components/utilization/components/TestSectionView/TestSectionView.tsx
@@ -1,7 +1,8 @@
+import { Paper } from "@mui/material";
 import { getDuration } from "components/utilization/helper";
 import { Segment } from "lib/utilization/types";
 import { useEffect, useState } from "react";
-import { Description, Divider, InfoTitle } from "../../styles";
+import { Blank, Description, Divider, InfoTitle } from "../../styles";
 import { SingleTestView } from "./SingleTestView";
 import ToggleTestsGroup from "./ToggleTestsGroup";
 
@@ -45,13 +46,15 @@ export const TestSectionView = ({
           />
         )}
         <div>
-          {pickedSegment && (
-            <div>
+          {pickedSegment ? (
+            <Paper>
               <SingleTestView
                 testSegment={pickedSegment}
                 timeSeriesList={timeSeriesList}
               />
-            </div>
+            </Paper>
+          ) : (
+            <Blank></Blank>
           )}
         </div>
       </div>

--- a/torchci/components/utilization/components/TestSectionView/TestSectionView.tsx
+++ b/torchci/components/utilization/components/TestSectionView/TestSectionView.tsx
@@ -1,48 +1,9 @@
-import {
-  List,
-  ListItemButton,
-  ListItemText,
-  Paper,
-  styled,
-} from "@mui/material";
-import LineRectChart from "components/charts/line_rect_chart/LineRectChart";
-import { ToggleGroup } from "components/common/ToggleGroup";
-import { formatSeconds, getDuration } from "components/utilization/helper";
+import { getDuration } from "components/utilization/helper";
 import { Segment } from "lib/utilization/types";
 import { useEffect, useState } from "react";
-import { Divider, InfoTitle } from "../../styles";
+import { Description, Divider, InfoTitle } from "../../styles";
 import { SingleTestView } from "./SingleTestView";
-
-const toggleItems = [
-  {
-    name: "list view",
-    value: "list",
-  },
-  {
-    name: "chart view",
-    value: "chart",
-  },
-];
-const defaultTestViewValue = "list";
-
-export const TestList = styled(Paper)({
-  margin: "10px",
-  padding: "10px",
-  maxHeight: 300,
-  maxWidth: 800,
-  overflow: "auto",
-  backgroundColor: "#f5f5f5",
-});
-export const FlexSection = styled("div")({
-  margin: "5px",
-  display: "flex",
-});
-
-export const Description = styled("div")({
-  margin: "10px",
-  padding: "10px",
-  fontSize: "20px",
-});
+import ToggleTestsGroup from "./ToggleTestsGroup";
 
 export const TestSectionView = ({
   testSegments,
@@ -53,9 +14,6 @@ export const TestSectionView = ({
 }) => {
   const [pickedSegment, setPickedSegment] = useState<any | null>();
   const [renderSegments, setRenderSegments] = useState<Segment[]>([]);
-  const [showSegmentLocation, setShowSegmentLocation] = useState<any | null>();
-  const [selectedListItem, setSelectedListItem] = useState<string | null>();
-  const [toggleTestView, setTestView] = useState<string>(defaultTestViewValue);
 
   useEffect(() => {
     const sorted = testSegments.sort((a, b) => {
@@ -64,31 +22,11 @@ export const TestSectionView = ({
     setRenderSegments(sorted);
   }, [testSegments, timeSeriesList]);
 
-  function clickChartTest(id: string) {
-    renderView(id);
-  }
-
-  function handleListItemClick(name: string) {
-    renderView(name);
-  }
-
-  function renderView(id: string) {
-    const segment = renderSegments.find((segment) => segment.name === id);
-    if (!segment) return;
-    setPickedSegment({ opacity: 0.9, color: "red", ...segment });
-    setSelectedListItem(segment.name);
-    setShowSegmentLocation({ opacity: 0.9, color: "red", ...segment });
-  }
-
-  function handleToggleTestView(value: string) {
-    const item = toggleItems.find((item) => item.value === value);
-    if (!item) {
-      setTestView("list");
-    }
-    setTestView(value);
-  }
-
   if (renderSegments.length === 0) return <div></div>;
+
+  const pickSegment = (segment: any) => {
+    setPickedSegment(segment);
+  };
 
   return (
     <div>
@@ -97,79 +35,25 @@ export const TestSectionView = ({
       <div>
         <InfoTitle>Tests ({renderSegments.length}) </InfoTitle>
         <Description>
-          {`We detected (${renderSegments.length}) tests on python_CMD level,`}
+          {`We detected (${renderSegments.length}) tests on PYTHON_CMD level`}
         </Description>
-        <ToggleGroup
-          defaultValue={"list"}
-          items={toggleItems}
-          onChange={handleToggleTestView}
-        />
-        {toggleTestView == "list" && (
-          <FlexSection>
-            <div>
-              <div> click on the test name to see the single test details:</div>
-              <TestList>
-                <List>
-                  {renderSegments.map((segment) => (
-                    <ListItemButton
-                      dense
-                      key={segment.name}
-                      disableGutters
-                      onClick={() => handleListItemClick(segment.name)}
-                      selected={segment.name == selectedListItem}
-                    >
-                      <ListItemText
-                        primary={`${segment.name}`}
-                        secondary={`Duration ${formatSeconds(
-                          getDuration(segment)
-                        )}`}
-                      />
-                    </ListItemButton>
-                  ))}
-                </List>
-              </TestList>
-            </div>
-            <div>
-              {showSegmentLocation && (
-                <div>
-                  <div> Location of the test: </div>
-                  <LineRectChart
-                    inputLines={timeSeriesList}
-                    chartWidth={800}
-                    rects={[showSegmentLocation]}
-                    disableLineTooltip={true}
-                    disableRect={false}
-                  ></LineRectChart>
-                </div>
-              )}
-            </div>
-          </FlexSection>
+        {renderSegments.length > 0 && timeSeriesList.length > 0 && (
+          <ToggleTestsGroup
+            pickSegment={pickSegment}
+            segments={renderSegments}
+            timeSeriesList={timeSeriesList}
+          />
         )}
-      </div>
-      {toggleTestView == "chart" && (
         <div>
-          <Description>
-            Click on the test segment on the graph to see the test details.
-          </Description>
-          <LineRectChart
-            inputLines={timeSeriesList}
-            chartWidth={1200}
-            rects={renderSegments}
-            disableLineTooltip={true}
-            disableRect={false}
-            onClickedRect={clickChartTest}
-          ></LineRectChart>
+          {pickedSegment && (
+            <div>
+              <SingleTestView
+                testSegment={pickedSegment}
+                timeSeriesList={timeSeriesList}
+              />
+            </div>
+          )}
         </div>
-      )}
-      <div>
-        {pickedSegment && (
-          <div>
-            <SingleTestView
-              testSegment={pickedSegment}
-              timeSeriesList={timeSeriesList}
-            />
-          </div>
-        )}
       </div>
     </div>
   );

--- a/torchci/components/utilization/components/TestSectionView/ToggleTestsGroup.tsx
+++ b/torchci/components/utilization/components/TestSectionView/ToggleTestsGroup.tsx
@@ -27,7 +27,6 @@ const toggleItems = [
     value: "rank",
   },
 ];
-
 export const TestList = styled(Paper)({
   margin: "10px",
   padding: "10px",
@@ -100,6 +99,10 @@ export const ToggleTestsGroup = ({
                     dense
                     key={segment.name}
                     disableGutters
+                    sx={{
+                      color:
+                        selectedListItem === segment.name ? "blue" : "inherit",
+                    }}
                     onClick={() => handleListItemClick(segment.name)}
                     selected={segment.name == selectedListItem}
                   >

--- a/torchci/components/utilization/components/TestSectionView/ToggleTestsGroup.tsx
+++ b/torchci/components/utilization/components/TestSectionView/ToggleTestsGroup.tsx
@@ -1,0 +1,159 @@
+import {
+  List,
+  ListItemButton,
+  ListItemText,
+  Paper,
+  styled,
+} from "@mui/material";
+import LineRectChart from "components/charts/line_rect_chart/LineRectChart";
+import { ToggleGroup } from "components/common/ToggleGroup";
+import { formatSeconds, getDuration } from "components/utilization/helper";
+import { Description, FlexSection } from "components/utilization/styles";
+import { Segment } from "lib/utilization/types";
+import { useState } from "react";
+import { RankTestView } from "./RankTestView/RankTestView";
+
+const toggleItems = [
+  {
+    name: "list view",
+    value: "list",
+  },
+  {
+    name: "chart view",
+    value: "chart",
+  },
+  {
+    name: "rank view",
+    value: "rank",
+  },
+];
+
+export const TestList = styled(Paper)({
+  margin: "10px",
+  padding: "10px",
+  maxHeight: 300,
+  maxWidth: 800,
+  overflow: "auto",
+  backgroundColor: "#f5f5f5",
+});
+const defaultTestViewValue = "list";
+
+export const ToggleTestsGroup = ({
+  pickSegment,
+  segments,
+  timeSeriesList,
+}: {
+  pickSegment: (segment: any) => void;
+  segments: Segment[];
+  timeSeriesList: any[];
+}) => {
+  const [showSegmentLocation, setShowSegmentLocation] = useState<any | null>();
+  const [selectedListItem, setSelectedListItem] = useState<string | null>();
+  const [toggleTestView, setTestView] = useState<string>(defaultTestViewValue);
+
+  function handleToggleTestView(value: string) {
+    const item = toggleItems.find((item) => item.value === value);
+    if (!item) {
+      setTestView("list");
+    }
+    setTestView(value);
+  }
+
+  function clickChartTest(id: string) {
+    renderView(id);
+  }
+
+  function handleListItemClick(id: string) {
+    renderView(id);
+  }
+
+  function handleRankViewClick(id: string) {
+    renderView(id);
+  }
+
+  function renderView(id: string) {
+    const segment = segments.find((segment) => segment.name === id);
+    if (!segment) return;
+    pickSegment({ opacity: 0.9, color: "red", ...segment });
+    setSelectedListItem(segment.name);
+    setShowSegmentLocation({ opacity: 0.9, color: "red", ...segment });
+  }
+
+  return (
+    <div>
+      <ToggleGroup
+        defaultValue={"list"}
+        items={toggleItems}
+        onChange={handleToggleTestView}
+      />
+      {toggleTestView == "list" && (
+        <FlexSection>
+          <div>
+            <Description>
+              {" "}
+              click on the test name to see the single test details:
+            </Description>
+            <TestList>
+              <List>
+                {segments.map((segment) => (
+                  <ListItemButton
+                    dense
+                    key={segment.name}
+                    disableGutters
+                    onClick={() => handleListItemClick(segment.name)}
+                    selected={segment.name == selectedListItem}
+                  >
+                    <ListItemText
+                      primary={`${segment.name}`}
+                      secondary={`Duration ${formatSeconds(
+                        getDuration(segment)
+                      )}`}
+                    />
+                  </ListItemButton>
+                ))}
+              </List>
+            </TestList>
+          </div>
+          <div>
+            {showSegmentLocation && (
+              <div>
+                <div> Location of the test: </div>
+                <LineRectChart
+                  inputLines={timeSeriesList}
+                  chartWidth={800}
+                  rects={[showSegmentLocation]}
+                  disableLineTooltip={true}
+                  disableRect={false}
+                ></LineRectChart>
+              </div>
+            )}
+          </div>
+        </FlexSection>
+      )}
+      {toggleTestView == "chart" && (
+        <div>
+          <Description>
+            Click on the test segment on the graph to see the test details.
+          </Description>
+          <LineRectChart
+            inputLines={timeSeriesList}
+            chartWidth={1200}
+            rects={segments}
+            disableLineTooltip={true}
+            disableRect={false}
+            onClickedRect={clickChartTest}
+          ></LineRectChart>
+        </div>
+      )}
+      {toggleTestView == "rank" && (
+        <RankTestView
+          timeSeriesList={timeSeriesList}
+          segments={segments}
+          onRankClick={handleRankViewClick}
+        />
+      )}
+    </div>
+  );
+};
+
+export default ToggleTestsGroup;

--- a/torchci/components/utilization/components/TestSectionView/ToggleTestsGroup.tsx
+++ b/torchci/components/utilization/components/TestSectionView/ToggleTestsGroup.tsx
@@ -150,7 +150,7 @@ export const ToggleTestsGroup = ({
           timeSeriesList={timeSeriesList}
           segments={segments}
           onRankClick={handleRankViewClick}
-          selectedId = {selectedListItem}
+          selectedId={selectedListItem}
         />
       )}
     </div>

--- a/torchci/components/utilization/components/TestSectionView/ToggleTestsGroup.tsx
+++ b/torchci/components/utilization/components/TestSectionView/ToggleTestsGroup.tsx
@@ -150,6 +150,7 @@ export const ToggleTestsGroup = ({
           timeSeriesList={timeSeriesList}
           segments={segments}
           onRankClick={handleRankViewClick}
+          selectedId = {selectedListItem}
         />
       )}
     </div>

--- a/torchci/components/utilization/components/UtilizationJobSummary/UtilizationJobSummary.tsx
+++ b/torchci/components/utilization/components/UtilizationJobSummary/UtilizationJobSummary.tsx
@@ -23,7 +23,7 @@ const AggregationModeInfo = styled(Paper)({
 });
 
 const StatsTable = styled("div")({
-  width: "1200px",
+  width: "1400px",
   margin: "10px",
 });
 

--- a/torchci/components/utilization/components/UtilizationStatsTable.tsx
+++ b/torchci/components/utilization/components/UtilizationStatsTable.tsx
@@ -10,6 +10,7 @@ export default function UtilizationStatsTable({ data }: { data: any[] }) {
       p10: row.columns.find((col: any) => col.type == StatType.P10)?.value,
       p50: row.columns.find((col: any) => col.type == StatType.P50)?.value,
       p90: row.columns.find((col: any) => col.type == StatType.P90)?.value,
+      max: row.columns.find((col: any) => col.type == StatType.Max)?.value,
       spike_frequency: row.columns.find(
         (col: any) => col.type == StatType.SpikeFrequency
       )?.value,
@@ -34,14 +35,23 @@ export default function UtilizationStatsTable({ data }: { data: any[] }) {
   );
 }
 
-const valueFormatter = (value: number) => {
+const valueFormatter = (value?: number) => {
+  if (value == null || value == undefined) {
+    return "N/A";
+  }
   return `${value.toFixed(2)}%`;
 };
-const valueFormatterSpike = (value: number) => {
+const valueFormatterSpike = (value?: number) => {
+  if (value == null || value == undefined) {
+    return "N/A";
+  }
   return `${value.toFixed(2)}%`;
 };
 
 const valueFormatterSeconds = (value: number) => {
+  if (value == null || value == undefined) {
+    return "N/A";
+  }
   return `${value.toFixed(2)}s`;
 };
 
@@ -68,6 +78,12 @@ const columns: GridColDef[] = [
   {
     field: "p90",
     headerName: "90th percentile",
+    valueFormatter: valueFormatter,
+    minWidth: 150,
+  },
+  {
+    field: "max",
+    headerName: "max",
     valueFormatter: valueFormatter,
     minWidth: 150,
   },

--- a/torchci/components/utilization/helper.ts
+++ b/torchci/components/utilization/helper.ts
@@ -341,7 +341,7 @@ function aggregateStats(
   }
   return {
     type: statType,
-    value: value,
+    value: Number(value.toFixed(2)),
     unit: "%",
   };
 }

--- a/torchci/components/utilization/helper.ts
+++ b/torchci/components/utilization/helper.ts
@@ -283,10 +283,10 @@ function getAllGpusStats(stats: StatsInfo[]) {
       name: "gpus_util_all",
       id: "gpus_util_all",
       columns: [
-        aggregateStats(gpuUtils, StatType.Average, "average"),
-        aggregateStats(gpuUtils, StatType.Max, "max"),
-        aggregateStats(gpuUtils, StatType.SpikeFrequency, "average"),
-        aggregateStats(gpuUtils, StatType.SpikeAvgInterval, "average"),
+        aggregateStats(gpuUtils, StatType.Average, AgggregateMethod.Average),
+        aggregateStats(gpuUtils, StatType.Max, AgggregateMethod.Max),
+        aggregateStats(gpuUtils, StatType.SpikeFrequency,AgggregateMethod.Average),
+        aggregateStats(gpuUtils, StatType.SpikeAvgInterval,AgggregateMethod.Average),
       ],
     },
     {

--- a/torchci/components/utilization/helper.ts
+++ b/torchci/components/utilization/helper.ts
@@ -277,6 +277,10 @@ function getAllGpusStats(stats: StatsInfo[]) {
   const gpuUtils = stats.filter((item) => item.id.includes("|util_percent"));
   const gpuMems = stats.filter((item) => item.id.includes("|mem_util_percent"));
 
+  if (gpuUtils.length == 0) {
+    return [];
+  }
+
   // calculate stats for all gpus
   const allGpus: StatsInfo[] = [
     {

--- a/torchci/components/utilization/helper.ts
+++ b/torchci/components/utilization/helper.ts
@@ -289,8 +289,16 @@ function getAllGpusStats(stats: StatsInfo[]) {
       columns: [
         aggregateStats(gpuUtils, StatType.Average, AgggregateMethod.Average),
         aggregateStats(gpuUtils, StatType.Max, AgggregateMethod.Max),
-        aggregateStats(gpuUtils, StatType.SpikeFrequency,AgggregateMethod.Average),
-        aggregateStats(gpuUtils, StatType.SpikeAvgInterval,AgggregateMethod.Average),
+        aggregateStats(
+          gpuUtils,
+          StatType.SpikeFrequency,
+          AgggregateMethod.Average
+        ),
+        aggregateStats(
+          gpuUtils,
+          StatType.SpikeAvgInterval,
+          AgggregateMethod.Average
+        ),
       ],
     },
     {

--- a/torchci/components/utilization/helper.ts
+++ b/torchci/components/utilization/helper.ts
@@ -4,7 +4,7 @@ import {
   TimeSeriesWrapper,
 } from "lib/utilization/types";
 import { sortBy } from "lodash";
-import { StatsInfo, StatType } from "./types";
+import { AgggregateMethod, StatsInfo, StatsItem, StatType } from "./types";
 
 export function findClosestDate(targetDate: Date, dates: Date[]): number {
   if (dates.length === 0) {
@@ -48,14 +48,19 @@ export function getIgnoredSegmentName(): string[] {
   return ["tools.stats.monitor", "pip install", "filter_test_configs.py"];
 }
 
-export function processStatsData(ts: TimeSeriesWrapper[]): StatsInfo[] {
+export function processStatsData(
+  resourceTimeSeries: TimeSeriesWrapper[]
+): StatsInfo[] {
   let results: any[] = [];
-  ts.forEach((ts) => {
+  resourceTimeSeries.forEach((ts) => {
     results = [
       ...results,
       { name: ts.name, id: ts.id, columns: getTimeSeriesStats(ts.records) },
     ];
   });
+
+  const allGpus = getAllGpusStats(results);
+  results = [...results, ...allGpus];
   results.sort((a, b) => a.name.localeCompare(b.name));
   return results;
 }
@@ -93,6 +98,13 @@ export function getTimeSeriesStats(dps: TimeSeriesDataPoint[]) {
   };
   results.push(spikeMetric);
 
+  const max = findMaxValue(records);
+  const maxStat = {
+    type: StatType.Max,
+    value: max,
+    unit: "%",
+  };
+  results.push(maxStat);
   const avgSpikeInterval = findAvgSpikeIntervals(dps, p90Metric.value);
   const spikeAvgInterval = {
     type: StatType.SpikeAvgInterval,
@@ -102,6 +114,12 @@ export function getTimeSeriesStats(dps: TimeSeriesDataPoint[]) {
   results.push(spikeAvgInterval);
   return results;
 }
+
+export const findMaxValue = (data: number[]) => {
+  if (data.length == 0) return 0; // No data
+  const max = data.reduce((a, b) => Math.max(a, b), 0);
+  return max;
+};
 
 const findAvgSpikeIntervals = (
   timestamps: TimeSeriesDataPoint[],
@@ -237,4 +255,81 @@ export function formatSeconds(seconds: number) {
   }
 
   return (seconds / 3600).toFixed(2) + "hs";
+}
+
+export function toNumberList(data: StatsInfo[], statType: StatType) {
+  return data.map((item) => {
+    const val = item.columns.find((col) => col.type === statType);
+    if (val == undefined) {
+      return 0;
+    }
+    return val.value;
+  });
+}
+export function calculateAverage(data: number[]) {
+  if (data.length == 0) return 0; // No data
+  const sum = data.reduce((a, b) => a + b, 0);
+  return sum / data.length;
+}
+
+function getAllGpusStats(stats: StatsInfo[]) {
+  // get all gpus stats for the test
+  const gpuUtils = stats.filter((item) => item.id.includes("|util_percent"));
+  const gpuMems = stats.filter((item) => item.id.includes("|mem_util_percent"));
+
+  // calculate stats for all gpus
+  const allGpus: StatsInfo[] = [
+    {
+      name: "gpus_util_all",
+      id: "gpus_util_all",
+      columns: [
+        aggregateStats(gpuUtils, StatType.Average, "average"),
+        aggregateStats(gpuUtils, StatType.Max, "max"),
+        aggregateStats(gpuUtils, StatType.SpikeFrequency, "average"),
+        aggregateStats(gpuUtils, StatType.SpikeAvgInterval, "average"),
+      ],
+    },
+    {
+      name: "gpu_mem_all",
+      id: "gpu_mem_all",
+      columns: [
+        aggregateStats(gpuMems, StatType.Average, AgggregateMethod.Average),
+        aggregateStats(gpuMems, StatType.Max, AgggregateMethod.Average),
+        aggregateStats(
+          gpuMems,
+          StatType.SpikeFrequency,
+          AgggregateMethod.Average
+        ),
+        aggregateStats(
+          gpuMems,
+          StatType.SpikeAvgInterval,
+          AgggregateMethod.Max
+        ),
+      ],
+    },
+  ];
+  return allGpus;
+}
+
+function aggregateStats(
+  stats: StatsInfo[],
+  statType: StatType,
+  method: AgggregateMethod
+): StatsItem {
+  let value = 0;
+  switch (method) {
+    case AgggregateMethod.Average:
+      value = calculateAverage(toNumberList(stats, statType));
+      break;
+    case AgggregateMethod.Max:
+      value = findMaxValue(toNumberList(stats, statType));
+      break;
+    default:
+      value = 0;
+  }
+  return {
+    type: statType,
+    value: value,
+    unit: "%",
+  };
 }

--- a/torchci/components/utilization/styles.tsx
+++ b/torchci/components/utilization/styles.tsx
@@ -29,3 +29,14 @@ export const InfoTitle = styled("span")({
   fontSize: "16px",
   fontWeight: "bold",
 });
+
+export const FlexSection = styled("div")({
+  margin: "5px",
+  display: "flex",
+});
+
+export const Description = styled("div")({
+  margin: "10px",
+  padding: "10px",
+  fontSize: "20px",
+});

--- a/torchci/components/utilization/styles.tsx
+++ b/torchci/components/utilization/styles.tsx
@@ -40,3 +40,9 @@ export const Description = styled("div")({
   padding: "10px",
   fontSize: "20px",
 });
+
+export const Blank = styled(Paper)({
+  margin: "10px",
+  padding: "10px",
+  height: "400px",
+});

--- a/torchci/components/utilization/types.ts
+++ b/torchci/components/utilization/types.ts
@@ -14,8 +14,37 @@ export interface StatsItem {
   unit: string;
 }
 
+/**
+ * StatsInfo is a struct that contains information about a stat.
+ *
+ * It contains the following fields:
+ * @name the name of hardware reource
+ * @id the id of hardware resource
+ * @columns the stats of the hardware resource.
+ * e.g data:
+ *  {
+ *   name: "cpu",
+ *   id: "cpu",
+ *   columns: [
+ *     {
+ *       type: "average",
+ *      value: 0.5,
+ *      unit: "%",
+ *      },
+ *    {
+ *      type: "max",
+ *      value: 0.8,
+ *      unit: "%",
+ *     }],
+ * }
+ */
 export interface StatsInfo {
   name: string;
   id: string;
   columns: StatsItem[];
+}
+
+export enum AgggregateMethod {
+  Average = "average",
+  Max = "max",
 }


### PR DESCRIPTION
- add rank table view for choosing the single test
- calculate all gpus' mem and util avg,max to show in rank and stats table
- able to cick on test to show on rank too

## Demo
https://torchci-1fhqvklex-fbopensource.vercel.app/utilization/13143119394/36681447812/1

## Select single test based on rank chart:
![rabk1gif](https://github.com/user-attachments/assets/6dc796de-ced0-4380-9124-78e52baddd72)

## Sync selected test on test view and rank chart for easy tracking.
![rank2](https://github.com/user-attachments/assets/5d2b7b13-e076-4b2d-9854-cbf6900ff1df)

