### PR TITLE
Fix s3 update workflow after: #6639

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -215,7 +215,7 @@ KEEP_THRESHOLD = 60
 # TODO (huydhn): Clean this up afte https://github.com/pytorch/pytorch/pull/152238
 # is in the release branch, be it via cherry picking to the next release branch
 # cut
-KEEP_NIGHTLY_PACKAGES_FOR_EXECUTORCH = {datetime(2025, 03, 10, 0, 0)}
+KEEP_NIGHTLY_PACKAGES_FOR_EXECUTORCH = {datetime(2025, 3, 10, 0, 0)}
 
 S3IndexType = TypeVar('S3IndexType', bound='S3Index')
 


### PR DESCRIPTION
Fixes error after #6639
Failure: https://github.com/pytorch/test-infra/actions/runs/15139622052/job/42565306129

```
+ python s3_management/manage.py whl/nightly
  File "/__w/test-infra/test-infra/s3_management/manage.py", line 218
    KEEP_NIGHTLY_PACKAGES_FOR_EXECUTORCH = {datetime(2025, 03, 10, 0, 0)}
                                                           ^
SyntaxError: leading zeros in decimal integer literals are not permitted; use an 0o prefix for octal integers
```