### PR TITLE
Add ClickHouse schema for OOT workflow job table

### DIFF
--- a/clickhouse_db_schema/default.oot_workflow_job/schema.sql
+++ b/clickhouse_db_schema/default.oot_workflow_job/schema.sql
@@ -1,0 +1,40 @@
+CREATE TABLE default.oot_workflow_job
+(
+    `dynamoKey` String,
+    `status` String,
+    `downstream_repo` String COMMENT 'Downstream repo org/name, from trusted.verified_repo',
+    `upstream_repo` String COMMENT 'Upstream repo, typically pytorch/pytorch',
+    `pr_number` UInt64 COMMENT 'PyTorch PR number',
+    `pytorch_head_sha` String COMMENT 'PyTorch PR commit SHA',
+    `delivery_id` String COMMENT 'GitHub webhook delivery ID from L1 dispatch',
+    `workflow_run_url` String COMMENT 'Link to downstream GHA workflow run',
+    `workflow_name` String COMMENT 'Downstream workflow name (github.workflow)',
+    `job_name` String DEFAULT '' COMMENT 'Downstream job name (github.job)',
+    `check_run_id` String DEFAULT '' COMMENT 'GitHub-assigned unique ID per job execution (job.check_run_id)',
+    `run_id` String DEFAULT '' COMMENT 'GitHub workflow run ID (github.run_id), same across retries',
+    `run_attempt` UInt32 DEFAULT 1 COMMENT 'Workflow run attempt number (github.run_attempt)',
+    `conclusion` String COMMENT 'success, failure, cancelled, timed_out (set on completed)',
+    `queue_time` Nullable(Float64) COMMENT 'Relay-measured dispatch-to-in_progress time in seconds',
+    `execution_time` Nullable(Float64) COMMENT 'Relay-measured in_progress-to-completed time in seconds',
+    `started_at` DateTime64(9) COMMENT 'Downstream-reported timestamp when job started',
+    `completed_at` DateTime64(9) COMMENT 'Downstream-reported timestamp when job completed',
+    `total_tests` UInt64 DEFAULT 0,
+    `passed_tests` UInt64 DEFAULT 0,
+    `failed_tests` UInt64 DEFAULT 0,
+    `skipped_tests` UInt64 DEFAULT 0,
+    `failed_tests_json` String DEFAULT '' COMMENT 'JSON array of failed/errored test details',
+    `artifact_url` String DEFAULT '' COMMENT 'URL to downstream-hosted artifacts (logs, reports)',
+    `environment` String DEFAULT '' COMMENT 'JSON: {"sdk": "<version>", "device": "<hardware>", ...}',
+    `downstream_repo_level` String DEFAULT '' COMMENT 'Relay level at dispatch time: L2, L3, L4',
+    `_inserted_at` DateTime MATERIALIZED now(),
+    `repository_full_name` String ALIAS downstream_repo COMMENT 'Alias for consistency with workflow_job queries',
+    `duration_seconds` Float64 ALIAS if(completed_at = toDateTime64(0, 9), 0, dateDiff(second, started_at, completed_at)),
+    INDEX status_index status TYPE bloom_filter GRANULARITY 1,
+    INDEX started_at_index started_at TYPE minmax GRANULARITY 1,
+    INDEX completed_at_index completed_at TYPE minmax GRANULARITY 1,
+    INDEX pr_number_index pr_number TYPE bloom_filter GRANULARITY 1,
+    INDEX downstream_repo_index downstream_repo TYPE bloom_filter GRANULARITY 1
+)
+ENGINE = SharedReplacingMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')
+ORDER BY (downstream_repo, delivery_id, dynamoKey)
+SETTINGS index_granularity = 8192


### PR DESCRIPTION
## Summary

Creates the `default.oot_workflow_job` ClickHouse table for storing out-of-tree backend CI results. Split out from #8069 so the table can be deployed independently and populated with test data.

The DynamoDB → ClickHouse replicator mapping (`torchci-oot-workflow-job` → `default.oot_workflow_job`) is already on main.

### Schema highlights

- `SharedReplacingMergeTree` engine for upsert semantics (in_progress → completed)
- Ordered by `(downstream_repo, delivery_id, dynamoKey)` for efficient per-backend and per-delivery queries
- Bloom filter indexes on `status`, `pr_number`, `downstream_repo`
- Timing fields: `queue_time`, `execution_time`, `started_at`, `completed_at`
- Test result columns: `total_tests`, `passed_tests`, `failed_tests`, `skipped_tests`

### Related

- Full HUD pipeline PR: #8069
- RFC: https://github.com/pytorch/rfcs/pull/96
- Reference: Similar to #7365 (vLLM ClickHouse table)

## Test Plan

- [x] Table creation succeeds on ClickHouse
- [x] Populate with fake data and verify queries from #8069 return expected results