### PR TITLE
[autorevert] treat test failures as successes in job-track Signals

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
@@ -482,16 +482,15 @@ class SignalExtractor:
                     # Map aggregation verdict to outer SignalStatus
                     if meta.status is None:
                         continue
-                    if meta.status == AggStatus.FAILURE:
+                    if meta.status == AggStatus.FAILURE and meta.has_non_test_failures:
                         # mark presence of non-test failures (relevant for job track)
-                        if meta.has_non_test_failures:
-                            has_relevant_failures = True
-
+                        has_relevant_failures = True
                         ev_status = SignalStatus.FAILURE
-                    elif meta.status == AggStatus.SUCCESS:
-                        ev_status = SignalStatus.SUCCESS
-                    else:
+                    elif meta.status == AggStatus.PENDING:
                         ev_status = SignalStatus.PENDING
+                    else:
+                        # Note: when all failures are caused by tests, we do NOT emit job-level failures
+                        ev_status = SignalStatus.SUCCESS
 
                     # Extract wf_run_id/run_attempt from the attempt key
                     _, _, _, wf_run_id, run_attempt = akey


### PR DESCRIPTION
Currently, we have a slight overlap between job and test Signals. Specifically, when there is any non-test related failure in the job within the lookback window (e.g. any infra flake), the job signal is extracted, and it extracts ANY job failures, including test failures as the job signal. This potentially leads to the duplication, when the same test failure is processed both as test and job-track Signals, and it increases the chance of false positives.

This PR makes the separation explicit:
1. test failures are extracted as test-track Signals
2. job-track Signals deliberately **ignore** job failures caused **exclusively** by tests (such events are extracted as successes)

---

The intended outcome of this change:
1. job-track signals will only try to revert infra-breaking changes and ignore test failures
2. test-track signal processing remains as it is