### PR TITLE
[ez][TD] Fix historical failure json generations

### DIFF
--- a/tools/torchci/td/historical_class_failure_correlation.py
+++ b/tools/torchci/td/historical_class_failure_correlation.py
@@ -22,7 +22,7 @@ FROM
 where
     t.file is not null
     and t.time_inserted > CURRENT_TIMESTAMP() - interval 90 day
-    # Slightly larger time span just in case
+    # Slightly more relaxed time window just in case
     and j.started_at > now() - interval 100 day
 """
 

--- a/tools/torchci/td/historical_file_failure_correlation.py
+++ b/tools/torchci/td/historical_file_failure_correlation.py
@@ -19,6 +19,8 @@ from
 where
     t.metric_name = 'td_test_failure_stats_v2'
     and t.timestamp > CURRENT_TIMESTAMP() - interval 90 day
+    # Slightly more relaxed time window just in case
+    and w.created_at > now() - interval 100 day
 """
 
 


### PR DESCRIPTION
Example failure: https://github.com/pytorch/test-infra/actions/runs/17611845434/job/50035433293
```
    raise OperationalError(err_str) if retried else DatabaseError(err_str) from None
clickhouse_connect.driver.exceptions.DatabaseError: HTTPDriver for *** received ClickHouse error code 241
Error: Process completed with exit code 1.
```

When running in the console, it OOMs

My solution is to filter the workflow tables so there are fewer things to scan and join