### PR TITLE
Share EBS snapshot publicly when building Windows AMI

### DIFF
--- a/aws/ami/windows/windows.pkr.hcl
+++ b/aws/ami/windows/windows.pkr.hcl
@@ -16,6 +16,7 @@ locals {
 source "amazon-ebs" "windows_ebs_builder" {
   ami_name                    = "Windows 2019 GHA CI - ${local.timestamp}"
   ami_groups                  = ["all"]
+  snapshot_groups             = ["all"]
   associate_public_ip_address = true
   communicator                = "winrm"
   instance_type               = "g5.4xlarge"


### PR DESCRIPTION
ami_groups = ["all"] makes the AMI registration public but does not share the backing EBS snapshot. External accounts fail to launch the AMI without snapshot access. Adding snapshot_groups = ["all"] fixes this.