### PR TITLE
Remove 'rocm' checks from chown actions

### DIFF
--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -283,14 +283,12 @@ jobs:
           fail-on-empty: false
 
       - name: Chown repository directory
-        if: ${{ inputs.gpu-arch-type != 'rocm' }}
         uses: ./test-infra/.github/actions/chown-directory
         with:
           directory: ${{ github.workspace }}/${{ env.repository }}
           ALPINE_IMAGE: ${{ startsWith(inputs.runner, 'linux.arm64') && 'arm64v8/alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
 
       - name: Chown runner temp
-        if: ${{ inputs.gpu-arch-type != 'rocm' }}
         uses: ./test-infra/.github/actions/chown-directory
         with:
           directory: ${{ runner.temp }}


### PR DESCRIPTION
Removed conditional checks for 'rocm' architecture from chown steps.

Tested that:
* this fixes the [failures](https://github.com/meta-pytorch/monarch/actions/runs/20977099155/job/60294086394?pr=2001) seen in monarch CI: successfully tested via https://github.com/meta-pytorch/monarch/actions/runs/21004716212/job/60383875690?pr=2001
* and it doesn't break torchao ROCm CI: https://github.com/pytorch/ao/pull/3638 (successfully tested via https://github.com/pytorch/ao/actions/runs/21006722122/job/60411193415?pr=3638)