### PR TITLE
[CH] optimize master_commit_red_jobs by eliminating join and adding pre-filtering

### DIFF
--- a/torchci/clickhouse_queries/master_commit_red_jobs/params.json
+++ b/torchci/clickhouse_queries/master_commit_red_jobs/params.json
@@ -4,5 +4,16 @@
     "stopTime": "DateTime64(3)",
     "workflowNames": "Array(String)"
   },
-  "tests": []
+  "tests": [
+    {
+      "startTime": "2025-03-18T21:09:47.987",
+      "stopTime": "2025-03-25T21:09:47.987",
+      "workflowNames": ["pull"]
+    },
+    {
+      "startTime": "2025-03-18T21:09:47.987",
+      "stopTime": "2025-03-25T21:09:47.987",
+      "workflowNames": ["lint", "pull", "trunk"]
+    }
+  ]
 }


### PR DESCRIPTION
```
./clickhouse_query_perf.py --query master_commit_red_jobs --perf --times 3 --base HEAD
Using unstaged changes for --head
Gathering perf stats for: master_commit_red_jobs
Num tests: 2
Num times: 3
+------+----------+-----------+-------------+---------------+-----------+------------+------------+--------------+
| Test | Avg Time | Base Time | Time Change | % Time Change |  Avg Mem  |  Base Mem  | Mem Change | % Mem Change |
+------+----------+-----------+-------------+---------------+-----------+------------+------------+--------------+
|  0   |   987    |    9401   |    -8414    |      -90      | 271203271 | 803400038  | -532196767 |     -66      |
|  1   |   733    |   10425   |    -9692    |      -93      | 323819095 | 1255600040 | -931780945 |     -74      |
+------+----------+-----------+-------------+---------------+-----------+------------+------------+--------------+
```



### Testing

note: the query as is returns unstable results, the testing below was done by wrapping arrays in sort for both base and head versions:
```
        arraySort(arrayFilter(x -> x != '', groupArray(IF (any_red > 0, name, '')))) AS failures,
        arraySort(arrayFilter(x -> x != '', groupArray(IF (any_red = 0, name, '')))) AS successes,
```


```
/clickhouse_query_perf.py --query master_commit_red_jobs --results --times 1 --base HEAD  --strict-results
Using unstaged changes for --head
Comparing results for query: master_commit_red_jobs
Num tests: 2
Head: unstaged
 Base: HEAD
Results for test 0 match
Results for test 1 match
```