### PR TITLE
fix dropdown gap causing issues dropping down

### DIFF
--- a/torchci/components/NavBar.module.css
+++ b/torchci/components/NavBar.module.css
@@ -67,5 +67,4 @@
   background-color: var(--dropdown-bg);
   display: none;
   border-radius: 4px;
-  margin-top: 0.15rem;
 }


### PR DESCRIPTION
Regression since https://github.com/pytorch/test-infra/pull/6405 - making the dropdown of the navbar hide at times.

