### PR TITLE
Add workflow to automate post release branch cut tasks

### DIFF
--- a/.github/workflows/release-pytorch-post-branch-cut.yml
+++ b/.github/workflows/release-pytorch-post-branch-cut.yml
@@ -67,7 +67,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
           RELEASE_VERSION: ${{ inputs.release_version }}
         run: |
-          BRANCH_NAME="automated/release-changes-${RELEASE_VERSION}"
+          BRANCH_NAME="automated/changes-${RELEASE_VERSION}"
 
           # Check for an existing open PR from this branch
           EXISTING_PR=$(gh pr list \


### PR DESCRIPTION
Followup after https://github.com/pytorch/test-infra/pull/7975
Don't use release in ``branch`` name