### PR TITLE
clickhouse_query_perf: remove wait-time argument in favour of polling

### DIFF
--- a/tools/torchci/clickhouse_query_perf.py
+++ b/tools/torchci/clickhouse_query_perf.py
@@ -96,11 +96,15 @@ where
 def get_avg_stats(query_ids: Optional[List[str]]) -> tuple:
     if not query_ids:
         return None, None
+    i = 0
     while True:
         metrics = query_clickhouse(EXECUTION_METRICS, {"query_ids": query_ids})
         if int(metrics[0]["cnt"]) == len(query_ids):
             break
+        if i == 1:
+            print("Waiting for metrics to populate, please be patient")
         time.sleep(5)
+        i += 1
 
     return metrics[0]["realTimeMSAvg"], metrics[0]["memoryBytesAvg"]
 


### PR DESCRIPTION
1. Instead of relying on fixed delay for `system.query_log` population, do a periodic polling. 
2. Add `event_time` filter to make stats query faster

on average, cuts waiting time by half