### PR TITLE
Add the option to pass device info to upload_benchmark_results GHA

### DIFF
--- a/.github/actions/upload-benchmark-results/action.yml
+++ b/.github/actions/upload-benchmark-results/action.yml
@@ -10,8 +10,17 @@ inputs:
     default: 'v3'
   github-token:
     default: ''
+  # Optional parameters
   venv:
     description: 'Path to virtual environment to activate'
+    required: false
+    default: ''
+  device-name:
+    description: 'Manually set the device name, i.e rocm'
+    required: false
+    default: ''
+  device-type:
+    description: 'Manually set the device type, i.e. AMD Instinct Mi325X VF'
     required: false
     default: ''
 
@@ -20,29 +29,40 @@ runs:
   steps:
     - name: Install dependencies
       shell: bash
+      env:
+        INPUT_DEVICE_NAME: ${{ inputs.device-name }}
+        INPUT_DEVICE_TYPE: ${{ inputs.device-type }}
       run: |
         set -eux
 
         if [[ -n "${{ inputs.venv }}" ]]; then
           source "${{ inputs.venv }}"
         fi
-        python3 -mpip install boto3==1.35.33 psutil==7.0.0 pynvml==12.0.0
 
         DEVICE_NAME=""
         DEVICE_TYPE=""
 
-        if command -v nvidia-smi; then
-          # NB: I'm using PyTorch here to get the device name, however, it needs to
-          # install the correct version of PyTorch manually for now. Any PyTorch
-          # version is fine, I just use 2.7.1 to satify PYPIDEP linter
-          python3 -mpip install torch==2.7.1
-        elif command -v rocminfo; then
-          # NB: Installing torch on ROCm runner with pip here causes CI to fail
-          # with a memoryview is too large error only on MI300 runners. Is pip
-          # version on ROCm runner there too old? As a workaround, let's use the
-          # GPU device name coming from rocminfo instead
-          DEVICE_NAME=rocm
-          DEVICE_TYPE=$(rocminfo | grep "Marketing Name" | tail -n1 | awk -F':' '{print $2}' | xargs)
+        if [[ -z "${INPUT_DEVICE_NAME:-}" ]] || [[ -z "${INPUT_DEVICE_TYPE:-}" ]]; then
+          echo "Device name or type is not provided, trying to get them"
+          python3 -mpip install boto3==1.35.33 psutil==7.0.0 pynvml==12.0.0
+
+          if command -v nvidia-smi; then
+            # NB: I'm using PyTorch here to get the device name, however, it needs to
+            # install the correct version of PyTorch manually for now. Any PyTorch
+            # version is fine, I just use 2.7.1 to satify PYPIDEP linter
+            python3 -mpip install torch==2.7.1
+          elif command -v rocminfo; then
+            # NB: Installing torch on ROCm runner with pip here causes CI to fail
+            # with a memoryview is too large error only on MI300 runners. Is pip
+            # version on ROCm runner there too old? As a workaround, let's use the
+            # GPU device name coming from rocminfo instead
+            DEVICE_NAME=rocm
+            DEVICE_TYPE=$(rocminfo | grep "Marketing Name" | tail -n1 | awk -F':' '{print $2}' | xargs)
+          fi
+        else
+          echo "Set device name to ${INPUT_DEVICE_NAME} and device type to ${INPUT_DEVICE_TYPE}"
+          DEVICE_NAME="${INPUT_DEVICE_NAME}"
+          DEVICE_TYPE="${INPUT_DEVICE_TYPE}"
         fi
 
         echo "DEVICE_NAME=$DEVICE_NAME" >> $GITHUB_ENV

--- a/.github/workflows/test_upload_benchmark_results.yml
+++ b/.github/workflows/test_upload_benchmark_results.yml
@@ -20,3 +20,18 @@ jobs:
           schema-version: v3
           dry-run: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  test-device-name-and-type:
+    runs-on: linux.2xlarge
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Test upload the benchmark results with device name and type (v3)
+        uses: ./.github/actions/upload-benchmark-results
+        with:
+          benchmark-results-dir: .github/scripts/benchmark-results-dir-for-testing/v3
+          schema-version: v3
+          dry-run: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          device-name: rocm
+          device-type: 'AMD Instinct Mi325X VF'


### PR DESCRIPTION
By setting the `DEVICE_NAME` and `DEVICE_TYPE` env variables, they will be used accordingly by the action.  These name will be used as they are on HUD dashboard