### PR TITLE
[HUD] Merge ephemeral job columns on HUD with their non ephemeral counterparts

### DIFF
--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -388,5 +388,7 @@ export function isUnstableGroup(name: string, unstableIssues?: IssueData[]) {
 
 export function getNameWithoutLF(name: string) {
   const lfRegex = /, lf\.(linux|windows)/g;
-  return name.replace(lfRegex, ", $1");
+  name = name.replace(lfRegex, ", $1");
+  const ephemeralRegex = /, ephemeral\.(linux|windows)/g;
+  return name.replace(ephemeralRegex, ", $1");
 }

--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -387,7 +387,7 @@ export function isUnstableGroup(name: string, unstableIssues?: IssueData[]) {
 }
 
 export function getNameWithoutLF(name: string) {
-  const lfRegex = /, lf\.(linux|windows)/g;
+  const lfRegex = /, lf\.(ephemeral|linux|windows)/g;
   name = name.replace(lfRegex, ", $1");
   const ephemeralRegex = /, ephemeral\.(linux|windows)/g;
   return name.replace(ephemeralRegex, ", $1");

--- a/torchci/lib/fetchHud.ts
+++ b/torchci/lib/fetchHud.ts
@@ -98,7 +98,7 @@ export default async function fetchHud(
       jobsBySha[job.sha!] = {};
     }
     let key = job.name!;
-    if (params.mergeLF) {
+    if (params.mergeEphemeralLF) {
       key = getNameWithoutLF(key);
     }
 

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -125,7 +125,7 @@ export interface HudParams {
   nameFilter?: string;
   filter_reruns: boolean;
   filter_unstable: boolean;
-  mergeLF?: boolean;
+  mergeEphemeralLF?: boolean;
 }
 
 export interface PRData {
@@ -250,7 +250,7 @@ export function packHudParams(input: any) {
     nameFilter: input.name_filter as string | undefined,
     filter_reruns: input.filter_reruns ?? (false as boolean),
     filter_unstable: input.filter_unstable ?? (false as boolean),
-    mergeLF: input.mergeLF as boolean,
+    mergeEphemeralLF: input.mergeEphemeralLF as boolean,
   };
 }
 
@@ -291,8 +291,8 @@ function formatHudURL(
     base += `&name_filter=${encodeURIComponent(params.nameFilter)}`;
   }
 
-  if (params.mergeLF) {
-    base += `&mergeLF=true`;
+  if (params.mergeEphemeralLF) {
+    base += `&mergeEphemeralLF=true`;
   }
 
   return base;

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -443,7 +443,10 @@ export const MergeLFContext = createContext<[boolean, (val: boolean) => void]>([
 export default function Hud() {
   const router = useRouter();
   const [mergeEphemeralLF, setMergeEphemeralLF] = usePreference("mergeLF");
-  const params = packHudParams({ ...router.query, mergeEphemeralLF: mergeEphemeralLF });
+  const params = packHudParams({
+    ...router.query,
+    mergeEphemeralLF: mergeEphemeralLF,
+  });
 
   // Logic to handle tooltip pinning. The behavior we want is:
   // - If the user clicks on a tooltip, it should be pinned.
@@ -487,7 +490,9 @@ export default function Hud() {
       </Head>
       <PinnedTooltipContext.Provider value={[pinnedTooltip, setPinnedTooltip]}>
         <MonsterFailuresProvider>
-          <MergeLFContext.Provider value={[mergeEphemeralLF, setMergeEphemeralLF]}>
+          <MergeLFContext.Provider
+            value={[mergeEphemeralLF, setMergeEphemeralLF]}
+          >
             {params.branch !== undefined && (
               <div onClick={handleClick}>
                 <div style={{ display: "flex", alignItems: "flex-end" }}>

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -305,7 +305,7 @@ function GroupFilterableHudTable({
 }) {
   const { jobFilter, handleSubmit } = useTableFilter(params);
   const headerNames = groupNames;
-  const [mergeLF, setMergeLF] = useContext(MergeLFContext);
+  const [mergeEphemeralLF, setMergeEphemeralLF] = useContext(MergeLFContext);
   return (
     <>
       <div style={{ position: "relative", clear: "both" }}>
@@ -333,10 +333,10 @@ function GroupFilterableHudTable({
             labelText={"Hide green columns"}
           />
           <CheckBoxSelector
-            value={mergeLF}
-            setValue={setMergeLF}
-            checkBoxName="mergeLF"
-            labelText={"Condense LF jobs"}
+            value={mergeEphemeralLF}
+            setValue={setMergeEphemeralLF}
+            checkBoxName="mergeEphemeralLF"
+            labelText={"Condense LF, ephemeral jobs"}
           />
           <MonsterFailuresCheckbox />
         </div>
@@ -442,8 +442,8 @@ export const MergeLFContext = createContext<[boolean, (val: boolean) => void]>([
 
 export default function Hud() {
   const router = useRouter();
-  const [mergeLF, setMergeLF] = usePreference("mergeLF");
-  const params = packHudParams({ ...router.query, mergeLF: mergeLF });
+  const [mergeEphemeralLF, setMergeEphemeralLF] = usePreference("mergeLF");
+  const params = packHudParams({ ...router.query, mergeEphemeralLF: mergeEphemeralLF });
 
   // Logic to handle tooltip pinning. The behavior we want is:
   // - If the user clicks on a tooltip, it should be pinned.
@@ -487,7 +487,7 @@ export default function Hud() {
       </Head>
       <PinnedTooltipContext.Provider value={[pinnedTooltip, setPinnedTooltip]}>
         <MonsterFailuresProvider>
-          <MergeLFContext.Provider value={[mergeLF, setMergeLF]}>
+          <MergeLFContext.Provider value={[mergeEphemeralLF, setMergeEphemeralLF]}>
             {params.branch !== undefined && (
               <div onClick={handleClick}>
                 <div style={{ display: "flex", alignItems: "flex-end" }}>


### PR DESCRIPTION
Change the option that merges lf with non lf columns to also merge ephemeral and non ephemeral columns

old:
<img width="1461" alt="image" src="https://github.com/user-attachments/assets/9e309357-b56e-4a5e-af47-9722d38025f6" />

new:
<img width="946" alt="image" src="https://github.com/user-attachments/assets/02b3f37a-fb64-4605-9b17-16ce54249feb" />
