### PR TITLE
Keep ciflow labels on PRs and defer tag creation until workflow approval

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -1,4 +1,3 @@
-import assert from "assert";
 import { minimatch } from "minimatch";
 import { Context, Probot } from "probot";
 import { addLabelErrComment, hasRequiredLabels } from "./checkLabelsUtils";
@@ -225,9 +224,9 @@ export async function canRunWorkflows(
 async function filterCIFlowLabels(
   isIssue: boolean,
   labels: string[],
-  context?: Context<"pull_request">,
-  owner?: string,
-  repo?: string
+  _context?: Context<"pull_request">,
+  _owner?: string,
+  _repo?: string
 ) {
   const noCIFlowLabels = labels.filter((l) => !l.startsWith("ciflow/"));
   if (noCIFlowLabels.length === labels.length) {
@@ -238,11 +237,9 @@ async function filterCIFlowLabels(
     return noCIFlowLabels;
   }
 
-  assert(context && owner && repo, "context, owner, and repo must be provided");
-
-  if (!(await canRunWorkflows(context))) {
-    return noCIFlowLabels;
-  }
+  // Allow ciflow labels to be added to PRs even without workflow approval.
+  // The ciflowPushTrigger will defer tag creation and post a pending comment
+  // until workflows are approved, rather than stripping the labels.
   return labels;
 }
 

--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -8,8 +8,69 @@ import {
   isPyTorchPyTorch,
 } from "./utils";
 
+const CIFLOW_PENDING_MARKER = "<!-- ciflow-pending -->";
+
 function isCIFlowLabel(label: string): boolean {
   return label.startsWith("ciflow/");
+}
+
+/**
+ * Find an existing pending ciflow comment on the PR (identified by the marker).
+ */
+async function findPendingCiflowComment(context: Context, prNum: number) {
+  const comments = await context.octokit.issues.listComments(
+    context.repo({ issue_number: prNum, per_page: 100 })
+  );
+  return comments.data.find((c) => c.body?.includes(CIFLOW_PENDING_MARKER));
+}
+
+/**
+ * Create or update a comment explaining that ciflow labels are pending
+ * workflow approval before CI can be triggered.
+ */
+async function upsertPendingComment(
+  context: Context,
+  prNum: number,
+  pendingLabels: string[]
+) {
+  const body =
+    CIFLOW_PENDING_MARKER +
+    "\n" +
+    "The following ciflow label(s) have been added but CI has not been triggered yet " +
+    "because the workflows are awaiting approval:\n\n" +
+    pendingLabels.map((l) => `- \`${l}\``).join("\n") +
+    "\n\n" +
+    "Once a maintainer approves the workflows (scroll to the bottom of the PR page), " +
+    "the corresponding CI jobs will be triggered automatically. " +
+    "Please ping one of the reviewers if you do not have access to approve and run workflows.";
+
+  const existing = await findPendingCiflowComment(context, prNum);
+  if (existing) {
+    await context.octokit.issues.updateComment(
+      context.repo({ comment_id: existing.id, body })
+    );
+  } else {
+    await context.octokit.issues.createComment(
+      context.repo({ body, issue_number: prNum })
+    );
+  }
+}
+
+/**
+ * Edit the pending comment to indicate that CI has now been triggered.
+ */
+async function resolvePendingComment(context: Context, prNum: number) {
+  const existing = await findPendingCiflowComment(context, prNum);
+  if (existing) {
+    const body =
+      CIFLOW_PENDING_MARKER +
+      "\n" +
+      "~~Workflows were awaiting approval.~~ " +
+      "CI has now been triggered for the ciflow labels on this PR.";
+    await context.octokit.issues.updateComment(
+      context.repo({ comment_id: existing.id, body })
+    );
+  }
 }
 
 function labelToTag(label: string, prNum: number): string {
@@ -92,17 +153,11 @@ async function handleSyncEvent(
   context.log.debug("START Processing sync event");
 
   if (!(await canRunWorkflows(context as any))) {
-    context.log.info("PR does not have permissions to run workflows");
-    for (const label of payload.pull_request.labels) {
-      if (isCIFlowLabel(label.name)) {
-        await context.octokit.issues.removeLabel(
-          context.repo({
-            issue_number: payload.pull_request.number,
-            name: label.name,
-          })
-        );
-      }
-    }
+    context.log.info(
+      "PR does not have permissions to run workflows, skipping tag sync"
+    );
+    // Don't remove labels -- they represent user intent.
+    // Tags simply won't be created until workflows are approved.
     return;
   }
 
@@ -112,6 +167,12 @@ async function handleSyncEvent(
     async (tag) => await syncTag(context, tag, headSha)
   );
   await Promise.all(promises);
+
+  // If we successfully synced tags, resolve any pending comment
+  if (tags.length > 0) {
+    await resolvePendingComment(context, payload.pull_request.number);
+  }
+
   context.log.info("END Processing sync event");
 }
 
@@ -203,25 +264,15 @@ async function handleLabelEvent(
     }
   }
   if (!has_ci_approved) {
-    let body =
-      "To add the ciflow label `" +
-      label +
-      "` please first approve the workflows " +
-      "that are awaiting approval (scroll to the bottom of this page).\n\n" +
-      "This helps ensure we don't trigger CI on this PR until it is actually authorized to do so. " +
-      "Please ping one of the reviewers if you do not have access to approve and run workflows.";
-    await context.octokit.issues.createComment(
-      context.repo({
-        body,
-        issue_number: prNum,
-      })
-    );
-    await context.octokit.issues.removeLabel({
-      owner,
-      repo,
-      issue_number: prNum,
-      name: label,
-    });
+    // Keep the label (it represents user intent) but don't create the tag.
+    // Post/update a pending comment listing all ciflow labels awaiting approval.
+    const allCiflowLabels = payload.pull_request.labels
+      .map((l) => l.name)
+      .filter(isCIFlowLabel);
+    if (!allCiflowLabels.includes(label)) {
+      allCiflowLabels.push(label);
+    }
+    await upsertPendingComment(context, prNum, allCiflowLabels);
     return;
   }
 
@@ -232,6 +283,51 @@ async function handleLabelEvent(
   }
   const tag = labelToTag(payload.label.name, prNum);
   await syncTag(context, tag, payload.pull_request.head.sha);
+}
+
+/**
+ * When a workflow_run is requested (e.g. a maintainer clicks "Approve and run"),
+ * check if the associated PR has pending ciflow labels and create the tags.
+ */
+async function handleWorkflowRunEvent(context: Context<"workflow_run">) {
+  const payload = context.payload;
+
+  // Only care about pull_request workflow runs
+  if (payload.workflow_run.event !== "pull_request") {
+    return;
+  }
+
+  const pullRequests = payload.workflow_run.pull_requests;
+  if (!pullRequests || pullRequests.length === 0) {
+    return;
+  }
+
+  for (const pr of pullRequests) {
+    const prData = await context.octokit.pulls.get(
+      context.repo({ pull_number: pr.number })
+    );
+
+    if (prData.data.state === "closed") {
+      continue;
+    }
+
+    const ciflowLabels = prData.data.labels
+      .map((l: any) => l.name)
+      .filter(isCIFlowLabel);
+
+    if (ciflowLabels.length === 0) {
+      continue;
+    }
+
+    const headSha = prData.data.head.sha;
+    const tags = ciflowLabels.map((l: string) => labelToTag(l, pr.number));
+    const promises = tags.map(
+      async (tag: string) => await syncTag(context as any, tag, headSha)
+    );
+    await Promise.all(promises);
+
+    await resolvePendingComment(context as any, pr.number);
+  }
 }
 
 export default function ciflowPushTrigger(app: Probot) {
@@ -279,4 +375,19 @@ export default function ciflowPushTrigger(app: Probot) {
 
     await handleUnlabeledEvent(context, context.payload);
   });
+
+  // When a workflow run is requested (e.g. maintainer approves pending workflows),
+  // create ciflow tags for any PR that has pending ciflow labels.
+  app.on(
+    ["workflow_run.requested", "workflow_run.completed"],
+    async (context) => {
+      const owner = context.payload.repository.owner.login;
+      if (!isPyTorchbotSupportedOrg(owner)) {
+        context.log(`${__filename} isn't enabled on ${owner}'s repos`);
+        return;
+      }
+
+      await handleWorkflowRunEvent(context);
+    }
+  );
 }

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -472,14 +472,17 @@ The explanation needs to be clear on why this is needed. Here are some good exam
         ctx.payload?.comment?.user?.login
       ))
     ) {
-      return await this.addComment(
-        "To add these label(s) (" +
+      // Still add the labels (they represent user intent), but inform
+      // that CI won't be triggered until workflows are approved.
+      // The ciflowPushTrigger will handle posting a detailed pending comment.
+      await this.addComment(
+        "The ciflow label(s) " +
           ciflowLabels.join(", ") +
-          ") to the PR, please first approve the " +
-          "workflows that are awaiting approval (scroll to the bottom of this page).\n\n" +
-          "This helps ensure we don't trigger CI on this PR until it is actually authorized to do so. " +
+          " will be added, but CI won't be triggered until " +
+          "the workflows are approved (scroll to the bottom of this page).\n\n" +
           "Please ping one of the reviewers if you do not have access to approve and run workflows."
       );
+      // Don't return -- let the labels be added below
     }
     if (invalidLabels.length > 0) {
       await this.addComment(

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -1120,7 +1120,9 @@ describe("auto-label-bot: labeler.yml config", () => {
   });
 
   test("getLabelsFromLabelerConfig multiple match but no workflow permissions", async () => {
-    // Matches both module: dynamo and ciflow/inductor, but removes ciflow due to lacking perms
+    // Matches both module: dynamo and ciflow/inductor. ciflow labels are now
+    // kept even without workflow permissions -- the ciflowPushTrigger will
+    // defer tag creation until workflows are approved.
     const event = requireDeepCopy("./fixtures/pull_request.opened");
     const prFiles = requireDeepCopy("./fixtures/pull_files");
     prFiles["items"] = [{ filename: "torch/_dynamo/blah.py" }];
@@ -1128,22 +1130,8 @@ describe("auto-label-bot: labeler.yml config", () => {
     const prNumber = 31;
     const scope = mockChangedFiles(prFiles, prNumber, repoFullName);
     defaultMockConfig(repoFullName);
-    nock("https://api.github.com")
-      .get((uri) => uri.startsWith(`/repos/${repoFullName}/actions/runs`))
-      .reply(200, {
-        workflow_runs: [
-          {
-            event: "pull_request",
-            conclusion: "action_required",
-          },
-        ],
-      })
-      .get(`/repos/${repoFullName}/collaborators/zzj-bot/permission`)
-      .reply(200, {
-        permission: "read",
-      });
     const scope2 = utils.mockAddLabels(
-      ["module: dynamo"],
+      ["module: dynamo", "ciflow/inductor"],
       repoFullName,
       prNumber
     );

--- a/torchci/test/ciflow-push-trigger.test.ts
+++ b/torchci/test/ciflow-push-trigger.test.ts
@@ -487,9 +487,7 @@ describe("Push trigger integration tests", () => {
   test("CIFlow label without approval keeps label and posts pending comment", async () => {
     // Deep-clone fixture to avoid mutating the cached require() result
     const payload = JSON.parse(
-      JSON.stringify(
-        require("./fixtures/push-trigger/pull_request.labeled")
-      )
+      JSON.stringify(require("./fixtures/push-trigger/pull_request.labeled"))
     );
     payload.pull_request.state = "open";
     payload.label.name = "ciflow/trunk";
@@ -508,11 +506,7 @@ describe("Push trigger integration tests", () => {
 
     mockPermissions("suo/actions-test", login, "read");
 
-    mockApprovedWorkflowRuns(
-      "suo/actions-test",
-      head_sha,
-      false
-    );
+    mockApprovedWorkflowRuns("suo/actions-test", head_sha, false);
 
     // Should search for existing pending comment
     mockListComments("suo/actions-test", prNum);

--- a/torchci/test/ciflow-push-trigger.test.ts
+++ b/torchci/test/ciflow-push-trigger.test.ts
@@ -10,13 +10,43 @@ import {
 
 nock.disableNetConnect();
 
-function mockDeleteLabel(repoFullName: string, number: number, label: string) {
+function mockListComments(
+  repoFullName: string,
+  prNum: number,
+  comments: any[] = []
+) {
   return nock("https://api.github.com")
-    .delete(
-      `/repos/${repoFullName}/issues/${number}/labels/${encodeURIComponent(
-        label
-      )}`
-    )
+    .get(`/repos/${repoFullName}/issues/${prNum}/comments?per_page=100`)
+    .reply(200, comments);
+}
+
+function mockCreateComment(
+  repoFullName: string,
+  prNum: number,
+  bodyContains?: string
+) {
+  return nock("https://api.github.com")
+    .post(`/repos/${repoFullName}/issues/${prNum}/comments`, (body) => {
+      if (bodyContains) {
+        expect(body.body).toContain(bodyContains);
+      }
+      return true;
+    })
+    .reply(200, { id: 1 });
+}
+
+function mockUpdateComment(
+  repoFullName: string,
+  commentId: number,
+  bodyContains?: string
+) {
+  return nock("https://api.github.com")
+    .patch(`/repos/${repoFullName}/issues/comments/${commentId}`, (body) => {
+      if (bodyContains) {
+        expect(body.body).toContain(bodyContains);
+      }
+      return true;
+    })
     .reply(200);
 }
 
@@ -240,10 +270,14 @@ describe("Push trigger integration tests", () => {
         })
         .reply(200);
     }
+
+    // After syncing tags, should check for pending comment to resolve
+    mockListComments("suo/actions-test", prNum);
+
     await probot.receive({ name: "pull_request", id: "123", payload });
   });
 
-  test("synchronization of PR requires permissions", async () => {
+  test("synchronization of PR without permissions skips tag sync but keeps labels", async () => {
     const payload = require("./fixtures/push-trigger/pull_request.synchronize");
     mockApprovedWorkflowRuns(
       payload.repository.full_name,
@@ -255,16 +289,8 @@ describe("Push trigger integration tests", () => {
       payload.pull_request.user.login,
       "read"
     );
-    mockDeleteLabel(
-      payload.repository.full_name,
-      payload.pull_request.number,
-      "ciflow/test"
-    );
-    mockDeleteLabel(
-      payload.repository.full_name,
-      payload.pull_request.number,
-      "ciflow/1"
-    );
+    // No label removal or tag creation should happen -- labels are kept,
+    // tags are simply not created until workflows are approved.
     await probot.receive({ name: "pull_request", id: "123", payload });
   });
 
@@ -323,6 +349,68 @@ describe("Push trigger integration tests", () => {
         )}`
       )
       .reply(404, { message: "There is nothing here" });
+    await probot.receive({ name: "pull_request", id: "123", payload });
+  });
+
+  test("sync event with approval resolves pending comment", async () => {
+    const payload = require("./fixtures/push-trigger/pull_request.synchronize");
+    const prNum = payload.pull_request.number;
+    const labels = ["ciflow/test", "ciflow/1"];
+
+    mockHasApprovedWorkflowRun(payload.repository.full_name);
+
+    for (const label of labels) {
+      nock("https://api.github.com")
+        .get(
+          `/repos/suo/actions-test/git/matching-refs/${encodeURIComponent(
+            `tags/${label}/${prNum}`
+          )}`
+        )
+        .reply(200, [
+          {
+            ref: `refs/tags/${label}/${prNum}`,
+            node_id: "123",
+            object: { sha: "abc" },
+          },
+        ]);
+    }
+
+    for (const label of labels) {
+      nock("https://api.github.com")
+        .delete(
+          `/repos/suo/actions-test/git/refs/${encodeURIComponent(
+            `tags/${label}/${prNum}`
+          )}`
+        )
+        .reply(200);
+    }
+
+    for (const label of labels) {
+      nock("https://api.github.com")
+        .post("/repos/suo/actions-test/git/refs", (body) => {
+          expect(body).toMatchObject({
+            ref: `refs/tags/${label}/${prNum}`,
+            sha: payload.pull_request.head.sha,
+          });
+          return true;
+        })
+        .reply(200);
+    }
+
+    // Should look for and resolve pending comment
+    const pendingCommentId = 42;
+    mockListComments("suo/actions-test", prNum, [
+      {
+        id: pendingCommentId,
+        body: "<!-- ciflow-pending -->\nWorkflows awaiting approval",
+      },
+    ]);
+    mockUpdateComment(
+      "suo/actions-test",
+      pendingCommentId,
+      "CI has now been triggered"
+    );
+
     await probot.receive({ name: "pull_request", id: "123", payload });
   });
 
@@ -393,6 +481,46 @@ describe("Push trigger integration tests", () => {
       })
       .reply(200);
 
+    await probot.receive({ name: "pull_request", id: "123", payload });
+  });
+
+  test("CIFlow label without approval keeps label and posts pending comment", async () => {
+    // Deep-clone fixture to avoid mutating the cached require() result
+    const payload = JSON.parse(
+      JSON.stringify(
+        require("./fixtures/push-trigger/pull_request.labeled")
+      )
+    );
+    payload.pull_request.state = "open";
+    payload.label.name = "ciflow/trunk";
+    payload.pull_request.user.login = "new_contributor";
+    const prNum = payload.pull_request.number;
+    const head_sha = payload.pull_request.head.sha;
+    const login = payload.pull_request.user.login;
+
+    nock("https://api.github.com")
+      .get(
+        `/repos/suo/actions-test/contents/${encodeURIComponent(
+          ".github/pytorch-probot.yml"
+        )}`
+      )
+      .reply(200, '{ ciflow_push_tags: ["ciflow/trunk" ]}');
+
+    mockPermissions("suo/actions-test", login, "read");
+
+    mockApprovedWorkflowRuns(
+      "suo/actions-test",
+      head_sha,
+      false
+    );
+
+    // Should search for existing pending comment
+    mockListComments("suo/actions-test", prNum);
+
+    // Should post a NEW pending comment (not remove the label)
+    mockCreateComment("suo/actions-test", prNum, "awaiting approval");
+
+    // No tag creation or label removal should happen
     await probot.receive({ name: "pull_request", id: "123", payload });
   });
 });

--- a/torchci/test/labelCommands.test.ts
+++ b/torchci/test/labelCommands.test.ts
@@ -162,16 +162,34 @@ describe("label-bot", () => {
     const owner = event.payload.repository.owner.login;
     const repo = event.payload.repository.name;
     const pr_number = event.payload.issue.number;
+    const comment_number = event.payload.comment.id;
 
+    // With the new behavior, labels are still added even without approval,
+    // but a comment warns that CI won't be triggered until approved.
     const scope = nock("https://api.github.com")
       .get(`/repos/${owner}/${repo}/labels`)
       .reply(200, existingRepoLabelsResponse)
       .post(`/repos/${owner}/${repo}/issues/${pr_number}/comments`, (body) => {
         expect(JSON.stringify(body)).toContain(
-          `{"body":"To add these label(s) (ciflow/trunk`
+          `{"body":"The ciflow label(s) ciflow/trunk will be added, but CI won't be triggered`
         );
         return true;
       })
+      .reply(200, {})
+      .post(`/repos/${owner}/${repo}/issues/${pr_number}/labels`, (body) => {
+        expect(body).toMatchObject({
+          labels: ["enhancement", "ciflow/trunk"],
+        });
+        return true;
+      })
+      .reply(200, {})
+      .post(
+        `/repos/${owner}/${repo}/issues/comments/${comment_number}/reactions`,
+        (body) => {
+          expect(body).toMatchObject({ content: "+1" });
+          return true;
+        }
+      )
       .reply(200, {});
     const additionalScopes = [
       utils.mockPermissions(


### PR DESCRIPTION
Instead of removing ciflow/ labels when a PR's workflows haven't been approved yet, keep the labels (they represent user's/reviewer's intent) and defer creating the git tags (which trigger CI) until workflow approval happens.

- Post/update a pending comment explaining the state
- On workflow_run events, automatically create tags and resolve comment
- Update pytorchbot label command to add labels even without approval"
