### PR TITLE
[autorevert] refactoring: extract Signal, decouple pattern detection

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -1,0 +1,291 @@
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional, Set, Union
+
+
+class SignalStatus(Enum):
+    """signal status enum"""
+
+    PENDING = "pending"
+    SUCCESS = "success"
+    FAILURE = "failure"
+
+
+# data classes:
+
+
+@dataclass
+class AutorevertPattern:
+    """
+    Represents an autorevert pattern detected in a signal.
+    """
+
+    pattern_detected: bool
+    workflow_name: str
+    newer_commits: List[str]
+    older_commit: str
+    # failed_job_names: List[str]  # TODO: Uncomment when needed
+    # failure_rule: str              # TODO: Uncomment when needed
+    # job_name_base: str             # TODO: Uncomment when needed
+
+
+@dataclass
+class RestartCommits:
+    """
+    Represents an intent to restart a specific set of commits on the signal.
+    """
+
+    commit_shas: Set[str]
+
+
+class SignalEvent:
+    """A single observation contributing to a Signal on a given commit.
+
+    Represents one job/test/classification-derived event with a status and
+    start/end timestamps used to reason about ordering and patterns.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        status: SignalStatus,
+        started_at: datetime,
+        ended_at: Optional[datetime] = None,
+    ):
+        self.name = name
+        self.status = status
+        self.started_at = started_at
+        self.ended_at = ended_at
+
+    @property
+    def is_pending(self) -> bool:
+        return self.status == SignalStatus.PENDING
+
+    @property
+    def is_success(self) -> bool:
+        return self.status == SignalStatus.SUCCESS
+
+    @property
+    def is_failure(self) -> bool:
+        return self.status == SignalStatus.FAILURE
+
+
+class SignalCommit:
+    """All events for a single commit, ordered oldest → newest by start time."""
+
+    def __init__(self, head_sha: str, events: List[SignalEvent]):
+        self.head_sha = head_sha
+        # enforce events ordered by time, oldest first
+        self.events = sorted(events, key=lambda e: e.started_at) if events else []
+
+    def events_by_status(self, status: SignalStatus) -> List[SignalEvent]:
+        """Get all events with the specified status."""
+        return [event for event in self.events if event.status == status]
+
+    # make iterable
+    def __iter__(self):
+        return iter(self.events)
+
+
+class Signal:
+    """A refined, column-like view of raw CI data for pattern detection.
+
+    - key: stable identifier for the signal (e.g., normalized job/test name)
+    - workflow_name: source workflow this signal is derived from
+    - commits: newest → older list of SignalCommit objects for this signal
+    """
+
+    def __init__(self, key: str, workflow_name: str, commits: List[SignalCommit]):
+        self.key = key
+        self.workflow_name = workflow_name
+        # commits are ordered from newest to oldest
+        self.commits = commits
+
+    def detect_recovered(self) -> bool:
+        """
+        Find the first commit with any non‑pending event; if it contains a success, consider the signal recovered.
+        """
+        # find the first non-pending existing commit in the signal
+        for commit in self.commits:
+            if not all(event.is_pending for event in commit):
+                # If we found a commit with no pending jobs, check if it has any failed jobs
+                return any(event.is_success for event in commit)  # recovered
+        return False
+
+    def detect_flaky(self) -> bool:
+        """
+        Checks whether signal is flaky, i.e. has both successful and failed events for any commit.
+        Note: false result can mean that there is not enough data to determine flakiness.
+        """
+        for commit in self.commits:
+            if any(event.is_success for event in commit) and any(
+                event.is_failure for event in commit
+            ):
+                return True
+        return False
+
+    def confirm_not_an_infra_issue(self) -> Optional[bool]:
+        """
+        Considers pairs of commits: an older one with two successful jobs, and a newer one (not necessarily an immediate successor) with a failure.
+        Checks if there is a "sandwich" pattern where:
+        - The failure of the newer commit is between two successes of the older commit (time-wise).
+
+        The goal of this it to eliminate the possibility of transient infra issue.
+
+        Note: in the real world this relies on the previously checked invariants:
+            * no flakiness - older commit will not have failures if it has successful job
+            * not recovered - there is a newer commit with failure that is followed by an older commit with at least one success
+
+        Returns:
+            True if such a pattern exists, meaning the failure is likely **not** an infra issue (previously successful signal stays stable),
+            False means no bracketing successes were observed; we can’t rule out infra, so prefer restarts (i.e. "not enough data", given "no flakiness" invariant is true).
+            None is "Maybe", meaning the result depends on the resolution of the existing pending job.
+        """
+        if len(self.commits) < 2:
+            return False
+
+        maybe = False
+
+        # Iterate through commits, looking for a newer commit with failure
+        for i in range(0, len(self.commits) - 1):
+            nc = self.commits[i]
+
+            # Check all older commits before this one
+            for j in range(i + 1, len(self.commits)):
+                oc = self.commits[j]
+                # Check if this older commit has two successful jobs
+                oc_successes = oc.events_by_status(SignalStatus.SUCCESS)
+                oc_pending = oc.events_by_status(SignalStatus.PENDING)
+
+                if len(oc_successes) >= 2:
+                    # Check if the failure of the newer commit is between the two successes of the older commit
+                    # Events are ordered by time within each commit, oldest events first
+                    for e in nc.events:
+                        if (
+                            oc_successes[0].started_at
+                            < e.started_at
+                            < oc_successes[-1].started_at
+                        ):
+                            if e.is_failure:
+                                # We have a sandwich pattern
+                                return True
+                            elif e.is_pending:
+                                # We have a pending job, possible pattern, cannot confirm yet
+                                maybe = True
+
+                elif (
+                    len(oc_successes) == 1
+                    and len(oc_pending) > 1
+                    and oc_successes[0].started_at < oc_pending[-1].started_at
+                ):
+                    # If there is only one success and multiple pending jobs, we cannot confirm the sandwich
+                    if any(
+                        oc_successes[0].started_at
+                        < e.started_at
+                        < oc_pending[-1].started_at
+                        and (e.is_failure or e.is_pending)
+                        for e in nc.events
+                    ):
+                        maybe = True
+
+        return None if maybe else False
+
+    def has_loose_autorevert_pattern(self) -> bool:
+        """
+        Checks if there is subsequence of commits, where:
+        - there are two commits with a failure (not necessarily consecutive)
+        - there is at least one older commit with a success (not necessarily immediate predecessor)
+        :return:
+            True if such a pattern exists, False otherwise.
+        """
+        if len(self.commits) < 3:
+            return False
+
+        # Check for two newer commits with failure and one older commit with success
+        found_failures = 0
+        for c in self.commits:
+            if c.events_by_status(SignalStatus.FAILURE):
+                found_failures += 1
+            elif c.events_by_status(SignalStatus.SUCCESS):
+                if found_failures >= 2:
+                    return True
+                else:
+                    # potentially recovered Signal + one flake, not enough confidence
+                    return False
+
+        return False
+
+    def detect_autorevert_pattern(self) -> Optional[AutorevertPattern]:
+        """
+        Detect first autorevert pattern in the Signal.
+
+        Pattern: 3 consecutive commits where:
+        - 2 newer commits have failure
+        - 1 older commit doesn't have this failure
+
+        Note:
+            in real world relies on the previously checked invariants, such as:
+            no flakiness, no infra issues, etc.
+
+        Returns:
+            First detected autorevert pattern if exists, None otherwise.
+        """
+        # Commits are ordered newest -> older
+        if len(self.commits) < 3:
+            return None
+
+        for i in range(1, len(self.commits) - 1):
+            suspected_commit1 = self.commits[i]
+            newer_commit = self.commits[i - 1]
+            successful_base_commit = self.commits[i + 1]
+
+            if (
+                newer_commit.events_by_status(SignalStatus.FAILURE)
+                and suspected_commit1.events_by_status(SignalStatus.FAILURE)
+                and successful_base_commit.events_by_status(SignalStatus.SUCCESS)
+            ):
+                return AutorevertPattern(
+                    pattern_detected=True,
+                    workflow_name=self.workflow_name,
+                    newer_commits=[
+                        newer_commit.head_sha,
+                        suspected_commit1.head_sha,
+                    ],
+                    older_commit=successful_base_commit.head_sha,
+                )
+
+        return None
+
+    def process_valid_autorevert_pattern(
+        self,
+    ) -> Optional[Union[AutorevertPattern, RestartCommits]]:
+        """
+        Detect valid autorevert pattern in the Signal.
+
+        Validates all invariants before checking for the pattern.
+
+        Returns:
+            AutorevertPattern if a valid pattern is detected, None if no pattern is detected,
+            or RestartCommit if the pattern is not confirmed but a restart is needed.
+        """
+        if (
+            self.detect_flaky()
+            or self.detect_recovered()
+            or not self.has_loose_autorevert_pattern()
+        ):
+            return None
+
+        infra_failure = self.confirm_not_an_infra_issue()
+        if infra_failure is None:
+            # If we have pending jobs, we cannot confirm the pattern yet
+            return None
+
+        if not infra_failure:
+            # not enough data to confirm the pattern, need to issue restarts
+            # TODO find a commit to restart
+            pass
+
+        # TODO close the gaps in the signal (find commits to restart)
+
+        return self.detect_autorevert_pattern()

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -159,9 +159,10 @@ class Signal:
         """
         # find the first non-pending existing commit in the signal
         for commit in self.commits:
-            if not all(event.is_pending for event in commit):
-                # If we found a commit with no pending jobs, check if it has any failed jobs
-                return any(event.is_success for event in commit)  # recovered
+            # not all events are pending
+            if commit.has_success or commit.has_failure:
+                # If we found a commit that has resolved jobs, check if it has failed jobs
+                return commit.has_success  # recovered
         return False
 
     def detect_flaky(self) -> bool:

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -212,9 +212,7 @@ class Signal:
         """
         Checks if there is at least one successful event in the signal.
         """
-        return any(
-            commit.events_by_status(SignalStatus.SUCCESS) for commit in self.commits
-        )
+        return any(commit.has_success for commit in self.commits)
 
     def detect_autorevert_pattern(self) -> Optional[AutorevertPattern]:
         """
@@ -241,9 +239,9 @@ class Signal:
             successful_base_commit = self.commits[i + 1]
 
             if (
-                newer_commit.events_by_status(SignalStatus.FAILURE)
-                and suspected_commit1.events_by_status(SignalStatus.FAILURE)
-                and successful_base_commit.events_by_status(SignalStatus.SUCCESS)
+                newer_commit.has_failure
+                and suspected_commit1.has_failure
+                and successful_base_commit.has_success
             ):
                 return AutorevertPattern(
                     pattern_detected=True,

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -267,11 +267,7 @@ class Signal:
             AutorevertPattern if a valid pattern is detected, None if no pattern is detected,
             or RestartCommit if the pattern is not confirmed but a restart is needed.
         """
-        if (
-            self.detect_flaky()
-            or self.detect_fixed()
-            or not self.has_successes()
-        ):
+        if self.detect_flaky() or self.detect_fixed() or not self.has_successes():
             return None
 
         infra_failure = self.confirm_not_an_infra_issue()

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
@@ -1,0 +1,282 @@
+import unittest
+from datetime import datetime, timedelta
+
+from pytorch_auto_revert.signal import Signal, SignalCommit, SignalEvent, SignalStatus
+
+
+def ts(base: datetime, minutes: int) -> datetime:
+    return base + timedelta(minutes=minutes)
+
+
+class TestSignal(unittest.TestCase):
+    def setUp(self) -> None:
+        self.t0 = datetime(2025, 8, 19, 12, 0, 0)
+
+    def _ev(self, name: str, status: SignalStatus, minute: int) -> SignalEvent:
+        return SignalEvent(name=name, status=status, started_at=ts(self.t0, minute))
+
+    def test_detect_recovered_first_non_pending_success(self):
+        # Newest commit has success (even with pending present) -> recovered
+        c_new = SignalCommit(
+            head_sha="new",
+            events=[
+                self._ev("job", SignalStatus.PENDING, 1),
+                self._ev("job", SignalStatus.SUCCESS, 2),
+            ],
+        )
+        c_old = SignalCommit(
+            head_sha="old",
+            events=[self._ev("job", SignalStatus.FAILURE, 1)],
+        )
+        s = Signal(key="job", workflow_name="wf", commits=[c_new, c_old])
+        self.assertTrue(s.detect_recovered())
+
+    def test_detect_recovered_false_when_first_non_pending_failure(self):
+        # Newest commit only has failure (no success)
+        c_new = SignalCommit(
+            head_sha="new",
+            events=[self._ev("job", SignalStatus.FAILURE, 1)],
+        )
+        c_old = SignalCommit(
+            head_sha="old",
+            events=[self._ev("job", SignalStatus.SUCCESS, 1)],
+        )
+        s = Signal(key="job", workflow_name="wf", commits=[c_new, c_old])
+        self.assertFalse(s.detect_recovered())
+
+    def test_detect_recovered_skips_all_pending_then_success(self):
+        # First commit is all pending; next has success -> recovered
+        c_new = SignalCommit(
+            head_sha="new",
+            events=[self._ev("job", SignalStatus.PENDING, 1)],
+        )
+        c_mid = SignalCommit(
+            head_sha="mid",
+            events=[self._ev("job", SignalStatus.SUCCESS, 1)],
+        )
+        s = Signal(key="job", workflow_name="wf", commits=[c_new, c_mid])
+        self.assertTrue(s.detect_recovered())
+
+    def test_detect_flaky_true_on_same_commit_success_and_failure(self):
+        c = SignalCommit(
+            head_sha="sha",
+            events=[
+                self._ev("job", SignalStatus.SUCCESS, 1),
+                self._ev("job", SignalStatus.FAILURE, 2),
+            ],
+        )
+        s = Signal(key="job", workflow_name="wf", commits=[c])
+        self.assertTrue(s.detect_flaky())
+
+    def test_detect_flaky_false_when_separate_commits(self):
+        c_new = SignalCommit(
+            head_sha="new",
+            events=[self._ev("job", SignalStatus.SUCCESS, 1)],
+        )
+        c_old = SignalCommit(
+            head_sha="old",
+            events=[self._ev("job", SignalStatus.FAILURE, 1)],
+        )
+        s = Signal(key="job", workflow_name="wf", commits=[c_new, c_old])
+        self.assertFalse(s.detect_flaky())
+
+    def test_confirm_not_an_infra_issue_true_on_sandwich(self):
+        # Older commit has two successes at t=10 and t=30
+        # Newer commit has a failure at t=20 (between) -> True
+        c_new = SignalCommit(
+            head_sha="new",
+            events=[self._ev("job", SignalStatus.FAILURE, 20)],
+        )
+        c_old = SignalCommit(
+            head_sha="old",
+            events=[
+                self._ev("job", SignalStatus.SUCCESS, 10),
+                self._ev("job", SignalStatus.SUCCESS, 30),
+            ],
+        )
+        s = Signal(key="job", workflow_name="wf", commits=[c_new, c_old])
+        self.assertIs(s.confirm_not_an_infra_issue(), True)
+
+    def test_confirm_not_an_infra_issue_none_with_pending_between(self):
+        # Older has two successes; newer has pending between -> Maybe (None)
+        c_new = SignalCommit(
+            head_sha="new",
+            events=[self._ev("job", SignalStatus.PENDING, 20)],
+        )
+        c_old = SignalCommit(
+            head_sha="old",
+            events=[
+                self._ev("job", SignalStatus.SUCCESS, 10),
+                self._ev("job", SignalStatus.SUCCESS, 30),
+            ],
+        )
+        s = Signal(key="job", workflow_name="wf", commits=[c_new, c_old])
+        self.assertIsNone(s.confirm_not_an_infra_issue())
+
+    def test_confirm_not_an_infra_issue_false_when_pending_outside_window(self):
+        # Older has two successes; newer has pending outside the [oldest, newest] success window -> False
+        c_new = SignalCommit(
+            head_sha="new",
+            events=[self._ev("job", SignalStatus.PENDING, 35)],
+        )
+        c_old = SignalCommit(
+            head_sha="old",
+            events=[
+                self._ev("job", SignalStatus.SUCCESS, 10),
+                self._ev("job", SignalStatus.SUCCESS, 30),
+            ],
+        )
+        s = Signal(key="job", workflow_name="wf", commits=[c_new, c_old])
+        self.assertIs(s.confirm_not_an_infra_issue(), False)
+
+    def test_confirm_not_an_infra_issue_false_no_bracketing_success(self):
+        # Older has one success (t=10) and then pending to t=30; newer failure at t=40
+        # Not within bracketing window -> False (and no maybe)
+        c_new = SignalCommit(
+            head_sha="new",
+            events=[self._ev("job", SignalStatus.FAILURE, 40)],
+        )
+        c_old = SignalCommit(
+            head_sha="old",
+            events=[
+                self._ev("job", SignalStatus.SUCCESS, 10),
+                self._ev("job", SignalStatus.PENDING, 20),
+                self._ev("job", SignalStatus.PENDING, 30),
+            ],
+        )
+        s = Signal(key="job", workflow_name="wf", commits=[c_new, c_old])
+        self.assertIs(s.confirm_not_an_infra_issue(), False)
+
+    def test_detect_autorevert_pattern_basic(self):
+        # Commits newest -> older
+        c_newer = SignalCommit(
+            head_sha="sha_newer",
+            events=[self._ev("job", SignalStatus.FAILURE, 5)],
+        )
+        c_suspected = SignalCommit(
+            head_sha="sha_mid",
+            events=[self._ev("job", SignalStatus.FAILURE, 4)],
+        )
+        c_base = SignalCommit(
+            head_sha="sha_old",
+            events=[self._ev("job", SignalStatus.SUCCESS, 3)],
+        )
+        s = Signal(
+            key="job", workflow_name="wf", commits=[c_newer, c_suspected, c_base]
+        )
+        pat = s.detect_autorevert_pattern()
+        self.assertIsNotNone(pat)
+        self.assertEqual(pat.workflow_name, "wf")
+        self.assertEqual(pat.newer_commits, ["sha_newer", "sha_mid"])
+        self.assertEqual(pat.older_commit, "sha_old")
+
+    def test_detect_autorevert_pattern_none_when_missing_failure(self):
+        c_newer = SignalCommit(
+            head_sha="sha_newer",
+            events=[self._ev("job", SignalStatus.SUCCESS, 5)],
+        )
+        c_suspected = SignalCommit(
+            head_sha="sha_mid",
+            events=[self._ev("job", SignalStatus.FAILURE, 4)],
+        )
+        c_base = SignalCommit(
+            head_sha="sha_old",
+            events=[self._ev("job", SignalStatus.SUCCESS, 3)],
+        )
+        s = Signal(
+            key="job", workflow_name="wf", commits=[c_newer, c_suspected, c_base]
+        )
+        self.assertIsNone(s.detect_autorevert_pattern())
+
+    def test_has_loose_autorevert_pattern_true(self):
+        # Order newest -> older; two failures first, then a success older
+        c1 = SignalCommit(
+            head_sha="sha1",
+            events=[self._ev("job", SignalStatus.FAILURE, 5)],
+        )
+        c2 = SignalCommit(
+            head_sha="sha2",
+            events=[self._ev("job", SignalStatus.FAILURE, 4)],
+        )
+        c3 = SignalCommit(
+            head_sha="sha3",
+            events=[self._ev("job", SignalStatus.SUCCESS, 3)],
+        )
+        s = Signal(key="job", workflow_name="wf", commits=[c1, c2, c3])
+        self.assertTrue(s.has_loose_autorevert_pattern())
+
+    def test_has_loose_autorevert_pattern_false_when_success_before_two_failures(self):
+        # Success encountered before counting 2 failures (in newest->older order)
+        c1 = SignalCommit(
+            head_sha="sha1",
+            events=[self._ev("job", SignalStatus.FAILURE, 5)],
+        )
+        c2 = SignalCommit(
+            head_sha="sha2",
+            events=[self._ev("job", SignalStatus.SUCCESS, 4)],
+        )
+        c3 = SignalCommit(
+            head_sha="sha3",
+            events=[self._ev("job", SignalStatus.FAILURE, 3)],
+        )
+        s = Signal(key="job", workflow_name="wf", commits=[c1, c2, c3])
+        self.assertFalse(s.has_loose_autorevert_pattern())
+
+    def test_has_loose_autorevert_pattern_false_when_only_one_failure(self):
+        c1 = SignalCommit(
+            head_sha="sha1",
+            events=[self._ev("job", SignalStatus.FAILURE, 5)],
+        )
+        c2 = SignalCommit(
+            head_sha="sha2",
+            events=[self._ev("job", SignalStatus.SUCCESS, 4)],
+        )
+        c3 = SignalCommit(
+            head_sha="sha3",
+            events=[self._ev("job", SignalStatus.SUCCESS, 3)],
+        )
+        s = Signal(key="job", workflow_name="wf", commits=[c1, c2, c3])
+        self.assertFalse(s.has_loose_autorevert_pattern())
+
+    def test_has_loose_autorevert_pattern_ignores_pending_only_commits(self):
+        # Newest->older: failure, pending-only, failure, success(older) => True
+        c1 = SignalCommit(
+            head_sha="sha1",
+            events=[self._ev("job", SignalStatus.FAILURE, 6)],
+        )
+        c2 = SignalCommit(
+            head_sha="sha2",
+            events=[self._ev("job", SignalStatus.PENDING, 5)],
+        )
+        c3 = SignalCommit(
+            head_sha="sha3",
+            events=[self._ev("job", SignalStatus.FAILURE, 4)],
+        )
+        c4 = SignalCommit(
+            head_sha="sha4",
+            events=[self._ev("job", SignalStatus.SUCCESS, 3)],
+        )
+        s = Signal(key="job", workflow_name="wf", commits=[c1, c2, c3, c4])
+        self.assertTrue(s.has_loose_autorevert_pattern())
+
+    def test_has_loose_autorevert_pattern_ignores_empty_event_commits(self):
+        # Newest->older: failure, <empty>, failure, success(older) => True
+        c1 = SignalCommit(
+            head_sha="sha1",
+            events=[self._ev("job", SignalStatus.FAILURE, 6)],
+        )
+        c2 = SignalCommit(head_sha="sha_empty", events=[])
+        c3 = SignalCommit(
+            head_sha="sha3",
+            events=[self._ev("job", SignalStatus.FAILURE, 4)],
+        )
+        c4 = SignalCommit(
+            head_sha="sha4",
+            events=[self._ev("job", SignalStatus.SUCCESS, 3)],
+        )
+        s = Signal(key="job", workflow_name="wf", commits=[c1, c2, c3, c4])
+        self.assertTrue(s.has_loose_autorevert_pattern())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
@@ -188,5 +188,6 @@ class TestSignal(unittest.TestCase):
         )
         self.assertIsNone(s.detect_autorevert_pattern())
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
@@ -102,10 +102,9 @@ class TestSignal(unittest.TestCase):
                 self._ev("job", SignalStatus.SUCCESS, 30),
             ],
         )
-        s = Signal(key="job", workflow_name="wf", commits=[c_new, c_old])
         partition = PartitionedCommits(failed=[c_new], unknown=[], successful=[c_old])
         self.assertEqual(
-            s.confirm_not_an_infra_issue(partition), InfraCheckResult.CONFIRMED
+            partition.confirm_not_an_infra_issue(), InfraCheckResult.CONFIRMED
         )
 
     def test_confirm_not_an_infra_issue_none_with_pending_between(self):
@@ -121,10 +120,9 @@ class TestSignal(unittest.TestCase):
                 self._ev("job", SignalStatus.SUCCESS, 30),
             ],
         )
-        s = Signal(key="job", workflow_name="wf", commits=[c_new, c_old])
         partition = PartitionedCommits(failed=[c_new], unknown=[], successful=[c_old])
         self.assertEqual(
-            s.confirm_not_an_infra_issue(partition), InfraCheckResult.PENDING
+            partition.confirm_not_an_infra_issue(), InfraCheckResult.PENDING
         )
 
     def test_confirm_not_an_infra_issue_false_when_pending_outside_window(self):
@@ -140,10 +138,9 @@ class TestSignal(unittest.TestCase):
                 self._ev("job", SignalStatus.SUCCESS, 30),
             ],
         )
-        s = Signal(key="job", workflow_name="wf", commits=[c_new, c_old])
         partition = PartitionedCommits(failed=[c_new], unknown=[], successful=[c_old])
         self.assertEqual(
-            s.confirm_not_an_infra_issue(partition), InfraCheckResult.RESTART_SUCCESS
+            partition.confirm_not_an_infra_issue(), InfraCheckResult.RESTART_SUCCESS
         )
 
     def test_confirm_not_an_infra_issue_false_no_bracketing_success(self):
@@ -161,10 +158,9 @@ class TestSignal(unittest.TestCase):
                 self._ev("job", SignalStatus.PENDING, 30),
             ],
         )
-        s = Signal(key="job", workflow_name="wf", commits=[c_new, c_old])
         partition = PartitionedCommits(failed=[c_new], unknown=[], successful=[c_old])
         self.assertEqual(
-            s.confirm_not_an_infra_issue(partition), InfraCheckResult.RESTART_SUCCESS
+            partition.confirm_not_an_infra_issue(), InfraCheckResult.RESTART_SUCCESS
         )
 
     def test_detect_autorevert_pattern_basic(self):

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
@@ -192,8 +192,12 @@ class TestSignal(unittest.TestCase):
         self.assertIsNotNone(res)
         self.assertIsInstance(res, AutorevertPattern)
         self.assertEqual(res.workflow_name, "wf")
-        self.assertEqual(res.newer_commits, ["sha_newer", "sha_mid"])
-        self.assertEqual(res.older_commit, "sha_old")
+        # newer failing commits are those after the suspected one (newest->older)
+        self.assertEqual(
+            res.newer_failing_commits, ["sha_newer"]
+        )  # only newer of the two
+        self.assertEqual(res.suspected_commit, "sha_mid")
+        self.assertEqual(res.older_successful_commit, "sha_old")
 
     def test_detect_autorevert_pattern_none_when_missing_failure(self):
         c_newer = SignalCommit(


### PR DESCRIPTION
Sketching up the new simplified scalable architecture for autorevert.

Introduces a modular Signal abstraction that cleanly separates signal extraction (from jobs/tests/classifications) from pattern detection.


### Motivation

Decouple “how we extract signal” from “how we detect patterns” so we can:
    - Incorporate richer sources (tests, multiple failures, classification) without rewriting pattern logic.
    - Handle missing/partial signal more gracefully.
    - Iterate on detection rules independently.
    - Self-contained code much easier to cover in tests.


What’s Implemented

- New core types in pytorch_auto_revert/signal.py & most of the pattern detection logic (the **new one** that we discussed)
- Tests in tests/test_signal.py pending-only and empty commits).


What’s Not Yet Wired / Behavior Changes

- Existing production detection flow remains unchanged (migration is not started).

Next Steps (Migration Plan)

- Finish pattern detection and issue `RestartCommits` when needed
- Build Signal extractors:
    - From workflow_job for job-level signal (including classification).
    - From test_run_s3/test_run_summary for per-test failures (optional, staged).
    - Normalize names (stable keys)
- Switch to using Signals & Extractors
