### PR TITLE
[autoscalers] Only use auth to download github files if needed

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.test.ts
@@ -878,7 +878,7 @@ runner_types:
   });
 
   it('return is not 200', async () => {
-    const repo = { owner: 'owner', repo: 'repo' };
+    const repo = { owner: 'owner', repo: 'repo_fail' };
 
     // Mock the HTTP request to return a 500 error
     const scope = nock('https://raw.githubusercontent.com')

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
@@ -356,8 +356,6 @@ export async function getRunnerTypes(
       // Get the file via HTTP request
       configYml = await downloadFileFromGitHub(filerepo, filepath, metrics);
 
-      console.debug(`'${filepath}' contents: ${configYml}`);
-
       const config = YAML.parse(configYml);
       const result: Map<string, RunnerTypeScaleConfig> = new Map(
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
@@ -350,7 +350,7 @@ export async function getRunnerTypes(
 
       console.debug(
         `[getRunnerTypes]: Fetching runner types from ${filepath} for https://github.com/` +
-        `${filerepo.owner}/${filerepo.repo}/`,
+          `${filerepo.owner}/${filerepo.repo}/`,
       );
 
       // Get the file via HTTP request

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
@@ -349,7 +349,8 @@ export async function getRunnerTypes(
       status = 'doRun';
 
       console.debug(
-        `[getRunnerTypes]: Fetching runner types from ${filepath} for https://github.com/${filerepo.owner}/${filerepo.repo}/`,
+        `[getRunnerTypes]: Fetching runner types from ${filepath} for https://github.com/` +
+        `${filerepo.owner}/${filerepo.repo}/`,
       );
 
       // Get the file via HTTP request

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/gh-runners.ts
@@ -8,7 +8,6 @@ import LRU from 'lru-cache';
 import { Metrics } from './metrics';
 import { Octokit } from '@octokit/rest';
 import YAML from 'yaml';
-import axios from 'axios';
 
 const ghMainClientCache = new LRU({ maxAge: 10 * 1000 });
 const ghClientCache = new LRU({ maxAge: 10 * 1000 });
@@ -309,33 +308,11 @@ export async function getRunnerOrg(org: string, runnerID: string, metrics: Metri
 }
 
 /**
- * Download a file from GitHub using a direct HTTP request to raw.githubusercontent.com
- */
-export async function downloadFileFromGitHub(repo: Repo, filepath: string, metrics: Metrics): Promise<string> {
-  const rawFileUrl = `https://raw.githubusercontent.com/${repo.owner}/${repo.repo}/main/${filepath}`;
-
-  const response = await expBackOff(() => {
-    return metrics.trackRequest(metrics.reposGetContentGHCallSuccess, metrics.reposGetContentGHCallFailure, () => {
-      return axios.get(rawFileUrl);
-    });
-  });
-
-  /* istanbul ignore next */
-  if (response?.status != 200 || !response.data) {
-    throw Error(
-      `Issue (${response.status}) retrieving '${filepath}' for https://github.com/${repo.owner}/${repo.repo}/`,
-    );
-  }
-
-  console.debug(`[downloadFileFromGitHub]: Successfully fetched file via HTTP`);
-  return response.data;
-}
-
-/**
  Get runner types from scale-config.yml
  */
 export async function getRunnerTypes(
   filerepo: Repo,
+  authrepo: Repo,
   metrics: Metrics,
   filepath = Config.Instance.scaleConfigRepoPath,
 ): Promise<Map<string, RunnerType>> {
@@ -343,18 +320,38 @@ export async function getRunnerTypes(
 
   return await redisCached('ghRunners', `getRunnerTypes-${filerepo.owner}.${filerepo.repo}`, 10 * 60, 0.5, async () => {
     let status = 'noRun';
-    let configYml: string;
-
     try {
-      status = 'doRun';
+      const githubAppClient = Config.Instance.enableOrganizationRunners
+        ? await createGitHubClientForRunnerOrg(authrepo.owner, metrics)
+        : await createGitHubClientForRunnerRepo(authrepo, metrics);
 
       console.debug(
-        `[getRunnerTypes]: Fetching runner types from ${filepath} for https://github.com/` +
-          `${filerepo.owner}/${filerepo.repo}/`,
+        `[getRunnerTypes]: Fetching runner types from ${filepath} for ` +
+          `https://github.com/${filerepo.owner}/${filerepo.repo}/`,
       );
 
-      // Get the file via HTTP request
-      configYml = await downloadFileFromGitHub(filerepo, filepath, metrics);
+      const response = await expBackOff(() => {
+        return metrics.trackRequest(metrics.reposGetContentGHCallSuccess, metrics.reposGetContentGHCallFailure, () => {
+          return githubAppClient.repos.getContent({
+            ...filerepo,
+            path: filepath,
+          });
+        });
+      });
+
+      /* istanbul ignore next */
+      const { content }: { content?: string } = { ...(response?.data || {}) } as { content?: string };
+      if (response?.status != 200 || !content) {
+        throw Error(
+          `Issue (${response.status}) retrieving '${filepath}' for ` +
+            `https://github.com/${filerepo.owner}/${filerepo.repo}/`,
+        );
+      }
+
+      const buff = Buffer.from(content, 'base64');
+      const configYml = buff.toString('ascii');
+
+      console.debug(`'${filepath}' contents: ${configYml}`);
 
       const config = YAML.parse(configYml);
       const result: Map<string, RunnerTypeScaleConfig> = new Map(

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
@@ -156,7 +156,7 @@ describe('scale-down', () => {
   describe('org', () => {
     const environment = 'environment';
     const scaleConfigRepo = 'test-infra';
-    const theOrg = ' a-owner';
+    const theOrg = 'a-owner';
     const dateRef = moment(new Date());
     const runnerTypes = new Map([
       ['ignore-no-org-no-repo', { is_ephemeral: false } as RunnerType],
@@ -455,7 +455,11 @@ describe('scale-down', () => {
       expect(mockedListGithubRunnersOrg).toBeCalledWith(theOrg, metrics);
 
       expect(mockedGetRunnerTypes).toBeCalledTimes(9);
-      expect(mockedGetRunnerTypes).toBeCalledWith({ owner: theOrg, repo: scaleConfigRepo }, metrics);
+      expect(mockedGetRunnerTypes).toBeCalledWith(
+        { owner: theOrg, repo: scaleConfigRepo },
+        { owner: theOrg, repo: '' },
+        metrics,
+      );
 
       expect(mockedRemoveGithubRunnerOrg).toBeCalledTimes(5);
       {
@@ -797,7 +801,7 @@ describe('scale-down', () => {
       expect(mockedListGithubRunnersRepo).toBeCalledWith(repo, metrics);
 
       expect(mockedGetRunnerTypes).toBeCalledTimes(9);
-      expect(mockedGetRunnerTypes).toBeCalledWith(repo, metrics);
+      expect(mockedGetRunnerTypes).toBeCalledWith(repo, repo, metrics);
 
       expect(mockedRemoveGithubRunnerRepo).toBeCalledTimes(5);
       {
@@ -1253,10 +1257,19 @@ describe('scale-down', () => {
 
         mockedGetRunnerTypes.mockResolvedValueOnce(new Map([[runnerType, {} as RunnerType]]));
 
-        expect(await isEphemeralRunner({ runnerType: runnerType, org: owner } as RunnerInfo, metrics)).toEqual(false);
+        expect(
+          await isEphemeralRunner(
+            { runnerType: runnerType, org: owner, repo: `${owner}/${scaleConfigRepo}` } as RunnerInfo,
+            metrics,
+          ),
+        ).toEqual(false);
 
         expect(mockedGetRunnerTypes).toBeCalledTimes(1);
-        expect(mockedGetRunnerTypes).toBeCalledWith({ owner: owner, repo: scaleConfigRepo }, metrics);
+        expect(mockedGetRunnerTypes).toBeCalledWith(
+          { owner: owner, repo: scaleConfigRepo },
+          { owner: owner, repo: scaleConfigRepo },
+          metrics,
+        );
       });
 
       it('org in runner, is_ephemeral === false', async () => {
@@ -1265,10 +1278,19 @@ describe('scale-down', () => {
 
         mockedGetRunnerTypes.mockResolvedValueOnce(new Map([[runnerType, { is_ephemeral: false } as RunnerType]]));
 
-        expect(await isEphemeralRunner({ runnerType: runnerType, org: owner } as RunnerInfo, metrics)).toEqual(false);
+        expect(
+          await isEphemeralRunner(
+            { runnerType: runnerType, org: owner, repo: `${owner}/${scaleConfigRepo}` } as RunnerInfo,
+            metrics,
+          ),
+        ).toEqual(false);
 
         expect(mockedGetRunnerTypes).toBeCalledTimes(1);
-        expect(mockedGetRunnerTypes).toBeCalledWith({ owner: owner, repo: scaleConfigRepo }, metrics);
+        expect(mockedGetRunnerTypes).toBeCalledWith(
+          { owner: owner, repo: scaleConfigRepo },
+          { owner: owner, repo: scaleConfigRepo },
+          metrics,
+        );
       });
 
       it('org not in runner, is_ephemeral === true', async () => {
@@ -1282,7 +1304,11 @@ describe('scale-down', () => {
         ).toEqual(true);
 
         expect(mockedGetRunnerTypes).toBeCalledTimes(1);
-        expect(mockedGetRunnerTypes).toBeCalledWith({ owner: owner, repo: scaleConfigRepo }, metrics);
+        expect(mockedGetRunnerTypes).toBeCalledWith(
+          { owner: owner, repo: scaleConfigRepo },
+          { owner: owner, repo: 'a-repo' },
+          metrics,
+        );
       });
     });
 
@@ -1316,7 +1342,7 @@ describe('scale-down', () => {
           ).toEqual(false);
 
           expect(mockedGetRunnerTypes).toBeCalledTimes(1);
-          expect(mockedGetRunnerTypes).toBeCalledWith(runnerRepo, metrics);
+          expect(mockedGetRunnerTypes).toBeCalledWith(runnerRepo, runnerRepo, metrics);
         });
 
         it('is_ephemeral === true', async () => {
@@ -1329,7 +1355,7 @@ describe('scale-down', () => {
           ).toEqual(true);
 
           expect(mockedGetRunnerTypes).toBeCalledTimes(1);
-          expect(mockedGetRunnerTypes).toBeCalledWith(runnerRepo, metrics);
+          expect(mockedGetRunnerTypes).toBeCalledWith(runnerRepo, runnerRepo, metrics);
         });
 
         it('is_ephemeral === false', async () => {
@@ -1342,7 +1368,7 @@ describe('scale-down', () => {
           ).toEqual(false);
 
           expect(mockedGetRunnerTypes).toBeCalledTimes(1);
-          expect(mockedGetRunnerTypes).toBeCalledWith(runnerRepo, metrics);
+          expect(mockedGetRunnerTypes).toBeCalledWith(runnerRepo, runnerRepo, metrics);
         });
       });
 
@@ -1374,7 +1400,7 @@ describe('scale-down', () => {
           ).toEqual(false);
 
           expect(mockedGetRunnerTypes).toBeCalledTimes(1);
-          expect(mockedGetRunnerTypes).toBeCalledWith(centralRepo, metrics);
+          expect(mockedGetRunnerTypes).toBeCalledWith(centralRepo, runnerRepo, metrics);
         });
 
         it('is_ephemeral === true', async () => {
@@ -1387,7 +1413,7 @@ describe('scale-down', () => {
           ).toEqual(true);
 
           expect(mockedGetRunnerTypes).toBeCalledTimes(1);
-          expect(mockedGetRunnerTypes).toBeCalledWith(centralRepo, metrics);
+          expect(mockedGetRunnerTypes).toBeCalledWith(centralRepo, runnerRepo, metrics);
         });
 
         it('is_ephemeral === false', async () => {
@@ -1400,7 +1426,7 @@ describe('scale-down', () => {
           ).toEqual(false);
 
           expect(mockedGetRunnerTypes).toBeCalledTimes(1);
-          expect(mockedGetRunnerTypes).toBeCalledWith(centralRepo, metrics);
+          expect(mockedGetRunnerTypes).toBeCalledWith(centralRepo, runnerRepo, metrics);
         });
       });
     });

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -268,7 +268,11 @@ export async function isEphemeralRunner(ec2runner: RunnerInfo, metrics: ScaleDow
     return false;
   }
 
-  const runnerTypes = await getRunnerTypes(backwardCompatibleGetRepoForgetRunnerTypes(ec2runner), metrics);
+  const runnerTypes = await getRunnerTypes(
+    backwardCompatibleGetRepoForgetRunnerTypes(ec2runner),
+    ec2runner.repo ? getRepo(ec2runner.repo as string) : { owner: ec2runner.org as string, repo: '' },
+    metrics,
+  );
   return runnerTypes.get(ec2runner.runnerType)?.is_ephemeral ?? false;
 }
 
@@ -278,7 +282,11 @@ export async function minRunners(ec2runner: RunnerInfo, metrics: ScaleDownMetric
     return Config.Instance.minAvailableRunners;
   }
 
-  const runnerTypes = await getRunnerTypes(backwardCompatibleGetRepoForgetRunnerTypes(ec2runner), metrics);
+  const runnerTypes = await getRunnerTypes(
+    backwardCompatibleGetRepoForgetRunnerTypes(ec2runner),
+    ec2runner.repo ? getRepo(ec2runner.repo as string) : { owner: ec2runner.org as string, repo: '' },
+    metrics,
+  );
   return runnerTypes.get(ec2runner.runnerType)?.min_available ?? Config.Instance.minAvailableRunners;
 }
 

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up-chron.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up-chron.ts
@@ -14,8 +14,12 @@ export async function scaleUpChron(metrics: ScaleUpChronMetrics): Promise<void> 
   // 3. For each runner queued for longer than the minimum delay, try to scale it up
 
   try {
+    const repo = getRepo(Config.Instance.scaleConfigOrg, Config.Instance.scaleConfigRepo);
     const validRunnerTypes = await getRunnerTypes(
-      getRepo(Config.Instance.scaleConfigOrg, Config.Instance.scaleConfigRepo),
+      // For scaleUpChron, we don't have a situation where the auth repo is different from the config repo
+      // so we can just pass the same repo for both parameters
+      repo,
+      repo,
       metrics,
       Config.Instance.scaleConfigRepoPath,
     );

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
@@ -95,7 +95,11 @@ describe('scaleUp', () => {
 
     await scaleUp('aws:sqs', payload, metrics);
     expect(mockedGetRunnerTypes).toBeCalledTimes(1);
-    expect(mockedGetRunnerTypes).toBeCalledWith({ repo: 'repo', owner: 'owner' }, metrics);
+    expect(mockedGetRunnerTypes).toBeCalledWith(
+      { repo: 'repo', owner: 'owner' },
+      { repo: 'repo', owner: 'owner' },
+      metrics,
+    );
     expect(mockedListGithubRunners).not.toBeCalled();
   });
 
@@ -135,7 +139,11 @@ describe('scaleUp', () => {
 
     await scaleUp('aws:sqs', payload, metrics);
     expect(mockedGetRunnerTypes).toBeCalledTimes(1);
-    expect(mockedGetRunnerTypes).toBeCalledWith({ repo: 'scale-config-repo', owner: 'owner' }, metrics);
+    expect(mockedGetRunnerTypes).toBeCalledWith(
+      { repo: 'scale-config-repo', owner: 'owner' },
+      { repo: 'repo', owner: 'owner' },
+      metrics,
+    );
     expect(mockedListGithubRunners).not.toBeCalled();
   });
 
@@ -243,7 +251,7 @@ describe('scaleUp', () => {
 
     await scaleUp('aws:sqs', payload, metrics);
     expect(mockedGetRunnerTypes).toBeCalledTimes(1);
-    expect(mockedGetRunnerTypes).toBeCalledWith(repo, metrics);
+    expect(mockedGetRunnerTypes).toBeCalledWith(repo, repo, metrics);
     expect(mockedListGithubRunners).toBeCalledTimes(2);
     expect(mockedListGithubRunners).toBeCalledWith(repo, metrics);
     expect(mockedCreateRegistrationTokenForRepo).not.toBeCalled();

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -68,7 +68,7 @@ export async function scaleUp(
     owner: Config.Instance.scaleConfigOrg || repo.owner,
     repo: Config.Instance.scaleConfigRepo || repo.repo,
   };
-  const runnerTypes = await getRunnerTypes(scaleConfigRepo, metrics);
+  const runnerTypes = await getRunnerTypes(scaleConfigRepo, repo, metrics);
   /* istanbul ignore next */
   const runnerLabels = payload?.runnerLabels ?? Array.from(runnerTypes.keys());
 


### PR DESCRIPTION
This enables autoscalers to use a scale-config that's located in an organization other than the one they're located in, as long as that scale-config is located in a public repo (which all our scale configs currently are).

Bug it fixes: The old code would create a github client to download the scale-config.yml file, but `createGitHubClientForRunnerOrg` will fail if you try to try to create a client for an org your app doesn't have access to.  Using a full blown git client for a public file also seems unnecessary.

This version uses a normal http request to pull the raw file.  So authentication doesn't matter.  (Aside: I considered keeping the old flow as a backup path for if we ever want the scale config to live in a public repo, but if and when that day comes I'd rather we add the logic afresh than leave dead, unused code around in the script.)

Testing: Verified the getRunnerTypes functionality locally to ensure it worked end-to-end without mocks.