### PR TITLE
[ez][HUD] Move inductor periodic workflows into its own group

### DIFF
--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -6,6 +6,7 @@ const GROUP_MEMORY_LEAK_CHECK = "Memory Leak Check";
 const GROUP_RERUN_DISABLED_TESTS = "Rerun Disabled Tests";
 const GROUP_UNSTABLE = "Unstable";
 const GROUP_PERIODIC = "Periodic";
+const GROUP_INDUCTOR_PERIODIC = "Inductor Periodic";
 const GROUP_SLOW = "Slow";
 const GROUP_LINT = "Lint";
 const GROUP_INDUCTOR = "Inductor";
@@ -43,6 +44,10 @@ export const groups = [
   {
     regex: /unstable/,
     name: GROUP_UNSTABLE,
+  },
+  {
+    regex: /inductor-periodic/,
+    name: GROUP_INDUCTOR_PERIODIC,
   },
   {
     regex: /periodic/,
@@ -155,6 +160,7 @@ const HUD_GROUP_SORTING = [
   GROUP_SLOW,
   GROUP_DOCS,
   GROUP_INDUCTOR,
+  GROUP_INDUCTOR_PERIODIC,
   GROUP_ANNOTATIONS_AND_LABELING,
   GROUP_OTHER,
   GROUP_BINARY_WINDOWS,


### PR DESCRIPTION
Previously they were under periodic, now they're under inductor periodic
old
<img width="1757" alt="image" src="https://github.com/user-attachments/assets/495b7095-edb0-49cc-89eb-fd2bcaad7910" />

new
<img width="1332" alt="image" src="https://github.com/user-attachments/assets/493efac4-4e93-4ae7-a180-6b972a7d557b" />
