### PR TITLE
[HUD] Add scroll to for commit link in job links, add highlight, fix commit link for non pytorch repos

### DIFF
--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -24,7 +24,7 @@ export default function JobLinks({
       <a
         target="_blank"
         rel="noreferrer"
-        href={`/pytorch/pytorch/commit/${job.sha}#${job.id}-box`}
+        href={`/${job.repo}/commit/${job.sha}#${job.id}-box`}
       >
         Commit
       </a>

--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -24,7 +24,7 @@ export default function JobLinks({
       <a
         target="_blank"
         rel="noreferrer"
-        href={`/pytorch/pytorch/commit/${job.sha}`}
+        href={`/pytorch/pytorch/commit/${job.sha}#${job.id}-box`}
       >
         Commit
       </a>

--- a/torchci/lib/useScrollTo.ts
+++ b/torchci/lib/useScrollTo.ts
@@ -8,6 +8,7 @@ export default function useScrollTo() {
     if (id != null) {
       const job = document.getElementById(id);
       window.scrollTo({ top: job?.offsetTop, behavior: "smooth" });
+      job?.style.setProperty("background-color", "LightYellow");
     }
   }, [router.asPath]);
 }


### PR DESCRIPTION
Not sure if this is a good idea but

Adds anchor to the link so that it will scroll to the job when the commit link is clicked and the job will get highlighted

For reference, the commit link looks like
<img width="516" alt="image" src="https://github.com/user-attachments/assets/fe739233-02a5-4402-aaae-e08e144e6a62" />
in the job tooltip on HUD.  It is also present in a few other places, like the failures page

Clicking on the commit link will now go to the commit page, scroll to the job, and highlight the job

Highlight example:
<img width="371" alt="image" src="https://github.com/user-attachments/assets/8d810c29-2cd4-4616-9bd7-003125e5feb4" />

This will also highlight jobs when clicking on links from Dr. CI:
<img width="764" alt="image" src="https://github.com/user-attachments/assets/5b900b8a-4e28-4a8a-a006-d9fe95490a9a" />


---

Also fix link for non pytorch repos