### PR TITLE
[crcr] Send HUD bot key via x-hud-internal-bot header

### DIFF
--- a/aws/lambda/cross_repo_ci_relay/tests/test_hud.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_hud.py
@@ -45,6 +45,24 @@ class TestForwardToHud(unittest.TestCase):
         self.assertEqual(sent["untrusted"]["callback_payload"], report)
 
     @patch("utils.hud.urllib.request.urlopen")
+    def test_bot_key_sent_as_internal_bot_header(self, mock_urlopen):
+        # HUD identifies internal-bot traffic by the x-hud-internal-bot header
+        # and exempts it from rate limiting; the relay must send the bot key
+        # under that header so its callbacks are not throttled (HTTP 429).
+        resp = MagicMock()
+        resp.status = 200
+        mock_urlopen.return_value.__enter__.return_value = resp
+
+        forward_to_hud(
+            _cfg(key="secret-bot-key"),
+            {"ci_metrics": {}, "verified_repo": "org/repo"},
+            {"callback_payload": {}},
+        )
+
+        req = mock_urlopen.call_args[0][0]
+        self.assertEqual(req.get_header("X-hud-internal-bot"), "secret-bot-key")
+
+    @patch("utils.hud.urllib.request.urlopen")
     def test_4xx_propagates_with_huds_status(self, mock_urlopen):
         # 4xx means the caller sent bad data — propagate so the downstream
         # workflow author sees a red step.

--- a/aws/lambda/cross_repo_ci_relay/utils/hud.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/hud.py
@@ -46,7 +46,7 @@ def forward_to_hud(config: RelayConfig, trusted: dict, untrusted: dict) -> None:
         data=hud_payload,
         headers={
             "Content-Type": "application/json",
-            "X-OOT-Relay-Token": config.hud_bot_key,
+            "x-hud-internal-bot": config.hud_bot_key,
         },
         method="POST",
     )


### PR DESCRIPTION
## Summary

The cross-repo CI relay forwards each downstream callback to the HUD as a separate POST. Under bursty workloads (`in_progress` + `completed` per job, amplified by matrix and edge-case fan-out), these requests were rejected by the HUD's rate-limit layer with HTTP 429, surfacing in the callback Lambda logs as:

```
[ERROR] HUD rejected callback: HTTP 429: Too Many Requests
  File "/var/task/utils/hud.py", line 58, in forward_to_hud
```

**Root cause:** the HUD exempts internal-bot traffic from rate limiting based on the `x-hud-internal-bot` request header, but `forward_to_hud` was sending `HUD_BOT_KEY` under `X-OOT-Relay-Token`. Without the recognized header the relay's callbacks were treated as public traffic and throttled.

**Fix:** send `HUD_BOT_KEY` as the value of the `x-hud-internal-bot` header so the HUD identifies the relay as an internal bot and skips rate limiting.

## Test Plan

Added a unit test asserting the bot key is sent under `x-hud-internal-bot`, and ran the relay's HUD test suite:

```
cd aws/lambda/cross_repo_ci_relay
python3 -m unittest tests.test_hud -v
```

All 6 tests pass.

This PR was authored with the assistance of an AI coding assistant.