### PR TITLE
Fix build-pypi-cache workflow failing on PRs

### DIFF
--- a/.github/scripts/pypi_cache/build.py
+++ b/.github/scripts/pypi_cache/build.py
@@ -306,6 +306,7 @@ def main() -> None:
     script_dir = Path(__file__).resolve().parent
     cuda_dir = os.environ.get("CUDA_DIR", "")
     force_rebuild = os.environ.get("FORCE_REBUILD", "")
+    dry_run = os.environ.get("DRY_RUN", "").lower() in ("1", "true", "yes")
 
     wants_dir = BUILD_DIR / "wants"
     wheel_dir = BUILD_DIR / "wheels"
@@ -314,6 +315,9 @@ def main() -> None:
 
     BUILD_DIR.mkdir(parents=True, exist_ok=True)
     FAILURE_SUMMARY_PATH.write_text("")
+
+    if dry_run:
+        print("==> DRY RUN: wheels will be built but not uploaded to S3")
 
     try:
         # Step 1: CUDA
@@ -392,7 +396,8 @@ def main() -> None:
 
                 for whl in sorted(out.glob("*.whl")):
                     whl = repair_if_needed(whl, script_dir, BUILD_DIR)
-                    upload_wheel(whl, s3_bucket, variant)
+                    if not dry_run:
+                        upload_wheel(whl, s3_bucket, variant)
                     existing_wheels.append(whl.name)
                     built += 1
 

--- a/.github/scripts/pypi_cache/build.py
+++ b/.github/scripts/pypi_cache/build.py
@@ -154,11 +154,17 @@ def run_cmd(
     )
 
 
+def _no_sign() -> bool:
+    return os.environ.get("AWS_NO_SIGN_REQUEST", "").lower() in ("1", "true", "yes")
+
+
 def aws_s3_cp(src: str, dst: str, *, recursive: bool = False) -> None:
     """``aws s3 cp`` wrapper.  Raises on failure."""
     cmd = ["aws", "s3", "cp", src, dst]
     if recursive:
         cmd.append("--recursive")
+    if _no_sign():
+        cmd.append("--no-sign-request")
     run_cmd(cmd)
 
 
@@ -168,7 +174,10 @@ def aws_s3_ls(path: str) -> list[str]:
     Returns an empty list when the prefix does not exist or the command
     fails (mirrors the ``|| true`` in the original bash).
     """
-    result = run_cmd(["aws", "s3", "ls", path], check=False, capture=True)
+    cmd = ["aws", "s3", "ls", path]
+    if _no_sign():
+        cmd.append("--no-sign-request")
+    result = run_cmd(cmd, check=False, capture=True)
     if result.returncode != 0:
         return []
     names: list[str] = []

--- a/.github/workflows/build-pypi-cache.yml
+++ b/.github/workflows/build-pypi-cache.yml
@@ -21,7 +21,6 @@ on:
         required: false
 
 concurrency:
-  # TODO: Remove pr-specific concurrency key before merging
   group: ${{ github.event_name == 'pull_request' && format('pypi-cache-pr-{0}', github.event.pull_request.number) || 'pypi-cache-build' }}
   cancel-in-progress: false
 
@@ -81,6 +80,7 @@ jobs:
           echo "/opt/python/cp312-cp312/bin" >> "${GITHUB_PATH}"
 
       - name: Configure AWS credentials
+        if: github.event_name != 'pull_request'
         uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
         with:
           role-to-assume: ${{ env.AWS_ROLE }}
@@ -94,6 +94,8 @@ jobs:
           CUDA_DIR: ${{ matrix.cuda_dir }}
           FORCE_REBUILD: ${{ inputs.force_rebuild }}
           MANYWHEEL_VERSION: ${{ inputs.manywheel_version || '2_28' }}
+          DRY_RUN: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          AWS_NO_SIGN_REQUEST: ${{ github.event_name == 'pull_request' && 'true' || '' }}
         run: python3 .github/scripts/pypi_cache/build.py
 
       - name: Build failure summary

--- a/.github/workflows/build-pypi-cache.yml
+++ b/.github/workflows/build-pypi-cache.yml
@@ -94,7 +94,7 @@ jobs:
           CUDA_DIR: ${{ matrix.cuda_dir }}
           FORCE_REBUILD: ${{ inputs.force_rebuild }}
           MANYWHEEL_VERSION: ${{ inputs.manywheel_version || '2_28' }}
-          DRY_RUN: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          DRY_RUN: ${{ github.event_name == 'pull_request' && 'true' || '' }}
           AWS_NO_SIGN_REQUEST: ${{ github.event_name == 'pull_request' && 'true' || '' }}
         run: python3 .github/scripts/pypi_cache/build.py
 


### PR DESCRIPTION
Previously failing on PRs with messages such as [the following](https://github.com/pytorch/test-infra/actions/runs/25676525224/job/75375922473):
```
It looks like you might be trying to authenticate with OIDC. Did you mean to set the `id-token` permission? If you are not trying to authenticate with OIDC and the action is working successfully, you can ignore this message.
Error: Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers
Error: [OSDC] Step script exited with code 1. This is a script/workflow error, not an infrastructure issue. Check the step logs above for the actual failure.
```
Since the S3 bucket (pytorch-pypi-wheel-cache) already has a public bucket policy granting GetObject and ListBucket to all principals, PR runs can read the wants list and existing wheel listing without credentials. This change:

- Skips the Configure AWS credentials step on PRs
- Sets `--no-sign-request` to ensure credentials aren't required given bucket permissions
- Adds DRY_RUN support to build.py to skip S3 uploads on PRs

The full build pipeline (download wants, check existing wheels, build, manylinux repair) still runs on PRs — only the upload is skipped.