### PR TITLE
DrCI: mark PyTorch OSDC job failures as unstable

### DIFF
--- a/torchci/lib/jobUtils.ts
+++ b/torchci/lib/jobUtils.ts
@@ -90,6 +90,19 @@ export function isUnstableJob(
   return openUnstableIssues !== undefined && openUnstableIssues.length !== 0;
 }
 
+// Matches the `-osdc` suffix that PyTorch's OSDC (ARC) workflow variants
+// append to the job id, e.g. `test-osdc`, `test-osdc (cfg, ...)`,
+// `linux-jammy-py3.10-clang12 / test-osdc`. Mirrors the regex used by
+// `getNameWithoutOSDC` in JobClassifierUtil.ts.
+export const OSDC_JOB_NAME_REGEX = /-osdc(?=[\s()/]|$)/;
+
+export function isOSDCJob(jobName?: string): boolean {
+  if (!jobName) {
+    return false;
+  }
+  return OSDC_JOB_NAME_REGEX.test(jobName);
+}
+
 export function getOpenUnstableIssues(
   jobName?: string,
   unstableIssues?: IssueData[]

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -39,6 +39,7 @@ import {
   getOpenUnstableIssues,
   isDisabledTest,
   isDisabledTestMentionedInPR,
+  isOSDCJob,
   isRecentlyCloseDisabledTest,
   isSameFailure,
   isUnstableJob,
@@ -1026,9 +1027,17 @@ export async function getWorkflowJobsStatuses(
       continue;
     }
 
+    // PyTorch OSDC (ARC) jobs are still rolling out, so treat any failure or
+    // pending signal from them as unstable to avoid blocking PRs on the
+    // migration.
+    const isPyTorchOSDC = prInfo.repo === "pytorch" && isOSDCJob(job.name);
+
     if (isPending(job)) {
       pending++;
-      if (isUnstableJob(job as any, unstableIssues)) {
+      if (isPyTorchOSDC) {
+        unstableJobs.push(job);
+        relatedInfo.set(job.id, "PyTorch OSDC job marked as unstable");
+      } else if (isUnstableJob(job as any, unstableIssues)) {
         unstableJobs.push(job);
         relatedIssues.set(
           job.id,
@@ -1040,6 +1049,12 @@ export async function getWorkflowJobsStatuses(
       if (prInfo.repo === "pytorch" && suppressedLabels.length !== 0) {
         flakyJobs.push(job);
         relatedInfo.set(job.id, `suppressed by ${suppressedLabels.join(", ")}`);
+        continue;
+      }
+
+      if (isPyTorchOSDC) {
+        unstableJobs.push(job);
+        relatedInfo.set(job.id, "PyTorch OSDC job marked as unstable");
         continue;
       }
 

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -551,6 +551,75 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     expect(comment.includes("## :x: 1 New Failure, 1 Pending")).toBeTruthy();
   });
 
+  test("PyTorch OSDC failures are marked unstable", async () => {
+    const failedOSDC = getDummyJob({
+      name: "linux-jammy-py3.10-clang12 / test-osdc (default, 1, 3, mt-l-x86iavx512-8-64)",
+      conclusion: "failure",
+      completed_at: "2022-07-13 19:34:03",
+      html_url: "a",
+      head_sha: "abcdefg",
+      id: 42,
+      pr_number: 1001,
+      failure_lines: ["a"],
+      failure_captures: ["a"],
+      runnerName: "dummy",
+    });
+    const pendingOSDC = getDummyJob({
+      name: "linux-jammy-py3.10-clang12 / test-osdc (default, 2, 3, mt-l-x86iavx512-8-64)",
+      conclusion: "",
+      completed_at: TIME_0,
+      html_url: "b",
+      head_sha: "abcdefg",
+      id: 43,
+      pr_number: 1001,
+      runnerName: "dummy",
+    });
+
+    const workflowsByPR = await updateDrciBot.reorganizeWorkflows(
+      "pytorch",
+      "pytorch",
+      [failedOSDC, pendingOSDC]
+    );
+    const pr_1001 = workflowsByPR.get(1001)!;
+
+    const { failedJobs, flakyJobs, brokenTrunkJobs, unstableJobs, pending } =
+      await updateDrciBot.getWorkflowJobsStatuses(pr_1001, [], new Map());
+    expect(failedJobs.length).toBe(0);
+    expect(brokenTrunkJobs.length).toBe(0);
+    expect(flakyJobs.length).toBe(0);
+    expect(unstableJobs.length).toBe(2);
+    // The pending OSDC job still counts as pending overall, like other
+    // pending-and-unstable jobs.
+    expect(pending).toBe(1);
+  });
+
+  test("OSDC jobs in non-pytorch repos are not auto-marked unstable", async () => {
+    const failedOSDC = getDummyJob({
+      name: "linux-jammy-py3.10-clang12 / test-osdc (default, 1, 3, mt-l-x86iavx512-8-64)",
+      conclusion: "failure",
+      completed_at: "2022-07-13 19:34:03",
+      html_url: "a",
+      head_sha: "abcdefg",
+      id: 42,
+      pr_number: 1001,
+      failure_lines: ["a"],
+      failure_captures: ["a"],
+      runnerName: "dummy",
+    });
+
+    const workflowsByPR = await updateDrciBot.reorganizeWorkflows(
+      "meta-pytorch",
+      "some-other-repo",
+      [failedOSDC]
+    );
+    const pr_1001 = workflowsByPR.get(1001)!;
+
+    const { failedJobs, unstableJobs } =
+      await updateDrciBot.getWorkflowJobsStatuses(pr_1001, [], new Map());
+    expect(unstableJobs.length).toBe(0);
+    expect(failedJobs.length).toBe(1);
+  });
+
   test("test flaky, broken trunk, and unstable jobs are filtered out", async () => {
     const originalWorkflows = [failedA, failedB, unstableA, unstableB];
     const workflowsByPR = await updateDrciBot.reorganizeWorkflows(

--- a/torchci/test/jobUtils.test.ts
+++ b/torchci/test/jobUtils.test.ts
@@ -8,6 +8,7 @@ import {
   isDisabledTest,
   isDisabledTestMentionedInPR,
   isFailureFromPrevMergeCommit,
+  isOSDCJob,
   isRecentlyCloseDisabledTest,
   isSameContext,
   isSameFailure,
@@ -61,6 +62,28 @@ describe("Test various job utils", () => {
     expect(
       removeJobNameSuffix("Test `run_test.py` is usable without boto3/rockset")
     ).toStrictEqual("Test `run_test.py` is usable without boto3/rockset");
+  });
+
+  test("test isOSDCJob", () => {
+    expect(isOSDCJob(undefined)).toBe(false);
+    expect(isOSDCJob("")).toBe(false);
+    // Not OSDC jobs
+    expect(
+      isOSDCJob(
+        "linux-jammy-py3.10-clang12 / test (default, 1, 3, linux.c7i.2xlarge)"
+      )
+    ).toBe(false);
+    expect(isOSDCJob("linux-jammy-py3.10-clang12 / build")).toBe(false);
+    // `osdc` substring inside an unrelated token must not match
+    expect(isOSDCJob("some-osdc-prefixed-thing / build")).toBe(false);
+    // OSDC variants
+    expect(isOSDCJob("linux-jammy-py3.10-clang12 / test-osdc")).toBe(true);
+    expect(
+      isOSDCJob(
+        "linux-jammy-py3.10-clang12 / test-osdc (default, 1, 3, mt-l-x86iavx512-8-64)"
+      )
+    ).toBe(true);
+    expect(isOSDCJob("test-osdc / something-else")).toBe(true);
   });
 
   test("test isSameAuthor", async () => {


### PR DESCRIPTION
OSDC (ARC) job variants are still rolling out in pytorch/pytorch and should not block PRs. Treat any pytorch/pytorch job whose name carries the `-osdc` suffix as unstable in Dr.CI for both pending and failure/cancelled signals, matching the suffix detection used by getNameWithoutOSDC. Scoped to the pytorch repo so the rule does not apply to other repos that DrCI serves.