### PR TITLE
[Remove cache] Fix concurrent issue

### DIFF
--- a/aws/lambda/oss_ci_job_queue_time/lambda_function.py
+++ b/aws/lambda/oss_ci_job_queue_time/lambda_function.py
@@ -29,7 +29,6 @@ ENVS = {
 _bucket_name = "ossci-raw-job-status"
 
 
-@lru_cache()
 def get_clickhouse_client(
     host: str, user: str, password: str
 ) -> clickhouse_connect.driver.client.Client:

--- a/aws/lambda/oss_ci_job_queue_time/lambda_function.py
+++ b/aws/lambda/oss_ci_job_queue_time/lambda_function.py
@@ -26,16 +26,12 @@ ENVS = {
     "CLICKHOUSE_USERNAME": os.getenv("CLICKHOUSE_USERNAME,"),
 }
 
-_bucket_name = "ossci-raw-job-status"
-
 
 def get_clickhouse_client(
     host: str, user: str, password: str
 ) -> clickhouse_connect.driver.client.Client:
     # for local testing only, disable SSL verification
-    return clickhouse_connect.get_client(
-        host=host, user=user, password=password, secure=True, verify=False
-    )
+    # return clickhouse_connect.get_client(host=host, user=user, password=password, secure=True, verify=False)
 
     return clickhouse_connect.get_client(
         host=host, user=user, password=password, secure=True


### PR DESCRIPTION
Forgot to remove LRU_CACHE, 
this makes threads share same session of clickhouse-client, which should not allow.


Error:
```
clickhouse Attempt to execute concurrent queries within the same session.
Please use a separate client instance per thread/process.

```