### PR TITLE
Add ghstack PR detection to Claude Code workflow

### DIFF
--- a/.github/workflows/_claude-code.yml
+++ b/.github/workflows/_claude-code.yml
@@ -141,7 +141,7 @@ jobs:
             ].join(',');
             core.setOutput('extra_claude_args', `--disallowedTools "${disabledTools}"`);
             core.setOutput('ghstack_notice',
-              'This is a ghstack PR. Write operations (file edits, git commits, git push) are disabled.');
+              'This is a ghstack PR. Write operations are disabled.');
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Adds a "Check for ghstack PR" step after "Verify write access" in the reusable Claude Code workflow
- Detects ghstack PRs by matching the head ref against `gh/<user>/<N>/head`
- When detected, runs Claude in read-only mode by passing `--disallowedTools` to block write operations (Edit, Write, NotebookEdit, git push/add/commit/rm, and MCP file ops)
- Appends a system prompt (`INPUT_APPEND_SYSTEM_PROMPT`) telling Claude it's a ghstack PR with writes disabled, so it explains the situation clearly instead of guessing at permissions issues
- Claude can still read code, search, and answer questions on ghstack PRs

Fixes T259491933

## Test plan
All tested on [pytorch/ciforge](https://github.com/pytorch/ciforge), human verified:
- [x] Trigger `@claude` on a ghstack PR — verify Claude responds but cannot push changes ([ciforge#183](https://github.com/pytorch/ciforge/pull/183))
- [x] Trigger `@claude` on a normal PR — verify no behavior change ([ciforge#184](https://github.com/pytorch/ciforge/pull/184))
- [x] Trigger `@claude` on an issue — verify ghstack check is skipped ([ciforge#185](https://github.com/pytorch/ciforge/issues/185))