### PR TITLE
Migrate upload-s3 action for mobile_job

### DIFF
--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -402,7 +402,7 @@ jobs:
           fi
 
       - name: Upload artifacts to S3
-        uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5.1.0
+        uses: ./.github/actions/upload-artifact-s3@2bc02bf10219ee519970d8883e3c613a4b2850b8 # v6.0.0
         if: always()
         with:
           retention-days: 14


### PR DESCRIPTION
This PR is part of a family of PRs that migrate the use of the upload-artifact-s3 action to the new version hosted in this repository. Together, they address step 1 of #6755.