### PR TITLE
Bump bytes to 1.11.1 in log-classifier

### DIFF
--- a/aws/lambda/log-classifier/Cargo.toml
+++ b/aws/lambda/log-classifier/Cargo.toml
@@ -16,7 +16,7 @@ rayon = "1.5.3"
 regex = "1.10.5"
 serde_json = "1.0.85"
 url = "2.2.2"
-bytes = "1.2.1"
+bytes = "1.11.1"
 toml = "0.5.9"
 native-tls = { version = "0.2.10", features = ["vendored"] }
 aws-config = "1.5.4"


### PR DESCRIPTION
## Summary
- Bumps `bytes` minimum version from 1.2.1 to 1.11.1 in `aws/lambda/log-classifier/Cargo.toml`
- Fixes GHSA-434x-w66g-qw3r (severity: MODERATE)
- **Note:** `Cargo.lock` needs regeneration — run `cd aws/lambda/log-classifier && cargo update -p bytes`

## Deploy steps
- Merge PR, then rebuild and redeploy the log-classifier Lambda

## Test steps
- `cd aws/lambda/log-classifier && cargo build` — verify it compiles
- `cd aws/lambda/log-classifier && cargo test` — run existing tests