### PR TITLE
Add series of c7i instance types

### DIFF
--- a/.github/canary-scale-config.yml
+++ b/.github/canary-scale-config.yml
@@ -32,6 +32,36 @@
 #     is_ephemeral: true
 
 runner_types:
+  c.linux.c7i.large:
+    disk_size: 15
+    instance_type: c7i.large
+    is_ephemeral: true
+    os: linux
+  c.linux.c7i.2xlarge:
+    disk_size: 150
+    instance_type: c7i.2xlarge
+    is_ephemeral: true
+    os: linux
+  c.linux.c7i.4xlarge:
+    disk_size: 150
+    instance_type: c7i.4xlarge
+    is_ephemeral: true
+    os: linux
+  c.linux.c7i.8xlarge:
+    disk_size: 200
+    instance_type: c7i.8xlarge
+    is_ephemeral: true
+    os: linux
+  c.linux.c7i.12xlarge:
+    disk_size: 200
+    instance_type: c7i.12xlarge
+    is_ephemeral: true
+    os: linux
+  c.linux.c7i.24xlarge:
+    disk_size: 150
+    instance_type: c7i.24xlarge
+    is_ephemeral: true
+    os: linux
   c.linux.8xlarge.amx:
     disk_size: 200
     instance_type: m7i-flex.8xlarge
@@ -90,16 +120,6 @@ runner_types:
   c.linux.2xlarge:
     disk_size: 150
     instance_type: c5.2xlarge
-    is_ephemeral: true
-    os: linux
-  c.linux.2xlarge.c7i.test.donotuse:
-    disk_size: 150
-    instance_type: c7i.2xlarge
-    is_ephemeral: true
-    os: linux
-  c.linux.2xlarge.c7a.test.donotuse:
-    disk_size: 150
-    instance_type: c7a.2xlarge
     is_ephemeral: true
     os: linux
   c.linux.4xlarge:

--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -32,6 +32,36 @@
 #     is_ephemeral: true
 
 runner_types:
+  lf.c.linux.c7i.large:
+    disk_size: 15
+    instance_type: c7i.large
+    is_ephemeral: true
+    os: linux
+  lf.c.linux.c7i.2xlarge:
+    disk_size: 150
+    instance_type: c7i.2xlarge
+    is_ephemeral: true
+    os: linux
+  lf.c.linux.c7i.4xlarge:
+    disk_size: 150
+    instance_type: c7i.4xlarge
+    is_ephemeral: true
+    os: linux
+  lf.c.linux.c7i.8xlarge:
+    disk_size: 200
+    instance_type: c7i.8xlarge
+    is_ephemeral: true
+    os: linux
+  lf.c.linux.c7i.12xlarge:
+    disk_size: 200
+    instance_type: c7i.12xlarge
+    is_ephemeral: true
+    os: linux
+  lf.c.linux.c7i.24xlarge:
+    disk_size: 150
+    instance_type: c7i.24xlarge
+    is_ephemeral: true
+    os: linux
   lf.c.linux.8xlarge.amx:
     disk_size: 200
     instance_type: m7i-flex.8xlarge
@@ -90,16 +120,6 @@ runner_types:
   lf.c.linux.2xlarge:
     disk_size: 150
     instance_type: c5.2xlarge
-    is_ephemeral: true
-    os: linux
-  lf.c.linux.2xlarge.c7i.test.donotuse:
-    disk_size: 150
-    instance_type: c7i.2xlarge
-    is_ephemeral: true
-    os: linux
-  lf.c.linux.2xlarge.c7a.test.donotuse:
-    disk_size: 150
-    instance_type: c7a.2xlarge
     is_ephemeral: true
     os: linux
   lf.c.linux.4xlarge:

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -32,6 +32,36 @@
 #     is_ephemeral: true
 
 runner_types:
+  lf.linux.c7i.large:
+    disk_size: 15
+    instance_type: c7i.large
+    is_ephemeral: true
+    os: linux
+  lf.linux.c7i.2xlarge:
+    disk_size: 150
+    instance_type: c7i.2xlarge
+    is_ephemeral: true
+    os: linux
+  lf.linux.c7i.4xlarge:
+    disk_size: 150
+    instance_type: c7i.4xlarge
+    is_ephemeral: true
+    os: linux
+  lf.linux.c7i.8xlarge:
+    disk_size: 200
+    instance_type: c7i.8xlarge
+    is_ephemeral: true
+    os: linux
+  lf.linux.c7i.12xlarge:
+    disk_size: 200
+    instance_type: c7i.12xlarge
+    is_ephemeral: true
+    os: linux
+  lf.linux.c7i.24xlarge:
+    disk_size: 150
+    instance_type: c7i.24xlarge
+    is_ephemeral: true
+    os: linux
   lf.linux.8xlarge.amx:
     disk_size: 200
     instance_type: m7i-flex.8xlarge
@@ -90,16 +120,6 @@ runner_types:
   lf.linux.2xlarge:
     disk_size: 150
     instance_type: c5.2xlarge
-    is_ephemeral: true
-    os: linux
-  lf.linux.2xlarge.c7i.test.donotuse:
-    disk_size: 150
-    instance_type: c7i.2xlarge
-    is_ephemeral: true
-    os: linux
-  lf.linux.2xlarge.c7a.test.donotuse:
-    disk_size: 150
-    instance_type: c7a.2xlarge
     is_ephemeral: true
     os: linux
   lf.linux.4xlarge:

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -28,6 +28,36 @@
 #     is_ephemeral: true
 
 runner_types:
+  linux.c7i.large:
+    disk_size: 15
+    instance_type: c7i.large
+    is_ephemeral: true
+    os: linux
+  linux.c7i.2xlarge:
+    disk_size: 150
+    instance_type: c7i.2xlarge
+    is_ephemeral: true
+    os: linux
+  linux.c7i.4xlarge:
+    disk_size: 150
+    instance_type: c7i.4xlarge
+    is_ephemeral: true
+    os: linux
+  linux.c7i.8xlarge:
+    disk_size: 200
+    instance_type: c7i.8xlarge
+    is_ephemeral: true
+    os: linux
+  linux.c7i.12xlarge:
+    disk_size: 200
+    instance_type: c7i.12xlarge
+    is_ephemeral: true
+    os: linux
+  linux.c7i.24xlarge:
+    disk_size: 150
+    instance_type: c7i.24xlarge
+    is_ephemeral: true
+    os: linux
   linux.8xlarge.amx:
     disk_size: 200
     instance_type: m7i-flex.8xlarge
@@ -86,16 +116,6 @@ runner_types:
   linux.2xlarge:
     disk_size: 150
     instance_type: c5.2xlarge
-    is_ephemeral: true
-    os: linux
-  linux.2xlarge.c7i.test.donotuse:
-    disk_size: 150
-    instance_type: c7i.2xlarge
-    is_ephemeral: true
-    os: linux
-  linux.2xlarge.c7a.test.donotuse:
-    disk_size: 150
-    instance_type: c7a.2xlarge
     is_ephemeral: true
     os: linux
   linux.4xlarge:


### PR DESCRIPTION
This relates to pytorch/test-infra#7175 to add several c7i instance types that we can migrate workflows that currently use c5 instance types over to.