### PR TITLE
[Hotfix] Upload bm results doesn't work with MacOS

### DIFF
--- a/.github/actions/upload-benchmark-results/action.yml
+++ b/.github/actions/upload-benchmark-results/action.yml
@@ -62,7 +62,6 @@ runs:
               DEVICE_NAME=cpu
               ;;
           esac
-          lscpu
         fi
         echo "DEVICE_NAME=$DEVICE_NAME" >> $GITHUB_ENV
 


### PR DESCRIPTION
This single line is causing the GHA to fail on MacOS because the command isn't available there.  I tested https://github.com/pytorch/test-infra/pull/7620 with all the Linux platforms, but forgot that this also exists on MacOS.  I'll create a task to fix this properly using something like MacOS sysctl.