### PR TITLE
Filter out devices that are not run

### DIFF
--- a/torchci/components/benchmark/llms/SummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/SummaryPanel.tsx
@@ -235,7 +235,7 @@ export function SummaryPanel({
         height={
           data.length > 90
             ? 90 * ROW_HEIGHT
-            : data.length * ROW_HEIGHT + ROW_GAP
+            : (data.length + 1) * ROW_HEIGHT + ROW_GAP
         }
       >
         <TablePanelWithData

--- a/torchci/components/benchmark/llms/SummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/SummaryPanel.tsx
@@ -142,7 +142,7 @@ export function SummaryPanel({
           flex: 1,
           cellClassName: (params: GridCellParams<any, any>) => {
             const v = params.value;
-            if (v === undefined || v.l.actual === 0) {
+            if (v === undefined) {
               return "";
             }
 
@@ -161,6 +161,11 @@ export function SummaryPanel({
               // It didn't error in the past, but now it does error
               if (r === 0) {
                 return styles.error;
+              }
+
+              // If it didn't run and now it runs, mark it as green
+              if (l === 0) {
+                return styles.ok;
               }
 
               if (metric in IS_INCREASING_METRIC_VALUE_GOOD) {

--- a/torchci/components/benchmark/llms/SummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/SummaryPanel.tsx
@@ -206,12 +206,11 @@ export function SummaryPanel({
                 : "";
             const showTarget =
               target && target != 0 ? `[target = ${target}]` : "";
-            const isNewModel = l === 0 ? "(NEW!)" : "";
 
             if (lCommit === rCommit || l === r) {
               return `${r} ${rPercent} ${showTarget}`;
             } else {
-              return `${l} ${lPercent} → ${r} ${rPercent} ${showTarget} ${isNewModel} `;
+              return `${l} ${lPercent} → ${r} ${rPercent} ${showTarget}`;
             }
           },
         };
@@ -225,8 +224,8 @@ export function SummaryPanel({
       <Grid2
         size={{ xs: 12, lg: 12 }}
         height={
-          data.length > 98
-            ? 98 * ROW_HEIGHT
+          data.length > 90
+            ? 90 * ROW_HEIGHT
             : data.length * ROW_HEIGHT + ROW_GAP
         }
       >

--- a/torchci/components/benchmark/llms/SummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/SummaryPanel.tsx
@@ -150,6 +150,10 @@ export function SummaryPanel({
             const l = v.l.actual;
             const r = v.r.actual;
 
+            if (!v.highlight) {
+              return "";
+            }
+
             if (lCommit === rCommit) {
               return "";
             } else {
@@ -212,7 +216,7 @@ export function SummaryPanel({
             const showTarget =
               target && target != 0 ? `[target = ${target}]` : "";
 
-            if (lCommit === rCommit || l === r) {
+            if (lCommit === rCommit || l === r || !v.highlight) {
               return `${r} ${rPercent} ${showTarget}`;
             } else {
               return `${l} ${lPercent} → ${r} ${rPercent} ${showTarget}`;

--- a/torchci/components/benchmark/llms/SummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/SummaryPanel.tsx
@@ -216,7 +216,7 @@ export function SummaryPanel({
             const showTarget =
               target && target != 0 ? `[target = ${target}]` : "";
 
-            if (lCommit === rCommit || l === r || !v.highlight) {
+            if (lCommit === rCommit || !v.highlight) {
               return `${r} ${rPercent} ${showTarget}`;
             } else {
               return `${l} ${lPercent} → ${r} ${rPercent} ${showTarget}`;

--- a/torchci/components/benchmark/llms/common.tsx
+++ b/torchci/components/benchmark/llms/common.tsx
@@ -27,12 +27,22 @@ export const IS_INCREASING_METRIC_VALUE_GOOD: { [k: string]: boolean } = {
   flops_utilization: true,
   "compilation_time(s)": false,
   speedup: true,
+  "avg_inference_latency(ms)": false,
+  "model_load_time(ms)": false,
+  "peak_inference_mem_usage(mb)": false,
+  "peak_load_mem_usuage(mb)": false,
+  "generate_time(ms)": false,
 };
 export const METRIC_DISPLAY_SHORT_HEADERS: { [k: string]: string } = {
   "memory_bandwidth(GB/s)": "Bandwidth",
   token_per_sec: "TPS",
   flops_utilization: "FLOPs",
   "compilation_time(s)": "CompTime",
+  "avg_inference_latency(ms)": "InferenceTime",
+  "model_load_time(ms)": "LoadTime",
+  "peak_inference_mem_usage(mb)": "InferenceMem",
+  "peak_load_mem_usuage(mb)": "LoadMem",
+  "generate_time(ms)": "GenerateTime",
 };
 export const DEFAULT_DEVICE_NAME = "All Devices";
 export const DEFAULT_ARCH_NAME = "All Platforms";
@@ -45,7 +55,7 @@ export const ARCH_NAMES: { [k: string]: string[] } = {
 };
 
 // Relative thresholds
-export const RELATIVE_THRESHOLD = 0.05;
+export const RELATIVE_THRESHOLD = 0.15;
 
 export interface LLMsBenchmarkData {
   granularity_bucket: string;

--- a/torchci/components/benchmark/llms/common.tsx
+++ b/torchci/components/benchmark/llms/common.tsx
@@ -55,7 +55,7 @@ export const ARCH_NAMES: { [k: string]: string[] } = {
 };
 
 // Relative thresholds
-export const RELATIVE_THRESHOLD = 0.15;
+export const RELATIVE_THRESHOLD = 0.10;
 
 export interface LLMsBenchmarkData {
   granularity_bucket: string;

--- a/torchci/components/benchmark/llms/common.tsx
+++ b/torchci/components/benchmark/llms/common.tsx
@@ -55,7 +55,7 @@ export const ARCH_NAMES: { [k: string]: string[] } = {
 };
 
 // Relative thresholds
-export const RELATIVE_THRESHOLD = 0.10;
+export const RELATIVE_THRESHOLD = 0.1;
 
 export interface LLMsBenchmarkData {
   granularity_bucket: string;

--- a/torchci/lib/benchmark/llmUtils.ts
+++ b/torchci/lib/benchmark/llmUtils.ts
@@ -187,7 +187,7 @@ export function combineLeftAndRight(
               actual: 0,
               target: 0,
             },
-        highlight: validDevices.size !== 0
+        highlight: validDevices.size !== 0,
       };
     }
 

--- a/torchci/lib/benchmark/llmUtils.ts
+++ b/torchci/lib/benchmark/llmUtils.ts
@@ -112,7 +112,6 @@ export function combineLeftAndRight(
       }
     }
   });
-  console.log(validDevices);
 
   // Transform the data into a displayable format
   const data: { [k: string]: any }[] = [];

--- a/torchci/lib/benchmark/llmUtils.ts
+++ b/torchci/lib/benchmark/llmUtils.ts
@@ -196,7 +196,7 @@ export function combineLeftAndRight(
               actual: 0,
               target: 0,
             },
-        highlight: validDevices.size !== 0 && hasL,
+        highlight: validDevices.size !== 0,
       };
     }
 

--- a/torchci/lib/benchmark/llmUtils.ts
+++ b/torchci/lib/benchmark/llmUtils.ts
@@ -128,7 +128,13 @@ export function combineLeftAndRight(
       const hasR = "r" in record;
 
       // Skip devices that weren't run in this commit
-      if (!validDevices.has(device)) {
+      if (validDevices.size !== 0 && !validDevices.has(device)) {
+        continue;
+      }
+
+      // No overlapping between left and right commits, just show what it's on the
+      // right commit instead of showing a blank page
+      if (validDevices.size === 0 && !hasR) {
         continue;
       }
 
@@ -181,6 +187,7 @@ export function combineLeftAndRight(
               actual: 0,
               target: 0,
             },
+        highlight: validDevices.size !== 0
       };
     }
 

--- a/torchci/lib/benchmark/llmUtils.ts
+++ b/torchci/lib/benchmark/llmUtils.ts
@@ -94,6 +94,7 @@ export function combineLeftAndRight(
   // 0 on the dashboard. Note that we can do a join with workflow_job table to get this
   // information, but it's a rather slow and expensive route
   const validDevices = new Set<string>();
+  const validModelBackends = new Set<string>();
   // First round to get all the valid devices
   Object.keys(dataGroupedByModel).forEach((key: string) => {
     const [model, backend, dtype, device, arch] = key.split(";");
@@ -109,6 +110,10 @@ export function combineLeftAndRight(
 
       if (hasL && hasR) {
         validDevices.add(device);
+      }
+
+      if (hasR) {
+        validModelBackends.add(`${model} ${backend}`);
       }
     }
   });
@@ -127,8 +132,12 @@ export function combineLeftAndRight(
       const hasL = "l" in record;
       const hasR = "r" in record;
 
-      // Skip devices that weren't run in this commit
-      if (validDevices.size !== 0 && !validDevices.has(device)) {
+      // Skip devices and models that weren't run in this commit
+      if (
+        (validDevices.size !== 0 && !validDevices.has(device)) ||
+        (validModelBackends.size !== 0 &&
+          !validModelBackends.has(`${model} ${backend}`))
+      ) {
         continue;
       }
 
@@ -187,7 +196,7 @@ export function combineLeftAndRight(
               actual: 0,
               target: 0,
             },
-        highlight: validDevices.size !== 0,
+        highlight: validDevices.size !== 0 && hasL,
       };
     }
 

--- a/torchci/lib/benchmark/llmUtils.ts
+++ b/torchci/lib/benchmark/llmUtils.ts
@@ -94,6 +94,7 @@ export function combineLeftAndRight(
   // 0 on the dashboard. Note that we can do a join with workflow_job table to get this
   // information, but it's a rather slow and expensive route
   const validDevices = new Set<string>();
+  const validModels = new Set<string>();
   const validModelBackends = new Set<string>();
   // First round to get all the valid devices
   Object.keys(dataGroupedByModel).forEach((key: string) => {
@@ -110,6 +111,7 @@ export function combineLeftAndRight(
 
       if (hasL && hasR) {
         validDevices.add(device);
+        validModels.add(model);
       }
 
       if (hasR) {
@@ -135,6 +137,7 @@ export function combineLeftAndRight(
       // Skip devices and models that weren't run in this commit
       if (
         (validDevices.size !== 0 && !validDevices.has(device)) ||
+        (validModels.size !== 0 && !validModels.has(model)) ||
         (validModelBackends.size !== 0 &&
           !validModelBackends.has(`${model} ${backend}`))
       ) {
@@ -196,7 +199,7 @@ export function combineLeftAndRight(
               actual: 0,
               target: 0,
             },
-        highlight: validDevices.size !== 0,
+        highlight: validDevices.size !== 0 && validModels.has(model),
       };
     }
 

--- a/torchci/lib/benchmark/llmUtils.ts
+++ b/torchci/lib/benchmark/llmUtils.ts
@@ -94,8 +94,7 @@ export function combineLeftAndRight(
   // 0 on the dashboard. Note that we can do a join with workflow_job table to get this
   // information, but it's a rather slow and expensive route
   const validDevices = new Set<string>();
-  const validModels = new Set<string>();
-  const validModelBackends = new Set<string>();
+  const validBackends = new Set<string>();
   // First round to get all the valid devices
   Object.keys(dataGroupedByModel).forEach((key: string) => {
     const [model, backend, dtype, device, arch] = key.split(";");
@@ -111,11 +110,7 @@ export function combineLeftAndRight(
 
       if (hasL && hasR) {
         validDevices.add(device);
-        validModels.add(model);
-      }
-
-      if (hasR) {
-        validModelBackends.add(`${model} ${backend}`);
+        validBackends.add(`${model} ${backend}`);
       }
     }
   });
@@ -137,16 +132,14 @@ export function combineLeftAndRight(
       // Skip devices and models that weren't run in this commit
       if (
         (validDevices.size !== 0 && !validDevices.has(device)) ||
-        (validModels.size !== 0 && !validModels.has(model)) ||
-        (validModelBackends.size !== 0 &&
-          !validModelBackends.has(`${model} ${backend}`))
+        (validBackends.size !== 0 && !validBackends.has(`${model} ${backend}`))
       ) {
         continue;
       }
 
       // No overlapping between left and right commits, just show what it's on the
       // right commit instead of showing a blank page
-      if (validDevices.size === 0 && !hasR) {
+      if (!hasR) {
         continue;
       }
 
@@ -199,7 +192,11 @@ export function combineLeftAndRight(
               actual: 0,
               target: 0,
             },
-        highlight: validDevices.size !== 0 && validModels.has(model),
+        highlight:
+          validDevices.size !== 0 &&
+          validBackends.has(`${model} ${backend}`) &&
+          hasL &&
+          hasR,
       };
     }
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/executorch/issues/7986 (for real this time)

The problem is that the records in the benchmark database alone don't have the information to differentiate between benchmarks that are failed to run and benchmarks that are not run. Both show up as 0 on the dashboard. Note that we can do a join with `workflow_job` table to get this information, but it's a rather slow and expensive route.  So, I opt for a quicker approach to keep track of the list of valid devices on the dashboard side.  A valid device is one that is run by the selected commit and has at least one non-zero record there.

### Testing

https://torchci-git-fork-huydhn-better-model-filter-fbopensource.vercel.app/benchmark/llms?repoName=pytorch%2Fexecutorch