### PR TITLE
[drci] Remove drci updates from some data and torchtune

### DIFF
--- a/.github/workflows/update-drci-comments.yml
+++ b/.github/workflows/update-drci-comments.yml
@@ -16,13 +16,11 @@ jobs:
         include: [
           { repo: ao, org: pytorch },
           { repo: audio, org: pytorch },
-          { repo: data, org: meta-pytorch },
           { repo: executorch, org: pytorch },
           { repo: pytorch, org: pytorch },
           { repo: rl, org: pytorch },
           { repo: text, org: pytorch },
           { repo: torchchat, org: pytorch },
-          { repo: torchtune, org: meta-pytorch },
           { repo: tutorials, org: pytorch },
           { repo: vision, org: pytorch },
         ]


### PR DESCRIPTION
The most recent PR updates for these repos was 1 month ago.  They previously had pytorch-bot installed on them but currently do not after the migration to meta-pytorch.  I requested it to be added to torchtune, but there have been no PR updates to this repo for more than a month so I'm not sure if it's worth it