### PR TITLE
Fix branch fetching in linux job v2

### DIFF
--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -42,7 +42,7 @@ on:
         type: number
       single-branch:
         description: 'Whether to fetch only a single branch, defaults to true'
-        default: true
+        default: false
         type: boolean
       checkout-mode:
         description: 'Mode of checkout; one of "normal", "blobless", "treeless".'


### PR DESCRIPTION
To allow merge-base to work, all required branches need to be fetched. With the current default of single-branch, workflows can break, see, e.g., https://github.com/pytorch/pytorch/actions/runs/21164529985/job/60871122753.