### PR TITLE
[ez][HUD] Fix metrics page layout after #6956

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -771,7 +771,7 @@ export default function Page() {
               queryParams={timeParams}
               badThreshold={(value) => value > 2.0} // 2.0 average retries
             />
-             <ScalarPanel
+            <ScalarPanel
               title={"PR landing time (avg)"}
               queryName={"pr_landing_time_avg"}
               metricName={"avg_hours"}


### PR DESCRIPTION
Metrics page very unaligned after https://github.com/pytorch/test-infra/pull/6956

Old:
<img width="1719" height="783" alt="image" src="https://github.com/user-attachments/assets/42423730-38df-42af-a56a-6093a1ab8c1f" />


New:
<img width="1720" height="792" alt="image" src="https://github.com/user-attachments/assets/23079b61-2453-4206-becf-9b1c7c50080a" />
