### PR TITLE
Serve spmd-types on download.pytorch.org via external-link index

### DIFF
--- a/s3_management/manage_v2.py
+++ b/s3_management/manage_v2.py
@@ -481,6 +481,7 @@ PACKAGE_LINKS_ALLOW_LIST = {
         "numpy",
         "fsspec",
         "typing-extensions",
+        "spmd-types",
         "cuda-bindings",
         "cuda-toolkit",
         "nvidia-cuda-nvrtc-cu12",

--- a/s3_management/update_dependencies.py
+++ b/s3_management/update_dependencies.py
@@ -62,7 +62,7 @@ PACKAGES_PER_PROJECT: Dict[str, List[Dict[str, str]]] = {
     "jinja2": [{"project": "torch"}],
     "filelock": [{"project": "torch"}],
     "fsspec": [{"project": "torch"}],
-    "spmd_types": [{"project": "torch"}],
+    "spmd-types": [{"project": "torch"}],
     "nvidia-cudnn-cu11": [{"project": "torch"}],
     "typing-extensions": [{"project": "torch"}],
     "cuda-bindings": [


### PR DESCRIPTION
## Summary

Makes the `spmd_types` dependency (added to torch's wheel metadata in pytorch/pytorch#180880) resolvable from `download.pytorch.org`, fixing `pip install torch --index-url https://download.pytorch.org/whl/nightly/<arch>`.

Two coordinated fixes:

1. **`update_dependencies.py`** — the mirror key was `spmd_types` (underscore), so the PyPI-linking `index.html` was written to `whl/<channel>/<arch>/spmd_types/index.html`. pip normalizes torch's `Requires-Dist` to `spmd-types` (PEP 503), and the top-level index links to the normalized name, so the lookup 404'd. Use the normalized key `spmd-types`, matching every other multi-word entry (`typing-extensions`, `charset-normalizer`, ...).
2. **`manage_v2.py`** — add `spmd-types` to `PACKAGE_LINKS_ALLOW_LIST` so `manage_v2` copies the parent external-link `index.html` down into each per-arch subdir instead of regenerating it from S3 wheels (which don't exist for a PyPI-only dependency).

## Context

Follow-up to #8153, which mirrored the package but under the non-normalized name. Pairs with the pytorch/pytorch change that emits `Requires-Dist: spmd-types==0.2.0`.

## Testing

Re-run the `update-s3-dependencies` workflow after merge, then `manage_v2.py` over `whl/nightly` (and `whl/test`/`whl`) so the links propagate into the per-arch subdirs.
