### PR TITLE
Bump pip from 23.3 to 26.0 in tools/stronghold

### DIFF
--- a/tools/stronghold/requirements.txt
+++ b/tools/stronghold/requirements.txt
@@ -1,7 +1,7 @@
 black==22.10.0
 flake8==5.0.4
 mypy==0.990
-pip==23.3
+pip==26.0
 pytest==7.2.0
 PyYAML==6.0.2
 pathspec==0.12.1


### PR DESCRIPTION
## Summary
- Bumps `pip` from 23.3 to 26.0 in `tools/stronghold/requirements.txt`
- Fixes CVE-2026-1703 / GHSA-6vgw-5pg2-w6jp (severity: LOW)

## Deploy steps
- Merge PR; stronghold will pick up the new pinned version on next run

## Test steps
- `cd tools/stronghold && pip install -r requirements.txt` — verify pip 26.0 installs cleanly
- Run existing stronghold tests if any: `pytest tools/stronghold/`