### PR TITLE
[Benchmark UI] Add indicator for trimmean_inference_latency(ms)

### DIFF
--- a/torchci/lib/benchmark/llms/common.ts
+++ b/torchci/lib/benchmark/llms/common.ts
@@ -52,6 +52,7 @@ export const IS_INCREASING_METRIC_VALUE_GOOD: { [k: string]: boolean } = {
   "compilation_time(s)": false,
   speedup: true,
   "avg_inference_latency(ms)": false,
+  "trimmean_inference_latency(ms)": false,
   "model_load_time(ms)": false,
   "peak_inference_mem_usage(mb)": false,
   "peak_load_mem_usuage(mb)": false,


### PR DESCRIPTION
issue: https://github.com/pytorch/test-infra/issues/6430

add indicateor for trimmean_inference_latency

the preview:
[vercel](https://torchci-git-addrate-fbopensource.vercel.app/benchmark/llms?startTime=Thu%2C%2013%20Mar%202025%2001%3A10%3A38%20GMT&stopTime=Thu%2C%2020%20Mar%202025%2001%3A10%3A38%20GMT&granularity=day&lBranch=main&lCommit=0ccf5093823761cf8ad98c75e5fe81f15ea42366&rBranch=main&rCommit=8c03d0453cfe789513e2f3cf9fef1ee4b6a527cd&repoName=pytorch%2Fexecutorch&benchmarkName=&modelName=All%20Models&backendName=All%20Backends&modeName=All%20Modes&dtypeName=All%20DType&deviceName=All%20Devices&archName=All%20Platforms)