### PR TITLE
Validate Manylinux 2.28 builds using almalinux-builder image

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -1,4 +1,5 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+export DESIRED_DEVTOOLSET="cxx11-abi"
 
 if [[ ${MATRIX_PACKAGE_TYPE} == "libtorch" ]]; then
     curl ${MATRIX_INSTALLATION} -o libtorch.zip
@@ -78,13 +79,9 @@ else
 
     pushd ${PWD}/.ci/pytorch/
 
-    if [[ ${MATRIX_GPU_ARCH_VERSION} == "12.6" || ${MATRIX_GPU_ARCH_TYPE} == "xpu" || ${MATRIX_GPU_ARCH_TYPE} == "rocm" ]]; then
-        export DESIRED_DEVTOOLSET="cxx11-abi"
-
-        # TODO: enable torch-compile on ROCM
-        if [[ ${MATRIX_GPU_ARCH_TYPE} == "rocm" ]]; then
-            TEST_SUFFIX=${TEST_SUFFIX}" --torch-compile-check disabled"
-        fi
+    # TODO: enable torch-compile on ROCM
+    if [[ ${MATRIX_GPU_ARCH_TYPE} == "rocm" ]]; then
+        TEST_SUFFIX=${TEST_SUFFIX}" --torch-compile-check disabled"
     fi
 
     if [[ ${TARGET_OS} == 'linux' ]]; then

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -134,7 +134,7 @@ jobs:
       repository: "pytorch/pytorch"
       ref: main
       job-name: ${{ matrix.build_name }}
-      docker-image: ${{ ((matrix.gpu_arch_type == 'xpu' || matrix.gpu_arch_type == 'rocm') && matrix.container_image) || (matrix.gpu_arch_version == '12.6' && 'pytorch/almalinux-builder:cpu-main') || 'pytorch/conda-builder' }}
+      docker-image: ${{ ((matrix.gpu_arch_type == 'xpu' || matrix.gpu_arch_type == 'rocm') && matrix.container_image) || 'pytorch/almalinux-builder:cpu-main' }}
       binary-matrix: ${{ toJSON(matrix) }}
       docker-build-dir: "skip-docker-build"
       timeout: 180


### PR DESCRIPTION
For release 2.6 we restricted Manylinux 2.28 builds to cuda 12.6 only. Now its time to remove this restriction and use cxx11-abi=1 by default