### PR TITLE
Skip workflow_run with conclusion=action_required

### DIFF
--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -297,12 +297,18 @@ async function handleWorkflowRunEvent(context: Context<"workflow_run">) {
     return;
   }
 
-  // Skip runs that GitHub created but hasn't actually started yet, e.g. those
-  // awaiting maintainer approval on first-time-contributor PRs. workflow_run.requested
-  // fires when the run record is created, including in `waiting` / `action_required`
-  // state, and creating tags here would defeat the deferral this handler exists for.
-  const status = (payload.workflow_run as any).status;
-  if (status === "waiting" || status === "action_required") {
+  // Skip runs that are gated on maintainer approval (e.g. first-time-contributor PRs).
+  // GitHub may surface this as either status=waiting/action_required, or — when it
+  // immediately completes the run pending approval — status=completed with
+  // conclusion=action_required (see pytorch/pytorch#182109). startup_failure mirrors
+  // hasApprovedPullRuns in utils.ts, which treats it as not-yet-approved.
+  const wr = payload.workflow_run as any;
+  if (
+    wr.status === "waiting" ||
+    wr.status === "action_required" ||
+    wr.conclusion === "action_required" ||
+    wr.conclusion === "startup_failure"
+  ) {
     return;
   }
 

--- a/torchci/test/ciflow-push-trigger.test.ts
+++ b/torchci/test/ciflow-push-trigger.test.ts
@@ -518,37 +518,50 @@ describe("Push trigger integration tests", () => {
     await probot.receive({ name: "pull_request", id: "123", payload });
   });
 
-  test("workflow_run awaiting approval does not create tags", async () => {
-    // workflow_run.requested fires when GitHub creates the run record, including
-    // for runs that haven't been approved yet on first-time-contributor PRs.
-    // The handler must not mint tags off these events.
-    const payload = {
-      action: "requested",
-      workflow_run: {
-        event: "pull_request",
-        status: "waiting",
-        head_sha: "abc123",
-        head_branch: "feature-branch",
-        head_repository: {
-          owner: { login: "fork-user" },
+  test.each([
+    // Transient pre-approval states surfaced via `status`.
+    { status: "waiting", conclusion: null },
+    { status: "action_required", conclusion: null },
+    // Observed on pytorch/pytorch#182109: GitHub created and "completed" the
+    // run in the same instant, expressing the deferral via `conclusion` rather
+    // than a transient `status`. The handler must catch this shape too.
+    { status: "completed", conclusion: "action_required" },
+    { status: "completed", conclusion: "startup_failure" },
+  ])(
+    "workflow_run gated on approval (status=$status, conclusion=$conclusion) does not create tags",
+    async ({ status, conclusion }) => {
+      // workflow_run.requested fires when GitHub creates the run record, including
+      // for runs that haven't been approved yet on first-time-contributor PRs.
+      // The handler must not mint tags off these events.
+      const payload = {
+        action: "requested",
+        workflow_run: {
+          event: "pull_request",
+          status,
+          conclusion,
+          head_sha: "abc123",
+          head_branch: "feature-branch",
+          head_repository: {
+            owner: { login: "fork-user" },
+          },
+          pull_requests: [{ number: 42 }],
         },
-        pull_requests: [{ number: 42 }],
-      },
-      repository: {
-        owner: { login: "suo" },
-        name: "actions-test",
-        full_name: "suo/actions-test",
-      },
-    };
+        repository: {
+          owner: { login: "suo" },
+          name: "actions-test",
+          full_name: "suo/actions-test",
+        },
+      };
 
-    // No requests should be made -- the handler should bail out before
-    // touching the GitHub API.
-    await probot.receive({
-      name: "workflow_run" as any,
-      id: "789",
-      payload: payload as any,
-    });
-  });
+      // No requests should be made -- the handler should bail out before
+      // touching the GitHub API.
+      await probot.receive({
+        name: "workflow_run" as any,
+        id: "789",
+        payload: payload as any,
+      });
+    }
+  );
 
   test("workflow_run with empty pull_requests falls back to SHA lookup", async () => {
     const head_sha = "abc123def456";


### PR DESCRIPTION
## Summary

- The status-only guard added in #8028 missed the shape GitHub actually delivered for pytorch/pytorch#182109: the three gated `pull_request` runs (BC Lint / Lint / pull) for `8e1ac02…` arrived at the webhook with `status=completed, conclusion=action_required` (created/started/updated all at the same second), rather than transiently sitting in `status=waiting`. The handler fell through, minted `refs/tags/ciflow/mps/182109`, and the resulting push triggered Mac MPS even though the workflows were still awaiting first-time-contributor approval.
- Broaden `handleWorkflowRunEvent`'s bail-out to also match `conclusion=action_required` and `conclusion=startup_failure`. The latter mirrors `hasApprovedPullRuns` in `utils.ts`, which already treats it as not-yet-approved.
- Convert the existing `workflow_run awaiting approval` regression test to `test.each` so it covers both the status-based shapes (`waiting`, `action_required`) and the conclusion-based shapes (`completed + action_required`, `completed + startup_failure`).

## Test plan

- [x] `yarn jest test/ciflow-push-trigger.test.ts` — all 4 parametrized cases plus the rest of the suite pass.
- [x] `yarn format --check lib/bot/ciflowPushTrigger.ts test/ciflow-push-trigger.test.ts` — clean.