### PR TITLE
[td] Use ch query to get failures for a commit

### DIFF
--- a/tools/torchci/td/get_reverts_caused_by_td.py
+++ b/tools/torchci/td/get_reverts_caused_by_td.py
@@ -189,7 +189,7 @@ def get_failures_additional_test_info(
     """Fetches additional test info for failures in the given run_id."""
 
     query = """
-    with job as (
+with job as (
     select
         distinct id,
         regexp_replace(
@@ -243,7 +243,8 @@ GROUP BY
     classname,
     job.name,
     job.workflow_name
-having status = 'failure'
+having
+    status = 'failure'
     """
     return query_clickhouse(
         query,


### PR DESCRIPTION
Instead of using a kind of adhoc data source, use the CH table that has all the test info from all commits since that is what stuff like autorevert and the test info pages on HUD should use

Also this way I can get rid of the flow that uploads this source