### PR TITLE
Trigger scale-up-cron lambda more frequently

### DIFF
--- a/terraform-aws-github-runner/modules/runners/variables.tf
+++ b/terraform-aws-github-runner/modules/runners/variables.tf
@@ -97,7 +97,7 @@ variable "scale_down_schedule_expression" {
 variable "scale_up_chron_schedule_expression" {
   description = "Scheduler expression to check every x for scale down."
   type        = string
-  default     = "cron(*/30 * * * ? *)" # every 30 minutes
+  default     = "cron(*/10 * * * ? *)" # every 10 minutes
 }
 
 variable "minimum_running_time_in_minutes" {


### PR DESCRIPTION
Our auto-healing scale up chron lambda currently kicks in every 30 minutes, and looks for jobs that have been queuing for at least 30 mins.  This means that a job could potentially be queuing for 59 mins before it is healed.

We want this fallback pattern to be used for jobs that have been queuing for 30 mins, so we ideally want to get jobs retried when they've been queued for exactly 30 mins.  

> **Aside: Why not retry jobs with if they've been queued for even 1 minute?** 
> In order to avoid double-provisioning for a given job, we want to make sure we've given the regular scale-up lambda sufficient time to provision the instance. When a job is queued, it can take ~5 minutes for an instance to be provisioned, and if there are minor infra hiccups that the regular retry logic can catch, it could take a few more minutes for that instance to get provisioned.  After ~15-30 minutes it's reasonable to expect that any jobs still queued are likely to be affected by dropped webhooks and would benefit from a more proactive infra provisioning. We're opting for the larger end of that range for now but can adjust it later (it's a cost vs tail end potential queue time tradeoff)

The potential max queueing time for a job is the allowed queueing time + delay between cron invocations, so this safely reduces the time range a job could be queued for from from 30-60 mins to 30-40 mins

