### PR TITLE
[CRCR] Set `callback-url` default as the in-prod lambda url

### DIFF
--- a/.github/actions/cross-repo-ci-relay-callback/action.yml
+++ b/.github/actions/cross-repo-ci-relay-callback/action.yml
@@ -33,7 +33,8 @@ inputs:
   callback-url:
     description: >
       Base URL of the result callback server.
-    required: true
+    required: false
+    default: https://gwuj7w5coh4y4l66urspge6mnm0pwaxq.lambda-url.us-east-1.on.aws/github/callback/
   artifact-url:
     description: >
       URL to downstream-hosted artifacts (logs, reports, results),


### PR DESCRIPTION
Set the `callback-url` default to make convenience to downstream repos.

@zxiiro @atalman @fffrog @can-gaa-hou @subinz1