### PR TITLE
Add patch_libstdc.sh step to x86_64 Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -92,6 +92,11 @@ RUN --mount=type=bind,source=install_cuda.py,target=/tmp/install_cuda.py \
         uv run /tmp/install_cuda.py; \
     fi
 
+# Patch libstdc++ for CXX11 ABI symbol workaround
+# See: https://github.com/pytorch/pytorch/issues/133437
+RUN --mount=type=bind,source=patch_libstdc.sh,target=/tmp/patch_libstdc.sh \
+    bash /tmp/patch_libstdc.sh
+
 # Install sccache (do this last so /opt/cache/bin gets PATH priority)
 RUN --mount=type=bind,source=install_cache.py,target=/tmp/install_cache.py \
     uv run /tmp/install_cache.py


### PR DESCRIPTION
  ## Summary

  - Add the patch_libstdc.sh CXX11 ABI symbol workaround to docker/Dockerfile (x86_64), aligning it with
  Dockerfile.aarch64 and the upstream pytorch/pytorch
  https://github.com/pytorch/pytorch/blob/main/.ci/docker/manywheel/Dockerfile_2_28#L119
  - This was already applied for aarch64 but missing from x86_64

  ## Context

 -  See https://github.com/pytorch/pytorch/issues/133437 for details on the libstdc++ CXX11 ABI symbol issue
   this patch addresses.
- See recent error: https://github.com/pytorch/pytorch/actions/runs/24487334106/job/71580575973#step:7:171
```
RuntimeError: Found statically linked libstdc++ symbols (recursive_directory_iterator): ['std::filesystem::__cxx11::recursive_directory_iterator::recursion_pending() const', 'std::filesystem::__cxx11::recursive_directory_iterator::depth() const', 'std::filesystem::__cxx11::recursive_directory_iterator::options() const', 'std::filesystem::__cxx11::recursive_directory_iterator::operator*() const', 'std::filesystem::__cxx11::recursive_directory_iterator::disable_recursion_pending()', 'std::filesystem::__cxx11::recursive_directory_iterator::pop(std::error_code&)', 'std::filesystem::__cxx11::recursive_directory_iterator::pop()', 'std::filesystem::__cxx11::recursive_directory_iterator::increment(std::error_code&)', 'std::filesystem::__cxx11::recursive_directory_iterator::operator=(std::filesystem::__cxx11::recursive_directory_iterator&&)', 'std::filesystem::__cxx11::recursive_directory_iterator::operator=(std::filesystem::__cxx11::recursive_directory_iterator const&)', 'std::filesystem::__cxx11::recursive_directory_iterator::recursive_directory_iterator(std::filesystem::__cxx11::path const&, std::filesystem::directory_options, std::error_code*)', 'std::filesystem::__cxx11::recursive_directory_iterator::recursive_directory_iterator(std::filesystem::__cxx11::path const&, std::filesystem::directory_options, std::error_code*)', 'std::filesystem::__cxx11::recursive_directory_iterator::~recursive_directory_iterator()', 'std::filesystem::__cxx11::recursive_directory_iterator::~recursive_directory_iterator()', 'std::filesystem::__cxx11::recursive_directory_iterator::operator++()']
```

  ## Test plan

  - Build the x86_64 Docker image and verify patch_libstdc.sh runs successfully
  - Confirm CXX11 ABI symbols are correctly patched in the resulting image