### PR TITLE
[release/2.12] Pin torch to 2.12.1 in binary validations

### DIFF
--- a/.github/workflows/validate-binaries.yml
+++ b/.github/workflows/validate-binaries.yml
@@ -22,6 +22,11 @@ on:
         default: false
         required: false
         type: boolean
+      version:
+        description: 'Version to validate'
+        default: "2.12.1"
+        required: false
+        type: string
       include-test-ops:
         description: 'Include Test Ops tests (only Linux)'
         default: false
@@ -82,7 +87,7 @@ on:
         type: boolean
       version:
         description: 'Version to validate'
-        default: ""
+        default: "2.12.1"
         required: false
         type: string
       include-test-ops:


### PR DESCRIPTION
The `test` channel now serves torch `2.13.0`, so the unpinned `pip3 install torch torchvision torchaudio --index-url .../test/...` command pulls `2.13.0` and validation fails:

```
RuntimeError: Torch version mismatch, expected 2.12.1 for channel test. But its 2.13.0+cpu
```
(see https://github.com/pytorch/test-infra/actions/runs/27662566427)

The install command only gets a `==` version pin when `RELEASE_VERSION` is set, which comes from the `version` input (previously defaulting to `""`).

This defaults the `validate-binaries` `version` input to `2.12.1` for both the `workflow_call` and `workflow_dispatch` triggers, so `RELEASE_VERSION=2.12.1` and the install command becomes `pip3 install torch==2.12.1 ...`.