### PR TITLE
Cherry-picks in 2.12 branch for 0.13 TorchCodec release

### DIFF
--- a/.github/actions/setup-nvidia-windows/action.yml
+++ b/.github/actions/setup-nvidia-windows/action.yml
@@ -1,0 +1,14 @@
+name: Setup NVIDIA Windows
+
+description: Update NVIDIA driver on Windows GPU runners
+
+runs:
+  using: composite
+  steps:
+    - name: Update NVIDIA driver
+      shell: cmd
+      run: |
+        ${{ github.action_path }}\..\..\scripts\driver_update.bat
+    - name: Verify NVIDIA driver
+      shell: cmd
+      run: nvidia-smi

--- a/.github/workflows/_binary_upload.yml
+++ b/.github/workflows/_binary_upload.yml
@@ -41,6 +41,11 @@ on:
         required: false
         type: string
         default: ''
+      also-upload-to-gpu-arch-versions:
+        description: "Comma-separated list of extra gpu_arch_versions to upload the wheel to (e.g. 'xpu' to also upload a cpu wheel to the xpu index)"
+        required: false
+        type: string
+        default: ''
       wheel-nightly-policy:
         description: Custom wheel upload policy for nightly
         type: string
@@ -141,6 +146,29 @@ jobs:
             shm_id=$(sha256sum "${pkg}" | awk '{print $1}')
             ${AWS_CMD} "$pkg" "${PYTORCH_S3_BUCKET_PATH}" --acl public-read \
               --metadata "checksum-sha256=${shm_id}"
+          done
+
+      - name: Upload package to extra gpu arch versions
+        if: ${{ inputs.also-upload-to-gpu-arch-versions != '' }}
+        shell: bash
+        working-directory: ${{ inputs.repository }}
+        env:
+          ALSO_UPLOAD_TO: ${{ inputs.also-upload-to-gpu-arch-versions }}
+        run: |
+          set -ex
+
+          AWS_CMD="aws s3 cp --dryrun"
+          if [[ "${NIGHTLY_OR_TEST:-0}" == "1" ]]; then
+            AWS_CMD="aws s3 cp"
+          fi
+
+          for extra_gpu_arch_version in ${ALSO_UPLOAD_TO//,/ }; do
+            EXTRA_PATH="s3://pytorch/whl/${CHANNEL}/${extra_gpu_arch_version}/"
+            for pkg in dist/*; do
+              shm_id=$(sha256sum "${pkg}" | awk '{print $1}')
+              ${AWS_CMD} "$pkg" "${EXTRA_PATH}" --acl public-read \
+                --metadata "checksum-sha256=${shm_id}"
+            done
           done
 
       - name: Upload package to pypi

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -100,6 +100,11 @@ on:
         description: Custom wheel upload policy for nightly
         type: string
         default: ''
+      also-upload-to-gpu-arch-versions:
+        description: "Comma-separated list of extra gpu_arch_versions to upload the wheel to (e.g. 'xpu' to also upload a cpu wheel to the xpu index)"
+        required: false
+        type: string
+        default: ''
       run-smoke-test:
         description: Set to true if smoke test is needed
         required: false
@@ -347,6 +352,7 @@ jobs:
       upload-to-pypi: ${{ inputs.upload-to-pypi }}
       wheel-upload-path: ${{ inputs.wheel-upload-path }}
       wheel-nightly-policy: ${{ inputs.wheel-nightly-policy }}
+      also-upload-to-gpu-arch-versions: ${{ inputs.also-upload-to-gpu-arch-versions }}
     secrets:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}


### PR DESCRIPTION
I plan to release TorchCodec 0.13 soon, I'll build against the `release/2.12` branch of `test-infra`. This PR includes 2 small cherry-pick (see below) that I think I'll need