### PR TITLE
Migrate upload-s3 action for clang-tidy-upload

### DIFF
--- a/.github/actions/clang-tidy-upload/action.yml
+++ b/.github/actions/clang-tidy-upload/action.yml
@@ -41,7 +41,7 @@ runs:
         aws-region: us-east-1
         output-credentials: true
 
-    - uses: seemethere/upload-artifact-s3@v5
+    - uses: ./test-infra/.github/actions/upload-artifact-s3
       name: Publish clang-tidy binary
       if: ${{ fromJSON(inputs.upload-to-s3) }}
       with:
@@ -50,7 +50,7 @@ runs:
         s3-bucket: oss-clang-format
         path: clang-tidy
 
-    - uses: seemethere/upload-artifact-s3@v5
+    - uses: ./test-infra/.github/actions/upload-artifact-s3
       name: Publish clang-format binary
       if: ${{ fromJSON(inputs.upload-to-s3) }}
       with:


### PR DESCRIPTION
This PR is part of a family of PRs that migrate the use of the upload-artifact-s3 action to the new version hosted in this repository. Together, they address step 1 of #6755.

All the PRs are:
- [ ] -> #6840
- [ ] #6873
- [ ] #6872
- [ ] #6874
- [ ] #6875
- [ ] #6876