### PR TITLE
cost_analysis: region / fleet / per-PR-commit / category breakdowns

### DIFF
--- a/torchci/clickhouse_queries/autorevert_activity/params.json
+++ b/torchci/clickhouse_queries/autorevert_activity/params.json
@@ -1,0 +1,9 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/autorevert_activity/query.sql
+++ b/torchci/clickhouse_queries/autorevert_activity/query.sql
@@ -1,0 +1,22 @@
+-- Autorevert system activity per time bucket, by action:
+--   revert   = a bad commit was reverted
+--   restart  = workflows re-run on a suspected-bad commit
+--   advisor  = advisory signal only (no action taken)
+-- Excludes dry-run events. `commits` is distinct commit_sha touched.
+select
+    DATE_TRUNC({granularity: String}, ts) as granularity_bucket,
+    action,
+    count() as events,
+    uniqExact(commit_sha) as commits
+from
+    misc.autorevert_events_v2
+where
+    repo in {selectedRepos: Array(String)}
+    and dry_run = 0
+    and ts > {startTime: DateTime64(9)}
+    and ts < {stopTime: DateTime64(9)}
+group by
+    granularity_bucket,
+    action
+order by
+    granularity_bucket asc

--- a/torchci/clickhouse_queries/ci_counts/params.json
+++ b/torchci/clickhouse_queries/ci_counts/params.json
@@ -1,0 +1,9 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/ci_counts/query.sql
+++ b/torchci/clickhouse_queries/ci_counts/query.sql
@@ -1,0 +1,39 @@
+-- Per-bucket CI volume + cost-by-category + merge/slop for pytorch/pytorch (long format for a table).
+-- Categories: inside-PR (PR CI) / after-merge (main) / nightly / benchmark·periodic·other.
+-- merged PRs come from squash-merge messages on main (pull_request.merged is unreliable here).
+with
+  k as (
+    select DATE_TRUNC({granularity: String}, date) as b,
+           uniqExactIf(key, kind='pr') as n_pr,
+           uniqExactIf(key, kind='plain') as n_plain,
+           uniqExactIf(key, kind='main') as n_main,
+           uniqExactIf(key, kind='merged') as n_merged
+    from misc.unit_keys
+    where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
+      and repo in {selectedRepos: Array(String)}
+    group by b
+  ),
+  c as (
+    select DATE_TRUNC({granularity: String}, date) as b,
+           sum(pr_cost) as prc, sum(main_cost) as mc, sum(nightly_cost) as nc,
+           sum(bpo_cost) as bpo, sum(total_cost) as tot
+    from misc.unit_cost_daily
+    where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
+      and repo in {selectedRepos: Array(String)}
+    group by b
+  )
+select granularity_bucket, metric, value
+from (
+    select b as granularity_bucket, '# PRs ran CI' as metric, toFloat64(n_pr) as value from k
+    union all select b, '# PRs merged', toFloat64(n_merged) from k
+    union all select b, 'merge rate %', round(100 * n_merged / nullIf(n_pr, 0), 0) from k
+    union all select b, 'commits / PR', round(n_plain / nullIf(n_pr, 0), 2) from k
+    union all select c.b, 'inside-PR $', round(prc) from c
+    union all select c.b, 'after-merge $', round(mc) from c
+    union all select c.b, 'nightly $', round(nc) from c
+    union all select c.b, 'benchmark/periodic/other $', round(bpo) from c
+    union all select c.b, 'TOTAL $', round(tot) from c
+    union all select k.b, 'unmerged PR $ (est)', round(prc * (1 - n_merged / nullIf(n_pr, 0)))
+      from k inner join c on k.b = c.b
+)
+order by granularity_bucket asc

--- a/torchci/clickhouse_queries/ci_counts/query.sql
+++ b/torchci/clickhouse_queries/ci_counts/query.sql
@@ -1,5 +1,5 @@
 -- Per-bucket CI volume + cost-by-category + merge/slop for pytorch/pytorch (long format for a table).
--- Categories: inside-PR (PR CI) / after-merge (main) / nightly / benchmark·periodic·other.
+-- Categories: inside-PR / after-merge / nightly / periodic / benchmark / other.
 -- merged PRs come from squash-merge messages on main (pull_request.merged is unreliable here).
 with
   k as (
@@ -15,8 +15,8 @@ with
   ),
   c as (
     select DATE_TRUNC({granularity: String}, date) as b,
-           sum(pr_cost) as prc, sum(main_cost) as mc, sum(nightly_cost) as nc,
-           sum(bpo_cost) as bpo, sum(total_cost) as tot
+           sum(pr_cost) prc, sum(main_cost) mc, sum(nightly_cost) nc,
+           sum(periodic_cost) pe, sum(benchmark_cost) be, sum(other_cost) ot, sum(total_cost) tot
     from misc.unit_cost_daily
     where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
       and repo in {selectedRepos: Array(String)}
@@ -31,7 +31,9 @@ from (
     union all select c.b, 'inside-PR $', round(prc) from c
     union all select c.b, 'after-merge $', round(mc) from c
     union all select c.b, 'nightly $', round(nc) from c
-    union all select c.b, 'benchmark/periodic/other $', round(bpo) from c
+    union all select c.b, 'periodic $', round(pe) from c
+    union all select c.b, 'benchmark $', round(be) from c
+    union all select c.b, 'other $', round(ot) from c
     union all select c.b, 'TOTAL $', round(tot) from c
     union all select k.b, 'unmerged PR $ (est)', round(prc * (1 - n_merged / nullIf(n_pr, 0)))
       from k inner join c on k.b = c.b

--- a/torchci/clickhouse_queries/ci_hours_per_unit/params.json
+++ b/torchci/clickhouse_queries/ci_hours_per_unit/params.json
@@ -1,0 +1,9 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/ci_hours_per_unit/query.sql
+++ b/torchci/clickhouse_queries/ci_hours_per_unit/query.sql
@@ -1,0 +1,31 @@
+-- Average CI compute-hours per commit and per PR, per time bucket. Long format
+-- (metric/value) so it can be grouped by `metric` in a time-series panel.
+-- commit = distinct head_sha on push events; PR = distinct PR branch on
+-- pull_request events. Hours = sum of job wall-clock (completed - started).
+with base as (
+    select
+        DATE_TRUNC({granularity: String}, created_at) as granularity_bucket,
+        round(
+            sumIf(dateDiff('second', started_at, completed_at), workflow_event = 'push') / 3600
+                / nullIf(uniqExactIf(head_sha, workflow_event = 'push'), 0),
+            1
+        ) as hours_per_commit,
+        round(
+            sumIf(dateDiff('second', started_at, completed_at), workflow_event = 'pull_request') / 3600
+                / nullIf(uniqExactIf(head_branch, workflow_event = 'pull_request'), 0),
+            1
+        ) as hours_per_pr
+    from
+        default.workflow_job
+    where
+        repository_full_name in {selectedRepos: Array(String)}
+        and completed_at > started_at
+        and created_at > {startTime: DateTime64(9)}
+        and created_at < {stopTime: DateTime64(9)}
+    group by
+        granularity_bucket
+)
+select granularity_bucket, 'per commit' as metric, hours_per_commit as value from base
+union all
+select granularity_bucket, 'per PR' as metric, hours_per_pr as value from base
+order by granularity_bucket asc

--- a/torchci/clickhouse_queries/ci_volume_per_period/params.json
+++ b/torchci/clickhouse_queries/ci_volume_per_period/params.json
@@ -1,0 +1,9 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/ci_volume_per_period/query.sql
+++ b/torchci/clickhouse_queries/ci_volume_per_period/query.sql
@@ -1,0 +1,21 @@
+-- Number of commits (push-triggered, distinct head_sha) and PRs (distinct PR
+-- branch on pull_request events) that ran CI, per time bucket. Long format
+-- (metric/value) so it can be grouped by `metric` in a time-series panel.
+with base as (
+    select
+        DATE_TRUNC({granularity: String}, created_at) as granularity_bucket,
+        uniqExactIf(head_sha, workflow_event = 'push') as commits,
+        uniqExactIf(head_branch, workflow_event = 'pull_request') as prs
+    from
+        default.workflow_job
+    where
+        repository_full_name in {selectedRepos: Array(String)}
+        and created_at > {startTime: DateTime64(9)}
+        and created_at < {stopTime: DateTime64(9)}
+    group by
+        granularity_bucket
+)
+select granularity_bucket, 'commits' as metric, commits as value from base
+union all
+select granularity_bucket, 'PRs' as metric, prs as value from base
+order by granularity_bucket asc

--- a/torchci/clickhouse_queries/cost_by_category/params.json
+++ b/torchci/clickhouse_queries/cost_by_category/params.json
@@ -1,0 +1,9 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/cost_by_category/query.sql
+++ b/torchci/clickhouse_queries/cost_by_category/query.sql
@@ -1,0 +1,16 @@
+-- pytorch/pytorch CI cost split into 4 mutually-exclusive categories, per time bucket (for a stacked chart).
+with c as (
+  select DATE_TRUNC({granularity: String}, date) as b,
+    sum(pr_cost) as pr, sum(main_cost) as mn, sum(nightly_cost) as ni, sum(bpo_cost) as bp
+  from misc.unit_cost_daily
+  where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
+    and repo in {selectedRepos: Array(String)}
+  group by b
+)
+select granularity_bucket, category, value from (
+  select b as granularity_bucket, 'inside PR' as category, round(pr) as value from c
+  union all select b, 'after merge', round(mn) from c
+  union all select b, 'nightly (builds)', round(ni) from c
+  union all select b, 'benchmark/periodic/other', round(bp) from c
+)
+order by granularity_bucket asc

--- a/torchci/clickhouse_queries/cost_by_category/query.sql
+++ b/torchci/clickhouse_queries/cost_by_category/query.sql
@@ -1,7 +1,8 @@
--- pytorch/pytorch CI cost split into 4 mutually-exclusive categories, per time bucket (for a stacked chart).
+-- pytorch/pytorch CI cost by category, per time bucket (for a stacked chart).
 with c as (
   select DATE_TRUNC({granularity: String}, date) as b,
-    sum(pr_cost) as pr, sum(main_cost) as mn, sum(nightly_cost) as ni, sum(bpo_cost) as bp
+    sum(pr_cost) as pr, sum(main_cost) as mn, sum(nightly_cost) as ni,
+    sum(periodic_cost) as pe, sum(benchmark_cost) as be, sum(other_cost) as ot
   from misc.unit_cost_daily
   where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
     and repo in {selectedRepos: Array(String)}
@@ -11,6 +12,8 @@ select granularity_bucket, category, value from (
   select b as granularity_bucket, 'inside PR' as category, round(pr) as value from c
   union all select b, 'after merge', round(mn) from c
   union all select b, 'nightly (builds)', round(ni) from c
-  union all select b, 'benchmark/periodic/other', round(bp) from c
+  union all select b, 'periodic', round(pe) from c
+  union all select b, 'benchmark', round(be) from c
+  union all select b, 'other', round(ot) from c
 )
 order by granularity_bucket asc

--- a/torchci/clickhouse_queries/cost_job_per_fleet/params.json
+++ b/torchci/clickhouse_queries/cost_job_per_fleet/params.json
@@ -7,9 +7,7 @@
     "selectedGPU": "Array(UInt8)",
     "selectedPlatforms": "Array(String)",
     "selectedProviders": "Array(String)",
-    "selectedOwners": "Array(String)",
-    "selectedRegions": "Array(String)",
-    "selectedFleets": "Array(String)"
+    "selectedOwners": "Array(String)"
   },
   "tests": []
 }

--- a/torchci/clickhouse_queries/cost_job_per_fleet/params.json
+++ b/torchci/clickhouse_queries/cost_job_per_fleet/params.json
@@ -1,0 +1,15 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)",
+    "selectedGPU": "Array(UInt8)",
+    "selectedPlatforms": "Array(String)",
+    "selectedProviders": "Array(String)",
+    "selectedOwners": "Array(String)",
+    "selectedRegions": "Array(String)",
+    "selectedFleets": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/cost_job_per_fleet/query.sql
+++ b/torchci/clickhouse_queries/cost_job_per_fleet/query.sql
@@ -1,8 +1,6 @@
+-- Cost by fleet. Region/fleet is inferred from the runner type (runner_cost has no region column); approximate.
 select
-    DATE_TRUNC(
-        {granularity: String},
-        rc.date
-    ) as granularity_bucket,
+    DATE_TRUNC({granularity: String}, rc.date) as granularity_bucket,
     multiIf(rc.runner_type like 'mt-%', 'OSDC/ciforge', rc.provider = 'github', 'GitHub-hosted', rc.owning_account = 'linux_foundation', 'Linux Foundation', 'Regular EC2') as fleet,
     sum(rc.cost) as total_cost
 from
@@ -16,8 +14,6 @@ where
     and rc.os in {selectedPlatforms: Array(String)}
     and rc.provider in {selectedProviders: Array(String)}
     and rc.owning_account in {selectedOwners: Array(String)}
-    and rc.region in {selectedRegions: Array(String)}
-    and multiIf(rc.runner_type like 'mt-%', 'OSDC/ciforge', rc.provider = 'github', 'GitHub-hosted', rc.owning_account = 'linux_foundation', 'Linux Foundation', 'Regular EC2') in {selectedFleets: Array(String)}
 group by
     granularity_bucket,
     fleet

--- a/torchci/clickhouse_queries/cost_job_per_fleet/query.sql
+++ b/torchci/clickhouse_queries/cost_job_per_fleet/query.sql
@@ -1,0 +1,25 @@
+select
+    DATE_TRUNC(
+        {granularity: String},
+        rc.date
+    ) as granularity_bucket,
+    multiIf(rc.runner_type like 'mt-%', 'OSDC/ciforge', rc.provider = 'github', 'GitHub-hosted', rc.owning_account = 'linux_foundation', 'Linux Foundation', 'Regular EC2') as fleet,
+    sum(rc.cost) as total_cost
+from
+    misc.runner_cost rc final
+where
+    rc.date > {startTime: DateTime64(9)}
+    and rc.date < {stopTime: DateTime64(9)}
+    and rc.cost > 0
+    and rc.group_repo in {selectedRepos: Array(String)}
+    and rc.gpu in {selectedGPU: Array(UInt8)}
+    and rc.os in {selectedPlatforms: Array(String)}
+    and rc.provider in {selectedProviders: Array(String)}
+    and rc.owning_account in {selectedOwners: Array(String)}
+    and rc.region in {selectedRegions: Array(String)}
+    and multiIf(rc.runner_type like 'mt-%', 'OSDC/ciforge', rc.provider = 'github', 'GitHub-hosted', rc.owning_account = 'linux_foundation', 'Linux Foundation', 'Regular EC2') in {selectedFleets: Array(String)}
+group by
+    granularity_bucket,
+    fleet
+order by
+    granularity_bucket asc

--- a/torchci/clickhouse_queries/cost_job_per_region/params.json
+++ b/torchci/clickhouse_queries/cost_job_per_region/params.json
@@ -7,9 +7,7 @@
     "selectedGPU": "Array(UInt8)",
     "selectedPlatforms": "Array(String)",
     "selectedProviders": "Array(String)",
-    "selectedOwners": "Array(String)",
-    "selectedRegions": "Array(String)",
-    "selectedFleets": "Array(String)"
+    "selectedOwners": "Array(String)"
   },
   "tests": []
 }

--- a/torchci/clickhouse_queries/cost_job_per_region/params.json
+++ b/torchci/clickhouse_queries/cost_job_per_region/params.json
@@ -1,0 +1,15 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)",
+    "selectedGPU": "Array(UInt8)",
+    "selectedPlatforms": "Array(String)",
+    "selectedProviders": "Array(String)",
+    "selectedOwners": "Array(String)",
+    "selectedRegions": "Array(String)",
+    "selectedFleets": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/cost_job_per_region/query.sql
+++ b/torchci/clickhouse_queries/cost_job_per_region/query.sql
@@ -1,9 +1,7 @@
+-- Cost by region. Region/fleet is inferred from the runner type (runner_cost has no region column); approximate.
 select
-    DATE_TRUNC(
-        {granularity: String},
-        rc.date
-    ) as granularity_bucket,
-    rc.region as region,
+    DATE_TRUNC({granularity: String}, rc.date) as granularity_bucket,
+    multiIf(rc.runner_type like 'mt-%', 'us-east-2', rc.provider = 'github', 'github-hosted', 'us-east-1') as region,
     sum(rc.cost) as total_cost
 from
     misc.runner_cost rc final
@@ -16,8 +14,6 @@ where
     and rc.os in {selectedPlatforms: Array(String)}
     and rc.provider in {selectedProviders: Array(String)}
     and rc.owning_account in {selectedOwners: Array(String)}
-    and rc.region in {selectedRegions: Array(String)}
-    and multiIf(rc.runner_type like 'mt-%', 'OSDC/ciforge', rc.provider = 'github', 'GitHub-hosted', rc.owning_account = 'linux_foundation', 'Linux Foundation', 'Regular EC2') in {selectedFleets: Array(String)}
 group by
     granularity_bucket,
     region

--- a/torchci/clickhouse_queries/cost_job_per_region/query.sql
+++ b/torchci/clickhouse_queries/cost_job_per_region/query.sql
@@ -1,0 +1,25 @@
+select
+    DATE_TRUNC(
+        {granularity: String},
+        rc.date
+    ) as granularity_bucket,
+    rc.region as region,
+    sum(rc.cost) as total_cost
+from
+    misc.runner_cost rc final
+where
+    rc.date > {startTime: DateTime64(9)}
+    and rc.date < {stopTime: DateTime64(9)}
+    and rc.cost > 0
+    and rc.group_repo in {selectedRepos: Array(String)}
+    and rc.gpu in {selectedGPU: Array(UInt8)}
+    and rc.os in {selectedPlatforms: Array(String)}
+    and rc.provider in {selectedProviders: Array(String)}
+    and rc.owning_account in {selectedOwners: Array(String)}
+    and rc.region in {selectedRegions: Array(String)}
+    and multiIf(rc.runner_type like 'mt-%', 'OSDC/ciforge', rc.provider = 'github', 'GitHub-hosted', rc.owning_account = 'linux_foundation', 'Linux Foundation', 'Regular EC2') in {selectedFleets: Array(String)}
+group by
+    granularity_bucket,
+    region
+order by
+    granularity_bucket asc

--- a/torchci/clickhouse_queries/cost_per_pr_by_fleet/params.json
+++ b/torchci/clickhouse_queries/cost_per_pr_by_fleet/params.json
@@ -1,0 +1,9 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/cost_per_pr_by_fleet/query.sql
+++ b/torchci/clickhouse_queries/cost_per_pr_by_fleet/query.sql
@@ -1,0 +1,26 @@
+-- Average $ per PR, split by the fleet the PR's CI ran on (OSDC/ciforge mt-* vs regular EC2 vs GitHub-hosted).
+-- Same #PRs denominator per bucket; shows where per-PR spend is shifting (e.g. OSDC migration).
+with
+  c as (
+    select DATE_TRUNC({granularity: String}, date) as b,
+           sum(pr_cost_osdc) as osdc, sum(pr_cost_regular) as regular, sum(pr_cost_github) as github
+    from misc.unit_cost_daily
+    where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
+      and repo in {selectedRepos: Array(String)}
+    group by b
+  ),
+  k as (
+    select DATE_TRUNC({granularity: String}, date) as b, uniqExactIf(key, kind='pr') as n_pr
+    from misc.unit_keys
+    where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
+      and repo in {selectedRepos: Array(String)}
+    group by b
+  )
+select granularity_bucket, fleet, avg_cost
+from (
+    select c.b as granularity_bucket, 'OSDC/ciforge' as fleet, round(osdc / nullIf(n_pr,0), 2) as avg_cost
+      from c inner join k on c.b=k.b
+    union all select c.b, 'Regular EC2', round(regular / nullIf(n_pr,0), 2) from c inner join k on c.b=k.b
+    union all select c.b, 'GitHub-hosted', round(github / nullIf(n_pr,0), 2) from c inner join k on c.b=k.b
+)
+order by granularity_bucket asc

--- a/torchci/clickhouse_queries/cost_per_unit/params.json
+++ b/torchci/clickhouse_queries/cost_per_unit/params.json
@@ -1,0 +1,9 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/cost_per_unit/query.sql
+++ b/torchci/clickhouse_queries/cost_per_unit/query.sql
@@ -1,0 +1,35 @@
+-- Average CI cost per PR / per plain commit / per main commit, per time bucket.
+-- PR/plain-commit share the PR-CI cost pool (different denominators); main uses push-to-main cost.
+-- Distinct counts are computed PER BUCKET so avg_cost * count reconciles to the bucket total.
+with
+  c as (
+    select DATE_TRUNC({granularity: String}, date) as b,
+           sum(pr_cost) as prc, sum(main_cost) as mc
+    from misc.unit_cost_daily
+    where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
+      and repo in {selectedRepos: Array(String)}
+    group by b
+  ),
+  k as (
+    select DATE_TRUNC({granularity: String}, date) as b,
+           uniqExactIf(key, kind='pr') as n_pr,
+           uniqExactIf(key, kind='plain') as n_plain,
+           uniqExactIf(key, kind='main') as n_main
+    from misc.unit_keys
+    where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
+      and repo in {selectedRepos: Array(String)}
+    group by b
+  )
+select granularity_bucket, unit, avg_cost
+from (
+    select c.b as granularity_bucket, 'per PR' as unit,
+           round(prc / nullIf(n_pr, 0), 2) as avg_cost
+      from c inner join k on c.b = k.b
+    union all
+    select c.b, 'per plain commit', round(prc / nullIf(n_plain, 0), 2)
+      from c inner join k on c.b = k.b
+    union all
+    select c.b, 'per main commit', round(mc / nullIf(n_main, 0), 2)
+      from c inner join k on c.b = k.b
+)
+order by granularity_bucket asc

--- a/torchci/clickhouse_queries/duration_job_per_fleet/params.json
+++ b/torchci/clickhouse_queries/duration_job_per_fleet/params.json
@@ -7,9 +7,7 @@
     "selectedGPU": "Array(UInt8)",
     "selectedPlatforms": "Array(String)",
     "selectedProviders": "Array(String)",
-    "selectedOwners": "Array(String)",
-    "selectedRegions": "Array(String)",
-    "selectedFleets": "Array(String)"
+    "selectedOwners": "Array(String)"
   },
   "tests": []
 }

--- a/torchci/clickhouse_queries/duration_job_per_fleet/params.json
+++ b/torchci/clickhouse_queries/duration_job_per_fleet/params.json
@@ -1,0 +1,15 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)",
+    "selectedGPU": "Array(UInt8)",
+    "selectedPlatforms": "Array(String)",
+    "selectedProviders": "Array(String)",
+    "selectedOwners": "Array(String)",
+    "selectedRegions": "Array(String)",
+    "selectedFleets": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/duration_job_per_fleet/query.sql
+++ b/torchci/clickhouse_queries/duration_job_per_fleet/query.sql
@@ -1,0 +1,25 @@
+select
+    DATE_TRUNC(
+        {granularity: String},
+        rc.date
+    ) as granularity_bucket,
+    multiIf(rc.runner_type like 'mt-%', 'OSDC/ciforge', rc.provider = 'github', 'GitHub-hosted', rc.owning_account = 'linux_foundation', 'Linux Foundation', 'Regular EC2') as fleet,
+    sum(rc.duration) as total_duration
+from
+    misc.runner_cost rc final
+where
+    rc.date > {startTime: DateTime64(9)}
+    and rc.date < {stopTime: DateTime64(9)}
+    and rc.duration > 0
+    and rc.group_repo in {selectedRepos: Array(String)}
+    and rc.gpu in {selectedGPU: Array(UInt8)}
+    and rc.os in {selectedPlatforms: Array(String)}
+    and rc.provider in {selectedProviders: Array(String)}
+    and rc.owning_account in {selectedOwners: Array(String)}
+    and rc.region in {selectedRegions: Array(String)}
+    and multiIf(rc.runner_type like 'mt-%', 'OSDC/ciforge', rc.provider = 'github', 'GitHub-hosted', rc.owning_account = 'linux_foundation', 'Linux Foundation', 'Regular EC2') in {selectedFleets: Array(String)}
+group by
+    granularity_bucket,
+    fleet
+order by
+    granularity_bucket asc

--- a/torchci/clickhouse_queries/duration_job_per_fleet/query.sql
+++ b/torchci/clickhouse_queries/duration_job_per_fleet/query.sql
@@ -1,8 +1,6 @@
+-- Duration (hours) by fleet. Region/fleet is inferred from the runner type (runner_cost has no region column); approximate.
 select
-    DATE_TRUNC(
-        {granularity: String},
-        rc.date
-    ) as granularity_bucket,
+    DATE_TRUNC({granularity: String}, rc.date) as granularity_bucket,
     multiIf(rc.runner_type like 'mt-%', 'OSDC/ciforge', rc.provider = 'github', 'GitHub-hosted', rc.owning_account = 'linux_foundation', 'Linux Foundation', 'Regular EC2') as fleet,
     sum(rc.duration) as total_duration
 from
@@ -16,8 +14,6 @@ where
     and rc.os in {selectedPlatforms: Array(String)}
     and rc.provider in {selectedProviders: Array(String)}
     and rc.owning_account in {selectedOwners: Array(String)}
-    and rc.region in {selectedRegions: Array(String)}
-    and multiIf(rc.runner_type like 'mt-%', 'OSDC/ciforge', rc.provider = 'github', 'GitHub-hosted', rc.owning_account = 'linux_foundation', 'Linux Foundation', 'Regular EC2') in {selectedFleets: Array(String)}
 group by
     granularity_bucket,
     fleet

--- a/torchci/clickhouse_queries/duration_job_per_region/params.json
+++ b/torchci/clickhouse_queries/duration_job_per_region/params.json
@@ -7,9 +7,7 @@
     "selectedGPU": "Array(UInt8)",
     "selectedPlatforms": "Array(String)",
     "selectedProviders": "Array(String)",
-    "selectedOwners": "Array(String)",
-    "selectedRegions": "Array(String)",
-    "selectedFleets": "Array(String)"
+    "selectedOwners": "Array(String)"
   },
   "tests": []
 }

--- a/torchci/clickhouse_queries/duration_job_per_region/params.json
+++ b/torchci/clickhouse_queries/duration_job_per_region/params.json
@@ -1,0 +1,15 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)",
+    "selectedGPU": "Array(UInt8)",
+    "selectedPlatforms": "Array(String)",
+    "selectedProviders": "Array(String)",
+    "selectedOwners": "Array(String)",
+    "selectedRegions": "Array(String)",
+    "selectedFleets": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/duration_job_per_region/query.sql
+++ b/torchci/clickhouse_queries/duration_job_per_region/query.sql
@@ -1,9 +1,7 @@
+-- Duration (hours) by region. Region/fleet is inferred from the runner type (runner_cost has no region column); approximate.
 select
-    DATE_TRUNC(
-        {granularity: String},
-        rc.date
-    ) as granularity_bucket,
-    rc.region as region,
+    DATE_TRUNC({granularity: String}, rc.date) as granularity_bucket,
+    multiIf(rc.runner_type like 'mt-%', 'us-east-2', rc.provider = 'github', 'github-hosted', 'us-east-1') as region,
     sum(rc.duration) as total_duration
 from
     misc.runner_cost rc final
@@ -16,8 +14,6 @@ where
     and rc.os in {selectedPlatforms: Array(String)}
     and rc.provider in {selectedProviders: Array(String)}
     and rc.owning_account in {selectedOwners: Array(String)}
-    and rc.region in {selectedRegions: Array(String)}
-    and multiIf(rc.runner_type like 'mt-%', 'OSDC/ciforge', rc.provider = 'github', 'GitHub-hosted', rc.owning_account = 'linux_foundation', 'Linux Foundation', 'Regular EC2') in {selectedFleets: Array(String)}
 group by
     granularity_bucket,
     region

--- a/torchci/clickhouse_queries/duration_job_per_region/query.sql
+++ b/torchci/clickhouse_queries/duration_job_per_region/query.sql
@@ -1,0 +1,25 @@
+select
+    DATE_TRUNC(
+        {granularity: String},
+        rc.date
+    ) as granularity_bucket,
+    rc.region as region,
+    sum(rc.duration) as total_duration
+from
+    misc.runner_cost rc final
+where
+    rc.date > {startTime: DateTime64(9)}
+    and rc.date < {stopTime: DateTime64(9)}
+    and rc.duration > 0
+    and rc.group_repo in {selectedRepos: Array(String)}
+    and rc.gpu in {selectedGPU: Array(UInt8)}
+    and rc.os in {selectedPlatforms: Array(String)}
+    and rc.provider in {selectedProviders: Array(String)}
+    and rc.owning_account in {selectedOwners: Array(String)}
+    and rc.region in {selectedRegions: Array(String)}
+    and multiIf(rc.runner_type like 'mt-%', 'OSDC/ciforge', rc.provider = 'github', 'GitHub-hosted', rc.owning_account = 'linux_foundation', 'Linux Foundation', 'Regular EC2') in {selectedFleets: Array(String)}
+group by
+    granularity_bucket,
+    region
+order by
+    granularity_bucket asc

--- a/torchci/clickhouse_queries/hours_by_category/params.json
+++ b/torchci/clickhouse_queries/hours_by_category/params.json
@@ -1,0 +1,9 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/hours_by_category/query.sql
+++ b/torchci/clickhouse_queries/hours_by_category/query.sql
@@ -1,0 +1,16 @@
+-- pytorch/pytorch CI compute-HOURS split into the same 4 categories, per time bucket (exact, no rate est).
+with c as (
+  select DATE_TRUNC({granularity: String}, date) as b,
+    sum(pr_hours) as pr, sum(main_hours) as mn, sum(nightly_hours) as ni, sum(bpo_hours) as bp
+  from misc.unit_cost_daily
+  where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
+    and repo in {selectedRepos: Array(String)}
+  group by b
+)
+select granularity_bucket, category, value from (
+  select b as granularity_bucket, 'inside PR' as category, round(pr) as value from c
+  union all select b, 'after merge', round(mn) from c
+  union all select b, 'nightly (builds)', round(ni) from c
+  union all select b, 'benchmark/periodic/other', round(bp) from c
+)
+order by granularity_bucket asc

--- a/torchci/clickhouse_queries/hours_by_category/query.sql
+++ b/torchci/clickhouse_queries/hours_by_category/query.sql
@@ -1,7 +1,8 @@
--- pytorch/pytorch CI compute-HOURS split into the same 4 categories, per time bucket (exact, no rate est).
+-- pytorch/pytorch CI hours by category, per time bucket (for a stacked chart).
 with c as (
   select DATE_TRUNC({granularity: String}, date) as b,
-    sum(pr_hours) as pr, sum(main_hours) as mn, sum(nightly_hours) as ni, sum(bpo_hours) as bp
+    sum(pr_hours) as pr, sum(main_hours) as mn, sum(nightly_hours) as ni,
+    sum(periodic_hours) as pe, sum(benchmark_hours) as be, sum(other_hours) as ot
   from misc.unit_cost_daily
   where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
     and repo in {selectedRepos: Array(String)}
@@ -11,6 +12,8 @@ select granularity_bucket, category, value from (
   select b as granularity_bucket, 'inside PR' as category, round(pr) as value from c
   union all select b, 'after merge', round(mn) from c
   union all select b, 'nightly (builds)', round(ni) from c
-  union all select b, 'benchmark/periodic/other', round(bp) from c
+  union all select b, 'periodic', round(pe) from c
+  union all select b, 'benchmark', round(be) from c
+  union all select b, 'other', round(ot) from c
 )
 order by granularity_bucket asc

--- a/torchci/clickhouse_queries/hours_per_pr_by_fleet/params.json
+++ b/torchci/clickhouse_queries/hours_per_pr_by_fleet/params.json
@@ -1,0 +1,9 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/hours_per_pr_by_fleet/query.sql
+++ b/torchci/clickhouse_queries/hours_per_pr_by_fleet/query.sql
@@ -1,0 +1,27 @@
+-- CI compute-HOURS per PR, split by fleet (OSDC/ciforge mt-* vs Regular EC2 vs GitHub-hosted).
+-- Hours are exact (no rate estimate). During the OSDC shadow period both fleets ran the SAME
+-- PRs, so comparing the two lines in that window shows OSDC vs EC2 efficiency for identical work.
+with
+  c as (
+    select DATE_TRUNC({granularity: String}, date) as b,
+           sum(pr_hours_osdc) as osdc, sum(pr_hours_regular) as regular, sum(pr_hours_github) as github
+    from misc.unit_cost_daily
+    where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
+      and repo in {selectedRepos: Array(String)}
+    group by b
+  ),
+  k as (
+    select DATE_TRUNC({granularity: String}, date) as b, uniqExactIf(key, kind='pr') as n_pr
+    from misc.unit_keys
+    where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
+      and repo in {selectedRepos: Array(String)}
+    group by b
+  )
+select granularity_bucket, fleet, hours_per_pr
+from (
+    select c.b as granularity_bucket, 'OSDC/ciforge' as fleet, round(osdc / nullIf(n_pr,0), 1) as hours_per_pr
+      from c inner join k on c.b=k.b
+    union all select c.b, 'Regular EC2', round(regular / nullIf(n_pr,0), 1) from c inner join k on c.b=k.b
+    union all select c.b, 'GitHub-hosted', round(github / nullIf(n_pr,0), 1) from c inner join k on c.b=k.b
+)
+order by granularity_bucket asc

--- a/torchci/clickhouse_queries/infra_overhead/params.json
+++ b/torchci/clickhouse_queries/infra_overhead/params.json
@@ -1,0 +1,8 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/infra_overhead/query.sql
+++ b/torchci/clickhouse_queries/infra_overhead/query.sql
@@ -1,16 +1,19 @@
--- Top-down account-level EC2 cost (list basis), split into attributed CI vs overhead/idle.
--- provisioned (all EC2 usage x Vantage list) = attributed CI (sum runner_cost) + overhead.
--- Overhead = idle/min_available warm runners, k8s control plane, base infra, non-CI EC2.
+-- Top-down account-level EC2 cost (list basis), split into non-idle CI / idle / control-plane.
+-- provisioned (all EC2 usage x Vantage list) = CI (sum runner_cost) + idle + control-plane.
+--   non-idle (CI) = attributed to CI jobs
+--   idle         = runner-fleet capacity (classic EC2 + EKS nodes) not running a job
+--   control-plane = dedicated base/system nodes (pypi-cache, base nodegroups, mgmt)
 -- Account-wide: not affected by the repo / dimension filters above.
 with c as (
   select DATE_TRUNC({granularity: String}, date) as b,
-         sum(ci_cost) as ci, sum(overhead_cost) as ov
+         sum(ci_cost) as ci, sum(idle_cost) as idle, sum(control_plane_cost) as cp
   from misc.infra_overhead_daily
   where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
   group by b
 )
 select granularity_bucket, series, value from (
-  select b as granularity_bucket, 'attributed CI' as series, round(ci) as value from c
-  union all select b, 'overhead / idle', round(ov) from c
+  select b as granularity_bucket, 'non-idle (CI)' as series, round(ci) as value from c
+  union all select b, 'idle (runner fleet)', round(idle) from c
+  union all select b, 'control-plane / base', round(cp) from c
 )
 order by granularity_bucket asc

--- a/torchci/clickhouse_queries/infra_overhead/query.sql
+++ b/torchci/clickhouse_queries/infra_overhead/query.sql
@@ -1,0 +1,16 @@
+-- Top-down account-level EC2 cost (list basis), split into attributed CI vs overhead/idle.
+-- provisioned (all EC2 usage x Vantage list) = attributed CI (sum runner_cost) + overhead.
+-- Overhead = idle/min_available warm runners, k8s control plane, base infra, non-CI EC2.
+-- Account-wide: not affected by the repo / dimension filters above.
+with c as (
+  select DATE_TRUNC({granularity: String}, date) as b,
+         sum(ci_cost) as ci, sum(overhead_cost) as ov
+  from misc.infra_overhead_daily
+  where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
+  group by b
+)
+select granularity_bucket, series, value from (
+  select b as granularity_bucket, 'attributed CI' as series, round(ci) as value from c
+  union all select b, 'overhead / idle', round(ov) from c
+)
+order by granularity_bucket asc

--- a/torchci/clickhouse_queries/pct_by_category/params.json
+++ b/torchci/clickhouse_queries/pct_by_category/params.json
@@ -1,0 +1,9 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/pct_by_category/query.sql
+++ b/torchci/clickhouse_queries/pct_by_category/query.sql
@@ -1,0 +1,17 @@
+-- Each category's SHARE (% of total $) per time bucket — for a 100%-stacked view.
+with c as (
+  select DATE_TRUNC({granularity: String}, date) as b,
+    sum(pr_cost) as pr, sum(main_cost) as mn, sum(nightly_cost) as ni, sum(bpo_cost) as bp,
+    nullIf(sum(total_cost), 0) as tot
+  from misc.unit_cost_daily
+  where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
+    and repo in {selectedRepos: Array(String)}
+  group by b
+)
+select granularity_bucket, category, value from (
+  select b as granularity_bucket, 'inside PR' as category, round(100*pr/tot, 1) as value from c
+  union all select b, 'after merge', round(100*mn/tot, 1) from c
+  union all select b, 'nightly (builds)', round(100*ni/tot, 1) from c
+  union all select b, 'benchmark/periodic/other', round(100*bp/tot, 1) from c
+)
+order by granularity_bucket asc

--- a/torchci/clickhouse_queries/pct_by_category/query.sql
+++ b/torchci/clickhouse_queries/pct_by_category/query.sql
@@ -1,17 +1,20 @@
--- Each category's SHARE (% of total $) per time bucket — for a 100%-stacked view.
+-- Each category's SHARE (% of total $) per time bucket, for a 100%-stacked view.
 with c as (
   select DATE_TRUNC({granularity: String}, date) as b,
-    sum(pr_cost) as pr, sum(main_cost) as mn, sum(nightly_cost) as ni, sum(bpo_cost) as bp,
-    nullIf(sum(total_cost), 0) as tot
+    sum(pr_cost) pr, sum(main_cost) mn, sum(nightly_cost) ni,
+    sum(periodic_cost) pe, sum(benchmark_cost) be, sum(other_cost) ot,
+    nullIf(sum(total_cost), 0) tot
   from misc.unit_cost_daily
   where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
     and repo in {selectedRepos: Array(String)}
   group by b
 )
 select granularity_bucket, category, value from (
-  select b as granularity_bucket, 'inside PR' as category, round(100*pr/tot, 1) as value from c
-  union all select b, 'after merge', round(100*mn/tot, 1) from c
-  union all select b, 'nightly (builds)', round(100*ni/tot, 1) from c
-  union all select b, 'benchmark/periodic/other', round(100*bp/tot, 1) from c
+  select b as granularity_bucket, 'inside PR' as category, round(100*pr/tot,1) as value from c
+  union all select b, 'after merge', round(100*mn/tot,1) from c
+  union all select b, 'nightly (builds)', round(100*ni/tot,1) from c
+  union all select b, 'periodic', round(100*pe/tot,1) from c
+  union all select b, 'benchmark', round(100*be/tot,1) from c
+  union all select b, 'other', round(100*ot/tot,1) from c
 )
 order by granularity_bucket asc

--- a/torchci/clickhouse_queries/pct_by_fleet/params.json
+++ b/torchci/clickhouse_queries/pct_by_fleet/params.json
@@ -1,0 +1,9 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/pct_by_fleet/query.sql
+++ b/torchci/clickhouse_queries/pct_by_fleet/query.sql
@@ -1,0 +1,16 @@
+-- Each fleet's SHARE (% of total inside-PR compute-hours) per time bucket — 100%-stacked view.
+with c as (
+  select DATE_TRUNC({granularity: String}, date) as b,
+    sum(pr_hours_osdc) as o, sum(pr_hours_regular) as r, sum(pr_hours_github) as g,
+    nullIf(sum(pr_hours_osdc)+sum(pr_hours_regular)+sum(pr_hours_github), 0) as tot
+  from misc.unit_cost_daily
+  where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
+    and repo in {selectedRepos: Array(String)}
+  group by b
+)
+select granularity_bucket, fleet, value from (
+  select b as granularity_bucket, 'OSDC/ciforge' as fleet, round(100*o/tot, 1) as value from c
+  union all select b, 'Regular EC2', round(100*r/tot, 1) from c
+  union all select b, 'GitHub-hosted', round(100*g/tot, 1) from c
+)
+order by granularity_bucket asc

--- a/torchci/clickhouse_queries/pr_cost_drivers/params.json
+++ b/torchci/clickhouse_queries/pr_cost_drivers/params.json
@@ -1,0 +1,9 @@
+{
+  "params": {
+    "granularity": "String",
+    "startTime": "DateTime64(9)",
+    "stopTime": "DateTime64(9)",
+    "selectedRepos": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/pr_cost_drivers/query.sql
+++ b/torchci/clickhouse_queries/pr_cost_drivers/query.sql
@@ -1,0 +1,29 @@
+-- Drivers behind per-PR cost: PR volume, commits/PR, jobs/PR, compute-hours/PR, effective $/hr.
+-- Lets you see WHY $/PR moved (more tests? more PRs? more commits/PR? price/fleet mix?).
+with
+  k as (
+    select DATE_TRUNC({granularity: String}, date) as b,
+           uniqExactIf(key, kind='pr') as n_pr, uniqExactIf(key, kind='plain') as n_plain
+    from misc.unit_keys
+    where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
+      and repo in {selectedRepos: Array(String)}
+    group by b
+  ),
+  c as (
+    select DATE_TRUNC({granularity: String}, date) as b,
+           sum(pr_cost) as prc, sum(pr_jobs) as jobs, sum(pr_hours) as hours
+    from misc.unit_cost_daily
+    where date > {startTime: DateTime64(9)} and date < {stopTime: DateTime64(9)}
+      and repo in {selectedRepos: Array(String)}
+    group by b
+  )
+select granularity_bucket, metric, value
+from (
+    select k.b as granularity_bucket, '# PRs' as metric, toFloat64(n_pr) as value from k
+    union all select k.b, 'commits / PR', round(n_plain / nullIf(n_pr,0), 2) from k
+    union all select c.b, 'jobs / PR', round(jobs / nullIf(n_pr,0), 1) from c inner join k on c.b=k.b
+    union all select c.b, 'CI hours / PR', round(hours / nullIf(n_pr,0), 1) from c inner join k on c.b=k.b
+    union all select c.b, '$ / hr (effective)', round(prc / nullIf(hours,0), 3) from c
+    union all select c.b, '$ / PR', round(prc / nullIf(n_pr,0), 2) from c inner join k on c.b=k.b
+)
+order by granularity_bucket asc

--- a/torchci/components/metrics/panels/TimeSeriesTable.tsx
+++ b/torchci/components/metrics/panels/TimeSeriesTable.tsx
@@ -310,6 +310,7 @@ export default function TimeSeriesTable({
           rows={tableData}
           columns={columns}
           density="compact"
+          disableVirtualization
           pageSizeOptions={[25, 50, 100]}
           columnVisibilityModel={{
             // Ensure all columns are visible by default
@@ -348,14 +349,25 @@ export default function TimeSeriesTable({
                   ? "rgba(255, 255, 255, 0.04)"
                   : "rgba(0, 0, 0, 0.04)",
             },
-            // First column styling
+            // First column: pinned/sticky so row titles stay visible when scrolling right.
+            // (Community DataGrid has no column pinning, so we do it with sticky CSS +
+            // disableVirtualization so off-screen columns still render.)
             "& .first-column-header": {
+              position: "sticky",
+              left: 0,
+              zIndex: 4,
               backgroundColor: "#1a635d" /* Darker shade for emphasis */,
               color: "#ffffff",
             },
             "& .first-column-cell": {
-              backgroundColor: "rgba(47, 132, 124, 0.1)",
+              position: "sticky",
+              left: 0,
+              zIndex: 3,
+              // opaque (not translucent) so scrolled cells don't show through
+              backgroundColor: (theme) =>
+                theme.palette.mode === "dark" ? "#10403b" : "#e8f1f0",
               fontWeight: "bold",
+              borderRight: "2px solid var(--table-border-color)",
             },
             // Cell borders using CSS variable
             "& .MuiDataGrid-cell": {

--- a/torchci/lib/clickhouse.ts
+++ b/torchci/lib/clickhouse.ts
@@ -4,11 +4,19 @@
 // deploy.
 import { createClient } from "@clickhouse/client";
 import { readFileSync } from "fs";
+import { HttpsProxyAgent } from "https-proxy-agent";
 import { v4 as uuidv4 } from "uuid";
 // Import itself to ensure that mocks can be applied, see
 // https://stackoverflow.com/questions/51900413/jest-mock-function-doesnt-work-while-it-was-called-in-the-other-function
 // https://stackoverflow.com/questions/45111198/how-to-mock-functions-in-the-same-module-using-jest
 import * as thisModule from "./clickhouse";
+
+// Route ClickHouse traffic through an HTTP(S) proxy when one is configured (e.g. local
+// dev behind the x2p agent proxy). No-op in production where no proxy env is set.
+function proxyAgent() {
+  const proxy = process.env.HTTPS_PROXY ?? process.env.https_proxy;
+  return proxy ? new HttpsProxyAgent(proxy) : undefined;
+}
 
 export function getClickhouseClient() {
   return createClient({
@@ -16,6 +24,7 @@ export function getClickhouseClient() {
     username: process.env.CLICKHOUSE_HUD_USER_USERNAME ?? "default",
     password: process.env.CLICKHOUSE_HUD_USER_PASSWORD ?? "",
     request_timeout: 180_000, // 3 mins
+    http_agent: proxyAgent(),
   });
 }
 //

--- a/torchci/pages/cost_analysis.tsx
+++ b/torchci/pages/cost_analysis.tsx
@@ -1137,13 +1137,13 @@ export default function Page() {
         <Grid container marginTop={4} size={{ xs: 11.5 }}>
           <Grid size={{ xs: 12 }} height={ROW_HEIGHT}>
             <Typography fontSize={"1rem"} fontWeight={"bold"}>
-              Top-down: attributed CI vs overhead/idle (account-wide, list prices, ignores the
-              repo/dimension filters). Overhead = idle warm runners, k8s control plane, base
-              infra, non-CI EC2.
+              Top-down: non-idle CI vs idle vs control-plane (account-wide, list prices, ignores
+              the repo/dimension filters). Idle = runner fleet (classic EC2 + EKS nodes) not
+              running a job; control-plane = dedicated base/system nodes.
             </Typography>
             {!isLoading && (
               <TimeSeriesPanel
-                title={`EC2 cost: CI vs overhead per ${granularity}`}
+                title={`EC2 cost: CI / idle / control-plane per ${granularity}`}
                 queryName={"infra_overhead"}
                 queryParams={{ ...timeParamsClickHouse }}
                 granularity={granularity}

--- a/torchci/pages/cost_analysis.tsx
+++ b/torchci/pages/cost_analysis.tsx
@@ -1133,6 +1133,34 @@ export default function Page() {
             </div>
           </Grid>
         </Grid>
+
+        <Grid container marginTop={4} size={{ xs: 11.5 }}>
+          <Grid size={{ xs: 12 }} height={ROW_HEIGHT}>
+            <Typography fontSize={"1rem"} fontWeight={"bold"}>
+              Top-down: attributed CI vs overhead/idle (account-wide, list prices, ignores the
+              repo/dimension filters). Overhead = idle warm runners, k8s control plane, base
+              infra, non-CI EC2.
+            </Typography>
+            {!isLoading && (
+              <TimeSeriesPanel
+                title={`EC2 cost: CI vs overhead per ${granularity}`}
+                queryName={"infra_overhead"}
+                queryParams={{ ...timeParamsClickHouse }}
+                granularity={granularity}
+                groupByFieldName={"series"}
+                timeFieldName={"granularity_bucket"}
+                yAxisFieldName={"value"}
+                yAxisRenderer={costDisplay}
+                chartType={"stacked_bar"}
+                smooth={false}
+                timeFieldDisplayFormat="M/D (UTC)"
+                sort_by="name"
+                auto_refresh={false}
+                useUTC={true}
+              />
+            )}
+          </Grid>
+        </Grid>
       </Grid>
     </div>
   );

--- a/torchci/pages/cost_analysis.tsx
+++ b/torchci/pages/cost_analysis.tsx
@@ -992,8 +992,9 @@ export default function Page() {
               sx={{ mb: 1 }}
             >
               <Typography fontSize={"1rem"} fontWeight={"bold"}>
-                Per PR by fleet (OSDC vs Regular EC2) — during shadow both ran the
-                same PRs; compare for efficiency/regression ($ is estimated for OSDC)
+                Per PR by fleet (OSDC vs Regular EC2). During the shadow window both
+                ran the same PRs, so the lines are directly comparable. $ is Vantage
+                list price (OSDC GPUs priced per card).
               </Typography>
               <ToggleButtonGroup
                 size="small"

--- a/torchci/pages/cost_analysis.tsx
+++ b/torchci/pages/cost_analysis.tsx
@@ -152,6 +152,8 @@ type CostCategory =
   | "provider"
   | "repo"
   | "gpu"
+  | "region"
+  | "fleet"
   | "owning_account";
 
 type YAxis = "cost" | "duration";
@@ -185,12 +187,65 @@ const hourDisplay = (value: number) => {
   return `${(value / 1000).toFixed(0)}k h`;
 };
 
+const pctDisplay = (value: number) => `${Number(value).toFixed(0)}%`;
+// renderer for the "by category / by fleet over time" metric toggle
+const metricRenderer = (m: "cost" | "hours" | "pct") =>
+  m === "cost" ? costDisplay : m === "hours" ? hourDisplay : pctDisplay;
+
+// Line / Stacked-bar / Bar selector using the same icons as the top chart.
+function ChartTypeToggle({
+  value,
+  onChange,
+}: {
+  value: ChartType;
+  onChange: (_v: ChartType) => void;
+}) {
+  const icon = { display: "flex", alignItems: "center", justifyContent: "center" };
+  return (
+    <ToggleButtonGroup
+      size="small"
+      exclusive
+      value={value}
+      onChange={(_e, v) => v && onChange(v)}
+    >
+      <ToggleButton value="line">
+        <Tooltip title="Line Chart">
+          <Box sx={icon}>
+            <BiLineChart size={"1.4em"} />
+          </Box>
+        </Tooltip>
+      </ToggleButton>
+      <ToggleButton value="stacked_bar">
+        <Tooltip title="Stacked Bar Chart">
+          <Box sx={icon}>
+            <MdOutlineStackedBarChart size={"1.4em"} />
+          </Box>
+        </Tooltip>
+      </ToggleButton>
+      <ToggleButton value="bar">
+        <Tooltip title="Bar Chart">
+          <Box sx={icon}>
+            <FaRegChartBar size={"1.4em"} />
+          </Box>
+        </Tooltip>
+      </ToggleButton>
+    </ToggleButtonGroup>
+  );
+}
+
 const ROW_HEIGHT = 700;
 
 const OS_OPTIONS = ["linux", "windows", "macos", "NA"];
 const GPU_OPTIONS = ["gpu", "non-gpu"];
 const PROVIDER_OPTIONS = ["aws", "gcp", "github", "amd", "NA"];
 const OWNER_OPTIONS = ["linux_foundation", "meta", "amd", "NA"];
+const REGION_OPTIONS = ["us-east-1", "us-east-2", "us-west-1", "github-hosted"];
+const FLEET_OPTIONS = [
+  "Regular EC2",
+  "OSDC/ciforge",
+  "Linux Foundation",
+  "GitHub-hosted",
+];
 
 export default function Page() {
   const router = useRouter();
@@ -259,6 +314,16 @@ export default function Page() {
   const [selectedProviders, setSelectedProviders] = useState(
     initialSelectedProviders
   );
+  const [selectedRegions, setSelectedRegions] =
+    useState<string[]>(REGION_OPTIONS);
+  const [selectedFleets, setSelectedFleets] = useState<string[]>(FLEET_OPTIONS);
+  // local controls for the "by category over time" chart
+  const [catMetric, setCatMetric] = useState<"cost" | "hours" | "pct">("cost");
+  const [catChartType, setCatChartType] = useState<ChartType>("stacked_bar");
+  const [fleetMetric, setFleetMetric] = useState<"cost" | "hours" | "pct">(
+    "hours"
+  );
+  const [fleetChartType, setFleetChartType] = useState<ChartType>("line");
   const [selectedYAxis, setSelectedYAxis] = useState<YAxis>(
     initialSelectedYAxis || "cost"
   );
@@ -288,7 +353,10 @@ export default function Page() {
     setSearchFilter(initialSearchFilter as string);
     setIsRegex(initialIsRegex);
     setShowInstanceType(initialShowInstanceType);
-    if (initialSelectedRepos) {
+    // Only restore repos from the URL when a non-empty set was specified; otherwise
+    // leave selection empty so the repo-list loader defaults it to all repos. ([] is
+    // truthy, so an empty `repos=` param must not reset/clear the selection.)
+    if (initialSelectedRepos && initialSelectedRepos.length > 0) {
       setSelectedRepos(initialSelectedRepos);
     }
   }
@@ -411,6 +479,8 @@ export default function Page() {
               selectedOwners,
               selectedPlatforms: selectedOS,
               selectedProviders,
+              selectedRegions,
+              selectedFleets,
             }}
             granularity={granularity}
             groupByFieldName={actualGroupBy}
@@ -483,6 +553,8 @@ export default function Page() {
               <MenuItem value={"job_name"}>Job Name</MenuItem>
               <MenuItem value={"platform"}>Platform</MenuItem>
               <MenuItem value={"provider"}>Provider</MenuItem>
+              <MenuItem value={"region"}>Region</MenuItem>
+              <MenuItem value={"fleet"}>Fleet (OSDC/ciforge vs EC2)</MenuItem>
               <MenuItem value={"owning_account"}>Owning Account</MenuItem>
               <MenuItem value={"gpu"}>GPU/Non-GPU</MenuItem>
               <MenuItem value={"repo"}>Repository</MenuItem>
@@ -602,6 +674,34 @@ export default function Page() {
             label={"GPU/Non-GPU"}
             renderValue={(selectedItems) => {
               if (selectedItems.length == GPU_OPTIONS.length) return "All";
+              if (selectedItems.length == 0) return "None";
+              return selectedItems.join(",");
+            }}
+            style={{ width: "100%" }}
+          />
+        </Grid>
+        <Grid size={{ xs: 2 }}>
+          <MultiSelectPicker
+            initialSelected={selectedRegions}
+            onSelectChanged={setSelectedRegions}
+            options={REGION_OPTIONS}
+            label={"Region"}
+            renderValue={(selectedItems) => {
+              if (selectedItems.length == REGION_OPTIONS.length) return "All";
+              if (selectedItems.length == 0) return "None";
+              return selectedItems.join(",");
+            }}
+            style={{ width: "100%" }}
+          />
+        </Grid>
+        <Grid size={{ xs: 2 }}>
+          <MultiSelectPicker
+            initialSelected={selectedFleets}
+            onSelectChanged={setSelectedFleets}
+            options={FLEET_OPTIONS}
+            label={"Fleet"}
+            renderValue={(selectedItems) => {
+              if (selectedItems.length == FLEET_OPTIONS.length) return "All";
               if (selectedItems.length == 0) return "None";
               return selectedItems.join(",");
             }}
@@ -805,6 +905,8 @@ export default function Page() {
                 selectedOwners,
                 selectedPlatforms: selectedOS,
                 selectedProviders,
+                selectedRegions,
+                selectedFleets,
               }}
               granularity={granularity}
               groupByFieldName={
@@ -833,6 +935,202 @@ export default function Page() {
             />
           )}
           {isLoading && <div>Loading...</div>}
+        </Grid>
+
+        <Grid container marginTop={4} size={{ xs: 11.5 }} spacing={2}>
+          <Grid size={{ xs: 12, lg: 7 }} height={ROW_HEIGHT}>
+            <Typography fontSize={"1rem"} fontWeight={"bold"}>
+              Average CI cost per PR / plain commit / main commit
+            </Typography>
+            {!isLoading && (
+              <TimeSeriesPanel
+                title={`CI cost per unit per ${granularity}`}
+                queryName={"cost_per_unit"}
+                queryParams={{ ...timeParamsClickHouse, selectedRepos }}
+                granularity={granularity}
+                groupByFieldName={"unit"}
+                timeFieldName={"granularity_bucket"}
+                yAxisFieldName={"avg_cost"}
+                yAxisRenderer={costDisplay}
+                chartType={"line"}
+                smooth={false}
+                timeFieldDisplayFormat="M/D (UTC)"
+                sort_by="name"
+                auto_refresh={false}
+                useUTC={true}
+              />
+            )}
+          </Grid>
+          <Grid size={{ xs: 12, lg: 5 }} height={ROW_HEIGHT}>
+            <Typography fontSize={"1rem"} fontWeight={"bold"}>
+              CI volume — cross-check ($/unit × count = total)
+            </Typography>
+            {!isLoading && (
+              <TimeSeriesTable
+                title={""}
+                queryName={"ci_counts"}
+                queryParams={{ ...timeParamsClickHouse, selectedRepos }}
+                granularity={granularity}
+                groupByFieldName={"metric"}
+                timeFieldName={"granularity_bucket"}
+                timeFieldDisplayFormat="M/D (UTC)"
+                useUTC={true}
+                yAxisFieldName={"value"}
+                yAxisRenderer={(v) => Number(v).toLocaleString()}
+              />
+            )}
+          </Grid>
+        </Grid>
+
+        <Grid container marginTop={4} size={{ xs: 11.5 }}>
+          <Grid size={{ xs: 12 }}>
+            <Stack
+              direction="row"
+              spacing={2}
+              alignItems="center"
+              flexWrap="wrap"
+              sx={{ mb: 1 }}
+            >
+              <Typography fontSize={"1rem"} fontWeight={"bold"}>
+                Per PR by fleet (OSDC vs Regular EC2) — during shadow both ran the
+                same PRs; compare for efficiency/regression ($ is estimated for OSDC)
+              </Typography>
+              <ToggleButtonGroup
+                size="small"
+                exclusive
+                value={fleetMetric}
+                onChange={(_e, v) => v && setFleetMetric(v)}
+              >
+                <ToggleButton value="hours">Hours</ToggleButton>
+                <ToggleButton value="cost">$</ToggleButton>
+                <ToggleButton value="pct">%</ToggleButton>
+              </ToggleButtonGroup>
+              <ChartTypeToggle
+                value={fleetChartType}
+                onChange={setFleetChartType}
+              />
+            </Stack>
+            <div style={{ height: ROW_HEIGHT }}>
+              {!isLoading && (
+                <TimeSeriesPanel
+                  title={`${
+                    fleetMetric === "cost"
+                      ? "$"
+                      : fleetMetric === "hours"
+                      ? "CI hours"
+                      : "Share %"
+                  } per PR by fleet per ${granularity}`}
+                  queryName={
+                    fleetMetric === "cost"
+                      ? "cost_per_pr_by_fleet"
+                      : fleetMetric === "hours"
+                      ? "hours_per_pr_by_fleet"
+                      : "pct_by_fleet"
+                  }
+                  queryParams={{ ...timeParamsClickHouse, selectedRepos }}
+                  granularity={granularity}
+                  groupByFieldName={"fleet"}
+                  timeFieldName={"granularity_bucket"}
+                  yAxisFieldName={
+                    fleetMetric === "cost"
+                      ? "avg_cost"
+                      : fleetMetric === "hours"
+                      ? "hours_per_pr"
+                      : "value"
+                  }
+                  yAxisRenderer={metricRenderer(fleetMetric)}
+                  chartType={fleetChartType}
+                  smooth={false}
+                  timeFieldDisplayFormat="M/D (UTC)"
+                  sort_by="name"
+                  auto_refresh={false}
+                  useUTC={true}
+                />
+              )}
+            </div>
+          </Grid>
+        </Grid>
+
+        <Grid container marginTop={4} size={{ xs: 11.5 }} spacing={2}>
+          <Grid size={{ xs: 12, lg: 7 }} height={ROW_HEIGHT}>
+            <Typography fontSize={"1rem"} fontWeight={"bold"}>
+              PR cost drivers — why $/PR moves (PRs · commits/PR · jobs/PR · hours/PR · $/hr)
+            </Typography>
+            {!isLoading && (
+              <TimeSeriesTable
+                title={""}
+                queryName={"pr_cost_drivers"}
+                queryParams={{ ...timeParamsClickHouse, selectedRepos }}
+                granularity={granularity}
+                groupByFieldName={"metric"}
+                timeFieldName={"granularity_bucket"}
+                timeFieldDisplayFormat="M/D (UTC)"
+                useUTC={true}
+                yAxisFieldName={"value"}
+                yAxisRenderer={(v) => Number(v).toLocaleString()}
+              />
+            )}
+          </Grid>
+        </Grid>
+
+        <Grid container marginTop={4} size={{ xs: 11.5 }}>
+          <Grid size={{ xs: 12 }}>
+            <Stack
+              direction="row"
+              spacing={2}
+              alignItems="center"
+              flexWrap="wrap"
+              sx={{ mb: 1 }}
+            >
+              <Typography fontSize={"1rem"} fontWeight={"bold"}>
+                By category over time (inside-PR · after-merge · nightly ·
+                benchmark/periodic/other)
+              </Typography>
+              <ToggleButtonGroup
+                size="small"
+                exclusive
+                value={catMetric}
+                onChange={(_e, v) => v && setCatMetric(v)}
+              >
+                <ToggleButton value="cost">$</ToggleButton>
+                <ToggleButton value="hours">Hours</ToggleButton>
+                <ToggleButton value="pct">%</ToggleButton>
+              </ToggleButtonGroup>
+              <ChartTypeToggle value={catChartType} onChange={setCatChartType} />
+            </Stack>
+            <div style={{ height: ROW_HEIGHT }}>
+              {!isLoading && (
+                <TimeSeriesPanel
+                  title={`${
+                    catMetric === "cost"
+                      ? "Cost ($)"
+                      : catMetric === "hours"
+                      ? "Compute-hours"
+                      : "Share (%)"
+                  } by category per ${granularity}`}
+                  queryName={
+                    catMetric === "cost"
+                      ? "cost_by_category"
+                      : catMetric === "hours"
+                      ? "hours_by_category"
+                      : "pct_by_category"
+                  }
+                  queryParams={{ ...timeParamsClickHouse, selectedRepos }}
+                  granularity={granularity}
+                  groupByFieldName={"category"}
+                  timeFieldName={"granularity_bucket"}
+                  yAxisFieldName={"value"}
+                  yAxisRenderer={metricRenderer(catMetric)}
+                  chartType={catChartType}
+                  smooth={false}
+                  timeFieldDisplayFormat="M/D (UTC)"
+                  sort_by="name"
+                  auto_refresh={false}
+                  useUTC={true}
+                />
+              )}
+            </div>
+          </Grid>
         </Grid>
       </Grid>
     </div>


### PR DESCRIPTION
## What
New breakdowns on `/cost_analysis`: region, fleet (OSDC/ciforge vs regular EC2), cost per PR / commit / main commit, cost by category (inside-PR / after-merge / nightly / periodic / benchmark / other), merge rate and slop, CI volume, and a top-down CI-vs-overhead view.

## UI (pages/cost_analysis.tsx)
- Region and Fleet added as group-by dimensions.
- Cost per unit (PR / plain commit / main commit) + a CI volume / merge / slop / category-$ table.
- Per-PR-by-fleet and by-category over time, each with $ / hours / % and line / stacked toggles (icons match the top chart).
- Top-down panel: attributed CI vs overhead/idle (account-wide).
- Tables pin the first column.

## Queries (clickhouse_queries/*)
- Region and fleet are inferred from the runner type (no runner_cost column needed); region is approximate.
- Per-PR/commit/category/slop read `misc.unit_cost_daily` / `misc.unit_keys`; the overhead panel reads `misc.infra_overhead_daily`.

## Depends on
- meta-pytorch/pytorch-gha-infra#1189 (prices mt-* runners via Vantage; builds unit_cost_daily / unit_keys)
- meta-pytorch/pytorch-gha-infra#1192 (builds infra_overhead_daily)

Draft until those land in prod. Verified locally against a dev ClickHouse.
