### PR TITLE
HUD: respect Hide non-viable-strict in grouped view

### DIFF
--- a/torchci/components/job/GroupJobConclusion.tsx
+++ b/torchci/components/job/GroupJobConclusion.tsx
@@ -14,6 +14,7 @@ import {
   isUnstableJob,
 } from "lib/jobUtils";
 import { IssueData, JobData, RowData } from "lib/types";
+import { useHideNonViableStrictPreference } from "lib/useGroupingPreference";
 import {
   MonsterFailuresContext,
   PinnedTooltipContext,
@@ -159,10 +160,20 @@ export default function HudGroupedCell({
 }) {
   const [pinnedId, setPinnedId] = useContext(PinnedTooltipContext);
   const [monsterFailures] = useContext(MonsterFailuresContext);
+  const [hideNonViableStrict] = useHideNonViableStrictPreference();
+
+  // When hiding non-viable-strict, restrict the group's status calculation
+  // (and tooltip contents) to viable/strict-blocking jobs only — otherwise a
+  // non-viable-strict failure would still light up a kept group column.
+  const effectiveJobs = hideNonViableStrict
+    ? jobs.filter((job) =>
+        isJobViableStrictBlocking(job.name, repoOwner, repoName)
+      )
+    : jobs;
 
   // Check if this group contains autorevert signals
   const isAutorevertSignal = rowData
-    ? isGroupAutorevertSignal(jobs, rowData)
+    ? isGroupAutorevertSignal(effectiveJobs, rowData)
     : false;
 
   // Build cell style classes
@@ -183,7 +194,7 @@ export default function HudGroupedCell({
   const failedPreviousRunJobs = [];
 
   let viableStrictBlocking = false;
-  for (const job of jobs) {
+  for (const job of effectiveJobs) {
     if (isFailedJob(job)) {
       if (
         isRerunDisabledTestsJob(job) ||
@@ -219,7 +230,7 @@ export default function HudGroupedCell({
     conclusion = GroupedJobStatus.WarningOnly;
   } else if (!(queuedJobs.length === 0)) {
     conclusion = GroupedJobStatus.Queued;
-  } else if (noStatusJobs.length === jobs.length) {
+  } else if (noStatusJobs.length === effectiveJobs.length) {
     conclusion = GroupedJobStatus.AllNull;
   }
 


### PR DESCRIPTION
## Summary
- When both **Use grouped view** and **Hide non-viable-strict jobs** were enabled, non-viable-strict failures still lit up grouped columns. The page-level filter kept any group containing at least one viable/strict-blocking job, but `HudGroupedCell` aggregated status across *every* job in the group, so a non-viable-strict failure would still color the cell red.
- Fix: inside `HudGroupedCell`, when the preference is on, filter the group's jobs down to viable/strict-blocking ones before computing the conclusion, autorevert flag, and tooltip contents.

## Test plan
- [x] In HUD with both "Use grouped view" and "Hide non-viable-strict jobs" enabled, verify groups whose only failing jobs are non-viable-strict no longer show as failures.
- [x] Confirm tooltips on those grouped cells only list viable/strict-blocking jobs.
- [x] Toggling off "Hide non-viable-strict jobs" restores prior behavior (all jobs feed the group status).