### PR TITLE
[Bugfix] wait for ssm parameter to be created

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -572,7 +572,7 @@ export async function createRunner(runnerParameters: RunnerInputParameters, metr
               ` [${runnerParameters.runnerType.runnerTypeName}] [AMI?:${customAmi}] ${labelsStrLog}: `,
               runInstancesResponse.Instances.map((i) => i.InstanceId).join(','),
             );
-            addSSMParameterRunnerConfig(
+            await addSSMParameterRunnerConfig(
               runInstancesResponse.Instances,
               runnerParameters,
               customAmiExperiment,


### PR DESCRIPTION
Sometimes SSM parameter is not properly created. After investigation I identified that the promise is not being properly awaited. What could cause some operations to be canceled.