### PR TITLE
[release/2.12] Pin torch in amazon-linux-2023 validation job

### DIFF
--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -204,5 +204,11 @@ jobs:
           DWN_PYTORCH_ORG="https://download.pytorch.org/whl/cu${CUDA_VERSION_NODOT}"
         fi
 
-        python3.11 -m pip install torch --progress-bar off --index-url ${DWN_PYTORCH_ORG}
+        # Pin torch to the release version so we don't pick up a newer
+        # version that happens to be in the channel (e.g. the next RC).
+        TORCH_SPEC="torch"
+        if [[ -n "${{ inputs.version }}" ]]; then
+          TORCH_SPEC="torch==${{ inputs.version }}"
+        fi
+        python3.11 -m pip install ${TORCH_SPEC} --progress-bar off --index-url ${DWN_PYTORCH_ORG}
         python3.11 .ci/pytorch/smoke_test/smoke_test.py --package torchonly


### PR DESCRIPTION
The `amazon-linux-2023-test` job does its own `pip install torch` (unpinned), so unlike the other validation jobs it bypasses the `RELEASE_VERSION` pin. The `test` channel now serves torch `2.13.0`, so the job installs `2.13.0+cu130` and fails the downstream cuDNN check:

```
RuntimeError: cuDNN version mismatch for CUDA 13.0. Loaded: 9.20.0 Expected: 9.23.1 (from generate_binary_build_matrix.py)
```
(see https://github.com/pytorch/test-infra/actions/runs/27697537691/job/81924815518)

The cuDNN mismatch is a symptom - the real problem is the wrong torch version. Pin the install to `torch==${{ inputs.version }}` (`2.12.1`), guarded so it stays unpinned when `version` is empty (e.g. on `main`/nightly).