### PR TITLE
Pin setuptools<82 to fix pkg_resources removal breakage

### DIFF
--- a/aws/lambda/pytorch-auto-revert/dev_requirements.txt
+++ b/aws/lambda/pytorch-auto-revert/dev_requirements.txt
@@ -1,3 +1,3 @@
 boto3-stubs>=1.34.51
 lintrunner==0.12.5
-setuptools>=80.9.0
+setuptools>=80.9.0,<82

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
 requires = [
-    "setuptools",
+    "setuptools<82",
     "wheel",
     "astunparse",
     "numpy",
     "ninja",
     "pyyaml",
-    "setuptools",
+    "setuptools<82",
     "cmake",
     "typing-extensions",
     "requests",

--- a/tools/torchci/pyproject.toml
+++ b/tools/torchci/pyproject.toml
@@ -3,7 +3,7 @@ name = "torchci"
 dynamic = ["version"]
 
 [build-system]
-requires = ["setuptools>=68.2.2"]
+requires = ["setuptools>=68.2.2,<82"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.package-dir]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #7746
* #7745
* #7744

setuptools 82.0.0 (released Feb 8, 2026) removed pkg_resources,
which breaks transitive dependencies that import it. Pin
setuptools<82 in build-system requires and dev requirements.