### PR TITLE
Bump astral-sh/setup-uv to v8.1.0

### DIFF
--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -39,7 +39,7 @@ runs:
   steps:
     - name: Setup uv
       id: setup-uv
-      uses: astral-sh/setup-uv@6ee6290f1cbc4156c0bdd66691b2c144ef8df19a # v7.4.0
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         version: "0.11.14"
         python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
## Summary
- Updates the pinned version of `astral-sh/setup-uv` in `.github/actions/setup-uv/action.yml` from v7.4.0 to v8.1.0.
- Picks up the fix for https://github.com/astral-sh/setup-uv/issues/882.

## Test plan
- [ ] CI green on workflows that consume the wrapper action.