### PR TITLE
[EZ] Replace `pytorch-labs` with `meta-pytorch`

### DIFF
--- a/.github/workflows/trigger_nightly.yml
+++ b/.github/workflows/trigger_nightly.yml
@@ -117,7 +117,7 @@ jobs:
         uses: ./.github/actions/trigger-nightly
         with:
           ref: main
-          repository: pytorch-labs/torchvision-extra-decoders
+          repository: meta-pytorch/torchvision-extra-decoders
           token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
           path: torchvision-extra-decoders
       - name: Trigger nightly torchtitan

--- a/aws/lambda/README.md
+++ b/aws/lambda/README.md
@@ -61,18 +61,18 @@ Run ncipollo/release-action@v1
 Use the release name to find your release artifacts in the release page. [pytorch/test-infra/releases](https://github.com/pytorch/test-infra/releases). If you build successfully, you can find your zip file in the release Assets.
 
 ## Setup infra resources and deploy the function to cloud
-Go to [pytorch-gha-infra](https://github.com/pytorch-labs/pytorch-gha-infra)
+Go to [pytorch-gha-infra](https://github.com/meta-pytorch/pytorch-gha-infra)
 
 ### Setup Permission and Deployment for the lambda function
-   - Add your lambda function config (such as create role, func-name, and permissions), similar to [PR: set up Aws Resources for queue time histogram lambda ](https://github.com/pytorch-labs/pytorch-gha-infra/pull/647)
+   - Add your lambda function config (such as create role, func-name, and permissions), similar to [PR: set up Aws Resources for queue time histogram lambda ](https://github.com/meta-pytorch/pytorch-gha-infra/pull/647)
         -  You should only grab permission the lambda need for resource access, make sure to ask one person from pytorch dev infra team to review the permission.
-   - Update the release-tag and add your zip file name in [runners/common/Terrafile](https://github.com/pytorch-labs/pytorch-gha-infra/blob/5fde9cdadaad584de3140488adba8eb9c9fe6722/runners/common/Terrafile)
+   - Update the release-tag and add your zip file name in [runners/common/Terrafile](https://github.com/meta-pytorch/pytorch-gha-infra/blob/5fde9cdadaad584de3140488adba8eb9c9fe6722/runners/common/Terrafile)
         -  During the deploy process, the workflow will download your file based on the Terrafile.
    - If you need ClickHouse account permission, you need ask pytorch dev infra teammate to create a ClickHouse role for your lambda.
-       - Add the ClickHouse role secret to the repo secret,  `bunnylol oss pytorch-labs/pytorch-gha-infra` and update it in settings-> secrets.
+       - Add the ClickHouse role secret to the repo secret,  `bunnylol oss meta-pytorch/pytorch-gha-infra` and update it in settings-> secrets.
 
 ### Deploy the lambda
-Once the pr is submitted, go to [Runners Do Terraform Release (apply)](https://github.com/pytorch-labs/pytorch-gha-infra/actions/workflows/runners-on-dispatch-release.yml), and click Run workflow.
+Once the pr is submitted, go to [Runners Do Terraform Release (apply)](https://github.com/meta-pytorch/pytorch-gha-infra/actions/workflows/runners-on-dispatch-release.yml), and click Run workflow.
 
 
 Page maintainers: @pytorch/pytorch-dev-infra

--- a/tools/torchfix/README.md
+++ b/tools/torchfix/README.md
@@ -1,1 +1,1 @@
-TorchFix moved to a separate repo - https://github.com/pytorch-labs/torchfix
+TorchFix moved to a separate repo - https://github.com/meta-pytorch/torchfix

--- a/torchci/clickhouse_queries/queued_jobs_aggregate/query.sql
+++ b/torchci/clickhouse_queries/queued_jobs_aggregate/query.sql
@@ -50,7 +50,7 @@ queued_jobs AS (
         job.id IN (SELECT id FROM possible_queued_jobs)
         AND workflow.id IN (SELECT run_id FROM possible_queued_jobs)
         AND workflow.repository.owner.login IN (
-            'pytorch', 'pytorch-labs', 'meta-pytorch'
+            'pytorch', 'meta-pytorch', 'meta-pytorch'
         )
         AND job.status = 'queued'
         /* These two conditions are workarounds for GitHub's broken API. Sometimes */

--- a/torchci/clickhouse_queries/queued_jobs_aggregate/query.sql
+++ b/torchci/clickhouse_queries/queued_jobs_aggregate/query.sql
@@ -50,7 +50,7 @@ queued_jobs AS (
         job.id IN (SELECT id FROM possible_queued_jobs)
         AND workflow.id IN (SELECT run_id FROM possible_queued_jobs)
         AND workflow.repository.owner.login IN (
-            'pytorch', 'meta-pytorch', 'meta-pytorch'
+            'pytorch', 'pytorch-labs', 'meta-pytorch'
         )
         AND job.status = 'queued'
         /* These two conditions are workarounds for GitHub's broken API. Sometimes */


### PR DESCRIPTION
This PR replaces all instances of `pytorch-labs` with `meta-pytorch` in this repository now that the `pytorch-labs` org has been renamed to `meta-pytorch`

## Changes Made
- Replaced all occurrences of `pytorch-labs` with `meta-pytorch`
- Skipped binary files and files larger than 1MB due to GitHub api payload limits in the script to cover all repos in this org. Will do a more manual second pass later to cover any larger files

## Files Modified
This PR updates files that contained the target text.

Generated by automated script on 2025-08-12T22:48:48.097834+00:00Z