### PR TITLE
Modify getting started page to add aarch64 builds

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -304,7 +304,7 @@ def get_wheel_install_command(
 {WHL_INSTALL_BASE} {PACKAGES_TO_INSTALL}
 
 For Linux Aarch64:
-{WHL_INSTALL_BASE} {PACKAGES_TO_INSTALL} --index-url {get_base_download_url_for_repo('whl', channel, gpu_arch_type, desired_cuda)}"""
+{WHL_INSTALL_BASE} {PACKAGES_TO_INSTALL} --index-url {get_base_download_url_for_repo("whl", channel, gpu_arch_type, desired_cuda)}"""
 
     if (
         channel == RELEASE


### PR DESCRIPTION
1. Fixes: https://github.com/pytorch/pytorch/issues/168065
Implements this approach: https://github.com/pytorch/pytorch/issues/168065#issuecomment-3548733199

When stable CUDA is chosen, we display:
```
For Linux x86 use:
pip3 install torch torchvision

For Linux Aarch64:
pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cu128
```
2. Remove cuda 12.9 from matrix, since its somehwat limited release.