### PR TITLE
ci: declare workflow-level contents: read on lint and tflint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lintrunner:
     name: lintrunner

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -8,6 +8,9 @@ on:
       - ".github/workflows/tflint.yml"
       - "terraform-aws-github-runner/**"
 
+permissions:
+  contents: read
+
 jobs:
   tflint:
     name: TFLint


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at the workflow level. The workflow runs checks only; no GitHub API writes.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) supply-chain hardening pattern. YAML validated locally with `yaml.safe_load`.