### PR TITLE
add torchcodec to Dr CI

### DIFF
--- a/.github/workflows/update-drci-comments.yml
+++ b/.github/workflows/update-drci-comments.yml
@@ -21,6 +21,7 @@ jobs:
           { repo: rl, org: pytorch },
           { repo: text, org: pytorch },
           { repo: torchchat, org: pytorch },
+          { repo: torchcodec, org: meta-pytorch },
           { repo: tutorials, org: pytorch },
           { repo: vision, org: pytorch },
         ]

--- a/torchci/lib/bot/utils.ts
+++ b/torchci/lib/bot/utils.ts
@@ -44,6 +44,7 @@ export function isDrCIEnabled(owner: string, repo: string): boolean {
       "torchtune",
       "ao",
       "torchchat",
+      "torchcodec",
     ].includes(repo)
   );
 }


### PR DESCRIPTION
This PR adds `torchcodec` to the list of repos in `update-drci-comments.yml` and in `isDrCIEnabled`, similar to https://github.com/pytorch/test-infra/pull/5121.

Please let me know if any other steps need to be taken to enable Dr. CI, thanks!