### PR TITLE
[HUD] Selector for workflow id in commit and PR pages

### DIFF
--- a/torchci/clickhouse_queries/commit_jobs_query/params.json
+++ b/torchci/clickhouse_queries/commit_jobs_query/params.json
@@ -1,12 +1,14 @@
 {
   "params": {
     "repo": "String",
-    "sha": "String"
+    "sha": "String",
+    "workflowId": "Int64"
   },
   "tests": [
     {
       "repo": "pytorch/pytorch",
-      "sha": "85df746892d9b0e87e7a5dfa78ef81a84aec6de0"
+      "sha": "85df746892d9b0e87e7a5dfa78ef81a84aec6de0",
+      "workflow_id": 0
     }
   ]
 }

--- a/torchci/clickhouse_queries/commit_jobs_query/query.sql
+++ b/torchci/clickhouse_queries/commit_jobs_query/query.sql
@@ -46,6 +46,10 @@ WITH job AS (
         AND workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
         AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
         AND workflow.id in (select id from materialized_views.workflow_run_by_head_sha where head_sha = {sha: String})
+        AND (
+            {workflowId: Int64} = 0
+            OR workflow.id = {workflowId: Int64} -- If a specific workflow ID is provided, filter by it
+        )
         AND job.id in (select id from materialized_views.workflow_job_by_head_sha where head_sha = {sha: String})
         AND workflow.repository. 'full_name' = {repo: String } --         UNION
         AND workflow.name != 'Upload test stats while running' -- Continuously running cron job that cancels itself to avoid running concurrently
@@ -84,6 +88,10 @@ WITH job AS (
         workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
         AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
         AND workflow.id in (select id from materialized_views.workflow_run_by_head_sha where head_sha = {sha: String})
+        AND (
+            {workflowId: Int64} = 0
+            OR workflow.id = {workflowId: Int64} -- If a specific workflow ID is provided, filter by it
+        )
         AND workflow.repository.full_name = {repo: String }
         AND workflow.name != 'Upload test stats while running' -- Continuously running cron job that cancels itself to avoid running concurrently
 )

--- a/torchci/components/commit/CommitInfo.tsx
+++ b/torchci/components/commit/CommitInfo.tsx
@@ -43,7 +43,7 @@ export function CommitInfo({
     return <div>Loading...</div>;
   }
 
-  const { commit, jobs } = commitData;
+  const { commit, jobs, workflowIdsByName } = commitData;
 
   return (
     <div>
@@ -53,6 +53,7 @@ export function CommitInfo({
         repoName={repoName}
         commit={commit}
         jobs={jobs}
+        workflowIdsByName={workflowIdsByName}
         isCommitPage={isCommitPage}
         unstableIssues={unstableIssuesData ?? []}
       />

--- a/torchci/components/commit/CommitStatus.tsx
+++ b/torchci/components/commit/CommitStatus.tsx
@@ -54,10 +54,12 @@ function getBoxOrdering(jobs: JobData[], wideBoxes: Set<string>) {
 function WorkflowsContainer({
   jobs,
   unstableIssues,
+  workflowIdsByName,
   repoFullName,
 }: {
   jobs: JobData[];
   unstableIssues: IssueData[];
+  workflowIdsByName: Record<string, number[]>;
   repoFullName: string;
 }) {
   useScrollTo();
@@ -81,6 +83,7 @@ function WorkflowsContainer({
               repoFullName={repoFullName}
               key={workflowName}
               workflowName={workflowName}
+              allWorkflowIds={workflowIdsByName[workflowName] || []}
               jobs={jobs}
               unstableIssues={unstableIssues}
               wide={wideBoxes.has(workflowName)}
@@ -106,6 +109,7 @@ export default function CommitStatus({
   repoName,
   commit,
   jobs,
+  workflowIdsByName,
   isCommitPage,
   unstableIssues,
 }: {
@@ -113,6 +117,7 @@ export default function CommitStatus({
   repoName: string;
   commit: CommitData;
   jobs: JobData[];
+  workflowIdsByName: Record<string, number[]>;
   isCommitPage: boolean;
   unstableIssues: IssueData[];
 }) {
@@ -174,6 +179,7 @@ export default function CommitStatus({
       />
       <WorkflowsContainer
         jobs={jobs}
+        workflowIdsByName={workflowIdsByName}
         unstableIssues={unstableIssues}
         repoFullName={`${repoOwner}/${repoName}`}
       />

--- a/torchci/pages/api/[repoOwner]/[repoName]/commit/[sha].ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/commit/[sha].ts
@@ -5,19 +5,22 @@ import type { NextApiRequest, NextApiResponse } from "next";
 export type CommitApiResponse = {
   commit: CommitData;
   jobs: JobData[];
+  workflowIdsByName: Record<string, number[]>;
 };
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<CommitApiResponse>
 ) {
+  const workflowId = parseInt(req.query.workflowId as string, 10) || 0;
   res
     .status(200)
     .json(
       await fetchCommit(
         req.query.repoOwner as string,
         req.query.repoName as string,
-        req.query.sha as string
+        req.query.sha as string,
+        workflowId
       )
     );
 }


### PR DESCRIPTION
When multiple workflows run on the same commit (ex memory leak check + non mem leak check), HUD tries to filter the results so that only the most recent job is shown, but sometimes I want to find older ones.

An unfortunately large change because we usually query jobs for the entire commit instead of workflow by workflow

I reused the commit query because it already queries the necessary fields (name id time duration etc) and didn't want to write another query that we would have to keep in sync

Open to better solutions for how to get this data b/c imo this is kind of ugly

TODO: also handle reruns, better error handling



New
<img width="1257" height="117" alt="image" src="https://github.com/user-attachments/assets/ecb1b246-573a-45fd-ba3c-0a7cd39f31ef" />
<img width="250" height="124" alt="image" src="https://github.com/user-attachments/assets/bb145f65-7c62-4bb4-adb4-aba3816cf1f5" />



Probably review https://github.com/pytorch/test-infra/pull/6922 first