### PR TITLE
autorevert: dispatch advisor on born-red test signals

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -86,6 +86,11 @@ class DispatchAdvisor:
     suspect_commit: str
     failed_commits: Tuple[str, ...]  # SHAs in failed partition (newest first)
     successful_commits: Tuple[str, ...]  # SHAs in successful partition (newest first)
+    # When True, `successful_commits` are baseline commits where this signal
+    # did NOT exist (test-track born-red case), not green observations.
+    # The advisor JSON layer relabels them so the model is asked "did the
+    # suspect commit introduce this failing test?".
+    is_born_red: bool = False
 
 
 @dataclass
@@ -496,8 +501,60 @@ class Signal:
 
         return PartitionedCommits(failed=failed, unknown=unknown, successful=successful)
 
+    def partition_born_red(self) -> Optional[PartitionedCommits]:
+        """Partition for the test-track "born-red" pattern: failing head + empty-events tail.
+
+        Returns a partition only when the signal shape is `[FAIL...][EMPTY...]`
+        (newest → oldest) with no interleaving:
+        - At least 2 commits in window
+        - No commits with success events (otherwise the main partition path applies)
+        - At least 1 commit with failure events at the head
+        - At least 1 trailing commit with no events — these are commits where this
+          test did not run or did not yet exist, used as the implicit baseline
+          ("commits without the signal")
+        - No pending-only or other-shape commits in between
+
+        Trailing empty-events commits are placed in `successful` so the advisor
+        check / pattern construction can reuse the standard primitives. The
+        advisor JSON layer relabels them via `DispatchAdvisor.is_born_red` so
+        the model is asked about test introduction, not green→red transition.
+        `unknown` is always empty — there is no gap to bisect.
+        """
+        if len(self.commits) < 2 or self.has_successes():
+            return None
+
+        failed: List[SignalCommit] = []
+        baseline: List[SignalCommit] = []
+        for c in self.commits:
+            if c.has_failure:
+                if baseline:
+                    # Failure after an empty-events commit (newer→older order) —
+                    # out of shape.
+                    return None
+                failed.append(c)
+            elif not c.events:
+                baseline.append(c)
+            else:
+                # Pending-only or other shape — bail; the advisor needs a clean
+                # introduction-vs-baseline split.
+                return None
+
+        if not failed or not baseline:
+            return None
+
+        return PartitionedCommits(failed=failed, unknown=[], successful=baseline)
+
     # Minimum confidence threshold for acting on advisor verdicts
     ADVISOR_CONFIDENCE_THRESHOLD = 0.89
+
+    # Minimum number of *distinct failing commits* required before dispatching
+    # an advisor on a born-red test signal. Counting distinct commits (rather
+    # than events) is deliberate: multiple FAILURE events on the same commit
+    # (retries, multiple shards / variants of the same test, etc.) describe
+    # one trunk observation, not two. Requiring two failing commits means the
+    # failure has persisted across at least one trunk advance — strong enough
+    # to justify the advisor cost without waiting indefinitely.
+    REQUIRE_FAILED_COMMITS_BORN_RED = 2
 
     def _build_autorevert_pattern(
         self,
@@ -571,6 +628,66 @@ class Signal:
         # "unsure" or expired garbage → continue normally
         return None
 
+    def _handle_no_successes(self) -> Union[AutorevertPattern, Ineligible]:
+        """Handle the `not has_successes()` branch.
+
+        Default behavior: emit `Ineligible(NO_SUCCESSES)` with no advisor — the
+        standard green→red partition has no anchor to work from.
+
+        Test-track exception (born-red detection): when the signal shape matches
+        `[FAIL...][EMPTY...]` (`partition_born_red` returns a partition), the
+        suspect commit is likely the one that introduced the test. Defer to the
+        AI advisor:
+        - If a prior advisor verdict exists on the suspect, act on it
+          (revert/related → `AutorevertPattern`; not_related/garbage → blocked).
+        - Otherwise, dispatch a fresh advisor request alongside the `Ineligible`
+          response. Next tick can act on the verdict.
+
+        Advisor dedup + the per-(workflow, commit) cap of 8 are handled by
+        `SignalActionsLogger`; this method just emits the request.
+        """
+        born_red = (
+            self.partition_born_red()
+            if self.source == SignalSource.TEST
+            else None
+        )
+        if born_red is None:
+            return Ineligible(
+                IneligibleReason.NO_SUCCESSES,
+                "no successful commits present in window",
+            )
+
+        if len(born_red.failed) < self.REQUIRE_FAILED_COMMITS_BORN_RED:
+            # Not enough distinct failing commits to justify advisor cost —
+            # wait for the next trunk advance. Retries / multiple shards on a
+            # single commit do not count as independent observations.
+            return Ineligible(
+                IneligibleReason.NO_SUCCESSES,
+                f"born-red test signal: need ≥{self.REQUIRE_FAILED_COMMITS_BORN_RED} "
+                f"failing commits before advisor dispatch (have "
+                f"{len(born_red.failed)})",
+            )
+
+        # If the advisor already weighed in on the suspect, use that verdict.
+        advisor_decision = self._check_advisor_verdict(born_red)
+        if advisor_decision is not None:
+            return advisor_decision
+
+        # No verdict yet — request one. `successful_commits` carry the implicit
+        # baseline (commits where the signal didn't exist); `is_born_red=True`
+        # tells the advisor JSON builder to relabel them accordingly.
+        advisor = DispatchAdvisor(
+            suspect_commit=born_red.failed[-1].head_sha,
+            failed_commits=tuple(c.head_sha for c in born_red.failed),
+            successful_commits=tuple(c.head_sha for c in born_red.successful),
+            is_born_red=True,
+        )
+        return Ineligible(
+            IneligibleReason.NO_SUCCESSES,
+            "born-red test signal: no successful commits in window — advisor dispatched",
+            advisor=advisor,
+        )
+
     def process_valid_autorevert_pattern(
         self, *, bisection_limit: Optional[int] = None
     ) -> Union[AutorevertPattern, RestartCommits, Ineligible]:
@@ -591,9 +708,7 @@ class Signal:
                 IneligibleReason.FIXED, "signal appears recovered at head"
             )
         if not self.has_successes():
-            return Ineligible(
-                IneligibleReason.NO_SUCCESSES, "no successful commits present in window"
-            )
+            return self._handle_no_successes()
 
         partition = self.partition_by_autorevert_pattern()
         if partition is None:

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -647,9 +647,7 @@ class Signal:
         `SignalActionsLogger`; this method just emits the request.
         """
         born_red = (
-            self.partition_born_red()
-            if self.source == SignalSource.TEST
-            else None
+            self.partition_born_red() if self.source == SignalSource.TEST else None
         )
         if born_red is None:
             return Ineligible(

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
@@ -736,15 +736,44 @@ class SignalActionProcessor:
             "unknown: commits between failed and successful partitions "
             "with no resolved events (pending or missing data)"
         )
-        LABEL_SUCCESSFUL = (
-            "successful: baseline commits where this signal was GREEN "
-            "before the suspect commit"
-        )
-        LABEL_PRIOR = (
-            "prior: older commits before the successful baseline. "
-            "Important: the signal may have been fixed and then failed again. "
-            "Don't make assumptions just based on the presence of failures here."
-        )
+        # Born-red / newly-observed-red case: a test-track signal with no green
+        # observations in the lookback window. The "successful" set actually
+        # carries commits where this test signal was NOT OBSERVED (no extracted
+        # events). Empty events could mean any of: the test was added by the
+        # suspect, the test was previously TD-filtered / disabled / sharded out
+        # and is now in scope, the test was renamed / moved, or the underlying
+        # job didn't run. Relabel so the advisor knows it has to figure out
+        # WHICH of those is true from the suspect commit's diff.
+        if dispatch_advisor.is_born_red:
+            LABEL_SUCCESSFUL = (
+                "no_signal: baseline commits where this test signal was NOT "
+                "OBSERVED (no extracted events). The suspect commit is the "
+                "first commit on which the test signal appears, and it fails. "
+                "Possible causes — distinguish from the suspect commit's diff: "
+                "(a) the suspect ADDED this test; "
+                "(b) the suspect ENABLED/UN-SKIPPED an existing test or "
+                "removed a TD/skipping filter that previously masked it; "
+                "(c) the suspect MOVED or RENAMED the test so its identity "
+                "is newly visible; "
+                "(d) the suspect changed sharding / job selection so an "
+                "existing already-failing test became visible. "
+                "Recommend revert only if the suspect's diff explicitly "
+                "introduces or enables the failing test (cases a/b/c)."
+            )
+            LABEL_PRIOR = (
+                "prior: even older commits before the no-signal baseline. "
+                "Same property: this test signal was not observed here."
+            )
+        else:
+            LABEL_SUCCESSFUL = (
+                "successful: baseline commits where this signal was GREEN "
+                "before the suspect commit"
+            )
+            LABEL_PRIOR = (
+                "prior: older commits before the successful baseline. "
+                "Important: the signal may have been fixed and then failed again. "
+                "Don't make assumptions just based on the presence of failures here."
+            )
 
         def _fmt_ts(dt: Optional[datetime]) -> str:
             if dt is None:
@@ -831,6 +860,7 @@ class SignalActionProcessor:
                 "job_base_name": signal.job_base_name,
                 "commit_order": "newest_first",
                 "suspect_commit": dispatch_advisor.suspect_commit,
+                "is_born_red": dispatch_advisor.is_born_red,
                 "commits": commits_json,
             }
         )

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
@@ -35,6 +35,33 @@ from .workflow_checker import WorkflowRestartChecker
 SignalProcOutcome = Union[AutorevertPattern, RestartCommits, Ineligible]
 
 
+# Top-level natural-language framing attached to the advisor's
+# `signal_pattern.json` payload when `DispatchAdvisor.is_born_red` is set.
+# Said once at the top level rather than duplicated into every baseline
+# commit's `partition` label.
+_BORN_RED_PATTERN_CONTEXT = (
+    "born-red / newly-observed-red test signal: this test signal has NO "
+    "observations on any commit older than the suspect in the lookback "
+    "window. The suspect commit is the first commit on which the signal "
+    "appears, and it fails. Older commits in the `no_signal` partition "
+    "have empty events because the test was not extracted there — this "
+    "is ambiguous and could mean any of:\n"
+    "  (a) the suspect ADDED this test;\n"
+    "  (b) the suspect ENABLED / un-skipped an existing test or removed a "
+    "TD / skipping filter that previously masked it;\n"
+    "  (c) the suspect MOVED or RENAMED the test so its identity is newly "
+    "visible;\n"
+    "  (d) the suspect changed sharding / job selection so an existing "
+    "already-failing test became visible.\n"
+    "Read the suspect commit's diff and decide which of (a)-(d) applies. "
+    "Recommend `revert` only if the suspect's diff explicitly introduces "
+    "or enables the failing test (cases a / b / c). For (d) — sharding "
+    "or job-selection change exposing a pre-existing failure — recommend "
+    "`not_related` because the suspect did not cause the test to fail, "
+    "only made it observable."
+)
+
+
 class CommitPRSourceAction(Enum):
     MERGE = "merge"
     REVERT = "revert"
@@ -739,30 +766,16 @@ class SignalActionProcessor:
         # Born-red / newly-observed-red case: a test-track signal with no green
         # observations in the lookback window. The "successful" set actually
         # carries commits where this test signal was NOT OBSERVED (no extracted
-        # events). Empty events could mean any of: the test was added by the
-        # suspect, the test was previously TD-filtered / disabled / sharded out
-        # and is now in scope, the test was renamed / moved, or the underlying
-        # job didn't run. Relabel so the advisor knows it has to figure out
-        # WHICH of those is true from the suspect commit's diff.
+        # events). The label stays short — the natural-language framing of what
+        # the advisor needs to figure out lives in `pattern_context` at the
+        # top level (so it's said once, not duplicated per commit).
         if dispatch_advisor.is_born_red:
             LABEL_SUCCESSFUL = (
-                "no_signal: baseline commits where this test signal was NOT "
-                "OBSERVED (no extracted events). The suspect commit is the "
-                "first commit on which the test signal appears, and it fails. "
-                "Possible causes — distinguish from the suspect commit's diff: "
-                "(a) the suspect ADDED this test; "
-                "(b) the suspect ENABLED/UN-SKIPPED an existing test or "
-                "removed a TD/skipping filter that previously masked it; "
-                "(c) the suspect MOVED or RENAMED the test so its identity "
-                "is newly visible; "
-                "(d) the suspect changed sharding / job selection so an "
-                "existing already-failing test became visible. "
-                "Recommend revert only if the suspect's diff explicitly "
-                "introduces or enables the failing test (cases a/b/c)."
+                "no_signal: baseline commits where this test signal was not "
+                "observed (no extracted events). See top-level pattern_context."
             )
             LABEL_PRIOR = (
-                "prior: even older commits before the no-signal baseline. "
-                "Same property: this test signal was not observed here."
+                "prior: even older commits with no signal observation"
             )
         else:
             LABEL_SUCCESSFUL = (
@@ -852,18 +865,18 @@ class SignalActionProcessor:
                 }
             )
 
-        return json.dumps(
-            {
-                "signal_key": signal.key,
-                "signal_source": signal.source.value if signal.source else "unknown",
-                "workflow_name": signal.workflow_name,
-                "job_base_name": signal.job_base_name,
-                "commit_order": "newest_first",
-                "suspect_commit": dispatch_advisor.suspect_commit,
-                "is_born_red": dispatch_advisor.is_born_red,
-                "commits": commits_json,
-            }
-        )
+        payload = {
+            "signal_key": signal.key,
+            "signal_source": signal.source.value if signal.source else "unknown",
+            "workflow_name": signal.workflow_name,
+            "job_base_name": signal.job_base_name,
+            "commit_order": "newest_first",
+            "suspect_commit": dispatch_advisor.suspect_commit,
+            "commits": commits_json,
+        }
+        if dispatch_advisor.is_born_red:
+            payload["pattern_context"] = _BORN_RED_PATTERN_CONTEXT
+        return json.dumps(payload)
 
     def _commit_message_check_pr_is_revert(
         self, commit_message: str, ctx: RunContext

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
@@ -774,9 +774,7 @@ class SignalActionProcessor:
                 "no_signal: baseline commits where this test signal was not "
                 "observed (no extracted events). See top-level pattern_context."
             )
-            LABEL_PRIOR = (
-                "prior: even older commits with no signal observation"
-            )
+            LABEL_PRIOR = "prior: even older commits with no signal observation"
         else:
             LABEL_SUCCESSFUL = (
                 "successful: baseline commits where this signal was GREEN "

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
@@ -1306,9 +1306,7 @@ class TestBornRedTestSignal(unittest.TestCase):
         )
 
     def _empty(self, sha: str, minute: int) -> SignalCommit:
-        return SignalCommit(
-            head_sha=sha, timestamp=ts(self.t0, minute), events=[]
-        )
+        return SignalCommit(head_sha=sha, timestamp=ts(self.t0, minute), events=[])
 
     def _test_signal(self, commits, key: str = "f.py::t") -> Signal:
         return Signal(

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
@@ -1269,5 +1269,235 @@ class TestSignalCommitReplace(unittest.TestCase):
             c.replace(this_field_does_not_exist=42)
 
 
+class TestBornRedTestSignal(unittest.TestCase):
+    """Test-track born-red detection: failing head + empty-events tail.
+
+    Covers the blind spot where a test was introduced by the same commit that
+    breaks it (or by a recent ancestor): the green→red partition path returns
+    `Ineligible(NO_SUCCESSES)` and bails before dispatching the advisor. The
+    born-red path asks the advisor "did the suspect commit introduce this
+    failing test?" instead.
+    """
+
+    def setUp(self) -> None:
+        self.t0 = datetime(2026, 5, 21, 12, 0, 0)
+
+    def _ev(
+        self,
+        name: str,
+        status: SignalStatus,
+        minute: int,
+        wf_run_id: int = 1,
+        job_id: int = 100,
+    ) -> SignalEvent:
+        return SignalEvent(
+            name=name,
+            status=status,
+            started_at=ts(self.t0, minute),
+            wf_run_id=wf_run_id,
+            job_id=job_id,
+        )
+
+    def _fail(self, sha: str, minute: int, *, job_id: int = 100) -> SignalCommit:
+        return SignalCommit(
+            head_sha=sha,
+            timestamp=ts(self.t0, minute),
+            events=[self._ev("t", SignalStatus.FAILURE, minute, job_id=job_id)],
+        )
+
+    def _empty(self, sha: str, minute: int) -> SignalCommit:
+        return SignalCommit(
+            head_sha=sha, timestamp=ts(self.t0, minute), events=[]
+        )
+
+    def _test_signal(self, commits, key: str = "f.py::t") -> Signal:
+        return Signal(
+            key=key,
+            workflow_name="trunk",
+            commits=commits,
+            source=SignalSource.TEST,
+        )
+
+    # ---- partition_born_red shape checks ----
+
+    def test_partition_born_red_canonical_shape(self):
+        commits = [
+            self._fail("f1", 0, job_id=1),
+            self._fail("f2", -10, job_id=2),
+            self._empty("e1", -20),
+            self._empty("e2", -30),
+        ]
+        part = self._test_signal(commits).partition_born_red()
+        assert part is not None
+        self.assertEqual([c.head_sha for c in part.failed], ["f1", "f2"])
+        self.assertEqual([c.head_sha for c in part.successful], ["e1", "e2"])
+        self.assertEqual(part.unknown, [])
+
+    def test_partition_born_red_none_when_has_successes(self):
+        # Even one success disqualifies the born-red shape — the main partition
+        # path applies instead.
+        commits = [
+            self._fail("f1", 0),
+            SignalCommit(
+                head_sha="s1",
+                timestamp=ts(self.t0, -10),
+                events=[self._ev("t", SignalStatus.SUCCESS, -10)],
+            ),
+        ]
+        self.assertIsNone(self._test_signal(commits).partition_born_red())
+
+    def test_partition_born_red_none_without_empty_tail(self):
+        # All commits fail — chronic infra shape, not born-red.
+        commits = [self._fail("f1", 0), self._fail("f2", -10)]
+        self.assertIsNone(self._test_signal(commits).partition_born_red())
+
+    def test_partition_born_red_none_without_failures(self):
+        # Only empty commits — nothing to act on.
+        commits = [self._empty("e1", 0), self._empty("e2", -10)]
+        self.assertIsNone(self._test_signal(commits).partition_born_red())
+
+    def test_partition_born_red_none_on_interleaved_empty_then_fail(self):
+        # newest=empty, older=fail violates the [FAIL...][EMPTY...] order.
+        commits = [self._empty("e1", 0), self._fail("f1", -10), self._empty("e2", -20)]
+        self.assertIsNone(self._test_signal(commits).partition_born_red())
+
+    def test_partition_born_red_none_on_pending_only_commit(self):
+        # Pending-only commits are neither failures nor empty — bail.
+        commits = [
+            self._fail("f1", 0),
+            SignalCommit(
+                head_sha="p1",
+                timestamp=ts(self.t0, -10),
+                events=[self._ev("t", SignalStatus.PENDING, -10)],
+            ),
+            self._empty("e1", -20),
+        ]
+        self.assertIsNone(self._test_signal(commits).partition_born_red())
+
+    def test_partition_born_red_requires_two_commits(self):
+        # Single commit can't form a partition.
+        self.assertIsNone(self._test_signal([self._fail("f1", 0)]).partition_born_red())
+
+    # ---- process_valid_autorevert_pattern wiring ----
+
+    def test_process_dispatches_advisor_for_born_red(self):
+        commits = [
+            self._fail("f1", 0, job_id=11),
+            self._fail("f2", -10, job_id=12),
+            self._empty("e1", -20),
+        ]
+        res = self._test_signal(commits).process_valid_autorevert_pattern()
+        self.assertIsInstance(res, Ineligible)
+        self.assertEqual(res.reason, IneligibleReason.NO_SUCCESSES)
+        self.assertIsNotNone(res.advisor)
+        # Suspect = oldest failing commit (f2)
+        self.assertEqual(res.advisor.suspect_commit, "f2")
+        self.assertEqual(res.advisor.failed_commits, ("f1", "f2"))
+        self.assertEqual(res.advisor.successful_commits, ("e1",))
+        self.assertTrue(res.advisor.is_born_red)
+
+    def test_process_holds_advisor_below_failing_commit_threshold(self):
+        # Single failing commit — wait for the next trunk advance before paying
+        # advisor cost (REQUIRE_FAILED_COMMITS_BORN_RED == 2). Distinct
+        # commits, not raw event counts, gate the dispatch.
+        commits = [self._fail("f1", 0), self._empty("e1", -10)]
+        res = self._test_signal(commits).process_valid_autorevert_pattern()
+        self.assertIsInstance(res, Ineligible)
+        self.assertEqual(res.reason, IneligibleReason.NO_SUCCESSES)
+        self.assertIsNone(res.advisor)
+
+    def test_process_threshold_counts_distinct_commits_not_events(self):
+        # Single commit with multiple FAILURE events (e.g. retries / multiple
+        # shards) is one trunk observation, NOT two — should not dispatch.
+        c_multi_event = SignalCommit(
+            head_sha="f1",
+            timestamp=ts(self.t0, 0),
+            events=[
+                self._ev("t", SignalStatus.FAILURE, 0, wf_run_id=1, job_id=11),
+                self._ev("t", SignalStatus.FAILURE, 1, wf_run_id=2, job_id=12),
+                self._ev("t", SignalStatus.FAILURE, 2, wf_run_id=3, job_id=13),
+            ],
+        )
+        commits = [c_multi_event, self._empty("e1", -10)]
+        res = self._test_signal(commits).process_valid_autorevert_pattern()
+        self.assertIsInstance(res, Ineligible)
+        self.assertEqual(res.reason, IneligibleReason.NO_SUCCESSES)
+        self.assertIsNone(res.advisor)
+
+    def test_process_no_advisor_for_job_track_born_red(self):
+        # Born-red detection is test-track only. Job-track signals with the
+        # same shape are likely persistent infra failures or new jobs with a
+        # warm-up — not actionable via this path.
+        commits = [
+            self._fail("f1", 0, job_id=21),
+            self._fail("f2", -10, job_id=22),
+            self._empty("e1", -20),
+        ]
+        s = Signal(
+            key="job",
+            workflow_name="trunk",
+            commits=commits,
+            source=SignalSource.JOB,
+        )
+        res = s.process_valid_autorevert_pattern()
+        self.assertIsInstance(res, Ineligible)
+        self.assertEqual(res.reason, IneligibleReason.NO_SUCCESSES)
+        self.assertIsNone(res.advisor)
+
+    def test_process_no_advisor_when_chronic_failure_no_empty_tail(self):
+        # Chronic shape — every commit fails, no empties. Lambda continues to
+        # return the existing NO_SUCCESSES without an advisor.
+        commits = [self._fail("f1", 0), self._fail("f2", -10), self._fail("f3", -20)]
+        res = self._test_signal(commits).process_valid_autorevert_pattern()
+        self.assertIsInstance(res, Ineligible)
+        self.assertEqual(res.reason, IneligibleReason.NO_SUCCESSES)
+        self.assertIsNone(res.advisor)
+
+    def test_process_returns_autorevert_pattern_on_advisor_revert_verdict(self):
+        # Advisor previously returned `revert` on the suspect with high
+        # confidence → born-red path lifts the verdict into an
+        # `AutorevertPattern` so the lambda actions a revert.
+        verdict = AIAdvisorResult(
+            verdict=AdvisorVerdict.REVERT,
+            confidence=0.95,
+            timestamp=self.t0,
+            signal_key="f.py::t",
+        )
+        suspect = SignalCommit(
+            head_sha="f2",
+            timestamp=ts(self.t0, -10),
+            events=[self._ev("t", SignalStatus.FAILURE, -10, job_id=12)],
+            advisor_result=verdict,
+        )
+        commits = [self._fail("f1", 0, job_id=11), suspect, self._empty("e1", -20)]
+        res = self._test_signal(commits).process_valid_autorevert_pattern()
+        self.assertIsInstance(res, AutorevertPattern)
+        self.assertEqual(res.suspected_commit, "f2")
+        # Newer failing commit reported alongside the suspect.
+        self.assertEqual(res.newer_failing_commits, ["f1"])
+        # Older "successful" reference = newest empty-events commit (implicit
+        # baseline) — used in the revert PR body.
+        self.assertEqual(res.older_successful_commit, "e1")
+        self.assertIsNotNone(res.advisor_verdict)
+
+    def test_process_blocks_on_advisor_not_related_verdict(self):
+        verdict = AIAdvisorResult(
+            verdict=AdvisorVerdict.NOT_RELATED,
+            confidence=0.95,
+            timestamp=self.t0,
+            signal_key="f.py::t",
+        )
+        suspect = SignalCommit(
+            head_sha="f2",
+            timestamp=ts(self.t0, -10),
+            events=[self._ev("t", SignalStatus.FAILURE, -10, job_id=12)],
+            advisor_result=verdict,
+        )
+        commits = [self._fail("f1", 0, job_id=11), suspect, self._empty("e1", -20)]
+        res = self._test_signal(commits).process_valid_autorevert_pattern()
+        self.assertIsInstance(res, Ineligible)
+        self.assertEqual(res.reason, IneligibleReason.ADVISOR_NOT_RELATED)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
@@ -1328,7 +1328,8 @@ class TestBornRedTestSignal(unittest.TestCase):
             self._empty("e2", -30),
         ]
         part = self._test_signal(commits).partition_born_red()
-        assert part is not None
+        self.assertIsNotNone(part)
+        assert part is not None  # narrow type for mypy
         self.assertEqual([c.head_sha for c in part.failed], ["f1", "f2"])
         self.assertEqual([c.head_sha for c in part.successful], ["e1", "e2"])
         self.assertEqual(part.unknown, [])

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_actions.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_actions.py
@@ -759,6 +759,78 @@ class TestBuildSignalPatternJson(unittest.TestCase):
         # Timestamps are human-readable
         self.assertIn("UTC", commits["sha_fail"]["timestamp"])
 
+    def test_born_red_relabels_baseline_partition(self):
+        """When is_born_red=True, the SUCCESSFUL partition is relabeled.
+
+        The advisor must be asked "did the suspect introduce the failing
+        test?" rather than "was this signal green here?" — the new label
+        names the four causes (introduction / enable / move / sharding)
+        explicitly so the model picks the right one.
+        """
+        import json
+
+        from pytorch_auto_revert.signal import (
+            DispatchAdvisor,
+            Signal,
+            SignalCommit,
+            SignalEvent,
+            SignalSource,
+            SignalStatus,
+        )
+
+        t0 = datetime(2026, 5, 21, 12, 0, 0)
+        c_newer_fail = SignalCommit(
+            head_sha="f1",
+            timestamp=t0,
+            events=[
+                SignalEvent("t", SignalStatus.FAILURE, t0, wf_run_id=1, job_id=11),
+            ],
+        )
+        c_suspect = SignalCommit(
+            head_sha="f2",
+            timestamp=t0,
+            events=[
+                SignalEvent("t", SignalStatus.FAILURE, t0, wf_run_id=2, job_id=12),
+            ],
+        )
+        c_baseline = SignalCommit(head_sha="e1", timestamp=t0, events=[])
+
+        signal = Signal(
+            key="inductor/test_flip.py::test_flip_zero_dim",
+            workflow_name="trunk",
+            commits=[c_newer_fail, c_suspect, c_baseline],
+            source=SignalSource.TEST,
+        )
+        advisor = DispatchAdvisor(
+            suspect_commit="f2",
+            failed_commits=("f1", "f2"),
+            successful_commits=("e1",),
+            is_born_red=True,
+        )
+
+        result = json.loads(
+            SignalActionProcessor._build_signal_pattern_json(
+                signal=signal,
+                dispatch_advisor=advisor,
+                repo_full_name="pytorch/pytorch",
+            )
+        )
+
+        # Top-level flag plumbed for advisor prompt branching
+        self.assertTrue(result["is_born_red"])
+
+        commits = {c["sha"]: c for c in result["commits"]}
+        baseline_label = commits["e1"]["partition"]
+        # Relabeled from "successful: ... GREEN ..." to a "no_signal:" framing
+        # that explicitly asks the advisor to distinguish introduction vs.
+        # enable vs. move vs. sharding.
+        self.assertIn("no_signal", baseline_label)
+        self.assertNotIn("GREEN", baseline_label)
+        self.assertIn("NOT", baseline_label.upper())
+        # Must enumerate the four ambiguity causes the advisor has to pick from.
+        for cue in ("ADDED", "ENABLED", "MOVED", "sharding"):
+            self.assertIn(cue, baseline_label)
+
     def test_unknown_partition_label(self):
         """Commits between failed and successful partitions get 'unknown' label."""
         import json

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_actions.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_actions.py
@@ -759,13 +759,14 @@ class TestBuildSignalPatternJson(unittest.TestCase):
         # Timestamps are human-readable
         self.assertIn("UTC", commits["sha_fail"]["timestamp"])
 
-    def test_born_red_relabels_baseline_partition(self):
-        """When is_born_red=True, the SUCCESSFUL partition is relabeled.
+    def test_born_red_attaches_pattern_context_and_short_label(self):
+        """When is_born_red=True, the JSON carries the long framing once at
+        the top level (`pattern_context`) and uses a SHORT partition label
+        for each baseline commit.
 
-        The advisor must be asked "did the suspect introduce the failing
-        test?" rather than "was this signal green here?" — the new label
-        names the four causes (introduction / enable / move / sharding)
-        explicitly so the model picks the right one.
+        Earlier iterations duplicated the full natural-language framing into
+        every commit's `partition` field. Said once: `pattern_context`. Per
+        commit: a terse label that points back at the top-level context.
         """
         import json
 
@@ -816,20 +817,79 @@ class TestBuildSignalPatternJson(unittest.TestCase):
             )
         )
 
-        # Top-level flag plumbed for advisor prompt branching
-        self.assertTrue(result["is_born_red"])
+        # Top-level pattern_context carries the long framing (said once).
+        self.assertIn("pattern_context", result)
+        ctx = result["pattern_context"]
+        self.assertIn("born-red", ctx)
+        # Enumerates the four ambiguity causes the advisor must distinguish.
+        for cue in ("ADDED", "ENABLED", "MOVED", "sharding"):
+            self.assertIn(cue, ctx)
+        # Tells the advisor what to recommend in each case.
+        self.assertIn("revert", ctx)
+        self.assertIn("not_related", ctx)
 
+        # Per-commit partition labels stay SHORT — they only point back at
+        # the top-level context.
         commits = {c["sha"]: c for c in result["commits"]}
         baseline_label = commits["e1"]["partition"]
-        # Relabeled from "successful: ... GREEN ..." to a "no_signal:" framing
-        # that explicitly asks the advisor to distinguish introduction vs.
-        # enable vs. move vs. sharding.
         self.assertIn("no_signal", baseline_label)
-        self.assertNotIn("GREEN", baseline_label)
-        self.assertIn("NOT", baseline_label.upper())
-        # Must enumerate the four ambiguity causes the advisor has to pick from.
-        for cue in ("ADDED", "ENABLED", "MOVED", "sharding"):
-            self.assertIn(cue, baseline_label)
+        self.assertLess(
+            len(baseline_label),
+            len(ctx) // 3,
+            "per-commit label must be short relative to pattern_context",
+        )
+        # The fully-spelled-out cause cues live in pattern_context, NOT in
+        # every commit's label.
+        for cue in ("ADDED", "ENABLED", "MOVED"):
+            self.assertNotIn(cue, baseline_label)
+
+    def test_non_born_red_has_no_pattern_context(self):
+        """`pattern_context` is born-red-only — not emitted for normal
+        green→red patterns."""
+        import json
+
+        from pytorch_auto_revert.signal import (
+            DispatchAdvisor,
+            Signal,
+            SignalCommit,
+            SignalEvent,
+            SignalSource,
+            SignalStatus,
+        )
+
+        t0 = datetime(2026, 5, 21, 12, 0, 0)
+        c_fail = SignalCommit(
+            head_sha="f1",
+            timestamp=t0,
+            events=[
+                SignalEvent("t", SignalStatus.FAILURE, t0, wf_run_id=1, job_id=11),
+            ],
+        )
+        c_base = SignalCommit(
+            head_sha="b1",
+            timestamp=t0,
+            events=[
+                SignalEvent("t", SignalStatus.SUCCESS, t0, wf_run_id=2, job_id=12),
+            ],
+        )
+        signal = Signal(
+            key="k", workflow_name="trunk", commits=[c_fail, c_base],
+            source=SignalSource.TEST,
+        )
+        advisor = DispatchAdvisor(
+            suspect_commit="f1",
+            failed_commits=("f1",),
+            successful_commits=("b1",),
+            is_born_red=False,
+        )
+        result = json.loads(
+            SignalActionProcessor._build_signal_pattern_json(
+                signal=signal,
+                dispatch_advisor=advisor,
+                repo_full_name="pytorch/pytorch",
+            )
+        )
+        self.assertNotIn("pattern_context", result)
 
     def test_unknown_partition_label(self):
         """Commits between failed and successful partitions get 'unknown' label."""

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_actions.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_actions.py
@@ -873,7 +873,9 @@ class TestBuildSignalPatternJson(unittest.TestCase):
             ],
         )
         signal = Signal(
-            key="k", workflow_name="trunk", commits=[c_fail, c_base],
+            key="k",
+            workflow_name="trunk",
+            commits=[c_fail, c_base],
             source=SignalSource.TEST,
         )
         advisor = DispatchAdvisor(


### PR DESCRIPTION
## Summary

Closes a structural blind spot in the autorevert lambda: a test introduced by the same commit that breaks it (or by a recent commit that re-enabled / moved / unsharded it) has no green observations in the lookback window, so the existing green→red partition path returns `Ineligible(NO_SUCCESSES)` and never asks the advisor.

This PR adds a "born-red" detection path that hands these cases to the AI advisor with framing tailored for the introduction question.

## Motivation

[pytorch/pytorch#184104](https://github.com/pytorch/pytorch/pull/184104) (2026-05-21, "[Inductor] Fix flip on 0-d tensors in prims.rev lowering") added two new tests to inductor codegen-dynamic-shapes and registered them as `expectedFailure` on cuda/xpu. The lowering fix actually worked on cuda → "Unexpected success" → FAILED. The lambda saw the failures on every trunk run from the PR landing onward but emitted `Ineligible(NO_SUCCESSES, "no successful commits present in window")` for ~9h until a human revert. Verified from `misc.autorevert_state.outcomes` JSON:

```
trunk:inductor/test_torchinductor_codegen_dynamic_shapes.py::test_flip_zero_dim_dynamic_shapes_cuda
  → Ineligible / reason="no_successes" / "no successful commits present in window"
```

The lambda was healthy on the same tick — it emitted an `AutorevertPattern` (advisor verdict=revert, confidence=0.97) for an unrelated `linux-jammy-cuda13.0-py3.10-gcc11` job-track signal. The blind spot is per-signal, not lambda-wide.

## Approach

Three primitives, all reusing the existing data model:

1. **`Signal.partition_born_red()`** — returns a `PartitionedCommits` only when the signal shape (newest→oldest) is exactly `[FAIL...][EMPTY...]`. No interleaving, no pending-only commits in between. The trailing empty-events commits act as the implicit baseline ("commits where this test signal was not observed").

2. **`Signal._handle_no_successes()`** — called from the existing early-exit point in `process_valid_autorevert_pattern`. For test-track signals where `partition_born_red()` succeeds and there are ≥2 distinct failing commits (counted by commits, not events — retries / multiple shards on a single commit are still one trunk observation), it either lifts an existing advisor verdict into an `AutorevertPattern` (revert/related) or dispatches a fresh advisor request alongside the `Ineligible(NO_SUCCESSES)` outcome. Job-track no-success signals stay on the original path (likely persistent infra or warm-up).

3. **`DispatchAdvisor.is_born_red` flag** — tells `_build_signal_pattern_json` to relabel the SUCCESSFUL partition. The new label asks the advisor to distinguish four causes from the suspect's diff: (a) ADDED the test, (b) ENABLED / un-skipped / removed a TD filter, (c) MOVED / RENAMED so the test identity is newly visible, (d) sharding / job-selection change. Recommend revert only when the suspect explicitly introduces or enables the failing test (cases a/b/c).

Reused infrastructure:
- `_check_advisor_verdict()` and `_build_autorevert_pattern()` from the existing partition path — the born-red partition slots in cleanly.
- Advisor de-dup (`prior_advisor_exists`) and per-(workflow, commit) cap of 8 in `SignalActionsLogger` — no new infra.

## What changes for the advisor prompt

When `is_born_red=True`, the SUCCESSFUL partition in `signal_pattern.json` is labeled:

> **no_signal**: baseline commits where this test signal was NOT OBSERVED (no extracted events). The suspect commit is the first commit on which the test signal appears, and it fails. Possible causes — distinguish from the suspect commit's diff: (a) the suspect ADDED this test; (b) the suspect ENABLED/UN-SKIPPED an existing test or removed a TD/skipping filter that previously masked it; (c) the suspect MOVED or RENAMED the test so its identity is newly visible; (d) the suspect changed sharding / job selection so an existing already-failing test became visible. Recommend revert only if the suspect's diff explicitly introduces or enables the failing test (cases a/b/c).

A top-level `is_born_red: true` flag is also surfaced in the JSON so the advisor workflow can branch on it cleanly.

## Test plan

- [x] `pytorch_auto_revert/tests/test_signal.py::TestBornRedTestSignal` — 11 new tests covering:
  - canonical `[FAIL][EMPTY]` shape
  - rejection of shapes that aren't born-red (has successes, no empty tail, no failures, interleaved empty→fail, pending-only between, single commit)
  - end-to-end dispatch on the 2-failing-commits + 1-empty case
  - threshold counts distinct commits, not raw events (single commit with 3 retries doesn't dispatch)
  - job-track signals don't get the born-red path
  - chronic `[FAIL...]` without empty tail stays on the original `NO_SUCCESSES` path
  - existing advisor verdict (revert) lifts the born-red partition into `AutorevertPattern` with the right `suspected_commit` and `older_successful_commit`
  - `NOT_RELATED` verdict blocks (returns `ADVISOR_NOT_RELATED`)
- [x] `pytorch_auto_revert/tests/test_signal_actions.py::test_born_red_relabels_baseline_partition` — verifies the JSON relabel and the `is_born_red` top-level flag, including all four ambiguity-cause cues.
- [x] Full local suite: `./venv/bin/python -m unittest discover -s pytorch_auto_revert/tests -p "test_*.py"` — 175 tests, all pass.

## Notes

- Cross-model adversarial review (`gpt-5.5` via Codex CLI) flagged three MEDIUM concerns; all three were addressed in this PR before submission: the introduction-vs-enable framing in the JSON label, gating on distinct failing commits (not raw events), and the verdict-key check (already keyed by `signal_key + suspect_commit`, no fix needed).
- The advisor prompt template (`.github/workflows/claude-autorevert-advisor.yml`) is not touched here — the existing prompt already consumes the partition labels, so the relabel propagates through without a workflow change. If the upstream prompt benefits from explicitly branching on `is_born_red`, that can be a follow-up.