### PR TITLE
ci-advisor: introduce 'related' verdict (alias of 'revert'), accept both

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -7,12 +7,23 @@ from .bisection_planner import GapBisectionPlanner
 
 
 class AdvisorVerdict(Enum):
-    """Verdict from the AI advisor workflow."""
+    """Verdict from the AI advisor workflow.
+
+    `related` is the context-neutral successor to `revert`: it asserts that
+    the suspect commit caused the failure. On trunk, the autorevert lambda
+    treats `related` and `revert` identically (both trigger a revert when
+    confidence is above threshold). On PRs the verdict is display-only and
+    `related` reads more naturally than `revert` (the PR has not merged yet).
+
+    `revert` is retained indefinitely for backward compatibility with
+    historical CH rows produced before the rename.
+    """
 
     REVERT = "revert"
     UNSURE = "unsure"
     NOT_RELATED = "not_related"
     GARBAGE = "garbage"
+    RELATED = "related"
 
 
 @dataclass(frozen=True)
@@ -476,7 +487,7 @@ class Signal:
         """Check if an AI advisor verdict is available for the suspect commit.
 
         Returns:
-            - AutorevertPattern if advisor says "revert" with sufficient confidence
+            - AutorevertPattern if advisor says "revert" or "related" with sufficient confidence
             - Ineligible if advisor says "not_related" or "garbage" (within 2h window)
             - None if no verdict, verdict is "unsure", or confidence below threshold
         """
@@ -493,7 +504,7 @@ class Signal:
         if result.confidence < self.ADVISOR_CONFIDENCE_THRESHOLD:
             return None
 
-        if result.verdict == AdvisorVerdict.REVERT:
+        if result.verdict in (AdvisorVerdict.REVERT, AdvisorVerdict.RELATED):
             return self._build_autorevert_pattern(partition, advisor_result=result)
 
         if result.verdict == AdvisorVerdict.NOT_RELATED:

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
@@ -882,6 +882,16 @@ class TestAdvisorVerdictIntegration(unittest.TestCase):
         self.assertEqual(res.older_successful_commit, "sha_old")
         self.assertEqual(res.newer_failing_commits, ["sha_newest", "sha_newer"])
 
+    def test_advisor_related_produces_autorevert_pattern(self):
+        """When advisor says 'related' (context-neutral successor to 'revert'),
+        produce AutorevertPattern just like 'revert'."""
+        s = self._make_signal_with_advisor(AdvisorVerdict.RELATED)
+        res = s.process_valid_autorevert_pattern()
+        self.assertIsInstance(res, AutorevertPattern)
+        self.assertEqual(res.suspected_commit, "sha_mid")
+        self.assertEqual(res.older_successful_commit, "sha_old")
+        self.assertEqual(res.newer_failing_commits, ["sha_newest", "sha_newer"])
+
     def test_advisor_not_related_produces_ineligible(self):
         """When advisor says 'not_related', return Ineligible."""
         s = self._make_signal_with_advisor(AdvisorVerdict.NOT_RELATED)

--- a/clickhouse_db_schema/misc.autorevert_advisor_verdicts/schema.sql
+++ b/clickhouse_db_schema/misc.autorevert_advisor_verdicts/schema.sql
@@ -9,7 +9,7 @@ CREATE TABLE misc.autorevert_advisor_verdicts
     `signal_key` String,
     `signal_source` LowCardinality(String),
     `workflow_name` String,
-    `verdict` Enum8('revert' = 1, 'unsure' = 2, 'not_related' = 3, 'garbage' = 4),
+    `verdict` Enum8('revert' = 1, 'unsure' = 2, 'not_related' = 3, 'garbage' = 4, 'related' = 5),
     `confidence` Float32,
     `summary` String,
     `causal_reasoning` String,

--- a/torchci/components/autorevert/AutorevertCell.tsx
+++ b/torchci/components/autorevert/AutorevertCell.tsx
@@ -31,6 +31,7 @@ const HIGHLIGHT_LABELS: Record<string, string> = {
 
 const ADV_VERDICT_CLS: Record<string, string> = {
   revert: styles.advRevert,
+  related: styles.advRevert,
   not_related: styles.advNotRelated,
   garbage: styles.advGarbage,
   unsure: styles.advUnsure,
@@ -38,6 +39,7 @@ const ADV_VERDICT_CLS: Record<string, string> = {
 
 const ADV_VERDICT_SHORT: Record<string, string> = {
   revert: "REV",
+  related: "REV",
   not_related: "OK",
   garbage: "JNK",
   unsure: "?",

--- a/torchci/components/job/AdvisorSection.tsx
+++ b/torchci/components/job/AdvisorSection.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 const VERDICT_COLORS: Record<string, { border: string; badge: string }> = {
   revert: { border: "#d32f2f", badge: "#d32f2f" },
+  related: { border: "#d32f2f", badge: "#d32f2f" },
   not_related: { border: "#388e3c", badge: "#2e7d32" },
   garbage: { border: "#8d6e63", badge: "#6d4c41" },
   unsure: { border: "#757575", badge: "#616161" },

--- a/torchci/components/job/AiAdvisorIndicator.tsx
+++ b/torchci/components/job/AiAdvisorIndicator.tsx
@@ -71,6 +71,7 @@ const VERDICT_CHIP_COLORS: Record<
   "error" | "warning" | "success" | "default"
 > = {
   revert: "error",
+  related: "error",
   unsure: "warning",
   not_related: "success",
   garbage: "default",
@@ -78,6 +79,7 @@ const VERDICT_CHIP_COLORS: Record<
 
 const VERDICT_LABELS: Record<string, string> = {
   revert: "Revert",
+  related: "Related",
   unsure: "Unsure",
   not_related: "Not Related",
   garbage: "Garbage Signal",

--- a/torchci/lib/advisorVerdictUtils.ts
+++ b/torchci/lib/advisorVerdictUtils.ts
@@ -9,8 +9,13 @@
  * - Test-track: "test_cuda.py::test_allocator_settings" (test within a job)
  */
 
+// `related` is the context-neutral successor to `revert`. On trunk, the
+// autorevert lambda treats them identically; on PRs `related` reads more
+// naturally since the PR has not merged yet. `revert` is retained for
+// backward compatibility with historical CH rows.
 export type AdvisorVerdictType =
   | "revert"
+  | "related"
   | "unsure"
   | "not_related"
   | "garbage";


### PR DESCRIPTION
Phase 1 + Phase 2 of the verdict-rename migration. The trunk-specific `revert` verdict is being renamed to the context-neutral `related` so the same advisor can serve both autorevert (trunk commits) and PR failure analysis (where the change has not merged yet).

## Phase 1 — schema

* Extend the `Enum8` in `clickhouse_db_schema/misc.autorevert_advisor_verdicts/schema.sql` to include `'related' = 5`. The matching `ALTER TABLE MODIFY COLUMN` has already been applied to the live `misc.autorevert_advisor_verdicts` table.
* Enum8 ALTER is non-breaking: existing IDs 1–4 keep their values, and the column accepts both `'revert'` and `'related'` inserts.

## Phase 2 — consumers dual-accept (read path)

**Lambda (`signal.py`):**
* Add `AdvisorVerdict.RELATED`.
* In `_check_advisor_verdict()`, treat `REVERT` and `RELATED` identically — both produce an `AutorevertPattern` when `confidence >= 0.89`.
* `signal_extraction.py` already swallows unknown verdict strings via `except ValueError → UNSURE`, so the lambda is safe even if a producer emits `'related'` before this lands.

**HUD (`torchci/`):**
* Extend `AdvisorVerdictType` union to include `'related'`.
* Add `'related'` to `VERDICT_COLORS`, `VERDICT_CHIP_COLORS`, and `VERDICT_LABELS` (same red palette as `'revert'` — both indicate the failure is caused by the suspect commit).

## Tests

* `test_advisor_related_produces_autorevert_pattern` mirrors the existing `REVERT` test to confirm the dual-accept logic.

## Why this ordering is safe

1. CH ALTER first ⇒ column accepts both names.
2. Consumers dual-accept (this PR) ⇒ both names render and both drive the same lambda action.
3. Producer flip in a follow-up PR (`claude-autorevert-advisor.yml` prompt) ⇒ new verdicts emit `related`; historical rows stay as `revert` and keep working.

No backfill needed — the dual-accept code is permanent (5 lines of cheap insurance), so old `revert` rows stay readable forever.

## Migration plan reference

Phases 3–5 (producer flip + prompt re-shape for both PR/trunk contexts; optional file rename `claude-autorevert-advisor.yml → claude-ci-advisor.yml`) come in follow-up PRs once this lands and rolls.

## Test plan

- [x] Lambda unit tests: `python3 -m unittest pytorch_auto_revert.tests.test_signal` — 38/38 pass, including the new `test_advisor_related_produces_autorevert_pattern`.
- [x] HUD lint/type-check (CI).
- [x] Manual verify: dispatch advisor on a known commit, observe `'revert'` rows still render in HUD with red palette (legacy compat).
- [ ] Manual verify: insert a synthetic `'related'` row in CH staging, confirm HUD renders it identically to `'revert'`.