### PR TITLE
Add Playwright tests for TorchAgent page

### DIFF
--- a/torchci/components/TorchAgentPage/ChatHistorySidebar.tsx
+++ b/torchci/components/TorchAgentPage/ChatHistorySidebar.tsx
@@ -49,6 +49,7 @@ export const ChatHistorySidebar: React.FC<ChatHistorySidebarProps> = ({
       variant="persistent"
       anchor="left"
       open={drawerOpen}
+      data-test-id="chat-history-drawer"
       sx={{
         width: sidebarWidth,
         flexShrink: 0,
@@ -71,7 +72,11 @@ export const ChatHistorySidebar: React.FC<ChatHistorySidebarProps> = ({
         >
           <Typography variant="h6">Chat History</Typography>
           <Tooltip title="New Chat">
-            <IconButton onClick={onStartNewChat} color="primary">
+            <IconButton
+              onClick={onStartNewChat}
+              color="primary"
+              data-test-id="new-chat-button"
+            >
               <AddIcon />
             </IconButton>
           </Tooltip>
@@ -106,6 +111,7 @@ export const ChatHistorySidebar: React.FC<ChatHistorySidebarProps> = ({
               <ListItemButton
                 selected={selectedSession === session.sessionId}
                 onClick={() => onLoadChatSession(session.sessionId)}
+                data-test-id={`chat-session-${session.sessionId}`}
               >
                 {session.status === "in_progress" ? (
                   <CircularProgress size={14} sx={{ mr: 1 }} />

--- a/torchci/components/TorchAgentPage/QueryInputSection.tsx
+++ b/torchci/components/TorchAgentPage/QueryInputSection.tsx
@@ -44,6 +44,7 @@ export const QueryInputSection: React.FC<QueryInputSectionProps> = ({
           InputProps={{
             readOnly: isReadOnly,
           }}
+          inputProps={{ "data-test-id": "query-input" }}
           onKeyDown={(e) => {
             if (!isReadOnly && (e.ctrlKey || e.metaKey) && e.key === "Enter") {
               e.preventDefault();
@@ -60,7 +61,12 @@ export const QueryInputSection: React.FC<QueryInputSectionProps> = ({
             mt: 2,
           }}
         >
-          <Button variant="outlined" color="secondary" onClick={onToggleDebug}>
+          <Button
+            variant="outlined"
+            color="secondary"
+            onClick={onToggleDebug}
+            data-test-id="toggle-debug"
+          >
             {debugVisible ? "Hide Debug" : "Show Debug"}
           </Button>
           <Box>
@@ -70,6 +76,7 @@ export const QueryInputSection: React.FC<QueryInputSectionProps> = ({
                 color="error"
                 onClick={onCancel}
                 sx={{ mr: 1 }}
+                data-test-id="cancel-button"
               >
                 Cancel
               </Button>
@@ -80,6 +87,7 @@ export const QueryInputSection: React.FC<QueryInputSectionProps> = ({
                 color="primary"
                 type="submit"
                 disabled={isLoading}
+                data-test-id="run-button"
               >
                 {isLoading ? "Running..." : "RUN"}
               </Button>

--- a/torchci/components/TorchAgentPage/WelcomeSection.tsx
+++ b/torchci/components/TorchAgentPage/WelcomeSection.tsx
@@ -74,6 +74,7 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
             placeholder="Example: Make a graph of the number of failing jobs per day  (Tip: Ctrl+Enter to submit)"
             variant="outlined"
             disabled={isLoading}
+            inputProps={{ "data-test-id": "query-input" }}
             onKeyDown={(e) => {
               if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
                 e.preventDefault();
@@ -94,6 +95,7 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
               variant="outlined"
               color="secondary"
               onClick={onToggleDebug}
+              data-test-id="toggle-debug"
             >
               {debugVisible ? "Hide Debug" : "Show Debug"}
             </Button>
@@ -104,6 +106,7 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
                   color="error"
                   onClick={onCancel}
                   sx={{ mr: 1 }}
+                  data-test-id="cancel-button"
                 >
                   Cancel
                 </Button>
@@ -113,6 +116,7 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
                 color="primary"
                 type="submit"
                 disabled={isLoading}
+                data-test-id="run-button"
               >
                 {isLoading ? "Running..." : "RUN"}
               </Button>

--- a/torchci/package.json
+++ b/torchci/package.json
@@ -71,6 +71,7 @@
     "zod": "^3.25.64"
   },
   "devDependencies": {
+    "@playwright/test": "^1.53.1",
     "@types/argparse": "^2.0.10",
     "@types/d3": "^7.4.3",
     "@types/echarts": "^4.9.14",

--- a/torchci/playwright.config.ts
+++ b/torchci/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./playwright",
+  fullyParallel: true,
+  use: {
+    baseURL: "http://localhost:3000",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/torchci/playwright/torchagent.spec.ts
+++ b/torchci/playwright/torchagent.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("TorchAgent page", () => {
+  test("requires authentication when no cookie is present", async ({
+    page,
+  }) => {
+    await page.goto("/torchagent");
+    await expect(page.getByText("Authentication Required")).toBeVisible();
+  });
+
+  test("shows query input when authenticated via cookie", async ({ page }) => {
+    await page.context().addCookies([
+      {
+        name: "GRAFANA_MCP_AUTH_TOKEN",
+        value: "test",
+        domain: "localhost",
+        path: "/",
+        httpOnly: false,
+        secure: false,
+      },
+    ]);
+    await page.goto("/torchagent");
+    await expect(page.getByTestId("query-input")).toBeVisible();
+    await expect(page.getByTestId("run-button")).toBeVisible();
+  });
+});

--- a/torchci/yarn.lock
+++ b/torchci/yarn.lock
@@ -2653,6 +2653,13 @@
   resolved "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.0.4.tgz"
   integrity sha512-003xWiCuvePbLaPHT+CRuaV4GlyCAVm6XYSbBZDHoWZGn1mNkVKFaDbGJjjxmEFvizUwlCoM6O18FCBMMky2zQ==
 
+"@playwright/test@^1.53.1":
+  version "1.53.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.53.1.tgz#3ad5a2ce334b4a78390fd91e0a9d8423c09bc808"
+  integrity sha512-Z4c23LHV0muZ8hfv4jw6HngPJkbbtZxTkxPNIg7cJcTc9C28N/p2q7g3JZS2SiKBBHJ3uM1dgDye66bB7LEk5w==
+  dependencies:
+    playwright "1.53.1"
+
 "@popperjs/core@^2.11.8":
   version "2.11.8"
   resolved "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz"
@@ -5425,6 +5432,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@^2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -7647,6 +7659,20 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+playwright-core@1.53.1:
+  version "1.53.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.53.1.tgz#0b6f7a2006ccb6126ffcc3e3b2fa9efda23b6638"
+  integrity sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==
+
+playwright@1.53.1:
+  version "1.53.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.53.1.tgz#86fb041b237a6868d163c87c4b9737fd1cac145e"
+  integrity sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==
+  dependencies:
+    playwright-core "1.53.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 postcss-value-parser@^3.3.0:
   version "3.3.1"


### PR DESCRIPTION
## Summary
- add Playwright config and torchagent e2e tests
- expose `data-test-id` attributes in TorchAgent components for easier testing
- install Playwright dependencies

## Testing
- `yarn test` *(fails: mocks not satisfied)*
- `yarn format`
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68568b13c8a08333be5edfdc4955c7fd