### PR TITLE
Make torchaudio validation optional. Remove use-cloudflare-cdn and use-version-set options.

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -64,14 +64,14 @@ build_installation_command() {
         installation=${installation/"--index-url"/"--extra-index-url"}
     fi
 
-    # use-cloudflare-cdn: use cloudflare cdn for pypi download
-    if [[ ${USE_CLOUDFLARE_CDN:-} == 'true' ]]; then
-        installation=${installation/"download.pytorch.org"/"download-r2.pytorch.org"}
+    # torch-only option: remove torchvision
+    if [[ ${TORCH_ONLY:-} == 'true' ]]; then
+        installation=${installation/" torchvision"/""}
     fi
 
-    # torch-only option: remove vision and audio
-    if [[ ${TORCH_ONLY:-} == 'true' ]]; then
-        installation=${installation/"torchvision torchaudio"/""}
+    # include-torchaudio option: add torchaudio to installation
+    if [[ ${INCLUDE_TORCHAUDIO:-} == 'true' ]]; then
+        installation=${installation/"torchvision "/"torchvision torchaudio "}
     fi
 
     # if RELEASE version is passed as parameter - install specific version
@@ -79,11 +79,6 @@ build_installation_command() {
         installation=${installation/"torch "/"torch==${RELEASE_VERSION} "}
         installation=${installation/"-y pytorch "/"-y pytorch==${RELEASE_VERSION} "}
         installation=${installation/"::pytorch "/"::pytorch==${RELEASE_VERSION} "}
-
-        if [[ ${USE_VERSION_SET:-} == 'true' ]]; then
-            installation=${installation/"torchvision "/"torchvision==${VISION_RELEASE_VERSION} "}
-            installation=${installation/"torchaudio "/"torchaudio==${AUDIO_RELEASE_VERSION} "}
-        fi
     fi
 
     echo "${installation}"
@@ -93,8 +88,10 @@ build_installation_command() {
 get_test_suffix() {
     if [[ ${TORCH_ONLY:-} == 'true' ]]; then
         echo "--package torchonly"
-    else
+    elif [[ ${INCLUDE_TORCHAUDIO:-} == 'true' ]]; then
         echo ""
+    else
+        echo "--package torch_torchvision"
     fi
 }
 

--- a/.github/scripts/validate_poetry.sh
+++ b/.github/scripts/validate_poetry.sh
@@ -11,6 +11,10 @@ cd test_poetry
 TEST_SUFFIX=""
 if [[ ${TORCH_ONLY} == 'true' ]]; then
     TEST_SUFFIX=" --package torchonly"
+elif [[ ${INCLUDE_TORCHAUDIO:-} == 'true' ]]; then
+    TEST_SUFFIX=""
+else
+    TEST_SUFFIX=" --package torch_torchvision"
 fi
 
 RELEASE_SUFFIX=""
@@ -21,8 +25,10 @@ fi
 
 if [[ ${TORCH_ONLY} == 'true' ]]; then
     poetry --quiet add torch${RELEASE_SUFFIX}
-else
+elif [[ ${INCLUDE_TORCHAUDIO:-} == 'true' ]]; then
     poetry --quiet add torch${RELEASE_SUFFIX} torchaudio torchvision
+else
+    poetry --quiet add torch${RELEASE_SUFFIX} torchvision
 fi
 
 pushd ${PWD}/../.ci/pytorch/

--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -17,26 +17,21 @@ on:
         default: ""
         required: false
         type: string
-      use-version-set:
-        description: 'Applies when version is used, use version for each domain'
-        default: false
-        required: false
-        type: boolean
       release-matrix:
         description: 'Release matrix - optional'
         default: ""
         required: false
         type: string
+      include-torchaudio:
+        description: 'Include torchaudio in validation (by default only torch and torchvision are validated)'
+        default: false
+        required: false
+        type: boolean
       use-only-dl-pytorch-org:
         description: 'Use only download.pytorch.org when generating wheel install command'
         default: "false"
         required: false
         type: string
-      use-cloudflare-cdn:
-        description: 'Use cloudflare cdn for installing pip binaries'
-        default: false
-        required: false
-        type: boolean
       use-extra-index-url:
         description: 'Use extra-index url for pip tests'
         default: false
@@ -73,16 +68,16 @@ on:
         default: ""
         required: false
         type: string
+      include-torchaudio:
+        description: 'Include torchaudio in validation (by default only torch and torchvision are validated)'
+        default: false
+        required: false
+        type: boolean
       use-only-dl-pytorch-org:
         description: 'Use only download.pytorch.org when generating wheel install command'
         default: "false"
         required: false
         type: string
-      use-cloudflare-cdn:
-        description: 'Use cloudflare cdn for installing pip binaries'
-        default: false
-        required: false
-        type: boolean
       use-extra-index-url:
         description: 'Use extra-index url for pip tests'
         default: false
@@ -90,11 +85,6 @@ on:
         type: boolean
       use-wheel-variants:
         description: 'Use wheel-variants for installing pip binaries'
-        default: false
-        required: false
-        type: boolean
-      use-version-set:
-        description: 'Applies when version is used, use version for each domain'
         default: false
         required: false
         type: boolean
@@ -148,14 +138,9 @@ jobs:
         export TORCH_ONLY=${{ inputs.torchonly }}
         export RELEASE_VERSION=${{ inputs.version }}
         export USE_FORCE_REINSTALL="true"
+        export INCLUDE_TORCHAUDIO=${{ inputs.include-torchaudio }}
         export USE_EXTRA_INDEX_URL=${{ inputs.use-extra-index-url }}
-        export USE_CLOUDFLARE_CDN=${{ inputs.use-cloudflare-cdn }}
         export USE_WHEEL_VARIANTS=${{ inputs.use-wheel-variants }}
-        export USE_VERSION_SET=${{ inputs.use-version-set }}
-        if [[ ${USE_VERSION_SET} == 'true' ]]; then
-          export VISION_RELEASE_VERSION=${{ fromJson(inputs.release-matrix).torchvision }}
-          export AUDIO_RELEASE_VERSION=${{ fromJson(inputs.release-matrix).torchaudio }}
-        fi
 
         printf '%s\n' ${{ toJson(inputs.release-matrix) }} > release_matrix.json
         eval "$(conda shell.bash hook)"

--- a/.github/workflows/validate-binaries.yml
+++ b/.github/workflows/validate-binaries.yml
@@ -27,8 +27,8 @@ on:
         default: false
         required: false
         type: boolean
-      use-version-set:
-        description: 'Use version for each domain'
+      include-torchaudio:
+        description: 'Include torchaudio in validation (by default only torch and torchvision are validated)'
         default: false
         required: false
         type: boolean
@@ -37,11 +37,6 @@ on:
         default: "false"
         required: false
         type: string
-      use-cloudflare-cdn:
-        description: 'Use cloudflare cdn for installing pip binaries'
-        default: false
-        required: false
-        type: boolean
       use-extra-index-url:
         description: 'Use extra-index url for pip tests'
         default: false
@@ -90,16 +85,16 @@ on:
         default: false
         required: false
         type: boolean
+      include-torchaudio:
+        description: 'Include torchaudio in validation (by default only torch and torchvision are validated)'
+        default: false
+        required: false
+        type: boolean
       use-only-dl-pytorch-org:
         description: 'Use only download.pytorch.org when generating wheel install command'
         default: "false"
         required: false
         type: string
-      use-cloudflare-cdn:
-        description: 'Use cloudflare cdn for installing pip binaries'
-        default: false
-        required: false
-        type: boolean
       use-extra-index-url:
         description: 'Use extra-index url for pip tests'
         default: false
@@ -126,9 +121,9 @@ jobs:
       torchonly: ${{ inputs.torchonly }}
       version: ${{ inputs.version }}
       release-matrix: ${{ needs.generate-release-matrix.outputs.matrix }}
+      include-torchaudio: ${{ inputs.include-torchaudio }}
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
       use-extra-index-url: ${{ inputs.use-extra-index-url }}
-      use-cloudflare-cdn: ${{ inputs.use-cloudflare-cdn }}
       use-wheel-variants: ${{ inputs.use-wheel-variants }}
 
   linux:
@@ -141,9 +136,9 @@ jobs:
       version: ${{ inputs.version }}
       release-matrix: ${{ needs.generate-release-matrix.outputs.matrix }}
       include-test-ops: ${{ inputs.include-test-ops }}
+      include-torchaudio: ${{ inputs.include-torchaudio }}
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
       use-extra-index-url: ${{ inputs.use-extra-index-url }}
-      use-cloudflare-cdn: ${{ inputs.use-cloudflare-cdn }}
       use-wheel-variants: ${{ inputs.use-wheel-variants }}
 
   linux-aarch64:
@@ -155,9 +150,9 @@ jobs:
       torchonly: ${{ inputs.torchonly }}
       version: ${{ inputs.version }}
       release-matrix: ${{ needs.generate-release-matrix.outputs.matrix }}
+      include-torchaudio: ${{ inputs.include-torchaudio }}
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
       use-extra-index-url: ${{ inputs.use-extra-index-url }}
-      use-cloudflare-cdn: ${{ inputs.use-cloudflare-cdn }}
       use-wheel-variants: ${{ inputs.use-wheel-variants }}
 
   mac-arm64:
@@ -169,7 +164,7 @@ jobs:
       torchonly: ${{ inputs.torchonly }}
       version: ${{ inputs.version }}
       release-matrix: ${{ needs.generate-release-matrix.outputs.matrix }}
+      include-torchaudio: ${{ inputs.include-torchaudio }}
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
       use-extra-index-url: ${{ inputs.use-extra-index-url }}
-      use-cloudflare-cdn: ${{ inputs.use-cloudflare-cdn }}
       use-wheel-variants: ${{ inputs.use-wheel-variants }}

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -17,11 +17,6 @@ on:
         default: ""
         required: false
         type: string
-      use-version-set:
-        description: 'Applies when version is used, use version for each domain'
-        default: false
-        required: false
-        type: boolean
       release-matrix:
         description: 'Release matrix - optional'
         default: ""
@@ -32,16 +27,16 @@ on:
         default: false
         required: false
         type: boolean
+      include-torchaudio:
+        description: 'Include torchaudio in validation (by default only torch and torchvision are validated)'
+        default: false
+        required: false
+        type: boolean
       use-only-dl-pytorch-org:
         description: 'Use only download.pytorch.org when generating wheel install command'
         default: "false"
         required: false
         type: string
-      use-cloudflare-cdn:
-        description: 'Use cloudflare cdn for installing pip binaries'
-        default: false
-        required: false
-        type: boolean
       use-extra-index-url:
         description: 'Use extra-index url for pip tests'
         default: false
@@ -83,16 +78,16 @@ on:
         default: false
         required: false
         type: boolean
+      include-torchaudio:
+        description: 'Include torchaudio in validation (by default only torch and torchvision are validated)'
+        default: false
+        required: false
+        type: boolean
       use-only-dl-pytorch-org:
         description: 'Use only download.pytorch.org when generating wheel install command'
         default: "false"
         required: false
         type: string
-      use-cloudflare-cdn:
-        description: 'Use cloudflare cdn for installing pip binaries'
-        default: false
-        required: false
-        type: boolean
       use-extra-index-url:
         description: 'Use extra-index url for pip tests'
         default: false
@@ -100,11 +95,6 @@ on:
         type: boolean
       use-wheel-variants:
         description: 'Use wheel-variants for installing pip binaries'
-        default: false
-        required: false
-        type: boolean
-      use-version-set:
-        description: 'Applies when version is used, use version for each domain'
         default: false
         required: false
         type: boolean
@@ -140,16 +130,11 @@ jobs:
         export ENV_NAME="conda-env-${{ github.run_id }}"
         export TORCH_ONLY=${{ inputs.torchonly }}
         export INCLUDE_TEST_OPS=${{ inputs.include-test-ops }}
+        export INCLUDE_TORCHAUDIO=${{ inputs.include-torchaudio }}
         export USE_ONLY_DL_PYTORCH_ORG=${{ inputs.use-only-dl-pytorch-org }}
         export USE_EXTRA_INDEX_URL=${{ inputs.use-extra-index-url }}
-        export USE_CLOUDFLARE_CDN=${{ inputs.use-cloudflare-cdn }}
         export USE_WHEEL_VARIANTS=${{ inputs.use-wheel-variants }}
         export RELEASE_VERSION=${{ inputs.version }}
-        export USE_VERSION_SET=${{ inputs.use-version-set }}
-        if [[ ${USE_VERSION_SET} == 'true' ]]; then
-          export VISION_RELEASE_VERSION=${{ fromJson(inputs.release-matrix).torchvision }}
-          export AUDIO_RELEASE_VERSION=${{ fromJson(inputs.release-matrix).torchaudio }}
-        fi
 
         export USE_FORCE_REINSTALL="true"
         export TARGET_OS="linux"

--- a/.github/workflows/validate-macos-arm64-binaries.yml
+++ b/.github/workflows/validate-macos-arm64-binaries.yml
@@ -17,26 +17,21 @@ on:
         default: ""
         required: false
         type: string
-      use-version-set:
-        description: 'Applies when version is used, use version for each domain'
-        default: false
-        required: false
-        type: boolean
       release-matrix:
         description: 'Release matrix - optional'
         default: ""
         required: false
         type: string
+      include-torchaudio:
+        description: 'Include torchaudio in validation (by default only torch and torchvision are validated)'
+        default: false
+        required: false
+        type: boolean
       use-only-dl-pytorch-org:
         description: 'Use only download.pytorch.org when generating wheel install command'
         default: "false"
         required: false
         type: string
-      use-cloudflare-cdn:
-        description: 'Use cloudflare cdn for installing pip binaries'
-        default: false
-        required: false
-        type: boolean
       use-extra-index-url:
         description: 'Use extra-index url for pip tests'
         default: false
@@ -73,16 +68,16 @@ on:
         default: ""
         required: false
         type: string
+      include-torchaudio:
+        description: 'Include torchaudio in validation (by default only torch and torchvision are validated)'
+        default: false
+        required: false
+        type: boolean
       use-only-dl-pytorch-org:
         description: 'Use only download.pytorch.org when generating wheel install command'
         default: "false"
         required: false
         type: string
-      use-cloudflare-cdn:
-        description: 'Use cloudflare cdn for installing pip binaries'
-        default: false
-        required: false
-        type: boolean
       use-extra-index-url:
         description: 'Use extra-index url for pip tests'
         default: false
@@ -90,11 +85,6 @@ on:
         type: boolean
       use-wheel-variants:
         description: 'Use wheel-variants for installing pip binaries'
-        default: false
-        required: false
-        type: boolean
-      use-version-set:
-        description: 'Applies when version is used, use version for each domain'
         default: false
         required: false
         type: boolean
@@ -128,18 +118,12 @@ jobs:
         export TORCH_ONLY=${{ inputs.torchonly }}
         export RELEASE_VERSION=${{ inputs.version }}
         export USE_FORCE_REINSTALL="true"
+        export INCLUDE_TORCHAUDIO=${{ inputs.include-torchaudio }}
         export USE_EXTRA_INDEX_URL=${{ inputs.use-extra-index-url }}
-        export USE_CLOUDFLARE_CDN=${{ inputs.use-cloudflare-cdn }}
         export USE_WHEEL_VARIANTS=${{ inputs.use-wheel-variants }}
-        export USE_VERSION_SET=${{ inputs.use-version-set }}
 
         if [[ ${{ matrix.package_type }} == "conda" ]]; then
           export IS_M1_CONDA_BUILD_JOB=1
-        fi
-
-        if [[ ${USE_VERSION_SET} == 'true' ]]; then
-          export VISION_RELEASE_VERSION=${{ fromJson(inputs.release-matrix).torchvision }}
-          export AUDIO_RELEASE_VERSION=${{ fromJson(inputs.release-matrix).torchaudio }}
         fi
 
         printf '%s\n' ${{ toJson(inputs.release-matrix) }} > release_matrix.json

--- a/.github/workflows/validate-nightly-binaries.yml
+++ b/.github/workflows/validate-nightly-binaries.yml
@@ -33,4 +33,3 @@ jobs:
     with:
       channel: nightly
       os: all
-      use-cloudflare-cdn: true

--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -17,26 +17,21 @@ on:
         default: ""
         required: false
         type: string
-      use-version-set:
-        description: 'Applies when version is used, use version for each domain'
-        default: false
-        required: false
-        type: boolean
       release-matrix:
         description: 'Release matrix - optional'
         default: ""
         required: false
         type: string
+      include-torchaudio:
+        description: 'Include torchaudio in validation (by default only torch and torchvision are validated)'
+        default: false
+        required: false
+        type: boolean
       use-only-dl-pytorch-org:
         description: 'Use only download.pytorch.org when generating wheel install command'
         default: "false"
         required: false
         type: string
-      use-cloudflare-cdn:
-        description: 'Use cloudflare cdn for installing pip binaries'
-        default: false
-        required: false
-        type: boolean
       use-extra-index-url:
         description: 'Use extra-index url for pip tests'
         default: false
@@ -73,16 +68,16 @@ on:
         default: ""
         required: false
         type: string
+      include-torchaudio:
+        description: 'Include torchaudio in validation (by default only torch and torchvision are validated)'
+        default: false
+        required: false
+        type: boolean
       use-only-dl-pytorch-org:
         description: 'Use only download.pytorch.org when generating wheel install command'
         default: "false"
         required: false
         type: string
-      use-cloudflare-cdn:
-        description: 'Use cloudflare cdn for installing pip binaries'
-        default: false
-        required: false
-        type: boolean
       use-extra-index-url:
         description: 'Use extra-index url for pip tests'
         default: false
@@ -90,11 +85,6 @@ on:
         type: boolean
       use-wheel-variants:
         description: 'Use wheel-variants for installing pip binaries'
-        default: false
-        required: false
-        type: boolean
-      use-version-set:
-        description: 'Applies when version is used, use version for each domain'
         default: false
         required: false
         type: boolean
@@ -130,14 +120,9 @@ jobs:
         export TORCH_ONLY=${{ inputs.torchonly }}
         export RELEASE_VERSION=${{ inputs.version }}
         export USE_FORCE_REINSTALL="true"
+        export INCLUDE_TORCHAUDIO=${{ inputs.include-torchaudio }}
         export USE_EXTRA_INDEX_URL=${{ inputs.use-extra-index-url }}
-        export USE_CLOUDFLARE_CDN=${{ inputs.use-cloudflare-cdn }}
         export USE_WHEEL_VARIANTS=${{ inputs.use-wheel-variants }}
-        export USE_VERSION_SET=${{ inputs.use-version-set }}
-        if [[ ${USE_VERSION_SET} == 'true' ]]; then
-          export VISION_RELEASE_VERSION=${{ fromJson(inputs.release-matrix).torchvision }}
-          export AUDIO_RELEASE_VERSION=${{ fromJson(inputs.release-matrix).torchaudio }}
-        fi
 
         printf '%s\n' ${{ toJson(inputs.release-matrix) }} > release_matrix.json
         source /c/Jenkins/Miniconda3/etc/profile.d/conda.sh

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -107,7 +107,7 @@ WIN_CPU_RUNNER = "windows.4xlarge"
 WIN_ARM64_RUNNER = "windows-11-arm64-preview"
 MACOS_M1_RUNNER = "macos-m1-stable"
 
-PACKAGES_TO_INSTALL_WHL = "torch torchvision torchaudio"
+PACKAGES_TO_INSTALL_WHL = "torch torchvision"
 PACKAGES_TO_INSTALL_GETTING_STARTED_WHL = "torch torchvision"
 PACKAGES_TO_INSTALL_WHL_WIN_ARM64 = "torch"
 WHL_INSTALL_BASE = "pip3 install"

--- a/tools/tests/assets/build_matrix_linux_wheel_cuda.json
+++ b/tools/tests/assets/build_matrix_linux_wheel_cuda.json
@@ -9,7 +9,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -23,7 +23,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -37,7 +37,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -51,7 +51,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -65,7 +65,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-rocm7_1",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -79,7 +79,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -93,7 +93,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -107,7 +107,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -121,7 +121,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -135,7 +135,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -149,7 +149,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-rocm7_1",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -163,7 +163,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -177,7 +177,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -191,7 +191,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -205,7 +205,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -219,7 +219,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -233,7 +233,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-rocm7_1",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -247,7 +247,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -261,7 +261,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -275,7 +275,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -289,7 +289,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -303,7 +303,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -317,7 +317,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-rocm7_1",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -331,7 +331,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -345,7 +345,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13t-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -359,7 +359,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13t-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -373,7 +373,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13t-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -387,7 +387,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13t-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -401,7 +401,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13t-rocm7_1",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -415,7 +415,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13t-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -429,7 +429,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -443,7 +443,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -457,7 +457,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -471,7 +471,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -485,7 +485,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-rocm7_1",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -499,7 +499,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -513,7 +513,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -527,7 +527,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -541,7 +541,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -555,7 +555,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -569,7 +569,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-rocm7_1",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -583,7 +583,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"

--- a/tools/tests/assets/build_matrix_linux_wheel_cuda_norocm.json
+++ b/tools/tests/assets/build_matrix_linux_wheel_cuda_norocm.json
@@ -9,7 +9,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -23,7 +23,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -37,7 +37,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -51,7 +51,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -65,7 +65,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -79,7 +79,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -93,7 +93,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -107,7 +107,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -121,7 +121,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -135,7 +135,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -149,7 +149,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -163,7 +163,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -177,7 +177,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -191,7 +191,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -205,7 +205,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -219,7 +219,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -233,7 +233,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13t-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -247,7 +247,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13t-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -261,7 +261,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13t-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -275,7 +275,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13t-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -289,7 +289,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -303,7 +303,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -317,7 +317,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -331,7 +331,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -345,7 +345,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -359,7 +359,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -373,7 +373,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -387,7 +387,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"

--- a/tools/tests/assets/build_matrix_linux_wheel_nocpu.json
+++ b/tools/tests/assets/build_matrix_linux_wheel_nocpu.json
@@ -9,7 +9,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -23,7 +23,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -37,7 +37,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -51,7 +51,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-rocm7_1",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -65,7 +65,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -79,7 +79,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -93,7 +93,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -107,7 +107,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -121,7 +121,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-rocm7_1",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -135,7 +135,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -149,7 +149,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -163,7 +163,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -177,7 +177,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -191,7 +191,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-rocm7_1",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -205,7 +205,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -219,7 +219,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -233,7 +233,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -247,7 +247,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -261,7 +261,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-rocm7_1",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -275,7 +275,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -289,7 +289,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13t-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -303,7 +303,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13t-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -317,7 +317,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13t-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -331,7 +331,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13t-rocm7_1",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -345,7 +345,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13t-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -359,7 +359,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -373,7 +373,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -387,7 +387,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -401,7 +401,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-rocm7_1",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -415,7 +415,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -429,7 +429,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -443,7 +443,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -457,7 +457,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -471,7 +471,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-rocm7_1",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -485,7 +485,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"

--- a/tools/tests/assets/build_matrix_linux_wheel_xpu.json
+++ b/tools/tests/assets/build_matrix_linux_wheel_xpu.json
@@ -9,7 +9,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -23,7 +23,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -37,7 +37,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -51,7 +51,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-xpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -65,7 +65,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -79,7 +79,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -93,7 +93,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -107,7 +107,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-xpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -121,7 +121,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -135,7 +135,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -149,7 +149,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -163,7 +163,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-xpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -177,7 +177,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -191,7 +191,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -205,7 +205,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -219,7 +219,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-xpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -233,7 +233,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13t-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -247,7 +247,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13t-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -261,7 +261,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13t-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -275,7 +275,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13t-xpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -289,7 +289,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -303,7 +303,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -317,7 +317,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -331,7 +331,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-xpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -345,7 +345,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-cuda12_6",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -359,7 +359,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-cuda13_0",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -373,7 +373,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-cuda13_2",
       "validation_runner": "linux.g5.4xlarge.nvidia.gpu",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -387,7 +387,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-xpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"

--- a/tools/tests/assets/build_matrix_macos_wheel.json
+++ b/tools/tests/assets/build_matrix_macos_wheel.json
@@ -9,7 +9,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_10-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"
@@ -23,7 +23,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_11-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"
@@ -37,7 +37,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_12-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"
@@ -51,7 +51,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_13-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"
@@ -65,7 +65,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_13t-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"
@@ -79,7 +79,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_14-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"
@@ -93,7 +93,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_14t-cpu",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"

--- a/tools/tests/assets/build_matrix_windows_wheel_cuda.json
+++ b/tools/tests/assets/build_matrix_windows_wheel_cuda.json
@@ -9,7 +9,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_10-cpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -23,7 +23,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_10-cuda12_6",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -37,7 +37,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_10-cuda13_0",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -51,7 +51,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_10-cuda13_2",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -65,7 +65,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_10-xpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -79,7 +79,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_11-cpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -93,7 +93,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_11-cuda12_6",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -107,7 +107,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_11-cuda13_0",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -121,7 +121,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_11-cuda13_2",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -135,7 +135,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_11-xpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -149,7 +149,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_12-cpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -163,7 +163,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_12-cuda12_6",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -177,7 +177,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_12-cuda13_0",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -191,7 +191,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_12-cuda13_2",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -205,7 +205,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_12-xpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -219,7 +219,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_13-cpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -233,7 +233,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_13-cuda12_6",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -247,7 +247,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_13-cuda13_0",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -261,7 +261,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_13-cuda13_2",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -275,7 +275,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_13-xpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -289,7 +289,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_13t-cpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -303,7 +303,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_13t-cuda12_6",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -317,7 +317,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_13t-cuda13_0",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -331,7 +331,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_13t-cuda13_2",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -345,7 +345,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_13t-xpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -359,7 +359,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_14-cpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -373,7 +373,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_14-cuda12_6",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -387,7 +387,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_14-cuda13_0",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -401,7 +401,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_14-cuda13_2",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -415,7 +415,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_14-xpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -429,7 +429,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_14t-cpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -443,7 +443,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_14t-cuda12_6",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -457,7 +457,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_14t-cuda13_0",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -471,7 +471,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_14t-cuda13_2",
       "validation_runner": "windows.g4dn.xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"
@@ -485,7 +485,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_14t-xpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.11.0"

--- a/tools/tests/assets/build_matrix_windows_wheel_xpu.json
+++ b/tools/tests/assets/build_matrix_windows_wheel_xpu.json
@@ -9,7 +9,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_10-cpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"
@@ -23,7 +23,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_10-xpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"
@@ -37,7 +37,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_11-cpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"
@@ -51,7 +51,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_11-xpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"
@@ -65,7 +65,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_12-cpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"
@@ -79,7 +79,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_12-xpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"
@@ -93,7 +93,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_13-cpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"
@@ -107,7 +107,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_13-xpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"
@@ -121,7 +121,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_13t-cpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"
@@ -135,7 +135,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_13t-xpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"
@@ -149,7 +149,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_14-cpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"
@@ -163,7 +163,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_14-xpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"
@@ -177,7 +177,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_14t-cpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"
@@ -191,7 +191,7 @@
       "package_type": "wheel",
       "build_name": "wheel-py3_14t-xpu",
       "validation_runner": "windows.4xlarge",
-      "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
+      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
       "stable_version": "2.11.0"


### PR DESCRIPTION
## Summary
  - Remove `use-cloudflare-cdn` option from validate-binaries workflows and scripts (no longer needed)
  - Remove `use-version-set` option from validate-binaries workflows and scripts (no longer needed)
  - Change default binary validation to install and test **torch + torchvision** only (using `--package torch_torchvision` smoke test flag)
  - Add new `include-torchaudio` boolean option to validate torchaudio when explicitly needed

  ## Details

  The `use-cloudflare-cdn` and `use-version-set` options are removed from all validation workflow files and the `validate_binaries.sh` script as they are no longer used.

  Torchaudio is removed from default validation since `smoke_test.py` already supports `--package torch_torchvision` for testing only torch and torchvision. The new `include-torchaudio` option (default: false) can be set to include torchaudio when needed — this adds torchaudio to the install command and runs the full smoke test without a package filter.

  ## Test plan
  - [ ] Verify nightly validation workflow runs successfully with default (torch + torchvision only)
  - [ ] Verify `include-torchaudio: true` correctly installs and tests torchaudio
  - [ ] Verify `torchonly: true` still works as expected
  - [ ] Verify manual `workflow_dispatch` shows new `include-torchaudio` option