### PR TITLE
Base64 decode the app secret for pytorch-auto-revert lamba

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import base64
 import logging
 import os
 
@@ -133,7 +134,7 @@ def main(*args, **kwargs) -> None:
     )
     GHClientFactory.setup_client(
         opts.github_app_id,
-        opts.github_app_secret,
+        base64.b64decode(opts.github_app_secret).decode("utf-8") if opts.github_app_secret else "",
         opts.github_installation_id,
         opts.github_access_token,
     )

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
@@ -124,6 +124,11 @@ def get_opts() -> argparse.Namespace:
 def main(*args, **kwargs) -> None:
     load_dotenv()
     opts = get_opts()
+
+    gh_app_secret = ""
+    if opts.github_app_secret:
+        gh_app_secret = base64.b64decode(opts.github_app_secret).decode("utf-8")
+
     setup_logging(opts.log_level)
     CHCliFactory.setup_client(
         opts.clickhouse_host,
@@ -134,7 +139,7 @@ def main(*args, **kwargs) -> None:
     )
     GHClientFactory.setup_client(
         opts.github_app_id,
-        base64.b64decode(opts.github_app_secret).decode("utf-8") if opts.github_app_secret else "",
+        gh_app_secret,
         opts.github_installation_id,
         opts.github_access_token,
     )


### PR DESCRIPTION
They way that the lambdas are structured and the terraform is setup, it is not possible to pass newlines as environment variables.

So the github app key, that is a private key, needs to be b64 encoded.