### PR TITLE
Fix VERSION_SUFFIX in aarch64 builds. Use standart naming +cpu, +cuXX 

### DIFF
--- a/tools/pkg-helpers/pytorch_pkg_helpers/cuda.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/cuda.py
@@ -31,7 +31,7 @@ def get_cuda_variables(
     version_suffix = ""
     pytorch_version_suffix = ""
     wheel_dir = ""
-    if package_type == "wheel" and platform != "darwin" and platform != "linux-aarch64":
+    if package_type == "wheel" and platform != "darwin":
         version_suffix = f"+{gpu_arch_version}"
         pytorch_version_suffix = f"+{gpu_arch_version}"
         wheel_dir = f"{gpu_arch_version}/"


### PR DESCRIPTION
Fixes: https://github.com/pytorch/vision/issues/9249

cc @charliermarsh @konstin @seemethere 