### PR TITLE
[CI] Enable setup xpu in linux job v2 workflow

### DIFF
--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -176,11 +176,15 @@ jobs:
 
       - name: Setup Linux
         uses: ./test-infra/.github/actions/setup-linux
-        if: ${{ inputs.gpu-arch-type != 'rocm' }}
+        if: ${{ inputs.gpu-arch-type != 'rocm' || inputs.gpu-arch-version != 'xpu' }}
 
       - name: Setup ROCM
         uses: pytorch/pytorch/.github/actions/setup-rocm@main
         if: ${{ inputs.gpu-arch-type == 'rocm' }}
+
+      - name: Setup XPU
+        uses: pytorch/pytorch/.github/actions/setup-xpu@main
+        if: ${{ inputs.gpu-arch-type == 'xpu' }}
 
       - name: Setup SSH
         uses: ./test-infra/.github/actions/setup-ssh


### PR DESCRIPTION
Add setup xpu in linux_job_v2.yml. It depends on https://github.com/pytorch/pytorch/pull/177831