### PR TITLE
[EZ] Fix TorchInductor CH queries for A100

### DIFF
--- a/torchci/clickhouse_queries/compilers_benchmark_performance/query.sql
+++ b/torchci/clickhouse_queries/compilers_benchmark_performance/query.sql
@@ -76,7 +76,7 @@ WHERE
     -- in 6 months
     AND (
         (
-            {arch: String } = ''
+            ({arch: String } = '' OR {arch: String } = 'a100')
             AND output LIKE CONCAT(
                 '%_',
                 {dtype: String },

--- a/torchci/clickhouse_queries/compilers_benchmark_performance_branches/query.sql
+++ b/torchci/clickhouse_queries/compilers_benchmark_performance_branches/query.sql
@@ -14,7 +14,7 @@ WHERE
     -- in 6 months
     AND (
         (
-            {arch: String } = ''
+            ({arch: String } = '' OR {arch: String } = 'a100')
             AND benchmark_extra_info['output'] LIKE CONCAT(
                 '%_',
                 {dtype: String },


### PR DESCRIPTION
As reported by @aorenste where [a100 results were not loaded on the dashboard](https://hud.pytorch.org/benchmark/compilers?dashboard=torchinductor&startTime=Wed%2C%2009%20Jul%202025%2023%3A22%3A18%20GMT&stopTime=Wed%2C%2016%20Jul%202025%2023%3A22%3A18%20GMT&granularity=hour&mode=inference&dtype=bfloat16&deviceName=cuda%20(a100)&lBranch=main&lCommit=&rBranch=main&rCommit=).  The bug here is in the SQL queries where `arch` is now set correctly to `a100` by HUD.  On the other hand, this legacy field in the database is empty because `a100` was the only arch in the past and wasn't set explicitly.

With the work that @yangw-dev plans to do, these queries would likely not staying around for much longer.  So, I just opt for the easy fix of handling `a100` explicitly.

### Testing

[a100](https://torchci-git-fork-huydhn-fix-a100-query-fbopensource.vercel.app/benchmark/compilers?dashboard=torchinductor&startTime=Wed%2C%2009%20Jul%202025%2023%3A59%3A25%20GMT&stopTime=Wed%2C%2016%20Jul%202025%2023%3A59%3A25%20GMT&granularity=hour&mode=inference&dtype=bfloat16&deviceName=cuda%20(a100)&lBranch=main&lCommit=&rBranch=main&rCommit=) shows up correctly now

cc @aorenste 