### PR TITLE
Increase data fetch range for compiler inductor

### DIFF
--- a/aws/lambda/benchmark_regression_summary_report/common/config.py
+++ b/aws/lambda/benchmark_regression_summary_report/common/config.py
@@ -51,7 +51,7 @@ COMPILER_BENCHMARK_CONFIG = BenchmarkConfig(
     policy=Policy(
         frequency=Frequency(value=1, unit="days"),
         range=RangeConfig(
-            baseline=DayRangeWindow(value=8),
+            baseline=DayRangeWindow(value=6),
             comparison=DayRangeWindow(value=4),
         ),
         metrics={


### PR DESCRIPTION
the compiler inductor runs benchmark from 2 times per day to 1 time per day.
Increase the time range for regression notification in case we run into insufficient data situation

see change https://github.com/pytorch/pytorch/pull/165185