### PR TITLE
[HUD] Add workflow run attempt to the elector for workflow id in commit and PR pages

### DIFF
--- a/torchci/clickhouse_queries/commit_jobs_query/params.json
+++ b/torchci/clickhouse_queries/commit_jobs_query/params.json
@@ -2,13 +2,15 @@
   "params": {
     "repo": "String",
     "sha": "String",
-    "workflowId": "Int64"
+    "workflowId": "Int64",
+    "runAttempt": "Int64"
   },
   "tests": [
     {
       "repo": "pytorch/pytorch",
       "sha": "85df746892d9b0e87e7a5dfa78ef81a84aec6de0",
-      "workflow_id": 0
+      "workflow_id": 0,
+      "run_attempt": 0
     }
   ]
 }

--- a/torchci/components/commit/CommitStatus.tsx
+++ b/torchci/components/commit/CommitStatus.tsx
@@ -7,6 +7,7 @@ import {
 import { CommitData, IssueData, JobData } from "lib/types";
 import useScrollTo from "lib/useScrollTo";
 import _ from "lodash";
+import { WorkflowRunInfo } from "pages/api/[repoOwner]/[repoName]/commit/[sha]";
 import { useState } from "react";
 import { linkIt, UrlComponent, urlRegex } from "react-linkify-it";
 import { getConclusionSeverityForSorting } from "../../lib/JobClassifierUtil";
@@ -59,7 +60,7 @@ function WorkflowsContainer({
 }: {
   jobs: JobData[];
   unstableIssues: IssueData[];
-  workflowIdsByName: Record<string, number[]>;
+  workflowIdsByName: Record<string, [WorkflowRunInfo]>;
   repoFullName: string;
 }) {
   useScrollTo();
@@ -117,7 +118,7 @@ export default function CommitStatus({
   repoName: string;
   commit: CommitData;
   jobs: JobData[];
-  workflowIdsByName: Record<string, number[]>;
+  workflowIdsByName: Record<string, [WorkflowRunInfo]>;
   isCommitPage: boolean;
   unstableIssues: IssueData[];
 }) {

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -30,6 +30,7 @@ export interface JobData extends BasicJobData {
   repo?: string;
   failureAnnotation?: string;
   failedPreviousRun?: boolean;
+  runAttempt?: number;
 }
 
 // Used by Dr.CI

--- a/torchci/pages/api/[repoOwner]/[repoName]/commit/[sha].ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/commit/[sha].ts
@@ -2,10 +2,15 @@ import fetchCommit from "lib/fetchCommit";
 import { CommitData, JobData } from "lib/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+export type WorkflowRunInfo = {
+  id: number;
+  attempt: number;
+};
+
 export type CommitApiResponse = {
   commit: CommitData;
   jobs: JobData[];
-  workflowIdsByName: Record<string, number[]>;
+  workflowIdsByName: Record<string, [WorkflowRunInfo]>;
 };
 
 export default async function handler(
@@ -13,6 +18,7 @@ export default async function handler(
   res: NextApiResponse<CommitApiResponse>
 ) {
   const workflowId = parseInt(req.query.workflowId as string, 10) || 0;
+  const runAttempt = parseInt(req.query.runAttempt as string, 10) || 0;
   res
     .status(200)
     .json(
@@ -20,7 +26,8 @@ export default async function handler(
         req.query.repoOwner as string,
         req.query.repoName as string,
         req.query.sha as string,
-        workflowId
+        workflowId,
+        runAttempt
       )
     );
 }


### PR DESCRIPTION
This is a continuation of https://github.com/pytorch/test-infra/pull/6919

There can be multiple attempts per workflow, this makes it so you can select which one.

This is mostly so I can get the TD info easier in the UI since TD info is per workflow and run attempt https://github.com/pytorch/test-infra/pull/6919#issuecomment-3071528184

Old: 
<img width="262" height="97" alt="image" src="https://github.com/user-attachments/assets/7dce3d30-cb06-4eb9-adca-8b405721f2ab" />

New:
<img width="279" height="108" alt="image" src="https://github.com/user-attachments/assets/8c541a41-d53f-4202-a515-6d90b88b4a6d" />
