### PR TITLE
Fix nitpicker config filename to .github/nitpicks.yml

### DIFF
--- a/torchci/lib/bot/nitpickBot.ts
+++ b/torchci/lib/bot/nitpickBot.ts
@@ -4,7 +4,7 @@ import { Context, Probot } from "probot";
 import { getFilesChangedByPr, isPyTorchPyTorch } from "./utils";
 
 // Implements logic similar to https://github.com/ethanis/nitpicker.
-// Reads `.github/nitpick.yml` from the repo's default branch and posts
+// Reads `.github/nitpicks.yml` from the repo's default branch and posts
 // (or updates) a single sticky comment on PRs whose changed files match
 // any of the configured rules.
 //
@@ -25,7 +25,7 @@ import { getFilesChangedByPr, isPyTorchPyTorch } from "./utils";
 
 export const NITPICK_COMMENT_START = "<!-- nitpick-bot-start -->";
 export const NITPICK_COMMENT_END = "<!-- nitpick-bot-end -->";
-export const NITPICK_CONFIG_PATH = ".github/nitpick.yml";
+export const NITPICK_CONFIG_PATH = ".github/nitpicks.yml";
 
 export interface NitpickRule {
   markdown: string;

--- a/torchci/test/nitpickBot.test.ts
+++ b/torchci/test/nitpickBot.test.ts
@@ -15,7 +15,7 @@ nock.disableNetConnect();
 const PYTORCH_REPO = "pytorch/pytorch";
 
 function mockNitpickConfig(content: string | null) {
-  const path = encodeURIComponent(".github/nitpick.yml");
+  const path = encodeURIComponent(".github/nitpicks.yml");
   if (content === null) {
     return nock("https://api.github.com")
       .get(`/repos/${PYTORCH_REPO}/contents/${path}`)
@@ -25,8 +25,8 @@ function mockNitpickConfig(content: string | null) {
     .get(`/repos/${PYTORCH_REPO}/contents/${path}`)
     .reply(200, {
       type: "file",
-      path: ".github/nitpick.yml",
-      name: "nitpick.yml",
+      path: ".github/nitpicks.yml",
+      name: "nitpicks.yml",
       encoding: "base64",
       content: Buffer.from(content).toString("base64"),
     });


### PR DESCRIPTION
The upstream config file in pytorch/pytorch is [`.github/nitpicks.yml`](https://github.com/pytorch/pytorch/blob/main/.github/nitpicks.yml) (with an `s`), not `.github/nitpick.yml`. The previously-merged bot was 404'ing on every PR because it looked at the wrong path. Schema (`markdown` + `pathFilter`) is unchanged, so no logic changes are needed — just the filename constant.

## Test plan
- [x] `npx jest test/nitpickBot.test.ts` passes (12 tests, all updated to the new filename).
- [ ] After merge, verify on a fresh pytorch/pytorch PR touching `aten/src/ATen/native/native_functions.yaml` that the sticky nitpick comment appears.