### PR TITLE
[CI] Pre-install cmake and handle on Windows AMI

### DIFF
--- a/aws/ami/windows/scripts/Installers/Install-Tools.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-Tools.ps1
@@ -3,6 +3,16 @@ choco install jq awscli archiver 7zip.install curl vswhere -y
 choco install git --params "/GitAndUnixToolsOnPath" -y
 choco install windows-sdk-10-version-2004-all --version=10.0.19041.0 -y
 
+# cmake: ADD_CMAKE_TO_PATH=System is required for MKL detection during PyTorch builds.
+# Without it, CMake's FindMKL module can't locate MKL libraries and the CUDA build fails
+# with unresolved LAPACK/BLAS symbols from MAGMA. See pytorch/pytorch#178963.
+choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System' --apply-install-arguments-to-dependencies --version=3.27.9 -y
+
+# handle (Sysinternals): used by setup-win/teardown-win to diagnose file locks.
+# Pre-installing avoids runtime dependency on Chocolatey CDN, which has had repeated
+# outages causing false CI failures. See pytorch-gha-infra#1044, #1049, #1078.
+choco install handle -y
+
 refreshenv
 
 Get-Command curl
@@ -11,4 +21,6 @@ Get-Command 7z
 Get-Command jq
 Get-Command vswhere
 Get-Command bash.exe
+Get-Command cmake
+Get-Command handle
 Test-Path "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\gflags.exe"


### PR DESCRIPTION
## Summary

- Pre-install `cmake` (3.27.9 with `ADD_CMAKE_TO_PATH=System`) and `handle` (Sysinternals) on the Windows runner AMI during image build
- Removes runtime dependency on Chocolatey CDN, which has had 3 separate outages in 2 weeks causing false CI failures

## Why

**cmake**: The `ADD_CMAKE_TO_PATH=System` flag is required for CMake's `FindMKL` module to locate MKL libraries during the PyTorch build. Without it:
- CUDA builds fail with ~20 unresolved LAPACK/BLAS linker errors from MAGMA (`error LNK2019: unresolved external symbol zgetrf_`, etc.)
- CPU builds produce binaries where `torch.backends.mkl.is_available()` returns `False`

Currently cmake is installed at runtime via `choco upgrade cmake` in `build_pytorch.bat`. When the Chocolatey CDN goes down, this step fails and breaks the entire build.

**handle**: Used by `setup-win`/`teardown-win` workflow steps to diagnose file locks. Currently installed at runtime via `choco install handle` in the `setup-win` action. The `continue-on-error: true` flag prevents job failure, but the diagnostic step becomes useless when the CDN is down.

## Context

Chocolatey CDN outages have caused 3 incidents of false Windows CI failures in 2 weeks:
- https://github.com/meta-pytorch/pytorch-gha-infra/issues/1044
- https://github.com/meta-pytorch/pytorch-gha-infra/issues/1049
- https://github.com/meta-pytorch/pytorch-gha-infra/issues/1078

## Rollout plan

1. **Land this PR** and build the new AMI
2. **Update AMI filter** in `pytorch-gha-infra` (`runners/regions/us-east-1/main.tf`) to point to the new AMI
3. **Remove runtime choco calls** in `pytorch/pytorch` — cleanup PR: pytorch/pytorch#178963 (will be updated to remove the calls entirely once the AMI is live)

## Test plan

- [x] `packer validate` passes (CI on this PR)
- [ ] Build new AMI and verify `cmake --version` and `handle /?` work on a fresh instance
- [ ] Update AMI filter in pytorch-gha-infra and verify Windows trunk builds pass
- [ ] Land cleanup PR in pytorch/pytorch to remove runtime `choco upgrade cmake` and `choco install handle`