### PR TITLE
[Add Tags] add tags for ec2 instances

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
@@ -89,6 +89,9 @@ function createExpectedRunInstancesLinux(
   const tags = [
     { Key: 'Application', Value: 'github-action-runner' },
     { Key: 'RunnerType', Value: runnerParameters.runnerType.runnerTypeName },
+    { Key: 'RunnerTypeLabels', Value: runnerParameters.runnerType.labels?  runnerParameters.runnerType.labels.join(','):'' },
+    { Key: 'RepositoryOwner', Value: runnerParameters.repositoryOwner },
+    { Key: 'RepositoryName', Value: runnerParameters.repositoryName },
   ];
   if (enableOrg) {
     tags.push({
@@ -500,6 +503,8 @@ describe('tryReuseRunner', () => {
         runnerTypeName: 'linuxCpu',
         is_ephemeral: true,
       },
+      repositoryOwner: 'jeanschmidt',
+      repositoryName: 'regularizationTheory'
     };
 
     it('does not have any runner', async () => {
@@ -831,6 +836,8 @@ describe('tryReuseRunner', () => {
         runnerTypeName: 'linuxCpu',
         is_ephemeral: true,
       },
+      repositoryOwner: 'jeanschmidt',
+      repositoryName: 'test-repo'
     };
 
     it('does not have any runner', async () => {
@@ -1125,7 +1132,7 @@ describe('createRunner', () => {
     });
 
     it('calls run instances with the correct config for repo && linux', async () => {
-      const runnerParameters = {
+      const runnerParameters: RunnerInputParameters = {
         runnerConfig: runnerConfigFn,
         environment: 'wg113',
         repoName: 'SomeAwesomeCoder/some-amazing-library',
@@ -1138,6 +1145,8 @@ describe('createRunner', () => {
           runnerTypeName: 'linuxCpu',
           is_ephemeral: true,
         },
+        repositoryOwner: 'SomeAwesomeCoder',
+        repositoryName: 'some-amazing-library'
       };
 
       await createRunner(runnerParameters, metrics);
@@ -1149,7 +1158,7 @@ describe('createRunner', () => {
     });
 
     it('calls run instances with the correct config for repo && linux && organization', async () => {
-      const runnerParameters = {
+      const runnerParameters: RunnerInputParameters= {
         runnerConfig: runnerConfigFn,
         environment: 'wg113',
         repoName: undefined,
@@ -1162,6 +1171,8 @@ describe('createRunner', () => {
           runnerTypeName: 'linuxCpu.nvidia.gpu',
           is_ephemeral: true,
         },
+        repositoryOwner: 'SomeAwesomeCoder',
+        repositoryName: 'test-repo'
       };
 
       await createRunner(runnerParameters, metrics);
@@ -1173,7 +1184,7 @@ describe('createRunner', () => {
     });
 
     it('calls run instances with the correct config for repo && windows', async () => {
-      const runnerParameters = {
+      const runnerParameters: RunnerInputParameters= {
         runnerConfig: runnerConfigFn,
         environment: 'wg113',
         repoName: 'SomeAwesomeCoder/some-amazing-library',
@@ -1186,6 +1197,8 @@ describe('createRunner', () => {
           runnerTypeName: 'linuxCpu',
           is_ephemeral: true,
         },
+        repositoryOwner: 'SomeAwesomeCoder',
+        repositoryName: 'some-amazing-library'
       };
 
       await createRunner(runnerParameters, metrics);
@@ -1228,6 +1241,9 @@ describe('createRunner', () => {
             Tags: [
               { Key: 'Application', Value: 'github-action-runner' },
               { Key: 'RunnerType', Value: runnerParameters.runnerType.runnerTypeName },
+              { Key: "RunnerTypeLabels", Value: ''},
+              { Key: 'RepositoryOwner', Value: runnerParameters.repositoryOwner },
+              { Key: 'RepositoryName', Value: runnerParameters.repositoryName },
               {
                 Key: 'Repo',
                 Value: runnerParameters.repoName,
@@ -1245,6 +1261,8 @@ describe('createRunner', () => {
           environment: 'wg113',
           repoName: 'SomeAwesomeCoder/some-amazing-library',
           orgName: undefined,
+          repositoryName: 'some-amazing-library',
+          repositoryOwner: 'SomeAwesomeCoder',
           runnerType: {
             instance_type: 'c5.2xlarge',
             os: 'linux',
@@ -1267,7 +1285,7 @@ describe('createRunner', () => {
     });
 
     it('creates ssm experiment parameters when joining experiment', async () => {
-      const runnerParameters = {
+      const runnerParameters: RunnerInputParameters = {
         runnerConfig: runnerConfigFn,
         environment: 'wg113',
         repoName: 'SomeAwesomeCoder/some-amazing-library',
@@ -1284,6 +1302,8 @@ describe('createRunner', () => {
             percentage: 0.1,
           },
         },
+        repositoryOwner: 'SomeAwesomeCoder',
+        repositoryName: 'some-amazing-library'
       };
       jest.spyOn(global.Math, 'random').mockReturnValueOnce(0.0999);
 
@@ -1323,6 +1343,8 @@ describe('createRunner', () => {
           {
             runnerConfig: runnerConfigFn,
             environment: 'wg113',
+            repositoryName: 'some-amazing-library',
+            repositoryOwner: 'SomeAwesomeCoder',
             repoName: 'SomeAwesomeCoder/some-amazing-library',
             orgName: undefined,
             runnerType: {
@@ -1344,7 +1366,7 @@ describe('createRunner', () => {
     it('fails to attach to any network and raises exception', async () => {
       const errorMsg = 'test error msg ASDF';
       mockRunInstances.promise.mockClear().mockRejectedValue(new Error(errorMsg));
-      const runnerParameters = {
+      const runnerParameters: RunnerInputParameters = {
         runnerConfig: runnerConfigFn,
         environment: 'wg113',
         repoName: 'SomeAwesomeCoder/some-amazing-library',
@@ -1357,6 +1379,8 @@ describe('createRunner', () => {
           runnerTypeName: 'linuxCpu',
           is_ephemeral: true,
         },
+        repositoryOwner: 'SomeAwesomeCoder',
+        repositoryName: 'some-amazing-library'
       };
 
       await expect(createRunner(runnerParameters, metrics)).rejects.toThrow();
@@ -1495,7 +1519,7 @@ describe('createRunner', () => {
     });
 
     it('succeed in the first try, first subnet and region', async () => {
-      const runnerParameters = {
+      const runnerParameters: RunnerInputParameters = {
         runnerConfig: runnerConfigFn,
         environment: 'wg113',
         repoName: 'SomeAwesomeCoder/some-amazing-library',
@@ -1508,6 +1532,8 @@ describe('createRunner', () => {
           runnerTypeName: 'linuxCpu',
           is_ephemeral: true,
         },
+        repositoryOwner: 'SomeAwesomeCoder',
+        repositoryName: 'some-amazing-library'
       };
 
       expect(await createRunner(runnerParameters, metrics)).toEqual(config.shuffledAwsRegionInstances[0]);
@@ -1522,7 +1548,7 @@ describe('createRunner', () => {
       mockRunInstances.promise.mockClear().mockRejectedValueOnce(new Error('test error msg'));
       mockRunInstances.promise.mockClear().mockResolvedValueOnce(runInstanceSuccess);
 
-      const runnerParameters = {
+      const runnerParameters: RunnerInputParameters= {
         runnerConfig: runnerConfigFn,
         environment: 'wg113',
         repoName: 'SomeAwesomeCoder/some-amazing-library',
@@ -1535,6 +1561,8 @@ describe('createRunner', () => {
           runnerTypeName: 'linuxCpu',
           is_ephemeral: true,
         },
+        repositoryOwner: 'SomeAwesomeCoder',
+        repositoryName: 'some-amazing-library'
       };
 
       expect(await createRunner(runnerParameters, metrics)).toEqual(config.shuffledAwsRegionInstances[0]);
@@ -1556,7 +1584,7 @@ describe('createRunner', () => {
       }
       mockRunInstances.promise.mockClear().mockResolvedValueOnce(runInstanceSuccess);
 
-      const runnerParameters = {
+      const runnerParameters: RunnerInputParameters = {
         runnerConfig: runnerConfigFn,
         environment: 'wg113',
         repoName: 'SomeAwesomeCoder/some-amazing-library',
@@ -1569,6 +1597,8 @@ describe('createRunner', () => {
           runnerTypeName: 'linuxCpu',
           is_ephemeral: true,
         },
+        repositoryOwner: 'SomeAwesomeCoder',
+        repositoryName: 'some-amazing-library'
       };
 
       expect(await createRunner(runnerParameters, metrics)).toEqual(config.shuffledAwsRegionInstances[1]);
@@ -1603,7 +1633,7 @@ describe('createRunner', () => {
         mockRunInstances.promise.mockClear().mockRejectedValueOnce(new Error('test error msg'));
       }
 
-      const runnerParameters = {
+      const runnerParameters: RunnerInputParameters = {
         runnerConfig: runnerConfigFn,
         environment: 'wg113',
         repoName: 'SomeAwesomeCoder/some-amazing-library',
@@ -1616,6 +1646,8 @@ describe('createRunner', () => {
           runnerTypeName: 'linuxCpu',
           is_ephemeral: true,
         },
+        repositoryOwner: 'SomeAwesomeCoder',
+        repositoryName: 'some-amazing-library',
       };
 
       await expect(createRunner(runnerParameters, metrics)).rejects.toThrow();

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -25,6 +25,8 @@ export interface RunnerInputParameters {
   repoName?: string;
   orgName?: string;
   runnerType: RunnerType;
+  repositoryOwner: string;
+  repositoryName: string;
 }
 
 export interface AmiExpermient {
@@ -691,7 +693,11 @@ export async function createRunner(runnerParameters: RunnerInputParameters, metr
     const tags = [
       { Key: 'Application', Value: 'github-action-runner' },
       { Key: 'RunnerType', Value: runnerParameters.runnerType.runnerTypeName },
+      { Key: 'RunnerTypeLabels', Value: runnerParameters.runnerType.labels?.join(',') ?? '' },
+      { Key: 'RepositoryOwner', Value: runnerParameters.repositoryOwner },
+      { Key: 'RepositoryName', Value: runnerParameters.repositoryName },
     ];
+
     /* istanbul ignore next */
     if (Config.Instance.datetimeDeploy) {
       tags.push({ Key: 'ApplicationDeployDatetime', Value: Config.Instance.datetimeDeploy });
@@ -708,6 +714,10 @@ export async function createRunner(runnerParameters: RunnerInputParameters, metr
         Value: runnerParameters.orgName,
       });
     }
+
+
+
+
     let customAmi = runnerParameters.runnerType.ami;
     let customAmiExperiment = false;
     if (runnerParameters.runnerType.ami_experiment) {

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
@@ -321,6 +321,8 @@ describe('scaleUp', () => {
         runnerConfig: expect.any(Function),
         orgName: repo.owner,
         runnerType: runnerType1,
+        repositoryName: repo.repo,
+        repositoryOwner: repo.owner,
       },
       metrics,
     );
@@ -406,6 +408,8 @@ describe('scaleUp', () => {
         runnerConfig: expect.any(Function),
         repoName: 'owner/repo',
         runnerType: runnerType1,
+        repositoryName: repo.repo,
+        repositoryOwner: repo.owner,
       },
       metrics,
     );
@@ -491,6 +495,8 @@ describe('scaleUp', () => {
         runnerConfig: expect.any(Function),
         repoName: 'owner/repo',
         runnerType: runnerType1,
+        repositoryName: repo.repo,
+        repositoryOwner: repo.owner,
       },
       metrics,
     );
@@ -575,6 +581,8 @@ describe('scaleUp', () => {
         runnerConfig: expect.any(Function),
         repoName: 'owner/repo',
         runnerType: runnerType1,
+        repositoryName: repo.repo,
+        repositoryOwner: repo.owner,
       },
       metrics,
     );
@@ -660,6 +668,8 @@ describe('scaleUp', () => {
         runnerConfig: expect.any(Function),
         repoName: 'owner/repo',
         runnerType: runnerType1,
+        repositoryName: repo.repo,
+        repositoryOwner: repo.owner,
       },
       metrics,
     );
@@ -745,6 +755,8 @@ describe('scaleUp', () => {
         runnerConfig: expect.any(Function),
         repoName: 'owner/repo',
         runnerType: runnerType1,
+        repositoryName: repo.repo,
+        repositoryOwner: repo.owner,
       },
       metrics,
     );
@@ -830,6 +842,8 @@ describe('scaleUp', () => {
         runnerConfig: expect.any(Function),
         repoName: 'owner/repo',
         runnerType: runnerType1,
+        repositoryName: repo.repo,
+        repositoryOwner: repo.owner,
       },
       metrics,
     );
@@ -945,10 +959,12 @@ describe('scaleUp', () => {
     expect(mockedCreateRunner).toBeCalledWith(
       {
         environment: config.environment,
-        // eslint-disable-next-line max-len
-        runnerConfig: expect.any(Function),
         repoName: 'owner/repo',
         runnerType: runnerType1,
+        repositoryName: 'repo',
+        repositoryOwner: 'owner',
+         // eslint-disable-next-line max-len
+         runnerConfig: expect.any(Function),
       },
       metrics,
     );

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -110,10 +110,12 @@ export async function scaleUp(
               payload.installationId,
               metrics,
               awsRegion,
-              experimentalRunner,
+              experimentalRunner
             );
           },
           runnerType: runnerType,
+          repositoryOwner: repo.owner,
+          repositoryName: repo.repo,
         };
         if (Config.Instance.enableOrganizationRunners) {
           createRunnerParams.orgName = repo.owner;


### PR DESCRIPTION
It's not very straightforward  to fetch necessary infos when try to refresh a instance.
The best way is store those info in Ec2 Instance tags

This is preparation for set up refresh-runner lambda
See doc design:https://docs.google.com/document/d/1iI6UAtm4J4JZsNnG3356tpyyvqxVvW9JLs-PdV6tv8E/edit?tab=t.0