### PR TITLE
[HUD] Fix SLI page scroll reset and navigation hijacking

### DIFF
--- a/torchci/pages/sli.tsx
+++ b/torchci/pages/sli.tsx
@@ -263,9 +263,9 @@ export default function Page() {
 
   useEffect(() => {
     if (!router.isReady) return;
-    
+
     // Only update URL if we're still on the SLI page
-    if (router.pathname !== '/sli') return;
+    if (router.pathname !== "/sli") return;
 
     const params = new URLSearchParams();
 
@@ -289,10 +289,14 @@ export default function Page() {
       params.set("ttsPercentile", initialTtsPercentile);
     }
 
-    router.push({
-      pathname: router.pathname,
-      query: params.toString(),
-    }, undefined, { shallow: true });
+    router.push(
+      {
+        pathname: router.pathname,
+        query: params.toString(),
+      },
+      undefined,
+      { shallow: true }
+    );
   }, [
     initialTtsPercentile,
     initialWorkerTypes,

--- a/torchci/pages/sli.tsx
+++ b/torchci/pages/sli.tsx
@@ -263,6 +263,9 @@ export default function Page() {
 
   useEffect(() => {
     if (!router.isReady) return;
+    
+    // Only update URL if we're still on the SLI page
+    if (router.pathname !== '/sli') return;
 
     const params = new URLSearchParams();
 
@@ -289,7 +292,7 @@ export default function Page() {
     router.push({
       pathname: router.pathname,
       query: params.toString(),
-    });
+    }, undefined, { shallow: true });
   }, [
     initialTtsPercentile,
     initialWorkerTypes,


### PR DESCRIPTION
Fix SLI page navigation and scroll issues

This PR fixes two issues on the /sli page:

  1. Scroll position was locked at the top of the page
  2. Navigation hijacking: Clicking navbar links would briefly navigate away but then immediately return to /sli

  Changes:

- Added shallow: true to router.push() to prevent full page re-renders when updating URL parameters
- Added pathname check to prevent the useEffect from running when navigating away from the page