### PR TITLE
[autorevert] fix regression

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/workflow_checker.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/workflow_checker.py
@@ -172,5 +172,6 @@ class WorkflowRestartChecker:
             logging.error(f"Error dispatching workflow {workflow_name}: {e}")
             return False
 
+    @property
     def resolver(self) -> WorkflowResolver:
         return WorkflowResolver.get(f"{self.repo_owner}/{self.repo_name}")


### PR DESCRIPTION
fixing a regression from https://github.com/pytorch/test-infra/pull/7013 

Root cause: The `@cached_property` decorator was removed from `WorkflowRestart
Checker.resolver`, but callsites still use `self.resolver.require(...)`, treatin
g it like a property.


### Testing
<details>
<summary> python -m pytorch_auto_revert</summary>

```
Fetching commits for workflow(s) 'Lint, trunk, pull, inductor' (last 16h)...

Commit data by workflow:
Fetching workflow data for 4 workflows since 2025-08-13T23:02:58.374241...
Found 38 commits with job data for workflow 'Lint'
Found 39 commits with job data for workflow 'inductor'
Found 41 commits with job data for workflow 'pull'
Found 39 commits with job data for workflow 'trunk'
  Lint: 38 commits
  trunk: 39 commits
  pull: 41 commits
  inductor: 39 commits
✓ 1 AUTOREVERT PATTERN DETECTED

Pattern #1:
Failure rule: 'Python ModuleNotFoundError'
Recent commits with failure: 7e27347f 1d80d697
Older commit without failure: b6b74aed
✓ REVERTED (nosignal): 1d80d697a269234b47ec7ede192faf3bb9b159e3 was reverted by eac2d9d6 after 5.0 hours
Failed jobs (2):
  - unit-test / cuda12.8-py3.10-gcc9-sm86 / test (inductor_cpp_wrapper, 1, 2, linux.g5.4xlarge.nvidia.gpu)
  - unit-test / cuda12.8-py3.10-gcc9-sm86 / test (inductor_cpp_wrapper, 2, 2, linux.g5.4xlarge.nvidia.gpu)
Revert message: Revert "appending the pythonpath (#160219)"

This reverts commit 1d80d697a269234b47ec7ede192faf3bb9b...

==================================================
SUMMARY STATISTICS
==================================================
Workflow(s): Lint, trunk, pull, inductor
Timeframe: 16 hours
Commits checked: 157
Auto revert patterns detected: 1
Actual reverts inside auto revert patterns detected (%): 1 (100.0%)
Total revert commits in period: 1

Revert categories:
  nosignal: 1 (100.0%)

Total reverts excluding ghfirst: 1
Reverts (excluding ghfirst) that dont match any auto revert pattern detected (%): (0) (0.0%)

*********************************************************************
STATS SUMMARY:
 PRECISION: 100.0%
 RECALL: 100.0%
 F1: 100.0%
*********************************************************************

Per workflow precision:
  inductor: 1 reverts out of 1 patterns (100.0%) [excluding ghfirst: 1 (100.0%)]

Reverted patterns:
  - Python ModuleNotFoundError: 1d80d697 (nosignal)
  ```
  </details>