### PR TITLE
improve time series api 

### DIFF
--- a/torchci/clickhouse_queries/compilers_benchmark_api_query/params.json
+++ b/torchci/clickhouse_queries/compilers_benchmark_api_query/params.json
@@ -1,0 +1,17 @@
+{
+  "params": {
+    "branches": "Array(String)",
+    "commits": "Array(String)",
+    "compilers": "Array(String)",
+    "device": "String",
+    "arch": "String",
+    "dtype": "String",
+    "granularity": "String",
+    "mode": "String",
+    "startTime": "DateTime64(3)",
+    "stopTime": "DateTime64(3)",
+    "suites": "Array(String)",
+    "workflowId": "Int64"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/compilers_benchmark_api_query/query.sql
+++ b/torchci/clickhouse_queries/compilers_benchmark_api_query/query.sql
@@ -1,0 +1,36 @@
+SELECT
+    workflow_id,
+    job_id,
+    head_sha,
+    replaceOne(head_branch, 'refs/heads/', '') AS head_branch,
+    suite,
+    model_name AS model,
+    metric_name AS metric,
+    value,
+    metric_extra_info AS extra_info,
+    benchmark_extra_info['output'] AS output,
+    timestamp,
+    DATE_TRUNC({granularity: String}, fromUnixTimestamp(timestamp))
+        AS granularity_bucket
+FROM benchmark.oss_ci_benchmark_torchinductor
+WHERE
+    (head_sha) IN (
+        SELECT DISTINCT head_sha
+        FROM benchmark.oss_ci_benchmark_torchinductor
+        PREWHERE
+            timestamp >= toUnixTimestamp({startTime: DateTime64(3,)})
+            AND timestamp < toUnixTimestamp({stopTime: DateTime64(3)})
+    )
+    AND (
+        has(
+            {branches: Array(String)},
+            replaceOne(head_branch, 'refs/heads/', '')
+        )
+        OR empty({branches: Array(String)})
+    )
+    AND benchmark_dtype = {dtype: String}
+    AND benchmark_mode = {mode: String}
+    AND device = {device: String}
+    AND positionCaseInsensitive(arch, {arch: String}) > 0
+
+SETTINGS session_timezone = 'UTC';

--- a/torchci/lib/benchmark/api_helper/utils.ts
+++ b/torchci/lib/benchmark/api_helper/utils.ts
@@ -135,9 +135,12 @@ export function getNestedField(obj: any, path: string): any {
   return path.split(".").reduce((o, key) => (o && key in o ? o[key] : ""), obj);
 }
 
+
 export type BenchmarkTimeSeriesResponse = {
+  total_rows: number;
   time_series: any[];
   time_range: { start: string; end: string };
+  total_raw_rows?: number;
 };
 
 export type CommitRow = {

--- a/torchci/lib/benchmark/api_helper/utils.ts
+++ b/torchci/lib/benchmark/api_helper/utils.ts
@@ -135,7 +135,6 @@ export function getNestedField(obj: any, path: string): any {
   return path.split(".").reduce((o, key) => (o && key in o ? o[key] : ""), obj);
 }
 
-
 export type BenchmarkTimeSeriesResponse = {
   total_rows: number;
   time_series: any[];

--- a/torchci/lib/benchmark/compilerUtils.ts
+++ b/torchci/lib/benchmark/compilerUtils.ts
@@ -440,6 +440,8 @@ export function convertToCompilerPerformanceData(data: BenchmarkData[]) {
         suite: r.suite,
         workflow_id: r.workflow_id,
         job_id: r.job_id,
+        branch: r.head_branch,
+        commit: r.head_sha,
       };
     }
 

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -205,7 +205,7 @@ export interface CompilerPerformanceData {
   workflow_id: number;
   job_id?: number;
   branch?: string;
-  commit?: string
+  commit?: string;
 }
 
 export interface TritonBenchPerformanceData {
@@ -220,7 +220,6 @@ export interface TritonBenchPerformanceData {
   mode: string;
   dtype: string;
   backend: string;
-
 }
 
 export interface BenchmarkData {
@@ -234,6 +233,8 @@ export interface BenchmarkData {
   suite: string;
   value: number;
   workflow_id: number;
+  head_sha?: string;
+  head_branch?: string;
 }
 
 export interface RepoBranchAndCommit {

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -204,6 +204,8 @@ export interface CompilerPerformanceData {
   suite: string;
   workflow_id: number;
   job_id?: number;
+  branch?: string;
+  commit?: string
 }
 
 export interface TritonBenchPerformanceData {
@@ -218,6 +220,7 @@ export interface TritonBenchPerformanceData {
   mode: string;
   dtype: string;
   backend: string;
+
 }
 
 export interface BenchmarkData {


### PR DESCRIPTION
# Overview
create a sql for compiler time series fetch. 

# details
1.  use the primary keys arch and device instead of extract info from output string. mapping can be different(see  ` New arch values in table` below for mapping details)
2. we fetch list of commits based on timestamp, instead of fetch data from timestamp, this avoid partial data fetch situation that can creating false alert for regression.

## New arch values in table
list below is nductor distinct device and arch for Pass 3 month from clickhouse oss_ci_benchmark_torchinductor table
```
SELECT DISTINCT device,arch
FROM oss_ci_benchmark_torchinductor
WHERE timestamp >= toUnixTimestamp(now() - INTERVAL 3 MONTH)
```


| device | arch                   | mapping   |
|--------|------------------------|---------|
| cpu    | x86_64                 | cpu(x86_64）        |
| cpu    | aarch64                |  cpu(aarch64）     |
| cuda   | NVIDIA A10G            |    ?     |
| cuda   | NVIDIA A100-SXM4-40GB  |      cuda(a100)   |
| cuda   | NVIDIA B200            |     cuda(b200)    |
| cuda   | NVIDIA H100 80GB HBM3  |     cuda(h100)    |
| cpu    | arm                    |      ?   |
| mps    | arm                    |      mps  |
| rocm   | AMD Instinct Mi325X VF |     rocm(mi300x) [new instance to mark as mi300x)   |
| cuda   | NVIDIA H100            |     cuda(h100)    |
| cuda   | x86_64                 |      ?   |
| rocm   | AMD Instinct MI300X    |      rocm(mi300x)   |

@huydhn  I listed question mark for unknown mapping to arch values from output, like those:
<img width="268" height="371" alt="image" src="https://github.com/user-attachments/assets/aec58455-a479-412e-ad96-39bb18547a80" />

## Next steps
add mapping support for  [AMD Instinct MI300X,AMD Instinct Mi325X VF] -> rocm(mi300x)
