### PR TITLE
[XPU] Enable python 3.13t in binary build matrix

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -488,8 +488,8 @@ def generate_wheels_matrix(
                 "" if arch_version in [CPU, CPU_AARCH64, XPU] else arch_version
             )
 
-            # TODO: Enable python 3.13t on xpu and cpu-s390x or Windows
-            if (gpu_arch_type in ["xpu", "cpu-s390x"]) and python_version == "3.13t":
+            # TODO: Enable python 3.13t on cpu-s390x or Windows
+            if (gpu_arch_type == "cpu-s390x") and python_version == "3.13t":
                 continue
 
             desired_cuda = translate_desired_cuda(gpu_arch_type, gpu_arch_version)

--- a/tools/tests/assets/build_matrix_linux_wheel_xpu.json
+++ b/tools/tests/assets/build_matrix_linux_wheel_xpu.json
@@ -344,6 +344,21 @@
       "upload_to_base_bucket": "no",
       "stable_version": "2.6.0",
       "use_split_build": false
+    },
+    {
+      "python_version": "3.13t",
+      "gpu_arch_type": "xpu",
+      "gpu_arch_version": "",
+      "desired_cuda": "xpu",
+      "container_image": "pytorch/manylinux2_28-builder:xpu",
+      "package_type": "manywheel",
+      "build_name": "manywheel-py3_13t-xpu",
+      "validation_runner": "linux.2xlarge",
+      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "channel": "nightly",
+      "upload_to_base_bucket": "no",
+      "stable_version": "2.6.0",
+      "use_split_build": false
     }
   ]
 }

--- a/tools/tests/assets/build_matrix_windows_wheel_cuda.json
+++ b/tools/tests/assets/build_matrix_windows_wheel_cuda.json
@@ -434,6 +434,21 @@
       "upload_to_base_bucket": "no",
       "stable_version": "2.6.0",
       "use_split_build": false
+    },
+    {
+      "python_version": "3.13t",
+      "gpu_arch_type": "xpu",
+      "gpu_arch_version": "",
+      "desired_cuda": "xpu",
+      "container_image": "pytorch/manylinux2_28-builder:xpu",
+      "package_type": "wheel",
+      "build_name": "wheel-py3_13t-xpu",
+      "validation_runner": "windows.4xlarge",
+      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "channel": "nightly",
+      "upload_to_base_bucket": "no",
+      "stable_version": "2.6.0",
+      "use_split_build": false
     }
   ]
 }

--- a/tools/tests/assets/build_matrix_windows_wheel_xpu.json
+++ b/tools/tests/assets/build_matrix_windows_wheel_xpu.json
@@ -164,6 +164,21 @@
       "upload_to_base_bucket": "yes",
       "stable_version": "2.6.0",
       "use_split_build": false
+    },
+    {
+      "python_version": "3.13t",
+      "gpu_arch_type": "xpu",
+      "gpu_arch_version": "",
+      "desired_cuda": "xpu",
+      "container_image": "pytorch/manylinux2_28-builder:xpu",
+      "package_type": "wheel",
+      "build_name": "wheel-py3_13t-xpu",
+      "validation_runner": "windows.4xlarge",
+      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "channel": "nightly",
+      "upload_to_base_bucket": "yes",
+      "stable_version": "2.6.0",
+      "use_split_build": false
     }
   ]
 }


### PR DESCRIPTION
As pytorch xpu enabled python 3.13t by https://github.com/pytorch/pytorch/pull/146614, enable python 3.13t for XPU binary build matrix