### PR TITLE
Update job from 3.9 to 3.10

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -92,7 +92,7 @@ runs:
         uses: conda-incubator/setup-miniconda@v3.1.1
         with:
           miniconda-version: "latest"
-          python-version: 3.9
+          python-version: "3.10"
       - name: Clean conda environment
         shell: bash -l {0}
         run: |
@@ -113,7 +113,7 @@ runs:
           conda create \
             --yes --quiet \
             --prefix "${CONDA_ENV}" \
-            "python=3.9" pip
+            "python=3.10" pip
           CONDA_ENV="${CONDA_ENV}"
           CONDA_RUN="conda run --no-capture-output -p ${CONDA_ENV}"
           ${CONDA_RUN} python -m pip install ${GITHUB_WORKSPACE}/test-infra/tools/pkg-helpers

--- a/.github/workflows/test_linux_job.yml
+++ b/.github/workflows/test_linux_job.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         runner_type: ["linux.g5.4xlarge.nvidia.gpu"]
     with:
-      job-name: "linux-py3.9-cu121"
+      job-name: "linux-py3.10-cu121"
       runner: ${{ matrix.runner_type }}
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
@@ -52,7 +52,7 @@ jobs:
       script: |
         nvidia-smi
         nvcc --version | grep "cuda_12.1"
-        conda create --yes --quiet -n test python=3.9
+        conda create --yes --quiet -n test python=3.10
         conda activate test
         python3 -m pip install --index-url https://download.pytorch.org/whl/nightly/cu121 --pre torch
         # Can import pytorch, cuda is available
@@ -65,7 +65,7 @@ jobs:
       matrix:
         runner_type: ["linux.aws.a100"]
     with:
-      job-name: "linux-py3.9-cu121-container"
+      job-name: "linux-py3.10-cu121-container"
       runner: ${{ matrix.runner_type }}
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
@@ -76,7 +76,7 @@ jobs:
       script: |
         nvidia-smi
         nvcc --version | grep "cuda_12.1"
-        conda create --yes --quiet -n test python=3.9
+        conda create --yes --quiet -n test python=3.10
         conda activate test
         python3 -m pip install --index-url https://download.pytorch.org/whl/nightly/cu121 --pre torch
         # Can import pytorch, cuda is available
@@ -164,7 +164,7 @@ jobs:
     uses: ./.github/workflows/linux_job.yml
     strategy:
       matrix:
-        python_version: ["3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.10", "3.11", "3.12"]
     with:
       runner: linux.2xlarge
       test-infra-repository: ${{ github.repository }}

--- a/.github/workflows/test_linux_job_v2.yml
+++ b/.github/workflows/test_linux_job_v2.yml
@@ -63,7 +63,7 @@ jobs:
       matrix:
         runner_type: ["linux.aws.a100"]
     with:
-      job-name: "linux-py3.9-cu121-container"
+      job-name: "linux-py3.10-cu121-container"
       runner: ${{ matrix.runner_type }}
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
@@ -74,7 +74,7 @@ jobs:
       script: |
         nvidia-smi
         nvcc --version | grep "cuda_12.1"
-        conda create --yes --quiet -n test python=3.9
+        conda create --yes --quiet -n test python=3.10
         conda activate test
         python3 -m pip install --index-url https://download.pytorch.org/whl/nightly/cu121 --pre torch
         # Can import pytorch, cuda is available

--- a/.github/workflows/test_windows_job.yml
+++ b/.github/workflows/test_windows_job.yml
@@ -15,9 +15,9 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       submodules: "recursive"
-      job-name: "win-py3.9-cpu"
+      job-name: "win-py3.10-cpu"
       script: |
-        conda create --yes --quiet -n test python=3.9
+        conda create --yes --quiet -n test python=3.10
         conda activate test
         python -m pip install --index-url https://download.pytorch.org/whl/nightly/cpu --pre torch
         # Can import pytorch
@@ -29,10 +29,10 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       submodules: ${{ 'true' }}
-      job-name: "win-py3.9-cu118"
+      job-name: "win-py3.10-cu118"
       timeout: 60
       script: |
-        conda create --yes --quiet -n test python=3.9
+        conda create --yes --quiet -n test python=3.10
         conda activate test
         python -m pip install --index-url=https://download.pytorch.org/whl/nightly/cu118 --pre torch
         # Can import pytorch, cuda is available


### PR DESCRIPTION
TorchCodec CI is entirely broken ([example](https://github.com/meta-pytorch/torchcodec/actions/runs/26626629558/job/78464894361?pr=1459)), and I suspect other repos are broken too. The `setup-binary-builds` steps fail with:

```
  File "/__w/_temp/pytorch_pkg_helpers_26626629558/lib/python3.9/site-packages/pip/_internal/models/scheme.py", line 13, in <module>
    @dataclass(frozen=True, slots=True)
TypeError: dataclass() got an unexpected keyword argument 'slots'
ERROR conda.cli.main_run:execute(47): `conda run python -m pip install /__w/torchcodec/torchcodec/test-infra/tools/pkg-helpers` failed. (See above for error)
```

It's because `pip` was [recently updated on `conda`](https://anaconda.org/channels/anaconda/packages/pip/overview) and is `>3.10` only, but some of the jobs in `test-infra` are still relying on 3.9. This PR updates jobs to rely on 3.10 instead of 3.9.

Please feel free to commandeer the PR or close it with a better fix (I just want the TorchCodec CI to be back! :) )