### PR TITLE
Push nightly source to dedicated branch

### DIFF
--- a/.github/actions/trigger-nightly/action.yml
+++ b/.github/actions/trigger-nightly/action.yml
@@ -37,5 +37,7 @@ runs:
         # shellcheck disable=SC1083
         NIGHTLY_RELEASE_COMMIT=$(git commit-tree -p FETCH_HEAD HEAD^{tree} -m "${NIGHTLY_DATE} nightly release (${HEAD_COMMIT_HASH})")
         # shellcheck disable=SC1083
+        git push -f origin "${HEAD_COMMIT_HASH}:nightly-source"
+        # shellcheck disable=SC1083
         git push -f origin "${NIGHTLY_RELEASE_COMMIT}:nightly"
         popd


### PR DESCRIPTION
## Summary
- track nightly builds by pushing their source commit to `nightly-source`

## Testing
- `actionlint .github/actions/trigger-nightly/action.yml` *(fails: command not found)*
- `npm install -g actionlint` *(fails: 403 Forbidden)*
- `go install github.com/rhysd/actionlint/cmd/actionlint@latest` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6893cf1948c88323adee410b9145da59