### PR TITLE
Pre-install all CI compilers in base Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,45 @@ RUN dnf install -y \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 
+# Install GCC toolset versions needed by CI.
+# The manylinux_2_28 base image (AlmaLinux 8) ships with GCC 8 as the system
+# default and bundles gcc-toolset-12 under /usr/local/bin. Install the
+# additional toolset versions that PyTorch CI requires.
+RUN dnf install -y \
+        gcc-toolset-11-gcc \
+        gcc-toolset-11-gcc-c++ \
+        gcc-toolset-11-gcc-gfortran \
+        gcc-toolset-13-gcc \
+        gcc-toolset-13-gcc-c++ \
+        gcc-toolset-13-gcc-gfortran \
+        gcc-toolset-14-gcc \
+        gcc-toolset-14-gcc-c++ \
+        gcc-toolset-14-gcc-gfortran \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+
+# Install pre-built clang 15 and 18 (clang 20 is already the system default)
+RUN ARCH=$(uname -m) && PLATFORM="linux-${ARCH}" && \
+    for CLANG_VERSION in 15 18; do \
+        S3_URL="https://gha-artifacts.s3.amazonaws.com/clang/${PLATFORM}/clang-${CLANG_VERSION}/clang-${CLANG_VERSION}-${PLATFORM}.tar.gz" && \
+        INSTALL_DIR="/opt/clang-${CLANG_VERSION}" && \
+        echo "Installing clang ${CLANG_VERSION} from ${S3_URL}" && \
+        curl -fsSL "${S3_URL}" -o /tmp/clang.tar.gz && \
+        mkdir -p "${INSTALL_DIR}" && \
+        tar xzf /tmp/clang.tar.gz -C "${INSTALL_DIR}" --strip-components=1 && \
+        rm -f /tmp/clang.tar.gz; \
+    done
+
+# Register clang runtime library directories so the linker can find libclang_rt.asan.so
+# etc. without needing LD_LIBRARY_PATH hacks at CI time.
+RUN for CLANG_VERSION in 15 18; do \
+        INSTALL_DIR="/opt/clang-${CLANG_VERSION}" && \
+        CLANG_RT_DIR=$("${INSTALL_DIR}/bin/clang" --print-runtime-dir 2>/dev/null || true) && \
+        if [ -n "${CLANG_RT_DIR}" ] && [ -d "${CLANG_RT_DIR}" ]; then \
+            echo "${CLANG_RT_DIR}" > "/etc/ld.so.conf.d/clang-${CLANG_VERSION}.conf"; \
+        fi; \
+    done && ldconfig
+
 # Install uv (Python package manager) — needed before CUDA install for uv run
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH="/root/.local/bin:${PATH}"


### PR DESCRIPTION
Pre-install GCC 11, GCC 13, GCC 14, clang 15, and clang 18 in the base image so that the setup-linux action only needs to activate the right compiler instead of downloading/installing at runtime. This reduces CI job latency and removes fragile S3/dnf dependencies from the critical path.

Also register clang runtime library directories with ldconfig so that libclang_rt.asan.so is discoverable by the linker without LD_LIBRARY_PATH workarounds in CI scripts.