### PR TITLE
Improve TorchAgent mobile sidebar

### DIFF
--- a/torchci/components/TorchAgentPage.tsx
+++ b/torchci/components/TorchAgentPage.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Typography, useTheme } from "@mui/material";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import { useSession } from "next-auth/react";
 import { useEffect, useRef, useState } from "react";
 import AISpinner from "./AISpinner";
@@ -62,6 +63,7 @@ const hasAuthCookie = () => {
 export const TorchAgentPage = () => {
   const session = useSession();
   const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   const featureRequestUrl =
     "https://github.com/pytorch/test-infra/issues/new?title=" +
@@ -99,7 +101,7 @@ export const TorchAgentPage = () => {
   const [selectedSession, setSelectedSession] = useState<string | null>(null);
   const [isHistoryLoading, setIsHistoryLoading] = useState(false);
   const [isSessionLoading, setIsSessionLoading] = useState(false);
-  const [drawerOpen, setDrawerOpen] = useState(true);
+  const [drawerOpen, setDrawerOpen] = useState(!isMobile);
 
   const fetchControllerRef = useRef<AbortController | null>(null);
 
@@ -109,8 +111,16 @@ export const TorchAgentPage = () => {
   const { showScrollButton, scrollToBottomAndEnable, resetAutoScroll } =
     useAutoScroll(isLoading, parsedResponses);
 
+  useEffect(() => {
+    setDrawerOpen(!isMobile);
+  }, [isMobile]);
+
   const handleQueryChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setQuery(event.target.value);
+  };
+
+  const handleToggleDrawer = () => {
+    setDrawerOpen((prev) => !prev);
   };
 
   // Fetch chat history on component mount
@@ -748,6 +758,8 @@ export const TorchAgentPage = () => {
         isHistoryLoading={isHistoryLoading}
         onStartNewChat={startNewChat}
         onLoadChatSession={loadChatSession}
+        isMobile={isMobile}
+        onClose={handleToggleDrawer}
       />
 
       {/* Main Content */}
@@ -761,6 +773,7 @@ export const TorchAgentPage = () => {
               onScrollToBottom={scrollToBottomAndEnable}
               featureRequestUrl={featureRequestUrl}
               bugReportUrl={bugReportUrl}
+              onToggleDrawer={handleToggleDrawer}
             />
 
             {/* Show welcome message for completely new chats */}

--- a/torchci/components/TorchAgentPage/ChatHistorySidebar.tsx
+++ b/torchci/components/TorchAgentPage/ChatHistorySidebar.tsx
@@ -33,6 +33,8 @@ interface ChatHistorySidebarProps {
   isHistoryLoading: boolean;
   onStartNewChat: () => void;
   onLoadChatSession: (sessionId: string) => void;
+  isMobile: boolean;
+  onClose: () => void;
 }
 
 export const ChatHistorySidebar: React.FC<ChatHistorySidebarProps> = ({
@@ -43,19 +45,22 @@ export const ChatHistorySidebar: React.FC<ChatHistorySidebarProps> = ({
   isHistoryLoading,
   onStartNewChat,
   onLoadChatSession,
+  isMobile,
+  onClose,
 }) => {
   return (
     <Drawer
-      variant="persistent"
+      variant={isMobile ? "temporary" : "persistent"}
       anchor="left"
       open={drawerOpen}
+      onClose={onClose}
       sx={{
         width: sidebarWidth,
         flexShrink: 0,
         "& .MuiDrawer-paper": {
           width: sidebarWidth,
           boxSizing: "border-box",
-          position: "relative",
+          position: isMobile ? "fixed" : "relative",
           height: "100%",
         },
       }}

--- a/torchci/components/TorchAgentPage/HeaderSection.tsx
+++ b/torchci/components/TorchAgentPage/HeaderSection.tsx
@@ -1,5 +1,6 @@
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
-import { Box, Button, Tooltip, Typography } from "@mui/material";
+import MenuIcon from "@mui/icons-material/Menu";
+import { Box, Button, IconButton, Tooltip, Typography, useMediaQuery, useTheme } from "@mui/material";
 import React from "react";
 import { ScrollToBottomButton } from "./styles";
 
@@ -8,6 +9,7 @@ interface HeaderSectionProps {
   onScrollToBottom: () => void;
   featureRequestUrl: string;
   bugReportUrl: string;
+  onToggleDrawer: () => void;
 }
 
 export const HeaderSection: React.FC<HeaderSectionProps> = ({
@@ -15,7 +17,10 @@ export const HeaderSection: React.FC<HeaderSectionProps> = ({
   onScrollToBottom,
   featureRequestUrl,
   bugReportUrl,
+  onToggleDrawer,
 }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   return (
     <>
       {showScrollButton && (
@@ -31,29 +36,38 @@ export const HeaderSection: React.FC<HeaderSectionProps> = ({
         </Tooltip>
       )}
 
-      <Typography variant="h4" gutterBottom>
-        TorchAgent
-      </Typography>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 2 }}>
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          {isMobile && (
+            <IconButton onClick={onToggleDrawer} sx={{ mr: 1 }}>
+              <MenuIcon />
+            </IconButton>
+          )}
+          <Typography variant="h4" gutterBottom sx={{ mb: 0 }}>
+            TorchAgent
+          </Typography>
+        </Box>
 
-      <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 2 }}>
-        <Button
-          variant="outlined"
-          component="a"
-          href={featureRequestUrl}
-          target="_blank"
-          sx={{ mr: 1 }}
-        >
-          Feature Request
-        </Button>
-        <Button
-          variant="outlined"
-          color="error"
-          component="a"
-          href={bugReportUrl}
-          target="_blank"
-        >
-          Report Bug
-        </Button>
+        <Box>
+          <Button
+            variant="outlined"
+            component="a"
+            href={featureRequestUrl}
+            target="_blank"
+            sx={{ mr: 1 }}
+          >
+            Feature Request
+          </Button>
+          <Button
+            variant="outlined"
+            color="error"
+            component="a"
+            href={bugReportUrl}
+            target="_blank"
+          >
+            Report Bug
+          </Button>
+        </Box>
       </Box>
     </>
   );


### PR DESCRIPTION
## Summary
- make TorchAgent header show menu button on mobile
- support temporary drawer variant on small screens
- default the sidebar to collapsed on mobile

## Testing
- `yarn lint`
- `yarn test` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6853c106e36c8333a92cbcf33c4e6fe5