### PR TITLE
[BetterEngineering]Deprecate Cachebench

### DIFF
--- a/torchci/components/benchmark_v3/configs/configurations.tsx
+++ b/torchci/components/benchmark_v3/configs/configurations.tsx
@@ -21,7 +21,7 @@ import {
 } from "./config_book_types";
 import {
   PYTORCH_GPTFAST_BENCHMARK_ID,
-  PytorchGptFastBenchmarkDashoboardConfig,
+  PytorchGptFastBenchmarkDashboardConfig,
 } from "./teams/gptfast/config";
 import {
   PytorcAoMicroApiBenchmarkDashoboardConfig,
@@ -59,7 +59,7 @@ export const PREDEFINED_BENCHMARK_CONFIG: BenchmarkConfigMap = {
     [BenchmarkPageType.DashboardPage]: PytorchVllmBenchmarkDashoboardConfig,
   },
   [PYTORCH_GPTFAST_BENCHMARK_ID]: {
-    [BenchmarkPageType.DashboardPage]: PytorchGptFastBenchmarkDashoboardConfig,
+    [BenchmarkPageType.DashboardPage]: PytorchGptFastBenchmarkDashboardConfig,
   },
 };
 

--- a/torchci/components/benchmark_v3/configs/teams/gptfast/config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/gptfast/config.ts
@@ -59,7 +59,7 @@ const RENDER_MAPPING_BOOK = {
   },
 };
 
-export const PytorchGptFastBenchmarkDashoboardConfig: BenchmarkUIConfig = {
+export const PytorchGptFastBenchmarkDashboardConfig: BenchmarkUIConfig = {
   benchmarkId: PYTORCH_GPTFAST_BENCHMARK_ID,
   apiId: PYTORCH_GPTFAST_BENCHMARK_ID,
   title: "Gpt-fast Benchmark Dashboard",


### PR DESCRIPTION
deprecate cachebench from benchmark list since it's not used anymore,
fix type:
PytorchGptFastBenchmarkDashoboardConfig
