### PR TITLE
[testing] file report: notifs go through alerting-infra repo

### DIFF
--- a/.github/workflows/update_test_file_report.yml
+++ b/.github/workflows/update_test_file_report.yml
@@ -7,13 +7,11 @@ on:
     # Run every tuesday at 3am UTC
     - cron: '0 3 * * 2'
   workflow_dispatch:
-  pull_request:
 
 jobs:
   file-report:
     if: >
       (github.event_name == 'schedule' && github.event.schedule.cron == '0 2 * * *') ||
-      (github.event_name == 'pull_request') ||
       (github.event_name == 'workflow_dispatch')
     permissions:
       issues: write
@@ -51,7 +49,6 @@ jobs:
   weekly-file-report-notification:
     if: >
       (github.event_name == 'schedule' && github.event.schedule.cron == '0 3 * * 2') ||
-      (github.event_name == 'pull_request') ||
       (github.event_name == 'workflow_dispatch')
     permissions:
       issues: write

--- a/.github/workflows/update_test_file_report.yml
+++ b/.github/workflows/update_test_file_report.yml
@@ -7,11 +7,13 @@ on:
     # Run every tuesday at 3am UTC
     - cron: '0 3 * * 2'
   workflow_dispatch:
+  pull_request:
 
 jobs:
   file-report:
     if: >
       (github.event_name == 'schedule' && github.event.schedule.cron == '0 2 * * *') ||
+      (github.event_name == 'pull_request') ||
       (github.event_name == 'workflow_dispatch')
     permissions:
       issues: write
@@ -41,12 +43,15 @@ jobs:
           CLICKHOUSE_USERNAME: ${{ secrets.CLICKHOUSE_HUD_USER_USERNAME }}
           CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_HUD_USER_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_INFRA_ALERTS_LAMBDA_URL: ${{ secrets.AWS_INFRA_ALERTS_LAMBDA_URL }}
+          TEST_REPORT_AWS_LAMBDA_TOKEN: ${{ secrets.TEST_REPORT_AWS_LAMBDA_TOKEN }}
         run: |
           python3 tools/torchci/test_insights/daily_regression.py
 
   weekly-file-report-notification:
     if: >
       (github.event_name == 'schedule' && github.event.schedule.cron == '0 3 * * 2') ||
+      (github.event_name == 'pull_request') ||
       (github.event_name == 'workflow_dispatch')
     permissions:
       issues: write
@@ -61,6 +66,8 @@ jobs:
 
       - name: Run notifier
         env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_INFRA_ALERTS_LAMBDA_URL: ${{ secrets.AWS_INFRA_ALERTS_LAMBDA_URL }}
+          TEST_REPORT_AWS_LAMBDA_TOKEN: ${{ secrets.TEST_REPORT_AWS_LAMBDA_TOKEN }}
         run: |
           python3 tools/torchci/test_insights/weekly_notification.py

--- a/tools/torchci/test_insights/daily_regression.py
+++ b/tools/torchci/test_insights/daily_regression.py
@@ -12,7 +12,7 @@ FILE_REPORT_URL = "https://hud.pytorch.org/tests/fileReport"
 
 CONFIG: list[dict[str, Any]] = [
     {
-        "team": "dev-infra",
+        "team": "pytorch-dev-infra",
         "condition": lambda _: True,
         "link": FILE_REPORT_URL,
     },
@@ -184,6 +184,10 @@ class RegressionNotification:
         now = datetime.datetime.now(datetime.timezone.utc).strftime(
             "%Y-%m-%dT%H:%M:%S.%fZ"
         )
+        body = (
+            f"{regression_str}\n"
+            "This issue is a notification and should close immediately after creation to avoid clutter."
+        )
         return {
             "schema_version": 1,
             "source": "test-infra-test-file-reports",
@@ -194,7 +198,9 @@ class RegressionNotification:
             "priority": "P2",
             "occurred_at": now,
             "teams": [team],
-            "identity": {"alarm_id": f"test-file-reports-daily-regression-{team}"},
+            "identity": {
+                "alarm_id": f"test-file-reports-daily-regression-{team}-{now}"
+            },
             "links": {
                 "dashboard_url": report_url,
             },

--- a/tools/torchci/test_insights/daily_regression.py
+++ b/tools/torchci/test_insights/daily_regression.py
@@ -1,15 +1,16 @@
+import datetime
 import json
 from collections import defaultdict
 from functools import lru_cache
 from typing import Any
 
 from torchci.test_insights.file_report_generator import FileReportGenerator
-from torchci.test_insights.weekly_notification import create_comment
+from torchci.test_insights.weekly_notification import send_to_aws_alerting_lambda
 
 
 FILE_REPORT_URL = "https://hud.pytorch.org/tests/fileReport"
 
-CONFIG = [
+CONFIG: list[dict[str, Any]] = [
     {
         "team": "dev-infra",
         "condition": lambda _: True,
@@ -176,6 +177,29 @@ class RegressionNotification:
             + f"\\# skipped change: {_get_change('skipped', additional_processing=lambda x: round(x, 2))}\n"
         )
 
+    def generate_alert_json(
+        self, team: str, report_url: str, regression_str: str
+    ) -> dict[str, Any]:
+        title = f"Regression Detected in Test Reports for {team}"
+        now = datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%S.%fZ"
+        )
+        return {
+            "schema_version": 1,
+            "source": "test-infra-test-file-reports",
+            "state": "FIRING",
+            "title": title,
+            "description": regression_str,
+            "summary": regression_str,
+            "priority": "P2",
+            "occurred_at": now,
+            "teams": [team],
+            "identity": {"alarm_id": f"test-file-reports-daily-regression-{team}"},
+            "links": {
+                "dashboard_url": report_url,
+            },
+        }
+
     def determine_regressions(self) -> None:
         """
         Determine regressions in the test data based on the provided filter.
@@ -214,7 +238,6 @@ class RegressionNotification:
             f"additional_info/weekly_file_report/data_{current_sha}.json.gz",
         )
 
-        regressions = []
         for team in CONFIG:
             change = self.gen_regression_for_team(
                 team=team,
@@ -223,19 +246,17 @@ class RegressionNotification:
                 status_changes=status_changes,
             )
             if self.filter_thresholds(change):
-                regressions.append(
-                    {
-                        "team": team["team"],
-                        "regression": change,
-                        "link": team["link"],
-                    }
+                print(f"Regression detected for team: {team['team']}")
+                print(self.format_regression_string(team, change))
+
+                alert = self.generate_alert_json(
+                    team=team["team"],
+                    report_url=team["link"],
+                    regression_str=self.format_regression_string(team, change),
                 )
-                create_comment(
-                    {
-                        # "title": f"Regression detected for {team['team']}",
-                        "body": self.format_regression_string(team, change),
-                    }
-                )
+                send_to_aws_alerting_lambda(alert)
+            else:
+                print(f"No significant regression for team: {team['team']}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow up to https://github.com/pytorch/test-infra/pull/7303 since I fixed the pre-normalized alert thing earlier than expected

Format is a bit weird since the alerting infra isn't really set up for notification style alerts where its never really closed by anything, so it just sends a "resolved" alert right after to prevent open issues from cluttering up the issue list.  Not sure if this is the best way

TODO: move secrets to aws secret manager?  

Testing:
Ran the script a couple of times and saw that issues got created and closed in the alerting repo, also put pull request trigger to see if that would work too and it did