### PR TITLE
[BE] Use info logs for normal operations

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
@@ -7,6 +7,7 @@ import {
   resetRunnersCaches,
   terminateRunner,
   tryReuseRunner,
+  NoRunnersAvailable,
 } from './runners';
 import { RunnerInfo } from './utils';
 import { ScaleUpMetrics } from './metrics';
@@ -500,7 +501,7 @@ describe('tryReuseRunner', () => {
       };
       mockDescribeInstances.promise.mockClear().mockResolvedValue(mockRunningInstances);
 
-      await expect(tryReuseRunner(runnerParameters, metrics)).rejects.toThrowError('No runners available');
+      await expect(tryReuseRunner(runnerParameters, metrics)).rejects.toThrow(NoRunnersAvailable);
 
       expect(mockEC2.describeInstances).toBeCalledWith({
         Filters: [
@@ -563,7 +564,7 @@ describe('tryReuseRunner', () => {
       };
       mockDescribeInstances.promise.mockClear().mockResolvedValue(mockRunningInstances);
 
-      await expect(tryReuseRunner(runnerParameters, metrics)).rejects.toThrowError('No runners available');
+      await expect(tryReuseRunner(runnerParameters, metrics)).rejects.toThrow(NoRunnersAvailable);
 
       expect(mockEC2.describeInstances).toBeCalledWith({
         Filters: [
@@ -630,7 +631,7 @@ describe('tryReuseRunner', () => {
       };
       mockDescribeInstances.promise.mockClear().mockResolvedValue(mockRunningInstances);
 
-      await expect(tryReuseRunner(runnerParameters, metrics)).rejects.toThrowError('No runners available');
+      await expect(tryReuseRunner(runnerParameters, metrics)).rejects.toThrow(NoRunnersAvailable);
 
       expect(mockEC2.describeInstances).toBeCalledWith({
         Filters: [
@@ -772,7 +773,7 @@ describe('tryReuseRunner', () => {
       };
       mockDescribeInstances.promise.mockClear().mockResolvedValue(mockRunningInstances);
 
-      await expect(tryReuseRunner(runnerParameters, metrics)).rejects.toThrowError('No runners available');
+      await expect(tryReuseRunner(runnerParameters, metrics)).rejects.toThrow(NoRunnersAvailable);
 
       expect(mockEC2.describeInstances).toBeCalledWith({
         Filters: [
@@ -831,7 +832,7 @@ describe('tryReuseRunner', () => {
       };
       mockDescribeInstances.promise.mockClear().mockResolvedValue(mockRunningInstances);
 
-      await expect(tryReuseRunner(runnerParameters, metrics)).rejects.toThrowError('No runners available');
+      await expect(tryReuseRunner(runnerParameters, metrics)).rejects.toThrow(NoRunnersAvailable);
 
       expect(mockEC2.describeInstances).toBeCalledWith({
         Filters: [
@@ -974,7 +975,7 @@ describe('tryReuseRunner', () => {
       };
       mockDescribeInstances.promise.mockClear().mockResolvedValue(mockRunningInstances);
 
-      await expect(tryReuseRunner(runnerParameters, metrics)).rejects.toThrowError('No runners available');
+      await expect(tryReuseRunner(runnerParameters, metrics)).rejects.toThrow(NoRunnersAvailable);
 
       expect(mockEC2.describeInstances).toBeCalledWith({
         Filters: [

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -9,6 +9,13 @@ import { getJoinedStressTestExperiment, redisCached, redisLocked } from './cache
 import moment from 'moment';
 import { RetryableScalingError } from './scale-up';
 
+export class NoRunnersAvailable extends Error {
+  constructor() {
+    super('No runners available');
+    this.name = 'NoRunnersAvailable';
+  }
+}
+
 export interface ListRunnerFilters {
   applicationDeployDatetime?: string;
   containsTags?: Array<string>;
@@ -649,7 +656,7 @@ export async function tryReuseRunner(
     );
   }
 
-  throw new Error('No runners available');
+  throw new NoRunnersAvailable();
 }
 
 export async function createRunner(runnerParameters: RunnerInputParameters, metrics: Metrics): Promise<string> {

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -1,6 +1,6 @@
 import { Metrics, ScaleUpMetrics } from './metrics';
 import { Repo, getRepoKey, sleep } from './utils';
-import { RunnerType, RunnerInputParameters, createRunner, tryReuseRunner } from './runners';
+import { RunnerType, RunnerInputParameters, createRunner, tryReuseRunner, NoRunnersAvailable } from './runners';
 import {
   createRegistrationTokenOrg,
   createRegistrationTokenRepo,
@@ -126,7 +126,11 @@ export async function scaleUp(
             await tryReuseRunner(createRunnerParams, metrics);
             continue; // Runner successfuly reused, no need to create a new one, continue to next runner
           } catch (e) {
-            console.error(`Error reusing runner: ${e}`);
+            if (e instanceof NoRunnersAvailable) {
+              console.info(`No runners available for reuse`);
+            } else {
+              console.error(`Error reusing runner: ${e}`);
+            }
           }
         }
 


### PR DESCRIPTION
It's normal for there not being runners available for reuse, those events should not be logged as errors.