### PR TITLE
Show PyTorch x vLLM results with use_compile set

### DIFF
--- a/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/benchmarkDataQueryBuilder.ts
+++ b/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/benchmarkDataQueryBuilder.ts
@@ -717,6 +717,12 @@ export class VllmBenchmarkDataFetcher
           OR startsWith(tupleElement(o.model, 'name'), {modelCategory:String})
       )
     `,
+      `(
+          {useCompile:String} = ''
+          OR tupleElement(o.benchmark, 'extra_info')['use_compile'] = ''
+          OR tupleElement(o.benchmark, 'extra_info')['use_compile'] = {useCompile:String}
+      )
+    `,
     ]);
   }
   applyFormat(
@@ -754,6 +760,7 @@ export class VllmBenchmarkDataFetcher
     const params = {
       ...inputs,
       modelCategory: inputs.modelCategory ?? "",
+      useCompile: inputs.useCompile ?? "true",
       excludedMetrics: excludedMetrics,
     };
 


### PR DESCRIPTION
After https://github.com/pytorch/pytorch-integration-testing/pull/135 merged, we are now running vLLM benchmark results on both compile and eager modes. With 2 set of results, the current query used by the dashboard failed to separate them and could return the compile or eager results (non-deterministic from what I see)

The fix from vLLM side to add `use_compile` field https://github.com/vllm-project/vllm/pull/32990 was landed last Friday, so now the query can use this field to query compile or eager results selectively.  Eventually, we will need both on the dashboard to compute the speed up (compile v.s. eager) T252039384, but let's just show only compile results for now to avoid confusion. This is the default behavior of the dashboard before https://github.com/pytorch/pytorch-integration-testing/pull/135

The massive regression captured in https://hud.pytorch.org/benchmark/regression/report/67d6c26c-7063-4955-ba3c-0bb5776dd5ac is due to this where the query compare the compile results on Jan 30th v.s. the eager results on Jan 31st (again, non-deterministic on which results were return).  This is a data point proving that the notification is working though, at least when the regression is massive cc @georgehong 

cc @desertfire @zou3519 