### PR TITLE
Update Lambdas to use NodeJS 22

### DIFF
--- a/terraform-aws-github-runner/.tflint.hcl
+++ b/terraform-aws-github-runner/.tflint.hcl
@@ -5,7 +5,7 @@ plugin "terraform" {
 
 plugin "aws" {
   enabled = true
-  version = "0.31.0"
+  version = "0.45.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/terraform-aws-github-runner/modules/download-lambda/.tflint.hcl
+++ b/terraform-aws-github-runner/modules/download-lambda/.tflint.hcl
@@ -5,7 +5,7 @@ plugin "terraform" {
 
 plugin "aws" {
   enabled = true
-  version = "0.31.0"
+  version = "0.45.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/terraform-aws-github-runner/modules/runner-binaries-syncer/.tflint.hcl
+++ b/terraform-aws-github-runner/modules/runner-binaries-syncer/.tflint.hcl
@@ -5,7 +5,7 @@ plugin "terraform" {
 
 plugin "aws" {
   enabled = true
-  version = "0.31.0"
+  version = "0.45.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/terraform-aws-github-runner/modules/runner-binaries-syncer/runner-binaries-syncer.tf
+++ b/terraform-aws-github-runner/modules/runner-binaries-syncer/runner-binaries-syncer.tf
@@ -9,7 +9,7 @@ resource "aws_lambda_function" "syncer" {
   function_name    = "${var.environment}-syncer"
   role             = aws_iam_role.syncer_lambda.arn
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs22.x"
   timeout          = var.lambda_timeout
   memory_size      = 500
 

--- a/terraform-aws-github-runner/modules/runners/.tflint.hcl
+++ b/terraform-aws-github-runner/modules/runners/.tflint.hcl
@@ -5,7 +5,7 @@ plugin "terraform" {
 
 plugin "aws" {
   enabled = true
-  version = "0.31.0"
+  version = "0.45.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/terraform-aws-github-runner/modules/runners/scale-down.tf
+++ b/terraform-aws-github-runner/modules/runners/scale-down.tf
@@ -21,7 +21,7 @@ resource "aws_lambda_function" "scale_down" {
   function_name     = "${var.environment}-scale-down"
   role              = aws_iam_role.scale_down.arn
   handler           = "index.scaleDown"
-  runtime           = "nodejs20.x"
+  runtime           = "nodejs22.x"
   timeout           = var.lambda_timeout_scale_down
   tags              = local.tags
   memory_size       = 2048

--- a/terraform-aws-github-runner/modules/runners/scale-up-chron.tf
+++ b/terraform-aws-github-runner/modules/runners/scale-up-chron.tf
@@ -22,7 +22,7 @@ resource "aws_lambda_function" "scale_up_chron" {
   function_name     = "${var.environment}-scale-up-chron"
   role              = aws_iam_role.scale_up_chron[0].arn
   handler           = "index.scaleUpChron"
-  runtime           = "nodejs20.x"
+  runtime           = "nodejs22.x"
   timeout           = var.lambda_timeout_scale_up_chron
   tags              = local.tags
   memory_size       = 2048

--- a/terraform-aws-github-runner/modules/runners/scale-up.tf
+++ b/terraform-aws-github-runner/modules/runners/scale-up.tf
@@ -21,7 +21,7 @@ resource "aws_lambda_function" "scale_up" {
   function_name                  = "${var.environment}-scale-up"
   role                           = aws_iam_role.scale_up.arn
   handler                        = "index.scaleUp"
-  runtime                        = "nodejs20.x"
+  runtime                        = "nodejs22.x"
   timeout                        = var.lambda_timeout_scale_up
   reserved_concurrent_executions = var.scale_up_lambda_concurrency
   tags                           = local.tags

--- a/terraform-aws-github-runner/modules/setup-iam-permissions/.tflint.hcl
+++ b/terraform-aws-github-runner/modules/setup-iam-permissions/.tflint.hcl
@@ -5,7 +5,7 @@ plugin "terraform" {
 
 plugin "aws" {
   enabled = true
-  version = "0.31.0"
+  version = "0.45.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/terraform-aws-github-runner/modules/webhook/.tflint.hcl
+++ b/terraform-aws-github-runner/modules/webhook/.tflint.hcl
@@ -5,7 +5,7 @@ plugin "terraform" {
 
 plugin "aws" {
   enabled = true
-  version = "0.31.0"
+  version = "0.45.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/terraform-aws-github-runner/modules/webhook/webhook.tf
+++ b/terraform-aws-github-runner/modules/webhook/webhook.tf
@@ -35,7 +35,7 @@ resource "aws_lambda_function" "webhook" {
   function_name     = "${var.environment}-webhook"
   role              = aws_iam_role.webhook_lambda.arn
   handler           = "index.githubWebhook"
-  runtime           = "nodejs20.x"
+  runtime           = "nodejs22.x"
   timeout           = var.lambda_timeout
 
   environment {


### PR DESCRIPTION
NodeJS 20 is entering end of life on April 30th, 2026. Time to migrate to a newer recent version. While NodeJS 24 is available, migrating to it requires updating our terraform module. This bumps to NodeJS 22 first to buy us more time to upgrade the Terraform module. NodeJS 22 has a deprecation date of April 3, 2027.

Reference: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html?icmpid=docs_lambda_help