### PR TITLE
autorevert metrics: parallelize FP verification + default to 30d window

### DIFF
--- a/torchci/package.json
+++ b/torchci/package.json
@@ -53,6 +53,7 @@
     "next": "15.5.16",
     "next-auth": "^4.24.11",
     "octokit": "^1.7.1",
+    "p-limit": "^3.1.0",
     "pino-std-serializers": "^7.0.0",
     "probot": "^12.3.3",
     "react": "^18.3.1",

--- a/torchci/pages/api/autorevert/metrics.ts
+++ b/torchci/pages/api/autorevert/metrics.ts
@@ -2,6 +2,13 @@ import { verifyFpForPr } from "lib/autorevert/fpVerification";
 import { queryClickhouseSaved } from "lib/clickhouse";
 import { getOctokit } from "lib/github";
 import type { NextApiRequest, NextApiResponse } from "next";
+import pLimit from "p-limit";
+
+// Max concurrent GitHub PR verifications. GitHub Enterprise PAT rate limit is
+// 5000 req/hour and each verification issues 2–4 API calls; 8 concurrent stays
+// well within both rate and burst budgets while collapsing what was a 100–300s
+// serial fan-out at the 90d window into ~10–30s.
+const FP_VERIFY_CONCURRENCY = 8;
 
 // Simple in-memory cache with TTL
 interface CacheEntry {
@@ -196,24 +203,29 @@ export default async function handler(
       (r) => !r.is_autorevert && r.recovery_type === "human_revert_recovery"
     );
 
-    // Verify false positive candidates via GitHub API
+    // Verify false positive candidates via GitHub API. Each verification issues
+    // 2–4 API calls; running them serially over a 90d window can take 100–300s.
+    // Fan out with a bounded concurrency to keep total wall time in the 10–30s
+    // range without overwhelming the GitHub rate limit.
     let verifiedFPs: VerifiedFalsePositive[] = [];
     if (falsePositiveCandidates.length > 0) {
       const octokit = await getOctokit("pytorch", "pytorch");
+      const limit = pLimit(FP_VERIFY_CONCURRENCY);
 
-      for (const candidate of falsePositiveCandidates) {
-        // Check per-PR cache
-        const prCacheKey = `pr-verify-${candidate.pr_number}-${candidate.autorevert_time}`;
-        const cachedVerification = getCached(prCacheKey);
-
-        if (cachedVerification) {
-          verifiedFPs.push(cachedVerification);
-        } else {
-          const verified = await verifyFalsePositive(octokit, candidate);
-          setCache(prCacheKey, verified);
-          verifiedFPs.push(verified);
-        }
-      }
+      verifiedFPs = await Promise.all(
+        falsePositiveCandidates.map((candidate) =>
+          limit(async () => {
+            const prCacheKey = `pr-verify-${candidate.pr_number}-${candidate.autorevert_time}`;
+            const cachedVerification = getCached(prCacheKey);
+            if (cachedVerification) {
+              return cachedVerification as VerifiedFalsePositive;
+            }
+            const verified = await verifyFalsePositive(octokit, candidate);
+            setCache(prCacheKey, verified);
+            return verified;
+          })
+        )
+      );
     }
 
     // Separate confirmed FPs from legit reverts

--- a/torchci/pages/metrics/autorevert.tsx
+++ b/torchci/pages/metrics/autorevert.tsx
@@ -513,9 +513,9 @@ function SignificantRevertsTable({ data }: { data: any[] | undefined }) {
 }
 
 export default function AutorevertMetricsPage() {
-  const [startTime, setStartTime] = useState(dayjs().subtract(90, "day"));
+  const [startTime, setStartTime] = useState(dayjs().subtract(30, "day"));
   const [stopTime, setStopTime] = useState(dayjs());
-  const [timeRange, setTimeRange] = useState<number>(90);
+  const [timeRange, setTimeRange] = useState<number>(30);
   const [selectedWorkflows, setSelectedWorkflows] = useState<string[]>(
     VIABLE_STRICT_WORKFLOWS
   );


### PR DESCRIPTION
## Summary

The HUD Autorevert Metrics page is slow to load. Profiling on prod ClickHouse showed the bottleneck is **not** the ClickHouse queries (~15s, ~2-3 GiB peak — well under cluster cap) but the **serial GitHub fan-out** in `verifyFpForPr`. At the 90d default window there are ~100-150 false-positive candidates; each fires 2-4 GitHub API calls in a strict `for…of await` loop = **100-300s** of cold latency, gated behind the CH queries.

Two changes:

1. **Parallelize `verifyFpForPr`** in `pages/api/autorevert/metrics.ts` with `p-limit` at concurrency 8. GitHub Enterprise PAT limit is 5000 req/hour; 8 concurrent × 2-4 calls/PR stays well under both rate and burst budgets while cutting the fan-out wall time from 100-300s → 10-30s.

2. **Default time window 90d → 30d** in `pages/metrics/autorevert.tsx`. CH cost scales near-linearly with the window, so a 30d default keeps cold loads snappy. Quarter view remains one click away via the time-range picker.

`p-limit@^3.1.0` was already a transitive dep (yarn.lock entry unchanged); promoting it to a direct dep in `package.json` makes the runtime requirement explicit. Verified `yarn install --frozen-lockfile` still passes.

## Why these two together

The 30d default already cuts CH wall time roughly 3×; with the serial GitHub fan-out gone, the 30d cold load should land in single-digit seconds. The 90d view stays usable for ad-hoc deep dives but isn't paid for on every page open.

## Test plan

- [x] `yarn tsc` (typecheck — no errors)
- [x] `yarn eslint` on changed files (no errors)
- [x] `yarn install --frozen-lockfile --offline --ignore-engines` succeeds (no lockfile churn from the new direct dep)
- [x] Adversarial review via Codex (gpt-5.5): no concurrency hazards — `Map` set under Node event loop is atomic, duplicate cache-miss writes are idempotent, `verifyFpForPr` wraps GitHub exceptions to return `verification_status: "unknown"` so `Promise.all` doesn't see a rejected child
- [ ] Smoke-test on staging: open the metrics page, confirm 30d default loads in <30s cold; switch to 90d and confirm no rate-limit hits

## Out of scope (follow-ups noted from profiling)

- Persistent (not just in-memory) PR-verification cache — would eliminate even the parallelized fan-out on warm hits across server redeploys.
- Pre-materialize `signal_status` / `recovery_events` ClickHouse MVs — the streak GROUP BY + window functions account for ~55% of CH-side time at 90d.
- Drop `push.repository.*` Tuple-read filter and `workflow_run` join in the three saved queries (v2b path explored separately) — small wall-clock win but ~30% cluster memory reduction per query.
- Merge the 3 parallel saved queries into 1 (shared CTE prefix).