### PR TITLE
Fix python 3.13t builds on aarch64

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -141,6 +141,8 @@ runs:
                 conda uninstall -y conda-anaconda-telemetry conda-anaconda-tos
               fi
               conda install -y conda=24.7.1 conda-libmamba-solver=24.1.0
+            else
+              conda install -y conda=24.7.1
             fi
           fi
 

--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -141,7 +141,7 @@ runs:
                 conda uninstall -y conda-anaconda-telemetry conda-anaconda-tos
               fi
             fi
-            conda install -y conda=24.7.1 conda-libmamba-solver=24.1.0
+            conda install -y conda=24.7.1
           fi
 
           conda create \

--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -140,8 +140,8 @@ runs:
               if [[ -n "$(conda list | grep conda-anaconda-telemetry)" ]]; then
                 conda uninstall -y conda-anaconda-telemetry conda-anaconda-tos
               fi
+              conda install -y conda=24.7.1 conda-libmamba-solver=24.1.0
             fi
-            conda install -y conda=24.7.1
           fi
 
           conda create \

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -442,7 +442,7 @@ def generate_wheels_matrix(
             arches += [XPU]
 
     if limit_pr_builds:
-        python_versions = [python_versions[0]]
+        python_versions = [python_versions[-1]]
 
     global WHEEL_CONTAINER_IMAGES
 

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -442,7 +442,7 @@ def generate_wheels_matrix(
             arches += [XPU]
 
     if limit_pr_builds:
-        python_versions = [python_versions[-1]]
+        python_versions = [python_versions[0]]
 
     global WHEEL_CONTAINER_IMAGES
 


### PR DESCRIPTION
Trying to fix 3.13t build failure : https://github.com/pytorch/vision/actions/runs/14936575189/job/41965300242
Log:
```
+ conda install -y conda=24.7.1 conda-libmamba-solver=24.1.0
Channels:
 - conda-forge
Platform: linux-aarch64
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... failed

LibMambaUnsatisfiableError: Encountered problems while solving:
  - package conda-libmamba-solver-24.1.0-pyhd8ed1ab_0 requires libmambapy >=1.5.6,<2.0a0, but none of the providers can be installed

Could not solve for environment specs
The following packages are incompatible
├─ conda-libmamba-solver =24.1.0 * is installable and it requires
│  └─ libmambapy >=1.5.6,<2.0a0 * with the potential options
│     ├─ libmambapy [1.5.10|1.5.11|...|1.5.9] would require
│     │  └─ python >=3.10,<3.11.0a0 *, which can be installed;
│     ├─ libmambapy [1.5.10|1.5.11|...|1.5.9] would require
│     │  └─ python >=3.11,<3.12.0a0 *, which can be installed;
│     ├─ libmambapy 1.5.10 would require
│     │  └─ libmamba ==1.5.10 h489cd8b_1, which can be installed;
│     ├─ libmambapy 1.5.10 would require
│     │  └─ libmamba ==1.5.10 hee7cc92_0, which can be installed;
│     ├─ libmambapy [1.5.10|1.5.11|...|1.5.9] would require
│     │  └─ python >=3.9,<3.10.0a0 *, which can be installed;
│     ├─ libmambapy 1.5.11 would require
│     │  └─ libmamba ==1.5.11 h489cd8b_0, which can be installed;
│     ├─ libmambapy 1.5.11 would require
│     │  └─ libmamba ==1.5.11 h4f7d7cb_1, which can be installed;
│     ├─ libmambapy 1.5.12 would require
│     │  └─ libmamba ==1.5.12 h4f7d7cb_0, which can be installed;
│     ├─ libmambapy 1.5.12 would require
│     │  └─ libmamba ==1.5.12 hb22c4c9_1, which can be installed;
│     ├─ libmambapy 1.5.6 would require
│     │  └─ libmamba ==1.5.6 hea3be6c_0, which can be installed;
│     ├─ libmambapy [1.5.6|1.5.7|1.5.8] would require
│     │  └─ python >=3.8,<3.9.0a0 *, which can be installed;
│     ├─ libmambapy [1.5.6|1.5.7|1.5.8|1.5.9] would require
│     │  └─ python >=3.9,<3.10.0a0 *_73_pypy, which can be installed;
│     ├─ libmambapy 1.5.7 would require
│     │  └─ libmamba ==1.5.7 hea3be6c_0, which can be installed;
│     ├─ libmambapy 1.5.8 would require
│     │  └─ libmamba ==1.5.8 hea3be6c_0, which can be installed;
│     └─ libmambapy 1.5.9 would require
│        └─ libmamba ==1.5.9 hee7cc92_0, which can be installed;
├─ mamba >=2.0.8 * is not installable because there are no viable options
│  ├─ mamba 2.0.8 would require
│  │  └─ libmamba ==2.0.8 h63ffdf8_0, which conflicts with any installable versions previously reported;
│  ├─ mamba 2.0.8 would require
│  │  └─ libmamba ==2.0.8 h63ffdf8_1, which conflicts with any installable versions previously reported;
│  ├─ mamba 2.0.8 would require
│  │  └─ libmamba ==2.0.8 hc3f49f9_2, which conflicts with any installable versions previously reported;
│  ├─ mamba 2.0.8 would require
│  │  └─ libmamba ==2.0.8 hbe5a9cd_2, which conflicts with any installable versions previously reported;
│  ├─ mamba 2.0.8 would require
│  │  └─ libmamba ==2.0.8 hd0952cb_0, which conflicts with any installable versions previously reported;
│  ├─ mamba 2.0.8 would require
│  │  └─ libmamba ==2.0.8 hd0952cb_1, which conflicts with any installable versions previously reported;
│  ├─ mamba 2.1.0 would require
│  │  └─ libmamba ==2.1.0 hc3f49f9_0, which conflicts with any installable versions previously reported;
│  ├─ mamba 2.1.0 would require
│  │  └─ libmamba ==2.1.0 hc3f49f9_1, which conflicts with any installable versions previously reported;
│  ├─ mamba 2.1.0 would require
│  │  └─ libmamba ==2.1.0 hbe5a9cd_0, which conflicts with any installable versions previously reported;
│  ├─ mamba 2.1.0 would require
│  │  └─ libmamba ==2.1.0 hbe5a9cd_1, which conflicts with any installable versions previously reported;
│  ├─ mamba 2.1.1 would require
│  │  └─ libmamba ==2.1.1 hc3f49f9_0, which conflicts with any installable versions previously reported;
│  └─ mamba 2.1.1 would require
│     └─ libmamba ==2.1.1 hbe5a9cd_0, which conflicts with any installable versions previously reported;
└─ pin on python 3.12.* =* * is not installable because it requires
   └─ python =3.12 *, which conflicts with any installable versions previously reported.

Pins seem to be involved in the conflict. Currently pinned specs:
 - python=3.12
 ```

Move conda pinning for 3.13t builds to: ``conda=24.7.1 conda-libmamba-solver=24.1.0`` to apply only to mac