### PR TITLE
Fix poetry-test resolver failure when torchvision excludes a future Python (pytorch/vision#9307)

### DIFF
--- a/.github/scripts/validate_poetry.sh
+++ b/.github/scripts/validate_poetry.sh
@@ -9,8 +9,15 @@ curl -sSL https://install.python-poetry.org | python3 - --version "${POETRY_VERS
 export PATH="/root/.local/bin:$PATH"
 
 poetry --version
-poetry new test_poetry
+# `poetry init` (instead of `poetry new`) so we can give the project a
+# narrow Python range. `poetry new` always writes an open-ended
+# requires-python = ">=X.Y", which breaks Poetry resolution whenever a
+# target wheel excludes a future Python that falls in the range (e.g.
+# torchvision 0.27.0 excludes Python 3.14.1 -- pytorch/vision#9307).
+mkdir test_poetry
 cd test_poetry
+poetry init --no-interaction --name test_poetry \
+    --python ">=${MATRIX_PYTHON_VERSION},<3.$((${MATRIX_PYTHON_VERSION#*.} + 1))"
 
 TEST_SUFFIX=""
 if [[ ${TORCH_ONLY} == 'true' ]]; then


### PR DESCRIPTION
## Summary

Fixes the `poetry-test` job's release-channel failure observed in [run 25819051911](https://github.com/pytorch/test-infra/actions/runs/25819051911/job/75855222112). The root cause is the torchvision-side bug tracked in [pytorch/vision#9307](https://github.com/pytorch/vision/issues/9307): torchvision 0.27.0's wheel metadata excludes Python 3.14.1 specifically (`Requires-Python: !=3.14.1,>=3.10`). Combined with Poetry's strict resolver, this blocks the smoke test entirely.

## Why this breaks

`validate_poetry.sh` previously called `poetry new test_poetry`, which writes an **open-ended** `requires-python = ">=X.Y"` (e.g. `">=3.11"`) into the generated `pyproject.toml`. Poetry's resolver then has to find a torchvision version that's installable across the project's entire declared Python range — including Python 3.14.1. Because torchvision 0.27.0 excludes that exact patch ([pytorch/vision#9307](https://github.com/pytorch/vision/issues/9307)), no version is lockable:

```
The current project's supported Python range (>=3.11) is not compatible
with some of the required packages Python requirement:
  - torchvision requires Python !=3.14.1,>=3.10, so it will not be
    installable for Python 3.14.1

Because no versions of torchvision match >0.27.0,<0.28.0
 and torchvision (0.27.0) requires Python !=3.14.1,>=3.10,
 torchvision is forbidden.
So, because test-poetry depends on torchvision (^0.27.0), version
 solving failed.
```

(This error only became visible after #8075 dropped `--quiet` from the `poetry add` calls.)

## Fix

Replace `poetry new test_poetry` with `poetry init --no-interaction --python ">=X.Y,<X.(Y+1)"`, which writes a **narrow** Python range into the generated `pyproject.toml` directly. For `MATRIX_PYTHON_VERSION=3.11` the project ends up at `requires-python = ">=3.11,<3.12"`. That range excludes 3.14.1 entirely, so torchvision's `!=3.14.1` constraint no longer applies and resolution succeeds.

This is also more accurate: the test now reflects the runtime we actually set up via `conda create python=${MATRIX_PYTHON_VERSION}`, rather than the open-ended `">=X.Y"` Poetry defaults to.

No workflow-file changes — `linux-poetry:` is already present on `main` from #8075. The cosmetic display of `linux-poetry:` in this PR's diff is a GitHub artifact (the merge-base predates #8075's squash merge); the workflow file content is byte-identical to `pytorch/test-infra:main` and the merge will be a no-op on it.

## Test plan

- [x] Diagnosed against [run 25819051911](https://github.com/pytorch/test-infra/actions/runs/25819051911/job/75855222112), the first run that surfaced Poetry's real error after `--quiet` was removed.
- [ ] CI on this PR's release-channel `poetry-test` job re-runs `poetry add torch torchvision` cleanly.

## Upstream tracking

- [pytorch/vision#9307](https://github.com/pytorch/vision/issues/9307) — torchvision excludes Python 3.14.1 in its wheel metadata.

Authored with Claude Code.