### PR TITLE
Add CLAUDE.md for torchci dark/light mode guidance

### DIFF
--- a/.github/workflows/_claude-code.yml
+++ b/.github/workflows/_claude-code.yml
@@ -28,10 +28,6 @@ on:
         description: 'Claude settings JSON'
         type: string
         default: '{"alwaysThinkingEnabled": true}'
-      prompt:
-        description: 'Custom prompt passed to claude-code-action'
-        type: string
-        default: ''
       setup_script:
         description: 'Shell commands to run before Claude (e.g. install lintrunner)'
         type: string
@@ -122,7 +118,6 @@ jobs:
           allowed_bots: "*"
           use_bedrock: "true"
           claude_args: "--model ${{ inputs.model }} ${{ inputs.additional_claude_args }}"
-          prompt: ${{ inputs.prompt }}
           settings: ${{ inputs.settings }}
 
       - name: Upload usage metrics


### PR DESCRIPTION
## Summary

- Adds a `torchci/CLAUDE.md` with instructions that all HUD pages must support both dark and light mode
- Specifies to use MUI's `useTheme()` for palette detection and to never hardcode single-mode colors

## Test plan
- N/A — documentation only