### PR TITLE
[autorevert][QoL] Add workflow filter to HUD command for state retrieval

### DIFF
--- a/aws/lambda/pytorch-auto-revert/README.md
+++ b/aws/lambda/pytorch-auto-revert/README.md
@@ -103,3 +103,8 @@ python -m pytorch_auto_revert --help
   ```bash
   python -m pytorch_auto_revert hud "2025-09-17 20:29:15" --repo-full-name pytorch/pytorch --hud-html hud.html
   ```
+
+- If you run multiple autorevert configs and want a specific one, filter by workflow name present in the stored run state:
+  ```bash
+  python -m pytorch_auto_revert hud --workflow trunk --repo-full-name pytorch/pytorch --hud-html hud.html
+  ```

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/__main__.py
@@ -365,6 +365,14 @@ def get_opts(default_config: DefaultConfig) -> argparse.Namespace:
         ),
     )
     hud_parser.add_argument(
+        "--workflow",
+        default=None,
+        help=(
+            "Optional workflow filter (e.g. trunk). Only consider run states whose stored workflow"
+            " list includes this value."
+        ),
+    )
+    hud_parser.add_argument(
         "--hud-html",
         nargs="?",
         const=HUD_HTML_NO_VALUE_FLAG,
@@ -681,6 +689,7 @@ def main_run(
         render_hud_html_from_clickhouse(
             config.timestamp,
             repo_full_name=config.repo_full_name,
+            workflow=config.workflow,
             out_path=out_path,
         )
 

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_datasource.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_datasource.py
@@ -280,7 +280,11 @@ class SignalExtractionDatasource:
         return rows
 
     def fetch_autorevert_state_rows(
-        self, *, ts: str, repo_full_name: Optional[str] = None
+        self,
+        *,
+        ts: str,
+        repo_full_name: Optional[str] = None,
+        workflow: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Fetch run state rows from misc.autorevert_state for a given timestamp."""
 
@@ -292,6 +296,9 @@ class SignalExtractionDatasource:
         if repo_full_name:
             query += " AND repo = {repo:String}"
             params["repo"] = repo_full_name
+        if workflow:
+            query += " AND has(workflows, {workflow:String})"
+            params["workflow"] = workflow
 
         for attempt in RetryWithBackoff():
             with attempt:
@@ -308,7 +315,7 @@ class SignalExtractionDatasource:
                 return rows
 
     def fetch_latest_non_dry_run_timestamp(
-        self, *, repo_full_name: Optional[str] = None
+        self, *, repo_full_name: Optional[str] = None, workflow: Optional[str] = None
     ) -> Optional[str]:
         """Return the most recent non-dry-run autorevert_state timestamp."""
 
@@ -317,6 +324,9 @@ class SignalExtractionDatasource:
         if repo_full_name:
             query += " AND repo = {repo:String}"
             params["repo"] = repo_full_name
+        if workflow:
+            query += " AND has(workflows, {workflow:String})"
+            params["workflow"] = workflow
         query += " ORDER BY ts DESC LIMIT 1"
 
         for attempt in RetryWithBackoff():


### PR DESCRIPTION
If you run multiple autorevert configs and want a specific one, filter by workflow name present in the stored run state:
  ```bash
  python -m pytorch_auto_revert hud --workflow trunk --repo-full-name pytorch/pytorch --hud-html hud.html
  ```


### Testing

```
python -m pytorch_auto_revert hud --workflow trunk
2025-12-12 12:06:06,467 INFO [root] [hud] Fetching run state ts=2025-12-12 20:05:05 repo=<any> workflow=trunk
2025-12-12 12:06:29,887 INFO [root] [hud] Loaded state for repo=pytorch/pytorch workflows=Lint,trunk,pull,inductor,linux-aarch64
2025-12-12 12:06:29,891 INFO [root] [hud] Rendering HTML for repo=pytorch/pytorch workflows=Lint,trunk,pull,inductor,linux-aarch64 lookback=16 → 2025-12-12_20-05-05.html
2025-12-12 12:06:29,896 INFO [root] HUD written to 2025-12-12_20-05-05.html


python -m pytorch_auto_revert hud --workflow slow
2025-12-12 12:07:22,476 INFO [root] [hud] Fetching run state ts=2025-12-12 20:01:40 repo=<any> workflow=slow
2025-12-12 12:07:22,997 INFO [root] [hud] Loaded state for repo=pytorch/pytorch workflows=slow
2025-12-12 12:07:22,997 INFO [root] [hud] Rendering HTML for repo=pytorch/pytorch workflows=slow lookback=16 → 2025-12-12_20-01-40.html
2025-12-12 12:07:22,999 INFO [root] HUD written to 2025-12-12_20-01-40.html
```