### PR TITLE
[release/2.12] Pin test-infra-ref to release/2.12 in validation matrix generation

### DIFF
--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -106,6 +106,7 @@ jobs:
       package-type: wheel
       os: linux-aarch64
       channel: ${{ inputs.channel }}
+      test-infra-ref: release/2.12
       with-cuda: enable
       with-cpu: enable
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -116,6 +116,7 @@ jobs:
       package-type: wheel,libtorch
       os: linux
       channel: ${{ inputs.channel }}
+      test-infra-ref: release/2.12
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
       with-xpu: enable
 

--- a/.github/workflows/validate-macos-arm64-binaries.yml
+++ b/.github/workflows/validate-macos-arm64-binaries.yml
@@ -106,6 +106,7 @@ jobs:
       package-type: wheel,libtorch #  We stopped producing conda nightlies
       os: macos-arm64
       channel: ${{ inputs.channel }}
+      test-infra-ref: release/2.12
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
 
   macos-arm64:

--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -106,6 +106,7 @@ jobs:
       package-type: wheel,libtorch #  We stopped producing conda nightlies
       os: windows
       channel: ${{ inputs.channel }}
+      test-infra-ref: release/2.12
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
       with-xpu: enable
 


### PR DESCRIPTION
The per-platform validate workflows call generate_binary_build_matrix.yml without passing test-infra-ref, so it falls back to the workflow default of 'main'. The build matrix (and its stable_version / CURRENT_CANDIDATE_VERSION) is therefore computed from main's generate_binary_build_matrix.py even when validating release/2.12.

main still has CURRENT_CANDIDATE_VERSION=2.12.0 while the test channel serves 2.12.1, so validation installs 2.12.1 and smoke_test.py fails:

  RuntimeError: Torch version mismatch, expected 2.12.0 for channel test.
  But its 2.12.1+cu132

Pin test-infra-ref: release/2.12 in the matrix-generation calls so the matrix is computed from the release branch (CURRENT_CANDIDATE_VERSION=2.12.1).