### PR TITLE
torchi: Remove unprivileged access to ciflow

### DIFF
--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -474,7 +474,8 @@ The explanation needs to be clear on why this is needed. Here are some good exam
     ) {
       return await this.addComment(
         "Only people with write access to the repo can add these labels: " +
-          write_required_labels.join(", ") + ciflowLabels.join(", ") +
+          write_required_labels.join(", ") +
+          ciflowLabels.join(", ") +
           ". Please ping one of the reviewers for help."
       );
     }

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -463,32 +463,22 @@ The explanation needs to be clear on why this is needed. Here are some good exam
       )
     );
 
+    // Punt all requests for applying labels that we've blocklisted or ciflow labels
+    // > Why block ciflow labels?
+    // > Giving unprivileged users the ability to apply ciflow labels gives them the ability to
+    // > bypass our protections for workflow approvals potentially allowing them to run workflows
+    // > when they shouldn't be allowed to run workflows.
     if (
-      write_required_labels.length > 0 &&
+      (write_required_labels.length > 0 || ciflowLabels.length > 0) &&
       !(await this.hasWritePermissions(ctx.payload?.comment?.user?.login))
     ) {
       return await this.addComment(
         "Only people with write access to the repo can add these labels: " +
-          write_required_labels.join(", ") +
+          write_required_labels.join(", ") + ciflowLabels.join(", ") +
           ". Please ping one of the reviewers for help."
       );
     }
 
-    if (
-      ciflowLabels.length > 0 &&
-      !(await this.hasWorkflowRunningPermissions(
-        ctx.payload?.comment?.user?.login
-      ))
-    ) {
-      return await this.addComment(
-        "To add these label(s) (" +
-          ciflowLabels.join(", ") +
-          ") to the PR, please first approve the " +
-          "workflows that are awaiting approval (scroll to the bottom of this page).\n\n" +
-          "This helps ensure we don't trigger CI on this PR until it is actually authorized to do so. " +
-          "Please ping one of the reviewers if you do not have access to approve and run workflows."
-      );
-    }
     if (invalidLabels.length > 0) {
       await this.addComment(
         "Didn't find following labels among repository labels: " +


### PR DESCRIPTION
Removes the ability for users who are unprivileged to apply ciflow labels to PRs. This is a potential security risk since it allows for the following workflow:

* Users submits benign PR
* Maintainer approves workflows to be run
* User modifies PR to include malicious code in workflows triggered by ciflow
* User uses `@pytorchbot label ciflow/<bleh>` to apply ciflow labels