### PR TITLE
[ez] Adding results from B200 benchmark to TorchInductor dashboard

### DIFF
--- a/torchci/components/benchmark/compilers/common.tsx
+++ b/torchci/components/benchmark/compilers/common.tsx
@@ -61,6 +61,7 @@ export const DEFAULT_DEVICE_NAME = "cuda (h100)";
 export const DISPLAY_NAMES_TO_DEVICE_NAMES: { [k: string]: string } = {
   "cuda (a100)": "cuda",
   "cuda (h100)": "cuda",
+  "cuda (b200)": "cuda",
   "cpu (x86_64)": "cpu",
   "cpu (x86_zen)": "cpu",
   "cpu (aarch64)": "cpu",
@@ -70,6 +71,7 @@ export const DISPLAY_NAMES_TO_DEVICE_NAMES: { [k: string]: string } = {
 export const DISPLAY_NAMES_TO_ARCH_NAMES: { [k: string]: string } = {
   "cuda (a100)": "a100",
   "cuda (h100)": "h100",
+  "cuda (b200)": "b200",
   "cpu (x86_64)": "x86_64",
   "cpu (x86_zen)": "x86_zen",
   "cpu (aarch64)": "aarch64",
@@ -80,6 +82,7 @@ export const DISPLAY_NAMES_TO_ARCH_NAMES: { [k: string]: string } = {
 export const DISPLAY_NAMES_TO_WORKFLOW_NAMES: { [k: string]: string } = {
   "cuda (a100)": "inductor-A100-perf-nightly",
   "cuda (h100)": "inductor-perf-nightly-h100",
+  "cuda (b200)": "inductor-perf-b200",
   "cpu (x86)": "inductor-perf-nightly-x86",
   "cpu (x86_zen)": "inductor-perf-nightly-x86-zen",
   "cpu (aarch64)": "inductor-perf-nightly-aarch64",


### PR DESCRIPTION
TSIA, running from sample benchmark from https://github.com/pytorch/pytorch/pull/158011

## Preview

https://torchci-git-fork-huydhn-add-b200-benchmark-fbopensource.vercel.app/benchmark/compilers?dashboard=torchinductor&startTime=Sat%2C%2005%20Jul%202025%2005%3A38%3A21%20GMT&stopTime=Sat%2C%2012%20Jul%202025%2005%3A38%3A21%20GMT&granularity=hour&mode=inference&dtype=bfloat16&deviceName=cuda%20(b200)&lBranch=enable-b200-benchmark&lCommit=5144d1552a4cd59d007f42c3744044cb30b044ed&rBranch=enable-b200-benchmark&rCommit=5144d1552a4cd59d007f42c3744044cb30b044ed

cc @nWEIdia 