### PR TITLE
Add vLLM CI metrics

### DIFF
--- a/torchci/clickhouse_queries/vllm/merges_percentage/params.json
+++ b/torchci/clickhouse_queries/vllm/merges_percentage/params.json
@@ -9,8 +9,8 @@
     {
       "granularity": "day",
       "repo": "vllm-project/vllm",
-      "startTime": "2025-09-29T00:00:00.000",
-      "stopTime": "2025-09-22T00:00:00.000"
+      "startTime": "2025-09-22T00:00:00.000",
+      "stopTime": "2025-09-29T00:00:00.000"
     }
   ]
 }

--- a/torchci/clickhouse_queries/vllm/merges_percentage/params.json
+++ b/torchci/clickhouse_queries/vllm/merges_percentage/params.json
@@ -5,6 +5,12 @@
     "startTime": "DateTime64(3)",
     "stopTime": "DateTime64(3)"
   },
-  "tests": []
+  "tests": [
+    {
+      "granularity": "day",
+      "repo": "vllm-project/vllm",
+      "startTime": "2025-09-29T00:00:00.000",
+      "stopTime": "2025-09-22T00:00:00.000"
+    }
+  ]
 }
-

--- a/torchci/clickhouse_queries/vllm/merges_percentage/params.json
+++ b/torchci/clickhouse_queries/vllm/merges_percentage/params.json
@@ -1,0 +1,10 @@
+{
+  "params": {
+    "granularity": "String",
+    "repo": "String",
+    "startTime": "DateTime64(3)",
+    "stopTime": "DateTime64(3)"
+  },
+  "tests": []
+}
+

--- a/torchci/clickhouse_queries/vllm/merges_percentage/query.sql
+++ b/torchci/clickhouse_queries/vllm/merges_percentage/query.sql
@@ -1,0 +1,154 @@
+WITH prs AS (
+    SELECT
+        number,
+        state,
+        merged,
+        merged_by,
+        auto_merge,
+        updated_at,
+        formatDateTime(
+            DATE_TRUNC(
+                {granularity: String },
+                parseDateTimeBestEffort(updated_at)
+            ),
+            '%Y-%m-%d'
+        ) AS bucket
+    FROM
+        pull_request
+    WHERE
+        dynamoKey like concat({repo: String }, '%')
+        AND parseDateTimeBestEffort(updated_at) >= {startTime: DateTime64(3) }
+        AND parseDateTimeBestEffort(updated_at) < {stopTime: DateTime64(3) }
+),
+total_prs AS (
+    SELECT
+        bucket,
+        count(number) AS total_count
+    FROM
+        prs
+    GROUP BY
+        bucket
+),
+open_prs AS (
+    SELECT
+        bucket,
+        count(number) AS open_count
+    FROM
+        prs
+    WHERE
+        state = 'open'
+    GROUP BY
+        bucket
+),
+abandon_prs AS (
+    SELECT
+        bucket,
+        count(number) AS abandon_count
+    FROM
+        prs
+    WHERE
+        state = 'closed'
+        AND merged = 'false'
+    GROUP BY
+        bucket
+),
+merged_prs AS (
+    SELECT
+        *
+    FROM
+        prs
+    WHERE
+        state = 'closed'
+        AND merged = 'true'
+),
+buildkite_jobs AS (
+    SELECT
+        tupleElement(vllm.vllm_buildkite_jobs.build, 'pull_request').id AS number,
+        tupleElement(vllm.vllm_buildkite_jobs.job, 'name') AS job_name,
+        tupleElement(vllm.vllm_buildkite_jobs.job, 'state') AS job_state,
+        tupleElement(vllm.vllm_buildkite_jobs.job, 'created_at') AS job_created_at,
+        -- Row 1 is the latest run of the job
+        ROW_NUMBER() OVER (
+            PARTITION BY number,
+            job_name
+            ORDER BY
+                job_created_at DESC
+        ) AS row_num
+    FROM
+        vllm.vllm_buildkite_jobs
+    WHERE
+        tupleElement(vllm.vllm_buildkite_jobs.build, 'pull_request').id IN (
+            SELECT
+                toString(number)
+            FROM
+                merged_prs
+        )
+        -- Don't care for soft_failed jobs
+        AND tupleElement(vllm.vllm_buildkite_jobs.job, 'soft_failed') = 'false'
+),
+latest_buildkite_jobs AS (
+    SELECT
+        *
+    FROM
+        buildkite_jobs
+    WHERE
+        row_num = 1
+),
+manual_merged_prs AS (
+    SELECT
+        bucket,
+        count(number) AS manual_merged_count
+    FROM
+        merged_prs
+    WHERE
+        tupleElement(auto_merge, 'merge_method') = ''
+    GROUP BY
+        bucket
+),
+manual_merged_prs_with_failures AS (
+    SELECT
+        bucket,
+        count(number) AS manual_merged_with_failures_count
+    FROM
+        merged_prs
+        LEFT JOIN latest_buildkite_jobs ON toString(merged_prs.number) = latest_buildkite_jobs.number
+    WHERE
+        tupleElement(auto_merge, 'merge_method') = ''
+        AND job_state = 'failed'
+    GROUP BY
+        bucket
+),
+auto_merged_prs AS (
+    SELECT
+        bucket,
+        count(number) AS auto_merged_count
+    FROM
+        merged_prs
+    WHERE
+        tupleElement(auto_merge, 'merge_method') != ''
+    GROUP BY
+        bucket
+),
+results AS (
+    SELECT
+        total_prs.bucket AS granularity_bucket,
+        total_count,
+        open_count,
+        abandon_count,
+        auto_merged_count,
+        manual_merged_count,
+        manual_merged_with_failures_count
+    FROM
+        total_prs
+        LEFT JOIN open_prs ON total_prs.bucket = open_prs.bucket
+        LEFT JOIN abandon_prs ON total_prs.bucket = abandon_prs.bucket
+        LEFT JOIN auto_merged_prs ON total_prs.bucket = auto_merged_prs.bucket
+        LEFT JOIN manual_merged_prs ON total_prs.bucket = manual_merged_prs.bucket
+        LEFT JOIN manual_merged_prs_with_failures ON total_prs.bucket = manual_merged_prs_with_failures.bucket
+)
+SELECT
+    *
+FROM
+    results
+ORDER BY
+    granularity_bucket DESC

--- a/torchci/clickhouse_queries/vllm/merges_percentage/query.sql
+++ b/torchci/clickhouse_queries/vllm/merges_percentage/query.sql
@@ -151,4 +151,4 @@ SELECT
 FROM
     results
 ORDER BY
-    granularity_bucket DESC
+    granularity_bucket ASC

--- a/torchci/components/layout/NavBar.tsx
+++ b/torchci/components/layout/NavBar.tsx
@@ -220,6 +220,10 @@ function NavBar() {
       ),
       href: "/flambeau",
     },
+    {
+      name: "vLLM CI metrics",
+      href: "/metrics/vllm",
+    },
   ];
 
   return (

--- a/torchci/pages/metrics/vllm.tsx
+++ b/torchci/pages/metrics/vllm.tsx
@@ -1,0 +1,176 @@
+import { Grid, Paper, Skeleton, Stack, Typography } from "@mui/material";
+import { ScalarPanelWithValue } from "components/metrics/panels/ScalarPanel";
+import dayjs from "dayjs";
+import { EChartsOption } from "echarts";
+import ReactECharts from "echarts-for-react";
+import { useDarkMode } from "lib/DarkModeContext";
+import { useClickHouseAPIImmutable } from "lib/GeneralUtils";
+import _ from "lodash";
+import { useState } from "react";
+import { TimeRangePicker } from "../metrics";
+
+const ROW_HEIGHT = 375;
+
+function MergesPanel({ data }: { data: any }) {
+  // Use the dark mode context to determine whether to use the dark theme
+  const { darkMode } = useDarkMode();
+
+  const options: EChartsOption = {
+    title: {
+      text: "Merged pull requests, by day",
+      subtext: "",
+    },
+    grid: { top: 60, right: 8, bottom: 24, left: 36 },
+    dataset: { source: data },
+    xAxis: { type: "category" },
+    yAxis: {
+      type: "value",
+    },
+    series: [
+      {
+        type: "bar",
+        stack: "all",
+        encode: {
+          x: "granularity_bucket",
+          y: "auto_merged_count",
+        },
+      },
+      {
+        type: "bar",
+        stack: "all",
+        encode: {
+          x: "granularity_bucket",
+          y: "manual_merged_count",
+        },
+      },
+      {
+        type: "bar",
+        stack: "all",
+        encode: {
+          x: "granularity_bucket",
+          y: "manual_merged_with_failures_count",
+        },
+      },
+    ],
+    color: ["#3ba272", "#fc9403", "#ee6666"],
+    tooltip: {
+      trigger: "axis",
+      formatter: (params: any) => {
+        const manualMergedFailures =
+          params[0].data.manual_merged_with_failures_count;
+        const manualMerged = params[0].data.manual_merged_count;
+        const autoMerged = params[0].data.auto_merged_count;
+        const total = manualMergedFailures + manualMerged + autoMerged;
+
+        const manualMergedFailuresPct =
+          ((manualMergedFailures / total) * 100).toFixed(2) + "%";
+        const manualMergedPct = ((manualMerged / total) * 100).toFixed(2) + "%";
+        const autoMergedPct = ((autoMerged / total) * 100).toFixed(2) + "%";
+        return `Force merges: ${manualMergedFailures} (${manualMergedFailuresPct})<br/>Manual merges: ${manualMerged} (${manualMergedPct})<br/>Auto merges: ${autoMerged} (${autoMergedPct})<br/>Total: ${total}`;
+      },
+    },
+  };
+
+  return (
+    <Paper sx={{ p: 2, height: "100%" }} elevation={3}>
+      <ReactECharts
+        theme={darkMode ? "dark-hud" : undefined}
+        style={{ height: "100%", width: "100%" }}
+        option={options}
+      />
+    </Paper>
+  );
+}
+
+export default function Page() {
+  const [startTime, setStartTime] = useState(dayjs().subtract(1, "week"));
+  const [stopTime, setStopTime] = useState(dayjs());
+  const [timeRange, setTimeRange] = useState<number>(7);
+
+  const timeParams = {
+    startTime: startTime.utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
+    stopTime: stopTime.utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
+  };
+
+  const { data, isLoading } = useClickHouseAPIImmutable(
+    "vllm/merges_percentage",
+    {
+      ...timeParams,
+      granularity: "day",
+      repo: "vllm-project/vllm",
+    }
+  );
+
+  if (data === undefined) {
+    return <Skeleton variant={"rectangular"} height={"100%"} />;
+  }
+
+  const manualMergedFailures =
+    data === undefined || data.length === 0
+      ? 0
+      : _.sumBy(data, "manual_merged_with_failures_count");
+  const manualMerged =
+    data === undefined || data.length === 0
+      ? 0
+      : _.sumBy(data, "manual_merged_count");
+  const autoMerged =
+    data === undefined || data.length === 0
+      ? 0
+      : _.sumBy(data, "auto_merged_count");
+  const total = manualMergedFailures + manualMerged + autoMerged;
+
+  // Show their percentages instead the absolute count
+  const manualMergedFailuresPct =
+    total === 0 ? 0 : manualMergedFailures / total;
+  const manualMergedPct = total == 0 ? 0 : manualMerged / total;
+
+  return (
+    <div>
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <Typography fontSize={"2rem"} fontWeight={"bold"}>
+          vLLM CI Metrics
+        </Typography>
+        <TimeRangePicker
+          startTime={startTime}
+          setStartTime={setStartTime}
+          stopTime={stopTime}
+          setStopTime={setStopTime}
+          timeRange={timeRange}
+          setTimeRange={setTimeRange}
+        />
+      </Stack>
+
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 12, md: 6 }} height={ROW_HEIGHT}>
+          <MergesPanel data={data} />
+        </Grid>
+
+        <Grid
+          container
+          size={{ xs: 6, md: 3, lg: 2 }}
+          justifyContent={"stretch"}
+        >
+          <Stack
+            justifyContent={"space-between"}
+            flexGrow={1}
+            flexWrap="wrap"
+            spacing={1}
+          >
+            <ScalarPanelWithValue
+              title={"% force merges (with failures)"}
+              value={manualMergedFailuresPct}
+              valueRenderer={(value) => (value * 100).toFixed(1) + "%"}
+              badThreshold={(value) => value > 0.2}
+            />
+            <ScalarPanelWithValue
+              title={"% manual merges"}
+              value={manualMergedPct}
+              valueRenderer={(value) => (value * 100).toFixed(1) + "%"}
+              badThreshold={(value) => value > 0.5}
+            />
+          </Stack>
+        </Grid>
+      </Grid>
+    </div>
+  );
+}

--- a/torchci/pages/metrics/vllm.tsx
+++ b/torchci/pages/metrics/vllm.tsx
@@ -63,10 +63,16 @@ function MergesPanel({ data }: { data: any }) {
         const total = manualMergedFailures + manualMerged + autoMerged;
 
         const manualMergedFailuresPct =
-          ((manualMergedFailures / total) * 100).toFixed(2) + "%";
-        const manualMergedPct = ((manualMerged / total) * 100).toFixed(2) + "%";
-        const autoMergedPct = ((autoMerged / total) * 100).toFixed(2) + "%";
-        return `Force merges: ${manualMergedFailures} (${manualMergedFailuresPct})<br/>Manual merges: ${manualMerged} (${manualMergedPct})<br/>Auto merges: ${autoMerged} (${autoMergedPct})<br/>Total: ${total}`;
+          ((manualMergedFailures / total) * 100).toFixed(1) + "%";
+        const manualMergedPct = ((manualMerged / total) * 100).toFixed(1) + "%";
+        const autoMergedPct = ((autoMerged / total) * 100).toFixed(1) + "%";
+        return `Force merges (red): ${manualMergedFailures} (${manualMergedFailuresPct})
+          <br/>
+          Manual merges (orange): ${manualMerged} (${manualMergedPct})
+          <br/>
+          Auto merges (green): ${autoMerged} (${autoMergedPct})
+          <br/>
+          Total: ${total}`;
       },
     },
   };


### PR DESCRIPTION
This PR has two parts, the query `vllm/merges_percentage` and a new HUD page `metrics/vllm.tsx` to display vLLM CI metrics.  There are 2 KPIs to start with:

1. The % of force merges with CI failures.  Its meaning is clear.
2. The % of manual merges where a vLLM maintainer merged the pull request manually without using GitHub auto-merge. But there wasn't any failures in the pull request at the time of the merge.

### What is a vLLM CI failure?
As vLLM CI is on Buildkite, a CI failure means a failed Buildkite job that (1) is not a soft fail, and (2) fails on its latest retry at the time of the merge.  We can get this information by joining the GitHub `pull_request` with Buildkite `vllm_buildkite_jobs` on the pull request number.

### Testing

https://torchci-git-vllm-metrics-fbopensource.vercel.app/metrics/vllm

cc @rzabarazesh @yeqcharlotte @simon-mo