### PR TITLE
[tritonbench] Add device info to the query

### DIFF
--- a/torchci/clickhouse_queries/tritonbench_benchmark/query.sql
+++ b/torchci/clickhouse_queries/tritonbench_benchmark/query.sql
@@ -7,7 +7,7 @@ WITH results AS (
         model.name AS operator,
         model.type AS suite,
         model.backend AS backend,
-        tupleElement(runners[1], 'name') AS device,
+        tupleElement(runners[1], 'gpu_info') AS device,
         workflow_id,
         replaceOne(head_branch, 'refs/heads/', '') AS head_branch,
         metric.name AS metric_name,


### PR DESCRIPTION
Add device info field to the metric rows.

Returns:

```
[{"workflow_id":19900383274,"head_branch":"main","device":"AMD Instinct MI355X","name":"nightly","operator":"bf16_flash_attention","suite":"tritonbench-oss","mode":"bwd","dtype":"unknown","backend":"","metric_name":"pass","metric_value":0,"granularity_bucket":"2025-12-03T17:00:00Z"},{"workflow_id":19900383274,"head_branch":"main","device":"AMD Instinct MI355X","name":"nightly","operator":"bf16_flash_attention","suite":"tritonbench-oss","mode":"fwd","dtype":"unknown","backend":"","metric_name":"pass","metric_value":1,"granularity_bucket":"2025-12-03T17:00:00Z"},{"workflow_id":19900383274,"head_branch":"main","device":"NVIDIA H100 80GB HBM3","name":"nightly","operator":"bf16_flash_attention","suite":"tritonbench-oss","mode":"bwd","dtype":"unknown","backend":"","metric_name":"pass","metric_value":1,"granularity_bucket":"2025-12-03T17:00:00Z"},{"workflow_id":19900383274,"head_branch":"main","device":"NVIDIA H100 80GB HBM3","name":"nightly","operator":"bf16_flash_attention","suite":"tritonbench-oss","mode":"fwd","dtype":"unknown","backend":"","metric_name":"pass","metric_value":1,"granularity_bucket":"2025-12-03T17:00:00Z"},{"workflow_id":19900383274,"head_branch":"main","device":"AMD Instinct MI355X","name":"nightly","operator":"bf16_flex_attention","suite":"tritonbench-oss","mode":"fwd","dtype":"unknown","backend":"","metric_name":"pass","metric_value":1,"granularity_bucket":"2025-12-03T17:00:00Z"},{"workflow_id":19900383274,"head_branch":"main","device":"AMD Instinct MI355X","name":"nightly","operator":"bf16_flex_attention","suite":"tritonbench-oss","mode":"bwd","dtype":"unknown","backend":"","metric_name":"pass","metric_value":1,"granularity_bucket":"2025-12-03T17:00:00Z"},{"workflow_id":19900383274,"head_branch":"main","device":"NVIDIA H100 80GB HBM3","name":"nightly","operator":"bf16_flex_attention","suite":"tritonbench-oss","mode":"fwd","dtype":"unknown","backend":"","metric_name":"pass","metric_value":1,"granularity_bucket":"2025-12-03T17:00:00Z"},{"workflow_id":19900383274,"head_branch":"main","device":"NVIDIA H100 80GB HBM3","name":"nightly","operator":"bf16_flex_attention","suite":"tritonbench-oss","mode":"bwd","dtype":"unknown","backend":"","metric_name":"pass","metric_value":1,"granularity_bucket":"2025-12-03T17:00:00Z"},{"workflow_id":19900383274,"head_branch":"main","device":"AMD Instinct MI355X","name":"nightly","operator":"bf16_gdpa","suite":"tritonbench-oss","mode":"fwd","dtype":"unknown","backend":"","metric_name":"pass","metric_value":1,"granularity_bucket":"2025-12-03T17:00:00Z"},{"workflow_id":19900383274,"head_branch":"main","device":"AMD Instinct MI355X","name":"nightly","operator":"bf16_gdpa","suite":"tritonbench-oss","mode":"bwd","dtype":"unknown","backend":"","metric_name":"pass","metric_value":1,"granularity_bucket":"2025-12-03T17:00:00Z"},{"workflow_id":19900383274,"head_branch":"main","device":"NVIDIA H100 80GB HBM3","name":"nightly","operator":"bf16_gdpa","suite":"tritonbench-oss","mode":"bwd","dtype":"unknown","backend":"","metric_name":"pass","metric_value":1,"granularity_bucket":"2025-12-03T17:00:00Z"}]
```