### PR TITLE
Migrate upload-s3 action for workflow linux_job_v2

### DIFF
--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -334,7 +334,7 @@ jobs:
 
       # NB: This only works with our AWS runners
       - name: Upload artifacts to S3 (if any)
-        uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5.1.0
+        uses: ./test-infra/.github/actions/upload-artifact-s3
         if: ${{ always() && inputs.upload-artifact != '' && inputs.upload-artifact-to-s3 }}
         with:
           retention-days: 14
@@ -344,7 +344,7 @@ jobs:
           path: ${{ runner.temp }}/artifacts/
 
       - name: Upload documentation to S3 (if any)
-        uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5.1.0
+        uses: ./test-infra/.github/actions/upload-artifact-s3
         if: ${{ steps.check-artifacts.outputs.upload-docs == 1 && github.event.pull_request.number != '' }}
         with:
           retention-days: 14


### PR DESCRIPTION
This PR is part of a family of PRs that migrate the use of the upload-artifact-s3 action to the new version hosted in this repository. Together, they address step 1 of #6755.


All the PRs are:
- [ ] #6840
- [ ] #6872
- [ ] -> #6873
- [ ] #6874
- [ ] #6875
- [ ] #6876