### PR TITLE
[HUD][disabled tests] Use historical data from json to make chart and metrics

### DIFF
--- a/torchci/clickhouse_queries/disabled_test_historical/params.json
+++ b/torchci/clickhouse_queries/disabled_test_historical/params.json
@@ -1,12 +1,9 @@
 {
   "params": {
-    "granularity": "String",
     "label": "String",
     "platform": "String",
-    "repo": "String",
     "startTime": "DateTime64(3)",
     "stopTime": "DateTime64(3)",
-    "timezone": "String",
     "triaged": "String"
   },
   "tests": []

--- a/torchci/clickhouse_queries/disabled_test_total/params.json
+++ b/torchci/clickhouse_queries/disabled_test_total/params.json
@@ -1,6 +1,0 @@
-{
-  "params": {
-    "state": "String"
-  },
-  "tests": []
-}

--- a/torchci/clickhouse_queries/disabled_test_total/query.sql
+++ b/torchci/clickhouse_queries/disabled_test_total/query.sql
@@ -1,6 +1,0 @@
-SELECT COUNT(issues.title) AS number_of_open_disabled_tests
-FROM
-    default.issues FINAL
-WHERE
-    issues.title LIKE '%DISABLED%'
-    AND issues.state = {state: String}

--- a/torchci/components/metrics/panels/TimeSeriesPanel.tsx
+++ b/torchci/components/metrics/panels/TimeSeriesPanel.tsx
@@ -316,6 +316,8 @@ export default function TimeSeriesPanel({
   dataReader = undefined,
   // Whether to keep dates in UTC or convert to local time
   useUTC = false,
+  // Whether to fill in missing data points with 0s
+  fillMissingData = true,
 }: {
   title: string;
   queryName: string;
@@ -338,6 +340,7 @@ export default function TimeSeriesPanel({
   legendPadding?: number;
   dataReader?: (_data: { [k: string]: any }[]) => { [k: string]: any }[];
   useUTC?: boolean;
+  fillMissingData?: boolean;
 }) {
   // - Granularity
   // - Group by
@@ -374,7 +377,7 @@ export default function TimeSeriesPanel({
     groupByFieldName,
     timeFieldName,
     yAxisFieldName,
-    true,
+    fillMissingData,
     smooth,
     sort_by,
     chartType,

--- a/torchci/pages/disabled.tsx
+++ b/torchci/pages/disabled.tsx
@@ -1,7 +1,6 @@
 import { Grid2, Stack, Typography } from "@mui/material";
 import { GridCellParams, GridRenderCellParams } from "@mui/x-data-grid";
 import CopyLink from "components/CopyLink";
-import GranularityPicker from "components/GranularityPicker";
 import styles from "components/metrics.module.css";
 import { TablePanelWithData } from "components/metrics/panels/TablePanel";
 import TimeSeriesPanel, {
@@ -61,7 +60,7 @@ function getLabels(data: any) {
 function generateDisabledTestsTable(data: any) {
   const disabledTests: any = [];
   data.forEach((r: any) => {
-    const title = r.title.substring("DISABLED ".length);
+    const title = r.name;
     const titleMatch = title.match(DISABLED_TEST_TITLE_REGEX);
     const testCase = titleMatch ? titleMatch.groups.testCase : title;
     const testClass = titleMatch ? titleMatch.groups.testClass : "";
@@ -94,9 +93,10 @@ function GraphPanel({ queryParams }: { queryParams: { [key: string]: any } }) {
         queryName={"disabled_test_historical"}
         queryParams={queryParams}
         granularity={"day"}
-        timeFieldName={"granularity_bucket"}
-        yAxisFieldName={"number_of_open_disabled_tests"}
+        timeFieldName={"day"}
+        yAxisFieldName={"count"}
         yAxisRenderer={(duration) => duration}
+        fillMissingData={false}
       />
     </Grid2>
   );
@@ -219,7 +219,10 @@ function DisabledTestsPanel({
               },
             },
           ]}
-          dataGridProps={{ getRowId: (el: any) => el.metadata.number }}
+          dataGridProps={{
+            getRowId: (el: any) =>
+              `${el.metadata.number}-${el.testCase}-${el.testClass}`,
+          }}
           showFooter={true}
           pageSize={100}
         />
@@ -367,11 +370,6 @@ export default function Page() {
           setStopTime={setStopTime}
           timeRange={timeRange}
           setTimeRange={setTimeRange}
-          setGranularity={setGranularity}
-        />
-        <GranularityPicker
-          granularity={granularity}
-          setGranularity={setGranularity}
         />
         <ValuePicker
           value={platform}

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -187,9 +187,10 @@ export default function Kpis() {
           queryName={"disabled_test_historical"}
           queryParams={{ ...timeParams, repo: "pytorch/pytorch" }}
           granularity={"day"}
-          timeFieldName={"granularity_bucket"}
-          yAxisFieldName={"number_of_open_disabled_tests"}
+          timeFieldName={"day"}
+          yAxisFieldName={"count"}
           yAxisRenderer={(duration) => duration}
+          fillMissingData={false}
         />
       </Grid2>
     </Grid2>

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -25,7 +25,10 @@ import ReactECharts from "echarts-for-react";
 import { useDarkMode } from "lib/DarkModeContext";
 import { fetcher } from "lib/GeneralUtils";
 import { useEffect, useState } from "react";
-import useSWR from "swr";
+import { default as useSWR, default as useSWRImmutable } from "swr";
+
+const DISABLED_TESTS_CONDENSED_URL =
+  "https://raw.githubusercontent.com/pytorch/test-infra/refs/heads/generated-stats/stats/disabled-tests-condensed.json";
 
 function MasterCommitRedPanel({
   params,
@@ -490,6 +493,10 @@ export default function Page() {
     "docs push / build-docs-functorch-true",
   ];
 
+  const disabledTestsTotal = Object.keys(
+    useSWRImmutable(DISABLED_TESTS_CONDENSED_URL, fetcher).data || {}
+  ).length;
+
   return (
     <div>
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
@@ -642,12 +649,10 @@ export default function Page() {
               }}
               badThreshold={(value) => value > 60 * 60 * 6} // 6 hours
             />
-            <ScalarPanel
+            <ScalarPanelWithValue
               title={"# disabled tests"}
-              queryName={"disabled_test_total"}
-              metricName={"number_of_open_disabled_tests"}
+              value={disabledTestsTotal}
               valueRenderer={(value) => value}
-              queryParams={{ state: "open" }}
               badThreshold={(_) => false} // we haven't decided on the threshold here yet
             />
           </Stack>
@@ -919,8 +924,8 @@ export default function Page() {
             queryName={"disabled_test_historical"}
             queryParams={{ ...timeParams, repo: "pytorch/pytorch" }}
             granularity={"day"}
-            timeFieldName={"granularity_bucket"}
-            yAxisFieldName={"number_of_new_disabled_tests"}
+            timeFieldName={"day"}
+            yAxisFieldName={"new"}
             yAxisRenderer={(value) => value}
             additionalOptions={{ yAxis: { scale: true } }}
           />


### PR DESCRIPTION
Instead of getting info about disabled tests from issues, get it from the table that holds the historical data, populated in https://github.com/pytorch/test-infra/pull/6687, that is created based on the json, or from the json itself

This makes it so we don't need to parse the body for the platforms, and also makes it so that aggregate issues can be handled without more parsing logic

Pros:
* More closely aligned with what's disabled in CI
* Take advantage of the bot having already parsed the issues to get all the info so we don't have to reimplement the logic

Cons
* Not reflective of how many issues are open

Requires the above linked PR to be merged