### PR TITLE
autorevert: don't classify abandoned-after-revert PRs as confirmed false positives

### DIFF
--- a/torchci/lib/autorevert/fpVerification.ts
+++ b/torchci/lib/autorevert/fpVerification.ts
@@ -1,0 +1,178 @@
+// Shared PR-level false-positive verification used by both autorevert API
+// endpoints (`pages/api/autorevert/metrics.ts` and
+// `pages/api/autorevert/false-positives.ts`).
+//
+// Background: PyTorch lands via `pytorchmergebot` cherry-pick, so GitHub's
+// `merged_at` is unreliable; the `Merged` label is the truth signal that a PR
+// shipped. But both `Merged` and `Reverted` labels are STICKY — added by
+// mergebot on each cycle, never removed even after a subsequent revert. A PR
+// that goes merge → revert → abandon-without-reland still carries the `Merged`
+// label, looks "closed-and-was-merged-with-no-post-revert-commits", and gets
+// mis-classified as a confirmed FP.
+//
+// The decisive signal for abandonment is the actor of the LAST `closed`
+// timeline event. If the PR's terminal close is by someone other than
+// `pytorchmergebot` (typically the PR author or a maintainer), the human
+// stepped in to give up on relanding via this PR — that's a legitimate
+// revert, not an autorevert false positive.
+//
+// See: https://github.com/pytorch/pytorch/pull/182078 for a canonical case.
+
+export const MERGEBOT_LOGIN = "pytorchmergebot";
+
+export interface FpVerificationResult {
+  pr_state: string;
+  pr_merged: boolean;
+  commits_after_revert: number;
+  verification_status: "confirmed_fp" | "legit_revert" | "unknown";
+  verification_reason: string;
+}
+
+interface PrLike {
+  state: string;
+  labels?: Array<{ name: string }>;
+}
+
+interface CommitLike {
+  commit: {
+    committer?: { date?: string };
+    author?: { date?: string };
+  };
+}
+
+interface TimelineEventLike {
+  event: string;
+  actor?: { login?: string } | null;
+}
+
+export function countCommitsAfter(
+  commits: CommitLike[],
+  cutoff: Date
+): number {
+  return commits.filter((c) => {
+    const ts = new Date(
+      c.commit.committer?.date || c.commit.author?.date || 0
+    );
+    return ts > cutoff;
+  }).length;
+}
+
+export function lastCloseActor(
+  timeline: TimelineEventLike[]
+): string | undefined {
+  for (let i = timeline.length - 1; i >= 0; i--) {
+    const ev = timeline[i];
+    if (ev.event === "closed") {
+      return ev.actor?.login ?? undefined;
+    }
+  }
+  return undefined;
+}
+
+export function classifyFp(args: {
+  pr: PrLike;
+  commits: CommitLike[];
+  timeline: TimelineEventLike[];
+  revertTime: Date;
+}): FpVerificationResult {
+  const { pr, commits, timeline, revertTime } = args;
+  const labelNames = (pr.labels ?? []).map((l) => l.name);
+  const hasMergedLabel = labelNames.includes("Merged");
+  const hasAutorevertDisable = labelNames.includes("autorevert: disable");
+  const commitsAfterRevert = countCommitsAfter(commits, revertTime);
+
+  let verificationStatus: FpVerificationResult["verification_status"];
+  let verificationReason: string;
+
+  if (hasAutorevertDisable) {
+    verificationStatus = "confirmed_fp";
+    verificationReason = "PR has 'autorevert: disable' label";
+  } else if (pr.state === "open") {
+    verificationStatus = "legit_revert";
+    verificationReason = "PR is still open (not relanded)";
+  } else if (commitsAfterRevert > 0) {
+    verificationStatus = "legit_revert";
+    verificationReason = `PR had ${commitsAfterRevert} commit(s) after revert (author fixed issues)`;
+  } else if (terminalCloseByHuman(timeline)) {
+    // PR was closed by someone other than pytorchmergebot — author abandoned
+    // the PR after the revert rather than letting mergebot reland. The
+    // `Merged` label is sticky from earlier cycles and cannot be trusted.
+    const actor = lastCloseActor(timeline) ?? "non-mergebot";
+    verificationStatus = "legit_revert";
+    verificationReason = `PR was closed by ${actor} (not pytorchmergebot) — author abandoned after revert`;
+  } else if (hasMergedLabel) {
+    verificationStatus = "confirmed_fp";
+    verificationReason =
+      "PR was merged (has 'Merged' label) with no changes after revert";
+  } else {
+    verificationStatus = "legit_revert";
+    verificationReason = "PR was closed without merging (abandoned)";
+  }
+
+  return {
+    pr_state: pr.state,
+    pr_merged: hasMergedLabel,
+    commits_after_revert: commitsAfterRevert,
+    verification_status: verificationStatus,
+    verification_reason: verificationReason,
+  };
+}
+
+function terminalCloseByHuman(timeline: TimelineEventLike[]): boolean {
+  const actor = lastCloseActor(timeline);
+  return actor !== undefined && actor !== MERGEBOT_LOGIN;
+}
+
+export async function verifyFpForPr(
+  octokit: any,
+  prNumber: number,
+  revertTime: Date
+): Promise<FpVerificationResult> {
+  try {
+    const { data: pr } = await octokit.rest.pulls.get({
+      owner: "pytorch",
+      repo: "pytorch",
+      pull_number: prNumber,
+    });
+
+    const commits = (await octokit.paginate(octokit.rest.pulls.listCommits, {
+      owner: "pytorch",
+      repo: "pytorch",
+      pull_number: prNumber,
+      per_page: 100,
+    })) as CommitLike[];
+
+    // Only fetch the timeline when we might need the actor check — i.e. the
+    // PR is closed AND has no post-revert commits AND doesn't carry the
+    // disable label. Open PRs short-circuit on step 2, PRs with post-revert
+    // commits short-circuit on step 3, and the disable label is decisive.
+    let timeline: TimelineEventLike[] = [];
+    const labelNames = (pr.labels ?? []).map((l: any) => l.name);
+    const needsTimeline =
+      pr.state === "closed" &&
+      !labelNames.includes("autorevert: disable") &&
+      countCommitsAfter(commits, revertTime) === 0;
+    if (needsTimeline) {
+      timeline = (await octokit.paginate(
+        octokit.rest.issues.listEventsForTimeline,
+        {
+          owner: "pytorch",
+          repo: "pytorch",
+          issue_number: prNumber,
+          per_page: 100,
+        }
+      )) as TimelineEventLike[];
+    }
+
+    return classifyFp({ pr, commits, timeline, revertTime });
+  } catch (error: any) {
+    console.error(`Error verifying PR #${prNumber}:`, error.message);
+    return {
+      pr_state: "unknown",
+      pr_merged: false,
+      commits_after_revert: -1,
+      verification_status: "unknown",
+      verification_reason: `Failed to fetch PR data: ${error.message}`,
+    };
+  }
+}

--- a/torchci/pages/api/autorevert/false-positives.ts
+++ b/torchci/pages/api/autorevert/false-positives.ts
@@ -1,6 +1,6 @@
+import { verifyFpForPr } from "lib/autorevert/fpVerification";
 import { queryClickhouseSaved } from "lib/clickhouse";
 import { getOctokit } from "lib/github";
-import { verifyFpForPr } from "lib/autorevert/fpVerification";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 // Simple in-memory cache with TTL

--- a/torchci/pages/api/autorevert/false-positives.ts
+++ b/torchci/pages/api/autorevert/false-positives.ts
@@ -1,5 +1,6 @@
 import { queryClickhouseSaved } from "lib/clickhouse";
 import { getOctokit } from "lib/github";
+import { verifyFpForPr } from "lib/autorevert/fpVerification";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 // Simple in-memory cache with TTL
@@ -39,6 +40,7 @@ interface FalsePositiveCandidate {
 
 interface VerifiedFalsePositive extends FalsePositiveCandidate {
   pr_state: string;
+  pr_merged: boolean;
   commits_after_revert: number;
   verification_status: "confirmed_fp" | "legit_revert" | "unknown";
   verification_reason: string;
@@ -50,66 +52,8 @@ async function verifyFalsePositive(
 ): Promise<VerifiedFalsePositive> {
   const prNumber = parseInt(candidate.original_pr);
   const revertTime = new Date(candidate.revert_time);
-
-  try {
-    // Fetch PR details
-    const { data: pr } = await octokit.rest.pulls.get({
-      owner: "pytorch",
-      repo: "pytorch",
-      pull_number: prNumber,
-    });
-
-    // Fetch commits on the PR
-    const commits = await octokit.paginate(octokit.rest.pulls.listCommits, {
-      owner: "pytorch",
-      repo: "pytorch",
-      pull_number: prNumber,
-      per_page: 100,
-    });
-
-    // Count commits after the revert time
-    const commitsAfterRevert = commits.filter((commit: any) => {
-      const commitTime = new Date(
-        commit.commit.committer?.date || commit.commit.author?.date
-      );
-      return commitTime > revertTime;
-    }).length;
-
-    // Determine verification status
-    let verificationStatus: "confirmed_fp" | "legit_revert" | "unknown";
-    let verificationReason: string;
-
-    if (pr.state === "open") {
-      // PR is still open - revert was legit, author hasn't relanded yet
-      verificationStatus = "legit_revert";
-      verificationReason = "PR is still open (not relanded)";
-    } else if (commitsAfterRevert > 0) {
-      // PR had commits after revert - author fixed something
-      verificationStatus = "legit_revert";
-      verificationReason = `PR had ${commitsAfterRevert} commit(s) after revert (author fixed issues)`;
-    } else {
-      // PR was merged and had no commits after revert - likely false positive
-      verificationStatus = "confirmed_fp";
-      verificationReason = "PR relanded with no changes after revert";
-    }
-
-    return {
-      ...candidate,
-      pr_state: pr.state,
-      commits_after_revert: commitsAfterRevert,
-      verification_status: verificationStatus,
-      verification_reason: verificationReason,
-    };
-  } catch (error: any) {
-    console.error(`Error verifying PR #${prNumber}:`, error.message);
-    return {
-      ...candidate,
-      pr_state: "unknown",
-      commits_after_revert: -1,
-      verification_status: "unknown",
-      verification_reason: `Failed to fetch PR data: ${error.message}`,
-    };
-  }
+  const result = await verifyFpForPr(octokit, prNumber, revertTime);
+  return { ...candidate, ...result };
 }
 
 export default async function handler(

--- a/torchci/pages/api/autorevert/metrics.ts
+++ b/torchci/pages/api/autorevert/metrics.ts
@@ -1,6 +1,6 @@
+import { verifyFpForPr } from "lib/autorevert/fpVerification";
 import { queryClickhouseSaved } from "lib/clickhouse";
 import { getOctokit } from "lib/github";
-import { verifyFpForPr } from "lib/autorevert/fpVerification";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 // Simple in-memory cache with TTL

--- a/torchci/pages/api/autorevert/metrics.ts
+++ b/torchci/pages/api/autorevert/metrics.ts
@@ -1,5 +1,6 @@
 import { queryClickhouseSaved } from "lib/clickhouse";
 import { getOctokit } from "lib/github";
+import { verifyFpForPr } from "lib/autorevert/fpVerification";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 // Simple in-memory cache with TTL
@@ -90,87 +91,8 @@ async function verifyFalsePositive(
 ): Promise<VerifiedFalsePositive> {
   const prNumber = parseInt(candidate.pr_number);
   const revertTime = new Date(candidate.autorevert_time);
-
-  try {
-    // Fetch PR details
-    const { data: pr } = await octokit.rest.pulls.get({
-      owner: "pytorch",
-      repo: "pytorch",
-      pull_number: prNumber,
-    });
-
-    // Fetch commits on the PR
-    const commits = await octokit.paginate(octokit.rest.pulls.listCommits, {
-      owner: "pytorch",
-      repo: "pytorch",
-      pull_number: prNumber,
-      per_page: 100,
-    });
-
-    // Count commits after the revert time
-    const commitsAfterRevert = commits.filter((commit: any) => {
-      const commitTime = new Date(
-        commit.commit.committer?.date || commit.commit.author?.date
-      );
-      return commitTime > revertTime;
-    }).length;
-
-    // Determine verification status
-    let verificationStatus: "confirmed_fp" | "legit_revert" | "unknown";
-    let verificationReason: string;
-
-    // Get PR labels
-    const labelNames = (pr.labels || []).map((l: any) => l.name);
-
-    // Check for "Merged" label - PyTorch uses cherry-pick merging via merge bot,
-    // so GitHub's merged_at won't be set. The "Merged" label indicates actual merge.
-    const hasMergedLabel = labelNames.includes("Merged");
-
-    // Check for "autorevert: disable" label - clear signal that autorevert was wrong
-    const hasAutorevertDisable = labelNames.includes("autorevert: disable");
-
-    if (hasAutorevertDisable) {
-      // Author explicitly disabled autorevert - clear false positive
-      verificationStatus = "confirmed_fp";
-      verificationReason = "PR has 'autorevert: disable' label";
-    } else if (pr.state === "open") {
-      // PR is still open - revert was legit, author hasn't relanded
-      verificationStatus = "legit_revert";
-      verificationReason = "PR is still open (not relanded)";
-    } else if (commitsAfterRevert > 0) {
-      // PR had commits after revert - author fixed something
-      verificationStatus = "legit_revert";
-      verificationReason = `PR had ${commitsAfterRevert} commit(s) after revert (author fixed issues)`;
-    } else if (hasMergedLabel) {
-      // PR has "Merged" label and no commits after revert - false positive
-      verificationStatus = "confirmed_fp";
-      verificationReason =
-        "PR was merged (has 'Merged' label) with no changes after revert";
-    } else {
-      // PR was closed but not merged (abandoned)
-      verificationStatus = "legit_revert";
-      verificationReason = "PR was closed without merging (abandoned)";
-    }
-
-    return {
-      ...candidate,
-      pr_state: pr.state,
-      pr_merged: hasMergedLabel,
-      commits_after_revert: commitsAfterRevert,
-      verification_status: verificationStatus,
-      verification_reason: verificationReason,
-    };
-  } catch (error: any) {
-    console.error(`Error verifying PR #${prNumber}:`, error.message);
-    return {
-      ...candidate,
-      pr_state: "unknown",
-      pr_merged: false,
-      commits_after_revert: -1,
-      verification_status: "unknown",
-      verification_reason: `Failed to fetch PR data: ${error.message}`,
-    };
-  }
+  const result = await verifyFpForPr(octokit, prNumber, revertTime);
+  return { ...candidate, ...result };
 }
 
 export default async function handler(

--- a/torchci/test/autorevertFpVerification.test.ts
+++ b/torchci/test/autorevertFpVerification.test.ts
@@ -1,0 +1,214 @@
+import {
+  classifyFp,
+  lastCloseActor,
+  MERGEBOT_LOGIN,
+  verifyFpForPr,
+} from "../lib/autorevert/fpVerification";
+
+const REVERT_TIME = new Date("2026-05-04T21:30:00Z");
+
+function pr(state: "open" | "closed", labels: string[] = []) {
+  return { state, labels: labels.map((name) => ({ name })) };
+}
+
+function commitAt(iso: string) {
+  return { commit: { committer: { date: iso } } };
+}
+
+function timeline(
+  ...events: Array<{ event: string; actor?: string | null }>
+) {
+  return events.map((e) => ({
+    event: e.event,
+    actor: e.actor === undefined ? null : { login: e.actor ?? "" },
+  }));
+}
+
+describe("lastCloseActor", () => {
+  it("returns the actor of the most recent closed event", () => {
+    expect(
+      lastCloseActor(
+        timeline(
+          { event: "closed", actor: MERGEBOT_LOGIN },
+          { event: "reopened", actor: MERGEBOT_LOGIN },
+          { event: "closed", actor: "alice" }
+        )
+      )
+    ).toBe("alice");
+  });
+
+  it("returns undefined when no closed event exists", () => {
+    expect(lastCloseActor(timeline({ event: "labeled", actor: "bot" }))).toBe(
+      undefined
+    );
+  });
+});
+
+describe("classifyFp decision tree", () => {
+  it("autorevert: disable label -> confirmed_fp", () => {
+    const result = classifyFp({
+      pr: pr("closed", ["autorevert: disable", "Merged"]),
+      commits: [],
+      timeline: timeline({ event: "closed", actor: MERGEBOT_LOGIN }),
+      revertTime: REVERT_TIME,
+    });
+    expect(result.verification_status).toBe("confirmed_fp");
+    expect(result.verification_reason).toMatch(/autorevert: disable/);
+  });
+
+  it("open PR -> legit_revert (not relanded)", () => {
+    const result = classifyFp({
+      pr: pr("open", ["Merged"]),
+      commits: [],
+      timeline: [],
+      revertTime: REVERT_TIME,
+    });
+    expect(result.verification_status).toBe("legit_revert");
+    expect(result.verification_reason).toMatch(/still open/);
+  });
+
+  it("commits after revert -> legit_revert (author fixed)", () => {
+    const result = classifyFp({
+      pr: pr("closed", ["Merged"]),
+      commits: [commitAt("2026-05-04T22:00:00Z"), commitAt("2026-05-04T22:30:00Z")],
+      timeline: timeline({ event: "closed", actor: MERGEBOT_LOGIN }),
+      revertTime: REVERT_TIME,
+    });
+    expect(result.verification_status).toBe("legit_revert");
+    expect(result.commits_after_revert).toBe(2);
+    expect(result.verification_reason).toMatch(/2 commit\(s\) after revert/);
+  });
+
+  it("terminal close by non-mergebot -> legit_revert (the fix; PR #182078 shape)", () => {
+    // The canonical case: PR went through merge->revert cycles, mergebot
+    // closed+reopened on each cycle, then the AUTHOR closed manually after
+    // the last revert. Sticky `Merged` label is present but the author's
+    // close is the authoritative signal that the PR was abandoned.
+    const result = classifyFp({
+      pr: pr("closed", ["Merged", "Reverted", "fb-exported"]),
+      commits: [],
+      timeline: timeline(
+        { event: "closed", actor: MERGEBOT_LOGIN },
+        { event: "reopened", actor: MERGEBOT_LOGIN },
+        { event: "closed", actor: MERGEBOT_LOGIN },
+        { event: "reopened", actor: MERGEBOT_LOGIN },
+        { event: "closed", actor: "Ruishenl" }
+      ),
+      revertTime: REVERT_TIME,
+    });
+    expect(result.verification_status).toBe("legit_revert");
+    expect(result.verification_reason).toMatch(
+      /closed by Ruishenl.*not pytorchmergebot/
+    );
+    // Sticky Merged label is reported but does not change classification.
+    expect(result.pr_merged).toBe(true);
+  });
+
+  it("terminal close by mergebot + Merged label -> confirmed_fp (clean reland)", () => {
+    const result = classifyFp({
+      pr: pr("closed", ["Merged"]),
+      commits: [],
+      timeline: timeline(
+        { event: "closed", actor: MERGEBOT_LOGIN },
+        { event: "reopened", actor: MERGEBOT_LOGIN },
+        { event: "closed", actor: MERGEBOT_LOGIN }
+      ),
+      revertTime: REVERT_TIME,
+    });
+    expect(result.verification_status).toBe("confirmed_fp");
+    expect(result.verification_reason).toMatch(/'Merged' label/);
+  });
+
+  it("closed-not-merged with no actor info and no Merged label -> legit_revert (abandoned)", () => {
+    const result = classifyFp({
+      pr: pr("closed"),
+      commits: [],
+      timeline: [],
+      revertTime: REVERT_TIME,
+    });
+    expect(result.verification_status).toBe("legit_revert");
+    expect(result.verification_reason).toMatch(/abandoned/);
+  });
+});
+
+describe("verifyFpForPr (mocked octokit)", () => {
+  function makeOctokit(opts: {
+    pr: any;
+    commits: any[];
+    timeline?: any[];
+    throwOn?: "pr" | "commits" | "timeline";
+  }) {
+    let timelineCalled = false;
+    const get = jest.fn(async () => {
+      if (opts.throwOn === "pr") throw new Error("boom-pr");
+      return { data: opts.pr };
+    });
+    const listCommits = jest.fn();
+    const listEventsForTimeline = jest.fn();
+    const paginate = jest.fn(async (fn: any) => {
+      if (fn === listCommits) {
+        if (opts.throwOn === "commits") throw new Error("boom-commits");
+        return opts.commits;
+      }
+      if (fn === listEventsForTimeline) {
+        timelineCalled = true;
+        if (opts.throwOn === "timeline") throw new Error("boom-timeline");
+        return opts.timeline ?? [];
+      }
+      return [];
+    });
+    return {
+      paginate,
+      timelineCalledRef: () => timelineCalled,
+      rest: {
+        pulls: { get, listCommits },
+        issues: { listEventsForTimeline },
+      },
+    };
+  }
+
+  it("does NOT fetch timeline when PR is open (saves an API call)", async () => {
+    const octokit = makeOctokit({
+      pr: pr("open", ["Merged"]),
+      commits: [],
+    });
+    const result = await verifyFpForPr(octokit, 182078, REVERT_TIME);
+    expect(result.verification_status).toBe("legit_revert");
+    expect(octokit.timelineCalledRef()).toBe(false);
+  });
+
+  it("does NOT fetch timeline when PR has commits after revert", async () => {
+    const octokit = makeOctokit({
+      pr: pr("closed", ["Merged"]),
+      commits: [commitAt("2026-05-04T22:00:00Z")],
+    });
+    const result = await verifyFpForPr(octokit, 182078, REVERT_TIME);
+    expect(result.verification_status).toBe("legit_revert");
+    expect(octokit.timelineCalledRef()).toBe(false);
+  });
+
+  it("FETCHES timeline for closed PR with no post-revert commits", async () => {
+    const octokit = makeOctokit({
+      pr: pr("closed", ["Merged", "Reverted"]),
+      commits: [],
+      timeline: [
+        { event: "closed", actor: { login: "Ruishenl" } },
+      ],
+    });
+    const result = await verifyFpForPr(octokit, 182078, REVERT_TIME);
+    expect(octokit.timelineCalledRef()).toBe(true);
+    expect(result.verification_status).toBe("legit_revert");
+    expect(result.verification_reason).toMatch(/Ruishenl/);
+  });
+
+  it("returns unknown on API error", async () => {
+    const octokit = makeOctokit({
+      pr: null,
+      commits: [],
+      throwOn: "pr",
+    });
+    const result = await verifyFpForPr(octokit, 999999, REVERT_TIME);
+    expect(result.verification_status).toBe("unknown");
+    expect(result.commits_after_revert).toBe(-1);
+  });
+});

--- a/torchci/test/autorevertFpVerification.test.ts
+++ b/torchci/test/autorevertFpVerification.test.ts
@@ -15,9 +15,7 @@ function commitAt(iso: string) {
   return { commit: { committer: { date: iso } } };
 }
 
-function timeline(
-  ...events: Array<{ event: string; actor?: string | null }>
-) {
+function timeline(...events: Array<{ event: string; actor?: string | null }>) {
   return events.map((e) => ({
     event: e.event,
     actor: e.actor === undefined ? null : { login: e.actor ?? "" },
@@ -70,7 +68,10 @@ describe("classifyFp decision tree", () => {
   it("commits after revert -> legit_revert (author fixed)", () => {
     const result = classifyFp({
       pr: pr("closed", ["Merged"]),
-      commits: [commitAt("2026-05-04T22:00:00Z"), commitAt("2026-05-04T22:30:00Z")],
+      commits: [
+        commitAt("2026-05-04T22:00:00Z"),
+        commitAt("2026-05-04T22:30:00Z"),
+      ],
       timeline: timeline({ event: "closed", actor: MERGEBOT_LOGIN }),
       revertTime: REVERT_TIME,
     });
@@ -191,9 +192,7 @@ describe("verifyFpForPr (mocked octokit)", () => {
     const octokit = makeOctokit({
       pr: pr("closed", ["Merged", "Reverted"]),
       commits: [],
-      timeline: [
-        { event: "closed", actor: { login: "Ruishenl" } },
-      ],
+      timeline: [{ event: "closed", actor: { login: "Ruishenl" } }],
     });
     const result = await verifyFpForPr(octokit, 182078, REVERT_TIME);
     expect(octokit.timelineCalledRef()).toBe(true);


### PR DESCRIPTION
## Summary

The FP-verification decision tree on both `/api/autorevert/metrics` and `/api/autorevert/false-positives` was mis-classifying PRs that went through a merge -> revert -> author-abandoned cycle as `confirmed_fp`. GitHub's `Merged` label is sticky -- added by `pytorchmergebot` on the first merge attempt and never removed even after a subsequent revert. A PR that gets reverted and then closed by the author (without re-landing) ends up with `pr.state === "closed"`, `commitsAfterRevert === 0`, and `hasMergedLabel === true`, hitting the `confirmed_fp` branch in the decision tree even though the autorevert was actually correct.

This depresses the HUD precision number we report on hud.pytorch.org and feeds noise into our daily autorevert feedback investigations.

### Canonical case

[pytorch/pytorch#182078](https://github.com/pytorch/pytorch/pull/182078) went through 3 merge -> revert cycles in 36h on the co-dev (`fb-exported`) path. Autorevert correctly flagged the underlying lint failure each cycle. The author closed the PR 11 min after the 3rd revert, intending to reland via a fresh export PR. Timeline structural events (the ~60 `merging`-label cycles in between are elided):

```
2026-05-04T05:46:39Z  closed     pytorchmergebot   commit=1f41b97c58
2026-05-04T06:13:01Z  reopened   pytorchmergebot
2026-05-04T21:19:43Z  closed     pytorchmergebot   commit=8145d630e8
2026-05-04T21:48:04Z  reopened   pytorchmergebot
2026-05-04T21:59:00Z  closed     Ruishenl                            <- author manual abandon
```

HUD currently classifies #182078 as `confirmed_fp`; with this fix it becomes `legit_revert (abandoned)`.

## Fix

Before falling back to the `hasMergedLabel` branch (step 4 of the decision tree), check the actor of the PR's most recent `closed` timeline event. If it's anyone other than `pytorchmergebot` (typically the author or a maintainer), the human decided the PR is done -> `legit_revert (abandoned)`. The timeline fetch is gated to only run when the PR is closed AND has no post-revert commits AND isn't carrying the disable label, so the extra octokit call only fires on candidates that would otherwise reach step 4.

Shared verification logic is extracted to `torchci/lib/autorevert/fpVerification.ts` so both API endpoints stay in sync. `pages/api/autorevert/false-positives.ts` had the same gap as `metrics.ts` and is fixed in the same diff.

## Decision tree (new step inserted as step 4)

1. `autorevert: disable` label -> `confirmed_fp`
2. `pr.state === "open"` -> `legit_revert` (not relanded)
3. `commitsAfterRevert > 0` -> `legit_revert` (author fixed)
4. **NEW -- terminal close by non-mergebot -> `legit_revert (abandoned)`**
5. `hasMergedLabel` -> `confirmed_fp` (clean reland with sticky Merged label and no post-revert commits)
6. else -> `legit_revert` (closed without merging)

## Test plan

- [x] Unit tests covering all 5 decision branches + the timeline-fetch gating in `torchci/test/autorevertFpVerification.test.ts`
- [x] Tests use mock octokit; no live API calls
- [ ] CI green
- [ ] Once merged: read HUD precision metric one cycle later and observe whether any of the 7 historical `confirmed_fp` cases in the 2026-04-28->2026-05-12 backfill window flip to `legit_revert (abandoned)`. If >=3 flip, the current precision number is meaningfully understated.
