### PR TITLE
Select the correct device (arch) on benchmark dashboard(s)

### DIFF
--- a/torchci/lib/benchmark/llms/utils/llmUtils.ts
+++ b/torchci/lib/benchmark/llms/utils/llmUtils.ts
@@ -67,7 +67,7 @@ export function getLLMsBenchmarkPropsQueryParameter(props: LLMsBenchmarkProps) {
   if (archName === "") {
     // All the dashboards currently put device and arch into the same field in
     // device (arch) format, i.e. cuda (NVIDIA B200). So, we need to extract
-    //extract the arch name here to use it in the query
+    // the arch name here to use it in the query
     const deviceArchRegex = new RegExp("^(?<device>.+)\\s+\\((?<arch>.+)\\)$");
     const m = deviceName.match(deviceArchRegex);
 


### PR DESCRIPTION
There is a bug when a device is select where all the different arch(s) of the same device are showing up too.  For example, selecting `cuda (NVIDIA B200)` would also query the results from `cuda (NVIDIA H100)` and `cuda (NVIDIA A100)` in addition to B200.  The problem here is that we are using a single device drop-down list to query both device and arch, and this confuses the ClickHouse queries.  The fix here is to parse the content from the device drop-down list to set the device and the arch names correctly.  This basically unravels [getDeviceArch](https://github.com/pytorch/test-infra/blob/bcc20e4fcae874ed65f8a5036ab6b8989a93aefc/torchci/components/benchmark/llms/components/LLMsSummaryPanel.tsx#L33-L40) into its components

### Testing

The current prod dashboards show all arch(s) of the same devices, for example:
* [vLLM](https://hud.pytorch.org/benchmark/llms?startTime=Tue%2C%2005%20Aug%202025%2002%3A07%3A52%20GMT&stopTime=Tue%2C%2012%20Aug%202025%2002%3A07%3A52%20GMT&granularity=day&lBranch=main&lCommit=bd3db7f46965bfc979734a6d4b50cf96184c10d8&rBranch=main&rCommit=458e74eb907f96069e6d8a4f3c9f457001fef2ea&repoName=vllm-project%2Fvllm&benchmarkName=&modelName=All%20Models&backendName=All%20Backends&modeName=All%20Modes&dtypeName=All%20DType&deviceName=cuda%20(NVIDIA%20B200)&archName=All%20Platforms) shows B200, H100, and A100
* [ExecuTorch](https://hud.pytorch.org/benchmark/llms?startTime=Tue%2C%2005%20Aug%202025%2002%3A08%3A58%20GMT&stopTime=Tue%2C%2012%20Aug%202025%2002%3A08%3A58%20GMT&granularity=day&lBranch=main&lCommit=123fe91a5bd4e582f0d660926ec9fea620f5c9c5&rBranch=main&rCommit=8e858570a2dba922142cad667f7ba84f82e2859a&repoName=pytorch%2Fexecutorch&benchmarkName=&modelName=All%20Models&backendName=All%20Backends&modeName=All%20Modes&dtypeName=All%20DType&deviceName=Apple%20iPhone%2015%20(iOS%2018.0)&archName=All%20Platforms) shows both iOS 18.0 and 18.5

The preview dashboards show only the selected device (arch), for example:
* [vLLM B200](https://torchci-git-fork-huydhn-fix-device-selection-fbopensource.vercel.app/benchmark/llms?startTime=Tue%2C%2005%20Aug%202025%2002%3A10%3A13%20GMT&stopTime=Tue%2C%2012%20Aug%202025%2002%3A10%3A13%20GMT&granularity=day&lBranch=main&lCommit=f825c6bd22133a8b2242457069f59654a2ae401b&rBranch=main&rCommit=458e74eb907f96069e6d8a4f3c9f457001fef2ea&repoName=vllm-project%2Fvllm&benchmarkName=&modelName=All%20Models&backendName=All%20Backends&modeName=All%20Modes&dtypeName=All%20DType&deviceName=cuda%20(NVIDIA%20B200)&archName=All%20Platforms)
* [ExecuTorch iOS 18.0](https://torchci-git-fork-huydhn-fix-device-selection-fbopensource.vercel.app/benchmark/llms?startTime=Tue%2C%2005%20Aug%202025%2002%3A10%3A38%20GMT&stopTime=Tue%2C%2012%20Aug%202025%2002%3A10%3A38%20GMT&granularity=day&lBranch=main&lCommit=123fe91a5bd4e582f0d660926ec9fea620f5c9c5&rBranch=main&rCommit=8e858570a2dba922142cad667f7ba84f82e2859a&repoName=pytorch%2Fexecutorch&benchmarkName=&modelName=All%20Models&backendName=All%20Backends&modeName=All%20Modes&dtypeName=All%20DType&deviceName=Apple%20iPhone%2015%20(iOS%2018.0)&archName=All%20Platforms)