### PR TITLE
Custom script path and tag prefix for calculate docker image

### DIFF
--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -215,7 +215,7 @@ runs:
 
           IMAGE_NAME=$(echo ${DOCKER_IMAGE#"${DOCKER_REGISTRY}/${REPO_NAME}/"} | awk -F '[:,]' '{print $1}')
           # Build new image
-          ${DOCKER_BUILD_SCRIPT} "${IMAGE_NAME}${CUSTOM_TAG_PREFIX:+${CUSTOM_TAG_PREFIX}-}" -t "${DOCKER_IMAGE}"
+          ${DOCKER_BUILD_SCRIPT} "${IMAGE_NAME}${CUSTOM_TAG_PREFIX:+:${CUSTOM_TAG_PREFIX}}" -t "${DOCKER_IMAGE}"
 
           popd
 

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: |
       The script to build the docker image. Should be relative to the docker-build-dir.
     default: build.sh
+  custom-tag-prefix:
+    description: |
+      The prefix to use for the docker image tag.
+    default: ""
   working-directory:
     description: The working directory where the repo is checked out.
     default: .
@@ -53,6 +57,7 @@ runs:
         DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
         DOCKER_BUILD_SCRIPT: ${{ inputs.docker-build-script }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
+        CUSTOM_TAG_PREFIX: ${{ inputs.custom-tag-prefix }}
       run: |
         set -ex
 
@@ -76,7 +81,7 @@ runs:
           echo "docker-tag=${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
           echo "docker-image=${DOCKER_IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
         else
-          DOCKER_TAG=$(git rev-parse HEAD:"${DOCKER_BUILD_DIR}")
+          DOCKER_TAG=${CUSTOM_TAG_PREFIX:+${CUSTOM_TAG_PREFIX}-}$(git rev-parse HEAD:"${DOCKER_BUILD_DIR}")
           echo "docker-tag=${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
           echo "docker-image=${DOCKER_REGISTRY}/${REPO_NAME}/${DOCKER_IMAGE_NAME}:${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
         fi

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -14,6 +14,10 @@ inputs:
       The script parameters can be passed to docker build similar to how it is used
       in PyTorch, i.e. build.sh "${IMAGE_NAME}" -t "${DOCKER_IMAGE}".
     default: .ci/docker
+  docker-build-script:
+    description: |
+      The script to build the docker image. Should be relative to the docker-build-dir.
+    default: build.sh
   working-directory:
     description: The working directory where the repo is checked out.
     default: .
@@ -47,6 +51,7 @@ runs:
         REPO_NAME: ${{ github.event.repository.name }}
         DOCKER_IMAGE_NAME: ${{ inputs.docker-image-name }}
         DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
+        DOCKER_BUILD_SCRIPT: ${{ inputs.docker-build-script }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       run: |
         set -ex
@@ -54,7 +59,7 @@ runs:
         # If the docker build directory or the build script doesn't exist, the action will
         # gracefully return the docker image name as it is.  Pulling docker image in Linux
         # job could then download the pre-built image as usual
-        if [[ ! -d "${DOCKER_BUILD_DIR}" ]] || [[ ! -f "${DOCKER_BUILD_DIR}/build.sh" ]]; then
+        if [[ ! -d "${DOCKER_BUILD_DIR}" ]] || [[ ! -f "${DOCKER_SCRIPT_DIR}/${DOCKER_BUILD_SCRIPT}" ]]; then
           echo "skip=true" >> "${GITHUB_OUTPUT}"
           echo "docker-image=${DOCKER_IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
 
@@ -188,6 +193,7 @@ runs:
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
         WORKING_DIRECTORY: ${{ inputs.working-directory }}/${{ inputs.docker-build-dir }}
+        DOCKER_SCRIPT: ${{ inputs.docker-build-script }}
       # NB: Retry here as this step frequently fails with network error downloading various stuffs
       uses: nick-fields/retry@v3.0.0
       with:
@@ -203,7 +209,7 @@ runs:
 
           IMAGE_NAME=$(echo ${DOCKER_IMAGE#"${DOCKER_REGISTRY}/${REPO_NAME}/"} | awk -F '[:,]' '{print $1}')
           # Build new image
-          ./build.sh "${IMAGE_NAME}" -t "${DOCKER_IMAGE}"
+          ${DOCKER_SCRIPT} "${IMAGE_NAME}" -t "${DOCKER_IMAGE}"
 
           popd
 

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -196,9 +196,10 @@ runs:
       env:
         REPO_NAME: ${{ github.event.repository.name }}
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
+        CUSTOM_TAG_PREFIX: ${{ inputs.custom-tag-prefix }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
         WORKING_DIRECTORY: ${{ inputs.working-directory }}/${{ inputs.docker-build-dir }}
-        DOCKER_SCRIPT: ${{ inputs.docker-build-script }}
+        DOCKER_BUILD_SCRIPT: ${{ inputs.docker-build-script }}
       # NB: Retry here as this step frequently fails with network error downloading various stuffs
       uses: nick-fields/retry@v3.0.0
       with:
@@ -214,7 +215,7 @@ runs:
 
           IMAGE_NAME=$(echo ${DOCKER_IMAGE#"${DOCKER_REGISTRY}/${REPO_NAME}/"} | awk -F '[:,]' '{print $1}')
           # Build new image
-          ${DOCKER_SCRIPT} "${IMAGE_NAME}" -t "${DOCKER_IMAGE}"
+          ${DOCKER_BUILD_SCRIPT} "${IMAGE_NAME}${CUSTOM_TAG_PREFIX:+${CUSTOM_TAG_PREFIX}-}" -t "${DOCKER_IMAGE}"
 
           popd
 

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -64,7 +64,7 @@ runs:
         # If the docker build directory or the build script doesn't exist, the action will
         # gracefully return the docker image name as it is.  Pulling docker image in Linux
         # job could then download the pre-built image as usual
-        if [[ ! -d "${DOCKER_BUILD_DIR}" ]] || [[ ! -f "${DOCKER_SCRIPT_DIR}/${DOCKER_BUILD_SCRIPT}" ]]; then
+        if [[ ! -d "${DOCKER_BUILD_DIR}" ]] || [[ ! -f "${DOCKER_BUILD_DIR}/${DOCKER_BUILD_SCRIPT}" ]]; then
           echo "skip=true" >> "${GITHUB_OUTPUT}"
           echo "docker-image=${DOCKER_IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -17,7 +17,7 @@ inputs:
   docker-build-script:
     description: |
       The script to build the docker image. Should be relative to the docker-build-dir.
-    default: build.sh
+    default: ./build.sh
   custom-tag-prefix:
     description: |
       The prefix to use for the docker image tag.


### PR DESCRIPTION
Lets you prefix the tag with a custom string, also lets you put a custom path to the build script.

Tested on https://github.com/pytorch/pytorch/pull/151354

custom tag prefix:
Usually docker image names look like docker-image-name:folderhash
This lets you name it docker-image-name:custom-tag-prefix-folderhash
This is used in https://github.com/pytorch/pytorch/pull/150558/files and can help with the issue where we keep needing to make new ecr repositories
Alternate syntax: just include the tag in the docker image name input and parse it out

custom path to build script:
Usually its just build.sh, but https://github.com/pytorch/pytorch/pull/150558/files has a subfolder but wants to still use .ci/docker folder as the folder hash