### PR TITLE
Fix time metrics highlight rule (lower is better)

### DIFF
--- a/torchci/components/benchmark_v3/configs/teams/vllm/config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/vllm/config.ts
@@ -1,10 +1,32 @@
 import { BenchmarkUIConfig } from "../../config_book_types";
+import { BenchmarkComparisonPolicyConfig } from "../../helpers/RegressionPolicy";
 import {
   BRANCH_METADATA_COLUMN,
   DEFAULT_DASHBOARD_BENCHMARK_INITIAL,
 } from "../defaults/default_dashboard_config";
 
 export const VLLM_BENCHMARK_ID = "vllm_benchmark";
+
+// Comparison policies for time-based metrics (lower is better)
+const TIME_METRIC_POLICY: BenchmarkComparisonPolicyConfig = {
+  target: "time_metric",
+  type: "ratio",
+  ratioPolicy: {
+    badRatio: 1.2,
+    goodRatio: 0.8,
+    direction: "down",
+  },
+};
+
+const COMPARISON_POLICY_BOOK = {
+  latency: TIME_METRIC_POLICY,
+  median_itl_ms: TIME_METRIC_POLICY,
+  median_tpot_ms: TIME_METRIC_POLICY,
+  median_ttft_ms: TIME_METRIC_POLICY,
+  p99_itl_ms: TIME_METRIC_POLICY,
+  p99_tpot_ms: TIME_METRIC_POLICY,
+  p99_ttft_ms: TIME_METRIC_POLICY,
+};
 
 const COMPARISON_TABLE_METADATA_COLUMNS = [
   {
@@ -148,6 +170,7 @@ export const VllmBenchmarkDashboardConfig: BenchmarkUIConfig = {
             },
           },
           extraMetadata: COMPARISON_TABLE_METADATA_COLUMNS,
+          comparisonPolicy: COMPARISON_POLICY_BOOK,
           renderOptions: {
             missingText: "none",
             bothMissingText: "",

--- a/torchci/components/benchmark_v3/configs/teams/vllm/pytorch_x_vllm_config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/vllm/pytorch_x_vllm_config.ts
@@ -1,10 +1,32 @@
 import { BenchmarkUIConfig } from "../../config_book_types";
+import { BenchmarkComparisonPolicyConfig } from "../../helpers/RegressionPolicy";
 import {
   BRANCH_METADATA_COLUMN,
   DEFAULT_DASHBOARD_BENCHMARK_INITIAL,
 } from "../defaults/default_dashboard_config";
 
 export const PYTORCH_X_VLLM_BENCHMARK_ID = "pytorch_x_vllm_benchmark";
+
+// Comparison policies for time-based metrics (lower is better)
+const TIME_METRIC_POLICY: BenchmarkComparisonPolicyConfig = {
+  target: "time_metric",
+  type: "ratio",
+  ratioPolicy: {
+    badRatio: 1.2,
+    goodRatio: 0.8,
+    direction: "down",
+  },
+};
+
+const COMPARISON_POLICY_BOOK = {
+  latency: TIME_METRIC_POLICY,
+  median_itl_ms: TIME_METRIC_POLICY,
+  median_tpot_ms: TIME_METRIC_POLICY,
+  median_ttft_ms: TIME_METRIC_POLICY,
+  p99_itl_ms: TIME_METRIC_POLICY,
+  p99_tpot_ms: TIME_METRIC_POLICY,
+  p99_ttft_ms: TIME_METRIC_POLICY,
+};
 
 const COMPARISON_TABLE_METADATA_COLUMNS = [
   {
@@ -156,6 +178,7 @@ export const PytorchXVllmBenchmarkDashboardConfig: BenchmarkUIConfig = {
             },
           },
           extraMetadata: COMPARISON_TABLE_METADATA_COLUMNS,
+          comparisonPolicy: COMPARISON_POLICY_BOOK,
           renderOptions: {
             missingText: "none",
             bothMissingText: "",


### PR DESCRIPTION
@zou3519 points out that time metrics like latency, the lower the better, the dashboard currently highlights it wrong.  This PR fixes that issue, the ratio comes from https://github.com/pytorch/test-infra/pull/7684, same as what is used in notification