### PR TITLE
[ez][HUD] Filter out upload test stats in hud query

### DIFF
--- a/torchci/clickhouse_queries/hud_query/query.sql
+++ b/torchci/clickhouse_queries/hud_query/query.sql
@@ -24,6 +24,7 @@ WITH job AS (
     WHERE
         job.name != 'ciflow_should_run'
         AND job.name != 'generate-test-matrix'
+        and job.workflow_name != 'Upload test stats'  -- Should be filtered out by the workflow_event filters, but sometimes workflow_event is empty
         AND job.workflow_event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
         AND job.workflow_event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
         AND job.id in (select id from materialized_views.workflow_job_by_head_sha where head_sha in {shas: Array(String)})


### PR DESCRIPTION
This should get filtered out by the workflow_event filters but sometimes the field is empty, maybe because the job is too new?  I'm not sure

Each upload test stats job has a different name, based on the job its uploading stats for, so whenever I open the "other" category, which is where these jobs go into, it takes a very long time