### PR TITLE
[HUD] Restrict 'Hide non-viable-strict jobs' to pytorch/pytorch

### DIFF
--- a/torchci/components/common/CheckBoxSelector.tsx
+++ b/torchci/components/common/CheckBoxSelector.tsx
@@ -3,34 +3,50 @@ export default function CheckBoxSelector({
   setValue,
   checkBoxName,
   labelText,
+  disabled = false,
+  title,
 }: {
   value: boolean;
   setValue: (_value: boolean) => void;
   checkBoxName: string;
   labelText: string;
+  disabled?: boolean;
+  title?: string;
 }) {
   return (
     <div style={{ margin: 0 }}>
       <span
         onClick={() => {
+          if (disabled) {
+            return;
+          }
           setValue(!value);
         }}
+        title={title}
         style={{
           display: "flex",
           alignItems: "center",
           gap: "0.25rem",
-          cursor: "pointer",
+          cursor: disabled ? "not-allowed" : "pointer",
           whiteSpace: "nowrap",
+          opacity: disabled ? 0.5 : 1,
         }}
       >
         <input
           type="checkbox"
           name={checkBoxName}
           checked={value}
+          disabled={disabled}
           onChange={() => {}}
-          style={{ margin: 0 }}
+          style={{ margin: 0, cursor: disabled ? "not-allowed" : "pointer" }}
         />
-        <label htmlFor={checkBoxName} style={{ margin: 0, cursor: "pointer" }}>
+        <label
+          htmlFor={checkBoxName}
+          style={{
+            margin: 0,
+            cursor: disabled ? "not-allowed" : "pointer",
+          }}
+        >
           {labelText}
         </label>
       </span>

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -135,6 +135,10 @@ export interface HudParams {
   useRegexFilter?: boolean;
 }
 
+export function isPyTorchPyTorchRepo(params: HudParams): boolean {
+  return params.repoOwner === "pytorch" && params.repoName === "pytorch";
+}
+
 export interface PRData {
   title: string;
   body: string;

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -45,6 +45,7 @@ import {
   formatHudUrlForRoute,
   Highlight,
   HudParams,
+  isPyTorchPyTorchRepo,
   IssueData,
   JobData,
   packHudParams,
@@ -399,9 +400,11 @@ function FiltersAndSettings({}: {}) {
 
   // Only show autorevert toggle for pytorch/pytorch main
   const isPyTorchMain =
-    params.repoOwner === "pytorch" &&
-    params.repoName === "pytorch" &&
-    params.branch === "main";
+    isPyTorchPyTorchRepo(params) && params.branch === "main";
+
+  // The viable/strict concept (and thus this filter) only exists for
+  // pytorch/pytorch, so the toggle is a no-op for any other repo.
+  const isPyTorchRepo = isPyTorchPyTorchRepo(params);
 
   return (
     <div className={styles.hudControlsRow}>
@@ -450,6 +453,12 @@ function FiltersAndSettings({}: {}) {
                   checkBoxName="hideNonViableStrict"
                   key="hideNonViableStrict"
                   labelText={"Hide non-viable-strict jobs"}
+                  disabled={!isPyTorchRepo}
+                  title={
+                    isPyTorchRepo
+                      ? undefined
+                      : "Only applies to the pytorch/pytorch repo"
+                  }
                 />,
                 <CheckBoxSelector
                   value={hideAlwaysSkipped}
@@ -855,8 +864,10 @@ function GroupedHudTable({ params }: { params: HudParams }) {
       return false;
     }
 
-    // If hiding non-viable-strict, only show jobs/groups that are viable/strict blocking
-    if (hideNonViableStrict) {
+    // If hiding non-viable-strict, only show jobs/groups that are viable/strict
+    // blocking. The viable/strict concept only exists for pytorch/pytorch, so
+    // this filter is ignored for any other repo (even if the setting is checked).
+    if (hideNonViableStrict && isPyTorchPyTorchRepo(params)) {
       if (
         !groupsViableStrictBlocking.has(name) &&
         !jobsViableStrictBlocking.has(name)


### PR DESCRIPTION
## Summary

The "Hide non-viable-strict jobs" setting was [defaulted to enabled in #8146](https://github.com/pytorch/test-infra/pull/8146). However, the viable/strict concept — and the `VIABLE_STRICT_BLOCKING_JOBS` map the filter relies on (`lib/JobClassifierUtil.ts`) — only exists for `pytorch/pytorch`. On any other repo that map is empty, so with the setting now on by default, opening the HUD for a non-pytorch repo would hide **every** column.

This PR makes the setting pytorch/pytorch-only:

- **Grays out / disables the checkbox** for non-pytorch/pytorch repos (with a tooltip explaining why), via a new `disabled`/`title` prop on `CheckBoxSelector`.
- **Makes the filter a no-op** for non-pytorch/pytorch repos in `GroupedHudTable`, so even a value left in `localStorage` from visiting pytorch/pytorch won't hide anything elsewhere.
- Adds an `isPyTorchPyTorchRepo(params)` helper in `lib/types.ts` (alongside the other `HudParams` helpers) and uses it for the gating, including the existing `isPyTorchMain` check.

## Test plan

- On `pytorch/pytorch`: checkbox is enabled and filtering behaves as before.
- On any other repo (e.g. `pytorch/vision`): checkbox is grayed out / not clickable, and no columns are hidden regardless of the stored setting.