### PR TITLE
Switch backfill-workflow-job from cron schedule to manual dispatch

### DIFF
--- a/.github/workflows/backfill-workflow-job.yml
+++ b/.github/workflows/backfill-workflow-job.yml
@@ -1,9 +1,7 @@
 name: Backfill workflow jobs in DynamoDB and ClickHouse
 
 on:
-  schedule:
-    # Every 5 minutes
-    - cron: "*/5 * * * *"
+  workflow_dispatch:
 
 permissions:
   id-token: write


### PR DESCRIPTION
**Impact:** CI data backfill pipeline (DynamoDB + ClickHouse)

**Risk:** low

## What
Replaces the every-5-minute cron schedule on the backfill-workflow-job workflow with `workflow_dispatch`, making it manual-trigger only.

## Why
The cron-based CI schedule is unreliable and in practice only runs roughly every hour despite being configured for every 5 minutes. Switching to manual dispatch avoids the false sense of regular execution and lets operators trigger backfills on demand when actually needed.

see https://github.com/meta-pytorch/pytorch-gha-infra/pull/1217