### PR TITLE
[validations] Remove libtorch PRE_CXX11_ABI from matrix. 

### DIFF
--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -185,10 +185,6 @@ jobs:
       script: |
         set -ex
         python3 -m ensurepip --upgrade
-
-        # install Dev Tools in order to test torch.compile
-        dnf groupinstall -y "Development Tools"
-
         CUDA_VERSION=$(python3 ../../test-infra/tools/scripts/get_stable_cuda_version.py --channel ${{ inputs.channel }})
         CUDA_VERSION_NODOT=$(echo $CUDA_VERSION | tr -d '.')
 
@@ -199,8 +195,6 @@ jobs:
           DWN_PYTORCH_ORG="https://download.pytorch.org/whl/cu${CUDA_VERSION_NODOT}"
         fi
 
-        # smoke tests include numpy tests hence install numpy
-        python3 -m pip install numpy
         # install torch using default python version and smoke test
         python3 -m pip install torch --index-url ${DWN_PYTORCH_ORG}
         python3 .ci/pytorch/smoke_test/smoke_test.py --package torchonly

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -195,6 +195,5 @@ jobs:
           DWN_PYTORCH_ORG="https://download.pytorch.org/whl/cu${CUDA_VERSION_NODOT}"
         fi
 
-        # install torch using default python version and smoke test
         python3 -m pip install torch --index-url ${DWN_PYTORCH_ORG}
         python3 .ci/pytorch/smoke_test/smoke_test.py --package torchonly

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -195,5 +195,8 @@ jobs:
           DWN_PYTORCH_ORG="https://download.pytorch.org/whl/cu${CUDA_VERSION_NODOT}"
         fi
 
+        # smoke tests include numpy tests hence install numpy
+        python3 -m pip install numpy
+        # install torch using default python version and smoke test
         python3 -m pip install torch --index-url ${DWN_PYTORCH_ORG}
         python3 .ci/pytorch/smoke_test/smoke_test.py --package torchonly

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -185,6 +185,10 @@ jobs:
       script: |
         set -ex
         python3 -m ensurepip --upgrade
+
+        # install Dev Tools in order to test torch.compile
+        dnf groupinstall -y "Development Tools"
+
         CUDA_VERSION=$(python3 ../../test-infra/tools/scripts/get_stable_cuda_version.py --channel ${{ inputs.channel }})
         CUDA_VERSION_NODOT=$(echo $CUDA_VERSION | tr -d '.')
 

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -53,7 +53,6 @@ STABLE_CUDA_VERSIONS = {
 CUDA_AARCH64_ARCHES = ["12.8-aarch64"]
 
 PACKAGE_TYPES = ["wheel", "conda", "libtorch"]
-PRE_CXX11_ABI = "pre-cxx11"
 CXX11_ABI = "cxx11-abi"
 RELEASE = "release"
 DEBUG = "debug"
@@ -178,22 +177,13 @@ def initialize_globals(channel: str, build_python_only: bool) -> None:
     }
     LIBTORCH_CONTAINER_IMAGES = {
         **{
-            (gpu_arch, PRE_CXX11_ABI): f"pytorch/manylinux-builder:cuda{gpu_arch}"
-            for gpu_arch in CUDA_ARCHES
-        },
-        **{
             (gpu_arch, CXX11_ABI): f"pytorch/libtorch-cxx11-builder:cuda{gpu_arch}"
             for gpu_arch in CUDA_ARCHES
-        },
-        **{
-            (gpu_arch, PRE_CXX11_ABI): f"pytorch/manylinux-builder:rocm{gpu_arch}"
-            for gpu_arch in ROCM_ARCHES
         },
         **{
             (gpu_arch, CXX11_ABI): f"pytorch/libtorch-cxx11-builder:rocm{gpu_arch}"
             for gpu_arch in ROCM_ARCHES
         },
-        (CPU, PRE_CXX11_ABI): "pytorch/manylinux-builder:cpu",
         (CPU, CXX11_ABI): "pytorch/libtorch-cxx11-builder:cpu",
     }
 
@@ -364,7 +354,7 @@ def generate_libtorch_matrix(
         if os == WINDOWS:
             abi_versions = [RELEASE, DEBUG]
         elif os == LINUX:
-            abi_versions = [PRE_CXX11_ABI, CXX11_ABI]
+            abi_versions = [CXX11_ABI]
         elif os in [MACOS_ARM64]:
             abi_versions = [CXX11_ABI]
         else:
@@ -385,10 +375,6 @@ def generate_libtorch_matrix(
                 # matter
                 gpu_arch_type = arch_type(arch_version)
                 gpu_arch_version = "" if arch_version == CPU else arch_version
-
-                # Rocm builds where removed for pre-cxx11 abi
-                if gpu_arch_type == "rocm" and abi_version == PRE_CXX11_ABI:
-                    continue
 
                 desired_cuda = translate_desired_cuda(gpu_arch_type, gpu_arch_version)
                 devtoolset = abi_version if os != WINDOWS else ""


### PR DESCRIPTION
Remove libtorch PRE_CXX11_ABI from matrix

 failures can be seen here: https://github.com/pytorch/test-infra/actions/runs/13906844473/job/38911966250