### PR TITLE
Avoid overwriting the default test times if the new default is empty

### DIFF
--- a/tools/torchci/tests/test_update_test_times.py
+++ b/tools/torchci/tests/test_update_test_times.py
@@ -80,6 +80,12 @@ class TestUpdateTestTimesFile(unittest.TestCase):
         }
         self.assertDictEqual(res, expected)
 
+        data = []
+        res = gen_test_file_times(data, {"default": {"config": {"a": 57}}})
+        # When having no data, the old default should be kept
+        expected = {"default": {"config": {"a": 57}}}
+        self.assertDictEqual(res, expected)
+
     def test_gen_test_file_times_old_values_still_present(self) -> None:
         data = [
             self.make_db_row("env", "config", "a", 5),

--- a/tools/torchci/update_test_times.py
+++ b/tools/torchci/update_test_times.py
@@ -97,11 +97,17 @@ def gen_test_file_times(db_results, old_test_times):
     for test, times in test_times_no_test_config.items():
         test_times_no_test_config[test] = sum(times) / len(times)
 
-    # Default should never be a build env
-    test_times["default"] = test_times_no_build_env
-    # Replace default's default with our own to account for tests that aren't
-    # usually in the default test config like distributed
-    test_times["default"]["default"] = test_times_no_test_config
+    # Avoid overwriting the default if the new default is empty
+    if test_times_no_build_env:
+        # Default should never be a build env
+        test_times["default"] = test_times_no_build_env
+
+    # Avoid overwriting the default if the new default is empty
+    if test_times_no_test_config:
+        # Replace default's default with our own to account for tests that aren't
+        # usually in the default test config like distributed
+        test_times["default"]["default"] = test_times_no_test_config
+
     return test_times
 
 
@@ -136,11 +142,17 @@ def gen_test_class_times(db_results, old_test_times):
         for testclass, times in test_times_no_test_config[file].items():
             test_times_no_test_config[file][testclass] = sum(times) / len(times)
 
-    # Default should never be a build env
-    test_times["default"] = test_times_no_build_env
-    # Replace default's default with our own to account for tests that aren't
-    # usually in the default test config like distributed
-    test_times["default"]["default"] = test_times_no_test_config
+    # Avoid overwriting the default if the new default is empty
+    if test_times_no_build_env:
+        # Default should never be a build env
+        test_times["default"] = test_times_no_build_env
+
+    # Avoid overwriting the default if the new default is empty
+    if test_times_no_test_config:
+        # Replace default's default with our own to account for tests that aren't
+        # usually in the default test config like distributed
+        test_times["default"]["default"] = test_times_no_test_config
+
     return test_times
 
 


### PR DESCRIPTION
Due to the recent issue with https://github.com/octokit/request-action/issues/315, the workflow to upload test stats was broken for a few days.  The issue has been mitigated by https://github.com/pytorch/pytorch/pull/146940, but we still have a gap in test times until new stats come in.

The test times from the last 3 viable/strict commits were used to compute test times https://github.com/pytorch/test-infra/blob/main/torchci/clickhouse_queries/test_time_per_file/query.sql#L11-L12

The `tools/torchci/update_test_times.py` script had a bug in which it overwrote the default test times even when there was no stats from the above query. The effect of this was that [run_test](https://github.com/pytorch/pytorch/blob/main/test/run_test.py#L1909-L1936) had no default values to use in some cases, forcing these jobs to run sequentially, for example:

* https://github.com/pytorch/pytorch/actions/runs/13295462436/job/37129445091#step:22:670
* https://github.com/pytorch/pytorch/actions/runs/13297960390/job/37134948183#step:8:100

(Notice that they all had just 1/1 shard)

The proposed fix here is to keep the old default values when there is no new stats.  We could also, maybe, create a metric for this so that we can monitor the age of the default test times.
