### PR TITLE
Send metrics before callback() for scaleUpChron

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/lambda.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/lambda.test.ts
@@ -256,6 +256,6 @@ describe('scaleUpChron', () => {
     await scaleUpChronL({} as unknown as ScheduledEvent, {} as unknown as Context, callback);
     expect(mockedScaleUpChron).toBeCalledTimes(1);
     expect(callback).toBeCalledTimes(1);
-    expect(callback).toBeCalledWith('Failed');
+    expect(callback).toBeCalledWith('Failed to scale up chron: Error: error');
   });
 });


### PR DESCRIPTION
The code currently calls:

```
callback(null);
```

before

```
await metrics.sendMetrics();
```

This causes no metrics to actually be sent, unless a timeout or exception happens. This fixe just addresses this to make sure metrics are being sent.