### PR TITLE
[autorever] fix indentation in `fetch_tests_for_job_ids`

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_datasource.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_datasource.py
@@ -192,22 +192,22 @@ class SignalExtractionDatasource:
                 "failed_job_ids": [int(j) for j in failed_job_ids],
             }
 
-        for attempt in RetryWithBackoff():
-            with attempt:
-                res = CHCliFactory().client.query(query, parameters=params)
-                for r in res.result_rows:
-                    rows.append(
-                        TestRow(
-                            job_id=JobId(int(r[0])),
-                            wf_run_id=WfRunId(int(r[1])),
-                            workflow_run_attempt=RunAttempt(int(r[2])),
-                            file=str(r[3] or ""),
-                            classname=str(r[4] or ""),
-                            name=str(r[5] or ""),
-                            failing=int(r[6] or 0),
-                            errored=int(r[7] or 0),
+            for attempt in RetryWithBackoff():
+                with attempt:
+                    res = CHCliFactory().client.query(query, parameters=params)
+                    for r in res.result_rows:
+                        rows.append(
+                            TestRow(
+                                job_id=JobId(int(r[0])),
+                                wf_run_id=WfRunId(int(r[1])),
+                                workflow_run_attempt=RunAttempt(int(r[2])),
+                                file=str(r[3] or ""),
+                                classname=str(r[4] or ""),
+                                name=str(r[5] or ""),
+                                failing=int(r[6] or 0),
+                                errored=int(r[7] or 0),
+                            )
                         )
-                    )
         dt = time.perf_counter() - t0
         log.info(
             "[extract] Tests fetched: %d rows for %d job_ids in %.2fs",


### PR DESCRIPTION
Accidentally noticed another bug introduced by https://github.com/pytorch/test-infra/pull/7241 when testing locally on the large lookback windows:

```
python -m pytorch_auto_revert --dry-run autorevert-checker periodic --hours 256 --bisection-limit 2   --hud-html
2025-09-29 15:56:16,356 INFO [root] [v2] Start: workflows=periodic hours=256 repo=pytorch/pytorch restart_action=log revert_action=log notify_issue_number=163650
2025-09-29 15:56:16,356 INFO [root] [v2] Run timestamp (CH log ts) = 2025-09-29T22:56:16.356213+00:00
2025-09-29 15:56:16,356 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Fetching commits in time range: repo=pytorch/pytorch lookback=256h
2025-09-29 15:56:16,909 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Commits fetched: 419 commits in 0.55s
2025-09-29 15:56:16,909 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Fetching jobs: repo=pytorch/pytorch workflows=periodic commits=419 lookback=256h
2025-09-29 15:56:56,850 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Jobs fetched: 2848 rows in 39.94s
2025-09-29 15:56:56,859 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Fetching tests for 1077 job_ids (453 failed jobs) in batches
2025-09-29 15:56:56,859 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Test batch 1/2 (size=1024)
2025-09-29 15:56:56,859 INFO [pytorch_auto_revert.signal_extraction_datasource] existing rows: 0
2025-09-29 15:56:56,859 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Test batch 2/2 (size=53)
2025-09-29 15:56:56,859 INFO [pytorch_auto_revert.signal_extraction_datasource] existing rows: 0
2025-09-29 15:56:57,718 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Tests fetched: 265 rows for 1077 job_ids in 0.86s
```

notice, that no tests are read in the first batch!


after this fix:
```
python -m pytorch_auto_revert --dry-run autorevert-checker periodic --hours 256   --hud-html
2025-09-29 16:03:06,896 INFO [root] [v2] Start: workflows=periodic hours=256 repo=pytorch/pytorch restart_action=log revert_action=log notify_issue_number=163650
2025-09-29 16:03:06,896 INFO [root] [v2] Run timestamp (CH log ts) = 2025-09-29T23:03:06.896595+00:00
2025-09-29 16:03:06,897 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Fetching jobs: repo=pytorch/pytorch workflows=periodic lookback=256h
2025-09-29 16:03:49,456 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Jobs fetched: 2887 rows in 42.56s
2025-09-29 16:03:49,466 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Fetching tests for 1113 job_ids (454 failed jobs) in batches
2025-09-29 16:03:49,466 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Test batch 1/2 (size=1024)
2025-09-29 16:03:51,753 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Test batch 2/2 (size=89)
2025-09-29 16:03:53,056 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Tests fetched: 5002 rows for 1113 job_ids in 3.59s
2025-09-29 16:03:53,122 INFO [root] [v2] Extracted 144 signals
```