### PR TITLE
Revert "Support clang in MSVC"

### DIFF
--- a/aws/ami/windows/scripts/Installers/Install-VS.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-VS.ps1
@@ -22,9 +22,7 @@ $VS_INSTALL_ARGS = @("--nocache","--quiet","--wait", "--add Microsoft.VisualStud
                                                      "--add Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
                                                      "--add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core",
                                                      "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
-                                                     "--add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81",
-                                                     "--add Microsoft.VisualStudio.Component.VC.Llvm.Clang",
-                                                     "--add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset")
+                                                     "--add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81")
 
 if (${env:INSTALL_WINDOWS_SDK} -eq "1") {
     $VS_INSTALL_ARGS += "--add Microsoft.VisualStudio.Component.Windows10SDK.19041"


### PR DESCRIPTION
Reverts pytorch/test-infra#6654
Errors found realted to vs2019 install.
Hence reverting this for now