### PR TITLE
Add [cuda/mac]_test_stats HUD page

### DIFF
--- a/torchci/clickhouse_queries/test_stats_per_commit/params.json
+++ b/torchci/clickhouse_queries/test_stats_per_commit/params.json
@@ -1,0 +1,18 @@
+{
+  "params": {
+    "repo": "String",
+    "ref": "String",
+    "workflow": "String",
+    "jobFilter": "String",
+    "count": "UInt32"
+  },
+  "tests": [
+    {
+      "repo": "pytorch/pytorch",
+      "ref": "refs/heads/main",
+      "workflow": "trunk",
+      "jobFilter": "(?i)macos",
+      "count": 5
+    }
+  ]
+}

--- a/torchci/clickhouse_queries/test_stats_per_commit/params.json
+++ b/torchci/clickhouse_queries/test_stats_per_commit/params.json
@@ -4,7 +4,8 @@
     "ref": "String",
     "workflow": "String",
     "jobFilter": "String",
-    "count": "UInt32"
+    "count": "UInt32",
+    "sha": "String"
   },
   "tests": [
     {
@@ -12,7 +13,8 @@
       "ref": "refs/heads/main",
       "workflow": "trunk",
       "jobFilter": "(?i)macos",
-      "count": 5
+      "count": 5,
+      "sha": ""
     }
   ]
 }

--- a/torchci/clickhouse_queries/test_stats_per_commit/query.sql
+++ b/torchci/clickhouse_queries/test_stats_per_commit/query.sql
@@ -13,7 +13,8 @@ WITH anchor_time AS (
             (
                 SELECT p.head_commit.timestamp
                 FROM default.push p
-                WHERE p.repository.full_name = {repo: String }
+                WHERE
+                    p.repository.full_name = {repo: String }
                     AND p.ref = {ref: String }
                     AND startsWith(p.head_commit.id, {sha: String })
                 ORDER BY p.head_commit.timestamp DESC
@@ -29,7 +30,8 @@ recent_commits AS (
         p.head_commit.author.name AS author,
         p.head_commit.timestamp AS time
     FROM default.push p
-    WHERE p.repository.full_name = {repo: String }
+    WHERE
+        p.repository.full_name = {repo: String }
         AND p.ref = {ref: String }
         AND p.head_commit.timestamp <= (SELECT ts FROM anchor_time)
     ORDER BY p.head_commit.timestamp DESC
@@ -41,12 +43,13 @@ matched_runs AS (
         wr.head_sha AS sha,
         min(wr.id) AS workflow_id
     FROM default.workflow_run wr FINAL
-    WHERE wr.id IN (
-        SELECT id FROM materialized_views.workflow_run_by_head_sha
-        WHERE head_sha IN (SELECT sha FROM recent_commits)
-    )
-    AND wr.name = {workflow: String }
-    AND wr.repository.full_name = {repo: String }
+    WHERE
+        wr.id IN (
+            SELECT id FROM materialized_views.workflow_run_by_head_sha
+            WHERE head_sha IN (SELECT sha FROM recent_commits)
+        )
+        AND wr.name = {workflow: String }
+        AND wr.repository.full_name = {repo: String }
     GROUP BY wr.head_sha
 ),
 

--- a/torchci/clickhouse_queries/test_stats_per_commit/query.sql
+++ b/torchci/clickhouse_queries/test_stats_per_commit/query.sql
@@ -4,83 +4,83 @@
 -- Mirrors the per-commit table produced by skip_delta.py: the "earliest"
 -- workflow_run (min id) is picked per commit so reruns don't shift the totals.
 WITH anchor_time AS (
-    -- If a sha is supplied, window ends at that commit's timestamp; otherwise
-    -- the window ends at the latest push.
+    -- If a sha prefix is supplied, window ends at that commit's timestamp;
+    -- otherwise the window ends at the latest push (sentinel far-future date).
     SELECT
         if(
             {sha: String } = '',
             toDateTime64('2099-01-01 00:00:00', 3),
             (
-                SELECT head_commit.'timestamp'
-                FROM default.push
-                WHERE repository.'full_name' = {repo: String }
-                    AND ref = {ref: String }
-                    AND startsWith(head_commit.'id', {sha: String })
-                ORDER BY head_commit.'timestamp' DESC
+                SELECT p.head_commit.timestamp
+                FROM default.push p
+                WHERE p.repository.full_name = {repo: String }
+                    AND p.ref = {ref: String }
+                    AND startsWith(p.head_commit.id, {sha: String })
+                ORDER BY p.head_commit.timestamp DESC
                 LIMIT 1
             )
         ) AS ts
 ),
 recent_commits AS (
     SELECT
-        head_commit.'id' AS sha,
-        head_commit.'message' AS message,
-        head_commit.'author'.'name' AS author,
-        head_commit.'timestamp' AS time
-    FROM default.push
-    WHERE repository.'full_name' = {repo: String }
-        AND ref = {ref: String }
-        AND head_commit.'timestamp' <= (SELECT ts FROM anchor_time)
-    ORDER BY head_commit.'timestamp' DESC
+        p.head_commit.id AS sha,
+        p.head_commit.message AS message,
+        p.head_commit.author.name AS author,
+        p.head_commit.timestamp AS time
+    FROM default.push p
+    WHERE p.repository.full_name = {repo: String }
+        AND p.ref = {ref: String }
+        AND p.head_commit.timestamp <= (SELECT ts FROM anchor_time)
+    ORDER BY p.head_commit.timestamp DESC
     LIMIT {count: UInt32 }
 ),
 matched_runs AS (
     SELECT
-        head_sha AS sha,
-        min(id) AS workflow_id
-    FROM default.workflow_run
-    WHERE id IN (
+        wr.head_sha AS sha,
+        min(wr.id) AS workflow_id
+    FROM default.workflow_run wr FINAL
+    WHERE wr.id IN (
         SELECT id FROM materialized_views.workflow_run_by_head_sha
         WHERE head_sha IN (SELECT sha FROM recent_commits)
     )
-    AND name = {workflow: String }
-    AND repository.'full_name' = {repo: String }
-    GROUP BY head_sha
+    AND wr.name = {workflow: String }
+    AND wr.repository.full_name = {repo: String }
+    GROUP BY wr.head_sha
 ),
 matched_jobs AS (
     SELECT
         wj.id AS job_id,
         mr.sha AS sha
-    FROM default.workflow_job wj
+    FROM default.workflow_job wj FINAL
     JOIN matched_runs mr ON wj.run_id = mr.workflow_id
     WHERE match(wj.name, {jobFilter: String })
 ),
 test_statuses AS (
     SELECT
         mj.sha AS sha,
-        invoking_file,
+        atr.invoking_file AS invoking_file,
         atr.name AS test_name,
-        classname,
+        atr.classname AS classname,
         multiIf(
             countIf(
-                failure_count = 0
-                AND error_count = 0
-                AND skipped_count = 0
-                AND rerun_count = 0
+                atr.failure_count = 0
+                AND atr.error_count = 0
+                AND atr.skipped_count = 0
+                AND atr.rerun_count = 0
             ) = count(*),
             'success',
-            sum(skipped_count) > 0,
+            sum(atr.skipped_count) > 0,
             'skipped',
             countIf(
-                failure_count = 0
-                AND error_count = 0
+                atr.failure_count = 0
+                AND atr.error_count = 0
             ) > 0,
             'flaky',
             'failure'
         ) AS status
     FROM tests.all_test_runs atr
     JOIN matched_jobs mj ON mj.job_id = atr.job_id
-    GROUP BY mj.sha, invoking_file, atr.name, classname
+    GROUP BY mj.sha, atr.invoking_file, atr.name, atr.classname
 ),
 per_sha_counts AS (
     SELECT

--- a/torchci/clickhouse_queries/test_stats_per_commit/query.sql
+++ b/torchci/clickhouse_queries/test_stats_per_commit/query.sql
@@ -52,10 +52,22 @@ matched_jobs AS (
     -- enough that the cost of merging ReplacingMergeTree parts isn't worth it.
     SELECT
         wj.id AS job_id,
-        mr.sha AS sha
+        mr.sha AS sha,
+        wj.status AS status,
+        wj.conclusion_kg AS conclusion
     FROM default.workflow_job wj
     JOIN matched_runs mr ON wj.run_id = mr.workflow_id
     WHERE match(wj.name, {jobFilter: String })
+),
+per_sha_pending AS (
+    -- A job is "in progress" until it reaches a final conclusion.
+    -- conclusion_kg is empty while queued / in_progress and gets filled when
+    -- the job completes (mirrors the logic in hud_query / commit_jobs_query).
+    SELECT
+        sha,
+        countIf(conclusion = '' OR status != 'completed') AS pending_jobs
+    FROM matched_jobs
+    GROUP BY sha
 ),
 test_statuses AS (
     -- Mirror the join+IN pattern from tests/test_status_counts_on_commits_by_file:
@@ -107,8 +119,10 @@ SELECT
     coalesce(s.success, 0) AS success,
     coalesce(s.skipped, 0) AS skipped,
     coalesce(s.flaky, 0) AS flaky,
-    coalesce(s.failure, 0) AS failure
+    coalesce(s.failure, 0) AS failure,
+    coalesce(p.pending_jobs, 0) AS pending_jobs
 FROM recent_commits rc
 LEFT JOIN matched_runs mr ON mr.sha = rc.sha
 LEFT JOIN per_sha_counts s ON s.sha = rc.sha
+LEFT JOIN per_sha_pending p ON p.sha = rc.sha
 ORDER BY rc.time DESC

--- a/torchci/clickhouse_queries/test_stats_per_commit/query.sql
+++ b/torchci/clickhouse_queries/test_stats_per_commit/query.sql
@@ -39,9 +39,12 @@ recent_commits AS (
 ),
 
 matched_runs AS (
+    -- argMin grabs the status of the SAME row that min(id) picks, so run_status
+    -- describes the original push run that we're aggregating jobs from.
     SELECT
         wr.head_sha AS sha,
-        min(wr.id) AS workflow_id
+        min(wr.id) AS workflow_id,
+        argMin(wr.status, wr.id) AS run_status
     FROM default.workflow_run wr FINAL
     WHERE
         wr.id IN (
@@ -130,7 +133,8 @@ SELECT
     coalesce(s.skipped, 0) AS skipped,
     coalesce(s.flaky, 0) AS flaky,
     coalesce(s.failure, 0) AS failure,
-    coalesce(p.pending_jobs, 0) AS pending_jobs
+    coalesce(p.pending_jobs, 0) AS pending_jobs,
+    mr.run_status AS run_status
 FROM recent_commits rc
 LEFT JOIN matched_runs mr ON mr.sha = rc.sha
 LEFT JOIN per_sha_counts s ON s.sha = rc.sha

--- a/torchci/clickhouse_queries/test_stats_per_commit/query.sql
+++ b/torchci/clickhouse_queries/test_stats_per_commit/query.sql
@@ -1,0 +1,89 @@
+-- Per-commit aggregated test pass/skip/flaky/fail counts for the last N pushes
+-- on a branch, restricted to a single workflow and a job-name regex.
+--
+-- Mirrors the per-commit table produced by skip_delta.py: the "earliest"
+-- workflow_run (min id) is picked per commit so reruns don't shift the totals.
+WITH recent_commits AS (
+    SELECT
+        head_commit.'id' AS sha,
+        head_commit.'message' AS message,
+        head_commit.'author'.'name' AS author,
+        head_commit.'timestamp' AS time
+    FROM default.push
+    WHERE repository.'full_name' = {repo: String }
+        AND ref = {ref: String }
+    ORDER BY head_commit.'timestamp' DESC
+    LIMIT {count: UInt32 }
+),
+matched_runs AS (
+    SELECT
+        head_sha AS sha,
+        min(id) AS workflow_id
+    FROM default.workflow_run
+    WHERE id IN (
+        SELECT id FROM materialized_views.workflow_run_by_head_sha
+        WHERE head_sha IN (SELECT sha FROM recent_commits)
+    )
+    AND name = {workflow: String }
+    AND repository.'full_name' = {repo: String }
+    GROUP BY head_sha
+),
+matched_jobs AS (
+    SELECT
+        wj.id AS job_id,
+        mr.sha AS sha
+    FROM default.workflow_job wj
+    JOIN matched_runs mr ON wj.run_id = mr.workflow_id
+    WHERE match(wj.name, {jobFilter: String })
+),
+test_statuses AS (
+    SELECT
+        mj.sha AS sha,
+        invoking_file,
+        atr.name AS test_name,
+        classname,
+        multiIf(
+            countIf(
+                failure_count = 0
+                AND error_count = 0
+                AND skipped_count = 0
+                AND rerun_count = 0
+            ) = count(*),
+            'success',
+            sum(skipped_count) > 0,
+            'skipped',
+            countIf(
+                failure_count = 0
+                AND error_count = 0
+            ) > 0,
+            'flaky',
+            'failure'
+        ) AS status
+    FROM tests.all_test_runs atr
+    JOIN matched_jobs mj ON mj.job_id = atr.job_id
+    GROUP BY mj.sha, invoking_file, atr.name, classname
+),
+per_sha_counts AS (
+    SELECT
+        sha,
+        countIf(status = 'success') AS success,
+        countIf(status = 'skipped') AS skipped,
+        countIf(status = 'flaky') AS flaky,
+        countIf(status = 'failure') AS failure
+    FROM test_statuses
+    GROUP BY sha
+)
+SELECT
+    rc.sha AS sha,
+    rc.message AS message,
+    rc.author AS author,
+    rc.time AS time,
+    mr.workflow_id AS workflow_id,
+    coalesce(s.success, 0) AS success,
+    coalesce(s.skipped, 0) AS skipped,
+    coalesce(s.flaky, 0) AS flaky,
+    coalesce(s.failure, 0) AS failure
+FROM recent_commits rc
+LEFT JOIN matched_runs mr ON mr.sha = rc.sha
+LEFT JOIN per_sha_counts s ON s.sha = rc.sha
+ORDER BY rc.time DESC

--- a/torchci/clickhouse_queries/test_stats_per_commit/query.sql
+++ b/torchci/clickhouse_queries/test_stats_per_commit/query.sql
@@ -21,6 +21,7 @@ WITH anchor_time AS (
             )
         ) AS ts
 ),
+
 recent_commits AS (
     SELECT
         p.head_commit.id AS sha,
@@ -34,6 +35,7 @@ recent_commits AS (
     ORDER BY p.head_commit.timestamp DESC
     LIMIT {count: UInt32 }
 ),
+
 matched_runs AS (
     SELECT
         wr.head_sha AS sha,
@@ -47,6 +49,7 @@ matched_runs AS (
     AND wr.repository.full_name = {repo: String }
     GROUP BY wr.head_sha
 ),
+
 matched_jobs AS (
     -- No FINAL: workflow_job is wide and run_id+name filtering is selective
     -- enough that the cost of merging ReplacingMergeTree parts isn't worth it.
@@ -59,6 +62,7 @@ matched_jobs AS (
     JOIN matched_runs mr ON wj.run_id = mr.workflow_id
     WHERE match(wj.name, {jobFilter: String })
 ),
+
 per_sha_pending AS (
     -- A job is "in progress" until it reaches a final conclusion.
     -- conclusion_kg is empty while queued / in_progress and gets filled when
@@ -69,6 +73,7 @@ per_sha_pending AS (
     FROM matched_jobs
     GROUP BY sha
 ),
+
 test_statuses AS (
     -- Mirror the join+IN pattern from tests/test_status_counts_on_commits_by_file:
     -- the WHERE...IN gives ClickHouse a sargable predicate to skip data parts
@@ -100,6 +105,7 @@ test_statuses AS (
     WHERE atr.job_id IN (SELECT job_id FROM matched_jobs)
     GROUP BY mj.sha, atr.invoking_file, atr.name, atr.classname
 ),
+
 per_sha_counts AS (
     SELECT
         sha,
@@ -110,6 +116,7 @@ per_sha_counts AS (
     FROM test_statuses
     GROUP BY sha
 )
+
 SELECT
     rc.sha AS sha,
     rc.message AS message,

--- a/torchci/clickhouse_queries/test_stats_per_commit/query.sql
+++ b/torchci/clickhouse_queries/test_stats_per_commit/query.sql
@@ -48,14 +48,19 @@ matched_runs AS (
     GROUP BY wr.head_sha
 ),
 matched_jobs AS (
+    -- No FINAL: workflow_job is wide and run_id+name filtering is selective
+    -- enough that the cost of merging ReplacingMergeTree parts isn't worth it.
     SELECT
         wj.id AS job_id,
         mr.sha AS sha
-    FROM default.workflow_job wj FINAL
+    FROM default.workflow_job wj
     JOIN matched_runs mr ON wj.run_id = mr.workflow_id
     WHERE match(wj.name, {jobFilter: String })
 ),
 test_statuses AS (
+    -- Mirror the join+IN pattern from tests/test_status_counts_on_commits_by_file:
+    -- the WHERE...IN gives ClickHouse a sargable predicate to skip data parts
+    -- before the JOIN materializes the (sha) column.
     SELECT
         mj.sha AS sha,
         atr.invoking_file AS invoking_file,
@@ -80,6 +85,7 @@ test_statuses AS (
         ) AS status
     FROM tests.all_test_runs atr
     JOIN matched_jobs mj ON mj.job_id = atr.job_id
+    WHERE atr.job_id IN (SELECT job_id FROM matched_jobs)
     GROUP BY mj.sha, atr.invoking_file, atr.name, atr.classname
 ),
 per_sha_counts AS (

--- a/torchci/clickhouse_queries/test_stats_per_commit/query.sql
+++ b/torchci/clickhouse_queries/test_stats_per_commit/query.sql
@@ -3,7 +3,25 @@
 --
 -- Mirrors the per-commit table produced by skip_delta.py: the "earliest"
 -- workflow_run (min id) is picked per commit so reruns don't shift the totals.
-WITH recent_commits AS (
+WITH anchor_time AS (
+    -- If a sha is supplied, window ends at that commit's timestamp; otherwise
+    -- the window ends at the latest push.
+    SELECT
+        if(
+            {sha: String } = '',
+            toDateTime64('2099-01-01 00:00:00', 3),
+            (
+                SELECT head_commit.'timestamp'
+                FROM default.push
+                WHERE repository.'full_name' = {repo: String }
+                    AND ref = {ref: String }
+                    AND startsWith(head_commit.'id', {sha: String })
+                ORDER BY head_commit.'timestamp' DESC
+                LIMIT 1
+            )
+        ) AS ts
+),
+recent_commits AS (
     SELECT
         head_commit.'id' AS sha,
         head_commit.'message' AS message,
@@ -12,6 +30,7 @@ WITH recent_commits AS (
     FROM default.push
     WHERE repository.'full_name' = {repo: String }
         AND ref = {ref: String }
+        AND head_commit.'timestamp' <= (SELECT ts FROM anchor_time)
     ORDER BY head_commit.'timestamp' DESC
     LIMIT {count: UInt32 }
 ),

--- a/torchci/clickhouse_queries/test_stats_per_commit/query.sql
+++ b/torchci/clickhouse_queries/test_stats_per_commit/query.sql
@@ -57,16 +57,27 @@ matched_runs AS (
 ),
 
 matched_jobs AS (
-    -- No FINAL: workflow_job is wide and run_id+name filtering is selective
-    -- enough that the cost of merging ReplacingMergeTree parts isn't worth it.
+    -- FINAL is needed: workflow_job is a ReplacingMergeTree and unmerged parts
+    -- can carry stale duplicate rows for the same job_id with differing
+    -- status/conclusion_kg, which would inflate pending_jobs and could even
+    -- misclassify a completed job as pending.
+    --
+    -- The id IN (materialized_views.workflow_job_by_head_sha ...) predicate is
+    -- the same trick commit_jobs_batch_query uses: it bounds the workflow_job
+    -- scan to just the rows for our 30 commits via the materialized view's
+    -- sort key, instead of letting the JOIN stream all rows of the wide table.
     SELECT
         wj.id AS job_id,
         mr.sha AS sha,
         wj.status AS status,
         wj.conclusion_kg AS conclusion
-    FROM default.workflow_job wj
+    FROM default.workflow_job wj FINAL
     JOIN matched_runs mr ON wj.run_id = mr.workflow_id
-    WHERE match(wj.name, {jobFilter: String })
+    WHERE wj.id IN (
+        SELECT id FROM materialized_views.workflow_job_by_head_sha
+        WHERE head_sha IN (SELECT sha FROM recent_commits)
+    )
+    AND match(wj.name, {jobFilter: String })
 ),
 
 per_sha_pending AS (

--- a/torchci/components/layout/NavBar.tsx
+++ b/torchci/components/layout/NavBar.tsx
@@ -67,6 +67,14 @@ function NavBar() {
       name: "Test File Reports",
       href: "/tests/fileReport",
     },
+    {
+      name: "CUDA Trunk test stats",
+      href: "/cuda_test_stats",
+    },
+    {
+      name: "MacOS test stats",
+      href: "/mac_test_stats",
+    },
   ].map((item) => ({
     label: item.name,
     route: item.href,

--- a/torchci/components/testStats/TestStatsPage.tsx
+++ b/torchci/components/testStats/TestStatsPage.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Button,
   Link,
   Stack,
   Table,
@@ -37,8 +38,15 @@ type Row = {
   run_status: string | null;
 };
 
-const COUNT_KEYS = ["success", "skipped", "flaky", "failure"] as const;
+const COUNT_KEYS = ["total", "skipped", "flaky", "failure"] as const;
 type CountKey = typeof COUNT_KEYS[number];
+
+const COUNT_LABELS: Record<CountKey, string> = {
+  total: "Total",
+  skipped: "Skip",
+  flaky: "Flaky",
+  failure: "Fail",
+};
 
 function formatDelta(d: number | undefined): string {
   if (d === undefined) return "";
@@ -52,8 +60,9 @@ function deltaColor(
   mode: "light" | "dark"
 ): string | undefined {
   if (delta === 0) return undefined;
-  // For success: more is better. For skipped/flaky/failure: more is worse.
-  const isImprovement = key === "success" ? delta > 0 : delta < 0;
+  // For total: more tests is "more coverage" → green. For skipped/flaky/failure:
+  // more is worse → red.
+  const isImprovement = key === "total" ? delta > 0 : delta < 0;
   if (mode === "dark") {
     return isImprovement ? "#4caf50" : "#ef5350";
   }
@@ -104,6 +113,17 @@ export function TestStatsPage({
     return <LoadingPage />;
   }
 
+  // Pre-compute the "total" column (sum of every category, not just success).
+  const counts: Record<string, Record<CountKey, number>> = {};
+  for (const row of data) {
+    counts[row.sha] = {
+      total: row.success + row.skipped + row.flaky + row.failure,
+      skipped: row.skipped,
+      flaky: row.flaky,
+      failure: row.failure,
+    };
+  }
+
   // Iterate oldest -> newest so deltas reference the prior commit, then flip
   // back to newest-first for display.
   const oldestFirst = [...data].reverse();
@@ -115,12 +135,7 @@ export function TestStatsPage({
       prevCounts = null;
       continue;
     }
-    const curr: Record<CountKey, number> = {
-      success: row.success,
-      skipped: row.skipped,
-      flaky: row.flaky,
-      failure: row.failure,
-    };
+    const curr = counts[row.sha];
     deltas[row.sha] = {};
     if (prevCounts) {
       for (const k of COUNT_KEYS) {
@@ -134,7 +149,7 @@ export function TestStatsPage({
     <Stack spacing={2} sx={{ p: 2 }}>
       <Typography variant="h4">{title}</Typography>
       <Typography>
-        Per-commit pass/skip/flaky/fail counts for the last {count} commits on{" "}
+        Per-commit total/skip/flaky/fail counts for the last {count} commits on{" "}
         <code>
           {REPO}@{REF.replace("refs/heads/", "")}
         </code>
@@ -150,20 +165,43 @@ export function TestStatsPage({
         URL params: <code>?count=N</code> (max {MAX_COUNT}),{" "}
         <code>?sha=&lt;hex&gt;</code> to end the window at a specific commit.
       </Typography>
+      <Stack direction="row" spacing={1}>
+        <Button
+          variant="outlined"
+          size="small"
+          disabled={!sha}
+          onClick={() => router.back()}
+        >
+          ← Prev
+        </Button>
+        <Button
+          variant="outlined"
+          size="small"
+          disabled={data.length === 0}
+          onClick={() =>
+            router.push({
+              pathname: router.pathname,
+              query: { ...router.query, sha: data[data.length - 1].sha, count },
+            })
+          }
+        >
+          Next →
+        </Button>
+      </Stack>
       <TableContainer>
         <Table size="small">
           <TableHead>
             <TableRow>
               <TableCell>Commit</TableCell>
               <TableCell>Time</TableCell>
-              <TableCell align="right">Pass</TableCell>
-              <TableCell align="right">Δ</TableCell>
-              <TableCell align="right">Skip</TableCell>
-              <TableCell align="right">Δ</TableCell>
-              <TableCell align="right">Flaky</TableCell>
-              <TableCell align="right">Δ</TableCell>
-              <TableCell align="right">Fail</TableCell>
-              <TableCell align="right">Δ</TableCell>
+              {COUNT_KEYS.flatMap((k) => [
+                <TableCell key={`${k}-h`} align="right">
+                  {COUNT_LABELS[k]}
+                </TableCell>,
+                <TableCell key={`${k}-dh`} align="right">
+                  Δ
+                </TableCell>,
+              ])}
               <TableCell>Title</TableCell>
             </TableRow>
           </TableHead>
@@ -229,7 +267,7 @@ export function TestStatsPage({
                           : undefined;
                       return [
                         <TableCell key={`${k}-v`} align="right">
-                          {row[k]}
+                          {counts[row.sha][k]}
                         </TableCell>,
                         <TableCell
                           key={`${k}-d`}

--- a/torchci/components/testStats/TestStatsPage.tsx
+++ b/torchci/components/testStats/TestStatsPage.tsx
@@ -1,0 +1,262 @@
+import {
+  Box,
+  Link,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  useTheme,
+} from "@mui/material";
+import { ensureUtc } from "components/autorevert/types";
+import LoadingPage from "components/common/LoadingPage";
+import { LocalTimeHuman } from "components/common/TimeUtils";
+import { useClickHouseAPIImmutable } from "lib/GeneralUtils";
+import { useRouter } from "next/router";
+
+const REPO = "pytorch/pytorch";
+const REF = "refs/heads/main";
+const WORKFLOW = "trunk";
+const DEFAULT_COUNT = 30;
+const MAX_COUNT = 200;
+
+type Row = {
+  sha: string;
+  message: string;
+  author: string;
+  time: string;
+  workflow_id: number | null;
+  success: number;
+  skipped: number;
+  flaky: number;
+  failure: number;
+  pending_jobs: number;
+};
+
+const COUNT_KEYS = ["success", "skipped", "flaky", "failure"] as const;
+type CountKey = typeof COUNT_KEYS[number];
+
+function formatDelta(d: number | undefined): string {
+  if (d === undefined) return "";
+  if (d === 0) return "0";
+  return d > 0 ? `+${d}` : `${d}`;
+}
+
+function deltaColor(
+  key: CountKey,
+  delta: number,
+  mode: "light" | "dark"
+): string | undefined {
+  if (delta === 0) return undefined;
+  // For success: more is better. For skipped/flaky/failure: more is worse.
+  const isImprovement = key === "success" ? delta > 0 : delta < 0;
+  if (mode === "dark") {
+    return isImprovement ? "#4caf50" : "#ef5350";
+  }
+  return isImprovement ? "#1b5e20" : "#b71c1c";
+}
+
+export function TestStatsPage({
+  title,
+  jobFilter,
+}: {
+  title: string;
+  jobFilter: string;
+}) {
+  const router = useRouter();
+  const theme = useTheme();
+  const mode = theme.palette.mode;
+
+  const parsed = parseInt((router.query.count as string) ?? "");
+  const count = Number.isFinite(parsed)
+    ? Math.max(1, Math.min(MAX_COUNT, parsed))
+    : DEFAULT_COUNT;
+  const shaParam = ((router.query.sha as string) ?? "").trim();
+  // Only forward full 40-char or short (>=7) hex shas; anything else is ignored
+  // and the query falls back to "most recent".
+  const sha = /^[0-9a-f]{7,40}$/i.test(shaParam) ? shaParam : "";
+
+  const { data, error, isLoading } = useClickHouseAPIImmutable<Row>(
+    "test_stats_per_commit",
+    {
+      repo: REPO,
+      ref: REF,
+      workflow: WORKFLOW,
+      jobFilter,
+      count,
+      sha,
+    }
+  );
+
+  if (error) {
+    return (
+      <Stack spacing={2} sx={{ p: 2 }}>
+        <Typography variant="h4">{title}</Typography>
+        <Typography color="error">Error loading data: {`${error}`}</Typography>
+      </Stack>
+    );
+  }
+  if (isLoading || !data) {
+    return <LoadingPage />;
+  }
+
+  // Iterate oldest -> newest so deltas reference the prior commit, then flip
+  // back to newest-first for display.
+  const oldestFirst = [...data].reverse();
+  const deltas: Record<string, Partial<Record<CountKey, number>>> = {};
+  let prevCounts: Record<CountKey, number> | null = null;
+  for (const row of oldestFirst) {
+    if (row.workflow_id == null) {
+      deltas[row.sha] = {};
+      prevCounts = null;
+      continue;
+    }
+    const curr: Record<CountKey, number> = {
+      success: row.success,
+      skipped: row.skipped,
+      flaky: row.flaky,
+      failure: row.failure,
+    };
+    deltas[row.sha] = {};
+    if (prevCounts) {
+      for (const k of COUNT_KEYS) {
+        deltas[row.sha][k] = curr[k] - prevCounts[k];
+      }
+    }
+    prevCounts = curr;
+  }
+
+  return (
+    <Stack spacing={2} sx={{ p: 2 }}>
+      <Typography variant="h4">{title}</Typography>
+      <Typography>
+        Per-commit pass/skip/flaky/fail counts for the last {count} commits on{" "}
+        <code>
+          {REPO}@{REF.replace("refs/heads/", "")}
+        </code>
+        {sha ? (
+          <>
+            {" "}
+            ending at <code>{sha}</code>
+          </>
+        ) : null}
+        , restricted to the <code>{WORKFLOW}</code> workflow and jobs matching{" "}
+        <code>{jobFilter}</code>. Δ is relative to the previous commit shown.
+        Rows tinted amber (⏳) still have running jobs &mdash; counts may rise.
+        URL params: <code>?count=N</code> (max {MAX_COUNT}),{" "}
+        <code>?sha=&lt;hex&gt;</code> to end the window at a specific commit.
+      </Typography>
+      <TableContainer>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Commit</TableCell>
+              <TableCell>Time</TableCell>
+              <TableCell align="right">Pass</TableCell>
+              <TableCell align="right">Δ</TableCell>
+              <TableCell align="right">Skip</TableCell>
+              <TableCell align="right">Δ</TableCell>
+              <TableCell align="right">Flaky</TableCell>
+              <TableCell align="right">Δ</TableCell>
+              <TableCell align="right">Fail</TableCell>
+              <TableCell align="right">Δ</TableCell>
+              <TableCell>Title</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data.map((row) => {
+              const hasRun = row.workflow_id != null;
+              const rowDeltas = deltas[row.sha] ?? {};
+              const title = (row.message ?? "").split("\n")[0].slice(0, 80);
+              const pending = row.pending_jobs > 0;
+              // Subtle amber tint so the row stands out without clashing with
+              // the red/green delta colors. Lower alpha on dark mode.
+              const pendingBg = pending
+                ? mode === "dark"
+                  ? "rgba(255, 193, 7, 0.12)"
+                  : "rgba(255, 193, 7, 0.18)"
+                : undefined;
+              return (
+                <TableRow
+                  key={row.sha}
+                  hover
+                  sx={{ backgroundColor: pendingBg }}
+                  title={
+                    pending
+                      ? `${row.pending_jobs} job(s) still running`
+                      : undefined
+                  }
+                >
+                  <TableCell>
+                    <Link
+                      href={`/${REPO}/commit/${row.sha}`}
+                      sx={{ fontFamily: "monospace" }}
+                    >
+                      {row.sha.slice(0, 9)}
+                    </Link>
+                    {pending ? (
+                      <Box
+                        component="span"
+                        sx={{ ml: 1, fontSize: "0.85em" }}
+                        aria-label={`${row.pending_jobs} jobs still running`}
+                      >
+                        ⏳
+                      </Box>
+                    ) : null}
+                  </TableCell>
+                  <TableCell sx={{ whiteSpace: "nowrap" }}>
+                    <LocalTimeHuman timestamp={ensureUtc(row.time)} />
+                  </TableCell>
+                  {hasRun ? (
+                    COUNT_KEYS.flatMap((k) => {
+                      const delta = rowDeltas[k];
+                      const color =
+                        delta !== undefined
+                          ? deltaColor(k, delta, mode)
+                          : undefined;
+                      return [
+                        <TableCell key={`${k}-v`} align="right">
+                          {row[k]}
+                        </TableCell>,
+                        <TableCell
+                          key={`${k}-d`}
+                          align="right"
+                          sx={{ color, fontVariantNumeric: "tabular-nums" }}
+                        >
+                          {formatDelta(delta)}
+                        </TableCell>,
+                      ];
+                    })
+                  ) : (
+                    <TableCell
+                      colSpan={8}
+                      align="center"
+                      sx={{ color: theme.palette.text.secondary }}
+                    >
+                      (no {WORKFLOW} run)
+                    </TableCell>
+                  )}
+                  <TableCell sx={{ maxWidth: 500 }}>
+                    <Box
+                      sx={{
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                      title={row.message}
+                    >
+                      {title}
+                    </Box>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Stack>
+  );
+}

--- a/torchci/components/testStats/TestStatsPage.tsx
+++ b/torchci/components/testStats/TestStatsPage.tsx
@@ -34,6 +34,7 @@ type Row = {
   flaky: number;
   failure: number;
   pending_jobs: number;
+  run_status: string | null;
 };
 
 const COUNT_KEYS = ["success", "skipped", "flaky", "failure"] as const;
@@ -171,7 +172,14 @@ export function TestStatsPage({
               const hasRun = row.workflow_id != null;
               const rowDeltas = deltas[row.sha] ?? {};
               const title = (row.message ?? "").split("\n")[0].slice(0, 80);
-              const pending = row.pending_jobs > 0;
+              // Pending if any matched job is still running, OR if the run
+              // itself is queued/in_progress (in which case workflow_job rows
+              // for the matched jobs may not exist yet, so pending_jobs is 0).
+              const runPending =
+                hasRun &&
+                row.run_status !== null &&
+                row.run_status !== "completed";
+              const pending = row.pending_jobs > 0 || runPending;
               // Subtle amber tint so the row stands out without clashing with
               // the red/green delta colors. Lower alpha on dark mode.
               const pendingBg = pending
@@ -186,7 +194,9 @@ export function TestStatsPage({
                   sx={{ backgroundColor: pendingBg }}
                   title={
                     pending
-                      ? `${row.pending_jobs} job(s) still running`
+                      ? runPending && row.pending_jobs === 0
+                        ? `workflow run is ${row.run_status}`
+                        : `${row.pending_jobs} job(s) still running`
                       : undefined
                   }
                 >

--- a/torchci/components/testStats/TestStatsPage.tsx
+++ b/torchci/components/testStats/TestStatsPage.tsx
@@ -86,8 +86,9 @@ export function TestStatsPage({
     : DEFAULT_COUNT;
   const shaParam = ((router.query.sha as string) ?? "").trim();
   // Only forward full 40-char or short (>=7) hex shas; anything else is ignored
-  // and the query falls back to "most recent".
-  const sha = /^[0-9a-f]{7,40}$/i.test(shaParam) ? shaParam : "";
+  // and the query falls back to "most recent". Lowercased so a SHA pasted from
+  // GitHub's URL still matches the case-sensitive startsWith() in the query.
+  const sha = /^[0-9a-f]{7,40}$/i.test(shaParam) ? shaParam.toLowerCase() : "";
 
   const { data, error, isLoading } = useClickHouseAPIImmutable<Row>(
     "test_stats_per_commit",
@@ -170,7 +171,13 @@ export function TestStatsPage({
           variant="outlined"
           size="small"
           disabled={!sha}
-          onClick={() => router.back()}
+          onClick={() => {
+            // Drop ?sha so we go back to the HEAD window. Works for both the
+            // "navigated via Next" case and the "landed on a sha-anchored URL
+            // directly" case (where router.back() would leave the page).
+            const { sha: _drop, ...rest } = router.query;
+            router.push({ pathname: router.pathname, query: rest });
+          }}
         >
           ← Prev
         </Button>
@@ -209,7 +216,9 @@ export function TestStatsPage({
             {data.map((row) => {
               const hasRun = row.workflow_id != null;
               const rowDeltas = deltas[row.sha] ?? {};
-              const title = (row.message ?? "").split("\n")[0].slice(0, 80);
+              const commitTitle = (row.message ?? "")
+                .split("\n")[0]
+                .slice(0, 80);
               // Pending if any matched job is still running, OR if the run
               // itself is queued/in_progress (in which case workflow_job rows
               // for the matched jobs may not exist yet, so pending_jobs is 0).
@@ -296,7 +305,7 @@ export function TestStatsPage({
                       }}
                       title={row.message}
                     >
-                      {title}
+                      {commitTitle}
                     </Box>
                   </TableCell>
                 </TableRow>

--- a/torchci/pages/cuda_test_stats.tsx
+++ b/torchci/pages/cuda_test_stats.tsx
@@ -1,5 +1,5 @@
 import { TestStatsPage } from "components/testStats/TestStatsPage";
 
 export default function Page() {
-  return <TestStatsPage title="macOS Test Stats" jobFilter="(?i)macos" />;
+  return <TestStatsPage title="CUDA Test Stats" jobFilter="(?i)cuda" />;
 }

--- a/torchci/pages/cuda_test_stats.tsx
+++ b/torchci/pages/cuda_test_stats.tsx
@@ -1,5 +1,10 @@
 import { TestStatsPage } from "components/testStats/TestStatsPage";
 
 export default function Page() {
-  return <TestStatsPage title="CUDA Test Stats" jobFilter="(?i)cuda" />;
+  return (
+    <TestStatsPage
+      title="CUDA Test Stats"
+      jobFilter="(?i)jammy.*cuda|cuda.*jammy"
+    />
+  );
 }

--- a/torchci/pages/mac_test_stats.tsx
+++ b/torchci/pages/mac_test_stats.tsx
@@ -70,6 +70,10 @@ export default function Page() {
   const count = Number.isFinite(parsed)
     ? Math.max(1, Math.min(MAX_COUNT, parsed))
     : DEFAULT_COUNT;
+  const shaParam = ((router.query.sha as string) ?? "").trim();
+  // Only forward full 40-char or short (>=7) hex shas; anything else is ignored
+  // and the query falls back to "most recent".
+  const sha = /^[0-9a-f]{7,40}$/i.test(shaParam) ? shaParam : "";
 
   const { data, error, isLoading } = useClickHouseAPIImmutable<Row>(
     "test_stats_per_commit",
@@ -79,6 +83,7 @@ export default function Page() {
       workflow: WORKFLOW,
       jobFilter: JOB_FILTER,
       count,
+      sha,
     }
   );
 
@@ -128,9 +133,16 @@ export default function Page() {
         <code>
           {REPO}@{REF.replace("refs/heads/", "")}
         </code>
+        {sha ? (
+          <>
+            {" "}
+            ending at <code>{sha}</code>
+          </>
+        ) : null}
         , restricted to the <code>{WORKFLOW}</code> workflow and jobs matching{" "}
         <code>{JOB_FILTER}</code>. Δ is relative to the previous commit shown.
-        Override the window with <code>?count=N</code> (max {MAX_COUNT}).
+        URL params: <code>?count=N</code> (max {MAX_COUNT}),{" "}
+        <code>?sha=&lt;hex&gt;</code> to end the window at a specific commit.
       </Typography>
       <TableContainer>
         <Table size="small">

--- a/torchci/pages/mac_test_stats.tsx
+++ b/torchci/pages/mac_test_stats.tsx
@@ -1,0 +1,219 @@
+import {
+  Box,
+  Link,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  useTheme,
+} from "@mui/material";
+import LoadingPage from "components/common/LoadingPage";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import { useClickHouseAPIImmutable } from "lib/GeneralUtils";
+import { useRouter } from "next/router";
+
+dayjs.extend(utc);
+
+const REPO = "pytorch/pytorch";
+const REF = "refs/heads/main";
+const WORKFLOW = "trunk";
+const JOB_FILTER = "(?i)macos";
+const DEFAULT_COUNT = 30;
+const MAX_COUNT = 200;
+
+type Row = {
+  sha: string;
+  message: string;
+  author: string;
+  time: string;
+  workflow_id: number | null;
+  success: number;
+  skipped: number;
+  flaky: number;
+  failure: number;
+};
+
+const COUNT_KEYS = ["success", "skipped", "flaky", "failure"] as const;
+type CountKey = typeof COUNT_KEYS[number];
+
+function formatDelta(d: number | undefined): string {
+  if (d === undefined) return "";
+  if (d === 0) return "0";
+  return d > 0 ? `+${d}` : `${d}`;
+}
+
+function deltaColor(
+  key: CountKey,
+  delta: number,
+  mode: "light" | "dark"
+): string | undefined {
+  if (delta === 0) return undefined;
+  // For success: more is better. For skipped/flaky/failure: more is worse.
+  const isImprovement = key === "success" ? delta > 0 : delta < 0;
+  if (mode === "dark") {
+    return isImprovement ? "#4caf50" : "#ef5350";
+  }
+  return isImprovement ? "#1b5e20" : "#b71c1c";
+}
+
+export default function Page() {
+  const router = useRouter();
+  const theme = useTheme();
+  const mode = theme.palette.mode;
+
+  const parsed = parseInt((router.query.count as string) ?? "");
+  const count = Number.isFinite(parsed)
+    ? Math.max(1, Math.min(MAX_COUNT, parsed))
+    : DEFAULT_COUNT;
+
+  const { data, error, isLoading } = useClickHouseAPIImmutable<Row>(
+    "test_stats_per_commit",
+    {
+      repo: REPO,
+      ref: REF,
+      workflow: WORKFLOW,
+      jobFilter: JOB_FILTER,
+      count,
+    }
+  );
+
+  if (error) {
+    return (
+      <Stack spacing={2} sx={{ p: 2 }}>
+        <Typography variant="h4">macOS Test Stats</Typography>
+        <Typography color="error">Error loading data: {`${error}`}</Typography>
+      </Stack>
+    );
+  }
+  if (isLoading || !data) {
+    return <LoadingPage />;
+  }
+
+  // Iterate oldest -> newest so deltas reference the prior commit, then flip
+  // back to newest-first for display.
+  const oldestFirst = [...data].reverse();
+  const deltas: Record<string, Partial<Record<CountKey, number>>> = {};
+  let prevCounts: Record<CountKey, number> | null = null;
+  for (const row of oldestFirst) {
+    if (row.workflow_id == null) {
+      deltas[row.sha] = {};
+      prevCounts = null;
+      continue;
+    }
+    const curr: Record<CountKey, number> = {
+      success: row.success,
+      skipped: row.skipped,
+      flaky: row.flaky,
+      failure: row.failure,
+    };
+    deltas[row.sha] = {};
+    if (prevCounts) {
+      for (const k of COUNT_KEYS) {
+        deltas[row.sha][k] = curr[k] - prevCounts[k];
+      }
+    }
+    prevCounts = curr;
+  }
+
+  return (
+    <Stack spacing={2} sx={{ p: 2 }}>
+      <Typography variant="h4">macOS Test Stats</Typography>
+      <Typography>
+        Per-commit pass/skip/flaky/fail counts for the last {count} commits on{" "}
+        <code>
+          {REPO}@{REF.replace("refs/heads/", "")}
+        </code>
+        , restricted to the <code>{WORKFLOW}</code> workflow and jobs matching{" "}
+        <code>{JOB_FILTER}</code>. Δ is relative to the previous commit shown.
+        Override the window with <code>?count=N</code> (max {MAX_COUNT}).
+      </Typography>
+      <TableContainer>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Commit</TableCell>
+              <TableCell>Time (UTC)</TableCell>
+              <TableCell align="right">Pass</TableCell>
+              <TableCell align="right">Δ</TableCell>
+              <TableCell align="right">Skip</TableCell>
+              <TableCell align="right">Δ</TableCell>
+              <TableCell align="right">Flaky</TableCell>
+              <TableCell align="right">Δ</TableCell>
+              <TableCell align="right">Fail</TableCell>
+              <TableCell align="right">Δ</TableCell>
+              <TableCell>Title</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data.map((row) => {
+              const hasRun = row.workflow_id != null;
+              const rowDeltas = deltas[row.sha] ?? {};
+              const title = (row.message ?? "").split("\n")[0].slice(0, 80);
+              return (
+                <TableRow key={row.sha} hover>
+                  <TableCell>
+                    <Link
+                      href={`/${REPO}/commit/${row.sha}`}
+                      sx={{ fontFamily: "monospace" }}
+                    >
+                      {row.sha.slice(0, 9)}
+                    </Link>
+                  </TableCell>
+                  <TableCell sx={{ whiteSpace: "nowrap" }}>
+                    {dayjs(row.time).utc().format("YYYY-MM-DD HH:mm")}
+                  </TableCell>
+                  {hasRun ? (
+                    COUNT_KEYS.flatMap((k) => {
+                      const delta = rowDeltas[k];
+                      const color =
+                        delta !== undefined
+                          ? deltaColor(k, delta, mode)
+                          : undefined;
+                      return [
+                        <TableCell key={`${k}-v`} align="right">
+                          {row[k]}
+                        </TableCell>,
+                        <TableCell
+                          key={`${k}-d`}
+                          align="right"
+                          sx={{ color, fontVariantNumeric: "tabular-nums" }}
+                        >
+                          {formatDelta(delta)}
+                        </TableCell>,
+                      ];
+                    })
+                  ) : (
+                    <TableCell
+                      colSpan={8}
+                      align="center"
+                      sx={{ color: theme.palette.text.secondary }}
+                    >
+                      (no {WORKFLOW} run)
+                    </TableCell>
+                  )}
+                  <TableCell sx={{ maxWidth: 500 }}>
+                    <Box
+                      sx={{
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                      title={row.message}
+                    >
+                      {title}
+                    </Box>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Stack>
+  );
+}


### PR DESCRIPTION
Add two new HUD pages under **Dev Infra** — `/mac_test_stats` and `/cuda_test_stats` — that show per-commit **total/skip/flaky/fail** counts for `pytorch/pytorch` trunk macOS / linux-jammy-cuda test jobs. Both are thin wrappers around a shared `TestStatsPage` component.

- URL params: `?count=N` (default 30, cap 200), `?sha=<hex>` to anchor the window at a specific commit. Prev/Next pagination via `?sha`.
- Δ vs the previous commit shown, color-coded via `useTheme()` for dark/light mode.
- Rows whose `trunk` run is still queued/in_progress (or has running jobs) are tinted amber with a ⏳ marker — counts may still rise.
- Time rendered using `LocalTimeHuman` widget, used by the main HUD page.

## Query

`test_stats_per_commit` query taking `repo / ref / workflow / jobFilter / count / sha`. Returns one row per recent push with `sha, message, author, time, workflow_id, run_status, pending_jobs` and `success / skipped / flaky / failure`. Earliest `workflow_run.id` per `head_sha` is picked so reruns don't shift totals.

## Test plan

Go to https://torchci-git-malfet-mac-test-stats-page-fbopensource.vercel.app/cuda_test_stats?sha=9661ae6e5416b89d274c2a348889264ac5816d68 and enjoy 14K skipped test spike