### PR TITLE
[CRCR] Update conclusion input description to clarify requirements and accepted values

### DIFF
--- a/.github/actions/cross-repo-ci-relay-callback/action.yml
+++ b/.github/actions/cross-repo-ci-relay-callback/action.yml
@@ -18,9 +18,10 @@ inputs:
     required: true
   conclusion:
     description: >
-      Conclusion of the workflow run.  Required (and must be "success" or
-      "failure") when status is "completed".  Ignored when status is
-      "in_progress".
+      Conclusion of the workflow run, passed through to the check run as-is
+      (typically "${{ job.status }}").  Required when status is "completed" and
+      must be a value GitHub accepts (e.g. success, failure, cancelled).  Ignored
+      when status is "in_progress".
     required: false
     default: ''
   test-results:
@@ -100,9 +101,9 @@ runs:
         if status not in ("in_progress", "completed"):
             sys.exit(f"::error::status must be 'in_progress' or 'completed', got {status!r}")
 
+        # Pass the conclusion through as-is for completed runs; GitHub validates
+        # it when the check run is created. in_progress runs carry no conclusion.
         conclusion = os.environ.get("CONCLUSION", "").strip() or None
-        if status == "completed" and conclusion not in ("success", "failure"):
-            sys.exit("::error::conclusion must be 'success' or 'failure' when status is 'completed'")
         if status == "in_progress":
             conclusion = None
 

--- a/aws/lambda/cross_repo_ci_relay/README.md
+++ b/aws/lambda/cross_repo_ci_relay/README.md
@@ -170,7 +170,7 @@ jobs:
 | Input | Required | Default | Description |
 |---|---|---|---|
 | `status` | **yes** | — | `in_progress` or `completed` |
-| `conclusion` | no | `''` | `success` or `failure` (required when `status=completed`) |
+| `conclusion` | no | `''` | Passed through to the check run as-is (typically `${{ job.status }}`); required when `status=completed` and must be a value GitHub accepts (e.g. `success`, `failure`, `cancelled`) |
 | `test-results` | no | `''` | Optional JSON string with test result summary (counts: passed/failed/skipped) |
 | `callback-url` | **yes** | — | Callback endpoint URL (production Lambda URL; set once at the workflow level) |
 | `artifact-url` | no | `''` | URL to downstream-hosted artifacts (logs, reports, results) |


### PR DESCRIPTION
This PR makes `conclusion` a passthrough value from GitHub to AWS Lambda so that we can have more status showing on the `L2+` HUD and `L3+` check run (especially for the `cancelled` status).

cc @KarhouTam @fffrog @atalman @subinz1 @@jewelkm89