### PR TITLE
Separate private and public devices on benchmark dashboard

### DIFF
--- a/torchci/clickhouse_queries/oss_ci_benchmark_branches/query.sql
+++ b/torchci/clickhouse_queries/oss_ci_benchmark_branches/query.sql
@@ -33,7 +33,20 @@ WHERE
     )
     AND notEmpty(metric_name)
     AND (
-        startsWith({device: String }, device)
+        (
+            startsWith({device: String }, device)
+            AND (
+                (
+                    {device: String } LIKE '%(private)%'
+                    AND device LIKE '%(private)%'
+                )
+                OR
+                (
+                    {device: String } NOT LIKE '%(private)%'
+                    AND device NOT LIKE '%(private)%'
+                )
+            )
+        )
         OR {device: String } = ''
     )
     AND notEmpty(device)

--- a/torchci/clickhouse_queries/oss_ci_benchmark_llms/query.sql
+++ b/torchci/clickhouse_queries/oss_ci_benchmark_llms/query.sql
@@ -128,7 +128,12 @@ WHERE
         OR empty({branches: Array(String) })
     )
     AND (
-        startsWith({device: String }, device)
+        (startsWith({device: String }, device)
+        AND (
+            ({device: String } LIKE '%(private)%' AND device LIKE '%(private)%')
+            OR
+            ({device: String } NOT LIKE '%(private)%' AND device NOT LIKE '%(private)%')
+        ))
         OR {device: String } = ''
     )
     AND notEmpty(device)

--- a/torchci/clickhouse_queries/oss_ci_benchmark_names/query.sql
+++ b/torchci/clickhouse_queries/oss_ci_benchmark_names/query.sql
@@ -36,7 +36,20 @@ WHERE
     )
     AND notEmpty(metric_name)
     AND (
-        startsWith({device: String }, device)
+        (
+            startsWith({device: String }, device)
+            AND (
+                (
+                    {device: String } LIKE '%(private)%'
+                    AND device LIKE '%(private)%'
+                )
+                OR
+                (
+                    {device: String } NOT LIKE '%(private)%'
+                    AND device NOT LIKE '%(private)%'
+                )
+            )
+        )
         OR {device: String } = ''
     )
     AND notEmpty(device)


### PR DESCRIPTION
I made a questionable decision when appending the `private` suffix to the device name, i.e. `Apple iPhone 15 (private)`.  The problem here is that a device name already have another suffix in the OS version, i.e. `iOS 18.0`.  Take `Apple iPhone 15 (private) (iOS 18.0)` as an example, it would match both `Apple iPhone 15 (private) (iOS 18.0)`  and `Apple iPhone 15 (iOS 18.0)` because both start with `Apple iPhone 15`.

In hindsight, I should have use a prefix, i.e. `[private] Apple iPhone 15` to indicate a private device.  But as the new name has sticked around for sometimes, it's easier to just tweak the dashboard instead IMO.

### Testing

https://hud.pytorch.org/benchmark/llms?startTime=Thu%2C%2024%20Apr%202025%2001%3A05%3A16%20GMT&stopTime=Thu%2C%2001%20May%202025%2001%3A05%3A16%20GMT&granularity=day&lBranch=main&lCommit=2837867cccf7b7c9d32af90e5d084c1676d2c11e&rBranch=main&rCommit=b2eac7d7acc1fc0b9777514052f51303955eed5a&repoName=pytorch%2Fexecutorch&benchmarkName=&modelName=All%20Models&backendName=All%20Backends&modeName=All%20Modes&dtypeName=All%20DType&deviceName=Apple%20iPhone%2015%20Pro%20Max%20(private)%20(iOS%2017.2.1)&archName=All%20Platforms show both private and public devices

https://torchci-git-fork-huydhn-fix-device-filter-fbopensource.vercel.app/benchmark/llms?startTime=Thu%2C%2024%20Apr%202025%2001%3A11%3A56%20GMT&stopTime=Thu%2C%2001%20May%202025%2001%3A11%3A56%20GMT&granularity=day&lBranch=main&lCommit=cda554cda4bc5cc57dbf32e3d2d1b5daa472d301&rBranch=main&rCommit=b2eac7d7acc1fc0b9777514052f51303955eed5a&repoName=pytorch%2Fexecutorch&benchmarkName=&modelName=All%20Models&backendName=All%20Backends&modeName=All%20Modes&dtypeName=All%20DType&deviceName=Apple%20iPhone%2015%20Pro%20Max%20(private)%20(iOS%2017.2.1)&archName=All%20Platforms now shows only the private devices