### PR TITLE
update nvidia-container-toolkit to 1.17.8

### DIFF
--- a/.github/actions/setup-nvidia/action.yml
+++ b/.github/actions/setup-nvidia/action.yml
@@ -42,10 +42,10 @@ runs:
                   sudo yum-config-manager --add-repo "${YUM_REPO_URL}"
                   sudo yum install -y \
                     nvidia-docker2 \
-                    nvidia-container-toolkit-1.16.2 \
-                    libnvidia-container-tools-1.16.2 \
-                    libnvidia-container1-1.16.2 \
-                    nvidia-container-toolkit-base-1.16.2
+                    nvidia-container-toolkit-1.16.8 \
+                    libnvidia-container-tools-1.16.8 \
+                    libnvidia-container1-1.16.8 \
+                    nvidia-container-toolkit-base-1.16.8
                   sudo systemctl restart docker
               )
           }

--- a/.github/actions/setup-nvidia/action.yml
+++ b/.github/actions/setup-nvidia/action.yml
@@ -42,10 +42,10 @@ runs:
                   sudo yum-config-manager --add-repo "${YUM_REPO_URL}"
                   sudo yum install -y \
                     nvidia-docker2 \
-                    nvidia-container-toolkit-1.16.8 \
-                    libnvidia-container-tools-1.16.8 \
-                    libnvidia-container1-1.16.8 \
-                    nvidia-container-toolkit-base-1.16.8
+                    nvidia-container-toolkit-1.17.8 \
+                    libnvidia-container-tools-1.17.8 \
+                    libnvidia-container1-1.17.8 \
+                    nvidia-container-toolkit-base-1.17.8
                   sudo systemctl restart docker
               )
           }


### PR DESCRIPTION
Mitigating CVE-2025-23266

Tested by
```
sudo sudo yum install -y \
                    nvidia-docker2 \
                    nvidia-container-toolkit-1.17.8 \
                    libnvidia-container-tools-1.17.8 \
                    libnvidia-container1-1.17.8 \
                    nvidia-container-toolkit-base-1.17.8
```

and 
```
docker run --rm --gpus all nvidia/cuda:12.2.0-base-ubuntu22.04 nvidia-smi
```

on a runner, which resulted in
```
Unable to find image 'nvidia/cuda:12.2.0-base-ubuntu22.04' locally
12.2.0-base-ubuntu22.04: Pulling from nvidia/cuda
aece8493d397: Pull complete
9fe5ccccae45: Pull complete
8054e9d6e8d6: Pull complete
bdddd5cb92f6: Pull complete
5324914b4472: Pull complete
Digest: sha256:ecdf8549dd5f12609e365217a64dedde26ecda26da8f3ff3f82def6749f53051
Status: Downloaded newer image for nvidia/cuda:12.2.0-base-ubuntu22.04
Fri Jul 18 18:59:36 2025
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 570.133.07             Driver Version: 570.133.07     CUDA Version: 12.8     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA A10G                    On  |   00000000:00:1E.0 Off |                    0 |
|  0%   40C    P0             63W /  300W |    2351MiB /  23028MiB |      7%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
```