### PR TITLE
Update validation workflows to use relative path

### DIFF
--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -100,7 +100,7 @@ jobs:
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
 
   generate-aarch64-linux-gpu-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: ./.github/workflows/generate_binary_build_matrix.yml
     with:
       package-type: wheel
       os: linux-aarch64
@@ -114,7 +114,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.generate-aarch64-linux-cpu-matrix.outputs.matrix) }}
       fail-fast: false
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: ./.github/workflows/linux_job_v2.yml
     name: ${{ matrix.build_name }}
     with:
       runner: ${{ matrix.validation_runner }}


### PR DESCRIPTION
This fixes issue when running the valdation on branch
See similar code from validate-linux: https://github.com/pytorch/test-infra/blob/main/.github/workflows/validate-linux-binaries.yml#L104