### PR TITLE
Delete TorchBench from NavBar

### DIFF
--- a/torchci/components/NavBar.tsx
+++ b/torchci/components/NavBar.tsx
@@ -46,10 +46,6 @@ function NavBar() {
       href: "/benchmark/torchao",
     },
     {
-      name: "TorchBench",
-      href: "/torchbench/userbenchmark",
-    },
-    {
       name: "Triton",
       href: "/tritonbench/commit_view",
     },


### PR DESCRIPTION
Because whatever ranges to select it crashes
But if one wants to experience crashes, page is still accessible via https://hud.pytorch.org/torchbench/userbenchmark

Fixes https://github.com/pytorch/test-infra/issues/6567 thru out-of-sight-out-of-mind incantation