### PR TITLE
Use a floor pin for conda in setup-binary-builds to fix macOS solver conflicts

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -129,7 +129,7 @@ runs:
           set -euxo pipefail
           CONDA_ENV="${RUNNER_TEMP}/conda_environment_${GITHUB_RUN_ID}"
           export CONDA_EXTRA_PARAM=""
-          conda install -y conda=25.3.0
+          conda install -y conda=25.11.1
 
           # shellcheck disable=SC2153
           case $PYTHON_VERSION in

--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -129,7 +129,14 @@ runs:
           set -euxo pipefail
           CONDA_ENV="${RUNNER_TEMP}/conda_environment_${GITHUB_RUN_ID}"
           export CONDA_EXTRA_PARAM=""
-          conda install -y conda=25.3.0
+          # Floor pin instead of an exact pin: the runner's active conda env
+          # dictates which conda builds are installable (e.g. the macOS M1
+          # runners' base env moved to python 3.14, and conda only ships
+          # py3.14 builds from 26.1.0 on; exact conda=25.3.0 became
+          # unsolvable and broke all macOS wheel builds on 2026-07-08).
+          # A floor keeps the original >=25.3.0 requirement while letting
+          # each runner solve a conda compatible with its base python.
+          conda install -y "conda>=25.3.0"
 
           # shellcheck disable=SC2153
           case $PYTHON_VERSION in


### PR DESCRIPTION
## Problem

`setup-binary-builds` runs `conda install -y conda=25.3.0` in the runner's active conda env. An exact pin becomes unsolvable whenever that env's python has no matching conda build. This has now broken macOS wheel builds twice:

1. (April) macOS runners shipping `conda-libmamba-solver=25.11.0` (requires `conda>=25.9`) made the downgrade to 25.3.0 unsatisfiable. Example: https://github.com/pytorch/tensordict/actions/runs/24287554120/job/70920726226
2. (2026-07-08, current, ecosystem-wide) The M1 runners' miniconda base env moved to **python 3.14**. The defaults channel only ships py3.14 conda builds from **26.1.0** onward, so `conda=25.3.0` fails with:

```
LibMambaUnsatisfiableError: Encountered problems while solving:
  - package conda-25.3.0-py310hca03da5_0 requires python >=3.10,<3.11.0a0, ...
└─ pin on python =3.14 * is not installable ...
```

Every macOS wheel build across pytorch/rl, pytorch/vision, pytorch/tensordict, etc. has been failing at env setup since ~2026-07-08 20:00 UTC, regardless of the matrix python version (the pin conflict is with the runner base env's python, not the target build python). Examples: https://github.com/pytorch/rl/actions/runs/28971958178/job/85973758390, https://github.com/pytorch/vision/actions/runs/28971539817

## Fix

Replace the exact pin with a floor pin: `conda install -y "conda>=25.3.0"`. This preserves the original minimum-version intent of #7753 while letting each runner solve a conda release compatible with its base python (e.g. 25.9.1 on a py3.9 base, 26.5.3 on a py3.14 base). An exact bump (e.g. `conda=26.5.3`) would fix macOS today but would drop runners whose base python has no 26.x build (26.x has no py3.9 builds) and would break again on the next base-python bump.

(This PR previously proposed bumping to `conda=25.11.1`, which fixed failure mode 1 but not mode 2 — 25.11.1 has no py3.14 build either. Updated to the floor pin.)