### PR TITLE
Fix ciflow tag creation for cross-fork PRs

### DIFF
--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -297,14 +297,34 @@ async function handleWorkflowRunEvent(context: Context<"workflow_run">) {
     return;
   }
 
-  const pullRequests = payload.workflow_run.pull_requests;
-  if (!pullRequests || pullRequests.length === 0) {
+  let prNumbers: number[] = (payload.workflow_run.pull_requests ?? []).map(
+    (pr: any) => pr.number
+  );
+
+  // For cross-fork PRs, the pull_requests array is empty.
+  // Fall back to searching for PRs by the fork's owner and branch name.
+  if (prNumbers.length === 0) {
+    const headRepo = payload.workflow_run.head_repository;
+    const headBranch = payload.workflow_run.head_branch;
+    if (headRepo && headBranch) {
+      const head = `${headRepo.owner.login}:${headBranch}`;
+      context.log.info(
+        `workflow_run has empty pull_requests, looking up PRs with head=${head}`
+      );
+      const prs = await context.octokit.pulls.list(
+        context.repo({ head, state: "open" })
+      );
+      prNumbers = prs.data.map((pr) => pr.number);
+    }
+  }
+
+  if (prNumbers.length === 0) {
     return;
   }
 
-  for (const pr of pullRequests) {
+  for (const prNum of prNumbers) {
     const prData = await context.octokit.pulls.get(
-      context.repo({ pull_number: pr.number })
+      context.repo({ pull_number: prNum })
     );
 
     if (prData.data.state === "closed") {
@@ -320,13 +340,13 @@ async function handleWorkflowRunEvent(context: Context<"workflow_run">) {
     }
 
     const headSha = prData.data.head.sha;
-    const tags = ciflowLabels.map((l: string) => labelToTag(l, pr.number));
+    const tags = ciflowLabels.map((l: string) => labelToTag(l, prNum));
     const promises = tags.map(
       async (tag: string) => await syncTag(context as any, tag, headSha)
     );
     await Promise.all(promises);
 
-    await resolvePendingComment(context as any, pr.number);
+    await resolvePendingComment(context as any, prNum);
   }
 }
 

--- a/torchci/test/ciflow-push-trigger.test.ts
+++ b/torchci/test/ciflow-push-trigger.test.ts
@@ -517,4 +517,81 @@ describe("Push trigger integration tests", () => {
     // No tag creation or label removal should happen
     await probot.receive({ name: "pull_request", id: "123", payload });
   });
+
+  test("workflow_run with empty pull_requests falls back to SHA lookup", async () => {
+    const head_sha = "abc123def456";
+    const prNum = 42;
+    const repoFullName = "suo/actions-test";
+
+    const payload = {
+      action: "requested",
+      workflow_run: {
+        event: "pull_request",
+        head_sha: head_sha,
+        head_branch: "feature-branch",
+        head_repository: {
+          owner: { login: "fork-user" },
+        },
+        pull_requests: [],
+      },
+      repository: {
+        owner: { login: "suo" },
+        name: "actions-test",
+        full_name: repoFullName,
+      },
+    };
+
+    // Fall back: lookup PRs by fork owner and branch
+    nock("https://api.github.com")
+      .get(
+        `/repos/${repoFullName}/pulls?head=${encodeURIComponent(
+          "fork-user:feature-branch"
+        )}&state=open`
+      )
+      .reply(200, [{ number: prNum }]);
+
+    // Fetch PR data
+    nock("https://api.github.com")
+      .get(`/repos/${repoFullName}/pulls/${prNum}`)
+      .reply(200, {
+        state: "open",
+        head: { sha: head_sha },
+        labels: [{ name: "ciflow/trunk" }],
+      });
+
+    // syncTag: check existing tags
+    nock("https://api.github.com")
+      .get(
+        `/repos/${repoFullName}/git/matching-refs/${encodeURIComponent(
+          `tags/ciflow/trunk/${prNum}`
+        )}`
+      )
+      .reply(200, []);
+
+    // syncTag: create tag
+    nock("https://api.github.com")
+      .post(`/repos/${repoFullName}/git/refs`, (body) => {
+        expect(body).toMatchObject({
+          ref: `refs/tags/ciflow/trunk/${prNum}`,
+          sha: head_sha,
+        });
+        return true;
+      })
+      .reply(200);
+
+    // Resolve pending comment
+    mockListComments(repoFullName, prNum, [
+      {
+        id: 99,
+        body: "<!-- ciflow-pending -->\nWorkflows awaiting approval",
+      },
+    ]);
+    mockUpdateComment(repoFullName, 99, "CI has now been triggered");
+
+    await probot.receive({
+      name: "workflow_run" as any,
+      id: "456",
+      payload: payload as any,
+    });
+  });
 });


### PR DESCRIPTION
For cross-fork PRs, GitHub's workflow_run webhook payload has an empty pull_requests array, so handleWorkflowRunEvent could never find the PR to create ciflow tags for. Fall back to searching for open PRs by the fork owner and branch name.
