### PR TITLE
[alerts] HUD failing job alerts handles failures that move across shards and a lot of other changes

### DIFF
--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Dependencies
-        run: pip3 install requests setuptools==61.2.0
+        run: pip3 install requests setuptools==80.9.0
       - name: Check for alerts and creates issue
         run: |
           cd tools
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Dependencies
-        run: pip3 install requests setuptools==61.2.0
+        run: pip3 install requests setuptools==80.9.0
       - name: Check for alerts and creates issue
         run: |
           cd tools

--- a/.github/workflows/check-alerts.yml
+++ b/.github/workflows/check-alerts.yml
@@ -32,7 +32,7 @@ jobs:
       JOB_NAME_REGEX: ${{ matrix.job_filter_regex }}
       # Don't do actual work on pull request
       DRY_RUN: ${{ github.event_name == 'pull_request'}}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
     steps:
@@ -51,7 +51,7 @@ jobs:
   update-queue-alert:
     env:
       DRY_RUN: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
     steps:

--- a/tools/torchci/requirements.txt
+++ b/tools/torchci/requirements.txt
@@ -1,4 +1,4 @@
-setuptools==78.1.1
+setuptools==80.9.0
 requests
 boto3==1.19.12
 pytest==7.2.0


### PR DESCRIPTION
HUD failing job alerts handles failures that move across shards and remove logic that supports features that I don't think are really used effectively

Changes
* Swap runner to 24.04 which has default python version 3.12 so I can take advantage of 3.11 features (StrEnum)
* Upgrade setuptools for 3.12?
* Alert can now track failures that jump shards
* failure -> pending -> failure is now considered a continuous failure
* Remove the flaky stuff (it wasn't doing anything I think)
* Remove tracking which sha it started it (didn't show up in the comment, only the issue body -> doesn't get sent in chat -> basically ignored)
* Remove requirement that failure captures need to be the same for a failure to be considered continuous (I think this is ok to remove because I don't think we see that many different failures close to each other, and sometimes log classifier is wrong)
* Use classes so I can group functions (pros: type checking, cons: annoying to mock, need to transform from API/hud output to classes)
* Idk what DISABLED_JOB_NAMES is for so I got rid of the test there
  * Maybe for filtering out rerun + mem leak?  But I don't see any logic for that and it's probably better off in the regex or something

Testing:
 1044  python tools/torchci/check_alerts.py --dry-run=true --branch=db32b60662b2f2bdcad980127d5dc4b66b02a7e4                                                                                                                                                      
 1045  python tools/torchci/check_alerts.py --dry-run=true --branch=ba47821f524eee50a214ed39fa2e7765d54aabf4

And check for jobs that I know to be bad on these commits 