### PR TITLE
Rename forge->torchforge in allow list for download.pytorch.org

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -327,7 +327,7 @@ PACKAGE_ALLOW_LIST = {
         "docker",
         "docstring_parser",
         "exceptiongroup",
-        "forge",
+        "torchforge",
         "gitdb",
         "GitPython",
         "grpcio",


### PR DESCRIPTION
The forge repo was renamed to torchforge