### PR TITLE
[ez][drci] Remove unused mock in test

### DIFF
--- a/torchci/test/drciBot.test.ts
+++ b/torchci/test/drciBot.test.ts
@@ -30,9 +30,6 @@ describe("verify-drci-functionality", () => {
     const mockS3 = {
       send: jest.fn(),
     };
-    jest.mock("aws-sdk", () => ({
-      S3: jest.fn().mockImplementation(() => mockS3),
-    }));
     const mockS3Client = jest.spyOn(getS3Client, "getS3Client");
     mockS3Client.mockImplementation(() => mockS3 as unknown as S3Client);
   });


### PR DESCRIPTION
Realized this mock doesn't matter since we use `@aws-sdk/client-s3` not `aws-sdk`

Some answers from chatgpt about mocking so I don't forget:
`spyOn().mockImplementation` good for mocking single function in a file (also seems to be stricter typed)
`jest.mock('./s3-wrapper/path/to/import')` + `(getS3Client as jest.Mock).mockImplementation(() => mockS3);` good for mocking entire file
After jest29 (?) `mocked(func)` is basically the same as `(func as jest.Mock)` but with better typing?