### PR TITLE
Add Amazon EC2 M8g Instances

### DIFF
--- a/.github/canary-scale-config.yml
+++ b/.github/canary-scale-config.yml
@@ -157,6 +157,11 @@ runner_types:
     instance_type: m7g.4xlarge
     is_ephemeral: true
     os: linux
+  c.linux.arm64.m8g.4xlarge:
+    disk_size: 256
+    instance_type: m8g.4xlarge
+    is_ephemeral: true
+    os: linux
   c.linux.arm64.2xlarge.ephemeral:
     disk_size: 256
     instance_type: t4g.2xlarge
@@ -165,6 +170,11 @@ runner_types:
   c.linux.arm64.m7g.4xlarge.ephemeral:
     disk_size: 256
     instance_type: m7g.4xlarge
+    is_ephemeral: true
+    os: linux
+  c.linux.arm64.m8g.4xlarge.ephemeral:
+    disk_size: 256
+    instance_type: m8g.4xlarge
     is_ephemeral: true
     os: linux
   c.linux.arm64.m7g.metal:

--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -157,6 +157,11 @@ runner_types:
     instance_type: m7g.4xlarge
     is_ephemeral: true
     os: linux
+  lf.c.linux.arm64.m8g.4xlarge:
+    disk_size: 256
+    instance_type: m8g.4xlarge
+    is_ephemeral: true
+    os: linux
   lf.c.linux.arm64.2xlarge.ephemeral:
     disk_size: 256
     instance_type: t4g.2xlarge
@@ -165,6 +170,11 @@ runner_types:
   lf.c.linux.arm64.m7g.4xlarge.ephemeral:
     disk_size: 256
     instance_type: m7g.4xlarge
+    is_ephemeral: true
+    os: linux
+  lf.c.linux.arm64.m8g.4xlarge.ephemeral:
+    disk_size: 256
+    instance_type: m8g.4xlarge
     is_ephemeral: true
     os: linux
   lf.c.linux.arm64.m7g.metal:

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -157,6 +157,11 @@ runner_types:
     instance_type: m7g.4xlarge
     is_ephemeral: true
     os: linux
+  lf.linux.arm64.m8g.4xlarge:
+    disk_size: 256
+    instance_type: m8g.4xlarge
+    is_ephemeral: true
+    os: linux
   lf.linux.arm64.2xlarge.ephemeral:
     disk_size: 256
     instance_type: t4g.2xlarge
@@ -165,6 +170,11 @@ runner_types:
   lf.linux.arm64.m7g.4xlarge.ephemeral:
     disk_size: 256
     instance_type: m7g.4xlarge
+    is_ephemeral: true
+    os: linux
+  lf.linux.arm64.m8g.4xlarge.ephemeral:
+    disk_size: 256
+    instance_type: m8g.4xlarge
     is_ephemeral: true
     os: linux
   lf.linux.arm64.m7g.metal:

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -153,6 +153,11 @@ runner_types:
     instance_type: m7g.4xlarge
     is_ephemeral: true
     os: linux
+  linux.arm64.m8g.4xlarge:
+    disk_size: 256
+    instance_type: m8g.4xlarge
+    is_ephemeral: true
+    os: linux
   linux.arm64.2xlarge.ephemeral:
     disk_size: 256
     instance_type: t4g.2xlarge
@@ -161,6 +166,11 @@ runner_types:
   linux.arm64.m7g.4xlarge.ephemeral:
     disk_size: 256
     instance_type: m7g.4xlarge
+    is_ephemeral: true
+    os: linux
+  linux.arm64.m8g.4xlarge.ephemeral:
+    disk_size: 256
+    instance_type: m8g.4xlarge
     is_ephemeral: true
     os: linux
   linux.arm64.m7g.metal:


### PR DESCRIPTION
This would allow us to test on AWS Graviton4 processors. 

Our intention is to add this alongside the existing AWS Graviton3 processors for unit tests.