### PR TITLE
Use <br> instead of newline in Installation instructions

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -300,11 +300,7 @@ def get_wheel_install_command(
         and gpu_arch_version == STABLE_CUDA_VERSIONS[channel]
         and os == LINUX
     ):
-        return f"""For Linux x86 use:
-{WHL_INSTALL_BASE} {PACKAGES_TO_INSTALL}
-
-For Linux Aarch64:
-{WHL_INSTALL_BASE} {PACKAGES_TO_INSTALL} --index-url {get_base_download_url_for_repo("whl", channel, gpu_arch_type, desired_cuda)}"""
+        return f"""For Linux x86 use:<br />{WHL_INSTALL_BASE} {PACKAGES_TO_INSTALL}<br /><br />For Linux Aarch64:<br />{WHL_INSTALL_BASE} {PACKAGES_TO_INSTALL} --index-url {get_base_download_url_for_repo("whl", channel, gpu_arch_type, desired_cuda)}"""
 
     if (
         channel == RELEASE


### PR DESCRIPTION
Make sure we can use this text in html.
Instructions used in:
https://pytorch.org/get-started/locally/