### PR TITLE
OpenSourcing multi-tenant GHA solution for pytorch/* CI

### DIFF
--- a/tools/multi-tenant/.gitignore
+++ b/tools/multi-tenant/.gitignore
@@ -1,0 +1,4 @@
+venv/
+inventory/refresh_inventory
+temp/multi-tenant-gpu-tag
+

--- a/tools/multi-tenant/.gitignore
+++ b/tools/multi-tenant/.gitignore
@@ -1,4 +1,3 @@
 venv/
 inventory/refresh_inventory
 temp/multi-tenant-gpu-tag
-

--- a/tools/multi-tenant/Makefile
+++ b/tools/multi-tenant/Makefile
@@ -1,0 +1,102 @@
+DATE_TAG_NOW := $(shell date +'%Y%m%d%H%M%S')
+RESET_OLDEST_EBS_LOG_LEVEL ?= INFO
+MAX_SIMULTANEOUS_DRAINING ?= 1
+
+all: ansible reset_oldest_ebs
+
+.PHONY: clean
+clean:
+	rm -rf inventory/refresh_inventory temp venv
+
+.PHONY: venv
+venv: venv/bin/python3
+
+venv/bin/python3:
+	python3 -m venv venv
+	venv/bin/pip install --upgrade pip
+	venv/bin/pip install -r requirements.txt
+
+temp/multi-tenant-gpu-tag:
+	mkdir -p temp
+	aws ecr describe-images --repository-name multi-tenant-gpu \
+		| jq '[.imageDetails[] | (.imageTags // [])[] | select(. != "latest") | select(test("^[0-9]+$$")) | tonumber] | max' \
+		| tee temp/multi-tenant-gpu-tag
+
+.PHONY: check-environment-variables-setup-host
+check-environment-variables-setup-host:
+	if [ -z "$$A100_GH_APP_PK" ] ; then \
+		echo "Please set A100_GH_APP_PK environment variable" ; \
+		exit 1 ; \
+	fi
+	if [ -z "$$INSTANCE_LABELS" ] ; then \
+		echo "Please set INSTANCE_LABELS environment variable" ; \
+		exit 1 ; \
+	fi
+
+.PHONY: ansible-setup-host-all
+ansible-setup-host-all: venv/bin/python3 temp/multi-tenant-gpu-tag check-environment-variables-setup-host
+	venv/bin/ansible-playbook \
+		-i inventory/manual_inventory \
+		-u ubuntu \
+		playbooks/setup-host.yml \
+		-vv
+
+.PHONY: ansible-setup-host-refresh-inventory
+ansible-setup-host-refresh-inventory: venv/bin/python3 temp/multi-tenant-gpu-tag check-environment-variables-setup-host
+	venv/bin/ansible-playbook \
+		-i inventory/refresh_inventory \
+		-u ubuntu \
+		playbooks/setup-host.yml \
+		-vv
+
+.PHONY: ansible-restart-refresh-inventory
+ansible-restart-refresh-inventory: venv/bin/python3
+	venv/bin/ansible-playbook \
+		-i inventory/refresh_inventory \
+		-u ubuntu \
+		playbooks/restart-services.yml \
+		-vv
+
+.PHONY: ansible-restart-ghad-refresh-inventory
+ansible-restart-ghad-refresh-inventory: venv/bin/python3
+	venv/bin/ansible-playbook \
+		-i inventory/refresh_inventory \
+		-u ubuntu \
+		playbooks/restart-ghad-service.yml \
+		-vv
+
+.PHONY: reset-oldest-ebs
+reset-oldest-ebs: venv/bin/python3
+	if [ -z "$(RESET_OLDEST_EBS_INSTANCE_NAME)" ] ; then \
+		echo "Please set RESET_OLDEST_EBS_INSTANCE_NAME variable" ; \
+		exit 1 ; \
+	fi
+	if [ -z "$(FORCE_ON_DRAIN_TIMEOUT)" ] ; then \
+		echo "Please set FORCE_ON_DRAIN_TIMEOUT variable" ; \
+		exit 1 ; \
+	fi
+	venv/bin/python3 scripts/reset_oldest_ebs.py --logging-level $(RESET_OLDEST_EBS_LOG_LEVEL) --instance-name "$(RESET_OLDEST_EBS_INSTANCE_NAME)" --force-on-drain-timeout "$(FORCE_ON_DRAIN_TIMEOUT)" reset-oldest-ebs
+
+.PHONY: check-last-ebs-connection
+check-last-ebs-connection: venv/bin/python3
+	if [ -z "$(RESET_OLDEST_EBS_INSTANCE_NAME)" ] ; then \
+		echo "Please set RESET_OLDEST_EBS_INSTANCE_NAME environment variable" ; \
+		exit 1 ; \
+	fi
+	venv/bin/python3 scripts/reset_oldest_ebs.py --logging-level $(RESET_OLDEST_EBS_LOG_LEVEL) --instance-name "$(RESET_OLDEST_EBS_INSTANCE_NAME)" check-last-ebs-connection
+
+.PHONY: safely-restart-all-instances
+safely-restart-all-instances: venv/bin/python3
+	if [ -z "$(INSTANCE_NAME)" ] ; then \
+		echo "Please set INSTANCE_NAME environment variable" ; \
+		exit 1 ; \
+	fi
+	venv/bin/python3 scripts/reset_oldest_ebs.py --logging-level $(RESET_OLDEST_EBS_LOG_LEVEL) --instance-name "$(INSTANCE_NAME)" safely-restart-all-instances --max-simultaneous-draining "$(MAX_SIMULTANEOUS_DRAINING)"
+
+.PHONY: docker-build-multi-tenant-gpu
+docker-build-multi-tenant-gpu:
+	docker build -t multi-tenant-gpu images/multi-tenant-gpu
+	docker tag multi-tenant-gpu:latest 308535385114.dkr.ecr.us-east-1.amazonaws.com/multi-tenant-gpu:latest
+	docker tag multi-tenant-gpu:latest 308535385114.dkr.ecr.us-east-1.amazonaws.com/multi-tenant-gpu:$(DATE_TAG_NOW)
+	docker push 308535385114.dkr.ecr.us-east-1.amazonaws.com/multi-tenant-gpu:latest
+	docker push 308535385114.dkr.ecr.us-east-1.amazonaws.com/multi-tenant-gpu:$(DATE_TAG_NOW)

--- a/tools/multi-tenant/README.md
+++ b/tools/multi-tenant/README.md
@@ -1,0 +1,41 @@
+# multi-tenant
+
+## A brief warning
+Please be aware that running locally ansible or reset_oldest_ebs can be harmful and dangerous. Those operations are destructive and running multiple in parallel can hinder hosts in a bad state, potentially hard to recover. So, if you are planning to do so, please communicate and reach out to teamates to make sure nothing is running in parallel, this includes the CI `.github/workflows/pet-runners-benchmark-spa.yml`.
+
+The recommended approach is to open a PR and test your changes by pushing to the PR, it is safer: keys are already there. Also, other users can see your actions and changes. And more importantly: it should be concurrency protected.
+
+## You can run ansible into all instances by:
+```bash
+make ansible
+```
+
+## You can also, refresh the main EBS volume for the oldest instance by running
+```bash
+make reset_oldest_ebs
+```
+
+## Aditional
+To request more instances, I still didn't develop a proper way, but this can be completed by running the script `scrips/create_instance.sh` and then following the additional manual steps that are in a comment inside the script.
+
+The ansible inventory is manually managed (for now) and can be found on `inventory/manual_inventory`, please make sure to keep it up to date, and if instances are deployed in other regions, it will be necessary to update the script `scripts/reset_oldest_ebs.py`
+
+Some notes about dev setup:
+* You need ubuntu deep learning AMI (non-pytorch one)
+* g4dn.12xlarge as the instance type
+
+Some commands for debug:
+
+```bash
+# for checking which cgroups a process is aligned with
+systemd-cgls
+# logging in as a specific user with systemd enabled
+sudo su -l $USER
+# status and logs for the service
+systemctl status ghad-manager
+journalctl -u ghad-manager.service
+# full command docker is running for github daemon in a specific user environment (after logging in as that user)
+docker ps --all --no-trunc
+docker logs ghad-main-shared-instance-container -f
+```
+

--- a/tools/multi-tenant/README.md
+++ b/tools/multi-tenant/README.md
@@ -38,4 +38,3 @@ journalctl -u ghad-manager.service
 docker ps --all --no-trunc
 docker logs ghad-main-shared-instance-container -f
 ```
-

--- a/tools/multi-tenant/configs/cloudwatch_config.json
+++ b/tools/multi-tenant/configs/cloudwatch_config.json
@@ -1,0 +1,84 @@
+{
+    "agent": {
+        "metrics_collection_interval": 10
+    },
+    "metrics": {
+      "namespace": "GHARunners/gi-ci-pet-benchmark",
+      "append_dimensions": {
+        "ImageID":"${aws:ImageId}",
+        "InstanceId":"${aws:InstanceId}",
+        "InstanceType":"${aws:InstanceType}"
+      },
+      "aggregation_dimensions": [
+        ["ImageID"],
+        ["InstanceType"],
+        ["ImageID", "InstanceType"],
+        ["InstanceId"]
+      ],
+       "metrics_collected": {
+            "cpu": {
+                "measurement": [
+                    "cpu_usage_idle",
+                    "cpu_usage_iowait",
+                    "cpu_usage_user",
+                    "cpu_usage_system"
+                ],
+                "metrics_collection_interval": 10
+            },
+            "disk": {
+                "measurement": [
+                    "free",
+                    "total",
+                    "used",
+                    "used_percent",
+                    "inodes_free",
+                    "inodes_total"
+                ],
+                "metrics_collection_interval": 10,
+                "resources": [
+                    "/"
+                ]
+            },
+            "diskio": {
+                "measurement": [
+                    "io_time"
+                ],
+                "metrics_collection_interval": 10,
+                "resources": [
+                    "/"
+                ]
+            },
+            "mem": {
+                "measurement": [
+                    "total",
+                    "used",
+                    "free",
+                    "used_percent"
+                ],
+                "metrics_collection_interval": 10
+            },
+            "swap": {
+                "measurement": [
+                    "swap_used_percent"
+                ],
+                "metrics_collection_interval": 10
+            }
+        }
+    },
+    "logs": {
+        "logs_collected": {
+            "files": {
+                "collect_list": [{
+                    "log_group_name": "benchmark_ghad",
+                    "file_path": "/var/log/ghad-manager.log",
+                    "log_stream_name": "{instance_id}"
+                },
+                {
+                    "log_group_name" : "linux_msyslog",
+                    "file_path" : "/var/log/syslog",
+                    "log_stream_name" : "{instance_id}"
+                }]
+            }
+        }
+    }
+}

--- a/tools/multi-tenant/images/multi-tenant-gpu/Dockerfile
+++ b/tools/multi-tenant/images/multi-tenant-gpu/Dockerfile
@@ -1,0 +1,59 @@
+FROM --platform=linux/amd64 ghcr.io/actions/actions-runner:latest AS BUILD
+
+SHELL ["/bin/bash", "-c"]
+
+USER root
+
+RUN usermod -u 1000 runner && \
+    groupmod -g 1000 runner && \
+    groupadd -g 2375 docker2 && \
+    usermod -aG 1000 runner && \
+    usermod -aG 2375 runner && \
+    usermod -aG docker runner && \
+    chown -R 1000:1000 /home/runner
+
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        cmake \
+        curl \
+        dnsutils \
+        fontconfig \
+        g++ \
+        gcc \
+        git \
+        jq \
+        kmod \
+        libfontconfig1-dev \
+        libgl1-mesa-glx \
+        libjpeg-dev \
+        libpango-1.0-0 \
+        libpangoft2-1.0-0 \
+        libpng-dev \
+        libsdl2-2.0-0 \
+        libsdl2-dev \
+        libsndfile1-dev \
+        libxml2-dev \
+        libxslt1-dev \
+        ninja-build \
+        python3-pip \
+        ubuntu-dev-tools \
+        unzip \
+        wget \
+        zip \
+        zlib1g-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN cd /home/runner && \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip aws
+
+RUN touch /.inarc && \
+    chmod 0444 /.inarc
+
+FROM --platform=linux/amd64 ghcr.io/actions/actions-runner:latest AS RUNNER
+COPY --from=BUILD / /
+USER runner

--- a/tools/multi-tenant/inventory/manual_inventory
+++ b/tools/multi-tenant/inventory/manual_inventory
@@ -1,0 +1,6 @@
+i-03028b1668c838483-us-east-1-p4d.24xlarge ansible_host=35.175.230.89
+i-01a21955dc3821a00-us-east-2-p4d.24xlarge ansible_host=18.218.212.92
+i-04318a58cd30ea7bb-us-east-2-p4d.24xlarge ansible_host=18.227.140.233
+i-04bedcebd1f4c5e73-us-west-2-p4d.24xlarge ansible_host=54.188.247.175
+i-0e4172a00b41fa6c6-us-east-2-p5.48xlarge ansible_host=3.145.186.79
+i-0d3ed1ff3ccbeec77-us-east-1-p5.48xlarge ansible_host=172.31.59.55

--- a/tools/multi-tenant/inventory/manual_inventory
+++ b/tools/multi-tenant/inventory/manual_inventory
@@ -1,6 +1,0 @@
-i-03028b1668c838483-us-east-1-p4d.24xlarge ansible_host=35.175.230.89
-i-01a21955dc3821a00-us-east-2-p4d.24xlarge ansible_host=18.218.212.92
-i-04318a58cd30ea7bb-us-east-2-p4d.24xlarge ansible_host=18.227.140.233
-i-04bedcebd1f4c5e73-us-west-2-p4d.24xlarge ansible_host=54.188.247.175
-i-0e4172a00b41fa6c6-us-east-2-p5.48xlarge ansible_host=3.145.186.79
-i-0d3ed1ff3ccbeec77-us-east-1-p5.48xlarge ansible_host=172.31.59.55

--- a/tools/multi-tenant/playbooks/restart-ghad-service.yml
+++ b/tools/multi-tenant/playbooks/restart-ghad-service.yml
@@ -1,4 +1,7 @@
 ---
+# Should safely restart only ghad service
+# does not require draining the instance as 
+# it does not interrupt running jobs
 - name: Restart ghad service
   hosts: all
   become: yes

--- a/tools/multi-tenant/playbooks/restart-ghad-service.yml
+++ b/tools/multi-tenant/playbooks/restart-ghad-service.yml
@@ -1,0 +1,17 @@
+---
+- name: Restart ghad service
+  hosts: all
+  become: yes
+  vars:
+    runner_version: "2.315.0"
+    ansible_host_key_checking: false
+  module_defaults:
+    shell:
+      executable: /bin/bash
+
+  tasks:
+    - name: Restart the runner manager service
+      ansible.builtin.systemd:
+        name: ghad-manager
+        state: restarted
+        enabled: yes

--- a/tools/multi-tenant/playbooks/restart-services.yml
+++ b/tools/multi-tenant/playbooks/restart-services.yml
@@ -1,0 +1,58 @@
+---
+- name: Restart all relevant services
+  hosts: all
+  become: yes
+  vars:
+    user_names:
+      - alice
+      - bob
+      - charlie
+      - david
+      - eve
+      - frank
+      - grace
+      - henry
+      - isaac
+      - julia
+      - kevin
+      - lisa
+    runner_version: "2.315.0"
+    ansible_host_key_checking: false
+  module_defaults:
+    shell:
+      executable: /bin/bash
+
+  tasks:
+    - name: Get number of NVIDIA GPUs
+      ansible.builtin.shell: nvidia-smi --list-gpus | wc -l
+      register: gpu_count
+      changed_when: false
+
+    - name: Set num_users based on GPU count
+      ansible.builtin.set_fact:
+        num_users: "{{ gpu_count.stdout | int }}"
+
+    - name: Reload systemd
+      ansible.builtin.systemd:
+        daemon_reload: yes
+
+    - getent:
+        database: passwd
+
+    - name: restart cgroup slices
+      ansible.builtin.systemd:
+        name: user-{{ getent_passwd[item].1 }}.slice  # getent_passwd[item].1 returns UID
+        state: restarted
+      loop: "{{ user_names[:num_users | int] }}"
+
+    - name: restart user docker services
+      become: true
+      ansible.builtin.shell: |
+        machinectl shell {{ item }}@ /bin/bash -c 'systemctl --user restart docker'
+      loop: "{{ user_names[:num_users | int] }}"
+
+    - name: Restart the runner manager service
+      ansible.builtin.systemd:
+        name: ghad-manager
+        state: restarted
+        enabled: yes

--- a/tools/multi-tenant/playbooks/restart-services.yml
+++ b/tools/multi-tenant/playbooks/restart-services.yml
@@ -1,4 +1,7 @@
 ---
+# Restart all services, including docker in each user space,
+# is not safe to run in healthy or working nodes as it will 
+# cause current running jobs to be canceled;
 - name: Restart all relevant services
   hosts: all
   become: yes

--- a/tools/multi-tenant/playbooks/setup-host.yml
+++ b/tools/multi-tenant/playbooks/setup-host.yml
@@ -1,0 +1,321 @@
+---
+- name: Create users and assign cgroup slices based on GPU count and setup ghad-manager service
+  hosts: all
+  become: yes
+  vars:
+    user_names:
+      - alice
+      - bob
+      - charlie
+      - david
+      - eve
+      - frank
+      - grace
+      - henry
+      - isaac
+      - julia
+      - kevin
+      - lisa
+    runner_version: "2.315.0"
+    ansible_host_key_checking: false
+  module_defaults:
+    shell:
+      executable: /bin/bash
+
+  tasks:
+    - name: remediate the broken dpkg
+      ansible.builtin.shell: |
+        sudo dpkg --configure -a
+
+    - name: remediate correto GPG key changes
+      ansible.builtin.shell: |
+        wget -O - https://apt.corretto.aws/corretto.key  | gpg --dearmor -o /usr/share/keyrings/corretto-keyring.gpg --yes
+
+    - name: Ensure apt is up to date
+      ansible.builtin.apt:
+        update_cache: yes
+
+    - name: Ensure required packages are installed for rootless docker
+      ansible.builtin.apt:
+        name:
+          - uidmap
+          - systemd-container
+          - acl
+          - cgroup-tools
+          - amazon-cloudwatch-agent
+        state: present
+
+    - name: Copy the cloudwatch config
+      ansible.builtin.copy:
+        src: ../configs/cloudwatch_config.json
+        dest: /tmp/cloudwatch_config.json
+        mode: '0644'
+
+    - name: configure cloudwatch agent
+      ansible.builtin.shell: |
+        sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/tmp/cloudwatch_config.json -s
+
+    - name: Ensure nvidia is installed
+      register: install_nvidia_dependencies
+      changed_when: install_nvidia_dependencies.stdout != 'NVIDIA_DRIVER INSTALLED'
+      ansible.builtin.shell: |
+        if [ -x "$(command -v nvidia-smi)" ]; then
+          echo "NVIDIA_DRIVER INSTALLED"
+          exit 0
+        else
+          exit 1
+        fi
+
+    - name: Get number of NVIDIA GPUs
+      ansible.builtin.shell: nvidia-smi --list-gpus | wc -l
+      register: gpu_count
+      changed_when: false
+
+    - name: Set num_users based on GPU count
+      ansible.builtin.set_fact:
+        num_users: "{{ gpu_count.stdout | int }}"
+
+    - name: Get available memory per user
+      become: true
+      ansible.builtin.shell: |
+        # TOTAL_MEMORY=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+        echo "$(($(grep MemTotal /proc/meminfo | awk '{print $2}') * 1024 / {{ num_users }}))"
+      register: available_memory
+      changed_when: false
+
+    - name: Set available memory
+      ansible.builtin.set_fact:
+        memory_per_user: "{{ available_memory.stdout | int }}"
+
+    - name: Gather number of CPU cores
+      command: nproc
+      register: cpu_cores
+
+    - name: Create users with randomized names
+      ansible.builtin.user:
+        name: "{{ item }}"
+        state: present
+        create_home: yes
+        shell: /bin/bash
+      loop: "{{ user_names[:num_users | int] }}"
+      register: created_users
+
+    - name: append DOCKER_HOST export to bashrc for users
+      ansible.builtin.lineinfile:
+        path: "{{ item.home }}/.bashrc"
+        line: |
+          export DOCKER_HOST=unix:///run/user/{{ item.uid }}/docker.sock
+        create: yes
+        search_string: "export DOCKER_HOST=unix:///run/user/{{ item.uid }}/docker.sock"
+      loop: "{{ created_users.results }}"
+
+    - name: append PATH export to bashrc for users
+      ansible.builtin.lineinfile:
+        path: "{{ item.home }}/.bashrc"
+        line: |
+          export PATH=/home/{{ item.name }}/bin:$PATH
+        create: yes
+        search_string: "export PATH=/home/{{ item.name }}/bin:$PATH"
+      loop: "{{ created_users.results }}"
+
+    - name: append DBUS_SESSION_BUS_ADDRESS export to bashrc for users
+      ansible.builtin.lineinfile:
+        path: "{{ item.home }}/.bashrc"
+        line: |
+          export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ item.uid }}/bus
+        create: yes
+        search_string: "export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ item.uid }}/bus"
+      loop: "{{ created_users.results }}"
+
+    - name: append XDG_RUNTIME_DIR export to bashrc for users
+      ansible.builtin.lineinfile:
+        path: "{{ item.home }}/.bashrc"
+        line: |
+          export XDG_RUNTIME_DIR=/run/user/{{ item.uid }}
+        create: yes
+        search_string: "export XDG_RUNTIME_DIR=/run/user/{{ item.uid }}"
+      loop: "{{ created_users.results }}"
+
+    - name: make sure users can linger processes
+      ansible.builtin.shell: sudo loginctl enable-linger {{ item.name }}
+      loop: "{{ created_users.results }}"
+
+    - name: create cgroup slices
+      copy:
+        dest: /etc/systemd/system/user-{{ item.uid }}.slice
+        content: |
+          [Unit]
+          Description=User Slice of {{ item.name }}
+          Before=slices.target
+
+          [Slice]
+          AllowedCPUs={{ (cpu_cores.stdout | int // ansible_loop.length | int) * ansible_loop.index0 }}-{{ ((cpu_cores.stdout | int // ansible_loop.length | int) * ansible_loop.index) - 1 }}
+          MemoryMax={{ memory_per_user }}
+          TasksMax=10000
+          DevicePolicy=closed
+          DeviceAllow=/dev/nvidia{{ ansible_loop.index0 }}
+      loop: "{{ created_users.results }}"
+      loop_control:
+        extended: true
+
+    - name: Add permision to all devices except nvidia gpus to all users cgroup slices
+      ansible.builtin.shell: |
+        find /dev/ -type b -o -type c 2>/dev/null | sed 's|^|DeviceAllow=|' | sort | grep -v -E 'nvidia[0-9]+' >> /etc/systemd/system/user-{{ item.uid }}.slice
+      loop: "{{ created_users.results }}"
+
+    - name: Reload systemd
+      ansible.builtin.systemd:
+        daemon_reload: yes
+
+    # Hard to see, but docker daemon depends on cgroup slices
+    # so restarting them will restart docker, which is not what we want
+    # - name: restart cgroup slices
+    #   ansible.builtin.systemd:
+    #     name: user-{{ item.uid }}.slice
+    #     state: restarted
+    #   loop: "{{ created_users.results }}"
+
+    - name: (gpu) Assign gpu numbers to users
+      ansible.builtin.copy:
+        dest: /home/{{ item.name }}/.assigned_gpu
+        content: "{{ gpu_num }}"
+      loop: "{{ created_users.results }}"
+      loop_control:
+        index_var: gpu_num
+
+    - name: (gpu) Add GPU assignment to /etc/profile
+      ansible.builtin.lineinfile:
+        path: "/etc/profile"
+        line: "if [[ -e $HOME/.assigned_gpu ]];then export CUDA_VISIBLE_DEVICES=$(cat $HOME/.assigned_gpu);fi"
+
+    - name: Create directory /opt/runner with permissions 0644
+      ansible.builtin.file:
+        path: /opt/runner
+        state: directory
+        mode: '0644'
+
+    - name: Create directory /opt/runner with permissions 0644
+      ansible.builtin.file:
+        path: /opt/docker/
+        state: directory
+        mode: '0644'
+
+    - name: Download rootless docker install script
+      ansible.builtin.get_url:
+        url: "https://get.docker.com/rootless"
+        dest: /opt/docker/get-rootless-docker.sh
+        mode: '0755'
+
+    - name: Copy file to user's home directory
+      ansible.builtin.copy:
+        src: /opt/docker/get-rootless-docker.sh
+        dest: "/home/{{ item.name }}/get-rootless-docker.sh"
+        remote_src: yes
+        owner: "{{ item.name }}"
+        group: "{{ item.name }}"
+        mode: '0644'
+      become: yes
+      loop: "{{ created_users.results }}"
+
+    - name: run nvidia-ctk config to disable cgroups
+      ansible.builtin.shell: |
+        # /etc/nvidia-container-runtime/config.toml
+        sudo nvidia-ctk config --set nvidia-container-cli.no-cgroups --in-place
+
+    - name: Install and run rootless docker in the background (also does nvidia-ctk setup)
+      become: true
+      ansible.builtin.shell: |
+        if (! sudo su -l {{ item.name }} /bin/bash -c 'docker stats --no-stream' ); then
+          sudo chown -R {{ item.name }}:{{ item.name }} /home/{{ item.name }}
+          machinectl shell {{ item.name }}@ /bin/bash -c 'systemctl --user stop docker'
+          sudo rm -f /home/{{ item.name }}/bin/dockerd
+          machinectl shell {{ item.name }}@ /bin/bash '/home/{{ item.name }}/get-rootless-docker.sh'
+          nvidia-ctk runtime configure --runtime=docker --config=/home/{{ item.name }}/.config/docker/daemon.json
+          machinectl shell {{ item.name }}@ /bin/bash -c 'systemctl --user enable docker ; systemctl --user start docker'
+        fi
+      loop: "{{ created_users.results }}"
+
+    - name: Login all users to ecr
+      become: true
+      ansible.builtin.shell: |
+        machinectl shell {{ item.name }}@ /bin/bash -c 'aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 308535385114.dkr.ecr.us-east-1.amazonaws.com/multi-tenant-gpu'
+      loop: "{{ created_users.results }}"
+
+    - name: create the runner config directory
+      ansible.builtin.file:
+        path: /etc/gha-runner-config
+        state: directory
+
+    - name: Create file with instance label
+      ansible.builtin.copy:
+        dest: /etc/gha-runner-config/instance-label
+        content: "{{ lookup('ansible.builtin.env', 'INSTANCE_LABELS') }}"
+        mode: '0644'
+
+    - name: Create file with repository/org url for client registration
+      ansible.builtin.copy:
+        dest: /etc/gha-runner-config/runner-url
+        content: "https://github.com/pytorch"
+        mode: '0644'
+
+    - name: Create file with private key for ghapp authentication registration
+      ansible.builtin.copy:
+        dest: /etc/gha-runner-config/private-key
+        content: "{{ lookup('ansible.builtin.env', 'A100_GH_APP_PK') }}"
+        mode: '0400'
+
+    - name: Create file with app id for ghapp authentication registration
+      ansible.builtin.copy:
+        dest: /etc/gha-runner-config/app-id
+        content: "1007062"
+        mode: '0400'
+
+    - name: Create file with installation id for ghapp authentication registration
+      ansible.builtin.copy:
+        dest: /etc/gha-runner-config/installation-id
+        content: "55231883"
+        mode: '0400'
+
+    - name: Copy the tag version file
+      ansible.builtin.copy:
+        src: ../temp/multi-tenant-gpu-tag
+        dest: /etc/gha-runner-config/image-tag-version
+        mode: '0644'
+
+    - name: Copy the runner manager service file
+      ansible.builtin.copy:
+        src: ../services/ghad-manager/ghad-manager.service
+        dest: /etc/systemd/system/ghad-manager.service
+        mode: '0644'
+
+    - name: Copy the manager service script
+      ansible.builtin.copy:
+        src: ../services/ghad-manager/ghad-manager.py
+        dest: /root/ghad-manager.py
+        mode: '0644'
+
+    - name: Copy the requirements.txt file
+      ansible.builtin.copy:
+        src: ../services/ghad-manager/requirements.txt
+        dest: /root/requirements.txt
+        mode: '0644'
+
+    - name: Copy multi-tenant-gpu-main.sh
+      ansible.builtin.copy:
+        src: ../scripts/multi-tenant-gpu-main.sh
+        dest: /etc/gha-runner-config/multi-tenant-gpu-main.sh
+        mode: '0755'
+
+    - name: Install the required python packages
+      ansible.builtin.pip:
+        requirements: /root/requirements.txt
+
+    - name: Reload systemd
+      ansible.builtin.systemd:
+        daemon_reload: yes
+
+    - name: Restart the runner manager service
+      ansible.builtin.systemd:
+        name: ghad-manager
+        state: restarted
+        enabled: yes

--- a/tools/multi-tenant/requirements.txt
+++ b/tools/multi-tenant/requirements.txt
@@ -1,0 +1,4 @@
+ansible
+boto3
+paramiko
+PyGithub

--- a/tools/multi-tenant/scripts/multi-tenant-gpu-main.sh
+++ b/tools/multi-tenant/scripts/multi-tenant-gpu-main.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+RUNNER_USER=$1
+DOCKER_GROUP_ID=$2
+RUNNER_URL=$3
+GH_TOKEN=$4
+INSTANCE_ID=$5
+export RUNNER_UID=$6
+INSTANCE_LABEL=$7
+
+if [[ "$#" -ne 7 ]] ; then
+    echo "Invalid usage, not going to work"
+    exit 1
+fi
+
+sudo groupadd -g $DOCKER_GROUP_ID dockerlink
+sudo usermod -aG dockerlink runner
+sudo useradd $RUNNER_USER --uid 1000 --gid 1000 --groups 1000,2375,docker,docker2,dockerlink --non-unique --shell /bin/bash
+sudo usermod -a -G sudo $RUNNER_USER
+
+sudo cp -a /home/runner/. /home/$RUNNER_USER/.
+echo "RUNNER_UID=$RUNNER_UID" >> /home/$RUNNER_USER/.env
+sudo chown -R 1000:1000 /home/$RUNNER_USER
+
+sudo su - $RUNNER_USER -c "/bin/bash -c './config.sh --url $RUNNER_URL --token $GH_TOKEN --name ${INSTANCE_ID}-${RUNNER_UID} --labels $INSTANCE_LABEL --ephemeral && ./run.sh'"

--- a/tools/multi-tenant/scripts/reset_oldest_ebs.py
+++ b/tools/multi-tenant/scripts/reset_oldest_ebs.py
@@ -1,0 +1,572 @@
+from typing import Any, Dict, List, NamedTuple
+import argparse
+import datetime
+import logging
+import os
+import socket
+import time
+
+from github import Auth, Github, SelfHostedActionsRunner, PaginatedList
+import boto3
+import paramiko
+
+
+DRAIN_REQUESTED_LABEL="DrainRequested"
+DRAIN_SUCCESS_LABEL="DrainSuccess"
+DRAIN_STARTED_LABEL="DrainStarted"
+
+GH_APP_ID = 1007062
+GH_APP_INSTALATION_ID = 55231883
+GH_APP_PK_ENVIRON = 'A100_GH_APP_PK'
+
+INSTANCE_NAMES=[
+    # TODO: Update those values to gh-ci-
+    # Reason not to: fear of not being able to acquire back released resources
+    "gi-ci-benchmark-pet-action-runner",
+    "gi-ci-benchmark-h100-pet-action-runner",
+]
+INSTANCE_REGIONS=['us-east-1', 'us-east-2', 'us-west-2']
+
+DRAIN_START_TIMEOUT=5*60
+DRAIN_SUCCESS_TIMEOUT=9*60*60 - DRAIN_START_TIMEOUT - 5*60
+
+LOGGING_LEVEL_MAP = {
+    'CRITICAL': logging.CRITICAL,
+    'FATAL': logging.FATAL,
+    'ERROR': logging.ERROR,
+    'WARNING': logging.WARNING,
+    'WARN': logging.WARNING,
+    'INFO': logging.INFO,
+    'DEBUG': logging.DEBUG,
+}
+
+class InstanceInfo(NamedTuple):
+    instance_id: str
+    instance_type: str
+    public_ips: List[str]
+    region: str
+    volume_creation_date: datetime.datetime
+    volume_id: str
+
+
+logger = logging.getLogger(__name__)
+
+
+def from_human_str_to_bool(i: str) -> bool:
+    if i.lower() in ['true', '1', 'yes', 'y', 'enabled']:
+        return True
+    elif i.lower() in ['false', '0', 'no', 'n', 'disabled']:
+        return False
+    raise ValueError(f"Invalid boolean value: {i}")
+
+
+def get_ec2_instances_by_tag(tag_name: str, tag_value: str, regions: List[str]) -> List[InstanceInfo]:
+    def get_volume_creation_date(volume_id: str, ec2_client: Any) -> datetime.datetime:
+        response = ec2_client.describe_volumes(VolumeIds=[volume_id])
+        volume = response['Volumes'][0]
+        return volume['CreateTime']
+
+    instances_info: List[InstanceInfo] = []
+
+    for region in regions:
+        ec2_client = boto3.client('ec2', region_name=region)
+
+        response = ec2_client.describe_instances(
+            Filters=[
+                {'Name': f'tag:{tag_name}', 'Values': [tag_value]}
+            ]
+        )
+
+        for reservation in response['Reservations']:
+            for instance in reservation['Instances']:
+                instance_id = instance['InstanceId']
+                volumes = instance.get('BlockDeviceMappings', [])
+
+                for volume in volumes:
+                    volume_id = volume['Ebs']['VolumeId']
+                    volume_creation_date = get_volume_creation_date(volume_id, ec2_client)
+
+                    instances_info.append(InstanceInfo(
+                        instance_id=instance_id,
+                        instance_type=instance['InstanceType'],
+                        volume_id=volume_id,
+                        volume_creation_date=volume_creation_date,
+                        region=region,
+                        public_ips=[
+                            address
+                            for address in (
+                                interface.get('Association', {}).get('PublicIp', '')
+                                for interface in instance.get('NetworkInterfaces', [])
+                            )
+                            if address != ''
+                        ]
+                    ))
+
+    instances_info.sort(key=lambda x: x.volume_creation_date)
+
+    return instances_info
+
+
+def wait_for_tag(client: boto3.client, instance_id: str, tag_name: str, tag_value: str, check_interval: int = 10, timeout: int = 300) -> bool:
+    start_time = time.time()
+
+    while True:
+        response = client.describe_instances(InstanceIds=[instance_id])
+        instance = response['Reservations'][0]['Instances'][0]
+
+        if 'Tags' in instance:
+            for tag in instance['Tags']:
+                if tag['Key'] == tag_name and tag['Value'] == tag_value:
+                    return True
+
+        elapsed_time = time.time() - start_time
+        if elapsed_time > timeout:
+            if timeout <= 0:
+                break
+            else:
+                raise TimeoutError(f"Timeout reached: Tag '{tag_name}' with value '{tag_value}' was not found on instance '{instance_id}' within {timeout} seconds.")
+
+        time.sleep(check_interval)
+
+    return False
+
+
+def remove_tags_from_instance(client: boto3.client, instance_id: str, tag_keys: list) -> bool:
+    client.delete_tags(
+        Resources=[instance_id],
+        Tags=[{'Key': key} for key in tag_keys]  # List of tags to delete (only key is required)
+    )
+
+    logging.info(f"Tags {tag_keys} removed from instance: {instance_id}")
+    return True
+
+
+def restart_instance(client: boto3.client, instance_id: str, check_interval: int = 10, timeout: int = 300) -> bool:
+    logging.info(f"Requesting reboot for instance: {instance_id}")
+    client.reboot_instances(InstanceIds=[instance_id])
+
+    logging.info(f"Reboot requested for instance {instance_id}, waiting 2 minutes before checking instance state")
+    time.sleep(2*60)
+
+    start_time = time.time()
+
+    current_instance_status = ""
+
+    while True:
+        elapsed_time = time.time() - start_time
+        if elapsed_time > timeout:
+            raise TimeoutError(f"Timeout: Instance '{instance_id}' did not reach 'running' state within {timeout} seconds.")
+
+        try:
+            response = client.describe_instance_status(InstanceIds=[instance_id])
+            statuses = response.get('InstanceStatuses', [])
+        except Exception as e:
+            logging.error(f"Error while checking instance status: {e}")
+            continue
+
+        if statuses:
+            instance_status = statuses[0]['InstanceState']['Name']
+
+            if instance_status != current_instance_status:
+                current_instance_status = instance_status
+                logging.info(f"Current instance status: {instance_status}")
+
+            if instance_status == 'running':
+                logging.info(f"Instance '{instance_id}' is now running.")
+                return True
+            elif instance_status in ['stopping', 'stopped', 'terminated']:
+                raise Exception(f"Instance '{instance_id}' is in '{instance_status}' state, unable to complete reboot.")
+
+        time.sleep(check_interval)
+
+
+def wait_ssh_alive(ipv4_address: str, username: str, check_interval: int = 10, timeout: int = 300) -> None:
+    ssh_client = paramiko.SSHClient()
+    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    start_time = time.time()
+
+    while True:
+        elapsed_time = time.time() - start_time
+
+        if elapsed_time > timeout:
+            raise Exception(f"SSH connection attempts to {ipv4_address} exceeded {timeout} seconds")
+
+        try:
+            ssh_client.connect(ipv4_address, username=username, timeout=check_interval)
+            logging.info(f"SSH connection successful to {ipv4_address}")
+            return
+
+        except paramiko.ssh_exception.BadHostKeyException as e:
+            logging.info(f"ERROR: BadHostKeyException: {e}")
+            return
+        except paramiko.ssh_exception.AuthenticationException as e:
+            logging.info(f"ERROR: AuthenticationException: {e}")
+            return
+        except paramiko.ssh_exception.UnableToAuthenticate as e:
+            logging.info(f"ERROR: UnableToAuthenticate: {e}")
+            return
+        except socket.error as e:
+            logging.info(f"ERROR: Socket error: {e}")
+        except paramiko.ssh_exception.NoValidConnectionsError:
+            logging.info(f"ERROR: NoValidConnectionsError")
+        except paramiko.ssh_exception.SSHException as e:
+            logging.info(f"ERROR: SSHException")
+            return
+        except EOFError as e:
+            logging.info(f"ERROR: EOFError: {e}")
+        except TimeoutError:
+            logging.info(f"ERROR: Timed out while trying to connect to {ipv4_address}")
+        except Exception as e:
+            logging.info(f"ERROR: {e}")
+            return
+
+        finally:
+            try:
+                ssh_client.close()
+            except:
+                pass
+
+        time.sleep(check_interval)
+
+
+def replace_root_volume(client: boto3.client, instance_id: str, check_interval: int = 10, timeout: int = 600) -> bool:
+    response = client.create_replace_root_volume_task(
+        InstanceId=instance_id,
+        DeleteReplacedRootVolume=True
+    )
+
+    task_id = response['ReplaceRootVolumeTask']['ReplaceRootVolumeTaskId']
+    logging.info(f"Started root volume replacement task: {task_id}")
+
+    start_time = time.time()
+    curr_state = ""
+
+    while True:
+        elapsed_time = time.time() - start_time
+        if elapsed_time > timeout:
+            raise TimeoutError(f"Timeout: The root volume replacement for instance '{instance_id}' did not complete within {timeout} seconds.")
+
+        task_response = client.describe_replace_root_volume_tasks(ReplaceRootVolumeTaskIds=[task_id])
+        task_status = task_response['ReplaceRootVolumeTasks'][0]['TaskState']
+
+        if task_status != curr_state:
+            curr_state = task_status
+            logging.info(f"Current task state: {task_status}")
+
+        if task_status == 'succeeded':
+            logging.info(f"Root volume replacement succeeded for task: {task_id}")
+            return True
+        elif task_status in ['failed', 'failing']:
+            raise Exception(f"Root volume replacement failed for task: {task_id}, status: {task_status}")
+
+        time.sleep(check_interval)
+
+
+def create_instance_tag(ec2_client: boto3.client, instance_id: str, tag_key: str, tag_value: str) -> bool:
+    logging.info(f"Tagging instance {instance_id} with tag {tag_key}={tag_value}...")
+
+    response = ec2_client.create_tags(
+        Resources=[instance_id],
+        Tags=[
+            {
+                'Key': tag_key,
+                'Value': tag_value
+            }
+        ]
+    )
+
+    if response['ResponseMetadata']['HTTPStatusCode'] != 200:
+        raise Exception(f"Failed to tag instance {instance_id} with tag {tag_key}={tag_value}")
+
+    logging.info(f"Tagged instance {instance_id} with tag {tag_key}")
+    return True
+
+
+def kindly_ask_instance_to_drain_and_wait_start(instance_info: InstanceInfo, ec2_client: Any) -> None:
+    create_instance_tag(ec2_client, instance_info.instance_id, DRAIN_REQUESTED_LABEL, 'true')
+
+    logging.info(f"Waiting for instance {instance_info.instance_id} to be tagged with {DRAIN_STARTED_LABEL} with timeout of {DRAIN_START_TIMEOUT}...")
+    wait_for_tag(ec2_client, instance_info.instance_id, DRAIN_STARTED_LABEL, 'true', timeout=DRAIN_START_TIMEOUT)
+    logging.info(f"Instance {instance_info.instance_id} tagged with {DRAIN_STARTED_LABEL}")
+
+
+def wait_instance_to_be_fully_drained(instance_info: InstanceInfo, ec2_client: Any) -> None:
+    logging.info(f"Waiting for instance {instance_info.instance_id} to be tagged with {DRAIN_SUCCESS_LABEL} with timeout of {DRAIN_SUCCESS_TIMEOUT}...")
+    wait_for_tag(ec2_client, instance_info.instance_id, DRAIN_SUCCESS_LABEL, 'true', timeout=DRAIN_SUCCESS_TIMEOUT)
+    logging.info(f"Instance {instance_info.instance_id} tagged with {DRAIN_SUCCESS_LABEL}")
+
+
+def kindly_ask_instance_to_drain_and_wait(instance_info: InstanceInfo, force_on_drain_timeout: bool, ec2_client: Any) -> None:
+    create_instance_tag(ec2_client, instance_info.instance_id, DRAIN_REQUESTED_LABEL, 'true')
+
+    try:
+        kindly_ask_instance_to_drain_and_wait_start(instance_info, ec2_client)
+        wait_instance_to_be_fully_drained(instance_info, ec2_client)
+    except Exception as e:
+        logging.error(f"Error while refreshing EBS volume for instance {instance_info.instance_id}: {e}")
+        if not force_on_drain_timeout:
+            logging.warning("Force on drain timeout is disabled, skipping EBS volume refresh...")
+            raise
+
+
+def do_refresh_ebs_instance(instance_info: InstanceInfo, force_on_drain_timeout: bool) -> None:
+    logging.info(f"Refreshing EBS volume for instance {instance_info.instance_id} in region {instance_info.region}...")
+
+    ec2_client = boto3.client('ec2', region_name=instance_info.region)
+
+    kindly_ask_instance_to_drain_and_wait(instance_info, force_on_drain_timeout, ec2_client)
+    replace_root_volume(ec2_client, instance_info.instance_id)
+    remove_tags_from_instance(ec2_client, instance_info.instance_id, [DRAIN_REQUESTED_LABEL, DRAIN_STARTED_LABEL, DRAIN_SUCCESS_LABEL])
+    restart_instance(ec2_client, instance_info.instance_id)
+
+    logging.info("Sleeping for 2 minutes to allow the instance to fully restart...")
+    time.sleep(2*60)
+
+    if instance_info.public_ips:
+        logging.info("Trying to SSH to the instance, as so to wait for it to restart and become ready for ansible...")
+        wait_ssh_alive(instance_info.public_ips[0], 'ubuntu')
+    else:
+        logging.error("Instance does not have a public IP (Seems something is wrong here...), skipping SSH check...")
+
+    logging.info("Instance restarted and SSH is live, EBS volume refresh completed.")
+
+
+def get_github_app_client() -> Github:
+    auth = Auth.AppAuth(GH_APP_ID, os.environ[GH_APP_PK_ENVIRON]).get_installation_auth(GH_APP_INSTALATION_ID)
+    return Github(auth=auth)
+
+
+def get_self_hosted_runners_org(gh_org: Any) -> PaginatedList.PaginatedList:
+    return PaginatedList.PaginatedList(
+        SelfHostedActionsRunner.SelfHostedActionsRunner,
+        gh_org._requester,
+        f"https://api.github.com/orgs/{gh_org.login}/actions/runners",
+        None,
+        list_item="runners",
+    )
+
+
+def check_instance_is_registered(instance_id: str) -> bool:
+    logging.info(f"Checking if instance {instance_id} is registered as gha runner...")
+
+    try:
+        gh = get_github_app_client()
+        gh_org = gh.get_organization("pytorch")
+        for runner in get_self_hosted_runners_org(gh_org):
+            if runner.name.lower().startswith(instance_id.lower()):
+                logging.info(f"Instance {instance_id} is registered as gha runner")
+                return True
+
+    except Exception as e:
+        logging.error(f"Error while checking if instance {instance_id} is registered as gha runner: {e}")
+
+    logging.info(f"Instance {instance_id} is not registered as gha runner")
+    return False
+
+
+def create_refresh_inventory_file(instance_info: InstanceInfo) -> None:
+    logging.info(f"Creating inventory file (inventory/refresh_inventory) for instance {instance_info.instance_id}...")
+
+    with open('inventory/refresh_inventory', 'w') as f:
+        f.write(f"{instance_info.instance_id}-{instance_info.region}-{instance_info.instance_type} ansible_host={instance_info.public_ips[0]}")
+
+    logging.info("Inventory file created.")
+
+
+def get_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Reset the oldest EBS volume of the instances with the specified tag.')
+
+    parser.add_argument('--instance-name', action='store', type=str, default=INSTANCE_NAMES[0], choices=INSTANCE_NAMES, help='The tag value of the instances to reset the EBS volume.')
+    parser.add_argument('--instance-regions', type=str, nargs='+', default=INSTANCE_REGIONS, help='The regions to search for the instances.')
+    parser.add_argument('--logging-level', action='store', type=str, choices=list(LOGGING_LEVEL_MAP.keys()), default='DEBUG', help='The logging level.')
+    parser.add_argument('--force-on-drain-timeout', action='store', type=from_human_str_to_bool, default=True, help='Force the EBS volume refresh even if the drain timeout is reached.')
+
+    subparsers = parser.add_subparsers(title='subcommands', dest='subcommand')
+    subparsers.required = True
+
+    subparsers.add_parser(refresh_oldest_ebs_volume.__doc__, help='Reset the oldest EBS volume of the instances with the specified tag.')
+    subparsers.add_parser(check_last_ebs_connection.__doc__, help='Check if the last instance that had its EBS volume refreshed is registered as gha runner.')
+
+    safely_restart_all_instances_parser = subparsers.add_parser(safely_restart_all_instances.__doc__, help='Reboot ALL the instances, safely waiting then for properly drain.')
+    safely_restart_all_instances_parser.add_argument('--max-simultaneous-draining', action='store', type=int, default=3, help='The maximum number of instances to drain simultaneously.')
+    safely_restart_all_instances_parser.add_argument('--dry-run', action='store', type=from_human_str_to_bool, default=False, help='Do not actually restart the instances, just print the actions.')
+
+    return parser.parse_args()
+
+
+def refresh_oldest_ebs_volume(args: argparse.Namespace) -> None:
+    '''reset-oldest-ebs'''
+
+    logging.info(f"Getting instances with the tag {args.instance_name} in the regions {args.instance_regions}...")
+    instances = get_ec2_instances_by_tag('Name', args.instance_name, args.instance_regions)
+
+    if not instances:
+        raise Exception(f"No instances found with tag 'Name={args.instance_name}'")
+
+    if not check_instance_is_registered(instances[-1].instance_id):
+        logging.info(
+            f"Last instance that had its EBS volume refreshed ({instances[-1].instance_id}) is"
+            " not registered as gha runner, proceeding to refresh its EBS volume..."
+        )
+        do_refresh_ebs_instance(instances[-1], args.force_on_drain_timeout)
+        create_refresh_inventory_file(instances[-1])
+    else:
+        logging.info(
+            f"Last instance that had its EBS volume refreshed ({instances[-1].instance_id}) is "
+            f"registered as gha runner, proceeding to refresh the oldest ({instances[0].instance_id}) "
+            "instance's EBS volume..."
+        )
+        do_refresh_ebs_instance(instances[0], args.force_on_drain_timeout)
+        create_refresh_inventory_file(instances[0])
+
+
+def check_last_ebs_connection(args: argparse.Namespace) -> None:
+    '''check-last-ebs-connection'''
+
+    logging.info("Checking if the last instance that had its EBS volume refreshed is registered as gha runner...")
+
+    logging.debug(f"Getting instances with the tag {args.instance_name} in the regions {args.instance_regions}...")
+    instances = get_ec2_instances_by_tag('Name', args.instance_name, args.instance_regions)
+
+    if not instances:
+        raise Exception(f"No instances found with tag 'Name={args.instance_name}'")
+
+    last_instance = instances[-1]
+    logging.info(f"Last instance that had its EBS volume refreshed: {last_instance.instance_id} in region {last_instance.region}")
+
+    logging.debug('Checking if the last instance is registered as gha runner...')
+    if not check_instance_is_registered(last_instance.instance_id):
+        raise Exception(f'Last instance {last_instance.instance_id} with Name tag {args.instance_name} on region {last_instance.region} that had its EBS volume refreshed is not registered as gha runner')
+
+    logging.debug('Trying to connect to the instance via ssh...')
+    try:
+        wait_ssh_alive(last_instance.public_ips[0], 'ubuntu')
+        logging.info('successfully connected to the instance via ssh')
+    except:
+        raise
+
+
+def safely_restart_all_instances(args: argparse.Namespace) -> None:
+    '''safely-restart-all-instances'''
+
+    logging.info("Will restart all instances with the tag {args.instance_name} in the regions {args.instance_regions}...")
+
+    logging.info(f"Getting instances with the tag {args.instance_name} in the regions {args.instance_regions}...")
+    instances = get_ec2_instances_by_tag('Name', args.instance_name, args.instance_regions)
+
+    if not instances:
+        raise Exception(f"No instances found with tag 'Name={args.instance_name}'")
+
+    ec2_clients = {}
+    to_drain = []
+    wait_drain = []
+    to_restart = []
+    restarted = []
+
+    for instance in instances:
+        if check_instance_is_registered(instance.instance_id):
+            to_drain.append(instance)
+        else:
+            logging.warning(f"Instance {instance.instance_id} is not registered as gha runner, skipping drain...")
+            to_restart.append(instance)
+
+    if to_drain:
+        logging.info("Will proceed to safely drain the instances...")
+        logging.info(f"Instances to drain: {', '.join([instance.instance_id for instance in to_drain])}")
+    else:
+        logging.info("No instances to drain, skipping drain...")
+
+    while to_drain or wait_drain or to_restart:
+        for instance in to_drain:
+            if len(wait_drain) >= args.max_simultaneous_draining:
+                break
+
+            if instance.region not in ec2_clients:
+                ec2_clients[instance.region] = boto3.client('ec2', region_name=instance.region)
+
+            logging.info(f"Asking to drain instance {instance.instance_id}...")
+            try:
+                if not args.dry_run:
+                    kindly_ask_instance_to_drain_and_wait_start(instance, ec2_clients[instance.region])
+                logging.info(f"Instance {instance.instance_id} is now draining...")
+                wait_drain.append(instance)
+                logging.info(f"Instances to wait for: {', '.join([instance.instance_id for instance in wait_drain])}")
+            except Exception as e:
+                logging.error(f"Error while asking to drain instance {instance.instance_id}, will restart it anyways: {e}")
+                to_restart.append(instance)
+                logging.info(f"Instances to restart: {', '.join([instance.instance_id for instance in to_drain])}")
+
+        # Lists should be fairly small, so no point on using sets
+        to_drain = [instance for instance in to_drain if instance not in wait_drain and instance not in to_restart]
+
+        for instance in wait_drain:
+            if instance.region not in ec2_clients:
+                ec2_clients[instance.region] = boto3.client('ec2', region_name=instance.region)
+
+            try:
+                if args.dry_run or wait_for_tag(ec2_clients[instance.region], instance.instance_id, DRAIN_SUCCESS_LABEL, 'true', 0, -1):
+                    logging.info(f"Instance {instance.instance_id} is now fully drained.")
+                    to_restart.append(instance)
+                    logging.info(f"Instances to restart: {', '.join([instance.instance_id for instance in to_restart])}")
+            except Exception as e:
+                logging.error(f"Error while draining instance {instance.instance_id}: {e}")
+                to_restart.append(instance)
+                logging.info(f"Instances to restart: {', '.join([instance.instance_id for instance in to_restart])}")
+
+        # Lists should be fairly small, so no point on using sets
+        wait_drain = [instance for instance in wait_drain if instance not in to_restart]
+
+        for instance in to_restart:
+            if instance.region not in ec2_clients:
+                ec2_clients[instance.region] = boto3.client('ec2', region_name=instance.region)
+
+            logging.info(f"Removing drain tags from instance {instance.instance_id}...")
+            try:
+                if not args.dry_run:
+                    remove_tags_from_instance(ec2_clients[instance.region], instance.instance_id, [DRAIN_REQUESTED_LABEL, DRAIN_STARTED_LABEL, DRAIN_SUCCESS_LABEL])
+                    logging.info(f"Drain tags removed from instance {instance.instance_id}")
+            except Exception as e:
+                logging.error(f"Error while removing drain tags from instance {instance.instance_id}: {e}")
+                try:
+                    time.sleep(30)
+                    remove_tags_from_instance(ec2_clients[instance.region], instance.instance_id, [DRAIN_REQUESTED_LABEL, DRAIN_STARTED_LABEL, DRAIN_SUCCESS_LABEL])
+                    logging.info(f"Drain tags removed from instance {instance.instance_id}")
+                except Exception as e:
+                    logging.critical(f"Error while removing drain tags from instance {instance.instance_id}: {e}")
+
+            logging.info(f"Restarting instance {instance.instance_id}...")
+            try:
+                if not args.dry_run:
+                    ec2_clients[instance.region].reboot_instances(InstanceIds=[instance.instance_id])
+                restarted.append(instance)
+                logging.info(f"Instance {instance.instance_id} restarted.")
+            except Exception as e:
+                logging.error(f"Error while restarting instance {instance.instance_id}: {e}")
+
+        # Lists should be fairly small, so no point on using sets
+        to_restart = [instance for instance in to_restart if instance not in restarted]
+
+        if to_drain or wait_drain or to_restart:
+            time.sleep(10)
+
+    logging.info(f"Instances restarted: {', '.join([instance.instance_id for instance in restarted])}")
+
+
+def main() -> None:
+    cmds = {
+        check_last_ebs_connection.__doc__: check_last_ebs_connection,
+        refresh_oldest_ebs_volume.__doc__: refresh_oldest_ebs_volume,
+        safely_restart_all_instances.__doc__: safely_restart_all_instances,
+    }
+    args = get_args()
+    logging.basicConfig(level=LOGGING_LEVEL_MAP[args.logging_level], format='%(asctime)s %(message)s')
+
+    if GH_APP_PK_ENVIRON not in os.environ:
+        raise Exception(f"Environment variable '{GH_APP_PK_ENVIRON}' not found")
+
+    cmds[args.subcommand](args)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/multi-tenant/services/ghad-manager/ghad-manager.py
+++ b/tools/multi-tenant/services/ghad-manager/ghad-manager.py
@@ -1,0 +1,508 @@
+from collections import defaultdict
+import grp
+import logging
+import os
+import pwd
+from typing import List
+import requests
+import subprocess
+import sys
+import time
+
+import docker
+from github import Auth, Github, SelfHostedActionsRunner, PaginatedList
+
+
+logger = logging.getLogger(__name__)
+
+
+# The name of the container that should always be running
+REQUIRED_CONTAINER_NAME = 'ghad-main-shared-instance-container'
+DOCKER_REPOSITORY = '308535385114.dkr.ecr.us-east-1.amazonaws.com/multi-tenant-gpu'
+DOCKER_TAG = 'latest'
+_IMDSV2_TOKEN = ""
+DRAIN_REQUESTED_LABEL="DrainRequested"
+DRAIN_SUCCESS_LABEL="DrainSuccess"
+DRAIN_STARTED_LABEL="DrainStarted"
+
+
+class UserSocketsPath:
+    def __init__(self, uid: int, socket_path: str, user_name: str):
+        self._uid = uid
+        self._socket_path = socket_path
+        self._user_name = user_name
+        self._docker_client = None
+
+    @property
+    def uid(self) -> int:
+        return self._uid
+
+    @property
+    def socket_path(self) -> str:
+        return self._socket_path
+
+    @property
+    def user_name(self) -> str:
+        return self._user_name
+
+    @property
+    def docker_client(self) -> docker.DockerClient:
+        if not self._docker_client:
+            self._docker_client = get_docker_client(self.socket_path)
+        return self._docker_client
+
+
+def get_home_users() -> list[pwd.struct_passwd]:
+    users = []
+    for user in pwd.getpwall():
+        if os.path.isdir(f'/home/{user.pw_name}') and user.pw_name != 'ubuntu':
+            users.append(user)
+    return users
+
+
+def check_socket_for_users(timeout=10*60, check_interval=1) -> List[UserSocketsPath]:
+    users = get_home_users()
+    user_sockets = {user.pw_uid: (False, user.pw_name, ) for user in users}
+    start_time = time.time()
+
+    logger.info(f"Checking for Docker sockets for users: {', '.join([user.pw_name for user in users])}")
+
+    while time.time() - start_time < timeout:
+        for user in users:
+            if user_sockets.get(user.pw_uid, (False, '', ))[0]:
+                continue
+
+            uid = user.pw_uid
+            socket_path = f'/run/user/{uid}/docker.sock'
+
+            if os.path.exists(socket_path):
+                user_sockets[uid] = (True, user.pw_name, )
+
+        if all(has_socket for has_socket, _ in user_sockets.values()):
+            logger.info("All Docker sockets found. Starting manager...")
+            break
+        else:
+            logger.debug(f"Still missing Docker sockets for users: {[uid for uid, has_socket in user_sockets.items() if not has_socket]}")
+
+        time.sleep(check_interval)
+
+    return [
+        UserSocketsPath(uid, f'/run/user/{uid}/docker.sock', user_name)
+        for (uid, (has_socket, user_name, ), ) in user_sockets.items()
+        if has_socket
+    ]
+
+
+def get_docker_client(socket_path: str) -> docker.DockerClient | None:
+    try:
+        logger.info(f"Connecting to Docker socket {socket_path}")
+        client = docker.DockerClient(base_url=f'unix://{socket_path}')
+        return client
+    except Exception as e:
+        logger.info(f"Error connecting to Docker socket {socket_path}: {str(e)}")
+        return None
+
+
+def is_container_running(client: docker.DockerClient, container_name: str) -> bool:
+    try:
+        containers = client.containers.list(filters={"name": container_name}, all=True)
+        for container in containers:
+            if container.name == container_name and container.status == 'running':
+                return True
+        return False
+    except Exception as e:
+        logger.warning(f"Error checking containers: {str(e)}")
+        return False
+
+
+def stop_all_containers(client: docker.DockerClient, uid: int) -> None:
+    logger.info(f"Stopping all containers for user {uid}")
+    try:
+        containers = client.containers.list(all=True)
+        for container in containers:
+            try:
+                container.stop()
+                container.remove()
+            except Exception as e:
+                logger.warning(f"Error stopping container {container.name}: {str(e)}")
+    except Exception as e:
+        logger.warning(f"Error stopping all containers: {str(e)}")
+
+
+def prune_images(client: docker.DockerClient, uid: int) -> None:
+    logger.info(f"Pruning images for {uid}, so that we don't run out of disk space.")
+    client.images.prune({'dangling': False})
+
+
+def start_container_if_not_running(
+        runner_url: str, instance_label: str, instance_id: str, uid: int, client: docker.DockerClient,
+        docker_group_id: int, container_name: str, user_name: str, docker_tag: str
+        ) -> None:
+    if not is_container_running(client, container_name):
+        stop_all_containers(client, uid)
+        prune_images(client, uid)
+        login_to_ecr(client)
+
+        logger.info(f"Container {container_name} for user {uid} is not running, attempting to start it.")
+        logger.info("Getting GH token")
+        gh_token = get_gh_runner_token()
+        logger.info(f"GH token obtained, starting container.")
+        try:
+            subprocess.run(["rm", "-rf", f"/home/{user_name}/_work"])
+            subprocess.run(["mkdir", "-p", f"/hone/{user_name}/_work"])
+            subprocess.run(["chown", "-R", f"1000:1000", f"/home/{user_name}/_work"])
+        except Exception as e:
+            logger.warning(f"Error setting up container environment on host user {container_name}: {str(e)}")
+        try:
+            response = client.containers.run(
+                image=f"{DOCKER_REPOSITORY}:{docker_tag}",
+                name=container_name,
+                command=f'/bin/bash /multi-tenant-gpu-main.sh "{user_name}" "{docker_group_id}" "{runner_url}" "{gh_token}" "{instance_id}" "{uid}" "{instance_label}"',
+                volumes={
+                    f'/run/user/{uid}/docker.sock': {'bind': '/var/run/docker.sock', 'mode': 'rw'},
+                    f'/home/{user_name}/_work': {'bind': f'/home/{user_name}/_work', 'mode': 'rw'},
+                    '/etc/gha-runner-config/multi-tenant-gpu-main.sh': {'bind': '/multi-tenant-gpu-main.sh', 'mode': 'ro'},
+                },
+                device_requests=[
+                    docker.types.DeviceRequest(count=-1, capabilities=[['gpu']])
+                ],
+                remove=True,
+                detach=True
+            )
+            logger.info(f"the response from the docker daemon: {response}")
+        except Exception as e:
+            logger.warning(f"Error starting container {container_name}: {str(e)}")
+
+
+def drain_all_containers(instance_id: str, instance_az: str, instance_region: str, uid_sockets_list: List[UserSocketsPath]) -> None:
+    logger.warning(f"Instance {instance_id} {instance_az} {instance_region} is marked to drain, stopping all idle containers.")
+
+    gh = get_github_app_client()
+    gh_org = gh.get_organization("pytorch")
+
+    not_found_count = defaultdict(int)
+
+    while True:
+        terminated_all = True
+
+        gh_runners = {
+            runner.name: runner
+            for runner in get_self_hosted_runners_org(gh_org)
+        }
+
+        for uid_sockets in uid_sockets_list:
+            logger.debug(f"Checking container for user {uid_sockets.user_name}")
+
+            if not is_container_running(uid_sockets.docker_client, REQUIRED_CONTAINER_NAME):
+                logger.info(f"Container {REQUIRED_CONTAINER_NAME} for user {uid_sockets.user_name} is not running, skipping.")
+                continue
+
+            runner_gh_name = f"{instance_id}-{uid_sockets.uid}"
+
+            if runner_gh_name in gh_runners:
+                if runner_gh_name in not_found_count:
+                    logger.info(f"Runner {runner_gh_name} found after {not_found_count[runner_gh_name]} consecutive not founds.")
+                    del not_found_count[runner_gh_name]
+                else:
+                    logger.info(f"Runner {runner_gh_name} found, checking if it's busy.")
+
+                if gh_runners[runner_gh_name].busy:
+                    logger.info(f"Runner {runner_gh_name} is busy, not stopping container.")
+                    terminated_all = False
+                    continue
+
+                if not remove_self_hosted_runner_org(gh_org, gh_runners[runner_gh_name]):
+                    logger.error(f"Error removing runner {runner_gh_name}")
+                    terminated_all = False
+                    continue
+
+                logger.info(f"Runner {runner_gh_name} removed.")
+            else:
+                # It is possible that the runner is not returned by the API but it should and it is running
+                # This is a known issue with the GitHub API
+                # There is no way to check if the runner is busy or not unless we have the runner ID, but we don't keep track of it
+                # So, we check multiple times, and if we can't find it after 5 tries, we assume it is not running
+                not_found_count[runner_gh_name] += 1
+
+                if not_found_count[runner_gh_name] < 5:
+                    logger.info(f"Runner {runner_gh_name} not found. Count of 'not founds': {not_found_count[runner_gh_name]}. Will check again.")
+                    terminated_all = False
+                    continue
+
+                logger.info(f"Runner {runner_gh_name} not found after 5 consecutive not founds. Stopping container.")
+
+            try:
+                container = uid_sockets.docker_client.containers.get(REQUIRED_CONTAINER_NAME)
+                container.stop()
+                try:
+                    container.remove()
+                except Exception as e:
+                    logger.warning(f"Error removing container {REQUIRED_CONTAINER_NAME}: {str(e)}")
+                logger.info(f"Container {REQUIRED_CONTAINER_NAME} for user {uid_sockets.user_name} stopped and removed.")
+            except Exception as e:
+                logger.error(f"Error stopping container {REQUIRED_CONTAINER_NAME}: {str(e)}")
+                terminated_all = False
+
+        if terminated_all:
+            logger.debug("All containers stopped.")
+            break
+
+        time.sleep(20)
+
+
+def trap_stuck_inactive_daemon() -> None:
+    while True:
+        logger.debug("Trapping stuck inactive daemon")
+        time.sleep(120)
+
+
+def add_instance_tag(instance_id: str, instance_region: str, label: str, value: str) -> None:
+    try:
+        subprocess.run(["/usr/bin/aws", "ec2", "create-tags", "--region", instance_region, "--resources", instance_id, "--tags", f"Key={label},Value={value}"])
+    except Exception as e:
+        logger.warning(f"Error adding drain label to instance {instance_id}: {str(e)}")
+
+
+def add_drained_label(instance_id: str, instance_region: str) -> None:
+    add_instance_tag(instance_id, instance_region, DRAIN_SUCCESS_LABEL, 'true')
+
+
+def add_drain_started_label(instance_id: str, instance_region: str) -> None:
+    add_instance_tag(instance_id, instance_region, DRAIN_STARTED_LABEL, 'true')
+
+
+def get_self_hosted_runners_org(org: any) -> PaginatedList.PaginatedList[SelfHostedActionsRunner.SelfHostedActionsRunner]:
+    return PaginatedList.PaginatedList(
+        SelfHostedActionsRunner.SelfHostedActionsRunner,
+        org._requester,
+        f"https://api.github.com/orgs/{org.login}/actions/runners",
+        None,
+        list_item="runners",
+    )
+
+
+def remove_self_hosted_runner_org(org: any, runner: any) -> bool:
+    status, _, _ = org._requester.requestJson(
+        "DELETE", f"/orgs/{org.login}/actions/runners/{runner.id}"
+    )
+    return status == 204
+
+
+def get_imdsv2_token() -> str:
+    try:
+        return requests.put("http://169.254.169.254/latest/api/token", headers={"X-aws-ec2-metadata-token-ttl-seconds": "60"}).text
+    except Exception as e:
+        logger.error(f"Error getting IMDSv2 token: {str(e)}")
+        raise
+
+
+def do_imdsv2_request_w_token(url: str) -> str:
+    global _IMDSV2_TOKEN
+
+    def _do_request() -> str:
+        global _IMDSV2_TOKEN
+        response = requests.get(url, headers={"X-aws-ec2-metadata-token": _IMDSV2_TOKEN})
+
+        if response.status_code != 200:
+            raise Exception(f"Error getting IMDSv2 data: {response.text}")
+
+        return response.text
+
+    if not _IMDSV2_TOKEN:
+        _IMDSV2_TOKEN = get_imdsv2_token()
+
+    try:
+        return _do_request()
+    except Exception as e:
+        _IMDSV2_TOKEN = get_imdsv2_token()
+        try:
+            return _do_request()
+        except Exception as e:
+            logger.error(f"Error getting IMDSv2 data: {str(e)}")
+            raise
+
+
+def get_instance_az() -> str:
+    return do_imdsv2_request_w_token("http://169.254.169.254/latest/meta-data/placement/availability-zone")
+
+
+def get_instance_region() -> str:
+    return do_imdsv2_request_w_token("http://169.254.169.254/latest/meta-data/placement/region")
+
+
+def get_instance_id() -> str:
+    return do_imdsv2_request_w_token("http://169.254.169.254/latest/meta-data/instance-id")
+
+
+def get_instance_labels() -> List[str]:
+    response = do_imdsv2_request_w_token("http://169.254.169.254/latest/meta-data/tags/instance")
+    return [x for x in [x.strip() for x in response.split("\n")] if x]
+
+
+def get_instance_label_value(label: str) -> str:
+    response = do_imdsv2_request_w_token(f"http://169.254.169.254/latest/meta-data/tags/instance/{label}")
+    return response.strip()
+
+
+def login_to_ecr(client: docker.DockerClient) -> None:
+    logger.info("Logging into ECR")
+    token = subprocess.check_output(["aws", "ecr", "get-login-password", "--region", "us-east-1", ], text=True).strip()
+    try:
+        response = client.login(username='AWS', password=token, registry=DOCKER_REPOSITORY)
+        if 'Status' in response and response['Status'] == 'Login Succeeded':
+            logger.debug("Login to ECR succeeded.")
+        else:
+            msg = f"Login to ECR failed: {response}"
+            logger.error(f"Login to ECR failed: {response}")
+            raise Exception(msg)
+    except Exception as e:
+        logger.error(f"Error logging into ECR: {str(e)}")
+        # sometimes, after while, aws ecr commands starts giving invalid tokens
+        # I hope that this will fix the issue
+        sys.exit(1)
+
+
+def get_github_app_client() -> Github:
+    auth = Auth.AppAuth(get_github_app_id(), get_private_key()).get_installation_auth(get_github_app_installation_id())
+    return Github(auth=auth)
+
+
+def get_gh_runner_token() -> str:
+    gh_client = get_github_app_client()
+    org = gh_client.get_organization('pytorch')
+    _, data = org._requester.requestJsonAndCheck(
+        "POST",
+        f"/orgs/{org.login}/actions/runners/registration-token",
+    )
+    return data['token']
+
+
+def read_from_file(file_path: str) -> str:
+    try:
+        with open(file_path, 'r') as f:
+            return f.read().strip()
+    except Exception as e:
+        logger.info(f"Error reading file {file_path}: {str(e)}")
+        raise
+
+
+def get_instance_label_from_file() -> str:
+    return read_from_file('/etc/gha-runner-config/instance-label')
+
+
+def get_runner_url_from_file() -> str:
+    return read_from_file('/etc/gha-runner-config/runner-url')
+
+
+def get_private_key() -> str:
+    return read_from_file('/etc/gha-runner-config/private-key')
+
+
+def get_github_app_id() -> str:
+    return int(read_from_file('/etc/gha-runner-config/app-id'))
+
+
+def get_github_app_installation_id() -> str:
+    return int(read_from_file('/etc/gha-runner-config/installation-id'))
+
+
+def get_docker_tag_from_file() -> str:
+    return read_from_file('/etc/gha-runner-config/image-tag-version')
+
+
+def lock_nvidia_gpu_clock() -> None:
+    with_a100 = False
+    with_h100 = False
+
+    try:
+        result = subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE)
+        if "A100-SXM4-40GB" in result.stdout.decode():
+            logger.info("Detected A100-SXM4-40GB GPU")
+            with_a100 = True
+        elif "H100 80GB HBM3" in result.stdout.decode():
+            logger.info("Detected H100 80GB HBM3 GPU")
+            with_h100 = True
+    except Exception as e:
+        logger.warning(f"Error checking GPU model: {str(e)}")
+
+    if with_a100:
+        logger.info("Locking GPU clock to 1410 MHz (40GiB A100)")
+        try:
+            subprocess.run(["nvidia-smi", "-pm", "1"], check=True)
+            subprocess.run(["nvidia-smi", "-ac", "1215,1410"], check=True)
+            subprocess.run(["nvidia-smi", "-pl", "250"], check=True)
+        except Exception as e:
+            logger.warning(f"Error locking GPU clock: {str(e)}")
+    elif with_h100:
+        logger.info("Locking GPU clock to 1410 MHz (40GiB A100)")
+        try:
+            subprocess.run(["nvidia-smi", "-pm", "1"], check=True)
+            subprocess.run(["nvidia-smi", "-ac", "1980,2619"], check=True)
+            subprocess.run(["nvidia-smi", "-pl", "700"], check=True)
+        except Exception as e:
+            logger.warning(f"Error locking GPU clock: {str(e)}")
+
+
+def check_should_drain(instance_id: str) -> bool:
+    try:
+        logger.debug("Checking if instance should drain")
+        labels = get_instance_labels()
+        logger.debug(f"Instance {instance_id} labels: {', '.join(labels)}")
+        if DRAIN_REQUESTED_LABEL in labels:
+            logger.debug(f"Instance {instance_id} has label {DRAIN_REQUESTED_LABEL}.")
+            value = get_instance_label_value(DRAIN_REQUESTED_LABEL)
+            logger.debug(f"Instance {instance_id} has label {DRAIN_REQUESTED_LABEL} with value {value}.")
+            if value == 'true':
+                logger.info(f"Instance {instance_id} is marked for drain, exiting.")
+                return True
+    except Exception as e:
+        logger.warning(f"Error checking drain label: {str(e)}")
+        return False
+
+
+def monitor_containers() -> None:
+    logger.info(f"Starting container monitor on instance daemon...")
+
+    uid_sockets_list = check_socket_for_users()
+    instance_id = get_instance_id()
+    instance_az = get_instance_az()
+    instance_region = get_instance_region()
+
+    logger.info(f"Container monitor on instance {instance_id} {instance_az} {instance_region}")
+    user_name_print = ', '.join([uid_socket.user_name for uid_socket in uid_sockets_list])
+    logger.info(f"Users to monitor: {user_name_print}")
+
+    docker_group_id = grp.getgrnam('docker').gr_gid
+    valid_uid_sockets_list = [uid_socket for uid_socket in uid_sockets_list if uid_socket.docker_client]
+
+    instance_label = get_instance_label_from_file()
+    runner_url = get_runner_url_from_file()
+
+    try:
+        docker_tag = get_docker_tag_from_file()
+    except Exception as e:
+        docker_tag = DOCKER_TAG
+        logger.warning(f"Error reading Docker tag from file: {str(e)}, using default {DOCKER_TAG}")
+
+    logger.info(f"Container monitor for instance {instance_id} {instance_az} {instance_region} with label {instance_label} and runner URL {runner_url}")
+
+    while not check_should_drain(instance_id):
+        for uid_sockets in valid_uid_sockets_list:
+            logger.debug(f"Checking container for user {uid_sockets.user_name}")
+            start_container_if_not_running(
+                runner_url, instance_label, instance_id, uid_sockets.uid, uid_sockets.docker_client,
+                docker_group_id, REQUIRED_CONTAINER_NAME, uid_sockets.user_name, docker_tag
+            )
+        logger.debug("Sleeping for 20 seconds")
+        time.sleep(20)
+
+    add_drain_started_label(instance_id, instance_region)
+    drain_all_containers(instance_id, instance_az, instance_region, valid_uid_sockets_list)
+    add_drained_label(instance_id, instance_region)
+    trap_stuck_inactive_daemon()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(filename='/var/log/ghad-manager.log', level=logging.INFO, format='%(asctime)s %(message)s')
+    lock_nvidia_gpu_clock()
+    monitor_containers()

--- a/tools/multi-tenant/services/ghad-manager/ghad-manager.service
+++ b/tools/multi-tenant/services/ghad-manager/ghad-manager.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=GHA daemon manager
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+User=root
+ExecStart=/usr/bin/python3 /root/ghad-manager.py
+Environment=PYTHONUNBUFFERED=1
+
+[Install]
+WantedBy=multi-user.target

--- a/tools/multi-tenant/services/ghad-manager/requirements.txt
+++ b/tools/multi-tenant/services/ghad-manager/requirements.txt
@@ -1,0 +1,3 @@
+docker
+PyGithub
+requests


### PR DESCRIPTION
# Toolset to manage and run GHA runners for pytorch/* repositories

Imported the toolset to manage runners for pytorch/* repositories in the `tools/multi-tenant` folder.

## It includes:
* `tools/multi-tenant/playbooks/setup-host.yml` - Ansible playbook to setup hosts as GHA runners;
* `tools/multi-tenant/services/ghad-manager/ghad-manager.py` - Main daemon running as a root responsible to make sure GHA daemon is authenticated and running for all users;
* `tools/multi-tenant/scripts/reset_oldest_ebs.py` - AWS-specific. Tool to help safely reset ebs, safely draining instances with jobs for maintenances or cattle spa runs;
* `tools/multi-tenant/images/multi-tenant-gpu/Dockerfile` - Main docker image where CI runs;

## Design
Each GPU is assigned to a linux unix user. Each user is assigned a quota for both CPU and memory based on available resources and number of GPUs using cgroups quotas. Then each user runs docker in userspace. A main daemon running as root controls the authentication to GH API using a private key. It then spawns for each user, in its respective docker constrained environment, a docker container that runs GHA daemon and the user docker is made available inside of it by mounting the docker daemon socket inside the running container;

Except from few limitations to hardware access (that are there for security and are intentional) the user running the CI is not aware that the CI is running in a docker container, and the ci can spawn new docker images with the same hardware access as the main docker image. 

As each job gets a new fresh environment, there is very limited worry in regards to trash buildup in the main instance. 