### PR TITLE
autorevert: extract FP-verification logic to shared lib (no behavior change)

### DIFF
--- a/torchci/lib/autorevert/fpVerification.ts
+++ b/torchci/lib/autorevert/fpVerification.ts
@@ -1,0 +1,105 @@
+// Shared PR-level false-positive verification used by the autorevert API
+// endpoints under `pages/api/autorevert/`.
+//
+// PyTorch lands via `pytorchmergebot` cherry-pick, so GitHub's `merged_at` is
+// unreliable — the `Merged` label is the truth signal that a PR shipped.
+
+export interface FpVerificationResult {
+  pr_state: string;
+  pr_merged: boolean;
+  commits_after_revert: number;
+  verification_status: "confirmed_fp" | "legit_revert" | "unknown";
+  verification_reason: string;
+}
+
+interface PrLike {
+  state: string;
+  labels?: Array<{ name: string }>;
+}
+
+interface CommitLike {
+  commit: {
+    committer?: { date?: string };
+    author?: { date?: string };
+  };
+}
+
+export function countCommitsAfter(commits: CommitLike[], cutoff: Date): number {
+  return commits.filter((c) => {
+    const ts = new Date(c.commit.committer?.date || c.commit.author?.date || 0);
+    return ts > cutoff;
+  }).length;
+}
+
+export function classifyFp(args: {
+  pr: PrLike;
+  commits: CommitLike[];
+  revertTime: Date;
+}): FpVerificationResult {
+  const { pr, commits, revertTime } = args;
+  const labelNames = (pr.labels ?? []).map((l) => l.name);
+  const hasMergedLabel = labelNames.includes("Merged");
+  const hasAutorevertDisable = labelNames.includes("autorevert: disable");
+  const commitsAfterRevert = countCommitsAfter(commits, revertTime);
+
+  let verificationStatus: FpVerificationResult["verification_status"];
+  let verificationReason: string;
+
+  if (hasAutorevertDisable) {
+    verificationStatus = "confirmed_fp";
+    verificationReason = "PR has 'autorevert: disable' label";
+  } else if (pr.state === "open") {
+    verificationStatus = "legit_revert";
+    verificationReason = "PR is still open (not relanded)";
+  } else if (commitsAfterRevert > 0) {
+    verificationStatus = "legit_revert";
+    verificationReason = `PR had ${commitsAfterRevert} commit(s) after revert (author fixed issues)`;
+  } else if (hasMergedLabel) {
+    verificationStatus = "confirmed_fp";
+    verificationReason =
+      "PR was merged (has 'Merged' label) with no changes after revert";
+  } else {
+    verificationStatus = "legit_revert";
+    verificationReason = "PR was closed without merging (abandoned)";
+  }
+
+  return {
+    pr_state: pr.state,
+    pr_merged: hasMergedLabel,
+    commits_after_revert: commitsAfterRevert,
+    verification_status: verificationStatus,
+    verification_reason: verificationReason,
+  };
+}
+
+export async function verifyFpForPr(
+  octokit: any,
+  prNumber: number,
+  revertTime: Date
+): Promise<FpVerificationResult> {
+  try {
+    const { data: pr } = await octokit.rest.pulls.get({
+      owner: "pytorch",
+      repo: "pytorch",
+      pull_number: prNumber,
+    });
+
+    const commits = (await octokit.paginate(octokit.rest.pulls.listCommits, {
+      owner: "pytorch",
+      repo: "pytorch",
+      pull_number: prNumber,
+      per_page: 100,
+    })) as CommitLike[];
+
+    return classifyFp({ pr, commits, revertTime });
+  } catch (error: any) {
+    console.error(`Error verifying PR #${prNumber}:`, error.message);
+    return {
+      pr_state: "unknown",
+      pr_merged: false,
+      commits_after_revert: -1,
+      verification_status: "unknown",
+      verification_reason: `Failed to fetch PR data: ${error.message}`,
+    };
+  }
+}

--- a/torchci/pages/api/autorevert/metrics.ts
+++ b/torchci/pages/api/autorevert/metrics.ts
@@ -1,3 +1,4 @@
+import { verifyFpForPr } from "lib/autorevert/fpVerification";
 import { queryClickhouseSaved } from "lib/clickhouse";
 import { getOctokit } from "lib/github";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -90,87 +91,8 @@ async function verifyFalsePositive(
 ): Promise<VerifiedFalsePositive> {
   const prNumber = parseInt(candidate.pr_number);
   const revertTime = new Date(candidate.autorevert_time);
-
-  try {
-    // Fetch PR details
-    const { data: pr } = await octokit.rest.pulls.get({
-      owner: "pytorch",
-      repo: "pytorch",
-      pull_number: prNumber,
-    });
-
-    // Fetch commits on the PR
-    const commits = await octokit.paginate(octokit.rest.pulls.listCommits, {
-      owner: "pytorch",
-      repo: "pytorch",
-      pull_number: prNumber,
-      per_page: 100,
-    });
-
-    // Count commits after the revert time
-    const commitsAfterRevert = commits.filter((commit: any) => {
-      const commitTime = new Date(
-        commit.commit.committer?.date || commit.commit.author?.date
-      );
-      return commitTime > revertTime;
-    }).length;
-
-    // Determine verification status
-    let verificationStatus: "confirmed_fp" | "legit_revert" | "unknown";
-    let verificationReason: string;
-
-    // Get PR labels
-    const labelNames = (pr.labels || []).map((l: any) => l.name);
-
-    // Check for "Merged" label - PyTorch uses cherry-pick merging via merge bot,
-    // so GitHub's merged_at won't be set. The "Merged" label indicates actual merge.
-    const hasMergedLabel = labelNames.includes("Merged");
-
-    // Check for "autorevert: disable" label - clear signal that autorevert was wrong
-    const hasAutorevertDisable = labelNames.includes("autorevert: disable");
-
-    if (hasAutorevertDisable) {
-      // Author explicitly disabled autorevert - clear false positive
-      verificationStatus = "confirmed_fp";
-      verificationReason = "PR has 'autorevert: disable' label";
-    } else if (pr.state === "open") {
-      // PR is still open - revert was legit, author hasn't relanded
-      verificationStatus = "legit_revert";
-      verificationReason = "PR is still open (not relanded)";
-    } else if (commitsAfterRevert > 0) {
-      // PR had commits after revert - author fixed something
-      verificationStatus = "legit_revert";
-      verificationReason = `PR had ${commitsAfterRevert} commit(s) after revert (author fixed issues)`;
-    } else if (hasMergedLabel) {
-      // PR has "Merged" label and no commits after revert - false positive
-      verificationStatus = "confirmed_fp";
-      verificationReason =
-        "PR was merged (has 'Merged' label) with no changes after revert";
-    } else {
-      // PR was closed but not merged (abandoned)
-      verificationStatus = "legit_revert";
-      verificationReason = "PR was closed without merging (abandoned)";
-    }
-
-    return {
-      ...candidate,
-      pr_state: pr.state,
-      pr_merged: hasMergedLabel,
-      commits_after_revert: commitsAfterRevert,
-      verification_status: verificationStatus,
-      verification_reason: verificationReason,
-    };
-  } catch (error: any) {
-    console.error(`Error verifying PR #${prNumber}:`, error.message);
-    return {
-      ...candidate,
-      pr_state: "unknown",
-      pr_merged: false,
-      commits_after_revert: -1,
-      verification_status: "unknown",
-      verification_reason: `Failed to fetch PR data: ${error.message}`,
-    };
-  }
+  const result = await verifyFpForPr(octokit, prNumber, revertTime);
+  return { ...candidate, ...result };
 }
 
 export default async function handler(


### PR DESCRIPTION
## Summary

Pure refactor. Moves the body of `verifyFalsePositive` from `torchci/pages/api/autorevert/metrics.ts` into a new shared module `torchci/lib/autorevert/fpVerification.ts`. The decision tree, return shape, error path, and cache wiring are unchanged.

Splits the work so that follow-up behavior changes (a new decision-tree step for abandoned-after-revert PRs, see #182078) can be reviewed as a separate diff against the extracted module.

Stacked PR for the behavior change: see https://github.com/pytorch/test-infra/pull/new/iz/autorevert-fp-abandon-actor-check (opened together with this PR).

## Test plan

- [x] `yarn tsc --noEmit` passes locally (node 20)
- [x] `yarn prettier --check` passes locally
- [ ] CI green
