### PR TITLE
[bc-lint] preserve source location info for async functions

### DIFF
--- a/tools/stronghold/src/api/ast.py
+++ b/tools/stronghold/src/api/ast.py
@@ -211,6 +211,9 @@ class _ContextualNodeVisitor(ast.NodeVisitor):
             returns=node.returns,
             type_comment=node.type_comment,
         )
+        # Preserve source location info (lineno/col_offset)
+        fnode = ast.copy_location(fnode, node)
+        ast.fix_missing_locations(fnode)
         self._functions[name] = fnode
 
 

--- a/tools/stronghold/tests/api/test_ast.py
+++ b/tools/stronghold/tests/api/test_ast.py
@@ -213,6 +213,38 @@ def test_extract_class_method(tmp_path: pathlib.Path) -> None:
     }
 
 
+def test_extract_async_function(tmp_path: pathlib.Path) -> None:
+    async def func(a: int, *, b: int = 0) -> None:
+        pass  # pragma: no cover
+
+    funcs = api.ast.extract(source.make_file(tmp_path, func)).functions
+    assert funcs == {
+        "func": api.Parameters(
+            parameters=[
+                api.Parameter(
+                    name="a",
+                    positional=True,
+                    keyword=True,
+                    required=True,
+                    line=1,
+                    type_annotation=api.types.TypeName("int"),
+                ),
+                api.Parameter(
+                    name="b",
+                    positional=False,
+                    keyword=True,
+                    required=False,
+                    line=1,
+                    type_annotation=api.types.TypeName("int"),
+                ),
+            ],
+            variadic_args=False,
+            variadic_kwargs=False,
+            line=1,
+        )
+    }
+
+
 def test_extract_dataclass(tmp_path: pathlib.Path) -> None:
     @dataclasses.dataclass
     class Class:


### PR DESCRIPTION
Fixes errors like:
```
  File "/home/runner/work/vllm/vllm/_repo/../_test-infra/tools/stronghold/bin/check-api-compatibility/api/ast.py", line 90, in _function_def_to_parameters
    return tuple(map(_convert, node.elts))
     ^^^^^^^^^^^
AttributeError: 'FunctionDef' object has no attribute 'lineno'
```

https://github.com/vllm-project/vllm/actions/runs/17661069007/job/50194417224?pr=24219


### Testing

unit-tests