### PR TITLE
[autorevert] Add event logging for autorevert actions

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
@@ -101,6 +101,11 @@ def get_opts() -> argparse.Namespace:
         help="When restarts complete and secondary pattern matches, log REVERT",
     )
     workflow_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be restarted without actually doing it",
+    )
+    workflow_parser.add_argument(
         "--ignore-common-errors",
         action="store_true",
         help="Ignore common errors in autorevert patterns (e.g., 'No tests found')",
@@ -179,7 +184,7 @@ def main(*args, **kwargs) -> None:
                 "linux-binary-manywheel",
             ],
             do_restart=True,
-            do_revert=False,
+            do_revert=True,
             hours=2,
             verbose=True,
             dry_run=opts.dry_run,

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
@@ -101,11 +101,6 @@ def get_opts() -> argparse.Namespace:
         help="When restarts complete and secondary pattern matches, log REVERT",
     )
     workflow_parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Show what would be restarted without actually doing it",
-    )
-    workflow_parser.add_argument(
         "--ignore-common-errors",
         action="store_true",
         help="Ignore common errors in autorevert patterns (e.g., 'No tests found')",

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/event_logger.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/event_logger.py
@@ -1,0 +1,103 @@
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from .clickhouse_client_helper import CHCliFactory
+
+
+def log_autorevert_event(
+    *,
+    workflow: str,
+    action: str,
+    first_failing_sha: str,
+    previous_sha: str,
+    failure_rule: str,
+    job_name_base: str,
+    second_failing_sha: Optional[str] = None,
+    dry_run: bool = False,
+    notes: str = "",
+) -> None:
+    """Insert a single autorevert event row into ClickHouse.
+
+    Uses the misc.autorevert_events table. Best-effort: logs and continues on failure.
+    """
+    try:
+        client = CHCliFactory().client
+        columns = [
+            "workflow",
+            "action",
+            "first_failing_sha",
+            "previous_sha",
+            "second_failing_sha",
+            "failure_rule",
+            "job_name_base",
+            "dry_run",
+            "notes",
+        ]
+        data = [
+            [
+                workflow,
+                action,
+                first_failing_sha,
+                previous_sha,
+                second_failing_sha,
+                failure_rule,
+                job_name_base,
+                1 if dry_run else 0,
+                notes or "",
+            ]
+        ]
+        # Specify database explicitly since this table lives in 'misc'
+        client.insert(
+            table="autorevert_events",
+            data=data,
+            column_names=columns,
+            database="misc",
+        )
+    except Exception as e:
+        logging.warning(f"Failed to log autorevert event to ClickHouse: {e}")
+
+
+@dataclass
+class AutoRevertEvent:
+    workflow: str
+    first_failing_sha: str
+    previous_sha: str
+    second_failing_sha: Optional[str]
+    failure_rule: str
+    job_name_base: str
+    dry_run: bool = False
+    notes: str = ""
+
+    def send(self, action: str, notes: Optional[str] = None) -> None:
+        """Send this event with the given action; optional notes override."""
+        log_autorevert_event(
+            workflow=self.workflow,
+            action=action,
+            first_failing_sha=self.first_failing_sha,
+            previous_sha=self.previous_sha,
+            second_failing_sha=self.second_failing_sha,
+            failure_rule=self.failure_rule,
+            job_name_base=self.job_name_base,
+            dry_run=self.dry_run,
+            notes=(notes if notes is not None else self.notes),
+        )
+
+    def send_restart_outcome(
+        self, *, already_count: int, success_count: int, failure_count: int
+    ) -> None:
+        """Consolidated restart outcome sender with minimal branching."""
+        if self.dry_run or (
+            already_count > 0 and success_count == 0 and failure_count == 0
+        ):
+            self.send(
+                "restart_skipped",
+                notes=(
+                    "dry_run" if self.dry_run else f"already_restarted={already_count}"
+                ),
+            )
+            return
+
+        action = "restart_dispatched" if success_count > 0 else "restart_failed"
+        notes = f"success={success_count}, failures={failure_count}, already={already_count}"
+        self.send(action, notes=notes)

--- a/clickhouse_db_schema/misc.autorevert_events/schema.sql
+++ b/clickhouse_db_schema/misc.autorevert_events/schema.sql
@@ -1,0 +1,18 @@
+CREATE TABLE misc.autorevert_events
+(
+    `ts` DateTime DEFAULT now(),
+    `repo` LowCardinality(String) DEFAULT 'pytorch/pytorch',
+    `workflow` LowCardinality(String),
+    `action` Enum8('detected' = 1, 'restart_dispatched' = 2, 'restart_skipped' = 3, 'restart_failed' = 4, 'secondary_confirmed' = 5),
+    `first_failing_sha` FixedString(40),
+    `previous_sha` FixedString(40),
+    `second_failing_sha` Nullable(FixedString(40)) DEFAULT NULL,
+    `failure_rule` LowCardinality(String),
+    `job_name_base` String,
+    `dry_run` UInt8 DEFAULT 0,
+    `notes` String DEFAULT '',
+    `version` UInt64 MATERIALIZED toUInt64(toUnixTimestamp(ts))
+)
+    ENGINE = SharedReplacingMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}', version)
+        ORDER BY (repo, workflow, action, first_failing_sha, dry_run)
+        SETTINGS index_granularity = 8192


### PR DESCRIPTION
Core changes:

* add clickHouse event logging: log detection, restart outcomes, and secondary c
onfirmations to `misc.autorevert_events`
* define schema for `misc.autorevert_events`

Misc:
* allow `--dry-run` after the `autorevert-checker` subcommand.


# Testing

locally:
```
 python -m pytorch_auto_revert autorevert-checker inductor --hours 164 --do-restart --do-revert --dry-run
 ```
patterns were detected, events were logged