### PR TITLE
Fix stream continuation on navigation to historic chats

### DIFF
--- a/torchci/components/TorchAgentPage.tsx
+++ b/torchci/components/TorchAgentPage.tsx
@@ -136,6 +136,14 @@ export const TorchAgentPage = () => {
 
   // Load a specific chat session
   const loadChatSession = async (sessionId: string) => {
+    // Cancel any active stream first
+    if (fetchControllerRef.current && isLoading) {
+      console.log("Cancelling active stream to load historic chat");
+      fetchControllerRef.current.abort();
+      fetchControllerRef.current = null;
+      setIsLoading(false);
+    }
+
     setIsSessionLoading(true);
     // Clear existing content while loading
     setParsedResponses([]);
@@ -199,6 +207,14 @@ export const TorchAgentPage = () => {
 
   // Start a new chat
   const startNewChat = () => {
+    // Cancel any active stream first
+    if (fetchControllerRef.current && isLoading) {
+      console.log("Cancelling active stream to start new chat");
+      fetchControllerRef.current.abort();
+      fetchControllerRef.current = null;
+      setIsLoading(false);
+    }
+
     setQuery("");
     setResponse("");
     setParsedResponses([]);


### PR DESCRIPTION
## Summary
- Cancel active streaming when loading a historic chat session
- Cancel active streaming when starting a new chat
- Prevent streams from continuing in background when user navigates away
- Add console logging for debugging stream cancellation
- Ensure clean state transitions between active and historic chats

## Test plan
- [x] Test stream stops when navigating to historic chat
- [x] Test stream stops when starting new chat
- [x] Run `yarn test` - all pass

🤖 Generated with [Claude Code](https://claude.ai/code)