### PR TITLE
Add OSDC step script failure rule to log classifier

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -314,6 +314,10 @@ name = 'ghstack merge check error'
 pattern = '^Mergeability Error: .*'
 
 [[rule]]
+name = 'OSDC step script failure'
+pattern = '\[OSDC\] Step script exited.*'
+
+[[rule]]
 name = 'GHA error'
 pattern = '^##\[error\](.*)'
 


### PR DESCRIPTION
Captures `[OSDC] Step script exited` failures with priority above the generic `##[error]` catch-all so OSDC failures are surfaced instead of collapsing into a generic exit-code message.

The error comes from https://github.com/pytorch/ci-infra/blob/da74bf5c87c27a8afcaa86b47c43ea1fadfc1024/osdc/modules/arc-runners/templates/runner.yaml.tpl#L493