### PR TITLE
[tritonbench] Exclude low_mem_dropout from the data to avoid zeros.

### DIFF
--- a/torchci/components/benchmark/tritonbench/TimeSeries.tsx
+++ b/torchci/components/benchmark/tritonbench/TimeSeries.tsx
@@ -137,7 +137,8 @@ function SingleGraphPanel({
     // to avoid all zero numbers
     return (
       ((id >= lWorkflowId && id <= rWorkflowId) ||
-      (id <= lWorkflowId && id >= rWorkflowId)) && (op_name !== "low_mem_dropout")
+        (id <= lWorkflowId && id >= rWorkflowId)) &&
+      op_name !== "low_mem_dropout"
     );
   });
 

--- a/torchci/components/benchmark/tritonbench/TimeSeries.tsx
+++ b/torchci/components/benchmark/tritonbench/TimeSeries.tsx
@@ -132,9 +132,12 @@ function SingleGraphPanel({
 
   const metricData = computeMetric(data).filter((r: any) => {
     const id = r.workflow_id;
+    const op_name = r.operator;
+    // low_mem_dropout tflops is too low and we have to exclude it from the dashboard
+    // to avoid all zero numbers
     return (
-      (id >= lWorkflowId && id <= rWorkflowId) ||
-      (id <= lWorkflowId && id >= rWorkflowId)
+      ((id >= lWorkflowId && id <= rWorkflowId) ||
+      (id <= lWorkflowId && id >= rWorkflowId)) && (op_name !== "low_mem_dropout")
     );
   });
 


### PR DESCRIPTION
Explicitly exclude low_mem_dropout as its tflops is very low. We will remove this workload from tflops as it is memory bounded and does not make sense to calculate its tflops.

Before:
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/4b73f4f7-175e-4e3f-a8d4-3423e800602c" />


After:
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/9a76d561-2c8d-46a3-a329-ad02e2f49396" />

