### PR TITLE
Update upload-benchmark-results to use local action paths

### DIFF
--- a/.github/actions/upload-benchmark-results/action.yml
+++ b/.github/actions/upload-benchmark-results/action.yml
@@ -28,7 +28,7 @@ runs:
   using: composite
   steps:
     - name: Setup uv
-      uses: pytorch/test-infra/.github/actions/setup-uv@main
+      uses: .github/actions/setup-uv
 
     - name: Install dependencies
       shell: bash
@@ -112,7 +112,7 @@ runs:
     - name: Get workflow job id
       if: ${{ inputs.github-token != '' }}
       id: get-job-id
-      uses: pytorch/test-infra/.github/actions/get-workflow-job-id@main
+      uses: .github/actions/get-workflow-job-id
       with:
         github-token: ${{ inputs.github-token }}
 

--- a/.github/actions/upload-benchmark-results/action.yml
+++ b/.github/actions/upload-benchmark-results/action.yml
@@ -28,7 +28,7 @@ runs:
   using: composite
   steps:
     - name: Setup uv
-      uses: .github/actions/setup-uv
+      uses: ./.github/actions/setup-uv
 
     - name: Install dependencies
       shell: bash
@@ -112,7 +112,7 @@ runs:
     - name: Get workflow job id
       if: ${{ inputs.github-token != '' }}
       id: get-job-id
-      uses: .github/actions/get-workflow-job-id
+      uses: ./.github/actions/get-workflow-job-id
       with:
         github-token: ${{ inputs.github-token }}
 


### PR DESCRIPTION
Some people might argue that referencing @main is not secure But it also can uncover some subtle bugs or create weird conflict if someone uses actionl.yml@sha which is not equal to main