### PR TITLE
Add Claude Code billing dashboard and HUD page

### DIFF
--- a/torchci/clickhouse_queries/claude_code_usage_by_actor/params.json
+++ b/torchci/clickhouse_queries/claude_code_usage_by_actor/params.json
@@ -1,0 +1,9 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/claude_code_usage_by_actor/query.sql
+++ b/torchci/clickhouse_queries/claude_code_usage_by_actor/query.sql
@@ -1,0 +1,17 @@
+SELECT
+    DATE_TRUNC({granularity: String}, cu.timestamp) AS granularity_bucket,
+    cu.actor AS actor,
+    count(*) AS invocations,
+    round(sum(cu.total_cost_usd), 2) AS total_cost,
+    sum(cu.num_turns) AS total_turns,
+    round(sum(cu.duration_ms) / 1000 / 60, 2) AS total_minutes
+FROM misc.claude_code_usage cu
+WHERE
+    cu.timestamp >= {startTime: DateTime64(9)}
+    AND cu.timestamp < {stopTime: DateTime64(9)}
+    AND cu.repo IN {selectedRepos: Array(String)}
+GROUP BY
+    granularity_bucket,
+    actor
+ORDER BY
+    granularity_bucket ASC

--- a/torchci/clickhouse_queries/claude_code_usage_by_repo/params.json
+++ b/torchci/clickhouse_queries/claude_code_usage_by_repo/params.json
@@ -1,0 +1,8 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/claude_code_usage_by_repo/query.sql
+++ b/torchci/clickhouse_queries/claude_code_usage_by_repo/query.sql
@@ -1,0 +1,16 @@
+SELECT
+    DATE_TRUNC({granularity: String}, cu.timestamp) AS granularity_bucket,
+    cu.repo AS repo,
+    count(*) AS invocations,
+    round(sum(cu.total_cost_usd), 2) AS total_cost,
+    sum(cu.num_turns) AS total_turns,
+    round(sum(cu.duration_ms) / 1000 / 60, 2) AS total_minutes
+FROM misc.claude_code_usage cu
+WHERE
+    cu.timestamp >= {startTime: DateTime64(9)}
+    AND cu.timestamp < {stopTime: DateTime64(9)}
+GROUP BY
+    granularity_bucket,
+    repo
+ORDER BY
+    granularity_bucket ASC

--- a/torchci/clickhouse_queries/claude_code_usage_by_workflow/params.json
+++ b/torchci/clickhouse_queries/claude_code_usage_by_workflow/params.json
@@ -1,0 +1,9 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/claude_code_usage_by_workflow/query.sql
+++ b/torchci/clickhouse_queries/claude_code_usage_by_workflow/query.sql
@@ -1,0 +1,24 @@
+SELECT
+    DATE_TRUNC({granularity: String}, cu.timestamp) AS granularity_bucket,
+    COALESCE(wj.workflow_name, cu.event_name) AS workflow_name,
+    count(*) AS invocations,
+    round(sum(cu.total_cost_usd), 2) AS total_cost,
+    sum(cu.num_turns) AS total_turns,
+    round(sum(cu.duration_ms) / 1000 / 60, 2) AS total_minutes
+FROM misc.claude_code_usage cu
+LEFT JOIN (
+    SELECT DISTINCT
+        run_id,
+        run_attempt,
+        workflow_name
+    FROM default.workflow_job
+) wj ON cu.run_id = wj.run_id AND cu.run_attempt = wj.run_attempt
+WHERE
+    cu.timestamp >= {startTime: DateTime64(9)}
+    AND cu.timestamp < {stopTime: DateTime64(9)}
+    AND cu.repo IN {selectedRepos: Array(String)}
+GROUP BY
+    granularity_bucket,
+    workflow_name
+ORDER BY
+    granularity_bucket ASC

--- a/torchci/clickhouse_queries/claude_code_usage_daily/params.json
+++ b/torchci/clickhouse_queries/claude_code_usage_daily/params.json
@@ -1,0 +1,7 @@
+{
+  "params": {
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/claude_code_usage_daily/query.sql
+++ b/torchci/clickhouse_queries/claude_code_usage_daily/query.sql
@@ -1,0 +1,28 @@
+SELECT
+    toDate(cu.timestamp) AS day,
+    COALESCE(wj.workflow_name, cu.event_name) AS workflow_name,
+    cu.repo AS repo,
+    count(*) AS invocations,
+    round(sum(cu.total_cost_usd), 2) AS total_cost,
+    sum(cu.num_turns) AS total_turns,
+    round(sum(cu.duration_ms) / 1000 / 60, 2) AS total_minutes,
+    round(avg(cu.total_cost_usd), 4) AS avg_cost_per_invocation,
+    round(avg(cu.num_turns), 1) AS avg_turns_per_invocation
+FROM misc.claude_code_usage cu
+LEFT JOIN (
+    SELECT DISTINCT
+        run_id,
+        run_attempt,
+        workflow_name
+    FROM default.workflow_job
+) wj ON cu.run_id = wj.run_id AND cu.run_attempt = wj.run_attempt
+WHERE
+    cu.timestamp >= {startTime: DateTime64(9)}
+    AND cu.timestamp < {stopTime: DateTime64(9)}
+GROUP BY
+    day,
+    workflow_name,
+    repo
+ORDER BY
+    day ASC,
+    total_cost DESC

--- a/torchci/components/layout/NavBar.tsx
+++ b/torchci/components/layout/NavBar.tsx
@@ -109,6 +109,10 @@ function NavBar() {
       name: "Autorevert Metrics",
       href: "/metrics/autorevert",
     },
+    {
+      name: "Claude Billing",
+      href: "/claude_billing",
+    },
   ].map((item) => ({
     label: item.name,
     route: item.href,

--- a/torchci/pages/claude_billing.tsx
+++ b/torchci/pages/claude_billing.tsx
@@ -1,0 +1,73 @@
+import { Box, Button, Container, Typography } from "@mui/material";
+import Head from "next/head";
+import { useDarkMode } from "../lib/DarkModeContext";
+
+const CLAUDE_BILLING_DASHBOARD_ID = "9127e39ec5a7410ebb419fac06a08ca0";
+
+export default function ClaudeBillingPage() {
+  const { themeMode, darkMode } = useDarkMode();
+
+  let chartTheme = "light";
+  if (themeMode === "system") {
+    chartTheme = darkMode ? "dark" : "light";
+  } else {
+    chartTheme = themeMode;
+  }
+
+  const dashboardUrl = `https://disz2yd9jqnwc.cloudfront.net/public-dashboards/${CLAUDE_BILLING_DASHBOARD_ID}?theme=${chartTheme}`;
+  const grafanaUrl = `https://pytorchci.grafana.net/public-dashboards/${CLAUDE_BILLING_DASHBOARD_ID}`;
+
+  return (
+    <>
+      <Head>
+        <title>Claude Code Review Billing - PyTorch CI HUD</title>
+      </Head>
+      <Container maxWidth={false} sx={{ py: 2 }}>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            mb: 2,
+          }}
+        >
+          <Typography variant="h4" component="h1">
+            Claude Code Review Billing
+          </Typography>
+          <Button
+            href={grafanaUrl}
+            target="_blank"
+            variant="outlined"
+            size="small"
+          >
+            Open in Grafana
+          </Button>
+        </Box>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Track Claude AI usage costs for code review, issue triage, and other
+          GitHub Actions workflows. Costs are tracked per invocation with
+          breakdowns by workflow, user, and repository.
+        </Typography>
+        <Box
+          sx={{
+            border: 1,
+            borderColor: "divider",
+            borderRadius: 1,
+            overflow: "hidden",
+            height: "calc(100vh - 180px)",
+            minHeight: "600px",
+          }}
+        >
+          <iframe
+            src={dashboardUrl}
+            width="100%"
+            height="100%"
+            frameBorder="0"
+            title="Claude Code Review Billing Dashboard"
+            style={{ display: "block" }}
+          />
+        </Box>
+      </Container>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds ClickHouse queries for Claude Code usage tracking (by workflow, actor, repo, daily)
- Adds HUD page at `/claude_billing` that embeds the Grafana dashboard
- Created corresponding Grafana dashboard with daily cost, workflow breakdown, and actor stats

## Links
- **Public Dashboard**: https://pytorchci.grafana.net/public-dashboards/efc9fo2zuuhvke
- **HUD Page (after deploy)**: https://hud.pytorch.org/claude_billing

## Test plan
- [ ] Verify HUD page loads and displays the embedded Grafana dashboard
- [ ] Verify dashboard shows correct data for different time ranges
- [ ] Check dark/light mode theming works

🤖 Generated with [Claude Code](https://claude.com/claude-code)