### PR TITLE
Add /api/gcx-token: self-serve read-only Grafana token for gcx

### DIFF
--- a/torchci/README.md
+++ b/torchci/README.md
@@ -76,6 +76,33 @@ We use [Vercel](https://vercel.com/torchci) as our deployment platform. Pushes
 to `main` and any other branches will automatically be deployed to Vercel; check out
 the bot comments for how to view.
 
+## Grafana CLI token (`gcx`)
+
+`GET /api/gcx-token` mints a **read-only (Viewer)** Grafana service-account
+token for the [`gcx`](https://github.com/grafana/gcx) CLI, so contributors can
+self-serve a `GRAFANA_TOKEN` instead of creating one by hand in the Grafana UI.
+Access is gated by GitHub identity exactly like Flambeau: the caller must have
+write access to `pytorch/pytorch` (or be on the Flambeau allow list).
+
+Primary usage — reuse an existing GitHub token (no browser, nothing to install):
+
+```bash
+export GRAFANA_TOKEN=$(curl -fsSL \
+  -H "Authorization: Bearer $(gh auth token)" \
+  https://hud.pytorch.org/api/gcx-token)
+```
+
+Each GitHub user gets a dedicated service account named `gcx-<github-login>`
+with the Viewer role. Tokens are long-lived; revoke them manually in the Grafana
+UI (delete the token or the `gcx-<login>` service account).
+
+Required server-side env vars (Vercel):
+
+- `GRAFANA_ADMIN_TOKEN` — a Grafana service-account token with Admin role
+  (`serviceaccounts:write` / `serviceaccounts.tokens:write`). Used only
+  server-side to mint Viewer tokens; never returned to callers.
+- `GRAFANA_SERVER` — optional, defaults to `https://pytorchci.grafana.net`.
+
 ## How to edit ClickHouse queries
 
 If you are familiar with the old setup for Rockset, ClickHouse does not have

--- a/torchci/lib/auth/githubAuth.ts
+++ b/torchci/lib/auth/githubAuth.ts
@@ -1,0 +1,78 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth";
+import { hasWritePermissionsUsingOctokit } from "../GeneralUtils";
+import { getOctokitWithUserToken } from "../github";
+// Give access to people who do not have write permissions to pytorch/pytorch
+import allowList from "../torchagent/allowList.json";
+
+const REPO_OWNER = "pytorch";
+const REPO_NAME = "pytorch";
+
+export type GithubAuthResult =
+  | { ok: true; login: string }
+  | { ok: false; status: number; error: string };
+
+/**
+ * Resolve a GitHub token from the request: an `Authorization: Bearer <token>`
+ * header takes precedence (used by CLI/curl callers), otherwise fall back to
+ * the browser NextAuth session's accessToken. Returns null if neither is present.
+ */
+export function bearerToken(req: NextApiRequest): string | null {
+  const auth = req.headers["authorization"];
+  if (typeof auth === "string" && auth.toLowerCase().startsWith("bearer ")) {
+    return auth.slice("bearer ".length).trim() || null;
+  }
+  return null;
+}
+
+export async function resolveGithubToken(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  authOptions: any
+): Promise<string | null> {
+  const header = bearerToken(req);
+  if (header) {
+    return header;
+  }
+  const session = await getServerSession(req, res, authOptions);
+  // @ts-ignore – next-auth's Session type is not exported here
+  return (session?.accessToken as string) ?? null;
+}
+
+/**
+ * The shared Flambeau gate: given a GitHub token, return the login if the user
+ * has write access to pytorch/pytorch (or is on the allow list), otherwise a
+ * tagged failure with the HTTP status the caller should return.
+ */
+export async function authorizeGithubToken(
+  token: string
+): Promise<GithubAuthResult> {
+  try {
+    const octokit = await getOctokitWithUserToken(token);
+    const user = await octokit.rest.users.getAuthenticated();
+    const login = user?.data?.login;
+    if (!login) {
+      return { ok: false, status: 401, error: "GitHub authentication failed" };
+    }
+    if (allowList.includes(login)) {
+      return { ok: true, login };
+    }
+    const hasWrite = await hasWritePermissionsUsingOctokit(
+      octokit,
+      login,
+      REPO_OWNER,
+      REPO_NAME
+    );
+    if (!hasWrite) {
+      return {
+        ok: false,
+        status: 403,
+        error: `Write permissions to ${REPO_OWNER}/${REPO_NAME} repository required`,
+      };
+    }
+    return { ok: true, login };
+  } catch (error) {
+    console.error("authorizeGithubToken: permission check failed", error);
+    return { ok: false, status: 500, error: "Permission check failed" };
+  }
+}

--- a/torchci/lib/getAuthorizedUsername.ts
+++ b/torchci/lib/getAuthorizedUsername.ts
@@ -1,9 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth";
-import { hasWritePermissionsUsingOctokit } from "./GeneralUtils";
-import { getOctokitWithUserToken } from "./github";
-// Give access to people who do not have write permissions to pytorch/pytorch
-import allowList from "./torchagent/allowList.json";
+import { authorizeGithubToken } from "./auth/githubAuth";
 
 /**
  * Helper that implements the common auth logic shared by the TorchAgent
@@ -16,7 +13,7 @@ import allowList from "./torchagent/allowList.json";
  *       request immediately and return the special placeholder user
  *       "grafana-bypass-user".
  *   2.  Otherwise ensure that the caller is authenticated with GitHub and
- *       has write-level access to pytorch/pytorch.
+ *       has write-level access to pytorch/pytorch (see `authorizeGithubToken`).
  *
  * Each API route should call this function early.  If the function returns
  * `null` the route must `return` immediately because the HTTP response has
@@ -27,7 +24,7 @@ export async function getAuthorizedUsername(
   res: NextApiResponse,
   authOptions: any
 ): Promise<string | null> {
-  // 1. Cookie bypass logic -------------------------------------------------
+  // 1. Cookie bypass logic
   const AUTH_TOKEN = process.env.GRAFANA_MCP_AUTH_TOKEN || "";
   const authCookie = req.cookies["GRAFANA_MCP_AUTH_TOKEN"];
 
@@ -36,7 +33,7 @@ export async function getAuthorizedUsername(
     return "grafana-bypass-user";
   }
 
-  // 2. Standard GitHub authentication flow --------------------------------
+  // 2. Standard GitHub authentication flow
   // @ts-ignore – next-auth's Session type is not exported client-side
   const session = await getServerSession(req, res, authOptions);
 
@@ -47,51 +44,14 @@ export async function getAuthorizedUsername(
     return null;
   }
 
-  const repoOwner = "pytorch";
-  const repoName = "pytorch";
-
-  try {
-    const octokit = await getOctokitWithUserToken(
-      // @ts-ignore – next-auth's Session type is not exported client-side
-      session.accessToken as string
-    );
-    const user = await octokit.rest.users.getAuthenticated();
-
-    if (!user?.data?.login) {
-      console.log("Rejected: Could not authenticate user with GitHub");
-      res.status(401).json({ error: "GitHub authentication failed" });
-      return null;
-    }
-
-    if (allowList.includes(user.data.login)) {
-      console.log(
-        `Authorized: User ${user.data.login} is in the flambeau allow list`
-      );
-      return user.data.login;
-    }
-
-    const hasWritePermissions = await hasWritePermissionsUsingOctokit(
-      octokit,
-      user.data.login,
-      repoOwner,
-      repoName
-    );
-
-    if (!hasWritePermissions) {
-      console.log(
-        `Rejected: User ${user.data.login} does not have write permissions to ${repoOwner}/${repoName}`
-      );
-      res.status(403).json({
-        error: "Write permissions to pytorch/pytorch repository required",
-      });
-      return null;
-    }
-
-    console.log(`Authorized: User ${user.data.login} has write permissions`);
-    return user.data.login;
-  } catch (error) {
-    console.error("Error checking permissions:", error);
-    res.status(500).json({ error: "Permission check failed" });
+  // @ts-ignore – next-auth's Session type is not exported client-side
+  const result = await authorizeGithubToken(session.accessToken as string);
+  if (!result.ok) {
+    console.log(`Rejected: ${result.error}`);
+    res.status(result.status).json({ error: result.error });
     return null;
   }
+
+  console.log(`Authorized: User ${result.login}`);
+  return result.login;
 }

--- a/torchci/lib/grafana/serviceAccount.ts
+++ b/torchci/lib/grafana/serviceAccount.ts
@@ -1,0 +1,113 @@
+/**
+ * Helpers for minting per-user, read-only (Viewer) Grafana service-account
+ * tokens against pytorchci.grafana.net.
+ *
+ * Used by the `/api/gcx-token` route so contributors can self-serve a
+ * `GRAFANA_TOKEN` for the `gcx` CLI without manually creating one in the
+ * Grafana UI. Each GitHub user gets a dedicated service account named
+ * `gcx-<github-login>` with the Viewer role; revocation is manual (delete the
+ * token or the service account in the Grafana UI).
+ *
+ * Requires the server-side env var `GRAFANA_ADMIN_TOKEN`: a Grafana
+ * service-account token with `serviceaccounts:write` /
+ * `serviceaccounts.tokens:write` (Admin role). It is NEVER returned to callers.
+ */
+
+const DEFAULT_GRAFANA_SERVER = "https://pytorchci.grafana.net";
+
+export function grafanaServer(): string {
+  return process.env.GRAFANA_SERVER || DEFAULT_GRAFANA_SERVER;
+}
+
+async function grafanaFetch(
+  path: string,
+  init?: RequestInit
+): Promise<Response> {
+  const adminToken = process.env.GRAFANA_ADMIN_TOKEN;
+  if (!adminToken) {
+    throw new Error("GRAFANA_ADMIN_TOKEN is not configured");
+  }
+  return fetch(`${grafanaServer()}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${adminToken}`,
+      "Content-Type": "application/json",
+      ...(init?.headers || {}),
+    },
+  });
+}
+
+// GitHub logins are [A-Za-z0-9-]; strip anything else defensively so the
+// service-account name can never be used to smuggle unexpected characters.
+function serviceAccountName(login: string): string {
+  const safe = login.replace(/[^A-Za-z0-9-]/g, "");
+  if (!safe) {
+    throw new Error("Invalid GitHub login");
+  }
+  return `gcx-${safe}`;
+}
+
+async function findServiceAccountIdByName(
+  name: string
+): Promise<number | null> {
+  const res = await grafanaFetch(
+    `/api/serviceaccounts/search?perpage=100&page=1&query=${encodeURIComponent(
+      name
+    )}`
+  );
+  if (!res.ok) {
+    throw new Error(
+      `Grafana service-account search failed: ${res.status} ${await res.text()}`
+    );
+  }
+  const data = await res.json();
+  const match = (data?.serviceAccounts || []).find(
+    (sa: { id: number; name: string }) => sa.name === name
+  );
+  return match ? match.id : null;
+}
+
+async function createViewerServiceAccount(name: string): Promise<number> {
+  const res = await grafanaFetch("/api/serviceaccounts", {
+    method: "POST",
+    body: JSON.stringify({ name, role: "Viewer", isDisabled: false }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Grafana service-account create failed: ${res.status} ${await res.text()}`
+    );
+  }
+  const data = await res.json();
+  return data.id;
+}
+
+/**
+ * Find-or-create the Viewer service account for `login` and mint a new
+ * long-lived token on it. Returns the raw token key (the only time Grafana
+ * ever exposes it).
+ */
+export async function mintGcxViewerToken(login: string): Promise<string> {
+  const name = serviceAccountName(login);
+
+  let saId = await findServiceAccountIdByName(name);
+  if (saId == null) {
+    saId = await createViewerServiceAccount(name);
+  }
+
+  // Long-lived (no secondsToLive); timestamp keeps the token name unique per SA.
+  const tokenName = `${name}-${Date.now()}`;
+  const res = await grafanaFetch(`/api/serviceaccounts/${saId}/tokens`, {
+    method: "POST",
+    body: JSON.stringify({ name: tokenName }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Grafana token create failed: ${res.status} ${await res.text()}`
+    );
+  }
+  const data = await res.json();
+  if (!data?.key) {
+    throw new Error("Grafana token create returned no key");
+  }
+  return data.key;
+}

--- a/torchci/lib/grafana/serviceAccount.ts
+++ b/torchci/lib/grafana/serviceAccount.ts
@@ -5,8 +5,7 @@
  * Used by the `/api/gcx-token` route so contributors can self-serve a
  * `GRAFANA_TOKEN` for the `gcx` CLI without manually creating one in the
  * Grafana UI. Each GitHub user gets a dedicated service account named
- * `gcx-<github-login>` with the Viewer role; revocation is manual (delete the
- * token or the service account in the Grafana UI).
+ * `gcx-<github-login>` with the Viewer role.
  *
  * Requires the server-side env var `GRAFANA_ADMIN_TOKEN`: a Grafana
  * service-account token with `serviceaccounts:write` /
@@ -82,9 +81,8 @@ async function createViewerServiceAccount(name: string): Promise<number> {
 }
 
 /**
- * Find-or-create the Viewer service account for `login` and mint a new
- * long-lived token on it. Returns the raw token key (the only time Grafana
- * ever exposes it).
+ * Find-or-create the Viewer service account for `login` and mint a token on it.
+ * Returns the raw token key (the only time Grafana exposes it).
  */
 export async function mintGcxViewerToken(login: string): Promise<string> {
   const name = serviceAccountName(login);
@@ -94,7 +92,7 @@ export async function mintGcxViewerToken(login: string): Promise<string> {
     saId = await createViewerServiceAccount(name);
   }
 
-  // Long-lived (no secondsToLive); timestamp keeps the token name unique per SA.
+  // Timestamp keeps the token name unique per service account.
   const tokenName = `${name}-${Date.now()}`;
   const res = await grafanaFetch(`/api/serviceaccounts/${saId}/tokens`, {
     method: "POST",

--- a/torchci/pages/api/gcx-token.ts
+++ b/torchci/pages/api/gcx-token.ts
@@ -6,7 +6,7 @@
  * the caller must have write access to pytorch/pytorch (or be on the
  * Flambeau allow list).
  *
- * Primary usage (no browser, no extra CLI to install) — reuse an existing
+ * Primary usage (no browser, no extra CLI to install) reuses an existing
  * GitHub token:
  *
  *   export GRAFANA_TOKEN=$(curl -fsSL \
@@ -18,27 +18,15 @@
  * caller sends `Accept: application/json` or `?format=json`.
  */
 import { NextApiRequest, NextApiResponse } from "next";
-import { getServerSession } from "next-auth";
-import { hasWritePermissionsUsingOctokit } from "../../lib/GeneralUtils";
-import { getOctokitWithUserToken } from "../../lib/github";
+import {
+  authorizeGithubToken,
+  resolveGithubToken,
+} from "../../lib/auth/githubAuth";
 import {
   grafanaServer,
   mintGcxViewerToken,
 } from "../../lib/grafana/serviceAccount";
-import allowList from "../../lib/torchagent/allowList.json";
 import { authOptions } from "./auth/[...nextauth]";
-
-const REPO_OWNER = "pytorch";
-const REPO_NAME = "pytorch";
-
-function getBearerToken(req: NextApiRequest): string | null {
-  const auth = req.headers["authorization"];
-  if (typeof auth === "string" && auth.toLowerCase().startsWith("bearer ")) {
-    const token = auth.slice("bearer ".length).trim();
-    return token || null;
-  }
-  return null;
-}
 
 export default async function handler(
   req: NextApiRequest,
@@ -48,15 +36,8 @@ export default async function handler(
     return res.status(405).json({ error: "Method not allowed" });
   }
 
-  // 1. Resolve a GitHub token: bearer header (curl one-liner) takes precedence,
-  //    otherwise fall back to a browser NextAuth session.
-  let githubToken = getBearerToken(req);
-  if (!githubToken) {
-    // @ts-ignore – next-auth's Session type is not exported here
-    const session = await getServerSession(req, res, authOptions);
-    // @ts-ignore
-    githubToken = session?.accessToken ?? null;
-  }
+  // 1. Resolve a GitHub token (bearer header, else NextAuth session).
+  const githubToken = await resolveGithubToken(req, res, authOptions);
   if (!githubToken) {
     return res.status(401).json({
       error:
@@ -66,37 +47,15 @@ export default async function handler(
   }
 
   // 2. Validate GitHub identity + pytorch/pytorch write access (Flambeau gate).
-  let login: string;
-  try {
-    const octokit = await getOctokitWithUserToken(githubToken);
-    const user = await octokit.rest.users.getAuthenticated();
-    login = user?.data?.login;
-    if (!login) {
-      return res.status(401).json({ error: "GitHub authentication failed" });
-    }
-
-    const allowed =
-      (allowList as string[]).includes(login) ||
-      (await hasWritePermissionsUsingOctokit(
-        octokit,
-        login,
-        REPO_OWNER,
-        REPO_NAME
-      ));
-    if (!allowed) {
-      return res.status(403).json({
-        error: `Write permissions to ${REPO_OWNER}/${REPO_NAME} required`,
-      });
-    }
-  } catch (error) {
-    console.error("gcx-token: GitHub auth/permission check failed", error);
-    return res.status(401).json({ error: "GitHub authentication failed" });
+  const auth = await authorizeGithubToken(githubToken);
+  if (!auth.ok) {
+    return res.status(auth.status).json({ error: auth.error });
   }
 
   // 3. Mint a read-only (Viewer) Grafana token for this user.
   try {
-    const token = await mintGcxViewerToken(login);
-    console.log(`gcx-token: minted Viewer token for ${login}`);
+    const token = await mintGcxViewerToken(auth.login);
+    console.log(`gcx-token: minted Viewer token for ${auth.login}`);
 
     const accept = (req.headers["accept"] as string) || "";
     if (accept.includes("application/json") || req.query.format === "json") {

--- a/torchci/pages/api/gcx-token.ts
+++ b/torchci/pages/api/gcx-token.ts
@@ -6,6 +6,10 @@
  * the caller must have write access to pytorch/pytorch (or be on the
  * Flambeau allow list).
  *
+ * Intended use: one-time setup. Run it once, save the returned token in
+ * GRAFANA_TOKEN, and reuse it for read-only `gcx` access. Not meant to be
+ * called on every gcx invocation.
+ *
  * Primary usage (no browser, no extra CLI to install) reuses an existing
  * GitHub token:
  *

--- a/torchci/pages/api/gcx-token.ts
+++ b/torchci/pages/api/gcx-token.ts
@@ -1,0 +1,111 @@
+/**
+ * GET/POST /api/gcx-token
+ *
+ * Self-serve endpoint that mints a read-only (Viewer) Grafana service-account
+ * token for the `gcx` CLI, gated by GitHub identity the same way Flambeau is:
+ * the caller must have write access to pytorch/pytorch (or be on the
+ * Flambeau allow list).
+ *
+ * Primary usage (no browser, no extra CLI to install) — reuse an existing
+ * GitHub token:
+ *
+ *   export GRAFANA_TOKEN=$(curl -fsSL \
+ *     -H "Authorization: Bearer $(gh auth token)" \
+ *     https://hud.pytorch.org/api/gcx-token)
+ *
+ * Browser-authenticated users (a live NextAuth session) are also accepted as a
+ * fallback. Returns the raw token as text/plain by default, or JSON when the
+ * caller sends `Accept: application/json` or `?format=json`.
+ */
+import { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth";
+import { hasWritePermissionsUsingOctokit } from "../../lib/GeneralUtils";
+import { getOctokitWithUserToken } from "../../lib/github";
+import {
+  grafanaServer,
+  mintGcxViewerToken,
+} from "../../lib/grafana/serviceAccount";
+import allowList from "../../lib/torchagent/allowList.json";
+import { authOptions } from "./auth/[...nextauth]";
+
+const REPO_OWNER = "pytorch";
+const REPO_NAME = "pytorch";
+
+function getBearerToken(req: NextApiRequest): string | null {
+  const auth = req.headers["authorization"];
+  if (typeof auth === "string" && auth.toLowerCase().startsWith("bearer ")) {
+    const token = auth.slice("bearer ".length).trim();
+    return token || null;
+  }
+  return null;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET" && req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  // 1. Resolve a GitHub token: bearer header (curl one-liner) takes precedence,
+  //    otherwise fall back to a browser NextAuth session.
+  let githubToken = getBearerToken(req);
+  if (!githubToken) {
+    // @ts-ignore – next-auth's Session type is not exported here
+    const session = await getServerSession(req, res, authOptions);
+    // @ts-ignore
+    githubToken = session?.accessToken ?? null;
+  }
+  if (!githubToken) {
+    return res.status(401).json({
+      error:
+        "Authentication required: pass 'Authorization: Bearer <github_token>' " +
+        "(e.g. $(gh auth token)) or sign in to hud.pytorch.org.",
+    });
+  }
+
+  // 2. Validate GitHub identity + pytorch/pytorch write access (Flambeau gate).
+  let login: string;
+  try {
+    const octokit = await getOctokitWithUserToken(githubToken);
+    const user = await octokit.rest.users.getAuthenticated();
+    login = user?.data?.login;
+    if (!login) {
+      return res.status(401).json({ error: "GitHub authentication failed" });
+    }
+
+    const allowed =
+      (allowList as string[]).includes(login) ||
+      (await hasWritePermissionsUsingOctokit(
+        octokit,
+        login,
+        REPO_OWNER,
+        REPO_NAME
+      ));
+    if (!allowed) {
+      return res.status(403).json({
+        error: `Write permissions to ${REPO_OWNER}/${REPO_NAME} required`,
+      });
+    }
+  } catch (error) {
+    console.error("gcx-token: GitHub auth/permission check failed", error);
+    return res.status(401).json({ error: "GitHub authentication failed" });
+  }
+
+  // 3. Mint a read-only (Viewer) Grafana token for this user.
+  try {
+    const token = await mintGcxViewerToken(login);
+    console.log(`gcx-token: minted Viewer token for ${login}`);
+
+    const accept = (req.headers["accept"] as string) || "";
+    if (accept.includes("application/json") || req.query.format === "json") {
+      return res.status(200).json({ token, grafanaServer: grafanaServer() });
+    }
+    res.setHeader("Content-Type", "text/plain; charset=utf-8");
+    return res.status(200).send(token);
+  } catch (error) {
+    console.error("gcx-token: minting failed", error);
+    return res.status(500).json({ error: "Failed to mint Grafana token" });
+  }
+}

--- a/torchci/test/gcxToken.test.ts
+++ b/torchci/test/gcxToken.test.ts
@@ -1,0 +1,131 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import * as nextAuth from "next-auth";
+import handler from "../pages/api/gcx-token";
+import * as generalUtils from "../lib/GeneralUtils";
+import * as github from "../lib/github";
+import * as serviceAccount from "../lib/grafana/serviceAccount";
+
+function mockReqRes(overrides: Partial<NextApiRequest> = {}) {
+  const req = {
+    method: "GET",
+    headers: {},
+    query: {},
+    cookies: {},
+    ...overrides,
+  } as unknown as NextApiRequest;
+
+  const res = {
+    statusCode: 0,
+    body: undefined as any,
+    headers: {} as Record<string, string>,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: any) {
+      this.body = payload;
+      return this;
+    },
+    send(payload: any) {
+      this.body = payload;
+      return this;
+    },
+    setHeader(key: string, value: string) {
+      this.headers[key] = value;
+    },
+  };
+
+  return { req, res: res as unknown as NextApiResponse & typeof res };
+}
+
+function mockOctokit(login: string | null) {
+  return {
+    rest: {
+      users: {
+        getAuthenticated: jest
+          .fn()
+          .mockResolvedValue({ data: login ? { login } : {} }),
+      },
+    },
+  } as any;
+}
+
+describe("/api/gcx-token", () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  test("405 on unsupported method", async () => {
+    const { req, res } = mockReqRes({ method: "DELETE" } as any);
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  test("401 when no bearer token and no session", async () => {
+    jest.spyOn(nextAuth, "getServerSession").mockResolvedValue(null as any);
+    const { req, res } = mockReqRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  test("403 when authenticated but lacks pytorch/pytorch write access", async () => {
+    jest
+      .spyOn(github, "getOctokitWithUserToken")
+      .mockResolvedValue(mockOctokit("someuser"));
+    jest
+      .spyOn(generalUtils, "hasWritePermissionsUsingOctokit")
+      .mockResolvedValue(false);
+    const mint = jest.spyOn(serviceAccount, "mintGcxViewerToken");
+
+    const { req, res } = mockReqRes({
+      headers: { authorization: "Bearer gho_faketoken" },
+    } as any);
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(mint).not.toHaveBeenCalled();
+  });
+
+  test("200 + plain-text token for a writer", async () => {
+    jest
+      .spyOn(github, "getOctokitWithUserToken")
+      .mockResolvedValue(mockOctokit("writeruser"));
+    jest
+      .spyOn(generalUtils, "hasWritePermissionsUsingOctokit")
+      .mockResolvedValue(true);
+    jest
+      .spyOn(serviceAccount, "mintGcxViewerToken")
+      .mockResolvedValue("glsa_minted_for_writeruser");
+
+    const { req, res } = mockReqRes({
+      headers: { authorization: "Bearer gho_faketoken" },
+    } as any);
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe("glsa_minted_for_writeruser");
+    expect(res.headers["Content-Type"]).toContain("text/plain");
+  });
+
+  test("200 + JSON token when Accept: application/json", async () => {
+    jest
+      .spyOn(github, "getOctokitWithUserToken")
+      .mockResolvedValue(mockOctokit("writeruser"));
+    jest
+      .spyOn(generalUtils, "hasWritePermissionsUsingOctokit")
+      .mockResolvedValue(true);
+    jest
+      .spyOn(serviceAccount, "mintGcxViewerToken")
+      .mockResolvedValue("glsa_minted_for_writeruser");
+
+    const { req, res } = mockReqRes({
+      headers: {
+        authorization: "Bearer gho_faketoken",
+        accept: "application/json",
+      },
+    } as any);
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.token).toBe("glsa_minted_for_writeruser");
+    expect(res.body.grafanaServer).toContain("grafana.net");
+  });
+});

--- a/torchci/test/gcxToken.test.ts
+++ b/torchci/test/gcxToken.test.ts
@@ -1,9 +1,9 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import * as nextAuth from "next-auth";
-import handler from "../pages/api/gcx-token";
 import * as generalUtils from "../lib/GeneralUtils";
 import * as github from "../lib/github";
 import * as serviceAccount from "../lib/grafana/serviceAccount";
+import handler from "../pages/api/gcx-token";
 
 function mockReqRes(overrides: Partial<NextApiRequest> = {}) {
   const req = {


### PR DESCRIPTION
## What

New `GET/POST /api/gcx-token` endpoint that mints a **read-only (Viewer)** Grafana service-account token for the [`gcx`](https://github.com/grafana/gcx) CLI, so contributors can self-serve a `GRAFANA_TOKEN` instead of creating one by hand in the Grafana UI.

## Auth

Gated by GitHub identity **exactly like Flambeau**: the caller must have write access to `pytorch/pytorch` (or be on the Flambeau allow list). Reuses `getOctokitWithUserToken` + `hasWritePermissionsUsingOctokit`.

## Usage (no browser, nothing to install)

```bash
export GRAFANA_TOKEN=$(curl -fsSL \
  -H "Authorization: Bearer $(gh auth token)" \
  https://hud.pytorch.org/api/gcx-token)
```

Also accepts a browser NextAuth session as a fallback. Returns the token as `text/plain` by default, or JSON with `Accept: application/json` / `?format=json`.

## Token model

Each GitHub user gets a dedicated service account `gcx-<github-login>` (Viewer role). Tokens are **long-lived**; revocation is manual via the Grafana UI. Viewer = read-only: good for `gcx resources validate`/dry-run and querying, **not** for `push` (publishing needs Editor).

## Deploy prerequisite (not in this PR)

Set in Vercel env:
- `GRAFANA_ADMIN_TOKEN` — Grafana Admin SA token (`serviceaccounts:write` / `serviceaccounts.tokens:write`). Server-side only; never returned.
- `GRAFANA_SERVER` — optional, defaults to `https://pytorchci.grafana.net`.

## Validation

- Grafana mint path verified end-to-end against pytorchci.grafana.net (create Viewer SA → create token → token reads OK, writes 403 → cleanup).
- Unit tests (`test/gcxToken.test.ts`): 405 / 401 / 403 / 200 text / 200 JSON. `tsc` clean.

Draft until reviewed.