### PR TITLE
[HUD] Update some queries and regex for better viable/strict job definitions

### DIFF
--- a/torchci/clickhouse_queries/master_commit_red/query.sql
+++ b/torchci/clickhouse_queries/master_commit_red/query.sql
@@ -27,7 +27,14 @@ all_runs AS (
     JOIN commits commit ON workflow_run.head_commit.'id' = commit.sha
     WHERE
         -- Limit it to workflows which block viable/strict upgrades
-        workflow_run.name IN ('Lint', 'pull', 'trunk', 'linux-binary-libtorch-release', 'linux-binary-manywheel', 'linux-aarch64')
+        workflow_run.name IN (
+            'Lint',
+            'pull',
+            'trunk',
+            'linux-binary-libtorch-release',
+            'linux-binary-manywheel',
+            'linux-aarch64'
+        )
         AND workflow_run.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
         AND workflow_run.id IN (
             SELECT id FROM materialized_views.workflow_run_by_head_sha

--- a/torchci/clickhouse_queries/master_commit_red/query.sql
+++ b/torchci/clickhouse_queries/master_commit_red/query.sql
@@ -26,11 +26,8 @@ all_runs AS (
         workflow_run FINAL
     JOIN commits commit ON workflow_run.head_commit.'id' = commit.sha
     WHERE
-        (
-            -- Limit it to workflows which block viable/strict upgrades
-            workflow_run.name IN ('Lint', 'pull', 'trunk')
-            OR workflow_run.name LIKE 'linux-binary%'
-        )
+        -- Limit it to workflows which block viable/strict upgrades
+        workflow_run.name IN ('Lint', 'pull', 'trunk', 'linux-binary-libtorch-release', 'linux-binary-manywheel', 'linux-aarch64')
         AND workflow_run.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
         AND workflow_run.id IN (
             SELECT id FROM materialized_views.workflow_run_by_head_sha

--- a/torchci/clickhouse_queries/master_commit_red_avg/query.sql
+++ b/torchci/clickhouse_queries/master_commit_red_avg/query.sql
@@ -19,11 +19,8 @@ all_runs as (
     default.workflow_run as workflow_run FINAL
     JOIN pushes as push ON workflow_run.head_sha = push.sha
   WHERE
-     (
-      -- Limit it to workflows which block viable/strict upgrades
-      lower(workflow_run.name) in {workflowNames:Array(String)}
-      OR workflow_run.name like 'linux-binary%'
-    )
+    -- Limit it to workflows which block viable/strict upgrades
+    lower(workflow_run.name) in {workflowNames:Array(String)}
     AND workflow_run.event != 'workflow_run' -- Filter out worflow_run-triggered jobs, which have nothing to do with the SHA
     and workflow_run.id in (
         select id from materialized_views.workflow_run_by_head_sha

--- a/torchci/clickhouse_queries/master_commit_red_percent/query.sql
+++ b/torchci/clickhouse_queries/master_commit_red_percent/query.sql
@@ -32,11 +32,7 @@ all_jobs AS (
             WHERE head_sha in (SELECT distinct p.sha FROM pushes p)
         )
         AND j.workflow_event != 'workflow_run' -- Filter out worflow_run-triggered jobs, which have nothing to do with the SHA
-        AND (
-            -- Limit it to jobs which block viable/strict upgrades
-            has({workflowNames: Array(String) }, lower(j.workflow_name))
-            OR j.workflow_name like 'linux-binary%'
-        )
+        AND has({workflowNames: Array(String) }, lower(j.workflow_name))
         AND j.name != 'ciflow_should_run'
         AND j.name != 'generate-test-matrix'
         AND j.name NOT LIKE '%rerun_disabled_tests%'

--- a/torchci/components/job/GroupJobConclusion.tsx
+++ b/torchci/components/job/GroupJobConclusion.tsx
@@ -46,7 +46,14 @@ type RepoViableStrictBlockingJobsMap = {
 // TODO: Move this to a config file
 const VIABLE_STRICT_BLOCKING_JOBS: RepoViableStrictBlockingJobsMap = {
   // Source of truth for these jobs is in https://github.com/pytorch/pytorch/blob/main/.github/workflows/update-viablestrict.yml#L26
-  "pytorch/pytorch": [/trunk/i, /pull/i, /linux-binary/i, /lint/i],
+  "pytorch/pytorch": [
+    /trunk/i,
+    /pull/i,
+    /lint/i,
+    /linux-binary-libtorch-release /i,
+    /linux-binary-manywheel /i,
+    /linux-aarch64/i,
+  ],
 };
 
 function isJobViableStrictBlocking(

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -470,7 +470,14 @@ export default function Page() {
     JSON.stringify({
       ...timeParams,
       // TODO (huydhn): Figure out a way to have default parameters for ClickHouse queries
-      workflowNames: ["lint", "pull", "trunk"],
+      workflowNames: [
+        "lint",
+        "pull",
+        "trunk",
+        "linux-binary-libtorch-release",
+        "linux-binary-manywheel",
+        "linux-aarch64",
+      ],
     })
   )}`;
 

--- a/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
+++ b/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
@@ -20,7 +20,14 @@ import { useCallback, useState } from "react";
 import useSWR from "swr";
 import { TimeRangePicker } from "../../../metrics";
 
-const PRIMARY_WORKFLOWS = ["lint", "pull", "trunk"];
+const PRIMARY_WORKFLOWS = [
+  "lint",
+  "pull",
+  "trunk",
+  "linux-binary-libtorch-release",
+  "linux-binary-manywheel",
+  "linux-aarch64",
+];
 const SECONDARY_WORKFLOWS = ["periodic", "inductor"];
 const UNSTABLE_WORKFLOWS = ["unstable"];
 const LAST_WEEK = 7;


### PR DESCRIPTION
Similar to https://github.com/pytorch/pytorch/pull/162100

Reason:
rocm binary builds should not be included in viable strict upgrades and metrics that look at viable strict.  Also add linux-aarch64 to some since that was missing

Is this the correct way to measure trunk redness?  Idk but I want it be consistent with what it says it is (considers only viable/strict blocking jobs) so we don't get confused

Some have spaces after them b/c thats the easier way to guarantee that we won't accidentally include linux-binary-manywheel-rocm when we do regex for linux-binary-manywheel, and convention states that job names that include workflow is `workflow name / job name`.  The places we don't need it are places that only look at workflow name and look for strict equality