### PR TITLE
[Nova] Escape forward slashes in ref name

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -95,8 +95,9 @@ runs:
         run: |
           set -euxo pipefail
           # Set artifact name here since github actions doesn't have string manipulation tools
-          # and "/" is not allowed in artifact names
-          echo "ARTIFACT_NAME=${REPOSITORY/\//_}_${REF/\//_}_${PYTHON_VERSION}_${CU_VERSION}_${ARCH}" >> "${GITHUB_ENV}"
+          # and "/" is not allowed in artifact names. //\//_ is to replace all forward slashes,
+          # not just the first one
+          echo "ARTIFACT_NAME=${REPOSITORY//\//_}_${REF//\//_}_${PYTHON_VERSION}_${CU_VERSION}_${ARCH}" >> "${GITHUB_ENV}"
       - name: Setup miniconda (for pytorch_pkg_helpers)
         if: ${{ inputs.setup-miniconda == 'true' }}
         uses: conda-incubator/setup-miniconda@v2.1.1

--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -96,7 +96,7 @@ runs:
           set -euxo pipefail
           # Set artifact name here since github actions doesn't have string manipulation tools
           # and "/" is not allowed in artifact names
-          echo "ARTIFACT_NAME=${REPOSITORY/\//_}_${REF}_${PYTHON_VERSION}_${CU_VERSION}_${ARCH}" >> "${GITHUB_ENV}"
+          echo "ARTIFACT_NAME=${REPOSITORY/\//_}_${REF/\//_}_${PYTHON_VERSION}_${CU_VERSION}_${ARCH}" >> "${GITHUB_ENV}"
       - name: Setup miniconda (for pytorch_pkg_helpers)
         if: ${{ inputs.setup-miniconda == 'true' }}
         uses: conda-incubator/setup-miniconda@v2.1.1

--- a/.github/actions/setup-binary-upload/action.yml
+++ b/.github/actions/setup-binary-upload/action.yml
@@ -50,8 +50,9 @@ runs:
         set -ex
 
         # Set artifact name here since github actions doesn't have string manipulation tools
-        # and "/" is not allowed in artifact names
-        echo "ARTIFACT_NAME=${REPOSITORY/\//_}_${REF/\//_}_${PYTHON_VERSION}_${CU_VERSION}_${ARCH}" >> "${GITHUB_ENV}"
+        # and "/" is not allowed in artifact names. //\//_ is to replace all forward slashes,
+        # not just the first one
+        echo "ARTIFACT_NAME=${REPOSITORY//\//_}_${REF//\//_}_${PYTHON_VERSION}_${CU_VERSION}_${ARCH}" >> "${GITHUB_ENV}"
 
     # Need to checkout the target repository to run pkg-helpers
     - uses: actions/checkout@v4

--- a/.github/actions/setup-binary-upload/action.yml
+++ b/.github/actions/setup-binary-upload/action.yml
@@ -51,7 +51,7 @@ runs:
 
         # Set artifact name here since github actions doesn't have string manipulation tools
         # and "/" is not allowed in artifact names
-        echo "ARTIFACT_NAME=${REPOSITORY/\//_}_${REF}_${PYTHON_VERSION}_${CU_VERSION}_${ARCH}" >> "${GITHUB_ENV}"
+        echo "ARTIFACT_NAME=${REPOSITORY/\//_}_${REF/\//_}_${PYTHON_VERSION}_${CU_VERSION}_${ARCH}" >> "${GITHUB_ENV}"
 
     # Need to checkout the target repository to run pkg-helpers
     - uses: actions/checkout@v4

--- a/.github/workflows/test_build_wheels_linux_without_cuda.yml
+++ b/.github/workflows/test_build_wheels_linux_without_cuda.yml
@@ -44,4 +44,7 @@ jobs:
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       package-name: ${{ matrix.package-name }}
       trigger-event: "${{ github.event_name }}"
-      build-platform: 'python-build-package'
+      build-platform: python-build-package
+      pip-install-torch-extra-args:
+        torchvision
+        torchao

--- a/.github/workflows/test_build_wheels_m1.yml
+++ b/.github/workflows/test_build_wheels_m1.yml
@@ -22,7 +22,6 @@ jobs:
       os: macos-arm64
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
-
   test:
     needs: generate-matrix
     strategy:
@@ -56,18 +55,3 @@ jobs:
       trigger-event: "${{ github.event_name }}"
       cache-path: ${{ matrix.cache-path }}
       cache-key: ${{ matrix.cache-key }}
-
-  test-artifact-name:
-    needs: generate-matrix
-    uses: ./.github/workflows/build_wheels_macos.yml
-    name: pytorch/ao
-    with:
-      repository: pytorch/ao
-      ref: drisspg/stack/31
-      test-infra-repository: pytorch/test-infra
-      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      pre-script: packaging/pre_build_script.sh
-      smoke-test-script: test/smoke_test.py
-      runner-type: macos-m1-stable
-      package-name: torchao
-      trigger-event: "${{ github.event_name }}"

--- a/.github/workflows/test_build_wheels_m1.yml
+++ b/.github/workflows/test_build_wheels_m1.yml
@@ -22,6 +22,7 @@ jobs:
       os: macos-arm64
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
+
   test:
     needs: generate-matrix
     strategy:
@@ -55,3 +56,18 @@ jobs:
       trigger-event: "${{ github.event_name }}"
       cache-path: ${{ matrix.cache-path }}
       cache-key: ${{ matrix.cache-key }}
+
+  test-artifact-name:
+    needs: generate-matrix
+    uses: ./.github/workflows/build_wheels_macos.yml
+    name: ${{ matrix.repository }}
+    with:
+      repository: pytorch/ao
+      ref: drisspg/stack/31
+      test-infra-repository: pytorch/test-infra
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      pre-script: packaging/pre_build_script.sh
+      smoke-test-script: test/smoke_test.py
+      runner-type: macos-m1-stable
+      package-name: torchao
+      trigger-event: "${{ github.event_name }}"

--- a/.github/workflows/test_build_wheels_m1.yml
+++ b/.github/workflows/test_build_wheels_m1.yml
@@ -60,7 +60,7 @@ jobs:
   test-artifact-name:
     needs: generate-matrix
     uses: ./.github/workflows/build_wheels_macos.yml
-    name: ${{ matrix.repository }}
+    name: pytorch/ao
     with:
       repository: pytorch/ao
       ref: drisspg/stack/31

--- a/.github/workflows/test_build_wheels_windows_with_cuda.yml
+++ b/.github/workflows/test_build_wheels_windows_with_cuda.yml
@@ -46,7 +46,6 @@ jobs:
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
       env-script: ${{ matrix.env-script }}
-      wheel-build-params: ${{ matrix.wheel-build-params }}
       post-script: ${{ matrix.post-script }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
       package-name: ${{ matrix.package-name }}

--- a/.github/workflows/test_build_wheels_windows_with_cuda.yml
+++ b/.github/workflows/test_build_wheels_windows_with_cuda.yml
@@ -28,11 +28,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - repository: pytorch/audio
-          env-script: packaging/vc_env_helper.bat
-          wheel-build-params: "--plat-name win_amd64"
-          smoke-test-script: test/smoke_test/smoke_test.py
-          package-name: torchaudio
         - repository: pytorch/vision
           pre-script: packaging/pre_build_script.sh
           env-script: packaging/windows/internal/vc_env_helper.bat


### PR DESCRIPTION
As reported by @drisspg where his build fails because the ref includes some forward slashes https://github.com/pytorch/ao/actions/runs/13275832470/job/37065164277

@drisspg I add your ref as a test case, so please keep it around instead of deleting it.  I wonder if this is a smart thing to include.

### Testing

https://github.com/pytorch/test-infra/actions/runs/13281773348/job/37081535345?pr=6281