### PR TITLE
Propagate Python version to pytorch_pkg_helpers

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -118,6 +118,8 @@ runs:
       - name: Generate file from pytorch_pkg_helpers
         working-directory: ${{ inputs.repository }}
         shell: bash -l {0}
+        env:
+          PYTHON_VERSION: ${{ inputs.python-version }}
         run: |
           set -euxo pipefail
           CONDA_ENV="${RUNNER_TEMP}/pytorch_pkg_helpers_${GITHUB_RUN_ID}"

--- a/.github/workflows/test_build_wheels_linux_python_versions.yml
+++ b/.github/workflows/test_build_wheels_linux_python_versions.yml
@@ -33,9 +33,9 @@ jobs:
       matrix:
         include:
           - repository: pytorch/executorch
-            pre-script: build/packaging/pre_build_script.sh
-            post-script: build/packaging/post_build_script.sh
-            smoke-test-script: build/packaging/smoke_test.py
+            pre-script: .ci/scripts/wheel/pre_build_script.sh
+            post-script: .ci/scripts/wheel/post_build_script.sh
+            smoke-test-script: .ci/scripts/wheel/test_linux.py
             package-name: executorch
     uses: ./.github/workflows/build_wheels_linux.yml
     name: ${{ matrix.repository }}
@@ -46,7 +46,7 @@ jobs:
       test-infra-ref: ${{ github.ref }}
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       submodules: recursive
-      env-var-script: build/packaging/env_var_script_linux.sh
+      env-var-script: .ci/scripts/wheel/envvar_linux.sh
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}


### PR DESCRIPTION
When using the [build_wheels_macos](https://github.com/pytorch/test-infra/blob/main/.github/workflows/build_wheels_macos.yml), with miniconda turned on, I started seeing this error:

```
+ conda run -p /Users/runner/work/_temp/conda_environment_14089147803 pip install torch --pre --index-url https://download.pytorch.org/whl/nightly/cpu
ERROR conda.cli.main_run:execute(41): `conda run pip install torch --pre --index-url https://download.pytorch.org/whl/nightly/cpu` failed. (See above for error)
ERROR: Could not find a version that satisfies the requirement torch (from versions: none)
ERROR: No matching distribution found for torch
Looking in indexes: https://download.pytorch.org/whl/nightly/cpu
```

Seems like the version is `none`. This is where we configure this install command:

https://github.com/pytorch/test-infra/blob/f768dcf0a722172508eb7a7c5dd9e967ceed832d/tools/pkg-helpers/pytorch_pkg_helpers/wheel.py#L16-L28

This is provided by this CLI argument, which by default gets it from the `PYTHON_VERSION` env var:

https://github.com/pytorch/test-infra/blob/f768dcf0a722172508eb7a7c5dd9e967ceed832d/tools/pkg-helpers/pytorch_pkg_helpers/__main__.py#L66-L71

However note that when we call this generator, we do not use explicit CLI arguments. Thus, it implies the Python version will be propagated via the env var:

https://github.com/pytorch/test-infra/blob/f768dcf0a722172508eb7a7c5dd9e967ceed832d/.github/actions/setup-binary-builds/action.yml#L122-L134

Since we are not providing the env var, I suspect this is causing the python version to be evaluated to `None`.