### PR TITLE
chore(security): harden Dependabot config with cooldowns and missing ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,28 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+
+  - package-ecosystem: 'pip'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+
+  - package-ecosystem: 'terraform'
+    directory: '/terraform-aws-github-runner'
+    schedule:
+      interval: 'daily'
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3


### PR DESCRIPTION
## Summary

This PR hardens `.github/dependabot.yml` against supply-chain risk in three ways:

### 1. Add `cooldown` to the existing `github-actions` entry
Without a cooldown, a freshly-published (potentially compromised) Action version can land in this repo the same day it is released — before the security community has had time to detect a compromise. The 7-day default gives a window for malicious releases to be caught and pulled.

### 2. Add `pip` ecosystem (daily + cooldown)
The repo contains **26+ `requirements*.txt` files** across `tools/`, `aws/lambda/`, `s3_management/`, and elsewhere with **no automated CVE update PRs** today. This entry scans from the repo root so Dependabot will discover all pip dependency files.

### 3. Add `terraform` ecosystem scoped to `/terraform-aws-github-runner`
The OpenTofu provider constraints (`~> 5.5`, `~> 3.4.2`, etc.) are currently unmonitored. A separate PR tightens these to exact pins; this entry ensures future upgrades still get automated PRs.

> ⚠️ **Known limitation:** Dependabot cooldown for terraform providers has a [known bug (dependabot/dependabot-core#13715)](https://github.com/dependabot/dependabot-core/issues/13715). Exact provider pinning (tracked in a companion PR) is the primary supply-chain control for Terraform; this entry provides the update automation.

---

## Cooldown values used (all ecosystems)
| Semver bump | Days held |
|---|---|
| major | 30 |
| minor | 7 |
| patch | 3 |
| default | 7 |

---

This change is part of a broader supply-chain hardening effort following a repository audit. See https://github.com/jordanconway/package-manager-hardening for the full methodology.