### PR TITLE
Adding windows.9xlarge instance type, trying to mitigate OOM with CUDA 12.9 build

### DIFF
--- a/.github/canary-scale-config.yml
+++ b/.github/canary-scale-config.yml
@@ -214,6 +214,22 @@ runner_types:
     variants:
       wincanary:
         ami: Windows 2019 GHA CI - 20250526202723
+  c.windows.9xlarge:
+    disk_size: 256
+    instance_type: c5d.9xlarge
+    is_ephemeral: true
+    os: windows
+    variants:
+      wincanary:
+        ami: Windows 2019 GHA CI - 20250526202723
+  c.windows.9xlarge.nonephemeral:
+    disk_size: 256
+    instance_type: c5d.9xlarge
+    is_ephemeral: true
+    os: windows
+    variants:
+      wincanary:
+        ami: Windows 2019 GHA CI - 20250526202723
   c.windows.8xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: p3.2xlarge

--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -214,6 +214,22 @@ runner_types:
     variants:
       wincanary:
         ami: Windows 2019 GHA CI - 20250526202723
+  lf.c.windows.9xlarge:
+    disk_size: 256
+    instance_type: c5d.9xlarge
+    is_ephemeral: true
+    os: windows
+    variants:
+      wincanary:
+        ami: Windows 2019 GHA CI - 20250526202723
+  lf.c.windows.9xlarge.nonephemeral:
+    disk_size: 256
+    instance_type: c5d.9xlarge
+    is_ephemeral: true
+    os: windows
+    variants:
+      wincanary:
+        ami: Windows 2019 GHA CI - 20250526202723
   lf.c.windows.8xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: p3.2xlarge

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -214,6 +214,22 @@ runner_types:
     variants:
       wincanary:
         ami: Windows 2019 GHA CI - 20250526202723
+  lf.windows.9xlarge:
+    disk_size: 256
+    instance_type: c5d.9xlarge
+    is_ephemeral: true
+    os: windows
+    variants:
+      wincanary:
+        ami: Windows 2019 GHA CI - 20250526202723
+  lf.windows.9xlarge.nonephemeral:
+    disk_size: 256
+    instance_type: c5d.9xlarge
+    is_ephemeral: true
+    os: windows
+    variants:
+      wincanary:
+        ami: Windows 2019 GHA CI - 20250526202723
   lf.windows.8xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: p3.2xlarge

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -210,6 +210,22 @@ runner_types:
     variants:
       wincanary:
         ami: Windows 2019 GHA CI - 20250526202723
+  windows.9xlarge:
+    disk_size: 256
+    instance_type: c5d.9xlarge
+    is_ephemeral: true
+    os: windows
+    variants:
+      wincanary:
+        ami: Windows 2019 GHA CI - 20250526202723
+  windows.9xlarge.nonephemeral:
+    disk_size: 256
+    instance_type: c5d.9xlarge
+    is_ephemeral: true
+    os: windows
+    variants:
+      wincanary:
+        ami: Windows 2019 GHA CI - 20250526202723
   windows.8xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: p3.2xlarge


### PR DESCRIPTION
Please see:
https://github.com/pytorch/test-infra/pull/6734#issuecomment-2970827894

Error:
```
2025-06-13T15:23:17.4386475Z [6879/7604] Building CUDA object caffe2\CMakeFiles\torch_cuda.dir\__\aten\src\ATen\native\cuda\SegmentReduce.cu.obj
2025-06-13T15:23:17.4392489Z FAILED: caffe2/CMakeFiles/torch_cuda.dir/__/aten/src/ATen/native/cuda/SegmentReduce.cu.obj 
2025-06-13T15:23:17.4457308Z C:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\.ci\pytorch\windows\\tmp_bin\randomtemp.exe C:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\.ci\pytorch\windows\\tmp_bin\sccache.exe C:\PROGRA~1\NVIDIA~2\CUDA\v12.9\bin\nvcc.exe -forward-unknown-to-host-compiler -DAT_PER_OPERATOR_HEADERS -DEXPORT_AOTI_FUNCTIONS -DFMT_HEADER_ONLY=1 -DIDEEP_USE_MKL -DMINIZ_DISABLE_ZIP_READER_CRC32_CHECKS -DNOMINMAX -DONNXIFI_ENABLE_EXT=1 -DONNX_ML=1 -DONNX_NAMESPACE=onnx_torch -DTORCH_CUDA_BUILD_MAIN_LIB -DTORCH_CUDA_USE_NVTX3 -DUSE_C10D_GLOO -DUSE_CUDA -DUSE_DISTRIBUTED -DUSE_EXTERNAL_MZCRC -DUSE_MEM_EFF_ATTENTION -DUSE_MIMALLOC -DWIN32_LEAN_AND_MEAN -D_CRT_SECURE_NO_DEPRECATE=1 -D_UCRT_LEGACY_INFINITY -Dtorch_cuda_EXPORTS -IC:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\build\aten\src -IC:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\aten\src -IC:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\build -IC:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch -IC:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\nlohmann -IC:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\moodycamel -IC:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\third_party\mimalloc\include -IC:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\aten\src\THC -IC:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\aten\src\ATen\cuda -IC:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\third_party\fmt\include -IC:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\aten\src\ATen\..\..\..\third_party\cutlass\include -IC:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\aten\src\ATen\..\..\..\third_party\cutlass\tools\util\include -IC:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\build\caffe2\aten\src -IC:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\aten\src\ATen\.. -IC:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\c10\cuda\..\.. -IC:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\c10\.. -IC:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\torch\csrc\api -IC:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\torch\csrc\api\include -isystem C:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\build\third_party\gloo -isystem C:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\cmake\..\third_party\gloo -isystem C:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\cmake\..\third_party\googletest\googlemock\include -isystem C:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\cmake\..\third_party\googletest\googletest\include -isystem C:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\third_party\protobuf\src -isystem C:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\.ci\pytorch\windows\Python\Library\include -isystem C:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\third_party\XNNPACK\include -isystem C:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\third_party\ittapi\include -isystem C:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\cmake\..\third_party\eigen -isystem "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.9\include" -isystem C:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\third_party\ideep\mkl-dnn\include\oneapi\dnnl -isystem C:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\third_party\ideep\include -isystem C:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\INTERFACE -isystem C:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\third_party\nlohmann\include -isystem C:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\third_party\concurrentqueue -isystem C:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\third_party\NVTX\c\include -isystem C:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\cmake\..\third_party\cudnn_frontend\include -DLIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_OPERATIONS -Xcompiler  /Zc:__cplusplus -Xcompiler /w -w -Xcompiler /FS -Xfatbin -compress-all -DONNX_NAMESPACE=onnx_torch --use-local-env -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_90,code=sm_90 -gencode arch=compute_100,code=sm_100 -gencode arch=compute_120,code=sm_120 -Xcudafe --diag_suppress=cc_clobber_ignored,--diag_suppress=field_without_dll_interface,--diag_suppress=base_class_has_different_dll_interface,--diag_suppress=dll_interface_conflict_none_assumed,--diag_suppress=dll_interface_conflict_dllexport_assumed,--diag_suppress=bad_friend_decl --Werror cross-execution-space-call --no-host-device-move-forward --expt-relaxed-constexpr --expt-extended-lambda -Xfatbin -compress-all -Xcompiler=/wd4819,/wd4503,/wd4190,/wd4244,/wd4251,/wd4275,/wd4522 -Wno-deprecated-gpu-targets --expt-extended-lambda -DCUB_WRAPPED_NAMESPACE=at_cuda_detail -DCUDA_HAS_FP16=1 -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -Xcompiler="-O2 -Ob2" -DNDEBUG -Xcompiler /MD -std=c++17 -Xcompiler=-MD -DMKL_HAS_SBGEMM -DMKL_HAS_SHGEMM -DCAFFE2_USE_GLOO -MD -MT caffe2\CMakeFiles\torch_cuda.dir\__\aten\src\ATen\native\cuda\SegmentReduce.cu.obj -MF caffe2\CMakeFiles\torch_cuda.dir\__\aten\src\ATen\native\cuda\SegmentReduce.cu.obj.d -x cu -c C:\actions-runner\_work\pytorch-canary\pytorch-canary\pytorch\aten\src\ATen\native\cuda\SegmentReduce.cu -o caffe2\CMakeFiles\torch_cuda.dir\__\aten\src\ATen\native\cuda\SegmentReduce.cu.obj -Xcompiler=-Fdcaffe2\CMakeFiles\torch_cuda.dir\,-FS
2025-06-13T15:23:17.4498591Z LLVM ERROR: out of memory
2025-06-13T15:23:17.4499035Z SegmentReduce.cu
2025-06-13T15:23:17.4499607Z nvcc error   : '""%CICC_PATH%\cicc"' died with status 0xC0000409 
2025-06-13T15:23:17.4500502Z Retry attempt: 1
2025-06-13T15:23:17.4500895Z LLVM ERROR: out of memory
2025-06-13T15:23:17.4501337Z SegmentReduce.cu
```