### PR TITLE
[BetterEngineering 2026]fix the compiler display for comparison policy in benchmark dashboard page

### DIFF
--- a/torchci/components/benchmark_v3/configs/teams/compilers/config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/compilers/config.ts
@@ -34,7 +34,7 @@ const PASSRATE_COMPARISON_POLICY: BenchmarkComparisonPolicyConfig = {
 };
 
 // regression page metric policy
-const GEOMEAN_COMPARISON_POLICY: BenchmarkComparisonPolicyConfig = {
+const GEOMEAN_SPEEDUP_COMPARISON_POLICY: BenchmarkComparisonPolicyConfig = {
   target: "geomean_speedup",
   type: "ratio",
   ratioPolicy: {
@@ -44,7 +44,7 @@ const GEOMEAN_COMPARISON_POLICY: BenchmarkComparisonPolicyConfig = {
   },
 };
 
-// regression page metric policy
+// dashboard page metric policy
 const ASBSOLUTE_LATENCY_COMPARISON_POLICY: BenchmarkComparisonPolicyConfig = {
   target: "abs_latency",
   type: "ratio",
@@ -105,6 +105,7 @@ const COMPILATION_LATENCY_COMPARISON_POLICY: BenchmarkComparisonPolicyConfig = {
   },
 };
 
+// dashboard page metric policy books
 const DashboardComparisonPolicyBook = {
   accuracy: ACCURACY_STATUS_POLICY,
   compression_ratio: COMPRESSION_RATIO_POLICY,
@@ -251,7 +252,6 @@ export const compilerQueryParameterConverter: QueryParameterConverter = (
 
 // the benchmark id for the compiler regression page
 export const COMPILTER_PRECOMPUTE_BENCHMARK_ID = "compiler_precompute";
-
 // The initial config for the compiler benchmark regression page
 export const COMPILTER_PRECOMPUTE_BENCHMARK_INITIAL = {
   benchmarkId: COMPILTER_PRECOMPUTE_BENCHMARK_ID,
@@ -280,7 +280,6 @@ export const COMPILTER_PRECOMPUTE_BENCHMARK_INITIAL = {
 
 // the benchmark id for the compiler dashboard page
 export const COMPILTER_BENCHMARK_NAME = "compiler_inductor";
-
 // The initial config for the compiler dashboard page
 const COMPILER_DASHBOARD_BENCHMARK_DATABINDING = {
   initial: {
@@ -536,7 +535,7 @@ export const CompilerPrecomputeBenchmarkUIConfig: BenchmarkUIConfig = {
             targetField: "metric",
             comparisonPolicy: {
               passrate: PASSRATE_COMPARISON_POLICY,
-              geomean_speedup: GEOMEAN_COMPARISON_POLICY,
+              geomean_speedup: GEOMEAN_SPEEDUP_COMPARISON_POLICY,
               compilation_latency: COMPILATION_LATENCY_COMPARISON_POLICY,
               compression_ratio: COMPRESSION_RATIO_POLICY,
             },

--- a/torchci/components/benchmark_v3/configs/teams/compilers/config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/compilers/config.ts
@@ -22,6 +22,7 @@ import {
 } from "../defaults/default_dashboard_config";
 dayjs.extend(utc);
 
+// regression page metric policy
 const PASSRATE_COMPARISON_POLICY: BenchmarkComparisonPolicyConfig = {
   target: "passrate",
   type: "ratio",
@@ -31,6 +32,8 @@ const PASSRATE_COMPARISON_POLICY: BenchmarkComparisonPolicyConfig = {
     direction: "up",
   },
 };
+
+// regression page metric policy
 const GEOMEAN_COMPARISON_POLICY: BenchmarkComparisonPolicyConfig = {
   target: "geomean_speedup",
   type: "ratio",
@@ -40,8 +43,10 @@ const GEOMEAN_COMPARISON_POLICY: BenchmarkComparisonPolicyConfig = {
     direction: "up",
   },
 };
-const COMPILATION_LATENCY_COMPARISON_POLICY: BenchmarkComparisonPolicyConfig = {
-  target: "compilation_latency",
+
+// regression page metric policy
+const ASBSOLUTE_LATENCY_COMPARISON_POLICY: BenchmarkComparisonPolicyConfig = {
+  target: "abs_latency",
   type: "ratio",
   ratioPolicy: {
     badRatio: 1.15,
@@ -49,6 +54,8 @@ const COMPILATION_LATENCY_COMPARISON_POLICY: BenchmarkComparisonPolicyConfig = {
     direction: "down",
   },
 };
+
+// dashboard page metric policy
 const COMPRESSION_RATIO_POLICY: BenchmarkComparisonPolicyConfig = {
   target: "compression_ratio",
   type: "ratio",
@@ -59,11 +66,56 @@ const COMPRESSION_RATIO_POLICY: BenchmarkComparisonPolicyConfig = {
   },
 };
 
+// dashboard page metric policy
 const ACCURACY_STATUS_POLICY: BenchmarkComparisonPolicyConfig = {
   target: "accuracy",
   type: "status",
 };
 
+// dashboard page metric policy
+const DYNAMO_PEAK_MEMORY_POLICY: BenchmarkComparisonPolicyConfig = {
+  target: "dynamo_peak_mem",
+  type: "ratio",
+  ratioPolicy: {
+    badRatio: 1.15,
+    goodRatio: 0.85,
+    direction: "down",
+  },
+};
+
+// dashboard page metric policy
+const EAGER_PEAK_MEMORY_POLICY: BenchmarkComparisonPolicyConfig = {
+  target: "eager_peak_mem",
+  type: "ratio",
+  ratioPolicy: {
+    badRatio: 1.15,
+    goodRatio: 0.85,
+    direction: "down",
+  },
+};
+
+// regression& dashboard page metric policy
+const COMPILATION_LATENCY_COMPARISON_POLICY: BenchmarkComparisonPolicyConfig = {
+  target: "compilation_latency",
+  type: "ratio",
+  ratioPolicy: {
+    badRatio: 1.15,
+    goodRatio: 0.85,
+    direction: "down",
+  },
+};
+
+const DashboardComparisonPolicyBook = {
+  accuracy: ACCURACY_STATUS_POLICY,
+  compression_ratio: COMPRESSION_RATIO_POLICY,
+  abs_latency: ASBSOLUTE_LATENCY_COMPARISON_POLICY,
+  dynamo_peak_mem: DYNAMO_PEAK_MEMORY_POLICY,
+  eager_peak_mem: EAGER_PEAK_MEMORY_POLICY,
+  compilation_latency: COMPILATION_LATENCY_COMPARISON_POLICY,
+};
+
+// render book for the compiler dashboard page
+// benchmark/v3/dashboard/compiler_inductor
 const DashboardRenderBook = {
   accuracy: {
     displayName: "Accuracy",
@@ -75,7 +127,7 @@ const DashboardRenderBook = {
     },
   },
   dynamo_peak_mem: {
-    displayName: "Dynamo memory usage",
+    displayName: "Dynamo memory usage (MB)",
   },
   compilation_latency: {
     displayName: "Compilation time (seconds)",
@@ -97,8 +149,12 @@ const DashboardRenderBook = {
       unit: "ms",
     },
   },
+  eager_peak_mem: {
+    displayName: "eager peak memory",
+  },
 };
 
+// render book for the compiler regression page
 const RENDER_MAPPING_BOOK = {
   passrate: {
     unit: {
@@ -140,6 +196,7 @@ const RENDER_MAPPING_BOOK = {
   },
 };
 
+// converter function
 export function toQueryArch(device: string, arch: string) {
   if (arch === undefined) return [];
   if (!device) return [];
@@ -192,6 +249,7 @@ export const compilerQueryParameterConverter: QueryParameterConverter = (
   return params;
 };
 
+// the benchmark id for the compiler regression page
 export const COMPILTER_PRECOMPUTE_BENCHMARK_ID = "compiler_precompute";
 
 // The initial config for the compiler benchmark regression page
@@ -220,8 +278,10 @@ export const COMPILTER_PRECOMPUTE_BENCHMARK_INITIAL = {
   maxSampling: 110, // max number of job run results to show in the table, this avoid out of memory issue
 };
 
+// the benchmark id for the compiler dashboard page
 export const COMPILTER_BENCHMARK_NAME = "compiler_inductor";
 
+// The initial config for the compiler dashboard page
 const COMPILER_DASHBOARD_BENCHMARK_DATABINDING = {
   initial: {
     ...DEFAULT_DASHBOARD_BENCHMARK_INITIAL,
@@ -251,6 +311,7 @@ const DASHBOARD_COMPARISON_TABLE_METADATA_COLUMNS = [
 ] as const;
 
 // config for the compiler dashboard page
+// benchmark/v3/dashboard/compiler_inductor
 export const CompilerDashboardBenchmarkUIConfig: BenchmarkUIConfig = {
   benchmarkId: COMPILTER_BENCHMARK_NAME,
   apiId: COMPILTER_BENCHMARK_NAME,
@@ -321,11 +382,7 @@ export const CompilerDashboardBenchmarkUIConfig: BenchmarkUIConfig = {
             },
           },
           targetField: "metric",
-          comparisonPolicy: {
-            accuracy: ACCURACY_STATUS_POLICY,
-            compilation_latency: COMPILATION_LATENCY_COMPARISON_POLICY,
-            compression_ratio: COMPRESSION_RATIO_POLICY,
-          },
+          comparisonPolicy: DashboardComparisonPolicyBook,
           extraMetadata: DASHBOARD_COMPARISON_TABLE_METADATA_COLUMNS,
           renderOptions: {
             tableRenderingBook: DashboardRenderBook,

--- a/torchci/components/benchmark_v3/configs/teams/compilers/config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/compilers/config.ts
@@ -128,7 +128,7 @@ const DashboardRenderBook = {
     },
   },
   dynamo_peak_mem: {
-    displayName: "Dynamo memory usage (MB)",
+    displayName: "Dynamo memory usage (GB)",
   },
   compilation_latency: {
     displayName: "Compilation time (seconds)",
@@ -151,7 +151,7 @@ const DashboardRenderBook = {
     },
   },
   eager_peak_mem: {
-    displayName: "eager peak memory",
+    displayName: "eager peak memory (GB)",
   },
 };
 
@@ -190,7 +190,7 @@ const RENDER_MAPPING_BOOK = {
     },
   },
   dynamo_peak_mem: {
-    displayName: "Dynamo memory usage",
+    displayName: "Dynamo memory usage (GB)",
     unit: {
       unit: "mb",
     },
@@ -501,7 +501,7 @@ export const CompilerPrecomputeBenchmarkUIConfig: BenchmarkUIConfig = {
                     text: "Execution time (seconds)",
                   },
                   dynamo_peak_mem: {
-                    text: "Dynamo memory usage (MB)",
+                    text: "Dynamo memory usage (GB)",
                   },
                 },
               },

--- a/torchci/components/benchmark_v3/configs/teams/torchao/config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/torchao/config.ts
@@ -14,8 +14,8 @@ const initialOptions = {
   benchmarkId: PYTORCH_OPERATOR_MICROBENCHMARK_ID,
   filters: {
     device: "cuda",
-    arch: "NVIDIA B200",
-    deviceName: "cuda||NVIDIA B200",
+    arch: "B200",
+    deviceName: "cuda||B200",
     operatorName: "addmm",
   },
 };


### PR DESCRIPTION
# Overview
render dashboard metrics  with comparison policy:
Abs. execution time (ms)
Dynamo memory usage
eager_peak_mem

increase is bad (15%), decrease is good (15%)

## Other fixes
modify another pytorch_operator_microbenchmark's initial setting to b200


## Demo
Before
<img width="1896" height="362" alt="image" src="https://github.com/user-attachments/assets/b698edcf-0c2d-4ec3-bef6-593ee9ef5b4b" />


After
<img width="1833" height="483" alt="image" src="https://github.com/user-attachments/assets/6a82fb58-a42c-45b6-9693-493b30240eef" />


### Demo preview:
[link](https://torchci-git-fixdisplay-fbopensource.vercel.app/benchmark/v3/dashboard/compiler_inductor?renderGroupId=main&time.start=2026-01-01T00%3A00%3A00.000Z&time.end=2026-01-08T23%3A59%3A59.999Z&filters.repo=pytorch%2Fpytorch&filters.benchmarkName=compiler&filters.backend=&filters.mode=inference&filters.dtype=bfloat16&filters.deviceName=cuda+%28h100%29&filters.device=cuda&filters.arch=h100&filters.suite=torchbench&filters.compiler=cudagraphs&lcommit.commit=be32f077fb50b49ad856e957a6860d37565583db&lcommit.workflow_id=20799100249&lcommit.date=2026-01-08T02%3A00%3A00Z&lcommit.branch=prepare-perf-number-2.9.1&rcommit.commit=80c5addf062fd9acd5d7ab84c905183ae71d277f&rcommit.workflow_id=20799249069&rcommit.date=2026-01-08T01%3A00%3A00Z&rcommit.branch=prepare-perf-number-2.10&lbranch=prepare-perf-number-2.9.1&rbranch=prepare-perf-number-2.10&maxSampling=110)

for preview, you need to login with test account, please reach out to dev infra team to get the pwd and account name.

<img width="422" height="484" alt="image" src="https://github.com/user-attachments/assets/2e3fa2e0-0b3f-4a36-8e83-be0537f6b97f" />

