### PR TITLE
[Reland] Fix gather_runners_info script on ROCm

### DIFF
--- a/.github/actions/upload-benchmark-results/action.yml
+++ b/.github/actions/upload-benchmark-results/action.yml
@@ -18,7 +18,27 @@ runs:
       shell: bash
       run: |
         set -eux
-        python3 -mpip install boto3==1.35.33 psutil==7.0.0 pynvml==12.0.0 torch
+        python3 -mpip install boto3==1.35.33 psutil==7.0.0 pynvml==12.0.0
+
+        DEVICE_NAME=""
+        DEVICE_TYPE=""
+
+        if command -v nvidia-smi; then
+          # NB: I'm using PyTorch here to get the device name, however, it needs to
+          # install the correct version of PyTorch manually for now. Any PyTorch
+          # version is fine, I just use 2.7.1 to satify PYPIDEP linter
+          python3 -mpip install torch==2.7.1
+        elif command -v rocminfo; then
+          # NB: Installing torch on ROCm runner with pip here causes CI to fail
+          # with a memoryview is too large error only on MI300 runners. Is pip
+          # version on ROCm runner there too old? As a workaround, let's use the
+          # GPU device name coming from rocminfo instead
+          DEVICE_NAME=rocm
+          DEVICE_TYPE=$(rocminfo | grep "Marketing Name" | tail -n1 | awk -F':' '{print $2}' | xargs)
+        fi
+
+        echo "DEVICE_NAME=$DEVICE_NAME" >> $GITHUB_ENV
+        echo "DEVICE_TYPE=$DEVICE_TYPE" >> $GITHUB_ENV
 
     - name: Check that GITHUB_TOKEN is defined
       env:

--- a/.github/scripts/benchmarks/gather_runners_info.py
+++ b/.github/scripts/benchmarks/gather_runners_info.py
@@ -35,7 +35,6 @@ def get_runner_info() -> Dict[str, Any]:
         import torch
 
         if torch.cuda.is_available():
-            # TODO (huydhn): only support CUDA and ROCm for now
             if torch.version.hip:
                 device_name = "rocm"
             elif torch.version.cuda:
@@ -55,7 +54,6 @@ def get_runner_info() -> Dict[str, Any]:
         },
     }
 
-    # TODO (huydhn): only support CUDA and ROCm for now
     if device_name and device_type:
         runner_info["name"] = device_name
         runner_info["type"] = device_type
@@ -65,6 +63,10 @@ def get_runner_info() -> Dict[str, Any]:
             * torch.cuda.device_count()
             / (1024 * 1024 * 1024)
         )
+    else:
+        # Check if the workflow has already set the device name and type
+        runner_info["name"] = os.getenv("DEVICE_NAME", "")
+        runner_info["type"] = os.getenv("DEVICE_TYPE", "")
 
     return runner_info
 


### PR DESCRIPTION
I reverted the first attempt because pip install failed with a memory error only on MI300 runners, for example https://github.com/pytorch/pytorch/actions/runs/15767425131/job/44447322381 (wut? maybe pip version on MI300 ROCm runner is too old).  So, let's try to use `rocminfo` instead.

### Testing

I create a test PR to run this on ROCm https://github.com/pytorch/pytorch/pull/156468 with some MI300 jobs running at https://github.com/pytorch/pytorch/actions/runs/15772321806

The test looks ok now https://github.com/pytorch/pytorch/actions/runs/15772321806/job/44460624447#step:24:293