### PR TITLE
Add cuda (h100) device to PT2 inductor dashboard

### DIFF
--- a/torchci/components/benchmark/compilers/common.tsx
+++ b/torchci/components/benchmark/compilers/common.tsx
@@ -63,6 +63,7 @@ export const DEFAULT_DEVICE_NAME = "cuda (a100)";
 export const DISPLAY_NAMES_TO_DEVICE_NAMES: { [k: string]: string } = {
   "cuda (a100)": "cuda",
   "cuda (a10g)": "cuda_a10g",
+  "cuda (h100)": "cuda_h100",
   "cpu (x86)": "cpu_x86",
   "cpu (aarch64)": "cpu_aarch64",
   "rocm (mi300x)": "rocm",
@@ -71,6 +72,7 @@ export const DISPLAY_NAMES_TO_DEVICE_NAMES: { [k: string]: string } = {
 export const DISPLAY_NAMES_TO_WORKFLOW_NAMES: { [k: string]: string } = {
   "cuda (a100)": "inductor-A100-perf-nightly",
   "cuda (a10g)": "inductor-perf-nightly-A10g",
+  "cuda (h100)": "inductor-perf-nightly-h100",
   "cpu (x86)": "inductor-perf-nightly-x86",
   "cpu (aarch64)": "inductor-perf-nightly-aarch64",
   rocm: "inductor-perf-nightly-rocm",


### PR DESCRIPTION
This is going to be needed by https://github.com/pytorch/pytorch/pull/146868