### PR TITLE
[py 3.13t] Fix for vision nightly failure on MacOS M1 machines

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -118,8 +118,6 @@ runs:
       - name: Generate file from pytorch_pkg_helpers
         working-directory: ${{ inputs.repository }}
         shell: bash -l {0}
-        env:
-          PYTHON_VERSION: ${{ inputs.python-version }}
         run: |
           set -euxo pipefail
           CONDA_ENV="${RUNNER_TEMP}/pytorch_pkg_helpers_${GITHUB_RUN_ID}"

--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -118,6 +118,8 @@ runs:
       - name: Generate file from pytorch_pkg_helpers
         working-directory: ${{ inputs.repository }}
         shell: bash -l {0}
+        env:
+          PYTHON_VERSION: ${{ inputs.python-version }}
         run: |
           set -euxo pipefail
           CONDA_ENV="${RUNNER_TEMP}/pytorch_pkg_helpers_${GITHUB_RUN_ID}"
@@ -132,6 +134,13 @@ runs:
           ${CONDA_RUN} python -m pytorch_pkg_helpers > "${BUILD_ENV_FILE}"
           cat "${BUILD_ENV_FILE}"
           echo "BUILD_ENV_FILE=${BUILD_ENV_FILE}" >> "${GITHUB_ENV}"
+
+          # downgrade conda version for python 3.13t install.
+          # TODO: remove this once python 3.13t is fully suported on conda
+          # Please see : https://github.com/conda/conda/issues/14554
+          if [[ "${PYTHON_VERSION:-}" == "3.13t" ]]; then
+            ${CONDA_RUN} conda install -y conda=24.7.1 conda-libmamba-solver=24.1.0
+          fi
       - name: Setup conda environment for build
         shell: bash -l {0}
         env:
@@ -144,12 +153,6 @@ runs:
           if [[ "${PYTHON_VERSION:-}" == "3.13t" ]]; then
             export PYTHON_VERSION=3.13
             export CONDA_EXTRA_PARAM=" python-freethreading -c conda-forge"
-            if [[ "$(uname)" != Darwin ]]; then
-              # Pin conda and conda-libmamba-solver for 3.13t linux build
-              # this solver allows us to install anaconda dependencies on
-              # python-freethreading on conda-forge environment
-              conda install conda==24.7.1 conda-libmamba-solver=24.1.0
-            fi
           fi
 
           conda create \

--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -134,13 +134,6 @@ runs:
           ${CONDA_RUN} python -m pytorch_pkg_helpers > "${BUILD_ENV_FILE}"
           cat "${BUILD_ENV_FILE}"
           echo "BUILD_ENV_FILE=${BUILD_ENV_FILE}" >> "${GITHUB_ENV}"
-
-          # downgrade conda version for python 3.13t install.
-          # TODO: remove this once python 3.13t is fully suported on conda
-          # Please see : https://github.com/conda/conda/issues/14554
-          if [[ "${PYTHON_VERSION:-}" == "3.13t" ]]; then
-            ${CONDA_RUN} conda install -y conda=24.7.1 conda-libmamba-solver=24.1.0
-          fi
       - name: Setup conda environment for build
         shell: bash -l {0}
         env:
@@ -153,6 +146,16 @@ runs:
           if [[ "${PYTHON_VERSION:-}" == "3.13t" ]]; then
             export PYTHON_VERSION=3.13
             export CONDA_EXTRA_PARAM=" python-freethreading -c conda-forge"
+
+            # downgrade conda version for python 3.13t install.
+            # TODO: remove this once python 3.13t is fully suported on conda
+            # Please see : https://github.com/conda/conda/issues/14554
+            if [[ "$(uname)" == Darwin ]]; then
+              # required to be able to downgrade on MacOS m1 side
+              conda install -y python=3.9
+              conda uninstall -y conda-anaconda-telemetry conda-anaconda-tos
+            fi
+            conda install -y conda=24.7.1 conda-libmamba-solver=24.1.0
           fi
 
           conda create \


### PR DESCRIPTION
Follow up after:
https://github.com/pytorch/test-infra/pull/6242

Newer conda is having trouble installing py3.13t artifacts, please see:
https://github.com/pytorch/vision/actions/runs/13659383307/job/38186887882#step:10:98

```
Could not solve for environment specs
The following packages are incompatible
├─ libpng =* * is installable with the potential options
│  ├─ libpng 1.6.37 would require
│  │  └─ zlib >=1.2.11,<1.3.0a0 *, which can be installed;
│  └─ libpng 1.6.39 would require
│     └─ zlib >=1.2.13,<1.3.0a0 *, which can be installed;
└─ python-freethreading =* * is not installable because it requires
   ├─ cpython =3.13.2 *, which requires
   │  └─ python =3.13.2 * with the potential options
   │     ├─ python 3.13.2 would require
   │     │  └─ libzlib >=1.3.1,<2.0a0 *, which requires
   │     │     └─ zlib ==1.3.1 *_2, which conflicts with any installable versions previously reported;
   │     └─ python 3.13.2, which can be installed;
   └─ python_abi =* *_cp313t, which requires
      └─ python =3.13 *_cp313t, which conflicts with any installable versions previously reported.
```

As a consequence vision is compiled without png support and failing smoke tests

Test PR: https://github.com/pytorch/test-infra/pull/6356