### PR TITLE
Executorch release. Fix staging to pypi script

### DIFF
--- a/.github/workflows/release-stage-pypi.yml
+++ b/.github/workflows/release-stage-pypi.yml
@@ -101,7 +101,7 @@ jobs:
               # shellcheck disable=SC2086
               PLATFORM="${MACOS_ARM64}" VERSION_SUFFIX="" upload_pypi_to_staging executorch "${!version}"
               # shellcheck disable=SC2086
-              PLATFORM="manylinux_2_28_aarch64" VERSION_SUFFIX="" upload_pypi_to_staging executorch "${!version}"
+              PLATFORM="manylinux_2_28_aarch64" VERSION_SUFFIX="${CPU_VERSION_SUFFIX}" upload_pypi_to_staging executorch "${!version}"
               # shellcheck disable=SC2086
               PLATFORM="win_amd64" VERSION_SUFFIX="${CPU_VERSION_SUFFIX}" upload_pypi_to_staging executorch "${!version}"
             fi


### PR DESCRIPTION
Executorch aarch64 filename was changed as follows for release 1.1.0:

``executorch-1.0.1-cp311-cp311-manylinux_2_28_aarch64.whl -> executorch-1.1.0+cpu-cp310-cp310-manylinux_2_28_aarch64.whl``