### PR TITLE
[HUD] Add "Condense OSDC, non-OSDC jobs" checkbox

### DIFF
--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -1,5 +1,6 @@
 import { GroupedJobStatus, JobStatus } from "components/job/GroupJobConclusion";
 import { getOpenUnstableIssues } from "lib/jobUtils";
+import { EC2_TO_ARC_RUNNER_MAPPING } from "./arcRunnerMapping";
 import { IssueData, RowData } from "./types";
 
 type RepoViableStrictBlockingJobsMap = {
@@ -524,10 +525,35 @@ export function getNameWithoutLF(name: string) {
   return name.replace(ephemeralRegex, ", $1");
 }
 
-// Strip the `-osdc` suffix that distinguishes the ARC (OSDC) variant of a
-// job from its EC2 counterpart (e.g. `build-osdc`, `test-osdc (cfg, 1, 3)`,
-// `build-and-test-osdc`). Only matches at a segment boundary to avoid
-// mangling unrelated strings.
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Precomputed regex that matches any EC2 runner label present in the mapping
+// as a whole token (preceded by `,`, `(`, or whitespace; followed by `,`,
+// `)`, whitespace, or end-of-string) so substrings like `linux.2xlarge`
+// inside `linux.2xlarge.amx` do not match.
+const EC2_RUNNER_REGEX = new RegExp(
+  `(?<=[,(\\s])(${Object.keys(EC2_TO_ARC_RUNNER_MAPPING)
+    .map(escapeRegex)
+    .join("|")})(?=[,)\\s]|$)`,
+  "g"
+);
+
+// Condense the ARC (OSDC) variant of a job down to its EC2 counterpart so
+// both variants collapse into one HUD column. Performs three rewrites:
+//   1. Strip the `-osdc` suffix from job IDs (`test-osdc` -> `test`).
+//   2. Strip the `mt-` prefix the ARC launcher prepends to runner labels.
+//   3. Forward-map EC2 runner labels to their ARC equivalents using the
+//      same table that `map_ec2_to_arc.py` uses in the workflow, so
+//      matrix-expanded names like `test (cfg, 1, 3, linux.c7i.2xlarge)`
+//      and `test-osdc (cfg, 1, 3, mt-l-x86iavx512-8-64)` line up.
 export function getNameWithoutOSDC(name: string) {
-  return name.replace(/-osdc(?=[\s()/]|$)/g, "");
+  let result = name.replace(/-osdc(?=[\s()/]|$)/g, "");
+  result = result.replace(/(?<=[,(\s])mt-(?=l-)/g, "");
+  result = result.replace(
+    EC2_RUNNER_REGEX,
+    (match) => EC2_TO_ARC_RUNNER_MAPPING[match] ?? match
+  );
+  return result;
 }

--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -523,3 +523,11 @@ export function getNameWithoutLF(name: string) {
   const ephemeralRegex = /, ephemeral\.(linux|windows)/g;
   return name.replace(ephemeralRegex, ", $1");
 }
+
+// Strip the `-osdc` suffix that distinguishes the ARC (OSDC) variant of a
+// job from its EC2 counterpart (e.g. `build-osdc`, `test-osdc (cfg, 1, 3)`,
+// `build-and-test-osdc`). Only matches at a segment boundary to avoid
+// mangling unrelated strings.
+export function getNameWithoutOSDC(name: string) {
+  return name.replace(/-osdc(?=[\s()/]|$)/g, "");
+}

--- a/torchci/lib/arcRunnerMapping.ts
+++ b/torchci/lib/arcRunnerMapping.ts
@@ -1,0 +1,66 @@
+// Mapping of EC2 (Meta) runner labels to their ARC (OSDC) equivalents.
+//
+// Source of truth: pytorch/pytorch/.github/arc.yaml. Keep in sync manually.
+// Used by `getNameWithoutOSDC` (in `JobClassifierUtil`) to condense HUD
+// columns across the EC2 and OSDC variants of the same job, mirroring the
+// rewrite that `map_ec2_to_arc.py` performs when producing the ARC test
+// matrix.
+//
+// Entries where the value equals the key are passthrough runners
+// (e.g. ROCm/XPU partner hardware) that are not OSDC-managed — they are
+// omitted here because they require no rewrite.
+export const EC2_TO_ARC_RUNNER_MAPPING: Readonly<Record<string, string>> = {
+  // x86 CPU — Intel AVX-512 (c5, c7i families)
+  "linux.large": "l-x86iavx512-2-4",
+  "linux.2xlarge": "l-x86iavx512-8-64",
+  "linux.c7i.2xlarge": "l-x86iavx512-8-64",
+  "linux.4xlarge": "l-x86iavx512-16-128",
+  "linux.c7i.4xlarge": "l-x86iavx512-16-128",
+  "linux.12xlarge": "l-x86iavx512-48-384",
+  "linux.c7i.12xlarge": "l-x86iavx512-48-384",
+  "linux.24xl.spr-metal": "l-bx86iamx-92-167",
+
+  // x86 CPU — Intel AMX (m7i-flex family)
+  "linux.2xlarge.amx": "l-x86iamx-8-64",
+  "linux.8xlarge.amx": "l-x86iamx-32-128",
+
+  // x86 CPU — Intel AVX2 (m4 family)
+  "linux.2xlarge.avx2": "l-x86iavx2-8-32",
+  "linux.10xlarge.avx2": "l-x86iavx2-40-160",
+
+  // x86 CPU — Memory-optimized (r5, r7i families)
+  "linux.r7i.2xlarge": "l-x86iavx512-8-64",
+  "linux.r7i.4xlarge": "l-x86iavx512-16-128",
+  "linux.4xlarge.memory": "l-x86iavx512-16-128",
+  "linux.8xlarge.memory": "l-x86iavx512-32-256",
+  "linux.12xlarge.memory": "l-x86iavx512-48-384",
+  "linux.24xlarge.memory": "l-x86iavx512-94-768",
+
+  // x86 CPU — AMD (m6a, m7a families)
+  "linux.24xlarge.amd": "l-x86aavx512-125-463",
+
+  // x86 GPU — T4 (g4dn family)
+  "linux.g4dn.4xlarge.nvidia.gpu": "l-x86iavx512-29-115-t4",
+  "linux.g4dn.12xlarge.nvidia.gpu": "l-x86iavx512-45-172-t4-4",
+  "linux.g4dn.metal.nvidia.gpu": "l-bx86iavx512-94-344-t4-8",
+
+  // x86 GPU — A10G (g5 family)
+  "linux.g5.4xlarge.nvidia.gpu": "l-x86aavx2-29-113-a10g",
+  "linux.g5.12xlarge.nvidia.gpu": "l-x86aavx2-45-167-a10g-4",
+  "linux.g5.48xlarge.nvidia.gpu": "l-x86aavx2-189-704-a10g-8",
+
+  // x86 GPU — L4 (g6 family)
+  "linux.g6.4xlarge.experimental.nvidia.gpu": "l-x86aavx2-29-113-l4",
+  "linux.g6.12xlarge.nvidia.gpu": "l-x86aavx2-45-172-l4-4",
+
+  // ARM64 — Graviton
+  "linux.arm64.2xlarge": "l-arm64g2-6-32",
+  "linux.arm64.2xlarge.ephemeral": "l-arm64g2-6-32",
+  "linux.arm64.m7g.4xlarge": "l-arm64g3-16-62",
+  "linux.arm64.m8g.4xlarge": "l-arm64g4-16-62",
+  "linux.arm64.r7g.12xlarge.memory": "l-arm64g3-61-463",
+  "linux.arm64.m7g.metal": "l-barm64g4-62-226",
+
+  // x86 GPU — B200 (p6 family)
+  "linux.dgx.b200": "l-x86iamx-22-225-b200",
+};

--- a/torchci/lib/fetchHud.ts
+++ b/torchci/lib/fetchHud.ts
@@ -2,7 +2,11 @@ import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
 import _ from "lodash";
 import { queryClickhouseSaved } from "./clickhouse";
 import { commitDataFromResponse, getOctokit } from "./github";
-import { getNameWithoutLF, isFailure } from "./JobClassifierUtil";
+import {
+  getNameWithoutLF,
+  getNameWithoutOSDC,
+  isFailure,
+} from "./JobClassifierUtil";
 import { isRerunDisabledTestsJob, isUnstableJob } from "./jobUtils";
 import {
   HudDataAPIResponse,
@@ -122,6 +126,9 @@ export default async function fetchHud(
     let key = job.name!;
     if (params.mergeEphemeralLF) {
       key = getNameWithoutLF(key);
+    }
+    if (params.mergeOSDC) {
+      key = getNameWithoutOSDC(key);
     }
 
     const existingJob = jobsBySha[job.sha!][key];

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -131,6 +131,7 @@ export interface HudParams {
   filter_reruns: boolean;
   filter_unstable: boolean;
   mergeEphemeralLF?: boolean;
+  mergeOSDC?: boolean;
   useRegexFilter?: boolean;
 }
 
@@ -291,6 +292,7 @@ export function packHudParams(input: any) {
     filter_reruns: input.filter_reruns ?? (false as boolean),
     filter_unstable: input.filter_unstable ?? (false as boolean),
     mergeEphemeralLF: input.mergeEphemeralLF as boolean,
+    mergeOSDC: input.mergeOSDC as boolean,
     useRegexFilter: input.useRegexFilter === "true",
   };
 }
@@ -338,6 +340,10 @@ function formatHudURL(
 
   if (params.mergeEphemeralLF) {
     base += `&mergeEphemeralLF=true`;
+  }
+
+  if (params.mergeOSDC) {
+    base += `&mergeOSDC=true`;
   }
 
   // Preserve autorevert view params so router.push doesn't strip them.

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -383,6 +383,7 @@ function FiltersAndSettings({}: {}) {
   const params = packHudParams(router.query);
   const { jobFilter, handleSubmit } = useTableFilter(params);
   const [mergeEphemeralLF, setMergeEphemeralLF] = useContext(MergeLFContext);
+  const [mergeOSDC, setMergeOSDC] = useContext(MergeOSDCContext);
   const [autorevertView, setAutorevertView] = useContext(AutorevertViewContext);
   const [settingsPanelOpen, setSettingsPanelOpen] = useState(false);
   const [hideUnstable, setHideUnstable] = usePreference("hideUnstable");
@@ -463,6 +464,13 @@ function FiltersAndSettings({}: {}) {
                   checkBoxName="mergeEphemeralLF"
                   key="mergeEphemeralLF"
                   labelText={"Condense LF, ephemeral jobs"}
+                />,
+                <CheckBoxSelector
+                  value={mergeOSDC}
+                  setValue={setMergeOSDC}
+                  checkBoxName="mergeOSDC"
+                  key="mergeOSDC"
+                  labelText={"Condense OSDC, non-OSDC jobs"}
                 />,
               ],
             }}
@@ -569,6 +577,10 @@ export const MergeLFContext = createContext<[boolean, (val: boolean) => void]>([
   (_) => {},
 ]);
 
+export const MergeOSDCContext = createContext<
+  [boolean, (val: boolean) => void]
+>([false, (_) => {}]);
+
 export const AutorevertViewContext = createContext<
   [boolean, (val: boolean) => void]
 >([false, (_) => {}]);
@@ -576,6 +588,11 @@ export const AutorevertViewContext = createContext<
 export default function Hud() {
   const router = useRouter();
   const [mergeEphemeralLF, setMergeEphemeralLF] = usePreference("mergeLF");
+  const [mergeOSDC, setMergeOSDC] = usePreference(
+    "mergeOSDC",
+    /*override*/ undefined,
+    /*default*/ false
+  );
   const [autorevertView, setAutorevertView] = useState(() =>
     isAutorevertActive(router.query)
   );
@@ -586,6 +603,7 @@ export default function Hud() {
   const params = packHudParams({
     ...router.query,
     mergeEphemeralLF: mergeEphemeralLF,
+    mergeOSDC: mergeOSDC,
   });
 
   // Logic to handle tooltip pinning. The behavior we want is:
@@ -633,39 +651,41 @@ export default function Hud() {
           <MergeLFContext.Provider
             value={[mergeEphemeralLF, setMergeEphemeralLF]}
           >
-            <AutorevertViewContext.Provider
-              value={[autorevertView, setAutorevertView]}
-            >
-              {params.branch !== undefined && (
-                <div onClick={handleClick}>
-                  <div style={{ display: "flex", alignItems: "flex-end" }}>
-                    <HudHeader params={params} />
-                    <CopyPermanentLink
-                      params={params}
-                      style={{ marginLeft: "10px" }}
-                      autorevertView={autorevertView}
-                    />
-                  </div>
-                  <div style={{ position: "relative", clear: "both" }}>
-                    <FiltersAndSettings />
-                    {autorevertView ? (
-                      <AutorevertView />
-                    ) : (
-                      <GroupedHudTable params={params} />
+            <MergeOSDCContext.Provider value={[mergeOSDC, setMergeOSDC]}>
+              <AutorevertViewContext.Provider
+                value={[autorevertView, setAutorevertView]}
+              >
+                {params.branch !== undefined && (
+                  <div onClick={handleClick}>
+                    <div style={{ display: "flex", alignItems: "flex-end" }}>
+                      <HudHeader params={params} />
+                      <CopyPermanentLink
+                        params={params}
+                        style={{ marginLeft: "10px" }}
+                        autorevertView={autorevertView}
+                      />
+                    </div>
+                    <div style={{ position: "relative", clear: "both" }}>
+                      <FiltersAndSettings />
+                      {autorevertView ? (
+                        <AutorevertView />
+                      ) : (
+                        <GroupedHudTable params={params} />
+                      )}
+                    </div>
+                    {!autorevertView && (
+                      <>
+                        <PageSelector params={params} baseUrl="hud" />
+                        <br />
+                        <div>
+                          <em>This page automatically updates.</em>
+                        </div>
+                      </>
                     )}
                   </div>
-                  {!autorevertView && (
-                    <>
-                      <PageSelector params={params} baseUrl="hud" />
-                      <br />
-                      <div>
-                        <em>This page automatically updates.</em>
-                      </div>
-                    </>
-                  )}
-                </div>
-              )}
-            </AutorevertViewContext.Provider>
+                )}
+              </AutorevertViewContext.Provider>
+            </MergeOSDCContext.Provider>
           </MergeLFContext.Provider>
         </MonsterFailuresProvider>
       </PinnedTooltipContext.Provider>

--- a/torchci/test/jobClassifierUtil.test.ts
+++ b/torchci/test/jobClassifierUtil.test.ts
@@ -1,0 +1,49 @@
+import { getNameWithoutOSDC } from "../lib/JobClassifierUtil";
+
+describe("getNameWithoutOSDC", () => {
+  test.each([
+    // job-id suffix strip at segment boundaries
+    ["trunk / build-osdc", "trunk / build"],
+    ["trunk / build-osdc (cfg)", "trunk / build (cfg)"],
+    ["trunk / build", "trunk / build"],
+
+    // don't mangle -osdc inside a longer token
+    ["trunk / build-osdc-extra", "trunk / build-osdc-extra"],
+
+    // matrix-expanded jobs line up across EC2 and OSDC variants
+    [
+      "trunk / test (default, 1, 3, linux.c7i.2xlarge)",
+      "trunk / test (default, 1, 3, l-x86iavx512-8-64)",
+    ],
+    [
+      "trunk / test-osdc (default, 1, 3, mt-l-x86iavx512-8-64)",
+      "trunk / test (default, 1, 3, l-x86iavx512-8-64)",
+    ],
+    // Both of these EC2 labels map to the same ARC label (confirming
+    // the mapping collapses synonymous EC2 variants too)
+    [
+      "trunk / test (default, 1, 3, linux.2xlarge)",
+      "trunk / test (default, 1, 3, l-x86iavx512-8-64)",
+    ],
+
+    // build-and-test with ARM64 runner
+    [
+      "trunk / build-and-test-osdc (config, 1, 1, linux.arm64.m8g.4xlarge)",
+      "trunk / build-and-test (config, 1, 1, l-arm64g4-16-62)",
+    ],
+
+    // LF-prefixed runners are not touched here (user must enable mergeLF too)
+    [
+      "trunk / test (default, 1, 3, lf.linux.c7i.2xlarge)",
+      "trunk / test (default, 1, 3, lf.linux.c7i.2xlarge)",
+    ],
+
+    // longer EC2 labels are not eaten by shorter prefixes
+    [
+      "trunk / test (default, 1, 3, linux.2xlarge.amx)",
+      "trunk / test (default, 1, 3, l-x86iamx-8-64)",
+    ],
+  ])("rewrites %j -> %j", (input, expected) => {
+    expect(getNameWithoutOSDC(input)).toBe(expected);
+  });
+});


### PR DESCRIPTION
Adds a new Filter Options checkbox (default off) on the HUD that collapses the EC2 and ARC/OSDC variants of the same job into a single column, mirroring the existing Condense LF, ephemeral jobs toggle.

Condensing runs server-side in `fetchHud` alongside `getNameWithoutLF`, so columns merge before `jobsBySha` is built and the existing highest-id-wins dedup picks the surviving run per sha. Preference is persisted via `usePreference("mergeOSDC", ...)` (localStorage) and flows through the URL as `&mergeOSDC=true` so permalinks preserve the view.

`getNameWithoutOSDC` rewrites job names in three passes:

1. Strip the `-osdc` job-id suffix, only at segment boundaries (`-osdc` followed by whitespace, `(`, `)`, `/`, or end-of-string), so `build-osdc`, `test-osdc (cfg, 1, 3)`, and `build-and-test-osdc` collapse cleanly without mangling unrelated names like `build-osdc-extra`.
2. Strip the `mt-` prefix the ARC launcher prepends to runner labels (`mt-l-x86iavx512-8-64` → `l-x86iavx512-8-64`).
3. Forward-map EC2 runner labels to their ARC equivalents using a copy of `runner_mapping` from `pytorch/pytorch/.github/arc.yaml` — the same table that `map_ec2_to_arc.py` applies when generating the ARC test matrix. Without this step matrix-expanded names would still diverge: `test (cfg, 1, 3, linux.c7i.2xlarge)` vs `test (cfg, 1, 3, l-x86iavx512-8-64)` after the `mt-` strip. The mapping is a precomputed regex of all keys so all substitutions run in a single pass.

The mapping table is stored in `torchci/lib/arcRunnerMapping.ts`; its header notes that it needs manual sync with `arc.yaml`. Identity-passthrough runners (ROCm/XPU partner hardware) are omitted because they need no rewrite. A jest test (`test/jobClassifierUtil.test.ts`) covers all three behaviors plus guards against eating longer tokens (`linux.2xlarge` vs `linux.2xlarge.amx`, `-osdc` vs `-osdc-extra`) and confirms LF-prefixed runners are left alone when only `mergeOSDC` is on.