### PR TITLE
[CI] Remove sarif upload in lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,12 +46,3 @@ jobs:
         if: always() && matrix.os == 'ubuntu-latest'
         run: |
           python tools/linter/convert_to_sarif.py --input lint.json --output lintrunner.sarif
-      - name: Upload SARIF file
-        if: always() && matrix.os == 'ubuntu-latest'
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@28deaeda66b76a05916b6923827895f2b14ab387 # v3.28.16
-        with:
-          # Path to SARIF file relative to the root of the repository
-          sarif_file: lintrunner.sarif
-          category: lintrunner
-          checkout_path: ${{ github.workspace }}


### PR DESCRIPTION
remove sarif upload

I think this causes comments like 
![image](https://github.com/user-attachments/assets/e543ef32-8542-4e54-aaaa-323c1703fd9f)

I don't like it because I'd rather just look at the lint job, depending on the linter it puts comments on unrelated lines, and when it does comment on the right line it doesnt suggest changes so you still have to run lintrunner yourself