### PR TITLE
Add ciflow/rocm label only for non-pytorch/pytorch PRs

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -24,7 +24,6 @@ const IssueAndPRRegexToLabel: [RegExp, string][] = [
 const PrTitleRegexToLabel: [RegExp, string][] = [
   [/reland/gi, "ci-no-td"],
   [/revert/gi, "ci-no-td"],
-  [/rocm/gi, "ciflow/rocm-mi300"],
   ...IssueAndPRRegexToLabel,
 ];
 

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -496,7 +496,7 @@ function myBot(app: Probot): void {
       var labelsToAdd = getLabelsToAddFromPrTitle(title);
       // Apply ciflow/rocm label on non-pytorch/pytorch PRs to trigger ROCm CI
       // pytorch/pytorch PRs already run ROCm CI as part of trunk workflow
-      if (!isPyTorchPyTorch(owner, repo) && title.match(/rocm/gi)) {
+      if (!isPyTorchPyTorch(owner, repo) && title.match(/\brocm\b/gi)) {
         labelsToAdd.push("ciflow/rocm");
       }
 

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -495,6 +495,7 @@ function myBot(app: Probot): void {
 
       var labelsToAdd = getLabelsToAddFromPrTitle(title);
       // Apply ciflow/rocm label on non-pytorch/pytorch PRs to trigger ROCm CI
+      // pytorch/pytorch PRs already run ROCm CI as part of trunk workflow
       if (!isPyTorchPyTorch(owner, repo) && title.match(/rocm/gi)) {
         labelsToAdd.push("ciflow/rocm");
       }

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -494,6 +494,10 @@ function myBot(app: Probot): void {
       context.log({ labels, title, filesChanged });
 
       var labelsToAdd = getLabelsToAddFromPrTitle(title);
+      // Apply ciflow/rocm label on non-pytorch/pytorch PRs to trigger ROCm CI
+      if (!isPyTorchPyTorch(owner, repo) && title.match(/rocm/gi)) {
+        labelsToAdd.push("ciflow/rocm");
+      }
 
       // only categorize for release notes for prs in pytorch/pytorch
       if (isPyTorchPyTorch(owner, repo)) {

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -118,7 +118,7 @@ describe("auto-label-bot", () => {
       .reply(200)
       .post("/repos/zhouzhuojie/gha-ci-playground/issues/31/labels", (body) => {
         expect(body).toMatchObject({
-          labels: ["ciflow/rocm-mi300", "module: rocm"],
+          labels: ["module: rocm"],
         });
         return true;
       })

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -135,6 +135,48 @@ describe("auto-label-bot", () => {
     handleScope(checkLabelsScope);
   });
 
+  test("add ciflow/rocm label when non pytorch/pytorch PR title contains ROCm", async () => {
+    // Reset mock to return false for isPyTorchPyTorch
+    jest.restoreAllMocks();
+    const mock = jest.spyOn(botUtils, "isPyTorchPyTorch");
+    mock.mockReturnValue(false);
+    const mockbotSupportedOrg = jest.spyOn(
+      botUtils,
+      "isPyTorchbotSupportedOrg"
+    );
+    mockbotSupportedOrg.mockReturnValue(true);
+
+    nock("https://api.github.com")
+      .post("/app/installations/2/access_tokens")
+      .reply(200, { token: "test" });
+
+    const payload = requireDeepCopy("./fixtures/pull_request.opened")[
+      "payload"
+    ];
+    payload["pull_request"]["title"] = "Issue regarding ROCm";
+    payload["pull_request"]["labels"] = [];
+
+    const scope = nock("https://api.github.com")
+      .get("/repos/zhouzhuojie/gha-ci-playground/pulls/31/files?per_page=100")
+      .reply(200)
+      .post("/repos/zhouzhuojie/gha-ci-playground/issues/31/labels", (body) => {
+        expect(body).toMatchObject({
+          labels: ["module: rocm", "ciflow/rocm"],
+        });
+        return true;
+      })
+      .reply(200);
+    // Check-labels will post a comment since rocm labels are not required labels
+    const checkLabelsScope = mockCheckLabelsComment(
+      "zhouzhuojie/gha-ci-playground",
+      31
+    );
+
+    await probot.receive({ name: "pull_request", payload: payload, id: "2" });
+
+    scope.done();
+  });
+
   test("add ci-no-td label when PR title contains Reland", async () => {
     nock("https://api.github.com")
       .post("/app/installations/2/access_tokens")


### PR DESCRIPTION
* Since we added [ROCm testing to trunk.yml in pytorch/pytorch](https://github.com/pytorch/pytorch/pull/170294), we get ROCm testing for `default` and `distributed` config in trunk.yml, hence no need to automatically add `ciflow/rocm-mi300` or `ciflow/rocm-mi355`. Users can still add these labels manually if they want continuous ROCm testing on their pytorch/pytorch PR.
That being said, this same logic is useful on ecosystem repos to trigger ROCm CI via the `ciflow/rocm` label if any PR mentions ROCm. Hence limit the autolabeling to any non-pytorch/pytorch repos.
* Also, update the ROCm regex pattern to avoid PRs such as [this](https://github.com/meta-pytorch/monarch/pull/3467) resulting in a `ciflow/rocm` label being applied



### Test plan:
Added a new test to check that `ciflow/rocm` label is added for a non-pytorch/pytorch repo: https://github.com/pytorch/test-infra/pull/7801/changes#diff-ed658674d71aaaa8b69a1f1e50e3c5caac25b56874edf448de868bc0918e31d0R138

Job: https://github.com/pytorch/test-infra/actions/runs/24690936818/job/72212348607?pr=7801
```
INFO (event):
    id: "2"
    labels: []
    title: "Issue regarding ROCm"
    filesChanged: []
INFO (event): loadConfig
    id: "2"
    key: "zhouzhuojie/gha-ci-playground"
INFO (event): Adding label(s) module: rocm,ciflow/rocm to pull request https://github.com/zhouzhuojie/gha-ci-playground/pull/31
    id: "2"
```