### PR TITLE
[TD] Fix file ratings workflow: upgrade boto3, make query faster, timezone api deprecation

### DIFF
--- a/.github/workflows/update_test_file_ratings.yml
+++ b/.github/workflows/update_test_file_ratings.yml
@@ -36,11 +36,11 @@ jobs:
           cd test-infra/tools/torchci
           pip3 install -e .
 
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
-        with:
-          role-to-assume: arn:aws:iam::308535385114:role/upload_to_ossci_raw_job_status
-          aws-region: us-east-1
+      # - name: configure aws credentials
+      #   uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
+      #   with:
+      #     role-to-assume: arn:aws:iam::308535385114:role/upload_to_ossci_raw_job_status
+      #     aws-region: us-east-1
 
       - name: Get merge base info
         run: |

--- a/.github/workflows/update_test_file_ratings.yml
+++ b/.github/workflows/update_test_file_ratings.yml
@@ -1,6 +1,7 @@
 name: Update test file ratings for TD Heuristics
 
 on:
+  push:
   schedule:
     - cron: 5 11 * * *  # At 11:05 UTC every day or about 4am PT
 
@@ -31,7 +32,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pip3 install --upgrade pip
-          pip3 install boto3==1.19.12 clickhouse-connect==0.8.14
+          pip3 install boto3==1.35.42 clickhouse-connect==0.8.14
           cd test-infra/tools/torchci
           pip3 install -e .
 

--- a/.github/workflows/update_test_file_ratings.yml
+++ b/.github/workflows/update_test_file_ratings.yml
@@ -1,7 +1,6 @@
 name: Update test file ratings for TD Heuristics
 
 on:
-  push:
   schedule:
     - cron: 5 11 * * *  # At 11:05 UTC every day or about 4am PT
 
@@ -36,11 +35,11 @@ jobs:
           cd test-infra/tools/torchci
           pip3 install -e .
 
-      # - name: configure aws credentials
-      #   uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
-      #   with:
-      #     role-to-assume: arn:aws:iam::308535385114:role/upload_to_ossci_raw_job_status
-      #     aws-region: us-east-1
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/upload_to_ossci_raw_job_status
+          aws-region: us-east-1
 
       - name: Get merge base info
         run: |

--- a/tools/torchci/td/get_merge_base_info.py
+++ b/tools/torchci/td/get_merge_base_info.py
@@ -92,14 +92,14 @@ def upload_merge_base_info(shas: List[str]) -> None:
             }
             body = io.StringIO()
             json.dump(data, body)
-            # S3_RESOURCE.Object(
-            #     f"ossci-raw-job-status",
-            #     f"merge_bases/pytorch/pytorch/{sha}.gzip",
-            # ).put(
-            #     Body=gzip.compress(body.getvalue().encode()),
-            #     ContentEncoding="gzip",
-            #     ContentType="application/json",
-            # )
+            S3_RESOURCE.Object(
+                f"ossci-raw-job-status",
+                f"merge_bases/pytorch/pytorch/{sha}.gzip",
+            ).put(
+                Body=gzip.compress(body.getvalue().encode()),
+                ContentEncoding="gzip",
+                ContentType="application/json",
+            )
         except Exception as e:
             return
 

--- a/tools/torchci/td/get_merge_base_info.py
+++ b/tools/torchci/td/get_merge_base_info.py
@@ -16,14 +16,27 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 S3_RESOURCE = boto3.resource("s3")
 
 FAILED_TEST_SHAS_QUERY = """
+with job_ids as (
+    SELECT
+        DISTINCT t.job_id
+    FROM
+        default .failed_test_runs t
+    where
+        t.time_inserted > CURRENT_TIMESTAMP() - interval 90 days
+)
 SELECT
     DISTINCT j.head_sha as head_sha
 FROM
-    default.failed_test_runs t
-    join default.workflow_job j on t.job_id = j.id
-    left anti join default.merge_bases mb on j.head_sha = mb.sha
+    job_ids
+    join default .workflow_job j on job_ids.job_id = j.id left anti
+    join default .merge_bases mb on j.head_sha = mb.sha
 where
-    t.time_inserted > CURRENT_TIMESTAMP() - interval 90 days
+    j.id in (
+        select
+            job_id
+        from
+            job_ids
+    )
 """
 
 NOT_IN_MERGE_BASES_TABLE = """

--- a/tools/torchci/td/get_merge_base_info.py
+++ b/tools/torchci/td/get_merge_base_info.py
@@ -1,8 +1,7 @@
+import datetime
 import gzip
 import io
 import json
-import subprocess
-import datetime
 from pathlib import Path
 from typing import List
 
@@ -77,7 +76,12 @@ def upload_merge_base_info(shas: List[str]) -> None:
             unix_timestamp = run_command(
                 f"git show --no-patch --format=%ct {merge_base}"
             )
-            timestamp = datetime.datetime.fromtimestamp(int(unix_timestamp), tz=datetime.timezone.utc).isoformat() + "Z"
+            timestamp = (
+                datetime.datetime.fromtimestamp(
+                    int(unix_timestamp), tz=datetime.timezone.utc
+                ).isoformat()
+                + "Z"
+            )
             data = {
                 "sha": sha,
                 "merge_base": merge_base,

--- a/tools/torchci/td/get_merge_base_info.py
+++ b/tools/torchci/td/get_merge_base_info.py
@@ -76,11 +76,9 @@ def upload_merge_base_info(shas: List[str]) -> None:
             unix_timestamp = run_command(
                 f"git show --no-patch --format=%ct {merge_base}"
             )
-            timestamp = (
-                datetime.datetime.fromtimestamp(
-                    int(unix_timestamp), tz=datetime.timezone.utc
-                ).isoformat()
-            )
+            timestamp = datetime.datetime.fromtimestamp(
+                int(unix_timestamp), tz=datetime.timezone.utc
+            ).isoformat()
             data = {
                 "sha": sha,
                 "merge_base": merge_base,

--- a/tools/torchci/td/get_merge_base_info.py
+++ b/tools/torchci/td/get_merge_base_info.py
@@ -20,7 +20,7 @@ SELECT
     DISTINCT j.head_sha as head_sha
 FROM
     default.failed_test_runs t
-    join default.workflow_job j final on t.job_id = j.id
+    join default.workflow_job j on t.job_id = j.id
     left anti join default.merge_bases mb on j.head_sha = mb.sha
 where
     t.time_inserted > CURRENT_TIMESTAMP() - interval 90 days

--- a/tools/torchci/td/get_merge_base_info.py
+++ b/tools/torchci/td/get_merge_base_info.py
@@ -80,7 +80,6 @@ def upload_merge_base_info(shas: List[str]) -> None:
                 datetime.datetime.fromtimestamp(
                     int(unix_timestamp), tz=datetime.timezone.utc
                 ).isoformat()
-                + "Z"
             )
             data = {
                 "sha": sha,

--- a/tools/torchci/td/get_merge_base_info.py
+++ b/tools/torchci/td/get_merge_base_info.py
@@ -2,7 +2,7 @@ import gzip
 import io
 import json
 import subprocess
-from datetime import datetime
+import datetime
 from pathlib import Path
 from typing import List
 
@@ -64,7 +64,7 @@ def upload_merge_base_info(shas: List[str]) -> None:
             unix_timestamp = run_command(
                 f"git show --no-patch --format=%ct {merge_base}"
             )
-            timestamp = datetime.utcfromtimestamp(int(unix_timestamp)).isoformat() + "Z"
+            timestamp = datetime.datetime.fromtimestamp(int(unix_timestamp), tz=datetime.timezone.utc).isoformat() + "Z"
             data = {
                 "sha": sha,
                 "merge_base": merge_base,

--- a/tools/torchci/td/get_merge_base_info.py
+++ b/tools/torchci/td/get_merge_base_info.py
@@ -75,14 +75,14 @@ def upload_merge_base_info(shas: List[str]) -> None:
             }
             body = io.StringIO()
             json.dump(data, body)
-            S3_RESOURCE.Object(
-                f"ossci-raw-job-status",
-                f"merge_bases/pytorch/pytorch/{sha}.gzip",
-            ).put(
-                Body=gzip.compress(body.getvalue().encode()),
-                ContentEncoding="gzip",
-                ContentType="application/json",
-            )
+            # S3_RESOURCE.Object(
+            #     f"ossci-raw-job-status",
+            #     f"merge_bases/pytorch/pytorch/{sha}.gzip",
+            # ).put(
+            #     Body=gzip.compress(body.getvalue().encode()),
+            #     ContentEncoding="gzip",
+            #     ContentType="application/json",
+            # )
         except Exception as e:
             return
 


### PR DESCRIPTION
Fix TD file ratings workflow
Example failure:
https://github.com/pytorch/test-infra/actions/runs/15731225202

* upgrade boto3
* make query faster/use less memory
* timezone api is getting deprecated, remove it

Testing:added trigger on push. I saw that the workflow started but it's pretty long so I didn't wait for the entire thing

Might be an issue wrt the timezone thing, I think the format changed