### PR TITLE
[linux_job_v3] Pin shell: bash on run steps using bashisms

### DIFF
--- a/.github/workflows/linux_job_v3.yml
+++ b/.github/workflows/linux_job_v3.yml
@@ -135,6 +135,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout }}
     steps:
       - name: Clean workspace
+        shell: bash
         run: |
           set -euxo pipefail
           echo "::group::Cleanup debug output"
@@ -234,6 +235,7 @@ jobs:
 
       - name: Prepare artifacts for upload
         if: always()
+        shell: bash
         working-directory: ${{ inputs.repository || github.repository }}
         id: check-artifacts
         env:


### PR DESCRIPTION
The `Clean workspace` (`set -euxo pipefail`) and `Prepare artifacts for upload` (`[[ … ]]`) steps had no explicit `shell:`, so in a container job they run under the default `sh`. On images where `/bin/sh` is **dash** (Ubuntu/Debian), `set -o pipefail` fails with `Illegal option -o pipefail`; RHEL-family images (`/bin/sh` → bash) masked it.

Pinning `shell: bash` on those steps makes them independent of the container's `/bin/sh`.

Repro: a v3 job on an Ubuntu-based image fails at Clean workspace ([torchtitan#3464](https://github.com/pytorch/torchtitan/pull/3464)); the same workflow on `almalinux-builder` passes.