### PR TITLE
[forward fix] Fix addtional where with brackets

### DIFF
--- a/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/listCommitQueryBuilder.ts
+++ b/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/listCommitQueryBuilder.ts
@@ -113,7 +113,7 @@ export class PytorchOperatorMicroListCommitsDataFetcher
 
   toQueryParams(inputs: any, id?: string): Record<string, any> {
     const params = this._data_query.toQueryParams(inputs);
-    return params
+    return params;
   }
 
   build() {


### PR DESCRIPTION
add bracket to handle situation when no operator name is set, if not this will fetch all commits in benchmark 