### PR TITLE
[release/2.12] Ignore known GDS/cuFile smoke test failure on CUDA 13.2

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -171,6 +171,34 @@ install_numpy_1x() {
     fi
 }
 
+# Known smoke test failure that should not fail validation.
+#
+# CUDA 13.2 ships cuFile >= 1.17, whose expanded compatibility mode lets
+# cuFileHandleRegister succeed without the nvidia-fs driver (I/O falls back to
+# POSIX). test_cuda_gds_errors_captured() in pytorch's smoke_test.py assumes
+# registration always fails in CI and errors out. This is fixed on pytorch
+# main (pytorch/pytorch#180577) but not on release/2.12, so ignore it here.
+GDS_KNOWN_FAILURE="Expected cuFileHandleRegister failed RuntimeError but have not received!"
+
+# Run smoke_test.py, tolerating the known GDS/cuFile failure above. Any other
+# failure is propagated so it still fails validation.
+run_smoke_test_script() {
+    local smoke_test_log
+    smoke_test_log="$(mktemp)"
+    local rc=0
+    if ${PYTHON_RUN} ./smoke_test/smoke_test.py "$@" 2>&1 | tee "${smoke_test_log}"; then
+        rc=0
+    else
+        rc=${PIPESTATUS[0]}
+        if grep -qF "${GDS_KNOWN_FAILURE}" "${smoke_test_log}"; then
+            echo "::warning::Ignoring known GDS/cuFile smoke test failure on CUDA 13.2 (pytorch/pytorch#180577)"
+            rc=0
+        fi
+    fi
+    rm -f "${smoke_test_log}"
+    return ${rc}
+}
+
 # Run smoke tests
 run_smoke_tests() {
     local test_suffix="$1"
@@ -189,12 +217,12 @@ run_smoke_tests() {
     fi
 
     # Regular smoke test
-    ${PYTHON_RUN} ./smoke_test/smoke_test.py ${test_suffix}
+    run_smoke_test_script ${test_suffix}
 
     # For pip install also test with latest numpy
     if [[ ${MATRIX_PACKAGE_TYPE} == 'wheel' ]]; then
         pip3 install numpy --upgrade --force-reinstall
-        ${PYTHON_RUN} ./smoke_test/smoke_test.py ${test_suffix}
+        run_smoke_test_script ${test_suffix}
     fi
 
     popd


### PR DESCRIPTION
## Why

CUDA 13.2 ships cuFile >= 1.17, whose expanded compatibility mode lets `cuFileHandleRegister` succeed without the nvidia-fs kernel driver (I/O silently falls back to POSIX). pytorch's `test_cuda_gds_errors_captured()` assumes registration always fails in CI and errors with:

```
RuntimeError: Expected cuFileHandleRegister failed RuntimeError but have not received!
```
(see https://github.com/pytorch/test-infra/actions/runs/27699283817/job/81931103799)

This is already fixed on pytorch `main` by pytorch/pytorch#180577, but that fix is not on pytorch `release/2.12` (which validation now checks out).

## What

Wrap the `smoke_test.py` invocations in `validate_binaries.sh` with `run_smoke_test_script`, which tees the output and treats **only** this specific GDS/cuFile failure as a known issue (logs a `::warning::` and continues). Any other smoke-test failure still propagates and fails validation.

This is a stop-gap for the release branch; the proper fix is cherry-picking pytorch/pytorch#180577 into pytorch `release/2.12`.