### PR TITLE
[re]Release blast

### DIFF
--- a/.github/workflows/blast-release.yml
+++ b/.github/workflows/blast-release.yml
@@ -1,9 +1,7 @@
 name: Blast CLI Release
 
 on:
-  push:
-    tags:
-      - "blast-v*"
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -21,19 +19,30 @@ jobs:
           python-version: "3.11"
 
       - name: Install build tools
-        run: pip install build
+        run: pip install build==1.2.2
 
       - name: Build wheel
         run: |
           cd tools/remote_execution/blast
           python -m build --wheel
 
+      - name: Get version from wheel
+        id: version
+        run: |
+          WHEEL=$(ls tools/remote_execution/blast/dist/*.whl)
+          VERSION=$(echo "$WHEEL" | grep -oP '\d+\.\d+\.\d+')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Built version: $VERSION"
+
       - name: Smoke test
         run: |
           pip install tools/remote_execution/blast/dist/*.whl
           blast --help
 
-      - name: Upload wheel to GitHub Release
+      - name: Create tag and release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: blast-v${{ steps.version.outputs.version }}
+          name: Blast CLI v${{ steps.version.outputs.version }}
           files: tools/remote_execution/blast/dist/*.whl
+          generate_release_notes: true

--- a/.github/workflows/blast-release.yml
+++ b/.github/workflows/blast-release.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
@@ -40,9 +40,9 @@ jobs:
           blast --help
 
       - name: Create tag and release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05d0d1a5d7c9bf04 # v2.2.1
         with:
-          tag_name: blast-v${{ steps.version.outputs.version }}
+          tag_name: blast-cli-v${{ steps.version.outputs.version }}
           name: Blast CLI v${{ steps.version.outputs.version }}
           files: tools/remote_execution/blast/dist/*.whl
           generate_release_notes: true

--- a/.github/workflows/blast-release.yml
+++ b/.github/workflows/blast-release.yml
@@ -1,0 +1,39 @@
+name: Blast CLI Release
+
+on:
+  push:
+    tags:
+      - "blast-v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build wheel
+        run: |
+          cd tools/remote_execution/blast
+          python -m build --wheel
+
+      - name: Smoke test
+        run: |
+          pip install tools/remote_execution/blast/dist/*.whl
+          blast --help
+
+      - name: Upload wheel to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: tools/remote_execution/blast/dist/*.whl

--- a/tools/remote_execution/README.md
+++ b/tools/remote_execution/README.md
@@ -2,30 +2,44 @@
 
 Remote execution CLI for running multi-step jobs on Kubernetes.
 
+## Quick Install
+
+### Quick install (from GitHub Release)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/pytorch/test-infra/main/tools/remote_execution/install.sh | bash
+```
+
+This automatically downloads and installs the latest version. Run the same command to upgrade.
+
+### Development Install
+
+Clone the repo and install in editable mode:
+
+```bash
+git clone https://github.com/pytorch/test-infra.git
+cd test-infra/tools/remote_execution
+pip install -e blast/
+```
+
 ## Prerequisites
 
 - Python 3.9+
 - AWS CLI (`aws`) — installed and configured with SSO admin role or SSO gpu role
+- `kubectl` — configured for the EKS cluster:
+  ```bash
+  aws eks update-kubeconfig --name pytorch-re-prod-production --region us-east-2
+  ```
 
 ## Quick Start
 
 ```bash
-chmod +x setup.sh
-./setup.sh
-source ~/.blast-venv/bin/activate
-
 # Run a single step with pure command
 blast run --script "echo hello" --type cpu-44 --raw --follow
 
 # Run multi-step with predefined json input
 blast run-steps --config demo_script/simple/multi_run_simple.json --follow
 ```
-
-This will:
-1. Create a virtual environment at `~/.blast-venv`
-2. Install the Blast CLI (`pip install -e blast/`)
-3. Configure `~/.kube/config` for the EKS cluster
-4. Verify the installation
 
 ## Usage
 ### Run a single step
@@ -113,7 +127,8 @@ blast cancel <run_id>         # Cancel a run
 
 ```
 remote_execution/
-├── setup.sh                 # Setup script
+├── install.sh               # One-liner install script
+├── setup.sh                 # Dev setup script (editable install)
 ├── demo_script/             # Demo scripts and JSON configs
 │   ├── simple/              # Hello-world demos
 │   │   ├── build_demo.sh

--- a/tools/remote_execution/blast/pyproject.toml
+++ b/tools/remote_execution/blast/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "re-cli"
+name = "blast-cli"
 version = "0.1.0"
-description = "Elaine Playground CLI - Run tasks on remote infrastructure"
+description = "Blast CLI - Run tasks on remote infrastructure"
 readme = "README.md"
 requires-python = ">=3.9"
 license = {text = "MIT"}

--- a/tools/remote_execution/blast/src/re_cli/cli_helper.py
+++ b/tools/remote_execution/blast/src/re_cli/cli_helper.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
 
-import click
 from rich.panel import Panel
 from rich.table import Table
 
@@ -195,7 +194,7 @@ def build_step_configs_from_json(steps_json: list) -> list[StepConfig]:
 
 
 def execute_job(
-    ctx: click.Context,
+    client: object,
     step_configs: list[StepConfig],
     name: str,
     follow: bool,
@@ -237,7 +236,6 @@ def execute_job(
             if not cfg.runner_modules:
                 cfg.runner_modules = modules_without_submodule
 
-    client = ctx.obj["client"]
     runner = JobRunner(
         client=client,
         name=name,

--- a/tools/remote_execution/blast/src/re_cli/cli_helper.py
+++ b/tools/remote_execution/blast/src/re_cli/cli_helper.py
@@ -193,8 +193,11 @@ def build_step_configs_from_json(steps_json: list) -> list[StepConfig]:
 # =============================================================================
 
 
+from .core.k8s_client import K8sClient
+
+
 def execute_job(
-    client: object,
+    client: K8sClient,
     step_configs: list[StepConfig],
     name: str,
     follow: bool,

--- a/tools/remote_execution/blast/src/re_cli/main.py
+++ b/tools/remote_execution/blast/src/re_cli/main.py
@@ -12,6 +12,7 @@ Usage:
 """
 
 import sys
+from typing import cast
 
 import click
 from rich.panel import Panel
@@ -53,7 +54,7 @@ def cli(ctx, namespace, timeout, as_json):
     ctx.obj["_client"] = None
 
 
-def _get_client(ctx) -> K8sClient:
+def _get_client(ctx: click.Context) -> K8sClient:
     """Lazy-init K8sClient on first use. Call this instead of ctx.obj['client']."""
     if ctx.obj["_client"] is None:
         console.print("[Auth] getting K8sConfig")
@@ -62,7 +63,8 @@ def _get_client(ctx) -> K8sClient:
             timeout=ctx.obj["_k8s_timeout"],
         )
         ctx.obj["_client"] = K8sClient(config)
-    return ctx.obj["_client"]
+    client: K8sClient = cast(K8sClient, ctx.obj["_client"])
+    return client
 
 
 @cli.command("cancel")

--- a/tools/remote_execution/blast/src/re_cli/main.py
+++ b/tools/remote_execution/blast/src/re_cli/main.py
@@ -45,13 +45,24 @@ from .core.k8s_client import K8sClient, K8sConfig
 def cli(ctx, namespace, timeout, as_json):
     """Blast CLI - Run and monitor remote execution jobs."""
     ctx.ensure_object(dict)
-    # silence console output if --json output is used
     ctx.obj["as_json"] = as_json
     if as_json:
         console.quiet = True
-    console.print("[Auth] getting K8sConfig")
-    config = K8sConfig(namespace=namespace, timeout=timeout)
-    ctx.obj["client"] = K8sClient(config)
+    ctx.obj["_k8s_namespace"] = namespace
+    ctx.obj["_k8s_timeout"] = timeout
+    ctx.obj["_client"] = None
+
+
+def _get_client(ctx) -> K8sClient:
+    """Lazy-init K8sClient on first use. Call this instead of ctx.obj['client']."""
+    if ctx.obj["_client"] is None:
+        console.print("[Auth] getting K8sConfig")
+        config = K8sConfig(
+            namespace=ctx.obj["_k8s_namespace"],
+            timeout=ctx.obj["_k8s_timeout"],
+        )
+        ctx.obj["_client"] = K8sClient(config)
+    return ctx.obj["_client"]
 
 
 @cli.command("cancel")
@@ -62,7 +73,7 @@ def cancel(ctx, run_id):
     as_json = ctx.obj.get("as_json", False)
     import json
 
-    client = ctx.obj["client"]
+    client = _get_client(ctx)
 
     try:
         result = client.cancel_run(run_id)
@@ -87,7 +98,7 @@ def task_status(ctx, task_id):
     import json
 
     as_json = ctx.obj.get("as_json", False)
-    client = ctx.obj["client"]
+    client = _get_client(ctx)
 
     try:
         if as_json:
@@ -111,7 +122,7 @@ def run_status(ctx, run_id, detail):
 
     as_json = ctx.obj.get("as_json", False)
 
-    client = ctx.obj["client"]
+    client = _get_client(ctx)
 
     try:
         run_info = client.query_run_status(run_id)
@@ -212,7 +223,7 @@ def logs(ctx, id, task):
     from .core.core_types import TaskInfo
     from .core.log_stream import follow_all_steps
 
-    client = ctx.obj["client"]
+    client = _get_client(ctx)
 
     try:
         if task:
@@ -438,7 +449,7 @@ def run_single(
         additional=(),
     )
     execute_job(
-        ctx,
+        _get_client(ctx),
         step_configs,
         job_name,
         follow,
@@ -634,7 +645,7 @@ def run_steps(
         sys.exit(1)
 
     execute_job(
-        ctx,
+        _get_client(ctx),
         step_configs,
         name,
         follow,

--- a/tools/remote_execution/install.sh
+++ b/tools/remote_execution/install.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="pytorch/test-infra"
+
+echo "=== Blast CLI Installer ==="
+echo ""
+
+# Check Python 3.9+
+if ! command -v python3 &>/dev/null; then
+    echo "ERROR: python3 not found. Please install Python 3.9+."
+    exit 1
+fi
+
+PY_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+PY_MAJOR=$(echo "$PY_VERSION" | cut -d. -f1)
+PY_MINOR=$(echo "$PY_VERSION" | cut -d. -f2)
+
+if [ "$PY_MAJOR" -lt 3 ] || { [ "$PY_MAJOR" -eq 3 ] && [ "$PY_MINOR" -lt 9 ]; }; then
+    echo "ERROR: Python 3.9+ required, found Python $PY_VERSION"
+    exit 1
+fi
+echo "✓ Python $PY_VERSION"
+
+# Install from latest GitHub Release
+echo ""
+echo "Installing Blast CLI from latest release..."
+WHEEL_URL=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=50" | python3 -c "
+import json, sys
+for r in json.load(sys.stdin):
+    if r['tag_name'].startswith('blast-v'):
+        for a in r.get('assets', []):
+            if a['name'].endswith('.whl'):
+                print(a['browser_download_url'])
+                sys.exit(0)
+sys.exit(1)
+")
+
+if [[ -z "$WHEEL_URL" ]]; then
+    echo "ERROR: No blast release found on GitHub"
+    exit 1
+fi
+
+echo "Downloading: $WHEEL_URL"
+pip install "$WHEEL_URL"
+echo "✓ Blast CLI installed"
+
+# Verify installation
+if ! command -v blast &>/dev/null; then
+    echo "ERROR: blast command not found after install. Check your PATH."
+    exit 1
+fi
+echo "✓ blast command available"
+
+# Configure kubectl for EKS cluster
+echo ""
+echo "Configuring kubectl for EKS cluster..."
+if command -v aws &>/dev/null; then
+    if ! aws eks update-kubeconfig --name pytorch-re-prod-production --region us-east-2; then
+        echo ""
+        echo "ERROR: Failed to configure kubectl."
+        echo "  Make sure your AWS credentials are set up correctly:"
+        echo "    aws sso login"
+        echo "  Then re-run this script."
+        exit 1
+    fi
+    echo "✓ kubectl configured"
+else
+    echo "⚠ aws CLI not found — skipping kubectl config."
+    echo "  Install AWS CLI and run:"
+    echo "    aws eks update-kubeconfig --name pytorch-re-prod-production --region us-east-2"
+fi
+
+echo ""
+echo "=== Installation complete ==="
+echo "Run 'blast --help' to get started."

--- a/tools/remote_execution/install.sh
+++ b/tools/remote_execution/install.sh
@@ -28,7 +28,7 @@ echo "Installing Blast CLI from latest release..."
 WHEEL_URL=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=50" | python3 -c "
 import json, sys
 for r in json.load(sys.stdin):
-    if r['tag_name'].startswith('blast-v'):
+    if r['tag_name'].startswith('blast-cli-v'):
         for a in r.get('assets', []):
             if a['name'].endswith('.whl'):
                 print(a['browser_download_url'])
@@ -42,7 +42,7 @@ if [[ -z "$WHEEL_URL" ]]; then
 fi
 
 echo "Downloading: $WHEEL_URL"
-pip install "$WHEEL_URL"
+pip install "$WHEEL_URL" --force-reinstall --quiet
 echo "✓ Blast CLI installed"
 
 # Verify installation
@@ -69,6 +69,7 @@ else
     echo "⚠ aws CLI not found — skipping kubectl config."
     echo "  Install AWS CLI and run:"
     echo "    aws eks update-kubeconfig --name pytorch-re-prod-production --region us-east-2"
+    echo "  please notice that you need to be authenticated to use this tool"
 fi
 
 echo ""

--- a/tools/remote_execution/setup.sh
+++ b/tools/remote_execution/setup.sh
@@ -28,7 +28,14 @@ pip install -e "$SCRIPT_DIR/blast" --quiet
 
 # 4. Configure kubectl
 echo "[3/4] Configuring kubectl for $CLUSTER ($REGION)..."
-aws eks update-kubeconfig --name "$CLUSTER" --region "$REGION"
+if ! aws eks update-kubeconfig --name "$CLUSTER" --region "$REGION"; then
+    echo ""
+    echo "ERROR: Failed to configure kubectl."
+    echo "  Make sure your AWS credentials are set up correctly:"
+    echo "    aws sso login"
+    echo "  Then re-run this script."
+    exit 1
+fi
 
 # 5. Verify
 echo "[4/4] Verifying..."


### PR DESCRIPTION
# overview
add workflow to release blast binary , manually only, it will create 
tag： blast-v${{ steps.version.outputs.version }}, same version will be overrided.

# others
remove kubeconfig init from main cli entrypoint, this avoid triger kubeconfig auth for non client cli command such as --help and --history


# how to install 
user simply run:
```
curl -fsSL https://raw.githubusercontent.com/pytorch/test-infra/main/tools/remote_execution/install.sh | bash
```
to get latest cli binary



