### PR TITLE
[Benchmark] Fetch regression summary report to benchmark db table 

### DIFF
--- a/torchci/pages/api/benchmark/get_regression_summary_report.ts
+++ b/torchci/pages/api/benchmark/get_regression_summary_report.ts
@@ -7,7 +7,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { mapReportField } from "./list_regression_summary_reports";
 
 const EXCLUDED_FILTER_OPTIONS = ["branch"];
-const REPORT_TABLE = "fortesting.benchmark_regression_report";
+const REPORT_TABLE = "benchmark.benchmark_regression_report";
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse

--- a/torchci/pages/api/benchmark/list_regression_summary_reports.ts
+++ b/torchci/pages/api/benchmark/list_regression_summary_reports.ts
@@ -9,7 +9,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 const DEFAULT_QUERY_LIMIT = 25;
 const MAX_QUERY_LIMIT = 200;
 
-const REPORT_TABLE = "fortesting.benchmark_regression_report";
+const REPORT_TABLE = "benchmark.benchmark_regression_report";
 
 export default async function handler(
   req: NextApiRequest,


### PR DESCRIPTION
We backfilled everything in the bechmark db table from the fortesting, and point lambda to send regression report to it too