### PR TITLE
Add increased memory r7i runners

### DIFF
--- a/.github/canary-scale-config.yml
+++ b/.github/canary-scale-config.yml
@@ -62,6 +62,36 @@ runner_types:
     instance_type: c7i.24xlarge
     is_ephemeral: true
     os: linux
+  c.linux.r7i.large:
+    disk_size: 150
+    instance_type: r7i.large
+    is_ephemeral: true
+    os: linux
+  c.linux.r7i.xlarge:
+    disk_size: 150
+    instance_type: r7i.xlarge
+    is_ephemeral: true
+    os: linux
+  c.linux.r7i.2xlarge:
+    disk_size: 150
+    instance_type: r7i.2xlarge
+    is_ephemeral: true
+    os: linux
+  c.linux.r7i.4xlarge:
+    disk_size: 150
+    instance_type: r7i.4xlarge
+    is_ephemeral: true
+    os: linux
+  c.linux.r7i.8xlarge:
+    disk_size: 150
+    instance_type: r7i.8xlarge
+    is_ephemeral: true
+    os: linux
+  c.linux.r7i.12xlarge:
+    disk_size: 150
+    instance_type: r7i.12xlarge
+    is_ephemeral: true
+    os: linux
   c.linux.2xlarge.amx:
     disk_size: 200
     instance_type: m7i-flex.2xlarge

--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -62,6 +62,36 @@ runner_types:
     instance_type: c7i.24xlarge
     is_ephemeral: true
     os: linux
+  lf.c.linux.r7i.large:
+    disk_size: 150
+    instance_type: r7i.large
+    is_ephemeral: true
+    os: linux
+  lf.c.linux.r7i.xlarge:
+    disk_size: 150
+    instance_type: r7i.xlarge
+    is_ephemeral: true
+    os: linux
+  lf.c.linux.r7i.2xlarge:
+    disk_size: 150
+    instance_type: r7i.2xlarge
+    is_ephemeral: true
+    os: linux
+  lf.c.linux.r7i.4xlarge:
+    disk_size: 150
+    instance_type: r7i.4xlarge
+    is_ephemeral: true
+    os: linux
+  lf.c.linux.r7i.8xlarge:
+    disk_size: 150
+    instance_type: r7i.8xlarge
+    is_ephemeral: true
+    os: linux
+  lf.c.linux.r7i.12xlarge:
+    disk_size: 150
+    instance_type: r7i.12xlarge
+    is_ephemeral: true
+    os: linux
   lf.c.linux.2xlarge.amx:
     disk_size: 200
     instance_type: m7i-flex.2xlarge

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -62,6 +62,36 @@ runner_types:
     instance_type: c7i.24xlarge
     is_ephemeral: true
     os: linux
+  lf.linux.r7i.large:
+    disk_size: 150
+    instance_type: r7i.large
+    is_ephemeral: true
+    os: linux
+  lf.linux.r7i.xlarge:
+    disk_size: 150
+    instance_type: r7i.xlarge
+    is_ephemeral: true
+    os: linux
+  lf.linux.r7i.2xlarge:
+    disk_size: 150
+    instance_type: r7i.2xlarge
+    is_ephemeral: true
+    os: linux
+  lf.linux.r7i.4xlarge:
+    disk_size: 150
+    instance_type: r7i.4xlarge
+    is_ephemeral: true
+    os: linux
+  lf.linux.r7i.8xlarge:
+    disk_size: 150
+    instance_type: r7i.8xlarge
+    is_ephemeral: true
+    os: linux
+  lf.linux.r7i.12xlarge:
+    disk_size: 150
+    instance_type: r7i.12xlarge
+    is_ephemeral: true
+    os: linux
   lf.linux.2xlarge.amx:
     disk_size: 200
     instance_type: m7i-flex.2xlarge

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -58,6 +58,36 @@ runner_types:
     instance_type: c7i.24xlarge
     is_ephemeral: true
     os: linux
+  linux.r7i.large:
+    disk_size: 150
+    instance_type: r7i.large
+    is_ephemeral: true
+    os: linux
+  linux.r7i.xlarge:
+    disk_size: 150
+    instance_type: r7i.xlarge
+    is_ephemeral: true
+    os: linux
+  linux.r7i.2xlarge:
+    disk_size: 150
+    instance_type: r7i.2xlarge
+    is_ephemeral: true
+    os: linux
+  linux.r7i.4xlarge:
+    disk_size: 150
+    instance_type: r7i.4xlarge
+    is_ephemeral: true
+    os: linux
+  linux.r7i.8xlarge:
+    disk_size: 150
+    instance_type: r7i.8xlarge
+    is_ephemeral: true
+    os: linux
+  linux.r7i.12xlarge:
+    disk_size: 150
+    instance_type: r7i.12xlarge
+    is_ephemeral: true
+    os: linux
   linux.2xlarge.amx:
     disk_size: 200
     instance_type: m7i-flex.2xlarge


### PR DESCRIPTION
Relates to pytorch/test-infra#7175. Add the increased memory versions of the Intel 7th gen runners r7i.