### PR TITLE
chore(security): commit Terraform provider lockfiles and enforce in CI

### DIFF
--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -38,6 +38,10 @@ jobs:
       run:
         tofu --version
 
+    - name: Verify lockfile integrity
+      working-directory: terraform-aws-github-runner
+      run: tofu init -backend=false -lockfile=readonly
+
     - name: "tflint"
       working-directory: terraform-aws-github-runner
       run: make tflint

--- a/terraform-aws-github-runner/.gitignore
+++ b/terraform-aws-github-runner/.gitignore
@@ -1,5 +1,7 @@
-# Terraform lock files
-*.lock.hcl
+# Terraform lock files — *.lock.hcl is intentionally NOT ignored here.
+# .terraform.lock.hcl must be committed to version control so that
+# `tofu init -lockfile=readonly` can enforce provider hash integrity in CI.
+# See: https://opentofu.org/docs/language/files/dependency-lock/
 
 # state
 *.tfstate*

--- a/terraform-aws-github-runner/.terraform.lock.hcl
+++ b/terraform-aws-github-runner/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.5"
+  hashes = [
+    "h1:BrNG7eFOdRrRRbHdvrTjMJ8X8Oh/tiegURiKf7J2db8=",
+    "h1:H8CH2vfXXP/WQgJw+Qrn72umKs9UlGYQvn+QdnwO8Nc=",
+    "h1:J7L5bgyYNRAbtwAFJl2Lj+IMI2DJTrbbL33PTK4OWVY=",
+    "h1:zef23ac/YWw9O2FepFWRs+my9iWWUkniL4dT4LnCKjU=",
+    "zh:1a41f3ee26720fee7a9a0a361890632a1701b5dc1cf5355dc651ddbe115682ff",
+    "zh:30457f36690c19307921885cc5e72b9dbeba369445815903acd5c39ac0e41e7a",
+    "zh:42c22674d5f23f6309eaf3ac3a4f1f8b66b566c1efe1dcb0dd2fb30c17ce1f78",
+    "zh:4cc271c795ff8ce6479ec2d11a8ba65a0a9ed6331def6693f4b9dccb6e662838",
+    "zh:60932aa376bb8c87cd1971240063d9d38ba6a55502c867fdbb9f5361dc93d003",
+    "zh:864e42784bde77b18393ebfcc0104cea9123da5f4392e8a059789e296952eefa",
+    "zh:9750423138bb01ecaa5cec1a6691664f7783d301fb1628d3b64a231b6b564e0e",
+    "zh:e5d30c4dec271ef9d6fe09f48237ec6cfea1036848f835b4e47f274b48bda5a7",
+    "zh:e62bd314ae97b43d782e0841b13e68a3f8ec85cc762004f973ce5ce7b6cdbfd0",
+    "zh:ea851a3c072528a4445ac6236ba2ce58ffc99ec466019b0bd0e4adde63a248e4",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.4.3"
+  constraints = "~> 3.4.2"
+  hashes = [
+    "h1:57xIMCTAE78wv9naPFb3atFFEFn3rW1hOFYTrXMk/C0=",
+    "h1:Qpht4jLDVODDdLpEqh3om/e4WVknY4+d1lpjlDwISVU=",
+    "h1:fMkGvO6VXyUx1l7i9PtoUQjk1MpFQfiIhB97Tt4nm/o=",
+    "h1:iCZVmgN6g7YdT28fW08vJmEQLqok6KrqB/USCGP+9w4=",
+    "zh:40f2ab718f177b0f8ec29da906104583047531de32cd7dc7f005a606a099d474",
+    "zh:6a6684084bd1624b93a262663c5849f9efb597c99d6b03eeb6dbd685760561fb",
+    "zh:8dc1973537166b468c08526ef38fa353f389df4ae9639cf8591dbc6e6048336b",
+    "zh:aa260ea7793988e7f45ea3916ed6e177f8827e9dd3959fe799cbeda2329e7d23",
+    "zh:b59bbf92b7be796c1921acf22b40fbb5e699bd3e9bdc06fa27a7e273509e1028",
+    "zh:c4603614ca8c73f3c9b00cb4e89d3b859a62864cf09faba2ae376689a354f326",
+    "zh:d82ba8432161763525dc7e8f32ac2377ea444829f805511cb90369b147c62b0c",
+    "zh:ee058d8839b35e1dbcfea224652e6e921e015d3454e0c06e8afce3516bb50910",
+    "zh:efffc2adfbfdbfde4f7fc9f423338c5969054de064b7afcd391fa2c419da2bc2",
+    "zh:f0530bdae9985a3be630679d6c29396721616148a08594bb0a55551a69c53c13",
+  ]
+}

--- a/terraform-aws-github-runner/modules/download-lambda/.terraform.lock.hcl
+++ b/terraform-aws-github-runner/modules/download-lambda/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version     = "3.2.4"
+  constraints = "~> 3.2.1"
+  hashes = [
+    "h1:346niW/SBt/jtCZctHefjkQGqtX9YgxSkCAKeCzQhXw=",
+    "h1:8ghdTVY6mALCeMuACnbrTmPaEzgamIYlgvunvqI2ZSY=",
+    "h1:i+WKhUHL2REY5EGmiHjfUljJB8UKZ9QdhdM5uTeUhC4=",
+    "h1:jsKjBiLb+v3OIC3xuDiY4sR0r1OHUMSWPYKult9MhT0=",
+    "zh:1769783386610bed8bb1e861a119fe25058be41895e3996d9216dd6bb8a7aee3",
+    "zh:32c62a9387ad0b861b5262b41c5e9ed6e940eda729c2a0e58100e6629af27ddb",
+    "zh:339bf8c2f9733fce068eb6d5612701144c752425cebeafab36563a16be460fb2",
+    "zh:36731f23343aee12a7e078067a98644c0126714c4fe9ac930eecb0f2361788c4",
+    "zh:3d106c7e32a929e2843f732625a582e562ff09120021e510a51a6f5d01175b8d",
+    "zh:74bcb3567708171ad83b234b92c9d63ab441ef882b770b0210c2b14fdbe3b1b6",
+    "zh:90b55bdbffa35df9204282251059e62c178b0ac7035958b93a647839643c0072",
+    "zh:ae24c0e5adc692b8f94cb23a000f91a316070fdc19418578dcf2134ff57cf447",
+    "zh:b5c10d4ad860c4c21273203d1de6d2f0286845edf1c64319fa2362df526b5f58",
+    "zh:e05bbd88e82e1d6234988c85db62fd66f11502645838fff594a2ec25352ecd80",
+  ]
+}


### PR DESCRIPTION
## Summary

Provider lockfiles (`.terraform.lock.hcl`) were explicitly gitignored via `*.lock.hcl` in `terraform-aws-github-runner/.gitignore`. This means every `tofu init` resolves provider versions live from the registry — a compromised or unexpected provider version (e.g. one matching the existing `~> 5.5` / `~> 3.4.2` loose constraints) could be silently installed with no diff ever appearing in this repo.

---

## Changes

### 1. Un-ignore `.terraform.lock.hcl` in `terraform-aws-github-runner/.gitignore`
Removes the `*.lock.hcl` glob and replaces it with a comment explaining why the file must be tracked. The `.tfstate` and `.terraform/` patterns are untouched.

### 2. Commit `terraform-aws-github-runner/.terraform.lock.hcl`
Generated with:
```bash
tofu init -backend=false
tofu providers lock \
  -platform=linux_amd64 -platform=linux_arm64 \
  -platform=darwin_arm64 -platform=darwin_amd64
```

Providers locked (all signed with key `0C0AF313E5FD9F80`):
| Provider | Version | Constraint |
|---|---|---|
| hashicorp/aws | 5.100.0 | `~> 5.5` |
| hashicorp/random | 3.4.3 | `~> 3.4.2` |

### 3. Commit `modules/download-lambda/.terraform.lock.hcl`
This module is not called from the root module (it appears to be a standalone utility root module). It has its own `required_providers` for `hashicorp/null` and therefore needs its own lockfile.

| Provider | Version | Constraint |
|---|---|---|
| hashicorp/null | 3.2.4 | `~> 3.2.1` |

### 4. Add `Verify lockfile integrity` step to `tflint.yml`
Runs `tofu init -backend=false -lockfile=readonly` before linting. CI will now fail if the lockfile is missing, out of date, or inconsistent with the checked-in constraints — ensuring the lockfile is always kept current.

---

## Keeping lockfiles up to date

After a provider version bump (from a Dependabot PR or manual update), re-run:

```bash
cd terraform-aws-github-runner
tofu providers lock \
  -platform=linux_amd64 -platform=linux_arm64 \
  -platform=darwin_arm64 -platform=darwin_amd64
```

Commit the updated `.terraform.lock.hcl`. The `-lockfile=readonly` CI step will then verify it matches.

---

> ⚠️ Note: the provider constraints (`~> 5.5`, `~> 3.4.2`, `~> 3.2.1`) are still loose ranges. A companion PR tightens these to exact `= X.Y.Z` pins, which is the stronger control. This PR and that one are independent and can be merged in either order.

This change is part of a broader supply-chain hardening effort following a repository audit. See https://github.com/jordanconway/package-manager-hardening for the full methodology.