### PR TITLE
Fix TorchCodec PyPI upload

### DIFF
--- a/.github/workflows/release-stage-pypi.yml
+++ b/.github/workflows/release-stage-pypi.yml
@@ -112,8 +112,6 @@ jobs:
               # shellcheck disable=SC2086
               PLATFORM="manylinux_2_28_x86_64"  VERSION_SUFFIX="${LINUX_VERSION_SUFFIX}" ARCH="${CUDA_ARCH}" upload_pypi_to_staging ${PACKAGE} "${!version}"
               # shellcheck disable=SC2086
-              PLATFORM="manylinux_2_28_x86_64"  VERSION_SUFFIX="${CPU_VERSION_SUFFIX}" upload_pypi_to_staging ${PACKAGE} "${!version}"
-              # shellcheck disable=SC2086
               PLATFORM="manylinux_2_28_aarch64" VERSION_SUFFIX="${LINUX_VERSION_SUFFIX}" ARCH="${CUDA_ARCH}" upload_pypi_to_staging ${PACKAGE} "${!version}"
               # shellcheck disable=SC2086
               PLATFORM="${MACOS_ARM64}"          VERSION_SUFFIX=""                                          upload_pypi_to_staging ${PACKAGE} "${!version}"


### PR DESCRIPTION
The `.github/workflows/release-stage-pypi.yml` script was processing both CUDA and CPU wheels for `manylinux_2_28_x86_64`, in that order, which caused the CPU wheels to override the CUDA wheels, and the CPU wheels being uploaded on PyPI instead of the CPU wheels.