### PR TITLE
[HUD][TTS] Add granularity, time, etc to permalink

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -322,7 +322,7 @@ export function TtsPercentilePicker({
           Percentile
         </InputLabel>
         <Select
-          defaultValue={ttsPercentile}
+          value={ttsPercentile}
           label="Percentile"
           labelId="tts-percentile-picker-select-label"
           onChange={handleChange}


### PR DESCRIPTION
Fixes https://github.com/pytorch/test-infra/issues/6939

Add time range, granularity, percentile to permalink (previously only had job names)

Also fixes percentile picker to use value instead of default value so the values from the router will be used?

Should have no visual changes

Is there a better way to do retrieve the router info?  This seems really annoying