### PR TITLE
[autorevert] Fix bug on job retrival for autorevert lambda

### DIFF
--- a/aws/lambda/pytorch-auto-revert/Makefile
+++ b/aws/lambda/pytorch-auto-revert/Makefile
@@ -23,7 +23,7 @@ run-local: venv/bin/python
 
 .PHONY: run-local-workflows
 run-local-workflows: venv/bin/python
-	venv/bin/python -m pytorch_auto_revert workflows pull.yml
+	venv/bin/python -m pytorch_auto_revert autorevert-checker Lint trunk pull inductor linux-binary-manywheel --hours 4320
 
 deployment.zip:
 	mkdir -p deployment

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
@@ -159,8 +159,14 @@ def main(*args, **kwargs) -> None:
             "ClickHouse connection test failed. Please check your configuration."
         )
 
-    if opts.subcommand == "lambda":
-        print("TODO: run lambda flow")
+    if opts.subcommand is None:
+        autorevert_checker(
+            ["Lint", "trunk", "pull", "inductor", "linux-binary-manywheel", ],
+            hours=2,
+            verbose=True,
+            do_restart=True,
+            dry_run=False,
+        )
     elif opts.subcommand == "autorevert-checker":
         autorevert_checker(
             opts.workflows,

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/testers/autorevert.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/testers/autorevert.py
@@ -108,7 +108,7 @@ def autorevert_checker(
                     "category", "uncategorized"
                 )
                 print(
-                    f"✓ REVERTED ({category}): {second_commit[:8]} was reverted by {revert_result['revert_sha'][:8]} "
+                    f"✓ REVERTED ({category}): {second_commit} was reverted by {revert_result['revert_sha'][:8]} "
                     f"after {revert_result['hours_after_target']:.1f} hours"
                 )
                 reverted_patterns.append(pattern)


### PR DESCRIPTION
After fixing the bug, the new statistics are:

```
==================================================
SUMMARY STATISTICS
==================================================
Workflow(s): Lint, trunk, pull, inductor, linux-binary-manywheel
Timeframe: 4320 hours
Commits checked: 33519
Auto revert patterns detected: 1789
Actual reverts inside auto revert patterns detected (precision): 262 (14.6%)
Total revert commits in period: 585

Revert categories:
  nosignal: 202 (34.5%)
  ghfirst: 156 (26.7%)
  uncategorized: 104 (17.8%)
  ignoredsignal: 68 (11.6%)
  weird: 45 (7.7%)
  landrace: 10 (1.7%)

Total reverts excluding ghfirst: 429
Reverts (excluding ghfirst) that dont match any auto revert pattern detected (recall): 228 (53.1%)
Per workflow precision:
  Lint: 45 reverts out of 77 patterns (58.4%) [excluding ghfirst: 41 (53.2%)]
  trunk: 36 reverts out of 153 patterns (23.5%) [excluding ghfirst: 32 (20.9%)]
  pull: 135 reverts out of 1232 patterns (11.0%) [excluding ghfirst: 112 (9.1%)]
  inductor: 45 reverts out of 314 patterns (14.3%) [excluding ghfirst: 41 (13.1%)]
  linux-binary-manywheel: 1 reverts out of 13 patterns (7.7%) [excluding ghfirst: 0 (0.0%)]
```

The main bug is that when checking for commits before/after with the same job, it actually concatenated all commits+jobs before and after, instead of only returning the next one.

I added also the ergonomics for lambda invocation