### PR TITLE
[Autoscaler] Add logging to better understand why a scale down occurred

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -350,7 +350,7 @@ export async function getGHRunnerRepo(ec2runner: RunnerInfo, metrics: ScaleDownM
   }
 
   if (ghRunner === undefined) {
-    if (ec2runner.ghRunnerId == undefined) {
+    if (ec2runner.ghRunnerId === undefined) {
       console.warn(
         `Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}](${repo}) not found in ` +
           `listGithubRunnersRepo call, and it did not have the GithubRunnerId EC2 tag set.  This ` +

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -352,9 +352,9 @@ export async function getGHRunnerRepo(ec2runner: RunnerInfo, metrics: ScaleDownM
   if (ghRunner === undefined) {
     if (ec2runner.ghRunnerId === undefined) {
       console.warn(
-        `Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}](${repo}) not found in ` +
-          `listGithubRunnersRepo call, and it did not have the GithubRunnerId EC2 tag set.  This ` +
-          `can happen if there's no runner running on the instance.`,
+        `Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}](${repo}) was neither found in ` +
+          `the list of runners returned by the listGithubRunnersRepo api call, nor did it have the ` +
+          `GithubRunnerId EC2 tag set.  This can happen if there's no runner running on the instance.`,
       );
     } else {
       console.warn(
@@ -432,8 +432,6 @@ export function isRunnerRemovable(
   ec2runner: RunnerInfo,
   metrics: ScaleDownMetrics,
 ): boolean {
-  console.debug(`Evaluating removability for runner: ${ec2runner.instanceId}`);
-
   /* istanbul ignore next */
   if (ec2runner.instanceManagement?.toLowerCase() === 'pet') {
     console.debug(`Runner ${ec2runner.instanceId} is a pet instance and cannot be removed.`);
@@ -468,7 +466,7 @@ export function isRunnerRemovable(
  */
 export function runnerMinimumTimeExceeded(runner: RunnerInfo): boolean {
   let baseTime: moment.Moment;
-  let reason = '';
+  let reason: string;
   if (runner.ephemeralRunnerFinished !== undefined) {
     baseTime = moment.unix(runner.ephemeralRunnerFinished);
     reason = `is an ephemeral runner that finished at ${baseTime}`;

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -349,20 +349,28 @@ export async function getGHRunnerRepo(ec2runner: RunnerInfo, metrics: ScaleDownM
     }
   }
 
-  if (ghRunner === undefined && ec2runner.ghRunnerId !== undefined) {
-    console.warn(
-      `Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}](${repo}) not found in ` +
-        `listGithubRunnersRepo call, attempting to grab directly`,
-    );
-    try {
-      ghRunner = await getRunnerRepo(repo, ec2runner.ghRunnerId, metrics);
-    } catch (e) {
+  if (ghRunner === undefined) {
+    if (ec2runner.ghRunnerId == undefined) {
       console.warn(
-        `Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}](${repo}) error when getRunnerRepo call: ${e}`,
+        `Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}](${repo}) not found in ` +
+          `listGithubRunnersRepo call, and it did not have the GithubRunnerId EC2 tag set.  This ` +
+          `can happen if there's no runner running on the instance.`,
       );
-      /* istanbul ignore next */
-      if (isGHRateLimitError(e)) {
-        throw e;
+    } else {
+      console.warn(
+        `Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}](${repo}) not found in ` +
+          `listGithubRunnersRepo call, attempting to grab directly`,
+      );
+      try {
+        ghRunner = await getRunnerRepo(repo, ec2runner.ghRunnerId, metrics);
+      } catch (e) {
+        console.warn(
+          `Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}](${repo}) error when getRunnerRepo call: ${e}`,
+        );
+        /* istanbul ignore next */
+        if (isGHRateLimitError(e)) {
+          throw e;
+        }
       }
     }
   }
@@ -424,32 +432,65 @@ export function isRunnerRemovable(
   ec2runner: RunnerInfo,
   metrics: ScaleDownMetrics,
 ): boolean {
+  console.debug(`Evaluating removability for runner: ${ec2runner.instanceId}`);
+
   /* istanbul ignore next */
   if (ec2runner.instanceManagement?.toLowerCase() === 'pet') {
+    console.debug(`Runner ${ec2runner.instanceId} is a pet instance and cannot be removed.`);
     return false;
   }
+
   if (ghRunner !== undefined && ghRunner.busy) {
+    console.debug(`Runner ${ec2runner.instanceId} is busy and cannot be removed.`);
     return false;
   }
+
   if (!runnerMinimumTimeExceeded(ec2runner)) {
+    console.debug(`Runner ${ec2runner.instanceId} has not exceeded the minimum running time.`);
     metrics.runnerLessMinimumTime(ec2runner);
     return false;
   }
+
+  if (ghRunner === undefined) {
+    console.debug(`Runner ${ec2runner.instanceId} was not found on GitHub. It might not be running an agent`);
+  }
+
+  console.debug(`Runner ${ec2runner.instanceId} is removable.`);
   metrics.runnerIsRemovable(ec2runner);
   return true;
 }
 
+/**
+ * Determines if the runner has been provisioned for at least the minimum running time configured.
+ * This is used to allow runners to stay idle for a certain amount of time in case they pick up
+ * extra jobs, and to avoid the case where a runner is provisioned and then immediately scaled down.
+ * The limit gives us some buffer room while avoiding unnecessary costs.
+ */
 export function runnerMinimumTimeExceeded(runner: RunnerInfo): boolean {
   let baseTime: moment.Moment;
+  let reason = '';
   if (runner.ephemeralRunnerFinished !== undefined) {
     baseTime = moment.unix(runner.ephemeralRunnerFinished);
+    reason = `is an ephemeral runner that finished at ${baseTime}`;
   } else if (runner.ebsVolumeReplacementRequestTimestamp !== undefined) {
     baseTime = moment.unix(runner.ebsVolumeReplacementRequestTimestamp);
+    reason = `had an EBS volume replacement request started at ${baseTime}`;
   } else {
     baseTime = moment(runner.launchTime || new Date()).utc();
+    reason = `was launched at ${baseTime}`;
   }
+
   const maxTime = moment(new Date()).subtract(Config.Instance.minimumRunningTimeInMinutes, 'minutes').utc();
-  return baseTime < maxTime;
+  const minTimeExceeded = baseTime < maxTime;
+  if (minTimeExceeded) {
+    console.debug(
+      `[runnerMinimumTimeExceeded] Instance ${runner.instanceId} ${reason} and has ` +
+      `exceeded the minimum running time of ${Config.Instance.minimumRunningTimeInMinutes} mins ` +
+      `by ${maxTime.diff(baseTime, 'minutes')} mins.`
+    );
+  }
+
+  return minTimeExceeded;
 }
 
 export function sortRunnersByLaunchTime(runners: RunnerInfo[]): RunnerInfo[] {

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -485,8 +485,8 @@ export function runnerMinimumTimeExceeded(runner: RunnerInfo): boolean {
   if (minTimeExceeded) {
     console.debug(
       `[runnerMinimumTimeExceeded] Instance ${runner.instanceId} ${reason} and has ` +
-      `exceeded the minimum running time of ${Config.Instance.minimumRunningTimeInMinutes} mins ` +
-      `by ${maxTime.diff(baseTime, 'minutes')} mins.`
+        `exceeded the minimum running time of ${Config.Instance.minimumRunningTimeInMinutes} mins ` +
+        `by ${maxTime.diff(baseTime, 'minutes')} mins.`,
     );
   }
 


### PR DESCRIPTION
Add logging to better be able to track why scale down events occurred.

Specifically tracks the following kinds of issues:
* Calls out the exact reason why a runner might be considered idle for long enough to be decomissioned
* Highlights if an active runner's EC2 instance is somehow lacking EC2 tags that mark it as being active

Part of follow up to sev https://github.com/pytorch/pytorch/issues/151669