### PR TITLE
[CRCR]  Use {run_id}:{run_attempt} instead of {check_run_id} in state machine key composition

### DIFF
--- a/aws/lambda/cross_repo_ci_relay/README.md
+++ b/aws/lambda/cross_repo_ci_relay/README.md
@@ -44,13 +44,13 @@ The callback endpoint validates incoming callbacks and forwards them to HUD for 
 - **Identity**: the `Authorization: Bearer <oidc-token>` header is verified against GitHub's JWKS.  The OIDC `repository` claim is a trusted identity for the caller and is used for the L2+ allowlist check. Relay forwards this trusted value to HUD as a top-level `verified_repo` field; HUD should prefer it over anything self-reported in `callback_payload`.
 - **Repo level**: Relay determines the downstream repository's allowlist level (L1–L4) and forwards it to HUD as `downstream_repo_level`. This authoritative level information is determined once by the relay, ensuring HUD doesn't need to recompute it and avoiding synchronization/timing issues if tiering information becomes dynamic.
 - **Schema validation**: Relay validates that required fields (`delivery_id` and `workflow.status`) are present in the callback body.  Missing fields result in a `400` error to signal contract violations to the caller.  HUD receives validated data and does not need to perform schema checks.
-- **State machine**: Relay maintains a **unified state machine** in Redis to validate callback lifecycles, compute timing metrics, and support per-job tracking:
-  - **Unified structure**: Single enum `CallbackState` with states `DISPATCHED` (webhook side, keyed by sentinel `check_run_id="dispatched"`), `IN_PROGRESS`, and `COMPLETED` (callback side, per-job). State records stored as JSON: `{"state": "...", "timestamp": 1234.56, "job_name": "...", "run_id": "..."}`.
+- **State machine**: Relay maintains a **unified state machine** in Redis to validate callback lifecycles, compute timing metrics, and support per-workflow tracking:
+  - **Unified structure**: Single enum `CallbackState` with states `DISPATCHED` (webhook side, keyed by sentinel `run_id=0, run_attempt=0`), `IN_PROGRESS`, and `COMPLETED` (callback side, per-workflow). State records stored as JSON: `{"state": "...", "timestamp": 1234.56}`.
   - **Dispatch validation**: `DISPATCHED` state proves valid webhook origin. Callbacks without this state are rejected (no prior dispatch).
-  - **Job-level tracking**: Each job has independent state and timestamps keyed by `check_run_id` (`oot:state:{delivery_id}:{repo}:{check_run_id}`). Supports multiple jobs per webhook.
+  - **Workflow-level tracking**: Each workflow has independent state and timestamps keyed by `{run_id}:{run_attempt}` (`oot:state:{delivery_id}:{repo}:{run_id}:{run_attempt}`). Supports multiple workflows per webhook.
   - **Timing metrics**: `queue_time = dispatch_timestamp → in_progress_timestamp`, `execution_time = in_progress_timestamp → completed_timestamp`. Timestamps extracted from state records.
-  - **State transitions**: Rejects invalid flows (`COMPLETED` without prior `IN_PROGRESS`, duplicate `IN_PROGRESS` for the same `check_run_id`, duplicate `COMPLETED`, callbacks without a prior `DISPATCHED` record).
-    Note that the direction graph below is for a single check run, reruns have different `check_run_id` and are treated as separate jobs, so they won't violate the state machine since they won't have a prior `IN_PROGRESS` or `COMPLETED` record.
+  - **State transitions**: Rejects invalid flows (`COMPLETED` without prior `IN_PROGRESS`, duplicate `IN_PROGRESS` for the same `{run_id}:{run_attempt}`, duplicate `COMPLETED`, callbacks without a prior `DISPATCHED` record).
+    Note that the direction graph below is for a single check run, reruns have different `run_attempt` and are treated as separate workflows, so they won't violate the state machine since they won't have a prior `IN_PROGRESS` or `COMPLETED` record.
     ```mermaid
     stateDiagram-v2
         direction LR

--- a/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
@@ -11,7 +11,8 @@ from utils.hud import forward_to_hud
 from utils.misc import (
     CallbackState,
     CallbackStateRecord,
-    DISPATCH_CHECK_RUN_ID,
+    DISPATCH_RUN_ATTEMPT,
+    DISPATCH_RUN_ID,
     HTTPException,
 )
 from utils.redis_helper import check_rate_limit
@@ -59,11 +60,11 @@ def _verify_access(
     return allowlist, repo_level
 
 
-def _parse_callback_body(body: dict) -> tuple[str, str, str, str, str]:
-    """Return (delivery_id, status, check_run_id, job_name, run_id) from ``body``.
+def _parse_callback_body(body: dict) -> tuple[str, str, int, int, str]:
+    """Return (delivery_id, status, run_id, run_attempt, workflow_name) from ``body``.
 
-    check_run_id is set by GitHub Actions (job.check_run_id context) and
-    cannot be tampered with, ensuring replay-attack detection integrity.
+    run_id and run_attempt uniquely identify a workflow run execution.
+    run_attempt defaults to 1 when not present in the callback body.
 
     Raises HTTPException(400) on any missing or mis-typed field.
     """
@@ -71,29 +72,29 @@ def _parse_callback_body(body: dict) -> tuple[str, str, str, str, str]:
         delivery_id = body["delivery_id"]
         workflow_dict = body["workflow"]
         status = workflow_dict["status"]
-        check_run_id = workflow_dict["check_run_id"]  # Required
-        job_name = workflow_dict["job_name"]  # Required for HUD grouping
         run_id = workflow_dict["run_id"]  # Required for HUD grouping
+        run_attempt = workflow_dict.get("run_attempt", 1)  # Default to 1 if not present
+        workflow_name = workflow_dict["name"]  # Required for HUD grouping
     except (KeyError, TypeError) as exc:
         logger.warning(f"missing required field in callback body: {exc}")
         raise HTTPException(
             400, f"callback body missing required field: {exc}"
         ) from exc
-    return delivery_id, status, check_run_id, job_name, run_id
+    return delivery_id, status, run_id, run_attempt, workflow_name
 
 
 def _update_state_and_compute_metrics(
     config: RelayConfig,
     delivery_id: str,
     verified_repo: str,
-    check_run_id: str,
-    job_name: str,
-    run_id: str,
+    run_id: int,
+    run_attempt: int,
+    workflow_name: str,
     status: str,
     dispatch_record: CallbackStateRecord,
-    job_record: CallbackStateRecord | None,
+    workflow_record: CallbackStateRecord | None,
 ) -> dict:
-    """Persist the new job state to Redis and return CI timing metrics.
+    """Persist the new workflow state to Redis and return CI timing metrics.
 
     Writes IN_PROGRESS or COMPLETED state (with the current timestamp), then
     reads back the stored record to compute:
@@ -119,11 +120,11 @@ def _update_state_and_compute_metrics(
             config,
             delivery_id,
             verified_repo,
-            check_run_id,
+            run_id,
+            run_attempt,
             state,
             current_timestamp,
-            job_name,
-            run_id,
+            workflow_name,
         )
     except RedisError:
         raise HTTPException(
@@ -138,22 +139,24 @@ def _update_state_and_compute_metrics(
     except Exception:
         raise
 
-    updated_job_record = redis_helper.get_callback_state(
-        config, delivery_id, verified_repo, check_run_id
+    updated_workflow_record = redis_helper.get_callback_state(
+        config, delivery_id, verified_repo, run_id, run_attempt
     )
-    if updated_job_record is None:
+    if updated_workflow_record is None:
         return ci_metrics
 
     if state == CallbackState.IN_PROGRESS:
         ci_metrics["queue_time"] = _safe_delta(
             dispatch_record.timestamp,
-            updated_job_record.timestamp,
+            updated_workflow_record.timestamp,
             "queue_time",
         )
     else:
-        if job_record is not None:
+        if workflow_record is not None:
             ci_metrics["execution_time"] = _safe_delta(
-                job_record.timestamp, updated_job_record.timestamp, "execution_time"
+                workflow_record.timestamp,
+                updated_workflow_record.timestamp,
+                "execution_time",
             )
 
     return ci_metrics
@@ -181,10 +184,10 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
         return {"ok": True, "status": "ignored"}
     _, repo_level = result
 
-    delivery_id, status, check_run_id, job_name, run_id = _parse_callback_body(body)
+    delivery_id, status, run_id, run_attempt, workflow_name = _parse_callback_body(body)
 
     dispatch_record = redis_helper.get_callback_state(
-        config, delivery_id, verified_repo, DISPATCH_CHECK_RUN_ID
+        config, delivery_id, verified_repo, DISPATCH_RUN_ID, DISPATCH_RUN_ATTEMPT
     )
     if not dispatch_record:
         logger.warning(
@@ -194,20 +197,20 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
         )
         raise HTTPException(400, "callback rejected: no matching dispatch record")
 
-    job_record = redis_helper.get_callback_state(
-        config, delivery_id, verified_repo, check_run_id
+    workflow_record = redis_helper.get_callback_state(
+        config, delivery_id, verified_repo, run_id, run_attempt
     )
 
     ci_metrics = _update_state_and_compute_metrics(
         config,
         delivery_id,
         verified_repo,
-        check_run_id,
-        job_name,
         run_id,
+        run_attempt,
+        workflow_name,
         status,
         dispatch_record,
-        job_record,
+        workflow_record,
     )
 
     trusted = {

--- a/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from callback.callback_handler import handle
 from utils.allowlist import AllowlistLevel
-from utils.misc import CallbackState, DISPATCH_CHECK_RUN_ID, HTTPException
+from utils.misc import CallbackState, DISPATCH_RUN_ID, HTTPException
 from utils.redis_helper import CallbackStateRecord
 
 
@@ -19,7 +19,7 @@ def _cfg():
     return cfg
 
 
-def _body(status="completed", job_name="default", check_run_id="12345", run_id="99999"):
+def _body(status="completed", workflow_name="default", run_id=99999, run_attempt=1):
     return {
         "event_type": "pull_request",
         "delivery_id": "del-123",
@@ -32,9 +32,9 @@ def _body(status="completed", job_name="default", check_run_id="12345", run_id="
             "conclusion": "success" if status == "completed" else None,
             "name": "CI",
             "url": "http://ci.example.com/run/1",
-            "job_name": job_name,
-            "check_run_id": check_run_id,
+            "workflow_name": workflow_name,
             "run_id": run_id,
+            "run_attempt": run_attempt,
         },
     }
 
@@ -52,15 +52,19 @@ class TestCallbackHandler(unittest.TestCase):
         self.mock_redis = self.patcher_redis.start()
         self.mock_redis.create_client.return_value = MagicMock()
 
-        # Setup default: dispatch exists, job state is None (in_progress not yet reported)
-        def default_get_state(cfg, delivery_id, repo, check_run_id_arg, client=None):
-            if check_run_id_arg == DISPATCH_CHECK_RUN_ID:
+        # Setup default: dispatch exists, workflow state is None (in_progress not yet reported)
+        def default_get_state(
+            cfg, delivery_id, repo, run_id_arg, run_attempt_arg, client=None
+        ):
+            if run_id_arg == DISPATCH_RUN_ID:
                 return CallbackStateRecord(
-                    CallbackState.DISPATCHED, time.time() - 30, "dispatch-job", 11111
+                    CallbackState.DISPATCHED,
+                    time.time() - 30,
                 )
-            elif check_run_id_arg == "12345":  # default check_run_id in _body()
+            elif run_id_arg == 99999:  # default run_id in _body()
                 return CallbackStateRecord(
-                    CallbackState.IN_PROGRESS, time.time() - 20, "default", 99999
+                    CallbackState.IN_PROGRESS,
+                    time.time() - 20,
                 )
             return None
 
@@ -110,15 +114,17 @@ class TestCallbackHandler(unittest.TestCase):
     def test_queue_time_calculated_from_state_records(self):
         """queue_time is the dispatch-to-in_progress delta."""
         dispatch_record = CallbackStateRecord(
-            CallbackState.DISPATCHED, 1000.0, "dispatch-job", 11111
+            CallbackState.DISPATCHED,
+            1000.0,
         )
-        job_record = CallbackStateRecord(
-            CallbackState.IN_PROGRESS, 1030.0, "default", 99999
+        workflow_record = CallbackStateRecord(
+            CallbackState.IN_PROGRESS,
+            1030.0,
         )
         self.mock_redis.get_callback_state.side_effect = [
             dispatch_record,  # dispatch lookup
-            None,  # job state: not yet set
-            job_record,  # re-read after set_callback_state
+            None,  # workflow state: not yet set
+            workflow_record,  # re-read after set_callback_state
         ]
 
         handle(_cfg(), _body(status="in_progress"), verified_repo="org/repo")
@@ -131,17 +137,20 @@ class TestCallbackHandler(unittest.TestCase):
     def test_execution_time_calculated_from_state_records(self):
         """execution_time is the in_progress-to-completed delta."""
         dispatch_record = CallbackStateRecord(
-            CallbackState.DISPATCHED, 1000.0, "dispatch-job", 11111
+            CallbackState.DISPATCHED,
+            1000.0,
         )
-        job_record = CallbackStateRecord(
-            CallbackState.IN_PROGRESS, 1030.0, "default", 99999
+        workflow_record = CallbackStateRecord(
+            CallbackState.IN_PROGRESS,
+            1030.0,
         )
         completed_record = CallbackStateRecord(
-            CallbackState.COMPLETED, 1060.0, "default", 99999
+            CallbackState.COMPLETED,
+            1060.0,
         )
         self.mock_redis.get_callback_state.side_effect = [
             dispatch_record,  # dispatch lookup
-            job_record,  # job state: in_progress
+            workflow_record,  # workflow state: in_progress
             completed_record,  # re-read after set_callback_state
         ]
 
@@ -199,16 +208,17 @@ class TestCallbackHandler(unittest.TestCase):
             handle(_cfg(), _body(status="completed"), verified_repo="org/repo")
         self.assertEqual(ctx.exception.status_code, 400)
 
-    def test_redis_error_fetching_job_record_proceeds(self):
-        """Redis error on job record lookup returns None; callback proceeds."""
+    def test_redis_error_fetching_workflow_record_proceeds(self):
+        """Redis error on workflow record lookup returns None; callback proceeds."""
         dispatch_record = CallbackStateRecord(
-            CallbackState.DISPATCHED, 1000.0, "dispatch-job", 11111
+            CallbackState.DISPATCHED,
+            1000.0,
         )
-        # Three calls: dispatch lookup, job record lookup, re-read after set.
+        # Three calls: dispatch lookup, workflow record lookup, re-read after set.
         self.mock_redis.get_callback_state.side_effect = [
             dispatch_record,
-            None,  # job record lookup returns None (get_callback_state catches RedisError)
-            None,  # updated_job_record re-read → early return with empty metrics
+            None,  # workflow record lookup returns None (get_callback_state catches RedisError)
+            None,  # updated_workflow_record re-read → early return with empty metrics
         ]
 
         handle(_cfg(), _body(status="completed"), verified_repo="org/repo")

--- a/aws/lambda/cross_repo_ci_relay/tests/test_redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_redis_helper.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import redis as redis_lib
 from utils import redis_helper
-from utils.misc import CallbackState, DISPATCH_CHECK_RUN_ID
+from utils.misc import CallbackState, DISPATCH_RUN_ATTEMPT, DISPATCH_RUN_ID
 from utils.redis_helper import (
     _ALLOWLIST_CACHE_KEY,
     CallbackStateRecord,
@@ -76,7 +76,8 @@ class TestCallbackStateMachine(unittest.TestCase):
             _cfg(),
             "del-123",
             "org/repo",
-            DISPATCH_CHECK_RUN_ID,
+            DISPATCH_RUN_ID,
+            DISPATCH_RUN_ATTEMPT,
             CallbackState.DISPATCHED,
             1000.0,
             client=client,
@@ -90,19 +91,15 @@ class TestCallbackStateMachine(unittest.TestCase):
             {
                 "state": "IN_PROGRESS",
                 "timestamp": 1010.5,
-                "job_name": "test-job",
-                "run_id": "12345",
             }
         )
         cfg = _cfg()
 
-        record = get_callback_state(cfg, "del-123", "org/repo", "test-job", client)
+        record = get_callback_state(cfg, "del-123", "org/repo", 12345, 1, client)
 
         self.assertIsNotNone(record)
         self.assertEqual(record.state, CallbackState.IN_PROGRESS)
         self.assertEqual(record.timestamp, 1010.5)
-        self.assertEqual(record.job_name, "test-job")
-        self.assertEqual(record.run_id, "12345")
 
     def test_get_callback_state_returns_none_on_missing_key_and_on_redis_error(self):
         """get_callback_state returns None on missing key and on Redis error."""
@@ -111,24 +108,29 @@ class TestCallbackStateMachine(unittest.TestCase):
 
         client.get.return_value = None
         self.assertIsNone(
-            get_callback_state(cfg, "del-123", "org/repo", "test-job", client)
+            get_callback_state(cfg, "del-123", "org/repo", 12345, 1, client)
         )
 
         client.get.side_effect = redis_lib.exceptions.RedisError("boom")
         self.assertIsNone(
-            get_callback_state(cfg, "del-123", "org/repo", "test-job", client)
+            get_callback_state(cfg, "del-123", "org/repo", 12345, 1, client)
         )
 
     def test_invalid_state_transitions_rejected(self):
         """Duplicate or invalid state transitions are all rejected."""
         cases = [
-            # (check_run_id, new_state, existing_state_value_or_None)
-            (DISPATCH_CHECK_RUN_ID, CallbackState.DISPATCHED, "DISPATCHED"),
-            ("check-run", CallbackState.IN_PROGRESS, "IN_PROGRESS"),
-            ("check-run", CallbackState.COMPLETED, None),  # None → COMPLETED
-            ("check-run", CallbackState.COMPLETED, "COMPLETED"),
+            # (run_id, run_attempt, new_state, existing_state_value_or_None)
+            (
+                DISPATCH_RUN_ID,
+                DISPATCH_RUN_ATTEMPT,
+                CallbackState.DISPATCHED,
+                "DISPATCHED",
+            ),
+            (12345, 1, CallbackState.IN_PROGRESS, "IN_PROGRESS"),
+            (12345, 1, CallbackState.COMPLETED, None),  # None → COMPLETED
+            (12345, 1, CallbackState.COMPLETED, "COMPLETED"),
         ]
-        for check_run_id, state, existing in cases:
+        for run_id, run_attempt, state, existing in cases:
             with self.subTest(state=state, existing=existing):
                 client = MagicMock()
                 client.get.return_value = (
@@ -136,8 +138,6 @@ class TestCallbackStateMachine(unittest.TestCase):
                         {
                             "state": existing,
                             "timestamp": 1000.0,
-                            "job_name": "job",
-                            "run_id": "111",
                         }
                     )
                     if existing
@@ -148,7 +148,8 @@ class TestCallbackStateMachine(unittest.TestCase):
                         _cfg(),
                         "del-123",
                         "org/repo",
-                        check_run_id,
+                        run_id,
+                        run_attempt,
                         state,
                         1100.0,
                         client=client,
@@ -162,30 +163,28 @@ class TestCallbackStateMachine(unittest.TestCase):
             {
                 "state": "IN_PROGRESS",
                 "timestamp": 1010.0,
-                "job_name": "test-job",
-                "run_id": "12345",
             }
         )
         set_callback_state(
             _cfg(),
             "del-123",
             "org/repo",
-            "test-job",
+            12345,
+            1,
             CallbackState.COMPLETED,
             1020.0,
-            job_name="test-job",
-            run_id="12345",
+            workflow_name="test-workflow",
             client=client,
         )
 
     def test_set_in_progress_accepts_first_callback(self):
         """None → IN_PROGRESS is accepted when dispatch record exists."""
 
-        def get_side_effect(cfg, delivery_id, repo, check_run_id_arg, client=None):
-            if check_run_id_arg == DISPATCH_CHECK_RUN_ID:
-                return CallbackStateRecord(
-                    CallbackState.DISPATCHED, 1000.0, "dispatch-job", 11111
-                )
+        def get_side_effect(
+            cfg, delivery_id, repo, run_id_arg, run_attempt_arg, client=None
+        ):
+            if run_id_arg == DISPATCH_RUN_ID:
+                return CallbackStateRecord(CallbackState.DISPATCHED, 1000.0)
             return None
 
         client = MagicMock()
@@ -196,16 +195,16 @@ class TestCallbackStateMachine(unittest.TestCase):
                 _cfg(),
                 "del-123",
                 "org/repo",
-                "check-run-456",
+                99999,
+                1,
                 CallbackState.IN_PROGRESS,
                 1010.0,
-                job_name="test-job",
-                run_id="99999",
+                workflow_name="test-workflow",
                 client=client,
             )
 
-    def test_set_non_dispatched_state_with_reserved_check_run_id_rejected(self):
-        """Using the reserved DISPATCH_CHECK_RUN_ID for non-DISPATCHED state is rejected."""
+    def test_set_non_dispatched_state_with_reserved_run_id_rejected(self):
+        """Using the reserved DISPATCH_RUN_ID for non-DISPATCHED state is rejected."""
         client = MagicMock()
         cfg = _cfg()
 
@@ -217,7 +216,8 @@ class TestCallbackStateMachine(unittest.TestCase):
                         cfg,
                         "del-123",
                         "org/repo",
-                        DISPATCH_CHECK_RUN_ID,
+                        DISPATCH_RUN_ID,
+                        DISPATCH_RUN_ATTEMPT,
                         state,
                         1010.0,
                         client=client,
@@ -227,11 +227,11 @@ class TestCallbackStateMachine(unittest.TestCase):
     def test_set_callback_state_redis_exception_raises(self):
         """Redis write failure is re-raised as RedisError."""
 
-        def get_side_effect(cfg, delivery_id, repo, check_run_id_arg, client=None):
-            if check_run_id_arg == DISPATCH_CHECK_RUN_ID:
-                return CallbackStateRecord(
-                    CallbackState.DISPATCHED, 1000.0, "dispatch-job", "11111"
-                )
+        def get_side_effect(
+            cfg, delivery_id, repo, run_id_arg, run_attempt_arg, client=None
+        ):
+            if run_id_arg == DISPATCH_RUN_ID:
+                return CallbackStateRecord(CallbackState.DISPATCHED, 1000.0)
             return None
 
         cfg = _cfg()
@@ -245,11 +245,11 @@ class TestCallbackStateMachine(unittest.TestCase):
                 cfg,
                 "del-123",
                 "org/repo",
-                "check-run-456",
+                99999,
+                1,
                 CallbackState.IN_PROGRESS,
                 1010.0,
-                job_name="test-job",
-                run_id="99999",
+                workflow_name="test-workflow",
                 client=client,
             )
 

--- a/aws/lambda/cross_repo_ci_relay/utils/config.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/config.py
@@ -122,7 +122,7 @@ class RelayConfig:
         # avoidable rate-limit risk in production.
         allowlist_ttl_seconds = max(allowlist_ttl_seconds, 900)
 
-        # GitHub can keep a workflow job in `pending` state for up to 3 days before
+        # GitHub can keep a workflow in `pending` state for up to 3 days before
         # auto-cancelling it, so OOT-status records must live at least that long.
         # Default to 3 days (259200 s).
         try:

--- a/aws/lambda/cross_repo_ci_relay/utils/misc.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/misc.py
@@ -27,19 +27,20 @@ class EventDispatchPayload(TypedDict):
     payload: dict
 
 
-# Specific check_run_id used to identify callbacks
-# from dispatches that didn't specify a real check_run_id.
-# Here we set as a string for better readability,
-# but it could be any unique identifier.
-DISPATCH_CHECK_RUN_ID = "dispatched"
+# Sentinels for dispatch records in the state machine.
+# DISPATCH_RUN_ID = 0 is used as the run_id for dispatch records
+# (real GitHub Actions run_ids are positive integers).
+# DISPATCH_RUN_ATTEMPT = 0 is used as the run_attempt for dispatch records.
+DISPATCH_RUN_ID = 0
+DISPATCH_RUN_ATTEMPT = 0
 
 
 class CallbackState(str, Enum):
     """Unified state machine for callback lifecycle (both webhook and callback sides).
 
-    - ``DISPATCHED``: webhook side, when repository_dispatch is sent (job_name=DISPATCH_JOB_NAME).
-    - ``IN_PROGRESS``: callback side, when downstream workflow reports started (per-job).
-    - ``COMPLETED``: callback side, when downstream workflow reports finished (per-job).
+    - ``DISPATCHED``: webhook side, when repository_dispatch is sent (run_id=DISPATCH_CHECK_RUN_ID).
+    - ``IN_PROGRESS``: callback side, when downstream workflow reports started (per-workflow).
+    - ``COMPLETED``: callback side, when downstream workflow reports finished (per-workflow).
     """
 
     DISPATCHED = "DISPATCHED"
@@ -49,12 +50,10 @@ class CallbackState(str, Enum):
 
 @dataclass
 class CallbackStateRecord:
-    """Record containing state, timestamp, and job metadata for HUD grouping."""
+    """Record containing state, timestamp."""
 
     state: CallbackState
     timestamp: float
-    job_name: str
-    run_id: str
 
 
 def parse_lambda_event(event: dict) -> tuple[str, str, bytes, dict]:

--- a/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
@@ -9,12 +9,7 @@ import redis as redis_lib
 from redis.exceptions import RedisError
 
 from .config import RelayConfig
-from .misc import (
-    CallbackState,
-    CallbackStateRecord,
-    DISPATCH_CHECK_RUN_ID,
-    HTTPException,
-)
+from .misc import CallbackState, CallbackStateRecord, DISPATCH_RUN_ID, HTTPException
 
 
 logger = logging.getLogger(__name__)
@@ -172,30 +167,33 @@ def check_rate_limit(
         raise HTTPException(500, f"rate limit check failed: {e}") from e
 
 
-def _state_key(delivery_id: str, downstream_repo: str, check_run_id: str) -> str:
+def _state_key(
+    delivery_id: str, downstream_repo: str, run_id: int, run_attempt: int
+) -> str:
     """Redis key for callback state machine.
 
-    Keyed by delivery_id + repo + check_run_id to support per-execution state tracking.
-    check_run_id is unique per job execution, enabling replay attack detection.
+    Keyed by delivery_id + repo + run_id + run_attempt to support per-execution state tracking.
+    run_id + run_attempt uniquely identify a workflow run execution.
     """
-    return f"{_STATE_PREFIX}{delivery_id}:{downstream_repo}:{check_run_id}"
+    return f"{_STATE_PREFIX}{delivery_id}:{downstream_repo}:{run_id}:{run_attempt}"
 
 
 def get_callback_state(
     config: RelayConfig,
     delivery_id: str,
     downstream_repo: str,
-    check_run_id: str,
+    run_id: int,
+    run_attempt: int,
     client: redis_lib.Redis | None = None,
 ) -> CallbackStateRecord | None:
     """Get callback state record from Redis, or None if no record exists.
 
-    Returns a record containing state, timestamp, and optional job metadata.
+    Returns a record containing state, timestamp.
     """
     try:
         if client is None:
             client = create_client(config)
-        key = _state_key(delivery_id, downstream_repo, check_run_id)
+        key = _state_key(delivery_id, downstream_repo, run_id, run_attempt)
         value = client.get(key)
         if value is None:
             return None
@@ -203,8 +201,6 @@ def get_callback_state(
         return CallbackStateRecord(
             state=CallbackState(data["state"]),
             timestamp=data["timestamp"],
-            job_name=data["job_name"],
-            run_id=data["run_id"],
         )
     except RedisError:
         logger.exception("redis temporary outage or unreachable")
@@ -217,11 +213,11 @@ def set_callback_state(
     config: RelayConfig,
     delivery_id: str,
     downstream_repo: str,
-    check_run_id: str,
+    run_id: int,
+    run_attempt: int,
     state: CallbackState,
     timestamp: float,
-    job_name: str | None = None,
-    run_id: int | None = None,
+    workflow_name: str | None = None,
     client: redis_lib.Redis | None = None,
 ) -> None:
     """Set callback state with timestamp in Redis.
@@ -233,8 +229,8 @@ def set_callback_state(
     - DISPATCHED -> DISPATCHED: reject (duplicate webhook)
 
     IN_PROGRESS state (callback-side):
-    - None -> IN_PROGRESS: accept (first callback for this check_run_id)
-    - IN_PROGRESS -> IN_PROGRESS: reject (replay attack for same check_run_id)
+    - None -> IN_PROGRESS: accept (first callback for this run_id + run_attempt)
+    - IN_PROGRESS -> IN_PROGRESS: reject (replay attack for same run_id + run_attempt)
 
     COMPLETED state (callback-side):
     - None -> COMPLETED: reject (no prior in_progress)
@@ -246,19 +242,19 @@ def set_callback_state(
         if client is None:
             client = create_client(config)
 
-        if check_run_id == DISPATCH_CHECK_RUN_ID and state != CallbackState.DISPATCHED:
+        if run_id == DISPATCH_RUN_ID and state != CallbackState.DISPATCHED:
             error_msg = (
-                "check_run_id '%s' is preserved for DISPATCHED state only, rejecting invalid state=%s"
+                "run_id '%s' is preserved for DISPATCHED state only, rejecting invalid state=%s"
                 % (
-                    DISPATCH_CHECK_RUN_ID,
+                    DISPATCH_RUN_ID,
                     state.value,
                 )
             )
 
-        key = _state_key(delivery_id, downstream_repo, check_run_id)
+        key = _state_key(delivery_id, downstream_repo, run_id, run_attempt)
 
         current_record = get_callback_state(
-            config, delivery_id, downstream_repo, check_run_id, client
+            config, delivery_id, downstream_repo, run_id, run_attempt, client
         )
 
         if state == CallbackState.DISPATCHED:
@@ -268,12 +264,12 @@ def set_callback_state(
             if current_record is not None:
                 error_msg = (
                     "rejecting replay attack IN_PROGRESS for same "
-                    "check_run_id=%s, downstream_repo=%s, job_name=%s, run_id=%s"
+                    "run_id=%s, run_attempt=%s, downstream_repo=%s, workflow_name=%s"
                     % (
-                        check_run_id,
-                        downstream_repo,
-                        job_name,
                         run_id,
+                        run_attempt,
+                        downstream_repo,
+                        workflow_name,
                     )
                 )
 
@@ -281,12 +277,13 @@ def set_callback_state(
             if current_record is None:
                 error_msg = (
                     "rejecting COMPLETED without prior IN_PROGRESS "
-                    "key=%s, downstream_repo=%s, job_name=%s, run_id=%s"
+                    "key=%s, downstream_repo=%s, workflow_name=%s, run_id=%s, run_attempt=%s"
                     % (
                         key,
                         downstream_repo,
-                        job_name,
+                        workflow_name,
                         run_id,
+                        run_attempt,
                     )
                 )
             elif current_record.state == CallbackState.COMPLETED:
@@ -294,13 +291,14 @@ def set_callback_state(
             elif current_record.state != CallbackState.IN_PROGRESS:
                 error_msg = (
                     "rejecting abnormal state transition %s -> COMPLETED "
-                    "key=%s, downstream_repo=%s, job_name=%s, run_id=%s"
+                    "key=%s, downstream_repo=%s, workflow_name=%s, run_id=%s, run_attempt=%s"
                     % (
                         current_record.state.value,
                         key,
                         downstream_repo,
-                        job_name,
+                        workflow_name,
                         run_id,
+                        run_attempt,
                     )
                 )
 
@@ -311,17 +309,13 @@ def set_callback_state(
         data: dict = {
             "state": state.value,
             "timestamp": timestamp,
-            "job_name": job_name,
-            "run_id": run_id,
         }
         client.setex(key, config.oot_status_ttl, json.dumps(data))
         logger.info(
-            "callback state set key=%s state=%s timestamp=%s job_name=%s run_id=%s",
+            "callback state set key=%s state=%s timestamp=%s",
             key,
             state.value,
             timestamp,
-            job_name,
-            run_id,
         )
     except RedisError:
         logger.exception("set_callback_state: redis is temporary outage or unreachable")

--- a/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
@@ -10,7 +10,8 @@ from utils.allowlist import AllowlistLevel, load_allowlist
 from utils.config import RelayConfig
 from utils.misc import (
     CallbackState,
-    DISPATCH_CHECK_RUN_ID,
+    DISPATCH_RUN_ATTEMPT,
+    DISPATCH_RUN_ID,
     EventDispatchPayload,
     HTTPException,
 )
@@ -40,13 +41,15 @@ def _dispatch_one(
     )
 
     # Set dispatch state with timestamp to prove valid webhook occurred.
-    # Keyed by delivery_id + repo + DISPATCH_JOB_NAME="*" (repo-level, not job-specific).
+    # Keyed by delivery_id + repo + run_id + run_attempt.
+    # Uses DISPATCH_RUN_ID/DISPATCH_RUN_ATTEMPT sentinels for repo-level dispatch.
     # Timestamp is used for queue_time calculation (dispatch → in_progress).
     redis_helper.set_callback_state(
         config,
         client_payload["delivery_id"],
         downstream_repo,
-        DISPATCH_CHECK_RUN_ID,
+        DISPATCH_RUN_ID,
+        DISPATCH_RUN_ATTEMPT,
         CallbackState.DISPATCHED,
         time.time(),
     )


### PR DESCRIPTION
Use `f"{_STATE_PREFIX}{delivery_id}:{downstream_repo}:{run_id}:{run_attempt}"` instead of `f"{_STATE_PREFIX}{delivery_id}:{downstream_repo}:{check_run_id}"` to extend support of enabling downstream setting multiple jobs within one workflow. Because `run_id` is workflow-level and `check_run_id` is job-level and we don't want to see too many entries (one for each job within a single workflow) displayed on HUD and PR CI panel.

cc @fffrog @can-gaa-hou @subinz1 @jewelkm89