### PR TITLE
Revert "[Mergebot] Adding ciflow/pull in PR without pull and lint workflows"

### DIFF
--- a/torchci/clickhouse_queries/get_workflows_for_commit/params.json
+++ b/torchci/clickhouse_queries/get_workflows_for_commit/params.json
@@ -1,7 +1,0 @@
-{
-    "params": {
-      "prNum": "Int64",
-      "headSha": "String"
-    },
-    "tests": []
-  }

--- a/torchci/clickhouse_queries/get_workflows_for_commit/query.sql
+++ b/torchci/clickhouse_queries/get_workflows_for_commit/query.sql
@@ -1,6 +1,0 @@
-SELECT DISTINCT name AS workflow_name
-FROM
-    workflow_run
-WHERE
-    tupleElement(pull_requests[1], 'number') = { prNum: Int64 }
-    AND head_sha = { headSha: String }

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -2,7 +2,6 @@ import { PullRequestReview } from "@octokit/webhooks-types";
 import _ from "lodash";
 import { updateDrciComments } from "pages/api/drci/drci";
 import shlex from "shlex";
-import { queryClickhouseSaved } from "../clickhouse";
 import { getHelp, getParser } from "./cliParser";
 import { cherryPickClassifications } from "./Constants";
 import PytorchBotLogger from "./pytorchbotLogger";
@@ -18,7 +17,6 @@ import {
 } from "./utils";
 
 export const CIFLOW_TRUNK_LABEL = "ciflow/trunk";
-export const CIFLOW_PULL_LABEL = "ciflow/pull";
 
 export interface PytorchbotParams {
   owner: string;
@@ -346,9 +344,6 @@ The explanation needs to be clear on why this is needed. Here are some good exam
         }
         await addLabels(this.ctx, [CIFLOW_TRUNK_LABEL]);
       }
-      if (!(await this.hasCiFlowPull())) {
-        await addLabels(this.ctx, [CIFLOW_PULL_LABEL]);
-      }
     }
 
     await this.dispatchEvent("try-merge", {
@@ -614,22 +609,6 @@ The explanation needs to be clear on why this is needed. Here are some good exam
       default:
         return await this.handleConfused(false);
     }
-  }
-
-  async hasCiFlowPull(): Promise<boolean> {
-    const workflowNames = await this.getWorkflowsLatest();
-    if (workflowNames.length > 0 && workflowNames.includes("pull")) {
-      return true;
-    }
-    return false;
-  }
-
-  // Returns the workflows attached to the PR only for the latest commit
-  async getWorkflowsLatest(): Promise<any> {
-    return await queryClickhouseSaved("get_workflows_for_commit", {
-      prNumber: this.prNum,
-      headSha: this.headSha,
-    });
   }
 }
 

--- a/torchci/test/mergeCommands.test.ts
+++ b/torchci/test/mergeCommands.test.ts
@@ -2,7 +2,6 @@ import { getFailureMessage, getMessage } from "lib/GeneralUtils";
 import nock from "nock";
 import * as probot from "probot";
 import pytorchBot from "../lib/bot/pytorchBot";
-import * as clickhouse from "../lib/clickhouse";
 import { handleScope, requireDeepCopy } from "./common";
 import * as utils from "./utils";
 
@@ -15,9 +14,6 @@ describe("merge-bot", () => {
     probot = utils.testProbot();
     probot.load(pytorchBot);
     utils.mockConfig("pytorch-probot.yml", "mergebot: True");
-    jest
-      .spyOn(clickhouse, "queryClickhouseSaved")
-      .mockImplementation(() => Promise.resolve(["pull"]));
   });
 
   afterEach(() => {


### PR DESCRIPTION
Reverts pytorch/test-infra#6604

ret value of queryclickhouse is list of jsons, not list of strs

[ workflow_name: "pull"] not ["pull"]

merge is broken atm, probably due to this