### PR TITLE
[SetupPython] Rename argument

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -2,10 +2,9 @@ name: Setup Python macOS
 description: Install Homebrew Python if missing and create a temporary virtual environment.
 
 inputs:
-  version:
+  python-version:
     description: Python version to create venv for
-    required: false
-    default: 3.12
+    required: true
   pip-requirements-file:
     description: An optional pip requirements file to be installed in the conda environment
     required: false

--- a/.github/actions/setup-python/setup.js
+++ b/.github/actions/setup-python/setup.js
@@ -8,15 +8,21 @@ if (process.platform !== 'darwin') {
   process.exit(1);
 }
 
-const pythonVersion = process.env['INPUT_VERSION'] || '3.11';
+let pythonVersion = process.env['INPUT_PYTHON_VERSION'];
 const requirementsPath = process.env['INPUT_PIP-REQUIREMENTS-FILE'];
+
+if (pythonVersion.split('.').length > 2) {
+  console.log(`Warning: HomeBrew only supports version specified by major and minor, but got ${pythonVersion}`)
+  pythonVersion = pythonVersion.split('.', 2).join('.')
+}
 const formula = `python@${pythonVersion}`;
 
 const timestamp = Math.floor(Date.now() / 1000);
 const venvPath = path.join(process.env['RUNNER_TEMP'], `venv-${pythonVersion}-${timestamp}`);
 
+execSync('brew update', {stdio: 'inherit'});
 execSync(`brew install ${formula}`, {stdio: 'inherit'});
-const prefix = execSync(`brew --prefix`, {encoding: 'utf8'}).trim();
+const prefix = execSync('brew --prefix', {encoding: 'utf8'}).trim();
 const pythonBin = path.join(prefix, 'bin', `python${pythonVersion}`);
 
 console.log(`Using python at ${pythonBin} to create venv ${venvPath}`);
@@ -27,5 +33,6 @@ if (requirementsPath) {
   execSync(`"${venvPath}/bin/python" -m pip install -r "${requirementsPath}"`, {stdio: 'inherit'});
 }
 
+fs.appendFileSync(process.env['GITHUB_ENV'], `VENV_PATH=${venvPath}${os.EOL}`);
 fs.appendFileSync(process.env['GITHUB_PATH'], path.join(venvPath, 'bin') + os.EOL);
 fs.appendFileSync(process.env['GITHUB_STATE'], `venvPath=${venvPath}${os.EOL}`);

--- a/.github/workflows/test-setup-python.yml
+++ b/.github/workflows/test-setup-python.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-python
         with:
-          version: '3.12'
+          python-version: '3.11.5'
           pip-requirements-file: .github/workflows/test-pip-requirements-macOS.txt
       - name: Print env (including PATH)
         run: env


### PR DESCRIPTION
From `version` to `python-version` to better match the behavior of https://github.com/actions/setup-python

If `python-version` is provided as `major.minor.revision`, strip revision
Always run `brew update` as part of the action
Store venv path as `VENV_PATH` environment variable
