### PR TITLE
Remove sha256 from index for nightlies

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -382,7 +382,8 @@ class S3Index:
         out.append('  <body>')
         out.append('    <h1>Links for {}</h1>'.format(package_name.lower().replace("_", "-")))
         for obj in sorted(self.gen_file_list(subdir, package_name)):
-            maybe_fragment = f"#sha256={obj.checksum}" if obj.checksum else ""
+            # maybe_fragment = f"#sha256={obj.checksum}" if obj.checksum else ""
+            maybe_fragment = ""
             pep658_attribute = ""
             if obj.pep658:
                 pep658_sha = f"sha256={obj.pep658}"

--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -382,8 +382,9 @@ class S3Index:
         out.append('  <body>')
         out.append('    <h1>Links for {}</h1>'.format(package_name.lower().replace("_", "-")))
         for obj in sorted(self.gen_file_list(subdir, package_name)):
-            # maybe_fragment = f"#sha256={obj.checksum}" if obj.checksum else ""
-            maybe_fragment = ""
+            # Do not include checksum for nightly packages, see
+            # https://github.com/pytorch/test-infra/pull/6307
+            maybe_fragment = f"#sha256={obj.checksum}" if obj.checksum and not obj.orig_key.startswith("whl/nightly") else ""
             pep658_attribute = ""
             if obj.pep658:
                 pep658_sha = f"sha256={obj.pep658}"


### PR DESCRIPTION
The cloudfront cache sometimes serves old versions of the whl but the index will have the sha of the new wheel, resulting in errors where pip says
```
ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE. If you have updated the package versions, please update the hashes. Otherwise, examine the package contents carefully; someone may have tampered with them.
    unknown package:
        Expected sha[256](https://github.com/pytorch/FBGEMM/actions/runs/13420201693/job/37492521940#step:14:257) 7dc1686d7207eb3eb340b5bc7e6076d41acebd6013cf4f32d4afbab7c97aa579
             Got        fb8cf5ad5e1c2d0fd3a1fb8ad3beec5f86c527d2e7cdb6842226ebf24178d1e0
```

like https://github.com/pytorch/FBGEMM/actions/runs/13420201693/job/37492521940

The error eventually gets fixed when the cache stops serving the old whl, and we can speed this up by invalidating the cache, but it's still causing failures in the meantime, so this PR removes the hash until we can figure out a better way to deal with this.  Maybe automatically invalidating the cache or specifying versions?