### PR TITLE
[ez][HUD] Expand log search to other repos

### DIFF
--- a/torchci/lib/searchLogs.ts
+++ b/torchci/lib/searchLogs.ts
@@ -60,9 +60,14 @@ async function searchLog(
       };
     }
 
-    const log = await fetch(
-      `https://ossci-raw-job-status.s3.amazonaws.com/log/${job.id!}`
-    );
+    if (job.logUrl == undefined) {
+      return {
+        results: [],
+        info: "No log URL",
+      };
+    }
+
+    const log = await fetch(job.logUrl);
     if (log.status != 200) {
       return {
         results: [],


### PR DESCRIPTION
I noticed it wasn't working on tutorials because the url is hardcoded to be one that assumes it is pytorch/pytorch.  Instead, just use the job.logUrl field