### PR TITLE
Revert "Add miniconda install=true to build_wheels_macos.yml"

### DIFF
--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -78,7 +78,7 @@ on:
         description: Set to true if setup-miniconda is needed
         required: false
         type: boolean
-        default: true
+        default: false
       delocate-wheel:
         description: "Whether to run delocate-wheel after building."
         required: false


### PR DESCRIPTION
Reverts pytorch/test-infra#6847
I believe revert is required I see its failing quite badly: https://github.com/pytorch/vision/actions/runs/16174574484/job/45656408659