### PR TITLE
Clean up the unused sync from DynamoDB to benchmark.oss_ci_benchmark_v2

### DIFF
--- a/aws/lambda/clickhouse-replicator-dynamo/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-dynamo/lambda_function.py
@@ -176,7 +176,7 @@ def get_doc_for_upsert(record: Any) -> Optional[Tuple[str, str, Any]]:
         body = handle_workflow_job(body)
 
     id = extract_dynamodb_key(record)
-    print(f"Parsing {id}")
+    print(f"Parsing {id}: {json.dumps(body)}")
     if not id:
         return
     return table, id, body


### PR DESCRIPTION
This route is not used anymore, and always fails.  I will need to clean up the write into dynamoDB in another PR and the dynamoDB table `torchci-oss-ci-benchmark` itself later.

```
UPSERTING 3 INTO benchmark.oss_ci_benchmark_v2
--
/var/task/lambda_function.py:206: UserWarning: Failed to upsert 3 into benchmark.oss_ci_benchmark_v2: HTTPDriver for https://hyt81izu0c.us-east-1.aws.clickhouse.cloud:8443 received ClickHouse error code 60
Code: 60. DB::Exception: Table benchmark.oss_ci_benchmark_v2 does not exist. Maybe you meant benchmark.oss_ci_benchmark_v3?. (UNKNOWN_TABLE) (version 25.4.1.37615 (official build))
warn(f"Failed to upsert {len(documents)} into {table}: {error}")
[ERROR] DatabaseError: HTTPDriver for https://hyt81izu0c.us-east-1.aws.clickhouse.cloud:8443 received ClickHouse error code 60 Code: 60. DB::Exception: Table benchmark.oss_ci_benchmark_v2 does not exist. Maybe you meant benchmark.oss_ci_benchmark_v3?. (UNKNOWN_TABLE) (version 25.4.1.37615 (official build))Traceback (most recent call last):  File "/var/task/lambda_function.py", line 58, in lambda_handler    handle_event(event, False)  File "/var/task/lambda_function.py", line 83, in handle_event    upsert_documents(table, ids_and_docs, dry_run)  File "/var/task/lambda_function.py", line 219, in upsert_documents    raise error  File "/var/task/lambda_function.py", line 203, in upsert_documents    res = get_clickhouse_client().query(query)  File "/var/task/clickhouse_connect/driver/client.py", line 228, in query    return self._query_with_context(query_context)  File "/var/task/clickhouse_connect/driver/httpclient.py", line 239, in _query_with_context    response = self._raw_request(body,  File "/var/task/clickhouse_connect/driver/httpclient.py", line 472, in _raw_request    self._error_handler(response)  File "/var/task/clickhouse_connect/driver/httpclient.py", line 395, in _error_handler    raise OperationalError(err_str) if retried else DatabaseError(err_str) from None
```

The error dropped to 0 after I removed this line:

<img width="507" height="276" alt="Screenshot 2025-08-15 at 18 30 13" src="https://github.com/user-attachments/assets/50198cf3-65f4-41fa-9a36-8ffba63514d8" />

~~Also remove the print `json.dumps(body)` part because it's writing too much information into the log.  We needed it at the start to debug issue, but it's too verbose now.  We can remove the whole print statement now if no one really looks into it. @clee2000 Your thoughts on this?~~ I'll do this in a separate PR to improve the logging mechanism here instead of using poor man `print`
