### PR TITLE
[CRCR] Add CRCR CI Summary link to HUD navigation bar

### DIFF
--- a/torchci/components/layout/NavBar.tsx
+++ b/torchci/components/layout/NavBar.tsx
@@ -75,6 +75,10 @@ function NavBar() {
       name: "MacOS test stats",
       href: "/mac_test_stats",
     },
+    {
+      name: "CRCR CI Summary",
+      href: "/crcr",
+    },
   ].map((item) => ({
     label: item.name,
     route: item.href,


### PR DESCRIPTION
## Summary
- Adds the **CRCR CI Summary** page (`/crcr`) to the **Dev Infra** dropdown in the top navigation bar, so users can discover the CRCR dashboard directly from the HUD homepage.
- Aligned with PR #8142 which renames `/oot` → `/crcr`.

## Test plan
- [ ] Verify the "CRCR CI Summary" link appears in the Dev Infra dropdown on the HUD nav bar
- [ ] Verify clicking the link navigates to `/crcr` and loads the summary page correctly

CC @groenenboomj @jewelkm89