### PR TITLE
[autorevert] dispatch untargeted signals without tests-to-include filter

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
@@ -335,6 +335,20 @@ class SignalActionProcessor:
         for (wf, sha), sources in restart_map.items():
             jobs = [_derive_job_filter(src.job_base_name) for src in sources]
 
+            # If any contributing signal in the group is untargeted at the
+            # test-module level — i.e. a JOB-track signal (test_module always
+            # None), or a TEST-track signal whose CH row had empty `file` so
+            # signal_extraction couldn't derive a module — drop the
+            # tests-to-include filter for the whole group. Otherwise the
+            # narrowing contributed by sibling TEST signals would silently
+            # starve the untargeted signal's "full job re-run" intent.
+            has_untargeted = any(src.test_module is None for src in sources)
+            tests_to_include = (
+                frozenset()
+                if has_untargeted
+                else frozenset(src.test_module for src in sources)
+            )
+
             groups.append(
                 ActionGroup(
                     type="restart",
@@ -342,9 +356,7 @@ class SignalActionProcessor:
                     workflow_target=wf,
                     sources=sources,
                     jobs_to_include=frozenset(j for j in jobs if j is not None),
-                    tests_to_include=frozenset(
-                        src.test_module for src in sources if src.test_module
-                    ),
+                    tests_to_include=tests_to_include,
                 )
             )
         return groups

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
@@ -520,9 +520,18 @@ class SignalExtractor:
                 )
 
             if has_any_events:
-                # Extract test module from test_id (format: "file.py::test_name")
-                # Result: "file" or "path/to/file" without .py extension
-                test_module = test_id.split("::")[0].replace(".py", "")
+                # Extract test module from test_id (format: "file.py::test_name").
+                # When the CH row's `file` column is empty, TestRow.test_id falls
+                # back to the bare `name` (no `::`) and we can't derive a path
+                # that `run_test.py --include` would accept. Mark such signals
+                # as untargeted (test_module=None) so the action layer dispatches
+                # them without a tests-to-include filter (job-style restart),
+                # rather than emitting a bogus method-named module that argparse
+                # would reject with "invalid choice".
+                if "::" in test_id:
+                    test_module = test_id.split("::")[0].replace(".py", "")
+                else:
+                    test_module = None
 
                 signals.append(
                     Signal(

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_actions.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_actions.py
@@ -1271,5 +1271,169 @@ class TestAttachAdvisorVerdicts(unittest.TestCase):
         )
 
 
+class TestGroupActionsTestsToInclude(unittest.TestCase):
+    """Coalescing rules around `tests_to_include` in `group_actions`.
+
+    Covers the empty-`file` CH-row class (T262...) and the JOB+TEST mixed
+    coalescing case where a JOB-track signal's "full job re-run" intent
+    must not be silently narrowed by sibling TEST signals.
+    """
+
+    def _signal(
+        self,
+        *,
+        key: str,
+        commit: str,
+        source,
+        job_base_name: str,
+        test_module=None,
+    ):
+        from pytorch_auto_revert.signal import (
+            Signal,
+            SignalCommit,
+            SignalEvent,
+            SignalStatus,
+        )
+
+        t0 = datetime(2025, 8, 19, 12, 0, 0)
+        c = SignalCommit(
+            commit,
+            t0,
+            [SignalEvent("j", SignalStatus.FAILURE, t0, wf_run_id=1, job_id=1)],
+        )
+        return Signal(
+            key=key,
+            workflow_name="trunk",
+            commits=[c],
+            job_base_name=job_base_name,
+            test_module=test_module,
+            source=source,
+        )
+
+    def _make_restart(self, commit: str):
+        from pytorch_auto_revert.signal import RestartCommits
+
+        return RestartCommits(commit_shas={commit})
+
+    def test_only_test_signals_with_modules_keeps_test_filter(self):
+        from pytorch_auto_revert.signal import SignalSource
+
+        proc = SignalActionProcessor()
+        s1 = self._signal(
+            key="test_jit.py::test_a",
+            commit="abc",
+            source=SignalSource.TEST,
+            job_base_name="linux-jammy-py3.10-clang18 / test",
+            test_module="test_jit",
+        )
+        s2 = self._signal(
+            key="test_jit.py::test_b",
+            commit="abc",
+            source=SignalSource.TEST,
+            job_base_name="linux-jammy-py3.10-clang18 / test",
+            test_module="test_jit",
+        )
+        groups = proc.group_actions(
+            [(s1, self._make_restart("abc")), (s2, self._make_restart("abc"))]
+        )
+        restarts = [g for g in groups if g.type == "restart"]
+        self.assertEqual(len(restarts), 1)
+        g = restarts[0]
+        self.assertEqual(g.tests_to_include, frozenset({"test_jit"}))
+        self.assertEqual(g.jobs_to_include, frozenset({"linux-jammy-py3.10-clang18"}))
+
+    def test_test_signal_with_no_module_drops_test_filter(self):
+        # TEST signal whose CH row had empty `file` (signal_extraction left
+        # test_module=None). Group must dispatch with no tests-to-include —
+        # no run_test.py-recognized module to filter on.
+        from pytorch_auto_revert.signal import SignalSource
+
+        proc = SignalActionProcessor()
+        s = self._signal(
+            key="test_partial_eval_graph_conv",
+            commit="abc",
+            source=SignalSource.TEST,
+            job_base_name="linux-jammy-py3.10-clang18 / test",
+            test_module=None,
+        )
+        groups = proc.group_actions([(s, self._make_restart("abc"))])
+        restarts = [g for g in groups if g.type == "restart"]
+        self.assertEqual(len(restarts), 1)
+        self.assertEqual(restarts[0].tests_to_include, frozenset())
+        self.assertEqual(
+            restarts[0].jobs_to_include,
+            frozenset({"linux-jammy-py3.10-clang18"}),
+        )
+
+    def test_mixed_test_module_and_no_module_drops_test_filter(self):
+        # When some sibling TEST signals carry a module and others don't
+        # (some CH rows had empty `file`, others didn't — the original
+        # bug shape), drop the test filter for the whole group rather
+        # than narrowing only the targetable ones and starving the rest.
+        from pytorch_auto_revert.signal import SignalSource
+
+        proc = SignalActionProcessor()
+        s_targeted = self._signal(
+            key="test_jit.py::test_a",
+            commit="abc",
+            source=SignalSource.TEST,
+            job_base_name="linux-jammy-py3.10-clang18 / test",
+            test_module="test_jit",
+        )
+        s_untargeted = self._signal(
+            key="test_partial_eval_graph_conv",
+            commit="abc",
+            source=SignalSource.TEST,
+            job_base_name="linux-jammy-py3.10-clang18 / test",
+            test_module=None,
+        )
+        groups = proc.group_actions(
+            [
+                (s_targeted, self._make_restart("abc")),
+                (s_untargeted, self._make_restart("abc")),
+            ]
+        )
+        restarts = [g for g in groups if g.type == "restart"]
+        self.assertEqual(len(restarts), 1)
+        self.assertEqual(restarts[0].tests_to_include, frozenset())
+
+    def test_job_track_and_test_track_same_workflow_drops_test_filter(self):
+        # Mixed JOB-track + TEST-track signals on the same (workflow, sha).
+        # JOB signal wants the entire job re-run; coalescing previously
+        # narrowed the dispatch to TEST signals' modules, throwing the JOB
+        # signal's intent away. New rule: any untargeted source → empty
+        # tests_to_include.
+        from pytorch_auto_revert.signal import SignalSource
+
+        proc = SignalActionProcessor()
+        s_job = self._signal(
+            key="linux-jammy-py3.10-clang18 / build",
+            commit="abc",
+            source=SignalSource.JOB,
+            job_base_name="linux-jammy-py3.10-clang18 / build",
+            test_module=None,
+        )
+        s_test = self._signal(
+            key="test_jit.py::test_a",
+            commit="abc",
+            source=SignalSource.TEST,
+            job_base_name="linux-jammy-py3.10-clang18 / test",
+            test_module="test_jit",
+        )
+        groups = proc.group_actions(
+            [(s_job, self._make_restart("abc")), (s_test, self._make_restart("abc"))]
+        )
+        restarts = [g for g in groups if g.type == "restart"]
+        self.assertEqual(len(restarts), 1)
+        g = restarts[0]
+        self.assertEqual(g.tests_to_include, frozenset())
+        self.assertEqual(
+            g.jobs_to_include,
+            frozenset(
+                {"linux-jammy-py3.10-clang18"}
+            ),  # both job_base_names normalize to same display name
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
@@ -1062,6 +1062,71 @@ class TestSignalExtraction(unittest.TestCase):
         self.assertEqual(c2.advisor_result.verdict.value, "garbage")
         self.assertEqual(c2.advisor_result.signal_key, test_key)
 
+    def test_test_signal_with_empty_file_has_no_test_module(self):
+        # When tests.all_test_runs has empty `file` for a row, TestRow.test_id
+        # falls back to the bare `name` (no `::`). signal_extraction must mark
+        # the resulting Signal as untargeted (test_module=None) instead of
+        # emitting a bogus method-named module that run_test.py --include
+        # would later reject with "invalid choice".
+        jobs = [
+            J(
+                sha="C1",
+                run=900,
+                job=900,
+                attempt=1,
+                started_at=ts(self.t0, 1),
+                conclusion="failure",
+                rule="pytest failure",
+            )
+        ]
+        tests = [
+            T(
+                job=900,
+                run=900,
+                attempt=1,
+                file="",  # CH row with no file path — primary failure mode
+                name="test_partial_eval_graph_conv",
+                failure_runs=1,
+                success_runs=0,
+            )
+        ]
+        signals = self._extract(jobs, tests)
+        sig = self._find_test_signal(signals, "trunk", "test_partial_eval_graph_conv")
+        self.assertIsNotNone(sig)
+        self.assertIsNone(sig.test_module)
+
+    def test_test_signal_with_populated_file_has_test_module(self):
+        # Sanity: the normal `file::name` path still produces a usable
+        # test_module (`test_jit` from `test_jit.py::...`).
+        jobs = [
+            J(
+                sha="C1",
+                run=901,
+                job=901,
+                attempt=1,
+                started_at=ts(self.t0, 1),
+                conclusion="failure",
+                rule="pytest failure",
+            )
+        ]
+        tests = [
+            T(
+                job=901,
+                run=901,
+                attempt=1,
+                file="test_jit.py",
+                name="test_partial_eval_graph_conv",
+                failure_runs=1,
+                success_runs=0,
+            )
+        ]
+        signals = self._extract(jobs, tests)
+        sig = self._find_test_signal(
+            signals, "trunk", "test_jit.py::test_partial_eval_graph_conv"
+        )
+        self.assertIsNotNone(sig)
+        self.assertEqual(sig.test_module, "test_jit")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Two related fixes to the autorevert lambda's `tests-to-include` dispatch path. Both surface the same anti-pattern: a signal that *cannot* be narrowed to a `run_test.py`-recognized module should be dispatched as a "re-run the whole job(s)" restart, not as a TEST-narrow restart.

## Bug 1 — empty-`file` rows in `tests.all_test_runs` produce bogus `tests-to-include` entries

`TestRow.test_id` (`signal_extraction_types.py:138-141`) builds the test key as `f"{file}::{name}" if file else name`. When the CH row has empty `file`, the test key falls back to just the bare `name` (no `::`).

`signal_extraction.py` then derived `test_module` from the key:

```python
test_module = test_id.split("::")[0].replace(".py", "")
```

With no `::`, `test_module` becomes the bare method name (e.g. `test_partial_eval_graph_conv`). The lambda forwards that into `workflow_dispatch.tests-to-include`, and `pytorch/pytorch:test/run_test.py:144` `TestChoices.__contains__` rejects it with:

```
argument -i/--include: invalid choice: 'test_partial_eval_graph_conv'
```

The dispatched shard fails before running any tests, surfacing as 15-25 spurious `test-osdc` failures per affected commit on HUD trunk. Tracking: pytorch/pytorch-gha-infra#1137.

Verified primary-source: `tests.all_test_runs` for `name='test_partial_eval_graph_conv'` over the last 2 days returns three distinct `file` values: `'test_jit.py'`, `'test_jit_legacy.py'`, `''`.

Concrete instance — pytorch/pytorch run [25294380825](https://github.com/pytorch/pytorch/actions/runs/25294380825) (workflow_dispatch by `pytorch-auto-revert[bot]`, 2026-05-03 23:51 UTC):

```
jobs-to-include: linux-jammy-py3.10-clang18
tests-to-include: test_jit test_freeze_module_detach_gradient test_partial_eval_graph_conv test_freeze_interface_swapping_two_methods test_partial_eval_stitching test_returning_input_symbolic_shapes
```

`test_jit` is the actual file name; the other five are method names that leaked through the empty-`file` fallback. The `default` / `crossref` / `dynamo_wrapped` shards on this run failed at argparse; the `openreg` / `einops` shards were green only because their `test.sh` paths bypass `$INCLUDE_CLAUSE` entirely.

## Bug 2 — JOB+TEST signals on the same (workflow, commit) silently lose JOB intent

`signal_actions.py::group_actions` keys the restart map on `(workflow_name, commit_sha)`. ALL contributing signals — JOB-track and TEST-track — are merged into a single `ActionGroup` with the union of `jobs_to_include` and `tests_to_include`. A JOB-track signal (`test_module=None`, intent = "re-run the whole job") coexisting with a TEST-track signal in the same group becomes a TEST-narrow restart: only the test modules contributed by the TEST signals run, and the JOB signal's full-job-restart intent is silently thrown away.

This was a latent bug independent of Bug 1 — surfaced while auditing the `tests-to-include` path.

## Fix

1. `signal_extraction.py`: when `test_id` lacks `::`, set `test_module=None`. The signal stays alive but is marked untargeted.
2. `signal_actions.py::group_actions`: if any source in the group has `test_module is None`, dispatch with `tests_to_include=frozenset()` for the whole group.

JOB-track signals (always `test_module=None`) and TEST-track signals with no extractable module both reach the new branch, so they get identical "re-run the whole job(s)" treatment instead of being narrowed by sibling targetable TEST signals. `workflow_checker.py:165` already drops the `tests-to-include` input when the frozenset is empty — no change needed there.

## Test plan

- [x] `tests/test_signal_extraction.py` (2 new): empty `file` → Signal with `test_module=None`; populated `file` → existing module path.
- [x] `tests/test_signal_actions.py` (4 new in `TestGroupActionsTestsToInclude`): only-targeted-tests keeps filter; TEST-with-no-module drops filter; mixed targeted+untargeted TEST drops filter; JOB+TEST same-(wf,sha) drops filter.
- [x] `make test` — all 146 tests pass (1 skipped due to no `GITHUB_TOKEN`).
- [x] `ruff format --check` + `ruff check` clean.

## Audit follow-up (not in this PR)

Worth checking which test uploader writes empty-`file` rows to `tests.all_test_runs` — likely a partial-export issue from a specific reporter — to fix the data leak at source. Open question carried in `iz2-memory:core/knowledge/autorevert-bot-retry.md`.