### PR TITLE
[Autorevert] Separate signal columns for jobs with different failures rules outputs

### DIFF
--- a/aws/lambda/pytorch-auto-revert/SIGNAL_EXTRACTION.md
+++ b/aws/lambda/pytorch-auto-revert/SIGNAL_EXTRACTION.md
@@ -82,28 +82,6 @@ Notes
 - Each commit holds a list of `SignalEvent`s (time‑ordered by `started_at`).
   Ordering: dicts in Python 3.7+ preserve insertion order. Phase A inserts commit keys in push‑timestamp DESC order, so iterating the mapping yields newest→older commits without extra sorting.
 
-### Test‑track semantics
-- Source of truth for SUCCESS/FAILURE is `tests.all_test_runs` per test id.
-- When a test row exists for an attempt:
-  - Emit at most one FAILURE if any failed runs exist; at most one SUCCESS if any successful runs exist.
-- When no test rows exist for an attempt and any grouped job for that attempt is pending → emit PENDING.
-- Otherwise (no test rows and not pending) → no event for that attempt.
-
-### Job‑track semantics (non‑test)
-- Build per normalized job base across commits; aggregate shards by `(wf_run_id, run_attempt)`.
-- Event mapping per attempt uses aggregated job meta with test‑failure filtering:
-  - FAILURE only when the attempt had non‑test failures (e.g. infra‑related).
-  - PENDING when the attempt is still running.
-  - SUCCESS otherwise, including when failures are exclusively test‑caused (these are handled by test‑track).
-- Cancelled attempts are treated as missing (no event).
-- Emit a job‑track Signal only when at least one attempt/commit shows a non‑test (infra) failure within the window.
-
-Event naming (for debuggability):
-- Consistent key=value format: `wf=<workflow> kind=<test|job> id=<test_id|job_base> run=<wf_run_id> attempt=<run_attempt>`
-- Examples:
-  - Test event: `wf=trunk kind=test id=inductor/test_foo.py::test_bar run=1744 attempt=1`
-  - Job event:  `wf=trunk kind=job  id=linux-jammy-cuda12.8-py3.10-gcc11 / test run=1744 attempt=2`
-
 ### Test‑track mapping
 - Build a per‑commit map `test_id -> list[SignalEvent]` by combining all relevant jobs and shards:
   - For each (wf_run_id, run_attempt, job_base_name) group in the commit, consult `tests.all_test_runs` rows (if any) for each candidate `test_id`:

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/job_agg_index.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/job_agg_index.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from typing import (
@@ -51,7 +51,7 @@ class JobMeta:
     """
 
     all_completed_success: bool = False
-    rules: List[str] = []
+    rules: List[str] = field(default_factory=lambda: [])
     has_failures: bool = False
     has_non_test_failures: bool = False
     is_cancelled: bool = False

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/job_agg_index.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/job_agg_index.py
@@ -50,13 +50,14 @@ class JobMeta:
     - job_id: Optional job_id from the failing job, or from the first job if none failed.
     """
 
-    started_at: datetime = datetime.min
-    is_pending: bool = False
-    is_cancelled: bool = False
-    has_failures: bool = False
     all_completed_success: bool = False
+    rules: List[str] = []
+    has_failures: bool = False
     has_non_test_failures: bool = False
+    is_cancelled: bool = False
+    is_pending: bool = False
     job_id: Optional[int] = None
+    started_at: datetime = datetime.min
 
     @property
     def status(self) -> Optional[SignalStatus]:
@@ -183,6 +184,7 @@ class JobAggIndex(Generic[KeyT]):
             has_non_test_failures=(
                 any((r.is_failure and not r.is_test_failure) for r in jrows)
             ),
+            rules=[r.rule for r in jrows if r.rule],
             job_id=job_id,
         )
         self._meta_cache[key] = meta

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import Callable, List, Optional, Set, Tuple, Union
 
 from .bisection_planner import GapBisectionPlanner
+from .signal_extraction_types import JobBaseName, JobBaseNameRule
 
 
 class SignalStatus(Enum):
@@ -289,6 +290,14 @@ class Signal:
     - commits: newest → older list of SignalCommit objects for this signal
     - job_base_name: optional job base name for job-level signals (recorded when signal is created)
     """
+
+    @classmethod
+    def derive_base_name_with_rule(
+        cls, base_name: JobBaseName, rule: str | None
+    ) -> JobBaseNameRule:
+        if not rule:
+            return JobBaseNameRule(f"{base_name}::UNDEFINED")
+        return JobBaseNameRule(f"{base_name}::{rule}")
 
     def __init__(
         self,

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_types.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_types.py
@@ -23,6 +23,7 @@ Sha = NewType("Sha", str)
 WorkflowName = NewType("WorkflowName", str)
 JobName = NewType("JobName", str)
 JobBaseName = NewType("JobBaseName", str)
+JobBaseNameRule = NewType("JobBaseNameRule", str)
 TestId = NewType("TestId", str)
 
 

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
@@ -2,7 +2,7 @@ import unittest
 from datetime import datetime, timedelta
 from typing import Iterable, List
 
-from pytorch_auto_revert.signal import SignalStatus
+from pytorch_auto_revert.signal import Signal, SignalStatus
 from pytorch_auto_revert.signal_extraction import SignalExtractor
 from pytorch_auto_revert.signal_extraction_datasource import SignalExtractionDatasource
 from pytorch_auto_revert.signal_extraction_types import (
@@ -148,8 +148,12 @@ class TestSignalExtraction(unittest.TestCase):
             J(sha="C1", run=100, job=2, attempt=1, started_at=ts(self.t0, 5)),
         ]
         signals = self._extract(jobs, tests=[])
-        base = jobs[0].base_name
-        sig = self._find_job_signal(signals, "trunk", base)
+        base = jobs[0]
+        sig = self._find_job_signal(
+            signals,
+            "trunk",
+            Signal.derive_base_name_with_rule(base_name=base.base_name, rule=base.rule),
+        )
         self.assertIsNotNone(sig)
         self.assertEqual([c.head_sha for c in sig.commits], ["C2", "C1"])
 
@@ -174,8 +178,12 @@ class TestSignalExtraction(unittest.TestCase):
             ),
         ]
         signals = self._extract(jobs, tests=[])
-        base = jobs[0].base_name
-        sig = self._find_job_signal(signals, "trunk", base)
+        base = jobs[0]
+        sig = self._find_job_signal(
+            signals,
+            "trunk",
+            Signal.derive_base_name_with_rule(base_name=base.base_name, rule=""),
+        )
         self.assertIsNotNone(sig)
         self.assertEqual(len(sig.commits), 1)
         events = sig.commits[0].events
@@ -241,8 +249,12 @@ class TestSignalExtraction(unittest.TestCase):
             ),
         ]
         signals = self._extract(jobs, tests=[])
-        base = jobs[0].base_name
-        sig = self._find_job_signal(signals, "trunk", base)
+        base = jobs[0]
+        sig = self._find_job_signal(
+            signals,
+            "trunk",
+            Signal.derive_base_name_with_rule(base_name=base.base_name, rule=base.rule),
+        )
         self.assertIsNotNone(sig)
         # find X1 commit in the signal and ensure it has no events
         x1 = next(c for c in sig.commits if c.head_sha == "X1")
@@ -291,8 +303,12 @@ class TestSignalExtraction(unittest.TestCase):
         se._datasource = FakeDatasourceWithExtraCommit(jobs, [])
         signals = se.extract()
 
-        base = jobs[0].base_name
-        sig = self._find_job_signal(signals, "trunk", base)
+        base = jobs[0]
+        sig = self._find_job_signal(
+            signals,
+            "trunk",
+            Signal.derive_base_name_with_rule(base_name=base.base_name, rule=base.rule),
+        )
         self.assertIsNotNone(sig)
         # Should have 3 commits: C2 (with events), C3 (no events), C1 (with events)
         self.assertEqual(len(sig.commits), 3)

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
@@ -318,7 +318,9 @@ class TestSignalExtraction(unittest.TestCase):
         sig2 = self._find_job_signal(
             signals,
             "trunk",
-            Signal.derive_base_name_with_rule(base_name=base2.base_name, rule=base2.rule),
+            Signal.derive_base_name_with_rule(
+                base_name=base2.base_name, rule=base2.rule
+            ),
         )
         self.assertIsNotNone(sig2)
         self.assertEqual(len(sig2.commits), 1)


### PR DESCRIPTION
Currently, we ignore all job signals that are 'pytest failure's. This is done as we parse test signals independently in a separate track. This have been introduced to avoid reverts to get confused with signals that are noisy / flaky. A typical case would be a flakiness hapening right before a streak of test failures. Without the current behaviour autorevert would act on the flaky commit instead in the commit that introduced the failure.

With the test track, we noticed a few cases where for some reason we're not obtaining information for tests, and we're investigating all of them with the goal of improving the quality and fix all possible gaps. Having stated that, it is bad that in a few cases we could have reacted based on job signal but we failed to do so as we ignore job signals.

So, after discussion, we decided to re-include job signals that have pytest failures. But, to avoid problems and avoid flakiness, we opted to separate jobs in different columns for each classification rule into the loopback window.