### PR TITLE
opensearch/search similar failures: setup for using ttl

### DIFF
--- a/aws/lambda/opensearch-gha-jobs/lambda_function.py
+++ b/aws/lambda/opensearch-gha-jobs/lambda_function.py
@@ -188,6 +188,10 @@ def upsert_document(client: OpenSearch, record: Any) -> None:
     if not index:
         return
 
+    # Use monthly index for easier data retention management
+    month = record.get("dynamodb", {}).get("NewImage", {}).get("created_at", {}).get("S", "")[:7]
+    index += "-" + month.replace("-", ".")
+
     # Create index using the table name if it's not there yet
     if not client.indices.exists(index):
         # https://www.elastic.co/guide/en/elasticsearch/reference/current/coerce.html

--- a/torchci/lib/searchUtils.ts
+++ b/torchci/lib/searchUtils.ts
@@ -7,7 +7,7 @@ import { getOpenSearchClient } from "./opensearch";
 // https://stackoverflow.com/questions/45111198/how-to-mock-functions-in-the-same-module-using-jest
 import * as thisModule from "./searchUtils";
 
-export const WORKFLOW_JOB_INDEX = "torchci-workflow-job";
+export const WORKFLOW_JOB_INDEX = "torchci-workflow-job*";
 // https://www.elastic.co/guide/en/elasticsearch/reference/7.17/similarity.html#similarity
 // OpenSearch uses https://en.wikipedia.org/wiki/Okapi_BM25 by default.  TODO: learn more
 // about which is a reasonable value here and how to tune it


### PR DESCRIPTION
Some context is https://github.com/pytorch/test-infra/issues/7221

This makes it so that the search can search multiple indexes, and the insertion gets inserted to an index that is based on the month

Then we can delete the indices when they get too old

We could also do some stuff with rollovers and aliases?, but I think this is more convenient 