### PR TITLE
ci: switch claude-code-action pin to upstream anthropics/claude-code-action@v1.0.104

### DIFF
--- a/.github/workflows/_claude-code.yml
+++ b/.github/workflows/_claude-code.yml
@@ -179,7 +179,7 @@ jobs:
             console.log(`Set commit author to: ${name} <${email}>`);
 
       - name: Run Claude Code
-        uses: izaitsevfb/claude-code-action@forked-pr-fix
+        uses: anthropics/claude-code-action@v1.0.104
         with:
           allowed_bots: "*"
           use_bedrock: "true"

--- a/.github/workflows/_claude-code.yml
+++ b/.github/workflows/_claude-code.yml
@@ -179,7 +179,7 @@ jobs:
             console.log(`Set commit author to: ${name} <${email}>`);
 
       - name: Run Claude Code
-        uses: anthropics/claude-code-action@v1.0.104
+        uses: anthropics/claude-code-action@b4d67413279fc18c6e5de930ae307c4f108714eb # v1.0.104
         with:
           allowed_bots: "*"
           use_bedrock: "true"


### PR DESCRIPTION
## Summary

Switches the reusable Claude workflow's action pin from the personal fork `izaitsevfb/claude-code-action@forked-pr-fix` to upstream `anthropics/claude-code-action@b4d67413279fc18c6e5de930ae307c4f108714eb` (v1.0.104), pinned by commit SHA for supply-chain security. The fork was created to fix a fork-PR checkout bug that upstream now handles natively as of v1.0.104.

## Verification

### Static analysis

`izaitsevfb/claude-code-action@forked-pr-fix` has exactly **2** commits past its merge-base with upstream:

| commit | kind | status |
|---|---|---|
| `ececd56` (GITHUB_EVENT_NAME override for workflow_run rehydration) | feature — part of the separate `pull_request_review_comment` secure-trigger effort | out of scope for this pin |
| `69b53a1` (unique branch name generation for forked PRs) | bug fix — fork PRs failed because `git fetch origin <branch>` didn't find the fork's branch in the base repo | **fixed upstream** in [`c3bf66d`](https://github.com/anthropics/claude-code-action/commit/c3bf66d) ("handle fork PRs by fetching via refs/pull/N/head", PR anthropics/claude-code-action#962), landed in v1.0.104. Same `isCrossRepository` check, same `refs/pull/N/head` fetch refspec. |

Conclusion: upstream v1.0.104 is at parity with `forked-pr-fix` for the only bug it fixes.

### Live end-to-end test (pytorch/ciforge)

- **Setup**: Added a dedicated `.github/workflows/claude-parity-test.yml` workflow pinning `anthropics/claude-code-action@v1.0.104` to ciforge main via [pytorch/ciforge#475](https://github.com/pytorch/ciforge/pull/475).
- **Fork PR**: Opened [pytorch/ciforge#476](https://github.com/pytorch/ciforge/pull/476) from `izaitsevfb/ciforge:iz2/fork-parity-test` → `pytorch/ciforge:main` — exactly the fork-PR scenario that the `forked-pr-fix` bug fix covers.
- **Workflow run**: [run 24914345416](https://github.com/pytorch/ciforge/actions/runs/24914345416) — upstream v1.0.104 correctly detected the cross-repo PR and handled it safely:
  - Restored `.claude`, `.mcp.json`, `.claude.json`, `.gitmodules`, `.ripgreprc`, `CLAUDE.md`, `CLAUDE.local.md`, `.husky` from `origin/main` (PR head treated as untrusted).
  - Preserved PR's sensitive paths to `.claude-pr/` for review agents (not executed in-tree).
  - Claude agent ran 12 turns in 42s, $0.25 cost, status=success.

This is exactly the behavior the fork was built to provide, now native in upstream.

## Risk

Low. The two branches produce equivalent behavior for fork-PR checkout; the fork's one feature delta (`ececd56`) is tied to the `pull_request_review_comment` trigger, which `_claude-code.yml` doesn't use (it was deliberately excluded for security — see the existing comment in the workflow citing github/community#55940).

## Rollback

Revert this commit — no schema / config surface change.