### PR TITLE
[AUTOREVERT] Adds circuit breaker with issue in pytorch/pytorch 'ci: disable-autorevert'

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
@@ -244,18 +244,18 @@ def main(*args, **kwargs) -> None:
             )
             return
 
-        # autorevert_v2(
-        #     os.environ.get("WORKFLOWS", ",".join(DEFAULT_WORKFLOWS)).split(","),
-        #     hours=int(os.environ.get("HOURS", DEFAULT_HOURS)),
-        #     notify_issue_number=int(
-        #         os.environ.get("NOTIFY_ISSUE_NUMBER", DEFAULT_COMMENT_ISSUE_NUMBER)
-        #     ),
-        #     repo_full_name=repo_name,
-        #     restart_action=(RestartAction.LOG if opts.dry_run else RestartAction.RUN),
-        #     revert_action=(
-        #         RevertAction.LOG if opts.dry_run else RevertAction.RUN_NOTIFY
-        #     ),
-        # )
+        autorevert_v2(
+            os.environ.get("WORKFLOWS", ",".join(DEFAULT_WORKFLOWS)).split(","),
+            hours=int(os.environ.get("HOURS", DEFAULT_HOURS)),
+            notify_issue_number=int(
+                os.environ.get("NOTIFY_ISSUE_NUMBER", DEFAULT_COMMENT_ISSUE_NUMBER)
+            ),
+            repo_full_name=repo_name,
+            restart_action=(RestartAction.LOG if opts.dry_run else RestartAction.RUN),
+            revert_action=(
+                RevertAction.LOG if opts.dry_run else RevertAction.RUN_NOTIFY
+            ),
+        )
     elif opts.subcommand == "autorevert-checker":
         # New default behavior under the same subcommand
         _, _, state_json = autorevert_v2(

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 from dotenv import load_dotenv
 
+from .autorevert_circuit_breaker import check_autorevert_disabled
 from .clickhouse_client_helper import CHCliFactory
 from .github_client_helper import GHClientFactory
 from .testers.autorevert_v2 import autorevert_v2
@@ -234,18 +235,27 @@ def main(*args, **kwargs) -> None:
         )
 
     if opts.subcommand is None:
-        autorevert_v2(
-            os.environ.get("WORKFLOWS", ",".join(DEFAULT_WORKFLOWS)).split(","),
-            hours=int(os.environ.get("HOURS", DEFAULT_HOURS)),
-            notify_issue_number=int(
-                os.environ.get("NOTIFY_ISSUE_NUMBER", DEFAULT_COMMENT_ISSUE_NUMBER)
-            ),
-            repo_full_name=os.environ.get("REPO_FULL_NAME", DEFAULT_REPO_FULL_NAME),
-            restart_action=(RestartAction.LOG if opts.dry_run else RestartAction.RUN),
-            revert_action=(
-                RevertAction.LOG if opts.dry_run else RevertAction.RUN_NOTIFY
-            ),
-        )
+        repo_name = os.environ.get("REPO_FULL_NAME", DEFAULT_REPO_FULL_NAME)
+
+        if check_autorevert_disabled(repo_name):
+            logging.error(
+                "Autorevert is disabled via circuit breaker (ci: disable-autorevert issue found). "
+                "Exiting successfully."
+            )
+            return
+
+        # autorevert_v2(
+        #     os.environ.get("WORKFLOWS", ",".join(DEFAULT_WORKFLOWS)).split(","),
+        #     hours=int(os.environ.get("HOURS", DEFAULT_HOURS)),
+        #     notify_issue_number=int(
+        #         os.environ.get("NOTIFY_ISSUE_NUMBER", DEFAULT_COMMENT_ISSUE_NUMBER)
+        #     ),
+        #     repo_full_name=repo_name,
+        #     restart_action=(RestartAction.LOG if opts.dry_run else RestartAction.RUN),
+        #     revert_action=(
+        #         RevertAction.LOG if opts.dry_run else RevertAction.RUN_NOTIFY
+        #     ),
+        # )
     elif opts.subcommand == "autorevert-checker":
         # New default behavior under the same subcommand
         _, _, state_json = autorevert_v2(

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_circuit_breaker.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_circuit_breaker.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List, Optional
 
 from .github_client_helper import GHClientFactory
 
@@ -24,7 +23,9 @@ def check_autorevert_disabled(repo_full_name: str = "pytorch/pytorch") -> bool:
         should_disable = False
 
         # Search for open issues with the specific label
-        disable_issues = repo.get_issues(state="open", labels=["ci: disable-autorevert"])
+        disable_issues = repo.get_issues(
+            state="open", labels=["ci: disable-autorevert"]
+        )
 
         for issue in disable_issues:
             logger.info(

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_circuit_breaker.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_circuit_breaker.py
@@ -21,18 +21,32 @@ def check_autorevert_disabled(repo_full_name: str = "pytorch/pytorch") -> bool:
         gh_client = GHClientFactory().client
         repo = gh_client.get_repo(repo_full_name)
 
-        # Search for open issues with the specific label
-        issues = repo.get_issues(state="open", labels=["ci: disable-autorevert"])
+        should_disable = False
 
-        for issue in issues:
+        # Search for open issues with the specific label
+        disable_issues = repo.get_issues(state="open", labels=["ci: disable-autorevert"])
+
+        for issue in disable_issues:
             logger.info(
                 f"Found open issue #{issue.number} with 'ci: disable-autorevert' label "
                 f"created by user {issue.user.login}. "
                 f"Autorevert circuit breaker is ACTIVE."
             )
+            should_disable = True
+
+        sev_issues = repo.get_issues(state="open", labels=["ci: sev"])
+        for issue in sev_issues:
+            logger.info(
+                f"Found open issue #{issue.number} with 'ci: sev' label "
+                f"created by user {issue.user.login}. "
+                f"Autorevert circuit breaker is ACTIVE."
+            )
+            should_disable = True
+
+        if should_disable:
             return True
 
-        logger.debug("No open issues with 'ci: disable-autorevert' label from authorized users found.")
+        logger.debug("No open issues with 'ci: disable-autorevert' label found.")
         return False
 
     except Exception as e:

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_circuit_breaker.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_circuit_breaker.py
@@ -27,7 +27,7 @@ def check_autorevert_disabled(repo_full_name: str = "pytorch/pytorch") -> bool:
         for issue in issues:
             logger.info(
                 f"Found open issue #{issue.number} with 'ci: disable-autorevert' label "
-                f"created by authorized user {issue.user.login}. "
+                f"created by user {issue.user.login}. "
                 f"Autorevert circuit breaker is ACTIVE."
             )
             return True

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_circuit_breaker.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/autorevert_circuit_breaker.py
@@ -6,21 +6,10 @@ from .github_client_helper import GHClientFactory
 
 logger = logging.getLogger(__name__)
 
-ALLOWED_USERS = [
-    "clee2000",
-    "huydhn",
-    "izaitsevfb",
-    "jeanschmidt",
-    "malfet",
-    "seemethere",
-    "ZainRizvi",
-]
-
 
 def check_autorevert_disabled(repo_full_name: str = "pytorch/pytorch") -> bool:
     """
-    Check if autorevert is disabled by looking for open issues with 'ci: disable-autorevert' label
-    created by authorized users.
+    Check if autorevert is disabled by looking for open issues with 'ci: disable-autorevert' label.
 
     Args:
         repo_full_name: Repository name in format 'owner/repo'
@@ -36,13 +25,12 @@ def check_autorevert_disabled(repo_full_name: str = "pytorch/pytorch") -> bool:
         issues = repo.get_issues(state="open", labels=["ci: disable-autorevert"])
 
         for issue in issues:
-            if issue.user.login in ALLOWED_USERS:
-                logger.info(
-                    f"Found open issue #{issue.number} with 'ci: disable-autorevert' label "
-                    f"created by authorized user {issue.user.login}. "
-                    f"Autorevert circuit breaker is ACTIVE."
-                )
-                return True
+            logger.info(
+                f"Found open issue #{issue.number} with 'ci: disable-autorevert' label "
+                f"created by authorized user {issue.user.login}. "
+                f"Autorevert circuit breaker is ACTIVE."
+            )
+            return True
 
         logger.debug("No open issues with 'ci: disable-autorevert' label from authorized users found.")
         return False


### PR DESCRIPTION
This adds a circuit breaker to pytorch autorevert. This can be accomplished by opening an issue on pytorch/pytorch with a tag `ci: disable-autorevert`. 

The decision to NOT gatekeep who are the users that can disable autorevert is based on `ci: sev`. Currently any user that can open a issue in PyTorch can add a `ci: sev` issue that is merge blocking. If we believe this is a safe action and does not require getekeeping, surely it is OK to disable autorevert with the same level of access.