### PR TITLE
Silent the annotation error when getting docker_hub_readonly_token secret

### DIFF
--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -195,11 +195,10 @@ runs:
 
     - name: Login to Docker Hub
       shell: bash
-      # It's ok if this steps fails, it would then be an anonymous user like what we used to have
-      continue-on-error: true
       run: |
         set -eux
-        aws secretsmanager get-secret-value --secret-id docker_hub_readonly_token | jq --raw-output '.SecretString' | jq -r .docker_hub_readonly_token | docker login --username pytorchbot --password-stdin
+        # It's ok if this steps fails, it would then be an anonymous user like what we used to have
+        aws secretsmanager get-secret-value --secret-id docker_hub_readonly_token | jq --raw-output '.SecretString' | jq -r .docker_hub_readonly_token | docker login --username pytorchbot --password-stdin || true
 
     - name: Build docker image
       if: ${{ steps.calculate-image.outputs.skip != 'true' && (inputs.always-rebuild || steps.check-image.outputs.rebuild) }}


### PR DESCRIPTION
This annoyance is showing up on all pet instances benchmark jobs, for example https://github.com/pytorch/pytorch/actions/runs/17201748116.  As the failure is ignored anyway, let's just pipe that to `true` to silent it.

### Testing

https://github.com/pytorch/pytorch/pull/161496