### PR TITLE
[Benchmark] Prepare for execuTorch failure handling

### DIFF
--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -386,8 +386,10 @@ jobs:
               --new-json-output-format "${NEW_OUTPUT_FORMAT_FLAG}"
             popd
 
+
       - name: Check artifacts if any job fails
         if: failure()
+        working-directory: test-infra/tools/device-farm-runner
         shell: bash
         env:
           WORKING_DIRECTORY: test-infra/tools/device-farm-runner
@@ -395,14 +397,13 @@ jobs:
           IOS_FILE: ios-artifacts-${{ steps.get-job-id.outputs.job-id }}.json
           ANDROID_FILE: android-artifacts-${{ steps.get-job-id.outputs.job-id }}.json
           GIT_JOB_NAME: ${{ steps.get-job-id.outputs.job-name }}
-        run:
-          pushd "${WORKING_DIRECTORY}"
+        run: |
           if [[ "$DEVICE_TYPE" == "android" && ! -f "$ANDROID_FILE"]]; then
-            echo "missing andrroid artifact json, generating ..."
-            echo '{"git_job_name": "$GIT_JOB_NAME" }' >> $ANDROID_FILE
+            echo "missing android artifact json, generating ..."
+            '{"git_job_name": "%s"}\n' "$GIT_JOB_NAME" >> $ANDROID_FILE
           if [[ "$DEVICE_TYPE" == "ios" && ! -f "$IOS_FILE"]]; then
             echo "missing ios artifact json, generating ..."
-            echo '{"git_job_name": "$GIT_JOB_NAME" }' >> $IOS_FILE
+            '{"git_job_name": "%s"}\n' "$GIT_JOB_NAME" >> $IOS_FILE
 
       - name: Upload iOS artifacts to S3
         uses: seemethere/upload-artifact-s3@v5

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -392,7 +392,6 @@ jobs:
         working-directory: test-infra/tools/device-farm-runner
         shell: bash
         env:
-          WORKING_DIRECTORY: test-infra/tools/device-farm-runner
           DEVICE_TYPE: ${{ inputs.device-type }}
           IOS_FILE: ios-artifacts-${{ steps.get-job-id.outputs.job-id }}.json
           ANDROID_FILE: android-artifacts-${{ steps.get-job-id.outputs.job-id }}.json

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -23,7 +23,6 @@ on:
         required: false
         type: string
         default: '3.11'
-
       # AWS Device Farm, this can be copied from AWS console and it's default to
       # PyTorch project
       project-arn:
@@ -34,6 +33,11 @@ on:
         description: The device pool associated with the project
         default: 'arn:aws:devicefarm:us-west-2::devicepool:082d10e5-d7d7-48a5-ba5c-b33d66efa1f5'
         type: string
+      new-output-format-flag:
+        description: experiment flag to enable the new artifact json format
+        required: false
+        default: false
+        type: boolean
 
       # Pulling test-infra itself for device farm runner script
       test-infra-repository:
@@ -362,6 +366,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
           JOB_ID: ${{ steps.get-job-id.outputs.job-id }}
           WORKING_DIRECTORY: test-infra/tools/device-farm-runner
+          NEW_OUTPUT_FORMAT_FLAG: ${{ inputs.new-output-format-flag }}
         uses: nick-fields/retry@v3.0.0
         with:
           shell: bash
@@ -382,7 +387,8 @@ jobs:
               --name-prefix "${JOB_NAME}-${DEVICE_TYPE}" \
               --workflow-id "${RUN_ID}" \
               --workflow-attempt "${RUN_ATTEMPT}" \
-              --output "android-artifacts-${JOB_ID}.json"
+              --output "android-artifacts-${JOB_ID}.json" \
+              --new-json-output-format ${NEW_OUTPUT_FORMAT_FLAG}
             popd
 
       - name: Upload Android artifacts to S3

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -393,21 +393,15 @@ jobs:
         shell: bash
         env:
           DEVICE_TYPE: ${{ inputs.device-type }}
-          IOS_FILE: ios-artifacts-${{ steps.get-job-id.outputs.job-id }}.json
-          ANDROID_FILE: android-artifacts-${{ steps.get-job-id.outputs.job-id }}.json
+          ARTIFACT_FILE: ${{ inputs.device-type }}-artifacts-${{ steps.get-job-id.outputs.job-id }}.json
           GIT_JOB_NAME: ${{ steps.get-job-id.outputs.job-name }}
         run: |
-          if [[ "$DEVICE_TYPE" == "android" && ! -f "$ANDROID_FILE" ]]; then
-            echo "missing android artifact json ${ANDROID_FILE}, generating ... "
-            echo "{\"git_job_name\": \"$GIT_JOB_NAME\"}" >> "$ANDROID_FILE"
+          if [[ ! -f "$ARTIFACT_FILE" ]]; then
+            echo "missing artifact json file for ${DEVICE_TYPE} with name ${ARTIFACT_FILE}, generating ... "
+            echo "{\"git_job_name\": \"$GIT_JOB_NAME\"}" >> "$ARTIFACT_FILE"
           fi
 
-          if [[ "$DEVICE_TYPE" == "ios" && ! -f "$IOS_FILE" ]]; then
-            echo "missing ios artifact json, generating ..."
-            echo "{\"git_job_name\": \"$GIT_JOB_NAME\"}" >> "$IOS_FILE"
-          fi
-
-      - name: Upload iOS artifacts to S3
+      - name: Upload artifacts to S3
         uses: seemethere/upload-artifact-s3@v5
         if: always()
         with:
@@ -416,15 +410,4 @@ jobs:
           s3-prefix: |
             device_farm/${{ github.run_id }}/${{ github.run_attempt }}/artifacts
           path: |
-            test-infra/tools/device-farm-runner/ios-artifacts-${{ steps.get-job-id.outputs.job-id }}.json
-
-      - name: Upload Android artifacts to S3
-        uses: seemethere/upload-artifact-s3@v5
-        if: always()
-        with:
-          retention-days: 14
-          s3-bucket: gha-artifacts
-          s3-prefix: |
-            device_farm/${{ github.run_id }}/${{ github.run_attempt }}/artifacts
-          path: |
-            test-infra/tools/device-farm-runner/android-artifacts-${{ steps.get-job-id.outputs.job-id }}.json
+            test-infra/tools/device-farm-runner/${{ inputs.device-type }}-artifacts-${{ steps.get-job-id.outputs.job-id }}.json

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -390,15 +390,18 @@ jobs:
         if: failure()
         shell: bash
         env:
+          WORKING_DIRECTORY: test-infra/tools/device-farm-runner
           DEVICE_TYPE: ${{ inputs.device-type }}
           IOS_FILE: ios-artifacts-${{ steps.get-job-id.outputs.job-id }}.json
           ANDROID_FILE: android-artifacts-${{ steps.get-job-id.outputs.job-id }}.json
-          GIT_JOB_NAME: ${{ GIT_JOB_NAME}}
-        run: |
+          GIT_JOB_NAME: ${{ steps.get-job-id.outputs.job-name }}
+        run:
+          pushd "${WORKING_DIRECTORY}"
           if [[ "$DEVICE_TYPE" == "android" && ! -f "$ANDROID_FILE"]]; then
+            echo "missing andrroid artifact json, generating ..."
             echo '{"git_job_name": "$GIT_JOB_NAME" }' >> $ANDROID_FILE
-
           if [[ "$DEVICE_TYPE" == "ios" && ! -f "$IOS_FILE"]]; then
+            echo "missing ios artifact json, generating ..."
             echo '{"git_job_name": "$GIT_JOB_NAME" }' >> $IOS_FILE
 
       - name: Upload iOS artifacts to S3

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -388,7 +388,7 @@ jobs:
               --workflow-id "${RUN_ID}" \
               --workflow-attempt "${RUN_ATTEMPT}" \
               --output "android-artifacts-${JOB_ID}.json" \
-              --new-json-output-format ${NEW_OUTPUT_FORMAT_FLAG}
+              --new-json-output-format "${NEW_OUTPUT_FORMAT_FLAG}"
             popd
 
       - name: Upload Android artifacts to S3

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -398,10 +398,13 @@ jobs:
         run: |
           if [[ "$DEVICE_TYPE" == "android" && ! -f "$ANDROID_FILE" ]]; then
             echo "missing android artifact json, generating ..."
-            '{"git_job_name": "%s"}\n' "$GIT_JOB_NAME" >> $ANDROID_FILE
+            '{"git_job_name": "%s"}\n' "$GIT_JOB_NAME" >> "$ANDROID_FILE"
+          fi
+
           if [[ "$DEVICE_TYPE" == "ios" && ! -f "$IOS_FILE" ]]; then
             echo "missing ios artifact json, generating ..."
-            '{"git_job_name": "%s"}\n' "$GIT_JOB_NAME" >> $IOS_FILE
+            '{"git_job_name": "%s"}\n' "$GIT_JOB_NAME" >> "$IOS_FILE"
+          fi
 
       - name: Upload iOS artifacts to S3
         uses: seemethere/upload-artifact-s3@v5

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -386,7 +386,6 @@ jobs:
               --new-json-output-format "${NEW_OUTPUT_FORMAT_FLAG}"
             popd
 
-
       - name: Check artifacts if any job fails
         if: failure()
         working-directory: test-infra/tools/device-farm-runner
@@ -397,10 +396,10 @@ jobs:
           ANDROID_FILE: android-artifacts-${{ steps.get-job-id.outputs.job-id }}.json
           GIT_JOB_NAME: ${{ steps.get-job-id.outputs.job-name }}
         run: |
-          if [[ "$DEVICE_TYPE" == "android" && ! -f "$ANDROID_FILE"]]; then
+          if [[ "$DEVICE_TYPE" == "android" && ! -f "$ANDROID_FILE" ]]; then
             echo "missing android artifact json, generating ..."
             '{"git_job_name": "%s"}\n' "$GIT_JOB_NAME" >> $ANDROID_FILE
-          if [[ "$DEVICE_TYPE" == "ios" && ! -f "$IOS_FILE"]]; then
+          if [[ "$DEVICE_TYPE" == "ios" && ! -f "$IOS_FILE" ]]; then
             echo "missing ios artifact json, generating ..."
             '{"git_job_name": "%s"}\n' "$GIT_JOB_NAME" >> $IOS_FILE
 

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -393,12 +393,12 @@ jobs:
         shell: bash
         env:
           DEVICE_TYPE: ${{ inputs.device-type }}
-          ARTIFACT_FILE: ${{ inputs.device-type }}-artifacts-${{ steps.get-job-id.outputs.job-id }}.json
+          BENCHMARK_OUTPUT: ${{ inputs.device-type }}-artifacts-${{ steps.get-job-id.outputs.job-id }}.json
           GIT_JOB_NAME: ${{ steps.get-job-id.outputs.job-name }}
         run: |
-          if [[ ! -f "$ARTIFACT_FILE" ]]; then
-            echo "missing artifact json file for ${DEVICE_TYPE} with name ${ARTIFACT_FILE}, generating ... "
-            echo "{\"git_job_name\": \"$GIT_JOB_NAME\"}" >> "$ARTIFACT_FILE"
+          if [[ ! -f "$BENCHMARK_OUTPUT" ]]; then
+            echo "missing artifact json file for ${DEVICE_TYPE} with name ${BENCHMARK_OUTPUT}, generating ... "
+            echo "{\"git_job_name\": \"$GIT_JOB_NAME\"}" >> "$BENCHMARK_OUTPUT"
           fi
 
       - name: Upload artifacts to S3

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -314,7 +314,9 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
           JOB_ID: ${{ steps.get-job-id.outputs.job-id }}
+          GIT_JOB_NAME:  ${{ steps.get-job-id.outputs.job-name }}
           WORKING_DIRECTORY: test-infra/tools/device-farm-runner
+          NEW_OUTPUT_FORMAT_FLAG: ${{ inputs.new-output-format-flag }}
         uses: nick-fields/retry@v3.0.0
         with:
           shell: bash
@@ -336,6 +338,8 @@ jobs:
               --workflow-id "${RUN_ID}" \
               --workflow-attempt "${RUN_ATTEMPT}" \
               --output "ios-artifacts-${JOB_ID}.json"
+              --git-job-name "${GIT_JOB_NAME}"
+              --new-json-output-format "${NEW_OUTPUT_FORMAT_FLAG}"
             popd
 
       - name: Upload iOS artifacts to S3
@@ -365,6 +369,7 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
           JOB_ID: ${{ steps.get-job-id.outputs.job-id }}
+          GIT_JOB_NAME:  ${{ steps.get-job-id.outputs.job-name }}
           WORKING_DIRECTORY: test-infra/tools/device-farm-runner
           NEW_OUTPUT_FORMAT_FLAG: ${{ inputs.new-output-format-flag }}
         uses: nick-fields/retry@v3.0.0
@@ -388,6 +393,7 @@ jobs:
               --workflow-id "${RUN_ID}" \
               --workflow-attempt "${RUN_ATTEMPT}" \
               --output "android-artifacts-${JOB_ID}.json" \
+              --git-job-name "${GIT_JOB_NAME}"
               --new-json-output-format "${NEW_OUTPUT_FORMAT_FLAG}"
             popd
 

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -342,17 +342,6 @@ jobs:
               --new-json-output-format "${NEW_OUTPUT_FORMAT_FLAG}"
             popd
 
-      - name: Upload iOS artifacts to S3
-        uses: seemethere/upload-artifact-s3@v5
-        if: always()
-        with:
-          retention-days: 14
-          s3-bucket: gha-artifacts
-          s3-prefix: |
-            device_farm/${{ github.run_id }}/${{ github.run_attempt }}/artifacts
-          path: |
-            test-infra/tools/device-farm-runner/ios-artifacts-${{ steps.get-job-id.outputs.job-id }}.json
-
       - name: Run Android tests on devices
         id: android-test
         if: ${{ inputs.device-type == 'android' }}
@@ -396,6 +385,32 @@ jobs:
               --git-job-name "${GIT_JOB_NAME}" \
               --new-json-output-format "${NEW_OUTPUT_FORMAT_FLAG}"
             popd
+
+      - name: Check artifacts if any job fails
+        if: failure()
+        shell: bash
+        env:
+          DEVICE_TYPE: ${{ inputs.device-type }}
+          IOS_FILE: ios-artifacts-${{ steps.get-job-id.outputs.job-id }}.json
+          ANDROID_FILE: android-artifacts-${{ steps.get-job-id.outputs.job-id }}.json
+          GIT_JOB_NAME: ${{ GIT_JOB_NAME}}
+        run: |
+          if [[ "$DEVICE_TYPE" == "android" && ! -f "$ANDROID_FILE"]]; then
+            echo '{"git_job_name": "$GIT_JOB_NAME" }' >> $ANDROID_FILE
+
+          if [[ "$DEVICE_TYPE" == "ios" && ! -f "$IOS_FILE"]]; then
+            echo '{"git_job_name": "$GIT_JOB_NAME" }' >> $IOS_FILE
+
+      - name: Upload iOS artifacts to S3
+        uses: seemethere/upload-artifact-s3@v5
+        if: always()
+        with:
+          retention-days: 14
+          s3-bucket: gha-artifacts
+          s3-prefix: |
+            device_farm/${{ github.run_id }}/${{ github.run_attempt }}/artifacts
+          path: |
+            test-infra/tools/device-farm-runner/ios-artifacts-${{ steps.get-job-id.outputs.job-id }}.json
 
       - name: Upload Android artifacts to S3
         uses: seemethere/upload-artifact-s3@v5

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -397,13 +397,13 @@ jobs:
           GIT_JOB_NAME: ${{ steps.get-job-id.outputs.job-name }}
         run: |
           if [[ "$DEVICE_TYPE" == "android" && ! -f "$ANDROID_FILE" ]]; then
-            echo "missing android artifact json, generating ..."
-            '{"git_job_name": "%s"}\n' "$GIT_JOB_NAME" >> "$ANDROID_FILE"
+            echo "missing android artifact json ${ANDROID_FILE}, generating ... "
+            echo "{\"git_job_name\": \"$GIT_JOB_NAME\"}" >> "$ANDROID_FILE"
           fi
 
           if [[ "$DEVICE_TYPE" == "ios" && ! -f "$IOS_FILE" ]]; then
             echo "missing ios artifact json, generating ..."
-            '{"git_job_name": "%s"}\n' "$GIT_JOB_NAME" >> "$IOS_FILE"
+            echo "{\"git_job_name\": \"$GIT_JOB_NAME\"}" >> "$IOS_FILE"
           fi
 
       - name: Upload iOS artifacts to S3

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -23,6 +23,7 @@ on:
         required: false
         type: string
         default: '3.11'
+
       # AWS Device Farm, this can be copied from AWS console and it's default to
       # PyTorch project
       project-arn:

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -337,8 +337,8 @@ jobs:
               --name-prefix "${JOB_NAME}-${DEVICE_TYPE}" \
               --workflow-id "${RUN_ID}" \
               --workflow-attempt "${RUN_ATTEMPT}" \
-              --output "ios-artifacts-${JOB_ID}.json"
-              --git-job-name "${GIT_JOB_NAME}"
+              --output "ios-artifacts-${JOB_ID}.json" \
+              --git-job-name "${GIT_JOB_NAME}" \
               --new-json-output-format "${NEW_OUTPUT_FORMAT_FLAG}"
             popd
 
@@ -393,7 +393,7 @@ jobs:
               --workflow-id "${RUN_ID}" \
               --workflow-attempt "${RUN_ATTEMPT}" \
               --output "android-artifacts-${JOB_ID}.json" \
-              --git-job-name "${GIT_JOB_NAME}"
+              --git-job-name "${GIT_JOB_NAME}" \
               --new-json-output-format "${NEW_OUTPUT_FORMAT_FLAG}"
             popd
 

--- a/.github/workflows/test_mobile_job.yml
+++ b/.github/workflows/test_mobile_job.yml
@@ -42,7 +42,6 @@ jobs:
       test-spec: https://ossci-assets.s3.amazonaws.com/android-llm-device-farm-test-spec.yml
       extra-data: https://ossci-assets.s3.amazonaws.com/executorch-android-llama2-7b-0717.zip
 
-
   test-ios-job-with-new-output-flag:
     permissions:
       id-token: write

--- a/.github/workflows/test_mobile_job.yml
+++ b/.github/workflows/test_mobile_job.yml
@@ -18,7 +18,7 @@ jobs:
       device-type: ios
       # For iOS testing, the runner just needs to call AWS Device Farm, so there is no need to run this on macOS
       runner: ubuntu-latest
-      # There values are prepared beforehand for the test
+      # These values are prepared beforehand for the test
       project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:b531574a-fb82-40ae-b687-8f0b81341ae0
       device-pool-arn: arn:aws:devicefarm:us-west-2:308535385114:devicepool:b531574a-fb82-40ae-b687-8f0b81341ae0/da5d902d-45db-477b-ae0a-766e06ef3845
       ios-ipa-archive: https://ossci-assets.s3.amazonaws.com/DeviceFarm.ipa
@@ -34,7 +34,7 @@ jobs:
       device-type: android
       runner: ubuntu-latest
       timeout: 120
-      # There values are prepared beforehand for the test
+      # These values are prepared beforehand for the test
       project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:b531574a-fb82-40ae-b687-8f0b81341ae0
       device-pool-arn: arn:aws:devicefarm:us-west-2:308535385114:devicepool:b531574a-fb82-40ae-b687-8f0b81341ae0/bd86eb80-74a6-4511-8183-09aa66e3ccc4
       android-app-archive: https://ossci-assets.s3.amazonaws.com/app-debug.apk
@@ -51,7 +51,7 @@ jobs:
       device-type: ios
       # For iOS testing, the runner just needs to call AWS Device Farm, so there is no need to run this on macOS
       runner: ubuntu-latest
-      # There values are prepared beforehand for the test
+      # These values are prepared beforehand for the test
       project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:b531574a-fb82-40ae-b687-8f0b81341ae0
       device-pool-arn: arn:aws:devicefarm:us-west-2:308535385114:devicepool:b531574a-fb82-40ae-b687-8f0b81341ae0/da5d902d-45db-477b-ae0a-766e06ef3845
       ios-ipa-archive: https://ossci-assets.s3.amazonaws.com/DeviceFarm.ipa
@@ -68,7 +68,7 @@ jobs:
       device-type: android
       runner: ubuntu-latest
       timeout: 120
-      # There values are prepared beforehand for the test
+      # These values are prepared beforehand for the test
       project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:b531574a-fb82-40ae-b687-8f0b81341ae0
       device-pool-arn: arn:aws:devicefarm:us-west-2:308535385114:devicepool:b531574a-fb82-40ae-b687-8f0b81341ae0/bd86eb80-74a6-4511-8183-09aa66e3ccc4
       android-app-archive: https://ossci-assets.s3.amazonaws.com/app-debug.apk

--- a/.github/workflows/test_mobile_job.yml
+++ b/.github/workflows/test_mobile_job.yml
@@ -41,3 +41,39 @@ jobs:
       android-test-archive: https://ossci-assets.s3.amazonaws.com/app-debug-androidTest.apk
       test-spec: https://ossci-assets.s3.amazonaws.com/android-llm-device-farm-test-spec.yml
       extra-data: https://ossci-assets.s3.amazonaws.com/executorch-android-llama2-7b-0717.zip
+
+
+  test-ios-job-with-new-output-flag:
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/mobile_job.yml
+    with:
+      device-type: ios
+      # For iOS testing, the runner just needs to call AWS Device Farm, so there is no need to run this on macOS
+      runner: ubuntu-latest
+      # There values are prepared beforehand for the test
+      project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:b531574a-fb82-40ae-b687-8f0b81341ae0
+      device-pool-arn: arn:aws:devicefarm:us-west-2:308535385114:devicepool:b531574a-fb82-40ae-b687-8f0b81341ae0/da5d902d-45db-477b-ae0a-766e06ef3845
+      ios-ipa-archive: https://ossci-assets.s3.amazonaws.com/DeviceFarm.ipa
+      ios-xctestrun-zip: https://ossci-assets.s3.amazonaws.com/MobileNetClassifierTest_MobileNetClassifierTest_iphoneos17.4-arm64.xctestrun.zip
+      test-spec: https://ossci-assets.s3.amazonaws.com/default-ios-device-farm-appium-test-spec.yml
+      new-output-format-flag: true
+
+  test-android-llama2-job-with-new-output-flag:
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/mobile_job.yml
+    with:
+      device-type: android
+      runner: ubuntu-latest
+      timeout: 120
+      # There values are prepared beforehand for the test
+      project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:b531574a-fb82-40ae-b687-8f0b81341ae0
+      device-pool-arn: arn:aws:devicefarm:us-west-2:308535385114:devicepool:b531574a-fb82-40ae-b687-8f0b81341ae0/bd86eb80-74a6-4511-8183-09aa66e3ccc4
+      android-app-archive: https://ossci-assets.s3.amazonaws.com/app-debug.apk
+      android-test-archive: https://ossci-assets.s3.amazonaws.com/app-debug-androidTest.apk
+      test-spec: https://ossci-assets.s3.amazonaws.com/android-llm-device-farm-test-spec.yml
+      extra-data: https://ossci-assets.s3.amazonaws.com/executorch-android-llama2-7b-0717.zip
+      new-output-format-flag: true

--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -415,6 +415,7 @@ class DeviceFarmReport:
     status: str
     result: str
     counters: Dict[str, str]
+    app_type: str
     infos: Dict[str, str]
     parent_arn: str
 
@@ -540,7 +541,7 @@ class ReportProcessor:
         return artifacts
 
     def _to_job_report(
-        self, report: Dict[str, Any], parent_arn: str, infos: Dict[str, str] = dict()
+        self, report: Dict[str, Any],parent_arn: str, infos: Dict[str, str] = dict()
     ) -> JobReport:
         arn = report.get("arn", "")
         status = report.get("status", "")
@@ -551,6 +552,7 @@ class ReportProcessor:
         return JobReport(
             arn=arn,
             name=name,
+            app_type=self.app_type,
             report_type=ReportType.JOB.value,
             status=status,
             result=result,
@@ -570,6 +572,7 @@ class ReportProcessor:
         return DeviceFarmReport(
             name=name,
             arn=arn,
+            app_type=self.app_type,
             report_type=ReportType.RUN.value,
             status=status,
             result=result,
@@ -667,7 +670,8 @@ class ReportProcessor:
             return DeviceFarmReport(
                 name="",
                 arn="",
-                report_type="",
+                app_type=self.app_type,
+                report_type=ReportType.RUN.value,
                 status="",
                 result="",
                 counters={},

--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -208,7 +208,7 @@ def parse_args() -> Any:
     )
 
     parser.add_argument(
-        "--new-json-output",
+        "--new-json-output-format",
         action="store_true",
         help="enable new json artifact output format with jobrun, and list of artifacts, this is temporary ",
     )

--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -709,10 +709,8 @@ def generate_artifacts_output(
     artifacts: List[Dict[str, str]],
     run_report: DeviceFarmReport,
     job_reports: List[JobReport],
-    app_type: str,
 ):
     output = {
-        "app_type": app_type,
         "artifacts": artifacts,
         "run_report": asdict(run_report),
         "job_reports": [asdict(job_report) for job_report in job_reports],
@@ -722,6 +720,12 @@ def generate_artifacts_output(
 
 def main() -> None:
     args = parse_args()
+
+    # (TODO): remove this once remove the flag.
+    if args.args.new_json_output_format == "true":
+        info("use new json output format")
+    else:
+        info("use legacy json output format")
 
     project_arn = args.project_arn
     name_prefix = args.name_prefix
@@ -818,14 +822,11 @@ def main() -> None:
         )
         artifacts = processor.start(r.get("run"))
 
-        info(f"set new_json_output_format: {args.new_json_output_format}")
         if args.new_json_output_format == "true":
-            info("Generating new json output")
             output = generate_artifacts_output(
                 artifacts,
                 processor.get_run_report(),
                 processor.get_job_reports(),
-                app_type
             )
             set_output(json.dumps(output), "artifacts", args.output)
         else:

--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -699,6 +699,19 @@ class ReportProcessor:
         )
 
 
+def generate_artifacts_output(
+    artifacts: List[Dict[str, str]],
+    run_report: DeviceFarmReport,
+    job_reports: List[JobReport],
+):
+    output = {
+        "artifacts": artifacts,
+        "run_report": asdict(run_report),
+        "job_reports": [asdict(job_report) for job_report in job_reports],
+    }
+    return output
+
+
 def main() -> None:
     args = parse_args()
 
@@ -797,7 +810,7 @@ def main() -> None:
         )
         artifacts = processor.start(r.get("run"))
 
-        if args.new_json_output:
+        if args.new_json_output_format:
             info("Generating new json output")
             output = generate_artifacts_output(
                 artifacts, processor.get_run_report(), processor.get_job_reports()
@@ -809,19 +822,6 @@ def main() -> None:
         processor.print_test_spec()
     if not is_success(result):
         sys.exit(1)
-
-
-def generate_artifacts_output(
-    artifacts: List[Dict[str, str]],
-    run_report: DeviceFarmReport,
-    job_reports: List[JobReport],
-):
-    output = {
-        "artifacts": artifacts,
-        "run_report": asdict(run_report),
-        "job_reports": [asdict(job_report) for job_report in job_reports],
-    }
-    return output
 
 
 if __name__ == "__main__":

--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -223,7 +223,8 @@ def parse_args() -> Any:
 
     # in case when removing the flag, the mobile jobs does not failed due to unrecognized flag.
     args, unknown = parser.parse_known_args()
-    info(f"detected unknown flags: {unknown}")
+    if len(unknown) > 0:
+        info(f"detected unknown flags: {unknown}")
     return args
 
 
@@ -734,9 +735,9 @@ def main() -> None:
 
     # (TODO): remove this once remove the flag.
     if args.new_json_output_format == "true":
-        info("use new json output format")
+        info(f"use new json output format for {args.output}")
     else:
-        info("use legacy json output format")
+        info("use legacy json output format for {args.output}")
 
     project_arn = args.project_arn
     name_prefix = args.name_prefix
@@ -824,11 +825,11 @@ def main() -> None:
             time.sleep(30)
     except Exception as error:
         warn(f"Failed to run {unique_prefix}: {error}")
-        if args.new_json_output_format == "true":
-            json_file = {
-                "git_job_name": args.git_job_name,
-            }
-            set_output(json.dumps(json_file), "artifacts", args.output)
+        # just use the new json output format
+        json_file = {
+            "git_job_name": args.git_job_name,
+        }
+        set_output(json.dumps(json_file), "artifacts", args.output)
         sys.exit(1)
     finally:
         info(f"Run {unique_prefix} finished with state {state} and result {result}")

--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -706,8 +706,10 @@ def generate_artifacts_output(
     artifacts: List[Dict[str, str]],
     run_report: DeviceFarmReport,
     job_reports: List[JobReport],
+    app_type: str,
 ):
     output = {
+        "app_type": app_type,
         "artifacts": artifacts,
         "run_report": asdict(run_report),
         "job_reports": [asdict(job_report) for job_report in job_reports],
@@ -816,7 +818,10 @@ def main() -> None:
         if args.new_json_output_format == "true":
             info("Generating new json output")
             output = generate_artifacts_output(
-                artifacts, processor.get_run_report(), processor.get_job_reports()
+                artifacts,
+                processor.get_run_report(),
+                processor.get_job_reports(),
+                app_type
             )
             set_output(json.dumps(output), "artifacts", args.output)
         else:

--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -209,8 +209,11 @@ def parse_args() -> Any:
 
     parser.add_argument(
         "--new-json-output-format",
-        action="store_true",
-        help="enable new json artifact output format with jobrun, and list of artifacts, this is temporary ",
+        type=str,
+        choices=["true", "false"],
+        default="false",
+        required=False,
+        help="enable new json artifact output format with mobile job reports and list of artifacts",
     )
 
     return parser.parse_args()
@@ -810,7 +813,7 @@ def main() -> None:
         )
         artifacts = processor.start(r.get("run"))
 
-        if args.new_json_output_format:
+        if args.new_json_output_format == "true":
             info("Generating new json output")
             output = generate_artifacts_output(
                 artifacts, processor.get_run_report(), processor.get_job_reports()

--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -722,7 +722,7 @@ def main() -> None:
     args = parse_args()
 
     # (TODO): remove this once remove the flag.
-    if args.args.new_json_output_format == "true":
+    if args.new_json_output_format == "true":
         info("use new json output format")
     else:
         info("use legacy json output format")

--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -216,7 +216,10 @@ def parse_args() -> Any:
         help="enable new json artifact output format with mobile job reports and list of artifacts",
     )
 
-    return parser.parse_args()
+    # in case when removing the flag, the mobile jobs does not failed due to unrecognized flag.
+    args, unknown = parser.parse_known_args()
+    info(f"detected unknown flags: {unknown}")
+    return args
 
 
 def upload_file(
@@ -815,6 +818,7 @@ def main() -> None:
         )
         artifacts = processor.start(r.get("run"))
 
+        info(f"set new_json_output_format: {args.new_json_output_format}")
         if args.new_json_output_format == "true":
             info("Generating new json output")
             output = generate_artifacts_output(


### PR DESCRIPTION
# Description
Issue: https://github.com/pytorch/test-infra/issues/6294
Prepare mobile_job yml to generate benchmark record when job fails.

## Background:  
When a git benchmark job failed (or some of the mobile job failed), we need to generate a benchmark record to indicate that model has failures.

For instace, a benchmark job with name:`benchmark-on-device (ic3, coreml_fp16, apple_iphone_15, arn:aws:devicefarm:us-west-2:308535385114... / mobile-job (ios) `
when the whole job failed, we want to indicate that the model ic3 with backend coreml_fp16 and IOS for all metrics is failed
when one of the devices in job is failed, (IPHONE 15 with os 17.1), we want to indicate that  the model ic3 with backend coreml_fp16 for IPHONE 15 with os 17.1 is failed, but others are success

key: always generate the artifact json with git job name.

## Change Details
- [yaml]add logic to generate artifact.json if any previous step fails and there is no expected artifact.json, this makes sure we always has the artifact json with git job name
- [script] add a flag `--new-json-output-format` to toggle the mobile job to generate artifact.json with new format.
   - see example of new json result ([s3 link](https://gha-artifacts.s3.us-east-1.amazonaws.com/device_farm/13821036006/1/artifacts/ios-artifacts-38666170088.json?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=ASIAUPVRELQNEU5O2WYP%2F20250312%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250312T212644Z&X-Amz-Expires=300&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEH4aCXVzLWVhc3QtMSJHMEUCIQC7%2BkVAOsGTimttLszL6u3N4HeFdSzwmPzlOYQBh%2BU%2BzwIgNjk%2FM73TZ9YfN6W92yjuRBUevYQ1BWWf0M7rmky4IT0q0AMIx%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARAFGgwzMDg1MzUzODUxMTQiDCWs46GorlC4PkgCmCqkA7TQ41pTu7Pw2vUyPArSC95%2FUUHvRy5DCUEGOUwKmscwv%2B0D9jRdGfQ05E4dtVKliXhNnBRu2oH2u9WIPGKgR3fFjrVRvy2bzQhMYVjAqfUnG%2BhVO2hOKC6U33bMMNJ4SziagDSsAwHBRXl2YLsd9x4ToLubWcHFd4RtE5ZTFQFBHoB05KmzRJ5O00P6m%2BmzBvNh0T%2F2nj2l5c66VmBOe5xeyqEEHXsw3jD98NGrff7nQrONMDpRLjS74Hz%2Fz%2BGJL9RNwNQ2yJYSUdmkrTk4wi7ToNGrzpJm4Lh7wOprHQVwqpVnYaZjw7bJrTk4of4%2FE0%2FBsI1L3GqCxCt6kig02JKYBOy2nFNeRMR09xCSVQCvZE39zKZxrbilH%2FwBzHCS8KvqP14hhGbo%2F%2F08DWVBTZIgrQii0lNaPkB6c%2F0%2BCghTCQv1hUqhIY3avR3TquZzdZNeavNVU6is%2ByJtFpVZzCCH1AzeCRMcnJAlHdGyv9guD5q5wMpRICAihdmFnFy1LQZNAjSisMr0Z4zFfRKJzGdKSpdyL9D5O063WU0VVtmfI0U4fzCz38e%2BBjqEApAZr2cVZ87wIvVZOhcPBDmz%2F9mBgH5LSIK0bfkuZz6vhkUpJbmHbID6YjraMitF1ht1%2FgQtCQkHaejdA9y99K0KEwcT5JVEFaiJNhm5o7KvZJ1jlDqNAklD8brH63PQ705eszJeILnBAmKdOxTrqb83EEmg5Z2eSIjf7Cl04Si21S%2FZomsjHG1zlcHT4jZ9%2FzXPHNHFVmuMwqOVSTzMXx2BKHrOrtwW%2BbpQ8x8rOC5E9P85c86MSDefTk%2BC9Hoee16B45ywR%2BbH7I9fK%2FZ27v%2BCE0gHQglXCHTFVSp7mk18KQw67BJqq5nJDAQ%2BtEdezGj2O5iiG2Amto3XgUbeSRvTi7iF&X-Amz-Signature=49b1065e9246c807c434b8fd2dc510c014fb12a3ceb2605034da70ee2a64ca68&X-Amz-SignedHeaders=host&response-content-disposition=inline))
- [script] add git_job_name, run_report and job_reports to artifacts.json
    - git_job_name:  used to build benchmark record if a git job failed [ a trick way to grab model info]
    - job_reports & run_report: we currently don't have extra info about mobile job concolusions, this can be used to upload to time_series or notification system for failure details.



## prs that simulate failure cases for generating logics
Mimic step failed before the benchmark test (no json generated):https://github.com/pytorch/test-infra/pull/6397
Mimic step benchmark test failed but with artifact: https://github.com/pytorch/test-infra/pull/6398
ExecuTorch Sync Test: https://github.com/pytorch/executorch/pull/9204


## Details
when the flag is on, artifact.json is converted from 
```
[ 
   ....
]
```
to

```
{
   "git_job_name": str
    "artifacts":[ ],
    "run_report":{}
    "job_reports":[....]
}

```
This flag is temporary to in case the logics are in sync between repos.
