### PR TITLE
[Ephemeral Scale Downs] Reduce min runtime and better track buffer time

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -519,11 +519,9 @@ export async function tryReuseRunner(
 
       if (finishedAt.add(Config.Instance.minimumRunningTimeInMinutes, 'minutes') < moment(new Date()).utc()) {
         console.debug(
-          `[tryReuseRunner]: Runner ${runner.instanceId} has been idle for over minimumRunningTimeInMinutes time of ${
-            Config.Instance.minimumRunningTimeInMinutes
-          } mins, so it's likely to be reclaimed soon and should not be reused. It's been idle since ${
-            finishedAt.format()
-          }`,
+          `[tryReuseRunner]: Runner ${runner.instanceId} has been idle for over minimumRunningTimeInMinutes time of ` +
+            `${Config.Instance.minimumRunningTimeInMinutes} mins, so it's likely to be reclaimed soon and should ` +
+            `not be reused. It's been idle since ${finishedAt.format()}`,
         );
         continue;
       }

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -517,13 +517,11 @@ export async function tryReuseRunner(
         continue;
       }
 
-      if (finishedAt.add(Config.Instance.minimumRunningTimeInMinutes - 5, 'minutes') < moment(new Date()).utc()) {
+      if (finishedAt.add(Config.Instance.minimumRunningTimeInMinutes, 'minutes') < moment(new Date()).utc()) {
         console.debug(
-          `[tryReuseRunner]: Runner ${
-            runner.instanceId
-          } is already over minimumRunningTimeInMinutes time to be reused ${
+          `[tryReuseRunner]: Runner ${runner.instanceId} has been idle for over minimumRunningTimeInMinutes time of ${
             Config.Instance.minimumRunningTimeInMinutes
-          } ${runner.ephemeralRunnerFinished} ${moment(new Date()).utc().toDate().getTime() / 1000}`,
+          } mins, so it's likely to be reclaimed soon and should not be reused. It's been idle since ${finishedAt.format()}`,
         );
         continue;
       }
@@ -552,7 +550,7 @@ export async function tryReuseRunner(
           const ec2 = ec2M.get(runner.awsRegion) as EC2;
 
           // should come before removing other tags, this is useful so
-          // there is always a tag present for scaeDown to know that
+          // there is always a tag present for scaleDown to know that
           // it can/will be reused and avoid deleting it
           await expBackOff(() => {
             return metrics.trackRequestRegion(

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -521,7 +521,9 @@ export async function tryReuseRunner(
         console.debug(
           `[tryReuseRunner]: Runner ${runner.instanceId} has been idle for over minimumRunningTimeInMinutes time of ${
             Config.Instance.minimumRunningTimeInMinutes
-          } mins, so it's likely to be reclaimed soon and should not be reused. It's been idle since ${finishedAt.format()}`,
+          } mins, so it's likely to be reclaimed soon and should not be reused. It's been idle since ${
+            finishedAt.format()
+          }`,
         );
         continue;
       }

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -471,7 +471,9 @@ export function runnerMinimumTimeExceeded(runner: RunnerInfo): boolean {
     baseTime = moment.unix(runner.ephemeralRunnerFinished);
     reason = `is an ephemeral runner that finished at ${baseTime}`;
   } else if (runner.ebsVolumeReplacementRequestTimestamp !== undefined) {
-    baseTime = moment.unix(runner.ebsVolumeReplacementRequestTimestamp);
+    // Add 5 minutes to the EBS volume replacement request timestamp to account
+    // for the time it takes to replace the volume and start the runner.
+    baseTime = moment.unix(runner.ebsVolumeReplacementRequestTimestamp).add(5, 'minutes');
     reason = `had an EBS volume replacement request started at ${baseTime}`;
   } else {
     baseTime = moment(runner.launchTime || new Date()).utc();

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -471,16 +471,18 @@ export function runnerMinimumTimeExceeded(runner: RunnerInfo): boolean {
     // When both `ebsVolumeReplacementRequestTimestamp` and `ephemeralRunnerFinished` are defined,
     // we want to use the more recent timestamp to ensure that we don't scale down a runner
     // that is still in the process of being refreshed.
-    if (runner.ephemeralRunnerFinished !== undefined &&
-        runner.ebsVolumeReplacementRequestTimestamp < runner.ephemeralRunnerFinished) {
-        baseTime = moment.unix(runner.ephemeralRunnerFinished);
-        reason = `is an ephemeral runner that finished at ${baseTime}`;
-      } else {
-        // Add 5 minutes to the EBS volume replacement request timestamp to account
-        // for the time it takes to replace the volume and start the runner.
-        baseTime = moment.unix(runner.ebsVolumeReplacementRequestTimestamp).add(5, 'minutes');
-        reason = `had an EBS volume replacement request started at ${baseTime}`;
-      }
+    if (
+      runner.ephemeralRunnerFinished !== undefined &&
+      runner.ebsVolumeReplacementRequestTimestamp < runner.ephemeralRunnerFinished
+    ) {
+      baseTime = moment.unix(runner.ephemeralRunnerFinished);
+      reason = `is an ephemeral runner that finished at ${baseTime}`;
+    } else {
+      // Add 5 minutes to the EBS volume replacement request timestamp to account
+      // for the time it takes to replace the volume and start the runner.
+      baseTime = moment.unix(runner.ebsVolumeReplacementRequestTimestamp).add(5, 'minutes');
+      reason = `had an EBS volume replacement request started at ${baseTime}`;
+    }
   } else if (runner.ephemeralRunnerFinished !== undefined) {
     baseTime = moment.unix(runner.ephemeralRunnerFinished);
     reason = `is an ephemeral runner that finished at ${baseTime}`;

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -467,14 +467,23 @@ export function isRunnerRemovable(
 export function runnerMinimumTimeExceeded(runner: RunnerInfo): boolean {
   let baseTime: moment.Moment;
   let reason: string;
-  if (runner.ephemeralRunnerFinished !== undefined) {
+  if (runner.ebsVolumeReplacementRequestTimestamp !== undefined) {
+    // When both `ebsVolumeReplacementRequestTimestamp` and `ephemeralRunnerFinished` are defined,
+    // we want to use the more recent timestamp to ensure that we don't scale down a runner
+    // that is still in the process of being refreshed.
+    if (runner.ephemeralRunnerFinished !== undefined &&
+        runner.ebsVolumeReplacementRequestTimestamp < runner.ephemeralRunnerFinished) {
+        baseTime = moment.unix(runner.ephemeralRunnerFinished);
+        reason = `is an ephemeral runner that finished at ${baseTime}`;
+      } else {
+        // Add 5 minutes to the EBS volume replacement request timestamp to account
+        // for the time it takes to replace the volume and start the runner.
+        baseTime = moment.unix(runner.ebsVolumeReplacementRequestTimestamp).add(5, 'minutes');
+        reason = `had an EBS volume replacement request started at ${baseTime}`;
+      }
+  } else if (runner.ephemeralRunnerFinished !== undefined) {
     baseTime = moment.unix(runner.ephemeralRunnerFinished);
     reason = `is an ephemeral runner that finished at ${baseTime}`;
-  } else if (runner.ebsVolumeReplacementRequestTimestamp !== undefined) {
-    // Add 5 minutes to the EBS volume replacement request timestamp to account
-    // for the time it takes to replace the volume and start the runner.
-    baseTime = moment.unix(runner.ebsVolumeReplacementRequestTimestamp).add(5, 'minutes');
-    reason = `had an EBS volume replacement request started at ${baseTime}`;
   } else {
     baseTime = moment(runner.launchTime || new Date()).utc();
     reason = `was launched at ${baseTime}`;

--- a/terraform-aws-github-runner/modules/runners/variables.tf
+++ b/terraform-aws-github-runner/modules/runners/variables.tf
@@ -103,7 +103,7 @@ variable "scale_up_chron_schedule_expression" {
 variable "minimum_running_time_in_minutes" {
   description = "The time an ec2 action runner should be running at minimum before terminated if non busy."
   type        = number
-  default     = 45
+  default     = 5
 }
 
 variable "lambda_timeout_scale_down" {

--- a/terraform-aws-github-runner/variables.tf
+++ b/terraform-aws-github-runner/variables.tf
@@ -71,7 +71,7 @@ variable "scale_down_schedule_expression" {
 variable "minimum_running_time_in_minutes" {
   description = "The time an ec2 action runner should be running at minimum before terminated if non busy."
   type        = number
-  default     = 45
+  default     = 5
 }
 
 variable "runner_extra_labels" {


### PR DESCRIPTION
Brings down the minimum_running_time_in_minutes that was earlier increased in https://github.com/pytorch/test-infra/pull/6477

In order to do so, it required a few changes:
1. Remove the check to always treat minimumRunningTimeInMinutes as 5 less than it actually was.  This logic had likely been added to account for the 5 minutes it can take for a runner to be refreshed.
2. Instead, add a buffer of 5 mins to the scale down cron job for when 
3. Handle the case when both EC2 tags, ebsVolumeReplacementRequestTimestamp and ephemeralRunnerFinished, are set during scale down (which happens in a narrow window during refresh)
