### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/actions-check-dist.yml
+++ b/.github/workflows/actions-check-dist.yml
@@ -25,10 +25,10 @@ jobs:
         working-directory: ./.github/actions/upload-artifact-s3
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
           cache: 'npm'
@@ -50,7 +50,7 @@ jobs:
         id: diff
 
       # If index.js was different than expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist

--- a/.github/workflows/actions-test.yml
+++ b/.github/workflows/actions-test.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup Node 20
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 20.x
         cache: 'npm'

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -158,7 +158,7 @@ jobs:
           cmd //c .\\test-infra\\.github\\scripts\\install_xpu.bat
       - name: Checkout Target Repository (${{ env.REPOSITORY }})
         if: inputs.architecture == 'arm64'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
             repository: ${{ env.REPOSITORY }}
             ref: ${{ env.REF }}
@@ -166,7 +166,7 @@ jobs:
             submodules: recursive
       - name: Bootstrap python
         if: inputs.architecture == 'arm64'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
           architecture: arm64

--- a/.github/workflows/github-analytics-daily.yml
+++ b/.github/workflows/github-analytics-daily.yml
@@ -39,17 +39,17 @@ jobs:
 
     steps:
     - name: Checkout test-infra
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Checkout PyTorch repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: pytorch/pytorch
         path: pytorch
         fetch-depth: 0  # Need full history for analysis
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
 

--- a/.github/workflows/test-setup-python.yml
+++ b/.github/workflows/test-setup-python.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-m1-stable
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Setup Python
         uses: ./.github/actions/setup-python
         with:

--- a/.github/workflows/update_test_file_report.yml
+++ b/.github/workflows/update_test_file_report.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: linux.2xlarge
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           path: test-infra
       - name: Checkout pytorch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           repository: pytorch/pytorch
@@ -67,7 +67,7 @@ jobs:
     runs-on: linux.2xlarge
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           python3 -mpip install -r tools/torchci/requirements.txt


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v3`](https://github.com/actions/checkout/releases/tag/v3), [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | actions-check-dist.yml, actions-test.yml, build_wheels_windows.yml, github-analytics-daily.yml, test-setup-python.yml, update_test_file_report.yml |
| `actions/setup-node` | [`v4`](https://github.com/actions/setup-node/releases/tag/v4) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) | actions-check-dist.yml, actions-test.yml |
| `actions/setup-python` | [`v4`](https://github.com/actions/setup-python/releases/tag/v4), [`v5`](https://github.com/actions/setup-python/releases/tag/v5) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | build_wheels_windows.yml, github-analytics-daily.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | actions-check-dist.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.