### PR TITLE
Add method to analyze reverts: analyze_reverts_missing_from_branch

### DIFF
--- a/tools/analytics/github_analyze.py
+++ b/tools/analytics/github_analyze.py
@@ -570,7 +570,9 @@ def analyze_reverts_missing_from_branch(repo: GitRepo, branch: str) -> None:
         print(f"No reverts found in main branch that are missing from {branch} branch.")
         return
 
-    print(f"Found {len(reverts_missing_from_branch)} revert(s) in main branch not present in {branch} branch:")
+    print(
+        f"Found {len(reverts_missing_from_branch)} revert(s) in main branch not present in {branch} branch:"
+    )
     print("=" * 80)
 
     for commit in reverts_missing_from_branch:
@@ -590,7 +592,9 @@ def analyze_reverts_missing_from_branch(repo: GitRepo, branch: str) -> None:
         elif ghf_revert_revision:
             print(f"Reverted GitHub Commit: {ghf_revert_revision}")
 
-        print(f"Body Preview: {commit.body[:200]}{'...' if len(commit.body) > 200 else ''}")
+        print(
+            f"Body Preview: {commit.body[:200]}{'...' if len(commit.body) > 200 else ''}"
+        )
         print("-" * 80)
 
 
@@ -614,8 +618,11 @@ def parse_arguments():
     parser.add_argument("--missing-in-branch", action="store_true")
     parser.add_argument("--missing-in-release", action="store_true")
     parser.add_argument("--analyze-stacks", action="store_true")
-    parser.add_argument("--analyze-missing-reverts-from-branch", action="store_true",
-                        help="Analyze reverts applied to main branch but not applied to specified branch")
+    parser.add_argument(
+        "--analyze-missing-reverts-from-branch",
+        action="store_true",
+        help="Analyze reverts applied to main branch but not applied to specified branch",
+    )
     parser.add_argument("--date", type=lambda d: datetime.strptime(d, "%Y-%m-%d"))
     parser.add_argument("--issue-num", type=int)
     return parser.parse_args()
@@ -642,7 +649,9 @@ def main():
 
     if args.analyze_missing_reverts_from_branch:
         if not args.branch:
-            print("Error: --branch argument is required for --analyze-missing-reverts-from-branch")
+            print(
+                "Error: --branch argument is required for --analyze-missing-reverts-from-branch"
+            )
             return
         analyze_reverts_missing_from_branch(repo, args.branch)
         return


### PR DESCRIPTION
Usage:
```
python github_analyze.py --analyze-missing-reverts-from-branch --repo-path ~/local/pytorch --remote upstream --branch release/2.8
Analyzing reverts in main branch not present in release/2.8 branch
Total commits in main but not in release/2.8: 62
Total commits in release/2.8 but not in main: 1

Found 8 revert(s) in main branch not present in release/2.8 branch:
================================================================================
Commit Hash: 029e2b05c225588098d3eba445fd04189691f77d
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-06-25 06:05:40
Title: Revert "[Quant][CPU] fix fake_quantize_per_tensor_affine of inf values (#155109)"
Reverted GitHub Commit: 19ffb5e6f7606436249742b0f3efc0bab244dc55
Body Preview:     
    This reverts commit 19ffb5e6f7606436249742b0f3efc0bab244dc55.
    
    Reverted https://github.com/pytorch/pytorch/pull/155109 on behalf of https://github.com/albanD due to The corresponding ...
--------------------------------------------------------------------------------
Commit Hash: 3dd872e6d53560933d8d7fc11357617746d37168
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-06-24 17:11:35
Title: Revert "Add DeviceAllocator as the base device allocator (#138222)"
Reverted GitHub Commit: 92409b6c89fbfbd3caa79c81b1e3d9e7917d3bc7
Body Preview:     
    This reverts commit 92409b6c89fbfbd3caa79c81b1e3d9e7917d3bc7.
    
    Reverted https://github.com/pytorch/pytorch/pull/138222 on behalf of https://github.com/Camyll due to internal build fai...
--------------------------------------------------------------------------------
Commit Hash: 6459a5c7a92e7a38db374780b91116cc958b6af9
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-06-24 17:11:35
Title: Revert "Add unified memory APIs for torch.accelerator (#152932)"
Reverted GitHub Commit: 35e44067c4d9cc9be2652c0b9098885c5a321029
Body Preview:     
    This reverts commit 35e44067c4d9cc9be2652c0b9098885c5a321029.
    
    Reverted https://github.com/pytorch/pytorch/pull/152932 on behalf of https://github.com/Camyll due to internal build fai...
--------------------------------------------------------------------------------
Commit Hash: fd4bb29410c035b31ca55262c3012cadb1194aae
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-06-24 16:45:13
Title: Revert "[logging] dynamo_timed for CachingAutotuner.coordinate_descent_tuning (#156517)"
Reverted GitHub Commit: fb75dea2c1b93c78dccf08d5fd5e20b362ecd405
Body Preview:     
    This reverts commit fb75dea2c1b93c78dccf08d5fd5e20b362ecd405.
    
    Reverted https://github.com/pytorch/pytorch/pull/156517 on behalf of https://github.com/Camyll due to internal reverted ...
--------------------------------------------------------------------------------
Commit Hash: 4bd18e31e5a38d0e84ce915b1fa124058c6373fa
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-06-24 16:34:21
Title: Revert "Add fx_graph_runnable tests boilerplate (#156552)"
Reverted GitHub Commit: 0a2ec7681d2af973d8daaf7905431a088739dc90
Body Preview:     
    This reverts commit 0a2ec7681d2af973d8daaf7905431a088739dc90.
    
    Reverted https://github.com/pytorch/pytorch/pull/156552 on behalf of https://github.com/Camyll due to breaking internal ...
--------------------------------------------------------------------------------
Commit Hash: 1dc1eedd4369f6e6bb79d5315e3ffc1bdc59b709
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-06-24 13:44:42
Title: Revert "[dynamo] Graph break on `torch.Tensor.data` assignment with mismatched dtype (#156623)"
Reverted GitHub Commit: c1ad4b8e7a16f54c35a3908b56ed7d9f95eef586
Body Preview:     
    This reverts commit c1ad4b8e7a16f54c35a3908b56ed7d9f95eef586.
    
    Reverted https://github.com/pytorch/pytorch/pull/156623 on behalf of https://github.com/albanD due to Breaks Dynamo test...
--------------------------------------------------------------------------------
Commit Hash: aa280ea19fb20923d048909fa98af092e18ca2fb
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-06-24 13:05:39
Title: Revert "Remove remaining CUDA 12.4 CI code (#155412)"
Reverted GitHub Commit: 9fed2addedb42da86b657165fe14eadc911232cf
Body Preview:     
    This reverts commit 9fed2addedb42da86b657165fe14eadc911232cf.
    
    Reverted https://github.com/pytorch/pytorch/pull/155412 on behalf of https://github.com/Camyll due to cuda 12.4 still ne...
--------------------------------------------------------------------------------
Commit Hash: 19f851ce10b16f0ed11d18d937ca7b32746153b0
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-06-24 13:02:07
Title: Revert "Simplify nvtx3 CMake handling, always use nvtx3 (#153784)"
Reverted GitHub Commit: 099d0d6121125062ebc05771c8330cb7cd8d053a
Body Preview:     
    This reverts commit 099d0d6121125062ebc05771c8330cb7cd8d053a.
    
    Reverted https://github.com/pytorch/pytorch/pull/153784 on behalf of https://github.com/Camyll due to breaking internal ...
--------------------------------------------------------------------------------
```