### PR TITLE
[HUD] Restore tts page jobName router query

### DIFF
--- a/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -153,23 +153,37 @@ export default function Page() {
   );
 
   useEffect(() => {
-    if (tts_true_series === undefined) {
-      return;
-    }
-
+    console.log(router.query)
     const jobNamesFromLink = JSON.parse(
       jobNamesCompressed != ""
         ? decompressFromEncodedURIComponent(jobNamesCompressed)
         : "[]"
     );
 
-    setSelectedJobs(
-      tts_true_series.reduce((acc: any, item: any) => {
-        acc[item.name] = jobNamesFromLink.includes(item.name);
-        return acc;
-      }, {} as any)
-    );
-  }, [data, jobNamesCompressed]);
+    if (router.query.jobName) {
+      jobNamesFromLink.push(router.query.jobName as string);
+    }
+
+    if (tts_true_series.length > 0) {
+      setSelectedJobs(
+        tts_true_series.reduce((acc: any, item: any) => {
+          acc[item.name] = jobNamesFromLink.includes(item.name);
+          return acc;
+        }, {} as any)
+      );
+    } else {
+      console.log(jobNamesFromLink)
+      setSelectedJobs(
+        jobNamesFromLink.reduce((acc: any, item: any) => {
+          acc[item] = true;
+          return acc;
+        }, {} as any)
+      );
+      console.log(selectedJobs)
+
+    }
+
+  }, [data, jobNamesCompressed, router.query.jobName]);
 
   const permalink =
     typeof window !== "undefined" &&

--- a/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -153,7 +153,7 @@ export default function Page() {
   );
 
   useEffect(() => {
-    console.log(router.query)
+    console.log(router.query);
     const jobNamesFromLink = JSON.parse(
       jobNamesCompressed != ""
         ? decompressFromEncodedURIComponent(jobNamesCompressed)
@@ -172,17 +172,13 @@ export default function Page() {
         }, {} as any)
       );
     } else {
-      console.log(jobNamesFromLink)
       setSelectedJobs(
         jobNamesFromLink.reduce((acc: any, item: any) => {
           acc[item] = true;
           return acc;
         }, {} as any)
       );
-      console.log(selectedJobs)
-
     }
-
   }, [data, jobNamesCompressed, router.query.jobName]);
 
   const permalink =

--- a/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/tts/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -153,7 +153,6 @@ export default function Page() {
   );
 
   useEffect(() => {
-    console.log(router.query);
     const jobNamesFromLink = JSON.parse(
       jobNamesCompressed != ""
         ? decompressFromEncodedURIComponent(jobNamesCompressed)


### PR DESCRIPTION
The tts and job duration tables in the metrics page use jobName in the link to quickly specify a job.  I got rid of it in https://github.com/pytorch/test-infra/pull/6326 in favor of a compressed list so you could permalink multiple jobs and forgot that the metrics page linked here.  This PR restores the functionality and allows both jobNames and jobNamesCompressed