### PR TITLE
Fix wrong benchmark data associated with commits

### DIFF
--- a/torchci/components/benchmark/llms/components/LLMsGraphPanel.tsx
+++ b/torchci/components/benchmark/llms/components/LLMsGraphPanel.tsx
@@ -289,7 +289,9 @@ export default function LLMsGraphPanel({
                       .filter((metric) => chartData[metric].length !== 0)
                       .map((metric: string) => (
                         <td key={`${metric}-${index}`}>
-                          {chartData[metric][index] !== undefined
+                          {chartData[metric][index] !== undefined &&
+                          chartData[metric][index].workflow_id ===
+                            entry.workflow_id
                             ? chartData[metric][index].actual
                             : ""}
                         </td>


### PR DESCRIPTION
While debugging the issue on vLLM dashboard in https://github.com/vllm-project/vllm/pull/14303#issue-2898264192, I notice another issue where benchmark data is associated with the wrong commit in the detail chart table.

For example, https://hud.pytorch.org/benchmark/llms?startTime=Wed%2C%2026%20Feb%202025%2021%3A05%3A15%20GMT&stopTime=Wed%2C%2005%20Mar%202025%2021%3A05%3A15%20GMT&granularity=day&lBranch=main&lCommit=257e200a2537a8175392d3bb285473ab80867576&rBranch=main&rCommit=f71b00a19e25abebdff13a5ae9acc93749125e11&repoName=vllm-project%2Fvllm&benchmarkName=&modelName=meta-llama%2FMeta-Llama-3.1-8B-Instruct&backendName=&modeName=&dtypeName=&deviceName=cuda%20(NVIDIA%20H100)&archName=All%20Platforms wrongly show data from other commits with different `workflow_id`.

![Screenshot 2025-03-05 at 13 06 28](https://github.com/user-attachments/assets/b054def4-d7be-4a11-a4d9-5a5a93328e52)
