### PR TITLE
Add m8g.metal-24xl as CI runner

### DIFF
--- a/.github/canary-scale-config.yml
+++ b/.github/canary-scale-config.yml
@@ -277,6 +277,11 @@ runner_types:
     instance_type: m7g.metal
     is_ephemeral: true
     os: linux
+  c.linux.arm64.m8g.metal-24xl:
+    disk_size: 256
+    instance_type: m8g.metal-24xl
+    is_ephemeral: true
+    os: linux
   c.windows.g4dn.xlarge:
     disk_size: 256
     instance_type: g4dn.xlarge

--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -277,6 +277,11 @@ runner_types:
     instance_type: m7g.metal
     is_ephemeral: true
     os: linux
+  lf.c.linux.arm64.m8g.metal-24xl:
+    disk_size: 256
+    instance_type: m8g.metal-24xl
+    is_ephemeral: true
+    os: linux
   lf.c.windows.g4dn.xlarge:
     disk_size: 256
     instance_type: g4dn.xlarge

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -277,6 +277,11 @@ runner_types:
     instance_type: m7g.metal
     is_ephemeral: true
     os: linux
+  lf.linux.arm64.m8g.metal-24xl:
+    disk_size: 256
+    instance_type: m8g.metal-24xl
+    is_ephemeral: true
+    os: linux
   lf.windows.g4dn.xlarge:
     disk_size: 256
     instance_type: g4dn.xlarge

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -273,6 +273,11 @@ runner_types:
     instance_type: m7g.metal
     is_ephemeral: true
     os: linux
+  linux.arm64.m8g.metal-24xl:
+    disk_size: 256
+    instance_type: m8g.metal-24xl
+    is_ephemeral: true
+    os: linux
   windows.g4dn.xlarge:
     disk_size: 256
     instance_type: g4dn.xlarge


### PR DESCRIPTION
## Summary
This PR adds support for the `m8g.metal-24xl` instance type as a new Linux AArch64 self-hosted CI runner.

The configuration mirrors the existing `m7g.metal` runner setup and enables provisioning of Graviton4-based bare-metal instances for CI workloads.

## Changes

+ Add linux.arm64.m8g.metal-24xl entry to scale-config.yml
+ Regenerated derived scale configuration via:
```
python .github/scripts/validate_scale_config.py --generate
```
Which led to other related yaml files changes as show in this PR.

cc: @aditew01 @robert-hardwick @nikhil-arm 