### PR TITLE
[ez][disablebot] Lower threshold for creating aggregate flaky issues 10 -> 4

### DIFF
--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -14,7 +14,7 @@ import { Octokit } from "octokit";
 
 export const NUM_HOURS = 3;
 const PYTORCH = "pytorch";
-const THRESHOLD = 5;
+const THRESHOLD = 4;
 
 export default async function handler(
   req: NextApiRequest,

--- a/torchci/pages/api/flaky-tests/disable.ts
+++ b/torchci/pages/api/flaky-tests/disable.ts
@@ -14,7 +14,7 @@ import { Octokit } from "octokit";
 
 export const NUM_HOURS = 3;
 const PYTORCH = "pytorch";
-const THRESHOLD = 10;
+const THRESHOLD = 5;
 
 export default async function handler(
   req: NextApiRequest,


### PR DESCRIPTION
10 is kind of high, IMO lowering it would be ok since its still annoying if there are >4 issues created at once that all seem related.  The restriction that they all be from the same file is strict enough so that lowering is ok i think

See the successfully created disable issues here: https://github.com/pytorch/pytorch/issues?q=state%3Aopen%20label%3A%22aggregate%20flaky%20test%20issue%22

(Now we just have to see if they also get updated automatically too)