### PR TITLE
Improvements to test times queries

### DIFF
--- a/tools/torchci/clickhouse_query_perf.py
+++ b/tools/torchci/clickhouse_query_perf.py
@@ -327,7 +327,7 @@ def results_compare(args: argparse.Namespace) -> None:
             print("Results can be found in the _logs/query_results folder")
             print()
         else:
-            print(f"Results for test {i} match")
+            print(f"Results ({len(new_results)} rows) for test {i} match")
 
 
 if __name__ == "__main__":

--- a/torchci/clickhouse_queries/test_time_per_class/params.json
+++ b/torchci/clickhouse_queries/test_time_per_class/params.json
@@ -1,4 +1,4 @@
 {
   "params": {},
-  "tests": []
+  "tests": [{}]
 }

--- a/torchci/clickhouse_queries/test_time_per_class/query.sql
+++ b/torchci/clickhouse_queries/test_time_per_class/query.sql
@@ -1,7 +1,7 @@
 WITH most_recent_strict_commits AS (
     SELECT push.head_commit.id AS sha
     FROM
-        default.push FINAL
+        default.push
     WHERE
         push.ref = 'refs/heads/viable/strict'
         AND push.repository.full_name = 'pytorch/pytorch'
@@ -11,25 +11,18 @@ WITH most_recent_strict_commits AS (
         3
 ),
 
-workflow AS (
-    SELECT id
-    FROM
-        materialized_views.workflow_run_by_head_sha w
-    WHERE head_sha IN (SELECT sha FROM most_recent_strict_commits)
-),
-
 job AS (
     SELECT
+        distinct
         j.name,
         j.id,
         j.run_id
     FROM
-        default.workflow_job j FINAL
+        default.workflow_job j
     WHERE j.id IN (
         SELECT id FROM materialized_views.workflow_job_by_head_sha
         WHERE head_sha IN (SELECT sha FROM most_recent_strict_commits)
     )
-    AND j.run_id IN (SELECT id FROM workflow)
 ),
 
 class_duration_per_job AS (
@@ -46,7 +39,7 @@ class_duration_per_job AS (
         /* cpp tests do not populate `file` for some reason. */
         /* Exclude them as we don't include them in our slow test infra */
         test_run.file != ''
-        AND test_run.workflow_id IN (SELECT id FROM workflow)
+        AND test_run.workflow_id IN (SELECT run_id FROM job)
     GROUP BY
         test_run.invoking_file,
         test_run.classname,

--- a/torchci/clickhouse_queries/test_time_per_class/query.sql
+++ b/torchci/clickhouse_queries/test_time_per_class/query.sql
@@ -12,8 +12,7 @@ WITH most_recent_strict_commits AS (
 ),
 
 job AS (
-    SELECT
-        distinct
+    SELECT DISTINCT
         j.name,
         j.id,
         j.run_id

--- a/torchci/clickhouse_queries/test_time_per_class_periodic_jobs/params.json
+++ b/torchci/clickhouse_queries/test_time_per_class_periodic_jobs/params.json
@@ -1,4 +1,4 @@
 {
   "params": {},
-  "tests": []
+  "tests": [{}]
 }

--- a/torchci/clickhouse_queries/test_time_per_class_periodic_jobs/query.sql
+++ b/torchci/clickhouse_queries/test_time_per_class_periodic_jobs/query.sql
@@ -23,8 +23,7 @@ WITH good_periodic_sha AS (
 ),
 
 job AS (
-    SELECT
-        distinct
+    SELECT DISTINCT
         j.name,
         j.id,
         j.run_id

--- a/torchci/clickhouse_queries/test_time_per_class_periodic_jobs/query.sql
+++ b/torchci/clickhouse_queries/test_time_per_class_periodic_jobs/query.sql
@@ -2,7 +2,7 @@
 WITH good_periodic_sha AS (
     SELECT job.head_sha AS sha
     FROM
-        default.workflow_job job final
+        default.workflow_job job
     JOIN default.push ON job.head_sha = push.head_commit.'id'
     WHERE
         job.workflow_name = 'periodic'
@@ -22,30 +22,18 @@ WITH good_periodic_sha AS (
         3
 ),
 
-workflow AS (
-    SELECT id
-    FROM
-        default.workflow_run FINAL
-    WHERE
-        id IN (
-            SELECT id FROM materialized_views.workflow_run_by_head_sha w
-            WHERE head_sha IN (SELECT sha FROM good_periodic_sha)
-        )
-        AND name = 'periodic'
-),
-
 job AS (
     SELECT
+        distinct
         j.name,
         j.id,
         j.run_id
     FROM
-        default.workflow_job j FINAL
+        default.workflow_job j
     WHERE j.id IN (
         SELECT id FROM materialized_views.workflow_job_by_head_sha
         WHERE head_sha IN (SELECT sha FROM good_periodic_sha)
     )
-    AND j.run_id IN (SELECT id FROM workflow)
 ),
 
 class_duration_per_job AS (
@@ -62,7 +50,7 @@ class_duration_per_job AS (
         /* cpp tests do not populate `file` for some reason. */
         /* Exclude them as we don't include them in our slow test infra */
         test_run.file != ''
-        AND test_run.workflow_id IN (SELECT id FROM workflow)
+        AND test_run.workflow_id IN (SELECT run_id FROM job)
     GROUP BY
         test_run.invoking_file,
         test_run.classname,

--- a/torchci/clickhouse_queries/test_time_per_class_periodic_jobs/query.sql
+++ b/torchci/clickhouse_queries/test_time_per_class_periodic_jobs/query.sql
@@ -2,13 +2,12 @@
 WITH good_periodic_sha AS (
     SELECT job.head_sha AS sha
     FROM
-        default.workflow_job job FINAL
-    JOIN default.workflow_run workflow FINAL ON workflow.id = job.run_id
-    JOIN default.push ON workflow.head_commit.'id' = push.head_commit.'id'
+        default.workflow_job job final
+    JOIN default.push ON job.head_sha = push.head_commit.'id'
     WHERE
-        workflow.name = 'periodic'
-        AND workflow.head_branch LIKE 'main'
-        AND workflow.repository.'full_name' = 'pytorch/pytorch'
+        job.workflow_name = 'periodic'
+        AND job.head_branch LIKE 'main'
+        AND job.repository_full_name = 'pytorch/pytorch'
     GROUP BY
         job.head_sha,
         push.head_commit.'timestamp'

--- a/torchci/clickhouse_queries/test_time_per_file/params.json
+++ b/torchci/clickhouse_queries/test_time_per_file/params.json
@@ -1,4 +1,4 @@
 {
   "params": {},
-  "tests": []
+  "tests": [{}]
 }

--- a/torchci/clickhouse_queries/test_time_per_file/query.sql
+++ b/torchci/clickhouse_queries/test_time_per_file/query.sql
@@ -12,8 +12,7 @@ WITH most_recent_strict_commits AS (
 ),
 
 job AS (
-    SELECT
-        distinct
+    SELECT DISTINCT
         j.name,
         j.id,
         j.run_id
@@ -38,7 +37,7 @@ file_duration_per_job AS (
         /* cpp tests do not populate `file` for some reason. */
         /* Exclude them as we don't include them in our slow test infra */
         test_run.file != ''
-        AND test_run.workflow_id IN (SELECT run_id from job)
+        AND test_run.workflow_id IN (SELECT run_id FROM job)
     GROUP BY
         test_run.invoking_file,
         base_name,

--- a/torchci/clickhouse_queries/test_time_per_file/query.sql
+++ b/torchci/clickhouse_queries/test_time_per_file/query.sql
@@ -1,7 +1,7 @@
 WITH most_recent_strict_commits AS (
     SELECT push.head_commit.id AS sha
     FROM
-        default.push FINAL
+        default.push
     WHERE
         push.ref = 'refs/heads/viable/strict'
         AND push.repository.full_name = 'pytorch/pytorch'
@@ -11,25 +11,18 @@ WITH most_recent_strict_commits AS (
         3
 ),
 
-workflow AS (
-    SELECT id
-    FROM
-        materialized_views.workflow_run_by_head_sha w
-    WHERE head_sha IN (SELECT sha FROM most_recent_strict_commits)
-),
-
 job AS (
     SELECT
+        distinct
         j.name,
         j.id,
         j.run_id
     FROM
-        default.workflow_job j FINAL
+        default.workflow_job j
     WHERE j.id IN (
         SELECT id FROM materialized_views.workflow_job_by_head_sha
         WHERE head_sha IN (SELECT sha FROM most_recent_strict_commits)
     )
-    AND j.run_id IN (SELECT id FROM workflow)
 ),
 
 file_duration_per_job AS (
@@ -45,7 +38,7 @@ file_duration_per_job AS (
         /* cpp tests do not populate `file` for some reason. */
         /* Exclude them as we don't include them in our slow test infra */
         test_run.file != ''
-        AND test_run.workflow_id IN (SELECT id FROM workflow)
+        AND test_run.workflow_id IN (SELECT run_id from job)
     GROUP BY
         test_run.invoking_file,
         base_name,

--- a/torchci/clickhouse_queries/test_time_per_file_periodic_jobs/params.json
+++ b/torchci/clickhouse_queries/test_time_per_file_periodic_jobs/params.json
@@ -1,4 +1,4 @@
 {
   "params": {},
-  "tests": []
+  "tests": [{}]
 }

--- a/torchci/clickhouse_queries/test_time_per_file_periodic_jobs/query.sql
+++ b/torchci/clickhouse_queries/test_time_per_file_periodic_jobs/query.sql
@@ -23,8 +23,7 @@ WITH good_periodic_sha AS (
 ),
 
 job AS (
-    SELECT
-        distinct
+    SELECT DISTINCT
         j.name,
         j.id,
         j.run_id

--- a/torchci/clickhouse_queries/test_time_per_file_periodic_jobs/query.sql
+++ b/torchci/clickhouse_queries/test_time_per_file_periodic_jobs/query.sql
@@ -2,7 +2,7 @@
 WITH good_periodic_sha AS (
     SELECT job.head_sha AS sha
     FROM
-        default.workflow_job job final
+        default.workflow_job job
     JOIN default.push ON job.head_sha = push.head_commit.'id'
     WHERE
         job.workflow_name = 'periodic'
@@ -22,30 +22,19 @@ WITH good_periodic_sha AS (
         3
 ),
 
-workflow AS (
-    SELECT id
-    FROM
-        default.workflow_run FINAL
-    WHERE
-        id IN (
-            SELECT id FROM materialized_views.workflow_run_by_head_sha w
-            WHERE head_sha IN (SELECT sha FROM good_periodic_sha)
-        )
-        AND name = 'periodic'
-),
-
 job AS (
     SELECT
+        distinct
         j.name,
         j.id,
         j.run_id
     FROM
-        default.workflow_job j FINAL
+        default.workflow_job j
     WHERE j.id IN (
         SELECT id FROM materialized_views.workflow_job_by_head_sha
         WHERE head_sha IN (SELECT sha FROM good_periodic_sha)
     )
-    AND j.run_id IN (SELECT id FROM workflow)
+    AND j.workflow_name = 'periodic'
 ),
 
 file_duration_per_job AS (
@@ -61,7 +50,7 @@ file_duration_per_job AS (
         /* cpp tests do not populate `file` for some reason. */
         /* Exclude them as we don't include them in our slow test infra */
         test_run.file != ''
-        AND test_run.workflow_id IN (SELECT id FROM workflow)
+        AND test_run.workflow_id IN (SELECT run_id FROM job)
     GROUP BY
         test_run.invoking_file,
         base_name,

--- a/torchci/clickhouse_queries/test_time_per_file_periodic_jobs/query.sql
+++ b/torchci/clickhouse_queries/test_time_per_file_periodic_jobs/query.sql
@@ -2,13 +2,12 @@
 WITH good_periodic_sha AS (
     SELECT job.head_sha AS sha
     FROM
-        default.workflow_job job FINAL
-    JOIN default.workflow_run workflow FINAL ON workflow.id = job.run_id
-    JOIN default.push ON workflow.head_commit.'id' = push.head_commit.'id'
+        default.workflow_job job final
+    JOIN default.push ON job.head_sha = push.head_commit.'id'
     WHERE
-        workflow.name = 'periodic'
-        AND workflow.head_branch LIKE 'main'
-        AND workflow.repository.'full_name' = 'pytorch/pytorch'
+        job.workflow_name = 'periodic'
+        AND job.head_branch LIKE 'main'
+        AND job.repository_full_name = 'pytorch/pytorch'
     GROUP BY
         job.head_sha,
         push.head_commit.'timestamp'


### PR DESCRIPTION
The update test times workflow was failing due to OOMing on the periodic queries https://github.com/pytorch/test-infra/actions/runs/14788036069/job/41521901353

So I tried to make some improvements:
* Get rid of join with workflow_run table: all information needed from it can actually be gotten from workflow_job table and should be the same
* Get rid of intermediate workflow query: reason is same as above
* Get rid of final: push doesn't really need it, I expect that it's always the same.  The one on workflow job should be ok due to either the group by or the distinct depending on which part of the query

Correctness: 
* non periodic stayed the same
* periodic queries OOMed on base so couldn't actually test.  I did my best to do the minimal changes to get rid of the OOM and check results against that.  There were some differences, but they were mostly pretty small

Also super small change to clickhouse query perf to print number of rows so you can be sure it's not just empty

Didn't run perf for all of them but here's an example
```
 ~/z/test-infra/tools  csl/linux_jo…m_docker_tag *129 !8  python torchci/clickhouse_query_perf.py --query test_time_per_file --perf --results --base HEAD 
Using unstaged changes for --head
Gathering perf stats for: test_time_per_file
Num tests: 1
Num times: 10
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:15<00:00,  1.57s/it]
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:58<00:00,  5.87s/it]
Waiting for metrics to populate, please be patient
+------+----------+-----------+-------------+---------------+----------+--------------+---------------+--------------+
| Test | Avg Time | Base Time | Time Change | % Time Change | Avg Mem  |   Base Mem   |   Mem Change  | % Mem Change |
+------+----------+-----------+-------------+---------------+----------+--------------+---------------+--------------+
|  0   |   1083   |    5026   |    -3943    |      -78      | 37930540 | 1234645014.5 | -1196714474.5 |     -97      |
+------+----------+-----------+-------------+---------------+----------+--------------+---------------+--------------+
Comparing results for query: test_time_per_file
Num tests: 1
Head: unstaged
 Base: HEAD
Results for test 0 match```