### PR TITLE
Support multi branch 

### DIFF
--- a/torchci/components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesComparisonSection/BenchmarkTimeSeriesSingleSlider.tsx
+++ b/torchci/components/benchmark_v3/components/dataRender/components/benchmarkTimeSeries/components/BenchmarkTimeSeriesComparisonSection/BenchmarkTimeSeriesSingleSlider.tsx
@@ -1,0 +1,112 @@
+import styled from "@emotion/styled";
+import { Box, Chip, Slider, Stack, Typography } from "@mui/material";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { shortSha } from "../../helper";
+
+export type WorkflowMetaInfo = {
+  workflow_id: string;
+  commit: string;
+  branch: string;
+  [k: string]: any;
+};
+
+const BenchmarkSlider = styled(Slider)(() => ({
+  "& .MuiSlider-valueLabelLabel": {
+    whiteSpace: "pre-line",
+    fontSize: 12,
+    lineHeight: 1.25,
+    padding: 0,
+    display: "block",
+  },
+}));
+
+export function BenchmarkTimeSeriesSingleSlider({
+  workflows,
+  onChange,
+  selectedWorkflowId,
+  label,
+}: {
+  workflows: WorkflowMetaInfo[];
+  onChange: (next: string) => void;
+  selectedWorkflowId?: string;
+  label: string;
+}) {
+  const { ids, byId } = useMemo(() => {
+    const byId: Record<string, WorkflowMetaInfo> = {};
+    workflows.forEach((it) => (byId[it.workflow_id] = it));
+    const ids = workflows.map((it) => it.workflow_id);
+    return { ids, byId };
+  }, [workflows]);
+
+  const [index, setIndex] = useState<number>(() => {
+    const n = workflows.length;
+    return n >= 1 ? 0 : 0;
+  });
+
+  useEffect(() => {
+    const n = ids.length;
+    if (n === 0) return;
+
+    const idx = selectedWorkflowId ? ids.indexOf(selectedWorkflowId) : -1;
+
+    if (idx >= 0) {
+      setIndex(idx);
+    } else {
+      setIndex(0);
+    }
+  }, [ids, selectedWorkflowId]);
+
+  function rangeLabelFormat(wfi: number) {
+    const wf = byId[ids[wfi]];
+    if (!wf) return "-";
+    const commit = wf.commit ? shortSha(wf.commit) : "";
+    return `${wf.workflow_id} (commit: ${commit})`;
+  }
+
+  function valueLabelFormat(idx: number) {
+    const wf = byId[ids[idx]];
+    if (!wf) return "";
+    return (
+      <Box sx={{ p: 0.5 }}>
+        <strong>WorkflowId: {wf.workflow_id}</strong>
+        <div>Commit: {shortSha(wf.commit)}</div>
+        <div>time: {wf.date}</div>
+        <div>branch: {wf.branch}</div>
+      </Box>
+    );
+  }
+
+  const handleChange = useCallback(
+    (_e: Event, value: number | number[]) => {
+      if (typeof value === "number") {
+        setIndex(value);
+        onChange(ids[value]);
+      }
+    },
+    [ids, onChange]
+  );
+
+  const minWidth = Math.min(200, 50 * ids.length);
+
+  return (
+    <Box sx={{ p: 2, width: "100%", minWidth }}>
+      <Typography variant="subtitle1" gutterBottom>
+        Select {label}
+      </Typography>
+      <Stack direction="row" alignItems="center" spacing={2}>
+        <Chip label={`${label}: ${rangeLabelFormat(index)}`} />
+        <Box sx={{ flex: 1, px: 2 }}>
+          <BenchmarkSlider
+            value={index}
+            onChange={handleChange}
+            min={0}
+            max={Math.max(0, ids.length - 1)}
+            step={1}
+            valueLabelDisplay="auto"
+            valueLabelFormat={valueLabelFormat}
+          />
+        </Box>
+      </Stack>
+    </Box>
+  );
+}

--- a/torchci/components/benchmark_v3/components/dataRender/fanout/FanoutComponents.tsx
+++ b/torchci/components/benchmark_v3/components/dataRender/fanout/FanoutComponents.tsx
@@ -1,4 +1,5 @@
 import { FanoutComponentProps } from "components/benchmark_v3/configs/utils/fanoutRegistration";
+import { useDashboardSelector } from "lib/benchmark/store/benchmark_dashboard_provider";
 import BenchmarkChartSection from "../components/benchmarkTimeSeries/components/BenchmarkTimeSeriesChart/BenchmarkTimeSeriesChartSection";
 import { BenchmarkComparisonGithubExternalLink } from "../components/benchmarkTimeSeries/components/BenchmarkTimeSeriesComparisonSection/BenchmarkTimeSeriesComparisonTable/GithubExternalLink";
 import BenchmarkTimeSeriesComparisonTableSection from "../components/benchmarkTimeSeries/components/BenchmarkTimeSeriesComparisonSection/BenchmarkTimeSeriesComparisonTableSection";
@@ -52,6 +53,10 @@ export function FanoutBenchmarkTimeSeriesComparisonTableSection({
   lcommit,
   rcommit,
 }: FanoutComponentProps) {
+  const enableMultiBranchOption = useDashboardSelector(
+    (s) => s.enableMultiBranchOption
+  );
+
   return (
     <>
       <BenchmarkTimeSeriesComparisonTableSection
@@ -60,6 +65,7 @@ export function FanoutBenchmarkTimeSeriesComparisonTableSection({
         lcommit={lcommit ?? undefined}
         rcommit={rcommit ?? undefined}
         onChange={onChange}
+        enableMultiBranchOption={enableMultiBranchOption}
       />
     </>
   );

--- a/torchci/components/benchmark_v3/configs/teams/compilers/config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/compilers/config.ts
@@ -258,6 +258,7 @@ export const COMPILTER_PRECOMPUTE_BENCHMARK_INITIAL = {
   lbranch: "main",
   rbranch: "main",
   enableSamplingFeature: true,
+  enableMultiBranchOption: true,
   maxSampling: 110, // max number of job run results to show in the table, this avoid out of memory issue
 };
 


### PR DESCRIPTION
# Enable Multi Branch
Enable Multi Branch for both Inductor and Vllm Aggregated Dashboard.
The time series charts are automatically detected based on branch

### Improve the component
BenchmarkTimeSeriesComparisonTableSection support multi branch
one (two side) slider when it's single branch
two (single side) slideres when multi branch is selected and enabled

# Demo

<img width="1703" height="850" alt="image" src="https://github.com/user-attachments/assets/019855b1-45f6-440a-9062-646a9f83a303" />

https://torchci-git-elainewy-checkcheck-fbopensource.vercel.app/benchmark/compilers_regression
