### PR TITLE
Isolate Poetry validation into its own release-only job

### DIFF
--- a/.github/scripts/validate_poetry.sh
+++ b/.github/scripts/validate_poetry.sh
@@ -1,7 +1,11 @@
 
 conda create -y -n ${ENV_NAME}_poetry python=${MATRIX_PYTHON_VERSION} numpy ffmpeg
 conda activate ${ENV_NAME}_poetry
-curl -sSL https://install.python-poetry.org | python3 - --git https://github.com/python-poetry/poetry.git@main
+# Pin Poetry to a released version. Installing from @main has caused
+# recurring CI flakes whenever Poetry's dev branch regresses. Bump
+# POETRY_VERSION deliberately when you want to upgrade.
+POETRY_VERSION="${POETRY_VERSION:-2.4.1}"
+curl -sSL https://install.python-poetry.org | python3 - --version "${POETRY_VERSION}"
 export PATH="/root/.local/bin:$PATH"
 
 poetry --version
@@ -24,11 +28,11 @@ if [[ ! -z ${RELEASE_VERSION} ]]; then
 fi
 
 if [[ ${TORCH_ONLY} == 'true' ]]; then
-    poetry --quiet add torch${RELEASE_SUFFIX}
+    poetry add --no-interaction torch${RELEASE_SUFFIX}
 elif [[ ${INCLUDE_TORCHAUDIO:-} == 'true' ]]; then
-    poetry --quiet add torch${RELEASE_SUFFIX} torchaudio torchvision
+    poetry add --no-interaction torch${RELEASE_SUFFIX} torchaudio torchvision
 else
-    poetry --quiet add torch${RELEASE_SUFFIX} torchvision
+    poetry add --no-interaction torch${RELEASE_SUFFIX} torchvision
 fi
 
 pushd ${PWD}/../.ci/pytorch/

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -141,18 +141,41 @@ jobs:
         eval "$(conda shell.bash hook)"
         printf '%s\n' ${{ toJson(inputs.release-matrix) }} > release_matrix.json
 
-        CUDA_VERSION_STABLE=$(python3 ../../test-infra/tools/scripts/get_stable_cuda_version.py --channel ${MATRIX_CHANNEL})
-        # Special case PyPi installation package. And Install of PyPi package via poetry
-        if [[ ${MATRIX_PACKAGE_TYPE} == "manywheel" && \
-              ${MATRIX_GPU_ARCH_VERSION} == "${CUDA_VERSION_STABLE}" && \
-              ${MATRIX_CHANNEL} == "release" && \
-              ${USE_ONLY_DL_PYTORCH_ORG} == "false" && \
-              ${USE_WHEEL_VARIANTS} == "false" ]]; then
-          source ../../test-infra/.github/scripts/validate_poetry.sh
-        fi
-
-        # Validate binaries
+        # Validate binaries. Poetry-based validation now lives in the
+        # standalone linux-poetry job below so Poetry's own ecosystem
+        # churn (it was previously installed from poetry@main) cannot
+        # flake the binary matrix.
         source ../../test-infra/.github/scripts/validate_binaries.sh
+
+  linux-poetry:
+    if: ${{ inputs.channel == 'release' }}
+    uses: ./.github/workflows/linux_job_v2.yml
+    name: poetry-test
+    with:
+      runner: "linux.g5.4xlarge.nvidia.gpu"
+      repository: "pytorch/pytorch"
+      ref: main
+      job-name: "poetry-test"
+      docker-image: 'pytorch/almalinux-builder:cpu-main'
+      docker-build-dir: "skip-docker-build"
+      timeout: 60
+      script: |
+        set -ex
+        export ENV_NAME="conda-env-${{ github.run_id }}"
+        export TORCH_ONLY=${{ inputs.torchonly }}
+        export INCLUDE_TORCHAUDIO=${{ inputs.include-torchaudio }}
+        export RELEASE_VERSION=${{ inputs.version }}
+        export TARGET_OS="linux"
+        eval "$(conda shell.bash hook)"
+        printf '%s\n' ${{ toJson(inputs.release-matrix) }} > release_matrix.json
+
+        # Poetry test is release-channel-only and covers a single
+        # stable-CUDA / Python 3.11 path. The full validate-binaries
+        # matrix above already covers every other combination via pip.
+        export MATRIX_PYTHON_VERSION="3.11"
+        export MATRIX_GPU_ARCH_VERSION=$(python3 ../../test-infra/tools/scripts/get_stable_cuda_version.py --channel ${{ inputs.channel }})
+
+        source ../../test-infra/.github/scripts/validate_poetry.sh
 
   linux-amazon-2023:
     uses: ./.github/workflows/linux_job_v2.yml


### PR DESCRIPTION
## Summary

The Poetry-based validation was sourced inline inside the main `manywheel` matrix job in `validate-linux-binaries.yml`, gated by a 5-condition check, and Poetry itself was installed from its dev branch (`poetry@main`). When Poetry's main branch regressed, the whole binary-validation job went red for the stable-CUDA Python 3.11 combination, masking the actual binary signal. See [this failed run](https://github.com/pytorch/test-infra/actions/runs/25807301043/job/75813679800) for the most recent example.

Three coordinated changes:

### 1. Split Poetry into a standalone `linux-poetry` job

In `.github/workflows/validate-linux-binaries.yml`, the inline `source validate_poetry.sh` block (with its 5-condition gate) is removed from the `linux:` matrix job. A new `linux-poetry:` top-level job is added, modeled on the existing `linux-amazon-2023:` job:

```yaml
linux-poetry:
  if: ${{ inputs.channel == 'release' }}
  uses: ./.github/workflows/linux_job_v2.yml
  name: poetry-test
  with:
    runner: "linux.g5.4xlarge.nvidia.gpu"
    repository: "pytorch/pytorch"
    ref: main
    job-name: "poetry-test"
    docker-image: 'pytorch/almalinux-builder:cpu-main'
    docker-build-dir: "skip-docker-build"
    timeout: 60
```

It runs **only on `inputs.channel == 'release'`** and exports a fixed Python 3.11 / stable-CUDA combination, matching what the old inline gate selected.

### 2. Pin Poetry to a released version

In `.github/scripts/validate_poetry.sh`:

```diff
-curl -sSL https://install.python-poetry.org | python3 - --git https://github.com/python-poetry/poetry.git@main
+POETRY_VERSION="${POETRY_VERSION:-2.4.1}"
+curl -sSL https://install.python-poetry.org | python3 - --version "${POETRY_VERSION}"
```

Installing from `poetry@main` has caused recurring CI flakes whenever Poetry's dev branch regresses. `POETRY_VERSION` is env-overridable; bump deliberately to upgrade.

### 3. Surface Poetry's actual error

`poetry --quiet add ...` silenced resolution errors (today's `exit 1` had no further output). Replaced with `poetry add --no-interaction ...` so resolution errors print but Poetry still doesn't prompt.

## Test plan

- [x] `bash -n .github/scripts/validate_poetry.sh` passes.
- [x] The new `linux-poetry:` job mirrors the existing `linux-amazon-2023:` job structure; both reuse `linux_job_v2.yml` with the same input shape.
- [ ] Verify via dispatch on the `release` channel that the new `linux-poetry` job appears and runs; verify on `nightly` / `test` channels that it is skipped.
- [ ] Verify that the next `validate-linux-binaries` run is no longer red when Poetry's main is broken.

## Effect on `vllm#40077`-style flakes

| Before | After |
|---|---|
| Poetry-main breakage → red `manywheel-py3_11-cuda13_0` job → looks like a binary regression | Poetry-main breakage → red `poetry-test` job only; binary validation is unaffected |
| `--quiet` hides the real error | `--no-interaction` keeps prompts off but lets errors print |
| Poetry installed from `@main` | Poetry pinned to `${POETRY_VERSION:-2.4.1}` |
| Poetry runs on every matrix entry matching 5 conditions | Poetry runs once, on `channel == 'release'` only |

Authored with Claude Code.