### PR TITLE
runners: Add scaleCycle lambda to reuse runners

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/metrics.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/metrics.ts
@@ -1813,3 +1813,30 @@ export function sendMetricsAtTimeout(metricsTimeouts: sendMetricsTimeoutVars) {
     }
   };
 }
+
+export class ScaleCycleMetrics extends ScaleUpMetrics {
+  constructor() {
+    super('scaleCycle');
+  }
+
+  scaleCycleRunnerReuseFound(runnerType: string) {
+    const dimensions = new Map([['RunnerType', runnerType]]);
+    this.countEntry('run.scaleCycle.runnerReuse.found', 1, dimensions);
+  }
+
+  scaleCycleRunnerReuseFoundOrg(org: string, runnerType: string) {
+    const dimensions = new Map([
+      ['Org', org],
+      ['RunnerType', runnerType],
+    ]);
+    this.countEntry('run.scaleCycle.runnerReuse.found.org', 1, dimensions);
+  }
+
+  scaleCycleRunnerReuseFoundRepo(repo: string, runnerType: string) {
+    const dimensions = new Map([
+      ['Repo', repo],
+      ['RunnerType', runnerType],
+    ]);
+    this.countEntry('run.scaleCycle.runnerReuse.found.repo', 1, dimensions);
+  }
+}

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-cycle.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-cycle.ts
@@ -1,0 +1,77 @@
+import { Config } from './config';
+import { listRunners, RunnerInputParameters, tryReuseRunner } from './runners';
+import { getRepo, getRepoKey } from './utils';
+import { ScaleCycleMetrics } from './metrics';
+import { getRunnerTypes } from './gh-runners';
+import { createRunnerConfigArgument } from './scale-up';
+
+export async function scaleCycle(metrics: ScaleCycleMetrics) {
+  // Get runner types configuration first
+  const scaleConfigRepo = getRepo(Config.Instance.scaleConfigOrg, Config.Instance.scaleConfigRepo);
+  const runnerTypes = await getRunnerTypes(scaleConfigRepo, metrics);
+
+  // Get all valid runner type names for filtering
+  const validRunnerTypeNames = Array.from(runnerTypes.keys());
+
+  // Make separate calls for each runner type to filter at EC2 level
+  const allRunners = await Promise.all(
+    validRunnerTypeNames.map((runnerTypeName) =>
+      listRunners(metrics, {
+        containsTags: ['GithubRunnerID', 'EphemeralRunnerFinished', 'RunnerType'],
+        runnerType: runnerTypeName,
+      }),
+    ),
+  );
+
+  // Flatten the results
+  const runners = allRunners.flat();
+
+  for (const runner of runners) {
+    // Skip if required fields are missing (org/repo still need to be checked)
+    if (!runner.runnerType || !runner.org || !runner.repo) {
+      console.warn(`Skipping runner ${runner.instanceId} due to missing required tags`);
+      continue;
+    }
+
+    // Get the RunnerType object from the string (we know it exists since we filtered by it)
+    const runnerType = runnerTypes.get(runner.runnerType);
+    if (!runnerType) {
+      console.warn(`Unknown runner type: ${runner.runnerType}, skipping`);
+      continue;
+    }
+
+    // Create repo object
+    const repo = getRepo(runner.org, runner.repo);
+
+    // For each runner send an EBS volume replacement task
+    const runnerInputParameters: RunnerInputParameters = {
+      runnerConfig: (awsRegion: string, experimentalRunner: boolean) => {
+        return createRunnerConfigArgument(
+          runnerType,
+          repo,
+          // NOTE: installationId can actually be undefined here but this may incur lower rate limits
+          // TODO: figure out if we need to pass an actual installationId here
+          undefined,
+          metrics,
+          awsRegion,
+          experimentalRunner,
+        );
+      },
+      environment: Config.Instance.environment,
+      runnerType: runnerType,
+    };
+
+    // Set orgName or repoName based on configuration
+    if (Config.Instance.enableOrganizationRunners) {
+      runnerInputParameters.orgName = runner.org;
+      metrics.scaleCycleRunnerReuseFoundOrg(runner.org, runner.runnerType);
+      console.info(`Reusing runner ${runner.instanceId} for ${runner.org}`);
+    } else {
+      runnerInputParameters.repoName = getRepoKey(repo);
+      metrics.scaleCycleRunnerReuseFoundRepo(getRepoKey(repo), runner.runnerType);
+      console.info(`Reusing runner ${runner.instanceId} for ${getRepoKey(repo)}`);
+    }
+
+    await tryReuseRunner(runnerInputParameters, metrics);
+  }
+}

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -163,7 +163,7 @@ export async function scaleUp(
   }
 }
 
-async function createRunnerConfigArgument(
+export async function createRunnerConfigArgument(
   runnerType: RunnerType,
   repo: Repo,
   installationId: number | undefined,


### PR DESCRIPTION

This lambda will attempt to reuse runners that have
finished jobs that are sitting idle. Plan is to have this run in AWS on
a cron.

The functionality within this lambda will eventually replace the
tryReuseRunner function in scale-up.ts.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>
ghstack-source-id: debc42744e94c65a4ae23e4b02dbaa4f9dbfaf72
ghstack-comment-id: 3046547816
Pull-Request: https://github.com/pytorch/test-infra/pull/6892
Signed-off-by: Eli Uriegas <eliuriegas@meta.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/test-infra/pull/6894).
* #6897
* #6895
* __->__ #6894