### PR TITLE
Revert CUDA 13.2.1 toolkit installer — S3 file is corrupt

### DIFF
--- a/aws/ami/windows/scripts/Installers/Install-CUDA-Tools.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-CUDA-Tools.ps1
@@ -35,7 +35,7 @@ Switch ($cudaVersion) {
   }
   "13.2" {
     $cudnn_subfolder="cudnn-windows-x86_64-9.20.0.48_cuda13-archive"
-    $toolkitInstaller = "cuda_13.2.1_windows.exe"
+    $toolkitInstaller = "cuda_13.2.0_windows.exe"
     $installerArgs = ""
   }
 }


### PR DESCRIPTION
## Summary

Reverts the toolkit installer change from #7971 (`cuda_13.2.1_windows.exe` → `cuda_13.2.0_windows.exe`). The cuDNN 9.20 update from #7972 is preserved.

## Why

The `cuda_13.2.1_windows.exe` file in `s3://ossci-windows/` is corrupt/truncated:

| File | Size | Status |
|------|------|--------|
| `cuda_13.2.0_windows.exe` | 2.31 GB | OK |
| `cuda_13.2.1_windows.exe` | 1.04 GB | **Corrupt** — 7-Zip: `Checksum error`, `Unexpected end of archive` |

This blocks all Windows AMI builds. The [Build Windows AMI](https://github.com/pytorch/test-infra/actions/workflows/build-windows-ami.yml) workflow has been failing since Apr 14 because of this:
- [Run 24422832929](https://github.com/pytorch/test-infra/actions/runs/24422832929)
- [Run 24432694316](https://github.com/pytorch/test-infra/actions/runs/24432694316)

CUDA 12.6, 12.8, 12.9, and 13.0 all install fine — only 13.2 fails.

Prod is unaffected (still on `Windows 2019 GHA CI - 20260325213408` from March 25, which uses 13.2.0), but no new AMI can be built until this is fixed.

## Follow-up

Once a valid `cuda_13.2.1_windows.exe` is re-uploaded to S3, this revert can be re-landed.

cc @tinglvv @atalman

## Test plan

- [x] `packer validate` passes
- [ ] AMI build workflow succeeds after landing this + re-triggering