### PR TITLE
[Win] Update pip dependencies

### DIFF
--- a/aws/ami/windows/scripts/Installers/Install-Pip-Dependencies.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-Pip-Dependencies.ps1
@@ -13,4 +13,4 @@ if (-Not (Test-Path -Path $condaHook -PathType Leaf)) {
 conda activate base
 
 # Some dependencies are installed by pip before testing, pin all of them
-pip install "ninja==1.10.0.post1" "future==0.18.2" "hypothesis==5.35.1" "expecttest==0.1.3" "librosa>=0.6.2" "scipy==1.6.3" "psutil==5.9.1" "pynvml==11.4.1" "pillow==9.2.0" "unittest-xml-reporting<=3.2.0,>=2.0.0" "pytest==7.1.3" "pytest-xdist==2.5.0" "pytest-flakefinder==1.1.0" "pytest-shard==0.1.2" "sympy==1.11.1" "xdoctest==1.0.2" "pygments==2.12.0" "opt-einsum>=3.3" "networkx==2.8.8" "mpmath==1.2.1" "pytest-rerunfailures==10.3" "pytest-cpp==2.3.0"
+pip install "ninja==1.10.0.post1" "future==0.18.2" "hypothesis==5.35.1" "expecttest==0.3.0" "librosa>=0.6.2" "scipy==1.6.3" "psutil==5.9.1" "pynvml==11.4.1" "pillow==9.2.0" "unittest-xml-reporting<=3.2.0,>=2.0.0" "pytest==7.1.3" "pytest-xdist==2.5.0" "pytest-flakefinder==1.1.0" "pytest-shard==0.1.2" "sympy==1.11.1" "xdoctest==1.3.0" "pygments==2.12.0" "opt-einsum>=3.3" "networkx==2.8.8" "mpmath==1.2.1" "pytest-rerunfailures==10.3" "pytest-cpp==2.3.0"


### PR DESCRIPTION
`xdoctests` from 0.1.3 to 1.3.0 to meet the rule set in  

https://github.com/pytorch/pytorch/blob/264e7f68a095b5b2f10e7ca66a3bbb16f6e56e28/.github/workflows/_win-test.yml#L119

`expecttest` from 0.1.3 to 0.3.0 to match the version set in 

https://github.com/pytorch/pytorch/blob/264e7f68a095b5b2f10e7ca66a3bbb16f6e56e28/.ci/pytorch/win-test.sh#L56
