### PR TITLE
[Queue Time Histogran][Fetch Github Config File -> find closest commit config file

### DIFF
--- a/aws/lambda/oss_ci_job_queue_time/lambda_function.py
+++ b/aws/lambda/oss_ci_job_queue_time/lambda_function.py
@@ -139,6 +139,9 @@ class LazyFileHistory:
                     commit = self._fetch_until_timestamp(timestamp)
                     if commit:
                         return self._fetch_content_for_commit(commit)
+                info(
+                    f" [LazyFileHistory] No config file found in cache and in commits for {self.repo}/{self.path}."
+                )
                 return None
         except Exception as e:
             warning(

--- a/aws/lambda/oss_ci_job_queue_time/lambda_function.py
+++ b/aws/lambda/oss_ci_job_queue_time/lambda_function.py
@@ -31,7 +31,9 @@ def get_clickhouse_client(
     host: str, user: str, password: str
 ) -> clickhouse_connect.driver.client.Client:
     # for local testing only, disable SSL verification
-    return clickhouse_connect.get_client(host=host, user=user, password=password, secure=True, verify=False)
+    return clickhouse_connect.get_client(
+        host=host, user=user, password=password, secure=True, verify=False
+    )
 
     return clickhouse_connect.get_client(
         host=host, user=user, password=password, secure=True
@@ -160,9 +162,11 @@ class LazyFileHistory:
                 break
 
         info(f" [LazyFileHistory] Fetched new commits {len(newly_fetched)}")
-        if len(newly_fetched)>0:
+        if len(newly_fetched) > 0:
             newly_fetched.sort(key=lambda c: c.commit.author.date)
-            info(f" [LazyFileHistory] Fetched new commits with latest: {newly_fetched[-1].commit.author.date}, oldest:{newly_fetched[-1].commit.author.date}")
+            info(
+                f" [LazyFileHistory] Fetched new commits with latest: {newly_fetched[-1].commit.author.date}, oldest:{newly_fetched[-1].commit.author.date}"
+            )
 
         self._commits_cache.extend(newly_fetched)
         self._commits_cache.sort(key=lambda c: c.commit.author.date)
@@ -172,8 +176,9 @@ class LazyFileHistory:
 
         return self._find_closest_before_or_equal_in_cache(timestamp)
 
-
-    def _find_closest_before_or_equal_in_cache(self, timestamp: datetime) -> Optional[str]:
+    def _find_closest_before_or_equal_in_cache(
+        self, timestamp: datetime
+    ) -> Optional[str]:
         commits_before_equal = [
             c for c in self._commits_cache if c.commit.author.date <= timestamp
         ]
@@ -1183,7 +1188,9 @@ class TimeIntervalGenerator:
         query = """
         SELECT toUnixTimestamp(MAX(time)) as latest FROM fortesting.oss_ci_queue_time_histogram
         """
-        info(" Getting lastest timestamp from fortesting.oss_ci_queue_time_histogram....")
+        info(
+            " Getting lastest timestamp from fortesting.oss_ci_queue_time_histogram...."
+        )
         res = cc.query(query, {})
 
         if res.row_count != 1:

--- a/aws/lambda/oss_ci_job_queue_time/lambda_function.py
+++ b/aws/lambda/oss_ci_job_queue_time/lambda_function.py
@@ -31,7 +31,9 @@ def get_clickhouse_client(
     host: str, user: str, password: str
 ) -> clickhouse_connect.driver.client.Client:
     # for local testing only, disable SSL verification
-    return clickhouse_connect.get_client(host=host, user=user, password=password, secure=True, verify=False)
+    return clickhouse_connect.get_client(
+        host=host, user=user, password=password, secure=True, verify=False
+    )
 
     return clickhouse_connect.get_client(
         host=host, user=user, password=password, secure=True
@@ -110,7 +112,9 @@ class LazyFileHistory:
         self._fetched_all_commits = False
         self._lock = threading.RLock()
 
-    def get_version_close_to_timestamp(self, timestamp: str | datetime) -> Optional[str]:
+    def get_version_close_to_timestamp(
+        self, timestamp: str | datetime
+    ) -> Optional[str]:
         try:
             with self._lock:
                 if not isinstance(timestamp, datetime):
@@ -121,13 +125,17 @@ class LazyFileHistory:
                     else:
                         timestamp = parse(timestamp)
 
-                info(f" Getting earliest commit with file changes {self.repo}/{self.path} at time {timestamp.isoformat()}")
+                info(
+                    f" Getting earliest commit with file changes {self.repo}/{self.path} at time {timestamp.isoformat()}"
+                )
                 commit = self._find_earliest_after_in_cache(timestamp)
                 if commit:
                     return self._fetch_content_for_commit(commit)
 
                 if not self._fetched_all_commits:
-                    info(f" Nothing found in cache, fetching all commit includes {self.path} in {self.path} close/equal to {timestamp.isoformat()}")
+                    info(
+                        f" Nothing found in cache, fetching all commit includes {self.path} in {self.path} close/equal to {timestamp.isoformat()}"
+                    )
                     commit = self._fetch_until_timestamp(timestamp)
                     if commit:
                         return self._fetch_content_for_commit(commit)
@@ -148,7 +156,6 @@ class LazyFileHistory:
         return commits_after[-1]
 
     def _fetch_until_timestamp(self, timestamp: datetime) -> Optional[str]:
-
         # call github api, with path parameter
         # Only commits containing this file path will be returned.
         all_commits = self.repo.get_commits(path=self.path)
@@ -182,7 +189,6 @@ class LazyFileHistory:
             c for c in self._commits_cache if c.commit.author.date <= timestamp
         ]
         return commits_before_equal[-1] if commits_before_equal else None
-
 
     def _fetch_content_for_commit(self, commit: Any) -> str:
         if commit.sha not in self._content_cache:
@@ -607,7 +613,6 @@ class QueueTimeProcessor:
         lf_runner_config_retriever,
         old_lf_lf_runner_config_retriever,
     ) -> None:
-
         # create dictionary of tags with set of targeting machine types
         lf_runner_config = get_runner_config(lf_runner_config_retriever, start_time)
         if not lf_runner_config or not lf_runner_config["runner_types"]:

--- a/aws/lambda/oss_ci_job_queue_time/lambda_function.py
+++ b/aws/lambda/oss_ci_job_queue_time/lambda_function.py
@@ -31,9 +31,7 @@ def get_clickhouse_client(
     host: str, user: str, password: str
 ) -> clickhouse_connect.driver.client.Client:
     # for local testing only, disable SSL verification
-    return clickhouse_connect.get_client(
-        host=host, user=user, password=password, secure=True, verify=False
-    )
+    # return clickhouse_connect.get_client(host=host, user=user, password=password, secure=True, verify=False)
 
     return clickhouse_connect.get_client(
         host=host, user=user, password=password, secure=True
@@ -100,7 +98,7 @@ def write_to_file(data: Any, filename="", path=""):
 #  ---------  Github Config File Methods Start----
 class LazyFileHistory:
     """
-    Reads the content of a file from a GitHub repository on the version that it was on a specific time and date provided. It then caches the commits and file contents avoiding unnecessary requests to the GitHub API.
+    Reads the content of a file from a GitHub repository on the version that it was closest to a specific time and date provided. It then caches the commits and file contents avoiding unnecessary requests to the GitHub API.
     All public methods are thread-safe.
     """
 
@@ -126,7 +124,7 @@ class LazyFileHistory:
                         timestamp = parse(timestamp)
 
                 info(
-                    f" Getting earliest commit with file changes {self.repo}/{self.path} at time {timestamp.isoformat()}"
+                    f" [LazyFileHistory]Getting earliest commit with file changes {self.repo}/{self.path} at time {timestamp.isoformat()}"
                 )
                 commit = self._find_earliest_after_in_cache(timestamp)
                 if commit:
@@ -134,17 +132,15 @@ class LazyFileHistory:
 
                 if not self._fetched_all_commits:
                     info(
-                        f" Nothing found in cache, fetching all commit includes {self.path} in {self.path} close/equal to {timestamp.isoformat()}"
+                        f" [LazyFileHistory]Nothing found in cache, fetching all commit includes {self.path} in {self.path} close/equal to {timestamp.isoformat()}"
                     )
                     commit = self._fetch_until_timestamp(timestamp)
                     if commit:
                         return self._fetch_content_for_commit(commit)
-
         except Exception as e:
             warning(
-                f"Error fetching content for {self.repo} : {self.path} at {timestamp}: {e}"
+                f" [LazyFileHistory] Error fetching content for {self.repo} : {self.path} at {timestamp}: {e}"
             )
-
         return None
 
     def _find_earliest_after_in_cache(self, timestamp: datetime) -> Optional[str]:
@@ -180,7 +176,9 @@ class LazyFileHistory:
         res = self._find_earliest_after_in_cache(timestamp)
 
         if not res:
-            info(f" Nothing found, get equal/latest before {timestamp.isoformat()}  ")
+            info(
+                f" [LazyFileHistory] Nothing found, get latest commit before {timestamp.isoformat()}  "
+            )
             return self._find_closest_before_or_equal(timestamp)
         return res
 

--- a/aws/lambda/oss_ci_job_queue_time/lambda_function.py
+++ b/aws/lambda/oss_ci_job_queue_time/lambda_function.py
@@ -143,6 +143,7 @@ class LazyFileHistory:
             warning(
                 f" [LazyFileHistory] Error fetching content for {self.repo} : {self.path} at {timestamp}: {e}"
             )
+            return None
         return None
 
     def _fetch_until_timestamp(self, timestamp: datetime) -> Optional[str]:

--- a/aws/lambda/oss_ci_job_queue_time/lambda_function.py
+++ b/aws/lambda/oss_ci_job_queue_time/lambda_function.py
@@ -139,12 +139,12 @@ class LazyFileHistory:
                     commit = self._fetch_until_timestamp(timestamp)
                     if commit:
                         return self._fetch_content_for_commit(commit)
+                return None
         except Exception as e:
             warning(
                 f" [LazyFileHistory] Error fetching content for {self.repo} : {self.path} at {timestamp}: {e}"
             )
             return None
-        return None
 
     def _fetch_until_timestamp(self, timestamp: datetime) -> Optional[str]:
         # call github api, with path parameter

--- a/aws/lambda/tests/test_lambda_oss_ci_job_queue_time.py
+++ b/aws/lambda/tests/test_lambda_oss_ci_job_queue_time.py
@@ -238,13 +238,14 @@ class EnvironmentBaseTest(unittest.TestCase):
         self.mock_get_config_retrievers = patcher4.start()
         self.mock_envs = envs_patcher.start()
 
-        self.mock_get_runner_config.return_value = {"runner_types": {}}
+        self.mock_get_runner_config.return_value = {
+            "runner_types": {"pet": {"os": "linux", "is_ephemeral": "false"}}
+        }
         self.mock_get_config_retrievers.return_value = {
             "meta": MagicMock(),
             "lf": MagicMock(),
             "old_lf": MagicMock(),
         }
-
         self.addCleanup(patcher2.stop)
         self.addCleanup(patcher3.stop)
         self.addCleanup(patcher4.stop)


### PR DESCRIPTION
[Bug]
when  call github apiwith path parameter. Only commits containing this file path will be returned (have changes)
`all_commits = self.repo.get_commits(path=self.path)`

This causes issue since the config file fetch will always return empty if there is no cofig file change happen after our time to take snapshot.

Proposal Change
1. find the first commit that is later than start_time -> found, fetch config
2. if nothing find, fetch commits that are before/equal to commit time  -> get the closest commit and fetch config
