### PR TITLE
[CDN Migration] Use R2 for nightly and test channel by default

### DIFF
--- a/tools/pkg-helpers/pytorch_pkg_helpers/wheel.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/wheel.py
@@ -28,7 +28,7 @@ def get_pytorch_pip_install_command(
 
     if channel in ["nightly", "test"]:
         download_pytorch_org = "r2-test.pytorch.org"
-        
+
     extra_index = f"https://{download_pytorch_org}/whl/{channel}/{gpu_arch_version}"
     return [f"export PIP_INSTALL_TORCH='{pip_install} --index-url {extra_index}'"]
 


### PR DESCRIPTION
Part of CDN Migration deploying R2 usage by default.
Validation workflows are successful: https://github.com/pytorch/test-infra/actions/runs/19897943319