### PR TITLE
[HUD] Fix metrics page erroring due to sometimes getting null

### DIFF
--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -782,7 +782,9 @@ export default function Page() {
               title={"Merge retry rate (avg)"}
               queryName={"merge_retry_rate"}
               metricName={"avg_retry_rate"}
-              valueRenderer={(value) => (value ? value.toFixed(2) + "x" : "N/A")}
+              valueRenderer={(value) =>
+                value ? value.toFixed(2) + "x" : "N/A"
+              }
               queryParams={timeParams}
               badThreshold={(value) => value > 2.0} // 2.0 average retries
             />


### PR DESCRIPTION
The query uses avg(something) but if there are no rows to average over it returns null, so just make it display N/A if that happens.

Could also add a null check but maybe people want to do things if the value is null idk