### PR TITLE
[Mobile Benchmark Test] Add os, job_arn, and job_conclusion to artifact

### DIFF
--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -434,9 +434,9 @@ class ReportProcessor:
         self.app_type = app_type
         self.workflow_id = workflow_id
         self.workflow_attempt = workflow_attempt
-        self.run_report = None
+        self.run_report: Optional[DeviceFarmReport] = None
         self.job_reports: list[JobReport] = []
-        self.test_spec_info_list = []
+        self.test_spec_info_list:list[Dict] = []
         self.is_debug = is_debug
 
     def start(self, report: Dict[str, Any]):

--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -4,6 +4,7 @@ import copy
 import datetime
 import json
 import logging
+from math import inf
 import os
 import random
 import string
@@ -774,6 +775,7 @@ def main() -> None:
         warn(f"Failed to run {unique_prefix}: {error}")
         sys.exit(1)
     finally:
+        info(f"Run {unique_prefix} finished with state {state} and result {result}")
         s3_client = boto3.client("s3")
         processor = ReportProcessor(
             device_farm_client, s3_client, app_type, workflow_id, workflow_attempt
@@ -783,7 +785,6 @@ def main() -> None:
         processor.print_test_spec()
     if not is_success(result):
         sys.exit(1)
-
 
 if __name__ == "__main__":
     main()

--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from dataclasses import dataclass, asdict
+import copy
 import datetime
 import json
 import logging
@@ -10,11 +10,11 @@ import string
 import sys
 import time
 from argparse import Action, ArgumentParser, Namespace
+from dataclasses import asdict, dataclass
 from enum import Enum
 from logging import info
 from typing import Any, Dict, List, Optional
 from warnings import warn
-import copy
 
 import boto3  # type: ignore[import-not-found]
 import requests

--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -573,7 +573,7 @@ class ReportProcessor:
         from Device Farm including FILE, LOG, and SCREENSHOT
         """
         gathered_artifacts = []
-        info("{' ' * indent} start gathering artifacts")
+        info(f"{' ' * indent} start gathering artifacts")
         for artifact_type in ["FILE", "LOG", "SCREENSHOT"]:
             r = self.aws_client.list_artifacts(arn=test_arn, type=artifact_type)
             for artifact in r.get("artifacts", []):

--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -25,7 +25,7 @@ MAX_UPLOAD_WAIT_IN_SECOND = 600
 
 AWS_REGION = "us-west-2"
 # NB: This is the curated top devices from AWS. We could create our own device
-# pool if we want to
+# pool if we want to.
 AWS_GUID = "082d10e5-d7d7-48a5-ba5c-b33d66efa1f5"
 AWS_ARN_PREFIX = "arn:aws:devicefarm:"
 DEFAULT_DEVICE_POOL_ARN = f"{AWS_ARN_PREFIX}{AWS_REGION}::devicepool:{AWS_GUID}"

--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -589,11 +589,6 @@ class ReportProcessor:
                     self._upload_file_to_s3(artifacts, DEVICE_FARM_BUCKET, s3_key)
                     s3_url = f"https://{DEVICE_FARM_BUCKET}.s3.amazonaws.com/{s3_key}"
                     artifact["s3_url"] = s3_url
-
-                # Download the artifact locally
-                artifacts = download_artifact(artifact["url"], local_filename)
-                # upload artifacts to s3 bucket
-                self._upload_file_to_s3(artifacts, DEVICE_FARM_BUCKET, s3_key)
                 s3_url = f"https://{DEVICE_FARM_BUCKET}.s3.amazonaws.com/{s3_key}"
                 artifact["s3_url"] = s3_url
 
@@ -623,9 +618,9 @@ class ReportProcessor:
         info(f"Test Spec Outputs:")
         for test_spec_info in self.test_spec_info_list:
             print_testspec(
-                test_spec_info.job_name,
-                test_spec_info.os,
-                test_spec_info.local_filename,
+                test_spec_info['job_name'],
+                test_spec_info['os'],
+                test_spec_info['local_filename'],
             )
 
     def get_run_report(self):
@@ -772,6 +767,17 @@ def main() -> None:
     if not is_success(result):
         sys.exit(1)
 
+def test():
+    dc = boto3.client("devicefarm", region_name=AWS_REGION)
+    s3 = boto3.client("s3")
+    processor = ReportProcessor(dc,s3,"1","1",1,True)
+    fakeReport = {"name":"test","arn":"arn:aws:devicefarm:us-west-2:308535385114:run:b531574a-fb82-40ae-b687-8f0b81341ae0/d54bd41b-d546-4cbf-91f9-e17b866390a9"}
+    artifacts = processor.start(fakeReport)
+    set_output(json.dumps(artifacts), "artifacts", "yang_test.txt")
+    processor.print_test_spec()
+    processor.print_run_report()
+    processor.print_job_reports()
+
 
 if __name__ == "__main__":
-    main()
+    test()

--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -281,21 +281,6 @@ def set_output(val: Any, gh_var_name: str, filename: Optional[str]) -> None:
             print(val, file=f)
 
 
-def print_testspec(
-    job_name: str,
-    os: str,
-    job_conclusion: str,
-    file_name: str,
-) -> None:
-    """
-    The test spec output from AWS Device Farm is the main output of the test job.
-    """
-    print(f"::group::{job_name} {os} test output [Job Result: {job_conclusion}]")
-    with open(file_name) as f:
-        print(f.read())
-    print("::endgroup::")
-
-
 def generate_ios_xctestrun(
     client: Any, project_arn: str, prefix: str, ios_xctestrun: str, test_spec: str
 ) -> Dict[str, str]:
@@ -635,12 +620,27 @@ class ReportProcessor:
     def print_test_spec(self) -> None:
         info(f"Test Spec Outputs:")
         for test_spec_info in self.test_spec_info_list:
-            print_testspec(
+            self.print_single_testspec(
                 test_spec_info["job_name"],
                 test_spec_info["os"],
                 test_spec_info["job_conclusion"],
                 test_spec_info["local_filename"],
             )
+
+    def print_single_testspec(
+        self,
+        job_name: str,
+        os: str,
+        job_conclusion: str,
+        file_name: str,
+    ) -> None:
+        """
+        The test spec output from AWS Device Farm is the main output of the test job.
+        """
+        print(f"::group::{job_name} {os} test output [Job Result: {job_conclusion}]")
+        with open(file_name) as f:
+            print(f.read())
+        print("::endgroup::")
 
     def get_run_report(self):
         if not self.run_report:

--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -4,7 +4,6 @@ import copy
 import datetime
 import json
 import logging
-from math import inf
 import os
 import random
 import string
@@ -14,6 +13,7 @@ from argparse import Action, ArgumentParser, Namespace
 from dataclasses import asdict, dataclass
 from enum import Enum
 from logging import info
+from math import inf
 from typing import Any, Dict, List, Optional
 from warnings import warn
 
@@ -785,6 +785,7 @@ def main() -> None:
         processor.print_test_spec()
     if not is_success(result):
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -20,6 +20,7 @@ import boto3  # type: ignore[import-not-found]
 import requests
 
 
+# TODO(elainewy): refactor and add unit tests for benchmark test logic
 POLLING_DELAY_IN_SECOND = 5
 MAX_UPLOAD_WAIT_IN_SECOND = 600
 
@@ -422,6 +423,14 @@ class JobReport(DeviceFarmReport):
 
 
 class ReportProcessor:
+    """
+    A helper class to process the modebile test result from AWS Device Farm.
+
+    Usage:
+        processor = ReportProcessor(...) \n
+        processor.start(mobile_run_report)
+    """
+
     def __init__(
         self,
         device_farm_client: Any,
@@ -441,10 +450,17 @@ class ReportProcessor:
         self.test_spec_info_list: list[Dict] = []
         self.is_debug = is_debug
 
-    def start(self, report: Dict[str, Any]):
+    # todo(elainewy): add main method to pass run arn
+    def start(self, report: Dict[str, Any]) -> List[Dict[str, str]]:
         if not report:
             warn("Missing report, returning...")
             return []
+
+        arn = report.get("arn", "")
+        if not arn:
+            warn("Missing arn from input report, returning...")
+            return []
+
         if self.is_debug:
             info(
                 "[DEBUG MODE] the artifacts won't be uploaded to s3, it should mainly used in local env"
@@ -548,6 +564,7 @@ class ReportProcessor:
         name = report.get("name", "")
         result = report.get("result", "")
         counters = report.get("counters", "{}")
+
         return DeviceFarmReport(
             name=name,
             arn=arn,

--- a/tools/device-farm-runner/test_run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/test_run_on_aws_devicefarm.py
@@ -193,6 +193,7 @@ class MockDeviceFarmClient:
 class Test(unittest.TestCase):
     @mock.patch("run_on_aws_devicefarm.download_artifact")
     def test_reportProcessor(self, download_artifact_mock):
+        # setup
         m_df = MockDeviceFarmClient()
         m_s3 = MockS3Client()
         fakeReport = {
@@ -205,6 +206,8 @@ class Test(unittest.TestCase):
         processor = ReportProcessor(
             m_df.getMockClient(), m_s3.getMockClient(), "IOS", "wf1", 1
         )
+
+        # execute
         artifacts = processor.start(fakeReport)
 
         # assert aws client calls
@@ -245,6 +248,7 @@ class Test(unittest.TestCase):
 
     @mock.patch("run_on_aws_devicefarm.download_artifact")
     def test_reportProcessor_debug(self, download_artifact_mock):
+        # setup
         m_df = MockDeviceFarmClient()
         m_s3 = MockS3Client()
         fakeReport = {
@@ -257,8 +261,11 @@ class Test(unittest.TestCase):
         processor = ReportProcessor(
             m_df.getMockClient(), m_s3.getMockClient(), "IOS", "wf1", 1, True
         )
+
+        # execute
         artifacts = processor.start(fakeReport)
 
+        # assert aws client calls
         m_df.getMockClient().list_jobs.assert_called_once()
         self.assertEqual(m_df.getMockClient().list_suites.call_count, 2)
         self.assertEqual(m_df.getMockClient().list_tests.call_count, 4)
@@ -268,18 +275,23 @@ class Test(unittest.TestCase):
         self.assertEqual(m_s3.getMockClient().upload_file.call_count, 0)
 
     def test_reportProcessor_emptyReportInput_returnEmptyList(self):
+        # setup
         m_df = MockDeviceFarmClient()
         m_s3 = MockS3Client()
         fakeReport = {}
         processor = ReportProcessor(
             m_df.getMockClient(), m_s3.getMockClient(), "IOS", "wf1", 1, True
         )
+
+        # execute
         artifacts = processor.start(fakeReport)
 
+        # assert
         self.assertEqual(m_df.getMockClient().list_jobs.call_count, 0)
         self.assertEqual(len(artifacts), 0)
 
     def test_reportProcessor_missingArnInReportInput_returnEmptyList(self):
+        # setup
         m_df = MockDeviceFarmClient()
         m_s3 = MockS3Client()
         fakeReport = {
@@ -289,8 +301,11 @@ class Test(unittest.TestCase):
         processor = ReportProcessor(
             m_df.getMockClient(), m_s3.getMockClient(), "IOS", "wf1", 1
         )
+
+        # execute
         artifacts = processor.start(fakeReport)
 
+        # assert
         self.assertEqual(m_df.getMockClient().list_jobs.call_count, 0)
         self.assertEqual(len(artifacts), 0)
 

--- a/tools/device-farm-runner/test_run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/test_run_on_aws_devicefarm.py
@@ -1,17 +1,18 @@
+import copy
 import json
-from re import M
 import unittest
+from re import M
+from typing import Any, Dict
 from unittest import mock
 from unittest.mock import MagicMock
-from typing import Any, Dict
-from run_on_aws_devicefarm import ReportProcessor, download_artifact
-import copy
+
+from run_on_aws_devicefarm import download_artifact, ReportProcessor
 
 
 class MockS3Client:
     def __init__(self):
         self.mock_aws_client = MagicMock()
-        self.mock_aws_client.upload_file.return_value=None
+        self.mock_aws_client.upload_file.return_value = None
 
     def getMockClient(self) -> MagicMock:
         return self.mock_aws_client
@@ -213,7 +214,7 @@ class Test(unittest.TestCase):
         self.assertEqual(m_s3.getMockClient().upload_file.call_count, 12)
         self.assertEqual(m_s3.getMockClient().upload_file.call_count, 12)
         self.assertEqual(download_artifact_mock.call_count, 12)
-        self.assertEqual(m_s3.getMockClient().upload_file.call_count,12)
+        self.assertEqual(m_s3.getMockClient().upload_file.call_count, 12)
 
         # assert artifacts
         self.assertEqual(len(artifacts), 12)
@@ -223,24 +224,24 @@ class Test(unittest.TestCase):
         ]
         self.assertEqual(len(job1_artifacts), 6)
         a1 = job1_artifacts[0]
-        self.assertEqual(a1["app_type"], 'IOS')
-        self.assertEqual(a1["job_arn"], 'arn-job-1')
-        self.assertEqual(a1["job_conclusion"], 'PASSED')
-        self.assertEqual(a1["job_name"], 'Apple iPhone 15')
-        self.assertEqual(a1["os"], '18.0')
-        self.assertEqual(a1["name"], 'test spec output')
+        self.assertEqual(a1["app_type"], "IOS")
+        self.assertEqual(a1["job_arn"], "arn-job-1")
+        self.assertEqual(a1["job_conclusion"], "PASSED")
+        self.assertEqual(a1["job_name"], "Apple iPhone 15")
+        self.assertEqual(a1["os"], "18.0")
+        self.assertEqual(a1["name"], "test spec output")
 
         job2_artifacts = [
             artifact for artifact in artifacts if artifact["job_arn"] == "arn-job-2"
         ]
         self.assertEqual(len(job2_artifacts), 6)
         a2 = job2_artifacts[0]
-        self.assertEqual(a2["app_type"], 'IOS')
-        self.assertEqual(a2["job_arn"], 'arn-job-2')
-        self.assertEqual(a2["job_conclusion"], 'PASSED')
-        self.assertEqual(a2["job_name"], 'Apple iPhone 17 Pro')
-        self.assertEqual(a2["os"], '11.0')
-        self.assertEqual(a2["name"], 'test spec output')
+        self.assertEqual(a2["app_type"], "IOS")
+        self.assertEqual(a2["job_arn"], "arn-job-2")
+        self.assertEqual(a2["job_conclusion"], "PASSED")
+        self.assertEqual(a2["job_name"], "Apple iPhone 17 Pro")
+        self.assertEqual(a2["os"], "11.0")
+        self.assertEqual(a2["name"], "test spec output")
 
     @mock.patch("run_on_aws_devicefarm.download_artifact")
     def test_reportProcessor_debug(self, download_artifact_mock):
@@ -264,7 +265,7 @@ class Test(unittest.TestCase):
         self.assertEqual(download_artifact_mock.call_count, 12)
         self.assertEqual(len(artifacts), 12)
 
-        self.assertEqual(m_s3.getMockClient().upload_file.call_count,0)
+        self.assertEqual(m_s3.getMockClient().upload_file.call_count, 0)
 
 
 if __name__ == "__main__":

--- a/tools/device-farm-runner/test_run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/test_run_on_aws_devicefarm.py
@@ -1,0 +1,206 @@
+import json
+from re import M
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock
+from typing import Any, Dict
+from run_on_aws_devicefarm import ReportProcessor, download_artifact
+
+
+class MockS3Client:
+    def __init__(self):
+        self.mock_aws_client = MagicMock()
+
+    def getMockClient(self) -> MagicMock:
+        return self.mock_aws_client
+
+
+class MockDeviceFarmClient:
+    def __init__(self):
+        self.mock_aws_client = MagicMock()
+        self.mock_aws_client.list_jobs.return_value = self.mockJobs()
+        self.mock_aws_client.list_suites.return_value = self.mockSuites()
+        self.mock_aws_client.list_tests.return_value = self.mockTests()
+        self.mock_aws_client.list_artifacts.return_value = {
+            "artifacts": [
+                {
+                    "type": "LOGS",
+                    "name": "logs",
+                    "extension": "test",
+                    "arn": "arn-artifact1",
+                    "url": "url-artifact1",
+                },
+                {
+                    "type": "TESTSPEC_OUTPUT",
+                    "name": "test spec output",
+                    "extension": "output",
+                    "arn": "arn-artifact2",
+                    "url": "url-artifact2",
+                },
+            ]
+        }
+
+    def getMockClient(self) -> MagicMock:
+        return self.mock_aws_client
+
+    def mockTests(self) -> Any:
+        return {
+            "tests": [
+                {
+                    "arn": "arn-test1",
+                    "name": "Setup Test",
+                    "status": "COMPLETED",
+                    "result": "PASSED",
+                    "counters": {
+                        "total": 1,
+                        "passed": 1,
+                        "failed": 0,
+                        "warned": 0,
+                        "errored": 0,
+                        "stopped": 0,
+                        "skipped": 0,
+                    },
+                    "message": "Successful test lifecycle of Setup Test",
+                }
+            ],
+            "ResponseMetadata": {},
+        }
+
+    def mockSuites(self):
+        return {
+            "suites": [
+                {
+                    "arn": "arn-suite1",
+                    "name": "Setup Suite",
+                    "status": "COMPLETED",
+                    "result": "PASSED",
+                    "counters": {
+                        "total": 1,
+                        "passed": 1,
+                        "failed": 0,
+                        "warned": 0,
+                        "errored": 0,
+                        "stopped": 0,
+                        "skipped": 0,
+                    },
+                    "message": "Successful",
+                },
+                {
+                    "arn": "arn-suite2",
+                    "name": "Tests Suite",
+                    "status": "COMPLETED",
+                    "result": "PASSED",
+                    "counters": {
+                        "total": 1,
+                        "passed": 1,
+                        "failed": 0,
+                        "warned": 0,
+                        "errored": 0,
+                        "stopped": 0,
+                        "skipped": 0,
+                    },
+                    "message": "Tests passed",
+                },
+                {
+                    "arn": "arn-suite3",
+                    "name": "Teardown Suite",
+                    "status": "COMPLETED",
+                    "result": "PASSED",
+                    "counters": {
+                        "total": 1,
+                        "passed": 1,
+                        "failed": 0,
+                        "warned": 0,
+                        "errored": 0,
+                        "stopped": 0,
+                        "skipped": 0,
+                    },
+                },
+            ],
+            "ResponseMetadata": {},
+        }
+
+    def mockJobs(self):
+        return {
+            "jobs": [
+                {
+                    "arn": "arn-job1",
+                    "name": "Apple iPhone 15",
+                    "status": "COMPLETED",
+                    "result": "PASSED",
+                    "counters": {
+                        "total": 3,
+                        "passed": 3,
+                        "failed": 0,
+                        "warned": 0,
+                        "errored": 0,
+                        "stopped": 0,
+                        "skipped": 0,
+                    },
+                    "message": "fake1",
+                    "device": {
+                        "arn": "device:00",
+                        "name": "Apple iPhone 15",
+                        "manufacturer": "Apple",
+                        "model": "Apple iPhone 15",
+                        "modelId": "A2846",
+                        "formFactor": "PHONE",
+                        "platform": "IOS",
+                        "os": "18.0",
+                    },
+                },
+                {
+                    "arn": "arn-job2",
+                    "name": "Apple iPhone 15 Pro",
+                    "status": "COMPLETED",
+                    "result": "PASSED",
+                    "counters": {
+                        "total": 3,
+                        "passed": 2,
+                        "failed": 1,
+                        "warned": 0,
+                        "errored": 0,
+                        "stopped": 0,
+                        "skipped": 0,
+                    },
+                    "message": "fake1",
+                    "device": {
+                        "arn": "device:00",
+                        "name": "Apple iPhone 15",
+                        "model": "Apple iPhone 15 Pro",
+                        "modelId": "A2222",
+                        "formFactor": "PHONE",
+                        "platform": "IOS",
+                        "os": "17.7",
+                    },
+                },
+            ]
+        }
+
+class Test(unittest.TestCase):
+    @mock.patch("run_on_aws_devicefarm.download_artifact")
+    def test_reportProcessor(self, download_artifact_mock):
+        m_df = MockDeviceFarmClient()
+        m_s3 = MockS3Client()
+        fakeReport = {
+            "name": "test",
+            "arn": "arn-run-report",
+            "status": "COMPLETED",
+            "result": "PASSED",
+            "counters": {"total": 3, "passed": 3, "failed": 0, "warned": 0},
+        }
+        processor = ReportProcessor(
+            m_df.getMockClient(), m_s3.getMockClient(), "IOS", "wf1", 1
+        )
+        artifacts = processor.start(fakeReport)
+
+        m_df.getMockClient().list_jobs.assert_called_once()
+        self.assertEqual(m_df.getMockClient().list_suites.call_count, 2)
+        self.assertEqual(m_df.getMockClient().list_tests.call_count, 6)
+
+        self.assertEqual(len(artifacts), 36)
+        print(artifacts[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/device-farm-runner/test_run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/test_run_on_aws_devicefarm.py
@@ -5,11 +5,13 @@ from unittest import mock
 from unittest.mock import MagicMock
 from typing import Any, Dict
 from run_on_aws_devicefarm import ReportProcessor, download_artifact
+import copy
 
 
 class MockS3Client:
     def __init__(self):
         self.mock_aws_client = MagicMock()
+        self.mock_aws_client.upload_file.return_value=None
 
     def getMockClient(self) -> MagicMock:
         return self.mock_aws_client
@@ -21,27 +23,50 @@ class MockDeviceFarmClient:
         self.mock_aws_client.list_jobs.return_value = self.mockJobs()
         self.mock_aws_client.list_suites.return_value = self.mockSuites()
         self.mock_aws_client.list_tests.return_value = self.mockTests()
-        self.mock_aws_client.list_artifacts.return_value = {
-            "artifacts": [
-                {
-                    "type": "LOGS",
-                    "name": "logs",
-                    "extension": "test",
-                    "arn": "arn-artifact1",
-                    "url": "url-artifact1",
-                },
-                {
-                    "type": "TESTSPEC_OUTPUT",
-                    "name": "test spec output",
-                    "extension": "output",
-                    "arn": "arn-artifact2",
-                    "url": "url-artifact2",
-                },
-            ]
-        }
+        self.mock_aws_client.list_artifacts.side_effect = (
+            lambda arn, type: self.getArtifacts(arn, type)
+        )
 
     def getMockClient(self) -> MagicMock:
         return self.mock_aws_client
+
+    def getArtifacts(self, arn: str, type: str):
+        if type == "FILE":
+            return {
+                "artifacts": [
+                    {
+                        "type": "TESTSPEC_OUTPUT",
+                        "name": "test spec output",
+                        "extension": "output",
+                        "arn": "arn-artifact1",
+                        "url": "url-artifact1",
+                    },
+                ]
+            }
+        elif type == "LOG":
+            return {
+                "artifacts": [
+                    {
+                        "type": "LOG",
+                        "name": "test log",
+                        "extension": "output",
+                        "arn": "arn-artifact2",
+                        "url": "url-artifact2",
+                    },
+                ]
+            }
+        else:
+            return {
+                "artifacts": [
+                    {
+                        "type": "VIDEO",
+                        "name": "test video",
+                        "extension": "output",
+                        "arn": "arn-artifac3",
+                        "url": "url-artifact3",
+                    },
+                ]
+            }
 
     def mockTests(self) -> Any:
         return {
@@ -89,7 +114,7 @@ class MockDeviceFarmClient:
                     "arn": "arn-suite2",
                     "name": "Tests Suite",
                     "status": "COMPLETED",
-                    "result": "PASSED",
+                    "result": "FAILED",
                     "counters": {
                         "total": 1,
                         "passed": 1,
@@ -101,21 +126,6 @@ class MockDeviceFarmClient:
                     },
                     "message": "Tests passed",
                 },
-                {
-                    "arn": "arn-suite3",
-                    "name": "Teardown Suite",
-                    "status": "COMPLETED",
-                    "result": "PASSED",
-                    "counters": {
-                        "total": 1,
-                        "passed": 1,
-                        "failed": 0,
-                        "warned": 0,
-                        "errored": 0,
-                        "stopped": 0,
-                        "skipped": 0,
-                    },
-                },
             ],
             "ResponseMetadata": {},
         }
@@ -124,7 +134,7 @@ class MockDeviceFarmClient:
         return {
             "jobs": [
                 {
-                    "arn": "arn-job1",
+                    "arn": "arn-job-1",
                     "name": "Apple iPhone 15",
                     "status": "COMPLETED",
                     "result": "PASSED",
@@ -150,14 +160,14 @@ class MockDeviceFarmClient:
                     },
                 },
                 {
-                    "arn": "arn-job2",
-                    "name": "Apple iPhone 15 Pro",
-                    "status": "COMPLETED",
+                    "arn": "arn-job-2",
+                    "name": "Apple iPhone 17 Pro",
+                    "status": "FAILED",
                     "result": "PASSED",
                     "counters": {
                         "total": 3,
-                        "passed": 2,
-                        "failed": 1,
+                        "passed": 3,
+                        "failed": 0,
                         "warned": 0,
                         "errored": 0,
                         "stopped": 0,
@@ -167,15 +177,17 @@ class MockDeviceFarmClient:
                     "device": {
                         "arn": "device:00",
                         "name": "Apple iPhone 15",
-                        "model": "Apple iPhone 15 Pro",
-                        "modelId": "A2222",
+                        "manufacturer": "Apple",
+                        "model": "Apple iPhone 15",
+                        "modelId": "A2846",
                         "formFactor": "PHONE",
                         "platform": "IOS",
-                        "os": "17.7",
+                        "os": "11.0",
                     },
                 },
             ]
         }
+
 
 class Test(unittest.TestCase):
     @mock.patch("run_on_aws_devicefarm.download_artifact")
@@ -194,17 +206,44 @@ class Test(unittest.TestCase):
         )
         artifacts = processor.start(fakeReport)
 
+        # assert aws client calls
         m_df.getMockClient().list_jobs.assert_called_once()
         self.assertEqual(m_df.getMockClient().list_suites.call_count, 2)
-        self.assertEqual(m_df.getMockClient().list_tests.call_count, 6)
-        self.assertEqual(m_s3.getMockClient().upload_file.call_count, 36)
-        self.assertEqual(len(artifacts), 36)
+        self.assertEqual(m_df.getMockClient().list_tests.call_count, 4)
+        self.assertEqual(m_s3.getMockClient().upload_file.call_count, 12)
+        self.assertEqual(m_s3.getMockClient().upload_file.call_count, 12)
+        self.assertEqual(download_artifact_mock.call_count, 12)
+        self.assertEqual(m_s3.getMockClient().upload_file.call_count,12)
 
-        print("yang",artifacts[0])
+        # assert artifacts
+        self.assertEqual(len(artifacts), 12)
+
+        job1_artifacts = [
+            artifact for artifact in artifacts if artifact.get("job_arn") == "arn-job-1"
+        ]
+        self.assertEqual(len(job1_artifacts), 6)
+        a1 = job1_artifacts[0]
+        self.assertEqual(a1["app_type"], 'IOS')
+        self.assertEqual(a1["job_arn"], 'arn-job-1')
+        self.assertEqual(a1["job_conclusion"], 'PASSED')
+        self.assertEqual(a1["job_name"], 'Apple iPhone 15')
+        self.assertEqual(a1["os"], '18.0')
+        self.assertEqual(a1["name"], 'test spec output')
+
+        job2_artifacts = [
+            artifact for artifact in artifacts if artifact["job_arn"] == "arn-job-2"
+        ]
+        self.assertEqual(len(job2_artifacts), 6)
+        a2 = job2_artifacts[0]
+        self.assertEqual(a2["app_type"], 'IOS')
+        self.assertEqual(a2["job_arn"], 'arn-job-2')
+        self.assertEqual(a2["job_conclusion"], 'PASSED')
+        self.assertEqual(a2["job_name"], 'Apple iPhone 17 Pro')
+        self.assertEqual(a2["os"], '11.0')
+        self.assertEqual(a2["name"], 'test spec output')
 
     @mock.patch("run_on_aws_devicefarm.download_artifact")
     def test_reportProcessor_debug(self, download_artifact_mock):
-
         m_df = MockDeviceFarmClient()
         m_s3 = MockS3Client()
         fakeReport = {
@@ -221,10 +260,11 @@ class Test(unittest.TestCase):
 
         m_df.getMockClient().list_jobs.assert_called_once()
         self.assertEqual(m_df.getMockClient().list_suites.call_count, 2)
-        self.assertEqual(m_df.getMockClient().list_tests.call_count, 6)
-        self.assertEqual(len(artifacts), 36)
+        self.assertEqual(m_df.getMockClient().list_tests.call_count, 4)
+        self.assertEqual(download_artifact_mock.call_count, 12)
+        self.assertEqual(len(artifacts), 12)
 
-        self.assertEqual(m_s3.getMockClient().upload_file.call_count, 0)
+        self.assertEqual(m_s3.getMockClient().upload_file.call_count,0)
 
 
 if __name__ == "__main__":

--- a/tools/device-farm-runner/test_run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/test_run_on_aws_devicefarm.py
@@ -204,6 +204,7 @@ class Test(unittest.TestCase):
 
     @mock.patch("run_on_aws_devicefarm.download_artifact")
     def test_reportProcessor_debug(self, download_artifact_mock):
+
         m_df = MockDeviceFarmClient()
         m_s3 = MockS3Client()
         fakeReport = {

--- a/tools/device-farm-runner/test_run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/test_run_on_aws_devicefarm.py
@@ -267,6 +267,33 @@ class Test(unittest.TestCase):
 
         self.assertEqual(m_s3.getMockClient().upload_file.call_count, 0)
 
+    def test_reportProcessor_emptyReportInput_returnEmptyList(self):
+        m_df = MockDeviceFarmClient()
+        m_s3 = MockS3Client()
+        fakeReport = {}
+        processor = ReportProcessor(
+            m_df.getMockClient(), m_s3.getMockClient(), "IOS", "wf1", 1, True
+        )
+        artifacts = processor.start(fakeReport)
+
+        self.assertEqual(m_df.getMockClient().list_jobs.call_count, 0)
+        self.assertEqual(len(artifacts), 0)
+
+    def test_reportProcessor_missingArnInReportInput_returnEmptyList(self):
+        m_df = MockDeviceFarmClient()
+        m_s3 = MockS3Client()
+        fakeReport = {
+            "status": "COMPLETED",
+            "result": "PASSED",
+        }
+        processor = ReportProcessor(
+            m_df.getMockClient(), m_s3.getMockClient(), "IOS", "wf1", 1
+        )
+        artifacts = processor.start(fakeReport)
+
+        self.assertEqual(m_df.getMockClient().list_jobs.call_count, 0)
+        self.assertEqual(len(artifacts), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/device-farm-runner/test_run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/test_run_on_aws_devicefarm.py
@@ -197,9 +197,33 @@ class Test(unittest.TestCase):
         m_df.getMockClient().list_jobs.assert_called_once()
         self.assertEqual(m_df.getMockClient().list_suites.call_count, 2)
         self.assertEqual(m_df.getMockClient().list_tests.call_count, 6)
-
+        self.assertEqual(m_s3.getMockClient().upload_file.call_count, 36)
         self.assertEqual(len(artifacts), 36)
-        print(artifacts[0])
+
+        print("yang",artifacts[0])
+
+    @mock.patch("run_on_aws_devicefarm.download_artifact")
+    def test_reportProcessor_debug(self, download_artifact_mock):
+        m_df = MockDeviceFarmClient()
+        m_s3 = MockS3Client()
+        fakeReport = {
+            "name": "test",
+            "arn": "arn-run-report",
+            "status": "COMPLETED",
+            "result": "PASSED",
+            "counters": {"total": 3, "passed": 3, "failed": 0, "warned": 0},
+        }
+        processor = ReportProcessor(
+            m_df.getMockClient(), m_s3.getMockClient(), "IOS", "wf1", 1, True
+        )
+        artifacts = processor.start(fakeReport)
+
+        m_df.getMockClient().list_jobs.assert_called_once()
+        self.assertEqual(m_df.getMockClient().list_suites.call_count, 2)
+        self.assertEqual(m_df.getMockClient().list_tests.call_count, 6)
+        self.assertEqual(len(artifacts), 36)
+
+        self.assertEqual(m_s3.getMockClient().upload_file.call_count, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
https://github.com/pytorch/test-infra/issues/6294

Details:
- print `os` in test spect printout section
- store os, job_arn (mobile job) and job_conclusion to each artifact metadata. Notice this is not github job conclusion, this is mobile job conclusion.
- wrap post-test logics into ReportProcessor, 
    - pass aws client as parameter for test-driven purpose
    - add unit test for ReportProcessor