### PR TITLE
Add release-docker workflow

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -18,7 +18,7 @@ on:
         description: 'Dry run (skip push to Docker Hub)'
         required: false
         type: boolean
-        default: false
+        default: true
       channel:
         description: 'Channel to use for matrix generation'
         required: false


### PR DESCRIPTION
Automate publishing of docker images from https://github.com/orgs/pytorch/packages/container/package/pytorch to 
https://hub.docker.com/r/pytorch/pytorch/tags

Please note. This runs in environment: ``promote-env`` and require PyTorch Dev Infra member approval to execute