### PR TITLE
Keep nightly dev20250310 for ExecuTorch

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -204,11 +204,10 @@ PACKAGE_DATE_REGEX = r"([a-zA-z]*-[0-9.]*.dev)([0-9]*)"
 # How many packages should we keep of a specific package?
 KEEP_THRESHOLD = 60
 
-# TODO (huydhn): Clean this up once ExecuTorch has a new stable release that
-# match PyTorch stable release cadence. This nightly version is currently
-# referred to publicly in ExecuTorch alpha 0.1 release. So we want to keep
-# nightly binaries around for now
-KEEP_NIGHTLY_PACKAGES_FOR_EXECUTORCH = {datetime(2023, 10, 10, 0, 0)}
+# TODO (huydhn): Clean this up afte https://github.com/pytorch/pytorch/pull/152238
+# is in the release branch, be it via cherry picking to the next release branch
+# cut
+KEEP_NIGHTLY_PACKAGES_FOR_EXECUTORCH = {datetime(2025, 03, 10, 0, 0)}
 
 S3IndexType = TypeVar('S3IndexType', bound='S3Index')
 


### PR DESCRIPTION
To make https://github.com/pytorch/pytorch/pull/153750 pass ExecuTorch tests