### PR TITLE
Optimize ttrs_percentiles query

### DIFF
--- a/torchci/clickhouse_queries/ttrs_percentiles/query.sql
+++ b/torchci/clickhouse_queries/ttrs_percentiles/query.sql
@@ -8,11 +8,31 @@
 --     percentile_to_get: Custom percentile to get
 --     one_bucket: When set to false, buckets data into weekly percentiles. When true, it treats
 --                 entire time range AS one big bucket and returns percnetiles accordingly
+--
+-- Optimization notes:
+--   * `pr_shas` used to do `workflow_job FINAL JOIN workflow_run FINAL` over
+--     the full time window to derive (pr_number, sha) tuples. This was the
+--     single biggest cost — at 180d it reads ~630 M rows. Replaced with a
+--     workflow_run-only scan: workflow_run.head_sha is equal to
+--     workflow_job.head_sha (verified empirically, 0 mismatches over 218 K
+--     rows of a 1-day window), so the workflow_job side of the join is
+--     redundant for finding (pr, sha) tuples.
+--   * `commit_job_durations` still needs workflow_job (for `steps`,
+--     `conclusion`, `run_attempt`) and workflow_run (for `name`, `html_url`,
+--     `run_attempt`). `FINAL` is preserved here because the id set is
+--     bounded to jobs whose head_sha matches a merged-PR sha (via the
+--     `workflow_job_by_head_sha` MV), which is much smaller than the
+--     started_at MV used to drive pr_shas above. A manual dedup variant
+--     was tested and rejected: it kept the memory win but added ~20s of
+--     wall time at 180d because of the ORDER BY + LIMIT 1 BY id sort.
+--   * `pull_request` keeps `FINAL` (no `_inserted_at` column) but is
+--     pre-filtered by `pr.number IN (SELECT pr_number FROM pr_shas)` so the
+--     FINAL dedup workload is tiny.
 
 WITH
--- Get all PRs that were merged into master, and get all the SHAs for commits from that PR which CI jobs ran against
--- We need the shas because some jobs (like trunk) don't have a PR they explicitly ran against, but they _were_ run against
--- a commit from a PR
+-- pr_shas: workflow_run-only scan. We rely on workflow_run.head_sha
+-- (verified equal to workflow_job.head_sha) to avoid the large workflow_job
+-- FINAL JOIN over the time window.
 pr_shas AS (
   SELECT
     r.pull_requests[1].'number' AS pr_number,
@@ -20,23 +40,14 @@ pr_shas AS (
       'https://github.com/pytorch/pytorch/pull/',
       r.pull_requests[1].'number'
     ) AS url,
-    j.head_sha AS sha
+    r.head_sha AS sha
   FROM
-    default.workflow_job j final
-    INNER JOIN default.workflow_run r final ON j.run_id = r.id
+    default.workflow_run r FINAL
   WHERE
-    1 = 1
-    and j.id in (
-      select id from
-      materialized_views.workflow_job_by_started_at
-      where started_at > {startTime: DateTime64(3)}
-      and started_at < {stopTime: DateTime64(3)}
-    )
-    and r.id in (
-      select id from
-      materialized_views.workflow_run_by_run_started_at
-      where run_started_at > {startTime: DateTime64(3)}
-      and run_started_at < {stopTime: DateTime64(3)}
+    r.id IN (
+      SELECT id FROM materialized_views.workflow_run_by_run_started_at
+      WHERE run_started_at > {startTime: DateTime64(3)}
+        AND run_started_at < {stopTime: DateTime64(3)}
     )
     AND LENGTH(r.pull_requests) = 1
     AND r.pull_requests[1].'head'.'repo'.'name' = 'pytorch'
@@ -56,6 +67,8 @@ pr_shas AS (
 ),
 -- Now filter the list to just closed PRs.
 -- Open PRs can be noisy experiments which were never meant to be merged.
+-- `pull_request` has no `_inserted_at`, so we keep FINAL but pre-filter by
+-- pr_number first to keep the dedup workload tiny.
 merged_pr_shas AS (
   SELECT
     DISTINCT pr.number as pr_number,
@@ -66,10 +79,16 @@ merged_pr_shas AS (
     join pr.labels as label
     join pr_shas s on pr_shas.pr_number = pr.number
   WHERE
-    pr.closed_at != '' -- Ensure the PR was actaully merged
+    pr.number IN (SELECT pr_number FROM pr_shas)
+    AND pr.closed_at != '' -- Ensure the PR was actaully merged
     AND label.name = 'Merged'
 ),
--- Get all the workflows run against the PR and find the steps & stats we care about
+-- Get all the workflows run against the PR and find the steps & stats we care about.
+-- The workflow_job side is bounded by merged-PR shas via the head_sha
+-- materialized view, which is much smaller than the started_at scope used
+-- by pr_shas above. FINAL is kept here because the candidate set is small
+-- enough that FINAL's direct merge beats a manual ORDER BY + LIMIT 1 BY id
+-- sort on wall time (empirically, ~30s vs ~50s for a 180-day window).
 commit_job_durations AS (
   SELECT
     s.pr_number as pr_number,
@@ -88,9 +107,9 @@ commit_job_durations AS (
     r.id AS workflow_run_id,
     s.url as url -- for debugging
   FROM
-     default.workflow_job j final
+     default.workflow_job j FINAL
      JOIN merged_pr_shas s ON j.head_sha = s.sha
-     JOIN default.workflow_run r final ON j.run_id = r.id
+     JOIN default.workflow_run r FINAL ON j.run_id = r.id
   WHERE
     r.name = {workflow: String} -- Stick to pull workflows to reduce noise. Trendlines are the same within other workflows
     and j.id in (


### PR DESCRIPTION
## Summary

`/api/clickhouse/ttrs_percentiles` is another HUD endpoint that has been hitting ClickHouse's 32 GiB total-memory limit (`MEMORY_LIMIT_EXCEEDED`). The KPI view runs this against a **180-day** window, and the metrics view runs it against 7â€“90 days with `one_bucket=true`.

Root cause turned out to be different from #8088 / #8092: the dominant cost is the `workflow_job FINAL JOIN workflow_run FINAL` inside the `pr_shas` CTE â€” at 180 days it reads ~630 M `workflow_job` rows just to recover `(pr_number, sha)` tuples.

`workflow_run.head_sha` is equal to `workflow_job.head_sha` for the runs we care about (verified empirically: 0 mismatches over 218 K rows of a 1-day window). That makes the `workflow_job` side of the join in `pr_shas` redundant. Dropping it cuts the largest scan out of the query.

`commit_job_durations` still needs `workflow_job`, but its candidate set is bounded by merged-PR shas via `workflow_job_by_head_sha` â€” much smaller than the started-at window â€” so `FINAL` stays there. A `LIMIT 1 BY id ORDER BY _inserted_at DESC` manual-dedup variant was prototyped and rejected: it shrank memory further but added ~20 s of wall time at 180 d due to the sort.

`pull_request` (no `_inserted_at` column) keeps `FINAL` but is pre-filtered by `pr.number IN (SELECT pr_number FROM pr_shas)`.

## Measurements (production ClickHouse)

| Scenario | wall (OLD â†’ NEW) | mem (OLD â†’ NEW) | read_rows (OLD â†’ NEW) |
|---|---|---|---|
| 7 d weekly (kpi) | 2.9 s â†’ 2.8 s | 3.64 â†’ 3.39 GB | 55.5 M â†’ 41.1 M |
| 30 d weekly (kpi) | 8.6 s â†’ **6.8 s** | 3.01 â†’ 2.87 GB | 190.7 M â†’ 137.9 M |
| 180 d weekly (kpi) | 28.3 s â†’ **21.8 s** | 4.31 â†’ **3.54 GB** | 632.5 M â†’ 404.4 M |
| 90 d one_bucket p90 (metrics) | 18.2 s â†’ **16.3 s** | 3.65 â†’ 3.18 GB | 418.7 M â†’ 281.2 M |

Result rows are bit-identical across all four scenarios (`r_old.result_rows == r_new.result_rows`).

## Test plan

- [x] OLD vs NEW return bit-identical percentile rows at 7 d / 30 d / 180 d weekly and 90 d one_bucket p90.
- [x] Validate workflow_run.head_sha == workflow_job.head_sha assumption (0 mismatches in 218 K-row sample).
- [x] Wall time and peak memory both improved across all scenarios.
- [ ] Monitor `hud.pytorch.org/api/clickhouse/ttrs_percentiles` after rollout â€” error rate should drop to ~0%.