### PR TITLE
[release/2.12] Pin test-infra-ref to release/2.12 for generate-release-matrix

### DIFF
--- a/.github/workflows/validate-binaries.yml
+++ b/.github/workflows/validate-binaries.yml
@@ -121,6 +121,7 @@ jobs:
     uses: ./.github/workflows/generate_release_matrix.yml
     with:
       version: ${{ inputs.version }}
+      test-infra-ref: release/2.12
 
   win:
     if:  inputs.os == 'windows' || inputs.os == 'all'


### PR DESCRIPTION
The `generate-release-matrix` job in `validate-binaries.yml` calls `generate_release_matrix.yml` without passing `test-infra-ref`, so it defaults to `main` and runs `generate_release_matrix.py` from `main` - which has no `2.12.1` entry in `RELEASE_DICT`.

So even after adding `2.12.1` to `RELEASE_DICT` on `release/2.12`, the job still fails:

```
ValueError: 2.12.1 is not a valid release
```
(see https://github.com/pytorch/test-infra/actions/runs/27695214935/job/81916500279)

Pin `test-infra-ref: release/2.12` on that job so the script is run from the release branch, matching the matrix-generation pinning done in #8167.