### PR TITLE
[bug]fix url push with shallow == true

### DIFF
--- a/torchci/components/benchmark_v3/components/benchmarkSideBar/components/useUrlSync.tsx
+++ b/torchci/components/benchmark_v3/components/benchmarkSideBar/components/useUrlSync.tsx
@@ -81,7 +81,7 @@ export function useUrlStoreSync<T extends Record<string, any>>(
 
     isApplyingUrlRef.current = true;
     navigate({ pathname, query: nextQueryObj }, undefined, {
-      shallow: false,
+      shallow: true,
     }).finally(() => {
       lastPushedSigRef.current = nextSig;
       setTimeout(() => {


### PR DESCRIPTION
without { shallow: true }, Next.js performs a full route navigation, it:
- destroys and remounts your page component.
- Browser scroll resets to top.

this makes our UI reset to top when we have UI animation to navigate from point A to point B since everything is remounted

Demo: https://torchci-git-addshadow-fbopensource.vercel.app/benchmark/compilers_regression