### PR TITLE
[log classifier] Rule for graph break registry check

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -21,6 +21,10 @@ name = 'Operator backwards compatibility'
 pattern = '^The PR is introducing backward incompatible changes to the operator library.'
 
 [[rule]]
+name = 'Failed graph_break_registry check'
+pattern = '^Found the unimplemented_v2 or unimplemented_v2_with_warning calls below that don.t match the registry in graph_break_registry.json.'
+
+[[rule]]
 name = 'Lintrunner failure'
 pattern = '^>>> Lint for.*'
 


### PR DESCRIPTION
For failures like [GH job link](https://github.com/pytorch/pytorch/actions/runs/15859789097/job/44714997710) [HUD commit link](https://hud.pytorch.org/pytorch/pytorch/commit/c1ad4b8e7a16f54c35a3908b56ed7d9f95eef586)

Currently matches ` ##[error]Process completed with exit code 1.`
but there is a better line
`Found the unimplemented_v2 or unimplemented_v2_with_warning calls below that don't match the registry in graph_break_registry.json.`