### PR TITLE
refactor: use SWR for LLM comparison dashboard

### DIFF
--- a/torchci/lib/benchmark/llms/utils/llmUtils.ts
+++ b/torchci/lib/benchmark/llms/utils/llmUtils.ts
@@ -115,20 +115,24 @@ export const useBenchmarkPropsData = (queryParams: any) => {
   });
 };
 
-export function fetchBenchmarkDataForRepos(
+export function useBenchmarkDataForRepos(
   queryName: string,
   queryParamsList: any[]
-): Promise<{ data?: any; error?: any }[]> {
-  return Promise.all(
-    queryParamsList.map((queryParam) => {
-      const url = `/api/clickhouse/${queryName}?parameters=${encodeURIComponent(
-        JSON.stringify(queryParam)
-      )}`;
-      return fetcher(url)
-        .then((data: any) => ({ data }))
-        .catch((error: any) => ({ error }));
-    })
-  );
+) {
+  const fetchAll = async () =>
+    Promise.all(
+      queryParamsList.map((queryParam) => {
+        const url = `/api/clickhouse/${queryName}?parameters=${encodeURIComponent(
+          JSON.stringify(queryParam)
+        )}`;
+        return fetcher(url)
+          .then((data: any) => ({ data }))
+          .catch((error: any) => ({ error }));
+      })
+    );
+  return useSWR([queryName, queryParamsList], fetchAll, {
+    refreshInterval: 60 * 60 * 1000, // refresh every hour
+  });
 }
 
 export function combineLeftAndRight(


### PR DESCRIPTION
## Summary
- introduce useBenchmarkDataForRepos hook backed by SWR
- refactor comparison graph, report, and benchmark page to consume new hook
- remove manual Promise.all logic and unmount cancellation

## Testing
- `yarn format`
- `yarn lint`
- `yarn tsc`