### PR TITLE
fix tooltip width

### DIFF
--- a/torchci/components/TooltipTarget.module.css
+++ b/torchci/components/TooltipTarget.module.css
@@ -31,6 +31,7 @@
   max-width: 95vw;
   min-height: 3em;
   margin-bottom: 10px;
+  width: max-content;
 }
 
 .contentPinned {
@@ -44,6 +45,7 @@
   z-index: 1;
   max-width: 95vw;
   margin-bottom: 10px;
+  width: max-content;
 }
 
 .content pre {


### PR DESCRIPTION
tooltip width was no longer wide - side effect of dark mode PRs. This fixes that:

<img width="1491" alt="image" src="https://github.com/user-attachments/assets/373797c2-0ef8-415f-a7a0-3e3778270194" />
