### PR TITLE
[autorevert] Configure root logger for AWS lambda

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
@@ -23,7 +23,22 @@ def setup_logging(log_level: str) -> None:
     numeric_level = getattr(logging, log_level.upper(), None)
     if not isinstance(numeric_level, int):
         raise ValueError(f"Invalid log level: {log_level}")
-    logging.basicConfig(level=numeric_level)
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(numeric_level)
+
+    if not root_logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setLevel(numeric_level)
+        formatter = logging.Formatter(
+            "%(asctime)s %(levelname)s [%(name)s] %(message)s"
+        )
+        handler.setFormatter(formatter)
+        root_logger.addHandler(handler)
+    else:
+        for handler in root_logger.handlers:
+            if handler.level == logging.NOTSET:
+                handler.setLevel(numeric_level)
 
 
 def get_opts() -> argparse.Namespace:


### PR DESCRIPTION
Explanation from gpt-5-codex:

> Info-level lines from the new flow disappear in Lambda because of how Python logging behaves once the runtime has already attached its own handler. On every cold start AWS sets up the root logger with a handler that streams to CloudWatch and leaves the logger at its default WARNING level. Python’s logging.basicConfig(...) (which setup_logging calls
  in pytorch_auto_revert/__main__.py:24) only configures the root logger when it has no handlers; if one is already present, the call is a no-op—no level change, no formatter change. Even though LOG_LEVEL is DEBUG, we never actually lower the root logger’s threshold, so logging.info(...) statements from testers/autorevert_v2.py respect the still-
  WARNING root level and get filtered out. The lone line you’re seeing ([WARNING] Workflow … already restarted …) comes from logging.warning(...) in workflow_checker.py:121, which survives because it meets the logger’s threshold.

>  In the legacy flow (see pytorch_auto_revert/testers/autorevert.py), most “logs” were literal print(...) calls. Lambda captures stdout/stderr and labels it as INFO, so those showed up even without any logging configuration. We shifted to structured logging in v2, but because the runtime’s pre-existing handler prevented basicConfig from taking effect,
  everything below WARNING was silently dropped. The patch we discussed explicitly sets the root logger level (and adjusts handler levels when they’re left at NOTSET), so the value from LOG_LEVEL truly applies and the [v2] … info lines will appear once the Lambda is redeployed.
  
  
  ----
  
  The fix verified by monkey-patching the logger setup in prod.
