### PR TITLE
Bump pyjwt from 2.10.1 to 2.13.0 in /aws/lambda/cross_repo_ci_relay

### DIFF
--- a/aws/lambda/cross_repo_ci_relay/requirements.txt
+++ b/aws/lambda/cross_repo_ci_relay/requirements.txt
@@ -2,4 +2,4 @@ PyYAML==6.0.3
 PyGithub==2.9.0
 redis==7.4.0
 boto3==1.42.78
-PyJWT==2.10.1
+PyJWT==2.13.0


### PR DESCRIPTION
Fix CVE:
- https://github.com/pypa/advisory-database/blob/main/vulns/pyjwt/PYSEC-2026-179.yaml 
- https://github.com/jpadilla/pyjwt/security/advisories/GHSA-xgmm-8j9v-c9wx

cc @jordanconway @fffrog 