### PR TITLE
[autorevert] born-red: order-independent detection (pending head + interleaved gaps)

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/job_agg_index.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/job_agg_index.py
@@ -46,6 +46,11 @@ class JobMeta:
       skip when an upstream dependency was cancelled/failed). Requires
       ALL rows skipped so a real attempt that ran alongside a skipped
       shard still drives the verdict.
+    - is_workflow_dispatch: True if the run was triggered via workflow_dispatch
+      (how autorevert fires its own restarts). Such runs are job/test-filtered
+      and therefore cannot establish a born-red baseline (a concluded dispatch
+      with no event for a test is not proof the test was absent). Does not
+      affect `status`.
     - has_failures: True if any grouped row is a failure (KG-adjusted conclusion).
       If True, overall status resolves to FAILURE.
     - all_completed_success: True if all grouped rows completed successfully. If
@@ -60,6 +65,7 @@ class JobMeta:
     is_pending: bool = False
     is_cancelled: bool = False
     is_skipped: bool = False
+    is_workflow_dispatch: bool = False
     has_failures: bool = False
     all_completed_success: bool = False
     has_non_test_failures: bool = False
@@ -186,6 +192,8 @@ class JobAggIndex(Generic[KeyT]):
             is_pending=(any(r.is_pending for r in jrows)),
             is_cancelled=(any(r.is_cancelled for r in jrows)),
             is_skipped=(all(r.is_skipped for r in jrows)),
+            # All rows here share one wf_run_id, hence one trigger.
+            is_workflow_dispatch=(any(r.is_workflow_dispatch for r in jrows)),
             has_failures=(any(r.is_failure for r in jrows)),
             all_completed_success=(all(r.is_success for r in jrows)),
             has_non_test_failures=(

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -540,10 +540,10 @@ class Signal:
 
         The strict shape was abandoned because it never matched real trunk
         signals: the newest commits are almost always still running (pending),
-        and the test legitimately isn't observed on every commit (sharding /
-        TD), so empty commits are interleaved among the failures. Both of those
-        defeated the old contiguous walk. This predicate ignores ordering and
-        ignores pending commits entirely.
+        and *pending* commits (jobs not finished yet) also appear interleaved
+        between the failures and the older baseline. Both of those defeated the
+        old contiguous walk. This predicate ignores ordering and ignores
+        pending commits entirely for the suspect decision.
 
         Born-red requires (the caller guarantees `not has_successes()`):
         - ≥1 failing commit; the suspect is the OLDEST *observed* failing
@@ -577,13 +577,14 @@ class Signal:
 
         `unknown` carries the *introduction gap*: commits strictly between the
         suspect and the newest concluded baseline. Uncovered ones — *unrun*
-        commits (`not job_group_concluded and not events`: no jobs ever
-        scheduled, e.g. the stack-middle commits when a ghstack lands and
-        `push` only runs jobs for the stack head) — are bisection candidates
-        the caller restarts via `cover_gap_unknown_commits` to find the true
-        introducer. Pending gap commits sit here too but act as already-covered
-        separators (they have events). Commits older than the newest baseline
-        are past proven absence and are not included.
+        commits (`not job_group_concluded and not events`: no job result for
+        this test, because the job was never scheduled (ghstack lands a stack
+        and `push` only runs jobs for the stack head), the test did not run, or
+        it crashed without reporting) — are bisection candidates the caller
+        restarts via `cover_gap_unknown_commits` to find the true introducer.
+        Pending gap commits sit here too but act as already-covered separators
+        (they have events). Commits older than the newest baseline are past
+        proven absence and are not included.
 
         `failed` = all failing commits (newest first; `failed[-1]` is the
         suspect); `successful` = concluded baseline commits older than the

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -546,19 +546,34 @@ class Signal:
         ignores pending commits entirely.
 
         Born-red requires (the caller guarantees `not has_successes()`):
+        - ≥1 failing commit; the suspect is the OLDEST *observed* failing
+          commit (the introduction point). `failed` collects every failing
+          commit so the caller's distinct-commit threshold and pattern builder
+          work unchanged.
         - ≥1 *concluded baseline* commit OLDER than the suspect — a commit
           where the test's job group ran to conclusion but produced no event
           for this test (`job_group_concluded and not events`). That is proof
           the test was genuinely absent there, as opposed to a commit whose
           jobs are merely still pending and carry no information yet.
-        - ≥1 failing commit; the suspect is the OLDEST failing commit (the
-          introduction point). `failed` collects every failing commit so the
-          caller's distinct-commit threshold and pattern builder work unchanged.
-        - An unambiguous introduction boundary: no unconcluded (pending)
-          commit sits between the suspect and the nearest older concluded
-          baseline. If one does, it might itself be the real introducer, so we
-          return None and defer to a later tick rather than dispatch the
-          advisor on a too-new suspect (which would read the wrong diff).
+
+        Pending commits are ignored wherever they sit — at the head, *or*
+        interleaved in the introduction gap between the suspect and the
+        baseline. The advisor is dispatched on the oldest observed failure
+        now, rather than deferring until every gap commit settles. If a
+        pending gap commit later concludes to a failure older than the current
+        suspect, the suspect moves and a second advisor runs on the corrected
+        commit; the stale verdict on the too-new suspect is keyed to that
+        commit (`_check_advisor_verdict` matches on `failed[-1]`; dedup/caps in
+        `SignalActionsLogger` are per-(commit, signal_key)) and is never
+        consulted for the corrected suspect. On real `autorevert_state` data
+        this costs ≤1 superfluous advisor run per episode, usually 0.
+
+        This is an accepted precision/latency tradeoff, not a free lunch: the
+        advisor reads the too-new suspect's diff, and while it almost always
+        returns `not_related` (the commit didn't introduce the test), a
+        confident wrong verdict is possible — bounded by the
+        `ADVISOR_CONFIDENCE_THRESHOLD` gate. We prefer that bounded risk over
+        deferring every born-red episode until its introduction gap settles.
 
         `failed` = all failing commits (newest first; `failed[-1]` is the
         suspect); `successful` = concluded baseline commits older than the
@@ -572,26 +587,17 @@ class Signal:
         if not failed:
             return None
 
-        # Suspect = oldest failing commit (the introduction point).
+        # Suspect = oldest observed failing commit (the introduction point).
         suspect_idx = max(i for i, c in enumerate(self.commits) if c.has_failure)
         older = self.commits[suspect_idx + 1 :]
 
+        # ≥1 concluded-empty baseline older than the suspect is positive proof
+        # the test was absent before it. Pending commits in the gap carry no
+        # information yet and are ignored (see docstring) rather than deferred
+        # on — we dispatch on the oldest observed failure.
         baseline = [c for c in older if c.job_group_concluded and not c.events]
         if not baseline:
             return None
-
-        # Introduction-boundary gate: walk commits older than the suspect; the
-        # first concluded baseline confirms the boundary, but an unconcluded
-        # (pending) commit encountered first means the true introducer is
-        # ambiguous — defer.
-        for c in older:
-            if c.job_group_concluded and not c.events:
-                break  # reached the baseline with no pending gap in between
-            if not c.job_group_concluded:
-                return None  # pending / unresolved in the introduction gap
-            # A concluded commit WITH events older than the suspect would be a
-            # failure older than the oldest failure (no successes exist) —
-            # impossible by construction; ignore defensively and keep scanning.
 
         return PartitionedCommits(failed=failed, unknown=[], successful=baseline)
 

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -530,67 +530,41 @@ class Signal:
         return PartitionedCommits(failed=failed, unknown=unknown, successful=successful)
 
     def partition_born_red(self) -> Optional[PartitionedCommits]:
-        """Partition for the test-track "born-red" pattern (order-independent).
+        """Detect the test-track "born-red" pattern (order-independent).
 
-        A test introduced — or enabled / un-skipped / renamed-into-existence —
-        already broken has no green observation to bisect, so the green→red
-        partition path bails with NO_SUCCESSES and the advisor is never asked.
-        This detects that case from the signal *contents* rather than a strict
-        `[FAIL...][EMPTY...]` shape.
+        A test introduced already-broken — added, enabled / un-skipped, or
+        renamed-into-existence — has no green run to bisect, so the green→red
+        path bails with NO_SUCCESSES without asking the advisor. This recognizes
+        that case from the signal contents.
 
-        The strict shape was abandoned because it never matched real trunk
-        signals: the newest commits are almost always still running (pending),
-        and *pending* commits (jobs not finished yet) also appear interleaved
-        between the failures and the older baseline. Both of those defeated the
-        old contiguous walk. This predicate ignores ordering and ignores
-        pending commits entirely for the suspect decision.
+        Test-track only; the caller guarantees `not has_successes()`. Returns a
+        partition when both hold:
+        - ≥1 failing commit — the suspect is the OLDEST failing one (the
+          introduction point);
+        - ≥1 *concluded baseline* commit older than the suspect: its job group
+          ran to a terminal conclusion but recorded no event for this test
+          (`job_group_concluded and not events`), proving the test was genuinely
+          absent there. A pending or unrun commit is not a baseline — it carries
+          no information.
 
-        Born-red requires (the caller guarantees `not has_successes()`):
-        - ≥1 failing commit; the suspect is the OLDEST *observed* failing
-          commit (the introduction point). `failed` collects every failing
-          commit so the caller's distinct-commit threshold and pattern builder
-          work unchanged.
-        - ≥1 *concluded baseline* commit OLDER than the suspect — a commit
-          where the test's job group ran to conclusion but produced no event
-          for this test (`job_group_concluded and not events`). That is proof
-          the test was genuinely absent there, as opposed to a commit whose
-          jobs are merely still pending and carry no information yet.
+        Ordering and pending commits are ignored for the suspect choice: act on
+        the oldest *observed* failure now instead of waiting for in-flight
+        commits to settle. A pending gap commit that later concludes to an older
+        failure simply moves the suspect; the stale verdict on the too-new one
+        is keyed per-(commit, signal_key) and never reused.
 
-        Pending commits are ignored for the *suspect* decision wherever they
-        sit — at the head, *or* interleaved in the introduction gap between the
-        suspect and the baseline. The advisor is dispatched on the oldest
-        observed failure now, rather than deferring until every gap commit
-        settles. If a pending gap commit later concludes to a failure older
-        than the current suspect, the suspect moves and a second advisor runs
-        on the corrected commit; the stale verdict on the too-new suspect is
-        keyed to that commit (`_check_advisor_verdict` matches on `failed[-1]`;
-        dedup/caps in `SignalActionsLogger` are per-(commit, signal_key)) and is
-        never consulted for the corrected suspect. On real `autorevert_state`
-        data this costs ≤1 superfluous advisor run per episode, usually 0.
-
-        This is an accepted precision/latency tradeoff, not a free lunch: the
-        advisor reads the too-new suspect's diff, and while it almost always
-        returns `not_related` (the commit didn't introduce the test), a
-        confident wrong verdict is possible — bounded by the
-        `ADVISOR_CONFIDENCE_THRESHOLD` gate. We prefer that bounded risk over
-        deferring every born-red episode until its introduction gap settles.
-
-        `unknown` carries the *introduction gap*: commits strictly between the
-        suspect and the newest concluded baseline. Uncovered ones — *unrun*
-        commits (`not job_group_concluded and not events`: no job result for
-        this test, because the job was never scheduled (ghstack lands a stack
-        and `push` only runs jobs for the stack head), the test did not run, or
-        it crashed without reporting) — are bisection candidates the caller
-        restarts via `cover_gap_unknown_commits` to find the true introducer.
-        Pending gap commits sit here too but act as already-covered separators
-        (they have events). Commits older than the newest baseline are past
-        proven absence and are not included.
-
-        `failed` = all failing commits (newest first; `failed[-1]` is the
-        suspect); `successful` = concluded baseline commits older than the
-        suspect (relabeled `no_signal` in the advisor JSON via
-        `DispatchAdvisor.is_born_red`); `unknown` = introduction-gap commits to
-        cover by restart.
+        Partition layout:
+        - `failed`: every failing commit, newest first; `failed[-1]` = suspect.
+        - `successful`: concluded baselines older than the suspect (relabeled
+          `no_signal` in the advisor JSON via `DispatchAdvisor.is_born_red`);
+          `successful[0]` = newest baseline.
+        - `unknown`: the *introduction gap* — commits strictly between the
+          suspect and the newest baseline. *Unrun* ones (no job result: a job
+          never scheduled — e.g. a ghstack stack-middle, since `push` only runs
+          jobs for the stack head — the test not run, or a crash without
+          reporting) are restarted by the caller (`cover_gap_unknown_commits`)
+          to bisect the true introducer; pending commits here are
+          already-covered separators.
         """
         if self.has_successes():
             return None

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -176,9 +176,18 @@ class SignalCommit:
         timestamp: datetime,
         events: List[SignalEvent],
         advisor_result: Optional[AIAdvisorResult] = None,
+        job_group_concluded: bool = False,
     ):
         self.head_sha = head_sha
         self.timestamp = timestamp
+        # For TEST signals: True when the test's job group (workflow,
+        # job_base_name) ran to a terminal conclusion on this commit — i.e.
+        # the jobs that would have run this test are done, not still pending.
+        # A concluded commit with no events for this test is positive proof
+        # the test was genuinely absent / not-yet-failing there (the born-red
+        # baseline), as opposed to a commit whose jobs simply have not
+        # finished yet and carry no information.
+        self.job_group_concluded = job_group_concluded
         # enforce events ordered by time, then by wf_run_id (oldest first)
         self.events = (
             sorted(events, key=lambda e: (e.started_at, e.wf_run_id)) if events else []
@@ -201,6 +210,9 @@ class SignalCommit:
             "timestamp": changes.pop("timestamp", self.timestamp),
             "events": changes.pop("events", self.events),
             "advisor_result": changes.pop("advisor_result", self.advisor_result),
+            "job_group_concluded": changes.pop(
+                "job_group_concluded", self.job_group_concluded
+            ),
         }
         if changes:
             raise TypeError(
@@ -518,45 +530,68 @@ class Signal:
         return PartitionedCommits(failed=failed, unknown=unknown, successful=successful)
 
     def partition_born_red(self) -> Optional[PartitionedCommits]:
-        """Partition for the test-track "born-red" pattern: failing head + empty-events tail.
+        """Partition for the test-track "born-red" pattern (order-independent).
 
-        Returns a partition only when the signal shape is `[FAIL...][EMPTY...]`
-        (newest → oldest) with no interleaving:
-        - At least 2 commits in window
-        - No commits with success events (otherwise the main partition path applies)
-        - At least 1 commit with failure events at the head
-        - At least 1 trailing commit with no events — these are commits where this
-          test did not run or did not yet exist, used as the implicit baseline
-          ("commits without the signal")
-        - No pending-only or other-shape commits in between
+        A test introduced — or enabled / un-skipped / renamed-into-existence —
+        already broken has no green observation to bisect, so the green→red
+        partition path bails with NO_SUCCESSES and the advisor is never asked.
+        This detects that case from the signal *contents* rather than a strict
+        `[FAIL...][EMPTY...]` shape.
 
-        Trailing empty-events commits are placed in `successful` so the advisor
-        check / pattern construction can reuse the standard primitives. The
-        advisor JSON layer relabels them via `DispatchAdvisor.is_born_red` so
-        the model is asked about test introduction, not green→red transition.
-        `unknown` is always empty — there is no gap to bisect.
+        The strict shape was abandoned because it never matched real trunk
+        signals: the newest commits are almost always still running (pending),
+        and the test legitimately isn't observed on every commit (sharding /
+        TD), so empty commits are interleaved among the failures. Both of those
+        defeated the old contiguous walk. This predicate ignores ordering and
+        ignores pending commits entirely.
+
+        Born-red requires (the caller guarantees `not has_successes()`):
+        - ≥1 *concluded baseline* commit OLDER than the suspect — a commit
+          where the test's job group ran to conclusion but produced no event
+          for this test (`job_group_concluded and not events`). That is proof
+          the test was genuinely absent there, as opposed to a commit whose
+          jobs are merely still pending and carry no information yet.
+        - ≥1 failing commit; the suspect is the OLDEST failing commit (the
+          introduction point). `failed` collects every failing commit so the
+          caller's distinct-commit threshold and pattern builder work unchanged.
+        - An unambiguous introduction boundary: no unconcluded (pending)
+          commit sits between the suspect and the nearest older concluded
+          baseline. If one does, it might itself be the real introducer, so we
+          return None and defer to a later tick rather than dispatch the
+          advisor on a too-new suspect (which would read the wrong diff).
+
+        `failed` = all failing commits (newest first; `failed[-1]` is the
+        suspect); `successful` = concluded baseline commits older than the
+        suspect (relabeled `no_signal` in the advisor JSON via
+        `DispatchAdvisor.is_born_red`); `unknown` = [] (nothing to bisect).
         """
-        if len(self.commits) < 2 or self.has_successes():
+        if self.has_successes():
             return None
 
-        failed: List[SignalCommit] = []
-        baseline: List[SignalCommit] = []
-        for c in self.commits:
-            if c.has_failure:
-                if baseline:
-                    # Failure after an empty-events commit (newer→older order) —
-                    # out of shape.
-                    return None
-                failed.append(c)
-            elif not c.events:
-                baseline.append(c)
-            else:
-                # Pending-only or other shape — bail; the advisor needs a clean
-                # introduction-vs-baseline split.
-                return None
-
-        if not failed or not baseline:
+        failed = [c for c in self.commits if c.has_failure]
+        if not failed:
             return None
+
+        # Suspect = oldest failing commit (the introduction point).
+        suspect_idx = max(i for i, c in enumerate(self.commits) if c.has_failure)
+        older = self.commits[suspect_idx + 1 :]
+
+        baseline = [c for c in older if c.job_group_concluded and not c.events]
+        if not baseline:
+            return None
+
+        # Introduction-boundary gate: walk commits older than the suspect; the
+        # first concluded baseline confirms the boundary, but an unconcluded
+        # (pending) commit encountered first means the true introducer is
+        # ambiguous — defer.
+        for c in older:
+            if c.job_group_concluded and not c.events:
+                break  # reached the baseline with no pending gap in between
+            if not c.job_group_concluded:
+                return None  # pending / unresolved in the introduction gap
+            # A concluded commit WITH events older than the suspect would be a
+            # failure older than the oldest failure (no successes exist) —
+            # impossible by construction; ignore defensively and keep scanning.
 
         return PartitionedCommits(failed=failed, unknown=[], successful=baseline)
 
@@ -650,8 +685,9 @@ class Signal:
         Default behavior: emit `Ineligible(NO_SUCCESSES)` with no advisor — the
         standard green→red partition has no anchor to work from.
 
-        Test-track exception (born-red detection): when the signal shape matches
-        `[FAIL...][EMPTY...]` (`partition_born_red` returns a partition), the
+        Test-track exception (born-red detection): when `partition_born_red`
+        returns a partition (≥1 failing commit + a concluded baseline commit
+        older than the suspect, with an unambiguous introduction boundary), the
         suspect commit is likely the one that introduced the test. Defer to the
         AI advisor:
         - If a prior advisor verdict exists on the suspect, act on it

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -556,17 +556,17 @@ class Signal:
           the test was genuinely absent there, as opposed to a commit whose
           jobs are merely still pending and carry no information yet.
 
-        Pending commits are ignored wherever they sit — at the head, *or*
-        interleaved in the introduction gap between the suspect and the
-        baseline. The advisor is dispatched on the oldest observed failure
-        now, rather than deferring until every gap commit settles. If a
-        pending gap commit later concludes to a failure older than the current
-        suspect, the suspect moves and a second advisor runs on the corrected
-        commit; the stale verdict on the too-new suspect is keyed to that
-        commit (`_check_advisor_verdict` matches on `failed[-1]`; dedup/caps in
-        `SignalActionsLogger` are per-(commit, signal_key)) and is never
-        consulted for the corrected suspect. On real `autorevert_state` data
-        this costs ≤1 superfluous advisor run per episode, usually 0.
+        Pending commits are ignored for the *suspect* decision wherever they
+        sit — at the head, *or* interleaved in the introduction gap between the
+        suspect and the baseline. The advisor is dispatched on the oldest
+        observed failure now, rather than deferring until every gap commit
+        settles. If a pending gap commit later concludes to a failure older
+        than the current suspect, the suspect moves and a second advisor runs
+        on the corrected commit; the stale verdict on the too-new suspect is
+        keyed to that commit (`_check_advisor_verdict` matches on `failed[-1]`;
+        dedup/caps in `SignalActionsLogger` are per-(commit, signal_key)) and is
+        never consulted for the corrected suspect. On real `autorevert_state`
+        data this costs ≤1 superfluous advisor run per episode, usually 0.
 
         This is an accepted precision/latency tradeoff, not a free lunch: the
         advisor reads the too-new suspect's diff, and while it almost always
@@ -575,10 +575,21 @@ class Signal:
         `ADVISOR_CONFIDENCE_THRESHOLD` gate. We prefer that bounded risk over
         deferring every born-red episode until its introduction gap settles.
 
+        `unknown` carries the *introduction gap*: commits strictly between the
+        suspect and the newest concluded baseline. Uncovered ones — *unrun*
+        commits (`not job_group_concluded and not events`: no jobs ever
+        scheduled, e.g. the stack-middle commits when a ghstack lands and
+        `push` only runs jobs for the stack head) — are bisection candidates
+        the caller restarts via `cover_gap_unknown_commits` to find the true
+        introducer. Pending gap commits sit here too but act as already-covered
+        separators (they have events). Commits older than the newest baseline
+        are past proven absence and are not included.
+
         `failed` = all failing commits (newest first; `failed[-1]` is the
         suspect); `successful` = concluded baseline commits older than the
         suspect (relabeled `no_signal` in the advisor JSON via
-        `DispatchAdvisor.is_born_red`); `unknown` = [] (nothing to bisect).
+        `DispatchAdvisor.is_born_red`); `unknown` = introduction-gap commits to
+        cover by restart.
         """
         if self.has_successes():
             return None
@@ -593,13 +604,24 @@ class Signal:
 
         # ≥1 concluded-empty baseline older than the suspect is positive proof
         # the test was absent before it. Pending commits in the gap carry no
-        # information yet and are ignored (see docstring) rather than deferred
-        # on — we dispatch on the oldest observed failure.
+        # information yet and are ignored for the suspect decision (see
+        # docstring) rather than deferred on — we dispatch on the oldest
+        # observed failure.
         baseline = [c for c in older if c.job_group_concluded and not c.events]
         if not baseline:
             return None
 
-        return PartitionedCommits(failed=failed, unknown=[], successful=baseline)
+        # Introduction gap = commits strictly between the suspect and the
+        # NEWEST concluded baseline. Unrun commits here (no jobs, no events) are
+        # bisection candidates the caller restarts; pending commits are covered
+        # separators. Everything older than the newest baseline is past proven
+        # absence and needs no coverage.
+        first_baseline_offset = next(
+            i for i, c in enumerate(older) if c.job_group_concluded and not c.events
+        )
+        gap = older[:first_baseline_offset]
+
+        return PartitionedCommits(failed=failed, unknown=gap, successful=baseline)
 
     # Minimum confidence threshold for acting on advisor verdicts
     ADVISOR_CONFIDENCE_THRESHOLD = 0.89
@@ -685,7 +707,9 @@ class Signal:
         # "unsure" or expired garbage → continue normally
         return None
 
-    def _handle_no_successes(self) -> Union[AutorevertPattern, Ineligible]:
+    def _handle_no_successes(
+        self, *, bisection_limit: Optional[int] = None
+    ) -> Union[AutorevertPattern, RestartCommits, Ineligible]:
         """Handle the `not has_successes()` branch.
 
         Default behavior: emit `Ineligible(NO_SUCCESSES)` with no advisor — the
@@ -693,13 +717,31 @@ class Signal:
 
         Test-track exception (born-red detection): when `partition_born_red`
         returns a partition (≥1 failing commit + a concluded baseline commit
-        older than the suspect, with an unambiguous introduction boundary), the
-        suspect commit is likely the one that introduced the test. Defer to the
-        AI advisor:
-        - If a prior advisor verdict exists on the suspect, act on it
-          (revert/related → `AutorevertPattern`; not_related/garbage → blocked).
-        - Otherwise, dispatch a fresh advisor request alongside the `Ineligible`
-          response. Next tick can act on the verdict.
+        older than the suspect), the suspect commit is likely the one that
+        introduced the test. Two actions, which can happen on the same tick:
+
+        1. **Cover the introduction gap.** Unrun commits between the suspect and
+           the baseline (e.g. ghstack stack-middles that `push` never scheduled
+           jobs for) are restarted via the same hybrid bisection the green→red
+           path uses (`cover_gap_unknown_commits`), so a later tick can pinpoint
+           the true introducer. This fires independent of the failing-commit
+           threshold — the ghstack case starts with a single observed failure.
+        2. **Dispatch / act on the advisor** (only with ≥2 distinct failing
+           commits). If a prior verdict exists on the suspect: revert/related →
+           `AutorevertPattern`; not_related/garbage → blocked (unless the gap
+           still has uncovered commits, in which case keep covering it — the
+           real introducer may be there). Otherwise dispatch a fresh advisor on
+           the oldest observed failure, *in parallel* with any gap restarts.
+
+        Option-A tradeoff: a confident revert/related verdict on the oldest
+        observed failure is acted on immediately, even if an unrun gap commit
+        below it has not yet concluded (so could in principle be an older, truer
+        introducer). This is bounded by the advisor's own semantics — it is
+        asked whether *this* commit's diff introduced the test, so it returns
+        revert only when it sees the introduction there — and by the
+        `ADVISOR_CONFIDENCE_THRESHOLD` gate. In the normal ghstack flow the gap
+        is already being restarted on earlier ticks, so by the time ≥2 failures
+        exist the suspect is usually the true (oldest) one.
 
         Advisor dedup + the per-(workflow, commit) cap of 8 are handled by
         `SignalActionsLogger`; this method just emits the request.
@@ -713,31 +755,50 @@ class Signal:
                 "no successful commits present in window",
             )
 
-        if len(born_red.failed) < self.REQUIRE_FAILED_COMMITS_BORN_RED:
-            # Not enough distinct failing commits to justify advisor cost —
-            # wait for the next trunk advance. Retries / multiple shards on a
-            # single commit do not count as independent observations.
+        # (1) Restart unrun commits in the introduction gap (bisection-limited).
+        # Independent of the failing-commit threshold: the ghstack case starts
+        # with one observed failure and needs the restarts to gather coverage.
+        restart_commits = born_red.cover_gap_unknown_commits(
+            bisection_limit=bisection_limit
+        )
+
+        # (2) Advisor path — only with ≥2 distinct failing commits. Retries /
+        # multiple shards on a single commit are one observation, not two.
+        advisor: Optional[DispatchAdvisor] = None
+        if len(born_red.failed) >= self.REQUIRE_FAILED_COMMITS_BORN_RED:
+            advisor_decision = self._check_advisor_verdict(born_red)
+            if isinstance(advisor_decision, AutorevertPattern):
+                # Confident revert/related on the suspect — act now.
+                return advisor_decision
+            if advisor_decision is not None:
+                # Block verdict (not_related / garbage) on the current suspect.
+                # If the gap still has uncovered commits, the real introducer
+                # may be there → keep covering it (fall through to restart, no
+                # fresh advisor). Otherwise surface the block.
+                if not restart_commits:
+                    return advisor_decision
+            else:
+                # No verdict yet — dispatch on the oldest observed failure, in
+                # parallel with any gap restarts. `successful_commits` carry the
+                # implicit baseline; `is_born_red=True` tells the advisor JSON
+                # builder to relabel them.
+                advisor = DispatchAdvisor(
+                    suspect_commit=born_red.failed[-1].head_sha,
+                    failed_commits=tuple(c.head_sha for c in born_red.failed),
+                    successful_commits=tuple(c.head_sha for c in born_red.successful),
+                    is_born_red=True,
+                )
+
+        if restart_commits:
+            return RestartCommits(commit_shas=restart_commits, advisor=advisor)
+
+        if advisor is None:
             return Ineligible(
                 IneligibleReason.NO_SUCCESSES,
                 f"born-red test signal: need ≥{self.REQUIRE_FAILED_COMMITS_BORN_RED} "
                 f"failing commits before advisor dispatch (have "
                 f"{len(born_red.failed)})",
             )
-
-        # If the advisor already weighed in on the suspect, use that verdict.
-        advisor_decision = self._check_advisor_verdict(born_red)
-        if advisor_decision is not None:
-            return advisor_decision
-
-        # No verdict yet — request one. `successful_commits` carry the implicit
-        # baseline (commits where the signal didn't exist); `is_born_red=True`
-        # tells the advisor JSON builder to relabel them accordingly.
-        advisor = DispatchAdvisor(
-            suspect_commit=born_red.failed[-1].head_sha,
-            failed_commits=tuple(c.head_sha for c in born_red.failed),
-            successful_commits=tuple(c.head_sha for c in born_red.successful),
-            is_born_red=True,
-        )
         return Ineligible(
             IneligibleReason.NO_SUCCESSES,
             "born-red test signal: no successful commits in window — advisor dispatched",
@@ -764,7 +825,7 @@ class Signal:
                 IneligibleReason.FIXED, "signal appears recovered at head"
             )
         if not self.has_successes():
-            return self._handle_no_successes()
+            return self._handle_no_successes(bisection_limit=bisection_limit)
 
         partition = self.partition_by_autorevert_pattern()
         if partition is None:

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -537,15 +537,16 @@ class Signal:
         path bails with NO_SUCCESSES without asking the advisor. This recognizes
         that case from the signal contents.
 
-        Test-track only; the caller guarantees `not has_successes()`. Returns a
-        partition when both hold:
-        - ≥1 failing commit — the suspect is the OLDEST failing one (the
-          introduction point);
-        - ≥1 *concluded baseline* commit older than the suspect: its job group
-          ran to a terminal conclusion but recorded no event for this test
-          (`job_group_concluded and not events`), proving the test was genuinely
-          absent there. A pending or unrun commit is not a baseline — it carries
-          no information.
+        Test-track only; the caller guarantees `not has_successes()` across the
+        full window. The partition is scoped to the most-recent *concluded
+        baseline* (`job_group_concluded and not events` — the latest commit
+        proving the test absent) and everything newer than it; commits older
+        than that baseline are out of scope. Returns a partition when, in scope:
+        - there is ≥1 failing commit — the suspect is the OLDEST failing one
+          (the introduction point).
+        A concluded baseline NEWER than every failure means the test was removed
+        / disabled again (recovered): the scope then holds no failure and
+        nothing fires — the born-red analog of "recovered at head".
 
         Ordering and pending commits are ignored for the suspect choice: act on
         the oldest *observed* failure now instead of waiting for in-flight
@@ -554,47 +555,49 @@ class Signal:
         is keyed per-(commit, signal_key) and never reused.
 
         Partition layout:
-        - `failed`: every failing commit, newest first; `failed[-1]` = suspect.
-        - `successful`: concluded baselines older than the suspect (relabeled
+        - `failed`: every in-scope failing commit, newest first; `failed[-1]` =
+          suspect.
+        - `successful`: the most-recent concluded baseline (relabeled
           `no_signal` in the advisor JSON via `DispatchAdvisor.is_born_red`);
-          `successful[0]` = newest baseline.
+          `successful[0]` = that baseline.
         - `unknown`: the *introduction gap* — commits strictly between the
-          suspect and the newest baseline. *Unrun* ones (no job result: a job
-          never scheduled — e.g. a ghstack stack-middle, since `push` only runs
-          jobs for the stack head — the test not run, or a crash without
-          reporting) are restarted by the caller (`cover_gap_unknown_commits`)
-          to bisect the true introducer; pending commits here are
-          already-covered separators.
+          suspect and the baseline. *Unrun* ones (no job result: a job never
+          scheduled — e.g. a ghstack stack-middle, since `push` only runs jobs
+          for the stack head — the test not run, or a crash without reporting)
+          are restarted by the caller (`cover_gap_unknown_commits`) to bisect
+          the true introducer; pending commits here are already-covered
+          separators.
         """
         if self.has_successes():
             return None
 
-        failed = [c for c in self.commits if c.has_failure]
+        # Scope to the most-recent concluded baseline (the latest proof the test
+        # was absent) and everything newer. A baseline NEWER than the failures
+        # means the test recovered — its stale failures fall out of scope.
+        baseline_idx = next(
+            (
+                i
+                for i, c in enumerate(self.commits)
+                if c.job_group_concluded and not c.events
+            ),
+            None,
+        )
+        if baseline_idx is None:
+            return None
+        window = self.commits[: baseline_idx + 1]
+
+        failed = [c for c in window if c.has_failure]
         if not failed:
             return None
 
-        # Suspect = oldest observed failing commit (the introduction point).
-        suspect_idx = max(i for i, c in enumerate(self.commits) if c.has_failure)
-        older = self.commits[suspect_idx + 1 :]
+        # Suspect = oldest observed failing commit in scope (introduction point).
+        suspect_idx = max(i for i, c in enumerate(window) if c.has_failure)
 
-        # ≥1 concluded-empty baseline older than the suspect is positive proof
-        # the test was absent before it. Pending commits in the gap carry no
-        # information yet and are ignored for the suspect decision (see
-        # docstring) rather than deferred on — we dispatch on the oldest
-        # observed failure.
-        baseline = [c for c in older if c.job_group_concluded and not c.events]
-        if not baseline:
-            return None
-
-        # Introduction gap = commits strictly between the suspect and the
-        # NEWEST concluded baseline. Unrun commits here (no jobs, no events) are
-        # bisection candidates the caller restarts; pending commits are covered
-        # separators. Everything older than the newest baseline is past proven
-        # absence and needs no coverage.
-        first_baseline_offset = next(
-            i for i, c in enumerate(older) if c.job_group_concluded and not c.events
-        )
-        gap = older[:first_baseline_offset]
+        # The most-recent concluded baseline (window's last commit, at
+        # `baseline_idx`) is the only one in scope; the introduction gap is
+        # everything strictly between it and the suspect.
+        baseline = [self.commits[baseline_idx]]
+        gap = window[suspect_idx + 1 : -1]
 
         return PartitionedCommits(failed=failed, unknown=gap, successful=baseline)
 

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -177,9 +177,19 @@ class SignalCommit:
         events: List[SignalEvent],
         advisor_result: Optional[AIAdvisorResult] = None,
         job_group_concluded: bool = False,
+        has_dispatch_run: bool = False,
     ):
         self.head_sha = head_sha
         self.timestamp = timestamp
+        # True when a `workflow_dispatch` run is present for the test's job
+        # group on this commit — i.e. it has already been restarted once (that
+        # is how autorevert fires its gap restarts). The gap-bisection
+        # (`cover_gap_unknown_commits`) treats such a commit as a covered
+        # separator — already probed, do not restart it again — so a gap commit
+        # is dispatched at most once. Distinct from `job_group_concluded`: a
+        # filtered dispatch can't establish a baseline (it may not have run this
+        # test), but its presence does mean "this commit was already probed".
+        self.has_dispatch_run = has_dispatch_run
         # For TEST signals: True when the test's job group (workflow,
         # job_base_name) ran to a terminal conclusion on this commit — i.e.
         # the jobs that would have run this test are done, not still pending.
@@ -213,6 +223,7 @@ class SignalCommit:
             "job_group_concluded": changes.pop(
                 "job_group_concluded", self.job_group_concluded
             ),
+            "has_dispatch_run": changes.pop("has_dispatch_run", self.has_dispatch_run),
         }
         if changes:
             raise TypeError(
@@ -293,6 +304,12 @@ class PartitionedCommits:
         using the hybrid bisection algorithm with an optional limit.
 
         - Already pending commits act as separators (covered=True)
+        - Commits we already dispatched a restart on (`has_dispatch_run`) are
+          also separators: they have been probed once, so we never restart the
+          same commit twice. If that probe found the test failing it surfaces a
+          FAILURE event (the commit leaves the gap and moves the suspect); if it
+          found the test absent there is no event, but we still must not
+          re-dispatch.
         - Missing commits are candidates (covered=False)
         - When limit is None: schedule all candidates
         - When limit is set: allowed = max(0, limit - currently_pending)
@@ -301,7 +318,7 @@ class PartitionedCommits:
         if not self.unknown:
             return set()
 
-        covered = [bool(c.events) for c in self.unknown]
+        covered = [bool(c.events) or c.has_dispatch_run for c in self.unknown]
         if all(covered) or bisection_limit == 0:
             return set()
 

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
@@ -417,6 +417,11 @@ class SignalExtractor:
                 # filtered and so cannot prove the test absent).
                 group_runs = 0
                 group_pending = False
+                # True once autorevert has dispatched a restart on this commit's
+                # job group (a workflow_dispatch run is present, pending or
+                # concluded). Drives `SignalCommit.has_dispatch_run` so the gap
+                # bisection won't restart the same commit twice.
+                group_had_dispatch = False
 
                 # x-axis: events for the signal
                 for wf_run_id, run_attempt in run_ids_attempts.get(
@@ -441,7 +446,11 @@ class SignalExtractor:
                     # emit their outcome/pending events below — so a gap-restart
                     # that the test fails still surfaces a FAILURE and moves the
                     # suspect — they just don't count toward `job_group_concluded`.
-                    if not meta.is_workflow_dispatch:
+                    if meta.is_workflow_dispatch:
+                        # A restart we already dispatched on this commit — probed
+                        # once, so the gap bisection must not restart it again.
+                        group_had_dispatch = True
+                    else:
                         group_runs += 1
                         if meta.is_pending:
                             group_pending = True
@@ -513,6 +522,7 @@ class SignalExtractor:
                         timestamp=commit_timestamps[commit_sha],
                         events=events,
                         job_group_concluded=(group_runs > 0 and not group_pending),
+                        has_dispatch_run=group_had_dispatch,
                     )
                 )
 

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
@@ -407,6 +407,14 @@ class SignalExtractor:
             # y-axis: commits (newest → older)
             for commit_sha, _ in commits:
                 events: List[SignalEvent] = []
+                # Track whether this test's job group ran to a terminal
+                # conclusion on this commit: ≥1 non-cancelled run and none of
+                # them still pending. A concluded commit with no events is a
+                # born-red baseline witness (the test was genuinely absent),
+                # as opposed to a commit whose jobs are still running and thus
+                # carry no information about whether the test exists yet.
+                group_runs = 0
+                group_pending = False
 
                 # x-axis: events for the signal
                 for wf_run_id, run_attempt in run_ids_attempts.get(
@@ -419,6 +427,9 @@ class SignalExtractor:
                     if meta.is_cancelled:
                         # canceled attempts are treated as missing
                         continue
+                    group_runs += 1
+                    if meta.is_pending:
+                        group_pending = True
                     outcome = tests_by_group_attempt.get(
                         (
                             commit_sha,
@@ -486,6 +497,7 @@ class SignalExtractor:
                         head_sha=commit_sha,
                         timestamp=commit_timestamps[commit_sha],
                         events=events,
+                        job_group_concluded=(group_runs > 0 and not group_pending),
                     )
                 )
 

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
@@ -424,8 +424,13 @@ class SignalExtractor:
                         (commit_sha, wf_name, job_base_name, wf_run_id, run_attempt),
                         default=JobMeta(),
                     )
-                    if meta.is_cancelled:
-                        # canceled attempts are treated as missing
+                    if meta.is_cancelled or meta.is_skipped:
+                        # Cancelled / skipped attempts are treated as missing
+                        # (same as JobMeta.status → None). A skipped job — an
+                        # `if:` gate, or a required-check skip when an upstream
+                        # dependency failed/cancelled — never ran the test, so
+                        # it is NOT proof the test was absent. Counting it would
+                        # fabricate a born-red baseline witness.
                         continue
                     group_runs += 1
                     if meta.is_pending:

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
@@ -408,11 +408,13 @@ class SignalExtractor:
             for commit_sha, _ in commits:
                 events: List[SignalEvent] = []
                 # Track whether this test's job group ran to a terminal
-                # conclusion on this commit: ≥1 non-cancelled run and none of
-                # them still pending. A concluded commit with no events is a
-                # born-red baseline witness (the test was genuinely absent),
-                # as opposed to a commit whose jobs are still running and thus
-                # carry no information about whether the test exists yet.
+                # conclusion on this commit via a NATURAL run: ≥1 non-cancelled,
+                # non-skipped, non-workflow_dispatch run, and none still pending.
+                # A naturally-concluded commit with no events is a born-red
+                # baseline witness (the test was genuinely absent), as opposed
+                # to a commit whose jobs are still running (no info yet) or were
+                # only exercised by an autorevert restart (which is job/test-
+                # filtered and so cannot prove the test absent).
                 group_runs = 0
                 group_pending = False
 
@@ -432,9 +434,17 @@ class SignalExtractor:
                         # it is NOT proof the test was absent. Counting it would
                         # fabricate a born-red baseline witness.
                         continue
-                    group_runs += 1
-                    if meta.is_pending:
-                        group_pending = True
+                    # Only NATURAL runs (push/schedule) establish the born-red
+                    # baseline. An autorevert workflow_dispatch restart is
+                    # job/test-filtered, so a concluded dispatch with no event
+                    # for this test is not proof of absence. Dispatch runs still
+                    # emit their outcome/pending events below — so a gap-restart
+                    # that the test fails still surfaces a FAILURE and moves the
+                    # suspect — they just don't count toward `job_group_concluded`.
+                    if not meta.is_workflow_dispatch:
+                        group_runs += 1
+                        if meta.is_pending:
+                            group_pending = True
                     outcome = tests_by_group_attempt.get(
                         (
                             commit_sha,

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_datasource.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_datasource.py
@@ -154,7 +154,11 @@ class SignalExtractionDatasource:
             wf.conclusion_kg AS conclusion_kg,
             wf.started_at,
             wf.created_at,
-            tupleElement(wf.torchci_classification_kg,'rule') AS rule
+            tupleElement(wf.torchci_classification_kg,'rule') AS rule,
+            -- Trigger of the run (push / schedule / workflow_dispatch / ...).
+            -- Used to exclude autorevert's own workflow_dispatch restarts from
+            -- establishing a born-red baseline (they are job/test-filtered).
+            wf.workflow_event AS workflow_event
         FROM default.workflow_job AS wf FINAL
         WHERE wf.repository_full_name = {{repo:String}}
           AND wf.head_sha IN {{head_shas:Array(String)}}
@@ -194,6 +198,7 @@ class SignalExtractionDatasource:
                     started_at,
                     created_at,
                     rule,
+                    workflow_event,
                 ) in res.result_rows:
                     # Guard against placeholder started_at by using the later of
                     # started_at and created_at as the effective start.
@@ -212,6 +217,7 @@ class SignalExtractionDatasource:
                             started_at=effective_started,
                             created_at=created_at,
                             rule=str(rule or ""),
+                            workflow_event=str(workflow_event or ""),
                         )
                     )
         dt = time.perf_counter() - t0

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_types.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_types.py
@@ -55,6 +55,11 @@ class JobRow:
     started_at: datetime
     created_at: datetime
     rule: str
+    # GitHub Actions trigger of the run this job belongs to (push / schedule /
+    # workflow_dispatch / ...). Default "" for callers that don't populate it
+    # (treated as a natural run). Autorevert's own restarts are
+    # `workflow_dispatch`; see `is_workflow_dispatch`.
+    workflow_event: str = ""
 
     @cached_property
     def base_name(self) -> JobBaseName:
@@ -138,6 +143,16 @@ class JobRow:
         # produced no signal-bearing outcome (e.g. `if:` gate, required-check
         # skip when an upstream dependency was cancelled/failed).
         return self._conclusion_l == "skipped"
+
+    @property
+    def is_workflow_dispatch(self) -> bool:
+        # True when this run was triggered via the GitHub workflow_dispatch
+        # API — which is how autorevert fires its own restarts. Such runs are
+        # job/test-filtered, so a concluded dispatch run with no event for a
+        # given test is NOT proof the test was absent (it may simply not have
+        # been in the dispatch's test filter). They must not establish a
+        # born-red baseline; see signal_extraction._build_test_signals.
+        return self.workflow_event.lower() == "workflow_dispatch"
 
     @property
     def is_failure(self) -> bool:

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
@@ -1367,7 +1367,8 @@ class TestBornRedTestSignal(unittest.TestCase):
         self.assertIsNotNone(part)
         assert part is not None  # narrow type for mypy
         self.assertEqual([c.head_sha for c in part.failed], ["f1", "f2"])
-        self.assertEqual([c.head_sha for c in part.successful], ["e1", "e2"])
+        # Scope stops at the most-recent baseline (e1); e2 is out of scope.
+        self.assertEqual([c.head_sha for c in part.successful], ["e1"])
         self.assertEqual(part.unknown, [])
 
     def test_partition_born_red_fires_despite_leading_pending(self):
@@ -1387,22 +1388,35 @@ class TestBornRedTestSignal(unittest.TestCase):
         self.assertEqual([c.head_sha for c in part.failed], ["f1", "f2"])
         self.assertEqual([c.head_sha for c in part.successful], ["e1"])
 
-    def test_partition_born_red_fires_with_interleaved_empty(self):
-        # A concluded-empty commit sits BETWEEN two failures (the test isn't
-        # observed on every commit — sharding / TD). The old strict shape
-        # rejected this; the set predicate does not.
+    def test_partition_born_red_scoped_to_most_recent_baseline(self):
+        # A concluded baseline (g1) sits between two failures: it proves the
+        # test was absent there, i.e. the older failure (f_old) belongs to a
+        # *prior* episode that already recovered. Scope is the most-recent
+        # baseline (g1) and newer, so only the newer failures fire on it.
         commits = [
             self._fail("f1", 0),
-            self._baseline("g1", -5),  # interleaved concluded-empty
-            self._fail("f2", -10),
+            self._fail("f2", -5),
+            self._baseline("g1", -10),  # most-recent baseline → scope boundary
+            self._fail("f_old", -15),  # pre-recovery failure, out of scope
             self._baseline("e1", -20),
         ]
         part = self._test_signal(commits).partition_born_red()
         self.assertIsNotNone(part)
         assert part is not None
-        # Suspect = oldest failure (f2); both failures collected.
         self.assertEqual([c.head_sha for c in part.failed], ["f1", "f2"])
-        self.assertEqual(part.failed[-1].head_sha, "f2")
+        self.assertEqual(part.failed[-1].head_sha, "f2")  # suspect = oldest in scope
+        self.assertEqual([c.head_sha for c in part.successful], ["g1"])
+
+    def test_partition_born_red_none_when_recovered_at_head(self):
+        # A concluded baseline NEWER than the failures (the test was removed /
+        # disabled again) → recovered. Scope = [C] only, holds no failure → None.
+        commits = [
+            self._baseline("c_head", 0),  # most-recent baseline, newer than fails
+            self._fail("f1", -10),
+            self._fail("f2", -20),
+            self._baseline("e1", -30),
+        ]
+        self.assertIsNone(self._test_signal(commits).partition_born_red())
 
     def test_partition_born_red_fires_with_unrun_in_introduction_gap(self):
         # An unrun (no jobs, no events) commit sits between the suspect and the
@@ -1449,12 +1463,12 @@ class TestBornRedTestSignal(unittest.TestCase):
         assert part is not None
         self.assertEqual([c.head_sha for c in part.failed], ["f3", "f4"])
         self.assertEqual(part.failed[-1].head_sha, "f4")  # suspect = oldest fail
-        # Baselines = concluded-empty commits older than the suspect.
-        self.assertEqual([c.head_sha for c in part.successful], ["c8", "c10"])
+        # Baseline = the most-recent concluded-empty (c8); c10 is out of scope.
+        self.assertEqual([c.head_sha for c in part.successful], ["c8"])
         # Introduction gap = commits strictly between suspect (f4) and the
-        # newest baseline (c8): the pending p5/p6/p7. They are covered
-        # separators (have events), so they trigger no restart — see the
-        # process-level test below.
+        # baseline (c8): the pending p5/p6/p7. They are covered separators
+        # (have events), so they trigger no restart — see the process-level
+        # test below.
         self.assertEqual([c.head_sha for c in part.unknown], ["p5", "p6", "p7"])
 
     def test_partition_born_red_none_without_concluded_baseline(self):
@@ -1511,14 +1525,14 @@ class TestBornRedTestSignal(unittest.TestCase):
 
     def test_process_dispatches_on_real_flip_shape(self):
         # Regression for the real-world shape that the old strict partition
-        # never fired on: pending head + a failure + an interleaved
-        # concluded-empty + another failure + concluded baseline tail.
-        # (Mirrors inductor flip_zero_dim_dynamic_shapes_cuda, 2026-05-21.)
+        # never fired on: pending head + a failure + an interleaved *pending*
+        # commit (jobs not finished yet) + another failure + concluded baseline
+        # tail. (Mirrors inductor flip_zero_dim_dynamic_shapes_cuda, 2026-05-21.)
         commits = [
             self._pending("p1", 30),
             self._pending("p2", 25),
             self._fail("f1", 20, job_id=11),
-            self._baseline("g1", 15),  # interleaved: test not observed here
+            self._pending("g1", 15),  # interleaved pending (not yet finished)
             self._fail("f2", 10, job_id=12),
             self._baseline("e1", 0),
             self._baseline("e2", -10),
@@ -1531,8 +1545,8 @@ class TestBornRedTestSignal(unittest.TestCase):
         # Suspect = oldest failure (f2); both failures reported.
         self.assertEqual(res.advisor.suspect_commit, "f2")
         self.assertEqual(res.advisor.failed_commits, ("f1", "f2"))
-        # Baseline = concluded-empty commits older than the suspect.
-        self.assertEqual(res.advisor.successful_commits, ("e1", "e2"))
+        # Baseline = the most-recent concluded-empty (e1); e2 is out of scope.
+        self.assertEqual(res.advisor.successful_commits, ("e1",))
 
     def test_process_holds_advisor_below_failing_commit_threshold(self):
         # Single failing commit — wait for the next trunk advance before paying

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
@@ -1404,17 +1404,52 @@ class TestBornRedTestSignal(unittest.TestCase):
         self.assertEqual([c.head_sha for c in part.failed], ["f1", "f2"])
         self.assertEqual(part.failed[-1].head_sha, "f2")
 
-    def test_partition_born_red_defers_on_pending_in_introduction_gap(self):
-        # An unconcluded (pending) commit between the suspect and the nearest
-        # older baseline could itself be the real introducer → defer (None)
-        # rather than dispatch on a too-new suspect.
+    def test_partition_born_red_fires_with_pending_in_introduction_gap(self):
+        # An unconcluded (pending) commit sits between the suspect and the
+        # nearest older baseline. We do NOT defer: dispatch on the oldest
+        # OBSERVED failure (f2) now. If p1 later concludes to a failure older
+        # than f2, the suspect moves and a second advisor runs on the corrected
+        # commit — accepted (≤1 superfluous, rare in practice).
         commits = [
             self._fail("f1", 0),
             self._fail("f2", -10),
-            self._unrun("p1", -15),  # unconcluded gap commit, no info yet
+            self._unrun("p1", -15),  # unconcluded gap commit, ignored
             self._baseline("e1", -20),
         ]
-        self.assertIsNone(self._test_signal(commits).partition_born_red())
+        part = self._test_signal(commits).partition_born_red()
+        self.assertIsNotNone(part)
+        assert part is not None
+        self.assertEqual([c.head_sha for c in part.failed], ["f1", "f2"])
+        self.assertEqual(part.failed[-1].head_sha, "f2")  # suspect = oldest fail
+        self.assertEqual([c.head_sha for c in part.successful], ["e1"])
+
+    def test_partition_born_red_fires_with_pending_head_and_gap(self):
+        # Full real-world shape (newest→oldest): a pending head, two failures,
+        # pending commits in the introduction gap, then concluded baselines
+        # with another pending interleaved among them:
+        #     P P P F F P P P C P C
+        # Born-red fires on the oldest observed failure (f4); every pending is
+        # ignored regardless of position.
+        commits = [
+            self._pending("p0", 100),
+            self._pending("p1", 90),
+            self._pending("p2", 80),
+            self._fail("f3", 70, job_id=13),
+            self._fail("f4", 60, job_id=14),
+            self._pending("p5", 50),
+            self._pending("p6", 40),
+            self._pending("p7", 30),
+            self._baseline("c8", 20),
+            self._pending("p9", 10),
+            self._baseline("c10", 0),
+        ]
+        part = self._test_signal(commits).partition_born_red()
+        self.assertIsNotNone(part)
+        assert part is not None
+        self.assertEqual([c.head_sha for c in part.failed], ["f3", "f4"])
+        self.assertEqual(part.failed[-1].head_sha, "f4")  # suspect = oldest fail
+        # Baselines = concluded-empty commits older than the suspect.
+        self.assertEqual([c.head_sha for c in part.successful], ["c8", "c10"])
 
     def test_partition_born_red_none_without_concluded_baseline(self):
         # The only empty commits are unconcluded (jobs not finished) → no proof

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
@@ -1404,16 +1404,15 @@ class TestBornRedTestSignal(unittest.TestCase):
         self.assertEqual([c.head_sha for c in part.failed], ["f1", "f2"])
         self.assertEqual(part.failed[-1].head_sha, "f2")
 
-    def test_partition_born_red_fires_with_pending_in_introduction_gap(self):
-        # An unconcluded (pending) commit sits between the suspect and the
-        # nearest older baseline. We do NOT defer: dispatch on the oldest
-        # OBSERVED failure (f2) now. If p1 later concludes to a failure older
-        # than f2, the suspect moves and a second advisor runs on the corrected
-        # commit — accepted (≤1 superfluous, rare in practice).
+    def test_partition_born_red_fires_with_unrun_in_introduction_gap(self):
+        # An unrun (no jobs, no events) commit sits between the suspect and the
+        # nearest older baseline. We do NOT defer the suspect decision: dispatch
+        # on the oldest OBSERVED failure (f2). The unrun commit lands in
+        # `unknown` so the caller can restart it to find the true introducer.
         commits = [
             self._fail("f1", 0),
             self._fail("f2", -10),
-            self._unrun("p1", -15),  # unconcluded gap commit, ignored
+            self._unrun("u1", -15),  # unrun gap commit → restart candidate
             self._baseline("e1", -20),
         ]
         part = self._test_signal(commits).partition_born_red()
@@ -1422,6 +1421,8 @@ class TestBornRedTestSignal(unittest.TestCase):
         self.assertEqual([c.head_sha for c in part.failed], ["f1", "f2"])
         self.assertEqual(part.failed[-1].head_sha, "f2")  # suspect = oldest fail
         self.assertEqual([c.head_sha for c in part.successful], ["e1"])
+        # Introduction gap = the unrun commit between suspect and baseline.
+        self.assertEqual([c.head_sha for c in part.unknown], ["u1"])
 
     def test_partition_born_red_fires_with_pending_head_and_gap(self):
         # Full real-world shape (newest→oldest): a pending head, two failures,
@@ -1450,6 +1451,11 @@ class TestBornRedTestSignal(unittest.TestCase):
         self.assertEqual(part.failed[-1].head_sha, "f4")  # suspect = oldest fail
         # Baselines = concluded-empty commits older than the suspect.
         self.assertEqual([c.head_sha for c in part.successful], ["c8", "c10"])
+        # Introduction gap = commits strictly between suspect (f4) and the
+        # newest baseline (c8): the pending p5/p6/p7. They are covered
+        # separators (have events), so they trigger no restart — see the
+        # process-level test below.
+        self.assertEqual([c.head_sha for c in part.unknown], ["p5", "p6", "p7"])
 
     def test_partition_born_red_none_without_concluded_baseline(self):
         # The only empty commits are unconcluded (jobs not finished) → no proof
@@ -1556,6 +1562,153 @@ class TestBornRedTestSignal(unittest.TestCase):
         self.assertIsInstance(res, Ineligible)
         self.assertEqual(res.reason, IneligibleReason.NO_SUCCESSES)
         self.assertIsNone(res.advisor)
+
+    def test_process_restarts_unrun_gap_and_dispatches_advisor_in_parallel(self):
+        # ≥2 failures + an unrun (no jobs, no events) commit in the introduction
+        # gap → restart the unrun commit to bisect AND dispatch the advisor on
+        # the oldest observed failure in the same tick (Option A).
+        commits = [
+            self._fail("f1", 0, job_id=11),
+            self._fail("f2", -10, job_id=12),
+            self._unrun("u1", -15),  # ghstack stack-middle: never scheduled
+            self._baseline("e1", -20),
+        ]
+        res = self._test_signal(commits).process_valid_autorevert_pattern()
+        self.assertIsInstance(res, RestartCommits)
+        assert isinstance(res, RestartCommits)
+        self.assertIn("u1", res.commit_shas)
+        # Advisor fires in parallel, on the oldest observed failure.
+        self.assertIsNotNone(res.advisor)
+        assert res.advisor is not None
+        self.assertEqual(res.advisor.suspect_commit, "f2")
+        self.assertTrue(res.advisor.is_born_red)
+
+    def test_process_ghstack_restarts_gap_below_single_failure(self):
+        # The motivating case: a ghstack of commits lands and introduces a
+        # broken test; `push` only runs jobs for the stack head, so the
+        # stack-middles are unrun. Only the head has failed so far (< 2
+        # observed failures → no advisor yet), but we still restart the unrun
+        # middles to gather the coverage needed to pinpoint the introducer.
+        commits = [
+            self._fail("head", 0, job_id=11),
+            self._unrun("mid1", -10),
+            self._unrun("mid2", -20),
+            self._baseline("base", -30),
+        ]
+        res = self._test_signal(commits).process_valid_autorevert_pattern()
+        self.assertIsInstance(res, RestartCommits)
+        assert isinstance(res, RestartCommits)
+        self.assertEqual(res.commit_shas, {"mid1", "mid2"})
+        # No advisor: only one observed failure so far.
+        self.assertIsNone(res.advisor)
+
+    def test_process_pending_gap_no_restart_dispatches_advisor(self):
+        # A *pending* (jobs running) commit in the gap is a covered separator,
+        # not a restart candidate — it resolves on its own. No restart; the
+        # advisor dispatches on the oldest observed failure.
+        commits = [
+            self._fail("f1", 0, job_id=11),
+            self._fail("f2", -10, job_id=12),
+            self._pending("p1", -15),  # jobs running — covered separator
+            self._baseline("e1", -20),
+        ]
+        res = self._test_signal(commits).process_valid_autorevert_pattern()
+        self.assertIsInstance(res, Ineligible)
+        self.assertEqual(res.reason, IneligibleReason.NO_SUCCESSES)
+        self.assertIsNotNone(res.advisor)
+        self.assertEqual(res.advisor.suspect_commit, "f2")
+
+    def test_process_restart_respects_bisection_limit(self):
+        # Three unrun commits in the gap, bisection_limit=1 → only the bisection
+        # midpoint is scheduled (the same hybrid planner the green→red path uses).
+        commits = [
+            self._fail("f1", 0, job_id=11),
+            self._fail("f2", -10, job_id=12),
+            self._unrun("u1", -15),
+            self._unrun("u2", -20),
+            self._unrun("u3", -25),
+            self._baseline("e1", -30),
+        ]
+        res = self._test_signal(commits).process_valid_autorevert_pattern(
+            bisection_limit=1
+        )
+        self.assertIsInstance(res, RestartCommits)
+        assert isinstance(res, RestartCommits)
+        self.assertEqual(len(res.commit_shas), 1)
+        self.assertTrue(res.commit_shas <= {"u1", "u2", "u3"})
+
+    def test_process_mixed_pending_and_unrun_gap_restarts_only_unrun(self):
+        # Gap holds one pending (covered separator) and one unrun (candidate).
+        # Only the unrun commit is restarted; the pending resolves on its own.
+        commits = [
+            self._fail("f1", 0, job_id=11),
+            self._fail("f2", -10, job_id=12),
+            self._pending("p1", -13),  # jobs running — separator, no restart
+            self._unrun("u1", -16),  # no jobs — restart candidate
+            self._baseline("e1", -20),
+        ]
+        res = self._test_signal(commits).process_valid_autorevert_pattern()
+        self.assertIsInstance(res, RestartCommits)
+        assert isinstance(res, RestartCommits)
+        self.assertEqual(res.commit_shas, {"u1"})
+
+    def test_process_block_verdict_keeps_covering_uncovered_gap(self):
+        # A not_related verdict on the current suspect, but an unrun commit is
+        # still uncovered in the gap → keep restarting it (the real introducer
+        # may be there) rather than surfacing the block. No fresh advisor.
+        verdict = AIAdvisorResult(
+            verdict=AdvisorVerdict.NOT_RELATED,
+            confidence=0.95,
+            timestamp=self.t0,
+            signal_key="f.py::t",
+        )
+        suspect = SignalCommit(
+            head_sha="f2",
+            timestamp=ts(self.t0, -10),
+            events=[self._ev("t", SignalStatus.FAILURE, -10, job_id=12)],
+            advisor_result=verdict,
+            job_group_concluded=True,
+        )
+        commits = [
+            self._fail("f1", 0, job_id=11),
+            suspect,
+            self._unrun("u1", -15),
+            self._baseline("e1", -20),
+        ]
+        res = self._test_signal(commits).process_valid_autorevert_pattern()
+        self.assertIsInstance(res, RestartCommits)
+        assert isinstance(res, RestartCommits)
+        self.assertEqual(res.commit_shas, {"u1"})
+        self.assertIsNone(res.advisor)  # suspect ruled out — no re-dispatch
+
+    def test_process_revert_verdict_acts_even_with_uncovered_gap(self):
+        # Option-A tradeoff, made explicit: a confident revert verdict on the
+        # oldest observed failure is acted on immediately, even though an unrun
+        # gap commit below it has not concluded. Bounded by the advisor's
+        # diff-introduction semantics + the confidence gate.
+        verdict = AIAdvisorResult(
+            verdict=AdvisorVerdict.REVERT,
+            confidence=0.95,
+            timestamp=self.t0,
+            signal_key="f.py::t",
+        )
+        suspect = SignalCommit(
+            head_sha="f2",
+            timestamp=ts(self.t0, -10),
+            events=[self._ev("t", SignalStatus.FAILURE, -10, job_id=12)],
+            advisor_result=verdict,
+            job_group_concluded=True,
+        )
+        commits = [
+            self._fail("f1", 0, job_id=11),
+            suspect,
+            self._unrun("u1", -15),
+            self._baseline("e1", -20),
+        ]
+        res = self._test_signal(commits).process_valid_autorevert_pattern()
+        self.assertIsInstance(res, AutorevertPattern)
+        assert isinstance(res, AutorevertPattern)
+        self.assertEqual(res.suspected_commit, "f2")
 
     def test_process_no_advisor_for_job_track_born_red(self):
         # Born-red detection is test-track only. Job-track signals with the

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
@@ -1216,6 +1216,7 @@ class TestSignalCommitReplace(unittest.TestCase):
             timestamp=datetime(2025, 8, 19, 12, 0, 0),
             signal_key="k",
         ),
+        "job_group_concluded": True,
     }
 
     def _init_params(self):
@@ -1273,13 +1274,19 @@ class TestSignalCommitReplace(unittest.TestCase):
 
 
 class TestBornRedTestSignal(unittest.TestCase):
-    """Test-track born-red detection: failing head + empty-events tail.
+    """Test-track born-red detection (order-independent set predicate).
 
-    Covers the blind spot where a test was introduced by the same commit that
-    breaks it (or by a recent ancestor): the green→red partition path returns
-    `Ineligible(NO_SUCCESSES)` and bails before dispatching the advisor. The
-    born-red path asks the advisor "did the suspect commit introduce this
-    failing test?" instead.
+    Covers the blind spot where a test is introduced — or enabled / un-skipped
+    / renamed — already broken: the green→red partition path returns
+    `Ineligible(NO_SUCCESSES)` and bails before dispatching the advisor.
+
+    The detector ignores commit ordering and pending commits. It fires when the
+    signal has no successes, ≥1 failing commit, and ≥1 *concluded baseline*
+    commit (`job_group_concluded and not events`) OLDER than the suspect (the
+    oldest failure), provided no unconcluded/pending commit sits in the
+    introduction gap. Real trunk signals always carry a pending head and empty
+    commits interleaved among the failures, both of which the earlier strict
+    `[FAIL...][EMPTY...]` shape rejected — so it never fired in practice.
     """
 
     def setUp(self) -> None:
@@ -1302,14 +1309,42 @@ class TestBornRedTestSignal(unittest.TestCase):
         )
 
     def _fail(self, sha: str, minute: int, *, job_id: int = 100) -> SignalCommit:
+        # A failing commit whose job group concluded.
         return SignalCommit(
             head_sha=sha,
             timestamp=ts(self.t0, minute),
             events=[self._ev("t", SignalStatus.FAILURE, minute, job_id=job_id)],
+            job_group_concluded=True,
         )
 
-    def _empty(self, sha: str, minute: int) -> SignalCommit:
-        return SignalCommit(head_sha=sha, timestamp=ts(self.t0, minute), events=[])
+    def _baseline(self, sha: str, minute: int) -> SignalCommit:
+        # Job group concluded, no event for this test → born-red baseline
+        # witness (the test was genuinely absent on this commit).
+        return SignalCommit(
+            head_sha=sha,
+            timestamp=ts(self.t0, minute),
+            events=[],
+            job_group_concluded=True,
+        )
+
+    def _pending(self, sha: str, minute: int) -> SignalCommit:
+        # Job group still running → carries a PENDING event, not concluded.
+        return SignalCommit(
+            head_sha=sha,
+            timestamp=ts(self.t0, minute),
+            events=[self._ev("t", SignalStatus.PENDING, minute)],
+            job_group_concluded=False,
+        )
+
+    def _unrun(self, sha: str, minute: int) -> SignalCommit:
+        # No jobs concluded for this group yet → empty AND not concluded. Not a
+        # baseline witness: we cannot tell whether the test exists here.
+        return SignalCommit(
+            head_sha=sha,
+            timestamp=ts(self.t0, minute),
+            events=[],
+            job_group_concluded=False,
+        )
 
     def _test_signal(self, commits, key: str = "f.py::t") -> Signal:
         return Signal(
@@ -1319,14 +1354,14 @@ class TestBornRedTestSignal(unittest.TestCase):
             source=SignalSource.TEST,
         )
 
-    # ---- partition_born_red shape checks ----
+    # ---- partition_born_red predicate ----
 
     def test_partition_born_red_canonical_shape(self):
         commits = [
             self._fail("f1", 0, job_id=1),
             self._fail("f2", -10, job_id=2),
-            self._empty("e1", -20),
-            self._empty("e2", -30),
+            self._baseline("e1", -20),
+            self._baseline("e2", -30),
         ]
         part = self._test_signal(commits).partition_born_red()
         self.assertIsNotNone(part)
@@ -1335,49 +1370,84 @@ class TestBornRedTestSignal(unittest.TestCase):
         self.assertEqual([c.head_sha for c in part.successful], ["e1", "e2"])
         self.assertEqual(part.unknown, [])
 
+    def test_partition_born_red_fires_despite_leading_pending(self):
+        # The newest commits are still running (pending head) — the common
+        # real-world case. Pending commits are ignored; the predicate still
+        # fires on the failures + concluded baseline below them.
+        commits = [
+            self._pending("p1", 10),
+            self._pending("p2", 5),
+            self._fail("f1", 0),
+            self._fail("f2", -10),
+            self._baseline("e1", -20),
+        ]
+        part = self._test_signal(commits).partition_born_red()
+        self.assertIsNotNone(part)
+        assert part is not None
+        self.assertEqual([c.head_sha for c in part.failed], ["f1", "f2"])
+        self.assertEqual([c.head_sha for c in part.successful], ["e1"])
+
+    def test_partition_born_red_fires_with_interleaved_empty(self):
+        # A concluded-empty commit sits BETWEEN two failures (the test isn't
+        # observed on every commit — sharding / TD). The old strict shape
+        # rejected this; the set predicate does not.
+        commits = [
+            self._fail("f1", 0),
+            self._baseline("g1", -5),  # interleaved concluded-empty
+            self._fail("f2", -10),
+            self._baseline("e1", -20),
+        ]
+        part = self._test_signal(commits).partition_born_red()
+        self.assertIsNotNone(part)
+        assert part is not None
+        # Suspect = oldest failure (f2); both failures collected.
+        self.assertEqual([c.head_sha for c in part.failed], ["f1", "f2"])
+        self.assertEqual(part.failed[-1].head_sha, "f2")
+
+    def test_partition_born_red_defers_on_pending_in_introduction_gap(self):
+        # An unconcluded (pending) commit between the suspect and the nearest
+        # older baseline could itself be the real introducer → defer (None)
+        # rather than dispatch on a too-new suspect.
+        commits = [
+            self._fail("f1", 0),
+            self._fail("f2", -10),
+            self._unrun("p1", -15),  # unconcluded gap commit, no info yet
+            self._baseline("e1", -20),
+        ]
+        self.assertIsNone(self._test_signal(commits).partition_born_red())
+
+    def test_partition_born_red_none_without_concluded_baseline(self):
+        # The only empty commits are unconcluded (jobs not finished) → no proof
+        # the test was ever absent → not born-red.
+        commits = [self._fail("f1", 0), self._fail("f2", -10), self._unrun("u1", -20)]
+        self.assertIsNone(self._test_signal(commits).partition_born_red())
+
     def test_partition_born_red_none_when_has_successes(self):
-        # Even one success disqualifies the born-red shape — the main partition
-        # path applies instead.
+        # Any success disqualifies born-red — the main partition path applies.
         commits = [
             self._fail("f1", 0),
             SignalCommit(
                 head_sha="s1",
                 timestamp=ts(self.t0, -10),
                 events=[self._ev("t", SignalStatus.SUCCESS, -10)],
+                job_group_concluded=True,
             ),
+            self._baseline("e1", -20),
         ]
         self.assertIsNone(self._test_signal(commits).partition_born_red())
 
-    def test_partition_born_red_none_without_empty_tail(self):
-        # All commits fail — chronic infra shape, not born-red.
-        commits = [self._fail("f1", 0), self._fail("f2", -10)]
+    def test_partition_born_red_none_chronic_failure_no_baseline(self):
+        # All commits fail, no concluded-empty baseline — chronic shape.
+        commits = [self._fail("f1", 0), self._fail("f2", -10), self._fail("f3", -20)]
         self.assertIsNone(self._test_signal(commits).partition_born_red())
 
     def test_partition_born_red_none_without_failures(self):
-        # Only empty commits — nothing to act on.
-        commits = [self._empty("e1", 0), self._empty("e2", -10)]
+        # Only baseline commits — nothing to act on.
+        commits = [self._baseline("e1", 0), self._baseline("e2", -10)]
         self.assertIsNone(self._test_signal(commits).partition_born_red())
 
-    def test_partition_born_red_none_on_interleaved_empty_then_fail(self):
-        # newest=empty, older=fail violates the [FAIL...][EMPTY...] order.
-        commits = [self._empty("e1", 0), self._fail("f1", -10), self._empty("e2", -20)]
-        self.assertIsNone(self._test_signal(commits).partition_born_red())
-
-    def test_partition_born_red_none_on_pending_only_commit(self):
-        # Pending-only commits are neither failures nor empty — bail.
-        commits = [
-            self._fail("f1", 0),
-            SignalCommit(
-                head_sha="p1",
-                timestamp=ts(self.t0, -10),
-                events=[self._ev("t", SignalStatus.PENDING, -10)],
-            ),
-            self._empty("e1", -20),
-        ]
-        self.assertIsNone(self._test_signal(commits).partition_born_red())
-
-    def test_partition_born_red_requires_two_commits(self):
-        # Single commit can't form a partition.
+    def test_partition_born_red_none_single_failure_no_baseline(self):
+        # Single failing commit with no baseline below it.
         self.assertIsNone(self._test_signal([self._fail("f1", 0)]).partition_born_red())
 
     # ---- process_valid_autorevert_pattern wiring ----
@@ -1386,7 +1456,7 @@ class TestBornRedTestSignal(unittest.TestCase):
         commits = [
             self._fail("f1", 0, job_id=11),
             self._fail("f2", -10, job_id=12),
-            self._empty("e1", -20),
+            self._baseline("e1", -20),
         ]
         res = self._test_signal(commits).process_valid_autorevert_pattern()
         self.assertIsInstance(res, Ineligible)
@@ -1398,11 +1468,36 @@ class TestBornRedTestSignal(unittest.TestCase):
         self.assertEqual(res.advisor.successful_commits, ("e1",))
         self.assertTrue(res.advisor.is_born_red)
 
+    def test_process_dispatches_on_real_flip_shape(self):
+        # Regression for the real-world shape that the old strict partition
+        # never fired on: pending head + a failure + an interleaved
+        # concluded-empty + another failure + concluded baseline tail.
+        # (Mirrors inductor flip_zero_dim_dynamic_shapes_cuda, 2026-05-21.)
+        commits = [
+            self._pending("p1", 30),
+            self._pending("p2", 25),
+            self._fail("f1", 20, job_id=11),
+            self._baseline("g1", 15),  # interleaved: test not observed here
+            self._fail("f2", 10, job_id=12),
+            self._baseline("e1", 0),
+            self._baseline("e2", -10),
+        ]
+        res = self._test_signal(commits).process_valid_autorevert_pattern()
+        self.assertIsInstance(res, Ineligible)
+        self.assertEqual(res.reason, IneligibleReason.NO_SUCCESSES)
+        self.assertIsNotNone(res.advisor)
+        self.assertTrue(res.advisor.is_born_red)
+        # Suspect = oldest failure (f2); both failures reported.
+        self.assertEqual(res.advisor.suspect_commit, "f2")
+        self.assertEqual(res.advisor.failed_commits, ("f1", "f2"))
+        # Baseline = concluded-empty commits older than the suspect.
+        self.assertEqual(res.advisor.successful_commits, ("e1", "e2"))
+
     def test_process_holds_advisor_below_failing_commit_threshold(self):
         # Single failing commit — wait for the next trunk advance before paying
         # advisor cost (REQUIRE_FAILED_COMMITS_BORN_RED == 2). Distinct
         # commits, not raw event counts, gate the dispatch.
-        commits = [self._fail("f1", 0), self._empty("e1", -10)]
+        commits = [self._fail("f1", 0), self._baseline("e1", -10)]
         res = self._test_signal(commits).process_valid_autorevert_pattern()
         self.assertIsInstance(res, Ineligible)
         self.assertEqual(res.reason, IneligibleReason.NO_SUCCESSES)
@@ -1419,8 +1514,9 @@ class TestBornRedTestSignal(unittest.TestCase):
                 self._ev("t", SignalStatus.FAILURE, 1, wf_run_id=2, job_id=12),
                 self._ev("t", SignalStatus.FAILURE, 2, wf_run_id=3, job_id=13),
             ],
+            job_group_concluded=True,
         )
-        commits = [c_multi_event, self._empty("e1", -10)]
+        commits = [c_multi_event, self._baseline("e1", -10)]
         res = self._test_signal(commits).process_valid_autorevert_pattern()
         self.assertIsInstance(res, Ineligible)
         self.assertEqual(res.reason, IneligibleReason.NO_SUCCESSES)
@@ -1433,7 +1529,7 @@ class TestBornRedTestSignal(unittest.TestCase):
         commits = [
             self._fail("f1", 0, job_id=21),
             self._fail("f2", -10, job_id=22),
-            self._empty("e1", -20),
+            self._baseline("e1", -20),
         ]
         s = Signal(
             key="job",
@@ -1446,9 +1542,9 @@ class TestBornRedTestSignal(unittest.TestCase):
         self.assertEqual(res.reason, IneligibleReason.NO_SUCCESSES)
         self.assertIsNone(res.advisor)
 
-    def test_process_no_advisor_when_chronic_failure_no_empty_tail(self):
-        # Chronic shape — every commit fails, no empties. Lambda continues to
-        # return the existing NO_SUCCESSES without an advisor.
+    def test_process_no_advisor_when_chronic_failure_no_baseline(self):
+        # Chronic shape — every commit fails, no concluded-empty baseline.
+        # Lambda continues to return the existing NO_SUCCESSES without advisor.
         commits = [self._fail("f1", 0), self._fail("f2", -10), self._fail("f3", -20)]
         res = self._test_signal(commits).process_valid_autorevert_pattern()
         self.assertIsInstance(res, Ineligible)
@@ -1470,14 +1566,15 @@ class TestBornRedTestSignal(unittest.TestCase):
             timestamp=ts(self.t0, -10),
             events=[self._ev("t", SignalStatus.FAILURE, -10, job_id=12)],
             advisor_result=verdict,
+            job_group_concluded=True,
         )
-        commits = [self._fail("f1", 0, job_id=11), suspect, self._empty("e1", -20)]
+        commits = [self._fail("f1", 0, job_id=11), suspect, self._baseline("e1", -20)]
         res = self._test_signal(commits).process_valid_autorevert_pattern()
         self.assertIsInstance(res, AutorevertPattern)
         self.assertEqual(res.suspected_commit, "f2")
         # Newer failing commit reported alongside the suspect.
         self.assertEqual(res.newer_failing_commits, ["f1"])
-        # Older "successful" reference = newest empty-events commit (implicit
+        # Older "successful" reference = newest baseline commit (implicit
         # baseline) — used in the revert PR body.
         self.assertEqual(res.older_successful_commit, "e1")
         self.assertIsNotNone(res.advisor_verdict)
@@ -1494,8 +1591,9 @@ class TestBornRedTestSignal(unittest.TestCase):
             timestamp=ts(self.t0, -10),
             events=[self._ev("t", SignalStatus.FAILURE, -10, job_id=12)],
             advisor_result=verdict,
+            job_group_concluded=True,
         )
-        commits = [self._fail("f1", 0, job_id=11), suspect, self._empty("e1", -20)]
+        commits = [self._fail("f1", 0, job_id=11), suspect, self._baseline("e1", -20)]
         res = self._test_signal(commits).process_valid_autorevert_pattern()
         self.assertIsInstance(res, Ineligible)
         self.assertEqual(res.reason, IneligibleReason.ADVISOR_NOT_RELATED)

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
@@ -1217,6 +1217,7 @@ class TestSignalCommitReplace(unittest.TestCase):
             signal_key="k",
         ),
         "job_group_concluded": True,
+        "has_dispatch_run": True,
     }
 
     def _init_params(self):
@@ -1344,6 +1345,18 @@ class TestBornRedTestSignal(unittest.TestCase):
             timestamp=ts(self.t0, minute),
             events=[],
             job_group_concluded=False,
+        )
+
+    def _dispatched(self, sha: str, minute: int) -> SignalCommit:
+        # Already restarted once via workflow_dispatch, concluded with no event
+        # for this test (test absent / filtered out). Not a baseline (the
+        # dispatch can't prove absence), but must NOT be restarted again.
+        return SignalCommit(
+            head_sha=sha,
+            timestamp=ts(self.t0, minute),
+            events=[],
+            job_group_concluded=False,
+            has_dispatch_run=True,
         )
 
     def _test_signal(self, commits, key: str = "f.py::t") -> Signal:
@@ -1723,6 +1736,39 @@ class TestBornRedTestSignal(unittest.TestCase):
         self.assertIsInstance(res, AutorevertPattern)
         assert isinstance(res, AutorevertPattern)
         self.assertEqual(res.suspected_commit, "f2")
+
+    def test_process_does_not_redispatch_already_dispatched_gap_commit(self):
+        # The whole point of has_dispatch_run: a gap commit we already restarted
+        # once (workflow_dispatch concluded, test still absent → no event) is a
+        # covered separator. Only the not-yet-probed unrun commit is restarted —
+        # no second dispatch on the same commit.
+        commits = [
+            self._fail("f1", 0, job_id=11),
+            self._fail("f2", -10, job_id=12),
+            self._dispatched("d1", -15),  # already restarted once → don't repeat
+            self._unrun("u1", -18),  # never probed → restart this one
+            self._baseline("e1", -25),
+        ]
+        res = self._test_signal(commits).process_valid_autorevert_pattern()
+        self.assertIsInstance(res, RestartCommits)
+        assert isinstance(res, RestartCommits)
+        self.assertEqual(res.commit_shas, {"u1"})
+
+    def test_process_all_gap_commits_dispatched_no_restart(self):
+        # Once every gap commit has been probed once, there is nothing left to
+        # restart — the advisor still dispatches on the oldest observed failure.
+        commits = [
+            self._fail("f1", 0, job_id=11),
+            self._fail("f2", -10, job_id=12),
+            self._dispatched("d1", -15),
+            self._dispatched("d2", -18),
+            self._baseline("e1", -25),
+        ]
+        res = self._test_signal(commits).process_valid_autorevert_pattern()
+        self.assertIsInstance(res, Ineligible)
+        self.assertEqual(res.reason, IneligibleReason.NO_SUCCESSES)
+        self.assertIsNotNone(res.advisor)
+        self.assertEqual(res.advisor.suspect_commit, "f2")
 
     def test_process_no_advisor_for_job_track_born_red(self):
         # Born-red detection is test-track only. Job-track signals with the

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
@@ -88,6 +88,7 @@ def J(
     conclusion: str = "success",
     started_at: datetime,
     rule: str = "",
+    workflow_event: str = "push",
 ):
     return JobRow(
         head_sha=Sha(sha),
@@ -101,6 +102,7 @@ def J(
         started_at=started_at,
         created_at=started_at,
         rule=rule,
+        workflow_event=workflow_event,
     )
 
 
@@ -1356,6 +1358,90 @@ class TestSignalExtraction(unittest.TestCase):
         # No genuine concluded baseline anywhere → NOT born-red (the skipped
         # commit must not serve as the baseline witness).
         self.assertIsNone(sig.partition_born_red())
+
+    def test_workflow_dispatch_run_does_not_establish_baseline(self):
+        # An autorevert restart is a workflow_dispatch run. It is job/test-
+        # filtered, so a concluded dispatch with no event for this test is NOT
+        # proof the test was absent — it must not establish a born-red
+        # baseline. Only a natural (push) run can.
+        jobs = [
+            J(
+                sha="C1",
+                run=301,
+                job=21,
+                attempt=1,
+                started_at=ts(self.t0, 30),
+                conclusion="failure",
+                rule="pytest failure",
+            ),
+            # C2: a workflow_dispatch run concluded (success), but this test had
+            # no row (it was filtered out of the dispatch / didn't run).
+            J(
+                sha="C2",
+                run=302,
+                job=22,
+                attempt=1,
+                started_at=ts(self.t0, 20),
+                conclusion="success",
+                workflow_event="workflow_dispatch",
+            ),
+        ]
+        tests = [
+            T(
+                job=21,
+                run=301,
+                attempt=1,
+                file="foo.py",
+                name="test_bar",
+                failure_runs=1,
+            ),
+        ]
+        signals = self._extract(jobs, tests)
+        sig = self._find_test_signal(signals, "trunk", "foo.py::test_bar")
+        self.assertIsNotNone(sig)
+        by_sha = {c.head_sha: c for c in sig.commits}
+        self.assertTrue(by_sha["C1"].job_group_concluded)
+        # Dispatch-only commit: NOT a baseline (no natural run), no event.
+        self.assertFalse(by_sha["C2"].job_group_concluded)
+        self.assertEqual(by_sha["C2"].events, [])
+        # Only a dispatch "baseline" → not born-red.
+        self.assertIsNone(sig.partition_born_red())
+
+    def test_workflow_dispatch_failure_still_emits_event(self):
+        # A workflow_dispatch (gap-restart) run where the test DID run and
+        # failed must still surface a FAILURE event — that is how a gap restart
+        # moves the suspect — even though the dispatch run does not count toward
+        # job_group_concluded.
+        jobs = [
+            J(
+                sha="C1",
+                run=401,
+                job=31,
+                attempt=1,
+                started_at=ts(self.t0, 30),
+                conclusion="failure",
+                rule="pytest failure",
+                workflow_event="workflow_dispatch",
+            ),
+        ]
+        tests = [
+            T(
+                job=31,
+                run=401,
+                attempt=1,
+                file="foo.py",
+                name="test_bar",
+                failure_runs=1,
+            ),
+        ]
+        signals = self._extract(jobs, tests)
+        sig = self._find_test_signal(signals, "trunk", "foo.py::test_bar")
+        self.assertIsNotNone(sig)
+        c1 = next(c for c in sig.commits if c.head_sha == "C1")
+        # Dispatch failure still emits the FAILURE event (moves the suspect)…
+        self.assertTrue(c1.has_failure)
+        # …but the dispatch run does not establish the group as concluded.
+        self.assertFalse(c1.job_group_concluded)
 
 
 if __name__ == "__main__":

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
@@ -1248,6 +1248,64 @@ class TestSignalExtraction(unittest.TestCase):
         self.assertEqual(sig.test_file, "test_dataloader.py")
         self.assertEqual(sig.test_name, "test_shuffle_pin_memory")
 
+    def test_job_group_concluded_flag_per_commit(self):
+        # The per-commit `job_group_concluded` flag drives born-red baseline
+        # detection. It must be True when the test's job group reached a
+        # terminal conclusion on a commit (even with no event for this test —
+        # the baseline witness) and False when the job group is still pending.
+        jobs = [
+            # C1 (newest): job concluded, the test failed here.
+            J(
+                sha="C1",
+                run=101,
+                job=1,
+                attempt=1,
+                started_at=ts(self.t0, 30),
+                conclusion="failure",
+                rule="pytest failure",
+            ),
+            # C2: job concluded (success), but this test has no row → baseline.
+            J(sha="C2", run=102, job=2, attempt=1, started_at=ts(self.t0, 20)),
+            # C3 (oldest): job still running → not concluded, no info yet.
+            J(
+                sha="C3",
+                run=103,
+                job=3,
+                attempt=1,
+                started_at=ts(self.t0, 10),
+                status="in_progress",
+                conclusion="",
+            ),
+        ]
+        tests = [
+            T(
+                job=1,
+                run=101,
+                attempt=1,
+                file="foo.py",
+                name="test_bar",
+                failure_runs=1,
+            ),
+        ]
+        signals = self._extract(jobs, tests)
+        sig = self._find_test_signal(signals, "trunk", "foo.py::test_bar")
+        self.assertIsNotNone(sig)
+        by_sha = {c.head_sha: c for c in sig.commits}
+        # Failing commit: concluded.
+        self.assertTrue(by_sha["C1"].job_group_concluded)
+        self.assertTrue(by_sha["C1"].has_failure)
+        # Concluded baseline: concluded, no events for this test.
+        self.assertTrue(by_sha["C2"].job_group_concluded)
+        self.assertEqual(by_sha["C2"].events, [])
+        # Pending job group: not concluded.
+        self.assertFalse(by_sha["C3"].job_group_concluded)
+        # End to end: this is a born-red signal (C2 is the concluded baseline).
+        part = sig.partition_born_red()
+        self.assertIsNotNone(part)
+        assert part is not None
+        self.assertEqual(part.failed[-1].head_sha, "C1")
+        self.assertIn("C2", [c.head_sha for c in part.successful])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
@@ -1442,6 +1442,55 @@ class TestSignalExtraction(unittest.TestCase):
         self.assertTrue(c1.has_failure)
         # …but the dispatch run does not establish the group as concluded.
         self.assertFalse(c1.job_group_concluded)
+        # …and it records that we already dispatched a restart here.
+        self.assertTrue(c1.has_dispatch_run)
+
+    def test_has_dispatch_run_flag_tracks_workflow_dispatch(self):
+        # `has_dispatch_run` records that autorevert already restarted a commit
+        # (a workflow_dispatch run is present), so the gap bisection won't
+        # restart it twice. A natural-only commit has it False.
+        jobs = [
+            # C1: natural run only → no dispatch recorded.
+            J(
+                sha="C1",
+                run=501,
+                job=41,
+                attempt=1,
+                started_at=ts(self.t0, 30),
+                conclusion="failure",
+                rule="pytest failure",
+            ),
+            # C2: a workflow_dispatch restart concluded here with no event for
+            # this test (test absent / filtered) → has_dispatch_run, not a
+            # baseline.
+            J(
+                sha="C2",
+                run=502,
+                job=42,
+                attempt=1,
+                started_at=ts(self.t0, 20),
+                conclusion="success",
+                workflow_event="workflow_dispatch",
+            ),
+        ]
+        tests = [
+            T(
+                job=41,
+                run=501,
+                attempt=1,
+                file="foo.py",
+                name="test_bar",
+                failure_runs=1,
+            ),
+        ]
+        signals = self._extract(jobs, tests)
+        sig = self._find_test_signal(signals, "trunk", "foo.py::test_bar")
+        self.assertIsNotNone(sig)
+        by_sha = {c.head_sha: c for c in sig.commits}
+        self.assertFalse(by_sha["C1"].has_dispatch_run)  # natural only
+        self.assertTrue(by_sha["C2"].has_dispatch_run)  # restarted once
+        self.assertFalse(by_sha["C2"].job_group_concluded)  # not a baseline
+        self.assertEqual(by_sha["C2"].events, [])
 
 
 if __name__ == "__main__":

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
@@ -1306,6 +1306,57 @@ class TestSignalExtraction(unittest.TestCase):
         self.assertEqual(part.failed[-1].head_sha, "C1")
         self.assertIn("C2", [c.head_sha for c in part.successful])
 
+    def test_job_group_concluded_excludes_skipped_group(self):
+        # A fully-skipped job group (e.g. an `if:` gate, or a required-check
+        # skip when an upstream dependency failed/cancelled) never ran the
+        # test, so it must NOT count as a concluded born-red baseline — it is
+        # "missing", same as cancelled. Otherwise a skipped commit fabricates a
+        # "test absent" baseline witness and can manufacture / mis-scope a
+        # born-red detection.
+        jobs = [
+            # C1 (newest): job concluded, the test failed here.
+            J(
+                sha="C1",
+                run=201,
+                job=11,
+                attempt=1,
+                started_at=ts(self.t0, 30),
+                conclusion="failure",
+                rule="pytest failure",
+            ),
+            # C2 (oldest): the test's job group was SKIPPED — no run.
+            J(
+                sha="C2",
+                run=202,
+                job=12,
+                attempt=1,
+                started_at=ts(self.t0, 20),
+                status="completed",
+                conclusion="skipped",
+            ),
+        ]
+        tests = [
+            T(
+                job=11,
+                run=201,
+                attempt=1,
+                file="foo.py",
+                name="test_bar",
+                failure_runs=1,
+            ),
+        ]
+        signals = self._extract(jobs, tests)
+        sig = self._find_test_signal(signals, "trunk", "foo.py::test_bar")
+        self.assertIsNotNone(sig)
+        by_sha = {c.head_sha: c for c in sig.commits}
+        self.assertTrue(by_sha["C1"].job_group_concluded)
+        # Skipped group → treated as missing: not concluded, no event.
+        self.assertFalse(by_sha["C2"].job_group_concluded)
+        self.assertEqual(by_sha["C2"].events, [])
+        # No genuine concluded baseline anywhere → NOT born-red (the skipped
+        # commit must not serve as the baseline witness).
+        self.assertIsNone(sig.partition_born_red())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Make the born-red test-signal detector (#8107) fire on real trunk signals,
cover the ghstack-landing case where the introducing commit never ran jobs, and
gate the "recovered" case where the test was removed/disabled again.

A test introduced already-broken (added / enabled / un-skipped / moved-into-existence)
has no green to bisect, so the green→red path bails with `NO_SUCCESSES` and the
advisor is never asked. The old detector required a strict contiguous
`[FAIL…][EMPTY…]` shape that never occurs in production — **0 dispatches over 11
real born-red episodes** in a month of `autorevert_state`. Real signals carry
**pending** commits (jobs not finished yet) at the head *and* interleaved
between the failures and the older baseline, which the contiguous walk rejected.

## What it checks

Notation, newest→oldest: `F` failing · `C` concluded baseline (job ran, test
absent) · `P` pending (job running) · `U` unrun (no job result — ghstack
stack-middle `push` never scheduled, test didn't run, or test crashed without
reporting).

Test-track only; the caller guarantees no successful run anywhere in the window.
The partition is **scoped to the most-recent concluded baseline `C` (inclusive)
and everything newer** — `C` is positive proof the test was absent, so a `C`
*newer* than the failures means the test was removed/disabled again (recovered)
and the stale older failures are out of scope. Within that scope, born-red fires
when:

1. **≥1 failing commit.** Suspect = the *oldest in-scope* `F` (the introduction point).
2. **≥2 distinct failing commits** before the advisor is dispatched (retries /
   shards on one commit count as one observation).

`has_successes()` is still checked over the **full** window (any success
anywhere disqualifies born-red). `P` commits are ignored for the suspect
decision — we act on the oldest observed `F` now instead of waiting. `U` commits
in the introduction gap (between the suspect and the baseline) are restarted —
bisection / linear coverage honoring `BISECTION_LIMIT`, reusing the green→red
gap-closure logic — to find the true introducer, with the advisor dispatched in
parallel.

### Matches

| signal | action |
|---|---|
| `F F C` | advisor on oldest `F`, baseline `C` |
| `P P F F P C` | advisor on oldest `F` (pending ignored; no restart) |
| `F F U C` | restart `U` **and** advisor on oldest `F`, in parallel |
| `F U C` | restart `U` only (1 failure < 2 → no advisor yet) |
| `F F C F C` | advisor on the oldest *in-scope* `F`; the older `F` is a prior, recovered episode (scoped out by the newer `C`) |

### Does not act

| signal | why |
|---|---|
| any success in window | not born-red — the green→red path handles it |
| `C F F C` | **recovered**: a baseline newer than the failures (test removed/disabled) → out of scope |
| `F F` | no concluded baseline → can't prove the test was ever absent (chronic) |
| `F U` | only an unrun commit below → no proof of absence |
| `C C` | no failures |
| `F C` | partition forms but advisor **held** — needs ≥2 distinct failures |

## How

- `SignalCommit.job_group_concluded` (set in `_build_test_signals`): the test's
  `(workflow, job_base)` group reached a terminal conclusion (≥1 non-cancelled
  run, none pending) — distinguishes a real baseline from "no info yet".
- `partition_born_red`: the scoped set predicate above. `failed[-1]` = suspect,
  `successful[0]` = the most-recent baseline, `unknown` = introduction gap.
- `_handle_no_successes`: dispatches the advisor and/or returns `RestartCommits`
  (reusing `cover_gap_unknown_commits` + `GapBisectionPlanner`).

## Test plan

Full lambda suite green (209, 1 skipped); lintrunner clean. `TestBornRedTestSignal`
covers each match / no-act row (incl. recovered-at-head and most-recent-baseline
scoping), gap population, restart + advisor parallelism, the ghstack
single-failure case, `bisection_limit` throttling, and block- / revert-verdict
with an uncovered gap.

## Notes

Cross-model review (DP17, Codex gpt-5.5): SHIP / SHIP-WITH-NITS across the
predicate, gate removal, gap-restart, and recovered-at-head gate; nits
addressed. No advisor-prompt change.
