### PR TITLE
Script to get sizes of all s3 buckets

### DIFF
--- a/tools/analytics/get_s3_bucket_sizes.py
+++ b/tools/analytics/get_s3_bucket_sizes.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+"""
+This script retrieves the storage size of all S3 buckets in your AWS account
+using CloudWatch metrics. It lists the buckets and their respective sizes
+in gigabytes (GB).
+
+Requirements:
+  Before running this script, ensure you have the boto3 library installed
+  and your AWS credentials are configured.
+
+Installation:
+  pip install boto3
+"""
+
+import boto3
+import sys
+from datetime import datetime, timedelta, timezone
+import os
+
+
+def main():
+
+    print("🔍 Fetching S3 bucket list...")
+
+    # Create S3 and CloudWatch clients
+    s3 = boto3.client('s3')
+
+    try:
+        # Get buckets
+        response = s3.list_buckets()
+        buckets = [bucket['Name'] for bucket in response['Buckets']]
+    except Exception as e:
+        print(f"❌ Error accessing AWS: {str(e)}")
+        sys.exit(1)
+
+    if not buckets:
+        print("🚫 No S3 buckets found.")
+        sys.exit(0)
+
+    bucket_count = len(buckets)
+    print(f"✅ Found {bucket_count} buckets. Fetching storage metrics...")
+
+    # Store results
+    results = []
+
+    # Process each bucket
+    for i, bucket in enumerate(buckets, 1):
+        print(f"({i}/{bucket_count}): Bucket {bucket}")
+
+        # Get bucket region
+        try:
+            location = s3.get_bucket_location(Bucket=bucket)
+            region = location.get('LocationConstraint')
+            # # If None, assume it's in us-east-1
+            # region = region if region else 'us-east-1'
+        except Exception as e:
+            print(f"   ⚠️ Error getting region for {bucket}: {str(e)}")
+            region = 'us-east-1'
+
+        # Create CloudWatch client for the bucket's region
+        cloudwatch = boto3.client('cloudwatch', region_name=region)
+
+        # Get metrics
+        try:
+            response = cloudwatch.get_metric_statistics(
+                Namespace='AWS/S3',
+                MetricName='BucketSizeBytes',
+                Dimensions=[
+                    {'Name': 'BucketName', 'Value': bucket},
+                    {'Name': 'StorageType', 'Value': 'StandardStorage'}
+                ],
+                StartTime=datetime.now(timezone.utc) - timedelta(days=1),
+                EndTime=datetime.now(timezone.utc),
+                Period=86400,
+                Statistics=['Average']
+            )
+
+            if response['Datapoints']:
+                size = response['Datapoints'][0]['Average']
+            else:
+                size = 0
+        except Exception as e:
+            print(f"   ⚠️ Error getting metrics for {bucket}: {str(e)}")
+            size = 0
+
+        if size <= 0:
+            print(f"   🫥 No metrics found for bucket: {bucket}. Is it unused?")
+        else:
+            size_gb = size / 1073741824  # Convert bytes to GB
+            formatted_size = f"{size_gb:.1f}"
+            print(f"   💿 Storage used: {formatted_size} GB")
+
+        size_gb = size / 1073741824  # Convert bytes to GB
+        results.append((size_gb, bucket))
+
+    # Sort by size in descending order
+    results.sort(reverse=True)
+
+    # Display results
+    print("\n\n📌 Storage Usage Summary:")
+    print("Size (GB)\tBucket Name")
+    print("----------------------------")
+    for size_gb, bucket in results:
+        print(f"{size_gb:9.2f}\t{bucket}")
+
+    print("\n✅ Done!")
+
+if __name__ == "__main__":
+    main()

--- a/tools/analytics/get_s3_bucket_sizes.py
+++ b/tools/analytics/get_s3_bucket_sizes.py
@@ -52,10 +52,9 @@ def main():
         try:
             location = s3.get_bucket_location(Bucket=bucket)
             region = location.get("LocationConstraint")
-            # # If None, assume it's in us-east-1
-            # region = region if region else 'us-east-1'
         except Exception as e:
             print(f"   ⚠️ Error getting region for {bucket}: {str(e)}")
+            # Assume it's in us-east-1
             region = "us-east-1"
 
         # Create CloudWatch client for the bucket's region

--- a/tools/analytics/get_s3_bucket_sizes.py
+++ b/tools/analytics/get_s3_bucket_sizes.py
@@ -13,23 +13,23 @@ Installation:
   pip install boto3
 """
 
-import boto3
+import os
 import sys
 from datetime import datetime, timedelta, timezone
-import os
+
+import boto3
 
 
 def main():
-
     print("🔍 Fetching S3 bucket list...")
 
     # Create S3 and CloudWatch clients
-    s3 = boto3.client('s3')
+    s3 = boto3.client("s3")
 
     try:
         # Get buckets
         response = s3.list_buckets()
-        buckets = [bucket['Name'] for bucket in response['Buckets']]
+        buckets = [bucket["Name"] for bucket in response["Buckets"]]
     except Exception as e:
         print(f"❌ Error accessing AWS: {str(e)}")
         sys.exit(1)
@@ -51,33 +51,33 @@ def main():
         # Get bucket region
         try:
             location = s3.get_bucket_location(Bucket=bucket)
-            region = location.get('LocationConstraint')
+            region = location.get("LocationConstraint")
             # # If None, assume it's in us-east-1
             # region = region if region else 'us-east-1'
         except Exception as e:
             print(f"   ⚠️ Error getting region for {bucket}: {str(e)}")
-            region = 'us-east-1'
+            region = "us-east-1"
 
         # Create CloudWatch client for the bucket's region
-        cloudwatch = boto3.client('cloudwatch', region_name=region)
+        cloudwatch = boto3.client("cloudwatch", region_name=region)
 
         # Get metrics
         try:
             response = cloudwatch.get_metric_statistics(
-                Namespace='AWS/S3',
-                MetricName='BucketSizeBytes',
+                Namespace="AWS/S3",
+                MetricName="BucketSizeBytes",
                 Dimensions=[
-                    {'Name': 'BucketName', 'Value': bucket},
-                    {'Name': 'StorageType', 'Value': 'StandardStorage'}
+                    {"Name": "BucketName", "Value": bucket},
+                    {"Name": "StorageType", "Value": "StandardStorage"},
                 ],
                 StartTime=datetime.now(timezone.utc) - timedelta(days=1),
                 EndTime=datetime.now(timezone.utc),
                 Period=86400,
-                Statistics=['Average']
+                Statistics=["Average"],
             )
 
-            if response['Datapoints']:
-                size = response['Datapoints'][0]['Average']
+            if response["Datapoints"]:
+                size = response["Datapoints"][0]["Average"]
             else:
                 size = 0
         except Exception as e:
@@ -105,6 +105,7 @@ def main():
         print(f"{size_gb:9.2f}\t{bucket}")
 
     print("\n✅ Done!")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This code was used when recently analyzing our S3 buckets to see which ones were the largest and may have room for optimization (resulting in us setting a new lifecycle policy: https://github.com/pytorch-labs/pytorch-gha-infra/pull/626) 

What it does:
* It gets the size of each bucket using CloudWatch, which is much faster than checking directly in S3. The latter iterates over every item in the bucket and can take hours to complete.
* It sorts the output to show the largest buckets.

Checking in the code in case we want to use it again

Output looks like this (dummy data below):

```
> python bucket_size_metrics.py
🔍 Fetching S3 bucket list...
✅ Found 7 buckets. Fetching storage metrics...
(1/7): Bucket marketing-assets
   💿 Storage used: 100.0 GB
(2/7): Bucket devops-tools
   💿 Storage used: 50.0 GB
(3/7): Bucket software-releases
   💿 Storage used: 200.0 GB
(4/7): Bucket analytics-reports
   🫥 No metrics found for bucket: analytics-reports. Is it unused?
(5/7): Bucket product-images
   💿 Storage used: 10.0 GB
(6/7): Bucket company-videos
   💿 Storage used: 500.0 GB
(7/7): Bucket sales-documents
   💿 Storage used: 20.0 GB

📌 Storage Usage Summary:
Size (GB)       Bucket Name
----------------------------
  500.00       company-videos
  200.00       software-releases
  100.00       marketing-assets
   50.00       devops-tools
   20.00       sales-documents
   10.00       product-images
    0.00       analytics-reports

```