### PR TITLE
Forward fix release wheel variants workflow

### DIFF
--- a/.github/workflows/release-wheel-variants.yml
+++ b/.github/workflows/release-wheel-variants.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           path: test-infra
           # For PRs, use the merge commit SHA; for workflow_dispatch use the branch
-          ref: ${{ github.event_name == 'pull_request' && github.sha || 'wheel_variant_210' }}
+          ref: ${{ github.event_name == 'pull_request' && github.sha || 'main' }}
 
       - name: Checkout variant-repack
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
After https://github.com/pytorch/test-infra/pull/7667 remove debug code, use main as default branch