### PR TITLE
Fix pkg-helpers conda env: explicitly install pip (#8035)

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -113,7 +113,7 @@ runs:
           conda create \
             --yes --quiet \
             --prefix "${CONDA_ENV}" \
-            "python=3.9"
+            "python=3.9" pip
           CONDA_ENV="${CONDA_ENV}"
           CONDA_RUN="conda run --no-capture-output -p ${CONDA_ENV}"
           ${CONDA_RUN} python -m pip install ${GITHUB_WORKSPACE}/test-infra/tools/pkg-helpers


### PR DESCRIPTION
Conda 25.x (now resolved as miniconda `latest`, after #7753 upgraded conda to 25.3.0) no longer installs `pip` by default when only `python=X.Y` is requested in `conda create`, which breaks the `pytorch_pkg_helpers` step in `setup-binary-builds/action.yml`, which immediately calls `python -m pip install ...` against the new env and fails with `No module named pip` (e.g. observed in torchcomms wheel builds).
Fix: add `pip` explicitly to the `conda create` invocation so the env is usable regardless of conda's default-package behavior.