### PR TITLE
[skills] Update OSDC migration playbook for ci-docker-hash

### DIFF
--- a/.claude/skills/migrate-workflow-ec2-to-osdc/SKILL.md
+++ b/.claude/skills/migrate-workflow-ec2-to-osdc/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: migrate-workflow-ec2-to-osdc
-description: Step-by-step playbook for migrating a pytorch/pytorch .github/workflows/*.yml from EC2 to OSDC (ARC) runners — covers both dial-up and 100% opt-in patterns, with the inputs that must be plumbed through _linux-build.yml / _linux-test.yml. Use when migrating a workflow off EC2 onto on-site data center / EKS-hosted self-hosted runners (OSDC / ARC), enabling the ARC experiment, or wiring up `use-arc` / `runner_prefix` / `python-version` / `compiler` / `cuda-version` inputs.
+description: Step-by-step playbook for migrating a pytorch/pytorch .github/workflows/*.yml from EC2 to OSDC (ARC) runners — covers both dial-up and 100% opt-in patterns, with the inputs that must be plumbed through _linux-build.yml / _linux-test.yml. Use when migrating a workflow off EC2 onto on-site data center / EKS-hosted self-hosted runners (OSDC / ARC), enabling the ARC experiment, or wiring up `use-arc` / `runner_prefix` / `ci-docker-hash` / `python-version` / `compiler` / `cuda-version` inputs.
 ---
 
 # Migrating a workflow from EC2 to OSDC
 
 OSDC (= ARC = on-site data center, EKS-hosted self-hosted runners) replaces EC2 runners. Migration touches the workflow file *and* requires a few inputs to flow into the reusable `_linux-build.yml` / `_linux-test.yml` so the OSDC code paths (`build-osdc`, `test-osdc`) activate. EC2 paths (`build`, `test`) and OSDC paths gate on `inputs.use-arc` (`!inputs.use-arc` vs `inputs.use-arc`), so flipping that input swaps execution lanes.
 
-This playbook is for workflows that **call the reusable `_linux-build.yml` / `_linux-test.yml`** (e.g. `test-b200.yml`, `pull.yml`, `trunk.yml`, `tsan.yml`, `operator_microbenchmark.yml`). For *standalone* OSDC workflows (raw ARC label + `container:` directive), see `osdc-workflow-pattern.md`.
+This playbook is for workflows that **call the reusable `_linux-build.yml` / `_linux-test.yml`** (e.g. `test-b200.yml`, `pull.yml`, `trunk.yml`, `tsan.yml`, `operator_microbenchmark.yml`). Standalone OSDC workflows (raw ARC label + `container:` directive) follow a different pattern not covered here.
 
 ## Decide: dial-up vs. 100% opt-in
 
@@ -16,7 +16,7 @@ This playbook is for workflows that **call the reusable `_linux-build.yml` / `_l
 | **Dial-up** (preferred) | Existing workflow with broad coverage; you want to ramp OSDC adoption via labels like `pull.yml`/`trunk.yml`. | `test-b200.yml` (PR #181544) |
 | **100% opt-in** | Workflow is meant to *always* run on OSDC (e.g. testing the single B200 we own on EKS). | `operator_microbenchmark.yml`, `attention_op_microbenchmark.yml` (B200 jobs) |
 
-The two pieces — `runner_prefix` and `use-arc` — **must move together**. Hardcoding one but driving the other off the determinator is a bug. See `feedback-osdc-migration-dial-up.md`.
+The two pieces — `runner_prefix` and `use-arc` — **must move together**. Hardcoding one but driving the other off the determinator is a bug.
 
 ## Migration steps (dial-up pattern)
 
@@ -32,7 +32,7 @@ check_experiments: arc,lf
 
 Without this the determinator won't consider the ARC experiment and `use-arc` will always be `false`.
 
-### 2. Plumb four inputs into the build job
+### 2. Plumb five inputs into the build job
 
 On the call to `./.github/workflows/_linux-build.yml`:
 
@@ -40,15 +40,18 @@ On the call to `./.github/workflows/_linux-build.yml`:
 with:
   runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"  # likely already present
   ...existing inputs...
+  ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
   use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
   python-version: "3.10"     # match the docker-image-name's python
   compiler: gcc11            # match the docker-image-name's compiler
-  cuda-version: "13.0"       # match the docker-image-name's cuda (or "" for CPU)
+  cuda-version: "13.0"       # match the docker-image-name's cuda (or "cpu" for CPU)
 ```
 
-The last three feed `setup-linux` so it can configure the OSDC container env. Read them off the existing `docker-image-name` (e.g. `pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11` → py3.10 / gcc11 / cuda13.0).
+`ci-docker-hash` is the `git rev-parse HEAD:.ci/docker` hash that the determinator computes. `_linux-build.yml` appends it to the ghcr.io image tag (`ghcr.io/pytorch/<docker-image-name>-<hash>`); without it the OSDC build pulls the unhashed tag, which may not exist or may resolve to a stale image. The build job must have `needs: get-label-type` for this expression to resolve.
 
-### 3. Add `get-label-type` to the test job's `needs` and plumb the same inputs
+The last three (`python-version` / `compiler` / `cuda-version`) feed `setup-linux` so it can configure the OSDC container env. Read them off the existing `docker-image-name` (e.g. `pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11` → py3.10 / gcc11 / cuda13.0).
+
+### 3. Add `get-label-type` to the test job's `needs` and plumb the use-arc + setup-linux inputs
 
 On the call to `./.github/workflows/_linux-test.yml`:
 
@@ -64,7 +67,7 @@ with:
   cuda-version: "13.0"
 ```
 
-The test job needs a direct `needs: get-label-type` dependency to read its outputs (it can't rely on transitive `needs` through the build job).
+The test job needs a direct `needs: get-label-type` dependency to read its outputs (it can't rely on transitive `needs` through the build job). `ci-docker-hash` is **not** an input to `_linux-test.yml` — the test job picks the right image up via `needs.<build>.outputs.docker-image`.
 
 ### 4. Drop the OSDC-incompatible inputs
 
@@ -82,18 +85,20 @@ aws-role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_
 
 ## Migration steps (100% opt-in pattern)
 
-For a job that should always run on OSDC, skip the determinator-driven plumbing and hardcode:
+For a job that should always run on OSDC, hardcode `runner_prefix` and `use-arc` instead of pulling them from the determinator. The build job still needs `ci-docker-hash` from `get-label-type`, so keep `needs: get-label-type`:
 
 ```yaml
+needs: get-label-type
 with:
   runner_prefix: "mt-"
+  ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
   use-arc: true
   python-version: "3.10"
   compiler: gcc11
   cuda-version: "13.0"
 ```
 
-Both jobs (build *and* test) need the four inputs. The build job's `runner:` stays as the EC2 label (e.g. `linux.r7i.4xlarge`); `_linux-build.yml`'s `build-osdc` job translates that to the right ARC runner via `map_ec2_to_arc.py`.
+Both jobs (build *and* test) need the `use-arc` + `python-version` / `compiler` / `cuda-version` inputs; only the build job needs `ci-docker-hash`. The build job's `runner:` stays as the EC2 label (e.g. `linux.r7i.4xlarge`); `_linux-build.yml`'s `build-osdc` job translates that to the right ARC runner via `map_ec2_to_arc.py`.
 
 Reference: `operator_microbenchmark.yml` jobs `opmicrobenchmark-build-b200` / `opmicrobenchmark-test-b200`.
 
@@ -102,21 +107,16 @@ Reference: `operator_microbenchmark.yml` jobs `opmicrobenchmark-build-b200` / `o
 `_linux-build.yml` and `_linux-test.yml` each define **two jobs**:
 
 - `build` / `test` — EC2 path. Runs directly on the runner host VM. Gated on `!inputs.use-arc`.
-- `build-osdc` / `test-osdc` — OSDC path. Runs inside a `container:` from `ghcr.io/pytorch/${docker-image-name}`. Gated on `inputs.use-arc`.
+- `build-osdc` / `test-osdc` — OSDC path. Runs inside a `container:` from `ghcr.io/pytorch/${docker-image-name}${ci-docker-hash ? '-' + ci-docker-hash : ''}`. Gated on `inputs.use-arc`.
 
-The OSDC jobs call `setup-linux` with `use-arc: true` and pass `python-version` / `compiler` / `cuda-version` so the container env matches the build environment. That's why the migration must pass these three inputs — `setup-linux` errors out without them on the OSDC path.
+The OSDC jobs call `setup-linux` with `use-arc: true` and pass `python-version` / `compiler` / `cuda-version` so the container env matches the build environment. That's why the migration must pass these three inputs — `setup-linux` errors out without them on the OSDC path. `ci-docker-hash` is what pins the ghcr.io image tag to a specific `.ci/docker` tree state so the build doesn't drift onto an unhashed (or wrong) image.
 
 ## Common gotchas
 
 - **Forgetting `check_experiments: arc,lf`** → `use-arc` is always `false`, so OSDC never activates and you'll think the migration silently failed.
 - **Forgetting `needs: get-label-type` on the test job** → `${{ needs.get-label-type.outputs.use-arc }}` evaluates to empty, dial-up doesn't engage.
+- **Forgetting `ci-docker-hash` on the build job** → OSDC pulls the unhashed ghcr.io tag (`<docker-image-name>` with no `-<hash>` suffix), which may not exist or may resolve to a stale image. The failure mode is a `manifest unknown` pull error in the OSDC container step.
+- **Plumbing `ci-docker-hash` from `needs.get-label-type.outputs.*` without adding `needs: get-label-type`** → the expression resolves to empty, so it's a silent no-op equivalent to not setting it at all.
 - **Mismatched `python-version` / `compiler` / `cuda-version` vs. `docker-image-name`** → container has one toolchain, `setup-linux` configures another, build fails confusingly.
 - **Leaving `aws-role-to-assume:` for ECR** → harmless on OSDC (it's only used by EC2 path) but stale and misleading; remove it.
-- **Mixing patterns** (dynamic `runner_prefix` + hardcoded `use-arc: true`, or vice versa) — see `feedback-osdc-migration-dial-up.md`. Pick one pattern and apply it consistently.
-
-## Cross-references
-
-- `osdc-workflow-pattern.md` — for *standalone* OSDC workflows (no reusable build/test).
-- `feedback-osdc-migration-dial-up.md` — why both inputs must move together.
-- `ci-consolidation.md` — what's shared / different between EC2 (`build`/`test`) and OSDC (`build-osdc`/`test-osdc`) jobs in the reusable workflows.
-- `arc-cpu-build-test.md` — how the OSDC path actually runs once activated.
+- **Mixing patterns** (dynamic `runner_prefix` + hardcoded `use-arc: true`, or vice versa). Pick one pattern and apply it consistently.


### PR DESCRIPTION
## Summary

- Update the `migrate-workflow-ec2-to-osdc` skill to include `ci-docker-hash` as a required input on the build side. Without it, the OSDC `build-osdc` job pulls `ghcr.io/pytorch/<docker-image-name>` (no `-<hash>` suffix) and fails with `manifest unknown`. Recent migrations of `pull.yml`/`trunk.yml` already plumb this; the playbook didn't reflect that yet.
- Note that `ci-docker-hash` is **not** an input to `_linux-test.yml`; only the build job needs it.
- Show `ci-docker-hash` in the 100% opt-in example with explicit `needs: get-label-type`, and add a gotcha for the silent no-op when the expression is plumbed without that dependency.
- Drop cross-references to local-only memory files (`osdc-workflow-pattern.md`, `feedback-osdc-migration-dial-up.md`, `ci-consolidation.md`, `arc-cpu-build-test.md`) — those files don't exist in environments that load this skill, so the relevant rules have been inlined.

Authored by Claude.

## Test plan

- [ ] Visual review of the rendered skill markdown.
- [ ] Confirm the worked example matches the `pull.yml`/`trunk.yml` shape on `pytorch/pytorch@main`.