### PR TITLE
Add Claude Code usage metrics upload action and database schema

### DIFF
--- a/.github/actions/upload-claude-usage/action.yml
+++ b/.github/actions/upload-claude-usage/action.yml
@@ -1,0 +1,57 @@
+name: Upload Claude Code usage metrics
+
+description: Upload Claude Code execution metrics to S3 for ClickHouse ingestion
+
+inputs:
+  metrics-file:
+    description: Path to the Claude execution output JSON file
+    default: /home/runner/work/_temp/claude-execution-output.json
+  s3-bucket:
+    description: S3 bucket for upload
+    default: ossci-raw-job-status
+  s3-prefix:
+    description: S3 prefix for the upload
+    default: claude_code_usage
+
+runs:
+  using: composite
+  steps:
+    - name: Upload usage metrics
+      shell: bash
+      run: |
+        METRICS_FILE="${{ inputs.metrics-file }}"
+        if [ ! -f "$METRICS_FILE" ]; then
+          echo "Metrics file not found: $METRICS_FILE"
+          exit 0
+        fi
+
+        # Extract fields and add context
+        jq -n \
+          --arg repo "${{ github.repository }}" \
+          --argjson run_id "${{ github.run_id }}" \
+          --argjson run_attempt "${{ github.run_attempt }}" \
+          --arg actor "${{ github.actor }}" \
+          --arg event_name "${{ github.event_name }}" \
+          --argjson pr_number "${{ github.event.issue.number || github.event.pull_request.number || 0 }}" \
+          --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%S.000)" \
+          --argjson duration_ms "$(jq -r '.duration_ms // 0' "$METRICS_FILE")" \
+          --argjson num_turns "$(jq -r '.num_turns // 0' "$METRICS_FILE")" \
+          --argjson total_cost_usd "$(jq -r '.total_cost_usd // 0' "$METRICS_FILE")" \
+          '{
+            repo: $repo,
+            run_id: $run_id,
+            run_attempt: $run_attempt,
+            actor: $actor,
+            event_name: $event_name,
+            pr_number: $pr_number,
+            timestamp: $timestamp,
+            duration_ms: $duration_ms,
+            num_turns: $num_turns,
+            total_cost_usd: $total_cost_usd
+          }' > /tmp/claude_usage.json
+
+        echo "Uploading metrics:"
+        cat /tmp/claude_usage.json
+
+        aws s3 cp /tmp/claude_usage.json \
+          "s3://${{ inputs.s3-bucket }}/${{ inputs.s3-prefix }}/${{ github.repository }}/${{ github.run_id }}_${{ github.run_attempt }}.json"

--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -669,6 +669,22 @@ def cloudwatch_metrics_adapter(table, bucket, key):
     general_adapter(table, bucket, key, schema, ["none"], "JSONEachRow")
 
 
+def claude_code_usage_adapter(table, bucket, key):
+    schema = """
+    `repo` String,
+    `run_id` Int64,
+    `run_attempt` Int32,
+    `actor` String,
+    `event_name` String,
+    `pr_number` Int64,
+    `timestamp` DateTime64(3),
+    `duration_ms` Int64,
+    `num_turns` Int32,
+    `total_cost_usd` Float64
+    """
+    general_adapter(table, bucket, key, schema, ["none"], "JSONEachRow")
+
+
 SUPPORTED_PATHS = {
     "merges": "default.merges",
     "queue_times_historical": "default.queue_times_historical",
@@ -689,6 +705,7 @@ SUPPORTED_PATHS = {
     "util_metadata": "misc.oss_ci_utilization_metadata",
     "util_timeseries": "misc.oss_ci_time_series",
     "disabled_tests_historical": "misc.disabled_tests_historical",
+    "claude_code_usage": "misc.claude_code_usage",
     # fbossci-cloudwatch-metrics bucket
     "ghci-related": "infra_metrics.cloudwatch_metrics",
     "test_jsons_while_running": "tests.all_test_runs",
@@ -715,6 +732,7 @@ OBJECT_CONVERTER = {
     "misc.oss_ci_utilization_metadata": oss_ci_util_metadata_adapter,
     "misc.oss_ci_time_series": oss_ci_util_time_series_adapter,
     "misc.disabled_tests_historical": disabled_tests_historical_adapter,
+    "misc.claude_code_usage": claude_code_usage_adapter,
     "infra_metrics.cloudwatch_metrics": cloudwatch_metrics_adapter,
 }
 

--- a/clickhouse_db_schema/misc.claude_code_usage/schema.sql
+++ b/clickhouse_db_schema/misc.claude_code_usage/schema.sql
@@ -1,0 +1,17 @@
+CREATE TABLE misc.claude_code_usage
+(
+    `repo` String,
+    `run_id` Int64,
+    `run_attempt` Int32,
+    `actor` String,
+    `event_name` String,
+    `pr_number` Int64,
+    `timestamp` DateTime64(3),
+    `duration_ms` Int64,
+    `num_turns` Int32,
+    `total_cost_usd` Float64,
+    `_inserted_at` DateTime MATERIALIZED now()
+)
+ENGINE = SharedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')
+ORDER BY (repo, timestamp, run_id)
+SETTINGS index_granularity = 8192


### PR DESCRIPTION
This pull request introduces a new pipeline for collecting and ingesting Claude Code usage metrics into ClickHouse for analytics. The changes span GitHub Actions, AWS Lambda ingestion logic, and database schema additions to support this new data flow.


* reusable action to upload claude code metrics to s3
* clickhouse schema for the metrics
* turns on ingestion
