### PR TITLE
Adding runner linux.12xlarge.memory.ephemeral

### DIFF
--- a/.github/canary-scale-config.yml
+++ b/.github/canary-scale-config.yml
@@ -218,3 +218,8 @@ runner_types:
     instance_type: r5.12xlarge
     is_ephemeral: false
     os: linux
+  c.linux.12xlarge.memory.ephemeral:
+    disk_size: 400
+    instance_type: r5.12xlarge
+    is_ephemeral: true
+    os: linux

--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -222,3 +222,8 @@ runner_types:
     instance_type: r5.12xlarge
     is_ephemeral: false
     os: linux
+  lf.c.linux.12xlarge.memory.ephemeral:
+    disk_size: 400
+    instance_type: r5.12xlarge
+    is_ephemeral: true
+    os: linux

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -222,3 +222,8 @@ runner_types:
     instance_type: r5.12xlarge
     is_ephemeral: false
     os: linux
+  lf.linux.12xlarge.memory.ephemeral:
+    disk_size: 400
+    instance_type: r5.12xlarge
+    is_ephemeral: true
+    os: linux

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -218,3 +218,8 @@ runner_types:
     instance_type: r5.12xlarge
     is_ephemeral: false
     os: linux
+  linux.12xlarge.memory.ephemeral:
+    disk_size: 400
+    instance_type: r5.12xlarge
+    is_ephemeral: true
+    os: linux


### PR DESCRIPTION
This runner is to be used for binary builds as identified in https://github.com/pytorch/pytorch/pull/147542