### PR TITLE
Update ``trigger_nightly.yml`` to add torchtitan

### DIFF
--- a/.github/workflows/trigger_nightly.yml
+++ b/.github/workflows/trigger_nightly.yml
@@ -23,6 +23,7 @@ on:
           - torchtune
           - torchcodec
           - torchvision-extra-decoders
+          - torchtitan
           - all
 jobs:
   trigger:
@@ -119,3 +120,11 @@ jobs:
           repository: pytorch-labs/torchvision-extra-decoders
           token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
           path: torchvision-extra-decoders
+      - name: Trigger nightly torchtitan
+        if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'torchtitan' || inputs.domain == 'all' }}
+        uses: ./.github/actions/trigger-nightly
+        with:
+          ref: main
+          repository: pytorch/torchtitan
+          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+          path: torchtitan


### PR DESCRIPTION
Add torchtitan to the nightly build trigger so that every night, `main` is cut into a `nightly` branch, which can then be built and released on the PyTorch Index. 

Pre-reqs: @tianyu-l has already added the pytorch-bot to the torchtitan repo and given it write permissions.