### PR TITLE
[HUD] Make GH incident banner style closer to sev report style

### DIFF
--- a/torchci/components/githubIncident/GithubIncident.tsx
+++ b/torchci/components/githubIncident/GithubIncident.tsx
@@ -1,7 +1,6 @@
-"use client";
-
 import styled from "@mui/system/styled";
 import useSWR from "swr";
+import styles from "../SevReport.module.css";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 export default function GitHubIncidentBanner() {
@@ -23,25 +22,18 @@ export default function GitHubIncidentBanner() {
     : null;
 
   return (
-    <Banner>
+    <div
+      className={styles.sevBox}
+      style={{ backgroundColor: "var(--background-color)" }}
+    >
       <Title>GitHub Incident:</Title> {incident.name}
       {lastUpdateDate && <> — Updated: {lastUpdateDate}</>}{" "}
       <a href={incident.shortlink} target="_blank" rel="noreferrer">
         (link)
       </a>
-    </Banner>
+    </div>
   );
 }
-
-const Banner = styled("div")({
-  fontSize: "0.875rem",
-  color: "#666",
-  padding: "6px 12px",
-  borderRadius: "4px",
-  marginBottom: "8px",
-  display: "inline-block",
-  outline: "1px solid #ccc",
-});
 
 const Title = styled("span")({
   fontWeight: 600,


### PR DESCRIPTION
Purely a personal preference thing

Makes the gh incident banner more like the sev report banner

Old 
![image](https://github.com/user-attachments/assets/2e91979f-7a2e-4b5c-b593-76b955dc410d)

New
![image](https://github.com/user-attachments/assets/113c0792-10c1-4001-af58-337f3a84522b)
