### PR TITLE
[HUD] Crude way to show if log classifier error matches aggregate disable issue

### DIFF
--- a/torchci/components/JobLinks.tsx
+++ b/torchci/components/JobLinks.tsx
@@ -201,10 +201,16 @@ function DisableTest({ job, label }: { job: JobData; label: string }) {
 
   // At this point, we should show something. Search the existing disable issues
   // for a matching one.
+  const formattedTestName = `${testName.testName} (__main__.${testName.suite})`;
   const issueTitle = `DISABLED ${testName.testName} (__main__.${testName.suite})`;
   const issueBody = formatDisableTestBody(job);
 
-  const matchingIssues = issues.filter((issue) => issue.title === issueTitle);
+  const matchingIssues = issues.filter(
+    (issue) =>
+      issue.title === issueTitle ||
+      // Crude way to match with aggregate issues
+      issue.body.includes(formattedTestName)
+  );
   const repo = job.repo ?? "pytorch/pytorch";
 
   return (


### PR DESCRIPTION
It's pretty crude

Things I'm not sure how to handle:
* If a test was recently reenabled, we like to link the issue since issue closing + change landing can be out of sync and knowing there was a disable issue can be useful context.  But I would also prefer to not reopen aggregate issues and I'm not sure how to discourage that
* If there are multiple disable issues for a test

Alt solutions:
* Parse body to see if it matches better - pros: more accurate, cons: parsing
* Query for disabled-tests-condensed json - pros: more accurate, cons: lagging since the json only gets updated every 15 minutes, and you'd probably have to query CH for the history (https://github.com/pytorch/test-infra/pull/6687) to know if something was previously disabled