### PR TITLE
Fixing the behaviour for getRunnerTypes with scaleConfigOrg

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
@@ -323,6 +323,10 @@ export async function getRunnerTypes(
         ? await createGitHubClientForRunnerOrg(repo.owner, metrics)
         : await createGitHubClientForRunnerRepo(repo, metrics);
 
+      console.debug(
+        `[getRunnerTypes]: Fetching runner types from ${filepath} for https://github.com/${repo.owner}/${repo.repo}/`,
+      );
+
       const response = await expBackOff(() => {
         return metrics.trackRequest(metrics.reposGetContentGHCallSuccess, metrics.reposGetContentGHCallFailure, () => {
           return githubAppClient.repos.getContent({
@@ -435,6 +439,9 @@ export async function getRunnerTypes(
       status = 'success';
       return filteredResult;
     } catch (e) {
+      console.error(
+        `[getRunnerTypes]: Error for path '${filepath}' for https://github.com/${repo.owner}/${repo.repo}/`,
+      );
       console.error(`[getRunnerTypes]: ${e}`);
       throw e;
     } finally {

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up-chron.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up-chron.ts
@@ -14,8 +14,11 @@ export async function scaleUpChron(metrics: ScaleUpChronMetrics): Promise<void> 
   // 3. For each runner queued for longer than the minimum delay, try to scale it up
 
   try {
-    const scaleConfigRepo = getRepo(Config.Instance.scaleConfigOrg, Config.Instance.scaleConfigRepo);
-    const validRunnerTypes = await getRunnerTypes(scaleConfigRepo, metrics, Config.Instance.scaleConfigRepoPath);
+    const validRunnerTypes = await getRunnerTypes(
+      getRepo(Config.Instance.scaleConfigOrg, Config.Instance.scaleConfigRepo),
+      metrics,
+      Config.Instance.scaleConfigRepoPath,
+    );
 
     if (!Config.Instance.scaleUpChronRecordQueueUrl) {
       throw new Error('scaleUpChronRecordQueueUrl is not set. Cannot send queued scale up requests');

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -65,7 +65,7 @@ export async function scaleUp(
   }
 
   const scaleConfigRepo = {
-    owner: repo.owner,
+    owner: Config.Instance.scaleConfigOrg || repo.owner,
     repo: Config.Instance.scaleConfigRepo || repo.repo,
   };
   const runnerTypes = await getRunnerTypes(scaleConfigRepo, metrics);


### PR DESCRIPTION
Currently, when scaleConfigOrg is pointing to an organization that is not the one runners are assigned to, it is not always correctly selected for `getRunnerTypes` call.

Triggering errors similar to:

```
ERROR [getRunnerTypes]: HttpError: Not Found
```

This is due it not be correctly matched in all places where its usage is called. 
