### PR TITLE
Add action for setting up Windows CUDA driver

### DIFF
--- a/.github/actions/setup-nvidia-windows/action.yml
+++ b/.github/actions/setup-nvidia-windows/action.yml
@@ -1,0 +1,14 @@
+name: Setup NVIDIA Windows
+
+description: Update NVIDIA driver on Windows GPU runners
+
+runs:
+  using: composite
+  steps:
+    - name: Update NVIDIA driver
+      shell: cmd
+      run: |
+        ${{ github.action_path }}\..\..\scripts\driver_update.bat
+    - name: Verify NVIDIA driver
+      shell: cmd
+      run: nvidia-smi

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -171,8 +171,7 @@ jobs:
           cmd //c .\\test-infra\\.github\\scripts\\install_xpu.bat
       - name: Update NVIDIA driver
         if: inputs.architecture == 'x64' && matrix.gpu_arch_type == 'cuda'
-        run: |
-          cmd //c .\\test-infra\\.github\\scripts\\driver_update.bat
+        uses: pytorch/test-infra/.github/actions/setup-nvidia-windows@main
       - name: Checkout Target Repository (${{ env.REPOSITORY }})
         if: inputs.architecture == 'arm64'
         uses: actions/checkout@v4

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -171,7 +171,8 @@ jobs:
           cmd //c .\\test-infra\\.github\\scripts\\install_xpu.bat
       - name: Update NVIDIA driver
         if: inputs.architecture == 'x64' && matrix.gpu_arch_type == 'cuda'
-        uses: pytorch/test-infra/.github/actions/setup-nvidia-windows@main
+        run: |
+          cmd //c .\\test-infra\\.github\\scripts\\driver_update.bat
       - name: Checkout Target Repository (${{ env.REPOSITORY }})
         if: inputs.architecture == 'arm64'
         uses: actions/checkout@v4


### PR DESCRIPTION
As discussed offline, some Windows TorchCodec jobs need to manually update the CUDA driver. That's better done here as a single Action in `test-infra` so that TorchCodec can rely on it instead of inlining the logic.