### PR TITLE
Forward fix for variant validation after #7705

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -207,7 +207,8 @@ run_smoke_tests() {
 # Test CUDA device visibility
 test_cuda_device() {
     if [[ ${MATRIX_GPU_ARCH_TYPE:-} == 'cuda' ]]; then
-        python -c "import torch;import os;print(torch.cuda.device_count(), torch.__version__);os.environ['CUDA_VISIBLE_DEVICES']='0';print(torch.empty(2, device='cuda'))"
+        # Run from /tmp to avoid importing torch source directory instead of installed package
+        (cd /tmp && python -c "import torch;import os;print(torch.cuda.device_count(), torch.__version__);os.environ['CUDA_VISIBLE_DEVICES']='0';print(torch.empty(2, device='cuda'))")
     fi
 }
 


### PR DESCRIPTION
Fixes Failures : https://github.com/pytorch/test-infra/actions/runs/21526332612
After landing https://github.com/pytorch/test-infra/pull/7705
The root cause: install_wheel_variants is called inside command substitution  $(install_wheel_variants), which runs in a subshell. In this case we don't want to run within subshell.

Succesful run: https://github.com/pytorch/test-infra/actions/runs/21526699846/job/62032120479