### PR TITLE
Reapply "Support clang in MSVC and removal of Visual Studio 2019"

### DIFF
--- a/aws/ami/windows/scripts/Installers/Install-VS.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-VS.ps1
@@ -22,7 +22,9 @@ $VS_INSTALL_ARGS = @("--nocache","--quiet","--wait", "--add Microsoft.VisualStud
                                                      "--add Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
                                                      "--add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core",
                                                      "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
-                                                     "--add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81")
+                                                     "--add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81",
+                                                     "--add Microsoft.VisualStudio.Component.VC.Llvm.Clang",
+                                                     "--add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset")
 
 if (${env:INSTALL_WINDOWS_SDK} -eq "1") {
     $VS_INSTALL_ARGS += "--add Microsoft.VisualStudio.Component.Windows10SDK.19041"

--- a/aws/ami/windows/windows.pkr.hcl
+++ b/aws/ami/windows/windows.pkr.hcl
@@ -68,15 +68,6 @@ build {
     ]
   }
 
-  # Install the Visual Studio 2019
-  provisioner "powershell" {
-    environment_vars = ["INSTALL_WINDOWS_SDK=1", "VS_YEAR=2019", "VS_VERSION=16.11.21", "VS_UNINSTALL_PREVIOUS=1"]
-    execution_policy = "unrestricted"
-    scripts = [
-      "${path.root}/scripts/Installers/Install-VS.ps1",
-    ]
-  }
-
   # Install the Visual Studio 2022
   provisioner "powershell" {
     environment_vars = ["INSTALL_WINDOWS_SDK=1", "VS_YEAR=2022", "VS_VERSION=17.4.1", "VS_UNINSTALL_PREVIOUS=0"]


### PR DESCRIPTION
I believe we should be good to do another Windows AMI deployment. Hence proposing this PR