### PR TITLE
[ez] Fix the wrong output length on vLLM dashboard

### DIFF
--- a/torchci/lib/benchmark/llms/utils/llmUtils.ts
+++ b/torchci/lib/benchmark/llms/utils/llmUtils.ts
@@ -151,6 +151,7 @@ export function combineLeftAndRight(
     if (jobFailureKeySet.has(key)) {
       continue;
     }
+
     const row = toRowData(dataGroupedByModel, key, repoName, benchmarkName);
     if ("metadata" in row) {
       data.push(row);


### PR DESCRIPTION
Silly bug, hard to track.  The `output_len` column printed the wrong value from the `input_len` column.