### PR TITLE
Add setup-uv wrapper action to avoid GitHub API rate limits

### DIFF
--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -39,7 +39,7 @@ runs:
   steps:
     - name: Setup uv
       id: setup-uv
-      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
       with:
         version: "0.9.21"
         python-version: ${{ inputs.python-version }}

--- a/.github/workflows/test-setup-uv.yml
+++ b/.github/workflows/test-setup-uv.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Test setup-uv action
         id: setup-uv
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Test setup-uv with python-version
         uses: ./.github/actions/setup-uv
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Test setup-uv with activate-environment
         id: setup-uv


### PR DESCRIPTION
When uv.toml specifies a version range like `>=0.9.21`, setup-uv calls the GitHub API to resolve to a specific version. At PyTorch's CI scale, this exhausts rate limits.

This adds a centralized wrapper action that pins an explicit uv version, avoiding API calls entirely. All pytorch workflows can use this wrapper instead of directly using astral-sh/setup-uv.

Also adds a test workflow for the new action.