### PR TITLE
[autorevert] fix local cli

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
@@ -255,9 +255,7 @@ def main(*args, **kwargs) -> None:
     if opts.github_app_secret:
         gh_app_secret = base64.b64decode(opts.github_app_secret).decode("utf-8")
 
-    ch_password = ""
-    if ch_password:
-        ch_password = opts.clickhouse_password
+    ch_password = opts.clickhouse_password
 
     if opts.secret_store_name:
         secrets = get_secret_from_aws(opts.secret_store_name)


### PR DESCRIPTION
Before:

```
(venv) ivanzaitsev@ivanzaitsev-mbp pytorch-auto-revert % python -m pytorch_auto_revert hud
2025-09-29 12:12:37,159 WARNING [pytorch_auto_revert.clickhouse_client_helper] Connection test failed: HTTPDriver for https://hyt81izu0c.us-east-1.aws.clickhouse.cloud:8443 received ClickHouse error code 516
 Code: 516. DB::Exception: revert_lambda: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED) (version 25.6.2.6151 (official build))

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/ivanzaitsev/test-infra/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py", line 336, in <module>
    main()
  File "/Users/ivanzaitsev/test-infra/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py", line 283, in main
    raise RuntimeError(
RuntimeError: ClickHouse connection test failed. Please check your configuration.
```

After:
```
(venv) ivanzaitsev@ivanzaitsev-mbp pytorch-auto-revert %
(venv) ivanzaitsev@ivanzaitsev-mbp pytorch-auto-revert %
(venv) ivanzaitsev@ivanzaitsev-mbp pytorch-auto-revert %
(venv) ivanzaitsev@ivanzaitsev-mbp pytorch-auto-revert %
(venv) ivanzaitsev@ivanzaitsev-mbp pytorch-auto-revert % python -m pytorch_auto_revert hud
2025-09-29 12:18:23,118 INFO [root] [hud] Fetching run state ts=2025-09-29 19:13:18 repo=<any>
2025-09-29 12:18:23,521 INFO [root] [hud] Loaded state for repo=pytorch/pytorch workflows=Lint,trunk,pull,inductor
2025-09-29 12:18:23,521 INFO [root] [hud] Rendering HTML for repo=pytorch/pytorch workflows=Lint,trunk,pull,inductor lookback=16 → 2025-09-29_19-13-18.html
2025-09-29 12:18:23,523 INFO [root] HUD written to 2025-09-29_19-13-18.html
(venv) ivanzaitsev@ivanzaitsev-mbp pytorch-auto-revert %
```