### PR TITLE
Fix `clickhouse_query_perf.py` crash when all samples fail

### DIFF
--- a/tools/torchci/clickhouse_query_perf.py
+++ b/tools/torchci/clickhouse_query_perf.py
@@ -101,7 +101,9 @@ where
 """
 
 
-def get_avg_stats(query_ids: list) -> tuple:
+def get_avg_stats(query_ids: Optional[List[str]]) -> tuple:
+    if not query_ids:
+        return None, None
     metrics = query_clickhouse(EXECUTION_METRICS, {"query_ids": query_ids})
     return metrics[0]["realTimeMSAvg"], metrics[0]["memoryBytesAvg"]
 
@@ -233,8 +235,25 @@ def perf_compare(args: argparse.Namespace) -> None:
         table.field_names = ["Test", "Avg Time", "Avg Mem"]
     for i, (new, base) in enumerate(query_ids):
         avg_time, avg_bytes = get_avg_stats(new)
-        if base:
+        if args.base:
             old_avg_time, old_avg_bytes = get_avg_stats(base)
+
+            if avg_time is None or old_avg_time is None:
+                table.add_row(
+                    [
+                        i,
+                        avg_time,
+                        old_avg_time,
+                        None,
+                        None,
+                        avg_bytes,
+                        old_avg_bytes,
+                        None,
+                        None,
+                    ]
+                )
+                continue
+
             table.add_row(
                 [
                     i,


### PR DESCRIPTION
Now:


```
/clickhouse_query_perf.py --query flaky_workflows_jobs --perf --times 1 --base HEAD
Using unstaged changes for --head
Gathering perf stats for: flaky_workflows_jobs
Num tests: 5
Num times: 1
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:11<00:00, 11.26s/it]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:11<00:00, 11.65s/it]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:03<00:00,  3.59s/it]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:11<00:00, 11.37s/it]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:04<00:00,  4.50s/it]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:11<00:00, 11.12s/it]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:08<00:00,  8.31s/it]
  0%|                                                                                                                                                                                                                                                                                                                                     | 0/1 [00:00<?, ?it/s]
Error: HTTPDriver for https://hyt81izu0c.us-east-1.aws.clickhouse.cloud:8443 received ClickHouse error code 241
 Code: 241. DB::Exception: Memory limit (total) exceeded: would use 10.20 GiB (attempt to allocate chunk of 4208478 bytes), current RSS 14.41 GiB, maximum: 14.40 GiB. OvercommitTracker decision: Query was selected to stop by OvercommitTracker.: (while reading column head_repository): (while reading from part data/53075557-0137-49fd-8d18-c8c1a652b611/all_0_292_9/ in table default.workflow_run (53075557-0137-49fd-8d18-c8c1a652b611) located on disk s3WithKeeperDisk of type s3, from mark 2665 with max_rows_to_read = 864): While executing MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder). (MEMORY_LIMIT_EXCEEDED) (version 24.10.1.11464 (official build))

100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:18<00:00, 18.11s/it]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:09<00:00,  9.16s/it]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:10<00:00, 10.30s/it]
+------+----------+-----------+-------------+---------------+------------+------------+-------------+--------------+
| Test | Avg Time | Base Time | Time Change | % Time Change |  Avg Mem   |  Base Mem  |  Mem Change | % Mem Change |
+------+----------+-----------+-------------+---------------+------------+------------+-------------+--------------+
|  0   |  10336   |   11558   |    -1222    |      -11      | 3768573856 | 7531159681 | -3762585825 |     -50      |
|  1   |   3447   |   11277   |    -7830    |      -69      | 3663866244 | 7528742940 | -3864876696 |     -51      |
|  2   |   4331   |   11002   |    -6671    |      -61      | 3674588617 | 7479081544 | -3804492927 |     -51      |
|  3   |   8210   |    None   |     None    |      None     | 3702279607 |    None    |     None    |     None     |
|  4   |   9064   |   10208   |    -1144    |      -11      | 3699561949 | 7623698595 | -3924136646 |     -51      |
+------+----------+-----------+-------------+---------------+------------+------------+-------------+--------------+
```


Previously this run would fail with:
```
  Traceback (most recent call last):
    File "/Users/ivanzaitsev/test-infra/tools/torchci/./clickhouse_query_perf.py", line 339, in <module>
      perf_compare(args)
    File "/Users/ivanzaitsev/test-infra/tools/torchci/./clickhouse_query_perf.py", line 247, in perf_compare
      table.add_row([i, avg_time, avg_bytes])
    File "/Users/ivanzaitsev/test-infra/tools/torchci/venv/lib/python3.12/site-packages/prettytable/prettytable.py", line 1674, in add_row
      raise ValueError(msg)
  ValueError: Row has incorrect number of values, (actual) 3!=9 (expected)
```
