### PR TITLE
[validations] Set MATRIX_GPU_ARCH_VERSION for amazon linux 2023 test

### DIFF
--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -191,6 +191,7 @@ jobs:
 
         CUDA_VERSION=$(python3 ../../test-infra/tools/scripts/get_stable_cuda_version.py --channel ${{ inputs.channel }})
         CUDA_VERSION_NODOT=$(echo $CUDA_VERSION | tr -d '.')
+        export MATRIX_GPU_ARCH_VERSION="${CUDA_VERSION}"
 
         DWN_PYTORCH_ORG="https://download.pytorch.org/whl/nightly/cu${CUDA_VERSION_NODOT}"
         if [[ ${{ inputs.channel }} == 'test' ]]; then


### PR DESCRIPTION
Set MATRIX_GPU_ARCH_VERSION  to required cuda version. Fixes failure in the validations