### PR TITLE
workflow to manually promote .dev{date} FA3 package from test to nightly

### DIFF
--- a/.github/workflows/release-test-to-nightly.yml
+++ b/.github/workflows/release-test-to-nightly.yml
@@ -1,0 +1,86 @@
+name: Promote ecosystem library from test to nightly.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dryrun:
+        required: true
+        type: choice
+        default: enabled
+        options:
+          - enabled
+          - disabled
+      package:
+        description: "Domain to promote from test to nightly"
+        required: true
+        type: choice
+        default: flash_attn_3
+        options:
+          - flash_attn_3
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: promote-env
+    container:
+      image: pytorch/almalinux-builder:cpu
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Configure aws credentials (pytorch account)
+        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
+        with:
+          role-to-assume: arn:aws:iam::749337293305:role/gha_workflow_promote_wheels
+          aws-region: us-east-1
+      - name: Promote library from test to nightly
+        shell: bash
+        env:
+          PACKAGE: ${{ inputs.package || 'flash_attn_3' }}
+          DRY_RUN: ${{ inputs.dryrun || 'enabled' }}
+        run: |
+            set -ex
+            cd release
+            # Install requirements
+            pip install awscli==1.32.18
+
+            promote_s3() {
+              local package_name
+              package_name=$1
+              local package_type
+              package_type=$2
+              local promote_version
+              promote_version=$3
+
+              # shellcheck disable=SC2086
+              echo "=-=-=-= Promoting ${package_name}'s v${promote_version} ${package_type} packages from test to nightly =-=-=-="
+              (
+                  set -x
+                  # shellcheck disable=SC2086
+                  TEST_PYTORCH_PROMOTE_VERSION="${promote_version}" \
+                      PACKAGE_NAME="${package_name}" \
+                      PACKAGE_TYPE="${package_type}" \
+                      FROM="test" \
+                      TO="nightly" \
+                      TEST_WITHOUT_GIT_TAG=1 \
+                      DRY_RUN="${DRY_RUN}" ./promote/s3_to_s3.sh
+              )
+              echo
+            }
+
+            # Init release versions variables
+            source ./release_versions.sh
+            # Run promotion
+            # shellcheck disable=SC2086
+            version="${PACKAGE^^}_VERSION"
+
+            # only promote .dev wheels to nightly
+            if [[ "${PACKAGE}" == "flash_attn_3" ]]; then
+              export PACKAGE_INCLUDE_SUFFIX=".dev*"
+            fi
+
+            # shellcheck disable=SC2086
+            promote_s3 ${PACKAGE} whl "${!version}"


### PR DESCRIPTION
as title, followed structure of `.github/workflows/release-download-pytorch-org.yml`