### PR TITLE
Remove outdated MacOS and Python tests

### DIFF
--- a/.github/actions/setup-build-test/action.yml
+++ b/.github/actions/setup-build-test/action.yml
@@ -22,7 +22,7 @@ inputs:
     description: Python version to setup the environment for
     required: false
     type: string
-    default: "3.8"
+    default: "3.9"
 
 runs:
   using: composite

--- a/.github/workflows/test-setup-miniconda.yml
+++ b/.github/workflows/test-setup-miniconda.yml
@@ -13,13 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         runner-type:
-          - macos-12
           - macos-m1-stable
           - linux.2xlarge
         # Only testing minimum and maximum versions here
         python-version:
-          - "3.8"
-          - "3.11"
+          - "3.9"
+          - "3.12"
         env-file:
           - ""
           - "./.github/workflows/test-setup-miniconda-env-file"


### PR DESCRIPTION
Remove MacOS 12 and Python 3.8 test cases since they have reached End Of Life.