### PR TITLE
Skip workflow_run events that are awaiting approval

### DIFF
--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -297,6 +297,15 @@ async function handleWorkflowRunEvent(context: Context<"workflow_run">) {
     return;
   }
 
+  // Skip runs that GitHub created but hasn't actually started yet, e.g. those
+  // awaiting maintainer approval on first-time-contributor PRs. workflow_run.requested
+  // fires when the run record is created, including in `waiting` / `action_required`
+  // state, and creating tags here would defeat the deferral this handler exists for.
+  const status = (payload.workflow_run as any).status;
+  if (status === "waiting" || status === "action_required") {
+    return;
+  }
+
   let prNumbers: number[] = (payload.workflow_run.pull_requests ?? []).map(
     (pr: any) => pr.number
   );

--- a/torchci/test/ciflow-push-trigger.test.ts
+++ b/torchci/test/ciflow-push-trigger.test.ts
@@ -518,6 +518,38 @@ describe("Push trigger integration tests", () => {
     await probot.receive({ name: "pull_request", id: "123", payload });
   });
 
+  test("workflow_run awaiting approval does not create tags", async () => {
+    // workflow_run.requested fires when GitHub creates the run record, including
+    // for runs that haven't been approved yet on first-time-contributor PRs.
+    // The handler must not mint tags off these events.
+    const payload = {
+      action: "requested",
+      workflow_run: {
+        event: "pull_request",
+        status: "waiting",
+        head_sha: "abc123",
+        head_branch: "feature-branch",
+        head_repository: {
+          owner: { login: "fork-user" },
+        },
+        pull_requests: [{ number: 42 }],
+      },
+      repository: {
+        owner: { login: "suo" },
+        name: "actions-test",
+        full_name: "suo/actions-test",
+      },
+    };
+
+    // No requests should be made -- the handler should bail out before
+    // touching the GitHub API.
+    await probot.receive({
+      name: "workflow_run" as any,
+      id: "789",
+      payload: payload as any,
+    });
+  });
+
   test("workflow_run with empty pull_requests falls back to SHA lookup", async () => {
     const head_sha = "abc123def456";
     const prNum = 42;


### PR DESCRIPTION
## Summary

- `handleWorkflowRunEvent` (added in #7958, refined in #7970) listens to `workflow_run.requested`, which GitHub fires as soon as it creates the run record — including runs in `waiting` / `action_required` state on first-time-contributor PRs.
- The handler never checked status, so it would mint ciflow tags off the *request* event, defeating the approval deferral that #7958 was built for.
- Bail out early when `workflow_run.status` is `waiting` or `action_required`. Approved runs transition out of those states before subsequent `workflow_run` events, so legitimate post-approval triggers (and the `.completed` path) still work.

## Test plan

- [x] New unit test asserts that a `workflow_run` payload with `status: "waiting"` does not issue any GitHub API calls.
- [x] Existing tests (including the cross-fork fallback from #7970) still pass.
- [ ] After deploy, observe that an unapproved external-fork PR with a ciflow label no longer gets a ciflow tag created until a maintainer actually approves the workflows.