### PR TITLE
Uses a very basic ML model to decide if a commit should be retried for autorevert

### DIFF
--- a/aws/lambda/pytorch-auto-revert/Makefile
+++ b/aws/lambda/pytorch-auto-revert/Makefile
@@ -23,7 +23,7 @@ run-local: venv/bin/python
 
 .PHONY: run-local-workflows
 run-local-workflows: venv/bin/python
-	venv/bin/python -m pytorch_auto_revert autorevert-checker Lint trunk pull inductor --hours 4320 --generate-commit-data-csv
+	venv/bin/python -m pytorch_auto_revert autorevert-checker Lint trunk pull inductor --hours 4320 --generate-commit-data-csv --verbose
 
 deployment.zip:
 	mkdir -p deployment

--- a/aws/lambda/pytorch-auto-revert/Makefile
+++ b/aws/lambda/pytorch-auto-revert/Makefile
@@ -23,7 +23,7 @@ run-local: venv/bin/python
 
 .PHONY: run-local-workflows
 run-local-workflows: venv/bin/python
-	venv/bin/python -m pytorch_auto_revert workflows pull.yml
+	venv/bin/python -m pytorch_auto_revert autorevert-checker Lint trunk pull inductor --hours 4320 --generate-commit-data-csv
 
 deployment.zip:
 	mkdir -p deployment

--- a/aws/lambda/pytorch-auto-revert/Makefile
+++ b/aws/lambda/pytorch-auto-revert/Makefile
@@ -23,7 +23,7 @@ run-local: venv/bin/python
 
 .PHONY: run-local-workflows
 run-local-workflows: venv/bin/python
-	venv/bin/python -m pytorch_auto_revert autorevert-checker Lint trunk pull inductor --hours 4320 --generate-commit-data-csv --verbose
+	venv/bin/python -m pytorch_auto_revert autorevert-checker Lint trunk pull inductor --hours 4320 #--generate-commit-data-csv --verbose
 
 deployment.zip:
 	mkdir -p deployment

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
@@ -84,6 +84,11 @@ def get_opts() -> argparse.Namespace:
         action="store_true",
         help="Show detailed output including commit summaries",
     )
+    workflow_parser.add_argument(
+        "--generate-commit-data-csv",
+        action="store_true",
+        help="generate a CSV file with the commit data for analysis",
+    )
 
     # workflow-restart-checker subcommand
     workflow_restart_parser = subparsers.add_parser(
@@ -146,7 +151,12 @@ def main(*args, **kwargs) -> None:
     if opts.subcommand == "lambda":
         print("TODO: run lambda flow")
     elif opts.subcommand == "autorevert-checker":
-        autorevert_checker(opts.workflows, hours=opts.hours, verbose=opts.verbose)
+        autorevert_checker(
+            opts.workflows,
+            hours=opts.hours,
+            verbose=opts.verbose,
+            generate_commit_data_csv=opts.generate_commit_data_csv,
+        )
     elif opts.subcommand == "workflow-restart-checker":
         workflow_restart_checker(opts.workflow, commit=opts.commit, days=opts.days)
     elif opts.subcommand == "do-restart":

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_checker.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_checker.py
@@ -310,11 +310,6 @@ class AutorevertPatternChecker:
                     # No newer commit with the same job found
                     continue
 
-                # if any(
-                #     j.classification_rule == suspected_failure_class_rule
-                #     for j in newer_same_jobs
-                # ):
-                #     # The newer commit has the same job failing
                 failure_key = (
                     suspected_failure_class_rule,
                     suspected_failure_job_name,

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/testers/autorevert.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/testers/autorevert.py
@@ -45,11 +45,29 @@ def autorevert_checker(
                 print(f"  {workflow}: {len(commits)} commits")
 
     # Detect patterns
+    if verbose:
+        print(f"\nDetecting autorevert patterns in last {hours} hours...")
     patterns = checker.detect_autorevert_pattern()
+    if verbose:
+        print(f"Found {len(patterns)} patterns in last {hours} hours")
+        print("\nChecking for reverts of detected patterns...")
+
     reverts = checker.get_commits_reverted()
+    if verbose:
+        print(f"Found {len(reverts)} reverts in last {hours} hours")
+        print("Fetching revert information...")
+
     reverts_with_info = checker.get_commits_reverted_with_info()
+    if verbose:
+        print(f"Found {len(reverts_with_info)} reverts with additional info")
+
     if generate_commit_data_csv:
+        if verbose:
+            print("Generating commit data CSV for autorevert patterns...")
         revert_patterns = checker.get_revert_patterns_training_data()
+        if verbose:
+            print(f"Found {len(revert_patterns)} revert patterns for CSV generation")
+
         # Generate CSV file with commit data
         csv_file = "autorevert_patterns.csv"
         fieldnames = list(revert_patterns[0].keys()) if revert_patterns else []

--- a/aws/lambda/pytorch-auto-revert/requirements.txt
+++ b/aws/lambda/pytorch-auto-revert/requirements.txt
@@ -1,3 +1,8 @@
 clickhouse-connect==0.8.14
 PyGithub==2.6.1
 python-dotenv>=1.0.0
+
+joblib
+pandas
+scikit-learn
+scipy

--- a/aws/lambda/pytorch-auto-revert/train_model.py
+++ b/aws/lambda/pytorch-auto-revert/train_model.py
@@ -1,87 +1,312 @@
 import pandas as pd
 import ast
 from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import precision_score, recall_score
-from sklearn.model_selection import train_test_split, TunedThresholdClassifierCV
+from sklearn.metrics import precision_score, recall_score, f1_score
+from sklearn.feature_selection import SelectFromModel
+from sklearn.model_selection import train_test_split
+from sklearn.calibration import CalibratedClassifierCV
 from sklearn.preprocessing import OneHotEncoder
-from sklearn.compose import ColumnTransformer
+from sklearn.compose import ColumnTransformer, make_column_transformer
 from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import MultiLabelBinarizer
 import joblib
 
 # Load CSV
 df = pd.read_csv("autorevert_patterns.csv")
 
-# Parse 'newer_failure_rules' from string to list
+# variables that are array
 df["newer_failure_rules"] = df["newer_failure_rules"].apply(ast.literal_eval)
 
-# Drop 'sha' as instructed
-df = df.drop(columns=["sha"])
-
-# Add combined field: (failure_rule, job_name)
 df["failure_job"] = df["failure_rule"] + "||" + df["job_name"]
 
-# Generate (failure_rule, newer_failure_rule) combinations
-combos = []
-for idx, row in df.iterrows():
-    for rule in row["newer_failure_rules"]:
-        combos.append((idx, f"{row['failure_rule']}||{rule}"))
-combo_df = pd.DataFrame(combos, columns=["index", "failure_newer"])
-df = df.merge(combo_df, left_index=True, right_on="index", how="left").drop(columns=["index"])
+# Step 1: Generate the list of failure_rule||newer_failure_rule combos per row
+df["failure_newer"] = df.apply(
+    lambda row: [f"{row['failure_rule']}||{rule}" for rule in row["newer_failure_rules"]],
+    axis=1
+)
 
-# Fill missing failure_newer values for rows with empty newer_failure_rules
-df["failure_newer"] = df["failure_newer"].fillna("none")
+df = df.drop(columns=["is_reverted", "sha"])
 
-# We no longer need the raw list column
-df = df.drop(columns=["newer_failure_rules", "is_reverted"])
+print("\nSample data:")
+print(df.head())
+print(df.info())
 
-# Define target and features
+# Target and input features
 y = df["is_reverted_non_ghfirst"]
 X = df.drop(columns=["is_reverted_non_ghfirst"])
 
-for column in X.columns:
-    unique_values = X[column].unique()
-    print(f"Count of unique values in column '{column}': {unique_values.size}")
+# Columns to encode
+categorical_features = ["failure_rule", "job_name", "workflow_name", "failure_job"]
+boolean_features = ["repeated_failure"]
+multilabel_feature = "failure_newer"
 
-# Define categorical and boolean fields
-categorical_features = ["failure_rule", "job_name", "workflow_name", "failure_job", "failure_newer"]
-boolean_features = ["is_reverted", "repeated_failure"]
+# No longer needed as we're using MultiLabelBinarizer directly
 
-# Set up the column transformer for one-hot encoding
-preprocessor = ColumnTransformer(
-    transformers=[
-        ("cat", OneHotEncoder(handle_unknown="ignore"), categorical_features),
-    ],
-    remainder="passthrough"  # This passes through the boolean columns
+# Create separate transformers for the multilabel features
+# Handle failure_newer combinations
+mlb_failure_newer = MultiLabelBinarizer()
+mlb_failure_newer_result = mlb_failure_newer.fit_transform(df[multilabel_feature])
+mlb_failure_newer_names = [f"failure_combo_{i}" for i in range(mlb_failure_newer_result.shape[1])]
+
+# Handle newer_failure_rules which is already a list
+mlb_rules = MultiLabelBinarizer()
+mlb_rules_result = mlb_rules.fit_transform(df["newer_failure_rules"])
+mlb_rules_names = [f"rule_{i}" for i in range(mlb_rules_result.shape[1])]
+
+# Create DataFrames from the binary matrices with proper column names
+failure_newer_df = pd.DataFrame(
+    mlb_failure_newer_result,
+    columns=mlb_failure_newer_names,
+    index=X.index
 )
 
-# Define model with elastic net regularization (L1 + L2)
+rules_df = pd.DataFrame(
+    mlb_rules_result, 
+    columns=mlb_rules_names,
+    index=X.index
+)
+
+# Drop the original multilabel columns
+X = X.drop(columns=[multilabel_feature, "newer_failure_rules"])
+
+# Concatenate the original X with the new binary feature DataFrames
+X = pd.concat([X, failure_newer_df, rules_df], axis=1)
+
+# Build preprocessing for the remaining categorical features
+preprocessor = make_column_transformer(
+    (OneHotEncoder(handle_unknown="ignore"), categorical_features),
+    remainder="passthrough"  # includes boolean fields and our new binary features
+)
+
+# Check class distribution
+print("\nClass distribution:")
+print(y.value_counts())
+class_weight = None
+if y.value_counts().shape[0] > 1:
+    # Calculate class weights
+    class_weight = {
+        0: 1.0,
+        1: y.value_counts()[0] / y.value_counts()[1]  # Weight positive examples more if there are fewer
+    }
+    print(f"Using class weights: {class_weight}")
+
+# Define model with feature selection and class weights
 model = Pipeline(steps=[
     ("preprocessor", preprocessor),
-    ("classifier", TunedThresholdClassifierCV(
-        LogisticRegression(penalty="elasticnet", solver="saga", l1_ratio=0.5, max_iter=10000),
-        scoring="f1",
+    ("feature_selection", SelectFromModel(
+        estimator=LogisticRegression(
+            penalty="l1", 
+            C=0.05, 
+            solver='liblinear',
+            max_iter=10000,
+            class_weight=class_weight
+        ),
+        threshold="median"  # Select features with importance > median
+    )),
+    ("classifier", LogisticRegression(
+        penalty="elasticnet", 
+        solver="saga", 
+        l1_ratio=0.5, 
+        max_iter=10000,
+        class_weight=class_weight,
+        C=0.1  # Increase regularization
     )),
 ])
+
+# Print dataset dimensions
+print(f"\nFull dataset dimensions: {X.shape}")
+print(f"Number of categorical features: {len(categorical_features)}")
+print(f"Number of failure_newer combinations: {len(mlb_failure_newer_names)}")
+print(f"Number of rule combinations: {len(mlb_rules_names)}")
+
+# Add a bias term (intercept column)
+X['intercept'] = 1.0
 
 # Train/test split
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
+# Print split dimensions
+print(f"Training set dimensions: {X_train.shape}")
+print(f"Testing set dimensions: {X_test.shape}")
+
 # Fit model
-model.fit(X_train, y_train)
+try:
+    model.fit(X_train, y_train)
+    print("Fitted model successfully")
+except Exception as e:
+    print(f"Error fitting model: {e}")
+    print("Trying a simpler model...")
+    
+    # Try a simpler model if the first one fails
+    from sklearn.linear_model import SGDClassifier
+    model = Pipeline(steps=[
+        ("preprocessor", preprocessor),
+        ("classifier", SGDClassifier(
+            loss="modified_huber", 
+            penalty="l2",
+            max_iter=1000, 
+            class_weight="balanced",
+            random_state=42
+        )),
+    ])
+    model.fit(X_train, y_train)
+    print("Fitted simpler model successfully")
 
-# Evaluate
+# Add some diagnostics to understand the data and model predictions
+print("\nDiagnostics:")
+print(f"Target value counts: \n{y.value_counts()}")
+print(f"Training target value counts: \n{y_train.value_counts()}")
+print(f"Testing target value counts: \n{y_test.value_counts()}")
+
+# Try probabilities rather than just binary predictions
+y_pred_proba = model.predict_proba(X_test)
+if y_pred_proba.shape[1] > 1:
+    print(f"\nPrediction probabilities statistics:")
+    print(f"Min positive probability: {y_pred_proba[:, 1].min()}")
+    print(f"Max positive probability: {y_pred_proba[:, 1].max()}")
+    print(f"Mean positive probability: {y_pred_proba[:, 1].mean()}")
+
+    # Try different thresholds and find the one that maximizes F1
+    print("\nFinding optimal threshold for F1:")
+    thresholds = [i/100 for i in range(1, 100, 1)]  # 0.01 to 0.99 in steps of 0.01
+    best_f1 = 0
+    best_threshold = 0.5
+    best_precision = 0
+    best_recall = 0
+    threshold_results = []
+
+    for threshold in thresholds:
+        y_pred_threshold = (y_pred_proba[:, 1] >= threshold).astype(int)
+        precision = precision_score(y_test, y_pred_threshold, zero_division=0)
+        recall = recall_score(y_test, y_pred_threshold, zero_division=0)
+        f1 = f1_score(y_test, y_pred_threshold, zero_division=0)
+        threshold_results.append((threshold, precision, recall, f1))
+        
+        if f1 > best_f1:
+            best_f1 = f1
+            best_threshold = threshold
+            best_precision = precision
+            best_recall = recall
+
+    # Print the results for a range of thresholds
+    print("\nThreshold results (selected):")
+    selected_thresholds = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+    for threshold, precision, recall, f1 in threshold_results:
+        if abs(threshold - round(threshold, 1)) < 0.001:  # Only print thresholds close to 0.1, 0.2, etc.
+            print(f"Threshold {threshold:.1f}: Precision {precision:.4f}, Recall {recall:.4f}, F1 {f1:.4f}")
+
+    print(f"\nOptimal threshold: {best_threshold:.4f}")
+    print(f"Best F1 score: {best_f1:.4f}")
+    print(f"Precision at optimal threshold: {best_precision:.4f}")
+    print(f"Recall at optimal threshold: {best_recall:.4f}")
+
+# Standard evaluation with default threshold (0.5)
 y_pred = model.predict(X_test)
-testing_precision = precision_score(y_test, y_pred)
-testing_recall = recall_score(y_test, y_pred)
+testing_precision = precision_score(y_test, y_pred, zero_division=0)
+testing_recall = recall_score(y_test, y_pred, zero_division=0)
+testing_f1 = f1_score(y_test, y_pred, zero_division=0)
 
+print(f"\nDefault threshold (0.5) metrics:")
 print(f"Testing Precision: {testing_precision:.4f}")
 print(f"Testing Recall: {testing_recall:.4f}")
+print(f"Testing F1 Score: {testing_f1:.4f}")
+print(f"Predictions sum: {sum(y_pred)}, Total: {len(y_pred)}")
+print(f"Actuals sum: {sum(y_test)}, Total: {len(y_test)}")
 
+# Evaluation with optimal threshold
+if 'best_threshold' in locals():
+    y_pred_optimal = (y_pred_proba[:, 1] >= best_threshold).astype(int)
+    optimal_precision = precision_score(y_test, y_pred_optimal, zero_division=0)
+    optimal_recall = recall_score(y_test, y_pred_optimal, zero_division=0)
+    optimal_f1 = f1_score(y_test, y_pred_optimal, zero_division=0)
+    
+    print(f"\nOptimal threshold ({best_threshold:.4f}) metrics:")
+    print(f"Testing Precision: {optimal_precision:.4f}")
+    print(f"Testing Recall: {optimal_recall:.4f}")
+    print(f"Testing F1 Score: {optimal_f1:.4f}")
+    print(f"Predictions sum: {sum(y_pred_optimal)}, Total: {len(y_pred_optimal)}")
+
+# Full dataset with default threshold (0.5)
 y_pred = model.predict(X)
-toatl_precision = precision_score(y, y_pred)
-total_recall = recall_score(y, y_pred)
-print("Full Dataset Precision: {:.4f}".format(toatl_precision))
-print("Full Dataset Recall: {:.4f}".format(total_recall))
+total_precision = precision_score(y, y_pred, zero_division=0)
+total_recall = recall_score(y, y_pred, zero_division=0)
+total_f1 = f1_score(y, y_pred, zero_division=0)
+print("\nFull Dataset (default threshold 0.5):")
+print(f"Precision: {total_precision:.4f}")
+print(f"Recall: {total_recall:.4f}")
+print(f"F1 Score: {total_f1:.4f}")
+print(f"Predictions sum: {sum(y_pred)}, Total: {len(y_pred)}")
+print(f"Actuals sum: {sum(y)}, Total: {len(y)}")
 
-# Save model
+# Full dataset with optimal threshold
+if 'best_threshold' in locals():
+    y_pred_proba_full = model.predict_proba(X)
+    y_pred_optimal_full = (y_pred_proba_full[:, 1] >= best_threshold).astype(int)
+    optimal_precision_full = precision_score(y, y_pred_optimal_full, zero_division=0)
+    optimal_recall_full = recall_score(y, y_pred_optimal_full, zero_division=0)
+    optimal_f1_full = f1_score(y, y_pred_optimal_full, zero_division=0)
+    
+    print(f"\nFull Dataset (optimal threshold {best_threshold:.4f}):")
+    print(f"Precision: {optimal_precision_full:.4f}")
+    print(f"Recall: {optimal_recall_full:.4f}")
+    print(f"F1 Score: {optimal_f1_full:.4f}")
+    print(f"Predictions sum: {sum(y_pred_optimal_full)}, Total: {len(y_pred_optimal_full)}")
+
+# Check feature importance and selected features
+try:
+    # Get information about selected features
+    print("\nFeature selection information:")
+    feature_selector = model.named_steps['feature_selection']
+    selected_mask = feature_selector.get_support()
+    
+    # Get original feature names from the preprocessor plus our binary encoded features
+    try:
+        original_feature_names = list(preprocessor.get_feature_names_out()) + list(mlb_failure_newer_names) + list(mlb_rules_names)
+        
+        # Number of selected features
+        n_selected = sum(selected_mask)
+        print(f"Number of features selected: {n_selected} out of {len(selected_mask)}")
+        
+        # Get the selected feature names
+        selected_features = [name for name, selected in zip(original_feature_names, selected_mask) if selected]
+        print(f"\nTop 20 selected features (alphabetical):")
+        for feature in sorted(selected_features)[:20]:
+            print(f"- {feature}")
+    except Exception as e:
+        print(f"Could not get selected feature names: {e}")
+    
+    # Get coefficients from the final classifier
+    coefficients = model.named_steps['classifier'].coef_[0]
+    
+    # For the final model, we need to get the feature names after selection
+    # Since we can't directly access these, we'll display coefficients by their magnitude
+    sorted_coef_idx = sorted(range(len(coefficients)), key=lambda i: abs(coefficients[i]), reverse=True)
+    
+    print("\nTop 10 most important features by coefficient magnitude:")
+    for i in sorted_coef_idx[:10]:
+        print(f"Feature #{i}: {coefficients[i]:.4f}")
+    
+    print("\nBottom 10 features by coefficient magnitude:")
+    for i in sorted_coef_idx[-10:]:
+        print(f"Feature #{i}: {coefficients[i]:.4f}")
+
+except Exception as e:
+    print(f"Could not extract feature importance: {e}")
+
+# Save model and the multilabel binarizers for later use
+print("\nSaving model and metadata...")
 joblib.dump(model, "model.joblib")
+joblib.dump({
+    'mlb_failure_newer': mlb_failure_newer,
+    'mlb_rules': mlb_rules,
+    'feature_names': {
+        'failure_combo': mlb_failure_newer_names,
+        'rules': mlb_rules_names
+    },
+    'optimal_threshold': best_threshold if 'best_threshold' in locals() else 0.5
+}, "multilabel_binarizers.joblib")
+
+print("Done. Model and metadata saved to disk.")
+
+import sys
+sys.exit(0)

--- a/aws/lambda/pytorch-auto-revert/train_model.py
+++ b/aws/lambda/pytorch-auto-revert/train_model.py
@@ -1,0 +1,87 @@
+import pandas as pd
+import ast
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import precision_score, recall_score
+from sklearn.model_selection import train_test_split, TunedThresholdClassifierCV
+from sklearn.preprocessing import OneHotEncoder
+from sklearn.compose import ColumnTransformer
+from sklearn.pipeline import Pipeline
+import joblib
+
+# Load CSV
+df = pd.read_csv("autorevert_patterns.csv")
+
+# Parse 'newer_failure_rules' from string to list
+df["newer_failure_rules"] = df["newer_failure_rules"].apply(ast.literal_eval)
+
+# Drop 'sha' as instructed
+df = df.drop(columns=["sha"])
+
+# Add combined field: (failure_rule, job_name)
+df["failure_job"] = df["failure_rule"] + "||" + df["job_name"]
+
+# Generate (failure_rule, newer_failure_rule) combinations
+combos = []
+for idx, row in df.iterrows():
+    for rule in row["newer_failure_rules"]:
+        combos.append((idx, f"{row['failure_rule']}||{rule}"))
+combo_df = pd.DataFrame(combos, columns=["index", "failure_newer"])
+df = df.merge(combo_df, left_index=True, right_on="index", how="left").drop(columns=["index"])
+
+# Fill missing failure_newer values for rows with empty newer_failure_rules
+df["failure_newer"] = df["failure_newer"].fillna("none")
+
+# We no longer need the raw list column
+df = df.drop(columns=["newer_failure_rules", "is_reverted"])
+
+# Define target and features
+y = df["is_reverted_non_ghfirst"]
+X = df.drop(columns=["is_reverted_non_ghfirst"])
+
+for column in X.columns:
+    unique_values = X[column].unique()
+    print(f"Count of unique values in column '{column}': {unique_values.size}")
+
+# Define categorical and boolean fields
+categorical_features = ["failure_rule", "job_name", "workflow_name", "failure_job", "failure_newer"]
+boolean_features = ["is_reverted", "repeated_failure"]
+
+# Set up the column transformer for one-hot encoding
+preprocessor = ColumnTransformer(
+    transformers=[
+        ("cat", OneHotEncoder(handle_unknown="ignore"), categorical_features),
+    ],
+    remainder="passthrough"  # This passes through the boolean columns
+)
+
+# Define model with elastic net regularization (L1 + L2)
+model = Pipeline(steps=[
+    ("preprocessor", preprocessor),
+    ("classifier", TunedThresholdClassifierCV(
+        LogisticRegression(penalty="elasticnet", solver="saga", l1_ratio=0.5, max_iter=10000),
+        scoring="f1",
+    )),
+])
+
+# Train/test split
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+
+# Fit model
+model.fit(X_train, y_train)
+
+# Evaluate
+y_pred = model.predict(X_test)
+testing_precision = precision_score(y_test, y_pred)
+testing_recall = recall_score(y_test, y_pred)
+
+print(f"Testing Precision: {testing_precision:.4f}")
+print(f"Testing Recall: {testing_recall:.4f}")
+
+y_pred = model.predict(X)
+toatl_precision = precision_score(y, y_pred)
+total_recall = recall_score(y, y_pred)
+print("Full Dataset Precision: {:.4f}".format(toatl_precision))
+print("Full Dataset Recall: {:.4f}".format(total_recall))
+
+# Save model
+joblib.dump(model, "model.joblib")


### PR DESCRIPTION
Introduced a very simple log regression model to classify commits if should auto-revert.

# new results:

```
==================================================
SUMMARY STATISTICS
==================================================
Workflow(s): Lint, trunk, pull, inductor
Timeframe: 4320 hours
Commits checked: 26990
Auto revert patterns detected: 1764
Actual reverts inside auto revert patterns detected (precision): 248 (14.1%)
Total revert commits in period: 573

Revert categories:
  nosignal: 204 (35.6%)
  ghfirst: 157 (27.4%)
  uncategorized: 95 (16.6%)
  ignoredsignal: 65 (11.3%)
  weird: 42 (7.3%)
  landrace: 10 (1.7%)

Total reverts excluding ghfirst: 416
Reverts (excluding ghfirst) that dont match any auto revert pattern detected (recall): 203 (48.8%)
Per workflow precision:
  Lint: 62 reverts out of 298 patterns (20.8%) [excluding ghfirst: 54 (18.1%)]
  trunk: 61 reverts out of 342 patterns (17.8%) [excluding ghfirst: 54 (15.8%)]
  pull: 104 reverts out of 898 patterns (11.6%) [excluding ghfirst: 90 (10.0%)]
  inductor: 21 reverts out of 226 patterns (9.3%) [excluding ghfirst: 15 (6.6%)]
  ```
  
# old results:

```
==================================================
SUMMARY STATISTICS
==================================================
Workflow(s): Lint, trunk, pull, inductor, linux-binary-manywheel
Timeframe: 720 hours
Commits checked: 6741
Auto revert patterns detected: 419
Actual reverts inside auto revert patterns detected (precision): 50 (11.9%)
Total revert commits in period: 121

Revert categories:
  nosignal: 46 (38.0%)
  ghfirst: 28 (23.1%)
  uncategorized: 21 (17.4%)
  ignoredsignal: 16 (13.2%)
  weird: 9 (7.4%)
  landrace: 1 (0.8%)

Total reverts excluding ghfirst: 93
Reverts (excluding ghfirst) that dont match any auto revert pattern detected (recall): 50 (53.8%)
Per workflow precision:
  Lint: 6 reverts out of 17 patterns (35.3%) [excluding ghfirst: 6 (35.3%)]
  trunk: 2 reverts out of 14 patterns (14.3%) [excluding ghfirst: 2 (14.3%)]
  pull: 40 reverts out of 354 patterns (11.3%) [excluding ghfirst: 33 (9.3%)]
  inductor: 2 reverts out of 31 patterns (6.5%) [excluding ghfirst: 2 (6.5%)]
  linux-binary-manywheel: 0 reverts out of 3 patterns (0.0%) [excluding ghfirst: 0 (0.0%)]
```
  
# how to run?
  
```
  venv/bin/python -m pytorch_auto_revert autorevert-checker Lint trunk pull inductor --hours 4320
  venv/bin/python train_model.py
  venv/bin/python -m pytorch_auto_revert autorevert-checker Lint trunk pull inductor --hours 4320 --generate-commit-data-csv
```