### PR TITLE
Revert "Temporarily shrink the interval we wait for during chaos testing"

### DIFF
--- a/torchci/clickhouse_queries/queued_jobs_aggregate/query.sql
+++ b/torchci/clickhouse_queries/queued_jobs_aggregate/query.sql
@@ -14,7 +14,7 @@ WITH possible_queued_jobs AS (
         status = 'queued'
         AND created_at < (
         -- Only consider jobs that have been queued for a significant period of time
-            CURRENT_TIMESTAMP() - INTERVAL 10 MINUTE
+            CURRENT_TIMESTAMP() - INTERVAL 30 MINUTE
         )
         AND created_at > (
         -- Queued jobs are automatically cancelled after this long. Any allegedly pending


### PR DESCRIPTION
Was a temporary change during testing.  Now it's time to revert this back