### PR TITLE
[test info] Use CH to get info about how many tests on commit

### DIFF
--- a/torchci/components/additionalTestInfo/TestCounts.tsx
+++ b/torchci/components/additionalTestInfo/TestCounts.tsx
@@ -28,6 +28,7 @@ function convertInfoToMap(info: any) {
       successes: row.success,
       failures: row.failure,
       skipped: row.skipped,
+      flaky: row.flaky,
       time: row.time || 0,
       id: key,
     });
@@ -57,11 +58,15 @@ function TestFileCountsInfo({
       failuresChange: 0,
       skippedChange: 0,
       successesChange: 0,
+      flaky: 0,
+      flakyChange: 0,
     };
     for (const value of headMap?.values() || []) {
       totals.successesChange += value.successesChange || 0;
       totals.skippedChange += value.skippedChange || 0;
       totals.failuresChange += value.failuresChange || 0;
+      totals.flakyChange += value.flakyChange || 0;
+      totals.flaky += value.flaky || 0;
       totals.failures += value.failures || 0;
       totals.skipped += value.skipped || 0;
       totals.successes += value.successes || 0;
@@ -149,6 +154,19 @@ function TestFileCountsInfo({
     },
     {
       field: "skippedChange",
+      headerName: "+/-",
+      type: "number",
+      flex: 1,
+      cellClassName: "change",
+    },
+    {
+      field: "flaky",
+      headerName: "Flaky",
+      type: "number",
+      flex: 2,
+    },
+    {
+      field: "flakyChange",
       headerName: "+/-",
       type: "number",
       flex: 1,


### PR DESCRIPTION
Swap data source from file on s3 to the table on CH.

This also adds info about success, skip, flaky counts, so it's better and the table can display more things

New
<img width="1906" height="606" alt="image" src="https://github.com/user-attachments/assets/c608003f-93e1-4f20-84ff-7939ad9740fb" />
Old
<img width="1905" height="590" alt="image" src="https://github.com/user-attachments/assets/de038aad-6c82-4abf-8e91-941b83e0f3b7" />
