### PR TITLE
[HUD] add filter for non-viable strict jobs

### DIFF
--- a/torchci/components/job/JobConclusion.module.css
+++ b/torchci/components/job/JobConclusion.module.css
@@ -103,8 +103,9 @@
 }
 
 .viablestrict_blocking {
-  border-left: 1px solid var(--color-failure);
-  border-right: 1px solid var(--color-failure);
+  border: 2px solid var(--color-failure);
+  background-color: rgba(255, 0, 0, 0.1);
+  border-radius: 2px;
 }
 
 .autorevert_tooltip_anchor {

--- a/torchci/components/job/JobTooltip.tsx
+++ b/torchci/components/job/JobTooltip.tsx
@@ -1,3 +1,4 @@
+import { isJobViableStrictBlocking } from "lib/JobClassifierUtil";
 import { JobData } from "../../lib/types";
 import { SingleWorkflowDispatcher } from "../commit/WorkflowDispatcher";
 import LogViewer from "../common/log/LogViewer";
@@ -7,10 +8,14 @@ export default function JobTooltip({
   job,
   sha,
   isAutorevertSignal,
+  repoOwner,
+  repoName,
 }: {
   job: JobData;
   sha?: string;
   isAutorevertSignal?: boolean;
+  repoOwner?: string;
+  repoName?: string;
 }) {
   // For nonexistent jobs, just show something basic:
   if (!job.hasOwnProperty("id")) {
@@ -24,12 +29,22 @@ export default function JobTooltip({
     );
   }
 
+  const isViableStrictBlocking =
+    repoOwner &&
+    repoName &&
+    isJobViableStrictBlocking(job.name, repoOwner, repoName);
+
   return (
     <div>
       {`[${job.conclusion}] ${job.name}`}
       {isAutorevertSignal && (
         <div style={{ color: "red", fontWeight: "bold" }}>
           Failure in this job has triggered autorevert.
+        </div>
+      )}
+      {isViableStrictBlocking && (
+        <div style={{ color: "orange", fontWeight: "bold" }}>
+          This job is viable/strict blocking.
         </div>
       )}
       <div>

--- a/torchci/lib/useGroupingPreference.tsx
+++ b/torchci/lib/useGroupingPreference.tsx
@@ -77,3 +77,15 @@ export function useHideGreenColumnsPreference(): [
   );
   return [state, setState];
 }
+
+export function useHideNonViableStrictPreference(): [
+  boolean,
+  (_hideNonViableStrictValue: boolean) => void
+] {
+  const [state, setState] = usePreference(
+    "hideNonViableStrict",
+    /*override*/ undefined,
+    /*default*/ false
+  );
+  return [state, setState];
+}


### PR DESCRIPTION
1. adds a filter to hide non-viable strict jobs:
    <img width="240" height="34" alt="image" src="https://github.com/user-attachments/assets/8e8a6eef-bc7c-492b-9de2-c28412b439a8" />


2. in grouped view makes the border more obvious / adds tooltip info:
    <img width="826" height="173" alt="image" src="https://github.com/user-attachments/assets/c5e9d07a-1651-4f0d-86f5-4430b5a6c3f8" />
    <img width="303" height="108" alt="image" src="https://github.com/user-attachments/assets/c4b8ba14-461e-42d2-a970-3489c7e2cc5d" />


3. syncs the viable-strict logic with [the source](https://github.com/pytorch/pytorch/blob/main/.github/workflows/update-viablestrict.yml#L26)  (per the comment in the original implementation)
    Note: we really need to centralize the config for viable/strict, but that's out of the scope of this PR.