### PR TITLE
[cherry-pick] Fix 3.14 domain build (#7774)

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -134,9 +134,6 @@ runs:
               export PYTHON_VERSION=3.14
               export CONDA_EXTRA_PARAM=" python-freethreading"
               ;;
-            3.14)
-              export CONDA_EXTRA_PARAM=" python-freethreading"
-              ;;
             3.13t)
               export PYTHON_VERSION=3.13
               # python-freethreading package for 3.13t only exist in conda-forge


### PR DESCRIPTION
Followup fix after https://github.com/pytorch/test-infra/pull/7769 this change force all 3.14 builds to be free-threaded which is not correct.