### PR TITLE
Use resolution-strategy: lowest for setup-uv to avoid API rate limits

### DIFF
--- a/.github/actions/upload-benchmark-results/action.yml
+++ b/.github/actions/upload-benchmark-results/action.yml
@@ -29,6 +29,8 @@ runs:
   steps:
     - name: Setup uv
       uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      with:
+        resolution-strategy: lowest
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
When uv.toml specifies a minimum version like `>=0.9.21`, setup-uv needs to resolve this to a specific version. With the default `resolution-strategy: highest`, it calls the GitHub API to find the latest release. At PyTorch's CI scale, this exhausts rate limits.

With `resolution-strategy: lowest`, setup-uv resolves the specifier to the minimum satisfying version locally, avoiding API calls.