### PR TITLE
[HUD] fix query for experiment returning nonsensical numbers

### DIFF
--- a/torchci/clickhouse_queries/experiment_rollover_percentage/query.sql
+++ b/torchci/clickhouse_queries/experiment_rollover_percentage/query.sql
@@ -51,11 +51,11 @@ WITH
             count(*) AS group_size,
             bucket,
             replaceOne(replaceOne(label, 'lf.', ''), concat({experiment_name: String}, '.'), '') AS label_ref,
-            if(match(label, concat('(?-s)(lf.)?([[:alnum:]]\\.)*?', {experiment_name: String}, '(\\..)+')), True, False) AS is_ephemeral_exp
+            if(match(label, concat('(?-s)(lf.)?([[:alnum:]]\\.)*?', {experiment_name: String}, '(\\..)+')), True, False) AS is_experiment
         FROM
             comparable_jobs
         GROUP BY
-            bucket, label_ref, is_ephemeral_exp
+            bucket, label_ref, is_experiment
     ),
     comparison_stats AS (
         SELECT
@@ -63,10 +63,10 @@ WITH
             SUM(experiment.group_size + m.group_size) AS total_jobs,
             SUM(m.group_size) AS compliment_jobs,
             SUM(experiment.group_size) AS counted_jobs,
-            m.is_ephemeral_exp AS c_fleet,
-            experiment.is_ephemeral_exp AS m_fleet,
+            m.is_experiment AS c_fleet,
+            experiment.is_experiment AS m_fleet,
             CAST(SUM(experiment.group_size) AS Float32) / SUM(experiment.group_size + m.group_size) * 100 AS percentage,
-            IF(experiment.is_ephemeral_exp, 'On experiment', 'Not on experiment') AS fleet
+            IF(experiment.is_experiment, 'On experiment', 'Not on experiment') AS fleet
         FROM
             success_stats AS experiment
         INNER JOIN
@@ -75,9 +75,9 @@ WITH
             experiment.label_ref = m.label_ref
             AND experiment.bucket = m.bucket
         WHERE
-            experiment.is_ephemeral_exp = 1 AND m.is_ephemeral_exp = 0
+            experiment.is_experiment = 1 AND m.is_experiment = 0
         GROUP BY
-            experiment.bucket, experiment.is_ephemeral_exp, m.is_ephemeral_exp
+            experiment.bucket, experiment.is_experiment, m.is_experiment
     )
 SELECT * FROM comparison_stats
 ORDER BY  bucket DESC

--- a/torchci/clickhouse_queries/experiment_rollover_percentage/query.sql
+++ b/torchci/clickhouse_queries/experiment_rollover_percentage/query.sql
@@ -4,7 +4,7 @@ WITH
             l AS label,
             extract(j.name, '[^,]*') AS job_name, -- Remove shard number and label from job names
             j.workflow_name,
-            toStartOfInterval(j.started_at, INTERVAL 1 HOUR) AS bucket
+            toStartOfInterval(j.created_at, INTERVAL 1 HOUR) AS bucket
         FROM
             -- Deliberatly not adding FINAL to this workflow_job.
             -- Risks of not using it:
@@ -19,7 +19,7 @@ WITH
             workflow_job AS j
             ARRAY JOIN j.labels as l
         WHERE
-            j.started_at > now() - INTERVAL {days_ago: Int64} DAY
+            j.created_at > now() - INTERVAL {days_ago: Int64} DAY
             AND j.status = 'completed'
             AND l != 'self-hosted'
             AND l NOT LIKE 'lf.c.%'


### PR DESCRIPTION
Experiment rollout percentage on hud was returning wrong numbers for some cases/hours.

Fixes performed:
* uses `created_at` both for bucket interval AND for for selection of days of reference. Not sure why one is created and another started. Seems more reasonable to query by jobs 'created';
* There was a bug on matching for experiment, the LIKE statement matched only `lf.experiment.runner` because of the preceding `%.`. A regex match is more correct as it can even leverage the existence of multiple experiments;
* Instead of grouping per `job_name`, `workflow_name`, `label` on `success_stats`. I create a reference column for the runner type (ignoring LF/Meta status) and group by `bucket` `label_ref` and `is_ephemeral_exp`. This correctly counts the instances;
* Removed the check of group size > 3, now counting ALL job runs;
* Finally, `comparison_stats` is updated to reflect changes in `success_stats`;

bellow is the graph, before and after:

![Screenshot 2025-04-01 at 17 12 27](https://github.com/user-attachments/assets/d2130490-4936-4aee-9380-cc153b03a293)
![Screenshot 2025-04-01 at 17 13 13](https://github.com/user-attachments/assets/1f89074d-93f2-4dbd-939b-dddc389becaa)