### PR TITLE
Add miniconda install=true to build_wheels_macos.yml

### DIFF
--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -78,7 +78,7 @@ on:
         description: Set to true if setup-miniconda is needed
         required: true
         type: boolean
-        default: false
+        default: true
       delocate-wheel:
         description: "Whether to run delocate-wheel after building."
         required: false

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -76,7 +76,7 @@ on:
         default: recursive
       setup-miniconda:
         description: Set to true if setup-miniconda is needed
-        required: true
+        required: false
         type: boolean
         default: true
       delocate-wheel:

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -76,7 +76,7 @@ on:
         default: recursive
       setup-miniconda:
         description: Set to true if setup-miniconda is needed
-        required: false
+        required: true
         type: boolean
         default: false
       delocate-wheel:


### PR DESCRIPTION
Miniconda is required for M1 wheel builds

This action will, by default, activate an environment called test and not activate the base environment. This encourages the recommended practice of not installing workflow packages into the base environment and leaving it with only conda (and/or mamba).