### PR TITLE
Use Docker Hub alpine for IDC runners in chown-directory steps

### DIFF
--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -308,13 +308,13 @@ jobs:
         uses: ./test-infra/.github/actions/chown-directory
         with:
           directory: ${{ github.workspace }}/${{ env.repository }}
-          ALPINE_IMAGE: ${{ startsWith(inputs.runner, 'linux.arm64') && 'arm64v8/alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
+          ALPINE_IMAGE: ${{ (startsWith(inputs.runner, 'linux.arm64') || startsWith(inputs.runner, 'linux.idc')) && 'alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
 
       - name: Chown runner temp
         uses: ./test-infra/.github/actions/chown-directory
         with:
           directory: ${{ runner.temp }}
-          ALPINE_IMAGE: ${{ startsWith(inputs.runner, 'linux.arm64') && 'arm64v8/alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
+          ALPINE_IMAGE: ${{ (startsWith(inputs.runner, 'linux.arm64') || startsWith(inputs.runner, 'linux.idc')) && 'alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
 
       - name: Prepare artifacts for upload
         if: always()

--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -308,13 +308,13 @@ jobs:
         uses: ./test-infra/.github/actions/chown-directory
         with:
           directory: ${{ github.workspace }}/${{ env.repository }}
-          ALPINE_IMAGE: ${{ (startsWith(inputs.runner, 'linux.arm64') || startsWith(inputs.runner, 'linux.idc')) && 'alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
+          ALPINE_IMAGE: ${{ startsWith(inputs.runner, 'linux.arm64') && 'arm64v8/alpine' || startsWith(inputs.runner, 'linux.idc') && 'alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
 
       - name: Chown runner temp
         uses: ./test-infra/.github/actions/chown-directory
         with:
           directory: ${{ runner.temp }}
-          ALPINE_IMAGE: ${{ (startsWith(inputs.runner, 'linux.arm64') || startsWith(inputs.runner, 'linux.idc')) && 'alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
+          ALPINE_IMAGE: ${{ startsWith(inputs.runner, 'linux.arm64') && 'arm64v8/alpine' || startsWith(inputs.runner, 'linux.idc') && 'alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
 
       - name: Prepare artifacts for upload
         if: always()


### PR DESCRIPTION
The `linux.idc.*` runners (e.g. XPU) don't have the ECR alpine image cached and lack ECR credentials at the chown-directory cleanup stage, causing post-test failures even when all tests pass. Use the public Docker Hub alpine image for these runners, matching the existing pattern for `linux.arm64` runners.

I hit this when trying to get XPU workflows going on Kineto: https://github.com/pytorch/kineto/pull/1302