### PR TITLE
Use windows.8xlarge.memory, remove unused instance windows.9xlarge

### DIFF
--- a/.github/canary-scale-config.yml
+++ b/.github/canary-scale-config.yml
@@ -214,33 +214,17 @@ runner_types:
     variants:
       wincanary:
         ami: Windows 2019 GHA CI - 20250526202723
-  c.windows.4xlarge.memory:
+  c.windows.8xlarge.memory:
     disk_size: 256
-    instance_type: r5n.4xlarge
+    instance_type: r5n.8xlarge
     is_ephemeral: true
     os: windows
     variants:
       wincanary:
         ami: Windows 2019 GHA CI - 20250526202723
-  c.windows.4xlarge.memory.nonephemeral:
+  c.windows.8xlarge.memory.nonephemeral:
     disk_size: 256
-    instance_type: r5n.4xlarge
-    is_ephemeral: true
-    os: windows
-    variants:
-      wincanary:
-        ami: Windows 2019 GHA CI - 20250526202723
-  c.windows.9xlarge:
-    disk_size: 256
-    instance_type: c5d.9xlarge
-    is_ephemeral: true
-    os: windows
-    variants:
-      wincanary:
-        ami: Windows 2019 GHA CI - 20250526202723
-  c.windows.9xlarge.nonephemeral:
-    disk_size: 256
-    instance_type: c5d.9xlarge
+    instance_type: r5n.8xlarge
     is_ephemeral: true
     os: windows
     variants:

--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -214,33 +214,17 @@ runner_types:
     variants:
       wincanary:
         ami: Windows 2019 GHA CI - 20250526202723
-  lf.c.windows.4xlarge.memory:
+  lf.c.windows.8xlarge.memory:
     disk_size: 256
-    instance_type: r5n.4xlarge
+    instance_type: r5n.8xlarge
     is_ephemeral: true
     os: windows
     variants:
       wincanary:
         ami: Windows 2019 GHA CI - 20250526202723
-  lf.c.windows.4xlarge.memory.nonephemeral:
+  lf.c.windows.8xlarge.memory.nonephemeral:
     disk_size: 256
-    instance_type: r5n.4xlarge
-    is_ephemeral: true
-    os: windows
-    variants:
-      wincanary:
-        ami: Windows 2019 GHA CI - 20250526202723
-  lf.c.windows.9xlarge:
-    disk_size: 256
-    instance_type: c5d.9xlarge
-    is_ephemeral: true
-    os: windows
-    variants:
-      wincanary:
-        ami: Windows 2019 GHA CI - 20250526202723
-  lf.c.windows.9xlarge.nonephemeral:
-    disk_size: 256
-    instance_type: c5d.9xlarge
+    instance_type: r5n.8xlarge
     is_ephemeral: true
     os: windows
     variants:

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -214,33 +214,17 @@ runner_types:
     variants:
       wincanary:
         ami: Windows 2019 GHA CI - 20250526202723
-  lf.windows.4xlarge.memory:
+  lf.windows.8xlarge.memory:
     disk_size: 256
-    instance_type: r5n.4xlarge
+    instance_type: r5n.8xlarge
     is_ephemeral: true
     os: windows
     variants:
       wincanary:
         ami: Windows 2019 GHA CI - 20250526202723
-  lf.windows.4xlarge.memory.nonephemeral:
+  lf.windows.8xlarge.memory.nonephemeral:
     disk_size: 256
-    instance_type: r5n.4xlarge
-    is_ephemeral: true
-    os: windows
-    variants:
-      wincanary:
-        ami: Windows 2019 GHA CI - 20250526202723
-  lf.windows.9xlarge:
-    disk_size: 256
-    instance_type: c5d.9xlarge
-    is_ephemeral: true
-    os: windows
-    variants:
-      wincanary:
-        ami: Windows 2019 GHA CI - 20250526202723
-  lf.windows.9xlarge.nonephemeral:
-    disk_size: 256
-    instance_type: c5d.9xlarge
+    instance_type: r5n.8xlarge
     is_ephemeral: true
     os: windows
     variants:

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -210,33 +210,17 @@ runner_types:
     variants:
       wincanary:
         ami: Windows 2019 GHA CI - 20250526202723
-  windows.4xlarge.memory:
+  windows.8xlarge.memory:
     disk_size: 256
-    instance_type: r5n.4xlarge
+    instance_type: r5n.8xlarge
     is_ephemeral: true
     os: windows
     variants:
       wincanary:
         ami: Windows 2019 GHA CI - 20250526202723
-  windows.4xlarge.memory.nonephemeral:
+  windows.8xlarge.memory.nonephemeral:
     disk_size: 256
-    instance_type: r5n.4xlarge
-    is_ephemeral: true
-    os: windows
-    variants:
-      wincanary:
-        ami: Windows 2019 GHA CI - 20250526202723
-  windows.9xlarge:
-    disk_size: 256
-    instance_type: c5d.9xlarge
-    is_ephemeral: true
-    os: windows
-    variants:
-      wincanary:
-        ami: Windows 2019 GHA CI - 20250526202723
-  windows.9xlarge.nonephemeral:
-    disk_size: 256
-    instance_type: c5d.9xlarge
+    instance_type: r5n.8xlarge
     is_ephemeral: true
     os: windows
     variants:


### PR DESCRIPTION
Windows.9xlarge was added by https://github.com/pytorch/test-infra/pull/6759 and currently not used
Memory optimized r5n.4xlarge add by https://github.com/pytorch/test-infra/pull/6774 is not enough trying with 8xlarge
Error: https://github.com/pytorch/pytorch/actions/runs/15758396612/job/44418951066?pr=156179