### PR TITLE
[ez][testing] file report: route to pytorch-dev-infra team, remove unused var, etc

### DIFF
--- a/.github/workflows/update_test_file_report.yml
+++ b/.github/workflows/update_test_file_report.yml
@@ -25,7 +25,6 @@ jobs:
           cd tools/torchci && python3 -mpip install -e .
 
       - name: Run file report generator
-        if: false
         env:
           CLICKHOUSE_ENDPOINT: ${{ secrets.CLICKHOUSE_HUD_USER_URL }}
           CLICKHOUSE_USERNAME: ${{ secrets.CLICKHOUSE_HUD_USER_USERNAME }}

--- a/.github/workflows/update_test_file_report.yml
+++ b/.github/workflows/update_test_file_report.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   file-report:
     if: >
-      (github.event_name == 'schedule' && github.event.schedule.cron == '0 2 * * *') ||
+      (github.event_name == 'schedule' && github.event.schedule == '0 2 * * *') ||
       (github.event_name == 'workflow_dispatch')
     permissions:
       issues: write
@@ -46,7 +46,7 @@ jobs:
 
   weekly-file-report-notification:
     if: >
-      (github.event_name == 'schedule' && github.event.schedule.cron == '0 3 * * 2') ||
+      (github.event_name == 'schedule' && github.event.schedule == '0 3 * * 2') ||
       (github.event_name == 'workflow_dispatch')
     permissions:
       issues: write

--- a/tools/torchci/test_insights/daily_regression.py
+++ b/tools/torchci/test_insights/daily_regression.py
@@ -11,7 +11,7 @@ FILE_REPORT_URL = "https://hud.pytorch.org/tests/fileReport"
 
 CONFIG = [
     {
-        "team": "dev-infra",
+        "team": "pytorch-dev-infra",
         "condition": lambda _: True,
         "link": FILE_REPORT_URL,
     },
@@ -74,9 +74,7 @@ class RegressionNotification:
             if (info["short_job_name"], info["file"]) in relevant_keys
         ]
 
-        def _sum_invoking_file_info(
-            data: list[dict[str, Any]], field: str
-        ) -> dict[str, Any]:
+        def _sum_invoking_file_info(data: list[dict[str, Any]]) -> dict[str, Any]:
             info = {
                 "count": sum(item["count"] for item in data),
                 "cost": sum(item["cost"] for item in data),
@@ -85,12 +83,8 @@ class RegressionNotification:
             }
             return info
 
-        agg_prev_file_info = _sum_invoking_file_info(
-            relevant_prev_invoking_file_info, "prev"
-        )
-        agg_curr_file_info = _sum_invoking_file_info(
-            relevant_curr_invoking_file_info, "curr"
-        )
+        agg_prev_file_info = _sum_invoking_file_info(relevant_prev_invoking_file_info)
+        agg_curr_file_info = _sum_invoking_file_info(relevant_curr_invoking_file_info)
 
         invoking_file_info_diff = {
             "count": {

--- a/tools/torchci/test_insights/file_report_generator.py
+++ b/tools/torchci/test_insights/file_report_generator.py
@@ -209,6 +209,7 @@ class FileReportGenerator:
         where
             j.created_at > now() - interval 8 day
             and j.created_at < now() - interval 1 day
+            and j.conclusion != 'cancelled'
         group by
             name
         """

--- a/torchci/pages/tests/fileReport.tsx
+++ b/torchci/pages/tests/fileReport.tsx
@@ -1058,14 +1058,29 @@ export default function Page() {
       <CommitInfo data={data} />
       <Overview
         data={data}
-        setFileFilter={setFileFilter}
-        setJobFilter={setJobFilter}
-        setLabelFilter={setLabelFilter}
+        setFileFilter={(input) => {
+          setFileFilter(input);
+          setFileRegex(false);
+        }}
+        setJobFilter={(input) => {
+          setJobFilter(input);
+          setJobRegex(false);
+        }}
+        setLabelFilter={(input) => {
+          setLabelFilter(input);
+          setLabelRegex(false);
+        }}
       />
       <Diffs
         data={data}
-        setFileFilter={setFileFilter}
-        setJobFilter={setJobFilter}
+        setFileFilter={(input) => {
+          setFileFilter(input);
+          setFileRegex(false);
+        }}
+        setJobFilter={(input) => {
+          setJobFilter(input);
+          setJobRegex(false);
+        }}
       />
       <Graphs data={data} />
       <Stack spacing={2}>

--- a/torchci/pages/tests/fileReport.tsx
+++ b/torchci/pages/tests/fileReport.tsx
@@ -464,44 +464,33 @@ function Overview({
   );
 
   const groupedRows = _.map(groupByTarget, (rows, key) => {
-    // Sum within sha
-    const summedBySha = _.map(_.groupBy(rows, "sha"), (shaRows) => {
-      return _.reduce(
-        shaRows,
-        (acc, row) => {
-          acc.count += row.count || 0;
-          acc.time += row.time || 0;
-          acc.cost += row.cost || 0;
-          acc.skipped += row.skipped || 0;
-          acc.frequency += row.frequency || 0;
-          return acc;
-        },
-        { count: 0, time: 0, cost: 0, skipped: 0, frequency: 0 }
-      );
-    });
-    // the reduce across shas for average
-    return _.reduce(
-      summedBySha,
-      (acc, summed) => {
-        acc.count += summed.count;
-        acc.time += summed.time;
-        acc.cost += summed.cost;
-        acc.skipped += summed.skipped;
-        acc.frequency += summed.frequency;
+    // Sum
+    const summed = _.reduce(
+      rows,
+      (acc, row) => {
+        acc.count += row.count || 0;
+        acc.time += row.time || 0;
+        acc.cost += row.cost || 0;
+        acc.skipped += row.skipped || 0;
+        acc.frequency += row.frequency || 0;
         return acc;
       },
-      {
-        id: rows[0].id,
-        file: rows[0].file,
-        short_job_name: rows[0].short_job_name,
-        labels: key,
-        count: 0,
-        time: 0,
-        cost: 0,
-        skipped: 0,
-        frequency: 0,
-      }
+      { count: 0, time: 0, cost: 0, skipped: 0, frequency: 0 }
     );
+
+    // Average across sha data points
+    const numShas = _.uniq(rows.map((r) => r.sha)).length;
+    return {
+      id: rows[0].id,
+      file: rows[0].file,
+      short_job_name: rows[0].short_job_name,
+      labels: key,
+      count: summed.count / numShas,
+      time: summed.time / numShas,
+      cost: summed.cost / numShas,
+      skipped: summed.skipped / numShas,
+      frequency: summed.frequency / numShas,
+    };
   });
 
   return (


### PR DESCRIPTION
Some small changes bundled together

Fix team name for pytorch dev infra
Remove unused var
Frequency weighting should not include cancelled jobs
Fix file report HUD page overview page calculating averages across commits wrong
When double clicking, set the regex to be false since it's supposed to search for that specific thing (also because the input probably isn't correct regex)
Fix workflow cron if statement
Remove if statement left in from testing
