### PR TITLE
Redirect libtorch zip downloads to download-r2.pytorch.org

### DIFF
--- a/aws/websites/download.pytorch.org/pep503_whl_redirect.js
+++ b/aws/websites/download.pytorch.org/pep503_whl_redirect.js
@@ -21,6 +21,16 @@ function handler(event) {
 
     // Similar behavior for libtorch
     if (uri.startsWith('/libtorch')) {
+        // Redirect libtorch downloads (.zip files) to R2
+        if (last_uri_part.endsWith('.zip')) {
+            return {
+                statusCode: 301,
+                statusDescription: 'Moved Permanently',
+                headers: {
+                    'location': { value: 'https://download-r2.pytorch.org' + uri }
+                }
+            };
+        }
         // Check whether the URI is missing a file name.
         if (uri.endsWith('/')) {
             request.uri += 'index.html';

--- a/aws/websites/download.pytorch.org/pep503_whl_redirect.js
+++ b/aws/websites/download.pytorch.org/pep503_whl_redirect.js
@@ -25,7 +25,7 @@ function handler(event) {
         if (last_uri_part.endsWith('.zip')) {
             return {
                 statusCode: 301,
-                statusDescription: 'Moved Permanently',
+                statusDescription: 'new download.pytorch.org mirror',
                 headers: {
                     'location': { value: 'https://download-r2.pytorch.org' + uri }
                 }


### PR DESCRIPTION
  ## Summary
  - Adds a 301 redirect in the `pep503_whl_redirect` CloudFront Function so that any request for a `/libtorch/**/*.zip` artifact on `download.pytorch.org` is
   redirected to the equivalent path on `download-r2.pytorch.org`.
  - Index pages and folder listings under `/libtorch/` continue to be served from the original origin — only the actual download artifacts shift to R2.
  - Example: `https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-2.11.0+cpu.zip` →
  `https://download-r2.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-2.11.0+cpu.zip`.

  ## Test plan
  - [ ] Validate function syntax with `aws cloudfront test-function` against a sample `/libtorch/cpu/libtorch-shared-with-deps-2.11.0+cpu.zip` event and
  confirm a 301 with the expected `location` header.
  - [ ] Test a folder-style URI (e.g. `/libtorch/cpu`) and confirm it still rewrites to `/libtorch/cpu/index.html` (no redirect).
  - [ ] Test a trailing-slash URI (e.g. `/libtorch/`) and confirm it still rewrites to `/libtorch/index.html` (no redirect).
  - [ ] Test a `/whl/...` request and confirm behavior is unchanged.
  - [ ] After deploy + publish, curl a real libtorch zip URL and confirm the 301 lands at `download-r2.pytorch.org` and the file downloads successfully.