### PR TITLE
Fix float16/bfloat16 mix-up on TorchInductor dashboard

### DIFF
--- a/torchci/clickhouse_queries/compilers_benchmark_performance/query.sql
+++ b/torchci/clickhouse_queries/compilers_benchmark_performance/query.sql
@@ -78,27 +78,27 @@ WHERE
         (
             ({arch: String } = '' OR {arch: String } = 'a100')
             AND output LIKE CONCAT(
-                '%_',
+                '%\_',
                 {dtype: String },
-                '_',
+                '\_',
                 {mode: String },
-                '_',
+                '\_',
                 {device: String },
-                '_%'
+                '\_%'
             )
         )
         OR (
             {arch: String } != ''
             AND output LIKE CONCAT(
-                '%_',
+                '%\_',
                 {dtype: String },
-                '_',
+                '\_',
                 {mode: String },
-                '_',
+                '\_',
                 {device: String },
-                '_',
+                '\_',
                 {arch: String },
-                '_%'
+                '\_%'
             )
         )
         OR (

--- a/torchci/clickhouse_queries/compilers_benchmark_performance_branches/query.sql
+++ b/torchci/clickhouse_queries/compilers_benchmark_performance_branches/query.sql
@@ -16,27 +16,27 @@ WHERE
         (
             ({arch: String } = '' OR {arch: String } = 'a100')
             AND benchmark_extra_info['output'] LIKE CONCAT(
-                '%_',
+                '%\_',
                 {dtype: String },
-                '_',
+                '\_',
                 {mode: String },
-                '_',
+                '\_',
                 {device: String },
-                '_performance%'
+                '\_performance%'
             )
         )
         OR (
             {arch: String } != ''
             AND benchmark_extra_info['output'] LIKE CONCAT(
-                '%_',
+                '%\_',
                 {dtype: String },
-                '_',
+                '\_',
                 {mode: String },
-                '_',
+                '\_',
                 {device: String },
-                '_',
+                '\_',
                 {arch: String },
-                '_performance%'
+                '\_performance%'
             )
         )
         OR (


### PR DESCRIPTION
TIL, these two queries has a bug in which the literal `_`, which is part of the output filename, is actually treated as a wildcard matching one alphanumeric character https://www.w3schools.com/sql/sql_like.asp.  So, a `LIKE` statement such as `%_float16` would match both `abc_float16` and `abc_bfloat16` where the `_` matched with `b`.

### Testing

Before, broken parsing in `float16` [MPS dashboard](https://hud.pytorch.org/benchmark/compilers?dashboard=torchinductor&startTime=Fri%2C%2008%20Aug%202025%2008%3A40%3A45%20GMT&stopTime=Fri%2C%2015%20Aug%202025%2008%3A40%3A45%20GMT&granularity=hour&mode=inference&dtype=float16&deviceName=mps&lBranch=main&lCommit=a7c75ae976ffd3352b68b21fe8300c393c9ea52b&rBranch=main&rCommit=3a562374401113187ce2566b87e3f1d87d7c53aa)

After, [2 inductor configs](https://torchci-git-fork-huydhn-fix-float16-bfloat16-mixup-fbopensource.vercel.app/benchmark/compilers?dashboard=torchinductor&startTime=Fri%2C%2008%20Aug%202025%2008%3A39%3A00%20GMT&stopTime=Fri%2C%2015%20Aug%202025%2008%3A39%3A00%20GMT&granularity=hour&mode=inference&dtype=float16&deviceName=mps&lBranch=main&lCommit=a7c75ae976ffd3352b68b21fe8300c393c9ea52b&rBranch=main&rCommit=3a562374401113187ce2566b87e3f1d87d7c53aa) are showing up correctly