### PR TITLE
[torch-infra] Support multiple build targets

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -40,7 +40,11 @@ on:
         default: ""
         type: string
       package-name:
-        description: "Name of the actual python package that is imported"
+        description: "Name of the actual python package that is imported in the smoke test"
+        default: ""
+        type: string
+      build-target:
+        description: "The target to build and publish (for repos that build multiple packages)"
         default: ""
         type: string
       trigger-event:
@@ -124,6 +128,7 @@ jobs:
       UPLOAD_TO_BASE_BUCKET: ${{ matrix.upload_to_base_bucket }}
       ARCH: ${{ inputs.architecture }}
       IS_MANYLINUX2_28: ${{ contains(matrix.container_image, '2_28') || contains(matrix.container_image, 'manylinuxaarch64-builder:cuda') }}
+      BUILD_TARGET: ${{ inputs.build-target }}
     name: build-${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
     environment: ${{(inputs.trigger-event == 'schedule' || (inputs.trigger-event == 'push' && (startsWith(github.event.ref, 'refs/heads/nightly') || startsWith(github.event.ref, 'refs/tags/v')))) && 'pytorchbot-env' || ''}}


### PR DESCRIPTION
- Some repos (e.g. FBGEMM) can build multiple targets (i.e. packages with different names and functionality altogether, such as FBGEMM-GPU vs FBGEMM-GPU-GenAI), but there is no generic mechanism inside Nova to specify which target to build other than `CU_VERSION` environment variable, which is intended for target variants.  As such, BUILD_TARGET is provided as an environment variable to the Nova build scripts so that it can be leveraged for specifying a build target if needed