### PR TITLE
Always upload mobile artifacts if they are found

### DIFF
--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -336,7 +336,7 @@ jobs:
 
       - name: Upload iOS artifacts to S3
         uses: seemethere/upload-artifact-s3@v5
-        if: ${{ inputs.device-type == 'ios' }}
+        if: always()
         with:
           retention-days: 14
           s3-bucket: gha-artifacts
@@ -387,7 +387,7 @@ jobs:
 
       - name: Upload Android artifacts to S3
         uses: seemethere/upload-artifact-s3@v5
-        if: ${{ inputs.device-type == 'android' }}
+        if: always()
         with:
           retention-days: 14
           s3-bucket: gha-artifacts


### PR DESCRIPTION
This is the first step to fix https://github.com/pytorch/executorch/issues/7989.  We need to always upload mobile artifacts if they are found.  I think I will also need to update https://github.com/pytorch/executorch/blob/main/.github/scripts/extract_benchmark_results.py after this to handle the failure case, but it can come after this change.

### Testing

The upload steps are always run but will give a warning if there is no file https://github.com/pytorch/test-infra/actions/runs/13404882215/job/37442926309#step:14:27