### PR TITLE
Use setup-uv wrapper in upload-benchmark-results

### DIFF
--- a/.github/actions/upload-benchmark-results/action.yml
+++ b/.github/actions/upload-benchmark-results/action.yml
@@ -28,7 +28,7 @@ runs:
   using: composite
   steps:
     - name: Setup uv
-      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      uses: pytorch/test-infra/.github/actions/setup-uv@main
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
## Summary

`upload-benchmark-results` calls `astral-sh/setup-uv@v6.1.0` directly without
pinning a `version:`, so setup-uv has to query the GitHub API to resolve the
latest uv release. In PyTorch CI, setup-uv has been observed rejecting the
workflow `GITHUB_TOKEN` (logs `No (valid) GitHub token provided`) and falling
back to anonymous requests, which then hit the per-IP rate limit. This is
especially painful on the OSDC ARC fleet where many jobs share a NAT egress
IP (e.g. `3.139.130.18`), so the 60/hr anonymous budget is exhausted almost
immediately. Example failure:
https://github.com/pytorch/pytorch/actions/runs/25825809816/job/75882485920

Switch to `pytorch/test-infra/.github/actions/setup-uv`, the wrapper we
introduced precisely for this case — it pins uv to an explicit version so no
GitHub API call is made.

## Test plan

- [ ] After merge, re-run an OSDC ARC test job that uploads benchmark results
  (e.g. a `linux-jammy-py3.10-clang18` test-osdc shard) and confirm the
  "Upload the benchmark results" step no longer falls back to anonymous uv
  setup.