### PR TITLE
[CRCR] Implement zombie workflow entries cleaner

### DIFF
--- a/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
@@ -73,7 +73,9 @@ def _parse_callback_body(body: dict) -> tuple[str, str, int, int, str]:
         workflow_dict = body["workflow"]
         status = workflow_dict["status"]
         run_id = int(workflow_dict["run_id"])  # Required for HUD grouping
-        run_attempt = int(workflow_dict.get("run_attempt", 1))  # Default to 1 if not present
+        run_attempt = int(
+            workflow_dict.get("run_attempt", 1)
+        )  # Default to 1 if not present
         workflow_name = workflow_dict["name"]  # Required for HUD grouping
     except (KeyError, TypeError) as exc:
         logger.warning(f"missing required field in callback body: {exc}")

--- a/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
@@ -93,6 +93,7 @@ def _update_state_and_compute_metrics(
     status: str,
     dispatch_record: CallbackStateRecord,
     workflow_record: CallbackStateRecord | None,
+    payload: dict | None = None,
 ) -> dict:
     """Persist the new workflow state to Redis and return CI timing metrics.
 
@@ -125,6 +126,7 @@ def _update_state_and_compute_metrics(
             state,
             current_timestamp,
             workflow_name,
+            payload=payload,
         )
     except RedisError:
         raise HTTPException(
@@ -201,6 +203,20 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
         config, delivery_id, verified_repo, run_id, run_attempt
     )
 
+    payload = None
+    if status == "in_progress":
+        payload = {
+            "trusted": {
+                "ci_metrics": {
+                    "queue_time": None,
+                    "execution_time": None,
+                },
+                "verified_repo": verified_repo,
+                "downstream_repo_level": repo_level.value,
+            },
+            "untrusted": {"callback_payload": body},
+        }
+
     ci_metrics = _update_state_and_compute_metrics(
         config,
         delivery_id,
@@ -211,7 +227,18 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
         status,
         dispatch_record,
         workflow_record,
+        payload=payload,
     )
+
+    # Track in-progress jobs for zombie detection.
+    if status == "in_progress":
+        redis_helper.add_in_progress_tracker(
+            config, delivery_id, verified_repo, run_id, run_attempt
+        )
+    elif status == "completed":
+        redis_helper.remove_in_progress_tracker(
+            config, delivery_id, verified_repo, run_id, run_attempt
+        )
 
     trusted = {
         "ci_metrics": ci_metrics,

--- a/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
@@ -72,8 +72,8 @@ def _parse_callback_body(body: dict) -> tuple[str, str, int, int, str]:
         delivery_id = body["delivery_id"]
         workflow_dict = body["workflow"]
         status = workflow_dict["status"]
-        run_id = workflow_dict["run_id"]  # Required for HUD grouping
-        run_attempt = workflow_dict.get("run_attempt", 1)  # Default to 1 if not present
+        run_id = int(workflow_dict["run_id"])  # Required for HUD grouping
+        run_attempt = int(workflow_dict.get("run_attempt", 1))  # Default to 1 if not present
         workflow_name = workflow_dict["name"]  # Required for HUD grouping
     except (KeyError, TypeError) as exc:
         logger.warning(f"missing required field in callback body: {exc}")

--- a/aws/lambda/cross_repo_ci_relay/callback/cleanup_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/cleanup_handler.py
@@ -29,8 +29,8 @@ def _build_timeout_payload(zombie: dict, completed_at: str) -> tuple[dict, dict]
     """
     state_record = zombie["state_record"]
     stored = state_record.payload
-    stored_trusted = stored["trusted"]
-    stored_untrusted = stored["untrusted"]
+    stored_trusted = dict(stored["trusted"])
+    stored_untrusted = dict(stored["untrusted"])
 
     # ci_metrics: execution_time from in_progress → now
     execution_time = round(time.time() - state_record.timestamp, 3)

--- a/aws/lambda/cross_repo_ci_relay/callback/cleanup_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/cleanup_handler.py
@@ -1,0 +1,166 @@
+"""Zombie-job cleanup handler.
+
+Triggered by EventBridge cron events.  Scans the Redis in-progress ZSET for
+jobs whose timeout has expired, marks them as timed_out in HUD, and cleans up
+the Redis records.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from concurrent.futures import as_completed, ThreadPoolExecutor
+
+import utils.redis_helper as redis_helper
+from redis.exceptions import RedisError
+from utils.config import RelayConfig
+from utils.hud import forward_to_hud
+from utils.misc import CallbackState
+
+
+logger = logging.getLogger(__name__)
+
+
+def _build_timeout_payload(zombie: dict, completed_at: str) -> tuple[dict, dict]:
+    """Build trusted and untrusted HUD payloads for a timed-out job.
+
+    Starts from the stored HUD envelope that was captured at IN_PROGRESS time,
+    then updates ci_metrics and workflow status/conclusion for the timeout.
+    """
+    state_record = zombie["state_record"]
+    stored = state_record.payload
+    stored_trusted = stored["trusted"]
+    stored_untrusted = stored["untrusted"]
+
+    # ci_metrics: execution_time from in_progress → now
+    execution_time = round(time.time() - state_record.timestamp, 3)
+    if execution_time < 0:
+        execution_time = 0
+
+    stored_trusted["ci_metrics"] = {
+        "queue_time": None,
+        "execution_time": execution_time,
+    }
+
+    # Update the stored workflow with timeout conclusion
+
+    workflow = stored_untrusted["callback_payload"]["workflow"]
+    workflow["status"] = "completed"
+    workflow["conclusion"] = "timed_out"
+    workflow["completed_at"] = completed_at
+
+    return stored_trusted, stored_untrusted
+
+
+def _cleanup_one(
+    *,
+    config: RelayConfig,
+    zombie: dict,
+    completed_at: str,
+) -> dict:
+    """Process a single zombie job: forward timeout to HUD, update Redis,
+    and remove the in-progress tracker.
+
+    Returns a dict with ``ok`` indicating whether the zombie was cleaned
+    successfully (HUD forward succeeded).
+    """
+    delivery_id = zombie["delivery_id"]
+    repo = zombie["downstream_repo"]
+    run_id = zombie["run_id"]
+    run_attempt = zombie["run_attempt"]
+    hud_ok = True
+
+    # 1. Build and forward timeout payload to HUD
+    try:
+        trusted, untrusted = _build_timeout_payload(zombie, completed_at)
+        forward_to_hud(config, trusted, untrusted)
+        logger.info(
+            "zombie HUD forward succeeded repo=%s run_id=%s run_attempt=%s",
+            repo,
+            run_id,
+            run_attempt,
+        )
+    except Exception:
+        logger.exception(
+            "zombie HUD forward failed repo=%s run_id=%s run_attempt=%s",
+            repo,
+            run_id,
+            run_attempt,
+        )
+        hud_ok = False
+
+    if hud_ok:
+        # 2. Mark state as COMPLETED in Redis (best-effort)
+        try:
+            redis_helper.set_callback_state(
+                config,
+                delivery_id,
+                repo,
+                run_id,
+                run_attempt,
+                CallbackState.COMPLETED,
+                time.time(),
+            )
+        except (AssertionError, RedisError):
+            # Race: another process already resolved this record, or Redis
+            # was unavailable.
+            logger.warning(
+                "zombie state transition failed (may already be resolved) "
+                "delivery_id=%s repo=%s run_id=%s run_attempt=%s",
+                delivery_id,
+                repo,
+                run_id,
+                run_attempt,
+            )
+        # Erase the records from Redis only when HUD was successfully
+        # updated, keeping the two systems in sync.
+        redis_helper.remove_in_progress_tracker(
+            config, delivery_id, repo, run_id, run_attempt
+        )
+
+    return {"ok": hud_ok}
+
+
+def handle(config: RelayConfig) -> dict:
+    """Scan for zombie jobs and clean them up in parallel.
+
+    Returns a summary dict with counts of cleaned and errored zombies.
+    """
+    zombies = redis_helper.scan_expired_in_progress(config)
+    results = {"cleaned": 0, "errors": 0}
+
+    if not zombies:
+        logger.info("zombie scan: no expired jobs found")
+        return {"ok": True, **results}
+
+    logger.info("zombie scan: found %d expired job(s)", len(zombies))
+    completed_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    with ThreadPoolExecutor(max_workers=config.max_cleanup_workers) as pool:
+        future_to_zombie = {
+            pool.submit(
+                _cleanup_one,
+                config=config,
+                zombie=zombie,
+                completed_at=completed_at,
+            ): zombie
+            for zombie in zombies
+        }
+
+        for future in as_completed(future_to_zombie):
+            zombie = future_to_zombie[future]
+            try:
+                result = future.result()
+                if result["ok"]:
+                    results["cleaned"] += 1
+                else:
+                    results["errors"] += 1
+            except Exception:
+                logger.exception(
+                    "zombie cleanup unexpected failure repo=%s run_id=%s",
+                    zombie.get("downstream_repo"),
+                    zombie.get("run_id"),
+                )
+                results["errors"] += 1
+
+    return {"ok": True, **results}

--- a/aws/lambda/cross_repo_ci_relay/callback/lambda_function.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/lambda_function.py
@@ -7,7 +7,7 @@ from utils import jwt_helper
 from utils.config import get_config
 from utils.misc import HTTPException, JSON_HEADERS, parse_lambda_event
 
-from . import callback_handler
+from . import callback_handler, cleanup_handler
 
 
 logging.getLogger().setLevel(logging.INFO)
@@ -15,6 +15,16 @@ logger = logging.getLogger(__name__)
 
 
 def lambda_handler(event, context):
+    # EventBridge scheduled events trigger zombie-job cleanup.
+    if event.get("source") == "crcr.sweeper":
+        config = get_config()
+        result = cleanup_handler.handle(config)
+        return {
+            "statusCode": 200,
+            "headers": JSON_HEADERS,
+            "body": json.dumps(result),
+        }
+
     method, path, body_bytes, headers = parse_lambda_event(event)
 
     logger.info("request method=%s path=%s", method, path)

--- a/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
@@ -60,11 +60,13 @@ class TestCallbackHandler(unittest.TestCase):
                 return CallbackStateRecord(
                     CallbackState.DISPATCHED,
                     time.time() - 30,
+                    {},
                 )
             elif run_id_arg == 99999:  # default run_id in _body()
                 return CallbackStateRecord(
                     CallbackState.IN_PROGRESS,
                     time.time() - 20,
+                    {},
                 )
             return None
 
@@ -116,10 +118,12 @@ class TestCallbackHandler(unittest.TestCase):
         dispatch_record = CallbackStateRecord(
             CallbackState.DISPATCHED,
             1000.0,
+            {},
         )
         workflow_record = CallbackStateRecord(
             CallbackState.IN_PROGRESS,
             1030.0,
+            {},
         )
         self.mock_redis.get_callback_state.side_effect = [
             dispatch_record,  # dispatch lookup
@@ -139,14 +143,17 @@ class TestCallbackHandler(unittest.TestCase):
         dispatch_record = CallbackStateRecord(
             CallbackState.DISPATCHED,
             1000.0,
+            {},
         )
         workflow_record = CallbackStateRecord(
             CallbackState.IN_PROGRESS,
             1030.0,
+            {},
         )
         completed_record = CallbackStateRecord(
             CallbackState.COMPLETED,
             1060.0,
+            {},
         )
         self.mock_redis.get_callback_state.side_effect = [
             dispatch_record,  # dispatch lookup
@@ -213,6 +220,7 @@ class TestCallbackHandler(unittest.TestCase):
         dispatch_record = CallbackStateRecord(
             CallbackState.DISPATCHED,
             1000.0,
+            {},
         )
         # Three calls: dispatch lookup, workflow record lookup, re-read after set.
         self.mock_redis.get_callback_state.side_effect = [

--- a/aws/lambda/cross_repo_ci_relay/tests/test_cleanup_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_cleanup_handler.py
@@ -1,0 +1,262 @@
+"""Tests for zombie-job cleanup handler."""
+
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+from callback.cleanup_handler import _build_timeout_payload, handle
+from utils.misc import CallbackState
+from utils.redis_helper import CallbackStateRecord
+
+
+def _cfg():
+    cfg = MagicMock()
+    cfg.hud_api_url = "http://hud/api/oot/results"
+    cfg.hud_bot_key = "bot-key-123"
+    cfg.zombie_timeout_seconds = 86400
+    cfg.max_cleanup_workers = 4
+    return cfg
+
+
+def _callback_body(
+    delivery_id="del-123",
+    run_id=99999,
+    run_attempt=1,
+    status="in_progress",
+    conclusion=None,
+):
+    """Build a minimal callback body matching the downstream composite action."""
+    return {
+        "event_type": "pull_request",
+        "delivery_id": delivery_id,
+        "payload": {
+            "pull_request": {"number": 42, "head": {"sha": "abc123"}},
+            "repository": {"full_name": "pytorch/pytorch"},
+        },
+        "workflow": {
+            "schema_version": "1",
+            "status": status,
+            "conclusion": conclusion,
+            "name": "CI",
+            "url": "https://github.com/org/repo/actions/runs/999",
+            "run_id": str(run_id),
+            "run_attempt": str(run_attempt),
+            "job_name": "my-job",
+            "check_run_id": "cr-456",
+            "started_at": "2026-06-17T10:00:00Z",
+            "completed_at": None,
+        },
+    }
+
+
+def _zombie_entry(
+    delivery_id="del-123",
+    repo="org/repo",
+    run_id=99999,
+    run_attempt=1,
+    in_progress_ts=None,
+    body_overrides=None,
+):
+    """Build a zombie dict as returned by scan_expired_in_progress."""
+    if in_progress_ts is None:
+        in_progress_ts = time.time() - 90000  # expired: ~25h ago
+
+    body = _callback_body(delivery_id, run_id, run_attempt)
+    if body_overrides:
+        _deep_update(body, body_overrides)
+
+    stored_payload = {
+        "trusted": {
+            "ci_metrics": {"queue_time": None, "execution_time": None},
+            "verified_repo": repo,
+            "downstream_repo_level": "L2",
+        },
+        "untrusted": {"callback_payload": body},
+    }
+
+    return {
+        "delivery_id": delivery_id,
+        "downstream_repo": repo,
+        "run_id": run_id,
+        "run_attempt": run_attempt,
+        "state_record": CallbackStateRecord(
+            CallbackState.IN_PROGRESS, in_progress_ts, stored_payload
+        ),
+    }
+
+
+def _deep_update(d, u):
+    """Recursively update dict d with dict u."""
+    for k, v in u.items():
+        if isinstance(v, dict) and isinstance(d.get(k), dict):
+            _deep_update(d[k], v)
+        else:
+            d[k] = v
+
+
+class TestBuildTimeoutPayload(unittest.TestCase):
+    def test_happy_path(self):
+        """Payload includes all required fields for HUD."""
+        now = time.time()
+        zombie = _zombie_entry(in_progress_ts=now - 3600)  # 1h ago
+        trusted, untrusted = _build_timeout_payload(zombie, "2026-06-18T11:00:00Z")
+
+        # trusted
+        self.assertEqual(trusted["verified_repo"], "org/repo")
+        self.assertEqual(trusted["downstream_repo_level"], "L2")
+        self.assertIsNone(trusted["ci_metrics"]["queue_time"])
+        self.assertGreaterEqual(trusted["ci_metrics"]["execution_time"], 3600)
+
+        # untrusted
+        cp = untrusted["callback_payload"]
+        self.assertEqual(cp["delivery_id"], "del-123")
+        self.assertEqual(cp["event_type"], "pull_request")
+        self.assertEqual(cp["payload"]["pull_request"]["number"], 42)
+        self.assertEqual(cp["payload"]["repository"]["full_name"], "pytorch/pytorch")
+
+        wf = cp["workflow"]
+        self.assertEqual(wf["status"], "completed")
+        self.assertEqual(wf["conclusion"], "timed_out")
+        self.assertEqual(wf["name"], "CI")
+        self.assertEqual(wf["job_name"], "my-job")
+        self.assertEqual(wf["check_run_id"], "cr-456")
+        self.assertEqual(wf["run_id"], "99999")
+        self.assertEqual(wf["run_attempt"], "1")
+        self.assertEqual(wf["completed_at"], "2026-06-18T11:00:00Z")
+
+    def test_minimal_body(self):
+        """Payload handles push events (no PR) correctly."""
+        zombie = _zombie_entry(
+            body_overrides={
+                "event_type": "push",
+                "payload": {
+                    "pull_request": None,
+                    "repository": {"full_name": "pytorch/pytorch"},
+                },
+            }
+        )
+        trusted, untrusted = _build_timeout_payload(zombie, "2026-06-18T11:00:00Z")
+
+        cp = untrusted["callback_payload"]
+        self.assertEqual(cp["event_type"], "push")
+        self.assertIsNotNone(trusted["ci_metrics"]["execution_time"])
+
+    def test_negative_execution_time_clamped_to_zero(self):
+        """If in_progress timestamp is somehow in the future, execution_time is 0."""
+        future_ts = time.time() + 3600
+        zombie = _zombie_entry(in_progress_ts=future_ts)
+        trusted, _ = _build_timeout_payload(zombie, "2026-06-18T11:00:00Z")
+        self.assertEqual(trusted["ci_metrics"]["execution_time"], 0)
+
+
+class TestCleanupHandler(unittest.TestCase):
+    def setUp(self):
+        self.patcher_redis = patch("callback.cleanup_handler.redis_helper")
+        self.mock_redis = self.patcher_redis.start()
+
+        self.patcher_hud = patch("callback.cleanup_handler.forward_to_hud")
+        self.mock_hud = self.patcher_hud.start()
+
+    def tearDown(self):
+        self.patcher_redis.stop()
+        self.patcher_hud.stop()
+
+    def test_no_expired_jobs(self):
+        """Empty scan returns cleanly."""
+        self.mock_redis.scan_expired_in_progress.return_value = []
+        result = handle(_cfg())
+        self.assertEqual(result, {"ok": True, "cleaned": 0, "errors": 0})
+        self.mock_hud.assert_not_called()
+
+    def test_cleans_single_zombie(self):
+        """Happy path: one expired zombie gets HUD forward + Redis cleanup."""
+        zombie = _zombie_entry()
+        self.mock_redis.scan_expired_in_progress.return_value = [zombie]
+
+        result = handle(_cfg())
+
+        self.assertEqual(result["cleaned"], 1)
+        self.assertEqual(result["errors"], 0)
+
+        # HUD was called
+        self.mock_hud.assert_called_once()
+        trusted, untrusted = self.mock_hud.call_args[0][1:]
+        self.assertEqual(trusted["verified_repo"], "org/repo")
+        self.assertEqual(
+            untrusted["callback_payload"]["workflow"]["conclusion"], "timed_out"
+        )
+
+        # Redis state was updated to COMPLETED
+        self.mock_redis.set_callback_state.assert_called_once()
+        call_args = self.mock_redis.set_callback_state.call_args[0]
+        self.assertEqual(call_args[1], "del-123")
+        self.assertEqual(call_args[2], "org/repo")
+        self.assertEqual(call_args[3], 99999)
+        self.assertEqual(call_args[4], 1)
+        self.assertEqual(call_args[5], CallbackState.COMPLETED)
+
+        # ZSET entry was removed
+        self.mock_redis.remove_in_progress_tracker.assert_called_once()
+        rm_args = self.mock_redis.remove_in_progress_tracker.call_args[0]
+        self.assertEqual(rm_args[1], "del-123")
+        self.assertEqual(rm_args[2], "org/repo")
+        self.assertEqual(rm_args[3], 99999)
+        self.assertEqual(rm_args[4], 1)
+
+    def test_cleans_multiple_zombies(self):
+        """Multiple zombies are all cleaned independently."""
+        zombies = [
+            _zombie_entry(delivery_id="del-1", run_id=1),
+            _zombie_entry(delivery_id="del-2", run_id=2),
+            _zombie_entry(delivery_id="del-3", run_id=3),
+        ]
+        self.mock_redis.scan_expired_in_progress.return_value = zombies
+
+        result = handle(_cfg())
+
+        self.assertEqual(result["cleaned"], 3)
+        self.assertEqual(result["errors"], 0)
+        self.assertEqual(self.mock_hud.call_count, 3)
+        self.assertEqual(self.mock_redis.set_callback_state.call_count, 3)
+        self.assertEqual(self.mock_redis.remove_in_progress_tracker.call_count, 3)
+
+    def test_hud_failure_records_error_continues(self):
+        """If HUD forward fails for one zombie, it's counted as error and others continue."""
+        zombie1 = _zombie_entry(delivery_id="del-1", run_id=1)
+        zombie2 = _zombie_entry(delivery_id="del-2", run_id=2)
+
+        self.mock_redis.scan_expired_in_progress.return_value = [zombie1, zombie2]
+
+        def _hud_side_effect(_config, _trusted, untrusted):
+            if untrusted["callback_payload"]["delivery_id"] == "del-1":
+                raise Exception("HUD unreachable")
+            # else succeeds
+
+        self.mock_hud.side_effect = _hud_side_effect
+
+        result = handle(_cfg())
+
+        self.assertEqual(result["cleaned"], 1)
+        self.assertEqual(result["errors"], 1)
+        # Both zombies were attempted
+        self.assertEqual(self.mock_hud.call_count, 2)
+
+    def test_state_transition_assertion_error_continues(self):
+        """If set_callback_state raises AssertionError (race condition), cleanup continues."""
+        zombie = _zombie_entry()
+        self.mock_redis.scan_expired_in_progress.return_value = [zombie]
+        self.mock_redis.set_callback_state.side_effect = AssertionError(
+            "rejecting duplicate COMPLETED"
+        )
+
+        result = handle(_cfg())
+
+        # Still considered "cleaned" — HUD was forwarded and ZSET removed
+        self.assertEqual(result["cleaned"], 1)
+        self.assertEqual(result["errors"], 0)
+        self.mock_hud.assert_called_once()
+        self.mock_redis.remove_in_progress_tracker.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/aws/lambda/cross_repo_ci_relay/tests/test_redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_redis_helper.py
@@ -231,7 +231,7 @@ class TestCallbackStateMachine(unittest.TestCase):
             cfg, delivery_id, repo, run_id_arg, run_attempt_arg, client=None
         ):
             if run_id_arg == DISPATCH_RUN_ID:
-                return CallbackStateRecord(CallbackState.DISPATCHED, 1000.0)
+                return CallbackStateRecord(CallbackState.DISPATCHED, 1000.0, {})
             return None
 
         cfg = _cfg()
@@ -251,6 +251,7 @@ class TestCallbackStateMachine(unittest.TestCase):
                 1010.0,
                 workflow_name="test-workflow",
                 client=client,
+                payload={},
             )
 
 
@@ -292,6 +293,7 @@ class TestInProgressTracker(unittest.TestCase):
     def _cfg_with_zombie_timeout(self):
         cfg = _cfg()
         cfg.zombie_timeout_seconds = 86400
+        cfg.in_progress_warn_threshold = 1000
         return cfg
 
     def test_add_in_progress_tracker_zadd_with_correct_score(self):
@@ -353,6 +355,7 @@ class TestInProgressTracker(unittest.TestCase):
 
         cfg = self._cfg_with_zombie_timeout()
         client = MagicMock()
+        client.zcard.return_value = 0
         now = 1700000000.0
         client.zrangebyscore.return_value = [
             "del-1:org/repo:10:1",
@@ -390,6 +393,7 @@ class TestInProgressTracker(unittest.TestCase):
 
         cfg = self._cfg_with_zombie_timeout()
         client = MagicMock()
+        client.zcard.return_value = 0
         client.zrangebyscore.return_value = ["del-missing:org/repo:5:1"]
         client.get.return_value = None  # state record expired
 
@@ -408,6 +412,7 @@ class TestInProgressTracker(unittest.TestCase):
 
         cfg = self._cfg_with_zombie_timeout()
         client = MagicMock()
+        client.zcard.return_value = 0
         client.zrangebyscore.return_value = ["bad-member"]
 
         with unittest.mock.patch("utils.redis_helper.time") as mock_time:

--- a/aws/lambda/cross_repo_ci_relay/tests/test_redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_redis_helper.py
@@ -184,7 +184,7 @@ class TestCallbackStateMachine(unittest.TestCase):
             cfg, delivery_id, repo, run_id_arg, run_attempt_arg, client=None
         ):
             if run_id_arg == DISPATCH_RUN_ID:
-                return CallbackStateRecord(CallbackState.DISPATCHED, 1000.0)
+                return CallbackStateRecord(CallbackState.DISPATCHED, 1000.0, {})
             return None
 
         client = MagicMock()
@@ -282,6 +282,181 @@ class TestRateLimit(unittest.TestCase):
         with self.assertRaises(HTTPException) as ctx:
             check_rate_limit(_cfg(), "org/repo", client=client)
         self.assertEqual(ctx.exception.status_code, 500)
+
+
+class TestInProgressTracker(unittest.TestCase):
+    def setUp(self):
+        redis_helper._cached_client = None
+        redis_helper._cached_client_url = None
+
+    def _cfg_with_zombie_timeout(self):
+        cfg = _cfg()
+        cfg.zombie_timeout_seconds = 86400
+        return cfg
+
+    def test_add_in_progress_tracker_zadd_with_correct_score(self):
+        """ZADD with now + zombie_timeout_seconds as score."""
+        from utils.redis_helper import add_in_progress_tracker
+
+        client = MagicMock()
+        cfg = self._cfg_with_zombie_timeout()
+        now = 1700000000.0
+
+        with unittest.mock.patch("utils.redis_helper.time") as mock_time:
+            mock_time.time.return_value = now
+            add_in_progress_tracker(cfg, "del-123", "org/repo", 99999, 1, client=client)
+
+        expected_member = "del-123:org/repo:99999:1"
+        expected_score = now + 86400
+        client.zadd.assert_called_once_with(
+            "oot:in_progress", {expected_member: expected_score}
+        )
+        client.expire.assert_called_once_with("oot:in_progress", 172800)
+
+    def test_add_in_progress_tracker_redis_error_is_silent(self):
+        """Redis errors are logged but not raised — tracker is best-effort."""
+        from utils.redis_helper import add_in_progress_tracker
+
+        client = MagicMock()
+        client.zadd.side_effect = redis_lib.exceptions.RedisError("boom")
+        cfg = self._cfg_with_zombie_timeout()
+
+        # Should not raise
+        add_in_progress_tracker(cfg, "del-123", "org/repo", 99999, 1, client=client)
+
+    def test_remove_in_progress_tracker_zrem(self):
+        """ZREM removes the member from the ZSET."""
+        from utils.redis_helper import remove_in_progress_tracker
+
+        client = MagicMock()
+        cfg = _cfg()
+        remove_in_progress_tracker(cfg, "del-123", "org/repo", 99999, 1, client=client)
+
+        client.zrem.assert_called_once_with(
+            "oot:in_progress", "del-123:org/repo:99999:1"
+        )
+
+    def test_remove_in_progress_tracker_redis_error_is_silent(self):
+        """Redis errors on removal are logged but not raised."""
+        from utils.redis_helper import remove_in_progress_tracker
+
+        client = MagicMock()
+        client.zrem.side_effect = redis_lib.exceptions.RedisError("boom")
+        cfg = _cfg()
+
+        # Should not raise
+        remove_in_progress_tracker(cfg, "del-123", "org/repo", 99999, 1, client=client)
+
+    def test_scan_expired_returns_only_in_progress_zombies(self):
+        """scan_expired_in_progress returns entries whose state is IN_PROGRESS."""
+        from utils.redis_helper import scan_expired_in_progress
+
+        cfg = self._cfg_with_zombie_timeout()
+        client = MagicMock()
+        now = 1700000000.0
+        client.zrangebyscore.return_value = [
+            "del-1:org/repo:10:1",
+            "del-2:org/repo:20:1",
+        ]
+
+        # First entry is IN_PROGRESS (zombie), second is already COMPLETED
+        get_returns = [
+            json.dumps({"state": "IN_PROGRESS", "timestamp": now - 90000}),
+            json.dumps({"state": "COMPLETED", "timestamp": now - 100}),
+        ]
+
+        def get_side_effect(key):
+            return get_returns.pop(0) if get_returns else None
+
+        client.get.side_effect = get_side_effect
+
+        with unittest.mock.patch("utils.redis_helper.time") as mock_time:
+            mock_time.time.return_value = now
+            results = scan_expired_in_progress(cfg, client=client)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["delivery_id"], "del-1")
+        self.assertEqual(results[0]["downstream_repo"], "org/repo")
+        self.assertEqual(results[0]["run_id"], 10)
+        self.assertEqual(results[0]["run_attempt"], 1)
+        self.assertEqual(results[0]["state_record"].state, CallbackState.IN_PROGRESS)
+
+        # Second entry (COMPLETED) had its tracker cleaned up
+        client.zrem.assert_any_call("oot:in_progress", "del-2:org/repo:20:1")
+
+    def test_scan_expired_skips_missing_state_records(self):
+        """Members whose state record is gone are cleaned from the ZSET."""
+        from utils.redis_helper import scan_expired_in_progress
+
+        cfg = self._cfg_with_zombie_timeout()
+        client = MagicMock()
+        client.zrangebyscore.return_value = ["del-missing:org/repo:5:1"]
+        client.get.return_value = None  # state record expired
+
+        with unittest.mock.patch("utils.redis_helper.time") as mock_time:
+            mock_time.time.return_value = 1700000000.0
+            results = scan_expired_in_progress(cfg, client=client)
+
+        self.assertEqual(results, [])
+        client.zrem.assert_called_once_with(
+            "oot:in_progress", "del-missing:org/repo:5:1"
+        )
+
+    def test_scan_expired_handles_malformed_member(self):
+        """Malformed ZSET members are removed with a warning."""
+        from utils.redis_helper import scan_expired_in_progress
+
+        cfg = self._cfg_with_zombie_timeout()
+        client = MagicMock()
+        client.zrangebyscore.return_value = ["bad-member"]
+
+        with unittest.mock.patch("utils.redis_helper.time") as mock_time:
+            mock_time.time.return_value = 1700000000.0
+            results = scan_expired_in_progress(cfg, client=client)
+
+        self.assertEqual(results, [])
+        client.zrem.assert_called_once_with("oot:in_progress", "bad-member")
+
+    def test_set_callback_state_with_payload(self):
+        """Payload is stored alongside state and timestamp under a "payload" key."""
+        client = MagicMock()
+        cfg = _cfg()
+        payload = {
+            "trusted": {
+                "ci_metrics": {"queue_time": None, "execution_time": None},
+                "verified_repo": "org/repo",
+                "downstream_repo_level": "L2",
+            },
+            "untrusted": {
+                "delivery_id": "del-123",
+                "workflow": {"name": "CI", "run_id": "99999"},
+            },
+        }
+
+        with unittest.mock.patch(
+            "utils.redis_helper.get_callback_state", return_value=None
+        ):
+            set_callback_state(
+                cfg,
+                "del-123",
+                "org/repo",
+                99999,
+                1,
+                CallbackState.IN_PROGRESS,
+                1010.0,
+                workflow_name="test-workflow",
+                client=client,
+                payload=payload,
+            )
+
+        # setex(key, ttl, value): args[0] is key, args[1] is ttl, args[2] is JSON.
+        call_args = client.setex.call_args
+        stored_json = call_args[0][2]
+        stored = json.loads(stored_json)
+        self.assertEqual(stored["state"], "IN_PROGRESS")
+        self.assertEqual(stored["timestamp"], 1010.0)
+        self.assertEqual(stored["payload"]["trusted"]["verified_repo"], "org/repo")
+        self.assertEqual(stored["payload"]["untrusted"]["workflow"]["name"], "CI")
 
 
 if __name__ == "__main__":

--- a/aws/lambda/cross_repo_ci_relay/utils/config.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/config.py
@@ -48,6 +48,16 @@ def _require(name: str) -> str:
     return value
 
 
+def _check_if_positive_int(name: str, default: str | int | None) -> int:
+    try:
+        int_value = int(os.getenv(name, default))
+        if int_value <= 0:
+            raise ValueError(f"{name} must be a positive integer")
+        return int_value
+    except ValueError as e:
+        raise RuntimeError(f"{name} must be a positive integer") from e
+
+
 @dataclass(frozen=True)
 class RelayConfig:
     github_app_id: str
@@ -66,6 +76,7 @@ class RelayConfig:
     rate_limit_per_min: int
     zombie_timeout_seconds: int
     max_cleanup_workers: int
+    in_progress_warn_threshold: int
 
     @classmethod
     def from_env(cls) -> "RelayConfig":
@@ -113,24 +124,19 @@ class RelayConfig:
                     f"Secret at {secret_store_arn!r} is missing keys: {', '.join(missing_in_secret)}"
                 )
 
-        try:
-            allowlist_ttl_seconds = int(os.getenv("ALLOWLIST_TTL_SECONDS", "1200"))
-        except ValueError:
-            raise RuntimeError("ALLOWLIST_TTL_SECONDS must be a valid integer")
-
         # The allowlist is fetched from GitHub without authentication, so cache churn must
         # stay comfortably below GitHub's unauthenticated 60 requests/hour rate limit.
         # Enforce a 15-minute floor so an overly aggressive TTL change does not create
         # avoidable rate-limit risk in production.
-        allowlist_ttl_seconds = max(allowlist_ttl_seconds, 900)
+        allowlist_ttl_seconds = max(
+            _check_if_positive_int("ALLOWLIST_TTL_SECONDS", "900"),
+            900,
+        )
 
         # GitHub can keep a workflow in `pending` state for up to 3 days before
         # auto-cancelling it, so OOT-status records must live at least that long.
         # Default to 3 days (259200 s).
-        try:
-            oot_status_ttl = int(os.getenv("OOT_STATUS_TTL", "259200"))
-        except ValueError:
-            raise RuntimeError("OOT_STATUS_TTL must be a valid integer")
+        oot_status_ttl = _check_if_positive_int("OOT_STATUS_TTL", "259200")
 
         # Maximum number of retry attempts for HUD API calls.
         # Default to 3 retries with exponential backoff.
@@ -141,21 +147,22 @@ class RelayConfig:
         except ValueError:
             raise RuntimeError("HUD_MAX_RETRIES must be a non-negative integer")
 
-        try:
-            rate_limit_per_min = int(os.getenv("RATE_LIMIT_PER_MIN", "60"))
-            if rate_limit_per_min <= 0:
-                raise ValueError("must be positive")
-        except ValueError:
-            raise RuntimeError("RATE_LIMIT_PER_MIN must be a positive integer")
+        max_dispatch_workers = _check_if_positive_int("MAX_DISPATCH_WORKERS", "32")
+
+        rate_limit_per_min = _check_if_positive_int("RATE_LIMIT_PER_MIN", "20")
 
         # Maximum duration an in-progress job is expected to run before being
         # considered abandoned (zombie).  Default 24 hours (86400 s).
-        try:
-            zombie_timeout_seconds = int(os.getenv("ZOMBIE_TIMEOUT_SECONDS", "86400"))
-            if zombie_timeout_seconds <= 0:
-                raise ValueError("must be positive")
-        except ValueError:
-            raise RuntimeError("ZOMBIE_TIMEOUT_SECONDS must be a positive integer")
+        zombie_timeout_seconds = _check_if_positive_int(
+            "ZOMBIE_TIMEOUT_SECONDS", "86400"
+        )
+
+        max_cleanup_workers = _check_if_positive_int("MAX_CLEANUP_WORKERS", "16")
+
+        in_progress_warn_threshold = _check_if_positive_int(
+            "IN_PROGRESS_WARN_THRESHOLD",
+            "1000",
+        )
 
         hud_api_url = os.getenv("HUD_API_URL", "https://hud.pytorch.org/api")
         if hud_api_url and not hud_api_url.startswith("https://"):
@@ -175,14 +182,15 @@ class RelayConfig:
             redis_endpoint=_require("REDIS_ENDPOINT"),
             redis_login=redis_login,
             allowlist_ttl_seconds=allowlist_ttl_seconds,
-            max_dispatch_workers=int(os.getenv("MAX_DISPATCH_WORKERS", "32")),
+            max_dispatch_workers=max_dispatch_workers,
             hud_api_url=hud_api_url,
             hud_bot_key=hud_bot_key,
             oot_status_ttl=oot_status_ttl,
             hud_max_retries=hud_max_retries,
             rate_limit_per_min=rate_limit_per_min,
             zombie_timeout_seconds=zombie_timeout_seconds,
-            max_cleanup_workers=int(os.getenv("MAX_CLEANUP_WORKERS", "16")),
+            max_cleanup_workers=max_cleanup_workers,
+            in_progress_warn_threshold=in_progress_warn_threshold,
         )
 
 

--- a/aws/lambda/cross_repo_ci_relay/utils/config.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/config.py
@@ -64,6 +64,8 @@ class RelayConfig:
     oot_status_ttl: int
     hud_max_retries: int
     rate_limit_per_min: int
+    zombie_timeout_seconds: int
+    max_cleanup_workers: int
 
     @classmethod
     def from_env(cls) -> "RelayConfig":
@@ -146,6 +148,15 @@ class RelayConfig:
         except ValueError:
             raise RuntimeError("RATE_LIMIT_PER_MIN must be a positive integer")
 
+        # Maximum duration an in-progress job is expected to run before being
+        # considered abandoned (zombie).  Default 24 hours (86400 s).
+        try:
+            zombie_timeout_seconds = int(os.getenv("ZOMBIE_TIMEOUT_SECONDS", "86400"))
+            if zombie_timeout_seconds <= 0:
+                raise ValueError("must be positive")
+        except ValueError:
+            raise RuntimeError("ZOMBIE_TIMEOUT_SECONDS must be a positive integer")
+
         hud_api_url = os.getenv("HUD_API_URL", "https://hud.pytorch.org/api")
         if hud_api_url and not hud_api_url.startswith("https://"):
             raise RuntimeError(
@@ -170,6 +181,8 @@ class RelayConfig:
             oot_status_ttl=oot_status_ttl,
             hud_max_retries=hud_max_retries,
             rate_limit_per_min=rate_limit_per_min,
+            zombie_timeout_seconds=zombie_timeout_seconds,
+            max_cleanup_workers=int(os.getenv("MAX_CLEANUP_WORKERS", "16")),
         )
 
 

--- a/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 
 import jwt
-
 from utils.misc import HTTPException
 
 

--- a/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 import jwt
+
 from utils.misc import HTTPException
 
 

--- a/aws/lambda/cross_repo_ci_relay/utils/misc.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/misc.py
@@ -50,10 +50,11 @@ class CallbackState(str, Enum):
 
 @dataclass
 class CallbackStateRecord:
-    """Record containing state, timestamp."""
+    """Record containing state, timestamp, and stored payload (optional)."""
 
     state: CallbackState
     timestamp: float
+    payload: dict | None
 
 
 def parse_lambda_event(event: dict) -> tuple[str, str, bytes, dict]:

--- a/aws/lambda/cross_repo_ci_relay/utils/misc.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/misc.py
@@ -38,7 +38,7 @@ DISPATCH_RUN_ATTEMPT = 0
 class CallbackState(str, Enum):
     """Unified state machine for callback lifecycle (both webhook and callback sides).
 
-    - ``DISPATCHED``: webhook side, when repository_dispatch is sent (run_id=DISPATCH_CHECK_RUN_ID).
+    - ``DISPATCHED``: webhook side, when repository_dispatch is sent (run_id=DISPATCH_RUN_ID).
     - ``IN_PROGRESS``: callback side, when downstream workflow reports started (per-workflow).
     - ``COMPLETED``: callback side, when downstream workflow reports finished (per-workflow).
     """

--- a/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
@@ -424,6 +424,18 @@ def scan_expired_in_progress(
         if client is None:
             client = create_client(config)
         now = time.time()
+
+        # Warn if the ZSET is growing unusually large — may indicate the sweeper
+        # is not keeping up or has stopped running, allowing zombies to accumulate.
+        zset_size = client.zcard(_IN_PROGRESS_ZSET)
+        if zset_size > config.in_progress_warn_threshold:
+            logger.warning(
+                "in_progress ZSET cardinality %d exceeds threshold %d — "
+                "sweeper may be falling behind or not running",
+                zset_size,
+                config.in_progress_warn_threshold,
+            )
+
         expired_members = client.zrangebyscore(_IN_PROGRESS_ZSET, "-inf", now)
         if not expired_members:
             logger.info("no expired in_progress members found")

--- a/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 _ALLOWLIST_CACHE_KEY = "oot:allowlist_yaml"
 _STATE_PREFIX = "oot:state:"
 _RATE_LIMIT_PREFIX = "oot:rate:"
+_IN_PROGRESS_ZSET = "oot:in_progress"
 _cached_client: redis_lib.Redis | None = None
 _cached_client_url: str | None = None
 
@@ -188,7 +189,7 @@ def get_callback_state(
 ) -> CallbackStateRecord | None:
     """Get callback state record from Redis, or None if no record exists.
 
-    Returns a record containing state, timestamp.
+    Returns a record containing state, timestamp, and any stored payload.
     """
     try:
         if client is None:
@@ -201,11 +202,12 @@ def get_callback_state(
         return CallbackStateRecord(
             state=CallbackState(data["state"]),
             timestamp=data["timestamp"],
+            payload=data.get("payload"),
         )
     except RedisError:
         logger.exception("redis temporary outage or unreachable")
     except Exception:
-        logger.exception("redis get_callback_state failed")
+        logger.exception("redis get_callback_state failed to parse record")
     return None
 
 
@@ -219,6 +221,7 @@ def set_callback_state(
     timestamp: float,
     workflow_name: str | None = None,
     client: redis_lib.Redis | None = None,
+    payload: dict | None = None,
 ) -> None:
     """Set callback state with timestamp in Redis.
 
@@ -310,6 +313,8 @@ def set_callback_state(
             "state": state.value,
             "timestamp": timestamp,
         }
+        if payload:
+            data["payload"] = payload
         client.setex(key, config.oot_status_ttl, json.dumps(data))
         logger.info(
             "callback state set key=%s state=%s timestamp=%s",
@@ -323,3 +328,149 @@ def set_callback_state(
     except Exception:
         logger.exception("redis set_callback_state failed")
         raise
+
+
+def _in_progress_member(
+    delivery_id: str, downstream_repo: str, run_id: int, run_attempt: int
+) -> str:
+    """Build a ZSET member string from the state-key components."""
+    return f"{delivery_id}:{downstream_repo}:{run_id}:{run_attempt}"
+
+
+def _parse_in_progress_member(member: str) -> tuple[str, str, int, int]:
+    """Parse a ZSET member string back into its components.
+
+    The repo part may contain '/' (e.g. 'org/repo'), so we split from the right
+    for the integer fields and from the left for delivery_id.
+    """
+    parts = member.split(":")
+    if len(parts) < 4:
+        raise ValueError(f"invalid in-progress member: {member!r}")
+    # delivery_id is the first token, then repo is everything up to the last two tokens
+    delivery_id = parts[0]
+    run_attempt = int(parts[-1])
+    run_id = int(parts[-2])
+    downstream_repo = ":".join(parts[1:-2])
+    return delivery_id, downstream_repo, run_id, run_attempt
+
+
+def add_in_progress_tracker(
+    config: RelayConfig,
+    delivery_id: str,
+    downstream_repo: str,
+    run_id: int,
+    run_attempt: int,
+    client: redis_lib.Redis | None = None,
+) -> None:
+    """Add a job to the in-progress ZSET for zombie detection.
+
+    The ZSET score is the expected timeout timestamp (now + zombie_timeout_seconds).
+    Logs and ignores Redis errors — a missed tracker addition only affects zombie
+    detection for this one job, not the core callback flow.
+    """
+    try:
+        if client is None:
+            client = create_client(config)
+        member = _in_progress_member(delivery_id, downstream_repo, run_id, run_attempt)
+        timeout_ts = time.time() + config.zombie_timeout_seconds
+        client.zadd(_IN_PROGRESS_ZSET, {member: timeout_ts})
+        # Auto-expire the ZSET key so it doesn't accumulate stale members forever.
+        client.expire(_IN_PROGRESS_ZSET, config.zombie_timeout_seconds * 2)
+        logger.info(
+            "in_progress tracker added member=%s timeout_ts=%s", member, timeout_ts
+        )
+    except RedisError:
+        logger.exception("failed to add in_progress tracker member=%s", member)
+
+
+def remove_in_progress_tracker(
+    config: RelayConfig,
+    delivery_id: str,
+    downstream_repo: str,
+    run_id: int,
+    run_attempt: int,
+    client: redis_lib.Redis | None = None,
+) -> None:
+    """Remove a job from the in-progress ZSET after normal completion.
+
+    Logs and ignores Redis errors — the ZSET member will eventually expire anyway.
+    """
+    try:
+        if client is None:
+            client = create_client(config)
+        member = _in_progress_member(delivery_id, downstream_repo, run_id, run_attempt)
+        client.zrem(_IN_PROGRESS_ZSET, member)
+        logger.info("in_progress tracker removed member=%s", member)
+    except RedisError:
+        logger.exception("failed to remove in_progress tracker member=%s", member)
+
+
+def scan_expired_in_progress(
+    config: RelayConfig,
+    client: redis_lib.Redis | None = None,
+) -> list[dict]:
+    """Scan the in-progress ZSET for members whose timeout has expired.
+
+    For each expired member, fetch the corresponding state record.  Only return
+    entries whose state is still IN_PROGRESS (a concurrent normal completion may
+    have already resolved it).
+
+    Returns a list of dicts with keys:
+      delivery_id, downstream_repo, run_id, run_attempt, state_record
+    The state_record includes the stored payload via ``state_record.payload``.
+    """
+    results: list[dict] = []
+    try:
+        if client is None:
+            client = create_client(config)
+        now = time.time()
+        expired_members = client.zrangebyscore(_IN_PROGRESS_ZSET, "-inf", now)
+        if not expired_members:
+            logger.info("no expired in_progress members found")
+            return results
+
+        logger.info("found %d expired in_progress members", len(expired_members))
+        for member in expired_members:
+            try:
+                delivery_id, downstream_repo, run_id, run_attempt = (
+                    _parse_in_progress_member(member)
+                )
+            except ValueError:
+                logger.warning("malformed in_progress member, removing: %s", member)
+                client.zrem(_IN_PROGRESS_ZSET, member)
+                continue
+
+            state_record = get_callback_state(
+                config, delivery_id, downstream_repo, run_id, run_attempt, client
+            )
+            if state_record is None:
+                # State record already expired/removed — clean up the stale ZSET entry.
+                logger.info(
+                    "state record missing for expired member=%s, removing tracker",
+                    member,
+                )
+                client.zrem(_IN_PROGRESS_ZSET, member)
+                continue
+
+            if state_record.state != CallbackState.IN_PROGRESS:
+                # Already resolved (race with normal completion) — just clean up.
+                logger.info(
+                    "state already %s for member=%s, removing tracker",
+                    state_record.state.value,
+                    member,
+                )
+                client.zrem(_IN_PROGRESS_ZSET, member)
+                continue
+
+            results.append(
+                {
+                    "delivery_id": delivery_id,
+                    "downstream_repo": downstream_repo,
+                    "run_id": run_id,
+                    "run_attempt": run_attempt,
+                    "state_record": state_record,
+                }
+            )
+    except RedisError:
+        logger.exception("scan_expired_in_progress failed")
+    return results


### PR DESCRIPTION
Implement CRCR zombie workflow entries that live in Redis and HUD, which have long time no update from their downstreams.

**Note**: This PR is stacked on another PR's changes: https://github.com/pytorch/test-infra/pull/8170. So this PR should be merged later.

Reference:
- Stack thread: https://pytorch.slack.com/archives/C0AEQAQHA2Z/p1780996156736239?thread_ts=1780914809.844389&cid=C0AEQAQHA2Z
- GitHub issue: https://github.com/pytorch/crcr-test/issues/5