### PR TITLE
Add libomp-devel to base Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,6 +18,7 @@ RUN dnf install -y \
         gdb \
         git \
         jq \
+        libomp-devel \
         make \
         sudo \
         unzip \


### PR DESCRIPTION
This goes together with clang installation