### PR TITLE
[BE] [Bot] Add --into as an alias for --onto in cherry-pick command

### DIFF
--- a/torchci/lib/bot/cliParser.ts
+++ b/torchci/lib/bot/cliParser.ts
@@ -155,7 +155,7 @@ const cherryPick = commands.add_parser("cherry-pick", {
   formatter_class: RawTextHelpFormatter,
   add_help: false,
 });
-cherryPick.add_argument("--onto", {
+cherryPick.add_argument("--onto", "--into", {
   required: true,
   help: "Branch you would like to cherry pick onto (Example: release/2.1)",
 });

--- a/torchci/test/cliParser.test.ts
+++ b/torchci/test/cliParser.test.ts
@@ -1,0 +1,35 @@
+import { getParser, getInputArgs } from "../lib/bot/cliParser";
+
+describe("CLI Parser", () => {
+  describe("cherry-pick command", () => {
+    it("should accept --onto parameter", () => {
+      const parser = getParser();
+      const args = parser.parse_args([
+        "cherry-pick",
+        "--onto",
+        "release/2.1",
+        "-c",
+        "regression"
+      ]);
+
+      expect(args.command).toBe("cherry-pick");
+      expect(args.onto).toBe("release/2.1");
+      expect(args.classification).toBe("regression");
+    });
+
+    it("should accept --into as an alias for --onto", () => {
+      const parser = getParser();
+      const args = parser.parse_args([
+        "cherry-pick",
+        "--into",
+        "release/2.1",
+        "-c",
+        "regression"
+      ]);
+
+      expect(args.command).toBe("cherry-pick");
+      expect(args.onto).toBe("release/2.1"); // Value should be stored in args.onto regardless of flag used
+      expect(args.classification).toBe("regression");
+    });
+  });
+});

--- a/torchci/test/cliParser.test.ts
+++ b/torchci/test/cliParser.test.ts
@@ -1,4 +1,4 @@
-import { getParser, getInputArgs } from "../lib/bot/cliParser";
+import { getParser } from "../lib/bot/cliParser";
 
 describe("CLI Parser", () => {
   describe("cherry-pick command", () => {
@@ -9,7 +9,7 @@ describe("CLI Parser", () => {
         "--onto",
         "release/2.1",
         "-c",
-        "regression"
+        "regression",
       ]);
 
       expect(args.command).toBe("cherry-pick");
@@ -24,7 +24,7 @@ describe("CLI Parser", () => {
         "--into",
         "release/2.1",
         "-c",
-        "regression"
+        "regression",
       ]);
 
       expect(args.command).toBe("cherry-pick");


### PR DESCRIPTION
I've been seeing people often try to use --into instead of --onto when using the PyTorch bot's cherry-pick command, as both parameters are semantically reasonable. 

This change adds --into as an alias for the --onto parameter, allowing users to use either version without getting an error.

The implementation leverages the argparse library's ability to have multiple option strings for the same argument. Added tests to verify that both parameter versions work correctly.