### PR TITLE
chore(security): tighten Terraform provider constraints to exact pins

### DIFF
--- a/terraform-aws-github-runner/.terraform.lock.hcl
+++ b/terraform-aws-github-runner/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "5.100.0"
+  hashes = [
+    "h1:BrNG7eFOdRrRRbHdvrTjMJ8X8Oh/tiegURiKf7J2db8=",
+    "h1:H8CH2vfXXP/WQgJw+Qrn72umKs9UlGYQvn+QdnwO8Nc=",
+    "h1:J7L5bgyYNRAbtwAFJl2Lj+IMI2DJTrbbL33PTK4OWVY=",
+    "h1:zef23ac/YWw9O2FepFWRs+my9iWWUkniL4dT4LnCKjU=",
+    "zh:1a41f3ee26720fee7a9a0a361890632a1701b5dc1cf5355dc651ddbe115682ff",
+    "zh:30457f36690c19307921885cc5e72b9dbeba369445815903acd5c39ac0e41e7a",
+    "zh:42c22674d5f23f6309eaf3ac3a4f1f8b66b566c1efe1dcb0dd2fb30c17ce1f78",
+    "zh:4cc271c795ff8ce6479ec2d11a8ba65a0a9ed6331def6693f4b9dccb6e662838",
+    "zh:60932aa376bb8c87cd1971240063d9d38ba6a55502c867fdbb9f5361dc93d003",
+    "zh:864e42784bde77b18393ebfcc0104cea9123da5f4392e8a059789e296952eefa",
+    "zh:9750423138bb01ecaa5cec1a6691664f7783d301fb1628d3b64a231b6b564e0e",
+    "zh:e5d30c4dec271ef9d6fe09f48237ec6cfea1036848f835b4e47f274b48bda5a7",
+    "zh:e62bd314ae97b43d782e0841b13e68a3f8ec85cc762004f973ce5ce7b6cdbfd0",
+    "zh:ea851a3c072528a4445ac6236ba2ce58ffc99ec466019b0bd0e4adde63a248e4",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.4.3"
+  constraints = "3.4.3"
+  hashes = [
+    "h1:57xIMCTAE78wv9naPFb3atFFEFn3rW1hOFYTrXMk/C0=",
+    "h1:Qpht4jLDVODDdLpEqh3om/e4WVknY4+d1lpjlDwISVU=",
+    "h1:fMkGvO6VXyUx1l7i9PtoUQjk1MpFQfiIhB97Tt4nm/o=",
+    "h1:iCZVmgN6g7YdT28fW08vJmEQLqok6KrqB/USCGP+9w4=",
+    "zh:40f2ab718f177b0f8ec29da906104583047531de32cd7dc7f005a606a099d474",
+    "zh:6a6684084bd1624b93a262663c5849f9efb597c99d6b03eeb6dbd685760561fb",
+    "zh:8dc1973537166b468c08526ef38fa353f389df4ae9639cf8591dbc6e6048336b",
+    "zh:aa260ea7793988e7f45ea3916ed6e177f8827e9dd3959fe799cbeda2329e7d23",
+    "zh:b59bbf92b7be796c1921acf22b40fbb5e699bd3e9bdc06fa27a7e273509e1028",
+    "zh:c4603614ca8c73f3c9b00cb4e89d3b859a62864cf09faba2ae376689a354f326",
+    "zh:d82ba8432161763525dc7e8f32ac2377ea444829f805511cb90369b147c62b0c",
+    "zh:ee058d8839b35e1dbcfea224652e6e921e015d3454e0c06e8afce3516bb50910",
+    "zh:efffc2adfbfdbfde4f7fc9f423338c5969054de064b7afcd391fa2c419da2bc2",
+    "zh:f0530bdae9985a3be630679d6c29396721616148a08594bb0a55551a69c53c13",
+  ]
+}

--- a/terraform-aws-github-runner/main.tf
+++ b/terraform-aws-github-runner/main.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.4.2"
+      version = "= 3.4.3"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.5"
+      version = "= 5.100.0"
     }
   }
 }

--- a/terraform-aws-github-runner/modules/download-lambda/.terraform.lock.hcl
+++ b/terraform-aws-github-runner/modules/download-lambda/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version     = "3.2.4"
+  constraints = "3.2.4"
+  hashes = [
+    "h1:346niW/SBt/jtCZctHefjkQGqtX9YgxSkCAKeCzQhXw=",
+    "h1:8ghdTVY6mALCeMuACnbrTmPaEzgamIYlgvunvqI2ZSY=",
+    "h1:i+WKhUHL2REY5EGmiHjfUljJB8UKZ9QdhdM5uTeUhC4=",
+    "h1:jsKjBiLb+v3OIC3xuDiY4sR0r1OHUMSWPYKult9MhT0=",
+    "zh:1769783386610bed8bb1e861a119fe25058be41895e3996d9216dd6bb8a7aee3",
+    "zh:32c62a9387ad0b861b5262b41c5e9ed6e940eda729c2a0e58100e6629af27ddb",
+    "zh:339bf8c2f9733fce068eb6d5612701144c752425cebeafab36563a16be460fb2",
+    "zh:36731f23343aee12a7e078067a98644c0126714c4fe9ac930eecb0f2361788c4",
+    "zh:3d106c7e32a929e2843f732625a582e562ff09120021e510a51a6f5d01175b8d",
+    "zh:74bcb3567708171ad83b234b92c9d63ab441ef882b770b0210c2b14fdbe3b1b6",
+    "zh:90b55bdbffa35df9204282251059e62c178b0ac7035958b93a647839643c0072",
+    "zh:ae24c0e5adc692b8f94cb23a000f91a316070fdc19418578dcf2134ff57cf447",
+    "zh:b5c10d4ad860c4c21273203d1de6d2f0286845edf1c64319fa2362df526b5f58",
+    "zh:e05bbd88e82e1d6234988c85db62fd66f11502645838fff594a2ec25352ecd80",
+  ]
+}

--- a/terraform-aws-github-runner/modules/download-lambda/main.tf
+++ b/terraform-aws-github-runner/modules/download-lambda/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     null = {
       source  = "hashicorp/null"
-      version = "~> 3.2.1"
+      version = "= 3.2.4"
     }
   }
 }

--- a/terraform-aws-github-runner/modules/runner-binaries-syncer/main.tf
+++ b/terraform-aws-github-runner/modules/runner-binaries-syncer/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.5"
+      version = "= 5.100.0"
     }
   }
 }

--- a/terraform-aws-github-runner/modules/runners-instances/main.tf
+++ b/terraform-aws-github-runner/modules/runners-instances/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.5"
+      version = "= 5.100.0"
     }
   }
 }

--- a/terraform-aws-github-runner/modules/runners/main.tf
+++ b/terraform-aws-github-runner/modules/runners/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.5"
+      version = "= 5.100.0"
     }
   }
 }

--- a/terraform-aws-github-runner/modules/setup-iam-permissions/main.tf
+++ b/terraform-aws-github-runner/modules/setup-iam-permissions/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.5"
+      version = "= 5.100.0"
     }
   }
 }

--- a/terraform-aws-github-runner/modules/webhook/main.tf
+++ b/terraform-aws-github-runner/modules/webhook/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.5"
+      version = "= 5.100.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

Replace all loose `~>` and `>=` provider version constraints across all 7 OpenTofu modules with exact `= X.Y.Z` pins. This eliminates silent provider drift — with loose constraints, every `tofu init` could install a different version than the last run, and a compromised new release matching the range would be picked up automatically.

> ⚠️ **This PR requires human review before merging.** Changing `version` constraints can cause `tofu init` to fail if the environment uses cached provider binaries from a different version. Please validate in a non-production environment first.

> ℹ️ **Dependency note:** This PR includes `.terraform.lock.hcl` via `git add -f` because the companion PR [#8018](https://github.com/pytorch/test-infra/pull/8018) removes the `*.lock.hcl` gitignore entry. Either PR can merge first; if this merges before #8018, the lockfiles are tracked via force-add. If #8018 merges first, the force-add here is redundant but harmless.

---

## Changes

### Provider pins — all 7 modules

| Module | Provider | Old constraint | New constraint | Resolved version |
|---|---|---|---|---|
| root | hashicorp/aws | `~> 5.5` | `= 5.100.0` | 5.100.0 |
| root | hashicorp/random | `~> 3.4.2` | `= 3.4.3` | 3.4.3 |
| modules/webhook | hashicorp/aws | `~> 5.5` | `= 5.100.0` | 5.100.0 |
| modules/download-lambda | hashicorp/null | `~> 3.2.1` | `= 3.2.4` | 3.2.4 |
| modules/runners-instances | hashicorp/aws | `~> 5.5` | `= 5.100.0` | 5.100.0 |
| modules/setup-iam-permissions | hashicorp/aws | `~> 5.5` | `= 5.100.0` | 5.100.0 |
| modules/runners | hashicorp/aws | `~> 5.5` | `= 5.100.0` | 5.100.0 |
| modules/runner-binaries-syncer | hashicorp/aws | `~> 5.5` | `= 5.100.0` | 5.100.0 |

All versions were verified against the OpenTofu registry and confirmed as the latest that satisfied each prior constraint. All providers are signed with HashiCorp key `0C0AF313E5FD9F80`.

### Intentionally unchanged: `required_version`
The `required_version = ">= 1.5"` directive (which governs the OpenTofu CLI binary) is left as-is. Pinning it to a single exact version would break anyone running a different `tofu` release without a coordinated team upgrade. A separate decision is recommended to align CI (`tflint.yml` currently installs `1.5.7`) with the version in active use locally.

### Lockfiles updated
Both `.terraform.lock.hcl` files are regenerated to reflect the updated `constraints =` field, keeping them consistent with the new exact pins.

---

## Keeping providers up to date going forward

When a Dependabot PR bumps a provider (or you want to upgrade manually):

```bash
# 1. Update the = X.Y.Z version in the relevant main.tf
# 2. Reinitialise
cd terraform-aws-github-runner
tofu init -upgrade

# 3. Regenerate multi-platform lockfile hashes
tofu providers lock \
  -platform=linux_amd64 -platform=linux_arm64 \
  -platform=darwin_arm64 -platform=darwin_amd64

# 4. Commit both main.tf and .terraform.lock.hcl
```

---

This change is part of a broader supply-chain hardening effort following a repository audit. See https://github.com/jordanconway/package-manager-hardening for the full methodology.