### PR TITLE
Fix width inconsistency in TorchAgent chat interface

### DIFF
--- a/torchci/components/TorchAgentPage.tsx
+++ b/torchci/components/TorchAgentPage.tsx
@@ -751,7 +751,17 @@ export const TorchAgentPage = () => {
       />
 
       {/* Main Content */}
-      <Box sx={{ flexGrow: 1, display: "flex", flexDirection: "column" }}>
+      <Box
+        sx={{
+          flexGrow: 1,
+          display: "flex",
+          flexDirection: "column",
+          width: `calc(100% - ${drawerOpen ? sidebarWidth : 0}px)`,
+          maxWidth: `calc(100% - ${drawerOpen ? sidebarWidth : 0}px)`,
+          minWidth: `calc(100% - ${drawerOpen ? sidebarWidth : 0}px)`,
+          overflow: "hidden",
+        }}
+      >
         {isSessionLoading ? (
           <LoadingDisplay message="Loading Conversation..." showFullScreen />
         ) : (

--- a/torchci/components/TorchAgentPage/styles.ts
+++ b/torchci/components/TorchAgentPage/styles.ts
@@ -6,6 +6,8 @@ export const TorchAgentPageContainer = styled("div")({
   padding: "20px",
   maxWidth: "1200px",
   margin: "0 auto",
+  width: "100%",
+  boxSizing: "border-box",
 });
 
 export const QuerySection = styled(Paper)({


### PR DESCRIPTION
## Summary
- Add consistent width constraints to TorchAgentPageContainer
- Set explicit width calculations for main content box  
- Prevent layout shift when switching between WelcomeSection and QueryInputSection
- Ensure consistent width regardless of chat state

## Test plan
- [x] Test width stays consistent when clicking RUN
- [x] Run `yarn test` - all pass

🤖 Generated with [Claude Code](https://claude.ai/code)