### PR TITLE
Expand setup script: auto-detect repo, create workflow, show next steps

### DIFF
--- a/.github/scripts/setup-claude-environment.py
+++ b/.github/scripts/setup-claude-environment.py
@@ -161,8 +161,7 @@ def configure_environment(repo: str) -> bool:
     # Reconcile branch policies
     ep = f"repos/{repo}/environments/bedrock/deployment-branch-policies"
     existing = {
-        p["name"]: p["id"]
-        for p in (gh("GET", ep) or {}).get("branch_policies", [])
+        p["name"]: p["id"] for p in (gh("GET", ep) or {}).get("branch_policies", [])
     }
     for name, pid in existing.items():
         if name not in ALLOWED_BRANCHES:


### PR DESCRIPTION
## Summary
Simplifies and expands `setup-claude-environment.py` into a one-stop onboarding tool. Run it from inside any pytorch/meta-pytorch repo:

```bash
cd /path/to/my-repo
uv run https://raw.githubusercontent.com/pytorch/test-infra/main/.github/scripts/setup-claude-environment.py
```

### What it does
1. **Detects the repo** from `git remote origin` — no args needed
2. **Configures the `bedrock` GitHub environment** (best-effort — skips gracefully without admin access)
3. **Creates `.github/workflows/claude-code.yml`** with the reusable workflow reference
4. **Prints remaining manual steps** (IAM trust policy, Claude app install, CLAUDE.md)

### Changes from previous version
- No positional args — always detects repo from cwd
- Creates the workflow file (previously left to the user)
- Best-effort environment setup — non-admins can still generate the workflow
- Simplified from 460 to 190 lines: dropped `argparse`, `--json` mode, redundant helpers
- Links to https://github.com/apps/claude for app installation

## Test plan
- [x] Run from inside a repo with admin access — configures environment + creates workflow
- [x] Run from inside a repo without admin access — skips environment, still creates workflow
- [x] Run from a non-git directory — shows clear error
- [x] Run in a repo that already has `claude-code.yml` — skips workflow creation
- [x] Run with `--force` on a repo with mismatched environment — overwrites settings