### PR TITLE
Add group view for regression report 

### DIFF
--- a/torchci/components/benchmark_v3/components/benchmarkRegressionReport/BenchmarkReportFeatureSidePanel.tsx
+++ b/torchci/components/benchmark_v3/components/benchmarkRegressionReport/BenchmarkReportFeatureSidePanel.tsx
@@ -85,7 +85,8 @@ export function BenchmarkReportFeatureSidePanel({
               <BenchmarkRegressionReportWrapper
                 id={id}
                 enableTableSidePanel={false}
-                chartSizeSx={{ sx: 12, lg: 12 }}
+                singleChartSizeSx={{ sx: 12, lg: 12 }}
+                groupChartSizeSx={{ sx: 12, lg: 12 }}
               />
             </>
           )}

--- a/torchci/components/benchmark_v3/components/benchmarkRegressionReport/reportView/RegressionReportDetail.tsx
+++ b/torchci/components/benchmark_v3/components/benchmarkRegressionReport/reportView/RegressionReportDetail.tsx
@@ -239,7 +239,7 @@ function ReportTimeSeriesGroupChartBucketList({
       {groups.length > 0 && (
         <Typography variant="body2" sx={{ mb: 1.5 }}>
           We found {groups.length} groups of {subtitle} based on hardware,
-          metric, and user's filters. To see more details, please select line in
+          metric, and filters. To see more details, please select line in
           the time series chart.
         </Typography>
       )}

--- a/torchci/components/benchmark_v3/components/benchmarkRegressionReport/reportView/RegressionReportDetail.tsx
+++ b/torchci/components/benchmark_v3/components/benchmarkRegressionReport/reportView/RegressionReportDetail.tsx
@@ -238,9 +238,9 @@ function ReportTimeSeriesGroupChartBucketList({
       )}
       {groups.length > 0 && (
         <Typography variant="body2" sx={{ mb: 1.5 }}>
-          We found {groups.length} groups of {subtitle} based on hardware and
-          metric, and filters. To see the details, Please select line in the
-          time series chart to see the details.
+          We found {groups.length} groups of {subtitle} based on hardware,
+          metric, and user's filters. To see more details, please select line in
+          the time series chart.
         </Typography>
       )}
       <Grid container spacing={1}>

--- a/torchci/components/benchmark_v3/components/benchmarkRegressionReport/reportView/RegressionReportDetail.tsx
+++ b/torchci/components/benchmark_v3/components/benchmarkRegressionReport/reportView/RegressionReportDetail.tsx
@@ -239,8 +239,8 @@ function ReportTimeSeriesGroupChartBucketList({
       {groups.length > 0 && (
         <Typography variant="body2" sx={{ mb: 1.5 }}>
           We found {groups.length} groups of {subtitle} based on hardware,
-          metric, and filters. To see more details, please select line in
-          the time series chart.
+          metric, and filters. To see more details, please select line in the
+          time series chart.
         </Typography>
       )}
       <Grid container spacing={1}>

--- a/torchci/components/benchmark_v3/components/benchmarkRegressionReport/reportView/RegressionReportTimeSeriesChart.tsx
+++ b/torchci/components/benchmark_v3/components/benchmarkRegressionReport/reportView/RegressionReportTimeSeriesChart.tsx
@@ -1,11 +1,11 @@
 import { Divider, Paper, Typography } from "@mui/material";
 import { Box, Stack } from "@mui/system";
 import { StaticRenderViewOnlyContent } from "components/benchmark_v3/components/common/StaticRenderViewOnlyContent";
-import BenchmarkTimeSeriesChart from "components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/BenchmarkTimeSeriesChart";
 import {
   BenchmarkTimeSeriesInput,
   RawTimeSeriesPoint,
 } from "components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/helper";
+import BenchmarkTimeLineSelectSeriesChart from "../../dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/BenchmarkTimeLineSelectSeriesChart";
 import {
   DEFAULT_BASELINE_COLOR,
   DEFAULT_REGRESSION_COLOR,
@@ -13,6 +13,121 @@ import {
   RegressionReportChartIndicatorsSection,
   ReportPageToV3MainPageNavigationButton,
 } from "../common";
+
+type SingleReportSectionConfig = {
+  hidePolicy?: boolean;
+  hideBaseline?: boolean;
+  hideChips?: boolean;
+  subtitle?: string;
+  enableIndicator?: boolean;
+  enableNavigation?: boolean;
+  report_id: string;
+  id?: string;
+};
+
+type SingleReportSectionProps = {
+  data: any;
+  config?: SingleReportSectionConfig;
+};
+
+const DEFAULT_CONFIG: Required<
+  Pick<
+    SingleReportSectionConfig,
+    | "hidePolicy"
+    | "hideBaseline"
+    | "hideChips"
+    | "subtitle"
+    | "enableIndicator"
+    | "enableNavigation"
+  >
+> = {
+  hidePolicy: false,
+  hideBaseline: false,
+  hideChips: false,
+  subtitle: "",
+  enableIndicator: false,
+  enableNavigation: true,
+};
+
+export function SingleReportSection({
+  data,
+  config,
+}: SingleReportSectionProps) {
+  const cfg = {
+    ...DEFAULT_CONFIG,
+    ...config,
+  };
+
+  if (!data) {
+    return <div />;
+  }
+
+  const group_info = data?.group_info ?? {};
+  const tsData = [toTimeSeriesData(data, ["metric"])];
+  const baseline = data?.baseline_point;
+  const latestPoint = data?.points[data?.points?.length - 1];
+
+  return (
+    <Stack spacing={1.25}>
+      {cfg?.subtitle && (
+        <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+          {cfg?.subtitle}
+        </Typography>
+      )}
+      {!cfg.hideChips && (
+        <GroupInfoChips info={group_info} chipSx={{ fontSize: 10 }} />
+      )}
+      <Box sx={{ mt: 0.5 }}>
+        <BenchmarkTimeLineSelectSeriesChart
+          timeseries={tsData}
+          enableSelectLine={false}
+        />
+      </Box>
+      <Divider />
+      {cfg?.enableIndicator && (
+        <>
+          <RegressionReportChartIndicatorsSection />
+          <Divider />
+        </>
+      )}
+
+      {!cfg?.hidePolicy && (
+        <Box>
+          <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+            Policy: how we detect the regression based on baseline point
+          </Typography>
+          <StaticRenderViewOnlyContent
+            data={data.policy}
+            title=""
+            maxDepth={10}
+          />
+        </Box>
+      )}
+      {!cfg?.hideBaseline && (
+        <Box>
+          <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+            Baseline Point: the point we use as baseline to detect the
+            regression
+          </Typography>
+          <StaticRenderViewOnlyContent data={baseline} title="" maxDepth={10} />
+        </Box>
+      )}
+      {cfg?.enableNavigation && cfg?.report_id && (
+        <Stack direction="row" alignItems="center">
+          <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+            Go to the benchmark main page
+          </Typography>
+          <ReportPageToV3MainPageNavigationButton
+            report_id={cfg?.report_id}
+            group_info={group_info}
+            startCommit={baseline}
+            endCommit={latestPoint}
+          />
+        </Stack>
+      )}
+    </Stack>
+  );
+}
 
 export function ReportTimeSereisChartSection({
   data,
@@ -22,7 +137,6 @@ export function ReportTimeSereisChartSection({
   hidePolicy = false,
   hideBaseline = false,
   hideChips = false,
-  enableSelectMode = false,
   enableIndicator = false,
   enableNavigation = true,
 }: {
@@ -33,83 +147,89 @@ export function ReportTimeSereisChartSection({
   hidePolicy?: boolean;
   hideBaseline?: boolean;
   hideChips?: boolean;
-  enableSelectMode?: boolean;
   enableIndicator?: boolean;
   enableNavigation?: boolean;
 }) {
-  const group_info = data?.group_info ?? {};
-  const tsData = toTimeSeriesData(data);
-  const baseline = data?.baseline_point;
-  const latestPoint = data?.points[data?.points?.length - 1];
-
   return (
     <Paper id={id} variant="outlined" sx={{ p: 2 }}>
+      <SingleReportSection
+        data={data}
+        config={{
+          report_id,
+          id,
+          hidePolicy,
+          hideBaseline,
+          hideChips,
+          subtitle,
+          enableIndicator,
+          enableNavigation,
+        }}
+      />
+    </Paper>
+  );
+}
+
+/**
+ * Single Report Wrapper for the customized dialog in group chart view
+ * @param param0
+ * @returns
+ */
+export function SingleReportSectionDialog({
+  data,
+  config,
+}: SingleReportSectionProps) {
+  const d = data?.raw_data;
+  return <SingleReportSection data={d} config={config} />;
+}
+
+export function ReportTimeSereisGroupChartSection({
+  data,
+  subtitle = "",
+  id,
+  report_id,
+  enableSelectLine = false,
+}: {
+  data: any[];
+  subtitle: string;
+  report_id: string;
+  id?: string;
+  enableSelectLine?: boolean;
+  enableNavigation?: boolean;
+}) {
+  const tsData = data.map((item) =>
+    toTimeSeriesData(item, [], ["device", "arch", "metric"])
+  );
+  const dialogConfig = {
+    report_id: report_id,
+  };
+  return (
+    <Paper id={id} variant="outlined" sx={{ p: 2 }}>
+      <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+        {subtitle}
+      </Typography>
       <Stack spacing={1.25}>
-        <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
-          {subtitle}
-        </Typography>
-        {!hideChips && (
-          <GroupInfoChips info={group_info} chipSx={{ fontSize: 10 }} />
-        )}
         <Box sx={{ mt: 0.5 }}>
-          <BenchmarkTimeSeriesChart
+          <BenchmarkTimeLineSelectSeriesChart
             timeseries={tsData}
-            enableSelectMode={enableSelectMode}
+            enableSelectLine={enableSelectLine}
+            renderOptions={{ height: 300 }}
+            customizedDialog={{
+              config: dialogConfig,
+              comp: SingleReportSectionDialog,
+            }}
           />
         </Box>
-        <Divider />
-        {enableIndicator && (
-          <>
-            <RegressionReportChartIndicatorsSection />
-            <Divider />
-          </>
-        )}
-
-        {!hidePolicy && (
-          <Box>
-            <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
-              Policy: how we detect the regression based on baseline point
-            </Typography>
-            <StaticRenderViewOnlyContent
-              data={data.policy}
-              title=""
-              maxDepth={10}
-            />
-          </Box>
-        )}
-        {!hideBaseline && (
-          <Box>
-            <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
-              Baseline Point: the point we use as baseline to detect the
-              regression
-            </Typography>
-            <StaticRenderViewOnlyContent
-              data={baseline}
-              title=""
-              maxDepth={10}
-            />
-          </Box>
-        )}
-        {enableNavigation && (
-          <Stack direction="row" alignItems="center">
-            <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
-              Go to the benchmark main page
-            </Typography>
-            <ReportPageToV3MainPageNavigationButton
-              report_id={report_id}
-              group_info={group_info}
-              startCommit={baseline}
-              endCommit={latestPoint}
-            />
-          </Stack>
-        )}
       </Stack>
     </Paper>
   );
 }
 
 // Converts the regression report data to a format that can be used by the benchmark time series chart
-function toTimeSeriesData(data: any): BenchmarkTimeSeriesInput[] {
+function toTimeSeriesData(
+  data: any,
+  legend_name_fields: string[] = [],
+  execludes_legend_names: string[] = []
+): BenchmarkTimeSeriesInput {
   let res: BenchmarkTimeSeriesInput[] = [];
   const group_info = data?.group_info ?? {};
   const baseline = data?.baseline_point;
@@ -139,12 +259,23 @@ function toTimeSeriesData(data: any): BenchmarkTimeSeriesInput[] {
     return res;
   });
 
-  res.push({
+  let groups = Object.entries(group_info);
+  if (legend_name_fields.length > 0) {
+    groups = groups.filter(([key, value]) => legend_name_fields.includes(key));
+  }
+
+  if (execludes_legend_names.length > 0) {
+    groups = groups.filter(
+      ([key, value]) => !execludes_legend_names.includes(key)
+    );
+  }
+
+  return {
     group_info,
-    legend_name: group_info?.metric ?? "unknown",
+    legend_name: groups.map(([key, value]) => `${key}: ${value}`).join(" "),
     data: all,
-  });
-  return res;
+    raw_data: data,
+  } as BenchmarkTimeSeriesInput;
 }
 
 function toRawTimeSeriesPoint(data: any, group_info: any): RawTimeSeriesPoint {

--- a/torchci/components/benchmark_v3/components/benchmarkRegressionReport/reportView/RegressionReportTimeSeriesChart.tsx
+++ b/torchci/components/benchmark_v3/components/benchmarkRegressionReport/reportView/RegressionReportTimeSeriesChart.tsx
@@ -197,7 +197,7 @@ export function ReportTimeSereisGroupChartSection({
   enableNavigation?: boolean;
 }) {
   const tsData = data.map((item) =>
-    toTimeSeriesData(item, [], ["device", "arch", "metric"])
+    toTimeSeriesData(item, [], ["device", "arch", "metric", "branch"])
   );
   const dialogConfig = {
     report_id: report_id,

--- a/torchci/components/benchmark_v3/components/benchmarkRegressionReport/reportView/RegressionReportViewWrapper.tsx
+++ b/torchci/components/benchmark_v3/components/benchmarkRegressionReport/reportView/RegressionReportViewWrapper.tsx
@@ -8,11 +8,13 @@ import { RegressionReportDetail } from "./RegressionReportDetail";
 export function BenchmarkRegressionReportWrapper({
   id,
   enableTableSidePanel,
-  chartSizeSx,
+  singleChartSizeSx,
+  groupChartSizeSx,
 }: {
   id: string;
   enableTableSidePanel?: boolean;
-  chartSizeSx?: any;
+  singleChartSizeSx?: any;
+  groupChartSizeSx?: any;
 }) {
   // initial load
   const { data, isLoading, error } = useGetBenchmarkRegressionReportData(
@@ -33,7 +35,8 @@ export function BenchmarkRegressionReportWrapper({
       <RegressionReportDetail
         report={data}
         enableTableSidePanel={enableTableSidePanel}
-        chartSizeSx={chartSizeSx}
+        singleChartSizeSx={singleChartSizeSx}
+        groupChartSizeSx={groupChartSizeSx}
       />
     </Box>
   );

--- a/torchci/components/benchmark_v3/components/common/SelectionDialog.tsx
+++ b/torchci/components/benchmark_v3/components/common/SelectionDialog.tsx
@@ -76,9 +76,6 @@ export function resolveDialogContentRenderer(config?: any) {
 export function DefaultSelectionDialogContent({
   left,
   right,
-  other,
-  closeDialog,
-  triggerUpdate,
 }: TimeSeriesChartDialogContentProps): React.ReactNode {
   return (
     <>

--- a/torchci/components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/BenchmarkTimeLineSelectSeriesChart.tsx
+++ b/torchci/components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/BenchmarkTimeLineSelectSeriesChart.tsx
@@ -1,0 +1,253 @@
+import { Box } from "@mui/material";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import * as echarts from "echarts";
+import ReactECharts from "echarts-for-react";
+import React, { useMemo, useRef, useState } from "react";
+import {
+  BenchmarkTimeSeriesCharRenderOpiton,
+  BenchmarkTimeSeriesInput,
+  fmtFixed2,
+  getBenchmarkTimeSeriesChartRenderingConfig,
+  getSmartValue,
+  RawTimeSeriesPoint,
+  renderBasedOnUnitConifg,
+} from "../../helper";
+import {
+  ChartLineSelectDialog,
+  ChartLineSelectionDialogComponent,
+} from "./ChartLineSelectionControl";
+import { echartRenderingOptions } from "./RenderingOptions";
+import { toEchartTimeSeriesData } from "./type";
+
+dayjs.extend(utc);
+
+type ConfirmPayload = {
+  seriesIndex: number;
+  seriesName: string;
+  groupInfo: Record<string, string | number>;
+};
+
+type Props = {
+  timeseries: BenchmarkTimeSeriesInput[];
+  customizedDialog?: { config: any; comp: ChartLineSelectionDialogComponent };
+  renderOptions?: BenchmarkTimeSeriesCharRenderOpiton;
+  markArea?: {
+    start?: string;
+    end?: string;
+    singleGap?: number;
+  };
+  enableSelectLine?: boolean;
+  legendKeys?: string[];
+  /** Called when user clicks Confirm with L/R selected for a single series. */
+  onSelect?: (sel: ConfirmPayload) => void;
+};
+
+const DEFAULT_HEIGHT = 200;
+const NORMAL_DOT_SIZE = 4;
+
+const BenchmarkTimeLineSelectSeriesChart: React.FC<Props> = ({
+  timeseries,
+  renderOptions,
+  customizedDialog,
+  legendKeys,
+  enableSelectLine = false,
+  onSelect = () => {},
+}) => {
+  const chartRef = useRef<ReactECharts>(null);
+
+  // Selection state
+  const [selectedSeriesIdx, setSelectedSeriesIdx] = useState<number | null>(
+    null
+  );
+  const seriesDatas = useMemo(
+    () => timeseries.map((s) => toEchartTimeSeriesData(s)),
+    [timeseries]
+  );
+  const tooltipFormatter: NonNullable<
+    echarts.TooltipComponentOption["formatter"]
+  > = ((raw: unknown) => {
+    const p = Array.isArray(raw) ? raw[0] : (raw as any);
+    const meta = p?.data?.meta as RawTimeSeriesPoint | undefined;
+    if (!meta) return "";
+
+    const t = dayjs
+      .utc(meta.granularity_bucket)
+      .format("YYYY-MM-DD HH:mm [UTC]");
+    const pct = fmtFixed2(meta.value);
+    const commitShort = meta.commit.slice(0, 7);
+    const rc = getBenchmarkTimeSeriesChartRenderingConfig(
+      meta.metric,
+      renderOptions
+    );
+
+    let value = pct;
+    let displayName = meta.metric;
+    if (rc) {
+      value = renderBasedOnUnitConifg(value, rc?.unit);
+      displayName = rc?.displayName ?? meta.metric;
+    }
+
+    let legendKeyItems: string[] = [];
+    if (renderOptions?.showLegendDetails) {
+      legendKeys?.forEach((k) => {
+        const v = getSmartValue(meta, k);
+        if (v) {
+          legendKeyItems.push(
+            `<div style="font-size:10px;"><i>${k}:${v}</i></div>`
+          );
+        }
+      });
+      if (legendKeyItems.length > 0) {
+        const legendItemTitle = `<div style="margin-top:4px;"><i>Metadata:</i></div>`;
+        legendKeyItems = [legendItemTitle, ...legendKeyItems];
+      }
+    }
+
+    return [
+      `<div style="font-weight:600;margin-bottom:4px;">${t}</div>`,
+      `<div style="
+          font-size:12px;
+          max-width:240px;
+          white-space: normal;
+          word-break: break-word;
+          line-height:1.4;
+        ">
+        <b>legend name</b>: ${p?.data?.legend_name ?? ""}
+      </div>`,
+      `<div><b>${displayName}</b>: <b>${value}</b></div>`,
+      `<div>commit <code>${commitShort}</code> · workflow ${meta.workflow_id} · branch ${meta.branch}</div>`,
+      ...legendKeyItems,
+    ].join("");
+  }) as any;
+
+  function resetSelection() {
+    setSelectedSeriesIdx(null);
+  }
+
+  function handleLineClick(seriesIndex: number) {
+    // In line-select mode, treat any click on the line as selecting that series
+    setSelectedSeriesIdx(seriesIndex); // or a separate state if you don’t want to reuse
+    // resetPointSelection(); // uncomment if you want to clear L/R when selecting a line
+  }
+
+  // Build line series first (indices 0..N-1 map to logical timeseries)
+  const lineSeries: echarts.SeriesOption[] = useMemo(() => {
+    let ma: any = [];
+
+    const lines = seriesDatas.map((data, idx) => {
+      const mlData: any[] = [];
+
+      return {
+        name: timeseries[idx]?.legend_name ?? `Series ${idx + 1}`,
+        type: "line",
+        showSymbol: true,
+        symbolSize: (_: any, params: any) => {
+          const s = params?.data?.meta?.renderOptions?.size;
+          return s ? s : NORMAL_DOT_SIZE;
+        },
+        data,
+        silent: false,
+        triggerLineEvent: enableSelectLine,
+        lineStyle: {},
+        itemStyle: {
+          color: (params: any) => {
+            const color = params?.data?.meta?.renderOptions?.color;
+            return color ? color : params?.color;
+          },
+        },
+        ...(mlData.length
+          ? { markLine: { data: mlData, symbol: "none" } }
+          : {}),
+      } as echarts.SeriesOption;
+    });
+    return [...lines];
+  }, [seriesDatas, timeseries, selectedSeriesIdx]);
+
+  // Highlight overlays appended after all lines
+  const overlaySeries: echarts.SeriesOption[] = useMemo(() => {
+    if (selectedSeriesIdx == null) return [];
+    const sel: any[] = [];
+    if (!sel.length) return [];
+    return [
+      {
+        name: `sel-${selectedSeriesIdx}`,
+        type: "effectScatter",
+        z: 5,
+        rippleEffect: { scale: 2.1 },
+        symbolSize: NORMAL_DOT_SIZE,
+        data: sel,
+      } as echarts.SeriesOption,
+    ];
+  }, [seriesDatas, selectedSeriesIdx]);
+
+  // form the final option
+  const option: echarts.EChartsOption = useMemo(() => {
+    return {
+      ...echartRenderingOptions,
+      legend: {
+        ...echartRenderingOptions.legend,
+      },
+      tooltip: {
+        trigger: "item",
+        triggerOn: "mousemove|click",
+        formatter: tooltipFormatter,
+      },
+      series: [...lineSeries, ...overlaySeries],
+    };
+  }, [lineSeries, overlaySeries]);
+
+  const onEvents = {
+    click: (p: any) => {
+      if (!p || p.seriesType !== "line") return;
+      if (typeof p.seriesIndex !== "number") return;
+      console.log("clicked:", p);
+      if (enableSelectLine) {
+        handleLineClick(p.seriesIndex);
+        return; // 🔴 critical
+      }
+    },
+  };
+  const selectline = selectedSeriesIdx != null;
+  const currentSeriesName =
+    selectedSeriesIdx != null
+      ? timeseries[selectedSeriesIdx].legend_name ??
+        `Series ${selectedSeriesIdx + 1}`
+      : null;
+  const input =
+    selectedSeriesIdx != null ? timeseries[selectedSeriesIdx] : null;
+  return (
+    <Box
+      sx={{
+        width: "100%",
+        height: renderOptions?.height ?? `${DEFAULT_HEIGHT + 30}`,
+      }}
+    >
+      {/* Selection controls */}
+      {enableSelectLine ? (
+        <ChartLineSelectDialog
+          onClose={resetSelection}
+          open={selectline}
+          Component={customizedDialog?.comp}
+          config={customizedDialog?.config}
+          data={input}
+        />
+      ) : null}
+
+      {/* Echart controls */}
+      <ReactECharts
+        ref={chartRef}
+        echarts={echarts}
+        option={option}
+        notMerge={true}
+        lazyUpdate
+        onEvents={onEvents}
+        style={{
+          width: "100%",
+          height: renderOptions?.height ?? DEFAULT_HEIGHT,
+        }}
+      />
+    </Box>
+  );
+};
+export default BenchmarkTimeLineSelectSeriesChart;

--- a/torchci/components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/ChartLineSelectionControl.tsx
+++ b/torchci/components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/ChartLineSelectionControl.tsx
@@ -1,0 +1,45 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from "@mui/material";
+import { RenderRawContent } from "components/benchmark_v3/components/common/RawContentDialog";
+
+export type ChartLineSelectionDialogComponentProps = {
+  data: any;
+  config: any;
+};
+export type ChartLineSelectionDialogComponent =
+  React.ComponentType<ChartLineSelectionDialogComponentProps>;
+
+type ChartLineSelectDialogProps = {
+  onClose: () => void;
+  onSelect?: () => void;
+  open?: boolean;
+  config?: any;
+  Component?: ChartLineSelectionDialogComponent;
+  data?: any;
+};
+
+export const ChartLineSelectDialog: React.FC<ChartLineSelectDialogProps> = ({
+  onClose,
+  Component,
+  config,
+  open = false,
+  data,
+}) => {
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle>{config?.subtitle ?? "Details"}</DialogTitle>
+      <DialogContent dividers>
+        {Component ? <Component data={data} config={config} /> : null}
+        <RenderRawContent data={data} />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/torchci/components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/helper.tsx
+++ b/torchci/components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/helper.tsx
@@ -61,7 +61,7 @@ export interface BenchmarkComparisonTitleMapping {
 }
 // Full renderOptions container
 export interface BenchmarkComparisonTableRenderingOptions {
-  title_group_mapping: BenchmarkComparisonTitleMapping;
+  title_group_mapping?: BenchmarkComparisonTitleMapping;
   tableRenderingBook: BenchmarkComparisonTableRenderingBook;
   flex?: {
     [key: string]: number;
@@ -128,7 +128,7 @@ export type ChartConfig = {
 
 export type BenchmarkTimeSeriesCharRenderOpiton = {
   height?: string | number;
-  title_group_mapping: BenchmarkComparisonTitleMapping;
+  title_group_mapping?: BenchmarkComparisonTitleMapping;
   chartRenderBook?: BenchmarkTimeSeriesChartRenderingBook;
   showLegendDetails?: boolean;
 };


### PR DESCRIPTION
Add grouped chart view for regression report
New component: time series chart with line selection logics. it's different from the comparison one

<img width="1661" height="945" alt="image" src="https://github.com/user-attachments/assets/a7bfff1c-c03c-4ce5-a725-ce7576d10239" />

when click on time series line, the dialog shows up
<img width="1601" height="905" alt="image" src="https://github.com/user-attachments/assets/952a2004-59ef-4a8f-a334-660099bb73ca" />


preview: https://torchci-git-improveregressionreport2-fbopensource.vercel.app/benchmark/regression/report/aaec7cff-6d60-4487-8280-4e5111e57f0a
