### PR TITLE
[HUD][ODC] Show gpu dev instructions even when the command can't be found

### DIFF
--- a/torchci/components/job/ODCCommand.tsx
+++ b/torchci/components/job/ODCCommand.tsx
@@ -211,12 +211,20 @@ export function ODCommandInstructions({
             />
             <InstructionItem
               index={5}
-              title="Download the binary"
+              title="Run the test"
               component={
-                <>
-                  <Typography variant="body1">Run the test</Typography>
-                  <TerminalCopyBox text={command} />
-                </>
+                command == undefined ? (
+                  <Typography variant="body1">
+                    We were unable to extract the test command from the job log.
+                    Please check the log manually to find the command to run the
+                    test.
+                  </Typography>
+                ) : (
+                  <>
+                    <Typography variant="body1">Run the test</Typography>
+                    <TerminalCopyBox text={command} />
+                  </>
+                )
               }
             />
           </Stack>
@@ -366,10 +374,10 @@ function useInformationFromJobLog(
         "To execute this test, run the following from the base repo dir:"
       )
     );
-  if (reproCommandLine === -1) {
-    return undefined;
-  }
-  const command = noTimeStampLogLines[reproCommandLine + 1].trim();
+  const command =
+    reproCommandLine === -1
+      ? undefined
+      : noTimeStampLogLines[reproCommandLine + 1].trim();
 
   // Machine type
   let gpuType: string = "CPU-X86";


### PR DESCRIPTION
Still show the gpu dev instructions even when the test repro command can't be found.  This way people can still get a similar machine even when its unclear what failed so they can repro other things or just get an environment similar to CI

Also fix a typo in the instruction item

<img width="700" height="87" alt="image" src="https://github.com/user-attachments/assets/68af9f52-ce6c-4f2e-aa03-f763e94723f2" />
