### PR TITLE
[Windows CI] Pin openssl=3.5.6 in setup-binary-builds to fix cert-store ASN.1 failure

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -139,6 +139,10 @@ runs:
               ;;
           esac
 
+          # Pin openssl=3.5.6: openssl 3.5.7 regressed ASN.1 parsing and rejects a
+          # malformed cert in the Windows machine cert store, breaking
+          # ssl.create_default_context() with "[ASN1: NOT_ENOUGH_DATA]" at smoke-test
+          # time. See https://github.com/pytorch/pytorch/pull/186846
           conda create \
               --yes --quiet \
               --prefix "${CONDA_ENV}" \
@@ -149,6 +153,7 @@ runs:
               libpng \
               pkg-config=0.29 \
               wheel=0.37  \
+              "openssl=3.5.6" \
               ${CONDA_EXTRA_PARAM}
 
           echo "CONDA_ENV=${CONDA_ENV}" >> "${GITHUB_ENV}"


### PR DESCRIPTION
## Summary

Windows wheel-build smoke tests started failing at **import / SSL-context creation time** with:

```
ssl.SSLError: [ASN1: NOT_ENOUGH_DATA] not enough data (_ssl.c:4040)
```

in `ssl.create_default_context() -> load_default_certs -> _load_windows_store_certs`.

Example: torchvision "Build Windows Wheels" smoke test — https://github.com/pytorch/vision/actions/runs/27246136085/job/80460480702 — crashes in `smoke_test_torchvision_resnet50_classify`.

## Root cause

The build/test conda env in `setup-binary-builds` creates `openssl` as an **unpinned** transitive dep. conda silently pulled the newly released **openssl 3.5.7** (the job log shows `openssl 3.5.6 --> 3.5.7`), which tightened/regressed ASN.1 parsing and now hard-rejects a malformed certificate in the Windows machine cert store that 3.5.6 tolerated.

This is the same failure and fix as **pytorch/pytorch#186846**, which pinned `openssl=3.5.6` in `.github/actions/setup-win/action.yml`. test-infra's wheel-build path uses a different conda env (`setup-binary-builds`), so it needs the same pin.

## Fix

Pin `openssl=3.5.6` directly in the `conda create` for the build/test environment in `.github/actions/setup-binary-builds/action.yml` (same approach as the PyTorch PR). Applied unconditionally for all platforms for simplicity — only Windows hits the cert-store path, and openssl 3.5.6 is available for Linux/macOS too.

## Test plan

Windows wheel-build smoke tests (e.g. torchvision) should get openssl 3.5.6 and run `smoke_test.py` without the ASN.1 error.