### PR TITLE
Enable runners to have specific secrets be made available to them

### DIFF
--- a/terraform-aws-github-runner/modules/runners-instances/policies-runner.tf
+++ b/terraform-aws-github-runner/modules/runners-instances/policies-runner.tf
@@ -54,16 +54,16 @@ resource "aws_iam_role_policy" "create_tags" {
   policy = file("${path.module}/policies/instance-ec2-create-tags-policy.json")
 }
 
-# This policy is conditionally created only when secrets_arn is provided.
+# This policy is conditionally created only when runner_secrets_arns is provided.
 # This ensures we don't create empty policies when no secret access is needed,
 # making the security configuration more explicit and reducing IAM clutter.
 resource "aws_iam_role_policy" "secrets_access" {
-  count  = var.secrets_arn != "" ? 1 : 0
+  count  = length(var.runner_secrets_arns) > 0 ? 1 : 0
   name   = "runner-secrets-access"
   role   = aws_iam_role.runner.name
   policy = templatefile("${path.module}/policies/instance-secrets-policy.json",
     {
-      secrets_arn = var.secrets_arn
+      secrets_arns = jsonencode(var.runner_secrets_arns)
     }
   )
 }

--- a/terraform-aws-github-runner/modules/runners-instances/policies-runner.tf
+++ b/terraform-aws-github-runner/modules/runners-instances/policies-runner.tf
@@ -53,3 +53,17 @@ resource "aws_iam_role_policy" "create_tags" {
   role   = aws_iam_role.runner.name
   policy = file("${path.module}/policies/instance-ec2-create-tags-policy.json")
 }
+
+# This policy is conditionally created only when secrets_arn is provided.
+# This ensures we don't create empty policies when no secret access is needed,
+# making the security configuration more explicit and reducing IAM clutter.
+resource "aws_iam_role_policy" "secrets_access" {
+  count  = var.secrets_arn != "" ? 1 : 0
+  name   = "runner-secrets-access"
+  role   = aws_iam_role.runner.name
+  policy = templatefile("${path.module}/policies/instance-secrets-policy.json",
+    {
+      secrets_arn = var.secrets_arn
+    }
+  )
+}

--- a/terraform-aws-github-runner/modules/runners-instances/policies/instance-secrets-policy.json
+++ b/terraform-aws-github-runner/modules/runners-instances/policies/instance-secrets-policy.json
@@ -6,9 +6,7 @@
       "Action": [
         "secretsmanager:GetSecretValue"
       ],
-      "Resource": [
-        "${secrets_arn}"
-      ]
+      "Resource": "${secrets_arns}"
     }
   ]
 } 

--- a/terraform-aws-github-runner/modules/runners-instances/policies/instance-secrets-policy.json
+++ b/terraform-aws-github-runner/modules/runners-instances/policies/instance-secrets-policy.json
@@ -1,0 +1,14 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": [
+        "${secrets_arn}"
+      ]
+    }
+  ]
+} 

--- a/terraform-aws-github-runner/modules/runners-instances/variables.tf
+++ b/terraform-aws-github-runner/modules/runners-instances/variables.tf
@@ -196,8 +196,8 @@ variable "key_name" {
   default     = null
 }
 
-variable "secrets_arn" {
-  description = "ARN of the AWS Secrets Manager secret that the runner should have access to"
-  type        = string
-  default     = ""
+variable "runner_secrets_arns" {
+  description = "List of ARNs of AWS Secrets Manager secrets that the runner role should have access to"
+  type        = list(string)
+  default     = []
 }

--- a/terraform-aws-github-runner/modules/runners-instances/variables.tf
+++ b/terraform-aws-github-runner/modules/runners-instances/variables.tf
@@ -173,7 +173,7 @@ variable "enable_ssm_on_runners" {
 }
 
 variable "runner_iam_role_managed_policy_arns" {
-  description = "Attach AWS or customer-managed IAM policies (by ARN) to the runner IAM role"
+  description = "List of IAM managed policy ARNs to be attached to the runner IAM role"
   type        = list(string)
   default     = []
 }
@@ -194,4 +194,10 @@ variable "key_name" {
   description = "Key pair name"
   type        = string
   default     = null
+}
+
+variable "secrets_arn" {
+  description = "ARN of the AWS Secrets Manager secret that the runner should have access to"
+  type        = string
+  default     = ""
 }


### PR DESCRIPTION
There's a secret we want to enable runners to read.  

We add a new variable to the module to specify the arns for these secrets. They're marked as sensitive in order to not show up in the logs, and the runner is then given a policy allowing it to access the secret directly from secret store.

The variable is left as a conditional one since the secret may not be available to all the fleets this terraform script can run in.  When the variable isn't passed in, we don't add the policy