### PR TITLE
Auto-dispatch AI CI Advisor on Dr.CI new failures (dark)

### DIFF
--- a/torchci/clickhouse_db_schema/misc.ai_advisor_dispatches/schema.sql
+++ b/torchci/clickhouse_db_schema/misc.ai_advisor_dispatches/schema.sql
@@ -1,0 +1,34 @@
+-- AI CI Advisor dispatch log.
+--
+-- Durable dedup + retry state for advisor workflow_dispatch runs, written
+-- synchronously by HUD (both the manual "AI Analyze" button and the automatic
+-- Dr.CI dispatch loop). Dedup is keyed on (owner, repo, head_sha, signal_key);
+-- head_sha rotates on every push, so a changed PR re-analyzes automatically and
+-- no TTL is needed.
+--
+-- Two writes per dispatch: 'dispatching' (pre-dispatch, also gates dispatch on
+-- write-path health -- if we cannot record the marker we must not dispatch)
+-- then 'dispatched' (post-dispatch). A 'failed' row supersedes the pre-dispatch
+-- row when the dispatch call throws, re-enabling retry up to retry_count = MAX.
+--
+-- ReplacingMergeTree(version) keeps the latest-version row per ORDER BY key. The
+-- version (a write timestamp) is deliberately NOT part of ORDER BY so the pre-
+-- and post-dispatch rows for a single dispatch collapse into one row (putting
+-- the timestamp in the sort key is the bug that stops misc.autorevert_events_v2
+-- rows from collapsing).
+CREATE TABLE misc.ai_advisor_dispatches
+(
+    `owner` LowCardinality(String),
+    `repo` LowCardinality(String),
+    `head_sha` FixedString(40),
+    `signal_key` String,
+    `state` Enum8('dispatching' = 1, 'dispatched' = 2, 'failed' = 3),
+    `retry_count` UInt8 DEFAULT 0,
+    `pr_number` Int64,
+    `job_name` String,
+    `version` DateTime64(3),
+    `_inserted_at` DateTime MATERIALIZED now()
+)
+ENGINE = SharedReplacingMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}', version)
+ORDER BY (owner, repo, head_sha, signal_key)
+SETTINGS index_granularity = 8192

--- a/torchci/clickhouse_queries/advisor_dispatch_states/params.json
+++ b/torchci/clickhouse_queries/advisor_dispatch_states/params.json
@@ -1,0 +1,9 @@
+{
+  "params": {
+    "owner": "String",
+    "repo": "String",
+    "headSha": "String",
+    "signalKeys": "Array(String)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/advisor_dispatch_states/query.sql
+++ b/torchci/clickhouse_queries/advisor_dispatch_states/query.sql
@@ -1,0 +1,14 @@
+-- Latest AI advisor dispatch state + retry_count per signal_key for one PR head
+-- commit. Used to dedup auto-dispatch. argMax over the replacing version returns
+-- the latest row; reading (state, retry_count) as one tuple keeps them paired
+-- even if two writes ever share a version timestamp.
+SELECT
+    signal_key,
+    argMax((state, retry_count), version) AS sr
+FROM misc.ai_advisor_dispatches
+WHERE
+    owner = {owner: String}
+    AND repo = {repo: String}
+    AND head_sha = {headSha: String}
+    AND signal_key IN {signalKeys: Array(String)}
+GROUP BY signal_key

--- a/torchci/components/job/FilteredJobList.tsx
+++ b/torchci/components/job/FilteredJobList.tsx
@@ -1,3 +1,4 @@
+import { isAdvisorEnabled } from "lib/advisor/advisorConfig";
 import { fetcher } from "lib/GeneralUtils";
 import { IssueData, JobAnnotation, JobData } from "lib/types";
 import useScrollTo from "lib/useScrollTo";
@@ -27,15 +28,18 @@ function FailedJobInfo({
   return (
     <li key={job.id} id={job.id}>
       <JobSummary job={job} unstableIssues={unstableIssues} />
-      {prNum > 0 && job.name && job.sha && (
-        <AiAdvisorIndicator
-          jobName={job.name}
-          sha={job.sha}
-          prNumber={prNum}
-          conclusion={job.conclusion}
-          workflowName={job.workflowName}
-        />
-      )}
+      {prNum > 0 &&
+        job.name &&
+        job.sha &&
+        isAdvisorEnabled(repoOwner as string, repoName as string) && (
+          <AiAdvisorIndicator
+            jobName={job.name}
+            sha={job.sha}
+            prNumber={prNum}
+            conclusion={job.conclusion}
+            workflowName={job.workflowName}
+          />
+        )}
       <div>
         <JobLinks job={job} />
       </div>

--- a/torchci/lib/advisor/advisorConfig.ts
+++ b/torchci/lib/advisor/advisorConfig.ts
@@ -1,0 +1,56 @@
+// Per-repo configuration for the AI CI Advisor.
+//
+// Single source of truth shared by:
+//   - the manual "AI Analyze" dispatch endpoint (pull/dispatch-advisor.ts),
+//   - the automatic Dr.CI dispatch loop (lib/advisor/advisorDispatch.ts),
+//   - the frontend (FilteredJobList.tsx) to gate the manual button.
+//
+// It is pure data with no server-only imports, so it can be imported from both
+// API routes and React components.
+
+// If a PR has more than this many NEW failures, auto-dispatch bails for that PR
+// entirely (dispatches nothing) -- a flood of new failures is almost always an
+// outage rather than a PR problem, and we don't want to fan dozens of advisor
+// runs out per PR. Used as the fallback when a repo doesn't set its own.
+export const DEFAULT_MAX_NEW_FAILURES = 8;
+
+export interface AdvisorRepoConfig {
+  // The workflow_dispatch file (on the repo's default branch) that runs the
+  // advisor analysis for this repo.
+  workflowFile: string;
+  // Auto-dispatch bails entirely if a PR has more than this many NEW failures
+  // (outage guard). Falls back to DEFAULT_MAX_NEW_FAILURES when unset.
+  maxNewFailures?: number;
+}
+
+// Repos with the AI advisor enabled, keyed by "owner/repo".
+//
+// Adding a repo here enables BOTH the manual button and -- when the
+// DRCI_ADVISOR_AUTODISPATCH_ENABLED flag is on and VERCEL_ENV is production --
+// automatic dispatch on Dr.CI new failures. Enabling a repo is a deliberate,
+// reviewed action because every dispatch costs an LLM analysis.
+export const ADVISOR_REPOS: Record<string, AdvisorRepoConfig> = {
+  "pytorch/pytorch": {
+    workflowFile: "claude-autorevert-advisor.yml",
+    maxNewFailures: 8,
+  },
+};
+
+export function getAdvisorRepoConfig(
+  owner: string,
+  repo: string
+): AdvisorRepoConfig | undefined {
+  return ADVISOR_REPOS[`${owner}/${repo}`];
+}
+
+export function isAdvisorEnabled(owner: string, repo: string): boolean {
+  return getAdvisorRepoConfig(owner, repo) !== undefined;
+}
+
+// The NEW-failure count above which auto-dispatch bails for a PR, per repo.
+export function getMaxNewFailures(owner: string, repo: string): number {
+  return (
+    getAdvisorRepoConfig(owner, repo)?.maxNewFailures ??
+    DEFAULT_MAX_NEW_FAILURES
+  );
+}

--- a/torchci/lib/advisor/advisorDispatch.ts
+++ b/torchci/lib/advisor/advisorDispatch.ts
@@ -1,14 +1,31 @@
-// Shared AI advisor dispatch logic.
+// Shared AI advisor dispatch + auto-dispatch logic.
 //
-// Extracted from the manual "AI Analyze" endpoint (pull/dispatch-advisor.ts) so
-// the signal_pattern build + workflow dispatch can be reused by other callers.
-// Behavior-preserving: this is the same logic the manual endpoint already ran.
+// dispatchAdvisorWorkflow (the signal_pattern build + workflow dispatch) is
+// shared with the manual "AI Analyze" endpoint (pull/dispatch-advisor.ts). The
+// rest -- the misc.ai_advisor_dispatches dedup/retry state and the
+// autoDispatchAdvisorForNewFailures loop -- backs the automatic Dr.CI path.
 
-import { queryClickhouseSaved } from "lib/clickhouse";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import {
+  getAdvisorRepoConfig,
+  getMaxNewFailures,
+} from "lib/advisor/advisorConfig";
+import {
+  getClickhouseClientWritable,
+  queryClickhouseSaved,
+} from "lib/clickhouse";
+import { CANCELLED_STEP_ERROR } from "lib/drciUtils";
 import { getOctokit } from "lib/github";
+import { RecentWorkflowsData } from "lib/types";
 
-// The advisor workflow_dispatch file on the repo's default branch.
-const ADVISOR_WORKFLOW_FILE = "claude-autorevert-advisor.yml";
+dayjs.extend(utc);
+
+const DISPATCH_TABLE = "misc.ai_advisor_dispatches";
+
+// Max times we re-attempt a dispatch whose workflow_dispatch POST threw. Bounds
+// the retry so a permanently-failing dispatch cannot re-attempt every cron pass.
+export const MAX_DISPATCH_RETRIES = 3;
 
 const SHA_REGEX = /^[0-9a-f]{7,40}$/i;
 
@@ -130,13 +147,22 @@ export interface DispatchParams {
 
 /**
  * Dispatch one advisor analysis as the bot. Builds the signal_pattern (PR head +
- * merge base + recent trunk runs of the same job) and triggers the advisor
- * workflow. Throws on failure so the caller can map it to an HTTP error.
+ * merge base + recent trunk runs of the same job) and triggers the per-repo
+ * advisor workflow. Throws on failure so the caller can map it to an HTTP error.
+ *
+ * Note: GitHub's POST /actions/workflows/{id}/dispatches is not idempotent (it
+ * can create the run and then return 5xx on the response), and the default
+ * Octokit retry plugin would retry the POST and create duplicate runs -- so we
+ * pass `request: { retries: 0 }` to disable auto-retry on the dispatch.
  */
 export async function dispatchAdvisorWorkflow(
   params: DispatchParams
 ): Promise<void> {
   const { owner, repo, prNumber, headSha, jobName } = params;
+  const cfg = getAdvisorRepoConfig(owner, repo);
+  if (!cfg) {
+    throw new Error(`AI advisor is not enabled for ${owner}/${repo}`);
+  }
   const repoFullName = `${owner}/${repo}`;
   const botOctokit = await getOctokit(owner, repo);
   const jobPattern = jobNameToBasePattern(jobName);
@@ -244,12 +270,278 @@ export async function dispatchAdvisorWorkflow(
   await botOctokit.rest.actions.createWorkflowDispatch({
     owner,
     repo,
-    workflow_id: ADVISOR_WORKFLOW_FILE,
+    workflow_id: cfg.workflowFile,
     ref: defaultBranch,
     inputs: {
       suspect_commit: headSha,
       pr_number: String(prNumber),
       signal_pattern: JSON.stringify(signalPattern),
     },
+    // Storm guard: never auto-retry the non-idempotent dispatch POST.
+    request: { retries: 0 },
   });
+}
+
+export type DispatchState = "dispatching" | "dispatched" | "failed";
+
+interface DispatchStateRow {
+  state: DispatchState;
+  retryCount: number;
+}
+
+/**
+ * Read the latest dispatch state per signal_key for one PR head. argMax over the
+ * replacing version returns the latest row without a FINAL merge. Filters on the
+ * (owner, repo, head_sha) ORDER BY prefix, so it touches only relevant granules.
+ */
+export async function readDispatchStates(
+  owner: string,
+  repo: string,
+  headSha: string,
+  signalKeys: string[]
+): Promise<Map<string, DispatchStateRow>> {
+  const result = new Map<string, DispatchStateRow>();
+  if (signalKeys.length === 0) return result;
+
+  // Reads state + retry_count from the SAME latest row as one argMax tuple, so
+  // a shared version timestamp can't pair fields from different rows.
+  const rows = await queryClickhouseSaved("advisor_dispatch_states", {
+    owner,
+    repo,
+    headSha,
+    signalKeys,
+  });
+
+  for (const row of rows) {
+    // ClickHouse returns a tuple as a positional array: [state, retry_count].
+    const sr = row.sr as [string, number];
+    result.set(row.signal_key as string, {
+      state: sr[0] as DispatchState,
+      retryCount: Number(sr[1] ?? 0),
+    });
+  }
+  return result;
+}
+
+export interface DispatchRecord {
+  owner: string;
+  repo: string;
+  headSha: string;
+  signalKey: string;
+  state: DispatchState;
+  retryCount: number;
+  prNumber: number;
+  jobName: string;
+}
+
+// Monotonic version generator. The ReplacingMergeTree keeps the row with the
+// max `version` per key, and reads pick it with argMax(version); on a version
+// TIE that choice is non-deterministic. The pre-dispatch ('dispatching') and
+// terminal ('dispatched'/'failed') rows for one dispatch are written from the
+// same process microseconds apart and could share a millisecond, which would
+// let a 'dispatching' row mask a terminal one (e.g. a fast-failing dispatch
+// would never retry). Clamp to strictly-increasing-per-process so the terminal
+// write always outranks its pre-dispatch write.
+let lastVersionMs = 0;
+function nextDispatchVersion(): string {
+  let ms = dayjs().valueOf();
+  if (ms <= lastVersionMs) ms = lastVersionMs + 1;
+  lastVersionMs = ms;
+  return dayjs(ms).utc().format("YYYY-MM-DD HH:mm:ss.SSS");
+}
+
+/** Insert one row into the dispatch log. ReplacingMergeTree collapses by key. */
+export async function recordDispatch(record: DispatchRecord): Promise<void> {
+  await getClickhouseClientWritable().insert({
+    table: DISPATCH_TABLE,
+    values: [
+      {
+        owner: record.owner,
+        repo: record.repo,
+        head_sha: record.headSha,
+        signal_key: record.signalKey,
+        state: record.state,
+        retry_count: record.retryCount,
+        pr_number: record.prNumber,
+        job_name: record.jobName,
+        version: nextDispatchVersion(),
+      },
+    ],
+    format: "JSONEachRow",
+  });
+}
+
+// Injectable dependencies so the orchestration logic is unit-testable without
+// touching ClickHouse or GitHub.
+export interface AutoDispatchDeps {
+  readDispatchStates: typeof readDispatchStates;
+  recordDispatch: typeof recordDispatch;
+  dispatchAdvisorWorkflow: typeof dispatchAdvisorWorkflow;
+}
+
+const defaultDeps: AutoDispatchDeps = {
+  readDispatchStates,
+  recordDispatch,
+  dispatchAdvisorWorkflow,
+};
+
+export interface AutoDispatchArgs {
+  owner: string;
+  repo: string;
+  prNumber: number;
+  headSha: string;
+  mergeBaseSha?: string;
+  // The FAILED bucket from Dr.CI (RecentWorkflowsData[]). Cancelled jobs are
+  // filtered out here so only true NEW failures are dispatched.
+  newFailures: RecentWorkflowsData[];
+}
+
+/** Whether auto-dispatch is enabled for this environment + repo. */
+export function autoDispatchEnabled(owner: string, repo: string): boolean {
+  return (
+    process.env.DRCI_ADVISOR_AUTODISPATCH_ENABLED === "true" &&
+    process.env.VERCEL_ENV === "production" &&
+    getAdvisorRepoConfig(owner, repo) !== undefined
+  );
+}
+
+/**
+ * Automatically dispatch the AI advisor on a PR's NEW failures.
+ *
+ * Dispatch-only: this never edits the Dr.CI comment or merge behavior. Behavior:
+ *   - gated by feature flag + production env + per-repo config (no-op otherwise),
+ *   - fails CLOSED: if the dedup read throws (CH down) we dispatch nothing,
+ *   - two-phase write: a 'dispatching' row is written BEFORE the dispatch and
+ *     gates it (if that write throws, the write path is down -- we abort the PR
+ *     rather than dispatch without a dedup record),
+ *   - 'dispatched' is written on success; a 'failed' row supersedes the pre row
+ *     when the dispatch throws, re-enabling retry up to MAX_DISPATCH_RETRIES,
+ *   - bails entirely (dispatches nothing) if a PR has more NEW failures than the
+ *     per-repo max (outage guard).
+ */
+export async function autoDispatchAdvisorForNewFailures(
+  args: AutoDispatchArgs,
+  deps: AutoDispatchDeps = defaultDeps
+): Promise<void> {
+  const { owner, repo, prNumber, headSha, mergeBaseSha } = args;
+
+  if (!autoDispatchEnabled(owner, repo)) return;
+  if (!isValidSha(headSha)) return;
+
+  // True NEW failures only -- mirror constructResultsComment's cancelled filter.
+  const candidates = args.newFailures.filter(
+    (job) =>
+      job.conclusion !== "cancelled" &&
+      !(job.failure_captures || []).includes(CANCELLED_STEP_ERROR)
+  );
+  if (candidates.length === 0) return;
+
+  // One entry per signal_key (a job can appear once); preserve first occurrence.
+  const byKey = new Map<string, RecentWorkflowsData>();
+  for (const job of candidates) {
+    if (!job.name) continue;
+    const key = signalKeyForJob(job.name);
+    if (!byKey.has(key)) byKey.set(key, job);
+  }
+  const signalKeys = Array.from(byKey.keys());
+  if (signalKeys.length === 0) return;
+
+  // Outage guard: if a PR has more NEW failures than the per-repo max, bail
+  // entirely (dispatch nothing). A flood of new failures is almost always an
+  // outage, not a PR problem, and we don't want to fan dozens of advisor runs
+  // out across one PR.
+  const maxNewFailures = getMaxNewFailures(owner, repo);
+  if (byKey.size > maxNewFailures) {
+    console.log(
+      `advisor auto-dispatch: PR ${prNumber} has ${byKey.size} new failures ` +
+        `(> ${maxNewFailures}); skipping auto-dispatch (likely an outage)`
+    );
+    return;
+  }
+
+  // Fail closed: if we cannot read dedup state, dispatch nothing.
+  let states: Map<string, DispatchStateRow>;
+  try {
+    states = await deps.readDispatchStates(owner, repo, headSha, signalKeys);
+  } catch (e) {
+    console.error(
+      `advisor auto-dispatch: dedup read failed for PR ${prNumber}, skipping pass`,
+      e
+    );
+    return;
+  }
+
+  // The byKey set is already bounded by the outage guard above (<= the per-repo
+  // max), so dispatch every fresh failure; dedup state skips repeats.
+  for (const [signalKey, job] of byKey) {
+    const prev = states.get(signalKey);
+    if (prev) {
+      // Already dispatching or completed -> permanent skip.
+      if (prev.state === "dispatching" || prev.state === "dispatched") continue;
+      // Failed and out of retries -> permanent skip.
+      if (prev.state === "failed" && prev.retryCount >= MAX_DISPATCH_RETRIES) {
+        continue;
+      }
+    }
+    const retryCount = prev?.state === "failed" ? prev.retryCount + 1 : 0;
+
+    const base = {
+      owner,
+      repo,
+      headSha,
+      signalKey,
+      retryCount,
+      prNumber,
+      jobName: job.name,
+    };
+
+    // Pre-dispatch write gates the dispatch on write-path health: if we cannot
+    // record the marker (e.g. bad write creds) we must NOT dispatch, otherwise
+    // a later verdict-write failure would re-dispatch forever. The same creds
+    // fail for every key, so abort the whole PR.
+    try {
+      await deps.recordDispatch({ ...base, state: "dispatching" });
+    } catch (e) {
+      console.error(
+        `advisor auto-dispatch: pre-dispatch write failed for PR ${prNumber}, aborting`,
+        e
+      );
+      return;
+    }
+
+    try {
+      await deps.dispatchAdvisorWorkflow({
+        owner,
+        repo,
+        prNumber,
+        headSha,
+        mergeBaseSha,
+        jobName: job.name,
+        workflowName: job.name.split(" / ")[0],
+      });
+    } catch (e) {
+      console.error(
+        `advisor auto-dispatch: dispatch failed for PR ${prNumber} ${signalKey}`,
+        e
+      );
+      // Supersede the pre-dispatch row so it is retryable next pass.
+      try {
+        await deps.recordDispatch({ ...base, state: "failed" });
+      } catch (e2) {
+        console.error("advisor auto-dispatch: failed-state write failed", e2);
+      }
+      continue;
+    }
+
+    // Confirm completion. If this write throws, the 'dispatching' row already
+    // blocks re-dispatch, so the only cost is losing the explicit confirmation.
+    try {
+      await deps.recordDispatch({ ...base, state: "dispatched" });
+    } catch (e) {
+      console.error(
+        "advisor auto-dispatch: post-dispatch write failed (non-fatal)",
+        e
+      );
+    }
+  }
 }

--- a/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/pull/dispatch-advisor.ts
@@ -1,13 +1,25 @@
+import { isAdvisorEnabled } from "lib/advisor/advisorConfig";
 import {
   dispatchAdvisorWorkflow,
   isValidSha,
+  readDispatchStates,
+  recordDispatch,
   signalKeyForJob,
 } from "lib/advisor/advisorDispatch";
-import { queryClickhouse } from "lib/clickhouse";
 import { hasWritePermissionsUsingOctokit } from "lib/GeneralUtils";
 import { getOctokitWithUserToken } from "lib/github";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+/**
+ * Manual "AI Analyze" dispatch endpoint (the HUD button). Thin wrapper over the
+ * shared advisor dispatch logic in lib/advisor/advisorDispatch: it adds the
+ * interactive auth + write-permission gate, the per-repo enable check, and a
+ * best-effort dedup record so the automatic Dr.CI loop won't re-dispatch a job a
+ * human already triggered.
+ *
+ * Unlike the auto path, dedup here is best-effort (human-rate, no storm risk):
+ * a ClickHouse read/write hiccup must not block a user's click.
+ */
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
@@ -37,12 +49,18 @@ export default async function handler(
   if (!Number.isInteger(prNumber) || prNumber <= 0) {
     return void res.status(400).json({ error: "Invalid prNumber" });
   }
-
   if (!isValidSha(headSha)) {
     return void res.status(400).json({ error: "Invalid headSha format" });
   }
   if (mergeBaseSha && !isValidSha(mergeBaseSha)) {
     return void res.status(400).json({ error: "Invalid mergeBaseSha format" });
+  }
+
+  // Per-repo enable gate (shared with the auto loop and the button visibility).
+  if (!isAdvisorEnabled(owner, repo)) {
+    return void res.status(404).json({
+      error: `AI advisor is not enabled for ${owner}/${repo}`,
+    });
   }
 
   const octokit = await getOctokitWithUserToken(authorization);
@@ -64,28 +82,35 @@ export default async function handler(
   }
 
   const signalKey = signalKeyForJob(jobName);
+  const record = {
+    owner,
+    repo,
+    headSha,
+    signalKey,
+    retryCount: 0,
+    prNumber,
+    jobName,
+  };
 
-  // Server-side dedup: skip if a verdict for this (sha, signal_key) was
-  // already produced in the last 10 minutes, meaning a prior dispatch
-  // already completed or is in-flight.
+  // Best-effort dedup: skip if already dispatching/dispatched. A read failure
+  // must not block the click, so fall through on error.
   try {
-    const recentRows = await queryClickhouse(
-      `SELECT 1
-       FROM misc.autorevert_advisor_verdicts
-       WHERE repo = {repo: String}
-         AND suspect_commit = {sha: String}
-         AND signal_key = {signalKey: String}
-         AND timestamp > now() - INTERVAL 10 MINUTE
-       LIMIT 1`,
-      { repo: `${owner}/${repo}`, sha: headSha, signalKey }
-    );
-    if (recentRows.length > 0) {
+    const states = await readDispatchStates(owner, repo, headSha, [signalKey]);
+    const prev = states.get(signalKey);
+    if (prev && (prev.state === "dispatching" || prev.state === "dispatched")) {
       return void res.status(409).json({
-        error: "Advisor was already dispatched for this job recently",
+        error: "Advisor was already dispatched for this job",
       });
     }
-  } catch {
-    // If the dedup check fails, proceed with dispatch anyway
+  } catch (e) {
+    console.error("dispatch-advisor: dedup read failed, proceeding", e);
+  }
+
+  // Best-effort pre-dispatch marker (so the auto loop sees the manual dispatch).
+  try {
+    await recordDispatch({ ...record, state: "dispatching" });
+  } catch (e) {
+    console.error("dispatch-advisor: pre-dispatch write failed", e);
   }
 
   try {
@@ -98,18 +123,30 @@ export default async function handler(
       jobName,
       workflowName,
     });
-    return void res.status(200).json({
-      message: "Advisor workflow dispatched",
-      prNumber,
-      headSha,
-      jobName,
-    });
   } catch (error: any) {
     console.error("Failed to dispatch advisor:", error);
+    try {
+      await recordDispatch({ ...record, state: "failed" });
+    } catch {
+      // best-effort
+    }
     return void res.status(500).json({
       error: "Failed to dispatch advisor workflow",
       details:
         process.env.NODE_ENV === "development" ? error.message : undefined,
     });
   }
+
+  try {
+    await recordDispatch({ ...record, state: "dispatched" });
+  } catch (e) {
+    console.error("dispatch-advisor: post-dispatch write failed", e);
+  }
+
+  return void res.status(200).json({
+    message: "Advisor workflow dispatched",
+    prNumber,
+    headSha,
+    jobName,
+  });
 }

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -1,6 +1,7 @@
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import { autoDispatchAdvisorForNewFailures } from "lib/advisor/advisorDispatch";
 import { fetchJSON, isTime0 } from "lib/bot/utils";
 import { queryClickhouse, queryClickhouseSaved } from "lib/clickhouse";
 import {
@@ -239,6 +240,27 @@ export async function updateDrciComments(
         UNKNOWN: unknownJobs,
         AWAITING_APPROVAL: awaitingApprovalJobs,
       };
+
+      // Auto-dispatch the AI CI Advisor on NEW failures. No-op unless the
+      // feature flag + production env + per-repo config are all set; dispatch
+      // only (no comment/merge changes), with its own ClickHouse dedup +
+      // outage guard. Wrapped so an advisor error can never break the comment.
+      try {
+        await autoDispatchAdvisorForNewFailures({
+          owner,
+          repo,
+          prNumber: pr_info.pr_number,
+          headSha: pr_info.head_sha,
+          mergeBaseSha: pr_info.merge_base,
+          newFailures: failedJobs,
+        });
+      } catch (e) {
+        console.error(
+          "advisor auto-dispatch threw for PR",
+          pr_info.pr_number,
+          e
+        );
+      }
 
       const failureInfo = constructResultsComment(
         pending,

--- a/torchci/test/advisorConfig.test.ts
+++ b/torchci/test/advisorConfig.test.ts
@@ -1,0 +1,19 @@
+import {
+  getAdvisorRepoConfig,
+  isAdvisorEnabled,
+} from "lib/advisor/advisorConfig";
+
+describe("advisorConfig", () => {
+  it("returns config for an enabled repo", () => {
+    const cfg = getAdvisorRepoConfig("pytorch", "pytorch");
+    expect(cfg).toBeDefined();
+    expect(cfg?.workflowFile).toBe("claude-autorevert-advisor.yml");
+    expect(isAdvisorEnabled("pytorch", "pytorch")).toBe(true);
+  });
+
+  it("returns undefined / false for a disabled repo", () => {
+    expect(getAdvisorRepoConfig("pytorch", "vision")).toBeUndefined();
+    expect(isAdvisorEnabled("pytorch", "vision")).toBe(false);
+    expect(isAdvisorEnabled("some", "other")).toBe(false);
+  });
+});

--- a/torchci/test/advisorDispatch.test.ts
+++ b/torchci/test/advisorDispatch.test.ts
@@ -1,0 +1,245 @@
+import { DEFAULT_MAX_NEW_FAILURES } from "lib/advisor/advisorConfig";
+import {
+  autoDispatchAdvisorForNewFailures,
+  AutoDispatchDeps,
+  MAX_DISPATCH_RETRIES,
+  signalKeyForJob,
+} from "lib/advisor/advisorDispatch";
+import { RecentWorkflowsData } from "lib/types";
+
+const VALID_SHA = "a".repeat(40);
+
+function job(
+  name: string,
+  conclusion = "failure",
+  failure_captures: string[] = []
+): RecentWorkflowsData {
+  return {
+    name,
+    conclusion,
+    failure_captures,
+  } as unknown as RecentWorkflowsData;
+}
+
+function makeDeps(overrides: Partial<AutoDispatchDeps> = {}): AutoDispatchDeps {
+  return {
+    readDispatchStates: jest.fn().mockResolvedValue(new Map()),
+    recordDispatch: jest.fn().mockResolvedValue(undefined),
+    dispatchAdvisorWorkflow: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+const baseArgs = {
+  owner: "pytorch",
+  repo: "pytorch",
+  prNumber: 123,
+  headSha: VALID_SHA,
+  mergeBaseSha: "b".repeat(40),
+};
+
+describe("autoDispatchAdvisorForNewFailures", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...OLD_ENV };
+    process.env.DRCI_ADVISOR_AUTODISPATCH_ENABLED = "true";
+    process.env.VERCEL_ENV = "production";
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    jest.restoreAllMocks();
+  });
+
+  it("no-ops when the feature flag is off", async () => {
+    process.env.DRCI_ADVISOR_AUTODISPATCH_ENABLED = "false";
+    const deps = makeDeps();
+    await autoDispatchAdvisorForNewFailures(
+      { ...baseArgs, newFailures: [job("wf / a")] },
+      deps
+    );
+    expect(deps.readDispatchStates).not.toHaveBeenCalled();
+    expect(deps.dispatchAdvisorWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when not in production", async () => {
+    process.env.VERCEL_ENV = "preview";
+    const deps = makeDeps();
+    await autoDispatchAdvisorForNewFailures(
+      { ...baseArgs, newFailures: [job("wf / a")] },
+      deps
+    );
+    expect(deps.dispatchAdvisorWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("no-ops for a repo without advisor config", async () => {
+    const deps = makeDeps();
+    await autoDispatchAdvisorForNewFailures(
+      { ...baseArgs, repo: "vision", newFailures: [job("wf / a")] },
+      deps
+    );
+    expect(deps.dispatchAdvisorWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("dispatches each new failure with pre/post writes", async () => {
+    const deps = makeDeps();
+    await autoDispatchAdvisorForNewFailures(
+      { ...baseArgs, newFailures: [job("wf / a"), job("wf / b")] },
+      deps
+    );
+    expect(deps.dispatchAdvisorWorkflow).toHaveBeenCalledTimes(2);
+    // 2 jobs x (dispatching + dispatched)
+    expect(deps.recordDispatch).toHaveBeenCalledTimes(4);
+    const states = (deps.recordDispatch as jest.Mock).mock.calls.map(
+      (c) => c[0].state
+    );
+    expect(states).toEqual([
+      "dispatching",
+      "dispatched",
+      "dispatching",
+      "dispatched",
+    ]);
+    expect(deps.dispatchAdvisorWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({ jobName: "wf / a", workflowName: "wf" })
+    );
+  });
+
+  it("excludes cancelled jobs", async () => {
+    const deps = makeDeps();
+    await autoDispatchAdvisorForNewFailures(
+      {
+        ...baseArgs,
+        newFailures: [job("wf / a", "cancelled"), job("wf / b")],
+      },
+      deps
+    );
+    expect(deps.dispatchAdvisorWorkflow).toHaveBeenCalledTimes(1);
+    expect(deps.dispatchAdvisorWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({ jobName: "wf / b" })
+    );
+  });
+
+  it("skips jobs already dispatching or dispatched", async () => {
+    const states = new Map([
+      [
+        signalKeyForJob("wf / a"),
+        { state: "dispatched" as const, retryCount: 0 },
+      ],
+      [
+        signalKeyForJob("wf / b"),
+        { state: "dispatching" as const, retryCount: 0 },
+      ],
+    ]);
+    const deps = makeDeps({
+      readDispatchStates: jest.fn().mockResolvedValue(states),
+    });
+    await autoDispatchAdvisorForNewFailures(
+      { ...baseArgs, newFailures: [job("wf / a"), job("wf / b")] },
+      deps
+    );
+    expect(deps.dispatchAdvisorWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("does not retry a failed job that is out of retries", async () => {
+    const states = new Map([
+      [
+        signalKeyForJob("wf / a"),
+        { state: "failed" as const, retryCount: MAX_DISPATCH_RETRIES },
+      ],
+    ]);
+    const deps = makeDeps({
+      readDispatchStates: jest.fn().mockResolvedValue(states),
+    });
+    await autoDispatchAdvisorForNewFailures(
+      { ...baseArgs, newFailures: [job("wf / a")] },
+      deps
+    );
+    expect(deps.dispatchAdvisorWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("retries a failed job under the retry limit and increments retry_count", async () => {
+    const states = new Map([
+      [signalKeyForJob("wf / a"), { state: "failed" as const, retryCount: 1 }],
+    ]);
+    const deps = makeDeps({
+      readDispatchStates: jest.fn().mockResolvedValue(states),
+    });
+    await autoDispatchAdvisorForNewFailures(
+      { ...baseArgs, newFailures: [job("wf / a")] },
+      deps
+    );
+    expect(deps.dispatchAdvisorWorkflow).toHaveBeenCalledTimes(1);
+    expect(deps.recordDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ state: "dispatching", retryCount: 2 })
+    );
+  });
+
+  it("fails closed when the dedup read throws (dispatches nothing)", async () => {
+    const deps = makeDeps({
+      readDispatchStates: jest.fn().mockRejectedValue(new Error("CH down")),
+    });
+    await autoDispatchAdvisorForNewFailures(
+      { ...baseArgs, newFailures: [job("wf / a")] },
+      deps
+    );
+    expect(deps.recordDispatch).not.toHaveBeenCalled();
+    expect(deps.dispatchAdvisorWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("aborts the PR when the pre-dispatch write throws", async () => {
+    const deps = makeDeps({
+      recordDispatch: jest.fn().mockRejectedValue(new Error("write down")),
+    });
+    await autoDispatchAdvisorForNewFailures(
+      { ...baseArgs, newFailures: [job("wf / a"), job("wf / b")] },
+      deps
+    );
+    // Pre-write attempted once, then aborts before dispatching anything.
+    expect(deps.recordDispatch).toHaveBeenCalledTimes(1);
+    expect(deps.dispatchAdvisorWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("records a failed state when the dispatch throws", async () => {
+    const deps = makeDeps({
+      dispatchAdvisorWorkflow: jest.fn().mockRejectedValue(new Error("gh 500")),
+    });
+    await autoDispatchAdvisorForNewFailures(
+      { ...baseArgs, newFailures: [job("wf / a")] },
+      deps
+    );
+    const states = (deps.recordDispatch as jest.Mock).mock.calls.map(
+      (c) => c[0].state
+    );
+    expect(states).toEqual(["dispatching", "failed"]);
+  });
+
+  it("bails entirely when new failures exceed the per-repo max", async () => {
+    const failures = Array.from(
+      { length: DEFAULT_MAX_NEW_FAILURES + 1 },
+      (_, i) => job(`wf / job-${i}`)
+    );
+    const deps = makeDeps();
+    await autoDispatchAdvisorForNewFailures(
+      { ...baseArgs, newFailures: failures },
+      deps
+    );
+    // Bails before even reading dedup state.
+    expect(deps.readDispatchStates).not.toHaveBeenCalled();
+    expect(deps.dispatchAdvisorWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("dispatches all when new failures are exactly at the max", async () => {
+    const failures = Array.from({ length: DEFAULT_MAX_NEW_FAILURES }, (_, i) =>
+      job(`wf / job-${i}`)
+    );
+    const deps = makeDeps();
+    await autoDispatchAdvisorForNewFailures(
+      { ...baseArgs, newFailures: failures },
+      deps
+    );
+    expect(deps.dispatchAdvisorWorkflow).toHaveBeenCalledTimes(
+      DEFAULT_MAX_NEW_FAILURES
+    );
+  });
+});


### PR DESCRIPTION
**⚠️ Stacked on #8195** (the dispatch-extraction refactor) — this PR is based on `iz/advisor-refactor`, so the diff here is **only the new functionality**. Review/land #8195 first; this will retarget to `main` once it lands.

Part 1 of the "auto-run CI Advisor on Dr.CI new failures" workstream, shipped **dark**: dispatch-only, feature-flagged, and prod-gated, so merging is inert until `DRCI_ADVISOR_AUTODISPATCH_ENABLED=true` **and** `VERCEL_ENV=production` **and** an `advisorConfig` entry are all present.

## What this does
On every Dr.CI pass, after classification, auto-dispatch the AI advisor on each **NEW failure** (the `FAILED` bucket, cancelled jobs excluded) for enabled repos — reusing the shared dispatch lib from #8195 plus the existing advisor workflow + verdict store + PR/HUD verdict UI (which light up for free via the `dr_ci_${jobName}` signal-key convention).

## Reliable dedup (no dispatch storms)
Dedup keys off a durable **dispatch marker**, not the verdict row (a verdict-write failure must not cause re-dispatch).
- **`misc.ai_advisor_dispatches`** (new CH table): `SharedReplacingMergeTree`, `ORDER BY (owner, repo, head_sha, signal_key)`; the replacing `version` is deliberately **not** in `ORDER BY` so the pre/post rows collapse. No TTL — `head_sha` rotates on every push.
- **Two-phase write**: a `dispatching` row is written **before** the dispatch and gates it (write-path down ⇒ don't dispatch); `dispatched` on success; a `failed` row supersedes for bounded retry (`retry_count` ≤ `MAX_DISPATCH_RETRIES`).
- **Fails closed**: dedup read throws ⇒ dispatch nothing.

## Outage guard (per-repo)
`AdvisorRepoConfig.maxNewFailures` (default 8): if a PR has more NEW failures than the max, **bail entirely** — a flood is almost always an outage, not a PR problem.

## Storm guard
`request: { retries: 0 }` on the dispatch — GitHub's `workflow_dispatch` POST is non-idempotent and the default Octokit retry would create dup runs on a 5xx (the 2026-05-08 autorevert storm).

## Per-repo config (manual + auto)
`lib/advisor/advisorConfig.ts` is the single source of truth: gates the auto loop, the manual endpoint (404 for non-enabled repos), and the manual button's visibility. Initial config: `pytorch/pytorch`.

## Minimal `drci.ts` change
The auto-dispatch is a single try/catch after the `failures` map is built; the existing comment / early-return / check-run structure is untouched.

## ⚠️ Manual steps before enabling
1. Create the `misc.ai_advisor_dispatches` table (`schema.sql`). HUD's read/write users already hold DB-level access (no committed grants needed; `hud_user` SELECT verified).
2. Set `DRCI_ADVISOR_AUTODISPATCH_ENABLED=true` in the prod Vercel env.

## Test plan
- `tsc --noEmit` clean; local lintrunner clean (incl. SQLFLUFF).
- Unit tests: env/config gating, dedup skip states, retry bound, fail-closed read, pre-write-gate abort, dispatch-failure recording, outage bail (>max) + dispatch-all (=max), cancelled-job exclusion. (jest runs in CI on node 20.)

## Not in this PR
- Verdicts inline in the Dr.CI comment (part 3); auto-suppress at merge (part 4); HUD PR-view classification reconcile (part 2).