### PR TITLE
[HUD] Fix benchmark nav bar dropdown hover behavior?

### DIFF
--- a/torchci/components/layout/NavBarGroupDropdown.tsx
+++ b/torchci/components/layout/NavBarGroupDropdown.tsx
@@ -113,6 +113,7 @@ export function NavBarGroupDropdown({
                     fontWeight: 800,
                     textTransform: "uppercase",
                     letterSpacing: 0.5,
+                    lineHeight: 2,
                   }}
                 >
                   {group.label}


### PR DESCRIPTION
Really minor thing where if you hover over the benchmark in the navbar, and then move your mouse away without ever entering the menu, the menu stays open.  This changes it so that the menu closes if you move your mouse away.  The change looks big but it's mostly indent, my vscode diff view looks better
