### PR TITLE
Add sbsa CUDA 13.0 domain builds

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -52,7 +52,7 @@ STABLE_CUDA_VERSIONS = {
     "release": "12.8",
 }
 
-CUDA_AARCH64_ARCHES = ["12.9-aarch64"]
+CUDA_AARCH64_ARCHES = ["12.9-aarch64", "13.0-aarch64"]
 
 PACKAGE_TYPES = ["wheel", "libtorch"]
 CXX11_ABI = "cxx11-abi"


### PR DESCRIPTION
now that CUDA 13.0 aarch64 build is available, add domain builds too

cc @atalman 