### PR TITLE
Add triton_rocm and triton_xpu to allow list

### DIFF
--- a/s3_management/manage_v2.py
+++ b/s3_management/manage_v2.py
@@ -183,6 +183,8 @@ PACKAGE_ALLOW_LIST = {
         "pytorch_triton",
         "pytorch_triton_rocm",
         "pytorch_triton_xpu",
+        "triton_rocm",
+        "triton_xpu",
         "requests",
         "torch_no_python",
         "torch",


### PR DESCRIPTION
Resolves an error:
https://github.com/pytorch/pytorch/actions/runs/20091005212/job/57648251628
```
ERROR: Could not find a version that satisfies the requirement triton-xpu==3.6.0+git225cdbde (from torch) (from versions: none)
ERROR: No matching distribution found for triton-xpu==3.6.0+git225cdbde
```