### PR TITLE
Include older subfolders in the index computation

### DIFF
--- a/s3_management/manage_v2.py
+++ b/s3_management/manage_v2.py
@@ -73,8 +73,8 @@ ACCEPTED_SUBDIR_PATTERNS = [
 NOT_ACCEPTED_SUBDIR_PATTERNS = [
     "cpu-cxx11-abi",
     "cpu_pypi_pkg",
-    "cu126_full",
-    "cu128_full",
+    "cu[0-9]+_full",
+    "cu[0-9]+_pypi_cudnn",
 ]
 
 PREFIXES = [


### PR DESCRIPTION
1. Include older subfloders in process. This will make sure package from older architectures are included in index root: https://download.pytorch.org/whl/torch-tensorrt/ . Excluding these caused: https://github.com/pytorch/TensorRT/discussions/3967#discussioncomment-15266612

2. Add more folders to NOT_ACCEPTED_SUBDIR_PATTERNS