### PR TITLE
[validation] Add pip to conda install

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -238,7 +238,7 @@ fi
 # Setup conda environment
 update_conda
 get_python_config
-conda create -y -n "${ENV_NAME}" python="${PYTHON_V}" ${CONDA_EXTRA_PARAM}
+conda create -y -n "${ENV_NAME}" python="${PYTHON_V}" pip ${CONDA_EXTRA_PARAM}
 conda activate "${ENV_NAME}"
 
 # Save original PATH for macos-arm64 workaround


### PR DESCRIPTION
Fixes validation failures due to missing pip: https://github.com/pytorch/test-infra/actions/runs/25382074768/job/74433006895