### PR TITLE
Bump openssl 0.10.75 -> 0.10.78 to fix CVE-2026-41676

### DIFF
--- a/aws/lambda/log-classifier/Cargo.lock
+++ b/aws/lambda/log-classifier/Cargo.lock
@@ -1879,9 +1879,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1920,9 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Summary

Bumps the transitive `openssl` crate from 0.10.75 to 0.10.78 to resolve [GHSA-pqf5-4pqq-29f5](https://github.com/rust-openssl/rust-openssl/security/advisories/GHSA-pqf5-4pqq-29f5) (CVE-2026-41676).

**Vulnerability:** `Deriver::derive` and `PkeyCtxRef::derive` can overflow short buffers on OpenSSL 1.1.1 — a caller passing a short slice gets a heap/stack overflow from safe code.

## Changes

- `openssl`: 0.10.75 → 0.10.78
- `openssl-sys`: 0.9.111 → 0.9.114

Only `Cargo.lock` is modified — no code changes.