### PR TITLE
Add AI advisor manual dispatch to HUD PR page

### DIFF
--- a/torchci/clickhouse_queries/advisor_verdicts_for_pr/params.json
+++ b/torchci/clickhouse_queries/advisor_verdicts_for_pr/params.json
@@ -2,5 +2,6 @@
   "params": {
     "repo": "String",
     "prNumber": "Int64"
-  }
+  },
+  "tests": []
 }

--- a/torchci/clickhouse_queries/advisor_verdicts_for_pr/params.json
+++ b/torchci/clickhouse_queries/advisor_verdicts_for_pr/params.json
@@ -1,0 +1,6 @@
+{
+  "params": {
+    "repo": "String",
+    "prNumber": "Int64"
+  }
+}

--- a/torchci/clickhouse_queries/advisor_verdicts_for_pr/query.sql
+++ b/torchci/clickhouse_queries/advisor_verdicts_for_pr/query.sql
@@ -1,0 +1,19 @@
+-- Fetch AI advisor verdicts for a given PR number
+SELECT
+    suspect_commit AS suspectCommit,
+    signal_key AS signalKey,
+    signal_source AS signalSource,
+    workflow_name AS workflowName,
+    verdict,
+    confidence,
+    summary,
+    causal_reasoning AS causalReasoning,
+    run_id AS runId,
+    timestamp
+FROM
+    misc.autorevert_advisor_verdicts
+WHERE
+    repo = {repo: String}
+    AND pr_number = {prNumber: Int64}
+ORDER BY
+    timestamp DESC

--- a/torchci/clickhouse_queries/advisor_verdicts_for_pr/query.sql
+++ b/torchci/clickhouse_queries/advisor_verdicts_for_pr/query.sql
@@ -1,14 +1,15 @@
 -- Fetch AI advisor verdicts for a given PR number
 SELECT
-    suspect_commit AS suspectCommit,
-    signal_key AS signalKey,
-    signal_source AS signalSource,
-    workflow_name AS workflowName,
+    suspect_commit AS sha,
+    signal_key,
+    signal_source,
+    workflow_name,
     verdict,
     confidence,
     summary,
-    causal_reasoning AS causalReasoning,
-    run_id AS runId,
+    causal_reasoning,
+    run_id,
+    pr_number,
     timestamp
 FROM
     misc.autorevert_advisor_verdicts

--- a/torchci/components/job/AiAdvisorIndicator.tsx
+++ b/torchci/components/job/AiAdvisorIndicator.tsx
@@ -1,4 +1,9 @@
-import { Button, Chip, CircularProgress, Tooltip } from "@mui/material";
+import {
+  Button,
+  Chip,
+  CircularProgress,
+  Tooltip,
+} from "@mui/material";
 import { fetcher } from "lib/GeneralUtils";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
@@ -8,7 +13,11 @@ import useSWR from "swr";
 interface AdvisorVerdict {
   suspectCommit: string;
   signalKey: string;
-  verdict: "revert" | "unsure" | "not_related" | "garbage";
+  verdict:
+    | "revert"
+    | "unsure"
+    | "not_related"
+    | "garbage";
   confidence: number;
   summary: string;
   causalReasoning: string;
@@ -16,7 +25,10 @@ interface AdvisorVerdict {
   timestamp: string;
 }
 
-const VERDICT_COLORS: Record<string, "error" | "warning" | "success" | "default"> = {
+const VERDICT_COLORS: Record<
+  string,
+  "error" | "warning" | "success" | "default"
+> = {
   revert: "error",
   unsure: "warning",
   not_related: "success",
@@ -30,9 +42,15 @@ const VERDICT_LABELS: Record<string, string> = {
   garbage: "Garbage Signal",
 };
 
-function VerdictChip({ verdict }: { verdict: AdvisorVerdict }) {
-  const color = VERDICT_COLORS[verdict.verdict] || "default";
-  const label = VERDICT_LABELS[verdict.verdict] || verdict.verdict;
+function VerdictChip({
+  verdict,
+}: {
+  verdict: AdvisorVerdict;
+}) {
+  const color =
+    VERDICT_COLORS[verdict.verdict] || "default";
+  const label =
+    VERDICT_LABELS[verdict.verdict] || verdict.verdict;
   const runUrl = `https://github.com/pytorch/pytorch/actions/runs/${verdict.runId}`;
 
   return (
@@ -40,10 +58,19 @@ function VerdictChip({ verdict }: { verdict: AdvisorVerdict }) {
       title={
         <div>
           <div>
-            <strong>{label}</strong> (confidence: {(verdict.confidence * 100).toFixed(0)}%)
+            <strong>{label}</strong> (confidence:{" "}
+            {(verdict.confidence * 100).toFixed(0)}%)
           </div>
-          <div style={{ marginTop: 4 }}>{verdict.summary}</div>
-          <div style={{ marginTop: 4, fontSize: "0.85em", opacity: 0.8 }}>
+          <div style={{ marginTop: 4 }}>
+            {verdict.summary}
+          </div>
+          <div
+            style={{
+              marginTop: 4,
+              fontSize: "0.85em",
+              opacity: 0.8,
+            }}
+          >
             {new Date(verdict.timestamp).toLocaleString()}
             {" · "}
             <a
@@ -91,18 +118,17 @@ export default function AiAdvisorIndicator({
   const [dispatched, setDispatched] = useState(false);
   const [error, setError] = useState("");
 
-  // Fetch existing verdicts for this PR
   const { data: verdicts } = useSWR<AdvisorVerdict[]>(
     prNumber
       ? `/api/${repoOwner}/${repoName}/pull/advisor-runs?prNumber=${prNumber}`
       : null,
     fetcher,
-    { refreshInterval: 60_000 }
+    { refreshInterval: 60_000 },
   );
 
-  // Find verdict matching this specific job
   const matchingVerdict = verdicts?.find(
-    (v) => v.signalKey === jobName && v.suspectCommit === sha
+    (v) =>
+      v.signalKey === jobName && v.suspectCommit === sha,
   );
 
   const isAuthenticated =
@@ -111,7 +137,8 @@ export default function AiAdvisorIndicator({
     session.data["user"] !== undefined;
 
   const handleDispatch = async () => {
-    if (!isAuthenticated || dispatching || dispatched) return;
+    if (!isAuthenticated || dispatching || dispatched)
+      return;
 
     setDispatching(true);
     setError("");
@@ -123,7 +150,9 @@ export default function AiAdvisorIndicator({
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            Authorization: session.data!["accessToken"] as string,
+            Authorization: session.data![
+              "accessToken"
+            ] as string,
           },
           body: JSON.stringify({
             prNumber,
@@ -132,7 +161,7 @@ export default function AiAdvisorIndicator({
             jobName,
             workflowName: workflowName || "",
           }),
-        }
+        },
       );
 
       if (!res.ok) {
@@ -149,32 +178,45 @@ export default function AiAdvisorIndicator({
   };
 
   return (
-    <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
-      {matchingVerdict && <VerdictChip verdict={matchingVerdict} />}
-      {!matchingVerdict && !dispatched && isAuthenticated && (
-        <Tooltip title="Run AI advisor to analyze this failure">
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={handleDispatch}
-            disabled={dispatching}
-            sx={{
-              ml: 1,
-              textTransform: "none",
-              fontSize: "0.75rem",
-              py: 0,
-              minHeight: 24,
-            }}
-          >
-            {dispatching ? (
-              <CircularProgress size={14} sx={{ mr: 0.5 }} />
-            ) : (
-              "🤖"
-            )}{" "}
-            AI Analyze
-          </Button>
-        </Tooltip>
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+      }}
+    >
+      {matchingVerdict && (
+        <VerdictChip verdict={matchingVerdict} />
       )}
+      {!matchingVerdict &&
+        !dispatched &&
+        isAuthenticated && (
+          <Tooltip title="Run AI advisor to analyze this failure">
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={handleDispatch}
+              disabled={dispatching}
+              sx={{
+                ml: 1,
+                textTransform: "none",
+                fontSize: "0.75rem",
+                py: 0,
+                minHeight: 24,
+              }}
+            >
+              {dispatching ? (
+                <CircularProgress
+                  size={14}
+                  sx={{ mr: 0.5 }}
+                />
+              ) : (
+                "🤖"
+              )}{" "}
+              AI Analyze
+            </Button>
+          </Tooltip>
+        )}
       {dispatched && (
         <Chip
           label="AI: Dispatched"

--- a/torchci/components/job/AiAdvisorIndicator.tsx
+++ b/torchci/components/job/AiAdvisorIndicator.tsx
@@ -8,11 +8,7 @@ import useSWR from "swr";
 interface AdvisorVerdict {
   suspectCommit: string;
   signalKey: string;
-  verdict:
-    | "revert"
-    | "unsure"
-    | "not_related"
-    | "garbage";
+  verdict: "revert" | "unsure" | "not_related" | "garbage";
   confidence: number;
   summary: string;
   causalReasoning: string;
@@ -37,15 +33,9 @@ const VERDICT_LABELS: Record<string, string> = {
   garbage: "Garbage Signal",
 };
 
-function VerdictChip({
-  verdict,
-}: {
-  verdict: AdvisorVerdict;
-}) {
-  const color =
-    VERDICT_COLORS[verdict.verdict] || "default";
-  const label =
-    VERDICT_LABELS[verdict.verdict] || verdict.verdict;
+function VerdictChip({ verdict }: { verdict: AdvisorVerdict }) {
+  const color = VERDICT_COLORS[verdict.verdict] || "default";
+  const label = VERDICT_LABELS[verdict.verdict] || verdict.verdict;
   const runUrl = `https://github.com/pytorch/pytorch/actions/runs/${verdict.runId}`;
 
   return (
@@ -56,9 +46,7 @@ function VerdictChip({
             <strong>{label}</strong> (confidence:{" "}
             {(verdict.confidence * 100).toFixed(0)}%)
           </div>
-          <div style={{ marginTop: 4 }}>
-            {verdict.summary}
-          </div>
+          <div style={{ marginTop: 4 }}>{verdict.summary}</div>
           <div
             style={{
               marginTop: 4,
@@ -131,8 +119,7 @@ export default function AiAdvisorIndicator({
     session.data["user"] !== undefined;
 
   const handleDispatch = async () => {
-    if (!isAuthenticated || dispatching || dispatched)
-      return;
+    if (!isAuthenticated || dispatching || dispatched) return;
 
     setDispatching(true);
     setError("");
@@ -177,38 +164,31 @@ export default function AiAdvisorIndicator({
         gap: 4,
       }}
     >
-      {matchingVerdict && (
-        <VerdictChip verdict={matchingVerdict} />
+      {matchingVerdict && <VerdictChip verdict={matchingVerdict} />}
+      {!matchingVerdict && !dispatched && isAuthenticated && (
+        <Tooltip title="Run AI advisor to analyze this failure">
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={handleDispatch}
+            disabled={dispatching}
+            sx={{
+              ml: 1,
+              textTransform: "none",
+              fontSize: "0.75rem",
+              py: 0,
+              minHeight: 24,
+            }}
+          >
+            {dispatching ? (
+              <CircularProgress size={14} sx={{ mr: 0.5 }} />
+            ) : (
+              "🤖"
+            )}{" "}
+            AI Analyze
+          </Button>
+        </Tooltip>
       )}
-      {!matchingVerdict &&
-        !dispatched &&
-        isAuthenticated && (
-          <Tooltip title="Run AI advisor to analyze this failure">
-            <Button
-              size="small"
-              variant="outlined"
-              onClick={handleDispatch}
-              disabled={dispatching}
-              sx={{
-                ml: 1,
-                textTransform: "none",
-                fontSize: "0.75rem",
-                py: 0,
-                minHeight: 24,
-              }}
-            >
-              {dispatching ? (
-                <CircularProgress
-                  size={14}
-                  sx={{ mr: 0.5 }}
-                />
-              ) : (
-                "🤖"
-              )}{" "}
-              AI Analyze
-            </Button>
-          </Tooltip>
-        )}
       {dispatched && (
         <Chip
           label="AI: Dispatched"

--- a/torchci/components/job/AiAdvisorIndicator.tsx
+++ b/torchci/components/job/AiAdvisorIndicator.tsx
@@ -1,0 +1,198 @@
+import { Button, Chip, CircularProgress, Tooltip } from "@mui/material";
+import { fetcher } from "lib/GeneralUtils";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/router";
+import { useState } from "react";
+import useSWR from "swr";
+
+interface AdvisorVerdict {
+  suspectCommit: string;
+  signalKey: string;
+  verdict: "revert" | "unsure" | "not_related" | "garbage";
+  confidence: number;
+  summary: string;
+  causalReasoning: string;
+  runId: number;
+  timestamp: string;
+}
+
+const VERDICT_COLORS: Record<string, "error" | "warning" | "success" | "default"> = {
+  revert: "error",
+  unsure: "warning",
+  not_related: "success",
+  garbage: "default",
+};
+
+const VERDICT_LABELS: Record<string, string> = {
+  revert: "Revert",
+  unsure: "Unsure",
+  not_related: "Not Related",
+  garbage: "Garbage Signal",
+};
+
+function VerdictChip({ verdict }: { verdict: AdvisorVerdict }) {
+  const color = VERDICT_COLORS[verdict.verdict] || "default";
+  const label = VERDICT_LABELS[verdict.verdict] || verdict.verdict;
+  const runUrl = `https://github.com/pytorch/pytorch/actions/runs/${verdict.runId}`;
+
+  return (
+    <Tooltip
+      title={
+        <div>
+          <div>
+            <strong>{label}</strong> (confidence: {(verdict.confidence * 100).toFixed(0)}%)
+          </div>
+          <div style={{ marginTop: 4 }}>{verdict.summary}</div>
+          <div style={{ marginTop: 4, fontSize: "0.85em", opacity: 0.8 }}>
+            {new Date(verdict.timestamp).toLocaleString()}
+            {" · "}
+            <a
+              href={runUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: "inherit" }}
+            >
+              GHA Run
+            </a>
+          </div>
+        </div>
+      }
+      arrow
+    >
+      <Chip
+        label={`AI: ${label}`}
+        color={color}
+        size="small"
+        variant="outlined"
+        sx={{ ml: 1, cursor: "pointer" }}
+        onClick={() => window.open(runUrl, "_blank")}
+      />
+    </Tooltip>
+  );
+}
+
+export default function AiAdvisorIndicator({
+  jobName,
+  sha,
+  prNumber,
+  mergeBaseSha,
+  workflowName,
+}: {
+  jobName: string;
+  sha: string;
+  prNumber: number;
+  mergeBaseSha?: string;
+  workflowName?: string;
+}) {
+  const router = useRouter();
+  const { repoOwner, repoName } = router.query;
+  const session = useSession();
+  const [dispatching, setDispatching] = useState(false);
+  const [dispatched, setDispatched] = useState(false);
+  const [error, setError] = useState("");
+
+  // Fetch existing verdicts for this PR
+  const { data: verdicts } = useSWR<AdvisorVerdict[]>(
+    prNumber
+      ? `/api/${repoOwner}/${repoName}/pull/advisor-runs?prNumber=${prNumber}`
+      : null,
+    fetcher,
+    { refreshInterval: 60_000 }
+  );
+
+  // Find verdict matching this specific job
+  const matchingVerdict = verdicts?.find(
+    (v) => v.signalKey === jobName && v.suspectCommit === sha
+  );
+
+  const isAuthenticated =
+    session?.data &&
+    session.data["accessToken"] !== undefined &&
+    session.data["user"] !== undefined;
+
+  const handleDispatch = async () => {
+    if (!isAuthenticated || dispatching || dispatched) return;
+
+    setDispatching(true);
+    setError("");
+
+    try {
+      const res = await fetch(
+        `/api/${repoOwner}/${repoName}/pull/dispatch-advisor`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: session.data!["accessToken"] as string,
+          },
+          body: JSON.stringify({
+            prNumber,
+            headSha: sha,
+            mergeBaseSha: mergeBaseSha || "",
+            jobName,
+            workflowName: workflowName || "",
+          }),
+        }
+      );
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || `HTTP ${res.status}`);
+      }
+
+      setDispatched(true);
+    } catch (e: any) {
+      setError(e.message || "Failed to dispatch");
+    } finally {
+      setDispatching(false);
+    }
+  };
+
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+      {matchingVerdict && <VerdictChip verdict={matchingVerdict} />}
+      {!matchingVerdict && !dispatched && isAuthenticated && (
+        <Tooltip title="Run AI advisor to analyze this failure">
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={handleDispatch}
+            disabled={dispatching}
+            sx={{
+              ml: 1,
+              textTransform: "none",
+              fontSize: "0.75rem",
+              py: 0,
+              minHeight: 24,
+            }}
+          >
+            {dispatching ? (
+              <CircularProgress size={14} sx={{ mr: 0.5 }} />
+            ) : (
+              "🤖"
+            )}{" "}
+            AI Analyze
+          </Button>
+        </Tooltip>
+      )}
+      {dispatched && (
+        <Chip
+          label="AI: Dispatched"
+          size="small"
+          variant="outlined"
+          color="info"
+          sx={{ ml: 1 }}
+        />
+      )}
+      {error && (
+        <Chip
+          label={`Error: ${error}`}
+          size="small"
+          variant="outlined"
+          color="error"
+          sx={{ ml: 1 }}
+        />
+      )}
+    </span>
+  );
+}

--- a/torchci/components/job/AiAdvisorIndicator.tsx
+++ b/torchci/components/job/AiAdvisorIndicator.tsx
@@ -1,9 +1,4 @@
-import {
-  Button,
-  Chip,
-  CircularProgress,
-  Tooltip,
-} from "@mui/material";
+import { Button, Chip, CircularProgress, Tooltip } from "@mui/material";
 import { fetcher } from "lib/GeneralUtils";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
@@ -123,12 +118,11 @@ export default function AiAdvisorIndicator({
       ? `/api/${repoOwner}/${repoName}/pull/advisor-runs?prNumber=${prNumber}`
       : null,
     fetcher,
-    { refreshInterval: 60_000 },
+    { refreshInterval: 60_000 }
   );
 
   const matchingVerdict = verdicts?.find(
-    (v) =>
-      v.signalKey === jobName && v.suspectCommit === sha,
+    (v) => v.signalKey === jobName && v.suspectCommit === sha
   );
 
   const isAuthenticated =
@@ -150,9 +144,7 @@ export default function AiAdvisorIndicator({
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            Authorization: session.data![
-              "accessToken"
-            ] as string,
+            Authorization: session.data!["accessToken"] as string,
           },
           body: JSON.stringify({
             prNumber,
@@ -161,7 +153,7 @@ export default function AiAdvisorIndicator({
             jobName,
             workflowName: workflowName || "",
           }),
-        },
+        }
       );
 
       if (!res.ok) {

--- a/torchci/components/job/AiAdvisorIndicator.tsx
+++ b/torchci/components/job/AiAdvisorIndicator.tsx
@@ -157,6 +157,13 @@ export default function AiAdvisorIndicator({
         }
       );
 
+      if (res.status === 409) {
+        // Already dispatched — treat as success so we show "Dispatched"
+        markDispatched(prNumber, sha, signalKey);
+        setTick((t) => t + 1);
+        return;
+      }
+
       if (!res.ok) {
         const data = await res.json();
         throw new Error(data.error || `HTTP ${res.status}`);

--- a/torchci/components/job/AiAdvisorIndicator.tsx
+++ b/torchci/components/job/AiAdvisorIndicator.tsx
@@ -1,10 +1,14 @@
 import { Button, Chip, CircularProgress, Tooltip } from "@mui/material";
 import { fetcher } from "lib/GeneralUtils";
+import {
+  AdvisorVerdict,
+  AdvisorVerdictType,
+} from "lib/advisorVerdictUtils";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
-import type { AdvisorVerdict } from "pages/api/[repoOwner]/[repoName]/pull/advisor-runs";
 import { useCallback, useState } from "react";
 import useSWR from "swr";
+import AdvisorSection from "./AdvisorSection";
 
 const DISPATCH_STORAGE_KEY = "ai_advisor_dispatches";
 const DISPATCH_TTL_MS = 10 * 60 * 1000; // 10 minutes
@@ -65,7 +69,7 @@ function isDispatched(
   return Date.now() - entry.timestamp < DISPATCH_TTL_MS;
 }
 
-const VERDICT_COLORS: Record<
+const VERDICT_CHIP_COLORS: Record<
   string,
   "error" | "warning" | "success" | "default"
 > = {
@@ -81,54 +85,6 @@ const VERDICT_LABELS: Record<string, string> = {
   not_related: "Not Related",
   garbage: "Garbage Signal",
 };
-
-function VerdictChip({ verdict }: { verdict: AdvisorVerdict }) {
-  const color = VERDICT_COLORS[verdict.verdict] || "default";
-  const label = VERDICT_LABELS[verdict.verdict] || verdict.verdict;
-  const runUrl = `https://github.com/pytorch/pytorch/actions/runs/${verdict.runId}`;
-
-  return (
-    <Tooltip
-      title={
-        <div>
-          <div>
-            <strong>{label}</strong> (confidence:{" "}
-            {(verdict.confidence * 100).toFixed(0)}%)
-          </div>
-          <div style={{ marginTop: 4 }}>{verdict.summary}</div>
-          <div
-            style={{
-              marginTop: 4,
-              fontSize: "0.85em",
-              opacity: 0.8,
-            }}
-          >
-            {new Date(verdict.timestamp).toLocaleString()}
-            {" · "}
-            <a
-              href={runUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{ color: "inherit" }}
-            >
-              GHA Run
-            </a>
-          </div>
-        </div>
-      }
-      arrow
-    >
-      <Chip
-        label={`AI: ${label}`}
-        color={color}
-        size="small"
-        variant="outlined"
-        sx={{ ml: 1, cursor: "pointer" }}
-        onClick={() => window.open(runUrl, "_blank")}
-      />
-    </Tooltip>
-  );
-}
 
 export default function AiAdvisorIndicator({
   jobName,
@@ -166,7 +122,7 @@ export default function AiAdvisorIndicator({
   );
 
   const matchingVerdict = verdicts?.find(
-    (v) => v.signalKey === signalKey && v.suspectCommit === sha
+    (v) => v.signalKey === signalKey && v.sha === sha
   );
 
   const dispatched =
@@ -231,6 +187,13 @@ export default function AiAdvisorIndicator({
     session.data,
   ]);
 
+  const chipColor =
+    VERDICT_CHIP_COLORS[matchingVerdict?.verdict as AdvisorVerdictType] ||
+    "default";
+  const chipLabel =
+    VERDICT_LABELS[matchingVerdict?.verdict as AdvisorVerdictType] ||
+    matchingVerdict?.verdict;
+
   return (
     <span
       style={{
@@ -239,7 +202,32 @@ export default function AiAdvisorIndicator({
         gap: 4,
       }}
     >
-      {matchingVerdict && <VerdictChip verdict={matchingVerdict} />}
+      {matchingVerdict && (
+        <Tooltip
+          title={
+            <AdvisorSection
+              verdict={matchingVerdict}
+              repoOwner={repoOwner as string}
+              repoName={repoName as string}
+            />
+          }
+          arrow
+          placement="bottom-start"
+          slotProps={{
+            tooltip: {
+              sx: { maxWidth: 500, fontSize: "inherit", p: 0.5 },
+            },
+          }}
+        >
+          <Chip
+            label={`AI: ${chipLabel}`}
+            color={chipColor}
+            size="small"
+            variant="outlined"
+            sx={{ ml: 1, cursor: "pointer" }}
+          />
+        </Tooltip>
+      )}
       {!matchingVerdict && !dispatched && isFailed && isAuthenticated && (
         <Tooltip title="Run AI advisor to analyze this failure">
           <Button

--- a/torchci/components/job/AiAdvisorIndicator.tsx
+++ b/torchci/components/job/AiAdvisorIndicator.tsx
@@ -108,6 +108,7 @@ export default function AiAdvisorIndicator({
   const [dispatching, setDispatching] = useState(false);
   const [error, setError] = useState("");
 
+  // dr_ci_ prefix separates HUD-dispatched verdicts from autorevert-system ones
   const signalKey = `dr_ci_${jobName}`;
 
   const { data: verdicts } = useSWR<AdvisorVerdict[]>(

--- a/torchci/components/job/AiAdvisorIndicator.tsx
+++ b/torchci/components/job/AiAdvisorIndicator.tsx
@@ -1,9 +1,6 @@
 import { Button, Chip, CircularProgress, Tooltip } from "@mui/material";
 import { fetcher } from "lib/GeneralUtils";
-import {
-  AdvisorVerdict,
-  AdvisorVerdictType,
-} from "lib/advisorVerdictUtils";
+import { AdvisorVerdict, AdvisorVerdictType } from "lib/advisorVerdictUtils";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import { useCallback, useState } from "react";
@@ -125,8 +122,7 @@ export default function AiAdvisorIndicator({
     (v) => v.signalKey === signalKey && v.sha === sha
   );
 
-  const dispatched =
-    !matchingVerdict && isDispatched(prNumber, sha, signalKey);
+  const dispatched = !matchingVerdict && isDispatched(prNumber, sha, signalKey);
 
   const isAuthenticated =
     session?.data &&

--- a/torchci/components/job/AiAdvisorIndicator.tsx
+++ b/torchci/components/job/AiAdvisorIndicator.tsx
@@ -2,18 +2,67 @@ import { Button, Chip, CircularProgress, Tooltip } from "@mui/material";
 import { fetcher } from "lib/GeneralUtils";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
-import { useState } from "react";
+import type { AdvisorVerdict } from "pages/api/[repoOwner]/[repoName]/pull/advisor-runs";
+import { useCallback, useState } from "react";
 import useSWR from "swr";
 
-interface AdvisorVerdict {
-  suspectCommit: string;
-  signalKey: string;
-  verdict: "revert" | "unsure" | "not_related" | "garbage";
-  confidence: number;
-  summary: string;
-  causalReasoning: string;
-  runId: number;
-  timestamp: string;
+const DISPATCH_STORAGE_KEY = "ai_advisor_dispatches";
+const DISPATCH_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+interface DispatchEntry {
+  timestamp: number;
+}
+
+function getDispatchKey(
+  prNumber: number,
+  sha: string,
+  signalKey: string
+): string {
+  return `${prNumber}:${sha}:${signalKey}`;
+}
+
+function getDispatches(): Record<string, DispatchEntry> {
+  try {
+    const raw = localStorage.getItem(DISPATCH_STORAGE_KEY);
+    if (!raw) return {};
+    const entries = JSON.parse(raw) as Record<string, DispatchEntry>;
+    const now = Date.now();
+    const valid: Record<string, DispatchEntry> = {};
+    for (const [k, v] of Object.entries(entries)) {
+      if (now - v.timestamp < DISPATCH_TTL_MS) {
+        valid[k] = v;
+      }
+    }
+    if (Object.keys(valid).length !== Object.keys(entries).length) {
+      localStorage.setItem(DISPATCH_STORAGE_KEY, JSON.stringify(valid));
+    }
+    return valid;
+  } catch {
+    return {};
+  }
+}
+
+function markDispatched(
+  prNumber: number,
+  sha: string,
+  signalKey: string
+): void {
+  const dispatches = getDispatches();
+  dispatches[getDispatchKey(prNumber, sha, signalKey)] = {
+    timestamp: Date.now(),
+  };
+  localStorage.setItem(DISPATCH_STORAGE_KEY, JSON.stringify(dispatches));
+}
+
+function isDispatched(
+  prNumber: number,
+  sha: string,
+  signalKey: string
+): boolean {
+  const dispatches = getDispatches();
+  const entry = dispatches[getDispatchKey(prNumber, sha, signalKey)];
+  if (!entry) return false;
+  return Date.now() - entry.timestamp < DISPATCH_TTL_MS;
 }
 
 const VERDICT_COLORS: Record<
@@ -85,21 +134,28 @@ export default function AiAdvisorIndicator({
   jobName,
   sha,
   prNumber,
+  conclusion,
   mergeBaseSha,
   workflowName,
 }: {
   jobName: string;
   sha: string;
   prNumber: number;
+  conclusion?: string;
   mergeBaseSha?: string;
   workflowName?: string;
 }) {
+  const isFailed =
+    conclusion === "failure" ||
+    conclusion === "cancelled" ||
+    conclusion === "timed_out";
   const router = useRouter();
   const { repoOwner, repoName } = router.query;
   const session = useSession();
   const [dispatching, setDispatching] = useState(false);
-  const [dispatched, setDispatched] = useState(false);
   const [error, setError] = useState("");
+
+  const signalKey = `dr_ci_${jobName}`;
 
   const { data: verdicts } = useSWR<AdvisorVerdict[]>(
     prNumber
@@ -110,15 +166,20 @@ export default function AiAdvisorIndicator({
   );
 
   const matchingVerdict = verdicts?.find(
-    (v) => v.signalKey === jobName && v.suspectCommit === sha
+    (v) => v.signalKey === signalKey && v.suspectCommit === sha
   );
+
+  const dispatched =
+    !matchingVerdict && isDispatched(prNumber, sha, signalKey);
 
   const isAuthenticated =
     session?.data &&
     session.data["accessToken"] !== undefined &&
     session.data["user"] !== undefined;
 
-  const handleDispatch = async () => {
+  const [, setTick] = useState(0);
+
+  const handleDispatch = useCallback(async () => {
     if (!isAuthenticated || dispatching || dispatched) return;
 
     setDispatching(true);
@@ -148,13 +209,27 @@ export default function AiAdvisorIndicator({
         throw new Error(data.error || `HTTP ${res.status}`);
       }
 
-      setDispatched(true);
+      markDispatched(prNumber, sha, signalKey);
+      setTick((t) => t + 1);
     } catch (e: any) {
       setError(e.message || "Failed to dispatch");
     } finally {
       setDispatching(false);
     }
-  };
+  }, [
+    isAuthenticated,
+    dispatching,
+    dispatched,
+    repoOwner,
+    repoName,
+    prNumber,
+    sha,
+    mergeBaseSha,
+    jobName,
+    signalKey,
+    workflowName,
+    session.data,
+  ]);
 
   return (
     <span
@@ -165,7 +240,7 @@ export default function AiAdvisorIndicator({
       }}
     >
       {matchingVerdict && <VerdictChip verdict={matchingVerdict} />}
-      {!matchingVerdict && !dispatched && isAuthenticated && (
+      {!matchingVerdict && !dispatched && isFailed && isAuthenticated && (
         <Tooltip title="Run AI advisor to analyze this failure">
           <Button
             size="small"

--- a/torchci/components/job/FilteredJobList.tsx
+++ b/torchci/components/job/FilteredJobList.tsx
@@ -4,6 +4,7 @@ import useScrollTo from "lib/useScrollTo";
 import { useRouter } from "next/router";
 import useSWR from "swr";
 import LogViewer from "../common/log/LogViewer";
+import AiAdvisorIndicator from "./AiAdvisorIndicator";
 import JobAnnotationToggle from "./JobAnnotationToggle";
 import JobLinks from "./JobLinks";
 import JobSummary from "./JobSummary";
@@ -21,10 +22,19 @@ function FailedJobInfo({
 }) {
   const router = useRouter();
   useScrollTo();
-  const { repoOwner, repoName } = router.query;
+  const { repoOwner, repoName, prNumber } = router.query;
+  const prNum = prNumber ? parseInt(prNumber as string, 10) : 0;
   return (
     <li key={job.id} id={job.id}>
       <JobSummary job={job} unstableIssues={unstableIssues} />
+      {prNum > 0 && job.name && job.sha && (
+        <AiAdvisorIndicator
+          jobName={job.name}
+          sha={job.sha}
+          prNumber={prNum}
+          workflowName={job.workflowName}
+        />
+      )}
       <div>
         <JobLinks job={job} />
       </div>

--- a/torchci/components/job/FilteredJobList.tsx
+++ b/torchci/components/job/FilteredJobList.tsx
@@ -32,6 +32,7 @@ function FailedJobInfo({
           jobName={job.name}
           sha={job.sha}
           prNumber={prNum}
+          conclusion={job.conclusion}
           workflowName={job.workflowName}
         />
       )}

--- a/torchci/pages/api/[repoOwner]/[repoName]/pull/advisor-runs.ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/pull/advisor-runs.ts
@@ -6,11 +6,7 @@ export interface AdvisorVerdict {
   signalKey: string;
   signalSource: string;
   workflowName: string;
-  verdict:
-    | "revert"
-    | "unsure"
-    | "not_related"
-    | "garbage";
+  verdict: "revert" | "unsure" | "not_related" | "garbage";
   confidence: number;
   summary: string;
   causalReasoning: string;
@@ -25,29 +21,22 @@ export default async function handler(
   const { repoOwner, repoName, prNumber } = req.query;
 
   if (!repoOwner || !repoName || !prNumber) {
-    res
-      .status(400)
-      .json({ error: "Missing required parameters" });
+    res.status(400).json({ error: "Missing required parameters" });
     return;
   }
 
   try {
-    const results = await queryClickhouseSaved(
-      "advisor_verdicts_for_pr",
-      {
-        repo: `${repoOwner}/${repoName}`,
-        prNumber: parseInt(prNumber as string, 10),
-      }
-    );
+    const results = await queryClickhouseSaved("advisor_verdicts_for_pr", {
+      repo: `${repoOwner}/${repoName}`,
+      prNumber: parseInt(prNumber as string, 10),
+    });
 
     res.status(200).json(results as AdvisorVerdict[]);
   } catch (error: any) {
     res.status(500).json({
       error: "Internal server error",
       details:
-        process.env.NODE_ENV === "development"
-          ? error.message
-          : undefined,
+        process.env.NODE_ENV === "development" ? error.message : undefined,
     });
   }
 }

--- a/torchci/pages/api/[repoOwner]/[repoName]/pull/advisor-runs.ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/pull/advisor-runs.ts
@@ -6,7 +6,11 @@ export interface AdvisorVerdict {
   signalKey: string;
   signalSource: string;
   workflowName: string;
-  verdict: "revert" | "unsure" | "not_related" | "garbage";
+  verdict:
+    | "revert"
+    | "unsure"
+    | "not_related"
+    | "garbage";
   confidence: number;
   summary: string;
   causalReasoning: string;
@@ -16,27 +20,34 @@ export interface AdvisorVerdict {
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse
+  res: NextApiResponse,
 ) {
   const { repoOwner, repoName, prNumber } = req.query;
 
   if (!repoOwner || !repoName || !prNumber) {
-    res.status(400).json({ error: "Missing required parameters" });
+    res
+      .status(400)
+      .json({ error: "Missing required parameters" });
     return;
   }
 
   try {
-    const results = await queryClickhouseSaved("advisor_verdicts_for_pr", {
-      repo: `${repoOwner}/${repoName}`,
-      prNumber: parseInt(prNumber as string, 10),
-    });
+    const results = await queryClickhouseSaved(
+      "advisor_verdicts_for_pr",
+      {
+        repo: `${repoOwner}/${repoName}`,
+        prNumber: parseInt(prNumber as string, 10),
+      },
+    );
 
     res.status(200).json(results as AdvisorVerdict[]);
   } catch (error: any) {
     res.status(500).json({
       error: "Internal server error",
       details:
-        process.env.NODE_ENV === "development" ? error.message : undefined,
+        process.env.NODE_ENV === "development"
+          ? error.message
+          : undefined,
     });
   }
 }

--- a/torchci/pages/api/[repoOwner]/[repoName]/pull/advisor-runs.ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/pull/advisor-runs.ts
@@ -1,0 +1,42 @@
+import { queryClickhouseSaved } from "lib/clickhouse";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export interface AdvisorVerdict {
+  suspectCommit: string;
+  signalKey: string;
+  signalSource: string;
+  workflowName: string;
+  verdict: "revert" | "unsure" | "not_related" | "garbage";
+  confidence: number;
+  summary: string;
+  causalReasoning: string;
+  runId: number;
+  timestamp: string;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { repoOwner, repoName, prNumber } = req.query;
+
+  if (!repoOwner || !repoName || !prNumber) {
+    res.status(400).json({ error: "Missing required parameters" });
+    return;
+  }
+
+  try {
+    const results = await queryClickhouseSaved("advisor_verdicts_for_pr", {
+      repo: `${repoOwner}/${repoName}`,
+      prNumber: parseInt(prNumber as string, 10),
+    });
+
+    res.status(200).json(results as AdvisorVerdict[]);
+  } catch (error: any) {
+    res.status(500).json({
+      error: "Internal server error",
+      details:
+        process.env.NODE_ENV === "development" ? error.message : undefined,
+    });
+  }
+}

--- a/torchci/pages/api/[repoOwner]/[repoName]/pull/advisor-runs.ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/pull/advisor-runs.ts
@@ -20,7 +20,7 @@ export interface AdvisorVerdict {
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse,
+  res: NextApiResponse
 ) {
   const { repoOwner, repoName, prNumber } = req.query;
 
@@ -37,7 +37,7 @@ export default async function handler(
       {
         repo: `${repoOwner}/${repoName}`,
         prNumber: parseInt(prNumber as string, 10),
-      },
+      }
     );
 
     res.status(200).json(results as AdvisorVerdict[]);

--- a/torchci/pages/api/[repoOwner]/[repoName]/pull/advisor-runs.ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/pull/advisor-runs.ts
@@ -1,18 +1,9 @@
+import {
+  AdvisorVerdictRow,
+  deduplicateVerdicts,
+} from "lib/advisorVerdictUtils";
 import { queryClickhouseSaved } from "lib/clickhouse";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export interface AdvisorVerdict {
-  suspectCommit: string;
-  signalKey: string;
-  signalSource: string;
-  workflowName: string;
-  verdict: "revert" | "unsure" | "not_related" | "garbage";
-  confidence: number;
-  summary: string;
-  causalReasoning: string;
-  runId: number;
-  timestamp: string;
-}
 
 export default async function handler(
   req: NextApiRequest,
@@ -26,12 +17,12 @@ export default async function handler(
   }
 
   try {
-    const results = await queryClickhouseSaved("advisor_verdicts_for_pr", {
+    const rows = (await queryClickhouseSaved("advisor_verdicts_for_pr", {
       repo: `${repoOwner}/${repoName}`,
       prNumber: parseInt(prNumber as string, 10),
-    });
+    })) as AdvisorVerdictRow[];
 
-    res.status(200).json(results as AdvisorVerdict[]);
+    res.status(200).json(deduplicateVerdicts(rows));
   } catch (error: any) {
     res.status(500).json({
       error: "Internal server error",

--- a/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
@@ -65,8 +65,7 @@ async function fetchJobStatusForShas(
       conclusion: (row.conclusion as string) || "pending",
       htmlUrl: row.htmlUrl as string,
       logUrl: row.logUrl as string,
-      failureCaptures:
-        (row.failureCaptures as string[]) || [],
+      failureCaptures: (row.failureCaptures as string[]) || [],
       failureLines: (row.failureLines as string[]) || [],
     });
   }
@@ -96,80 +95,55 @@ export default async function handler(
   res: NextApiResponse
 ) {
   if (req.method !== "POST") {
-    return void res
-      .status(405)
-      .json({ error: "Method not allowed" });
+    return void res.status(405).json({ error: "Method not allowed" });
   }
 
   const authorization = req.headers.authorization;
   if (!authorization) {
-    return void res
-      .status(403)
-      .json({ error: "Authorization required" });
+    return void res.status(403).json({ error: "Authorization required" });
   }
 
   const owner = req.query["repoOwner"] as string;
   const repo = req.query["repoName"] as string;
   if (!owner || !repo) {
-    return void res
-      .status(400)
-      .json({ error: "Missing repo parameters" });
+    return void res.status(400).json({ error: "Missing repo parameters" });
   }
 
-  const {
-    prNumber,
-    headSha,
-    mergeBaseSha,
-    jobName,
-    workflowName,
-  } = req.body;
+  const { prNumber, headSha, mergeBaseSha, jobName, workflowName } = req.body;
   if (!prNumber || !headSha || !jobName) {
     return void res.status(400).json({
-      error:
-        "Missing required fields: prNumber, headSha, jobName",
+      error: "Missing required fields: prNumber, headSha, jobName",
     });
   }
 
   if (!isValidSha(headSha)) {
-    return void res
-      .status(400)
-      .json({ error: "Invalid headSha format" });
+    return void res.status(400).json({ error: "Invalid headSha format" });
   }
   if (mergeBaseSha && !isValidSha(mergeBaseSha)) {
-    return void res
-      .status(400)
-      .json({ error: "Invalid mergeBaseSha format" });
+    return void res.status(400).json({ error: "Invalid mergeBaseSha format" });
   }
 
-  const octokit =
-    await getOctokitWithUserToken(authorization);
+  const octokit = await getOctokitWithUserToken(authorization);
   const user = await octokit.rest.users.getAuthenticated();
   if (!user?.data?.login) {
-    return void res
-      .status(403)
-      .json({ error: "Invalid credentials" });
+    return void res.status(403).json({ error: "Invalid credentials" });
   }
 
-  const hasWritePerms =
-    await hasWritePermissionsUsingOctokit(
-      octokit,
-      user.data.login,
-      owner,
-      repo
-    );
+  const hasWritePerms = await hasWritePermissionsUsingOctokit(
+    octokit,
+    user.data.login,
+    owner,
+    repo
+  );
   if (!hasWritePerms) {
     return void res.status(403).json({
-      error:
-        "Write permission required to dispatch advisor",
+      error: "Write permission required to dispatch advisor",
     });
   }
 
   try {
     const repoFullName = `${owner}/${repo}`;
-    const trunkShas = await fetchRecentTrunkShas(
-      repoFullName,
-      5
-    );
+    const trunkShas = await fetchRecentTrunkShas(repoFullName, 5);
     const allShas = [headSha];
     if (mergeBaseSha) allShas.push(mergeBaseSha);
     allShas.push(...trunkShas);
@@ -206,8 +180,7 @@ export default async function handler(
         {
           sha: headSha,
           is_suspect: true,
-          partition:
-            "pr_head: the PR head commit under investigation",
+          partition: "pr_head: the PR head commit under investigation",
           timestamp: new Date().toISOString(),
           events: mkEvents(headSha),
         },
@@ -217,8 +190,7 @@ export default async function handler(
           ? [
               {
                 sha: mergeBaseSha,
-                partition:
-                  "merge_base: the merge base commit",
+                partition: "merge_base: the merge base commit",
                 events: mkEvents(mergeBaseSha),
               },
             ]
@@ -226,9 +198,7 @@ export default async function handler(
         ...trunkCommits.filter(
           (c) =>
             c.events.length > 0 &&
-            c.events.some(
-              (e) => e.conclusion === "success"
-            )
+            c.events.some((e) => e.conclusion === "success")
         ),
       ],
       trunk_status: trunkCommits,
@@ -258,9 +228,7 @@ export default async function handler(
     return void res.status(500).json({
       error: "Failed to dispatch advisor workflow",
       details:
-        process.env.NODE_ENV === "development"
-          ? error.message
-          : undefined,
+        process.env.NODE_ENV === "development" ? error.message : undefined,
     });
   }
 }

--- a/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
@@ -20,7 +20,7 @@ interface JobEvent {
 async function fetchJobStatusForShas(
   repo: string,
   jobName: string,
-  shas: string[],
+  shas: string[]
 ): Promise<Record<string, JobEvent[]>> {
   if (shas.length === 0) return {};
 
@@ -75,7 +75,7 @@ async function fetchJobStatusForShas(
 
 async function fetchRecentTrunkShas(
   repo: string,
-  limit: number = 5,
+  limit: number = 5
 ): Promise<string[]> {
   const query = `
     SELECT DISTINCT head_sha
@@ -93,7 +93,7 @@ async function fetchRecentTrunkShas(
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse,
+  res: NextApiResponse
 ) {
   if (req.method !== "POST") {
     return void res
@@ -155,7 +155,7 @@ export default async function handler(
       octokit,
       user.data.login,
       owner,
-      repo,
+      repo
     );
   if (!hasWritePerms) {
     return void res.status(403).json({
@@ -168,7 +168,7 @@ export default async function handler(
     const repoFullName = `${owner}/${repo}`;
     const trunkShas = await fetchRecentTrunkShas(
       repoFullName,
-      5,
+      5
     );
     const allShas = [headSha];
     if (mergeBaseSha) allShas.push(mergeBaseSha);
@@ -177,7 +177,7 @@ export default async function handler(
     const jobStatus = await fetchJobStatusForShas(
       repoFullName,
       jobName,
-      allShas,
+      allShas
     );
 
     const mkEvents = (sha: string) =>
@@ -227,8 +227,8 @@ export default async function handler(
           (c) =>
             c.events.length > 0 &&
             c.events.some(
-              (e) => e.conclusion === "success",
-            ),
+              (e) => e.conclusion === "success"
+            )
         ),
       ],
       trunk_status: trunkCommits,

--- a/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
@@ -1,0 +1,219 @@
+import { hasWritePermissionsUsingOctokit } from "lib/GeneralUtils";
+import { queryClickhouse } from "lib/clickhouse";
+import { getOctokit, getOctokitWithUserToken } from "lib/github";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+// Fetch job results for a specific job name across multiple SHAs
+async function fetchJobStatusForShas(
+  repo: string,
+  jobName: string,
+  shas: string[]
+): Promise<
+  Record<
+    string,
+    {
+      conclusion: string;
+      htmlUrl: string;
+      logUrl: string;
+      failureCaptures: string[];
+      failureLines: string[];
+    }[]
+  >
+> {
+  if (shas.length === 0) return {};
+
+  const shaList = shas.map((s) => `'${s}'`).join(",");
+  const query = `
+    SELECT
+      workflow.head_sha AS sha,
+      job.conclusion_kg AS conclusion,
+      job.html_url AS htmlUrl,
+      job.log_url AS logUrl,
+      job.torchci_classification_kg.'captures' AS failureCaptures,
+      arrayMap(x -> x, if(job.torchci_classification_kg.'line' = '', [], [job.torchci_classification_kg.'line'])) AS failureLines
+    FROM workflow_job job FINAL
+    INNER JOIN workflow_run workflow FINAL ON workflow.id = job.run_id
+    WHERE
+      workflow.head_sha IN (${shaList})
+      AND workflow.repository.full_name = {repo: String}
+      AND CONCAT(workflow.name, ' / ', job.name) = {jobName: String}
+    ORDER BY job.started_at DESC
+  `;
+
+  const rows = await queryClickhouse(query, { repo, jobName });
+
+  const result: Record<string, any[]> = {};
+  for (const row of rows) {
+    const sha = row.sha as string;
+    if (!result[sha]) result[sha] = [];
+    result[sha].push({
+      conclusion: row.conclusion || "pending",
+      htmlUrl: row.htmlUrl,
+      logUrl: row.logUrl,
+      failureCaptures: row.failureCaptures || [],
+      failureLines: row.failureLines || [],
+    });
+  }
+  return result;
+}
+
+// Fetch recent trunk commits for this repo
+async function fetchRecentTrunkShas(
+  repo: string,
+  limit: number = 5
+): Promise<string[]> {
+  const query = `
+    SELECT DISTINCT head_sha
+    FROM workflow_run FINAL
+    WHERE
+      repository.full_name = {repo: String}
+      AND head_branch = 'main'
+      AND event = 'push'
+    ORDER BY created_at DESC
+    LIMIT {limit: UInt32}
+  `;
+  const rows = await queryClickhouse(query, { repo, limit });
+  return rows.map((r: any) => r.head_sha as string);
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST") {
+    return void res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const authorization = req.headers.authorization;
+  if (!authorization) {
+    return void res.status(403).json({ error: "Authorization required" });
+  }
+
+  const owner = req.query["repoOwner"] as string;
+  const repo = req.query["repoName"] as string;
+  if (!owner || !repo) {
+    return void res.status(400).json({ error: "Missing repo parameters" });
+  }
+
+  const { prNumber, headSha, mergeBaseSha, jobName, workflowName } = req.body;
+  if (!prNumber || !headSha || !jobName) {
+    return void res
+      .status(400)
+      .json({ error: "Missing required fields: prNumber, headSha, jobName" });
+  }
+
+  // Verify user has write permissions
+  const octokit = await getOctokitWithUserToken(authorization);
+  const user = await octokit.rest.users.getAuthenticated();
+  if (!user?.data?.login) {
+    return void res.status(403).json({ error: "Invalid credentials" });
+  }
+
+  const hasWritePerms = await hasWritePermissionsUsingOctokit(
+    octokit,
+    user.data.login,
+    owner,
+    repo
+  );
+  if (!hasWritePerms) {
+    return void res
+      .status(403)
+      .json({ error: "Write permission required to dispatch advisor" });
+  }
+
+  try {
+    const repoFullName = `${owner}/${repo}`;
+
+    // Gather SHAs to query: head, merge base, and recent trunk
+    const trunkShas = await fetchRecentTrunkShas(repoFullName, 5);
+    const allShas = [headSha];
+    if (mergeBaseSha) allShas.push(mergeBaseSha);
+    allShas.push(...trunkShas);
+
+    // Fetch job status across all SHAs
+    const jobStatus = await fetchJobStatusForShas(
+      repoFullName,
+      jobName,
+      allShas
+    );
+
+    // Build signal pattern JSON (compatible with autorevert advisor workflow)
+    const mkEvents = (sha: string) =>
+      (jobStatus[sha] || []).map((e) => ({
+        url: e.htmlUrl,
+        log_url: e.logUrl,
+        conclusion: e.conclusion,
+        failure_captures: e.failureCaptures,
+        failure_lines: e.failureLines,
+      }));
+
+    const trunkCommits = trunkShas.map((sha) => ({
+      sha,
+      partition: "trunk: recent main branch commit",
+      events: mkEvents(sha),
+    }));
+
+    const signalPattern = {
+      signal_key: jobName,
+      signal_source: "job",
+      workflow_name: workflowName || "",
+      pr_number: prNumber,
+      head_sha: headSha,
+      merge_base_sha: mergeBaseSha || "",
+      failed_partition: [
+        {
+          sha: headSha,
+          is_suspect: true,
+          partition: "pr_head: the PR head commit under investigation",
+          timestamp: new Date().toISOString(),
+          events: mkEvents(headSha),
+        },
+      ],
+      successful_partition: [
+        ...(mergeBaseSha
+          ? [
+              {
+                sha: mergeBaseSha,
+                partition: "merge_base: the merge base commit",
+                events: mkEvents(mergeBaseSha),
+              },
+            ]
+          : []),
+        ...trunkCommits.filter(
+          (c) =>
+            c.events.length > 0 &&
+            c.events.some((e) => e.conclusion === "success")
+        ),
+      ],
+      trunk_status: trunkCommits,
+    };
+
+    // Dispatch the workflow using the bot token
+    const botOctokit = await getOctokit(owner, repo);
+    await botOctokit.rest.actions.createWorkflowDispatch({
+      owner,
+      repo,
+      workflow_id: "claude-autorevert-advisor.yml",
+      ref: "main",
+      inputs: {
+        suspect_commit: headSha,
+        pr_number: String(prNumber),
+        signal_pattern: JSON.stringify(signalPattern),
+      },
+    });
+
+    return void res.status(200).json({
+      message: "Advisor workflow dispatched",
+      prNumber,
+      headSha,
+      jobName,
+    });
+  } catch (error: any) {
+    console.error("Failed to dispatch advisor:", error);
+    return void res.status(500).json({
+      error: "Failed to dispatch advisor workflow",
+      details:
+        process.env.NODE_ENV === "development" ? error.message : undefined,
+    });
+  }
+}

--- a/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
@@ -3,64 +3,79 @@ import { queryClickhouse } from "lib/clickhouse";
 import { getOctokit, getOctokitWithUserToken } from "lib/github";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-// Fetch job results for a specific job name across multiple SHAs
+const SHA_REGEX = /^[0-9a-f]{4,40}$/i;
+
+function isValidSha(sha: string): boolean {
+  return SHA_REGEX.test(sha);
+}
+
+interface JobEvent {
+  conclusion: string;
+  htmlUrl: string;
+  logUrl: string;
+  failureCaptures: string[];
+  failureLines: string[];
+}
+
 async function fetchJobStatusForShas(
   repo: string,
   jobName: string,
-  shas: string[]
-): Promise<
-  Record<
-    string,
-    {
-      conclusion: string;
-      htmlUrl: string;
-      logUrl: string;
-      failureCaptures: string[];
-      failureLines: string[];
-    }[]
-  >
-> {
+  shas: string[],
+): Promise<Record<string, JobEvent[]>> {
   if (shas.length === 0) return {};
 
-  const shaList = shas.map((s) => `'${s}'`).join(",");
   const query = `
     SELECT
       workflow.head_sha AS sha,
       job.conclusion_kg AS conclusion,
       job.html_url AS htmlUrl,
       job.log_url AS logUrl,
-      job.torchci_classification_kg.'captures' AS failureCaptures,
-      arrayMap(x -> x, if(job.torchci_classification_kg.'line' = '', [], [job.torchci_classification_kg.'line'])) AS failureLines
+      job.torchci_classification_kg.'captures'
+        AS failureCaptures,
+      arrayMap(
+        x -> x,
+        if(
+          job.torchci_classification_kg.'line' = '',
+          [],
+          [job.torchci_classification_kg.'line']
+        )
+      ) AS failureLines
     FROM workflow_job job FINAL
-    INNER JOIN workflow_run workflow FINAL ON workflow.id = job.run_id
+    INNER JOIN workflow_run workflow FINAL
+      ON workflow.id = job.run_id
     WHERE
-      workflow.head_sha IN (${shaList})
+      workflow.head_sha IN ({shas: Array(String)})
       AND workflow.repository.full_name = {repo: String}
-      AND CONCAT(workflow.name, ' / ', job.name) = {jobName: String}
+      AND CONCAT(workflow.name, ' / ', job.name)
+        = {jobName: String}
     ORDER BY job.started_at DESC
   `;
 
-  const rows = await queryClickhouse(query, { repo, jobName });
+  const rows = await queryClickhouse(query, {
+    repo,
+    jobName,
+    shas,
+  });
 
-  const result: Record<string, any[]> = {};
+  const result: Record<string, JobEvent[]> = {};
   for (const row of rows) {
     const sha = row.sha as string;
     if (!result[sha]) result[sha] = [];
     result[sha].push({
-      conclusion: row.conclusion || "pending",
-      htmlUrl: row.htmlUrl,
-      logUrl: row.logUrl,
-      failureCaptures: row.failureCaptures || [],
-      failureLines: row.failureLines || [],
+      conclusion: (row.conclusion as string) || "pending",
+      htmlUrl: row.htmlUrl as string,
+      logUrl: row.logUrl as string,
+      failureCaptures:
+        (row.failureCaptures as string[]) || [],
+      failureLines: (row.failureLines as string[]) || [],
     });
   }
   return result;
 }
 
-// Fetch recent trunk commits for this repo
 async function fetchRecentTrunkShas(
   repo: string,
-  limit: number = 5
+  limit: number = 5,
 ): Promise<string[]> {
   const query = `
     SELECT DISTINCT head_sha
@@ -78,66 +93,93 @@ async function fetchRecentTrunkShas(
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse
+  res: NextApiResponse,
 ) {
   if (req.method !== "POST") {
-    return void res.status(405).json({ error: "Method not allowed" });
+    return void res
+      .status(405)
+      .json({ error: "Method not allowed" });
   }
 
   const authorization = req.headers.authorization;
   if (!authorization) {
-    return void res.status(403).json({ error: "Authorization required" });
+    return void res
+      .status(403)
+      .json({ error: "Authorization required" });
   }
 
   const owner = req.query["repoOwner"] as string;
   const repo = req.query["repoName"] as string;
   if (!owner || !repo) {
-    return void res.status(400).json({ error: "Missing repo parameters" });
-  }
-
-  const { prNumber, headSha, mergeBaseSha, jobName, workflowName } = req.body;
-  if (!prNumber || !headSha || !jobName) {
     return void res
       .status(400)
-      .json({ error: "Missing required fields: prNumber, headSha, jobName" });
+      .json({ error: "Missing repo parameters" });
   }
 
-  // Verify user has write permissions
-  const octokit = await getOctokitWithUserToken(authorization);
+  const {
+    prNumber,
+    headSha,
+    mergeBaseSha,
+    jobName,
+    workflowName,
+  } = req.body;
+  if (!prNumber || !headSha || !jobName) {
+    return void res.status(400).json({
+      error:
+        "Missing required fields: prNumber, headSha, jobName",
+    });
+  }
+
+  if (!isValidSha(headSha)) {
+    return void res
+      .status(400)
+      .json({ error: "Invalid headSha format" });
+  }
+  if (mergeBaseSha && !isValidSha(mergeBaseSha)) {
+    return void res
+      .status(400)
+      .json({ error: "Invalid mergeBaseSha format" });
+  }
+
+  const octokit =
+    await getOctokitWithUserToken(authorization);
   const user = await octokit.rest.users.getAuthenticated();
   if (!user?.data?.login) {
-    return void res.status(403).json({ error: "Invalid credentials" });
-  }
-
-  const hasWritePerms = await hasWritePermissionsUsingOctokit(
-    octokit,
-    user.data.login,
-    owner,
-    repo
-  );
-  if (!hasWritePerms) {
     return void res
       .status(403)
-      .json({ error: "Write permission required to dispatch advisor" });
+      .json({ error: "Invalid credentials" });
+  }
+
+  const hasWritePerms =
+    await hasWritePermissionsUsingOctokit(
+      octokit,
+      user.data.login,
+      owner,
+      repo,
+    );
+  if (!hasWritePerms) {
+    return void res.status(403).json({
+      error:
+        "Write permission required to dispatch advisor",
+    });
   }
 
   try {
     const repoFullName = `${owner}/${repo}`;
-
-    // Gather SHAs to query: head, merge base, and recent trunk
-    const trunkShas = await fetchRecentTrunkShas(repoFullName, 5);
+    const trunkShas = await fetchRecentTrunkShas(
+      repoFullName,
+      5,
+    );
     const allShas = [headSha];
     if (mergeBaseSha) allShas.push(mergeBaseSha);
     allShas.push(...trunkShas);
 
-    // Fetch job status across all SHAs
     const jobStatus = await fetchJobStatusForShas(
       repoFullName,
       jobName,
-      allShas
+      allShas,
     );
 
-    // Build signal pattern JSON (compatible with autorevert advisor workflow)
     const mkEvents = (sha: string) =>
       (jobStatus[sha] || []).map((e) => ({
         url: e.htmlUrl,
@@ -164,7 +206,8 @@ export default async function handler(
         {
           sha: headSha,
           is_suspect: true,
-          partition: "pr_head: the PR head commit under investigation",
+          partition:
+            "pr_head: the PR head commit under investigation",
           timestamp: new Date().toISOString(),
           events: mkEvents(headSha),
         },
@@ -174,7 +217,8 @@ export default async function handler(
           ? [
               {
                 sha: mergeBaseSha,
-                partition: "merge_base: the merge base commit",
+                partition:
+                  "merge_base: the merge base commit",
                 events: mkEvents(mergeBaseSha),
               },
             ]
@@ -182,13 +226,14 @@ export default async function handler(
         ...trunkCommits.filter(
           (c) =>
             c.events.length > 0 &&
-            c.events.some((e) => e.conclusion === "success")
+            c.events.some(
+              (e) => e.conclusion === "success",
+            ),
         ),
       ],
       trunk_status: trunkCommits,
     };
 
-    // Dispatch the workflow using the bot token
     const botOctokit = await getOctokit(owner, repo);
     await botOctokit.rest.actions.createWorkflowDispatch({
       owner,
@@ -213,7 +258,9 @@ export default async function handler(
     return void res.status(500).json({
       error: "Failed to dispatch advisor workflow",
       details:
-        process.env.NODE_ENV === "development" ? error.message : undefined,
+        process.env.NODE_ENV === "development"
+          ? error.message
+          : undefined,
     });
   }
 }

--- a/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
@@ -251,7 +251,7 @@ export default async function handler(
     }
 
     // Fetch trunk SHAs that actually ran this job (using pattern match)
-    const trunkShas = await fetchTrunkShasWithJob(repoFullName, jobPattern, 5);
+    const trunkShas = await fetchTrunkShasWithJob(repoFullName, jobPattern, 3);
 
     // Fetch events: exact match for PR head, pattern match for trunk/merge-base
     const headStatus = await fetchJobStatusExact(repoFullName, jobName, [
@@ -317,26 +317,19 @@ export default async function handler(
           events: mkEvents(headStatus, headSha),
         },
       ],
-      successful_partition: [
-        ...(resolvedMergeBase
-          ? [
-              {
-                sha: resolvedMergeBase,
-                partition: "merge_base: the trunk commit this PR is based on",
-                timestamp: commitTimestamp(
-                  baseAndTrunkStatus,
-                  resolvedMergeBase
-                ),
-                events: mkEvents(baseAndTrunkStatus, resolvedMergeBase),
-              },
-            ]
-          : []),
-        ...trunkCommits.filter(
-          (c) =>
-            c.events.length > 0 &&
-            c.events.some((e) => e.conclusion === "success")
-        ),
-      ],
+      successful_partition: resolvedMergeBase
+        ? [
+            {
+              sha: resolvedMergeBase,
+              partition: "merge_base: the trunk commit this PR is based on",
+              timestamp: commitTimestamp(
+                baseAndTrunkStatus,
+                resolvedMergeBase
+              ),
+              events: mkEvents(baseAndTrunkStatus, resolvedMergeBase),
+            },
+          ]
+        : [],
       trunk_status: trunkCommits,
     };
 

--- a/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
@@ -9,15 +9,37 @@ function isValidSha(sha: string): boolean {
   return SHA_REGEX.test(sha);
 }
 
+/**
+ * Derive a LIKE pattern from a HUD job name that matches both
+ * PR variants (-partial) and trunk variants (-all).
+ * E.g. "Lint / lintrunner-pyrefly-partial / lint"
+ *   -> "Lint / lintrunner-pyrefly-% / lint"
+ * Also strips shard parentheticals: "pull / job (default, 1, 5, ...)"
+ *   -> "pull / job%"
+ */
+function jobNameToBasePattern(jobName: string): string {
+  let pattern = jobName;
+  // Replace -partial or -all with -%
+  pattern = pattern.replace(/-(partial|all)\b/g, "-%");
+  // Strip trailing shard parenthetical
+  pattern = pattern.replace(/\s*\([^)]*\)$/, "%");
+  return pattern;
+}
+
 interface JobEvent {
   conclusion: string;
+  fullName: string;
   htmlUrl: string;
   logUrl: string;
   failureCaptures: string[];
   failureLines: string[];
 }
 
-async function fetchJobStatusForShas(
+/**
+ * Fetch job events for specific SHAs using exact name match.
+ * Used for the PR head commit where we know the exact job name.
+ */
+async function fetchJobStatusExact(
   repo: string,
   jobName: string,
   shas: string[]
@@ -28,6 +50,7 @@ async function fetchJobStatusForShas(
     SELECT
       job.head_sha AS sha,
       job.conclusion_kg AS conclusion,
+      CONCAT(job.workflow_name, ' / ', job.name) AS fullName,
       job.html_url AS htmlUrl,
       job.log_url AS logUrl,
       job.torchci_classification_kg.'captures'
@@ -51,18 +74,60 @@ async function fetchJobStatusForShas(
     ORDER BY job.started_at DESC
   `;
 
-  const rows = await queryClickhouse(query, {
-    repo,
-    jobName,
-    shas,
-  });
+  return groupJobRows(await queryClickhouse(query, { repo, jobName, shas }));
+}
 
+/**
+ * Fetch job events for specific SHAs using LIKE pattern match.
+ * Used for trunk/merge-base where job names may differ
+ * (e.g. -partial on PR vs -all on trunk).
+ */
+async function fetchJobStatusPattern(
+  repo: string,
+  jobPattern: string,
+  shas: string[]
+): Promise<Record<string, JobEvent[]>> {
+  if (shas.length === 0) return {};
+
+  const query = `
+    SELECT
+      job.head_sha AS sha,
+      job.conclusion_kg AS conclusion,
+      CONCAT(job.workflow_name, ' / ', job.name) AS fullName,
+      job.html_url AS htmlUrl,
+      job.log_url AS logUrl,
+      job.torchci_classification_kg.'captures'
+        AS failureCaptures,
+      IF(
+        job.torchci_classification_kg.'line' = '',
+        [],
+        [job.torchci_classification_kg.'line']
+      ) AS failureLines
+    FROM default.workflow_job job FINAL
+    WHERE
+      job.id IN (
+        SELECT id
+        FROM materialized_views.workflow_job_by_head_sha
+        WHERE head_sha IN ({shas: Array(String)})
+      )
+      AND job.head_sha IN ({shas: Array(String)})
+      AND job.repository_full_name = {repo: String}
+      AND CONCAT(job.workflow_name, ' / ', job.name)
+        LIKE {jobPattern: String}
+    ORDER BY job.started_at DESC
+  `;
+
+  return groupJobRows(await queryClickhouse(query, { repo, jobPattern, shas }));
+}
+
+function groupJobRows(rows: any[]): Record<string, JobEvent[]> {
   const result: Record<string, JobEvent[]> = {};
   for (const row of rows) {
     const sha = row.sha as string;
     if (!result[sha]) result[sha] = [];
     result[sha].push({
       conclusion: (row.conclusion as string) || "pending",
+      fullName: (row.fullName as string) || "",
       htmlUrl: row.htmlUrl as string,
       logUrl: row.logUrl as string,
       failureCaptures: (row.failureCaptures as string[]) || [],
@@ -72,20 +137,32 @@ async function fetchJobStatusForShas(
   return result;
 }
 
-async function fetchRecentTrunkShas(
+/**
+ * Fetch recent trunk commit SHAs that have finished runs matching
+ * the given job pattern. Returns up to `limit` distinct SHAs.
+ */
+async function fetchTrunkShasWithJob(
   repo: string,
+  jobPattern: string,
   limit: number = 5
 ): Promise<string[]> {
   const query = `
-    SELECT head_commit.'id' AS head_sha
-    FROM default.push
+    SELECT DISTINCT job.head_sha AS head_sha
+    FROM default.workflow_job job FINAL
     WHERE
-      repository.full_name = {repo: String}
-      AND ref = 'refs/heads/main'
-    ORDER BY head_commit.'timestamp' DESC
+      job.id IN (
+        SELECT id FROM materialized_views.workflow_job_by_created_at
+        WHERE created_at > now() - INTERVAL 3 DAY
+      )
+      AND job.repository_full_name = {repo: String}
+      AND job.head_branch = 'main'
+      AND CONCAT(job.workflow_name, ' / ', job.name)
+        LIKE {jobPattern: String}
+      AND job.conclusion_kg IN ('success', 'failure', 'cancelled', 'timed_out')
+    ORDER BY job.started_at DESC
     LIMIT {limit: UInt32}
   `;
-  const rows = await queryClickhouse(query, { repo, limit });
+  const rows = await queryClickhouse(query, { repo, jobPattern, limit });
   return rows.map((r: any) => r.head_sha as string);
 }
 
@@ -146,21 +223,48 @@ export default async function handler(
 
   try {
     const repoFullName = `${owner}/${repo}`;
-    const trunkShas = await fetchRecentTrunkShas(repoFullName, 5);
-    const allShas = [headSha];
-    if (mergeBaseSha) allShas.push(mergeBaseSha);
-    allShas.push(...trunkShas);
+    const botOctokit = await getOctokit(owner, repo);
+    const jobPattern = jobNameToBasePattern(jobName);
 
-    const jobStatus = await fetchJobStatusForShas(
+    // Fetch merge base SHA from GitHub
+    let resolvedMergeBase = mergeBaseSha || "";
+    if (!resolvedMergeBase) {
+      try {
+        const compare = await botOctokit.rest.repos.compareCommits({
+          owner,
+          repo,
+          base: "main",
+          head: headSha,
+        });
+        resolvedMergeBase = compare.data.merge_base_commit.sha;
+      } catch {
+        // If compare fails (e.g. force-pushed branch), continue without merge base
+      }
+    }
+
+    // Fetch trunk SHAs that actually ran this job (using pattern match)
+    const trunkShas = await fetchTrunkShasWithJob(repoFullName, jobPattern, 5);
+
+    // Fetch events: exact match for PR head, pattern match for trunk/merge-base
+    const headStatus = await fetchJobStatusExact(repoFullName, jobName, [
+      headSha,
+    ]);
+
+    const baseAndTrunkShas = [
+      ...(resolvedMergeBase ? [resolvedMergeBase] : []),
+      ...trunkShas,
+    ];
+    const baseAndTrunkStatus = await fetchJobStatusPattern(
       repoFullName,
-      jobName,
-      allShas
+      jobPattern,
+      baseAndTrunkShas
     );
 
-    const mkEvents = (sha: string) =>
-      (jobStatus[sha] || []).map((e) => ({
+    const mkEvents = (status: Record<string, JobEvent[]>, sha: string) =>
+      (status[sha] || []).map((e) => ({
         url: e.htmlUrl,
         log_url: e.logUrl,
+        full_name: e.fullName,
         conclusion: e.conclusion,
         failure_captures: e.failureCaptures,
         failure_lines: e.failureLines,
@@ -168,8 +272,8 @@ export default async function handler(
 
     const trunkCommits = trunkShas.map((sha) => ({
       sha,
-      partition: "trunk: recent main branch commit",
-      events: mkEvents(sha),
+      partition: "trunk: recent main commit with this job",
+      events: mkEvents(baseAndTrunkStatus, sha),
     }));
 
     const signalKey = `dr_ci_${jobName}`;
@@ -179,23 +283,23 @@ export default async function handler(
       workflow_name: workflowName || "",
       pr_number: prNumber,
       head_sha: headSha,
-      merge_base_sha: mergeBaseSha || "",
+      merge_base_sha: resolvedMergeBase,
       failed_partition: [
         {
           sha: headSha,
           is_suspect: true,
           partition: "pr_head: the PR head commit under investigation",
           timestamp: new Date().toISOString(),
-          events: mkEvents(headSha),
+          events: mkEvents(headStatus, headSha),
         },
       ],
       successful_partition: [
-        ...(mergeBaseSha
+        ...(resolvedMergeBase
           ? [
               {
-                sha: mergeBaseSha,
-                partition: "merge_base: the merge base commit",
-                events: mkEvents(mergeBaseSha),
+                sha: resolvedMergeBase,
+                partition: "merge_base: the trunk commit this PR is based on",
+                events: mkEvents(baseAndTrunkStatus, resolvedMergeBase),
               },
             ]
           : []),
@@ -208,7 +312,6 @@ export default async function handler(
       trunk_status: trunkCommits,
     };
 
-    const botOctokit = await getOctokit(owner, repo);
     await botOctokit.rest.actions.createWorkflowDispatch({
       owner,
       repo,

--- a/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
@@ -31,6 +31,8 @@ interface JobEvent {
   fullName: string;
   htmlUrl: string;
   logUrl: string;
+  startedAt: string;
+  completedAt: string;
   failureCaptures: string[];
   failureLines: string[];
 }
@@ -53,6 +55,8 @@ async function fetchJobStatusExact(
       CONCAT(job.workflow_name, ' / ', job.name) AS fullName,
       job.html_url AS htmlUrl,
       job.log_url AS logUrl,
+      job.started_at AS startedAt,
+      job.completed_at AS completedAt,
       job.torchci_classification_kg.'captures'
         AS failureCaptures,
       IF(
@@ -96,6 +100,8 @@ async function fetchJobStatusPattern(
       CONCAT(job.workflow_name, ' / ', job.name) AS fullName,
       job.html_url AS htmlUrl,
       job.log_url AS logUrl,
+      job.started_at AS startedAt,
+      job.completed_at AS completedAt,
       job.torchci_classification_kg.'captures'
         AS failureCaptures,
       IF(
@@ -130,6 +136,8 @@ function groupJobRows(rows: any[]): Record<string, JobEvent[]> {
       fullName: (row.fullName as string) || "",
       htmlUrl: row.htmlUrl as string,
       logUrl: row.logUrl as string,
+      startedAt: (row.startedAt as string) || "",
+      completedAt: (row.completedAt as string) || "",
       failureCaptures: (row.failureCaptures as string[]) || [],
       failureLines: (row.failureLines as string[]) || [],
     });
@@ -266,13 +274,29 @@ export default async function handler(
         log_url: e.logUrl,
         full_name: e.fullName,
         conclusion: e.conclusion,
+        started_at: e.startedAt,
+        completed_at: e.completedAt,
         failure_captures: e.failureCaptures,
         failure_lines: e.failureLines,
       }));
 
+    // Derive a commit-level timestamp from the earliest event started_at
+    const commitTimestamp = (
+      status: Record<string, JobEvent[]>,
+      sha: string
+    ): string => {
+      const events = status[sha] || [];
+      const times = events
+        .map((e) => e.startedAt)
+        .filter(Boolean)
+        .sort();
+      return times[0] || "";
+    };
+
     const trunkCommits = trunkShas.map((sha) => ({
       sha,
       partition: "trunk: recent main commit with this job",
+      timestamp: commitTimestamp(baseAndTrunkStatus, sha),
       events: mkEvents(baseAndTrunkStatus, sha),
     }));
 
@@ -299,6 +323,10 @@ export default async function handler(
               {
                 sha: resolvedMergeBase,
                 partition: "merge_base: the trunk commit this PR is based on",
+                timestamp: commitTimestamp(
+                  baseAndTrunkStatus,
+                  resolvedMergeBase
+                ),
                 events: mkEvents(baseAndTrunkStatus, resolvedMergeBase),
               },
             ]

--- a/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
@@ -26,27 +26,27 @@ async function fetchJobStatusForShas(
 
   const query = `
     SELECT
-      workflow.head_sha AS sha,
+      job.head_sha AS sha,
       job.conclusion_kg AS conclusion,
       job.html_url AS htmlUrl,
       job.log_url AS logUrl,
       job.torchci_classification_kg.'captures'
         AS failureCaptures,
-      arrayMap(
-        x -> x,
-        if(
-          job.torchci_classification_kg.'line' = '',
-          [],
-          [job.torchci_classification_kg.'line']
-        )
+      IF(
+        job.torchci_classification_kg.'line' = '',
+        [],
+        [job.torchci_classification_kg.'line']
       ) AS failureLines
-    FROM workflow_job job FINAL
-    INNER JOIN workflow_run workflow FINAL
-      ON workflow.id = job.run_id
+    FROM default.workflow_job job FINAL
     WHERE
-      workflow.head_sha IN ({shas: Array(String)})
-      AND workflow.repository.full_name = {repo: String}
-      AND CONCAT(workflow.name, ' / ', job.name)
+      job.id IN (
+        SELECT id
+        FROM materialized_views.workflow_job_by_head_sha
+        WHERE head_sha IN ({shas: Array(String)})
+      )
+      AND job.head_sha IN ({shas: Array(String)})
+      AND job.repository_full_name = {repo: String}
+      AND CONCAT(job.workflow_name, ' / ', job.name)
         = {jobName: String}
     ORDER BY job.started_at DESC
   `;
@@ -77,13 +77,12 @@ async function fetchRecentTrunkShas(
   limit: number = 5
 ): Promise<string[]> {
   const query = `
-    SELECT DISTINCT head_sha
-    FROM workflow_run FINAL
+    SELECT head_commit.'id' AS head_sha
+    FROM default.push
     WHERE
       repository.full_name = {repo: String}
-      AND head_branch = 'main'
-      AND event = 'push'
-    ORDER BY created_at DESC
+      AND ref = 'refs/heads/main'
+    ORDER BY head_commit.'timestamp' DESC
     LIMIT {limit: UInt32}
   `;
   const rows = await queryClickhouse(query, { repo, limit });
@@ -114,6 +113,10 @@ export default async function handler(
     return void res.status(400).json({
       error: "Missing required fields: prNumber, headSha, jobName",
     });
+  }
+
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    return void res.status(400).json({ error: "Invalid prNumber" });
   }
 
   if (!isValidSha(headSha)) {
@@ -169,8 +172,9 @@ export default async function handler(
       events: mkEvents(sha),
     }));
 
+    const signalKey = `dr_ci_${jobName}`;
     const signalPattern = {
-      signal_key: jobName,
+      signal_key: signalKey,
       signal_source: "job",
       workflow_name: workflowName || "",
       pr_number: prNumber,

--- a/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
@@ -300,7 +300,15 @@ export default async function handler(
       events: mkEvents(baseAndTrunkStatus, sha),
     }));
 
+    // Signal key uses dr_ci_ prefix to distinguish manual HUD dispatches
+    // from autorevert-system dispatches. Autorevert uses normalized base_name
+    // (e.g. "linux-jammy-py3.10-gcc11 / test") while HUD uses the full
+    // concatenated job name (e.g. "pull / linux-jammy-... / test (shard)").
+    // Keeping them separate avoids verdict collisions between the two systems.
     const signalKey = `dr_ci_${jobName}`;
+
+    // Use semantic partition names instead of failed/successful labels,
+    // since the merge base or trunk commits may themselves be red.
     const signalPattern = {
       signal_key: signalKey,
       signal_source: "job",
@@ -308,29 +316,23 @@ export default async function handler(
       pr_number: prNumber,
       head_sha: headSha,
       merge_base_sha: resolvedMergeBase,
-      failed_partition: [
-        {
-          sha: headSha,
-          is_suspect: true,
-          partition: "pr_head: the PR head commit under investigation",
-          timestamp: new Date().toISOString(),
-          events: mkEvents(headStatus, headSha),
-        },
-      ],
-      successful_partition: resolvedMergeBase
-        ? [
-            {
-              sha: resolvedMergeBase,
-              partition: "merge_base: the trunk commit this PR is based on",
-              timestamp: commitTimestamp(
-                baseAndTrunkStatus,
-                resolvedMergeBase
-              ),
-              events: mkEvents(baseAndTrunkStatus, resolvedMergeBase),
-            },
-          ]
-        : [],
-      trunk_status: trunkCommits,
+      pr_head: {
+        sha: headSha,
+        is_suspect: true,
+        timestamp: new Date().toISOString(),
+        events: mkEvents(headStatus, headSha),
+      },
+      merge_base: resolvedMergeBase
+        ? {
+            sha: resolvedMergeBase,
+            timestamp: commitTimestamp(
+              baseAndTrunkStatus,
+              resolvedMergeBase
+            ),
+            events: mkEvents(baseAndTrunkStatus, resolvedMergeBase),
+          }
+        : null,
+      trunk: trunkCommits,
     };
 
     await botOctokit.rest.actions.createWorkflowDispatch({

--- a/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
@@ -372,7 +372,7 @@ export default async function handler(
       owner,
       repo,
       workflow_id: "claude-autorevert-advisor.yml",
-      ref: "main",
+      ref: defaultBranch,
       inputs: {
         suspect_commit: headSha,
         pr_number: String(prNumber),

--- a/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
@@ -3,7 +3,7 @@ import { queryClickhouse } from "lib/clickhouse";
 import { getOctokit, getOctokitWithUserToken } from "lib/github";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-const SHA_REGEX = /^[0-9a-f]{4,40}$/i;
+const SHA_REGEX = /^[0-9a-f]{7,40}$/i;
 
 function isValidSha(sha: string): boolean {
   return SHA_REGEX.test(sha);
@@ -152,6 +152,7 @@ function groupJobRows(rows: any[]): Record<string, JobEvent[]> {
 async function fetchTrunkShasWithJob(
   repo: string,
   jobPattern: string,
+  branch: string,
   limit: number = 5
 ): Promise<string[]> {
   const query = `
@@ -163,14 +164,19 @@ async function fetchTrunkShasWithJob(
         WHERE created_at > now() - INTERVAL 3 DAY
       )
       AND job.repository_full_name = {repo: String}
-      AND job.head_branch = 'main'
+      AND job.head_branch = {branch: String}
       AND CONCAT(job.workflow_name, ' / ', job.name)
         LIKE {jobPattern: String}
       AND job.conclusion_kg IN ('success', 'failure', 'cancelled', 'timed_out')
     ORDER BY job.started_at DESC
     LIMIT {limit: UInt32}
   `;
-  const rows = await queryClickhouse(query, { repo, jobPattern, limit });
+  const rows = await queryClickhouse(query, {
+    repo,
+    jobPattern,
+    branch,
+    limit,
+  });
   return rows.map((r: any) => r.head_sha as string);
 }
 
@@ -229,10 +235,42 @@ export default async function handler(
     });
   }
 
+  // Signal key uses dr_ci_ prefix to distinguish manual HUD dispatches
+  // from autorevert-system dispatches (see comment below where signalKey
+  // is constructed for full rationale).
+  const signalKey = `dr_ci_${jobName}`;
+
+  // Server-side dedup: skip if a verdict for this (sha, signal_key) was
+  // already produced in the last 10 minutes, meaning a prior dispatch
+  // already completed or is in-flight.
+  try {
+    const recentRows = await queryClickhouse(
+      `SELECT 1
+       FROM misc.autorevert_advisor_verdicts
+       WHERE repo = {repo: String}
+         AND suspect_commit = {sha: String}
+         AND signal_key = {signalKey: String}
+         AND timestamp > now() - INTERVAL 10 MINUTE
+       LIMIT 1`,
+      { repo: `${owner}/${repo}`, sha: headSha, signalKey }
+    );
+    if (recentRows.length > 0) {
+      return void res.status(409).json({
+        error: "Advisor was already dispatched for this job recently",
+      });
+    }
+  } catch {
+    // If the dedup check fails, proceed with dispatch anyway
+  }
+
   try {
     const repoFullName = `${owner}/${repo}`;
     const botOctokit = await getOctokit(owner, repo);
     const jobPattern = jobNameToBasePattern(jobName);
+
+    // Look up default branch (usually "main") instead of hardcoding
+    const repoData = await botOctokit.rest.repos.get({ owner, repo });
+    const defaultBranch = repoData.data.default_branch;
 
     // Fetch merge base SHA from GitHub
     let resolvedMergeBase = mergeBaseSha || "";
@@ -241,7 +279,7 @@ export default async function handler(
         const compare = await botOctokit.rest.repos.compareCommits({
           owner,
           repo,
-          base: "main",
+          base: defaultBranch,
           head: headSha,
         });
         resolvedMergeBase = compare.data.merge_base_commit.sha;
@@ -251,7 +289,12 @@ export default async function handler(
     }
 
     // Fetch trunk SHAs that actually ran this job (using pattern match)
-    const trunkShas = await fetchTrunkShasWithJob(repoFullName, jobPattern, 3);
+    const trunkShas = await fetchTrunkShasWithJob(
+      repoFullName,
+      jobPattern,
+      defaultBranch,
+      3
+    );
 
     // Fetch events: exact match for PR head, pattern match for trunk/merge-base
     const headStatus = await fetchJobStatusExact(repoFullName, jobName, [
@@ -300,13 +343,6 @@ export default async function handler(
       events: mkEvents(baseAndTrunkStatus, sha),
     }));
 
-    // Signal key uses dr_ci_ prefix to distinguish manual HUD dispatches
-    // from autorevert-system dispatches. Autorevert uses normalized base_name
-    // (e.g. "linux-jammy-py3.10-gcc11 / test") while HUD uses the full
-    // concatenated job name (e.g. "pull / linux-jammy-... / test (shard)").
-    // Keeping them separate avoids verdict collisions between the two systems.
-    const signalKey = `dr_ci_${jobName}`;
-
     // Use semantic partition names instead of failed/successful labels,
     // since the merge base or trunk commits may themselves be red.
     const signalPattern = {
@@ -325,10 +361,7 @@ export default async function handler(
       merge_base: resolvedMergeBase
         ? {
             sha: resolvedMergeBase,
-            timestamp: commitTimestamp(
-              baseAndTrunkStatus,
-              resolvedMergeBase
-            ),
+            timestamp: commitTimestamp(baseAndTrunkStatus, resolvedMergeBase),
             events: mkEvents(baseAndTrunkStatus, resolvedMergeBase),
           }
         : null,


### PR DESCRIPTION
## Summary

Adds the ability to trigger AI advisor analysis for individual failed jobs on the HUD PR page (hud.pytorch.org).

### New features:
- **Verdict display**: Each failed job on a PR page shows existing AI advisor verdicts as colored chips (red=revert, green=not_related, yellow=unsure, grey=garbage)
- **Manual dispatch**: An "AI Analyze" button appears next to failed jobs with no existing verdict, dispatching the `claude-autorevert-advisor.yml` workflow
- **Signal pattern**: The dispatch builds a JSON payload with job status across PR head, merge base, and recent trunk commits from ClickHouse

### Files:
- `clickhouse_queries/advisor_verdicts_for_pr/` — CH query for existing verdicts
- `pages/api/.../pull/advisor-runs.ts` — API to fetch verdicts for a PR
- `pages/api/.../pull/dispatch-advisor.ts` — API to dispatch advisor workflow
- `components/job/AiAdvisorIndicator.tsx` — Verdict chip + dispatch button component
- `components/job/FilteredJobList.tsx` — Integration into failed job list

## Test plan
- [x] Verify TypeScript compiles
- [x] Test on a PR page with known failed jobs
- [x] Verify dispatch creates workflow run
- [x] Verify verdict display after workflow completes


tested locally on the PRs with failures: http://localhost:3000/pr/pytorch/pytorch/181449#72961893295

<details>
<summary>screenshot</summary>
<img width="1486" height="1365" alt="image" src="https://github.com/user-attachments/assets/9b1217b7-117d-465b-b196-5c11f3dafceb" />
</details>