### PR TITLE
[Bot] Don't remove `module:` labels from PRs

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -576,7 +576,7 @@ function myBot(app: Probot): void {
     context.log({ addedLabel });
 
     // Remove issue-only labels from PRs
-    if (addedLabel.startsWith("module:") || addedLabel.startsWith("oncall:")) {
+    if (addedLabel.startsWith("oncall:")) {
       context.log(
         `Removing issue-only label "${addedLabel}" from PR ${context.payload.pull_request.html_url}`
       );

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -1363,31 +1363,6 @@ describe("auto-label-bot: label restrictions", () => {
     handleScope(scope);
   });
 
-  test("remove module label from pull request", async () => {
-    nock("https://api.github.com")
-      .post("/app/installations/2/access_tokens")
-      .reply(200, { token: "test" });
-
-    const payload = requireDeepCopy("./fixtures/pull_request.labeled");
-    payload["label"] = { name: "module: ci" };
-    payload["pull_request"]["labels"] = [{ name: "module: ci" }];
-    emptyMockConfig(payload.repository.full_name);
-
-    const scope = nock("https://api.github.com")
-      .delete("/repos/seemethere/test-repo/issues/20/labels/module%3A%20ci")
-      .reply(200)
-      .post("/repos/seemethere/test-repo/issues/20/comments", (body) => {
-        expect(body.body).toContain("module: ci");
-        expect(body.body).toContain("only applicable to issues");
-        return true;
-      })
-      .reply(200);
-
-    await probot.receive({ name: "pull_request", payload, id: "2" });
-
-    handleScope(scope);
-  });
-
   test("remove oncall label from pull request", async () => {
     nock("https://api.github.com")
       .post("/app/installations/2/access_tokens")


### PR DESCRIPTION
As they are used in conjunction with CC bot and there are number of `autolabeller` configs that adds `module:` labels see https://github.com/pytorch/pytorch/blob/0cd0bd7217fc298e7470cc7d138994cd44f59256/.github/labeler.yml#L7 for example