### PR TITLE
[CH] optimize hud_query by eliminating joins

### DIFF
--- a/torchci/clickhouse_queries/hud_query/params.json
+++ b/torchci/clickhouse_queries/hud_query/params.json
@@ -1,7 +1,39 @@
 {
   "params": {
     "repo": "String",
-    "shas": "String"
+    "shas": "Array(String)"
   },
-  "tests": []
+  "tests": [
+    {
+      "repo": "pytorch/pytorch",
+      "shas": ["dac34906abc21722537eee56f5f2430eb00c75fc"]
+    },
+    {
+      "repo": "pytorch/ao",
+      "shas": ["42e1345f0bc451383bcd27e39e93d4ae673eabe0"]
+    },
+    {
+      "repo": "pytorch/executorch",
+      "shas": ["ce74f8e28076517e00f2940bd57ed96e3f1b2f22"]
+    },
+    {
+      "repo": "pytorch/torchx",
+      "shas": ["f7ab10ac0b79b00193f7b6e3010bfa913e3c3fd2"]
+    },
+    {
+      "repo": "pytorch/ao",
+      "shas": [
+        "42e1345f0bc451383bcd27e39e93d4ae673eabe0",
+        "ce759d556be1e5bc6eeda41e7cb220aacdbe116a",
+        "59bf66613d54cca97d703752fdedaaa3b819c39d",
+        "7e3978cce243282990dc32953bec727f7b2ad04c",
+        "3766ed7f010f83bd93da56231fd2d8efcb1ceabc",
+        "09c276039e35d914be31484d39dc25ee3049e188",
+        "b948c4ef95ea2e87ec4b62f2832d638c71aa0a45",
+        "2d11289cc1d6fad2d872d069a1f113c80d43b152",
+        "e92c7216daaac9920f75fb7db1c5cefa6ebdab1b",
+        "7bb7f2387328ad7893b70d27113c0d538cf233d2"
+      ]
+    }
+  ]
 }

--- a/torchci/clickhouse_queries/hud_query/query.sql
+++ b/torchci/clickhouse_queries/hud_query/query.sql
@@ -2,7 +2,7 @@ WITH job AS (
     SELECT
         job.head_sha as sha,
         job.name as job_name,
-        workflow.name as workflow_name,
+        job.workflow_name as workflow_name,
         job.id as id,
         job.status as status,
         job.conclusion as conclusion,
@@ -25,24 +25,23 @@ WITH job AS (
             null,
             DATE_DIFF('SECOND', job.started_at, job.completed_at)
         ) AS duration_s,
-        workflow.repository.'full_name' as repo,
+        job.repository_full_name as repo,
         job.torchci_classification.'line' as line,
         job.torchci_classification.'captures' as captures,
         job.torchci_classification.'line_num' as line_num,
-        annotation.annotation as annotation
+        annotation.annotation as annotation,
+        job._inserted_at as job_inserted_at
     FROM
         workflow_job job final
-        INNER JOIN workflow_run workflow final on workflow.id = job.run_id
         LEFT JOIN job_annotation annotation final ON job.id = annotation.jobID
     WHERE
         job.name != 'ciflow_should_run'
         AND job.name != 'generate-test-matrix'
-        AND workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
-        AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
-        AND job.id in (select id from materialized_views.workflow_job_by_head_sha where head_sha in {shas: Array(String)})
-        AND workflow.id in (select id from materialized_views.workflow_run_by_head_sha where head_sha in {shas: Array(String)})
-        AND workflow.repository.'full_name' = {repo: String}
-        AND workflow.name != 'Upload test stats while running' -- Continuously running cron job that cancels itself to avoid running concurrently
+        AND job.workflow_event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
+        AND job.workflow_event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
+        AND job.id in (select distinct id from materialized_views.workflow_job_by_head_sha where head_sha in {shas: Array(String)})
+        AND job.repository_full_name = {repo: String}
+        AND job.workflow_name != 'Upload test stats while running' -- Continuously running cron job that cancels itself to avoid running concurrently
     -- Removed CircleCI query
 )
 SELECT

--- a/torchci/clickhouse_queries/hud_query/query.sql
+++ b/torchci/clickhouse_queries/hud_query/query.sql
@@ -29,8 +29,7 @@ WITH job AS (
         job.torchci_classification.'line' as line,
         job.torchci_classification.'captures' as captures,
         job.torchci_classification.'line_num' as line_num,
-        annotation.annotation as annotation,
-        job._inserted_at as job_inserted_at
+        annotation.annotation as annotation
     FROM
         workflow_job job final
         LEFT JOIN job_annotation annotation final ON job.id = annotation.jobID
@@ -39,7 +38,7 @@ WITH job AS (
         AND job.name != 'generate-test-matrix'
         AND job.workflow_event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
         AND job.workflow_event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
-        AND job.id in (select distinct id from materialized_views.workflow_job_by_head_sha where head_sha in {shas: Array(String)})
+        AND job.id in (select id from materialized_views.workflow_job_by_head_sha where head_sha in {shas: Array(String)})
         AND job.repository_full_name = {repo: String}
         AND job.workflow_name != 'Upload test stats while running' -- Continuously running cron job that cancels itself to avoid running concurrently
     -- Removed CircleCI query


### PR DESCRIPTION
Utilizing the new dict + aliased column approach to eliminate expensive join.

perf

```./clickhouse_query_perf.py --query hud_query --perf --times 5 --base HEAD
Using unstaged changes for --head
Gathering perf stats for: hud_query
Num tests: 5
Num times: 5
Waiting for metrics to populate, please be patient
+------+----------+-----------+-------------+---------------+----------+-----------+------------+--------------+
| Test | Avg Time | Base Time | Time Change | % Time Change | Avg Mem  |  Base Mem | Mem Change | % Mem Change |
+------+----------+-----------+-------------+---------------+----------+-----------+------------+--------------+
|  0   |   134    |    415    |     -281    |      -68      | 38258808 | 148456303 | -110197495 |     -74      |
|  1   |   155    |    347    |     -192    |      -55      | 26351850 | 148452495 | -122100645 |     -82      |
|  2   |   130    |    298    |     -168    |      -56      | 52304420 | 148453247 | -96148827  |     -65      |
|  3   |   133    |    309    |     -176    |      -57      | 48468858 | 148452607 | -99983749  |     -67      |
|  4   |   320    |    994    |     -674    |      -68      | 40857464 | 148481827 | -107624363 |     -72      |
+------+----------+-----------+-------------+---------------+----------+-----------+------------+--------------+

```


### Test

```
./clickhouse_query_perf.py --query hud_query --results --times 1  --base HEAD --strict-results
Using unstaged changes for --head
Comparing results for query: hud_query
Num tests: 5
Head: unstaged
 Base: HEAD
Results for test 0 match
Results for test 1 match
Results for test 2 match
Results for test 3 match
Results for test 4 match
```