### PR TITLE
[release/2.12] Check out pytorch release/2.12 for binary validation

### DIFF
--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -121,7 +121,7 @@ jobs:
     with:
       runner: ${{ matrix.validation_runner }}
       repository: "pytorch/pytorch"
-      ref: main
+      ref: release/2.12
       job-name: ${{ matrix.build_name }}
       docker-image: ${{ matrix.container_image }}
       binary-matrix: ${{ toJSON(matrix) }}

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -130,7 +130,7 @@ jobs:
     with:
       runner: ${{ matrix.validation_runner }}
       repository: "pytorch/pytorch"
-      ref: main
+      ref: release/2.12
       job-name: ${{ matrix.build_name }}
       docker-image: ${{ ((matrix.gpu_arch_type == 'xpu' || matrix.gpu_arch_type == 'rocm') && matrix.container_image) || 'pytorch/almalinux-builder:cpu-main' }}
       binary-matrix: ${{ toJSON(matrix) }}
@@ -176,7 +176,7 @@ jobs:
     with:
       runner: "linux.g5.4xlarge.nvidia.gpu"
       repository: "pytorch/pytorch"
-      ref: main
+      ref: release/2.12
       job-name: "amazon-linux-2023-test"
       docker-image: 'almalinux/9-base'
       docker-build-dir: "skip-docker-build"

--- a/.github/workflows/validate-macos-arm64-binaries.yml
+++ b/.github/workflows/validate-macos-arm64-binaries.yml
@@ -119,7 +119,7 @@ jobs:
     with:
       runner: ${{ matrix.validation_runner }}
       repository: "pytorch/pytorch"
-      ref: main
+      ref: release/2.12
       job-name: ${{ matrix.build_name }}
       binary-matrix: ${{ toJSON(matrix) }}
       script: |

--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -120,7 +120,7 @@ jobs:
     with:
       runner: ${{ matrix.package_type == 'libtorch' && 'windows.4xlarge' || matrix.validation_runner }}
       repository: "pytorch/pytorch"
-      ref: main
+      ref: release/2.12
       job-name: ${{ matrix.build_name }}
       binary-matrix: ${{ toJSON(matrix) }}
       timeout: 60


### PR DESCRIPTION
The `validate-*-binaries` jobs check out pytorch `@main` to run `smoke_test.py`. The cuDNN check in smoke_test reads the expected version from `PYTORCH_ROOT/.github/scripts/generate_binary_build_matrix.py`, which on `main` is `nvidia-cudnn-cu13==9.23.1.3` (the 2.13.0 line). But we install the 2.12.1 release wheel, which bundles cuDNN `9.20.0.48`, so validation fails:

```
RuntimeError: cuDNN version mismatch for CUDA 13.0. Loaded: 9.20.0 Expected: 9.23.1 (from generate_binary_build_matrix.py)
```
(see https://github.com/pytorch/test-infra/actions/runs/27697537691/job/81924914938)

Check out pytorch at `release/2.12` so the smoke tests and the cuDNN/matrix expectations match the release being validated - `release/2.12` pins `nvidia-cudnn-cu13==9.20.0.48`, which matches the installed wheel.

Verified that pytorch `release/2.12`'s `smoke_test.py` still reads `release_matrix.json` from the same `.ci` location (BASE_DIR unchanged), so PR #8190's handling is unaffected.