### PR TITLE
Double-check runner status when it is free with different API using GHA API runner id

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -344,7 +344,7 @@ export async function getGHRunnerOrg(
     try {
       const ghLimitInfo = await getGitHubRateLimit({ owner: org, repo: '' }, metrics);
       metrics.gitHubRateLimitStats(ghLimitInfo.limit, ghLimitInfo.remaining, ghLimitInfo.used);
-      if (ghLimitInfo.remaining > ghLimitInfo.limit * 0.3) {
+      if (ghLimitInfo.remaining > ghLimitInfo.limit * 0.4) {
         console.debug(
           `Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}](${org}) - We have enough GHA API quotas` +
             ` to call the API and double-check runner status by grabbing it directly. ` +
@@ -465,7 +465,7 @@ export async function getGHRunnerRepo(
     try {
       const ghLimitInfo = await getGitHubRateLimit(repo, metrics);
       metrics.gitHubRateLimitStats(ghLimitInfo.limit, ghLimitInfo.remaining, ghLimitInfo.used);
-      if (ghLimitInfo.remaining > ghLimitInfo.limit * 0.3) {
+      if (ghLimitInfo.remaining > ghLimitInfo.limit * 0.4) {
         console.debug(
           `Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}](${repo}) - We have enough GHA API quotas` +
             ` to call the API and double-check runner status by grabbing it directly. ` +


### PR DESCRIPTION
We recently [had a CI:SEV](https://github.com/pytorch/pytorch/issues/151669) in our infra due to what we suspect to be outdated information present in gha api.

During the discussion we evaluated the very small risk of having slightly outdated information (< 50 seconds) for the status of some runners and how this could potentially cause in rare edge cases the termination of busy workers. This was not the cause of the issue we experienced, but the edge case bug exists and during the discussion we concluded that this change could potentially be another thing that might prevent similar issues in the future.

This change introduces the following behaviour change for scaleDown:

Before terminate a runner, the ones that are free are double-checked by performing a GHA API request by runner id. This is ignored in case we're running low in GHA API quotas. If we can't perform the request and double-check, we assume the runner to be busy.

A quick analysis of the numbers concludes that we're probably OK if we use up to 75% of the quota for this check (what would be very unlikely to happen). We decided to play safe and consider a 60% margin just in case.