### PR TITLE
[ez][bot] Add ci-no-td label on PRs titled revert

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -21,6 +21,7 @@ const IssueAndPRRegexToLabel: [RegExp, string][] = [
 // List of regex patterns for assigning labels to Pull Requests
 const PrTitleRegexToLabel: [RegExp, string][] = [
   [/reland/gi, "ci-no-td"],
+  [/revert/gi, "ci-no-td"],
   [/rocm/gi, "ciflow/rocm"],
   ...IssueAndPRRegexToLabel,
 ];

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -128,6 +128,30 @@ describe("auto-label-bot", () => {
     scope.done();
   });
 
+  test("add ci-no-td label when PR title contains Reland", async () => {
+    nock("https://api.github.com")
+      .post("/app/installations/2/access_tokens")
+      .reply(200, { token: "test" });
+
+    const payload = requireDeepCopy("./fixtures/pull_request.opened")[
+      "payload"
+    ];
+    payload["pull_request"]["title"] = "Failed test [Revert]";
+    payload["pull_request"]["labels"] = [];
+
+    const scope = nock("https://api.github.com")
+      .get("/repos/zhouzhuojie/gha-ci-playground/pulls/31/files?per_page=100")
+      .reply(200)
+      .post("/repos/zhouzhuojie/gha-ci-playground/issues/31/labels", (body) => {
+        expect(body).toMatchObject({ labels: ["ci-no-td"] });
+        return true;
+      })
+      .reply(200);
+    await probot.receive({ name: "pull_request", payload: payload, id: "2" });
+
+    handleScope(scope);
+  });
+
   test("add ci-no-td label when PR title contains mixed cases reLanD", async () => {
     nock("https://api.github.com")
       .post("/app/installations/2/access_tokens")

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -128,7 +128,7 @@ describe("auto-label-bot", () => {
     scope.done();
   });
 
-  test("add ci-no-td label when PR title contains Reland", async () => {
+  test("add ci-no-td label when PR title contains Revert", async () => {
     nock("https://api.github.com")
       .post("/app/installations/2/access_tokens")
       .reply(200, { token: "test" });


### PR DESCRIPTION
In addition to "reland", also add the ci-no-td label to PRs that have "revert" in the title