### PR TITLE
Re-re-update test-times.json to have a more accurate number for inductor/test_torchinductor_opinfo for ROCm (Attempt 3)

### DIFF
--- a/stats/test-times.json
+++ b/stats/test-times.json
@@ -24353,7 +24353,7 @@
       "inductor/test_torchinductor_codegen_config_overrides": 5.517000198364258,
       "inductor/test_torchinductor_codegen_dynamic_shapes": 1141.802993774414,
       "inductor/test_torchinductor_dynamic_shapes": 3587.809006214142,
-      "inductor/test_torchinductor_opinfo": 9.58400011062622,
+      "inductor/test_torchinductor_opinfo": 4484.0,
       "inductor/test_torchinductor_opinfo_properties": 647.0280151367188,
       "inductor/test_torchinductor_strided_blocks": 98.8320000579115,
       "inductor/test_triton_extension_backend": 23.98900032043457,

--- a/stats/test-times.json
+++ b/stats/test-times.json
@@ -25711,7 +25711,7 @@
       "inductor/test_torchinductor_codegen_config_overrides": 3.4583999633789064,
       "inductor/test_torchinductor_codegen_dynamic_shapes": 2370.349789428711,
       "inductor/test_torchinductor_dynamic_shapes": 2996.6476037323473,
-      "inductor/test_torchinductor_opinfo": 4.774799919128418,
+      "inductor/test_torchinductor_opinfo": 4484.0,
       "inductor/test_torchinductor_opinfo_properties": 8116.990576171875,
       "inductor/test_torchinductor_strided_blocks": 63.84419985851273,
       "inductor/test_triton_extension_backend": 7.428599953651428,


### PR DESCRIPTION
The last manual update didn't stick because it [got overwritten](https://github.com/pytorch/test-infra/commits/603b0867f8c98dcd2e183073923f5a777a716697/stats/test-times.json) by the auto-update job. This time, @huydhn agreed to pause the auto-updates for a few days to allow the CI to catch up, while we try to resolve the [timeouts seen on trunk](https://hud.pytorch.org/hud/pytorch/pytorch/1aa5e3688834d71502abb9ae3b69ef9ac35307b6/1?per_page=50&name_filter=trunk.*rocm&useRegexFilter=true&mergeEphemeralLF=true) via these manual updates.