### PR TITLE
[ez][CH] Fix infra_metrics.cloud.watch_metrics schema: use DateTime64

### DIFF
--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -552,7 +552,7 @@ def cloudwatch_metrics_adapter(table, bucket, key):
     `namespace` LowCardinality(String),
     `metric_name` LowCardinality(String),
     `dimensions` Map(String, String),
-    `timestamp` DateTime,
+    `timestamp` DateTime64,
     `value` Tuple(
         max Float32,
         min Float32,

--- a/clickhouse_db_schema/infra_metrics.cloudwatch_metrics/schema.sql
+++ b/clickhouse_db_schema/infra_metrics.cloudwatch_metrics/schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE infra_metrics.cloudwatch_metrics
+CREATE or replace TABLE infra_metrics.cloudwatch_metrics
 (
     `metric_stream_name` LowCardinality(String),
     `account_id` LowCardinality(String),
@@ -6,7 +6,7 @@ CREATE TABLE infra_metrics.cloudwatch_metrics
     `namespace` LowCardinality(String),
     `metric_name` LowCardinality(String),
     `dimensions` Map(String, String),
-    `timestamp` DateTime,
+    `timestamp` DateTime64,
     `value` Tuple(
         max Float32,
         min Float32,
@@ -20,5 +20,5 @@ CREATE TABLE infra_metrics.cloudwatch_metrics
 ENGINE = SharedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')
 PARTITION BY toYYYYMM(timestamp)
 ORDER BY (namespace, metric_name, timestamp, dimensions)
-TTL timestamp + toIntervalMonth(12)
+TTL toDateTime(timestamp) + toIntervalMonth(12)
 SETTINGS index_granularity = 8192

--- a/clickhouse_db_schema/infra_metrics.cloudwatch_metrics/schema.sql
+++ b/clickhouse_db_schema/infra_metrics.cloudwatch_metrics/schema.sql
@@ -1,4 +1,4 @@
-CREATE or replace TABLE infra_metrics.cloudwatch_metrics
+CREATE TABLE infra_metrics.cloudwatch_metrics
 (
     `metric_stream_name` LowCardinality(String),
     `account_id` LowCardinality(String),


### PR DESCRIPTION
The timestamp used by cloudwatch has milliseconds, so change the timestamp field to match that

Testing: replaced the old table, then ran `python tools/rockset_migration/s32ch.py --clickhouse-table "infra_metrics.cloudwatch_metrics" --stored-data t.json --s3-bucket fbossci-cloudwatch-metrics --s3-prefix ghci-related `