### PR TITLE
[HUD] Hack for rerun disable tests and mem leak regex

### DIFF
--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -33,6 +33,7 @@ const GROUP_OTHER = "other";
 export const groups = [
   {
     // Weird regex because some names are too long and getting cut off
+    // TODO: figure out a better way to name the job or filter them
     regex: /, mem_leak/,
     name: GROUP_MEMORY_LEAK_CHECK,
     persistent: true,

--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -32,12 +32,13 @@ const GROUP_OTHER = "other";
 // Jobs will be grouped with the first regex they match in this list
 export const groups = [
   {
-    regex: /mem_leak_check/,
+    // Weird regex because some names are too long and getting cut off
+    regex: /, mem_leak/,
     name: GROUP_MEMORY_LEAK_CHECK,
     persistent: true,
   },
   {
-    regex: /rerun_disabled_tests/,
+    regex: /, rerun_/,
     name: GROUP_RERUN_DISABLED_TESTS,
     persistent: true,
   },


### PR DESCRIPTION
The job name is so long its getting cut off 
<img width="1041" alt="image" src="https://github.com/user-attachments/assets/692e07ea-eb36-45a0-a5ab-b5dd0bead284" />
so the regex is returning false.

This is a bad hack which I figure out what to do with the job name so I don't have to stare at those jobs in the normal periodic group of the hud page