### PR TITLE
Do not include the latest viable/strict commit for the check

### DIFF
--- a/tools/scripts/fetch_latest_green_commit.py
+++ b/tools/scripts/fetch_latest_green_commit.py
@@ -42,7 +42,7 @@ def get_latest_commits(viable_strict_branch: str, main_branch: str) -> List[str]
         [
             "git",
             "rev-list",
-            f"{latest_viable_commit}^..HEAD",
+            f"{latest_viable_commit}..HEAD",
             f"--remotes=*origin/{main_branch}",
         ],
         encoding="ascii",


### PR DESCRIPTION
The range {latest_viable_commit}^..HEAD includes the current viable/strict commit itself (using ^ means "parent of", so the range starts from the parent, which includes the commit).

When all newer commits fail, the script eventually checks the current viable/strict commit, finds it's green (because it was already validated), and returns it as "success" - even though there's nothing new to advance to.
