### PR TITLE
[HUD] [Bug] Show repository column only for comparsion mode

### DIFF
--- a/torchci/components/benchmark/llms/components/LLMsSummaryPanel.tsx
+++ b/torchci/components/benchmark/llms/components/LLMsSummaryPanel.tsx
@@ -165,9 +165,7 @@ export default function LLMsSummaryPanel({
   ];
 
   // Add source repository column for multi-repo comparisons
-  const shouldShowRepoColumn =
-    mode === LLMsBenchmarkMode.RepoComparison ||
-    data.some((row) => row.sourceRepo || row.repo_name);
+  const shouldShowRepoColumn = mode === LLMsBenchmarkMode.RepoComparison;
   if (shouldShowRepoColumn) {
     columns.push({
       field: "sourceRepo",


### PR DESCRIPTION
We were currently showing the `repository` column for all the benchmarking modes (single and comparison).
But, I think we should show it only for the `comparison` mode, as that mode has more than one repositories.

This PR fixes that issue.

**Testing**
* Single Benchmarking mode (repo column not visible)
<img width="1720" height="946" alt="Screenshot 2025-09-16 at 9 32 49 AM" src="https://github.com/user-attachments/assets/29e7537c-cc5d-47e7-a320-fea776c5619a" />

* Comparison Benchmarking mode (repo column visible)
<img width="1720" height="946" alt="Screenshot 2025-09-16 at 9 32 37 AM" src="https://github.com/user-attachments/assets/9f02e5e9-c2fc-4607-b42d-a07d4edc30a0" />

