### PR TITLE
pr label event table in dynamo

### DIFF
--- a/aws/lambda/clickhouse-replicator-dynamo/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-dynamo/lambda_function.py
@@ -24,6 +24,7 @@ SUPPORTED_TABLES = {
     "torchci-issues": "default.issues",
     "torchci-issue-comment": "default.issue_comment",
     "torchci-issues-label-event": "default.issues_label_event",
+    "torchci-pull-label-event": "default.pull_label_event",
     "torchci-job-annotation": "default.job_annotation",
     "torchci-pull-request-review": "default.pull_request_review",
     "torchci-pull-request-review-comment": "default.pull_request_review_comment",

--- a/torchci/test/wehookToDynamoBot.test.ts
+++ b/torchci/test/wehookToDynamoBot.test.ts
@@ -78,7 +78,7 @@ describe("webhookToDynamo tests", () => {
   });
 
   test("pull_request.labeled", async () => {
-    await helper("./fixtures/pull_request.labeled.json", "pull_request");
+    await helper("./fixtures/pull_request.labeled.json", "pull_request", 2);
   });
 
   test("issue.opened", async () => {


### PR DESCRIPTION
only merge this after [pytorch-labs/pytorch-gha-infra#646](https://github.com/pytorch-labs/pytorch-gha-infra/pull/678) has been merged & deployed

Goal is to keep track of when issues are labeled or unlabeled for statistics purposes.
