### PR TITLE
[BetterEngineering 2026]Add rocm 355x to compiler inductor

### DIFF
--- a/torchci/components/benchmark/compilers/common.tsx
+++ b/torchci/components/benchmark/compilers/common.tsx
@@ -66,6 +66,7 @@ export const DISPLAY_NAMES_TO_DEVICE_NAMES: { [k: string]: string[] } = {
   "cpu (x86_zen)": ["cpu"],
   "cpu (aarch64)": ["cpu", "arm64-cpu"],
   "rocm (mi325x)": ["rocm"],
+  "rocm (mi355x)": ["rocm"],
   // TODO (huydhn): Fix this on the gather runner info script to set it to mps correctly
   mps: ["mps", "arm64-cpu"],
   xpu: ["xpu"],
@@ -78,6 +79,7 @@ export const DISPLAY_NAMES_TO_ARCH_NAMES: { [k: string]: string[] } = {
   "cpu (x86_zen)": ["AMD_EPYC_9R14_96c"],
   "cpu (aarch64)": ["aarch64"],
   "rocm (mi325x)": ["AMD Instinct MI325X"],
+  "rocm (mi355x)": ["AMD Radeon Graphics"],
   mps: ["arm"],
   xpu: ["x86_64", "Intel(R) Data Center GPU Max 1100"],
 };

--- a/torchci/lib/benchmark/api_helper/backend/compilers/helpers/common.ts
+++ b/torchci/lib/benchmark/api_helper/backend/compilers/helpers/common.ts
@@ -46,6 +46,7 @@ export function toApiDeviceArch(
     case "rocm":
       if (norm.includes("mi300x")) return [device, "mi300x"];
       if (norm.includes("mi325x")) return [device, "mi325x"];
+      if (norm.includes("radeon")) return [device, "mi355x"];
       return [device, norm];
     case "mps":
       return [device, norm];


### PR DESCRIPTION
The ROCM is currently recognized as `AMD Radeon Graphics`, AMD ask for the benchmark result for this. This is a workaround to add the query

<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/869004c9-714a-4910-9199-b80921e05aa6" />


## Demo
[preview link](https://torchci-git-addrocm350-fbopensource.vercel.app/benchmark/compilers_regression?renderGroupId=main&time.start=2026-01-19T00%3A00%3A00.000Z&time.end=2026-01-26T23%3A59%3A59.999Z&filters.repo=pytorch%2Fpytorch&filters.benchmarkName=compiler&filters.backend=&filters.mode=inference&filters.dtype=bfloat16&filters.deviceName=rocm+%28mi355x%29&filters.device=rocm&filters.arch=AMD+Radeon+Graphics&lbranch=main&rbranch=main&rcommit.commit=ad5a78268395989006af147ac9eab66393170573&rcommit.workflow_id=21342600391&rcommit.date=2026-01-26T02%3A00%3A00Z&rcommit.branch=main&lcommit.commit=994425e8a94d3449ffc972ca8a1aaa45130ef57d&lcommit.workflow_id=21121587974&lcommit.date=2026-01-19T02%3A00%3A00Z&lcommit.branch=main&maxSampling=110)

You can click the external link as shown: all workflows associate with is for 355i
<img width="414" height="139" alt="image" src="https://github.com/user-attachments/assets/4e5b2e53-7d69-4ff5-ad42-d3c2f71fa523" />
