### PR TITLE
Add missing dependency boto3 to release download.pytorch.org

### DIFF
--- a/.github/workflows/release-download-pytorch-org.yml
+++ b/.github/workflows/release-download-pytorch-org.yml
@@ -60,7 +60,8 @@ jobs:
             set -ex
             cd release
             # Install requirements
-            pip install awscli==1.32.18 boto3
+            pip install awscli==1.32.18
+            pip install -r s3_management/requirements.txt
 
             promote_s3() {
               local package_name


### PR DESCRIPTION
This is required in order to recompute the missing sha256