### PR TITLE
Fix wheel variant promotion for MacOS

### DIFF
--- a/.github/workflows/release-wheel-variants.yml
+++ b/.github/workflows/release-wheel-variants.yml
@@ -145,9 +145,15 @@ jobs:
         id: version-suffix
         run: |
           ARCH="${{ matrix.arch }}"
+          PLATFORM="${{ matrix.platform }}"
           case "${ARCH}" in
             cpu)
-              echo "suffix=%2Bcpu" >> "$GITHUB_OUTPUT"
+              # macOS wheels don't have +cpu suffix
+              if [[ "${PLATFORM}" == macosx* ]]; then
+                echo "suffix=" >> "$GITHUB_OUTPUT"
+              else
+                echo "suffix=%2Bcpu" >> "$GITHUB_OUTPUT"
+              fi
               ;;
             cu*)
               echo "suffix=%2B${ARCH}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
MacOS wheels don't have +cpu suffix in them