### PR TITLE
[autorevert] Fix pacing query logic

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
@@ -113,7 +113,7 @@ class ActionLogger:
             "    SELECT\n"
             "      count() AS total_restarts,\n"
             "      maxIf(ts, failed = 1) AS last_failure_ts,\n"
-            "      any(failed = 0 AND ts > (now() - toIntervalSecond({pacing_sec:UInt32}))) "
+            "      (countIf(failed = 0 AND ts > (now() - toIntervalSecond({pacing_sec:UInt32}))) > 0) "
             "               AS has_success_within_window\n"
             "    FROM rows\n"
             "  )\n"


### PR DESCRIPTION
`Any` has an unexpected semantics in CH, it returns [first value](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/any), the correct way to check if any value is true is to use `countIf`.

The effect of this bug was that pacing was not working in some rare cases when there are multiple events for commit and some were not matching the condition.

Basically, when the first event goes out of the window, and second event is added, we get two rows: 0 and 1, and depending on the random order either would be returned by `any`.

The correct way (among many) would use `countIf` instead.

Testing:

```
  SELECT
  (countIf(failed = 0 AND ts > now() - toIntervalSecond(5200)) > 0) AS has_success_within_window,
    any(failed = 0 AND ts > now() - toIntervalSecond(5200)) AS has_success_within_window_old
  FROM misc.autorevert_events_v2
  WHERE repo = 'pytorch/pytorch'
  AND action = 'restart'
  AND dry_run = 0
  AND commit_sha = 'b5c4f46bb9ede8dc6adf11975c93b9f285d9ed67'
  ```
  
  result:
```
"has_success_within_window","has_success_within_window_old"
"1","0"
```



more testing:

```
python -m pytorch_auto_revert --dry-run autorevert-checker Lint trunk pull inductor rocm rocm-mi300 --hours 18   --hud-html
```