### PR TITLE
[autorevert] When checking job status, only expect target job list to be finished, not waiting for all jobs to have finished

### DIFF
--- a/aws/lambda/pytorch-auto-revert/Makefile
+++ b/aws/lambda/pytorch-auto-revert/Makefile
@@ -27,7 +27,7 @@ run-local-dry: venv/bin/python
 
 .PHONY: run-local-workflows
 run-local-workflows: venv/bin/python
-	venv/bin/python -m pytorch_auto_revert autorevert-checker Lint trunk pull inductor linux-binary-manywheel --hours 4380 --ignore-common-errors
+	venv/bin/python -m pytorch_auto_revert autorevert-checker Lint trunk pull inductor linux-binary-manywheel --hours 4380 --ignore-common-errors --verbose
 
 deployment.zip:
 	mkdir -p deployment

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_checker.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_checker.py
@@ -512,10 +512,6 @@ class AutorevertPatternChecker:
         if not failing_jobs or not prev_jobs:
             return False
 
-        # Pending check
-        if failing_jobs.has_pending_jobs or prev_jobs.has_pending_jobs:
-            return False
-
         def has_rule(cj: CommitJobs, rule: str) -> bool:
             return any(
                 cj.normalize_job_name(j.name) == job_base

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_checker.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_checker.py
@@ -507,9 +507,11 @@ class AutorevertPatternChecker:
 
         # Fetch restarted jobs for first failing and previous commits
         failing_commit_jobs = self._fetch_single_commit_jobs(
-                workflow_name, first_failing, restarted_only=True)
+            workflow_name, first_failing, restarted_only=True
+        )
         prev_commit_jobs = self._fetch_single_commit_jobs(
-                workflow_name, previous_commit, restarted_only=True)
+            workflow_name, previous_commit, restarted_only=True
+        )
         if not failing_commit_jobs or not prev_commit_jobs:
             return False
 

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_checker.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_checker.py
@@ -340,8 +340,8 @@ class AutorevertPatternChecker:
                     # No older commit with same normalized job name found
                     continue
 
-                # Ensure the oldest commit has stable signal (no running jobs)
-                if last_commit_with_same_job.has_pending_jobs:
+                # Ensure the oldest commit has stable signal for the jobs we care about (no running jobs)
+                if any(j.status != "completed" for j in last_same_jobs):
                     continue
 
                 if any(

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_checker.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_checker.py
@@ -523,8 +523,7 @@ class AutorevertPatternChecker:
 
         def has_rule(cj: CommitJobs, rule: str) -> bool:
             return any(
-                j.classification_rule == rule
-                and j.conclusion == "failure"
+                j.classification_rule == rule and j.conclusion == "failure"
                 for j in cj.jobs
             )
 


### PR DESCRIPTION
There are some pending jobs checks that are overly cautious and could be problematic in case of queuing of some exotic type of runner. This can hold autorevert hostage if there is a long queue or an outage in some type of runner that is unrelated to the patterns we're looking for.

## Older commits (baseline)

When checking for patterns, we don't really care if there are pending jobs for the older commit, as long it is unrelated to the identified pattern.

## Repeated error identification

Already correctly handled, it should retry jobs at first opportunity of a single repeated breaking job.

## `confirm_commit_caused_failure_on_restarted`

`has_rule` already checks for failure conclusion. So it is more correct ignore if jobs are still pending and match in the first confirmation. But it is important to only check for the relevant job names if they finished in base, as any newly job could finish as failure, what should avoid reverting.