### PR TITLE
[checkout] Fix fetch-tags ignored when fetch-depth is 0

### DIFF
--- a/.github/actions/checkout/dist/index.js
+++ b/.github/actions/checkout/dist/index.js
@@ -1523,6 +1523,7 @@ function getSource(settings) {
             else if (settings.sparseCheckout) {
                 fetchOptions.filter = 'blob:none';
             }
+            fetchOptions.fetchTags = settings.fetchTags;
             if (settings.fetchDepth <= 0) {
                 let refSpec = settings.singleBranch
                     ? refHelper.getRefSpec(settings.ref, settings.commit, settings.additionalFetchRefs)
@@ -1537,7 +1538,6 @@ function getSource(settings) {
             }
             else {
                 fetchOptions.fetchDepth = settings.fetchDepth;
-                fetchOptions.fetchTags = settings.fetchTags;
                 const refSpec = refHelper.getRefSpec(settings.ref, settings.commit, settings.additionalFetchRefs);
                 yield git.fetch(refSpec, fetchOptions);
             }

--- a/.github/actions/checkout/src/git-source-provider.ts
+++ b/.github/actions/checkout/src/git-source-provider.ts
@@ -169,6 +169,8 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
       fetchOptions.filter = 'blob:none'
     }
 
+    fetchOptions.fetchTags = settings.fetchTags
+
     if (settings.fetchDepth <= 0) {
       let refSpec: string[] = settings.singleBranch
         ? refHelper.getRefSpec(
@@ -191,7 +193,6 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
       }
     } else {
       fetchOptions.fetchDepth = settings.fetchDepth
-      fetchOptions.fetchTags = settings.fetchTags
       const refSpec = refHelper.getRefSpec(
         settings.ref,
         settings.commit,


### PR DESCRIPTION
## Summary
            
  - The checkout action's `fetch-tags` input was silently ignored when
  `fetch-depth: 0` (full history clone). The `fetchOptions.fetchTags`  
  was only set in the shallow clone code path (`fetchDepth > 0`), never
   in the full clone path (`fetchDepth <= 0`).                         
  - This broke release tag detection in `pytorch/pytorch` CI:     
  `checkout-pytorch` uses `fetch-depth: 0` + `single-branch: true` +
  `fetch-tags: true`, but tags were never actually fetched, causing    
  `git describe --tags --exact` to fail in `binary_populate_env.sh`
  during RC builds.                                                    
                                                                  
  Fixes the issue by setting `fetchOptions.fetchTags =
  settings.fetchTags` in both code paths.             
                                         
  See pytorch/pytorch#175917 (comment) and https://github.com/pytorch/p
  ytorch/actions/runs/24480406410/job/71543349938 for the failing CI.  
                                                                     
  ## Test plan                                                         
                                                                  
  - [ ] Verify that `fetch-tags: true` with `fetch-depth: 0` and
  `single-branch: true` correctly fetches tags                  
  - [ ] Trigger a pytorch/pytorch release candidate build and confirm
  `git describe --tags --exact` succeeds 