### PR TITLE
Support clang in MSVC

### DIFF
--- a/aws/ami/windows/scripts/Installers/Install-VS.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-VS.ps1
@@ -22,7 +22,9 @@ $VS_INSTALL_ARGS = @("--nocache","--quiet","--wait", "--add Microsoft.VisualStud
                                                      "--add Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
                                                      "--add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core",
                                                      "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
-                                                     "--add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81")
+                                                     "--add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81",
+                                                     "--add Microsoft.VisualStudio.Component.VC.Llvm.Clang",
+                                                     "--add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset")
 
 if (${env:INSTALL_WINDOWS_SDK} -eq "1") {
     $VS_INSTALL_ARGS += "--add Microsoft.VisualStudio.Component.Windows10SDK.19041"


### PR DESCRIPTION
In ExecuTorch, we [use clang](https://github.com/pytorch/executorch/blob/df5e7df9de08a0bb9622c60a090d9d038b0f022b/install_executorch.py#L224-L228) and are not compatible with MSVC. So, let's support ClangCL.

Got this from: https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022