### PR TITLE
Update setup-miniconda to 3.1.1

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -100,9 +100,9 @@ runs:
           echo "ARTIFACT_NAME=${REPOSITORY//\//_}_${REF//\//_}_${PYTHON_VERSION}_${CU_VERSION}_${ARCH}" >> "${GITHUB_ENV}"
       - name: Setup miniconda (for pytorch_pkg_helpers)
         if: ${{ inputs.setup-miniconda == 'true' }}
-        uses: conda-incubator/setup-miniconda@v2.1.1
+        uses: conda-incubator/setup-miniconda@v3.1.1
         with:
-          miniconda-version: "py39_4.12.0"
+          miniconda-version: "latest"
           python-version: 3.9
       - name: Clean conda environment
         shell: bash -l {0}

--- a/.github/workflows/test_build_wheels_linux_python_versions.yml
+++ b/.github/workflows/test_build_wheels_linux_python_versions.yml
@@ -33,9 +33,9 @@ jobs:
       matrix:
         include:
           - repository: pytorch/executorch
-            pre-script: build/packaging/pre_build_script.sh
-            post-script: build/packaging/post_build_script.sh
-            smoke-test-script: build/packaging/smoke_test.py
+            pre-script: .ci/scripts/wheel/pre_build_script.sh
+            post-script: .ci/scripts/wheel/post_build_script.sh
+            smoke-test-script: .ci/scripts/wheel/test_linux.py
             package-name: executorch
     uses: ./.github/workflows/build_wheels_linux.yml
     name: ${{ matrix.repository }}
@@ -46,7 +46,7 @@ jobs:
       test-infra-ref: ${{ github.ref }}
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       submodules: recursive
-      env-var-script: build/packaging/env_var_script_linux.sh
+      env-var-script: .ci/scripts/wheel/envvar_linux.sh
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}


### PR DESCRIPTION
### Summary 

We recently noticed that v2.1.1 always uses x86 miniconda even on arm64 macOS runners. [v3.1.1](https://github.com/conda-incubator/setup-miniconda/releases/tag/v3.1.1) includes a fix to support ARM runners.

We use the "latest" version of `miniconda-version` since the [version requires specifying the os and arch](https://github.com/conda-incubator/setup-miniconda/blob/142632f154bced74dde05dfc628e82581df045ac/action.yml#L37-L43) — it's just easier to use latest.

### Test plan

Tested this branch in:

https://github.com/pytorch/executorch/actions/runs/14092157997/job/39471257525?pr=9647