### PR TITLE
macos_job: forward default-packages input to setup-miniconda

### DIFF
--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -80,6 +80,16 @@ on:
         required: false
         type: string
         default: "3.9"
+      default-packages:
+        description: |
+          Default packages to pre-install in the conda env. Forwarded to
+          setup-miniconda. Set to "" to skip pre-installing the default
+          packages entirely (useful when the caller installs its own conda
+          env from a single channel and wants to avoid mixed-channel
+          solver conflicts with the defaults-channel pre-population).
+        required: false
+        type: string
+        default: "cmake=3.22 ninja=1.10 pkg-config=0.29 wheel=0.37"
 
 jobs:
   job:
@@ -109,6 +119,7 @@ jobs:
         uses: ./test-infra/.github/actions/setup-miniconda
         with:
           python-version: ${{ inputs.python-version }}
+          default-packages: ${{ inputs.default-packages }}
 
       - name: Checkout repository (${{ inputs.repository || github.repository }}@${{ inputs.ref }})
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
The setup-miniconda composite action already accepts a default-packages input that controls which packages get pre-installed in the conda env it creates. macos_job currently does not forward this input, so callers have no way to opt out of the hardcoded default `cmake=3.22 ninja=1.10 pkg-config=0.29 wheel=0.37` from the anaconda defaults channel.

This becomes a problem for callers (notably pytorch/executorch) that install their own conda env from conda-forge: the pre-populated defaults-channel packages and the caller's conda-forge packages have disagreeing transitive dep version pins (e.g. zlib=1.2.13 from defaults vs libzlib>=1.3.1 required by conda-forge cmake=3.31.2), and libmamba fails the solve when the two have to be reconciled in a single env.

Plumb the input through with the same default the action already uses, so existing behavior is preserved for callers that don't pass anything. Callers that want a clean, single-channel env can pass `default-packages: ""`.

Authored with Claude Code.