### PR TITLE
Fix libtorch file naming in matrix

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -238,9 +238,7 @@ def get_libtorch_install_command(
         else libtorch_variant
     )
     build_name = (
-        f"{prefix}-{devtoolset}-{_libtorch_variant}-latest.zip"
-        if devtoolset == "cxx11-abi"
-        else f"{prefix}-{_libtorch_variant}-latest.zip"
+        f"{prefix}-{_libtorch_variant}-latest.zip"
     )
 
     if os == MACOS_ARM64:
@@ -251,9 +249,7 @@ def get_libtorch_install_command(
 
     elif os == LINUX and (channel in (RELEASE, TEST)):
         build_name = (
-            f"{prefix}-{devtoolset}-{_libtorch_variant}-{CURRENT_VERSION}%2B{desired_cuda}.zip"
-            if devtoolset == "cxx11-abi"
-            else f"{prefix}-{_libtorch_variant}-{CURRENT_VERSION}%2B{desired_cuda}.zip"
+            f"{prefix}-{_libtorch_variant}-{CURRENT_VERSION}%2B{desired_cuda}.zip"
         )
     elif os == WINDOWS and (channel in (RELEASE, TEST)):
         build_name = (

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -237,9 +237,7 @@ def get_libtorch_install_command(
         if libtorch_config == "debug"
         else libtorch_variant
     )
-    build_name = (
-        f"{prefix}-{_libtorch_variant}-latest.zip"
-    )
+    build_name = f"{prefix}-{_libtorch_variant}-latest.zip"
 
     if os == MACOS_ARM64:
         arch = "arm64"


### PR DESCRIPTION
``cxx11-abi`` was removed from file name in all libtorch builds.
This should fix validation of these builds here: https://github.com/pytorch/test-infra/actions/runs/16472470897/job/46565023340