### PR TITLE
Use ciflow/rocm-mi355 as default label for ROCm PRs

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -23,7 +23,7 @@ const IssueAndPRRegexToLabel: [RegExp, string][] = [
 const PrTitleRegexToLabel: [RegExp, string][] = [
   [/reland/gi, "ci-no-td"],
   [/revert/gi, "ci-no-td"],
-  [/rocm/gi, "ciflow/rocm-mi300"],
+  [/rocm/gi, "ciflow/rocm-mi355"],
   ...IssueAndPRRegexToLabel,
 ];
 


### PR DESCRIPTION
Companion PR to https://github.com/pytorch/pytorch/pull/173209