### PR TITLE
Allow using a different registry than AWS ECR us-east-1

### DIFF
--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -32,6 +32,12 @@ inputs:
   docker-registry:
     description: The registry to store the image after it is built.
     default: 308535385114.dkr.ecr.us-east-1.amazonaws.com
+  docker-username:
+    description: |
+      The username for the registry to store the image after it is built. You must specify it
+      if you want to connect to another registry than *.ecr.us-east-1.amazonaws.com
+  docker-password:
+    description: The password for the docker-username user to docker-registry
   always-rebuild:
     description: If set to any value, always build a fresh docker image.
     required: false
@@ -112,6 +118,13 @@ runs:
           echo "custom-tag-prefix=${CUSTOM_TAG_PREFIX}" >> "${GITHUB_OUTPUT}"
         fi
 
+    - name: Login to Container Registry
+      uses: pytorch/test-infra/.github/actions/login-container-registry@main
+      with:
+        docker-registry: ${{ inputs.docker-registry }}
+        docker-username: ${{ inputs.docker-username }}
+        docker-password: ${{ inputs.docker-password }}
+
     - name: Check if image should be built
       id: check-image
       shell: bash
@@ -122,21 +135,10 @@ runs:
         BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
         DOCKER_IMAGE: ${{ steps.calculate-image.outputs.docker-image }}
         DOCKER_TAG: ${{ steps.calculate-image.outputs.docker-tag }}
-        DOCKER_REGISTRY: ${{ inputs.docker-registry }}
         DOCKER_PUSH: ${{ inputs.push }}
       run: |
         set +e
         set -x
-
-        login() {
-          aws ecr get-login-password --region us-east-1 | docker login -u AWS --password-stdin "$1"
-        }
-
-        retry () {
-          $*  || (sleep 1 && $*) || (sleep 2 && $*)
-        }
-
-        retry login "${DOCKER_REGISTRY}"
 
         START_TIME=$(date +%s)
         # Wait up to 120 minutes
@@ -189,26 +191,6 @@ runs:
 
         echo "rebuild=true" >> "${GITHUB_OUTPUT}"
 
-    - name: Login to ECR
-      if: ${{ steps.calculate-image.outputs.skip != 'true' && (inputs.always-rebuild || steps.check-image.outputs.rebuild) }}
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}/${{ inputs.docker-build-dir }}
-      env:
-        DOCKER_REGISTRY: ${{ inputs.docker-registry }}
-      run: |
-        set -x
-        set +e
-
-        login() {
-          aws ecr get-login-password --region us-east-1 | docker login -u AWS --password-stdin "$1"
-        }
-
-        retry () {
-          $*  || (sleep 1 && $*) || (sleep 2 && $*)
-        }
-
-        retry login "${DOCKER_REGISTRY}"
-
     - name: Login to Docker Hub
       shell: bash
       run: |
@@ -244,7 +226,7 @@ runs:
 
           popd
 
-    - name: Push to ECR
+    - name: Push to Container Registry
       if: ${{ steps.calculate-image.outputs.skip != 'true' && (inputs.always-rebuild || steps.check-image.outputs.rebuild) }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}/${{ inputs.docker-build-dir }}

--- a/.github/actions/login-container-registry/action.yml
+++ b/.github/actions/login-container-registry/action.yml
@@ -1,0 +1,45 @@
+name: Login to docker registry
+
+description: login to a docker registry
+
+inputs:
+  docker-registry:
+    description: The registry to login to.
+    required: true
+    type: string
+  docker-username:
+    description: |
+      The username for the registry to login to. You must specify it if you want
+      to connect to another registry than *.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
+  docker-password:
+    description: The password for the docker-username user to docker-registry
+
+runs:
+  using: composite
+  steps:
+    - name: Login to ECR
+      if: ${{ !inputs.docker-username }}
+      shell: bash
+      env:
+        DOCKER_REGISTRY: ${{ inputs.docker-registry }}
+      run: |
+        set -x
+        set +e
+
+        login() {
+          aws ecr get-login-password --region ${{ env.AWS_DEFAULT_REGION || 'us-east-1' }} | docker login -u AWS --password-stdin "$1"
+        }
+
+        retry () {
+          $*  || (sleep 1 && $*) || (sleep 2 && $*)
+        }
+
+        retry login "${DOCKER_REGISTRY}"
+
+    - name: Login to ${{ inputs.docker-registry }}
+      if: ${{ inputs.docker-username }}
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      with:
+        registry: ${{ inputs.docker-registry }}
+        username: ${{ inputs.docker-username }}
+        password: ${{ inputs.docker-password }}

--- a/.github/actions/pull-docker-image/action.yml
+++ b/.github/actions/pull-docker-image/action.yml
@@ -9,28 +9,36 @@ inputs:
   docker-registry:
     description: The registry to store the image after it is built.
     default: 308535385114.dkr.ecr.us-east-1.amazonaws.com
+  docker-username:
+    description: |
+      The username for the registry to store the image after it is built. You must specify it
+      if you want to connect to another registry than *.ecr.us-east-1.amazonaws.com
+  docker-password:
+    description: The password for the docker-username user to docker-registry
 
 runs:
   using: composite
   steps:
+    - name: Login to Container Registry
+      uses: pytorch/test-infra/.github/actions/login-container-registry@main
+      with:
+        docker-registry: ${{ inputs.docker-registry }}
+        docker-username: ${{ inputs.docker-username }}
+        docker-password: ${{ inputs.docker-password }}
+
     - name: Pull Docker image
       shell: bash
       env:
         DOCKER_IMAGE: ${{ inputs.docker-image }}
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
+        DOCKER_USERNAME: ${{ inputs.docker-username }}
       run: |
         set -x
         set +e
 
-        login() {
-          aws ecr get-login-password --region us-east-1 | docker login -u AWS --password-stdin "$1"
-        }
-
         retry () {
           $*  || (sleep 1 && $*) || (sleep 2 && $*)
         }
-
-        retry login "${DOCKER_REGISTRY}"
 
         IMAGE_SIZE=$(docker manifest inspect "${DOCKER_IMAGE}" | jq '[.layers[].size, .config.size] | add / 1024 / 1024')
         echo "Compressed size of image in MB: ${IMAGE_SIZE}"

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -6,6 +6,7 @@ runs:
   using: composite
   steps:
     - name: Display EC2 information
+      if: github.repository_owner == 'pytorch'
       shell: bash
       run: |
         set -euo pipefail
@@ -19,6 +20,15 @@ runs:
         echo "instance-id: $(get_ec2_metadata instance-id)"
         echo "instance-type: $(get_ec2_metadata instance-type)"
         echo "system info $(uname -a)"
+
+        echo "AWS_DEFAULT_REGION=us-east-1" >> $GITHUB_ENV
+        echo "AWS_ACCOUNT_ID=$(aws sts get-caller-identity|grep Account|cut -f4 -d\")" >> $GITHUB_ENV
+
+    - name: Login to ECR
+      if: github.repository_owner == 'pytorch'
+      uses: pytorch/test-infra/.github/actions/login-container-registry@main
+      with:
+        docker-registry: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_DEFAULT_REGION }}.amazonaws.com
 
     - name: Check if in a container runner
       shell: bash
@@ -36,18 +46,6 @@ runs:
               echo "Starting docker daemon..." && sudo systemctl start docker;
           fi
         fi
-
-    - name: Log in to ECR
-      shell: bash
-      env:
-        AWS_RETRY_MODE: standard
-        AWS_MAX_ATTEMPTS: "5"
-        AWS_DEFAULT_REGION: us-east-1
-      run: |
-        AWS_ACCOUNT_ID=$(aws sts get-caller-identity|grep Account|cut -f4 -d\")
-        retry () { "$@"  || (sleep 1 && "$@") || (sleep 2 && "$@") }
-        retry aws ecr get-login-password --region "$AWS_DEFAULT_REGION" | docker login --username AWS \
-            --password-stdin "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com"
 
     - name: Preserve github env variables for use in docker
       shell: bash


### PR DESCRIPTION
This is most useful for forks of PyTorch which want to build and test on their own infrastructure. We still want to be able to reuse as much of the existing code and structure provided, but we can't always rely on being on an AWS host.