### PR TITLE
Refresh ciflow pending comment when a new commit re-gates approval

### DIFF
--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -158,6 +158,18 @@ async function handleSyncEvent(
     );
     // Don't remove labels -- they represent user intent.
     // Tags simply won't be created until workflows are approved.
+    // Refresh the pending comment so it doesn't show a stale "CI has now been
+    // triggered" message after a new commit re-gates approval.
+    const ciflowLabels = payload.pull_request.labels
+      .map((l) => l.name)
+      .filter(isCIFlowLabel);
+    if (ciflowLabels.length > 0) {
+      await upsertPendingComment(
+        context,
+        payload.pull_request.number,
+        ciflowLabels
+      );
+    }
     return;
   }
 

--- a/torchci/test/ciflow-push-trigger.test.ts
+++ b/torchci/test/ciflow-push-trigger.test.ts
@@ -279,6 +279,7 @@ describe("Push trigger integration tests", () => {
 
   test("synchronization of PR without permissions skips tag sync but keeps labels", async () => {
     const payload = require("./fixtures/push-trigger/pull_request.synchronize");
+    const prNum = payload.pull_request.number;
     mockApprovedWorkflowRuns(
       payload.repository.full_name,
       payload.pull_request.head.sha,
@@ -290,7 +291,21 @@ describe("Push trigger integration tests", () => {
       "read"
     );
     // No label removal or tag creation should happen -- labels are kept,
-    // tags are simply not created until workflows are approved.
+    // tags are simply not created until workflows are approved. The pending
+    // comment is refreshed so a previous "CI has now been triggered" message
+    // doesn't linger after a new commit re-gates approval.
+    const pendingCommentId = 99;
+    mockListComments(payload.repository.full_name, prNum, [
+      {
+        id: pendingCommentId,
+        body: "<!-- ciflow-pending -->\n~~Workflows were awaiting approval.~~ CI has now been triggered for the ciflow labels on this PR.",
+      },
+    ]);
+    mockUpdateComment(
+      payload.repository.full_name,
+      pendingCommentId,
+      "awaiting approval"
+    );
     await probot.receive({ name: "pull_request", id: "123", payload });
   });
 


### PR DESCRIPTION
## Summary
- For first-time-contributor PRs, every push re-gates CI on maintainer approval. `handleSyncEvent` returned early when `canRunWorkflows` was false and never touched the existing pending comment, so the previous "~~Workflows were awaiting approval.~~ CI has now been triggered for the ciflow labels on this PR." message lingered after the new HEAD started awaiting approval again.
- Observed on https://github.com/pytorch/pytorch/pull/182067, where the user pushed a merge commit but the bot's pending comment kept claiming CI had been triggered.
- Fix: when bailing out of `handleSyncEvent` because the author can't run workflows, re-`upsertPendingComment` for the PR's current ciflow labels so the comment flips back to the pending wording.

## Test plan
- [x] `yarn jest --watchman=false test/ciflow-push-trigger.test.ts` (existing tests pass; the "synchronization of PR without permissions" test was tightened to also assert the comment refresh)
- [x] `yarn format --check`