### PR TITLE
Gate claude_billing behind login + clarify estimated costs

### DIFF
--- a/aws/cloudfront/grafana-proxy/viewer-response.js
+++ b/aws/cloudfront/grafana-proxy/viewer-response.js
@@ -1,0 +1,25 @@
+// CloudFront Function (viewer-response) for distribution E2Z345QRXN6Y77
+// Strips frame-ancestors from CSP and x-frame-options to allow iframe embedding
+// on hud.pytorch.org.
+//
+// Deploy: CloudFront Console > Functions > Create > paste this code >
+// Associate with distribution E2Z345QRXN6Y77 (disz2yd9jqnwc.cloudfront.net),
+// event type: viewer-response, cache behavior: Default (*).
+function handler(event) {
+  var response = event.response;
+  var headers = response.headers;
+
+  // Remove x-frame-options (legacy frame-blocking header)
+  delete headers["x-frame-options"];
+
+  // Rewrite CSP: replace frame-ancestors 'none' with hud.pytorch.org
+  if (headers["content-security-policy"]) {
+    headers["content-security-policy"].value =
+      headers["content-security-policy"].value.replace(
+        /frame-ancestors\s+'none'/,
+        "frame-ancestors 'self' https://hud.pytorch.org"
+      );
+  }
+
+  return response;
+}

--- a/torchci/pages/claude_billing.tsx
+++ b/torchci/pages/claude_billing.tsx
@@ -1,11 +1,50 @@
-import { Box, Button, Container, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  Typography,
+} from "@mui/material";
 import Head from "next/head";
+import { signIn, useSession } from "next-auth/react";
+import { useCallback, useEffect, useState } from "react";
 import { useDarkMode } from "../lib/DarkModeContext";
 
 const CLAUDE_BILLING_DASHBOARD_ID = "9127e39ec5a7410ebb419fac06a08ca0";
 
 export default function ClaudeBillingPage() {
   const { themeMode, darkMode } = useDarkMode();
+  const session = useSession();
+  const [permissionState, setPermissionState] = useState<
+    "unchecked" | "checking" | "sufficient" | "insufficient"
+  >("unchecked");
+
+  const checkUserPermissions = useCallback(async () => {
+    if (!session.data?.user || permissionState !== "unchecked") return;
+
+    setPermissionState("checking");
+    try {
+      const response = await fetch("/api/torchagent-check-permissions", {
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      if (response.ok) {
+        setPermissionState("sufficient");
+      } else {
+        setPermissionState("insufficient");
+      }
+    } catch (error) {
+      console.error("Error checking permissions:", error);
+      setPermissionState("insufficient");
+    }
+  }, [session.data?.user, permissionState]);
+
+  useEffect(() => {
+    if (session.data?.user && permissionState === "unchecked") {
+      checkUserPermissions();
+    }
+  }, [session.data?.user, permissionState, checkUserPermissions]);
 
   let chartTheme = "light";
   if (themeMode === "system") {
@@ -17,6 +56,136 @@ export default function ClaudeBillingPage() {
   const dashboardUrl = `https://disz2yd9jqnwc.cloudfront.net/public-dashboards/${CLAUDE_BILLING_DASHBOARD_ID}?theme=${chartTheme}`;
   const grafanaUrl = `https://pytorchci.grafana.net/public-dashboards/${CLAUDE_BILLING_DASHBOARD_ID}`;
 
+  // Loading state
+  if (session.status === "loading" || permissionState === "checking") {
+    return (
+      <>
+        <Head>
+          <title>Claude Code Review Billing - PyTorch CI HUD</title>
+        </Head>
+        <Container
+          maxWidth={false}
+          sx={{
+            py: 10,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
+        >
+          <CircularProgress />
+          <Typography variant="h6" sx={{ mt: 2 }}>
+            {session.status === "loading"
+              ? "Checking authentication..."
+              : "Checking permissions..."}
+          </Typography>
+        </Container>
+      </>
+    );
+  }
+
+  // Unauthenticated
+  if (
+    session.status === "unauthenticated" ||
+    !session.data?.user ||
+    !(session.data as any)?.accessToken
+  ) {
+    return (
+      <>
+        <Head>
+          <title>Claude Code Review Billing - PyTorch CI HUD</title>
+        </Head>
+        <Container
+          maxWidth={false}
+          sx={{
+            py: 10,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
+        >
+          <Typography variant="h4" gutterBottom>
+            Authentication Required
+          </Typography>
+          <Typography variant="body1" sx={{ mb: 2 }}>
+            You must be signed in with write permissions to pytorch/pytorch to
+            view Claude billing data.
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+            Please sign in with GitHub to continue.
+          </Typography>
+          <Button
+            variant="contained"
+            color="primary"
+            size="large"
+            onClick={() => signIn()}
+            sx={{ minWidth: "200px" }}
+          >
+            Sign In
+          </Button>
+        </Container>
+      </>
+    );
+  }
+
+  // Insufficient permissions
+  if (permissionState === "insufficient") {
+    return (
+      <>
+        <Head>
+          <title>Claude Code Review Billing - PyTorch CI HUD</title>
+        </Head>
+        <Container
+          maxWidth={false}
+          sx={{
+            py: 10,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
+        >
+          <Typography variant="h4" gutterBottom>
+            Insufficient Permissions
+          </Typography>
+          <Typography variant="body1" sx={{ mb: 2 }}>
+            You are signed in as{" "}
+            <strong>{session.data.user.name || session.data.user.email}</strong>,
+            but you need write permissions to pytorch/pytorch to view this page.
+          </Typography>
+          <Box
+            sx={{
+              display: "flex",
+              gap: 2,
+              justifyContent: "center",
+              flexWrap: "wrap",
+            }}
+          >
+            <Button
+              variant="contained"
+              color="primary"
+              component="a"
+              href="https://forms.gle/SoLgaCucjJqc6F647"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Request Access
+            </Button>
+            <Button
+              variant="outlined"
+              color="secondary"
+              onClick={() => {
+                setPermissionState("unchecked");
+                checkUserPermissions();
+              }}
+            >
+              Try Again
+            </Button>
+          </Box>
+        </Container>
+      </>
+    );
+  }
+
+  // Authorized — show the dashboard
   return (
     <>
       <Head>

--- a/torchci/pages/claude_billing.tsx
+++ b/torchci/pages/claude_billing.tsx
@@ -5,8 +5,8 @@ import {
   Container,
   Typography,
 } from "@mui/material";
-import Head from "next/head";
 import { signIn, useSession } from "next-auth/react";
+import Head from "next/head";
 import { useCallback, useEffect, useState } from "react";
 import { useDarkMode } from "../lib/DarkModeContext";
 
@@ -148,8 +148,9 @@ export default function ClaudeBillingPage() {
           </Typography>
           <Typography variant="body1" sx={{ mb: 2 }}>
             You are signed in as{" "}
-            <strong>{session.data.user.name || session.data.user.email}</strong>,
-            but you need write permissions to pytorch/pytorch to view this page.
+            <strong>{session.data.user.name || session.data.user.email}</strong>
+            , but you need write permissions to pytorch/pytorch to view this
+            page.
           </Typography>
           <Box
             sx={{


### PR DESCRIPTION
## Summary
- Gate the `claude_billing` page behind GitHub authentication (requires write permissions to pytorch/pytorch, matching the flambeau/TorchAgent pattern)
- Rename heading to **Claude Code Review — Estimated Costs** to clarify these are estimates
- Add disclaimer explaining costs are calculated from GitHub Actions token counts × Anthropic list prices

Context: Team discussion concluded the billing page should be semi-private (behind login) since it shows per-user token usage data.

## Test plan
- [ ] Visit `/claude_billing` while logged out → see Authentication Required + Sign In button
- [ ] Sign in with GitHub account WITHOUT write access → see Insufficient Permissions
- [ ] Sign in with write access → see the Grafana dashboard
- [ ] Verify heading reads Claude Code Review — Estimated Costs
- [ ] Verify disclaimer text is shown above the dashboard