### PR TITLE
[HUD][CI] Show errors in lint CI job

### DIFF
--- a/.github/workflows/torchci.yml
+++ b/.github/workflows/torchci.yml
@@ -34,7 +34,7 @@ jobs:
             exit 1
           fi
 
-          git stash pop stash^{/pre-format} || true
+          git stash pop "stash^{/pre-format}" || true
 
       - name: yarn prettier --check .
         run: |


### PR DESCRIPTION
Reason: yarn prettier doesn't show the changes, only that it failed, which can be annoying if you don't want to install yarn or if something is different between local and CI

This runs yarn format in the CI and shows the git diff to see what is different

Testing:
Made an ugly change and got: https://github.com/pytorch/test-infra/actions/runs/17619474692/job/50061257986

Fixes https://github.com/pytorch/test-infra/issues/7099