### PR TITLE
Add Windows memory optimized r5n.4xlarge instance

### DIFF
--- a/.github/canary-scale-config.yml
+++ b/.github/canary-scale-config.yml
@@ -214,6 +214,22 @@ runner_types:
     variants:
       wincanary:
         ami: Windows 2019 GHA CI - 20250526202723
+  c.windows.4xlarge.memory:
+    disk_size: 256
+    instance_type: r5n.4xlarge
+    is_ephemeral: true
+    os: windows
+    variants:
+      wincanary:
+        ami: Windows 2019 GHA CI - 20250526202723
+  c.windows.4xlarge.memory.nonephemeral:
+    disk_size: 256
+    instance_type: r5n.4xlarge
+    is_ephemeral: true
+    os: windows
+    variants:
+      wincanary:
+        ami: Windows 2019 GHA CI - 20250526202723
   c.windows.9xlarge:
     disk_size: 256
     instance_type: c5d.9xlarge

--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -214,6 +214,22 @@ runner_types:
     variants:
       wincanary:
         ami: Windows 2019 GHA CI - 20250526202723
+  lf.c.windows.4xlarge.memory:
+    disk_size: 256
+    instance_type: r5n.4xlarge
+    is_ephemeral: true
+    os: windows
+    variants:
+      wincanary:
+        ami: Windows 2019 GHA CI - 20250526202723
+  lf.c.windows.4xlarge.memory.nonephemeral:
+    disk_size: 256
+    instance_type: r5n.4xlarge
+    is_ephemeral: true
+    os: windows
+    variants:
+      wincanary:
+        ami: Windows 2019 GHA CI - 20250526202723
   lf.c.windows.9xlarge:
     disk_size: 256
     instance_type: c5d.9xlarge

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -214,6 +214,22 @@ runner_types:
     variants:
       wincanary:
         ami: Windows 2019 GHA CI - 20250526202723
+  lf.windows.4xlarge.memory:
+    disk_size: 256
+    instance_type: r5n.4xlarge
+    is_ephemeral: true
+    os: windows
+    variants:
+      wincanary:
+        ami: Windows 2019 GHA CI - 20250526202723
+  lf.windows.4xlarge.memory.nonephemeral:
+    disk_size: 256
+    instance_type: r5n.4xlarge
+    is_ephemeral: true
+    os: windows
+    variants:
+      wincanary:
+        ami: Windows 2019 GHA CI - 20250526202723
   lf.windows.9xlarge:
     disk_size: 256
     instance_type: c5d.9xlarge

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -210,6 +210,22 @@ runner_types:
     variants:
       wincanary:
         ami: Windows 2019 GHA CI - 20250526202723
+  windows.4xlarge.memory:
+    disk_size: 256
+    instance_type: r5n.4xlarge
+    is_ephemeral: true
+    os: windows
+    variants:
+      wincanary:
+        ami: Windows 2019 GHA CI - 20250526202723
+  windows.4xlarge.memory.nonephemeral:
+    disk_size: 256
+    instance_type: r5n.4xlarge
+    is_ephemeral: true
+    os: windows
+    variants:
+      wincanary:
+        ami: Windows 2019 GHA CI - 20250526202723
   windows.9xlarge:
     disk_size: 256
     instance_type: c5d.9xlarge


### PR DESCRIPTION
Testing r5n.4xlarge instance, the price per hour for this instance is lower then c.windows.9xlarge however it has more memory