### PR TITLE
Filter out restarted jobs from CH queries

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_checker.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_checker.py
@@ -116,6 +116,7 @@ class AutorevertPatternChecker:
             AND head_branch = 'main'
             AND created_at >= {lookback_time:DateTime}
             AND dynamoKey LIKE 'pytorch/pytorch/%'
+            AND workflow_event != 'workflow_dispatch'  -- Exclude restart jobs
         ORDER BY
             workflow_name, workflow_created_at DESC, head_sha, name
         """

--- a/torchci/clickhouse_queries/commit_jobs_batch_query/query.sql
+++ b/torchci/clickhouse_queries/commit_jobs_batch_query/query.sql
@@ -30,6 +30,7 @@ WITH job AS (
         AND job.name != 'generate-test-matrix'
         AND workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
         AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
+        AND NOT (workflow.event = 'workflow_dispatch' AND workflow.head_branch LIKE 'trunk/%') -- Filter out restart jobs
         and job.id in (select id from materialized_views.workflow_job_by_head_sha where head_sha in {shas: Array(String)})
         and workflow.id in (select id from materialized_views.workflow_run_by_head_sha where head_sha in {shas: Array(String)})
 ),

--- a/torchci/clickhouse_queries/commit_jobs_query/query.sql
+++ b/torchci/clickhouse_queries/commit_jobs_query/query.sql
@@ -45,6 +45,7 @@ WITH job AS (
         AND job.name != 'generate-test-matrix'
         AND workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
         AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
+        AND NOT (workflow.event = 'workflow_dispatch' AND workflow.head_branch LIKE 'trunk/%') -- Filter out restart jobs
         AND workflow.id in (select id from materialized_views.workflow_run_by_head_sha where head_sha = {sha: String})
         AND (
             {workflowId: Int64} = 0
@@ -87,6 +88,7 @@ WITH job AS (
     WHERE
         workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
         AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
+        AND NOT (workflow.event = 'workflow_dispatch' AND workflow.head_branch LIKE 'trunk/%') -- Filter out restart jobs
         AND workflow.id in (select id from materialized_views.workflow_run_by_head_sha where head_sha = {sha: String})
         AND (
             {workflowId: Int64} = 0

--- a/torchci/clickhouse_queries/flaky_tests/across_jobs/query.sql
+++ b/torchci/clickhouse_queries/flaky_tests/across_jobs/query.sql
@@ -37,6 +37,7 @@ with failed_jobs as (
         and w.name in ('trunk', 'pull')
         and job.name not like '%mem_leak_check%'
         and job.name not like '%rerun_disabled_tests%'
+        and w.event != 'workflow_dispatch'  -- Filter out restart jobs
     order by
         job._event_time
 ),

--- a/torchci/clickhouse_queries/hud_query/query.sql
+++ b/torchci/clickhouse_queries/hud_query/query.sql
@@ -32,6 +32,7 @@ WITH job AS (
         )  -- Should be filtered out by the workflow_event filters, but workflow_event takes some time to populate
         AND job.workflow_event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
         AND job.workflow_event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
+        AND NOT (job.workflow_event = 'workflow_dispatch' AND job.head_branch LIKE 'trunk/%') -- Filter out restart jobs
         AND job.id in (select id from materialized_views.workflow_job_by_head_sha where head_sha in {shas: Array(String)})
         AND job.repository_full_name = {repo: String}
         AND job.workflow_name != 'Upload test stats while running' -- Continuously running cron job that cancels itself to avoid running concurrently


### PR DESCRIPTION
As the prerequisite for running autorevert in shadow mode, we need to filter out restarted jobs from the existing queries where they might skew the results.