### PR TITLE
Remove ROCm docker image default in linux_job_v2.yml

### DIFF
--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -116,10 +116,7 @@ jobs:
     name: ${{ inputs.job-name }}
     env:
       DOCKER_IMAGE: >-
-        ${{ inputs.gpu-arch-type == 'rocm' && format('pytorch/manylinux2_28-builder:{0}{1}',
-                                                                      inputs.gpu-arch-type,
-                                                                      inputs.gpu-arch-version)
-                                                            || inputs.docker-image == 'pytorch/almalinux-builder' && format('pytorch/almalinux-builder:{0}{1}',
+        ${{ inputs.docker-image == 'pytorch/almalinux-builder' && format('pytorch/almalinux-builder:{0}{1}',
                                                                       inputs.gpu-arch-type,
                                                                       inputs.gpu-arch-version)
                                                             || inputs.docker-image }}


### PR DESCRIPTION
Use `inputs.docker-image` to explicitly provide the docker image to be used.

Relates to: https://github.com/pytorch/ao/pull/2562