### PR TITLE
[release/2.12] Write release_matrix.json into .ci so smoke_test finds it

### DIFF
--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -158,7 +158,7 @@ jobs:
           export AUDIO_RELEASE_VERSION=${{ fromJson(inputs.release-matrix).torchaudio }}
         fi
 
-        printf '%s\n' ${{ toJson(inputs.release-matrix) }} > release_matrix.json
+        printf '%s\n' ${{ toJson(inputs.release-matrix) }} > .ci/release_matrix.json
         eval "$(conda shell.bash hook)"
 
         # NB: The latest conda 23.11.0 pulls in some dependencies of conda-libmamba-solver that

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -155,7 +155,7 @@ jobs:
         export USE_FORCE_REINSTALL="true"
         export TARGET_OS="linux"
         eval "$(conda shell.bash hook)"
-        printf '%s\n' ${{ toJson(inputs.release-matrix) }} > release_matrix.json
+        printf '%s\n' ${{ toJson(inputs.release-matrix) }} > .ci/release_matrix.json
 
         CUDA_VERSION_STABLE=$(python3 ../../test-infra/tools/scripts/get_stable_cuda_version.py --channel ${MATRIX_CHANNEL})
         # Special case PyPi installation package. And Install of PyPi package via poetry

--- a/.github/workflows/validate-macos-arm64-binaries.yml
+++ b/.github/workflows/validate-macos-arm64-binaries.yml
@@ -143,5 +143,5 @@ jobs:
           export AUDIO_RELEASE_VERSION=${{ fromJson(inputs.release-matrix).torchaudio }}
         fi
 
-        printf '%s\n' ${{ toJson(inputs.release-matrix) }} > release_matrix.json
+        printf '%s\n' ${{ toJson(inputs.release-matrix) }} > .ci/release_matrix.json
         source ../../test-infra/.github/scripts/validate_binaries.sh

--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -140,7 +140,7 @@ jobs:
           export AUDIO_RELEASE_VERSION=${{ fromJson(inputs.release-matrix).torchaudio }}
         fi
 
-        printf '%s\n' ${{ toJson(inputs.release-matrix) }} > release_matrix.json
+        printf '%s\n' ${{ toJson(inputs.release-matrix) }} > .ci/release_matrix.json
         source /c/Jenkins/Miniconda3/etc/profile.d/conda.sh
         if [[ ${MATRIX_GPU_ARCH_TYPE} == "cuda" ]]; then
           ./.ci/pytorch/windows/internal/driver_update.bat


### PR DESCRIPTION
Now that `RELEASE_VERSION` is set (`2.12.1`) for the release validations, pytorch's `smoke_test.py` reads the release matrix from `BASE_DIR / release_matrix.json`, where `BASE_DIR = Path(__file__).parent.parent.parent` resolves to `<pytorch>/.ci`. The validate workflows wrote `release_matrix.json` to the pytorch checkout root instead, so smoke_test fails:

```
ImportError: File release_matrix.json not found error: No such file or directory
```
(see https://github.com/pytorch/test-infra/actions/runs/27696461816/job/81921043446)

Write the `release-matrix` input to `.ci/release_matrix.json` in the four `validate-*-binaries` workflows so it lands where smoke_test reads it.

This wasn't hit on `main` because `RELEASE_VERSION` is empty there, so smoke_test takes the `else` branch (`MATRIX_STABLE_VERSION`) and never reads the file.