### PR TITLE
[hud][ch][drci] add api to cache ch queries + cache issues query

### DIFF
--- a/tools/scripts/fetch_latest_green_commit.py
+++ b/tools/scripts/fetch_latest_green_commit.py
@@ -83,7 +83,7 @@ def get_commit_results(
 
 @lru_cache
 def fetch_unstable_issues() -> List[str]:
-    issues = query_clickhouse_saved("issue_query", {"label": "unstable"})
+    issues = query_clickhouse_saved("issue_query", {"label": "unstable"}, useChQueryCache=True)
     return [
         issue["title"][len("UNSTABLE") :].strip()
         for issue in issues

--- a/tools/scripts/fetch_latest_green_commit.py
+++ b/tools/scripts/fetch_latest_green_commit.py
@@ -83,7 +83,9 @@ def get_commit_results(
 
 @lru_cache
 def fetch_unstable_issues() -> List[str]:
-    issues = query_clickhouse_saved("issue_query", {"label": "unstable"}, useChQueryCache=True)
+    issues = query_clickhouse_saved(
+        "issue_query", {"label": "unstable"}, useChQueryCache=True
+    )
     return [
         issue["title"][len("UNSTABLE") :].strip()
         for issue in issues

--- a/tools/torchci/clickhouse.py
+++ b/tools/torchci/clickhouse.py
@@ -1,14 +1,15 @@
 import json
 import os
 from functools import lru_cache
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import clickhouse_connect
+from clickhouse_connect.driver import Client
 from torchci.utils import cache_json, REPO_ROOT
 
 
 @lru_cache(maxsize=1)
-def get_clickhouse_client() -> Any:
+def get_clickhouse_client() -> Client:
     endpoint = os.environ["CLICKHOUSE_ENDPOINT"]
     # I cannot figure out why these values aren't being handled automatically
     # when it is fine in the lambda
@@ -26,7 +27,14 @@ def get_clickhouse_client() -> Any:
     )
 
 
-def query_clickhouse_saved(queryName: str, inputParams: Dict[str, Any]) -> Any:
+def query_clickhouse_saved(
+    queryName: str, inputParams: Dict[str, Any], useChQueryCache=False
+) -> Any:
+    """
+    Queries ClickHouse using a saved query file and parameters.
+    :param useChQueryCache: If True, caches the query result on ClickHouse side (1 minute TTL).
+    :return:
+    """
     path = REPO_ROOT / "torchci" / "clickhouse_queries" / queryName
     with open(path / "query.sql") as f:
         queryText = f.read()
@@ -34,15 +42,24 @@ def query_clickhouse_saved(queryName: str, inputParams: Dict[str, Any]) -> Any:
         paramsText = json.load(f).get("params", {})
 
     queryParams = {name: inputParams[name] for name in paramsText}
-    return query_clickhouse(queryText, queryParams)
+    return query_clickhouse(
+        queryText, queryParams, use_ch_query_cache=useChQueryCache
+    )
 
 
 def query_clickhouse(
-    query: str, params: Dict[str, Any], use_cache: bool = False
+    query: str,
+    params: Dict[str, Any],
+    use_cache: bool = False,
+    use_ch_query_cache=False,
 ) -> Any:
     """
     Queries ClickHouse.  Returns datetime in YYYY-MM-DD HH:MM:SS format.
+    :param use_ch_query_cache: If True, uses ClickHouse's query cache (1 minute TTL).
     """
+    settings = None
+    if use_ch_query_cache:
+        settings = {"use_query_cache": 1}
 
     def convert_to_json_list(res: str) -> List[Dict[str, Any]]:
         rows = []
@@ -52,13 +69,19 @@ def query_clickhouse(
         return rows
 
     if not use_cache:
-        res = get_clickhouse_client().raw_query(query, params, fmt="JSONEachRow")
+        res = get_clickhouse_client().raw_query(
+            query, params, settings=settings, fmt="JSONEachRow"
+        )
         return convert_to_json_list(res)
     else:
 
         @cache_json
-        def cache_query_clickhouse(query, params):
-            res = get_clickhouse_client().raw_query(query, params, fmt="JSONEachRow")
+        def cache_query_clickhouse(
+            query, params, settings: Optional[Dict[str, Any]] = None
+        ) -> Any:
+            res = get_clickhouse_client().raw_query(
+                query, params, settings=settings, fmt="JSONEachRow"
+            )
             return convert_to_json_list(res)
 
-        return cache_query_clickhouse(query, params)
+        return cache_query_clickhouse(query, params, settings)

--- a/tools/torchci/clickhouse.py
+++ b/tools/torchci/clickhouse.py
@@ -42,9 +42,7 @@ def query_clickhouse_saved(
         paramsText = json.load(f).get("params", {})
 
     queryParams = {name: inputParams[name] for name in paramsText}
-    return query_clickhouse(
-        queryText, queryParams, use_ch_query_cache=useChQueryCache
-    )
+    return query_clickhouse(queryText, queryParams, use_ch_query_cache=useChQueryCache)
 
 
 def query_clickhouse(

--- a/tools/torchci/tests/test_ch_query.py
+++ b/tools/torchci/tests/test_ch_query.py
@@ -9,6 +9,7 @@ from torchci.clickhouse import (
     query_clickhouse_saved,
 )
 
+
 # This test is intended to run locally against a real ClickHouse instance
 # Provide the necessary environment variables (e.g., in a .env file)
 class TestClickhouseQueries(unittest.TestCase):
@@ -129,16 +130,12 @@ class TestClickhouseQueries(unittest.TestCase):
 
         # First call with timing
         start_time = time.time()
-        results1 = query_clickhouse_saved(
-            "issue_query", params, useChQueryCache=True
-        )
+        results1 = query_clickhouse_saved("issue_query", params, useChQueryCache=True)
         first_call_time = time.time() - start_time
 
         # Second call with timing
         start_time = time.time()
-        results2 = query_clickhouse_saved(
-            "issue_query", params, useChQueryCache=True
-        )
+        results2 = query_clickhouse_saved("issue_query", params, useChQueryCache=True)
         second_call_time = time.time() - start_time
 
         # Print timing information

--- a/tools/torchci/tests/test_ch_query.py
+++ b/tools/torchci/tests/test_ch_query.py
@@ -1,0 +1,197 @@
+import os
+import time
+import unittest
+
+from dotenv import load_dotenv
+from torchci.clickhouse import (
+    get_clickhouse_client,
+    query_clickhouse,
+    query_clickhouse_saved,
+)
+
+# This test is intended to run locally against a real ClickHouse instance
+# Provide the necessary environment variables (e.g., in a .env file)
+class TestClickhouseQueries(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        load_dotenv()
+        # Check if ClickHouse credentials are available
+        cls.can_run = all(
+            env_var in os.environ
+            for env_var in [
+                "CLICKHOUSE_ENDPOINT",
+                "CLICKHOUSE_USERNAME",
+                "CLICKHOUSE_PASSWORD",
+            ]
+        )
+        if not cls.can_run:
+            print("Skipping ClickHouse tests: required environment variables not set")
+        else:
+            # Test connection before running tests
+            try:
+                client = get_clickhouse_client()
+                # Simple query to check connection
+                client.query("SELECT 1")
+                cls.can_run = True
+            except Exception as e:
+                print(f"ClickHouse connection failed: {e}")
+                cls.can_run = False
+
+    def setUp(self):
+        """Skip tests if ClickHouse is not available"""
+        if not self.can_run:
+            self.skipTest(
+                "ClickHouse environment variables not set or connection failed"
+            )
+
+    def test_simple_query_no_cache(self):
+        """Test a simple SELECT 1 query without cache"""
+        query = "SELECT 1 AS value"
+        results = query_clickhouse(query, {}, use_cache=False)
+
+        self.assertIsInstance(results, list)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["value"], 1)
+
+    def test_simple_query_with_cache(self):
+        """Test a simple SELECT 1 query with cache"""
+        query = "SELECT 1 AS value"
+
+        # First call should hit database
+        start_time = time.time()
+        results1 = query_clickhouse(query, {}, use_cache=True)
+        first_call_time = time.time() - start_time
+
+        # Second call should use cache
+        start_time = time.time()
+        results2 = query_clickhouse(query, {}, use_cache=True)
+        second_call_time = time.time() - start_time
+
+        # Both should return same result
+        self.assertEqual(results1, results2)
+        self.assertEqual(results1[0]["value"], 1)
+
+        # Second call should be faster or similar (allowing for measurement noise)
+        # We don't assert on exact timing as it depends on many factors
+        print(
+            f"First call: {first_call_time:.6f}s, Second call: {second_call_time:.6f}s"
+        )
+
+    def test_simple_query_with_clickhouse_cache(self):
+        """Test a simple query with ClickHouse's query cache"""
+        query = "SELECT 1 AS value"
+
+        # First call
+        results1 = query_clickhouse(query, {}, use_ch_query_cache=True)
+
+        # Second call
+        results2 = query_clickhouse(query, {}, use_ch_query_cache=True)
+
+        # Both should return same result
+        self.assertEqual(results1, results2)
+        self.assertEqual(results1[0]["value"], 1)
+
+    def test_parameterized_query(self):
+        """Test a query with parameters"""
+        query = "SELECT {value:UInt8} AS value"
+        params = {"value": 42}
+
+        results = query_clickhouse(query, params)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["value"], 42)
+
+    def test_saved_query(self):
+        """Test using a saved query (issue_query)"""
+        try:
+            results = query_clickhouse_saved("issue_query", {"label": "flaky"})
+            self.assertIsInstance(results, list)
+
+            # Check structure of results based on query.sql
+            if results:
+                expected_columns = [
+                    "number",
+                    "title",
+                    "html_url",
+                    "state",
+                    "body",
+                    "updated_at",
+                    "author_association",
+                    "labels",
+                ]
+                for col in expected_columns:
+                    self.assertIn(col, results[0], f"Missing expected column: {col}")
+        except Exception as e:
+            self.fail(f"Saved query test failed with: {e}")
+
+    def test_saved_query_with_cache(self):
+        """Test saved query with cache"""
+        params = {"label": "bug"}
+
+        # First call with timing
+        start_time = time.time()
+        results1 = query_clickhouse_saved(
+            "issue_query", params, useChQueryCache=True
+        )
+        first_call_time = time.time() - start_time
+
+        # Second call with timing
+        start_time = time.time()
+        results2 = query_clickhouse_saved(
+            "issue_query", params, useChQueryCache=True
+        )
+        second_call_time = time.time() - start_time
+
+        # Print timing information
+        print(
+            f"Saved query - First call: {first_call_time:.6f}s, Second call: {second_call_time:.6f}s"
+        )
+        print(
+            f"Speedup ratio: {first_call_time/second_call_time if second_call_time > 0 else 'inf':.2f}x"
+        )
+
+        # Both should return same data structure
+        self.assertEqual(type(results1), type(results2))
+
+        # Verify the results are identical (same number of rows)
+        self.assertEqual(
+            len(results1),
+            len(results2),
+            "Cached query returned different number of results",
+        )
+
+        # If we got results, check they match expected structure based on query.sql
+        if results1:
+            expected_columns = [
+                "number",
+                "title",
+                "html_url",
+                "state",
+                "body",
+                "updated_at",
+                "author_association",
+                "labels",
+            ]
+            for col in expected_columns:
+                self.assertIn(col, results1[0], f"Missing expected column: {col}")
+
+            # Verify the labels array contains the search parameter
+            if results1[0]["labels"]:
+                # At least one issue should have the label we searched for
+                found_label = False
+                for issue in results1:
+                    if any(label == params["label"] for label in issue["labels"]):
+                        found_label = True
+                        break
+                self.assertTrue(
+                    found_label,
+                    f"Couldn't find any issue with label '{params['label']}'",
+                )
+            else:
+                # If there are no labels, the test will pass but we'll print a warning
+                print(
+                    "Warning: No labels found in results, can't verify label filtering"
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchci/lib/clickhouse.ts
+++ b/torchci/lib/clickhouse.ts
@@ -30,7 +30,8 @@ export function getClickhouseClientWritable() {
 export async function queryClickhouse(
   query: string,
   params: Record<string, unknown>,
-  query_id?: string
+  query_id?: string,
+  useQueryCache?: boolean
 ): Promise<any[]> {
   if (query_id === undefined) {
     query_id = "adhoc";
@@ -41,6 +42,7 @@ export async function queryClickhouse(
    * queryClickhouse
    * @param query: string, the sql query
    * @param params: Record<string, unknown>, the parameters to the query ex { sha: "abcd" }
+   * @param useQueryCache: boolean, if true, cache the query result on Ch side (1 minute TTL)
    */
   const clickhouseClient = getClickhouseClient();
 
@@ -51,6 +53,7 @@ export async function queryClickhouse(
     clickhouse_settings: {
       output_format_json_quote_64bit_integers: 0,
       date_time_output_format: "iso",
+      use_query_cache: useQueryCache ? 1 : 0,
     },
     query_id,
   });
@@ -60,12 +63,14 @@ export async function queryClickhouse(
 
 export async function queryClickhouseSaved(
   queryName: string,
-  inputParams: Record<string, unknown>
+  inputParams: Record<string, unknown>,
+  useQueryCache?: boolean
 ) {
   /**
    * queryClickhouseSaved
    * @param queryName: string, the name of the query, which is the name of the folder in clickhouse_queries
    * @param inputParams: Record<string, unknown>, the parameters to the query, an object where keys are the parameter names
+   * @param useQueryCache: boolean, if true, cache the query result on Ch side (1 minute TTL)
    *
    * This function will filter the inputParams to only include the parameters
    * that are in the query params json file.
@@ -90,6 +95,7 @@ export async function queryClickhouseSaved(
   return await thisModule.queryClickhouse(
     query,
     Object.fromEntries(queryParams),
-    queryName
+    queryName,
+    useQueryCache
   );
 }

--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -204,7 +204,7 @@ export async function upsertDrCiComment(
   );
   const existingDrciID = existingDrciData.id;
   const existingDrciComment = existingDrciData.body;
-  const sev = getActiveSEVs(await fetchIssuesByLabel("ci: sev"));
+  const sev = getActiveSEVs(await fetchIssuesByLabel("ci: sev", /*cache*/true));
   const drciComment = formDrciComment(
     prNum,
     owner,

--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -204,7 +204,9 @@ export async function upsertDrCiComment(
   );
   const existingDrciID = existingDrciData.id;
   const existingDrciComment = existingDrciData.body;
-  const sev = getActiveSEVs(await fetchIssuesByLabel("ci: sev", /*cache*/true));
+  const sev = getActiveSEVs(
+    await fetchIssuesByLabel("ci: sev", /*cache*/ true)
+  );
   const drciComment = formDrciComment(
     prNum,
     owner,

--- a/torchci/lib/fetchHud.ts
+++ b/torchci/lib/fetchHud.ts
@@ -83,7 +83,7 @@ export default async function fetchHud(
     results = results?.filter((job: JobData) => !isRerunDisabledTestsJob(job));
   }
   if (params.filter_unstable) {
-    const unstableIssues = await fetchIssuesByLabel("unstable");
+    const unstableIssues = await fetchIssuesByLabel("unstable", /*cache*/ true);
     results = results?.filter(
       (job: JobData) => !isUnstableJob(job, unstableIssues ?? [])
     );

--- a/torchci/lib/fetchIssuesByLabel.ts
+++ b/torchci/lib/fetchIssuesByLabel.ts
@@ -2,9 +2,10 @@ import { queryClickhouseSaved } from "./clickhouse";
 import { IssueData } from "./types";
 
 export default async function fetchIssuesByLabel(
-  label: string
+  label: string,
+  useChCache?: boolean
 ): Promise<IssueData[]> {
   return await queryClickhouseSaved("issue_query", {
     label,
-  });
+  }, useChCache);
 }

--- a/torchci/lib/fetchIssuesByLabel.ts
+++ b/torchci/lib/fetchIssuesByLabel.ts
@@ -5,7 +5,11 @@ export default async function fetchIssuesByLabel(
   label: string,
   useChCache?: boolean
 ): Promise<IssueData[]> {
-  return await queryClickhouseSaved("issue_query", {
-    label,
-  }, useChCache);
+  return await queryClickhouseSaved(
+    "issue_query",
+    {
+      label,
+    },
+    useChCache
+  );
 }

--- a/torchci/package.json
+++ b/torchci/package.json
@@ -17,7 +17,7 @@
     "@aws-sdk/client-dynamodb": "^3.347.1",
     "@aws-sdk/client-s3": "^3.347.1",
     "@aws-sdk/lib-dynamodb": "^3.72.0",
-    "@clickhouse/client": "^0.1.0",
+    "@clickhouse/client": "^1.11.1",
     "@codemirror/basic-setup": "^0.20.0",
     "@codemirror/state": "^0.20.0",
     "@codemirror/theme-one-dark": "^0.20.0",

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -136,10 +136,18 @@ export async function updateDrciComments(
   );
   const head = get_head_branch(repo);
   await addMergeBaseCommits(octokit, repo, head, workflowsByPR);
-  const sevs = getActiveSEVs(await fetchIssuesByLabel("ci: sev", /*cache*/ true));
+  const sevs = getActiveSEVs(
+    await fetchIssuesByLabel("ci: sev", /*cache*/ true)
+  );
   const flakyRules: FlakyRule[] = (await fetchJSON(FLAKY_RULES_JSON)) || [];
-  const unstableIssues: IssueData[] = await fetchIssuesByLabel("unstable", /*cache*/ true);
-  const disabledTestIssues: IssueData[] = await fetchIssuesByLabel("skipped", /*cache*/ true);
+  const unstableIssues: IssueData[] = await fetchIssuesByLabel(
+    "unstable",
+    /*cache*/ true
+  );
+  const disabledTestIssues: IssueData[] = await fetchIssuesByLabel(
+    "skipped",
+    /*cache*/ true
+  );
   const baseCommitJobs = await getBaseCommitJobs(workflowsByPR);
   const existingDrCiComments = await getExistingDrCiComments(
     `${OWNER}/${repo}`,

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -136,10 +136,10 @@ export async function updateDrciComments(
   );
   const head = get_head_branch(repo);
   await addMergeBaseCommits(octokit, repo, head, workflowsByPR);
-  const sevs = getActiveSEVs(await fetchIssuesByLabel("ci: sev"));
+  const sevs = getActiveSEVs(await fetchIssuesByLabel("ci: sev", /*cache*/ true));
   const flakyRules: FlakyRule[] = (await fetchJSON(FLAKY_RULES_JSON)) || [];
-  const unstableIssues: IssueData[] = await fetchIssuesByLabel("unstable");
-  const disabledTestIssues: IssueData[] = await fetchIssuesByLabel("skipped");
+  const unstableIssues: IssueData[] = await fetchIssuesByLabel("unstable", /*cache*/ true);
+  const disabledTestIssues: IssueData[] = await fetchIssuesByLabel("skipped", /*cache*/ true);
   const baseCommitJobs = await getBaseCommitJobs(workflowsByPR);
   const existingDrCiComments = await getExistingDrCiComments(
     `${OWNER}/${repo}`,

--- a/torchci/yarn.lock
+++ b/torchci/yarn.lock
@@ -1372,12 +1372,17 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@clickhouse/client@^0.1.0":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@clickhouse/client/-/client-0.1.1.tgz#1a848438baf5deefadf7dcee40ad441c8666c398"
-  integrity sha512-oeALCAjNFEXHPxMHJgj0QERiLM2ZknOOavvHB1mxmztZLhTuj86HaQEfh9q8x7LgKnv3jep7lb/fhFgD71WTjA==
+"@clickhouse/client-common@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@clickhouse/client-common/-/client-common-1.11.1.tgz#73a78165656f6e058e2d4eb09cce0f9cf6195255"
+  integrity sha512-bme0le2yhDSAh13d2fxhSW5ZrNoVqZ3LTyac8jK6hNH0qkksXnjYkLS6KQalPU6NMpffxHmpI4+/Gi2MnX0NCA==
+
+"@clickhouse/client@^1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@clickhouse/client/-/client-1.11.1.tgz#a8f7a7ff891bfc5181601d027c9b5230be5f0484"
+  integrity sha512-u9h++h72SmWystijNqfNvMkfA+5+Y1LNfmLL/odCL3VgI3oyAPP9ubSw/Yrt2zRZkLKehMMD1kuOej0QHbSoBA==
   dependencies:
-    uuid "^9.0.0"
+    "@clickhouse/client-common" "1.11.1"
 
 "@codemirror/autocomplete@^0.20.0":
   version "0.20.0"
@@ -8987,11 +8992,6 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-uuid@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 uvu@^0.5.0:
   version "0.5.6"


### PR DESCRIPTION
As evident from the [hud](https://hud.pytorch.org/query_execution_metrics), issues_query is biggest cumulative time and memory hoggers, simply because it runs too frequently (≈27 times / minute)
<img width="2329" alt="image" src="https://github.com/user-attachments/assets/28c46f90-0ebf-49d7-9601-3e83a544b3f4" />

Since there are only three parameter values that dominate the executions:
    - ci: sev 
    - skipped
    - unstable

it makes sense to cache this query.


This PR:
* adds parameter to our ch apis to `use_query_cache` (1 minute TTL by default)
* adds a python test (intended to be run locally, as we don't expose CH credentials in CI)
* caches `issues_query` in several places
* updates the ch client node package (the old one didn't expose `use_query_cache`)


---

The intended effect of using query cache is to drop time and memory to 0 for cache hits.
