### PR TITLE
DrCI: classify failures with no merge-base signal as Unknown

### DIFF
--- a/torchci/clickhouse_queries/commit_job_names/params.json
+++ b/torchci/clickhouse_queries/commit_job_names/params.json
@@ -1,0 +1,13 @@
+{
+  "params": {
+    "shas": "String"
+  },
+  "tests": [
+    {
+      "shas": [
+        "53f73cdeb6fe53155f91064ca15b722e80dec2f3",
+        "7f88bf96f9ff37f3873cc5cb8c962ebcbf509c65"
+      ]
+    }
+  ]
+}

--- a/torchci/clickhouse_queries/commit_job_names/query.sql
+++ b/torchci/clickhouse_queries/commit_job_names/query.sql
@@ -1,0 +1,11 @@
+-- This query is used by Dr.CI to enumerate every job that ran on the merge-base
+-- commit, regardless of conclusion. It is used to distinguish "this job failed
+-- on base" (broken trunk), "this job passed on base" (PR-introduced regression),
+-- and "this job did not run on base at all" (no signal -> Unknown).
+SELECT DISTINCT
+  j.head_sha AS head_sha,
+  CONCAT(j.workflow_name, ' / ', j.name) AS name
+FROM
+  default.workflow_job j final
+WHERE
+  j.id in (select id from materialized_views.workflow_job_by_head_sha where head_sha in {shas: Array(String)})

--- a/torchci/lib/fetchRecentWorkflows.ts
+++ b/torchci/lib/fetchRecentWorkflows.ts
@@ -20,3 +20,11 @@ export async function fetchFailedJobsFromCommits(
     shas,
   });
 }
+
+export async function fetchJobNamesFromCommits(
+  shas: string[]
+): Promise<{ head_sha: string; name: string }[]> {
+  return await queryClickhouseSaved("commit_job_names", {
+    shas,
+  });
+}

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -29,6 +29,7 @@ import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
 import fetchPR from "lib/fetchPR";
 import {
   fetchFailedJobsFromCommits,
+  fetchJobNamesFromCommits,
   fetchRecentWorkflows,
 } from "lib/fetchRecentWorkflows";
 import { getOctokit, getOctokitWithUserToken } from "lib/github";
@@ -180,6 +181,7 @@ export async function updateDrciComments(
     /*cache*/ true
   );
   const baseCommitJobs = await getBaseCommitJobs(workflowsByPR);
+  const baseCommitJobNames = await getBaseCommitJobNames(workflowsByPR);
   const existingDrCiComments = await getExistingDrCiComments(
     `${owner}/${repo}`,
     workflowsByPR
@@ -212,6 +214,7 @@ export async function updateDrciComments(
         flakyJobs,
         brokenTrunkJobs,
         unstableJobs,
+        unknownJobs,
         awaitingApprovalJobs,
         relatedJobs,
         relatedIssues,
@@ -223,7 +226,8 @@ export async function updateDrciComments(
         labels || [],
         unstableIssues || [],
         disabledTestIssues || [],
-        mergeCommits || []
+        mergeCommits || [],
+        baseCommitJobNames.get(pr_info.merge_base)
       );
 
       failures[pr_info.pr_number] = {
@@ -231,6 +235,7 @@ export async function updateDrciComments(
         FLAKY: flakyJobs,
         BROKEN_TRUNK: brokenTrunkJobs,
         UNSTABLE: unstableJobs,
+        UNKNOWN: unknownJobs,
         AWAITING_APPROVAL: awaitingApprovalJobs,
       };
 
@@ -240,6 +245,7 @@ export async function updateDrciComments(
         flakyJobs,
         brokenTrunkJobs,
         unstableJobs,
+        unknownJobs,
         awaitingApprovalJobs,
         relatedJobs,
         relatedIssues,
@@ -514,6 +520,29 @@ export async function getBaseCommitJobs(
   return jobsByShaByName;
 }
 
+// Returns the set of job names (with shard/unstable suffix stripped) that ran
+// at each merge-base SHA, regardless of conclusion. DrCI uses this to tell
+// "this job did not run on base at all" (no signal -> Unknown) apart from
+// "this job ran on base and passed" (PR-introduced regression -> new failure).
+export async function getBaseCommitJobNames(
+  workflowsByPR: Map<number, PRandJobs>
+): Promise<Map<string, Set<string>>> {
+  const baseShas = _.uniq(
+    Array.from(workflowsByPR.values()).map((v) => v.merge_base)
+  );
+
+  const rows = await fetchJobNamesFromCommits(baseShas);
+
+  const namesBySha = new Map<string, Set<string>>();
+  for (const row of rows) {
+    if (!namesBySha.has(row.head_sha)) {
+      namesBySha.set(row.head_sha, new Set());
+    }
+    namesBySha.get(row.head_sha)!.add(removeJobNameSuffix(row.name));
+  }
+  return namesBySha;
+}
+
 async function getExistingDrCiComments(
   repoFullName: string,
   workflowsByPR: Map<number, PRandJobs>
@@ -641,6 +670,7 @@ export function constructResultsComment(
   flakyJobs: RecentWorkflowsData[],
   brokenTrunkJobs: RecentWorkflowsData[],
   unstableJobs: RecentWorkflowsData[],
+  unknownJobs: RecentWorkflowsData[],
   awaitingApprovalJobs: RecentWorkflowsData[],
   relatedJobs: Map<number, RecentWorkflowsData>,
   relatedIssues: Map<number, IssueData[]>,
@@ -689,6 +719,10 @@ export function constructResultsComment(
     "Failure",
     unrelatedFailureCount
   )}`;
+  const unknownFailures = `${unknownJobs.length} Unclassified ${pluralize(
+    "Failure",
+    unknownJobs.length
+  )}`;
   const pendingJobs = `${pending} Pending`;
   const awaitingApprovalMsg = `${awaitingApprovalJobs.length} Awaiting Approval`;
 
@@ -697,6 +731,7 @@ export function constructResultsComment(
   const hasCancelledFailures = cancelledJobs.length > 0;
   const hasPending = pending > 0;
   const hasUnrelatedFailures = unrelatedFailureCount > 0;
+  const hasUnknownFailures = unknownJobs.length > 0;
   const hasAwaitingApproval = awaitingApprovalJobs.length > 0;
 
   let icon = "";
@@ -735,6 +770,9 @@ export function constructResultsComment(
     }
 
     title_messages.push(unrelatedFailuresMsg);
+  }
+  if (hasUnknownFailures) {
+    title_messages.push(unknownFailures);
   }
 
   let title = headerPrefix + icon + " " + title_messages.join(", ");
@@ -783,6 +821,32 @@ export function constructResultsComment(
       newFailedJobs,
       "",
       false,
+      relatedJobs,
+      relatedIssues,
+      relatedInfo
+    );
+  }
+
+  if (unknownJobs.length) {
+    output += constructResultsJobsSections(
+      hudBaseUrl,
+      owner,
+      repo,
+      prNumber,
+      `UNCLASSIFIED ${pluralize(
+        "FAILURE",
+        unknownJobs.length
+      ).toLocaleUpperCase()}`,
+      `DrCI could not classify the following ${pluralize(
+        "job",
+        unknownJobs.length
+      )} because the workflow did not run on the merge base. The ${pluralize(
+        "failure",
+        unknownJobs.length
+      )} may be pre-existing on trunk or introduced by this PR`,
+      unknownJobs,
+      "",
+      true,
       relatedJobs,
       relatedIssues,
       relatedInfo
@@ -921,13 +985,15 @@ export async function getWorkflowJobsStatuses(
   labels: string[] = [],
   unstableIssues: IssueData[] = [],
   disabledTestIssues: IssueData[] = [],
-  mergeCommits: string[] = []
+  mergeCommits: string[] = [],
+  baseJobNames?: Set<string>
 ): Promise<{
   pending: number;
   failedJobs: RecentWorkflowsData[];
   flakyJobs: RecentWorkflowsData[];
   brokenTrunkJobs: RecentWorkflowsData[];
   unstableJobs: RecentWorkflowsData[];
+  unknownJobs: RecentWorkflowsData[];
   awaitingApprovalJobs: RecentWorkflowsData[];
   relatedJobs: Map<number, RecentWorkflowsData>;
   relatedIssues: Map<number, IssueData[]>;
@@ -939,6 +1005,7 @@ export async function getWorkflowJobsStatuses(
   const brokenTrunkJobs: RecentWorkflowsData[] = [];
   const unstableJobs: RecentWorkflowsData[] = [];
   const failedJobs: RecentWorkflowsData[] = [];
+  const unknownJobs: RecentWorkflowsData[] = [];
   const awaitingApprovalJobs: RecentWorkflowsData[] = [];
 
   // This map holds the list of the base failures for broken trunk jobs or the similar
@@ -999,6 +1066,19 @@ export async function getWorkflowJobsStatuses(
       }
 
       if (isExcludedFromFlakiness(job)) {
+        // No flakiness signal will be checked for this job. If it also did not
+        // run on the merge base, DrCI has nothing to compare against -> Unknown.
+        if (
+          baseJobNames !== undefined &&
+          !baseJobNames.has(removeJobNameSuffix(job.name))
+        ) {
+          unknownJobs.push(job);
+          relatedInfo.set(
+            job.id,
+            "this job did not run on the merge base, so DrCI cannot tell whether the failure is pre-existing"
+          );
+          continue;
+        }
         failedJobs.push(job);
         continue;
       }
@@ -1147,6 +1227,22 @@ export async function getWorkflowJobsStatuses(
       continue;
     }
 
+    // If this job did not run on the merge base at all, DrCI has no signal to
+    // tell whether the failure is pre-existing or PR-introduced. Surface it as
+    // Unknown rather than blaming the PR. Only applies when the caller passes
+    // baseJobNames; tests that omit it preserve legacy behavior.
+    if (
+      baseJobNames !== undefined &&
+      !baseJobNames.has(removeJobNameSuffix(job.name))
+    ) {
+      unknownJobs.push(job);
+      relatedInfo.set(
+        job.id,
+        "this job did not run on the merge base, so DrCI cannot tell whether the failure is pre-existing"
+      );
+      continue;
+    }
+
     failedJobs.push(job);
   }
 
@@ -1156,6 +1252,7 @@ export async function getWorkflowJobsStatuses(
     flakyJobs,
     brokenTrunkJobs,
     unstableJobs,
+    unknownJobs,
     awaitingApprovalJobs,
     relatedJobs,
     relatedIssues,

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -265,6 +265,7 @@ function constructResultsCommentHelper({
   flakyJobs = [],
   brokenTrunkJobs = [],
   unstableJobs = [],
+  unknownJobs = [],
   awaitingApprovalJobs = [],
   sha = "random sha",
   merge_base = "random_merge_base_sha",
@@ -279,6 +280,7 @@ function constructResultsCommentHelper({
   flakyJobs?: RecentWorkflowsData[];
   brokenTrunkJobs?: RecentWorkflowsData[];
   unstableJobs?: RecentWorkflowsData[];
+  unknownJobs?: RecentWorkflowsData[];
   awaitingApprovalJobs?: RecentWorkflowsData[];
   sha?: string;
   merge_base?: string;
@@ -294,6 +296,7 @@ function constructResultsCommentHelper({
     flakyJobs,
     brokenTrunkJobs,
     unstableJobs,
+    unknownJobs,
     awaitingApprovalJobs,
     new Map(),
     new Map(),
@@ -829,6 +832,112 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     expect(brokenTrunkJobs.length).toBe(2);
     expect(flakyJobs.length).toBe(0);
     expect(unstableJobs.length).toBe(0);
+  });
+
+  test("test getBaseCommitJobNames groups names by sha and strips suffix", async () => {
+    const originalWorkflows = [failedA, failedD];
+    const workflowsByPR = await updateDrciBot.reorganizeWorkflows(
+      "pytorch",
+      "pytorch",
+      originalWorkflows
+    );
+    const mock = jest.spyOn(fetchRecentWorkflows, "fetchJobNamesFromCommits");
+    mock.mockImplementation(() =>
+      Promise.resolve([
+        { head_sha: failedA.head_sha!, name: failedA.name! },
+        // Different shard than failedD; should collapse to the same key
+        { head_sha: failedA.head_sha!, name: failedE.name! },
+      ])
+    );
+
+    const baseJobNames = await updateDrciBot.getBaseCommitJobNames(
+      workflowsByPR
+    );
+    const names = baseJobNames.get(failedA.head_sha!)!;
+    expect(names.has(failedA.name!)).toBeTruthy();
+    expect(names.has(removeJobNameSuffix(failedD.name!))).toBeTruthy();
+    expect(names.size).toBe(2);
+  });
+
+  test("job that did not run on merge base is classified as Unknown", async () => {
+    const originalWorkflows = [failedC];
+    const workflowsByPR = await updateDrciBot.reorganizeWorkflows(
+      "pytorch",
+      "pytorch",
+      originalWorkflows
+    );
+    const pr_1001 = workflowsByPR.get(1001)!;
+    const {
+      failedJobs,
+      brokenTrunkJobs,
+      flakyJobs,
+      unstableJobs,
+      unknownJobs,
+    } = await updateDrciBot.getWorkflowJobsStatuses(
+      pr_1001,
+      [],
+      new Map(),
+      [],
+      [],
+      [],
+      [],
+      new Set() // base ran no jobs at all -> failedC didn't run on base
+    );
+    expect(unknownJobs.length).toBe(1);
+    expect(unknownJobs[0].name).toBe(failedC.name);
+    expect(failedJobs.length).toBe(0);
+    expect(brokenTrunkJobs.length).toBe(0);
+    expect(flakyJobs.length).toBe(0);
+    expect(unstableJobs.length).toBe(0);
+  });
+
+  test("job that ran on merge base and passed stays a New Failure", async () => {
+    const originalWorkflows = [failedC];
+    const workflowsByPR = await updateDrciBot.reorganizeWorkflows(
+      "pytorch",
+      "pytorch",
+      originalWorkflows
+    );
+    const pr_1001 = workflowsByPR.get(1001)!;
+    const baseJobNames = new Set<string>([removeJobNameSuffix(failedC.name!)]);
+    const {
+      failedJobs,
+      brokenTrunkJobs,
+      flakyJobs,
+      unstableJobs,
+      unknownJobs,
+    } = await updateDrciBot.getWorkflowJobsStatuses(
+      pr_1001,
+      [],
+      new Map(), // no failed jobs on base
+      [],
+      [],
+      [],
+      [],
+      baseJobNames
+    );
+    expect(unknownJobs.length).toBe(0);
+    expect(failedJobs.length).toBe(1);
+    expect(brokenTrunkJobs.length).toBe(0);
+    expect(flakyJobs.length).toBe(0);
+    expect(unstableJobs.length).toBe(0);
+  });
+
+  test("Unknown failures are rendered in their own section and excluded from New Failures count", async () => {
+    const failureInfoComment = constructResultsCommentHelper({
+      pending: 0,
+      failedJobs: [failedA],
+      unknownJobs: [failedC],
+    });
+    expect(failureInfoComment.includes("1 New Failure")).toBeTruthy();
+    expect(failureInfoComment.includes("1 Unclassified Failure")).toBeTruthy();
+    expect(failureInfoComment.includes("UNCLASSIFIED FAILURE")).toBeTruthy();
+    expect(
+      failureInfoComment.includes(
+        "DrCI could not classify the following job because the workflow did not run on the merge base"
+      )
+    ).toBeTruthy();
+    expect(failureInfoComment.includes(failedC.name!)).toBeTruthy();
   });
 
   test("test similar failures marked as flaky", async () => {


### PR DESCRIPTION
Workflows like `Build Official Docker Images` only run on a narrow set of triggers (pull_request when docker files change, push to nightly/tags). When such a workflow runs on a PR but did not run on the merge-base commit, DrCI's broken-trunk check structurally cannot fire (no row to compare against), and for jobs whose name matches `EXCLUDED_FROM_FLAKINESS` (e.g. the generic `/ build` substring) the flaky/log-classifier checks are skipped too. The result was that any failure of those workflows on a PR landed in "New Failures", even when it was an environmental issue or pre-existing breakage on nightly.

This change introduces a new "Unclassified" bucket. A new ClickHouse query (`commit_job_names`) returns the set of job names that ran at the merge-base SHA regardless of conclusion. `getWorkflowJobsStatuses` accepts that set as `baseJobNames` and, when a failed job is not present in it, classifies the failure as Unknown rather than New. Two placements catch both code paths: (1) at the `isExcludedFromFlakiness` short-circuit (covers Build Official Docker Images and other build-job carve-outs), and (2) at the very end of the post-processing pass (covers anything that survived all flaky / log-classifier / similar-failure checks). Lint cannot reach either branch because it short-circuits earlier at `isExcludedFromBrokenTrunk`.

The DrCI comment renders a new `UNCLASSIFIED FAILURE` section, the title gets a separate "N Unclassified Failure(s)" piece (it is not folded into "New Failures" or "Unrelated Failures"), and the check-run summary JSON gains an `UNKNOWN` field. `baseJobNames` is optional with a default of `undefined` so existing tests keep their legacy behavior; new tests cover (a) name-set construction with shard suffixes, (b) "didn't run on base" -> Unknown, (c) "ran on base and passed" stays a New Failure (no false-negative downgrade), and (d) the new comment section / title math.
