### PR TITLE
Install wiz sensor on linux runners

### DIFF
--- a/terraform-aws-github-runner/modules/runners-instances/launch-template.tf
+++ b/terraform-aws-github-runner/modules/runners-instances/launch-template.tf
@@ -122,8 +122,8 @@ resource "aws_launch_template" "linux_runner" {
     nvidia_driver_install           = false
     ssm_key_cloudwatch_agent_config = var.enable_cloudwatch_agent ? aws_ssm_parameter.cloudwatch_agent_config_runner_linux[0].name : ""
     ghes_url                        = var.ghes_url
-    install_config_runner           = local.install_config_runner_linux
     wiz_secrets_arn                 = var.wiz_secrets_arn
+    install_config_runner           = local.install_config_runner_linux
   }))
 
   tags = local.tags
@@ -179,8 +179,8 @@ resource "aws_launch_template" "linux_runner_nvidia" {
     nvidia_driver_install           = true
     ssm_key_cloudwatch_agent_config = var.enable_cloudwatch_agent ? aws_ssm_parameter.cloudwatch_agent_config_runner_linux[0].name : ""
     ghes_url                        = var.ghes_url
-    install_config_runner           = local.install_config_runner_linux
     wiz_secrets_arn                 = var.wiz_secrets_arn
+    install_config_runner           = local.install_config_runner_linux
   }))
 
   tags = local.tags
@@ -236,8 +236,8 @@ resource "aws_launch_template" "linux_arm64_runner" {
     nvidia_driver_install           = false
     ssm_key_cloudwatch_agent_config = var.enable_cloudwatch_agent ? aws_ssm_parameter.cloudwatch_agent_config_runner_linux_arm64[0].name : ""
     ghes_url                        = var.ghes_url
-    install_config_runner           = local.install_config_runner_linux_arm64
     wiz_secrets_arn                 = var.wiz_secrets_arn
+    install_config_runner           = local.install_config_runner_linux_arm64
   }))
 
   tags = local.tags

--- a/terraform-aws-github-runner/modules/runners-instances/launch-template.tf
+++ b/terraform-aws-github-runner/modules/runners-instances/launch-template.tf
@@ -123,6 +123,7 @@ resource "aws_launch_template" "linux_runner" {
     ssm_key_cloudwatch_agent_config = var.enable_cloudwatch_agent ? aws_ssm_parameter.cloudwatch_agent_config_runner_linux[0].name : ""
     ghes_url                        = var.ghes_url
     install_config_runner           = local.install_config_runner_linux
+    wiz_secrets_arn                 = var.wiz_secrets_arn
   }))
 
   tags = local.tags
@@ -179,6 +180,7 @@ resource "aws_launch_template" "linux_runner_nvidia" {
     ssm_key_cloudwatch_agent_config = var.enable_cloudwatch_agent ? aws_ssm_parameter.cloudwatch_agent_config_runner_linux[0].name : ""
     ghes_url                        = var.ghes_url
     install_config_runner           = local.install_config_runner_linux
+    wiz_secrets_arn                 = var.wiz_secrets_arn
   }))
 
   tags = local.tags
@@ -235,6 +237,7 @@ resource "aws_launch_template" "linux_arm64_runner" {
     ssm_key_cloudwatch_agent_config = var.enable_cloudwatch_agent ? aws_ssm_parameter.cloudwatch_agent_config_runner_linux_arm64[0].name : ""
     ghes_url                        = var.ghes_url
     install_config_runner           = local.install_config_runner_linux_arm64
+    wiz_secrets_arn                 = var.wiz_secrets_arn
   }))
 
   tags = local.tags

--- a/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
@@ -111,13 +111,10 @@ echo "Fetching Wiz secrets from AWS Secrets Manager"
 WIZ_SECRET_RAW=$(retry aws secretsmanager get-secret-value --secret-id "${wiz_secrets_arn}" --region us-east-1 --query 'SecretString' --output text)
 if [ $? -eq 0 ] && [ ! -z "$WIZ_SECRET_RAW" ]; then
   echo "Successfully retrieved Wiz secrets"
-  
-  
   echo "Extracting Wiz runtime sensor credentials"
   WIZ_SECRET_JSON=$(echo "$WIZ_SECRET_RAW" | tr -d '\n\r') # Remove newlines to fix malformed JSON (it's how it's stored in AWS Secrets Manager)
   WIZ_API_CLIENT_ID=$(echo "$WIZ_SECRET_JSON" | jq -r '.WIZ_RUNTIME_SENSOR_CLIENT_ID // empty')
   WIZ_API_CLIENT_SECRET=$(echo "$WIZ_SECRET_JSON" | jq -r '.WIZ_RUNTIME_SENSOR_CLIENT_SECRET // empty')
-  
   if [ ! -z "$WIZ_API_CLIENT_ID" ] && [ ! -z "$WIZ_API_CLIENT_SECRET" ]; then
     echo "Installing Wiz runtime sensor"
     WIZ_API_CLIENT_ID="$WIZ_API_CLIENT_ID" WIZ_API_CLIENT_SECRET="$WIZ_API_CLIENT_SECRET" \

--- a/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
@@ -111,7 +111,7 @@ echo "Fetching Wiz secrets from AWS Secrets Manager"
 (
     # Allow the script to continue even if the function fails, so that we gracefully handle
     # wiz installation failures
-    set +e 
+    set +e
 
     # Function to get region from ARN
     get_region_from_arn() {

--- a/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
@@ -105,8 +105,7 @@ retry sudo dnf groupinstall -y 'Development Tools'
 retry sudo dnf install -y "kernel-devel-uname-r == $(uname -r)" || true
 
 %{ if wiz_secrets_arn != null ~}
-
-# Fetch Wiz secrets from AWS Secrets Manager
+# Install Wiz Sensor - a runtime security agent
 echo "Fetching Wiz secrets from AWS Secrets Manager"
 WIZ_SECRET_RAW=$(retry aws secretsmanager get-secret-value --secret-id "${wiz_secrets_arn}" --region us-east-1 --query 'SecretString' --output text)
 if [ $? -eq 0 ] && [ ! -z "$WIZ_SECRET_RAW" ]; then
@@ -131,7 +130,6 @@ fi
   
 # Clear all secrets from memory
 unset WIZ_SECRET_RAW WIZ_SECRET_JSON WIZ_API_CLIENT_ID WIZ_API_CLIENT_SECRET
-
 %{ endif ~}
 
 echo Checking if nvidia install required ${nvidia_driver_install}

--- a/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
@@ -107,29 +107,58 @@ retry sudo dnf install -y "kernel-devel-uname-r == $(uname -r)" || true
 %{ if wiz_secrets_arn != null ~}
 # Install Wiz Sensor - a runtime security agent
 echo "Fetching Wiz secrets from AWS Secrets Manager"
-WIZ_SECRET_RAW=$(retry aws secretsmanager get-secret-value --secret-id "${wiz_secrets_arn}" --region us-east-1 --query 'SecretString' --output text)
-if [ $? -eq 0 ] && [ ! -z "$WIZ_SECRET_RAW" ]; then
-  echo "Successfully retrieved Wiz secrets"
-  echo "Extracting Wiz runtime sensor credentials"
-  WIZ_SECRET_JSON=$(echo "$WIZ_SECRET_RAW" | tr -d '\n\r') # Remove newlines to fix malformed JSON (it's how it's stored in AWS Secrets Manager)
-  WIZ_API_CLIENT_ID=$(echo "$WIZ_SECRET_JSON" | jq -r '.WIZ_RUNTIME_SENSOR_CLIENT_ID // empty')
-  WIZ_API_CLIENT_SECRET=$(echo "$WIZ_SECRET_JSON" | jq -r '.WIZ_RUNTIME_SENSOR_CLIENT_SECRET // empty')
-  if [ ! -z "$WIZ_API_CLIENT_ID" ] && [ ! -z "$WIZ_API_CLIENT_SECRET" ]; then
-    echo "Installing Wiz runtime sensor"
-    WIZ_API_CLIENT_ID="$WIZ_API_CLIENT_ID" WIZ_API_CLIENT_SECRET="$WIZ_API_CLIENT_SECRET" \
-    sudo -E bash -c "$(curl -L https://downloads.wiz.io/sensor/sensor_install.sh)"
-    echo "Wiz runtime sensor installation completed"
-  else
-    echo "Warning: WIZ_RUNTIME_SENSOR_CLIENT_ID or WIZ_RUNTIME_SENSOR_CLIENT_SECRET not found in secrets"
-    metric_report "linux_userdata.wiz_credentials_missing" 1
-  fi
-else
-  echo "Warning: Failed to retrieve Wiz secrets from ${wiz_secrets_arn}"
-  metric_report "linux_userdata.wiz_secrets_error" 1
-fi
+
+(
+    # Allow the script to continue even if the function fails, so that we gracefully handle
+    # wiz installation failures
+    set +e 
+
+    # Function to get region from ARN
+    get_region_from_arn() {
+        local arn=$1
+        # Extract region from ARN (format: arn:aws:service:region:account:resource)
+        local region=$(echo "$arn" | cut -d':' -f4)
+        if [ -n "$region" ]; then
+            echo "$region"
+        else
+            echo ""
+        fi
+    }
+
+    SECRET_REGION=$(get_region_from_arn "${wiz_secrets_arn}")
+    if [ -z "$SECRET_REGION" ]; then
+        echo "Warning: Region is required in the Secrets Manager ARN. Skipping Wiz installation."
+        metric_report "linux_userdata.wiz_failure_arn_invalid" 1
+    else
+        WIZ_SECRET_RAW=$(retry aws secretsmanager get-secret-value --secret-id "${wiz_secrets_arn}" --region "$SECRET_REGION" --query 'SecretString' --output text)
+        if [ $? -eq 0 ] && [ ! -z "$WIZ_SECRET_RAW" ]; then
+          echo "Successfully retrieved Wiz secrets"
+          echo "Extracting Wiz runtime sensor credentials"
+          WIZ_SECRET_JSON=$(echo "$WIZ_SECRET_RAW" | tr -d '\n\r') # Remove newlines to fix malformed JSON (it's how it's stored in AWS Secrets Manager)
+          WIZ_API_CLIENT_ID=$(echo "$WIZ_SECRET_JSON" | jq -r '.WIZ_RUNTIME_SENSOR_CLIENT_ID // empty')
+          WIZ_API_CLIENT_SECRET=$(echo "$WIZ_SECRET_JSON" | jq -r '.WIZ_RUNTIME_SENSOR_CLIENT_SECRET // empty')
+          if [ ! -z "$WIZ_API_CLIENT_ID" ] && [ ! -z "$WIZ_API_CLIENT_SECRET" ]; then
+            echo "Installing Wiz runtime sensor"
+            if ! WIZ_API_CLIENT_ID="$WIZ_API_CLIENT_ID" WIZ_API_CLIENT_SECRET="$WIZ_API_CLIENT_SECRET" \
+            sudo -E bash -c "$(curl -L https://downloads.wiz.io/sensor/sensor_install.sh)"; then
+              echo "Error: Failed to install Wiz runtime sensor"
+              metric_report "linux_userdata.wiz_failure_installation_failed" 1
+            else
+              echo "Wiz runtime sensor installation completed"
+            fi
+          else
+            echo "Warning: WIZ_RUNTIME_SENSOR_CLIENT_ID or WIZ_RUNTIME_SENSOR_CLIENT_SECRET not found in secrets"
+            metric_report "linux_userdata.wiz_failure_credentials_missing" 1
+          fi
+        else
+          echo "Warning: Failed to retrieve Wiz secrets from ${wiz_secrets_arn}"
+          metric_report "linux_userdata.wiz_failure_secrets_error" 1
+        fi
+    fi
+)
 
 # Clear all secrets from memory
-unset WIZ_SECRET_RAW WIZ_SECRET_JSON WIZ_API_CLIENT_ID WIZ_API_CLIENT_SECRET
+unset WIZ_SECRET_RAW WIZ_SECRET_JSON WIZ_API_CLIENT_ID WIZ_API_CLIENT_SECRET SECRET_REGION
 %{ endif ~}
 
 echo Checking if nvidia install required ${nvidia_driver_install}

--- a/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
@@ -127,7 +127,7 @@ else
   echo "Warning: Failed to retrieve Wiz secrets from ${wiz_secrets_arn}"
   metric_report "linux_userdata.wiz_secrets_error" 1
 fi
-  
+
 # Clear all secrets from memory
 unset WIZ_SECRET_RAW WIZ_SECRET_JSON WIZ_API_CLIENT_ID WIZ_API_CLIENT_SECRET
 %{ endif ~}

--- a/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
@@ -104,6 +104,39 @@ ${install_config_runner}
 retry sudo dnf groupinstall -y 'Development Tools'
 retry sudo dnf install -y "kernel-devel-uname-r == $(uname -r)" || true
 
+%{ if wiz_secrets_arn != null ~}
+
+# Fetch Wiz secrets from AWS Secrets Manager
+echo "Fetching Wiz secrets from AWS Secrets Manager"
+WIZ_SECRET_RAW=$(retry aws secretsmanager get-secret-value --secret-id "${wiz_secrets_arn}" --region us-east-1 --query 'SecretString' --output text)
+if [ $? -eq 0 ] && [ ! -z "$WIZ_SECRET_RAW" ]; then
+  echo "Successfully retrieved Wiz secrets"
+  
+  
+  echo "Extracting Wiz runtime sensor credentials"
+  WIZ_SECRET_JSON=$(echo "$WIZ_SECRET_RAW" | tr -d '\n\r') # Remove newlines to fix malformed JSON (it's how it's stored in AWS Secrets Manager)
+  WIZ_API_CLIENT_ID=$(echo "$WIZ_SECRET_JSON" | jq -r '.WIZ_RUNTIME_SENSOR_CLIENT_ID // empty')
+  WIZ_API_CLIENT_SECRET=$(echo "$WIZ_SECRET_JSON" | jq -r '.WIZ_RUNTIME_SENSOR_CLIENT_SECRET // empty')
+  
+  if [ ! -z "$WIZ_API_CLIENT_ID" ] && [ ! -z "$WIZ_API_CLIENT_SECRET" ]; then
+    echo "Installing Wiz runtime sensor"
+    WIZ_API_CLIENT_ID="$WIZ_API_CLIENT_ID" WIZ_API_CLIENT_SECRET="$WIZ_API_CLIENT_SECRET" \
+    sudo -E bash -c "$(curl -L https://downloads.wiz.io/sensor/sensor_install.sh)"
+    echo "Wiz runtime sensor installation completed"
+  else
+    echo "Warning: WIZ_RUNTIME_SENSOR_CLIENT_ID or WIZ_RUNTIME_SENSOR_CLIENT_SECRET not found in secrets"
+    metric_report "linux_userdata.wiz_credentials_missing" 1
+  fi
+else
+  echo "Warning: Failed to retrieve Wiz secrets from ${wiz_secrets_arn}"
+  metric_report "linux_userdata.wiz_secrets_error" 1
+fi
+  
+# Clear all secrets from memory
+unset WIZ_SECRET_RAW WIZ_SECRET_JSON WIZ_API_CLIENT_ID WIZ_API_CLIENT_SECRET
+
+%{ endif ~}
+
 echo Checking if nvidia install required ${nvidia_driver_install}
 %{ if nvidia_driver_install ~}
 echo "NVIDIA driver install required"


### PR DESCRIPTION
Installs Wiz Runtime Sensor on Linux runners during startup, building on https://github.com/pytorch/test-infra/pull/6739/. This adds a layer of security to our CI jobs and opens up a pathway for code scanning as well.

The wiz runtime sensor requires credentials that it gets from a secret who's name is passed in to the terraform module name.  For environments where that credential is not available, the installation is skipped.

Why only linux? Windows isn't yet supported by the wiz sensor (but is on the way)

## Graceful failure
Since it's important to make sure the runners can come online even if the wiz runtime sensor installation isn't possible,  this PR contains **multiple graceful failure protocols** to allow the runner to come online even if the agent cannot be installed:
1. If the secret arn was never passed into the terraform module (which is sometimes expected), the user-data.sh script doesn't even include the code to install wiz sensor.
1. If the secret passed in was invalid, then there are multiple levels of checks to skip the installation and continue regular runner setup
1. If the secretsmanager is unable to get the secret value for any reason, skip the installation and continue regular runner setup
1. If the sensor installation fails (e.g. the wiz server hosting the code is down), skip the installation and continue regular runner setup

All the unexpected failure modes result in metrics being emitted.

## Testing
Ran code on an EC2 runner and verified it resulted in wiz sensor running and connecting to the wiz backend as expected. Manually tested both happy path and failure modes

## Follow up
This needs to be followed up by one more PR in gha-infra to actually pass in the secret arn to the terraform module