### PR TITLE
Add vLLM Buildkite CI failure report tool

### DIFF
--- a/tools/vllm/README.md
+++ b/tools/vllm/README.md
@@ -1,0 +1,54 @@
+# vLLM Buildkite CI Failure Reporter
+
+Fetches the latest Buildkite CI build for a given branch, extracts all failed steps with failure reasons, and provides direct links to the relevant log lines.
+
+## Usage
+
+```bash
+python3 fetch_failures.py --branch <BRANCH> --token <BUILDKITE_TOKEN>
+```
+
+### Arguments
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--branch` | Yes | Buildkite branch name, e.g. `atalman:release_212_tests` |
+| `--token` | Yes | Buildkite API token (create at https://buildkite.com/user/api-access-tokens, scope: `read_builds`) |
+| `--save-local-logs` | No | Save raw logs for each failed job to local files |
+| `--output-dir` | No | Directory for saved logs (default: current directory) |
+
+### Examples
+
+```bash
+# Print failure report
+python3 fetch_failures.py --branch "atalman:release_212_tests" --token "bkua_xxx"
+
+# Print report + save raw logs locally
+python3 fetch_failures.py --branch "atalman:release_212_tests" --token "bkua_xxx" --save-local-logs
+
+# Save logs to a specific directory
+python3 fetch_failures.py --branch "atalman:release_212_tests" --token "bkua_xxx" --save-local-logs --output-dir /tmp/logs
+```
+
+### Sample Output
+
+```
+======================================================================
+Build #63095 | Branch: atalman:release_212_tests | State: failed
+Message: [CI] Fix Dockerfile.cpu to resolve torch 2.12.0 from CPU test channel
+Created: 2026-04-27T13:15:10.279Z
+Failed steps: 13
+======================================================================
+
+  1. [Fusion E2E TP2 Quick (H100)]
+    Log: https://buildkite.com/vllm/ci/builds/63095#019dcf15-7f55-...
+    Local: /tmp/logs/build_63095/Fusion_E2E_TP2_Quick_H100.log
+    - tests/compile/fusions_e2e/test_tp2_ar_rms.py::test_tp2_ar_rms_fp8_fusions[...] | RuntimeError: ...
+      https://buildkite.com/vllm/ci/builds/63095#019dcf15-7f55-.../L1144
+```
+
+## How It Works
+
+1. **Get latest build** -- queries Buildkite REST API for the most recent build on the given branch
+2. **Get failed steps** -- fetches all steps with `hard_failed` outcome and their job IDs
+3. **Extract failure reasons** -- fetches each failed job's log, parses `FAILED` lines from pytest output, and records the line number for deep linking

--- a/tools/vllm/fetch_failures.py
+++ b/tools/vllm/fetch_failures.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Fetch vLLM Buildkite CI failure reports for a given branch."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import time
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+ORG = "vllm"
+PIPELINE = "ci"
+API_BASE = f"https://api.buildkite.com/v2/organizations/{ORG}/pipelines/{PIPELINE}"
+PUBLIC_BASE = f"https://buildkite.com/{ORG}/{PIPELINE}"
+
+Failure = tuple[str, str]
+
+
+@dataclass
+class FailedStep:
+    label: str
+    job_id: str
+    log_url: str = ""
+    raw_log: str = ""
+    local_log_path: str = ""
+    failures: list[Failure] = field(default_factory=list)
+
+
+@dataclass
+class BuildInfo:
+    number: int
+    state: str
+    message: str
+    branch: str
+    created_at: str
+    failed_steps: list[FailedStep] = field(default_factory=list)
+
+
+def _request(url: str, token: Optional[str] = None, max_retries: int = 3) -> Any:
+    cmd = ["curl", "-s"]
+    if token:
+        cmd += ["-H", f"Authorization: Bearer {token}"]
+    cmd.append(url)
+    for _ in range(max_retries):
+        r = subprocess.run(cmd, capture_output=True, text=True)
+        try:
+            data = json.loads(r.stdout)
+        except json.JSONDecodeError:
+            return None
+        if isinstance(data, dict) and "rate limit" in data.get("message", ""):
+            time.sleep(6)
+            continue
+        return data
+    return None
+
+
+def get_latest_build(branch: str, token: str) -> Optional[BuildInfo]:
+    """Step 1: Get the latest build for a branch."""
+    branch_enc = branch.replace(":", "%3A")
+    url = f"{API_BASE}/builds?branch={branch_enc}&per_page=1"
+    data = _request(url, token=token)
+    if not data or not isinstance(data, list) or len(data) == 0:
+        return None
+    b = data[0]
+    return BuildInfo(
+        number=b["number"],
+        state=b["state"],
+        message=b["message"].split("\n")[0],
+        branch=b["branch"],
+        created_at=b["created_at"],
+    )
+
+
+def get_failed_steps(build_number: int) -> list[FailedStep]:
+    """Step 2: Get all failed command steps and their job IDs."""
+    url = f"{PUBLIC_BASE}/builds/{build_number}/data/steps?state=failed"
+    data = _request(url)
+    if not data or not isinstance(data, list):
+        return []
+    steps = []
+    for step in data:
+        if step.get("type") == "command" and step.get("outcome") == "hard_failed":
+            job_id = step.get("statistics", {}).get("latest_job_id", "")
+            log_url = f"{PUBLIC_BASE}/builds/{build_number}#{job_id}"
+            steps.append(
+                FailedStep(label=step["label"], job_id=job_id, log_url=log_url)
+            )
+    return steps
+
+
+def get_failure_reasons(
+    build_number: int, job_id: str, token: str
+) -> tuple[list[Failure], str]:
+    """Step 3: Fetch a job's log and extract failure reasons.
+
+    Returns (failures, raw_log).
+    """
+    url = f"{API_BASE}/builds/{build_number}/jobs/{job_id}/log"
+    time.sleep(1.5)
+    data = _request(url, token=token)
+    if not data or not isinstance(data, dict):
+        return [("Could not fetch log", "")], ""
+    content = data.get("content", "")
+    lines = content.split("\n")
+
+    log_url = f"{PUBLIC_BASE}/builds/{build_number}#{job_id}"
+    failures: list[Failure] = []
+    for line_num, line in enumerate(lines, 1):
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", line)
+        clean = re.sub(r"_bk;t=\d+\s*", "", clean)
+        clean = re.sub(r"\[\d{4}-\d{2}-\d{2}T[\d:Z]+\]\s*", "", clean)
+        if "FAILED" in clean and "::" in clean:
+            parts = clean.split(" - ", 1)
+            test = parts[0].replace("FAILED ", "").strip()
+            err = parts[1].strip() if len(parts) > 1 else ""
+            link = f"{log_url}/L{line_num}"
+            entry = f"{test} | {err}" if err else test
+            failures.append((entry, link))
+        elif "ERROR: No matching distribution" in clean:
+            link = f"{log_url}/L{line_num}"
+            failures.append((clean.strip()[:200], link))
+    return failures, content
+
+
+def fetch_failure_report(branch: str, token: str) -> Optional[BuildInfo]:
+    """Run the full pipeline: latest build -> failed steps -> failure reasons."""
+    build = get_latest_build(branch, token)
+    if not build:
+        print(f"No builds found for branch '{branch}'")
+        return None
+
+    build.failed_steps = get_failed_steps(build.number)
+
+    for step in build.failed_steps:
+        step.failures, step.raw_log = get_failure_reasons(
+            build.number, step.job_id, token
+        )
+
+    return build
+
+
+def save_logs(build: BuildInfo, output_dir: str) -> None:
+    """Save raw logs for each failed step to local files."""
+    log_dir = os.path.join(output_dir, f"build_{build.number}")
+    os.makedirs(log_dir, exist_ok=True)
+    for step in build.failed_steps:
+        if not step.raw_log:
+            continue
+        safe_label = re.sub(r"[^\w\- ]", "", step.label).strip().replace(" ", "_")
+        path = os.path.abspath(os.path.join(log_dir, f"{safe_label}.log"))
+        with open(path, "w") as f:
+            f.write(step.raw_log)
+        step.local_log_path = path
+    print(f"Logs saved to {log_dir}/")
+
+
+def print_report(build: BuildInfo) -> None:
+    """Print a formatted failure report."""
+    print("=" * 70)
+    print(f"Build #{build.number} | Branch: {build.branch} | State: {build.state}")
+    print(f"Message: {build.message}")
+    print(f"Created: {build.created_at}")
+    print(f"Failed steps: {len(build.failed_steps)}")
+    print("=" * 70)
+
+    for i, step in enumerate(build.failed_steps, 1):
+        print(f"\n  {i}. [{step.label}]")
+        print(f"    Log: {step.log_url}")
+        if step.local_log_path:
+            print(f"    Local: {step.local_log_path}")
+        if step.failures:
+            for entry, link in step.failures:
+                print(f"    - {entry}")
+                print(f"      {link}")
+        else:
+            print("    (no specific test failures extracted)")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Fetch vLLM Buildkite CI failures")
+    parser.add_argument(
+        "--branch",
+        required=True,
+        help="Branch name, e.g. atalman:release_212_tests",
+    )
+    parser.add_argument("--token", required=True, help="Buildkite API token")
+    parser.add_argument(
+        "--save-local-logs",
+        action="store_true",
+        help="Save raw logs to local files",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=".",
+        help="Directory for saved logs (default: current dir)",
+    )
+    args = parser.parse_args()
+
+    build = fetch_failure_report(args.branch, args.token)
+    if build:
+        if args.save_local_logs:
+            save_logs(build, args.output_dir)
+        print_report(build)


### PR DESCRIPTION
Script to fetch the latest vllm Buildkite CI build for a given branch, extract all failed steps with their failure reasons, and provide direct links to the relevant log lines.

you need to pass the buidkite token for this, see readme, simply log in as buildkite user, and generate a access token: 
https://buildkite.com/user/api-access-tokens


this can potentially used to auto-detect failures after a release run. Ideal route:
1. the release branch in vllm is updated (release engineer pushed)
2. release engineer triggers the buildkite
3. a cron job periodically check if buildkite tests are completed and use this tool to detect failed error and logs
5. generate issues or call claude to evaluate
6. pin release engineer/related pytorch engineer


example local result
```
python3 tools/vllm/fetch_failures.py --branch "atalman:release_212_tests" --save-local-logs
Logs saved to ./build_63095/
======================================================================
Build #63095 | Branch: atalman:release_212_tests | State: failed
Message: [CI] Fix Dockerfile.cpu to resolve torch 2.12.0 from CPU test channel
Created: 2026-04-27T13:15:10.279Z
Failed steps: 13
======================================================================

  1. [Fusion E2E TP2 Quick (H100)]
    Log: https://buildkite.com/vllm/ci/builds/63095#019dcf15-7f55-4614-89ff-7663a81087fe
    Local: /Users/elainewy/Documents/vllm_buildkite/build_63095/Fusion_E2E_TP2_Quick_H100.log
    - tests/compile/fusions_e2e/test_tp2_ar_rms.py::test_tp2_ar_rms_fp8_fusions[inductor_partition--quant_fp8,-rms_norm-4-TRITON_ATTN-nvidia/Llama-4-Scout-17B-16E-Instruct-FP8-<lambda>-model_kwargs1-<lambda>] | RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-7f55-4614-89ff-7663a81087fe/L1144

  7. [Entrypoints Integration (API Server openai - Part 3)]
    Log: https://buildkite.com/vllm/ci/builds/63095#019dcf15-7f94-413f-8833-7f61c5b5b519
    Local: /Users/elainewy/Documents/vllm_buildkite/build_63095/Entrypoints_Integration_API_Server_openai_-_Part_3.log
    - entrypoints/openai/realtime/test_realtime_validation.py::test_multi_chunk_streaming[mistralai/Voxtral-Mini-4B-Realtime-2602] | AssertionError: assert ' First words...s sure to go.' == ' First words...s sure to go.'
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-7f94-413f-8833-7f61c5b5b519/L25272

  8. [LoRA %N]
    Log: https://buildkite.com/vllm/ci/builds/63095#019dcf15-801f-4374-90e2-c70b02636115
    Local: /Users/elainewy/Documents/vllm_buildkite/build_63095/LoRA_N.log
    (no specific test failures extracted)

  9. [Batch Invariance (B200)]
    Log: https://buildkite.com/vllm/ci/builds/63095#019dcf15-802a-456a-aae7-93c4931e983e
    Local: /Users/elainewy/Documents/vllm_buildkite/build_63095/Batch_Invariance_B200.log
    - v1/determinism/test_batch_invariance.py::test_v1_generation_is_deterministic_across_batch_sizes_with_needle[FLASH_ATTN] | Failed: Nondeterministic outputs detected: 3 failed out of 5 trials (max_batch_size=128).
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-802a-456a-aae7-93c4931e983e/L2867

  10. [Python-only Installation]
    Log: https://buildkite.com/vllm/ci/builds/63095#019dcf15-802c-4d8e-9671-0af9c46d347b
    Local: /Users/elainewy/Documents/vllm_buildkite/build_63095/Python-only_Installation.log
    - ERROR: No matching distribution found for torch==2.12.0
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-802c-4d8e-9671-0af9c46d347b/L5696

  11. [V1 Core + KV + Metrics]
    Log: https://buildkite.com/vllm/ci/builds/63095#019dcf15-802d-40fe-b406-c932ae335b0c
    Local: /Users/elainewy/Documents/vllm_buildkite/build_63095/V1_Core__KV__Metrics.log
    - entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine | AssertionError: Expected: 0.54 |  Measured: 0.4806671721000758
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-802d-40fe-b406-c932ae335b0c/L6168

  12. [Model Runner V2 Spec Decode]
    Log: https://buildkite.com/vllm/ci/builds/63095#019dcf15-803b-4f80-9b8d-a71b7f81774f
    Local: /Users/elainewy/Documents/vllm_buildkite/build_63095/Model_Runner_V2_Spec_Decode.log
    - v1/spec_decode/test_max_len.py::test_eagle_max_len[FLASH_ATTN-10] | RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-803b-4f80-9b8d-a71b7f81774f/L2413
    - v1/spec_decode/test_max_len.py::test_eagle_max_len[TRITON_ATTN-10] | RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-803b-4f80-9b8d-a71b7f81774f/L2414
    - v1/spec_decode/test_max_len.py::test_eagle_max_len[TREE_ATTN-10] | RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-803b-4f80-9b8d-a71b7f81774f/L2415

  13. [Distributed Model Tests (2 GPUs)]
    Log: https://buildkite.com/vllm/ci/builds/63095#019dcf15-805f-4ccb-a1d4-565db48920b8
    Local: /Users/elainewy/Documents/vllm_buildkite/build_63095/Distributed_Model_Tests_2_GPUs.log
    - models/multimodal/generation/test_common.py::test_single_image_models_heavy[chameleon-broadcast-test_case0] | ValueError: Pointer argument cannot be accessed from Triton (cpu tensor?)
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-805f-4ccb-a1d4-565db48920b8/L3309
    - models/multimodal/generation/test_common.py::test_single_image_models_heavy[chameleon-broadcast-test_case1] | ValueError: Pointer argument cannot be accessed from Triton (cpu tensor?)
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-805f-4ccb-a1d4-565db48920b8/L3310
    - models/multimodal/generation/test_common.py::test_single_image_models_heavy[llava-broadcast-test_case2] | ValueError: Pointer argument cannot be accessed from Triton (cpu tensor?)
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-805f-4ccb-a1d4-565db48920b8/L3311
    - models/multimodal/generation/test_common.py::test_single_image_models_heavy[llava-broadcast-test_case3] | ValueError: Pointer argument cannot be accessed from Triton (cpu tensor?)
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-805f-4ccb-a1d4-565db48920b8/L3312
    - models/multimodal/generation/test_common.py::test_single_image_models_heavy[llava_next-broadcast-test_case4] | ValueError: Pointer argument cannot be accessed from Triton (cpu tensor?)
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-805f-4ccb-a1d4-565db48920b8/L3313
    - models/multimodal/generation/test_common.py::test_single_image_models_heavy[llava_next-broadcast-test_case5] | ValueError: Pointer argument cannot be accessed from Triton (cpu tensor?)
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-805f-4ccb-a1d4-565db48920b8/L3314

  14. [Language Models Tests (Standard)]
    Log: https://buildkite.com/vllm/ci/builds/63095#019dcf15-8073-40d5-81c1-dc5a93f94427
    Local: /Users/elainewy/Documents/vllm_buildkite/build_63095/Language_Models_Tests_Standard.log
    - models/language/pooling/test_reward.py::test_prm_models_with_golden_outputs[half-Qwen/Qwen2.5-Math-PRM-7B] | assert False
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-8073-40d5-81c1-dc5a93f94427/L743

  15. [Plugin Tests (2 GPUs)]
    Log: https://buildkite.com/vllm/ci/builds/63095#019dcf15-8095-4c67-a489-0e84f2c0199b
    Local: /Users/elainewy/Documents/vllm_buildkite/build_63095/Plugin_Tests_2_GPUs.log
    - models/test_oot_registration.py::test_oot_registration_embedding | RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-8095-4c67-a489-0e84f2c0199b/L1812

  16. [PyTorch Compilation Unit Tests]
    Log: https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32
    Local: /Users/elainewy/Documents/vllm_buildkite/build_63095/PyTorch_Compilation_Unit_Tests.log
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-True-0-backed-gpt2] | AssertionError: assert 'no' == 'yes'
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5443
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-True-0-backed-Qwen/Qwen2-7B-Instruct] | RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5447
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-True-0-backed_size_oblivious-gpt2] | AssertionError: assert 'no' == 'yes'
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5448
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-True-0-backed_size_oblivious-Qwen/Qwen2-7B-Instruct] | RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5452
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-True-1-backed-gpt2] | AssertionError: assert 'no' == 'yes'
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5453
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-True-1-backed-Qwen/Qwen2-7B-Instruct] | RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5457
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-True-1-backed-Qwen/Qwen3-4B-Instruct-2507] | AssertionError: assert 'no' == 'yes'
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5458
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-True-1-backed_size_oblivious-gpt2] | AssertionError: assert 'no' == 'yes'
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5462
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-True-1-backed_size_oblivious-Qwen/Qwen2-7B-Instruct] | RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5466
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-False-0-backed-gpt2] | AssertionError: assert 'no' == 'yes'
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5467
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-False-0-backed-Qwen/Qwen2-7B-Instruct] | RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5471
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-False-0-unbacked-gpt2] | AssertionError: assert 'no' == 'yes'
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5472
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-False-0-unbacked-Qwen/Qwen2-7B-Instruct] | RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5476
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-False-0-unbacked-Qwen/Qwen3-4B-Instruct-2507] | AssertionError: assert 'no' == 'yes'
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5477
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-False-0-backed_size_oblivious-gpt2] | RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5481
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-False-1-backed-gpt2] | AssertionError: assert 'no' == 'yes'
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5482
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-False-1-backed-Qwen/Qwen2-7B-Instruct] | RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5486
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-False-1-backed-Qwen/Qwen3-4B-Instruct-2507] | AssertionError: assert 'no' == 'yes'
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5487
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-False-1-unbacked-gpt2] | RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5491
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-False-1-backed_size_oblivious-gpt2] | AssertionError: assert 'no' == 'yes'
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5492
    - compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[False-False-1-backed_size_oblivious-Qwen/Qwen2-7B-Instruct] | RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a5-4d18-8569-dfa79929df32/L5496

  17. [PyTorch Compilation Unit Tests (H100)]
    Log: https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a6-4397-a7e0-84bad5534d30
    Local: /Users/elainewy/Documents/vllm_buildkite/build_63095/PyTorch_Compilation_Unit_Tests_H100.log
    - compile/h100/test_startup.py::test_moe_startup[0] | KeyError: None
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80a6-4397-a7e0-84bad5534d30/L762

  18. [Quantization]
    Log: https://buildkite.com/vllm/ci/builds/63095#019dcf15-80ae-4e8a-a68a-b2f75c554b00
    Local: /Users/elainewy/Documents/vllm_buildkite/build_63095/Quantization.log
    - quantization/test_cpu_offload.py::test_cpu_offload_compressed_tensors | AssertionError: Results for model='nm-testing/Qwen1.5-MoE-A2.7B-Chat-quantized.w4a16' are not the same.
      https://buildkite.com/vllm/ci/builds/63095#019dcf15-80ae-4e8a-a68a-b2f75c554b00/L4310
```