### PR TITLE
autorevert: stop creating duplicate workflow runs on GitHub 5xx during dispatch

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/github_client_helper.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/github_client_helper.py
@@ -89,24 +89,41 @@ class GHClientFactory:
             and hasattr(cls, "_installation_id")
         )
 
+    def _build_auth(self) -> "github.Auth.Auth":
+        if self.token_auth_provided():
+            return github.Auth.Token(self._token)
+        if self.key_auth_provided():
+            return github.Auth.AppInstallationAuth(
+                github.Auth.AppAuth(
+                    app_id=self._app_id,
+                    private_key=self._app_secret,
+                ),
+                installation_id=self._installation_id,
+            )
+        raise RuntimeError(
+            "GitHub client not properly configured. Call setup_client first."
+            + " Please note that you can only use one type of authentication at a time."
+        )
+
     @property
     def client(self) -> github.Github:
         if "client" not in self._data:
-            if self.token_auth_provided():
-                auth = github.Auth.Token(self._token)
-            elif self.key_auth_provided():
-                auth = github.Auth.AppInstallationAuth(
-                    github.Auth.AppAuth(
-                        app_id=self._app_id,
-                        private_key=self._app_secret,
-                    ),
-                    installation_id=self._installation_id,
-                )
-            else:
-                raise RuntimeError(
-                    "GitHub client not properly configured. Call setup_client first."
-                    + " Please note that you can only use one type of authentication at a time."
-                )
-
-            self._data["client"] = github.Github(auth=auth)
+            self._data["client"] = github.Github(auth=self._build_auth())
         return self._data["client"]
+
+    @property
+    def dispatch_client(self) -> github.Github:
+        """Github client with urllib3 retries disabled — for non-idempotent POSTs.
+
+        GitHub's ``POST /repos/{owner}/{repo}/actions/workflows/{id}/dispatches`` can
+        return 5xx after it has already accepted the dispatch and created a workflow
+        run. PyGithub's default ``GithubRetry`` retries 5xx for POST, which silently
+        produces duplicate runs. This client opts out of those retries; callers are
+        expected to wrap dispatch calls in a small explicit retry (e.g.
+        ``RetryWithBackoff``) instead.
+        """
+        if "dispatch_client" not in self._data:
+            self._data["dispatch_client"] = github.Github(
+                auth=self._build_auth(), retry=0
+            )
+        return self._data["dispatch_client"]

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
@@ -652,9 +652,12 @@ class SignalActionProcessor:
         notes = ""
         if not dry_run:
             try:
-                gh_client = GHClientFactory().client
+                factory = GHClientFactory()
+                gh_client = factory.client
                 repo = gh_client.get_repo(ctx.repo_full_name)
                 workflow = repo.get_workflow("claude-autorevert-advisor.yml")
+                # /dispatches is non-idempotent — route the POST through dispatch_client
+                # (retry=0) so a 5xx from GitHub does not silently spawn duplicate runs.
                 proper_workflow_create_dispatch(
                     workflow,
                     ref="main",
@@ -663,6 +666,7 @@ class SignalActionProcessor:
                         "pr_number": str(pr_number),
                         "signal_pattern": signal_pattern_json,
                     },
+                    requester=factory.dispatch_client.requester,
                 )
             except Exception as exc:
                 ok = False

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_dispatch_no_retry.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_dispatch_no_retry.py
@@ -1,0 +1,124 @@
+"""Verify the dispatch path does not retry POST 5xx in PyGithub's urllib3 layer.
+
+GitHub's POST /repos/{owner}/{repo}/actions/workflows/{id}/dispatches is not idempotent:
+the server can return 5xx after it has already accepted the dispatch and created a
+workflow run. PyGithub's default GithubRetry retries 5xx for POST, which silently
+spawns duplicate runs during a GitHub outage. The autorevert lambda routes dispatches
+through ``GHClientFactory().dispatch_client`` (constructed with ``retry=0``) and asks
+``proper_workflow_create_dispatch`` to use that client's requester explicitly.
+"""
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+# Ensure package import when running from repo root
+sys.path.insert(0, "aws/lambda/pytorch-auto-revert")
+
+from pytorch_auto_revert.github_client_helper import GHClientFactory  # noqa: E402
+from pytorch_auto_revert.utils import proper_workflow_create_dispatch  # noqa: E402
+
+
+def _reset_factory() -> "GHClientFactory":
+    GHClientFactory.setup_client(token="test-token")
+    if hasattr(GHClientFactory, "_instance"):
+        del GHClientFactory._instance
+    factory = GHClientFactory()
+    factory._data.pop("client", None)
+    factory._data.pop("dispatch_client", None)
+    return factory
+
+
+class TestDispatchClientNoRetry(unittest.TestCase):
+    def test_dispatch_client_constructed_with_retry_zero(self):
+        """``dispatch_client`` passes ``retry=0`` to ``github.Github(...)``."""
+        factory = _reset_factory()
+        with patch(
+            "pytorch_auto_revert.github_client_helper.github.Github"
+        ) as mock_github:
+            mock_github.return_value = MagicMock(name="dispatch_client")
+            _ = factory.dispatch_client
+            self.assertEqual(mock_github.call_count, 1)
+            kwargs = mock_github.call_args.kwargs
+            self.assertEqual(
+                kwargs.get("retry"),
+                0,
+                f"dispatch_client must be constructed with retry=0, got kwargs={kwargs!r}",
+            )
+
+    def test_default_client_does_not_set_retry_zero(self):
+        """The default ``client`` keeps PyGithub's automatic retry behavior."""
+        factory = _reset_factory()
+        with patch(
+            "pytorch_auto_revert.github_client_helper.github.Github"
+        ) as mock_github:
+            mock_github.return_value = MagicMock(name="default_client")
+            _ = factory.client
+            self.assertEqual(mock_github.call_count, 1)
+            kwargs = mock_github.call_args.kwargs
+            # The default client must not opt out of PyGithub retries — that path
+            # also covers idempotent GETs and rate-limit-aware 403 retries.
+            self.assertNotEqual(kwargs.get("retry", "unset"), 0)
+
+    def test_dispatch_client_cached_and_distinct(self):
+        factory = _reset_factory()
+        with patch(
+            "pytorch_auto_revert.github_client_helper.github.Github"
+        ) as mock_github:
+            mock_github.side_effect = [
+                MagicMock(name="default"),
+                MagicMock(name="dispatch"),
+            ]
+            c1 = factory.client
+            c2 = factory.client
+            d1 = factory.dispatch_client
+            d2 = factory.dispatch_client
+            self.assertIs(c1, c2)
+            self.assertIs(d1, d2)
+            self.assertIsNot(c1, d1)
+            self.assertEqual(mock_github.call_count, 2)
+
+    def test_proper_workflow_create_dispatch_uses_passed_requester(self):
+        """When ``requester`` is provided, the workflow's own requester is bypassed."""
+        workflow = MagicMock()
+        workflow.url = "https://api.github.com/repos/o/r/actions/workflows/1"
+        workflow._requester = MagicMock()
+        workflow._requester.requestJson.return_value = (
+            204,
+            {},
+            "",
+        )
+
+        explicit_requester = MagicMock()
+        explicit_requester.requestJson.return_value = (204, {}, "")
+
+        proper_workflow_create_dispatch(
+            workflow,
+            ref="trunk/abc",
+            inputs={"k": "v"},
+            requester=explicit_requester,
+        )
+
+        # The explicit requester is used; the workflow's own requester is not.
+        explicit_requester.requestJson.assert_called_once()
+        workflow._requester.requestJson.assert_not_called()
+
+    def test_proper_workflow_create_dispatch_default_requester(self):
+        """Without ``requester``, the workflow's own requester is used (back-compat)."""
+        workflow = MagicMock()
+        workflow.url = "https://api.github.com/repos/o/r/actions/workflows/1"
+        workflow._requester = MagicMock()
+        workflow._requester.requestJson.return_value = (204, {}, "")
+
+        proper_workflow_create_dispatch(
+            workflow,
+            ref="trunk/abc",
+            inputs={"k": "v"},
+        )
+
+        workflow._requester.requestJson.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/utils.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/utils.py
@@ -3,6 +3,7 @@ import time
 import urllib.parse
 from datetime import datetime, timezone
 from enum import Enum
+from typing import Optional
 
 import github
 
@@ -180,12 +181,20 @@ def proper_workflow_create_dispatch(
     workflow: github.Workflow,
     ref: github.Branch.Branch | github.Tag.Tag | github.Commit.Commit | str,
     inputs: dict,
+    requester: Optional["github.Requester.Requester"] = None,
 ) -> bool:
     """
     :calls: `POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches
     <https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event>`
+
+    The /dispatches endpoint is **not idempotent**: GitHub can return a 5xx after it
+    has already created a workflow run, so transparent urllib3 retries on 5xx produce
+    duplicate runs. Pass an explicit `requester` (typically from a Github client
+    constructed with ``retry=0``) to disable PyGithub's default 5xx retry for this
+    POST. When ``requester`` is None, the workflow's own requester is used.
     """
-    status, headers, body = workflow._requester.requestJson(
+    req = requester if requester is not None else workflow._requester
+    status, headers, body = req.requestJson(
         "POST", f"{workflow.url}/dispatches", input={"ref": ref, "inputs": inputs}
     )
     if status != 204:

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/workflow_checker.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/workflow_checker.py
@@ -170,9 +170,23 @@ class WorkflowRestartChecker:
                 repo = client.get_repo(f"{self.repo_owner}/{self.repo_name}")
                 workflow = repo.get_workflow(wf_ref.file_name)
 
-        for attempt in RetryWithBackoff():
+        # The /dispatches endpoint is non-idempotent — GitHub can return 5xx after the
+        # workflow run has already been created, so transparent retries on 5xx produce
+        # duplicate runs. Two safeguards:
+        #   1. Use `factory.dispatch_client.requester` (constructed with retry=0) so
+        #      PyGithub's urllib3 layer does not retry POST 5xx automatically.
+        #   2. Cap the explicit outer retry at 2 attempts total (max_retries=1) — one
+        #      extra try buys resilience against a cold-network blip without inviting
+        #      a duplicate-run storm during a sustained GitHub outage.
+        dispatch_requester = factory.dispatch_client.requester
+        for attempt in RetryWithBackoff(max_retries=1):
             with attempt:
-                proper_workflow_create_dispatch(workflow, ref=tag_ref, inputs=inputs)
+                proper_workflow_create_dispatch(
+                    workflow,
+                    ref=tag_ref,
+                    inputs=inputs,
+                    requester=dispatch_requester,
+                )
 
         workflow_url = (
             f"https://github.com/{self.repo_owner}/{self.repo_name}"


### PR DESCRIPTION
## Summary

GitHub's `POST /repos/{owner}/{repo}/actions/workflows/{id}/dispatches` is **not idempotent**: the server can return 5xx after it has already accepted the dispatch and started a workflow run. PyGithub's default `GithubRetry` retries 5xx for POST, which silently spawns duplicate runs during a GitHub outage.

During a GitHub 5xx outage on 2026-05-08, a single restart attempt for one `(commit, workflow)` produced 47-56 duplicate `workflow_run` rows. The pattern repeated across `periodic`, `trunk`, `slow`, `inductor-periodic`, `pull`, and the `Claude Autorevert Advisor` workflow on six commits. Each storm came from a single dispatch call exhausting urllib3's retry budget against GitHub — `misc.autorevert_events_v2` correctly logged a single failed restart with note `Max retries exceeded ... too many 500 error responses`.

| sha (short) | workflow | runs from a single restart |
|---|---|---:|
| 2e8b70f9 | periodic | 56 |
| f999e459 | periodic | 56 |
| b3376039 | periodic | 55 |
| 3bb3648d | trunk | 55 |
| dfda4b2e | trunk | 55 |
| 8f9dd879 | trunk | 47 |

## What changed

- **`GHClientFactory.dispatch_client`** — new property that returns a `github.Github(...)` constructed with `retry=0`. Disables PyGithub's urllib3-layer retries on the dispatch path. The default `factory.client` is unchanged so idempotent GETs and rate-limit-aware 403 retries still benefit from PyGithub's automatic retry behavior.
- **`proper_workflow_create_dispatch`** — gains an optional `requester=` kwarg so dispatch callers can route the POST through the no-retry requester without re-resolving the workflow object.
- **Outer retry trimmed for dispatch** — `workflow_checker.restart_workflow` now wraps the POST in `RetryWithBackoff(max_retries=1)` (= 2 total attempts). One retry buys resilience against a cold-network blip without inviting a duplicate-run storm during a sustained outage. The workflow-resolution scope (idempotent GETs) still uses the default `RetryWithBackoff()`.
- Both call sites are wired up: the periodic restart path (`workflow_checker.restart_workflow`) and the AI advisor dispatch path (`signal_actions.dispatch_advisors`).

## Test plan

- [x] `make test` (full suite): 145 passed, 1 skipped (GitHub-token gated)
- [x] New `test_dispatch_no_retry.py` covers:
  - `dispatch_client` is constructed with `retry=0`
  - default `client` is not constructed with `retry=0` (regression guard)
  - both clients are cached and distinct
  - `proper_workflow_create_dispatch` uses an explicit `requester` when provided
  - `proper_workflow_create_dispatch` falls back to `workflow._requester` when not provided
- [ ] After deploy: monitor `default.workflow_run` for `pytorch-auto-revert[bot]` actor and verify per-`(sha, workflow)` dispatch counts stay at 1 (occasionally 2 on transient blips), not 40+, on the next 5xx event.


live-tested locally:

```
python -m pytorch_auto_revert autorevert-checker Lint trunk pull inductor --hours 18 --hud-html --revert-action log  --restart-action run --as-of "2026-05-08 09:55"
....

2026-05-08 18:56:31,747 INFO [root] Successfully dispatched workflow trunk for commit 8f2204d446ce1c38927d6e8b3acd7cf3ef06d13b with filters: jobs=linux-jammy-cuda13.0-py3.10-gcc11 (run: https://github.com/pytorch/pytorch/actions/workflows/trunk.yml?query=branch%3Atrunk%2F8f2204d446ce1c38927d6e8b3acd7cf3ef06d13b)
```