### PR TITLE
Support both spmd-types and spmd_types in PACKAGE_LINKS_ALLOW_LIST so it mirrors to subdirs

### DIFF
--- a/s3_management/manage_v2.py
+++ b/s3_management/manage_v2.py
@@ -470,8 +470,10 @@ PT_R2_PACKAGES_PROD = {
 # Packages that should have their root index.html copied to subdirectories
 # instead of processing wheels in subdirectories
 # For example: whl/nightly/filelock/index.html -> whl/nightly/cu128/filelock/index.html
+# Both dash and underscore forms are added so matching treats e.g.
+# "spmd-types" and "spmd_types" as the same package.
 PACKAGE_LINKS_ALLOW_LIST = {
-    x.lower()
+    variant
     for x in [
         "filelock",
         "sympy",
@@ -482,7 +484,6 @@ PACKAGE_LINKS_ALLOW_LIST = {
         "fsspec",
         "typing-extensions",
         "spmd-types",
-        "spmd_types",
         "cuda-bindings",
         "cuda-toolkit",
         "nvidia-cuda-nvrtc-cu12",
@@ -542,6 +543,7 @@ PACKAGE_LINKS_ALLOW_LIST = {
         "pyelftools",
         "pyzes",
     ]
+    for variant in (x.lower().replace("_", "-"), x.lower().replace("-", "_"))
 }
 
 

--- a/s3_management/manage_v2.py
+++ b/s3_management/manage_v2.py
@@ -481,6 +481,7 @@ PACKAGE_LINKS_ALLOW_LIST = {
         "numpy",
         "fsspec",
         "typing-extensions",
+        "spmd-types",
         "spmd_types",
         "cuda-bindings",
         "cuda-toolkit",

--- a/s3_management/manage_v2.py
+++ b/s3_management/manage_v2.py
@@ -730,14 +730,22 @@ class S3Index:
             relative_key = obj.key[len(prefix_to_search) :]
             parts = relative_key.split("/")
             if len(parts) == 2 and parts[1] == "index.html":
-                # Convert from URL format (dashes) to package name format (underscores)
-                pkg_name_with_underscores = parts[0].replace("-", "_")
-                parent_packages.add(pkg_name_with_underscores)
+                # S3 package directories and PACKAGE_LINKS_ALLOW_LIST are both
+                # keyed with dashes, so keep the dash form here. Converting to
+                # underscores caused hyphenated packages (e.g. spmd-types,
+                # typing-extensions) to never match the allow list and never get
+                # copied into the cpu/cu* subdirectories.
+                parent_packages.add(parts[0].lower())
 
-        # Now filter for PACKAGE_LINKS_ALLOW_LIST packages not in subdirectory
+        # Now filter for PACKAGE_LINKS_ALLOW_LIST packages not in subdirectory.
+        # Normalize subdir package names to the dash form too so both sides of
+        # the comparison agree regardless of wheel-name underscores.
+        packages_in_subdir_normalized = {
+            p.lower().replace("_", "-") for p in packages_in_subdir
+        }
         for pkg_name in parent_packages:
-            if pkg_name.lower() in PACKAGE_LINKS_ALLOW_LIST:
-                if pkg_name.lower() not in {p.lower() for p in packages_in_subdir}:
+            if pkg_name in PACKAGE_LINKS_ALLOW_LIST:
+                if pkg_name not in packages_in_subdir_normalized:
                     packages_to_copy.add(pkg_name)
                     print(
                         f"INFO: Found PACKAGE_LINKS_ALLOW_LIST package '{pkg_name}' in '{parent_prefix}' to copy to '{subdir}'"

--- a/s3_management/manage_v2.py
+++ b/s3_management/manage_v2.py
@@ -481,7 +481,7 @@ PACKAGE_LINKS_ALLOW_LIST = {
         "numpy",
         "fsspec",
         "typing-extensions",
-        "spmd-types",
+        "spmd_types",
         "cuda-bindings",
         "cuda-toolkit",
         "nvidia-cuda-nvrtc-cu12",
@@ -730,16 +730,14 @@ class S3Index:
             relative_key = obj.key[len(prefix_to_search) :]
             parts = relative_key.split("/")
             if len(parts) == 2 and parts[1] == "index.html":
-                # Keep the dash form to match PACKAGE_LINKS_ALLOW_LIST
-                parent_packages.add(parts[0].lower())
+                # Convert from URL format (dashes) to package name format (underscores)
+                pkg_name_with_underscores = parts[0].replace("-", "_")
+                parent_packages.add(pkg_name_with_underscores)
 
         # Now filter for PACKAGE_LINKS_ALLOW_LIST packages not in subdirectory
-        packages_in_subdir_normalized = {
-            p.lower().replace("_", "-") for p in packages_in_subdir
-        }
         for pkg_name in parent_packages:
-            if pkg_name in PACKAGE_LINKS_ALLOW_LIST:
-                if pkg_name not in packages_in_subdir_normalized:
+            if pkg_name.lower() in PACKAGE_LINKS_ALLOW_LIST:
+                if pkg_name.lower() not in {p.lower() for p in packages_in_subdir}:
                     packages_to_copy.add(pkg_name)
                     print(
                         f"INFO: Found PACKAGE_LINKS_ALLOW_LIST package '{pkg_name}' in '{parent_prefix}' to copy to '{subdir}'"

--- a/s3_management/manage_v2.py
+++ b/s3_management/manage_v2.py
@@ -470,10 +470,8 @@ PT_R2_PACKAGES_PROD = {
 # Packages that should have their root index.html copied to subdirectories
 # instead of processing wheels in subdirectories
 # For example: whl/nightly/filelock/index.html -> whl/nightly/cu128/filelock/index.html
-# Both dash and underscore forms are added so matching treats e.g.
-# "spmd-types" and "spmd_types" as the same package.
 PACKAGE_LINKS_ALLOW_LIST = {
-    variant
+    x.lower()
     for x in [
         "filelock",
         "sympy",
@@ -484,6 +482,7 @@ PACKAGE_LINKS_ALLOW_LIST = {
         "fsspec",
         "typing-extensions",
         "spmd-types",
+        "spmd_types",
         "cuda-bindings",
         "cuda-toolkit",
         "nvidia-cuda-nvrtc-cu12",
@@ -543,7 +542,6 @@ PACKAGE_LINKS_ALLOW_LIST = {
         "pyelftools",
         "pyzes",
     ]
-    for variant in (x.lower().replace("_", "-"), x.lower().replace("-", "_"))
 }
 
 

--- a/s3_management/manage_v2.py
+++ b/s3_management/manage_v2.py
@@ -730,16 +730,10 @@ class S3Index:
             relative_key = obj.key[len(prefix_to_search) :]
             parts = relative_key.split("/")
             if len(parts) == 2 and parts[1] == "index.html":
-                # S3 package directories and PACKAGE_LINKS_ALLOW_LIST are both
-                # keyed with dashes, so keep the dash form here. Converting to
-                # underscores caused hyphenated packages (e.g. spmd-types,
-                # typing-extensions) to never match the allow list and never get
-                # copied into the cpu/cu* subdirectories.
+                # Keep the dash form to match PACKAGE_LINKS_ALLOW_LIST
                 parent_packages.add(parts[0].lower())
 
-        # Now filter for PACKAGE_LINKS_ALLOW_LIST packages not in subdirectory.
-        # Normalize subdir package names to the dash form too so both sides of
-        # the comparison agree regardless of wheel-name underscores.
+        # Now filter for PACKAGE_LINKS_ALLOW_LIST packages not in subdirectory
         packages_in_subdir_normalized = {
             p.lower().replace("_", "-") for p in packages_in_subdir
         }


### PR DESCRIPTION
`spmd-types` is served at the root nightly index but not mirrored into the `cpu`/`cu*` subdirectories.

`get_packages_to_copy_from_parent()` converts package dir names dash->underscore before checking `PACKAGE_LINKS_ALLOW_LIST`, so the dash-only entry never matched. Add the `spmd_types` form alongside `spmd-types` so it gets copied into the subdirectories.
