### PR TITLE
[HUD] Add per-workflow Gantt chart to commit/PR pages

### DIFF
--- a/torchci/components/commit/JobTimeline.tsx
+++ b/torchci/components/commit/JobTimeline.tsx
@@ -1,0 +1,437 @@
+/**
+ * WorkflowGantt — a per-workflow Gantt / waterfall view, rendered inside a
+ * single WorkflowBox on the commit/PR page.
+ *
+ * Takes the jobs of ONE workflow (the box's jobs) and lays them on a time axis
+ * normalized to that workflow's trigger (t=0). Surfaces queue (spin-up) vs run
+ * time, pass/fail status, and dependency staggering (tests start after the build
+ * they wait on).
+ *
+ * Coloring:
+ *  - "Group" mode: every "/ build" job shares one fixed color; every other job
+ *    is colored by its config prefix (job name with the matrix "(...)" and the
+ *    test/build role stripped) via a deterministic hash → hue. So shards of the
+ *    same config share a color with NO hard-coded keyword lists.
+ *  - "Status" mode: colored by CI conclusion.
+ *
+ * Scale:
+ *  - By default the time axis is fit to the panel width (measured via
+ *    ResizeObserver), so short workflows (Lint) and long ones (trunk) both fill
+ *    the box. "Lock scale" switches to a fixed px/min for cross-box comparison.
+ *
+ * Data: reuses the JobData[] the box already has — time (started_at), durationS,
+ * queueTimeS → created/started/completed. No extra API call / backend change.
+ * Loaded lazily (next/dynamic, ssr:false) so it adds nothing until opened.
+ */
+import { JobData } from "lib/types";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+const BUILD_COLOR = "#1f77b4";
+const QUEUE_COLOR = "#d9d9d9";
+const STATUS_COLOR: Record<string, string> = {
+  success: "#2e9e44",
+  failure: "#e03b3b",
+  skipped: "#c7c7c7",
+  cancelled: "#f0932b",
+  pending: "#1b74e4",
+  queued: "#9aa0a6",
+  neutral: "#9aa0a6",
+};
+
+const ROW = 16;
+const AXIS = 20;
+const LBL = 340; // fixed label column width (px); long names scroll within it
+const PAD_L = 14; // left padding inside the bars pane (room for the 0m tick)
+const RIGHT = 40; // right padding for end-of-bar labels
+const FIXED_PXMIN = 3.4; // used when scale is locked
+const NICE_STEPS = [1, 2, 5, 10, 15, 30, 60, 120, 240, 480, 720];
+
+// "/ build" already matches "/ build-osdc" as a substring, so no osdc-specific
+// handling is needed. "build"/"test" are generic CI role suffixes, not workflow
+// or platform names.
+function isBuild(n: string) {
+  return n.includes("/ build");
+}
+function shortName(n: string) {
+  // Legend label: just strip the leading "<workflow> / " — the box already shows
+  // the workflow. (Only ever called on group keys, which carry no runner suffix.)
+  return n.includes(" / ") ? n.slice(n.indexOf(" / ") + 3) : n;
+}
+
+// Group key: collapses shards of the same config to one key, by dropping the
+// trailing matrix "(...)" and the generic role suffix.
+//   "... / linux-jammy-cuda13 / test (default, 1, 5, runner)" -> "... / linux-jammy-cuda13"
+//   any "/ build" job                                          -> "build"
+function groupKeyOf(name: string): string {
+  if (isBuild(name)) return "build";
+  let s = name.replace(/\s*\([^)]*\)\s*$/, ""); // drop trailing (matrix ...)
+  s = s.replace(/\s*\/\s*(test|build)(-osdc)?\b.*$/, ""); // drop role suffix + rest
+  return s.trim() || name;
+}
+
+// Evenly-spaced hues, computed per box: the distinct config groups present are
+// sorted and assigned hues 360/N apart, so they're maximally separated (kills the
+// coincidental crowding a global hash produced). "build" is always the fixed
+// color. Tradeoff vs hashing: a group's hue can shift if the SET of groups in the
+// box changes between commits (spacing is relative to who's present).
+function buildColorMap(keys: string[]): Record<string, string> {
+  const groups = Array.from(new Set(keys))
+    .filter((k) => k !== "build")
+    .sort();
+  const n = Math.max(groups.length, 1);
+  const map: Record<string, string> = { build: BUILD_COLOR };
+  groups.forEach((k, i) => {
+    map[k] = `hsl(${Math.round((i * 360) / n)}, 58%, 47%)`;
+  });
+  return map;
+}
+function statusColor(s: string) {
+  return STATUS_COLOR[s] || STATUS_COLOR.neutral;
+}
+
+function niceStep(span: number, targetTicks: number): number {
+  const raw = span / Math.max(1, targetTicks);
+  for (const s of NICE_STEPS) if (s >= raw) return s;
+  return NICE_STEPS[NICE_STEPS.length - 1];
+}
+
+interface PJob {
+  full: string;
+  label: string;
+  groupKey: string;
+  co: number;
+  so: number;
+  eo: number;
+  status: string;
+  dur: number;
+  q: number;
+}
+
+function processJobs(
+  jobs: JobData[]
+): { rows: PJob[]; maxEnd: number; skipped: number } | null {
+  const skipped = jobs.filter((j) => j.conclusion === "skipped").length;
+  const usable = jobs.filter((j) => {
+    if (!j.time || j.durationS == null) return false;
+    const ms = new Date(j.time).getTime();
+    // Guard against epoch/not-started timestamps (started_at = 0 -> 1970), which
+    // would corrupt the shared t0 on in-progress commits.
+    if (!isFinite(ms) || new Date(j.time).getUTCFullYear() < 2020) return false;
+    // Skipped jobs never ran; their timing is degenerate (e.g. durationS = -1).
+    if (j.conclusion === "skipped") return false;
+    return true;
+  });
+  if (usable.length === 0) return null;
+  const raw = usable.map((j) => ({
+    full: j.name || "",
+    label: j.jobName || j.name || "", // full name, matches the job list above
+    groupKey: groupKeyOf(j.name || ""),
+    startedMin: new Date(j.time as string).getTime() / 60000,
+    // clamp: clock skew can make queueTimeS slightly negative; durationS can be
+    // negative on degenerate rows. Keep created <= started <= completed.
+    q: Math.max((j.queueTimeS || 0) / 60, 0),
+    dur: Math.max((j.durationS || 0) / 60, 0),
+    status: j.conclusion || "neutral",
+  }));
+  const t0 = Math.min(...raw.map((p) => p.startedMin - p.q));
+  const rows: PJob[] = raw.map((p) => ({
+    full: p.full,
+    label: p.label,
+    groupKey: p.groupKey,
+    co: p.startedMin - p.q - t0,
+    so: p.startedMin - t0,
+    eo: p.startedMin - t0 + p.dur,
+    status: p.status,
+    dur: p.dur,
+    q: p.q,
+  }));
+  rows.sort((a, b) => a.so - b.so || b.dur - a.dur);
+  return { rows, maxEnd: Math.max(...rows.map((r) => r.eo), 1), skipped };
+}
+
+function useContainerWidth(): [React.RefObject<HTMLDivElement>, number] {
+  const ref = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      for (const e of entries) setWidth(e.contentRect.width);
+    });
+    ro.observe(el);
+    setWidth(el.clientWidth);
+    return () => ro.disconnect();
+  }, []);
+  return [ref, width];
+}
+
+export default function WorkflowGantt({ jobs }: { jobs: JobData[] }) {
+  const data = useMemo(() => processJobs(jobs), [jobs]);
+  const [colorMode, setColorMode] = useState<"group" | "status">("status");
+  const [locked, setLocked] = useState(false);
+  const [containerRef, containerWidth] = useContainerWidth();
+  // NOTE: we intentionally do NOT draw dependency edges. They can only be inferred
+  // from timing (created ~ completed of a predecessor), which is a guess, not the
+  // real `needs` DAG — it mislabels parallel siblings and multi-needs jobs. The
+  // bars below are exact; the build->test staggering is visible from positions.
+
+  if (!data) {
+    return (
+      <div style={{ padding: 8, fontSize: 12, color: "#888" }}>
+        No timing data available for this workflow.
+      </div>
+    );
+  }
+
+  const { rows, maxEnd, skipped } = data;
+  const nFail = rows.filter((r) => r.status === "failure").length;
+  const colorMap = buildColorMap(rows.map((r) => r.groupKey));
+
+  // px/minute: fit the (measured) bars pane by default, fixed when locked. The
+  // plot keeps a readable minimum and scrolls horizontally instead of squishing.
+  const effW = containerWidth || 700;
+  const fitPxMin = Math.max((effW - PAD_L - RIGHT) / maxEnd, 0.6);
+  const pxmin = locked ? FIXED_PXMIN : fitPxMin;
+
+  const plotW = maxEnd * pxmin;
+  const W = PAD_L + plotW + RIGHT;
+  const H = AXIS + rows.length * ROW + 8;
+  const xat = (m: number) => PAD_L + m * pxmin;
+
+  const targetTicks = Math.max(2, Math.round(plotW / 100));
+  const step = niceStep(maxEnd, targetTicks);
+  const grid: number[] = [];
+  for (let m = 0; m <= maxEnd + 1e-6; m += step) grid.push(Math.round(m));
+
+  const colorOf = (r: PJob) =>
+    colorMode === "group" ? colorMap[r.groupKey] : statusColor(r.status);
+
+  // legend entries for current mode
+  const legend =
+    colorMode === "group"
+      ? Array.from(new Set(rows.map((r) => r.groupKey)))
+          .sort((a, b) =>
+            a === "build" ? -1 : b === "build" ? 1 : a.localeCompare(b)
+          )
+          .map((k) => ({
+            color: colorMap[k],
+            label: k === "build" ? "build" : shortName(k),
+          }))
+      : Array.from(new Set(rows.map((r) => r.status))).map((s) => ({
+          color: statusColor(s),
+          label: s,
+        }));
+
+  return (
+    <div
+      style={{
+        border: "1px solid #ccc",
+        borderRadius: 8,
+        margin: "6px 0",
+        background: "rgba(127,127,127,0.04)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          gap: 16,
+          alignItems: "center",
+          flexWrap: "wrap",
+          padding: "6px 10px",
+          fontSize: 12,
+        }}
+      >
+        <span style={{ color: "#888" }}>
+          {rows.length} jobs · {Math.round(maxEnd)} min
+          {nFail > 0 && (
+            <span style={{ color: "#e03b3b" }}> · {nFail} failing</span>
+          )}
+          {skipped > 0 && ` · ${skipped} skipped hidden`}
+        </span>
+        <span>
+          <span style={{ color: "#888", marginRight: 6 }}>Color:</span>
+          <label style={{ marginRight: 8 }}>
+            <input
+              type="radio"
+              checked={colorMode === "status"}
+              onChange={() => setColorMode("status")}
+            />{" "}
+            Status
+          </label>
+          <label>
+            <input
+              type="radio"
+              checked={colorMode === "group"}
+              onChange={() => setColorMode("group")}
+            />{" "}
+            Group
+          </label>
+        </span>
+        <label title="Fit to panel width by default; lock for a fixed px/min so bars are comparable across workflow boxes.">
+          <input
+            type="checkbox"
+            checked={locked}
+            onChange={(e) => setLocked(e.target.checked)}
+          />{" "}
+          Lock scale
+        </label>
+      </div>
+
+      <div style={{ display: "flex", alignItems: "flex-start" }}>
+        {/* Label column: fixed width. Scrolls horizontally ONLY when a job name
+            is longer than the column, so one long name doesn't widen everything. */}
+        <div
+          style={{
+            flex: "0 0 auto",
+            width: LBL,
+            overflowX: "auto",
+            overflowY: "hidden",
+          }}
+        >
+          <div style={{ height: AXIS }} />
+          {rows.map((j, i) => (
+            <div
+              key={i}
+              title={j.full}
+              style={{
+                height: ROW,
+                lineHeight: `${ROW}px`,
+                fontSize: 9,
+                whiteSpace: "nowrap",
+                paddingLeft: 6,
+              }}
+            >
+              {j.label}
+            </div>
+          ))}
+        </div>
+
+        {/* Bars: fit the pane width by default, horizontal scroll when needed. */}
+        <div
+          ref={containerRef}
+          style={{
+            flex: "1 1 auto",
+            minWidth: 0,
+            overflowX: "auto",
+            marginLeft: 10,
+          }}
+        >
+          <svg
+            width={W}
+            height={H}
+            style={{ display: "block", maxWidth: "none" }}
+          >
+            {grid.map((m) => (
+              <g key={m}>
+                <line
+                  x1={xat(m)}
+                  y1={AXIS - 4}
+                  x2={xat(m)}
+                  y2={H}
+                  stroke="currentColor"
+                  strokeOpacity={0.12}
+                />
+                <text
+                  x={xat(m)}
+                  y={AXIS - 7}
+                  fontSize={9}
+                  fill="currentColor"
+                  fillOpacity={0.5}
+                  textAnchor="middle"
+                >
+                  {m}m
+                </text>
+              </g>
+            ))}
+            {rows.map((j, i) => {
+              const y = AXIS + i * ROW;
+              const bh = ROW - 4;
+              const qw = Math.max((j.so - j.co) * pxmin, 0);
+              const bw = Math.max((j.eo - j.so) * pxmin, 1.4);
+              return (
+                <g key={i}>
+                  {qw > 0.5 && (
+                    <rect
+                      x={xat(j.co)}
+                      y={y}
+                      width={qw}
+                      height={bh}
+                      fill={QUEUE_COLOR}
+                    />
+                  )}
+                  <rect
+                    x={xat(j.so)}
+                    y={y}
+                    width={bw}
+                    height={bh}
+                    rx={2}
+                    fill={colorOf(j)}
+                  >
+                    <title>
+                      {`${j.full}\nstatus: ${j.status}\nstart @${j.so.toFixed(
+                        1
+                      )}m · end @${j.eo.toFixed(1)}m · ${j.dur.toFixed(
+                        1
+                      )} min\nqueue ${j.q.toFixed(1)}m`}
+                    </title>
+                  </rect>
+                  {bw >= 28 && (
+                    <text
+                      x={xat(j.eo) + 3}
+                      y={y + bh - 2}
+                      fontSize={8}
+                      fill="currentColor"
+                      fillOpacity={0.55}
+                    >
+                      {Math.round(j.dur)}m
+                    </text>
+                  )}
+                </g>
+              );
+            })}
+          </svg>
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          gap: 12,
+          flexWrap: "wrap",
+          padding: "6px 10px",
+          fontSize: 11,
+          color: "#888",
+        }}
+      >
+        {legend.map((e) => (
+          <span
+            key={e.label}
+            style={{ display: "inline-flex", alignItems: "center", gap: 4 }}
+          >
+            <span
+              style={{
+                width: 11,
+                height: 10,
+                borderRadius: 2,
+                background: e.color,
+                display: "inline-block",
+              }}
+            />
+            {e.label}
+          </span>
+        ))}
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+          <span
+            style={{
+              width: 11,
+              height: 10,
+              borderRadius: 2,
+              background: QUEUE_COLOR,
+            }}
+          />
+          queue/spin-up
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/torchci/components/commit/JobTimeline.tsx
+++ b/torchci/components/commit/JobTimeline.tsx
@@ -23,19 +23,19 @@
  * queueTimeS → created/started/completed. No extra API call / backend change.
  * Loaded lazily (next/dynamic, ssr:false) so it adds nothing until opened.
  */
+import { useTheme } from "@mui/material";
 import { JobData } from "lib/types";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 const BUILD_COLOR = "#1f77b4";
-const QUEUE_COLOR = "#d9d9d9";
+// Vivid status hues read on both light and dark backgrounds. The neutral grays
+// (queued/neutral fallbacks) and the queue/spin-up bar are derived from the MUI
+// theme at render time instead (see WorkflowGantt), so they adapt to the mode.
 const STATUS_COLOR: Record<string, string> = {
   success: "#2e9e44",
   failure: "#e03b3b",
-  skipped: "#c7c7c7",
   cancelled: "#f0932b",
   pending: "#1b74e4",
-  queued: "#9aa0a6",
-  neutral: "#9aa0a6",
 };
 
 const ROW = 16;
@@ -85,8 +85,8 @@ function buildColorMap(keys: string[]): Record<string, string> {
   });
   return map;
 }
-function statusColor(s: string) {
-  return STATUS_COLOR[s] || STATUS_COLOR.neutral;
+function statusColor(s: string, neutral: string) {
+  return STATUS_COLOR[s] || neutral;
 }
 
 function niceStep(span: number, targetTicks: number): number {
@@ -170,6 +170,14 @@ export default function WorkflowGantt({ jobs }: { jobs: JobData[] }) {
   const [colorMode, setColorMode] = useState<"group" | "status">("status");
   const [locked, setLocked] = useState(false);
   const [containerRef, containerWidth] = useContainerWidth();
+  const theme = useTheme();
+  // Chrome/neutral colors must work on light and dark backgrounds (torchci
+  // guideline): take border/muted-text from the palette, and pick the queue and
+  // neutral-status grays by mode so they don't wash out on either background.
+  const muted = theme.palette.text.secondary;
+  const borderColor = theme.palette.divider;
+  const neutralColor = theme.palette.mode === "dark" ? "#7a7d82" : "#9aa0a6";
+  const queueColor = theme.palette.mode === "dark" ? "#4a4a4a" : "#d9d9d9";
   // NOTE: we intentionally do NOT draw dependency edges. They can only be inferred
   // from timing (created ~ completed of a predecessor), which is a guess, not the
   // real `needs` DAG — it mislabels parallel siblings and multi-needs jobs. The
@@ -177,7 +185,7 @@ export default function WorkflowGantt({ jobs }: { jobs: JobData[] }) {
 
   if (!data) {
     return (
-      <div style={{ padding: 8, fontSize: 12, color: "#888" }}>
+      <div style={{ padding: 8, fontSize: 12, color: muted }}>
         No timing data available for this workflow.
       </div>
     );
@@ -204,7 +212,9 @@ export default function WorkflowGantt({ jobs }: { jobs: JobData[] }) {
   for (let m = 0; m <= maxEnd + 1e-6; m += step) grid.push(Math.round(m));
 
   const colorOf = (r: PJob) =>
-    colorMode === "group" ? colorMap[r.groupKey] : statusColor(r.status);
+    colorMode === "group"
+      ? colorMap[r.groupKey]
+      : statusColor(r.status, neutralColor);
 
   // legend entries for current mode
   const legend =
@@ -218,14 +228,14 @@ export default function WorkflowGantt({ jobs }: { jobs: JobData[] }) {
             label: k === "build" ? "build" : shortName(k),
           }))
       : Array.from(new Set(rows.map((r) => r.status))).map((s) => ({
-          color: statusColor(s),
+          color: statusColor(s, neutralColor),
           label: s,
         }));
 
   return (
     <div
       style={{
-        border: "1px solid #ccc",
+        border: `1px solid ${borderColor}`,
         borderRadius: 8,
         margin: "6px 0",
         background: "rgba(127,127,127,0.04)",
@@ -241,7 +251,7 @@ export default function WorkflowGantt({ jobs }: { jobs: JobData[] }) {
           fontSize: 12,
         }}
       >
-        <span style={{ color: "#888" }}>
+        <span style={{ color: muted }}>
           {rows.length} jobs · {Math.round(maxEnd)} min
           {nFail > 0 && (
             <span style={{ color: "#e03b3b" }}> · {nFail} failing</span>
@@ -249,7 +259,7 @@ export default function WorkflowGantt({ jobs }: { jobs: JobData[] }) {
           {skipped > 0 && ` · ${skipped} skipped hidden`}
         </span>
         <span>
-          <span style={{ color: "#888", marginRight: 6 }}>Color:</span>
+          <span style={{ color: muted, marginRight: 6 }}>Color:</span>
           <label style={{ marginRight: 8 }}>
             <input
               type="radio"
@@ -356,7 +366,7 @@ export default function WorkflowGantt({ jobs }: { jobs: JobData[] }) {
                       y={y}
                       width={qw}
                       height={bh}
-                      fill={QUEUE_COLOR}
+                      fill={queueColor}
                     />
                   )}
                   <rect
@@ -400,7 +410,7 @@ export default function WorkflowGantt({ jobs }: { jobs: JobData[] }) {
           flexWrap: "wrap",
           padding: "6px 10px",
           fontSize: 11,
-          color: "#888",
+          color: muted,
         }}
       >
         {legend.map((e) => (
@@ -426,7 +436,7 @@ export default function WorkflowGantt({ jobs }: { jobs: JobData[] }) {
               width: 11,
               height: 10,
               borderRadius: 2,
-              background: QUEUE_COLOR,
+              background: queueColor,
             }}
           />
           queue/spin-up

--- a/torchci/components/commit/WorkflowBox.tsx
+++ b/torchci/components/commit/WorkflowBox.tsx
@@ -22,6 +22,7 @@ import {
   ListUtilizationMetadataInfoAPIResponse,
   UtilizationMetadataInfo,
 } from "lib/utilization/types";
+import dynamic from "next/dynamic";
 import {
   CommitApiResponse,
   WorkflowRunInfo,
@@ -30,6 +31,15 @@ import React, { useEffect, useState } from "react";
 import { FaInfoCircle } from "react-icons/fa";
 import useSWR from "swr";
 import useSWRImmutable from "swr/immutable";
+
+// Lazy-loaded: the Gantt code is fetched only when a box's toggle is opened,
+// so it stays off the initial commit/PR page bundle and render path.
+const WorkflowGantt = dynamic(() => import("components/commit/JobTimeline"), {
+  ssr: false,
+  loading: () => (
+    <div style={{ padding: 8, fontSize: 12 }}>Loading timeline…</div>
+  ),
+});
 
 function sortJobsByConclusion(jobA: JobData, jobB: JobData): number {
   // Show failed jobs first, then pending jobs, then successful jobs
@@ -202,6 +212,7 @@ export default function WorkflowBox({
   const [artifactsToShow, setArtifactsToShow] = useState(new Set<string>());
   const groupedArtifacts = groupArtifacts(jobs, artifacts);
 
+  const [showGantt, setShowGantt] = useState(false);
   const [searchString, setSearchString] = useState("");
   const [searchRes, setSearchRes] = useState<{
     results: Map<string, LogSearchResult>;
@@ -280,6 +291,12 @@ export default function WorkflowBox({
                   : "Show Additional Test Info"}
               </button>
             )}
+            <button
+              onClick={() => setShowGantt(!showGantt)}
+              className={styles.buttonBorder}
+            >
+              {showGantt ? "Hide Gantt Chart" : "View as Gantt Chart"}
+            </button>
           </div>
           <form
             onSubmit={(e: React.FormEvent<HTMLFormElement>) => {
@@ -310,6 +327,7 @@ export default function WorkflowBox({
           jobs={jobs}
         />
       )}
+      {showGantt && <WorkflowGantt jobs={jobs} />}
       <>
         {jobs.sort(sortJobsByConclusion).map((job) => (
           <div key={job.id} id={`${job.id}-box`}>


### PR DESCRIPTION
Add a **"View as Gantt Chart"** toggle to each workflow box on the commit and PR pages. For an example, try visiting: 
- https://torchci-git-hud-job-timeline-gantt-fbopensource.vercel.app/pytorch/pytorch/commit/9fa3acc169ac2b3dd6d651c39ed317cc2ee20529 and choose one of pull/trunk/lint and selecting *Show Additional Test Info*.

This visualization can help give a sense of the timeline of workflow families and what the distribution of build/runs are.

**Usage:**
1. Open a commit page (`/<owner>/<repo>/commit/<sha>`) or a PR page.
2. In the **Workflows** section, each box (Lint, pull, inductor, trunk, …) now has a **[View as Gantt Chart]** button next to *Show Additional Test Info*.
3. Click to expand the timeline inline. Controls:
   - **Color: Status** (default) or **Group** (by config prefix)
   - **Lock scale** — fixed px/min (comparable across boxes) vs. fit-to-width

**Additional Notes:**
- **No backend change.** Reuses the job payload the box already fetches (`time` / `durationS` / `queueTimeS`); `created = time − queue`, `completed = time + dur`.
- **No page-load impact.** Lazy-loaded via `next/dynamic` (`ssr:false`) and rendered only when a box is opened.
- **Fit-to-width** via `ResizeObserver` with adaptive gridlines; **Lock scale** pins a fixed scale.
- **Data-driven coloring** — `build` = fixed color; other configs = evenly-spaced hues per box. No hard-coded workflow/platform names.
- **No dependency edges.** Edges can only be *inferred* from timing, which is a guess (mislabels parallel siblings / multi-`needs` jobs) rather than the real `needs` DAG. Bars are exact; staggering is visible from positions. Real edges would require parsing workflow `needs` (future work).