### PR TITLE
[Dr. CI] Enable Dr. CI for pytorch/tensordict

### DIFF
--- a/.github/workflows/update-drci-comments.yml
+++ b/.github/workflows/update-drci-comments.yml
@@ -19,6 +19,7 @@ jobs:
           { repo: executorch, org: pytorch },
           { repo: pytorch, org: pytorch },
           { repo: rl, org: pytorch },
+          { repo: tensordict, org: pytorch },
           { repo: text, org: pytorch },
           { repo: torchchat, org: pytorch },
           { repo: torchcodec, org: meta-pytorch },

--- a/torchci/lib/bot/utils.ts
+++ b/torchci/lib/bot/utils.ts
@@ -45,6 +45,7 @@ export function isDrCIEnabled(owner: string, repo: string): boolean {
       "ao",
       "torchchat",
       "torchcodec",
+      "tensordict",
     ].includes(repo)
   );
 }


### PR DESCRIPTION
Hello infra team! 

TensorDict doesn't have Dr CI enabled. This PR fixes that.

- Add `"tensordict"` to `isDrCIEnabled()` in `torchci/lib/bot/utils.ts`
- Add `{ repo: tensordict, org: pytorch }` to the matrix in `.github/workflows/update-drci-comments.yml`

This enables Dr. CI bot comments on `pytorch/tensordict` PRs, including:
- Links to the HUD dashboard
- Doc preview links (docs are already uploaded to `RUNNER_DOCS_DIR` on PRs)
- CI failure summaries with classification

Companion PR on the tensordict side: pytorch/tensordict#1616 (adds `.github/pytorch-probot.yml`).