### PR TITLE
[autorevert] QoL for hud-html: default values

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
@@ -4,18 +4,26 @@ import argparse
 import base64
 import logging
 import os
+from typing import Optional
 
 from dotenv import load_dotenv
 
 from .clickhouse_client_helper import CHCliFactory
 from .github_client_helper import GHClientFactory
 from .testers.autorevert_v2 import autorevert_v2
-from .testers.hud import render_hud_html_from_clickhouse, write_hud_html
+from .testers.hud import (
+    default_hud_filename,
+    get_state_timestamp,
+    render_hud_html_from_clickhouse,
+    write_hud_html,
+)
 from .testers.restart_checker import workflow_restart_checker
 from .utils import RestartAction, RevertAction
 
 
 DEFAULT_WORKFLOWS = ["Lint", "trunk", "pull", "inductor"]
+# Special constant to indicate --hud-html was passed as a flag (without a value)
+HUD_HTML_NO_VALUE_FLAG = object()
 
 
 def setup_logging(log_level: str) -> None:
@@ -131,10 +139,10 @@ def get_opts() -> argparse.Namespace:
     workflow_parser.add_argument(
         "--hud-html",
         nargs="?",
-        const="hud.html",
+        const=HUD_HTML_NO_VALUE_FLAG,
         default=None,
         help=(
-            "If set, write the run state to HUD HTML at the given path (defaults to hud.html when flag provided)."
+            "If set, write the run state to HUD HTML; omit a value to use the run timestamp as the filename."
         ),
     )
 
@@ -163,6 +171,8 @@ def get_opts() -> argparse.Namespace:
     )
     hud_parser.add_argument(
         "timestamp",
+        nargs="?",
+        default=None,
         help="Run timestamp in UTC (e.g. '2025-09-17 20:29:15') matching misc.autorevert_state.ts",
     )
     hud_parser.add_argument(
@@ -176,9 +186,9 @@ def get_opts() -> argparse.Namespace:
     hud_parser.add_argument(
         "--hud-html",
         nargs="?",
-        const="hud.html",
-        default="hud.html",
-        help="Output HTML file path (default: hud.html)",
+        const=HUD_HTML_NO_VALUE_FLAG,
+        default=None,
+        help="Output HTML file path (defaults to the timestamp-based filename)",
     )
 
     return parser.parse_args()
@@ -229,16 +239,27 @@ def main(*args, **kwargs) -> None:
             restart_action=(RestartAction.LOG if opts.dry_run else opts.restart_action),
             revert_action=(RevertAction.LOG if opts.dry_run else opts.revert_action),
         )
-        if opts.hud_html:
-            write_hud_html(state_json, opts.hud_html)
+        hud_out_path: Optional[str] = None
+        if opts.hud_html is not None:
+            if opts.hud_html is HUD_HTML_NO_VALUE_FLAG:
+                ts = get_state_timestamp(state_json)
+                hud_out_path = default_hud_filename(ts)
+            else:
+                hud_out_path = opts.hud_html
+        if hud_out_path:
+            write_hud_html(state_json, hud_out_path)
     elif opts.subcommand == "workflow-restart-checker":
         workflow_restart_checker(opts.workflow, commit=opts.commit, days=opts.days)
     elif opts.subcommand == "hud":
+        out_path: Optional[str] = (
+            None if opts.hud_html is HUD_HTML_NO_VALUE_FLAG else opts.hud_html
+        )
+
         # Delegate to testers.hud module
         render_hud_html_from_clickhouse(
             opts.timestamp,
             repo_full_name=opts.repo_full_name,
-            out_path=opts.hud_html,
+            out_path=out_path,
         )
 
 

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/testers/hud.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/testers/hud.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from typing import Any, Mapping, Optional, Union
 
 from ..hud_renderer import render_html_from_state
@@ -13,6 +14,27 @@ def _ensure_state_dict(state: RunStatePayload) -> Mapping[str, Any]:
     if isinstance(state, str):
         return json.loads(state)
     return state
+
+
+def get_state_timestamp(state: RunStatePayload) -> str:
+    """Extract the run timestamp embedded in the HUD state payload."""
+    state_dict = _ensure_state_dict(state)
+    meta = state_dict.get("meta", {})
+    ts = meta.get("ts")
+    if not ts:
+        raise ValueError("State payload is missing meta.ts")
+    return str(ts)
+
+
+def default_hud_filename(timestamp: str) -> str:
+    """Produce a filesystem-friendly HUD filename for the given timestamp."""
+    # Replace separators that are invalid on some filesystems (e.g. Windows).
+    sanitized = timestamp.strip().replace(" ", "_").replace(":", "-")
+    # Whitelist characters to minimize surprises.
+    sanitized = re.sub(r"[^A-Za-z0-9._-]", "-", sanitized)
+    if not sanitized:
+        raise ValueError("Timestamp did not produce a usable filename")
+    return f"{sanitized}.html"
 
 
 def write_hud_html(state: RunStatePayload, out_path: str) -> str:
@@ -36,20 +58,35 @@ def write_hud_html(state: RunStatePayload, out_path: str) -> str:
 
 
 def render_hud_html_from_clickhouse(
-    timestamp: str,
+    timestamp: Optional[str],
     *,
     repo_full_name: Optional[str] = None,
-    out_path: str,
+    out_path: Optional[str] = None,
 ) -> str:
-    """Fetch a logged autorevert state from ClickHouse by timestamp and render HUD HTML."""
+    """Fetch a logged autorevert state from ClickHouse and render HUD HTML.
+
+    If ``timestamp`` is ``None``, the latest non-dry-run state is used.
+    When ``out_path`` is ``None``, the filename defaults to the resolved timestamp.
+    """
+
+    datasource = SignalExtractionDatasource()
+    resolved_ts = timestamp
+    if resolved_ts is None:
+        resolved_ts = datasource.fetch_latest_non_dry_run_timestamp(
+            repo_full_name=repo_full_name
+        )
+        if resolved_ts is None:
+            raise RuntimeError(
+                "No non-dry-run autorevert_state rows available for HUD rendering"
+            )
 
     logging.info(
         "[hud] Fetching run state ts=%s repo=%s",
-        timestamp,
+        resolved_ts,
         repo_full_name or "<any>",
     )
-    rows = SignalExtractionDatasource().fetch_autorevert_state_rows(
-        ts=timestamp, repo_full_name=repo_full_name
+    rows = datasource.fetch_autorevert_state_rows(
+        ts=resolved_ts, repo_full_name=repo_full_name
     )
     if not rows:
         raise RuntimeError(
@@ -72,5 +109,6 @@ def render_hud_html_from_clickhouse(
         workflows_display = workflows
     else:
         workflows_display = ",".join(workflows or [])
+    final_out_path = out_path or default_hud_filename(resolved_ts)
     logging.info("[hud] Loaded state for repo=%s workflows=%s", repo, workflows_display)
-    return write_hud_html(state_json, out_path)
+    return write_hud_html(state_json, final_out_path)

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_hud_helpers.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_hud_helpers.py
@@ -1,0 +1,28 @@
+import json
+
+import pytest
+from pytorch_auto_revert.testers.hud import default_hud_filename, get_state_timestamp
+
+
+def test_default_hud_filename_sanitizes_colons_and_spaces():
+    assert default_hud_filename("2025-09-22 18:59:14") == "2025-09-22_18-59-14.html"
+
+
+def test_default_hud_filename_rejects_blank_input():
+    with pytest.raises(ValueError):
+        default_hud_filename("   ")
+
+
+def test_get_state_timestamp_from_mapping():
+    state = {"meta": {"ts": "2025-09-22T18:59:14"}}
+    assert get_state_timestamp(state) == "2025-09-22T18:59:14"
+
+
+def test_get_state_timestamp_from_json_string():
+    state_json = json.dumps({"meta": {"ts": "2025-09-22T18:59:14"}})
+    assert get_state_timestamp(state_json) == "2025-09-22T18:59:14"
+
+
+def test_get_state_timestamp_missing_value():
+    with pytest.raises(ValueError):
+        get_state_timestamp({"meta": {}})


### PR DESCRIPTION
When running `hud` subcommand or when running autorevert checker with html output as a flag (no values):

 1. use the requested timestamp as the default file name.   e.g.
```
python -m pytorch_auto_revert hud "2025-09-22 18:59:14"
```
would produce "2025-09-22_18:59:14.html".


```
 python -m pytorch_auto_revert --dry-run autorevert-checker Lint trunk pull inductor rocm rocm-mi300 --hours 18  --hud-html
```
 would also generate timestamped filename based on the internal timestamp used to log state


2. when running hud subcommand without providing timestamp, e.g.:

```
python -m pytorch_auto_revert hud
```
the timestamp is read from the latest non-dry-run state in clickhouse (so, file like "2025-09-22_18:59:14.html" would be produced).