### PR TITLE
Enable pytorch ecosystem libraries promotion to prod

### DIFF
--- a/.github/workflows/release-download-pytorch-org.yml
+++ b/.github/workflows/release-download-pytorch-org.yml
@@ -5,6 +5,7 @@ on:
     inputs:
       dryrun:
         required: true
+        type: choice
         default: enabled
         options:
           - enabled
@@ -43,7 +44,7 @@ jobs:
         shell: bash
         env:
           PACKAGE: ${{ inputs.package || 'torchvision' }}
-          DRY_RUN: ${{ inputs.dryrun || 'enabled' }}'
+          DRY_RUN: ${{ inputs.dryrun || 'enabled' }}
         run: |
             set -ex
             cd release

--- a/.github/workflows/release-download-pytorch-org.yml
+++ b/.github/workflows/release-download-pytorch-org.yml
@@ -21,11 +21,11 @@ on:
           - executorch
           - torchvision
           - torchaudio
-          
+
 permissions:
   id-token: write
   contents: read
-  
+
 jobs:
   trigger:
     runs-on: ubuntu-latest
@@ -50,7 +50,7 @@ jobs:
             cd release
             # Install requirements
             pip install awscli==1.32.18
-            
+
             promote_s3() {
               local package_name
               package_name=$1
@@ -59,9 +59,11 @@ jobs:
               local promote_version
               promote_version=$3
 
+              # shellcheck disable=SC2086
               echo "=-=-=-= Promoting ${package_name}'s v${promote_version} ${package_type} packages' =-=-=-="
               (
                   set -x
+                  # shellcheck disable=SC2086
                   TEST_PYTORCH_PROMOTE_VERSION="${promote_version}" \
                       PACKAGE_NAME="${package_name}" \
                       PACKAGE_TYPE="${package_type}" \
@@ -74,5 +76,7 @@ jobs:
             # Init release versions variables
             source ./release_versions.sh
             # Run promotion
+            # shellcheck disable=SC2086
             version="${PACKAGE^^}_VERSION"
+            # shellcheck disable=SC2086
             promote_s3 ${PACKAGE} whl "${!version}"

--- a/.github/workflows/release-download-pytorch-org.yml
+++ b/.github/workflows/release-download-pytorch-org.yml
@@ -29,7 +29,7 @@ jobs:
   trigger:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: pytorchbot-env
+    environment: promote-env
     container:
       image: pytorch/almalinux-builder:cpu
     steps:

--- a/.github/workflows/release-download-pytorch-org.yml
+++ b/.github/workflows/release-download-pytorch-org.yml
@@ -1,11 +1,14 @@
 name: Release ecosystem library from test to production.
 
 on:
-  push:
-    branches:
-      - test-promotion
   workflow_dispatch:
     inputs:
+      dryrun:
+        required: true
+        default: enabled
+        options:
+          - enabled
+          - disabled
       package:
         description: "Domain to prepare and release"
         required: true
@@ -40,11 +43,11 @@ jobs:
         shell: bash
         env:
           PACKAGE: ${{ inputs.package || 'torchvision' }}
+          DRY_RUN: ${{ inputs.dryrun || 'enabled' }}'
         run: |
             set -ex
             cd release
             # Install requirements
-            DRY_RUN=enabled
             pip install awscli==1.32.18
             
             promote_s3() {

--- a/.github/workflows/release_library_download_pytorch_org.yml
+++ b/.github/workflows/release_library_download_pytorch_org.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths:
       - .github/workflows/release_library_download_pytorch_org.yml
+  push:
+    branches:
+      - test-promotion
   workflow_dispatch:
     inputs:
       domain:

--- a/.github/workflows/release_library_download_pytorch_org.yml
+++ b/.github/workflows/release_library_download_pytorch_org.yml
@@ -26,6 +26,7 @@ jobs:
   trigger:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: pytorchbot-env
     container:
       image: pytorch/almalinux-builder:cpu
     steps:

--- a/.github/workflows/release_library_download_pytorch_org.yml
+++ b/.github/workflows/release_library_download_pytorch_org.yml
@@ -11,7 +11,7 @@ on:
     inputs:
       package:
         description: "Domain to prepare and release"
-        required: false
+        required: true
         type: choice
         default: torchvision
         options:

--- a/.github/workflows/release_library_download_pytorch_org.yml
+++ b/.github/workflows/release_library_download_pytorch_org.yml
@@ -1,4 +1,4 @@
-name: Release ecosystem library from test to production
+name: Release ecosystem library from test to production.
 
 on:
   pull_request:

--- a/.github/workflows/release_library_download_pytorch_org.yml
+++ b/.github/workflows/release_library_download_pytorch_org.yml
@@ -9,14 +9,18 @@ on:
       - test-promotion
   workflow_dispatch:
     inputs:
-      domain:
+      package:
         description: "Domain to prepare and release"
         required: false
         type: choice
-        default: torchao
+        default: torchvision
         options:
           - torchao
-
+          - torchtune
+          - executorch
+          - torchvision
+          - torchaudio
+          
 permissions:
   id-token: write
   contents: read
@@ -36,6 +40,8 @@ jobs:
           aws-region: us-east-1
       - name: Promote library to download.pytorch.org
         shell: bash
+        env:
+          PACKAGE: ${{ inputs.package }}
         run: |
             set -ex
             cd release
@@ -43,7 +49,7 @@ jobs:
             DRY_RUN=enabled
             pip install awscli==1.32.18
             
-            # Init release versions vars
+            # Init release versions variables
             source ./release_versions.sh
             
             promote_s3() {
@@ -66,4 +72,5 @@ jobs:
               echo
             }
 
-            promote_s3 "torchao" whl "${TORCHAO_VERSION}"
+            version="${PACKAGE^^}_VERSION"
+            promote_s3 ${PACKAGE} whl "${!version}"

--- a/.github/workflows/release_library_download_pytorch_org.yml
+++ b/.github/workflows/release_library_download_pytorch_org.yml
@@ -14,6 +14,10 @@ on:
         options:
           - torchao
 
+permissions:
+  id-token: write
+  contents: read
+  
 jobs:
   trigger:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_library_download_pytorch_org.yml
+++ b/.github/workflows/release_library_download_pytorch_org.yml
@@ -1,0 +1,62 @@
+name: Release ecosystem library from test to production
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/release_library_download_pytorch_org.yml
+  workflow_dispatch:
+    inputs:
+      domain:
+        description: "Domain to prepare and release"
+        required: false
+        type: choice
+        default: torchao
+        options:
+          - torchao
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    container:
+      image: pytorch/almalinux-builder:cpu
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Configure aws credentials (pytorch account)
+        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
+        with:
+          role-to-assume: arn:aws:iam::749337293305:role/test_gha_read_s3_html
+          aws-region: us-east-1
+      - name: Promote library to download.pytorch.org
+        shell: bash
+        run: |
+            set -ex
+            cd release
+            # Install requirements
+            LINUX_VERSION_SUFFIX="%2Bcu128"
+            CPU_VERSION_SUFFIX="%2Bcpu"
+            DRY_RUN=enabled
+            TORCHAO_VERSION=0.13.0
+
+            pwd
+            promote_s3() {
+              local package_name
+              package_name=$1
+              local package_type
+              package_type=$2
+              local promote_version
+              promote_version=$3
+
+              echo "=-=-=-= Promoting ${package_name}'s v${promote_version} ${package_type} packages' =-=-=-="
+              (
+                  set -x
+                  TEST_PYTORCH_PROMOTE_VERSION="${promote_version}" \
+                      PACKAGE_NAME="${package_name}" \
+                      PACKAGE_TYPE="${package_type}" \
+                      TEST_WITHOUT_GIT_TAG=1 \
+                      DRY_RUN="${DRY_RUN}" ./promote/s3_to_s3.sh
+              )
+              echo
+            }
+
+            promote_s3 "torchao" whl "${TORCHAO_VERSION}"

--- a/.github/workflows/release_library_download_pytorch_org.yml
+++ b/.github/workflows/release_library_download_pytorch_org.yml
@@ -44,6 +44,7 @@ jobs:
             CPU_VERSION_SUFFIX="%2Bcpu"
             DRY_RUN=enabled
             TORCHAO_VERSION=0.13.0
+            pip install awscli==1.32.18
 
             pwd
             promote_s3() {

--- a/.github/workflows/release_library_download_pytorch_org.yml
+++ b/.github/workflows/release_library_download_pytorch_org.yml
@@ -29,11 +29,6 @@ jobs:
       image: pytorch/almalinux-builder:cpu
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Configure aws credentials (pytorch account)
-        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
-        with:
-          role-to-assume: arn:aws:iam::749337293305:role/test_gha_read_s3_html
-          aws-region: us-east-1
       - name: Promote library to download.pytorch.org
         shell: bash
         run: |

--- a/.github/workflows/release_library_download_pytorch_org.yml
+++ b/.github/workflows/release_library_download_pytorch_org.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Configure aws credentials (pytorch account)
         uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
         with:
-          role-to-assume: arn:aws:iam::749337293305:role/test_gha_read_s3_html
+          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_promote_wheels
           aws-region: us-east-1
       - name: Promote library to download.pytorch.org
         shell: bash

--- a/.github/workflows/release_library_download_pytorch_org.yml
+++ b/.github/workflows/release_library_download_pytorch_org.yml
@@ -29,19 +29,23 @@ jobs:
       image: pytorch/almalinux-builder:cpu
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Configure aws credentials (pytorch account)
+        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
+        with:
+          role-to-assume: arn:aws:iam::749337293305:role/test_gha_read_s3_html
+          aws-region: us-east-1
       - name: Promote library to download.pytorch.org
         shell: bash
         run: |
             set -ex
             cd release
             # Install requirements
-            LINUX_VERSION_SUFFIX="%2Bcu128"
-            CPU_VERSION_SUFFIX="%2Bcpu"
             DRY_RUN=enabled
-            TORCHAO_VERSION=0.13.0
             pip install awscli==1.32.18
-
-            pwd
+            
+            # Init release versions vars
+            source ./release_versions.sh
+            
             promote_s3() {
               local package_name
               package_name=$1

--- a/.github/workflows/release_library_download_pytorch_org.yml
+++ b/.github/workflows/release_library_download_pytorch_org.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Promote library to download.pytorch.org
         shell: bash
         env:
-          PACKAGE: ${{ inputs.package || "torchvision" }}
+          PACKAGE: ${{ inputs.package || 'torchvision' }}
         run: |
             set -ex
             cd release

--- a/.github/workflows/release_library_download_pytorch_org.yml
+++ b/.github/workflows/release_library_download_pytorch_org.yml
@@ -1,9 +1,6 @@
 name: Release ecosystem library from test to production.
 
 on:
-  pull_request:
-    paths:
-      - .github/workflows/release_library_download_pytorch_org.yml
   push:
     branches:
       - test-promotion
@@ -41,7 +38,7 @@ jobs:
       - name: Promote library to download.pytorch.org
         shell: bash
         env:
-          PACKAGE: ${{ inputs.package }}
+          PACKAGE: ${{ inputs.package || "torchvision" }}
         run: |
             set -ex
             cd release

--- a/.github/workflows/release_library_download_pytorch_org.yml
+++ b/.github/workflows/release_library_download_pytorch_org.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   trigger:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     container:
       image: pytorch/almalinux-builder:cpu
     steps:
@@ -45,9 +45,6 @@ jobs:
             # Install requirements
             DRY_RUN=enabled
             pip install awscli==1.32.18
-            
-            # Init release versions variables
-            source ./release_versions.sh
             
             promote_s3() {
               local package_name
@@ -69,5 +66,8 @@ jobs:
               echo
             }
 
+            # Init release versions variables
+            source ./release_versions.sh
+            # Run promotion
             version="${PACKAGE^^}_VERSION"
             promote_s3 ${PACKAGE} whl "${!version}"


### PR DESCRIPTION
This should allow promotion of ecosystem library from /test/ channel to /prod/
Plan is to allow only certain people to run this workflow.

When triggering the workflow the verison update need to be landed before:
https://github.com/pytorch/test-infra/blob/main/release/release_versions.sh

First run of the workflow needs to be DRY_RUN.
Second run is the promotion

Example of successful run:
https://github.com/pytorch/test-infra/actions/runs/18144952405/job/51644528583