### PR TITLE
runners: More scale-down perf improvements

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -371,53 +371,42 @@ async function terminateRunnersInRegion(runners: RunnerInfo[], metrics: Metrics,
   // We'll attempt to terminate all batches, but if any batch throws we still want to clean up the SSM
   // parameters for the instances that were already terminated.  To achieve this we wrap the whole
   // operation in a try / finally block so that the cleanup always executes.
-  try {
-    for (const [batchIndex, instanceBatch] of instanceBatches.entries()) {
-      console.info(
-        `[${region}] Processing batch ${batchIndex + 1}/${instanceBatches.length} with ${
-          instanceBatch.length
-        } instances: ${instanceBatch.map((r) => r.instanceId).join(', ')}`,
-      );
+  for (const [batchIndex, instanceBatch] of instanceBatches.entries()) {
+    console.info(
+      `[${region}] Processing batch ${batchIndex + 1}/${instanceBatches.length} with ${
+        instanceBatch.length
+      } instances: ${instanceBatch.map((r) => r.instanceId).join(', ')}`,
+    );
 
-      try {
-        await expBackOff(() => {
-          return metrics.trackRequestRegion(
-            region,
-            metrics.ec2TerminateInstancesAWSCallSuccess,
-            metrics.ec2TerminateInstancesAWSCallFailure,
-            () => {
-              return ec2.terminateInstances({ InstanceIds: instanceBatch.map((r) => r.instanceId) }).promise();
-            },
-          );
-        });
-
-        console.info(
-          `[${region}] Successfully terminated batch ${batchIndex + 1}/${instanceBatches.length}: ${instanceBatch
-            .map((r) => r.instanceId)
-            .join(', ')}`,
-        );
-
-        // Record successfully terminated runners so that we can clean up their SSM parameters later.
-        successfullyTerminated.push(...instanceBatch);
-      } catch (e) {
-        console.error(
-          `[${region}] Failed to terminate batch ${batchIndex + 1}/${instanceBatches.length}: ${instanceBatch
-            .map((r) => r.instanceId)
-            .join(', ')} - ${e}`,
-        );
-        // Re-throw so that callers are aware of the failure; the finally block will still execute and
-        // attempt SSM cleanup for the instances that were already terminated.
-        throw e;
-      }
-    }
-  } finally {
     try {
-      await cleanupSSMParametersForRunners(successfullyTerminated, metrics, region, ssm);
-    } catch (cleanupErr) {
-      // We do not want cleanup issues to mask the original termination error, just log them.
-      console.error(
-        `[${region}] Error during SSM parameter cleanup for ${successfullyTerminated.length} runners: ${cleanupErr}`,
+      await expBackOff(() => {
+        return metrics.trackRequestRegion(
+          region,
+          metrics.ec2TerminateInstancesAWSCallSuccess,
+          metrics.ec2TerminateInstancesAWSCallFailure,
+          () => {
+            return ec2.terminateInstances({ InstanceIds: instanceBatch.map((r) => r.instanceId) }).promise();
+          },
+        );
+      });
+
+      console.info(
+        `[${region}] Successfully terminated batch ${batchIndex + 1}/${instanceBatches.length}: ${instanceBatch
+          .map((r) => r.instanceId)
+          .join(', ')}`,
       );
+
+      // Record successfully terminated runners so that we can clean up their SSM parameters later.
+      successfullyTerminated.push(...instanceBatch);
+    } catch (e) {
+      console.error(
+        `[${region}] Failed to terminate batch ${batchIndex + 1}/${instanceBatches.length}: ${instanceBatch
+          .map((r) => r.instanceId)
+          .join(', ')} - ${e}`,
+      );
+      // Re-throw so that callers are aware of the failure; the finally block will still execute and
+      // attempt SSM cleanup for the instances that were already terminated.
+      throw e;
     }
   }
 }

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
@@ -1448,7 +1448,6 @@ describe('scale-down', () => {
 
     it('dont finds on listGithubRunnersRep, finds with getRunnerRepo, busy === false', async () => {
       const mockedListGithubRunnersRepo = mocked(listGithubRunnersRepo);
-      const mockedGetRunnerRepo = mocked(getRunnerRepo);
       const ec2runner: RunnerInfo = {
         awsRegion: baseConfig.awsRegion,
         repo: repoKey,
@@ -1456,22 +1455,17 @@ describe('scale-down', () => {
         runnerType: 'runnerType-01',
         ghRunnerId: 'ghRunnerId-01',
       };
-      const theGhRunner = { name: 'instance-id-03', busy: false } as GhRunner;
 
       mockedListGithubRunnersRepo.mockResolvedValueOnce(ghRunners);
-      mockedGetRunnerRepo.mockResolvedValueOnce(theGhRunner);
 
-      expect(await getGHRunnerRepo(ec2runner, metrics)).toEqual(theGhRunner);
+      expect(await getGHRunnerRepo(ec2runner, metrics)).toBeUndefined();
 
       expect(mockedListGithubRunnersRepo).toBeCalledTimes(1);
       expect(mockedListGithubRunnersRepo).toBeCalledWith(repo, metrics);
-      expect(mockedGetRunnerRepo).toBeCalledTimes(1);
-      expect(mockedGetRunnerRepo).toBeCalledWith(repo, ec2runner.ghRunnerId, metrics);
     });
 
     it('listGithubRunnersRep and getRunnerRepo throws exception', async () => {
       const mockedListGithubRunnersRepo = mocked(listGithubRunnersRepo);
-      const mockedGetRunnerRepo = mocked(getRunnerRepo);
       const ec2runner: RunnerInfo = {
         awsRegion: baseConfig.awsRegion,
         repo: repoKey,
@@ -1481,14 +1475,11 @@ describe('scale-down', () => {
       };
 
       mockedListGithubRunnersRepo.mockRejectedValueOnce('Error');
-      mockedGetRunnerRepo.mockRejectedValueOnce('Error');
 
       expect(await getGHRunnerRepo(ec2runner, metrics)).toBeUndefined();
 
       expect(mockedListGithubRunnersRepo).toBeCalledTimes(1);
       expect(mockedListGithubRunnersRepo).toBeCalledWith(repo, metrics);
-      expect(mockedGetRunnerRepo).toBeCalledTimes(1);
-      expect(mockedGetRunnerRepo).toBeCalledWith(repo, ec2runner.ghRunnerId, metrics);
     });
   });
 
@@ -1635,7 +1626,6 @@ describe('scale-down', () => {
 
     it('dont finds on listGithubRunnersOrg, finds with getRunnerOrg, busy === false', async () => {
       const mockedListGithubRunnersOrg = mocked(listGithubRunnersOrg);
-      const mockedGetRunnerOrg = mocked(getRunnerOrg);
       const ec2runner: RunnerInfo = {
         awsRegion: baseConfig.awsRegion,
         org: org,
@@ -1643,22 +1633,17 @@ describe('scale-down', () => {
         runnerType: 'runnerType-01',
         ghRunnerId: 'ghRunnerId-01',
       };
-      const theGhRunner = { name: 'instance-id-03', busy: false } as GhRunner;
 
       mockedListGithubRunnersOrg.mockResolvedValueOnce(ghRunners);
-      mockedGetRunnerOrg.mockResolvedValueOnce(theGhRunner);
 
-      expect(await getGHRunnerOrg(ec2runner, metrics)).toEqual(theGhRunner);
+      expect(await getGHRunnerOrg(ec2runner, metrics)).toBeUndefined();
 
       expect(mockedListGithubRunnersOrg).toBeCalledTimes(1);
       expect(mockedListGithubRunnersOrg).toBeCalledWith(org, metrics);
-      expect(mockedGetRunnerOrg).toBeCalledTimes(1);
-      expect(mockedGetRunnerOrg).toBeCalledWith(org, ec2runner.ghRunnerId, metrics);
     });
 
     it('listGithubRunnersRep and getRunnerRepo throws exception', async () => {
       const mockedListGithubRunnersOrg = mocked(listGithubRunnersOrg);
-      const mockedGetRunnerOrg = mocked(getRunnerOrg);
       const ec2runner: RunnerInfo = {
         awsRegion: baseConfig.awsRegion,
         org: org,
@@ -1668,14 +1653,11 @@ describe('scale-down', () => {
       };
 
       mockedListGithubRunnersOrg.mockRejectedValueOnce('Error');
-      mockedGetRunnerOrg.mockRejectedValueOnce('Error');
 
       expect(await getGHRunnerOrg(ec2runner, metrics)).toBeUndefined();
 
       expect(mockedListGithubRunnersOrg).toBeCalledTimes(1);
       expect(mockedListGithubRunnersOrg).toBeCalledWith(org, metrics);
-      expect(mockedGetRunnerOrg).toBeCalledTimes(1);
-      expect(mockedGetRunnerOrg).toBeCalledWith(org, ec2runner.ghRunnerId, metrics);
     });
 
     it('getRunner throws when api rate limit is hit', async () => {

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -298,24 +298,6 @@ export async function getGHRunnerOrg(ec2runner: RunnerInfo, metrics: ScaleDownMe
     }
   }
 
-  if (ghRunner === undefined && ec2runner.ghRunnerId !== undefined) {
-    console.warn(
-      `Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}](${org}) not found in ` +
-        `listGithubRunnersOrg call, attempting to grab directly`,
-    );
-    try {
-      ghRunner = await getRunnerOrg(ec2runner.org as string, ec2runner.ghRunnerId, metrics);
-    } catch (e) {
-      console.warn(
-        `Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}](${org}) error when ` +
-          `listGithubRunnersOrg call: ${e}`,
-      );
-      /* istanbul ignore next */
-      if (isGHRateLimitError(e)) {
-        throw e;
-      }
-    }
-  }
   if (ghRunner) {
     if (ghRunner.busy) {
       metrics.runnerGhFoundBusyOrg(org, ec2runner);
@@ -343,31 +325,6 @@ export async function getGHRunnerRepo(ec2runner: RunnerInfo, metrics: ScaleDownM
     }
   }
 
-  if (ghRunner === undefined) {
-    if (ec2runner.ghRunnerId === undefined) {
-      console.warn(
-        `Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}](${repo}) was neither found in ` +
-          `the list of runners returned by the listGithubRunnersRepo api call, nor did it have the ` +
-          `GithubRunnerId EC2 tag set.  This can happen if there's no runner running on the instance.`,
-      );
-    } else {
-      console.warn(
-        `Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}](${repo}) not found in ` +
-          `listGithubRunnersRepo call, attempting to grab directly`,
-      );
-      try {
-        ghRunner = await getRunnerRepo(repo, ec2runner.ghRunnerId, metrics);
-      } catch (e) {
-        console.warn(
-          `Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}](${repo}) error when getRunnerRepo call: ${e}`,
-        );
-        /* istanbul ignore next */
-        if (isGHRateLimitError(e)) {
-          throw e;
-        }
-      }
-    }
-  }
   if (ghRunner !== undefined) {
     if (ghRunner.busy) {
       metrics.runnerGhFoundBusyRepo(repo, ec2runner);

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/utils.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/utils.ts
@@ -78,6 +78,8 @@ export async function expBackOff<T>(
         if (expBackOffMs > maxMs) {
           throw e;
         }
+        const functionName = callback.name || 'anonymous';
+        console.warn(`[expBackOff]"${functionName}" needing to back off for function for ${expBackOffMs}ms: ${e}`);
         await new Promise((resolve) => setTimeout(resolve, expBackOffMs));
         expBackOffMs = expBackOffMs * backOffFactor;
       } else {


### PR DESCRIPTION
Does the following:
* Removes ssm parameter cleanup from terminateInstances (will be a follow-up PR to add a termination policy to parameters)
* Removed double check for ghRunner calls (was causing performance bottlenecks
  * NOTE: We will need to monitor removeGHRunnerOrg calls to see if those introduce another performance bottleneck + job cancellations (if they rise then we revert, dashboard: https://hud.pytorch.org/job_cancellation_dashboard)

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>