### PR TITLE
[HUD] Add "Hide green columns" checkbox

### DIFF
--- a/torchci/lib/useGroupingPreference.tsx
+++ b/torchci/lib/useGroupingPreference.tsx
@@ -65,3 +65,15 @@ export function useMonsterFailuresPreference(): [
   );
   return [state, setState];
 }
+
+export function useHideGreenColumnsPreference(): [
+  boolean,
+  (_hideGreenColumnsValue: boolean) => void
+] {
+  const [state, setState] = usePreference(
+    "hideGreenColumns",
+    /*override*/ undefined,
+    /*default*/ false
+  );
+  return [state, setState];
+}


### PR DESCRIPTION
This PR adds a "Hide green columns" checkbox to the PyTorch HUD interface that filters out columns without any failures. When enabled, only jobs or job groups with at least one failure across all displayed commits will be shown, reducing visual noise and helping users focus on problematic areas.

Implementation Details:

  - Added a new local storage preference using the existing preference system
  - Preprocessed failure data for efficient filtering and better performance
  - Added checkbox next to existing view options in the HUD UI
  - Works seamlessly with both grouped and ungrouped views

  This feature helps developers spot issues more quickly by eliminating the visual noise of successful builds.


---

generated with claude code in three iterations:

Total cost:            $2.69