### PR TITLE
[bots] Allow flakybot to make aggregate issues

### DIFF
--- a/torchci/lib/bot/verifyDisableTestIssueBot.ts
+++ b/torchci/lib/bot/verifyDisableTestIssueBot.ts
@@ -1,3 +1,4 @@
+import * as aggregateDisableIssue from "lib/flakyBot/aggregateDisableIssue";
 import * as singleDisableIssue from "lib/flakyBot/singleDisableIssue";
 import { Context, Probot } from "probot";
 import { hasWritePermissions } from "./utils";
@@ -97,6 +98,11 @@ export default function verifyDisableTestIssueBot(app: Probot): void {
         authorized
       );
       singleDisableIssue.fixLabels(context);
+    } else if (aggregateDisableIssue.isAggregateIssue(title)) {
+      validationComment = aggregateDisableIssue.formValidationComment(
+        context.payload["issue"],
+        authorized
+      );
     } else {
       // UNSTABLE
       const prefix = title.startsWith(unstableKey) ? unstableKey : disabledKey;

--- a/torchci/lib/flakyBot/aggregateDisableIssue.ts
+++ b/torchci/lib/flakyBot/aggregateDisableIssue.ts
@@ -1,0 +1,429 @@
+import dayjs from "dayjs";
+import { DisabledNonFlakyTestData, FlakyTestData, IssueData } from "lib/types";
+import _ from "lodash";
+import { Octokit } from "octokit";
+import { Context } from "probot";
+import {
+  formatTestNameForTitle,
+  getIssueBodyForFlakyTest,
+} from "./singleDisableIssue";
+import {
+  genInvalidPlatformsValidationSection,
+  genReenableValidationSection,
+  getLatestTrunkJobURL,
+  getPlatformsAffected,
+  getTestOwnerLabels,
+  getWorkflowJobNames,
+  NUM_HOURS_NOT_UPDATED_BEFORE_CLOSING,
+  supportedPlatforms,
+} from "./utils";
+
+const PYTORCH = "pytorch";
+export const MASS_FLAKY_TEST_ISSUE_LABEL = "aggregate flaky test issue";
+
+// MARK: create issue
+function getTitle(test: FlakyTestData) {
+  return `DISABLED MULTIPLE There are multiple flaky tests in ${test.file}`;
+}
+
+function formatPlatformsAffected(
+  platformMapping: Map<string, string[]>
+): string {
+  let body = "```\n";
+  for (const test of Array.from(platformMapping.keys()).sort()) {
+    const platforms = platformMapping.get(test)?.join(", ");
+    body += `${test}: ${platforms}`.trim();
+    body += "\n";
+  }
+  body += "```\n";
+  return body;
+}
+
+function formatTestsForBody(platformMapping: Map<string, string[]>): string {
+  let body = "disable the following tests:\n";
+  body += formatPlatformsAffected(platformMapping);
+  return body;
+}
+
+function getBody(tests: FlakyTestData[]) {
+  let body = `There are multiple flaky tests in ${tests[0].file}. Please investigate and fix the flakiness.\n\n`;
+  const platformMapping = tests.reduce((acc, test) => {
+    const platforms = getPlatformsAffected(getWorkflowJobNames(test));
+    const key = formatTestNameForTitle(test.name, test.suite);
+    if (acc.has(key)) {
+      const existingPlatforms = acc.get(key) || [];
+      acc.set(key, existingPlatforms.concat(platforms));
+    }
+    acc.set(key, platforms);
+    return acc;
+  }, new Map<string, string[]>());
+  body += formatTestsForBody(platformMapping);
+  body += `\nHere is an example for ${tests[0].name} (${tests[0].suite}):\n`;
+  body += getIssueBodyForFlakyTest(tests[0]);
+  return body;
+}
+
+export async function createNewAggregateIssue(
+  tests: FlakyTestData[],
+  octokit: Octokit
+) {
+  const title = getTitle(tests[0]);
+  let body = getBody(tests);
+  const { labels, additionalErrMessage } = await getTestOwnerLabels(tests[0]);
+  if (additionalErrMessage) {
+    body += `\n\n${additionalErrMessage}`;
+  }
+  await octokit.rest.issues.create({
+    owner: PYTORCH,
+    repo: PYTORCH,
+    title,
+    body,
+    labels: labels.concat(
+      MASS_FLAKY_TEST_ISSUE_LABEL,
+      "module: flaky-tests",
+      "skipped"
+    ),
+  });
+}
+
+// MARK: update issue
+
+/**
+ * Updates the issue with the given tests.  The issue should be open and the
+ * tests should correspond to the matching issue.
+ * @param octokit
+ * @param matchingIssue
+ * @param tests
+ */
+export async function updateAggregateFlakyTestIssue(
+  octokit: Octokit,
+  matchingIssue: IssueData,
+  tests: FlakyTestData[]
+) {
+  tests = tests.sort((a, b) => a.name.localeCompare(b.name));
+  const { platformMapping: existingPlatformMapping, bodyWithoutPlatforms } =
+    parseBody(matchingIssue.body);
+  const newPlatformMapping = new Map<string, string[]>();
+  const combinedPlatformMapping = new Map<string, string[]>();
+
+  for (const test of tests) {
+    const key = formatTestNameForTitle(test.name, test.suite);
+    const platforms = getPlatformsAffected(getWorkflowJobNames(test));
+    const existingPlatforms = existingPlatformMapping.get(key)!;
+    const newPlatforms = platforms.filter(
+      (p) => !existingPlatforms.includes(p)
+    );
+    newPlatformMapping.set(
+      key,
+      existingPlatforms.length == 0 ? [] : newPlatforms
+    );
+    combinedPlatformMapping.set(
+      key,
+      existingPlatforms.length == 0
+        ? []
+        : newPlatforms.concat(existingPlatforms)
+    );
+  }
+
+  const testPlatformBodySection = formatTestsForBody(combinedPlatformMapping);
+  const newBody = `${testPlatformBodySection}\n${bodyWithoutPlatforms}`;
+
+  const latestTrunkJobURL = getLatestTrunkJobURL(tests[0]);
+
+  let comment = `Another case of trunk flakiness has been found [here](${latestTrunkJobURL}). `;
+  if (matchingIssue.state !== "open") {
+    comment += `Reopening issue. `;
+  }
+
+  const hasNewPlatforms = [...newPlatformMapping]
+    .filter(([_, platforms]) => platforms.length > 0)
+    .sort((a, b) => a[0].localeCompare(b[0]));
+
+  if (hasNewPlatforms.length > 0) {
+    comment += `The lists of platforms does not appear to contain all the recently affected platforms. Adding the following platforms:`;
+    comment += `\n${formatPlatformsAffected(newPlatformMapping)}`;
+  } else {
+    comment +=
+      `The lists of platforms appear to contain all the recently affected platforms. ` +
+      `Either the change didn't propogate fast enough or disable bot might be broken. `;
+  }
+  await octokit.rest.issues.createComment({
+    owner: PYTORCH,
+    repo: PYTORCH,
+    issue_number: matchingIssue.number,
+    body: comment,
+  });
+  if (hasNewPlatforms.length > 0) {
+    await octokit.rest.issues.update({
+      owner: PYTORCH,
+      repo: PYTORCH,
+      issue_number: matchingIssue.number,
+      body: newBody,
+    });
+  }
+}
+
+// MARK: parse issue
+
+function parsePlatformsFromString(s: string) {
+  return s
+    .split(",")
+    .map((x) => x.trim().toLowerCase())
+    .filter((x) => x.length > 0);
+}
+
+/**
+ * Parse the body of an issue to find all the tests mentioned in code blocks.
+ * Might be incorrect if the body gets changed.
+ * @param body
+ * @returns
+ *   - platformMapping: a map of test name to platforms
+ *   - bodyWithoutPlatforms: the body without the platforms section
+ *   - invalidPlatformMapping: a map of test name to invalid platforms
+ *   - failedToParse: a list of tests that failed to parse
+ */
+function parseBody(body: string) {
+  const start = body.toLowerCase().search("disable the following tests:");
+  const platformMapping = new Map<string, string[]>();
+  const invalidPlatformMapping = new Map<string, string[]>();
+  const failedToParse: string[] = [];
+  if (start === -1) {
+    return {
+      platformMapping,
+      bodyWithoutPlatforms: body,
+      invalidPlatformMapping,
+      failedToParse,
+    };
+  }
+  const codeBlock = body.substring(start).split("```")[1];
+
+  const testRegex = new RegExp("(test_[a-zA-Z0-9_]+) \\(([a-zA-Z0-9\\._]+)\\)");
+  const possibleTests = codeBlock
+    .split("\n")
+    .filter((line) => line.trim().length > 0);
+  for (const test of possibleTests) {
+    const match = test.match(testRegex);
+    if (match) {
+      const platforms = parsePlatformsFromString(
+        test.split(":").length > 1 ? test.split(":")[1] : ""
+      );
+      const key = `${match[1]} (${match[2]})`;
+      const [validPlatforms, invalidPlatforms] = _.partition(
+        platforms,
+        (platform) => supportedPlatforms.has(platform)
+      );
+      platformMapping.set(key, validPlatforms);
+      if (invalidPlatforms.length > 0) {
+        invalidPlatformMapping.set(key, invalidPlatforms);
+      }
+    } else {
+      failedToParse.push(test);
+    }
+  }
+  const bodyWithoutPlatforms =
+    body.substring(0, start) +
+    body.substring(start).split("```").slice(2).join("```");
+  // Remove the platforms section from the body
+  return {
+    platformMapping,
+    bodyWithoutPlatforms,
+    invalidPlatformMapping,
+    failedToParse,
+  };
+}
+
+function testMatchesIssue(
+  issue: IssueData,
+  name: string,
+  suite: string
+): boolean {
+  if (issue.state !== "open") {
+    return false;
+  }
+  const { platformMapping } = parseBody(issue.body);
+  const testName = formatTestNameForTitle(name, suite);
+  return platformMapping.has(testName);
+}
+
+export function matchesAggregateFlakyTestIssue(
+  issue: IssueData,
+  test: FlakyTestData
+): boolean {
+  return testMatchesIssue(issue, test.name, test.suite);
+}
+
+// MARK: close issue
+
+export function nonFlakyTestMatchesIssue(
+  issue: IssueData,
+  test: DisabledNonFlakyTestData
+): boolean {
+  return testMatchesIssue(issue, test.name, test.classname);
+}
+
+/**
+ * Handle the case where a test is no longer flaky and the issue is still open.
+ * If all the tests are no longer flaky, close the issue.  Otherwise, remove the
+ * test from the list.  The issue should be open and the tests should correspond
+ * to the issue.
+ *
+ * @param tests
+ * @param issue
+ * @param octokit
+ * @returns
+ */
+export async function handleNoLongerFlakyTest(
+  tests: DisabledNonFlakyTestData[],
+  issue: IssueData,
+  octokit: Octokit
+) {
+  const updatedAt = dayjs(issue.updated_at);
+
+  // Only update the issue if the issue is not flaky and hasn't been updated in
+  // NUM_HOURS_NOT_UPDATED_BEFORE_CLOSING hours, defaults to 2 weeks
+  // Because this is an aggregate issue, it is possible that a few flaky test
+  // will block the rest, which might no longer be flaky, from being closed
+  if (
+    updatedAt.isAfter(
+      dayjs().subtract(NUM_HOURS_NOT_UPDATED_BEFORE_CLOSING, "hour")
+    )
+  ) {
+    console.log(
+      `Some tests in ${issue.number} is are not flaky but the issue was updated recently`
+    );
+    return;
+  }
+
+  const { platformMapping, bodyWithoutPlatforms } = parseBody(issue.body);
+  const noLongerFlakyTestNames = tests.map((test) =>
+    formatTestNameForTitle(test.name, test.classname)
+  );
+  const [noLongerFlaky, stillFlaky] = _.partition(
+    Array.from(platformMapping.keys()),
+    (key) => noLongerFlakyTestNames.includes(key)
+  );
+
+  if (stillFlaky.length > 0) {
+    console.log(
+      `Some tests in ${issue.number} are not flaky but others are still flaky`
+    );
+    // Remove the tests from the issue
+    const newPlatformMapping = new Map<string, string[]>();
+    for (const test of stillFlaky) {
+      const platforms = platformMapping.get(test);
+      if (platforms) {
+        newPlatformMapping.set(test, platforms);
+      }
+    }
+    const testPlatformBodySection = formatTestsForBody(newPlatformMapping);
+    const newBody = `${testPlatformBodySection}\n${bodyWithoutPlatforms}`;
+    await octokit.rest.issues.update({
+      owner: PYTORCH,
+      repo: PYTORCH,
+      issue_number: issue.number,
+      body: newBody,
+    });
+    const comment = `The following tests were removed from the list because they are no longer flaky: ${noLongerFlaky.join(
+      ", "
+    )}`;
+    await octokit.rest.issues.createComment({
+      owner: PYTORCH,
+      repo: PYTORCH,
+      issue_number: issue.number,
+      body: comment,
+    });
+    return;
+  }
+
+  const body =
+    `Resolving the issue because the tests are no longer flaky. Please reopen the ` +
+    `issue to re-disable the tests if you think this is a false positive`;
+  await octokit.rest.issues.createComment({
+    owner: PYTORCH,
+    repo: PYTORCH,
+    issue_number: issue.number,
+    body,
+  });
+
+  // Close the issue
+  await octokit.rest.issues.update({
+    owner: PYTORCH,
+    repo: PYTORCH,
+    issue_number: issue.number,
+    state: "closed",
+  });
+}
+
+// MARK: validation
+
+export function isAggregateIssue(title: string): boolean {
+  const prefix = "DISABLED MULTIPLE ";
+  return title.startsWith(prefix);
+}
+
+export function formValidationComment(
+  issue: Context<"issues">["payload"]["issue"],
+  authorized: boolean
+): string {
+  const username = issue.user.login;
+  const { platformMapping, invalidPlatformMapping, failedToParse } = parseBody(
+    issue.body || ""
+  );
+  const invalidPlatforms = _.uniq(
+    Array.from(invalidPlatformMapping.values()).flat()
+  ).sort();
+
+  let body =
+    "<body>Hello there! From the DISABLED MUTLIPLE prefix in this issue title, ";
+  body += "it looks like you are attempting to disable tests in PyTorch CI. ";
+  body += "The information I have parsed is below:\n\n";
+  for (const [testName, platforms] of platformMapping.entries()) {
+    const platformsToSkip = platforms.length > 0 ? platforms.join(", ") : "all";
+    body += `* Test name: \`${testName}\` on platforms: \`${platformsToSkip}\`\n`;
+  }
+  body += "\n";
+
+  if (invalidPlatforms.length > 0) {
+    body += genInvalidPlatformsValidationSection(invalidPlatforms);
+  }
+
+  if (!authorized) {
+    body += `<b>ERROR!</b> You (${username}) don't have permission to disable these tests.\n\n`;
+    body += "</body>";
+    return body;
+  }
+
+  if (failedToParse.length > 0) {
+    body +=
+      "<b>ERROR!</b> As you can see above, I could not properly parse the lines:\n";
+    body += "```\n";
+    body += failedToParse.join("\n");
+    body += "\n```\n\n";
+    body +=
+      "The format I expect is: `test_foo (__main__.TestBar): <platforms list>`.\n\n";
+  }
+
+  body += `Within ~15 minutes, the tests listed above will be disabled in CI.`;
+  body += `Please verify that the test names and platforms look correct.\n\n`;
+
+  body += "To modify the platforms list, please edit the list of tests. ";
+  body +=
+    "If no platforms are specified, then it will be disabled on every platform.  \n";
+  body += "We currently support the following platforms: ";
+  body += `${Array.from(supportedPlatforms.keys())
+    .sort((a, b) => a.localeCompare(b))
+    .join(", ")}.\n\n`;
+
+  body += genReenableValidationSection(issue.number);
+
+  body += "</body>";
+  return body;
+}
+
+export const __forTesting__ = {
+  getTitle,
+  parsePlatformsFromString,
+  getBody,
+  parseBody,
+  formatTestsForBody,
+};

--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -4,15 +4,17 @@ import fetchFlakyTests, {
   fetchFlakyTestsAcrossFileReruns,
 } from "lib/fetchFlakyTests";
 import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
+import * as aggregateDisableIssue from "lib/flakyBot/aggregateDisableIssue";
 import * as singleDisableIssue from "lib/flakyBot/singleDisableIssue";
 import { getOctokit } from "lib/github";
 import { DisabledNonFlakyTestData, FlakyTestData, IssueData } from "lib/types";
+import _ from "lodash";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Octokit } from "octokit";
 
 export const NUM_HOURS = 3;
-
 const PYTORCH = "pytorch";
+const THRESHOLD = 10;
 
 export default async function handler(
   req: NextApiRequest,
@@ -42,17 +44,36 @@ async function disableFlakyTestsAndReenableNonFlakyTests() {
     fetchDisabledNonFlakyTests(),
   ]);
 
+  // Separating this out to make it easier to test
+  await handleAll(
+    octokit,
+    flakyTests,
+    flakyTestsAcrossFileReruns,
+    issues,
+    disabledNonFlakyTests
+  );
+}
+
+async function handleAll(
+  octokit: Octokit,
+  flakyTests: FlakyTestData[],
+  flakyTestsAcrossFileReruns: FlakyTestData[],
+  issues: IssueData[],
+  disabledNonFlakyTests: DisabledNonFlakyTestData[]
+) {
   const allFlakyTests = flakyTests.concat(flakyTestsAcrossFileReruns);
+  allFlakyTests.forEach((test) => {
+    test.invoking_file = test.invoking_file.replaceAll(".", "/");
+  });
   // If the test is flaky only on PRs, we should not disable it yet.
+  const recentFlakyTests = allFlakyTests.filter((test) => wasRecent(test));
   const flakyTestsOnTrunk = filterThreshold(
-    filterOutPRFlakyTests(allFlakyTests)
+    filterOutPRFlakyTests(recentFlakyTests)
   );
 
   const dedupedIssues = await dedupFlakyTestIssues(octokit, issues);
 
-  flakyTestsOnTrunk.forEach(async function (test) {
-    await handleFlakyTest(test, dedupedIssues, octokit);
-  });
+  await handleFlakyTests(flakyTestsOnTrunk, dedupedIssues, octokit);
 
   // Get the list of non-flaky tests, the list of all flaky tests is used to guarantee
   // that no flaky test is accidentally closed
@@ -61,19 +82,16 @@ async function disableFlakyTestsAndReenableNonFlakyTests() {
     allFlakyTests
   );
 
-  nonFlakyTests.forEach(async function (test) {
-    await singleDisableIssue.handleNonFlakyTest(test, issues, octokit);
-  });
+  await handleNoLongerFlakyTests(nonFlakyTests, dedupedIssues, octokit);
 }
 
-export function filterOutPRFlakyTests(tests: FlakyTestData[]): FlakyTestData[] {
+function filterOutPRFlakyTests(tests: FlakyTestData[]): FlakyTestData[] {
   // Remove the PR-only instances of flakiness, but don't modify data within
   return tests.filter(
     (test) => test.branches.includes("master") || test.branches.includes("main")
   );
 }
-
-export function filterThreshold(
+function filterThreshold(
   tests: FlakyTestData[],
   threshold: number = 2
 ): FlakyTestData[] {
@@ -88,31 +106,81 @@ export function filterThreshold(
   );
 }
 
-export async function handleFlakyTest(
-  test: FlakyTestData,
+async function handleFlakyTests(
+  flakyTests: FlakyTestData[],
   issues: IssueData[],
   octokit: Octokit
 ) {
-  const issueTitle = singleDisableIssue.getIssueTitle(test.name, test.suite);
-  const matchingIssues = issues.filter((issue) => issue.title === issueTitle);
-  test.invoking_file = test.invoking_file.replaceAll(".", "/");
-  if (matchingIssues.length !== 0) {
-    // There is a matching issue
-    const matchingIssue = matchingIssues[0];
-    if (!wasRecent(test)) {
-      return;
+  // Determine the test 1. has a matching single issue, 2. has a matching
+  // aggregate issue, 3. needs a new single issue, 4. needs a new aggregate
+  // issue
+  const stillLeft = (
+    await Promise.all(
+      flakyTests.map(async (test) => {
+        for (const issue of issues) {
+          if (singleDisableIssue.matchesSingleFlakyTestIssue(issue, test)) {
+            await singleDisableIssue.updateExistingIssueForFlakyTest(
+              octokit,
+              issue,
+              test
+            );
+            return { test, keep: false };
+          }
+        }
+
+        return { test, keep: true };
+      })
+    )
+  )
+    .filter((x) => x.keep)
+    .map((x) => x.test);
+
+  // Map issue number -> tests that should update it
+  const aggregateIssueToBeUpdated = new Map<string, FlakyTestData[]>();
+
+  const needsNew = stillLeft.filter((test) => {
+    for (const issue of issues) {
+      if (aggregateDisableIssue.matchesAggregateFlakyTestIssue(issue, test)) {
+        aggregateIssueToBeUpdated.set(
+          issue.number.toString(),
+          (aggregateIssueToBeUpdated.get(issue.number.toString()) || []).concat(
+            [test]
+          )
+        );
+        return false;
+      }
     }
-    await singleDisableIssue.updateExistingIssueForFlakyTest(
+    return true;
+  });
+
+  for (const [issueNumber, tests] of aggregateIssueToBeUpdated.entries()) {
+    const issue = issues.find(
+      (issue) => issue.number.toString() === issueNumber
+    )!;
+    await aggregateDisableIssue.updateAggregateFlakyTestIssue(
       octokit,
-      matchingIssue,
-      test
+      issue,
+      tests
     );
-  } else {
-    await singleDisableIssue.createIssueFromFlakyTest(test, octokit);
+  }
+
+  const groupedByFile = _.groupBy(needsNew, (test) => test.file);
+
+  for (const file in groupedByFile) {
+    let tests = groupedByFile[file];
+    tests = tests.sort((a, b) => a.name.localeCompare(b.name));
+
+    if (tests.length > THRESHOLD) {
+      await aggregateDisableIssue.createNewAggregateIssue(tests, octokit);
+    } else {
+      for (const test of tests) {
+        await singleDisableIssue.createNewSingleIssue(test, octokit);
+      }
+    }
   }
 }
 
-export function filterOutNonFlakyTests(
+function filterOutNonFlakyTests(
   nonFlakyTests: DisabledNonFlakyTestData[],
   allFlakyTests: FlakyTestData[]
 ): DisabledNonFlakyTestData[] {
@@ -125,7 +193,7 @@ export function filterOutNonFlakyTests(
   );
 }
 
-export async function dedupFlakyTestIssues(
+async function dedupFlakyTestIssues(
   octokit: Octokit,
   issues: IssueData[]
 ): Promise<IssueData[]> {
@@ -133,8 +201,11 @@ export async function dedupFlakyTestIssues(
   // largest PR number.
 
   let deduped = new Map<string, IssueData>();
+  const [aggregateIssues, singleIssues] = _.partition(issues, (issue) =>
+    issue.labels.includes(aggregateDisableIssue.MASS_FLAKY_TEST_ISSUE_LABEL)
+  );
 
-  for (const issue of issues) {
+  for (const issue of singleIssues) {
     const key = issue.title;
     const existing_issue = deduped.get(key);
     if (
@@ -160,10 +231,73 @@ export async function dedupFlakyTestIssues(
       });
     }
   }
-  return dedupedArray;
+
+  return dedupedArray.concat(aggregateIssues);
 }
 
-export function wasRecent(test: FlakyTestData) {
+async function handleNoLongerFlakyTests(
+  tests: DisabledNonFlakyTestData[],
+  issues: IssueData[],
+  octokit: Octokit
+) {
+  const openIssues = issues.filter((issue) => issue.state === "open");
+
+  // Sort the tests by the issues they should update.
+  // Map issue number -> tests that should update it
+  const singleIssueToBeUpdated = new Map<string, DisabledNonFlakyTestData[]>();
+  const aggregateIssueToBeUpdated = new Map<
+    string,
+    DisabledNonFlakyTestData[]
+  >();
+
+  for (const test of tests) {
+    for (const issue of openIssues) {
+      if (singleDisableIssue.nonFlakyTestMatchesIssue(issue, test)) {
+        singleIssueToBeUpdated.set(
+          issue.number.toString(),
+          (singleIssueToBeUpdated.get(issue.number.toString()) || []).concat([
+            test,
+          ])
+        );
+      }
+      if (aggregateDisableIssue.nonFlakyTestMatchesIssue(issue, test)) {
+        aggregateIssueToBeUpdated.set(
+          issue.number.toString(),
+          (aggregateIssueToBeUpdated.get(issue.number.toString()) || []).concat(
+            [test]
+          )
+        );
+      }
+    }
+  }
+
+  for (const [issueNumber, tests] of singleIssueToBeUpdated) {
+    const issue = openIssues.find(
+      (issue) => issue.number.toString() === issueNumber
+    );
+    if (issue) {
+      await singleDisableIssue.handleNoLongerFlakyTest(
+        tests[0],
+        issue,
+        octokit
+      );
+    }
+  }
+  for (const [issueNumber, tests] of aggregateIssueToBeUpdated) {
+    const issue = openIssues.find(
+      (issue) => issue.number.toString() === issueNumber
+    );
+    if (issue) {
+      await aggregateDisableIssue.handleNoLongerFlakyTest(
+        tests,
+        issue,
+        octokit
+      );
+    }
+  }
+}
+
+function wasRecent(test: FlakyTestData) {
   if (test.eventTimes) {
     return test.eventTimes.some(
       (value) => dayjs().diff(dayjs(value), "minutes") < NUM_HOURS * 60
@@ -171,3 +305,11 @@ export function wasRecent(test: FlakyTestData) {
   }
   return true;
 }
+
+export const __forTesting__ = {
+  handleNoLongerFlakyTests,
+  filterOutPRFlakyTests,
+  filterOutNonFlakyTests,
+  dedupFlakyTestIssues,
+  handleAll,
+};

--- a/torchci/test/flakyBotTests/flakyAggregateIssue.test.ts
+++ b/torchci/test/flakyBotTests/flakyAggregateIssue.test.ts
@@ -1,0 +1,127 @@
+import nock from "nock";
+import { __forTesting__ as aggregateDisableIssue } from "../../lib/flakyBot/aggregateDisableIssue";
+import { flakyTestA } from "./flakyBotTestsUtils";
+
+nock.disableNetConnect();
+
+describe("Flaky Test Bot Aggregate Issue Unit Tests", () => {
+  test("getBody", () => {
+    const body = aggregateDisableIssue.getBody([flakyTestA]);
+    const shouldContain = [
+      "disable the following tests:\n",
+      "Test file path: `file_a.py`",
+      "https://hud.pytorch.org/flakytest?name=test_a&suite=suite_a&limit=100",
+      "test_a (__main__.suite_a): win\n",
+    ];
+    for (const str of shouldContain) {
+      expect(body).toContain(str);
+    }
+    expect(
+      body.startsWith(`There are multiple flaky tests in ${flakyTestA.file}. Please investigate and fix the flakiness.
+
+disable the following tests:
+\`\`\`
+test_a (__main__.suite_a): win
+\`\`\`
+
+Here is an example for`)
+    ).toEqual(true);
+  });
+
+  test("parseBody and getBody should correspond", async () => {
+    const body = aggregateDisableIssue.getBody([flakyTestA]);
+    const parsed = aggregateDisableIssue.parseBody(body);
+    expect(parsed.platformMapping).toEqual(
+      new Map([["test_a (__main__.suite_a)", ["win"]]])
+    );
+    expect(parsed.invalidPlatformMapping).toEqual(new Map());
+    expect(parsed.failedToParse).toEqual([]);
+    expect(
+      parsed.bodyWithoutPlatforms.startsWith(
+        "There are multiple flaky tests in file_a.py. Please investigate and fix the flakiness."
+      )
+    ).toEqual(true);
+  });
+
+  test("parseBody", () => {
+    function _helper(body: string, expected: Map<string, string[]>) {
+      const tests = aggregateDisableIssue.parseBody(body);
+      expect(tests.platformMapping).toEqual(expected);
+    }
+    _helper("no tests", new Map());
+    _helper("disable the following tests:\n```\n```", new Map());
+    _helper(
+      "disable the following tests:\n```test_a (__main__.testB): mac\n```",
+      new Map([["test_a (__main__.testB)", ["mac"]]])
+    );
+    // random casing
+    _helper(
+      "DiSaBlE ThE FoLloWing tests:\n```test_a (__main__.testB): mac\n```",
+      new Map([["test_a (__main__.testB)", ["mac"]]])
+    );
+    // Random extra block
+    _helper(
+      "disable the following tests:\n```test_a (__main__.testB): mac\n```test_a (testC): mac\n```",
+      new Map([["test_a (__main__.testB)", ["mac"]]])
+    );
+    // Mutliple platforms
+    _helper(
+      "disable the following tests:\n```test_a (__main__.testB): mac, win\n```",
+      new Map([["test_a (__main__.testB)", ["mac", "win"]]])
+    );
+    // No platforms (should be all)
+    _helper(
+      "disable the following tests:\n```test_a (__main__.testB):\n```",
+      new Map([["test_a (__main__.testB)", []]])
+    );
+    // Multiple tests
+    _helper(
+      "disable the following tests:\n```test_1 (__main__.testB):\ntest_2 (__main__.testB):\n```",
+      new Map([
+        ["test_1 (__main__.testB)", []],
+        ["test_2 (__main__.testB)", []],
+      ])
+    );
+  });
+
+  test("getTitle", () => {
+    const title = aggregateDisableIssue.getTitle(flakyTestA);
+    expect(title).toEqual(
+      "DISABLED MULTIPLE There are multiple flaky tests in file_a.py"
+    );
+  });
+
+  test("parsePlatformsFromString", () => {
+    function _helper(platforms: string, expected: string[]) {
+      const parsed = aggregateDisableIssue.parsePlatformsFromString(platforms);
+      expect(parsed).toEqual(expected);
+    }
+    _helper("", []);
+    _helper("mac", ["mac"]);
+    _helper("mac, win", ["mac", "win"]);
+    _helper("mac, win, linux", ["mac", "win", "linux"]);
+    // Whitespace checks
+    _helper("  ", []);
+    _helper("mac,  win", ["mac", "win"]);
+    _helper("mac,  win ", ["mac", "win"]);
+    _helper("  mac,  win ", ["mac", "win"]);
+  });
+
+  test("formatTestsForBody", async () => {
+    const body = aggregateDisableIssue.formatTestsForBody(
+      new Map([
+        ["test_a (__main__.suite_a)", ["win"]],
+        ["test_b (__main__.suite_a)", ["win", "linux"]],
+        ["test_c (__main__.suite_a)", []],
+      ])
+    );
+
+    expect(body).toEqual(`disable the following tests:
+\`\`\`
+test_a (__main__.suite_a): win
+test_b (__main__.suite_a): win, linux
+test_c (__main__.suite_a):
+\`\`\`
+`);
+  });
+});

--- a/torchci/test/flakyBotTests/flakyBotIntegration.test.ts
+++ b/torchci/test/flakyBotTests/flakyBotIntegration.test.ts
@@ -1,609 +1,733 @@
 import dayjs from "dayjs";
-import * as singleDisableIssue from "lib/flakyBot/singleDisableIssue";
-import { handleNonFlakyTest } from "lib/flakyBot/singleDisableIssue";
-import { NUM_HOURS_NOT_UPDATED_BEFORE_CLOSING } from "lib/flakyBot/utils";
-import { IssueData } from "lib/types";
+import { __forTesting__ as aggregateDisableIssue } from "lib/flakyBot/aggregateDisableIssue";
+import * as flakyBotUtils from "lib/flakyBot/utils";
+import { FlakyTestData, IssueData } from "lib/types";
 import nock from "nock";
-import { handleFlakyTest } from "pages/api/flaky-tests/disable";
-import { deepCopy, handleScope } from "test/common";
+import { __forTesting__ as disableFlakyTestBot } from "pages/api/flaky-tests/disable";
+import { deepCopy, handleScope } from "../common";
+import * as utils from "../utils";
 import {
   flakyTestA,
-  flakyTestAcrossJobA,
   flakyTestB,
+  genValidFlakyTest,
   mockGetRawTestFile,
   nonFlakyTestA,
-} from "test/flakyBotTests/flakyBotTestsUtils";
-import * as utils from "test/utils";
+} from "./flakyBotTestsUtils";
 
 nock.disableNetConnect();
 
-describe("Disable Flaky Test Bot Across Jobs", () => {
+function mockUpdateIssue({
+  issueNumber,
+  labels,
+  state,
+  bodyContains,
+}: {
+  issueNumber: number;
+  labels?: string[];
+  state?: string;
+  bodyContains?: string[];
+}) {
+  return nock("https://api.github.com")
+    .patch(`/repos/pytorch/pytorch/issues/${issueNumber}`, (body) => {
+      if (labels !== undefined) {
+        expect(body).toMatchObject({ labels });
+      }
+      if (state !== undefined) {
+        expect(body).toMatchObject({ state });
+      }
+      for (const containedString of bodyContains ?? []) {
+        expect(body.body).toContain(containedString);
+      }
+      return true;
+    })
+    .reply(200, {});
+}
+
+describe("Disable Flaky Test Integration Tests", () => {
   const octokit = utils.testOctokit();
 
   beforeEach(() => {});
 
   afterEach(() => {
+    nock.cleanAll();
     jest.restoreAllMocks();
   });
 
-  test("Create new issue", async () => {
-    const scope = mockGetRawTestFile(
-      flakyTestAcrossJobA.file,
-      `# Owner(s): ["module: fft"]\nimport blah;\nrest of file`
-    );
-    const scope2 = utils.mockCreateIssue(
-      "pytorch/pytorch",
-      "DISABLED test_conv1d_vs_scipy_mode_same_cuda_complex64 (__main__.TestConvolutionNNDeviceTypeCUDA)",
-      ["Platforms: "],
-      [
-        "skipped",
-        "module: flaky-tests",
-        "module: fft",
-        "module: rocm",
-        "triaged",
-      ]
-    );
-
-    await handleFlakyTest(flakyTestAcrossJobA, [], octokit);
-
-    handleScope(scope);
-    handleScope(scope2);
-  });
-
-  test("flaky test associated with an open issue should comment if recent", async () => {
-    let flakyTest = { ...flakyTestAcrossJobA };
-    flakyTest.eventTimes = [dayjs().subtract(1, "hour").toString()];
-    const scope = nock("https://api.github.com")
-      .post("/repos/pytorch/pytorch/issues/1/comments", (body) => {
-        const comment = JSON.stringify(body.body);
-        expect(comment).toContain(
-          "Another case of trunk flakiness has been found"
-        );
-        expect(comment).toContain("appears to contain");
-        expect(comment).toContain("Either the change didn't propogate");
-        return true;
-      })
-      .reply(200, {});
-
-    const issues = [
-      {
+  describe("Single Test Issue", () => {
+    function genSingleIssueFor(
+      test: FlakyTestData,
+      input: Partial<IssueData>
+    ): IssueData {
+      return {
         number: 1,
-        title:
-          "DISABLED test_conv1d_vs_scipy_mode_same_cuda_complex64 (__main__.TestConvolutionNNDeviceTypeCUDA)",
-        html_url: "https://api.github.com/repos/pytorch/pytorch/issues/1",
+        title: `DISABLED ${test.name} (__main__.${test.suite})`,
+        html_url: "test url",
         state: "open" as "open" | "closed",
-        body: "random",
-        updated_at: dayjs().toString(),
+        body: `Platforms: ${flakyBotUtils.getPlatformsAffected(test.jobNames)}`,
+        updated_at: dayjs().subtract(4, "hour").toString(),
         author_association: "MEMBER",
         labels: [],
-      },
-    ];
+        ...input,
+      };
+    }
+    describe("Create/update issues", () => {
+      test("Create new issue", async () => {
+        const flakyTest = { ...flakyTestA };
+        const scope = [
+          mockGetRawTestFile(
+            flakyTest.file,
+            `# Owner(s): ["module: fft"]\nimport blah;\nrest of file`
+          ),
+          utils.mockCreateIssue(
+            "pytorch/pytorch",
+            "DISABLED test_a (__main__.suite_a)",
+            ["Platforms: "],
+            [
+              "skipped",
+              "module: flaky-tests",
+              "module: fft",
+              "module: windows",
+              "triaged",
+            ]
+          ),
+        ];
 
-    await handleFlakyTest(flakyTest, issues, octokit);
+        await disableFlakyTestBot.handleAll(octokit, [flakyTest], [], [], []);
 
-    handleScope(scope);
+        handleScope(scope);
+      });
+
+      test("Comment on open issue", async () => {
+        const flakyTest = { ...flakyTestA };
+        const issues = [genSingleIssueFor(flakyTest, {})];
+
+        const scope = [
+          utils.mockPostComment("pytorch/pytorch", 1, [
+            "Another case of trunk flakiness has been found",
+            "appears to contain",
+            "Either the change didn't propogate",
+          ]),
+        ];
+
+        await disableFlakyTestBot.handleAll(
+          octokit,
+          [flakyTest],
+          [],
+          issues,
+          []
+        );
+
+        handleScope(scope);
+      });
+      test("No reopen if flake is old", async () => {
+        const flakyTest = {
+          ...flakyTestA,
+          eventTimes: [dayjs().subtract(5, "hour").toString()],
+        };
+        const issues = [genSingleIssueFor(flakyTest, { state: "closed" })];
+
+        await disableFlakyTestBot.handleAll(
+          octokit,
+          [flakyTest],
+          [],
+          issues,
+          []
+        );
+      });
+
+      test("Add platforms", async () => {
+        const flakyTest = { ...flakyTestA };
+        const issues = [genSingleIssueFor(flakyTest, {})];
+        flakyTest.jobNames = ["linux1", "linux2", "linux3"];
+
+        const scope = [
+          utils.mockPostComment("pytorch/pytorch", 1, [
+            "Another case of trunk flakiness has been found",
+            "list of platforms [win] does not appear to contain all",
+          ]),
+          mockUpdateIssue({
+            issueNumber: 1,
+            bodyContains: ["Platforms: win, linux"],
+            state: "open",
+          }),
+        ];
+
+        await disableFlakyTestBot.handleAll(
+          octokit,
+          [flakyTest],
+          [],
+          issues,
+          []
+        );
+
+        handleScope(scope);
+      });
+
+      test("Do not modify platforms (no platforms string)", async () => {
+        const flakyTest = { ...flakyTestA };
+        const issues = [genSingleIssueFor(flakyTest, { body: "a\nb\nc" })];
+        flakyTest.jobNames = ["linux1", "linux2", "linux3"];
+
+        const scope = [
+          utils.mockPostComment("pytorch/pytorch", 1, [
+            "Another case of trunk flakiness has been found",
+            "appears to contain all the recently affected",
+          ]),
+        ];
+
+        await disableFlakyTestBot.handleAll(
+          octokit,
+          [flakyTest],
+          [],
+          issues,
+          []
+        );
+
+        handleScope(scope);
+      });
+
+      test("Reopen and modify platforms", async () => {
+        const test = deepCopy(flakyTestA);
+        const issue = genSingleIssueFor(test, {
+          body: "Platforms: linux\nhello\n\na\nb",
+          state: "closed",
+        });
+
+        const scope = [
+          mockUpdateIssue({
+            issueNumber: issue.number,
+            bodyContains: ["Platforms: linux, win"],
+            state: "open",
+          }),
+          utils.mockPostComment("pytorch/pytorch", issue.number, [
+            "Another case of trunk flakiness has been found",
+            "does not appear to contain",
+            "Adding [win]",
+            "Reopening issue",
+          ]),
+        ];
+
+        await disableFlakyTestBot.handleAll(octokit, [test], [], [issue], []);
+        handleScope(scope);
+      });
+
+      test("Reopen issue, all platforms present", async () => {
+        const test = deepCopy(flakyTestA);
+        const issue = genSingleIssueFor(test, {
+          body: "Platforms: win\nhello\n\na\nb",
+          state: "closed",
+        });
+
+        const scope = [
+          mockUpdateIssue({
+            issueNumber: issue.number,
+            state: "open",
+          }),
+          utils.mockPostComment("pytorch/pytorch", issue.number, [
+            "Another case of trunk flakiness has been found",
+            "appears to contain all the recently affected",
+            "Reopening issue",
+          ]),
+        ];
+
+        await disableFlakyTestBot.handleAll(octokit, [test], [], [issue], []);
+
+        handleScope(scope);
+      });
+
+      test("Add platforms", async () => {
+        const test = deepCopy(flakyTestA);
+        const issue = genSingleIssueFor(test, {
+          body: "Platforms: inductor, dynamo\nhello",
+        });
+        test.jobNames.push("rocm");
+        test.workflowNames.push("test");
+
+        const scope = [
+          mockUpdateIssue({
+            issueNumber: issue.number,
+            state: "open",
+            bodyContains: ["Platforms: dynamo, inductor, rocm", "hello"],
+          }),
+
+          utils.mockPostComment("pytorch/pytorch", issue.number, [
+            "Another case of trunk flakiness has been found",
+            "does not appear to contain",
+            "Adding [rocm, win]",
+          ]),
+        ];
+
+        await disableFlakyTestBot.handleAll(octokit, [test], [], [issue], []);
+
+        handleScope(scope);
+      });
+
+      test("Reopen, add platforms", async () => {
+        const test = deepCopy(flakyTestA);
+        const issue = genSingleIssueFor(test, {
+          body: "Platforms: win, dynamo\nhello",
+          state: "closed",
+        });
+
+        const scope = [
+          mockUpdateIssue({
+            issueNumber: issue.number,
+            state: "open",
+          }),
+          utils.mockPostComment("pytorch/pytorch", issue.number, [
+            "Another case of trunk flakiness has been found",
+            "appears to contain",
+            "Reopening issue",
+          ]),
+        ];
+
+        await disableFlakyTestBot.handleAll(octokit, [test], [], [issue], []);
+
+        handleScope(scope);
+      });
+
+      test("No comment if flake is old", async () => {
+        // Same as Comment on open issue, but with a different event time
+        const flakyTest = {
+          ...flakyTestA,
+          eventTimes: [dayjs().subtract(5, "hour").toString()],
+        };
+        const issues = [genSingleIssueFor(flakyTest, {})];
+
+        await disableFlakyTestBot.handleAll(
+          octokit,
+          [flakyTest],
+          [],
+          issues,
+          []
+        );
+      });
+
+      test("Reopen closed issue and comment", async () => {
+        const flakyTest = { ...flakyTestA };
+        const issues = [genSingleIssueFor(flakyTest, { state: "closed" })];
+
+        const scope = [
+          mockUpdateIssue({
+            issueNumber: 1,
+            state: "open",
+          }),
+          utils.mockPostComment("pytorch/pytorch", 1, [
+            "Another case of trunk flakiness has been found",
+            "appears to contain",
+            "Reopening",
+          ]),
+        ];
+
+        await disableFlakyTestBot.handleAll(
+          octokit,
+          [flakyTest],
+          [],
+          issues,
+          []
+        );
+
+        handleScope(scope);
+      });
+    });
+
+    describe("Close no longer flaky tests", () => {
+      const flakyTestIssue = genSingleIssueFor(
+        genValidFlakyTest({ ...nonFlakyTestA, suite: nonFlakyTestA.classname }),
+        {
+          updated_at: dayjs()
+            .subtract(
+              flakyBotUtils.NUM_HOURS_NOT_UPDATED_BEFORE_CLOSING + 1,
+              "hour"
+            )
+            .toISOString(),
+        }
+      );
+
+      test("Comment and close", async () => {
+        const scope = [
+          utils.mockPostComment("pytorch/pytorch", 1, [
+            "Resolving the issue because the test is not flaky anymore",
+          ]),
+          mockUpdateIssue({
+            issueNumber: 1,
+            state: "closed",
+          }),
+        ];
+
+        const issues: IssueData[] = [{ ...flakyTestIssue }];
+
+        await disableFlakyTestBot.handleAll(octokit, [], [], issues, [
+          nonFlakyTestA,
+        ]);
+
+        handleScope(scope);
+      });
+
+      test("Do nothing if issue updated recently", async () => {
+        const issues: IssueData[] = [
+          {
+            ...flakyTestIssue,
+            updated_at: dayjs()
+              .subtract(
+                flakyBotUtils.NUM_HOURS_NOT_UPDATED_BEFORE_CLOSING - 1,
+                "hour"
+              )
+              .toISOString(),
+          },
+        ];
+        await disableFlakyTestBot.handleAll(octokit, [], [], issues, [
+          nonFlakyTestA,
+        ]);
+      });
+    });
   });
 
-  test("flaky test associated with an open issue should NOT comment if NOT recent", async () => {
-    let flakyTest = { ...flakyTestAcrossJobA };
-    flakyTest.eventTimes = [dayjs().subtract(5, "hour").toString()];
+  describe("Aggregate Test Issue", () => {
+    function genAggTests(test: FlakyTestData) {
+      return Array.from({ length: 11 }, (_, i) =>
+        genValidFlakyTest({
+          ...test,
 
-    const issues = [
-      {
+          name: `test_${i}`,
+          suite: `suite_${i}`,
+        })
+      );
+    }
+    function genAggIssueFor(
+      tests: FlakyTestData[],
+      input: Partial<IssueData>
+    ): IssueData {
+      return {
         number: 1,
-        title:
-          "DISABLED test_conv1d_vs_scipy_mode_same_cuda_complex64 (__main__.TestConvolutionNNDeviceTypeCUDA)",
-        html_url: "https://api.github.com/repos/pytorch/pytorch/issues/1",
+        title: aggregateDisableIssue.getTitle(tests[0]),
+        html_url: "test url",
         state: "open" as "open" | "closed",
-        body: "random",
-        updated_at: dayjs().toString(),
+        body: aggregateDisableIssue.getBody(tests),
+        updated_at: dayjs().subtract(4, "hour").toString(),
         author_association: "MEMBER",
         labels: [],
-      },
-    ];
+        ...input,
+      };
+    }
 
-    await handleFlakyTest(flakyTest, issues, octokit);
-  });
+    describe("Create/update issues", () => {
+      test("Create new issue", async () => {
+        const tests = genAggTests(flakyTestA);
+        const scope = [
+          mockGetRawTestFile(
+            tests[0].file,
+            `# Owner(s): ["module: fft"]\nimport blah;\nrest of file`
+          ),
+          utils.mockCreateIssue(
+            "pytorch/pytorch",
+            `DISABLED MULTIPLE There are multiple flaky tests in ${tests[0].file}`,
+            ["Platforms: "],
+            [
+              "aggregate flaky test issue",
+              "skipped",
+              "module: flaky-tests",
+              "module: windows",
+              "module: fft",
+              "triaged",
+            ]
+          ),
+        ];
 
-  test("flaky test associated with a closed issue should reopen issue and comment if recent", async () => {
-    let flakyTest = { ...flakyTestAcrossJobA };
-    flakyTest.eventTimes = [dayjs().subtract(1, "hour").toString()];
-    const scope = nock("https://api.github.com")
-      .patch("/repos/pytorch/pytorch/issues/1", (body) => {
-        expect(body).toMatchObject({ state: "open" });
-        return true;
-      })
-      .reply(200, {})
-      .post("/repos/pytorch/pytorch/issues/1/comments", (body) => {
-        const comment = JSON.stringify(body.body);
-        expect(comment).toContain(
-          "Another case of trunk flakiness has been found"
-        );
-        expect(comment).toContain("Reopening");
-        return true;
-      })
-      .reply(200, {});
+        await disableFlakyTestBot.handleAll(octokit, tests, [], [], []);
 
-    const issues = [
-      {
-        number: 1,
-        title:
-          "DISABLED test_conv1d_vs_scipy_mode_same_cuda_complex64 (__main__.TestConvolutionNNDeviceTypeCUDA)",
-        html_url: "https://api.github.com/repos/pytorch/pytorch/issues/1",
-        state: "closed" as "open" | "closed",
-        body: "random",
-        updated_at: dayjs().toString(),
-        author_association: "MEMBER",
-        labels: [],
-      },
-    ];
+        handleScope(scope);
+      });
 
-    await handleFlakyTest(flakyTest, issues, octokit);
+      test("Create two new issues", async () => {
+        const tests = [...genAggTests(flakyTestA), ...genAggTests(flakyTestB)];
+        const scope = [
+          mockGetRawTestFile(
+            tests[0].file,
+            `# Owner(s): ["module: fft"]\nimport blah;\nrest of file`
+          ),
+          mockGetRawTestFile(
+            tests[tests.length - 1].file,
+            `# Owner(s): ["module: idk"]\nimport blah;\nrest of file`
+          ),
+          utils.mockCreateIssue(
+            "pytorch/pytorch",
+            `DISABLED MULTIPLE There are multiple flaky tests in ${tests[0].file}`,
+            ["Platforms: "],
+            [
+              "aggregate flaky test issue",
+              "skipped",
+              "module: flaky-tests",
+              "module: windows",
+              "module: fft",
+              "triaged",
+            ]
+          ),
+          utils.mockCreateIssue(
+            "pytorch/pytorch",
+            `DISABLED MULTIPLE There are multiple flaky tests in ${
+              tests[tests.length - 1].file
+            }`,
+            ["Platforms: "],
+            [
+              "aggregate flaky test issue",
+              "skipped",
+              "module: idk",
+              "module: flaky-tests",
+              "module: windows",
+              "triaged",
+            ]
+          ),
+        ];
 
-    handleScope(scope);
-  });
+        await disableFlakyTestBot.handleAll(octokit, tests, [], [], []);
 
-  test("flaky test associated with a closed issue should NOT reopen issue and comment if NOT recent", async () => {
-    let flakyTest = { ...flakyTestAcrossJobA };
-    flakyTest.eventTimes = [dayjs().subtract(5, "hour").toString()];
+        handleScope(scope);
+      });
 
-    const issues = [
-      {
-        number: 1,
-        title:
-          "DISABLED test_conv1d_vs_scipy_mode_same_cuda_complex64 (__main__.TestConvolutionNNDeviceTypeCUDA)",
-        html_url: "https://api.github.com/repos/pytorch/pytorch/issues/1",
-        state: "closed" as "open" | "closed",
-        body: "random",
-        updated_at: dayjs().toString(),
-        author_association: "MEMBER",
-        labels: [],
-      },
-    ];
+      test("Comment on open issue", async () => {
+        const tests = genAggTests(flakyTestA);
+        const issues = [genAggIssueFor(tests, {})];
 
-    await handleFlakyTest(flakyTest, issues, octokit);
-  });
-});
+        const scope = [
+          utils.mockPostComment("pytorch/pytorch", 1, [
+            "Another case of trunk flakiness has been found",
+            "appear to contain",
+            "Either the change didn't propogate",
+          ]),
+        ];
 
-describe("Disable Flaky Test Bot Integration Tests", () => {
-  const octokit = utils.testOctokit();
+        await disableFlakyTestBot.handleAll(octokit, tests, [], issues, []);
 
-  beforeEach(() => {});
+        handleScope(scope);
+      });
 
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
+      test("No recomment if flake is old", async () => {
+        const tests = genAggTests({
+          ...flakyTestA,
+          eventTimes: [dayjs().subtract(5, "hour").toString()],
+        });
+        const issues = [genAggIssueFor(tests, {})];
 
-  test("previously undetected flaky test should create an issue", async () => {
-    const scope = mockGetRawTestFile(
-      flakyTestA.file,
-      `# Owner(s): ["module: fft"]\nimport blah;\nrest of file`
-    );
-    const scope2 = utils.mockCreateIssue(
-      "pytorch/pytorch",
-      "DISABLED test_a (__main__.suite_a)",
-      ["Platforms: "],
-      [
-        "skipped",
-        "module: flaky-tests",
-        "module: fft",
-        "module: windows",
-        "triaged",
-      ]
-    );
+        await disableFlakyTestBot.handleAll(octokit, tests, [], issues, []);
+      });
 
-    await handleFlakyTest(flakyTestA, [], octokit);
+      test("Add platforms for all tests", async () => {
+        const tests = genAggTests({
+          ...flakyTestA,
+        });
+        const issues = [genAggIssueFor(tests, {})];
+        tests.forEach((test) => {
+          test.jobNames = ["linux1", "linux2", "linux3"];
+        });
 
-    handleScope(scope);
-    handleScope(scope2);
-  });
+        const scope = [
+          utils.mockPostComment("pytorch/pytorch", 1, [
+            "Another case of trunk flakiness has been found",
+            "lists of platforms does not appear",
+          ]),
+          mockUpdateIssue({
+            issueNumber: 1,
+            bodyContains: ["test_10 (__main__.suite_10): linux, win"],
+          }),
+        ];
 
-  test("previously undetected flaky test should create an issue on main", async () => {
-    const scope = mockGetRawTestFile(
-      flakyTestB.file,
-      `# Owner(s): ["module: fft"]\nimport blah;\nrest of file`
-    );
-    const scope2 = utils.mockCreateIssue(
-      "pytorch/pytorch",
-      "DISABLED test_b (__main__.suite_b)",
-      ["Platforms:"],
-      [
-        "skipped",
-        "module: flaky-tests",
-        "module: fft",
-        "module: windows",
-        "triaged",
-      ]
-    );
+        await disableFlakyTestBot.handleAll(octokit, tests, [], issues, []);
 
-    await handleFlakyTest(flakyTestB, [], octokit);
+        handleScope(scope);
+      });
 
-    handleScope(scope);
-    handleScope(scope2);
-  });
+      test("Add platforms for a few tests", async () => {
+        const tests = genAggTests({
+          ...flakyTestA,
+        });
+        const issues = [genAggIssueFor(tests, {})];
+        tests[4].jobNames = ["linux1", "linux2", "linux3"];
+        tests[7].jobNames = ["linux1", "linux2", "linux3"];
 
-  test("flaky test associated with an open issue should comment", async () => {
-    const scope = nock("https://api.github.com")
-      .post("/repos/pytorch/pytorch/issues/1/comments", (body) => {
-        const comment = JSON.stringify(body.body);
-        expect(comment).toContain(
-          "Another case of trunk flakiness has been found"
-        );
-        expect(comment).toContain("Either the change didn't propogate");
-        return true;
-      })
-      .reply(200, {});
+        const scope = [
+          utils.mockPostComment("pytorch/pytorch", 1, [
+            "Another case of trunk flakiness has been found",
+            "lists of platforms does not appear",
+          ]),
+          mockUpdateIssue({
+            issueNumber: 1,
+            bodyContains: [
+              "test_2 (__main__.suite_2): win\n",
+              "test_4 (__main__.suite_4): linux, win\n",
+              "test_7 (__main__.suite_7): linux, win\n",
+              "test_5 (__main__.suite_5): win\n",
+            ],
+          }),
+        ];
 
-    const issues: IssueData[] = [
-      {
-        number: 1,
-        title: "DISABLED test_a (__main__.suite_a)",
-        html_url: "https://api.github.com/repos/pytorch/pytorch/issues/1",
-        state: "open" as "open" | "closed",
-        body: "random",
-        updated_at: dayjs().toString(),
-        author_association: "MEMBER",
-        labels: [],
-      },
-    ];
+        await disableFlakyTestBot.handleAll(octokit, tests, [], issues, []);
 
-    await handleFlakyTest(flakyTestA, issues, octokit);
+        handleScope(scope);
+      });
 
-    handleScope(scope);
-  });
+      test("Do not modify platforms (no platforms string)", async () => {
+        const tests = genAggTests({ ...flakyTestA });
+        const issues = [genAggIssueFor(tests, {})];
+        issues[0].body.replaceAll(": win\n", ":\n");
 
-  test("flaky test associated with a closed issue should reopen issue and comment", async () => {
-    const scope = nock("https://api.github.com")
-      .patch("/repos/pytorch/pytorch/issues/1", (body) => {
-        expect(body).toMatchObject({ state: "open" });
-        return true;
-      })
-      .reply(200, {})
-      .post("/repos/pytorch/pytorch/issues/1/comments", (body) => {
-        const comment = JSON.stringify(body.body);
-        expect(comment).toContain(
-          "Another case of trunk flakiness has been found"
-        );
-        expect(comment).toContain("Reopening");
-        return true;
-      })
-      .reply(200, {});
+        const scope = [
+          utils.mockPostComment("pytorch/pytorch", 1, [
+            "Another case of trunk flakiness has been found",
+            "appear to contain all the recently affected platform",
+          ]),
+        ];
 
-    const issues: IssueData[] = [
-      {
-        number: 1,
-        title: "DISABLED test_a (__main__.suite_a)",
-        html_url: "https://api.github.com/pytorch/pytorch/issues/1",
-        state: "closed" as "open" | "closed",
-        body: "random",
-        updated_at: dayjs().toString(),
-        author_association: "MEMBER",
-        labels: [],
-      },
-    ];
+        await disableFlakyTestBot.handleAll(octokit, tests, [], issues, []);
 
-    await handleFlakyTest(flakyTestA, issues, octokit);
+        handleScope(scope);
+      });
 
-    handleScope(scope);
-  });
+      test("Never reopen, always make a new one", async () => {
+        const tests = genAggTests({ ...flakyTestA });
+        const issues = [genAggIssueFor(tests, {})];
+        issues[0].state = "closed";
 
-  test("comment and close non flaky test", async () => {
-    const scope = nock("https://api.github.com")
-      .post("/repos/pytorch/pytorch/issues/1/comments", (body) => {
-        const comment = JSON.stringify(body.body);
-        expect(comment).toContain(
-          "Another case of trunk flakiness has been found"
-        );
-        expect(comment).toContain("Either the change didn't propogate");
-        return true;
-      })
-      .reply(200, {})
-      .post("/repos/pytorch/pytorch/issues/1/comments", (body) => {
-        const comment = JSON.stringify(body.body);
-        expect(comment).toContain(
-          "Resolving the issue because the test is not flaky anymore"
-        );
-        return true;
-      })
-      .reply(200, {})
-      .patch("/repos/pytorch/pytorch/issues/1", (body) => {
-        expect(body).toMatchObject({ state: "closed" });
-        return true;
-      })
-      .reply(200, {});
+        const scope = [
+          mockGetRawTestFile(
+            tests[0].file,
+            `# Owner(s): ["module: fft"]\nimport blah;\nrest of file`
+          ),
+          utils.mockCreateIssue(
+            "pytorch/pytorch",
+            `DISABLED MULTIPLE There are multiple flaky tests in ${tests[0].file}`,
+            ["Platforms: "],
+            [
+              "aggregate flaky test issue",
+              "skipped",
+              "module: flaky-tests",
+              "module: windows",
+              "module: fft",
+              "triaged",
+            ]
+          ),
+        ];
+        await disableFlakyTestBot.handleAll(octokit, tests, [], issues, []);
+        handleScope(scope);
+      });
 
-    const issues: IssueData[] = [
-      {
-        number: 1,
-        title: "DISABLED test_a (__main__.suite_a)",
-        html_url: "https://api.github.com/repos/pytorch/pytorch/issues/1",
-        state: "open" as "open" | "closed",
-        body: "random",
+      test("All platforms present", async () => {
+        const tests = genAggTests({ ...flakyTestA });
+        const issues = [genAggIssueFor(tests, {})];
+
+        const scope = [
+          utils.mockPostComment("pytorch/pytorch", 1, [
+            "Another case of trunk flakiness has been found",
+            "appear to contain all the recently affected platform",
+          ]),
+        ];
+
+        await disableFlakyTestBot.handleAll(octokit, tests, [], issues, []);
+        handleScope(scope);
+      });
+    });
+
+    describe("Close no longer flaky tests", () => {
+      const tests = genAggTests(
+        genValidFlakyTest({
+          ...nonFlakyTestA,
+          suite: nonFlakyTestA.classname,
+        })
+      );
+
+      const flakyTestIssue = genAggIssueFor(tests, {
         updated_at: dayjs()
-          .subtract(NUM_HOURS_NOT_UPDATED_BEFORE_CLOSING + 1, "hour")
-          .toString(),
-        author_association: "MEMBER",
-        labels: [],
-      },
-    ];
+          .subtract(
+            flakyBotUtils.NUM_HOURS_NOT_UPDATED_BEFORE_CLOSING + 1,
+            "hour"
+          )
+          .toISOString(),
+      });
 
-    await handleFlakyTest(flakyTestA, issues, octokit);
-    // Close the disabled issue if the test is not flaky anymore
-    await handleNonFlakyTest(nonFlakyTestA, issues, octokit);
+      test("Some tests are no longer flaky", async () => {
+        const scope = [
+          utils.mockPostComment("pytorch/pytorch", 1, [
+            "The following tests were removed from the list",
+          ]),
+          mockUpdateIssue({
+            issueNumber: 1,
+            bodyContains: ["test_2 (__main__.suite_2): linux\n"],
+          }),
+        ];
 
-    handleScope(scope);
-  });
+        const issues: IssueData[] = [{ ...flakyTestIssue }];
 
-  test("do not close non flaky test if it's manual updated recently", async () => {
-    const scope = nock("https://api.github.com")
-      .post("/repos/pytorch/pytorch/issues/1/comments", (body) => {
-        const comment = JSON.stringify(body.body);
-        expect(comment).toContain(
-          "Another case of trunk flakiness has been found"
+        await disableFlakyTestBot.handleAll(octokit, [], [], issues, [
+          {
+            ...nonFlakyTestA,
+            classname: "suite_0",
+            name: "test_0",
+          },
+          {
+            ...nonFlakyTestA,
+            classname: "suite_1",
+            name: "test_1",
+          },
+        ]);
+
+        handleScope(scope);
+      });
+
+      test("All tests are no longer flaky", async () => {
+        const scope = [
+          utils.mockPostComment("pytorch/pytorch", 1, [
+            "Resolving the issue because the tests are no longer flaky",
+          ]),
+          mockUpdateIssue({
+            issueNumber: 1,
+            state: "closed",
+          }),
+        ];
+
+        const issues: IssueData[] = [{ ...flakyTestIssue }];
+
+        await disableFlakyTestBot.handleAll(
+          octokit,
+          [],
+          [],
+          issues,
+          Array.from({ length: 11 }, (_, i) => {
+            return {
+              ...nonFlakyTestA,
+              classname: `suite_${i}`,
+              name: `test_${i}`,
+            };
+          })
         );
-        expect(comment).toContain("Either the change didn't propogate");
-        return true;
-      })
-      .reply(200, {});
 
-    const issues: IssueData[] = [
-      {
-        number: 1,
-        title: "DISABLED test_a (__main__.suite_a)",
-        html_url: "https://api.github.com/repos/pytorch/pytorch/issues/1",
-        state: "open" as "open" | "closed",
-        body: "random",
-        updated_at: dayjs()
-          .subtract(NUM_HOURS_NOT_UPDATED_BEFORE_CLOSING - 1, "hour")
-          .toString(),
-        author_association: "MEMBER",
-        labels: [],
-      },
-    ];
+        handleScope(scope);
+      });
 
-    await handleFlakyTest(flakyTestA, issues, octokit);
-    // Close the disabled issue if the test is not flaky anymore
-    await handleNonFlakyTest(nonFlakyTestA, issues, octokit);
-
-    handleScope(scope);
-  });
-
-  describe("updateExistingIssueForFlakyTest", () => {
-    const defaultIssue = utils.genIssueData({});
-    beforeEach(() => {});
-
-    afterEach(() => {
-      nock.cleanAll();
-      jest.restoreAllMocks();
-    });
-
-    test("open issue, contains platforms", async () => {
-      const test = deepCopy(flakyTestA);
-
-      const scope = nock("https://api.github.com");
-      scope
-        .post(
-          `/repos/pytorch/pytorch/issues/${defaultIssue.number}/comments`,
-          (body) => {
-            const comment = JSON.stringify(body.body);
-            expect(comment).toContain("Another case of trunk flakiness");
-            expect(comment).toContain("appears to contain");
-            expect(comment).toContain("Either the change didn't propogate");
-            expect(comment.includes("Reopening issue")).toBe(false);
-            return true;
-          }
-        )
-        .reply(200, {});
-
-      await singleDisableIssue.updateExistingIssueForFlakyTest(
-        octokit,
-        defaultIssue,
-        test
-      );
-
-      handleScope(scope);
-    });
-
-    test("closed issue, contains platforms", async () => {
-      const test = deepCopy(flakyTestA);
-      const issue: IssueData = { ...defaultIssue, state: "closed" };
-
-      const scope = nock("https://api.github.com");
-      scope
-        .post(
-          `/repos/pytorch/pytorch/issues/${issue.number}/comments`,
-          (body) => {
-            const comment = JSON.stringify(body.body);
-            expect(comment).toContain("Another case of trunk flakiness");
-            expect(comment).toContain("appears to contain");
-            expect(comment).toContain("Reopening issue");
-            expect(comment.includes("Either the change didn't propogate")).toBe(
-              false
-            );
-            return true;
-          }
-        )
-        .reply(200, {})
-        .patch(`/repos/pytorch/pytorch/issues/${issue.number}`, (body) => {
-          expect(body.state).toEqual("open");
-          expect(body.body).toBe(undefined);
-          return true;
-        })
-        .reply(200, {});
-
-      await singleDisableIssue.updateExistingIssueForFlakyTest(
-        octokit,
-        issue,
-        test
-      );
-
-      handleScope(scope);
-    });
-
-    test("open issue, does not contain platforms", async () => {
-      const test = deepCopy(flakyTestA);
-      const issue: IssueData = {
-        ...defaultIssue,
-        body: "Platforms: linux\nhello",
-      };
-
-      const scope = nock("https://api.github.com");
-      scope
-        .post(
-          `/repos/pytorch/pytorch/issues/${issue.number}/comments`,
-          (body) => {
-            const comment = JSON.stringify(body.body);
-            expect(comment).toContain("Another case of trunk flakiness");
-            expect(comment).toContain("Adding [win]");
-            expect(comment.includes("Reopening issue")).toBe(false);
-            expect(comment.includes("Either the change didn't propogate")).toBe(
-              false
-            );
-            return true;
-          }
-        )
-        .reply(200, {})
-        .patch(`/repos/pytorch/pytorch/issues/${issue.number}`, (body) => {
-          expect(body.state).toEqual("open");
-          expect(body.body).toContain("Platforms: linux, win");
-          expect(body.body).toContain("hello");
-          return true;
-        })
-        .reply(200, {});
-
-      await singleDisableIssue.updateExistingIssueForFlakyTest(
-        octokit,
-        issue,
-        test
-      );
-
-      handleScope(scope);
-    });
-
-    test("closed issue, does not contain platforms", async () => {
-      const test = deepCopy(flakyTestA);
-      const issue: IssueData = {
-        ...defaultIssue,
-        body: "Platforms: linux\nhello",
-        state: "closed",
-      };
-
-      const scope = nock("https://api.github.com");
-      scope
-        .post(
-          `/repos/pytorch/pytorch/issues/${issue.number}/comments`,
-          (body) => {
-            const comment = JSON.stringify(body.body);
-            expect(comment).toContain("Another case of trunk flakiness");
-            expect(comment).toContain("does not appear to contain");
-            expect(comment).toContain("Adding [win]");
-            expect(comment).toContain("Reopening issue");
-            expect(comment.includes("Either the change didn't propogate")).toBe(
-              false
-            );
-            return true;
-          }
-        )
-        .reply(200, {})
-        .patch(`/repos/pytorch/pytorch/issues/${issue.number}`, (body) => {
-          expect(body.body).toContain("Platforms: linux, win");
-          expect(body.body).toContain("hello");
-          expect(body.state).toEqual("open");
-          return true;
-        })
-        .reply(200, {});
-
-      await singleDisableIssue.updateExistingIssueForFlakyTest(
-        octokit,
-        issue,
-        test
-      );
-
-      handleScope(scope);
-    });
-
-    test("open issue, does not contain platforms, longer platforms lists", async () => {
-      const test = deepCopy(flakyTestA);
-      test.jobNames.push("rocm");
-      test.workflowNames.push("test");
-      const issue: IssueData = {
-        ...defaultIssue,
-        body: "Platforms: inductor, dynamo\nhello",
-        state: "closed",
-      };
-
-      const scope = nock("https://api.github.com");
-      scope
-        .post(
-          `/repos/pytorch/pytorch/issues/${issue.number}/comments`,
-          (body) => {
-            const comment = JSON.stringify(body.body);
-            expect(comment).toContain("Another case of trunk flakiness");
-            expect(comment).toContain("does not appear to contain");
-            expect(comment).toContain("Adding [rocm, win]");
-            expect(comment).toContain("Reopening issue");
-            expect(comment.includes("Either the change didn't propogate")).toBe(
-              false
-            );
-            return true;
-          }
-        )
-        .reply(200, {})
-        .patch(`/repos/pytorch/pytorch/issues/${issue.number}`, (body) => {
-          expect(body.body).toContain("Platforms: dynamo, inductor, rocm, win");
-          expect(body.body).toContain("hello");
-          expect(body.state).toEqual("open");
-          return true;
-        })
-        .reply(200, {});
-
-      await singleDisableIssue.updateExistingIssueForFlakyTest(
-        octokit,
-        issue,
-        test
-      );
-
-      handleScope(scope);
-    });
-
-    test("closed issue, contains platforms, longer platforms lists", async () => {
-      const test = deepCopy(flakyTestA);
-      const issue: IssueData = {
-        ...defaultIssue,
-        body: "Platforms: win\nhello",
-        state: "closed",
-      };
-
-      const scope = nock("https://api.github.com");
-      scope
-        .post(
-          `/repos/pytorch/pytorch/issues/${issue.number}/comments`,
-          (body) => {
-            const comment = JSON.stringify(body.body);
-            expect(comment).toContain("Another case of trunk flakiness");
-            expect(comment).toContain("appears to contain");
-            expect(comment).toContain("Reopening issue");
-            expect(comment.includes("Either the change didn't propogate")).toBe(
-              false
-            );
-            return true;
-          }
-        )
-        .reply(200, {})
-        .patch(`/repos/pytorch/pytorch/issues/${issue.number}`, (body) => {
-          expect(body.body).toBe(undefined);
-          expect(body.state).toEqual("open");
-          return true;
-        })
-        .reply(200, {});
-
-      await singleDisableIssue.updateExistingIssueForFlakyTest(
-        octokit,
-        issue,
-        test
-      );
-
-      handleScope(scope);
+      test("Do nothing if issue updated recently", async () => {
+        const issues: IssueData[] = [
+          {
+            ...flakyTestIssue,
+            updated_at: dayjs()
+              .subtract(
+                flakyBotUtils.NUM_HOURS_NOT_UPDATED_BEFORE_CLOSING - 1,
+                "hour"
+              )
+              .toISOString(),
+          },
+        ];
+        await disableFlakyTestBot.handleAll(octokit, [], [], issues, [
+          {
+            ...nonFlakyTestA,
+            classname: "suite_0",
+            name: "test_0",
+          },
+          {
+            ...nonFlakyTestA,
+            classname: "suite_1",
+            name: "test_1",
+          },
+        ]);
+      });
     });
   });
 });

--- a/torchci/test/flakyBotTests/flakyBotTestsUtils.ts
+++ b/torchci/test/flakyBotTests/flakyBotTestsUtils.ts
@@ -1,10 +1,34 @@
+import dayjs from "dayjs";
+import { FlakyTestData } from "lib/types";
 import nock from "nock";
 
 // This file contains utils and mock data for flaky bot tests. I think if you
 // import from one test file to another, it will also run the tests from the
 // imported file, so instead we put reused things here.
 
-export const flakyTestA = {
+export function genValidFlakyTest(
+  input: Partial<FlakyTestData>
+): FlakyTestData {
+  return {
+    name: "test_name",
+    suite: "test_suite",
+    file: "test_file.py",
+    invoking_file: "test_folder.test_file",
+    jobNames: ["linux1", "linux2", "linux3"],
+    jobIds: [111, 222, 333],
+    workflowIds: ["11", "22", "33"],
+    workflowNames: ["workflow_name1", "workflow_name2", "workflow_name3"],
+    eventTimes: [
+      dayjs().subtract(1, "hour").toISOString(),
+      dayjs().subtract(2, "hour").toISOString(),
+      dayjs().subtract(3, "hour").toISOString(),
+    ],
+    branches: ["master", "master", "master"],
+    ...input,
+  };
+}
+
+export const flakyTestA = genValidFlakyTest({
   file: "file_a.py",
   invoking_file: "file_a",
   suite: "suite_a",
@@ -20,9 +44,9 @@ export const flakyTestA = {
     "win-cuda11.3-vs-2019 / test",
   ],
   branches: ["master", "master", "master"],
-};
+});
 
-export const flakyTestB = {
+export const flakyTestB = genValidFlakyTest({
   file: "file_b.py",
   invoking_file: "file_b",
   suite: "suite_b",
@@ -42,9 +66,9 @@ export const flakyTestB = {
     "win-cuda11.3-vs-2019 / test",
   ],
   branches: ["main", "main", "main"],
-};
+});
 
-export const flakyTestE = {
+export const flakyTestE = genValidFlakyTest({
   file: "file_e.py",
   invoking_file: "file_e",
   suite: "suite_e",
@@ -61,9 +85,9 @@ export const flakyTestE = {
     "win-cpu-vs-2019 / test",
   ],
   branches: ["pr-fix", "master", "master", "another-pr-fx"],
-};
+});
 
-export const flakyTestAcrossJobA = {
+export const flakyTestAcrossJobA: FlakyTestData = genValidFlakyTest({
   name: "test_conv1d_vs_scipy_mode_same_cuda_complex64",
   suite: "TestConvolutionNNDeviceTypeCUDA",
   file: "nn/test_convolution.py",
@@ -71,14 +95,13 @@ export const flakyTestAcrossJobA = {
   jobNames: [
     "linux-focal-rocm5.2-py3.8 / test (default, 1, 2, linux.rocm.gpu)",
     "linux-focal-rocm5.2-py3.8 / test (default, 1, 2, linux.rocm.gpu)",
+    "linux-focal-rocm5.2-py3.8 / test (default, 1, 2, linux.rocm.gpu)",
   ],
-  jobIds: [9489898216, 9486287115],
-  workflowIds: ["3466924095", "3465587581"],
-  workflowNames: ["trunk", "trunk"],
-  runAttempts: [1, 1],
-  eventTimes: ["2022-11-15T02:52:20.311000Z", "2022-11-14T22:30:34.492000Z"],
-  branches: ["master", "master"],
-};
+  jobIds: [9489898216, 9486287115, 9486287114],
+  workflowIds: ["3466924095", "3465587581", "3465587582"],
+  workflowNames: ["trunk", "trunk", "trunk"],
+  branches: ["master", "master", "master"],
+});
 
 export const nonFlakyTestA = {
   name: "test_a",


### PR DESCRIPTION
Requires changes in https://github.com/pytorch/test-infra/pull/6661, please review + merge that one first

Allow flakybot to make aggregate issues, update them, and close them. Also allow the verification bot that comments on each issue to do aggregate issues.

Format should match the one in https://github.com/pytorch/test-infra/pull/6045

We should really make the verification script just the same as the script that updates the json...

No platform module labels are going to be added

There's some weirdness with closing issues / removing tests that are no longer flaky because I think it's hard (read: possible, probably annoying) to determine which test is responsible for an issue getting updated and which are old enough to be removed 

Threshold is 10