### PR TITLE
[bots] Change verify disable issues in prep for handling aggregate issues

### DIFF
--- a/torchci/lib/bot/verifyDisableTestIssueBot.ts
+++ b/torchci/lib/bot/verifyDisableTestIssueBot.ts
@@ -2,13 +2,10 @@ import * as singleDisableIssue from "lib/flakyBot/singleDisableIssue";
 import { Context, Probot } from "probot";
 import { hasWritePermissions } from "./utils";
 
-export const validationCommentStart = "<!-- validation-comment-start -->";
-export const validationCommentEnd = "<!-- validation-comment-end -->";
+const validationCommentStart = "<!-- validation-comment-start -->";
+const validationCommentEnd = "<!-- validation-comment-end -->";
 export const disabledKey = "DISABLED ";
 export const unstableKey = "UNSTABLE ";
-export const disabledTestIssueTitle = new RegExp(
-  "DISABLED\\s*test.+\\s*\\(.+\\)"
-);
 export const pytorchBotId = 54816060;
 
 async function getValidationComment(
@@ -57,11 +54,7 @@ export function formJobValidationComment(
   }
   body += "</body>";
 
-  return validationCommentStart + body + validationCommentEnd;
-}
-
-export function isDisabledTest(title: string): boolean {
-  return disabledTestIssueTitle.test(title);
+  return body;
 }
 
 export default function verifyDisableTestIssueBot(app: Probot): void {
@@ -71,14 +64,14 @@ export default function verifyDisableTestIssueBot(app: Probot): void {
     const owner = context.payload["repository"]["owner"]["login"];
     const repo = context.payload["repository"]["name"];
 
-    if (
-      state === "closed" ||
-      (!title.startsWith(disabledKey) && !title.startsWith(unstableKey))
-    ) {
+    if (state === "closed") {
       return;
     }
 
-    const prefix = title.startsWith(disabledKey) ? disabledKey : unstableKey;
+    if (!title.startsWith(disabledKey) && !title.startsWith(unstableKey)) {
+      return;
+    }
+
     const body = context.payload["issue"]["body"];
     const number = context.payload["issue"]["number"];
     const existingValidationCommentData = await getValidationComment(
@@ -90,10 +83,6 @@ export default function verifyDisableTestIssueBot(app: Probot): void {
     const existingValidationCommentID = existingValidationCommentData[0];
     const existingValidationComment = existingValidationCommentData[1];
 
-    const target = parseTitle(title, prefix);
-    const { platformsToSkip, invalidPlatforms } = singleDisableIssue.parseBody(
-      body!
-    );
     const username = context.payload["issue"]["user"]["login"];
     const authorized =
       context.payload["issue"]["user"]["id"] === pytorchBotId ||
@@ -101,16 +90,25 @@ export default function verifyDisableTestIssueBot(app: Probot): void {
     const labels =
       context.payload["issue"]["labels"]?.map((l) => l["name"]) ?? [];
 
-    const validationComment = isDisabledTest(title)
-      ? singleDisableIssue.formValidationComment(
-          username,
-          authorized,
-          target,
-          platformsToSkip,
-          invalidPlatforms,
-          number
-        )
-      : formJobValidationComment(username, authorized, target, prefix);
+    let validationComment = "";
+    if (singleDisableIssue.isSingleIssue(title)) {
+      validationComment = singleDisableIssue.formValidationComment(
+        context.payload["issue"],
+        authorized
+      );
+      singleDisableIssue.fixLabels(context);
+    } else {
+      // UNSTABLE
+      const prefix = title.startsWith(unstableKey) ? unstableKey : disabledKey;
+      validationComment = formJobValidationComment(
+        username,
+        authorized,
+        parseTitle(title, prefix),
+        prefix
+      );
+    }
+    validationComment = `${validationCommentStart}${validationComment}${validationCommentEnd}`;
+    console.log(validationComment);
 
     if (existingValidationComment === validationComment) {
       return;
@@ -140,30 +138,6 @@ export default function verifyDisableTestIssueBot(app: Probot): void {
         issue_number: number,
         state: "closed",
       });
-    } else {
-      // check labels, add labels as needed
-      let [expectedPlatformLabels, invalidPlatformLabels] =
-        singleDisableIssue.getExpectedPlatformModuleLabels(
-          platformsToSkip,
-          labels
-        );
-      let labelsSet = new Set(labels);
-      if (!expectedPlatformLabels.every((label) => labelsSet.has(label))) {
-        await context.octokit.issues.addLabels({
-          owner,
-          repo,
-          issue_number: number,
-          labels: expectedPlatformLabels,
-        });
-      }
-      for (const invalidLabel of invalidPlatformLabels) {
-        await context.octokit.issues.removeLabel({
-          owner,
-          repo,
-          issue_number: number,
-          name: invalidLabel,
-        });
-      }
     }
   });
 }

--- a/torchci/lib/bot/verifyDisableTestIssueBot.ts
+++ b/torchci/lib/bot/verifyDisableTestIssueBot.ts
@@ -108,7 +108,6 @@ export default function verifyDisableTestIssueBot(app: Probot): void {
       );
     }
     validationComment = `${validationCommentStart}${validationComment}${validationCommentEnd}`;
-    console.log(validationComment);
 
     if (existingValidationComment === validationComment) {
       return;

--- a/torchci/lib/flakyBot/singleDisableIssue.ts
+++ b/torchci/lib/flakyBot/singleDisableIssue.ts
@@ -267,7 +267,7 @@ function testNameIsExpected(testName: string): boolean {
     return false;
   }
 
-  const split = testName.split(/\s+/);
+  const split = testName.trim().split(/\s+/);
   if (split.length !== 2) {
     return false;
   }

--- a/torchci/lib/flakyBot/singleDisableIssue.ts
+++ b/torchci/lib/flakyBot/singleDisableIssue.ts
@@ -260,9 +260,7 @@ export const parseBody = _.memoize((body: string) => {
 
 // MARK: validation
 
-const disabledTestIssueTitle = new RegExp(
-  "test.+\\s*\\(.+\\)"
-);
+const disabledTestIssueTitle = new RegExp("test.+\\s*\\(.+\\)");
 
 function testNameIsExpected(testName: string): boolean {
   if (!disabledTestIssueTitle.test(testName)) {

--- a/torchci/lib/flakyBot/singleDisableIssue.ts
+++ b/torchci/lib/flakyBot/singleDisableIssue.ts
@@ -260,7 +260,15 @@ export const parseBody = _.memoize((body: string) => {
 
 // MARK: validation
 
+const disabledTestIssueTitle = new RegExp(
+  "test.+\\s*\\(.+\\)"
+);
+
 function testNameIsExpected(testName: string): boolean {
+  if (!disabledTestIssueTitle.test(testName)) {
+    return false;
+  }
+
   const split = testName.split(/\s+/);
   if (split.length !== 2) {
     return false;

--- a/torchci/lib/flakyBot/singleDisableIssue.ts
+++ b/torchci/lib/flakyBot/singleDisableIssue.ts
@@ -1,13 +1,11 @@
 import dayjs from "dayjs";
-import {
-  validationCommentEnd,
-  validationCommentStart,
-} from "lib/bot/verifyDisableTestIssueBot";
 import { DisabledNonFlakyTestData, FlakyTestData, IssueData } from "lib/types";
 import _ from "lodash";
 import { Octokit } from "octokit";
 import { NUM_HOURS } from "pages/api/flaky-tests/disable";
+import { Context } from "probot";
 import {
+  genReenableValidationSection,
   getLatestTrunkJobURL,
   getPlatformLabels,
   getPlatformsAffected,
@@ -220,7 +218,7 @@ export async function handleNonFlakyTest(
 }
 // MARK: parse issue
 
-export function parseBody(body: string) {
+export const parseBody = _.memoize((body: string) => {
   if (body === "") {
     return {
       platformsToSkip: [],
@@ -258,7 +256,7 @@ export function parseBody(body: string) {
     ),
     bodyWithoutPlatforms: bodyWithoutPlatforms.join(""),
   };
-}
+});
 
 // MARK: validation
 
@@ -275,14 +273,21 @@ function testNameIsExpected(testName: string): boolean {
   return true;
 }
 
+export function isSingleIssue(title: string): boolean {
+  const prefix = "DISABLED ";
+  return (
+    title.startsWith(prefix) &&
+    testNameIsExpected(title.substring(prefix.length))
+  );
+}
+
 export function formValidationComment(
-  username: string,
-  authorized: boolean,
-  testName: string,
-  platformsToSkip: string[],
-  invalidPlatforms: string[],
-  issueNumber: number
+  issue: Context<"issues">["payload"]["issue"],
+  authorized: boolean
 ): string {
+  const username = issue.user.login;
+  const { platformsToSkip, invalidPlatforms } = parseBody(issue.body || "");
+  const testName = issue.title.slice("DISABLED ".length);
   const platformMsg =
     platformsToSkip.length === 0
       ? "none parsed, defaulting to ALL platforms"
@@ -311,26 +316,16 @@ export function formValidationComment(
   if (!authorized) {
     body += `<b>ERROR!</b> You (${username}) don't have permission to disable ${testName} on ${platformMsg}.\n\n`;
     body += "</body>";
-    return validationCommentStart + body + validationCommentEnd;
+    return body;
   }
 
-  if (!testNameIsExpected(testName)) {
-    body +=
-      "<b>ERROR!</b> As you can see above, I could not properly parse the test ";
-    body +=
-      "information and determine which test to disable. Please modify the ";
-    body +=
-      "title to be of the format: DISABLED test_case_name (test.ClassName), ";
-    body += "for example, `test_cuda_assert_async (__main__.TestCuda)`.\n\n";
-  } else {
-    body += `Within ~15 minutes, \`${testName}\` will be disabled in PyTorch CI for `;
-    body +=
-      platformsToSkip.length === 0
-        ? "all platforms"
-        : `these platforms: ${platformsToSkip.join(", ")}`;
-    body +=
-      ". Please verify that your test name looks correct, e.g., `test_cuda_assert_async (__main__.TestCuda)`.\n\n";
-  }
+  body += `Within ~15 minutes, \`${testName}\` will be disabled in PyTorch CI for `;
+  body +=
+    platformsToSkip.length === 0
+      ? "all platforms"
+      : `these platforms: ${platformsToSkip.join(", ")}`;
+  body +=
+    ". Please verify that your test name looks correct, e.g., `test_cuda_assert_async (__main__.TestCuda)`.\n\n";
 
   body +=
     "To modify the platforms list, please include a line in the issue body, like below. The default ";
@@ -342,34 +337,64 @@ export function formValidationComment(
     .sort((a, b) => a.localeCompare(b))
     .join(", ")}.\n\n`;
 
-  body += `
-### How to re-enable a test
-To re-enable the test globally, close the issue. To re-enable a test for only a subset of platforms, remove the platforms from the list in the issue body. This may take some time to propagate. To re-enable a test only for a PR, put \`Fixes #${issueNumber}\` in the PR body and rerun the test jobs. Note that if a test is flaky, it maybe be difficult to tell if the test is still flaky on the PR.
-`;
+  body += genReenableValidationSection(issue.number);
 
   body += "</body>";
-  return validationCommentStart + body + validationCommentEnd;
+  return body;
 }
 
 // Returns the platform module labels that are expected, and invalid labels that we do not expect to be there
-export function getExpectedPlatformModuleLabels(
-  platforms: string[],
+function getExpectedLabels(
+  issueBody: string | null,
   labels: string[]
-): [string[], string[]] {
+): string[] {
   let supportedPlatformLabels = Array.from(supportedPlatforms.values())
     .flat()
     // Quick hack to make sure oncall: pt2 doesn't get deleted.
     // TODO: figure out a better way to differentiate between labels that should
     // stay and labels that shouldn't
     .filter((label) => label.startsWith("module: "));
-  let existingPlatformLabels = labels.filter((label) =>
-    supportedPlatformLabels.includes(label)
+  let existingNonPlatformLabels = labels.filter(
+    (label) => !supportedPlatformLabels.includes(label)
   );
-  let expectedPlatformLabels = getPlatformLabels(platforms);
-  // everything in labels that's not in expectedLabels is invalid
-  let invalidPlatformLabels = _.difference(
-    existingPlatformLabels,
-    expectedPlatformLabels
+  let expectedPlatformLabels = getPlatformLabels(
+    parseBody(issueBody || "").platformsToSkip
   );
-  return [expectedPlatformLabels, invalidPlatformLabels];
+  return expectedPlatformLabels.concat(existingNonPlatformLabels);
 }
+
+export async function fixLabels(context: Context<"issues">) {
+  const labels = context.payload.issue.labels?.map((label) => label.name) || [];
+  const owner = context.payload.repository.owner.login;
+  const repo = context.payload.repository.name;
+  const number = context.payload.issue.number;
+  // check labels, add labels as needed
+  let expectedLabels = getExpectedLabels(context.payload.issue.body, labels);
+  const toAdd = expectedLabels.filter((label) => !labels.includes(label));
+  if (toAdd.length > 0) {
+    await context.octokit.issues.addLabels({
+      owner,
+      repo,
+      issue_number: number,
+      labels: toAdd,
+    });
+  }
+  // remove invalid labels
+  let toRemove = labels.filter((label) => !expectedLabels.includes(label));
+  for (const invalidLabel of toRemove) {
+    await context.octokit.issues.removeLabel({
+      owner,
+      repo,
+      issue_number: number,
+      name: invalidLabel,
+    });
+  }
+}
+
+export const __forTesting__ = {
+  getIssueTitle,
+  getIssueBodyForFlakyTest,
+  parseBody,
+  getExpectedLabels,
+  isSingleIssue,
+};

--- a/torchci/lib/flakyBot/utils.ts
+++ b/torchci/lib/flakyBot/utils.ts
@@ -130,3 +130,27 @@ export function getWorkflowJobNames(test: FlakyTestData): string[] {
     (value, index) => `${value} / ${test.jobNames[index]}`
   );
 }
+
+// MARK: validation
+
+export function genInvalidPlatformsValidationSection(
+  invalidPlatforms: string[]
+) {
+  let body = "";
+  body +=
+    "<b>WARNING!</b> In the parsing process, I received these invalid inputs as platforms for ";
+  body += `which the test will be disabled: ${invalidPlatforms.join(
+    ", "
+  )}. These could `;
+  body += "be typos or platforms we do not yet support test disabling. Please ";
+  body +=
+    "verify the platform list above and modify your issue body if needed.\n\n";
+  return body;
+}
+
+export function genReenableValidationSection(number: number) {
+  return `
+### How to re-enable a test
+To re-enable the test globally, close the issue. To re-enable a test for only a subset of platforms, remove the platforms from the list in the issue body. This may take some time to propagate. To re-enable a test only for a PR, put \`Fixes #${number}\` in the PR body and rerun the test jobs. Note that if a test is flaky, it maybe be difficult to tell if the test is still flaky on the PR.
+`;
+}

--- a/torchci/test/common.ts
+++ b/torchci/test/common.ts
@@ -29,7 +29,7 @@ export function requireDeepCopy(fileName: string) {
   return deepCopy(require(fileName));
 }
 
-export function deepCopy(obj: any) {
+export function deepCopy<T>(obj: T): T {
   return JSON.parse(JSON.stringify(obj));
 }
 

--- a/torchci/test/verifyDisableTestIssue.test.ts
+++ b/torchci/test/verifyDisableTestIssue.test.ts
@@ -47,6 +47,17 @@ describe("Verify disable issues unittests", () => {
 });
 
 describe("Verify disable issues integration tests", () => {
+  let probot: Probot;
+
+  beforeEach(() => {
+    probot = utils.testProbot();
+    probot.load(myProbotApp);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    jest.restoreAllMocks();
+  });
   function mockCloseIssue(owner: string, repo: string, number: number) {
     return nock("https://api.github.com")
       .patch(
@@ -133,17 +144,6 @@ describe("Verify disable issues integration tests", () => {
       number,
     };
   }
-  let probot: Probot;
-
-  beforeEach(() => {
-    probot = utils.testProbot();
-    probot.load(myProbotApp);
-  });
-
-  afterEach(() => {
-    nock.cleanAll();
-    jest.restoreAllMocks();
-  });
 
   test("pytorch-bot[bot] is authorized", async () => {
     const { payload, owner, repo, number } = defaultE2ETestInputs({});

--- a/torchci/test/verifyDisableTestIssue.test.ts
+++ b/torchci/test/verifyDisableTestIssue.test.ts
@@ -1,7 +1,3 @@
-import {
-  formValidationComment,
-  parseBody,
-} from "lib/flakyBot/singleDisableIssue";
 import _ from "lodash";
 import nock from "nock";
 import { Probot } from "probot";
@@ -16,97 +12,7 @@ import * as utils from "./utils";
 
 nock.disableNetConnect();
 
-function mockCloseIssue(owner: string, repo: string, number: number) {
-  return nock("https://api.github.com")
-    .patch(
-      `/repos/${owner}/${repo}/issues/${number}`,
-      (body) => body.state === "closed"
-    )
-    .reply(200);
-}
-
-function mockFetchExistingComment(owner: string, repo: string, number: number) {
-  return nock("https://api.github.com")
-    .get(`/repos/${owner}/${repo}/issues/${number}/comments?per_page=10`)
-    .reply(200, []);
-}
-
-function mockCommentHas(
-  owner: string,
-  repo: string,
-  number: number,
-  shouldContain: string[],
-  shouldNotContain: string[]
-) {
-  return nock("https://api.github.com")
-    .post(
-      `/repos/${owner}/${repo}/issues/${number}/comments`,
-
-      (body) => {
-        for (const containedString of shouldContain) {
-          expect(body.body).toContain(containedString);
-        }
-        for (const notContainedString of shouldNotContain) {
-          expect(body.body).not.toContain(notContainedString);
-        }
-        return true;
-      }
-    )
-    .reply(200);
-}
-
-function defaultE2ETestInputs({
-  title,
-  body,
-  userLogin,
-  labels,
-}: {
-  title?: string;
-  body?: string;
-  userLogin?: string;
-  labels?: string[];
-}) {
-  const payload = requireDeepCopy("./fixtures/issues.opened.json");
-  payload.issue.title = "DISABLED testMethodName (testClass.TestSuite)";
-  payload.issue.user.id = pytorchBotId;
-  payload.issue.labels = [];
-
-  if (title !== undefined) {
-    payload.issue.title = title;
-  }
-  if (body !== undefined) {
-    payload.issue.body = body;
-  }
-  if (userLogin !== undefined) {
-    payload.issue.user.id = 12345;
-    payload.issue.user.login = userLogin;
-  }
-  if (labels !== undefined) {
-    payload.issue.labels = labels.map((label) => ({
-      name: label,
-    }));
-  }
-
-  const owner = payload.repository.owner.login;
-  const repo = payload.repository.name;
-  const number = payload.issue.number;
-
-  return {
-    payload,
-    owner,
-    repo,
-    number,
-  };
-}
-
-describe("verify-disable-test-issue", () => {
-  let probot: Probot;
-
-  beforeEach(() => {
-    probot = utils.testProbot();
-    probot.load(myProbotApp);
-  });
-
+describe("Verify disable issues unittests", () => {
   test("issue opened with title starts w/ DISABLED: unauthorized", async () => {
     let title = "DISABLED pull / linux-bionic-py3.8-clang9";
     const jobName = bot.parseTitle(title, disabledKey);
@@ -117,247 +23,10 @@ describe("verify-disable-test-issue", () => {
       disabledKey
     );
 
-    expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
     expect(
       comment.includes("You (mock-user) don't have permission to disable")
     ).toBeTruthy();
     expect(comment.includes("ERROR")).toBeTruthy();
-
-    title = "DISABLED testMethodName (testClass.TestSuite)";
-    const body = "Platforms:linux,macos";
-
-    const { platformsToSkip, invalidPlatforms } = parseBody(body);
-    const testName = bot.parseTitle(title, disabledKey);
-
-    comment = formValidationComment(
-      "mock-user",
-      false,
-      testName,
-      platformsToSkip,
-      invalidPlatforms,
-      0
-    );
-
-    expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
-    expect(
-      comment.includes("You (mock-user) don't have permission to disable")
-    ).toBeTruthy();
-    expect(comment.includes("ERROR")).toBeTruthy();
-  });
-
-  test("issue opened with title starts w/ DISABLED: disable for win", async () => {
-    const title = "DISABLED testMethodName (testClass.TestSuite)";
-    const body = "whatever\nPlatforms:win\nyay";
-
-    const { platformsToSkip, invalidPlatforms } = parseBody(body);
-    const testName = bot.parseTitle(title, disabledKey);
-    expect(platformsToSkip).toMatchObject(["win"]);
-    expect(invalidPlatforms).toMatchObject([]);
-    expect(testName).toEqual("testMethodName (testClass.TestSuite)");
-
-    const comment = formValidationComment(
-      "mock-user",
-      true,
-      testName,
-      platformsToSkip,
-      invalidPlatforms,
-      0
-    );
-    expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
-    expect(
-      comment.includes(
-        "~15 minutes, `testMethodName (testClass.TestSuite)` will be disabled"
-      )
-    ).toBeTruthy();
-    expect(comment.includes("these platforms: win.")).toBeTruthy();
-    expect(comment.includes("ERROR")).toBeFalsy();
-    expect(comment.includes("WARNING")).toBeFalsy();
-  });
-
-  test("issue opened with title starts w/ DISABLED: disable for windows, rocm, asan", async () => {
-    const title = "DISABLED testMethodName (testClass.TestSuite)";
-    const body = "whatever\nPlatforms:windows, ROCm, ASAN\nyay";
-
-    const { platformsToSkip, invalidPlatforms } = parseBody(body);
-    const testName = bot.parseTitle(title, disabledKey);
-    expect(platformsToSkip).toMatchObject(["asan", "rocm", "windows"]);
-    expect(invalidPlatforms).toMatchObject([]);
-    expect(testName).toEqual("testMethodName (testClass.TestSuite)");
-
-    const comment = formValidationComment(
-      "mock-user",
-      true,
-      testName,
-      platformsToSkip,
-      invalidPlatforms,
-      0
-    );
-    expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
-    expect(
-      comment.includes(
-        "~15 minutes, `testMethodName (testClass.TestSuite)` will be disabled"
-      )
-    ).toBeTruthy();
-    expect(
-      comment.includes("these platforms: asan, rocm, windows.")
-    ).toBeTruthy();
-    expect(comment.includes("ERROR")).toBeFalsy();
-    expect(comment.includes("WARNING")).toBeFalsy();
-  });
-
-  test("issue opened with title starts w/ DISABLED: disable for all", async () => {
-    const title = "DISABLED testMethodName (testClass.TestSuite)";
-    const body = "whatever yay";
-
-    const { platformsToSkip, invalidPlatforms } = parseBody(body);
-    const testName = bot.parseTitle(title, disabledKey);
-    expect(platformsToSkip).toMatchObject([]);
-    expect(invalidPlatforms).toMatchObject([]);
-    expect(testName).toEqual("testMethodName (testClass.TestSuite)");
-
-    const comment = formValidationComment(
-      "mock-user",
-      true,
-      testName,
-      platformsToSkip,
-      invalidPlatforms,
-      0
-    );
-    expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
-    expect(
-      comment.includes(
-        "~15 minutes, `testMethodName (testClass.TestSuite)` will be disabled"
-      )
-    ).toBeTruthy();
-    expect(comment.includes("all platforms.")).toBeTruthy();
-    expect(comment.includes("ERROR")).toBeFalsy();
-    expect(comment.includes("WARNING")).toBeFalsy();
-  });
-
-  test("issue opened with title starts w/ DISABLED: disable unknown platform", async () => {
-    const title = "DISABLED testMethodName (testClass.TestSuite)";
-    const body = "whatever\nPlatforms:everything\nyay";
-
-    const { platformsToSkip, invalidPlatforms } = parseBody(body);
-    const testName = bot.parseTitle(title, disabledKey);
-    expect(platformsToSkip).toMatchObject([]);
-    expect(invalidPlatforms).toMatchObject(["everything"]);
-    expect(testName).toEqual("testMethodName (testClass.TestSuite)");
-
-    const comment = formValidationComment(
-      "mock-user",
-      true,
-      testName,
-      platformsToSkip,
-      invalidPlatforms,
-      0
-    );
-    expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
-    expect(
-      comment.includes(
-        "~15 minutes, `testMethodName (testClass.TestSuite)` will be disabled"
-      )
-    ).toBeTruthy();
-    expect(comment.includes("all platforms.")).toBeTruthy();
-    expect(comment.includes("ERROR")).toBeFalsy();
-    expect(comment.includes("WARNING")).toBeTruthy();
-    expect(
-      comment.includes(
-        "invalid inputs as platforms for which the test will be disabled: everything."
-      )
-    ).toBeTruthy();
-  });
-
-  test("issue opened with title starts w/ DISABLED: can parse nested test suites", async () => {
-    const title =
-      "DISABLED testMethodName   (quantization.core.test_workflow_ops.TestFakeQuantizeOps)";
-    const body = "whatever\nPlatforms:\nyay";
-
-    const { platformsToSkip, invalidPlatforms } = parseBody(body);
-    const testName = bot.parseTitle(title, disabledKey);
-    expect(platformsToSkip).toMatchObject([]);
-    expect(invalidPlatforms).toMatchObject([]);
-    expect(testName).toEqual(
-      "testMethodName   (quantization.core.test_workflow_ops.TestFakeQuantizeOps)"
-    );
-
-    const comment = formValidationComment(
-      "mock-user",
-      true,
-      testName,
-      platformsToSkip,
-      invalidPlatforms,
-      0
-    );
-    expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
-    expect(comment.includes("~15 minutes")).toBeTruthy();
-    expect(comment.includes("ERROR")).toBeFalsy();
-    expect(comment.includes("WARNING")).toBeFalsy();
-  });
-
-  test("issue opened with title starts w/ DISABLED: cannot parse test", async () => {
-    const title = "DISABLED testMethodName   cuz it borked  ";
-    const body = "whatever\nPlatforms:\nyay";
-
-    const { platformsToSkip, invalidPlatforms } = parseBody(body);
-    const testName = bot.parseTitle(title, disabledKey);
-    expect(platformsToSkip).toMatchObject([]);
-    expect(invalidPlatforms).toMatchObject([]);
-    expect(testName).toEqual("testMethodName   cuz it borked");
-
-    const comment = formValidationComment(
-      "mock-user",
-      true,
-      testName,
-      platformsToSkip,
-      invalidPlatforms,
-      0
-    );
-    expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
-    expect(comment.includes("~15 minutes")).toBeFalsy();
-    expect(comment.includes("ERROR")).toBeTruthy();
-    expect(comment.includes("WARNING")).toBeFalsy();
-  });
-
-  test("issue opened with title starts w/ DISABLED: cannot parse test nor platforms", async () => {
-    const title = "DISABLED testMethodName   cuz it borked  ";
-    const body = "whatever\nPlatforms:all of them\nyay";
-
-    const { platformsToSkip, invalidPlatforms } = parseBody(body);
-    const testName = bot.parseTitle(title, disabledKey);
-    expect(platformsToSkip).toMatchObject([]);
-    expect(invalidPlatforms).toMatchObject(["all of them"]);
-    expect(testName).toEqual("testMethodName   cuz it borked");
-
-    const comment = formValidationComment(
-      "mock-user",
-      true,
-      testName,
-      platformsToSkip,
-      invalidPlatforms,
-      0
-    );
-    expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
-    expect(comment.includes("~15 minutes")).toBeFalsy();
-    expect(comment.includes("ERROR")).toBeTruthy();
-    expect(comment.includes("WARNING")).toBeTruthy();
-  });
-
-  test("issue opened with title starts w/ DISABLED: to disable a job", async () => {
-    const title = "DISABLED pull / linux-bionic-py3.8-clang9";
-
-    const jobName = bot.parseTitle(title, disabledKey);
-    expect(jobName).toEqual("pull / linux-bionic-py3.8-clang9");
-
-    let comment = bot.formJobValidationComment(
-      "mock-user",
-      true,
-      jobName,
-      disabledKey
-    );
-    expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
-    expect(comment.includes(`~15 minutes, \`${jobName}\``)).toBeTruthy();
-    expect(comment.includes("ERROR")).toBeFalsy();
   });
 
   test("issue opened with title starts w/ UNSTABLE: to mark a job as unstable", async () => {
@@ -372,13 +41,98 @@ describe("verify-disable-test-issue", () => {
       jobName,
       unstableKey
     );
-    expect(comment.includes("<!-- validation-comment-start -->")).toBeTruthy();
     expect(comment.includes(`~15 minutes, \`${jobName}\``)).toBeTruthy();
     expect(comment.includes("ERROR")).toBeFalsy();
   });
 });
 
-describe("verify-disable-test-issue-bot", () => {
+describe("Verify disable issues integration tests", () => {
+  function mockCloseIssue(owner: string, repo: string, number: number) {
+    return nock("https://api.github.com")
+      .patch(
+        `/repos/${owner}/${repo}/issues/${number}`,
+        (body) => body.state === "closed"
+      )
+      .reply(200);
+  }
+
+  function mockFetchExistingComment(
+    owner: string,
+    repo: string,
+    number: number
+  ) {
+    return nock("https://api.github.com")
+      .get(`/repos/${owner}/${repo}/issues/${number}/comments?per_page=10`)
+      .reply(200, []);
+  }
+
+  function mockCommentHas(
+    owner: string,
+    repo: string,
+    number: number,
+    shouldContain: string[],
+    shouldNotContain: string[]
+  ) {
+    return nock("https://api.github.com")
+      .post(
+        `/repos/${owner}/${repo}/issues/${number}/comments`,
+
+        (body) => {
+          for (const containedString of shouldContain) {
+            expect(body.body).toContain(containedString);
+          }
+          for (const notContainedString of shouldNotContain) {
+            expect(body.body).not.toContain(notContainedString);
+          }
+          return true;
+        }
+      )
+      .reply(200);
+  }
+
+  function defaultE2ETestInputs({
+    title,
+    body,
+    userLogin,
+    labels,
+  }: {
+    title?: string;
+    body?: string;
+    userLogin?: string;
+    labels?: string[];
+  }) {
+    const payload = requireDeepCopy("./fixtures/issues.opened.json");
+    payload.issue.title = "DISABLED testMethodName (testClass.TestSuite)";
+    payload.issue.user.id = pytorchBotId;
+    payload.issue.labels = [];
+
+    if (title !== undefined) {
+      payload.issue.title = title;
+    }
+    if (body !== undefined) {
+      payload.issue.body = body;
+    }
+    if (userLogin !== undefined) {
+      payload.issue.user.id = 12345;
+      payload.issue.user.login = userLogin;
+    }
+    if (labels !== undefined) {
+      payload.issue.labels = labels.map((label) => ({
+        name: label,
+      }));
+    }
+
+    const owner = payload.repository.owner.login;
+    const repo = payload.repository.name;
+    const number = payload.issue.number;
+
+    return {
+      payload,
+      owner,
+      repo,
+      number,
+    };
+  }
   let probot: Probot;
 
   beforeEach(() => {
@@ -396,9 +150,14 @@ describe("verify-disable-test-issue-bot", () => {
 
     const scope = [
       mockFetchExistingComment(owner, repo, number),
-      mockCommentHas(owner, repo, number, [], ["don't have permission"]),
+      mockCommentHas(
+        owner,
+        repo,
+        number,
+        ["<!-- validation-comment-start -->", "all platforms"],
+        ["don't have permission", "ERROR", "WARNING"]
+      ),
     ];
-
     await probot.receive({ name: "issues", payload: payload, id: "2" });
 
     handleScope(scope);
@@ -416,7 +175,17 @@ describe("verify-disable-test-issue-bot", () => {
         .reply(200, {
           permission: "read",
         }),
-      mockCommentHas(owner, repo, number, ["don't have permission"], []),
+      mockCommentHas(
+        owner,
+        repo,
+        number,
+        [
+          "You (randomuser) don't have permission",
+          "<!-- validation-comment-start -->",
+          "ERROR",
+        ],
+        ["WARNING"]
+      ),
       mockCloseIssue(owner, repo, number),
     ];
 
@@ -425,14 +194,21 @@ describe("verify-disable-test-issue-bot", () => {
     handleScope(scope);
   });
 
-  test("issue with missing labels gets labels", async () => {
+  test("issue with missing labels adds labels", async () => {
     const { payload, owner, repo, number } = defaultE2ETestInputs({
+      labels: [],
       body: "Platforms: rocm",
     });
 
     const scope = [
       mockFetchExistingComment(owner, repo, number),
-      mockCommentHas(owner, repo, number, [], ["don't have permission"]),
+      mockCommentHas(
+        owner,
+        repo,
+        number,
+        ["<!-- validation-comment-start -->", "these platforms: rocm."],
+        ["don't have permission", "ERROR", "WARNING"]
+      ),
       nock("https://api.github.com")
         .post(`/repos/${owner}/${repo}/issues/${number}/labels`, (body) =>
           _.isEqual(body.labels, ["module: rocm"])
@@ -453,13 +229,22 @@ describe("verify-disable-test-issue-bot", () => {
 
     const scope = [
       mockFetchExistingComment(owner, repo, number),
-      mockCommentHas(owner, repo, number, [], ["don't have permission"]),
+      mockCommentHas(
+        owner,
+        repo,
+        number,
+        ["<!-- validation-comment-start -->", "these platforms: rocm."],
+        ["don't have permission", "ERROR", "WARNING"]
+      ),
       nock("https://api.github.com")
         .post(`/repos/${owner}/${repo}/issues/${number}/labels`, (body) =>
           _.isEqual(body.labels, ["module: rocm"])
         )
+        .reply(200, [])
+        .delete(
+          `/repos/${owner}/${repo}/issues/${number}/labels/module%3A%20windows`
+        )
         .reply(200, []),
-      mockCloseIssue(owner, repo, number),
     ];
 
     await probot.receive({ name: "issues", payload: payload, id: "2" });
@@ -475,7 +260,201 @@ describe("verify-disable-test-issue-bot", () => {
 
     const scope = [
       mockFetchExistingComment(owner, repo, number),
-      mockCommentHas(owner, repo, number, [], ["don't have permission"]),
+      mockCommentHas(
+        owner,
+        repo,
+        number,
+        ["<!-- validation-comment-start -->", "these platforms: rocm."],
+        ["don't have permission", "ERROR", "WARNING"]
+      ),
+    ];
+    await probot.receive({ name: "issues", payload: payload, id: "2" });
+
+    handleScope(scope);
+  });
+
+  test("issue opened with title starts w/ DISABLED: disable for win", async () => {
+    const { payload, owner, repo, number } = defaultE2ETestInputs({
+      body: "Platforms: win",
+      labels: ["module: windows", "random label"],
+    });
+
+    const scope = [
+      mockFetchExistingComment(owner, repo, number),
+      mockCommentHas(
+        owner,
+        repo,
+        number,
+        ["<!-- validation-comment-start -->", "these platforms: win."],
+        ["don't have permission", "ERROR", "WARNING"]
+      ),
+    ];
+    await probot.receive({ name: "issues", payload: payload, id: "2" });
+
+    handleScope(scope);
+  });
+
+  test("issue opened with title starts w/ DISABLED: disable for win", async () => {
+    const { payload, owner, repo, number } = defaultE2ETestInputs({
+      body: "whatever\nPlatforms:win\nyay",
+      labels: ["module: windows", "random label"],
+    });
+
+    const scope = [
+      mockFetchExistingComment(owner, repo, number),
+      mockCommentHas(
+        owner,
+        repo,
+        number,
+        ["<!-- validation-comment-start -->", "these platforms: win."],
+        ["don't have permission", "ERROR", "WARNING"]
+      ),
+    ];
+    await probot.receive({ name: "issues", payload: payload, id: "2" });
+
+    handleScope(scope);
+  });
+
+  test("issue opened with title starts w/ DISABLED: disable for windows, rocm, asan", async () => {
+    const { payload, owner, repo, number } = defaultE2ETestInputs({
+      body: "Platforms: win, ROCm, ASAN",
+      labels: ["random label"],
+    });
+
+    const scope = [
+      mockFetchExistingComment(owner, repo, number),
+      mockCommentHas(
+        owner,
+        repo,
+        number,
+        [
+          "<!-- validation-comment-start -->",
+          "~15 minutes, `testMethodName (testClass.TestSuite)` will be disabled",
+          "these platforms: asan, rocm, win.",
+        ],
+        ["don't have permission", "ERROR", "WARNING"]
+      ),
+    ];
+    await probot.receive({ name: "issues", payload: payload, id: "2" });
+
+    handleScope(scope);
+  });
+
+  test("issue opened with title starts w/ DISABLED: disable for all", async () => {
+    const { payload, owner, repo, number } = defaultE2ETestInputs({
+      body: "whatever yay",
+      labels: ["random label"],
+    });
+
+    const scope = [
+      mockFetchExistingComment(owner, repo, number),
+      mockCommentHas(
+        owner,
+        repo,
+        number,
+        [
+          "<!-- validation-comment-start -->",
+          "~15 minutes, `testMethodName (testClass.TestSuite)` will be disabled",
+          "all platforms.",
+        ],
+        ["don't have permission", "ERROR", "WARNING"]
+      ),
+    ];
+    await probot.receive({ name: "issues", payload: payload, id: "2" });
+
+    handleScope(scope);
+  });
+
+  test("issue opened with title starts w/ DISABLED: disable unknown platform", async () => {
+    const { payload, owner, repo, number } = defaultE2ETestInputs({
+      body: "whatever\nPlatforms:invalid\nyay",
+      labels: ["random label"],
+    });
+
+    const scope = [
+      mockFetchExistingComment(owner, repo, number),
+      mockCommentHas(
+        owner,
+        repo,
+        number,
+        [
+          "<!-- validation-comment-start -->",
+          "all platforms",
+          "WARNING",
+          "invalid inputs as platforms for which the test will be disabled: invalid.",
+        ],
+        ["don't have permission", "ERROR"]
+      ),
+    ];
+    await probot.receive({ name: "issues", payload: payload, id: "2" });
+
+    handleScope(scope);
+  });
+
+  test("issue opened with title starts w/ DISABLED: can parse nested test suites", async () => {
+    const { payload, owner, repo, number } = defaultE2ETestInputs({
+      body: "Platforms: win",
+      labels: ["module: windows", "random label"],
+      title:
+        "DISABLED testMethodName   (quantization.core.test_workflow_ops.TestFakeQuantizeOps)",
+    });
+
+    const scope = [
+      mockFetchExistingComment(owner, repo, number),
+      mockCommentHas(
+        owner,
+        repo,
+        number,
+        [
+          "<!-- validation-comment-start -->",
+          "these platforms: win.",
+          "testMethodName   (quantization.core.test_workflow_ops.TestFakeQuantizeOps)",
+        ],
+        ["don't have permission", "ERROR", "WARNING"]
+      ),
+    ];
+    await probot.receive({ name: "issues", payload: payload, id: "2" });
+
+    handleScope(scope);
+  });
+
+  test("issue opened with title starts w/ DISABLED: cannot parse platforms", async () => {
+    const { payload, owner, repo, number } = defaultE2ETestInputs({
+      body: "Platforms: all of them",
+      labels: ["random label"],
+    });
+
+    const scope = [
+      mockFetchExistingComment(owner, repo, number),
+      mockCommentHas(
+        owner,
+        repo,
+        number,
+        ["<!-- validation-comment-start -->", "all platforms", "WARNING"],
+        ["don't have permission", "ERROR"]
+      ),
+    ];
+    await probot.receive({ name: "issues", payload: payload, id: "2" });
+
+    handleScope(scope);
+  });
+
+  test("issue opened with title starts w/ DISABLED:, not a test", async () => {
+    const { payload, owner, repo, number } = defaultE2ETestInputs({
+      body: "whatever\nPlatforms:\nyay",
+      labels: ["module: windows", "random label"],
+      title: "DISABLED testMethodName   cuz it borked  ",
+    });
+
+    const scope = [
+      mockFetchExistingComment(owner, repo, number),
+      mockCommentHas(
+        owner,
+        repo,
+        number,
+        ["<!-- validation-comment-start -->", "attempting to disabled a job"],
+        ["don't have permission", "WARNING", "ERROR"]
+      ),
     ];
 
     await probot.receive({ name: "issues", payload: payload, id: "2" });


### PR DESCRIPTION
Most of this is moving code around and changing APIs for things

Only major change in e2e behavior is that the fall back for invalid disable test title is to assume its a job name and will attempt to disable the weirdly named job.  Previously it would say the title is malformed for a test

Changes:
* Fall back thing mentioned above
* API/moving code around ex
  * Move module label logic moved to other file
  * Move parsing of issue body into other file
* Testing
  * I converted a lot of tests to be more integration style tests so we change change the api more often and tests will still be valid