### PR TITLE
[Benchmark] Rename and Change filter order

### DIFF
--- a/torchci/components/benchmark_v3/configs/configurations.tsx
+++ b/torchci/components/benchmark_v3/configs/configurations.tsx
@@ -189,7 +189,7 @@ export const BENCHMARK_CATEGORIES: BenchmarkCategoryGroup[] = [
     subtitle: "Benchmarks related to repo pytorch/torchao",
     items: [
       {
-        name: "TorchAO Micro API Benchmark",
+        name: "TorchAo API MicroBenchmark",
         route: `/benchmark/v3/dashboard/${PYTORCH_AO_MICRO_API_BENCHMARK_ID}`,
         info: "Powered by [code](https://github.com/pytorch/ao/blob/main/docs/source/benchmarking_api_guide.md)",
         actions: [

--- a/torchci/components/benchmark_v3/configs/teams/torchao/ao_micro_api_config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/torchao/ao_micro_api_config.ts
@@ -22,7 +22,7 @@ const COMPARISON_TABLE_METADATA_COLUMNS = [
 export const PytorcAoMicroApiBenchmarkDashoboardConfig: BenchmarkUIConfig = {
   benchmarkId: PYTORCH_AO_MICRO_API_BENCHMARK_ID,
   apiId: PYTORCH_AO_MICRO_API_BENCHMARK_ID,
-  title: "TorchAo Micro Api Benchmark",
+  title: "TorchAo API MicroBenchmark",
   type: "dashboard",
   dataBinding: {
     initial: {

--- a/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/listMetadataQueryBuilder.ts
+++ b/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/listMetadataQueryBuilder.ts
@@ -258,10 +258,18 @@ export class TorchAoMicrobApienchmarkMetadataFetcher
       "Quant Type"
     );
     if (customizedDtype) {
-      li.push(customizedDtype);
+      const modelNameIndex = li.findIndex(
+        (item) => item.type === BenchmarkMetadataType.ModelName
+      );
+      if (modelNameIndex !== -1) {
+        li.splice(modelNameIndex, 0, customizedDtype);
+      } else {
+        li.push(customizedDtype); // fallback if modelName not found
+      }
     }
     return li;
   }
+
   build() {
     return this._data_query.build();
   }


### PR DESCRIPTION
# Overview
based on request from torchao, change the name to 'TorchAo API MicroBenchmark', And put quant_type before model_name

# Demo
<img width="1676" height="565" alt="image" src="https://github.com/user-attachments/assets/18ea3705-3f41-4943-933d-961ca52c2c67" />
