### PR TITLE
[ez][HUD] Update .env.example instructions to mention Keeper

### DIFF
--- a/torchci/.env.example
+++ b/torchci/.env.example
@@ -1,6 +1,5 @@
 # Copy this file to .env.local and add keys based on the instructions.  All of
-# these keys can be found on Vercel.  Please see the README about getting access
-# to Vercel.
+# these keys can be found on Keeper or Vercel.
 
 # GitHub App credentials for probot. Only needed if testing bot stuff locally.
 PRIVATE_KEY=


### PR DESCRIPTION
I moved some env vars to Keeper to enable sensitive env vars for [T212882155](https://www.internalfb.com/intern/tasks/?t=212882155), so this updates the .env.example instructions to also mention Keeper