### PR TITLE
[BE] Optimize last_successful_workflow ClickHouse query 

### DIFF
--- a/torchci/clickhouse_queries/last_successful_workflow/params.json
+++ b/torchci/clickhouse_queries/last_successful_workflow/params.json
@@ -3,6 +3,6 @@
     "workflowName": "String"
   },
   "tests": [
-    "workflowName=docker-builds"
+    {"workflowName": "docker-builds"}
   ]
 }

--- a/torchci/clickhouse_queries/last_successful_workflow/params.json
+++ b/torchci/clickhouse_queries/last_successful_workflow/params.json
@@ -2,5 +2,7 @@
   "params": {
     "workflowName": "String"
   },
-  "tests": []
+  "tests": [
+    "workflowName=docker-builds"
+  ]
 }

--- a/torchci/clickhouse_queries/last_successful_workflow/query.sql
+++ b/torchci/clickhouse_queries/last_successful_workflow/query.sql
@@ -1,27 +1,29 @@
 WITH workflow AS (
     SELECT
-      head_commit.id as head_commit_id,
-      created_at
+        head_commit.id AS head_commit_id,
+        created_at
     FROM default.workflow_run
     WHERE
-      conclusion = 'success'
-      AND created_at > CURRENT_TIMESTAMP() - INTERVAL 15 DAY
-      AND name = {workflowName: String}
+        conclusion = 'success'
+        AND created_at > CURRENT_TIMESTAMP() - INTERVAL 15 DAY
+        AND name = {workflowName: String}
     ORDER BY created_at DESC
 ),
+
 push AS (
-    SELECT
-      push.head_commit.id as head_commit_id
+    SELECT push.head_commit.id AS head_commit_id
     FROM default.push
     WHERE
-      ref IN ('refs/heads/master', 'refs/heads/main')
-      AND repository.owner.name = 'pytorch'
-      AND repository.name = 'pytorch'
-    )
+        ref IN ('refs/heads/master', 'refs/heads/main')
+        AND repository.owner.name = 'pytorch'
+        AND repository.name = 'pytorch'
+)
+
 SELECT
-    DATE_DIFF('second', workflow.created_at, CURRENT_TIMESTAMP()) AS last_success_seconds_ago
+    DATE_DIFF('second', workflow.created_at, CURRENT_TIMESTAMP())
+        AS last_success_seconds_ago
 FROM workflow JOIN push
-ON workflow.head_commit_id = push.head_commit_id
+    ON workflow.head_commit_id = push.head_commit_id
 ORDER BY
     workflow.created_at DESC
 LIMIT 1

--- a/torchci/clickhouse_queries/last_successful_workflow/query.sql
+++ b/torchci/clickhouse_queries/last_successful_workflow/query.sql
@@ -1,27 +1,26 @@
-SELECT
-    DATE_DIFF('second', workflow.created_at, CURRENT_TIMESTAMP()) AS last_success_seconds_ago
-FROM
-(
+WITH workflow AS (
     SELECT
       head_commit.id as head_commit_id,
       created_at
     FROM default.workflow_run
-    PREWHERE
+    WHERE
       conclusion = 'success'
       AND created_at > CURRENT_TIMESTAMP() - INTERVAL 15 DAY
       AND name = {workflowName: String}
     ORDER BY created_at DESC
-) AS workflow
-JOIN
-(
+),
+push AS (
     SELECT
       push.head_commit.id as head_commit_id
     FROM default.push
-    PREWHERE
+    WHERE
       ref IN ('refs/heads/master', 'refs/heads/main')
       AND repository.owner.name = 'pytorch'
       AND repository.name = 'pytorch'
-) AS push
+    )
+SELECT
+    DATE_DIFF('second', workflow.created_at, CURRENT_TIMESTAMP()) AS last_success_seconds_ago
+FROM workflow JOIN push
 ON workflow.head_commit_id = push.head_commit_id
 ORDER BY
     workflow.created_at DESC


### PR DESCRIPTION
Reduces query:
* Execution time by 84% (4.2s -> 0.7s)
* Memory used by 98% (3.3 GB -> 79 MB)
* Data read by 98% (11.14 GB -> 272.80 MB)

This PR adds multiple optimizations:
* Remove unnecessary FINAL keywords
* Limit the time range that we search workflow queries to just the past two weeks instead of all stored workflows (can be tweaked if necessary) 
* Prefilter tables before the join using the WITH clause.  Note that Claude suggested using the [PREWHERE clause](https://clickhouse.com/docs/sql-reference/statements/select/prewhere) (which was an interesting discovery) but perf was way faster when using WITH instead (and more readable too)

It also updates the params.json file to add the test case used for this query

```
+------+----------+-----------+-------------+---------------+------------+------------+---------------+--------------+
| Test | Avg Time | Base Time | Time Change | % Time Change |  Avg Mem   |  Base Mem  |   Mem Change  | % Mem Change |
+------+----------+-----------+-------------+---------------+------------+------------+---------------+--------------+
|  0   |   662    |   4208.5  |   -3546.5   |      -84      | 79117695.5 | 3359318582 | -3280200886.5 |     -98      |
+------+----------+-----------+-------------+---------------+------------+------------+---------------+--------------+
```