### PR TITLE
Sync buildkite builds and jobs dynamoDB tables to ClickHouse

### DIFF
--- a/aws/lambda/clickhouse-replicator-dynamo/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-dynamo/lambda_function.py
@@ -31,6 +31,9 @@ SUPPORTED_TABLES = {
     "torchci-metrics-ci-wait-time": "misc.metrics_ci_wait_time",
     "torchci-dynamo-perf-stats": "benchmark.inductor_torch_dynamo_perf_stats",
     "torchci-oss-ci-benchmark": "benchmark.oss_ci_benchmark_v2",
+    # TODO: Find a home for these tables instead of using fortesting
+    "vllm-buildkite-build-events": "fortesting.vllm_buildkite_builds",
+    "vllm-buildkite-job-events": "fortesting.vllm_buildkite_jobs",
 }
 
 


### PR DESCRIPTION
A follow-up of https://github.com/pytorch/test-infra/pull/7001 to sync these dynamoDB tables to ClickHouse, I will need to find a permanent home for these tables instead of using `fortesting`