### PR TITLE
[autorevert] add signal extraction layer for transforming CI data into Signal objects

### DIFF
--- a/aws/lambda/pytorch-auto-revert/SIGNAL_EXTRACTION.md
+++ b/aws/lambda/pytorch-auto-revert/SIGNAL_EXTRACTION.md
@@ -1,0 +1,187 @@
+# Signal Extraction Layer
+
+This document specifies the extraction layer that converts raw CI data (workflows/jobs/tests) into Signal objects used by the Signal logic (`signal.py`).
+
+## Overview
+
+Two parallel tracks produce Signals:
+- Test‑track Signals: per‑test identities (file + test name) across commits.
+- Non‑test Signals: normalized job base names across commits (grouping shards).
+
+Extraction runs in two phases:
+- Phase A (jobs fetch): fetch recent commits and all workflow jobs (including restarts and retries) for target workflows.
+- Phase B (test details fetch): select relevant jobs for the test‑track in Python and batch query test artifacts for just those jobs.
+
+The output is a list of `Signal` instances, each with commits (newest → older) and time‑ordered `SignalEvent`s per commit.
+
+## Principles
+
+- Pure data mapping: no pattern logic; just construct Signals from source rows.
+- Prefer simple, batched queries aligned to ClickHouse primary keys.
+- Emit multiple events per commit when meaningful (different runs, retries, shards).
+- Reuse existing types and helpers where possible (`CommitJobs`, `JobResult`, `normalize_job_name`).
+- Keep the module self‑contained and easy to unit‑test.
+
+## Inputs and Windowing
+
+- Workflows of interest: e.g., `['trunk', 'pull', 'rocm-mi300', ...]` (configurable).
+- Time window: 16–32h (configurable). Window is short to keep flakiness assumptions stable and long enough to include restarts.
+- Commits considered: pushes to `refs/heads/main` within the window (deduplicated per head_sha).
+
+## Phase A — Jobs Fetch (single query)
+
+Fetch all workflow jobs (original, retries, and restarts) for the commits in the window.
+
+- Include both original runs and restarts (re‑runs via the UI or API).
+- Join to pushes to scope to recent main commits and order newest → older.
+- Select minimal fields used by the extractor:
+  - commit/run/job identity: `head_sha, workflow_name, id AS job_id, run_id (aka wf_run_id), run_attempt`
+  - names/time: `name, started_at, created_at, status, conclusion`
+  - classification shortcut: `tupleElement(torchci_classification_kg,'rule') AS rule`
+
+Notes
+- This preserves all runs (original + restarts) and per‑run attempts (`run_attempt`).
+- Job retries typically show up as separate job rows; names may include `Attempt #2` and have later `started_at`.
+
+## Phase B — Test Details Fetch (batched, from `default.test_run_s3`)
+
+Decide in Python which jobs belong to the test‑track (e.g., `rule IN ('pytest failure','Python unittest failure')`. For those (job_id, run_id[, run_attempt]) triples, fetch per‑test rows directly from `default.test_run_s3` — this table contains one row per testcase, including successful ones (failure_count=0, error_count=0).
+
+Why `test_run_s3` only?
+- We need per‑test identities to build per‑test Signals; `default.test_run_s3` has them. Summary is optional and redundant for this layer.
+- Performance remains good by filtering on `job_id IN (...)` (first PK column) and grouping; limit to the time window implicitly via the selected job set from Phase A.
+
+Job selection for test track:
+- Step 1: find normalized job base names that exhibited a test‑related classification in any commit within the window.
+- Step 2: include ALL jobs across ALL commits whose normalized base is in that set (original runs, restarts; any run_id/attempt) so we can observe successes or pendings for the same test on other commits.
+
+Optimized batched test_run_s3 query (for N job_ids):
+
+```
+SELECT job_id, workflow_id, workflow_run_attempt, file, classname, name,
+       max(failure_count > 0) AS failing,
+       max(error_count  > 0) AS errored,
+       max(rerun_count  > 0) AS rerun_seen,
+       count() AS rows
+FROM default.test_run_s3
+WHERE job_id IN {job_ids:Array(Int64)}
+GROUP BY job_id, workflow_id, workflow_run_attempt, file, classname, name
+```
+
+Notes
+- Use `job_id IN (...)` to leverage the PK prefix `(job_id, name, classname, invoking_file, file)`.
+- We keep `workflow_run_attempt` to distinguish attempts within the same workflow run.
+
+## Mapping to Signals
+
+### Common conventions
+- Commits are ordered newest → older using the push timestamp (`push_dedup.ts`).
+- Each Signal carries `workflow_name` and a stable `key`:
+  - Test‑track: `key = file + '::' + name` (optionally include `classname`).
+  - Non‑test: `key = normalize_job_name(job_name)` (reuse `CommitJobs.normalize_job_name`).
+- Each commit holds a list of `SignalEvent`s (time‑ordered by `started_at`).
+  Ordering: dicts in Python 3.7+ preserve insertion order. Phase A inserts commit keys in push‑timestamp DESC order, so iterating the mapping yields newest→older commits without extra sorting.
+
+Event naming (for debuggability):
+- Consistent key=value format: `wf=<workflow> kind=<test|job> id=<test_id|job_base> run=<wf_run_id> attempt=<run_attempt>`
+- Examples:
+  - Test event: `wf=trunk kind=test id=inductor/test_foo.py::test_bar run=1744 attempt=1`
+  - Job event:  `wf=trunk kind=job  id=linux-jammy-cuda12.8-py3.10-gcc11 / test run=1744 attempt=2`
+
+### Test‑track mapping
+- Build a per‑commit map `test_id -> list[SignalEvent]` by combining all relevant jobs and shards:
+  - For each (wf_run_id, run_attempt, job_base_name) group in the commit, consult `test_run_s3` rows (if any) for each candidate `test_id`:
+    - If `test_run_s3` rows exist for this `test_id` → status should reflect the found test verdict.
+    - If no `test_run_s3` rows exist and the group is still running (some jobs pending) → status = PENDING.
+    - Else (no rows and group completed) → missing/unknown (no event emitted).
+  - Event boundaries (naturally arise from grouping):
+    - Separate events for distinct workflow runs (different `wf_run_id`) on the same commit (regardless of how they were triggered).
+    - Within the same run, separate events for retries via `run_attempt` (name hints like "Attempt #2" are not relied upon).
+
+### Non‑test mapping
+- Similar to test‑track but grouping is coarser (by normalized job base name):
+- For each (run_id, run_attempt, job_base_name) group in the commit
+  - Within each group compute event status:
+    - FAILURE if any row concluded failure.
+    - SUCCESS if all rows concluded success.
+    - PENDING otherwise (some rows pending, none failed).
+  - Emit one event per group. The Signal model supports multiple events per commit.
+  - Results include Signals for (wf, job_base_name) that have at least one FAILURE across commits.
+  - Determine status for each event:
+    - FAILURE if `conclusion_kg = 'failure'` or `conclusion='failure'` with `status='completed'`.
+    - SUCCESS if `conclusion='success'` with `status='completed'`.
+    - PENDING if `status != 'completed'` or `conclusion=''` (keep‑going/pending).
+  - Event boundaries (naturally arise from grouping):
+    - Separate events for distinct workflow runs on the same commit (different `run_id`; trigger type is irrelevant).
+    - Separate events for retries using `run_attempt` within the same run (no string parsing of job names).
+    - Separate events for different normalized job base names.
+
+Example (same commit & workflow):
+
+- wf1 has: `jobX_(shard1, attempt1)`, `jobX_(shard1, attempt2)`, `jobX_(shard2, attempt1)`
+- wf2 (retry) has: `jobX_(shard1, attempt1)`
+
+Aggregation by normalized base `jobX`:
+- event1: group (wf1, attempt1) → rows: `[wf1:jobX_(shard1, attempt1), wf1:jobX_(shard2, attempt1)]`
+- event2: group (wf1, attempt2) → rows: `[wf1:jobX_(shard1, attempt2)]`
+- event3: group (wf2, attempt1) → rows: `[wf2:jobX_(shard1, attempt1)]`
+
+## Module Structure
+
+Create `pytorch_auto_revert/signal_extraction.py` with:
+- `class SignalExtractor` (entry point)
+  - `extract(workflow_names: list[str], hours: int) -> list[Signal]`
+  - Internals:
+    - `_fetch_commits_and_jobs(...) -> list[Commit]` (see data structures below)
+    - `_select_test_track_job_ids(commits) -> (job_ids: List[int], bases_to_track: Set[JobBaseNameKey])`
+    - `_fetch_tests_for_jobs(job_ids) -> List[TestRow]` (s3 only)
+    - `_build_test_signals(commits, test_rows, bases_to_track) -> list[Signal]`
+    - `_build_job_signals(commits) -> list[Signal]`
+- Keep logic small and pure; avoid side effects.
+
+Notes
+- Reuse `normalize_job_name` from `CommitJobs` for non‑test keys.
+- For minimal coupling, do not import the existing autorevert pattern logic here.
+- Prefer dataclass‑like simple structures for intermediate maps (dicts/tuples).
+
+### Indexing & Data Structures
+
+- `JobRow`: a single workflow_job row with fields we need (head_sha, workflow_name, wf_run_id, job_id, run_attempt, name, status, conclusion, started_at, created_at, rule).
+- `JobBaseNameKey`: groups jobs by `(workflow, normalized job base name)`.
+- `Commit`: top-level element with `sha: str` and `jobs: Dict[JobBaseNameKey, List[JobRow]]`.
+  - For each commit, the `List[JobRow]` under every key is ordered by `started_at` (None last).
+  - The extractor returns `List[Commit]` ordered newest→older by push timestamp.
+
+## Implementation Plan
+
+1) Add `signal_extraction.py` with `SignalExtractor` shell and clear method stubs. Keep types simple.
+2) Implement Phase A query in a helper (reuse CHCliFactory). Unit test: query builder emits expected SQL filters.
+3) Implement selectors for test‑track pairs (Python filter on `rule`).
+4) Implement batched Phase B queries:
+   - Use `(workflow_id, job_id) IN array(tuple(...))` to leverage PK prefixes.
+   - call `test_run_s3` to enumerate failing tests
+5) Implement mapping to Signals for both tracks, emitting multiple events per commit as specified.
+6) Add unit tests:
+   - Test‑track: a) failure on one commit; b) success on another; c) unknown/gap.
+   - Non‑test: separate events for main vs restart and for `Attempt #2` retries.
+7) Wire optional extraction invocation from the CLI/tester layer (behind a flag) without touching Signal’s pattern logic.
+
+## Performance Notes
+
+- Keep the window small (16–32h) and deduplicate commits via push timestamps.
+- Limit the batched pairs size; chunk when necessary.
+- Align filters with primary keys:  `job_id` for `test_run_s3`.
+- Avoid scanning all of `workflow_job` by joining to recent pushes and filtering repo/branches.
+
+## Open Questions
+
+- Exact classification list for “test failure” track (start with `pytest failure`, `Python unittest failure`).
+- Whether to include tests that succeeded but were present (for stronger success evidence) vs only failing tests.
+  - A: if a test failure is observed on any commit, that test status is extracted from all commits (success/failure/pending).
+- How to surface shard boundaries for test‑track Signals (usually we just OR across shards at status level).
+  - A: for test track shard boundaries are irrelevant:
+    - when test outcome was recorded, it is extracted as an Event (regardless of shard)
+    - when no outcome was recorded, all shards with the job base name are considered:
+      - when any shard is still running → PENDING
+      - when all shards completed → no event (unknown)
+- Whether to treat known infra classifications as gaps vs ignored (policy TBD).

--- a/aws/lambda/pytorch-auto-revert/SIGNAL_EXTRACTION.md
+++ b/aws/lambda/pytorch-auto-revert/SIGNAL_EXTRACTION.md
@@ -146,11 +146,10 @@ Notes
 
 ### Indexing & Data Structures
 
-- `JobRow`: a single workflow_job row with fields we need (head_sha, workflow_name, wf_run_id, job_id, run_attempt, name, status, conclusion, started_at, created_at, rule).
-- `JobBaseNameKey`: groups jobs by `(workflow, normalized job base name)`.
-- `Commit`: top-level element with `sha: str` and `jobs: Dict[JobBaseNameKey, List[JobRow]]`.
-  - For each commit, the `List[JobRow]` under every key is ordered by `started_at` (None last).
-  - The extractor returns `List[Commit]` ordered newest→older by push timestamp.
+- Strongly-typed ids for clarity (type-checker only), like:
+  - `WfRunId = NewType('WfRunId', int)`
+  - `RunAttempt = NewType('RunAttempt', int)`
+  These are used in the code for readability and to reduce keying mistakes.
 
 ## Implementation Plan
 

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/hud_renderer.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/hud_renderer.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Set, Tuple
+
+from .signal import (
+    AutorevertPattern,
+    RestartCommits,
+    Signal,
+    SignalCommit,
+    SignalEvent,
+    SignalStatus,
+)
+
+
+@dataclass
+class Column:
+    workflow_name: str
+    key: str  # signal key
+    signal: Signal
+
+
+@dataclass
+class GridModel:
+    commits: List[str]  # newest -> older
+    columns: List[Column]
+    # commit sha -> set of highlight classes
+    row_highlights: Dict[str, Set[str]]
+    # (workflow, key) -> human note for detection result
+    column_notes: Dict[Tuple[str, str], str]
+
+
+def collect_commit_order(signals: List[Signal]) -> List[str]:
+    seen: Set[str] = set()
+    ordered: List[str] = []
+    for sig in signals:
+        for c in sig.commits:
+            if c.head_sha not in seen:
+                seen.add(c.head_sha)
+                ordered.append(c.head_sha)
+    return ordered
+
+
+def build_grid_model(signals: List[Signal]) -> GridModel:
+    commits = collect_commit_order(signals)
+    columns = [
+        Column(workflow_name=s.workflow_name, key=s.key, signal=s) for s in signals
+    ]
+
+    row_highlights: Dict[str, Set[str]] = {sha: set() for sha in commits}
+    column_notes: Dict[Tuple[str, str], str] = {}
+
+    # run detection and capture highlights/notes
+    for s in signals:
+        res = s.process_valid_autorevert_pattern()
+        note: Optional[str] = None
+        if isinstance(res, AutorevertPattern):
+            # highlight rows involved in the pattern
+            for sha in res.newer_failing_commits:
+                row_highlights.setdefault(sha, set()).add("hl-newer-fail")
+            row_highlights.setdefault(res.suspected_commit, set()).add("hl-suspected")
+            row_highlights.setdefault(res.older_successful_commit, set()).add(
+                "hl-baseline"
+            )
+            note = (
+                f"Pattern: newer fail {len(res.newer_failing_commits)};"
+                f" suspect {res.suspected_commit[:7]}"
+                f" vs baseline {res.older_successful_commit[:7]}"
+            )
+        elif isinstance(res, RestartCommits):
+            for sha in res.commit_shas:
+                row_highlights.setdefault(sha, set()).add("hl-restart")
+            if res.commit_shas:
+                note = f"Suggest restart: {', '.join(sorted(s[:7] for s in res.commit_shas))}"
+        if note:
+            column_notes[(s.workflow_name, s.key)] = note
+
+    return GridModel(
+        commits=commits,
+        columns=columns,
+        row_highlights=row_highlights,
+        column_notes=column_notes,
+    )
+
+
+def _status_icon(status: SignalStatus) -> str:
+    if status == SignalStatus.FAILURE:
+        return "&#10060;"  # cross mark
+    if status == SignalStatus.SUCCESS:
+        return "&#9989;"  # check mark button
+    return "&#128993;"  # large yellow circle (pending)
+
+
+def _event_title(e: SignalEvent) -> str:
+    return f"{e.name}\n{e.status.value}\nstart={e.started_at.isoformat()}"
+
+
+def _parse_run_id(event_name: str) -> Optional[int]:
+    # event name format: "wf=<wf> kind=<kind> id=<id> run=<wf_run_id> attempt=<n>"
+    try:
+        for part in event_name.split():
+            if part.startswith("run="):
+                return int(part.split("=", 1)[1])
+    except Exception:
+        return None
+    return None
+
+
+def _commit_min_started_at(
+    sha: str, sig_map: Dict[Tuple[str, str], Dict[str, SignalCommit]]
+) -> Optional[str]:
+    """Return minimal started_at (YYYY-mm-dd HH:MM) across all events for this commit, if any."""
+    tmin: Optional[str] = None
+    for m in sig_map.values():
+        commit = m.get(sha)
+        if not commit or not commit.events:
+            continue
+        # events are sorted oldest first inside SignalCommit
+        ts = commit.events[0].started_at.strftime("%Y-%m-%d %H:%M")
+        if tmin is None or ts < tmin:
+            tmin = ts
+    return tmin
+
+
+def render_html(
+    model: GridModel, title: str = "Signal HUD", repo_full_name: str = "pytorch/pytorch"
+) -> str:
+    # Build fast lookup: (workflow,key)-> {sha: SignalCommit}
+    sig_map: Dict[Tuple[str, str], Dict[str, SignalCommit]] = {}
+    for col in model.columns:
+        m: Dict[str, SignalCommit] = {}
+        for c in col.signal.commits:
+            m[c.head_sha] = c
+        sig_map[(col.workflow_name, col.key)] = m
+
+    # HTML + CSS
+    css = """
+    body {
+        font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Arial, sans-serif;
+        margin: 16px;
+    }
+    h1 { font-size: 20px; margin-bottom: 12px; }
+    .legend { margin: 8px 0 16px; font-size: 13px; }
+    .legend span { margin-right: 12px; }
+    table { border-collapse: collapse; width: max-content; }
+    th, td { border: 1px solid #ddd; padding: 6px 8px; vertical-align: top; }
+    th.commit, td.commit {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 12px; }
+    thead th { height: 220px; }
+    .col-wrap { height: 200px; position: relative; }
+    .col-label { position: absolute; bottom: 4px; left: 4px;
+        transform: rotate(-65deg); transform-origin: left bottom; white-space: nowrap; }
+    td.cell { text-align: center; font-size: 14px; }
+    .ev { margin: 0 2px; display: inline-block; }
+    /* simple row highlights */
+    .hl-suspected { background: #fff2cc; }
+    .hl-baseline { background: #e6f7ff; }
+    .hl-newer-fail { background: #fdecea; }
+    .hl-restart { outline: 2px dashed #888; }
+    .notes { margin-top: 12px; font-size: 12px; }
+    """
+
+    html_parts: List[str] = []
+    html_parts.append("<!DOCTYPE html>")
+    html_parts.append(
+        '<html><head><meta charset="utf-8"><title>{}</title>'.format(title)
+    )
+    html_parts.append(f"<style>{css}</style>")
+    html_parts.append("</head><body>")
+    html_parts.append(f"<h1>{title}</h1>")
+    html_parts.append(
+        '<div class="legend">'
+        "<span>&#9989; success</span>"
+        "<span>&#10060; failure</span>"
+        "<span>&#128993; pending</span>"
+        "</div>"
+    )
+
+    # Table header
+    html_parts.append("<table>")
+    html_parts.append("<thead><tr>")
+    html_parts.append('<th class="commit">Commit (min started_at)</th>')
+    for col in model.columns:
+        label = f"{col.workflow_name}:{col.key}"
+        note = model.column_notes.get((col.workflow_name, col.key))
+        title_attr = (note + "\n" if note else "") + label
+        html_parts.append(
+            f"<th><div class=\"col-wrap\"><div class=\"col-label\" "
+            f"title=\"{title_attr.replace('\"', '\'')}\">{label}</div></div></th>"
+        )
+    html_parts.append("</tr></thead>")
+
+    # Rows
+    html_parts.append("<tbody>")
+    # Build fast lookup for body rendering
+    # (workflow,key) -> {sha -> commit}
+    for sha in model.commits:
+        classes = " ".join(sorted(model.row_highlights.get(sha, set())))
+        html_parts.append(f'<tr class="{classes}">')
+        tmin = _commit_min_started_at(sha, sig_map)
+        label = f"{sha} {tmin or ''}".strip()
+        html_parts.append(f'<td class="commit"><code>{label}</code></td>')
+        for col in model.columns:
+            commit = sig_map[(col.workflow_name, col.key)].get(sha)
+            if not commit or not commit.events:
+                html_parts.append('<td class="cell"></td>')
+                continue
+            cell_parts: List[str] = []
+            for e in commit.events:
+                icon = _status_icon(e.status)
+                title_attr = _event_title(e).replace('"', "'")
+                run_id = _parse_run_id(e.name)
+                if run_id is not None:
+                    url = f"https://github.com/{repo_full_name}/actions/runs/{run_id}"
+                    cell_parts.append(
+                        f'<a class="ev" href="{url}" title="{title_attr}" target="_blank" '
+                        f'rel="noopener noreferrer">{icon}</a>'
+                    )
+                else:
+                    cell_parts.append(
+                        f'<span class="ev" title="{title_attr}">{icon}</span>'
+                    )
+            html_parts.append(f"<td class=\"cell\">{''.join(cell_parts)}</td>")
+        html_parts.append("</tr>")
+    html_parts.append("</tbody>")
+    html_parts.append("</table>")
+
+    # Optional, simple notes block (keeps layout simple)
+    if model.column_notes:
+        html_parts.append('<div class="notes"><strong>Notes</strong><ul>')
+        for col in model.columns:
+            note = model.column_notes.get((col.workflow_name, col.key))
+            if not note:
+                continue
+            label = f"{col.workflow_name}:{col.key}"
+            html_parts.append(f"<li><code>{label}</code>: {note}</li>")
+        html_parts.append("</ul></div>")
+
+    html_parts.append("</body></html>")
+    return "".join(html_parts)

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/hud_renderer.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/hud_renderer.py
@@ -242,9 +242,10 @@ def render_html(
         label = f"{col.workflow_name}:{col.key}"
         note = model.column_notes.get((col.workflow_name, col.key))
         title_attr = (note + "\n" if note else "") + label
+        safe_title = title_attr.replace('"', "'")
         html_parts.append(
             f"<th><div class=\"col-wrap\"><div class=\"col-label\" "
-            f"title=\"{title_attr.replace('\"', '\'')}\">{label}</div></div></th>"
+            f"title=\"{safe_title}\">{label}</div></div></th>"
         )
     html_parts.append("</tr>")
     # Row 2: outcomes

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/hud_renderer.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/hud_renderer.py
@@ -75,6 +75,7 @@ def build_grid_model(signals: List[Signal]) -> GridModel:
                 f" suspect {res.suspected_commit[:7]}"
                 f" vs baseline {res.older_successful_commit[:7]}"
             )
+            column_outcomes[(s.workflow_name, s.key)] = "revert"
         elif isinstance(res, RestartCommits):
             for sha in res.commit_shas:
                 cell_highlights.setdefault((s.workflow_name, s.key, sha), set()).add(
@@ -89,9 +90,6 @@ def build_grid_model(signals: List[Signal]) -> GridModel:
                 msg += f" — {res.message}"
             note = msg
             column_outcomes[(s.workflow_name, s.key)] = "ineligible"
-        else:
-            # AutorevertPattern case above
-            column_outcomes[(s.workflow_name, s.key)] = "revert"
         if note:
             column_notes[(s.workflow_name, s.key)] = note
 
@@ -175,7 +173,7 @@ def render_html(
     td.cell { text-align: center; font-size: 14px; }
     .ev { margin: 0 2px; display: inline-block; }
     /* simple row highlights */
-    .hl-suspected { background: #fff2cc; }
+    .hl-suspected { background: #ffd0d0; }
     .hl-baseline { background: #e6f7ff; }
     .hl-newer-fail { background: #fdecea; }
     .hl-restart { outline: 2px dashed #888; }
@@ -192,7 +190,7 @@ def render_html(
     .outcome.open .details { display: block; }
     .outcome .close { float: right; cursor: pointer; color: #666; }
     /* apply highlights to individual cells */
-    td.cell.hl-suspected { background: #fff2cc; }
+    td.cell.hl-suspected { background: #ffd0d0; }
     td.cell.hl-baseline { background: #e6f7ff; }
     td.cell.hl-newer-fail { background: #fdecea; }
     td.cell.hl-restart { outline: 2px dashed #888; outline-offset: -2px; }
@@ -244,8 +242,8 @@ def render_html(
         title_attr = (note + "\n" if note else "") + label
         safe_title = title_attr.replace('"', "'")
         html_parts.append(
-            f"<th><div class=\"col-wrap\"><div class=\"col-label\" "
-            f"title=\"{safe_title}\">{label}</div></div></th>"
+            f'<th><div class="col-wrap"><div class="col-label" '
+            f'title="{safe_title}">{label}</div></div></th>'
         )
     html_parts.append("</tr>")
     # Row 2: outcomes

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/hud_renderer.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/hud_renderer.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional, Set, Tuple
 
 from .signal import (
     AutorevertPattern,
+    Ineligible,
     RestartCommits,
     Signal,
     SignalCommit,
@@ -24,10 +25,12 @@ class Column:
 class GridModel:
     commits: List[str]  # newest -> older
     columns: List[Column]
-    # commit sha -> set of highlight classes
-    row_highlights: Dict[str, Set[str]]
+    # per-cell highlight classes: (workflow, key, sha) -> {classes}
+    cell_highlights: Dict[Tuple[str, str, str], Set[str]]
     # (workflow, key) -> human note for detection result
     column_notes: Dict[Tuple[str, str], str]
+    # (workflow, key) -> outcome tag: 'revert' | 'restart' | 'ineligible'
+    column_outcomes: Dict[Tuple[str, str], str]
 
 
 def collect_commit_order(signals: List[Signal]) -> List[str]:
@@ -47,21 +50,26 @@ def build_grid_model(signals: List[Signal]) -> GridModel:
         Column(workflow_name=s.workflow_name, key=s.key, signal=s) for s in signals
     ]
 
-    row_highlights: Dict[str, Set[str]] = {sha: set() for sha in commits}
+    cell_highlights: Dict[Tuple[str, str, str], Set[str]] = {}
     column_notes: Dict[Tuple[str, str], str] = {}
+    column_outcomes: Dict[Tuple[str, str], str] = {}
 
     # run detection and capture highlights/notes
     for s in signals:
         res = s.process_valid_autorevert_pattern()
         note: Optional[str] = None
         if isinstance(res, AutorevertPattern):
-            # highlight rows involved in the pattern
+            # highlight cells for this signal
             for sha in res.newer_failing_commits:
-                row_highlights.setdefault(sha, set()).add("hl-newer-fail")
-            row_highlights.setdefault(res.suspected_commit, set()).add("hl-suspected")
-            row_highlights.setdefault(res.older_successful_commit, set()).add(
-                "hl-baseline"
-            )
+                cell_highlights.setdefault((s.workflow_name, s.key, sha), set()).add(
+                    "hl-newer-fail"
+                )
+            cell_highlights.setdefault(
+                (s.workflow_name, s.key, res.suspected_commit), set()
+            ).add("hl-suspected")
+            cell_highlights.setdefault(
+                (s.workflow_name, s.key, res.older_successful_commit), set()
+            ).add("hl-baseline")
             note = (
                 f"Pattern: newer fail {len(res.newer_failing_commits)};"
                 f" suspect {res.suspected_commit[:7]}"
@@ -69,17 +77,30 @@ def build_grid_model(signals: List[Signal]) -> GridModel:
             )
         elif isinstance(res, RestartCommits):
             for sha in res.commit_shas:
-                row_highlights.setdefault(sha, set()).add("hl-restart")
+                cell_highlights.setdefault((s.workflow_name, s.key, sha), set()).add(
+                    "hl-restart"
+                )
             if res.commit_shas:
                 note = f"Suggest restart: {', '.join(sorted(s[:7] for s in res.commit_shas))}"
+            column_outcomes[(s.workflow_name, s.key)] = "restart"
+        elif isinstance(res, Ineligible):
+            msg = f"Ineligible: {res.reason.value}"
+            if res.message:
+                msg += f" — {res.message}"
+            note = msg
+            column_outcomes[(s.workflow_name, s.key)] = "ineligible"
+        else:
+            # AutorevertPattern case above
+            column_outcomes[(s.workflow_name, s.key)] = "revert"
         if note:
             column_notes[(s.workflow_name, s.key)] = note
 
     return GridModel(
         commits=commits,
         columns=columns,
-        row_highlights=row_highlights,
+        cell_highlights=cell_highlights,
         column_notes=column_notes,
+        column_outcomes=column_outcomes,
     )
 
 
@@ -159,6 +180,22 @@ def render_html(
     .hl-newer-fail { background: #fdecea; }
     .hl-restart { outline: 2px dashed #888; }
     .notes { margin-top: 12px; font-size: 12px; }
+    /* outcome badges and expanders */
+    .outcome { text-align: center; vertical-align: top; cursor: pointer; min-width: 80px; }
+    .badge { display: inline-block; padding: 2px 6px; border-radius: 3px; font-size: 11px;
+     font-weight: 600; border: 1px solid transparent; }
+    .badge-revert { background: #fee; color: #a40000; border-color: #f8b4b4; }
+    .badge-restart { background: #fff3bf; color: #7a5a00; border-color: #ffe08a; }
+    .badge-ineligible { background: #eee; color: #555; border-color: #ccc; }
+    .outcome .details { display: none; margin-top: 6px;
+        background: #fafafa; border: 1px solid #ddd; padding: 6px; text-align: left; font-size: 12px; }
+    .outcome.open .details { display: block; }
+    .outcome .close { float: right; cursor: pointer; color: #666; }
+    /* apply highlights to individual cells */
+    td.cell.hl-suspected { background: #fff2cc; }
+    td.cell.hl-baseline { background: #e6f7ff; }
+    td.cell.hl-newer-fail { background: #fdecea; }
+    td.cell.hl-restart { outline: 2px dashed #888; outline-offset: -2px; }
     """
 
     html_parts: List[str] = []
@@ -167,6 +204,24 @@ def render_html(
         '<html><head><meta charset="utf-8"><title>{}</title>'.format(title)
     )
     html_parts.append(f"<style>{css}</style>")
+    # lightweight JS for single-open expander behavior
+    html_parts.append(
+        "<script>\n"
+        "let __openOutcome = null;\n"
+        "function toggleOutcome(id){\n"
+        "  const el = document.getElementById(id);\n"
+        "  if(!el) return;\n"
+        "  if(__openOutcome && __openOutcome !== id){\n"
+        "    const prev = document.getElementById(__openOutcome);\n"
+        "    if(prev) prev.classList.remove('open');\n"
+        "    __openOutcome = null;\n"
+        "  }\n"
+        "  const willOpen = !el.classList.contains('open');\n"
+        "  el.classList.toggle('open');\n"
+        "  __openOutcome = willOpen ? id : null;\n"
+        "}\n"
+        "</script>"
+    )
     html_parts.append("</head><body>")
     html_parts.append(f"<h1>{title}</h1>")
     html_parts.append(
@@ -179,7 +234,9 @@ def render_html(
 
     # Table header
     html_parts.append("<table>")
-    html_parts.append("<thead><tr>")
+    html_parts.append("<thead>")
+    # Row 1: titles
+    html_parts.append("<tr>")
     html_parts.append('<th class="commit">Commit (min started_at)</th>')
     for col in model.columns:
         label = f"{col.workflow_name}:{col.key}"
@@ -189,22 +246,55 @@ def render_html(
             f"<th><div class=\"col-wrap\"><div class=\"col-label\" "
             f"title=\"{title_attr.replace('\"', '\'')}\">{label}</div></div></th>"
         )
-    html_parts.append("</tr></thead>")
+    html_parts.append("</tr>")
+    # Row 2: outcomes
+    html_parts.append("<tr>")
+    html_parts.append('<th class="commit">Outcome</th>')
+    for idx, col in enumerate(model.columns):
+        key = (col.workflow_name, col.key)
+        outcome = model.column_outcomes.get(key, "ineligible")
+        note = model.column_notes.get(key, "")
+        rid = f"oc-{idx}"
+        if outcome == "revert":
+            badge = '<span class="badge badge-revert">REV</span>'
+        elif outcome == "restart":
+            badge = '<span class="badge badge-restart">RST</span>'
+        else:
+            badge = '<span class="badge badge-ineligible">N/A</span>'
+        html_parts.append(
+            f'<th id="{rid}" class="outcome" onclick="toggleOutcome(\'{rid}\')" title="Click to expand">'
+            f"{badge}"
+            f'<div class="details"><span class="close" onclick="toggleOutcome(\'{rid}\'); '
+            f'event.stopPropagation();">×</span>'
+            f"<div><strong>{col.workflow_name}:{col.key}</strong></div>"
+            f"<div>{note}</div>"
+            f"</div>"
+            f"</th>"
+        )
+    html_parts.append("</tr>")
+    html_parts.append("</thead>")
 
     # Rows
     html_parts.append("<tbody>")
     # Build fast lookup for body rendering
     # (workflow,key) -> {sha -> commit}
     for sha in model.commits:
-        classes = " ".join(sorted(model.row_highlights.get(sha, set())))
-        html_parts.append(f'<tr class="{classes}">')
+        html_parts.append("<tr>")
         tmin = _commit_min_started_at(sha, sig_map)
         label = f"{sha} {tmin or ''}".strip()
         html_parts.append(f'<td class="commit"><code>{label}</code></td>')
         for col in model.columns:
             commit = sig_map[(col.workflow_name, col.key)].get(sha)
             if not commit or not commit.events:
-                html_parts.append('<td class="cell"></td>')
+                # still apply cell-level highlight (e.g., suspected baseline without explicit events)
+                cell_cls = " ".join(
+                    sorted(
+                        model.cell_highlights.get(
+                            (col.workflow_name, col.key, sha), set()
+                        )
+                    )
+                )
+                html_parts.append(f'<td class="cell {cell_cls}"></td>')
                 continue
             cell_parts: List[str] = []
             for e in commit.events:
@@ -221,21 +311,19 @@ def render_html(
                     cell_parts.append(
                         f'<span class="ev" title="{title_attr}">{icon}</span>'
                     )
-            html_parts.append(f"<td class=\"cell\">{''.join(cell_parts)}</td>")
+            cell_cls = " ".join(
+                sorted(
+                    model.cell_highlights.get((col.workflow_name, col.key, sha), set())
+                )
+            )
+            html_parts.append(
+                f"<td class=\"cell {cell_cls}\">{''.join(cell_parts)}</td>"
+            )
         html_parts.append("</tr>")
     html_parts.append("</tbody>")
     html_parts.append("</table>")
 
-    # Optional, simple notes block (keeps layout simple)
-    if model.column_notes:
-        html_parts.append('<div class="notes"><strong>Notes</strong><ul>')
-        for col in model.columns:
-            note = model.column_notes.get((col.workflow_name, col.key))
-            if not note:
-                continue
-            label = f"{col.workflow_name}:{col.key}"
-            html_parts.append(f"<li><code>{label}</code>: {note}</li>")
-        html_parts.append("</ul></div>")
+    # Notes removed as they are available via per-signal outcome expanders
 
     html_parts.append("</body></html>")
     return "".join(html_parts)

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/job_agg_index.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/job_agg_index.py
@@ -78,8 +78,8 @@ class JobMeta:
 # -------------------------------------------------------------------
 
 KeyT = TypeVar("KeyT", bound=Hashable)
-K2 = TypeVar("K2", bound=Hashable)  # for enumerate() alternate grouping
-K3 = TypeVar("K3", bound=Hashable)  # for enumerate_keys()
+K2 = TypeVar("K2", bound=Hashable)  # for group_keys_by() alternate grouping
+K3 = TypeVar("K3", bound=Hashable)  # for group_map_values_by()
 
 
 class JobAggIndex(Generic[KeyT]):
@@ -181,7 +181,7 @@ class JobAggIndex(Generic[KeyT]):
         self._meta_cache[key] = meta
         return meta
 
-    def enumerate_keys(
+    def group_map_values_by(
         self, key_fn: Callable[[JobRow], K2], value_fn: Callable[[JobRow], K3]
     ) -> DefaultDict[K2, List[K3]]:
         """
@@ -190,7 +190,7 @@ class JobAggIndex(Generic[KeyT]):
         first appearance order within each bucket.
 
         Example (job ids grouped by (sha, workflow, base)):
-            groups = idx.enumerate_keys(
+            groups = idx.group_map_values_by(
                 key_fn=lambda r: (r.head_sha, r.workflow_name, base_name_fn(r.name)),
                 value_fn=lambda r: r.job_id,
             )
@@ -211,17 +211,19 @@ class JobAggIndex(Generic[KeyT]):
 
     # ---- Alternate grouping (generic enumeration) ----
 
-    def enumerate(self, key_fn: Callable[[JobRow], K2]) -> DefaultDict[K2, List[KeyT]]:
+    def group_keys_by(
+        self, key_fn: Callable[[JobRow], K2]
+    ) -> DefaultDict[K2, List[KeyT]]:
         """
         Build an alternate grouping (K2 -> [KeyT]) on demand.
 
         Each K2 bucket collects unique KeyT values in the order of their
-        **first appearance** in the original input. A given KeyT appears at most
+        first appearance in the original input. A given KeyT appears at most
         once per bucket.
 
         Example: attempts grouped by (sha, workflow, base):
 
-            groups = idx.enumerate(
+            groups = idx.group_keys_by(
                 lambda r: (r.head_sha, r.workflow_name, base_name_fn(r.name))
             )
             attempt_keys: list[AttemptKey] = groups[(sha, wf_name, base_name)]

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/job_agg_index.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/job_agg_index.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import (
+    Callable,
+    DefaultDict,
+    Dict,
+    Generic,
+    Hashable,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+)
+
+from .signal_extraction_types import JobRow
+
+
+class SignalStatus(Enum):
+    FAILURE = "failure"
+    SUCCESS = "success"
+    PENDING = "pending"
+
+
+@dataclass(frozen=True)
+class JobMeta:
+    """
+    Group-level aggregation over one or more JobRow records.
+    """
+
+    started_at: Optional[datetime] = None
+    is_pending: bool = False
+    is_cancelled: bool = False
+    has_failures: bool = False
+    all_completed_success: bool = False
+    has_non_test_failures: bool = False
+
+    @property
+    def status(self) -> Optional[SignalStatus]:
+        """
+        - canceled -> treat as 'missing' (None)
+        - any_failure -> FAILURE
+        - all_completed_success -> SUCCESS
+        - else -> PENDING
+        """
+        if self.is_cancelled:
+            return None
+        if self.has_failures:
+            return SignalStatus.FAILURE
+        if self.all_completed_success:
+            return SignalStatus.SUCCESS
+        return SignalStatus.PENDING
+
+
+# -------------------------------------------------------------------
+# Generic, typed index keyed by a single typed KeyT
+# -------------------------------------------------------------------
+
+KeyT = TypeVar("KeyT", bound=Hashable)
+K2 = TypeVar("K2", bound=Hashable)  # for enumerate() alternate grouping
+K3 = TypeVar("K3", bound=Hashable)  # for enumerate_keys()
+
+
+class JobAggIndex(Generic[KeyT]):
+    """
+    Generic, strongly typed index over JobRow records using a single key type.
+
+    Build via:
+        idx = JobAggIndex.from_rows(
+            rows,
+            key_fn=lambda row: AttemptKey(
+                sha=row.head_sha,
+                workflow_name=row.workflow_name,
+                job_base_name=base_name_fn(row.name),
+                wf_run_id=row.wf_run_id,
+                run_attempt=row.run_attempt,
+            ),
+        )
+    """
+
+    def __init__(
+        self,
+        *,
+        groups: Dict[KeyT, List[JobRow]],
+        ordered_pairs: List[Tuple[KeyT, JobRow]],
+    ) -> None:
+        # `groups` is a dict built in key-first-seen order; Python dict preserves insertion order.
+        self._groups: Dict[KeyT, List[JobRow]] = groups
+        # Global, original row order, paired with its group key.
+        self._ordered: List[Tuple[KeyT, JobRow]] = ordered_pairs
+        self._meta_cache: Dict[KeyT, JobMeta] = {}
+
+    @classmethod
+    def from_rows(
+        cls,
+        rows: Iterable[JobRow],
+        *,
+        key_fn: Callable[[JobRow], KeyT],
+    ) -> JobAggIndex[KeyT]:
+        """
+        Group directly from JobRow—no intermediary structs.
+        All order-sensitive structures are derived from the input iteration order.
+        """
+        grouped: Dict[KeyT, List[JobRow]] = {}
+        ordered_pairs: List[Tuple[KeyT, JobRow]] = []
+
+        for r in rows:
+            k = key_fn(r)
+            # Preserve first-seen key order
+            if k not in grouped:
+                grouped[k] = []
+            grouped[k].append(r)  # preserves per-key row order
+            ordered_pairs.append((k, r))  # preserves global row order
+
+        return cls(groups=grouped, ordered_pairs=ordered_pairs)
+
+    # ---- Query API ----
+
+    def keys(self) -> Iterator[KeyT]:
+        # Iterates in first-seen key order by construction
+        return iter(self._groups.keys())
+
+    def has(self, key: KeyT) -> bool:
+        return key in self._groups
+
+    def rows(self, key: KeyT) -> List[JobRow]:
+        # Per-key rows appear in the same order as the input iterable
+        return self._groups[key]
+
+    def get_stats(self, key: KeyT, default: Optional[JobMeta] = None) -> JobMeta:
+        if key in self._groups:
+            return self.stats(key)
+        if default is not None:
+            return default
+        # neutral meta
+        return JobMeta()
+
+    def stats(self, key: KeyT) -> JobMeta:
+        if key in self._meta_cache:
+            return self._meta_cache[key]
+        if key not in self._groups:
+            raise KeyError(key)
+        jrows = self._groups[key]
+
+        # Inline aggregations (only used here)
+        started_at: Optional[datetime]
+        times = [r.started_at for r in jrows if r.started_at is not None]
+        started_at = min(times) if times else None
+
+        is_pending = any(r.is_pending for r in jrows)
+        is_cancelled = any(r.is_cancelled for r in jrows)
+        has_failures = any(r.is_failure for r in jrows)
+        all_completed_success = all(r.is_success for r in jrows)
+        has_non_test_failures = any(
+            (r.is_failure and not r.is_test_failure) for r in jrows
+        )
+
+        meta = JobMeta(
+            started_at=started_at,
+            is_pending=is_pending,
+            is_cancelled=is_cancelled,
+            has_failures=has_failures,
+            all_completed_success=all_completed_success,
+            has_non_test_failures=has_non_test_failures,
+        )
+        self._meta_cache[key] = meta
+        return meta
+
+    def enumerate_keys(
+        self, key_fn: Callable[[JobRow], K2], value_fn: Callable[[JobRow], K3]
+    ) -> DefaultDict[K2, List[K3]]:
+        """
+        Convenience wrapper around enumerate() to directly extract distinct mapped values.
+
+        Each K2 bucket collects unique K3 values in the order of their **first appearance**
+        in the original input. A given K3 appears at most once per bucket.
+
+        Example: job ids grouped by (sha, workflow, base):
+            groups = idx.enumerate_keys(
+                key_fn=lambda r: (r.head_sha, r.workflow_name, base_name_fn(r.name)),
+                value_fn=lambda r: r.job_id,
+            )
+            job_ids: list[JobId] = groups[(sha, wf_name, base_name)]
+
+        """
+        full = self.enumerate(key_fn)
+        out: DefaultDict[K2, List[K3]] = defaultdict(list)
+        for k2, rows in full.items():
+            seen: set[K3] = set()
+            for r in rows:
+                v3 = value_fn(r)
+                if v3 not in seen:
+                    out[k2].append(v3)
+                    seen.add(v3)
+        return out
+
+    # ---- Alternate grouping (generic enumeration) ----
+
+    def enumerate(self, key_fn: Callable[[JobRow], K2]) -> DefaultDict[K2, List[KeyT]]:
+        """
+        Build an alternate grouping (K2 -> [KeyT]) on demand.
+
+        Each K2 bucket collects unique KeyT values in the order of their
+        **first appearance** in the original input. A given KeyT appears at most
+        once per bucket.
+
+        Example: attempts grouped by (sha, workflow, base):
+
+            groups = idx.enumerate(
+                lambda r: (r.head_sha, r.workflow_name, base_name_fn(r.name))
+            )
+            attempt_keys: list[AttemptKey] = groups[(sha, wf_name, base_name)]
+        """
+        out: DefaultDict[K2, List[KeyT]] = defaultdict(list)
+        seen_per_bucket: Dict[K2, set[KeyT]] = {}
+
+        for key, row in self._ordered:  # respects original global order
+            k2 = key_fn(row)
+            bucket_seen = seen_per_bucket.setdefault(k2, set())
+            if key not in bucket_seen:
+                out[k2].append(key)
+                bucket_seen.add(key)
+
+        return out
+
+    # (Aggregation helpers removed; logic is inlined in stats())

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
@@ -38,9 +38,11 @@ class SignalExtractor:
         self,
         workflows: Iterable[str],
         lookback_hours: int = 24,
+        repo_full_name: str = "pytorch/pytorch",
     ) -> None:
         self.workflows = list(workflows)
         self.lookback_hours = lookback_hours
+        self.repo_full_name = repo_full_name
         # Datasource for DB access
         self._datasource = SignalExtractionDatasource()
 
@@ -62,7 +64,9 @@ class SignalExtractor:
     def extract(self) -> List[Signal]:
         """Extract Signals for configured workflows within the lookback window."""
         jobs = self._datasource.fetch_jobs_for_workflows(
-            workflows=self.workflows, lookback_hours=self.lookback_hours
+            repo_full_name=self.repo_full_name,
+            workflows=self.workflows,
+            lookback_hours=self.lookback_hours,
         )
 
         # Select jobs to participate in test-track details fetch

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
@@ -8,69 +8,23 @@ Transforms raw workflow/job/test data into Signal objects used by signal.py.
 """
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
-from typing import Any, Dict, Iterable, List, NewType, Optional, Set, Tuple
+from datetime import datetime
+from typing import Dict, Iterable, List, Set, Tuple
 
-from .autorevert_checker import CommitJobs
-from .clickhouse_client_helper import CHCliFactory
+from .job_agg_index import JobAggIndex, JobMeta, SignalStatus as AggStatus
 from .signal import Signal, SignalCommit, SignalEvent, SignalStatus
-
-
-# Default classification rules that indicate test failures.
-DEFAULT_TEST_RULES: Set[str] = {
-    "pytest failure",
-    "Python unittest failure",
-}
-
-# Stronger typing for ids (type-checker only; runtime is still int/str)
-WfRunId = NewType("WfRunId", int)
-RunAttempt = NewType("RunAttempt", int)
-JobId = NewType("JobId", int)
-Sha = NewType("Sha", str)
-WorkflowName = NewType("WorkflowName", str)
-JobName = NewType("JobName", str)
-JobBaseName = NewType("JobBaseName", str)
-TestId = NewType("TestId", str)
-
-
-@dataclass(frozen=True)
-class JobRow:
-    head_sha: Sha
-    workflow_name: WorkflowName
-    wf_run_id: WfRunId
-    job_id: JobId
-    run_attempt: RunAttempt
-    name: JobName
-    status: str
-    conclusion: str
-    started_at: Optional[datetime]
-    created_at: Optional[datetime]
-    rule: str
-
-
-@dataclass(frozen=True)
-class TestRow:
-    job_id: JobId
-    wf_run_id: WfRunId
-    workflow_run_attempt: RunAttempt
-    file: str
-    classname: str
-    name: str
-    failing: int  # 0/1
-    errored: int  # 0/1
-
-    @property
-    def test_id(self) -> TestId:
-        # file::name is a stable, readable key; classname can be added if needed
-        test_key = f"{self.file}::{self.name}" if self.file else self.name
-        return TestId(test_key)
-
-
-@dataclass
-class Commit:
-    sha: Sha
-    # Map of (workflow, job_base_name) -> ordered JobRow list (by started_at)
-    jobs: Dict[Tuple[WorkflowName, JobBaseName], List[JobRow]]
+from .signal_extraction_datasource import SignalExtractionDatasource
+from .signal_extraction_types import (
+    JobBaseName,
+    JobId,
+    JobRow,
+    RunAttempt,
+    Sha,
+    TestId,
+    TestRow,
+    WfRunId,
+    WorkflowName,
+)
 
 
 @dataclass(frozen=True)
@@ -84,18 +38,11 @@ class SignalExtractor:
         self,
         workflows: Iterable[str],
         lookback_hours: int = 24,
-        test_rules: Optional[Set[str]] = None,
     ) -> None:
         self.workflows = list(workflows)
         self.lookback_hours = lookback_hours
-        self.test_rules = (
-            set(test_rules) if test_rules is not None else set(DEFAULT_TEST_RULES)
-        )
-        # Helper instance to reuse normalization logic
-        self._norm_dummy = CommitJobs(head_sha="_", created_at=datetime.now(), jobs=[])
-
-    def _norm(self, name: str) -> str:
-        return self._norm_dummy.normalize_job_name(name or "")
+        # Datasource for DB access
+        self._datasource = SignalExtractionDatasource()
 
     def _fmt_event_name(
         self,
@@ -110,406 +57,253 @@ class SignalExtractor:
         return f"wf={workflow} kind={kind} id={identifier} run={wf_run_id} attempt={run_attempt}"
 
     # -----------------------------
-    # Small helpers (readability / reuse)
-    # -----------------------------
-    @staticmethod
-    def _earliest_started_at(rows: List[JobRow]) -> datetime:
-        """Earliest non-null started_at among rows; datetime.min if none present."""
-        return min((r.started_at for r in rows if r.started_at is not None), default=datetime.min)
-
-    @staticmethod
-    def _any_pending(rows: List[JobRow]) -> bool:
-        """True if any row has a non-completed status."""
-        return any(((r.status or "").lower() != "completed") for r in rows)
-
-    @staticmethod
-    def _any_canceled(rows: List[JobRow]) -> bool:
-        """True if any row concluded as cancelled (DB uses 'cancelled')."""
-        return any(((r.conclusion or "").lower() == "cancelled") for r in rows)
-
-    @staticmethod
-    def _any_failure(rows: List[JobRow]) -> bool:
-        """True if any row concluded as failure."""
-        return any(((r.conclusion or "").lower() == "failure") for r in rows)
-
-    @staticmethod
-    def _all_completed_success(rows: List[JobRow]) -> bool:
-        """True if all rows concluded as success and are completed."""
-        return all(
-            ((r.conclusion or "").lower() == "success") and ((r.status or "").lower() == "completed")
-            for r in rows
-        )
-
-    # -----------------------------
     # Public API
     # -----------------------------
     def extract(self) -> List[Signal]:
         """Extract Signals for configured workflows within the lookback window."""
-        commits = self._fetch_commits_and_jobs()
+        jobs = self._datasource.fetch_jobs_for_workflows(
+            workflows=self.workflows, lookback_hours=self.lookback_hours
+        )
 
         # Select jobs to participate in test-track details fetch
-        test_track_job_ids, bases_to_track = self._select_test_track_job_ids(commits)
-        test_rows = self._fetch_tests_for_jobs(test_track_job_ids)
+        test_track_job_ids = self._select_test_track_job_ids(jobs)
+        test_rows = self._datasource.fetch_tests_for_job_ids(test_track_job_ids)
 
-        test_signals = self._build_test_signals(commits, test_rows, bases_to_track)
-        job_signals = self._build_non_test_signals(commits)
+        test_signals = self._build_test_signals(jobs, test_rows)
+        job_signals = self._build_non_test_signals(jobs)
         return test_signals + job_signals
-
-    # -----------------------------
-    # Phase A — Jobs
-    # -----------------------------
-    def _fetch_commits_and_jobs(self) -> List[Commit]:
-        """
-        Fetch workflow jobs for recent main commits plus any other workflow runs for those commits
-        (including dispatches). Returns mapping (workflow_name, head_sha) -> list of _JobRow
-        ordered by started_at (None last) for stable event ordering.
-        """
-        lookback_time = datetime.now() - timedelta(hours=self.lookback_hours)
-
-        workflow_filter = ""
-        params: Dict[str, Any] = {"lookback_time": lookback_time}
-        if self.workflows:
-            workflow_filter = "AND wf.workflow_name IN {workflows:Array(String)}"
-            params["workflows"] = self.workflows
-
-        query = f"""
-        WITH push_dedup AS (
-            SELECT head_commit.id AS sha, max(head_commit.timestamp) AS ts
-            FROM default.push
-            WHERE head_commit.timestamp >= {{lookback_time:DateTime}}
-              AND ref = 'refs/heads/main'
-            GROUP BY sha
-        )
-        SELECT
-            wf.head_sha,
-            wf.workflow_name,
-            wf.id AS job_id,
-            wf.run_id,
-            wf.run_attempt,
-            wf.name,
-            wf.status,
-            if(wf.conclusion = '' AND
-                tupleElement(wf.torchci_classification_temp,'line') != '', 'failure', wf.conclusion)
-                AS conclusion_kg,
-            wf.started_at,
-            wf.created_at,
-            tupleElement(wf.torchci_classification_kg,'rule') AS rule
-        FROM default.workflow_job AS wf FINAL
-        INNER JOIN push_dedup p ON wf.head_sha = p.sha
-        WHERE wf.dynamoKey LIKE 'pytorch/pytorch/%'
-          AND wf.created_at >= {{lookback_time:DateTime}}
-          {workflow_filter}
-        ORDER BY p.ts DESC, wf.head_sha, wf.run_id, wf.run_attempt, wf.name, wf.started_at
-        """
-
-        res = CHCliFactory().client.query(query, parameters=params)
-        commits: List[Commit] = []
-        current_sha: Optional[Sha] = None
-        current_jobs: Dict[Tuple[WorkflowName, JobBaseName], List[JobRow]] = {}
-
-        def flush_current():
-            if current_sha is not None:
-                # sort each job list by started_at for stable event ordering
-                for lst in current_jobs.values():
-                    lst.sort(
-                        key=lambda r: (r.started_at is None, r.started_at, r.job_id)
-                    )
-                commits.append(Commit(sha=current_sha, jobs=dict(current_jobs)))
-
-        for (
-            head_sha,
-            workflow_name,
-            job_id,
-            run_id,
-            run_attempt,
-            name,
-            status,
-            conclusion,
-            started_at,
-            created_at,
-            rule,
-        ) in res.result_rows:
-            # boundary by head_sha – rows are ordered by push ts desc, head_sha grouping
-            if current_sha is None:
-                current_sha = Sha(head_sha)
-            elif Sha(head_sha) != current_sha:
-                flush_current()
-                current_sha = Sha(head_sha)
-                current_jobs = {}
-
-            k: Tuple[WorkflowName, JobBaseName] = (
-                WorkflowName(workflow_name),
-                (JobBaseName(self._norm(name))),
-            )
-            current_jobs.setdefault(k, []).append(
-                JobRow(
-                    head_sha=current_sha,
-                    workflow_name=WorkflowName(workflow_name),
-                    wf_run_id=WfRunId(int(run_id)),
-                    job_id=JobId(int(job_id)),
-                    run_attempt=RunAttempt(int(run_attempt)),
-                    name=JobName(str(name or "")),
-                    status=str(status or ""),
-                    conclusion=str(conclusion or ""),
-                    started_at=started_at,
-                    created_at=created_at,
-                    rule=str(rule or ""),
-                )
-            )
-
-        flush_current()
-        return commits
 
     # -----------------------------
     # Phase B — Tests (test_run_s3 only)
     # -----------------------------
-    def _select_test_track_job_ids(
-        self, commits: List[Commit]
-    ) -> Tuple[List[JobId], Set[Tuple[WorkflowName, JobBaseName]]]:
+    def _select_test_track_job_ids(self, jobs: List[JobRow]) -> List[JobId]:
         """
         Select job_ids for the test-track batch fetch.
 
         Strategy:
-        1) Identify normalized job base names for jobs that exhibited test-related classifications anywhere in the window.
+        1) Identify normalized job base names for jobs that exhibited test-related classifications anywhere
+            in the window.
         2) Include ALL jobs across all commits whose normalized job base name is in that set
             (to capture successes or pendings on other commits).
         """
-        # Helper for normalization (reuse CommitJobs implementation)
-        bases_to_track: Set[Tuple[WorkflowName, JobBaseName]] = set()
-        for commit in commits:
-            for key, rows in commit.jobs.items():
-                for j in rows:
-                    if j.rule and j.rule in self.test_rules:
-                        bases_to_track.add(key)
-                        break
+        bases_to_track: Set[Tuple[WorkflowName, JobBaseName]] = {
+            (j.workflow_name, j.base_name) for j in jobs if j.rule and j.is_test_failure
+        }
 
         if not bases_to_track:
-            return [], set()
-
-        job_ids: List[JobId] = []
-        seen: Set[JobId] = set()
-        for commit in commits:
-            for base_key, rows in commit.jobs.items():
-                if base_key in bases_to_track:
-                    for j in rows:
-                        if j.job_id not in seen:
-                            seen.add(j.job_id)
-                            job_ids.append(j.job_id)
-        return job_ids, bases_to_track
-
-    def _fetch_tests_for_jobs(self, job_ids: List[JobId]) -> List[TestRow]:
-        if not job_ids:
             return []
 
-        rows: List[TestRow] = []
-        # Chunk to avoid very large IN lists
-        TEST_FETCH_CHUNK = 300
-        for start in range(0, len(job_ids), TEST_FETCH_CHUNK):
-            chunk = job_ids[start : start + TEST_FETCH_CHUNK]
-            res = CHCliFactory().client.query(
-                """
-                SELECT job_id, workflow_id, workflow_run_attempt, file, classname, name,
-                       max(failure_count > 0) AS failing,
-                       max(error_count  > 0) AS errored
-                FROM default.test_run_s3
-                WHERE job_id IN {job_ids:Array(Int64)}
-                GROUP BY job_id, workflow_id, workflow_run_attempt, file, classname, name
-                """,
-                parameters={"job_ids": [int(j) for j in chunk]},
-            )
-            for r in res.result_rows:
-                rows.append(
-                    TestRow(
-                        job_id=JobId(int(r[0])),
-                        wf_run_id=WfRunId(int(r[1])),
-                        workflow_run_attempt=RunAttempt(int(r[2])),
-                        file=str(r[3] or ""),
-                        classname=str(r[4] or ""),
-                        name=str(r[5] or ""),
-                        failing=int(r[6] or 0),
-                        errored=int(r[7] or 0),
-                    )
-                )
-        return rows
+        job_ids = {
+            j.job_id for j in jobs if (j.workflow_name, j.base_name) in bases_to_track
+        }
+
+        return list(job_ids)
 
     # -----------------------------
     # Build Signals
     # -----------------------------
     def _build_test_signals(
         self,
-        commits: List[Commit],
+        jobs: List[JobRow],
         test_rows: List[TestRow],
-        bases_to_track: Set[Tuple[WorkflowName, JobBaseName]],
     ) -> List[Signal]:
         """Build per-test Signals across commits, scoped to job base.
 
         We index `default.test_run_s3` rows per (wf_run_id, run_attempt, job_base) and collect
-        which base(s) (by normalized job name) a test appears in. For each commit and (workflow, base), we compute attempt
-        metadata (pending/completed, start time). Then, for tests that failed at least once in
+        which base(s) (by normalized job name) a test appears in. For each commit and (workflow, base),
+        we compute attempt metadata (pending/completed, start time). Then, for tests that failed at least once in
         that base, we emit events per commit/attempt:
           - If test_run_s3 rows exist → FAILURE if any failing/errored else SUCCESS
           - Else if group pending → PENDING
           - Else → no event (missing)
         """
 
-        # Map job_id -> (commit_sha, base key) for fast base resolution
-        @dataclass(frozen=True)
-        class JobLoc:
-            sha: Sha
-            base: Tuple[WorkflowName, JobBaseName]
+        commits_shas = {j.head_sha for j in jobs}
+        jobs_by_id = {j.job_id: j for j in jobs}
 
-        job_loc: Dict[JobId, JobLoc] = {}
-        # Keyed by (commit sha, workflow name, job base name) → list of attempts
-        attempts_by_commit_base: Dict[
-            Tuple[Sha, WorkflowName, JobBaseName], List[Tuple[WfRunId, RunAttempt]]
-        ] = {}
+        index_by_commit_job_base_wf_run_attempt: JobAggIndex[
+            Tuple[Sha, WorkflowName, JobBaseName, WfRunId, RunAttempt]
+        ] = JobAggIndex.from_rows(
+            jobs,
+            key_fn=lambda j: (
+                j.head_sha,
+                j.workflow_name,
+                j.base_name,
+                j.wf_run_id,
+                j.run_attempt,
+            ),
+        )
 
-        @dataclass(frozen=True)
-        class GroupMeta:
-            """Per (commit, base, attempt) metadata used to derive event status.
+        run_ids_attempts = index_by_commit_job_base_wf_run_attempt.enumerate_keys(
+            key_fn=lambda j: (j.head_sha, j.workflow_name, j.base_name),
+            value_fn=lambda j: (j.wf_run_id, j.run_attempt),
+        )
 
-            - started_at: earliest start time among rows in the group (for ordering)
-            - pending: at least one row in the group is not completed
-            - canceled: at least one row concluded as cancelled; group is treated as missing signal
-            """
-
-            started_at: Optional[datetime]
-            pending: bool
-            canceled: bool
-
-        # Keyed by (sha, workflow, base, wf_run_id, run_attempt)
-        group_meta: Dict[
-            Tuple[Sha, WorkflowName, JobBaseName, WfRunId, RunAttempt], GroupMeta
-        ] = {}
-
-        for c in commits:
-            for (wf_name, base_name), rows in c.jobs.items():
-                base_key = (wf_name, base_name)
-                if base_key not in bases_to_track:
-                    continue
-                by_attempt: Dict[Tuple[WfRunId, RunAttempt], List[JobRow]] = {}
-                for j in rows:
-                    job_loc[j.job_id] = JobLoc(c.sha, base_key)
-                    by_attempt.setdefault((j.wf_run_id, j.run_attempt), []).append(j)
-
-                for (wf_run_id, run_attempt), grows in by_attempt.items():
-                    group_meta[(c.sha, wf_name, base_name, wf_run_id, run_attempt)] = GroupMeta(
-                        started_at=(self._earliest_started_at(grows)), pending=(self._any_pending(grows)),
-                        canceled=(self._any_canceled(grows))
-                    )
-                    attempts_by_commit_base.setdefault((c.sha, wf_name, base_name), []).append(
-                        (wf_run_id, run_attempt)
-                    )
-
-        # Index test_run_s3 rows per (commit, base, attempt) and collect base-scoped failing tests
+        # Index test_run_s3 rows per (commit, job_base, wf_run, attempt, test_id) and collect base-scoped failing tests
         tests_by_group_attempt: Dict[
-            Tuple[Sha, WorkflowName, JobBaseName, WfRunId, RunAttempt],
-            Dict[TestId, TestOutcome],
+            Tuple[Sha, WorkflowName, JobBaseName, WfRunId, RunAttempt, TestId],
+            TestOutcome,
         ] = {}
-        failing_tests_by_base: Dict[Tuple[WorkflowName, JobBaseName], Set[TestId]] = {}
+        failing_tests_by_job_base_name: Set[
+            Tuple[WorkflowName, JobBaseName, TestId]
+        ] = set()
         for tr in test_rows:
-            loc = job_loc.get(tr.job_id)
-            if not loc:
-                continue
-            wf_name, base_name = loc.base
-            key = (loc.sha, wf_name, base_name, tr.wf_run_id, tr.workflow_run_attempt)
-            d = tests_by_group_attempt.setdefault(key, {})
-            prev = d.get(tr.test_id)
+            job = jobs_by_id.get(tr.job_id)
+            job_base_name = job.base_name
+            key = (
+                job.head_sha,
+                job.workflow_name,
+                job_base_name,
+                tr.wf_run_id,
+                tr.workflow_run_attempt,
+                tr.test_id,
+            )
+            prev = tests_by_group_attempt.get(key)
             outcome = TestOutcome(
                 failing=(prev.failing if prev else False) or bool(tr.failing),
                 errored=(prev.errored if prev else False) or bool(tr.errored),
             )
-            d[tr.test_id] = outcome
+            tests_by_group_attempt[key] = outcome
             if outcome.failing or outcome.errored:
-                failing_tests_by_base.setdefault(loc.base, set()).add(tr.test_id)
+                failing_tests_by_job_base_name.add(
+                    (job.workflow_name, job_base_name, tr.test_id)
+                )
 
-        # Emit per (workflow, base, test) across commits
+        # Emit signals per (workflow, jobs_base_name, test_id) across commits
         signals: List[Signal] = []
-        for (wf_name, base_name), failing_tests in failing_tests_by_base.items():
-            for test_id in failing_tests:
-                commit_objs: List[SignalCommit] = []
-                any_event = False
-                for c in commits:
-                    events: List[SignalEvent] = []
-                    for wf_run_id, run_attempt in attempts_by_commit_base.get(
-                        (c.sha, wf_name, base_name), []
-                    ):
-                        meta = group_meta.get(
-                            (c.sha, wf_name, base_name, wf_run_id, run_attempt),
-                            GroupMeta(started_at=None, pending=False, canceled=False),
-                        )
-                        if meta.canceled:
-                            # canceled attempts are treated as missing
-                            continue
-                        verdicts = tests_by_group_attempt.get(
-                            (c.sha, wf_name, base_name, wf_run_id, run_attempt)
-                        )
-                        def make_event(ev_status: SignalStatus) -> SignalEvent:
-                            return SignalEvent(
-                                    name=self._fmt_event_name(
-                                        workflow=wf_name,
-                                        kind="test",
-                                        identifier=test_id,
-                                        wf_run_id=wf_run_id,
-                                        run_attempt=run_attempt,
-                                    ),
-                                status=ev_status,
-                                    started_at=meta.started_at or datetime.min,
-                                    ended_at=None,
-                                )
+        for wf_name, job_base_name, test_id in failing_tests_by_job_base_name:
+            commit_objs: List[SignalCommit] = []
+            has_any_events = (
+                False  # if true, signal has at least one event for some commit
+            )
 
-                        if verdicts and test_id in verdicts:
-                            oc = verdicts[test_id]
-                            events.append(make_event(
-                                SignalStatus.FAILURE
-                                if (oc.failing or oc.errored)
-                                else SignalStatus.SUCCESS
-                            ))
-                        elif meta.pending:
-                            events.append(make_event(SignalStatus.PENDING))
-                        # else: missing (no event)
+            # y-axis: commits (newest → older)
+            for commit_sha in commits_shas:
+                events: List[SignalEvent] = []
 
-                    if events:
-                        any_event = True
-                    commit_objs.append(SignalCommit(head_sha=c.sha, events=events))
-
-                if any_event:
-                    signals.append(
-                        Signal(key=test_id, workflow_name=wf_name, commits=commit_objs)
+                # x-axis: events for the signal
+                for wf_run_id, run_attempt in run_ids_attempts.get(
+                    (commit_sha, wf_name, job_base_name)
+                ):
+                    meta = index_by_commit_job_base_wf_run_attempt.get_stats(
+                        (commit_sha, wf_name, job_base_name, wf_run_id, run_attempt),
+                        default=JobMeta(),
                     )
+                    if meta.is_cancelled:
+                        # canceled attempts are treated as missing
+                        continue
+                    verdict = tests_by_group_attempt.get(
+                        (
+                            commit_sha,
+                            wf_name,
+                            job_base_name,
+                            wf_run_id,
+                            run_attempt,
+                            test_id,
+                        )
+                    )
+
+                    event_common = {
+                        "name": self._fmt_event_name(
+                            workflow=wf_name,
+                            kind="test",
+                            identifier=test_id,
+                            wf_run_id=wf_run_id,
+                            run_attempt=run_attempt,
+                        ),
+                        "started_at": meta.started_at or datetime.min,
+                        "ended_at": None,
+                    }
+
+                    if verdict:
+                        events.append(
+                            SignalEvent(
+                                status=SignalStatus.FAILURE
+                                if (verdict.failing or verdict.errored)
+                                else SignalStatus.SUCCESS,
+                                **event_common,
+                            )
+                        )
+                    elif meta.is_pending:
+                        events.append(
+                            SignalEvent(status=SignalStatus.PENDING, **event_common)
+                        )
+                    # else: missing (no event)
+
+                if events:
+                    has_any_events = True
+
+                # important to always include the commit, even if no events
+                commit_objs.append(SignalCommit(head_sha=commit_sha, events=events))
+
+            if has_any_events:
+                signals.append(
+                    Signal(key=test_id, workflow_name=wf_name, commits=commit_objs)
+                )
 
         return signals
 
-    def _build_non_test_signals(self, commits: List[Commit]) -> List[Signal]:
-        # Build Signals keyed by normalized job base name per workflow
-        # Aggregate across shards within (wf_run_id, run_attempt)
-        signals_by_key: Dict[Tuple[WorkflowName, JobBaseName], List[SignalCommit]] = {}
+    def _build_non_test_signals(self, jobs: List[JobRow]) -> List[Signal]:
+        # Build Signals keyed by normalized job base name per workflow.
+        # Aggregate across shards within (wf_run_id, run_attempt) using JobAggIndex.
 
-        for c in commits:
-            # For each commit, process each (workflow, base) group
-            for (wf_name, base_name), rows in c.jobs.items():
-                by_attempt: Dict[Tuple[WfRunId, RunAttempt], List[JobRow]] = {}
-                for j in rows:
-                    by_attempt.setdefault((j.wf_run_id, j.run_attempt), []).append(j)
+        # Preserve commit order as first-seen in the job rows (datasource orders newest→older).
+        commits_shas: Set[Sha] = {j.head_sha for j in jobs}
 
+        index = JobAggIndex.from_rows(
+            jobs,
+            key_fn=lambda j: (
+                j.head_sha,
+                j.workflow_name,
+                j.base_name,
+                j.wf_run_id,
+                j.run_attempt,
+            ),
+        )
+
+        # Map (sha, workflow, base) -> [attempt_keys]
+        groups_index = index.enumerate(
+            key_fn=lambda j: (j.head_sha, j.workflow_name, j.base_name)
+        )
+
+        # Collect all (workflow, base) keys we need to produce signals for
+        wf_base_keys: Set[Tuple[WorkflowName, JobBaseName]] = {
+            (j.workflow_name, j.base_name) for j in jobs
+        }
+
+        signals: List[Signal] = []
+        for wf_name, base_name in wf_base_keys:
+            commit_objs: List[SignalCommit] = []
+            has_relevant_failures = False
+
+            for sha in commits_shas:
+                attempt_keys: List[
+                    Tuple[Sha, WorkflowName, JobBaseName, WfRunId, RunAttempt]
+                ] = groups_index.get((sha, wf_name, base_name), [])
                 events: List[SignalEvent] = []
-                for (wf_run_id, run_attempt), grows in by_attempt.items():
-                    any_fail = self._any_failure(grows)
-                    any_canceled = self._any_canceled(grows)
-                    all_success = self._all_completed_success(grows)
-                    if any_canceled:
-                        # treat canceled groups as missing signal; skip event
+
+                for akey in attempt_keys:
+                    meta = index.stats(akey)
+                    if meta.is_cancelled:
+                        # canceled attempts are treated as missing
                         continue
-                    status = (
-                        SignalStatus.FAILURE
-                        if any_fail
-                        else (
-                            SignalStatus.SUCCESS
-                            if all_success
-                            else SignalStatus.PENDING
-                        )
-                    )
-                    started_at = self._earliest_started_at(grows)
+                    # Map aggregation verdict to outer SignalStatus
+                    if meta.status is None:
+                        continue
+                    if meta.status == AggStatus.FAILURE:
+                        # check if not test failure (which is handled in test signals)
+                        if not (meta.has_failures and meta.has_non_test_failures):
+                            has_relevant_failures = True
+
+                        ev_status = SignalStatus.FAILURE
+                    elif meta.status == AggStatus.SUCCESS:
+                        ev_status = SignalStatus.SUCCESS
+                    else:
+                        ev_status = SignalStatus.PENDING
+
+                    # Extract wf_run_id/run_attempt from the attempt key
+                    _, _, _, wf_run_id, run_attempt = akey
+
                     events.append(
                         SignalEvent(
                             name=self._fmt_event_name(
@@ -519,19 +313,18 @@ class SignalExtractor:
                                 wf_run_id=wf_run_id,
                                 run_attempt=run_attempt,
                             ),
-                            status=status,
-                            started_at=started_at,
+                            status=ev_status,
+                            started_at=meta.started_at or datetime.min,
                             ended_at=None,
                         )
                     )
 
-                commit_obj = SignalCommit(head_sha=c.sha, events=events)
-                signals_by_key.setdefault((wf_name, base_name), []).append(commit_obj)
+                # important to always include the commit, even if no events
+                commit_objs.append(SignalCommit(head_sha=sha, events=events))
 
-        # Materialize Signals newest → older (already ordered from the query)
-        out: List[Signal] = []
-        for (wf_name, base_name), commit_list in signals_by_key.items():
-            out.append(
-                Signal(key=base_name, workflow_name=wf_name, commits=commit_list)
-            )
-        return out
+            if not has_relevant_failures:
+                signals.append(
+                    Signal(key=base_name, workflow_name=wf_name, commits=commit_objs)
+                )
+
+        return signals

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
@@ -1,0 +1,509 @@
+from __future__ import annotations
+
+"""
+Signal extraction layer.
+
+Transforms raw workflow/job/test data into Signal objects used by signal.py.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Dict, Iterable, List, Optional, Tuple, DefaultDict, Set
+
+from .clickhouse_client_helper import CHCliFactory
+from .autorevert_checker import CommitJobs, JobResult
+from .signal import Signal, SignalCommit, SignalEvent, SignalStatus
+
+
+# Default classification rules that indicate test failures.
+DEFAULT_TEST_RULES: Set[str] = {
+    "pytest failure",
+    "Python unittest failure",
+}
+
+
+@dataclass(frozen=True)
+class JobRow:
+    head_sha: str
+    workflow_name: str
+    wf_run_id: int
+    job_id: int
+    run_attempt: int
+    name: str
+    status: str
+    conclusion: str
+    started_at: Optional[datetime]
+    created_at: Optional[datetime]
+    rule: str
+
+
+@dataclass(frozen=True)
+class TestRow:
+    job_id: int
+    wf_run_id: int
+    workflow_run_attempt: int
+    file: str
+    classname: str
+    name: str
+    failing: int  # 0/1
+    errored: int  # 0/1
+    rerun_seen: int  # 0/1
+
+    @property
+    def test_id(self) -> str:
+        # file::name is a stable, readable key; classname can be added if needed
+        return f"{self.file}::{self.name}" if self.file else self.name
+
+
+@dataclass(frozen=True)
+class JobBaseNameKey:
+    workflow: str
+    job_base_name: str
+
+
+@dataclass
+class Commit:
+    sha: str
+    # Map of (workflow, job_base_name) -> ordered JobRow list (by started_at)
+    jobs: Dict[JobBaseNameKey, List[JobRow]]
+
+
+# ---------- Type aliases & small keys for clarity ----------
+
+@dataclass(frozen=True)
+class AttemptKey:
+    """Identifies a unique workflow run attempt for grouping events."""
+
+    wf_run_id: int
+    run_attempt: int
+
+
+@dataclass(frozen=True)
+class AttemptIndexKey:
+    """Index key for test rows: job, run, attempt triple."""
+
+    wf_run_id: int
+    job_id: int
+    run_attempt: int
+
+
+@dataclass(frozen=True)
+class TestOutcome:
+    failing: bool
+    errored: bool
+
+
+@dataclass(frozen=True)
+class WorkflowCommitRows:
+    sha: str
+    rows: List[JobRow]
+
+
+class SignalExtractor:
+    def __init__(
+        self,
+        workflows: Iterable[str],
+        lookback_hours: int = 24,
+        test_rules: Optional[Set[str]] = None,
+    ) -> None:
+        self.workflows = list(workflows)
+        self.lookback_hours = lookback_hours
+        self.test_rules = set(test_rules) if test_rules is not None else set(DEFAULT_TEST_RULES)
+        # Helper instance to reuse normalization logic
+        self._norm_dummy = CommitJobs(head_sha="_", created_at=datetime.now(), jobs=[])
+
+    def _norm(self, name: str) -> str:
+        return self._norm_dummy.normalize_job_name(name or "")
+
+    def _fmt_event_name(
+        self, *, workflow: str, kind: str, identifier: str, wf_run_id: int, run_attempt: int
+    ) -> str:
+        """Consistent, debuggable event name for SignalEvent."""
+        return f"wf={workflow} kind={kind} id={identifier} run={wf_run_id} attempt={run_attempt}"
+
+    # -----------------------------
+    # Public API
+    # -----------------------------
+    def extract(self) -> List[Signal]:
+        """Extract Signals for configured workflows within the lookback window."""
+        commits = self._fetch_commits_and_jobs()
+
+        # Select jobs to participate in test-track details fetch
+        test_track_job_ids, bases_to_track = self._select_test_track_job_ids(commits)
+        test_rows = self._fetch_tests_for_jobs(test_track_job_ids)
+
+        test_signals = self._build_test_signals(commits, test_rows, bases_to_track)
+        job_signals = self._build_non_test_signals(commits)
+        return test_signals + job_signals
+
+    # -----------------------------
+    # Phase A — Jobs
+    # -----------------------------
+    def _fetch_commits_and_jobs(self) -> List[Commit]:
+        """
+        Fetch workflow jobs for recent main commits plus any other workflow runs for those commits
+        (including dispatches). Returns mapping (workflow_name, head_sha) -> list of _JobRow
+        ordered by started_at (None last) for stable event ordering.
+        """
+        lookback_time = datetime.now() - timedelta(hours=self.lookback_hours)
+
+        workflow_filter = ""
+        params: Dict[str, Any] = {"lookback_time": lookback_time}
+        if self.workflows:
+            workflow_filter = "AND wf.workflow_name IN {workflows:Array(String)}"
+            params["workflows"] = self.workflows
+
+        query = f"""
+        WITH push_dedup AS (
+            SELECT head_commit.id AS sha, max(head_commit.timestamp) AS ts
+            FROM default.push
+            WHERE head_commit.timestamp >= {{lookback_time:DateTime}}
+              AND ref = 'refs/heads/main'
+            GROUP BY sha
+        )
+        SELECT
+            wf.head_sha,
+            wf.workflow_name,
+            wf.id AS job_id,
+            wf.run_id,
+            wf.run_attempt,
+            wf.name,
+            wf.status,
+            if(wf.conclusion = '' AND tupleElement(wf.torchci_classification_temp,'line') != '', 'failure', wf.conclusion) AS conclusion_kg,
+            wf.started_at,
+            wf.created_at,
+            tupleElement(wf.torchci_classification_kg,'rule') AS rule
+        FROM default.workflow_job AS wf FINAL
+        INNER JOIN push_dedup p ON wf.head_sha = p.sha
+        WHERE wf.dynamoKey LIKE 'pytorch/pytorch/%'
+          AND wf.created_at >= {{lookback_time:DateTime}}
+          {workflow_filter}
+        ORDER BY p.ts DESC, wf.head_sha, wf.run_id, wf.run_attempt, wf.name, wf.started_at
+        """
+
+        res = CHCliFactory().client.query(query, parameters=params)
+        commits: List[Commit] = []
+        current_sha: Optional[str] = None
+        current_jobs: Dict[JobBaseNameKey, List[JobRow]] = {}
+
+        def flush_current():
+            if current_sha is not None:
+                # sort each job list by started_at for stable event ordering
+                for lst in current_jobs.values():
+                    lst.sort(key=lambda r: (r.started_at is None, r.started_at, r.job_id))
+                commits.append(Commit(sha=current_sha, jobs=dict(current_jobs)))
+
+        for (
+            head_sha,
+            workflow_name,
+            job_id,
+            run_id,
+            run_attempt,
+            name,
+            status,
+            conclusion,
+            started_at,
+            created_at,
+            rule,
+        ) in res.result_rows:
+            # boundary by head_sha – rows are ordered by push ts desc, head_sha grouping
+            if current_sha is None:
+                current_sha = head_sha
+            elif head_sha != current_sha:
+                flush_current()
+                current_sha = head_sha
+                current_jobs = {}
+
+            base = self._norm(name)
+            k = JobBaseNameKey(workflow=workflow_name, job_base_name=base)
+            current_jobs.setdefault(k, []).append(
+                JobRow(
+                    head_sha=head_sha,
+                    workflow_name=workflow_name,
+                    wf_run_id=int(run_id),
+                    job_id=int(job_id),
+                    run_attempt=int(run_attempt),
+                    name=str(name or ""),
+                    status=str(status or ""),
+                    conclusion=str(conclusion or ""),
+                    started_at=started_at,
+                    created_at=created_at,
+                    rule=str(rule or ""),
+                )
+            )
+
+        flush_current()
+        return commits
+
+    # -----------------------------
+    # Phase B — Tests (test_run_s3 only)
+    # -----------------------------
+    def _select_test_track_job_ids(
+        self, commits: List[Commit]
+    ) -> Tuple[List[int], set[JobBaseNameKey]]:
+        """
+        Select job_ids for the test-track batch fetch.
+
+        Strategy:
+        1) Identify normalized base names for jobs that exhibited test-related classifications anywhere in the window.
+        2) Include ALL jobs across all commits whose normalized base is in that set (to capture successes or pendings on other commits).
+        """
+        # Helper for normalization (reuse CommitJobs implementation)
+        bases_to_track: set[JobBaseNameKey] = set()
+        for commit in commits:
+            for key, rows in commit.jobs.items():
+                for j in rows:
+                    if j.rule and j.rule in self.test_rules:
+                        bases_to_track.add(key)
+                        break
+
+        job_ids: List[int] = []
+        seen = set()
+        if bases_to_track:
+            for commit in commits:
+                for key, rows in commit.jobs.items():
+                    if key in bases_to_track:
+                        for j in rows:
+                            if j.job_id not in seen:
+                                seen.add(j.job_id)
+                                job_ids.append(j.job_id)
+        return job_ids, bases_to_track
+
+    def _fetch_tests_for_jobs(self, job_ids: List[int]) -> List[TestRow]:
+        if not job_ids:
+            return []
+
+        rows: List[TestRow] = []
+        # Chunk to avoid very large IN lists
+        CHUNK = 300
+        for i in range(0, len(job_ids), CHUNK):
+            chunk = job_ids[i : i + CHUNK]
+            res = CHCliFactory().client.query(
+                """
+                SELECT job_id, workflow_id, workflow_run_attempt, file, classname, name,
+                       max(failure_count > 0) AS failing,
+                       max(error_count  > 0) AS errored,
+                       max(rerun_count  > 0) AS rerun_seen,
+                       count() AS rows
+                FROM default.test_run_s3
+                WHERE job_id IN {job_ids:Array(Int64)}
+                GROUP BY job_id, workflow_id, workflow_run_attempt, file, classname, name
+                """,
+                parameters={"job_ids": chunk},
+            )
+            for r in res.result_rows:
+                rows.append(
+                    TestRow(
+                        job_id=int(r[0]),
+                        wf_run_id=int(r[1]),
+                        workflow_run_attempt=int(r[2]),
+                        file=str(r[3] or ""),
+                        classname=str(r[4] or ""),
+                        name=str(r[5] or ""),
+                        failing=int(r[6] or 0),
+                        errored=int(r[7] or 0),
+                        rerun_seen=int(r[8] or 0),
+                    )
+                )
+        return rows
+
+    # -----------------------------
+    # Build Signals
+    # -----------------------------
+    def _build_test_signals(
+        self,
+        commits: List[Commit],
+        test_rows: List[TestRow],
+        bases_to_track: set[JobBaseNameKey],
+    ) -> List[Signal]:
+        """Build per-test Signals across commits, scoped to job base.
+
+        We index `default.test_run_s3` rows per (wf_run_id, run_attempt, job_base) and collect
+        which base(s) a test appears in. For each commit and (workflow, base), we compute attempt
+        metadata (pending/completed, start time). Then, for tests that failed at least once in
+        that base, we emit events per commit/attempt:
+          - If test_run_s3 rows exist → FAILURE if any failing/errored else SUCCESS
+          - Else if group pending → PENDING
+          - Else → no event (missing)
+        """
+
+        # Map job_id -> (commit_sha, base key) for fast base resolution
+        @dataclass(frozen=True)
+        class JobLoc:
+            sha: str
+            base: JobBaseNameKey
+
+        job_loc: Dict[int, JobLoc] = {}
+        attempts_by_commit_base: Dict[Tuple[str, JobBaseNameKey], List[AttemptKey]] = {}
+
+        @dataclass(frozen=True)
+        class GroupMeta:
+            """Per (commit, base, attempt) metadata used to derive event status.
+
+            - started_at: earliest start time among rows in the group (for ordering)
+            - pending: at least one row in the group is not completed
+            - canceled: at least one row concluded as cancelled; group is treated as missing signal
+            """
+
+            started_at: Optional[datetime]
+            pending: bool
+            canceled: bool
+
+        group_meta: Dict[Tuple[str, JobBaseNameKey, AttemptKey], GroupMeta] = {}
+
+        for c in commits:
+            for base_key, rows in c.jobs.items():
+                if base_key not in bases_to_track:
+                    continue
+                by_attempt: Dict[AttemptKey, List[JobRow]] = {}
+                for j in rows:
+                    job_loc[j.job_id] = JobLoc(c.sha, base_key)
+                    by_attempt.setdefault(AttemptKey(j.wf_run_id, j.run_attempt), []).append(j)
+
+                for akey, grows in by_attempt.items():
+                    started_at = min((r.started_at for r in grows if r.started_at is not None), default=None)
+                    any_pending = any((r.status or "").lower() != "completed" for r in grows)
+                    any_canceled = any((r.conclusion or "").lower() == "cancelled" for r in grows)
+                    group_meta[(c.sha, base_key, akey)] = GroupMeta(
+                        started_at=started_at, pending=any_pending, canceled=any_canceled
+                    )
+                    attempts_by_commit_base.setdefault((c.sha, base_key), []).append(akey)
+
+        # Index test_run_s3 rows per (commit, base, attempt) and collect base-scoped failing tests
+        tests_by_group_attempt: Dict[Tuple[str, JobBaseNameKey, AttemptKey], Dict[str, TestOutcome]] = {}
+        failing_tests_by_base: Dict[JobBaseNameKey, Set[str]] = {}
+        for tr in test_rows:
+            loc = job_loc.get(tr.job_id)
+            if not loc:
+                continue
+            akey = AttemptKey(tr.wf_run_id, tr.workflow_run_attempt)
+            key = (loc.sha, loc.base, akey)
+            d = tests_by_group_attempt.setdefault(key, {})
+            prev = d.get(tr.test_id)
+            outcome = TestOutcome(
+                failing=(prev.failing if prev else False) or bool(tr.failing),
+                errored=(prev.errored if prev else False) or bool(tr.errored),
+            )
+            d[tr.test_id] = outcome
+            if outcome.failing or outcome.errored:
+                failing_tests_by_base.setdefault(loc.base, set()).add(tr.test_id)
+
+        # Emit per (workflow, base, test) across commits
+        signals: List[Signal] = []
+        for base_key, failing_tests in failing_tests_by_base.items():
+            for test_id in failing_tests:
+                commit_objs: List[SignalCommit] = []
+                any_event = False
+                for c in commits:
+                    events: List[SignalEvent] = []
+                    akeys = attempts_by_commit_base.get((c.sha, base_key), [])
+                    for akey in akeys:
+                        meta = group_meta.get((c.sha, base_key, akey), GroupMeta(None, False, False))
+                        if meta.canceled:
+                            # canceled attempts are treated as missing
+                            continue
+                        verdicts = tests_by_group_attempt.get((c.sha, base_key, akey))
+                        if verdicts and test_id in verdicts:
+                            oc = verdicts[test_id]
+                            status = SignalStatus.FAILURE if (oc.failing or oc.errored) else SignalStatus.SUCCESS
+                            events.append(
+                                SignalEvent(
+                                    name=self._fmt_event_name(
+                                        workflow=base_key.workflow,
+                                        kind="test",
+                                        identifier=test_id,
+                                        wf_run_id=akey.wf_run_id,
+                                        run_attempt=akey.run_attempt,
+                                    ),
+                                    status=status,
+                                    started_at=meta.started_at or datetime.min,
+                                    ended_at=None,
+                                )
+                            )
+                        elif meta.pending:
+                            events.append(
+                                SignalEvent(
+                                    name=self._fmt_event_name(
+                                        workflow=base_key.workflow,
+                                        kind="test",
+                                        identifier=test_id,
+                                        wf_run_id=akey.wf_run_id,
+                                        run_attempt=akey.run_attempt,
+                                    ),
+                                    status=SignalStatus.PENDING,
+                                    started_at=meta.started_at or datetime.min,
+                                    ended_at=None,
+                                )
+                            )
+                        # else: missing (no event)
+
+                    if events:
+                        any_event = True
+                    commit_objs.append(SignalCommit(head_sha=c.sha, events=events))
+
+                if any_event:
+                    signals.append(
+                        Signal(key=test_id, workflow_name=base_key.workflow, commits=commit_objs)
+                    )
+
+        return signals
+
+
+    def _build_non_test_signals(
+        self, commits: List[Commit]
+    ) -> List[Signal]:
+        # Build Signals keyed by normalized job base name per workflow
+        # Aggregate across shards within (run_id, run_attempt)
+        signals_by_key: Dict[Tuple[str, str], List[SignalCommit]] = {}
+
+        for c in commits:
+            # For each commit, process each (workflow, base) group
+            for key, rows in c.jobs.items():
+                by_attempt: Dict[Tuple[int, int], List[JobRow]] = {}
+                for j in rows:
+                    by_attempt.setdefault((j.wf_run_id, j.run_attempt), []).append(j)
+
+                events: List[SignalEvent] = []
+                for (wf_run_id, run_attempt), grows in by_attempt.items():
+                    any_fail = any((gr.conclusion or "").lower() == "failure" for gr in grows)
+                    any_cancel = any((gr.conclusion or "").lower() == "cancelled" for gr in grows)
+                    all_success = all(
+                        (gr.conclusion or "").lower() == "success"
+                        and (gr.status or "").lower() == "completed"
+                        for gr in grows
+                    )
+                    if any_cancel:
+                        # treat canceled groups as missing signal; skip event
+                        continue
+                    status = (
+                        SignalStatus.FAILURE
+                        if any_fail
+                        else (SignalStatus.SUCCESS if all_success else SignalStatus.PENDING)
+                    )
+                    started_at = min(
+                        (r.started_at for r in grows if r.started_at is not None),
+                        default=None,
+                    )
+                    events.append(
+                        SignalEvent(
+                            name=self._fmt_event_name(
+                                workflow=key.workflow,
+                                kind="job",
+                                identifier=key.job_base_name,
+                                wf_run_id=wf_run_id,
+                                run_attempt=run_attempt,
+                            ),
+                            status=status,
+                            started_at=started_at or datetime.min,
+                            ended_at=None,
+                        )
+                    )
+
+                commit_obj = SignalCommit(head_sha=c.sha, events=events)
+                signals_by_key.setdefault((key.workflow, key.job_base_name), []).append(commit_obj)
+
+        # Materialize Signals newest → older (already ordered from the query)
+        out: List[Signal] = []
+        for (wf, base), commit_list in signals_by_key.items():
+            out.append(Signal(key=base, workflow_name=wf, commits=commit_list))
+        return out

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
@@ -142,7 +142,7 @@ class SignalExtractor:
             lambda j: j.head_sha
         )
 
-        run_ids_attempts = index_by_commit_job_base_wf_run_attempt.enumerate_keys(
+        run_ids_attempts = index_by_commit_job_base_wf_run_attempt.group_map_values_by(
             key_fn=lambda j: (j.head_sha, j.workflow_name, j.base_name),
             value_fn=lambda j: (j.wf_run_id, j.run_attempt),
         )
@@ -270,7 +270,7 @@ class SignalExtractor:
         commit_shas = index.unique_values(lambda j: j.head_sha)
 
         # Map (sha, workflow, base) -> [attempt_keys]
-        groups_index = index.enumerate(
+        groups_index = index.group_keys_by(
             key_fn=lambda j: (j.head_sha, j.workflow_name, j.base_name)
         )
 

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_datasource.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_datasource.py
@@ -153,7 +153,7 @@ class SignalExtractionDatasource:
         TEST_FETCH_CHUNK = 1024  # Number of job_ids to fetch per query
         t0 = time.perf_counter()
         for start in range(0, total, TEST_FETCH_CHUNK):
-            chunk = job_ids[start: start + TEST_FETCH_CHUNK]
+            chunk = job_ids[start : start + TEST_FETCH_CHUNK]
             batch_idx = start // TEST_FETCH_CHUNK + 1
             batch_total = (total + TEST_FETCH_CHUNK - 1) // TEST_FETCH_CHUNK
             log.info(

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_datasource.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_datasource.py
@@ -150,7 +150,7 @@ class SignalExtractionDatasource:
             len(failed_job_ids),
         )
         rows: List[TestRow] = []
-        TEST_FETCH_CHUNK = 1024   # Number of job_ids to fetch per query
+        TEST_FETCH_CHUNK = 1024  # Number of job_ids to fetch per query
         t0 = time.perf_counter()
         for start in range(0, total, TEST_FETCH_CHUNK):
             chunk = job_ids[start: start + TEST_FETCH_CHUNK]

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_datasource.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_datasource.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any, Dict, Iterable, List
+
+from .clickhouse_client_helper import CHCliFactory
+from .signal_extraction_types import (
+    JobId,
+    JobName,
+    JobRow,
+    RunAttempt,
+    Sha,
+    TestRow,
+    WfRunId,
+    WorkflowName,
+)
+
+
+class SignalExtractionDatasource:
+    """
+    Encapsulates ClickHouse queries used by the signal extraction layer.
+    """
+
+    def fetch_jobs_for_workflows(
+        self, *, workflows: Iterable[str], lookback_hours: int
+    ) -> List[JobRow]:
+        """
+        Fetch recent workflow job rows for the given workflows within the lookback window.
+
+        Returns rows ordered by push timestamp desc, then by workflow run/job identity.
+        """
+        lookback_time = datetime.now() - timedelta(hours=lookback_hours)
+
+        workflow_filter = ""
+        params: Dict[str, Any] = {"lookback_time": lookback_time}
+        workflow_list = list(workflows)
+        if workflow_list:
+            workflow_filter = "AND wf.workflow_name IN {workflows:Array(String)}"
+            params["workflows"] = workflow_list
+
+        query = f"""
+        WITH push_dedup AS (
+            SELECT head_commit.id AS sha, max(head_commit.timestamp) AS ts
+            FROM default.push
+            WHERE head_commit.timestamp >= {{lookback_time:DateTime}}
+              AND ref = 'refs/heads/main'
+            GROUP BY sha
+        )
+        SELECT
+            wf.head_sha,
+            wf.workflow_name,
+            wf.id AS job_id,
+            wf.run_id,
+            wf.run_attempt,
+            wf.name,
+            wf.status,
+            if(wf.conclusion = '' AND
+                tupleElement(wf.torchci_classification_temp,'line') != '', 'failure', wf.conclusion)
+                AS conclusion_kg,
+            wf.started_at,
+            wf.created_at,
+            tupleElement(wf.torchci_classification_kg,'rule') AS rule
+        FROM default.workflow_job AS wf FINAL
+        INNER JOIN push_dedup p ON wf.head_sha = p.sha
+        WHERE wf.dynamoKey LIKE 'pytorch/pytorch/%'
+          AND wf.created_at >= {{lookback_time:DateTime}}
+          {workflow_filter}
+        ORDER BY p.ts DESC, wf.started_at ASC, wf.head_sha, wf.run_id, wf.run_attempt, wf.name
+        """
+
+        res = CHCliFactory().client.query(query, parameters=params)
+        rows: List[JobRow] = []
+        for (
+            head_sha,
+            workflow_name,
+            job_id,
+            run_id,
+            run_attempt,
+            name,
+            status,
+            conclusion,
+            started_at,
+            created_at,
+            rule,
+        ) in res.result_rows:
+            rows.append(
+                JobRow(
+                    head_sha=Sha(head_sha),
+                    workflow_name=WorkflowName(workflow_name),
+                    wf_run_id=WfRunId(int(run_id)),
+                    job_id=JobId(int(job_id)),
+                    run_attempt=RunAttempt(int(run_attempt)),
+                    name=JobName(str(name or "")),
+                    status=str(status or ""),
+                    conclusion=str(conclusion or ""),
+                    started_at=started_at,
+                    created_at=created_at,
+                    rule=str(rule or ""),
+                )
+            )
+        return rows
+
+    def fetch_tests_for_job_ids(self, job_ids: List[JobId]) -> List[TestRow]:
+        """Batch fetch test verdict rows from default.test_run_s3 for given job ids."""
+        if not job_ids:
+            return []
+
+        rows: List[TestRow] = []
+        TEST_FETCH_CHUNK = 300
+        for start in range(0, len(job_ids), TEST_FETCH_CHUNK):
+            chunk = job_ids[start : start + TEST_FETCH_CHUNK]
+            res = CHCliFactory().client.query(
+                """
+                SELECT job_id, workflow_id, workflow_run_attempt, file, classname, name,
+                       max(failure_count > 0) AS failing,
+                       max(error_count  > 0) AS errored
+                FROM default.test_run_s3
+                WHERE job_id IN {job_ids:Array(Int64)}
+                GROUP BY job_id, workflow_id, workflow_run_attempt, file, classname, name
+                """,
+                parameters={"job_ids": [int(j) for j in chunk]},
+            )
+            for r in res.result_rows:
+                rows.append(
+                    TestRow(
+                        job_id=JobId(int(r[0])),
+                        wf_run_id=WfRunId(int(r[1])),
+                        workflow_run_attempt=RunAttempt(int(r[2])),
+                        file=str(r[3] or ""),
+                        classname=str(r[4] or ""),
+                        name=str(r[5] or ""),
+                        failing=int(r[6] or 0),
+                        errored=int(r[7] or 0),
+                    )
+                )
+        return rows

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_types.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_types.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from functools import cached_property
+from typing import NewType, Optional, Set
+
+
+# Default classification rules that indicate test failures.
+DEFAULT_TEST_RULES: Set[str] = {
+    "pytest failure",
+    "Python unittest failure",
+}
+
+# Stronger typing for ids (type-checker only; runtime is still int/str)
+WfRunId = NewType("WfRunId", int)
+RunAttempt = NewType("RunAttempt", int)
+JobId = NewType("JobId", int)
+Sha = NewType("Sha", str)
+WorkflowName = NewType("WorkflowName", str)
+JobName = NewType("JobName", str)
+JobBaseName = NewType("JobBaseName", str)
+TestId = NewType("TestId", str)
+
+
+# Represents a job row from the jobs table in ClickHouse
+@dataclass(frozen=True)
+class JobRow:
+    head_sha: Sha
+    workflow_name: WorkflowName
+    wf_run_id: WfRunId
+    job_id: JobId
+    run_attempt: RunAttempt
+    name: JobName
+    status: str
+    conclusion: str
+    started_at: Optional[datetime]
+    created_at: Optional[datetime]
+    rule: str
+
+    @cached_property
+    def base_name(self) -> JobBaseName:
+        """Normalize job name to a stable base for matching across commits.
+
+        - Drop any trailing parenthetical qualifiers (e.g., "(rocm)", shard notes)
+        - Strip common shard suffixes like ", 1, 1, " used in CI naming
+        - Collapse redundant whitespace
+        """
+        # Drop any trailing parenthetical qualifier
+        base = re.sub(r"\s*\(.*\)$", "", self.name)
+        # Remove patterns like ", 1, 1, " or ", 2, 3, " from job names
+        base = re.sub(r", \d+, \d+, ", ", ", base)
+        # Collapse multiple spaces
+        base = re.sub(r"\s+", " ", base).strip()
+        return JobBaseName(base)
+
+    # ---- Convenience properties for verdicts/status ----
+    #
+    # Notes:
+    #
+    # - Table: default.workflow_job has status in {'completed','in_progress','queued'} and conclusion
+    # in {'', 'success', 'failure', 'cancelled', 'skipped'}.
+    #
+    #  - Column conclusion_kg (alias) maps keep-going cases to 'failure' when conclusion=''
+    #  and there is a temp classification.
+    #
+    #  - Some in_progress jobs already have conclusion_kg='failure' due to keep-going detection;
+    # is_failure True while is_pending True.
+
+    @cached_property
+    def _status_l(self) -> str:
+        return (self.status or "").lower()
+
+    @cached_property
+    def _conclusion_l(self) -> str:
+        return (self.conclusion or "").lower()
+
+    @property
+    def is_completed(self) -> bool:
+        return self._status_l == "completed"
+
+    @property
+    def is_cancelled(self) -> bool:
+        return self._conclusion_l == "cancelled"
+
+    @property
+    def is_failure(self) -> bool:
+        # conclusion is already KG-adjusted in the datasource
+        return self._conclusion_l == "failure"
+
+    @property
+    def is_success(self) -> bool:
+        return self.is_completed and self._conclusion_l == "success"
+
+    @property
+    def is_pending(self) -> bool:
+        # Pending if not completed or conclusion is empty (keep-going)
+        return (not self.is_completed) or (self._conclusion_l == "")
+
+    @cached_property
+    def is_test_failure(self) -> bool:
+        """True if this job is classified as a test failure."""
+
+        return self.is_failure and (self.rule in DEFAULT_TEST_RULES)
+
+
+# Represents a test verdict row from the test_run_s3 table in ClickHouse
+@dataclass(frozen=True)
+class TestRow:
+    job_id: JobId
+    wf_run_id: WfRunId
+    workflow_run_attempt: RunAttempt
+    file: str
+    classname: str
+    name: str
+    failing: int  # 0/1
+    errored: int  # 0/1
+
+    @property
+    def test_id(self) -> TestId:
+        # file::name is a stable, readable key; classname can be added if needed
+        test_key = f"{self.file}::{self.name}" if self.file else self.name
+        return TestId(test_key)

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/testers/hud.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/testers/hud.py
@@ -1,0 +1,94 @@
+import logging
+from typing import Iterable, Optional
+
+from ..hud_renderer import build_grid_model, render_html
+from ..signal_extraction import SignalExtractor
+
+
+def run_hud(
+    workflows: Iterable[str],
+    *,
+    hours: int = 24,
+    repo_full_name: str = "pytorch/pytorch",
+    out: str = "hud.html",
+    ignore_newer_than: Optional[str] = None,
+) -> str:
+    """
+    Extracts signals for the given workflows, optionally truncates commit history
+    to ignore commits newer than a specific SHA, builds a HUD model, and writes
+    an HTML report to `out`.
+
+    Returns the output filepath.
+    """
+
+    logging.info(
+        "[hud] Start: workflows=%s hours=%s repo=%s",
+        ",".join(workflows),
+        hours,
+        repo_full_name,
+    )
+
+    extractor = SignalExtractor(
+        workflows=workflows,
+        lookback_hours=hours,
+        repo_full_name=repo_full_name,
+    )
+    logging.info("[hud] Extracting signals ...")
+    signals = extractor.extract()
+    logging.info("[hud] Extracted %d signals", len(signals))
+
+    # Optionally cut off newest commits above a given commit SHA prefix
+    if ignore_newer_than:
+        cut_prefix = str(ignore_newer_than).strip()
+        if cut_prefix:
+            total_trimmed = 0
+            found_any = False
+            for s in signals:
+                # commits are ordered newest -> older; find first index that matches prefix
+                idx = next(
+                    (
+                        i
+                        for i, c in enumerate(s.commits)
+                        if c.head_sha.startswith(cut_prefix)
+                    ),
+                    None,
+                )
+                if idx is None:
+                    continue
+                found_any = True
+                trimmed = idx  # number of newer commits dropped
+                if trimmed > 0:
+                    total_trimmed += trimmed
+                    s.commits = s.commits[idx:]
+            if not found_any:
+                logging.warning(
+                    "[hud] ignore-newer-than='%s' did not match any commit in extracted signals",
+                    cut_prefix,
+                )
+            else:
+                logging.info(
+                    "[hud] Applied ignore-newer-than=%s; dropped %d newer commit entries across signals",
+                    cut_prefix,
+                    total_trimmed,
+                )
+
+    logging.info("[hud] Building grid model ...")
+    model = build_grid_model(signals)
+    logging.info(
+        "[hud] Model: %d commits, %d columns",
+        len(model.commits),
+        len(model.columns),
+    )
+
+    logging.info("[hud] Rendering HTML ...")
+    html = render_html(
+        model,
+        title=f"Signal HUD: {', '.join(workflows)} ({hours}h)",
+        repo_full_name=repo_full_name,
+    )
+    with open(out, "w", encoding="utf-8") as f:
+        f.write(html)
+    logging.info("[hud] HUD written to %s", out)
+    logging.info("HUD written to %s", out)
+
+    return out

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
@@ -3,6 +3,8 @@ from datetime import datetime, timedelta
 
 from pytorch_auto_revert.signal import (
     AutorevertPattern,
+    Ineligible,
+    IneligibleReason,
     InfraCheckResult,
     PartitionedCommits,
     Signal,
@@ -195,7 +197,7 @@ class TestSignal(unittest.TestCase):
         self.assertEqual(res.suspected_commit, "sha_mid")
         self.assertEqual(res.older_successful_commit, "sha_old")
 
-    def test_detect_autorevert_pattern_none_when_missing_failure(self):
+    def test_detect_autorevert_pattern_ineligible_when_fixed(self):
         c_newer = SignalCommit(
             head_sha="sha_newer",
             events=[self._ev("job", SignalStatus.SUCCESS, 5)],
@@ -211,7 +213,9 @@ class TestSignal(unittest.TestCase):
         s = Signal(
             key="job", workflow_name="wf", commits=[c_newer, c_suspected, c_base]
         )
-        self.assertIsNone(s.process_valid_autorevert_pattern())
+        res = s.process_valid_autorevert_pattern()
+        self.assertIsInstance(res, Ineligible)
+        self.assertEqual(res.reason, IneligibleReason.FIXED)
 
 
 if __name__ == "__main__":

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
@@ -30,7 +30,7 @@ class FakeDatasource(SignalExtractionDatasource):
         self._tests = tests
 
     def fetch_jobs_for_workflows(
-        self, *, workflows: Iterable[str], lookback_hours: int
+        self, *, workflows: Iterable[str], lookback_hours: int, repo_full_name: str
     ) -> List[JobRow]:
         return list(self._jobs)
 

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
@@ -1,0 +1,314 @@
+import unittest
+from datetime import datetime, timedelta
+from typing import Iterable, List
+
+from pytorch_auto_revert.signal import SignalStatus
+from pytorch_auto_revert.signal_extraction import SignalExtractor
+from pytorch_auto_revert.signal_extraction_datasource import SignalExtractionDatasource
+from pytorch_auto_revert.signal_extraction_types import (
+    JobBaseName,
+    JobId,
+    JobName,
+    JobRow,
+    RunAttempt,
+    Sha,
+    TestRow,
+    WfRunId,
+    WorkflowName,
+)
+
+
+def ts(base: datetime, minutes: int) -> datetime:
+    return base + timedelta(minutes=minutes)
+
+
+class FakeDatasource(SignalExtractionDatasource):
+    """Test double for the datasource returning provided rows."""
+
+    def __init__(self, jobs: List[JobRow], tests: List[TestRow]):
+        self._jobs = jobs
+        self._tests = tests
+
+    def fetch_jobs_for_workflows(
+        self, *, workflows: Iterable[str], lookback_hours: int
+    ) -> List[JobRow]:
+        return list(self._jobs)
+
+    def fetch_tests_for_job_ids(self, job_ids: List[JobId]) -> List[TestRow]:
+        ids = {int(j) for j in job_ids}
+        return [r for r in self._tests if int(r.job_id) in ids]
+
+
+def J(
+    *,
+    sha: str,
+    wf: str = "trunk",
+    run: int,
+    job: int,
+    attempt: int,
+    name: str = "linux-test",
+    status: str = "completed",
+    conclusion: str = "success",
+    started_at: datetime,
+    rule: str = "",
+):
+    return JobRow(
+        head_sha=Sha(sha),
+        workflow_name=WorkflowName(wf),
+        wf_run_id=WfRunId(run),
+        job_id=JobId(job),
+        run_attempt=RunAttempt(attempt),
+        name=JobName(name),
+        status=status,
+        conclusion=conclusion,
+        started_at=started_at,
+        created_at=started_at,
+        rule=rule,
+    )
+
+
+def T(
+    *,
+    job: int,
+    run: int,
+    attempt: int,
+    file: str,
+    name: str,
+    failing: int,
+    errored: int = 0,
+):
+    return TestRow(
+        job_id=JobId(job),
+        wf_run_id=WfRunId(run),
+        workflow_run_attempt=RunAttempt(attempt),
+        file=file,
+        classname="",
+        name=name,
+        failing=failing,
+        errored=errored,
+    )
+
+
+class TestSignalExtraction(unittest.TestCase):
+    def setUp(self) -> None:
+        self.t0 = datetime(2025, 8, 20, 12, 0, 0)
+
+    def _extract(self, jobs: List[JobRow], tests: List[TestRow]):
+        se = SignalExtractor(workflows=["trunk"], lookback_hours=24)
+        se._datasource = FakeDatasource(jobs, tests)
+        return se.extract()
+
+    def _find_job_signal(self, signals, wf: str, base: JobBaseName):
+        for s in signals:
+            if s.workflow_name == wf and s.key == base:
+                return s
+        return None
+
+    def _find_test_signal(self, signals, wf: str, test_key: str):
+        for s in signals:
+            if s.workflow_name == wf and s.key == test_key:
+                return s
+        return None
+
+    def test_commit_order_is_stable(self):
+        # Two commits newer->older; include a failure so the job signal is emitted
+        jobs = [
+            J(
+                sha="C2",
+                run=200,
+                job=1,
+                attempt=1,
+                started_at=ts(self.t0, 10),
+                conclusion="failure",
+                rule="infra",
+            ),
+            J(sha="C1", run=100, job=2, attempt=1, started_at=ts(self.t0, 5)),
+        ]
+        signals = self._extract(jobs, tests=[])
+        base = jobs[0].base_name
+        sig = self._find_job_signal(signals, "trunk", base)
+        self.assertIsNotNone(sig)
+        self.assertEqual([c.head_sha for c in sig.commits], ["C2", "C1"])
+
+    def test_attempt_boundary_two_events_time_ordered(self):
+        # One commit with attempt1(failure) then attempt2(success)
+        jobs = [
+            J(
+                sha="C",
+                run=300,
+                job=10,
+                attempt=1,
+                started_at=ts(self.t0, 1),
+                conclusion="failure",
+            ),
+            J(
+                sha="C",
+                run=300,
+                job=11,
+                attempt=2,
+                started_at=ts(self.t0, 2),
+                conclusion="success",
+            ),
+        ]
+        signals = self._extract(jobs, tests=[])
+        base = jobs[0].base_name
+        sig = self._find_job_signal(signals, "trunk", base)
+        self.assertIsNotNone(sig)
+        self.assertEqual(len(sig.commits), 1)
+        events = sig.commits[0].events
+        self.assertEqual(len(events), 2)
+        # time-ordered: failure then success
+        self.assertEqual(events[0].status, SignalStatus.FAILURE)
+        self.assertEqual(events[1].status, SignalStatus.SUCCESS)
+        # carry attempt ids in names
+        self.assertIn("attempt=1", events[0].name)
+        self.assertIn("attempt=2", events[1].name)
+
+    def test_keep_going_failure_test_track_failure_and_no_job_signal(self):
+        # in_progress + KG-adjusted failure for a test-classified job
+        jobs = [
+            J(
+                sha="K1",
+                run=400,
+                job=20,
+                attempt=1,
+                started_at=ts(self.t0, 3),
+                status="in_progress",
+                conclusion="failure",
+                rule="pytest failure",
+            )
+        ]
+        tests = [T(job=20, run=400, attempt=1, file="f.py", name="test_a", failing=1)]
+        signals = self._extract(jobs, tests)
+        # test signal present with FAILURE
+        test_sig = self._find_test_signal(signals, "trunk", "f.py::test_a")
+        self.assertIsNotNone(test_sig)
+        self.assertEqual(test_sig.commits[0].events[0].status, SignalStatus.FAILURE)
+        # Non-test signal for this base should be omitted due to test-only failure policy
+        self.assertIsNone(self._find_job_signal(signals, "trunk", jobs[0].base_name))
+
+    def test_cancelled_attempt_yields_no_event(self):
+        # Include a separate failing commit so the job signal is emitted
+        jobs = [
+            J(
+                sha="X2",
+                run=501,
+                job=31,
+                attempt=1,
+                started_at=ts(self.t0, 2),
+                conclusion="failure",
+                rule="infra",
+            ),
+            J(
+                sha="X1",
+                run=500,
+                job=30,
+                attempt=1,
+                started_at=ts(self.t0, 1),
+                status="completed",
+                conclusion="cancelled",
+            ),
+        ]
+        signals = self._extract(jobs, tests=[])
+        base = jobs[0].base_name
+        sig = self._find_job_signal(signals, "trunk", base)
+        self.assertIsNotNone(sig)
+        # find X1 commit in the signal and ensure it has no events
+        x1 = next(c for c in sig.commits if c.head_sha == "X1")
+        self.assertEqual(x1.events, [])
+
+    def test_non_test_inclusion_gate(self):
+        # (a) only test failures -> no job signal
+        jobs_a = [
+            J(
+                sha="A2",
+                run=600,
+                job=40,
+                attempt=1,
+                started_at=ts(self.t0, 10),
+                conclusion="failure",
+                rule="pytest failure",
+            ),
+            J(
+                sha="A1",
+                run=610,
+                job=41,
+                attempt=1,
+                started_at=ts(self.t0, 5),
+                conclusion="failure",
+                rule="pytest failure",
+            ),
+        ]
+        tests_a = [
+            T(job=40, run=600, attempt=1, file="f.py", name="test_x", failing=1),
+            T(job=41, run=610, attempt=1, file="f.py", name="test_x", failing=1),
+        ]
+        signals_a = self._extract(jobs_a, tests_a)
+        self.assertIsNone(
+            self._find_job_signal(signals_a, "trunk", jobs_a[0].base_name)
+        )
+
+        # (b) includes a non-test failure -> job signal emitted
+        jobs_b = [
+            J(
+                sha="B2",
+                run=700,
+                job=50,
+                attempt=1,
+                started_at=ts(self.t0, 10),
+                conclusion="failure",
+                rule="infra-flake",  # non-test classification
+            ),
+            J(
+                sha="B1",
+                run=710,
+                job=51,
+                attempt=1,
+                started_at=ts(self.t0, 5),
+                conclusion="success",
+                rule="",
+            ),
+        ]
+        signals_b = self._extract(jobs_b, tests=[])
+        self.assertIsNotNone(
+            self._find_job_signal(signals_b, "trunk", jobs_b[0].base_name)
+        )
+
+    def test_test_track_mapping_failure_then_success(self):
+        # Same test fails on newer commit and passes on older commit
+        jobs = [
+            J(
+                sha="N2",
+                run=800,
+                job=60,
+                attempt=1,
+                started_at=ts(self.t0, 11),
+                conclusion="failure",
+                rule="pytest failure",
+            ),
+            J(
+                sha="N1",
+                run=810,
+                job=61,
+                attempt=1,
+                started_at=ts(self.t0, 1),
+                conclusion="success",
+                rule="",
+            ),
+        ]
+        tests = [
+            T(job=60, run=800, attempt=1, file="g.py", name="test_y", failing=1),
+            T(job=61, run=810, attempt=1, file="g.py", name="test_y", failing=0),
+        ]
+        signals = self._extract(jobs, tests)
+        test_sig = self._find_test_signal(signals, "trunk", "g.py::test_y")
+        self.assertIsNotNone(test_sig)
+        # order newest -> older
+        self.assertEqual([c.head_sha for c in test_sig.commits], ["N2", "N1"])
+        # newer failure, older success
+        self.assertEqual(test_sig.commits[0].events[0].status, SignalStatus.FAILURE)
+        self.assertEqual(test_sig.commits[1].events[0].status, SignalStatus.SUCCESS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
@@ -34,7 +34,9 @@ class FakeDatasource(SignalExtractionDatasource):
     ) -> List[JobRow]:
         return list(self._jobs)
 
-    def fetch_tests_for_job_ids(self, job_ids: List[JobId]) -> List[TestRow]:
+    def fetch_tests_for_job_ids(
+        self, job_ids: List[JobId], *, failed_job_ids: List[JobId]
+    ) -> List[TestRow]:
         ids = {int(j) for j in job_ids}
         return [r for r in self._tests if int(r.job_id) in ids]
 


### PR DESCRIPTION
Implementation of the signal extraction layer and visual report generation utility.


### Testing

```
python -m pytorch_auto_revert hud Lint trunk pull inductor  --hours 32  --ignore-newer-than 30e16d638953d2 --out hud01.html
INFO:root:[hud] Start: workflows=Lint,trunk,pull,inductor hours=32 repo=pytorch/pytorch
INFO:root:[hud] Extracting signals ...
INFO:pytorch_auto_revert.signal_extraction_datasource:[extract] Fetching jobs: repo=pytorch/pytorch workflows=Lint,trunk,pull,inductor lookback=32h
INFO:pytorch_auto_revert.signal_extraction_datasource:[extract] Jobs fetched: 30018 rows in 38.83s
INFO:pytorch_auto_revert.signal_extraction_datasource:[extract] Fetching tests for 6899 job_ids (622 failed jobs) in batches
INFO:pytorch_auto_revert.signal_extraction_datasource:[extract] Test batch 1/7 (size=1024)
INFO:pytorch_auto_revert.signal_extraction_datasource:[extract] Test batch 2/7 (size=1024)
INFO:pytorch_auto_revert.signal_extraction_datasource:[extract] Test batch 3/7 (size=1024)
INFO:pytorch_auto_revert.signal_extraction_datasource:[extract] Test batch 4/7 (size=1024)
INFO:pytorch_auto_revert.signal_extraction_datasource:[extract] Test batch 5/7 (size=1024)
INFO:pytorch_auto_revert.signal_extraction_datasource:[extract] Test batch 6/7 (size=1024)
INFO:pytorch_auto_revert.signal_extraction_datasource:[extract] Test batch 7/7 (size=755)
INFO:pytorch_auto_revert.signal_extraction_datasource:[extract] Tests fetched: 16681 rows for 6899 job_ids in 23.41s
INFO:root:[hud] Extracted 222 signals
INFO:root:[hud] Applied ignore-newer-than=30e16d638953d2; dropped 7770 newer commit entries across signals
INFO:root:[hud] Building grid model ...
INFO:root:[hud] Model: 52 commits, 222 columns
INFO:root:[hud] Rendering HTML ...
INFO:root:[hud] HUD written to hud01.html
INFO:root:HUD written to hud01.html
```

[hud01.html](https://github.com/user-attachments/files/22307745/hud01.html)
