### PR TITLE
Migrate upload-s3 action for workflow windows_job

### DIFF
--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -204,7 +204,7 @@ jobs:
 
       # NB: This only works with our AWS runners
       - name: Upload artifacts to S3 (if any)
-        uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5.1.0
+        uses: ./.github/actions/upload-artifact-s3@2bc02bf10219ee519970d8883e3c613a4b2850b8 # v6.0.0
         if: ${{ always() && inputs.upload-artifact != '' && inputs.upload-artifact-to-s3 }}
         with:
           retention-days: 14


### PR DESCRIPTION
This PR is part of a family of PRs that migrate the use of the upload-artifact-s3 action to the new version hosted in this repository. Together, they address step 1 of #6755.