### PR TITLE
[HUD] Set cache control header for api/artifacts, use immutable swr for artifacts and utilization links

### DIFF
--- a/torchci/components/WorkflowBox.tsx
+++ b/torchci/components/WorkflowBox.tsx
@@ -9,7 +9,7 @@ import {
   UtilizationMetadataInfo,
 } from "lib/utilization/types";
 import React, { useEffect, useState } from "react";
-import useSWR from "swr";
+import useSWRImmutable from "swr/immutable";
 import { getConclusionSeverityForSorting } from "../lib/JobClassifierUtil";
 import { TestInfo } from "./additionalTestInfo/TestInfo";
 import JobArtifact from "./JobArtifact";
@@ -280,16 +280,11 @@ function useUtilMetadata(workflowId: string | undefined): {
   utilMetadataList: UtilizationMetadataInfo[];
   metaError: any;
 } {
-  const { data, error } = useSWR<ListUtilizationMetadataInfoAPIResponse>(
-    `/api/list_utilization_metadata_info/${workflowId}`,
-    fetcher,
-    {
-      refreshInterval: 60 * 1000, // refresh every minute
-      // Refresh even when the user isn't looking, so that switching to the tab
-      // will always have fresh info.
-      refreshWhenHidden: true,
-    }
-  );
+  const { data, error } =
+    useSWRImmutable<ListUtilizationMetadataInfoAPIResponse>(
+      `/api/list_utilization_metadata_info/${workflowId}`,
+      fetcher
+    );
 
   if (!workflowId) {
     return { utilMetadataList: [], metaError: "No workflow ID" };
@@ -321,13 +316,9 @@ function useArtifacts(workflowIds: (string | number | undefined)[]): {
     (id) => id !== undefined
   );
   // Get all artifacts for these ids
-  const { data, error } = useSWR<Artifact[]>(
+  const { data, error } = useSWRImmutable<Artifact[]>(
     `/api/artifacts/s3/${uniqueWorkflowIds.join(",")}`,
-    fetcher,
-    {
-      refreshInterval: 60 * 1000,
-      refreshWhenHidden: true,
-    }
+    fetcher
   );
   if (data == null) {
     return { artifacts: [], error: "Loading..." };

--- a/torchci/pages/api/artifacts/s3/[workflowId].ts
+++ b/torchci/pages/api/artifacts/s3/[workflowId].ts
@@ -6,5 +6,8 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Artifact[]>
 ) {
-  res.status(200).json(await fetchS3Links(req.query.workflowId as string));
+  res
+    .status(200)
+    .setHeader("Cache-Control", "s-maxage=300")
+    .json(await fetchS3Links(req.query.workflowId as string));
 }

--- a/torchci/pages/utilization/[workflowId]/[jobId]/[attempt]/[[...page]].tsx
+++ b/torchci/pages/utilization/[workflowId]/[jobId]/[attempt]/[[...page]].tsx
@@ -3,7 +3,7 @@ import { UtilizationPage } from "components/utilization/UtilizationPage";
 import { fetcherHandleError } from "lib/GeneralUtils";
 import { UtilizationAPIResponse } from "lib/utilization/types";
 import { useRouter } from "next/router";
-import useSWRImmutable from "swr";
+import useSWRImmutable from "swr/immutable";
 
 const Utilization = () => {
   const router = useRouter();


### PR DESCRIPTION
Setting cache control so we don't constantly rerun the lambda

Set useSWRImmutable to reduce api requests (ex when user clicks away etc)

Consequences:
stale data sometimes