### PR TITLE
[Fix Bug] remove bug to not parse the rcommit

### DIFF
--- a/torchci/components/benchmark/llms/components/dashboardPicker/LLMsDashboardPicker.tsx
+++ b/torchci/components/benchmark/llms/components/dashboardPicker/LLMsDashboardPicker.tsx
@@ -69,7 +69,7 @@ export const LLMsDashboardPicker = ({
           }}
           titlePrefix={"New"}
           fallbackIndex={0} // Default to the latest commit
-          timeRange={[props.timeRange]}
+          timeRange={props.timeRange}
         />
       </Stack>
     </div>


### PR DESCRIPTION
https://github.com/pytorch/test-infra/issues/6363

this is a typo when refactor the benchmark code, simply remove the [], I think visual studio auto-gen triggered it