### PR TITLE
Add a slash for torch/ao/ regex for release notes labeling

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -60,9 +60,8 @@ const filenameRegexToReleaseCategory: [RegExp, string][] = [
   // fx
   [/torch\/fx/gi, "release notes: fx"],
   [/test_fx/gi, "release notes: fx"],
-  // ao
-  [/(torch|test)\/ao/gi, "release notes: AO frontend"],
   // quantization
+  [/(torch|test)\/ao\//gi, "release notes: quantization"],
   [/(torch|test)\/quantization/gi, "release notes: quantization"],
   [/aten\/src\/ATen\/native\/quantized/gi, "release notes: quantization"],
   [/torch\/nn\/quantiz(ed|able)/gi, "release notes: quantization"],


### PR DESCRIPTION
So that aoti does not accidentally get picked up by the old regex.

Also, ao frontend + quantization are the same maintainers