### PR TITLE
Add 'advisor' to autorevert_events_v2 action enum

### DIFF
--- a/clickhouse_db_schema/misc.autorevert_events_v2/schema.sql
+++ b/clickhouse_db_schema/misc.autorevert_events_v2/schema.sql
@@ -2,7 +2,7 @@ CREATE TABLE misc.autorevert_events_v2
 (
     `ts` DateTime DEFAULT now(),
     `repo` LowCardinality(String) DEFAULT 'pytorch/pytorch',
-    `action` Enum8('none' = 0, 'restart' = 1, 'revert' = 2),
+    `action` Enum8('none' = 0, 'restart' = 1, 'revert' = 2, 'advisor' = 3),
     `commit_sha` FixedString(40),
     `workflows` Array(String),
     `source_signal_keys` Array(String),


### PR DESCRIPTION
## Summary

- Adds `'advisor' = 3` to the `action` Enum8 column in `misc.autorevert_events_v2`

The autorevert AI advisor lambda ([pytorch/pytorch PR #177404](https://github.com/pytorch/pytorch/pull/177404)) writes `action='advisor'` when logging dispatch events to ClickHouse. However, the table's Enum8 only accepted `none`, `restart`, `revert` — causing ClickHouse to silently store advisor rows as `action='none'`.

This broke `prior_advisor_exists()` and `advisor_count_for_commit()` which query `WHERE action = 'advisor'` — they always returned false/0, so the lambda re-dispatched the advisor workflow for the same (commit, signal) every ~5 minutes indefinitely.

Already applied live:
```sql
ALTER TABLE misc.autorevert_events_v2
  MODIFY COLUMN `action` Enum8('none' = 0, 'restart' = 1, 'revert' = 2, 'advisor' = 3)
```

## Test plan
- [x] Verify schema file matches expected Enum values
- [x] Apply ALTER TABLE on the live ClickHouse instance
- [ ] Confirm subsequent advisor dispatches create rows with `action='advisor'`
- [ ] Confirm `prior_advisor_exists()` returns true after first dispatch, preventing duplicates