### PR TITLE
[viable/strict] Ignore failing jobs with unstable issues

### DIFF
--- a/tools/scripts/fetch_latest_green_commit.py
+++ b/tools/scripts/fetch_latest_green_commit.py
@@ -1,7 +1,7 @@
-from functools import lru_cache
 import json
 import re
 import sys
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, cast, Dict, List, NamedTuple, Optional, Tuple
 
@@ -85,8 +85,9 @@ def get_commit_results(
 def fetch_unstable_issues() -> List[str]:
     issues = query_clickhouse_saved("issue_query", {"label": "unstable"})
     return [
-        issue["title"][len("UNSTABLE"):].strip()
-        for issue in issues if issue["title"].startswith("UNSTABLE") and issue["state"] == "open"
+        issue["title"][len("UNSTABLE") :].strip()
+        for issue in issues
+        if issue["title"].startswith("UNSTABLE") and issue["state"] == "open"
     ]
 
 

--- a/tools/tests/test_fetch_latest_green_commit.py
+++ b/tools/tests/test_fetch_latest_green_commit.py
@@ -46,6 +46,7 @@ class TestChecks:
             )
         return workflow_checks
 
+
 @mock.patch(
     "tools.scripts.fetch_latest_green_commit.fetch_unstable_issues",
     return_value=[],
@@ -55,7 +56,9 @@ class TestPrintCommits(TestCase):
         "tools.scripts.fetch_latest_green_commit.get_commit_results",
         return_value=TestChecks().make_test_checks(),
     )
-    def test_all_successful(self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any) -> None:
+    def test_all_successful(
+        self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any
+    ) -> None:
         """Test with workflows are successful"""
         workflow_checks = mock_get_commit_results()
         self.assertTrue(is_green("sha", requires, workflow_checks)[0])
@@ -64,7 +67,9 @@ class TestPrintCommits(TestCase):
         "tools.scripts.fetch_latest_green_commit.get_commit_results",
         return_value=TestChecks().make_test_checks(),
     )
-    def test_necessary_successful(self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any) -> None:
+    def test_necessary_successful(
+        self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any
+    ) -> None:
         """Test with necessary workflows are successful"""
         workflow_checks = mock_get_commit_results()
         workflow_checks = set_workflow_job_status(
@@ -88,7 +93,9 @@ class TestPrintCommits(TestCase):
         "tools.scripts.fetch_latest_green_commit.get_commit_results",
         return_value=TestChecks().make_test_checks(),
     )
-    def test_necessary_skipped(self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any) -> None:
+    def test_necessary_skipped(
+        self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any
+    ) -> None:
         """Test with necessary job (ex: pull) skipped"""
         workflow_checks = mock_get_commit_results()
         workflow_checks = set_workflow_job_status(workflow_checks, "pull", "skipped")
@@ -99,7 +106,9 @@ class TestPrintCommits(TestCase):
         "tools.scripts.fetch_latest_green_commit.get_commit_results",
         return_value=TestChecks().make_test_checks(),
     )
-    def test_skippable_skipped(self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any) -> None:
+    def test_skippable_skipped(
+        self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any
+    ) -> None:
         """Test with skippable jobs (periodic and docker-release-builds skipped"""
         workflow_checks = mock_get_commit_results()
         workflow_checks = set_workflow_job_status(
@@ -114,7 +123,9 @@ class TestPrintCommits(TestCase):
         "tools.scripts.fetch_latest_green_commit.get_commit_results",
         return_value=TestChecks().make_test_checks(),
     )
-    def test_necessary_failed(self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any) -> None:
+    def test_necessary_failed(
+        self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any
+    ) -> None:
         """Test with necessary job (ex: Lint) failed"""
         workflow_checks = mock_get_commit_results()
         workflow_checks = set_workflow_job_status(workflow_checks, "Lint", "failed")
@@ -126,7 +137,9 @@ class TestPrintCommits(TestCase):
         "tools.scripts.fetch_latest_green_commit.get_commit_results",
         return_value=TestChecks().make_test_checks(),
     )
-    def test_skippable_failed(self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any) -> None:
+    def test_skippable_failed(
+        self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any
+    ) -> None:
         """Test with failing skippable jobs (ex: docker-release-builds) should pass"""
         workflow_checks = mock_get_commit_results()
         workflow_checks = set_workflow_job_status(
@@ -141,7 +154,9 @@ class TestPrintCommits(TestCase):
     @mock.patch(
         "tools.scripts.fetch_latest_green_commit.get_commit_results", return_value={}
     )
-    def test_no_workflows(self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any) -> None:
+    def test_no_workflows(
+        self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any
+    ) -> None:
         """Test with missing workflows"""
         workflow_checks = mock_get_commit_results()
         result = is_green("sha", requires, workflow_checks)

--- a/tools/tests/test_fetch_latest_green_commit.py
+++ b/tools/tests/test_fetch_latest_green_commit.py
@@ -46,13 +46,16 @@ class TestChecks:
             )
         return workflow_checks
 
-
+@mock.patch(
+    "tools.scripts.fetch_latest_green_commit.fetch_unstable_issues",
+    return_value=[],
+)
 class TestPrintCommits(TestCase):
     @mock.patch(
         "tools.scripts.fetch_latest_green_commit.get_commit_results",
         return_value=TestChecks().make_test_checks(),
     )
-    def test_all_successful(self, mock_get_commit_results: Any) -> None:
+    def test_all_successful(self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any) -> None:
         """Test with workflows are successful"""
         workflow_checks = mock_get_commit_results()
         self.assertTrue(is_green("sha", requires, workflow_checks)[0])
@@ -61,7 +64,7 @@ class TestPrintCommits(TestCase):
         "tools.scripts.fetch_latest_green_commit.get_commit_results",
         return_value=TestChecks().make_test_checks(),
     )
-    def test_necessary_successful(self, mock_get_commit_results: Any) -> None:
+    def test_necessary_successful(self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any) -> None:
         """Test with necessary workflows are successful"""
         workflow_checks = mock_get_commit_results()
         workflow_checks = set_workflow_job_status(
@@ -85,7 +88,7 @@ class TestPrintCommits(TestCase):
         "tools.scripts.fetch_latest_green_commit.get_commit_results",
         return_value=TestChecks().make_test_checks(),
     )
-    def test_necessary_skipped(self, mock_get_commit_results: Any) -> None:
+    def test_necessary_skipped(self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any) -> None:
         """Test with necessary job (ex: pull) skipped"""
         workflow_checks = mock_get_commit_results()
         workflow_checks = set_workflow_job_status(workflow_checks, "pull", "skipped")
@@ -96,7 +99,7 @@ class TestPrintCommits(TestCase):
         "tools.scripts.fetch_latest_green_commit.get_commit_results",
         return_value=TestChecks().make_test_checks(),
     )
-    def test_skippable_skipped(self, mock_get_commit_results: Any) -> None:
+    def test_skippable_skipped(self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any) -> None:
         """Test with skippable jobs (periodic and docker-release-builds skipped"""
         workflow_checks = mock_get_commit_results()
         workflow_checks = set_workflow_job_status(
@@ -111,7 +114,7 @@ class TestPrintCommits(TestCase):
         "tools.scripts.fetch_latest_green_commit.get_commit_results",
         return_value=TestChecks().make_test_checks(),
     )
-    def test_necessary_failed(self, mock_get_commit_results: Any) -> None:
+    def test_necessary_failed(self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any) -> None:
         """Test with necessary job (ex: Lint) failed"""
         workflow_checks = mock_get_commit_results()
         workflow_checks = set_workflow_job_status(workflow_checks, "Lint", "failed")
@@ -123,7 +126,7 @@ class TestPrintCommits(TestCase):
         "tools.scripts.fetch_latest_green_commit.get_commit_results",
         return_value=TestChecks().make_test_checks(),
     )
-    def test_skippable_failed(self, mock_get_commit_results: Any) -> None:
+    def test_skippable_failed(self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any) -> None:
         """Test with failing skippable jobs (ex: docker-release-builds) should pass"""
         workflow_checks = mock_get_commit_results()
         workflow_checks = set_workflow_job_status(
@@ -138,7 +141,7 @@ class TestPrintCommits(TestCase):
     @mock.patch(
         "tools.scripts.fetch_latest_green_commit.get_commit_results", return_value={}
     )
-    def test_no_workflows(self, mock_get_commit_results: Any) -> None:
+    def test_no_workflows(self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any) -> None:
         """Test with missing workflows"""
         workflow_checks = mock_get_commit_results()
         result = is_green("sha", requires, workflow_checks)


### PR DESCRIPTION
Allows the viable strict promotion script to use unstable issues.  Jobs that have unstable issues open will be ignored in viable strict promotion.  

Tested with 
0ef2e938d0a9a4b90434f98b5e128d0ffacaae26 (passed, only thing failing is libtorch debug build which has an issue right now)
96afa8a2bb78e5410a83038fd1e3f83911601700 (failed since there's something pending)
c5d92edd5acfa56bae4f0c1057d667c6356fd6c1 (failed since lint failed)