### PR TITLE
[tritonbench] allow user to query any metric name

### DIFF
--- a/torchci/clickhouse_queries/tritonbench_benchmark/query.sql
+++ b/torchci/clickhouse_queries/tritonbench_benchmark/query.sql
@@ -19,7 +19,7 @@ WITH results AS (
         AND dependencies['triton'].repo = {repo: String}
         AND suite = {suite: String}
         AND name = {benchmark_name: String}
-        AND metric_name = {metric_name: String}
+        AND ({metric_name: String} = '*' OR metric_name = {metric_name: String})
         AND head_branch = {branch: String}
 )
 


### PR DESCRIPTION
Upon the request at https://github.com/meta-pytorch/tritonbench/issues/677, we are adding a feature where user can query all metric names by specifying the metric name as "*".

Test plan:

```
https://torchci-git-xz9-add-query-fbopensource.vercel.app/api/clickhouse/tritonbench_benchmark?parameters=%7B%22commits%22%3A%5B%5D%2C%22getJobId%22%3Afalse%2C%22granularity%22%3A%22hour%22%2C%22benchmark_name%22%3A%22nightly%22%2C%22deviceName%22%3A%22NVIDIA%20H100%22%2C%22startTime%22%3A%222025-11-26T19%3A29%3A35.025%22%2C%22stopTime%22%3A%222025-12-03T19%3A29%3A35.025%22%2C%22workflowId%22%3A0%2C%22repo%22%3A%22triton-lang%2Ftriton%22%2C%22suite%22%3A%22tritonbench-oss%22%2C%22metric_name%22%3A%22*%22%2C%22branch%22%3A%22main%22%7D
```