### PR TITLE
[queue time] Add Job Queue Time hook 

### DIFF
--- a/.github/workflows/update-job-queue-times.yml
+++ b/.github/workflows/update-job-queue-times.yml
@@ -1,7 +1,6 @@
 name: Update job queue times dataset
 
 on:
-  pull_request:
   schedule:
     # Run every 15 minutes
     - cron: "*/15 * * * *"

--- a/.github/workflows/update-job-queue-times.yml
+++ b/.github/workflows/update-job-queue-times.yml
@@ -1,0 +1,27 @@
+name: Update job queue times dataset
+
+on:
+  pull_request:
+  schedule:
+    # Run every 15 minutes
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: torchci
+jobs:
+  update-queue-times:
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - run: yarn install --frozen-lockfile
+      - name: configure aws credentials
+        id: aws_creds
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_update_queue_times
+          aws-region: us-east-1
+      - run: yarn node scripts/updatJobQueueTimes.mjs

--- a/.github/workflows/update-queue-times.yml
+++ b/.github/workflows/update-queue-times.yml
@@ -1,6 +1,7 @@
 name: Update queue times dataset
 
 on:
+  pull_request:
   schedule:
     # Run every 15 minutes
     - cron: "*/15 * * * *"
@@ -23,4 +24,4 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_update_queue_times
           aws-region: us-east-1
-      - run: yarn node scripts/updateQueueTimes.mjs
+      - run: yarn node scripts/updateJobQueueTimes.mjs

--- a/.github/workflows/update-queue-times.yml
+++ b/.github/workflows/update-queue-times.yml
@@ -1,7 +1,6 @@
 name: Update queue times dataset
 
 on:
-  pull_request:
   schedule:
     # Run every 15 minutes
     - cron: "*/15 * * * *"
@@ -24,4 +23,4 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_update_queue_times
           aws-region: us-east-1
-      - run: yarn node scripts/updateJobQueueTimes.mjs
+      - run: yarn node scripts/updateQueueTimes.mjs

--- a/torchci/clickhouse_queries/queued_jobs/query.sql
+++ b/torchci/clickhouse_queries/queued_jobs/query.sql
@@ -16,6 +16,7 @@ SELECT
         job.created_at,
         CURRENT_TIMESTAMP()
     ) AS queue_s,
+    workflow.repository.'full_name' as repo,
     workflow.name AS workflow_name,
     job.name AS job_name,
     job.html_url,

--- a/torchci/clickhouse_queries/queued_jobs/query.sql
+++ b/torchci/clickhouse_queries/queued_jobs/query.sql
@@ -16,7 +16,8 @@ SELECT
         job.created_at,
         CURRENT_TIMESTAMP()
     ) AS queue_s,
-    CONCAT(workflow.name, ' / ', job.name) AS name,
+    workflow.name AS workflow_name,
+    job.name AS job_name,
     job.html_url,
     IF(
         LENGTH(job.labels) = 0,

--- a/torchci/clickhouse_queries/queued_jobs/query.sql
+++ b/torchci/clickhouse_queries/queued_jobs/query.sql
@@ -16,7 +16,7 @@ SELECT
         job.created_at,
         CURRENT_TIMESTAMP()
     ) AS queue_s,
-    workflow.repository.'full_name' as repo,
+    workflow.repository.'full_name' AS repo,
     workflow.name AS workflow_name,
     job.name AS job_name,
     job.html_url,

--- a/torchci/components/metrics/panels/TablePanel.tsx
+++ b/torchci/components/metrics/panels/TablePanel.tsx
@@ -21,6 +21,8 @@ export default function TablePanel({
   helpLink,
   // An optional flag to show the table footer
   showFooter,
+  // A custom function to modify the data before it is passed to table rendering
+  dataModifier,
 }: {
   title: string;
   queryName: string;
@@ -29,6 +31,7 @@ export default function TablePanel({
   dataGridProps: any;
   helpLink?: string;
   showFooter?: boolean;
+  dataModifier?: (data: any) => any;
 }) {
   const url = `/api/clickhouse/${queryName}?parameters=${encodeURIComponent(
     JSON.stringify(queryParams)
@@ -38,10 +41,16 @@ export default function TablePanel({
     refreshInterval: 5 * 60 * 1000, // refresh every 5 minutes
   });
 
+
+  let inputData = data;
+  if  (dataModifier !== undefined && data!=undefined) {
+    inputData = dataModifier(data);
+  }
+
   return (
     <TablePanelWithData
       title={title}
-      data={data}
+      data={inputData}
       columns={columns}
       dataGridProps={dataGridProps}
       helpLink={helpLink}

--- a/torchci/components/metrics/panels/TablePanel.tsx
+++ b/torchci/components/metrics/panels/TablePanel.tsx
@@ -41,9 +41,8 @@ export default function TablePanel({
     refreshInterval: 5 * 60 * 1000, // refresh every 5 minutes
   });
 
-
   let inputData = data;
-  if  (dataModifier !== undefined && data!=undefined) {
+  if (dataModifier !== undefined && data != undefined) {
     inputData = dataModifier(data);
   }
 

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -778,14 +778,12 @@ export default function Page() {
               },
               getRowId: (el: any) => el.html_url,
             }}
-            dataModifier={
-              (data: any[]) =>{
-                return data.map((el) => {
-                  el.name = el.workflow_name+"/"+el.job_name;
-                  return el;
-                })
-              }
-            }
+            dataModifier={(data: any[]) => {
+              return data.map((el) => {
+                el.name = el.workflow_name + "/" + el.job_name;
+                return el;
+              });
+            }}
           />
         </Grid2>
 

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -778,6 +778,14 @@ export default function Page() {
               },
               getRowId: (el: any) => el.html_url,
             }}
+            dataModifier={
+              (data: any[]) =>{
+                return data.map((el) => {
+                  el.name = el.workflow_name+"/"+el.job_name;
+                  return el;
+                })
+              }
+            }
           />
         </Grid2>
 

--- a/torchci/scripts/updateJobQueueTimes.mjs
+++ b/torchci/scripts/updateJobQueueTimes.mjs
@@ -21,7 +21,7 @@ const response = await fetch(
 const unixTime = Math.floor(Date.now() / 1000);
 
 let repo = "pytorch/pytorch";
-if (response.length > 0 && response[0].repo) {
+if (response.length > 0 && response[0].repo != undefined) {
     repo = response[0].repo
 }
 

--- a/torchci/scripts/updateJobQueueTimes.mjs
+++ b/torchci/scripts/updateJobQueueTimes.mjs
@@ -19,12 +19,12 @@ const response = await fetch(
 ).then((r) => r.json());
 
 const unixTime = Math.floor(Date.now() / 1000);
-json_records = result.map((item) => JSON.stringify(item)).join("\n");
+const json_records = response.map((item) => JSON.stringify(item)).join("\n");
 
 s3client.send(
   new PutObjectCommand({
     Bucket: "ossci-raw-job-status",
-    Key: `job_queue_times_historical/${unixTime}.json`,
+    Key: `job_queue_times_historical/${unixTime}.txt`,
     Body: json_records,
   })
 );

--- a/torchci/scripts/updateJobQueueTimes.mjs
+++ b/torchci/scripts/updateJobQueueTimes.mjs
@@ -15,7 +15,7 @@ const s3client = getS3Client();
 
 // %7B%7D = encoded {}
 const response = await fetch(
-  "https://hud.pytorch.org/api/clickhouse/queued_jobs?parameters=%7B%7D"
+  "http://localhost:3000/api/clickhouse/queued_jobs?parameters=%7B%7D"
 ).then((r) => r.json());
 
 const unixTime = Math.floor(Date.now() / 1000);

--- a/torchci/scripts/updateJobQueueTimes.mjs
+++ b/torchci/scripts/updateJobQueueTimes.mjs
@@ -19,12 +19,12 @@ const response = await fetch(
 ).then((r) => r.json());
 
 const unixTime = Math.floor(Date.now() / 1000);
-json_records = result.map((item => JSON.stringify(item))).join('\n');
+json_records = result.map((item) => JSON.stringify(item)).join("\n");
 
 s3client.send(
-    new PutObjectCommand({
-      Bucket: "ossci-raw-job-status",
-      Key: `job_queue_times_historical/${unixTime}.json`,
-      Body: json_records,
-    })
-  );
+  new PutObjectCommand({
+    Bucket: "ossci-raw-job-status",
+    Key: `job_queue_times_historical/${unixTime}.json`,
+    Body: json_records,
+  })
+);

--- a/torchci/scripts/updateJobQueueTimes.mjs
+++ b/torchci/scripts/updateJobQueueTimes.mjs
@@ -21,8 +21,8 @@ const response = await fetch(
 const unixTime = Math.floor(Date.now() / 1000);
 
 let repo = "pytorch/pytorch";
-if (response.length != 0) {
-    repo = response[0].repo;
+if (response.length > 0 && response[0].repo) {
+    repo = response[0].repo
 }
 
 const json_records = response.map((item) => JSON.stringify(item)).join("\n");

--- a/torchci/scripts/updateJobQueueTimes.mjs
+++ b/torchci/scripts/updateJobQueueTimes.mjs
@@ -15,16 +15,22 @@ const s3client = getS3Client();
 
 // %7B%7D = encoded {}
 const response = await fetch(
-  "http://localhost:3000/api/clickhouse/queued_jobs?parameters=%7B%7D"
+  "https://hud.pytorch.org/api/clickhouse/queued_jobs?parameters=%7B%7D"
 ).then((r) => r.json());
 
 const unixTime = Math.floor(Date.now() / 1000);
+
+let repo = "pytorch/pytorch";
+if (response.length != 0) {
+    repo = response[0].repo;
+}
+
 const json_records = response.map((item) => JSON.stringify(item)).join("\n");
 
 s3client.send(
   new PutObjectCommand({
     Bucket: "ossci-raw-job-status",
-    Key: `job_queue_times_historical/${unixTime}.txt`,
+    Key: `job_queue_times_historical/${repo}/${unixTime}.txt`,
     Body: json_records,
   })
 );

--- a/torchci/scripts/updateJobQueueTimes.mjs
+++ b/torchci/scripts/updateJobQueueTimes.mjs
@@ -1,0 +1,30 @@
+// We compute queue times by looking at a snapshot of jobs in CI that are
+// currently queued and seeing how long they've existed. This approach doesn't
+// give us historical data, so write our snapshot regularly to s3 so we can get
+// a view of the queue over time.
+// this script is used to update the job queue times in s3 bucket for each job.
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+
+export function getS3Client() {
+  return new S3Client({
+    region: "us-east-1",
+  });
+}
+
+const s3client = getS3Client();
+
+// %7B%7D = encoded {}
+const response = await fetch(
+  "https://hud.pytorch.org/api/clickhouse/queued_jobs?parameters=%7B%7D"
+).then((r) => r.json());
+
+const unixTime = Math.floor(Date.now() / 1000);
+json_records = result.map((item => JSON.stringify(item))).join('\n');
+
+s3client.send(
+    new PutObjectCommand({
+      Bucket: "ossci-raw-job-status",
+      Key: `job_queue_times_historical/${unixTime}.json`,
+      Body: json_records,
+    })
+  );

--- a/torchci/scripts/updateJobQueueTimes.mjs
+++ b/torchci/scripts/updateJobQueueTimes.mjs
@@ -12,6 +12,7 @@ export function getS3Client() {
 }
 
 const s3client = getS3Client();
+const repo = "pytorch/pytorch";
 
 // %7B%7D = encoded {}
 const response = await fetch(
@@ -20,12 +21,12 @@ const response = await fetch(
 
 const unixTime = Math.floor(Date.now() / 1000);
 
-let repo = "pytorch/pytorch";
-if (response.length > 0 && response[0].repo != undefined) {
-    repo = response[0].repo
-}
-
-const json_records = response.map((item) => JSON.stringify(item)).join("\n");
+const json_records = response
+  .map((item) => {
+    item.time = unixTime;
+    return JSON.stringify(item);
+  })
+  .join("\n");
 
 s3client.send(
   new PutObjectCommand({


### PR DESCRIPTION
# Description
Add git work to insert new queue time data into s3 every 15 minutes,

the new data includes:
{ queue_s, repo,  workflow_name , job_name, machine_type, time}

Pending PR for permission:
https://github.com/pytorch-labs/pytorch-gha-infra/pull/627

Pending PR for db schema:
https://github.com/pytorch/test-infra/pull/6418

Design Doc:
https://docs.google.com/document/d/1OiPv-ku_NvMgvnaMIbtnIEHTixJY28CBaKeMKJtglEk/edit?tab=t.0#heading=h.87bg49h503n7

# Details
- refactor query queued_jobs to have workflow_name and job_name field
- add data modifier func to provide customize pre-rendering process for input data in UI component PanelTable
- add workflow UpdateJobQueueTimesDataset to upload data to s3

# working result in s3 
https://us-east-1.console.aws.amazon.com/s3/object/ossci-raw-job-status?region=us-east-1&bucketType=general&prefix=job_queue_times_historical/pytorch/pytorch/1742001203.txt
