### PR TITLE
autoLabelBot: don't re-add triage review if already triaged

### DIFF
--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -357,9 +357,10 @@ function getReleaseNotesCategoryAndTopic(
   return ["uncategorized", topic];
 }
 
-export async function wasLabelPreviouslyRemoved(
+export async function wasLabelRecentlyRemoved(
   context: Context,
-  labelName: string
+  labelName: string,
+  withinMs: number
 ): Promise<boolean> {
   const events = await context.octokit.paginate(
     context.octokit.issues.listEvents,
@@ -368,8 +369,12 @@ export async function wasLabelPreviouslyRemoved(
       per_page: 100,
     })
   );
+  const cutoff = Date.now() - withinMs;
   return events.some(
-    (e: any) => e.event === "unlabeled" && e.label?.name === labelName
+    (e: any) =>
+      e.event === "unlabeled" &&
+      e.label?.name === labelName &&
+      new Date(e.created_at).getTime() >= cutoff
   );
 }
 
@@ -428,9 +433,17 @@ function myBot(app: Probot): void {
     switch (addedLabel) {
       case "high priority":
       case "critical":
-        // Don't re-add triage review if a human already triaged the
-        // issue (i.e. previously removed the triage review label).
-        if (!(await wasLabelPreviouslyRemoved(context, "triage review"))) {
+        // Don't re-add triage review if a human just triaged the issue
+        // (removed triage review within the last hour). Older removals
+        // are ignored so that resurfacing an old issue with hi-pri does
+        // re-request triage.
+        if (
+          !(await wasLabelRecentlyRemoved(
+            context,
+            "triage review",
+            60 * 60 * 1000
+          ))
+        ) {
           newLabels.push("triage review");
         }
         break;

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -359,13 +359,14 @@ function getReleaseNotesCategoryAndTopic(
 
 export async function wasLabelRecentlyRemoved(
   context: Context,
+  issueNumber: number,
   labelName: string,
   withinMs: number
 ): Promise<boolean> {
   const events = await context.octokit.paginate(
     context.octokit.issues.listEvents,
     context.repo({
-      issue_number: context.payload.issue.number,
+      issue_number: issueNumber,
       per_page: 100,
     })
   );
@@ -440,6 +441,7 @@ function myBot(app: Probot): void {
         if (
           !(await wasLabelRecentlyRemoved(
             context,
+            context.payload.issue.number,
             "triage review",
             60 * 60 * 1000
           ))

--- a/torchci/lib/bot/autoLabelBot.ts
+++ b/torchci/lib/bot/autoLabelBot.ts
@@ -357,6 +357,22 @@ function getReleaseNotesCategoryAndTopic(
   return ["uncategorized", topic];
 }
 
+export async function wasLabelPreviouslyRemoved(
+  context: Context,
+  labelName: string
+): Promise<boolean> {
+  const events = await context.octokit.paginate(
+    context.octokit.issues.listEvents,
+    context.repo({
+      issue_number: context.payload.issue.number,
+      per_page: 100,
+    })
+  );
+  return events.some(
+    (e: any) => e.event === "unlabeled" && e.label?.name === labelName
+  );
+}
+
 export async function addNewLabels(
   existingLabels: string[],
   labelsToAdd: string[],
@@ -412,7 +428,11 @@ function myBot(app: Probot): void {
     switch (addedLabel) {
       case "high priority":
       case "critical":
-        newLabels.push("triage review");
+        // Don't re-add triage review if a human already triaged the
+        // issue (i.e. previously removed the triage review label).
+        if (!(await wasLabelPreviouslyRemoved(context, "triage review"))) {
+          newLabels.push("triage review");
+        }
         break;
     }
 

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -80,7 +80,7 @@ describe("auto-label-bot", () => {
     scope.done();
   });
 
-  test("do not re-add triage review if it was previously removed", async () => {
+  test("do not re-add triage review if it was just removed (within the hour)", async () => {
     nock("https://api.github.com")
       .post("/app/installations/2/access_tokens")
       .reply(200, { token: "test" });
@@ -90,17 +90,71 @@ describe("auto-label-bot", () => {
     payload["issue"]["labels"] = [{ name: "high priority" }];
     emptyMockConfig(payload.repository.full_name);
 
-    // Issue events show that triage review was previously removed (i.e.
-    // the issue was already triaged).
+    const recent = new Date(Date.now() - 5 * 60 * 1000).toISOString();
     const scope = nock("https://api.github.com")
       .get(
         "/repos/ezyang/testing-ideal-computing-machine/issues/5/events?per_page=100"
       )
       .reply(200, [
-        { event: "labeled", label: { name: "high priority" } },
-        { event: "labeled", label: { name: "triage review" } },
-        { event: "unlabeled", label: { name: "triage review" } },
+        {
+          event: "labeled",
+          label: { name: "high priority" },
+          created_at: recent,
+        },
+        {
+          event: "labeled",
+          label: { name: "triage review" },
+          created_at: recent,
+        },
+        {
+          event: "unlabeled",
+          label: { name: "triage review" },
+          created_at: recent,
+        },
       ]);
+
+    await probot.receive({ name: "issues", payload, id: "2" });
+
+    scope.done();
+  });
+
+  test("re-add triage review if old issue resurfaces (stale removal)", async () => {
+    nock("https://api.github.com")
+      .post("/app/installations/2/access_tokens")
+      .reply(200, { token: "test" });
+
+    const payload = requireDeepCopy("./fixtures/issues.labeled");
+    payload["label"] = { name: "high priority" };
+    payload["issue"]["labels"] = [{ name: "high priority" }];
+    emptyMockConfig(payload.repository.full_name);
+
+    // Triage review was removed long ago — issue is resurfacing and
+    // should be triaged again.
+    const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    const scope = nock("https://api.github.com")
+      .get(
+        "/repos/ezyang/testing-ideal-computing-machine/issues/5/events?per_page=100"
+      )
+      .reply(200, [
+        {
+          event: "labeled",
+          label: { name: "triage review" },
+          created_at: old,
+        },
+        {
+          event: "unlabeled",
+          label: { name: "triage review" },
+          created_at: old,
+        },
+      ])
+      .post(
+        "/repos/ezyang/testing-ideal-computing-machine/issues/5/labels",
+        (body) => {
+          expect(body).toMatchObject({ labels: ["triage review"] });
+          return true;
+        }
+      )
+      .reply(200);
 
     await probot.receive({ name: "issues", payload, id: "2" });
 

--- a/torchci/test/autoLabelBot.test.ts
+++ b/torchci/test/autoLabelBot.test.ts
@@ -62,6 +62,10 @@ describe("auto-label-bot", () => {
     emptyMockConfig(payload.repository.full_name);
 
     const scope = nock("https://api.github.com")
+      .get(
+        "/repos/ezyang/testing-ideal-computing-machine/issues/5/events?per_page=100"
+      )
+      .reply(200, [])
       .post(
         "/repos/ezyang/testing-ideal-computing-machine/issues/5/labels",
         (body) => {
@@ -70,6 +74,33 @@ describe("auto-label-bot", () => {
         }
       )
       .reply(200);
+
+    await probot.receive({ name: "issues", payload, id: "2" });
+
+    scope.done();
+  });
+
+  test("do not re-add triage review if it was previously removed", async () => {
+    nock("https://api.github.com")
+      .post("/app/installations/2/access_tokens")
+      .reply(200, { token: "test" });
+
+    const payload = requireDeepCopy("./fixtures/issues.labeled");
+    payload["label"] = { name: "high priority" };
+    payload["issue"]["labels"] = [{ name: "high priority" }];
+    emptyMockConfig(payload.repository.full_name);
+
+    // Issue events show that triage review was previously removed (i.e.
+    // the issue was already triaged).
+    const scope = nock("https://api.github.com")
+      .get(
+        "/repos/ezyang/testing-ideal-computing-machine/issues/5/events?per_page=100"
+      )
+      .reply(200, [
+        { event: "labeled", label: { name: "high priority" } },
+        { event: "labeled", label: { name: "triage review" } },
+        { event: "unlabeled", label: { name: "triage review" } },
+      ]);
 
     await probot.receive({ name: "issues", payload, id: "2" });
 


### PR DESCRIPTION
## Summary
- When `high priority` or `critical` is applied, the bot adds `triage review`. Previously, if a triager removed `triage review` and the priority label was later removed and re-applied, the bot would re-add `triage review` — re-triaging an already-triaged issue.
- Added `wasLabelPreviouslyRemoved()` helper that checks the issue's events for a prior `unlabeled` event for `triage review`, and skip the auto-add in that case.
- The comment at the call site (`autoLabelBot.ts:394-398`) already documented this as the intended behavior; this PR makes the code match.

## Test plan
- [x] `yarn jest test/autoLabelBot.test.ts` passes (existing test updated to mock the new GET; new test verifies re-add is skipped when an `unlabeled` event exists)
- [x] `yarn format --check` passes