### PR TITLE
runners: Add batching for terminateRunner

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
@@ -432,11 +432,13 @@ describe('terminateRunners', () => {
     });
 
     // First region succeeds, second region fails
-    mockEC2.terminateInstances.mockReturnValueOnce({
-      promise: jest.fn().mockResolvedValueOnce({}),
-    }).mockReturnValueOnce({
-      promise: jest.fn().mockRejectedValueOnce(new Error('Region failure')),
-    });
+    mockEC2.terminateInstances
+      .mockReturnValueOnce({
+        promise: jest.fn().mockResolvedValueOnce({}),
+      })
+      .mockReturnValueOnce({
+        promise: jest.fn().mockRejectedValueOnce(new Error('Region failure')),
+      });
 
     await expect(terminateRunners(runners, metrics)).rejects.toThrow(
       'Failed to terminate some runners: Instance i-9999: Region failure',

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
@@ -8,6 +8,7 @@ import {
   resetRunnersCaches,
   terminateRunner,
   tryReuseRunner,
+  terminateRunners,
 } from './runners';
 import { RunnerInfo } from './utils';
 import { ScaleUpMetrics } from './metrics';
@@ -326,10 +327,11 @@ describe('listSSMParameters', () => {
   });
 });
 
-describe('terminateRunner', () => {
+describe('terminateRunners', () => {
   beforeEach(() => {
     mockSSMdescribeParametersRet.mockClear();
     mockEC2.terminateInstances.mockClear();
+    mockSSM.deleteParameter.mockClear();
     const config = {
       environment: 'gi-ci',
       minimumRunningTimeInMinutes: 45,
@@ -339,66 +341,193 @@ describe('terminateRunner', () => {
     resetRunnersCaches();
   });
 
-  it('calls terminateInstances', async () => {
-    const runner: RunnerInfo = {
-      awsRegion: Config.Instance.awsRegion,
-      instanceId: 'i-1234',
-      environment: 'gi-ci',
-    };
+  it('terminates multiple runners in same region successfully', async () => {
+    const runners: RunnerInfo[] = [
+      {
+        awsRegion: 'us-east-1',
+        instanceId: 'i-1234',
+        environment: 'gi-ci',
+      },
+      {
+        awsRegion: 'us-east-1',
+        instanceId: 'i-5678',
+        environment: 'gi-ci',
+      },
+    ];
+
     mockSSMdescribeParametersRet.mockResolvedValueOnce({
-      Parameters: [getParameterNameForRunner(runner.environment as string, runner.instanceId)].map((s) => {
-        return { Name: s };
-      }),
+      Parameters: runners
+        .map((runner) => getParameterNameForRunner(runner.environment as string, runner.instanceId))
+        .map((s) => ({ Name: s })),
     });
-    await terminateRunner(runner, metrics);
 
+    await terminateRunners(runners, metrics);
+
+    expect(mockEC2.terminateInstances).toBeCalledTimes(1);
     expect(mockEC2.terminateInstances).toBeCalledWith({
-      InstanceIds: [runner.instanceId],
+      InstanceIds: ['i-1234', 'i-5678'],
     });
-    expect(mockSSM.describeParameters).toBeCalledTimes(1);
-    expect(mockSSM.deleteParameter).toBeCalledTimes(1);
-    expect(mockSSM.deleteParameter).toBeCalledWith({
-      Name: getParameterNameForRunner(runner.environment as string, runner.instanceId),
-    });
-  });
-
-  it('fails to terminate', async () => {
-    const errMsg = 'Error message';
-    const runner: RunnerInfo = {
-      awsRegion: Config.Instance.awsRegion,
-      instanceId: '1234',
-    };
-    mockEC2.terminateInstances.mockClear().mockReturnValue({
-      promise: jest.fn().mockRejectedValueOnce(Error(errMsg)),
-    });
-    expect(terminateRunner(runner, metrics)).rejects.toThrowError(errMsg);
-    expect(mockSSM.describeParameters).not.toBeCalled();
-    expect(mockSSM.deleteParameter).not.toBeCalled();
-  });
-
-  it('fails to list parameters on terminate, then force delete all next parameters', async () => {
-    const runner1: RunnerInfo = {
-      awsRegion: Config.Instance.awsRegion,
-      instanceId: '1234',
-      environment: 'environ',
-    };
-    const runner2: RunnerInfo = {
-      awsRegion: Config.Instance.awsRegion,
-      instanceId: '1235',
-      environment: 'environ',
-    };
-    mockSSMdescribeParametersRet.mockRejectedValueOnce('Some Error');
-    await terminateRunner(runner1, metrics);
-    await terminateRunner(runner2, metrics);
-
-    expect(mockEC2.terminateInstances).toBeCalledTimes(2);
     expect(mockSSM.describeParameters).toBeCalledTimes(1);
     expect(mockSSM.deleteParameter).toBeCalledTimes(2);
-    expect(mockSSM.deleteParameter).toBeCalledWith({
-      Name: getParameterNameForRunner(runner1.environment as string, runner1.instanceId),
+  });
+
+  it('terminates runners across multiple regions', async () => {
+    const runners: RunnerInfo[] = [
+      {
+        awsRegion: 'us-east-1',
+        instanceId: 'i-1234',
+        environment: 'gi-ci',
+      },
+      {
+        awsRegion: 'us-west-2',
+        instanceId: 'i-5678',
+        environment: 'gi-ci',
+      },
+    ];
+
+    mockSSMdescribeParametersRet.mockResolvedValue({
+      Parameters: [{ Name: 'gi-ci-i-1234' }, { Name: 'gi-ci-i-5678' }],
     });
+
+    await terminateRunners(runners, metrics);
+
+    expect(mockEC2.terminateInstances).toBeCalledTimes(2);
+    expect(mockEC2.terminateInstances).toHaveBeenNthCalledWith(1, {
+      InstanceIds: ['i-1234'],
+    });
+    expect(mockEC2.terminateInstances).toHaveBeenNthCalledWith(2, {
+      InstanceIds: ['i-5678'],
+    });
+    expect(mockSSM.describeParameters).toBeCalledTimes(2);
+    expect(mockSSM.deleteParameter).toBeCalledTimes(2);
+  });
+
+  it('handles partial failure - terminates some runners but fails on others', async () => {
+    const runners: RunnerInfo[] = [
+      {
+        awsRegion: 'us-east-1',
+        instanceId: 'i-1234',
+        environment: 'gi-ci',
+      },
+      {
+        awsRegion: 'us-east-1',
+        instanceId: 'i-5678',
+        environment: 'gi-ci',
+      },
+      {
+        awsRegion: 'us-west-2',
+        instanceId: 'i-9999',
+        environment: 'gi-ci',
+      },
+    ];
+
+    // First region succeeds
+    mockSSMdescribeParametersRet.mockResolvedValueOnce({
+      Parameters: [{ Name: 'gi-ci-i-1234' }, { Name: 'gi-ci-i-5678' }],
+    });
+
+    // Second region also gets SSM parameters but has no successful terminations to clean up
+    mockSSMdescribeParametersRet.mockResolvedValueOnce({
+      Parameters: [],
+    });
+
+    // First region succeeds, second region fails
+    mockEC2.terminateInstances.mockReturnValueOnce({
+      promise: jest.fn().mockResolvedValueOnce({}),
+    }).mockReturnValueOnce({
+      promise: jest.fn().mockRejectedValueOnce(new Error('Region failure')),
+    });
+
+    await expect(terminateRunners(runners, metrics)).rejects.toThrow(
+      'Failed to terminate some runners: Instance i-9999: Region failure',
+    );
+
+    expect(mockEC2.terminateInstances).toBeCalledTimes(2);
+    expect(mockSSM.describeParameters).toBeCalledTimes(2); // Called for both regions
+    expect(mockSSM.deleteParameter).toBeCalledTimes(2); // Only for successful region
+  });
+
+  it('handles large batches by splitting into chunks', async () => {
+    // Create 150 runners to test batching (should split into 2 batches of 100 and 50)
+    const runners: RunnerInfo[] = Array.from({ length: 150 }, (_, i) => ({
+      awsRegion: 'us-east-1',
+      instanceId: `i-${i.toString().padStart(4, '0')}`,
+      environment: 'gi-ci',
+    }));
+
+    mockSSMdescribeParametersRet.mockResolvedValueOnce({
+      Parameters: runners.map((runner) => ({
+        Name: getParameterNameForRunner(runner.environment as string, runner.instanceId),
+      })),
+    });
+
+    await terminateRunners(runners, metrics);
+
+    // Should make 2 terminate calls (batches of 100 and 50)
+    expect(mockEC2.terminateInstances).toBeCalledTimes(2);
+    expect(mockEC2.terminateInstances).toHaveBeenNthCalledWith(1, {
+      InstanceIds: runners.slice(0, 100).map((r) => r.instanceId),
+    });
+    expect(mockEC2.terminateInstances).toHaveBeenNthCalledWith(2, {
+      InstanceIds: runners.slice(100, 150).map((r) => r.instanceId),
+    });
+
+    // SSM cleanup should handle all 150 parameters
+    expect(mockSSM.describeParameters).toBeCalledTimes(1);
+    expect(mockSSM.deleteParameter).toBeCalledTimes(150);
+  });
+
+  it('cleans up SSM parameters for successful batches even when later batch fails', async () => {
+    // Create runners that will be split into 2 batches
+    const runners: RunnerInfo[] = Array.from({ length: 150 }, (_, i) => ({
+      awsRegion: 'us-east-1',
+      instanceId: `i-${i.toString().padStart(4, '0')}`,
+      environment: 'gi-ci',
+    }));
+
+    mockSSMdescribeParametersRet.mockResolvedValueOnce({
+      Parameters: runners.slice(0, 100).map((runner) => ({
+        Name: getParameterNameForRunner(runner.environment as string, runner.instanceId),
+      })),
+    });
+
+    // First batch succeeds, second batch fails
+    mockEC2.terminateInstances
+      .mockReturnValueOnce({
+        promise: jest.fn().mockResolvedValueOnce({}),
+      })
+      .mockReturnValueOnce({
+        promise: jest.fn().mockRejectedValueOnce(new Error('Batch 2 failed')),
+      });
+
+    await expect(terminateRunners(runners, metrics)).rejects.toThrow('Failed to terminate some runners');
+
+    expect(mockEC2.terminateInstances).toBeCalledTimes(2);
+    // SSM cleanup should still happen for the first 100 runners that were successfully terminated
+    expect(mockSSM.describeParameters).toBeCalledTimes(1);
+    expect(mockSSM.deleteParameter).toBeCalledTimes(100);
+  });
+
+  it('handles SSM parameter cleanup failure gracefully', async () => {
+    const runners: RunnerInfo[] = [
+      {
+        awsRegion: 'us-east-1',
+        instanceId: 'i-1234',
+        environment: 'gi-ci',
+      },
+    ];
+
+    // SSM describe fails, so it should attempt direct deletion
+    mockSSMdescribeParametersRet.mockRejectedValueOnce(new Error('SSM describe failed'));
+
+    await terminateRunners(runners, metrics);
+
+    expect(mockEC2.terminateInstances).toBeCalledTimes(1);
+    expect(mockSSM.describeParameters).toBeCalledTimes(1);
+    // Should still attempt direct deletion even when describe fails
+    expect(mockSSM.deleteParameter).toBeCalledTimes(1);
     expect(mockSSM.deleteParameter).toBeCalledWith({
-      Name: getParameterNameForRunner(runner2.environment as string, runner2.instanceId),
+      Name: getParameterNameForRunner(runners[0].environment as string, runners[0].instanceId),
     });
   });
 });
@@ -1622,6 +1751,47 @@ describe('createRunner', () => {
 
       expect(mockEC2.runInstances).toHaveBeenCalledTimes(8);
       expect(runnerConfigFn).toBeCalledTimes(0);
+    });
+  });
+});
+
+describe('terminateRunner', () => {
+  beforeEach(() => {
+    mockSSMdescribeParametersRet.mockClear();
+    mockEC2.terminateInstances.mockClear();
+    mockSSM.deleteParameter.mockClear();
+    const config = {
+      environment: 'gi-ci',
+      minimumRunningTimeInMinutes: 45,
+    };
+    jest.spyOn(Config, 'Instance', 'get').mockImplementation(() => config as unknown as Config);
+
+    resetRunnersCaches();
+  });
+
+  it('delegates to terminateRunners with single runner array', async () => {
+    const runner: RunnerInfo = {
+      awsRegion: 'us-east-1',
+      instanceId: 'i-1234',
+      environment: 'gi-ci',
+    };
+
+    // Mock terminateRunners by mocking the underlying calls
+    mockSSMdescribeParametersRet.mockResolvedValueOnce({
+      Parameters: [{ Name: 'gi-ci-i-1234' }],
+    });
+    mockEC2.terminateInstances.mockReturnValueOnce({
+      promise: jest.fn().mockResolvedValueOnce({}),
+    });
+
+    await terminateRunner(runner, metrics);
+
+    // Verify the calls match what terminateRunners would do with a single runner
+    expect(mockEC2.terminateInstances).toBeCalledWith({
+      InstanceIds: ['i-1234'],
+    });
+    expect(mockSSM.deleteParameter).toBeCalledWith({
+      Name: 'gi-ci-i-1234',
     });
   });
 });

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -314,49 +314,181 @@ export async function doDeleteSSMParameter(paramName: string, metrics: Metrics, 
 }
 
 export async function terminateRunner(runner: RunnerInfo, metrics: Metrics): Promise<void> {
-  try {
-    const ec2 = new EC2({ region: runner.awsRegion });
+  await terminateRunners([runner], metrics);
+}
 
-    await expBackOff(() => {
-      return metrics.trackRequestRegion(
-        runner.awsRegion,
-        metrics.ec2TerminateInstancesAWSCallSuccess,
-        metrics.ec2TerminateInstancesAWSCallFailure,
-        () => {
-          return ec2.terminateInstances({ InstanceIds: [runner.instanceId] }).promise();
-        },
-      );
-    });
-    console.info(`Runner terminated: ${runner.instanceId} ${runner.runnerType}`);
+export async function terminateRunners(runners: RunnerInfo[], metrics: Metrics): Promise<void> {
+  const errors: Array<{ instanceId: string; error: unknown }> = [];
 
-    const paramName = getParameterNameForRunner(runner.environment || Config.Instance.environment, runner.instanceId);
-    const cacheName = `${SHOULD_NOT_TRY_LIST_SSM}_${runner.awsRegion}`;
-
-    if (ssmParametersCache.has(cacheName)) {
-      doDeleteSSMParameter(paramName, metrics, runner.awsRegion);
-    } else {
-      try {
-        const params = await listSSMParameters(metrics, runner.awsRegion);
-
-        if (params.has(paramName)) {
-          doDeleteSSMParameter(paramName, metrics, runner.awsRegion);
-        } else {
-          /* istanbul ignore next */
-          console.info(`[${runner.awsRegion}] Parameter "${paramName}" not found in SSM, no need to delete it`);
-        }
-      } catch (e) {
-        ssmParametersCache.set(cacheName, 1, 60 * 1000);
-        console.error(
-          `[terminateRunner - listSSMParameters] [${runner.awsRegion}] ` +
-            `Failed to list parameters or check if available: ${e}`,
-        );
-        doDeleteSSMParameter(paramName, metrics, runner.awsRegion);
-      }
+  // Group runners by region for efficient AWS API calls
+  const runnersByRegion = new Map<string, RunnerInfo[]>();
+  runners.forEach((runner) => {
+    if (!runnersByRegion.has(runner.awsRegion)) {
+      runnersByRegion.set(runner.awsRegion, []);
     }
-  } catch (e) {
-    console.error(`[${runner.awsRegion}] [terminateRunner]: ${e}`);
-    throw e;
+    runnersByRegion.get(runner.awsRegion)!.push(runner);
+  });
+
+  // Process each region
+  for (const [region, regionRunners] of runnersByRegion) {
+    try {
+      await terminateRunnersInRegion(regionRunners, metrics, region);
+    } catch (e) {
+      // Mark all runners in this region as failed
+      regionRunners.forEach((runner) => {
+        errors.push({ instanceId: runner.instanceId, error: e });
+      });
+    }
   }
+
+  // Throw errors if any occurred
+  if (errors.length > 0) {
+    const errorMessage = errors
+      .map(
+        ({ instanceId, error }) => `Instance ${instanceId}: ${error instanceof Error ? error.message : String(error)}`,
+      )
+      .join('; ');
+    throw new Error(`Failed to terminate some runners: ${errorMessage}`);
+  }
+}
+
+async function terminateRunnersInRegion(runners: RunnerInfo[], metrics: Metrics, region: string): Promise<void> {
+  const ec2 = new EC2({ region });
+  const ssm = new SSM({ region });
+
+  // Terminate instances in batches of 100
+  const instanceBatches = chunkArray(
+    runners.map((r) => r.instanceId),
+    100,
+  );
+
+  console.info(`[${region}] Processing ${runners.length} runners in ${instanceBatches.length} batch(es)`);
+
+  for (const [batchIndex, instanceBatch] of instanceBatches.entries()) {
+    console.info(
+      `[${region}] Processing batch ${batchIndex + 1}/${instanceBatches.length} with ${
+        instanceBatch.length
+      } instances: ${instanceBatch.join(', ')}`,
+    );
+
+    try {
+      await expBackOff(() => {
+        return metrics.trackRequestRegion(
+          region,
+          metrics.ec2TerminateInstancesAWSCallSuccess,
+          metrics.ec2TerminateInstancesAWSCallFailure,
+          () => {
+            return ec2.terminateInstances({ InstanceIds: instanceBatch }).promise();
+          },
+        );
+      });
+
+      console.info(
+        `[${region}] Successfully terminated batch ${batchIndex + 1}/${instanceBatches.length}: ${instanceBatch.join(
+          ', ',
+        )}`,
+      );
+    } catch (e) {
+      console.error(
+        `[${region}] Failed to terminate batch ${batchIndex + 1}/${instanceBatches.length}: ${instanceBatch.join(
+          ', ',
+        )} - ${e}`,
+      );
+      throw e;
+    }
+  }
+
+  // Handle SSM parameter cleanup
+  await cleanupSSMParametersForRunners(runners, metrics, region, ssm);
+}
+
+async function cleanupSSMParametersForRunners(
+  runners: RunnerInfo[],
+  metrics: Metrics,
+  region: string,
+  ssm: SSM,
+): Promise<void> {
+  const paramNames = runners.map((runner) =>
+    getParameterNameForRunner(runner.environment || Config.Instance.environment, runner.instanceId),
+  );
+
+  const cacheName = `${SHOULD_NOT_TRY_LIST_SSM}_${region}`;
+
+  if (ssmParametersCache.has(cacheName)) {
+    // If we've had recent failures listing parameters, just try to delete them directly
+    await deleteSSMParametersInBatches(paramNames, metrics, region, ssm);
+  } else {
+    try {
+      const existingParams = await listSSMParameters(metrics, region);
+      const paramsToDelete = paramNames.filter((paramName) => existingParams.has(paramName));
+
+      if (paramsToDelete.length > 0) {
+        await deleteSSMParametersInBatches(paramsToDelete, metrics, region, ssm);
+      } else {
+        console.info(`[${region}] No SSM parameters found to delete for ${paramNames.length} runners`);
+      }
+    } catch (e) {
+      ssmParametersCache.set(cacheName, 1, 60 * 1000);
+      console.error(
+        `[terminateRunnersInRegion - listSSMParameters] [${region}] ` +
+          `Failed to list parameters, attempting direct deletion: ${e}`,
+      );
+      await deleteSSMParametersInBatches(paramNames, metrics, region, ssm);
+    }
+  }
+}
+
+async function deleteSSMParametersInBatches(
+  paramNames: string[],
+  metrics: Metrics,
+  region: string,
+  ssm: SSM,
+): Promise<void> {
+  const batches = chunkArray(paramNames, 10);
+
+  console.info(`[${region}] Processing ${paramNames.length} SSM parameters in ${batches.length} batch(es)`);
+
+  for (const [batchIndex, batch] of batches.entries()) {
+    console.info(
+      `[${region}] Processing SSM batch ${batchIndex + 1}/${batches.length} with ${
+        batch.length
+      } parameters: ${batch.join(', ')}`,
+    );
+
+    try {
+      await Promise.all(
+        batch.map((paramName) =>
+          expBackOff(() => {
+            return metrics.trackRequestRegion(
+              region,
+              metrics.ssmdeleteParameterAWSCallSuccess,
+              metrics.ssmdeleteParameterAWSCallFailure,
+              () => {
+                return ssm.deleteParameter({ Name: paramName }).promise();
+              },
+            );
+          }),
+        ),
+      );
+
+      console.info(
+        `[${region}] Successfully deleted SSM batch ${batchIndex + 1}/${batches.length}: ${batch.join(', ')}`,
+      );
+    } catch (e) {
+      console.error(
+        `[${region}] Failed to delete SSM batch ${batchIndex + 1}/${batches.length}: ${batch.join(', ')} - ${e}`,
+      );
+      // Continue with other batches even if one fails
+    }
+  }
+}
+
+function chunkArray<T>(array: T[], chunkSize: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < array.length; i += chunkSize) {
+    chunks.push(array.slice(i, i + chunkSize));
+  }
+  return chunks;
 }
 
 async function addSSMParameterRunnerConfig(

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -326,7 +326,10 @@ export async function terminateRunners(runners: RunnerInfo[], metrics: Metrics):
     if (!runnersByRegion.has(runner.awsRegion)) {
       runnersByRegion.set(runner.awsRegion, []);
     }
-    runnersByRegion.get(runner.awsRegion)!.push(runner);
+    const regionRunners = runnersByRegion.get(runner.awsRegion);
+    if (regionRunners) {
+      regionRunners.push(runner);
+    }
   });
 
   // Process each region

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -356,50 +356,67 @@ async function terminateRunnersInRegion(runners: RunnerInfo[], metrics: Metrics,
   const ec2 = new EC2({ region });
   const ssm = new SSM({ region });
 
-  // Terminate instances in batches of 100
-  const instanceBatches = chunkArray(
-    runners.map((r) => r.instanceId),
-    100,
-  );
+  // Keep track of runners that were successfully terminated so we can clean up their SSM parameters even
+  // if a later batch fails.
+  const successfullyTerminated: RunnerInfo[] = [];
+
+  // Terminate instances in batches of 100 RunnerInfo objects
+  const instanceBatches = chunkArray(runners, 100);
 
   console.info(`[${region}] Processing ${runners.length} runners in ${instanceBatches.length} batch(es)`);
 
-  for (const [batchIndex, instanceBatch] of instanceBatches.entries()) {
-    console.info(
-      `[${region}] Processing batch ${batchIndex + 1}/${instanceBatches.length} with ${
-        instanceBatch.length
-      } instances: ${instanceBatch.join(', ')}`,
-    );
-
-    try {
-      await expBackOff(() => {
-        return metrics.trackRequestRegion(
-          region,
-          metrics.ec2TerminateInstancesAWSCallSuccess,
-          metrics.ec2TerminateInstancesAWSCallFailure,
-          () => {
-            return ec2.terminateInstances({ InstanceIds: instanceBatch }).promise();
-          },
-        );
-      });
-
+  // We'll attempt to terminate all batches, but if any batch throws we still want to clean up the SSM
+  // parameters for the instances that were already terminated.  To achieve this we wrap the whole
+  // operation in a try / finally block so that the cleanup always executes.
+  try {
+    for (const [batchIndex, instanceBatch] of instanceBatches.entries()) {
       console.info(
-        `[${region}] Successfully terminated batch ${batchIndex + 1}/${instanceBatches.length}: ${instanceBatch.join(
-          ', ',
-        )}`,
+        `[${region}] Processing batch ${batchIndex + 1}/${instanceBatches.length} with ${
+          instanceBatch.length
+        } instances: ${instanceBatch.map((r) => r.instanceId).join(', ')}`,
       );
-    } catch (e) {
+
+      try {
+        await expBackOff(() => {
+          return metrics.trackRequestRegion(
+            region,
+            metrics.ec2TerminateInstancesAWSCallSuccess,
+            metrics.ec2TerminateInstancesAWSCallFailure,
+            () => {
+              return ec2.terminateInstances({ InstanceIds: instanceBatch.map((r) => r.instanceId) }).promise();
+            },
+          );
+        });
+
+        console.info(
+          `[${region}] Successfully terminated batch ${batchIndex + 1}/${instanceBatches.length}: ${instanceBatch
+            .map((r) => r.instanceId)
+            .join(', ')}`,
+        );
+
+        // Record successfully terminated runners so that we can clean up their SSM parameters later.
+        successfullyTerminated.push(...instanceBatch);
+      } catch (e) {
+        console.error(
+          `[${region}] Failed to terminate batch ${batchIndex + 1}/${instanceBatches.length}: ${instanceBatch
+            .map((r) => r.instanceId)
+            .join(', ')} - ${e}`,
+        );
+        // Re-throw so that callers are aware of the failure; the finally block will still execute and
+        // attempt SSM cleanup for the instances that were already terminated.
+        throw e;
+      }
+    }
+  } finally {
+    try {
+      await cleanupSSMParametersForRunners(successfullyTerminated, metrics, region, ssm);
+    } catch (cleanupErr) {
+      // We do not want cleanup issues to mask the original termination error, just log them.
       console.error(
-        `[${region}] Failed to terminate batch ${batchIndex + 1}/${instanceBatches.length}: ${instanceBatch.join(
-          ', ',
-        )} - ${e}`,
+        `[${region}] Error during SSM parameter cleanup for ${successfullyTerminated.length} runners: ${cleanupErr}`,
       );
-      throw e;
     }
   }
-
-  // Handle SSM parameter cleanup
-  await cleanupSSMParametersForRunners(runners, metrics, region, ssm);
 }
 
 async function cleanupSSMParametersForRunners(

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
@@ -21,7 +21,6 @@ import {
   doDeleteSSMParameter,
   listRunners,
   resetRunnersCaches,
-  terminateRunner,
   terminateRunners,
   RunnerType,
   listSSMParameters,

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
@@ -22,6 +22,7 @@ import {
   listRunners,
   resetRunnersCaches,
   terminateRunner,
+  terminateRunners,
   RunnerType,
   listSSMParameters,
 } from './runners';
@@ -53,15 +54,19 @@ jest.mock('./gh-runners', () => ({
   resetGHRunnersCaches: jest.fn(),
 }));
 
-jest.mock('./runners', () => ({
+jest.mock('./runners', () => {
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  ...(jest.requireActual('./runners') as any),
-  doDeleteSSMParameter: jest.fn(),
-  listRunners: jest.fn(),
-  listSSMParameters: jest.fn(),
-  resetRunnersCaches: jest.fn(),
-  terminateRunner: jest.fn(),
-}));
+  const actual = jest.requireActual('./runners') as any;
+  return {
+    ...actual,
+    doDeleteSSMParameter: jest.fn(),
+    listRunners: jest.fn(),
+    listSSMParameters: jest.fn().mockResolvedValue(new Map()),
+    resetRunnersCaches: jest.fn(),
+    terminateRunner: jest.fn(),
+    terminateRunners: jest.fn(),
+  };
+});
 
 jest.mock('./gh-auth', () => ({
   resetSecretCache: jest.fn(),
@@ -153,7 +158,7 @@ describe('scale-down', () => {
       const mockedListGithubRunnersOrg = mocked(listGithubRunnersOrg);
       const mockedRemoveGithubRunnerOrg = mocked(removeGithubRunnerOrg);
       const mockedRemoveGithubRunnerRepo = mocked(removeGithubRunnerRepo);
-      const mockedTerminateRunner = mocked(terminateRunner);
+      const mockedTerminateRunners = mocked(terminateRunners);
 
       await scaleDown();
 
@@ -164,7 +169,9 @@ describe('scale-down', () => {
       expect(mockedListGithubRunnersOrg).not.toBeCalled();
       expect(mockedRemoveGithubRunnerOrg).not.toBeCalled();
       expect(mockedRemoveGithubRunnerRepo).not.toBeCalled();
-      expect(mockedTerminateRunner).not.toBeCalled();
+
+      expect(mockedTerminateRunners).toBeCalledTimes(1);
+      expect(mockedTerminateRunners).toBeCalledWith([], metrics);
     });
   });
 
@@ -447,7 +454,7 @@ describe('scale-down', () => {
       const mockedListGithubRunnersOrg = mocked(listGithubRunnersOrg);
       const mockedGetRunnerTypes = mocked(getRunnerTypes);
       const mockedRemoveGithubRunnerOrg = mocked(removeGithubRunnerOrg);
-      const mockedTerminateRunner = mocked(terminateRunner);
+      const mockedTerminateRunners = mocked(terminateRunners);
 
       mockedListRunners.mockResolvedValueOnce(listRunnersRet);
       mockedListGithubRunnersOrg.mockResolvedValue(ghRunners);
@@ -490,27 +497,17 @@ describe('scale-down', () => {
         expect(mockedRemoveGithubRunnerOrg).toBeCalledWith(ghR.id, theOrg, metrics);
       }
 
-      expect(mockedTerminateRunner).toBeCalledTimes(5);
-      {
-        const { awsR } = getRunnerPair('keep-lt-min-no-ghrunner-no-ghr-02');
-        expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
-      }
-      {
-        const { awsR } = getRunnerPair('keep-lt-min-no-ghrunner-no-ghr-01');
-        expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
-      }
-      {
-        const { awsR } = getRunnerPair('keep-min-runners-oldest-02');
-        expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
-      }
-      {
-        const { awsR } = getRunnerPair('keep-min-runners-oldest-01');
-        expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
-      }
-      {
-        const { awsR } = getRunnerPair('remove-ephemeral-02');
-        expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
-      }
+      expect(mockedTerminateRunners).toBeCalledTimes(1);
+      const terminated = mockedTerminateRunners.mock.calls[0][0] as RunnerInfo[];
+      expect(terminated.map((r) => r.instanceId).sort()).toEqual(
+        [
+          'keep-lt-min-no-ghrunner-no-ghr-02',
+          'keep-lt-min-no-ghrunner-no-ghr-01',
+          'keep-min-runners-oldest-02',
+          'keep-min-runners-oldest-01',
+          'remove-ephemeral-02',
+        ].sort(),
+      );
     });
   });
 
@@ -789,7 +786,7 @@ describe('scale-down', () => {
       const mockedListGithubRunnersRepo = mocked(listGithubRunnersRepo);
       const mockedGetRunnerTypes = mocked(getRunnerTypes);
       const mockedRemoveGithubRunnerRepo = mocked(removeGithubRunnerRepo);
-      const mockedTerminateRunner = mocked(terminateRunner);
+      const mockedTerminateRunners = mocked(terminateRunners);
 
       mockedListRunners.mockResolvedValueOnce(listRunnersRet);
       mockedListGithubRunnersRepo.mockResolvedValue(ghRunners);
@@ -832,27 +829,17 @@ describe('scale-down', () => {
         expect(mockedRemoveGithubRunnerRepo).toBeCalledWith(ghR.id, repo, metrics);
       }
 
-      expect(mockedTerminateRunner).toBeCalledTimes(5);
-      {
-        const { awsR } = getRunnerPair('keep-lt-min-no-ghrunner-no-ghr-02');
-        expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
-      }
-      {
-        const { awsR } = getRunnerPair('keep-lt-min-no-ghrunner-no-ghr-01');
-        expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
-      }
-      {
-        const { awsR } = getRunnerPair('keep-min-runners-oldest-02');
-        expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
-      }
-      {
-        const { awsR } = getRunnerPair('keep-min-runners-oldest-01');
-        expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
-      }
-      {
-        const { awsR } = getRunnerPair('remove-ephemeral-02');
-        expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
-      }
+      expect(mockedTerminateRunners).toBeCalledTimes(1);
+      const terminatedRepo = mockedTerminateRunners.mock.calls[0][0] as RunnerInfo[];
+      expect(terminatedRepo.map((r) => r.instanceId).sort()).toEqual(
+        [
+          'keep-lt-min-no-ghrunner-no-ghr-02',
+          'keep-lt-min-no-ghrunner-no-ghr-01',
+          'keep-min-runners-oldest-02',
+          'keep-min-runners-oldest-01',
+          'remove-ephemeral-02',
+        ].sort(),
+      );
     });
   });
 

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -13,7 +13,14 @@ import {
   resetGHRunnersCaches,
 } from './gh-runners';
 import { ScaleDownMetrics, sendMetricsAtTimeout, sendMetricsTimeoutVars } from './metrics';
-import { doDeleteSSMParameter, listRunners, listSSMParameters, resetRunnersCaches, terminateRunner } from './runners';
+import {
+  doDeleteSSMParameter,
+  listRunners,
+  listSSMParameters,
+  resetRunnersCaches,
+  terminateRunner,
+  terminateRunners,
+} from './runners';
 import { getRepo, groupBy, Repo, RunnerInfo, isGHRateLimitError, shuffleArrayInPlace } from './utils';
 import { SSM } from 'aws-sdk';
 
@@ -55,6 +62,7 @@ export async function scaleDown(): Promise<void> {
 
     const foundOrgs = new Set<string>();
     const foundRepos = new Set<string>();
+    const runnersToRemove: RunnerInfo[] = [];
 
     for (const [runnerType, runners] of shuffleArrayInPlace(Array.from(runnersDict.entries()))) {
       if (runners.length < 1 || runners[0].runnerType === undefined || runnerType === undefined) continue;
@@ -175,23 +183,16 @@ export async function scaleDown(): Promise<void> {
 
         if (shouldRemoveEC2) {
           removedRunners += 1;
-
+          runnersToRemove.push(ec2runner);
           console.info(`Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}] will be removed.`);
-          try {
-            await terminateRunner(ec2runner, metrics);
-            metrics.runnerTerminateSuccess(ec2runner);
-          } catch (e) {
-            /* istanbul ignore next */
-            metrics.runnerTerminateFailure(ec2runner);
-            /* istanbul ignore next */
-            console.error(`Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}] cannot be removed: ${e}`);
-          }
         } else {
           /* istanbul ignore next */
           metrics.runnerTerminateSkipped(ec2runner);
         }
       }
     }
+
+    await terminateRunners(runnersToRemove, metrics);
 
     if (Config.Instance.enableOrganizationRunners) {
       for (const org of foundOrgs) {

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -13,13 +13,7 @@ import {
   resetGHRunnersCaches,
 } from './gh-runners';
 import { ScaleDownMetrics, sendMetricsAtTimeout, sendMetricsTimeoutVars } from './metrics';
-import {
-  doDeleteSSMParameter,
-  listRunners,
-  listSSMParameters,
-  resetRunnersCaches,
-  terminateRunners,
-} from './runners';
+import { doDeleteSSMParameter, listRunners, listSSMParameters, resetRunnersCaches, terminateRunners } from './runners';
 import { getRepo, groupBy, Repo, RunnerInfo, isGHRateLimitError, shuffleArrayInPlace } from './utils';
 import { SSM } from 'aws-sdk';
 

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -18,7 +18,6 @@ import {
   listRunners,
   listSSMParameters,
   resetRunnersCaches,
-  terminateRunner,
   terminateRunners,
 } from './runners';
 import { getRepo, groupBy, Repo, RunnerInfo, isGHRateLimitError, shuffleArrayInPlace } from './utils';


### PR DESCRIPTION
I had noticed that we were terminating instances 1 by 1 in the original code so this adds batching for terminateRunner calls in order to fix those performance bottlenecks.

As well during the termination we were deleting ssm parameters one by one so this also adds batching to the ssm parameter deletion as well.

Goal here was to implement the performance improvements with minimal changes.

This PR super-cedes #6725 
