### PR TITLE
[HUD][dark-mode]: Update JobLinks buttons to use theme variables for dark mode visibility

### DIFF
--- a/torchci/components/JobLinks.module.css
+++ b/torchci/components/JobLinks.module.css
@@ -1,10 +1,11 @@
 .disableTestButton {
-  background-color: #ffc107;
-  border-color: #ffc107;
+  background-color: var(--warning-button-bg);
+  border-color: var(--warning-button-border);
+  color: var(--warning-button-text);
 }
 
 .closedDisableIssueButton {
-  background-color: #17a2b8;
-  border-color: #17a2b8;
-  color: white;
+  background-color: var(--info-button-bg);
+  border-color: var(--info-button-border);
+  color: var(--info-button-text);
 }


### PR DESCRIPTION
Replaced hardcoded colors with CSS variables in JobLinks.module.css to ensure buttons are properly visible in dark mode. This improves contrast and readability of 'Mark unstable job' and related buttons.

Fixes https://github.com/pytorch/test-infra/issues/6500

Original
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/1a9517b3-688e-48dd-a0bd-cd288dbba1ef" />

New
<img width="1138" alt="image" src="https://github.com/user-attachments/assets/a6ba1fd6-9a7b-48ff-96c6-07c520f7460d" />
