### PR TITLE
Adds linux.4xlarge.for.testing.donotuse for testing

### DIFF
--- a/.github/canary-scale-config.yml
+++ b/.github/canary-scale-config.yml
@@ -125,6 +125,14 @@ runner_types:
     variants:
       ephemeral:
         is_ephemeral: true
+  c.linux.4xlarge.for.testing.donotuse:
+    disk_size: 150
+    instance_type: c5.4xlarge
+    is_ephemeral: false
+    os: linux
+    variants:
+      ephemeral:
+        is_ephemeral: true
   c.linux.4xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g3.4xlarge

--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -125,6 +125,14 @@ runner_types:
     variants:
       ephemeral:
         is_ephemeral: true
+  lf.c.linux.4xlarge.for.testing.donotuse:
+    disk_size: 150
+    instance_type: c5.4xlarge
+    is_ephemeral: false
+    os: linux
+    variants:
+      ephemeral:
+        is_ephemeral: true
   lf.c.linux.4xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g3.4xlarge

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -125,6 +125,14 @@ runner_types:
     variants:
       ephemeral:
         is_ephemeral: true
+  lf.linux.4xlarge.for.testing.donotuse:
+    disk_size: 150
+    instance_type: c5.4xlarge
+    is_ephemeral: false
+    os: linux
+    variants:
+      ephemeral:
+        is_ephemeral: true
   lf.linux.4xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g3.4xlarge

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -121,6 +121,14 @@ runner_types:
     variants:
       ephemeral:
         is_ephemeral: true
+  linux.4xlarge.for.testing.donotuse:
+    disk_size: 150
+    instance_type: c5.4xlarge
+    is_ephemeral: false
+    os: linux
+    variants:
+      ephemeral:
+        is_ephemeral: true
   linux.4xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g3.4xlarge


### PR DESCRIPTION
Adds the runner `linux.4xlarge.for.testing.donotuse` that will be used to test scaleUpChron in production.

The goal is to deploy version of scaleUp lambda that ignores this label, and open a pytorch PR requesting this label. This job will then be queued and never be picked up, until (hopefully) scaleUpChron lambda deploys a runner for it.

After the testing, we can revert this commit.