### PR TITLE
Show use torch.compile on TorchAO charts

### DIFF
--- a/torchci/components/benchmark/llms/components/LLMsGraphPanel.tsx
+++ b/torchci/components/benchmark/llms/components/LLMsGraphPanel.tsx
@@ -182,6 +182,11 @@ export default function LLMsGraphPanel({
               ) {
                 const isDynamic = record.extra!["is_dynamic"];
                 record.display = `${model} / ${isDynamic}`;
+              } else if (repoName === "pytorch/ao") {
+                let useCompile = record.extra!["use_torch_compile"];
+                record.display = `${model} (${dtype}${
+                  useCompile === "true" ? " / compile" : ""
+                })`;
               } else {
                 record.display = model.includes(dtype)
                   ? model.includes(device)


### PR DESCRIPTION
Some data is missing on the chart otherwise.   For example https://hud.pytorch.org/benchmark/llms?startTime=Thu%2C%2027%20Feb%202025%2001%3A12%3A08%20GMT&stopTime=Thu%2C%2006%20Mar%202025%2001%3A12%3A08%20GMT&granularity=day&lBranch=main&lCommit=6946094f6fe9ff77ca02736567ddf2fc031d5fd300ce7c60d832cf9c301c4c48&rBranch=main&rCommit=6946094f6fe9ff77ca02736567ddf2fc031d5fd300ce7c60d832cf9c301c4c48&repoName=pytorch%2Fao&benchmarkName=&modelName=AlbertForMaskedLM&backendName=&modeName=inference&dtypeName=autoquant&deviceName=cuda%20(NVIDIA%20H100)&archName=All%20Platforms shows only 0.99 on `compile v.s eager speedup` chart