### PR TITLE
[CDN] Use r2 for torchaudio nightly

### DIFF
--- a/s3_management/manage_v2.py
+++ b/s3_management/manage_v2.py
@@ -715,9 +715,8 @@ class S3Index:
         resolved_subdir = self._resolve_subdir(subdir)
 
         # Check if this package should use R2 for nightly builds
-        if (
-            package_name.lower() in PT_R2_PACKAGES
-            and resolved_subdir.startswith("whl/nightly")
+        if package_name.lower() in PT_R2_PACKAGES and resolved_subdir.startswith(
+            "whl/nightly"
         ):
             # Use R2 absolute URL for PT_R2_PACKAGES in nightly builds
             base_url = "https://download-r2.pytorch.org"


### PR DESCRIPTION
This will use r2 for torchaudio package in nightly channel.
PT_R2_PACKAGES is an array hence we will be enabling packages one by one.