### PR TITLE
Update inductor expected accuracy in pytorch/pytorch

### DIFF
--- a/.github/workflows/update-inductor-expected-accuracy.yml
+++ b/.github/workflows/update-inductor-expected-accuracy.yml
@@ -32,17 +32,19 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pandas requests
+          python -m pip install pandas==2.3.3 requests==2.32.5
 
       - name: Determine PyTorch SHA
         id: determine-sha
         run: |
+          # shellcheck disable=SC2086
           if [ -n "${{ github.event.inputs.pytorch_sha }}" ]; then
-            SHA="${{ github.event.inputs.pytorch_sha }}"
+            SHA=${{ github.event.inputs.pytorch_sha }}
           else
             # Use the latest commit SHA from main branch if not manually specified
             SHA=$(git rev-parse HEAD)
           fi
+          # shellcheck disable=SC2086
           echo "sha=${SHA}" >> $GITHUB_OUTPUT
           echo "Using PyTorch SHA: ${SHA}"
 
@@ -56,6 +58,7 @@ jobs:
       - name: Check for changes
         id: check-changes
         run: |
+          # shellcheck disable=SC2086
           if git diff --quiet benchmarks/dynamo/ci_expected_accuracy/; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
             echo "No changes detected"


### PR DESCRIPTION
Workflow to Create a PR to Update inductor expected accuracy in pytorch/pytorch

 1. Triggers:
    - Scheduled: Runs weekly on Sundays at 3:00 AM UTC
    - Manual: Can be triggered manually via workflow_dispatch with a specific PyTorch commit SHA
  2. What it does:
    - Checks out the pytorch/pytorch repository
    - Sets up Python 3.10 and installs dependencies (pandas, requests)
    - Runs the update_expected.py script with the specified SHA
    - Checks if there are any changes to the CSV files
    - If changes exist, creates a new branch and opens a PR from pytorchbot
  3. PR Details:
    - Branch name includes timestamp for uniqueness
    - Commits are signed by pytorchbot
    - PR includes a detailed description explaining what changed and why
    - Includes a test plan checklist for reviewers