### PR TITLE
[hud][ch] fix query_execution_metrics page

### DIFF
--- a/clickhouse_db_schema/all_query_logs/schema.sql
+++ b/clickhouse_db_schema/all_query_logs/schema.sql
@@ -1,0 +1,2 @@
+CREATE TABLE all_query_logs
+ENGINE = Merge('system', '^query_log(_\\d+)?$');

--- a/torchci/clickhouse_queries/query_execution_metrics/query.sql
+++ b/torchci/clickhouse_queries/query_execution_metrics/query.sql
@@ -8,9 +8,15 @@ SELECT
     count(*) as num,
     left(query_id, -37) as name
 FROM
-    clusterAllReplicas(default, system.query_log)
+    clusterAllReplicas(default, default.all_query_logs)
 where
-    event_time >= {startTime: DateTime64(3)}
+    -- for partitioned tables
+    toYYYYMM(event_date) >= toYYYYMM({startTime: DateTime64(3)})
+    and toYYYYMM(event_date) <= toYYYYMM({stopTime: DateTime64(3)})
+    -- utilize the table ordering
+    and event_date >= toDate({startTime: DateTime64(3)})
+    and event_date <= toDate({stopTime: DateTime64(3)})
+    and event_time >= {startTime: DateTime64(3)}
     and event_time < {stopTime: DateTime64(3)}
     and initial_user = 'hud_user'
     and length(query_id) > 37

--- a/torchci/clickhouse_queries/query_execution_metrics_individual/query.sql
+++ b/torchci/clickhouse_queries/query_execution_metrics_individual/query.sql
@@ -8,9 +8,15 @@ SELECT
     quantile(0.5)(memory_usage) as memoryBytesP50,
     count(*) as num
 FROM
-    clusterAllReplicas(default, system.query_log)
+    clusterAllReplicas(default, default.all_query_logs)
 where
-    event_time >= {startTime: DateTime64(3)}
+    -- for partitioned tables
+    toYYYYMM(event_date) >= toYYYYMM({startTime: DateTime64(3)})
+    and toYYYYMM(event_date) <= toYYYYMM({stopTime: DateTime64(3)})
+    -- utilize the table ordering
+    and event_date >= toDate({startTime: DateTime64(3)})
+    and event_date <= toDate({stopTime: DateTime64(3)})
+    and event_time >= {startTime: DateTime64(3)}
     and event_time < {stopTime: DateTime64(3)}
     and initial_user = 'hud_user'
     and length(query_id) > 37


### PR DESCRIPTION
Currently [query execution metrics](https://hud.pytorch.org/query_execution_metrics) hud page shows only a couple of previous days, regardless of date range selected. This happens because in CH query log data is spread across multiple query_log tables with numeric suffix:
<img width="203" alt="image" src="https://github.com/user-attachments/assets/44e03730-310e-4110-9423-1608b879bfe0" />
(apparently CH create a new table when the schema changes)

The solution is to create a special "merge" table:
```
CREATE TABLE all_query_logs
ENGINE = Merge('system', '^query_log(_\\d+)?$');
```
and query it instead.

This ephemeral table queries all the underlying tables under the hood and merges the results.

This is not a big performance hit, as I also added correct filters (matching partitioning and table order), so only relevant data is touched.