### PR TITLE
Add revert category extractionand exclude `ghfirst` reverts from stats

### DIFF
--- a/aws/lambda/pytorch-auto-revert/.env.example
+++ b/aws/lambda/pytorch-auto-revert/.env.example
@@ -1,7 +1,7 @@
 # ClickHouse Configuration
 CLICKHOUSE_HOST=your_clickhouse_host
 CLICKHOUSE_PORT=9000
-CLICKHOUSE_USER=default
+CLICKHOUSE_USERNAME=default
 CLICKHOUSE_PASSWORD=your_password
 CLICKHOUSE_DATABASE=pytorch
 

--- a/aws/lambda/pytorch-auto-revert/README.md
+++ b/aws/lambda/pytorch-auto-revert/README.md
@@ -1,0 +1,92 @@
+# PyTorch Auto Revert
+
+A tool for detecting autorevert patterns in PyTorch CI workflows.
+
+## Installation
+
+1. Navigate to the project directory:
+```bash
+cd test-infra/aws/lambda/pytorch-auto-revert
+```
+
+2. Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+## Configuration
+
+Set the following environment variables or pass them as command-line arguments:
+
+### Required:
+- **ClickHouse connection:**
+  - `CLICKHOUSE_HOST` (or `--clickhouse-host`)
+  - `CLICKHOUSE_USERNAME` (or `--clickhouse-username`)
+  - `CLICKHOUSE_PASSWORD` (or `--clickhouse-password`)
+
+- **GitHub credentials (one of):**
+  - `GITHUB_TOKEN` (or `--github-access-token`)
+  - GitHub App credentials:
+    - `GITHUB_APP_ID` (or `--github-app-id`)
+    - `GITHUB_APP_SECRET` (or `--github-app-secret`)
+    - `GITHUB_INSTALLATION_ID` (or `--github-installation-id`)
+
+### Optional:
+- `CLICKHOUSE_PORT` (default: 8443)
+- `CLICKHOUSE_DATABASE` (default: default)
+- `LOG_LEVEL` (default: INFO)
+
+## Usage
+
+Run the autorevert checker from the project directory:
+
+```bash
+python -m pytorch_auto_revert autorevert-checker <workflows> [options]
+```
+
+### Parameters:
+- `workflows`: One or more workflow names (space separated)
+- `--hours`: Lookback window in hours (default: 48)
+- `--verbose` or `-v`: Show detailed output including commit summaries
+
+### Examples:
+
+1. **Single workflow with default 48-hour lookback:**
+```bash
+python -m pytorch_auto_revert autorevert-checker pull
+```
+
+2. **Single workflow with custom lookback:**
+```bash
+python -m pytorch_auto_revert autorevert-checker trunk --hours 72
+```
+
+3. **Multiple workflows (space separated):**
+```bash
+python -m pytorch_auto_revert autorevert-checker pull trunk inductor --hours 24
+```
+
+4. **With verbose output:**
+```bash
+python -m pytorch_auto_revert autorevert-checker pull --hours 48 --verbose
+```
+
+5. **With explicit credentials:**
+```bash
+python -m pytorch_auto_revert autorevert-checker pull \
+  --clickhouse-host your-host \
+  --clickhouse-username your-user \
+  --clickhouse-password your-pass \
+  --github-access-token your-token
+```
+
+## Other Commands
+
+The tool also supports:
+- `workflow-restart-checker`: Check for restarted workflows
+- `do-restart`: Restart a workflow for a specific commit
+
+Run with `--help` for more information:
+```bash
+python -m pytorch_auto_revert --help
+```

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/testers/autorevert.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/testers/autorevert.py
@@ -32,7 +32,7 @@ def autorevert_checker(
                 total_count = len(commit.jobs)
                 pending = " (PENDING)" if commit.has_pending_jobs else ""
                 print(
-                    f"  {i+1:2d}. {commit.head_sha[:8]} ({commit.created_at.strftime('%m-%d %H:%M')}) - "
+                    f"  {i + 1:2d}. {commit.head_sha[:8]} ({commit.created_at.strftime('%m-%d %H:%M')}) - "
                     f"{failed_count:2d}/{total_count:2d} failed{pending}"
                 )
     else:
@@ -46,6 +46,15 @@ def autorevert_checker(
     # Detect patterns
     patterns = checker.detect_autorevert_pattern()
     reverts = checker.get_commits_reverted()
+    reverts_with_info = checker.get_commits_reverted_with_info()
+
+    # Categorize reverts
+    reverts_by_category = defaultdict(set)
+    for sha, info in reverts_with_info.items():
+        category = info.get("category", "uncategorized")
+        reverts_by_category[category].add(sha)
+
+    # For recall calculation, we only consider non-ghfirst reverts
     not_found_reverts = reverts.copy()
 
     if patterns:
@@ -86,8 +95,11 @@ def autorevert_checker(
 
             if revert_result:
                 not_found_reverts.discard(second_commit)
+                category = reverts_with_info.get(second_commit, {}).get(
+                    "category", "uncategorized"
+                )
                 print(
-                    f"✓ REVERTED: {second_commit[:8]} was reverted by {revert_result['revert_sha'][:8]} "
+                    f"✓ REVERTED ({category}): {second_commit[:8]} was reverted by {revert_result['revert_sha'][:8]} "
                     f"after {revert_result['hours_after_target']:.1f} hours"
                 )
                 reverted_patterns.append(pattern)
@@ -127,19 +139,54 @@ def autorevert_checker(
         print(f"Auto revert patterns detected: {len(patterns)}")
         print(
             "Actual reverts inside auto revert patterns detected (precision): "
-            + f"{len(reverted_patterns)} ({len(reverted_patterns)/len(patterns)*100:.1f}%)"
+            + f"{len(reverted_patterns)} ({len(reverted_patterns) / len(patterns) * 100:.1f}%)"
         )
         print(f"Total revert commits in period: {len(reverts)}")
-        print(
-            "Reverts that dont match any auto revert pattern detected (recall): "
-            + f"{len(not_found_reverts)} ({len(not_found_reverts)/len(reverts)*100:.1f}%)"
-        )
 
-        workflow_statistics = defaultdict(lambda: {"match_pattern": 0, "reverts": 0})
+        # Show breakdown by category
+        if reverts_by_category:
+            print("\nRevert categories:")
+            for category, shas in sorted(
+                reverts_by_category.items(), key=lambda x: len(x[1]), reverse=True
+            ):
+                percentage = len(shas) / len(reverts) * 100
+                print(f"  {category}: {len(shas)} ({percentage:.1f}%)")
+
+        # Calculate non-ghfirst metrics
+        non_ghfirst_reverts = set()
+        for sha in reverts:
+            if (
+                reverts_with_info.get(sha, {}).get("category", "uncategorized")
+                != "ghfirst"
+            ):
+                non_ghfirst_reverts.add(sha)
+
+        not_found_non_ghfirst = not_found_reverts & non_ghfirst_reverts
+
+        print(f"\nTotal reverts excluding ghfirst: {len(non_ghfirst_reverts)}")
+
+        # Calculate recall based on non-ghfirst reverts only
+        if non_ghfirst_reverts:
+            print(
+                "Reverts (excluding ghfirst) that dont match any auto revert pattern detected (recall): "
+                + f"{len(not_found_non_ghfirst)} ({len(not_found_non_ghfirst) / len(non_ghfirst_reverts) * 100:.1f}%)"
+            )
+        else:
+            print("No non-ghfirst reverts found in the period")
+
+        workflow_statistics = defaultdict(
+            lambda: {"match_pattern": 0, "reverts": 0, "reverts_non_ghfirst": 0}
+        )
         for pattern in patterns:
             workflow_statistics[pattern["workflow_name"]]["match_pattern"] += 1
-            if pattern["newer_commits"][1] in reverts:
+            second_commit = pattern["newer_commits"][1]
+            if second_commit in reverts:
                 workflow_statistics[pattern["workflow_name"]]["reverts"] += 1
+                # Check if it's non-ghfirst
+                if second_commit in non_ghfirst_reverts:
+                    workflow_statistics[pattern["workflow_name"]][
+                        "reverts_non_ghfirst"
+                    ] += 1
 
         print("Per workflow precision:")
         for workflow, stats in workflow_statistics.items():
@@ -148,15 +195,25 @@ def autorevert_checker(
                 if stats["match_pattern"] > 0
                 else 0.0
             )
+            precision_non_ghfirst = (
+                stats["reverts_non_ghfirst"] / stats["match_pattern"] * 100
+                if stats["match_pattern"] > 0
+                else 0.0
+            )
             print(
                 f"  {workflow}: {stats['reverts']} reverts out of {stats['match_pattern']} patterns ({precision:.1f}%)"
+                f" [excluding ghfirst: {stats['reverts_non_ghfirst']} ({precision_non_ghfirst:.1f}%)]"
             )
 
         if reverted_patterns:
             print("\nReverted patterns:")
             for pattern in reverted_patterns:
+                second_commit = pattern["newer_commits"][1]
+                category = reverts_with_info.get(second_commit, {}).get(
+                    "category", "uncategorized"
+                )
                 print(
-                    f"  - {pattern['failure_rule']}: {pattern['newer_commits'][1][:8]}"
+                    f"  - {pattern['failure_rule']}: {second_commit[:8]} ({category})"
                 )
 
     else:
@@ -173,7 +230,7 @@ def autorevert_checker(
                         if j.classification_rule
                     }
                     print(
-                        f"  {i+1}. {commit.head_sha[:8]}: {len(failures)} unique failure types"
+                        f"  {i + 1}. {commit.head_sha[:8]}: {len(failures)} unique failure types"
                     )
                     if failures:
                         for rule in list(failures)[:2]:


### PR DESCRIPTION
Adds revert category extraction from GitHub comments and excludes `ghfirst` reverts from precision/recall metrics.

## Changes

### 1. Added Revert Category Extraction
- New method `extract_revert_categories_batch()` in `autorevert_checker.py`
- Extracts categories (`nosignal`, `ignoredsignal`, `landrace`, `weird`, `ghfirst`) from GitHub issue comments
- Single batch query for performance


### 2. Enhanced `get_commits_reverted_with_info()`
- Now includes category information for each revert
- Uses batch extraction for all reverts at once


### 3. Updated Metrics Calculation
- Excludes `ghfirst` reverts from recall calculation
- Shows category breakdown in summary statistics
- Per-workflow precision now shows both total and non-ghfirst metrics


### 4. Fixed Pattern Detection Bug
- Fixed `AttributeError: 'NoneType' object has no attribute 'head_sha'`
- Created proper mapping between failures and their newer commits

<details>
<summary>Bug Fix Details</summary>

**Problem**: `newer_commit_same_job` was used outside its loop scope
**Solution**: Created `failure_to_newer_commit` dict to track mappings
```python
# Map each failure to its newer commit
failure_to_newer_commit = {}
for (rule, job) in suspected_failures:
    newer_commit_same_job, newer_same_jobs = self._find_last_commit_with_job(...)
    if newer_commit_same_job and any(...):
        failure_to_newer_commit[(rule, job)] = newer_commit_same_job

# Use mapping in pattern creation
for (failure_rule, job_name), newer_commit in failure_to_newer_commit.items():
    patterns.append({
        "newer_commits": [newer_commit.head_sha, suspected_commit1.head_sha],
        ...
    })
```
</details>

## Example Output

```
 python -m pytorch_auto_revert autorevert-checker Lint trunk pull inductor linux-binary-manywheel  --hours 720 --verbose

==================================================
SUMMARY STATISTICS
==================================================
Workflow(s): Lint, trunk, pull, inductor, linux-binary-manywheel
Timeframe: 720 hours
Commits checked: 6741
Auto revert patterns detected: 419
Actual reverts inside auto revert patterns detected (precision): 50 (11.9%)
Total revert commits in period: 121

Revert categories:
  nosignal: 46 (38.0%)
  ghfirst: 28 (23.1%)
  uncategorized: 21 (17.4%)
  ignoredsignal: 16 (13.2%)
  weird: 9 (7.4%)
  landrace: 1 (0.8%)

Total reverts excluding ghfirst: 93
Reverts (excluding ghfirst) that dont match any auto revert pattern detected (recall): 50 (53.8%)
Per workflow precision:
  Lint: 6 reverts out of 17 patterns (35.3%) [excluding ghfirst: 6 (35.3%)]
  trunk: 2 reverts out of 14 patterns (14.3%) [excluding ghfirst: 2 (14.3%)]
  pull: 40 reverts out of 354 patterns (11.3%) [excluding ghfirst: 33 (9.3%)]
  inductor: 2 reverts out of 31 patterns (6.5%) [excluding ghfirst: 2 (6.5%)]
  linux-binary-manywheel: 0 reverts out of 3 patterns (0.0%) [excluding ghfirst: 0 (0.0%)]

Reverted patterns:
  - Python RuntimeError: e1aee866 (ignoredsignal)
  - GitHub workflows weren't regenerated: 3b6569b1 (ignoredsignal)
  - GitHub workflows weren't regenerated: bbbced94 (landrace)
  - Python RuntimeError: 060838c2 (nosignal)
  - Lintrunner failure: 1a55fb0e (weird)
  - Lintrunner failure: 3239da0c (nosignal)
  - MSVC compiler error: eab45643 (ignoredsignal)
  - Bad response status code: ea7b2330 (uncategorized)
  - gtest failure: 347ace4c (nosignal)
  - pytest failure: 216bd609 (nosignal)
  - pytest failure: 84c588e5 (ignoredsignal)
  - GHA error: 863327ae (ignoredsignal)
  - GHA error: eb9efb37 (ghfirst)
  - GHA error: 9c39bc24 (ignoredsignal)
  - Python Test File RuntimeError: 6de41ce0 (uncategorized)
  - Fallback for other test failure rules: 3f920f3d (nosignal)
  - pytest failure: f179b719 (ghfirst)
  - pytest failure: 92409b6c (uncategorized)
  - pytest failure: d1b4e0fa (nosignal)
  - pytest failure: 099d0d61 (uncategorized)
  - pytest failure: c79c7bbe (nosignal)
  - pytest failure: c95f7fa8 (nosignal)
  - pytest failure: 08dae945 (weird)
  - pytest failure: fb75dea2 (uncategorized)
  - pytest failure: 9de23d0c (uncategorized)
  - pytest failure: 830a335a (ghfirst)
  - pytest failure: 6d3a4356 (ignoredsignal)
  - pytest failure: a6a3a441 (nosignal)
  - Python Test timeout (KeyboardInterrupt): 8142a028 (nosignal)
  - pr_time_benchmarks regression: 2b9d638e (weird)
  - pytest failure: dc5e8f79 (nosignal)
  - pytest failure: 5264f8cd (weird)
  - pytest failure: 8823138e (nosignal)
  - pytest failure: f154f9b3 (ignoredsignal)
  - pr_time_benchmarks regression: b07725a9 (ghfirst)
  - pr_time_benchmarks regression: d4d0ede6 (ignoredsignal)
  - Build error: 2596e3d0 (nosignal)
  - pytest failure: c1f531f0 (ghfirst)
  - GHA error: c6b4f986 (nosignal)
  - GHA error: 529e0357 (nosignal)
  - GHA error: e694280d (ghfirst)
  - GHA error: e1180c72 (weird)
  - GHA error: 7dcc77e4 (nosignal)
  - GHA error: a3098a74 (ignoredsignal)
  - GHA error: a14f427d (nosignal)
  - GHA error: bee9c70c (nosignal)
  - GHA error: 409c396a (ghfirst)
  - GHA error: 67fb9b7c (nosignal)
  - GHA error: 1b50c125 (nosignal)
  - pytest failure: 196c95d4 (nosignal)
```