### PR TITLE
Hud: mark groups with successfully cancelled jobs as warnings

### DIFF
--- a/torchci/components/GroupJobConclusion.tsx
+++ b/torchci/components/GroupJobConclusion.tsx
@@ -1,6 +1,7 @@
 import TooltipTarget from "components/TooltipTarget";
 import { getGroupConclusionChar } from "lib/JobClassifierUtil";
 import {
+  isCancellationSuccessJob,
   isFailedJob,
   isRerunDisabledTestsJob,
   isUnstableJob,
@@ -192,7 +193,11 @@ export default function HudGroupedCell({
   let viableStrictBlocking = false;
   for (const job of jobs) {
     if (isFailedJob(job)) {
-      if (isRerunDisabledTestsJob(job) || isUnstableJob(job, unstableIssues)) {
+      if (
+        isRerunDisabledTestsJob(job) ||
+        isUnstableJob(job, unstableIssues) ||
+        isCancellationSuccessJob(job)
+      ) {
         warningOnlyJobs.push(job);
       } else {
         erroredJobs.push(job);

--- a/torchci/lib/jobUtils.ts
+++ b/torchci/lib/jobUtils.ts
@@ -32,6 +32,16 @@ export function isFailedJob(job: JobData) {
   );
 }
 
+export function isCancellationSuccessJob(job: JobData) {
+  // job was cancelled successfully
+  return (
+    job.conclusion === "cancelled" &&
+    (!job.failureLines ||
+      job.failureLines.length == 0 ||
+      job.failureLines[0]?.includes("was canceled"))
+  );
+}
+
 export function isSuccessJob(job: BasicJobData) {
   return job.conclusion === "success";
 }


### PR DESCRIPTION
before:
<img width="611" alt="image" src="https://github.com/user-attachments/assets/3e8ba310-4d02-47aa-b953-6a1ef65b329d" />

after:
<img width="687" alt="image" src="https://github.com/user-attachments/assets/0bf7bfc5-8ad4-45a2-a985-6e4a4f6513a8" />

