### PR TITLE
[autorevert] Add Signal.replace / SignalCommit.replace for safe reconstruction

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -186,20 +186,10 @@ class SignalCommit:
         self.advisor_result = advisor_result
 
     def replace(self, **changes) -> "SignalCommit":
-        """Return a new SignalCommit with selected fields replaced and the
-        rest preserved (`dataclasses.replace`-style API).
+        """Return a copy with selected fields replaced (`dataclasses.replace`-style).
 
-        Used by every site in `signal_extraction` that reconstructs a
-        SignalCommit — `_dedup_signal_events` (replaces `events`),
-        `_inject_pending_workflow_events` (replaces `events`),
-        `_attach_advisor_verdicts` (replaces `advisor_result`). A unified
-        helper means adding a new SignalCommit field never silently gets
-        dropped during reconstruction. The introspection-based tests
-        `test_replace_with_no_changes_preserves_all_fields` and
-        `test_replace_unknown_kwarg_raises` enforce this.
-
-        Raises TypeError if `changes` contains an unknown field — catches
-        typos and stale kwargs at runtime.
+        Centralizes reconstruction so adding a new field never silently gets
+        dropped on schema evolution. Raises TypeError on unknown kwargs.
         """
         new_fields = {
             "head_sha": changes.pop("head_sha", self.head_sha),
@@ -212,7 +202,7 @@ class SignalCommit:
                 f"SignalCommit.replace() got unexpected keyword argument(s): "
                 f"{sorted(changes)}"
             )
-        return SignalCommit(**new_fields)
+        return type(self)(**new_fields)
 
     @property
     def has_pending(self) -> bool:
@@ -400,19 +390,10 @@ class Signal:
         self.source = source
 
     def replace(self, **changes) -> "Signal":
-        """Return a new Signal with selected fields replaced and the rest
-        preserved (`dataclasses.replace`-style API).
+        """Return a copy with selected fields replaced (`dataclasses.replace`-style).
 
-        Used by every site in `signal_extraction` that reconstructs a
-        Signal — `_dedup_signal_events`, `_inject_pending_workflow_events`,
-        `_attach_advisor_verdicts` (all replace `commits`). A unified helper
-        means adding a new Signal field never silently gets dropped during
-        reconstruction. The introspection-based tests
-        `test_replace_with_no_changes_preserves_all_fields` and
-        `test_replace_unknown_kwarg_raises` enforce this.
-
-        Raises TypeError if `changes` contains an unknown field — catches
-        typos and stale kwargs at runtime.
+        Centralizes reconstruction so adding a new field never silently gets
+        dropped on schema evolution. Raises TypeError on unknown kwargs.
         """
         new_fields = {
             "key": changes.pop("key", self.key),
@@ -427,7 +408,7 @@ class Signal:
                 f"Signal.replace() got unexpected keyword argument(s): "
                 f"{sorted(changes)}"
             )
-        return Signal(**new_fields)
+        return type(self)(**new_fields)
 
     def detect_fixed(self) -> bool:
         """

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -185,6 +185,35 @@ class SignalCommit:
         # Optional AI advisor result for this (commit, signal) pair
         self.advisor_result = advisor_result
 
+    def replace(self, **changes) -> "SignalCommit":
+        """Return a new SignalCommit with selected fields replaced and the
+        rest preserved (`dataclasses.replace`-style API).
+
+        Used by every site in `signal_extraction` that reconstructs a
+        SignalCommit — `_dedup_signal_events` (replaces `events`),
+        `_inject_pending_workflow_events` (replaces `events`),
+        `_attach_advisor_verdicts` (replaces `advisor_result`). A unified
+        helper means adding a new SignalCommit field never silently gets
+        dropped during reconstruction. The introspection-based tests
+        `test_replace_with_no_changes_preserves_all_fields` and
+        `test_replace_unknown_kwarg_raises` enforce this.
+
+        Raises TypeError if `changes` contains an unknown field — catches
+        typos and stale kwargs at runtime.
+        """
+        new_fields = {
+            "head_sha": changes.pop("head_sha", self.head_sha),
+            "timestamp": changes.pop("timestamp", self.timestamp),
+            "events": changes.pop("events", self.events),
+            "advisor_result": changes.pop("advisor_result", self.advisor_result),
+        }
+        if changes:
+            raise TypeError(
+                f"SignalCommit.replace() got unexpected keyword argument(s): "
+                f"{sorted(changes)}"
+            )
+        return SignalCommit(**new_fields)
+
     @property
     def has_pending(self) -> bool:
         return SignalStatus.PENDING in self.statuses
@@ -369,6 +398,36 @@ class Signal:
         self.test_module = test_module
         # Track the origin of the signal (test-track or job-track).
         self.source = source
+
+    def replace(self, **changes) -> "Signal":
+        """Return a new Signal with selected fields replaced and the rest
+        preserved (`dataclasses.replace`-style API).
+
+        Used by every site in `signal_extraction` that reconstructs a
+        Signal — `_dedup_signal_events`, `_inject_pending_workflow_events`,
+        `_attach_advisor_verdicts` (all replace `commits`). A unified helper
+        means adding a new Signal field never silently gets dropped during
+        reconstruction. The introspection-based tests
+        `test_replace_with_no_changes_preserves_all_fields` and
+        `test_replace_unknown_kwarg_raises` enforce this.
+
+        Raises TypeError if `changes` contains an unknown field — catches
+        typos and stale kwargs at runtime.
+        """
+        new_fields = {
+            "key": changes.pop("key", self.key),
+            "workflow_name": changes.pop("workflow_name", self.workflow_name),
+            "commits": changes.pop("commits", self.commits),
+            "job_base_name": changes.pop("job_base_name", self.job_base_name),
+            "test_module": changes.pop("test_module", self.test_module),
+            "source": changes.pop("source", self.source),
+        }
+        if changes:
+            raise TypeError(
+                f"Signal.replace() got unexpected keyword argument(s): "
+                f"{sorted(changes)}"
+            )
+        return Signal(**new_fields)
 
     def detect_fixed(self) -> bool:
         """

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
@@ -138,21 +138,8 @@ class SignalExtractor:
                         continue
                     filtered.append(e)
                     prev_key = key
-                new_commits.append(
-                    SignalCommit(
-                        head_sha=c.head_sha, timestamp=c.timestamp, events=filtered
-                    )
-                )
-            deduped.append(
-                Signal(
-                    key=s.key,
-                    workflow_name=s.workflow_name,
-                    commits=new_commits,
-                    job_base_name=s.job_base_name,
-                    test_module=s.test_module,
-                    source=s.source,
-                )
-            )
+                new_commits.append(c.replace(events=filtered))
+            deduped.append(s.replace(commits=new_commits))
         return deduped
 
     # -----------------------------
@@ -223,22 +210,9 @@ class SignalExtractor:
                             job_id=None,
                         )
                     )
-                new_commits.append(
-                    SignalCommit(
-                        head_sha=c.head_sha, timestamp=c.timestamp, events=synth_events
-                    )
-                )
+                new_commits.append(c.replace(events=synth_events))
 
-            out.append(
-                Signal(
-                    key=s.key,
-                    workflow_name=s.workflow_name,
-                    commits=new_commits,
-                    job_base_name=s.job_base_name,
-                    test_module=s.test_module,
-                    source=s.source,
-                )
-            )
+            out.append(s.replace(commits=new_commits))
         return out
 
     # -----------------------------
@@ -284,26 +258,10 @@ class SignalExtractor:
                         timestamp=ts,
                         signal_key=s.key,
                     )
-                    new_commits.append(
-                        SignalCommit(
-                            head_sha=c.head_sha,
-                            timestamp=c.timestamp,
-                            events=c.events,
-                            advisor_result=advisor_result,
-                        )
-                    )
+                    new_commits.append(c.replace(advisor_result=advisor_result))
                 else:
                     new_commits.append(c)
-            out.append(
-                Signal(
-                    key=s.key,
-                    workflow_name=s.workflow_name,
-                    commits=new_commits,
-                    job_base_name=s.job_base_name,
-                    test_module=s.test_module,
-                    source=s.source,
-                )
-            )
+            out.append(s.replace(commits=new_commits))
         return out
 
     # -----------------------------

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
@@ -1112,12 +1112,7 @@ class TestAdvisorVerdictIntegration(unittest.TestCase):
 
 
 class TestSignalReplace(unittest.TestCase):
-    """Tests for Signal.replace() — `dataclasses.replace`-style API.
-
-    The two introspection-based tests below are the load-bearing ones:
-    one catches dropped fields (replace() forgetting to propagate a new
-    field); the other catches stale/typo'd kwargs.
-    """
+    """Tests for Signal.replace() — `dataclasses.replace`-style API."""
 
     def setUp(self) -> None:
         self.t0 = datetime(2025, 8, 19, 12, 0, 0)
@@ -1188,7 +1183,7 @@ class TestSignalReplace(unittest.TestCase):
     def test_replace_unknown_kwarg_raises(self):
         """Stale or typo'd kwargs are caught at runtime."""
         s = Signal(**self._SENTINELS)
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, "this_field_does_not_exist"):
             s.replace(this_field_does_not_exist=42)
 
 
@@ -1270,7 +1265,7 @@ class TestSignalCommitReplace(unittest.TestCase):
 
     def test_replace_unknown_kwarg_raises(self):
         c = SignalCommit(**self._SENTINELS)
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, "this_field_does_not_exist"):
             c.replace(this_field_does_not_exist=42)
 
 

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
@@ -1111,5 +1111,168 @@ class TestAdvisorVerdictIntegration(unittest.TestCase):
         self.assertIsInstance(res, AutorevertPattern)
 
 
+class TestSignalReplace(unittest.TestCase):
+    """Tests for Signal.replace() — `dataclasses.replace`-style API.
+
+    The two introspection-based tests below are the load-bearing ones:
+    one catches dropped fields (replace() forgetting to propagate a new
+    field); the other catches stale/typo'd kwargs.
+    """
+
+    def setUp(self) -> None:
+        self.t0 = datetime(2025, 8, 19, 12, 0, 0)
+
+    # Sentinels pinned per current Signal API — non-default values for
+    # every __init__ field. Adding a new Signal field MUST add an entry
+    # here (otherwise the introspection assertion fires) AND propagate
+    # the field inside Signal.replace (otherwise the no-changes round
+    # trip assertion fires).
+    _SENTINELS = {
+        "key": "test/foo.py::test_bar",
+        "workflow_name": "trunk",
+        "commits": [SignalCommit("sha_a", datetime(2025, 8, 19, 12, 0, 0), [])],
+        "job_base_name": "linux-jammy / test",
+        "test_module": "test_foo",
+        "source": SignalSource.JOB,
+    }
+
+    def _init_params(self):
+        import inspect
+
+        return [p for p in inspect.signature(Signal.__init__).parameters if p != "self"]
+
+    def test_sentinels_cover_all_init_fields(self):
+        """Adding a new Signal field forces this test to fail until a
+        sentinel is pinned in `_SENTINELS`. Forces the test author to
+        consider whether `Signal.replace()` propagates the new field too
+        (which the next test would otherwise catch silently as a
+        "dropped field" with an unhelpful default value).
+        """
+        missing = set(self._init_params()) - set(self._SENTINELS)
+        self.assertFalse(
+            missing,
+            (
+                f"Signal has new __init__ field(s) {sorted(missing)!r} not "
+                "pinned in _SENTINELS. Add a sentinel value AND propagate the "
+                "field inside Signal.replace, then re-run."
+            ),
+        )
+
+    def test_replace_with_no_changes_preserves_all_fields(self):
+        """`replace()` with no kwargs must return a copy where every field
+        equals the original. Catches the bug class where Signal.replace
+        forgets to forward a field — without enumerating each individually.
+        """
+        s = Signal(**self._SENTINELS)
+        out = s.replace()
+        self.assertIsNot(out, s, "replace() must return a new instance")
+        for name in self._init_params():
+            self.assertEqual(
+                getattr(out, name),
+                self._SENTINELS[name],
+                f"Signal.replace() dropped field {name!r}",
+            )
+
+    def test_replace_swaps_a_field(self):
+        """Smoke test: `replace(commits=...)` actually swaps the commit list."""
+        s = Signal(**self._SENTINELS)
+        new_commits = [SignalCommit("sha_b", self.t0, [])]
+        out = s.replace(commits=new_commits)
+        self.assertEqual(out.commits, new_commits)
+        # original untouched
+        self.assertEqual(s.commits, self._SENTINELS["commits"])
+        # other fields preserved
+        self.assertEqual(out.key, self._SENTINELS["key"])
+        self.assertEqual(out.workflow_name, self._SENTINELS["workflow_name"])
+
+    def test_replace_unknown_kwarg_raises(self):
+        """Stale or typo'd kwargs are caught at runtime."""
+        s = Signal(**self._SENTINELS)
+        with self.assertRaises(TypeError):
+            s.replace(this_field_does_not_exist=42)
+
+
+class TestSignalCommitReplace(unittest.TestCase):
+    """Tests for SignalCommit.replace() — same shape as TestSignalReplace."""
+
+    def setUp(self) -> None:
+        self.t0 = datetime(2025, 8, 19, 12, 0, 0)
+
+    # Sentinels pinned per current SignalCommit API — non-default values
+    # for every __init__ field. Adding a new SignalCommit field MUST add
+    # an entry here AND propagate the field inside SignalCommit.replace.
+    _SENTINELS = {
+        "head_sha": "sha_abc",
+        "timestamp": datetime(2025, 8, 19, 12, 0, 0),
+        "events": [
+            SignalEvent(
+                "ev_a",
+                SignalStatus.FAILURE,
+                datetime(2025, 8, 19, 12, 0, 0),
+                wf_run_id=1,
+            )
+        ],
+        "advisor_result": AIAdvisorResult(
+            verdict=AdvisorVerdict.REVERT,
+            confidence=0.9,
+            timestamp=datetime(2025, 8, 19, 12, 0, 0),
+            signal_key="k",
+        ),
+    }
+
+    def _init_params(self):
+        import inspect
+
+        return [
+            p
+            for p in inspect.signature(SignalCommit.__init__).parameters
+            if p != "self"
+        ]
+
+    def test_sentinels_cover_all_init_fields(self):
+        missing = set(self._init_params()) - set(self._SENTINELS)
+        self.assertFalse(
+            missing,
+            (
+                f"SignalCommit has new __init__ field(s) {sorted(missing)!r} not "
+                "pinned in _SENTINELS. Add a sentinel value AND propagate the "
+                "field inside SignalCommit.replace, then re-run."
+            ),
+        )
+
+    def test_replace_with_no_changes_preserves_all_fields(self):
+        c = SignalCommit(**self._SENTINELS)
+        out = c.replace()
+        self.assertIsNot(out, c)
+        # `events` may have been re-sorted by SignalCommit.__init__; compare
+        # by event names which are preserved in order for our sentinels.
+        for name in self._init_params():
+            if name == "events":
+                self.assertEqual(
+                    [e.name for e in out.events],
+                    [e.name for e in self._SENTINELS["events"]],
+                    "SignalCommit.replace() dropped 'events'",
+                )
+            else:
+                self.assertEqual(
+                    getattr(out, name),
+                    self._SENTINELS[name],
+                    f"SignalCommit.replace() dropped field {name!r}",
+                )
+
+    def test_replace_swaps_a_field(self):
+        c = SignalCommit(**self._SENTINELS)
+        new_events = [SignalEvent("ev_b", SignalStatus.SUCCESS, self.t0, wf_run_id=2)]
+        out = c.replace(events=new_events)
+        self.assertEqual([e.name for e in out.events], ["ev_b"])
+        # advisor_result preserved
+        self.assertEqual(out.advisor_result, self._SENTINELS["advisor_result"])
+
+    def test_replace_unknown_kwarg_raises(self):
+        c = SignalCommit(**self._SENTINELS)
+        with self.assertRaises(TypeError):
+            c.replace(this_field_does_not_exist=42)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds `dataclasses.replace`-style helpers for the two non-leaf classes in the Signal hierarchy and routes **every reconstruction site** through them. Eliminates the bug class where adding a new field on `Signal` or `SignalCommit` silently gets dropped because it wasn't propagated in some downstream reconstruction.

```python
new_signal = signal.replace(commits=new_commits)
new_commit = commit.replace(events=new_events)
new_commit = commit.replace(advisor_result=advisor_result)
```

The `replace(**changes)` API mirrors `dataclasses.replace` semantically: it preserves every field by default and replaces only the fields named in `changes`. Unknown kwargs raise `TypeError` so typos and stale kwargs are caught at runtime.

## Hierarchy audit (per in-thread question)

| Class | Reconstruction sites in prod | Helper added? |
|---|---|---|
| `Signal` | 3 (`_dedup_signal_events`, `_inject_pending_workflow_events`, `_attach_advisor_verdicts`) — all replace `commits` | yes — `Signal.replace(...)` |
| `SignalCommit` | **3** (`_dedup_signal_events` + `_inject_pending_workflow_events` replace `events`; `_attach_advisor_verdicts` replaces `advisor_result`) | yes — `SignalCommit.replace(...)` |
| `SignalEvent` | 0 — always fresh-constructed from `JobRow`/`TestRow`/synthetic-pending data | n/a |
| `AIAdvisorResult` | 0 in prod — frozen dataclass, `dataclasses.replace` works for free if ever needed | n/a |
| `AutorevertPattern`, `RestartCommits`, `Ineligible` | dataclasses, single fresh construction per outcome | n/a |

### Latent-bug fix on SignalCommit

Two of the three SignalCommit reconstructions (`_dedup_signal_events`, `_inject_pending_workflow_events`) were dropping `advisor_result`. Currently a no-op — `_attach_advisor_verdicts` runs last in `extract()`, so `advisor_result` is always `None` at dedup/inject time — but a future pipeline-order change (or any new path that produces a `SignalCommit` with `advisor_result` set and pipes it through dedup/inject) would have silently lost the verdict. The helper structurally fixes this.

### Why earlier-this-PR design (`replace_commits` / `replace_events`) was wrong

The previous iteration of this PR added two specific helpers per replaceable field (`replace_commits` for Signal, `replace_events` for SignalCommit). On review, the `_attach_advisor_verdicts` site was identified as semantically-equivalent to `dataclasses.replace` too — it replaces `advisor_result` while preserving everything else. A field-specific helper would have required `replace_advisor_result`, then a third helper if SignalCommit ever needed to replace `head_sha` or `timestamp`, etc. The unified `replace(**changes)` API covers any field-replacement pattern with one method per class.

## Tests

Each class has the same test shape:

- `test_sentinels_cover_all_init_fields` — `inspect.signature` over the `__init__` parameters; the test fails if a new field isn't pinned in `_SENTINELS`. Forces the test author to update the helper at the same time.
- `test_replace_with_no_changes_preserves_all_fields` — calls `obj.replace()` and asserts every field equals the original. Catches dropped fields generically without enumerating each individually.
- `test_replace_swaps_a_field` — smoke test that `replace(field=...)` actually swaps.
- `test_replace_unknown_kwarg_raises` — `replace(typo=42)` raises `TypeError`. Catches stale kwargs.

All 46 tests in `test_signal.py` pass locally (under devserver Python — modules requiring `boto3`/`PyGithub`/etc. are deferred to CI).

## Why option 2 (manual helper + introspection test) over option 1 (auto-replace via introspection inside the helper)

An auto-replace `replace(**changes)` could iterate `inspect.signature(...).parameters` and copy each via `getattr(self, name)` — zero maintenance for new fields. But that couples on "every `__init__` param has a matching `self.<name>` attribute"; a future refactor that diverges those names would break the helper silently rather than at review time. Manual + introspection-test keeps the helper as plain explicit code (six `changes.pop(...)` lines for Signal) and makes the test fail loudly when a field is added without propagation.

## Diff

`+225/-48` across 3 files. No behavior change.

## Test plan

- [x] `pytorch_auto_revert.tests.test_signal` runs green locally (46 tests)
- [x] CI runs the full suite including the integration tests under `test_signal_dedup`, `test_signal_actions`, etc.
- [x] Manual: confirm each introspection test self-fails when a hypothetical new field is added without a sentinel
- [ ] After this lands and FF-merges, rebase #8031 on top — three reconstruction sites use the helper, per-site propagation tests are dropped