### PR TITLE
Add /api/raw-query (read-only ClickHouse) + hud sql

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -263,6 +263,7 @@ exclude_patterns = [
     '**/snapshots/**',
     # Putting this exclusion just to get the linter running.
     "tools/stronghold/bin/build-check-api-compatibility",
+    "tools/hud-cli/hud",
 ]
 command = [
     'python3',

--- a/tools/hud-cli/README.md
+++ b/tools/hud-cli/README.md
@@ -1,0 +1,32 @@
+# hud CLI
+
+CLI over the PyTorch HUD APIs, for humans (tables) and agents (`--json`).
+
+## Setup
+
+```bash
+gh auth login
+ln -s "$(pwd)/hud" ~/.local/bin/hud
+hud login              # also sets up gcx for dashboards (optional)
+```
+
+Reuses your GitHub token (`gh auth token`) against the authed shim
+(`/api/authed/*`).
+
+## Commands
+
+```bash
+hud trunk --days 1
+hud pr 12345
+hud user wdvr
+hud query <name> -p key=value      # any saved ClickHouse query
+```
+
+Add `--json` to any command for agent output.
+
+## Authed shim
+
+`pages/api/authed/[...path].ts` mirrors `/api/*`: it validates the GitHub token
+(bad token -> 401), then forwards with the internal bypass header. Requires two
+Vercel firewall bypass rules: path `/api/authed/`, and header
+`x-hud-internal-bot`.

--- a/tools/hud-cli/README.md
+++ b/tools/hud-cli/README.md
@@ -20,6 +20,7 @@ hud trunk --days 1
 hud pr 12345
 hud user wdvr
 hud query <name> -p key=value      # any saved ClickHouse query
+hud sql "SELECT ... LIMIT 10"       # any read-only ClickHouse query
 ```
 
 Add `--json` to any command for agent output.

--- a/tools/hud-cli/hud
+++ b/tools/hud-cli/hud
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+hud - a small CLI over the PyTorch HUD APIs (hud.pytorch.org).
+
+Auth: reuses your GitHub login via `gh auth token`, sent as a Bearer header to
+the authed API shim (/api/authed/*), which validates it and forwards to the real
+HUD endpoint. `hud login` also sets up gcx for Grafana dashboards / raw
+ClickHouse access.
+
+Serves humans (tables) and agents (`--json`). Replaces ad-hoc HUD MCP calls: the
+generic `hud query` runs any saved ClickHouse query, named commands wrap common
+ones.
+
+Examples:
+  hud login
+  hud trunk --days 1
+  hud pr 12345
+  hud user wdvr
+  hud query master_commit_red -p granularity=hour -p usePercentage=false --days 1
+"""
+import argparse
+import json
+import os
+import socket
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+
+HUD_URL = os.environ.get("HUD_URL", "https://hud.pytorch.org")
+API = "/api/authed"  # authed shim: validates the GitHub token, forwards to /api/*
+GITHUB_API = "https://api.github.com"
+_TOKEN = None
+
+
+def gh_token():
+    global _TOKEN
+    if _TOKEN is None:
+        try:
+            _TOKEN = subprocess.check_output(
+                ["gh", "auth", "token"], text=True
+            ).strip()
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            sys.exit("error: no GitHub token. Run `gh auth login`.")
+    return _TOKEN
+
+
+def _get(url):
+    req = urllib.request.Request(url)
+    req.add_header("Authorization", f"Bearer {gh_token()}")
+    req.add_header("Accept", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return json.load(resp)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", "replace")[:300]
+        if e.code == 429:
+            sys.exit(
+                "error: 429 (Vercel bot challenge). The /api/authed firewall "
+                "bypass rule is missing. See README."
+            )
+        sys.exit(f"error: HTTP {e.code} from {url}\n{body}")
+
+
+def hud_query(name, params):
+    qs = urllib.parse.urlencode({"parameters": json.dumps(params)})
+    return _get(f"{HUD_URL}{API}/clickhouse/{name}?{qs}")
+
+
+def hud_get(path):
+    return _get(f"{HUD_URL}{API}{path}")
+
+
+def github_get(path, params=None):
+    url = f"{GITHUB_API}{path}"
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    return _get(url)
+
+
+def ch_time(dt):
+    return dt.strftime("%Y-%m-%d %H:%M:%S.000")
+
+
+def now_utc():
+    return datetime.now(timezone.utc)
+
+
+def emit(data, as_json, rows=None, headers=None):
+    if as_json or rows is None:
+        print(json.dumps(data, indent=2, default=str))
+    else:
+        print_table(rows, headers)
+
+
+def print_table(rows, headers):
+    if not rows:
+        print("(no rows)")
+        return
+    cols = headers or list(rows[0].keys())
+    body = [[str(r.get(c, "")) for c in cols] for r in rows]
+    w = [max(len(cols[i]), *(len(r[i]) for r in body)) for i in range(len(cols))]
+    print("  ".join(h.ljust(w[i]) for i, h in enumerate(cols)))
+    print("  ".join("-" * w[i] for i in range(len(cols))))
+    for r in body:
+        print("  ".join(r[i].ljust(w[i]) for i in range(len(cols))))
+
+
+# ----- commands -----
+
+
+def cmd_login(args):
+    gh_token()  # verifies gh is logged in
+    label = socket.gethostname().split(".")[0]
+    info = _get(f"{HUD_URL}/api/gcx-token?token_name={label}&format=json")
+    grafana_token = info["token"]
+    server = info.get("grafanaServer", "https://pytorchci.grafana.net")
+    print(f"HUD: ready (uses your GitHub login as {label}).", flush=True)
+    if subprocess.run(["which", "gcx"], capture_output=True).returncode == 0:
+        subprocess.run(
+            ["gcx", "login", "pytorchci", "--server", server, "--yes",
+             "--token", grafana_token],
+            check=True,
+        )
+        print("gcx: configured. Try `gcx dashboards list`.")
+    else:
+        print("gcx not installed (optional, for dashboards/raw ClickHouse):")
+        print("  curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | sh")
+        print(f"  gcx login pytorchci --server {server} --yes --token {grafana_token}")
+
+
+def cmd_query(args):
+    params = {}
+    for kv in args.param or []:
+        if "=" not in kv:
+            sys.exit(f"bad -p '{kv}', expected key=value")
+        k, v = kv.split("=", 1)
+        try:
+            params[k] = json.loads(v)
+        except json.JSONDecodeError:
+            params[k] = v
+    if args.days is not None:
+        params.setdefault("stopTime", ch_time(now_utc()))
+        params.setdefault("startTime", ch_time(now_utc() - timedelta(days=args.days)))
+        params.setdefault("timezone", "UTC")
+    rows = hud_query(args.name, params)
+    emit(rows, args.json, rows=rows if isinstance(rows, list) else None)
+
+
+def cmd_trunk(args):
+    rows = hud_query("master_commit_red", {
+        "startTime": ch_time(now_utc() - timedelta(days=args.days)),
+        "stopTime": ch_time(now_utc()),
+        "timezone": "UTC",
+        "granularity": args.granularity,
+        "usePercentage": False,
+    })
+    emit(rows, args.json, rows=rows if isinstance(rows, list) else None)
+
+
+def cmd_pr(args):
+    owner, repo = args.repo.split("/", 1)
+    data = hud_get(f"/{owner}/{repo}/pull/{args.pr}")
+    if args.json:
+        emit(data, True)
+        return
+    jobs = data.get("jobs", []) if isinstance(data, dict) else []
+    failing = [j for j in jobs if (j.get("conclusion") or "") == "failure"]
+    print(f"PR {owner}/{repo}#{args.pr}: {data.get('title', '')}")
+    print(f"  jobs: {len(jobs)}  failing: {len(failing)}")
+    if failing:
+        print_table([{"job": j.get("name", ""), "conclusion": j.get("conclusion", "")}
+                     for j in failing], ["job", "conclusion"])
+
+
+def cmd_user(args):
+    q = f"repo:{args.repo} is:pr is:open author:{args.user}"
+    items = github_get("/search/issues", {"q": q, "per_page": args.limit}).get("items", [])
+    if args.json:
+        emit(items, True)
+        return
+    rows = [{"pr": f"#{it['number']}", "created": it["created_at"][:10],
+             "draft": "draft" if it.get("draft") else "", "title": it["title"][:70]}
+            for it in items]
+    print(f"open PRs by {args.user} in {args.repo}: {len(items)}")
+    print_table(rows, ["pr", "created", "draft", "title"])
+
+
+def main():
+    p = argparse.ArgumentParser(prog="hud", description="PyTorch HUD CLI")
+    p.add_argument("--json", action="store_true", help="JSON output (for agents)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("login", help="set up gh + gcx").set_defaults(func=cmd_login)
+
+    q = sub.add_parser("query", help="run any saved ClickHouse query")
+    q.add_argument("name")
+    q.add_argument("-p", "--param", action="append", help="key=value (repeatable)")
+    q.add_argument("--days", type=int, help="set startTime/stopTime to last N days")
+    q.set_defaults(func=cmd_query)
+
+    t = sub.add_parser("trunk", help="trunk red/green over time")
+    t.add_argument("--days", type=int, default=1)
+    t.add_argument("--granularity", default="hour", choices=["hour", "day"])
+    t.set_defaults(func=cmd_trunk)
+
+    pr = sub.add_parser("pr", help="CI status for a PR")
+    pr.add_argument("pr")
+    pr.add_argument("--repo", default="pytorch/pytorch")
+    pr.set_defaults(func=cmd_pr)
+
+    u = sub.add_parser("user", help="open PRs for a user")
+    u.add_argument("user")
+    u.add_argument("--repo", default="pytorch/pytorch")
+    u.add_argument("--limit", type=int, default=30)
+    u.set_defaults(func=cmd_user)
+
+    args = p.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/hud-cli/hud
+++ b/tools/hud-cli/hud
@@ -64,6 +64,26 @@ def _get(url):
         sys.exit(f"error: HTTP {e.code} from {url}\n{body}")
 
 
+def _post(url, body):
+    req = urllib.request.Request(
+        url, data=json.dumps(body).encode(), method="POST"
+    )
+    req.add_header("Authorization", f"Bearer {gh_token()}")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            return json.load(resp)
+    except urllib.error.HTTPError as e:
+        msg = e.read().decode("utf-8", "replace")[:300]
+        if e.code == 429:
+            sys.exit(
+                "error: 429 (Vercel bot challenge). The /api/authed firewall "
+                "bypass rule is missing. See README."
+            )
+        sys.exit(f"error: HTTP {e.code} from {url}\n{msg}")
+
+
 def hud_query(name, params):
     qs = urllib.parse.urlencode({"parameters": json.dumps(params)})
     return _get(f"{HUD_URL}{API}/clickhouse/{name}?{qs}")
@@ -109,6 +129,11 @@ def print_table(rows, headers):
 
 
 # ----- commands -----
+
+
+def cmd_sql(args):
+    rows = _post(f"{HUD_URL}{API}/raw-query", {"sql": args.sql})
+    emit(rows, args.json, rows=rows if isinstance(rows, list) else None)
 
 
 def cmd_login(args):
@@ -200,6 +225,10 @@ def main():
     q.add_argument("-p", "--param", action="append", help="key=value (repeatable)")
     q.add_argument("--days", type=int, help="set startTime/stopTime to last N days")
     q.set_defaults(func=cmd_query)
+
+    s = sub.add_parser("sql", help="run a read-only ClickHouse SELECT query")
+    s.add_argument("sql")
+    s.set_defaults(func=cmd_sql)
 
     t = sub.add_parser("trunk", help="trunk red/green over time")
     t.add_argument("--days", type=int, default=1)

--- a/torchci/lib/clickhouse.ts
+++ b/torchci/lib/clickhouse.ts
@@ -32,7 +32,8 @@ export async function queryClickhouse(
   query: string,
   params: Record<string, unknown>,
   query_id?: string,
-  useQueryCache?: boolean
+  useQueryCache?: boolean,
+  extraSettings?: Record<string, unknown>
 ): Promise<any[]> {
   if (query_id === undefined) {
     query_id = "adhoc";
@@ -44,6 +45,7 @@ export async function queryClickhouse(
    * @param query: string, the sql query
    * @param params: Record<string, unknown>, the parameters to the query ex { sha: "abcd" }
    * @param useQueryCache: boolean, if true, cache the query result on Ch side (1 minute TTL)
+   * @param extraSettings: extra ClickHouse settings, e.g. { readonly: 2 }
    */
   const clickhouseClient = getClickhouseClient();
 
@@ -55,6 +57,7 @@ export async function queryClickhouse(
       output_format_json_quote_64bit_integers: 0,
       date_time_output_format: "iso",
       use_query_cache: useQueryCache ? 1 : 0,
+      ...extraSettings,
     },
     query_id,
   });

--- a/torchci/pages/api/authed/[...path].ts
+++ b/torchci/pages/api/authed/[...path].ts
@@ -1,0 +1,55 @@
+/**
+ * Authed API shim: /api/authed/<path> mirrors /api/<path> but requires the same
+ * GitHub gate as flambeau / gcx-token (write access to pytorch/pytorch, or the
+ * allow list), then forwards with the internal bypass header. Lets the `hud`
+ * CLI / agents reach HUD APIs without the browser bot challenge. See
+ * tools/hud-cli/README.md for the required firewall rules.
+ */
+import { authorizeGithubToken, bearerToken } from "lib/auth/githubAuth";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const SELF_URL = process.env.HUD_SELF_URL || "https://hud.pytorch.org";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const token = bearerToken(req);
+  if (!token) {
+    return res.status(401).json({
+      error: "Authentication required: Authorization: Bearer <token>",
+    });
+  }
+  const auth = await authorizeGithubToken(token);
+  if (!auth.ok) {
+    return res.status(auth.status).json({ error: auth.error });
+  }
+
+  const segments = Array.isArray(req.query.path)
+    ? req.query.path
+    : [req.query.path];
+  const subpath = segments.join("/");
+  const qIndex = (req.url || "").indexOf("?");
+  const qs = qIndex >= 0 ? (req.url as string).slice(qIndex) : "";
+  const target = `${SELF_URL}/api/${subpath}${qs}`;
+
+  const init: RequestInit = {
+    method: req.method,
+    headers: { "x-hud-internal-bot": process.env.INTERNAL_API_TOKEN || "" },
+  };
+  if (req.method !== "GET" && req.method !== "HEAD" && req.body) {
+    (init.headers as Record<string, string>)["content-type"] =
+      "application/json";
+    init.body =
+      typeof req.body === "string" ? req.body : JSON.stringify(req.body);
+  }
+
+  const upstream = await fetch(target, init);
+  const text = await upstream.text();
+  res.status(upstream.status);
+  const ct = upstream.headers.get("content-type");
+  if (ct) {
+    res.setHeader("content-type", ct);
+  }
+  return res.send(text);
+}

--- a/torchci/pages/api/raw-query.ts
+++ b/torchci/pages/api/raw-query.ts
@@ -1,0 +1,58 @@
+/**
+ * POST /api/raw-query  { sql: string, params?: object }
+ *
+ * Runs an arbitrary read-only ClickHouse query. Not public: requires the
+ * internal bot token (checkAuthWithApiToken), which the /api/authed shim
+ * supplies after it has validated the caller's pytorch/pytorch write access.
+ * So the only way to reach this with a user identity is via /api/authed/raw-query.
+ *
+ * Read-only is enforced three ways: the HUD read client (no write creds),
+ * ClickHouse `readonly=2` (rejects writes/DDL), and a SELECT/WITH-only,
+ * single-statement check. Results are capped.
+ */
+import { checkAuthWithApiToken } from "lib/auth/auth";
+import { queryClickhouse } from "lib/clickhouse";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const SELECT_ONLY = /^\s*(select|with)\b/i;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  const auth = await checkAuthWithApiToken(req, res);
+  if (!auth.ok) {
+    return res.status(401).json({ error: "Authentication required" });
+  }
+
+  const body = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
+  const sql = (body?.sql ?? "").trim().replace(/;\s*$/, "");
+  const params = body?.params ?? {};
+
+  if (!sql) {
+    return res.status(400).json({ error: "Missing 'sql'" });
+  }
+  if (sql.includes(";")) {
+    return res.status(400).json({ error: "Single statement only" });
+  }
+  if (!SELECT_ONLY.test(sql)) {
+    return res
+      .status(400)
+      .json({ error: "Only SELECT / WITH queries allowed" });
+  }
+
+  try {
+    const rows = await queryClickhouse(sql, params, "raw-query", false, {
+      readonly: 2,
+      max_execution_time: 60,
+      max_result_rows: 10000,
+      result_overflow_mode: "break",
+    });
+    return res.status(200).json(rows);
+  } catch (error: any) {
+    return res.status(400).json({ error: String(error?.message ?? error) });
+  }
+}


### PR DESCRIPTION
Stacked on #8156.

Adds an arbitrary **read-only** ClickHouse query endpoint and a `hud sql` command.

## `POST /api/raw-query` { sql, params? }
- Not public: requires the internal bot token (`checkAuthWithApiToken`), which only the `/api/authed` shim supplies after validating pytorch/pytorch write access. So the user-facing path is `/api/authed/raw-query`.
- Read-only enforced three ways: the HUD read client (no write creds), ClickHouse `readonly=2`, and a SELECT/WITH single-statement check. Capped at 60s / 10k rows.

## `hud sql`
`hud sql "SELECT name, conclusion FROM default.workflow_job ORDER BY completed_at DESC LIMIT 10"`

## lib
`queryClickhouse` gains an optional `extraSettings` arg (backward compatible) to pass `readonly` etc.

Note: gcx already offers raw read-only ClickHouse via the Grafana datasource; this makes the `hud` CLI self-contained. Base is #8156's branch; will retarget to main once that merges.