### PR TITLE
Fix summary table for same commit on different devices

### DIFF
--- a/torchci/components/benchmark/compilers/ModelPanel.tsx
+++ b/torchci/components/benchmark/compilers/ModelPanel.tsx
@@ -75,7 +75,10 @@ export function ModelPanel({
   });
 
   // Combine with right data
-  if (lCommit !== rCommit && rData !== undefined) {
+  if (
+    (lDeviceName !== rDeviceName || lCommit !== rCommit) &&
+    rData !== undefined
+  ) {
     rData.forEach((record: CompilerPerformanceData) => {
       if (record.name in dataGroupedByModel) {
         dataGroupedByModel[record.name]["r"] = record;
@@ -241,7 +244,7 @@ export function ModelPanel({
                   return "";
                 }
 
-                if (lCommit === rCommit) {
+                if (lDeviceName === rDeviceName && lCommit === rCommit) {
                   return PASSING_ACCURACY.includes(v.l) ? "" : styles.warning;
                 } else {
                   if (
@@ -277,7 +280,10 @@ export function ModelPanel({
                       {v.l} (<strong>NEW!</strong>)
                     </>
                   );
-                } else if (lCommit === rCommit || v.l === v.r) {
+                } else if (
+                  (lDeviceName === rDeviceName && lCommit === rCommit) ||
+                  v.l === v.r
+                ) {
                   return v.l;
                 } else {
                   return `${v.r} → ${v.l}`;
@@ -297,7 +303,7 @@ export function ModelPanel({
                 const l = Number(v.l);
                 const r = Number(v.r);
 
-                if (lCommit === rCommit) {
+                if (lDeviceName === rDeviceName && lCommit === rCommit) {
                   return l >= SPEEDUP_THRESHOLD ? "" : styles.warning;
                 } else {
                   // l is the new value, r is the old value
@@ -334,7 +340,11 @@ export function ModelPanel({
                 const l = Number(v.l).toFixed(SCALE);
                 const r = Number(v.r).toFixed(SCALE);
 
-                if (lCommit === rCommit || l === r || v.r === 0) {
+                if (
+                  (lDeviceName === rDeviceName && lCommit === rCommit) ||
+                  l === r ||
+                  v.r === 0
+                ) {
                   return l;
                 } else {
                   return `${r} → ${l}`;
@@ -354,7 +364,7 @@ export function ModelPanel({
                 const l = Number(v.l);
                 const r = Number(v.r);
 
-                if (lCommit === rCommit) {
+                if (lDeviceName === rDeviceName && lCommit === rCommit) {
                   return "";
                 } else {
                   if (l === 0 || l === r) {
@@ -384,7 +394,11 @@ export function ModelPanel({
                 const l = Number(v.l).toFixed(0);
                 const r = Number(v.r).toFixed(0);
 
-                if (lCommit === rCommit || l === r || v.r === 0) {
+                if (
+                  (lDeviceName === rDeviceName && lCommit === rCommit) ||
+                  l === r ||
+                  v.r === 0
+                ) {
                   return l;
                 } else {
                   return `${r} → ${l}`;
@@ -404,7 +418,7 @@ export function ModelPanel({
                 const l = Number(v.l);
                 const r = Number(v.r);
 
-                if (lCommit === rCommit) {
+                if (lDeviceName === rDeviceName && lCommit === rCommit) {
                   return l >= COMPRESSION_RATIO_THRESHOLD ? "" : styles.warning;
                 } else {
                   if (l === 0 || l === r) {
@@ -438,7 +452,11 @@ export function ModelPanel({
                 const l = Number(v.l).toFixed(SCALE);
                 const r = Number(v.r).toFixed(SCALE);
 
-                if (lCommit === rCommit || l === r || v.r === 0) {
+                if (
+                  (lDeviceName === rDeviceName && lCommit === rCommit) ||
+                  l === r ||
+                  v.r === 0
+                ) {
                   return l;
                 } else {
                   return `${r} → ${l}`;
@@ -458,7 +476,7 @@ export function ModelPanel({
                 const l = Number(v.l);
                 const r = Number(v.r);
 
-                if (lCommit === rCommit) {
+                if (lDeviceName === rDeviceName && lCommit === rCommit) {
                   return "";
                 } else {
                   if (l === 0 || l === r) {
@@ -488,7 +506,11 @@ export function ModelPanel({
                 const l = Number(v.l).toFixed(SCALE);
                 const r = Number(v.r).toFixed(SCALE);
 
-                if (lCommit === rCommit || l === r || v.r === 0) {
+                if (
+                  (lDeviceName === rDeviceName && lCommit === rCommit) ||
+                  l === r ||
+                  v.r === 0
+                ) {
                   return l;
                 } else {
                   return `${r} → ${l}`;
@@ -508,7 +530,7 @@ export function ModelPanel({
                 const l = Number(v.l);
                 const r = Number(v.r);
 
-                if (lCommit === rCommit) {
+                if (lDeviceName === rDeviceName && lCommit === rCommit) {
                   return "";
                 } else {
                   if (l === 0 || l === r) {
@@ -538,7 +560,11 @@ export function ModelPanel({
                 const l = Number(v.l).toFixed(2);
                 const r = Number(v.r).toFixed(2);
 
-                if (lCommit === rCommit || l === r || v.r === 0) {
+                if (
+                  (lDeviceName === rDeviceName && lCommit === rCommit) ||
+                  l === r ||
+                  v.r === 0
+                ) {
                   return l;
                 } else {
                   return `${r} → ${l}`;

--- a/torchci/components/benchmark/compilers/SummaryPanel.tsx
+++ b/torchci/components/benchmark/compilers/SummaryPanel.tsx
@@ -65,8 +65,10 @@ function processSummaryData(
 
 function combineLeftAndRight(
   lCommit: string,
+  lDeviceName: string,
   lData: { [k: string]: any },
   rCommit: string,
+  rDeviceName: string,
   rData: { [k: string]: any },
   suites: string[]
 ) {
@@ -84,7 +86,7 @@ function combineLeftAndRight(
   });
 
   // Combine with right data
-  if (lCommit !== rCommit) {
+  if (lCommit !== rCommit || lDeviceName !== rDeviceName) {
     Object.keys(rData).forEach((compiler: string) => {
       if (!(compiler in data)) {
         data[compiler] = {
@@ -179,29 +181,37 @@ export function SummaryPanel({
   // Combine both sides
   const passrate = combineLeftAndRight(
     lCommit,
+    lDeviceName,
     lPassrate,
     rCommit,
+    rDeviceName,
     rPassrate,
     suites
   );
   const geomean = combineLeftAndRight(
     lCommit,
+    lDeviceName,
     lGeomean,
     rCommit,
+    rDeviceName,
     rGeomean,
     suites
   );
   const compTime = combineLeftAndRight(
     lCommit,
+    lDeviceName,
     lCompTime,
     rCommit,
+    rDeviceName,
     rCompTime,
     suites
   );
   const memory = combineLeftAndRight(
     lCommit,
+    lDeviceName,
     lMemory,
     rCommit,
+    rDeviceName,
     rMemory,
     suites
   );
@@ -259,7 +269,11 @@ export function SummaryPanel({
                       return "";
                     }
 
-                    if (lCommit === rCommit || l === r || r == undefined) {
+                    if (
+                      (lDeviceName === rDeviceName && lCommit === rCommit) ||
+                      l === r ||
+                      r == undefined
+                    ) {
                       return <a href={url}>{v.l}</a>;
                     } else {
                       return (
@@ -282,7 +296,10 @@ export function SummaryPanel({
                       return "";
                     }
 
-                    if (lCommit === rCommit || r === undefined) {
+                    if (
+                      (lDeviceName === rDeviceName && lCommit === rCommit) ||
+                      r === undefined
+                    ) {
                       return l >= ACCURACY_THRESHOLD ? "" : styles.warning;
                     } else {
                       if (l === r) {
@@ -348,7 +365,7 @@ export function SummaryPanel({
                     const r = Number(v.r).toFixed(SCALE);
 
                     if (
-                      lCommit === rCommit ||
+                      (lDeviceName === rDeviceName && lCommit === rCommit) ||
                       l === r ||
                       v.r === undefined ||
                       v.r === ""
@@ -377,7 +394,7 @@ export function SummaryPanel({
                     const l = Number(v.l);
                     const r = Number(v.r);
 
-                    if (lCommit === rCommit) {
+                    if (lDeviceName === rDeviceName && lCommit === rCommit) {
                       return l >= SPEEDUP_THRESHOLD ? "" : styles.warning;
                     } else {
                       if (l === r) {
@@ -443,7 +460,7 @@ export function SummaryPanel({
                     const r = Number(v.r).toFixed(0);
 
                     if (
-                      lCommit === rCommit ||
+                      (lDeviceName === rDeviceName && lCommit === rCommit) ||
                       l === r ||
                       v.r === undefined ||
                       v.r === ""
@@ -472,7 +489,7 @@ export function SummaryPanel({
                     const l = Number(v.l);
                     const r = Number(v.r);
 
-                    if (lCommit === rCommit) {
+                    if (lDeviceName === rDeviceName && lCommit === rCommit) {
                       return "";
                     } else {
                       if (l === r) {
@@ -534,7 +551,7 @@ export function SummaryPanel({
                     const r = Number(v.r).toFixed(SCALE);
 
                     if (
-                      lCommit === rCommit ||
+                      (lDeviceName === rDeviceName && lCommit === rCommit) ||
                       l === r ||
                       v.r === undefined ||
                       v.r === ""
@@ -563,7 +580,7 @@ export function SummaryPanel({
                     const l = Number(v.l);
                     const r = Number(v.r);
 
-                    if (lCommit === rCommit) {
+                    if (lDeviceName === rDeviceName && lCommit === rCommit) {
                       return l >= COMPRESSION_RATIO_THRESHOLD
                         ? ""
                         : styles.warning;


### PR DESCRIPTION
This is a bug reported by @malfet where the dashboard only shows the value from the new commit (right) when the left commit and the right commit are the same but on different devices.  This defeats the purpose of comparing different devices.

The bug here is that the `l → r` display worked under the assumption that same commit mean same benchmark, which is not true anymore.  Same benchmark now means same commit plus same device.

### Preview

https://torchci-git-fork-huydhn-fix-cross-device-sa-e8d1e5-fbopensource.vercel.app/benchmark/compilers?dashboard=torchinductor&startTime=Wed%2C%2019%20Feb%202025%2021%3A06%3A10%20GMT&stopTime=Wed%2C%2026%20Feb%202025%2021%3A06%3A10%20GMT&granularity=hour&mode=inference&dtype=bfloat16&lDeviceName=rocm%20(mi300x)&rDeviceName=cuda%20(a100)&lBranch=main&lCommit=d0adff761ea4d299528c89bee23008dbc622846e&rBranch=main&rCommit=d0adff761ea4d299528c89bee23008dbc622846e