### PR TITLE
[test times] Change query for periodic jobs

### DIFF
--- a/torchci/clickhouse_queries/test_times/per_class_periodic_jobs/query.sql
+++ b/torchci/clickhouse_queries/test_times/per_class_periodic_jobs/query.sql
@@ -1,23 +1,17 @@
 -- same as test_time_per_file query except for the first select
 WITH good_periodic_sha AS (
-    SELECT job.head_sha AS sha
+    SELECT
+        w.head_sha AS sha
     FROM
-        default.workflow_job job
-    JOIN default.push ON job.head_sha = push.head_commit.'id'
+        default .workflow_run w
     WHERE
-        job.workflow_name = 'periodic'
-        AND job.head_branch LIKE 'main'
-        AND job.repository_full_name = 'pytorch/pytorch'
-    GROUP BY
-        job.head_sha,
-        push.head_commit.'timestamp'
-    HAVING
-        groupBitAnd(
-            job.conclusion = 'success'
-            AND job.conclusion IS NOT null
-        ) = 1
+        w.name = 'periodic'
+        AND w.head_branch = 'main'
+        AND w.repository. 'full_name' = 'pytorch/pytorch'
+        and w.conclusion = 'success'
+        and w.run_attempt = 1
     ORDER BY
-        push.head_commit.'timestamp' DESC
+        w.head_commit. 'timestamp' DESC
     LIMIT
         3
 ),

--- a/torchci/clickhouse_queries/test_times/per_file_periodic_jobs/query.sql
+++ b/torchci/clickhouse_queries/test_times/per_file_periodic_jobs/query.sql
@@ -1,23 +1,17 @@
 -- same as test_time_per_file query except for the first select
 WITH good_periodic_sha AS (
-    SELECT job.head_sha AS sha
+    SELECT
+        w.head_sha AS sha
     FROM
-        default.workflow_job job
-    JOIN default.push ON job.head_sha = push.head_commit.'id'
+        default .workflow_run w
     WHERE
-        job.workflow_name = 'periodic'
-        AND job.head_branch LIKE 'main'
-        AND job.repository_full_name = 'pytorch/pytorch'
-    GROUP BY
-        job.head_sha,
-        push.head_commit.'timestamp'
-    HAVING
-        groupBitAnd(
-            job.conclusion = 'success'
-            AND job.conclusion IS NOT null
-        ) = 1
+        w.name = 'periodic'
+        AND w.head_branch = 'main'
+        AND w.repository. 'full_name' = 'pytorch/pytorch'
+        and w.conclusion = 'success'
+        and w.run_attempt = 1
     ORDER BY
-        push.head_commit.'timestamp' DESC
+        w.head_commit. 'timestamp' DESC
     LIMIT
         3
 ),


### PR DESCRIPTION
Query should be faster now since it doesn't need to do a join with push, and also queries a smaller table

Reason:
Query was hitting memory limits when I ran locally

Pros:
query no longer hits memory limits

Cons:
query semantics change slightly but should be ok
I don't think we even need the jobs to be successful now that we continue on error in main

This does not fix the asan time out thing, that is a separate issue.  If you don't know what this means, don't worry about it