### PR TITLE
tools: Update clear_offline_runners to clear ec2

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -57,6 +57,8 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
+    "boto3==1.38.29",
+    "botocore==1.38.29",
     'numpy==1.26.4 ; python_version >= "3.9" and python_version <= "3.11"',
     'numpy==2.1.0 ; python_version >= "3.12"',
     'expecttest==0.3.0',

--- a/tools/self-hosted-runner-utils/clear_offline_runners.py
+++ b/tools/self-hosted-runner-utils/clear_offline_runners.py
@@ -1,9 +1,11 @@
 import argparse
 import os
-import re
+import random
+import time
 from typing import List, Set
 
 import boto3  # type: ignore[import-untyped]
+from botocore.exceptions import ClientError  # type: ignore[import-untyped]
 from github import (  # type: ignore[import-not-found]
     Github,
     PaginatedList,
@@ -96,11 +98,6 @@ def get_runner_instance_intersection(
     ]
 
     return intersection, non_intersecting_instances
-
-
-from botocore.exceptions import ClientError
-import time
-import random
 
 
 def terminate_instances_safe(instance_ids, batch_size=100, dry_run=True):

--- a/tools/self-hosted-runner-utils/clear_offline_runners.py
+++ b/tools/self-hosted-runner-utils/clear_offline_runners.py
@@ -30,10 +30,10 @@ def parse_args() -> argparse.Namespace:
         default=False,
     )
     parser.add_argument(
-        "--include",
-        help="Regex to match runner names to remove offline runners of",
+        "--runner-name",
+        help="AWS Runner Name to filter for EC2 instances.",
         type=str,
-        default=".*",
+        default="gh-ci-action-runner",
     )
     parser.add_argument(
         "--token",

--- a/tools/self-hosted-runner-utils/clear_offline_runners.py
+++ b/tools/self-hosted-runner-utils/clear_offline_runners.py
@@ -157,9 +157,9 @@ def main() -> None:
     else:
         runners = get_self_hosted_runners_org(gh.get_organization(options.entity))
 
-    # Get AWS instances with name 'gh-ci-action-runner'
-    aws_instances = get_aws_instances_by_name(ec2, "gh-ci-action-runner")
-    print(f"Found {len(aws_instances)} AWS instances with name 'gh-ci-action-runner'")
+    # Get AWS instances with name {options.runner_name}
+    aws_instances = get_aws_instances_by_name(ec2, f"{options.runner_name}")
+    print(f"Found {len(aws_instances)} AWS instances with name '{options.runner_name}'")
 
     # Convert runners to list for intersection calculation
     runners_list = list(runners)

--- a/tools/self-hosted-runner-utils/clear_offline_runners.py
+++ b/tools/self-hosted-runner-utils/clear_offline_runners.py
@@ -1,9 +1,14 @@
 import argparse
 import os
 import re
-import sys
+from typing import List, Set
 
-from github import Github  # type: ignore[import-not-found]
+import boto3  # type: ignore[import-untyped]
+from github import (  # type: ignore[import-not-found]
+    Github,
+    PaginatedList,
+    SelfHostedActionsRunner,
+)
 from tqdm import tqdm  # type: ignore[import-untyped]
 
 
@@ -38,29 +43,143 @@ def parse_args() -> argparse.Namespace:
     return options
 
 
+def get_self_hosted_runners_org(org):  # type: ignore[no-untyped-def]
+    return PaginatedList.PaginatedList(
+        SelfHostedActionsRunner.SelfHostedActionsRunner,
+        org._requester,
+        f"https://api.github.com/orgs/{org.login}/actions/runners",
+        None,
+        list_item="runners",
+    )
+
+
+def get_aws_instances_by_name(ec2, name_pattern: str) -> List[dict]:
+    response = ec2.describe_instances(
+        Filters=[
+            {"Name": "tag:Name", "Values": [name_pattern]},
+            {
+                "Name": "instance-state-name",
+                "Values": ["running", "pending", "stopping", "stopped"],
+            },
+        ]
+    )
+
+    instances = []
+    for reservation in response["Reservations"]:
+        for instance in reservation["Instances"]:
+            name = ""
+            for tag in instance.get("Tags", []):
+                if tag["Key"] == "Name":
+                    name = tag["Value"]
+                    break
+            instances.append(
+                {
+                    "id": instance["InstanceId"],
+                    "name": name,
+                    "state": instance["State"]["Name"],
+                }
+            )
+
+    return instances
+
+
+def get_runner_instance_intersection(
+    runners: List, aws_instances: List[dict]
+) -> tuple[Set[str], List[dict]]:
+    runner_names = {runner.name for runner in runners}
+    aws_instance_names = {instance["id"] for instance in aws_instances}
+
+    intersection = runner_names.intersection(aws_instance_names)
+
+    non_intersecting_instances = [
+        instance for instance in aws_instances if instance["id"] not in intersection
+    ]
+
+    return intersection, non_intersecting_instances
+
+
+from botocore.exceptions import ClientError
+import time
+import random
+
+
+def terminate_instances_safe(instance_ids, batch_size=100, dry_run=True):
+    """
+    Terminate instances with exponential backoff for rate limiting
+    """
+    ec2 = boto3.client("ec2")
+
+    batches = [
+        instance_ids[i : i + batch_size]
+        for i in range(0, len(instance_ids), batch_size)
+    ]
+    results = []
+
+    for i, batch in tqdm(enumerate(batches, 1)):
+        max_retries = 3
+
+        for retry in range(max_retries):
+            try:
+                response = ec2.terminate_instances(InstanceIds=batch, DryRun=dry_run)
+                results.append(response)
+                print(f"Batch {i}/{len(batches)} successful")
+                break
+
+            except ClientError as e:
+                if e.response["Error"]["Code"] == "RequestLimitExceeded":
+                    if retry < max_retries - 1:
+                        # Exponential backoff with jitter
+                        delay = (2**retry) + random.uniform(0, 1)
+                        print(f"Rate limited, retrying in {delay:.1f}s...")
+                        time.sleep(delay)
+                    else:
+                        print(f"Batch {i} failed after {max_retries} retries")
+                        results.append(None)
+                else:
+                    print(f"Batch {i} failed: {e}")
+                    results.append(None)
+                    break
+
+        # Small delay between successful batches
+        if i < len(batches):
+            time.sleep(0.5)
+
+    return results
+
+
 def main() -> None:
+    ec2 = boto3.client("ec2")
     options = parse_args()
     if options.token == "":
         raise Exception("GITHUB_TOKEN or --token must be set")
     gh = Github(options.token)
-    entity_get = gh.get_organization
     if "/" in options.entity:
         entity_get = gh.get_repo
-    entity = entity_get(options.entity)
-    runners = entity.get_self_hosted_runners()
-    include_pattern = re.compile(options.include)
-    num_removed = 0
-    num_total = 0
-    to_delete = list()
-    for runner in runners:
-        num_total += 1
-        if runner.status == "offline" and include_pattern.match(runner.name):
-            to_delete.append(runner)
-    for runner in tqdm(to_delete):
-        if not options.dry_run:
-            entity.remove_self_hosted_runner(runner.id)
-        num_removed += 1
-    print(f"Removed {num_removed}/{num_total}")
+        entity = entity_get(options.entity)
+        runners = entity.get_self_hosted_runners()
+    else:
+        runners = get_self_hosted_runners_org(gh.get_organization(options.entity))
+
+    # Get AWS instances with name 'gh-ci-action-runner'
+    aws_instances = get_aws_instances_by_name(ec2, "gh-ci-action-runner")
+    print(f"Found {len(aws_instances)} AWS instances with name 'gh-ci-action-runner'")
+
+    # Convert runners to list for intersection calculation
+    runners_list = list(runners)
+    print(f"Found {len(runners_list)} GitHub runners")
+
+    # Get intersection and non-intersecting instances
+    intersection, non_intersecting_instances = get_runner_instance_intersection(
+        runners_list, aws_instances
+    )
+    instance_ids = list()
+    print(
+        f"\nAWS instances NOT part of intersection: {len(non_intersecting_instances)}"
+    )
+    for instance in non_intersecting_instances:
+        instance_ids.append(instance["id"])
+
+    terminate_instances_safe(instance_ids, dry_run=options.dry_run)
 
 
 if __name__ == "__main__":

--- a/tools/self-hosted-runner-utils/requirements.txt
+++ b/tools/self-hosted-runner-utils/requirements.txt
@@ -1,3 +1,4 @@
 PyGithub
 black
 tqdm
+boto3


### PR DESCRIPTION
We recently had an outage that required that we spin down all instances that were not actively connected to GitHub.

Requirements to run:
* Valid AWS credentials
* GITHUB_TOKEN with permissions to view self hosted runners for an organization

To run you can use:

```bash
pip install -r tools/self-hosted-runner-utils/requirements.txt
# To dry run first, pay attention to outputted numbers
python3 tools/self-hosted-runner-utils/clear_offline_runners.py --dry-run pytorch
# To do actual work
python3 tools/self-hosted-runner-utils/clear_offline_runners.py pytorch
```

This was used to remediate issues from https://github.com/pytorch/pytorch/issues/155265