### PR TITLE
[bots] Remove ciflow labels on sync if no perms, follow up to #6328

### DIFF
--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -92,6 +92,16 @@ async function handleSyncEvent(
 
   if (!(await canRunWorkflows(context as any))) {
     context.log.info("PR does not have permissions to run workflows");
+    for (const label of payload.pull_request.labels) {
+      if (isCIFlowLabel(label.name)) {
+        await context.octokit.issues.removeLabel(
+          context.repo({
+            issue_number: payload.pull_request.number,
+            name: label.name,
+          })
+        );
+      }
+    }
     return;
   }
 

--- a/torchci/test/ciflow-push-trigger.test.ts
+++ b/torchci/test/ciflow-push-trigger.test.ts
@@ -9,6 +9,12 @@ import {
 
 nock.disableNetConnect();
 
+function mockDeleteLabel(repoFullName: string, number: number, label: string) {
+  return nock("https://api.github.com")
+    .delete(`/repos/${repoFullName}/issues/${number}/labels/${encodeURIComponent(label)}`)
+    .reply(200);
+}
+
 describe("Push trigger integration tests", () => {
   let probot: Probot;
   beforeEach(() => {
@@ -238,6 +244,16 @@ describe("Push trigger integration tests", () => {
       payload.pull_request.user.login,
       "read"
     );
+    mockDeleteLabel(
+      payload.repository.full_name,
+      payload.pull_request.number,
+      "ciflow/test"
+    );
+    mockDeleteLabel(
+      payload.repository.full_name,
+      payload.pull_request.number,
+      "ciflow/1"
+    )
     await probot.receive({ name: "pull_request", id: "123", payload });
   });
 

--- a/torchci/test/ciflow-push-trigger.test.ts
+++ b/torchci/test/ciflow-push-trigger.test.ts
@@ -11,7 +11,11 @@ nock.disableNetConnect();
 
 function mockDeleteLabel(repoFullName: string, number: number, label: string) {
   return nock("https://api.github.com")
-    .delete(`/repos/${repoFullName}/issues/${number}/labels/${encodeURIComponent(label)}`)
+    .delete(
+      `/repos/${repoFullName}/issues/${number}/labels/${encodeURIComponent(
+        label
+      )}`
+    )
     .reply(200);
 }
 
@@ -253,7 +257,7 @@ describe("Push trigger integration tests", () => {
       payload.repository.full_name,
       payload.pull_request.number,
       "ciflow/1"
-    )
+    );
     await probot.receive({ name: "pull_request", id: "123", payload });
   });
 


### PR DESCRIPTION
Follow up to #6328

Remove the ciflow labels on sync to reduce confusion

Cons:
* add more events to the PR timeline