### PR TITLE
[CRCR] Implement on-call bot and allowlist functionality for downstream CI failures

### DIFF
--- a/torchci/lib/bot/crcrOncallBot.ts
+++ b/torchci/lib/bot/crcrOncallBot.ts
@@ -1,0 +1,195 @@
+import { Probot } from "probot";
+import { fetchCrcrAllowlist } from "../crcrAllowlist";
+import { isPyTorchbotSupportedOrg } from "./utils";
+
+export const FAILURE_CONCLUSIONS: ReadonlySet<string> = new Set([
+  "failure",
+  "cancelled",
+  "timed_out",
+]);
+
+function markerForRepo(downstreamRepo: string): string {
+  return `<!-- crcr-oncall:${downstreamRepo} -->`;
+}
+
+/**
+ * Parse the downstream ``owner/repo`` out of a CRCR check run name.
+ *
+ * Check runs are named ``crcr/<owner>/<repo>/<workflow_name>/<job_name>``
+ * (see the Python gh_helper.check_run_name), so the downstream repo is the
+ * first two path segments after the ``crcr/`` prefix.
+ */
+export function downstreamRepoFromCheckRunName(name: string): string | null {
+  const prefix = "crcr/";
+  if (!name.startsWith(prefix)) {
+    return null;
+  }
+  const parts = name.slice(prefix.length).split("/");
+  if (parts.length < 4 || !parts[0] || !parts[1]) {
+    return null;
+  }
+  return `${parts[0]}/${parts[1]}`;
+}
+
+/**
+ * Search existing PR comments for one with the CRCR on-call marker.
+ * Returns its ID (or 0 if none found).  Uses pagination so the marker
+ * is found even when a PR has more than 30 comments.
+ */
+async function findExistingComment(
+  octokit: any,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  downstreamRepo: string
+): Promise<number> {
+  const marker = markerForRepo(downstreamRepo);
+  const comments = await octokit.paginate(octokit.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: prNumber,
+  });
+  for (const comment of comments) {
+    if (comment.body?.includes(marker)) {
+      return comment.id;
+    }
+  }
+  return 0;
+}
+
+export default function crcrOncallBot(app: Probot): void {
+  app.on("check_run.completed", async (ctx) => {
+    const owner = ctx.payload.repository.owner.login;
+    if (!isPyTorchbotSupportedOrg(owner)) {
+      return;
+    }
+
+    const repo = ctx.payload.repository.name;
+    const checkRun = ctx.payload.check_run;
+
+    // Only act on CRCR-created check runs
+    const downstreamRepo = downstreamRepoFromCheckRunName(checkRun.name);
+    if (!downstreamRepo) {
+      return;
+    }
+
+    // Only comment on failures
+    const conclusion = checkRun.conclusion ?? "";
+    if (!FAILURE_CONCLUSIONS.has(conclusion)) {
+      return;
+    }
+
+    // Get the PRs this check run belongs to.
+    // checkRun.pull_requests is empty for cross-fork PRs (most pytorch
+    // contributions), so fall back to the commits API to resolve PRs
+    // from the head SHA — the same strategy used by the merge-blocking path.
+    let prNumbers: number[] = [];
+    if (checkRun.pull_requests && checkRun.pull_requests.length > 0) {
+      prNumbers = checkRun.pull_requests.map((pr) => pr.number);
+    } else if (checkRun.head_sha) {
+      try {
+        const result =
+          await ctx.octokit.rest.repos.listPullRequestsAssociatedWithCommit({
+            owner,
+            repo,
+            commit_sha: checkRun.head_sha,
+          });
+        prNumbers = result.data.map((pr: any) => pr.number);
+      } catch (err) {
+        ctx.log(
+          { err },
+          `crcrOncall: failed to resolve PRs for commit ${checkRun.head_sha}, skipping`
+        );
+        return;
+      }
+    }
+
+    if (prNumbers.length === 0) {
+      ctx.log(
+        `crcrOncall: no PR associated with check run ${checkRun.name}, skipping`
+      );
+      return;
+    }
+
+    const headSha = checkRun.head_sha;
+    const checkRunUrl = checkRun.html_url ?? "";
+
+    // Load oncalls from the allowlist
+    let oncalls: string[];
+    try {
+      const allowlist = await fetchCrcrAllowlist(ctx.octokit);
+      oncalls = allowlist.getOncallsForRepo(downstreamRepo);
+    } catch (err) {
+      ctx.log({ err }, "crcrOncall: failed to load allowlist, skipping");
+      return;
+    }
+
+    if (oncalls.length === 0) {
+      ctx.log(
+        `crcrOncall: no oncalls configured for ${downstreamRepo}, skipping`
+      );
+      return;
+    }
+
+    const mentions = oncalls.map((o) => `@${o}`).join(" ");
+
+    // Post a comment on each associated PR (typically just one)
+    for (const prNumber of prNumbers) {
+      try {
+        // Dedup by marker: only comment once per PR.
+        // NOTE: There is a theoretical TOCTOU race here — two concurrent
+        // check_run.completed events for the same PR could both pass the
+        // marker check and post duplicate comments. In practice, checks
+        // arrive sequentially, so this is unlikely to cause issues.
+        const existingId = await findExistingComment(
+          ctx.octokit,
+          owner,
+          repo,
+          prNumber,
+          downstreamRepo
+        );
+        if (existingId !== 0) {
+          ctx.log(
+            `crcrOncall: comment already exists on PR #${prNumber}, skipping`
+          );
+          continue;
+        }
+
+        const commentBody = `${markerForRepo(downstreamRepo)}
+## :x: CRCR downstream CI failure
+
+The downstream CI workflow in **${downstreamRepo}** has failed on commit \`${headSha.slice(
+          0,
+          7
+        )}\`.
+
+${mentions} please investigate.
+
+### Details
+
+| Field | Value |
+|---|---|
+| **Check Run** | [${checkRun.name}](${checkRunUrl}) |
+| **Commit** | \`${headSha}\` |
+| **Conclusion** | \`${conclusion}\` |
+`;
+
+        await ctx.octokit.issues.createComment({
+          owner,
+          repo,
+          issue_number: prNumber,
+          body: commentBody,
+        });
+
+        ctx.log(
+          `crcrOncall: commented on PR #${prNumber} for ${downstreamRepo} (${conclusion})`
+        );
+      } catch (err) {
+        ctx.log(
+          { err },
+          `crcrOncall: failed to comment on PR for ${downstreamRepo}`
+        );
+      }
+    }
+  });
+}

--- a/torchci/lib/bot/index.ts
+++ b/torchci/lib/bot/index.ts
@@ -6,6 +6,7 @@ import cancelWorkflowsOnCloseBot from "./cancelWorkflowsOnCloseBot";
 import checkLabelsBot from "./checkLabelsBot";
 import ciflowPushTrigger from "./ciflowPushTrigger";
 import codevNoWritePerm from "./codevNoWritePermBot";
+import crcrOncallBot from "./crcrOncallBot";
 import drciBot from "./drciBot";
 import nitpickBot from "./nitpickBot";
 import pytorchBot from "./pytorchBot";
@@ -22,6 +23,7 @@ export default function bot(app: Probot) {
   checkLabelsBot(app);
   ciflowPushTrigger(app);
   codevNoWritePerm(app);
+  crcrOncallBot(app);
   drciBot(app);
   nitpickBot(app);
   pytorchBot(app);

--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -3,8 +3,10 @@ import _ from "lodash";
 import { updateDrciComments } from "pages/api/drci/drci";
 import shlex from "shlex";
 import { queryClickhouseSaved } from "../clickhouse";
+import { fetchCrcrAllowlist } from "../crcrAllowlist";
 import { getHelp, getParser } from "./cliParser";
 import { cherryPickClassifications } from "./Constants";
+import { downstreamRepoFromCheckRunName } from "./crcrOncallBot";
 import PytorchBotLogger from "./pytorchbotLogger";
 import {
   hasWritePermissions as _hasWP,
@@ -319,7 +321,23 @@ The explanation needs to be clear on why this is needed. Here are some good exam
     }
 
     await this.logger.log("merge", extra_data);
+
+    // Check for L4 CRCR blocking failures (L3 failures are non-blocking).
+    // Force merge (-f) bypasses this check, consistent with the existing
+    // force-merge semantics for in-repo CI failures.
+    // Only applies to pytorch/pytorch — the CRCR allowlist and check runs
+    // are specific to that repo.
     if (!forceRequested && isPyTorchPyTorch(this.owner, this.repo)) {
+      const blockingRepos = await this.getCrcrBlockingFailures();
+      if (blockingRepos.length > 0) {
+        await this.addComment(
+          `The following L4 downstream CI workflows are blocking this merge (failed or still running):\n\n` +
+            blockingRepos.map((r) => `- \`${r}\``).join("\n") +
+            `\n\nPlease investigate or use \`@pytorchbot merge -f\` to bypass.`
+        );
+        return;
+      }
+
       let labels: string[] = this.ctx.payload?.issue?.labels.map(
         (e: any) => e["name"]
       );
@@ -401,10 +419,8 @@ The explanation needs to be clear on why this is needed. Here are some good exam
     );
   }
 
-  async hasWorkflowRunningPermissions(username: string): Promise<boolean> {
-    if (await _hasWP(this.ctx, username)) {
-      return true;
-    }
+  /** Lazy-load and cache the PR head SHA, then return it. */
+  private async ensureHeadSha(): Promise<string> {
     if (this.headSha === undefined) {
       const pullRequest = await this.ctx.octokit.pulls.get({
         owner: this.owner,
@@ -413,12 +429,19 @@ The explanation needs to be clear on why this is needed. Here are some good exam
       });
       this.headSha = pullRequest.data.head.sha;
     }
+    return this.headSha!;
+  }
+
+  async hasWorkflowRunningPermissions(username: string): Promise<boolean> {
+    if (await _hasWP(this.ctx, username)) {
+      return true;
+    }
 
     return await hasApprovedPullRuns(
       this.ctx.octokit,
       this.ctx.payload.repository.owner.login,
       this.ctx.payload.repository.name,
-      this.headSha!
+      await this.ensureHeadSha()
     );
   }
 
@@ -634,6 +657,81 @@ The explanation needs to be clear on why this is needed. Here are some good exam
       prNumber: this.prNum,
       headSha: this.headSha,
     });
+  }
+
+  /**
+   * Return the list of L4 downstream repos whose CRCR check runs are failing
+   * or still pending on this PR's head commit.  L3 workflows are intentionally
+   * omitted — they are non-blocking.
+   *
+   * A pending (not-yet-completed) L4 check run also blocks merge: a still-
+   * running check could fail, so merging before it completes would bypass
+   * the downstream gating.  Use ``@pytorchbot merge -f`` to override.
+   */
+  async getCrcrBlockingFailures(): Promise<string[]> {
+    // Only "failure" blocks merge — "cancelled" and "timed_out" are often
+    // superseded / infra-related and should not gate merge.
+    const BLOCKING_CONCLUSIONS = new Set(["failure"]);
+
+    // Query GitHub Check Runs API for all check runs on this commit.
+    // Use paginate to handle PRs with more than 100 check runs.
+    let checkRuns: any[] = [];
+    try {
+      const headSha = await this.ensureHeadSha();
+      checkRuns = await this.ctx.octokit.paginate(
+        this.ctx.octokit.checks.listForRef,
+        {
+          owner: this.owner,
+          repo: this.repo,
+          ref: headSha,
+          filter: "latest",
+          per_page: 100,
+        }
+      );
+    } catch {
+      // If we can't fetch check runs, fail open (don't block merge on
+      // an infrastructure error, including transient ensureHeadSha failure)
+      this.ctx.log("getCrcrBlockingFailures: failed to list check runs");
+      return [];
+    }
+
+    // Find all CRCR check runs (not just failures — we also need to
+    // gate on pending L4 checks so a still-running check isn't bypassed).
+    const crcrCheckRuns = checkRuns.filter((cr: any) =>
+      cr.name.startsWith("crcr/")
+    );
+
+    if (crcrCheckRuns.length === 0) {
+      return [];
+    }
+
+    // Load the allowlist to classify each repo as L3 or L4
+    let allowlist;
+    try {
+      allowlist = await fetchCrcrAllowlist(this.ctx.octokit);
+    } catch {
+      this.ctx.log("getCrcrBlockingFailures: failed to load allowlist");
+      return [];
+    }
+
+    const blocking = new Set<string>();
+    for (const cr of crcrCheckRuns) {
+      const downstreamRepo = downstreamRepoFromCheckRunName(cr.name);
+      if (!downstreamRepo || !allowlist.isBlocking(downstreamRepo)) {
+        continue; // Not L4
+      }
+
+      // Block when the L4 check has failed OR is still pending.
+      // Successful/completed L4 checks don't block.
+      const isFailure = BLOCKING_CONCLUSIONS.has(cr.conclusion ?? "");
+      const isPending = cr.status !== "completed";
+
+      if (isFailure || isPending) {
+        blocking.add(downstreamRepo);
+      }
+    }
+
+    return [...blocking];
   }
 }
 

--- a/torchci/lib/crcrAllowlist.ts
+++ b/torchci/lib/crcrAllowlist.ts
@@ -1,0 +1,245 @@
+import yaml from "js-yaml";
+import { Octokit } from "octokit";
+
+// Mirror of the Python AllowlistLevel enum in aws/lambda/cross_repo_ci_relay/utils/allowlist.py
+export type AllowlistLevel = "L1" | "L2" | "L3" | "L4";
+
+const LEVEL_ORDER: Record<AllowlistLevel, number> = {
+  L1: 0,
+  L2: 1,
+  L3: 2,
+  L4: 3,
+};
+
+export interface CrcrRepoEntry {
+  repo: string;
+  level: AllowlistLevel;
+  device: string; // L3 only: suffix of ciflow/crcr/{device} label
+  oncalls: string[];
+}
+
+/**
+ * Parsed and indexed CRCR allowlist.
+ *
+ * The source YAML format (from .github/allowlist.yml):
+ *   L1:
+ *     - org1/repo1
+ *   L2:
+ *     - org2/repo2
+ *   L3:
+ *     device1:
+ *       org3/device1-repo: [oncall1, oncall2]
+ *   L4:
+ *     - org5/repo5: oncall1, oncall2
+ */
+export class CrcrAllowlist {
+  private repoMap: Map<string, CrcrRepoEntry>;
+
+  constructor(entries: CrcrRepoEntry[]) {
+    this.repoMap = new Map();
+    for (const entry of entries) {
+      this.repoMap.set(entry.repo.toLowerCase(), entry);
+    }
+  }
+
+  getLevelForRepo(repo: string): AllowlistLevel | null {
+    const entry = this.repoMap.get(repo.toLowerCase());
+    return entry?.level ?? null;
+  }
+
+  getOncallsForRepo(repo: string): string[] {
+    const entry = this.repoMap.get(repo.toLowerCase());
+    return entry?.oncalls ?? [];
+  }
+
+  getDeviceForRepo(repo: string): string | null {
+    const entry = this.repoMap.get(repo.toLowerCase());
+    return entry?.device || null;
+  }
+
+  /** True when a failed check run for this repo should block PR merge (L4 only). */
+  isBlocking(repo: string): boolean {
+    const level = this.getLevelForRepo(repo);
+    return level !== null && LEVEL_ORDER[level] >= LEVEL_ORDER.L4;
+  }
+
+  /** Return all entries in the allowlist. */
+  getEntries(): CrcrRepoEntry[] {
+    return Array.from(this.repoMap.values());
+  }
+
+  /** Return repos at or above the given level (inclusive). */
+  getReposAtOrAboveLevel(level: AllowlistLevel): string[] {
+    const min = LEVEL_ORDER[level];
+    const repos: string[] = [];
+    for (const [, entry] of this.repoMap) {
+      if (LEVEL_ORDER[entry.level] >= min) {
+        repos.push(entry.repo);
+      }
+    }
+    return repos;
+  }
+
+  /** Parse raw YAML into a CrcrAllowlist. Throws on invalid format. */
+  static fromYaml(yamlStr: string): CrcrAllowlist {
+    const raw = yaml.load(yamlStr) as Record<string, unknown>;
+    if (!raw || typeof raw !== "object") {
+      throw new Error("Invalid allowlist: root must be a mapping");
+    }
+
+    const entries: CrcrRepoEntry[] = [];
+    const seenRepos = new Set<string>();
+
+    for (const level of ["L1", "L2", "L3", "L4"] as AllowlistLevel[]) {
+      if (level === "L3") {
+        const l3Raw = raw[level];
+        // L3 is a device mapping: { device: { repo: [oncalls] } }
+        if (l3Raw === undefined || l3Raw === null) continue;
+        if (typeof l3Raw !== "object" || Array.isArray(l3Raw)) {
+          throw new Error(
+            `Invalid allowlist: L3 must be a device mapping, got ${
+              Array.isArray(l3Raw) ? "list" : typeof l3Raw
+            }`
+          );
+        }
+        const devices = l3Raw as Record<string, unknown>;
+        for (const [device, reposRaw] of Object.entries(devices)) {
+          const trimmedDevice = String(device).trim();
+          if (!trimmedDevice) {
+            throw new Error(
+              "Invalid allowlist: L3 device name must not be empty"
+            );
+          }
+          if (
+            !reposRaw ||
+            typeof reposRaw !== "object" ||
+            Array.isArray(reposRaw)
+          ) {
+            throw new Error(
+              `Invalid allowlist: L3.${trimmedDevice} must be a repo mapping`
+            );
+          }
+          const repoMap = reposRaw as Record<string, unknown>;
+          for (const [repoRaw, oncallsRaw] of Object.entries(repoMap)) {
+            const repo = String(repoRaw)
+              .trim()
+              .replace(/^\/|\/$/g, "");
+            if (!repo || !repo.includes("/")) {
+              throw new Error(
+                `Invalid allowlist: L3.${trimmedDevice}.${repoRaw} must be in owner/repo format`
+              );
+            }
+            if (seenRepos.has(repo.toLowerCase())) {
+              throw new Error(`Invalid allowlist: duplicate repo ${repo}`);
+            }
+            seenRepos.add(repo.toLowerCase());
+
+            const oncalls: string[] = [];
+            if (Array.isArray(oncallsRaw)) {
+              for (const o of oncallsRaw) {
+                const trimmed = String(o).trim();
+                if (trimmed) oncalls.push(trimmed);
+              }
+            }
+            entries.push({ repo, level, device: trimmedDevice, oncalls });
+          }
+        }
+      } else {
+        const rawEntries = raw[level];
+        if (rawEntries === undefined || rawEntries === null) continue;
+        if (!Array.isArray(rawEntries)) {
+          throw new Error(
+            `Invalid allowlist: ${level} must be a list, got ${typeof rawEntries}`
+          );
+        }
+        for (const rawEntry of rawEntries as unknown[]) {
+          let repo: string;
+          let oncalls: string[] = [];
+
+          if (typeof rawEntry === "string") {
+            repo = rawEntry.trim();
+          } else if (typeof rawEntry === "object" && rawEntry !== null) {
+            const keys = Object.keys(rawEntry);
+            if (keys.length !== 1) {
+              throw new Error(
+                `Invalid allowlist: ${level} entry must be a string or single-key mapping`
+              );
+            }
+            repo = keys[0].trim();
+            const rawOncalls = (rawEntry as Record<string, unknown>)[keys[0]];
+            if (typeof rawOncalls === "string") {
+              oncalls = rawOncalls
+                .split(",")
+                .map((s) => s.trim())
+                .filter(Boolean);
+            } else if (Array.isArray(rawOncalls)) {
+              oncalls = (rawOncalls as unknown[])
+                .map((s) => String(s).trim())
+                .filter(Boolean);
+            }
+          } else {
+            continue;
+          }
+
+          if (seenRepos.has(repo.toLowerCase())) {
+            throw new Error(`Invalid allowlist: duplicate repo ${repo}`);
+          }
+          seenRepos.add(repo.toLowerCase());
+          entries.push({ repo, level, device: "", oncalls });
+        }
+      }
+    }
+
+    return new CrcrAllowlist(entries);
+  }
+}
+
+/** TTL for the in-memory allowlist cache, in milliseconds.  Default 15 minutes. */
+export const CRCR_ALLOWLIST_CACHE_TTL_MS = 15 * 60 * 1000;
+
+// In-memory cache
+let cachedAllowlist: { allowlist: CrcrAllowlist; ts: number } | null = null;
+
+/**
+ * Fetch and parse the CRCR allowlist from a GitHub repository.
+ *
+ * Uses an in-memory cache with a 15-minute TTL (matching the Redis TTL floor
+ * in the Python lambda).
+ */
+export async function fetchCrcrAllowlist(
+  octokit: Octokit,
+  owner: string = "pytorch",
+  repo: string = "pytorch",
+  path: string = ".github/allowlist.yml",
+  ref: string = "main"
+): Promise<CrcrAllowlist> {
+  if (
+    cachedAllowlist &&
+    Date.now() - cachedAllowlist.ts < CRCR_ALLOWLIST_CACHE_TTL_MS
+  ) {
+    return cachedAllowlist.allowlist;
+  }
+
+  const response = await octokit.rest.repos.getContent({
+    owner,
+    repo,
+    path,
+    ref,
+  });
+
+  if (!("content" in response.data)) {
+    throw new Error("Failed to fetch allowlist: unexpected response format");
+  }
+
+  const yamlStr = Buffer.from(response.data.content, "base64").toString(
+    "utf-8"
+  );
+  const allowlist = CrcrAllowlist.fromYaml(yamlStr);
+  cachedAllowlist = { allowlist, ts: Date.now() };
+  return allowlist;
+}
+
+/** Clear the in-memory cache (useful for testing). */
+export function clearAllowlistCache(): void {
+  cachedAllowlist = null;
+}

--- a/torchci/lib/fetchRecentWorkflows.ts
+++ b/torchci/lib/fetchRecentWorkflows.ts
@@ -1,4 +1,4 @@
-import { queryClickhouseSaved } from "./clickhouse";
+import { queryClickhouse, queryClickhouseSaved } from "./clickhouse";
 import { RecentWorkflowsData } from "./types";
 
 export async function fetchRecentWorkflows(
@@ -11,6 +11,52 @@ export async function fetchRecentWorkflows(
     prNumbers,
     repo,
   });
+}
+
+export async function fetchCrcrWorkflows(
+  repo: string = "pytorch/pytorch",
+  prNumbers: Array<number> = []
+): Promise<RecentWorkflowsData[]> {
+  // Query the crcr_workflow_job table for CRCR downstream CI jobs on open PRs.
+  // Map columns to RecentWorkflowsData shape so Dr.CI can classify them.
+  const rows = await queryClickhouse(
+    `SELECT
+      workflow_name AS name,
+      job_name AS jobName,
+      pr_number,
+      check_run_id AS id,
+      conclusion,
+      completed_at,
+      workflow_run_url AS html_url,
+      pytorch_head_sha AS head_sha,
+      downstream_repo,
+      downstream_repo_level
+    FROM default.crcr_workflow_job
+    WHERE upstream_repo = {repo:String}
+      AND pr_number IN ({prNumbers:Array(UInt64)})
+      AND status = 'completed'
+      AND conclusion IN ('failure', 'cancelled', 'timed_out')`,
+    { repo, prNumbers: prNumbers.length > 0 ? prNumbers : [0] }
+  );
+
+  return rows.map((row: any) => ({
+    name: `crcr/${row.downstream_repo}/${row.name}`,
+    jobName: row.jobName || row.name,
+    workflowId: 0,
+    workflowUniqueId: 0,
+    id: parseInt(row.id) || 0,
+    completed_at: row.completed_at || "",
+    html_url: row.html_url || "",
+    head_sha: row.head_sha || "",
+    head_sha_timestamp: "",
+    head_branch: "",
+    pr_number: parseInt(row.pr_number) || 0,
+    conclusion: row.conclusion || "failure",
+    failure_captures: [],
+    failure_lines: [],
+    failure_context: [],
+    downstreamLevel: row.downstream_repo_level || "",
+  }));
 }
 
 export async function fetchFailedJobsFromCommits(

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -55,6 +55,8 @@ export interface RecentWorkflowsData extends BasicJobData {
   failure_captures: string[];
   failure_lines: string[];
   failure_context: string[];
+  /** CRCR downstream repo level ("L3" or "L4") — set by fetchCrcrWorkflows. */
+  downstreamLevel?: string;
 }
 
 export interface Artifact {

--- a/torchci/pages/api/crcr/allowlist.ts
+++ b/torchci/pages/api/crcr/allowlist.ts
@@ -1,10 +1,8 @@
-import yaml from "js-yaml";
+import { CRCR_ALLOWLIST_CACHE_TTL_MS, CrcrAllowlist } from "lib/crcrAllowlist";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 const ALLOWLIST_RAW_URL =
   "https://raw.githubusercontent.com/pytorch/pytorch/main/.github/allowlist.yml";
-
-const CACHE_TTL_MS = 15 * 60 * 1000;
 
 export interface AllowlistEntry {
   repo: string;
@@ -20,37 +18,14 @@ export interface AllowlistResponse {
 
 let cached: { data: AllowlistResponse; expiry: number } | null = null;
 
-function parseEntry(raw: unknown): AllowlistEntry | null {
-  if (typeof raw === "string") {
-    const repo = raw.trim().replace(/^\/|\/$/g, "");
-    return repo.includes("/") ? { repo, oncalls: [] } : null;
-  }
-  if (typeof raw === "object" && raw !== null) {
-    const [key, val] = Object.entries(raw)[0] ?? [];
-    const repo = String(key ?? "")
-      .trim()
-      .replace(/^\/|\/$/g, "");
-    if (!repo.includes("/")) return null;
-    const oncalls = val
-      ? String(val)
-          .split(",")
-          .map((s: string) => s.trim())
-          .filter(Boolean)
-      : [];
-    return { repo, oncalls };
-  }
-  return null;
-}
-
-function parseAllowlist(rawYaml: Record<string, unknown>): AllowlistResponse {
+/** Convert a CrcrAllowlist into the AllowlistResponse shape for the API. */
+function toResponse(allowlist: CrcrAllowlist): AllowlistResponse {
   const result: AllowlistResponse = { L1: [], L2: [], L3: [], L4: [] };
-  for (const level of ["L1", "L2", "L3", "L4"] as const) {
-    const entries = rawYaml[level];
-    if (!Array.isArray(entries)) continue;
-    for (const raw of entries) {
-      const entry = parseEntry(raw);
-      if (entry) result[level].push(entry);
-    }
+  for (const entry of allowlist.getEntries()) {
+    result[entry.level].push({
+      repo: entry.repo,
+      oncalls: entry.oncalls,
+    });
   }
   return result;
 }
@@ -77,10 +52,10 @@ export default async function handler(
       );
     }
     const text = await response.text();
-    const parsed = (yaml.load(text) as Record<string, unknown>) || {};
-    const data = parseAllowlist(parsed);
+    const allowlist = CrcrAllowlist.fromYaml(text);
+    const data = toResponse(allowlist);
 
-    cached = { data, expiry: now + CACHE_TTL_MS };
+    cached = { data, expiry: now + CRCR_ALLOWLIST_CACHE_TTL_MS };
     res.setHeader("X-Cache", "MISS");
     return res.status(200).json(data);
   } catch (err: unknown) {

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -32,6 +32,7 @@ import { fetchCommitTimestamp } from "lib/fetchCommit";
 import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
 import fetchPR from "lib/fetchPR";
 import {
+  fetchCrcrWorkflows,
   fetchFailedJobsFromCommits,
   fetchJobNamesFromCommits,
   fetchRecentWorkflows,
@@ -292,6 +293,32 @@ export async function updateDrciComments(
         );
       }
 
+      // Classify CRCR downstream CI jobs (L3 = non-blocking, L4 = blocking).
+      // These jobs live in oot_workflow_job, not workflow_job, so they are fetched
+      // separately and classified based on their downstream_repo_level.
+      const crcrL3Jobs: RecentWorkflowsData[] = [];
+      try {
+        const crcrWorkflows = await fetchCrcrWorkflows(`${owner}/${repo}`, [
+          pr_info.pr_number,
+        ]);
+        for (const job of crcrWorkflows) {
+          const level = job.downstreamLevel || "";
+          if (level === "L3") {
+            crcrL3Jobs.push(job);
+          } else if (level === "L4") {
+            // L4 failures are blocking — merge them into failedJobs
+            failedJobs.push(job);
+          }
+        }
+      } catch (err) {
+        // If CRCR fetch fails, log and proceed — don't block the Dr.CI update
+        console.error("Failed to fetch CRCR workflows:", err);
+      }
+
+      if (crcrL3Jobs.length > 0) {
+        failures[pr_info.pr_number].CRCR_L3 = crcrL3Jobs;
+      }
+
       const failureInfo = constructResultsComment(
         pending,
         failedJobs,
@@ -300,6 +327,7 @@ export async function updateDrciComments(
         unstableJobs,
         unknownJobs,
         awaitingApprovalJobs,
+        crcrL3Jobs,
         relatedJobs,
         relatedIssues,
         relatedInfo,
@@ -757,6 +785,7 @@ export function constructResultsComment(
   unstableJobs: RecentWorkflowsData[],
   unknownJobs: RecentWorkflowsData[],
   awaitingApprovalJobs: RecentWorkflowsData[],
+  crcrL3Jobs: RecentWorkflowsData[],
   relatedJobs: Map<number, RecentWorkflowsData>,
   relatedIssues: Map<number, IssueData[]>,
   relatedInfo: Map<number, string>,
@@ -775,6 +804,7 @@ export function constructResultsComment(
   const unrelatedFailureCount = _(flakyJobs)
     .concat(brokenTrunkJobs)
     .concat(unstableJobs)
+    .concat(crcrL3Jobs)
     .filter((job) => !isPending(job))
     .value().length;
   const newFailedJobs: RecentWorkflowsData[] = failedJobs.filter(
@@ -1016,6 +1046,23 @@ export function constructResultsComment(
       "are"
     )} marked as unstable, possibly due to flakiness on trunk`,
     unstableJobs,
+    "",
+    true,
+    relatedJobs,
+    relatedIssues,
+    relatedInfo
+  );
+  output += constructResultsJobsSections(
+    hudBaseUrl,
+    owner,
+    repo,
+    prNumber,
+    "CRCR (non-blocking)",
+    `The following CRCR downstream CI ${pluralize(
+      "job",
+      crcrL3Jobs.length
+    )} failed but ${pluralize("is", crcrL3Jobs.length, "are")} non-blocking`,
+    crcrL3Jobs,
     "",
     true,
     relatedJobs,

--- a/torchci/test/crcrAllowlist.test.ts
+++ b/torchci/test/crcrAllowlist.test.ts
@@ -1,0 +1,152 @@
+import { CrcrAllowlist, clearAllowlistCache } from "../lib/crcrAllowlist";
+
+const VALID_YAML = `
+L1:
+  - org1/repo1
+L2:
+  - org2/repo2
+L3:
+  device1:
+    org3/device1-repo: [oncall1, oncall2]
+  device2:
+    org4/device2-repo: [oncall3]
+L4:
+  - org5/repo5: oncall_a, oncall_b
+`;
+
+describe("CrcrAllowlist", () => {
+  beforeEach(() => {
+    clearAllowlistCache();
+  });
+
+  describe("fromYaml", () => {
+    test("parses a valid YAML with all levels", () => {
+      const al = CrcrAllowlist.fromYaml(VALID_YAML);
+      expect(al.getLevelForRepo("org1/repo1")).toBe("L1");
+      expect(al.getLevelForRepo("org2/repo2")).toBe("L2");
+      expect(al.getLevelForRepo("org3/device1-repo")).toBe("L3");
+      expect(al.getLevelForRepo("org4/device2-repo")).toBe("L3");
+      expect(al.getLevelForRepo("org5/repo5")).toBe("L4");
+    });
+
+    test("L3 entries have correct device and oncalls", () => {
+      const al = CrcrAllowlist.fromYaml(VALID_YAML);
+      expect(al.getDeviceForRepo("org3/device1-repo")).toBe("device1");
+      expect(al.getDeviceForRepo("org4/device2-repo")).toBe("device2");
+      expect(al.getOncallsForRepo("org3/device1-repo")).toEqual([
+        "oncall1",
+        "oncall2",
+      ]);
+      expect(al.getOncallsForRepo("org4/device2-repo")).toEqual(["oncall3"]);
+    });
+
+    test("L4 entries have correct oncalls", () => {
+      const al = CrcrAllowlist.fromYaml(VALID_YAML);
+      expect(al.getOncallsForRepo("org5/repo5")).toEqual([
+        "oncall_a",
+        "oncall_b",
+      ]);
+    });
+
+    test("L1/L2 entries have no oncalls or device", () => {
+      const al = CrcrAllowlist.fromYaml(VALID_YAML);
+      expect(al.getOncallsForRepo("org1/repo1")).toEqual([]);
+      expect(al.getDeviceForRepo("org1/repo1")).toBeNull();
+      expect(al.getOncallsForRepo("org2/repo2")).toEqual([]);
+      expect(al.getDeviceForRepo("org2/repo2")).toBeNull();
+    });
+
+    test("unknown repo returns null level and empty oncalls", () => {
+      const al = CrcrAllowlist.fromYaml(VALID_YAML);
+      expect(al.getLevelForRepo("unknown/repo")).toBeNull();
+      expect(al.getOncallsForRepo("unknown/repo")).toEqual([]);
+      expect(al.getDeviceForRepo("unknown/repo")).toBeNull();
+    });
+
+    test("repo lookup is case-insensitive", () => {
+      const al = CrcrAllowlist.fromYaml(VALID_YAML);
+      expect(al.getLevelForRepo("ORG5/REPO5")).toBe("L4");
+      expect(al.getOncallsForRepo("Org5/Repo5")).toEqual([
+        "oncall_a",
+        "oncall_b",
+      ]);
+    });
+  });
+
+  describe("isBlocking", () => {
+    test("L4 is blocking, L3 and below are not", () => {
+      const al = CrcrAllowlist.fromYaml(VALID_YAML);
+      expect(al.isBlocking("org5/repo5")).toBe(true); // L4
+      expect(al.isBlocking("org3/device1-repo")).toBe(false); // L3
+      expect(al.isBlocking("org2/repo2")).toBe(false); // L2
+      expect(al.isBlocking("org1/repo1")).toBe(false); // L1
+      expect(al.isBlocking("unknown/repo")).toBe(false); // unknown
+    });
+  });
+
+  describe("getReposAtOrAboveLevel", () => {
+    test("L1 gives all repos", () => {
+      const al = CrcrAllowlist.fromYaml(VALID_YAML);
+      const repos = al.getReposAtOrAboveLevel("L1");
+      expect(repos).toHaveLength(5);
+      expect(repos).toContain("org1/repo1");
+    });
+
+    test("L3 gives L3+ repos only", () => {
+      const al = CrcrAllowlist.fromYaml(VALID_YAML);
+      const repos = al.getReposAtOrAboveLevel("L3");
+      expect(repos).toHaveLength(3);
+      expect(repos).toContain("org3/device1-repo");
+      expect(repos).toContain("org4/device2-repo");
+      expect(repos).toContain("org5/repo5");
+    });
+
+    test("L4 gives L4 repos only", () => {
+      const al = CrcrAllowlist.fromYaml(VALID_YAML);
+      const repos = al.getReposAtOrAboveLevel("L4");
+      expect(repos).toEqual(["org5/repo5"]);
+    });
+  });
+
+  describe("error handling", () => {
+    test("duplicate repo raises", () => {
+      expect(() =>
+        CrcrAllowlist.fromYaml(`
+L1:
+  - org/repo
+L2:
+  - org/repo
+`)
+      ).toThrow(/duplicate repo/i);
+    });
+
+    test("L3 as list raises", () => {
+      expect(() =>
+        CrcrAllowlist.fromYaml(`
+L3:
+  - org/repo
+`)
+      ).toThrow(/L3 must be a device mapping/);
+    });
+
+    test("L3 device with non-mapping raises", () => {
+      expect(() =>
+        CrcrAllowlist.fromYaml(`
+L3:
+  device1:
+    - org/repo
+`)
+      ).toThrow(/L3.device1 must be a repo mapping/);
+    });
+
+    test("empty L3 device name raises", () => {
+      expect(() =>
+        CrcrAllowlist.fromYaml(`
+L3:
+  "  ":
+    org/repo: []
+`)
+      ).toThrow(/device name must not be empty/);
+    });
+  });
+});

--- a/torchci/test/crcrBlockingFailures.test.ts
+++ b/torchci/test/crcrBlockingFailures.test.ts
@@ -1,0 +1,249 @@
+import PytorchBotHandler, {
+  PytorchbotParams,
+} from "../lib/bot/pytorchBotHandler";
+import { clearAllowlistCache } from "../lib/crcrAllowlist";
+
+const VALID_ALLOWLIST_YAML = `
+L3:
+  xpu:
+    intel/torch-xpu-ops: [oncall_xpu]
+L4:
+  - apple/mps-backend: [oncall_mps]
+  - nvidia/cuda-deep: [oncall_cuda]
+`;
+
+/** Base64-encode a string (Node.js Buffer → base64). */
+function toBase64(s: string): string {
+  return Buffer.from(s).toString("base64");
+}
+
+function makeHandler(
+  overrides: Partial<PytorchbotParams> = {}
+): PytorchBotHandler {
+  const params: PytorchbotParams = {
+    owner: "pytorch",
+    repo: "pytorch",
+    prNum: 42,
+    ctx: {
+      octokit: {
+        paginate: jest.fn(),
+        pulls: { get: jest.fn() },
+        checks: { listForRef: jest.fn() },
+        rest: {
+          repos: {
+            getContent: jest.fn().mockResolvedValue({
+              data: { content: toBase64(VALID_ALLOWLIST_YAML) },
+            }),
+          },
+        },
+      },
+      log: jest.fn(),
+    },
+    url: "https://github.com/pytorch/pytorch/pull/42#issuecomment-123",
+    login: "test-user",
+    commentId: 123,
+    commentBody: "@pytorchbot merge",
+    useReactions: false,
+    cachedConfigTracker: {} as any,
+    ...overrides,
+  };
+  const handler = new PytorchBotHandler(params);
+  // Pre-set headSha to avoid the ensureHeadSha() → octokit.pulls.get call
+  handler.headSha = "abc123def";
+  return handler;
+}
+
+describe("getCrcrBlockingFailures", () => {
+  beforeEach(() => {
+    clearAllowlistCache();
+  });
+
+  test("returns [] when there are no CRCR check runs", async () => {
+    const handler = makeHandler();
+    handler.ctx.octokit.paginate.mockResolvedValue([
+      { name: "some-other-check", status: "completed", conclusion: "failure" },
+    ]);
+
+    const result = await handler.getCrcrBlockingFailures();
+    expect(result).toEqual([]);
+  });
+
+  test("returns L4 repo name when an L4 check run has failed", async () => {
+    const handler = makeHandler();
+    handler.ctx.octokit.paginate.mockResolvedValue([
+      {
+        name: "crcr/apple/mps-backend/CI/build",
+        status: "completed",
+        conclusion: "failure",
+      },
+    ]);
+
+    const result = await handler.getCrcrBlockingFailures();
+    expect(result).toEqual(["apple/mps-backend"]);
+  });
+
+  test("does NOT return L3 repo when an L3 check run has failed", async () => {
+    const handler = makeHandler();
+    handler.ctx.octokit.paginate.mockResolvedValue([
+      {
+        name: "crcr/intel/torch-xpu-ops/CI/build",
+        status: "completed",
+        conclusion: "failure",
+      },
+    ]);
+
+    const result = await handler.getCrcrBlockingFailures();
+    expect(result).toEqual([]);
+  });
+
+  test("returns L4 repo when an L4 check run is still pending", async () => {
+    const handler = makeHandler();
+    handler.ctx.octokit.paginate.mockResolvedValue([
+      {
+        name: "crcr/apple/mps-backend/CI/build",
+        status: "in_progress",
+        conclusion: null,
+      },
+    ]);
+
+    const result = await handler.getCrcrBlockingFailures();
+    expect(result).toEqual(["apple/mps-backend"]);
+  });
+
+  test("does NOT return L4 repo when L4 check run has succeeded", async () => {
+    const handler = makeHandler();
+    handler.ctx.octokit.paginate.mockResolvedValue([
+      {
+        name: "crcr/apple/mps-backend/CI/build",
+        status: "completed",
+        conclusion: "success",
+      },
+    ]);
+
+    const result = await handler.getCrcrBlockingFailures();
+    expect(result).toEqual([]);
+  });
+
+  test("cancelled/timed_out L4 does NOT block merge", async () => {
+    const handler = makeHandler();
+    handler.ctx.octokit.paginate.mockResolvedValue([
+      {
+        name: "crcr/apple/mps-backend/CI/build",
+        status: "completed",
+        conclusion: "cancelled",
+      },
+      {
+        name: "crcr/apple/mps-backend/CI/test",
+        status: "completed",
+        conclusion: "timed_out",
+      },
+    ]);
+
+    const result = await handler.getCrcrBlockingFailures();
+    expect(result).toEqual([]);
+  });
+
+  test("fails open when checks.listForRef throws", async () => {
+    const handler = makeHandler();
+    handler.ctx.octokit.paginate.mockRejectedValue(new Error("API error"));
+
+    const result = await handler.getCrcrBlockingFailures();
+    expect(result).toEqual([]);
+  });
+
+  test("fails open when ensureHeadSha throws (headSha not preset)", async () => {
+    const handler = makeHandler();
+    handler.headSha = undefined; // force ensureHeadSha → pulls.get call
+    handler.ctx.octokit.pulls.get.mockRejectedValue(
+      new Error("transient pull fetch error")
+    );
+
+    const result = await handler.getCrcrBlockingFailures();
+    expect(result).toEqual([]);
+  });
+
+  test("fails open when allowlist fetch throws", async () => {
+    const handler = makeHandler();
+    handler.ctx.octokit.rest.repos.getContent.mockRejectedValue(
+      new Error("allowlist fetch error")
+    );
+    handler.ctx.octokit.paginate.mockResolvedValue([
+      {
+        name: "crcr/apple/mps-backend/CI/build",
+        status: "completed",
+        conclusion: "failure",
+      },
+    ]);
+
+    const result = await handler.getCrcrBlockingFailures();
+    expect(result).toEqual([]);
+  });
+
+  test("deduplicates repos with multiple failed/pending check runs", async () => {
+    const handler = makeHandler();
+    handler.ctx.octokit.paginate.mockResolvedValue([
+      {
+        name: "crcr/apple/mps-backend/CI/build",
+        status: "completed",
+        conclusion: "failure",
+      },
+      {
+        name: "crcr/apple/mps-backend/CI/test",
+        status: "in_progress",
+        conclusion: null,
+      },
+    ]);
+
+    const result = await handler.getCrcrBlockingFailures();
+    expect(result).toEqual(["apple/mps-backend"]);
+  });
+
+  test("returns multiple distinct L4 repos when both have failures", async () => {
+    const handler = makeHandler();
+    handler.ctx.octokit.paginate.mockResolvedValue([
+      {
+        name: "crcr/apple/mps-backend/CI/build",
+        status: "completed",
+        conclusion: "failure",
+      },
+      {
+        name: "crcr/nvidia/cuda-deep/CI/test",
+        status: "in_progress",
+        conclusion: null,
+      },
+    ]);
+
+    const result = await handler.getCrcrBlockingFailures();
+    expect(result.sort()).toEqual(
+      ["apple/mps-backend", "nvidia/cuda-deep"].sort()
+    );
+  });
+
+  test("ignores non-CRCR failures for known L4 repos", async () => {
+    const handler = makeHandler();
+    handler.ctx.octokit.paginate.mockResolvedValue([
+      {
+        name: "apple/mps-backend/CI", // no crcr/ prefix
+        status: "completed",
+        conclusion: "failure",
+      },
+    ]);
+
+    const result = await handler.getCrcrBlockingFailures();
+    expect(result).toEqual([]);
+  });
+
+  test("only returns allowlisted L4 repos, not unknown CRCR repos", async () => {
+    const handler = makeHandler();
+    handler.ctx.octokit.paginate.mockResolvedValue([
+      {
+        name: "crcr/unknown/repo/CI/build",
+        status: "completed",
+        conclusion: "failure",
+      },
+    ]);
+
+    const result = await handler.getCrcrBlockingFailures();
+    expect(result).toEqual([]);
+  });
+});

--- a/torchci/test/crcrOncallBot.test.ts
+++ b/torchci/test/crcrOncallBot.test.ts
@@ -1,0 +1,201 @@
+import nock from "nock";
+import { Probot } from "probot";
+import crcrOncallBot from "../lib/bot/crcrOncallBot";
+import * as crcrAllowlist from "../lib/crcrAllowlist";
+import { clearAllowlistCache, CrcrAllowlist } from "../lib/crcrAllowlist";
+import { handleScope } from "./common";
+import * as utils from "./utils";
+
+nock.disableNetConnect();
+
+const OWNER = "pytorch";
+const REPO = "pytorch";
+const PR_NUMBER = 42;
+const HEAD_SHA = "abc123def456789";
+
+function mockAllowlist() {
+  const mockAl = CrcrAllowlist.fromYaml(`
+L3:
+  xpu:
+    intel/torch-xpu-ops: [oncall_xpu]
+L4:
+  - apple/mps-backend: oncall_mps
+`);
+  jest.spyOn(crcrAllowlist, "fetchCrcrAllowlist").mockResolvedValue(mockAl);
+}
+
+describe("crcrOncallBot", () => {
+  let probot: Probot;
+
+  beforeEach(() => {
+    clearAllowlistCache();
+    probot = utils.testProbot();
+    probot.load(crcrOncallBot);
+    nock("https://api.github.com")
+      .post("/app/installations/2/access_tokens")
+      .reply(200, { token: "test" });
+    mockAllowlist();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    jest.restoreAllMocks();
+  });
+
+  function checkRunPayload(overrides: Record<string, unknown> = {}) {
+    return {
+      action: "completed",
+      check_run: {
+        name: "crcr/intel/torch-xpu-ops/CI/build",
+        head_sha: HEAD_SHA,
+        status: "completed",
+        conclusion: "failure",
+        html_url: "https://github.com/pytorch/pytorch/runs/12345",
+        pull_requests: [{ number: PR_NUMBER }],
+        ...overrides,
+      },
+      repository: {
+        owner: { login: OWNER },
+        name: REPO,
+      },
+    };
+  }
+
+  test("posts comment on L3 CRCR check run failure", async () => {
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments`)
+      .reply(200, [])
+      .post(
+        `/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments`,
+        (body: any) => {
+          expect(body.body).toContain(
+            "<!-- crcr-oncall:intel/torch-xpu-ops -->"
+          );
+          expect(body.body).toContain("intel/torch-xpu-ops");
+          expect(body.body).toContain("@oncall_xpu");
+          expect(body.body).toContain(HEAD_SHA.slice(0, 7));
+          return true;
+        }
+      )
+      .reply(200);
+
+    await probot.receive({
+      name: "check_run" as any,
+      payload: checkRunPayload() as any,
+      id: "1",
+    });
+    handleScope(scope);
+  });
+
+  test("posts comment on L4 CRCR check run failure", async () => {
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments`)
+      .reply(200, [])
+      .post(
+        `/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments`,
+        (body: any) => {
+          expect(body.body).toContain("apple/mps-backend");
+          expect(body.body).toContain("@oncall_mps");
+          return true;
+        }
+      )
+      .reply(200);
+
+    await probot.receive({
+      name: "check_run" as any,
+      payload: checkRunPayload({
+        name: "crcr/apple/mps-backend/CI/build",
+      }) as any,
+      id: "2",
+    });
+    handleScope(scope);
+  });
+
+  test("does not comment on non-CRCR check runs", async () => {
+    await probot.receive({
+      name: "check_run" as any,
+      payload: checkRunPayload({
+        name: "some-other-check",
+      }) as any,
+      id: "3",
+    });
+  });
+
+  test("does not comment on successful check runs", async () => {
+    await probot.receive({
+      name: "check_run" as any,
+      payload: checkRunPayload({
+        conclusion: "success",
+      }) as any,
+      id: "4",
+    });
+  });
+
+  test("does not comment on neutral check runs", async () => {
+    await probot.receive({
+      name: "check_run" as any,
+      payload: checkRunPayload({
+        conclusion: "neutral",
+      }) as any,
+      id: "5",
+    });
+  });
+
+  test("dedup: does not comment twice if marker already exists", async () => {
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments`)
+      .reply(200, [
+        {
+          id: 100,
+          body: "<!-- crcr-oncall:intel/torch-xpu-ops -->\nprevious comment",
+        },
+      ]);
+
+    await probot.receive({
+      name: "check_run" as any,
+      payload: checkRunPayload() as any,
+      id: "6",
+    });
+    handleScope(scope);
+  });
+
+  test("does not comment when allowlist has no oncalls for repo", async () => {
+    const mockAl = CrcrAllowlist.fromYaml(`
+L3:
+  xpu:
+    intel/no-oncall-repo: []
+`);
+    jest.spyOn(crcrAllowlist, "fetchCrcrAllowlist").mockResolvedValue(mockAl);
+
+    await probot.receive({
+      name: "check_run" as any,
+      payload: checkRunPayload({
+        name: "crcr/intel/no-oncall-repo/CI/build",
+      }) as any,
+      id: "7",
+    });
+  });
+
+  test("does not comment when no PR is associated", async () => {
+    await probot.receive({
+      name: "check_run" as any,
+      payload: checkRunPayload({
+        pull_requests: [],
+      }) as any,
+      id: "8",
+    });
+  });
+
+  test("does nothing for unsupported org", async () => {
+    const payload = checkRunPayload();
+    payload.repository = {
+      owner: { login: "some-other-org" },
+      name: REPO,
+    };
+    await probot.receive({
+      name: "check_run" as any,
+      payload: payload as any,
+      id: "9",
+    });
+  });
+});

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -267,6 +267,7 @@ function constructResultsCommentHelper({
   unstableJobs = [],
   unknownJobs = [],
   awaitingApprovalJobs = [],
+  crcrL3Jobs = [],
   sha = "random sha",
   merge_base = "random_merge_base_sha",
   merge_base_date = "2023-08-08 06:03:21",
@@ -282,6 +283,7 @@ function constructResultsCommentHelper({
   unstableJobs?: RecentWorkflowsData[];
   unknownJobs?: RecentWorkflowsData[];
   awaitingApprovalJobs?: RecentWorkflowsData[];
+  crcrL3Jobs?: RecentWorkflowsData[];
   sha?: string;
   merge_base?: string;
   merge_base_date?: string;
@@ -298,6 +300,7 @@ function constructResultsCommentHelper({
     unstableJobs,
     unknownJobs,
     awaitingApprovalJobs,
+    crcrL3Jobs,
     new Map(),
     new Map(),
     new Map(),


### PR DESCRIPTION

## Summary

Implement CRCR on-call bot and merge-blocking logic for downstream CI failures, driven by a structured allowlist (L1-L4) that maps downstream repos to severity levels and on-call contacts.

## Changes

### CRCR Allowlist (`lib/crcrAllowlist.ts`)
Parses `.github/allowlist.yml` from `pytorch/pytorch`, mapping downstream repos to four levels:
- **L1/L2**: Tracked only, no on-call behavior.
- **L3**: Non-blocking failure — on-call is notified but merge is not blocked.
- **L4**: Blocking failure — on-call is notified and merge is blocked.

Includes a 15-minute in-memory cache and strict YAML validation. Errors fail open.

### On-call Bot (`lib/bot/crcrOncallBot.ts`)
A Probot bot on `check_run.completed`: when a CRCR check run fails, looks up on-calls from the allowlist and posts a tagged comment on the associated PR. Deduplicates via an HTML comment marker (theoretical TOCTOU race exists but is negligible in practice since checks arrive sequentially).

### Merge Blocking (`lib/bot/pytorchBotHandler.ts`)
`@pytorchbot merge` checks the GitHub Checks API for CRCR failures on the PR head commit. L4 failures block the merge with a comment listing failing repos. `-f` bypasses this, consistent with existing force-merge semantics. Errors fail open.
- Introduced `ensureHeadSha()` helper to deduplicate the lazy-load pattern for `headSha` across methods.

### Dr.CI Integration
- `fetchRecentWorkflows.ts`: New `fetchOotWorkflows()` queries `oot_workflow_job` from ClickHouse. Uses a new `downstreamLevel` field on `RecentWorkflowsData` instead of overloading `failure_context`.
- `drci.ts`: L4 failures appear as blocking; L3 failures appear in a new "OUT OF TREE (non-blocking)" section.

### Tests
Unit tests for allowlist parsing and on-call bot behavior, plus updated Dr.CI test helpers.