### PR TITLE
Bump brace-expansion to fix GHSA-f886-m6hf-6m8v in /.github/actions/upload-artifact-s3

### DIFF
--- a/.github/actions/upload-artifact-s3/__tests__/brace-expansion.test.ts
+++ b/.github/actions/upload-artifact-s3/__tests__/brace-expansion.test.ts
@@ -3,38 +3,44 @@ import {braceExpand} from 'minimatch'
 
 // Regression tests for GHSA-f886-m6hf-6m8v / CVE-2026-33750 in brace-expansion.
 //
-// brace-expansion is reachable from this action at runtime via
-//   @actions/glob -> minimatch -> brace-expansion
-// and is bundled into dist/upload/index.js by @vercel/ncc. We exercise it
-// here via minimatch.braceExpand, which is the same entrypoint @actions/glob
-// uses internally when expanding a pattern.
+// minimatch is a direct runtime dep of this action and pulls in
+// brace-expansion 2.x. The vendored copy bundled into dist/upload/index.js
+// (via @actions/glob -> minimatch -> brace-expansion 1.x) carries the
+// same patches; check-dist guards lockfile/dist drift.
 //
 // Vulnerable versions: brace-expansion <=1.1.13 (1.x) and <=2.0.1 (2.x).
 // Patched versions:    1.1.14 / 2.1.0.
 //
 // On vulnerable versions both inputs below either hung indefinitely
-// (zero-step numeric range) or exhibited catastrophic regex backtracking
-// (dense-comma post). On patched versions both return promptly.
+// (zero-step numeric range) or quadratically backtracked the post-brace
+// regex (dense-comma post). On patched versions both return promptly with
+// the asserted output.
 
 const TIME_BUDGET_MS = 1000
 
 describe('brace-expansion (GHSA-f886-m6hf-6m8v) regression', () => {
-  it('zero-step numeric range terminates with a finite result', () => {
+  it('zero-step numeric range expands to a finite, deterministic list', () => {
     // Vulnerable versions infinite-looped on `{N..M..0}` because the step
-    // was used as-is. Patch clamps via Math.max(Math.abs(step), 1).
+    // was used as-is. Patch clamps via Math.max(Math.abs(step), 1) so the
+    // step degrades to 1 and the range expands deterministically.
     const start = Date.now()
     const out = braceExpand('{1..3..0}')
     expect(Date.now() - start).toBeLessThan(TIME_BUDGET_MS)
-    expect(out.length).toBeGreaterThan(0)
+    expect(out).toEqual(['1', '2', '3'])
   })
 
   it('dense-comma malformed input does not exhibit ReDoS', () => {
-    // Vulnerable versions matched the post-brace tail against /,.*\}/, which
-    // catastrophically backtracks on a long run of commas with no closing
-    // brace. Patch tightens the regex to /,(?!,).*\}/.
-    const dense = ','.repeat(60)
+    // Vulnerable versions matched the post-brace tail against /,.*\}/,
+    // which quadratically backtracks on a long run of commas with no
+    // closing brace. Patch tightens the regex to /,(?!,).*\}/. With no
+    // closing brace anywhere the input is malformed and brace-expansion
+    // returns it unchanged; we assert that to lock in correctness as
+    // well as termination.
+    const dense = ','.repeat(10_000)
+    const input = `{a}${dense}`
     const start = Date.now()
-    braceExpand(`{a}${dense}`)
+    const out = braceExpand(input)
     expect(Date.now() - start).toBeLessThan(TIME_BUDGET_MS)
+    expect(out).toEqual([input])
   })
 })

--- a/.github/actions/upload-artifact-s3/__tests__/brace-expansion.test.ts
+++ b/.github/actions/upload-artifact-s3/__tests__/brace-expansion.test.ts
@@ -1,0 +1,40 @@
+import {describe, expect, it} from '@jest/globals'
+import {braceExpand} from 'minimatch'
+
+// Regression tests for GHSA-f886-m6hf-6m8v / CVE-2026-33750 in brace-expansion.
+//
+// brace-expansion is reachable from this action at runtime via
+//   @actions/glob -> minimatch -> brace-expansion
+// and is bundled into dist/upload/index.js by @vercel/ncc. We exercise it
+// here via minimatch.braceExpand, which is the same entrypoint @actions/glob
+// uses internally when expanding a pattern.
+//
+// Vulnerable versions: brace-expansion <=1.1.13 (1.x) and <=2.0.1 (2.x).
+// Patched versions:    1.1.14 / 2.1.0.
+//
+// On vulnerable versions both inputs below either hung indefinitely
+// (zero-step numeric range) or exhibited catastrophic regex backtracking
+// (dense-comma post). On patched versions both return promptly.
+
+const TIME_BUDGET_MS = 1000
+
+describe('brace-expansion (GHSA-f886-m6hf-6m8v) regression', () => {
+  it('zero-step numeric range terminates with a finite result', () => {
+    // Vulnerable versions infinite-looped on `{N..M..0}` because the step
+    // was used as-is. Patch clamps via Math.max(Math.abs(step), 1).
+    const start = Date.now()
+    const out = braceExpand('{1..3..0}')
+    expect(Date.now() - start).toBeLessThan(TIME_BUDGET_MS)
+    expect(out.length).toBeGreaterThan(0)
+  })
+
+  it('dense-comma malformed input does not exhibit ReDoS', () => {
+    // Vulnerable versions matched the post-brace tail against /,.*\}/, which
+    // catastrophically backtracks on a long run of commas with no closing
+    // brace. Patch tightens the regex to /,(?!,).*\}/.
+    const dense = ','.repeat(60)
+    const start = Date.now()
+    braceExpand(`{a}${dense}`)
+    expect(Date.now() - start).toBeLessThan(TIME_BUDGET_MS)
+  })
+})

--- a/.github/actions/upload-artifact-s3/dist/upload/index.js
+++ b/.github/actions/upload-artifact-s3/dist/upload/index.js
@@ -5514,9 +5514,12 @@ function parseCommaParts(str) {
   return parts;
 }
 
-function expandTop(str) {
+function expandTop(str, options) {
   if (!str)
     return [];
+
+  options = options || {};
+  var max = options.max == null ? Infinity : options.max;
 
   // I don't know why Bash 4.3 does this, but it does.
   // Anything starting with {} will have the first two bytes preserved
@@ -5528,7 +5531,7 @@ function expandTop(str) {
     str = '\\{\\}' + str.substr(2);
   }
 
-  return expand(escapeBraces(str), true).map(unescapeBraces);
+  return expand(escapeBraces(str), max, true).map(unescapeBraces);
 }
 
 function identity(e) {
@@ -5549,7 +5552,7 @@ function gte(i, y) {
   return i >= y;
 }
 
-function expand(str, isTop) {
+function expand(str, max, isTop) {
   var expansions = [];
 
   var m = balanced('{', '}', str);
@@ -5561,9 +5564,9 @@ function expand(str, isTop) {
   var isOptions = m.body.indexOf(',') >= 0;
   if (!isSequence && !isOptions) {
     // {a},b}
-    if (m.post.match(/,.*\}/)) {
+    if (m.post.match(/,(?!,).*\}/)) {
       str = m.pre + '{' + m.body + escClose + m.post;
-      return expand(str);
+      return expand(str, max, true);
     }
     return [str];
   }
@@ -5575,10 +5578,10 @@ function expand(str, isTop) {
     n = parseCommaParts(m.body);
     if (n.length === 1) {
       // x{{a,b}}y ==> x{a}y x{b}y
-      n = expand(n[0], false).map(embrace);
+      n = expand(n[0], max, false).map(embrace);
       if (n.length === 1) {
         var post = m.post.length
-          ? expand(m.post, false)
+          ? expand(m.post, max, false)
           : [''];
         return post.map(function(p) {
           return m.pre + n[0] + p;
@@ -5593,7 +5596,7 @@ function expand(str, isTop) {
   // no need to expand pre, since it is guaranteed to be free of brace-sets
   var pre = m.pre;
   var post = m.post.length
-    ? expand(m.post, false)
+    ? expand(m.post, max, false)
     : [''];
 
   var N;
@@ -5603,7 +5606,7 @@ function expand(str, isTop) {
     var y = numeric(n[1]);
     var width = Math.max(n[0].length, n[1].length)
     var incr = n.length == 3
-      ? Math.abs(numeric(n[2]))
+      ? Math.max(Math.abs(numeric(n[2])), 1)
       : 1;
     var test = lte;
     var reverse = y < x;
@@ -5637,11 +5640,11 @@ function expand(str, isTop) {
       N.push(c);
     }
   } else {
-    N = concatMap(n, function(el) { return expand(el, false) });
+    N = concatMap(n, function(el) { return expand(el, max, false) });
   }
 
   for (var j = 0; j < N.length; j++) {
-    for (var k = 0; k < post.length; k++) {
+    for (var k = 0; k < post.length && expansions.length < max; k++) {
       var expansion = pre + N[j] + post[k];
       if (!isTop || isSequence || expansion)
         expansions.push(expansion);
@@ -5650,7 +5653,6 @@ function expand(str, isTop) {
 
   return expansions;
 }
-
 
 
 /***/ }),

--- a/.github/actions/upload-artifact-s3/package-lock.json
+++ b/.github/actions/upload-artifact-s3/package-lock.json
@@ -105,9 +105,9 @@
       }
     },
     "node_modules/@actions/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2838,9 +2838,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2888,9 +2888,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3216,9 +3216,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5222,9 +5222,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -6060,9 +6060,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6160,9 +6160,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6276,9 +6276,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7557,9 +7557,9 @@
       }
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7879,9 +7879,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -9066,9 +9066,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -9514,9 +9514,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -10121,9 +10121,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -12045,9 +12045,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -12088,9 +12088,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -12343,9 +12343,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -13822,9 +13822,9 @@
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "requires": {
         "balanced-match": "^1.0.0"
       }
@@ -14315,9 +14315,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -14512,9 +14512,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -14587,9 +14587,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -15519,9 +15519,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -15777,9 +15777,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -16661,9 +16661,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -17000,9 +17000,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",


### PR DESCRIPTION
## Summary

Patches the regex-DoS in `brace-expansion` ([GHSA-f886-m6hf-6m8v](https://github.com/advisories/GHSA-f886-m6hf-6m8v) / CVE-2026-33750) inside `.github/actions/upload-artifact-s3` by upgrading the transitive `brace-expansion` dependency:

- `1.1.11` → `1.1.14`
- `2.0.1`  → `2.1.0`

`brace-expansion` reaches this action's runtime through `@actions/glob` → `minimatch` → `brace-expansion` and is inlined into the action's bundled entrypoint by `@vercel/ncc`.

## Changes

1. **`package-lock.json`** — pins both transitive instances of `brace-expansion` to the patched releases. No `package.json` edits; nothing in this action's tree depends on `brace-expansion` directly.
2. **`dist/upload/index.js`** — regenerated with `npm run release` (`@vercel/ncc`). The bundled `brace-expansion` source now contains the upstream patches:
    - `expand()` accepts a `max` option and stops emitting expansions once that bound is reached.
    - The fast-path post-brace probe regex changes from `/,.*\}/` to `/,(?!,).*\}/`, eliminating quadratic backtracking on dense-comma inputs.
    - Numeric brace step is clamped via `Math.max(Math.abs(step), 1)`, so `{N..M..0}` no longer infinite-loops.
3. **`__tests__/brace-expansion.test.ts`** — two regression tests against `minimatch.braceExpand` covering the two patched code paths (zero-step `{1..3..0}` and dense-comma malformed input). The tests run against the brace-expansion 2.x copy that ships with the action's direct `minimatch` dep; the 1.x copy bundled into `dist/upload/index.js` carries the same upstream patches and is guarded against lockfile/dist drift by the existing `check-dist` CI job.

Closes T261666678.