### PR TITLE
Add vLLM benchmarks into vLLM HUD group

### DIFF
--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -71,7 +71,7 @@ const GROUP_OTHER = "other";
 // Jobs will be grouped with the first regex they match in this list
 export const groups = [
   {
-    regex: /vllm/,
+    regex: /vllm/i,
     name: GROUP_VLLM,
   },
   {


### PR DESCRIPTION
vLLM-compile oncall is now actively monitoring vLLM group on HUD, so adding vLLM benchmark jobs there will ensure that CI failures are given their due attention.