### PR TITLE
Adding tooling and documentation for locally run tflint

### DIFF
--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -30,9 +30,12 @@ jobs:
         terraform_version: 1.5.7
         terraform_wrapper: false
 
-    - name: Show version
+    - name: Show tflint version
       run:
         tflint --version
+
+    - name: Show tofu version
+      run:
         tofu --version
 
     - name: "tflint"

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -24,102 +24,17 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         tflint_version: v0.54.0
 
-    - name: Install Terraform
-      uses: hashicorp/setup-terraform@v2
+    - name: Install Tofu
+      uses: opentofu/setup-opentofu@v1
       with:
-        terraform_version: 1.5.1
+        terraform_version: 1.5.7
         terraform_wrapper: false
 
     - name: Show version
-      run: tflint --version
+      run:
+        tflint --version
+        tofu --version
 
-    - name: "Init TFLint download-lambda"
-      working-directory: terraform-aws-github-runner/modules/download-lambda
-      run: tflint --init
-    - name: "Init terraform download-lambda"
-      working-directory: terraform-aws-github-runner/modules/download-lambda
-      run: terraform init
-    - name: "Run TFLint download-lambda"
-      working-directory: terraform-aws-github-runner/modules/download-lambda
-      run: tflint --call-module-type=all
-    - name: "Run terraform validate download-lambda"
-      working-directory: terraform-aws-github-runner/modules/download-lambda
-      run: terraform validate
-
-    - name: "Init TFLint runner-binaries-syncer"
-      working-directory: terraform-aws-github-runner/modules/runner-binaries-syncer
-      run: tflint --init
-    - name: "Init terraform runner-binaries-syncer"
-      working-directory: terraform-aws-github-runner/modules/runner-binaries-syncer
-      run: terraform init
-    - name: "Run TFLint runner-binaries-syncer"
-      working-directory: terraform-aws-github-runner/modules/runner-binaries-syncer
-      run: tflint --call-module-type=all
-    - name: "Run terraform validate runner-binaries-syncer"
-      working-directory: terraform-aws-github-runner/modules/runner-binaries-syncer
-      run: terraform validate
-
-    - name: "Init TFLint runners-instances"
-      working-directory: terraform-aws-github-runner/modules/runners-instances
-      run: tflint --init
-    - name: "Init terraform runners-instances"
-      working-directory: terraform-aws-github-runner/modules/runners-instances
-      run: terraform init
-    - name: "Run TFLint runners-instances"
-      working-directory: terraform-aws-github-runner/modules/runners-instances
-      run: tflint --call-module-type=all
-    - name: "Run terraform validate runners-instances"
-      working-directory: terraform-aws-github-runner/modules/runners-instances
-      run: terraform validate
-
-    - name: "Init TFLint runners"
-      working-directory: terraform-aws-github-runner/modules/runners
-      run: tflint --init
-    - name: "Init terraform runners"
-      working-directory: terraform-aws-github-runner/modules/runners
-      run: terraform init
-    - name: "Run TFLint runners"
-      working-directory: terraform-aws-github-runner/modules/runners
-      run: tflint --call-module-type=all
-    - name: "Run terraform validate runners"
-      working-directory: terraform-aws-github-runner/modules/runners
-      run: terraform validate
-
-    - name: "Init TFLint setup-iam-permissions"
-      working-directory: terraform-aws-github-runner/modules/setup-iam-permissions
-      run: tflint --init
-    - name: "Init terraform setup-iam-permissions"
-      working-directory: terraform-aws-github-runner/modules/setup-iam-permissions
-      run: terraform init
-    - name: "Run TFLint setup-iam-permissions"
-      working-directory: terraform-aws-github-runner/modules/setup-iam-permissions
-      run: tflint --call-module-type=all
-    - name: "Run terraform validate setup-iam-permissions"
-      working-directory: terraform-aws-github-runner/modules/setup-iam-permissions
-      run: terraform validate
-
-    - name: "Init TFLint webhook"
-      working-directory: terraform-aws-github-runner/modules/webhook
-      run: tflint --init
-    - name: "Init terraform webhook"
-      working-directory: terraform-aws-github-runner/modules/webhook
-      run: terraform init
-    - name: "Run TFLint webhook"
-      working-directory: terraform-aws-github-runner/modules/webhook
-      run: tflint --call-module-type=all
-    - name: "Run terraform validate webhook"
-      working-directory: terraform-aws-github-runner/modules/webhook
-      run: terraform validate
-
-    - name: "Init TFLint main"
+    - name: "tflint"
       working-directory: terraform-aws-github-runner
-      run: tflint --init
-    - name: "Init terraform main"
-      working-directory: terraform-aws-github-runner
-      run: terraform init
-    - name: "Run TFLint main"
-      working-directory: terraform-aws-github-runner
-      run: tflint --call-module-type=all
-    - name: "Run terraform validate terraform-aws-github-runner"
-      working-directory: terraform-aws-github-runner
-      run: terraform validate
+      run: make tflint

--- a/terraform-aws-github-runner/Makefile
+++ b/terraform-aws-github-runner/Makefile
@@ -1,0 +1,62 @@
+all: tflint
+
+@PHONY: tflint
+tflint: tflint-download-lambda tflint-runner-binaries-syncer tflint-runners-instances tflint-runners tflint-setup-iam-permissions tflint-webhook tflint-main
+
+@PHONY: tflint-download-lambda
+tflint-download-lambda:
+	cd modules/download-lambda && \
+		tofu init && \
+		tflint --init && \
+		tflint --call-module-type=all && \
+		tofu validate
+
+@PHONY: tflint-runner-binaries-syncer
+tflint-runner-binaries-syncer:
+	cd modules/runner-binaries-syncer && \
+		tofu init && \
+		tflint --init && \
+		tflint --call-module-type=all && \
+		tofu validate
+
+@PHONY: tflint-runners-instances
+tflint-runners-instances:
+	cd modules/runners-instances && \
+		tofu init && \
+		tflint --init && \
+		tflint --call-module-type=all && \
+		tofu validate
+
+@PHONY: tflint-runners
+tflint-runners:
+	cd modules/runners && \
+		tofu init && \
+		tflint --init && \
+		tflint --call-module-type=all && \
+		tofu validate
+
+@PHONY: tflint-setup-iam-permissions
+tflint-setup-iam-permissions:
+	cd modules/setup-iam-permissions && \
+		tofu init && \
+		tflint --init && \
+		tflint --call-module-type=all && \
+		tofu validate
+
+@PHONY: tflint-webhook
+tflint-webhook:
+	cd modules/webhook && \
+		tofu init && \
+		tflint --init && \
+		tflint --call-module-type=all && \
+		tofu validate
+
+@PHONY: tflint-main
+tflint-main:
+	tofu init
+	tflint --init
+	tflint --call-module-type=all --recursive
+	tofu validate
+
+clean:
+	rm -rf .terraform terraform.lock.hcl

--- a/terraform-aws-github-runner/README.md
+++ b/terraform-aws-github-runner/README.md
@@ -2,6 +2,18 @@
 
 This is a terraform module that sets up self hosted github runners on AWS along with the infra needed to autoscale them
 
+# Testing your changes
+In order to verify if your changes will pass CI testing, you can simply run from this directory:
+
+```
+$ make tflint
+```
+
+This depends on Tofu, CMake and TFLint being installed.
+
+# Checking plan changes of your changes
+This module is not stand alone. It is a reusable module designed to be imported, configured, and used in your project.
+
 # Release
 Terraform code that uses this module specify the tag (version of test-infra) that they use via a file called `Terrafile`.  We need to create a new tag for any changes here that we want to deploy and update the `Terrafile` to refer to that tag:
 


### PR DESCRIPTION
created a Makefile on `./terraform-aws-github-runner` to perform tflint actions, and replaced the tflint calls on CI (`tflint.yml`) with this makefile.

This makes much easier to test locally and make sure to get green signals on CI. Reducing the loop time to fix small syntax bugs.