### PR TITLE
Add spmd_types to S3 dependency mirror 

### DIFF
--- a/s3_management/update_dependencies.py
+++ b/s3_management/update_dependencies.py
@@ -62,6 +62,29 @@ PACKAGES_PER_PROJECT: Dict[str, List[Dict[str, str]]] = {
     "jinja2": [{"project": "torch"}],
     "filelock": [{"project": "torch"}],
     "fsspec": [{"project": "torch"}],
+    "spmd_types": [
+        {"project": "torch"},
+        {
+            "project": "torch",
+            "target": "cu126",
+        },
+        {
+            "project": "torch",
+            "target": "cu128",
+        },
+        {
+            "project": "torch",
+            "target": "cu129",
+        },
+        {
+            "project": "torch",
+            "target": "cu130",
+        },
+        {
+            "project": "torch",
+            "target": "cu132",
+        },
+    ],
     "nvidia-cudnn-cu11": [{"project": "torch"}],
     "typing-extensions": [{"project": "torch"}],
     "cuda-bindings": [

--- a/s3_management/update_dependencies.py
+++ b/s3_management/update_dependencies.py
@@ -62,29 +62,7 @@ PACKAGES_PER_PROJECT: Dict[str, List[Dict[str, str]]] = {
     "jinja2": [{"project": "torch"}],
     "filelock": [{"project": "torch"}],
     "fsspec": [{"project": "torch"}],
-    "spmd_types": [
-        {"project": "torch"},
-        {
-            "project": "torch",
-            "target": "cu126",
-        },
-        {
-            "project": "torch",
-            "target": "cu128",
-        },
-        {
-            "project": "torch",
-            "target": "cu129",
-        },
-        {
-            "project": "torch",
-            "target": "cu130",
-        },
-        {
-            "project": "torch",
-            "target": "cu132",
-        },
-    ],
+    "spmd_types": [{"project": "torch"}],
     "nvidia-cudnn-cu11": [{"project": "torch"}],
     "typing-extensions": [{"project": "torch"}],
     "cuda-bindings": [


### PR DESCRIPTION
  ## Summary
  - Adds `spmd_types` to `PACKAGES_PER_PROJECT` in `update_dependencies.py` 
  - Mirrors the PyPI index for `spmd_types` onto `download.pytorch.org` for CPU and all CUDA targets (cu126, cu128, cu129, cu130, cu132)              
                                                                            
  ## Context                                                                
  `spmd_types==0.2.0` was added as a hard wheel dependency in pytorch/pytorch#180880 but was not mirrored on `download.pytorch.org`, causing `pip install torch` to fail when using `--index-url https://download.pytorch.org/whl/nightly/cu130` since the package couldn't
   be resolved.                                               
                  
  ## Testing                                     
  After merging, kick the `update-s3-dependencies` workflow



cc @atalman 