### PR TITLE
[Benchmark] add AutoBenchmarkMarkDownContent

### DIFF
--- a/torchci/components/benchmark_v3/components/dataRender/auto/autoComponents.tsx
+++ b/torchci/components/benchmark_v3/components/dataRender/auto/autoComponents.tsx
@@ -14,6 +14,7 @@ import { LOG_PREFIX } from "components/benchmark/common";
 import { UIRenderConfig } from "components/benchmark_v3/configs/config_book_types";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import { MarkdownText } from "../../benchmarkList/BenchmarkCategoryCard";
 import { BenchmarkLogSidePanelWrapper } from "../../common/BenchmarkLogViewer/BenchmarkSidePanel";
 import {
   BenchmarkShortcutCardList,
@@ -832,6 +833,38 @@ export function AutoBenchmarkSingleDataTable({ config }: AutoComponentProps) {
             description: config?.description ?? "list single workflow run data",
           }}
         />
+      </Grid>
+    </Grid>
+  );
+}
+
+/**
+ * Render customized content for the benchmark context
+ *
+ */
+export function AutoBenchmarkMarkDownContent({ config }: AutoComponentProps) {
+  const ctx = useBenchmarkCommittedContext();
+  const uiRenderConfig = config as UIRenderConfig;
+  const content = uiRenderConfig.config?.content;
+
+  if (!content) {
+    return <></>;
+  }
+
+  return (
+    <Grid container sx={{ m: 1 }}>
+      <Grid sx={{ p: 0.2 }} size={{ xs: 11.5 }}>
+        <Typography
+          variant="subtitle1"
+          color="text.secondary"
+          sx={{
+            "& p": { margin: 0, lineHeight: 1.2 },
+            "& ul, & ol": { margin: 0, paddingLeft: "1.2rem" },
+            "& li": { margin: 0, lineHeight: 1.2 },
+          }}
+        >
+          <MarkdownText text={content} />
+        </Typography>
       </Grid>
     </Grid>
   );

--- a/torchci/components/benchmark_v3/configs/teams/vllm/config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/vllm/config.ts
@@ -68,6 +68,13 @@ export const PytorchVllmBenchmarkDashoboardConfig: BenchmarkUIConfig = {
         },
         renders: [
           {
+            type: "AutoBenchmarkMarkDownContent",
+            config: {
+              content:
+                "The data is generaterd based on pinned pytorch with latest vllm, powered by pytorch-integration-testing [workflow](https://github.com/pytorch/pytorch-integration-testing/actions/workflows/vllm-benchmark.yml)",
+            },
+          },
+          {
             type: "AutoBenchmarkTimeSeriesChartGroup",
             title: "Metrics Time Series Chart Detail View",
             config: {
@@ -120,6 +127,13 @@ export const PytorchVllmBenchmarkDashoboardConfig: BenchmarkUIConfig = {
       },
     },
     renders: [
+      {
+        type: "AutoBenchmarkMarkDownContent",
+        config: {
+          content:
+            "The dashboard is generaterd based on pinned pytorch with latest vllm, powered by pytorch-integration-testing [workflow](https://github.com/pytorch/pytorch-integration-testing/actions/workflows/vllm-benchmark.yml)",
+        },
+      },
       {
         type: "AutoBenchmarkPairwiseTable",
         title: "Comparison Table",

--- a/torchci/components/benchmark_v3/configs/utils/autoRegistration.tsx
+++ b/torchci/components/benchmark_v3/configs/utils/autoRegistration.tsx
@@ -1,6 +1,7 @@
 import {
   AutoBenchmarkComparisonGithubExternalLink,
   AutoBenchmarkLogs,
+  AutoBenchmarkMarkDownContent,
   AutoBenchmarkPairwiseTable,
   AutoBenchmarkRawDataTable,
   AutoBenchmarkShortcutCardList,
@@ -73,6 +74,9 @@ export class AutoComponentRegistry {
       },
       AutoBenchmarkShortcutCardList: {
         Component: AutoBenchmarkShortcutCardList,
+      },
+      AutoBenchmarkMarkDownContent: {
+        Component: AutoBenchmarkMarkDownContent,
       },
       // Add your auto components here
     };


### PR DESCRIPTION
## Overview
add AutoBenchmarkMarkDownContent to allow user to put customized  info in their dashabord
One use case is we plan to have two benchmarks for vllm, and this add additional details to tell those two's difference


## Demo
<img width="1659" height="622" alt="image" src="https://github.com/user-attachments/assets/c1c99be0-22f8-4fb2-9b07-49f0920b3caa" />

## HUD Preview
https://torchci-git-addcontentdescriptionauto-fbopensource.vercel.app/benchmark/v3/dashboard/vllm_benchmark
you need to login with preview credentail, see guidance
 https://docs.google.com/document/d/1wA2iMDZdu-25clRj36Fx7r4R3B9q8QZ1NEkIZsgThwY/edit?tab=t.0#heading=h.47m2zormzz9p
