### PR TITLE
Allow Windows wheels to be built with custom commands

### DIFF
--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -47,6 +47,16 @@ on:
         description: "Name of the actual python package that is imported"
         default: ""
         type: string
+      build-platform:
+        description: Platform to build wheels, choose from 'python-build-package' or 'setup-py'
+        required: false
+        type: string
+        default: 'setup-py'
+      build-command:
+        description: The build command to use if build-platform is python-build-package
+        required: false
+        default: "python -m build --wheel"
+        type: string
       trigger-event:
         description: "Trigger Event in caller that determines whether or not to upload"
         default: ""
@@ -232,8 +242,33 @@ jobs:
               ${CONDA_RUN} ${ENV_SCRIPT} python setup.py clean
             fi
           fi
-      - name: Build the wheel (bdist_wheel) X64
-        if: inputs.architecture == 'x64'
+      - name: Build the wheel (python-build-package) X64
+        if: ${{ inputs.build-platform == 'python-build-package' && inputs.architecture == 'x64' }}
+        working-directory: ${{ inputs.repository }}
+        env:
+          ENV_SCRIPT: ${{ inputs.env-script }}
+          BUILD_PARAMS: ${{ inputs.wheel-build-params }}
+        run: |
+          source "${BUILD_ENV_FILE}"
+
+          if [[ "$CU_VERSION" == "cpu" ]]; then
+          # CUDA and CPU are ABI compatible on the CPU-only parts, so strip
+          # in this case
+            export PYTORCH_VERSION="$(${CONDA_RUN} pip show torch | grep ^Version: | sed 's/Version:  *//' | sed 's/+.\+//')"
+          else
+            export PYTORCH_VERSION="$(${CONDA_RUN} pip show torch | grep ^Version: | sed 's/Version:  *//')"
+          fi
+
+          ${CONDA_RUN} python -m pip install build==1.2.2
+          echo "Successfully installed Python build package"
+
+          if [[ -z "${ENV_SCRIPT}" ]]; then
+            ${CONDA_RUN} ${{ inputs.build-command }}
+          else
+            ${CONDA_RUN} ${ENV_SCRIPT} ${{ inputs.build-command }}
+          fi
+      - name: Build the wheel (setup-py) X64
+        if: ${{ inputs.build-platform == 'setup-py' && inputs.architecture == 'x64' }}
         working-directory: ${{ inputs.repository }}
         env:
           ENV_SCRIPT: ${{ inputs.env-script }}
@@ -254,8 +289,28 @@ jobs:
           else
             ${CONDA_RUN} ${ENV_SCRIPT} python setup.py bdist_wheel ${BUILD_PARAMS}
           fi
-      - name: Build the wheel (bdist_wheel) Arm64
-        if: inputs.architecture == 'arm64'
+      - name: Build the wheel (python-build-package) Arm64
+        if: ${{ inputs.build-platform == 'python-build-package' && inputs.architecture == 'arm64' }}
+        env:
+          SRC_DIR: ${{ inputs.repository }}
+          DEPENDENCIES_DIR: c:\temp\dependencies\
+        shell: cmd
+        run: |
+          set CONDA_PREFIX=%DEPENDENCIES_DIR%
+          set PATH=%PATH%;%DEPENDENCIES_DIR%\Library\bin
+          set DISTUTILS_USE_SDK=1
+          set VS_PATH=%DEPENDENCIES_DIR%\VSBuildTools\VC\Auxiliary\Build\vcvarsall.bat
+
+          call "%VS_PATH%" arm64
+          cd %SRC_DIR%
+          call .venv\Scripts\activate.bat
+
+          pip install --upgrade setuptools==72.1.0
+          pip install build==1.2.2
+          echo Successfully installed Python build package
+          ${{ inputs.build-command }}
+      - name: Build the wheel (setup-py) Arm64
+        if: ${{ inputs.build-platform == 'setup-py' && inputs.architecture == 'arm64' }}
         env:
           SRC_DIR: ${{ inputs.repository }}
           DEPENDENCIES_DIR: c:\temp\dependencies\


### PR DESCRIPTION
This adds the `build-platform` and `build-command` options to the windows wheel building scripts. These options are already present for both the linux and macos wheel building scripts. We need this for adding Windows support to torchcodec.