### PR TITLE
HUD: deprioritize skipped jobs when merging OSDC variants

### DIFF
--- a/torchci/lib/fetchHud.ts
+++ b/torchci/lib/fetchHud.ts
@@ -1,3 +1,4 @@
+import { JobStatus } from "components/job/GroupJobConclusion";
 import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
 import _ from "lodash";
 import { queryClickhouseSaved } from "./clickhouse";
@@ -137,7 +138,20 @@ export default async function fetchHud(
       // Q: How can there be more than one job with the same name for a given sha?
       // A: Periodic builds can be scheduled multiple times for one sha. In those
       // cases, we want the most recent job to be shown.
-      if (job.id! > existingJob.id!) {
+      // Exception: a `skipped` conclusion has lower priority than any other
+      // status, so a real result always wins over a skip even if the skipped
+      // job has a larger id. This matters for the OSDC merge, where the
+      // unselected variant reports as skipped and would otherwise mask a real
+      // failure on the selected variant.
+      const existingSkipped = existingJob.conclusion === JobStatus.Skipped;
+      const jobSkipped = job.conclusion === JobStatus.Skipped;
+      const replace =
+        existingSkipped && !jobSkipped
+          ? true
+          : !existingSkipped && jobSkipped
+          ? false
+          : job.id! > existingJob.id!;
+      if (replace) {
         jobsBySha[job.sha!][key] = job;
         jobsBySha[job.sha!][key].failedPreviousRun =
           existingJob.failedPreviousRun || isFailure(existingJob.conclusion);


### PR DESCRIPTION
- When `Merge OSDC/non-OSDC` is enabled in the HUD, two variants of the same logical job (EC2 and OSDC) collapse into a single column. The previous merge logic kept the job with the larger GitHub Actions `id`, so a passing variant whose `id` happened to be larger could mask a failing counterpart. In particular, if the OSDC variant was the one that actually ran (failure) but the EC2 variant was `skipped` with a larger id, the failure was hidden.
- Treat `skipped` as the lowest-priority conclusion: a real result always wins over a skip, regardless of `id`. Fall back to the existing most-recent-by-id rule when neither side is skipped, so the periodic-rerun behavior that motivated the original logic is preserved.
