### PR TITLE
Fetch summary report

### DIFF
--- a/torchci/lib/benchmark/api_helper/compilers/helpers/common.ts
+++ b/torchci/lib/benchmark/api_helper/compilers/helpers/common.ts
@@ -1,5 +1,3 @@
-import { NextResponse } from "next/server";
-
 export function extractBackendSqlStyle(
   output: string,
   suite: string,
@@ -103,6 +101,6 @@ export function parseTimestampTokenSeconds(
   return ms == null ? null : Math.floor(ms / 1000);
 }
 
-export function badRequest(message: string) {
-  return NextResponse.json({ error: message }, { status: 400 });
+export function badRequest(message: string, res: any) {
+  return res.json({ error: message }, { status: 400 });
 }

--- a/torchci/pages/api/benchmark/list_regression_summary_reports.ts
+++ b/torchci/pages/api/benchmark/list_regression_summary_reports.ts
@@ -28,7 +28,7 @@ export default async function handler(
 
   // validate params
   if (!params || !params.report_id) {
-    return badRequest("Missing required params report_id");
+    return badRequest("Missing required params report_id", res);
   }
 
   // list regression summary report for a given type. ex compiler_regression
@@ -39,7 +39,8 @@ export default async function handler(
     // validate last_ts_token only if it is provided
     if (last_ts_token && !last_ts) {
       return badRequest(
-        `invalid input params last_ts_token "${last_ts_token}"`
+        `invalid input params last_ts_token "${last_ts_token}"`,
+        res
       );
     }
 


### PR DESCRIPTION
Setup an API to fetch regression summary report.

Currently only return suspicious and regression level data

Demo Api resp:
https://torchci-git-fetchsummaryreport-fbopensource.vercel.app/api/benchmark/list_regression_summary_reports?report_id=compiler_regression&&limit=2