### PR TITLE
[FE 2026]Add regression UI access for vllm x pytorch

### DIFF
--- a/torchci/components/benchmark_v3/configs/configurations.tsx
+++ b/torchci/components/benchmark_v3/configs/configurations.tsx
@@ -168,6 +168,13 @@ export const BENCHMARK_CATEGORIES: BenchmarkCategoryGroup[] = [
         route: `/benchmark/v3/dashboard/${PYTORCH_X_VLLM_BENCHMARK_ID}`,
         info: "PyTorch x vLLM nightly benchmark using [vLLM pinned commit](https://github.com/pytorch/pytorch/blob/main/.github/ci_commit_pins/vllm.txt). Powered by [vllm-benchmark workflow](https://github.com/pytorch/pytorch/blob/main/.github/workflows/vllm-benchmark.yml) + [the benchmark configs](https://github.com/pytorch/pytorch-integration-testing/tree/main/vllm-benchmarks/benchmarks)",
         description: "Pytorch x vLLM nightly benchmark on PyTorch",
+        actions: [
+          {
+            label: "Regression Reports",
+            type: "regression_report",
+            href: `/benchmark/regression/reports/${PYTORCH_X_VLLM_BENCHMARK_ID}`,
+          },
+        ],
       },
       {
         name: "Gpt-fast Benchmark",

--- a/torchci/components/benchmark_v3/configs/teams/vllm/pytorch_x_vllm_config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/vllm/pytorch_x_vllm_config.ts
@@ -51,6 +51,15 @@ export const PytorchXVllmBenchmarkDashboardConfig: BenchmarkUIConfig = {
   },
   dataRender: {
     type: "auto",
+    sideRender: {
+      RegressionReportFeature: {
+        type: "RegressionReportFeature",
+        title: "Regression Report Section",
+        config: {
+          report_id: PYTORCH_X_VLLM_BENCHMARK_ID,
+        },
+      },
+    },
     subSectionRenders: {
       detail_view: {
         filterConstraint: {


### PR DESCRIPTION
In dashboard
<img width="1068" height="222" alt="image" src="https://github.com/user-attachments/assets/d8dbaece-5bcb-49cb-8da3-0a52ece343b0" />

In benchmark list view, regression report button
<img width="389" height="396" alt="image" src="https://github.com/user-attachments/assets/122b4656-313b-4704-802e-b7ff123fcfba" />

