### PR TITLE
[gcx-token] Name minted tokens by token_name; supersede same-label token

### DIFF
--- a/torchci/README.md
+++ b/torchci/README.md
@@ -89,12 +89,14 @@ Primary usage — reuse an existing GitHub token (no browser, nothing to install
 ```bash
 export GRAFANA_TOKEN=$(curl -fsSL \
   -H "Authorization: Bearer $(gh auth token)" \
-  https://hud.pytorch.org/api/gcx-token)
+  "https://hud.pytorch.org/api/gcx-token?token_name=$(hostname)")
 ```
 
 Each GitHub user gets a dedicated service account named `gcx-<github-login>`
-with the Viewer role. Tokens are long-lived; revoke them manually in the Grafana
-UI (delete the token or the `gcx-<login>` service account).
+with the Viewer role. The optional `token_name` param labels the token
+(defaults to "default"), so you can hold one token per machine; re-running with
+the same label replaces only that token. Revoke manually in the Grafana UI if
+needed.
 
 Required server-side env vars (Vercel):
 

--- a/torchci/lib/grafana/serviceAccount.ts
+++ b/torchci/lib/grafana/serviceAccount.ts
@@ -80,20 +80,57 @@ async function createViewerServiceAccount(name: string): Promise<number> {
   return data.id;
 }
 
+// Delete tokens on the service account whose name starts with `prefix`, so a
+// new mint supersedes only the previous token with the same label, leaving
+// other labels' tokens intact.
+async function revokeTokensWithPrefix(
+  saId: number,
+  prefix: string
+): Promise<void> {
+  const res = await grafanaFetch(`/api/serviceaccounts/${saId}/tokens`);
+  if (!res.ok) {
+    throw new Error(
+      `Grafana token list failed: ${res.status} ${await res.text()}`
+    );
+  }
+  const tokens: Array<{ id: number; name: string }> = (await res.json()) || [];
+  for (const token of tokens) {
+    if (token.name.startsWith(prefix)) {
+      await grafanaFetch(`/api/serviceaccounts/${saId}/tokens/${token.id}`, {
+        method: "DELETE",
+      });
+    }
+  }
+}
+
+// Slug for the caller-supplied token label (no dashes, so it can't collide with
+// the dash separators in the token name). Defaults to "default".
+function labelSlug(label: string): string {
+  return (label || "").replace(/[^A-Za-z0-9.]/g, "").slice(0, 40) || "default";
+}
+
 /**
- * Find-or-create the Viewer service account for `login` and mint a token on it.
- * Returns the raw token key (the only time Grafana exposes it).
+ * Find-or-create the Viewer service account for `login`, revoke any previous
+ * token with the same `label`, and mint a fresh one. Returns the raw token key
+ * (the only time Grafana exposes it). Tokens are named per label so a user can
+ * hold one per machine; re-minting with the same label replaces that token.
  */
-export async function mintGcxViewerToken(login: string): Promise<string> {
+export async function mintGcxViewerToken(
+  login: string,
+  label: string
+): Promise<string> {
   const name = serviceAccountName(login);
+  const prefix = `${name}-${labelSlug(label)}-`;
 
   let saId = await findServiceAccountIdByName(name);
   if (saId == null) {
     saId = await createViewerServiceAccount(name);
+  } else {
+    await revokeTokensWithPrefix(saId, prefix);
   }
 
-  // Timestamp keeps the token name unique per service account.
-  const tokenName = `${name}-${Date.now()}`;
+  // Timestamp keeps the token name unique per (service account, label).
+  const tokenName = `${prefix}${Date.now()}`;
   const res = await grafanaFetch(`/api/serviceaccounts/${saId}/tokens`, {
     method: "POST",
     body: JSON.stringify({ name: tokenName }),

--- a/torchci/pages/api/gcx-token.ts
+++ b/torchci/pages/api/gcx-token.ts
@@ -15,7 +15,11 @@
  *
  *   export GRAFANA_TOKEN=$(curl -fsSL \
  *     -H "Authorization: Bearer $(gh auth token)" \
- *     https://hud.pytorch.org/api/gcx-token)
+ *     "https://hud.pytorch.org/api/gcx-token?token_name=$(hostname)")
+ *
+ * The optional `token_name` param labels the token (defaults to "default"), so a
+ * user can hold one token per machine and re-minting only replaces the token
+ * with the same label.
  *
  * Browser-authenticated users (a live NextAuth session) are also accepted as a
  * fallback. Returns the raw token as text/plain by default, or JSON when the
@@ -56,10 +60,18 @@ export default async function handler(
     return res.status(auth.status).json({ error: auth.error });
   }
 
-  // 3. Mint a read-only (Viewer) Grafana token for this user.
+  // 3. Mint a read-only (Viewer) Grafana token for this user. The optional
+  //    `token_name` query param (e.g. ?token_name=$(hostname)) labels the token
+  //    so re-minting only supersedes the token with the same label.
   try {
-    const token = await mintGcxViewerToken(auth.login);
-    console.log(`gcx-token: minted Viewer token for ${auth.login}`);
+    const label =
+      typeof req.query.token_name === "string" ? req.query.token_name : "";
+    const token = await mintGcxViewerToken(auth.login, label);
+    console.log(
+      `gcx-token: minted Viewer token for ${auth.login}${
+        label ? ` (${label})` : ""
+      }`
+    );
 
     const accept = (req.headers["accept"] as string) || "";
     if (accept.includes("application/json") || req.query.format === "json") {


### PR DESCRIPTION
Follow-up to #8154 (review comment from @huydhn).

Each call to `/api/gcx-token` minted a new long-lived token without removing old ones, so repeat calls piled up valid tokens under the `gcx-<login>` service account.

Now the optional `?token_name=` query param (defaults to `default`) labels the token, and minting revokes only the previous token with the **same label**. So a user can hold one token per machine by passing `?token_name=$(hostname)`, and re-running with the same label replaces just that token. No server-side storage; the user holds the token.

```bash
export GRAFANA_TOKEN=$(curl -fsSL -H "Authorization: Bearer $(gh auth token)" "https://hud.pytorch.org/api/gcx-token?token_name=$(hostname)")
```