### PR TITLE
disable issues: throw error if issue retrieve goes wrong

### DIFF
--- a/torchci/test/flakyBotTests/getDisabledTestsAndJobs.test.ts
+++ b/torchci/test/flakyBotTests/getDisabledTestsAndJobs.test.ts
@@ -64,6 +64,29 @@ describe("Get disable/unstable job/test jsons", () => {
     handleScope(scope);
   });
 
+  test("Throw error if result from graphql is inconsistent", async () => {
+    // Number of tests != node list => throw error
+    const scope = nock("https://api.github.com")
+      .post("/graphql", (body) => {
+        return body.query.includes("search");
+      })
+      .reply(200, {
+        data: {
+          search: {
+            issueCount: 15,
+            pageInfo: { hasNextPage: false, endCursor: "" },
+            nodes: [],
+          },
+        },
+      });
+
+    await expect(
+      getDisabledTestsAndJobs.getDisabledTestsAndJobs(octokit)
+    ).rejects.toThrow();
+
+    handleScope(scope);
+  });
+
   test("One test", async () => {
     const issue = genSingleIssueFor(flakyTestA, {});
     const scope = [


### PR DESCRIPTION
Reason: I've noticed that sometimes a lot of stuff in the disable json gets removed even though the issues weren't closed -> CI runs the tests which should be disabled -> fails -> HUD is red.  Looking at the vercel logs, I can see `Expected 577 issues with prefix "DISABLED", but found 0.`, so it's probably that we are somehow failing to fetch the issues.  

My solution is to thrown an error in the API call, which then gets caught by the python script and raises an runtime error, so in the case of an error, the json won't get updated (and the old one will be left)

Additional things that could be done: don't update json if dramatic changes happen (ex count goes from 100 -> 0)

Testing:
Change hud url to localhost on python script, run the python script