### PR TITLE
[release/2.13] Pin test-infra-ref to release/2.13 in validation matrix generation

### DIFF
--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -96,6 +96,7 @@ jobs:
       package-type: wheel
       os: linux-aarch64
       channel: ${{ inputs.channel }}
+      test-infra-ref: release/2.13
       with-cuda: enable
       with-cpu: enable
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -106,6 +106,7 @@ jobs:
       package-type: wheel,libtorch
       os: linux
       channel: ${{ inputs.channel }}
+      test-infra-ref: release/2.13
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
       with-xpu: enable
 

--- a/.github/workflows/validate-macos-arm64-binaries.yml
+++ b/.github/workflows/validate-macos-arm64-binaries.yml
@@ -96,6 +96,7 @@ jobs:
       package-type: wheel,libtorch #  We stopped producing conda nightlies
       os: macos-arm64
       channel: ${{ inputs.channel }}
+      test-infra-ref: release/2.13
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
 
   macos-arm64:

--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -96,6 +96,7 @@ jobs:
       package-type: wheel,libtorch #  We stopped producing conda nightlies
       os: windows
       channel: ${{ inputs.channel }}
+      test-infra-ref: release/2.13
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
       with-xpu: enable
 


### PR DESCRIPTION
The per-platform validate workflows call generate_binary_build_matrix.yml without passing test-infra-ref, so it falls back to the workflow default of 'main'. The build matrix (and its stable_version / CURRENT_CANDIDATE_VERSION) is therefore computed from main's generate_binary_build_matrix.py even when validating release/2.13.

main's CURRENT_CANDIDATE_VERSION does not match the version served on the test channel for the 2.13 release, so validation installs the wrong version and smoke_test.py fails with a "Torch version mismatch, expected <x> for channel test" error.

Pin test-infra-ref: release/2.13 in the matrix-generation calls so the matrix is computed from the release branch.

Authored with the assistance of Claude Code.