### PR TITLE
[BE][lambdas] Use matrix for python lambda release to dedup code

### DIFF
--- a/.github/workflows/_lambda-do-release-runners.yml
+++ b/.github/workflows/_lambda-do-release-runners.yml
@@ -80,9 +80,18 @@ jobs:
           tag: ${{ inputs.tag }}
           updateOnlyUnreleased: true
 
-  # lambda/ci-queue-pct
-  release-ci-queue-pct:
-    name: Upload Release for ci-queue-pct lambda
+  release-python-lambdas:
+    strategy:
+      fail-fast: false
+      matrix:
+        include: [
+          { dir-name: 'ci-queue-pct',               zip-name: 'ci-queue-pct' },
+          { dir-name: 'oss_ci_job_queue_time',      zip-name: 'oss-ci-job-queue-time' },
+          { dir-name: 'oss_ci_cur',                 zip-name: 'oss-ci-cur' },
+          { dir-name: 'benchmark-results-uploader', zip-name: 'benchmark-results-uploader' },
+          { dir-name: 'pytorch-auto-revert',        zip-name: 'pytorch-auto-revert' }
+        ]
+    name: Upload Release for ${{ matrix.dir-name }} lambda
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -99,150 +108,15 @@ jobs:
           python-version: '3.10'
 
       - name: Build deployment.zip
-        working-directory: aws/lambda/ci-queue-pct
+        working-directory: aws/lambda/${{ matrix.dir-name }}
         run: make deployment.zip
 
       - name: Copy deployment.zip to root
-        run: cp aws/lambda/ci-queue-pct/deployment.zip ci-queue-pct.zip
+        run: cp aws/lambda/${{ matrix.dir-name }}/deployment.zip ${{ matrix.zip-name }}.zip
 
       - uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
         with:
-          artifacts: "ci-queue-pct.zip"
-          allowUpdates: true
-          draft: true
-          name: ${{ inputs.tag }}
-          tag: ${{ inputs.tag }}
-          updateOnlyUnreleased: true
-
-  # lambda/oss_ci_job_queue_time
-  release-oss-ci-job-queue-time:
-    name:  Upload Release for oss-ci-job-queue-time lambda
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    env:
-      REF: ${{ inputs.tag }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ inputs.tag }}
-
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.10'
-
-      - name: Build deployment.zip
-        working-directory: aws/lambda/oss_ci_job_queue_time
-        run: make deployment.zip
-
-      - name: Copy deployment.zip to root
-        run: cp aws/lambda/oss_ci_job_queue_time/deployment.zip oss-ci-job-queue-time.zip
-
-      - uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
-        with:
-          artifacts: "oss-ci-job-queue-time.zip"
-          allowUpdates: true
-          draft: true
-          name: ${{ inputs.tag }}
-          tag: ${{ inputs.tag }}
-          updateOnlyUnreleased: true
-
-  # lambda/oss_ci_cur
-  release-oss-ci-cur:
-    name:  Upload Release for oss-ci-cur lambda
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    env:
-      REF: ${{ inputs.tag }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ inputs.tag }}
-
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.10'
-
-      - name: Build deployment.zip
-        working-directory: aws/lambda/oss_ci_cur
-        run: make deployment.zip
-
-      - name: Copy deployment.zip to root
-        run: cp aws/lambda/oss_ci_cur/deployment.zip oss-ci-cur.zip
-
-      - uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
-        with:
-          artifacts: "oss-ci-cur.zip"
-          allowUpdates: true
-          draft: true
-          name: ${{ inputs.tag }}
-          tag: ${{ inputs.tag }}
-          updateOnlyUnreleased: true
-
-  # lambda/benchmark-results-uploader
-  release-benchmark-results-uploader:
-    name: Upload Release for benchmark-results-uploader lambda
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    env:
-      REF: ${{ inputs.tag }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ inputs.tag }}
-
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.10'
-
-      - name: Build deployment.zip
-        working-directory: aws/lambda/benchmark-results-uploader
-        run: make deployment.zip
-
-      - name: Copy deployment.zip to root
-        run: cp aws/lambda/benchmark-results-uploader/deployment.zip benchmark-results-uploader.zip
-
-      - uses: ncipollo/release-action@v1
-        with:
-          artifacts: "benchmark-results-uploader.zip"
-          allowUpdates: true
-          draft: true
-          name: ${{ inputs.tag }}
-          tag: ${{ inputs.tag }}
-          updateOnlyUnreleased: true
-
-  # lambda/pytorch-auto-revert
-  release-pytorch-auto-revert:
-    name:  Upload Release for pytorch-auto-revert lambda
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    env:
-      REF: ${{ inputs.tag }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ inputs.tag }}
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.10'
-
-      - name: Build deployment.zip
-        working-directory: aws/lambda/pytorch-auto-revert
-        run: make deployment.zip
-
-      - name: Copy deployment.zip to root
-        run: cp aws/lambda/pytorch-auto-revert/deployment.zip pytorch-auto-revert.zip
-
-      - uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
-        with:
-          artifacts: "pytorch-auto-revert.zip"
+          artifacts: "${{ matrix.zip-name }}.zip"
           allowUpdates: true
           draft: true
           name: ${{ inputs.tag }}
@@ -251,11 +125,7 @@ jobs:
 
   finish-release:
     needs:
-      - release-benchmark-results-uploader
-      - release-ci-queue-pct
-      - release-lambdas
-      - release-oss-ci-job-queue-time
-      - release-pytorch-auto-revert
+      - release-python-lambdas
     name: Mark the release as final and publish it
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
The python lambda releases are the same, so convert them into a matrix to reduce code duplication and the chance of error