### PR TITLE
Update wincanarylf AMI to Windows 2019 GHA CI - 20260501125018

### DIFF
--- a/.github/canary-scale-config.yml
+++ b/.github/canary-scale-config.yml
@@ -276,7 +276,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   c.windows.g4dn.xlarge.nonephemeral:
     disk_size: 256
     instance_type: g4dn.xlarge
@@ -286,7 +286,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   c.windows.4xlarge:
     disk_size: 256
     instance_type: c5d.4xlarge
@@ -296,7 +296,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   c.windows.4xlarge.nonephemeral:
     disk_size: 256
     instance_type: c5d.4xlarge
@@ -306,7 +306,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   c.windows.12xlarge:
     disk_size: 256
     instance_type: c5d.12xlarge
@@ -316,7 +316,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   c.windows.12xlarge.nonephemeral:
     disk_size: 256
     instance_type: c5d.12xlarge
@@ -326,7 +326,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   c.windows.8xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: p3.2xlarge
@@ -336,7 +336,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   c.windows.8xlarge.nvidia.gpu.nonephemeral:
     disk_size: 256
     instance_type: p3.2xlarge
@@ -346,7 +346,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   c.windows.g5.4xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: g5.4xlarge
@@ -356,7 +356,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   c.linux.2xlarge.memory:
     disk_size: 200
     instance_type: r5.2xlarge

--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -291,7 +291,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   lf.c.windows.g4dn.xlarge.nonephemeral:
     disk_size: 256
     instance_type: g4dn.xlarge
@@ -301,7 +301,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   lf.c.windows.4xlarge:
     disk_size: 256
     instance_type: c5d.4xlarge
@@ -311,7 +311,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   lf.c.windows.4xlarge.nonephemeral:
     disk_size: 256
     instance_type: c5d.4xlarge
@@ -321,7 +321,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   lf.c.windows.12xlarge:
     disk_size: 256
     instance_type: c5d.12xlarge
@@ -331,7 +331,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   lf.c.windows.12xlarge.nonephemeral:
     disk_size: 256
     instance_type: c5d.12xlarge
@@ -341,7 +341,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   lf.c.windows.8xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: p3.2xlarge
@@ -351,7 +351,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   lf.c.windows.8xlarge.nvidia.gpu.nonephemeral:
     disk_size: 256
     instance_type: p3.2xlarge
@@ -361,7 +361,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   lf.c.windows.g5.4xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: g5.4xlarge
@@ -371,7 +371,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   lf.c.linux.2xlarge.memory:
     disk_size: 200
     instance_type: r5.2xlarge

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -276,7 +276,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   lf.windows.g4dn.xlarge.nonephemeral:
     disk_size: 256
     instance_type: g4dn.xlarge
@@ -286,7 +286,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   lf.windows.4xlarge:
     disk_size: 256
     instance_type: c5d.4xlarge
@@ -296,7 +296,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   lf.windows.4xlarge.nonephemeral:
     disk_size: 256
     instance_type: c5d.4xlarge
@@ -306,7 +306,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   lf.windows.12xlarge:
     disk_size: 256
     instance_type: c5d.12xlarge
@@ -316,7 +316,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   lf.windows.12xlarge.nonephemeral:
     disk_size: 256
     instance_type: c5d.12xlarge
@@ -326,7 +326,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   lf.windows.8xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: p3.2xlarge
@@ -336,7 +336,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   lf.windows.8xlarge.nvidia.gpu.nonephemeral:
     disk_size: 256
     instance_type: p3.2xlarge
@@ -346,7 +346,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   lf.windows.g5.4xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: g5.4xlarge
@@ -356,7 +356,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   lf.linux.2xlarge.memory:
     disk_size: 200
     instance_type: r5.2xlarge

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -272,7 +272,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   windows.g4dn.xlarge.nonephemeral:
     disk_size: 256
     instance_type: g4dn.xlarge
@@ -282,7 +282,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   windows.4xlarge:
     disk_size: 256
     instance_type: c5d.4xlarge
@@ -292,7 +292,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   windows.4xlarge.nonephemeral:
     disk_size: 256
     instance_type: c5d.4xlarge
@@ -302,7 +302,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   windows.12xlarge:
     disk_size: 256
     instance_type: c5d.12xlarge
@@ -312,7 +312,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   windows.12xlarge.nonephemeral:
     disk_size: 256
     instance_type: c5d.12xlarge
@@ -322,7 +322,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   windows.8xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: p3.2xlarge
@@ -332,7 +332,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   windows.8xlarge.nvidia.gpu.nonephemeral:
     disk_size: 256
     instance_type: p3.2xlarge
@@ -342,7 +342,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   windows.g5.4xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: g5.4xlarge
@@ -352,7 +352,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260420192324|391835788720
+        ami: Windows 2019 GHA CI - 20260501125018|391835788720
   linux.2xlarge.memory:
     disk_size: 200
     instance_type: r5.2xlarge


### PR DESCRIPTION
Bumps the wincanarylf AMI from `Windows 2019 GHA CI - 20260420192324` to `Windows 2019 GHA CI - 20260501125018` across `.github/scale-config.yml`, `.github/canary-scale-config.yml`, `.github/lf-scale-config.yml`, and `.github/lf-canary-scale-config.yml`.

Follows the same pattern as #7997.

Authored with Claude.