### PR TITLE
[ez][CH][drci] Improve recent_pr_workflows_query perf

### DIFF
--- a/torchci/clickhouse_queries/recent_pr_workflows_query/params.json
+++ b/torchci/clickhouse_queries/recent_pr_workflows_query/params.json
@@ -4,5 +4,11 @@
     "prNumbers": "Array(Int64)",
     "repo": "String"
   },
-  "tests": []
+  "tests": [
+    {
+      "numMinutes": 30,
+      "prNumbers": [],
+      "repo": "pytorch/pytorch"
+    }
+  ]
 }

--- a/torchci/clickhouse_queries/recent_pr_workflows_query/query.sql
+++ b/torchci/clickhouse_queries/recent_pr_workflows_query/query.sql
@@ -22,8 +22,8 @@ recent_prs AS (
     pull_request.number AS number,
     argMax(push.timestamp, pull_request.updated_at) AS timestamp
   FROM
-    default.pull_request pull_request
-    JOIN relevant_shas r ON r.head_sha = pull_request.head.'sha'
+    relevant_shas r
+    JOIN default.pull_request pull_request ON r.head_sha = pull_request.head.'sha'
     -- Do a left join here because the push table won't have any information about
     -- commits from forked repo
     LEFT JOIN relevant_pushes push ON r.head_sha = push.id

--- a/torchci/clickhouse_queries/recent_pr_workflows_query/query.sql
+++ b/torchci/clickhouse_queries/recent_pr_workflows_query/query.sql
@@ -12,18 +12,18 @@ WITH relevant_shas as (
 ),
 relevant_pushes as (
   -- optimization because push is currently ordered by timestamp
-  select push.head_commit.'timestamp' as timestamp, push.head_commit.'id' as id
-  from default.push final
+  select distinct push.head_commit.'timestamp' as timestamp, push.head_commit.'id' as id
+  from default.push
   where push.head_commit.'timestamp' in (select timestamp from materialized_views.push_by_sha where id in relevant_shas)
 ),
 recent_prs AS (
   SELECT
-    distinct pull_request.head.'sha' AS sha,
+    argMax(pull_request.head.'sha', pull_request.updated_at) AS sha,
     pull_request.number AS number,
-    push.timestamp AS timestamp
+    argMax(push.timestamp, pull_request.updated_at) AS timestamp
   FROM
-    relevant_shas r
-    JOIN default.pull_request pull_request final ON r.head_sha = pull_request.head.'sha'
+    default.pull_request pull_request
+    JOIN relevant_shas r ON r.head_sha = pull_request.head.'sha'
     -- Do a left join here because the push table won't have any information about
     -- commits from forked repo
     LEFT JOIN relevant_pushes push ON r.head_sha = push.id
@@ -33,6 +33,8 @@ recent_prs AS (
     and pull_request.number in (select number from materialized_views.pr_by_sha where head_sha in (select head_sha from relevant_shas))
     -- This query is used by Dr.CI, so we just want to update open PR(s)
     and pull_request.state = 'open'
+  GROUP BY
+    pull_request.number
 )
 SELECT
   w.id AS workflowId,


### PR DESCRIPTION
This is the main query used by dr ci to get info on jobs.  It some times OOMs when querying:
```
(while reading column head): (while reading from part ... in table default.pull_request...
```

Remove final for push because it is not needed.
Remove final for pull_request in favor of argmax.

This brings down the time and the memory needed


```
 ~/zzzzzzzz/test-infra/tools  @c6e2eb46 *129 !2  python torchci/clickhouse_query_perf.py --query recent_pr_workflows_query  --results --perf  --base origin/main --strict                                                                                 ✔  1m 57s  forpytorch Py  09:23:07 AM 
Using unstaged changes for --head
Gathering perf stats for: recent_pr_workflows_query
Num tests: 1
Num times: 10
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:35<00:00,  3.57s/it]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:42<00:00,  4.28s/it]
Waiting for metrics to populate, please be patient
+------+----------+-----------+-------------+---------------+-------------+-----------+--------------+--------------+
| Test | Avg Time | Base Time | Time Change | % Time Change |   Avg Mem   |  Base Mem |  Mem Change  | % Mem Change |
+------+----------+-----------+-------------+---------------+-------------+-----------+--------------+--------------+
|  0   |  2946.5  |    3769   |    -822.5   |      -22      | 135942738.5 | 565914340 | -429971601.5 |     -76      |
+------+----------+-----------+-------------+---------------+-------------+-----------+--------------+--------------+
Comparing results for query: recent_pr_workflows_query
Num tests: 1
Head: unstaged
 Base: origin/main
Results (4206 rows) for test 0 match
```