### PR TITLE
Add option to generate matrix for getting started page

### DIFF
--- a/.github/workflows/generate_binary_build_matrix.yml
+++ b/.github/workflows/generate_binary_build_matrix.yml
@@ -59,6 +59,11 @@ on:
         required: false
         type: boolean
         default: false
+      getting-started:
+        description: "Release matrix for getting started page"
+        required: false
+        type: boolean
+        default: false
 
     outputs:
       matrix:
@@ -98,6 +103,7 @@ jobs:
           USE_ONLY_DL_PYTORCH_ORG: ${{ inputs.use-only-dl-pytorch-org }}
           BUILD_PYTHON_ONLY: ${{ inputs.build-python-only }}
           USE_SPLIT_BUILD: ${{ inputs.use_split_build }}
+          GETTING_STARTED: ${{ inputs.getting-started }}
           PYTHON_VERSIONS: ${{ inputs.python-versions }}
         run: |
           set -eou pipefail


### PR DESCRIPTION
We will be removing torchaudio from getting started page. However would still like to include it in validation.

Test:
```
python  tools/scripts/generate_binary_build_matrix.py --getting-started true
{"include": [{"python_version": "3.9", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux2_28-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_9-cpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "2.7.1", "use_split_build": false}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "12.6", "desired_cuda": "cu126", "container_image": "pytorch/manylinux2_28-builder:cuda12.6", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda12_6", "validation_runner": "linux.g5.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "2.7.1", "use_split_build": false}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "12.8", "desired_cuda": "cu128", "container_image": "pytorch/manylinux2_28-builder:cuda12.8", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda12_8", "validation_runner": "linux.g5.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "2.7.1", "use_split_build": false}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "12.9", "desired_cuda": "cu129", "container_image": "pytorch/manylinux2_28-builder:cuda12.9", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda12_9", "validation_runner": "linux.g5.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu129", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "2.7.1", "use_split_build": false}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "6.3", "desired_cuda": "rocm6.3", "container_image": "pytorch/manylinux2_28-builder:rocm6.3", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm6_3", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm6.3", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "2.7.1", "use_split_build": false}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "6.4", "desired_cuda": "rocm6.4", "container_image": "pytorch/manylinux2_28-builder:rocm6.4", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm6_4", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm6.4", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "2.7.1", "use_split_build": false}, {"python_version": "3.9", "gpu_arch_type": "xpu", "gpu_arch_version": "", "desired_cuda": "xpu", "container_image": "pytorch/manylinux2_28-builder:xpu", "package_type": "manywheel", "build_name": "manywheel-py3_9-xpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "2.7.1", "use_split_build": false}]}
```