### PR TITLE
[pytorchbot] Format `close` usage string in markdown block

### DIFF
--- a/torchci/lib/bot/cliParser.ts
+++ b/torchci/lib/bot/cliParser.ts
@@ -222,10 +222,11 @@ ${label.format_help()}\`\`\`
 ## Dr CI
 \`\`\`
 ${drCi.format_help()}\`\`\`
-## cherry-pick
+## Cherry pick
 \`\`\`
 ${cherryPick.format_help()}\`\`\`
 ## Close
-${close.format_help()}
+\`\`\`
+${close.format_help()}\`\`\`
 `;
 }


### PR DESCRIPTION
This PR also updates the cherry pick header.

Fixes #6745