### PR TITLE
Use short python version for macos builds (#7854)

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -83,7 +83,10 @@ runs:
           # Set artifact name here since github actions doesn't have string manipulation tools
           # and "/" is not allowed in artifact names. //\//_ is to replace all forward slashes,
           # not just the first one
-          echo "ARTIFACT_NAME=${REPOSITORY//\//_}_${REF//\//_}_${PYTHON_VERSION}_${CU_VERSION}_${ARCH}" >> "${GITHUB_ENV}"
+          # Convert long python version (e.g. 3.10.19) to short major.minor version
+          # (e.g. 3.10), while preserving special suffixes like "t" (e.g. 3.13t, 3.14t)
+          SHORT_PYTHON_VERSION=$(echo "${PYTHON_VERSION}" | sed -E 's/^([0-9]+\.[0-9]+[a-z]?).*/\1/')
+          echo "ARTIFACT_NAME=${REPOSITORY//\//_}_${REF//\//_}_${SHORT_PYTHON_VERSION}_${CU_VERSION}_${ARCH}" >> "${GITHUB_ENV}"
       - name: Setup miniconda (for pytorch_pkg_helpers)
         if: ${{ inputs.setup-miniconda == 'true' }}
         uses: conda-incubator/setup-miniconda@v3.1.1

--- a/.github/actions/setup-binary-upload/action.yml
+++ b/.github/actions/setup-binary-upload/action.yml
@@ -52,7 +52,10 @@ runs:
         # Set artifact name here since github actions doesn't have string manipulation tools
         # and "/" is not allowed in artifact names. //\//_ is to replace all forward slashes,
         # not just the first one
-        echo "ARTIFACT_NAME=${REPOSITORY//\//_}_${REF//\//_}_${PYTHON_VERSION}_${CU_VERSION}_${ARCH}" >> "${GITHUB_ENV}"
+        # Convert long python version (e.g. 3.10.19) to short major.minor version
+        # (e.g. 3.10), while preserving special suffixes like "t" (e.g. 3.13t, 3.14t)
+        SHORT_PYTHON_VERSION=$(echo "${PYTHON_VERSION}" | sed -E 's/^([0-9]+\.[0-9]+[a-z]?).*/\1/')
+        echo "ARTIFACT_NAME=${REPOSITORY//\//_}_${REF//\//_}_${SHORT_PYTHON_VERSION}_${CU_VERSION}_${ARCH}" >> "${GITHUB_ENV}"
 
     # Need to checkout the target repository to run pkg-helpers
     - uses: actions/checkout@v4


### PR DESCRIPTION
After https://github.com/pytorch/test-infra/pull/7848 - we would like to make sure that short python version is used for artifact name