### PR TITLE
Don't pin our own github actions

### DIFF
--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -164,7 +164,7 @@ jobs:
         if: ${{ inputs.gpu-arch-type != 'rocm' }}
 
       - name: Setup ROCM
-        uses: pytorch/pytorch/.github/actions/setup-rocm@9c1bc9ce4684de96db025292610c0664d3d55345 # main
+        uses: pytorch/pytorch/.github/actions/setup-rocm@main
         if: ${{ inputs.gpu-arch-type == 'rocm' }}
 
       - name: Setup SSH


### PR DESCRIPTION
For actions we ourselves host, we can continue to trust the branch name instead of risking actions being left on a stale pin

This one in particular is missing the ROCm6.4 update from https://github.com/pytorch/pytorch/pull/151368