### PR TITLE
cost dashboard: group by instance type (aws runners)

### DIFF
--- a/torchci/clickhouse_queries/cost_job_per_instance_type/params.json
+++ b/torchci/clickhouse_queries/cost_job_per_instance_type/params.json
@@ -1,0 +1,13 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)",
+    "selectedGPU": "Array(UInt8)",
+    "selectedPlatforms": "Array(String)",
+    "selectedProviders": "Array(String)",
+    "selectedOwners": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/cost_job_per_instance_type/query.sql
+++ b/torchci/clickhouse_queries/cost_job_per_instance_type/query.sql
@@ -1,0 +1,23 @@
+select
+    DATE_TRUNC(
+        {granularity: String},
+        rc.date
+    ) as granularity_bucket,
+    instance_type,
+    sum(rc.cost) as total_cost
+from
+    misc.runner_cost rc final
+where
+    rc.date > {startTime: DateTime64(9)}
+    and rc.date < {stopTime: DateTime64(9)}
+    and rc.cost > 0
+    and rc.group_repo in {selectedRepos: Array(String)}
+    and rc.gpu in {selectedGPU: Array(UInt8)}
+    and rc.os in {selectedPlatforms: Array(String)}
+    and rc.provider in {selectedProviders: Array(String)}
+    and rc.owning_account in {selectedOwners: Array(String)}
+group by
+    granularity_bucket,
+    instance_type
+order by
+    granularity_bucket asc

--- a/torchci/clickhouse_queries/duration_job_per_instance_type/params.json
+++ b/torchci/clickhouse_queries/duration_job_per_instance_type/params.json
@@ -1,0 +1,13 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)",
+    "selectedGPU": "Array(UInt8)",
+    "selectedPlatforms": "Array(String)",
+    "selectedProviders": "Array(String)",
+    "selectedOwners": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/duration_job_per_instance_type/query.sql
+++ b/torchci/clickhouse_queries/duration_job_per_instance_type/query.sql
@@ -1,0 +1,23 @@
+select
+    DATE_TRUNC(
+        {granularity: String},
+        rc.date
+    ) as granularity_bucket,
+    instance_type,
+    sum(rc.duration) as total_duration
+from
+    misc.runner_cost rc final
+where
+    rc.date > {startTime: DateTime64(9)}
+    and rc.date < {stopTime: DateTime64(9)}
+    and rc.duration > 0
+    and rc.group_repo in {selectedRepos: Array(String)}
+    and rc.gpu in {selectedGPU: Array(UInt8)}
+    and rc.os in {selectedPlatforms: Array(String)}
+    and rc.provider in {selectedProviders: Array(String)}
+    and rc.owning_account in {selectedOwners: Array(String)}
+group by
+    granularity_bucket,
+    instance_type
+order by
+    granularity_bucket asc

--- a/torchci/pages/cost_analysis.tsx
+++ b/torchci/pages/cost_analysis.tsx
@@ -264,7 +264,9 @@ export default function Page() {
     initialSearchFilter as string
   );
   const [isRegex, setIsRegex] = useState(initialIsRegex);
-  const [showInstanceType, setShowInstanceType] = useState(initialShowInstanceType);
+  const [showInstanceType, setShowInstanceType] = useState(
+    initialShowInstanceType
+  );
 
   const [routerReady, setRouterReady] = useState(false);
 
@@ -353,7 +355,8 @@ export default function Page() {
     if (selectedYAxis) params.set("yAxis", selectedYAxis);
     if (searchFilter) params.set("searchFilter", searchFilter);
     if (isRegex) params.set("isRegex", isRegex.toString());
-    if (showInstanceType) params.set("showInstanceType", showInstanceType.toString());
+    if (showInstanceType)
+      params.set("showInstanceType", showInstanceType.toString());
     if (selectedRepos && selectedRepos.length < availableRepos.length) {
       params.set("repos", selectedRepos.join(","));
     }
@@ -385,8 +388,12 @@ export default function Page() {
     yAxis: "cost" | "duration"
   ) => {
     // Handle toggle between runner_type and instance_type
-    const actualGroupBy = groupby === "runner_type" && showInstanceType ? "instance_type" : groupby;
-    const displayName = actualGroupBy === "instance_type" ? "instance type" : actualGroupBy.replace("_", " ");
+    const actualGroupBy =
+      groupby === "runner_type" && showInstanceType ? "instance_type" : groupby;
+    const displayName =
+      actualGroupBy === "instance_type"
+        ? "instance type"
+        : actualGroupBy.replace("_", " ");
 
     return (
       <Grid2 size={{ xs: 8 }} height={ROW_HEIGHT}>

--- a/torchci/pages/cost_analysis.tsx
+++ b/torchci/pages/cost_analysis.tsx
@@ -387,7 +387,7 @@ export default function Page() {
     // Handle toggle between runner_type and instance_type
     const actualGroupBy = groupby === "runner_type" && showInstanceType ? "instance_type" : groupby;
     const displayName = actualGroupBy === "instance_type" ? "instance type" : actualGroupBy.replace("_", " ");
-    
+
     return (
       <Grid2 size={{ xs: 8 }} height={ROW_HEIGHT}>
         {!isLoading && (

--- a/torchci/pages/cost_analysis.tsx
+++ b/torchci/pages/cost_analysis.tsx
@@ -143,6 +143,7 @@ export function DateRangePicker({
 
 type CostCategory =
   | "runner_type"
+  | "instance_type"
   | "workflow_name"
   | "job_name"
   | "platform"
@@ -230,6 +231,7 @@ export default function Page() {
   const initialSearchFilter = query.searchFilter || "";
   const initialIsRegex = query.isRegex === "true";
   const initialSelectedRepos = query.repos ? splitString(query.repos) : [];
+  const initialShowInstanceType = query.showInstanceType === "true";
 
   // State variables
   const [startDate, setStartDate] = useState(initialStartDate);
@@ -262,6 +264,7 @@ export default function Page() {
     initialSearchFilter as string
   );
   const [isRegex, setIsRegex] = useState(initialIsRegex);
+  const [showInstanceType, setShowInstanceType] = useState(initialShowInstanceType);
 
   const [routerReady, setRouterReady] = useState(false);
 
@@ -280,6 +283,7 @@ export default function Page() {
     setSelectedYAxis(initialSelectedYAxis || "cost");
     setSearchFilter(initialSearchFilter as string);
     setIsRegex(initialIsRegex);
+    setShowInstanceType(initialShowInstanceType);
     if (initialSelectedRepos) {
       setSelectedRepos(initialSelectedRepos);
     }
@@ -349,6 +353,7 @@ export default function Page() {
     if (selectedYAxis) params.set("yAxis", selectedYAxis);
     if (searchFilter) params.set("searchFilter", searchFilter);
     if (isRegex) params.set("isRegex", isRegex.toString());
+    if (showInstanceType) params.set("showInstanceType", showInstanceType.toString());
     if (selectedRepos && selectedRepos.length < availableRepos.length) {
       params.set("repos", selectedRepos.join(","));
     }
@@ -371,6 +376,7 @@ export default function Page() {
     selectedYAxis,
     searchFilter,
     isRegex,
+    showInstanceType,
     selectedRepos,
   ]);
 
@@ -378,15 +384,19 @@ export default function Page() {
     groupby: CostCategory,
     yAxis: "cost" | "duration"
   ) => {
+    // Handle toggle between runner_type and instance_type
+    const actualGroupBy = groupby === "runner_type" && showInstanceType ? "instance_type" : groupby;
+    const displayName = actualGroupBy === "instance_type" ? "instance type" : actualGroupBy.replace("_", " ");
+    
     return (
       <Grid2 size={{ xs: 8 }} height={ROW_HEIGHT}>
         {!isLoading && (
           <TimeSeriesPanel
-            title={`CI ${yAxis} per ${groupby} per ${granularity}`}
-            queryName={`${yAxis}_job_per_${groupby}`}
+            title={`CI ${yAxis} per ${displayName} per ${granularity}`}
+            queryName={`${yAxis}_job_per_${actualGroupBy}`}
             queryParams={{
               ...timeParamsClickHouse,
-              groupby,
+              groupby: actualGroupBy,
               selectedRepos,
               selectedGPU,
               selectedOwners,
@@ -394,7 +404,7 @@ export default function Page() {
               selectedProviders,
             }}
             granularity={granularity}
-            groupByFieldName={groupby}
+            groupByFieldName={actualGroupBy}
             timeFieldName={"granularity_bucket"}
             yAxisFieldName={`total_${yAxis}`}
             yAxisRenderer={yAxis === "cost" ? costDisplay : hourDisplay}
@@ -468,6 +478,29 @@ export default function Page() {
             </Select>
           </FormControl>
         </Grid2>
+        {groupby === "runner_type" && (
+          <Grid2 size={{ xs: 2 }}>
+            <FormControl style={{ width: "100%" }}>
+              <ToggleButtonGroup
+                exclusive
+                value={showInstanceType ? "instance_type" : "runner_type"}
+                onChange={(event, newValue) => {
+                  if (newValue !== null) {
+                    setShowInstanceType(newValue === "instance_type");
+                  }
+                }}
+                style={{ width: "100%", height: 56 }}
+              >
+                <ToggleButton value="runner_type" style={{ flex: 1 }}>
+                  Runner Type
+                </ToggleButton>
+                <ToggleButton value="instance_type" style={{ flex: 1 }}>
+                  Instance Type
+                </ToggleButton>
+              </ToggleButtonGroup>
+            </FormControl>
+          </Grid2>
+        )}
         <Grid2 size={{ xs: 2 }}>
           {generateFilterBar(groupby, marginStyle)}
         </Grid2>


### PR DESCRIPTION
Allow the cost dashboard to be filtered by instance type as well as well as the runner_type (for AWS runners) - this allows for an easier comparison with AWS billing dashboard

<img width="1592" alt="image" src="https://github.com/user-attachments/assets/61fd75a4-11c4-4d4e-94de-bbf7040cd1bb" />
