### PR TITLE
Fix single link

### DIFF
--- a/torchci/components/layout/NavBarGroupDropdown.tsx
+++ b/torchci/components/layout/NavBarGroupDropdown.tsx
@@ -131,6 +131,7 @@ export function NavBarGroupDropdown({
               <MenuItem
                 key={`single-${item.label}`}
                 component="a"
+                href={item.route}
                 sx={{
                   color: "primary.main",
                 }}


### PR DESCRIPTION
## Quick Bug fix
missing add single link's route

## Background
use component="a" instead of "link" due to it has weird link cache. This does not play good when navigate between benchmarks share same page with router params