### PR TITLE
runners: Move runner removal logic up

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
@@ -472,7 +472,7 @@ describe('scale-down', () => {
       expect(mockedGetRunnerTypes).toBeCalledTimes(9);
       expect(mockedGetRunnerTypes).toBeCalledWith({ owner: theOrg, repo: scaleConfigRepo }, metrics);
 
-      expect(mockedRemoveGithubRunnerOrg).toBeCalledTimes(4);
+      expect(mockedRemoveGithubRunnerOrg).toBeCalledTimes(5);
       {
         const { awsR, ghR } = getRunnerPair('keep-min-runners-oldest-02');
         expect(mockedRemoveGithubRunnerOrg).toBeCalledWith(ghR.id, awsR.org as string, metrics);
@@ -814,7 +814,7 @@ describe('scale-down', () => {
       expect(mockedGetRunnerTypes).toBeCalledTimes(9);
       expect(mockedGetRunnerTypes).toBeCalledWith(repo, metrics);
 
-      expect(mockedRemoveGithubRunnerRepo).toBeCalledTimes(4);
+      expect(mockedRemoveGithubRunnerRepo).toBeCalledTimes(5);
       {
         const { ghR } = getRunnerPair('keep-min-runners-oldest-02');
         expect(mockedRemoveGithubRunnerRepo).toBeCalledWith(ghR.id, repo, metrics);


### PR DESCRIPTION
This is a refactor of scale-down to move the runner removal logic up to the top of the loop. This is done to avoid long wait times between determining if a runner should be removed and actually removing it.

In practice we were observing wait times of up to 7 to 10 minutes.

This might only actually be testable with production traffic / rate limits.