### PR TITLE
Add linux_job_v3 workflow for OSDC runners

### DIFF
--- a/.github/workflows/linux_job_v3.yml
+++ b/.github/workflows/linux_job_v3.yml
@@ -1,0 +1,299 @@
+name: Build / Test on Linux v3 (OSDC)
+
+# Same inputs as linux_job_v2.yml, but compatible with OSDC (ARC) runners.
+on:
+  workflow_call:
+    inputs:
+      script:
+        description: 'Script to utilize'
+        default: "python setup.py bdist_wheel"
+        type: string
+      timeout:
+        description: 'Timeout for the job (in minutes)'
+        default: 30
+        type: number
+      runner:
+        description: 'ARC runner label to utilize (e.g. mt-l-x86iavx512-8-64)'
+        default: "mt-l-x86iavx512-8-64"
+        type: string
+      upload-artifact:
+        description: |
+          Name to give artifacts uploaded from ${RUNNER_ARTIFACT_DIR}, all the wheel files
+          under dist/ and any files under artifacts-to-be-uploaded/ will be uploaded
+        default: ''
+        type: string
+      upload-artifact-to-s3:
+        description: |
+          Upload the artifact to S3 instead of GitHub. This is used for large artifacts like
+          exported model
+        required: false
+        default: false
+        type: boolean
+      download-artifact:
+        description: 'Name to download artifacts to ${RUNNER_ARTIFACT_DIR}'
+        default: ''
+        type: string
+      repository:
+        description: 'Repository to checkout, defaults to ""'
+        default: ""
+        type: string
+      fetch-depth:
+        description: 'Number of commits to fetch, defaults to 1 similar to actions/checkout'
+        default: 1
+        type: number
+      single-branch:
+        description: 'Whether to fetch only a single branch, defaults to true'
+        default: true
+        type: boolean
+      additional-fetch-refs:
+        description: 'Additional refs to fetch, space separated'
+        default: |
+          refs/heads/main
+        type: string
+      checkout-mode:
+        description: 'Mode of checkout; one of "normal", "blobless", "treeless".'
+        default: "normal"
+        type: string
+      submodules:
+        description:
+          Same as actions/checkout, set to `true` to checkout submodules or `recursive` to
+          recursively checkout everything
+        default: ""
+        type: string
+      ref:
+        description: 'Reference to checkout, defaults to "nightly"'
+        default: ""
+        type: string
+      test-infra-repository:
+        description: "Test infra repository to use"
+        default: "pytorch/test-infra"
+        type: string
+      test-infra-ref:
+        description: "Test infra reference to use"
+        default: ""
+        type: string
+      use-custom-docker-registry:
+        description: "[Ignored on OSDC] Kept for compatibility with linux_job_v2.yml."
+        default: true
+        type: boolean
+      docker-image:
+        description: |
+          Fully-qualified, already-built Docker image to run the job inside, e.g.
+          ghcr.io/pytorch/test-infra:cpu-x86_64-<hash> or an ECR path. The image is pulled
+          by the runner before any step runs.
+        default: "pytorch/almalinux-builder"
+        type: string
+      gpu-arch-type:
+        description: "GPU arch type to use"
+        default: "cpu"
+        type: string
+      gpu-arch-version:
+        description: "GPU arch version to use"
+        default: ""
+        type: string
+      job-name:
+        description: "Name for the job, which is displayed in the GitHub UI"
+        default: "linux-job"
+        type: string
+      continue-on-error:
+        description: "Prevents a job from failing when a step fails. Set to true to allow a job to pass when exec script step fails."
+        default: false
+        type: boolean
+      binary-matrix:
+        description: "If we are calling this workflow with binary build matrix entry, will initialize matrix entries and env vars"
+        required: false
+        default: ''
+        type: string
+      secrets-env:
+        description: "List of secrets to be exported to environment variables"
+        type: string
+        default: ''
+
+jobs:
+  job:
+    strategy:
+      fail-fast: false
+    name: ${{ inputs.job-name }}
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      REPOSITORY: ${{ inputs.repository || github.repository }}
+      # Will be blank outside of this
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      SCRIPT: ${{ inputs.script }}
+      filter: ${{ inputs.checkout-mode == 'blobless' && 'blob:none' || inputs.checkout-mode == 'treeless' && 'tree:0' || null }}
+    runs-on: ${{ inputs.runner }}
+    # On OSDC the job runs inside this pre-built container; cuda exposes the GPUs.
+    container:
+      image: >-
+        ${{ inputs.docker-image == 'pytorch/almalinux-builder' && format('pytorch/almalinux-builder:{0}{1}',
+                                                                      inputs.gpu-arch-type,
+                                                                      inputs.gpu-arch-version)
+                                                            || inputs.docker-image }}
+      options: ${{ inputs.gpu-arch-type == 'cuda' && '--gpus all' || '' }}
+      # On ARC (k8s) the container is created as a pod, so GPU driver capabilities
+      # must be requested via container env at creation time (the --gpus / -e flags
+      # in `options` are not honored). These are harmless on CPU runners.
+      env:
+        NVIDIA_VISIBLE_DEVICES: ${{ inputs.gpu-arch-type == 'cuda' && 'all' || '' }}
+        NVIDIA_DRIVER_CAPABILITIES: ${{ inputs.gpu-arch-type == 'cuda' && 'compute,utility' || '' }}
+    timeout-minutes: ${{ inputs.timeout }}
+    steps:
+      - name: Clean workspace
+        run: |
+          set -euxo pipefail
+          echo "::group::Cleanup debug output"
+          rm -rfv "${GITHUB_WORKSPACE}"
+          mkdir -p "${GITHUB_WORKSPACE}"
+          echo "::endgroup::"
+
+      - name: Checkout repository (${{ inputs.test-infra-repository }}@${{ inputs.test-infra-ref }})
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Support the use case where we need to checkout someone's fork
+          repository: ${{ inputs.test-infra-repository }}
+          ref: ${{ inputs.test-infra-ref }}
+          path: test-infra
+
+          # PyTorch, the primary target for this job template, heavily
+          # relies on submodules. Clone them by default to avoid
+          # surprises.
+          submodules: 'recursive'
+
+      - name: Configure AWS credentials
+        id: aws-creds
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/arc
+          aws-region: us-east-1
+          # The max duration enforced by the server side
+          role-duration-seconds: 18000
+
+      - name: Setup environment variables
+        shell: bash
+        run: |
+          set -euo pipefail
+          for name in ARTIFACT:artifacts TEST_RESULTS:test-results DOCS:docs; do
+            var="RUNNER_${name%%:*}_DIR"
+            dir="${RUNNER_TEMP}/${name##*:}"
+            rm -rf "${dir}"
+            mkdir -p "${dir}"
+            echo "${var}=${dir}" >> "${GITHUB_ENV}"
+          done
+
+      - name: Checkout repository (${{ inputs.repository || github.repository }}@${{ inputs.ref }})
+        uses: pytorch/test-infra/.github/actions/checkout@main
+        with:
+          # Support the use case where we need to checkout someone's fork
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          single-branch: ${{ inputs.single-branch }}
+          additional-fetch-refs: ${{ inputs.additional-fetch-refs }}
+          path: ${{ inputs.repository || github.repository }}
+          fetch-depth: ${{ inputs.fetch-depth }}
+          submodules: ${{ inputs.submodules }}
+          filter: ${{ env.filter }}
+          submodules-filter: ${{ env.filter }}
+
+      - name: Download artifacts (if any)
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        if: ${{ inputs.download-artifact != '' }}
+        with:
+          name: ${{ inputs.download-artifact }}
+          path: ${{ runner.temp }}/artifacts/
+
+      - name: Export matrix variables (if any)
+        uses: pytorch/test-infra/.github/actions/export-matrix-variables@main
+        if: ${{ inputs.binary-matrix != '' }}
+        with:
+          binary-matrix: ${{ inputs.binary-matrix }}
+          target-os: "linux"
+
+      - name: Run script
+        continue-on-error: ${{ inputs.continue-on-error }}
+        working-directory: ${{ inputs.repository || github.repository }}
+        env:
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+        run: |
+          set -ex
+          {
+            echo "#!/usr/bin/env bash";
+            echo "set -eou pipefail";
+            # shellcheck disable=SC2016
+            echo 'eval "$(conda shell.bash hook)"';
+            echo "set -x";
+            echo "${SCRIPT}";
+          } > "${RUNNER_TEMP}/exec_script"
+          chmod +x "${RUNNER_TEMP}/exec_script"
+          # Use $GITHUB_WORKSPACE (remapped to the container mount, e.g. /__w/...)
+          # rather than the github.workspace expression, which returns the host path.
+          python3 -u "${GITHUB_WORKSPACE}/test-infra/.github/scripts/run_with_env_secrets.py" "${{ inputs.secrets-env }}"
+
+      - name: Surface failing tests
+        if: always()
+        uses: pmeier/pytest-results-action@a2c1430e2bddadbad9f49a6f9b879f062c6b19b1 # v0.3.0
+        with:
+          path: ${{ env.RUNNER_TEST_RESULTS_DIR }}
+          fail-on-empty: false
+
+      - name: Prepare artifacts for upload
+        if: always()
+        working-directory: ${{ inputs.repository || github.repository }}
+        id: check-artifacts
+        env:
+          UPLOAD_ARTIFACT_NAME: ${{ inputs.upload-artifact }}
+        run: |
+          # Only do these steps if we actually want to upload an artifact
+          if [[ -n "${UPLOAD_ARTIFACT_NAME}" ]]; then
+            # If the default execution path is followed then we should get a wheel in the dist/ folder
+            # attempt to just grab whatever is in there and scoop it all up
+            if find "dist/" -name "*.whl" >/dev/null 2>/dev/null; then
+              mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
+            fi
+            if [[ -d "artifacts-to-be-uploaded" ]]; then
+              mv -v artifacts-to-be-uploaded/* "${RUNNER_ARTIFACT_DIR}/"
+            fi
+            if [[ -d "${RUNNER_TEMP}/artifacts-to-be-uploaded" ]]; then
+              mv -v "${RUNNER_TEMP}"/artifacts-to-be-uploaded/* "${RUNNER_ARTIFACT_DIR}/"
+            fi
+          fi
+
+          upload_docs=0
+          # Check if there are files in the documentation folder to upload, note that
+          # empty folders do not count
+          if find "${RUNNER_DOCS_DIR}" -mindepth 1 -maxdepth 1 -type f | read -r; then
+            upload_docs=1
+          fi
+          echo "upload-docs=${upload_docs}" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload artifacts to GitHub (if any)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ always() && inputs.upload-artifact != '' && !inputs.upload-artifact-to-s3 }}
+        with:
+          name: ${{ inputs.upload-artifact }}
+          path: ${{ runner.temp }}/artifacts/
+
+      - name: Upload artifacts to S3 (if any)
+        uses: pytorch/test-infra/.github/actions/upload-artifact-s3@main
+        if: ${{ always() && inputs.upload-artifact != '' && inputs.upload-artifact-to-s3 }}
+        with:
+          retention-days: 14
+          s3-bucket: gha-artifacts
+          s3-prefix: |
+            ${{ env.REPOSITORY }}/${{ github.run_id }}/artifacts
+          path: ${{ runner.temp }}/artifacts/
+
+      - name: Upload documentation to S3 (if any)
+        uses: pytorch/test-infra/.github/actions/upload-artifact-s3@main
+        if: ${{ steps.check-artifacts.outputs.upload-docs == 1 && github.event.pull_request.number != '' }}
+        with:
+          retention-days: 14
+          s3-bucket: doc-previews
+          if-no-files-found: error
+          path: ${{ env.RUNNER_DOCS_DIR }}
+          # ${{ env.REPOSITORY }} is $OWNER/$REPO
+          s3-prefix: ${{ env.REPOSITORY }}/${{ github.event.pull_request.number }}
+          # Overwrite doc previews for the same PR
+          overwrite: true

--- a/.github/workflows/linux_job_v3.yml
+++ b/.github/workflows/linux_job_v3.yml
@@ -132,12 +132,6 @@ jobs:
                                                                       inputs.gpu-arch-version)
                                                             || inputs.docker-image }}
       options: ${{ inputs.gpu-arch-type == 'cuda' && '--gpus all' || '' }}
-      # On ARC (k8s) the container is created as a pod, so GPU driver capabilities
-      # must be requested via container env at creation time (the --gpus / -e flags
-      # in `options` are not honored). These are harmless on CPU runners.
-      env:
-        NVIDIA_VISIBLE_DEVICES: ${{ inputs.gpu-arch-type == 'cuda' && 'all' || '' }}
-        NVIDIA_DRIVER_CAPABILITIES: ${{ inputs.gpu-arch-type == 'cuda' && 'compute,utility' || '' }}
     timeout-minutes: ${{ inputs.timeout }}
     steps:
       - name: Clean workspace

--- a/.github/workflows/test_linux_job_v3.yml
+++ b/.github/workflows/test_linux_job_v3.yml
@@ -1,0 +1,207 @@
+name: Test build/test linux workflow (v3 / OSDC)
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/linux_job_v3.yml
+      - .github/workflows/test_linux_job_v3.yml
+      - .github/actions/setup-linux/action.yml
+      - .github/scripts/run_with_env_secrets.py
+  workflow_dispatch:
+
+jobs:
+  test-cpu:
+    uses: ./.github/workflows/linux_job_v3.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      job-name: "linux-py3.10-cpu"
+      runner: mt-l-x86iavx512-8-64
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      checkout-mode: "treeless"
+      submodules: "recursive"
+      gpu-arch-type: cpu
+      gpu-arch-version: ""
+      script: |
+        conda create --yes --quiet -n test python=3.10
+        conda activate test
+        python3 -m pip install --index-url https://download.pytorch.org/whl/nightly/cpu --pre torch
+        # Can import pytorch
+        python3 -c 'import torch'
+  test-cpu-arm64:
+    uses: ./.github/workflows/linux_job_v3.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      job-name: "linux-arm64-cpu"
+      runner: mt-l-arm64g4-16-62
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      gpu-arch-type: cpu
+      gpu-arch-version: ""
+      # The test-infra aarch64 image is a known, pre-built image that ARC can
+      # pull. It does not ship conda, so keep this script dependency-free.
+      docker-image: ghcr.io/pytorch/test-infra:cpu-aarch64-latest
+      script: |
+        uname -m | grep -E 'aarch64|arm64'
+        echo "hello from arm64 OSDC"
+  test-gpu:
+    uses: ./.github/workflows/linux_job_v3.yml
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        runner_type: ["mt-l-x86iavx512-11-125-a100"]
+    with:
+      job-name: "linux-py3.10-cu128"
+      runner: ${{ matrix.runner_type }}
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      submodules: ${{ 'true' }}
+      gpu-arch-type: cuda
+      gpu-arch-version: "12.8"
+      timeout: 60
+      script: |
+        nvidia-smi
+        nvcc --version | grep "cuda_12.8"
+        conda create --yes --quiet -n test python=3.10
+        conda activate test
+        # The ARC image's pip config + injected CPU-only mirror
+        # (PIP_EXTRA_INDEX_URL=.../whl/cpu) makes pip resolve torch to a +cpu
+        # wheel; clearing only the env var then falls through to external PyPI
+        # (files.pythonhosted.org), which ARC cannot reach. Disable both so pip
+        # uses only the self-contained, reachable cu128 index.
+        PIP_CONFIG_FILE=/dev/null PIP_EXTRA_INDEX_URL= \
+          python3 -m pip install --index-url https://download.pytorch.org/whl/nightly/cu128 --pre torch
+        # Can import pytorch, cuda is available
+        python3 -c 'import torch;cuda_avail = torch.cuda.is_available();print("CUDA available: " + str(cuda_avail));assert(cuda_avail)'
+        python3 -c 'import torch;t = torch.ones([2,2], device="cuda:0");print(t);print("tensor device:" + str(t.device))'
+        python3 -c 'import torch;assert(torch.version.cuda == "12.8")'
+  test-docker-image:
+    uses: ./.github/workflows/linux_job_v3.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      runner: mt-l-x86iavx512-8-64
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      # On OSDC the checkout runs inside the job container, so the image must
+      # ship git (>= 2.18). Use a pre-built pytorch image that has it rather
+      # than a bare distro image like fedora:37, which has no git installed.
+      docker-image: ghcr.io/pytorch/test-infra:cpu-x86_64-latest
+      script: |
+        source /etc/os-release && [[ "${ID}" = "almalinux" ]] || exit 1
+        git --version
+  test-upload-artifact:
+    uses: ./.github/workflows/linux_job_v3.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      runner: mt-l-x86iavx512-8-64
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      upload-artifact: my-cool-artifact-v3
+      script: |
+        echo "hello" > "${RUNNER_ARTIFACT_DIR}/cool_beans"
+  test-upload-artifact-no-artifact:
+    uses: ./.github/workflows/linux_job_v3.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      runner: mt-l-x86iavx512-8-64
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      upload-artifact: my-cool-artifact-v3
+      script: |
+        echo "hello"
+  test-upload-artifact-s3:
+    uses: ./.github/workflows/linux_job_v3.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      runner: mt-l-x86iavx512-8-64
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      upload-artifact: my-cool-artifact-v3
+      upload-artifact-to-s3: true
+      script: |
+        echo "hello" > "${RUNNER_ARTIFACT_DIR}/cool_beans"
+  test-upload-artifact-s3-no-artifact:
+    uses: ./.github/workflows/linux_job_v3.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      runner: mt-l-x86iavx512-8-64
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      upload-artifact: my-cool-artifact-v3
+      upload-artifact-to-s3: true
+      script: |
+        echo "hello"
+  test-download-artifact:
+    needs: test-upload-artifact
+    uses: ./.github/workflows/linux_job_v3.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      runner: mt-l-x86iavx512-8-64
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      download-artifact: my-cool-artifact-v3
+      script: |
+        grep  "hello" "${RUNNER_ARTIFACT_DIR}/cool_beans"
+  upload-docs:
+    uses: ./.github/workflows/linux_job_v3.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      runner: mt-l-x86iavx512-8-64
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      script: |
+        echo "hello" > "${RUNNER_DOCS_DIR}/index.html"
+  verify-upload-docs:
+    needs: upload-docs
+    uses: ./.github/workflows/linux_job_v3.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      runner: mt-l-x86iavx512-8-64
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      script: |
+        # Sleep a couple of seconds just in case S3 is being slow (might not be needed?)
+        sleep 10
+        REPO_NAME="$(echo "${GITHUB_REPOSITORY}" | cut -d '/' -f2)"
+        curl -fsSL "https://docs-preview.pytorch.org/pytorch/${REPO_NAME}/${PR_NUMBER}/index.html" | grep "hello"
+  test-with-matrix:
+    uses: ./.github/workflows/linux_job_v3.yml
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        python_version: ["3.10", "3.11", "3.12", "3.13"]
+    with:
+      runner: mt-l-x86iavx512-8-64
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      binary-matrix: ${{ toJSON(matrix) }}
+      script: |
+        set -x
+        PYTHON_VERSION="${{ matrix.python_version }}"
+        conda create --yes --quiet -n test python="${PYTHON_VERSION}"
+        conda activate test
+        python --version | grep "${PYTHON_VERSION}"

--- a/.github/workflows/test_linux_job_v3.yml
+++ b/.github/workflows/test_linux_job_v3.yml
@@ -71,14 +71,15 @@ jobs:
         conda create --yes --quiet -n test python=3.10
         conda activate test
 
-        sleep 7200
-        # The ARC image's pip config + injected CPU-only mirror
-        # (PIP_EXTRA_INDEX_URL=.../whl/cpu) makes pip resolve torch to a +cpu
-        # wheel; clearing only the env var then falls through to external PyPI
-        # (files.pythonhosted.org), which ARC cannot reach. Disable both so pip
-        # uses only the self-contained, reachable cu128 index.
-        PIP_CONFIG_FILE=/dev/null PIP_EXTRA_INDEX_URL= \
-          python3 -m pip install --index-url https://download.pytorch.org/whl/nightly/cu128 --pre torch
+        # Route the nightly cu128 channel THROUGH the in-cluster pypi-cache. It is the only
+        # source of the cu128 nightly (so pip can't prefer a competing pypi final torch), and
+        # the cache rewrites the deps' otherwise-blocked files.pythonhosted.org URLs to
+        # reachable proxied paths. (cache-enforcer iptables-blocks pypi.org/pythonhosted on ARC;
+        # a literal download.pytorch.org index can't fetch deps, and adding /simple/ as an extra
+        # index lets the pypi final torch win over the nightly.) Clear the runner's default cpu
+        # extra index so it can't add a competing torch.
+        PIP_EXTRA_INDEX_URL= PIP_TRUSTED_HOST=pypi-cache-cu128.pypi-cache.svc.cluster.local \
+          python3 -m pip install --index-url http://pypi-cache-cu128.pypi-cache.svc.cluster.local:8080/whl/nightly/cu128/ --pre torch
         # Can import pytorch, cuda is available
         python3 -c 'import torch;cuda_avail = torch.cuda.is_available();print("CUDA available: " + str(cuda_avail));assert(cuda_avail)'
         python3 -c 'import torch;t = torch.ones([2,2], device="cuda:0");print(t);print("tensor device:" + str(t.device))'

--- a/.github/workflows/test_linux_job_v3.yml
+++ b/.github/workflows/test_linux_job_v3.yml
@@ -71,15 +71,12 @@ jobs:
         conda create --yes --quiet -n test python=3.10
         conda activate test
 
-        # Route the nightly cu128 channel THROUGH the in-cluster pypi-cache. It is the only
-        # source of the cu128 nightly (so pip can't prefer a competing pypi final torch), and
-        # the cache rewrites the deps' otherwise-blocked files.pythonhosted.org URLs to
-        # reachable proxied paths. (cache-enforcer iptables-blocks pypi.org/pythonhosted on ARC;
-        # a literal download.pytorch.org index can't fetch deps, and adding /simple/ as an extra
-        # index lets the pypi final torch win over the nightly.) Clear the runner's default cpu
-        # extra index so it can't add a competing torch.
-        PIP_EXTRA_INDEX_URL= PIP_TRUSTED_HOST=pypi-cache-cu128.pypi-cache.svc.cluster.local \
-          python3 -m pip install --index-url http://pypi-cache-cu128.pypi-cache.svc.cluster.local:8080/whl/nightly/cu128/ --pre torch
+        # Pre-install torch's pure-python deps from the in-cluster pypi-cache for speed.
+        python3 -m pip install filelock typing-extensions "setuptools<82" sympy networkx jinja2 fsspec
+        # Clear PIP_EXTRA_INDEX_URL (the runner's default cpu /whl/cpu/) so it can't supply a
+        # +cpu torch; --index-url then makes the literal nightly cu128 index the only torch source.
+        PIP_EXTRA_INDEX_URL= \
+          python3 -m pip install --index-url https://download.pytorch.org/whl/nightly/cu128 --pre torch
         # Can import pytorch, cuda is available
         python3 -c 'import torch;cuda_avail = torch.cuda.is_available();print("CUDA available: " + str(cuda_avail));assert(cuda_avail)'
         python3 -c 'import torch;t = torch.ones([2,2], device="cuda:0");print(t);print("tensor device:" + str(t.device))'

--- a/.github/workflows/test_linux_job_v3.yml
+++ b/.github/workflows/test_linux_job_v3.yml
@@ -70,6 +70,8 @@ jobs:
         nvcc --version | grep "cuda_12.8"
         conda create --yes --quiet -n test python=3.10
         conda activate test
+
+        sleep 7200
         # The ARC image's pip config + injected CPU-only mirror
         # (PIP_EXTRA_INDEX_URL=.../whl/cpu) makes pip resolve torch to a +cpu
         # wheel; clearing only the env var then falls through to external PyPI


### PR DESCRIPTION
Add .github/workflows/linux_job_v3.yml, an OSDC (ARC) variant of linux_job_v2.yml that takes the same inputs but runs the job inside a job-level container on an ARC runner and executes the script directly, mirroring the OSDC code path in pytorch's _linux-build / _linux-test.

Also add .github/workflows/test_linux_job_v3.yml exercising the new workflow on mt- ARC runners (CPU x86/arm64, A100 GPU, artifact/docs upload, and binary-matrix cases).