### PR TITLE
[HUD] Fixes interval for timeranges on metrics page, avoiding page crashing when >half year

### DIFF
--- a/torchci/clickhouse_queries/experiment_rollover_percentage/params.json
+++ b/torchci/clickhouse_queries/experiment_rollover_percentage/params.json
@@ -1,6 +1,7 @@
 {
   "params": {
-    "days_ago": "Int64",
+    "startTime": "DateTime64(3)",
+    "stopTime": "DateTime64(3)",
     "experiment_name": "String",
     "granularity": "String"
   },

--- a/torchci/clickhouse_queries/experiment_rollover_percentage/query.sql
+++ b/torchci/clickhouse_queries/experiment_rollover_percentage/query.sql
@@ -19,7 +19,8 @@ WITH
             workflow_job AS j
             ARRAY JOIN j.labels as l
         WHERE
-            j.created_at > now() - INTERVAL {days_ago: Int64} DAY
+            j.created_at >= {startTime: DateTime64(3)}
+            AND j.created_at < {stopTime: DateTime64(3)}
             AND j.status = 'completed'
             AND l != 'self-hosted'
             AND l NOT LIKE 'lf.c.%'

--- a/torchci/clickhouse_queries/lf_rollover_percentage/params.json
+++ b/torchci/clickhouse_queries/lf_rollover_percentage/params.json
@@ -1,6 +1,7 @@
 {
   "params": {
-    "days_ago": "Int64",
+    "startTime": "DateTime64(3)",
+    "stopTime": "DateTime64(3)",
     "granularity": "String"
   },
   "tests": []

--- a/torchci/clickhouse_queries/lf_rollover_percentage/query.sql
+++ b/torchci/clickhouse_queries/lf_rollover_percentage/query.sql
@@ -19,7 +19,8 @@ WITH
             workflow_job AS j
             ARRAY JOIN j.labels as l
         WHERE
-            j.created_at > now() - INTERVAL {days_ago: Int64} DAY
+            j.created_at >= {startTime: DateTime64(3)}
+            AND j.created_at < {stopTime: DateTime64(3)}
             AND j.status = 'completed'
             AND l != 'self-hosted'
             AND l NOT LIKE 'lf.c.%'

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -1029,7 +1029,7 @@ export default function Page() {
           <TimeSeriesPanel
             title={`Percentage of jobs rolled over to Linux Foundation (per ${granularity})`}
             queryName={"lf_rollover_percentage"}
-            queryParams={{ ...timeParams, days_ago: timeRange, granularity }}
+            queryParams={{ ...timeParams, granularity }}
             granularity={granularity}
             timeFieldName={"bucket"}
             yAxisFieldName={"percentage"}
@@ -1060,7 +1060,6 @@ export default function Page() {
             queryName={"experiment_rollover_percentage"}
             queryParams={{
               ...timeParams,
-              days_ago: timeRange,
               experiment_name: experimentName,
               granularity,
             }}


### PR DESCRIPTION
Metrics page is crashing when the period is > than half a year, to avoid that I implemented the time bucketing to the graphs to match time range. I used the values we currently have there and is not working:

```
    switch (e.target.value as number) {
      case 1:
      case 3:
      case 7:
      case 14:
        setGranularity("hour");
        break;
      case 30:
        setGranularity("day");
        break;
      case 90:
      case 180:
      case 365:
        setGranularity("week");
        break;
    }
```

