### PR TITLE
Pin time >= 0.3.47 in log-classifier

### DIFF
--- a/aws/lambda/log-classifier/Cargo.toml
+++ b/aws/lambda/log-classifier/Cargo.toml
@@ -27,6 +27,7 @@ aws-sdk-bedrockruntime = "1.38.0"
 aws-smithy-runtime-api = "1.7.1"
 insta = { version = "1.20.0", features = ["redactions", "yaml"] }
 assert_unordered = "0.3.5"
+time = "0.3.47"
   [dependencies.serde]
   version = "1.0.144"
   features = [ "derive" ]


### PR DESCRIPTION
## Summary
- Adds explicit `time = "0.3.47"` dep to force transitive resolution to >= 0.3.47
- Fixes GHSA-r6v5-fh4h-64xc (severity: MODERATE)
- **Note:** `Cargo.lock` needs regeneration — run `cd aws/lambda/log-classifier && cargo update -p time`

## Deploy steps
- Merge PR, then rebuild and redeploy the log-classifier Lambda

## Test steps
- `cd aws/lambda/log-classifier && cargo build` — verify it compiles
- `cd aws/lambda/log-classifier && cargo test` — run existing tests