### PR TITLE
[ALI] Fix concurrency issues for tryReuse on scaleUp

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -509,7 +509,7 @@ export async function tryReuseRunner(
         continue;
       }
 
-      if (finishedAt.add(Config.Instance.minimumRunningTimeInMinutes - 1, 'minutes') < moment(new Date()).utc()) {
+      if (finishedAt.add(Config.Instance.minimumRunningTimeInMinutes - 5, 'minutes') < moment(new Date()).utc()) {
         console.debug(
           `[tryReuseRunner]: Runner ${
             runner.instanceId

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -441,10 +441,10 @@ export function isRunnerRemovable(
 
 export function runnerMinimumTimeExceeded(runner: RunnerInfo): boolean {
   let baseTime: moment.Moment;
-  if (runner.ebsVolumeReplacementRequestTimestamp !== undefined) {
-    baseTime = moment.unix(runner.ebsVolumeReplacementRequestTimestamp);
-  } else if (runner.ephemeralRunnerFinished !== undefined) {
+  if (runner.ephemeralRunnerFinished !== undefined) {
     baseTime = moment.unix(runner.ephemeralRunnerFinished);
+  } else if (runner.ebsVolumeReplacementRequestTimestamp !== undefined) {
+    baseTime = moment.unix(runner.ebsVolumeReplacementRequestTimestamp);
   } else {
     baseTime = moment(runner.launchTime || new Date()).utc();
   }

--- a/terraform-aws-github-runner/modules/runners/scale-up.tf
+++ b/terraform-aws-github-runner/modules/runners/scale-up.tf
@@ -60,6 +60,7 @@ resource "aws_lambda_function" "scale_up" {
       LAUNCH_TEMPLATE_VERSION_WINDOWS      = var.launch_template_version_windows
       MAX_RETRY_SCALEUP_RECORD             = "10"
       MIN_AVAILABLE_RUNNERS                = var.min_available_runners
+      MINIMUM_RUNNING_TIME_IN_MINUTES      = var.minimum_running_time_in_minutes
       MUST_HAVE_ISSUES_LABELS              = join(",", var.must_have_issues_labels)
       REDIS_ENDPOINT                       = var.redis_endpoint
       REDIS_LOGIN                          = var.redis_login

--- a/terraform-aws-github-runner/modules/runners/variables.tf
+++ b/terraform-aws-github-runner/modules/runners/variables.tf
@@ -103,7 +103,7 @@ variable "scale_up_chron_schedule_expression" {
 variable "minimum_running_time_in_minutes" {
   description = "The time an ec2 action runner should be running at minimum before terminated if non busy."
   type        = number
-  default     = 5
+  default     = 45
 }
 
 variable "lambda_timeout_scale_down" {

--- a/terraform-aws-github-runner/variables.tf
+++ b/terraform-aws-github-runner/variables.tf
@@ -71,7 +71,7 @@ variable "scale_down_schedule_expression" {
 variable "minimum_running_time_in_minutes" {
   description = "The time an ec2 action runner should be running at minimum before terminated if non busy."
   type        = number
-  default     = 5
+  default     = 45
 }
 
 variable "runner_extra_labels" {


### PR DESCRIPTION
As noted in [this](https://github.com/pytorch/test-infra/issues/6473) issue, there is a concurrency problem between tryReuse on scaleUp and scaleDown.

This PR addresses this by making sure `tryReuse` will not use 'stale' runners (older than a certain amount), and scaleDown will only remove the ones older than a certain time (logic was already implemented). 

Note that for this PR to properly work, it is expected that the TF variable `minimum_running_time_in_minutes` to be increased. I believe ideally 45 minutes or more.