### PR TITLE
Add c7i and c7a 2xlarge for testing

### DIFF
--- a/.github/canary-scale-config.yml
+++ b/.github/canary-scale-config.yml
@@ -92,6 +92,16 @@ runner_types:
     instance_type: c5.2xlarge
     is_ephemeral: true
     os: linux
+  c.linux.2xlarge.c7i.test.donotuse:
+    disk_size: 150
+    instance_type: c7i.2xlarge
+    is_ephemeral: true
+    os: linux
+  c.linux.2xlarge.c7a.test.donotuse:
+    disk_size: 150
+    instance_type: c7a.2xlarge
+    is_ephemeral: true
+    os: linux
   c.linux.4xlarge:
     disk_size: 150
     instance_type: c5.4xlarge

--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -92,6 +92,16 @@ runner_types:
     instance_type: c5.2xlarge
     is_ephemeral: true
     os: linux
+  lf.c.linux.2xlarge.c7i.test.donotuse:
+    disk_size: 150
+    instance_type: c7i.2xlarge
+    is_ephemeral: true
+    os: linux
+  lf.c.linux.2xlarge.c7a.test.donotuse:
+    disk_size: 150
+    instance_type: c7a.2xlarge
+    is_ephemeral: true
+    os: linux
   lf.c.linux.4xlarge:
     disk_size: 150
     instance_type: c5.4xlarge

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -92,6 +92,16 @@ runner_types:
     instance_type: c5.2xlarge
     is_ephemeral: true
     os: linux
+  lf.linux.2xlarge.c7i.test.donotuse:
+    disk_size: 150
+    instance_type: c7i.2xlarge
+    is_ephemeral: true
+    os: linux
+  lf.linux.2xlarge.c7a.test.donotuse:
+    disk_size: 150
+    instance_type: c7a.2xlarge
+    is_ephemeral: true
+    os: linux
   lf.linux.4xlarge:
     disk_size: 150
     instance_type: c5.4xlarge

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -88,6 +88,16 @@ runner_types:
     instance_type: c5.2xlarge
     is_ephemeral: true
     os: linux
+  linux.2xlarge.c7i.test.donotuse:
+    disk_size: 150
+    instance_type: c7i.2xlarge
+    is_ephemeral: true
+    os: linux
+  linux.2xlarge.c7a.test.donotuse:
+    disk_size: 150
+    instance_type: c7a.2xlarge
+    is_ephemeral: true
+    os: linux
   linux.4xlarge:
     disk_size: 150
     instance_type: c5.4xlarge


### PR DESCRIPTION
As part of efforts in pytorch/test-infra#7175 we'd like to be able to compare these 2 newer generation CPU hardware machines against the currently used c5 instance. This adds the 2 additional 2xlarge EC2 instance types for testing and is not meant to be used by production workflows.