### PR TITLE
[BE] Improve autoscaler logging about how many instances are being provisioned

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -366,10 +366,12 @@ export function _calculateScaleUpAmount(
     // Never proactively scale up above the minimum limit
     extraScaleUp = Math.min(extraScaleUp, minRunnersUnderprovisionCount);
 
-    console.info(
-      `Available (${availableCount}) runners will be below minimum ${minRunners}. ` +
-        `Will provision ${extraScaleUp} extra runners`,
-    );
+    if (extraScaleUp > 0) {
+      console.info(
+        `Available (${availableCount}) runners will be below minimum ${minRunners}. ` +
+          `Will provision ${extraScaleUp} additional runners above the requested amount to serve as a buffer.`,
+      );
+    }
   }
 
   let scaleUpAmount = extraNeededToAcceptRequests + extraScaleUp;
@@ -381,6 +383,10 @@ export function _calculateScaleUpAmount(
 
     scaleUpAmount = maxScaleUp;
   }
+
+  console.info(
+    `Will provision a total of ${scaleUpAmount} runners to handle the requested amount of ${requestedCount} runners.`
+  );
 
   return scaleUpAmount;
 }


### PR DESCRIPTION
The original log could result in lines like: `Available (0) runners will be below minimum 10. Will provision 0 extra runners` which sounds like it's not going to provision any instances, but actually what it's trying to say that the autoscaler will not be overprovisioning any bonus buffer instances beyond whatever the incoming request was for (i.e. if 5 instances were requested, we'll only be provisioning 5, not more than 5)