### PR TITLE
[BE] Tweak nvidia-smi to return the same device name as PyTorch

### DIFF
--- a/.github/actions/gather-runners-info/action.yml
+++ b/.github/actions/gather-runners-info/action.yml
@@ -51,7 +51,8 @@ runs:
         set -eux
 
         if [[ "${DEVICE_NAME}" == "cuda" ]]; then
-          DEVICE_TYPE=$(nvidia-smi -i 0 --query-gpu=name --format=csv,noheader | awk '{print $2}')
+          # Return the same device name as PyTorch
+          DEVICE_TYPE=$(nvidia-smi -i 0 --query-gpu=name --format=csv,noheader)
         elif [[ "${DEVICE_NAME}" == "rocm" ]]; then
           DEVICE_TYPE=$(rocminfo | grep "Marketing Name" | tail -n1 | awk -F':' '{print $2}' | xargs)
         elif [[ "${DEVICE_NAME}" == "hpu" ]]; then

--- a/.github/actions/upload-benchmark-results/action.yml
+++ b/.github/actions/upload-benchmark-results/action.yml
@@ -74,7 +74,8 @@ runs:
         set -eux
 
         if [[ "${DEVICE_NAME}" == "cuda" ]]; then
-          DEVICE_TYPE=$(nvidia-smi -i 0 --query-gpu=name --format=csv,noheader | awk '{print $2}')
+          # Return the same device name as PyTorch
+          DEVICE_TYPE=$(nvidia-smi -i 0 --query-gpu=name --format=csv,noheader)
         elif [[ "${DEVICE_NAME}" == "rocm" ]]; then
           DEVICE_TYPE=$(rocminfo | grep "Marketing Name" | tail -n1 | awk -F':' '{print $2}' | xargs)
         elif [[ "${DEVICE_NAME}" == "hpu" ]]; then


### PR DESCRIPTION
I realize that piping the output of nvidia-smi to awk is redundant, and we should use the same device name as what PyTorch returns. For example `nvidia-smi -i 0 --query-gpu=name --format=csv,noheader` returns `NVIDIA H100 80GB HBM3` and `NVIDIA B200` like PyTorch, but `nvidia-smi -i 0 --query-gpu=name --format=csv,noheader | awk '{print $2}'` only return `H100` and `B200` (the short form)

### Testing

https://github.com/pytorch/pytorch-integration-testing/actions/runs/20765773145/job/59631431108#step:8:30 correctly returns `NVIDIA B200`