### PR TITLE
Bring back ET dashboard per ET request

### DIFF
--- a/torchci/components/benchmark_v3/configs/configurations.tsx
+++ b/torchci/components/benchmark_v3/configs/configurations.tsx
@@ -257,4 +257,16 @@ export const BENCHMARK_CATEGORIES: BenchmarkCategoryGroup[] = [
       },
     ],
   },
+  {
+    title: "ExecuTorch Benchmarks",
+    subtitle: "Benchmarks related to repo pytorch/executorch",
+    tags: ["repo:pytorch/executorch"],
+    items: [
+      {
+        name: "ExecuTorch Benchmark",
+        route: "/benchmark/llms?repoName=pytorch%2Fexecutorch",
+        info: "Powered by [code](https://github.com/pytorch/executorch/tree/main/.github/workflows)",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
Although mobile benchmark numbers are not used.  ET plans to reuse the dashboard for their server-side benchmark like [CUDA backend](https://torchci-git-add-et-bm-dashboard-back-fbopensource.vercel.app/benchmark/llms?startTime=Thu%2C%2013%20Nov%202025%2000%3A48%3A48%20GMT&stopTime=Thu%2C%2020%20Nov%202025%2000%3A48%3A48%20GMT&granularity=day&lBranch=export-D87400561&lCommit=7dd02957cbd251726ce8011deda56f189cd4dcd5&rBranch=export-D87400561&rCommit=7dd02957cbd251726ce8011deda56f189cd4dcd5&repoName=pytorch%2Fexecutorch&benchmarkName=&modelName=All%20Models&backendName=All%20Backends&modeName=All%20Modes&dtypeName=All%20DType&deviceName=CUDA%20BACKEND%20(cuda)&archName=All%20Platforms)

Let's know if the dashboard needs to be cleaned up or not

cc @Gasoonjia @GregoryComer 