### PR TITLE
chore(security): add harden-runner to critical release and AI agent workflows

### DIFF
--- a/.github/workflows/_claude-code.yml
+++ b/.github/workflows/_claude-code.yml
@@ -76,6 +76,18 @@ jobs:
       issues: write
       id-token: write
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@6c439dc8bdf86240f7f3b9d8e5c8d3e9cf7af60c # v2.12.1
+        with:
+          egress-policy: audit
+          disable-sudo: true
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            sts.amazonaws.com:443
+            bedrock.us-east-1.amazonaws.com:443
+            bedrock-runtime.us-east-1.amazonaws.com:443
       - name: Verify write access
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -46,6 +46,18 @@ jobs:
       fail-fast: false
     name: ${{ matrix.cuda }}-cudnn${{ matrix.cudnn_version }}-${{ matrix.image_type }}
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@6c439dc8bdf86240f7f3b9d8e5c8d3e9cf7af60c # v2.12.1
+        with:
+          egress-policy: audit
+          disable-sudo: true
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            ghcr.io:443
+            registry.hub.docker.com:443
+            auth.docker.io:443
+            index.docker.io:443
       - name: Skip non-CUDA images
         if: matrix.cuda == 'cpu'
         run: |

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -33,6 +33,20 @@ jobs:
     timeout-minutes: 60
     environment: pytorchbot-env
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@6c439dc8bdf86240f7f3b9d8e5c8d3e9cf7af60c # v2.12.1
+        with:
+          egress-policy: audit
+          disable-sudo: true
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            awscli.amazonaws.com:443
+            sts.amazonaws.com:443
+            s3.amazonaws.com:443
+            pypi.org:443
+            upload.pypi.org:443
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Configure aws credentials (pytorch account)
         uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2


### PR DESCRIPTION
## Summary

Adds `step-security/harden-runner` (in **audit mode**) as the first step in the three highest-risk workflows in this repo. No existing behaviour is changed — audit mode only observes and logs; it does not block anything.

---

## Workflows covered

### `release-pypi.yml`
Publishes Python packages to PyPI for torchvision, torchaudio, torchao, executorch, torchcodec, and torchTune. This is the highest-value target for a supply-chain compromise — any secret exfiltration here affects millions of downstream PyTorch users. Allowed-endpoints baseline: GitHub, AWS STS/S3 (for staging bucket), PyPI upload.

### `release-docker.yml`
Pulls CUDA Docker images from GHCR and re-tags/pushes them to Docker Hub under the `pytorch/` namespace. Same risk tier as PyPI publishing. Allowed-endpoints baseline: GHCR, Docker Hub auth + registry.

### `_claude-code.yml` ⚠️ Highest priority
The centralised reusable Claude AI agent workflow used across pytorch and meta-pytorch orgs. It carries:
- `id-token: write` (OIDC → AWS Bedrock)
- `pull-requests: write` + `issues: write`
- `contents: read`

An AI agent workflow with open egress and write permissions is an especially sensitive surface. Audit mode will immediately show whether the `anthropics/claude-code-action` or any of its dependencies attempt to reach unexpected endpoints. Allowed-endpoints baseline: GitHub API, AWS STS, Bedrock runtime.

---

## What's not covered here (and why)

| Workflow | Reason skipped |
|---|---|
| `release-stage-pypi.yml` | Uses `container: pytorch/almalinux-builder:cpu` — harden-runner [does not support container jobs](https://docs.stepsecurity.io/harden-runner/how-tos/restrict-egress/#limitations) |
| `tflint.yml` | Uses `container: node:20` — same limitation |
| All other 100 workflows | Covered in a follow-up PR after the high-risk set is confirmed |

---

## Next steps after merge

1. Let the workflows run a few times in audit mode
2. Review the egress logs at [app.stepsecurity.io](https://app.stepsecurity.io)
3. Refine the `allowed-endpoints` lists based on observed traffic
4. Switch `egress-policy` from `audit` → `block` once the allowlist is confirmed

---

This change is part of a broader supply-chain hardening effort following a repository audit. See https://github.com/jordanconway/package-manager-hardening for the full methodology.