### PR TITLE
Call setup-windows in build_wheels_windows.yml

### DIFF
--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -143,6 +143,9 @@ jobs:
         with:
           architecture: aarch64
           path: "${{env.DEPENDENCIES_DIR}}\\git"
+      - uses: ./test-infra/.github/actions/setup-windows
+        with:
+          cuda-version: ${{ env.CU_VERSION }}
       - uses: ./test-infra/.github/actions/set-channel
       - name: Set PYTORCH_VERSION
         if: env.CHANNEL == 'test'


### PR DESCRIPTION
## Summary
- `build_wheels_windows.yml` previously did not run `./test-infra/.github/actions/setup-windows`, so the `LongPathsEnabled` registry tweak and `git config core.longpaths true` were never applied to wheel-build jobs.
- This caused the `Install torch dependency` step to fail on recent torch nightlies with `WinError 206: filename or extension is too long`, because pip writes deeply-nested license paths under torch's `dist-info` (e.g. `kineto/.../prometheus-cpp/.../civetweb/.../duktape-1.5.2`) that exceed Windows' 260-char `MAX_PATH`.
- Example failure: pytorch/vision build-wheel-py3_10-cuda12_6 in run https://github.com/pytorch/vision/actions/runs/25961163736/job/76316597796.

This PR inserts the `setup-windows` action right after the test-infra checkout / git-SDK setup, mirroring the same pattern used by `windows_job.yml`. As a side benefit, it also configures git long-paths/symlinks, Defender exclusions, and the `RUNNER_ARTIFACT_DIR` / `RUNNER_TEST_RESULTS_DIR` env vars.

## Test plan
- [ ] Re-run a failing Windows wheel build (e.g. pytorch/vision nightly) against this branch and confirm the `Install torch dependency` step succeeds.
- [ ] Confirm existing arm64 wheel builds still pass.