### PR TITLE
add regex filter for cost page

### DIFF
--- a/torchci/components/metrics/panels/TimeSeriesPanel.tsx
+++ b/torchci/components/metrics/panels/TimeSeriesPanel.tsx
@@ -121,7 +121,7 @@ export function seriesWithInterpolatedTimes(
   if (filter) {
     if (isRegex) {
       try {
-        const regex = new RegExp(filter, 'i');
+        const regex = new RegExp(filter, "i");
         series = series.filter((s) => regex.test(s.name));
       } catch (e) {
         // If regex is invalid, fall back to simple include

--- a/torchci/components/metrics/panels/TimeSeriesPanel.tsx
+++ b/torchci/components/metrics/panels/TimeSeriesPanel.tsx
@@ -39,7 +39,8 @@ export function seriesWithInterpolatedTimes(
   smooth: boolean = true,
   sort_by: "total" | "name" = "name",
   graph_type: ChartType = "line",
-  filter: string | undefined = undefined
+  filter: string | undefined = undefined,
+  isRegex: boolean = false
 ) {
   // We want to interpolate the data, filling any "holes" in our time series
   // with 0.
@@ -118,9 +119,21 @@ export function seriesWithInterpolatedTimes(
     return serie;
   });
   if (filter) {
-    series = series.filter((s) =>
-      s.name.toLocaleLowerCase().includes(filter.toLocaleLowerCase())
-    );
+    if (isRegex) {
+      try {
+        const regex = new RegExp(filter, 'i');
+        series = series.filter((s) => regex.test(s.name));
+      } catch (e) {
+        // If regex is invalid, fall back to simple include
+        series = series.filter((s) =>
+          s.name.toLocaleLowerCase().includes(filter.toLocaleLowerCase())
+        );
+      }
+    } else {
+      series = series.filter((s) =>
+        s.name.toLocaleLowerCase().includes(filter.toLocaleLowerCase())
+      );
+    }
   }
   if (sort_by === "name") {
     return _.sortBy(series, (x) => x.name);
@@ -288,6 +301,7 @@ export default function TimeSeriesPanel({
   sort_by = "name",
   max_items_in_series = 0,
   filter = undefined,
+  isRegex = false,
   auto_refresh = true,
   // Additional function to process the data after querying
   dataReader = undefined,
@@ -308,6 +322,7 @@ export default function TimeSeriesPanel({
   sort_by?: "total" | "name";
   max_items_in_series?: number;
   filter?: string;
+  isRegex?: boolean;
   auto_refresh?: boolean;
   dataReader?: (_data: { [k: string]: any }[]) => { [k: string]: any }[];
 }) {
@@ -350,7 +365,8 @@ export default function TimeSeriesPanel({
     smooth,
     sort_by,
     chartType,
-    filter
+    filter,
+    isRegex
   );
 
   // If we have too many series, we'll only show the top N series by total value

--- a/torchci/pages/cost_analysis.tsx
+++ b/torchci/pages/cost_analysis.tsx
@@ -24,13 +24,13 @@ import TimeSeriesPanel, {
 import MultiSelectPicker from "components/MultiSelectPicker";
 import dayjs from "dayjs";
 import { fetcher } from "lib/GeneralUtils";
+import _ from "lodash";
 import { useRouter } from "next/router";
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { BiLineChart } from "react-icons/bi";
 import { FaFilter, FaInfoCircle, FaRegChartBar } from "react-icons/fa";
 import { MdOutlineStackedBarChart } from "react-icons/md";
 import useSWR from "swr";
-import _ from "lodash";
 
 function CustomDatePicker({ label, value, setValue }: any) {
   return (
@@ -573,22 +573,23 @@ export default function Page() {
     }, 500),
     [] // Empty dependency array ensures this is created only once
   );
-  
+
+  // Local state for input value to keep input responsive
+  const [inputValue, setInputValue] = useState(initialSearchFilter || "");
+
+  // Update inputValue when searchFilter changes from URL/elsewhere
+  useEffect(() => {
+    setInputValue(searchFilter);
+  }, [searchFilter]);
+
   const generateFilterBar = (type: CostCategory, style = {}) => {
-    const [inputValue, setInputValue] = useState(searchFilter);
-    
     // Update the local input value immediately for responsiveness
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value;
       setInputValue(value);
       debouncedSetSearchFilter(value);
     };
-    
-    // Update inputValue when searchFilter changes from URL/elsewhere
-    useEffect(() => {
-      setInputValue(searchFilter);
-    }, [searchFilter]);
-    
+
     const handleRegexChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       setIsRegex(e.target.checked);
     };
@@ -606,19 +607,46 @@ export default function Page() {
           variant="outlined"
           fullWidth
           value={inputValue}
+          InputProps={{
+            endAdornment: (
+              <Tooltip
+                title={
+                  isRegex
+                    ? "Disable regex pattern matching"
+                    : "Enable regex pattern matching"
+                }
+              >
+                <div
+                  style={{ cursor: "pointer" }}
+                  onClick={() => setIsRegex(!isRegex)}
+                >
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      padding: "4px 8px",
+                      marginRight: "4px",
+                      borderRadius: "4px",
+                      fontSize: "0.75rem",
+                      fontFamily: "monospace",
+                      backgroundColor: isRegex
+                        ? "rgba(63, 81, 181, 0.1)"
+                        : "transparent",
+                      color: isRegex ? "#3f51b5" : "rgba(0, 0, 0, 0.54)",
+                      border: isRegex
+                        ? "1px solid rgba(63, 81, 181, 0.5)"
+                        : "1px solid transparent",
+                      transition: "all 0.2s",
+                    }}
+                  >
+                    .*
+                  </div>
+                </div>
+              </Tooltip>
+            ),
+          }}
         />
-        <FormGroup row>
-          <div style={{ display: 'flex', alignItems: 'center', marginTop: '8px' }}>
-            <input 
-              type="checkbox" 
-              id="regex-checkbox"
-              checked={isRegex}
-              onChange={handleRegexChange}
-              style={{ marginRight: '8px' }}
-            />
-            <label htmlFor="regex-checkbox">Use Regex</label>
-          </div>
-        </FormGroup>
       </Box>
     );
   };


### PR DESCRIPTION
allow user to filter by regex the cost page

Example: https://torchci-git-wdvr-costregexfilter-fbopensource.vercel.app/cost_analysis?dateRange=7&granularity=day&groupby=job_name&chartType=stacked_bar&gpu=1&os=linux%2Cwindows&yAxis=cost&searchFilter=%5E%28%28%3F%21build%7Cbinary%29.%29*%24&isRegex=true 

<img width="281" alt="image" src="https://github.com/user-attachments/assets/e6dff210-0661-4435-b29a-2580ff200d97" />

