### PR TITLE
[Cherry-Pick] Remove cuda 12.6 aarch (#6409) to release 2.7

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -50,7 +50,7 @@ STABLE_CUDA_VERSIONS = {
     "release": "12.4",
 }
 
-CUDA_AARCH64_ARCHES = ["12.6-aarch64", "12.8-aarch64"]
+CUDA_AARCH64_ARCHES = ["12.8-aarch64"]
 
 PACKAGE_TYPES = ["wheel", "conda", "libtorch"]
 PRE_CXX11_ABI = "pre-cxx11"


### PR DESCRIPTION
Cuda 12.6 aarch is not supported in Release 2.7. We release 12.8 aarch