### PR TITLE
[AUTOREVERT] Makefile targets pointing to canary

### DIFF
--- a/aws/lambda/pytorch-auto-revert/Makefile
+++ b/aws/lambda/pytorch-auto-revert/Makefile
@@ -19,15 +19,15 @@ venv/bin/lintrunner: venv/bin/python
 
 .PHONY: run-local
 run-local: venv/bin/python
-	venv/bin/python -m pytorch_auto_revert --dry-run
+	NOTIFY_ISSUE_NUMBER=265 REPO_FULL_NAME=pytorch/pytorch-canary venv/bin/python -m pytorch_auto_revert --dry-run
 
 .PHONY: run-local-workflows
 run-local-workflows: venv/bin/python
-	venv/bin/python -m pytorch_auto_revert --dry-run autorevert-checker Lint trunk pull inductor linux-binary-manywheel --hours 8 --revert-action log
+	NOTIFY_ISSUE_NUMBER=265 REPO_FULL_NAME=pytorch/pytorch-canary venv/bin/python -m pytorch_auto_revert --dry-run autorevert-checker Lint trunk pull inductor linux-binary-manywheel --hours 8 --revert-action log
 
 .PHONY: run-local-hud
 run-local-hud: venv/bin/python
-	venv/bin/python -m pytorch_auto_revert --dry-run hud
+	NOTIFY_ISSUE_NUMBER=265 REPO_FULL_NAME=pytorch/pytorch-canary venv/bin/python -m pytorch_auto_revert --dry-run hud
 
 deployment.zip:
 	mkdir -p deployment


### PR DESCRIPTION
Setting the makefile targets to point to `pytorch/pytorch-canary` as an example.