### PR TITLE
Fix Claude Bedrock model ID: remove :0 suffix for Opus 4.6

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           # We filter by github.actor at workflow level, there is no point of filtering here as well
           allowed_bots: "*"
-          claude_args: "--model global.anthropic.claude-opus-4-6-v1:0"
+          claude_args: "--model global.anthropic.claude-opus-4-6-v1"
           settings: '{"alwaysThinkingEnabled": true}'
           use_bedrock: "true"
 


### PR DESCRIPTION
Opus 4.6 model ID doesn't use the :0 version suffix unlike older models. This was causing Claude Code to exit with code 1 immediately.