### PR TITLE
Fix typo after #6612

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -121,7 +121,7 @@ PACKAGE_ALLOW_LIST = {x.lower() for x in [
     "onemkl_sycl_dft",
     "onemkl_sycl_lapack",
     "onemkl_sycl_sparse",
-    "onemkl_sycl_rng"
+    "onemkl_sycl_rng",
     # ----
     "Pillow",
     "certifi",


### PR DESCRIPTION
The #6612 had a typo missing comma after ``onemkl_sycl_rng``