### PR TITLE
Adds additional tests to getRunnerTypes, simplifies code a bit, adds the support for `c.` runners

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.test.ts
@@ -695,6 +695,15 @@ runner_types:
       variants:
         ephemeral:
           is_ephemeral: true
+    c.linux.4xlarge:
+      instance_type: c5.2xlarge
+      os: linux
+      min_available: 1
+      max_available: 1
+      disk_size: 150
+      is_ephemeral: false
+      variants:
+        dummyvariant: {}
     lf.c.linux.4xlarge:
       instance_type: c5.2xlarge
       os: linux
@@ -702,6 +711,7 @@ runner_types:
       disk_size: 150
       is_ephemeral: false
       variants:
+        dummyvariant: {}
         ephemeral:
           is_ephemeral: true`;
 
@@ -767,6 +777,30 @@ runner_types:
       },
     ],
     [
+      'c.dummyvariant.linux.4xlarge',
+      {
+        runnerTypeName: 'c.dummyvariant.linux.4xlarge',
+        instance_type: 'c5.2xlarge',
+        os: 'linux',
+        min_available: 1,
+        max_available: 1,
+        disk_size: 150,
+        is_ephemeral: false,
+      },
+    ],
+    [
+      'c.linux.4xlarge',
+      {
+        runnerTypeName: 'c.linux.4xlarge',
+        instance_type: 'c5.2xlarge',
+        os: 'linux',
+        min_available: 1,
+        max_available: 1,
+        disk_size: 150,
+        is_ephemeral: false,
+      },
+    ],
+    [
       'lf.linux.4xlarge',
       {
         runnerTypeName: 'lf.linux.4xlarge',
@@ -794,6 +828,17 @@ runner_types:
       'lf.c.linux.4xlarge',
       {
         runnerTypeName: 'lf.c.linux.4xlarge',
+        instance_type: 'c5.2xlarge',
+        os: 'linux',
+        min_available: 1,
+        disk_size: 150,
+        is_ephemeral: false,
+      },
+    ],
+    [
+      'lf.c.dummyvariant.linux.4xlarge',
+      {
+        runnerTypeName: 'lf.c.dummyvariant.linux.4xlarge',
         instance_type: 'c5.2xlarge',
         os: 'linux',
         min_available: 1,

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
@@ -377,26 +377,26 @@ export async function getRunnerTypes(
           return;
         }
 
-        if (runnerType.variants.size > 0) {
-          Array.from(runnerType.variants.keys()).forEach((variant) => {
-            const variantType = runnerType.variants?.get(variant);
-            /* istanbul ignore next */
-            if (!variantType) {
-              return;
-            }
+        Array.from(runnerType.variants.keys()).forEach((variant) => {
+          const variantType = runnerType.variants?.get(variant);
+          /* istanbul ignore next */
+          if (!variantType) {
+            return;
+          }
 
-            let variantRunnTypeName: string;
-            if (key.startsWith('lf.c.')) {
-              variantRunnTypeName = `lf.c.${variant}.${key.slice(5)}`;
-            } else if (key.startsWith('lf.')) {
-              variantRunnTypeName = `lf.${variant}.${key.slice(3)}`;
-            } else {
-              variantRunnTypeName = `${variant}.${key}`;
-            }
+          let variantRunnTypeName: string;
+          if (key.startsWith('lf.c.')) {
+            variantRunnTypeName = `lf.c.${variant}.${key.slice(5)}`;
+          } else if (key.startsWith('lf.')) {
+            variantRunnTypeName = `lf.${variant}.${key.slice(3)}`;
+          } else if (key.startsWith('c.')) {
+            variantRunnTypeName = `c.${variant}.${key.slice(2)}`;
+          } else {
+            variantRunnTypeName = `${variant}.${key}`;
+          }
 
-            result.set(variantRunnTypeName, { ...runnerType, ...variantType, runnerTypeName: variantRunnTypeName });
-          });
-        }
+          result.set(variantRunnTypeName, { ...runnerType, ...variantType, runnerTypeName: variantRunnTypeName });
+        });
       });
 
       const filteredResult: Map<string, RunnerType> = new Map(


### PR DESCRIPTION
## Support for `c.` runners

We don't really support well our canary environment with variants, not sure why, but this condition was not present, so variants will get the wrong naming when running at meta canary environment. `variant.c.runner.name` instead of `c.variant.runner.name`. This fix is very low impact and should not change anything in production.

## Simplifies the code

There is a useless `if` that I noticed when reading `getRunnerTypes`. I am removing that conditional;

## Additional tests for getRunnerTypes

As we're adding empty variants as part of the ephemeral migration, I want to make sure that we have green tests and we're covering this situation in our unit tests.

The new situations to cover are:
1) Empty variants
2) meta's canary environment naming convention `c.`