### PR TITLE
Fix gather_runners_info script on ROCm

### DIFF
--- a/.github/actions/upload-benchmark-results/action.yml
+++ b/.github/actions/upload-benchmark-results/action.yml
@@ -18,7 +18,15 @@ runs:
       shell: bash
       run: |
         set -eux
-        python3 -mpip install boto3==1.35.33 psutil==7.0.0 pynvml==12.0.0 torch
+
+        python3 -mpip install boto3==1.35.33 psutil==7.0.0 pynvml==12.0.0
+        # NB: I'm using PyTorch here to get the device name, however, it needs to
+        # install the correct version of PyTorch manually for now
+        if command -v nvidia-smi; then
+          python3 -mpip install torch
+        elif command -v amd-smi; then
+          python3 -mpip install torch --index-url https://download.pytorch.org/whl/rocm6.3
+        fi
 
     - name: Check that GITHUB_TOKEN is defined
       env:


### PR DESCRIPTION
The script only works correctly with the proper PyTorch version built for ROCm