### PR TITLE
Only add symm memory code path for auto labeling of h100-distributed

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -151,6 +151,7 @@ const repoSpecificAutoLabels: { [repo: string]: [RegExp, string][] } = {
     [/aten\/src\/ATen\/native\/mps/gi, "ciflow/mps"],
     [/torch\/_inductor\/codegen\/mps.py/gi, "ciflow/mps"],
     [/torch\/csrc\/distributed\/c10d\/symm_mem/gi, "ciflow/h100-symm-mem"],
+    [/torch\/distributed\/_symmetric_memory/gi, "ciflow/h100-symm-mem"],
     [/test\/distributed\/.*mem.*/gi, "ciflow/h100-symm-mem"],
     [/test\/test_mps.py/gi, "ciflow/mps"],
     [/test\/inductor\/test_mps_basic.py/gi, "ciflow/mps"],

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -150,7 +150,7 @@ const repoSpecificAutoLabels: { [repo: string]: [RegExp, string][] } = {
     [/aten\/src\/ATen\/mps/gi, "ciflow/mps"],
     [/aten\/src\/ATen\/native\/mps/gi, "ciflow/mps"],
     [/torch\/_inductor\/codegen\/mps.py/gi, "ciflow/mps"],
-    [/torch\/csrc\/distributed\/c10d\/symm_mem/gi, "ciflow/h100-distributed"],
+    [/torch\/csrc\/distributed\/c10d\/symm_mem/gi, "ciflow/h100-symm-mem"],
     [/test\/test_mps.py/gi, "ciflow/mps"],
     [/test\/inductor\/test_mps_basic.py/gi, "ciflow/mps"],
   ],

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -150,6 +150,7 @@ const repoSpecificAutoLabels: { [repo: string]: [RegExp, string][] } = {
     [/aten\/src\/ATen\/mps/gi, "ciflow/mps"],
     [/aten\/src\/ATen\/native\/mps/gi, "ciflow/mps"],
     [/torch\/_inductor\/codegen\/mps.py/gi, "ciflow/mps"],
+    [/torch\/csrc\/distributed\/c10d\/symm_mem/gi, "ciflow/h100-distributed"],
     [/test\/test_mps.py/gi, "ciflow/mps"],
     [/test\/inductor\/test_mps_basic.py/gi, "ciflow/mps"],
   ],

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -151,6 +151,7 @@ const repoSpecificAutoLabels: { [repo: string]: [RegExp, string][] } = {
     [/aten\/src\/ATen\/native\/mps/gi, "ciflow/mps"],
     [/torch\/_inductor\/codegen\/mps.py/gi, "ciflow/mps"],
     [/torch\/csrc\/distributed\/c10d\/symm_mem/gi, "ciflow/h100-symm-mem"],
+    [/test\/distributed\/.*mem.*/gi, "ciflow/h100-symm-mem"],
     [/test\/test_mps.py/gi, "ciflow/mps"],
     [/test\/inductor\/test_mps_basic.py/gi, "ciflow/mps"],
   ],


### PR DESCRIPTION
https://github.com/pytorch/test-infra/pull/6833/files gets reverted because we enabled the auto labeling for too broad code path, so we want to narrow down to symmetric memory only PRs.