### PR TITLE
[autorevert] filter out 'mem_leak_check' and 'rerun_disabled_tests' workflows from queries

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_checker.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_checker.py
@@ -155,6 +155,7 @@ class AutorevertPatternChecker:
                 -- it is just a optimization as this column is indexed
                 AND wf.created_at >= {lookback_time:DateTime}
                 AND wf.dynamoKey LIKE 'pytorch/pytorch/%'
+                AND (wf.name NOT LIKE '%mem_leak_check%' AND wf.name NOT LIKE '%rerun_disabled_tests%')
             ORDER BY
                 wf.workflow_name, push_dedup.timestamp DESC, wf.head_sha, wf.name
         """

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_datasource.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_datasource.py
@@ -78,6 +78,7 @@ class SignalExtractionDatasource:
         INNER JOIN push_dedup p ON wf.head_sha = p.sha
         WHERE wf.repository_full_name = {{repo:String}}
           AND wf.created_at >= {{lookback_time:DateTime}}
+          AND (wf.name NOT LIKE '%mem_leak_check%' AND wf.name NOT LIKE '%rerun_disabled_tests%')
           {workflow_filter}
         ORDER BY p.ts DESC, wf.started_at ASC, wf.head_sha, wf.run_id, wf.run_attempt, wf.name
         """


### PR DESCRIPTION
These special jobs are triggered once per day and introduce noise for the autorevert (see attached):
[hud-sep15-01.html](https://github.com/user-attachments/files/22352050/hud-sep15-01.html)


### Testing

```
 python -m pytorch_auto_revert hud Lint trunk pull inductor  --hours 32  --out hud-sep15-02.html 
 ```
 
[hud-sep15-02.html](https://github.com/user-attachments/files/22352058/hud-sep15-02.html)
