### PR TITLE
Alert on missing benchmark data

### DIFF
--- a/aws/lambda/benchmark_regression_summary_report/common/report_manager.py
+++ b/aws/lambda/benchmark_regression_summary_report/common/report_manager.py
@@ -35,6 +35,30 @@ Report Status: **{{ status }}**
 {% endif %}
 """
 
+MISSING_DATA_MD_TEMPLATE = """# Benchmark Data Availability Alert
+config_id: `{{ report_id }}`
+
+**Status: insufficient_data**
+
+More than 90% of benchmark data points have insufficient data.
+This may indicate a data pipeline outage or benchmark infrastructure issue.
+
+- Total: {{ summary.total_count | default(0) }}
+- Insufficient Data: {{ summary.insufficient_data_count | default(0) }}
+- No Regression: {{ summary.no_regression_count | default(0) }}
+
+See Page https://hud.pytorch.org/benchmark/regression/report/{{ id }} for more details.
+"""
+
+NO_DATA_MD_TEMPLATE = """# Benchmark Data Availability Alert
+config_id: `{{ report_id }}`
+
+**No benchmark data found** for `{{ report_id }}` in the configured time window.
+
+This likely indicates a complete data pipeline outage or benchmark infrastructure failure.
+Please investigate the benchmark runners and data ingestion pipeline.
+"""
+
 
 class ReportManager:
     """
@@ -129,10 +153,11 @@ class ReportManager:
         return result
 
     def notify_github_comments(self, github_token: str):
-        if self.status != "regression":
+        if self.status not in ("regression", "insufficient_data"):
             logger.info(
-                "[%s] no regression found, skip notification",
+                "[%s] status is '%s', skip notification",
                 self.config_id,
+                self.status,
             )
             return
         github_notifications = self.config.policy.get_github_notification_configs()
@@ -158,9 +183,16 @@ class ReportManager:
 
         for github_notification in github_notifications:
             condition = github_notification.condition
-            # verify condition if it is set
-            regression_devices = self.metadata.get("regression_devices", [])
-            if condition:
+            # For insufficient_data alerts, skip device-level condition matching
+            # since there are no regression_devices to match against
+            if self.status == "insufficient_data":
+                logger.info(
+                    "[%s] insufficient_data alert, skipping condition check",
+                    self.config_id,
+                )
+            elif condition:
+                # verify condition if it is set
+                regression_devices = self.metadata.get("regression_devices", [])
                 is_matched = condition.match_condition(regression_devices)
                 # skip if condition is not matched
                 if not is_matched:
@@ -209,8 +241,13 @@ class ReportManager:
             r for r in self.raw_report["results"] if r.get("label") == "regression"
         ]
         url = (self.config.hud_info or {}).get("url", "")
+        template = (
+            MISSING_DATA_MD_TEMPLATE
+            if self.status == "insufficient_data"
+            else REPORT_MD_TEMPLATE
+        )
         return Template(
-            REPORT_MD_TEMPLATE, trim_blocks=True, lstrip_blocks=True
+            template, trim_blocks=True, lstrip_blocks=True
         ).render(
             id=self.id,
             url=url,

--- a/aws/lambda/benchmark_regression_summary_report/lambda_function.py
+++ b/aws/lambda/benchmark_regression_summary_report/lambda_function.py
@@ -13,7 +13,8 @@ from common.benchmark_time_series_api_model import BenchmarkTimeSeriesApiRespons
 from common.config import get_benchmark_regression_config
 from common.config_model import BenchmarkApiSource, BenchmarkConfig, Frequency
 from common.regression_utils import BenchmarkRegressionReportGenerator
-from common.report_manager import ReportManager
+from common.report_manager import NO_DATA_MD_TEMPLATE, ReportManager
+from jinja2 import Template
 from dateutil.parser import isoparse
 
 
@@ -143,6 +144,7 @@ class BenchmarkSummaryProcessor:
             self.log_info(
                 f"no target data found for time range [{ls},{le}] with frequency {report_freq.get_text()}..."
             )
+            self._notify_no_data(cc, config, "target", ls, le)
             return
         baseline, bs, be = self.get_baseline(
             config, self.end_time, self.hud_access_token
@@ -152,6 +154,7 @@ class BenchmarkSummaryProcessor:
             self.log_info(
                 f"no baseline data found for time range [{bs},{be}] with frequency {report_freq.get_text()}..."
             )
+            self._notify_no_data(cc, config, "baseline", bs, be)
             return
         generator = BenchmarkRegressionReportGenerator(
             config=config, target_ts=target, baseline_ts=baseline
@@ -257,6 +260,69 @@ class BenchmarkSummaryProcessor:
             return True
         self.log_info(f"expect latest data to be after {cutoff}, but got {latest_ts}")
         return False
+
+    def _no_data_already_alerted(
+        self,
+        cc: clickhouse_connect.driver.client.Client,
+        config_id: str,
+        today_str: str,
+    ) -> bool:
+        """Check if a no-data alert was already sent today for this config."""
+        table = BENCHMARK_REGRESSION_REPORT_TABLE
+        sql = f"""
+            SELECT 1
+            FROM {table}
+            WHERE report_id = %(report_id)s
+            AND type = 'no_data_alert'
+            AND stamp = toDate(%(today)s)
+            LIMIT 1
+        """
+        res = cc.query(
+            sql,
+            parameters={"report_id": config_id, "today": today_str},
+        )
+        return bool(res.result_rows)
+
+    def _notify_no_data(
+        self,
+        cc: clickhouse_connect.driver.client.Client,
+        config: BenchmarkConfig,
+        data_type: str,
+        range_start: int,
+        range_end: int,
+    ) -> None:
+        """Post a GitHub comment when HUD API returns zero benchmark data."""
+        today_str = dt.datetime.fromtimestamp(
+            self.end_time, tz=dt.timezone.utc
+        ).strftime("%Y-%m-%d")
+
+        # Dedup: one alert per day per config
+        if self._no_data_already_alerted(cc, config.id, today_str):
+            self.log_info(
+                f"no-data alert already sent today ({today_str}) for {config.id}, skipping"
+            )
+            return
+
+        github_notifications = config.policy.get_github_notification_configs()
+        if not github_notifications:
+            self.log_info("no github notification config found, skip no-data alert")
+            return
+
+        content = Template(
+            NO_DATA_MD_TEMPLATE, trim_blocks=True, lstrip_blocks=True
+        ).render(report_id=config.id)
+
+        github_token = ENVS["GITHUB_TOKEN"]
+        for github_notification in github_notifications:
+            try:
+                github_notification.create_github_comment(content, github_token)
+                self.log_info(
+                    f"no-data alert sent to {github_notification.repo}/issues/{github_notification.issue_number}"
+                )
+            except Exception as e:
+                self.log_error(
+                    f"failed to send no-data alert: {e}"
+                )
 
     def _fetch_from_benchmark_ts_api(
         self,

--- a/aws/lambda/benchmark_regression_summary_report/tests/test_missing_data_alerts.py
+++ b/aws/lambda/benchmark_regression_summary_report/tests/test_missing_data_alerts.py
@@ -1,0 +1,273 @@
+"""
+Tests for missing-data / insufficient-data alerting.
+
+Verifies that:
+ 1. status="insufficient_data" triggers a GitHub comment (new behaviour)
+ 2. status="no_regression" does NOT trigger a GitHub comment (existing behaviour)
+ 3. status="regression" still triggers a GitHub comment (existing behaviour)
+ 4. Empty target data from HUD API triggers a no-data alert
+ 5. Empty baseline data from HUD API triggers a no-data alert
+ 6. The no-data alert is deduplicated (one per day per config)
+"""
+
+import datetime as dt
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers to build minimal fakes that satisfy ReportManager / lambda_function
+# ---------------------------------------------------------------------------
+
+FAKE_CONFIG_ID = "pytorch_helion"
+
+# Minimal regression report that ReportManager.__init__ can unpack
+def _make_regression_report(*, status: str):
+    """Return a minimal BenchmarkRegressionReport dict for the given *overall* status."""
+    # Map overall status -> summary counts
+    summary_map = {
+        "regression": {
+            "total_count": 10,
+            "regression_count": 3,
+            "suspicious_count": 0,
+            "no_regression_count": 7,
+            "insufficient_data_count": 0,
+            "is_regression": 1,
+        },
+        "insufficient_data": {
+            "total_count": 10,
+            "regression_count": 0,
+            "suspicious_count": 0,
+            "no_regression_count": 1,
+            "insufficient_data_count": 9,
+            "is_regression": 0,
+        },
+        "no_regression": {
+            "total_count": 10,
+            "regression_count": 0,
+            "suspicious_count": 0,
+            "no_regression_count": 10,
+            "insufficient_data_count": 0,
+            "is_regression": 0,
+        },
+    }
+    summary = summary_map[status]
+    ts_now = dt.datetime.now(dt.timezone.utc).isoformat()
+    meta = {"start": {"commit": "aaa", "branch": "main", "timestamp": ts_now, "workflow_id": "1"},
+            "end":   {"commit": "bbb", "branch": "main", "timestamp": ts_now, "workflow_id": "2"}}
+    return {
+        "summary": summary,
+        "results": [],
+        "baseline_meta_data": meta,
+        "new_meta_data": meta,
+        "device_info": ["cuda_h100"],
+        "metadata": {"regression_devices": []},
+    }
+
+
+def _make_config():
+    """Return a minimal BenchmarkConfig for FAKE_CONFIG_ID."""
+    from common.config_model import (
+        BenchmarkApiSource,
+        BenchmarkConfig,
+        DayRangeWindow,
+        Frequency,
+        Policy,
+        RangeConfig,
+        RegressionPolicy,
+        ReportConfig,
+    )
+
+    return BenchmarkConfig(
+        name="Test Benchmark",
+        id=FAKE_CONFIG_ID,
+        source=BenchmarkApiSource(
+            api_query_url="https://hud.pytorch.org/api/benchmark/get_time_series",
+            type="benchmark_time_series_api",
+            api_endpoint_params_template='{"name":"test","query_params":{"startTime":"{{ startTime }}","stopTime":"{{ stopTime }}"}}',
+        ),
+        policy=Policy(
+            frequency=Frequency(value=1, unit="days"),
+            range=RangeConfig(
+                baseline=DayRangeWindow(value=4),
+                comparison=DayRangeWindow(value=4),
+            ),
+            metrics={
+                "helion_speedup": RegressionPolicy(
+                    name="helion_speedup",
+                    condition="greater_equal",
+                    threshold=0.95,
+                    baseline_aggregation="median",
+                ),
+            },
+            notification_config={
+                "configs": [
+                    {
+                        "type": "github",
+                        "repo": "pytorch/test-infra",
+                        "issue": "7472",
+                    }
+                ]
+            },
+        ),
+        report_config=ReportConfig(report_level="insufficient_data"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1-3: ReportManager.notify_github_comments gate
+# ---------------------------------------------------------------------------
+
+class TestReportManagerNotifyGate:
+    """Verify the status gate in notify_github_comments."""
+
+    def _build_manager(self, status: str):
+        from common.report_manager import ReportManager
+
+        config = _make_config()
+        report = _make_regression_report(status=status)
+        return ReportManager(
+            db_table_name="benchmark.benchmark_regression_report",
+            config=config,
+            regression_report=report,
+            is_dry_run=True,
+        )
+
+    def test_notify_on_insufficient_data(self):
+        """When report status is 'insufficient_data', a GitHub comment SHOULD be created."""
+        mgr = self._build_manager("insufficient_data")
+        assert mgr.status == "insufficient_data"
+
+        with patch.object(mgr, "_to_markdown", return_value="md body"):
+            result = mgr.notify_github_comments("fake-token")
+
+        # Should NOT have returned early (the old code returned None for non-regression)
+        assert result is not None, (
+            "notify_github_comments returned None for insufficient_data — "
+            "it should post a comment"
+        )
+
+    def test_no_notify_on_no_regression(self):
+        """When status is 'no_regression', no comment should be posted (existing behaviour)."""
+        mgr = self._build_manager("no_regression")
+        assert mgr.status == "no_regression"
+
+        result = mgr.notify_github_comments("fake-token")
+        # The method returns None when it skips early
+        assert result is None
+
+    def test_notify_on_regression_unchanged(self):
+        """When status is 'regression', a comment SHOULD be posted (existing behaviour)."""
+        mgr = self._build_manager("regression")
+        assert mgr.status == "regression"
+
+        with patch.object(mgr, "_to_markdown", return_value="md body"):
+            result = mgr.notify_github_comments("fake-token")
+
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# 4-6: lambda_function no-data path
+# ---------------------------------------------------------------------------
+
+class TestNoDataAlerts:
+    """Verify that when HUD returns empty data, a no-data alert is posted."""
+
+    @patch("lambda_function.get_clickhouse_client_environment")
+    @patch("lambda_function.get_benchmark_regression_config")
+    def test_no_data_target_triggers_alert(self, mock_get_config, mock_get_cc):
+        """Empty target time_series → _notify_no_data is called."""
+        from lambda_function import BenchmarkSummaryProcessor
+
+        config = _make_config()
+        mock_get_config.return_value = config
+
+        mock_cc = MagicMock()
+        # _should_generate_report returns True
+        mock_cc.query.return_value = MagicMock(result_rows=[])
+
+        processor = BenchmarkSummaryProcessor(
+            config_id=FAKE_CONFIG_ID,
+            end_time=int(dt.datetime.now(dt.timezone.utc).timestamp()),
+            hud_access_token="fake",
+            is_dry_run=False,
+        )
+
+        # Make get_target return None (empty data)
+        with patch.object(
+            processor, "get_target", return_value=(None, 0, 0)
+        ), patch.object(
+            processor, "_notify_no_data"
+        ) as mock_notify:
+            processor.process(cc=mock_cc)
+
+        mock_notify.assert_called_once()
+
+    @patch("lambda_function.get_clickhouse_client_environment")
+    @patch("lambda_function.get_benchmark_regression_config")
+    def test_no_data_baseline_triggers_alert(self, mock_get_config, mock_get_cc):
+        """Empty baseline time_series → _notify_no_data is called."""
+        from lambda_function import BenchmarkSummaryProcessor
+
+        config = _make_config()
+        mock_get_config.return_value = config
+
+        mock_cc = MagicMock()
+        mock_cc.query.return_value = MagicMock(result_rows=[])
+
+        processor = BenchmarkSummaryProcessor(
+            config_id=FAKE_CONFIG_ID,
+            end_time=int(dt.datetime.now(dt.timezone.utc).timestamp()),
+            hud_access_token="fake",
+            is_dry_run=False,
+        )
+
+        # target returns data, baseline returns None
+        fake_target = MagicMock()
+        fake_target.time_series = [MagicMock()]
+        with patch.object(
+            processor, "get_target", return_value=(fake_target, 0, 0)
+        ), patch.object(
+            processor, "get_baseline", return_value=(None, 0, 0)
+        ), patch.object(
+            processor, "_notify_no_data"
+        ) as mock_notify:
+            processor.process(cc=mock_cc)
+
+        mock_notify.assert_called_once()
+
+    @patch("lambda_function.get_clickhouse_client_environment")
+    @patch("lambda_function.get_benchmark_regression_config")
+    def test_no_data_dedup(self, mock_get_config, mock_get_cc):
+        """No-data alert should be deduplicated (not sent twice for the same day)."""
+        from lambda_function import BenchmarkSummaryProcessor
+
+        config = _make_config()
+        mock_get_config.return_value = config
+
+        mock_cc = MagicMock()
+        # First query: _should_generate_report → True (no rows)
+        # Second query: _no_data_already_alerted → True (row exists → skip)
+        mock_cc.query.side_effect = [
+            MagicMock(result_rows=[]),   # _should_generate_report
+            MagicMock(result_rows=[(1,)]),  # _no_data_already_alerted → already sent
+        ]
+
+        processor = BenchmarkSummaryProcessor(
+            config_id=FAKE_CONFIG_ID,
+            end_time=int(dt.datetime.now(dt.timezone.utc).timestamp()),
+            hud_access_token="fake",
+            is_dry_run=False,
+        )
+
+        with patch.object(
+            processor, "get_target", return_value=(None, 0, 0)
+        ):
+            # _notify_no_data should be called but should NOT post because of dedup
+            with patch(
+                "common.config_model.GitHubNotificationConfig.create_github_comment"
+            ) as mock_gh:
+                processor.process(cc=mock_cc)
+
+            mock_gh.assert_not_called()


### PR DESCRIPTION
## Summary

- When the HUD API returns zero benchmark data (target or baseline), the regression lambda now posts a GitHub comment instead of silently exiting. This addresses multi-day data outages (e.g. B200 total outage since Mar 5) going unnoticed.
- The `insufficient_data` report status now also triggers GitHub notifications, using a dedicated markdown template that makes clear this is a data availability alert, not a regression.
- No-data alerts are deduplicated via ClickHouse (one alert per day per config).

## Test plan

- [x] Added 6 unit tests in `tests/test_missing_data_alerts.py`
  - `test_notify_on_insufficient_data` — insufficient_data status triggers comment
  - `test_no_notify_on_no_regression` — no_regression does not trigger (existing behavior)
  - `test_notify_on_regression_unchanged` — regression still triggers (existing behavior)
  - `test_no_data_target_triggers_alert` — empty target data triggers no-data alert
  - `test_no_data_baseline_triggers_alert` — empty baseline data triggers no-data alert
  - `test_no_data_dedup` — dedup prevents duplicate alerts same day
- [x] All 6 tests pass locally