### PR TITLE
Fix github_analyze script for reverted commits in release branch

### DIFF
--- a/.github/workflows/github-analytics-daily.yml
+++ b/.github/workflows/github-analytics-daily.yml
@@ -12,24 +12,24 @@ on:
     inputs:
       branch:
         description: "PyTorch release branch. e.g. release/2.7"
-        default: "release/2.9"
+        default: "release/2.10"
         required: false
         type: string
       milestone-id:
         description: 'Release milestone ID. e.g. 54'
-        default: 55
+        default: 57
         required: false
         type: string
   workflow_dispatch:
     inputs:
       branch:
         description: "PyTorch release branch. e.g. release/2.7"
-        default: "release/2.9"
+        default: "release/2.10"
         required: false
         type: string
       milestone-id:
         description: 'Release milestone ID. e.g. 54'
-        default: 55
+        default: 57
         required: false
         type: string
 
@@ -66,7 +66,7 @@ jobs:
         python3 tools/analytics/github_analyze.py \
           --repo-path ./pytorch \
           --remote origin \
-          --branch "${BRANCH:-release/2.9}" \
+          --branch "${BRANCH}" \
           --analyze-missing-reverts-from-branch
 
     - name: Show outstanding milestone issues
@@ -77,6 +77,6 @@ jobs:
         python3 tools/analytics/github_analyze.py \
           --repo-path ./pytorch \
           --remote origin \
-          --branch "${BRANCH:-release/2.9}" \
-          --milestone-id "${MILESTONE:-55}" \
+          --branch "${BRANCH}" \
+          --milestone-id "${MILESTONE}" \
           --missing-in-branch

--- a/tools/analytics/github_analyze.py
+++ b/tools/analytics/github_analyze.py
@@ -631,11 +631,13 @@ def analyze_reverts_missing_from_branch(repo: GitRepo, branch: str) -> None:
         if ghf_revert_revision:
             tags = repo.get_tags_for_commit(ghf_revert_revision)
             # Filter tags matching pattern: v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
-            pattern = re.compile(r'^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$')
+            pattern = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$")
             matching_tags = [tag for tag in tags if pattern.match(tag)]
             if matching_tags:
                 has_matching_tags = True
-                print(f"🏷️  Tags matching v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+ for commit {ghf_revert_revision}:")
+                print(
+                    f"🏷️  Tags matching v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+ for commit {ghf_revert_revision}:"
+                )
                 for tag in matching_tags:
                     print(f"   - {tag}")
 


### PR DESCRIPTION
Detect if commit in the question has a release rc tag.

Test :

```
Found 37 revert(s) in main branch not present in release/2.10 branch:
================================================================================
Reverted GitHub Commit: 9ca5d325e95f1520345f2fb6e94c4d8954cc089f
Commit Hash: 2ffa001c8e1048a668aab297d3fd4aedf0f2a89a
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-17 13:52:48
Title: Revert "Support exception traceback (#170299)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 9ca5d325e95f1520345f2fb6e94c4d8954cc089f.
    
    Reverted https://github.com/pytorch/pytorch/pull/170299 on behalf of https://github.com/albanD due to Breaks lint in tru...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 72f883c4aa3a864e2fece099591cd0f90498ca2d
Commit Hash: cac8ac0bc2b2acb8e20441513637d690d712a295
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-17 13:37:19
Title: Revert "[CI] Bump onnx version to 1.20.0 (#170141)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 72f883c4aa3a864e2fece099591cd0f90498ca2d.
    
    Reverted https://github.com/pytorch/pytorch/pull/170141 on behalf of https://github.com/pytorch-auto-revert due to Rever...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 65d346ff8c711731c6f2db4b3c045422bf87c582
🏷️  Tags matching v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+ for commit 65d346ff8c711731c6f2db4b3c045422bf87c582:
   - v2.10.0-rc1
Commit Hash: 643d3a9676be4ce218eae4586492e5a45cc9e8c2
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-17 12:42:01
Title: Revert "[annotation][export] Add metadata hook for all nodes created in runtime_assert pass (#169497)"
🔴  WARNING: This is possibly a revert of a commit that was included in a release candidate. The reverted commit may be present in release/2.10.
Body Preview:     
    This reverts commit 65d346ff8c711731c6f2db4b3c045422bf87c582.
    
    Reverted https://github.com/pytorch/pytorch/pull/169497 on behalf of https://github.com/facebook-github-bot due to Diff ...
--------------------------------------------------------------------------------
Reverted GitHub Commit: e270faa92bdffaa4d7a371fdbfa4e98b176c6f0b
Commit Hash: 38edfa2a5430bd0b705a02499fa0b66659f469f5
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-17 00:15:04
Title: Revert "[DebugMode] add DebugInterpreter for fx.Node metadata in  eager/aot_eager compiled regions (#170125)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit e270faa92bdffaa4d7a371fdbfa4e98b176c6f0b.
    
    Reverted https://github.com/pytorch/pytorch/pull/170125 on behalf of https://github.com/pytorch-auto-revert due to Rever...
--------------------------------------------------------------------------------
Reverted GitHub Commit: f927e00362058966090f2568351c9f8b0fa1e5c6
Commit Hash: a4876af74afee929daf7604bf8f2f88313324c56
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-16 08:37:21
Title: Revert "Move non-tensor nodes on boundary after split (#163605)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit f927e00362058966090f2568351c9f8b0fa1e5c6.
    
    Reverted https://github.com/pytorch/pytorch/pull/163605 on behalf of https://github.com/pytorch-auto-revert due to Rever...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 71ecbc44fb05ca618c42ce13ad90bce6d498c4e4
Commit Hash: beb6c77f8aa9d3b7313013e2506bf8a85a5121f8
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-16 07:53:07
Title: Revert "Checking if the input is finite before calculation in lowering of pow func (#167723)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 71ecbc44fb05ca618c42ce13ad90bce6d498c4e4.
    
    Reverted https://github.com/pytorch/pytorch/pull/167723 on behalf of https://github.com/seemethere due to This is breaki...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 6b7d588570b32bf1e2d058c26b94f3c56076659c
Commit Hash: bd7e9213d47d16104fcf99656d1b62433b529ee6
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-15 21:32:25
Title: Revert "[effects] Handle single return (#170460)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 6b7d588570b32bf1e2d058c26b94f3c56076659c.
    
    Reverted https://github.com/pytorch/pytorch/pull/170460 on behalf of https://github.com/pytorch-auto-revert due to Rever...
--------------------------------------------------------------------------------
Reverted GitHub Commit: cf935bcab3f5e7fb2e950ccb24351beaff4b5e55
Commit Hash: 9407f0951682dd6817aa37c8fec9e1532c0dd039
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-15 16:12:21
Title: Revert "[DebugMode] add DebugInterpreter for fx.Node metadata in  eager/aot_eager compiled regions (#170125)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit cf935bcab3f5e7fb2e950ccb24351beaff4b5e55.
    
    Reverted https://github.com/pytorch/pytorch/pull/170125 on behalf of https://github.com/pytorch-auto-revert due to Rever...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 237c3b696fa814d0fb86e51b1f5c6fb5c92394b1
Commit Hash: 02b757605e195fd332b3b677480c95e38bbb7dcc
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-15 15:47:16
Title: Revert "[BE][Typing][Dynamo] Type torch/_dynamo/variables/tensor.py (#170324)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 237c3b696fa814d0fb86e51b1f5c6fb5c92394b1.
    
    Reverted https://github.com/pytorch/pytorch/pull/170324 on behalf of https://github.com/pytorch-auto-revert due to Rever...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 63fc2b4813f3c6f1f425fa5a9cd66aa8847c4347
Commit Hash: f450b05ad88bd7199a3e3d22077ffa4ad792b145
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-15 09:47:02
Title: Revert "Add python stack and fix js formatting (#170129)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 63fc2b4813f3c6f1f425fa5a9cd66aa8847c4347.
    
    Reverted https://github.com/pytorch/pytorch/pull/170129 on behalf of https://github.com/jeanschmidt due to seems to have...
--------------------------------------------------------------------------------
Reverted Phabricator Diff: D88867088
Commit Hash: 2d65f3555162ca7eb04c0abedf4a3236f0a68e61
Author: Nicolas Macchioni <nmacchioni@meta.com>
Date: 2025-12-15 09:23:07
Title: Back out "Revert "[inductor][fx] clarify padding logic (#169577)"" (#170295)
PR URL: https://github.com/pytorch/pytorch/pull/170295
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    Summary:
    Original commit changeset: 763f4774364b
    
    Original Phabricator Diff: D88867088
    
    Differential Revision: D89049524
    
    Pull Request resolved: https://github.com...
--------------------------------------------------------------------------------
Reverted GitHub Commit: d3008cfb3cb885fb158c0c302d683656289a9f26
Commit Hash: 6c75344a1dffebdee2a7ff46f741164f41c04f1e
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-14 21:06:03
Title: Revert "[inductor] Fix cudagraph skip for index_put_ with boolean indices, graph partitioning logic (#170103)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit d3008cfb3cb885fb158c0c302d683656289a9f26.
    
    Reverted https://github.com/pytorch/pytorch/pull/170103 on behalf of https://github.com/izaitsevfb due to breaks inducto...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 1e041a8c5ca02684540f56ed64de69621a0197c2
Commit Hash: dd1f0f8f66671424347b323f59beae2964254491
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-14 14:50:21
Title: Revert "Fix redefining of TOCH_HIP_API (#170149)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 1e041a8c5ca02684540f56ed64de69621a0197c2.
    
    Reverted https://github.com/pytorch/pytorch/pull/170149 on behalf of https://github.com/jeffdaily due to breaks ROCm win...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 6a4469a761e4a6b55ab25854888eedfe0d73f0d3
Commit Hash: e9a55c87f6877ba17a5fb03e210ed9d1aca75e70
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-13 14:42:14
Title: Revert "[dynamo] Fix state leakage from test_streams.py (#170333)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 6a4469a761e4a6b55ab25854888eedfe0d73f0d3.
    
    Reverted https://github.com/pytorch/pytorch/pull/170333 on behalf of https://github.com/pytorch-auto-revert due to Rever...
--------------------------------------------------------------------------------
Reverted GitHub Commit: a35ae977ed1af46a23de9967523aa5827c8dee51
Commit Hash: a0f5941246d385a1900a5d3a1296687f389fbed4
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-13 14:20:39
Title: Revert "Change NamedTupleVariable implementation to subclass UserDefinedTupleVariable (#167468)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit a35ae977ed1af46a23de9967523aa5827c8dee51.
    
    Reverted https://github.com/pytorch/pytorch/pull/167468 on behalf of https://github.com/huydhn due to Sorry for revertin...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 04f3aee38eef731fa88be6df06c6c54cce1a704b
Commit Hash: 51f4ff3207554e995541866ede93ec76adfce8de
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-13 11:20:45
Title: Revert "Fix redefining of TOCH_HIP_API (#170149)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 04f3aee38eef731fa88be6df06c6c54cce1a704b.
    
    Reverted https://github.com/pytorch/pytorch/pull/170149 on behalf of https://github.com/izaitsevfb due to breaks interna...
--------------------------------------------------------------------------------
Reverted GitHub Commit: e2b0286aed173e1d83771c278a5f693715d654e9
Commit Hash: 540dea8732cae93653a99f5995950f624f399af6
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-13 11:12:15
Title: Revert "Remove outdated CUDA code (#170273)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit e2b0286aed173e1d83771c278a5f693715d654e9.
    
    Reverted https://github.com/pytorch/pytorch/pull/170273 on behalf of https://github.com/izaitsevfb due to Breaks interna...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 63923eac22792abeafc76fd5649716e461783107
Commit Hash: c30fd3adda6810bbf03d4076d6db2db7718359fd
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-13 09:39:59
Title: Revert "Fix resource leak: destroy CUDA event after waiting on it (#169790)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 63923eac22792abeafc76fd5649716e461783107.
    
    Reverted https://github.com/pytorch/pytorch/pull/169790 on behalf of https://github.com/jeanschmidt due to Reverted inte...
--------------------------------------------------------------------------------
Reverted GitHub Commit: c267695d2ac895a49cd7da9c1b3a508effdbd9e3
Commit Hash: cc4899c0561ffdf88c9585ae9f670054d663f863
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-13 04:52:09
Title: Revert "[xpu][fix] Fix UT test_fuse_mix_order_reductions_combo_kernels (#170297)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit c267695d2ac895a49cd7da9c1b3a508effdbd9e3.
    
    Reverted https://github.com/pytorch/pytorch/pull/170297 on behalf of https://github.com/pytorch-auto-revert due to Rever...
--------------------------------------------------------------------------------
Reverted GitHub Commit: d6604b821db81f109c29985f57076431e0c1d8e4
Commit Hash: d75f3668e710d93172f0fdb256f58c7e8d953267
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-12 19:42:17
Title: Revert "Fix unsafe_chunk decomposition for empty tensors (#170053)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit d6604b821db81f109c29985f57076431e0c1d8e4.
    
    Reverted https://github.com/pytorch/pytorch/pull/170053 on behalf of https://github.com/pytorch-auto-revert due to Rever...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 8982850fb675087c0fbd3e19af959222febf9339
🏷️  Tags matching v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+ for commit 8982850fb675087c0fbd3e19af959222febf9339:
   - v2.10.0-rc1
Commit Hash: bdad80fbe3634320dc4a70192da6c3d090c20454
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-12 15:55:10
Title: Revert "[Inductor] ReLU/GELU(Addmm) fusions (#168157)"
🔴  WARNING: This is possibly a revert of a commit that was included in a release candidate. The reverted commit may be present in release/2.10.
Body Preview:     
    This reverts commit 8982850fb675087c0fbd3e19af959222febf9339.
    
    Reverted https://github.com/pytorch/pytorch/pull/168157 on behalf of https://github.com/izaitsevfb due to needs to be ev...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 7ce6621bc89b433117b2aa09263a157178a9a2ec
Commit Hash: 8c5e14f76f2250bda3564a4f3eb8bb172b752265
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-12 14:26:27
Title: Revert "[dynamo] Preserve record function in aot_eager (#167787)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 7ce6621bc89b433117b2aa09263a157178a9a2ec.
    
    Reverted https://github.com/pytorch/pytorch/pull/167787 on behalf of https://github.com/izaitsevfb due to fails internal...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 58f90035706461abaf62d06207d3eb1c9f8ab9f3
Commit Hash: 47eb1311d3ec7e9d5c2e5b7f6f06125ad146f1c3
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-12 12:12:07
Title: Revert "[Inductor] Async Pipelined Autotune (#170128)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 58f90035706461abaf62d06207d3eb1c9f8ab9f3.
    
    Reverted https://github.com/pytorch/pytorch/pull/170128 on behalf of https://github.com/pytorch-auto-revert due to Rever...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 06d9d00fec7c1776ae24135e9b47f5ec3124d4f3
Commit Hash: 6b553b0f114299fa73d86d7105fc217dc79ddab7
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-12 12:03:24
Title: Revert "[ROCm][CI] Change diskspace check to be absolute rather than percentage (#170097)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 06d9d00fec7c1776ae24135e9b47f5ec3124d4f3.
    
    Reverted https://github.com/pytorch/pytorch/pull/170097 on behalf of https://github.com/jithunnair-amd due to Temporary ...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 3482c1c64583a72904e7512ae080c306477f3ab9
Commit Hash: ef516689bdd9461d7229b5b401d42b8a1d48edbe
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-12 09:07:33
Title: Revert "[17/N] Use Python 3.10 typing  (#169735)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 3482c1c64583a72904e7512ae080c306477f3ab9.
    
    Reverted https://github.com/pytorch/pytorch/pull/169735 on behalf of https://github.com/jeffdaily due to causing failure...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 6a39d67f06e21bde67b99d552eaa3113b5d02a36
Commit Hash: 7eff3fac7860322a4039c13ea333a5de66f4ae78
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-11 20:40:06
Title: Revert "[FX] Fix node normalization w.r.t. keyword "from" which breaks FX codegen (#169328)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 6a39d67f06e21bde67b99d552eaa3113b5d02a36.
    
    Reverted https://github.com/pytorch/pytorch/pull/169328 on behalf of https://github.com/izaitsevfb due to oops, this was...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 127539f2a4dd9910d1f90fb8dc6da69e84d7b479
Commit Hash: 3fd27fe94202b4a2b7c39e2ba99ebfd92e173f84
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-11 19:31:09
Title: Revert "[inductor][fx] clarify padding logic (#169577)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 127539f2a4dd9910d1f90fb8dc6da69e84d7b479.
    
    Reverted https://github.com/pytorch/pytorch/pull/169577 on behalf of https://github.com/izaitsevfb due to my bad, this i...
--------------------------------------------------------------------------------
Reverted GitHub Commit: eabb7ad2128580ef674446027b95bcf4e21e8df3
🏷️  Tags matching v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+ for commit eabb7ad2128580ef674446027b95bcf4e21e8df3:
   - v2.10.0-rc1
Commit Hash: 8b21f924c3c24d4cbe239265c87aeb7b271fe974
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-11 16:13:49
Title: Revert "[Inductor XPU GEMM] Step 1/N: Refactor cutlass configuration. (#160174)"
🔴  WARNING: This is possibly a revert of a commit that was included in a release candidate. The reverted commit may be present in release/2.10.
Body Preview:     
    This reverts commit eabb7ad2128580ef674446027b95bcf4e21e8df3.
    
    Reverted https://github.com/pytorch/pytorch/pull/160174 on behalf of https://github.com/huydhn due to Sorry for revertin...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 015826fc5a6022b579a2b692559597e4565e7c00
Commit Hash: bbef332f298b59a71e21e573a4d9f58073b34e20
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-11 16:07:26
Title: Revert "Differentiability Support for Functional Collectives (#168140)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 015826fc5a6022b579a2b692559597e4565e7c00.
    
    Reverted https://github.com/pytorch/pytorch/pull/168140 on behalf of https://github.com/pytorch-auto-revert due to Rever...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 68bb0dcbdcac2423400579e3f82850046ebc4f43
Commit Hash: d5c99e5d4ee7b601e8fd6455f9b067f4109747f6
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-11 14:34:49
Title: Revert "[DTensor] min/max dim reduction fix 2 (#170066)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 68bb0dcbdcac2423400579e3f82850046ebc4f43.
    
    Reverted https://github.com/pytorch/pytorch/pull/170066 on behalf of https://github.com/ezyang due to reenabled test is ...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 033659b2fb727f84f425f56550e5e2cb2d5db9f9
Commit Hash: fc85d4bd2f305b6871673194192602c620472b7f
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-11 12:24:01
Title: Revert "[c10d][Sym mem] Make nccl backend full fledged with nccl 2.28.9-1 (#168129)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 033659b2fb727f84f425f56550e5e2cb2d5db9f9.
    
    Reverted https://github.com/pytorch/pytorch/pull/168129 on behalf of https://github.com/albanD due to the auto-revert wa...
--------------------------------------------------------------------------------
Reverted GitHub Commit: db17cbfb36094ca6a813bfdaf0f4fd20944fc35a
Commit Hash: ceb1cb00c10f9f69303dda5ef5c856e78fb97620
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-11 12:12:22
Title: Revert "Add python stack and fix js formatting (#170129)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit db17cbfb36094ca6a813bfdaf0f4fd20944fc35a.
    
    Reverted https://github.com/pytorch/pytorch/pull/170129 on behalf of https://github.com/pytorch-auto-revert due to Rever...
--------------------------------------------------------------------------------
Reverted GitHub Commit: f457c51f28a8393325d23dd92b848537d786bd98
Commit Hash: 0ddb8edc7c75a35b8718403ec21f67440f464f2c
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-11 08:32:16
Title: Revert "[c10d][Sym mem] Make nccl backend full fledged with nccl 2.28.9-1 (#168129)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit f457c51f28a8393325d23dd92b848537d786bd98.
    
    Reverted https://github.com/pytorch/pytorch/pull/168129 on behalf of https://github.com/pytorch-auto-revert due to Rever...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 6cdb94f533a75b990db9828e9538da9c16256ebb
Commit Hash: 8121f2c5d0dbbee6322c7fadea90729573b85d4d
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-11 01:57:32
Title: Revert "[c10d][Sym mem] Make nccl backend full fledged with nccl 2.28.9-1 (#168129)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 6cdb94f533a75b990db9828e9538da9c16256ebb.
    
    Reverted https://github.com/pytorch/pytorch/pull/168129 on behalf of https://github.com/pytorch-auto-revert due to Rever...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 4aada15a726fd190ea950cb7eed76ec649d3d6d8
Commit Hash: 340b2abc8562e28382469f25f7994a235d3ca0d2
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-10 22:22:18
Title: Revert "[FX] Fix node normalization w.r.t. keyword "from" which breaks FX codegen (#169328)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 4aada15a726fd190ea950cb7eed76ec649d3d6d8.
    
    Reverted https://github.com/pytorch/pytorch/pull/169328 on behalf of https://github.com/pytorch-auto-revert due to Rever...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 4b395fcd767c1150c8a83025fb182df9ac88f8c4
Commit Hash: e3102f078ae1c5af4c9ea314e17ab0979a19e4dc
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-10 16:07:25
Title: Revert "ci: Ensure we pass through TPU env variables (#170099)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 4b395fcd767c1150c8a83025fb182df9ac88f8c4.
    
    Reverted https://github.com/pytorch/pytorch/pull/170099 on behalf of https://github.com/pytorch-auto-revert due to Rever...
--------------------------------------------------------------------------------
Reverted GitHub Commit: 832f73fe86fcdfc5a4068eb66073a40bdb2413ce
Commit Hash: 3c551c2480fa4d38f3fe634a39e7033a29a2517e
Author: PyTorch MergeBot <pytorchmergebot@users.noreply.github.com>
Date: 2025-12-10 14:27:21
Title: Revert "[ROCm][CI] Build therock with pytorch nightly (#168377)"
🟢  STATUS: The reverted commit does not appear to be in release/2.10, so this revert may not be needed.
Body Preview:     
    This reverts commit 832f73fe86fcdfc5a4068eb66073a40bdb2413ce.
    
    Reverted https://github.com/pytorch/pytorch/pull/168377 on behalf of https://github.com/jeffdaily due to after a rebase,...
```