### PR TITLE
Fix scale-up-chron test to match updated axios.get signature

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up-chron.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up-chron.test.ts
@@ -270,7 +270,7 @@ describe('getQueuedJobs', () => {
     await getQueuedJobs(metrics, 'url');
 
     expect(trackRequestSpy).toHaveBeenCalled();
-    expect(axiosGetSpy).toHaveBeenCalledWith('url');
+    expect(axiosGetSpy).toHaveBeenCalledWith('url', { headers: {} });
   });
 
   it('handles invalid data (not an array) from response', async () => {


### PR DESCRIPTION
## Summary

PR #7804 updated `getQueuedJobs` to pass a `headers` object to `axios.get`, but the corresponding test was not updated to match the new call signature.

**Before (#7804):**
```typescript
return axios.get<any, AxiosResponse<string>>(url);
```

**After (#7804):**
```typescript
return axios.get<any, AxiosResponse<string>>(url, { headers });
```

The test asserted `toHaveBeenCalledWith('url')` but the function now always passes a second argument (`{ headers: {} }` when no token is set). This causes Lambda Runners CI to fail on every subsequent commit.

## Fix

Update the test assertion to match the actual call:
```typescript
expect(axiosGetSpy).toHaveBeenCalledWith('url', { headers: {} });
```

## Test Plan

- [ ] Lambda Runners CI passes