### PR TITLE
Removing text from nightly job

### DIFF
--- a/.github/workflows/trigger_nightly.yml
+++ b/.github/workflows/trigger_nightly.yml
@@ -14,7 +14,6 @@ on:
         options:
           - vision
           - audio
-          - text
           - torchrec
           - tensorrt
           - data
@@ -48,14 +47,6 @@ jobs:
           repository: pytorch/data
           token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
           path: data
-      - name: Trigger nightly text build
-        if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'text' || inputs.domain == 'all' }}
-        uses: ./.github/actions/trigger-nightly
-        with:
-          ref: main
-          repository: pytorch/text
-          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-          path: text
       - name: Trigger nightly vision build
         if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'vision' || inputs.domain == 'all' }}
         uses: ./.github/actions/trigger-nightly


### PR DESCRIPTION
cc @ZainRizvi 

Nightly job failed:
https://github.com/pytorch/test-infra/actions/runs/17643236253/job/50134931363

```
 * [new branch]      nightly    -> origin/nightly
remote: This repository was archived so it is read-only.
fatal: unable to access 'https://github.com/pytorch/text/': The requested URL returned error: 403
Error: Process completed with exit code 128.
```