### PR TITLE
[bots] Check for permissions when syncing ciflow

### DIFF
--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -1,4 +1,5 @@
 import { Context, Probot } from "probot";
+import { canRunWorkflows } from "./autoLabelBot";
 import {
   CachedConfigTracker,
   hasApprovedPullRuns,
@@ -88,6 +89,11 @@ async function handleSyncEvent(
   payload: Context<"pull_request">["payload"]
 ) {
   context.log.debug("START Processing sync event");
+
+  if (!(await canRunWorkflows(context as any))) {
+    context.log.info("PR does not have permissions to run workflows");
+    return;
+  }
 
   const headSha = payload.pull_request.head.sha;
   const tags = getAllPRTags(context, payload);

--- a/torchci/test/ciflow-push-trigger.test.ts
+++ b/torchci/test/ciflow-push-trigger.test.ts
@@ -1,6 +1,7 @@
 import ciflowPushTrigger from "lib/bot/ciflowPushTrigger";
 import nock from "nock";
 import { Probot, ProbotOctokit } from "probot";
+import { mockApprovedWorkflowRuns, mockHasApprovedWorkflowRun, mockPermissions } from "./utils";
 
 nock.disableNetConnect();
 
@@ -179,6 +180,8 @@ describe("Push trigger integration tests", () => {
       "ciflow/1",
     ];
 
+    mockHasApprovedWorkflowRun(payload.repository.full_name);
+
     for (const label of labels) {
       nock("https://api.github.com")
         .get(
@@ -216,6 +219,21 @@ describe("Push trigger integration tests", () => {
         })
         .reply(200);
     }
+    await probot.receive({ name: "pull_request", id: "123", payload });
+  });
+
+  test("synchronization of PR requires permissions", async () => {
+    const payload = require("./fixtures/push-trigger/pull_request.synchronize");
+    mockApprovedWorkflowRuns(
+      payload.repository.full_name,
+      payload.pull_request.head.sha,
+      false
+    );
+    mockPermissions(
+      payload.repository.full_name,
+      payload.pull_request.user.login,
+      "read"
+    );
     await probot.receive({ name: "pull_request", id: "123", payload });
   });
 

--- a/torchci/test/ciflow-push-trigger.test.ts
+++ b/torchci/test/ciflow-push-trigger.test.ts
@@ -1,7 +1,11 @@
 import ciflowPushTrigger from "lib/bot/ciflowPushTrigger";
 import nock from "nock";
 import { Probot, ProbotOctokit } from "probot";
-import { mockApprovedWorkflowRuns, mockHasApprovedWorkflowRun, mockPermissions } from "./utils";
+import {
+  mockApprovedWorkflowRuns,
+  mockHasApprovedWorkflowRun,
+  mockPermissions,
+} from "./utils";
 
 nock.disableNetConnect();
 


### PR DESCRIPTION
As in title, check that a PR is able to run workflows when syncing (pushing a new commit)

The label stays on the PR, which might be a bit confusing