### PR TITLE
Add torch to PT_R2_PACKAGES

### DIFF
--- a/s3_management/manage_v2.py
+++ b/s3_management/manage_v2.py
@@ -373,6 +373,7 @@ PT_FOUNDATION_PACKAGES = {
 # These packages will have their URLs point to R2 instead of S3/CloudFront
 # when the path is whl/nightly
 PT_R2_PACKAGES = {
+    "torch",
     "torchaudio",
     "torchvision",
     "fbgemm_gpu",


### PR DESCRIPTION
PT_R2_PACKAGES - packages that point to download-r2.pytorch.org