### PR TITLE
Add torchaudio to cloudflare by default

### DIFF
--- a/s3_management/manage_v2.py
+++ b/s3_management/manage_v2.py
@@ -450,6 +450,7 @@ PT_R2_PACKAGES = {
 # These packages will have their URLs point to R2 instead of S3/CloudFront
 # when the path is NOT whl/test and NOT whl/nightly (i.e., prod)
 PT_R2_PACKAGES_PROD = {
+    "torchaudio",
     "fbgemm_gpu",
     "fbgemm_gpu_genai",
 }


### PR DESCRIPTION
torchaudio downloads from production will use cloudflare