### PR TITLE
Serve torch nightly from cloudflare

### DIFF
--- a/s3_management/manage_v2.py
+++ b/s3_management/manage_v2.py
@@ -374,6 +374,7 @@ PT_FOUNDATION_PACKAGES = {
 # These packages will have their URLs point to R2 instead of S3/CloudFront
 # when the path is whl/nightly
 PT_R2_PACKAGES = {
+    "torch",
     "torchvision",
     "torchaudio",
     "fbgemm_gpu",


### PR DESCRIPTION
Serve torch nightly from Cloudflare - Enable on Feb 26-27. To be Reverted on 27th Feb.