### PR TITLE
[autorevert] add 'slow' workflow

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
@@ -60,7 +60,7 @@ class DefaultConfig:
         self.secret_store_name = os.environ.get("SECRET_STORE_NAME", "")
         self.workflows = os.environ.get(
             "WORKFLOWS",
-            ",".join(["Lint", "trunk", "pull", "inductor", "linux-aarch64"]),
+            ",".join(["Lint", "trunk", "pull", "inductor", "linux-aarch64", "slow"]),
         ).split(",")
 
     def to_autorevert_v2_params(


### PR DESCRIPTION
### Testing

```
python -m pytorch_auto_revert --dry-run autorevert-checker slow --hours 18  --hud-html
2025-10-24 15:22:34,841 INFO [root] [v2] Start: workflows=slow hours=18 repo=pytorch/pytorch restart_action=log revert_action=log notify_issue_number=163650 bisection=unlimited
2025-10-24 15:22:34,842 INFO [root] [v2] Run timestamp (CH log ts) = 2025-10-24T22:22:34.841907+00:00
2025-10-24 15:22:34,842 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Fetching commits in time range: repo=pytorch/pytorch lookback=18h
2025-10-24 15:22:35,923 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Commits fetched: 19 commits in 1.08s
2025-10-24 15:22:35,923 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Fetching jobs: repo=pytorch/pytorch workflows=slow commits=19 lookback=18h
2025-10-24 15:23:12,303 INFO [pytorch_auto_revert.signal_extraction_datasource] [extract] Jobs fetched: 370 rows in 36.38s
2025-10-24 15:23:12,307 INFO [root] [v2] Extracted 2 signals
2025-10-24 15:23:12,307 INFO [root] [v2][signal] wf=slow key=linux-jammy-py3.10-clang18-asan / test outcome=Ineligible(reason=<IneligibleReason.FIXED: 'fixed'>, message='signal appears recovered at head')
2025-10-24 15:23:12,307 INFO [root] [v2][signal] wf=slow key=linux-jammy-py3.10-clang12 / test outcome=Ineligible(reason=<IneligibleReason.FIXED: 'fixed'>, message='signal appears recovered at head')
2025-10-24 15:23:12,307 INFO [root] [v2] Candidate action groups: 0
2025-10-24 15:23:12,307 INFO [root] [v2] Executed action groups: 0
2025-10-24 15:23:13,071 INFO [root] [v2] State logged
2025-10-24 15:23:13,072 INFO [root] [hud] Rendering HTML for repo=pytorch/pytorch workflows=slow lookback=18 → 2025-10-24T22-22-34.841907-00-00.html
2025-10-24 15:23:13,075 INFO [root] HUD written to 2025-10-24T22-22-34.841907-00-00.html
```