### PR TITLE
Add target MarkArea for time series chart when user change the lcommit and rcommit

### DIFF
--- a/torchci/clickhouse_queries/compilers_benchmark_api_commit_query/query.sql
+++ b/torchci/clickhouse_queries/compilers_benchmark_api_commit_query/query.sql
@@ -1,21 +1,33 @@
 SELECT
-  replaceOne(head_branch, 'refs/heads/', '') AS branch,
-  head_sha AS commit,
-  workflow_id,
-  toStartOfHour(min(fromUnixTimestamp(timestamp))) AS date
+    replaceOne(head_branch, 'refs/heads/', '') AS branch,
+    head_sha AS commit,
+    workflow_id,
+    toStartOfHour(min(fromUnixTimestamp(timestamp))) AS date
 FROM benchmark.oss_ci_benchmark_torchinductor
 PREWHERE
-  timestamp >= toUnixTimestamp({startTime: DateTime64(3)})
-  AND timestamp <  toUnixTimestamp({stopTime:  DateTime64(3)})
+    timestamp >= toUnixTimestamp({startTime: DateTime64(3)})
+    AND timestamp < toUnixTimestamp({stopTime:  DateTime64(3)})
 WHERE
-  (has({branches: Array(String)}, replaceOne(head_branch, 'refs/heads/', '')) OR empty({branches: Array(String)}))
-  AND (has({suites: Array(String)}, suite) OR empty({suites: Array(String)}))
-  AND (benchmark_dtype = {dtype: String} OR empty({dtype: String}))
-  AND (benchmark_mode  = {mode: String} OR empty({mode: String}))
-  AND (device          = {device: String} OR empty({device: String}))
-  AND (multiSearchAnyCaseInsensitive(arch, {arch: Array(String)}) OR empty({arch: Array(String)}))
+    (
+        has(
+            {branches: Array(String)},
+            replaceOne(head_branch, 'refs/heads/', '')
+        )
+        OR empty({branches: Array(String)})
+    )
+    AND (
+        has({suites: Array(String)}, suite)
+        OR empty({suites: Array(String)})
+    )
+    AND (benchmark_dtype = {dtype: String} OR empty({dtype: String}))
+    AND (benchmark_mode = {mode: String} OR empty({mode: String}))
+    AND (device = {device: String} OR empty({device: String}))
+    AND (
+        multiSearchAnyCaseInsensitive(arch, {arch: Array(String)})
+        OR empty({arch: Array(String)})
+    )
 GROUP BY
-  branch, commit, workflow_id
+    branch, commit, workflow_id
 ORDER BY
-  branch, date
+    branch, date
 SETTINGS session_timezone = 'UTC';

--- a/torchci/components/benchmark/v3/components/benchmarkList/BenchmarkCategoryCard.tsx
+++ b/torchci/components/benchmark/v3/components/benchmarkList/BenchmarkCategoryCard.tsx
@@ -15,7 +15,6 @@ import {
   Typography,
 } from "@mui/material";
 import { Box } from "@mui/system";
-import { wrap } from "module";
 import Link from "next/link";
 import ReactMarkdown from "react-markdown";
 

--- a/torchci/components/benchmark/v3/components/benchmarkList/BenchmarkCategoryCard.tsx
+++ b/torchci/components/benchmark/v3/components/benchmarkList/BenchmarkCategoryCard.tsx
@@ -15,6 +15,7 @@ import {
   Typography,
 } from "@mui/material";
 import { Box } from "@mui/system";
+import { wrap } from "module";
 import Link from "next/link";
 import ReactMarkdown from "react-markdown";
 

--- a/torchci/components/benchmark/v3/components/dataRender/components/benchmarkTimeSeries/BenchmarkChartSection.tsx
+++ b/torchci/components/benchmark/v3/components/dataRender/components/benchmarkTimeSeries/BenchmarkChartSection.tsx
@@ -28,6 +28,8 @@ export default function BenchmarkChartSection({
   data = [],
   chartSectionConfig,
   onSelect,
+  lcommit,
+  rcommit,
 }: {
   data?: BenchmarkTimeSeriesInput[];
   chartSectionConfig: BenchmarkChartSectionConfig;
@@ -96,6 +98,8 @@ export default function BenchmarkChartSection({
                   onSelect={(payload: any) => {
                     onSelect?.(payload);
                   }}
+                  lcommit={lcommit}
+                  rcommit={rcommit}
                 />
               </Paper>
             </Box>

--- a/torchci/components/benchmark/v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/BenchmarkTimeSeriesChart.tsx
+++ b/torchci/components/benchmark/v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/BenchmarkTimeSeriesChart.tsx
@@ -4,7 +4,7 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import * as echarts from "echarts";
 import ReactECharts from "echarts-for-react";
-import React, {useMemo, useRef, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import {
   BenchmarkTimeSeriesCharRenderOpiton,
   BenchmarkTimeSeriesInput,
@@ -34,8 +34,8 @@ type Props = {
   defaultSelectMode?: boolean;
   markArea?: {
     start?: string;
-    end?: string
-  }
+    end?: string;
+  };
   /** Called when user clicks Confirm with L/R selected for a single series. */
   onSelect?: (sel: ConfirmPayload) => void;
 };
@@ -51,7 +51,6 @@ const BenchmarkTimeSeriesChart: React.FC<Props> = ({
   onSelect = () => {},
 }) => {
   const chartRef = useRef<ReactECharts>(null);
-
 
   // Selection state
   const [selectMode, setSelectMode] = useState<boolean>(defaultSelectMode);
@@ -138,14 +137,19 @@ const BenchmarkTimeSeriesChart: React.FC<Props> = ({
 
   // Build line series first (indices 0..N-1 map to logical timeseries)
   const lineSeries: echarts.SeriesOption[] = useMemo(() => {
-     const ma = markArea?.start && markArea?.end ? [[
+    const ma =
+      markArea?.start && markArea?.end
+        ? [
+            [
               {
                 xAxis: markArea?.start,
               },
               {
                 xAxis: markArea?.end,
-              }
-            ]]: []
+              },
+            ],
+          ]
+        : [];
     const markAreaLine = {
       type: "line",
       name: "__markarea__",
@@ -157,7 +161,7 @@ const BenchmarkTimeSeriesChart: React.FC<Props> = ({
       markArea: {
         silent: true,
         itemStyle: { color: "rgba(255,173,177,0.25)" },
-        data:ma,
+        data: ma,
       },
     } as echarts.SeriesOption;
 
@@ -201,8 +205,16 @@ const BenchmarkTimeSeriesChart: React.FC<Props> = ({
           : {}),
       } as echarts.SeriesOption;
     });
-    return [...lines,markAreaLine]
-  }, [seriesDatas, timeseries, selectedSeriesIdx, leftIdx, rightIdx, markArea?.start, markArea?.end]);
+    return [...lines, markAreaLine];
+  }, [
+    seriesDatas,
+    timeseries,
+    selectedSeriesIdx,
+    leftIdx,
+    rightIdx,
+    markArea?.start,
+    markArea?.end,
+  ]);
 
   // Highlight overlays appended after all lines
   const overlaySeries: echarts.SeriesOption[] = useMemo(() => {

--- a/torchci/components/benchmark/v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/BenchmarkTimeSeriesChart.tsx
+++ b/torchci/components/benchmark/v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/BenchmarkTimeSeriesChart.tsx
@@ -42,6 +42,8 @@ type Props = {
 };
 
 const DEFAULT_HEIGHT = 200;
+
+// we want to show the mark area as a single point, default gap is 1 hour
 const DEFAULT_MARK_AREA_SINGLE_GAP = 60 * 60 * 1000;
 
 const BenchmarkTimeSeriesChart: React.FC<Props> = ({
@@ -141,8 +143,8 @@ const BenchmarkTimeSeriesChart: React.FC<Props> = ({
   const lineSeries: echarts.SeriesOption[] = useMemo(() => {
     let ma: any = [];
     if (markArea?.start && markArea?.end) {
-      const a = dayjs(markArea?.start).valueOf();
-      const b = dayjs(markArea?.end).valueOf();
+      const a = dayjs(markArea.start).valueOf();
+      const b = dayjs(markArea.end).valueOf();
       const [l, r] = a <= b ? [a, b] : [b, a];
       // when left === right, we want to show the mark area as a single point
       const gap = markArea?.singleGap ?? DEFAULT_MARK_AREA_SINGLE_GAP;

--- a/torchci/components/benchmark/v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/BenchmarkTimeSeriesChart.tsx
+++ b/torchci/components/benchmark/v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/BenchmarkTimeSeriesChart.tsx
@@ -170,7 +170,7 @@ const BenchmarkTimeSeriesChart: React.FC<Props> = ({
       tooltip: { show: false },
       markArea: {
         silent: true,
-        itemStyle: { color: "rgba(255,173,177,0.25)" },
+        itemStyle: { color: "rgba(0, 150, 136, 0.15)" } ,
         data: ma,
       },
     } as echarts.SeriesOption;

--- a/torchci/components/benchmark/v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/BenchmarkTimeSeriesChart.tsx
+++ b/torchci/components/benchmark/v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/BenchmarkTimeSeriesChart.tsx
@@ -170,7 +170,7 @@ const BenchmarkTimeSeriesChart: React.FC<Props> = ({
       tooltip: { show: false },
       markArea: {
         silent: true,
-        itemStyle: { color: "rgba(0, 150, 136, 0.15)" } ,
+        itemStyle: { color: "rgba(0, 150, 136, 0.06)" },
         data: ma,
       },
     } as echarts.SeriesOption;

--- a/torchci/components/benchmark/v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/RenderingOptions.ts
+++ b/torchci/components/benchmark/v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/RenderingOptions.ts
@@ -35,7 +35,7 @@ export const echartRenderingOptions: echarts.EChartsOption = {
   xAxis: {
     type: "time",
     axisLabel: {
-      formatter: (v: number) => dayjs.utc(v).format("MM-DD"),
+      formatter: (v: number) => dayjs.utc(v).format("MM-DD HH:mm"),
     },
   },
   yAxis: {

--- a/torchci/components/benchmark/v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChartGroup.tsx
+++ b/torchci/components/benchmark/v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChartGroup.tsx
@@ -1,5 +1,6 @@
 import { Grid, Typography } from "@mui/material";
 import { Box } from "@mui/system";
+import { BenchmarkCommitMeta } from "lib/benchmark/store/benchmark_regression_store";
 import { useMemo } from "react";
 import {
   BenchmarkTimeSeriesInput,
@@ -9,7 +10,6 @@ import {
   passesFilter,
 } from "../helper";
 import BenchmarkTimeSeriesChart from "./BenchmarkTimeSeriesChart/BenchmarkTimeSeriesChart";
-import { BenchmarkCommitMeta } from "lib/benchmark/store/benchmark_regression_store";
 
 type Props = {
   data: any[];
@@ -29,7 +29,6 @@ export default function BenchmarkTimeSeriesChartGroup({
   rcommit,
   onSelect = () => {},
 }: Props) {
-
   const filtered = useMemo(
     () =>
       data.filter((s) =>
@@ -100,8 +99,8 @@ export default function BenchmarkTimeSeriesChartGroup({
                 chartGroup?.chart?.customizedConfirmDialog
               }
               markArea={{
-                start: lcommit?.date?? undefined,
-                end: rcommit?.date?? undefined,
+                start: lcommit?.date ?? undefined,
+                end: rcommit?.date ?? undefined,
               }}
               renderOptions={chartGroup?.chart?.renderOptions}
               defaultSelectMode={defaultSelectMode}

--- a/torchci/components/benchmark/v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChartGroup.tsx
+++ b/torchci/components/benchmark/v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChartGroup.tsx
@@ -9,11 +9,14 @@ import {
   passesFilter,
 } from "../helper";
 import BenchmarkTimeSeriesChart from "./BenchmarkTimeSeriesChart/BenchmarkTimeSeriesChart";
+import { BenchmarkCommitMeta } from "lib/benchmark/store/benchmark_regression_store";
 
 type Props = {
   data: any[];
   chartGroup: ChartGroupConfig;
   defaultSelectMode?: boolean;
+  lcommit?: BenchmarkCommitMeta;
+  rcommit?: BenchmarkCommitMeta;
   onSelect?: (payload: any) => void;
 };
 
@@ -22,8 +25,11 @@ export default function BenchmarkTimeSeriesChartGroup({
   data,
   chartGroup,
   defaultSelectMode = false,
+  lcommit,
+  rcommit,
   onSelect = () => {},
 }: Props) {
+
   const filtered = useMemo(
     () =>
       data.filter((s) =>
@@ -93,6 +99,10 @@ export default function BenchmarkTimeSeriesChartGroup({
               customizedConfirmDialog={
                 chartGroup?.chart?.customizedConfirmDialog
               }
+              markArea={{
+                start: lcommit?.date?? undefined,
+                end: rcommit?.date?? undefined,
+              }}
               renderOptions={chartGroup?.chart?.renderOptions}
               defaultSelectMode={defaultSelectMode}
               onSelect={onSelect}

--- a/torchci/components/benchmark/v3/components/dataRender/fanout/FanoutComponents.tsx
+++ b/torchci/components/benchmark/v3/components/dataRender/fanout/FanoutComponents.tsx
@@ -39,6 +39,7 @@ export function FanoutBenchmarkTimeSeriesComparisonTableSection({
         data={data}
         lcommit={lcommit ?? undefined}
         rcommit={rcommit ?? undefined}
+        onChange={onChange}
       />
     </>
   );


### PR DESCRIPTION
# Overview
Add target MarkArea for time series chart when user change the lcommit and rcommit 

## Query list commit change:
Query: compilers_benchmark_api_commit_query

Details: Instead of use distinct, we use GROUP BY to find unique branch, commit, workflowId combo along with a hourly granularity timestamp.

This allow us to target right time range when targeting the MapArea in time series chart and sync with the timeseries data's timestamp

## Add MapArea
when lcommit and rcommit change, a mapArea in time series chart willl also change. THis helps users to identify where the datapoint they are targeting, reduce confusion.

# Preview
https://torchci-git-addmarkarea-fbopensource.vercel.app/benchmark/compilers_regression

# Demo
![Oct-02-2025 19-08-37](https://github.com/user-attachments/assets/0b61f2b5-d327-46a2-98ea-0e597e35c9da)


