### PR TITLE
[CH] Improve master_commit_red_avg query perf

### DIFF
--- a/torchci/clickhouse_queries/master_commit_red_avg/params.json
+++ b/torchci/clickhouse_queries/master_commit_red_avg/params.json
@@ -4,5 +4,18 @@
     "stopTime": "DateTime64(3)",
     "workflowNames": "Array(String)"
   },
-  "tests": []
+  "tests": [
+    {
+      "startTime": "2025-03-18T21:09:47.987",
+      "stopTime": "2025-03-25T21:09:47.987",
+      "workflowNames": ["lint", "pull", "trunk"],
+      "_comment": "1 week"
+    },
+    {
+      "startTime": "2025-02-18T21:09:47.987",
+      "stopTime": "2025-03-18T21:09:47.987",
+      "workflowNames": ["lint", "pull", "trunk"],
+      "_comment": "1 month"
+    }
+  ]
 }

--- a/torchci/clickhouse_queries/master_commit_red_avg/query.sql
+++ b/torchci/clickhouse_queries/master_commit_red_avg/query.sql
@@ -4,43 +4,51 @@ with pushes as (
   SELECT
     push.head_commit.'id' AS sha
   FROM
-    default.push FINAL
+    default.push
   WHERE
     push.ref IN ('refs/heads/master', 'refs/heads/main')
     AND push.repository.'owner'.'name' = 'pytorch'
     AND push.repository.'name' = 'pytorch'
     AND push.head_commit.'timestamp' >= {startTime : DateTime64(3)}
     AND push.head_commit.'timestamp' < {stopTime : DateTime64(3)}
-), all_jobs AS (
+),
+all_runs as (
   SELECT
-    job.conclusion AS conclusion,
-    push.sha AS sha,
-    ROW_NUMBER() OVER(
-      PARTITION BY job.name,
-      push.sha
-      ORDER BY
-        job.run_attempt DESC
-    ) AS row_num
+    id
   FROM
-    default.workflow_job job FINAL
-    JOIN default.workflow_run FINAL ON workflow_run.id = workflow_job.run_id
-    JOIN pushes push ON workflow_run.head_sha = push.sha
+    default.workflow_run as workflow_run FINAL
+    JOIN pushes as push ON workflow_run.head_sha = push.sha
   WHERE
-    job.name != 'ciflow_should_run'
-    AND job.name != 'generate-test-matrix'
-    AND (
+     (
       -- Limit it to workflows which block viable/strict upgrades
       lower(workflow_run.name) in {workflowNames:Array(String)}
       OR workflow_run.name like 'linux-binary%'
     )
-    AND job.name NOT LIKE '%rerun_disabled_tests%'
-    AND job.name NOT LIKE '%mem_leak_check%'
-    AND job.name NOT LIKE '%unstable%'
     AND workflow_run.event != 'workflow_run' -- Filter out worflow_run-triggered jobs, which have nothing to do with the SHA
     and workflow_run.id in (
         select id from materialized_views.workflow_run_by_head_sha
         where head_sha in (select sha from pushes)
     )
+),
+all_jobs AS (
+  SELECT
+    job.conclusion AS conclusion,
+    job.head_sha AS sha,
+    ROW_NUMBER() OVER(
+      PARTITION BY job.name,
+      job.head_sha
+      ORDER BY
+        job.run_attempt DESC
+    ) AS row_num
+  FROM
+    default.workflow_job as job FINAL
+    join all_runs as run ON run.id = workflow_job.run_id
+  WHERE
+    job.name != 'ciflow_should_run'
+    AND job.name != 'generate-test-matrix'
+    AND job.name NOT LIKE '%rerun_disabled_tests%'
+    AND job.name NOT LIKE '%mem_leak_check%'
+    AND job.name NOT LIKE '%unstable%'
     and job.id in (
         select id from materialized_views.workflow_job_by_head_sha
         where head_sha in (select sha from pushes)
@@ -48,45 +56,18 @@ with pushes as (
 ),
 all_reds AS (
   SELECT
-    CAST(
-      SUM(
-        CASE
-          WHEN conclusion = 'failure' THEN 1
-          WHEN conclusion = 'timed_out' THEN 1
-          WHEN conclusion = 'cancelled' THEN 1
-          ELSE 0
-        END
-      ) > 0 AS int
-    ) AS any_red,
-    CAST(
-      SUM(
-        CASE
-          WHEN conclusion = 'failure' AND row_num = 1 THEN 1
-          WHEN conclusion = 'timed_out' AND row_num = 1 THEN 1
-          WHEN conclusion = 'cancelled' AND row_num = 1 THEN 1
-          ELSE 0
-        END
-      ) > 0 AS int
-    ) AS broken_trunk_red
+    CAST(SUM(conclusion IN ('failure', 'timed_out', 'cancelled')) > 0 AS Int8) AS any_red,
+    CAST(SUM(conclusion IN ('failure', 'timed_out', 'cancelled') AND row_num = 1) > 0 AS Int8) AS _broken_trunk_red
   FROM
     all_jobs
   GROUP BY
     sha
   HAVING
     COUNT(sha) > 10 -- Filter out jobs that didn't run anything.
-    AND SUM(
-      IF(conclusion = '', 1, 0)
-    ) = 0 -- Filter out commits that still have pending jobs.
-),
-avg_reds AS (
-  SELECT
-    AVG(broken_trunk_red) AS broken_trunk_red,
-    AVG(any_red) AS any_red
-  FROM
-    all_reds
+    AND countIf(conclusion = '') = 0 -- Filter out commits that still have pending jobs.
 )
 SELECT
-  broken_trunk_red,
-  any_red - broken_trunk_red AS flaky_red
+  AVG(_broken_trunk_red) as broken_trunk_red,
+  AVG(any_red) - AVG(_broken_trunk_red) AS flaky_red
 FROM
-  avg_reds
+  all_reds

--- a/torchci/lib/clickhouse.ts
+++ b/torchci/lib/clickhouse.ts
@@ -87,9 +87,6 @@ export async function queryClickhouseSaved(
   const queryParams = new Map(
     Object.entries(paramsText).map(([key, _]) => [key, inputParams[key]])
   );
-  if (queryName == "master_commit_red_avg") {
-    console.log("queryClickhouseSaved",  queryParams);
-  }
   return await thisModule.queryClickhouse(
     query,
     Object.fromEntries(queryParams),

--- a/torchci/lib/clickhouse.ts
+++ b/torchci/lib/clickhouse.ts
@@ -87,6 +87,9 @@ export async function queryClickhouseSaved(
   const queryParams = new Map(
     Object.entries(paramsText).map(([key, _]) => [key, inputParams[key]])
   );
+  if (queryName == "master_commit_red_avg") {
+    console.log("queryClickhouseSaved",  queryParams);
+  }
   return await thisModule.queryClickhouse(
     query,
     Object.fromEntries(queryParams),


### PR DESCRIPTION
Main change is separating out the workflow run, workflow job, and push join so that workflow run and push get joined first, then workflow run and workflow job.  I don't really understand how this leads to less rows read since the filtering remains the same but I guess it's a join thing.

Most other changes are just making it look a bit nicer with things like "in" instead of casing and countIf.  I don't think these impact performance that much

I think sql fluff errors silently on this file

```
> python -m torchci.clickhouse_query_perf --head HEAD --base origin/main --perf --query master_commit_red_avg --results --perf                                                                ✔  forpytorch Py  10:03:31 AM 
Gathering perf stats for: master_commit_red_avg
Num tests: 2
Num times: 10

+------+----------+-----------+-------------+---------------+------------+-------------+--------------+--------------+
| Test | Avg Time | Base Time | Time Change | % Time Change |  Avg Mem   |   Base Mem  |  Mem Change  | % Mem Change |
+------+----------+-----------+-------------+---------------+------------+-------------+--------------+--------------+
|  0   |  1044.5  |    1512   |    -467.5   |      -31      | 69185052.5 |  142419149  | -73234096.5  |     -51      |
|  1   |  2383.5  |   2912.5  |    -529.0   |      -18      | 182675839  | 431140023.5 | -248464184.5 |     -58      |
+------+----------+-----------+-------------+---------------+------------+-------------+--------------+--------------+
Comparing results for query: master_commit_red_avg
Num tests: 2
Head: HEAD Base: origin/main
Results for test 0 match
Results for test 1 match
```