### PR TITLE
[FE 2026]fix the bug, should display warm/cold time for both non-compiled and compiled

### DIFF
--- a/torchci/components/benchmark_v3/configs/teams/vllm/pytoch_x_vllm_agg_config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/vllm/pytoch_x_vllm_agg_config.ts
@@ -36,11 +36,16 @@ export const PYTORCH_X_VLLM_AGGREGATED_COMPARISON_POLICY = {
   median_tpot_ms_compile_speedup: SPEEDUP_COMPARISON_POLICY,
   median_ttft_ms_compile_speedup: SPEEDUP_COMPARISON_POLICY,
   tokens_per_second_compile_speedup: SPEEDUP_COMPARISON_POLICY,
-  // Time metrics (lower is better) - geomean
-  geomean_avg_cold_compilation_time: TIME_COMPARISON_POLICY,
-  geomean_avg_warm_compilation_time: TIME_COMPARISON_POLICY,
-  geomean_avg_cold_startup_time: TIME_COMPARISON_POLICY,
-  geomean_avg_warm_startup_time: TIME_COMPARISON_POLICY,
+  // Time metrics (lower is better) - geomean, compiled
+  geomean_avg_cold_compilation_time_compiled: TIME_COMPARISON_POLICY,
+  geomean_avg_warm_compilation_time_compiled: TIME_COMPARISON_POLICY,
+  geomean_avg_cold_startup_time_compiled: TIME_COMPARISON_POLICY,
+  geomean_avg_warm_startup_time_compiled: TIME_COMPARISON_POLICY,
+  // Time metrics (lower is better) - geomean, noncompiled
+  geomean_avg_cold_compilation_time_noncompiled: TIME_COMPARISON_POLICY,
+  geomean_avg_warm_compilation_time_noncompiled: TIME_COMPARISON_POLICY,
+  geomean_avg_cold_startup_time_noncompiled: TIME_COMPARISON_POLICY,
+  geomean_avg_warm_startup_time_noncompiled: TIME_COMPARISON_POLICY,
 };
 
 export const PYTORCH_X_VLLM_AGGREGATED_TITLE_GROUP_MAPPING = {
@@ -70,16 +75,26 @@ export const PYTORCH_X_VLLM_AGGREGATED_TITLE_GROUP_MAPPING = {
     description:
       "Speedup ratio of token generation throughput with torch.compile enabled vs disabled. Value > 1 means compile improves performance.",
   },
-  // Grouped metric titles (cold + warm in same chart)
-  compilation_time: {
-    text: "Geomean Compilation Time (lower is better)",
+  // Grouped metric titles (compiled vs noncompiled in same chart)
+  cold_compilation_time: {
+    text: "Geomean Cold Compilation Time (lower is better)",
     description:
-      "Geometric mean of torch.compile compilation time across models. Cold = first compilation without cache. Warm = compilation with cache available.",
+      "Geometric mean of torch.compile cold compilation time across models. Compares compiled vs non-compiled. Cold = first compilation without cache.",
   },
-  startup_time: {
-    text: "Geomean Startup Time (lower is better)",
+  warm_compilation_time: {
+    text: "Geomean Warm Compilation Time (lower is better)",
     description:
-      "Geometric mean of total model startup time across models. Cold = first startup without cache. Warm = startup with cache available.",
+      "Geometric mean of torch.compile warm compilation time across models. Compares compiled vs non-compiled. Warm = compilation with cache available.",
+  },
+  cold_startup_time: {
+    text: "Geomean Cold Startup Time (lower is better)",
+    description:
+      "Geometric mean of model cold startup time across models. Compares compiled vs non-compiled. Cold = first startup without cache.",
+  },
+  warm_startup_time: {
+    text: "Geomean Warm Startup Time (lower is better)",
+    description:
+      "Geometric mean of model warm startup time across models. Compares compiled vs non-compiled. Warm = startup with cache available.",
   },
 };
 
@@ -112,22 +127,40 @@ export const PYTORCH_X_VLLM_AGGREGATED_RENDER_BOOK = {
   geomean_non_compiled: {
     displayName: "Non-compiled Geomean",
   },
-  // Compilation time metrics (geomean)
-  geomean_avg_cold_compilation_time: {
-    displayName: "Geomean Cold Compilation",
+  // Cold Compilation time metrics (geomean) - compiled vs noncompiled
+  geomean_avg_cold_compilation_time_compiled: {
+    displayName: "Cold Compilation (compiled)",
     unit: { type: "time", unit: "s" },
   },
-  geomean_avg_warm_compilation_time: {
-    displayName: "Geomean Warm Compilation",
+  geomean_avg_cold_compilation_time_noncompiled: {
+    displayName: "Cold Compilation (noncompiled)",
     unit: { type: "time", unit: "s" },
   },
-  // Startup time metrics (geomean)
-  geomean_avg_cold_startup_time: {
-    displayName: "Geomean Cold Startup",
+  // Warm Compilation time metrics (geomean) - compiled vs noncompiled
+  geomean_avg_warm_compilation_time_compiled: {
+    displayName: "Warm Compilation (compiled)",
     unit: { type: "time", unit: "s" },
   },
-  geomean_avg_warm_startup_time: {
-    displayName: "Geomean Warm Startup",
+  geomean_avg_warm_compilation_time_noncompiled: {
+    displayName: "Warm Compilation (noncompiled)",
+    unit: { type: "time", unit: "s" },
+  },
+  // Cold Startup time metrics (geomean) - compiled vs noncompiled
+  geomean_avg_cold_startup_time_compiled: {
+    displayName: "Cold Startup (compiled)",
+    unit: { type: "time", unit: "s" },
+  },
+  geomean_avg_cold_startup_time_noncompiled: {
+    displayName: "Cold Startup (noncompiled)",
+    unit: { type: "time", unit: "s" },
+  },
+  // Warm Startup time metrics (geomean) - compiled vs noncompiled
+  geomean_avg_warm_startup_time_compiled: {
+    displayName: "Warm Startup (compiled)",
+    unit: { type: "time", unit: "s" },
+  },
+  geomean_avg_warm_startup_time_noncompiled: {
+    displayName: "Warm Startup (noncompiled)",
     unit: { type: "time", unit: "s" },
   },
 };

--- a/torchci/components/benchmark_v3/configs/teams/vllm/pytoch_x_vllm_agg_config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/vllm/pytoch_x_vllm_agg_config.ts
@@ -79,12 +79,12 @@ export const PYTORCH_X_VLLM_AGGREGATED_TITLE_GROUP_MAPPING = {
   cold_compilation_time: {
     text: "Geomean Cold Compilation Time (lower is better)",
     description:
-      "Geometric mean of torch.compile cold compilation time across models. Compares compiled vs non-compiled. Cold = first compilation without cache.",
+      "Geometric mean of torch.compile cold compilation time across models. Cold = first compilation without cache. Note: Non-compiled is always zero (no compilation) and not displayed.",
   },
   warm_compilation_time: {
     text: "Geomean Warm Compilation Time (lower is better)",
     description:
-      "Geometric mean of torch.compile warm compilation time across models. Compares compiled vs non-compiled. Warm = compilation with cache available.",
+      "Geometric mean of torch.compile warm compilation time across models. Warm = compilation with cache available. Note: Non-compiled is always zero (no compilation) and not displayed.",
   },
   cold_startup_time: {
     text: "Geomean Cold Startup Time (lower is better)",

--- a/torchci/components/benchmark_v3/configs/teams/vllm/pytorch_x_vllm_config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/vllm/pytorch_x_vllm_config.ts
@@ -34,10 +34,22 @@ const COMPARISON_POLICY_BOOK = {
 
 // Render book for raw comparison table metrics
 const RAW_COMPARISON_RENDER_BOOK = {
-  avg_cold_compilation_time: { displayName: "Avg Cold Compilation Time" },
-  avg_cold_startup_time: { displayName: "Avg Cold Startup Time" },
-  avg_warm_compilation_time: { displayName: "Avg Warm Compilation Time" },
-  avg_warm_startup_time: { displayName: "Avg Warm Startup Time" },
+  avg_cold_compilation_time: {
+    displayName: "Avg Cold Compilation Time",
+    unit: { type: "time", unit: "s" },
+  },
+  avg_cold_startup_time: {
+    displayName: "Avg Cold Startup Time",
+    unit: { type: "time", unit: "s" },
+  },
+  avg_warm_compilation_time: {
+    displayName: "Avg Warm Compilation Time",
+    unit: { type: "time", unit: "s" },
+  },
+  avg_warm_startup_time: {
+    displayName: "Avg Warm Startup Time",
+    unit: { type: "time", unit: "s" },
+  },
   latency: { displayName: "Latency" },
   median_itl_ms: { displayName: "Median ITL (ms)" },
   median_tpot_ms: { displayName: "Median TPOT (ms)" },
@@ -185,7 +197,7 @@ export const PytorchXVllmBenchmarkDashboardConfig: BenchmarkUIConfig = {
         type: "AutoBenchmarkPairwiseTable",
         title: "Model-wise Compile Performance",
         description:
-          "Compares compiled vs non-compiled performance for selected benchmark data. Speedup > 1 indicates compile improves performance.",
+          "Compares compiled vs non-compiled performance for selected benchmark data. Speedup > 1 indicates compile improves performance. Toggle to 'Absolute value' view to see the geomean values (compiled/non-compiled) used in speedup calculation.",
         config: {
           // Use aggregated fetcher with per-model grouping
           fetcherId: "pytroch_x_vllm_aggregated",

--- a/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/vllmDataFetchers.ts
+++ b/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/vllmDataFetchers.ts
@@ -172,14 +172,20 @@ export class VllmXPytorchBenchmarkAggregatedDataFetcher extends VllmXPytorchBenc
 
   // Metric group mapping for chart grouping
   // For speedup metrics: metric_group = metric (each metric gets its own chart)
-  // For time metrics: group cold/warm together
+  // For time metrics: group compiled/non-compiled together by metric type
   private static readonly METRIC_GROUP_MAP: Record<string, string> = {
-    // Compilation time metrics - grouped together
-    geomean_avg_cold_compilation_time: "compilation_time",
-    geomean_avg_warm_compilation_time: "compilation_time",
-    // Startup time metrics - grouped together
-    geomean_avg_cold_startup_time: "startup_time",
-    geomean_avg_warm_startup_time: "startup_time",
+    // Cold Compilation time metrics - grouped together (compiled vs non-compiled)
+    geomean_avg_cold_compilation_time_compiled: "cold_compilation_time",
+    geomean_avg_cold_compilation_time_noncompiled: "cold_compilation_time",
+    // Warm Compilation time metrics - grouped together (compiled vs non-compiled)
+    geomean_avg_warm_compilation_time_compiled: "warm_compilation_time",
+    geomean_avg_warm_compilation_time_noncompiled: "warm_compilation_time",
+    // Cold Startup time metrics - grouped together (compiled vs non-compiled)
+    geomean_avg_cold_startup_time_compiled: "cold_startup_time",
+    geomean_avg_cold_startup_time_noncompiled: "cold_startup_time",
+    // Warm Startup time metrics - grouped together (compiled vs non-compiled)
+    geomean_avg_warm_startup_time_compiled: "warm_startup_time",
+    geomean_avg_warm_startup_time_noncompiled: "warm_startup_time",
   };
 
   /**
@@ -453,7 +459,7 @@ export class VllmXPytorchBenchmarkAggregatedDataFetcher extends VllmXPytorchBenc
   /**
    * Aggregate compilation time metrics by computing the geometric mean value
    * across all models for each workflow/metric/device/arch combination.
-   * These metrics are pass-through without compile vs non-compile comparison.
+   * Separates by compiled vs non-compiled (use_compile=true vs use_compile=false).
    */
   private aggregateCompilationTimeData(
     data: any[],
@@ -466,58 +472,93 @@ export class VllmXPytorchBenchmarkAggregatedDataFetcher extends VllmXPytorchBenc
       "granularity_bucket",
     ]
   ): any[] {
-    // Group by specified fields
+    // Group by specified fields AND use_compile
     const groupMap = new Map<
       string,
-      { values: number[]; template: any; models: Set<string> }
+      {
+        compiled: { values: number[]; models: Set<string> };
+        nonCompiled: { values: number[]; models: Set<string> };
+        template: any;
+      }
     >();
 
     data.forEach((d) => {
       const key = createGroupKey(d, groupByFields);
       if (!groupMap.has(key)) {
         groupMap.set(key, {
-          values: [],
+          compiled: { values: [], models: new Set() },
+          nonCompiled: { values: [], models: new Set() },
           template: { ...d },
-          models: new Set(),
         });
       }
 
       const group = groupMap.get(key)!;
-      if (d.value != null && d.value > 0) {
-        group.values.push(d.value);
-      }
-      if (d.model) {
-        group.models.add(d.model);
+      const useCompile = d.extra_key?.use_compile;
+
+      // Categorize by use_compile value
+      if (useCompile === "true" || useCompile === true) {
+        if (d.value != null && d.value > 0) {
+          group.compiled.values.push(d.value);
+        }
+        if (d.model) {
+          group.compiled.models.add(d.model);
+        }
+      } else if (useCompile === "false" || useCompile === false) {
+        if (d.value != null && d.value > 0) {
+          group.nonCompiled.values.push(d.value);
+        }
+        if (d.model) {
+          group.nonCompiled.models.add(d.model);
+        }
       }
     });
 
-    // Compute geomean for each group
+    // Compute geomean for each group, creating separate records for compiled and non-compiled
     const aggregatedData: any[] = [];
     groupMap.forEach((group) => {
-      const { values, template, models } = group;
+      const { compiled, nonCompiled, template } = group;
 
-      if (values.length === 0) {
-        return;
+      // Create record for compiled (use_compile=true)
+      if (compiled.values.length > 0) {
+        const geomeanValue = geometricMean(compiled.values);
+        const metricName = `geomean_${template.metric}_compiled`;
+        const baseRecord = buildBaseRecordFromTemplate(template, groupByFields);
+        const aggregatedRecord = {
+          ...baseRecord,
+          value: geomeanValue,
+          metric: metricName,
+          metric_group:
+            VllmXPytorchBenchmarkAggregatedDataFetcher.getMetricGroup(
+              metricName
+            ),
+          geomean_value: geomeanValue,
+          raw_values: compiled.values,
+          models: Array.from(compiled.models),
+          valid_models: Array.from(compiled.models),
+        };
+        aggregatedData.push(aggregatedRecord);
       }
 
-      // Compute geometric mean
-      const geomeanValue = geometricMean(values);
-
-      const metricName = `geomean_${template.metric}`;
-      const baseRecord = buildBaseRecordFromTemplate(template, groupByFields);
-      const aggregatedRecord = {
-        ...baseRecord,
-        value: geomeanValue,
-        metric: metricName,
-        metric_group:
-          VllmXPytorchBenchmarkAggregatedDataFetcher.getMetricGroup(metricName),
-        geomean_value: geomeanValue,
-        raw_values: values,
-        models: Array.from(models),
-        valid_models: Array.from(models),
-      };
-
-      aggregatedData.push(aggregatedRecord);
+      // Create record for non-compiled (use_compile=false)
+      if (nonCompiled.values.length > 0) {
+        const geomeanValue = geometricMean(nonCompiled.values);
+        const metricName = `geomean_${template.metric}_noncompiled`;
+        const baseRecord = buildBaseRecordFromTemplate(template, groupByFields);
+        const aggregatedRecord = {
+          ...baseRecord,
+          value: geomeanValue,
+          metric: metricName,
+          metric_group:
+            VllmXPytorchBenchmarkAggregatedDataFetcher.getMetricGroup(
+              metricName
+            ),
+          geomean_value: geomeanValue,
+          raw_values: nonCompiled.values,
+          models: Array.from(nonCompiled.models),
+          valid_models: Array.from(nonCompiled.models),
+        };
+        aggregatedData.push(aggregatedRecord);
+      }
     });
 
     return aggregatedData;


### PR DESCRIPTION
# description
the first iteration assume only use_compile =true has warm/cold data, 
that is not the case, we calcualte geomean for each  warm/cold metrics with noncompiled and compiled data.

# notice
notice since the non-compiled metrics below are all zeros, we do not return the data
- Geomean Cold Compilation Time 
- Geomean Warm Compilation Time
# demo url (you need permission to view this, ask author)
https://torchci-git-improvevllmx-fbopensource.vercel.app/benchmark/v3/aggregate/pytroch_x_vllm_aggregated
https://torchci-git-improvevllmx-fbopensource.vercel.app/benchmark/v3/dashboard/pytorch_x_vllm_benchmark

# demo screenshot
##  in aggregate view now
<img width="2148" height="1018" alt="image" src="https://github.com/user-attachments/assets/8d5fd766-10f1-4125-b348-962740737b81" />

## in dashboard now
<img width="2172" height="539" alt="image" src="https://github.com/user-attachments/assets/489dfdc2-e1f2-4c42-a1fd-d8f970589a8c" />
