### PR TITLE
Add experiment/stress test code

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/cache.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/cache.test.ts
@@ -5,6 +5,7 @@ import {
   shutdownRedisPool,
   redisClearCacheKeyPattern,
   getExperimentValue,
+  getJoinedStressTestExperiment,
 } from './cache';
 import { mocked } from 'ts-jest/utils';
 import { v4 as uuidv4 } from 'uuid';
@@ -141,6 +142,13 @@ describe('locallyCached', () => {
 describe('experiment functions', () => {
   beforeEach(async () => {
     await shutdownRedisPool();
+    clearLocalCache();
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await shutdownRedisPool();
   });
 
   describe('getExperimentValue', () => {
@@ -193,6 +201,105 @@ describe('experiment functions', () => {
 
       expect(result).toBe(defaultValue);
       expect(mockedRedisClient.get).toBeCalledTimes(1);
+    });
+  });
+
+  describe('getJoinedStressTestExperiment', () => {
+    it('returns false when RUNNER_NAME_SUFFIX is not set', async () => {
+      mockedRedisClient.get.mockResolvedValueOnce(null);
+
+      const result = await getJoinedStressTestExperiment('TEST_EXPERIMENT', 'runner-name');
+
+      expect(result).toBe(false);
+      expect(mockedRedisClient.get).toBeCalledTimes(1);
+      expect(mockedRedisClient.get).toBeCalledWith('gh-ci.EXPERIMENT.RUNNER_NAME_SUFFIX');
+    });
+
+    it('returns false when runner name does not match suffix', async () => {
+      mockedRedisClient.get.mockResolvedValueOnce('-suffix');
+
+      const result = await getJoinedStressTestExperiment('TEST_EXPERIMENT', 'runner-name-without-match');
+
+      expect(result).toBe(false);
+      expect(mockedRedisClient.get).toBeCalledTimes(1);
+      expect(mockedRedisClient.get).toBeCalledWith('gh-ci.EXPERIMENT.RUNNER_NAME_SUFFIX');
+    });
+
+    it('returns false when probability is less than random value', async () => {
+      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.6);
+
+      mockedRedisClient.get.mockResolvedValueOnce('-suffix');
+      mockedRedisClient.get.mockResolvedValueOnce('50');
+
+      const result = await getJoinedStressTestExperiment('TEST_EXPERIMENT', 'runner-name-suffix');
+
+      expect(result).toBe(false);
+      expect(mockedRedisClient.get).toBeCalledTimes(2);
+      expect(mockedRedisClient.get).toHaveBeenNthCalledWith(1, 'gh-ci.EXPERIMENT.RUNNER_NAME_SUFFIX');
+      expect(mockedRedisClient.get).toHaveBeenNthCalledWith(2, 'gh-ci.EXPERIMENT.TEST_EXPERIMENT');
+    });
+
+    it('returns true when probability is greater than random value', async () => {
+      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.4);
+
+      mockedRedisClient.get.mockResolvedValueOnce('-suffix');
+      mockedRedisClient.get.mockResolvedValueOnce('50');
+
+      const result = await getJoinedStressTestExperiment('TEST_EXPERIMENT', 'runner-name-suffix');
+
+      expect(result).toBe(true);
+      expect(mockedRedisClient.get).toBeCalledTimes(2);
+      expect(mockedRedisClient.get).toHaveBeenNthCalledWith(1, 'gh-ci.EXPERIMENT.RUNNER_NAME_SUFFIX');
+      expect(mockedRedisClient.get).toHaveBeenNthCalledWith(2, 'gh-ci.EXPERIMENT.TEST_EXPERIMENT');
+    });
+
+    it('returns false when experiment value is zero', async () => {
+      mockedRedisClient.get.mockResolvedValueOnce('-suffix');
+      mockedRedisClient.get.mockResolvedValueOnce('0');
+
+      const result = await getJoinedStressTestExperiment('TEST_EXPERIMENT', 'runner-name-suffix');
+
+      expect(result).toBe(false);
+      expect(mockedRedisClient.get).toBeCalledTimes(2);
+      expect(mockedRedisClient.get).toHaveBeenNthCalledWith(1, 'gh-ci.EXPERIMENT.RUNNER_NAME_SUFFIX');
+      expect(mockedRedisClient.get).toHaveBeenNthCalledWith(2, 'gh-ci.EXPERIMENT.TEST_EXPERIMENT');
+    });
+
+    it('returns true when experiment value is 100', async () => {
+      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.99);
+
+      mockedRedisClient.get.mockResolvedValueOnce('-suffix');
+      mockedRedisClient.get.mockResolvedValueOnce('100');
+
+      const result = await getJoinedStressTestExperiment('TEST_EXPERIMENT', 'runner-name-suffix');
+
+      expect(result).toBe(true);
+      expect(mockedRedisClient.get).toBeCalledTimes(2);
+      expect(mockedRedisClient.get).toHaveBeenNthCalledWith(1, 'gh-ci.EXPERIMENT.RUNNER_NAME_SUFFIX');
+      expect(mockedRedisClient.get).toHaveBeenNthCalledWith(2, 'gh-ci.EXPERIMENT.TEST_EXPERIMENT');
+    });
+
+    it('returns false when experiment value is not a valid number', async () => {
+      mockedRedisClient.get.mockResolvedValueOnce('-suffix');
+      mockedRedisClient.get.mockResolvedValueOnce('not-a-number');
+
+      const result = await getJoinedStressTestExperiment('TEST_EXPERIMENT', 'runner-name-suffix');
+
+      expect(result).toBe(false);
+      expect(mockedRedisClient.get).toBeCalledTimes(2);
+      expect(mockedRedisClient.get).toHaveBeenNthCalledWith(1, 'gh-ci.EXPERIMENT.RUNNER_NAME_SUFFIX');
+      expect(mockedRedisClient.get).toHaveBeenNthCalledWith(2, 'gh-ci.EXPERIMENT.TEST_EXPERIMENT');
+    });
+
+    it('returns false when experiment query throws an error', async () => {
+      mockedRedisClient.get.mockResolvedValueOnce('-suffix');
+      mockedRedisClient.get.mockRejectedValueOnce(new Error('Redis error'));
+
+      const result = await getJoinedStressTestExperiment('TEST_EXPERIMENT', 'runner-name-suffix');
+
+      expect(result).toBe(false);
+      expect(mockedRedisClient.get).toBeCalledTimes(2);
+      expect(mockedRedisClient.get).toHaveBeenNthCalledWith(1, 'gh-ci.EXPERIMENT.RUNNER_NAME_SUFFIX');
     });
   });
 });

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/cache.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/cache.ts
@@ -315,6 +315,7 @@ export async function getExperimentValue(experimentKey: string, defaultValue: nu
       console.warn(`Experiment ${experimentKey} found but value is not a valid number: ${experimentValue}`);
     }
   } catch (e) {
+    /* istanbul ignore next */
     console.error(`Error retrieving experiment ${experimentKey}: ${e}`);
   }
   return defaultValue;

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/cache.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/cache.ts
@@ -285,7 +285,7 @@ export async function getExperimentValueStr(experimentKey: string, defaultValue:
 
     const queryKey = `${Config.Instance.environment}.EXPERIMENT.${experimentKey}`;
 
-    console.debug(`Checking for experiment ${experimentKey} (${queryKey})`);
+    console.debug(`Checking redis entry for experiment ${experimentKey} (${queryKey})`);
     try {
       const experimentValue: string | undefined | null = await redisPool.use(async (client: RedisClientType) => {
         return await client.get(queryKey);
@@ -297,7 +297,7 @@ export async function getExperimentValueStr(experimentKey: string, defaultValue:
         console.debug(`Experiment ${queryKey} not found, using default value ${defaultValue}`);
       }
     } catch (e) {
-      console.error(`Error retrieving experiment ${queryKey}: ${e}`);
+      console.error(`Error retrieving experiment ${queryKey}, using default value ${defaultValue}: ${e}`);
     }
 
     return defaultValue;
@@ -312,11 +312,14 @@ export async function getExperimentValue(experimentKey: string, defaultValue: nu
       console.debug(`Found experiment ${experimentKey} with value ${numValue}`);
       return numValue;
     } else {
-      console.warn(`Experiment ${experimentKey} found but value is not a valid number: ${experimentValue}`);
+      console.warn(
+        `Experiment ${experimentKey} found but value is not a valid number:` +
+          ` ${experimentValue} - returning default value ${defaultValue}`,
+      );
     }
   } catch (e) {
     /* istanbul ignore next */
-    console.error(`Error retrieving experiment ${experimentKey}: ${e}`);
+    console.error(`Error retrieving experiment ${experimentKey} - returning default value ${defaultValue}: ${e}`);
   }
   return defaultValue;
 }
@@ -329,7 +332,9 @@ export async function getJoinedStressTestExperiment(experimentKey: string, runne
   }
 
   if (!runnerName.endsWith(runnerNameSuffix)) {
-    console.debug(`Runner name ${runnerName} does not match suffix ${runnerNameSuffix}`);
+    console.debug(
+      `Runner name ${runnerName} does not match suffix ${runnerNameSuffix} when checking experiment ${experimentKey}`,
+    );
     return false;
   }
 

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/cache.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/cache.ts
@@ -345,7 +345,7 @@ export async function getJoinedStressTestExperiment(experimentKey: string, runne
     return true;
   }
 
-  console.debug(`Skipping experiment ${experimentKey} for runner ${runnerName} with probability ${experimentValue}`);
+  console.debug(`Skipping experiment ${experimentKey} for runner ${runnerName}. Didn't reach probability threshold of ${experimentValue}%`);
   return false;
 }
 

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/cache.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/cache.ts
@@ -341,7 +341,7 @@ export async function getJoinedStressTestExperiment(experimentKey: string, runne
   const experimentValue = await getExperimentValue(experimentKey, 0);
 
   if (Math.random() * 100 < experimentValue) {
-    console.debug(`Joining experiment ${experimentKey} for runner ${runnerName} with probability ${experimentValue}`);
+    console.debug(`Enabling experiment ${experimentKey} for runner ${runnerName}. Reached probability threshold of ${experimentValue}%`);
     return true;
   }
 

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
@@ -71,6 +71,10 @@ jest.mock('./cache', () => ({
     .mockImplementation(async <T>(ns: string, k: string, t: number, j: number, fn: () => Promise<T>): Promise<T> => {
       return await locallyCached(ns, k, t, fn);
     }),
+  /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+  getJoinedStressTestExperiment: jest.fn().mockImplementation(async (experimentKey: string, defaultValue: string) => {
+    return false;
+  }),
 }));
 jest.mock('./gh-auth');
 
@@ -143,7 +147,7 @@ function createExpectedRunInstancesLinux(
 
 const metrics = new ScaleUpMetrics();
 
-beforeEach(() => {
+beforeEach(async () => {
   jest.resetModules();
   jest.clearAllMocks();
   jest.restoreAllMocks();

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -474,7 +474,9 @@ export async function tryReuseRunner(
     runnerType: runnerParameters.runnerType.runnerTypeName,
   };
   if (await getJoinedStressTestExperiment('stresstest_awsfail', runnerParameters.runnerType.runnerTypeName)) {
-    console.warn(`Joining stress test stresstest_awsfail, failing AWS reuse for ${runnerParameters.runnerType.runnerTypeName}`);
+    console.warn(
+      `Joining stress test stresstest_awsfail, failing AWS reuse for ${runnerParameters.runnerType.runnerTypeName}`,
+    );
     throw new RetryableScalingError('Stress test stockout');
   }
 
@@ -673,11 +675,17 @@ export async function createRunner(runnerParameters: RunnerInputParameters, metr
     console.debug('Runner configuration: ' + JSON.stringify(runnerParameters));
 
     if (await getJoinedStressTestExperiment('stresstest_awsfail', runnerParameters.runnerType.runnerTypeName)) {
-      console.warn(`Joining stress test stresstest_awsfail, failing instance creation for ${runnerParameters.runnerType.runnerTypeName}`);
+      console.warn(
+        `Joining stress test stresstest_awsfail, failing instance creation` +
+          ` for ${runnerParameters.runnerType.runnerTypeName}`,
+      );
       throw new RetryableScalingError('Stress test stresstest_awsfail');
     }
     if (await getJoinedStressTestExperiment('stresstest_stockout', runnerParameters.runnerType.runnerTypeName)) {
-      console.warn(`Joining stress test stresstest_stockout, failing instance creation for ${runnerParameters.runnerType.runnerTypeName}`);
+      console.warn(
+        `Joining stress test stresstest_stockout, failing instance ` +
+          `creation for ${runnerParameters.runnerType.runnerTypeName}`,
+      );
       throw new RetryableScalingError('Stress test stresstest_stockout');
     }
 

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up-chron.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up-chron.ts
@@ -24,10 +24,9 @@ export async function scaleUpChron(metrics: ScaleUpChronMetrics): Promise<void> 
     );
     throw new Error('scaleUpChronRecordQueueUrl is not set. Cannot send queued scale up requests');
   }
-  const scaleUpChronRecordQueueUrl = Config.Instance.scaleUpChronRecordQueueUrl;
   // Only proactively scale up the jobs that have been queued for longer than normal
   // Filter out the queued jobs that are do not correspond to a valid runner type
-  const queuedJobs = (await getQueuedJobs(metrics, scaleUpChronRecordQueueUrl))
+  const queuedJobs = (await getQueuedJobs(metrics, Config.Instance.scaleUpChronRecordQueueUrl))
     .filter((runner) => {
       return (
         runner.min_queue_time_minutes >= minAutoScaleupDelayMinutes && runner.org === Config.Instance.scaleConfigOrg

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -173,7 +173,7 @@ async function createRunnerConfigArgument(
 ): Promise<string> {
   if (await getJoinedStressTestExperiment('stresstest_ghapislow', runnerType.runnerTypeName)) {
     console.warn(
-      `Stress test slow gh api response, sleeping before reaching GH ` +
+      `Stress test slow gh api response active: Sleeping before reaching GH ` +
         `API for token creation for ${runnerType.runnerTypeName}`,
     );
     await sleep(60 * 1000);

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -1,5 +1,5 @@
 import { Metrics, ScaleUpMetrics } from './metrics';
-import { Repo, getRepoKey } from './utils';
+import { Repo, getRepoKey, sleep } from './utils';
 import { RunnerType, RunnerInputParameters, createRunner, tryReuseRunner } from './runners';
 import {
   createRegistrationTokenOrg,
@@ -12,6 +12,7 @@ import {
 
 import { Config } from './config';
 import { getRepoIssuesWithLabel } from './gh-issues';
+import { getExperimentValue } from './cache';
 
 export interface ActionRequestMessage {
   id: number;
@@ -75,6 +76,7 @@ export async function scaleUp(
   // if no labels are found this should just be a no-op
   for (const runnerLabel of runnerLabels) {
     const runnerType = runnerTypes.get(runnerLabel);
+
     if (runnerType === undefined) {
       console.info(
         `Runner label '${runnerLabel}' was not found in config at ` +
@@ -82,6 +84,14 @@ export async function scaleUp(
       );
       continue;
     }
+
+    if (runnerType.runnerTypeName.includes('linux.2xlarge')) {
+      if ((await getExperimentValue('stresstest_ignorereq', 0)) > Math.random() * 100) {
+        console.warn(`Stresstest ignore request for scale ${runnerType.runnerTypeName}`);
+        continue;
+      }
+    }
+
     const runnersRequested = 1;
     const runnersToCreate = await getCreatableRunnerCount(
       runnerType.runnerTypeName,
@@ -163,6 +173,16 @@ async function createRunnerConfigArgument(
   awsRegion: string,
   experimentalRunner: boolean,
 ): Promise<string> {
+  if (runnerType.runnerTypeName.includes('linux.2xlarge')) {
+    if ((await getExperimentValue('stresstest_ghapislow', 0)) !== 0) {
+      console.warn(
+        `Stress test slow gh api response, sleeping before reaching GH ` +
+          `API for token creation for ${runnerType.runnerTypeName}`,
+      );
+      await sleep(60 * 1000);
+    }
+  }
+
   const ephemeralArgument = runnerType.is_ephemeral || experimentalRunner ? '--ephemeral' : '';
   const labelsArgument = [
     `AWS:${awsRegion}`,

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -86,7 +86,7 @@ export async function scaleUp(
     }
 
     if (await getJoinedStressTestExperiment('stresstest_ignorereq', runnerType.runnerTypeName)) {
-      console.warn(`Stresstest stresstest_ignorereq: ignore request for scale ${runnerType.runnerTypeName}`);
+      console.warn(`Stresstest stresstest_ignorereq active: ignoring request for scale ${runnerType.runnerTypeName}`);
       continue;
     }
 

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/utils.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/utils.test.ts
@@ -9,6 +9,7 @@ import {
   groupBy,
   shuffleArrayInPlace,
   stochaticRunOvershoot,
+  sleep,
 } from './utils';
 import nock from 'nock';
 
@@ -275,41 +276,69 @@ describe('shuffleArrayInPlace', () => {
       expect(arr).toContain(number);
     }
   });
+});
 
-  describe('stochaticRunOvershoot', () => {
-    afterEach(() => {
-      jest.spyOn(global.Math, 'random').mockRestore();
-    });
+describe('stochaticRunOvershoot', () => {
+  afterEach(() => {
+    jest.spyOn(global.Math, 'random').mockRestore();
+  });
 
-    it('test some values', () => {
-      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.0);
-      expect(stochaticRunOvershoot(0, 100, 10)).toBe(true);
-      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.5);
-      expect(stochaticRunOvershoot(0, 100, 10)).toBe(true);
-      jest.spyOn(global.Math, 'random').mockReturnValueOnce(1.0);
-      expect(stochaticRunOvershoot(0, 100, 10)).toBe(true);
+  it('test some values', () => {
+    jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.0);
+    expect(stochaticRunOvershoot(0, 100, 10)).toBe(true);
+    jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.5);
+    expect(stochaticRunOvershoot(0, 100, 10)).toBe(true);
+    jest.spyOn(global.Math, 'random').mockReturnValueOnce(1.0);
+    expect(stochaticRunOvershoot(0, 100, 10)).toBe(true);
 
-      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.0);
-      expect(stochaticRunOvershoot(4, 100, 10)).toBe(true);
-      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.5);
-      expect(stochaticRunOvershoot(4, 100, 10)).toBe(true);
-      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.6249);
-      expect(stochaticRunOvershoot(4, 100, 10)).toBe(true);
-      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.6251);
-      expect(stochaticRunOvershoot(4, 100, 10)).toBe(false);
-      jest.spyOn(global.Math, 'random').mockReturnValueOnce(1.0);
-      expect(stochaticRunOvershoot(4, 100, 10)).toBe(false);
+    jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.0);
+    expect(stochaticRunOvershoot(4, 100, 10)).toBe(true);
+    jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.5);
+    expect(stochaticRunOvershoot(4, 100, 10)).toBe(true);
+    jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.6249);
+    expect(stochaticRunOvershoot(4, 100, 10)).toBe(true);
+    jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.6251);
+    expect(stochaticRunOvershoot(4, 100, 10)).toBe(false);
+    jest.spyOn(global.Math, 'random').mockReturnValueOnce(1.0);
+    expect(stochaticRunOvershoot(4, 100, 10)).toBe(false);
 
-      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.0);
-      expect(stochaticRunOvershoot(12, 100, 10)).toBe(true);
-      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.00244139);
-      expect(stochaticRunOvershoot(12, 100, 10)).toBe(true);
-      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.00244141);
-      expect(stochaticRunOvershoot(12, 100, 10)).toBe(false);
-      jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.5);
-      expect(stochaticRunOvershoot(12, 100, 10)).toBe(false);
-      jest.spyOn(global.Math, 'random').mockReturnValueOnce(1.0);
-      expect(stochaticRunOvershoot(12, 100, 10)).toBe(false);
-    });
+    jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.0);
+    expect(stochaticRunOvershoot(12, 100, 10)).toBe(true);
+    jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.00244139);
+    expect(stochaticRunOvershoot(12, 100, 10)).toBe(true);
+    jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.00244141);
+    expect(stochaticRunOvershoot(12, 100, 10)).toBe(false);
+    jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.5);
+    expect(stochaticRunOvershoot(12, 100, 10)).toBe(false);
+    jest.spyOn(global.Math, 'random').mockReturnValueOnce(1.0);
+    expect(stochaticRunOvershoot(12, 100, 10)).toBe(false);
+  });
+});
+
+describe('sleep', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should resolve after the specified time', async () => {
+    const sleepPromise = sleep(1000);
+
+    // Advance timers
+    jest.advanceTimersByTime(1000);
+
+    await expect(sleepPromise).resolves.toBeUndefined();
+  });
+
+  it('should handle undefined time value', async () => {
+    const sleepPromise = sleep(undefined);
+
+    // Since undefined should default to 0 or minimum time
+    jest.advanceTimersByTime(1);
+
+    await expect(sleepPromise).resolves.toBeUndefined();
   });
 });

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/utils.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/utils.ts
@@ -164,3 +164,7 @@ export function shuffleArrayInPlace<T>(arr: T[]): T[] {
   }
   return arr;
 }
+
+export function sleep(time: number | undefined) {
+  return new Promise((resolve) => setTimeout(resolve, time));
+}


### PR DESCRIPTION
As part of the infra stress test, we want to introduce the capability of running code experiments leveraging Redis.

This also introduce the checks we are planning to perform for the infra stress test.