### PR TITLE
Revert "Add oidc permissions to linux_job_v2"

### DIFF
--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -124,9 +124,6 @@ on:
 
 jobs:
   job:
-    permissions:
-      id-token: write
-      contents: read
     strategy:
       fail-fast: false
     name: ${{ inputs.job-name }}


### PR DESCRIPTION
Reverts pytorch/test-infra#7703
Don't think its actually required