### PR TITLE
runners: Add expiration policy to SSM parameters

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
@@ -1268,13 +1268,15 @@ describe('createRunner', () => {
       // Verify the Policies parameter contains the correct expiration policy structure
       const putParameterCall = mockSSM.putParameter.mock.calls[0][0];
       const policies = JSON.parse(putParameterCall.Policies);
-      expect(policies).toEqual([{
-        Type: 'Expiration',
-        Version: '1.0',
-        Attributes: {
-          Timestamp: expect.any(String),
+      expect(policies).toEqual([
+        {
+          Type: 'Expiration',
+          Version: '1.0',
+          Attributes: {
+            Timestamp: expect.any(String),
+          },
         },
-      }]);
+      ]);
 
       // Verify the timestamp is approximately 30 minutes in the future
       const expirationTime = new Date(policies[0].Attributes.Timestamp);

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
@@ -1263,7 +1263,25 @@ describe('createRunner', () => {
         Name: 'wg113-i-1234',
         Value: 'us-east-1-BLAH',
         Type: 'SecureString',
+        Policies: expect.any(String),
       });
+      // Verify the Policies parameter contains the correct expiration policy structure
+      const putParameterCall = mockSSM.putParameter.mock.calls[0][0];
+      const policies = JSON.parse(putParameterCall.Policies);
+      expect(policies).toEqual([{
+        Type: 'Expiration',
+        Version: '1.0',
+        Attributes: {
+          Timestamp: expect.any(String),
+        },
+      }]);
+
+      // Verify the timestamp is approximately 30 minutes in the future
+      const expirationTime = new Date(policies[0].Attributes.Timestamp);
+      const now = Date.now();
+      const timeDiff = expirationTime.getTime() - now;
+      expect(timeDiff).toBeGreaterThan(25 * 60 * 1000); // at least 25 minutes (allowing for test execution time)
+      expect(timeDiff).toBeLessThan(35 * 60 * 1000); // at most 35 minutes (allowing for clock differences)
     });
 
     it('creates ssm experiment parameters when joining experiment', async () => {
@@ -1307,6 +1325,7 @@ describe('createRunner', () => {
         Name: 'wg113-i-1234',
         Value: 'us-east-1-BLAH #ON_AMI_EXPERIMENT',
         Type: 'SecureString',
+        Policies: expect.any(String),
       });
       expect(mockEC2.runInstances).toBeCalledTimes(1);
       expect(mockEC2.runInstances).toBeCalledWith(

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -393,6 +393,16 @@ async function addSSMParameterRunnerConfig(
                 Name: parameterName,
                 Value: runnerConfig,
                 Type: 'SecureString',
+                // NOTE: This does need to be an stringified JSON array of objects, check docs at:
+                // https://docs.aws.amazon.com/systems-manager/latest/userguide/example_ssm_PutParameter_section.html
+                Policies: JSON.stringify([{
+                  "Type": "Expiration",
+                  "Version": "1.0",
+                  "Attributes": {
+                    //  Expire after 30 minutes from present time
+                    "Timestamp": new Date(Date.now() + 1000 * 60 * 30).toISOString()
+                  }
+                }])
               })
               .promise();
             return parameterName;

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -395,14 +395,16 @@ async function addSSMParameterRunnerConfig(
                 Type: 'SecureString',
                 // NOTE: This does need to be an stringified JSON array of objects, check docs at:
                 // https://docs.aws.amazon.com/systems-manager/latest/userguide/example_ssm_PutParameter_section.html
-                Policies: JSON.stringify([{
-                  "Type": "Expiration",
-                  "Version": "1.0",
-                  "Attributes": {
-                    //  Expire after 30 minutes from present time
-                    "Timestamp": new Date(Date.now() + 1000 * 60 * 30).toISOString()
-                  }
-                }])
+                Policies: JSON.stringify([
+                  {
+                    Type: 'Expiration',
+                    Version: '1.0',
+                    Attributes: {
+                      //  Expire after 30 minutes from present time
+                      Timestamp: new Date(Date.now() + 1000 * 60 * 30).toISOString(),
+                    },
+                  },
+                ]),
               })
               .promise();
             return parameterName;


### PR DESCRIPTION
This adds an expiration policy to the SSM parameters for the runners. This is to ensure that the parameters are deleted after 30 minutes.

Github Runner Tokens typically have a 1 hour expiration time, but our runners are typically expected to be up way quicker than that so 30 minutes is a good balance for when we expect the runners to be up.

If a runner isn't conencted to Github by at least 30 minutes we will more than likely have spun it down and it will be deleted.

This is an attempted re-land of 2 commits:
* #6855
* #6858