### PR TITLE
Add CUDA 12.9 builds for Linux (x86 + aarch64) in the test channel

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -49,6 +49,7 @@ ROCM_ARCHES_DICT = {
 CUDA_CUDNN_VERSIONS = {
     "12.6": {"cuda": "12.6.3", "cudnn": "9"},
     "12.8": {"cuda": "12.8.0", "cudnn": "9"},
+    "12.9": {"cuda": "12.9.1", "cudnn": "9"},
     "13.0": {"cuda": "13.0.0", "cudnn": "9"},
     "13.2": {"cuda": "13.2.0", "cudnn": "9"},
 }
@@ -59,7 +60,11 @@ STABLE_CUDA_VERSIONS = {
     "release": "13.0",
 }
 
-CUDA_AARCH64_ARCHES = ["12.6-aarch64", "13.0-aarch64", "13.2-aarch64"]
+CUDA_AARCH64_ARCHES_DICT = {
+    "nightly": ["12.6-aarch64", "13.0-aarch64", "13.2-aarch64"],
+    "test": ["12.6-aarch64", "12.9-aarch64", "13.0-aarch64", "13.2-aarch64"],
+    "release": ["12.6-aarch64", "13.0-aarch64", "13.2-aarch64"],
+}
 
 PACKAGE_TYPES = ["wheel", "libtorch"]
 CXX11_ABI = "cxx11-abi"
@@ -91,6 +96,7 @@ CURRENT_VERSION = CURRENT_STABLE_VERSION
 
 # By default use Nightly for CUDA arches
 CUDA_ARCHES = CUDA_ARCHES_DICT[NIGHTLY]
+CUDA_AARCH64_ARCHES = CUDA_AARCH64_ARCHES_DICT[NIGHTLY]
 ROCM_ARCHES = ROCM_ARCHES_DICT[NIGHTLY]
 PYTHON_ARCHES = PYTHON_ARCHES_DICT[NIGHTLY]
 
@@ -167,6 +173,13 @@ def initialize_globals(
         CURRENT_VERSION = CURRENT_STABLE_VERSION
 
     CUDA_ARCHES = CUDA_ARCHES_DICT[channel]
+    CUDA_AARCH64_ARCHES = CUDA_AARCH64_ARCHES_DICT[channel]
+    # CUDA 12.9 is built for Linux only (x86 and aarch64) in the test channel.
+    # Windows and macOS do not build 12.9. aarch64 is handled via the per-channel
+    # CUDA_AARCH64_ARCHES_DICT above; here we add the x86 arch for Linux only so
+    # that Windows (which shares CUDA_ARCHES_DICT) does not pick it up.
+    if channel == TEST and os == LINUX:
+        CUDA_ARCHES = CUDA_ARCHES + ["12.9"]
     ROCM_ARCHES = ROCM_ARCHES_DICT[channel]
     if build_python_only:
         # Only select the oldest version of python if building a python only package

--- a/tools/tests/assets/build_matrix_linux_wheel_cuda.json
+++ b/tools/tests/assets/build_matrix_linux_wheel_cuda.json
@@ -12,7 +12,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -26,7 +26,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -40,7 +40,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -54,7 +54,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -68,7 +68,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -82,7 +82,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -96,7 +96,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -110,7 +110,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -124,7 +124,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -138,7 +138,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -152,7 +152,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -166,7 +166,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -180,7 +180,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -194,7 +194,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -208,7 +208,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -222,7 +222,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -236,7 +236,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -250,7 +250,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -264,7 +264,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -278,7 +278,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -292,7 +292,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -306,7 +306,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -320,7 +320,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -334,7 +334,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -348,7 +348,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -362,7 +362,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -376,7 +376,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -390,7 +390,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -404,7 +404,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -418,7 +418,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -432,7 +432,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -446,7 +446,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -460,7 +460,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -474,7 +474,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -488,7 +488,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -502,7 +502,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -516,7 +516,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -530,7 +530,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -544,7 +544,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -558,7 +558,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -572,7 +572,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -586,7 +586,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     }
   ]
 }

--- a/tools/tests/assets/build_matrix_linux_wheel_cuda_norocm.json
+++ b/tools/tests/assets/build_matrix_linux_wheel_cuda_norocm.json
@@ -12,7 +12,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -26,7 +26,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -40,7 +40,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -54,7 +54,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -68,7 +68,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -82,7 +82,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -96,7 +96,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -110,7 +110,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -124,7 +124,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -138,7 +138,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -152,7 +152,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -166,7 +166,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -180,7 +180,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -194,7 +194,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -208,7 +208,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -222,7 +222,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -236,7 +236,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -250,7 +250,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -264,7 +264,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -278,7 +278,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -292,7 +292,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -306,7 +306,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -320,7 +320,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -334,7 +334,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -348,7 +348,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -362,7 +362,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -376,7 +376,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -390,7 +390,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     }
   ]
 }

--- a/tools/tests/assets/build_matrix_linux_wheel_nocpu.json
+++ b/tools/tests/assets/build_matrix_linux_wheel_nocpu.json
@@ -12,7 +12,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -26,7 +26,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -40,7 +40,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -54,7 +54,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -68,7 +68,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -82,7 +82,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -96,7 +96,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -110,7 +110,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -124,7 +124,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -138,7 +138,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -152,7 +152,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -166,7 +166,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -180,7 +180,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -194,7 +194,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -208,7 +208,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -222,7 +222,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -236,7 +236,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -250,7 +250,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -264,7 +264,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -278,7 +278,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -292,7 +292,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -306,7 +306,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -320,7 +320,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -334,7 +334,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -348,7 +348,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -362,7 +362,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -376,7 +376,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -390,7 +390,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -404,7 +404,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -418,7 +418,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -432,7 +432,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -446,7 +446,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -460,7 +460,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -474,7 +474,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -488,7 +488,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     }
   ]
 }

--- a/tools/tests/assets/build_matrix_linux_wheel_xpu.json
+++ b/tools/tests/assets/build_matrix_linux_wheel_xpu.json
@@ -12,7 +12,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -26,7 +26,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -40,7 +40,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -54,7 +54,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -68,7 +68,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -82,7 +82,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -96,7 +96,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -110,7 +110,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -124,7 +124,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -138,7 +138,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -152,7 +152,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -166,7 +166,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -180,7 +180,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -194,7 +194,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -208,7 +208,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -222,7 +222,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -236,7 +236,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -250,7 +250,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -264,7 +264,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -278,7 +278,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -292,7 +292,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -306,7 +306,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -320,7 +320,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -334,7 +334,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -348,7 +348,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -362,7 +362,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -376,7 +376,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -390,7 +390,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     }
   ]
 }

--- a/tools/tests/assets/build_matrix_macos_wheel.json
+++ b/tools/tests/assets/build_matrix_macos_wheel.json
@@ -12,7 +12,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -26,7 +26,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -40,7 +40,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -54,7 +54,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -68,7 +68,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -82,7 +82,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -96,7 +96,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     }
   ]
 }

--- a/tools/tests/assets/build_matrix_windows_wheel_cuda.json
+++ b/tools/tests/assets/build_matrix_windows_wheel_cuda.json
@@ -12,7 +12,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -26,7 +26,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -40,7 +40,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -54,7 +54,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -68,7 +68,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -82,7 +82,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -96,7 +96,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -110,7 +110,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -124,7 +124,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -138,7 +138,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -152,7 +152,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -166,7 +166,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -180,7 +180,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -194,7 +194,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -208,7 +208,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -222,7 +222,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -236,7 +236,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -250,7 +250,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -264,7 +264,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -278,7 +278,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -292,7 +292,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -306,7 +306,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -320,7 +320,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -334,7 +334,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -348,7 +348,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -362,7 +362,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -376,7 +376,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -390,7 +390,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -404,7 +404,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -418,7 +418,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -432,7 +432,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -446,7 +446,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -460,7 +460,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu130",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -474,7 +474,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu132",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -488,7 +488,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     }
   ]
 }

--- a/tools/tests/assets/build_matrix_windows_wheel_xpu.json
+++ b/tools/tests/assets/build_matrix_windows_wheel_xpu.json
@@ -12,7 +12,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.10",
@@ -26,7 +26,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -40,7 +40,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.11",
@@ -54,7 +54,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -68,7 +68,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.12",
@@ -82,7 +82,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -96,7 +96,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13",
@@ -110,7 +110,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -124,7 +124,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.13t",
@@ -138,7 +138,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -152,7 +152,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14",
@@ -166,7 +166,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -180,7 +180,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     },
     {
       "python_version": "3.14t",
@@ -194,7 +194,7 @@
       "installation": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu",
       "channel": "nightly",
       "upload_to_base_bucket": "yes",
-      "stable_version": "2.11.0"
+      "stable_version": "2.12.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds CUDA 12.9 wheel/libtorch builds to the **test** channel, scoped to **Linux only (x86 + aarch64)**. Windows and macOS do **not** build 12.9.

Changes in `tools/scripts/generate_binary_build_matrix.py`:
- **Linux x86**: 12.9 is added in `initialize_globals` only when `channel == test and os == linux`. It is intentionally **not** placed in `CUDA_ARCHES_DICT["test"]`, because Windows reads that same list and must not pick up 12.9.
- **Linux aarch64**: introduced a per-channel `CUDA_AARCH64_ARCHES_DICT` (mirroring `CUDA_ARCHES_DICT`) with `12.9-aarch64` in the `test` channel only. `linux-aarch64` is the only consumer of that list.
- `CUDA_CUDNN_VERSIONS`: added `"12.9": {"cuda": "12.9.1", "cudnn": "9"}`, matching how 12.9 was previously configured (pre-#7917).
- Container images (`manylinux2_28-builder:cuda12.9`, `manylinuxaarch64-builder:cuda12.9`) are derived automatically.

## Verification

Generated matrices per OS for `--channel test`:

| OS | CUDA arches |
|----|----|
| linux | `12.6, 12.9, 13.0, 13.2` ✅ |
| linux-aarch64 | `12.6-aarch64, 12.9-aarch64, 13.0-aarch64, 13.2-aarch64` ✅ |
| windows | `12.6, 13.0, 13.2` (no 12.9) ✅ |
| macos | none (no CUDA) ✅ |

Other channels unaffected: `nightly`/`release` linux do not include 12.9. Verified for both `wheel` and `libtorch`. Sample 12.9 entry: `build_name=manywheel-py3_10-cuda12_9`, `desired_cuda=cu129`, `container_image=pytorch/manylinux2_28-builder:cuda12.9`.

## Reference test assets

Regenerated via `python -m tools.tests.test_generate_binary_build_matrix --update-reference-files`.

The reference assets are generated for the **nightly** channel, so the test-channel 12.9 addition does not appear in them. The asset diffs are a **pre-existing staleness fix**: they carried `stable_version: 2.11.0` while the branch already declares `CURRENT_STABLE_VERSION = 2.12.0`, which had left all 7 matrix tests **red on the pristine branch**. Regenerating brings them to `2.12.0` and the tests now pass (7/7).