### PR TITLE
[ez][HUD] host -> url for clickhouse client

### DIFF
--- a/torchci/lib/clickhouse.ts
+++ b/torchci/lib/clickhouse.ts
@@ -12,7 +12,7 @@ import * as thisModule from "./clickhouse";
 
 export function getClickhouseClient() {
   return createClient({
-    host: process.env.CLICKHOUSE_HUD_USER_URL ?? "http://localhost:8123",
+    url: process.env.CLICKHOUSE_HUD_USER_URL ?? "http://localhost:8123",
     username: process.env.CLICKHOUSE_HUD_USER_USERNAME ?? "default",
     password: process.env.CLICKHOUSE_HUD_USER_PASSWORD ?? "",
   });


### PR DESCRIPTION
Kept getting
```
[2025-06-03T23:06:31.978Z][WARN][@clickhouse/client][Config] "host" is deprecated. Use "url" instead.
```

when developing locally

typescript says
```
(property) BaseClickHouseClientConfigOptions.host?: string | undefined
@deprecated
since version 1.0.0. Use [url](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) instead. A ClickHouse instance URL.

@default
```

Local seems normal?  Preview looks ok