### PR TITLE
[HUD] Query for artifacts of all workflow ids

### DIFF
--- a/torchci/components/WorkflowBox.tsx
+++ b/torchci/components/WorkflowBox.tsx
@@ -168,13 +168,7 @@ export default function WorkflowBox({
   const { utilMetadataList } = useUtilMetadata(workflowId);
   const groupUtilMetadataList = groupMetadataByJobId(utilMetadataList);
 
-  const { artifacts, error } = useArtifacts(
-    _(jobs)
-      .map("workflowId")
-      .uniq()
-      .filter((w) => w !== undefined)
-      .value() as (string | number)[]
-  );
+  const { artifacts, error } = useArtifacts(jobs.map((job) => job.workflowId));
   const [artifactsToShow, setArtifactsToShow] = useState(new Set<string>());
   const groupedArtifacts = groupArtifacts(jobs, artifacts);
   const [searchString, setSearchString] = useState("");
@@ -320,11 +314,13 @@ function useUtilMetadata(workflowId: string | undefined): {
   return { utilMetadataList: data.metadata_list, metaError: null };
 }
 
-function useArtifacts(workflowIds: (string | number )[]): {
+function useArtifacts(workflowIds: (string | number | undefined)[]): {
   artifacts: Artifact[];
   error: any;
 } {
-  const uniqueWorkflowIds = Array.from(new Set(workflowIds));
+  const uniqueWorkflowIds = Array.from(new Set(workflowIds)).filter(
+    (id) => id !== undefined
+  )
   // Get all artifacts for these ids
   const { data, error } = useSWR<Artifact[]>(
     `/api/artifacts/s3/${uniqueWorkflowIds.join(",")}`,

--- a/torchci/components/WorkflowBox.tsx
+++ b/torchci/components/WorkflowBox.tsx
@@ -319,7 +319,7 @@ function useArtifacts(workflowIds: (string | number | undefined)[]): {
 } {
   const uniqueWorkflowIds = Array.from(new Set(workflowIds)).filter(
     (id) => id !== undefined
-  )
+  );
   // Get all artifacts for these ids
   const { data, error } = useSWR<Artifact[]>(
     `/api/artifacts/s3/${uniqueWorkflowIds.join(",")}`,

--- a/torchci/components/WorkflowBox.tsx
+++ b/torchci/components/WorkflowBox.tsx
@@ -16,7 +16,6 @@ import JobArtifact from "./JobArtifact";
 import JobSummary from "./JobSummary";
 import LogViewer, { SearchLogViewer } from "./LogViewer";
 import { durationDisplay } from "./TimeUtils";
-import _ from "lodash";
 
 function sortJobsByConclusion(jobA: JobData, jobB: JobData): number {
   // Show failed jobs first, then pending jobs, then successful jobs

--- a/torchci/lib/fetchS3Links.ts
+++ b/torchci/lib/fetchS3Links.ts
@@ -5,42 +5,46 @@ const GHA_ARTIFACTS_LAMBDA =
   "https://np6xty2nm6jifkuuyb6wllx6ha0qtthb.lambda-url.us-east-1.on.aws";
 
 export default async function fetchS3Links(
-  suiteIds: string[]
+  suiteIds: string
 ): Promise<Artifact[]> {
-  const allArtifacts: Artifact[] = [];
-  // Probably should make this async
-  for (const suiteId of suiteIds) {
-    if (!suiteId) {
-      continue;
-    }
-    const response = await fetch(GHA_ARTIFACTS_LAMBDA, {
-      method: "POST",
-      body: JSON.stringify({
-        workflow_id: suiteId,
-      }),
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
+  const unflattenedList = await Promise.all(
+    _(suiteIds)
+      .split(",")
+      .map((suiteId) => suiteId.trim())
+      .uniq()
+      .map(async (suiteId) => {
+        const response = await fetch(GHA_ARTIFACTS_LAMBDA, {
+          method: "POST",
+          body: JSON.stringify({
+            workflow_id: suiteId,
+          }),
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
 
-    const results = await response.json();
-    const artifacts =
-      _.keys(results).map((url: string) => {
-        const size = results[url];
-        const basename = url.split("/").slice(-1)[0];
-        const name =
-          basename !== "artifacts.zip"
-            ? basename
-            : url.split("/").slice(-2).join("/");
-        return {
-          kind: "s3",
-          name: name ?? "",
-          sizeInBytes: size ?? 0,
-          url: url,
-          expired: false,
-        };
-      }) ?? [];
-    allArtifacts.push(...artifacts);
-  }
-  return allArtifacts.sort((a, b) => a.name.localeCompare(b.name));
+        const results = await response.json();
+        return (
+          _.keys(results).map((url: string) => {
+            const size = results[url];
+            const basename = url.split("/").slice(-1)[0];
+            const name =
+              basename !== "artifacts.zip"
+                ? basename
+                : url.split("/").slice(-2).join("/");
+            return {
+              kind: "s3",
+              name: name ?? "",
+              sizeInBytes: size ?? 0,
+              url: url,
+              expired: false,
+            };
+          }) ?? []
+        );
+      })
+      .value()
+  );
+  return _.flatten(unflattenedList).sort((a, b) => {
+    return a.name.localeCompare(b.name);
+  });
 }

--- a/torchci/lib/fetchS3Links.ts
+++ b/torchci/lib/fetchS3Links.ts
@@ -10,9 +10,9 @@ export default async function fetchS3Links(
   const unflattenedList = await Promise.all(
     _(suiteIds)
       .split(",")
-      .map((suiteId) => suiteId.trim())
       .uniq()
       .map(async (suiteId) => {
+        suiteId = suiteId.trim();
         const response = await fetch(GHA_ARTIFACTS_LAMBDA, {
           method: "POST",
           body: JSON.stringify({

--- a/torchci/lib/fetchS3Links.ts
+++ b/torchci/lib/fetchS3Links.ts
@@ -5,34 +5,42 @@ const GHA_ARTIFACTS_LAMBDA =
   "https://np6xty2nm6jifkuuyb6wllx6ha0qtthb.lambda-url.us-east-1.on.aws";
 
 export default async function fetchS3Links(
-  suiteId: string
+  suiteIds: string[]
 ): Promise<Artifact[]> {
-  const response = await fetch(GHA_ARTIFACTS_LAMBDA, {
-    method: "POST",
-    body: JSON.stringify({
-      workflow_id: suiteId,
-    }),
-    headers: {
-      "Content-Type": "application/json",
-    },
-  });
+  const allArtifacts: Artifact[] = [];
+  // Probably should make this async
+  for (const suiteId of suiteIds) {
+    if (!suiteId) {
+      continue;
+    }
+    const response = await fetch(GHA_ARTIFACTS_LAMBDA, {
+      method: "POST",
+      body: JSON.stringify({
+        workflow_id: suiteId,
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
 
-  const results = await response.json();
-  const artifacts =
-    _.keys(results).map((url: string) => {
-      const size = results[url];
-      const basename = url.split("/").slice(-1)[0];
-      const name =
-        basename !== "artifacts.zip"
-          ? basename
-          : url.split("/").slice(-2).join("/");
-      return {
-        kind: "s3",
-        name: name ?? "",
-        sizeInBytes: size ?? 0,
-        url: url,
-        expired: false,
-      };
-    }) ?? [];
-  return artifacts.sort((a, b) => a.name.localeCompare(b.name));
+    const results = await response.json();
+    const artifacts =
+      _.keys(results).map((url: string) => {
+        const size = results[url];
+        const basename = url.split("/").slice(-1)[0];
+        const name =
+          basename !== "artifacts.zip"
+            ? basename
+            : url.split("/").slice(-2).join("/");
+        return {
+          kind: "s3",
+          name: name ?? "",
+          sizeInBytes: size ?? 0,
+          url: url,
+          expired: false,
+        };
+      }) ?? [];
+    allArtifacts.push(...artifacts);
+  }
+  return allArtifacts.sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/torchci/pages/api/artifacts/s3/[workflowId].ts
+++ b/torchci/pages/api/artifacts/s3/[workflowId].ts
@@ -6,5 +6,8 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Artifact[]>
 ) {
-  res.status(200).json(await fetchS3Links(req.query.workflowId as string));
+  const workflowIds = (req.query.workflowId as string)
+    .split(",")
+    .map((id) => id.trim());
+  res.status(200).json(await fetchS3Links(workflowIds));
 }

--- a/torchci/pages/api/artifacts/s3/[workflowId].ts
+++ b/torchci/pages/api/artifacts/s3/[workflowId].ts
@@ -1,12 +1,10 @@
 import fetchS3Links from "lib/fetchS3Links";
 import { Artifact } from "lib/types";
-import _ from "lodash";
 import { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Artifact[]>
 ) {
-
   res.status(200).json(await fetchS3Links(req.query.workflowId as string));
 }

--- a/torchci/pages/api/artifacts/s3/[workflowId].ts
+++ b/torchci/pages/api/artifacts/s3/[workflowId].ts
@@ -1,13 +1,12 @@
 import fetchS3Links from "lib/fetchS3Links";
 import { Artifact } from "lib/types";
+import _ from "lodash";
 import { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Artifact[]>
 ) {
-  const workflowIds = (req.query.workflowId as string)
-    .split(",")
-    .map((id) => id.trim());
-  res.status(200).json(await fetchS3Links(workflowIds));
+
+  res.status(200).json(await fetchS3Links(req.query.workflowId as string));
 }


### PR DESCRIPTION
Query for the artifacts for all workflow ids in the box.  Previously we assumed that only one workflow would show up in the box at a time, but this might not be true.  

Change the api to accept a list of workflows in the form list.join(",") and get the artifacts for all the workflow ids in that list

https://torchci-git-csl-moreartifacts-fbopensource.vercel.app/pytorch/pytorch/commit/970ac2d907195dc31debe28e9a7ff8f4aa701683


old:
<img width="640" alt="image" src="https://github.com/user-attachments/assets/5aee2470-ff03-4f6b-a7bc-c7842a34044e" />


new:
<img width="620" alt="image" src="https://github.com/user-attachments/assets/37a54316-f245-4f16-a8b3-53b17989daf3" />

Note that the artifacts button shows up for the first job (non rerun or memory leak one)

Fixes https://github.com/pytorch/test-infra/issues/5298
