### PR TITLE
Dr. CI: only treat pytorch-bot's own comment as the Dr. CI comment

### DIFF
--- a/torchci/lib/drciUtils.ts
+++ b/torchci/lib/drciUtils.ts
@@ -26,6 +26,12 @@ export const NUM_MINUTES = 30;
 export const REPO: string = "pytorch";
 export const OWNER: string = "pytorch";
 export const DRCI_COMMENT_START = "<!-- drci-comment-start -->\n";
+// Dr. CI's comment is always created/updated through the pytorch-bot GitHub App
+// installation, so its author login is always this. Other tools (e.g. internal
+// diff-handoff bots) sometimes embed the DRCI_COMMENT_START marker inside their
+// own comments; without this author check Dr. CI mistakes such a comment for its
+// own and overwrites it. So match on the marker AND the author.
+export const DRCI_COMMENT_AUTHOR = "pytorch-bot[bot]";
 export const DOCS_URL = "https://docs-preview.pytorch.org";
 export const PYTHON_DOCS_PATH = "index.html";
 export const CPP_DOCS_PATH = "cppdocs/index.html";
@@ -121,7 +127,10 @@ export async function getDrciComment(
     issue_number: prNum,
   });
   for (const comment of commentsRes.data) {
-    if (comment.body!.includes(DRCI_COMMENT_START)) {
+    if (
+      comment.user?.login === DRCI_COMMENT_AUTHOR &&
+      comment.body!.includes(DRCI_COMMENT_START)
+    ) {
       return { id: comment.id, body: comment.body! };
     }
   }

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -5,6 +5,7 @@ import { fetchJSON, isTime0 } from "lib/bot/utils";
 import { queryClickhouse, queryClickhouseSaved } from "lib/clickhouse";
 import {
   CANCELLED_STEP_ERROR,
+  DRCI_COMMENT_AUTHOR,
   fetchPRLabels,
   FLAKY_RULES_JSON,
   formDrciComment,
@@ -556,11 +557,18 @@ from
   default.issue_comment final
 where
   body like '%<!-- drci-comment-start -->%'
+  and user.login = {drciCommentAuthor: String}
   and issue_url in {prUrls: Array(String)}
+-- Order so the oldest comment lands last; the Map below keeps the last entry
+-- per PR, so we deterministically pick the original Dr. CI comment if there
+-- ever are multiple bot-authored marker comments (matches getDrciComment,
+-- which returns the first match from chronologically-ordered listComments).
+order by id desc
     `;
   return new Map(
     (
       await queryClickhouse(existingCommentsQuery, {
+        drciCommentAuthor: DRCI_COMMENT_AUTHOR,
         prUrls: Array.from(workflowsByPR.keys()).map(
           (prNumber) =>
             `https://api.github.com/repos/${repoFullName}/issues/${prNumber}`

--- a/torchci/test/drciBot.test.ts
+++ b/torchci/test/drciBot.test.ts
@@ -101,6 +101,7 @@ describe("verify-drci-functionality", () => {
         {
           id: comment_id,
           node_id: comment_node_id,
+          user: { login: drciUtils.DRCI_COMMENT_AUTHOR },
           body: "<!-- drci-comment-start -->\nhello\n<!-- drci-comment-end -->\n",
         },
       ])
@@ -120,6 +121,52 @@ describe("verify-drci-functionality", () => {
         }
       )
       .reply(200);
+    await probot.receive({ name: "pull_request", payload: payload, id: "2" });
+    handleScope(scope);
+  });
+
+  test("Dr. CI ignores a marker-bearing comment from a non-bot author and posts its own", async () => {
+    // Regression test: another tool (e.g. an internal diff-handoff bot) can post
+    // a comment that embeds the DRCI_COMMENT_START marker. Dr. CI must not treat
+    // that comment as its own and overwrite it; it should post a fresh comment.
+    nock("https://api.github.com")
+      .post("/app/installations/2/access_tokens")
+      .reply(200, { token: "test" });
+
+    const payload = require("./fixtures/pull_request.opened")["payload"];
+    payload["pull_request"]["user"]["login"] = some_user;
+    payload["repository"]["owner"]["login"] = OWNER;
+    payload["repository"]["name"] = REPO;
+
+    jest
+      .spyOn(clickhouse, "queryClickhouse")
+      .mockImplementation((query, params) => {
+        return Promise.resolve([]);
+      });
+
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${OWNER}/${REPO}/issues/31/comments`, (body) => {
+        return true;
+      })
+      .reply(200, [
+        {
+          id: comment_id,
+          node_id: comment_node_id,
+          user: { login: some_user },
+          body: "<!-- drci-comment-start -->\nhandoff\n<!-- drci-comment-end -->\n",
+        },
+      ])
+      // Must create a new comment rather than patch the impostor one.
+      .post(`/repos/${OWNER}/${REPO}/issues/31/comments`, (body) => {
+        const comment = body.body;
+        expect(comment.includes(drciUtils.DRCI_COMMENT_START)).toBeTruthy();
+        expect(
+          comment.includes("See artifacts and rendered test results")
+        ).toBeTruthy();
+        return true;
+      })
+      .reply(200);
+
     await probot.receive({ name: "pull_request", payload: payload, id: "2" });
     handleScope(scope);
   });
@@ -221,6 +268,7 @@ describe("verify-drci-functionality", () => {
         {
           id: comment_id,
           node_id: comment_node_id,
+          user: { login: drciUtils.DRCI_COMMENT_AUTHOR },
           body: "<!-- drci-comment-start -->\nhello\n<!-- drci-comment-end -->\n",
         },
       ])


### PR DESCRIPTION
## Problem

Dr. CI keeps a single status comment per PR and finds "its" comment purely by scanning for the literal `<!-- drci-comment-start -->` marker, with **no author check**. Two selectors do this and neither filters by author:

- `getDrciComment()` (probot/webhook path, `lib/drciUtils.ts`) — `listComments`, returns the first comment whose body includes the marker.
- `getExistingDrCiComments()` (15-minute updater, `pages/api/drci/drci.ts`) — ClickHouse `issue_comment` `body like '%<!-- drci-comment-start -->%'`, with no `ORDER BY`, fed into `new Map()` (last row wins on duplicates).

If any other comment on the PR embeds that marker (e.g. a bot/tool that quotes or forwards the Dr. CI status block), Dr. CI mistakes it for its own and overwrites it in place.

Observed on #186611: a comment authored under a non-bot account embedded the marker and was repeatedly overwritten with Dr. CI's render, while the real `pytorch-bot[bot]` comment went stale.

## Fix

Require the comment author to be `pytorch-bot[bot]` in both selectors. Dr. CI always creates/updates its comment through the pytorch-bot GitHub App installation, so its author login is always `pytorch-bot[bot]` — in the API handler the user token is only used for rate-limit identity; the actual mutation uses `getOctokit(org, repo)` (the app installation). So the guard doesn't affect the normal create/update flow.

Also adds `order by id desc` to the ClickHouse query so selection stays deterministic (keeps the oldest bot comment, matching the chronologically-first match `getDrciComment` returns) in the unlikely event multiple bot-authored marker comments ever exist.

## Test plan

- New regression test in `drciBot.test.ts`: a marker-bearing comment from a non-bot author is ignored and Dr. CI posts its own comment instead.
- Updated the existing `drciBot.test.ts` fixtures to set the comment author to `pytorch-bot[bot]`.
- `yarn jest test/drciBot.test.ts test/drci.test.ts` → both suites pass.
- Verified the updated ClickHouse query against prod for #186611: without the author filter it returns 2 marker comments (`pytorch-bot[bot]` + the impostor); with the filter it returns exactly the `pytorch-bot[bot]` comment.