### PR TITLE
Update NVIDIA driver to 580.82.07

### DIFF
--- a/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
@@ -170,7 +170,7 @@ retry sudo dnf install kernel-modules-extra -y
 echo Installing Development Tools
 sudo modprobe backlight
 
-retry sudo curl -fsL -o /tmp/nvidia_driver 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-580.65.06.run'
+retry sudo curl -fsL -o /tmp/nvidia_driver 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-580.82.07.run'
 retry sudo /bin/bash /tmp/nvidia_driver -s --no-drm
 sudo rm -fv /tmp/nvidia_driver
 

--- a/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
+++ b/terraform-aws-github-runner/modules/runners-instances/templates/user-data.sh
@@ -170,7 +170,7 @@ retry sudo dnf install kernel-modules-extra -y
 echo Installing Development Tools
 sudo modprobe backlight
 
-retry sudo curl -fsL -o /tmp/nvidia_driver 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-570.133.07.run'
+retry sudo curl -fsL -o /tmp/nvidia_driver 'https://s3.amazonaws.com/ossci-linux/nvidia_driver/NVIDIA-Linux-x86_64-580.65.06.run'
 retry sudo /bin/bash /tmp/nvidia_driver -s --no-drm
 sudo rm -fv /tmp/nvidia_driver
 


### PR DESCRIPTION
This updates the nvidia driver to `580.82.07` to add support for CUDA 13.0 runtime.

This is similar to https://github.com/pytorch/pytorch/pull/162531 but for our entire fleet