### PR TITLE
[ez][HUD] Fix build artifacts grouping in workflow box

### DIFF
--- a/torchci/components/WorkflowBox.tsx
+++ b/torchci/components/WorkflowBox.tsx
@@ -384,6 +384,7 @@ function groupArtifacts(jobs: JobData[], artifacts: Artifact[]) {
         key = id;
       }
     } finally {
+      key = key.toString();
       if (!grouping.has(key)) {
         grouping.set(key, []);
       }


### PR DESCRIPTION
Some build artifacts weren't showing up under the job in the show artifacts button because the types for some things are incorrect, so key was actually a number and not a string, making the later read of the map incorrect.

Old:
Missing build artifact
<img width="391" alt="image" src="https://github.com/user-attachments/assets/a85e7420-9b0f-4efd-83e1-83d1a66a3656" />

New:
<img width="393" alt="image" src="https://github.com/user-attachments/assets/4edadfd5-769c-4988-be6c-a69ae7c69db1" />
