### PR TITLE
[ez] Apply ruff linter to s3 management scripts

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -348,7 +348,6 @@ exclude_patterns = [
     'aws/lambda/servicelab-ingestor/**',
     'aws/lambda/tests/**',
     'aws/lambda/whl_metadata_upload_pep658/**',
-    's3_management/**',
     'tools/**',
 ]
 command = [

--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -7,11 +7,9 @@ import dataclasses
 import functools
 import time
 from collections import defaultdict
-from contextlib import suppress
-from datetime import datetime
 from os import makedirs, path
-from re import match, search, sub
-from typing import Dict, Iterable, List, Optional, Set, Type, TypeVar, Union
+from re import match, sub
+from typing import Dict, Iterable, List, Optional, Set, TypeVar
 
 import boto3  # type: ignore[import]
 import botocore  # type: ignore[import]

--- a/s3_management/update_dependencies.py
+++ b/s3_management/update_dependencies.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, List, Union
+from typing import Dict, List
 
 import boto3  # type: ignore[import-untyped]
 
@@ -330,7 +330,6 @@ PACKAGES_PER_PROJECT: Dict[str, List[Dict[str, str]]] = {
     "certifi": [{"version": "latest", "project": "torchtune"}],
     "charset-normalizer": [{"version": "latest", "project": "torchtune"}],
     "datasets": [{"version": "latest", "project": "torchtune"}],
-    "dill": [{"version": "latest", "project": "torchtune"}],
     "frozenlist": [{"version": "latest", "project": "torchtune"}],
     "huggingface-hub": [{"version": "latest", "project": "torchtune"}],
     "idna": [{"version": "latest", "project": "torchtune"}],
@@ -339,12 +338,10 @@ PACKAGES_PER_PROJECT: Dict[str, List[Dict[str, str]]] = {
     "multidict": [{"version": "latest", "project": "torchtune"}],
     "multiprocess": [{"version": "latest", "project": "torchtune"}],
     "omegaconf": [{"version": "latest", "project": "torchtune"}],
-    "pandas": [{"version": "latest", "project": "torchtune"}],
     "pyarrow": [{"version": "latest", "project": "torchtune"}],
     "pyarrow-hotfix": [{"version": "latest", "project": "torchtune"}],
     "pycryptodomex": [{"version": "latest", "project": "torchtune"}],
     "python-dateutil": [{"version": "latest", "project": "torchtune"}],
-    "pytz": [{"version": "latest", "project": "torchtune"}],
     "pyyaml": [{"version": "latest", "project": "torchtune"}],
     "regex": [{"version": "latest", "project": "torchtune"}],
     "requests": [{"version": "latest", "project": "torchtune"}],
@@ -353,7 +350,6 @@ PACKAGES_PER_PROJECT: Dict[str, List[Dict[str, str]]] = {
     "six": [{"version": "latest", "project": "torchtune"}],
     "tiktoken": [{"version": "latest", "project": "torchtune"}],
     "tqdm": [{"version": "latest", "project": "torchtune"}],
-    "tzdata": [{"version": "latest", "project": "torchtune"}],
     "urllib3": [{"version": "latest", "project": "torchtune"}],
     "xxhash": [{"version": "latest", "project": "torchtune"}],
     "yarl": [{"version": "latest", "project": "torchtune"}],
@@ -577,11 +573,11 @@ def main() -> None:
     parser = ArgumentParser("Upload dependent packages to s3://pytorch")
     # Get unique paths from the packages list
     project_paths = list(
-        set(
+        {
             config["project"]
             for pkg_configs in PACKAGES_PER_PROJECT.values()
             for config in pkg_configs
-        )
+        }
     )
     parser.add_argument("--package", choices=project_paths, default="torch")
     parser.add_argument("--dry-run", action="store_true")


### PR DESCRIPTION
Enable ruff linter on s3 management scripts.  Some entries are removed from `s3_management/update_dependencies.py` because they are duplicated