### PR TITLE
Update CMake to 3.25

### DIFF
--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -28,7 +28,7 @@ inputs:
     description: Default packages to install
     required: false
     type: string
-    default: "cmake=3.22 ninja=1.10 pkg-config=0.29 wheel=0.37"
+    default: "cmake>=3.25 ninja=1.10 pkg-config=0.29 wheel=0.37"
 
 runs:
   using: composite

--- a/aws/ami/windows/scripts/Installers/Install-Conda-Dependencies.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-Conda-Dependencies.ps1
@@ -15,5 +15,5 @@ conda activate base
 Write-Output "Installing conda packages for building and testing PyTorch"
 # The list of dependencies is copied from the current PyTorch miniconda installation script
 conda install -y mkl protobuf numba scipy=1.6.2 typing_extensions dataclasses `
-conda==22.9.0 numpy"<1.23" ninja pyyaml setuptools cmake=3.22.* cffi typing_extensions `
+conda==22.9.0 numpy"<1.23" ninja pyyaml setuptools cmake>=3.25.* cffi typing_extensions `
 future six requests dataclasses boto3 libuv


### PR DESCRIPTION
In preparation for updating PyTorch's CMake version. See https://github.com/pytorch/pytorch/pull/130522