### PR TITLE
Restrict `actionable` label to users with write access

### DIFF
--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -450,6 +450,7 @@ The explanation needs to be clear on why this is needed. Here are some good exam
     // Labels only people with write access to the repo should be able to add
     const labels_requiring_write_access: string[] = [
       "skip-pr-sanity-check",
+      // Only regular contributors are expected to mark issues as actionable
       "actionable",
     ];
     const write_required_labels = labelsToAdd.filter((l: string) =>

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -448,7 +448,10 @@ The explanation needs to be clear on why this is needed. Here are some good exam
     }
 
     // Labels only people with write access to the repo should be able to add
-    const labels_requiring_write_access: string[] = ["skip-pr-sanity-check"];
+    const labels_requiring_write_access: string[] = [
+      "skip-pr-sanity-check",
+      "actionable",
+    ];
     const write_required_labels = labelsToAdd.filter((l: string) =>
       labels_requiring_write_access.some(
         (write_required_label) => write_required_label === l

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -447,12 +447,17 @@ The explanation needs to be clear on why this is needed. Here are some good exam
       );
     }
 
+    if (
+      labelsToAdd.includes("actionable") &&
+      !(await this.hasWritePermissions(ctx.payload?.comment?.user?.login))
+    ) {
+      return await this.addComment(
+        "Only regular contributors are expected to mark issues as actionable."
+      );
+    }
+
     // Labels only people with write access to the repo should be able to add
-    const labels_requiring_write_access: string[] = [
-      "skip-pr-sanity-check",
-      // Only regular contributors are expected to mark issues as actionable
-      "actionable",
-    ];
+    const labels_requiring_write_access: string[] = ["skip-pr-sanity-check"];
     const write_required_labels = labelsToAdd.filter((l: string) =>
       labels_requiring_write_access.some(
         (write_required_label) => write_required_label === l

--- a/torchci/test/labelCommands.test.ts
+++ b/torchci/test/labelCommands.test.ts
@@ -352,4 +352,32 @@ describe("label-bot", () => {
     await probot.receive(event);
     handleScope(scope);
   });
+
+  test("label actionable without write permissions is rejected", async () => {
+    const event = require("./fixtures/issue_comment.json");
+    event.payload.comment.body = "@pytorchbot label 'actionable'";
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    const issue_number = event.payload.issue.number;
+    const user = event.payload.comment.user.login;
+
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${owner}/${repo}/labels`)
+      .reply(200, existingRepoLabelsResponse)
+      .get(`/repos/${owner}/${repo}/collaborators/${user}/permission`)
+      .reply(200, { permission: "read" })
+      .post(
+        `/repos/${owner}/${repo}/issues/${issue_number}/comments`,
+        (body) => {
+          expect(JSON.stringify(body)).toContain(
+            "Only people with write access to the repo can add these labels: actionable"
+          );
+          return true;
+        }
+      )
+      .reply(200, {});
+
+    await probot.receive(event);
+    handleScope(scope);
+  });
 });

--- a/torchci/test/labelCommands.test.ts
+++ b/torchci/test/labelCommands.test.ts
@@ -370,7 +370,7 @@ describe("label-bot", () => {
         `/repos/${owner}/${repo}/issues/${issue_number}/comments`,
         (body) => {
           expect(JSON.stringify(body)).toContain(
-            "Only people with write access to the repo can add these labels: actionable"
+            "Only regular contributors are expected to mark issues as actionable."
           );
           return true;
         }


### PR DESCRIPTION
- Add `actionable` to the `labels_requiring_write_access` list in `pytorchBotHandler.handleLabel`, so `@pytorchbot label 'actionable'` is only applied when the commenter has write access to the repo; otherwise the bot responds with the existing "Only regular contributors are expected to mark issues as actionable" message.
