### PR TITLE
Add setup-uv wrapper action to avoid GitHub API rate limits

### DIFF
--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -1,0 +1,49 @@
+name: Setup uv
+description: |
+  Wrapper around astral-sh/setup-uv with a pinned version to avoid GitHub API
+  rate limits. When uv.toml specifies a version range, setup-uv calls the
+  GitHub API to resolve to a specific version. At PyTorch's CI scale, this
+  exhausts rate limits. Pinning an explicit version avoids API calls entirely.
+
+inputs:
+  python-version:
+    description: "The version of Python to set UV_PYTHON to"
+    required: false
+  activate-environment:
+    description: "Use uv venv to activate a venv ready to be used by later steps."
+    default: "false"
+  ignore-empty-workdir:
+    description: "Ignore when the working directory is empty."
+    default: "false"
+  enable-cache:
+    description: "Enable uploading of the uv cache"
+    default: "false"
+  github-token:
+    description: "Used to increase the rate limit when retrieving versions and downloading uv."
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  uv-version:
+    description: "The installed uv version."
+    value: ${{ steps.setup-uv.outputs.uv-version }}
+  uv-path:
+    description: "The path to the installed uv binary."
+    value: ${{ steps.setup-uv.outputs.uv-path }}
+  uvx-path:
+    description: "The path to the installed uvx binary."
+    value: ${{ steps.setup-uv.outputs.uvx-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup uv
+      id: setup-uv
+      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      with:
+        version: "0.9.21"
+        python-version: ${{ inputs.python-version }}
+        activate-environment: ${{ inputs.activate-environment }}
+        ignore-empty-workdir: ${{ inputs.ignore-empty-workdir }}
+        enable-cache: ${{ inputs.enable-cache }}
+        github-token: ${{ inputs.github-token }}

--- a/.github/workflows/test-setup-uv.yml
+++ b/.github/workflows/test-setup-uv.yml
@@ -1,0 +1,83 @@
+name: Test setup-uv
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/test-setup-uv.yml
+      - .github/actions/setup-uv/action.yml
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    name: Test setup-uv on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Test setup-uv action
+        id: setup-uv
+        uses: ./.github/actions/setup-uv
+
+      - name: Verify uv is installed
+        shell: bash
+        run: |
+          set -eux
+          uv --version
+          # Verify the expected version is installed
+          uv --version | grep -q "0.9.21"
+
+      - name: Verify outputs are set
+        shell: bash
+        run: |
+          set -eux
+          echo "uv-version: ${{ steps.setup-uv.outputs.uv-version }}"
+          echo "uv-path: ${{ steps.setup-uv.outputs.uv-path }}"
+          test -n "${{ steps.setup-uv.outputs.uv-version }}"
+          test -n "${{ steps.setup-uv.outputs.uv-path }}"
+
+  test-with-python:
+    name: Test setup-uv with python-version
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Test setup-uv with python-version
+        uses: ./.github/actions/setup-uv
+        with:
+          python-version: "3.12"
+
+      - name: Verify python version is set
+        run: |
+          set -eux
+          echo "UV_PYTHON=$UV_PYTHON"
+          test "$UV_PYTHON" = "3.12"
+
+  test-with-activate-environment:
+    name: Test setup-uv with activate-environment
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Test setup-uv with activate-environment
+        id: setup-uv
+        uses: ./.github/actions/setup-uv
+        with:
+          activate-environment: "true"
+
+      - name: Verify venv is activated
+        run: |
+          set -eux
+          echo "VIRTUAL_ENV=$VIRTUAL_ENV"
+          test -n "$VIRTUAL_ENV"
+          # Verify the venv directory exists
+          test -d "$VIRTUAL_ENV"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #7746
* #7745
* __->__ #7744

When uv.toml specifies a version range like `>=0.9.21`, setup-uv
calls the GitHub API to resolve to a specific version. At PyTorch's
CI scale, this exhausts rate limits.

This adds a centralized wrapper action that pins an explicit uv
version, avoiding API calls entirely. All pytorch workflows can
use this wrapper instead of directly using astral-sh/setup-uv.

Also adds a test workflow for the new action.