### PR TITLE
fix vertical position of tooltip on HUD

### DIFF
--- a/torchci/components/TooltipTarget.module.css
+++ b/torchci/components/TooltipTarget.module.css
@@ -19,33 +19,28 @@
   pointer-events: none;
 }
 
-.content {
-  background-color: var(--tooltip-bg);
+.content,
+.contentPinned {
   padding: 5px 8px;
   border-radius: 6px;
   cursor: default;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
   pointer-events: auto;
-  position: relative;
+  position: absolute;
   z-index: 1;
   max-width: 95vw;
-  min-height: 3em;
   margin-bottom: 10px;
   width: max-content;
+  top: 15px;
+  left: 15px;
+}
+
+.content {
+  background-color: var(--tooltip-bg);
 }
 
 .contentPinned {
   background-color: var(--tooltip-pinned-bg);
-  padding: 5px 8px;
-  border-radius: 6px;
-  cursor: default;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-  pointer-events: auto;
-  position: relative;
-  z-index: 1;
-  max-width: 95vw;
-  margin-bottom: 10px;
-  width: max-content;
 }
 
 .content pre {


### PR DESCRIPTION
regression after dark mode fixes:

old version (desired behavior):
![image](https://github.com/user-attachments/assets/2d0f48b0-9d6b-4603-9e74-9ad3bbe109d7)

broken version:
![image](https://github.com/user-attachments/assets/d88dea9a-26fd-4865-ba5b-662a053ad43d)

after this PR:
<img width="405" alt="image" src="https://github.com/user-attachments/assets/2b1f9a3d-da8d-4b5c-a37e-610683b1dbeb" />
