### PR TITLE
[ROCm] revert binary build matrix for test and release

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -34,8 +34,8 @@ CUDA_ARCHES_DICT = {
 
 ROCM_ARCHES_DICT = {
     "nightly": ["6.4", "7.0"],
-    "test": ["6.4", "7.0"],
-    "release": ["6.4", "7.0"],
+    "test": ["6.3", "6.4"],
+    "release": ["6.3", "6.4"],
 }
 
 CUDA_CUDNN_VERSIONS = {


### PR DESCRIPTION
Only nightly should have been updated in #7237.