### PR TITLE
Fix check-labels bot not recognizing its own comments

### DIFF
--- a/torchci/lib/bot/checkLabelsUtils.ts
+++ b/torchci/lib/bot/checkLabelsUtils.ts
@@ -52,7 +52,7 @@ export function formLabelErrComment(): string {
 export function isLabelErrComment(body: string, author: string): boolean {
   return (
     body.includes(LABEL_COMMENT_START) &&
-    BOT_AUTHORS.includes(author.toLowerCase())
+    BOT_AUTHORS.includes(author.toLowerCase().replace("[bot]", ""))
   );
 }
 

--- a/torchci/test/checkLabelsBot.test.ts
+++ b/torchci/test/checkLabelsBot.test.ts
@@ -75,6 +75,12 @@ describe("check-labels-bot", () => {
       expect(isLabelErrComment(body, "pytorch-bot")).toBe(true);
     });
 
+    test("returns true for bot comment with [bot] suffix", () => {
+      const body = formLabelErrComment();
+      expect(isLabelErrComment(body, "github-actions[bot]")).toBe(true);
+      expect(isLabelErrComment(body, "pytorch-bot[bot]")).toBe(true);
+    });
+
     test("returns false for non-bot author", () => {
       const body = formLabelErrComment();
       expect(isLabelErrComment(body, "random-user")).toBe(false);


### PR DESCRIPTION
The bot posts comments as `pytorch-bot[bot]` but `isLabelErrComment`
compared against `BOT_AUTHORS` which only contained the bare name
`pytorch-bot`. This caused two bugs: the error comment was never
deleted when a required label was added, and duplicates were posted
because the existing-comment check couldn't find the original.

Strip the `[bot]` suffix before comparing.

Authored with Claude.
