### PR TITLE
Revert "Fix gather_runners_info script on ROCm (#6799)"

### DIFF
--- a/.github/actions/upload-benchmark-results/action.yml
+++ b/.github/actions/upload-benchmark-results/action.yml
@@ -18,16 +18,7 @@ runs:
       shell: bash
       run: |
         set -eux
-
-        python3 -mpip install boto3==1.35.33 psutil==7.0.0 pynvml==12.0.0
-        # NB: I'm using PyTorch here to get the device name, however, it needs to
-        # install the correct version of PyTorch manually for now. Any PyTorch
-        # version is fine, I just use 2.7.1 to satify PYPIDEP linter
-        if command -v nvidia-smi; then
-          python3 -mpip install torch==2.7.1
-        elif command -v amd-smi; then
-          python3 -mpip install torch==2.7.1 --index-url https://download.pytorch.org/whl/rocm6.3
-        fi
+        python3 -mpip install boto3==1.35.33 psutil==7.0.0 pynvml==12.0.0 torch
 
     - name: Check that GITHUB_TOKEN is defined
       env:


### PR DESCRIPTION
This reverts commit 007e89b16033f8c484a190b805434e0a607f9fd3.

This is the first time I see a memory error with pip https://github.com/pytorch/pytorch/actions/runs/15767425131/job/44447322381