### PR TITLE
ci: Use docker version to check if running

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -29,10 +29,12 @@ runs:
       shell: bash
       if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' }}
       run: |
-        if systemctl is-active --quiet docker; then
-            echo "Docker daemon is running...";
-        else
-            echo "Starting docker deamon..." && sudo systemctl start docker;
+        if ! docker version >/dev/null 2>/dev/null; then
+          if systemctl is-active --quiet docker; then
+              echo "Docker daemon is running...";
+          else
+              echo "Starting docker deamon..." && sudo systemctl start docker;
+          fi
         fi
 
     - name: Log in to ECR


### PR DESCRIPTION
This used systemd which is not always available, prefer to use docker version first which should always work regardless if we're using docker in docker on ARC or if we're using our old setup with VMs.