### PR TITLE
Use rocm-mi300 as default label for any ROCm PRs

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -23,7 +23,7 @@ const IssueAndPRRegexToLabel: [RegExp, string][] = [
 const PrTitleRegexToLabel: [RegExp, string][] = [
   [/reland/gi, "ci-no-td"],
   [/revert/gi, "ci-no-td"],
-  [/rocm/gi, "ciflow/rocm"],
+  [/rocm/gi, "ciflow/rocm-mi300"],
   ...IssueAndPRRegexToLabel,
 ];
 


### PR DESCRIPTION
We would like to use the explicit label for MI300s