### PR TITLE
Add file status to tutorial statistics

### DIFF
--- a/.github/scripts/get_tutorials_stats.py
+++ b/.github/scripts/get_tutorials_stats.py
@@ -154,7 +154,7 @@ def get_file_names(
                 rc[-1].files.append(FileInfo(name, int(added), int(deleted), ""))
     # Process name-status output to add status information
     current_commit = None
-    status_map = {}  # Maps commit_id -> {filename -> status}
+    status_map: Dict[str, Dict[str, str]] = {}  # Maps commit_id -> {filename -> status}
 
     for line in status_lines:
         line = line.strip()

--- a/.github/scripts/get_tutorials_stats.py
+++ b/.github/scripts/get_tutorials_stats.py
@@ -162,8 +162,8 @@ def get_file_names(
             continue
         elif ";" in line:  # This is a commit line
             commit_hash, date = line.split(";")
-            current_commit = commit_hash
-            status_map[current_commit] = {}
+            if current_commit is not None and filename:
+                status_map.setdefault(current_commit, {})[filename] = status
         else:  # This is a file status line
             parts = line.split("\t")
             status = parts[0]


### PR DESCRIPTION
This PR adds file status information Added (A), Copied (C), Deleted (D), Modified (M), Renamed (R) to the tutorial statistics tracking. The change enhances the `get_tutorials_stats.py` script to capture Git status information using the `--name-status` flag and store it in the `filenames.csv` output.

Changes:

*   Added status field to FileInfo class
*   Modified file parsing logic to extract status information from Git output
*   Status is now included in the **filenames.csv** output for each file

Local test generates this `filenames.csv`:
| commit_id | date | filename | lines_added | lines_deleted | status |
|-----------|------|----------|-------------|---------------|--------|
| 7c45ceb313 | 2025-07-11 | tutorials/index.rst | 17 | 171 | M |
| f4dda5dca1 | 2025-07-10 | tutorials/conf.py | 4 | 2 | M |
| 3569db3e78 | 2025-07-10 | tutorials/conf.py | 0 | 1 | M |
... 

How to test:
1. Comment out the part that uploads to S3
2. Add save to local file: 
    ```
	def save_to_local_file(filename: str, docs: list[dict[str, Any]]) -> None:
	    print(f"Writing {len(docs)} documents to {filename}")
	    with open(filename, "w", newline="") as f:
	        writer = csv.DictWriter(f, fieldnames=sorted(docs[0].keys()))
	        writer.writeheader()
	        writer.writerows(docs)
    	print(f"Done writing to {filename}")
	```
4. Add this to main:
    ```
	save_to_local_file("metadata.csv", history_log)
	save_to_local_file("filenames.csv", filenames)
	```
5. Make sure the tutorias_dir and pytorch_doc_dir point to the correct location of tutorials and pytorch repos. 
