### PR TITLE
[Wiz Sensor] Fix typo in variable name

### DIFF
--- a/terraform-aws-github-runner/main.tf
+++ b/terraform-aws-github-runner/main.tf
@@ -211,8 +211,8 @@ module "runners_instances" {
 
   runner_iam_role_managed_policy_arns = var.runner_iam_role_managed_policy_arns
 
-  wiz_secrets_arn         = var.wiz_secrets_arn
-  wiz_secrets_kms_key_arn = var.wiz_secrets_kms_key_arn
+  wiz_secret_arn         = var.wiz_secret_arn
+  wiz_secret_kms_key_arn = var.wiz_secret_kms_key_arn
 
   ghes_url = var.ghes_url
 }

--- a/terraform-aws-github-runner/modules/runners-instances/launch-template.tf
+++ b/terraform-aws-github-runner/modules/runners-instances/launch-template.tf
@@ -122,7 +122,7 @@ resource "aws_launch_template" "linux_runner" {
     nvidia_driver_install           = false
     ssm_key_cloudwatch_agent_config = var.enable_cloudwatch_agent ? aws_ssm_parameter.cloudwatch_agent_config_runner_linux[0].name : ""
     ghes_url                        = var.ghes_url
-    wiz_secrets_arn                 = var.wiz_secrets_arn
+    wiz_secret_arn                  = var.wiz_secret_arn
     install_config_runner           = local.install_config_runner_linux
   }))
 
@@ -179,7 +179,7 @@ resource "aws_launch_template" "linux_runner_nvidia" {
     nvidia_driver_install           = true
     ssm_key_cloudwatch_agent_config = var.enable_cloudwatch_agent ? aws_ssm_parameter.cloudwatch_agent_config_runner_linux[0].name : ""
     ghes_url                        = var.ghes_url
-    wiz_secrets_arn                 = var.wiz_secrets_arn
+    wiz_secret_arn                  = var.wiz_secret_arn
     install_config_runner           = local.install_config_runner_linux
   }))
 
@@ -236,7 +236,7 @@ resource "aws_launch_template" "linux_arm64_runner" {
     nvidia_driver_install           = false
     ssm_key_cloudwatch_agent_config = var.enable_cloudwatch_agent ? aws_ssm_parameter.cloudwatch_agent_config_runner_linux_arm64[0].name : ""
     ghes_url                        = var.ghes_url
-    wiz_secrets_arn                 = var.wiz_secrets_arn
+    wiz_secret_arn                  = var.wiz_secret_arn
     install_config_runner           = local.install_config_runner_linux_arm64
   }))
 

--- a/terraform-aws-github-runner/modules/runners-instances/policies-runner.tf
+++ b/terraform-aws-github-runner/modules/runners-instances/policies-runner.tf
@@ -54,18 +54,18 @@ resource "aws_iam_role_policy" "create_tags" {
   policy = file("${path.module}/policies/instance-ec2-create-tags-policy.json")
 }
 
-# This policy is conditionally created only when wiz_secrets_arn is provided.
+# This policy is conditionally created only when wiz_secret_arn is provided.
 # This ensures we don't create empty policies when no secret access is needed,
 # making the security configuration more explicit and reducing IAM clutter.
 resource "aws_iam_role_policy" "secrets_access" {
-  count  = var.wiz_secrets_arn != null ? 1 : 0
+  count  = var.wiz_secret_arn != null ? 1 : 0
   name   = "runner-secrets-access"
   role   = aws_iam_role.runner.name
 
   lifecycle {
     precondition {
-      condition     = var.wiz_secrets_arn == null || var.wiz_secrets_kms_key_arn != null
-      error_message = "wiz_secrets_kms_key_arn must be provided when wiz_secrets_arn is specified. The secret requires explicit KMS key permissions for decryption."
+      condition     = var.wiz_secret_arn == null || var.wiz_secret_kms_key_arn != null
+      error_message = "wiz_secret_kms_key_arn must be provided when wiz_secret_arn is specified. The secret requires explicit KMS key permissions for decryption."
     }
   }
 
@@ -76,9 +76,9 @@ resource "aws_iam_role_policy" "secrets_access" {
       # (e.g., "MySecret" becomes "MySecret-a1b2c3")
       # We use "-??????" to match the format exactly, which is more secure than "*"
       # This handles cases where users provide bare secret names or already-complete ARNs
-      secrets_arn = endswith(var.wiz_secrets_arn, "*") || can(regex("-[a-zA-Z0-9]{6}$", var.wiz_secrets_arn)) ? var.wiz_secrets_arn : "${var.wiz_secrets_arn}-??????"
+      secrets_arn = endswith(var.wiz_secret_arn, "*") || can(regex("-[a-zA-Z0-9]{6}$", var.wiz_secret_arn)) ? var.wiz_secret_arn : "${var.wiz_secret_arn}-??????"
       # KMS key ARN for decrypting the secret - must be provided when secret is specified
-      kms_key_arn = var.wiz_secrets_kms_key_arn
+      kms_key_arn = var.wiz_secret_kms_key_arn
       aws_region = var.aws_region
     }
   )

--- a/terraform-aws-github-runner/modules/runners-instances/variables.tf
+++ b/terraform-aws-github-runner/modules/runners-instances/variables.tf
@@ -196,14 +196,14 @@ variable "key_name" {
   default     = null
 }
 
-variable "wiz_secrets_arn" {
+variable "wiz_secret_arn" {
   description = "ARN of AWS Secrets Manager secret that the runner role should have access to"
   type        = string
   sensitive   = true
 }
 
-variable "wiz_secrets_kms_key_arn" {
-  description = "ARN of KMS key used to encrypt the secret specified in wiz_secrets_arn. Must be provided if wiz_secrets_arn is specified."
+variable "wiz_secret_kms_key_arn" {
+  description = "ARN of KMS key used to encrypt the secret specified in wiz_secret_arn. Must be provided if wiz_secret_arn is specified."
   type        = string
   sensitive   = true
 }

--- a/terraform-aws-github-runner/variables.tf
+++ b/terraform-aws-github-runner/variables.tf
@@ -374,15 +374,15 @@ variable "retry_scale_up_chron_hud_query_url" {
   default     = ""
 }
 
-variable "wiz_secrets_arn" {
+variable "wiz_secret_arn" {
   description = "ARN of AWS Secrets Manager secret that the runner role should have access to"
   type        = string
   default     = null
   sensitive   = true
 }
 
-variable "wiz_secrets_kms_key_arn" {
-  description = "ARN of KMS key used to encrypt the secret specified in wiz_secrets_arn. Must be provided if wiz_secrets_arn is specified."
+variable "wiz_secret_kms_key_arn" {
+  description = "ARN of KMS key used to encrypt the secret specified in wiz_secret_arn. Must be provided if wiz_secret_arn is specified."
   type        = string
   default     = null
   sensitive   = true


### PR DESCRIPTION
Realized the variable name had accidentally left in the plural form instead of singular.

This is a safe change to make right now since this variable doesn't actually have a value passed in to it yet