### PR TITLE
[HUD] [vLLM vs SGLang] Minor Enhancements for the vLLM vs SGLang Dashboard

### DIFF
--- a/torchci/components/benchmark/llms/components/graphPanel/LLMsGraphPanelBase.tsx
+++ b/torchci/components/benchmark/llms/components/graphPanel/LLMsGraphPanelBase.tsx
@@ -317,8 +317,6 @@ const MetricTable = ({
   WORKFLOW_ID_TO_COMMIT: Record<string, string>;
   repo: string;
 }) => {
-  const repoUrl = "https://github.com/" + repo;
-
   const exportToCSV = () => {
     const baseData = chartData[availableMetric] ?? [];
     const rows = baseData.map((entry, index) => {
@@ -391,6 +389,9 @@ const MetricTable = ({
           <TableBody>
             {chartData[availableMetric].map((entry: any, index: number) => {
               const commit = WORKFLOW_ID_TO_COMMIT[entry.workflow_id];
+              // Get the source repository from the entry's extra field or use the default repo
+              const sourceRepo = entry?.extra?.["source_repo"] || repo;
+              const repoUrl = `https://github.com/${sourceRepo}`;
               return (
                 <TableRow key={index}>
                   <TableCell>


### PR DESCRIPTION
### Summary
This PR includes the following changes, related to the vLLM vs SGLang HUD Dashboard, and none of these changes affect the existing dashboards.

- The commit hash column in the "Data Details" table, was not clickable. And, we want it to render to the official source repository, when clicked on the commit hash.
- In the dashboard, currently the time series graph show the numbers by default with the lines, but due to a lot of different metrics being plotted on the same graph for two repos, it becomes difficult to read the lines. So, we need to hide the numbers by default for the comparison dashboard.
- In order to easily distinguish between vLLM and SGLang plottings in the HUD Dashboard, we need to make the SGLang related plots to "dashed lines" for better understanding.

### Testing

Verified that all the changes are working fine in the comparison dashboard ([link](https://torchci-git-huddashboard-fbopensource.vercel.app/benchmark/llms?startTime=Sun%2C%2028%20Sep%202025%2023%3A52%3A09%20GMT&stopTime=Sun%2C%2012%20Oct%202025%2023%3A52%3A09%20GMT&granularity=week&lBranch=main&lCommit=&rBranch=main&rCommit=&repoName=pytorch%2Fpytorch&benchmarkName=&modelName=meta-llama%2FMeta-Llama-3.1-8B-Instruct&backendName=All%20Backends&modeName=All%20Modes&dtypeName=All%20DType&deviceName=All%20Devices&archName=All%20Platforms&repos=vllm-project%2Fvllm%2Csgl-project%2Fsglang&qps=1))

<img width="1710" height="774" alt="Screenshot 2025-10-12 at 4 52 47 PM" src="https://github.com/user-attachments/assets/2c9fa5b9-5a8d-474d-b223-74c777c976ea" />


