### PR TITLE
[ez] revert tracker workflow: use workflow dispatch not repo dispatch

### DIFF
--- a/.github/workflows/revert-tracker.yml
+++ b/.github/workflows/revert-tracker.yml
@@ -1,7 +1,7 @@
 name: revert printer
 
 on:
-  repository_dispatch:
+  workflow_dispatch:
   schedule:
     # At 15:10 (8:10 AM PST) on Monday
     - cron: 10 15 * * 1


### PR DESCRIPTION
This should be workflow dispatch so we can trigger manually, not repository dispatch

Probably just an misunderstanding when I made this workflow