### PR TITLE
Add g4dn.4xlarge runners for testing Cuda 12.8 builds

### DIFF
--- a/.github/canary-scale-config.yml
+++ b/.github/canary-scale-config.yml
@@ -98,6 +98,11 @@ runner_types:
     instance_type: g3.8xlarge
     is_ephemeral: false
     os: linux
+  c.linux.g4dn.4xlarge.nvidia.gpu:
+    disk_size: 150
+    instance_type: g4dn.4xlarge
+    is_ephemeral: false
+    os: linux
   c.linux.g4dn.12xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g4dn.12xlarge

--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -102,6 +102,11 @@ runner_types:
     instance_type: g3.8xlarge
     is_ephemeral: false
     os: linux
+  lf.c.linux.g4dn.4xlarge.nvidia.gpu:
+    disk_size: 150
+    instance_type: g4dn.4xlarge
+    is_ephemeral: false
+    os: linux
   lf.c.linux.g4dn.12xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g4dn.12xlarge

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -97,6 +97,11 @@ runner_types:
     instance_type: g3.4xlarge
     is_ephemeral: false
     os: linux
+  lf.linux.g4dn.4xlarge.nvidia.gpu:
+    disk_size: 150
+    instance_type: g4dn.4xlarge
+    is_ephemeral: false
+    os: linux
   lf.linux.8xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g3.8xlarge

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -103,6 +103,11 @@ runner_types:
     instance_type: g4dn.12xlarge
     is_ephemeral: false
     os: linux
+  linux.g4dn.4xlarge.nvidia.gpu:
+    disk_size: 150
+    instance_type: g4dn.4xlarge
+    is_ephemeral: false
+    os: linux
   linux.g4dn.metal.nvidia.gpu:
     disk_size: 150
     instance_type: g4dn.metal


### PR DESCRIPTION
See: https://github.com/pytorch/pytorch/issues/145544#issuecomment-2644049797
We need bigger runner to test these architectures