### PR TITLE
[re]Add --pr and download option to blast CLI run commands

### DIFF
--- a/tools/remote_execution/blast/src/re_cli/commands/download.py
+++ b/tools/remote_execution/blast/src/re_cli/commands/download.py
@@ -1,0 +1,192 @@
+"""Download command: download outputs from a completed run."""
+
+import json
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+import click
+import requests
+
+from ..core.core_types import console
+from . import get_client
+
+
+@click.command()
+@click.argument("run_id")
+@click.option(
+    "--task",
+    "task_id",
+    default=None,
+    help="Download outputs for a specific task ID only",
+)
+@click.option(
+    "-o",
+    "--output",
+    "output_dir",
+    default="./outputs",
+    help="Local directory to save outputs (default: ./outputs)",
+)
+@click.option(
+    "--logs",
+    "include_logs",
+    is_flag=True,
+    help="Also download log files",
+)
+@click.pass_context
+def download(ctx, run_id, task_id, output_dir, include_logs):
+    """Download outputs from a completed or failed run.
+
+    Downloads and extracts the outputs archive (tar.gz) for each task.
+    Use --logs to also download individual log files.
+
+    Examples:
+        blast download <run-id>
+        blast download <run-id> --logs
+        blast download <run-id> --task <task-id>
+        blast download <run-id> -o ./my-outputs
+        blast --json download <run-id>
+    """
+    as_json = ctx.obj.get("as_json", False)
+    client = get_client(ctx)
+    out_path = Path(output_dir)
+
+    try:
+        if task_id:
+            # Query single task
+            task = client.query_task_status(task_id, include_downloads=True)
+            if not task:
+                if as_json:
+                    print(json.dumps({"error": f"Task {task_id} not found"}))
+                else:
+                    console.print(f"[red]Task {task_id} not found[/red]")
+                sys.exit(1)
+
+            status = task.get("current_status", "unknown")
+            if status not in ("completed", "failed"):
+                if as_json:
+                    print(json.dumps({"error": f"Task {task_id} is '{status}', not completed/failed"}))
+                else:
+                    console.print(
+                        f"[yellow]Task {task_id} is '{status}' — "
+                        f"download is only available for completed/failed tasks[/yellow]"
+                    )
+                sys.exit(1)
+
+            downloads = task.get("downloads", {})
+            if as_json:
+                print(json.dumps({"task_id": task_id, "downloads": downloads}, indent=2))
+                return
+
+            if not downloads.get("outputs") and not downloads.get("logs"):
+                console.print(f"[yellow]No outputs found for task {task_id}[/yellow]")
+                return
+
+            _download_task(downloads, out_path / task_id, include_logs)
+        else:
+            # Query run status (includes download URLs per task)
+            run_info = client.query_run_status(run_id, include_downloads=True)
+            if not run_info:
+                if as_json:
+                    print(json.dumps({"error": f"Run {run_id} not found"}))
+                else:
+                    console.print(f"[red]Run {run_id} not found[/red]")
+                sys.exit(1)
+
+            tasks = run_info.get("tasks", [])
+
+            if as_json:
+                output = [
+                    {
+                        "task_id": t.get("task_id", ""),
+                        "name": t.get("name", ""),
+                        "status": t.get("status", ""),
+                        "downloads": t.get("downloads", {}),
+                    }
+                    for t in tasks
+                    if t.get("downloads")
+                ]
+                print(json.dumps(output, indent=2))
+                return
+
+            if not tasks:
+                console.print(f"[yellow]No tasks found for run {run_id}[/yellow]")
+                return
+
+            downloaded = 0
+            for t in tasks:
+                tid = t.get("task_id", "")
+                status = t.get("status", "unknown")
+                downloads = t.get("downloads", {})
+
+                if not downloads.get("outputs") and not downloads.get("logs"):
+                    if status in ("completed", "failed"):
+                        console.print(
+                            f"[dim]  {t.get('name', tid)}: no outputs[/dim]"
+                        )
+                    continue
+
+                task_dir = out_path / tid
+                console.print(f"[blue]{t.get('name', tid)}[/blue] ({status})")
+                _download_task(downloads, task_dir, include_logs)
+                downloaded += 1
+
+            if downloaded == 0:
+                console.print("[yellow]No outputs found for any task[/yellow]")
+            else:
+                console.print(
+                    f"\n[green]Downloaded outputs for {downloaded} task(s) to {out_path}[/green]"
+                )
+
+    except Exception as e:
+        if as_json:
+            print(json.dumps({"error": str(e)}))
+        else:
+            console.print(f"[red]Error: {e}[/red]")
+        sys.exit(1)
+
+
+def _download_task(downloads: dict, dest_dir: Path, include_logs: bool):
+    """Download outputs archive and optionally log files for a task."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    # Download and extract outputs archive
+    outputs = downloads.get("outputs")
+    if outputs and outputs.get("url"):
+        _download_and_extract(outputs["key"], outputs["url"], dest_dir)
+
+    # Download log files if requested
+    if include_logs:
+        for log_entry in downloads.get("logs", []):
+            url = log_entry.get("url", "")
+            key = log_entry.get("key", "")
+            if not url:
+                continue
+            file_path = dest_dir / key
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                resp = requests.get(url, stream=True, timeout=300)
+                resp.raise_for_status()
+                with open(file_path, "wb") as f:
+                    for chunk in resp.iter_content(chunk_size=8192):
+                        f.write(chunk)
+                console.print(f"  [green]↓[/green] {key}")
+            except requests.RequestException as e:
+                console.print(f"  [red]✗[/red] {key}: {e}")
+
+
+def _download_and_extract(key: str, url: str, dest_dir: Path):
+    """Download a tar.gz archive and extract to dest_dir."""
+    try:
+        resp = requests.get(url, stream=True, timeout=300)
+        resp.raise_for_status()
+        with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=True) as tmp:
+            for chunk in resp.iter_content(chunk_size=8192):
+                tmp.write(chunk)
+            tmp.flush()
+            with tarfile.open(tmp.name, "r:gz") as tar:
+                tar.extractall(path=dest_dir)
+            console.print(f"  [green]↓[/green] {key} (extracted)")
+    except requests.RequestException as e:
+        console.print(f"  [red]✗[/red] {key}: {e}")

--- a/tools/remote_execution/blast/src/re_cli/commands/download.py
+++ b/tools/remote_execution/blast/src/re_cli/commands/download.py
@@ -66,7 +66,13 @@ def download(ctx, run_id, task_id, output_dir, include_logs):
             status = task.get("current_status", "unknown")
             if status not in ("completed", "failed"):
                 if as_json:
-                    print(json.dumps({"error": f"Task {task_id} is '{status}', not completed/failed"}))
+                    print(
+                        json.dumps(
+                            {
+                                "error": f"Task {task_id} is '{status}', not completed/failed"
+                            }
+                        )
+                    )
                 else:
                     console.print(
                         f"[yellow]Task {task_id} is '{status}' — "
@@ -76,7 +82,9 @@ def download(ctx, run_id, task_id, output_dir, include_logs):
 
             downloads = task.get("downloads", {})
             if as_json:
-                print(json.dumps({"task_id": task_id, "downloads": downloads}, indent=2))
+                print(
+                    json.dumps({"task_id": task_id, "downloads": downloads}, indent=2)
+                )
                 return
 
             if not downloads.get("outputs") and not downloads.get("logs"):
@@ -122,9 +130,7 @@ def download(ctx, run_id, task_id, output_dir, include_logs):
 
                 if not downloads.get("outputs") and not downloads.get("logs"):
                     if status in ("completed", "failed"):
-                        console.print(
-                            f"[dim]  {t.get('name', tid)}: no outputs[/dim]"
-                        )
+                        console.print(f"[dim]  {t.get('name', tid)}: no outputs[/dim]")
                     continue
 
                 task_dir = out_path / tid

--- a/tools/remote_execution/blast/src/re_cli/commands/query.py
+++ b/tools/remote_execution/blast/src/re_cli/commands/query.py
@@ -145,7 +145,12 @@ def print_task_detail(client, task_id: str):
 
 @click.command()
 @click.argument("task_id", type=str)
-@click.option("--log-tail", default=0, type=int, help="Show last N lines of logs (for running tasks)")
+@click.option(
+    "--log-tail",
+    default=0,
+    type=int,
+    help="Show last N lines of logs (for running tasks)",
+)
 @click.pass_context
 def task_status(ctx, task_id, log_tail):
     """Get task status with history."""
@@ -165,7 +170,9 @@ def task_status(ctx, task_id, log_tail):
         _print_task_panel(task)
         if log_tail > 0:
             if task.get("tail_logs"):
-                console.print(Panel(task["tail_logs"], title="Tail Logs", border_style="dim"))
+                console.print(
+                    Panel(task["tail_logs"], title="Tail Logs", border_style="dim")
+                )
             elif task.get("current_status") in ("completed", "failed"):
                 run_id = task.get("run_id", "<run-id>")
                 console.print(

--- a/tools/remote_execution/blast/src/re_cli/commands/query.py
+++ b/tools/remote_execution/blast/src/re_cli/commands/query.py
@@ -89,19 +89,15 @@ def _parse_time(ts: str):
 # =============================================================================
 
 
-def print_task_detail(client, task_id: str):
-    """Print detailed task status with history."""
-    task = client.query_task_status(task_id)
-    if not task:
-        console.print(f"[dim]  Task {task_id}: not found[/dim]")
-        return
-
+def _print_task_panel(task: dict):
+    """Print task status panel with history."""
+    task_id = task.get("id", "?")
     current_status = task.get("current_status", "unknown")
     status_color = get_status_color(current_status)
 
     console.print(
         Panel.fit(
-            f"[bold]Task ID:[/bold] {task.get('id')}\n"
+            f"[bold]Task ID:[/bold] {task_id}\n"
             f"[bold]Name:[/bold] {task.get('name')}\n"
             f"[bold]Status:[/bold] [{status_color}]{current_status}[/{status_color}]\n"
             f"[bold]Run ID:[/bold] {task.get('run_id', 'N/A')}\n"
@@ -133,6 +129,15 @@ def print_task_detail(client, task_id: str):
         console.print(table)
 
 
+def print_task_detail(client, task_id: str):
+    """Print detailed task status with history."""
+    task = client.query_task_status(task_id)
+    if not task:
+        console.print(f"[dim]  Task {task_id}: not found[/dim]")
+        return
+    _print_task_panel(task)
+
+
 # =============================================================================
 # Click commands
 # =============================================================================
@@ -140,8 +145,9 @@ def print_task_detail(client, task_id: str):
 
 @click.command()
 @click.argument("task_id", type=str)
+@click.option("--log-tail", default=0, type=int, help="Show last N lines of logs (for running tasks)")
 @click.pass_context
-def task_status(ctx, task_id):
+def task_status(ctx, task_id, log_tail):
     """Get task status with history."""
     as_json = ctx.obj.get("as_json", False)
 
@@ -149,13 +155,28 @@ def task_status(ctx, task_id):
 
     try:
         if as_json:
-            task = client.query_task_status(task_id)
+            task = client.query_task_status(task_id, tail_lines=log_tail)
             print(json.dumps(task or {"error": "not found"}, indent=2))
-        print_task_detail(client, task_id)
+            return
+        task = client.query_task_status(task_id, tail_lines=log_tail)
+        if not task:
+            console.print(f"[dim]  Task {task_id}: not found[/dim]")
+            return
+        _print_task_panel(task)
+        if log_tail > 0:
+            if task.get("tail_logs"):
+                console.print(Panel(task["tail_logs"], title="Tail Logs", border_style="dim"))
+            elif task.get("current_status") in ("completed", "failed"):
+                run_id = task.get("run_id", "<run-id>")
+                console.print(
+                    f"[dim]Pod cleaned up. Use: blast download {run_id} "
+                    f"--task {task_id} --logs[/dim]"
+                )
     except Exception as e:
         if as_json:
             print(json.dumps({"error": str(e)}))
-        console.print(f"[red]Error: {e}[/red]")
+        else:
+            console.print(f"[red]Error: {e}[/red]")
         sys.exit(1)
 
 

--- a/tools/remote_execution/blast/src/re_cli/commands/run.py
+++ b/tools/remote_execution/blast/src/re_cli/commands/run.py
@@ -65,7 +65,11 @@ def resolve_pr_url(pr_url: str) -> tuple[str, str]:
 
     data = resp.json()
     head_sha = data["head"]["sha"]
-    repo_url = data["head"]["repo"]["clone_url"]
+    head_repo = data["head"]["repo"]
+    if head_repo is None:
+        console.print("[red]Error: PR head repo is unavailable (fork may have been deleted)[/red]")
+        sys.exit(1)
+    repo_url = head_repo["clone_url"]
     # Strip .git suffix for consistency
     if repo_url.endswith(".git"):
         repo_url = repo_url[:-4]

--- a/tools/remote_execution/blast/src/re_cli/commands/run.py
+++ b/tools/remote_execution/blast/src/re_cli/commands/run.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import sys
 from typing import Optional
 
@@ -14,6 +15,66 @@ from ..core.k8s_client import K8sClient
 from ..core.log_stream import _prompt_cancel_action
 from . import get_client
 from .query import save_to_history
+
+
+# =============================================================================
+# PR URL helpers
+# =============================================================================
+
+
+def resolve_pr_url(pr_url: str) -> tuple[str, str]:
+    """Parse a GitHub PR URL and return (repo_url, head_commit_sha).
+
+    Accepts URLs like:
+        https://github.com/pytorch/pytorch/pull/12345
+
+    Calls the GitHub API to get the head branch's latest commit SHA.
+    Uses GH_TOKEN/GITHUB_TOKEN env var for authentication if available.
+    """
+    match = re.match(
+        r"https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)", pr_url
+    )
+    if not match:
+        console.print(
+            f"[red]Error: invalid PR URL: {pr_url}[/red]\n"
+            "[dim]Expected format: https://github.com/owner/repo/pull/NUMBER[/dim]"
+        )
+        sys.exit(1)
+
+    owner, repo_name, pr_number = match.group(1), match.group(2), match.group(3)
+    api_url = f"https://api.github.com/repos/{owner}/{repo_name}/pulls/{pr_number}"
+
+    import requests
+
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"token {token}"
+
+    resp = requests.get(api_url, headers=headers, timeout=15)
+    if resp.status_code != 200:
+        console.print(
+            f"[red]Error: GitHub API returned {resp.status_code} for PR #{pr_number}[/red]\n"
+            f"[dim]{api_url}[/dim]"
+        )
+        if resp.status_code == 404:
+            console.print(
+                "[dim]PR not found. If this is a private repo, set GH_TOKEN.[/dim]"
+            )
+        sys.exit(1)
+
+    data = resp.json()
+    head_sha = data["head"]["sha"]
+    repo_url = data["head"]["repo"]["clone_url"]
+    # Strip .git suffix for consistency
+    if repo_url.endswith(".git"):
+        repo_url = repo_url[:-4]
+
+    console.print(
+        f"[dim]PR #{pr_number}: {data['title']}[/dim]\n"
+        f"[dim]  repo: {repo_url}  commit: {head_sha[:12]}[/dim]"
+    )
+    return repo_url, head_sha
 
 
 # =============================================================================
@@ -267,6 +328,12 @@ def execute_job(
 )
 @click.option("--commit", default=None, help="Git commit SHA")
 @click.option("--repo", "-r", default=None, help="Git repo URL")
+@click.option(
+    "--pr",
+    "pr_url",
+    default=None,
+    help="GitHub PR URL (extracts repo + commit automatically)",
+)
 @click.option("--raw", is_flag=True, default=False, help="Raw mode: skip S3 upload")
 @click.option("--dry-run", is_flag=True, default=False, help="Dry run")
 @click.option(
@@ -298,6 +365,7 @@ def run_single(
     repo_cache,
     commit,
     repo,
+    pr_url,
     raw,
     dry_run,
     interactive,
@@ -308,8 +376,18 @@ def run_single(
     Examples:
         blast run --script build.sh --type cpu-44 --follow
         blast run --config single-step.json --follow
+        blast run --pr https://github.com/pytorch/pytorch/pull/12345 -c 'python test.py' -f
     """
     as_json = ctx.obj.get("as_json", False)
+
+    # Resolve --pr to --repo and --commit
+    if pr_url:
+        if repo or commit:
+            console.print(
+                "[red]Error: --pr cannot be used with --repo or --commit[/red]"
+            )
+            sys.exit(1)
+        repo, commit = resolve_pr_url(pr_url)
 
     # Load from config file if provided
     steps_json = []
@@ -491,6 +569,12 @@ def run_single(
     help="Git repo URL",
 )
 @click.option(
+    "--pr",
+    "pr_url",
+    default=None,
+    help="GitHub PR URL (extracts repo + commit automatically)",
+)
+@click.option(
     "--raw",
     is_flag=True,
     default=False,
@@ -532,6 +616,7 @@ def run_steps(
     repo_cache,
     commit,
     repo,
+    pr_url,
     raw,
     dry_run,
     depends_on,
@@ -547,8 +632,18 @@ def run_steps(
             --step build --script ./build.sh --type cpu \\
             --step test --script ./test.sh --type gpu-l6 \\
             --follow
+        blast run-steps --pr https://github.com/pytorch/pytorch/pull/12345 --config job.json
     """
     as_json = ctx.obj.get("as_json", False)
+
+    # Resolve --pr to --repo and --commit
+    if pr_url:
+        if repo or commit:
+            console.print(
+                "[red]Error: --pr cannot be used with --repo or --commit[/red]"
+            )
+            sys.exit(1)
+        repo, commit = resolve_pr_url(pr_url)
 
     # Load from config file if provided, and override CLI flags if present
     if config_file:

--- a/tools/remote_execution/blast/src/re_cli/commands/run.py
+++ b/tools/remote_execution/blast/src/re_cli/commands/run.py
@@ -31,9 +31,7 @@ def resolve_pr_url(pr_url: str) -> tuple[str, str]:
     Calls the GitHub API to get the head branch's latest commit SHA.
     Uses GH_TOKEN/GITHUB_TOKEN env var for authentication if available.
     """
-    match = re.match(
-        r"https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)", pr_url
-    )
+    match = re.match(r"https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)", pr_url)
     if not match:
         console.print(
             f"[red]Error: invalid PR URL: {pr_url}[/red]\n"
@@ -67,7 +65,9 @@ def resolve_pr_url(pr_url: str) -> tuple[str, str]:
     head_sha = data["head"]["sha"]
     head_repo = data["head"]["repo"]
     if head_repo is None:
-        console.print("[red]Error: PR head repo is unavailable (fork may have been deleted)[/red]")
+        console.print(
+            "[red]Error: PR head repo is unavailable (fork may have been deleted)[/red]"
+        )
         sys.exit(1)
     repo_url = head_repo["clone_url"]
     # Strip .git suffix for consistency

--- a/tools/remote_execution/blast/src/re_cli/core/k8s_client.py
+++ b/tools/remote_execution/blast/src/re_cli/core/k8s_client.py
@@ -299,7 +299,9 @@ class K8sClient:
     # RunQuery Operations
     # =========================================================================
 
-    def query_task_status(self, task_id: str, *, include_downloads: bool = False, tail_lines: int = 0) -> Optional[dict]:
+    def query_task_status(
+        self, task_id: str, *, include_downloads: bool = False, tail_lines: int = 0
+    ) -> Optional[dict]:
         """Query task status via RunQuery CRD."""
         crd_name = f"query-{uuid.uuid4().hex[:8]}"
 
@@ -339,7 +341,9 @@ class K8sClient:
             "run_id": result.get("run_id"),
         }
 
-    def query_run_status(self, run_id: str, *, include_downloads: bool = False) -> Optional[dict]:
+    def query_run_status(
+        self, run_id: str, *, include_downloads: bool = False
+    ) -> Optional[dict]:
         """Query run status via RunQuery CRD."""
         crd_name = f"query-{uuid.uuid4().hex[:8]}"
 

--- a/tools/remote_execution/blast/src/re_cli/core/k8s_client.py
+++ b/tools/remote_execution/blast/src/re_cli/core/k8s_client.py
@@ -299,7 +299,7 @@ class K8sClient:
     # RunQuery Operations
     # =========================================================================
 
-    def query_task_status(self, task_id: str) -> Optional[dict]:
+    def query_task_status(self, task_id: str, *, include_downloads: bool = False, tail_lines: int = 0) -> Optional[dict]:
         """Query task status via RunQuery CRD."""
         crd_name = f"query-{uuid.uuid4().hex[:8]}"
 
@@ -308,6 +308,10 @@ class K8sClient:
             "task_id": task_id,
             "ttlSecondsAfterFinished": 60,
         }
+        if include_downloads:
+            spec["include_downloads"] = True
+        if tail_lines > 0:
+            spec["tail_lines"] = tail_lines
 
         self._apply_crd("RunQuery", "runqueries", crd_name, spec)
 
@@ -335,7 +339,7 @@ class K8sClient:
             "run_id": result.get("run_id"),
         }
 
-    def query_run_status(self, run_id: str) -> Optional[dict]:
+    def query_run_status(self, run_id: str, *, include_downloads: bool = False) -> Optional[dict]:
         """Query run status via RunQuery CRD."""
         crd_name = f"query-{uuid.uuid4().hex[:8]}"
 
@@ -344,6 +348,8 @@ class K8sClient:
             "run_id": run_id,
             "ttlSecondsAfterFinished": 60,
         }
+        if include_downloads:
+            spec["include_downloads"] = True
 
         self._apply_crd("RunQuery", "runqueries", crd_name, spec)
 

--- a/tools/remote_execution/blast/src/re_cli/core/script_builder/builder.py
+++ b/tools/remote_execution/blast/src/re_cli/core/script_builder/builder.py
@@ -7,7 +7,7 @@ Two main outputs:
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 
 @dataclass

--- a/tools/remote_execution/blast/src/re_cli/core/script_builder/templates/upload_outputs.sh
+++ b/tools/remote_execution/blast/src/re_cli/core/script_builder/templates/upload_outputs.sh
@@ -1,36 +1,39 @@
 # MODULE: Upload Outputs
-# Uploads outputs from OUTPUT_PATH to S3 (per-task directory)
+# Uploads outputs as tar.gz archive + logs as individual files to S3
 
-# Upload user outputs
+ARCHIVE_PATH="/tmp/task_artifacts_${TASK_ID}.tar.gz"
+ARCHIVE_S3_PATH="${ARTIFACTS_PATH}artifacts/${TASK_ID}.tar.gz"
+LOG_DIR="${LOG_DIR:-/tmp/work/logs}"
+LOGS_S3_PATH="${ARTIFACTS_PATH}logs/${TASK_ID}/"
+
+# 1) Upload outputs as tar.gz
 if [[ -d "$OUTPUT_PATH" && "$(ls -A $OUTPUT_PATH 2>/dev/null)" ]]; then
-    OUTPUT_S3_PATH="${ARTIFACTS_PATH}outputs/${TASK_ID}/"
-    echo "[Runner] Uploading outputs from $OUTPUT_PATH to $OUTPUT_S3_PATH"
-    if aws s3 sync "$OUTPUT_PATH/" "$OUTPUT_S3_PATH" 2>&1 | sed 's/^/[Runner] /'; then
-        echo "[Runner] ✓ Outputs uploaded to $OUTPUT_S3_PATH"
+    echo "[Runner] Outputs: $(ls -1 $OUTPUT_PATH | wc -l) file(s) in $OUTPUT_PATH"
+    echo "[Runner] Packaging outputs..."
+    tar czf "$ARCHIVE_PATH" -C / "${OUTPUT_PATH#/}" 2>&1 | sed 's/^/[Runner] /'
+    ARCHIVE_SIZE=$(du -h "$ARCHIVE_PATH" | cut -f1)
+    echo "[Runner] Archive: $ARCHIVE_SIZE"
+
+    echo "[Runner] Uploading $ARCHIVE_PATH to $ARCHIVE_S3_PATH"
+    if aws s3 cp "$ARCHIVE_PATH" "$ARCHIVE_S3_PATH" 2>&1 | sed 's/^/[Runner] /'; then
+        echo "[Runner] ✓ Outputs uploaded to $ARCHIVE_S3_PATH"
     else
         echo "[Runner] Warning: Failed to upload outputs"
     fi
+    rm -f "$ARCHIVE_PATH"
 else
     echo "[Runner] No outputs to upload (OUTPUT_PATH empty or missing)"
 fi
 
-# Upload logs (LOG_DIR set in bootstrap.sh, fallback to /tmp/work/logs)
-LOG_DIR="${LOG_DIR:-/tmp/work/logs}"
-echo "[Runner] Looking for logs in: $LOG_DIR"
-if [[ -d "$LOG_DIR" ]]; then
-    echo "[Runner] LOG_DIR contents:"
-    ls -la "$LOG_DIR" 2>/dev/null | sed 's/^/[Runner] /' || echo "(empty)"
-    if [[ "$(ls -A $LOG_DIR 2>/dev/null)" ]]; then
-        LOGS_S3_PATH="${ARTIFACTS_PATH}logs/"
-        echo "[Runner] Uploading logs from $LOG_DIR to $LOGS_S3_PATH"
-        if aws s3 sync "$LOG_DIR/" "$LOGS_S3_PATH" 2>&1 | sed 's/^/[Runner] /'; then
-            echo "[Runner] ✓ Logs uploaded to $LOGS_S3_PATH"
-        else
-            echo "[Runner] Warning: Failed to upload logs"
-        fi
+# 2) Upload logs as individual files
+if [[ -d "$LOG_DIR" && "$(ls -A $LOG_DIR 2>/dev/null)" ]]; then
+    echo "[Runner] Logs: $(ls -1 $LOG_DIR | wc -l) file(s) in $LOG_DIR"
+    echo "[Runner] Uploading logs to $LOGS_S3_PATH"
+    if aws s3 sync "$LOG_DIR" "$LOGS_S3_PATH" 2>&1 | sed 's/^/[Runner] /'; then
+        echo "[Runner] ✓ Logs uploaded to $LOGS_S3_PATH"
     else
-        echo "[Runner] LOG_DIR exists but is empty"
+        echo "[Runner] Warning: Failed to upload logs"
     fi
 else
-    echo "[Runner] No logs to upload (LOG_DIR does not exist)"
+    echo "[Runner] No logs to upload (LOG_DIR empty or missing)"
 fi

--- a/tools/remote_execution/blast/src/re_cli/main.py
+++ b/tools/remote_execution/blast/src/re_cli/main.py
@@ -15,6 +15,7 @@ import click
 
 from .commands.cancel import cancel
 from .commands.debug import debug
+from .commands.download import download
 from .commands.query import history, logs, run_status, task_status
 from .commands.run import run_single, run_steps
 from .core.core_types import console
@@ -52,6 +53,7 @@ cli.add_command(task_status, "task-status")
 cli.add_command(run_status, "status")
 cli.add_command(logs, "stream")
 cli.add_command(history, "history")
+cli.add_command(download, "download")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `--pr` option to `blast run` and `blast run-steps` commands
- Accepts a GitHub PR URL (e.g. `https://github.com/pytorch/pytorch/pull/12345`), calls the GitHub API to extract the head repo URL and commit SHA
- Replaces the need to manually specify `--repo` and `--commit` when running against a PR
- Uses `GH_TOKEN` / `GITHUB_TOKEN` for auth if available (required for private repos)

## Usage
```bash
blast run --pr https://github.com/pytorch/pytorch/pull/12345 -c 'python test.py' --type cpu-large -f
blast run-steps --pr https://github.com/pytorch/pytorch/pull/12345 --config job.json -f
```

## Test plan
- [ ] `blast run --pr <public PR URL> -c 'echo hello' -f` resolves repo+commit and submits job
- [ ] `blast run --pr <url> --repo <url>` errors with mutual exclusivity message
- [ ] Invalid PR URL prints helpful error message
- [ ] Private repo without `GH_TOKEN` returns 404 with hint to set token