### PR TITLE
[HUD] SGLang benchmark integration

### DIFF
--- a/torchci/components/benchmark/llms/components/LLMsGraphPanel.tsx
+++ b/torchci/components/benchmark/llms/components/LLMsGraphPanel.tsx
@@ -169,7 +169,7 @@ export default function LLMsGraphPanel({
               const device = record.device;
               const metric = record.metric;
 
-              if (repoName === "vllm-project/vllm") {
+              if (repoName === "vllm-project/vllm" || repoName === "sgl-project/sglang") {
                 const requestRate = record.extra!["request_rate"];
                 const tensorParallel = record.extra!["tensor_parallel_size"];
                 const inputLen = record.extra!["random_input_len"]

--- a/torchci/components/benchmark/llms/components/LLMsGraphPanel.tsx
+++ b/torchci/components/benchmark/llms/components/LLMsGraphPanel.tsx
@@ -169,7 +169,10 @@ export default function LLMsGraphPanel({
               const device = record.device;
               const metric = record.metric;
 
-              if (repoName === "vllm-project/vllm" || repoName === "sgl-project/sglang") {
+              if (
+                repoName === "vllm-project/vllm" ||
+                repoName === "sgl-project/sglang"
+              ) {
                 const requestRate = record.extra!["request_rate"];
                 const tensorParallel = record.extra!["tensor_parallel_size"];
                 const inputLen = record.extra!["random_input_len"]

--- a/torchci/components/benchmark/llms/components/LLMsSummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/components/LLMsSummaryPanel.tsx
@@ -168,7 +168,7 @@ export default function LLMsSummaryPanel({
     });
   }
 
-  if (repoName === "vllm-project/vllm") {
+  if (repoName === "vllm-project/vllm" || repoName === "sgl-project/sglang") {
     columns.push({
       field: "tensor_parallel_size",
       headerName: "Tensor parallel",

--- a/torchci/components/layout/NavBar.tsx
+++ b/torchci/components/layout/NavBar.tsx
@@ -118,6 +118,10 @@ function NavBar() {
       name: "vLLM v1",
       href: "/benchmark/llms?repoName=vllm-project%2Fvllm",
     },
+    {
+      name: "SGLang",
+      href: "/benchmark/llms?repoName=sgl-project%2Fsglang",
+    },
   ];
 
   const devInfraDropdown = [

--- a/torchci/lib/benchmark/llms/common.ts
+++ b/torchci/lib/benchmark/llms/common.ts
@@ -6,6 +6,7 @@ export const REPO_TO_BENCHMARKS: { [k: string]: string[] } = {
   "pytorch/executorch": ["ExecuTorch"],
   "pytorch/ao": ["TorchAO benchmark"],
   "vllm-project/vllm": ["vLLM benchmark"],
+  "sgl-project/sglang": ["SGLang benchmark"],
 };
 export const EXCLUDED_METRICS: string[] = [
   "load_status",

--- a/torchci/lib/benchmark/llms/utils/llmUtils.ts
+++ b/torchci/lib/benchmark/llms/utils/llmUtils.ts
@@ -312,7 +312,7 @@ const toRowData = (
       arch: arch,
     };
 
-    if (repoName === "vllm-project/vllm") {
+    if (repoName === "vllm-project/vllm" || repoName === "sgl-project/sglang") {
       // These fields are only available on vLLM benchmark
       const extraInfo = JSON.parse(extra);
       row["extra"] = extraInfo;


### PR DESCRIPTION
These changes include adding a new benchmark dashboard for SGLang framework. Most of the implementation for SGLang is similar 

Verified the changes through the HUD dashboard that the SGLang dashboard is fetching the content from the Clickhouse database.
<img width="1722" height="803" alt="Screenshot 2025-08-27 at 4 10 56 PM" src="https://github.com/user-attachments/assets/5de8d04f-996d-413b-9eca-c2b3d0f435b8" />
<img width="1722" height="962" alt="Screenshot 2025-08-27 at 4 11 05 PM" src="https://github.com/user-attachments/assets/958608c9-2769-44bf-b653-4dd42cd3f9e8" />
<img width="755" height="496" alt="Screenshot 2025-08-27 at 4 14 01 PM" src="https://github.com/user-attachments/assets/fb7091a5-a9ef-483a-b548-81c434ca4fa7" />

