### PR TITLE
Fix aarch64 cpu/cuda include logic

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -443,17 +443,14 @@ def generate_wheels_matrix(
         arches = []
 
         if with_cpu == ENABLE:
-            arches += [CPU]
-
-        if os == LINUX_AARCH64:
-            # Only want the one arch as the CPU type is different and
-            # uses different build/test scripts
-            arches = [CPU_AARCH64] + CUDA_AARCH64_ARCHES
+            arches += [CPU_AARCH64] if os == LINUX_AARCH64 else [CPU]
 
         if with_cuda == ENABLE:
             upload_to_base_bucket = "no"
             if os in (LINUX, WINDOWS):
                 arches += CUDA_ARCHES
+            elif os == LINUX_AARCH64:
+                arches += CUDA_AARCH64_ARCHES
 
         if with_rocm == ENABLE and os == LINUX:
             arches += ROCM_ARCHES


### PR DESCRIPTION
Make sure `with-cuda` and `with-cpu` flags are correctly assigned to aarch64 builds
Test:
```
python generate_binary_build_matrix.py --with-cpu disable  --with-cuda enable --with-rocm disable --operating-system linux-aarch64
{"include": [{"python_version": "3.9", "gpu_arch_type": "cuda-aarch64", "gpu_arch_version": "12.8-aarch64", "desired_cuda": "cu128", "container_image": "pytorch/manylinuxaarch64-builder:cuda12.8", "package_type": "wheel", "build_name": "wheel-py3_9-cuda-aarch6412_8-aarch64", "validation_runner": "linux.arm64.m7g.4xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "2.7.0", "use_split_build": false}]}
```