### PR TITLE
ci: Pin more nvidia-container dependencies

### DIFF
--- a/.github/actions/setup-nvidia/action.yml
+++ b/.github/actions/setup-nvidia/action.yml
@@ -40,7 +40,12 @@ runs:
                   fi
 
                   sudo yum-config-manager --add-repo "${YUM_REPO_URL}"
-                  sudo yum install -y nvidia-docker2 nvidia-container-toolkit-1.16.2
+                  sudo yum install -y \
+                    nvidia-docker2 \
+                    nvidia-container-toolkit-1.16.2 \
+                    libnvidia-container-tools-1.16.2 \
+                    libnvidia-container1-1.16.2 \
+                    nvidia-container-toolkit-base-1.16.2
                   sudo systemctl restart docker
               )
           }


### PR DESCRIPTION
This pull request updates the `.github/actions/setup-nvidia/action.yml` file to enhance the NVIDIA container setup process by including additional dependencies for better compatibility and functionality.

Enhancements to NVIDIA container setup:

* Updated the `yum install` command to include additional packages: `libnvidia-container-tools-1.16.2`, `libnvidia-container1-1.16.2`, and `nvidia-container-toolkit-base-1.16.2`, alongside the existing `nvidia-docker2` and `nvidia-container-toolkit-1.16.2`. This ensures a more complete installation of NVIDIA container tools.