### PR TITLE
[ROCm] update nightly binary build matrix to 7.0 7.1

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -33,7 +33,7 @@ CUDA_ARCHES_DICT = {
 }
 
 ROCM_ARCHES_DICT = {
-    "nightly": ["6.4", "7.0"],
+    "nightly": ["7.0", "7.1"],
     "test": ["6.3", "6.4"],
     "release": ["6.3", "6.4"],
 }


### PR DESCRIPTION
ROCm 7.1 released 10/30.  pytorch images are built.  https://github.com/pytorch/pytorch/pull/166730 is merged.