### PR TITLE
[autorevert] Add 'linux-aarch64' to default workflows

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
@@ -21,7 +21,7 @@ from .testers.restart_checker import workflow_restart_checker
 from .utils import RestartAction, RetryWithBackoff, RevertAction
 
 
-DEFAULT_WORKFLOWS = ["Lint", "trunk", "pull", "inductor"]
+DEFAULT_WORKFLOWS = ["Lint", "trunk", "pull", "inductor", "linux-aarch64"]
 DEFAULT_REPO_FULL_NAME = "pytorch/pytorch"
 DEFAULT_HOURS = 16
 DEFAULT_COMMENT_ISSUE_NUMBER = (


### PR DESCRIPTION
see the list of viable strict workflows: https://github.com/pytorch/pytorch/pull/164374/files

testing:

```
HOURS=18 python -m pytorch_auto_revert --dry-run
2025-10-01 11:19:05,293 INFO [root] [v2] Start: workflows=Lint,trunk,pull,inductor,linux-aarch64 hours=18 repo=pytorch/pytorch restart_action=log revert_action=log notify_issue_number=163650 bisection=unlimited
2025-10-01 11:19:05,293 INFO [root] [v2] Run timestamp (CH log ts) = 2025-10-01T18:19:05.293306+00:00
2025-10-01 11:19:05,294 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Fetching commits in time range: repo=pytorch/pytorch lookback=18h
2025-10-01 11:19:06,055 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Commits fetched: 47 commits in 0.76s
2025-10-01 11:19:06,055 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Fetching jobs: repo=pytorch/pytorch workflows=Lint,trunk,pull,inductor,linux-aarch64 commits=47 lookback=18h
2025-10-01 11:20:14,477 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Jobs fetched: 7058 rows in 68.42s
2025-10-01 11:20:14,539 INFO [root] [v2] Extracted 1 signals
2025-10-01 11:20:14,539 INFO [root] [v2][signal] wf=inductor key=inductor-test / test outcome=Ineligible(reason=<IneligibleReason.FLAKY: 'flaky'>, message='signal is flaky (mixed outcomes on same commit)')
2025-10-01 11:20:14,539 INFO [root] [v2] Candidate action groups: 0
2025-10-01 11:20:14,539 INFO [root] [v2] Executed action groups: 0
2025-10-01 11:20:15,101 INFO [root] [v2] State logged
```


