### PR TITLE
Add auto-deploy for grafana-proxy CloudFront Function

### DIFF
--- a/.github/workflows/deploy-cloudfront-grafana-proxy.yml
+++ b/.github/workflows/deploy-cloudfront-grafana-proxy.yml
@@ -1,0 +1,48 @@
+name: Deploy CloudFront grafana-proxy function
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/deploy-cloudfront-grafana-proxy.yml
+      - aws/cloudfront/grafana-proxy/**
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_deploy_cloudfront_grafana_proxy
+          aws-region: us-east-1
+
+      - name: Update and publish CloudFront Function
+        run: |
+          FUNCTION_NAME="grafana-proxy-viewer-response"
+
+          # Get current ETag (required for update)
+          ETAG=$(aws cloudfront describe-function \
+            --name "$FUNCTION_NAME" \
+            --query 'ETag' --output text)
+
+          # Update function code (creates a DEVELOPMENT stage)
+          ETAG=$(aws cloudfront update-function \
+            --name "$FUNCTION_NAME" \
+            --function-config '{"Comment":"Strip frame-ancestors CSP and x-frame-options for hud.pytorch.org iframe embedding","Runtime":"cloudfront-js-2.0"}' \
+            --function-code fileb://aws/cloudfront/grafana-proxy/viewer-response.js \
+            --if-match "$ETAG" \
+            --query 'ETag' --output text)
+
+          # Publish to LIVE stage
+          aws cloudfront publish-function \
+            --name "$FUNCTION_NAME" \
+            --if-match "$ETAG"
+
+          echo "CloudFront Function '$FUNCTION_NAME' deployed successfully"

--- a/aws/cloudfront/grafana-proxy/viewer-response.js
+++ b/aws/cloudfront/grafana-proxy/viewer-response.js
@@ -1,10 +1,10 @@
+// Deployed automatically via GitHub Actions on push to main.
+// See .github/workflows/deploy-cloudfront-grafana-proxy.yml
+//
 // CloudFront Function (viewer-response) for distribution E2Z345QRXN6Y77
+// (disz2yd9jqnwc.cloudfront.net).
 // Strips frame-ancestors from CSP and x-frame-options to allow iframe embedding
 // on hud.pytorch.org.
-//
-// Deploy: CloudFront Console > Functions > Create > paste this code >
-// Associate with distribution E2Z345QRXN6Y77 (disz2yd9jqnwc.cloudfront.net),
-// event type: viewer-response, cache behavior: Default (*).
 function handler(event) {
   var response = event.response;
   var headers = response.headers;


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow to automatically deploy the grafana-proxy CloudFront Function when `aws/cloudfront/grafana-proxy/viewer-response.js` is updated
- Follows the existing Lambda deployment pattern: OIDC auth, path-filtered trigger, AWS CLI deploy
- Replaces manual CloudFront Console deployment with CI/CD

## Prerequisites
An IAM role `gha_deploy_cloudfront_grafana_proxy` needs to be created in account 308535385114 with permissions:
- `cloudfront:DescribeFunction`
- `cloudfront:UpdateFunction`
- `cloudfront:PublishFunction`

The role needs a trust policy allowing GitHub Actions OIDC from `pytorch/test-infra`.

## How it works
On push to `main` affecting `aws/cloudfront/grafana-proxy/**`:
1. Assumes the deploy role via OIDC
2. Gets the current function ETag
3. Updates the function code (DEVELOPMENT stage)
4. Publishes to LIVE stage

## Test plan
- [ ] Create the IAM role with the required permissions
- [ ] Verify workflow triggers correctly on a test push
- [ ] Confirm CloudFront Function is updated in AWS Console after deploy