### PR TITLE
autorevert: split job signals by test config (preserve config in base_name)

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_types.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_types.py
@@ -58,18 +58,49 @@ class JobRow:
 
     @cached_property
     def base_name(self) -> JobBaseName:
-        """Normalize job name to a stable base for matching across commits.
+        """Normalize a job name to a stable signal key for matching across commits.
 
-        - Drop any trailing parenthetical qualifiers (e.g., "(rocm)", shard notes)
-        - Strip common shard suffixes like ", 1, 1, " used in CI naming
-        - Collapse redundant whitespace
+        PyTorch CI test jobs are named like::
+
+            <env> / <step> (<config>, <shard_idx>, <num_shards>, <runner>[, <flags>])
+
+        e.g. ``linux-jammy-cuda13.0-py3.10-gcc11 / test (pr_time_benchmarks, 1, 1, runner)``.
+        The first token inside the parenthetical is the test *config*; the
+        remaining tokens are volatile per-run metadata (shard index, shard
+        count, runner label, and flags such as ``unstable`` /
+        ``rerun_disabled_tests``).
+
+        Normalization keeps the config so that distinct configs become distinct
+        signals, while shards of the same config still aggregate together:
+
+        1. **Config present** -- if any parenthetical contains a comma, its
+           first token is the config and is preserved as ``(<config>)``. This
+           stops a config (e.g. the ``pr_time_benchmarks`` perf gate) from being
+           merged into -- and diluted by -- noisier sibling configs such as
+           ``default`` / ``distributed`` under the same step.
+        2. **No config** -- drop every parenthetical qualifier and group on the
+           cleaned name.
+
+        Each parenthetical group is stripped independently (not as a single
+        greedy span), so a leading build-env qualifier like ``(3.12)`` does not
+        swallow the trailing config parenthetical or the step label in between.
+
+        DISCLAIMER: build-env qualifiers carried *outside* the config
+        parenthetical -- notably the Python version in
+        ``inductor-cpu-core-test (3.11|3.12|3.13)`` -- are dropped, so those
+        variants intentionally collapse into a single signal. This is accepted
+        for simplicity for now; revisit if one version proves independently
+        flaky and reintroduces cross-variant mixing.
         """
-        # Drop any trailing parenthetical qualifier
-        base = re.sub(r"\s*\(.*\)$", "", self.name)
-        # Remove patterns like ", 1, 1, " or ", 2, 3, " from job names
-        base = re.sub(r", \d+, \d+, ", ", ", base)
-        # Collapse multiple spaces
+        # Config = first token before the first comma inside any parenthetical.
+        m = re.search(r"\(([^,()]+),", self.name)
+        config = m.group(1).strip() if m else None
+        # Drop all parenthetical groups (each stripped on its own, not greedily
+        # spanning across multiple groups), then collapse whitespace.
+        base = re.sub(r"\s*\([^()]*\)", "", self.name)
         base = re.sub(r"\s+", " ", base).strip()
+        if config:
+            base = f"{base} ({config})".strip()
         return JobBaseName(base)
 
     # ---- Convenience properties for verdicts/status ----

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_job_base_name.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_job_base_name.py
@@ -1,0 +1,186 @@
+import unittest
+from datetime import datetime
+
+from pytorch_auto_revert.signal_extraction_types import (
+    JobId,
+    JobName,
+    JobRow,
+    RunAttempt,
+    Sha,
+    WfRunId,
+    WorkflowName,
+)
+
+
+def base_name_of(name: str) -> str:
+    """Build a JobRow with the given name and return its normalized base_name.
+
+    Only ``name`` affects ``base_name``; the other fields are filler.
+    """
+    row = JobRow(
+        head_sha=Sha("deadbeef"),
+        workflow_name=WorkflowName("trunk"),
+        wf_run_id=WfRunId(1),
+        job_id=JobId(1),
+        run_attempt=RunAttempt(1),
+        name=JobName(name),
+        status="completed",
+        conclusion="success",
+        started_at=datetime(2024, 1, 1),
+        created_at=datetime(2024, 1, 1),
+        rule="",
+    )
+    return str(row.base_name)
+
+
+class TestJobBaseNameConfigPreserved(unittest.TestCase):
+    """Rule 1: a parenthetical with a comma carries a config that is kept."""
+
+    POSITIVE_CASES = {
+        # The motivating case: a perf gate must not be folded into siblings.
+        "linux-jammy-cuda13.0-py3.10-gcc11 / test (pr_time_benchmarks, 1, 1, lf.linux.g4dn.metal.nvidia.gpu)": (
+            "linux-jammy-cuda13.0-py3.10-gcc11 / test (pr_time_benchmarks)"
+        ),
+        # Standard multi-shard config -> shard idx/total/runner dropped.
+        "linux-jammy-rocm-py3.10-mi355 / test (default, 6, 10, linux.rocm.gpu.gfx950.1)": (
+            "linux-jammy-rocm-py3.10-mi355 / test (default)"
+        ),
+        "linux-jammy-rocm-py3.10-mi355 / test (distributed, 2, 4, linux.rocm.gpu.gfx950.2)": (
+            "linux-jammy-rocm-py3.10-mi355 / test (distributed)"
+        ),
+        "win-vs2022-cpu-py3 / test (default, 2, 4, windows.4xlarge.nonephemeral)": (
+            "win-vs2022-cpu-py3 / test (default)"
+        ),
+        "macos-py3-arm64 / test (mps, 1, 1, macos-m1-14)": (
+            "macos-py3-arm64 / test (mps)"
+        ),
+        # Trailing flags (unstable / rerun_disabled_tests / mem_leak_check) drop.
+        "linux-jammy-rocm-py3.10-mi355 / test (default, 7, 10, linux.rocm.gpu.gfx950.1, unstable)": (
+            "linux-jammy-rocm-py3.10-mi355 / test (default)"
+        ),
+        "linux-jammy-py3.10-gcc11 / test-osdc (distributed, 3, 3, mt-l-x86iamx-8-64, rerun_disabled_tests)": (
+            "linux-jammy-py3.10-gcc11 / test-osdc (distributed)"
+        ),
+        "linux-jammy-rocm-py3.10-mi355 / test (default, 7, 10, runner, rerun_disabled_tests, unstable)": (
+            "linux-jammy-rocm-py3.10-mi355 / test (default)"
+        ),
+        # No-shard config matrix: (config, runner) with no shard integers.
+        "Test collect_env (without_torch, linux.24_04.4x)": "Test collect_env (without_torch)",
+        "Test collect_env (older_python_version, linux.24_04.4x)": (
+            "Test collect_env (older_python_version)"
+        ),
+        # Double parenthetical: a build-env (python version) qualifier precedes
+        # the real config paren. The version is dropped, the step label and the
+        # config are both preserved -- the old greedy regex collapsed all three.
+        "unit-test / inductor-cpu-core-test (3.12) / test-osdc (inductor_core, 1, 2, mt-l-x86iavx512-8-64)": (
+            "unit-test / inductor-cpu-core-test / test-osdc (inductor_core)"
+        ),
+        # Long config names survive intact.
+        "inductor-cpu-test / test-osdc (inductor_torchbench_cpu_smoketest_perf, 1, 1, mt-l-bx86iamx-92-167)": (
+            "inductor-cpu-test / test-osdc (inductor_torchbench_cpu_smoketest_perf)"
+        ),
+    }
+
+    def test_config_preserved(self):
+        for name, expected in self.POSITIVE_CASES.items():
+            with self.subTest(name=name):
+                self.assertEqual(base_name_of(name), expected)
+
+
+class TestJobBaseNameAggregationAndSeparation(unittest.TestCase):
+    """Shards of one config aggregate; distinct configs stay distinct."""
+
+    def test_shards_of_same_config_aggregate(self):
+        step = "linux-jammy-rocm-py3.10-mi355 / test"
+        shard1 = f"{step} (default, 1, 10, linux.rocm.gpu.gfx950.1)"
+        shard9 = f"{step} (default, 9, 10, linux.rocm.gpu.gfx950.1)"
+        self.assertEqual(base_name_of(shard1), base_name_of(shard9))
+        self.assertEqual(base_name_of(shard1), f"{step} (default)")
+
+    def test_retry_attempt_does_not_change_key(self):
+        # A rerun on a different runner is still the same config signal.
+        a = "macos-py3-arm64 / test (default, 1, 3, macos-m1-stable)"
+        b = "macos-py3-arm64 / test (default, 1, 3, macos-m2-15, rerun_disabled_tests)"
+        self.assertEqual(base_name_of(a), base_name_of(b))
+
+    def test_distinct_configs_get_distinct_keys(self):
+        step = "linux-jammy-cuda13.0-py3.10-gcc11 / test"
+        keys = {
+            base_name_of(f"{step} (default, 1, 5, r)"),
+            base_name_of(f"{step} (distributed, 1, 3, r)"),
+            base_name_of(f"{step} (pr_time_benchmarks, 1, 1, r)"),
+        }
+        # Three configs -> three separate signal keys (the core fix).
+        self.assertEqual(len(keys), 3)
+
+
+class TestJobBaseNameNoConfig(unittest.TestCase):
+    """Rule 2: no comma-bearing paren -> drop all parens and group."""
+
+    NEGATIVE_CASES = {
+        # No parenthetical at all (build / lint jobs) -> unchanged.
+        "linux-jammy-py3.10-gcc11 / build": "linux-jammy-py3.10-gcc11 / build",
+        "lintrunner-clang / lint": "lintrunner-clang / lint",
+        "linux-docs / build-docs (cpp)": "linux-docs / build-docs",
+        # Version-only qualifier (no config paren) -> version dropped, so
+        # 3.11/3.12/3.13 variants intentionally merge into one signal.
+        "unit-test / inductor-cpu-core-test (3.12) / test": (
+            "unit-test / inductor-cpu-core-test / test"
+        ),
+        "unit-test / inductor-cpu-core-build (3.11) / build-osdc": (
+            "unit-test / inductor-cpu-core-build / build-osdc"
+        ),
+        # Single-token paren (no comma) is treated as a qualifier, not a config.
+        "linux-jammy-rocm-py3.10 / test (rocm)": "linux-jammy-rocm-py3.10 / test",
+    }
+
+    def test_no_config_dropped(self):
+        for name, expected in self.NEGATIVE_CASES.items():
+            with self.subTest(name=name):
+                self.assertEqual(base_name_of(name), expected)
+
+    def test_python_version_variants_merge(self):
+        keys = {
+            base_name_of("unit-test / inductor-cpu-core-test (3.11) / test"),
+            base_name_of("unit-test / inductor-cpu-core-test (3.12) / test"),
+            base_name_of("unit-test / inductor-cpu-core-test (3.13) / test"),
+        }
+        self.assertEqual(len(keys), 1)
+
+
+class TestJobBaseNameWeirdInputs(unittest.TestCase):
+    """Defensive cases: empty / malformed / unusual names must not crash."""
+
+    def test_empty_name(self):
+        self.assertEqual(base_name_of(""), "")
+
+    def test_only_a_config_paren(self):
+        self.assertEqual(base_name_of("(default, 1, 2, runner)"), "(default)")
+
+    def test_unbalanced_open_paren_passes_through(self):
+        # No closing paren and no comma-config match -> returned cleaned as-is.
+        self.assertEqual(base_name_of("foo / test (bar"), "foo / test (bar")
+
+    def test_empty_parens(self):
+        self.assertEqual(base_name_of("foo / test ()"), "foo / test")
+
+    def test_whitespace_collapsed(self):
+        self.assertEqual(
+            base_name_of("foo  /   test   (default, 1, 2, r)"), "foo / test (default)"
+        )
+
+    def test_leading_space_in_config_token_is_trimmed(self):
+        self.assertEqual(
+            base_name_of("foo / test ( default , 1, 2, r)"), "foo / test (default)"
+        )
+
+    def test_first_comma_paren_wins_when_multiple(self):
+        # Defensive: not observed in the live corpus, but document the behavior
+        # -- the first comma-bearing parenthetical supplies the config.
+        self.assertEqual(
+            base_name_of("a / test (b, 1, 1, r) (c, 2, 2, r)"), "a / test (b)"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`JobRow.base_name` (in `signal_extraction_types.py`) normalized a job name by stripping the **entire** trailing parenthetical:

```python
base = re.sub(r"\s*\(.*\)$", "", self.name)
```

PyTorch CI test jobs are named `<env> / <step> (<config>, <shard_idx>, <num_shards>, <runner>[, <flags>])`. Stripping the whole parenthetical discards the **config** token, so every config of a step collapses into one base name. JOB-track signals are keyed on `(head_sha, workflow_name, base_name)` (`signal_extraction.py`), so distinct configs get merged into a single signal.

Concretely, under `linux-jammy-cuda13.0-py3.10-gcc11 / test` the configs `default`, `distributed`, and `pr_time_benchmarks` all become the same signal. A benchmark/perf gate like `pr_time_benchmarks` emits no per-test rows, so it has **no TEST-track fallback** — the merged JOB-track signal is its only path. Bundled with noisier sibling configs, its clean green→red transition gets contaminated (and mixed pass/fail across attempts can trip `detect_flaky`), so a real regression can be missed.

The old regex had a second flaw: `\(.*\)$` is greedy from the first `(` to the last `)`, so on names with two parentheticals — e.g. `unit-test / inductor-cpu-core-test (3.12) / test-osdc (inductor_core, 2, 2, runner)` — it deleted the build-env qualifier, the config, **and** the `/ test-osdc` step label in between.

## Fix

Normalize so the config token is preserved as `(<config>)`:

1. **Config present** — if any parenthetical contains a comma, its first token is the config and is kept. Distinct configs become distinct signals; shards of the same config still aggregate.
2. **No config** — drop every parenthetical qualifier and group on the cleaned name.

Each parenthetical group is stripped independently (not as one greedy span), fixing the double-parenthetical collapse above.

```python
m = re.search(r"\(([^,()]+),", self.name)
config = m.group(1).strip() if m else None
base = re.sub(r"\s*\([^()]*\)", "", self.name)
base = re.sub(r"\s+", " ", base).strip()
if config:
    base = f"{base} ({config})".strip()
return JobBaseName(base)
```

### Known, intentional simplification

Build-env qualifiers carried *outside* the config parenthetical — notably the Python version in `inductor-cpu-core-test (3.11|3.12|3.13)` — are dropped, so those variants merge into one signal. This is accepted for now and documented in the docstring; it can be revisited if a single version proves independently flaky.

## Validation

The "config = first token before the first comma inside any parenthetical" rule was checked against recent `pytorch/pytorch` `main` job names from ClickHouse `workflow_job` (the 6 autorevert-monitored workflows): **none** of the distinct job names had two comma-bearing parentheticals, so the first-comma-paren rule is unambiguous on real data; representative shapes (`pr_time_benchmarks`, `default`/`distributed` with `rerun_disabled_tests`/`unstable` flags, the double-parenthetical version+config case, and the `(config, runner)` no-shard Lint shape) all resolve correctly.

## Tests

Adds `pytorch_auto_revert/tests/test_job_base_name.py`:
- **Config preserved** — representative configs incl. the motivating `pr_time_benchmarks`, multi-shard, no-shard `(config, runner)`, trailing flags, and double-parenthetical version+config.
- **Aggregation vs separation** — shards of one config aggregate; three distinct configs yield three distinct keys; a rerun on a different runner keeps the same key.
- **No config** — build/lint jobs unchanged; Python-version-only variants merge; single-token paren treated as a qualifier.
- **Malformed/edge** — empty name, only-a-config-paren, unbalanced open paren, empty parens, whitespace collapse, leading-space config token, multiple parens.

Local run: full lambda suite green (`python -m unittest discover`), `ruff format` + `ruff check` clean.


-----

local run:
[2026-06-05T20-25-13.573757-00-00.html](https://github.com/user-attachments/files/28653175/2026-06-05T20-25-13.573757-00-00.html)

