### PR TITLE
ci: Give correct job names to binary builds

### DIFF
--- a/.github/workflows/_binary_upload.yml
+++ b/.github/workflows/_binary_upload.yml
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.build-matrix) }}
     timeout-minutes: 30
-    name: ${{ matrix.build_name }}
+    name: upload-${{ matrix.build_name }}
     env:
       DO_UPLOAD: ${{ contains(matrix.validation_runner, 'windows') || contains(matrix.validation_runner, 'macos') || contains(matrix.container_image, '2_28') || contains(matrix.container_image, 'manylinuxaarch64-builder:cuda') }}
     steps:

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -124,7 +124,7 @@ jobs:
       UPLOAD_TO_BASE_BUCKET: ${{ matrix.upload_to_base_bucket }}
       ARCH: ${{ inputs.architecture }}
       IS_MANYLINUX2_28: ${{ contains(matrix.container_image, '2_28') || contains(matrix.container_image, 'manylinuxaarch64-builder:cuda') }}
-    name: ${{ matrix.build_name }}
+    name: build-${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
     environment: ${{(inputs.trigger-event == 'schedule' || (inputs.trigger-event == 'push' && (startsWith(github.event.ref, 'refs/heads/nightly') || startsWith(github.event.ref, 'refs/tags/v')))) && 'pytorchbot-env' || ''}}
     container:

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -104,7 +104,7 @@ jobs:
       REPOSITORY: ${{ inputs.repository }}
       REF: ${{ inputs.ref }}
       CU_VERSION: ${{ matrix.desired_cuda }}
-    name: ${{ matrix.build_name }}
+    name: build-${{ matrix.build_name }}
     runs-on: ${{ inputs.runner-type }}
     # If a build is taking longer than 60 minutes on these runners we need
     # to have a conversation

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -85,7 +85,7 @@ jobs:
       REF: ${{ inputs.ref }}
       CU_VERSION: ${{ matrix.desired_cuda }}
       UPLOAD_TO_BASE_BUCKET: ${{ matrix.upload_to_base_bucket }}
-    name: ${{ matrix.build_name }}
+    name: build-${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
     defaults:
       run:


### PR DESCRIPTION
Binary build workflows were getting named incorrectly so this should name them the things that they're actually doing.

Example of what our old naming scheme looked like:
![Screenshot 2025-03-18 at 1 21 10 PM](https://github.com/user-attachments/assets/0147af71-23de-45fe-8a5e-b64cb33f3011)
