### PR TITLE
[BE] Limit trunk failure alerts to viable-strict breaking failures

### DIFF
--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -20,7 +20,7 @@ jobs:
           - repo: pytorch/pytorch
             branch: main
             with_flaky_test_alerting: YES
-            job_filter_regex: ""
+            job_filter_regex: "^(pull|trunk|lint|linux-binary-)"
           - repo: pytorch/pytorch
             branch: nightly
             with_flaky_test_alerting: NO

--- a/tools/torchci/check_alerts.py
+++ b/tools/torchci/check_alerts.py
@@ -524,7 +524,9 @@ def handle_flaky_tests_alert(
 def filter_job_names(job_names: List[str], job_name_regex: str) -> List[str]:
     if job_name_regex:
         return [
-            job_name for job_name in job_names if re.match(job_name_regex, job_name, re.IGNORECASE)
+            job_name
+            for job_name in job_names
+            if re.match(job_name_regex, job_name, re.IGNORECASE)
         ]
     return job_names
 

--- a/tools/torchci/check_alerts.py
+++ b/tools/torchci/check_alerts.py
@@ -524,7 +524,7 @@ def handle_flaky_tests_alert(
 def filter_job_names(job_names: List[str], job_name_regex: str) -> List[str]:
     if job_name_regex:
         return [
-            job_name for job_name in job_names if re.match(job_name_regex, job_name)
+            job_name for job_name in job_names if re.match(job_name_regex, job_name, re.IGNORECASE)
         ]
     return job_names
 
@@ -545,7 +545,7 @@ def check_for_recurrently_failing_jobs_alert(
         elif len(filtered_job_names) == len(job_names):
             print("All jobs matched the regex")
         else:
-            print("\n".join(filtered_job_names))
+            print("\n".join(sorted(filtered_job_names)))
 
     (jobs_to_alert_on, flaky_jobs) = classify_jobs(
         job_names, sha_grid, filtered_job_names


### PR DESCRIPTION
Denoises alerts by limiting them to the most important viable/strict upgrade blocking failures 

Testing: Ran script locally to verify it only considered the expected set of workflows