### PR TITLE
Add missing dependency boto3 to release download.pytorch.org

### DIFF
--- a/.github/workflows/release-download-pytorch-org.yml
+++ b/.github/workflows/release-download-pytorch-org.yml
@@ -61,7 +61,7 @@ jobs:
             cd release
             # Install requirements
             pip install awscli==1.32.18
-            pip install -r s3_management/requirements.txt
+            pip install -r ../s3_management/requirements.txt
 
             promote_s3() {
               local package_name


### PR DESCRIPTION
The code does 
```
cd release
```
on line 61 . Hence this change is necessary to fix the sha step