### PR TITLE
[BE] Fix lintrunner init for uv based environments

### DIFF
--- a/tools/linter/adapters/pip_init.py
+++ b/tools/linter/adapters/pip_init.py
@@ -2,16 +2,18 @@
 Initializer script that installs stuff to pip.
 """
 
+from __future__ import annotations
+
 import argparse
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import time
-from typing import List
 
 
-def run_command(args: List[str]) -> "subprocess.CompletedProcess[bytes]":
+def run_command(args: list[str]) -> subprocess.CompletedProcess[bytes]:
     logging.debug("$ %s", " ".join(args))
     start_time = time.monotonic()
     try:
@@ -50,7 +52,17 @@ if __name__ == "__main__":
         stream=sys.stderr,
     )
 
-    pip_args = ["pip3", "install"]
+    uv_available = (
+        any(prefix in sys.base_prefix for prefix in ["uv/python", "uv\\python"])
+        and shutil.which("uv") is not None
+    )
+
+    if uv_available:
+        pip_args = ["uv", "pip", "install"]
+    elif sys.executable:
+        pip_args = [sys.executable, "-mpip", "install"]
+    else:
+        pip_args = ["pip3", "install"]
 
     # If we are in a global install, use `--user` to install so that you do not
     # need root access in order to initialize linters.


### PR DESCRIPTION
Fixes lintrunner init when uv is installed locally and used to generated the venv, porting over `uv` related fixes from https://github.com/pytorch/pytorch/blob/main/tools/linter/adapters/pip_init.py