### PR TITLE
cost dashboard: table view

### DIFF
--- a/torchci/components/metrics/panels/TimeSeriesTable.tsx
+++ b/torchci/components/metrics/panels/TimeSeriesTable.tsx
@@ -1,0 +1,197 @@
+/**
+ * A metrics panel that shows time series data in a table format.
+ */
+import { Paper } from "@mui/material";
+import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import { formatTimeForCharts } from "components/TimeUtils";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import { fetcher } from "lib/GeneralUtils";
+import _ from "lodash";
+import { useMemo } from "react";
+import useSWR from "swr";
+import { ChartType, Granularity, seriesWithInterpolatedTimes } from "./TimeSeriesPanel";
+
+dayjs.extend(utc);
+
+export default function TimeSeriesTable({
+  // Human-readable title of the panel.
+  title,
+  // Query name
+  queryName,
+  // Query parameters
+  queryParams,
+  // Granularity of the time buckets.
+  granularity,
+  // What field name to group by. Each unique value in this field will show up
+  // as its own column.
+  groupByFieldName,
+  // What field name to treat as the time value.
+  timeFieldName,
+  // Display format for the time field (ex "M/D h:mm:ss A")
+  timeFieldDisplayFormat = "M/D (UTC)",
+  // What field name to put on the data cells.
+  yAxisFieldName,
+  // Callback to render the cell value in some nice way.
+  yAxisRenderer,
+  // Chart type (used for generating series data)
+  chartType = "line",
+  // Sort by total or name
+  sort_by = "name",
+  // Max items to show (the rest will be grouped as "Other")
+  max_items_in_series = 0,
+  // Filter string to limit displayed series
+  filter = undefined,
+  // Whether filter is regex
+  isRegex = false,
+  // Whether to auto-refresh
+  auto_refresh = true,
+  // Additional function to process the data after querying
+  dataReader = undefined,
+}: {
+  title: string;
+  queryName: string;
+  queryParams: { [key: string]: any };
+  granularity: Granularity;
+  groupByFieldName?: string;
+  timeFieldName: string;
+  timeFieldDisplayFormat?: string;
+  yAxisFieldName: string;
+  yAxisRenderer: (_value: any) => string;
+  chartType?: ChartType;
+  sort_by?: "total" | "name";
+  max_items_in_series?: number;
+  filter?: string;
+  isRegex?: boolean;
+  auto_refresh?: boolean;
+  dataReader?: (_data: { [k: string]: any }[]) => { [k: string]: any }[];
+}) {
+  const url = `/api/clickhouse/${queryName}?parameters=${encodeURIComponent(
+    JSON.stringify({
+      ...queryParams,
+      granularity: granularity as string,
+    })
+  )}`;
+
+  const { data: rawData, isLoading } = useSWR(url, fetcher, {
+    refreshInterval: auto_refresh ? 5 * 60 * 1000 : 0,
+  });
+
+  // Process data for table display
+  const { tableData, columns } = useMemo(() => {
+    if (!rawData || isLoading) {
+      return { tableData: [], columns: [] };
+    }
+
+    const data = dataReader ? dataReader(rawData) : rawData;
+    let startTime = dayjs.utc(queryParams["startTime"]);
+    let stopTime = dayjs.utc(queryParams["stopTime"]);
+    
+    // Clamp to the nearest granularity (e.g. nearest hour) so that the times will
+    // align with the data we get from the database
+    startTime = startTime.startOf(granularity);
+    stopTime = stopTime.endOf(granularity);
+
+    // Get series data using same function as chart
+    const series = seriesWithInterpolatedTimes(
+      data,
+      startTime,
+      stopTime,
+      granularity,
+      groupByFieldName,
+      timeFieldName,
+      yAxisFieldName,
+      true,
+      false, // Smooth doesn't apply to table
+      sort_by,
+      chartType,
+      filter,
+      isRegex
+    );
+
+    // Process series into table data
+    // First, we need to get all timestamps
+    const allTimestamps = new Set<string>();
+    series.forEach((s) => {
+      s.data.forEach((point: [string, number]) => {
+        allTimestamps.add(point[0]);
+      });
+    });
+
+    // Sort timestamps chronologically
+    const timestamps = Array.from(allTimestamps).sort();
+    
+    // Create rows with timestamp as first column and series values in subsequent columns
+    const tableData = timestamps.map((timestamp) => {
+      const formattedTime = formatTimeForCharts(timestamp, timeFieldDisplayFormat);
+      const row: any = {
+        id: timestamp,
+        timestamp: formattedTime,
+      };
+
+      // Add value for each series
+      series.forEach((s) => {
+        const point = s.data.find((d: [string, any]) => d[0] === timestamp);
+        row[s.name] = point ? point[1] : 0;
+      });
+
+      return row;
+    });
+
+    // Create columns definition
+    const columns: GridColDef[] = [
+      {
+        field: 'timestamp',
+        headerName: 'Time',
+        width: 120,
+      },
+      ...series.map((s) => ({
+        field: s.name,
+        headerName: s.name,
+        width: 150,
+        renderCell: (params) => (
+          <div>{yAxisRenderer(params.value)}</div>
+        ),
+      })),
+    ];
+
+    return { tableData, columns };
+  }, [rawData, isLoading, queryParams, granularity, groupByFieldName, timeFieldName, yAxisFieldName, sort_by, chartType, filter, isRegex, yAxisRenderer, timeFieldDisplayFormat, dataReader]);
+
+
+  return (
+    <Paper sx={{ p: 2, height: "100%" }} elevation={3}>
+      <div style={{ height: "100%", width: "100%" }}>
+        <DataGrid
+          rows={tableData}
+          columns={columns}
+          density="compact"
+          pageSizeOptions={[25, 50, 100]}
+          initialState={{
+            pagination: {
+              paginationModel: { pageSize: 25 }
+            }
+          }}
+          loading={isLoading}
+          sx={{
+            '& .MuiDataGrid-columnHeaders': {
+              backgroundColor: '#2f847c', /* Blueish-green to match common chart colors */
+              color: '#ffffff',
+              fontWeight: 'bold',
+            },
+            '& .MuiDataGrid-columnHeader': {
+              backgroundColor: '#2f847c',
+              color: '#ffffff',
+            },
+            '&.MuiDataGrid-root--densityCompact .MuiDataGrid-cell': {
+              py: '8px',
+            },
+            '& .MuiDataGrid-columnHeaderTitle': {
+              fontWeight: 'bold',
+            }
+          }}
+        />
+      </div>
+    </Paper>
+  );
+}

--- a/torchci/pages/cost_analysis.tsx
+++ b/torchci/pages/cost_analysis.tsx
@@ -21,6 +21,7 @@ import TimeSeriesPanel, {
   ChartType,
   Granularity,
 } from "components/metrics/panels/TimeSeriesPanel";
+import TimeSeriesTable from "components/metrics/panels/TimeSeriesTable";
 import MultiSelectPicker from "components/MultiSelectPicker";
 import dayjs from "dayjs";
 import { fetcher } from "lib/GeneralUtils";
@@ -28,7 +29,7 @@ import _ from "lodash";
 import { useRouter } from "next/router";
 import React, { useCallback, useEffect, useState } from "react";
 import { BiLineChart } from "react-icons/bi";
-import { FaFilter, FaInfoCircle, FaRegChartBar } from "react-icons/fa";
+import { FaFilter, FaInfoCircle, FaRegChartBar, FaTable } from "react-icons/fa";
 import { MdOutlineStackedBarChart } from "react-icons/md";
 import useSWR from "swr";
 
@@ -267,7 +268,7 @@ export default function Page() {
   const [showInstanceType, setShowInstanceType] = useState(
     initialShowInstanceType
   );
-
+  
   const [routerReady, setRouterReady] = useState(false);
 
   if (!routerReady && router.isReady) {
@@ -642,16 +643,13 @@ export default function Page() {
       <Box>
         <TextField
           id={`outlined-basic-${type}`}
-          label={
-            <div>
-              <FaFilter /> Filter {type}
-            </div>
-          }
+          label={`Filter ${type}`}
           onChange={handleChange}
           variant="outlined"
           fullWidth
           value={inputValue}
           InputProps={{
+            startAdornment: <FaFilter />,
             endAdornment: (
               <Tooltip
                 title={
@@ -816,6 +814,40 @@ export default function Page() {
           )}
           <Grid2 size={{ xs: 1 }}></Grid2>
           {generateGroupByAndFilterBar()}
+        </Grid2>
+        
+        <Grid2 container marginTop={1} size={{ xs: 12 }}>
+          <Grid2 size={{ xs: 8 }} height={400}>
+            {!isLoading && (
+              <TimeSeriesTable
+                queryName={`${selectedYAxis}_job_per_${groupby === "runner_type" && showInstanceType ? "instance_type" : groupby}`}
+                queryParams={{
+                  ...timeParamsClickHouse,
+                  groupby: groupby === "runner_type" && showInstanceType ? "instance_type" : groupby,
+                  selectedRepos,
+                  selectedGPU,
+                  selectedOwners,
+                  selectedPlatforms: selectedOS,
+                  selectedProviders,
+                }}
+                granularity={granularity}
+                groupByFieldName={groupby === "runner_type" && showInstanceType ? "instance_type" : groupby}
+                timeFieldName={"granularity_bucket"}
+                yAxisFieldName={`total_${selectedYAxis}`}
+                yAxisRenderer={selectedYAxis === "cost" ? costDisplay : hourDisplay}
+                chartType={chartType}
+                filter={searchFilter}
+                isRegex={isRegex}
+                timeFieldDisplayFormat="M/D (UTC)"
+                sort_by="total"
+                auto_refresh={false}
+                max_items_in_series={30}
+              />
+            )}
+            {isLoading && <div>Loading...</div>}
+          </Grid2>
+          <Grid2 size={{ xs: 1 }}></Grid2>
+          <Grid2 size={{ xs: 2 }}></Grid2>
         </Grid2>
       </Grid2>
     </div>

--- a/torchci/pages/cost_analysis.tsx
+++ b/torchci/pages/cost_analysis.tsx
@@ -817,7 +817,7 @@ export default function Page() {
         </Grid2>
         
         <Grid2 container marginTop={1} size={{ xs: 12 }}>
-          <Grid2 size={{ xs: 8 }} height={400}>
+          <Grid2 size={{ xs: 11 }}>
             {!isLoading && (
               <TimeSeriesTable
                 queryName={`${selectedYAxis}_job_per_${groupby === "runner_type" && showInstanceType ? "instance_type" : groupby}`}
@@ -846,8 +846,6 @@ export default function Page() {
             )}
             {isLoading && <div>Loading...</div>}
           </Grid2>
-          <Grid2 size={{ xs: 1 }}></Grid2>
-          <Grid2 size={{ xs: 2 }}></Grid2>
         </Grid2>
       </Grid2>
     </div>


### PR DESCRIPTION
Show the data underneath the graph as a table, without restrictions to amount of rows (so no 'other' category)