### PR TITLE
Fix Docker meta not tagging images with latest 

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -79,7 +79,7 @@ jobs:
             latest=false
           tags: |
             type=sha,prefix=${{ matrix.variant_tag }}-,format=short
-            type=raw,value=${{ matrix.variant_tag }}-latest,enable={{is_default_branch}}
+            type=raw,value=${{ matrix.variant_tag }}-latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2


### PR DESCRIPTION
 ## Summary                                                                 
                                                                             
  - The `{{is_default_branch}}` template in `docker/metadata-action` was not resolving correctly when running inside a container directive (`GITHUB_EVENT_PATH does not exist`), causing the `-latest` tag to never be applied.                                                                  
  - This meant images pushed on merge to main or workflow_dispatch only got the SHA tag (e.g., `cpu-x86_64-5c716ab`) but not the `latest` tag (e.g., `cpu-x86_64-latest`).                                                      
  - Remove the `enable={{is_default_branch}}` condition since the caller already gates `push: true` to non-PR events only.              

## Failure
- Here: https://github.com/pytorch/test-infra/actions/runs/24529169932/job/71707513243 the build and push is successful but the ``latest`` tag is not set hence Docker is not being picked up            
                                                                             
  ## Test plan
                                                                             
  - [ ] Trigger workflow_dispatch and verify both `cpu-x86_64-<sha>` and `cpu-x86_64-latest` tags appear in the Docker meta output                  
  - [ ] Verify PR builds still don't push any tags  