### PR TITLE
[BE] Cleanup the old torchao benchmark dashboard from TorchBench

### DIFF
--- a/torchci/components/layout/NavBar.tsx
+++ b/torchci/components/layout/NavBar.tsx
@@ -91,10 +91,6 @@ function NavBar() {
       href: "/benchmark/compilers",
     },
     {
-      name: "TorchAO",
-      href: "/benchmark/torchao",
-    },
-    {
       name: "Triton",
       href: "/tritonbench/commit_view",
     },
@@ -107,7 +103,7 @@ function NavBar() {
       href: "/benchmark/llms?repoName=pytorch%2Fexecutorch",
     },
     {
-      name: "TorchAO LLMs",
+      name: "TorchAO",
       href: "/benchmark/llms?repoName=pytorch%2Fao",
     },
     {


### PR DESCRIPTION
This is definitely not coming back.  We can reuse the name of TorchAO dashboard on the benchmark running on torchao itself.  Removing the old dashboard from HUD navigation bar is a good start, and there are more things to clean up here which I will follow later in a separate PR.