### PR TITLE
Remove cuda 12.6 aarch

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -50,7 +50,7 @@ STABLE_CUDA_VERSIONS = {
     "release": "12.4",
 }
 
-CUDA_AARCH64_ARCHES = ["12.6-aarch64", "12.8-aarch64"]
+CUDA_AARCH64_ARCHES = ["12.8-aarch64"]
 
 PACKAGE_TYPES = ["wheel", "conda", "libtorch"]
 PRE_CXX11_ABI = "pre-cxx11"


### PR DESCRIPTION
Aarch64 CUDA 12.6 builds where removed from pytorch/pytorch by https://github.com/pytorch/pytorch/pull/148895