### PR TITLE
[BE] Update flake8 configuration to ignore E203 for Black compatibility

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 120
-ignore = G004,B028,W504,W503,EXE001,G003,E402
+ignore = G004,B028,W504,W503,EXE001,G003,E402,E203

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ ignore = [
     "B904", "B905",
     "C408", # C408 ignored because we like the dict keyword argument syntax
     "E402",
+    "E203", # Black-compatible slicing whitespace
     "E501", # E501 is not flexible enough, we're using B950 instead
     "E721",
     "E731", # Assign lambda expression


### PR DESCRIPTION
PYFMT and FLAKE8 in test-infra have conflicting setting regarding whitespace before `:`

see:
https://github.com/pytorch/test-infra/actions/runs/17688919062/job/50279032133?pr=7111#step:5:90
https://github.com/pytorch/test-infra/actions/runs/17687778066/job/50275995128?pr=7111#step:5:87

this disables the check in FLAKE8 but leaves it in PYFMT


### Testing

```
lintrunner
Warning: Could not find a lintrunner config at: '.lintrunner.private.toml'. Continuing without using configuration file.
  FLAKE8 success!
  TYPEIGNORE success!
  MYPY success!
  NOQA success!
  SPACES success!
  NEWLINE success!
  TABS success!
  PYPIDEP success!
  ACTIONLINT success!
  EXEC success!
  LINTRUNNER_VERSION success!
  PYFMT failure
  COPYRIGHT success!
  RUFF success!
  SQLFLUFF success!
  SQL_PARAMS success!
  RUSTFMT success!


>>> Lint for aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_datasource.py:

  Warning (PYFMT) format
    Run `lintrunner -a` to apply this patch.

    You can run `lintrunner -a` to apply this patch.

    153  153 |         TEST_FETCH_CHUNK = 1024  # Number of job_ids to fetch per query
    154  154 |         t0 = time.perf_counter()
    155  155 |         for start in range(0, total, TEST_FETCH_CHUNK):
    155      |-            chunk = job_ids[start: start + TEST_FETCH_CHUNK]
         156 |+            chunk = job_ids[start : start + TEST_FETCH_CHUNK]
    157  157 |             batch_idx = start // TEST_FETCH_CHUNK + 1
    158  158 |             batch_total = (total + TEST_FETCH_CHUNK - 1) // TEST_FETCH_CHUNK
    159  159 |             log.info(


lintrunner -a
Warning: Could not find a lintrunner config at: '.lintrunner.private.toml'. Continuing without using configuration file.
  TYPEIGNORE success!
  FLAKE8 success!
  MYPY success!
  NEWLINE success!
  SPACES success!
  NOQA success!
  PYPIDEP success!
  COPYRIGHT success!
  TABS success!
  ACTIONLINT success!
  EXEC success!
  LINTRUNNER_VERSION success!
  PYFMT success!
  RUFF success!
  SQLFLUFF success!
  SQL_PARAMS success!
  RUSTFMT success!
ok No lint issues.
Successfully applied all patches.

```