### PR TITLE
[torch release 2026]Bump MACOSX_DEPLOYMENT_TARGET to 14.0

### DIFF
--- a/tools/pkg-helpers/pytorch_pkg_helpers/macos.py
+++ b/tools/pkg-helpers/pytorch_pkg_helpers/macos.py
@@ -1,9 +1,5 @@
 def get_macos_variables(arch_name: str, python_version: str = "3.8") -> list:
-    # Python 3.13+ requires macOS 12.0
-    # Handle full point versions like "3.11.14" and freethreaded like "3.13t"
-    parts = python_version.rstrip("t").split(".")
-    base_version = float(f"{parts[0]}.{parts[1]}")
-    deployment_target = "12.0" if base_version >= 3.13 else "11.0"
+    deployment_target = "14.0"
     variables = [
         f"export MACOSX_DEPLOYMENT_TARGET={deployment_target}",
         f"export _PYTHON_HOST_PLATFORM=macosx-{deployment_target}-arm64",

--- a/tools/pkg-helpers/tests/test_macos.py
+++ b/tools/pkg-helpers/tests/test_macos.py
@@ -5,13 +5,13 @@ from pytorch_pkg_helpers.macos import get_macos_variables
 @pytest.mark.parametrize(
     "python_version,expected_target",
     [
-        ("3.10", "11.0"),
-        ("3.11", "11.0"),
-        ("3.12", "11.0"),
-        ("3.13", "12.0"),
-        ("3.13t", "12.0"),
-        ("3.14", "12.0"),
-        ("3.14t", "12.0"),
+        ("3.10", "14.0"),
+        ("3.11", "14.0"),
+        ("3.12", "14.0"),
+        ("3.13", "14.0"),
+        ("3.13t", "14.0"),
+        ("3.14", "14.0"),
+        ("3.14t", "14.0"),
     ],
 )
 def test_get_macos_variables(python_version, expected_target):


### PR DESCRIPTION
## Summary
https://github.com/pytorch/pytorch/issues/177303

- Simplify `get_macos_variables` to always use `14.0` as deployment target (removes Python version conditional)
- Update all test expected values to `14.0`
- Companion PR in pytorch repo: https://github.com/pytorch/pytorch/pull/179083

## Files changed
- `tools/pkg-helpers/pytorch_pkg_helpers/macos.py`
- `tools/pkg-helpers/tests/test_macos.py`

## Test plan
- [ ] `python -m pytest tools/pkg-helpers/tests/test_macos.py` passes

Co-authored-by: Claude <noreply@anthropic.com>