### PR TITLE
Add Core Dark Mode Functionality

### DIFF
--- a/torchci/components/JobConclusion.module.css
+++ b/torchci/components/JobConclusion.module.css
@@ -9,11 +9,11 @@
 }
 
 .success {
-  color: green;
+  color: #4caf50; /* Green that works in both light and dark mode */
 }
 
 .failure {
-  color: red;
+  color: #f44336; /* Red that works in both light and dark mode */
 }
 
 .failure_monster {
@@ -51,46 +51,46 @@
 }
 
 .skipped {
-  color: grey;
+  color: #9e9e9e; /* Grey that works in both light and dark mode */
 }
 
 .neutral {
-  color: grey;
+  color: #9e9e9e; /* Grey that works in both light and dark mode */
 }
 
 .cancelled {
-  color: red;
+  color: #f44336; /* Red that works in both light and dark mode */
 }
 
 .timed_out {
-  color: red;
+  color: #f44336; /* Red that works in both light and dark mode */
 }
 
 .pending {
-  color: goldenrod;
+  color: #ffc107; /* Gold/yellow that works in both light and dark mode */
 }
 
 .queued {
-  color: lightgray;
+  color: #bdbdbd; /* Light gray that works in both light and dark mode */
 }
 
 .none {
-  color: lightgray;
+  color: #bdbdbd; /* Light gray that works in both light and dark mode */
 }
 
 .all_null {
-  color: grey;
+  color: #9e9e9e; /* Grey that works in both light and dark mode */
 }
 
 .flaky {
-  color: lightgreen;
+  color: #8bc34a; /* Light green that works in both light and dark mode */
 }
 
 .warning {
-  color: #f8b88b;
+  color: #ff9800; /* Orange that works in both light and dark mode */
 }
 
 .viablestrict_blocking {
-  border-left: 1px solid red;
-  border-right: 1px solid red;
+  border-left: 1px solid #f44336;
+  border-right: 1px solid #f44336;
 }

--- a/torchci/components/JobLinks.module.css
+++ b/torchci/components/JobLinks.module.css
@@ -1,10 +1,11 @@
 .disableTestButton {
-  background-color: #ffc107;
-  border-color: #ffc107;
+  background-color: var(--warning-button-bg, #ffc107);
+  border-color: var(--warning-button-border, #ffc107);
+  color: var(--warning-button-text, #212529);
 }
 
 .closedDisableIssueButton {
-  background-color: #17a2b8;
-  border-color: #17a2b8;
-  color: white;
+  background-color: var(--info-button-bg, #17a2b8);
+  border-color: var(--info-button-border, #17a2b8);
+  color: var(--info-button-text, white);
 }

--- a/torchci/components/NavBar.module.css
+++ b/torchci/components/NavBar.module.css
@@ -2,20 +2,25 @@
   display: flex;
   padding: 0 1rem;
   font: bold;
-  background: rgb(255, 227, 227);
-  background: linear-gradient(326deg, rgb(255 246 246), rgb(255 247 236));
-  box-shadow: 0 -4px 20px 0px #c2c2c2;
+  background: var(--navbar-bg);
+  box-shadow: var(--navbar-shadow);
   width: 100%;
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+  align-items: center;
 }
 
 .navbar li {
   padding: 0.7rem 1rem;
   position: relative;
   z-index: 9999;
+  display: flex;
+  align-items: center;
+  height: 100%;
 }
 
 .navbar a {
-  display: block;
+  display: flex;
+  align-items: center;
 }
 
 .navbar span {
@@ -38,6 +43,7 @@
   flex-wrap: wrap;
   margin: 0;
   padding: 0;
+  height: 100%;
 }
 
 .homeLink {
@@ -47,14 +53,26 @@
 
 .dropdowntitle {
   padding: 0.7rem 1rem;
+  display: flex;
+  align-items: center;
 }
 
 .dropdown {
   position: absolute;
-  box-shadow: 0 -4px 20px 0px #c2c2c2;
+  box-shadow: var(--dropdown-shadow);
   z-index: 9999;
   min-width: 10rem;
   padding: 0.5rem 0;
-  background-color: white;
+  background-color: var(--dropdown-bg);
   display: none;
+  transition: background-color 0.3s ease;
+  top: 100%;
+  left: 0;
+  border-radius: 4px;
+}
+
+.dropdown li {
+  padding: 0.5rem 1rem;
+  height: auto !important;
+  min-height: unset;
 }

--- a/torchci/components/NavBar.tsx
+++ b/torchci/components/NavBar.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { useState } from "react";
 import { AiFillGithub } from "react-icons/ai";
 import LoginSection from "./LoginSection";
+import ThemeModePicker from "./ThemeModePicker";
 
 const NavBarDropdown = ({
   title,
@@ -18,12 +19,12 @@ const NavBarDropdown = ({
     <li
       onMouseEnter={() => setDropdown(true)}
       onMouseLeave={() => setDropdown(false)}
-      style={{ padding: 0 }}
+      style={{ padding: 0, position: "relative" }}
     >
       <div className={styles.dropdowntitle}>{title} ▾</div>
       <ul className={styles.dropdown} style={dropdownStyle}>
         {items.map((item: any) => (
-          <li key={item.href}>
+          <li key={item.href} style={{ height: "auto" }}>
             <Link href={item.href} prefetch={false}>
               {item.name}
             </Link>
@@ -149,6 +150,8 @@ function NavBar() {
         style={{
           marginLeft: "auto",
           marginRight: "0px",
+          display: "flex",
+          alignItems: "center",
         }}
       >
         <ul className={styles.navbarlinkslist}>
@@ -174,14 +177,23 @@ function NavBar() {
           </li>
           <NavBarDropdown title="Benchmarks" items={benchmarksDropdown} />
           <NavBarDropdown title="Dev Infra" items={devInfraDropdown} />
-          <li style={{ cursor: "pointer" }}>
+          <li
+            style={{ cursor: "pointer", display: "flex", alignItems: "center" }}
+          >
             <Link
               href="https://github.com/pytorch/test-infra/tree/main/torchci"
               passHref
-              style={{ color: "black" }}
+              style={{
+                color: "var(--icon-color)",
+                display: "flex",
+                alignItems: "center",
+              }}
             >
               <AiFillGithub />
             </Link>
+          </li>
+          <li>
+            <ThemeModePicker />
           </li>
           <li style={{ padding: "0 1rem" }}>
             <LoginSection></LoginSection>

--- a/torchci/components/ThemeModePicker.module.css
+++ b/torchci/components/ThemeModePicker.module.css
@@ -1,0 +1,86 @@
+.container {
+  position: relative;
+}
+
+.toggleButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem;
+  font-size: 1.2rem;
+  transition: opacity 0.3s ease;
+}
+
+.toggleButton:hover {
+  opacity: 0.7;
+}
+
+.togglePlaceholder {
+  width: 1.2rem;
+  height: 1.2rem;
+  padding: 0.5rem;
+  opacity: 0;
+}
+
+.dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  background-color: var(--dropdown-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+  z-index: 1000;
+  min-width: 150px;
+}
+
+.option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  width: 100%;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  color: var(--text-color);
+  transition: background-color 0.2s ease;
+}
+
+.option:hover {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.option.active {
+  background-color: rgba(74, 144, 226, 0.1);
+  font-weight: bold;
+}
+
+.option span {
+  flex-grow: 1;
+}
+
+.iconGroup {
+  display: flex;
+  align-items: center;
+  position: relative;
+  width: 16px;
+  height: 16px;
+}
+
+.sunIcon {
+  position: absolute;
+  left: -2px;
+  top: 2px;
+}
+
+.moonIcon {
+  position: absolute;
+  right: -3px;
+  bottom: 0px;
+}

--- a/torchci/components/ThemeModePicker.tsx
+++ b/torchci/components/ThemeModePicker.tsx
@@ -1,0 +1,84 @@
+import { ThemeMode, useDarkMode } from "lib/DarkModeContext";
+import { useEffect, useState } from "react";
+import { BsMoon, BsSun } from "react-icons/bs";
+import styles from "./ThemeModePicker.module.css";
+
+export default function ThemeModePicker(): JSX.Element {
+  const { themeMode, setThemeMode, darkMode } = useDarkMode();
+  const [isMounted, setIsMounted] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+
+  // This ensures hydration mismatch is avoided
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  // Don't render anything until client-side
+  if (!isMounted) return <div className={styles.togglePlaceholder} />;
+
+  // Get the icon component based on active theme
+  const getIconComponent = () => {
+    if (themeMode === "system") {
+      const iconColor = darkMode ? "#E0E0E0" : "#212529";
+      return (
+        <div className={styles.iconGroup} style={{ width: 18, height: 18 }}>
+          <BsSun size={14} color={iconColor} className={styles.sunIcon} />
+          <BsMoon size={14} color={iconColor} className={styles.moonIcon} />
+        </div>
+      );
+    }
+    const Icon = darkMode ? BsMoon : BsSun;
+    return <Icon size={18} color={darkMode ? "#E0E0E0" : "#212529"} />;
+  };
+
+  const handleThemeChange = (mode: ThemeMode) => {
+    setThemeMode(mode);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className={styles.container}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className={styles.toggleButton}
+        title="Change theme"
+        aria-label="Change theme"
+      >
+        {getIconComponent()}
+      </button>
+
+      {isOpen && (
+        <div className={styles.dropdown}>
+          <button
+            className={`${styles.option} ${
+              themeMode === "light" ? styles.active : ""
+            }`}
+            onClick={() => handleThemeChange("light")}
+          >
+            <BsSun size={16} /> <span>Light</span>
+          </button>
+          <button
+            className={`${styles.option} ${
+              themeMode === "dark" ? styles.active : ""
+            }`}
+            onClick={() => handleThemeChange("dark")}
+          >
+            <BsMoon size={16} /> <span>Dark</span>
+          </button>
+          <button
+            className={`${styles.option} ${
+              themeMode === "system" ? styles.active : ""
+            }`}
+            onClick={() => handleThemeChange("system")}
+          >
+            <div className={styles.iconGroup}>
+              <BsSun size={12} className={styles.sunIcon} />
+              <BsMoon size={12} className={styles.moonIcon} />
+            </div>
+            <span>System</span>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/torchci/components/TooltipTarget.module.css
+++ b/torchci/components/TooltipTarget.module.css
@@ -7,10 +7,12 @@
 }
 
 .content {
-  background-color: lightgray;
+  background-color: var(--tooltip-bg, lightgray);
+  color: var(--tooltip-text, black);
   padding: 5px 0;
   border-radius: 6px;
   cursor: default;
+  border: 1px solid var(--border-color);
 
   position: absolute;
   z-index: 1;
@@ -20,10 +22,12 @@
 }
 
 .contentPinned {
-  background-color: lightblue;
+  background-color: var(--tooltip-pinned-bg, lightblue);
+  color: var(--tooltip-text, black);
   padding: 5px 0;
   border-radius: 6px;
   cursor: default;
+  border: 1px solid var(--border-color);
 
   position: absolute;
   z-index: 1;

--- a/torchci/components/commit.module.css
+++ b/torchci/components/commit.module.css
@@ -1,9 +1,10 @@
 .commitMessage {
-  background-color: whitesmoke;
+  background-color: var(--code-bg);
   white-space: pre;
   max-height: 13em;
   overflow: scroll;
   margin: 10px;
+  color: var(--text-color);
 }
 
 .workflowContainer {
@@ -13,23 +14,25 @@
 }
 
 .workflowBoxFail {
-  border: 1px solid gray;
+  border: 1px solid var(--border-color);
   padding: 10px;
   border-radius: 5px;
-  background-color: mistyrose;
+  background-color: var(--workflow-box-fail-bg);
 }
 
 .workflowBoxSuccess {
-  border: 1px solid gray;
+  border: 1px solid var(--border-color);
   padding: 10px;
   border-radius: 5px;
-  background-color: azure;
+  background-color: var(--workflow-box-success-bg);
 }
 
 .buttonBorder {
-  border: 1px solid;
+  border: 1px solid var(--border-color);
+  color: var(--button-color);
+  background-color: var(--button-bg);
 }
 
 .buttonBorder:hover {
-  background-color: lightgrey;
+  background-color: var(--dropdown-bg);
 }

--- a/torchci/components/hud.module.css
+++ b/torchci/components/hud.module.css
@@ -51,7 +51,7 @@
 
 .jobMetadata a {
   text-decoration: none;
-  color: #0064cf;
+  color: var(--link-color);
 }
 
 .jobMetadataTruncated {
@@ -85,29 +85,31 @@
 .branchFormInput {
   font-weight: bold;
   font-family: monospace;
-  background-color: aliceblue;
+  background-color: var(--dropdown-bg);
+  color: var(--text-color);
   font-size: 1em;
   border: 0px;
   padding: 0px;
   padding-left: 4px;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 .userbenchmarkTable {
-  border: 1px solid black;
+  border: 1px solid var(--border-color);
   border-collapse: collapse;
   padding: 3px;
 }
 
 .forcedMerge {
-  background-color: lightyellow;
+  background-color: var(--forced-merge-bg);
 }
 
 .forcedMergeWithFailure {
-  background-color: #ffe0b3;
+  background-color: var(--forced-merge-failure-bg);
 }
 
 .selectedRow {
-  background-color: lightblue;
+  background-color: var(--selected-row-bg);
   font-weight: bold;
 }
 
@@ -116,5 +118,5 @@
 }
 
 .highlight {
-  background-color: #ffa;
+  background-color: var(--highlight-bg);
 }

--- a/torchci/components/minihud.module.css
+++ b/torchci/components/minihud.module.css
@@ -1,42 +1,42 @@
 .workflowBoxNone {
-  border: 1px solid gray;
+  border: 1px solid var(--border-color);
   padding: 10px;
   border-radius: 5px;
-  background-color: lightgray;
+  background-color: var(--workflow-box-none-bg);
 }
 
 .workflowBoxFail {
-  border: 1px solid gray;
+  border: 1px solid var(--border-color);
   padding: 10px;
   border-radius: 5px;
-  background-color: mistyrose;
+  background-color: var(--workflow-box-fail-bg);
 }
 
 .workflowBoxPending {
-  border: 1px solid gray;
+  border: 1px solid var(--border-color);
   padding: 10px;
   border-radius: 5px;
-  background-color: azure;
+  background-color: var(--workflow-box-pending-bg);
 }
 
 .workflowBoxSuccess {
-  border: 1px solid gray;
+  border: 1px solid var(--border-color);
   padding: 10px;
   border-radius: 5px;
-  background-color: lightgreen;
+  background-color: var(--workflow-box-success-bg);
 }
 
 .workflowBoxClassified {
-  border: 1px solid gray;
+  border: 1px solid var(--border-color);
   padding: 10px;
   border-radius: 5px;
-  background-color: linen;
+  background-color: var(--workflow-box-classified-bg);
 }
 
 .workflowBoxHighlight {
-  border: 15px solid #5eced4;
+  border: 15px solid var(--workflow-box-highlight-border);
   padding: 10px;
-  box-shadow: 0 0 10px rgba(81, 203, 238, 1);
+  box-shadow: 0 0 10px var(--workflow-box-highlight-shadow);
   border-radius: 25px;
 }
 
@@ -45,8 +45,8 @@
     45deg,
     rgba(0, 0, 0, 0),
     rgba(0, 0, 0, 0) 80px,
-    rgba(125, 125, 125, 0.1) 80px,
-    rgba(125, 125, 125, 0.1) 160px
+    rgba(125, 125, 125, 0.2) 80px,
+    rgba(125, 125, 125, 0.2) 160px
   );
 }
 
@@ -75,9 +75,9 @@
 }
 
 .failedJobHighlighted {
-  border: 5px solid #5eced4;
+  border: 5px solid var(--failed-job-highlight-border);
   padding: 10px;
-  box-shadow: 0 0 5px rgba(81, 203, 238, 1);
+  box-shadow: 0 0 5px var(--workflow-box-highlight-shadow);
   border-radius: 5px;
 }
 
@@ -91,7 +91,29 @@
 }
 
 .revertButton {
-  background-color: #dc3545;
-  border-color: #dc3545;
-  color: white;
+  background-color: var(--revert-button-bg);
+  border-color: var(--revert-button-border);
+  color: var(--revert-button-text);
+}
+
+/* Table wrapper class to properly scope table styles */
+.tableWrapper {
+  width: 100%;
+}
+
+.tableWrapper :global(table) {
+  width: 100%;
+}
+
+.tableWrapper :global(a) {
+  color: var(--link-color);
+}
+
+/* Add even/odd row styling for better readability in tables */
+.tableWrapper :global(tbody tr:nth-child(odd)) {
+  background-color: var(--dropdown-bg);
+}
+
+.tableWrapper :global(tbody tr:nth-child(even)) {
+  background-color: rgba(125, 125, 125, 0.1);
 }

--- a/torchci/lib/DarkModeContext.tsx
+++ b/torchci/lib/DarkModeContext.tsx
@@ -1,0 +1,106 @@
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+// Theme mode options
+export type ThemeMode = "light" | "dark" | "system";
+
+type DarkModeContextType = {
+  themeMode: ThemeMode;
+  darkMode: boolean;
+  setThemeMode: (mode: ThemeMode) => void;
+};
+
+const DarkModeContext = createContext<DarkModeContextType | undefined>(
+  undefined
+);
+
+export function DarkModeProvider({ children }: { children: ReactNode }) {
+  // Initialize with a function to prevent execution during SSR
+  const [themeMode, setThemeMode] = useState<ThemeMode>(() => {
+    // Only run in browser context
+    if (typeof window !== "undefined") {
+      const savedThemeMode = localStorage.getItem(
+        "themeMode"
+      ) as ThemeMode | null;
+      if (
+        savedThemeMode &&
+        ["light", "dark", "system"].includes(savedThemeMode)
+      ) {
+        return savedThemeMode;
+      }
+    }
+    return "light";
+  });
+
+  const [darkMode, setDarkMode] = useState<boolean>(false);
+  const [systemDarkMode, setSystemDarkMode] = useState<boolean>(false);
+
+  // Check for system dark mode preference
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      // Check if system prefers dark mode
+      const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+      setSystemDarkMode(mediaQuery.matches);
+
+      // Listen for changes to the system dark mode preference
+      const handler = (e: MediaQueryListEvent) => {
+        setSystemDarkMode(e.matches);
+      };
+      mediaQuery.addEventListener("change", handler);
+      return () => mediaQuery.removeEventListener("change", handler);
+    }
+  }, []);
+
+  // Update darkMode based on themeMode and system preference
+  useEffect(() => {
+    if (themeMode === "system") {
+      setDarkMode(systemDarkMode);
+    } else {
+      setDarkMode(themeMode === "dark");
+    }
+  }, [themeMode, systemDarkMode]);
+
+  // Apply dark mode class and save preference
+  useEffect(() => {
+    // Apply or remove the dark class based on the darkMode state
+    if (darkMode) {
+      document.documentElement.classList.add("dark-mode");
+    } else {
+      document.documentElement.classList.remove("dark-mode");
+    }
+
+    // Save the preference to localStorage
+    if (typeof window !== "undefined") {
+      localStorage.setItem("themeMode", themeMode);
+    }
+  }, [darkMode, themeMode]);
+
+  const handleSetThemeMode = (mode: ThemeMode) => {
+    setThemeMode(mode);
+  };
+
+  return (
+    <DarkModeContext.Provider
+      value={{
+        themeMode,
+        darkMode,
+        setThemeMode: handleSetThemeMode,
+      }}
+    >
+      {children}
+    </DarkModeContext.Provider>
+  );
+}
+
+export function useDarkMode() {
+  const context = useContext(DarkModeContext);
+  if (context === undefined) {
+    throw new Error("useDarkMode must be used within a DarkModeProvider");
+  }
+  return context;
+}

--- a/torchci/pages/_app.tsx
+++ b/torchci/pages/_app.tsx
@@ -1,14 +1,18 @@
+import CssBaseline from "@mui/material/CssBaseline";
+import { ThemeProvider } from "@mui/material/styles";
 import { Analytics } from "@vercel/analytics/react";
 import AnnouncementBanner from "components/AnnouncementBanner";
 import TitleProvider from "components/DynamicTitle";
 import NavBar from "components/NavBar";
 import SevReport from "components/SevReport";
+import { DarkModeProvider, useDarkMode } from "lib/DarkModeContext";
 import { track } from "lib/track";
 import { SessionProvider } from "next-auth/react";
 import type { AppProps } from "next/app";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 import ReactGA from "react-ga4";
+import { useAppTheme } from "styles/MuiThemeOverrides";
 import "styles/globals.css";
 
 function MyApp({ Component, pageProps }: AppProps) {
@@ -20,20 +24,42 @@ function MyApp({ Component, pageProps }: AppProps) {
   }, [router, router.pathname]);
 
   ReactGA.initialize("G-HZEXJ323ZF");
+
+  // Wrap everything in DarkModeProvider
   return (
     <>
       <SessionProvider>
-        <TitleProvider>
-          <NavBar />
-          <AnnouncementBanner />
-          <SevReport />
-          <div style={{ margin: "20px" }}>
-            <Component {...pageProps} />
-            <Analytics />
-          </div>
-        </TitleProvider>
+        <DarkModeProvider>
+          <AppContent Component={Component} pageProps={pageProps} />
+        </DarkModeProvider>
       </SessionProvider>
     </>
+  );
+}
+
+// Separate component to use the dark mode hooks
+function AppContent({
+  Component,
+  pageProps,
+}: {
+  Component: any;
+  pageProps: any;
+}) {
+  const theme = useAppTheme();
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <TitleProvider>
+        <NavBar />
+        <AnnouncementBanner />
+        <SevReport />
+        <div style={{ margin: "20px" }}>
+          <Component {...pageProps} />
+          <Analytics />
+        </div>
+      </TitleProvider>
+    </ThemeProvider>
   );
 }
 

--- a/torchci/pages/_document.tsx
+++ b/torchci/pages/_document.tsx
@@ -1,0 +1,33 @@
+import { Head, Html, Main, NextScript } from "next/document";
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        {/* This script prevents flash of incorrect theme (FOIT) */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                try {
+                  var themeMode = localStorage.getItem('themeMode');
+                  var systemDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+                  if (themeMode === 'dark' || (themeMode === 'system' && systemDark)) {
+                    document.documentElement.classList.add('dark-mode');
+                  }
+                } catch (e) {}
+              })();
+            `,
+          }}
+        />
+        {/* Custom styles for charts */}
+        <link rel="stylesheet" href="/chart-legend.css" />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/torchci/styles/MuiThemeOverrides.tsx
+++ b/torchci/styles/MuiThemeOverrides.tsx
@@ -1,0 +1,91 @@
+import { createTheme } from "@mui/material/styles";
+import { useEffect, useState } from "react";
+import { useDarkMode } from "../lib/DarkModeContext";
+
+// Create a theme instance for light and dark mode
+export function useAppTheme() {
+  const { darkMode } = useDarkMode();
+  const [theme, setTheme] = useState(
+    createTheme({
+      palette: {
+        mode: "light",
+      },
+    })
+  );
+
+  useEffect(() => {
+    // Update theme when darkMode changes
+    setTheme(
+      createTheme({
+        palette: {
+          mode: darkMode ? "dark" : "light",
+          ...(darkMode
+            ? {
+                // Dark mode specific colors
+                background: {
+                  default: "#1E1E1E",
+                  paper: "#2A2A2A",
+                },
+                text: {
+                  primary: "#E0E0E0",
+                  secondary: "#AAAAAA",
+                },
+                primary: {
+                  main: "#4A90E2",
+                },
+                divider: "#3A3A3A",
+              }
+            : {
+                // Light mode colors - default theme
+              }),
+        },
+        components: {
+          MuiPaper: {
+            styleOverrides: {
+              root: {
+                backgroundColor: darkMode ? "#2A2A2A" : "#ffffff",
+                color: darkMode ? "#E0E0E0" : "inherit",
+              },
+            },
+          },
+          MuiInputBase: {
+            styleOverrides: {
+              root: {
+                backgroundColor: darkMode ? "#2A2A2A" : "inherit",
+                color: darkMode ? "#E0E0E0" : "inherit",
+              },
+            },
+          },
+          MuiSelect: {
+            styleOverrides: {
+              root: {
+                backgroundColor: darkMode ? "#2A2A2A" : "inherit",
+                color: darkMode ? "#E0E0E0" : "inherit",
+                "& .MuiOutlinedInput-notchedOutline": {
+                  borderColor: darkMode ? "#3A3A3A" : "inherit",
+                },
+                "&:hover .MuiOutlinedInput-notchedOutline": {
+                  borderColor: darkMode ? "#4A90E2" : "inherit",
+                },
+              },
+            },
+          },
+          MuiTooltip: {
+            styleOverrides: {
+              tooltip: {
+                backgroundColor: darkMode ? "#3A3A3A" : "#E0E0E0",
+                color: darkMode ? "#E0E0E0" : "#212529",
+                border: darkMode ? "1px solid #3A3A3A" : "1px solid #E1E1E1",
+              },
+              arrow: {
+                color: darkMode ? "#3A3A3A" : "#E0E0E0",
+              },
+            },
+          },
+        },
+      })
+    );
+  }, [darkMode]);
+
+  return theme;
+}

--- a/torchci/styles/globals.css
+++ b/torchci/styles/globals.css
@@ -1,3 +1,105 @@
+:root {
+  --background-color: #ffffff;
+  --text-color: #212529;
+  --link-color: #0064cf;
+  --navbar-bg: linear-gradient(326deg, rgb(255 246 246), rgb(255 247 236));
+  --navbar-shadow: 0 -4px 20px 0px #c2c2c2;
+  --dropdown-bg: white;
+  --code-bg: aliceblue;
+  --icon-color: black;
+  --dropdown-shadow: 0 -4px 20px 0px #c2c2c2;
+  --button-color: #212529;
+  --button-bg: transparent;
+  --border-color: #e1e1e1;
+
+  /* HUD specific colors */
+  --forced-merge-bg: lightyellow;
+  --forced-merge-failure-bg: #ffe0b3;
+  --selected-row-bg: lightblue;
+  --highlight-bg: #ffa;
+
+  /* MiniHud specific colors */
+  --workflow-box-none-bg: lightgray;
+  --workflow-box-fail-bg: mistyrose;
+  --workflow-box-pending-bg: azure;
+  --workflow-box-success-bg: lightgreen;
+  --workflow-box-classified-bg: linen;
+  --workflow-box-highlight-border: #5eced4;
+  --workflow-box-highlight-shadow: rgba(81, 203, 238, 1);
+  --failed-job-highlight-border: #5eced4;
+  --revert-button-bg: #dc3545;
+  --revert-button-border: #dc3545;
+  --revert-button-text: white;
+  --job-hover-bg: khaki;
+  --duration-color-normal: #212529;
+  --duration-color-good: green;
+  --duration-color-bad: red;
+
+  /* Button colors */
+  --warning-button-bg: #ffc107;
+  --warning-button-border: #ffc107;
+  --warning-button-text: #212529;
+  --info-button-bg: #17a2b8;
+  --info-button-border: #17a2b8;
+  --info-button-text: white;
+
+  /* Tooltip colors */
+  --tooltip-bg: #e0e0e0;
+  --tooltip-pinned-bg: #add8e6;
+  --tooltip-text: #212529;
+}
+
+.dark-mode {
+  --background-color: #1e1e1e;
+  --text-color: #e0e0e0;
+  --link-color: #4a90e2;
+  --navbar-bg: linear-gradient(326deg, #2a2a2a, #2d2d2d);
+  --navbar-shadow: 0 -4px 20px 0px rgba(0, 0, 0, 0.4);
+  --dropdown-bg: #2a2a2a;
+  --code-bg: #2a2a2a;
+  --icon-color: #e0e0e0;
+  --dropdown-shadow: 0 -4px 20px 0px rgba(0, 0, 0, 0.3);
+  --button-color: #e0e0e0;
+  --button-bg: transparent;
+  --border-color: #3a3a3a;
+
+  /* HUD specific colors - dark mode variants */
+  --forced-merge-bg: #453e00;
+  --forced-merge-failure-bg: #5e3a00;
+  --selected-row-bg: #0a3550;
+  --highlight-bg: #525200;
+
+  /* MiniHud specific colors - dark mode variants */
+  --workflow-box-none-bg: #383838;
+  --workflow-box-fail-bg: #4b2c2c;
+  --workflow-box-pending-bg: #1e3540;
+  --workflow-box-success-bg: #1e4020;
+  --workflow-box-classified-bg: #3b332a;
+  --workflow-box-highlight-border: #1e7e82;
+  --workflow-box-highlight-shadow: rgba(26, 98, 117, 0.7);
+  --failed-job-highlight-border: #1e7e82;
+  --revert-button-bg: #6b1a23;
+  --revert-button-border: #541217;
+  --revert-button-text: #e0e0e0;
+  --job-hover-bg: #5a512a;
+  --duration-color-normal: #e0e0e0;
+  --duration-color-good: #4caf50;
+  --duration-color-bad: #f44336;
+
+  /* Button colors - dark mode variants */
+  --warning-button-bg: #6d5304;
+  --warning-button-border: #574100;
+  --warning-button-text: #e0e0e0;
+  --info-button-bg: #0d5a66;
+  --info-button-border: #094954;
+  --info-button-text: #e0e0e0;
+
+  /* Tooltip colors - dark mode variants */
+  --tooltip-bg: #3a3a3a;
+  --tooltip-pinned-bg: #1e4555;
+  --tooltip-text: #e0e0e0;
+}
+
 html {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
@@ -11,7 +113,12 @@ h1 {
 body {
   margin: 0;
   padding: 5px;
+  background-color: var(--background-color);
+  color: var(--text-color);
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
+
+/* Chart styles will be added separately */
 
 a {
   color: inherit;
@@ -23,32 +130,94 @@ a {
 }
 
 pre {
-  background-color: aliceblue;
+  background-color: var(--code-bg);
 }
 
 code {
-  background-color: aliceblue;
+  background-color: var(--code-bg);
 }
 
 a {
   text-decoration: none;
-  color: #0064cf;
+  color: var(--link-color);
+}
+
+/* Specific styling for table links */
+table a,
+tbody a,
+tr a,
+td a {
+  color: var(--link-color);
+}
+
+/* MUI Data Grid specific styles */
+.MuiDataGrid-root .MuiDataGrid-cell a {
+  color: var(--link-color);
 }
 
 button {
   cursor: pointer;
   display: inline-block;
   font-weight: 400;
-  color: #212529;
+  color: var(--button-color);
   text-align: center;
   vertical-align: middle;
   user-select: none;
   border: 1px solid transparent;
   border-radius: 0.25rem;
+  background-color: var(--button-bg);
+}
+
+/* Form elements in dark mode */
+input,
+textarea,
+select {
+  background-color: var(--dropdown-bg);
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+  border-radius: 0.25rem;
+  transition: background-color 0.3s ease, color 0.3s ease,
+    border-color 0.3s ease;
+}
+
+/* Fix for select dropdown text color */
+select option {
+  background-color: var(--dropdown-bg);
+  color: var(--text-color);
+}
+
+/* Add table styling with border colors */
+table {
+  border-collapse: collapse;
+  border-color: var(--border-color);
+  color: var(--text-color);
+  background-color: var(--dropdown-bg);
+}
+
+th,
+td {
+  border-color: var(--border-color);
+  padding: 1px 3px;
+}
+
+/* Style for any element with a border */
+[class*="border"],
+[style*="border"] {
+  border-color: var(--border-color) !important;
+}
+
+/* For dividers and horizontal rules */
+hr {
+  border-color: var(--border-color);
+}
+
+/* Component background elements */
+.component-bg {
+  background-color: var(--dropdown-bg);
 }
 
 .animate-on-click {
-  background-color: white;
+  background-color: var(--background-color);
 }
 
 .animate-on-click:active {


### PR DESCRIPTION
## Summary
This PR adds the core dark mode functionality to the HUD:

- Implements a `DarkModeContext` provider to manage theme state
- Adds a theme toggle component in the navbar to switch between light/dark/system modes
- Creates CSS variables for theming in `globals.css`
- Implements Material UI theme overrides for dark mode
- Updates page structure to support dark mode switching
- Adds script to prevent flash of incorrect theme

This PR is part of splitting up PR #6392 as requested by @malfet. It does not include ECharts-related dark mode functionality, which will be added in a separate PR.

🤖 Generated with [Claude Code](https://claude.ai/code)