### PR TITLE
[drci] Set header for workflow when calling update drci api

### DIFF
--- a/.github/workflows/update-drci-comments.yml
+++ b/.github/workflows/update-drci-comments.yml
@@ -6,7 +6,6 @@ on:
     - cron: "*/15 * * * *"
   # Have the ability to trigger this job manually through the API
   workflow_dispatch:
-  pull_request:
 
 jobs:
   update-drci-comments:


### PR DESCRIPTION
Also changed the URL since that's the main reason I missed this one (I was searching for hud.pytorch.org/api)

Similar to https://github.com/pytorch/test-infra/pull/7511

Testing:
added pr trigger to test https://github.com/pytorch/test-infra/actions/runs/19646178221/job/56261830650?pr=7513

An example failure is https://github.com/pytorch/test-infra/actions/runs/19645854442/job/56260785042 (if the link expires, the result was that the api gets 429 and all the jobs fail)