### PR TITLE
[BE] [ez] READMEs - update lint/formatter info, remove dup info about hud

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,35 +31,11 @@ $ git clone --recursive https://github.com/pytorch/test-infra
 ```
 
 ## Setting up your Dev environment to locally run hud.pytorch.org
-1. Install yarn:
-    E.g. for macs: `brew install yarn`
-2. `cd torchci` and install dependencies with `yarn install`
-2. Setup your environment variables
-
-    a. Copy `torchci/.env.example` to `torchci/.env.local` to create a local copy of your environmnet variables. This will NOT be checked into git
-
-    b. For every environment setting defined in there, copy over the corresponding value [from Vercel](https://vercel.com/fbopensource/torchci/settings/environment-variables) (this requires access to our Vercel deployment)
-
-3. From `torchci` run `yarn dev` to start the dev server. The local endpoint will be printed on the console, it'll most likely be `http://localhost:3000`. You can find more useful yarn commands in `package.json` under the `scripts` section.
+See the [README.md in `torchci`](https://github.com/pytorch/test-infra/blob/main/torchci/README.md).
 
 ## Linting
-
-We use [`actionlint`](https://github.com/rhysd/actionlint) to verify that the GitHub Actions workflows in [`.github/workflows`](github/workflows) are correct. To run it locally:
-
-1. [Set up Go](https://golang.org/doc/install)
-2. Install actionlint
-
-    ```bash
-    go install github.com/rhysd/actionlint/cmd/actionlint@7040327ca40aefd92888871131adc30c7d9c1b6d
-    ```
-3. Run actionlint
-
-    ```bash
-    # The executable will be in ~/go/bin, so make sure that's on your PATH
-    # actionlint automatically detects and uses shellcheck, so if it's not in
-    # your PATH you will get different results than in CI
-    actionlint
-    ```
+We use [`lintrunner`](https://pypi.org/project/lintrunner/) for linting and
+formatting. `torchci` also uses `yarn`.
 
 ## Join the PyTorch TestInfra community
 See the [`CONTRIBUTING`](CONTRIBUTING.md) file for how to help out.

--- a/torchci/README.md
+++ b/torchci/README.md
@@ -37,6 +37,9 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 result! Any edits you make to the code will be reflected immediately in the
 browser. You can also run our test suite with `yarn test`.
 
+You can find additional yarn commands in `package.json` under the `scripts`
+section, such as `yarn test` to run the test suite.
+
 We use Next.js as our framework. To learn more about Next.js, take a look at the
 following resources:
 


### PR DESCRIPTION
As in title

* Update the lint/formatter info
* Remove the dup info about development on HUD and link to the torchci README instead