### PR TITLE
[BE] Do not pollute logs with progress bars

### DIFF
--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -199,5 +199,5 @@ jobs:
           DWN_PYTORCH_ORG="https://download.pytorch.org/whl/cu${CUDA_VERSION_NODOT}"
         fi
 
-        python3 -m pip install torch --no-progress-bar --index-url ${DWN_PYTORCH_ORG}
+        python3 -m pip install torch --progress-bar off --index-url ${DWN_PYTORCH_ORG}
         python3 .ci/pytorch/smoke_test/smoke_test.py --package torchonly

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -199,5 +199,5 @@ jobs:
           DWN_PYTORCH_ORG="https://download.pytorch.org/whl/cu${CUDA_VERSION_NODOT}"
         fi
 
-        python3 -m pip install torch --index-url ${DWN_PYTORCH_ORG}
+        python3 -m pip install torch --no-progress-bar --index-url ${DWN_PYTORCH_ORG}
         python3 .ci/pytorch/smoke_test/smoke_test.py --package torchonly


### PR DESCRIPTION
Logs produced by https://github.com/pytorch/test-infra/actions/runs/14177205860/job/39714879789#step:15:9806 are too long to be viewed, because it preserves progress bar output, which nobody really cares about once the tests were run