### PR TITLE
[Autorevert] gitignore /*.html in the main autorevert as a convenience

### DIFF
--- a/aws/lambda/pytorch-auto-revert/.gitignore
+++ b/aws/lambda/pytorch-auto-revert/.gitignore
@@ -1,3 +1,4 @@
 *.zip
 deployment/
 venv/
+./*.html

--- a/aws/lambda/pytorch-auto-revert/.gitignore
+++ b/aws/lambda/pytorch-auto-revert/.gitignore
@@ -1,4 +1,4 @@
 *.zip
 deployment/
 venv/
-./*.html
+/*.html


### PR DESCRIPTION
adding to `aws/lambda/pytorch-auto-revert/.gitignore`

```
+/*.html
```

as a simple convenience change to help use `-a` and not worry about adding the html generated while we do debugging :). 