### PR TITLE
Remove conda-forge from free threaded python installation for py 3.14

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -150,6 +150,8 @@ runs:
               "python=${PYTHON_VERSION}" \
               cmake=3.31.2 \
               ninja=1.12.1 \
+              libwebp \
+              libpng \
               pkg-config=0.29 \
               wheel=0.37  \
               ${CONDA_EXTRA_PARAM}


### PR DESCRIPTION
Package is relatively new, since Oct 25 available for 3.14 only https://anaconda.org/channels/main/packages/python-freethreading/overview

For vision 3.13t failures see: https://github.com/pytorch/vision/pull/9391