### PR TITLE
Add python_versions to validate-domain-library.yml

### DIFF
--- a/.github/workflows/validate-domain-library.yml
+++ b/.github/workflows/validate-domain-library.yml
@@ -54,6 +54,11 @@ on:
         default: ""
         required: false
         type: string
+      python_versions:
+        description: "A JSON-encoded list of python versions to validate. An empty list means validating all supported versions"
+        default: "[]"
+        required: false
+        type: string
 
 jobs:
   generate-linux-matrix:
@@ -65,6 +70,7 @@ jobs:
       channel: ${{ inputs.channel }}
       with-cuda: ${{ inputs.with_cuda }}
       with-rocm: ${{ inputs.with_rocm }}
+      python-versions: ${{ inputs.python_versions }}
   generate-windows-matrix:
     if:  (inputs.os == 'windows' || inputs.os == 'all')
     uses: ./.github/workflows/generate_binary_build_matrix.yml
@@ -73,6 +79,7 @@ jobs:
       os: windows
       channel: ${{ inputs.channel }}
       with-cuda: ${{ inputs.with_cuda }}
+      python-versions: ${{ inputs.python_versions }}
   generate-macos-arm64-matrix:
     if:  (inputs.os == 'macos-arm64' || inputs.os == 'all')
     uses: ./.github/workflows/generate_binary_build_matrix.yml
@@ -81,6 +88,7 @@ jobs:
       os: macos-arm64
       channel: ${{ inputs.channel }}
       with-cuda: ${{ inputs.with_cuda }}
+      python-versions: ${{ inputs.python_versions }}
   validate-linux:
     if:  (inputs.os == 'linux' || inputs.os == 'all')
     needs: generate-linux-matrix


### PR DESCRIPTION
I see torchdata CI failures like this https://github.com/meta-pytorch/data/actions/runs/23955895397/job/69874077642. I want to not have this job run 3.13t or 3.14t.

Currently there is no way to specify python_versions in validate-domain-library.yml. This PR adds that.