### PR TITLE
Print size of docker image

### DIFF
--- a/.github/actions/pull-docker-image/action.yml
+++ b/.github/actions/pull-docker-image/action.yml
@@ -32,7 +32,7 @@ runs:
 
         retry login "${DOCKER_REGISTRY}"
 
-        IMAGE_SIZE=$(docker manifest inspect "${DOCKER_IMAGE}" 2>/dev/null | jq '[.layers[].size, .config.size] | add / 1024 / 1024')
+        IMAGE_SIZE=$(docker manifest inspect "${DOCKER_IMAGE}" | jq '[.layers[].size, .config.size] | add / 1024 / 1024')
         echo "Compressed size of image in MB: ${IMAGE_SIZE}"
 
         set -e

--- a/.github/actions/pull-docker-image/action.yml
+++ b/.github/actions/pull-docker-image/action.yml
@@ -33,6 +33,10 @@ runs:
         retry login "${DOCKER_REGISTRY}"
 
         set -e
+
+        IMAGE_SIZE=$(docker manifest inspect "${DOCKER_IMAGE}" | jq '[.layers[].size, .config.size] | add / 1024 / 1024')
+        echo "Compressed size of image in MB: ${IMAGE_SIZE}"
+
         # ignore output since only exit code is used for conditional
         # only pull docker image if it's not available locally
         if ! docker inspect --type=image "${DOCKER_IMAGE}" >/dev/null 2>/dev/null; then

--- a/.github/actions/pull-docker-image/action.yml
+++ b/.github/actions/pull-docker-image/action.yml
@@ -32,10 +32,10 @@ runs:
 
         retry login "${DOCKER_REGISTRY}"
 
-        set -e
-
         IMAGE_SIZE=$(docker manifest inspect "${DOCKER_IMAGE}" | jq '[.layers[].size, .config.size] | add / 1024 / 1024')
         echo "Compressed size of image in MB: ${IMAGE_SIZE}"
+
+        set -e
 
         # ignore output since only exit code is used for conditional
         # only pull docker image if it's not available locally

--- a/.github/actions/pull-docker-image/action.yml
+++ b/.github/actions/pull-docker-image/action.yml
@@ -36,7 +36,6 @@ runs:
         echo "Compressed size of image in MB: ${IMAGE_SIZE}"
 
         set -e
-
         # ignore output since only exit code is used for conditional
         # only pull docker image if it's not available locally
         if ! docker inspect --type=image "${DOCKER_IMAGE}" >/dev/null 2>/dev/null; then

--- a/.github/actions/pull-docker-image/action.yml
+++ b/.github/actions/pull-docker-image/action.yml
@@ -32,7 +32,7 @@ runs:
 
         retry login "${DOCKER_REGISTRY}"
 
-        IMAGE_SIZE=$(docker manifest inspect "${DOCKER_IMAGE}" | jq '[.layers[].size, .config.size] | add / 1024 / 1024')
+        IMAGE_SIZE=$(docker manifest inspect "${DOCKER_IMAGE}" 2>/dev/null | jq '[.layers[].size, .config.size] | add / 1024 / 1024')
         echo "Compressed size of image in MB: ${IMAGE_SIZE}"
 
         set -e


### PR DESCRIPTION
Test: https://github.com/pytorch/pytorch/actions/runs/14118741506/job/39554959976?pr=149536#step:9:44

Not really sure why the prints and commands are interleaved
