### PR TITLE
Use 12.6.3 for CUDA 12.6 windows installation script

### DIFF
--- a/aws/ami/windows/scripts/Installers/Install-CUDA-Tools.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-CUDA-Tools.ps1
@@ -16,22 +16,19 @@ $installerArgs = "nvcc_$cudaVersion cuobjdump_$cudaVersion nvprune_$cudaVersion 
 $cudnn_subfolder="cuda"
 $cudnn_lib_folder="lib\x64"
 $cudnn_subfolder="cudnn-windows-x86_64-9.10.2.21_cuda12-archive"
-$toolkitInstaller = "cuda_12.6.2_560.94_windows.exe"
+$toolkitInstaller = "cuda_12.6.3_561.17_windows.exe"
 
 Switch ($cudaVersion) {
   "12.6" {
-    $toolkitInstaller = "cuda_12.6.2_560.94_windows.exe"
-    $cudnn_subfolder = "cudnn-windows-x86_64-9.10.2.21_cuda12-archive"
+    $toolkitInstaller = "cuda_12.6.3_561.17_windows.exe"
     $installerArgs += " cuda_profiler_api_$cudaVersion nvjitlink_$cudaVersion"
   }
   "12.8" {
     $toolkitInstaller = "cuda_12.8.1_572.61_windows.exe"
-    $cudnn_subfolder = "cudnn-windows-x86_64-9.10.2.21_cuda12-archive"
     $installerArgs += " cuda_profiler_api_$cudaVersion nvjitlink_$cudaVersion"
   }
   "12.9" {
     $toolkitInstaller = "cuda_12.9.1_576.57_windows.exe"
-    $cudnn_subfolder = "cudnn-windows-x86_64-9.10.2.21_cuda12-archive"
     $installerArgs += " cuda_profiler_api_$cudaVersion nvjitlink_$cudaVersion"
   }
 }


### PR DESCRIPTION
follow-up for https://github.com/pytorch/test-infra/pull/6742/files

Also removing the duplicate cudnn_subfolder name, CUDA 12 are all using the same cudnn scripts. 

cc @atalman 