### PR TITLE
Move TorchAgent bug & feature buttons to header icons

### DIFF
--- a/torchci/components/TorchAgentPage.tsx
+++ b/torchci/components/TorchAgentPage.tsx
@@ -870,26 +870,6 @@ export const TorchAgentPage = () => {
               )}
             </ResultsSection>
 
-            <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 2 }}>
-              <Button
-                variant="outlined"
-                component="a"
-                href={featureRequestUrl}
-                target="_blank"
-                sx={{ mr: 1 }}
-              >
-                Feature Request
-              </Button>
-              <Button
-                variant="outlined"
-                color="error"
-                component="a"
-                href={bugReportUrl}
-                target="_blank"
-              >
-                Report Bug
-              </Button>
-            </Box>
           </TorchAgentPageContainer>
         )}
       </Box>

--- a/torchci/components/TorchAgentPage/HeaderSection.tsx
+++ b/torchci/components/TorchAgentPage/HeaderSection.tsx
@@ -1,4 +1,6 @@
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
+import BugReportIcon from "@mui/icons-material/BugReport";
+import LightbulbIcon from "@mui/icons-material/Lightbulb";
 import { Box, Button, Tooltip, Typography } from "@mui/material";
 import React from "react";
 import { ScrollToBottomButton } from "./styles";
@@ -36,24 +38,29 @@ export const HeaderSection: React.FC<HeaderSectionProps> = ({
       </Typography>
 
       <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 2 }}>
-        <Button
-          variant="outlined"
-          component="a"
-          href={featureRequestUrl}
-          target="_blank"
-          sx={{ mr: 1 }}
-        >
-          Feature Request
-        </Button>
-        <Button
-          variant="outlined"
-          color="error"
-          component="a"
-          href={bugReportUrl}
-          target="_blank"
-        >
-          Report Bug
-        </Button>
+        <Tooltip title="Create feature request">
+          <Button
+            variant="outlined"
+            component="a"
+            href={featureRequestUrl}
+            target="_blank"
+            sx={{ mr: 1, minWidth: "auto", p: 1 }}
+          >
+            <LightbulbIcon />
+          </Button>
+        </Tooltip>
+        <Tooltip title="Report bug">
+          <Button
+            variant="outlined"
+            color="error"
+            component="a"
+            href={bugReportUrl}
+            target="_blank"
+            sx={{ minWidth: "auto", p: 1 }}
+          >
+            <BugReportIcon />
+          </Button>
+        </Tooltip>
       </Box>
     </>
   );


### PR DESCRIPTION
## Summary
- move bug/feature buttons from bottom of page to the HeaderSection
- use icon-only MUI buttons with tooltips

## Testing
- `yarn lint`
- `yarn test` *(fails: trigger-circleci-workflows tests)*

------
https://chatgpt.com/codex/tasks/task_e_6853c09725a08333977dbaea7be70a3e