### PR TITLE
Optimized issue_query

### DIFF
--- a/torchci/clickhouse_queries/issue_query/params.json
+++ b/torchci/clickhouse_queries/issue_query/params.json
@@ -2,5 +2,42 @@
   "params": {
     "label": "String"
   },
-  "tests": []
+  "tests": [
+    {
+      "label": "skipped"
+    },
+    {
+      "label": "unstable"
+    },
+    {
+      "label": "ci: sev"
+    },
+    {
+      "label": "bug"
+    },
+    {
+      "label": "feature"
+    },
+    {
+      "label": "enhancement"
+    },
+    {
+      "label": "high-priority"
+    },
+    {
+      "label": "flaky"
+    },
+    {
+      "label": "documentation"
+    },
+    {
+      "label": "help wanted"
+    },
+    {
+      "label": "CUDA"
+    },
+    {
+      "label": "Mobile"
+    }
+  ]
 }

--- a/torchci/clickhouse_queries/issue_query/query.sql
+++ b/torchci/clickhouse_queries/issue_query/query.sql
@@ -1,3 +1,6 @@
+-- Optimized query: uses arrayExists instead of array join for better performance
+-- Original query used array join which processes all arrays before filtering
+-- Using arrayExists reduces memory usage significantly (~2.4x reduction)
 SELECT
     issue.number,
     issue.title,
@@ -6,9 +9,8 @@ SELECT
     issue.body,
     issue.updated_at,
     issue.author_association,
-    arrayMap(x -> x.'name', issue.labels) as labels
+    arrayMap(x -> x.'name', issue.labels) AS labels
 FROM
-    default.issues AS issue final
-    array join issue.labels AS label
+    default.issues AS issue FINAL
 WHERE
-    label.name = {label: String}
+    arrayExists(x -> x.'name' = {label: String}, issue.labels)

--- a/torchci/clickhouse_queries/issue_query/query.sql
+++ b/torchci/clickhouse_queries/issue_query/query.sql
@@ -1,6 +1,3 @@
--- Optimized query: uses arrayExists instead of array join for better performance
--- Original query used array join which processes all arrays before filtering
--- Using arrayExists reduces memory usage significantly (~2.4x reduction)
 SELECT
     issue.number,
     issue.title,


### PR DESCRIPTION
### Changes

  1. Replacing ARRAY JOIN with arrayExists() function
  2. Filtering directly on the nested labels array using the function


### Perf

```
./clickhouse_query_perf.py --query issue_query --perf --times 3 --base HEAD
+------+----------+-----------+-------------+---------------+-----------+--------------+--------------+--------------+
| Test | Avg Time | Base Time | Time Change | % Time Change |  Avg Mem  |   Base Mem   |  Mem Change  | % Mem Change |
+------+----------+-----------+-------------+---------------+-----------+--------------+--------------+--------------+
|  0   |   558    |    576    |     -18     |       -3      | 479307788 |  1089064486  |  -609756698  |     -56      |
|  1   |   445    |    573    |     -128    |      -22      | 477587555 |  1038871736  |  -561284181  |     -54      |
|  2   |   640    |    609    |      31     |       5       | 494690535 |  1117168937  |  -622478402  |     -56      |
|  3   |   1804   |    1271   |     533     |       42      | 518423565 | 1116370275.5 | -597946710.5 |     -54      |
|  4   |   425    |    552    |     -127    |      -23      | 497446169 |  1089648776  |  -592202607  |     -54      |
|  5   |   453    |    555    |     -102    |      -18      | 522089665 |  1086026148  |  -563936483  |     -52      |
|  6   |   546    |    605    |     -59     |      -10      | 510843377 |  1086210318  |  -575366941  |     -53      |
|  7   |   474    |    613    |     -139    |      -23      | 517060492 |  1090440939  |  -573380447  |     -53      |
|  8   |   483    |    531    |     -48     |       -9      | 487622079 |  1087054224  |  -599432145  |     -55      |
|  9   |   523    |    649    |     -126    |      -19      | 476136141 |  1090161156  |  -614025015  |     -56      |
|  10  |   461    |    552    |     -91     |      -16      | 516971900 |  1200915774  |  -683943874  |     -57      |
|  11  |   599    |    587    |      12     |       2       | 517081843 |  1010326559  |  -493244716  |     -49      |
+------+----------+-----------+-------------+---------------+-----------+--------------+--------------+--------------+
```


### Tests

```
./clickhouse_query_perf.py --query issue_query --results --strict-results  --base HEAD
Using unstaged changes for --head
Comparing results for query: issue_query
Num tests: 12
Head: unstaged
 Base: HEAD
Results for test 0 match
Results for test 1 match
Results for test 2 match
Results for test 3 match
Results for test 4 match
Results for test 5 match
Results for test 6 match
Results for test 7 match
Results for test 8 match
Results for test 9 match
Results for test 10 match
Results for test 11 match
```