### PR TITLE
Add docs-build to viable-strict blocking workflows in HUD

### DIFF
--- a/clickhouse_db_schema/grafana_alerts/broken_viable_strict.sql
+++ b/clickhouse_db_schema/grafana_alerts/broken_viable_strict.sql
@@ -23,7 +23,7 @@ WITH raw_jobs AS (
     WHERE
         -- Filter down to the viable/strict blocking jobs we care about
         (
-            j.workflow_name IN ('pull', 'trunk')
+            j.workflow_name IN ('pull', 'trunk', 'docs-build')
             OR j.workflow_name LIKE 'linux-binary-%'
         )
         AND j.job_name NOT LIKE '%rerun_disabled_tests%'

--- a/torchci/clickhouse_queries/master_commit_red/query.sql
+++ b/torchci/clickhouse_queries/master_commit_red/query.sql
@@ -33,7 +33,8 @@ all_runs AS (
             'Lint',
             'pull',
             'trunk',
-            'linux-aarch64'
+            'linux-aarch64',
+            'docs-build'
         )
         AND workflow_run.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
         AND workflow_run.id IN (

--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -9,7 +9,7 @@ type RepoViableStrictBlockingJobsMap = {
 
 // Source of truth for these jobs is in https://github.com/pytorch/pytorch/blob/main/.github/workflows/update-viablestrict.yml#L26
 export const VIABLE_STRICT_BLOCKING_JOBS: RepoViableStrictBlockingJobsMap = {
-  "pytorch/pytorch": [/pull/i, /trunk/i, /lint/i, /linux-aarch64/i],
+  "pytorch/pytorch": [/pull/i, /trunk/i, /lint/i, /linux-aarch64/i, /docs-build/i],
 };
 
 export function isJobViableStrictBlocking(

--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -9,7 +9,13 @@ type RepoViableStrictBlockingJobsMap = {
 
 // Source of truth for these jobs is in https://github.com/pytorch/pytorch/blob/main/.github/workflows/update-viablestrict.yml#L26
 export const VIABLE_STRICT_BLOCKING_JOBS: RepoViableStrictBlockingJobsMap = {
-  "pytorch/pytorch": [/pull/i, /trunk/i, /lint/i, /linux-aarch64/i, /docs-build/i],
+  "pytorch/pytorch": [
+    /pull/i,
+    /trunk/i,
+    /lint/i,
+    /linux-aarch64/i,
+    /docs-build/i,
+  ],
 };
 
 export function isJobViableStrictBlocking(

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -24,7 +24,7 @@ export default function Kpis() {
           queryParams={{
             ...timeParams,
             granularity: "week",
-            workflowNames: ["lint", "pull", "trunk"],
+            workflowNames: ["lint", "pull", "trunk", "docs-build"],
           }}
           granularity={"week"}
           timeFieldName={"granularity_bucket"}

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -496,7 +496,7 @@ export default function Page() {
     JSON.stringify({
       ...timeParams,
       // TODO (huydhn): Figure out a way to have default parameters for ClickHouse queries
-      workflowNames: ["lint", "pull", "trunk", "linux-aarch64"],
+      workflowNames: ["lint", "pull", "trunk", "linux-aarch64", "docs-build"],
     })
   )}`;
 
@@ -841,7 +841,7 @@ export default function Page() {
             <WorkflowDuration
               percentile={ttsPercentile}
               timeParams={timeParams}
-              workflowNames={["pull", "trunk"]}
+              workflowNames={["pull", "trunk", "docs-build"]}
             />
           </Stack>
         </Grid>


### PR DESCRIPTION
## Summary

Adds the `docs-build` workflow to the viable-strict blocking set that HUD recognizes, across both the frontend classifier/metrics and the ClickHouse/Grafana queries.

## Why

`docs-build` is being added to the auto-revert bot's viable-strict blocking group (pytorch-gha-infra), so HUD needs to treat it as viable/strict blocking too — otherwise its failures wouldn't show in the viable-strict views, red-commit metrics, or the broken-viable-strict alert, leaving the two systems inconsistent.

The classifier comment points to `update-viablestrict.yml` in pytorch/pytorch as the source of truth — `docs-build` must also be added there for these mirrors to be correct.