### PR TITLE
[autorevert]  add job & hud links to the autorevert message and debug grid

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/hud_renderer.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/hud_renderer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import urllib.parse
 from datetime import datetime
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
@@ -388,6 +389,24 @@ def render_html_from_state(
             badge = '<span class="badge badge-ineligible">N/A</span>'
         header_label = f"{workflow}:{key}" if key else workflow
         safe_note = note.replace('"', "'")
+
+        # Build PyTorch HUD dashboard link if job_base_name is available
+        hud_link = ""
+        job_base_name = col.get("job_base_name")
+        if job_base_name and commits:
+            # Top commit (most recent)
+            top_sha = commits[0]
+            num_commits = len(commits)
+            encoded_name = urllib.parse.quote(job_base_name)
+            hud_url = (
+                f"https://hud.pytorch.org/hud/{repo_full_name}/{top_sha}/1?"
+                f"per_page={num_commits}&name_filter={encoded_name}&mergeEphemeralLF=true"
+            )
+            hud_link = (
+                f'<div><a href="{hud_url}" target="_blank" '
+                f'rel="noopener noreferrer">View in PyTorch HUD →</a></div>'
+            )
+
         html_parts.append(
             f'<th id="{rid}" class="outcome" onclick="toggleOutcome(\'{rid}\')" '
             f'title="Click to expand">{badge}'
@@ -395,6 +414,7 @@ def render_html_from_state(
             f"onclick=\"toggleOutcome('{rid}'); event.stopPropagation();\">×</span>"
             f"<div><strong>{header_label}</strong></div>"
             f"<div>{safe_note}</div>"
+            f"{hud_link}"
             "</div>"
             "</th>"
         )
@@ -423,8 +443,20 @@ def render_html_from_state(
                 status = event.get("status", "")
                 icon = _status_icon(status)
                 title_attr = _event_title_from_dict(event).replace('"', "'")
+
+                # Prefer job_id if available, otherwise fall back to parsing run_id from name
+                job_id = event.get("job_id")
                 run_id = _parse_run_id(str(event.get("name", "")))
-                if run_id is not None:
+
+                if job_id is not None and run_id is not None:
+                    # Link directly to the specific job
+                    url = f"https://github.com/{repo_full_name}/actions/runs/{run_id}/job/{job_id}"
+                    cell_parts.append(
+                        f'<a class="ev" href="{url}" title="{title_attr}" '
+                        f'target="_blank" rel="noopener noreferrer">{icon}</a>'
+                    )
+                elif run_id is not None:
+                    # Link to workflow run (no job_id available)
                     url = f"https://github.com/{repo_full_name}/actions/runs/{run_id}"
                     cell_parts.append(
                         f'<a class="ev" href="{url}" title="{title_attr}" '

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/hud_renderer.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/hud_renderer.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import re
-import urllib.parse
 from datetime import datetime
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
 from .signal import SignalStatus
+from .utils import build_pytorch_hud_url
 
 
 HUD_CSS = """
@@ -397,10 +397,11 @@ def render_html_from_state(
             # Top commit (most recent)
             top_sha = commits[0]
             num_commits = len(commits)
-            encoded_name = urllib.parse.quote(job_base_name)
-            hud_url = (
-                f"https://hud.pytorch.org/hud/{repo_full_name}/{top_sha}/1?"
-                f"per_page={num_commits}&name_filter={encoded_name}&mergeEphemeralLF=true"
+            hud_url = build_pytorch_hud_url(
+                repo_full_name=repo_full_name,
+                top_sha=top_sha,
+                num_commits=num_commits,
+                job_base_name=job_base_name,
             )
             hud_link = (
                 f'<div><a href="{hud_url}" target="_blank" '

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/run_state_logger.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/run_state_logger.py
@@ -53,14 +53,21 @@ class RunStateLogger:
             if isinstance(outcome, AutorevertPattern):
                 oc = "revert"
                 ineligible = None
+                data = {
+                    "workflow_name": outcome.workflow_name,
+                    "suspected_commit": outcome.suspected_commit,
+                    "older_successful_commit": outcome.older_successful_commit,
+                    "newer_failing_commits": list(outcome.newer_failing_commits),
+                }
+                if outcome.job_base_name:
+                    data["job_base_name"] = outcome.job_base_name
+                if outcome.wf_run_id is not None:
+                    data["wf_run_id"] = outcome.wf_run_id
+                if outcome.job_id is not None:
+                    data["job_id"] = outcome.job_id
                 serialized = {
                     "type": "AutorevertPattern",
-                    "data": {
-                        "workflow_name": outcome.workflow_name,
-                        "suspected_commit": outcome.suspected_commit,
-                        "older_successful_commit": outcome.older_successful_commit,
-                        "newer_failing_commits": list(outcome.newer_failing_commits),
-                    },
+                    "data": data,
                 }
             elif isinstance(outcome, RestartCommits):
                 oc = "restart"

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/run_state_logger.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/run_state_logger.py
@@ -97,6 +97,10 @@ class RunStateLogger:
                     }
                     if e.ended_at:
                         ev["ended_at"] = e.ended_at.isoformat()
+                    if e.job_id is not None:
+                        ev["job_id"] = e.job_id
+                    if e.run_attempt is not None:
+                        ev["run_attempt"] = e.run_attempt
                     evs.append(ev)
                 if evs:
                     cells[c.head_sha] = evs
@@ -107,6 +111,8 @@ class RunStateLogger:
                 "outcome": oc,
                 "cells": cells,
             }
+            if sig.job_base_name:
+                col["job_base_name"] = sig.job_base_name
             if ineligible is not None:
                 col["ineligible"] = ineligible
             cols.append(col)

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -77,12 +77,18 @@ class SignalEvent:
         started_at: datetime,
         wf_run_id: int,
         ended_at: Optional[datetime] = None,
+        run_attempt: Optional[int] = None,
+        job_name: Optional[str] = None,
+        job_id: Optional[int] = None,
     ):
         self.name = name
         self.status = status
         self.started_at = started_at
         self.ended_at = ended_at
         self.wf_run_id = wf_run_id
+        self.run_attempt = run_attempt
+        self.job_name = job_name
+        self.job_id = job_id
 
     @property
     def is_pending(self) -> bool:
@@ -237,13 +243,21 @@ class Signal:
     - key: stable identifier for the signal (e.g., normalized job/test name)
     - workflow_name: source workflow this signal is derived from
     - commits: newest → older list of SignalCommit objects for this signal
+    - job_base_name: optional job base name for job-level signals (recorded when signal is created)
     """
 
-    def __init__(self, key: str, workflow_name: str, commits: List[SignalCommit]):
+    def __init__(
+        self,
+        key: str,
+        workflow_name: str,
+        commits: List[SignalCommit],
+        job_base_name: Optional[str] = None,
+    ):
         self.key = key
         self.workflow_name = workflow_name
         # commits are ordered from newest to oldest
         self.commits = commits
+        self.job_base_name = job_base_name
 
     def detect_fixed(self) -> bool:
         """

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
@@ -14,7 +14,13 @@ from .clickhouse_client_helper import CHCliFactory
 from .github_client_helper import GHClientFactory
 from .signal import AutorevertPattern, Ineligible, RestartCommits, Signal
 from .signal_extraction_types import RunContext
-from .utils import build_pytorch_hud_url, build_job_pytorch_url, RestartAction, RetryWithBackoff, RevertAction
+from .utils import (
+    build_job_pytorch_url,
+    build_pytorch_hud_url,
+    RestartAction,
+    RetryWithBackoff,
+    RevertAction,
+)
 from .workflow_checker import WorkflowRestartChecker
 
 
@@ -611,7 +617,9 @@ class SignalActionProcessor:
 
         # Build a nice message to show which workflows are broken
         # used both to revert and notify
-        breaking_notification_msg = "This PR is breaking the following workflows:\n"
+        breaking_notification_msg = (
+            "This PR is attributed to have caused regression in:\n"
+        )
         for workflow_name, wf_sources in workflow_groups.items():
             all_signals_urls = []
             for wf_source in wf_sources:
@@ -634,7 +642,7 @@ class SignalActionProcessor:
                         num_commits=50,
                         job_base_name=wf_source.job_base_name,
                     )
-                    curr_url += f" ([\U0001F5D2]({hud_url}))"
+                    curr_url += f" ([\U0001f5d2]({hud_url}))"
 
                 all_signals_urls.append(curr_url)
 

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
@@ -642,7 +642,7 @@ class SignalActionProcessor:
                         num_commits=50,
                         job_base_name=wf_source.job_base_name,
                     )
-                    curr_url += f" ([\U0001f5d2]({hud_url}))"
+                    curr_url += f" ([hud]({hud_url}))"
 
                 all_signals_urls.append(curr_url)
 

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
@@ -14,7 +14,7 @@ from .clickhouse_client_helper import CHCliFactory
 from .github_client_helper import GHClientFactory
 from .signal import AutorevertPattern, Ineligible, RestartCommits, Signal
 from .signal_extraction_types import RunContext
-from .utils import build_pytorch_hud_url, RestartAction, RetryWithBackoff, RevertAction
+from .utils import build_pytorch_hud_url, build_job_pytorch_url, RestartAction, RetryWithBackoff, RevertAction
 from .workflow_checker import WorkflowRestartChecker
 
 
@@ -613,29 +613,33 @@ class SignalActionProcessor:
         # used both to revert and notify
         breaking_notification_msg = "This PR is breaking the following workflows:\n"
         for workflow_name, wf_sources in workflow_groups.items():
-            all_signals = ", ".join([source.key for source in wf_sources])
+            all_signals_urls = []
+            for wf_source in wf_sources:
+                curr_url = ""
+
+                if wf_source.job_id and wf_source.wf_run_id:
+                    job_url = build_job_pytorch_url(
+                        repo_full_name=ctx.repo_full_name,
+                        wf_run_id=str(wf_source.wf_run_id),
+                        job_id=str(wf_source.job_id),
+                    )
+                    curr_url += f"[{wf_source.key}]({job_url})"
+                else:
+                    curr_url += wf_source.key
+
+                if wf_source.job_base_name:
+                    hud_url = build_pytorch_hud_url(
+                        repo_full_name=ctx.repo_full_name,
+                        top_sha=commit_sha,
+                        num_commits=50,
+                        job_base_name=wf_source.job_base_name,
+                    )
+                    curr_url += f" ([\U0001F5D2]({hud_url}))"
+
+                all_signals_urls.append(curr_url)
+
+            all_signals = ", ".join(all_signals_urls)
             breaking_notification_msg += f"- {workflow_name}: {all_signals}\n"
-
-        # Add job link and HUD link from first source if available
-        if sources:
-            first_source = sources[0]
-            if first_source.job_id and first_source.wf_run_id:
-                job_link = (
-                    f"https://github.com/{ctx.repo_full_name}/"
-                    f"actions/runs/{first_source.wf_run_id}/job/{first_source.job_id}"
-                )
-                breaking_notification_msg += f"\n**Failed job:** {job_link}\n"
-
-            if first_source.job_base_name:
-                hud_url = build_pytorch_hud_url(
-                    repo_full_name=ctx.repo_full_name,
-                    top_sha=commit_sha,
-                    num_commits=50,
-                    job_base_name=first_source.job_base_name,
-                )
-                breaking_notification_msg += (
-                    f"\n**PyTorch HUD:** [View signal]({hud_url})\n"
-                )
 
         try:
             if should_do_revert_on_pr:

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_actions.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_actions.py
@@ -288,7 +288,7 @@ class TestCommentIssueRevert(unittest.TestCase):
         # Check that job link is in the comment
         self.assertEqual(
             comment_text,
-            "Autorevert detected a possible offender: abc123 from PR #12345.\n\nThe commit is a PR merge\n\nThis PR is attributed to have caused regression in:\n- trunk: [test_signal](https://github.com/pytorch/pytorch/actions/runs/12345/job/67890) ([\U0001f5d2](https://hud.pytorch.org/hud/pytorch/pytorch/abc123/1?per_page=50&name_filter=linux-jammy%20/%20test&mergeEphemeralLF=true))\n",
+            "Autorevert detected a possible offender: abc123 from PR #12345.\n\nThe commit is a PR merge\n\nThis PR is attributed to have caused regression in:\n- trunk: [test_signal](https://github.com/pytorch/pytorch/actions/runs/12345/job/67890) ([hud](https://hud.pytorch.org/hud/pytorch/pytorch/abc123/1?per_page=50&name_filter=linux-jammy%20/%20test&mergeEphemeralLF=true))\n",
         )
 
     @patch("pytorch_auto_revert.signal_actions.GHClientFactory")
@@ -372,7 +372,7 @@ class TestCommentIssueRevert(unittest.TestCase):
 
         # HUD link should still be present
         self.assertIn(
-            "- trunk: test_signal ([\U0001f5d2](https://hud.pytorch.org/hud/pytorch/pytorch/abc123/1?per_page=50&name_filter=linux-jammy%20/%20test&mergeEphemeralLF=true))\n",
+            "- trunk: test_signal ([hud](https://hud.pytorch.org/hud/pytorch/pytorch/abc123/1?per_page=50&name_filter=linux-jammy%20/%20test&mergeEphemeralLF=true))\n",
             comment_text,
         )
 
@@ -482,11 +482,11 @@ class TestCommentIssueRevert(unittest.TestCase):
 
         # Check workflow grouping
         self.assertIn(
-            "- trunk: [test_signal_1](https://github.com/pytorch/pytorch/actions/runs/12345/job/67890) ([\U0001f5d2](https://hud.pytorch.org/hud/pytorch/pytorch/abc123/1?per_page=50&name_filter=linux-jammy%20/%20test&mergeEphemeralLF=true)), [test_signal_2](https://github.com/pytorch/pytorch/actions/runs/12345/job/67890) ([\U0001f5d2](https://hud.pytorch.org/hud/pytorch/pytorch/abc123/1?per_page=50&name_filter=linux-jammy%20/%20test&mergeEphemeralLF=true))\n",
+            "- trunk: [test_signal_1](https://github.com/pytorch/pytorch/actions/runs/12345/job/67890) ([hud](https://hud.pytorch.org/hud/pytorch/pytorch/abc123/1?per_page=50&name_filter=linux-jammy%20/%20test&mergeEphemeralLF=true)), [test_signal_2](https://github.com/pytorch/pytorch/actions/runs/12345/job/67890) ([hud](https://hud.pytorch.org/hud/pytorch/pytorch/abc123/1?per_page=50&name_filter=linux-jammy%20/%20test&mergeEphemeralLF=true))\n",
             comment_text,
         )
         self.assertIn(
-            "- inductor: test_inductor ([\U0001f5d2](https://hud.pytorch.org/hud/pytorch/pytorch/abc123/1?per_page=50&name_filter=linux-jammy%20/%20inductor&mergeEphemeralLF=true))\n",
+            "- inductor: test_inductor ([hud](https://hud.pytorch.org/hud/pytorch/pytorch/abc123/1?per_page=50&name_filter=linux-jammy%20/%20inductor&mergeEphemeralLF=true))\n",
             comment_text,
         )
 

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_actions.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_actions.py
@@ -1,8 +1,10 @@
 import unittest
 from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, Mock, patch
 
 from pytorch_auto_revert.signal_actions import (
     ActionLogger,
+    CommitPRSourceAction,
     SignalActionProcessor,
     SignalMetadata,
 )
@@ -209,6 +211,247 @@ class TestSignalActionsPacing(unittest.TestCase):
         for i, msg in self.REVERT_MESSAGES:
             pr = self.proc._commit_message_check_pr_is_merge(msg, self.ctx)
             self.assertIsNone(pr, f"Incorrectly matched revert message {i}: {msg}")
+
+
+class TestCommentIssueRevert(unittest.TestCase):
+    def setUp(self) -> None:
+        self.proc = SignalActionProcessor()
+        self.fake_logger = FakeLogger()
+        self.proc._logger = self.fake_logger  # type: ignore[attr-defined]
+        self.ctx = RunContext(
+            ts=datetime.now(timezone.utc),
+            notify_issue_number=123456,
+            repo_full_name="pytorch/pytorch",
+            workflows=["trunk"],
+            lookback_hours=24,
+            revert_action=RevertAction.RUN_NOTIFY,
+            restart_action=RestartAction.SKIP,
+        )
+
+    @patch("pytorch_auto_revert.signal_actions.GHClientFactory")
+    def test_comment_no_pr_found(self, mock_gh_factory):
+        """Test that method returns False when no PR is found for commit."""
+        self.proc._find_pr_by_sha = Mock(return_value=None)
+
+        sources = [
+            SignalMetadata(
+                workflow_name="trunk",
+                key="test_signal",
+                job_base_name="linux-jammy / test",
+                wf_run_id=12345,
+                job_id=67890,
+            )
+        ]
+
+        result = self.proc._comment_issue_pr_revert("abc123", sources, self.ctx)
+
+        self.assertFalse(result)
+        mock_gh_factory.assert_not_called()
+
+    @patch("pytorch_auto_revert.signal_actions.GHClientFactory")
+    def test_comment_with_job_and_hud_links(self, mock_gh_factory):
+        """Test that comment includes job link and HUD link when available."""
+        # Mock PR and issue
+        mock_pr = Mock()
+        mock_pr.number = 12345
+        mock_pr.get_labels.return_value = []
+
+        mock_issue = Mock()
+        mock_repo = Mock()
+        mock_repo.get_issue.return_value = mock_issue
+        mock_client = Mock()
+        mock_client.get_repo.return_value = mock_repo
+        mock_gh_factory.return_value.client = mock_client
+
+        self.proc._find_pr_by_sha = Mock(
+            return_value=(CommitPRSourceAction.MERGE, mock_pr)
+        )
+
+        sources = [
+            SignalMetadata(
+                workflow_name="trunk",
+                key="test_signal",
+                job_base_name="linux-jammy / test",
+                wf_run_id=12345,
+                job_id=67890,
+            )
+        ]
+
+        result = self.proc._comment_issue_pr_revert("abc123", sources, self.ctx)
+
+        self.assertTrue(result)
+
+        # Verify issue comment was created
+        mock_issue.create_comment.assert_called_once()
+        comment_text = mock_issue.create_comment.call_args[0][0]
+
+        # Check that job link is in the comment
+        self.assertIn("**Failed job:**", comment_text)
+        self.assertIn(
+            "https://github.com/pytorch/pytorch/actions/runs/12345/job/67890",
+            comment_text,
+        )
+
+        # Check that HUD link is in the comment
+        self.assertIn("**PyTorch HUD:**", comment_text)
+        self.assertIn(
+            "https://hud.pytorch.org/hud/pytorch/pytorch/abc123/1", comment_text
+        )
+        # URL encoding: spaces become %20, / stays as /
+        self.assertIn("name_filter=linux-jammy%20/%20test", comment_text)
+
+    @patch("pytorch_auto_revert.signal_actions.GHClientFactory")
+    def test_comment_without_job_info(self, mock_gh_factory):
+        """Test that comment works without job_id/wf_run_id."""
+        mock_pr = Mock()
+        mock_pr.number = 12345
+        mock_pr.get_labels.return_value = []
+
+        mock_issue = Mock()
+        mock_repo = Mock()
+        mock_repo.get_issue.return_value = mock_issue
+        mock_client = Mock()
+        mock_client.get_repo.return_value = mock_repo
+        mock_gh_factory.return_value.client = mock_client
+
+        self.proc._find_pr_by_sha = Mock(
+            return_value=(CommitPRSourceAction.MERGE, mock_pr)
+        )
+
+        sources = [
+            SignalMetadata(
+                workflow_name="trunk",
+                key="test_signal",
+                job_base_name="linux-jammy / test",
+                wf_run_id=None,
+                job_id=None,
+            )
+        ]
+
+        result = self.proc._comment_issue_pr_revert("abc123", sources, self.ctx)
+
+        self.assertTrue(result)
+
+        # Verify issue comment was created
+        mock_issue.create_comment.assert_called_once()
+        comment_text = mock_issue.create_comment.call_args[0][0]
+
+        # Job link should not be present
+        self.assertNotIn("**Failed job:**", comment_text)
+
+        # HUD link should still be present
+        self.assertIn("**PyTorch HUD:**", comment_text)
+        self.assertIn(
+            "https://hud.pytorch.org/hud/pytorch/pytorch/abc123/1", comment_text
+        )
+
+    @patch("pytorch_auto_revert.signal_actions.GHClientFactory")
+    def test_comment_autorevert_disabled(self, mock_gh_factory):
+        """Test that revert is not requested when autorevert is disabled."""
+        mock_label = Mock()
+        mock_label.name = "autorevert: disable"
+
+        mock_pr = Mock()
+        mock_pr.number = 12345
+        mock_pr.labels = [mock_label]
+        mock_pr.get_labels.return_value = [mock_label]
+
+        mock_issue = Mock()
+        mock_repo = Mock()
+        mock_repo.get_issue.return_value = mock_issue
+        mock_client = Mock()
+        mock_client.get_repo.return_value = mock_repo
+        mock_gh_factory.return_value.client = mock_client
+
+        self.proc._find_pr_by_sha = Mock(
+            return_value=(CommitPRSourceAction.MERGE, mock_pr)
+        )
+
+        # Use RUN_REVERT to test the disable logic
+        ctx = RunContext(
+            ts=datetime.now(timezone.utc),
+            notify_issue_number=123456,
+            repo_full_name="pytorch/pytorch",
+            workflows=["trunk"],
+            lookback_hours=24,
+            revert_action=RevertAction.RUN_REVERT,
+            restart_action=RestartAction.SKIP,
+        )
+
+        sources = [
+            SignalMetadata(
+                workflow_name="trunk",
+                key="test_signal",
+                job_base_name="linux-jammy / test",
+                wf_run_id=12345,
+                job_id=67890,
+            )
+        ]
+
+        result = self.proc._comment_issue_pr_revert("abc123", sources, ctx)
+
+        # Returns False because RUN_REVERT was requested but disabled by label
+        self.assertFalse(result)
+
+        # PR comment should not be created (revert disabled)
+        mock_pr.create_issue_comment.assert_not_called()
+
+        # Issue notification should still be created
+        mock_issue.create_comment.assert_called_once()
+
+    @patch("pytorch_auto_revert.signal_actions.GHClientFactory")
+    def test_comment_multiple_workflows(self, mock_gh_factory):
+        """Test that comment groups signals by workflow."""
+        mock_pr = Mock()
+        mock_pr.number = 12345
+        mock_pr.get_labels.return_value = []
+
+        mock_issue = Mock()
+        mock_repo = Mock()
+        mock_repo.get_issue.return_value = mock_issue
+        mock_client = Mock()
+        mock_client.get_repo.return_value = mock_repo
+        mock_gh_factory.return_value.client = mock_client
+
+        self.proc._find_pr_by_sha = Mock(
+            return_value=(CommitPRSourceAction.MERGE, mock_pr)
+        )
+
+        sources = [
+            SignalMetadata(
+                workflow_name="trunk",
+                key="test_signal_1",
+                job_base_name="linux-jammy / test",
+                wf_run_id=12345,
+                job_id=67890,
+            ),
+            SignalMetadata(
+                workflow_name="trunk",
+                key="test_signal_2",
+                job_base_name="linux-jammy / test",
+                wf_run_id=12345,
+                job_id=67890,
+            ),
+            SignalMetadata(
+                workflow_name="inductor",
+                key="test_inductor",
+                job_base_name="linux-jammy / inductor",
+                wf_run_id=None,
+                job_id=None,
+            ),
+        ]
+
+        result = self.proc._comment_issue_pr_revert("abc123", sources, self.ctx)
+
+        self.assertTrue(result)
+
+        # Verify issue comment was created
+        mock_issue.create_comment.assert_called_once()
+        comment_text = mock_issue.create_comment.call_args[0][0]
+
+        # Check workflow grouping
+        self.assertIn("trunk: test_signal_1, test_signal_2", comment_text)
+        self.assertIn("inductor: test_inductor", comment_text)
 
 
 if __name__ == "__main__":

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/utils.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/utils.py
@@ -113,11 +113,8 @@ class RetryWithBackoff:
             self._attempt += 1
 
 
-def build_job_pytorch_url(self, repo_full_name: str, wf_run_id: str, job_id: str) -> str:
-    return (
-        f"https://github.com/{repo_full_name}/"
-        f"actions/runs/{wf_run_id}/job/{job_id}"
-    )
+def build_job_pytorch_url(repo_full_name: str, wf_run_id: str, job_id: str) -> str:
+    return f"https://github.com/{repo_full_name}/actions/runs/{wf_run_id}/job/{job_id}"
 
 
 def build_pytorch_hud_url(

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/utils.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/utils.py
@@ -113,6 +113,13 @@ class RetryWithBackoff:
             self._attempt += 1
 
 
+def build_job_pytorch_url(self, repo_full_name: str, wf_run_id: str, job_id: str) -> str:
+    return (
+        f"https://github.com/{repo_full_name}/"
+        f"actions/runs/{wf_run_id}/job/{job_id}"
+    )
+
+
 def build_pytorch_hud_url(
     *,
     repo_full_name: str,

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/utils.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/utils.py
@@ -1,5 +1,6 @@
 import random
 import time
+import urllib.parse
 from enum import Enum
 
 
@@ -110,3 +111,28 @@ class RetryWithBackoff:
             # Otherwise, a retryable exception occurred and was suppressed.
             # Move to the next attempt.
             self._attempt += 1
+
+
+def build_pytorch_hud_url(
+    *,
+    repo_full_name: str,
+    top_sha: str,
+    num_commits: int,
+    job_base_name: str,
+) -> str:
+    """Build PyTorch HUD dashboard URL for a signal.
+
+    Args:
+        repo_full_name: Repository in format "owner/repo"
+        top_sha: Most recent commit SHA
+        num_commits: Number of commits to display
+        job_base_name: Job base name to filter by
+
+    Returns:
+        URL to PyTorch HUD dashboard
+    """
+    encoded_name = urllib.parse.quote(job_base_name)
+    return (
+        f"https://hud.pytorch.org/hud/{repo_full_name}/{top_sha}/1?"
+        f"per_page={num_commits}&name_filter={encoded_name}&mergeEphemeralLF=true"
+    )


### PR DESCRIPTION
Here is an example of how the new links look like:
[2025-09-30T23-38-21.914320-00-00.html](https://github.com/user-attachments/files/22628924/2025-09-30T23-38-21.914320-00-00.html)

autorevert message changes verified with unit tests.