### PR TITLE
Revert "remove visual studio 2019 install in test infra"

### DIFF
--- a/aws/ami/windows/windows.pkr.hcl
+++ b/aws/ami/windows/windows.pkr.hcl
@@ -68,6 +68,15 @@ build {
     ]
   }
 
+  # Install the Visual Studio 2019
+  provisioner "powershell" {
+    environment_vars = ["INSTALL_WINDOWS_SDK=1", "VS_YEAR=2019", "VS_VERSION=16.11.21", "VS_UNINSTALL_PREVIOUS=1"]
+    execution_policy = "unrestricted"
+    scripts = [
+      "${path.root}/scripts/Installers/Install-VS.ps1",
+    ]
+  }
+
   # Install the Visual Studio 2022
   provisioner "powershell" {
     environment_vars = ["INSTALL_WINDOWS_SDK=1", "VS_YEAR=2022", "VS_VERSION=17.4.1", "VS_UNINSTALL_PREVIOUS=0"]


### PR DESCRIPTION
Reverts pytorch/test-infra#6226

Reverting to unblock Cuda 12.8 migration. Looks like we would need to step back and do some more testing on pytorch-canary before relanding this see the failure: https://github.com/pytorch/pytorch/pull/147053