### PR TITLE
[HUD] Add viable/strict test console pages

### DIFF
--- a/torchci/clickhouse_queries/viablestrict_run_summary/params.json
+++ b/torchci/clickhouse_queries/viablestrict_run_summary/params.json
@@ -1,0 +1,15 @@
+{
+  "params": {
+    "sha": "String",
+    "workflows": "Array(String)"
+  },
+  "defaults": {
+    "workflows": ["pull", "trunk", "lint"]
+  },
+  "tests": [
+    {
+      "sha": "c808af514d59e25ea4a880c1e1e07d3232984e5d",
+      "workflows": ["pull", "trunk", "lint"]
+    }
+  ]
+}

--- a/torchci/clickhouse_queries/viablestrict_run_summary/query.sql
+++ b/torchci/clickhouse_queries/viablestrict_run_summary/query.sql
@@ -1,0 +1,153 @@
+-- Summary for a single viable/strict commit's per-test page: one row per
+-- (conclusion, duration bucket) with a count. The frontend derives both the
+-- pass/fail/skip/flaky chip totals (sum over buckets) and the "Test Time
+-- Distribution" histogram (sum over conclusions) from this single result.
+--
+-- Classification matches viablestrict_run_tests exactly (latest attempt per
+-- config, new-process recovery, and job-conclusion gating), so the chip counts
+-- line up with the table. Fetched once per commit (independent of paging/filter).
+--
+-- Buckets are static per-test total duration (seconds), fine-grained at the low
+-- end where most unit tests live:
+--   0:<0.1  1:0.1-0.25  2:0.25-0.5  3:0.5-1  4:1-2  5:2-3  6:3-5  7:5-10
+--   8:10-20  9:20-30  10:30-60  11:60-120  12:120-300  13:>=300
+WITH tests_jobs AS (
+    SELECT
+        j.id AS job_id,
+        j.run_id AS workflow_id,
+        j.workflow_name AS workflow_name,
+        j.name AS job_name,
+        j.run_attempt AS run_attempt,
+        j.conclusion_kg AS conclusion,
+        j.started_at AS started_at
+    FROM
+        default.workflow_job j FINAL
+    WHERE
+        j.id IN (
+            SELECT id FROM materialized_views.workflow_job_by_head_sha
+            WHERE head_sha = {sha: String}
+        )
+        -- Only the canonical on-main evaluation of the commit (see run_tests).
+        AND j.head_branch = 'main'
+        AND j.workflow_name IN {workflows: Array(String)}
+        AND j.name NOT LIKE '%mem_leak_check%'
+        AND j.name NOT LIKE '%rerun_disabled_tests%'
+        AND j.name NOT LIKE '%unstable%'
+),
+job_conclusions AS (
+    SELECT
+        workflow_name,
+        job_name,
+        argMax(conclusion, run_attempt) AS job_conclusion
+    FROM tests_jobs
+    GROUP BY workflow_name, job_name
+),
+bounds AS (
+    SELECT
+        min(started_at) - INTERVAL 1 DAY AS lo,
+        max(started_at) + INTERVAL 2 DAY AS hi
+    FROM tests_jobs
+),
+test_rows AS (
+    SELECT
+        t.invoking_file AS invoking_file,
+        t.file AS file,
+        t.classname AS classname,
+        t.name AS name,
+        j.workflow_name AS workflow_name,
+        j.job_name AS job_name,
+        t.workflow_run_attempt AS run_attempt,
+        t.time AS time,
+        length(t.failure) AS failure_count,
+        length(t.error) AS error_count,
+        length(t.skipped) AS skipped_count,
+        length(t.rerun) AS rerun_count
+    FROM
+        tests.all_test_runs t
+        INNER JOIN tests_jobs j ON t.job_id = j.job_id
+    WHERE
+        t.workflow_id IN (SELECT workflow_id FROM tests_jobs)
+        AND t.time_inserted BETWEEN (SELECT lo FROM bounds) AND (SELECT hi FROM bounds)
+),
+test_rows_latest AS (
+    SELECT
+        *,
+        max(run_attempt) OVER (
+            PARTITION BY invoking_file, file, classname, name, workflow_name, job_name
+        ) AS max_attempt
+    FROM test_rows
+),
+per_config AS (
+    SELECT
+        invoking_file,
+        file,
+        classname,
+        name,
+        workflow_name,
+        job_name,
+        SUM(time) AS time,
+        SUM(rerun_count) AS config_reruns,
+        countIf(failure_count + error_count > 0) AS fail_rows,
+        countIf(failure_count + error_count = 0 AND skipped_count = 0) AS pass_rows,
+        countIf(skipped_count > 0) AS skip_rows
+    FROM test_rows_latest
+    WHERE run_attempt = max_attempt
+    GROUP BY
+        invoking_file,
+        file,
+        classname,
+        name,
+        workflow_name,
+        job_name
+),
+agg AS (
+    SELECT
+        pc.invoking_file AS invoking_file,
+        pc.file AS file,
+        pc.classname AS classname,
+        pc.name AS name,
+        SUM(pc.time) AS time,
+        -- number of (config) runs of this test = rows in per_config
+        count(*) AS runs,
+        multiIf(
+            countIf(
+                pc.fail_rows > 0 AND pc.pass_rows = 0
+                    AND jc.job_conclusion NOT IN ('success', 'skipped', '')
+            ) > 0, 'failed',
+            countIf(pc.fail_rows > 0) > 0 OR SUM(pc.config_reruns) > 0, 'flaky',
+            countIf(pc.skip_rows > 0 AND pc.pass_rows = 0) = count(*), 'skipped',
+            'success'
+        ) AS conclusion
+    FROM
+        per_config pc
+        LEFT JOIN job_conclusions jc
+            ON pc.workflow_name = jc.workflow_name AND pc.job_name = jc.job_name
+    GROUP BY
+        pc.invoking_file,
+        pc.file,
+        pc.classname,
+        pc.name
+)
+SELECT
+    conclusion,
+    multiIf(
+        time < 0.1, 0,
+        time < 0.25, 1,
+        time < 0.5, 2,
+        time < 1, 3,
+        time < 2, 4,
+        time < 3, 5,
+        time < 5, 6,
+        time < 10, 7,
+        time < 20, 8,
+        time < 30, 9,
+        time < 60, 10,
+        time < 120, 11,
+        time < 300, 12,
+        13
+    ) AS bucket,
+    count(*) AS cnt,
+    SUM(runs) AS executions
+FROM agg
+GROUP BY conclusion, bucket
+ORDER BY conclusion, bucket

--- a/torchci/clickhouse_queries/viablestrict_run_tests/params.json
+++ b/torchci/clickhouse_queries/viablestrict_run_tests/params.json
@@ -1,0 +1,30 @@
+{
+  "params": {
+    "sha": "String",
+    "workflows": "Array(String)",
+    "states": "Array(String)",
+    "name_filter": "String",
+    "sort": "String",
+    "limit": "Int64",
+    "offset": "Int64"
+  },
+  "defaults": {
+    "workflows": ["pull", "trunk", "lint"],
+    "states": ["failed", "skipped"],
+    "name_filter": "%",
+    "sort": "duration",
+    "limit": 100,
+    "offset": 0
+  },
+  "tests": [
+    {
+      "sha": "c808af514d59e25ea4a880c1e1e07d3232984e5d",
+      "workflows": ["pull", "trunk", "lint"],
+      "states": ["failed", "skipped"],
+      "name_filter": "%",
+      "sort": "duration",
+      "limit": 100,
+      "offset": 0
+    }
+  ]
+}

--- a/torchci/clickhouse_queries/viablestrict_run_tests/query.sql
+++ b/torchci/clickhouse_queries/viablestrict_run_tests/query.sql
@@ -1,0 +1,244 @@
+-- Per-commit individual-test breakdown for a single viable/strict commit,
+-- aggregated per test (name/classname/file) across the commit's strict-blocking
+-- jobs. Server-side paginated and filterable by state so we never scan or
+-- serialize the whole (millions-of-rows) all_test_runs result at once.
+--
+-- Powers the per-run page at /viablestrict/[sha].
+--
+-- Perf notes:
+--   * We derive a tight time window from the jobs' started_at and filter
+--     all_test_runs by time_inserted so ClickHouse can prune partitions instead
+--     of scanning the whole (very large) table.
+--   * State filter + LIMIT/OFFSET keep the payload small; count() OVER ()
+--     returns the full filtered count for the pager.
+--
+-- Matching GitHub's final state. Two retry mechanisms both have to read as
+-- "passed":
+--   1. Whole-job re-run -> a later workflow_run_attempt. We keep only the latest
+--      attempt per (test, config).
+--   2. "failed and then succeeded when run in a new process" -> the failed run
+--      and the passing retry are SEPARATE rows in all_test_runs with the SAME
+--      attempt. So within a config we look at whether there is any PASSING row,
+--      not just whether any row failed: fail+pass => flaky (recovered, green);
+--      fail with no pass => genuinely failed (red).
+WITH tests_jobs AS (
+    SELECT
+        j.id AS job_id,
+        j.run_id AS workflow_id,
+        j.workflow_name AS workflow_name,
+        j.name AS job_name,
+        j.run_attempt AS run_attempt,
+        j.conclusion_kg AS conclusion,
+        j.started_at AS started_at
+    FROM
+        default.workflow_job j FINAL
+    WHERE
+        j.id IN (
+            SELECT id FROM materialized_views.workflow_job_by_head_sha
+            WHERE head_sha = {sha: String}
+        )
+        -- Only the canonical on-main evaluation of the commit: drops PR/draft
+        -- runs, trunk/{sha} ciflow-tag duplicates, landchecks, and dispatch
+        -- restarts that share the SHA but aren't the main-branch signal.
+        AND j.head_branch = 'main'
+        -- Restrict to the strict-blocking workflows (mirror update-viablestrict.yml)
+        AND j.workflow_name IN {workflows: Array(String)}
+        -- Exclude jobs that never gate viable/strict
+        AND j.name NOT LIKE '%mem_leak_check%'
+        AND j.name NOT LIKE '%rerun_disabled_tests%'
+        AND j.name NOT LIKE '%unstable%'
+),
+job_conclusions AS (
+    -- Final (latest-attempt) conclusion per job. A test only counts as a real
+    -- "failed" if its job actually ended red -- mirrors the gate, and means a
+    -- failing test in a green job (e.g. a non-fatal XPASS, or a job re-run
+    -- green) reads as non-blocking instead of failed.
+    SELECT
+        workflow_name,
+        job_name,
+        argMax(conclusion, run_attempt) AS job_conclusion
+    FROM tests_jobs
+    GROUP BY workflow_name, job_name
+),
+bounds AS (
+    SELECT
+        min(started_at) - INTERVAL 1 DAY AS lo,
+        max(started_at) + INTERVAL 2 DAY AS hi
+    FROM tests_jobs
+),
+test_rows AS (
+    SELECT
+        t.invoking_file AS invoking_file,
+        t.file AS file,
+        t.classname AS classname,
+        t.name AS name,
+        j.workflow_name AS workflow_name,
+        j.job_name AS job_name,
+        t.workflow_run_attempt AS run_attempt,
+        t.time AS time,
+        length(t.failure) AS failure_count,
+        length(t.error) AS error_count,
+        length(t.skipped) AS skipped_count,
+        length(t.rerun) AS rerun_count,
+        -- Failure excerpt for the Details column (only failures populate this;
+        -- out-of-range array access returns '' in ClickHouse, so this is safe).
+        if(t.failure[1].'text' != '', t.failure[1].'text', t.error[1].'text') AS failure_text
+    FROM
+        tests.all_test_runs t
+        INNER JOIN tests_jobs j ON t.job_id = j.job_id
+    WHERE
+        t.workflow_id IN (SELECT workflow_id FROM tests_jobs)
+        AND t.time_inserted BETWEEN (SELECT lo FROM bounds) AND (SELECT hi FROM bounds)
+),
+-- Keep only the latest workflow_run_attempt's rows per (test, config), so a
+-- whole-job re-run supersedes the earlier attempt.
+test_rows_latest AS (
+    SELECT
+        *,
+        max(run_attempt) OVER (
+            PARTITION BY invoking_file, file, classname, name, workflow_name, job_name
+        ) AS max_attempt
+    FROM test_rows
+),
+per_config AS (
+    SELECT
+        invoking_file,
+        file,
+        classname,
+        name,
+        workflow_name,
+        job_name,
+        SUM(time) AS time,
+        SUM(failure_count) AS failures,
+        SUM(error_count) AS errors,
+        SUM(rerun_count) AS config_reruns,
+        -- A failing execution and a passing execution of the same test (the
+        -- "succeeded in a new process" case) both appear here as separate rows.
+        countIf(failure_count + error_count > 0) AS fail_rows,
+        countIf(failure_count + error_count = 0 AND skipped_count = 0) AS pass_rows,
+        countIf(skipped_count > 0) AS skip_rows,
+        anyIf(failure_text, failure_text != '') AS details
+    FROM test_rows_latest
+    WHERE run_attempt = max_attempt
+    GROUP BY
+        invoking_file,
+        file,
+        classname,
+        name,
+        workflow_name,
+        job_name
+),
+durations AS (
+    -- Per-execution duration stats per test (median/p90 over individual runs;
+    -- approximate quantiles -- sketch-based, cheap over already-scanned rows).
+    SELECT
+        invoking_file,
+        file,
+        classname,
+        name,
+        median(time) AS median_time,
+        quantile(0.9)(time) AS p90_time
+    FROM test_rows_latest
+    WHERE run_attempt = max_attempt
+    GROUP BY invoking_file, file, classname, name
+),
+agg AS (
+    SELECT
+        pc.invoking_file AS invoking_file,
+        pc.file AS file,
+        pc.classname AS classname,
+        pc.name AS name,
+        count(*) AS runs,
+        SUM(pc.time) AS time,
+        any(d.median_time) AS median_time,
+        any(d.p90_time) AS p90_time,
+        SUM(pc.failures) AS failures,
+        SUM(pc.errors) AS errors,
+        SUM(pc.skip_rows) AS skipped,
+        SUM(pc.config_reruns) AS reruns,
+        -- Full GitHub job identifier ("pull / linux-... / test-osdc (default)"),
+        -- with the matrix suffix collapsed from "(config, shard, total, runner)"
+        -- to just "(config)" -- keeps the meaningful config, drops shard indices
+        -- and the runner label.
+        groupUniqArray(
+            concat(
+                pc.workflow_name, ' / ',
+                replaceRegexpOne(pc.job_name, '\\(([^,)]+)[^)]*\\)', '(\\1)')
+            )
+        ) AS jobs,
+        anyIf(pc.details, pc.details != '') AS details,
+        -- Configs where the test failed, never passed, AND the job ended red.
+        groupUniqArrayIf(
+            concat(
+                pc.workflow_name, ' / ',
+                replaceRegexpOne(pc.job_name, '\\(([^,)]+)[^)]*\\)', '(\\1)')
+            ),
+            pc.fail_rows > 0 AND pc.pass_rows = 0
+                AND jc.job_conclusion NOT IN ('success', 'skipped', '')
+        ) AS failed_jobs,
+        -- "failed"  = a config failed with no passing run AND its job ended red
+        --             (i.e. it actually blocked -- matches GitHub).
+        -- "flaky"   = failed somewhere but did NOT block: recovered on retry /
+        --             in a new process, in-process reruns, or a non-fatal
+        --             failure (e.g. XPASS) in a job that stayed green.
+        -- "skipped" = every config only skipped.
+        multiIf(
+            countIf(
+                pc.fail_rows > 0 AND pc.pass_rows = 0
+                    AND jc.job_conclusion NOT IN ('success', 'skipped', '')
+            ) > 0, 'failed',
+            countIf(pc.fail_rows > 0) > 0 OR SUM(pc.config_reruns) > 0, 'flaky',
+            countIf(pc.skip_rows > 0 AND pc.pass_rows = 0) = count(*), 'skipped',
+            'success'
+        ) AS conclusion
+    FROM
+        per_config pc
+        LEFT JOIN job_conclusions jc
+            ON pc.workflow_name = jc.workflow_name AND pc.job_name = jc.job_name
+        LEFT JOIN durations d
+            ON pc.invoking_file = d.invoking_file
+            AND pc.file = d.file
+            AND pc.classname = d.classname
+            AND pc.name = d.name
+    GROUP BY
+        pc.invoking_file,
+        pc.file,
+        pc.classname,
+        pc.name
+)
+SELECT
+    invoking_file,
+    file,
+    classname,
+    name,
+    runs,
+    time,
+    median_time,
+    p90_time,
+    failures,
+    errors,
+    skipped,
+    reruns,
+    jobs,
+    failed_jobs,
+    details,
+    conclusion,
+    total_count
+FROM (
+    SELECT
+        *,
+        count() OVER () AS total_count
+    FROM
+        agg
+    WHERE
+        -- {states} is a list of conclusions to show; ['all'] shows everything.
+        (has({states: Array(String)}, 'all') OR has({states: Array(String)}, conclusion))
+        AND name LIKE {name_filter: String}
+)
+ORDER BY
+    -- Failed first, then skipped, then flaky, then success (mockup order).
+    multiIf(conclusion = 'failed', 0, conclusion = 'skipped', 1, conclusion = 'flaky', 2, 3) ASC,
+    -- {sort} = 'name' sorts by test name asc; anything else by duration desc.
+    if({sort: String} = 'name', name, '') ASC,
+    if({sort: String} = 'name', 0, time) DESC
+LIMIT {limit: Int64} OFFSET {offset: Int64}

--- a/torchci/clickhouse_queries/viablestrict_run_workflows/params.json
+++ b/torchci/clickhouse_queries/viablestrict_run_workflows/params.json
@@ -1,0 +1,15 @@
+{
+  "params": {
+    "sha": "String",
+    "workflows": "Array(String)"
+  },
+  "defaults": {
+    "workflows": ["pull", "trunk", "lint"]
+  },
+  "tests": [
+    {
+      "sha": "c808af514d59e25ea4a880c1e1e07d3232984e5d",
+      "workflows": ["pull", "trunk", "lint"]
+    }
+  ]
+}

--- a/torchci/clickhouse_queries/viablestrict_run_workflows/query.sql
+++ b/torchci/clickhouse_queries/viablestrict_run_workflows/query.sql
@@ -1,0 +1,49 @@
+-- Distribution of tests across build environments for one viable/strict commit:
+-- one row per build name (the first segment of the job name, e.g.
+-- "linux-jammy-aarch64-py3.10"), with the number of distinct tests that ran in
+-- it. Powers the "tests by build" strip under the histogram.
+--
+-- Same scoping as viablestrict_run_tests (on-main, strict-blocking, time-window
+-- pruned). uniqExact over the test identity dedupes shards and re-run attempts
+-- automatically, so no latest-attempt window is needed here.
+WITH tests_jobs AS (
+    SELECT
+        j.id AS job_id,
+        j.run_id AS workflow_id,
+        j.workflow_name AS workflow_name,
+        j.name AS job_name,
+        j.started_at AS started_at
+    FROM
+        default.workflow_job j FINAL
+    WHERE
+        j.id IN (
+            SELECT id FROM materialized_views.workflow_job_by_head_sha
+            WHERE head_sha = {sha: String}
+        )
+        AND j.head_branch = 'main'
+        AND j.workflow_name IN {workflows: Array(String)}
+        AND j.name NOT LIKE '%mem_leak_check%'
+        AND j.name NOT LIKE '%rerun_disabled_tests%'
+        AND j.name NOT LIKE '%unstable%'
+),
+bounds AS (
+    SELECT
+        min(started_at) - INTERVAL 1 DAY AS lo,
+        max(started_at) + INTERVAL 2 DAY AS hi
+    FROM tests_jobs
+)
+SELECT
+    j.workflow_name AS workflow,
+    splitByString(' / ', j.job_name)[1] AS build,
+    uniqExact(t.invoking_file, t.file, t.classname, t.name) AS tests
+FROM
+    tests.all_test_runs t
+    INNER JOIN tests_jobs j ON t.job_id = j.job_id
+WHERE
+    t.workflow_id IN (SELECT workflow_id FROM tests_jobs)
+    AND t.time_inserted BETWEEN (SELECT lo FROM bounds) AND (SELECT hi FROM bounds)
+GROUP BY
+    workflow,
+    build
+ORDER BY
+    tests DESC

--- a/torchci/clickhouse_queries/viablestrict_runs/params.json
+++ b/torchci/clickhouse_queries/viablestrict_runs/params.json
@@ -1,0 +1,16 @@
+{
+  "params": {
+    "repo": "String",
+    "days": "Int64"
+  },
+  "defaults": {
+    "repo": "pytorch/pytorch",
+    "days": 7
+  },
+  "tests": [
+    {
+      "repo": "pytorch/pytorch",
+      "days": 7
+    }
+  ]
+}

--- a/torchci/clickhouse_queries/viablestrict_runs/query.sql
+++ b/torchci/clickhouse_queries/viablestrict_runs/query.sql
@@ -1,0 +1,23 @@
+-- Lists the commits that viable/strict was advanced to (one row per promotion).
+-- Powers the /viablestrict list page; each row links to the per-commit test
+-- breakdown at /viablestrict/[sha].
+--
+-- NOTE: the push table has no push-event timestamp -- head_commit.timestamp is
+-- the commit author time (this is also what strict_lag_sec orders by). The
+-- "Update viable/strict" cron runs every ~30 min but only creates a push row
+-- here when it actually advances the branch, so this list is exactly the set of
+-- real promotions.
+SELECT DISTINCT
+    push.head_commit.id AS sha,
+    push.head_commit.message AS message,
+    push.head_commit.author.name AS author,
+    push.head_commit.timestamp AS timestamp
+FROM
+    default.push
+WHERE
+    push.ref = 'refs/heads/viable/strict'
+    AND push.repository.full_name = {repo: String}
+    AND push.head_commit.id != ''
+    AND push.head_commit.timestamp > now() - INTERVAL {days: Int64} DAY
+ORDER BY
+    timestamp DESC

--- a/torchci/components/layout/NavBar.tsx
+++ b/torchci/components/layout/NavBar.tsx
@@ -68,6 +68,10 @@ function NavBar() {
       href: "/tests/fileReport",
     },
     {
+      name: "viable/strict Tests",
+      href: "/viablestrict",
+    },
+    {
       name: "CUDA Trunk test stats",
       href: "/cuda_test_stats",
     },

--- a/torchci/pages/viablestrict/[sha].tsx
+++ b/torchci/pages/viablestrict/[sha].tsx
@@ -1,0 +1,455 @@
+import { Box, Chip, Stack, Tooltip, Typography } from "@mui/material";
+import { BarChart } from "@mui/x-charts";
+import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import LoadingPage from "components/common/LoadingPage";
+import { TextFieldSubmit } from "components/common/TextFieldSubmit";
+import { durationDisplay } from "components/common/TimeUtils";
+import { encodeParams, fetcher } from "lib/GeneralUtils";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useMemo, useState } from "react";
+import useSWR from "swr";
+import useSWRImmutable from "swr/immutable";
+
+const WORKFLOWS = ["pull", "trunk", "lint"];
+const DEFAULT_STATES = ["failed", "skipped"];
+
+// Static per-test duration buckets (seconds), matching the summary query.
+const BUCKET_LABELS = [
+  "<0.1s",
+  "0.1-0.25s",
+  "0.25-0.5s",
+  "0.5-1s",
+  "1-2s",
+  "2-3s",
+  "3-5s",
+  "5-10s",
+  "10-20s",
+  "20-30s",
+  "30-60s",
+  "1-2m",
+  "2-5m",
+  "5m+",
+];
+
+const CONCLUSION_COLOR: Record<string, string> = {
+  success: "#59a14f",
+  failed: "#e15759",
+  flaky: "#f28e2c",
+  skipped: "#e6c200",
+};
+
+interface TestRow {
+  invoking_file: string;
+  file: string;
+  classname: string;
+  name: string;
+  runs: number;
+  time: number;
+  median_time: number;
+  p90_time: number;
+  failures: number;
+  errors: number;
+  skipped: number;
+  reruns: number;
+  jobs: string[];
+  failed_jobs: string[];
+  details: string;
+  conclusion: "success" | "failed" | "flaky" | "skipped";
+  total_count: number;
+}
+
+// Show the full GitHub job name(s) the test ran in: the failing job(s) when
+// present, else all of them. First inline, "(+N)" with a tooltip listing the rest.
+function JobsCell({ row }: { row: TestRow }) {
+  const list = row.failed_jobs?.length ? row.failed_jobs : row.jobs ?? [];
+  if (list.length === 0) return <></>;
+  const [first, ...rest] = list;
+  return (
+    <Tooltip title={list.join("\n")}>
+      <span>
+        {first}
+        {rest.length > 0 ? ` (+${rest.length})` : ""}
+      </span>
+    </Tooltip>
+  );
+}
+
+interface SummaryRow {
+  conclusion: string;
+  bucket: number;
+  cnt: number;
+  executions: number;
+}
+
+interface BuildRow {
+  workflow: string;
+  build: string;
+  tests: number;
+}
+
+// How many build bars to show in the horizontal distribution.
+const TOP_BUILDS = 20;
+
+// Idiomatic pytest node id: "test/<path>.py::<Class>::<test_case>".
+// The invoking file is stored as a dotted module (e.g.
+// "inductor.test_aot_inductor_arrayref") -- the same convention test_times
+// reconstructs paths from -- so dots map to slashes, with a test/ prefix + .py.
+// classname may be module-qualified; keep only the final class segment. Tests
+// with no class render as "test/<path>.py::<test_case>".
+function testNodeId(row: TestRow): string {
+  const base = (row.invoking_file || "")
+    .replace(/\.py$/, "")
+    .replaceAll(".", "/");
+  const path = base ? `test/${base}.py` : row.file || "";
+  const cls = (row.classname || "").split(".").pop() || "";
+  return cls ? `${path}::${cls}::${row.name}` : `${path}::${row.name}`;
+}
+
+// The useful line of a traceback is usually the last non-empty one.
+function detailsExcerpt(text: string): string {
+  if (!text) return "";
+  const lines = text
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  return lines.length ? lines[lines.length - 1] : "";
+}
+
+function ConclusionChip({ conclusion }: { conclusion: string }) {
+  return (
+    <Chip
+      label={conclusion}
+      size="small"
+      sx={{
+        backgroundColor: CONCLUSION_COLOR[conclusion] ?? "grey",
+        color: "white",
+      }}
+    />
+  );
+}
+
+// Clickable count chip used as the state filter.
+function FilterChip({
+  label,
+  count,
+  color,
+  active,
+  onClick,
+}: {
+  label: string;
+  count: number;
+  color: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Chip
+      label={`${count} ${label}`}
+      onClick={onClick}
+      variant={active ? "filled" : "outlined"}
+      sx={{
+        backgroundColor: active ? color : "transparent",
+        color: active ? "white" : "text.primary",
+        borderColor: color,
+        fontWeight: active ? 700 : 400,
+        cursor: "pointer",
+      }}
+    />
+  );
+}
+
+export default function Page() {
+  const router = useRouter();
+  const sha = router.query.sha as string;
+
+  const [states, setStates] = useState<string[]>(DEFAULT_STATES);
+  const [nameFilter, setNameFilter] = useState("");
+  const [paginationModel, setPaginationModel] = useState({
+    page: 0,
+    pageSize: 100,
+  });
+
+  // Summary (chips + histogram): fetched once per commit, independent of filters.
+  const summaryUrl = sha
+    ? `/api/clickhouse/viablestrict_run_summary?parameters=${encodeURIComponent(
+        JSON.stringify({ sha, workflows: WORKFLOWS })
+      )}`
+    : null;
+  const { data: summary } = useSWRImmutable<SummaryRow[]>(summaryUrl, fetcher);
+
+  // Tests-per-build distribution (also once per commit).
+  const buildsUrl = sha
+    ? `/api/clickhouse/viablestrict_run_workflows?parameters=${encodeURIComponent(
+        JSON.stringify({ sha, workflows: WORKFLOWS })
+      )}`
+    : null;
+  const { data: builds } = useSWRImmutable<BuildRow[]>(buildsUrl, fetcher);
+
+  // Paginated, filtered table.
+  const tableUrl = sha
+    ? `/api/clickhouse/viablestrict_run_tests?parameters=${encodeURIComponent(
+        JSON.stringify({
+          sha,
+          workflows: WORKFLOWS,
+          states,
+          sort: "duration",
+          name_filter: nameFilter ? `%${nameFilter}%` : "%",
+          limit: paginationModel.pageSize,
+          offset: paginationModel.page * paginationModel.pageSize,
+        })
+      )}`
+    : null;
+  const { data, isLoading } = useSWR<TestRow[]>(tableUrl, fetcher, {
+    keepPreviousData: true,
+  });
+
+  const rows = data ?? [];
+  const rowCount = rows[0]?.total_count ?? 0;
+
+  // Derive chip totals, histogram, and execution totals from the summary.
+  const { counts, histogram, executions } = useMemo(() => {
+    const counts: Record<string, number> = {
+      success: 0,
+      failed: 0,
+      skipped: 0,
+      flaky: 0,
+    };
+    const histogram = new Array(BUCKET_LABELS.length).fill(0);
+    let executions = 0;
+    for (const r of summary ?? []) {
+      counts[r.conclusion] = (counts[r.conclusion] ?? 0) + r.cnt;
+      executions += r.executions ?? 0;
+      if (r.bucket >= 0 && r.bucket < histogram.length) {
+        histogram[r.bucket] += r.cnt;
+      }
+    }
+    return { counts, histogram, executions };
+  }, [summary]);
+
+  const distinctTests =
+    counts.success + counts.failed + counts.skipped + counts.flaky;
+
+  // Top-N builds for the horizontal distribution chart (already sorted desc).
+  const buildBars = (builds ?? []).slice(0, TOP_BUILDS);
+  const buildLabels = buildBars.map((b) => `${b.workflow} / ${b.build}`);
+  const buildValues = buildBars.map((b) => b.tests);
+
+  // Clicking a chip drills into that single state; clicking the active sole
+  // state resets to the default (failed + skipped).
+  function pickState(s: string) {
+    setStates((prev) =>
+      prev.length === 1 && prev[0] === s ? DEFAULT_STATES : [s]
+    );
+    setPaginationModel((m) => ({ ...m, page: 0 }));
+  }
+
+  const columns: GridColDef[] = [
+    {
+      field: "conclusion",
+      headerName: "Status",
+      width: 90,
+      sortable: false,
+      renderCell: (params) => <ConclusionChip conclusion={params.value} />,
+    },
+    {
+      field: "name",
+      headerName: "Test",
+      flex: 3,
+      sortable: false,
+      renderCell: (params) => {
+        const row = params.row as TestRow;
+        const id = testNodeId(row);
+        const href = `/tests/testInfo?${encodeParams({
+          name: row.name,
+          suite: row.classname,
+          file: row.file,
+        })}`;
+        return (
+          <Tooltip title={id}>
+            <Link href={href}>{id}</Link>
+          </Tooltip>
+        );
+      },
+    },
+    {
+      field: "jobs",
+      headerName: "Workflow / Job",
+      flex: 2,
+      sortable: false,
+      renderCell: (params) => <JobsCell row={params.row as TestRow} />,
+    },
+    {
+      field: "runs",
+      headerName: "Runs",
+      width: 80,
+      type: "number",
+      sortable: false,
+      description:
+        "Number of config/platform jobs the test ran in (shards and re-run attempts collapsed)",
+    },
+    {
+      field: "time",
+      headerName: "Total dur",
+      description: "Total time across all of this test's config runs",
+      width: 100,
+      type: "number",
+      sortable: false,
+      valueFormatter: (value: number) => durationDisplay(value),
+    },
+    {
+      field: "median_time",
+      headerName: "Median",
+      description: "Median duration of a single run of this test",
+      width: 90,
+      type: "number",
+      sortable: false,
+      valueFormatter: (value: number) => durationDisplay(value),
+    },
+    {
+      field: "p90_time",
+      headerName: "P90",
+      description: "90th-percentile duration of a single run of this test",
+      width: 90,
+      type: "number",
+      sortable: false,
+      valueFormatter: (value: number) => durationDisplay(value),
+    },
+    {
+      field: "details",
+      headerName: "Details",
+      flex: 3,
+      sortable: false,
+      renderCell: (params) => {
+        const text = (params.value as string) ?? "";
+        if (!text) return <></>;
+        return (
+          <Tooltip title={<pre style={{ whiteSpace: "pre-wrap" }}>{text}</pre>}>
+            <span>{detailsExcerpt(text)}</span>
+          </Tooltip>
+        );
+      },
+    },
+    {
+      field: "reruns",
+      headerName: "Retries",
+      width: 80,
+      type: "number",
+      sortable: false,
+    },
+  ];
+
+  if (!router.isReady) {
+    return <LoadingPage />;
+  }
+
+  return (
+    <Stack spacing={2} sx={{ p: 2 }}>
+      <Typography variant="h4">
+        viable/strict test run{" "}
+        <Link href={`/hud/pytorch/pytorch/${sha}`}>{sha?.slice(0, 7)}</Link>
+      </Typography>
+
+      <Typography variant="subtitle2" color="text.secondary">
+        Total Test Time Distribution (summed across all configs)
+      </Typography>
+      <Box sx={{ width: "100%" }}>
+        <BarChart
+          height={220}
+          xAxis={[{ data: BUCKET_LABELS, scaleType: "band" }]}
+          series={[{ data: histogram, label: "tests", color: "#59a14f" }]}
+        />
+      </Box>
+
+      <Typography variant="subtitle2" color="text.secondary">
+        Test coverage by build, top {buildBars.length}
+        {(builds?.length ?? 0) > buildBars.length
+          ? ` of ${builds?.length}`
+          : ""}{" "}
+        (workflow / build)
+      </Typography>
+      <Box sx={{ width: "100%" }}>
+        <BarChart
+          layout="horizontal"
+          height={Math.max(160, buildBars.length * 26 + 60)}
+          yAxis={[{ scaleType: "band", data: buildLabels, width: 320 }]}
+          series={[{ data: buildValues, label: "tests", color: "#4e79a7" }]}
+          barLabel="value"
+        />
+      </Box>
+
+      <Typography variant="subtitle2" color="text.secondary">
+        Distinct Test Status — {distinctTests.toLocaleString()} unique tests
+        (one per name/suite/file), de-duplicated across configs, from{" "}
+        {executions.toLocaleString()} executions across configs.
+      </Typography>
+      <Box
+        sx={{ display: "flex", gap: 1, flexWrap: "wrap", alignItems: "center" }}
+      >
+        <FilterChip
+          label="passed"
+          count={counts.success}
+          color={CONCLUSION_COLOR.success}
+          active={states.length === 1 && states[0] === "success"}
+          onClick={() => pickState("success")}
+        />
+        <FilterChip
+          label="failed"
+          count={counts.failed}
+          color={CONCLUSION_COLOR.failed}
+          active={states.includes("failed")}
+          onClick={() => pickState("failed")}
+        />
+        <FilterChip
+          label="skipped"
+          count={counts.skipped}
+          color={CONCLUSION_COLOR.skipped}
+          active={states.includes("skipped")}
+          onClick={() => pickState("skipped")}
+        />
+        <FilterChip
+          label="flaky"
+          count={counts.flaky}
+          color={CONCLUSION_COLOR.flaky}
+          active={states.length === 1 && states[0] === "flaky"}
+          onClick={() => pickState("flaky")}
+        />
+        <Box sx={{ flexGrow: 1 }} />
+        <TextFieldSubmit
+          textFieldValue={nameFilter}
+          onSubmit={(v) => {
+            setNameFilter(v);
+            setPaginationModel((m) => ({ ...m, page: 0 }));
+          }}
+          info={"Search for Test"}
+        />
+      </Box>
+
+      <Typography variant="body2" color="text.secondary">
+        Showing {rowCount} tests (states: {states.join(", ")}). Default view is
+        failed + skipped; click a chip to drill in.
+      </Typography>
+
+      <div style={{ height: "65vh", width: "100%" }}>
+        {isLoading && rows.length === 0 ? (
+          <LoadingPage />
+        ) : (
+          <DataGrid
+            rows={rows}
+            columns={columns}
+            density="compact"
+            getRowId={(row) =>
+              `${row.invoking_file}-${row.classname}-${row.name}`
+            }
+            paginationMode="server"
+            rowCount={rowCount}
+            paginationModel={paginationModel}
+            onPaginationModelChange={setPaginationModel}
+            pageSizeOptions={[50, 100, 250]}
+            loading={isLoading}
+          />
+        )}
+      </div>
+    </Stack>
+  );
+}

--- a/torchci/pages/viablestrict/index.tsx
+++ b/torchci/pages/viablestrict/index.tsx
@@ -1,0 +1,112 @@
+import { MenuItem, Select, Stack, Typography } from "@mui/material";
+import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import LoadingPage from "components/common/LoadingPage";
+import dayjs from "dayjs";
+import { fetcher } from "lib/GeneralUtils";
+import Link from "next/link";
+import { useState } from "react";
+import useSWR from "swr";
+
+const REPO = "pytorch/pytorch";
+
+interface ViableStrictRun {
+  sha: string;
+  message: string;
+  author: string;
+  timestamp: string;
+}
+
+export default function Page() {
+  const [days, setDays] = useState(7);
+
+  const url = `/api/clickhouse/viablestrict_runs?parameters=${encodeURIComponent(
+    JSON.stringify({ repo: REPO, days })
+  )}`;
+  const { data, isLoading } = useSWR<ViableStrictRun[]>(url, fetcher, {
+    refreshInterval: 5 * 60 * 1000, // 5 min
+  });
+
+  const columns: GridColDef[] = [
+    {
+      field: "sha",
+      headerName: "Commit",
+      flex: 1,
+      renderCell: (params) => (
+        <Link href={`/viablestrict/${params.value}`}>
+          {(params.value as string).slice(0, 7)}
+        </Link>
+      ),
+    },
+    {
+      field: "message",
+      headerName: "Title",
+      flex: 4,
+      // Commit messages can be multi-line; show only the first line.
+      valueGetter: (value: string) => (value ?? "").split("\n")[0],
+    },
+    { field: "author", headerName: "Author", flex: 1 },
+    {
+      field: "timestamp",
+      headerName: "Commit time (UTC)",
+      flex: 1.5,
+      valueGetter: (value: string) =>
+        value ? dayjs(value).format("YYYY-MM-DD HH:mm") : "",
+    },
+    {
+      field: "hud",
+      headerName: "HUD",
+      flex: 0.5,
+      sortable: false,
+      renderCell: (params) => (
+        <Link href={`/hud/pytorch/pytorch/${params.row.sha}`}>view</Link>
+      ),
+    },
+  ];
+
+  return (
+    <Stack spacing={2} sx={{ p: 2 }}>
+      <Typography variant="h4">viable/strict commits</Typography>
+      <Typography variant="body2" color="text.secondary">
+        Each commit the <code>viable/strict</code> branch was advanced to. Click
+        a commit to explore all of its tests (pass/fail/skip, duration, retries)
+        sorted and filterable.
+      </Typography>
+
+      <Stack direction="row" spacing={2} alignItems="center">
+        <span>Window:</span>
+        <Select
+          size="small"
+          value={days}
+          onChange={(e) => setDays(Number(e.target.value))}
+        >
+          <MenuItem value={1}>1 day</MenuItem>
+          <MenuItem value={3}>3 days</MenuItem>
+          <MenuItem value={7}>7 days</MenuItem>
+          <MenuItem value={14}>14 days</MenuItem>
+          <MenuItem value={30}>30 days</MenuItem>
+        </Select>
+        <Typography variant="body2" color="text.secondary">
+          {data?.length ?? 0} commits
+        </Typography>
+      </Stack>
+
+      <div style={{ height: "80vh", width: "100%" }}>
+        {isLoading ? (
+          <LoadingPage />
+        ) : (
+          <DataGrid
+            rows={data ?? []}
+            columns={columns}
+            density="compact"
+            getRowId={(row) => row.sha}
+            initialState={{
+              sorting: { sortModel: [{ field: "timestamp", sort: "desc" }] },
+              pagination: { paginationModel: { pageSize: 50 } },
+            }}
+            pageSizeOptions={[25, 50, 100]}
+          />
+        )}
+      </div>
+    </Stack>
+  );
+}


### PR DESCRIPTION
(DRAFT-only, query would need to be optimized and hoping to get feedback on usefulness of the chart)

**High Level Goal:**
Introduce an overview page of tests run in viable/strict CI, surfacing distribution of total test times and across workflows. This aims to facilitate tracking of test times and quality throughout the repo.

Some preliminary feedback:
- maybe make viable/strict toggle-able to also monitor all tests
- SQL query needs to be optimized and additional support for pagination could help. This page currently takes a significant amount of time to load.

**Per-commit page:**
- Test time distribution histogram (total time summed across all configs)
- Test coverage by build (workflow / build breakdown)
- Filterable, paginated test table with pass/fail/flaky/skipped classification, duration stats (total, median, P90), failure details, and retry counts

**Classification logic** mirrors GitHub's final state:
- **failed** — test failed with no recovery AND the job ended red
- **flaky** — test failed somewhere but recovered (retry, new process, or job re-run)
- **skipped** — every config skipped
- **success** — everything else

All test queries use `tests.all_test_runs` as the source of truth, with `time_inserted` partition pruning for performance.

