### PR TITLE
[torchci] Fix missing background on "AI: related" HUD grid badge

### DIFF
--- a/torchci/components/hud.module.css
+++ b/torchci/components/hud.module.css
@@ -243,7 +243,8 @@
   pointer-events: none;
 }
 
-.advisorVerdict_revert {
+.advisorVerdict_revert,
+.advisorVerdict_related {
   background: #d32f2f;
   color: #fff;
 }


### PR DESCRIPTION
## Summary

On the HUD commit×job grid, the small `ai` advisor badge overlaid on the failure icon renders with **no background** for the `related` verdict (it shows as bare text instead of the red pill the other verdicts get).

## Root cause

The grid badge builds its CSS class **dynamically** in `[[...page]].tsx`:

```tsx
className={`${styles.advisorBadge} ${
  styles[`advisorVerdict_${advisorVerdict.verdict}` as keyof typeof styles] ?? ""
}`}
```

`hud.module.css` defines `.advisorVerdict_revert`, `_not_related`, `_garbage`, and `_unsure` — but the recent **revert → related** verdict migration renamed the verdict without adding a matching `.advisorVerdict_related` class. So `related` verdicts fall through the `?? ""` fallback and get no background.

The other three render paths (`AutorevertCell.tsx`, `AdvisorSection.tsx`, `AiAdvisorIndicator.tsx`) were all updated for the migration to treat `related == revert`; only this CSS map was missed.

## Fix

Add `.advisorVerdict_related` sharing the same red styling as `.advisorVerdict_revert`. `revert` is kept for any legacy/in-flight verdicts still using the old value.

```css
.advisorVerdict_revert,
.advisorVerdict_related {
  background: #d32f2f;
  color: #fff;
}
```

## Test plan

- CSS-only change; `yarn prettier --check components/hud.module.css` passes.
- Verified the dynamic class `advisorVerdict_related` now resolves to a defined rule, matching how `AutorevertCell`/`AdvisorSection`/`AiAdvisorIndicator` already map `related → revert` (red).
