### PR TITLE
drci: Remove OH link

### DIFF
--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -26,8 +26,6 @@ export const NUM_MINUTES = 30;
 export const REPO: string = "pytorch";
 export const OWNER: string = "pytorch";
 export const DRCI_COMMENT_START = "<!-- drci-comment-start -->\n";
-export const OH_URL =
-  "https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours";
 export const DOCS_URL = "https://docs-preview.pytorch.org";
 export const PYTHON_DOCS_PATH = "index.html";
 export const CPP_DOCS_PATH = "cppdocs/index.html";
@@ -82,7 +80,7 @@ export function formDrciHeader(
 ### :test_tube: See artifacts and rendered test results at [hud.pytorch.org/pr/${prNum}](${HUD_URL}/pr/${prNum})
 * :page_facing_up: Preview [Python docs built from this PR](${DOCS_URL}/${owner}/${repo}/${prNum}/${PYTHON_DOCS_PATH})
 * :page_facing_up: Preview [C++ docs built from this PR](${DOCS_URL}/${owner}/${repo}/${prNum}/${CPP_DOCS_PATH})
-* :question: Need help or want to give feedback on the CI? Visit the [bot commands wiki](${BOT_COMMANDS_WIKI_URL}) or our [office hours](${OH_URL})
+* :question: Need help or want to give feedback on the CI? Visit the [bot commands wiki](${BOT_COMMANDS_WIKI_URL})
 
 Note: Links to docs will display an error until the docs builds have been completed.`;
   }

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -8,7 +8,6 @@ import {
   formDrciSevBody,
   getActiveSEVs,
   HUD_URL,
-  OH_URL,
 } from "lib/drciUtils";
 import * as fetchPR from "lib/fetchPR";
 import * as fetchRecentWorkflows from "lib/fetchRecentWorkflows";
@@ -395,7 +394,6 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     expect(
       comment.includes("Need help or want to give feedback on the CI?")
     ).toBeTruthy();
-    expect(comment.includes(OH_URL)).toBeTruthy();
     expect(comment.includes(DOCS_URL)).toBeTruthy();
   });
 

--- a/torchci/test/drciBot.test.ts
+++ b/torchci/test/drciBot.test.ts
@@ -71,7 +71,6 @@ describe("verify-drci-functionality", () => {
         expect(
           comment.includes("Need help or want to give feedback on the CI?")
         ).toBeTruthy();
-        expect(comment.includes(drciUtils.OH_URL)).toBeTruthy();
         expect(comment.includes(drciUtils.DOCS_URL)).toBeTruthy();
         return true;
       })
@@ -119,7 +118,6 @@ describe("verify-drci-functionality", () => {
           expect(
             comment.includes("Need help or want to give feedback on the CI?")
           ).toBeTruthy();
-          expect(comment.includes(drciUtils.OH_URL)).toBeTruthy();
           expect(comment.includes(drciUtils.DOCS_URL)).toBeTruthy();
           return true;
         }
@@ -252,7 +250,6 @@ describe("verify-drci-functionality", () => {
           expect(
             comment.includes("Need help or want to give feedback on the CI?")
           ).toBeTruthy();
-          expect(comment.includes(drciUtils.OH_URL)).toBeTruthy();
           expect(comment.includes(drciUtils.DOCS_URL)).toBeTruthy();
           return true;
         }


### PR DESCRIPTION
No one really attends these so let's just remove this from drci comment.

Also searched the codebase for more office hours references:
```
❯ rg office torchci

```