### PR TITLE
[Hud] option to hide rocm jobs

### DIFF
--- a/torchci/next-env.d.ts
+++ b/torchci/next-env.d.ts
@@ -1,7 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -290,6 +290,11 @@ function FiltersAndSettings({}: {}) {
   const [mergeEphemeralLF, setMergeEphemeralLF] = useContext(MergeLFContext);
   const [settingsPanelOpen, setSettingsPanelOpen] = useState(false);
   const [hideUnstable, setHideUnstable] = usePreference("hideUnstable");
+  const [hideRocm, setHideRocm] = usePreference(
+    "hideRocm",
+    /*override*/ undefined,
+    /*default*/ false
+  );
   const [hideGreenColumns, setHideGreenColumns] =
     useHideGreenColumnsPreference();
   const [useGrouping, setUseGrouping] = useGroupingPreference(
@@ -324,6 +329,13 @@ function FiltersAndSettings({}: {}) {
               checkBoxName="hideUnstable"
               key="hideUnstable"
               labelText={"Hide unstable jobs"}
+            />,
+            <CheckBoxSelector
+              value={hideRocm}
+              setValue={(value) => setHideRocm(value)}
+              checkBoxName="hideRocm"
+              key="hideRocm"
+              labelText={"Hide ROCm jobs"}
             />,
             <CheckBoxSelector
               value={hideGreenColumns}
@@ -558,6 +570,7 @@ function GroupedHudTable({ params }: { params: HudParams }) {
   );
 
   const [hideUnstable] = usePreference("hideUnstable");
+  const [hideRocm] = usePreference("hideRocm", /*override*/ undefined, /*default*/ false);
   const [hideGreenColumns] = useHideGreenColumnsPreference();
   const [useGrouping] = useGroupingPreference(params.nameFilter);
 
@@ -629,6 +642,14 @@ function GroupedHudTable({ params }: { params: HudParams }) {
       )
     ) {
       return false;
+    }
+
+    // Hide ROCm jobs/groups if enabled
+    if (hideRocm) {
+      const rocmRe = /\brocm\b/i;
+      if (rocmRe.test(name)) {
+        return false;
+      }
     }
 
     // If hiding green columns, filter out names that don't have any failed jobs

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -570,7 +570,11 @@ function GroupedHudTable({ params }: { params: HudParams }) {
   );
 
   const [hideUnstable] = usePreference("hideUnstable");
-  const [hideRocm] = usePreference("hideRocm", /*override*/ undefined, /*default*/ false);
+  const [hideRocm] = usePreference(
+    "hideRocm",
+    /*override*/ undefined,
+    /*default*/ false
+  );
   const [hideGreenColumns] = useHideGreenColumnsPreference();
   const [useGrouping] = useGroupingPreference(params.nameFilter);
 


### PR DESCRIPTION
Adds an option to hide ROCm jobs from the grid (regex: `'\brocm\b'i`), checkbox is **off** by default.  Try it out in vercel preview.

<img width="281" height="369" alt="image" src="https://github.com/user-attachments/assets/57c9992f-1344-455f-acc7-4e04ec0fcc6b" />