### PR TITLE
[CRCR] Use standard checkAuthWithApiToken for HUD API auth

### DIFF
--- a/torchci/pages/api/oot/results.ts
+++ b/torchci/pages/api/oot/results.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from "crypto";
+import { checkAuthWithApiToken } from "lib/auth/auth";
 import {
   ApiError,
   extractDynamoRecord,
@@ -24,18 +24,8 @@ export default async function handler(
   }
 
   try {
-    // 1. Auth: dedicated X-OOT-Relay-Token header (timing-safe comparison)
-    const expected = process.env.OOT_RELAY_TOKEN;
-    if (!expected) {
-      return res.status(500).json({ error: "Server misconfigured" });
-    }
-    const raw = req.headers["x-oot-relay-token"];
-    if (typeof raw !== "string") {
-      return res.status(401).json({ error: "Unauthorized" });
-    }
-    const a = new Uint8Array(Buffer.from(raw));
-    const b = new Uint8Array(Buffer.from(expected));
-    if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    const auth = await checkAuthWithApiToken(req, res);
+    if (!auth.ok) {
       return res.status(401).json({ error: "Unauthorized" });
     }
 

--- a/torchci/test/ootResults.test.ts
+++ b/torchci/test/ootResults.test.ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
+import * as authModule from "../lib/auth/auth";
 import * as ootUtils from "../lib/oot/ootUtils";
 import handler from "../pages/api/oot/results";
 
@@ -10,12 +11,16 @@ jest.mock("../lib/oot/ootUtils", () => {
   };
 });
 
-const VALID_TOKEN = "test-relay-token-abc123";
+jest.mock("../lib/auth/auth", () => ({
+  checkAuthWithApiToken: jest.fn(),
+}));
+
+const mockCheckAuth = authModule.checkAuthWithApiToken as jest.Mock;
 
 function mockReq(overrides: Partial<NextApiRequest> = {}): NextApiRequest {
   return {
     method: "POST",
-    headers: { "x-oot-relay-token": VALID_TOKEN },
+    headers: { "x-hud-internal-bot": "valid-token" },
     body: {
       trusted: {
         verified_repo: "Ascend/pytorch",
@@ -64,15 +69,9 @@ function mockRes(): NextApiResponse & { _status: number; _json: any } {
 }
 
 describe("POST /api/oot/results", () => {
-  const originalEnv = process.env;
-
   beforeEach(() => {
-    process.env = { ...originalEnv, OOT_RELAY_TOKEN: VALID_TOKEN };
     jest.clearAllMocks();
-  });
-
-  afterAll(() => {
-    process.env = originalEnv;
+    mockCheckAuth.mockResolvedValue({ ok: true, type: "header" });
   });
 
   test("rejects non-POST methods with 405", async () => {
@@ -82,34 +81,10 @@ describe("POST /api/oot/results", () => {
     expect(res._json.error).toBe("Method not allowed");
   });
 
-  test("returns 500 when OOT_RELAY_TOKEN env is not set", async () => {
-    delete process.env.OOT_RELAY_TOKEN;
+  test("returns 401 when auth fails", async () => {
+    mockCheckAuth.mockResolvedValue({ ok: false });
     const res = mockRes();
     await handler(mockReq(), res);
-    expect(res._status).toBe(500);
-    expect(res._json.error).toBe("Server misconfigured");
-  });
-
-  test("returns 401 when token header is missing", async () => {
-    const res = mockRes();
-    await handler(mockReq({ headers: {} }), res);
-    expect(res._status).toBe(401);
-    expect(res._json.error).toBe("Unauthorized");
-  });
-
-  test("returns 401 when token header is wrong", async () => {
-    const res = mockRes();
-    await handler(
-      mockReq({ headers: { "x-oot-relay-token": "wrong-token" } }),
-      res
-    );
-    expect(res._status).toBe(401);
-    expect(res._json.error).toBe("Unauthorized");
-  });
-
-  test("returns 401 when token has different length", async () => {
-    const res = mockRes();
-    await handler(mockReq({ headers: { "x-oot-relay-token": "short" } }), res);
     expect(res._status).toBe(401);
     expect(res._json.error).toBe("Unauthorized");
   });


### PR DESCRIPTION
## Summary

After #8143, the CRCR relay Lambda sends the standard `x-hud-internal-bot` header (with `HUD_BOT_KEY`) instead of the custom `X-OOT-Relay-Token` header.

This PR uses the standard `checkAuthWithApiToken()` from `lib/auth/auth.ts` — the same function used by other HUD internal APIs (e.g. `/api/benchmark/get_time_series`).

**What changes:**
- **`results.ts`**: Replaces the custom 10-line auth block (crypto import, `timingSafeEqual`, manual env var check) with a 3-line call to `checkAuthWithApiToken()`
- **`ootResults.test.ts`**: Mocks `checkAuthWithApiToken` instead of manually setting env vars and headers for each auth test case

**Why this works:**
- `checkAuthWithApiToken()` checks the `x-hud-internal-bot` header against `process.env.INTERNAL_API_TOKEN` — exactly what the relay now sends
- `INTERNAL_API_TOKEN` is already provisioned on Vercel (no new secrets needed)
- `OOT_RELAY_TOKEN` was never provisioned — this eliminates a dead env var dependency

## Test plan
- [ ] Confirm relay Lambda's `HUD_BOT_KEY` (in Secrets Manager) matches Vercel's `INTERNAL_API_TOKEN`
- [ ] Trigger a CRCR dispatch from `pytorch/crcr-test` and verify the callback reaches HUD without 401

CC @groenenboomj @jewelkm89