### PR TITLE
Add NA as option for most fields in the cost dashboard #6655

### DIFF
--- a/torchci/pages/cost_analysis.tsx
+++ b/torchci/pages/cost_analysis.tsx
@@ -184,10 +184,10 @@ const hourDisplay = (value: number) => {
 
 const ROW_HEIGHT = 700;
 
-const OS_OPTIONS = ["linux", "windows", "macos"];
+const OS_OPTIONS = ["linux", "windows", "macos", "NA"];
 const GPU_OPTIONS = ["gpu", "non-gpu"];
-const PROVIDER_OPTIONS = ["aws", "gcp", "github"];
-const OWNER_OPTIONS = ["linux_foundation", "meta"];
+const PROVIDER_OPTIONS = ["aws", "gcp", "github", "NA"];
+const OWNER_OPTIONS = ["linux_foundation", "meta", "NA"];
 
 export default function Page() {
   const router = useRouter();


### PR DESCRIPTION
Add NA as option for most fields in the cost dashboard. This is useful for items that are wrongly classified (in case of bugs such as the one with the experimental prefixes), but also for items that have a duration, but not a cost.