### PR TITLE
[Benchmark UI] Make the mui table scrollerable

### DIFF
--- a/torchci/components/benchmark/llms/components/LLMsSummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/components/LLMsSummaryPanel.tsx
@@ -345,8 +345,8 @@ export default function LLMsSummaryPanel({
 
   // TODO (huydhn): Table bigger than 100 rows requires x-data-grid-pro
   return (
-    <Grid2 container spacing={2}>
-      <Grid2 size={{ xs: 12, lg: 12 }}>
+    <Grid2 container spacing={10}>
+      <Grid2 size={{ xs: 12, lg: 11.8 }}>
         {" "}
         <TablePanelWithData
           title={"Models"}

--- a/torchci/components/benchmark/llms/components/LLMsSummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/components/LLMsSummaryPanel.tsx
@@ -13,9 +13,6 @@ import {
 } from "lib/benchmark/llms/common";
 import { combineLeftAndRight } from "lib/benchmark/llms/utils/llmUtils";
 
-const ROW_GAP = 100;
-const ROW_HEIGHT = 38;
-
 const getDeviceArch = (
   device: string | undefined,
   arch: string | undefined

--- a/torchci/components/benchmark/llms/components/LLMsSummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/components/LLMsSummaryPanel.tsx
@@ -1,4 +1,5 @@
 import { Grid2 } from "@mui/material";
+import { maxHeight } from "@mui/system";
 import { GridCellParams, GridRenderCellParams } from "@mui/x-data-grid";
 import styles from "components/metrics.module.css";
 import { TablePanelWithData } from "components/metrics/panels/TablePanel";
@@ -12,6 +13,7 @@ import {
   UNIT_FOR_METRIC,
 } from "lib/benchmark/llms/common";
 import { combineLeftAndRight } from "lib/benchmark/llms/utils/llmUtils";
+import { max } from "lodash";
 
 const ROW_GAP = 100;
 const ROW_HEIGHT = 38;
@@ -345,21 +347,17 @@ export default function LLMsSummaryPanel({
 
   // TODO (huydhn): Table bigger than 100 rows requires x-data-grid-pro
   return (
-    <Grid2 container spacing={2} style={{ height: "100%" }}>
+    <Grid2 container spacing={2} style={{ height: "auto" }}>
       <Grid2
         size={{ xs: 12, lg: 12 }}
-        height={
-          data.length > 90
-            ? 90 * ROW_HEIGHT
-            : (data.length + 1) * ROW_HEIGHT + ROW_GAP
-        }
-      >
-        <TablePanelWithData
+      >  <TablePanelWithData
           title={"Models"}
           data={data}
           columns={columns}
           dataGridProps={{ getRowId: (el: any) => el.name }}
           showFooter={true}
+          disableAutoPageSize={true}
+          customStyle={{maxHeight: "1000px"}}
         />
       </Grid2>
     </Grid2>

--- a/torchci/components/benchmark/llms/components/LLMsSummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/components/LLMsSummaryPanel.tsx
@@ -347,7 +347,6 @@ export default function LLMsSummaryPanel({
   return (
     <Grid2 container spacing={10}>
       <Grid2 size={{ xs: 12, lg: 11.8 }}>
-        {" "}
         <TablePanelWithData
           title={"Models"}
           data={data}
@@ -355,7 +354,9 @@ export default function LLMsSummaryPanel({
           dataGridProps={{ getRowId: (el: any) => el.name }}
           showFooter={true}
           disableAutoPageSize={true}
-          customStyle={{ maxHeight: "1000px" }}
+          customStyle={{
+            maxHeight: 1200,
+          }}
         />
       </Grid2>
     </Grid2>

--- a/torchci/components/benchmark/llms/components/LLMsSummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/components/LLMsSummaryPanel.tsx
@@ -347,7 +347,7 @@ export default function LLMsSummaryPanel({
 
   // TODO (huydhn): Table bigger than 100 rows requires x-data-grid-pro
   return (
-    <Grid2 container spacing={2} style={{ height: "auto" }}>
+    <Grid2 container spacing={2}>
       <Grid2
         size={{ xs: 12, lg: 12 }}
       >  <TablePanelWithData

--- a/torchci/components/benchmark/llms/components/LLMsSummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/components/LLMsSummaryPanel.tsx
@@ -1,5 +1,4 @@
 import { Grid2 } from "@mui/material";
-import { maxHeight } from "@mui/system";
 import { GridCellParams, GridRenderCellParams } from "@mui/x-data-grid";
 import styles from "components/metrics.module.css";
 import { TablePanelWithData } from "components/metrics/panels/TablePanel";
@@ -13,7 +12,6 @@ import {
   UNIT_FOR_METRIC,
 } from "lib/benchmark/llms/common";
 import { combineLeftAndRight } from "lib/benchmark/llms/utils/llmUtils";
-import { max } from "lodash";
 
 const ROW_GAP = 100;
 const ROW_HEIGHT = 38;
@@ -348,16 +346,16 @@ export default function LLMsSummaryPanel({
   // TODO (huydhn): Table bigger than 100 rows requires x-data-grid-pro
   return (
     <Grid2 container spacing={2}>
-      <Grid2
-        size={{ xs: 12, lg: 12 }}
-      >  <TablePanelWithData
+      <Grid2 size={{ xs: 12, lg: 12 }}>
+        {" "}
+        <TablePanelWithData
           title={"Models"}
           data={data}
           columns={columns}
           dataGridProps={{ getRowId: (el: any) => el.name }}
           showFooter={true}
           disableAutoPageSize={true}
-          customStyle={{maxHeight: "1000px"}}
+          customStyle={{ maxHeight: "1000px" }}
         />
       </Grid2>
     </Grid2>

--- a/torchci/components/metrics/panels/TablePanel.tsx
+++ b/torchci/components/metrics/panels/TablePanel.tsx
@@ -1,7 +1,8 @@
 import HelpIcon from "@mui/icons-material/Help";
-import { Skeleton, Typography } from "@mui/material";
+import { Box, Skeleton, Typography } from "@mui/material";
 import IconButton from "@mui/material/IconButton";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import { CSSProperties } from "react";
 import useSWR from "swr";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
@@ -64,6 +65,8 @@ export function TablePanelWithData({
   // An optional flag to show the table footer
   showFooter,
   pageSize,
+  disableAutoPageSize,
+  customStyle
 }: {
   title: string;
   data: any;
@@ -71,6 +74,8 @@ export function TablePanelWithData({
   dataGridProps: any;
   helpLink?: string;
   showFooter?: boolean;
+  disableAutoPageSize?: boolean;
+  customStyle?: CSSProperties;
   pageSize?: number;
 }) {
   if (data === undefined) {
@@ -95,15 +100,18 @@ export function TablePanelWithData({
   }
 
   return (
+    <>
     <DataGrid
+      style={customStyle}
       {...dataGridProps}
       density={"compact"}
       rows={data}
       columns={columns}
       hideFooter={!showFooter}
-      autoPageSize={showFooter && pageSize === undefined}
+      autoPageSize={showFooter && pageSize === undefined && !disableAutoPageSize}
       pageSize={pageSize}
       slots={{ toolbar: Header }}
     />
+    </>
   );
 }

--- a/torchci/components/metrics/panels/TablePanel.tsx
+++ b/torchci/components/metrics/panels/TablePanel.tsx
@@ -1,5 +1,5 @@
 import HelpIcon from "@mui/icons-material/Help";
-import { Box, Skeleton, Typography } from "@mui/material";
+import { Skeleton, Typography } from "@mui/material";
 import IconButton from "@mui/material/IconButton";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
 import { CSSProperties } from "react";
@@ -66,7 +66,7 @@ export function TablePanelWithData({
   showFooter,
   pageSize,
   disableAutoPageSize,
-  customStyle
+  customStyle,
 }: {
   title: string;
   data: any;
@@ -101,17 +101,19 @@ export function TablePanelWithData({
 
   return (
     <>
-    <DataGrid
-      style={customStyle}
-      {...dataGridProps}
-      density={"compact"}
-      rows={data}
-      columns={columns}
-      hideFooter={!showFooter}
-      autoPageSize={showFooter && pageSize === undefined && !disableAutoPageSize}
-      pageSize={pageSize}
-      slots={{ toolbar: Header }}
-    />
+      <DataGrid
+        style={customStyle}
+        {...dataGridProps}
+        density={"compact"}
+        rows={data}
+        columns={columns}
+        hideFooter={!showFooter}
+        autoPageSize={
+          showFooter && pageSize === undefined && !disableAutoPageSize
+        }
+        pageSize={pageSize}
+        slots={{ toolbar: Header }}
+      />
     </>
   );
 }


### PR DESCRIPTION
it is not ideal when a benchmark table has 100 records,  when user scrolls down, they cannot see the column headers

https://github.com/pytorch/test-infra/issues/6430


Preview UI with long data: [vercel](https://torchci-git-benchexfefix-fbopensource.vercel.app/benchmark/llms?startTime=Thu%2C%2006%20Mar%202025%2001%3A42%3A40%20GMT&stopTime=Thu%2C%2020%20Mar%202025%2000%3A42%3A40%20GMT&granularity=hour&lBranch=main&lCommit=51901f3849723b44f3a48768b7a7bf7ffdc08094&rBranch=main&rCommit=b195ed9a2564e5c2cd3554518213c4769d3ad022&repoName=pytorch%2Fexecutorch&benchmarkName=&modelName=All%20Models&backendName=All%20Backends&modeName=All%20Modes&dtypeName=All%20DType&deviceName=All%20Devices&archName=All%20Platforms)

Example with small data
