### PR TITLE
[BE] Mark custom terraform module tags as such

### DIFF
--- a/.github/workflows/lambda-release-tag-runners.yml
+++ b/.github/workflows/lambda-release-tag-runners.yml
@@ -7,6 +7,9 @@ on:
       - main
     paths:
       - 'terraform-aws-github-runner/**'
+  pull_request: # Generate tag when PR modifies this workflow file
+    paths:
+      - '.github/workflows/lambda-release-tag-runners.yml'
 
 jobs:
   tag:
@@ -28,10 +31,10 @@ jobs:
       - name: Create tag name
         id: tag
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag_name=v${{ steps.date.outputs.date }}-custom" >> "${GITHUB_OUTPUT}"
-          else
+          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "tag_name=v${{ steps.date.outputs.date }}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "tag_name=v${{ steps.date.outputs.date }}-custom" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Tag snapshot


### PR DESCRIPTION
This allows us to easily tell which terraform tags are custom ones manually created vs which ones were automatically generated by pushes to `main`

Goal of this PR is to prevent tags that were manually created but not on `main` from accidentally being deployed to prod

It:
- Appends "-custom" to any tag that wasn't generated by a push to main
- Also triggers the tag creation workflow when someone modifies it, for testing

Testing: Generated tags via this PR, updated local Terrafile, ran `make plan` locally and verified terraform module was downloaded successfully