### PR TITLE
Update MACOSX_DEPLOYMENT_TARGET 10.13 -> 10.15

### DIFF
--- a/tools/pkg-helpers/pytorch_pkg_helpers/macos.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/macos.py
@@ -1,6 +1,6 @@
 def get_macos_variables(arch_name: str, python_version: str = "3.8") -> list:
     variables = [
-        "export MACOSX_DEPLOYMENT_TARGET=10.13",
+        "export MACOSX_DEPLOYMENT_TARGET=10.15",
         "export CC=clang",
         "export CXX=clang++",
     ]


### PR DESCRIPTION
We are trying to bump the torchao pin in ExecuTorch, but CI jobs fail: https://github.com/pytorch/executorch/pull/9947.

In particular this job fails: https://github.com/pytorch/executorch/actions/runs/14321828652/job/40140080161?pr=9947

The root cause is "/Users/runner/work/executorch/executorch/pytorch/executorch/third-party/ao/torchao/experimental/../../torchao/experimental/ops/memory.h:22:34: error: 'aligned_alloc' is only available on macOS 10.15 or newer [-Werror,-Wunguarded-availability-new]"

This is because the test infra defines the "export MACOSX_DEPLOYMENT_TARGET=10.13".