### PR TITLE
[ez][HUD] Disabled tests page: Changes to query params and other small things

### DIFF
--- a/torchci/clickhouse_queries/disabled_test_labels/params.json
+++ b/torchci/clickhouse_queries/disabled_test_labels/params.json
@@ -1,7 +1,6 @@
 {
   "params": {
-    "repo": "String",
-    "states": "Array(String)"
+    "repo": "String"
   },
   "tests": []
 }

--- a/torchci/clickhouse_queries/disabled_test_labels/query.sql
+++ b/torchci/clickhouse_queries/disabled_test_labels/query.sql
@@ -5,11 +5,7 @@ SELECT
 FROM
     default .issues i FINAL
 WHERE
-    (
-        has({states: Array(String) }, i.state)
-        OR empty({states: Array(String) })
-    )
-    AND i.repository_url = CONCAT('https://api.github.com/repos/', {repo: String })
+    i.repository_url = CONCAT('https://api.github.com/repos/', {repo: String })
     AND i.title LIKE '%DISABLED%'
     AND NOT empty(label)
 ORDER BY

--- a/torchci/lib/GeneralUtils.ts
+++ b/torchci/lib/GeneralUtils.ts
@@ -96,6 +96,7 @@ export async function hasWritePermissionsUsingOctokit(
   return permissions === "admin" || permissions === "write";
 }
 
+type ConfigType = Parameters<typeof useSWR<any[]>>[2];
 /**
  * This hook function is a convenience wrapper for useSWR that fetches data from
  * the ClickHouse API.  Handles things like encoding the query name and
@@ -112,7 +113,8 @@ export async function hasWritePermissionsUsingOctokit(
 export function useClickHouseAPI<T = any>(
   queryName: string,
   parameters: { [key: string]: string },
-  condition: boolean = true
+  condition: boolean = true,
+  config?: ConfigType
 ) {
   // Helper function to format the URL nicely
   return useSWR<T[]>(
@@ -120,7 +122,8 @@ export function useClickHouseAPI<T = any>(
       `/api/clickhouse/${encodeURIComponent(queryName)}?${encodeParams({
         parameters: JSON.stringify(parameters),
       })}`,
-    fetcher
+    fetcher,
+    config
   );
 }
 

--- a/torchci/lib/GeneralUtils.ts
+++ b/torchci/lib/GeneralUtils.ts
@@ -1,5 +1,5 @@
 import { Octokit } from "octokit";
-import useSWR from "swr";
+import useSWR, { SWRConfiguration } from "swr";
 import useSWRImmutable from "swr/immutable";
 import { isFailure } from "./JobClassifierUtil";
 import { CommitData, JobData } from "./types";
@@ -96,7 +96,6 @@ export async function hasWritePermissionsUsingOctokit(
   return permissions === "admin" || permissions === "write";
 }
 
-type ConfigType = Parameters<typeof useSWR<any[]>>[2];
 /**
  * This hook function is a convenience wrapper for useSWR that fetches data from
  * the ClickHouse API.  Handles things like encoding the query name and
@@ -114,7 +113,7 @@ export function useClickHouseAPI<T = any>(
   queryName: string,
   parameters: { [key: string]: string },
   condition: boolean = true,
-  config?: ConfigType
+  config?: SWRConfiguration<T[]>
 ) {
   // Helper function to format the URL nicely
   return useSWR<T[]>(

--- a/torchci/pages/disabled.tsx
+++ b/torchci/pages/disabled.tsx
@@ -15,7 +15,6 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { TimeRangePicker } from "./metrics";
 
-const MIN_ENTRIES = 10;
 const GRAPH_ROW_HEIGHT = 240;
 const DEFAULT_ISSUE_STATE = "open";
 const ISSUE_STATES = [DEFAULT_ISSUE_STATE, "closed"];
@@ -227,8 +226,6 @@ function DisabledTestsPanel({
       </Grid2>
     </Grid2>
   );
-
-  return <></>;
 }
 
 export default function Page() {

--- a/torchci/pages/disabled.tsx
+++ b/torchci/pages/disabled.tsx
@@ -396,7 +396,7 @@ export default function Page() {
           label={"Triaged?"}
         />
       </Stack>
-      <GraphPanel queryParams={{...queryParams, state: "not used"}} />
+      <GraphPanel queryParams={{ ...queryParams, state: "not used" }} />
       <Stack direction="row" spacing={2}>
         <ValuePicker
           value={state}

--- a/torchci/pages/disabled.tsx
+++ b/torchci/pages/disabled.tsx
@@ -9,11 +9,10 @@ import TimeSeriesPanel, {
 } from "components/metrics/panels/TimeSeriesPanel";
 import ValuePicker from "components/ValuePicker";
 import dayjs from "dayjs";
-import { fetcher } from "lib/GeneralUtils";
+import { encodeParams, useClickHouseAPI } from "lib/GeneralUtils";
 import _ from "lodash";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
-import useSWR from "swr";
 import { TimeRangePicker } from "./metrics";
 
 const MIN_ENTRIES = 10;
@@ -110,13 +109,15 @@ function DisabledTestsPanel({
   queryParams: { [key: string]: any };
 }) {
   const queryName = "disabled_tests";
-  const url = `/api/clickhouse/${queryName}?parameters=${encodeURIComponent(
-    JSON.stringify(queryParams)
-  )}`;
 
-  let { data, error } = useSWR(url, fetcher, {
-    refreshInterval: 60 * 60 * 1000, // refresh every hour
-  });
+  let { data, error, isLoading } = useClickHouseAPI(
+    queryName,
+    queryParams,
+    true,
+    {
+      refreshInterval: 60 * 60 * 1000, // refresh every hour
+    }
+  );
 
   if (error) {
     return (
@@ -128,7 +129,7 @@ function DisabledTestsPanel({
     );
   }
 
-  if (data === undefined || data.length === 0) {
+  if (isLoading) {
     return (
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
         <Typography fontSize={"1rem"} fontStyle={"italic"}>
@@ -310,13 +311,15 @@ export default function Page() {
   };
 
   const queryName = "disabled_test_labels";
-  const url = `/api/clickhouse/${queryName}?parameters=${encodeURIComponent(
-    JSON.stringify({ ...queryParams, states: [] })
-  )}`;
 
-  let { data, error } = useSWR(url, fetcher, {
-    refreshInterval: 60 * 60 * 1000, // refresh every hour
-  });
+  let { data, error, isLoading } = useClickHouseAPI(
+    queryName,
+    { repo: queryParams.repo },
+    true,
+    {
+      refreshInterval: 60 * 60 * 1000, // refresh every hour
+    }
+  );
 
   if (error) {
     return (
@@ -328,7 +331,7 @@ export default function Page() {
     );
   }
 
-  if (data === undefined || data.length === 0) {
+  if (isLoading) {
     return (
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
         <Typography fontSize={"1rem"} fontStyle={"italic"}>
@@ -342,19 +345,21 @@ export default function Page() {
   const acceptLabels = getLabels(data);
 
   return (
-    <div>
+    <Stack spacing={2}>
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
         <Typography fontSize={"2rem"} fontWeight={"bold"}>
           PyTorch Disabled Tests DashBoard
         </Typography>
         <CopyLink
-          textToCopy={`${baseUrl}?startTime=${encodeURIComponent(
-            startTime.toString()
-          )}&stopTime=${encodeURIComponent(
-            stopTime.toString()
-          )}&granularity=${granularity}&state=${state}&platform=${platform}&label=${encodeURIComponent(
-            label
-          )}&triaged=${triaged}`}
+          textToCopy={`${baseUrl}?${encodeParams({
+            startTime: startTime.toString(),
+            stopTime: stopTime.toString(),
+            granularity: granularity,
+            state: state,
+            platform: platform,
+            label: label,
+            triaged: triaged,
+          })}`}
         />
       </Stack>
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
@@ -371,12 +376,7 @@ export default function Page() {
           granularity={granularity}
           setGranularity={setGranularity}
         />
-        <ValuePicker
-          value={state}
-          setValue={setState}
-          values={ISSUE_STATES}
-          label={"State"}
-        />
+
         <ValuePicker
           value={platform}
           setValue={setPlatform}
@@ -397,7 +397,15 @@ export default function Page() {
         />
       </Stack>
       <GraphPanel queryParams={queryParams} />
+      <Stack direction="row" spacing={2}>
+        <ValuePicker
+          value={state}
+          setValue={setState}
+          values={ISSUE_STATES}
+          label={"State"}
+        />
+      </Stack>
       <DisabledTestsPanel queryParams={queryParams} />
-    </div>
+    </Stack>
   );
 }

--- a/torchci/pages/disabled.tsx
+++ b/torchci/pages/disabled.tsx
@@ -396,7 +396,7 @@ export default function Page() {
           label={"Triaged?"}
         />
       </Stack>
-      <GraphPanel queryParams={queryParams} />
+      <GraphPanel queryParams={{...queryParams, state: "not used"}} />
       <Stack direction="row" spacing={2}>
         <ValuePicker
           value={state}

--- a/torchci/pages/disabled.tsx
+++ b/torchci/pages/disabled.tsx
@@ -373,7 +373,6 @@ export default function Page() {
           granularity={granularity}
           setGranularity={setGranularity}
         />
-
         <ValuePicker
           value={platform}
           setValue={setPlatform}


### PR DESCRIPTION
A lot of small changes
* disabled_test_labels query is only called here and it always sets states: [], so I got rid of the param
* Added config as input for useClickHouseAPI
* Use useClickHouseAPI in disabled page - not sure if this is actually better or worse
* Use encodeParams to get the permalink
* Set query params for disabled_test_labels to be more restrictive.  Previously if you change the label selector or the date selector, the selectors would reload because disabled_test_labels thought it had to requery, but now it doesn't
  * Same for the chart and the state, since state doesn't matter to the chart
* Move the state selector from above the chart to be above the table of tests since state doesn't matter to the chart (makes it more clear what things affect what to users)
* Use isLoading to differentiate between no data yet and returned no data
* Use more stacks for spacing
* Remove some dead code

Very few visual changes, but for context, the page is https://hud.pytorch.org/disabled and they look like:
New:
<img width="1710" alt="image" src="https://github.com/user-attachments/assets/23b220da-b703-4662-93ed-46f256575d08" />

Old:
<img width="1717" alt="image" src="https://github.com/user-attachments/assets/a9824fbe-1b8b-433a-8228-44088d2cc08a" />
