### PR TITLE
[CRCR] Implement CRCR upstream check run management for L3/L4 jobs 

### DIFF
--- a/.github/actions/cross-repo-ci-relay-callback/action.yml
+++ b/.github/actions/cross-repo-ci-relay-callback/action.yml
@@ -158,8 +158,6 @@ runs:
             --write-out "%{http_code}" \
             -X POST \
             --max-time ${MAX_TIME} \
-            --retry 5 \
-            --retry-connrefused \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${OIDC_TOKEN}" \
             --data "${PAYLOAD}" \

--- a/.github/actions/cross-repo-ci-relay-callback/action.yml
+++ b/.github/actions/cross-repo-ci-relay-callback/action.yml
@@ -60,6 +60,49 @@ runs:
           core.setSecret(token);
           core.setOutput('token', token);
 
+    # Resolve this job's full display name so the relay can give it its own
+    # upstream check run. `github.job` is only the job's key in the workflow file
+    # and is identical for every leg of a matrix, so it would collapse all legs
+    # into one check run. The jobs API's `name` field carries the real display
+    # name (e.g. "build (cuda)"), which the relay can't derive on its own — a
+    # plain callback can't tell the relay which leg sent it, but the job itself
+    # can identify its own record by runner_name (a runner runs one job at a time).
+    #
+    # The jobs API is an async, read-only view: right after start our own record
+    # may briefly still show status=queued / no runner_name. That lag is transient,
+    # so we retry up to 6x/3s (~15s cap; stops on first match) and match on
+    # status != 'completed'. If it still fails it's a real error (missing
+    # `actions: read`, cancelled job, API outage), so we hard-fail. Requires
+    # `actions: read`.
+    - name: Resolve job display name
+      id: jobname
+      uses: actions/github-script@v7
+      env:
+        RUN_ATTEMPT: ${{ github.run_attempt }}
+      with:
+        script: |
+          const wanted = process.env.RUNNER_NAME;
+          const attempt = Number(process.env.RUN_ATTEMPT);
+          let me = null;
+          for (let i = 0; i < 6 && !me; i++) {
+            if (i > 0) await new Promise(r => setTimeout(r, 3000));
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRunAttempt, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.runId,
+                attempt_number: attempt,
+              });
+            me = jobs.find(
+              j => j.runner_name === wanted && j.status !== 'completed');
+          }
+          if (!me) {
+            throw new Error(
+              `could not resolve job display name (runner=${wanted}); ` +
+              `ensure the calling workflow grants 'actions: read'`);
+          }
+          core.setOutput('job_name', me.name);
+
     - name: Send callback to relay server
       shell: bash
       env:
@@ -73,7 +116,7 @@ runs:
         OIDC_TOKEN: ${{ steps.oidc.outputs.token }}
         CALLBACK_URL: ${{ inputs.callback-url }}
         ARTIFACT_URL: ${{ inputs.artifact-url }}
-        JOB_NAME: ${{ github.job }}
+        JOB_NAME: ${{ steps.jobname.outputs.job_name }}
         CHECK_RUN_ID: ${{ job.check_run_id }}
         RUN_ID: ${{ github.run_id }}
         RUN_ATTEMPT: ${{ github.run_attempt }}
@@ -147,6 +190,8 @@ runs:
             --write-out "%{http_code}" \
             -X POST \
             --max-time ${MAX_TIME} \
+            --retry 5 \
+            --retry-connrefused \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${OIDC_TOKEN}" \
             --data "${PAYLOAD}" \

--- a/.github/actions/cross-repo-ci-relay-callback/action.yml
+++ b/.github/actions/cross-repo-ci-relay-callback/action.yml
@@ -47,6 +47,17 @@ inputs:
       Maximum time in seconds to wait for the callback HTTP request to complete.
     required: false
     default: 10
+  job-name:
+    description: >
+      Identifier for this job, used to name the upstream check run
+      (crcr/<repo>/<workflow>/<job-name>). Defaults to github.job, the job's key
+      in the workflow file, which is fine for a normal single job. For a MATRIX
+      job every leg shares the same github.job, so you MUST pass a value that
+      includes the matrix values (for example a job-name of "build-cpu" /
+      "build-cuda" for a matrix over cpu/cuda) to give each leg its own check
+      run; otherwise the legs collide on the same name.
+    required: false
+    default: ${{ github.job }}
 
 runs:
   using: composite
@@ -59,49 +70,6 @@ runs:
           const token = await core.getIDToken("pytorch-cross-repo-ci-relay");
           core.setSecret(token);
           core.setOutput('token', token);
-
-    # Resolve this job's full display name so the relay can give it its own
-    # upstream check run. `github.job` is only the job's key in the workflow file
-    # and is identical for every leg of a matrix, so it would collapse all legs
-    # into one check run. The jobs API's `name` field carries the real display
-    # name (e.g. "build (cuda)"), which the relay can't derive on its own — a
-    # plain callback can't tell the relay which leg sent it, but the job itself
-    # can identify its own record by runner_name (a runner runs one job at a time).
-    #
-    # The jobs API is an async, read-only view: right after start our own record
-    # may briefly still show status=queued / no runner_name. That lag is transient,
-    # so we retry up to 6x/3s (~15s cap; stops on first match) and match on
-    # status != 'completed'. If it still fails it's a real error (missing
-    # `actions: read`, cancelled job, API outage), so we hard-fail. Requires
-    # `actions: read`.
-    - name: Resolve job display name
-      id: jobname
-      uses: actions/github-script@v7
-      env:
-        RUN_ATTEMPT: ${{ github.run_attempt }}
-      with:
-        script: |
-          const wanted = process.env.RUNNER_NAME;
-          const attempt = Number(process.env.RUN_ATTEMPT);
-          let me = null;
-          for (let i = 0; i < 6 && !me; i++) {
-            if (i > 0) await new Promise(r => setTimeout(r, 3000));
-            const jobs = await github.paginate(
-              github.rest.actions.listJobsForWorkflowRunAttempt, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: context.runId,
-                attempt_number: attempt,
-              });
-            me = jobs.find(
-              j => j.runner_name === wanted && j.status !== 'completed');
-          }
-          if (!me) {
-            throw new Error(
-              `could not resolve job display name (runner=${wanted}); ` +
-              `ensure the calling workflow grants 'actions: read'`);
-          }
-          core.setOutput('job_name', me.name);
 
     - name: Send callback to relay server
       shell: bash
@@ -116,7 +84,7 @@ runs:
         OIDC_TOKEN: ${{ steps.oidc.outputs.token }}
         CALLBACK_URL: ${{ inputs.callback-url }}
         ARTIFACT_URL: ${{ inputs.artifact-url }}
-        JOB_NAME: ${{ steps.jobname.outputs.job_name }}
+        JOB_NAME: ${{ inputs.job-name }}
         CHECK_RUN_ID: ${{ job.check_run_id }}
         RUN_ID: ${{ github.run_id }}
         RUN_ATTEMPT: ${{ github.run_attempt }}

--- a/aws/lambda/cross_repo_ci_relay/README.md
+++ b/aws/lambda/cross_repo_ci_relay/README.md
@@ -63,12 +63,12 @@ The callback endpoint validates incoming callbacks and forwards them to HUD for 
 - **Identity**: the `Authorization: Bearer <oidc-token>` header is verified against GitHub's JWKS.  The OIDC `repository` claim is a trusted identity for the caller and is used for the L2+ allowlist check. Relay forwards this trusted value to HUD as a top-level `verified_repo` field; HUD should prefer it over anything self-reported in `callback_payload`.
 - **Repo level**: Relay determines the downstream repository's allowlist level (L1–L4) and forwards it to HUD as `downstream_repo_level`. This authoritative level information is determined once by the relay, ensuring HUD doesn't need to recompute it and avoiding synchronization/timing issues if tiering information becomes dynamic.
 - **Schema validation**: Relay validates that required fields (`delivery_id` and `workflow.status`) are present in the callback body.  Missing fields result in a `400` error to signal contract violations to the caller.  HUD receives validated data and does not need to perform schema checks.
-- **State machine**: Relay maintains a **unified state machine** in Redis to validate callback lifecycles, compute timing metrics, and support per-workflow tracking:
-  - **Unified structure**: Single enum `CallbackState` with states `DISPATCHED` (webhook side, keyed by sentinel `run_id=0, run_attempt=0`), `IN_PROGRESS`, and `COMPLETED` (callback side, per-workflow). State records stored as JSON: `{"state": "...", "timestamp": 1234.56}`.
+- **State machine**: Relay maintains a **unified state machine** in Redis to validate callback lifecycles, compute timing metrics, and support per-job tracking:
+  - **Unified structure**: Single enum `CallbackState` with states `DISPATCHED` (webhook side, keyed by sentinel `run_id=0, run_attempt=0`), `IN_PROGRESS`, and `COMPLETED` (callback side, per-job). State records stored as JSON: `{"state": "...", "timestamp": 1234.56}`.
   - **Dispatch validation**: `DISPATCHED` state proves valid webhook origin. Callbacks without this state are rejected (no prior dispatch).
-  - **Workflow-level tracking**: Each workflow has independent state and timestamps keyed by `{run_id}:{run_attempt}` (`crcr:state:{delivery_id}:{repo}:{run_id}:{run_attempt}`). Supports multiple workflows per webhook.
+  - **Job-level tracking**: Each job has independent state and timestamps keyed by `{run_id}:{run_attempt}:{job_name}` (`crcr:state:{delivery_id}:{repo}:{run_id}:{run_attempt}:{job_name}`). Supports multiple jobs (and workflows) per webhook; the `job_name` suffix keeps concurrent jobs of one run from colliding.
   - **Timing metrics**: `queue_time = dispatch_timestamp → in_progress_timestamp`, `execution_time = in_progress_timestamp → completed_timestamp`. Timestamps extracted from state records.
-  - **State transitions**: Rejects invalid flows (`COMPLETED` without prior `IN_PROGRESS`, duplicate `IN_PROGRESS` for the same `{run_id}:{run_attempt}`, duplicate `COMPLETED`, callbacks without a prior `DISPATCHED` record).
+  - **State transitions**: Rejects invalid flows (`COMPLETED` without prior `IN_PROGRESS`, duplicate `IN_PROGRESS` for the same `{run_id}:{run_attempt}:{job_name}`, duplicate `COMPLETED`, callbacks without a prior `DISPATCHED` record).
     Note that the direction graph below is for a single check run, reruns have different `run_attempt` and are treated as separate workflows, so they won't violate the state machine since they won't have a prior `IN_PROGRESS` or `COMPLETED` record.
     ```mermaid
     stateDiagram-v2
@@ -108,7 +108,7 @@ The HUD request looks like (two top-level namespaces: `trusted` and `untrusted`)
         "url": "https://github.com/org/repo/actions/runs/123",
         "run_id": "123",        // stable across re-runs of the same run
         "run_attempt": "2",     // increments each re-run; (run_id, run_attempt) distinguishes attempts
-        "job_name": "my-ci-job",
+        "job_name": "ci (cuda)",  // job's full display name from the jobs API; distinct per matrix leg
         "check_run_id": "456",  // unique per attempt
         "started_at": "2026-05-04T20:48:28Z", // when status == in_progress, else None
         "completed_at": "2026-05-04T21:23:45Z", // when status == completed, else None
@@ -155,6 +155,8 @@ All three attacks are **scoped to the attacker's own OIDC-authenticated repo ide
 
 - The downstream repository must be listed at level **L2 or higher** in the allowlist.
 - The **calling job** must declare `permissions: id-token: write` so that the action can mint a GitHub OIDC token for authentication.
+- The calling job must also grant `permissions: actions: read`. The action looks up its own job via the jobs API to read its full display name (used to name the upstream check run); `github.job` alone is just the workflow-file key and is identical for every leg of a matrix. If the lookup fails (e.g. the permission is missing) the action **hard-fails** rather than reporting a colliding name.
+- Each downstream **job** that should surface as its own upstream check run must invoke the action itself (one `in_progress`, one `completed`), so multi-job / matrix workflows report per job with no extra configuration.
 
 ### Usage
 
@@ -170,6 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write   # required for OIDC token minting
+      actions: read     # required to read this job's display name from the jobs API
       contents: read
     steps:
       - name: Report in-progress to relay
@@ -203,29 +206,29 @@ For L3 and L4 repositories the relay creates a **check run on the upstream PR** 
 
 ### How it works
 
-The check run is named `crcr/<downstream_repo>/<workflow_name>` and is created from the **callback**, not at dispatch time:
+Check runs are **per job**, named `crcr/<downstream_repo>/<workflow_name>/<job_name>`, and created from the **callback**, not at dispatch time. `job_name` is the job's **full display name**, which the action reads from the jobs API (not `github.job`, which is identical across matrix legs) — so a matrix leg like `ci (cuda)` gets its own check run automatically, no configuration needed. Each downstream job reports its own callbacks (one `in_progress`, one `completed`), so a multi-job or matrix workflow surfaces one check run per job on the upstream PR instead of a single collapsed one:
 
 - On an `in_progress` callback the relay creates an in-progress check run linking to the downstream run.
 - On a `completed` callback it creates a completed check run carrying the downstream `conclusion`.
 
-The relay always **creates** a new check run rather than editing an existing one. GitHub only surfaces the latest check run of a given name on a commit, so each new one naturally supersedes the previous. This keeps the logic stateless and makes reruns and reopens self-correcting.
+The relay always **creates** a new check run rather than editing an existing one. GitHub only surfaces the latest check run of a given name on a commit, so each new one naturally supersedes the previous. Scoping the name by `job_name` keeps distinct jobs from overwriting each other while an in_progress → completed pair for the *same* job still self-supersedes. This keeps the logic stateless and makes reruns and reopens self-correcting.
 
 ### L3 label timing
 
 For L3 the upstream check run is gated on the `ciflow/crcr/<device>` label, which a maintainer can add at any point relative to the workflow. The relay covers all three orderings:
 
 1. **Label present before dispatch** — the callback sees the label and creates the check run directly.
-2. **Label added while the workflow is running** — the `pull_request.labeled` handler reads the cached downstream job state (`crcr:dispatch_workflow:<head_sha>:<repo>`) and backfills an in-progress check run.
-3. **Label added after the workflow finished** — the `labeled` handler creates a completed check run directly from that cached state.
+2. **Label added while the workflow is running** — the `pull_request.labeled` handler reads the cached downstream job state (`crcr:dispatch_job:<head_sha>:<repo>`, a Redis hash whose fields are `<workflow_name>:<job_name>`) and backfills an in-progress check run for **every** job that has already reported.
+3. **Label added after the workflow finished** — the `labeled` handler creates a completed check run for each cached job directly from that state.
 
 Because the downstream echoes back the *dispatch-time* payload — whose labels can be stale, e.g. on **reopen** where no fresh `labeled` event fires — the relay records a per-commit "check run wanted" flag (`crcr:check_run_wanted:<head_sha>:<repo>`) at dispatch time (when the label is already present) and in the `labeled` handler. The callback consults this flag so it still creates the check run when the echoed labels don't reflect the PR's current state.
 
 ### Re-running checks
 
-A developer can re-run downstream CI directly from the upstream PR's checks UI. The GitHub App subscribes to the `check_run` and `check_suite` events, and the relay handles their `rerequested` action:
+A developer can re-run downstream CI directly from the upstream PR's checks UI. Re-runs happen at the **workflow-run** level via `rerun-failed-jobs`: the downstream `run_id` is stored as each check run's `external_id`, and GitHub rejects re-running individual jobs of a run that is already running, so one run-level call re-runs all failed jobs together without conflict. The GitHub App subscribes to the `check_run` and `check_suite` events, and the relay handles their `rerequested` action:
 
-- **Re-run a single check** (`check_run` `rerequested`) — the downstream `run_id` was stored as the check run's `external_id` when it was created, and the downstream repo is encoded in the check run name (`crcr/<owner>/<repo>/<workflow_name>`). The relay parses both, verifies the repo is L3+, and re-triggers that downstream workflow run.
-- **Re-run all checks** (`check_suite` `rerequested`) — the suite covers every check on the commit, so the relay re-triggers each L3+ downstream whose latest run it cached at `crcr:dispatch_workflow:<head_sha>:<repo>`.
+- **Re-run a single check** (`check_run` `rerequested`) — the downstream repo is parsed from the check run name (`crcr/<owner>/<repo>/<workflow_name>/<job_name>`) and the `run_id` from its `external_id`. The relay verifies the repo is L3+ and re-runs the failed jobs of that run (`POST /repos/<repo>/actions/runs/<run_id>/rerun-failed-jobs`). A 403 "run already running" is treated as a benign no-op.
+- **Re-run all checks** (`check_suite` `rerequested`) — the CRCR app owns a single check suite per commit, so the relay lists every check run in that suite, dedupes them by `(repo, run_id)`, and re-runs the failed jobs of each distinct L3+ run. Check runs with no `external_id` are skipped.
 
 Because the re-run carries the **original `delivery_id`** but a **new `check_run_id`** (GitHub mints fresh check runs per attempt), the two CI timing metrics behave differently:
 

--- a/aws/lambda/cross_repo_ci_relay/README.md
+++ b/aws/lambda/cross_repo_ci_relay/README.md
@@ -20,7 +20,10 @@ L1:
 L2:
   - org3/repo3
 L3:
-  - org4/repo4
+  device1:
+    org41/device1-repo: [oncall1, oncall2]
+  device2:
+    org42/device2-repo: [oncall3]
 L4:
   - org5/repo5: oncall1, oncall2
 ```
@@ -30,6 +33,22 @@ All levels (L1–L4) are dispatched to. Dispatch targets are the union of all re
 Each entry is either a plain `owner/repo` string or a `owner/repo: oncall1, oncall2` mapping. Duplicate repositories across levels are not allowed.
 
 The allowlist is cached in Redis under the key `crcr:allowlist_yaml` with a TTL controlled by `ALLOWLIST_TTL_SECONDS`. On a Redis error the function falls back to fetching directly from GitHub.
+
+### Repository levels
+
+Every level is dispatched to. Higher levels add capabilities on top, and each level includes everything the lower ones grant:
+
+| Level | Dispatch | Report results to HUD | Upstream check run on the PR |
+|---|---|---|---|
+| **L1** | ✅ | — | — |
+| **L2** | ✅ | ✅ | — |
+| **L3** | ✅ | ✅ | ✅ — only when the PR carries the matching `ciflow/crcr/<device>` label |
+| **L4** | ✅ | ✅ | ✅ — always |
+
+- **L3** entries are grouped by *device*. A repo registered under `device1` gets an upstream check run only when the PR has the `ciflow/crcr/device1` label, letting maintainers opt specific PRs into a backend's CI. The `[oncall, ...]` list is the oncalls associated with that repo.
+- **L4** repos always get an upstream check run, with no label required.
+
+The dispatch/HUD-reporting path (L1/L2) is covered below; the upstream check run path (L3/L4) is covered in [Upstream Check Runs](#upstream-check-runs-l3-and-l4).
 
 ## Reporting Results from Downstream CI
 
@@ -174,6 +193,29 @@ jobs:
 | `test-results` | no | `''` | Optional JSON string with test result summary (counts: passed/failed/skipped) |
 | `callback-url` | **yes** | — | Callback endpoint URL (production Lambda URL; set once at the workflow level) |
 | `artifact-url` | no | `''` | URL to downstream-hosted artifacts (logs, reports, results) |
+
+## Upstream Check Runs (L3 and L4)
+
+For L3 and L4 repositories the relay creates a **check run on the upstream PR** that mirrors the downstream workflow's status, so the upstream sees downstream CI as a normal PR check. This is built on top of the same callback used for HUD reporting (L2+), so an L3/L4 repo still reports results to HUD exactly as described above.
+
+### How it works
+
+The check run is named `crcr/<downstream_repo>/<workflow_name>` and is created from the **callback**, not at dispatch time:
+
+- On an `in_progress` callback the relay creates an in-progress check run linking to the downstream run.
+- On a `completed` callback it creates a completed check run carrying the downstream `conclusion`.
+
+The relay always **creates** a new check run rather than editing an existing one. GitHub only surfaces the latest check run of a given name on a commit, so each new one naturally supersedes the previous. This keeps the logic stateless and makes reruns and reopens self-correcting.
+
+### L3 label timing
+
+For L3 the upstream check run is gated on the `ciflow/crcr/<device>` label, which a maintainer can add at any point relative to the workflow. The relay covers all three orderings:
+
+1. **Label present before dispatch** — the callback sees the label and creates the check run directly.
+2. **Label added while the workflow is running** — the `pull_request.labeled` handler reads the cached downstream job state (`crcr:dispatch_workflow:<head_sha>:<repo>`) and backfills an in-progress check run.
+3. **Label added after the workflow finished** — the `labeled` handler creates a completed check run directly from that cached state.
+
+Because the downstream echoes back the *dispatch-time* payload — whose labels can be stale, e.g. on **reopen** where no fresh `labeled` event fires — the relay records a per-commit "check run wanted" flag (`crcr:check_run_wanted:<head_sha>:<repo>`) at dispatch time (when the label is already present) and in the `labeled` handler. The callback consults this flag so it still creates the check run when the echoed labels don't reflect the PR's current state.
 
 ## Build, Deploy, and Test
 

--- a/aws/lambda/cross_repo_ci_relay/README.md
+++ b/aws/lambda/cross_repo_ci_relay/README.md
@@ -108,7 +108,7 @@ The HUD request looks like (two top-level namespaces: `trusted` and `untrusted`)
         "url": "https://github.com/org/repo/actions/runs/123",
         "run_id": "123",        // stable across re-runs of the same run
         "run_attempt": "2",     // increments each re-run; (run_id, run_attempt) distinguishes attempts
-        "job_name": "ci (cuda)",  // job's full display name from the jobs API; distinct per matrix leg
+        "job_name": "build-cuda",  // from the action's job-name input (defaults to github.job)
         "check_run_id": "456",  // unique per attempt
         "started_at": "2026-05-04T20:48:28Z", // when status == in_progress, else None
         "completed_at": "2026-05-04T21:23:45Z", // when status == completed, else None
@@ -155,7 +155,7 @@ All three attacks are **scoped to the attacker's own OIDC-authenticated repo ide
 
 - The downstream repository must be listed at level **L2 or higher** in the allowlist.
 - The **calling job** must declare `permissions: id-token: write` so that the action can mint a GitHub OIDC token for authentication.
-- The calling job must also grant `permissions: actions: read`. The action looks up its own job via the jobs API to read its full display name (used to name the upstream check run); `github.job` alone is just the workflow-file key and is identical for every leg of a matrix. If the lookup fails (e.g. the permission is missing) the action **hard-fails** rather than reporting a colliding name.
+- The upstream check run is named after the calling job. By default it uses `github.job` (the job's workflow-file key), which is fine for a normal single job. A **matrix** job shares one `github.job` across all legs, so pass the `job-name` input with the matrix values (e.g. `job-name: build-${{ matrix.config }}`) to give each leg its own check run; otherwise the legs collide on the same name.
 - Each downstream **job** that should surface as its own upstream check run must invoke the action itself (one `in_progress`, one `completed`), so multi-job / matrix workflows report per job with no extra configuration.
 
 ### Usage
@@ -172,7 +172,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write   # required for OIDC token minting
-      actions: read     # required to read this job's display name from the jobs API
       contents: read
     steps:
       - name: Report in-progress to relay
@@ -206,7 +205,7 @@ For L3 and L4 repositories the relay creates a **check run on the upstream PR** 
 
 ### How it works
 
-Check runs are **per job**, named `crcr/<downstream_repo>/<workflow_name>/<job_name>`, and created from the **callback**, not at dispatch time. `job_name` is the job's **full display name**, which the action reads from the jobs API (not `github.job`, which is identical across matrix legs) — so a matrix leg like `ci (cuda)` gets its own check run automatically, no configuration needed. Each downstream job reports its own callbacks (one `in_progress`, one `completed`), so a multi-job or matrix workflow surfaces one check run per job on the upstream PR instead of a single collapsed one:
+Check runs are **per job**, named `crcr/<downstream_repo>/<workflow_name>/<job_name>`, and created from the **callback**, not at dispatch time. `job_name` comes from the action's `job-name` input, which defaults to `github.job`. Because every leg of a matrix shares one `github.job`, a matrix workflow must pass a distinct `job-name` per leg (e.g. `build-${{ matrix.config }}`) so the legs get separate check runs instead of colliding. Each downstream job reports its own callbacks (one `in_progress`, one `completed`), so a multi-job or matrix workflow surfaces one check run per job on the upstream PR instead of a single collapsed one:
 
 - On an `in_progress` callback the relay creates an in-progress check run linking to the downstream run.
 - On a `completed` callback it creates a completed check run carrying the downstream `conclusion`.

--- a/aws/lambda/cross_repo_ci_relay/README.md
+++ b/aws/lambda/cross_repo_ci_relay/README.md
@@ -106,7 +106,10 @@ The HUD request looks like (two top-level namespaces: `trusted` and `untrusted`)
         "conclusion": "success",
         "name": "CI",
         "url": "https://github.com/org/repo/actions/runs/123",
+        "run_id": "123",        // stable across re-runs of the same run
+        "run_attempt": "2",     // increments each re-run; (run_id, run_attempt) distinguishes attempts
         "job_name": "my-ci-job",
+        "check_run_id": "456",  // unique per attempt
         "started_at": "2026-05-04T20:48:28Z", // when status == in_progress, else None
         "completed_at": "2026-05-04T21:23:45Z", // when status == completed, else None
         "test_results": { "passed": 42, "failed": 3, "skipped": 5 },
@@ -216,6 +219,18 @@ For L3 the upstream check run is gated on the `ciflow/crcr/<device>` label, whic
 3. **Label added after the workflow finished** — the `labeled` handler creates a completed check run directly from that cached state.
 
 Because the downstream echoes back the *dispatch-time* payload — whose labels can be stale, e.g. on **reopen** where no fresh `labeled` event fires — the relay records a per-commit "check run wanted" flag (`crcr:check_run_wanted:<head_sha>:<repo>`) at dispatch time (when the label is already present) and in the `labeled` handler. The callback consults this flag so it still creates the check run when the echoed labels don't reflect the PR's current state.
+
+### Re-running checks
+
+A developer can re-run downstream CI directly from the upstream PR's checks UI. The GitHub App subscribes to the `check_run` and `check_suite` events, and the relay handles their `rerequested` action:
+
+- **Re-run a single check** (`check_run` `rerequested`) — the downstream `run_id` was stored as the check run's `external_id` when it was created, and the downstream repo is encoded in the check run name (`crcr/<owner>/<repo>/<workflow_name>`). The relay parses both, verifies the repo is L3+, and re-triggers that downstream workflow run.
+- **Re-run all checks** (`check_suite` `rerequested`) — the suite covers every check on the commit, so the relay re-triggers each L3+ downstream whose latest run it cached at `crcr:dispatch_workflow:<head_sha>:<repo>`.
+
+Because the re-run carries the **original `delivery_id`** but a **new `check_run_id`** (GitHub mints fresh check runs per attempt), the two CI timing metrics behave differently:
+
+- **`execution_time`** (in_progress → completed) is correct as-is — the new `check_run_id` gets its own fresh state records.
+- **`queue_time`** (dispatch → in_progress) would otherwise be measured against the *original* dispatch timestamp (possibly days old). Thus, using `run_attempt` keyword in payload to identify whether it is a trustworthy value.
 
 ## Build, Deploy, and Test
 

--- a/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
@@ -5,6 +5,7 @@ import time
 
 import utils.redis_helper as redis_helper
 from redis.exceptions import RedisError
+from utils import gh_helper
 from utils.allowlist import AllowlistLevel, AllowlistMap, load_allowlist
 from utils.config import RelayConfig
 from utils.hud import forward_to_hud
@@ -13,6 +14,7 @@ from utils.misc import (
     CallbackStateRecord,
     DISPATCH_RUN_ATTEMPT,
     DISPATCH_RUN_ID,
+    extract_pr_labels,
     HTTPException,
 )
 from utils.redis_helper import check_rate_limit
@@ -168,6 +170,93 @@ def _update_state_and_compute_metrics(
     return ci_metrics
 
 
+def _update_upstream_check_run(
+    *,
+    config: RelayConfig,
+    verified_repo: str,
+    delivery_id: str,
+    status: str,
+    run_id: str,
+    body: dict,
+    needs_check_run: bool = True,
+) -> None:
+    """Cache the downstream job state and update the upstream check run.
+
+    Called for L3+ repos before HUD forwarding so that a HUD error cannot
+    prevent the upstream PR check from reflecting the correct workflow status.
+
+    On the first in_progress callback the upstream check run is created with
+    the real workflow name and link.  Subsequent callbacks update the existing
+    check run.  If head_sha is absent the check run cannot be created.
+    """
+    payload_field = body.get("payload") or {}
+    pr_field = payload_field.get("pull_request") or {}
+    head_sha = (pr_field.get("head") or {}).get("sha", "")
+
+    workflow = body.get("workflow") or {}
+    conclusion = workflow.get("conclusion")
+    workflow_name = workflow.get("name", "")
+
+    details_url = f"https://github.com/{verified_repo}/actions/runs/{run_id}"
+
+    redis_helper.set_dispatch_workflow(
+        config,
+        head_sha,
+        verified_repo,
+        status,
+        conclusion,
+        details_url,
+        run_id=run_id,
+        workflow_name=workflow_name,
+    )
+
+    if not needs_check_run:
+        return
+
+    if not head_sha:
+        logger.warning(
+            "no head_sha; cannot create upstream check run delivery_id=%s repo=%s",
+            delivery_id,
+            verified_repo,
+        )
+        return
+
+    output = gh_helper.build_check_run_output(workflow_name, details_url, verified_repo)
+
+    try:
+        upstream_token = gh_helper.get_repo_access_token(
+            config.github_app_id,
+            config.github_app_private_key,
+            config.upstream_repo,
+        )
+        # Always create a new check run. GitHub shows only the latest check run
+        # with the same name on a commit, so this naturally replaces any previous one
+        cr_id = gh_helper.create_check_run(
+            token=upstream_token,
+            repo_full_name=config.upstream_repo,
+            name=gh_helper.check_run_name(verified_repo, workflow_name),
+            head_sha=head_sha,
+            status=status,
+            conclusion=conclusion,
+            details_url=details_url,
+            external_id=run_id,
+            output=output,
+        )
+        logger.info(
+            "upstream check run created delivery_id=%s repo=%s status=%s cr_id=%s",
+            delivery_id,
+            verified_repo,
+            status,
+            cr_id,
+        )
+    except Exception:
+        logger.exception(
+            "failed to manage upstream check run delivery_id=%s repo=%s",
+            delivery_id,
+            verified_repo,
+        )
+
+
 def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
     """Forward a downstream callback to HUD.
 
@@ -188,7 +277,7 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
     result = _verify_access(config, verified_repo)
     if result is None:
         return {"ok": True, "status": "ignored"}
-    _, repo_level = result
+    allowlist, repo_level = result
 
     delivery_id, status, run_id, run_attempt, workflow_name, job_name = (
         _parse_callback_body(body)
@@ -208,6 +297,29 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
     workflow_record = redis_helper.get_callback_state(
         config, delivery_id, verified_repo, run_id, run_attempt, job_name=job_name
     )
+
+    # L3+: update the upstream check run first so a HUD error cannot block it.
+    if repo_level.value >= AllowlistLevel.L3.value:
+        needs_cr = allowlist.needs_check_run(verified_repo, extract_pr_labels(body))
+        if not needs_cr and repo_level == AllowlistLevel.L3:
+            # The downstream's echoed payload labels may not reflect the PR's
+            # current state (e.g. on reopen). Fall back to the per-commit flag
+            # recorded at dispatch / label time for this (head_sha, repo).
+            pr_field = (body.get("payload") or {}).get("pull_request") or {}
+            head_sha = (pr_field.get("head") or {}).get("sha", "")
+            if head_sha:
+                needs_cr = redis_helper.is_check_run_wanted(
+                    config, head_sha, verified_repo
+                )
+        _update_upstream_check_run(
+            config=config,
+            verified_repo=verified_repo,
+            delivery_id=delivery_id,
+            status=status,
+            run_id=run_id,
+            body=body,
+            needs_check_run=needs_cr,
+        )
 
     payload = None
     if status == "in_progress":

--- a/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
@@ -109,6 +109,10 @@ def _update_state_and_compute_metrics(
 
     Both metrics default to None when the required prior state is unavailable
     (e.g. Redis cache miss or rerun without matching prior record).
+
+    For a re-run, ``queue_time`` is measured against the original dispatch (the
+    re-run reuses its delivery_id), so it is not a meaningful queue interval —
+    HUD distinguishes re-runs via ``workflow.run_attempt`` in the forwarded body.
     """
     if status not in ("in_progress", "completed"):
         raise HTTPException(400, f"unknown callback status: {status!r}")

--- a/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
@@ -174,71 +174,38 @@ def _update_state_and_compute_metrics(
     return ci_metrics
 
 
-def _update_upstream_check_run(
+def _create_upstream_check_run(
     *,
     config: RelayConfig,
     verified_repo: str,
     delivery_id: str,
     status: str,
-    run_id: str,
-    body: dict,
-    needs_check_run: bool = True,
+    conclusion: str | None,
+    run_id: int,
+    head_sha: str,
+    workflow_name: str,
+    job_name: str | None,
+    details_url: str,
 ) -> None:
-    """Cache the downstream job state and update the upstream check run.
+    """Create a new upstream check run mirroring the downstream job's status.
 
-    Called for L3+ repos before HUD forwarding so that a HUD error cannot
-    prevent the upstream PR check from reflecting the correct workflow status.
+    Called for L3+ repos (only when a check run is wanted and head_sha is known)
+    before HUD forwarding, so a HUD error cannot block the upstream PR check.
 
-    On the first in_progress callback the upstream check run is created with
-    the real workflow name and link.  Subsequent callbacks update the existing
-    check run.  If head_sha is absent the check run cannot be created.
+    Every callback always *creates* a new check run (never edits an existing
+    one): GitHub only surfaces the latest check run of a given name on a commit,
+    so each new one supersedes the previous, keeping the logic stateless.
+    Best-effort: a GitHub failure must not fail the callback.
     """
-    payload_field = body.get("payload") or {}
-    pr_field = payload_field.get("pull_request") or {}
-    head_sha = (pr_field.get("head") or {}).get("sha", "")
-
-    workflow = body.get("workflow") or {}
-    conclusion = workflow.get("conclusion")
-    workflow_name = workflow.get("name", "")
-    job_name = workflow.get("job_name")
-
-    details_url = f"https://github.com/{verified_repo}/actions/runs/{run_id}"
-
-    redis_helper.set_dispatch_job(
-        config,
-        head_sha,
-        verified_repo,
-        status,
-        conclusion,
-        details_url,
-        run_id=run_id,
-        workflow_name=workflow_name,
-        job_name=job_name,
-    )
-
-    if not needs_check_run:
-        return
-
-    if not head_sha:
-        logger.warning(
-            "no head_sha; cannot create upstream check run delivery_id=%s repo=%s",
-            delivery_id,
-            verified_repo,
-        )
-        return
-
     output = gh_helper.build_check_run_output(
         status, conclusion, details_url, verified_repo
     )
-
     try:
         upstream_token = gh_helper.get_repo_access_token(
             config.github_app_id,
             config.github_app_private_key,
             config.upstream_repo,
         )
-        # Always create a new check run. GitHub shows only the latest check run
-        # with the same name on a commit, so this naturally replaces any previous one
         cr_id = gh_helper.create_check_run(
             token=upstream_token,
             repo_full_name=config.upstream_repo,
@@ -261,7 +228,7 @@ def _update_upstream_check_run(
         )
     except Exception:
         logger.exception(
-            "failed to manage upstream check run delivery_id=%s repo=%s",
+            "failed to create upstream check run delivery_id=%s repo=%s",
             delivery_id,
             verified_repo,
         )
@@ -308,29 +275,6 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
         config, delivery_id, verified_repo, run_id, run_attempt, job_name=job_name
     )
 
-    # L3+: update the upstream check run first so a HUD error cannot block it.
-    if repo_level.value >= AllowlistLevel.L3.value:
-        needs_cr = allowlist.needs_check_run(verified_repo, extract_pr_labels(body))
-        if not needs_cr and repo_level == AllowlistLevel.L3:
-            # The downstream's echoed payload labels may not reflect the PR's
-            # current state (e.g. on reopen). Fall back to the per-commit flag
-            # recorded at dispatch / label time for this (head_sha, repo).
-            pr_field = (body.get("payload") or {}).get("pull_request") or {}
-            head_sha = (pr_field.get("head") or {}).get("sha", "")
-            if head_sha:
-                needs_cr = redis_helper.is_check_run_wanted(
-                    config, head_sha, verified_repo
-                )
-        _update_upstream_check_run(
-            config=config,
-            verified_repo=verified_repo,
-            delivery_id=delivery_id,
-            status=status,
-            run_id=run_id,
-            body=body,
-            needs_check_run=needs_cr,
-        )
-
     payload = None
     if status == "in_progress":
         payload = {
@@ -358,6 +302,54 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
         payload=payload,
         job_name=job_name,
     )
+
+    # L3+: cache the job and create its upstream check run. Runs after state
+    # validation (above) but before HUD forwarding, so a HUD error cannot block
+    # the PR check. Without a head_sha there is neither a check run to create nor
+    # a cache entry the label handler could ever look up.
+    if repo_level.value >= AllowlistLevel.L3.value:
+        pr_field = (body.get("payload") or {}).get("pull_request") or {}
+        head_sha = (pr_field.get("head") or {}).get("sha", "")
+        if head_sha:
+            conclusion = (body.get("workflow") or {}).get("conclusion")
+            details_url = f"https://github.com/{verified_repo}/actions/runs/{run_id}"
+
+            # Always cache the job so a later label event can backfill its check
+            # run, even when we are not creating one now.
+            redis_helper.set_dispatch_job(
+                config,
+                head_sha,
+                verified_repo,
+                status,
+                conclusion,
+                details_url,
+                run_id=str(run_id),
+                workflow_name=workflow_name,
+                job_name=job_name,
+            )
+
+            needs_cr = allowlist.needs_check_run(verified_repo, extract_pr_labels(body))
+            if not needs_cr and repo_level == AllowlistLevel.L3:
+                # The downstream's echoed payload labels may not reflect the PR's
+                # current state (e.g. on reopen). Fall back to the per-commit flag
+                # recorded at dispatch / label time for this (head_sha, repo).
+                needs_cr = redis_helper.is_check_run_wanted(
+                    config, head_sha, verified_repo
+                )
+
+            if needs_cr:
+                _create_upstream_check_run(
+                    config=config,
+                    verified_repo=verified_repo,
+                    delivery_id=delivery_id,
+                    status=status,
+                    conclusion=conclusion,
+                    run_id=run_id,
+                    head_sha=head_sha,
+                    workflow_name=workflow_name,
+                    job_name=job_name,
+                    details_url=details_url,
+                )
 
     if status == "in_progress":
         redis_helper.add_in_progress_tracker(

--- a/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
@@ -245,7 +245,9 @@ def _update_upstream_check_run(
             status=status,
             conclusion=conclusion,
             details_url=details_url,
-            external_id=run_id,
+            external_id=str(
+                run_id
+            ),  # run_id is an int; check run external_id must be str
             output=output,
         )
         logger.info(

--- a/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
@@ -200,10 +200,11 @@ def _update_upstream_check_run(
     workflow = body.get("workflow") or {}
     conclusion = workflow.get("conclusion")
     workflow_name = workflow.get("name", "")
+    job_name = workflow.get("job_name")
 
     details_url = f"https://github.com/{verified_repo}/actions/runs/{run_id}"
 
-    redis_helper.set_dispatch_workflow(
+    redis_helper.set_dispatch_job(
         config,
         head_sha,
         verified_repo,
@@ -212,6 +213,7 @@ def _update_upstream_check_run(
         details_url,
         run_id=run_id,
         workflow_name=workflow_name,
+        job_name=job_name,
     )
 
     if not needs_check_run:
@@ -240,14 +242,14 @@ def _update_upstream_check_run(
         cr_id = gh_helper.create_check_run(
             token=upstream_token,
             repo_full_name=config.upstream_repo,
-            name=gh_helper.check_run_name(verified_repo, workflow_name),
+            name=gh_helper.check_run_name(verified_repo, workflow_name, job_name),
             head_sha=head_sha,
             status=status,
             conclusion=conclusion,
             details_url=details_url,
-            external_id=str(
-                run_id
-            ),  # run_id is an int; check run external_id must be str
+            # Store the downstream run_id so a check-run rerequest can re-run
+            # the failed jobs of that workflow run.
+            external_id=str(run_id),
             output=output,
         )
         logger.info(

--- a/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
@@ -225,7 +225,9 @@ def _update_upstream_check_run(
         )
         return
 
-    output = gh_helper.build_check_run_output(workflow_name, details_url, verified_repo)
+    output = gh_helper.build_check_run_output(
+        status, conclusion, details_url, verified_repo
+    )
 
     try:
         upstream_token = gh_helper.get_repo_access_token(

--- a/aws/lambda/cross_repo_ci_relay/callback/cleanup_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/cleanup_handler.py
@@ -14,7 +14,7 @@ from concurrent.futures import as_completed, ThreadPoolExecutor
 import utils.redis_helper as redis_helper
 from redis.exceptions import RedisError
 from utils import gh_helper
-from utils.allowlist import AllowlistLevel, load_allowlist
+from utils.allowlist import AllowlistLevel, AllowlistMap, load_allowlist
 from utils.config import RelayConfig
 from utils.hud import forward_to_hud
 from utils.misc import CallbackState, extract_pr_labels
@@ -54,7 +54,9 @@ def _build_timeout_payload(zombie: dict, completed_at: str) -> tuple[dict, dict]
     return stored_trusted, stored_untrusted
 
 
-def _finalize_timed_out_check_run(config: RelayConfig, zombie: dict) -> None:
+def _finalize_timed_out_check_run(
+    config: RelayConfig, allowlist: AllowlistMap, zombie: dict
+) -> None:
     """Create a completed/timed_out upstream check run for an L3+ zombie.
 
     A zombie's downstream stopped reporting, so its upstream check run is left
@@ -75,7 +77,6 @@ def _finalize_timed_out_check_run(config: RelayConfig, zombie: dict) -> None:
     if trusted.get("downstream_repo_level", "") < AllowlistLevel.L3.value:
         return
 
-    allowlist = load_allowlist(config)
     level = allowlist.get_repo_level(verified_repo)
     if level is None or level.value < AllowlistLevel.L3.value:
         return
@@ -136,6 +137,7 @@ def _finalize_timed_out_check_run(config: RelayConfig, zombie: dict) -> None:
 def _cleanup_one(
     *,
     config: RelayConfig,
+    allowlist: AllowlistMap,
     zombie: dict,
     completed_at: str,
 ) -> dict:
@@ -145,7 +147,7 @@ def _cleanup_one(
     Returns a dict with ``ok`` indicating whether the zombie was cleaned
     successfully (HUD forward succeeded).
     """
-    _finalize_timed_out_check_run(config, zombie)
+    _finalize_timed_out_check_run(config, allowlist, zombie)
 
     delivery_id = zombie["delivery_id"]
     repo = zombie["downstream_repo"]
@@ -218,11 +220,14 @@ def handle(config: RelayConfig) -> dict:
     logger.info("zombie scan: found %d expired job(s)", len(zombies))
     completed_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
+    allowlist = load_allowlist(config)
+
     with ThreadPoolExecutor(max_workers=config.max_cleanup_workers) as pool:
         future_to_zombie = {
             pool.submit(
                 _cleanup_one,
                 config=config,
+                allowlist=allowlist,
                 zombie=zombie,
                 completed_at=completed_at,
             ): zombie

--- a/aws/lambda/cross_repo_ci_relay/callback/cleanup_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/cleanup_handler.py
@@ -95,6 +95,7 @@ def _finalize_timed_out_check_run(config: RelayConfig, zombie: dict) -> None:
 
     workflow = body.get("workflow") or {}
     workflow_name = workflow.get("name", "")
+    job_name = workflow.get("job_name")
     run_id = str(workflow.get("run_id"))
     details_url = f"https://github.com/{verified_repo}/actions/runs/{run_id}"
     output = gh_helper.build_check_run_output(
@@ -110,7 +111,7 @@ def _finalize_timed_out_check_run(config: RelayConfig, zombie: dict) -> None:
         cr_id = gh_helper.create_check_run(
             token=upstream_token,
             repo_full_name=config.upstream_repo,
-            name=gh_helper.check_run_name(verified_repo, workflow_name),
+            name=gh_helper.check_run_name(verified_repo, workflow_name, job_name),
             head_sha=head_sha,
             status="completed",
             conclusion="timed_out",

--- a/aws/lambda/cross_repo_ci_relay/callback/cleanup_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/cleanup_handler.py
@@ -13,9 +13,11 @@ from concurrent.futures import as_completed, ThreadPoolExecutor
 
 import utils.redis_helper as redis_helper
 from redis.exceptions import RedisError
+from utils import gh_helper
+from utils.allowlist import AllowlistLevel, load_allowlist
 from utils.config import RelayConfig
 from utils.hud import forward_to_hud
-from utils.misc import CallbackState
+from utils.misc import CallbackState, extract_pr_labels
 
 
 logger = logging.getLogger(__name__)
@@ -52,6 +54,84 @@ def _build_timeout_payload(zombie: dict, completed_at: str) -> tuple[dict, dict]
     return stored_trusted, stored_untrusted
 
 
+def _finalize_timed_out_check_run(config: RelayConfig, zombie: dict) -> None:
+    """Create a completed/timed_out upstream check run for an L3+ zombie.
+
+    A zombie's downstream stopped reporting, so its upstream check run is left
+    in_progress forever. The HUD/Redis updates don't touch GitHub, so for L3/L4
+    repos we mirror the live callback's check-run creation here — using the body
+    captured at IN_PROGRESS time — but with a terminal timed_out conclusion.
+    Best-effort: a GitHub failure must not block the rest of cleanup.
+    """
+    payload = zombie["state_record"].payload or {}
+    trusted = payload.get("trusted") or {}
+    verified_repo = trusted.get("verified_repo", "")
+    body = (payload.get("untrusted") or {}).get("callback_payload") or {}
+    if not verified_repo or not body:
+        return
+
+    # Cheap pre-check from the level captured at in_progress time: only L3+ repos
+    # ever get an upstream check run, so skip the allowlist/GitHub work otherwise.
+    if trusted.get("downstream_repo_level", "") < AllowlistLevel.L3.value:
+        return
+
+    allowlist = load_allowlist(config)
+    level = allowlist.get_repo_level(verified_repo)
+    if level is None or level.value < AllowlistLevel.L3.value:
+        return
+
+    pr_field = (body.get("payload") or {}).get("pull_request") or {}
+    head_sha = (pr_field.get("head") or {}).get("sha", "")
+    if not head_sha:
+        return
+
+    # Only finalize repos that actually had a check run at in_progress time —
+    # same gating as the live callback path.
+    needs_cr = allowlist.needs_check_run(verified_repo, extract_pr_labels(body))
+    if not needs_cr and level == AllowlistLevel.L3:
+        needs_cr = redis_helper.is_check_run_wanted(config, head_sha, verified_repo)
+    if not needs_cr:
+        return
+
+    workflow = body.get("workflow") or {}
+    workflow_name = workflow.get("name", "")
+    run_id = str(workflow.get("run_id"))
+    details_url = f"https://github.com/{verified_repo}/actions/runs/{run_id}"
+    output = gh_helper.build_check_run_output(
+        "completed", "timed_out", details_url, verified_repo
+    )
+
+    try:
+        upstream_token = gh_helper.get_repo_access_token(
+            config.github_app_id,
+            config.github_app_private_key,
+            config.upstream_repo,
+        )
+        cr_id = gh_helper.create_check_run(
+            token=upstream_token,
+            repo_full_name=config.upstream_repo,
+            name=gh_helper.check_run_name(verified_repo, workflow_name),
+            head_sha=head_sha,
+            status="completed",
+            conclusion="timed_out",
+            details_url=details_url,
+            external_id=run_id,
+            output=output,
+        )
+        logger.info(
+            "zombie check run finalized timed_out repo=%s run_id=%s cr_id=%s",
+            verified_repo,
+            run_id,
+            cr_id,
+        )
+    except Exception:
+        logger.exception(
+            "zombie check run finalize failed repo=%s run_id=%s",
+            verified_repo,
+            run_id,
+        )
+
+
 def _cleanup_one(
     *,
     config: RelayConfig,
@@ -64,6 +144,8 @@ def _cleanup_one(
     Returns a dict with ``ok`` indicating whether the zombie was cleaned
     successfully (HUD forward succeeded).
     """
+    _finalize_timed_out_check_run(config, zombie)
+
     delivery_id = zombie["delivery_id"]
     repo = zombie["downstream_repo"]
     run_id = zombie["run_id"]

--- a/aws/lambda/cross_repo_ci_relay/tests/test_allowlist.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_allowlist.py
@@ -4,21 +4,46 @@ from utils.allowlist import AllowlistLevel, AllowlistMap
 
 
 class TestAllowlistMap(unittest.TestCase):
-    def test_parse_and_get_repos_at_or_above_level(self):
-        raw = {
+    def _raw(self):
+        return {
             "L1": ["a/1"],
             "L2": [],
-            "L3": ["b/2"],
+            "L3": {
+                "device1": {"b/device1-repo": ["oncall_b"]},
+                "device2": {"b/device2-repo": []},
+            },
             "L4": [{"c/3": "oncall_c"}],
         }
-        amap = AllowlistMap._parse(raw)
+
+    def test_parse_and_get_repos_at_or_above_level(self):
+        amap = AllowlistMap._parse(self._raw())
         repos, oncalls = amap.get_repos_at_or_above_level(AllowlistLevel.L1)
-        self.assertEqual(sorted(repos), ["a/1", "b/2", "c/3"])
-        self.assertEqual(oncalls, ["oncall_c"])
+        self.assertEqual(
+            sorted(repos), ["a/1", "b/device1-repo", "b/device2-repo", "c/3"]
+        )
+        self.assertEqual(oncalls, ["oncall_b", "oncall_c"])
+
+    def test_get_repos_for_device(self):
+        amap = AllowlistMap._parse(self._raw())
+        repos, oncalls = amap.get_repos_for_device("device1")
+        self.assertEqual(repos, ["b/device1-repo"])
+        self.assertEqual(oncalls, ["oncall_b"])
+        empty_repos, _ = amap.get_repos_for_device("unknown")
+        self.assertEqual(empty_repos, [])
+
+    def test_get_repo_device(self):
+        amap = AllowlistMap._parse(self._raw())
+        self.assertEqual(amap.get_repo_device("b/device1-repo"), "device1")
+        self.assertEqual(amap.get_repo_device("b/device2-repo"), "device2")
+        self.assertIsNone(amap.get_repo_device("a/1"))
 
     def test_duplicate_repo_raises(self):
         with self.assertRaises(RuntimeError):
             AllowlistMap._parse({"L1": ["org/repo"], "L2": ["org/repo"]})
+
+    def test_l3_non_dict_raises(self):
+        with self.assertRaises(RuntimeError):
+            AllowlistMap._parse({"L3": ["org/repo"]})
 
 
 if __name__ == "__main__":

--- a/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
@@ -16,6 +16,7 @@ def _cfg():
     cfg.redis_login = ""
     cfg.crcr_status_ttl = 259200
     cfg.rate_limit_per_min = 20
+    cfg.upstream_repo = "pytorch/pytorch"
     return cfg
 
 
@@ -25,6 +26,7 @@ def _body(
     run_id=99999,
     run_attempt=1,
     job_name=None,
+    labels=None
 ):
     wf = {
         "status": status,
@@ -37,11 +39,16 @@ def _body(
     }
     if job_name is not None:
         wf["job_name"] = job_name
+
     return {
         "event_type": "pull_request",
         "delivery_id": "del-123",
         "payload": {
-            "pull_request": {"number": 42, "head": {"sha": "abc123"}},
+            "pull_request": {
+                "number": 42,
+                "head": {"sha": "abc123"},
+                "labels": [{"name": n} for n in (labels or [])],
+            },
             "repository": {"full_name": "pytorch/pytorch"},
         },
         "workflow": wf,
@@ -272,6 +279,139 @@ class TestCallbackHandler(unittest.TestCase):
         # add_in_progress_tracker should have been called with job_name="build"
         tracker_kwargs = self.mock_redis.add_in_progress_tracker.call_args
         self.assertEqual(tracker_kwargs.kwargs.get("job_name"), "build")
+
+
+class TestCallbackCheckRunUpdate(unittest.TestCase):
+    """Upstream check run is updated when an L3/L4 downstream job completes."""
+
+    def setUp(self):
+        self.patcher_allowlist = patch("callback.callback_handler.load_allowlist")
+        self.mock_load = self.patcher_allowlist.start()
+        mock_map = MagicMock()
+        mock_map.get_repo_level.return_value = AllowlistLevel.L4
+        self.mock_load.return_value = mock_map
+
+        self.patcher_redis = patch("callback.callback_handler.redis_helper")
+        self.mock_redis = self.patcher_redis.start()
+
+        def _get_state(
+            cfg,
+            delivery_id,
+            repo,
+            run_id_arg,
+            run_attempt_arg,
+            client=None,
+            job_name=None,
+        ):
+            if run_id_arg == DISPATCH_RUN_ID:
+                return CallbackStateRecord(CallbackState.DISPATCHED, 1000.0, {})
+            if run_id_arg == 99999:  # default run_id in _body()
+                return CallbackStateRecord(CallbackState.IN_PROGRESS, 1030.0, {})
+            return None
+
+        self.mock_redis.get_callback_state.side_effect = _get_state
+        self.patcher_rate = patch("callback.callback_handler.check_rate_limit")
+        self.mock_rate = self.patcher_rate.start()
+        self.mock_rate.return_value = True
+
+        self.patcher_hud = patch("callback.callback_handler.forward_to_hud")
+        self.patcher_hud.start()
+
+        self.patcher_gh = patch("callback.callback_handler.gh_helper")
+        self.mock_gh = self.patcher_gh.start()
+        self.mock_gh.get_repo_access_token.return_value = "tok"
+
+    def tearDown(self):
+        self.patcher_allowlist.stop()
+        self.patcher_redis.stop()
+        self.patcher_rate.stop()
+        self.patcher_hud.stop()
+        self.patcher_gh.stop()
+
+    def test_completed_callback_creates_check_run(self):
+        self.mock_gh.create_check_run.return_value = 888
+
+        handle(_cfg(), _body(status="completed"), verified_repo="org/repo")
+
+        self.mock_gh.create_check_run.assert_called_once()
+        kw = self.mock_gh.create_check_run.call_args[1]
+        self.assertEqual(kw["status"], "completed")
+        self.assertEqual(kw["conclusion"], "success")
+
+    def test_in_progress_callback_creates_check_run(self):
+        self.mock_gh.create_check_run.return_value = 999
+
+        handle(_cfg(), _body(status="in_progress"), verified_repo="org/repo")
+
+        self.mock_gh.create_check_run.assert_called_once()
+        kw = self.mock_gh.create_check_run.call_args[1]
+        self.assertEqual(kw["head_sha"], "abc123")
+        self.assertEqual(kw["status"], "in_progress")
+
+    def test_reopen_in_progress_creates_new_check_run(self):
+        """Reopen scenario: prior completed CR exists; in_progress always creates a new one."""
+        self.mock_gh.create_check_run.return_value = 999
+
+        handle(_cfg(), _body(status="in_progress"), verified_repo="org/repo")
+
+        self.mock_gh.create_check_run.assert_called_once()
+        kw = self.mock_gh.create_check_run.call_args[1]
+        self.assertEqual(kw["status"], "in_progress")
+
+    def test_l3_with_matching_label_creates_check_run(self):
+        """L3 repo: check run is created when needs_check_run returns True."""
+        mock_map = MagicMock()
+        mock_map.get_repo_level.return_value = AllowlistLevel.L3
+        mock_map.needs_check_run.return_value = True
+        self.mock_load.return_value = mock_map
+
+        handle(_cfg(), _body(status="in_progress"), verified_repo="org/repo")
+
+        self.mock_gh.create_check_run.assert_called_once()
+
+    def test_l3_without_label_does_not_create_check_run(self):
+        """L3 repo: no check run when needs_check_run=False and no label trigger."""
+        mock_map = MagicMock()
+        mock_map.get_repo_level.return_value = AllowlistLevel.L3
+        mock_map.needs_check_run.return_value = False
+        self.mock_load.return_value = mock_map
+        self.mock_redis.is_check_run_wanted.return_value = False
+
+        handle(_cfg(), _body(status="in_progress"), verified_repo="org/repo")
+
+        self.mock_gh.create_check_run.assert_not_called()
+
+    def test_l3_check_run_wanted_flag_creates_check_run(self):
+        """L3 reopen: echoed payload has no label, but the per-commit wanted flag
+        (set at dispatch for this head_sha) makes the callback create the check run."""
+        mock_map = MagicMock()
+        mock_map.get_repo_level.return_value = AllowlistLevel.L3
+        mock_map.needs_check_run.return_value = False
+        self.mock_load.return_value = mock_map
+        self.mock_redis.is_check_run_wanted.return_value = True
+
+        handle(_cfg(), _body(status="in_progress"), verified_repo="org/repo")
+
+        self.mock_gh.create_check_run.assert_called_once()
+        self.mock_redis.is_check_run_wanted.assert_called_once_with(
+            unittest.mock.ANY, "abc123", "org/repo"
+        )
+
+    def test_l2_completed_does_not_create_check_run(self):
+        mock_map = MagicMock()
+        mock_map.get_repo_level.return_value = AllowlistLevel.L2
+        self.mock_load.return_value = mock_map
+
+        handle(_cfg(), _body(status="completed"), verified_repo="org/repo")
+
+        self.mock_gh.create_check_run.assert_not_called()
+
+    def test_check_run_update_failure_does_not_break_response(self):
+        self.mock_gh.get_repo_access_token.side_effect = RuntimeError("token error")
+
+        result = handle(_cfg(), _body(status="completed"), verified_repo="org/repo")
+
+        self.assertEqual(result, {"ok": True, "status": "completed"})
 
 
 if __name__ == "__main__":

--- a/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
@@ -26,7 +26,7 @@ def _body(
     run_id=99999,
     run_attempt=1,
     job_name=None,
-    labels=None
+    labels=None,
 ):
     wf = {
         "status": status,
@@ -367,6 +367,22 @@ class TestCallbackCheckRunUpdate(unittest.TestCase):
 
         handle(_cfg(), _body(status="in_progress"), verified_repo="org/repo")
 
+        self.mock_gh.create_check_run.assert_called_once()
+
+    def test_l3_passes_body_labels_to_needs_check_run(self):
+        """The PR labels from the callback body are extracted and handed to
+        needs_check_run, which gates whether the L3 check run is created."""
+        mock_map = MagicMock()
+        mock_map.get_repo_level.return_value = AllowlistLevel.L3
+        mock_map.needs_check_run.return_value = True
+        self.mock_load.return_value = mock_map
+
+        body = _body(status="in_progress", labels=["ciflow/crcr/device1", "other"])
+        handle(_cfg(), body, verified_repo="org/repo")
+
+        mock_map.needs_check_run.assert_called_once_with(
+            "org/repo", {"ciflow/crcr/device1", "other"}
+        )
         self.mock_gh.create_check_run.assert_called_once()
 
     def test_l3_without_label_does_not_create_check_run(self):

--- a/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
@@ -338,6 +338,35 @@ class TestCallbackCheckRunUpdate(unittest.TestCase):
         self.assertEqual(kw["status"], "completed")
         self.assertEqual(kw["conclusion"], "success")
 
+    def test_check_run_name_is_scoped_by_job_name(self):
+        """The job_name from the callback body is threaded into the check run
+        name so multiple jobs in one workflow run get distinct check runs."""
+        self.mock_gh.create_check_run.return_value = 888
+
+        handle(
+            _cfg(),
+            _body(status="completed", job_name="ec05-multi-job-a"),
+            verified_repo="org/repo",
+        )
+
+        self.mock_gh.check_run_name.assert_called_once_with(
+            "org/repo", "CI", "ec05-multi-job-a"
+        )
+
+    def test_check_run_external_id_is_run_id(self):
+        """external_id carries the downstream run_id so a rerequest can re-run
+        the failed jobs of that run."""
+        self.mock_gh.create_check_run.return_value = 888
+
+        handle(
+            _cfg(),
+            _body(status="completed", job_name="build"),
+            verified_repo="org/repo",
+        )
+
+        kw = self.mock_gh.create_check_run.call_args[1]
+        self.assertEqual(kw["external_id"], "99999")  # run_id from _body
+
     def test_in_progress_callback_creates_check_run(self):
         self.mock_gh.create_check_run.return_value = 999
 

--- a/aws/lambda/cross_repo_ci_relay/tests/test_cleanup_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_cleanup_handler.py
@@ -5,6 +5,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from callback.cleanup_handler import _build_timeout_payload, handle
+from utils.allowlist import AllowlistLevel
 from utils.misc import CallbackState
 from utils.redis_helper import CallbackStateRecord
 
@@ -257,6 +258,61 @@ class TestCleanupHandler(unittest.TestCase):
         self.assertEqual(result["errors"], 0)
         self.mock_hud.assert_called_once()
         self.mock_redis.remove_in_progress_tracker.assert_called_once()
+
+
+class TestCleanupCheckRunFinalize(unittest.TestCase):
+    """L3+ zombies also get a completed/timed_out upstream check run."""
+
+    def setUp(self):
+        self.patcher_redis = patch("callback.cleanup_handler.redis_helper")
+        self.mock_redis = self.patcher_redis.start()
+        self.patcher_hud = patch("callback.cleanup_handler.forward_to_hud")
+        self.patcher_hud.start()
+
+        self.patcher_load = patch("callback.cleanup_handler.load_allowlist")
+        self.mock_load = self.patcher_load.start()
+        self.mock_map = MagicMock()
+        self.mock_map.get_repo_level.return_value = AllowlistLevel.L4
+        self.mock_map.needs_check_run.return_value = True
+        self.mock_load.return_value = self.mock_map
+
+        self.patcher_gh = patch("callback.cleanup_handler.gh_helper")
+        self.mock_gh = self.patcher_gh.start()
+        self.mock_gh.get_repo_access_token.return_value = "tok"
+        self.mock_gh.create_check_run.return_value = 777
+
+    def tearDown(self):
+        self.patcher_redis.stop()
+        self.patcher_hud.stop()
+        self.patcher_load.stop()
+        self.patcher_gh.stop()
+
+    def _level_zombie(self, level):
+        zombie = _zombie_entry()
+        zombie["state_record"].payload["trusted"]["downstream_repo_level"] = level
+        return zombie
+
+    def test_l4_zombie_finalizes_check_run_timed_out(self):
+        self.mock_redis.scan_expired_in_progress.return_value = [
+            self._level_zombie("L4")
+        ]
+
+        handle(_cfg())
+
+        self.mock_gh.create_check_run.assert_called_once()
+        kw = self.mock_gh.create_check_run.call_args[1]
+        self.assertEqual(kw["status"], "completed")
+        self.assertEqual(kw["conclusion"], "timed_out")
+        self.assertEqual(kw["head_sha"], "abc123")
+
+    def test_l2_zombie_does_not_finalize_check_run(self):
+        # Default zombie is L2 → the pre-check short-circuits, no upstream check run.
+        self.mock_redis.scan_expired_in_progress.return_value = [_zombie_entry()]
+
+        handle(_cfg())
+
+        self.mock_gh.create_check_run.assert_not_called()
+        self.mock_load.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/aws/lambda/cross_repo_ci_relay/tests/test_cleanup_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_cleanup_handler.py
@@ -160,9 +160,13 @@ class TestCleanupHandler(unittest.TestCase):
         self.patcher_hud = patch("callback.cleanup_handler.forward_to_hud")
         self.mock_hud = self.patcher_hud.start()
 
+        self.patcher_load = patch("callback.cleanup_handler.load_allowlist")
+        self.patcher_load.start()
+
     def tearDown(self):
         self.patcher_redis.stop()
         self.patcher_hud.stop()
+        self.patcher_load.stop()
 
     def test_no_expired_jobs(self):
         """Empty scan returns cleanly."""
@@ -306,13 +310,17 @@ class TestCleanupCheckRunFinalize(unittest.TestCase):
         self.assertEqual(kw["head_sha"], "abc123")
 
     def test_l2_zombie_does_not_finalize_check_run(self):
-        # Default zombie is L2 → the pre-check short-circuits, no upstream check run.
+        # Default zombie is L2 → the stored-level pre-check short-circuits, no
+        # upstream check run and no per-repo allowlist lookup.
         self.mock_redis.scan_expired_in_progress.return_value = [_zombie_entry()]
 
         handle(_cfg())
 
         self.mock_gh.create_check_run.assert_not_called()
-        self.mock_load.assert_not_called()
+        # Allowlist is loaded once for the whole sweep, then the L2 pre-check
+        # skips the per-repo get_repo_level lookup.
+        self.mock_load.assert_called_once()
+        self.mock_map.get_repo_level.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/aws/lambda/cross_repo_ci_relay/tests/test_event_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_event_handler.py
@@ -1,5 +1,6 @@
 import unittest
-from unittest.mock import call, MagicMock, patch
+import unittest.mock
+from unittest.mock import MagicMock, patch
 
 from webhook.event_handler import handle
 
@@ -10,6 +11,8 @@ def _cfg():
     cfg.github_app_private_key = "fake-key"
     cfg.max_dispatch_workers = 4
     cfg.github_app_secret = "test-secret"
+    cfg.upstream_repo = "pytorch/pytorch"
+    cfg.oot_status_ttl = 259200
     return cfg
 
 
@@ -21,9 +24,16 @@ def _payload(action="synchronize"):
             "head": {"sha": "abc123", "ref": "feat"},
             "base": {"ref": "main"},
             "number": 42,
+            "labels": [],
         },
         "installation": {"id": 99},
     }
+
+
+def _payload_with_labels(action="synchronize", labels=None):
+    payload = _payload(action)
+    payload["pull_request"]["labels"] = [{"name": n} for n in (labels or [])]
+    return payload
 
 
 class TestEventHandler(unittest.TestCase):
@@ -33,18 +43,20 @@ class TestEventHandler(unittest.TestCase):
             {"ignored": True},
         )
 
+    @patch("webhook.event_handler.redis_helper.mark_check_run_wanted")
     @patch("webhook.event_handler.redis_helper.set_callback_state")
     @patch("webhook.event_handler.gh_helper.create_repository_dispatch")
     @patch("webhook.event_handler.gh_helper.get_repo_access_token", return_value="tok")
     @patch("webhook.event_handler.load_allowlist")
-    def test_dispatch_success(self, mock_load, _tok, mock_dispatch, _mock_set_state):
-        mock_load.return_value = MagicMock(
-            get_repos_at_or_above_level=MagicMock(return_value=(["org/a"], []))
-        )
+    def test_dispatch_success(self, mock_load, _tok, mock_dispatch, _state, _trig):
+        mock_map = MagicMock()
+        mock_map.get_repos_at_or_above_level.return_value = (["org/a"], [])
+        mock_load.return_value = mock_map
         result = handle(_cfg(), _payload(action="opened"), "pull_request", "delivery-1")
         self.assertTrue(result["ok"])
         mock_dispatch.assert_called_once()
 
+    @patch("webhook.event_handler.redis_helper.mark_check_run_wanted")
     @patch("webhook.event_handler.redis_helper.set_callback_state")
     @patch("webhook.event_handler.gh_helper.create_repository_dispatch")
     @patch(
@@ -53,26 +65,164 @@ class TestEventHandler(unittest.TestCase):
     )
     @patch("webhook.event_handler.load_allowlist")
     def test_dispatch_mints_token_per_downstream_repo(
-        self, mock_load, mock_get_repo_access_token, mock_dispatch, _mock_set_state
+        self, mock_load, mock_get_repo_access_token, mock_dispatch, _state, _trig
     ):
-        mock_load.return_value = MagicMock(
-            get_repos_at_or_above_level=MagicMock(
-                return_value=(["huawei/repo", "pytorch/repo"], [])
-            )
+        mock_map = MagicMock()
+        mock_map.get_repos_at_or_above_level.return_value = (
+            ["huawei/repo", "pytorch/repo"],
+            [],
         )
+        mock_load.return_value = mock_map
 
         result = handle(_cfg(), _payload(action="opened"), "pull_request", "delivery-2")
 
         self.assertTrue(result["ok"])
+        # One token per downstream repo for dispatch only; CR creation moved to callback
         self.assertEqual(mock_get_repo_access_token.call_count, 2)
-        mock_get_repo_access_token.assert_has_calls(
-            [
-                call("12345", "fake-key", "huawei/repo"),
-                call("12345", "fake-key", "pytorch/repo"),
-            ],
-            any_order=True,
-        )
+        mock_get_repo_access_token.assert_any_call("12345", "fake-key", "huawei/repo")
+        mock_get_repo_access_token.assert_any_call("12345", "fake-key", "pytorch/repo")
         self.assertEqual(mock_dispatch.call_count, 2)
+
+
+class TestDispatchCheckRunCreation(unittest.TestCase):
+    """Check runs are never created at dispatch time; the callback creates them."""
+
+    @patch("webhook.event_handler.redis_helper.mark_check_run_wanted")
+    @patch("webhook.event_handler.redis_helper.set_callback_state")
+    @patch("webhook.event_handler.gh_helper.create_check_run")
+    @patch("webhook.event_handler.gh_helper.create_repository_dispatch")
+    @patch("webhook.event_handler.gh_helper.get_repo_access_token", return_value="tok")
+    @patch("webhook.event_handler.load_allowlist")
+    def test_l3_with_crcr_label_does_not_create_check_run_at_dispatch(
+        self, mock_load, _tok, _dispatch, mock_create_cr, _state, _trig
+    ):
+        """L3 with a matching label does not create a CR at dispatch; the in_progress callback does."""
+        mock_map = MagicMock()
+        mock_map.get_repos_at_or_above_level.return_value = (["org/repo"], [])
+        mock_load.return_value = mock_map
+
+        handle(
+            _cfg(),
+            _payload_with_labels(labels=["ciflow/crcr/device"]),
+            "pull_request",
+            "del-1",
+        )
+
+        mock_create_cr.assert_not_called()
+
+    @patch("webhook.event_handler.redis_helper.mark_check_run_wanted")
+    @patch("webhook.event_handler.redis_helper.set_callback_state")
+    @patch("webhook.event_handler.gh_helper.create_check_run")
+    @patch("webhook.event_handler.gh_helper.create_repository_dispatch")
+    @patch("webhook.event_handler.gh_helper.get_repo_access_token", return_value="tok")
+    @patch("webhook.event_handler.load_allowlist")
+    def test_l4_does_not_create_check_run_at_dispatch(
+        self, mock_load, _tok, _dispatch, mock_create_cr, _state, _trig
+    ):
+        """L4 does not create a CR at dispatch; the in_progress callback does."""
+        mock_map = MagicMock()
+        mock_map.get_repos_at_or_above_level.return_value = (["org/repo"], [])
+        mock_load.return_value = mock_map
+
+        handle(_cfg(), _payload(), "pull_request", "del-2")
+
+        mock_create_cr.assert_not_called()
+
+
+class TestPrLabeledHandler(unittest.TestCase):
+    """pull_request.labeled with ciflow/crcr/* triggers L3 check run backfill."""
+
+    def _labeled_payload(self, label="ciflow/crcr/device"):
+        return {
+            "action": "labeled",
+            "label": {"name": label},
+            "pull_request": {
+                "number": 42,
+                "head": {"sha": "abc123"},
+                "labels": [{"name": label}],
+            },
+            "repository": {"full_name": "pytorch/pytorch"},
+        }
+
+    def setUp(self):
+        self.patcher_redis = patch("webhook.event_handler.redis_helper")
+        self.mock_redis = self.patcher_redis.start()
+
+        self.patcher_gh = patch("webhook.event_handler.gh_helper")
+        self.mock_gh = self.patcher_gh.start()
+        self.mock_gh.get_repo_access_token.return_value = "tok"
+        self.mock_gh.create_check_run.return_value = 77
+        self.patcher_load = patch("webhook.event_handler.load_allowlist")
+        self.mock_load = self.patcher_load.start()
+        mock_map = MagicMock()
+        mock_map.get_repos_for_device.return_value = (["org/l3repo"], [])
+        self.mock_load.return_value = mock_map
+
+    def tearDown(self):
+        self.patcher_redis.stop()
+        self.patcher_gh.stop()
+        self.patcher_load.stop()
+
+    def test_scenario2_in_progress_job_creates_in_progress_check_run(self):
+        """Scenario 2: label arrives while workflow is in_progress → backfill in_progress CR."""
+        self.mock_redis.get_dispatch_workflow.return_value = {
+            "status": "in_progress",
+            "check_run_id": "555",
+            "conclusion": None,
+            "job_url": "https://github.com/org/l3repo/actions/runs/99999",
+            "run_id": "99999",
+            "workflow_name": "CI",
+        }
+
+        result = handle(_cfg(), self._labeled_payload(), "pull_request", "label-del")
+
+        self.assertTrue(result["ok"])
+        self.assertIn("org/l3repo", result["created_check_runs"])
+        self.mock_gh.create_check_run.assert_called_once()
+        kw = self.mock_gh.create_check_run.call_args[1]
+        self.assertEqual(kw["head_sha"], "abc123")
+        self.assertNotIn("conclusion", kw)
+
+    def test_scenario3_completed_job_creates_completed_check_run(self):
+        """Scenario 3: label arrives after workflow completed → create completed CR directly."""
+        self.mock_redis.get_dispatch_workflow.return_value = {
+            "status": "completed",
+            "check_run_id": "555",
+            "conclusion": "success",
+            "job_url": "https://github.com/org/l3repo/actions/runs/99999",
+            "run_id": "99999",
+            "workflow_name": "CI",
+        }
+
+        result = handle(_cfg(), self._labeled_payload(), "pull_request", "label-del")
+
+        self.assertTrue(result["ok"])
+        self.assertIn("org/l3repo", result["created_check_runs"])
+        kw = self.mock_gh.create_check_run.call_args[1]
+        self.assertEqual(kw["status"], "completed")
+        self.assertEqual(kw["conclusion"], "success")
+
+    def test_no_job_info_marks_check_run_wanted(self):
+        """No job info yet → mark check run wanted so the callback creates it when it fires."""
+        self.mock_redis.get_dispatch_workflow.return_value = None
+
+        result = handle(_cfg(), self._labeled_payload(), "pull_request", "label-del")
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["created_check_runs"], [])
+        self.mock_gh.create_check_run.assert_not_called()
+        self.mock_redis.mark_check_run_wanted.assert_called_once_with(
+            unittest.mock.ANY, "abc123", "org/l3repo"
+        )
+
+    def test_non_crcr_label_is_ignored(self):
+        result = handle(
+            _cfg(),
+            self._labeled_payload(label="some/other/label"),
+            "pull_request",
+            "del-x",
+        )
+        self.assertEqual(result, {"ignored": True})
 
 
 if __name__ == "__main__":

--- a/aws/lambda/cross_repo_ci_relay/tests/test_event_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_event_handler.py
@@ -164,41 +164,65 @@ class TestPrLabeledHandler(unittest.TestCase):
         self.patcher_gh.stop()
         self.patcher_load.stop()
 
+    def _job(self, job_name="ci", status="in_progress", conclusion=None, run_id="99999"):
+        return {
+            "status": status,
+            "conclusion": conclusion,
+            "job_url": "https://github.com/org/l3repo/actions/runs/99999",
+            "run_id": run_id,
+            "workflow_name": "CI",
+            "job_name": job_name,
+        }
+
     def test_scenario2_in_progress_job_creates_in_progress_check_run(self):
         """Scenario 2: label arrives while workflow is in_progress → backfill in_progress CR."""
-        self.mock_redis.get_dispatch_workflow.return_value = {
-            "status": "in_progress",
-            "check_run_id": "555",
-            "conclusion": None,
-            "job_url": "https://github.com/org/l3repo/actions/runs/99999",
-            "run_id": "99999",
-            "workflow_name": "CI",
-        }
+        self.mock_redis.get_dispatch_jobs.return_value = [self._job(status="in_progress")]
 
         result = handle(_cfg(), self._labeled_payload(), "pull_request", "label-del")
 
         self.assertTrue(result["ok"])
-        self.assertIn("org/l3repo", result["created_check_runs"])
+        self.assertIn("org/l3repo/ci", result["created_check_runs"])
         self.mock_gh.create_check_run.assert_called_once()
         kw = self.mock_gh.create_check_run.call_args[1]
         self.assertEqual(kw["head_sha"], "abc123")
-        self.assertNotIn("conclusion", kw)
+        self.assertEqual(kw["status"], "in_progress")
+        self.assertIsNone(kw["conclusion"])
+        self.assertEqual(kw["external_id"], "99999")  # run_id
+
+    def test_scenario2_backfills_every_job_not_just_one(self):
+        """Multi-job workflow: a mid-run label backfills a check run for EVERY
+        cached job, not only the last one that reported."""
+        self.mock_redis.get_dispatch_jobs.return_value = [
+            self._job(job_name="ci"),
+            self._job(job_name="ci-2"),
+        ]
+
+        result = handle(_cfg(), self._labeled_payload(), "pull_request", "label-del")
+
+        self.assertEqual(
+            set(result["created_check_runs"]), {"org/l3repo/ci", "org/l3repo/ci-2"}
+        )
+        self.assertEqual(self.mock_gh.create_check_run.call_count, 2)
+        # gh_helper.check_run_name is mocked, so assert it was asked to build a
+        # name for each job; jobs of the same run share run_id as external_id.
+        job_names = {c.args[2] for c in self.mock_gh.check_run_name.call_args_list}
+        self.assertEqual(job_names, {"ci", "ci-2"})
+        external_ids = {
+            c.kwargs["external_id"]
+            for c in self.mock_gh.create_check_run.call_args_list
+        }
+        self.assertEqual(external_ids, {"99999"})  # run_id
 
     def test_scenario3_completed_job_creates_completed_check_run(self):
         """Scenario 3: label arrives after workflow completed → create completed CR directly."""
-        self.mock_redis.get_dispatch_workflow.return_value = {
-            "status": "completed",
-            "check_run_id": "555",
-            "conclusion": "success",
-            "job_url": "https://github.com/org/l3repo/actions/runs/99999",
-            "run_id": "99999",
-            "workflow_name": "CI",
-        }
+        self.mock_redis.get_dispatch_jobs.return_value = [
+            self._job(status="completed", conclusion="success")
+        ]
 
         result = handle(_cfg(), self._labeled_payload(), "pull_request", "label-del")
 
         self.assertTrue(result["ok"])
-        self.assertIn("org/l3repo", result["created_check_runs"])
+        self.assertIn("org/l3repo/ci", result["created_check_runs"])
         kw = self.mock_gh.create_check_run.call_args[1]
         self.assertEqual(kw["status"], "completed")
         self.assertEqual(kw["conclusion"], "success")
@@ -209,24 +233,21 @@ class TestPrLabeledHandler(unittest.TestCase):
             ["org/repoA", "org/repoB"],
             [],
         )
-        self.mock_redis.get_dispatch_workflow.return_value = {
-            "status": "completed",
-            "check_run_id": "1",
-            "conclusion": "success",
-            "job_url": "https://github.com/org/repo/actions/runs/1",
-            "run_id": "1",
-            "workflow_name": "CI",
-        }
+        self.mock_redis.get_dispatch_jobs.return_value = [
+            self._job(status="completed", conclusion="success")
+        ]
 
         result = handle(_cfg(), self._labeled_payload(), "pull_request", "label-del")
 
-        self.assertEqual(set(result["created_check_runs"]), {"org/repoA", "org/repoB"})
+        self.assertEqual(
+            set(result["created_check_runs"]), {"org/repoA/ci", "org/repoB/ci"}
+        )
         self.assertEqual(self.mock_gh.get_repo_access_token.call_count, 1)
         self.assertEqual(self.mock_gh.create_check_run.call_count, 2)
 
     def test_no_job_info_marks_check_run_wanted(self):
         """No job info yet → mark check run wanted so the callback creates it when it fires."""
-        self.mock_redis.get_dispatch_workflow.return_value = None
+        self.mock_redis.get_dispatch_jobs.return_value = []
 
         result = handle(_cfg(), self._labeled_payload(), "pull_request", "label-del")
 
@@ -248,7 +269,7 @@ class TestPrLabeledHandler(unittest.TestCase):
 
 
 class TestCheckRunRerun(unittest.TestCase):
-    """check_run / check_suite rerequested re-trigger the downstream workflow run."""
+    """check_run rerequested re-runs the failed jobs of the run by its run_id."""
 
     def setUp(self):
         self.patcher_gh = patch("webhook.event_handler.gh_helper")
@@ -270,7 +291,7 @@ class TestCheckRunRerun(unittest.TestCase):
         self.patcher_redis.stop()
         self.patcher_load.stop()
 
-    def _check_run_payload(self, name="crcr/org/l3repo/CI", external_id="99999"):
+    def _check_run_payload(self, name="crcr/org/l3repo/CI/build", external_id="88888"):
         return {
             "action": "rerequested",
             "check_run": {
@@ -281,12 +302,21 @@ class TestCheckRunRerun(unittest.TestCase):
             "repository": {"full_name": "pytorch/pytorch"},
         }
 
-    def test_check_run_rerequested_reruns_downstream(self):
+    def test_check_run_rerequested_reruns_failed_jobs_of_run(self):
         result = handle(_cfg(), self._check_run_payload(), "check_run", "del-1")
         self.assertEqual(result, {"ok": True, "rerun": ["org/l3repo"]})
-        self.mock_gh.rerun_workflow.assert_called_once_with(
-            token="tok", repo_full_name="org/l3repo", run_id=99999
+        self.mock_gh.rerun_failed_jobs.assert_called_once_with(
+            token="tok", repo_full_name="org/l3repo", run_id=88888
         )
+
+    def test_check_run_already_running_is_benign(self):
+        """A 403 'already running' is not surfaced as an error (no 502)."""
+        self.mock_gh.rerun_failed_jobs.side_effect = Exception(
+            "The workflow run containing this job is already running: 403"
+        )
+        result = handle(_cfg(), self._check_run_payload(), "check_run", "del-1b")
+        self.assertTrue(result["ok"])
+        self.assertTrue(result["already_running"])
 
     def test_non_crcr_check_run_is_ignored(self):
         result = handle(
@@ -296,7 +326,18 @@ class TestCheckRunRerun(unittest.TestCase):
             "del-2",
         )
         self.assertTrue(result["ignored"])
-        self.mock_gh.rerun_workflow.assert_not_called()
+        self.mock_gh.rerun_failed_jobs.assert_not_called()
+
+    def test_check_run_without_external_id_is_ignored(self):
+        """No run_id stored -> nothing to rerun, not an error."""
+        result = handle(
+            _cfg(),
+            self._check_run_payload(external_id=""),
+            "check_run",
+            "del-2b",
+        )
+        self.assertTrue(result["ignored"])
+        self.mock_gh.rerun_failed_jobs.assert_not_called()
 
     def test_check_run_non_rerequested_action_ignored(self):
         payload = self._check_run_payload()
@@ -304,20 +345,75 @@ class TestCheckRunRerun(unittest.TestCase):
         self.assertEqual(
             handle(_cfg(), payload, "check_run", "del-3"), {"ignored": True}
         )
-        self.mock_gh.rerun_workflow.assert_not_called()
+        self.mock_gh.rerun_failed_jobs.assert_not_called()
 
-    def test_check_suite_rerequested_reruns_cached_runs(self):
-        self.mock_redis.get_dispatch_workflow.return_value = {"run_id": "12345"}
+    def test_check_suite_rerequested_reruns_each_distinct_run(self):
+        """The suite-level "re-run all" button re-runs the failed jobs of every
+        distinct run; jobs sharing a run_id are deduped to one call."""
+        self.mock_gh.list_check_runs_in_suite.return_value = [
+            {"name": "crcr/org/l3repo/CI/build", "external_id": "111"},
+            {"name": "crcr/org/l3repo/CI/test", "external_id": "111"},  # same run
+            {"name": "crcr/org/l3repo/Lint/lint", "external_id": "222"},
+        ]
         payload = {
             "action": "rerequested",
-            "check_suite": {"head_sha": "abc123"},
+            "check_suite": {"id": 9001, "head_sha": "abc123"},
             "repository": {"full_name": "pytorch/pytorch"},
         }
         result = handle(_cfg(), payload, "check_suite", "del-4")
+
+        self.assertEqual(result, {"ok": True, "rerun": ["org/l3repo", "org/l3repo"]})
+        self.assertEqual(self.mock_gh.rerun_failed_jobs.call_count, 2)
+        run_ids = {
+            c.kwargs["run_id"] for c in self.mock_gh.rerun_failed_jobs.call_args_list
+        }
+        self.assertEqual(run_ids, {111, 222})
+
+    def test_check_suite_already_running_run_is_skipped(self):
+        """A run that's already running is skipped, others still re-run."""
+        self.mock_gh.list_check_runs_in_suite.return_value = [
+            {"name": "crcr/org/l3repo/CI/build", "external_id": "111"},
+            {"name": "crcr/org/l3repo/Lint/lint", "external_id": "222"},
+        ]
+
+        def _side_effect(*, token, repo_full_name, run_id):
+            if run_id == 111:
+                raise Exception("workflow run ... is already running: 403")
+
+        self.mock_gh.rerun_failed_jobs.side_effect = _side_effect
+        payload = {
+            "action": "rerequested",
+            "check_suite": {"id": 9001, "head_sha": "abc123"},
+            "repository": {"full_name": "pytorch/pytorch"},
+        }
+        result = handle(_cfg(), payload, "check_suite", "del-4b")
         self.assertEqual(result, {"ok": True, "rerun": ["org/l3repo"]})
-        self.mock_gh.rerun_workflow.assert_called_once_with(
-            token="tok", repo_full_name="org/l3repo", run_id=12345
+
+    def test_check_suite_skips_non_crcr_and_missing_external_id(self):
+        """Non-crcr check runs and ones without a run_id are skipped, not errored."""
+        self.mock_gh.list_check_runs_in_suite.return_value = [
+            {"name": "some-other-check", "external_id": "999"},
+            {"name": "crcr/org/l3repo/CI/build", "external_id": ""},
+        ]
+        payload = {
+            "action": "rerequested",
+            "check_suite": {"id": 9002, "head_sha": "abc123"},
+            "repository": {"full_name": "pytorch/pytorch"},
+        }
+        result = handle(_cfg(), payload, "check_suite", "del-5")
+        self.assertEqual(result, {"ok": True, "rerun": []})
+        self.mock_gh.rerun_failed_jobs.assert_not_called()
+
+    def test_check_suite_non_rerequested_action_ignored(self):
+        payload = {
+            "action": "completed",
+            "check_suite": {"id": 9003},
+            "repository": {"full_name": "pytorch/pytorch"},
+        }
+        self.assertEqual(
+            handle(_cfg(), payload, "check_suite", "del-6"), {"ignored": True}
         )
+        self.mock_gh.rerun_failed_jobs.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/aws/lambda/cross_repo_ci_relay/tests/test_event_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_event_handler.py
@@ -2,6 +2,7 @@ import unittest
 import unittest.mock
 from unittest.mock import MagicMock, patch
 
+from utils.allowlist import AllowlistLevel
 from webhook.event_handler import handle
 
 
@@ -244,6 +245,79 @@ class TestPrLabeledHandler(unittest.TestCase):
             "del-x",
         )
         self.assertEqual(result, {"ignored": True})
+
+
+class TestCheckRunRerun(unittest.TestCase):
+    """check_run / check_suite rerequested re-trigger the downstream workflow run."""
+
+    def setUp(self):
+        self.patcher_gh = patch("webhook.event_handler.gh_helper")
+        self.mock_gh = self.patcher_gh.start()
+        self.mock_gh.get_repo_access_token.return_value = "tok"
+
+        self.patcher_redis = patch("webhook.event_handler.redis_helper")
+        self.mock_redis = self.patcher_redis.start()
+
+        self.patcher_load = patch("webhook.event_handler.load_allowlist")
+        self.mock_load = self.patcher_load.start()
+        self.mock_map = MagicMock()
+        self.mock_map.get_repo_level.return_value = AllowlistLevel.L3
+        self.mock_map.get_repos_at_or_above_level.return_value = (["org/l3repo"], [])
+        self.mock_load.return_value = self.mock_map
+
+    def tearDown(self):
+        self.patcher_gh.stop()
+        self.patcher_redis.stop()
+        self.patcher_load.stop()
+
+    def _check_run_payload(self, name="crcr/org/l3repo/CI", external_id="99999"):
+        return {
+            "action": "rerequested",
+            "check_run": {
+                "name": name,
+                "external_id": external_id,
+                "head_sha": "abc123",
+            },
+            "repository": {"full_name": "pytorch/pytorch"},
+        }
+
+    def test_check_run_rerequested_reruns_downstream(self):
+        result = handle(_cfg(), self._check_run_payload(), "check_run", "del-1")
+        self.assertEqual(result, {"ok": True, "rerun": ["org/l3repo"]})
+        self.mock_gh.rerun_workflow.assert_called_once_with(
+            token="tok", repo_full_name="org/l3repo", run_id=99999
+        )
+
+    def test_non_crcr_check_run_is_ignored(self):
+        result = handle(
+            _cfg(),
+            self._check_run_payload(name="some-other-check"),
+            "check_run",
+            "del-2",
+        )
+        self.assertTrue(result["ignored"])
+        self.mock_gh.rerun_workflow.assert_not_called()
+
+    def test_check_run_non_rerequested_action_ignored(self):
+        payload = self._check_run_payload()
+        payload["action"] = "created"
+        self.assertEqual(
+            handle(_cfg(), payload, "check_run", "del-3"), {"ignored": True}
+        )
+        self.mock_gh.rerun_workflow.assert_not_called()
+
+    def test_check_suite_rerequested_reruns_cached_runs(self):
+        self.mock_redis.get_dispatch_workflow.return_value = {"run_id": "12345"}
+        payload = {
+            "action": "rerequested",
+            "check_suite": {"head_sha": "abc123"},
+            "repository": {"full_name": "pytorch/pytorch"},
+        }
+        result = handle(_cfg(), payload, "check_suite", "del-4")
+        self.assertEqual(result, {"ok": True, "rerun": ["org/l3repo"]})
+        self.mock_gh.rerun_workflow.assert_called_once_with(
+            token="tok", repo_full_name="org/l3repo", run_id=12345
+        )
 
 
 if __name__ == "__main__":

--- a/aws/lambda/cross_repo_ci_relay/tests/test_event_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_event_handler.py
@@ -202,6 +202,27 @@ class TestPrLabeledHandler(unittest.TestCase):
         self.assertEqual(kw["status"], "completed")
         self.assertEqual(kw["conclusion"], "success")
 
+    def test_upstream_token_minted_once_for_multiple_repos(self):
+        """A device mapping to multiple repos mints the upstream token once, not per repo."""
+        self.mock_load.return_value.get_repos_for_device.return_value = (
+            ["org/repoA", "org/repoB"],
+            [],
+        )
+        self.mock_redis.get_dispatch_workflow.return_value = {
+            "status": "completed",
+            "check_run_id": "1",
+            "conclusion": "success",
+            "job_url": "https://github.com/org/repo/actions/runs/1",
+            "run_id": "1",
+            "workflow_name": "CI",
+        }
+
+        result = handle(_cfg(), self._labeled_payload(), "pull_request", "label-del")
+
+        self.assertEqual(set(result["created_check_runs"]), {"org/repoA", "org/repoB"})
+        self.assertEqual(self.mock_gh.get_repo_access_token.call_count, 1)
+        self.assertEqual(self.mock_gh.create_check_run.call_count, 2)
+
     def test_no_job_info_marks_check_run_wanted(self):
         """No job info yet → mark check run wanted so the callback creates it when it fires."""
         self.mock_redis.get_dispatch_workflow.return_value = None

--- a/aws/lambda/cross_repo_ci_relay/tests/test_event_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_event_handler.py
@@ -70,7 +70,7 @@ class TestEventHandler(unittest.TestCase):
     ):
         mock_map = MagicMock()
         mock_map.get_repos_at_or_above_level.return_value = (
-            ["huawei/repo", "pytorch/repo"],
+            ["org1/repo", "pytorch/repo"],
             [],
         )
         mock_load.return_value = mock_map
@@ -80,7 +80,7 @@ class TestEventHandler(unittest.TestCase):
         self.assertTrue(result["ok"])
         # One token per downstream repo for dispatch only; CR creation moved to callback
         self.assertEqual(mock_get_repo_access_token.call_count, 2)
-        mock_get_repo_access_token.assert_any_call("12345", "fake-key", "huawei/repo")
+        mock_get_repo_access_token.assert_any_call("12345", "fake-key", "org1/repo")
         mock_get_repo_access_token.assert_any_call("12345", "fake-key", "pytorch/repo")
         self.assertEqual(mock_dispatch.call_count, 2)
 

--- a/aws/lambda/cross_repo_ci_relay/tests/test_event_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_event_handler.py
@@ -164,7 +164,9 @@ class TestPrLabeledHandler(unittest.TestCase):
         self.patcher_gh.stop()
         self.patcher_load.stop()
 
-    def _job(self, job_name="ci", status="in_progress", conclusion=None, run_id="99999"):
+    def _job(
+        self, job_name="ci", status="in_progress", conclusion=None, run_id="99999"
+    ):
         return {
             "status": status,
             "conclusion": conclusion,
@@ -176,7 +178,9 @@ class TestPrLabeledHandler(unittest.TestCase):
 
     def test_scenario2_in_progress_job_creates_in_progress_check_run(self):
         """Scenario 2: label arrives while workflow is in_progress → backfill in_progress CR."""
-        self.mock_redis.get_dispatch_jobs.return_value = [self._job(status="in_progress")]
+        self.mock_redis.get_dispatch_jobs.return_value = [
+            self._job(status="in_progress")
+        ]
 
         result = handle(_cfg(), self._labeled_payload(), "pull_request", "label-del")
 
@@ -348,8 +352,8 @@ class TestCheckRunRerun(unittest.TestCase):
         self.mock_gh.rerun_failed_jobs.assert_not_called()
 
     def test_check_suite_rerequested_reruns_each_distinct_run(self):
-        """The suite-level "re-run all" button re-runs the failed jobs of every
-        distinct run; jobs sharing a run_id are deduped to one call."""
+        """The suite-level "Re-run all checks" button re-runs *all* jobs of every
+        distinct run (rerun-all); jobs sharing a run_id are deduped to one call."""
         self.mock_gh.list_check_runs_in_suite.return_value = [
             {"name": "crcr/org/l3repo/CI/build", "external_id": "111"},
             {"name": "crcr/org/l3repo/CI/test", "external_id": "111"},  # same run
@@ -363,9 +367,10 @@ class TestCheckRunRerun(unittest.TestCase):
         result = handle(_cfg(), payload, "check_suite", "del-4")
 
         self.assertEqual(result, {"ok": True, "rerun": ["org/l3repo", "org/l3repo"]})
-        self.assertEqual(self.mock_gh.rerun_failed_jobs.call_count, 2)
+        self.mock_gh.rerun_failed_jobs.assert_not_called()
+        self.assertEqual(self.mock_gh.rerun_workflow_run.call_count, 2)
         run_ids = {
-            c.kwargs["run_id"] for c in self.mock_gh.rerun_failed_jobs.call_args_list
+            c.kwargs["run_id"] for c in self.mock_gh.rerun_workflow_run.call_args_list
         }
         self.assertEqual(run_ids, {111, 222})
 
@@ -380,7 +385,7 @@ class TestCheckRunRerun(unittest.TestCase):
             if run_id == 111:
                 raise Exception("workflow run ... is already running: 403")
 
-        self.mock_gh.rerun_failed_jobs.side_effect = _side_effect
+        self.mock_gh.rerun_workflow_run.side_effect = _side_effect
         payload = {
             "action": "rerequested",
             "check_suite": {"id": 9001, "head_sha": "abc123"},
@@ -402,7 +407,7 @@ class TestCheckRunRerun(unittest.TestCase):
         }
         result = handle(_cfg(), payload, "check_suite", "del-5")
         self.assertEqual(result, {"ok": True, "rerun": []})
-        self.mock_gh.rerun_failed_jobs.assert_not_called()
+        self.mock_gh.rerun_workflow_run.assert_not_called()
 
     def test_check_suite_non_rerequested_action_ignored(self):
         payload = {
@@ -413,7 +418,7 @@ class TestCheckRunRerun(unittest.TestCase):
         self.assertEqual(
             handle(_cfg(), payload, "check_suite", "del-6"), {"ignored": True}
         )
-        self.mock_gh.rerun_failed_jobs.assert_not_called()
+        self.mock_gh.rerun_workflow_run.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/aws/lambda/cross_repo_ci_relay/tests/test_redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_redis_helper.py
@@ -297,6 +297,68 @@ class TestRateLimit(unittest.TestCase):
         self.assertEqual(ctx.exception.status_code, 500)
 
 
+class TestDispatchJob(unittest.TestCase):
+    def test_set_dispatch_job_stores_per_job_hash_field(self):
+        """Each job is stored under its own hash field keyed by workflow:job."""
+        client = MagicMock()
+        redis_helper.set_dispatch_job(
+            _cfg(),
+            "sha1",
+            "org/repo",
+            "in_progress",
+            None,
+            "url",
+            run_id="111",
+            workflow_name="CI",
+            job_name="build",
+            client=client,
+        )
+        client.hset.assert_called_once()
+        key, field, value = client.hset.call_args[0]
+        self.assertEqual(key, "crcr:dispatch_job:sha1:org/repo")
+        self.assertEqual(field, "CI:build")
+        self.assertEqual(json.loads(value)["run_id"], "111")
+        client.expire.assert_called_once_with(
+            "crcr:dispatch_job:sha1:org/repo", 3600
+        )
+
+    def test_same_job_name_in_different_workflows_does_not_collide(self):
+        """A same-named job in another workflow uses a distinct field."""
+        client = MagicMock()
+        common = dict(
+            status="in_progress",
+            conclusion=None,
+            job_url="url",
+            job_name="build",
+            client=client,
+        )
+        redis_helper.set_dispatch_job(
+            _cfg(), "sha1", "org/repo", workflow_name="CI", **common
+        )
+        redis_helper.set_dispatch_job(
+            _cfg(), "sha1", "org/repo", workflow_name="Lint", **common
+        )
+        fields = {c.args[1] for c in client.hset.call_args_list}
+        self.assertEqual(fields, {"CI:build", "Lint:build"})
+
+    def test_get_dispatch_jobs_returns_all_hash_values(self):
+        client = MagicMock()
+        client.hgetall.return_value = {
+            "CI:build": json.dumps({"job_name": "build", "run_id": "1"}),
+            "CI:test": json.dumps({"job_name": "test", "run_id": "1"}),
+        }
+        jobs = redis_helper.get_dispatch_jobs(_cfg(), "sha1", "org/repo", client=client)
+        self.assertEqual({j["job_name"] for j in jobs}, {"build", "test"})
+
+    def test_get_dispatch_jobs_empty_when_no_hash(self):
+        client = MagicMock()
+        client.hgetall.return_value = {}
+        self.assertEqual(
+            redis_helper.get_dispatch_jobs(_cfg(), "sha1", "org/repo", client=client),
+            [],
+        )
+
+
 class TestInProgressTracker(unittest.TestCase):
     def setUp(self):
         redis_helper._cached_client = None

--- a/aws/lambda/cross_repo_ci_relay/tests/test_redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_redis_helper.py
@@ -323,13 +323,13 @@ class TestDispatchJob(unittest.TestCase):
     def test_same_job_name_in_different_workflows_does_not_collide(self):
         """A same-named job in another workflow uses a distinct field."""
         client = MagicMock()
-        common = dict(
-            status="in_progress",
-            conclusion=None,
-            job_url="url",
-            job_name="build",
-            client=client,
-        )
+        common = {
+            "status": "in_progress",
+            "conclusion": None,
+            "job_url": "url",
+            "job_name": "build",
+            "client": client,
+        }
         redis_helper.set_dispatch_job(
             _cfg(), "sha1", "org/repo", workflow_name="CI", **common
         )

--- a/aws/lambda/cross_repo_ci_relay/tests/test_redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_redis_helper.py
@@ -318,9 +318,7 @@ class TestDispatchJob(unittest.TestCase):
         self.assertEqual(key, "crcr:dispatch_job:sha1:org/repo")
         self.assertEqual(field, "CI:build")
         self.assertEqual(json.loads(value)["run_id"], "111")
-        client.expire.assert_called_once_with(
-            "crcr:dispatch_job:sha1:org/repo", 3600
-        )
+        client.expire.assert_called_once_with("crcr:dispatch_job:sha1:org/repo", 3600)
 
     def test_same_job_name_in_different_workflows_does_not_collide(self):
         """A same-named job in another workflow uses a distinct field."""

--- a/aws/lambda/cross_repo_ci_relay/utils/allowlist.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/allowlist.py
@@ -4,6 +4,11 @@ YAML format:
   L1:
     - org1/repo1
     - org2/repo2
+  L3:
+    device1:
+      org3/device1-repo: [oncall1, oncall2]
+    device2:
+      org4/device2-repo: [oncall1]
   L4:
     - org5/repo5: oncall1, oncall2
 """
@@ -33,6 +38,7 @@ class AllowlistLevel(str, Enum):
 class AllowlistEntry:
     repo: str
     oncalls: list[str] = field(default_factory=list)
+    device: str = ""  # L3 only: suffix of the ciflow/crcr/{device} label
 
     @classmethod
     def _from_raw(cls, raw_entry, level: AllowlistLevel, idx: int) -> "AllowlistEntry":
@@ -79,6 +85,23 @@ class AllowlistMap:
             [o for e in entries for o in e.oncalls],
         )
 
+    def get_repos_for_device(self, device: str) -> tuple[list[str], list[str]]:
+        """Return (backends, oncalls) for L3 repos registered under the given device label.
+
+        device is the suffix of ciflow/crcr/{device}.
+        """
+        entries = [
+            e for e in self._levels.get(AllowlistLevel.L3, []) if e.device == device
+        ]
+        return [e.repo for e in entries], [o for e in entries for o in e.oncalls]
+
+    def get_repo_device(self, repo: str) -> str | None:
+        """Return the device label suffix for an L3 repo, or None if not L3."""
+        for entry in self._levels.get(AllowlistLevel.L3, []):
+            if entry.repo == repo:
+                return entry.device or None
+        return None
+
     def get_repos_at_or_above_level(
         self, level: AllowlistLevel
     ) -> tuple[list[str], list[str]]:
@@ -104,6 +127,21 @@ class AllowlistMap:
                     return level
         return None
 
+    def needs_check_run(self, repo: str, pr_labels: set[str]) -> bool:
+        """Return True when an upstream check run should be created for this repo.
+
+        L4+: always True.
+        L3: True only when the matching ciflow/crcr/<device> label is present.
+        L1/L2/unknown: False.
+        """
+        level = self.get_repo_level(repo)
+        if level is None or level.value < AllowlistLevel.L3.value:
+            return False
+        if level.value >= AllowlistLevel.L4.value:
+            return True
+        device = self.get_repo_device(repo)
+        return bool(device and f"ciflow/crcr/{device}" in pr_labels)
+
     @classmethod
     def _parse(cls, raw: dict) -> "AllowlistMap":
         if not isinstance(raw, dict):
@@ -113,20 +151,63 @@ class AllowlistMap:
         seen_repos: set[str] = set()
         levels: dict[AllowlistLevel, list[AllowlistEntry]] = {}
         for level in AllowlistLevel:
-            raw_entries = raw.get(level) or []
-            if not isinstance(raw_entries, list):
-                raise RuntimeError(
-                    f"Invalid allowlist: {level} must be a list, got {type(raw_entries).__name__}"
-                )
             entries: list[AllowlistEntry] = []
-            for idx, raw_entry in enumerate(raw_entries):
-                entry = AllowlistEntry._from_raw(raw_entry, level, idx)
-                if entry.repo in seen_repos:
+            if level == AllowlistLevel.L3:
+                raw_entries = raw.get(level) or {}
+                if not isinstance(raw_entries, dict):
                     raise RuntimeError(
-                        f"Invalid allowlist: duplicate repo {entry.repo!r}"
+                        f"Invalid allowlist: L3 must be a device mapping "
+                        f"(e.g. 'device:\\n  org/repo: [oncall]'), "
+                        f"got {type(raw_entries).__name__}"
                     )
-                seen_repos.add(entry.repo)
-                entries.append(entry)
+                for device, repos_raw in raw_entries.items():
+                    device = str(device).strip()
+                    if not device:
+                        raise RuntimeError(
+                            "Invalid allowlist: L3 device name must not be empty"
+                        )
+                    if not isinstance(repos_raw, dict):
+                        raise RuntimeError(
+                            f"Invalid allowlist: L3.{device} must be a repo mapping, "
+                            f"got {type(repos_raw).__name__}"
+                        )
+                    for repo_raw, oncalls_raw in repos_raw.items():
+                        repo = str(repo_raw).strip().strip("/")
+                        if not repo or "/" not in repo:
+                            raise RuntimeError(
+                                f"Invalid allowlist: L3.{device}.{repo_raw!r} must be in owner/repo format"
+                            )
+                        if repo in seen_repos:
+                            raise RuntimeError(
+                                f"Invalid allowlist: duplicate repo {repo!r}"
+                            )
+                        seen_repos.add(repo)
+                        oncalls = (
+                            [
+                                str(o).strip()
+                                for o in (oncalls_raw or [])
+                                if str(o).strip()
+                            ]
+                            if oncalls_raw
+                            else []
+                        )
+                        entries.append(
+                            AllowlistEntry(repo=repo, oncalls=oncalls, device=device)
+                        )
+            else:
+                raw_entries = raw.get(level) or []
+                if not isinstance(raw_entries, list):
+                    raise RuntimeError(
+                        f"Invalid allowlist: {level} must be a list, got {type(raw_entries).__name__}"
+                    )
+                for idx, raw_entry in enumerate(raw_entries):
+                    entry = AllowlistEntry._from_raw(raw_entry, level, idx)
+                    if entry.repo in seen_repos:
+                        raise RuntimeError(
+                            f"Invalid allowlist: duplicate repo {entry.repo!r}"
+                        )
+                    seen_repos.add(entry.repo)
+                    entries.append(entry)
             levels[level] = entries
         return cls(levels)
 

--- a/aws/lambda/cross_repo_ci_relay/utils/config.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/config.py
@@ -152,7 +152,7 @@ class RelayConfig:
 
         max_dispatch_workers = _check_if_positive_int("MAX_DISPATCH_WORKERS", "32")
 
-        rate_limit_per_min = _check_if_positive_int("RATE_LIMIT_PER_MIN", "20")
+        rate_limit_per_min = _check_if_positive_int("RATE_LIMIT_PER_MIN", "100")
 
         # Maximum duration an in-progress job is expected to run before being
         # considered abandoned (zombie).  Default 24 hours (86400 s).

--- a/aws/lambda/cross_repo_ci_relay/utils/gh_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/gh_helper.py
@@ -65,6 +65,29 @@ def rerun_failed_jobs(
     )
 
 
+def rerun_workflow_run(
+    *,
+    token: str,
+    repo_full_name: str,
+    run_id: int,
+    timeout: int = 20,
+    gh_client: github.Github | None = None,
+) -> None:
+    """Re-run all jobs of a downstream workflow run by its run_id.
+
+    Uses the run-level rerun endpoint, which re-runs every job of the run
+    (including ones that already succeeded) — unlike rerun-failed-jobs, so it
+    also works when the run has no failed jobs. PyGithub has no helper for this
+    endpoint, so the REST call is issued via the requester directly.
+    """
+    logger.info("rerun_workflow_run repo=%s run_id=%d", repo_full_name, run_id)
+    if gh_client is None:
+        gh_client = github.Github(login_or_token=token, timeout=timeout)
+    gh_client.requester.requestJsonAndCheck(
+        "POST", f"/repos/{repo_full_name}/actions/runs/{run_id}/rerun"
+    )
+
+
 def list_check_runs_in_suite(
     *,
     token: str,

--- a/aws/lambda/cross_repo_ci_relay/utils/gh_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/gh_helper.py
@@ -75,13 +75,20 @@ def create_repository_dispatch(
 
 
 def build_check_run_output(
-    workflow_name: str,
+    status: str,
+    conclusion: str,
     details_url: str,
     downstream_repo: str,
-) -> dict | None:
+) -> dict:
     """Return a GitHub Check Run output dict shown in the detail panel."""
+    if status != "completed":
+        title = "In progress"
+    elif conclusion:
+        title = conclusion.capitalize()
+    else:
+        title = "Completed"
     return {
-        "title": workflow_name,
+        "title": title,
         "summary": f"{downstream_repo} workflow: {details_url}",
     }
 

--- a/aws/lambda/cross_repo_ci_relay/utils/gh_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/gh_helper.py
@@ -41,6 +41,21 @@ def get_repo_access_token(
     return gh_client.get_access_token(installation.id).token
 
 
+def rerun_workflow(
+    *,
+    token: str,
+    repo_full_name: str,
+    run_id: int,
+    timeout: int = 20,
+    gh_client: github.Github | None = None,
+) -> None:
+    """Trigger a re-run of an existing downstream workflow run by its run_id."""
+    logger.info("rerun_workflow repo=%s run_id=%d", repo_full_name, run_id)
+    if gh_client is None:
+        gh_client = github.Github(login_or_token=token, timeout=timeout)
+    gh_client.get_repo(repo_full_name).get_workflow_run(run_id).rerun()
+
+
 def create_repository_dispatch(
     *,
     token: str,

--- a/aws/lambda/cross_repo_ci_relay/utils/gh_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/gh_helper.py
@@ -11,9 +11,9 @@ from .misc import EventDispatchPayload
 logger = logging.getLogger(__name__)
 
 
-def check_run_name(downstream_repo: str, workflow_name: str) -> str:
-    """Canonical check run name shown on the upstream PR (e.g. 'crcr/org/repo/CI')."""
-    return f"crcr/{downstream_repo}/{workflow_name}"
+def check_run_name(downstream_repo: str, workflow_name: str, job_name: str) -> str:
+    """Canonical per-job check run name shown on the upstream PR"""
+    return f"crcr/{downstream_repo}/{workflow_name}/{job_name}"
 
 
 def get_repo_access_token(
@@ -41,7 +41,7 @@ def get_repo_access_token(
     return gh_client.get_access_token(installation.id).token
 
 
-def rerun_workflow(
+def rerun_failed_jobs(
     *,
     token: str,
     repo_full_name: str,
@@ -49,11 +49,52 @@ def rerun_workflow(
     timeout: int = 20,
     gh_client: github.Github | None = None,
 ) -> None:
-    """Trigger a re-run of an existing downstream workflow run by its run_id."""
-    logger.info("rerun_workflow repo=%s run_id=%d", repo_full_name, run_id)
+    """Re-run all failed jobs of a downstream workflow run by its run_id.
+
+    Uses the run-level rerun-failed-jobs endpoint so every failed job of the run
+    is re-run in one call. Re-running individual jobs of a run that is already
+    running is rejected by GitHub (403), so one run-level call is both simpler
+    and avoids that conflict. PyGithub has no helper for this endpoint, so the
+    REST call is issued via the requester directly.
+    """
+    logger.info("rerun_failed_jobs repo=%s run_id=%d", repo_full_name, run_id)
     if gh_client is None:
         gh_client = github.Github(login_or_token=token, timeout=timeout)
-    gh_client.get_repo(repo_full_name).get_workflow_run(run_id).rerun()
+    gh_client.requester.requestJsonAndCheck(
+        "POST", f"/repos/{repo_full_name}/actions/runs/{run_id}/rerun-failed-jobs"
+    )
+
+
+def list_check_runs_in_suite(
+    *,
+    token: str,
+    repo_full_name: str,
+    check_suite_id: int,
+    timeout: int = 20,
+    gh_client: github.Github | None = None,
+) -> list[dict]:
+    """Return all check runs in a check suite (raw API dicts, paginated).
+
+    Used to re-run every run in a suite: the CRCR app owns a single suite per
+    commit, so this lists every check run it created there, each carrying the
+    downstream run_id in ``external_id``.
+    """
+    if gh_client is None:
+        gh_client = github.Github(login_or_token=token, timeout=timeout)
+    runs: list[dict] = []
+    page = 1
+    while True:
+        _, data = gh_client.requester.requestJsonAndCheck(
+            "GET",
+            f"/repos/{repo_full_name}/check-suites/{check_suite_id}/check-runs"
+            f"?per_page=100&page={page}",
+        )
+        batch = data.get("check_runs", [])
+        runs.extend(batch)
+        if not batch or len(runs) >= data.get("total_count", len(runs)):
+            break
+        page += 1
+    return runs
 
 
 def create_repository_dispatch(
@@ -111,8 +152,8 @@ def create_check_run(
 
     Pass status='completed' and conclusion for Scenario 3 (label arrives after
     workflow has already finished — create a completed check run directly).
-    external_id stores the downstream workflow run_id so rerequested events can
-    identify the original run.
+    external_id stores the downstream run_id so a rerequested event can re-run
+    the failed jobs of that workflow run.
     output (optional) sets the detail-panel content: {"title": str, "summary": str}.
     """
     logger.info(

--- a/aws/lambda/cross_repo_ci_relay/utils/gh_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/gh_helper.py
@@ -11,6 +11,11 @@ from .misc import EventDispatchPayload
 logger = logging.getLogger(__name__)
 
 
+def check_run_name(downstream_repo: str, workflow_name: str) -> str:
+    """Canonical check run name shown on the upstream PR (e.g. 'crcr/org/repo/CI')."""
+    return f"crcr/{downstream_repo}/{workflow_name}"
+
+
 def get_repo_access_token(
     app_id: str,
     private_key: str,
@@ -52,6 +57,58 @@ def create_repository_dispatch(
     gh_client.get_repo(repo_full_name).create_repository_dispatch(
         event_type, dict(client_payload)
     )
+
+
+def build_check_run_output(
+    workflow_name: str,
+    details_url: str,
+    downstream_repo: str,
+) -> dict | None:
+    """Return a GitHub Check Run output dict shown in the detail panel."""
+    return {
+        "title": workflow_name,
+        "summary": f"{downstream_repo} workflow: {details_url}",
+    }
+
+
+def create_check_run(
+    *,
+    token: str,
+    repo_full_name: str,
+    name: str,
+    head_sha: str,
+    status: str,
+    conclusion: str | None = None,
+    details_url: str | None = None,
+    external_id: str | None = None,
+    output: dict | None = None,
+    timeout: int = 20,
+    gh_client: github.Github | None = None,
+) -> int:
+    """Create a check run on the upstream repo. Returns the check run ID.
+
+    Pass status='completed' and conclusion for Scenario 3 (label arrives after
+    workflow has already finished — create a completed check run directly).
+    external_id stores the downstream workflow run_id so rerequested events can
+    identify the original run.
+    output (optional) sets the detail-panel content: {"title": str, "summary": str}.
+    """
+    logger.info(
+        "create_check_run repo=%s name=%s status=%s", repo_full_name, name, status
+    )
+    if gh_client is None:
+        gh_client = github.Github(login_or_token=token, timeout=timeout)
+    create_kwargs: dict = {"name": name, "head_sha": head_sha, "status": status}
+    if status == "completed" and conclusion is not None:
+        create_kwargs["conclusion"] = conclusion
+    if details_url is not None:
+        create_kwargs["details_url"] = details_url
+    if external_id is not None:
+        create_kwargs["external_id"] = external_id
+    if output is not None:
+        create_kwargs["output"] = output
+    check_run = gh_client.get_repo(repo_full_name).create_check_run(**create_kwargs)
+    return check_run.id
 
 
 def get_repo_file(

--- a/aws/lambda/cross_repo_ci_relay/utils/misc.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/misc.py
@@ -57,6 +57,17 @@ class CallbackStateRecord:
     payload: dict | None
 
 
+def extract_pr_labels(envelope: dict) -> set[str]:
+    """Return the set of PR label names from a dispatch/callback envelope.
+
+    Both the webhook dispatch ``client_payload`` and the downstream callback
+    ``body`` carry the original webhook under ``payload.pull_request``, so the
+    labels live at ``payload.pull_request.labels`` in either case.
+    """
+    pull_request = (envelope.get("payload") or {}).get("pull_request") or {}
+    return {lbl.get("name", "") for lbl in (pull_request.get("labels") or [])}
+
+
 def parse_lambda_event(event: dict) -> tuple[str, str, bytes, dict]:
     """Extract method, path, body bytes, and lower-cased headers from a Lambda event dict."""
     http = event.get("requestContext", {}).get("http", {})

--- a/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
@@ -19,6 +19,8 @@ _ALLOWLIST_CACHE_KEY = "crcr:allowlist_yaml"
 _STATE_PREFIX = "crcr:state:"
 _RATE_LIMIT_PREFIX = "crcr:rate:"
 _IN_PROGRESS_ZSET = "crcr:in_progress"
+_DISPATCH_WORKFLOW_PREFIX = "crcr:dispatch_workflow:"
+_CHECK_RUN_WANTED_PREFIX = "crcr:check_run_wanted:"
 _cached_client: redis_lib.Redis | None = None
 _cached_client_url: str | None = None
 
@@ -167,6 +169,89 @@ def check_rate_limit(
     except RedisError as e:
         logger.exception("redis rate limit check failed")
         raise HTTPException(500, f"rate limit check failed: {e}") from e
+
+
+def set_dispatch_workflow(
+    config: RelayConfig,
+    head_sha: str,
+    downstream_repo: str,
+    status: str,
+    conclusion: str | None,
+    job_url: str | None,
+    run_id: str | None = None,
+    workflow_name: str | None = None,
+    client: redis_lib.Redis | None = None,
+) -> None:
+    """Store the latest downstream job summary keyed by (head_sha, downstream_repo)."""
+    try:
+        if client is None:
+            client = create_client(config)
+        key = f"{_DISPATCH_WORKFLOW_PREFIX}{head_sha}:{downstream_repo}"
+        value = json.dumps(
+            {
+                "status": status,
+                "conclusion": conclusion,
+                "job_url": job_url,
+                "run_id": run_id,
+                "workflow_name": workflow_name,
+            }
+        )
+        client.setex(key, config.oot_status_ttl, value)
+    except RedisError:
+        logger.exception("set_dispatch_workflow: redis error")
+
+
+def get_dispatch_workflow(
+    config: RelayConfig,
+    head_sha: str,
+    downstream_repo: str,
+    client: redis_lib.Redis | None = None,
+) -> dict | None:
+    """Return the latest job summary for (head_sha, downstream_repo), or None if not found."""
+    try:
+        if client is None:
+            client = create_client(config)
+        key = f"{_DISPATCH_WORKFLOW_PREFIX}{head_sha}:{downstream_repo}"
+        val = client.get(key)
+        if val is None:
+            return None
+        return json.loads(val)
+    except (RedisError, json.JSONDecodeError, TypeError):
+        logger.exception("get_dispatch_workflow: failed")
+        return None
+
+
+def mark_check_run_wanted(
+    config: RelayConfig,
+    head_sha: str,
+    downstream_repo: str,
+    client: redis_lib.Redis | None = None,
+) -> None:
+    """Record that an upstream check run is wanted for this (head_sha, repo)."""
+    try:
+        if client is None:
+            client = create_client(config)
+        key = f"{_CHECK_RUN_WANTED_PREFIX}{head_sha}:{downstream_repo}"
+        client.setex(key, config.oot_status_ttl, "1")
+    except RedisError:
+        logger.exception("mark_check_run_wanted: redis error")
+
+
+def is_check_run_wanted(
+    config: RelayConfig,
+    head_sha: str,
+    downstream_repo: str,
+    client: redis_lib.Redis | None = None,
+) -> bool:
+    """Return True if an upstream check run is wanted for this (head_sha, repo)."""
+    try:
+        if client is None:
+            client = create_client(config)
+        key = f"{_CHECK_RUN_WANTED_PREFIX}{head_sha}:{downstream_repo}"
+        return bool(client.exists(key))
+    except RedisError:
+        logger.exception("is_check_run_wanted: redis error")
+        return False
 
 
 def _state_key(

--- a/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
@@ -196,7 +196,7 @@ def set_dispatch_workflow(
                 "workflow_name": workflow_name,
             }
         )
-        client.setex(key, config.oot_status_ttl, value)
+        client.setex(key, config.crcr_status_ttl, value)
     except RedisError:
         logger.exception("set_dispatch_workflow: redis error")
 
@@ -232,7 +232,7 @@ def mark_check_run_wanted(
         if client is None:
             client = create_client(config)
         key = f"{_CHECK_RUN_WANTED_PREFIX}{head_sha}:{downstream_repo}"
-        client.setex(key, config.oot_status_ttl, "1")
+        client.setex(key, config.crcr_status_ttl, "1")
     except RedisError:
         logger.exception("mark_check_run_wanted: redis error")
 

--- a/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
@@ -19,7 +19,7 @@ _ALLOWLIST_CACHE_KEY = "crcr:allowlist_yaml"
 _STATE_PREFIX = "crcr:state:"
 _RATE_LIMIT_PREFIX = "crcr:rate:"
 _IN_PROGRESS_ZSET = "crcr:in_progress"
-_DISPATCH_WORKFLOW_PREFIX = "crcr:dispatch_workflow:"
+_DISPATCH_JOB_PREFIX = "crcr:dispatch_job:"
 _CHECK_RUN_WANTED_PREFIX = "crcr:check_run_wanted:"
 _cached_client: redis_lib.Redis | None = None
 _cached_client_url: str | None = None
@@ -171,7 +171,7 @@ def check_rate_limit(
         raise HTTPException(500, f"rate limit check failed: {e}") from e
 
 
-def set_dispatch_workflow(
+def set_dispatch_job(
     config: RelayConfig,
     head_sha: str,
     downstream_repo: str,
@@ -180,13 +180,15 @@ def set_dispatch_workflow(
     job_url: str | None,
     run_id: str | None = None,
     workflow_name: str | None = None,
+    job_name: str | None = None,
     client: redis_lib.Redis | None = None,
 ) -> None:
-    """Store the latest downstream job summary keyed by (head_sha, downstream_repo)."""
+    """Store the latest summary for a single downstream job."""
     try:
         if client is None:
             client = create_client(config)
-        key = f"{_DISPATCH_WORKFLOW_PREFIX}{head_sha}:{downstream_repo}"
+        key = f"{_DISPATCH_JOB_PREFIX}{head_sha}:{downstream_repo}"
+        field = f"{workflow_name}:{job_name}"
         value = json.dumps(
             {
                 "status": status,
@@ -194,31 +196,31 @@ def set_dispatch_workflow(
                 "job_url": job_url,
                 "run_id": run_id,
                 "workflow_name": workflow_name,
+                "job_name": job_name,
             }
         )
-        client.setex(key, config.crcr_status_ttl, value)
+        client.hset(key, field, value)
+        client.expire(key, config.crcr_status_ttl)
     except RedisError:
-        logger.exception("set_dispatch_workflow: redis error")
+        logger.exception("set_dispatch_job: redis error")
 
 
-def get_dispatch_workflow(
+def get_dispatch_jobs(
     config: RelayConfig,
     head_sha: str,
     downstream_repo: str,
     client: redis_lib.Redis | None = None,
-) -> dict | None:
-    """Return the latest job summary for (head_sha, downstream_repo), or None if not found."""
+) -> list[dict]:
+    """Return the summaries of all downstream jobs for (head_sha, downstream_repo)."""
     try:
         if client is None:
             client = create_client(config)
-        key = f"{_DISPATCH_WORKFLOW_PREFIX}{head_sha}:{downstream_repo}"
-        val = client.get(key)
-        if val is None:
-            return None
-        return json.loads(val)
+        key = f"{_DISPATCH_JOB_PREFIX}{head_sha}:{downstream_repo}"
+        raw = client.hgetall(key)
+        return [json.loads(v) for v in raw.values()]
     except (RedisError, json.JSONDecodeError, TypeError):
-        logger.exception("get_dispatch_workflow: failed")
-        return None
+        logger.exception("get_dispatch_jobs: failed")
+        return []
 
 
 def mark_check_run_wanted(

--- a/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
@@ -203,9 +203,7 @@ def _handle_pr_labeled(config: RelayConfig, payload: dict) -> dict:
                     ),
                     head_sha=head_sha,
                     status=job_status,
-                    conclusion=(
-                        job_conclusion if job_status == "completed" else None
-                    ),
+                    conclusion=(job_conclusion if job_status == "completed" else None),
                     details_url=details_url,
                     external_id=str(run_id),
                     output=gh_helper.build_check_run_output(
@@ -258,8 +256,10 @@ def _is_run_already_running(exc: Exception) -> bool:
 def _handle_check_run_rerequested(config: RelayConfig, payload: dict) -> dict:
     """Re-run a downstream run's failed jobs when its check run is re-requested.
 
-    The downstream run_id is stored as the check run's ``external_id``. Clicking
-    re-run on one check re-runs all failed jobs of that workflow run.
+    GitHub sends ``check_run`` ``rerequested`` for the "Re-run failed checks"
+    button (one per failed check) and for a single check's own "Re-run", so this
+    re-runs the failed jobs of that check's workflow run. The downstream run_id
+    is stored as the check run's ``external_id``.
     """
     check_run = payload.get("check_run") or {}
     name = check_run.get("name", "")
@@ -311,12 +311,17 @@ def _handle_check_run_rerequested(config: RelayConfig, payload: dict) -> dict:
 
 
 def _handle_check_suite_rerequested(config: RelayConfig, payload: dict) -> dict:
-    """Re-run the failed jobs of every downstream run in the re-requested suite.
+    """Re-run every downstream run in the re-requested suite (all jobs).
+
+    GitHub sends ``check_suite`` ``rerequested`` only for the "Re-run all checks"
+    button (the "Re-run failed checks" button instead sends a ``check_run``
+    ``rerequested`` per failed check). So this reruns *all* jobs of each run via
+    the run-level rerun endpoint, including ones that already succeeded.
 
     The CRCR app owns a single suite per commit, so listing that suite yields
     every check run it created; each carries its downstream run_id in
     ``external_id``. Check runs of the same run share a run_id, so we dedupe by
-    (repo, run_id) and issue one run-level rerun-failed-jobs per distinct run.
+    (repo, run_id) and issue one run-level rerun per distinct run.
     """
     check_suite = payload.get("check_suite") or {}
     suite_id = check_suite.get("id")
@@ -359,7 +364,7 @@ def _handle_check_suite_rerequested(config: RelayConfig, payload: dict) -> dict:
                     downstream_repo,
                 )
                 tokens[downstream_repo] = token
-            gh_helper.rerun_failed_jobs(
+            gh_helper.rerun_workflow_run(
                 token=token, repo_full_name=downstream_repo, run_id=int(run_id)
             )
             rerun.append(downstream_repo)

--- a/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
@@ -233,10 +233,128 @@ def _handle_pr_labeled(config: RelayConfig, payload: dict) -> dict:
     return {"ok": True, "created_check_runs": created}
 
 
+def _downstream_repo_from_check_run(name: str) -> str | None:
+    """Parse the downstream ``owner/repo`` out of a check run name.
+
+    Check runs are named ``crcr/<owner>/<repo>/<workflow_name>`` (see
+    ``gh_helper.check_run_name``), so the downstream repo is the first two
+    path segments after the ``crcr/`` prefix. Returns None for any name the
+    relay didn't create.
+    """
+    prefix = "crcr/"
+    if not name.startswith(prefix):
+        return None
+    parts = name[len(prefix) :].split("/")
+    if len(parts) < 3 or not parts[0] or not parts[1]:
+        return None
+    return f"{parts[0]}/{parts[1]}"
+
+
+def _rerun_downstream_workflow(
+    config: RelayConfig, downstream_repo: str, run_id: str
+) -> None:
+    """Re-trigger a downstream workflow run by its run_id.
+
+    The run_id is stored as the upstream check run's ``external_id`` when the
+    check run is created, so a re-request can locate the original downstream run.
+    """
+    token = gh_helper.get_repo_access_token(
+        config.github_app_id,
+        config.github_app_private_key,
+        downstream_repo,
+    )
+    gh_helper.rerun_workflow(
+        token=token,
+        repo_full_name=downstream_repo,
+        run_id=int(run_id),
+    )
+
+
+def _handle_check_run_rerequested(config: RelayConfig, payload: dict) -> dict:
+    """Re-run a single downstream workflow when its upstream check run is re-requested."""
+    check_run = payload.get("check_run") or {}
+    name = check_run.get("name", "")
+    external_id = check_run.get("external_id") or ""
+    downstream_repo = _downstream_repo_from_check_run(name)
+    if not downstream_repo or not external_id:
+        return {"ignored": True, "reason": "not a crcr check run"}
+
+    allowlist = load_allowlist(config)
+    level = allowlist.get_repo_level(downstream_repo)
+    if level is None or level.value < AllowlistLevel.L3.value:
+        return {"ignored": True, "reason": "downstream repo not L3+"}
+
+    try:
+        _rerun_downstream_workflow(config, downstream_repo, external_id)
+    except Exception as e:
+        logger.exception(
+            "check_run rerequested: rerun failed repo=%s run_id=%s",
+            downstream_repo,
+            external_id,
+        )
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "message": "failed to rerun downstream workflow",
+                "repo": downstream_repo,
+                "error": str(e),
+            },
+        ) from e
+
+    logger.info(
+        "check_run rerequested: re-triggered repo=%s run_id=%s",
+        downstream_repo,
+        external_id,
+    )
+    return {"ok": True, "rerun": [downstream_repo]}
+
+
+def _handle_check_suite_rerequested(config: RelayConfig, payload: dict) -> dict:
+    """Re-run every downstream workflow whose check run is in a re-requested check suite."""
+    check_suite = payload.get("check_suite") or {}
+    head_sha = check_suite.get("head_sha", "")
+    if not head_sha:
+        return {"ignored": True, "reason": "missing head_sha"}
+
+    allowlist = load_allowlist(config)
+    repos, _ = allowlist.get_repos_at_or_above_level(AllowlistLevel.L3)
+    rerun: list[str] = []
+    for downstream_repo in repos:
+        job_info = redis_helper.get_dispatch_workflow(config, head_sha, downstream_repo)
+        run_id = (job_info or {}).get("run_id")
+        if not run_id:
+            continue
+        try:
+            _rerun_downstream_workflow(config, downstream_repo, run_id)
+            rerun.append(downstream_repo)
+        except Exception:
+            logger.exception(
+                "check_suite rerequested: rerun failed repo=%s run_id=%s",
+                downstream_repo,
+                run_id,
+            )
+
+    logger.info(
+        "check_suite rerequested: re-triggered repos=%s sha=%s", rerun, head_sha
+    )
+    return {"ok": True, "rerun": rerun}
+
+
 def handle(
     config: RelayConfig, payload: dict, event_type: str, delivery_id: str
 ) -> dict:
-    if event_type == "pull_request":
+    # Re-run requests for upstream check runs do not go through the dispatch
+    # path; they re-trigger the existing downstream run, which re-reports via the
+    # normal callback flow.
+    if event_type == "check_run":
+        if payload.get("action") == "rerequested":
+            return _handle_check_run_rerequested(config, payload)
+        return {"ignored": True}
+    elif event_type == "check_suite":
+        if payload.get("action") == "rerequested":
+            return _handle_check_suite_rerequested(config, payload)
+        return {"ignored": True}
+    elif event_type == "pull_request":
         action = payload.get("action", "")
         if action == "labeled":
             label_name = (payload.get("label") or {}).get("name", "")

--- a/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
@@ -13,6 +13,7 @@ from utils.misc import (
     DISPATCH_RUN_ATTEMPT,
     DISPATCH_RUN_ID,
     EventDispatchPayload,
+    extract_pr_labels,
     HTTPException,
 )
 
@@ -27,6 +28,7 @@ def _dispatch_one(
     downstream_repo: str,
     event_type: str,
     client_payload: EventDispatchPayload,
+    needs_check_run: bool = False,
 ) -> None:
     installation_token = gh_helper.get_repo_access_token(
         config.github_app_id,
@@ -54,6 +56,20 @@ def _dispatch_one(
         time.time(),
     )
 
+    if needs_check_run:
+        # This repo should get an upstream check run for this commit (L4 always,
+        # or L3 with the ciflow/crcr label already on the PR). Record a per-commit
+        # flag so the callback creates it even when the downstream echoes back a
+        # dispatch payload whose labels don't reflect the PR's current state
+        # (e.g. on reopen, where no new `labeled` event fires to set this flag).
+        head_sha = (
+            ((client_payload.get("payload") or {}).get("pull_request") or {})
+            .get("head", {})
+            .get("sha", "")
+        )
+        if head_sha:
+            redis_helper.mark_check_run_wanted(config, head_sha, downstream_repo)
+
 
 def _dispatch_to_allowlist(
     *,
@@ -70,6 +86,11 @@ def _dispatch_to_allowlist(
 
     targets = sorted(backends)
 
+    # Labels from the dispatch payload, used to record a per-commit check-run
+    # trigger for L3 repos whose ciflow/crcr label is already on the PR (so the
+    # callback can create the check run regardless of the downstream's echo).
+    pr_labels = extract_pr_labels(client_payload)
+
     dispatched: list[dict] = []
     failed: list[dict] = []
     # Dispatch is I/O bound on GitHub API calls, so cap workers by the number
@@ -83,6 +104,7 @@ def _dispatch_to_allowlist(
                 downstream_repo=downstream_repo,
                 event_type=event_type,
                 client_payload=client_payload,
+                needs_check_run=allowlist.needs_check_run(downstream_repo, pr_labels),
             ): downstream_repo
             for downstream_repo in targets
         }
@@ -113,12 +135,107 @@ def _dispatch_to_allowlist(
     return dispatched, failed
 
 
+def _handle_pr_labeled(config: RelayConfig, payload: dict) -> dict:
+    """Handle pull_request.labeled for ciflow/crcr/* labels.
+
+    - No job info yet: mark the check run as wanted so the callback creates it
+      when it fires (handles label-added-before-callback and label-before-dispatch).
+    - in_progress job: create in_progress check run with workflow name and link.
+    - completed job: create completed check run directly.
+    """
+    label_name = (payload.get("label") or {}).get("name", "")
+    device = label_name.removeprefix("ciflow/crcr/")
+
+    allowlist = load_allowlist(config)
+    l3_repos, _ = allowlist.get_repos_for_device(device)
+    if not l3_repos:
+        return {"ok": True, "created_check_runs": []}
+
+    pr = payload.get("pull_request") or {}
+    pr_number = str(pr.get("number", ""))
+    head_sha = (pr.get("head") or {}).get("sha", "")
+    if not pr_number or not head_sha:
+        return {"ignored": True, "reason": "missing pr context"}
+
+    created: list[str] = []
+    for downstream_repo in l3_repos:
+        redis_helper.mark_check_run_wanted(config, head_sha, downstream_repo)
+        job_info = redis_helper.get_dispatch_workflow(config, head_sha, downstream_repo)
+        if not job_info:
+            logger.info(
+                "l3_labeled: no job info for repo=%s; check run marked wanted for callback",
+                downstream_repo,
+            )
+            continue
+
+        try:
+            upstream_token = gh_helper.get_repo_access_token(
+                config.github_app_id,
+                config.github_app_private_key,
+                config.upstream_repo,
+            )
+
+            job_status = job_info.get("status")
+            job_conclusion = job_info.get("conclusion")
+            workflow_name = job_info.get("workflow_name")
+            external_id = job_info.get("run_id")  # opaque run identifier
+            details_url = job_info.get("job_url")  # full URL for the link
+
+            if job_status == "in_progress":
+                gh_helper.create_check_run(
+                    token=upstream_token,
+                    repo_full_name=config.upstream_repo,
+                    name=gh_helper.check_run_name(downstream_repo, workflow_name),
+                    head_sha=head_sha,
+                    status="in_progress",
+                    details_url=details_url,
+                    external_id=external_id,
+                    output=gh_helper.build_check_run_output(
+                        workflow_name, details_url, downstream_repo
+                    ),
+                )
+            elif job_status == "completed":
+                gh_helper.create_check_run(
+                    token=upstream_token,
+                    repo_full_name=config.upstream_repo,
+                    name=gh_helper.check_run_name(downstream_repo, workflow_name),
+                    head_sha=head_sha,
+                    status="completed",
+                    conclusion=job_conclusion,
+                    details_url=details_url,
+                    external_id=external_id,
+                    output=gh_helper.build_check_run_output(
+                        workflow_name, details_url, downstream_repo
+                    ),
+                )
+            else:
+                continue
+
+            created.append(downstream_repo)
+            logger.info(
+                "l3_labeled: check run created repo=%s status=%s",
+                downstream_repo,
+                job_status,
+            )
+        except Exception:
+            logger.exception(
+                "l3_labeled: failed to create check run for repo=%s", downstream_repo
+            )
+
+    return {"ok": True, "created_check_runs": created}
+
+
 def handle(
     config: RelayConfig, payload: dict, event_type: str, delivery_id: str
 ) -> dict:
     if event_type == "pull_request":
         action = payload.get("action", "")
-        if action not in _PULL_REQUEST_ALLOW_ACTIONS:
+        if action == "labeled":
+            label_name = (payload.get("label") or {}).get("name", "")
+            if label_name.startswith("ciflow/crcr/"):
+                return _handle_pr_labeled(config, payload)
+            return {"ignored": True}
+        elif action not in _PULL_REQUEST_ALLOW_ACTIONS:
             logger.info("pull_request action=%s ignored", action)
             return {"ignored": True}
 

--- a/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
@@ -158,6 +158,13 @@ def _handle_pr_labeled(config: RelayConfig, payload: dict) -> dict:
         return {"ignored": True, "reason": "missing pr context"}
 
     created: list[str] = []
+
+    # Minted lazily on the first repo that needs a check run, then reused: the
+    # token is always for config.upstream_repo, so it's shared across all repos
+    # under this device. A mint failure fails identically for every repo, so it
+    # is left to propagate rather than retried per-iteration.
+    upstream_token: str | None = None
+
     for downstream_repo in l3_repos:
         redis_helper.mark_check_run_wanted(config, head_sha, downstream_repo)
         job_info = redis_helper.get_dispatch_workflow(config, head_sha, downstream_repo)
@@ -168,13 +175,14 @@ def _handle_pr_labeled(config: RelayConfig, payload: dict) -> dict:
             )
             continue
 
-        try:
+        if upstream_token is None:
             upstream_token = gh_helper.get_repo_access_token(
                 config.github_app_id,
                 config.github_app_private_key,
                 config.upstream_repo,
             )
 
+        try:
             job_status = job_info.get("status")
             job_conclusion = job_info.get("conclusion")
             workflow_name = job_info.get("workflow_name")

--- a/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
@@ -186,7 +186,7 @@ def _handle_pr_labeled(config: RelayConfig, payload: dict) -> dict:
             job_status = job_info.get("status")
             job_conclusion = job_info.get("conclusion")
             workflow_name = job_info.get("workflow_name")
-            external_id = job_info.get("run_id")  # opaque run identifier
+            external_id = str(job_info.get("run_id"))  # opaque run identifier
             details_url = job_info.get("job_url")  # full URL for the link
 
             if job_status == "in_progress":

--- a/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
@@ -199,7 +199,7 @@ def _handle_pr_labeled(config: RelayConfig, payload: dict) -> dict:
                     details_url=details_url,
                     external_id=external_id,
                     output=gh_helper.build_check_run_output(
-                        workflow_name, details_url, downstream_repo
+                        "in_progress", None, details_url, downstream_repo
                     ),
                 )
             elif job_status == "completed":
@@ -213,7 +213,7 @@ def _handle_pr_labeled(config: RelayConfig, payload: dict) -> dict:
                     details_url=details_url,
                     external_id=external_id,
                     output=gh_helper.build_check_run_output(
-                        workflow_name, details_url, downstream_repo
+                        "completed", job_conclusion, details_url, downstream_repo
                     ),
                 )
             else:

--- a/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
@@ -167,8 +167,10 @@ def _handle_pr_labeled(config: RelayConfig, payload: dict) -> dict:
 
     for downstream_repo in l3_repos:
         redis_helper.mark_check_run_wanted(config, head_sha, downstream_repo)
-        job_info = redis_helper.get_dispatch_workflow(config, head_sha, downstream_repo)
-        if not job_info:
+        # Every job that has already reported gets its own backfilled check run,
+        # so a multi-job / matrix workflow is not collapsed to a single job.
+        jobs = redis_helper.get_dispatch_jobs(config, head_sha, downstream_repo)
+        if not jobs:
             logger.info(
                 "l3_labeled: no job info for repo=%s; check run marked wanted for callback",
                 downstream_repo,
@@ -182,53 +184,47 @@ def _handle_pr_labeled(config: RelayConfig, payload: dict) -> dict:
                 config.upstream_repo,
             )
 
-        try:
+        for job_info in jobs:
             job_status = job_info.get("status")
-            job_conclusion = job_info.get("conclusion")
-            workflow_name = job_info.get("workflow_name")
-            external_id = str(job_info.get("run_id"))  # opaque run identifier
-            details_url = job_info.get("job_url")  # full URL for the link
-
-            if job_status == "in_progress":
-                gh_helper.create_check_run(
-                    token=upstream_token,
-                    repo_full_name=config.upstream_repo,
-                    name=gh_helper.check_run_name(downstream_repo, workflow_name),
-                    head_sha=head_sha,
-                    status="in_progress",
-                    details_url=details_url,
-                    external_id=external_id,
-                    output=gh_helper.build_check_run_output(
-                        "in_progress", None, details_url, downstream_repo
-                    ),
-                )
-            elif job_status == "completed":
-                gh_helper.create_check_run(
-                    token=upstream_token,
-                    repo_full_name=config.upstream_repo,
-                    name=gh_helper.check_run_name(downstream_repo, workflow_name),
-                    head_sha=head_sha,
-                    status="completed",
-                    conclusion=job_conclusion,
-                    details_url=details_url,
-                    external_id=external_id,
-                    output=gh_helper.build_check_run_output(
-                        "completed", job_conclusion, details_url, downstream_repo
-                    ),
-                )
-            else:
+            if job_status not in ("in_progress", "completed"):
                 continue
+            job_name = job_info.get("job_name")  # disambiguates jobs in one run
+            try:
+                job_conclusion = job_info.get("conclusion")
+                workflow_name = job_info.get("workflow_name")
+                run_id = job_info.get("run_id")  # stored on the CR for re-runs
+                details_url = job_info.get("job_url")  # full URL for the link
 
-            created.append(downstream_repo)
-            logger.info(
-                "l3_labeled: check run created repo=%s status=%s",
-                downstream_repo,
-                job_status,
-            )
-        except Exception:
-            logger.exception(
-                "l3_labeled: failed to create check run for repo=%s", downstream_repo
-            )
+                gh_helper.create_check_run(
+                    token=upstream_token,
+                    repo_full_name=config.upstream_repo,
+                    name=gh_helper.check_run_name(
+                        downstream_repo, workflow_name, job_name
+                    ),
+                    head_sha=head_sha,
+                    status=job_status,
+                    conclusion=(
+                        job_conclusion if job_status == "completed" else None
+                    ),
+                    details_url=details_url,
+                    external_id=str(run_id),
+                    output=gh_helper.build_check_run_output(
+                        job_status, job_conclusion, details_url, downstream_repo
+                    ),
+                )
+                created.append(f"{downstream_repo}/{job_name}")
+                logger.info(
+                    "l3_labeled: check run created repo=%s job=%s status=%s",
+                    downstream_repo,
+                    job_name,
+                    job_status,
+                )
+            except Exception:
+                logger.exception(
+                    "l3_labeled: failed to create check run for repo=%s job=%s",
+                    downstream_repo,
+                    job_name,
+                )
 
     return {"ok": True, "created_check_runs": created}
 
@@ -236,7 +232,7 @@ def _handle_pr_labeled(config: RelayConfig, payload: dict) -> dict:
 def _downstream_repo_from_check_run(name: str) -> str | None:
     """Parse the downstream ``owner/repo`` out of a check run name.
 
-    Check runs are named ``crcr/<owner>/<repo>/<workflow_name>`` (see
+    Check runs are named ``crcr/<owner>/<repo>/<workflow_name>/<job_name>`` (see
     ``gh_helper.check_run_name``), so the downstream repo is the first two
     path segments after the ``crcr/`` prefix. Returns None for any name the
     relay didn't create.
@@ -250,33 +246,26 @@ def _downstream_repo_from_check_run(name: str) -> str | None:
     return f"{parts[0]}/{parts[1]}"
 
 
-def _rerun_downstream_workflow(
-    config: RelayConfig, downstream_repo: str, run_id: str
-) -> None:
-    """Re-trigger a downstream workflow run by its run_id.
+def _is_run_already_running(exc: Exception) -> bool:
+    """True for GitHub's 403 "workflow run ... is already running".
 
-    The run_id is stored as the upstream check run's ``external_id`` when the
-    check run is created, so a re-request can locate the original downstream run.
+    A benign, transient outcome (the run is already re-running), not a failure
+    to surface — re-running it again is impossible until it finishes.
     """
-    token = gh_helper.get_repo_access_token(
-        config.github_app_id,
-        config.github_app_private_key,
-        downstream_repo,
-    )
-    gh_helper.rerun_workflow(
-        token=token,
-        repo_full_name=downstream_repo,
-        run_id=int(run_id),
-    )
+    return "already running" in str(exc).lower()
 
 
 def _handle_check_run_rerequested(config: RelayConfig, payload: dict) -> dict:
-    """Re-run a single downstream workflow when its upstream check run is re-requested."""
+    """Re-run a downstream run's failed jobs when its check run is re-requested.
+
+    The downstream run_id is stored as the check run's ``external_id``. Clicking
+    re-run on one check re-runs all failed jobs of that workflow run.
+    """
     check_run = payload.get("check_run") or {}
     name = check_run.get("name", "")
-    external_id = check_run.get("external_id") or ""
+    run_id = check_run.get("external_id") or ""
     downstream_repo = _downstream_repo_from_check_run(name)
-    if not downstream_repo or not external_id:
+    if not downstream_repo or not run_id:
         return {"ignored": True, "reason": "not a crcr check run"}
 
     allowlist = load_allowlist(config)
@@ -284,50 +273,104 @@ def _handle_check_run_rerequested(config: RelayConfig, payload: dict) -> dict:
     if level is None or level.value < AllowlistLevel.L3.value:
         return {"ignored": True, "reason": "downstream repo not L3+"}
 
+    token = gh_helper.get_repo_access_token(
+        config.github_app_id, config.github_app_private_key, downstream_repo
+    )
     try:
-        _rerun_downstream_workflow(config, downstream_repo, external_id)
+        gh_helper.rerun_failed_jobs(
+            token=token, repo_full_name=downstream_repo, run_id=int(run_id)
+        )
     except Exception as e:
+        if _is_run_already_running(e):
+            logger.info(
+                "check_run rerequested: run already running repo=%s run_id=%s",
+                downstream_repo,
+                run_id,
+            )
+            return {"ok": True, "rerun": [], "already_running": True}
         logger.exception(
             "check_run rerequested: rerun failed repo=%s run_id=%s",
             downstream_repo,
-            external_id,
+            run_id,
         )
         raise HTTPException(
             status_code=502,
             detail={
-                "message": "failed to rerun downstream workflow",
+                "message": "failed to rerun downstream run",
                 "repo": downstream_repo,
                 "error": str(e),
             },
         ) from e
 
     logger.info(
-        "check_run rerequested: re-triggered repo=%s run_id=%s",
+        "check_run rerequested: re-ran failed jobs repo=%s run_id=%s",
         downstream_repo,
-        external_id,
+        run_id,
     )
     return {"ok": True, "rerun": [downstream_repo]}
 
 
 def _handle_check_suite_rerequested(config: RelayConfig, payload: dict) -> dict:
-    """Re-run every downstream workflow whose check run is in a re-requested check suite."""
+    """Re-run the failed jobs of every downstream run in the re-requested suite.
+
+    The CRCR app owns a single suite per commit, so listing that suite yields
+    every check run it created; each carries its downstream run_id in
+    ``external_id``. Check runs of the same run share a run_id, so we dedupe by
+    (repo, run_id) and issue one run-level rerun-failed-jobs per distinct run.
+    """
     check_suite = payload.get("check_suite") or {}
-    head_sha = check_suite.get("head_sha", "")
-    if not head_sha:
-        return {"ignored": True, "reason": "missing head_sha"}
+    suite_id = check_suite.get("id")
+    if not suite_id:
+        return {"ignored": True, "reason": "missing check_suite id"}
+
+    upstream_token = gh_helper.get_repo_access_token(
+        config.github_app_id,
+        config.github_app_private_key,
+        config.upstream_repo,
+    )
+    check_runs = gh_helper.list_check_runs_in_suite(
+        token=upstream_token,
+        repo_full_name=config.upstream_repo,
+        check_suite_id=suite_id,
+    )
 
     allowlist = load_allowlist(config)
-    repos, _ = allowlist.get_repos_at_or_above_level(AllowlistLevel.L3)
+    # One installation token per downstream repo, reused across its runs.
+    tokens: dict[str, str] = {}
+    seen: set[tuple[str, str]] = set()
     rerun: list[str] = []
-    for downstream_repo in repos:
-        job_info = redis_helper.get_dispatch_workflow(config, head_sha, downstream_repo)
-        run_id = (job_info or {}).get("run_id")
-        if not run_id:
+    for check_run in check_runs:
+        downstream_repo = _downstream_repo_from_check_run(check_run.get("name", ""))
+        run_id = check_run.get("external_id") or ""
+        if not downstream_repo or not run_id:
+            continue
+        if (downstream_repo, run_id) in seen:
+            continue
+        seen.add((downstream_repo, run_id))
+        level = allowlist.get_repo_level(downstream_repo)
+        if level is None or level.value < AllowlistLevel.L3.value:
             continue
         try:
-            _rerun_downstream_workflow(config, downstream_repo, run_id)
+            token = tokens.get(downstream_repo)
+            if token is None:
+                token = gh_helper.get_repo_access_token(
+                    config.github_app_id,
+                    config.github_app_private_key,
+                    downstream_repo,
+                )
+                tokens[downstream_repo] = token
+            gh_helper.rerun_failed_jobs(
+                token=token, repo_full_name=downstream_repo, run_id=int(run_id)
+            )
             rerun.append(downstream_repo)
-        except Exception:
+        except Exception as e:
+            if _is_run_already_running(e):
+                logger.info(
+                    "check_suite rerequested: run already running repo=%s run_id=%s",
+                    downstream_repo,
+                    run_id,
+                )
+                continue
             logger.exception(
                 "check_suite rerequested: rerun failed repo=%s run_id=%s",
                 downstream_repo,
@@ -335,7 +378,7 @@ def _handle_check_suite_rerequested(config: RelayConfig, payload: dict) -> dict:
             )
 
     logger.info(
-        "check_suite rerequested: re-triggered repos=%s sha=%s", rerun, head_sha
+        "check_suite rerequested: re-ran %d run(s) suite_id=%s", len(rerun), suite_id
     )
     return {"ok": True, "rerun": rerun}
 

--- a/aws/lambda/cross_repo_ci_relay/webhook/lambda_function.py
+++ b/aws/lambda/cross_repo_ci_relay/webhook/lambda_function.py
@@ -25,7 +25,7 @@ def _verify_signature(secret: str, body: bytes, signature: str) -> None:
         raise HTTPException(status_code=401, detail="Bad signature")
 
 
-_SUPPORTED_EVENTS = frozenset({"pull_request", "push"})
+_SUPPORTED_EVENTS = frozenset({"pull_request", "push", "check_run", "check_suite"})
 
 
 def lambda_handler(event, context):


### PR DESCRIPTION
# Summary

- The current implementation focuses on L3/L4 levels defined in the RFC: https://github.com/pytorch/rfcs/pull/90
- For detailed design for L3/L4, please refer to https://github.com/pytorch/rfcs/pull/93

# Architecture

- `webhook` function:
  - [x] Create PR label handling function for L3 repo (refer to the 3 scenario cases mentioned in https://github.com/pytorch/rfcs/pull/93)
    - **Scenario 1**: Label arrives before the downstream workflow job is triggered. So we cached this information in Redis using `mark_check_run_wanted` and let the `callback` lambda create this check run.
    - **Scenario 2**: Label arrives during the downstream workflow job is running. The `callback` lambda will cache workflow information beforehand so it can immediately create the `in_progress` check run.
    - **Scenario 3**: Label arrives after the downstream workflow job is done. If the cached workflow information is still alive in Redis (3 days by default, could be set by `CRCR_STATUS_TTL`), it will create a `completed` check run immediately. Otherwise, it will not create a check run.
  - [x] Dispatch function will check for L3 label or L4, and store this information in Redis for the `callback` to check whether a check run is needed.
  - [x] Create check run and check suite handling functions for the downstream workflow jobs re-run mechanism within the check run.
- `callback` function:
  - [x] Handle upstream check-run creation/update for L3/L4
    - **Scenario 1 & L4**: Check in Redis by calling `is_check_run_wanted` to see if this PR needs a check run. If so, immediately create one.
    - **All Scenarios**: Store workflow information in Redis for check run creation in the `webhook`.
  - [x] Set "in_progress" zombie check-runs to "time_out" through a sweeper periodically

# Changes
```md
.github/actions/cross-repo-ci-relay
└── action.yml                     # Add a step to capture job-name for re-run
aws/lambda/cross_repo_ci_relay/
├── tests/                         # Add more unit tests
├── allowlist.py                   # Update utils function for L3
├── redis_helper.py                # Set more keys for L3
├── gh_helper.py                   # Update utils function for L3
├── misc.py                        # Update utils function for L3
├── event_handler.py               # Create PR label/check run/check suites handling function
├── cleanup_handler.py             # Handle zombie check-run
└── callback_handler.py            # Handle upstream check-run creation
```

# Verification

We performed the following scenario verification on our AWS Lambda instance:

- L3:
  - [x] L3 labels named `ciflow/crcr/{device}` are added immediately after the PR is created, and show up in the corresponding check-run on the PR with the name `crcr/{repo}/{workflow_name}/{job_name}`.
  - [x] After clicking into the check-run, the corresponding information is correct.
  - [x] L3 labels are added while the workflow job is running, which should show up the `in_progress` check-run.
  - [x] L3 labels are added after the workflow job is done, which should show up the `completed` check-run.
  - [x] Check run is updated when the PR with L3 labels is reopened or synchronized.
 
- L4:
  - [x] Check run should be created after the PR is opened.
  - [x] Check run is updated when the PR is reopened or synchronized.

- Re-run
  - [x] Clicking the `Re-run` button in each failed check run will trigger the corresponding downstream workflow failed jobs to re-run and update the check run status to `in_progress`.
  - [x] Clicking the `Re-run all jobs` or `Re-run all failed jobs` button will trigger the corresponding downstream workflow jobs in the check suite and update the corresponding check run status to `in_progress`.

# Unit Tests

- [x] Unit Tests (Mock)

# TODO

- Modify PyTorchBot for L3 non-blocking merge: https://github.com/pytorch/pytorch/pull/185612
- Add a new feature in PyTorchBot that automatically mentions related on-call maintainers in L3/L4 repos when check-run fails: https://github.com/pytorch/test-infra/pull/8183


cc @albanD @fffrog @KarhouTam @atalman @huydhn @zxiiro @subinz1 @jewelkm89 
