### PR TITLE
[ez][HUD] Make main page column width wider

### DIFF
--- a/torchci/components/hud.module.css
+++ b/torchci/components/hud.module.css
@@ -20,7 +20,7 @@
   width: 8ch;
 }
 .colJob {
-  width: 1.2ch;
+  width: 2ch;
   min-width: 14px;
 }
 .colAuthor {


### PR DESCRIPTION
No code changes, but the column width of the jobs became smaller.  I think this is a change in my browser (google chrome) or something, since if you go back to old deployments (ex https://vercel.com/fbopensource/torchci/6s4pLsAQTjcmokPfZqQkWYdckXsJ from March) it is also present, even though I only started seeing it this week.

This changes the columns to be wider

Current:
<img width="320" alt="image" src="https://github.com/user-attachments/assets/eac9bad4-134d-4466-afe7-1aaf621940d1" />

New:
<img width="425" alt="image" src="https://github.com/user-attachments/assets/a4103f4e-623d-4ced-ae3d-e08ff6f67f13" />

on safari and firefox the width still looks normal, and this pr doesn't seem to change it
