### PR TITLE
set up PT x vLLM regression config

### DIFF
--- a/aws/lambda/benchmark_regression_summary_report/common/config.py
+++ b/aws/lambda/benchmark_regression_summary_report/common/config.py
@@ -347,24 +347,6 @@ PYTORCH_X_VLLM_BENCHMARK_CONFIG = BenchmarkConfig(
                 threshold=1.20,
                 baseline_aggregation="median",
             ),
-            "p99_itl_ms": RegressionPolicy(
-                name="p99_itl_ms",
-                condition="less_equal",
-                threshold=1.20,
-                baseline_aggregation="median",
-            ),
-            "p99_tpot_ms": RegressionPolicy(
-                name="p99_tpot_ms",
-                condition="less_equal",
-                threshold=1.20,
-                baseline_aggregation="median",
-            ),
-            "p99_ttft_ms": RegressionPolicy(
-                name="p99_ttft_ms",
-                condition="less_equal",
-                threshold=1.20,
-                baseline_aggregation="median",
-            ),
             "requests_per_second": RegressionPolicy(
                 name="requests_per_second",
                 condition="greater_equal",
@@ -387,7 +369,8 @@ PYTORCH_X_VLLM_BENCHMARK_CONFIG = BenchmarkConfig(
                     "condition": {
                         "type": "device_arch",
                         "device_arches": [
-                            {"device": "cuda", "arch": "NVIDIA H100 80GB HBM3"}
+                            {"device": "cuda", "arch": "NVIDIA H100 80GB HBM3"},
+                            {"device": "cuda", "arch": "NVIDIA B200"},
                         ],
                     },
                 }


### PR DESCRIPTION
Summary:
As title, this should connect regressions to the newly created GH issue. Using 1.20 and 0.8 as thresholds.

Test Plan:
Local run with the following:
```
python aws/lambda/benchmark_regression_summary_report/lambda_function.py --clickhouse-endpoint ${CLICKHOUSE_ENDPOINT} --clickhouse-username ${DEV_USERNAME} --clickhouse-password ${CLICKHOUSE_PASSWORD} --config-id pytorch_x_vllm_benchmark
```
Ran both yesterday and today, and run today was sufficient to trigger thresholds for regressions, so 20% seems appropriate here. 

Reviewers:

Subscribers:

Tasks:

Tags: