### PR TITLE
Run linux_job_v2 workflow called by ROCm job only on cron schedule and when push to main

### DIFF
--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -108,9 +108,15 @@ on:
         required: false
         default: false
         type: boolean
+      check-run-condition:
+        description: "Enable / Disable running workflow"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   job:
+    if: ${{ inputs.check-run-condition && inputs.gpu-arch-type == 'rocm' && (github.event_name == 'push' || github.event_name == 'schedule') }}
     strategy:
       fail-fast: false
     name: ${{ inputs.job-name }}


### PR DESCRIPTION
In this PR, added the condition in linux_job_v2.yml to run workflow called by ROCm job only on cron schedule and when push to main. This feature is optional and shouldn't affect other workflows. The calling ROCm workflow must set the input 'check-run-condition' to true for using this condition.
This effort is to limit the PR runs on ROCm runner due to limited CI resources and is part of torchtitan PR https://github.com/pytorch/torchtitan/pull/2018