### PR TITLE
Optimize query for getting flaky test info

### DIFF
--- a/torchci/pages/api/flaky-tests/failures.ts
+++ b/torchci/pages/api/flaky-tests/failures.ts
@@ -21,46 +21,68 @@ async function getFlakyTestInfo(
   limit: number
 ): Promise<JobData[]> {
   const query = `
-select
-  t.name as name,
-  t.classname as classname,
-  t.file as file,
-  t.invoking_file as invoking_file,
-  j.conclusion as conclusion,
-  j.id as job_id,
-  j.name as job_name,
-  j.html_url as job_url,
-  j.started_at as job_started_at,
-  j.torchci_classification.'line' as line,
-  j.torchci_classification.'line_num' as line_num,
-  j.torchci_classification.'captures' as captures,
-  w.head_branch as head_branch,
-  j.head_sha as head_sha
-from
-  default.workflow_job j
-  join default.failed_test_runs t on j.id = t.job_id
-  join default.workflow_run w on w.id = j.run_id
-where
-  t.name = {name: String}
-  and t.classname = {suite: String}
-  and t.file = {file: String}
-group by
-  t.name,
-  t.classname,
-  t.file,
-  t.invoking_file,
-  j.conclusion,
-  j.id,
-  j.name,
-  j.html_url,
-  j.started_at,
-  j.torchci_classification.'line',
-  j.torchci_classification.'line_num',
-  j.torchci_classification.'captures',
-  w.head_branch,
-  j.head_sha
-order by
-  j.started_at desc
+WITH failed_test_runs as (
+    SELECT
+        t.name AS name,
+        t.classname AS classname,
+        t.file AS file,
+        t.invoking_file AS invoking_file,
+        t.job_id
+    FROM default.failed_test_runs AS t
+    WHERE
+      t.name = {name: String}
+      and t.classname = {suite: String}
+      and t.file = {file: String}),
+failed_jobs AS (
+    SELECT
+        j.conclusion AS conclusion,
+        j.id AS id,
+        j.run_id AS run_id,
+        j.name AS name,
+        j.html_url AS html_url,
+        j.started_at AS started_at,
+        tupleElement(j.torchci_classification, 'line') AS line,
+        tupleElement(j.torchci_classification, 'line_num') AS line_num,
+        tupleElement(j.torchci_classification, 'captures') AS captures,
+        j.head_sha AS head_sha
+    FROM default.workflow_job AS j
+    WHERE
+        j.id IN (SELECT t.job_id from failed_test_runs t)
+)
+SELECT
+    t.name AS name,
+    t.classname AS classname,
+    t.file AS file,
+    t.invoking_file AS invoking_file,
+    j.conclusion AS conclusion,
+    j.id AS job_id,
+    j.name AS job_name,
+    j.html_url AS job_url,
+    j.started_at AS job_started_at,
+    j.line,
+    j.line_num,
+    j.captures,
+    w.head_branch AS head_branch,
+    j.head_sha AS head_sha
+FROM failed_jobs AS j
+    INNER JOIN failed_test_runs AS t ON j.id = t.job_id
+    INNER JOIN default.workflow_run AS w ON w.id = j.run_id
+GROUP BY
+    t.name,
+    t.classname,
+    t.file,
+    t.invoking_file,
+    j.conclusion,
+    j.id,
+    j.name,
+    j.html_url,
+    j.started_at,
+    j.line,
+    j.line_num,
+    j.captures,
+    w.head_branch AS head_branch,
+    j.head_sha
+ORDER BY j.started_at DESC
 limit
   {limit: Int32}
 `;

--- a/torchci/pages/api/flaky-tests/failures.ts
+++ b/torchci/pages/api/flaky-tests/failures.ts
@@ -49,7 +49,7 @@ failed_jobs AS (
     WHERE
         j.id IN (SELECT t.job_id from failed_test_runs t)
 )
-SELECT
+SELECT DISTINCT
     t.name AS name,
     t.classname AS classname,
     t.file AS file,
@@ -67,21 +67,6 @@ SELECT
 FROM failed_jobs AS j
     INNER JOIN failed_test_runs AS t ON j.id = t.job_id
     INNER JOIN default.workflow_run AS w ON w.id = j.run_id
-GROUP BY
-    t.name,
-    t.classname,
-    t.file,
-    t.invoking_file,
-    j.conclusion,
-    j.id,
-    j.name,
-    j.html_url,
-    j.started_at,
-    j.line,
-    j.line_num,
-    j.captures,
-    w.head_branch AS head_branch,
-    j.head_sha
 ORDER BY j.started_at DESC
 limit
   {limit: Int32}

--- a/torchci/pages/api/flaky-tests/failures.ts
+++ b/torchci/pages/api/flaky-tests/failures.ts
@@ -59,9 +59,9 @@ SELECT DISTINCT
     j.name AS job_name,
     j.html_url AS job_url,
     j.started_at AS job_started_at,
-    j.line,
-    j.line_num,
-    j.captures,
+    j.line AS line,
+    j.line_num AS line_num,
+    j.captures AS captures,
     w.head_branch AS head_branch,
     j.head_sha AS head_sha
 FROM failed_jobs AS j


### PR DESCRIPTION
This was an experiment on taking one of our slower queries (identified by the ClickHouse query insights table) and seeing what it would take to bring this into a more reasonable performance level

Perf improvements:
* Duration reduced 91%: 14.5s -> 1.29s
* Memory reduced 96%: 22.63GB -> 0.95GB 
* Rows read reduced 55%: 68.4 million -> 30.7 million

**Naive joins can be incredibly expensive in ClickHouse**. Turns out the biggest chunk of work here was happening in the join between `default.workflow_job` and `default.failed_test_runs`.

An example api call to hit against the prod and test endpoints:
- http://hud.pytorch.org/api/flaky-tests/failures?name=test_Tensor___bool__&suite=TestTorchFunctionOverride&file=test_overrides.py
vs
- https://torchci-git-zainr-optimizeflakytestquery-fbopensource.vercel.app/api/flaky-tests/failures?name=test_Tensor___bool__&suite=TestTorchFunctionOverride&file=test_overrides.py

## Key Experimental Steps
I had to play around with the query to figure out where optimizations were possible. Here the part of the process that led to discovering this optimization
1. Started separating out the select statements to see how much time/memory reading each table took when not doing joins.  This showed the `default.failed_test_runs` query read many rows but was still an very fast read and normally only returned a few results.
2. Inspected each table's schema to see how well their sort orders (indexes) aligned with the query.  
3. Discovered the id column was the primary sort mechanism in `default.workflow_job`.  This is also the join key with `failed_test_runs`. An ideal filtering opportunity, but CH joins were not optimizing these. 
4. Tried to pre-filter the `workflow_job` table before attempting a join by creating a subquery and using a `WHERE j.id IN (SELECT t.job_id from failed_test_runs t)` clause. Now there would be way less data that the join needs to be run over and this led to the huge performance increase

## Lesson: Pre-filter before JOINS 
  * JOINs in ClickHouse can benefit from shrinking the input tables as much as possible before hand. 
  * CH explicitly says to keep the smaller table on the right hand side of a join, but also shrinking the left-hand side as much as possible can yield future wins.
  * Clauses like `WHERE foo in (SELECT foo_id from bar)` can be efficient here
  * Experiment! Trying to prefilter the `default.workflow_run` table didn't help performance but did muddy the query's legibility significantly.  It was better to leave that as a simple join.
 
## Potential additional optimizations 
I didn't try these since this query hit the point of diminishing returns and these would have required tweaking the table schema, but here are extra avenues that could have been explored for eking out further wins:
* Add an additional index (in CH parlance: a projection) to `default.failed_test_runs` where the test file name and class are the primary sort keys instead of the job id, which would reduce the rows read by a much larger amount.  That read takes ~0.5s today.
* Reduce the range of data queried to the past X months. However, timestamps are not right now