### PR TITLE
Add aws-actions authentication to linux_job_v2.yml

### DIFF
--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -186,6 +186,19 @@ jobs:
           fetch-depth: ${{ inputs.fetch-depth }}
           submodules: ${{ inputs.submodules }}
 
+      - name: configure aws credentials
+        id: aws_creds
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
+          aws-region: us-east-1
+          role-duration-seconds: 18000
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        continue-on-error: true
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+
       - name: Calculate docker image
         id: calculate-docker-image
         uses: ./test-infra/.github/actions/calculate-docker-image


### PR DESCRIPTION
Some runners do not have AWS CLI installed. Hence, in PyTorch we rely on github aws-actions instead of the CLI for authentication. To provide support for workflow files using linux_job_v2.yml, added aws-actions authentication to linux_job_v2.yml.

It is needed to get torchtitan PR going https://github.com/pytorch/torchtitan/pull/1260. It currently faces issue with https://github.com/pytorch/torchtitan/actions/runs/16353043263/job/46204468985?pr=1260#step:8:221