### PR TITLE
[FE 2026]Add Vllm Aggreggate View

### DIFF
--- a/torchci/components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/BenchmarkTimeSeriesChart.tsx
+++ b/torchci/components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/BenchmarkTimeSeriesChart.tsx
@@ -96,6 +96,18 @@ const BenchmarkTimeSeriesChart: React.FC<Props> = ({
     }
 
     let legendKeyItems: string[] = [];
+    if (renderOptions?.additionalMetadataList) {
+      const additionalMetadataList = renderOptions.additionalMetadataList;
+      additionalMetadataList.forEach((k) => {
+        const v = getSmartValue(meta, k);
+        if (v) {
+          legendKeyItems.push(
+            `<div style="font-size:10px;"><i>${k}:${v}</i></div>`
+          );
+        }
+      });
+    }
+
     if (renderOptions?.showLegendDetails) {
       legendKeys?.forEach((k) => {
         const v = getSmartValue(meta, k);

--- a/torchci/components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesComparisonSection/BenchmarkTimeSeriesComparisonTableSection.tsx
+++ b/torchci/components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesComparisonSection/BenchmarkTimeSeriesComparisonTableSection.tsx
@@ -14,7 +14,6 @@ import {
 } from "../../helper";
 import { ComparisonTable } from "./BenchmarkTimeSeriesComparisonTable/ComparisonTable";
 import { BenchmarkTimeSeriesComparisonTableSlider } from "./BenchmarkTimeSeriesComparisonTableSlider";
-import { table } from "console";
 
 const styles = {
   container: {
@@ -97,7 +96,7 @@ export default function BenchmarkTimeSeriesComparisonTableSection({
     xs: 12,
     md: 12,
     lg: 6,
-    ...tableSectionConfig?.renderOptions?.dynamicSize
+    ...tableSectionConfig?.renderOptions?.dynamicSize,
   };
 
   if (!filtered || filtered.length == 0) {

--- a/torchci/components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesComparisonSection/BenchmarkTimeSeriesComparisonTableSection.tsx
+++ b/torchci/components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesComparisonSection/BenchmarkTimeSeriesComparisonTableSection.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../helper";
 import { ComparisonTable } from "./BenchmarkTimeSeriesComparisonTable/ComparisonTable";
 import { BenchmarkTimeSeriesComparisonTableSlider } from "./BenchmarkTimeSeriesComparisonTableSlider";
+import { table } from "console";
 
 const styles = {
   container: {
@@ -92,6 +93,13 @@ export default function BenchmarkTimeSeriesComparisonTableSection({
     setRWorkflowId(next[1]);
   };
 
+  const dynamicSize = {
+    xs: 12,
+    md: 12,
+    lg: 6,
+    ...tableSectionConfig?.renderOptions?.dynamicSize
+  };
+
   if (!filtered || filtered.length == 0) {
     return <></>;
   }
@@ -149,7 +157,7 @@ export default function BenchmarkTimeSeriesComparisonTableSection({
               <Grid
                 key={key}
                 sx={{ p: 0.2 }}
-                size={{ xs: 12, md: 12, lg: 6 }}
+                size={dynamicSize}
                 id={`benchmark-time-series-comparison-table-${key}`}
               >
                 <Paper sx={styles.paper}>

--- a/torchci/components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/helper.tsx
+++ b/torchci/components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/helper.tsx
@@ -14,6 +14,7 @@ export type BenchmarkComparisonTableSectionConfig = {
   titleMapping?: Record<string, string>;
   groupByFields: string[];
   filterByFieldValues?: Record<string, Array<string>>;
+  renderOptions: any;
   tableConfig: ComparisonTableConfig;
 };
 
@@ -130,6 +131,7 @@ export type BenchmarkTimeSeriesCharRenderOpiton = {
   height?: string | number;
   title_group_mapping?: BenchmarkComparisonTitleMapping;
   chartRenderBook?: BenchmarkTimeSeriesChartRenderingBook;
+  additionalMetadataList?: string[];
   showLegendDetails?: boolean;
 };
 

--- a/torchci/components/benchmark_v3/configs/configurations.tsx
+++ b/torchci/components/benchmark_v3/configs/configurations.tsx
@@ -32,10 +32,13 @@ import {
   VllmBenchmarkDashboardConfig,
 } from "./teams/vllm/config";
 import {
+  PYTORCH_X_VLLM_AGGREGATE_BENCHMARK_ID,
+  VllmXPytorchBenchmarkAggregatedConfig,
+} from "./teams/vllm/pytoch_x_vllm_agg_config";
+import {
   PYTORCH_X_VLLM_BENCHMARK_ID,
   PytorchXVllmBenchmarkDashboardConfig,
 } from "./teams/vllm/pytorch_x_vllm_config";
-import { PYTORCH_X_VLLM_AGGREGATE_BENCHMARK_ID, VllmXPytorchBenchmarkAggregatedConfig } from "./teams/vllm/pytoch_x_vllm_agg_config";
 
 export const REPORT_ID_TO_BENCHMARK_ID_MAPPING: Record<string, string> = {
   compiler_regression: "compiler_inductor",

--- a/torchci/components/benchmark_v3/configs/configurations.tsx
+++ b/torchci/components/benchmark_v3/configs/configurations.tsx
@@ -186,6 +186,10 @@ export const BENCHMARK_CATEGORIES: BenchmarkCategoryGroup[] = [
             type: "regression_report",
             href: `/benchmark/regression/reports/${PYTORCH_X_VLLM_BENCHMARK_ID}`,
           },
+          {
+            label: "Aggregated Dashboard",
+            href: `/benchmark/v3/aggregate/${PYTORCH_X_VLLM_AGGREGATE_BENCHMARK_ID}`,
+          },
         ],
       },
       {

--- a/torchci/components/benchmark_v3/configs/configurations.tsx
+++ b/torchci/components/benchmark_v3/configs/configurations.tsx
@@ -35,6 +35,7 @@ import {
   PYTORCH_X_VLLM_BENCHMARK_ID,
   PytorchXVllmBenchmarkDashboardConfig,
 } from "./teams/vllm/pytorch_x_vllm_config";
+import { PYTORCH_X_VLLM_AGGREGATE_BENCHMARK_ID, VllmXPytorchBenchmarkAggregatedConfig } from "./teams/vllm/pytoch_x_vllm_agg_config";
 
 export const REPORT_ID_TO_BENCHMARK_ID_MAPPING: Record<string, string> = {
   compiler_regression: "compiler_inductor",
@@ -46,6 +47,9 @@ export const PREDEFINED_BENCHMARK_CONFIG: BenchmarkConfigMap = {
   },
   [PYTORCH_X_VLLM_BENCHMARK_ID]: {
     [BenchmarkPageType.DashboardPage]: PytorchXVllmBenchmarkDashboardConfig,
+  },
+  [PYTORCH_X_VLLM_AGGREGATE_BENCHMARK_ID]: {
+    [BenchmarkPageType.AggregatePage]: VllmXPytorchBenchmarkAggregatedConfig,
   },
   [COMPILTER_PRECOMPUTE_BENCHMARK_ID]: {
     [BenchmarkPageType.AggregatePage]: CompilerPrecomputeBenchmarkUIConfig,
@@ -78,6 +82,11 @@ export const BENCHMARK_ID_MAPPING: Record<string, BenchmarkIdMappingItem> = {
   },
   [PYTORCH_X_VLLM_BENCHMARK_ID]: {
     id: PYTORCH_X_VLLM_BENCHMARK_ID,
+    repoName: "pytorch/pytorch",
+    benchmarkName: "PyTorch x vLLM benchmark",
+  },
+  [PYTORCH_X_VLLM_AGGREGATE_BENCHMARK_ID]: {
+    id: PYTORCH_X_VLLM_AGGREGATE_BENCHMARK_ID,
     repoName: "pytorch/pytorch",
     benchmarkName: "PyTorch x vLLM benchmark",
   },

--- a/torchci/components/benchmark_v3/configs/helpers/configRegistration.tsx
+++ b/torchci/components/benchmark_v3/configs/helpers/configRegistration.tsx
@@ -2,13 +2,13 @@ import React from "react";
 import { CompilerPrecomputeConfirmDialogContent } from "../teams/compilers/CompilerPrecomputeConfirmDialogContent";
 import { CompilerSearchBarDropdowns } from "../teams/compilers/CompilerSearchBarDropdowns";
 import { compilerQueryParameterConverter } from "../teams/compilers/config";
-import { QueryParameterConverter } from "../utils/dataBindingRegistration";
 import { VllmPrecomputeConfirmDialogContent } from "../teams/vllm/VllmPrecomputeConfirmDialogContent";
+import { QueryParameterConverter } from "../utils/dataBindingRegistration";
 
 export const COMPONENT_REGISTRY: Record<string, React.ComponentType<any>> = {
   CompilerSearchBarDropdowns,
   CompilerPrecomputeConfirmDialogContent,
-  VllmPrecomputeConfirmDialogContent
+  VllmPrecomputeConfirmDialogContent,
 };
 
 // register converters for data params, this is

--- a/torchci/components/benchmark_v3/configs/helpers/configRegistration.tsx
+++ b/torchci/components/benchmark_v3/configs/helpers/configRegistration.tsx
@@ -3,10 +3,12 @@ import { CompilerPrecomputeConfirmDialogContent } from "../teams/compilers/Compi
 import { CompilerSearchBarDropdowns } from "../teams/compilers/CompilerSearchBarDropdowns";
 import { compilerQueryParameterConverter } from "../teams/compilers/config";
 import { QueryParameterConverter } from "../utils/dataBindingRegistration";
+import { VllmPrecomputeConfirmDialogContent } from "../teams/vllm/VllmPrecomputeConfirmDialogContent";
 
 export const COMPONENT_REGISTRY: Record<string, React.ComponentType<any>> = {
   CompilerSearchBarDropdowns,
   CompilerPrecomputeConfirmDialogContent,
+  VllmPrecomputeConfirmDialogContent
 };
 
 // register converters for data params, this is

--- a/torchci/components/benchmark_v3/configs/teams/vllm/VllmPrecomputeConfirmDialogContent.tsx
+++ b/torchci/components/benchmark_v3/configs/teams/vllm/VllmPrecomputeConfirmDialogContent.tsx
@@ -1,6 +1,5 @@
 import { List } from "@mui/material";
 import { Box } from "@mui/system";
-import { DISPLAY_NAMES_TO_COMPILER_NAMES } from "components/benchmark/compilers/common";
 import { highlightUntilClick } from "components/benchmark_v3/components/common/highlight";
 import {
   getElementById,

--- a/torchci/components/benchmark_v3/configs/teams/vllm/VllmPrecomputeConfirmDialogContent.tsx
+++ b/torchci/components/benchmark_v3/configs/teams/vllm/VllmPrecomputeConfirmDialogContent.tsx
@@ -1,0 +1,167 @@
+import { List } from "@mui/material";
+import { Box } from "@mui/system";
+import { DISPLAY_NAMES_TO_COMPILER_NAMES } from "components/benchmark/compilers/common";
+import { highlightUntilClick } from "components/benchmark_v3/components/common/highlight";
+import {
+  getElementById,
+  navigateToDataGrid,
+  navigateToEchartInGroup,
+  scrollingToElement,
+} from "components/benchmark_v3/components/common/navigate";
+import { TimeSeriesChartDialogContentProps } from "components/benchmark_v3/components/common/SelectionDialog";
+import { NavListItem } from "components/benchmark_v3/components/common/styledComponents";
+import { toToggleSectionId } from "components/benchmark_v3/components/common/ToggleSection";
+import { toBenchmarkTimeseriesChartGroupId } from "components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/BenchmarkTimeSeriesChartGroup";
+import { toBenchmarkTimeseriesChartSectionId } from "components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/BenchmarkTimeSeriesChartSection";
+import { toBenchamrkTimeSeriesComparisonTableId } from "components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesComparisonSection/BenchmarkTimeSeriesComparisonTableSection";
+import { BenchmarkCommitMeta } from "lib/benchmark/store/benchmark_regression_store";
+import { stateToQuery } from "lib/helpers/urlQuery";
+import { NextRouter, useRouter } from "next/router";
+/**
+ * Customized dialog content for compiler precompute benchmark page.
+ * if parent is timeSeriesChart, we will show the following options:
+ *  1. Navigate to the time series comparison table section on this page.
+ *  2. Navigate to the legacy benchmark data page.
+ *
+ * if parent is comparisonTable, we will show the following options:
+ * 1. Navigate to the time series chart section on this page.
+ * 2. Navigate to the legacy benchmark data page.
+ *
+ * the option 2 will be replaced by new raw data page in the future.
+ * @returns
+ */
+export const VllmPrecomputeConfirmDialogContent: React.FC<
+  TimeSeriesChartDialogContentProps
+> = ({ left, right, other, closeDialog, triggerUpdate }) => {
+  const router = useRouter();
+  if (left == null || right == null) {
+    return (
+      <Box>
+        Can&apos;t provide options whent at least one value (left|right) is
+        missing
+      </Box>
+    );
+  }
+  const onGoToTable = async () => {
+    closeDialog();
+    const toggleSectonId = toToggleSectionId(3);
+    const elToggle = getElementById(toggleSectonId);
+    if (!elToggle) {
+      console.warn(`can't find the toggle section with id: {${toggleSectonId}`);
+      return;
+    }
+
+    const tableId = toBenchamrkTimeSeriesComparisonTableId(
+      `metric=${left.metric}`
+    );
+
+    const table = getElementById(tableId);
+    // if the table is not exist,scroll to the toggle section
+    if (!table) {
+      scrollingToElement(elToggle);
+      triggerUpdate();
+      return;
+    }
+    const cell = await navigateToDataGrid(
+      tableId,
+      [`${left?.compiler}|`],
+      `${left?.metric}`,
+      toggleSectonId
+    );
+
+    if (cell) {
+      highlightUntilClick(cell);
+    }
+    triggerUpdate();
+  };
+
+  const onGoToChart = async () => {
+    closeDialog();
+
+    const cell = await navigateToEchartInGroup(
+      toBenchmarkTimeseriesChartSectionId(`suite=${left.suite}`),
+      toBenchmarkTimeseriesChartGroupId(`metric=${left.metric}`),
+      toToggleSectionId(2)
+    );
+
+    if (cell) {
+      highlightUntilClick(cell);
+      triggerUpdate();
+    } else {
+      triggerUpdate();
+    }
+  };
+
+  const onGoToUrl = () => {
+    closeDialog();
+    triggerUpdate();
+    // const url = toBenchmarkLegacyUrl(left, right);
+    const url = toBenchmarkDashboardUrl(left, right, router);
+    window.open(url, "_blank");
+  };
+
+  return (
+    <List>
+      {other?.parent === "timeSeriesChart" && (
+        <NavListItem
+          primary="Navigate to comparison table"
+          secondary="Jump to the time series comparison table section on this page."
+          onClick={onGoToTable}
+        />
+      )}
+      {other?.parent === "comparisonTable" && (
+        <NavListItem
+          primary="Navigate to time series chart"
+          secondary="Jump to the comparison table section on this page."
+          onClick={onGoToChart}
+        />
+      )}
+      <NavListItem
+        primary="Navigate to detail view"
+        secondary={`Open the detail view for suite "${left?.suite}" and compiler "${left?.compiler}" in the compiler dashboard.`}
+        onClick={onGoToUrl}
+      />
+    </List>
+  );
+};
+
+function toBenchmarkDashboardUrl(left: any, right: any, router: NextRouter) {
+  const pathname = "/benchmark/v3/dashboard/pytorch_x_vllm_benchmark";
+  const lcommit: BenchmarkCommitMeta = {
+    commit: left.commit,
+    branch: left.branch,
+    workflow_id: left.workflow_id,
+    date: left.granularity_bucket,
+  };
+  const rcommit: BenchmarkCommitMeta = {
+    commit: right.commit,
+    branch: right.branch,
+    workflow_id: right.workflow_id,
+    date: right.granularity_bucket,
+  };
+
+  const filters = {
+    model: left?.model,
+    modelCategory: left?.modelCategory,
+  };
+
+  const reformattedPrams = stateToQuery({
+    lcommit,
+    rcommit,
+    filters,
+  });
+
+  const nextDashboardMainQuery = {
+    ...router.query, // keep existing params like lcommit, rcommit
+    ...reformattedPrams,
+    renderGroupId: "main",
+  };
+  const params = new URLSearchParams(
+    Object.entries(nextDashboardMainQuery)
+      .filter(([_, v]) => v != null && v !== "")
+      .map(([k, v]) => [k, String(v)])
+  );
+
+  const url = `${pathname}?${params.toString()}`;
+  return url;
+}

--- a/torchci/components/benchmark_v3/configs/teams/vllm/VllmPrecomputeConfirmDialogContent.tsx
+++ b/torchci/components/benchmark_v3/configs/teams/vllm/VllmPrecomputeConfirmDialogContent.tsx
@@ -17,7 +17,7 @@ import { BenchmarkCommitMeta } from "lib/benchmark/store/benchmark_regression_st
 import { stateToQuery } from "lib/helpers/urlQuery";
 import { NextRouter, useRouter } from "next/router";
 /**
- * Customized dialog content for compiler precompute benchmark page.
+ * Customized dialog content for vllm precompute benchmark page.
  * if parent is timeSeriesChart, we will show the following options:
  *  1. Navigate to the time series comparison table section on this page.
  *  2. Navigate to the legacy benchmark data page.
@@ -50,9 +50,7 @@ export const VllmPrecomputeConfirmDialogContent: React.FC<
       return;
     }
 
-    const tableId = toBenchamrkTimeSeriesComparisonTableId(
-      `metric=${left.metric}`
-    );
+    const tableId = toBenchamrkTimeSeriesComparisonTableId(`__ALL__`);
 
     const table = getElementById(tableId);
     // if the table is not exist,scroll to the toggle section
@@ -63,7 +61,7 @@ export const VllmPrecomputeConfirmDialogContent: React.FC<
     }
     const cell = await navigateToDataGrid(
       tableId,
-      [`${left?.compiler}|`],
+      [`${left?.device}`],
       `${left?.metric}`,
       toggleSectonId
     );
@@ -78,7 +76,7 @@ export const VllmPrecomputeConfirmDialogContent: React.FC<
     closeDialog();
 
     const cell = await navigateToEchartInGroup(
-      toBenchmarkTimeseriesChartSectionId(`suite=${left.suite}`),
+      toBenchmarkTimeseriesChartSectionId(`__ALL__`),
       toBenchmarkTimeseriesChartGroupId(`metric=${left.metric}`),
       toToggleSectionId(2)
     );

--- a/torchci/components/benchmark_v3/configs/teams/vllm/pytoch_x_vllm_agg_config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/vllm/pytoch_x_vllm_agg_config.ts
@@ -19,7 +19,7 @@ const CHART_METADATA_COLUMNS = [
 export const VllmXPytorchBenchmarkAggregatedConfig: BenchmarkUIConfig = {
   benchmarkId: PYTORCH_X_VLLM_AGGREGATE_BENCHMARK_ID,
   apiId: PYTORCH_X_VLLM_AGGREGATE_BENCHMARK_ID,
-  title: "Compiler Inductor Regression Tracking",
+  title:"Vllm x Pytorch Regression Tracking",
   type: "aggregate",
   dataBinding: {
     initial: {

--- a/torchci/components/benchmark_v3/configs/teams/vllm/pytoch_x_vllm_agg_config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/vllm/pytoch_x_vllm_agg_config.ts
@@ -1,0 +1,103 @@
+import { BenchmarkUIConfig } from "../../config_book_types";
+import { DEFAULT_DASHBOARD_BENCHMARK_INITIAL } from "../defaults/default_dashboard_config";
+
+export const PYTORCH_X_VLLM_AGGREGATE_BENCHMARK_ID = "pytroch_x_vllm_aggregated";
+
+const CHART_METADATA_COLUMNS = [
+  {
+    field: "geomean_compiled",
+    displayName: "Use Compile Geomean",
+  },
+  {
+    field: "geomean_non_compiled",
+    displayName: "Use Non-Compile Geomean",
+  }
+] as const;
+
+// main config for the compiler benchmark regression page
+export const VllmXPytorchBenchmarkAggregatedConfig: BenchmarkUIConfig = {
+  benchmarkId: PYTORCH_X_VLLM_AGGREGATE_BENCHMARK_ID,
+  apiId: PYTORCH_X_VLLM_AGGREGATE_BENCHMARK_ID,
+  title: "Compiler Inductor Regression Tracking",
+  type: "aggregate",
+dataBinding: {
+    initial: {
+      ...DEFAULT_DASHBOARD_BENCHMARK_INITIAL,
+      benchmarkId: PYTORCH_X_VLLM_AGGREGATE_BENCHMARK_ID,
+      filters: {
+        device: "cuda",
+        arch: "NVIDIA H100 80GB HBM3",
+        deviceName: "cuda||NVIDIA H100 80GB HBM3",
+    },
+
+    },
+    required_filter_fields: [],
+  },
+  dataRender: {
+    type: "fanout",
+    sideRender: {},
+    renders: [
+      {
+        type: "FanoutBenchmarkComparisonGithubExternalLink",
+        title: "Github Link (external)",
+        config: {
+          description: "See original github runs for left and right runs",
+        },
+      },
+      {
+        type: "FanoutBenchmarkTimeSeriesChartSection",
+        title: "Time Series Chart Section",
+        config: {
+          groupByFields: [],
+          chartGroup: {
+            type: "line",
+            groupByFields: ["metric"],
+            lineKey: ["device","arch", "branch"],
+            chart: {
+              enableDialog: true,
+              customizedConfirmDialog: {
+                type: "component",
+                id: "VllmPrecomputeConfirmDialogContent",
+              },
+              renderOptions: {
+                chartRenderBook: {},
+                showLegendDetails: true,
+                additionalMetadataList:["geomean_compiled", "geomean_non_compiled"],
+                title_group_mapping: {},
+              },
+            },
+          },
+        },
+      },
+      {
+        type: "FanoutBenchmarkTimeSeriesComparisonTableSection",
+        title: "Time Series Comparison Table Section",
+        config: {
+          groupByFields: [],
+          filterByFieldValues: {
+            metric: [],
+          },
+          renderOptions: {
+            dynamicSize: {lg: 12}
+
+          },
+          tableConfig: {
+            primary: {
+            },
+            customizedConfirmDialog: {
+              type: "component",
+              id: "VllmPrecomputeConfirmDialogContent",
+            },
+            enableDialog: true,
+            targetField: "metric",
+            comparisonPolicy: {},
+            renderOptions: {
+              tableRenderingBook: {},
+              renderMissing: true,
+            },
+          },
+        },
+      },
+    ],
+  },
+};

--- a/torchci/components/benchmark_v3/configs/teams/vllm/pytoch_x_vllm_agg_config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/vllm/pytoch_x_vllm_agg_config.ts
@@ -19,7 +19,7 @@ const CHART_METADATA_COLUMNS = [
 export const VllmXPytorchBenchmarkAggregatedConfig: BenchmarkUIConfig = {
   benchmarkId: PYTORCH_X_VLLM_AGGREGATE_BENCHMARK_ID,
   apiId: PYTORCH_X_VLLM_AGGREGATE_BENCHMARK_ID,
-  title:"Vllm x Pytorch Regression Tracking",
+  title: "Vllm x Pytorch Regression Tracking",
   type: "aggregate",
   dataBinding: {
     initial: {

--- a/torchci/components/benchmark_v3/configs/teams/vllm/pytoch_x_vllm_agg_config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/vllm/pytoch_x_vllm_agg_config.ts
@@ -1,7 +1,8 @@
 import { BenchmarkUIConfig } from "../../config_book_types";
 import { DEFAULT_DASHBOARD_BENCHMARK_INITIAL } from "../defaults/default_dashboard_config";
 
-export const PYTORCH_X_VLLM_AGGREGATE_BENCHMARK_ID = "pytroch_x_vllm_aggregated";
+export const PYTORCH_X_VLLM_AGGREGATE_BENCHMARK_ID =
+  "pytroch_x_vllm_aggregated";
 
 const CHART_METADATA_COLUMNS = [
   {
@@ -11,7 +12,7 @@ const CHART_METADATA_COLUMNS = [
   {
     field: "geomean_non_compiled",
     displayName: "Use Non-Compile Geomean",
-  }
+  },
 ] as const;
 
 // main config for the compiler benchmark regression page
@@ -20,7 +21,7 @@ export const VllmXPytorchBenchmarkAggregatedConfig: BenchmarkUIConfig = {
   apiId: PYTORCH_X_VLLM_AGGREGATE_BENCHMARK_ID,
   title: "Compiler Inductor Regression Tracking",
   type: "aggregate",
-dataBinding: {
+  dataBinding: {
     initial: {
       ...DEFAULT_DASHBOARD_BENCHMARK_INITIAL,
       benchmarkId: PYTORCH_X_VLLM_AGGREGATE_BENCHMARK_ID,
@@ -28,8 +29,7 @@ dataBinding: {
         device: "cuda",
         arch: "NVIDIA H100 80GB HBM3",
         deviceName: "cuda||NVIDIA H100 80GB HBM3",
-    },
-
+      },
     },
     required_filter_fields: [],
   },
@@ -52,7 +52,7 @@ dataBinding: {
           chartGroup: {
             type: "line",
             groupByFields: ["metric"],
-            lineKey: ["device","arch", "branch"],
+            lineKey: ["device", "arch", "branch"],
             chart: {
               enableDialog: true,
               customizedConfirmDialog: {
@@ -62,7 +62,10 @@ dataBinding: {
               renderOptions: {
                 chartRenderBook: {},
                 showLegendDetails: true,
-                additionalMetadataList:["geomean_compiled", "geomean_non_compiled"],
+                additionalMetadataList: [
+                  "geomean_compiled",
+                  "geomean_non_compiled",
+                ],
                 title_group_mapping: {},
               },
             },
@@ -78,12 +81,10 @@ dataBinding: {
             metric: [],
           },
           renderOptions: {
-            dynamicSize: {lg: 12}
-
+            dynamicSize: { lg: 12 },
           },
           tableConfig: {
-            primary: {
-            },
+            primary: {},
             customizedConfirmDialog: {
               type: "component",
               id: "VllmPrecomputeConfirmDialogContent",

--- a/torchci/lib/benchmark/api_helper/backend/dataFetchers/fetchers.ts
+++ b/torchci/lib/benchmark/api_helper/backend/dataFetchers/fetchers.ts
@@ -4,6 +4,8 @@ import {
   PytorchHelionDataFetcher,
   PytorchOperatorMicroBenchmarkDataFetcher,
   VllmBenchmarkDataFetcher,
+  VllmXPytorchBenchmarkAggregatedDataFetcher,
+  VllmXPytorchBenchmarkDataFetcher,
 } from "./queryBuilderUtils/benchmarkDataQueryBuilder";
 import {
   BenchmarkListCommitQueryBuilder,
@@ -14,6 +16,7 @@ import {
   BenchmarkMetadataQuery,
   PytorchOperatorMicrobenchmarkMetadataFetcher,
   TorchAoMicrobApienchmarkMetadataFetcher,
+  VllmAggregateBenchmarkMetadataFetcher,
   VllmBenchmarkMetadataFetcher,
 } from "./queryBuilderUtils/listMetadataQueryBuilder";
 import {
@@ -28,7 +31,8 @@ const dataCtors: Record<string, new () => BenchmarkDataFetcher> = {
   pytorch_helion: PytorchHelionDataFetcher,
   torchao_micro_api_benchmark: PytorchAoMicroApiBenchmarkDataFetcher,
   vllm_benchmark: VllmBenchmarkDataFetcher,
-  pytorch_x_vllm_benchmark: VllmBenchmarkDataFetcher,
+  pytorch_x_vllm_benchmark: VllmXPytorchBenchmarkDataFetcher,
+  pytroch_x_vllm_aggregated: VllmXPytorchBenchmarkAggregatedDataFetcher,
   default: BenchmarkDataQuery,
 };
 
@@ -38,6 +42,7 @@ const metaCtors: Record<string, new () => BenchmarkMetadataFetcher> = {
   torchao_micro_api_benchmark: TorchAoMicrobApienchmarkMetadataFetcher,
   vllm_benchmark: VllmBenchmarkMetadataFetcher,
   pytorch_x_vllm_benchmark: VllmBenchmarkMetadataFetcher,
+  pytroch_x_vllm_aggregated: VllmAggregateBenchmarkMetadataFetcher,
   default: BenchmarkMetadataQuery,
 };
 
@@ -46,6 +51,7 @@ const listCommitsCtors: Record<string, new () => BenchmarkListCommitFetcher> = {
   pytorch_operator_microbenchmark: PytorchOperatorMicroListCommitsDataFetcher,
   vllm_benchmark: VllmListCommitsDataFetcher,
   pytorch_x_vllm_benchmark: VllmListCommitsDataFetcher,
+  pytroch_x_vllm_aggregated: VllmListCommitsDataFetcher,
   default: BenchmarkListCommitQueryBuilder,
 };
 

--- a/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/benchmarkDataQueryBuilder.ts
+++ b/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/benchmarkDataQueryBuilder.ts
@@ -976,22 +976,13 @@ export class VllmXPytorchBenchmarkAggregatedDataFetcher extends VllmXPytorchBenc
       d.granularity_bucket = workflowBucketMap.get(wfId);
     });
 
-    console.log("data", data.length);
-
     // Filter to only allowed metrics
     const filteredData = data.filter((d) =>
       VllmXPytorchBenchmarkAggregatedDataFetcher.ALLOWED_METRICS.has(d.metric)
     );
-
-    console.log("filteredData", filteredData.length);
-
     // Aggregate data by computing geomean speedup (use_compile=true vs false)
     const aggregatedData = this.aggregateData(filteredData);
-
-    console.log("aggregatedData", aggregatedData.length);
-
     const resp = super.applyFormat(aggregatedData, formats, false);
-
     // Apply the standard format using the parent's format method
     return resp;
   }
@@ -1091,10 +1082,10 @@ export class VllmXPytorchBenchmarkAggregatedDataFetcher extends VllmXPytorchBenc
         if (item.model) models.add(item.model);
       });
 
-      console.log("key", key);
-      console.log("compiledValues", compiledValues);
-      console.log("nonCompiledValues", nonCompiledValues);
-      console.log("Models", Array.from(models));
+      //console.log("key", key);
+      //console.log("compiledValues", compiledValues);
+      //console.log("nonCompiledValues", nonCompiledValues);
+      //console.log("Models", Array.from(models));
 
       const aggregatedRecord = {
         commit: template.commit,

--- a/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/benchmarkDataQueryBuilder.ts
+++ b/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/benchmarkDataQueryBuilder.ts
@@ -993,7 +993,7 @@ export class VllmXPytorchBenchmarkAggregatedDataFetcher extends VllmXPytorchBenc
     const resp = super.applyFormat(aggregatedData, formats, false);
 
     // Apply the standard format using the parent's format method
-    return resp
+    return resp;
   }
 
   /**
@@ -1006,7 +1006,7 @@ export class VllmXPytorchBenchmarkAggregatedDataFetcher extends VllmXPytorchBenc
     // Group by all keys EXCEPT use_compile
     const groupMap = new Map<
       string,
-      { compiled: any[]; nonCompiled: any[]; template: any}
+      { compiled: any[]; nonCompiled: any[]; template: any }
     >();
 
     data.forEach((d) => {
@@ -1044,7 +1044,6 @@ export class VllmXPytorchBenchmarkAggregatedDataFetcher extends VllmXPytorchBenc
       const compiledValues = compiled
         .map((item) => item.value)
         .filter((v) => v != null && v >= 0);
-
 
       // Get values for non-compiled (use_compile=false)
       const nonCompiledValues = nonCompiled
@@ -1092,10 +1091,10 @@ export class VllmXPytorchBenchmarkAggregatedDataFetcher extends VllmXPytorchBenc
         if (item.model) models.add(item.model);
       });
 
-      console.log("key",key);
-      console.log("compiledValues",compiledValues);
-      console.log("nonCompiledValues",nonCompiledValues);
-      console.log("Models",Array.from(models));
+      console.log("key", key);
+      console.log("compiledValues", compiledValues);
+      console.log("nonCompiledValues", nonCompiledValues);
+      console.log("Models", Array.from(models));
 
       const aggregatedRecord = {
         commit: template.commit,

--- a/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/listMetadataQueryBuilder.ts
+++ b/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/listMetadataQueryBuilder.ts
@@ -325,3 +325,66 @@ export class VllmBenchmarkMetadataFetcher
     return this._data_query.toQueryParams(inputs);
   }
 }
+
+export class VllmAggregateBenchmarkMetadataFetcher
+  extends ExecutableQueryBase
+  implements BenchmarkMetadataFetcher
+{
+  private _data_query: BenchmarkMetadataQuery;
+
+  constructor() {
+    super();
+    this._data_query = new BenchmarkMetadataQuery();
+  }
+
+  postProcess(data: any[]) {
+    let li = getDefaultBenchmarkMetadataGroup(data);
+
+    // Remove the default option for device
+    const deviceItem = li.find(
+      (item) => item.type === BenchmarkMetadataType.DeviceName
+    );
+    if (deviceItem && deviceItem.options.length > 0) {
+      // Remove the first option (default option with empty value)
+      deviceItem.options = deviceItem.options.filter(
+        (opt) => opt.value !== ""
+      );
+      // Set initial value to first available option if exists
+      if (deviceItem.options.length > 0) {
+        deviceItem.initialValue = deviceItem.options[0].value;
+      }
+    }
+
+    const item = makeMetadataItem(
+      data,
+      "model_category",
+      BenchmarkMetadataType.ModelCategory,
+      { displayName: "All families", value: "" },
+      "Model Category",
+      "",
+      (r) => {
+        const splitted = r.model.split("/");
+        let value = undefined;
+        if (splitted.length > 1) {
+          value = splitted[0];
+        }
+        return {
+          value: value,
+          displayName: value,
+        };
+      }
+    );
+    if (item) {
+      li.push(item);
+    }
+    return li;
+  }
+
+  build() {
+    return this._data_query.build();
+  }
+
+  toQueryParams(inputs: any) {
+    return this._data_query.toQueryParams(inputs);
+  }
+}

--- a/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/listMetadataQueryBuilder.ts
+++ b/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/listMetadataQueryBuilder.ts
@@ -346,9 +346,7 @@ export class VllmAggregateBenchmarkMetadataFetcher
     );
     if (deviceItem && deviceItem.options.length > 0) {
       // Remove the first option (default option with empty value)
-      deviceItem.options = deviceItem.options.filter(
-        (opt) => opt.value !== ""
-      );
+      deviceItem.options = deviceItem.options.filter((opt) => opt.value !== "");
       // Set initial value to first available option if exists
       if (deviceItem.options.length > 0) {
         deviceItem.initialValue = deviceItem.options[0].value;

--- a/torchci/pages/benchmark/v3/aggregate/[id].tsx
+++ b/torchci/pages/benchmark/v3/aggregate/[id].tsx
@@ -1,0 +1,13 @@
+import { Alert } from "@mui/material";
+import BenchmarkDashboardPage from "components/benchmark_v3/pages/BenchmarkDashboardPage";
+import { useRouter } from "next/router";
+
+export default function Page() {
+  const router = useRouter();
+  const { id } = router.query;
+  const type = "aggregate";
+  if (!id) {
+    return <Alert severity="error">Cannot find the page </Alert>;
+  }
+  return <BenchmarkDashboardPage benchmarkId={id as string} type={type} />;
+}


### PR DESCRIPTION
# OVERVIEW
Add aggreagte view for vllm x pytorch:

Calculate compiled and non_compiled geomean speedup for
- Median x (itl, tpot, ttft)
- Latency
- Throughput

## Cleaning
Split vllmxpytorch seperately with the pytochxvllm since the data are not same

## Additional UI change due to the vllm x pytorch improvement
- Add page for aggregagte view with id (before it's only for compiler)
- Add additionalMetadataList to the time series chart for non key rendering
- Add dynamicSize to table section for resize option
## Demo
https://torchci-git-aggredashvllm-fbopensource.vercel.app/benchmark/v3/aggregate/pytroch_x_vllm_aggregated


snapshot
<img width="1634" height="908" alt="image" src="https://github.com/user-attachments/assets/c985ad6e-9549-490e-98d6-3b5ecb25482b" />


search and find in the list
<img width="429" height="382" alt="image" src="https://github.com/user-attachments/assets/6f37f0f9-c489-4611-b13c-1301cf1204b6" />
