### PR TITLE
[ch] optimize master_commit_red_percent query

### DIFF
--- a/torchci/clickhouse_queries/master_commit_red_percent/params.json
+++ b/torchci/clickhouse_queries/master_commit_red_percent/params.json
@@ -5,5 +5,24 @@
     "stopTime": "DateTime64(3)",
     "workflowNames": "Array(String)"
   },
-  "tests": []
+  "tests": [
+    {
+      "granularity": "day",
+      "startTime": "2025-03-18T21:09:47.987",
+      "stopTime": "2025-03-25T21:09:47.987",
+      "workflowNames": ["lint", "pull", "trunk"]
+    },
+    {
+      "granularity": "day",
+      "startTime": "2025-03-18T21:09:47.987",
+      "stopTime": "2025-05-25T21:09:47.987",
+      "workflowNames": ["lint", "pull", "trunk"]
+    },
+    {
+      "granularity": "day",
+      "startTime": "2025-03-24T00:00:00.000",
+      "stopTime": "2025-03-25T00:00:00.000",
+      "workflowNames": ["pull"]
+    }
+  ]
 }


### PR DESCRIPTION
perf:
```
./clickhouse_query_perf.py --query master_commit_red_percent  --perf --times 1 --base HEAD

+------+----------+-----------+-------------+---------------+-----------+------------+-------------+--------------+
| Test | Avg Time | Base Time | Time Change | % Time Change |  Avg Mem  |  Base Mem  |  Mem Change | % Mem Change |
+------+----------+-----------+-------------+---------------+-----------+------------+-------------+--------------+
|  0   |   1164   |    5585   |    -4421    |      -79      | 160555724 | 7544036697 | -7383480973 |     -98      |
|  1   |   2992   |    5483   |    -2491    |      -45      | 516092615 | 7858494950 | -7342402335 |     -93      |
+------+----------+-----------+-------------+---------------+-----------+------------+-------------+--------------+
```

Removes expensive join, improves the pre-filtering utilizing a materialized view.



### Testing

The new query in some cases returns slightly different results for `broken_trunk_red` metrics (although results for `all_red` metric are identical), which leads me to conclude that partitioning:

```
 ROW_NUMBER() OVER(
            PARTITION BY j.name,
            j.head_sha
            ORDER BY
                j.run_attempt DESC
        ) AS row_num
```
is not stable (missing workflow_name?  each row can have multiple pushes?)

but overall the results are close enough (ε  < 0.01) and further debugging and fixing could be made in a separate PR.