### PR TITLE
Default Docker images to GCC 13 and remove GCC 14

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,11 +55,12 @@ RUN dnf install -y \
         gcc-toolset-13-gcc \
         gcc-toolset-13-gcc-c++ \
         gcc-toolset-13-gcc-gfortran \
-        gcc-toolset-14-gcc \
-        gcc-toolset-14-gcc-c++ \
-        gcc-toolset-14-gcc-gfortran \
     && dnf clean all \
     && rm -rf /var/cache/dnf
+
+# Default to gcc-toolset-13 (matching aarch64 and legacy manylinux builders).
+ENV PATH=/opt/rh/gcc-toolset-13/root/usr/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-13/root/usr/lib64:/opt/rh/gcc-toolset-13/root/usr/lib:$LD_LIBRARY_PATH
 
 # Install pre-built clang 15 and 18 (clang 20 is already the system default)
 RUN ARCH=$(uname -m) && PLATFORM="linux-${ARCH}" && \

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -52,9 +52,6 @@ RUN dnf install -y \
         gcc-toolset-13-gcc-c++ \
         gcc-toolset-13-gcc-gfortran \
         gcc-toolset-13-gdb \
-        gcc-toolset-14-gcc \
-        gcc-toolset-14-gcc-c++ \
-        gcc-toolset-14-gcc-gfortran \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 

--- a/docker/install_cuda.py
+++ b/docker/install_cuda.py
@@ -32,7 +32,7 @@ PYTORCH_MATRIX_URL = (
 )
 
 # CUDA arches to skip (PyTorch supports them but we don't build Docker images for them)
-SKIP_CUDA_ARCHES = {"12.6"}
+SKIP_CUDA_ARCHES = {"12.9"}
 
 # ---------------------------------------------------------------------------
 # Fetching & parsing PyTorch version info


### PR DESCRIPTION
## Summary

  - Default x86_64 Docker image to gcc-toolset-13, matching the
  aarch64 image and legacy manylinux builders. GCC 14 caused issues
   with CUDA 12.6 nvcc (only supports up to GCC 13) and ld.gold
  incompatibilities with CMake 4.3's --dependency-file flag.
  - Add `patch_libstdc.sh` to x86_64 Dockerfile to weaken
  `recursive_directory_iterator` symbols in GCC 13's
  `libstdc++_nonshared.a`, preventing them from appearing as strong
   (T) symbols in `libtorch_cpu.so` (pytorch/pytorch#133437).
  - Remove gcc-toolset-14 installation from both x86_64 and aarch64
   images since it is no longer needed.
  - Also includes CUDA 12.6 addition to the Docker image.

  ## Test plan

  - [ ] Build CPU and CUDA x86_64 images and verify `gcc --version`
   reports GCC 13
  - [ ] Build aarch64 images and verify `gcc --version` reports GCC
   13
  - [ ] Verify `nm -g $(gcc -print-file-name=libstdc++_nonshared.a)
   | grep " T .*recursive_directory_iterator"` returns empty
  (symbols weakened)
  - [ ] Build a PyTorch wheel in the new image and verify
  `check_binary_symbols.py` passes (no strong
  `recursive_directory_iterator` symbols in `libtorch_cpu.so`)
  - [ ] Verify CUDA 12.6 nvcc compiles successfully with GCC 13