### PR TITLE
Bump mypy python_version from 3.9 to 3.11

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 
 # Copied from pytorch/mypy-strict.ini
 [mypy]
-python_version = 3.9
+python_version = 3.11
 
 show_error_codes = True
 show_column_numbers = True


### PR DESCRIPTION
## Summary

Bump mypy's `python_version` target from `3.9` to `3.11` (matching the actual CI runtime).

## Why

The `lintrunner` MYPY job is failing repo-wide on any PR because mypy follows imports into the `click` library, which now uses PEP 634 structural pattern matching (`match` / `case`). With `python_version = 3.9`, mypy rejects that syntax with:

```
Pattern matching is only supported in Python 3.10 and greater
  .local/lib/python3.11/site-packages/click/utils.py:298
```

Example failing run: https://github.com/pytorch/test-infra/actions/runs/26267476891/job/77394160454?pr=8069

The lintrunner CI job runs on Python 3.11 (`lintrunner (ubuntu-latest, 3.11)`), so aligning mypy's target to 3.11 matches the runtime and unblocks the lint job. 3.9 has been EOL since October 2025, so the target was overdue for a bump.

## Test plan

- [ ] Confirm `lintrunner` MYPY job goes green on this PR.
- [ ] Spot-check that no previously-passing files now error (the bump enables some newer-mypy diagnostics that 3.9 target suppressed).
