### PR TITLE
Reduce the threshold for alerting low instances for linux.aws.h100.4 to 1

### DIFF
--- a/tools/torchci/check_live_runners.py
+++ b/tools/torchci/check_live_runners.py
@@ -23,7 +23,7 @@ LIVE_RUNNERS_RULES = [
     },
     {
         "runner_label": "linux.aws.h100.4",
-        "threshold": 2,
+        "threshold": 1,
     },
     {
         "runner_label": "linux.aws.h100.8",


### PR DESCRIPTION
the alert is firing unnecessarily too frequently 