### PR TITLE
Add oidc permissions to linux_job_v2

### DIFF
--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -124,8 +124,8 @@ on:
 
 jobs:
   job:
-    permissions:                                                     
-      id-token: write                                                             
+    permissions:
+      id-token: write
       contents: read
     strategy:
       fail-fast: false


### PR DESCRIPTION
This allows it to be reusable for rocm workflows which require oidc login.

Workflow: https://github.com/meta-pytorch/torchcomms/blob/main/.github/workflows/build_test_rccl.yaml

Example of failure: https://github.com/meta-pytorch/torchcomms/pull/427?fbclid=IwY2xjawPnZMdleHRuA2FlbQIxMQBicmlkETF5OEVVUnZQaE8yemxmRzdxc3J0YwZhcHBfaWQBMAABHhxFS6dkvj8_sGecjWN1737KOulIbNEi-OlDcw00jCQ59kaura5S4znmzXd7_aem_TbihlyGxEldv0BL842VoLA

Test change: https://github.com/pytorch/vision/commit/79c13068abe8293cb929376d27e9f5c4994849b3
Test run: https://github.com/pytorch/vision/actions/runs/21459880198/job/61809653472