### PR TITLE
Use Linux x86 and arch64 install commands only for RELEASE binaries

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -299,6 +299,7 @@ def get_wheel_install_command(
         getting_started
         and gpu_arch_version == STABLE_CUDA_VERSIONS[channel]
         and os == LINUX
+        and channel == RELEASE
     ):
         return f"""For Linux x86 use:<br />{WHL_INSTALL_BASE} {PACKAGES_TO_INSTALL}<br /><br />For Linux Aarch64:<br />{WHL_INSTALL_BASE} {PACKAGES_TO_INSTALL} --index-url {get_base_download_url_for_repo("whl", channel, gpu_arch_type, desired_cuda)}"""
 


### PR DESCRIPTION
Nightlies are always served from download.pytorch.org. Hence this is needed only for release