### PR TITLE
[CI] Print python3/pip3 aliases in setup-python

### DIFF
--- a/.github/workflows/test-setup-python.yml
+++ b/.github/workflows/test-setup-python.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - .github/actions/setup-python/*
-      - .github/workflows/test-setup-python.yaml
+      - .github/workflows/test-setup-python.yml
 
 jobs:
   setup-python-job:

--- a/.github/workflows/test-setup-python.yml
+++ b/.github/workflows/test-setup-python.yml
@@ -15,8 +15,10 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-python
         with:
-          version: '3.11'
+          version: '3.12'
           pip-requirements-file: .github/workflows/test-pip-requirements-macOS.txt
+      - name: Show python, python3, pip and pip3 locations
+        run: for tool in python python3 pip pip3; do which $tool; done
       - name: Show Python and pip versions
         run: python3 --version; pip3 --version
       - name: List installed packages


### PR DESCRIPTION
Discovered while working on https://github.com/pytorch/pytorch/pull/155515 that sometimes python3 alias for python could be missing