### PR TITLE
Fix repository filter missing from URL params

### DIFF
--- a/torchci/pages/cost_analysis.tsx
+++ b/torchci/pages/cost_analysis.tsx
@@ -348,6 +348,9 @@ export default function Page() {
     if (selectedYAxis) params.set("yAxis", selectedYAxis);
     if (searchFilter) params.set("searchFilter", searchFilter);
     if (isRegex) params.set("isRegex", isRegex.toString());
+    if (selectedRepos && selectedRepos.length < availableRepos.length) {
+      params.set("repos", selectedRepos.join(","));
+    }
 
     router.push({
       pathname: router.pathname,

--- a/torchci/pages/cost_analysis.tsx
+++ b/torchci/pages/cost_analysis.tsx
@@ -229,14 +229,13 @@ export default function Page() {
   const initialSelectedYAxis = (query.yAxis as YAxis) || "cost";
   const initialSearchFilter = query.searchFilter || "";
   const initialIsRegex = query.isRegex === "true";
-  const initialSelectedRepos = query.repos
-    ? splitString(query.repos)
-    : undefined;
+  const initialSelectedRepos = query.repos ? splitString(query.repos) : [];
 
   // State variables
   const [startDate, setStartDate] = useState(initialStartDate);
   const [endDate, setEndDate] = useState(initialEndDate);
-  const [selectedRepos, setSelectedRepos] = useState<string[]>();
+  const [selectedRepos, setSelectedRepos] =
+    useState<string[]>(initialSelectedRepos);
   const [availableRepos, setAvailableRepos] = useState<string[]>([]);
 
   const [granularity, setGranularity] = useState<Granularity>(
@@ -281,6 +280,9 @@ export default function Page() {
     setSelectedYAxis(initialSelectedYAxis || "cost");
     setSearchFilter(initialSearchFilter as string);
     setIsRegex(initialIsRegex);
+    if (initialSelectedRepos) {
+      setSelectedRepos(initialSelectedRepos);
+    }
   }
 
   const timeParamsClickHouse = {
@@ -300,15 +302,14 @@ export default function Page() {
     isLoading,
   } = useSWR<{ repo: string }[]>(url, fetcher);
 
-  if (selectedRepos === undefined && repos) {
+  if (repos && availableRepos.length === 0) {
     const repoList = repos?.map((item) => item.repo) ?? [];
     setAvailableRepos(repoList);
-    if (initialSelectedRepos) {
-      setSelectedRepos(initialSelectedRepos);
-    } else {
+
+    if (!selectedRepos || selectedRepos.length === 0) {
+      // Only set all repos if none are already selected from URL params
       setSelectedRepos(repoList);
     }
-  } else {
   }
 
   // Update URL params on state change


### PR DESCRIPTION
Fixed repository filter not being saved in URL parameters on cost analysis page. Added code to ensure filter selections persist when sharing URL or using permalink.

Fixes #6458