### PR TITLE
Optimize index computation job

### DIFF
--- a/s3_management/manage_v2.py
+++ b/s3_management/manage_v2.py
@@ -574,7 +574,9 @@ class S3Index:
     def _get_bucket_listing(self, prefix: str) -> List:
         """Get bucket listing with caching to avoid repeated S3 API calls"""
         if prefix not in self._bucket_listing_cache:
-            self._bucket_listing_cache[prefix] = list(BUCKET.objects.filter(Prefix=prefix))
+            self._bucket_listing_cache[prefix] = list(
+                BUCKET.objects.filter(Prefix=prefix)
+            )
         return self._bucket_listing_cache[prefix]
 
     def get_packages_to_copy_from_parent(


### PR DESCRIPTION
  These optimizations should significantly reduce indexing time by:
  - Reducing S3 API calls: Caching eliminates redundant bucket listing requests
  - Better parallelism: Doubled the concurrent upload workers (10 → 20)
  - Batch operations: Pre-fetching amortizes network latency across all subdirectories
  - No functional changes: The output remains identical, only the performance is improved
  
