### PR TITLE
Temporarily exclude test channel from sha256

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -385,7 +385,8 @@ class S3Index:
         for obj in sorted(self.gen_file_list(subdir, package_name)):
             # Do not include checksum for nightly packages, see
             # https://github.com/pytorch/test-infra/pull/6307
-            maybe_fragment = f"#sha256={obj.checksum}" if obj.checksum and not obj.orig_key.startswith("whl/nightly") else ""
+            is_excluded = obj.key.startswith("whl/nightly") or obj.key.startswith("whl/test")
+            maybe_fragment = f"#sha256={obj.checksum}" if obj.checksum and not is_excluded else ""
             pep658_attribute = ""
             if obj.pep658:
                 pep658_sha = f"sha256={obj.pep658}"


### PR DESCRIPTION
Similar to: https://github.com/pytorch/test-infra/pull/6307
Please note. I am seeing something like this:
```
pip install -vvv pytorch_triton_rocm --index-url https://download.pytorch.org/whl/test/rocm6.3 --force-reinstall --no-cache-dir
.....
  Found link https://download.pytorch.org/whl/test/pytorch_triton_rocm-3.3.0-cp313-cp313t-linux_x86_64.whl#sha256=bab257d15b0ce561b92c30c6fd08ca2c89ceb0d0f61a7f68b6b80c80d5b864c1 (from https://download.pytorch.org/whl/test/rocm6.3/pytorch-triton-rocm/), version: 3.3.0
....
ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE. If you have updated the package versions, please update the hashes. Otherwise, examine the package contents carefully; someone may have tampered with them.
    unknown package:
        Expected sha256 bab257d15b0ce561b92c30c6fd08ca2c89ceb0d0f61a7f68b6b80c80d5b864c1
             Got        493de0322bbd5566f2f8e7c9249033dd2ae3cfd3885dc0607036609c8747f172
```
But the good hash is : 493de0322bbd5566f2f8e7c9249033dd2ae3cfd3885dc0607036609c8747f172
I suspect the index is cached somewhere not on aws cloudfront