### PR TITLE
[CH][BE][ez] Make queries on TTS page faster by removing join

### DIFF
--- a/torchci/clickhouse_queries/tts_duration_historical/query.sql
+++ b/torchci/clickhouse_queries/tts_duration_historical/query.sql
@@ -2,22 +2,19 @@
 SELECT
     DATE_TRUNC({granularity: String }, job.created_at) AS granularity_bucket,
     AVG(
-        DATE_DIFF('second', workflow.created_at, job.completed_at)
+        DATE_DIFF('second', job.workflow_created_at, job.completed_at)
     ) AS tts_avg_sec,
     AVG(
         DATE_DIFF('second', job.started_at, job.completed_at)
     ) AS duration_avg_sec,
-    CONCAT(workflow.name, ' / ', job.name) AS full_name
+    CONCAT(job.workflow_name, ' / ', job.name) AS full_name
 FROM
-    default .workflow_job job FINAL
-    JOIN default .workflow_run workflow FINAL on workflow.id = job.run_id
+    default .workflow_job job
 WHERE
     job.created_at >= {startTime: DateTime64(3) }
     AND job.created_at < {stopTime: DateTime64(3) }
-    AND not has({ignoredWorkflows: Array(String) }, workflow.name)
-    AND workflow.head_branch LIKE {branch: String }
-    AND workflow.run_attempt = 1
-    AND workflow.repository. 'full_name' = {repo: String }
+    AND not has({ignoredWorkflows: Array(String) }, job.workflow_name)
+    AND job.repository_full_name = {repo: String }
     AND job.name NOT LIKE '%before-test%'
     AND job.name NOT LIKE '%determinator%'
     AND job.name NOT LIKE '%mem_leak_check%'

--- a/torchci/clickhouse_queries/tts_duration_historical_percentile/query.sql
+++ b/torchci/clickhouse_queries/tts_duration_historical_percentile/query.sql
@@ -2,19 +2,17 @@
 WITH tts_duration AS (
     SELECT
         DATE_TRUNC({granularity: String }, job.created_at) AS granularity_bucket,
-        DATE_DIFF('second', workflow.created_at, job.completed_at) AS tts_sec,
+        DATE_DIFF('second', job.workflow_created_at, job.completed_at) AS tts_sec,
         DATE_DIFF('second', job.started_at, job.completed_at) AS duration_sec,
-        CONCAT(workflow.name, ' / ', job.name) AS full_name
+        CONCAT(job.workflow_name, ' / ', job.name) AS full_name
     FROM
-        default .workflow_job job FINAL
-        JOIN default .workflow_run workflow FINAL ON workflow.id = job.run_id
+        default .workflow_job job
     WHERE
         job.created_at >= {startTime: DateTime64(3) }
         AND job.created_at < {stopTime: DateTime64(3) }
-        AND not has({ignoredWorkflows: Array(String) }, workflow.name)
-        AND workflow.head_branch LIKE {branch: String }
-        AND workflow.run_attempt = 1
-        AND workflow.repository. 'full_name' = {repo: String }
+        AND not has({ignoredWorkflows: Array(String) }, job.workflow_name)
+        AND job.head_branch LIKE {branch: String }
+        AND job.repository_full_name = {repo: String }
         AND job.name NOT LIKE '%before-test%'
         AND job.name NOT LIKE '%determinator%'
         AND job.name NOT LIKE '%mem_leak_check%'


### PR DESCRIPTION
All the fields for workflow_run can be found in the workflow_job table except run attempt, but I don't really understand why we filter out run attempt so I just got rid of it

Also remove final because I don't think it matters that much when we filter for only stuff that have a completed_at date

I think TTS page was just broken before this due to OOM