### PR TITLE
[BE] Make upload-benchmark-results use v3 by default

### DIFF
--- a/.github/actions/upload-benchmark-results/action.yml
+++ b/.github/actions/upload-benchmark-results/action.yml
@@ -6,9 +6,8 @@ inputs:
     required: True
   dry-run:
     default: 'true'
-  # TODO (huydhn): Use this to gate the migration to oss_ci_benchmark_v3 on S3
   schema-version:
-    default: 'v2'
+    default: 'v3'
   github-token:
     default: ''
 
@@ -19,10 +18,9 @@ runs:
       shell: bash
       run: |
         set -eux
-        python3 -mpip install boto3==1.35.33 psutil==7.0.0 pynvml==12.0.0
+        python3 -mpip install boto3==1.35.33 psutil==7.0.0 pynvml==12.0.0 torch
 
     - name: Check that GITHUB_TOKEN is defined
-      if: ${{ inputs.schema-version != 'v2' }}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       shell: bash


### PR DESCRIPTION
Also install `torch` as one of the script needs it to get the runner info.  I will figure out a way to do this later without the need to install `torch`