### PR TITLE
ci: declare workflow-level `contents: read` on 26 read-only workflows

### DIFF
--- a/.github/workflows/actions-test.yml
+++ b/.github/workflows/actions-test.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - '.github/actions/upload-artifact-s3/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/bc-linter-tests.yml
+++ b/.github/workflows/bc-linter-tests.yml
@@ -16,6 +16,9 @@ defaults:
   run:
     working-directory: tools/stronghold/
 
+permissions:
+  contents: read
+
 jobs:
   bc-linter-tests:
     name: BC-Linter Tests

--- a/.github/workflows/checkout-licensed.yml
+++ b/.github/workflows/checkout-licensed.yml
@@ -12,6 +12,9 @@ on:
     paths:
       - '.github/actions/checkout/**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/checkout-test.yml
+++ b/.github/workflows/checkout-test.yml
@@ -17,6 +17,9 @@ on:
 # these refer to "test-data" branches on this actions/checkout repo.
 # (For example, test-data/v2/basic -> https://github.com/actions/checkout/tree/test-data/v2/basic)
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cross-repo-ci-relay-tests.yml
+++ b/.github/workflows/cross-repo-ci-relay-tests.yml
@@ -16,6 +16,9 @@ defaults:
   run:
     working-directory: aws/lambda/cross_repo_ci_relay/
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/lambda-runner-binaries-syncer.yml
+++ b/.github/workflows/lambda-runner-binaries-syncer.yml
@@ -8,6 +8,9 @@ on:
       - .github/workflows/lambda-runner-binaries-syncer.yml
       - "terraform-aws-github-runner/modules/runner-binaries-syncer/lambdas/runner-binaries-syncer/**"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Run tests for runner binaries syncer lambda"

--- a/.github/workflows/lambda-runners.yml
+++ b/.github/workflows/lambda-runners.yml
@@ -8,6 +8,9 @@ on:
       - .github/workflows/lambda-runners.yml
       - "terraform-aws-github-runner/modules/runners/lambdas/runners/**"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Run tests for runners lambda"

--- a/.github/workflows/lambda-webhook.yml
+++ b/.github/workflows/lambda-webhook.yml
@@ -8,6 +8,9 @@ on:
       - .github/workflows/lambda-webhook.yml
       - "terraform-aws-github-runner/modules/webhook/lambdas/webhook/**"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Run tests for webhook lambda"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lintrunner:
     name: lintrunner

--- a/.github/workflows/scale_config_validation.yml
+++ b/.github/workflows/scale_config_validation.yml
@@ -10,6 +10,9 @@ on:
       - .github/scale-config.yml
       - .github/scripts/validate_scale_config.py
 
+permissions:
+  contents: read
+
 jobs:
   scale-config-validation:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-binary-size-validation.yml
+++ b/.github/workflows/test-binary-size-validation.yml
@@ -7,6 +7,9 @@ on:
       - tools/binary_size_validation/binary_size_validation.py
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-binary-size-validation:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-export-matrix-variables.yml
+++ b/.github/workflows/test-export-matrix-variables.yml
@@ -6,6 +6,9 @@ on:
       - .github/workflows/test-export-matrix-variables.yml
       - .github/actions/export-matrix-variables/*
 
+permissions:
+  contents: read
+
 jobs:
   test-linux:
     uses: ./.github/workflows/linux_job_v2.yml

--- a/.github/workflows/test-setup-miniconda.yml
+++ b/.github/workflows/test-setup-miniconda.yml
@@ -7,6 +7,9 @@ on:
       - .github/actions/check-disk-space/*
       - .github/actions/setup-miniconda/*
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/test-setup-nvidia.yml
+++ b/.github/workflows/test-setup-nvidia.yml
@@ -7,6 +7,9 @@ on:
       - .github/actions/setup-nvidia/action.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/test-setup-python.yml
+++ b/.github/workflows/test-setup-python.yml
@@ -6,6 +6,9 @@ on:
       - .github/actions/setup-python/*
       - .github/workflows/test-setup-python.yml
 
+permissions:
+  contents: read
+
 jobs:
   setup-python-job:
     runs-on: macos-m1-stable

--- a/.github/workflows/test-setup-uv.yml
+++ b/.github/workflows/test-setup-uv.yml
@@ -7,6 +7,9 @@ on:
       - .github/actions/setup-uv/action.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/test-validate-domain-library.yml
+++ b/.github/workflows/test-validate-domain-library.yml
@@ -7,6 +7,9 @@ on:
       - .github/workflows/test-validate-domain-library.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-validate-domain-library:
     uses: ./.github/workflows/validate-domain-library.yml

--- a/.github/workflows/test_linux_job.yml
+++ b/.github/workflows/test_linux_job.yml
@@ -9,6 +9,9 @@ on:
       - .github/scripts/run_with_env_secrets.py
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-secrets-no-filter-var:
     uses: ./.github/workflows/linux_job.yml

--- a/.github/workflows/test_macos_job.yml
+++ b/.github/workflows/test_macos_job.yml
@@ -8,6 +8,9 @@ on:
       - .github/scripts/run_with_env_secrets.py
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-m1:
     uses: ./.github/workflows/macos_job.yml

--- a/.github/workflows/test_windows_job.yml
+++ b/.github/workflows/test_windows_job.yml
@@ -7,6 +7,9 @@ on:
       - .github/workflows/test_windows_job.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-cpu:
     uses: ./.github/workflows/windows_job.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test-tools:
     name: Test tools

--- a/.github/workflows/torchci.yml
+++ b/.github/workflows/torchci.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/trigger_nightly.yml
+++ b/.github/workflows/trigger_nightly.yml
@@ -27,6 +27,10 @@ on:
           - torchcomms
           - torchforge
           - all
+
+permissions:
+  contents: read
+
 jobs:
   trigger:
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger_nightly_core.yml
+++ b/.github/workflows/trigger_nightly_core.yml
@@ -6,6 +6,9 @@ on:
     - cron: 30 7 * * *
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   trigger:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-pypi-wheel-binary-size.yml
+++ b/.github/workflows/validate-pypi-wheel-binary-size.yml
@@ -17,6 +17,9 @@ on:
     # At 2:30 pm UTC (7:30 am PDT)
     - cron: "30 14 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   pypi-binary-size-validation:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-repackaged-binary-sizes.yml
+++ b/.github/workflows/validate-repackaged-binary-sizes.yml
@@ -18,6 +18,9 @@ on:
       - .github/workflows/validate-repackaged-binary-sizes.yml
       - release/pypi/prep_binary_for_pypi.sh
 
+permissions:
+  contents: read
+
 jobs:
   generate-linux-matrix:
     uses: ./.github/workflows/generate_binary_build_matrix.yml


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on the 26 workflows in `.github/workflows/` that don't actually need any write scope.

A mix of:

- Composite-action tests: `actions-test.yml`, `checkout-licensed.yml`, `checkout-test.yml`, `cross-repo-ci-relay-tests.yml`, `test_linux_job.yml`, `test_macos_job.yml`, `test_windows_job.yml`, `test-setup-miniconda.yml`, `test-setup-nvidia.yml`, `test-setup-python.yml`, `test-setup-uv.yml`, `test-export-matrix-variables.yml`.
- Linters and validators: `bc-linter-tests.yml`, `lint.yml`, `scale_config_validation.yml`, `test-binary-size-validation.yml`, `test-validate-domain-library.yml`, `tests.yml`, `torchci.yml`, `validate-pypi-wheel-binary-size.yml`, `validate-repackaged-binary-sizes.yml`.
- Nightly triggers: `trigger_nightly.yml`, `trigger_nightly_core.yml`.
- Lambda + webhook checks: `lambda-runners.yml`, `lambda-runner-binaries-syncer.yml`, `lambda-webhook.yml`.

None of those call a GitHub API beyond the initial checkout or use `github.token` / `GITHUB_TOKEN`.

Left implicit on purpose: workflows that pass `github.token` to a `gh` step or otherwise touch the API (`actions-check-dist.yml`, `checkout-check-dist.yml`, `disable-flaky-tests.yml`, `pytorch-auto-revert-tests.yml`, `test-setup-ssh.yml`, `tflint.yml`, `update-inductor-expected-accuracy.yml`, `validate-nightly-binaries.yml`, `windows-ami-validation.yml`) plus the explicit-write files (`update-drci-comments.yml`, `validate-release-binaries.yml`). Those scopes are best declared by maintainers who know the right shape.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps that runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.