### PR TITLE
[CH] swap all_test_runs to be in tests database, use different source

### DIFF
--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -691,14 +691,14 @@ SUPPORTED_PATHS = {
     "disabled_tests_historical": "misc.disabled_tests_historical",
     # fbossci-cloudwatch-metrics bucket
     "ghci-related": "infra_metrics.cloudwatch_metrics",
-    "all_test_runs": "fortesting.all_test_runs",
+    "test_jsons_while_running": "tests.all_test_runs",
 }
 
 OBJECT_CONVERTER = {
     "default.merges": merges_adapter,
     "default.test_run_s3": handle_test_run_s3,
     "default.failed_test_runs": handle_test_run_s3,
-    "fortesting.all_test_runs": handle_test_run_s3_small,
+    "tests.all_test_runs": handle_test_run_s3_small,
     "default.test_run_summary": handle_test_run_summary,
     "default.merge_bases": merge_bases_adapter,
     "default.rerun_disabled_tests": rerun_disabled_tests_adapter,


### PR DESCRIPTION
Source is https://github.com/pytorch/pytorch/pull/166988 <- uploads jsons while the job is running to this path