### PR TITLE
Reorganize TorchAgent chatbox positioning and implement session continuation

### DIFF
--- a/torchci/components/TorchAgentPage/QueryInputSection.tsx
+++ b/torchci/components/TorchAgentPage/QueryInputSection.tsx
@@ -5,23 +5,17 @@ import { QuerySection } from "./styles";
 interface QueryInputSectionProps {
   query: string;
   isLoading: boolean;
-  debugVisible: boolean;
   isReadOnly?: boolean;
   onQueryChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onSubmit: (event: React.FormEvent) => void;
-  onToggleDebug: () => void;
-  onCancel: () => void;
 }
 
 export const QueryInputSection: React.FC<QueryInputSectionProps> = ({
   query,
   isLoading,
-  debugVisible,
   isReadOnly = false,
   onQueryChange,
   onSubmit,
-  onToggleDebug,
-  onCancel,
 }) => {
   return (
     <QuerySection>
@@ -40,14 +34,11 @@ export const QueryInputSection: React.FC<QueryInputSectionProps> = ({
               : "Example: Make a graph of the number of failing jobs per day  (Tip: Ctrl+Enter to submit)"
           }
           variant="outlined"
-          disabled={isLoading || isReadOnly}
-          InputProps={{
-            readOnly: isReadOnly,
-          }}
+          disabled={false}
           onKeyDown={(e) => {
-            if (!isReadOnly && (e.ctrlKey || e.metaKey) && e.key === "Enter") {
+            if (!isLoading && (e.ctrlKey || e.metaKey) && e.key === "Enter") {
               e.preventDefault();
-              if (!isLoading && query.trim()) {
+              if (query.trim()) {
                 onSubmit(e);
               }
             }
@@ -56,35 +47,18 @@ export const QueryInputSection: React.FC<QueryInputSectionProps> = ({
         <Box
           sx={{
             display: "flex",
-            justifyContent: "space-between",
+            justifyContent: "flex-end",
             mt: 2,
           }}
         >
-          <Button variant="outlined" color="secondary" onClick={onToggleDebug}>
-            {debugVisible ? "Hide Debug" : "Show Debug"}
+          <Button
+            variant="contained"
+            color="primary"
+            type="submit"
+            disabled={isLoading}
+          >
+            {isLoading ? "Running..." : "RUN"}
           </Button>
-          <Box>
-            {isLoading && (
-              <Button
-                variant="outlined"
-                color="error"
-                onClick={onCancel}
-                sx={{ mr: 1 }}
-              >
-                Cancel
-              </Button>
-            )}
-            {!isReadOnly && (
-              <Button
-                variant="contained"
-                color="primary"
-                type="submit"
-                disabled={isLoading}
-              >
-                {isLoading ? "Running..." : "RUN"}
-              </Button>
-            )}
-          </Box>
         </Box>
       </Box>
     </QuerySection>

--- a/torchci/components/TorchAgentPage/WelcomeSection.tsx
+++ b/torchci/components/TorchAgentPage/WelcomeSection.tsx
@@ -5,21 +5,15 @@ import { QuerySection } from "./styles";
 interface WelcomeSectionProps {
   query: string;
   isLoading: boolean;
-  debugVisible: boolean;
   onQueryChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onSubmit: (event: React.FormEvent) => void;
-  onToggleDebug: () => void;
-  onCancel: () => void;
 }
 
 export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
   query,
   isLoading,
-  debugVisible,
   onQueryChange,
   onSubmit,
-  onToggleDebug,
-  onCancel,
 }) => {
   return (
     <>
@@ -86,37 +80,18 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
           <Box
             sx={{
               display: "flex",
-              justifyContent: "space-between",
+              justifyContent: "flex-end",
               mt: 2,
             }}
           >
             <Button
-              variant="outlined"
-              color="secondary"
-              onClick={onToggleDebug}
+              variant="contained"
+              color="primary"
+              type="submit"
+              disabled={isLoading}
             >
-              {debugVisible ? "Hide Debug" : "Show Debug"}
+              {isLoading ? "Running..." : "RUN"}
             </Button>
-            <Box>
-              {isLoading && (
-                <Button
-                  variant="outlined"
-                  color="error"
-                  onClick={onCancel}
-                  sx={{ mr: 1 }}
-                >
-                  Cancel
-                </Button>
-              )}
-              <Button
-                variant="contained"
-                color="primary"
-                type="submit"
-                disabled={isLoading}
-              >
-                {isLoading ? "Running..." : "RUN"}
-              </Button>
-            </Box>
           </Box>
         </Box>
       </QuerySection>


### PR DESCRIPTION
## Summary
- Move query input to bottom for historic chats (below results)
- Keep query input at top only for new chats
- Implement sessionId passing for chat continuation
- Update API to handle sessionId parameter for continuing existing sessions
- Remove deprecated userUuid and use sessionId consistently
- Clean up debug controls - single debug button in results section
- Remove duplicate input boxes and cancel buttons
- Fix session handling logic for better UX

## Test plan
- [x] Test chatbox appears at bottom for historic chats
- [x] Test session continuation works properly  
- [x] Test debug button only appears in results section
- [x] Test no duplicate input boxes
- [x] Run `yarn test` - all pass

🤖 Generated with [Claude Code](https://claude.ai/code)