### PR TITLE
[HUD][Test Insights] Better PR view for test counts

### DIFF
--- a/torchci/clickhouse_queries/merge_bases/params.json
+++ b/torchci/clickhouse_queries/merge_bases/params.json
@@ -1,0 +1,7 @@
+{
+  "params": {
+    "shas": "Array(String)",
+    "repo": "String"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/merge_bases/query.sql
+++ b/torchci/clickhouse_queries/merge_bases/query.sql
@@ -1,0 +1,10 @@
+select
+    sha as head_sha,
+    merge_base,
+    merge_base_commit_date,
+from
+    merge_bases
+where
+    sha in {shas: Array(String)}
+    and merge_base_commit_date != 0
+    and repo = {repo: String}

--- a/torchci/components/additionalTestInfo/TestCounts.tsx
+++ b/torchci/components/additionalTestInfo/TestCounts.tsx
@@ -392,7 +392,6 @@ export function TestCountsInfo({
     if (comparisonSha === undefined && mergeBase) {
       setComparisonSha(mergeBase[0]?.merge_base);
     }
-    console.log(comparisonSha);
   }, [mergeBase, comparisonSha]);
 
   const { data: comparisonId, error: comparisonIdError } = useSWR(

--- a/torchci/lib/GeneralUtils.ts
+++ b/torchci/lib/GeneralUtils.ts
@@ -152,7 +152,7 @@ export function useClickHouseAPI<T = any>(
  */
 export function useClickHouseAPIImmutable<T = any>(
   queryName: string,
-  parameters: { [key: string]: string },
+  parameters: { [key: string]: any },
   condition: boolean = true
 ) {
   // Helper function to format the URL nicely

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -2,7 +2,7 @@ import { PutObjectCommand } from "@aws-sdk/client-s3";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { fetchJSON, isTime0 } from "lib/bot/utils";
-import { queryClickhouse } from "lib/clickhouse";
+import { queryClickhouse, queryClickhouseSaved } from "lib/clickhouse";
 import {
   CANCELLED_STEP_ERROR,
   fetchPRLabels,
@@ -354,23 +354,11 @@ async function addMergeBaseCommits(
   head: string,
   workflowsByPR: Map<number, PRandJobs>
 ) {
-  const mergeBasesQuery = `
-select
-    sha as head_sha,
-    merge_base,
-    merge_base_commit_date,
-from
-    merge_bases
-where
-    sha in {shas: Array(String)}
-    and merge_base_commit_date != 0
-    and repo = {repo: String}
-  `;
   const s3client = getS3Client();
 
   const chMergeBases = new Map(
     (
-      await queryClickhouse(mergeBasesQuery, {
+      await queryClickhouseSaved("merge_bases", {
         shas: Array.from(workflowsByPR.values()).map((v) => v.head_sha),
         repo: `${OWNER}/${repo}`,
       })


### PR DESCRIPTION
* Change UI to get rid of nesting structure in favor of one big table. This might make it harder to determine which file caused the overall change in test times?  
* Automatically select a sha to do base comparison with
  * Move merge base query that was originally in Dr. CI to named query

Some of the code in this PR isn't directly used here but will be used in a different PR


https://torchci-git-csl-tibettertestcountsprview-fbopensource.vercel.app/pytorch/pytorch/commit/72e4786d1635681b8d053d0168c7d16b980e5124

Old
<img width="1679" height="520" alt="image" src="https://github.com/user-attachments/assets/477b3023-abac-4c3d-a57b-500587e2d37c" />

New
<img width="1675" height="571" alt="image" src="https://github.com/user-attachments/assets/2c3a3e55-f03d-4bec-a520-fa113d1e5a2c" />
