### PR TITLE
[CI] Fix condition in linux_job_v2 causing Setup Linux to trigger on ROCm tests

### DIFF
--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -176,7 +176,7 @@ jobs:
 
       - name: Setup Linux
         uses: ./test-infra/.github/actions/setup-linux
-        if: ${{ inputs.gpu-arch-type != 'rocm' || inputs.gpu-arch-version != 'xpu' }}
+        if: ${{ inputs.gpu-arch-type != 'rocm' && inputs.gpu-arch-type != 'xpu' }}
 
       - name: Setup ROCM
         uses: pytorch/pytorch/.github/actions/setup-rocm@main


### PR DESCRIPTION
I think the intent of this logic was to skip if the arch type is 'rocm' or 'xpu', so we need to make this an && (only run if the type is not one of the two). Also updated `inputs.gpu-arch-version` to `inputs.gpu-arch-type`.