### PR TITLE
[pytorchbot] Remove reference to the `close` command

### DIFF
--- a/torchci/lib/bot/cliParser.ts
+++ b/torchci/lib/bot/cliParser.ts
@@ -172,14 +172,6 @@ cherryPick.add_argument("-h", "--help", {
   help: SUPPRESS,
 });
 
-// close
-const close = commands.add_parser("close", {
-  help: "Close a PR",
-  description: "Close a PR [Can be used on issues]",
-  formatter_class: RawTextHelpFormatter,
-  add_help: false,
-});
-
 // Help
 parser.add_argument("-h", "--help", {
   default: SUPPRESS,
@@ -225,7 +217,5 @@ ${drCi.format_help()}\`\`\`
 ## cherry-pick
 \`\`\`
 ${cherryPick.format_help()}\`\`\`
-## Close
-${close.format_help()}
 `;
 }


### PR DESCRIPTION
The command was removed in #6749. This PR removes it from the help section.

cc @clee2000