### PR TITLE
[BE] Update setup-miniconda test

### DIFF
--- a/.github/workflows/test-setup-miniconda.yml
+++ b/.github/workflows/test-setup-miniconda.yml
@@ -13,13 +13,13 @@ jobs:
       fail-fast: false
       matrix:
         runner-type:
-          - macos-12
+          - macos-13
           - macos-m1-stable
           - linux.2xlarge
         # Only testing minimum and maximum versions here
         python-version:
-          - "3.8"
-          - "3.11"
+          - "3.9"
+          - "3.13"
         env-file:
           - ""
           - "./.github/workflows/test-setup-miniconda-env-file"


### PR DESCRIPTION
- Macos-12 (last x86 runner hosted by github) has been replaced by MacOS-13
- Update minimum tested Python version to 3.9
- Update latest tested Python version to 3.13