### PR TITLE
OOT HUD: Add frontend components — summary, dashboard, PR section (Part 2/3)

### DIFF
--- a/torchci/components/oot/OotPrSection.tsx
+++ b/torchci/components/oot/OotPrSection.tsx
@@ -1,0 +1,145 @@
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Chip,
+  Link,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import { durationDisplay } from "components/common/TimeUtils";
+import { fetcher } from "lib/GeneralUtils";
+import { conclusionColor, conclusionLabel } from "lib/oot/ootUtils";
+import useSWR from "swr";
+
+interface OotPrResult {
+  downstream_repo: string;
+  workflow_name: string;
+  job_name: string;
+  check_run_id: string;
+  run_id: string;
+  run_attempt: number;
+  status: string;
+  conclusion: string;
+  duration_seconds: number;
+  workflow_run_url: string;
+  artifact_url: string;
+  started_at: string;
+  queue_time: number | null;
+  execution_time: number | null;
+}
+
+export default function OotPrSection({ prNumber }: { prNumber: number }) {
+  const url = `/api/clickhouse/oot_pr_results?parameters=${encodeURIComponent(
+    JSON.stringify({ pr: String(prNumber) })
+  )}`;
+  const { data, error } = useSWR<OotPrResult[]>(url, fetcher, {
+    refreshInterval: 60_000,
+  });
+
+  if (error || !data || data.length === 0) return null;
+
+  const successCount = data.filter(
+    (r) => r.status === "completed" && r.conclusion === "success"
+  ).length;
+  const totalCompleted = data.filter((r) => r.status === "completed").length;
+  const inProgress = data.filter((r) => r.status === "in_progress").length;
+
+  const summaryText = [
+    totalCompleted > 0 ? `${successCount}/${totalCompleted} passed` : null,
+    inProgress > 0 ? `${inProgress} running` : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  return (
+    <Accordion defaultExpanded={false} sx={{ mt: 2 }}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Typography variant="subtitle1">
+            <strong>Out-of-Tree Backends</strong>
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            ({summaryText})
+          </Typography>
+        </Stack>
+      </AccordionSummary>
+      <AccordionDetails>
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>
+                  <strong>Backend</strong>
+                </TableCell>
+                <TableCell>
+                  <strong>Job</strong>
+                </TableCell>
+                <TableCell align="center">
+                  <strong>Status</strong>
+                </TableCell>
+                <TableCell align="right">
+                  <strong>Duration</strong>
+                </TableCell>
+                <TableCell>
+                  <strong>Links</strong>
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {data.map((row, i) => (
+                <TableRow key={i} hover>
+                  <TableCell>{row.downstream_repo}</TableCell>
+                  <TableCell>{row.job_name}</TableCell>
+                  <TableCell align="center">
+                    <Chip
+                      label={conclusionLabel(row.status, row.conclusion)}
+                      color={conclusionColor(row.status, row.conclusion)}
+                      size="small"
+                    />
+                  </TableCell>
+                  <TableCell align="right">
+                    {row.duration_seconds
+                      ? durationDisplay(Math.round(row.duration_seconds))
+                      : "–"}
+                  </TableCell>
+                  <TableCell>
+                    <Stack direction="row" spacing={1}>
+                      {row.workflow_run_url && (
+                        <Link
+                          href={row.workflow_run_url}
+                          target="_blank"
+                          rel="noopener"
+                          variant="body2"
+                        >
+                          Run
+                        </Link>
+                      )}
+                      {row.artifact_url && (
+                        <Link
+                          href={row.artifact_url}
+                          target="_blank"
+                          rel="noopener"
+                          variant="body2"
+                        >
+                          Artifacts
+                        </Link>
+                      )}
+                    </Stack>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </AccordionDetails>
+    </Accordion>
+  );
+}

--- a/torchci/pages/oot/[org]/[repo].tsx
+++ b/torchci/pages/oot/[org]/[repo].tsx
@@ -29,6 +29,7 @@ import { useMemo, useState } from "react";
 import useSWR from "swr";
 
 interface OotJobRow {
+  upstream_repo: string;
   pr_number: number;
   pytorch_head_sha: string;
   workflow_name: string;
@@ -92,6 +93,7 @@ function JobChip({ job }: { job: OotJobRow }) {
 interface MatrixRow {
   prNumber: number;
   sha: string;
+  upstreamRepo: string;
   jobs: Map<string, OotJobRow>;
 }
 
@@ -109,6 +111,7 @@ function buildMatrix(data: OotJobRow[]): {
       row = {
         prNumber: job.pr_number,
         sha: job.pytorch_head_sha,
+        upstreamRepo: job.upstream_repo ?? "pytorch/pytorch",
         jobs: new Map(),
       };
       prMap.set(job.pr_number, row);

--- a/torchci/pages/oot/[org]/[repo].tsx
+++ b/torchci/pages/oot/[org]/[repo].tsx
@@ -1,0 +1,290 @@
+import {
+  Box,
+  Chip,
+  FormControl,
+  InputLabel,
+  Link,
+  MenuItem,
+  Paper,
+  Select,
+  SelectChangeEvent,
+  Skeleton,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { durationDisplay } from "components/common/TimeUtils";
+import { fetcher } from "lib/GeneralUtils";
+import { conclusionColor, conclusionLabel } from "lib/oot/ootUtils";
+import Head from "next/head";
+import NextLink from "next/link";
+import { useRouter } from "next/router";
+import { useMemo, useState } from "react";
+import useSWR from "swr";
+
+interface OotJobRow {
+  pr_number: number;
+  pytorch_head_sha: string;
+  workflow_name: string;
+  job_name: string;
+  check_run_id: string;
+  run_id: string;
+  run_attempt: number;
+  status: string;
+  conclusion: string;
+  started_at: string;
+  completed_at: string;
+  duration_seconds: number;
+  total_tests: number;
+  passed_tests: number;
+  failed_tests: number;
+  skipped_tests: number;
+  workflow_run_url: string;
+  artifact_url: string;
+  queue_time: number | null;
+  execution_time: number | null;
+}
+
+function JobChip({ job }: { job: OotJobRow }) {
+  const color = conclusionColor(job.status, job.conclusion);
+  const label = conclusionLabel(job.status, job.conclusion);
+  const tooltipContent = [
+    `Job: ${job.job_name}`,
+    job.run_attempt > 1 ? `Attempt: ${job.run_attempt}` : null,
+    `Duration: ${
+      job.duration_seconds
+        ? durationDisplay(Math.round(job.duration_seconds))
+        : "–"
+    }`,
+    job.total_tests
+      ? `Tests: ${job.passed_tests}/${job.total_tests} passed`
+      : null,
+    job.queue_time != null ? `Queue: ${job.queue_time.toFixed(1)}s` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return (
+    <Tooltip
+      title={<span style={{ whiteSpace: "pre-line" }}>{tooltipContent}</span>}
+    >
+      <Chip
+        label={label}
+        color={color}
+        size="small"
+        component="a"
+        href={job.workflow_run_url}
+        target="_blank"
+        rel="noopener"
+        clickable
+        sx={{ mx: 0.25 }}
+      />
+    </Tooltip>
+  );
+}
+
+interface MatrixRow {
+  prNumber: number;
+  sha: string;
+  jobs: Map<string, OotJobRow>;
+}
+
+function buildMatrix(data: OotJobRow[]): {
+  jobNames: string[];
+  rows: MatrixRow[];
+} {
+  const jobNamesSet = new Set<string>();
+  const prMap = new Map<number, MatrixRow>();
+
+  for (const job of data) {
+    jobNamesSet.add(job.job_name);
+    let row = prMap.get(job.pr_number);
+    if (!row) {
+      row = {
+        prNumber: job.pr_number,
+        sha: job.pytorch_head_sha,
+        jobs: new Map(),
+      };
+      prMap.set(job.pr_number, row);
+    }
+    // Keep the latest attempt per job_name (highest run_attempt wins)
+    const existing = row.jobs.get(job.job_name);
+    if (!existing || job.run_attempt > existing.run_attempt) {
+      row.jobs.set(job.job_name, job);
+    }
+  }
+
+  const jobNames = Array.from(jobNamesSet).sort();
+  const rows = Array.from(prMap.values()).sort(
+    (a, b) => b.prNumber - a.prNumber
+  );
+  return { jobNames, rows };
+}
+
+function HealthSummary({ data }: { data: OotJobRow[] }) {
+  const completed = data.filter((j) => j.status === "completed");
+  const total = completed.length;
+  const success = completed.filter((j) => j.conclusion === "success").length;
+  const rate = total > 0 ? success / total : 0;
+
+  return (
+    <Stack direction="row" spacing={2} alignItems="center">
+      <Chip
+        label={`Pass rate: ${(rate * 100).toFixed(1)}%`}
+        color={rate >= 0.95 ? "success" : rate >= 0.8 ? "warning" : "error"}
+      />
+      <Typography variant="body2" color="text.secondary">
+        {success}/{total} jobs passed
+      </Typography>
+    </Stack>
+  );
+}
+
+function OotMatrix({
+  repoFullName,
+  days,
+}: {
+  repoFullName: string;
+  days: number;
+}) {
+  const url = `/api/clickhouse/oot_backend_dashboard?parameters=${encodeURIComponent(
+    JSON.stringify({ repo: repoFullName, days: String(days) })
+  )}`;
+  const { data, error } = useSWR<OotJobRow[]>(url, fetcher, {
+    refreshInterval: 60_000,
+  });
+
+  const matrix = useMemo(() => (data ? buildMatrix(data) : null), [data]);
+
+  if (error) {
+    return (
+      <Typography color="error">
+        Failed to load dashboard: {error.message}
+      </Typography>
+    );
+  }
+  if (!data || !matrix) {
+    return <Skeleton variant="rectangular" height={400} />;
+  }
+  if (data.length === 0) {
+    return (
+      <Typography color="text.secondary" sx={{ py: 4, textAlign: "center" }}>
+        No results for {repoFullName} in the last {days} days.
+      </Typography>
+    );
+  }
+
+  return (
+    <>
+      <HealthSummary data={data} />
+      <TableContainer component={Paper} elevation={2} sx={{ mt: 2 }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>
+                <strong>PR</strong>
+              </TableCell>
+              <TableCell>
+                <strong>SHA</strong>
+              </TableCell>
+              {matrix.jobNames.map((name) => (
+                <TableCell key={name} align="center">
+                  <strong>{name}</strong>
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {matrix.rows.map((row) => (
+              <TableRow key={row.prNumber} hover>
+                <TableCell>
+                  <NextLink
+                    href={`https://github.com/${
+                      row.upstreamRepo ?? "pytorch/pytorch"
+                    }/pull/${row.prNumber}`}
+                    passHref
+                    legacyBehavior
+                  >
+                    <Link target="_blank" rel="noopener" underline="hover">
+                      #{row.prNumber}
+                    </Link>
+                  </NextLink>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2" fontFamily="monospace">
+                    {row.sha.slice(0, 7)}
+                  </Typography>
+                </TableCell>
+                {matrix.jobNames.map((name) => {
+                  const job = row.jobs.get(name);
+                  return (
+                    <TableCell key={name} align="center">
+                      {job ? <JobChip job={job} /> : "–"}
+                    </TableCell>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </>
+  );
+}
+
+export default function OotBackendPage() {
+  const router = useRouter();
+  const { org, repo } = router.query;
+  const [days, setDays] = useState(7);
+
+  if (!org || !repo) return null;
+
+  const repoFullName = `${org}/${repo}`;
+
+  return (
+    <>
+      <Head>
+        <title>{repoFullName} — OOT CI | PyTorch HUD</title>
+      </Head>
+      <Stack spacing={3} sx={{ p: 3, maxWidth: 1600, mx: "auto" }}>
+        <Box display="flex" justifyContent="space-between" alignItems="center">
+          <Stack spacing={0.5}>
+            <Typography variant="h4">{repoFullName}</Typography>
+            <NextLink href="/oot" passHref legacyBehavior>
+              <Link variant="body2" underline="hover">
+                ← Back to OOT Summary
+              </Link>
+            </NextLink>
+          </Stack>
+          <FormControl size="small" sx={{ minWidth: 140 }}>
+            <InputLabel>Time Range</InputLabel>
+            <Select
+              value={days}
+              label="Time Range"
+              onChange={(e: SelectChangeEvent<number>) =>
+                setDays(Number(e.target.value))
+              }
+            >
+              <MenuItem value={1}>Last 24h</MenuItem>
+              <MenuItem value={7}>Last 7 days</MenuItem>
+              <MenuItem value={30}>Last 30 days</MenuItem>
+            </Select>
+          </FormControl>
+        </Box>
+
+        <Typography variant="body2" color="text.secondary">
+          Rows = PyTorch PRs, columns = downstream CI jobs. Click a chip to open
+          the workflow run.
+        </Typography>
+
+        <OotMatrix repoFullName={repoFullName} days={days} />
+      </Stack>
+    </>
+  );
+}

--- a/torchci/pages/oot/index.tsx
+++ b/torchci/pages/oot/index.tsx
@@ -1,0 +1,183 @@
+import {
+  Box,
+  Chip,
+  FormControl,
+  InputLabel,
+  Link,
+  MenuItem,
+  Paper,
+  Select,
+  SelectChangeEvent,
+  Skeleton,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import { durationDisplay } from "components/common/TimeUtils";
+import { fetcher } from "lib/GeneralUtils";
+import Head from "next/head";
+import NextLink from "next/link";
+import { useState } from "react";
+import useSWR from "swr";
+
+interface OotSummaryRow {
+  repo: string;
+  downstream_repo_level: string;
+  successes: number;
+  failures: number;
+  total: number;
+  pass_rate: number;
+  avg_duration_s: number;
+  last_run: string;
+}
+
+function PassRateChip({ rate }: { rate: number }) {
+  const pct = (rate * 100).toFixed(1) + "%";
+  if (rate >= 0.95) return <Chip label={pct} color="success" size="small" />;
+  if (rate >= 0.8) return <Chip label={pct} color="warning" size="small" />;
+  return <Chip label={pct} color="error" size="small" />;
+}
+
+function OotSummaryTable({ days }: { days: number }) {
+  const url = `/api/clickhouse/oot_summary?parameters=${encodeURIComponent(
+    JSON.stringify({ days: String(days) })
+  )}`;
+  const { data, error } = useSWR<OotSummaryRow[]>(url, fetcher, {
+    refreshInterval: 60_000,
+  });
+
+  if (error) {
+    return (
+      <Typography color="error">
+        Failed to load OOT summary: {error.message}
+      </Typography>
+    );
+  }
+  if (!data) {
+    return <Skeleton variant="rectangular" height={300} />;
+  }
+  if (data.length === 0) {
+    return (
+      <Typography color="text.secondary" sx={{ py: 4, textAlign: "center" }}>
+        No OOT CI results in the last {days} days.
+      </Typography>
+    );
+  }
+
+  return (
+    <TableContainer component={Paper} elevation={2}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>
+              <strong>Backend Repository</strong>
+            </TableCell>
+            <TableCell align="center">
+              <strong>Level</strong>
+            </TableCell>
+            <TableCell align="right">
+              <strong>Pass Rate</strong>
+            </TableCell>
+            <TableCell align="right">
+              <strong>Success</strong>
+            </TableCell>
+            <TableCell align="right">
+              <strong>Failures</strong>
+            </TableCell>
+            <TableCell align="right">
+              <strong>Total</strong>
+            </TableCell>
+            <TableCell align="right">
+              <strong>Avg Duration</strong>
+            </TableCell>
+            <TableCell align="right">
+              <strong>Last Run</strong>
+            </TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {data.map((row) => {
+            const parts = row.repo?.split("/") ?? [];
+            if (parts.length !== 2) return null;
+            const [org, repo] = parts;
+            return (
+              <TableRow key={row.repo} hover>
+                <TableCell>
+                  <NextLink
+                    href={`/oot/${org}/${repo}`}
+                    passHref
+                    legacyBehavior
+                  >
+                    <Link underline="hover">{row.repo}</Link>
+                  </NextLink>
+                </TableCell>
+                <TableCell align="center">
+                  <Chip
+                    label={row.downstream_repo_level || "–"}
+                    size="small"
+                    variant="outlined"
+                  />
+                </TableCell>
+                <TableCell align="right">
+                  <PassRateChip rate={row.pass_rate} />
+                </TableCell>
+                <TableCell align="right">{row.successes}</TableCell>
+                <TableCell align="right">{row.failures}</TableCell>
+                <TableCell align="right">{row.total}</TableCell>
+                <TableCell align="right">
+                  {durationDisplay(Math.round(row.avg_duration_s))}
+                </TableCell>
+                <TableCell align="right">
+                  {new Date(row.last_run).toLocaleString()}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+export default function OotSummaryPage() {
+  const [days, setDays] = useState(7);
+
+  return (
+    <>
+      <Head>
+        <title>Out-of-Tree CI Summary | PyTorch HUD</title>
+      </Head>
+      <Stack spacing={3} sx={{ p: 3, maxWidth: 1400, mx: "auto" }}>
+        <Box display="flex" justifyContent="space-between" alignItems="center">
+          <Typography variant="h4">Out-of-Tree CI Summary</Typography>
+          <FormControl size="small" sx={{ minWidth: 140 }}>
+            <InputLabel>Time Range</InputLabel>
+            <Select
+              value={days}
+              label="Time Range"
+              onChange={(e: SelectChangeEvent<number>) =>
+                setDays(Number(e.target.value))
+              }
+            >
+              <MenuItem value={1}>Last 24h</MenuItem>
+              <MenuItem value={7}>Last 7 days</MenuItem>
+              <MenuItem value={30}>Last 30 days</MenuItem>
+            </Select>
+          </FormControl>
+        </Box>
+
+        <Typography variant="body2" color="text.secondary">
+          Cross-repo CI health overview. Repos sorted by pass rate (worst
+          first). Click a row to see the per-backend dashboard.
+        </Typography>
+
+        <OotSummaryTable days={days} />
+      </Stack>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

This is **Part 2 of 3** of the OOT HUD pipeline, split from #8069 per reviewer request.

**Depends on:** #8110 (Part 1 — queries + utils + tests)

This PR adds the frontend pages and components for the OOT HUD:

- **OOT Summary page** (`torchci/pages/oot/index.tsx`) — aggregated view of all registered OOT backends with latest status, PR count, and success rates
- **Per-backend dashboard** (`torchci/pages/oot/[org]/[repo].tsx`) — detailed job history per downstream repo with filtering
- **OotPrSection component** (`torchci/components/oot/OotPrSection.tsx`) — shows OOT CI results inline on pytorch/pytorch PR pages

All components consume the ClickHouse queries and utility library added in Part 1.

### PR Stack
1. #8110 — OOT HUD: Add ClickHouse queries, utility library, and unit tests (Part 1/3)
2. **This PR** — OOT HUD: Add frontend components — summary, dashboard, PR section (Part 2/3)
3. #8112 — OOT HUD: Add API endpoint, PR page integration, and replicator mapping (Part 3/3)

## Test Plan
- Frontend pages can be verified via Vercel preview once dummy data is populated in the `oot_workflow_job` ClickHouse table (see #8105)
- Components import from `ootUtils.ts` (Part 1) — no runtime dependencies on the API endpoint (Part 3)