### PR TITLE
[HUD] [vLLM Profiling] Fix S3 path and add more filters for vLLM Profiling

### DIFF
--- a/torchci/components/benchmark/llms/LLMsBenchmarkPage.tsx
+++ b/torchci/components/benchmark/llms/LLMsBenchmarkPage.tsx
@@ -221,7 +221,7 @@ const MainPage = ({
         benchmarkPropsQueryParams={queryParams}
       />
       {props.repoName === "vllm-project/vllm" && (
-        <VllmArtifactsTable selectedModelName={props.modelName} />
+        <VllmArtifactsTable props={props} />
       )}
     </div>
   );

--- a/torchci/components/benchmark/llms/LLMsBenchmarkPage.tsx
+++ b/torchci/components/benchmark/llms/LLMsBenchmarkPage.tsx
@@ -34,8 +34,8 @@ import {
 } from "lib/benchmark/llms/utils/llmUtils";
 import { LLMsDashboardPicker } from "./components/dashboardPicker/LLMsDashboardPicker";
 import { LLMsTimeRangePicker } from "./components/dashboardPicker/LLMsTimeRangePicker";
+import { ProfilingArtifactsTable } from "./components/ProfilingArtifactsTable";
 import LLMsReport from "./components/report/LLMsReport";
-import { VllmArtifactsTable } from "./components/VllmArtifactsTable";
 
 export default function LLMsBenchmarkPage() {
   const router = useRouter();
@@ -220,9 +220,7 @@ const MainPage = ({
         metricNames={metricNames}
         benchmarkPropsQueryParams={queryParams}
       />
-      {props.repoName === "vllm-project/vllm" && (
-        <VllmArtifactsTable props={props} />
-      )}
+      <ProfilingArtifactsTable props={props} />
     </div>
   );
 };

--- a/torchci/components/benchmark/llms/components/ProfilingArtifactsTable.tsx
+++ b/torchci/components/benchmark/llms/components/ProfilingArtifactsTable.tsx
@@ -26,7 +26,7 @@ const columns: GridColDef<ArtifactRow>[] = [
     flex: 1.1,
     renderCell: (params) => (
       <span style={{ overflowWrap: "anywhere" }}>
-        {params.row.modelName || "—"}
+        {params.row.modelName.replace(/_/, "/") || "—"}
       </span>
     ),
   },
@@ -88,11 +88,13 @@ const columns: GridColDef<ArtifactRow>[] = [
   },
 ];
 
-type VllmArtifactsTableProps = {
+type ProfilingArtifactsTableProps = {
   props: LLMsBenchmarkProps;
 };
 
-export function VllmArtifactsTable({ props }: VllmArtifactsTableProps) {
+export function ProfilingArtifactsTable({
+  props,
+}: ProfilingArtifactsTableProps) {
   // Parse deviceName which is in format "deviceType (architecture)"
   // e.g., "cuda (NVIDIA B200)" -> deviceType: "cuda", deviceName: "NVIDIA B200"
   const deviceName =
@@ -130,7 +132,7 @@ export function VllmArtifactsTable({ props }: VllmArtifactsTableProps) {
       : undefined;
 
   const { data, error } = useArtifacts({
-    prefix: "vllm-project/vllm/",
+    repository: props.repoName,
     modelName: processedModelName,
     deviceType: device !== "" ? device : undefined,
     deviceName: arch !== "" ? arch : undefined,
@@ -159,7 +161,7 @@ export function VllmArtifactsTable({ props }: VllmArtifactsTableProps) {
     <Grid container spacing={10} sx={{ mt: 4 }}>
       <Grid size={{ xs: 12, lg: 11.8 }}>
         <TablePanelWithData
-          title={"vLLM Profiling Traces"}
+          title={"Profiling Traces"}
           data={tableData}
           columns={columns}
           dataGridProps={{

--- a/torchci/lib/benchmark/llms/utils/artifacts.ts
+++ b/torchci/lib/benchmark/llms/utils/artifacts.ts
@@ -19,7 +19,7 @@ export type ArtifactResponse = {
 };
 
 export type UseArtifactsOptions = {
-  prefix?: string;
+  repository?: string;
   lookbackDays?: number;
   modelName?: string;
   deviceType?: string;
@@ -34,8 +34,8 @@ export const useArtifacts = (options: UseArtifactsOptions = {}) => {
   const mergedOptions = { ...DEFAULT_OPTIONS, ...options };
   const params = new URLSearchParams();
 
-  if (options.prefix) {
-    params.set("prefix", options.prefix);
+  if (options.repository) {
+    params.set("repository", options.repository);
   }
 
   if (options.modelName) {

--- a/torchci/lib/benchmark/llms/utils/artifacts.ts
+++ b/torchci/lib/benchmark/llms/utils/artifacts.ts
@@ -1,3 +1,4 @@
+import { LAST_N_DAYS } from "components/benchmark/common";
 import { fetcher } from "lib/GeneralUtils";
 import useSWR from "swr";
 
@@ -6,6 +7,8 @@ export type ArtifactFile = {
   url: string;
   date: string;
   modelName: string;
+  deviceType: string;
+  deviceName: string;
   fileName: string;
   commitHash: string;
   workflowId: string;
@@ -17,11 +20,14 @@ export type ArtifactResponse = {
 
 export type UseArtifactsOptions = {
   prefix?: string;
-  lookbackMonths?: number;
+  lookbackDays?: number;
+  modelName?: string;
+  deviceType?: string;
+  deviceName?: string;
 };
 
-const DEFAULT_OPTIONS: Required<Pick<UseArtifactsOptions, "lookbackMonths">> = {
-  lookbackMonths: 6,
+const DEFAULT_OPTIONS: Required<Pick<UseArtifactsOptions, "lookbackDays">> = {
+  lookbackDays: LAST_N_DAYS,
 };
 
 export const useArtifacts = (options: UseArtifactsOptions = {}) => {
@@ -32,8 +38,20 @@ export const useArtifacts = (options: UseArtifactsOptions = {}) => {
     params.set("prefix", options.prefix);
   }
 
-  if (mergedOptions.lookbackMonths) {
-    params.set("lookbackMonths", String(mergedOptions.lookbackMonths));
+  if (options.modelName) {
+    params.set("modelName", options.modelName);
+  }
+
+  if (options.deviceType) {
+    params.set("deviceType", options.deviceType);
+  }
+
+  if (options.deviceName) {
+    params.set("deviceName", options.deviceName);
+  }
+
+  if (mergedOptions.lookbackDays) {
+    params.set("lookbackDays", String(mergedOptions.lookbackDays));
   }
 
   const queryString = params.toString();

--- a/torchci/pages/api/artifacts/index.ts
+++ b/torchci/pages/api/artifacts/index.ts
@@ -3,7 +3,7 @@ import dayjs from "dayjs";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 const S3_BASE_URL = "https://gha-artifacts.s3.us-east-1.amazonaws.com";
-const DEFAULT_TARGET_PREFIX = "vllm-project/vllm/";
+const DEFAULT_TARGET_REPO = "vllm-project/vllm/";
 
 type ArtifactFile = {
   key: string;
@@ -31,14 +31,14 @@ export default async function handler(
   }
 
   try {
-    const prefixParam = req.query.prefix as string | undefined;
+    const repositoryParam = req.query.repository as string | undefined;
     const lookbackParam = req.query.lookbackDays as string | undefined;
     const modelNameParam = req.query.modelName as string | undefined;
     const deviceTypeParam = req.query.deviceType as string | undefined;
     const deviceNameParam = req.query.deviceName as string | undefined;
 
     // Build the full S3 prefix path based on provided parameters
-    let targetPrefix = parsePrefix(prefixParam);
+    let targetPrefix = parsePrefix(repositoryParam);
 
     // Append model name if provided
     if (modelNameParam && modelNameParam.trim()) {
@@ -126,7 +126,7 @@ async function listS3Keys(prefix: string) {
 function parsePrefix(raw: string | undefined) {
   const value = raw?.trim();
   if (!value) {
-    return DEFAULT_TARGET_PREFIX;
+    return DEFAULT_TARGET_REPO;
   }
   return value.endsWith("/") ? value : `${value}/`;
 }


### PR DESCRIPTION
## Changes

- Implemented a Generic approach for showing profiling traces for any repository.
- Implemented filters for showing profiling traces based on "time_range", "model_name", "device_type" and "device_architecture".

## Testing

- Verified through the HUD Dashboard for a scenario when we have profiling traces for a model (i.e. `repo`: `vllm` and `model`: `facebook\opt-125m`) : [link](https://torchci-6vl6o8lmz-fbopensource.vercel.app/benchmark/llms?startTime=Sat%2C%2013%20Sep%202025%2022%3A45%3A56%20GMT&stopTime=Sat%2C%2020%20Sep%202025%2022%3A45%3A56%20GMT&granularity=day&lBranch=main&lCommit=3e903b6cb4292ca1425a37cb809c1e3cddfdadcb&rBranch=main&rCommit=d88918e4c2d189eb25724a6cff9a9028c67daa07&repoName=vllm-project%2Fvllm&benchmarkName=&modelName=facebook%2Fopt-125m&backendName=All%20Backends&modeName=All%20Modes&dtypeName=All%20DType&deviceName=All%20Devices&archName=All%20Platforms)
- Verified through the HUD Dashboard for a scenario when we don't have profiling traces for a model (i.e. `repo`: `vllm` and `model`: `llama3-8b`): [link](https://torchci-6vl6o8lmz-fbopensource.vercel.app/benchmark/llms?startTime=Sat%2C%2013%20Sep%202025%2022%3A45%3A56%20GMT&stopTime=Sat%2C%2020%20Sep%202025%2022%3A45%3A56%20GMT&granularity=day&lBranch=main&lCommit=3e903b6cb4292ca1425a37cb809c1e3cddfdadcb&rBranch=main&rCommit=bef180f00978186fcc84f7ca6328a6ae6c39676d&repoName=vllm-project%2Fvllm&benchmarkName=&modelName=meta-llama%2FMeta-Llama-3.1-8B-Instruct&backendName=All%20Backends&modeName=All%20Modes&dtypeName=All%20DType&deviceName=All%20Devices&archName=All%20Platforms)
- Filter based on TimeRange and Device selection (once model is selected) also works as expected.

<img width="1708" height="220" alt="Screenshot 2025-09-20 at 3 47 37 PM" src="https://github.com/user-attachments/assets/f985598f-968b-4793-80a3-468a30f0b79a" />
