### PR TITLE
[FE 2026]only send notification for compiler regression when it's h100

### DIFF
--- a/aws/lambda/benchmark_regression_summary_report/common/config.py
+++ b/aws/lambda/benchmark_regression_summary_report/common/config.py
@@ -278,7 +278,11 @@ COMPILER_BENCHMARK_CONFIG = BenchmarkConfig(
                     "type": "github",
                     "repo": "pytorch/test-infra",
                     "issue": "7081",
-                }
+                    "condition": {
+                        "type": "device_arch",
+                        "device_arches": [{"device": "cuda", "arch": "h100"}],
+                    },
+                },
             ]
         },
     ),


### PR DESCRIPTION
this pr still track regression for b200, but silence the notification if the regression exists

alternative is we can not query the b200 data at all, so no regression result is generated
