### PR TITLE
DrCI: surface Unclassified failures as a failing status

### DIFF
--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -735,7 +735,7 @@ export function constructResultsComment(
   const hasAwaitingApproval = awaitingApprovalJobs.length > 0;
 
   let icon = "";
-  if (hasSignificantFailures || hasCancelledFailures) {
+  if (hasSignificantFailures || hasCancelledFailures || hasUnknownFailures) {
     icon = failuresIcon;
   } else if (hasAwaitingApproval) {
     icon = warningIcon;
@@ -755,7 +755,7 @@ export function constructResultsComment(
   if (hasCancelledFailures) {
     title_messages.push(cancelledFailures);
   }
-  if (!hasAnyFailing && !hasAwaitingApproval) {
+  if (!hasAnyFailing && !hasAwaitingApproval && !hasUnknownFailures) {
     title_messages.push(noneFailing);
   }
   if (hasPending) {
@@ -785,7 +785,7 @@ export function constructResultsComment(
   }
   output += ":";
 
-  if (!hasAnyFailing && !hasAwaitingApproval) {
+  if (!hasAnyFailing && !hasAwaitingApproval && !hasUnknownFailures) {
     output += `\n:green_heart: Looks good so far! There are no failures yet. :green_heart:`;
   }
 
@@ -846,7 +846,7 @@ export function constructResultsComment(
       )} may be pre-existing on trunk or introduced by this PR`,
       unknownJobs,
       "",
-      true,
+      false,
       relatedJobs,
       relatedIssues,
       relatedInfo

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -940,6 +940,21 @@ describe("Update Dr. CI Bot Unit Tests", () => {
     expect(failureInfoComment.includes(failedC.name!)).toBeTruthy();
   });
 
+  test("Unclassified failures alone surface as a failure status, not success", async () => {
+    const failureInfoComment = constructResultsCommentHelper({
+      pending: 0,
+      unknownJobs: [failedC],
+    });
+    expect(failureInfoComment.includes(":x:")).toBeTruthy();
+    expect(failureInfoComment.includes("No Failures")).toBeFalsy();
+    expect(failureInfoComment.includes(":green_heart:")).toBeFalsy();
+    expect(failureInfoComment.includes("1 Unclassified Failure")).toBeTruthy();
+    // Section is expanded (not collapsed)
+    expect(
+      failureInfoComment.includes("<details open><summary><b>UNCLASSIFIED")
+    ).toBeTruthy();
+  });
+
   test("test similar failures marked as flaky", async () => {
     const mock = jest.spyOn(drciUtils, "hasSimilarFailures");
     mock.mockImplementation(() =>


### PR DESCRIPTION
## Summary

- Unclassified failures (workflow didn't run on the merge base) were rendered as success: title showed "No Failures", a `:green_heart: Looks good so far!` line was emitted, and the `UNCLASSIFIED FAILURE` `<details>` block was collapsed. Reviewers could easily miss real, potentially PR-introduced breakage.
- Now: `:x:` icon fires when `hasUnknownFailures`, "No Failures" and the `:green_heart:` reassurance are suppressed, and the unclassified section is rendered with `<details open>` so affected jobs are immediately visible.
- Adds a test covering the unclassified-only case (failure icon present; "No Failures"/`:green_heart:` absent; `<details open>` for the UNCLASSIFIED block).

## Test plan

- [x] `yarn jest drci.test.ts` passes (including the new test).
- [x] `yarn format --check` passes.
- [ ] Spot-check a PR like pytorch/pytorch#183019 in staging to confirm the title and section rendering.