### PR TITLE
[autorevert] introduce RevertAction.RUN_LOG with deduplication on write

### DIFF
--- a/aws/lambda/pytorch-auto-revert/SIGNAL_ACTIONS.md
+++ b/aws/lambda/pytorch-auto-revert/SIGNAL_ACTIONS.md
@@ -82,6 +82,6 @@ State JSON `meta` contains: `repo`, `workflows`, `lookback_hours`, `ts`, `restar
    - Restarts: skip if ≥2 prior restarts exist for `(workflow_target, commit_sha)`; skip if the latest is within 15 minutes of `ts`
 5. Execute eligible actions using the per-action mode:
    - Restart: `run` → dispatch and log; `log` → log only; `skip` → no logging
-   - Revert: currently record intent only; `run-notify`/`run-revert` modes are allowed but still log intent (no GH revert yet)
+   - Revert: currently record intent only; `run-log` writes the same non-dry-run log row used in prod (for dedup) but does not revert; `run-notify`/`run-revert` remain “log intent” placeholders until side effects are implemented
 6. Insert one `autorevert_events_v2` row per executed group with aggregated `workflows` and `source_signal_keys`.
 7. Separately (integration), build the full run state and call the run‑state logger to write a single `autorevert_state` row with the same `ts`.

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
@@ -110,7 +110,7 @@ def get_opts() -> argparse.Namespace:
         default=RevertAction.LOG,
         choices=list(RevertAction),
         help=(
-            "Revert mode: skip, log (no side effects), run-notify (side effect), or run-revert (side effect)."
+            "Revert mode: skip, log (no side effects), run-log (prod-style logging), run-notify, or run-revert."
         ),
     )
 
@@ -203,7 +203,7 @@ def main(*args, **kwargs) -> None:
             hours=int(os.environ.get("HOURS", 16)),
             repo_full_name=os.environ.get("REPO_FULL_NAME", "pytorch/pytorch"),
             restart_action=(RestartAction.LOG if opts.dry_run else RestartAction.RUN),
-            revert_action=RevertAction.LOG,
+            revert_action=(RevertAction.LOG if opts.dry_run else RevertAction.RUN_LOG),
         )
     elif opts.subcommand == "autorevert-checker":
         # New default behavior under the same subcommand

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/utils.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/utils.py
@@ -27,12 +27,14 @@ class RevertAction(Enum):
 
     - SKIP: no logging, no side effects
     - LOG: read prod state, log revert intent only (no side effects)
+    - RUN_LOG: read prod state, log revert intent with production dry-run flag (side effects limited to logging)
     - RUN_NOTIFY: read prod state, send notification (side effect) but no revert
     - RUN_REVERT: read prod state, perform revert (side effect)
     """
 
     SKIP = "skip"
     LOG = "log"
+    RUN_LOG = "run-log"
     RUN_NOTIFY = "run-notify"
     RUN_REVERT = "run-revert"
 
@@ -41,5 +43,9 @@ class RevertAction(Enum):
 
     @property
     def side_effects(self) -> bool:
-        """True if this mode performs external side effects (e.g. notify/revert)."""
-        return self in (RevertAction.RUN_NOTIFY, RevertAction.RUN_REVERT)
+        """True if this mode performs external side effects or non-dry-run logging."""
+        return self in (
+            RevertAction.RUN_LOG,
+            RevertAction.RUN_NOTIFY,
+            RevertAction.RUN_REVERT,
+        )


### PR DESCRIPTION
RevertAction.RUN_LOG  (side-effects=True)

Semantics:
1. provides a production-like deduplication, but doesn't have side effects beyond creating a log record with dry-run=0
2. a default mode for lambda entry point (main call without subcommand)