### PR TITLE
Fix libtorch nightly binaries links 2

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -359,7 +359,7 @@ def generate_libtorch_matrix(
         if with_rocm == ENABLE and os == LINUX:
             arches += ROCM_ARCHES
 
-    if abi_versions is None:
+    if abi_versions is None or len(abi_versions) == 0:
         if os == WINDOWS:
             abi_versions = [RELEASE, DEBUG]
         elif os == LINUX:


### PR DESCRIPTION
Test :
```
{"include": [{"python_version": "3.9", "gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "container_image": "pytorch/manylinux2_28-builder:cpu", "package_type": "manywheel", "build_name": "manywheel-py3_9-cpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "2.7.1", "use_split_build": false}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "12.6", "desired_cuda": "cu126", "container_image": "pytorch/manylinux2_28-builder:cuda12.6", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda12_6", "validation_runner": "linux.g5.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "2.7.1", "use_split_build": false}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "12.8", "desired_cuda": "cu128", "container_image": "pytorch/manylinux2_28-builder:cuda12.8", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda12_8", "validation_runner": "linux.g5.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "2.7.1", "use_split_build": false}, {"python_version": "3.9", "gpu_arch_type": "cuda", "gpu_arch_version": "12.9", "desired_cuda": "cu129", "container_image": "pytorch/manylinux2_28-builder:cuda12.9", "package_type": "manywheel", "build_name": "manywheel-py3_9-cuda12_9", "validation_runner": "linux.g5.4xlarge.nvidia.gpu", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu129", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "2.7.1", "use_split_build": false}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "6.3", "desired_cuda": "rocm6.3", "container_image": "pytorch/manylinux2_28-builder:rocm6.3", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm6_3", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.3", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "2.7.1", "use_split_build": false}, {"python_version": "3.9", "gpu_arch_type": "rocm", "gpu_arch_version": "6.4", "desired_cuda": "rocm6.4", "container_image": "pytorch/manylinux2_28-builder:rocm6.4", "package_type": "manywheel", "build_name": "manywheel-py3_9-rocm6_4", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.4", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "2.7.1", "use_split_build": false}, {"python_version": "3.9", "gpu_arch_type": "xpu", "gpu_arch_version": "", "desired_cuda": "xpu", "container_image": "pytorch/manylinux2_28-builder:xpu", "package_type": "manywheel", "build_name": "manywheel-py3_9-xpu", "validation_runner": "linux.2xlarge", "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu", "channel": "nightly", "upload_to_base_bucket": "no", "stable_version": "2.7.1", "use_split_build": false}, {"gpu_arch_type": "cpu", "gpu_arch_version": "", "desired_cuda": "cpu", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cpu", "package_type": "libtorch", "build_name": "libtorch-cpu-shared-with-deps-cxx11-abi", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-shared-with-deps-latest.zip", "channel": "nightly", "stable_version": "2.7.1"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "12.6", "desired_cuda": "cu126", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda12.6", "package_type": "libtorch", "build_name": "libtorch-cuda12_6-shared-with-deps-cxx11-abi", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/cu126/libtorch-shared-with-deps-latest.zip", "channel": "nightly", "stable_version": "2.7.1"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "12.8", "desired_cuda": "cu128", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda12.8", "package_type": "libtorch", "build_name": "libtorch-cuda12_8-shared-with-deps-cxx11-abi", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/cu128/libtorch-shared-with-deps-latest.zip", "channel": "nightly", "stable_version": "2.7.1"}, {"gpu_arch_type": "cuda", "gpu_arch_version": "12.9", "desired_cuda": "cu129", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:cuda12.9", "package_type": "libtorch", "build_name": "libtorch-cuda12_9-shared-with-deps-cxx11-abi", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/cu129/libtorch-shared-with-deps-latest.zip", "channel": "nightly", "stable_version": "2.7.1"}, {"gpu_arch_type": "rocm", "gpu_arch_version": "6.3", "desired_cuda": "rocm6.3", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:rocm6.3", "package_type": "libtorch", "build_name": "libtorch-rocm6_3-shared-with-deps-cxx11-abi", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/rocm6.3/libtorch-shared-with-deps-latest.zip", "channel": "nightly", "stable_version": "2.7.1"}, {"gpu_arch_type": "rocm", "gpu_arch_version": "6.4", "desired_cuda": "rocm6.4", "libtorch_variant": "shared-with-deps", "libtorch_config": "", "devtoolset": "cxx11-abi", "container_image": "pytorch/libtorch-cxx11-builder:rocm6.4", "package_type": "libtorch", "build_name": "libtorch-rocm6_4-shared-with-deps-cxx11-abi", "validation_runner": "linux.2xlarge", "installation": "https://download.pytorch.org/libtorch/nightly/rocm6.4/libtorch-shared-with-deps-latest.zip", "channel": "nightly", "stable_version": "2.7.1"}]}
```