### PR TITLE
Allow ROCm jobs to save artifacts in RUNNER_TEMP

### DIFF
--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -164,9 +164,8 @@ jobs:
         uses: ./test-infra/.github/actions/setup-linux
         if: ${{ inputs.gpu-arch-type != 'rocm' }}
 
-      # TESTING: TO BE REMOVED ONCE https://github.com/pytorch/pytorch/pull/165821 LANDS
       - name: Setup ROCM
-        uses: pytorch/pytorch/.github/actions/setup-rocm@save_github_env_rocm
+        uses: pytorch/pytorch/.github/actions/setup-rocm@main
         if: ${{ inputs.gpu-arch-type == 'rocm' }}
 
       - name: Setup SSH


### PR DESCRIPTION
Together with https://github.com/pytorch/pytorch/pull/165821, this is to unblock https://github.com/pytorch/pytorch/pull/165821 because ROCm runner can't create `artifacts-to-be-uploaded` directory on its `GITHUB_WORKSPACE` dir

cc @jithunnair-amd @akashveramd