### PR TITLE
Commandline option for github workflow to run android and apple perf workflows

### DIFF
--- a/tools/device-farm-runner/run_perf_workflow.py
+++ b/tools/device-farm-runner/run_perf_workflow.py
@@ -52,19 +52,27 @@ def parse_args() -> Any:
         type=str,
         required=False,
         default="llama",
-        help="the model to run on. Default is llama.",
+        help="the model to run on. Default is llama. See https://github.com/pytorch/executorch/blob/0342babc505bcb90244874e9ed9218d90dd67b87/examples/models/__init__.py#L53 for more model options",
     )
     parser.add_argument(
         "--devices",
         type=str,
         required=False,
         default="",
+        choices=[
+            "apple_iphone_15",
+            "apple_iphone_15+ios_18",
+            "samsung_galaxy_s22",
+            "samsung_galaxy_s24",
+            "google_pixel_8_pro",
+        ],
         help="specific devices to run on. Default is s22 for android and iphone 15 for ios.",
     )
     parser.add_argument(
         "--benchmark_configs",
         type=str,
         required=False,
+        choices=["xplat", "android", "ios"],
         default="",
         help="The list of configs used in the benchmark",
     )

--- a/tools/device-farm-runner/run_perf_workflow.py
+++ b/tools/device-farm-runner/run_perf_workflow.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+import copy
+import datetime
+import json
+import logging
+import os
+import random
+from re import A
+import string
+import sys
+import time
+from argparse import ArgumentParser
+from logging import info
+from typing import Any
+
+import requests
+
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
+logging.basicConfig(level=logging.INFO)
+
+def parse_args() -> Any:
+    parser = ArgumentParser("Run Android and iOS tests on AWS Device Farm via github actions workflow run")
+    parser.add_argument(
+        "--branch", 
+        type=str, 
+        default="main", 
+        required=False, 
+        help="what gh branch to use in pytorch/executorch"
+    )
+
+    app_type = parser.add_mutually_exclusive_group(required=True)
+    app_type.add_argument(
+        "--android",
+        action="store_true",
+        required=False,
+        help="run the test on Android",
+    )
+    app_type.add_argument(
+        "--ios",
+        action="store_true",
+        required=False,
+        help="run the test on iOS",
+    )
+
+    parser.add_argument(
+        "--models",
+        type=str,
+        required=False,
+        default="llama",
+        help="the model to run on. Default is llama."
+    )
+    parser.add_argument(
+        "--devices",
+        type=str,
+        required=False,
+        default="",
+        help="specific devices to run on. Default is s22 for android and iphone 15 for ios."
+    )
+    parser.add_argument(
+        "--benchmark_configs",
+        type=str,
+        required=False,
+        default="",
+        help="The list of configs used in the benchmark"
+    )
+
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="debug mode, the artifacts won't be uploaded to s3, it should mainly used in local env",
+    )
+
+
+    # in case when removing the flag, the mobile jobs does not failed due to unrecognized flag.
+    args, unknown = parser.parse_known_args()
+    if len(unknown) > 0:
+        info(f"detected unknown flags: {unknown}")
+    return args
+
+
+
+def run_workflow(app_type, branch, models, devices, benchmark_configs):
+    if app_type == "android":
+        #url = "https://api.github.com/users/camyll"
+        url = f"https://api.github.com/repos/pytorch/executorch/actions/workflows/android-perf.yml/dispatches"
+    else: 
+        url = f"https://api.github.com/repos/pytorch/executorch/actions/workflows/apple-perf.yml/dispatches"
+    
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "Authorization": f"Bearer {GITHUB_TOKEN}",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "X-Accepted-GitHub-Permissions": "contents=read"
+    }
+
+    data = '{"ref":"'+branch+'", inputs: {"branch": "'+branch+'", "models": "'+models+'", "device": "'+devices+'", "benchmark_configs": "'+benchmark_configs+'"}}'
+    
+    return requests.post(url, headers=headers, data=data)
+    
+
+def main() -> None:
+    args = parse_args()
+    if args.android:
+        resp = run_workflow("android", args.branch, args.models, args.devices, args.benchmark_configs)
+    elif args.ios:
+        resp = run_workflow("ios", args.branch, args.models, args.devices, args.benchmark_configs)
+    else:
+        raise Exception("No app type specified. Please specify either --android or --ios.")
+    print(resp.headers['X-Accepted-GitHub-Permissions'])
+    print(json.loads(resp.text))
+    print(resp.text)
+    
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/device-farm-runner/run_perf_workflow.py
+++ b/tools/device-farm-runner/run_perf_workflow.py
@@ -6,27 +6,31 @@ import json
 import logging
 import os
 import random
-from re import A
 import string
 import sys
 import time
 from argparse import ArgumentParser
 from logging import info
+from re import A
 from typing import Any
 
 import requests
 
+
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
 logging.basicConfig(level=logging.INFO)
 
+
 def parse_args() -> Any:
-    parser = ArgumentParser("Run Android and iOS tests on AWS Device Farm via github actions workflow run")
+    parser = ArgumentParser(
+        "Run Android and iOS tests on AWS Device Farm via github actions workflow run"
+    )
     parser.add_argument(
-        "--branch", 
-        type=str, 
-        default="main", 
-        required=False, 
-        help="what gh branch to use in pytorch/executorch"
+        "--branch",
+        type=str,
+        default="main",
+        required=False,
+        help="what gh branch to use in pytorch/executorch",
     )
 
     app_type = parser.add_mutually_exclusive_group(required=True)
@@ -48,21 +52,21 @@ def parse_args() -> Any:
         type=str,
         required=False,
         default="llama",
-        help="the model to run on. Default is llama."
+        help="the model to run on. Default is llama.",
     )
     parser.add_argument(
         "--devices",
         type=str,
         required=False,
         default="",
-        help="specific devices to run on. Default is s22 for android and iphone 15 for ios."
+        help="specific devices to run on. Default is s22 for android and iphone 15 for ios.",
     )
     parser.add_argument(
         "--benchmark_configs",
         type=str,
         required=False,
         default="",
-        help="The list of configs used in the benchmark"
+        help="The list of configs used in the benchmark",
     )
 
     parser.add_argument(
@@ -71,7 +75,6 @@ def parse_args() -> Any:
         help="debug mode, the artifacts won't be uploaded to s3, it should mainly used in local env",
     )
 
-
     # in case when removing the flag, the mobile jobs does not failed due to unrecognized flag.
     args, unknown = parser.parse_known_args()
     if len(unknown) > 0:
@@ -79,41 +82,57 @@ def parse_args() -> Any:
     return args
 
 
-
 def run_workflow(app_type, branch, models, devices, benchmark_configs):
     dispatch_hook = "/dispatches"
     if app_type == "android":
         url = f"https://api.github.com/repos/pytorch/executorch/actions/workflows/android-perf.yml"
-    else: 
+    else:
         url = f"https://api.github.com/repos/pytorch/executorch/actions/workflows/apple-perf.yml"
-    
+
     headers = {
         "Accept": "application/vnd.github.v3+json",
         "Authorization": f"Bearer {GITHUB_TOKEN}",
         "X-GitHub-Api-Version": "2022-11-28",
     }
 
-    data = {"ref":f"{branch}", "inputs": {"models": f"{models}", "devices": f"{devices}", "benchmark_configs": f"{benchmark_configs}"}}
-   
+    data = {
+        "ref": f"{branch}",
+        "inputs": {
+            "models": f"{models}",
+            "devices": f"{devices}",
+            "benchmark_configs": f"{benchmark_configs}",
+        },
+    }
+
     resp = requests.post(url + dispatch_hook, headers=headers, data=json.dumps(data))
     if resp.status_code != 204:
         raise Exception(f"Failed to start workflow: {resp.text}")
     else:
         print("Workflow started successfully.")
         if app_type == "android":
-            print("Find your workflow run here: https://github.com/pytorch/executorch/actions/workflows/android-perf.yml")
+            print(
+                "Find your workflow run here: https://github.com/pytorch/executorch/actions/workflows/android-perf.yml"
+            )
         else:
-            print("Find your workflow run here: https://github.com/pytorch/executorch/actions/workflows/apple-perf.yml")
-  
+            print(
+                "Find your workflow run here: https://github.com/pytorch/executorch/actions/workflows/apple-perf.yml"
+            )
+
 
 def main() -> None:
     args = parse_args()
     if args.android:
-        resp = run_workflow("android", args.branch, args.models, args.devices, args.benchmark_configs)
+        resp = run_workflow(
+            "android", args.branch, args.models, args.devices, args.benchmark_configs
+        )
     elif args.ios:
-        resp = run_workflow("ios", args.branch, args.models, args.devices, args.benchmark_configs)
+        resp = run_workflow(
+            "ios", args.branch, args.models, args.devices, args.benchmark_configs
+        )
     else:
-        raise Exception("No app type specified. Please specify either --android or --ios.")
+        raise Exception(
+            "No app type specified. Please specify either --android or --ios."
+        )
 
 
 if __name__ == "__main__":

--- a/tools/device-farm-runner/run_perf_workflow.py
+++ b/tools/device-farm-runner/run_perf_workflow.py
@@ -63,7 +63,7 @@ def parse_args() -> Any:
         ],
         help="specific devices to run on. Default is s22 for android and iphone 15 for ios.",
     )
-    
+
     parser.add_argument(
         "--benchmark_configs",
         type=str,
@@ -118,7 +118,11 @@ def run_workflow(app_type, branch, models, devices, benchmark_configs):
 
 def main() -> None:
     args = parse_args()
-    app_type = args.android ? "android" : args.ios ? "ios" : null
+    app_type = None
+    if args.android:
+        app_type = "android"
+    elif args.ios:
+        app_type = "ios"
     if app_type:
         resp = run_workflow(
             app_type, args.branch, args.models, args.devices, args.benchmark_configs

--- a/tools/device-farm-runner/run_perf_workflow.py
+++ b/tools/device-farm-runner/run_perf_workflow.py
@@ -77,12 +77,6 @@ def parse_args() -> Any:
         help="The list of configs used in the benchmark",
     )
 
-    parser.add_argument(
-        "--debug",
-        action="store_true",
-        help="debug mode, the artifacts won't be uploaded to s3, it should mainly used in local env",
-    )
-
     # in case when removing the flag, the mobile jobs does not failed due to unrecognized flag.
     args, unknown = parser.parse_known_args()
     if len(unknown) > 0:

--- a/tools/device-farm-runner/run_perf_workflow.py
+++ b/tools/device-farm-runner/run_perf_workflow.py
@@ -1,14 +1,7 @@
 #!/usr/bin/env python3
-
-import copy
-import datetime
 import json
 import logging
 import os
-import random
-import string
-import sys
-import time
 from argparse import ArgumentParser
 from logging import info
 from re import A
@@ -25,6 +18,7 @@ def parse_args() -> Any:
     parser = ArgumentParser(
         "Run Android and iOS tests on AWS Device Farm via github actions workflow run"
     )
+
     parser.add_argument(
         "--branch",
         type=str,
@@ -54,6 +48,7 @@ def parse_args() -> Any:
         default="llama",
         help="the model to run on. Default is llama. See https://github.com/pytorch/executorch/blob/0342babc505bcb90244874e9ed9218d90dd67b87/examples/models/__init__.py#L53 for more model options",
     )
+
     parser.add_argument(
         "--devices",
         type=str,
@@ -68,6 +63,7 @@ def parse_args() -> Any:
         ],
         help="specific devices to run on. Default is s22 for android and iphone 15 for ios.",
     )
+    
     parser.add_argument(
         "--benchmark_configs",
         type=str,
@@ -77,7 +73,6 @@ def parse_args() -> Any:
         help="The list of configs used in the benchmark",
     )
 
-    # in case when removing the flag, the mobile jobs does not failed due to unrecognized flag.
     args, unknown = parser.parse_known_args()
     if len(unknown) > 0:
         info(f"detected unknown flags: {unknown}")
@@ -123,13 +118,10 @@ def run_workflow(app_type, branch, models, devices, benchmark_configs):
 
 def main() -> None:
     args = parse_args()
-    if args.android:
+    app_type = args.android ? "android" : args.ios ? "ios" : null
+    if app_type:
         resp = run_workflow(
-            "android", args.branch, args.models, args.devices, args.benchmark_configs
-        )
-    elif args.ios:
-        resp = run_workflow(
-            "ios", args.branch, args.models, args.devices, args.benchmark_configs
+            app_type, args.branch, args.models, args.devices, args.benchmark_configs
         )
     else:
         raise Exception(


### PR DESCRIPTION
Request from Executorch team to run android-perf or apple-perf workflows via commandline 

https://github.com/pytorch/executorch/actions/workflows/android-perf.yml
https://github.com/pytorch/executorch/actions/workflows/apple-perf.yml


HOW TO: 
1. Make sure you have your GITHUB_TOKEN set (classic personal access token, not fine-grained) (`export GITHUB_TOKEN=<YOUR_TOKEN>`)
2. run  `python run_perf_workflow.py` with either `--android` or `--ios` as a required argument 
3. use `--help` to see other optional arguments (`--branch, --models, --devices, --benchmark-configs`)


![image](https://github.com/user-attachments/assets/5178aa36-e73b-49f9-9f84-424ccd28f0bc)
![image](https://github.com/user-attachments/assets/1e2e6aba-9d4c-44b5-9d74-1b631675e99f)
