### PR TITLE
fix timezone in cost dashboard 

### DIFF
--- a/torchci/components/TimeUtils.tsx
+++ b/torchci/components/TimeUtils.tsx
@@ -72,7 +72,11 @@ export const TIME_DISPLAY_FORMAT = "M/D h:mm:ss A";
 
 export function formatTimeForCharts(
   time: string,
-  format = TIME_DISPLAY_FORMAT
+  format = TIME_DISPLAY_FORMAT,
+  useUTC = false
 ) {
-  return dayjs.utc(time).format(format);
+  if (useUTC) {
+    return dayjs.utc(time).format(format);
+  }
+  return dayjs.utc(time).local().format(format);
 }

--- a/torchci/components/TimeUtils.tsx
+++ b/torchci/components/TimeUtils.tsx
@@ -74,5 +74,5 @@ export function formatTimeForCharts(
   time: string,
   format = TIME_DISPLAY_FORMAT
 ) {
-  return dayjs.utc(time).local().format(format);
+  return dayjs.utc(time).format(format);
 }

--- a/torchci/components/metrics/panels/TimeSeriesPanel.tsx
+++ b/torchci/components/metrics/panels/TimeSeriesPanel.tsx
@@ -310,6 +310,8 @@ export default function TimeSeriesPanel({
   auto_refresh = true,
   // Additional function to process the data after querying
   dataReader = undefined,
+  // Whether to keep dates in UTC or convert to local time
+  useUTC = false,
 }: {
   title: string;
   queryName: string;
@@ -331,6 +333,7 @@ export default function TimeSeriesPanel({
   auto_refresh?: boolean;
   legendPadding?: number;
   dataReader?: (_data: { [k: string]: any }[]) => { [k: string]: any }[];
+  useUTC?: boolean;
 }) {
   // - Granularity
   // - Group by

--- a/torchci/components/metrics/panels/TimeSeriesPanel.tsx
+++ b/torchci/components/metrics/panels/TimeSeriesPanel.tsx
@@ -180,6 +180,8 @@ export function TimeSeriesPanelWithData({
   // To avoid overlapping long legends and the chart
   legendPadding = 200,
   onEvents,
+  // Whether to keep dates in UTC or convert to local time
+  useUTC = false,
 }: {
   data: any;
   series: any;
@@ -191,6 +193,7 @@ export function TimeSeriesPanelWithData({
   additionalOptions?: EChartsOption;
   legendPadding?: number;
   onEvents?: { [key: string]: any };
+  useUTC?: boolean;
 }) {
   // Use the dark mode context to determine whether to use the dark theme
   const { darkMode } = useDarkMode();
@@ -247,7 +250,8 @@ export function TimeSeriesPanelWithData({
           `${params.seriesName}` +
           `<br/>${formatTimeForCharts(
             params.value[0],
-            timeFieldDisplayFormat
+            timeFieldDisplayFormat,
+            useUTC
           )}<br/>` +
           `${getTooltipMarker(params.color)}` +
           `<b>${yAxisRenderer(params.value[1])}</b>` +
@@ -436,6 +440,7 @@ export default function TimeSeriesPanel({
       timeFieldDisplayFormat={timeFieldDisplayFormat}
       additionalOptions={additionalOptions}
       legendPadding={legendPadding}
+      useUTC={useUTC}
     />
   );
 }

--- a/torchci/components/metrics/panels/TimeSeriesTable.tsx
+++ b/torchci/components/metrics/panels/TimeSeriesTable.tsx
@@ -37,6 +37,7 @@ export default function TimeSeriesTable({
   auto_refresh = true,
   dataReader = undefined,
   defaultOptions = {},
+  useUTC = false,
 }: {
   title: string;
   queryName: string;
@@ -54,6 +55,7 @@ export default function TimeSeriesTable({
   auto_refresh?: boolean;
   dataReader?: (_data: { [k: string]: any }[]) => { [k: string]: any }[];
   defaultOptions?: { [key: string]: string[] };
+  useUTC?: boolean;
 }) {
   const url = `/api/clickhouse/${queryName}?parameters=${encodeURIComponent(
     JSON.stringify({
@@ -117,7 +119,8 @@ export default function TimeSeriesTable({
       ...timestamps.map((timestamp) => {
         const formattedTime = formatTimeForCharts(
           timestamp,
-          timeFieldDisplayFormat
+          timeFieldDisplayFormat,
+          useUTC
         );
         return {
           field: timestamp,

--- a/torchci/pages/cost_analysis.tsx
+++ b/torchci/pages/cost_analysis.tsx
@@ -425,6 +425,7 @@ export default function Page() {
             auto_refresh={false}
             max_items_in_series={30}
             legendPadding={300}
+            useUTC={true}
           />
         )}
         {isLoading && <div>Loading...</div>}
@@ -855,6 +856,7 @@ export default function Page() {
               timeFieldDisplayFormat="M/D (UTC)"
               sort_by="total"
               auto_refresh={false}
+              useUTC={true}
               defaultOptions={{
                 platform: OS_OPTIONS,
                 gpu: GPU_OPTIONS,


### PR DESCRIPTION
always UTC, not local, to avoid dates being reported as the wrong date