### PR TITLE
Move all viable/strict blocking jobs closer to the beginning

### DIFF
--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -27,6 +27,7 @@ const GROUP_MAC = "Mac";
 const GROUP_PARALLEL = "Parallel";
 const GROUP_DOCS = "Docs";
 const GROUP_LIBTORCH = "Libtorch";
+const GROUP_OTHER_VIABLE_STRICT_BLOCKING = "Other viable/strict blocking";
 const GROUP_OTHER = "other";
 
 // Jobs will be grouped with the first regex they match in this list
@@ -138,6 +139,12 @@ export const groups = [
     regex: /libtorch/,
     name: GROUP_LIBTORCH,
   },
+  {
+    // This is a catch-all for jobs that are viable but strict blocking
+    // Excluding linux-binary-* jobs because they are already grouped further up
+    regex: /(pull)|(trunk)/,
+    name: GROUP_OTHER_VIABLE_STRICT_BLOCKING,
+  }
 ];
 
 // Jobs on HUD home page will be sorted according to this list, with anything left off at the end
@@ -150,6 +157,7 @@ const HUD_GROUP_SORTING = [
   GROUP_MAC,
   GROUP_ROCM,
   GROUP_XLA,
+  GROUP_OTHER_VIABLE_STRICT_BLOCKING, // placed after the last group that tends to have viable/strict blocking jobs
   GROUP_PARALLEL,
   GROUP_LIBTORCH,
   GROUP_ANDROID,
@@ -164,10 +172,11 @@ const HUD_GROUP_SORTING = [
   GROUP_INDUCTOR,
   GROUP_INDUCTOR_PERIODIC,
   GROUP_ANNOTATIONS_AND_LABELING,
-  GROUP_OTHER,
   GROUP_BINARY_WINDOWS,
   GROUP_MEMORY_LEAK_CHECK,
   GROUP_RERUN_DISABLED_TESTS,
+  // These two groups should always be at the end
+  GROUP_OTHER,
   GROUP_UNSTABLE,
 ];
 

--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -144,7 +144,7 @@ export const groups = [
     // Excluding linux-binary-* jobs because they are already grouped further up
     regex: /(pull)|(trunk)/,
     name: GROUP_OTHER_VIABLE_STRICT_BLOCKING,
-  }
+  },
 ];
 
 // Jobs on HUD home page will be sorted according to this list, with anything left off at the end


### PR DESCRIPTION
Some pull and trunk jobs had newer naming conventions, so they were getting dumped in the "other" category on HUD where failures are harder to notice.  Creating a new "other" category just for viable/strict blocking jobs in a place where the eye is more easily to notice the failure

Adds a new "Other viable/strict blocking" category for jobs on the HUD home page

New group and the jobs it contains:
<img width="1552" height="627" alt="image" src="https://github.com/user-attachments/assets/f98c254a-f632-46db-9ca3-6c4f292ef529" />
