### PR TITLE
Use conda 25.3.0 instead of 24.7.1 in setup-binary-builds

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -126,22 +126,7 @@ runs:
           set -euxo pipefail
           CONDA_ENV="${RUNNER_TEMP}/conda_environment_${GITHUB_RUN_ID}"
           export CONDA_EXTRA_PARAM=""
-
-          if [[ "${PYTHON_VERSION:-}" == *t || "${PYTHON_VERSION:-}" == 3.14* ]]; then
-            # downgrade conda version for python 3.13t, 3.14t, 3.14 install.
-            # TODO: remove this once python  3.13t, 3.14t, 3.14 is fully supported on conda
-            # Please see : https://github.com/conda/conda/issues/14554
-            if [[ "$(uname)" == Darwin ]]; then
-              # required to be able to downgrade on MacOS arm64
-              conda install -y python=3.9
-              if [[ -n "$(conda list | grep conda-anaconda-telemetry)" ]]; then
-                conda uninstall -y conda-anaconda-telemetry conda-anaconda-tos
-              fi
-              conda install -y conda=24.7.1 conda-libmamba-solver=24.1.0
-            else
-              conda install -y conda=24.7.1
-            fi
-          fi
+          conda install -y conda=25.3.0
 
           # shellcheck disable=SC2153
           case $PYTHON_VERSION in


### PR DESCRIPTION
24.7.1 causes a failure in aarch64 jobs: https://github.com/pytorch/vision/actions/runs/21863678249/job/63099145487 