### PR TITLE
[HUD] Default 'Hide non-viable-strict jobs' to enabled

### DIFF
--- a/torchci/lib/useGroupingPreference.tsx
+++ b/torchci/lib/useGroupingPreference.tsx
@@ -85,7 +85,7 @@ export function useHideNonViableStrictPreference(): [
   const [state, setState] = usePreference(
     "hideNonViableStrict",
     /*override*/ undefined,
-    /*default*/ false
+    /*default*/ true
   );
   return [state, setState];
 }


### PR DESCRIPTION
## Author Notes

It hurts every time I open the hud from a new place where this is not set.

## Agent Notes

Changes the default value of the "Hide non-viable-strict jobs" toggle on the HUD main page from `false` to `true`. Non-viable-strict jobs will now be hidden by default for new users or on fresh browsers. Users who have already explicitly toggled this setting keep their existing localStorage preference.