### PR TITLE
autorevert metrics: only count a recovered signal when the reverted commit is in the red streak

### DIFF
--- a/torchci/clickhouse_queries/autorevert_significant_reverts/query.sql
+++ b/torchci/clickhouse_queries/autorevert_significant_reverts/query.sql
@@ -147,10 +147,26 @@ streak_lengths AS (
     GROUP BY base_name, streak_id, status
 ),
 
+-- Step 5b: Collect the SHAs that make up each red streak (for causal attribution).
+-- A revert only genuinely "fixes" a signal if the reverted commit is actually part
+-- of the red streak that recovered. Otherwise the red->green transition at the
+-- revert commit is coincidental -- e.g. a flaky signal that merely happened to go
+-- green at the revert -- and crediting the revert with it inflates the FN count.
+red_streak_members AS (
+    SELECT
+        base_name,
+        streak_id,
+        groupArray(sha) AS red_shas
+    FROM signal_with_streak_ids
+    WHERE status = 'red'
+    GROUP BY base_name, streak_id
+),
+
 -- Step 6: Find recovery events: green streak that follows a red streak
 recovery_events AS (
     SELECT
         green.base_name AS signal_key,
+        red.streak_id AS red_streak_id,
         red.streak_length AS red_streak_length,
         green.streak_length AS green_streak_length,
         green.first_sha AS recovery_sha,
@@ -212,8 +228,12 @@ recovery_with_reverted_sha AS (
         -- The regex captures the full 40-char SHA since commit messages include full SHAs
         arrayElement(
             extractAll(r.recovery_message, 'reverts commit ([a-f0-9]+)'), 1
-        ) AS reverted_commit_sha
+        ) AS reverted_commit_sha,
+        -- SHAs comprising the red streak this recovery resolves (causal filter input)
+        rm.red_shas AS red_shas
     FROM recovery_events r
+    LEFT JOIN red_streak_members rm
+        ON rm.base_name = r.signal_key AND rm.streak_id = r.red_streak_id
 ),
 
 -- Step 9: Join with autorevert events on full SHA match
@@ -233,6 +253,7 @@ recovery_with_attribution AS (
         r.reverted_pr_numbers,
         r.merge_pr_numbers,
         r.reverted_commit_sha,
+        r.red_shas,
         -- Check for autorevert attribution by matching the reverted commit SHA
         a.reverted_sha IS NOT NULL AND a.reverted_sha != '' AS is_autorevert,
         a.autorevert_time,
@@ -241,10 +262,20 @@ recovery_with_attribution AS (
     LEFT JOIN autorevert_events a ON r.reverted_commit_sha = a.reverted_sha
 ),
 
--- Filter to only actual reverts before aggregating
+-- Filter to only actual reverts before aggregating, and require the reverted
+-- commit to actually belong to the red streak it supposedly recovered. This drops
+-- spurious recoveries where an unrelated/flaky signal merely went red->green at the
+-- revert commit while the reverted commit was never part of that red streak (e.g.
+-- out-of-plane reverts -- ghfirst/nosignal -- credited with a coincidental flake
+-- clear). When the reverted commit SHA can't be parsed from the message (e.g.
+-- Reapply / Back out shapes), the row is kept unchanged.
 reverts_only AS (
     SELECT * FROM recovery_with_attribution
     WHERE is_revert = 1
+        AND (
+            reverted_commit_sha = ''
+            OR has(red_shas, reverted_commit_sha)
+        )
 ),
 
 -- Aggregate by recovery_sha (one row per unique revert commit)

--- a/torchci/clickhouse_queries/autorevert_significant_reverts/query.sql
+++ b/torchci/clickhouse_queries/autorevert_significant_reverts/query.sql
@@ -233,7 +233,9 @@ recovery_with_reverted_sha AS (
         rm.red_shas AS red_shas
     FROM recovery_events r
     LEFT JOIN red_streak_members rm
-        ON rm.base_name = r.signal_key AND rm.streak_id = r.red_streak_id
+        ON
+            rm.base_name = r.signal_key
+            AND rm.streak_id = r.red_streak_id
 ),
 
 -- Step 9: Join with autorevert events on full SHA match
@@ -271,7 +273,8 @@ recovery_with_attribution AS (
 -- Reapply / Back out shapes), the row is kept unchanged.
 reverts_only AS (
     SELECT * FROM recovery_with_attribution
-    WHERE is_revert = 1
+    WHERE
+        is_revert = 1
         AND (
             reverted_commit_sha = ''
             OR has(red_shas, reverted_commit_sha)

--- a/torchci/clickhouse_queries/autorevert_weekly_metrics/query.sql
+++ b/torchci/clickhouse_queries/autorevert_weekly_metrics/query.sql
@@ -138,9 +138,23 @@ streak_lengths AS (
     GROUP BY base_name, streak_id, status
 ),
 
+-- SHAs comprising each red streak, for causal attribution: a revert only
+-- genuinely "fixes" a signal if the reverted commit is part of the red streak
+-- that recovered (mirrors autorevert_significant_reverts).
+red_streak_members AS (
+    SELECT
+        base_name,
+        streak_id,
+        groupArray(sha) AS red_shas
+    FROM signal_with_streak_ids
+    WHERE status = 'red'
+    GROUP BY base_name, streak_id
+),
+
 recovery_events AS (
     SELECT
         green.base_name AS signal_key,
+        red.streak_id AS red_streak_id,
         red.streak_length AS red_streak_length,
         green.streak_length AS green_streak_length,
         green.first_sha AS recovery_sha,
@@ -188,8 +202,13 @@ recovery_with_reverted_sha AS (
         -- The regex captures the full 40-char SHA since commit messages include full SHAs
         arrayElement(
             extractAll(r.recovery_message, 'reverts commit ([a-f0-9]+)'), 1
-        ) AS reverted_commit_sha
+        ) AS reverted_commit_sha,
+        rm.red_shas AS red_shas
     FROM recovery_events r
+    LEFT JOIN red_streak_members rm
+        ON
+            rm.base_name = r.signal_key
+            AND rm.streak_id = r.red_streak_id
 ),
 
 -- Join with autorevert events on full SHA match
@@ -205,6 +224,7 @@ recovery_with_attribution AS (
         r.last_red_time,
         r.is_revert,
         r.reverted_commit_sha,
+        r.red_shas,
         -- Check for autorevert attribution by matching the reverted commit SHA
         a.reverted_sha IS NOT NULL AND a.reverted_sha != '' AS is_autorevert
     FROM recovery_with_reverted_sha r
@@ -220,6 +240,14 @@ unique_recoveries AS (
         max(is_revert) AS is_revert,
         max(is_autorevert) AS is_autorevert
     FROM recovery_with_attribution
+    -- Causal filter (mirrors autorevert_significant_reverts): a revert only counts
+    -- as fixing a signal if the reverted commit is part of that signal's red streak.
+    -- Drops coincidental flake-clears at the revert commit so the weekly chart's
+    -- human_revert_recoveries / recall stay consistent with the summary numbers.
+    -- Non-revert recoveries have an empty reverted_commit_sha and are kept.
+    WHERE
+        reverted_commit_sha = ''
+        OR has(red_shas, reverted_commit_sha)
     GROUP BY recovery_sha
 )
 


### PR DESCRIPTION
## Summary

`autorevert_significant_reverts` (which powers the precision/recall numbers on the autorevert HUD metrics page) flags a revert as "recovering" a signal whenever a red streak (`>= minRedCommits`) is immediately followed by a green streak (`>= minGreenCommits`) and the green streak starts at the revert commit — **without verifying that the reverted commit was actually part of that red streak.**

This over-counts false negatives: any flaky/unrelated signal that happens to flake red for a couple commits just before a revert and green right after gets attributed to the revert, even though the reverted change had nothing to do with it. These spurious FNs depress the autorevert recall headline.

### Concrete example

PR #186928 was reverted at `889f6eb707c9eb75bcb2f3ca91ad1ed9b24d2446`. The metric credited it with "fixing" one signal: `linux-jammy-rocm-py3.10-mi350 / test`. But:

- The reverted commit `d0ef03a2…` landed **2026-06-10**.
- That signal's 2-commit red streak was **2026-06-15 02:41–04:01** — ~5 days later — and `linux-jammy-rocm-py3.10-mi350 / test` is a chronic flake (it oscillates red/green across many unrelated commits, both before and after the revert).
- The reverted commit never appears in that red streak; the red→green transition at the revert was coincidental.

(The revert itself was an out-of-plane `-c ghfirst` revert — a mobile/ExecuTorch build break that doesn't surface in the OSS pull/trunk data plane — so there was no real OSS signal to recover, yet the coincidental flake clear made it count as a recall miss.)

## Fix

Add a `red_streak_members` CTE that collects the SHAs comprising each red streak, carry the red streak id into `recovery_events`, and require the reverted commit SHA to be a member of the red streak it supposedly recovered:

```sql
WHERE is_revert = 1
    AND (
        reverted_commit_sha = ''
        OR has(red_shas, reverted_commit_sha)
    )
```

When the reverted commit SHA can't be parsed from the recovery message (`Reapply` / `Back out` shapes), the row is kept unchanged so existing behavior for those is preserved.

## Validation

Run against ClickHouse over `2026-06-08 .. 2026-06-15` (workflows `Lint,pull,trunk,linux-aarch64`):

| recovery | before | after |
|---|---|---|
| `889f6eb` (#186928) | FN, `signals_fixed=1` (mi350 flake) | **dropped** — only signal is non-causal |
| `a1b02648` | `signals_fixed=2` (macos + test-osdc) | `signals_fixed=1` — coincidental `test-osdc` pruned, causal `macos` kept |
| all other in-window recoveries (incl. every autorevert TP) | kept | kept |

Genuine recoveries — including all autorevert true-positives — are preserved; only signals whose red streak doesn't contain the reverted commit are pruned, and recoveries left with zero causal signals (the spurious FNs) drop out.

## Tradeoff

If a reverted commit genuinely broke a signal but that signal did **not** run on the exact reverted commit (e.g. a periodic/sharded job that skipped it), the reverted SHA won't be in the red streak and that recovery would be dropped. This is rare (most trunk signals run on most trunk commits) and is the conservative direction for an FN-precision fix — counting coincidental flake-clears as misses is the more damaging error for the recall metric. A time-window variant (`reverted_commit_time BETWEEN first_red_time AND last_red_time`) could be substituted if SHA-membership proves too strict in practice.