### PR TITLE
[release/2.12] Add no-torchaudio option to validate-binaries

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -68,6 +68,9 @@ build_installation_command() {
     # torch-only option: remove vision and audio
     if [[ ${TORCH_ONLY:-} == 'true' ]]; then
         installation=${installation/"torchvision torchaudio"/""}
+    # no-torchaudio option: remove audio only, keep vision
+    elif [[ ${NO_TORCHAUDIO:-} == 'true' ]]; then
+        installation=${installation/" torchaudio"/""}
     fi
 
     # if RELEASE version is passed as parameter - install specific version
@@ -89,6 +92,8 @@ build_installation_command() {
 get_test_suffix() {
     if [[ ${TORCH_ONLY:-} == 'true' ]]; then
         echo "--package torchonly"
+    elif [[ ${NO_TORCHAUDIO:-} == 'true' ]]; then
+        echo "--package torch_torchvision"
     else
         echo ""
     fi

--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -12,6 +12,11 @@ on:
         default: false
         required: false
         type: boolean
+      no-torchaudio:
+        description: 'Validate without torchaudio (torch + torchvision only)'
+        default: false
+        required: false
+        type: boolean
       version:
         description: 'Version to validate - optional'
         default: ""
@@ -60,6 +65,11 @@ on:
           - all
       torchonly:
         description: 'Validate torchonly'
+        default: false
+        required: false
+        type: boolean
+      no-torchaudio:
+        description: 'Validate without torchaudio (torch + torchvision only)'
         default: false
         required: false
         type: boolean
@@ -147,6 +157,7 @@ jobs:
         export ENV_NAME="conda-env-${{ github.run_id }}"
         export TARGET_OS="linux-aarch64"
         export TORCH_ONLY=${{ inputs.torchonly }}
+        export NO_TORCHAUDIO=${{ inputs.no-torchaudio }}
         export RELEASE_VERSION=${{ inputs.version }}
         export USE_FORCE_REINSTALL="true"
         export USE_EXTRA_INDEX_URL=${{ inputs.use-extra-index-url }}

--- a/.github/workflows/validate-binaries.yml
+++ b/.github/workflows/validate-binaries.yml
@@ -22,6 +22,11 @@ on:
         default: false
         required: false
         type: boolean
+      no-torchaudio:
+        description: 'Validate without torchaudio (torch + torchvision only)'
+        default: false
+        required: false
+        type: boolean
       version:
         description: 'Version to validate'
         default: "2.12.1"
@@ -85,6 +90,11 @@ on:
         default: false
         required: false
         type: boolean
+      no-torchaudio:
+        description: 'Validate without torchaudio (torch + torchvision only)'
+        default: false
+        required: false
+        type: boolean
       version:
         description: 'Version to validate'
         default: "2.12.1"
@@ -130,6 +140,7 @@ jobs:
     with:
       channel: ${{ inputs.channel }}
       torchonly: ${{ inputs.torchonly }}
+      no-torchaudio: ${{ inputs.no-torchaudio }}
       version: ${{ inputs.version }}
       release-matrix: ${{ needs.generate-release-matrix.outputs.matrix }}
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
@@ -144,6 +155,7 @@ jobs:
     with:
       channel: ${{ inputs.channel }}
       torchonly: ${{ inputs.torchonly }}
+      no-torchaudio: ${{ inputs.no-torchaudio }}
       version: ${{ inputs.version }}
       release-matrix: ${{ needs.generate-release-matrix.outputs.matrix }}
       include-test-ops: ${{ inputs.include-test-ops }}
@@ -159,6 +171,7 @@ jobs:
     with:
       channel: ${{ inputs.channel }}
       torchonly: ${{ inputs.torchonly }}
+      no-torchaudio: ${{ inputs.no-torchaudio }}
       version: ${{ inputs.version }}
       release-matrix: ${{ needs.generate-release-matrix.outputs.matrix }}
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
@@ -173,6 +186,7 @@ jobs:
     with:
       channel: ${{ inputs.channel }}
       torchonly: ${{ inputs.torchonly }}
+      no-torchaudio: ${{ inputs.no-torchaudio }}
       version: ${{ inputs.version }}
       release-matrix: ${{ needs.generate-release-matrix.outputs.matrix }}
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -12,6 +12,11 @@ on:
         default: false
         required: false
         type: boolean
+      no-torchaudio:
+        description: 'Validate without torchaudio (torch + torchvision only)'
+        default: false
+        required: false
+        type: boolean
       version:
         description: 'Version to validate - optional'
         default: ""
@@ -65,6 +70,11 @@ on:
           - all
       torchonly:
         description: 'Validate torchonly'
+        default: false
+        required: false
+        type: boolean
+      no-torchaudio:
+        description: 'Validate without torchaudio (torch + torchvision only)'
         default: false
         required: false
         type: boolean
@@ -140,6 +150,7 @@ jobs:
         set -ex
         export ENV_NAME="conda-env-${{ github.run_id }}"
         export TORCH_ONLY=${{ inputs.torchonly }}
+        export NO_TORCHAUDIO=${{ inputs.no-torchaudio }}
         export INCLUDE_TEST_OPS=${{ inputs.include-test-ops }}
         export USE_ONLY_DL_PYTORCH_ORG=${{ inputs.use-only-dl-pytorch-org }}
         export USE_EXTRA_INDEX_URL=${{ inputs.use-extra-index-url }}

--- a/.github/workflows/validate-macos-arm64-binaries.yml
+++ b/.github/workflows/validate-macos-arm64-binaries.yml
@@ -12,6 +12,11 @@ on:
         default: false
         required: false
         type: boolean
+      no-torchaudio:
+        description: 'Validate without torchaudio (torch + torchvision only)'
+        default: false
+        required: false
+        type: boolean
       version:
         description: 'Version to validate - optional'
         default: ""
@@ -60,6 +65,11 @@ on:
           - all
       torchonly:
         description: 'Validate torchonly'
+        default: false
+        required: false
+        type: boolean
+      no-torchaudio:
+        description: 'Validate without torchaudio (torch + torchvision only)'
         default: false
         required: false
         type: boolean
@@ -127,6 +137,7 @@ jobs:
         export ENV_NAME="conda-env-${{ github.run_id }}"
         export TARGET_OS="macos-arm64"
         export TORCH_ONLY=${{ inputs.torchonly }}
+        export NO_TORCHAUDIO=${{ inputs.no-torchaudio }}
         export RELEASE_VERSION=${{ inputs.version }}
         export USE_FORCE_REINSTALL="true"
         export USE_EXTRA_INDEX_URL=${{ inputs.use-extra-index-url }}

--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -12,6 +12,11 @@ on:
         default: false
         required: false
         type: boolean
+      no-torchaudio:
+        description: 'Validate without torchaudio (torch + torchvision only)'
+        default: false
+        required: false
+        type: boolean
       version:
         description: 'Version to validate - optional'
         default: ""
@@ -60,6 +65,11 @@ on:
           - all
       torchonly:
         description: 'Validate torchonly'
+        default: false
+        required: false
+        type: boolean
+      no-torchaudio:
+        description: 'Validate without torchaudio (torch + torchvision only)'
         default: false
         required: false
         type: boolean
@@ -129,6 +139,7 @@ jobs:
         export ENV_NAME="conda-env-${{ github.run_id }}"
         export TARGET_OS="windows"
         export TORCH_ONLY=${{ inputs.torchonly }}
+        export NO_TORCHAUDIO=${{ inputs.no-torchaudio }}
         export RELEASE_VERSION=${{ inputs.version }}
         export USE_FORCE_REINSTALL="true"
         export USE_EXTRA_INDEX_URL=${{ inputs.use-extra-index-url }}


### PR DESCRIPTION
### Summary
Adds a `no-torchaudio` option to `validate-binaries` (and the four per-OS validation workflows) that validates **torch + torchvision** while skipping torchaudio.

This is needed when a `torchaudio` binary is not available for a given configuration (e.g. the Windows XPU wheel in the [release/2.12 validate-binaries run](https://github.com/pytorch/test-infra/actions/runs/27709856019/job/81967949562)) but `torch` / `torchvision` should still be validated. Today the only way to skip audio is `torchonly`, which also drops torchvision.

### Changes
- New boolean input `no-torchaudio` (default `false`) on:
  - `validate-binaries.yml` (passed through to all OS jobs)
  - `validate-windows-binaries.yml`, `validate-linux-binaries.yml`, `validate-aarch64-linux-binaries.yml`, `validate-macos-arm64-binaries.yml` (exported as `NO_TORCHAUDIO`)
- `.github/scripts/validate_binaries.sh`:
  - install command removes only `torchaudio` (keeps `torchvision`)
  - smoke test invoked with `--package torch_torchvision`
- `torchonly` continues to take precedence when both are set.

The smoke test (`pytorch/pytorch` `.ci/pytorch/smoke_test/smoke_test.py`) already supports this via the existing `--package torch_torchvision` choice, so no smoke-test change is required.

### Test plan
- `bash -n .github/scripts/validate_binaries.sh` passes.
- Verified the install-string substitution keeps `torchvision` + `--index-url` and removes `torchaudio`.
- Run `validate-binaries` with `no-torchaudio=true` against the test channel to confirm Windows XPU validates without audio.