### PR TITLE
Use manylinux_2_28 base image for docker builds

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -22,26 +22,26 @@ jobs:
           # --- CPU ---
           - runner: mt-l-x86iamx-8-16
             platform: linux/amd64
-            base_image: quay.io/pypa/manylinux_2_34_x86_64
+            base_image: quay.io/pypa/manylinux_2_28_x86_64
             install_cuda: ""
             variant_tag: cpu-x86_64
             buildkit_addr: tcp://buildkitd-amd64.buildkit:1234
           - runner: mt-l-arm64g2-6-32
             platform: linux/arm64
-            base_image: quay.io/pypa/manylinux_2_34_aarch64
+            base_image: quay.io/pypa/manylinux_2_28_aarch64
             install_cuda: ""
             variant_tag: cpu-aarch64
             buildkit_addr: tcp://buildkitd-arm64.buildkit:1234
           # --- CUDA (all versions in one image, self-hosted DinD runners) ---
           - runner: mt-l-x86iamx-8-16
             platform: linux/amd64
-            base_image: quay.io/pypa/manylinux_2_34_x86_64
+            base_image: quay.io/pypa/manylinux_2_28_x86_64
             install_cuda: "1"
             variant_tag: cuda-x86_64
             buildkit_addr: tcp://buildkitd-amd64.buildkit:1234
           - runner: mt-l-arm64g2-6-32
             platform: linux/arm64
-            base_image: quay.io/pypa/manylinux_2_34_aarch64
+            base_image: quay.io/pypa/manylinux_2_28_aarch64
             install_cuda: "1"
             variant_tag: cuda-aarch64
             buildkit_addr: tcp://buildkitd-arm64.buildkit:1234

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG BASE_IMAGE=quay.io/pypa/manylinux_2_34_x86_64
+ARG BASE_IMAGE=quay.io/pypa/manylinux_2_28_x86_64
 FROM ${BASE_IMAGE}
 
 # INSTALL_CUDA: set to any non-empty value (e.g. "1") to install all CUDA versions;


### PR DESCRIPTION
Switch from manylinux_2_34 (glibc 2.34, AlmaLinux 9) to manylinux_2_28 (glibc 2.28, AlmaLinux 8) for broader compatibility across both x86_64 and aarch64 CPU/CUDA variants.