### PR TITLE
runners: Add expiration policy to SSM parameters

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
@@ -1340,7 +1340,26 @@ describe('createRunner', () => {
         Name: 'wg113-i-1234',
         Value: 'us-east-1-BLAH',
         Type: 'SecureString',
+        Policies: expect.any(String),
       });
+
+      // Verify the Policies parameter contains the correct expiration policy structure
+      const putParameterCall = mockSSM.putParameter.mock.calls[0][0];
+      const policies = JSON.parse(putParameterCall.Policies);
+      expect(policies).toEqual({
+        Type: 'Expiration',
+        Version: '1.0',
+        Attributes: {
+          Timestamp: expect.any(String),
+        },
+      });
+
+      // Verify the timestamp is approximately 30 minutes in the future
+      const expirationTime = new Date(policies.Attributes.Timestamp);
+      const now = Date.now();
+      const timeDiff = expirationTime.getTime() - now;
+      expect(timeDiff).toBeGreaterThan(25 * 60 * 1000); // at least 25 minutes (allowing for test execution time)
+      expect(timeDiff).toBeLessThan(35 * 60 * 1000); // at most 35 minutes (allowing for clock differences)
     });
 
     it('creates ssm experiment parameters when joining experiment', async () => {
@@ -1384,6 +1403,7 @@ describe('createRunner', () => {
         Name: 'wg113-i-1234',
         Value: 'us-east-1-BLAH #ON_AMI_EXPERIMENT',
         Type: 'SecureString',
+        Policies: expect.any(String),
       });
       expect(mockEC2.runInstances).toBeCalledTimes(1);
       expect(mockEC2.runInstances).toBeCalledWith(

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -534,6 +534,15 @@ async function addSSMParameterRunnerConfig(
                 Name: parameterName,
                 Value: runnerConfig,
                 Type: 'SecureString',
+                // NOTE: This does need to be a string, check docs at:
+                // https://docs.aws.amazon.com/systems-manager/latest/userguide/example_ssm_PutParameter_section.html
+                Policies: JSON.stringify({
+                  Type: 'Expiration',
+                  Version: '1.0',
+                  Attributes: {
+                    Timestamp: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+                  },
+                }),
               })
               .promise();
             return parameterName;


### PR DESCRIPTION
Instead of doing expensive cleanups we can rely on SSM parameter policies to do the cleanup for us!

This is a workaround to avoid the need to do expensive cleanup of SSM parameters.