### PR TITLE
[CRCR] Rename HUD pages /oot → /crcr

### DIFF
--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -253,15 +253,15 @@ export default function OotBackendPage() {
   return (
     <>
       <Head>
-        <title>{repoFullName} — OOT CI | PyTorch HUD</title>
+        <title>{repoFullName} — CRCR CI | PyTorch HUD</title>
       </Head>
       <Stack spacing={3} sx={{ p: 3, maxWidth: 1600, mx: "auto" }}>
         <Box display="flex" justifyContent="space-between" alignItems="center">
           <Stack spacing={0.5}>
             <Typography variant="h4">{repoFullName}</Typography>
-            <NextLink href="/oot" passHref legacyBehavior>
+            <NextLink href="/crcr" passHref legacyBehavior>
               <Link variant="body2" underline="hover">
-                ← Back to OOT Summary
+                ← Back to CRCR Summary
               </Link>
             </NextLink>
           </Stack>

--- a/torchci/pages/crcr/index.tsx
+++ b/torchci/pages/crcr/index.tsx
@@ -109,7 +109,7 @@ function OotSummaryTable({ days }: { days: number }) {
               <TableRow key={row.repo} hover>
                 <TableCell>
                   <NextLink
-                    href={`/oot/${org}/${repo}`}
+                    href={`/crcr/${org}/${repo}`}
                     passHref
                     legacyBehavior
                   >
@@ -150,11 +150,11 @@ export default function OotSummaryPage() {
   return (
     <>
       <Head>
-        <title>Out-of-Tree CI Summary | PyTorch HUD</title>
+        <title>Cross-Repository CI Summary | PyTorch HUD</title>
       </Head>
       <Stack spacing={3} sx={{ p: 3, maxWidth: 1400, mx: "auto" }}>
         <Box display="flex" justifyContent="space-between" alignItems="center">
-          <Typography variant="h4">Out-of-Tree CI Summary</Typography>
+          <Typography variant="h4">Cross-Repository CI Summary</Typography>
           <FormControl size="small" sx={{ minWidth: 140 }}>
             <InputLabel>Time Range</InputLabel>
             <Select


### PR DESCRIPTION
## Summary

Renames the HUD page routes from `/oot` to `/crcr` per maintainer feedback from @malfet and @jathu to align with the Cross-Repository CI Relay (CRCR) naming convention.

**Changes:**
- `torchci/pages/oot/` → `torchci/pages/crcr/` (route: `hud.pytorch.org/oot` → `hud.pytorch.org/crcr`)
- Internal links updated (`/oot/org/repo` → `/crcr/org/repo`)
- Page titles updated ("Out-of-Tree CI" → "Cross-Repository CI" / "CRCR CI")

## Test plan

- [ ] Verify `hud.pytorch.org/crcr` loads the summary page
- [ ] Verify `hud.pytorch.org/crcr/{org}/{repo}` loads the per-backend dashboard
- [ ] Verify back link on dashboard points to `/crcr`

CC @groenenboomj @jewelkm89