### PR TITLE
[ez] Add aws/lambda to release lambda action trigger

### DIFF
--- a/.github/workflows/lambda-release-tag-runners.yml
+++ b/.github/workflows/lambda-release-tag-runners.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - 'terraform-aws-github-runner/**'
+      - 'aws/lambda/**'
   pull_request: # Generate tag when PR modifies this workflow file
     paths:
       - '.github/workflows/lambda-release-tag-runners.yml'


### PR DESCRIPTION
I saw that I still had to do a custom release, even though it was from the main branch, for my lambda