### PR TITLE
autorevert metrics: third FN category for killswitch-active windows

### DIFF
--- a/torchci/clickhouse_queries/autorevert_killswitch_windows/params.json
+++ b/torchci/clickhouse_queries/autorevert_killswitch_windows/params.json
@@ -1,0 +1,15 @@
+{
+  "params": {
+    "stopTime": "DateTime64(3)"
+  },
+  "tests": [
+    {
+      "stopTime": "2026-05-15 00:00:00.000"
+    },
+    {
+      "stopTime": {
+        "from_now": 0
+      }
+    }
+  ]
+}

--- a/torchci/clickhouse_queries/autorevert_killswitch_windows/query.sql
+++ b/torchci/clickhouse_queries/autorevert_killswitch_windows/query.sql
@@ -1,0 +1,26 @@
+-- All add/remove events of the global autorevert killswitch label
+-- (`ci: disable-autorevert`) on pytorch/pytorch issues, plus each
+-- issue's `closed_at` (empty if still open). The caller folds the
+-- event stream per-issue into [on_ts, off_ts] active intervals,
+-- treating a `closed_at` as an implicit `unlabeled` (the autorevert
+-- lambda only honors the label on OPEN issues). Events outside the
+-- metrics window are needed to resolve intervals that span it.
+SELECT
+    e.event_time AS event_time,
+    e.action AS action,
+    e.issue_number AS issue_number,
+    coalesce(c.closed_at_str, '') AS issue_closed_at
+FROM default.issues_label_event AS e
+LEFT JOIN
+(
+    SELECT
+        number AS issue_number,
+        argMax(closed_at, updated_at) AS closed_at_str
+    FROM default.issues
+    WHERE repository_url = 'https://api.github.com/repos/pytorch/pytorch'
+    GROUP BY number
+) AS c ON c.issue_number = e.issue_number
+WHERE e.repo_name = 'pytorch/pytorch'
+  AND e.label_name = 'ci: disable-autorevert'
+  AND e.event_time <= {stopTime: DateTime64(3)} + INTERVAL 1 DAY
+ORDER BY e.issue_number, e.event_time

--- a/torchci/clickhouse_queries/autorevert_killswitch_windows/query.sql
+++ b/torchci/clickhouse_queries/autorevert_killswitch_windows/query.sql
@@ -5,22 +5,25 @@
 -- treating a `closed_at` as an implicit `unlabeled` (the autorevert
 -- lambda only honors the label on OPEN issues). Events outside the
 -- metrics window are needed to resolve intervals that span it.
+WITH issue_close AS (
+    SELECT
+        number AS issue_number,
+        argMax(closed_at, updated_at) AS closed_at_str
+    FROM default.issues
+    WHERE
+        repository_url = 'https://api.github.com/repos/pytorch/pytorch'
+    GROUP BY number
+)
+
 SELECT
     e.event_time AS event_time,
     e.action AS action,
     e.issue_number AS issue_number,
     coalesce(c.closed_at_str, '') AS issue_closed_at
 FROM default.issues_label_event AS e
-LEFT JOIN
-(
-    SELECT
-        number AS issue_number,
-        argMax(closed_at, updated_at) AS closed_at_str
-    FROM default.issues
-    WHERE repository_url = 'https://api.github.com/repos/pytorch/pytorch'
-    GROUP BY number
-) AS c ON c.issue_number = e.issue_number
-WHERE e.repo_name = 'pytorch/pytorch'
-  AND e.label_name = 'ci: disable-autorevert'
-  AND e.event_time <= {stopTime: DateTime64(3)} + INTERVAL 1 DAY
+LEFT JOIN issue_close AS c ON c.issue_number = e.issue_number
+WHERE
+    e.repo_name = 'pytorch/pytorch'
+    AND e.label_name = 'ci: disable-autorevert'
+    AND e.event_time <= {stopTime: DateTime64(3)} + INTERVAL 1 DAY
 ORDER BY e.issue_number, e.event_time

--- a/torchci/lib/autorevert/killswitchWindows.ts
+++ b/torchci/lib/autorevert/killswitchWindows.ts
@@ -1,0 +1,63 @@
+// Fold `ci: disable-autorevert` label add/remove events on pytorch/pytorch
+// issues into per-issue active intervals. The autorevert lambda only honors
+// the label on OPEN issues, so an issue close acts as an implicit
+// `unlabeled` event if no explicit one preceded it.
+
+export interface KillswitchLabelEvent {
+  event_time: string;
+  action: "labeled" | "unlabeled" | string;
+  issue_number: number;
+  issue_closed_at: string;
+}
+
+export interface KillswitchWindow {
+  issue_number: number;
+  on: string;
+  off: string | null;
+}
+
+export function foldKillswitchWindows(
+  events: KillswitchLabelEvent[]
+): KillswitchWindow[] {
+  const byIssue = new Map<number, KillswitchLabelEvent[]>();
+  for (const e of events) {
+    if (!byIssue.has(e.issue_number)) byIssue.set(e.issue_number, []);
+    byIssue.get(e.issue_number)!.push(e);
+  }
+  const windows: KillswitchWindow[] = [];
+  for (const [issueNumber, evs] of byIssue.entries()) {
+    evs.sort((a, b) => a.event_time.localeCompare(b.event_time));
+    let onTs: string | null = null;
+    for (const e of evs) {
+      if (e.action === "labeled" && onTs === null) {
+        onTs = e.event_time;
+      } else if (e.action === "unlabeled" && onTs !== null) {
+        windows.push({ issue_number: issueNumber, on: onTs, off: e.event_time });
+        onTs = null;
+      }
+    }
+    if (onTs !== null) {
+      const closedAt = evs[0].issue_closed_at;
+      windows.push({
+        issue_number: issueNumber,
+        on: onTs,
+        off: closedAt && closedAt !== "" ? closedAt : null,
+      });
+    }
+  }
+  windows.sort((a, b) => a.on.localeCompare(b.on));
+  return windows;
+}
+
+export function killswitchWindowAt(
+  windows: KillswitchWindow[],
+  t: string
+): KillswitchWindow | null {
+  const ts = new Date(t).getTime();
+  for (const w of windows) {
+    const on = new Date(w.on).getTime();
+    const off = w.off === null ? Infinity : new Date(w.off).getTime();
+    if (ts >= on && ts <= off) return w;
+  }
+  return null;
+}

--- a/torchci/lib/autorevert/killswitchWindows.ts
+++ b/torchci/lib/autorevert/killswitchWindows.ts
@@ -32,7 +32,11 @@ export function foldKillswitchWindows(
       if (e.action === "labeled" && onTs === null) {
         onTs = e.event_time;
       } else if (e.action === "unlabeled" && onTs !== null) {
-        windows.push({ issue_number: issueNumber, on: onTs, off: e.event_time });
+        windows.push({
+          issue_number: issueNumber,
+          on: onTs,
+          off: e.event_time,
+        });
         onTs = null;
       }
     }

--- a/torchci/pages/api/autorevert/metrics.ts
+++ b/torchci/pages/api/autorevert/metrics.ts
@@ -1,4 +1,9 @@
 import { verifyFpForPr } from "lib/autorevert/fpVerification";
+import {
+  foldKillswitchWindows,
+  KillswitchLabelEvent,
+  killswitchWindowAt,
+} from "lib/autorevert/killswitchWindows";
 import { queryClickhouseSaved } from "lib/clickhouse";
 import { getOctokit } from "lib/github";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -81,6 +86,7 @@ interface WeeklyMetric {
   human_revert_rate: number;
   // New metrics
   false_positives: number;
+  false_negatives_killswitch: number;
   precision: number;
   recall: number;
 }
@@ -148,21 +154,29 @@ export default async function handler(
     };
 
     // Run queries in parallel
-    const [significantReverts, autorevertEvents, weeklyMetricsRaw] =
-      await Promise.all([
-        queryClickhouseSaved(
-          "autorevert_significant_reverts",
-          queryParams
-        ) as Promise<SignificantRevert[]>,
-        queryClickhouseSaved(
-          "autorevert_events_with_commits",
-          queryParams
-        ) as Promise<AutorevertEvent[]>,
-        queryClickhouseSaved(
-          "autorevert_weekly_metrics",
-          queryParams
-        ) as Promise<any[]>,
-      ]);
+    const [
+      significantReverts,
+      autorevertEvents,
+      weeklyMetricsRaw,
+      killswitchEvents,
+    ] = await Promise.all([
+      queryClickhouseSaved(
+        "autorevert_significant_reverts",
+        queryParams
+      ) as Promise<SignificantRevert[]>,
+      queryClickhouseSaved(
+        "autorevert_events_with_commits",
+        queryParams
+      ) as Promise<AutorevertEvent[]>,
+      queryClickhouseSaved(
+        "autorevert_weekly_metrics",
+        queryParams
+      ) as Promise<any[]>,
+      queryClickhouseSaved("autorevert_killswitch_windows", {
+        stopTime: queryParams.stopTime,
+      }) as Promise<KillswitchLabelEvent[]>,
+    ]);
+    const killswitchWindows = foldKillswitchWindows(killswitchEvents);
 
     // Build set of recovery SHAs (reverts that fixed signals)
     const recoveryShaSet = new Set(
@@ -191,10 +205,27 @@ export default async function handler(
       }
     }
 
-    // Count False Negatives: human reverts with signal recovery
-    const falseNegatives = significantReverts.filter(
+    // Count False Negatives: human reverts with signal recovery. Partition
+    // out the ones where the autorevert killswitch was active at recovery
+    // time — those are not a lambda miss; they're an upstream_infra class
+    // (`ci: disable-autorevert` label on an open issue, see
+    // `default.issues_label_event`). Killswitch FNs are surfaced as a
+    // third category and excluded from the recall denominator.
+    const allFalseNegatives = significantReverts.filter(
       (r) => !r.is_autorevert && r.recovery_type === "human_revert_recovery"
     );
+    const falseNegatives: SignificantRevert[] = [];
+    const falseNegativesKillswitch: Array<
+      SignificantRevert & { killswitch_issue: number }
+    > = [];
+    for (const r of allFalseNegatives) {
+      const w = killswitchWindowAt(killswitchWindows, r.recovery_time);
+      if (w) {
+        falseNegativesKillswitch.push({ ...r, killswitch_issue: w.issue_number });
+      } else {
+        falseNegatives.push(r);
+      }
+    }
 
     // Verify false positive candidates via GitHub API
     let verifiedFPs: VerifiedFalsePositive[] = [];
@@ -236,22 +267,32 @@ export default async function handler(
     const precision = tp + fp > 0 ? (tp / (tp + fp)) * 100 : 100;
     const recall = tp + fn > 0 ? (tp / (tp + fn)) * 100 : 100;
 
-    // Enhance weekly metrics with precision/recall
-    // Group FPs by week for weekly precision calculation
+    // Enhance weekly metrics with precision/recall.
+    // Group FPs and killswitch-FNs by week for the weekly aggregation.
     const fpByWeek = new Map<string, number>();
     for (const fp of confirmedFPs) {
       const week = getWeekStart(new Date(fp.autorevert_time));
       fpByWeek.set(week, (fpByWeek.get(week) || 0) + 1);
     }
+    const fnKsByWeek = new Map<string, number>();
+    for (const r of falseNegativesKillswitch) {
+      const week = getWeekStart(new Date(r.recovery_time));
+      fnKsByWeek.set(week, (fnKsByWeek.get(week) || 0) + 1);
+    }
 
     const weeklyMetrics: WeeklyMetric[] = weeklyMetricsRaw.map((w) => {
       const weekFPs = fpByWeek.get(w.week) || 0;
+      const weekFNKs = fnKsByWeek.get(w.week) || 0;
       const weekTP = w.autorevert_recoveries;
-      const weekFN = w.human_revert_recoveries;
+      // human_revert_recoveries from the saved query counts all human
+      // reverts with signal recovery; subtract the killswitch-attributed
+      // ones so weekly recall matches the overall recall semantics.
+      const weekFN = Math.max(0, w.human_revert_recoveries - weekFNKs);
 
       return {
         ...w,
         false_positives: weekFPs,
+        false_negatives_killswitch: weekFNKs,
         precision:
           weekTP + weekFPs > 0
             ? Math.round((weekTP / (weekTP + weekFPs)) * 1000) / 10
@@ -272,6 +313,7 @@ export default async function handler(
         tp_without_signal_recovery: tpWithoutSignalRecovery,
         confirmed_false_positives: fp,
         false_negatives: fn,
+        false_negatives_killswitch: falseNegativesKillswitch.length,
         // Rates
         precision: Math.round(precision * 10) / 10,
         recall: Math.round(recall * 10) / 10,
@@ -282,6 +324,7 @@ export default async function handler(
       },
       weeklyMetrics,
       significantReverts,
+      killswitchWindows,
       falsePositives: {
         candidates_checked: falsePositiveCandidates.length,
         confirmed: confirmedFPs,
@@ -293,6 +336,13 @@ export default async function handler(
         recovery_time: r.recovery_time,
         signals_fixed: r.signals_fixed,
         reverted_pr_numbers: r.reverted_pr_numbers,
+      })),
+      falseNegativesKillswitch: falseNegativesKillswitch.map((r) => ({
+        recovery_sha: r.recovery_sha,
+        recovery_time: r.recovery_time,
+        signals_fixed: r.signals_fixed,
+        reverted_pr_numbers: r.reverted_pr_numbers,
+        killswitch_issue: r.killswitch_issue,
       })),
     };
 

--- a/torchci/pages/api/autorevert/metrics.ts
+++ b/torchci/pages/api/autorevert/metrics.ts
@@ -168,10 +168,9 @@ export default async function handler(
         "autorevert_events_with_commits",
         queryParams
       ) as Promise<AutorevertEvent[]>,
-      queryClickhouseSaved(
-        "autorevert_weekly_metrics",
-        queryParams
-      ) as Promise<any[]>,
+      queryClickhouseSaved("autorevert_weekly_metrics", queryParams) as Promise<
+        any[]
+      >,
       queryClickhouseSaved("autorevert_killswitch_windows", {
         stopTime: queryParams.stopTime,
       }) as Promise<KillswitchLabelEvent[]>,
@@ -221,7 +220,10 @@ export default async function handler(
     for (const r of allFalseNegatives) {
       const w = killswitchWindowAt(killswitchWindows, r.recovery_time);
       if (w) {
-        falseNegativesKillswitch.push({ ...r, killswitch_issue: w.issue_number });
+        falseNegativesKillswitch.push({
+          ...r,
+          killswitch_issue: w.issue_number,
+        });
       } else {
         falseNegatives.push(r);
       }

--- a/torchci/pages/metrics/autorevert.tsx
+++ b/torchci/pages/metrics/autorevert.tsx
@@ -110,6 +110,22 @@ function MetricsLegend() {
             </Typography>
           </Box>
         </Tooltip>
+        <Tooltip title="Human reverts that landed while autorevert was disabled via the `ci: disable-autorevert` label on an open issue. Excluded from recall.">
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            <Box
+              sx={{
+                width: 12,
+                height: 12,
+                bgcolor: "#9c6ade",
+                borderRadius: 0.5,
+              }}
+            />
+            <Typography variant="body2">
+              <strong>FN (disabled)</strong> = autorevert was off (excluded from
+              recall)
+            </Typography>
+          </Box>
+        </Tooltip>
         <Tooltip title="Autoreverts that were wrong: no signal recovery AND PR was merged unchanged after revert">
           <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
             <Box
@@ -178,6 +194,7 @@ function WeeklyTrendChart({ data }: { data: any[] | undefined }) {
       data: [
         "TP (Autorevert)",
         "FN (Human Revert)",
+        "FN (Disabled)",
         "FP (Wrong Revert)",
         "Non-Revert Fix",
         "Precision %",
@@ -212,8 +229,21 @@ function WeeklyTrendChart({ data }: { data: any[] | undefined }) {
         name: "FN (Human Revert)",
         type: "bar",
         stack: "counts",
-        data: data.map((d) => d.human_revert_recoveries),
+        data: data.map((d) =>
+          Math.max(
+            0,
+            (d.human_revert_recoveries || 0) -
+              (d.false_negatives_killswitch || 0)
+          )
+        ),
         itemStyle: { color: "#ed6c02" },
+      },
+      {
+        name: "FN (Disabled)",
+        type: "bar",
+        stack: "counts",
+        data: data.map((d) => d.false_negatives_killswitch || 0),
+        itemStyle: { color: "#9c6ade" },
       },
       {
         name: "FP (Wrong Revert)",
@@ -419,7 +449,27 @@ function FalsePositivesTable({ data }: { data: any | undefined }) {
   );
 }
 
-function SignificantRevertsTable({ data }: { data: any[] | undefined }) {
+function killswitchIssueAt(
+  windows: any[] | undefined,
+  t: string
+): number | null {
+  if (!windows) return null;
+  const ts = new Date(t).getTime();
+  for (const w of windows) {
+    const on = new Date(w.on).getTime();
+    const off = w.off === null ? Infinity : new Date(w.off).getTime();
+    if (ts >= on && ts <= off) return w.issue_number;
+  }
+  return null;
+}
+
+function SignificantRevertsTable({
+  data,
+  killswitchWindows,
+}: {
+  data: any[] | undefined;
+  killswitchWindows?: any[];
+}) {
   if (data === undefined) {
     return <Skeleton variant="rectangular" height={400} />;
   }
@@ -464,19 +514,47 @@ function SignificantRevertsTable({ data }: { data: any[] | undefined }) {
                   </Tooltip>
                 </TableCell>
                 <TableCell>
-                  <Chip
-                    label={
-                      row.recovery_type === "autorevert_recovery" ? "TP" : "FN"
-                    }
-                    size="small"
-                    sx={{
-                      backgroundColor:
-                        row.recovery_type === "autorevert_recovery"
-                          ? "#3ba272"
-                          : "#ed6c02",
-                      color: "white",
-                    }}
-                  />
+                  {(() => {
+                    const isAR = row.recovery_type === "autorevert_recovery";
+                    const ksIssue = isAR
+                      ? null
+                      : killswitchIssueAt(killswitchWindows, row.recovery_time);
+                    const label = isAR
+                      ? "TP"
+                      : ksIssue !== null
+                      ? "FN (disabled)"
+                      : "FN";
+                    const bg = isAR
+                      ? "#3ba272"
+                      : ksIssue !== null
+                      ? "#9c6ade"
+                      : "#ed6c02";
+                    const tooltip =
+                      ksIssue !== null
+                        ? `Killswitch active via ci: disable-autorevert on issue #${ksIssue}`
+                        : "";
+                    const chip = (
+                      <Chip
+                        label={label}
+                        size="small"
+                        sx={{ backgroundColor: bg, color: "white" }}
+                      />
+                    );
+                    return ksIssue !== null ? (
+                      <Tooltip title={tooltip}>
+                        <a
+                          href={`https://github.com/pytorch/pytorch/issues/${ksIssue}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          style={{ textDecoration: "none" }}
+                        >
+                          {chip}
+                        </a>
+                      </Tooltip>
+                    ) : (
+                      chip
+                    );
+                  })()}
                 </TableCell>
                 <TableCell>{row.max_red_streak_length}</TableCell>
                 <TableCell>
@@ -634,7 +712,7 @@ export default function AutorevertMetricsPage() {
             value={
               summary?.recall !== undefined ? `${summary.recall}%` : undefined
             }
-            tooltip="TP / (TP + FN) - How many reverts autorevert catches"
+            tooltip="TP / (TP + FN) - How many reverts autorevert catches. Excludes FN (Disabled) — reverts where the `ci: disable-autorevert` killswitch was active."
             color="#91cc75"
           />
         </Grid>
@@ -668,6 +746,14 @@ export default function AutorevertMetricsPage() {
         </Grid>
         <Grid size={{ xs: 6, sm: 2 }}>
           <ScalarMetric
+            title="FN (Disabled)"
+            value={summary?.false_negatives_killswitch}
+            tooltip="Human reverts that landed while autorevert was disabled via the `ci: disable-autorevert` label on an open issue. Excluded from recall."
+            color="#9c6ade"
+          />
+        </Grid>
+        <Grid size={{ xs: 6, sm: 2 }}>
+          <ScalarMetric
             title="Total Autoreverts"
             value={summary?.total_autoreverts}
             tooltip="Total autorevert events in the selected workflows"
@@ -682,7 +768,10 @@ export default function AutorevertMetricsPage() {
       <WeeklyTrendChart data={metricsData?.weeklyMetrics} />
 
       {/* Significant Reverts Table */}
-      <SignificantRevertsTable data={metricsData?.significantReverts} />
+      <SignificantRevertsTable
+        data={metricsData?.significantReverts}
+        killswitchWindows={metricsData?.killswitchWindows}
+      />
 
       {/* False Positives Table */}
       <FalsePositivesTable data={metricsData?.falsePositives} />

--- a/torchci/test/autorevertKillswitchWindows.test.ts
+++ b/torchci/test/autorevertKillswitchWindows.test.ts
@@ -1,0 +1,115 @@
+import {
+  foldKillswitchWindows,
+  KillswitchLabelEvent,
+  killswitchWindowAt,
+} from "../lib/autorevert/killswitchWindows";
+
+function ev(
+  issue: number,
+  action: "labeled" | "unlabeled",
+  time: string,
+  closed: string = ""
+): KillswitchLabelEvent {
+  return {
+    issue_number: issue,
+    action,
+    event_time: time,
+    issue_closed_at: closed,
+  };
+}
+
+describe("foldKillswitchWindows", () => {
+  it("pairs labeled with the next unlabeled on the same issue", () => {
+    const out = foldKillswitchWindows([
+      ev(183016, "labeled", "2026-05-09 01:36:48"),
+      ev(183016, "unlabeled", "2026-05-12 16:47:26"),
+    ]);
+    expect(out).toEqual([
+      {
+        issue_number: 183016,
+        on: "2026-05-09 01:36:48",
+        off: "2026-05-12 16:47:26",
+      },
+    ]);
+  });
+
+  it("falls back to issue closed_at when no unlabeled is present", () => {
+    const out = foldKillswitchWindows([
+      ev(170248, "labeled", "2025-12-11 22:46:59", "2025-12-11T22:59:45Z"),
+    ]);
+    expect(out).toEqual([
+      {
+        issue_number: 170248,
+        on: "2025-12-11 22:46:59",
+        off: "2025-12-11T22:59:45Z",
+      },
+    ]);
+  });
+
+  it("leaves off=null when label is still active on an open issue", () => {
+    const out = foldKillswitchWindows([
+      ev(999, "labeled", "2026-05-15 10:00:00"),
+    ]);
+    expect(out).toEqual([
+      { issue_number: 999, on: "2026-05-15 10:00:00", off: null },
+    ]);
+  });
+
+  it("handles multiple label-unlabel cycles on the same issue", () => {
+    const out = foldKillswitchWindows([
+      ev(1, "labeled", "2026-01-01 00:00:00"),
+      ev(1, "unlabeled", "2026-01-02 00:00:00"),
+      ev(1, "labeled", "2026-01-03 00:00:00"),
+      ev(1, "unlabeled", "2026-01-04 00:00:00"),
+    ]);
+    expect(out).toEqual([
+      {
+        issue_number: 1,
+        on: "2026-01-01 00:00:00",
+        off: "2026-01-02 00:00:00",
+      },
+      {
+        issue_number: 1,
+        on: "2026-01-03 00:00:00",
+        off: "2026-01-04 00:00:00",
+      },
+    ]);
+  });
+
+  it("returns windows sorted by on_ts across issues", () => {
+    const out = foldKillswitchWindows([
+      ev(2, "labeled", "2026-02-01 00:00:00", "2026-02-02T00:00:00Z"),
+      ev(1, "labeled", "2026-01-01 00:00:00", "2026-01-02T00:00:00Z"),
+    ]);
+    expect(out.map((w) => w.issue_number)).toEqual([1, 2]);
+  });
+});
+
+describe("killswitchWindowAt", () => {
+  const windows = [
+    {
+      issue_number: 183016,
+      on: "2026-05-09 01:36:48",
+      off: "2026-05-12 16:47:26",
+    },
+  ];
+
+  it("returns the matching window when t falls inside", () => {
+    const w = killswitchWindowAt(windows, "2026-05-12T16:11:46Z");
+    expect(w?.issue_number).toBe(183016);
+  });
+
+  it("returns null when t is before all windows", () => {
+    expect(killswitchWindowAt(windows, "2026-05-08T00:00:00Z")).toBeNull();
+  });
+
+  it("returns null when t is after all windows", () => {
+    expect(killswitchWindowAt(windows, "2026-05-13T00:00:00Z")).toBeNull();
+  });
+
+  it("treats null off as still-active", () => {
+    const open = [{ issue_number: 1, on: "2026-05-01 00:00:00", off: null }];
+    const w = killswitchWindowAt(open, "2026-12-01T00:00:00Z");
+    expect(w?.issue_number).toBe(1);
+  });
+});


### PR DESCRIPTION
Human reverts that landed while autorevert was disabled via the `ci: disable-autorevert` label on an open issue are misclassified as False Negatives — autorevert wasn't running, it didn't miss. Surface them as a third category and exclude from the recall denominator.

## What changed

- New saved query `autorevert_killswitch_windows` returns raw label add/remove events from `default.issues_label_event` plus each issue's `closed_at`.
- `lib/autorevert/killswitchWindows.ts` folds the events per-issue into `[on, off]` intervals, treating a close as an implicit `unlabeled` (the lambda only honors the label on **open** issues).
- `pages/api/autorevert/metrics.ts` partitions `falseNegatives` into the lambda-up subset (counted in recall) and a new `falseNegativesKillswitch` subset, linked to the killswitch issue. Weekly recall uses the lambda-up subset only.
- `pages/metrics/autorevert.tsx` adds a `FN (Disabled)` StatCard, chart series (purple, stacked next to FN), legend entry, and renders FN chips that fall in a killswitch window with the `FN (disabled)` label linking to the issue.

## API additions

```
summary.false_negatives_killswitch: number
weeklyMetrics[].false_negatives_killswitch: number
killswitchWindows: [{ issue_number, on, off }]
falseNegativesKillswitch: [{ recovery_sha, recovery_time, signals_fixed, reverted_pr_numbers, killswitch_issue }]
```

`recall` (overall and weekly) now uses `tp / (tp + fn_lambda_up)`.

## Validation

Historical signal verified: issue #183016 was `labeled` 2026-05-09 01:36:48Z and `unlabeled` 2026-05-12 16:47:26Z, matching the ~79h `misc.autorevert_state` row gap. Unit test (`test/autorevertKillswitchWindows.test.ts`) covers labeled/unlabeled pairing, `closed_at` fallback, still-active intervals, multi-cycle issues, and cross-issue ordering.

`yarn tsc --noEmit` and `eslint` clean on the changed files. New + existing autorevert jest tests pass.