### PR TITLE
Update pip on Amazon Linux 2023 validations

### DIFF
--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -177,6 +177,8 @@ jobs:
         yum install -y python3.11 python3.11-devel
         python3.11 -m ensurepip --upgrade
         python3.11 --version
+        python3.11 -m pip install --upgrade pip
+        python3.11 -m pip --version
 
         CUDA_VERSION=$(python3 ../../test-infra/tools/scripts/get_stable_cuda_version.py --channel ${{ inputs.channel }})
         CUDA_VERSION_NODOT=$(echo $CUDA_VERSION | tr -d '.')


### PR DESCRIPTION
Latest pip is required to install PyTorch dependency correctly.
Successful run: https://github.com/pytorch/test-infra/actions/runs/18511911515/job/52754496129