### PR TITLE
Promote wheels to both S3 and Cloudflare R2 during release

### DIFF
--- a/.github/workflows/release-download-pytorch-org.yml
+++ b/.github/workflows/release-download-pytorch-org.yml
@@ -52,6 +52,9 @@ jobs:
         env:
           PACKAGE: ${{ inputs.package || 'torchvision' }}
           DRY_RUN: ${{ inputs.dryrun || 'enabled' }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: |
             set -ex
             cd release

--- a/release/promote/common_utils.sh
+++ b/release/promote/common_utils.sh
@@ -82,3 +82,97 @@ aws_promote() {
         fi
     fi
 }
+
+r2_promote() {
+    package_name=$1
+    pytorch_version=$(get_pytorch_version)
+
+    # Check if R2 credentials are available
+    if [[ -z "${R2_ACCOUNT_ID:-}" || -z "${R2_ACCESS_KEY_ID:-}" || -z "${R2_SECRET_ACCESS_KEY:-}" ]]; then
+        echo "- WARNING: R2 credentials not configured, skipping R2 promotion"
+        return 0
+    fi
+
+    DRY_RUN=${DRY_RUN:-enabled}
+    AWS=${AWS:-aws}
+    R2_ENDPOINT_URL="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+    R2_BUCKET="s3://pytorch-downloads"
+
+    # Map S3 destination path to R2 path
+    # S3: s3://pytorch/whl/ -> R2: s3://pytorch-downloads/whl/
+    r2_dest="${PYTORCH_S3_TO/s3:\/\/pytorch/${R2_BUCKET}}"
+
+    echo "=-=-=-= Promoting ${package_name} v${pytorch_version} to R2 =-=-=-="
+    echo "+ R2 destination: ${r2_dest}"
+
+    if [[ $DRY_RUN = "enabled" ]]; then
+        echo "+ DRY RUN: Would copy matching files from ${PYTORCH_S3_FROM} to R2 ${r2_dest}"
+        # List what would be copied
+        ${AWS} s3 ls "${PYTORCH_S3_FROM/\/$//}/" --recursive \
+            | grep "${package_name}-${pytorch_version}${PACKAGE_INCLUDE_SUFFIX:-}" || true
+        return 0
+    fi
+
+    # Save current AWS credentials (OIDC-based for S3)
+    local saved_aws_access_key_id="${AWS_ACCESS_KEY_ID:-}"
+    local saved_aws_secret_access_key="${AWS_SECRET_ACCESS_KEY:-}"
+    local saved_aws_session_token="${AWS_SESSION_TOKEN:-}"
+    local saved_aws_default_region="${AWS_DEFAULT_REGION:-}"
+
+    # Create a temporary directory for downloads
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    trap "rm -rf ${tmp_dir}" RETURN
+
+    # Download matching files from S3 (using current OIDC credentials)
+    echo "+ Downloading matching files from S3..."
+    (
+        set -x
+        ${AWS} s3 cp \
+            --recursive \
+            --exclude '*' \
+            --include "*${package_name}-${pytorch_version}${PACKAGE_INCLUDE_SUFFIX:-*}" \
+            "${PYTORCH_S3_FROM/\/$//}" \
+            "${tmp_dir}/"
+    )
+
+    # Switch to R2 credentials
+    export AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
+    export AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
+    unset AWS_SESSION_TOKEN
+    export AWS_DEFAULT_REGION="auto"
+
+    # Upload each file to R2 with sha256 metadata
+    echo "+ Uploading files to R2..."
+    local file_count=0
+    for pkg in "${tmp_dir}"/*; do
+        if [[ ! -f "${pkg}" ]]; then
+            continue
+        fi
+        local filename
+        filename=$(basename "${pkg}")
+        local sha256
+        sha256=$(sha256sum "${pkg}" | awk '{print $1}')
+        (
+            set -x
+            ${AWS} s3 cp "${pkg}" "${r2_dest/\/$//}/${filename}" \
+                --metadata "checksum-sha256=${sha256}" \
+                --endpoint-url "${R2_ENDPOINT_URL}"
+        )
+        file_count=$((file_count + 1))
+    done
+
+    echo "+ Uploaded ${file_count} files to R2"
+
+    # Restore original AWS credentials
+    export AWS_ACCESS_KEY_ID="${saved_aws_access_key_id}"
+    export AWS_SECRET_ACCESS_KEY="${saved_aws_secret_access_key}"
+    if [[ -n "${saved_aws_session_token}" ]]; then
+        export AWS_SESSION_TOKEN="${saved_aws_session_token}"
+    fi
+    if [[ -n "${saved_aws_default_region}" ]]; then
+        export AWS_DEFAULT_REGION="${saved_aws_default_region}"
+    else
+        unset AWS_DEFAULT_REGION
+    fi
+}

--- a/release/promote/s3_to_s3.sh
+++ b/release/promote/s3_to_s3.sh
@@ -17,3 +17,6 @@ TO=${TO:-}
 PYTORCH_S3_TO=${PYTORCH_S3_TO:-${PYTORCH_S3_BUCKET}/${PACKAGE_TYPE}/${TO}}
 
 aws_promote "${PACKAGE_NAME}"
+
+# Also promote to R2 (Cloudflare) if credentials are available
+r2_promote "${PACKAGE_NAME}"


### PR DESCRIPTION
## Summary
  - Add R2 (Cloudflare) promotion to the wheel promotion pipeline so that stable/release
    binaries are available on both `download.pytorch.org` (S3) and `download-r2.pytorch.org` (R2)
  - Previously, only nightly wheels were uploaded to R2 at build time. Stable promotions
    (test -> prod) only targeted S3, leaving R2 without release wheels.
  - Add `r2_promote()` function in `common_utils.sh` that downloads matching wheels from S3
    and uploads them to the R2 bucket (`pytorch-downloads`) with SHA256 metadata
  - R2 promotion is a no-op when R2 credentials are not set, maintaining backward compatibility
    for local runs without R2 access
  - Pass R2 secrets in `release-download-pytorch-org.yml` workflow

  ## Files Changed
  - `release/promote/common_utils.sh` — New `r2_promote()` function
  - `release/promote/s3_to_s3.sh` — Call `r2_promote` after `aws_promote`
  - `.github/workflows/release-download-pytorch-org.yml` — Pass R2 secrets to promotion step

  ## Test plan
  - [ ] Run with `DRY_RUN=enabled` (default) — verifies script logic, lists files that would be copied
  - [ ] Run with R2 env vars unset — confirm graceful skip with warning message
  - [ ] Run with `DRY_RUN=disabled` and R2 credentials — verify files land in `s3://pytorch-downloads/whl/` - on Release day
  - [ ] Verify S3 promotion is unaffected (no behavior change to existing `aws_promote`)  - on Release day