### PR TITLE
autorevert: treat skipped jobs as missing, not pending

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/job_agg_index.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/job_agg_index.py
@@ -40,6 +40,12 @@ class JobMeta:
       status resolves to PENDING.
     - is_cancelled: True if any grouped row is cancelled. Cancelled groups are
       treated as "missing" (no event), i.e., `status` returns None.
+    - is_skipped: True if all grouped rows are skipped. Skipped groups are
+      treated as "missing" (no event), same as cancelled — a skipped job
+      produced no signal-bearing outcome (e.g. `if:` gate, required-check
+      skip when an upstream dependency was cancelled/failed). Requires
+      ALL rows skipped so a real attempt that ran alongside a skipped
+      shard still drives the verdict.
     - has_failures: True if any grouped row is a failure (KG-adjusted conclusion).
       If True, overall status resolves to FAILURE.
     - all_completed_success: True if all grouped rows completed successfully. If
@@ -53,6 +59,7 @@ class JobMeta:
     started_at: datetime = datetime.min
     is_pending: bool = False
     is_cancelled: bool = False
+    is_skipped: bool = False
     has_failures: bool = False
     all_completed_success: bool = False
     has_non_test_failures: bool = False
@@ -61,12 +68,12 @@ class JobMeta:
     @property
     def status(self) -> Optional[SignalStatus]:
         """
-        - canceled -> treat as 'missing' (None)
+        - canceled / skipped -> treat as 'missing' (None)
         - any_failure -> FAILURE
         - all_completed_success -> SUCCESS
         - else -> PENDING
         """
-        if self.is_cancelled:
+        if self.is_cancelled or self.is_skipped:
             return None
         if self.has_failures:
             return SignalStatus.FAILURE
@@ -178,6 +185,7 @@ class JobAggIndex(Generic[KeyT]):
             started_at=started_at,
             is_pending=(any(r.is_pending for r in jrows)),
             is_cancelled=(any(r.is_cancelled for r in jrows)),
+            is_skipped=(all(r.is_skipped for r in jrows)),
             has_failures=(any(r.is_failure for r in jrows)),
             all_completed_success=(all(r.is_success for r in jrows)),
             has_non_test_failures=(

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_types.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_types.py
@@ -102,6 +102,13 @@ class JobRow:
         return self._conclusion_l == "cancelled"
 
     @property
+    def is_skipped(self) -> bool:
+        # Treated as "missing" by the aggregator (same as cancelled): the job
+        # produced no signal-bearing outcome (e.g. `if:` gate, required-check
+        # skip when an upstream dependency was cancelled/failed).
+        return self._conclusion_l == "skipped"
+
+    @property
     def is_failure(self) -> bool:
         # conclusion is already KG-adjusted in the datasource
         return self._conclusion_l == "failure"

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
@@ -276,6 +276,38 @@ class TestSignalExtraction(unittest.TestCase):
         x1 = next(c for c in sig.commits if c.head_sha == "X1")
         self.assertEqual(x1.events, [])
 
+    def test_skipped_attempt_yields_no_event(self):
+        # Regression: a `skipped` job (status=completed, conclusion=skipped)
+        # used to fall through JobMeta.status's default and emit a PENDING
+        # event that persisted in autorevert_state until lookback expired.
+        # It should be treated as missing (no event), same as cancelled.
+        jobs = [
+            J(
+                sha="S2",
+                run=701,
+                job=51,
+                attempt=1,
+                started_at=ts(self.t0, 2),
+                conclusion="failure",
+                rule="infra",
+            ),
+            J(
+                sha="S1",
+                run=700,
+                job=50,
+                attempt=1,
+                started_at=ts(self.t0, 1),
+                status="completed",
+                conclusion="skipped",
+            ),
+        ]
+        signals = self._extract(jobs, tests=[])
+        base = jobs[0].base_name
+        sig = self._find_job_signal(signals, "trunk", base)
+        self.assertIsNotNone(sig)
+        s1 = next(c for c in sig.commits if c.head_sha == "S1")
+        self.assertEqual(s1.events, [])
+
     def test_non_test_inclusion_gate(self):
         # (a) only test failures -> test-failure job signal emitted (not non-test job signal)
         jobs_a = [


### PR DESCRIPTION
## Summary

A `workflow_job` with `conclusion=skipped` (e.g. `if:` gate, required-check skip on a cancelled/failed dependency) was recorded as **PENDING** in `misc.autorevert_state` with the real `started_at` / `job_id` and stuck around until the ~16h lookback dropped it.

Cause: `JobMeta.status` had no `skipped` predicate and fell through to its `return SignalStatus.PENDING` default.

Repro — job [74727873795](https://github.com/pytorch/pytorch/actions/runs/25468257317/job/74727873795):

| source | conclusion / status |
|---|---|
| GitHub + `default.workflow_job` | `skipped` |
| `misc.autorevert_state` (ts `2026-05-07 16:05:06`) | **`pending`** ❌ |

## Fix

- `JobRow.is_skipped` (`conclusion == 'skipped'`)
- `JobMeta.is_skipped = all(r.is_skipped for r in jrows)` — `all()` so a real attempt running alongside a skipped shard still drives the verdict
- Treat `is_skipped` like `is_cancelled` in `JobMeta.status` → return `None` (missing)

## Test plan

- New `test_skipped_attempt_yields_no_event` mirrors the cancelled-attempt test; verified it fails against pre-fix code, passes after.
- fed the real CH-sourced `JobRow` for job 74727873795 (the affected one) through the patched extractor. `JobMeta.status` returns `None` → `_build_non_test_signals` emits no event for the cell, matching the intended "missing" semantics.
- Full signal-track suite (97 tests) green; `ruff format` + `ruff check` clean.
- Ran autorevert locally, manually verified behavior before / after
