### PR TITLE
Push nightly source to dedicated branch

### DIFF
--- a/.github/actions/trigger-nightly/action.yml
+++ b/.github/actions/trigger-nightly/action.yml
@@ -37,5 +37,7 @@ runs:
         # shellcheck disable=SC1083
         NIGHTLY_RELEASE_COMMIT=$(git commit-tree -p FETCH_HEAD HEAD^{tree} -m "${NIGHTLY_DATE} nightly release (${HEAD_COMMIT_HASH})")
         # shellcheck disable=SC1083
+        git push -f origin "${HEAD_COMMIT_HASH}:nightly-source"
+        # shellcheck disable=SC1083
         git push -f origin "${NIGHTLY_RELEASE_COMMIT}:nightly"
         popd


### PR DESCRIPTION
The nightly branch is this weird disconnected branch from origin/main so it would be helpful to have a parallel branch that points to real commits.

## Summary
- track nightly builds by pushing their source commit to `nightly-source`

------
https://chatgpt.com/codex/tasks/task_e_6893cf1948c88323adee410b9145da59