### PR TITLE
Added AMD CI instances to inductor CI

### DIFF
--- a/.github/canary-scale-config.yml
+++ b/.github/canary-scale-config.yml
@@ -343,3 +343,27 @@ runner_types:
     os: linux
     variants:
       ephemeral: {}
+  c.linux.8xlarge.amd:
+    disk_size: 200
+    instance_type: m7a.8xlarge
+    is_ephemeral: false
+    os: linux
+    variants:
+      ephemeral:
+        is_ephemeral: true
+  c.linux.12xlarge.amd:
+    disk_size: 200
+    instance_type: m6a.12xlarge
+    is_ephemeral: false
+    os: linux
+    variants:
+      ephemeral:
+        is_ephemeral: true
+  c.linux.24xl.amd:
+    disk_size: 200
+    instance_type: m7a.24xlarge
+    is_ephemeral: false
+    os: linux
+    variants:
+      ephemeral:
+        is_ephemeral: true

--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -343,3 +343,27 @@ runner_types:
     os: linux
     variants:
       ephemeral: {}
+  lf.c.linux.8xlarge.amd:
+    disk_size: 200
+    instance_type: m7a.8xlarge
+    is_ephemeral: false
+    os: linux
+    variants:
+      ephemeral:
+        is_ephemeral: true
+  lf.c.linux.12xlarge.amd:
+    disk_size: 200
+    instance_type: m6a.12xlarge
+    is_ephemeral: false
+    os: linux
+    variants:
+      ephemeral:
+        is_ephemeral: true
+  lf.c.linux.24xl.amd:
+    disk_size: 200
+    instance_type: m7a.24xlarge
+    is_ephemeral: false
+    os: linux
+    variants:
+      ephemeral:
+        is_ephemeral: true

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -343,3 +343,27 @@ runner_types:
     os: linux
     variants:
       ephemeral: {}
+  lf.linux.8xlarge.amd:
+    disk_size: 200
+    instance_type: m7a.8xlarge
+    is_ephemeral: false
+    os: linux
+    variants:
+      ephemeral:
+        is_ephemeral: true
+  lf.linux.12xlarge.amd:
+    disk_size: 200
+    instance_type: m6a.12xlarge
+    is_ephemeral: false
+    os: linux
+    variants:
+      ephemeral:
+        is_ephemeral: true
+  lf.linux.24xl.amd:
+    disk_size: 200
+    instance_type: m7a.24xlarge
+    is_ephemeral: false
+    os: linux
+    variants:
+      ephemeral:
+        is_ephemeral: true

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -339,3 +339,27 @@ runner_types:
     os: linux
     variants:
       ephemeral: {}
+  linux.8xlarge.amd:
+    disk_size: 200
+    instance_type: m7a.8xlarge
+    is_ephemeral: false
+    os: linux
+    variants:
+      ephemeral:
+        is_ephemeral: true
+  linux.12xlarge.amd:
+    disk_size: 200
+    instance_type: m6a.12xlarge
+    is_ephemeral: false
+    os: linux
+    variants:
+      ephemeral:
+        is_ephemeral: true
+  linux.24xl.amd:
+    disk_size: 200
+    instance_type: m7a.24xlarge
+    is_ephemeral: false
+    os: linux
+    variants:
+      ephemeral:
+        is_ephemeral: true


### PR DESCRIPTION
Added AWS AMD instances and their corresponding runner types to the PyTorch CI. Once this is merged will add the corresponding changes to the PyTorch repo to trigger CI jobs using these runners.