### PR TITLE
upload-claude-usage: don't misattribute scheduled runs to a person

### DIFF
--- a/.github/actions/upload-claude-usage/action.yml
+++ b/.github/actions/upload-claude-usage/action.yml
@@ -32,12 +32,24 @@ runs:
           exit 0
         fi
 
+        # Resolve the actor. For scheduled runs there is no human trigger, so
+        # github.actor falls back to whoever last modified the workflow file —
+        # which misattributes automated usage to a person (e.g. a daily cron
+        # showing up under the maintainer who last edited it). Record the
+        # workflow name instead so these rows are clearly automated and remain
+        # distinguishable per-workflow. github.event_name is still stored, so
+        # the original signal isn't lost.
+        ACTOR="${{ github.actor }}"
+        if [ "${{ github.event_name }}" = "schedule" ]; then
+          ACTOR="${{ github.workflow }} (scheduled)"
+        fi
+
         # Extract fields and add context
         jq -n \
           --arg repo "${{ github.repository }}" \
           --argjson run_id "${{ github.run_id }}" \
           --argjson run_attempt "${{ github.run_attempt }}" \
-          --arg actor "${{ github.actor }}" \
+          --arg actor "$ACTOR" \
           --arg event_name "${{ github.event_name }}" \
           --argjson pr_number "${{ github.event.issue.number || github.event.pull_request.number || 0 }}" \
           --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%S.000)" \


### PR DESCRIPTION
## Problem

`misc.claude_code_usage` attributes a large, growing share of Claude Code spend to individual maintainers who never ran it. Concrete example — a single real row from the table:

| timestamp | repo | actor | event_name | pr_number | cost | turns |
|---|---|---|---|---|---|---|
| 2026-06-02 14:10 | meta-pytorch/pytorch-gha-infra | ZainRizvi | `schedule` | 0 | \$1.52 | 42 |

That row is **not** Zain's usage. It's the hourly `Claude Infra Investigations` cron (treehugger) in `meta-pytorch/pytorch-gha-infra`. For `schedule` events there is no human trigger, so GitHub sets `github.actor` to whoever last committed to the workflow file — which happens to be the maintainer who set it up. At ~24 runs/day this funnels all automated treehugger cost onto one person's name in the dashboard.

The same applies to any other scheduled Claude workflow (e.g. `claude-distributed-triage-cron`).

## Fix

This action records `github.actor` verbatim. For `schedule` events, record the **workflow name** (suffixed with `(scheduled)`) instead, so the rows are clearly automated and stay distinguishable per-workflow. `event_name` is still stored unchanged, so no signal is lost.

Human-triggered runs (`issue_comment`, `issues`, `workflow_dispatch`, `pull_request`, …) keep `github.actor` exactly as before.

## Notes / follow-ups
- `workflow_run`-triggered runs inherit the upstream actor, so chains rooted at a cron may still carry a stale actor; that path isn't touched here. If desired, a follow-up could also remap `workflow_run` when the upstream event was scheduled.
- Dashboards reading this table can additionally group by `event_name` to separate automated vs. human usage.