### PR TITLE
[HUD] Change regex toggle color (mostly for dark mode)

### DIFF
--- a/torchci/components/common/RegexButton.tsx
+++ b/torchci/components/common/RegexButton.tsx
@@ -24,7 +24,9 @@ export default function RegexButton({
           borderColor: "transparent",
           fontFamily: "monospace",
           color: "inherit",
-          backgroundColor: isRegex ? "rgba(182, 196, 223, 0.33)" : "transparent",
+          backgroundColor: isRegex
+            ? "rgba(182, 196, 223, 0.33)"
+            : "transparent",
         }}
         variant="outlined"
         onClick={() => setIsRegex(!isRegex)}


### PR DESCRIPTION
In light mode, it got slightly darker (and probably also changed hues a bit)
In dark mode, it became lighter (previously was pretty much unnoticeable)


Old:
<img width="494" height="120" alt="image" src="https://github.com/user-attachments/assets/07575507-b0e3-4081-96db-4448c58f17e9" />
<img width="439" height="70" alt="image" src="https://github.com/user-attachments/assets/3a1e4c69-e93f-4fe4-88e3-22da8ff8b47f" />


New:
<img width="470" height="84" alt="image" src="https://github.com/user-attachments/assets/0ecb0a7a-9f4a-4b88-9373-13c5affcb943" />

<img width="494" height="97" alt="image" src="https://github.com/user-attachments/assets/a57759c3-efc3-4b31-9dc0-a0a64389401a" />
