### PR TITLE
Add torchcodec to release-pypi package options

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -21,6 +21,7 @@ on:
           - executorch
           - torchvision
           - torchaudio
+          - torchcodec
 
 permissions:
   id-token: write


### PR DESCRIPTION
https://github.com/pytorch/test-infra/pull/7751 added `torchcodec` to `release-download-pytorch-org.yml` and `release-stage-pypi.yml`. 

This PR adds `torchcodec` to `release-pypi.yml`.