### PR TITLE
[ez][disabled tests] Fix historical records json not being uploaded to s3 in upload disable tests workflow

### DIFF
--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -98,6 +98,7 @@ jobs:
             disabled-tests-condensed.json
             disabled-jobs.json
             unstable-jobs.json
+            for_historical_records.json
 
   # NB: Use our self-hosted runner to upload the files to S3, the runners already
   # have access to the bucket


### PR DESCRIPTION
Missed a step in https://github.com/pytorch/test-infra/issues/6687 for uploading the json as an artifact so the next job could pick it up

Example failure https://github.com/pytorch/test-infra/actions/runs/15471922333/job/43558541041