### PR TITLE
Add Claude status page outage banner to HUD

### DIFF
--- a/torchci/components/statusPageIncidentBanner/StatusPageIncidentBanner.tsx
+++ b/torchci/components/statusPageIncidentBanner/StatusPageIncidentBanner.tsx
@@ -3,9 +3,18 @@ import useSWR from "swr";
 import styles from "../sevReport/SevReport.module.css";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
-export default function GitHubIncidentBanner() {
+
+interface StatusPageIncidentBannerProps {
+  statusPageUrl: string;
+  serviceName: string;
+}
+
+export default function StatusPageIncidentBanner({
+  statusPageUrl,
+  serviceName,
+}: StatusPageIncidentBannerProps) {
   const { data, error } = useSWR(
-    "https://www.githubstatus.com/api/v2/incidents/unresolved.json",
+    `${statusPageUrl}/api/v2/incidents/unresolved.json`,
     fetcher,
     { refreshInterval: 2 * 60 * 1000 } // every 2 minutes
   );
@@ -26,7 +35,7 @@ export default function GitHubIncidentBanner() {
       className={styles.sevBox}
       style={{ backgroundColor: "var(--background-color)" }}
     >
-      <Title>GitHub Incident:</Title> {incident.name}
+      <Title>{serviceName} Incident:</Title> {incident.name}
       {lastUpdateDate && <> — Updated: {lastUpdateDate}</>}{" "}
       <a href={incident.shortlink} target="_blank" rel="noreferrer">
         (link)

--- a/torchci/pages/_app.tsx
+++ b/torchci/pages/_app.tsx
@@ -1,11 +1,11 @@
 import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeProvider } from "@mui/material/styles";
 import { Analytics } from "@vercel/analytics/react";
-import GitHubIncidentBanner from "components/githubIncident/GithubIncident";
 import AnnouncementBanner from "components/layout/AnnouncementBanner";
 import TitleProvider from "components/layout/DynamicTitle";
 import NavBar from "components/layout/NavBar";
 import SevReport from "components/sevReport/SevReport";
+import StatusPageIncidentBanner from "components/statusPageIncidentBanner/StatusPageIncidentBanner";
 import { DarkModeProvider } from "lib/DarkModeContext";
 import { setupGAAttributeEventTracking } from "lib/tracking/eventTrackingHandler";
 import {
@@ -72,7 +72,14 @@ function AppContent({
         <NavBar />
         <AnnouncementBanner />
         <SevReport />
-        <GitHubIncidentBanner />
+        <StatusPageIncidentBanner
+          statusPageUrl="https://www.githubstatus.com"
+          serviceName="GitHub"
+        />
+        <StatusPageIncidentBanner
+          statusPageUrl="https://status.claude.com"
+          serviceName="Claude"
+        />
         <div style={{ margin: "2px" }}>
           <Component {...pageProps} />
           <Analytics />


### PR DESCRIPTION
Generalize GitHubIncidentBanner into a reusable StatusPageIncidentBanner component that accepts statusPageUrl and serviceName props. Both githubstatus.com and status.claude.com use the same Atlassian Statuspage API, so the same component handles both.