### PR TITLE
Fix dynamo key queries to use trailing slashes for accurate repo matching 

### DIFF
--- a/aws/lambda/ci-queue-pct/ci_queue_pct.py
+++ b/aws/lambda/ci-queue-pct/ci_queue_pct.py
@@ -335,7 +335,8 @@ def get_jobs_interval(
             default.workflow_job AS job
             INNER JOIN default.workflow_run AS workflow ON workflow.id = job.run_id
         WHERE
-            job.dynamoKey LIKE 'pytorch/pytorch%'
+            -- Use trailing slash to avoid matching pytorch/pytorch-integration-testing
+            job.dynamoKey LIKE 'pytorch/pytorch/%'
             AND job.created_at >= {start_time:DateTime}
             AND job.created_at < {end_time:DateTime}
             AND length(job.labels) > 0

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_datasource.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_datasource.py
@@ -68,7 +68,9 @@ class SignalExtractionDatasource:
 
         params: Dict[str, Any] = {
             "lookback_time": lookback_time,
-            "repo": f"{repo_full_name}%",
+            # Use double slash to match push table's dynamoKey format: {repo}//{uuid}
+            # This prevents matching repos with similar prefixes (e.g., pytorch/pytorch-integration-testing)
+            "repo": f"{repo_full_name}//%",
         }
         if as_of:
             params["as_of"] = as_of

--- a/torchci/clickhouse_queries/merge_retry_rate/query.sql
+++ b/torchci/clickhouse_queries/merge_retry_rate/query.sql
@@ -12,7 +12,8 @@ merged_prs AS (
         user.login AS author
     FROM default.pull_request
     WHERE
-        dynamoKey LIKE 'pytorch/pytorch%'
+        -- Use trailing slash to avoid matching pytorch/pytorch-integration-testing
+        dynamoKey LIKE 'pytorch/pytorch/%'
         AND state = 'closed'
         AND arrayExists(x -> x.'name' = 'Merged', labels)
         AND closed_at != ''
@@ -29,7 +30,8 @@ all_merge_attempts AS (
         created_at
     FROM default.issue_comment
     WHERE
-        dynamoKey LIKE 'pytorch/pytorch%'
+        -- Use trailing slash to avoid matching pytorch/pytorch-integration-testing
+        dynamoKey LIKE 'pytorch/pytorch/%'
         AND user.login = 'pytorchmergebot'
         AND body LIKE '%Merge started%'
 ),

--- a/torchci/clickhouse_queries/pr_landing_time_avg/query.sql
+++ b/torchci/clickhouse_queries/pr_landing_time_avg/query.sql
@@ -8,7 +8,8 @@ merge_started AS (
         MIN(created_at) AS first_merge_attempt
     FROM default.issue_comment
     WHERE
-        dynamoKey LIKE 'pytorch/pytorch%'
+        -- Use trailing slash to avoid matching pytorch/pytorch-integration-testing
+        dynamoKey LIKE 'pytorch/pytorch/%'
         AND user.login = 'pytorchmergebot'
         AND body LIKE '%Merge started%'
         AND created_at >= {startTime: DateTime64(3)}
@@ -23,7 +24,8 @@ merged_prs AS (
         parseDateTimeBestEffort(closed_at) AS merge_time
     FROM default.pull_request
     WHERE
-        dynamoKey LIKE 'pytorch/pytorch%'
+        -- Use trailing slash to avoid matching pytorch/pytorch-integration-testing
+        dynamoKey LIKE 'pytorch/pytorch/%'
         AND state = 'closed'
         AND arrayExists(x -> x.'name' = 'Merged', labels)
         AND closed_at != ''


### PR DESCRIPTION
###  Problem

  Queries using dynamoKey LIKE 'pytorch/pytorch%' incorrectly match commits from pytorch/pytorch-integration-testing, causing (among else) autorevert to process "ghost commits" that don't exist in pytorch/pytorch.

###  Solution

  Add trailing slash/delimiter to LIKE patterns:
  - push table: pytorch/pytorch//% (double slash matches {repo}//{uuid} format)
  - Other tables: pytorch/pytorch/% (single slash matches {repo}/{id} format)


---

### Testing

autorevert:
```
python -m pytorch_auto_revert --dry-run autorevert-checker pull --hours 12 --hud-html
```

rest: manual query run.