### PR TITLE
MacOS wheels py3.10-3.12 -> macosx_11_0 . For py3.13-3.14 -> macosx_12_0 whls (#7848)

### DIFF
--- a/tools/pkg-helpers/pytorch_pkg_helpers/macos.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/macos.py
@@ -1,6 +1,12 @@
 def get_macos_variables(arch_name: str, python_version: str = "3.8") -> list:
+    # Python 3.13+ requires macOS 12.0
+    # Handle full point versions like "3.11.14" and freethreaded like "3.13t"
+    parts = python_version.rstrip("t").split(".")
+    base_version = float(f"{parts[0]}.{parts[1]}")
+    deployment_target = "12.0" if base_version >= 3.13 else "11.0"
     variables = [
-        "export MACOSX_DEPLOYMENT_TARGET=10.15",
+        f"export MACOSX_DEPLOYMENT_TARGET={deployment_target}",
+        f"export _PYTHON_HOST_PLATFORM=macosx-{deployment_target}-arm64",
         "export CC=clang",
         "export CXX=clang++",
     ]

--- a/tools/pkg-helpers/tests/test_macos.py
+++ b/tools/pkg-helpers/tests/test_macos.py
@@ -3,26 +3,22 @@ from pytorch_pkg_helpers.macos import get_macos_variables
 
 
 @pytest.mark.parametrize(
-    "arch_name,expected",
+    "python_version,expected_target",
     [
-        (
-            ("arm64"),
-            [
-                "export MACOSX_DEPLOYMENT_TARGET=10.9",
-                "export CC=clang",
-                "export CXX=clang++",
-            ],
-        ),
-        (
-            ("x86_64"),
-            [
-                "export MACOSX_DEPLOYMENT_TARGET=10.9",
-                "export CC=clang",
-                "export CXX=clang++",
-                "export CONDA_EXTRA_BUILD_CONSTRAINT='- mkl<=2021.2.0'",
-            ],
-        ),
+        ("3.10", "11.0"),
+        ("3.11", "11.0"),
+        ("3.12", "11.0"),
+        ("3.13", "12.0"),
+        ("3.13t", "12.0"),
+        ("3.14", "12.0"),
+        ("3.14t", "12.0"),
     ],
 )
-def test_get_macos_variables(arch_name, expected):
-    assert get_macos_variables(arch_name) == expected
+def test_get_macos_variables(python_version, expected_target):
+    result = get_macos_variables("arm64", python_version)
+    assert result == [
+        f"export MACOSX_DEPLOYMENT_TARGET={expected_target}",
+        f"export _PYTHON_HOST_PLATFORM=macosx-{expected_target}-arm64",
+        "export CC=clang",
+        "export CXX=clang++",
+    ]

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -26,6 +26,14 @@ PYTHON_ARCHES_DICT = {
     "test": ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"],
     "release": ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"],
 }
+
+MACOS_PYTHON_POINT_VERSIONS = {
+    "3.10": "3.10.19",
+    "3.11": "3.11.14",
+    "3.12": "3.12.12",
+    "3.13": "3.13",
+    "3.14": "3.14.3",
+}
 CUDA_ARCHES_DICT = {
     "nightly": ["12.6", "12.8", "13.0"],
     "test": ["12.6", "12.8", "13.0"],
@@ -483,8 +491,16 @@ def generate_wheels_matrix(
                 continue
 
             desired_cuda = translate_desired_cuda(gpu_arch_type, gpu_arch_version)
+
+            # For macOS, use pinned .0 point versions for consistent builds
+            effective_python_version = python_version
+            if os == MACOS_ARM64:
+                effective_python_version = MACOS_PYTHON_POINT_VERSIONS.get(
+                    python_version, python_version
+                )
+
             entry = {
-                "python_version": python_version,
+                "python_version": effective_python_version,
                 "gpu_arch_type": gpu_arch_type,
                 "gpu_arch_version": gpu_arch_version,
                 "desired_cuda": desired_cuda,


### PR DESCRIPTION
This constraints
MacOS builds as follows:
Py 3.10-3.12 builds should support macosx_11 as minos Py 3.13, 3.13t, 3.14 and 3.14t  builds should support macosx_11 as minos

Reason: We can build 3.13, 3.13t, 3.14, 3.14t due to conda python version not supporting MacOS 11:
https://anaconda.org/channels/main/packages/python/overview