### PR TITLE
chore(security): Pin high-blast-radius actions to immutable SHAs

### DIFF
--- a/.github/workflows/_claude-code.yml
+++ b/.github/workflows/_claude-code.yml
@@ -77,7 +77,7 @@ jobs:
       id-token: write
     steps:
       - name: Verify write access
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const allowedBots = ['pytorch-auto-revert[bot]'];
@@ -104,7 +104,7 @@ jobs:
 
       - name: Check for ghstack PR
         id: ghstack-check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             // Only applies to issue_comment events on pull requests
@@ -147,7 +147,7 @@ jobs:
             core.setOutput('ghstack_notice',
               'This is a ghstack PR. Write operations are disabled.');
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
 
@@ -156,13 +156,13 @@ jobs:
         run: ${{ inputs.setup_script }}
 
       - name: Configure AWS credentials via OIDC
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_claude_code
           aws-region: us-east-1
 
       - name: Set commit author to invoking user
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const actor = context.actor;

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -139,7 +139,7 @@ jobs:
         env:
           DEPENDENCIES_DIR: c:\temp\dependencies\
         if: inputs.architecture == 'arm64'
-        uses: git-for-windows/setup-git-for-windows-sdk@v1
+        uses: git-for-windows/setup-git-for-windows-sdk@f52a672567ce424cb56dabb9b8d12995f041786f # v1.12.0
         with:
           architecture: aarch64
           path: "${{env.DEPENDENCIES_DIR}}\\git"

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -66,6 +66,6 @@ jobs:
         run: ls -R dist/
       - name: Publish package to PyPI
         if: ${{ inputs.dryrun == 'disabled' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           verbose: true


### PR DESCRIPTION
Pin third-party and sensitive GitHub Actions to commit SHAs in workflows where a compromised upstream action could impact release artifacts, AWS infrastructure, or package publishing.
Prioritized by blast radius:
- release-pypi.yml: pypa/gh-action-pypi-publish was on a branch ref
  (release/v1) — a compromise ships malicious packages to all pip users
- _claude-code.yml: github-script, aws-credentials, and checkout run
  with id-token:write + pull-requests:write — a compromise grants AWS
  IAM role assumption and code modification across all calling repos
- build_wheels_windows.yml: git-for-windows/setup-git-for-windows-sdk is community-maintained and runs in the wheel build pipeline — a
  compromise injects code into release binaries

Lower-risk actions (actions/checkout in test-only workflows, etc.) are
left on tags — Dependabot will keep all pinned SHAs up to date via the
existing weekly github-actions schedule.
