### PR TITLE
[validation] Fix timing out macos validations, add numpy 1.26 validations for python <=3.12

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -30,7 +30,6 @@ else
         conda create -y -n ${ENV_NAME} python=${MATRIX_PYTHON_VERSION}
         conda activate ${ENV_NAME}
     fi
-    
     INSTALLATION=${MATRIX_INSTALLATION/"conda install"/"conda install -y"}
     TEST_SUFFIX=""
 
@@ -38,23 +37,19 @@ else
     if [[ ${USE_FORCE_REINSTALL} == 'true' ]]; then
         INSTALLATION=${INSTALLATION/"pip3 install"/"pip3 install --force-reinstall"}
     fi
-    
     # extra-index-url: extra dependencies are downloaded from pypi
     if [[ ${USE_EXTRA_INDEX_URL} == 'true' ]]; then
         INSTALLATION=${INSTALLATION/"--index-url"/"--extra-index-url"}
     fi
-
     # use-meta-cdn: use meta cdn for pypi download
     if [[ ${USE_META_CDN} == 'true' ]]; then
         INSTALLATION=${INSTALLATION/"download.pytorch.org"/"d3kup0pazkvub8.cloudfront.net"}
     fi
-
-
+    # torch-only option: remove vision and audio
     if [[ ${TORCH_ONLY} == 'true' ]]; then
         INSTALLATION=${INSTALLATION/"torchvision torchaudio"/""}
         TEST_SUFFIX=" --package torchonly"
     fi
-
     # if RELESE version is passed as parameter - install speific version
     if [[ ! -z ${RELEASE_VERSION} ]]; then
           INSTALLATION=${INSTALLATION/"torch "/"torch==${RELEASE_VERSION} "}

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -103,7 +103,7 @@ else
     # For pip install also test with latest numpy
     if [[ ${MATRIX_PACKAGE_TYPE} == 'wheel' ]]; then
         # test with latest numpy 2.x
-        pip3 install numpy --force-reinstall
+        pip3 install numpy --upgrade --force-reinstall
         ${PYTHON_RUN}  ./smoke_test/smoke_test.py ${TEST_SUFFIX}
     fi
 

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -30,13 +30,6 @@ else
         conda create -y -n ${ENV_NAME} python=${MATRIX_PYTHON_VERSION}
         conda activate ${ENV_NAME}
     fi
-
-    MINOR_PYTHON_VERSION=$(echo "$MATRIX_PYTHON_VERSION" | cut -d . -f 2)
-    if [[ ${MINOR_PYTHON_VERSION} < 13 ]]; then
-        pip3 install numpy==1.26.4 --force-reinstall
-    else
-        pip3 install numpy --force-reinstall
-    fi
     
     INSTALLATION=${MATRIX_INSTALLATION/"conda install"/"conda install -y"}
     TEST_SUFFIX=""
@@ -85,6 +78,12 @@ else
         pip3 uninstall -y torch torchaudio torchvision
     fi
     eval $INSTALLATION
+
+    # test with numpy 1.x installation needs to happen after torch install
+    MINOR_PYTHON_VERSION=$(echo "$MATRIX_PYTHON_VERSION" | cut -d . -f 2)
+    if [[ ${MINOR_PYTHON_VERSION} < 13 ]]; then
+        pip3 install numpy==1.26.4 --force-reinstall
+    fi
 
     pushd ${PWD}/.ci/pytorch/
 

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -15,9 +15,7 @@ else
         fi
     fi
 
-    if [[ ${TARGET_OS} == 'macos-arm64' ]]; then
-        conda update -y -n base -c defaults conda
-    elif [[ ${TARGET_OS} != 'linux-aarch64' ]]; then
+    if [[ ${TARGET_OS} != 'linux-aarch64' ]]; then
         # Conda pinned see issue: https://github.com/ContinuumIO/anaconda-issues/issues/13350
         conda install -y conda=23.11.0
     fi
@@ -32,7 +30,7 @@ else
         conda activate ${ENV_NAME}
     fi
 
-    pip3 install numpy --force-reinstall
+    pip3 install numpy==1.24.1 --force-reinstall
     INSTALLATION=${MATRIX_INSTALLATION/"conda install"/"conda install -y"}
     TEST_SUFFIX=""
 

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -77,7 +77,7 @@ else
     # test with numpy 1.x installation needs to happen after torch install
     MINOR_PYTHON_VERSION=$(echo "$MATRIX_PYTHON_VERSION" | cut -d . -f 2)
     if [[ ${MINOR_PYTHON_VERSION} < 13 ]]; then
-        pip3 install numpy==1.26.4 --force-reinstall
+        pip3 install numpy==1.26.4 --force-reinstall # the latest 1.x release
     fi
 
     pushd ${PWD}/.ci/pytorch/

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -32,7 +32,7 @@ else
     fi
 
     MINOR_PYTHON_VERSION=$(echo "$MATRIX_PYTHON_VERSION" | cut -d . -f 2)
-    if [[ ${MINOR_PYTHON_VERSION} <= "12" ]]; then
+    if [[ ${MINOR_PYTHON_VERSION} < 13 ]]; then
         pip3 install numpy==1.26.4 --force-reinstall
     else
         pip3 install numpy --force-reinstall


### PR DESCRIPTION
1. This fixes Macos arm64 validations I am seeing here:
- Failure: https://github.com/pytorch/test-infra/actions/runs/14369578394/job/40289986253
- Success run: https://github.com/pytorch/test-infra/actions/runs/14387119603

3. Adds numpy (optional) depenency validations to binaries with python =<3.12