### PR TITLE
[HUD] Make time column wider

### DIFF
--- a/torchci/components/hud.module.css
+++ b/torchci/components/hud.module.css
@@ -8,7 +8,7 @@
 /* Fix the width of these columns to avoid layout shift when loading the HUD
  table. */
 .colTime {
-  width: 13ch;
+  width: 14ch;
 }
 .colSha {
   width: 8ch;


### PR DESCRIPTION
Still not wide enough even after #6432

<img width="531" alt="image" src="https://github.com/user-attachments/assets/d391e7f0-7f2d-4935-a619-fa3a5fb19b15" />

https://hud.pytorch.org/hud/pytorch/pytorch/71daeddde208872391e2f8005b4e8478cdb8eb01/34?per_page=100&name_filter=-xla&mergeLF=true


new:
<img width="783" alt="image" src="https://github.com/user-attachments/assets/3313b04f-be31-42a6-9284-bf6157769d6c" />
