### PR TITLE
[CRCR] Remove `max-retries` and `retry-delay` from `cross-repo-ci-relay-callback` action

### DIFF
--- a/.github/actions/cross-repo-ci-relay-callback/action.yml
+++ b/.github/actions/cross-repo-ci-relay-callback/action.yml
@@ -46,16 +46,6 @@ inputs:
       Maximum time in seconds to wait for the callback HTTP request to complete.
     required: false
     default: 10
-  max-retries:
-    description: >
-      Maximum number of retries for the callback HTTP request in case of failure.
-    required: false
-    default: 3
-  retry-delay:
-    description: >
-      Delay in seconds between retries for the callback HTTP request.
-    required: false
-    default: 2
 
 runs:
   using: composite
@@ -87,8 +77,6 @@ runs:
         RUN_ID: ${{ github.run_id }}
         RUN_ATTEMPT: ${{ github.run_attempt }}
         MAX_TIME: ${{ inputs.max-time }}
-        MAX_RETRIES: ${{ inputs.max-retries }}
-        RETRY_DELAY: ${{ inputs.retry-delay }}
       run: |
         set -euo pipefail
 
@@ -158,8 +146,6 @@ runs:
             --write-out "%{http_code}" \
             -X POST \
             --max-time ${MAX_TIME} \
-            --retry ${MAX_RETRIES} \
-            --retry-delay ${RETRY_DELAY} \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${OIDC_TOKEN}" \
             --data "${PAYLOAD}" \


### PR DESCRIPTION
Review of the callback lambda logs revealed invalid state transition errors. 

This issue is caused by redundant `curl` retries within the action that reuse the same `check_run_id` (used as state machine's key). If an initial request successfully transitions the state from `IN_PROGRESS` to `SUCCESS`, a subsequent `IN_PROGRESS` request from a retry is considered invalid because the status is already `COMPLETED`. 

Since hud.py already includes a retry loop, the curl retries should be removed to prevent these conflicts.

cc @zxiiro @atalman @huydhn