### PR TITLE
[ez] rstrip comments in alert messages

### DIFF
--- a/tools/torchci/check_alerts.py
+++ b/tools/torchci/check_alerts.py
@@ -322,7 +322,7 @@ def gen_update_comment(original_issue: Dict[str, Any], jobs: List[JobStatus]) ->
         s += "These jobs started failing:\n"
         for job in started_failing_jobs:
             s += f"* {job}\n"
-    return s
+    return s.rstrip()
 
 
 def generate_no_flaky_tests_issue() -> Any:

--- a/tools/torchci/queue_alert.py
+++ b/tools/torchci/queue_alert.py
@@ -45,7 +45,7 @@ def gen_update_comment(original_issue: Any, new_queues: List[QueueInfo]) -> str:
         for q in started_queueing:
             s += gen_queue_info_str(q)
         s += "\n"
-    return s
+    return s.rstrip()
 
 
 def gen_issue(queues: List[QueueInfo]) -> Any:


### PR DESCRIPTION
Super small, but it creates unnecessary new lines in the messages which takes up space in workchat