### PR TITLE
Upgrade NVIDIA driver for CUDA 12.6+

### DIFF
--- a/.github/actions/setup-nvidia/action.yml
+++ b/.github/actions/setup-nvidia/action.yml
@@ -87,7 +87,7 @@ runs:
                           echo "NVIDIA driver ($INSTALLED_DRIVER_VERSION) has been installed, but we expect to have $DRIVER_VERSION instead. Continuing"
 
                           # Turn off persistent mode so that the installation script can unload the kernel module
-                          sudo nvidia-persistenced --no-persistence-mode || true
+                          sudo nvidia-smi -pm 0 || true
                       else
                           HAS_NVIDIA_DRIVER=1
                           echo "NVIDIA driver ($INSTALLED_DRIVER_VERSION) has already been installed. Skipping NVIDIA driver installation"
@@ -252,6 +252,6 @@ runs:
           # more than one GPUs. This just needs to be run once. The command fails
           # on subsequent runs and complains that the mode is already on, but that's
           # ok
-          sudo nvidia-persistenced || true
+          sudo nvidia-smi -pm 1 || true
           # This should show persistence mode ON
           nvidia-smi

--- a/.github/actions/setup-nvidia/action.yml
+++ b/.github/actions/setup-nvidia/action.yml
@@ -87,7 +87,7 @@ runs:
                           echo "NVIDIA driver ($INSTALLED_DRIVER_VERSION) has been installed, but we expect to have $DRIVER_VERSION instead. Continuing"
 
                           # Turn off persistent mode so that the installation script can unload the kernel module
-                          sudo nvidia-smi -pm 0 || true
+                          sudo killall nvidia-persistenced || true
                       else
                           HAS_NVIDIA_DRIVER=1
                           echo "NVIDIA driver ($INSTALLED_DRIVER_VERSION) has already been installed. Skipping NVIDIA driver installation"
@@ -252,6 +252,6 @@ runs:
           # more than one GPUs. This just needs to be run once. The command fails
           # on subsequent runs and complains that the mode is already on, but that's
           # ok
-          sudo nvidia-smi -pm 1 || true
+          sudo nvidia-persistenced || true
           # This should show persistence mode ON
           nvidia-smi

--- a/.github/actions/setup-nvidia/action.yml
+++ b/.github/actions/setup-nvidia/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: which driver version to install
     required: false
     type: string
-    default: "550.54.15"   # https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-550-54-15/index.html
+    default: "570.133.07"   # https://www.nvidia.com/en-us/drivers/details/242273
 
 runs:
   using: composite
@@ -85,6 +85,9 @@ runs:
                           echo "Failed to get NVIDIA driver version ($INSTALLED_DRIVER_VERSION). Continuing"
                       elif [ "$INSTALLED_DRIVER_VERSION" != "$DRIVER_VERSION" ]; then
                           echo "NVIDIA driver ($INSTALLED_DRIVER_VERSION) has been installed, but we expect to have $DRIVER_VERSION instead. Continuing"
+
+                          # Turn off persistent mode so that the installation script can unload the kernel module
+                          sudo nvidia-persistenced --no-persistence-mode || true
                       else
                           HAS_NVIDIA_DRIVER=1
                           echo "NVIDIA driver ($INSTALLED_DRIVER_VERSION) has already been installed. Skipping NVIDIA driver installation"


### PR DESCRIPTION
This is reported by @jainapurva from TorchAO https://github.com/pytorch/ao/actions/runs/14461343872/job/40554407661 trying to upgrade CUDA from 12.4 to 12.6 https://github.com/pytorch/ao/pull/1962.  It turns out that the NVIDIA driver that we are currently using `550.54.15` is too old.

I grab the latest production driver from NVIDIA which should satisfy not only CUDA 12.6 but 12.8 too:

* https://docs.nvidia.com/cuda/archive/12.8.0/cuda-toolkit-release-notes/index.html

This should help fix the issue on AO, also need to update this driver in a couple of other places too.

### Testing

* Manual.  I install the driver manually and can start the container fine without any issue `docker run --gpus all -it pytorch/almalinux-builder:cuda12.6 /bin/bash`
* https://github.com/pytorch/test-infra/actions/runs/14481525016
* ~~Also test this out on AO https://github.com/pytorch/ao/actions/runs/14481627872/job/40619564626~~ I think this needs to be landed first as AO jobs still point to `test-infra@main` 