### PR TITLE
Render TorchAgent ClickHouse queries with real newlines

### DIFF
--- a/torchci/components/TorchAgentPage/ToolUse.tsx
+++ b/torchci/components/TorchAgentPage/ToolUse.tsx
@@ -62,7 +62,27 @@ export const ToolUse: React.FC<ToolUseProps> = ({
         >
           Input:
         </Typography>
-        <ToolInput>{JSON.stringify(toolInput, null, 2)}</ToolInput>
+        {(() => {
+          const hasQuery =
+            toolInput &&
+            typeof toolInput === "object" &&
+            typeof toolInput.query === "string";
+          if (!hasQuery) {
+            return <ToolInput>{JSON.stringify(toolInput, null, 2)}</ToolInput>;
+          }
+          const { query, ...rest } = toolInput;
+          const restKeys = Object.keys(rest);
+          return (
+            <>
+              <ToolInput>{query.trim()}</ToolInput>
+              {restKeys.length > 0 && (
+                <ToolInput sx={{ mt: 1 }}>
+                  {JSON.stringify(rest, null, 2)}
+                </ToolInput>
+              )}
+            </>
+          );
+        })()}
 
         {toolResult && (
           <>


### PR DESCRIPTION
## Summary
- In `TorchAgentPage/ToolUse.tsx`, the tool input was rendered via `JSON.stringify(toolInput, null, 2)`, so multi-line ClickHouse queries showed up with literal `\n` characters instead of being formatted.
- When `toolInput.query` is a string, render it as raw text inside the existing `<pre>` (`ToolInput`) so newlines render. Remaining input fields (e.g. `inline_result_limit_bytes`) are still shown as pretty-printed JSON below.

## Test plan
- [ ] Open a TorchAgent session that runs a ClickHouse query; expand the tool block and confirm the query renders with real newlines.
- [ ] Confirm non-ClickHouse tools (no `query` field) still render their input as JSON.
- [ ] Verify dark and light mode both render correctly.