### PR TITLE
Add device type (public, private) and id

### DIFF
--- a/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
@@ -211,7 +211,18 @@ get_labels_from_config() {
     esac
     shift
   done
-  echo $target | sed 's/,/\n/g'
+
+  set +e
+  # Masquerade an ephemeral runner as non-ephemeral one
+  for label in $(echo $target | sed 's/,/ /g')
+  do
+    echo $label
+    if [[ $label == *ephemeral.* ]]; then
+      label_wo_ephemeral=$(echo $label | sed 's/ephemeral.//g')
+      echo $label_wo_ephemeral
+    fi
+  done
+  set -e
 }
 
 cd /home/$USER_NAME

--- a/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
@@ -213,7 +213,7 @@ get_labels_from_config() {
   done
 
   set +e
-  # Masquerade an ephemeral runner as non-ephemeral one
+  # Masquerade an ephemeral runner as a non-ephemeral one
   for label in $(echo $target | sed 's/,/ /g')
   do
     echo $label

--- a/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
@@ -211,18 +211,7 @@ get_labels_from_config() {
     esac
     shift
   done
-
-  set +e
-  # Masquerade an ephemeral runner as non-ephemeral one
-  for label in $(echo $target | sed 's/,/ /g')
-  do
-    echo $label
-    if [[ $label == *ephemeral.* ]]; then
-      label_wo_ephemeral=$(echo $label | sed 's/ephemeral.//g')
-      echo $label_wo_ephemeral
-    fi
-  done
-  set -e
+  echo $target | sed 's/,/\n/g'
 }
 
 cd /home/$USER_NAME

--- a/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/install-config-runner.sh
@@ -213,7 +213,7 @@ get_labels_from_config() {
   done
 
   set +e
-  # Masquerade an ephemeral runner as a non-ephemeral one
+  # Masquerade an ephemeral runner as non-ephemeral one
   for label in $(echo $target | sed 's/,/ /g')
   do
     echo $label

--- a/tools/device-farm-runner/run_on_aws_devicefarm.py
+++ b/tools/device-farm-runner/run_on_aws_devicefarm.py
@@ -429,6 +429,8 @@ class DeviceFarmReport:
 @dataclass
 class JobReport(DeviceFarmReport):
     os: str
+    instance_arn: Optional[str]
+    is_private_instance: bool
 
 
 class ReportProcessor:
@@ -555,6 +557,16 @@ class ReportProcessor:
         result = report.get("result", "")
         counters = report.get("counters", "{}")
         os = report.get("device", {}).get("os", "")
+
+        fleet_type = report.get("device", {}).get("fleetType", "")
+        is_private_instance = True if fleet_type == "PRIVATE" else False
+
+        # NB: When running on a private device, AWS set the field instanceArn pointing
+        # to that device
+        instance_arn = report.get(
+            "instanceArn", report.get("device", {}).get("arn", "")
+        )
+
         return JobReport(
             arn=arn,
             name=name,
@@ -566,6 +578,8 @@ class ReportProcessor:
             counters=counters,
             infos=infos,
             os=os,
+            instance_arn=instance_arn,
+            is_private_instance=is_private_instance,
         )
 
     def _to_run_report(self, report: Dict[str, Any], infos: Dict[str, str] = dict()):


### PR DESCRIPTION
Adding 2 new fields in the job report:

* `is_private_instance`
* and `instance_arn`.  AFAICT, this field is only available for private devices and it contains the device ID showing on AWS