### PR TITLE
torchci: render AI advisor verdict inline in the Dr.CI comment

### DIFF
--- a/torchci/clickhouse_queries/advisor_verdict_for_job/params.json
+++ b/torchci/clickhouse_queries/advisor_verdict_for_job/params.json
@@ -1,0 +1,8 @@
+{
+  "params": {
+    "repo": "String",
+    "sha": "String",
+    "signalKey": "String"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/advisor_verdict_for_job/query.sql
+++ b/torchci/clickhouse_queries/advisor_verdict_for_job/query.sql
@@ -1,0 +1,17 @@
+-- Latest AI advisor verdict for one (repo, suspect commit, signal_key). Backs
+-- the Dr.CI advisor badge endpoint. Filters the verdict table's ORDER BY prefix
+-- (repo, suspect_commit, signal_key, timestamp), so it reads only the relevant
+-- granules.
+SELECT
+    verdict,
+    confidence,
+    run_id
+FROM
+    misc.autorevert_advisor_verdicts
+WHERE
+    repo = {repo: String}
+    AND suspect_commit = {sha: String}
+    AND signal_key = {signalKey: String}
+ORDER BY
+    timestamp DESC
+LIMIT 1

--- a/torchci/clickhouse_queries/advisor_verdict_for_job/query.sql
+++ b/torchci/clickhouse_queries/advisor_verdict_for_job/query.sql
@@ -4,8 +4,7 @@
 -- granules.
 SELECT
     verdict,
-    confidence,
-    run_id
+    confidence
 FROM
     misc.autorevert_advisor_verdicts
 WHERE

--- a/torchci/lib/advisor/advisorBadge.ts
+++ b/torchci/lib/advisor/advisorBadge.ts
@@ -1,0 +1,252 @@
+// Pure rendering helpers for the AI CI Advisor verdict surfaced in the Dr.CI
+// comment (no server-only imports, so this is unit-testable and importable
+// anywhere). Two outputs:
+//   - renderBadgeSvg: the colored status pill served by the advisorBadge API
+//     route (the <img> in the comment points at that route so it can flip
+//     analyzing -> verdict server-side without rewriting the comment).
+//   - selectAdvisorLines / renderVerdictLine / renderInProgressLine: the
+//     "AI verdict:" line emitted under each new failure in the comment.
+
+// The signal_key prefix for HUD-originated (Dr.CI) advisor dispatches. Mirrors
+// signalKeyForJob() in advisorDispatch.ts; duplicated here to keep this module
+// free of any server-only imports.
+export const DRCI_SIGNAL_KEY_PREFIX = "dr_ci_";
+
+export function drciSignalKeyForJob(fullJobName: string): string {
+  return `${DRCI_SIGNAL_KEY_PREFIX}${fullJobName}`;
+}
+
+export interface AdvisorBadge {
+  label: string;
+  // Hex fill, e.g. "#2da44e".
+  color: string;
+  // Use dark text for light (yellow-ish) fills that wash out white text.
+  darkText: boolean;
+}
+
+// Dispatched but no verdict yet.
+export const ANALYZING_BADGE: AdvisorBadge = {
+  label: "analyzing",
+  color: "#9f9f9f",
+  darkText: false,
+};
+
+// No verdict and no in-progress dispatch found (race / stale comment).
+export const PENDING_BADGE: AdvisorBadge = {
+  label: "pending",
+  color: "#9f9f9f",
+  darkText: false,
+};
+
+export type ConfidenceBucket = "high" | "med" | "low";
+
+// Confidence is shown as a word baked into the label, never a number:
+//   high >= 0.89, med (0.70, 0.89), low <= 0.70.
+export function confidenceBucket(confidence: number): ConfidenceBucket {
+  if (confidence >= 0.89) return "high";
+  if (confidence > 0.7) return "med";
+  return "low";
+}
+
+// Map a verdict + confidence to a label and a color on a green -> yellow -> red
+// gradient, with "uncertain" (low confidence) pulling toward yellow. The "AI
+// verdict:" prefix lives in the comment line, so the badge carries only the
+// status text.
+export function verdictBadge(
+  verdict: string,
+  confidence: number
+): AdvisorBadge {
+  const v = (verdict || "").toLowerCase();
+
+  if (v === "garbage") {
+    return { label: "garbage", color: "#6e7781", darkText: false };
+  }
+  if (v === "unsure") {
+    return { label: "inconclusive", color: "#8b949e", darkText: false };
+  }
+
+  const bucket = confidenceBucket(confidence);
+
+  // `related` is the context-neutral successor to `revert`; treat both as the
+  // "related to this PR" pole.
+  if (v === "related" || v === "revert") {
+    if (bucket === "high") {
+      return { label: "related", color: "#d1242f", darkText: false };
+    }
+    if (bucket === "med") {
+      return { label: "probably related", color: "#e8702a", darkText: false };
+    }
+    return { label: "related (uncertain)", color: "#e0a82e", darkText: true };
+  }
+
+  if (v === "not_related") {
+    if (bucket === "high") {
+      return { label: "not related", color: "#2da44e", darkText: false };
+    }
+    if (bucket === "med") {
+      return {
+        label: "probably not related",
+        color: "#94c11f",
+        darkText: true,
+      };
+    }
+    return {
+      label: "not related (uncertain)",
+      color: "#c9b81a",
+      darkText: true,
+    };
+  }
+
+  // Unknown verdict value -> treat as inconclusive rather than guessing a pole.
+  return { label: "inconclusive", color: "#8b949e", darkText: false };
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// A minimal flat single-segment SVG pill (shields "flat" look, no left label).
+export function renderBadgeSvg(badge: AdvisorBadge): string {
+  const text = badge.label;
+  // Approximate text width; Verdana ~6.5px/char at 11px, plus horizontal pad.
+  const width = Math.max(46, Math.round(text.length * 6.5) + 16);
+  const textColor = badge.darkText ? "#33333a" : "#ffffff";
+  const safe = escapeXml(text);
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="20" role="img" aria-label="${safe}">
+<title>${safe}</title>
+<rect width="${width}" height="20" rx="3" fill="${badge.color}"/>
+<text x="${(width / 2).toFixed(
+    1
+  )}" y="14" fill="${textColor}" font-family="Verdana,DejaVu Sans,Geneva,sans-serif" font-size="11" text-anchor="middle">${safe}</text>
+</svg>`;
+}
+
+// Absolute URL of the badge image for one (repo, sha, job). Camo fetches it
+// server-side; the route resolves the live state, so the same URL flips from
+// analyzing to the verdict without the comment changing.
+export function advisorBadgeUrl(
+  hudBaseUrl: string,
+  owner: string,
+  repo: string,
+  sha: string,
+  jobName: string
+): string {
+  const qs = new URLSearchParams({ owner, repo, sha, job: jobName });
+  return `${hudBaseUrl}/api/drci/advisorBadge?${qs.toString()}`;
+}
+
+function hudPrUrl(
+  hudBaseUrl: string,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  jobId: number
+): string {
+  return `${hudBaseUrl}/pr/${owner}/${repo}/${prNumber}#${jobId}`;
+}
+
+// In-progress line: just the badge (no expand), linked to HUD. The pill flips
+// to the verdict in place once the advisor finishes.
+export function renderInProgressLine(
+  hudBaseUrl: string,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  sha: string,
+  jobName: string,
+  jobId: number
+): string {
+  const badge = advisorBadgeUrl(hudBaseUrl, owner, repo, sha, jobName);
+  const link = hudPrUrl(hudBaseUrl, owner, repo, prNumber, jobId);
+  return `    AI verdict: <a href="${link}"><img src="${badge}"></a>\n`;
+}
+
+// Concluded line: "AI verdict:" plain text toggles the expand; the badge links
+// to HUD; the reasoning lives inside the expand.
+export function renderVerdictLine(
+  hudBaseUrl: string,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  sha: string,
+  jobName: string,
+  jobId: number,
+  summary: string
+): string {
+  const badge = advisorBadgeUrl(hudBaseUrl, owner, repo, sha, jobName);
+  const link = hudPrUrl(hudBaseUrl, owner, repo, prNumber, jobId);
+  // Collapse newlines so a multi-line summary can't break the blockquote.
+  const oneLine = (summary || "").replace(/\s*\n\s*/g, " ").trim();
+  return (
+    `  <details><summary>AI verdict: <a href="${link}"><img src="${badge}"></a></summary><blockquote>\n\n` +
+    `  ${oneLine}\n\n` +
+    `  <a href="${link}">Full reasoning on HUD &rarr;</a>\n` +
+    `  </blockquote></details>\n`
+  );
+}
+
+// Minimal shapes the pure selector needs (subset of RecentWorkflowsData /
+// AdvisorVerdict) so this module stays import-light.
+export interface AdvisorLineJob {
+  id: number;
+  name: string;
+}
+export interface AdvisorLineVerdict {
+  summary: string;
+}
+
+// Decide the per-job line: a finalized verdict wins; otherwise an in-progress
+// dispatch ('dispatching'/'dispatched') shows the analyzing badge; otherwise no
+// line. Pure so it is unit-testable without ClickHouse. Returns job.id -> HTML.
+export function selectAdvisorLines(
+  hudBaseUrl: string,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  headSha: string,
+  jobs: AdvisorLineJob[],
+  verdictByKey: Map<string, AdvisorLineVerdict>,
+  inProgressKeys: Set<string>
+): Map<number, string> {
+  const out = new Map<number, string>();
+  for (const job of jobs) {
+    if (!job.name) continue;
+    const key = drciSignalKeyForJob(job.name);
+    const verdict = verdictByKey.get(key);
+    if (verdict) {
+      out.set(
+        job.id,
+        renderVerdictLine(
+          hudBaseUrl,
+          owner,
+          repo,
+          prNumber,
+          headSha,
+          job.name,
+          job.id,
+          verdict.summary
+        )
+      );
+      continue;
+    }
+    if (inProgressKeys.has(key)) {
+      out.set(
+        job.id,
+        renderInProgressLine(
+          hudBaseUrl,
+          owner,
+          repo,
+          prNumber,
+          headSha,
+          job.name,
+          job.id
+        )
+      );
+    }
+  }
+  return out;
+}

--- a/torchci/lib/advisor/advisorBadge.ts
+++ b/torchci/lib/advisor/advisorBadge.ts
@@ -179,8 +179,11 @@ export function renderVerdictLine(
 ): string {
   const badge = advisorBadgeUrl(hudBaseUrl, owner, repo, sha, jobName);
   const link = hudPrUrl(hudBaseUrl, owner, repo, prNumber, jobId);
-  // Collapse newlines so a multi-line summary can't break the blockquote.
-  const oneLine = (summary || "").replace(/\s*\n\s*/g, " ").trim();
+  // The advisor summary is model-generated from (attacker-influenceable) PR
+  // content, so HTML-escape it before embedding in the comment: collapse
+  // newlines (can't break the blockquote) and neutralize markup so it can't
+  // close the <details>/<blockquote> or inject tags.
+  const oneLine = escapeXml((summary || "").replace(/\s*\n\s*/g, " ").trim());
   return (
     `  <details><summary>AI verdict: <a href="${link}"><img src="${badge}"></a></summary><blockquote>\n\n` +
     `  ${oneLine}\n\n` +

--- a/torchci/lib/advisor/advisorBadge.ts
+++ b/torchci/lib/advisor/advisorBadge.ts
@@ -7,6 +7,8 @@
 //   - selectAdvisorLines / renderVerdictLine / renderInProgressLine: the
 //     "AI verdict:" line emitted under each new failure in the comment.
 
+import _ from "lodash";
+
 // The signal_key prefix for HUD-originated (Dr.CI) advisor dispatches. Mirrors
 // signalKeyForJob() in advisorDispatch.ts; duplicated here to keep this module
 // free of any server-only imports.
@@ -101,21 +103,13 @@ export function verdictBadge(
   return { label: "inconclusive", color: "#8b949e", darkText: false };
 }
 
-function escapeXml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
-
 // A minimal flat single-segment SVG pill (shields "flat" look, no left label).
 export function renderBadgeSvg(badge: AdvisorBadge): string {
   const text = badge.label;
   // Approximate text width; Verdana ~6.5px/char at 11px, plus horizontal pad.
   const width = Math.max(46, Math.round(text.length * 6.5) + 16);
   const textColor = badge.darkText ? "#33333a" : "#ffffff";
-  const safe = escapeXml(text);
+  const safe = _.escape(text);
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="20" role="img" aria-label="${safe}">
 <title>${safe}</title>
 <rect width="${width}" height="20" rx="3" fill="${badge.color}"/>
@@ -183,7 +177,7 @@ export function renderVerdictLine(
   // content, so HTML-escape it before embedding in the comment: collapse
   // newlines (can't break the blockquote) and neutralize markup so it can't
   // close the <details>/<blockquote> or inject tags.
-  const oneLine = escapeXml((summary || "").replace(/\s*\n\s*/g, " ").trim());
+  const oneLine = _.escape((summary || "").replace(/\s*\n\s*/g, " ").trim());
   return (
     `  <details><summary>AI verdict: <a href="${link}"><img src="${badge}"></a></summary><blockquote>\n\n` +
     `  ${oneLine}\n\n` +

--- a/torchci/lib/advisor/advisorComment.ts
+++ b/torchci/lib/advisor/advisorComment.ts
@@ -1,0 +1,88 @@
+// Server-side glue for the inline AI advisor verdict lines in the Dr.CI comment.
+// Reads finalized verdicts + in-progress dispatch state from ClickHouse, then
+// delegates the (pure) line selection/rendering to lib/advisor/advisorBadge.
+//
+// The verdict's signal_key is exactly `dr_ci_${jobName}` (what auto-dispatch
+// wrote), so verdicts match jobs by exact signal-key equality -- no fuzzy
+// matchVerdictToJob needed for the PR side.
+
+import {
+  AdvisorLineVerdict,
+  selectAdvisorLines,
+} from "lib/advisor/advisorBadge";
+import { isAdvisorEnabled } from "lib/advisor/advisorConfig";
+import {
+  readDispatchStates,
+  signalKeyForJob,
+} from "lib/advisor/advisorDispatch";
+import {
+  AdvisorVerdictRow,
+  deduplicateVerdicts,
+} from "lib/advisorVerdictUtils";
+import { queryClickhouseSaved } from "lib/clickhouse";
+import { RecentWorkflowsData } from "lib/types";
+
+// Gate the inline verdict rendering behind its own flag so it ships dark and
+// can be enabled per deployment (Vercel env var), independently of the
+// auto-dispatch flag. Display-only, so it doesn't also require VERCEL_ENV
+// (unlike auto-dispatch, which fires real workflow_dispatches).
+export function advisorCommentEnabled(owner: string, repo: string): boolean {
+  return (
+    process.env.DRCI_ADVISOR_COMMENT_ENABLED === "true" &&
+    isAdvisorEnabled(owner, repo)
+  );
+}
+
+/**
+ * Build the per-job "AI verdict:" line for a PR's new/unclassified failures.
+ * Returns job.id -> rendered HTML (empty map when the comment flag is off, the
+ * repo isn't advisor-enabled, or there are no jobs). The caller wraps this so a
+ * ClickHouse error can never break the Dr.CI comment.
+ */
+export async function buildAdvisorVerdictLines(
+  hudBaseUrl: string,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  headSha: string,
+  jobs: RecentWorkflowsData[]
+): Promise<Map<number, string>> {
+  if (!advisorCommentEnabled(owner, repo) || jobs.length === 0) {
+    return new Map();
+  }
+
+  // Finalized verdicts for this PR, keyed by signal_key for the head commit.
+  const verdictRows = (await queryClickhouseSaved("advisor_verdicts_for_pr", {
+    repo: `${owner}/${repo}`,
+    prNumber,
+  })) as AdvisorVerdictRow[];
+  const verdictByKey = new Map<string, AdvisorLineVerdict>();
+  for (const v of deduplicateVerdicts(verdictRows)) {
+    if (v.sha === headSha) {
+      verdictByKey.set(v.signalKey, { summary: v.summary });
+    }
+  }
+
+  // In-progress dispatches (dispatching/dispatched) for the head commit.
+  const signalKeys = jobs
+    .filter((j) => j.name)
+    .map((j) => signalKeyForJob(j.name));
+  const states = await readDispatchStates(owner, repo, headSha, signalKeys);
+  const inProgressKeys = new Set<string>();
+  for (const [key, st] of states) {
+    if (st.state === "dispatching" || st.state === "dispatched") {
+      inProgressKeys.add(key);
+    }
+  }
+
+  return selectAdvisorLines(
+    hudBaseUrl,
+    owner,
+    repo,
+    prNumber,
+    headSha,
+    jobs.map((j) => ({ id: j.id, name: j.name })),
+    verdictByKey,
+    inProgressKeys
+  );
+}

--- a/torchci/pages/api/drci/advisorBadge.ts
+++ b/torchci/pages/api/drci/advisorBadge.ts
@@ -14,13 +14,23 @@ import {
   renderBadgeSvg,
   verdictBadge,
 } from "lib/advisor/advisorBadge";
+import { isAdvisorEnabled } from "lib/advisor/advisorConfig";
 import { isValidSha, readDispatchStates } from "lib/advisor/advisorDispatch";
 import { queryClickhouseSaved } from "lib/clickhouse";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 const SHORT_CACHE =
   "public, max-age=60, s-maxage=60, stale-while-revalidate=60";
-const LONG_CACHE = "public, max-age=31536000, s-maxage=31536000, immutable";
+// Long but NOT immutable: a verdict is normally written once per (sha, job),
+// but a manual re-analyze or a retried dispatch can land a newer row, and the
+// query returns the latest by timestamp. A finite TTL lets a corrected verdict
+// propagate (within a day) instead of being cached forever by the proxy.
+const LONG_CACHE =
+  "public, max-age=86400, s-maxage=86400, stale-while-revalidate=86400";
+
+// GitHub owner/repo name shape, to bound the public endpoint's CH lookups.
+const NAME_RE = /^[A-Za-z0-9._-]{1,100}$/;
+const MAX_JOB_LEN = 256;
 
 function one(value: string | string[] | undefined): string {
   return Array.isArray(value) ? value[0] : value ?? "";
@@ -47,8 +57,21 @@ export default async function handler(
 
   // Bad input -> a neutral pending pill (never a 4xx/5xx, which would render a
   // broken-image icon in the comment). Don't cache bad requests.
-  if (!owner || !repo || !job || !isValidSha(sha)) {
+  if (
+    !NAME_RE.test(owner) ||
+    !NAME_RE.test(repo) ||
+    !isValidSha(sha) ||
+    !job ||
+    job.length > MAX_JOB_LEN
+  ) {
     sendSvg(res, renderBadgeSvg(PENDING_BADGE), "no-store");
+    return;
+  }
+
+  // Only serve badges for advisor-enabled repos (same gate as the comment
+  // path); a neutral pending pill for anything else.
+  if (!isAdvisorEnabled(owner, repo)) {
+    sendSvg(res, renderBadgeSvg(PENDING_BADGE), SHORT_CACHE);
     return;
   }
 

--- a/torchci/pages/api/drci/advisorBadge.ts
+++ b/torchci/pages/api/drci/advisorBadge.ts
@@ -1,0 +1,90 @@
+// SVG badge for the AI CI Advisor verdict, embedded in the Dr.CI comment.
+//
+// The comment's <img> points here so the pill can flip analyzing -> verdict
+// server-side without rewriting the comment (which only happens on the ~15-min
+// Dr.CI cron). Caching is state-dependent: a short TTL while in-progress so the
+// proxy (GitHub camo) re-fetches and the badge updates soon after the verdict
+// lands, then a long immutable TTL once final (a verdict never changes for a
+// fixed repo+sha+job).
+
+import {
+  ANALYZING_BADGE,
+  drciSignalKeyForJob,
+  PENDING_BADGE,
+  renderBadgeSvg,
+  verdictBadge,
+} from "lib/advisor/advisorBadge";
+import { isValidSha, readDispatchStates } from "lib/advisor/advisorDispatch";
+import { queryClickhouseSaved } from "lib/clickhouse";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const SHORT_CACHE =
+  "public, max-age=60, s-maxage=60, stale-while-revalidate=60";
+const LONG_CACHE = "public, max-age=31536000, s-maxage=31536000, immutable";
+
+function one(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? value[0] : value ?? "";
+}
+
+function sendSvg(
+  res: NextApiResponse,
+  svg: string,
+  cacheControl: string
+): void {
+  res.setHeader("Content-Type", "image/svg+xml; charset=utf-8");
+  res.setHeader("Cache-Control", cacheControl);
+  res.status(200).send(svg);
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const owner = one(req.query.owner);
+  const repo = one(req.query.repo);
+  const sha = one(req.query.sha);
+  const job = one(req.query.job);
+
+  // Bad input -> a neutral pending pill (never a 4xx/5xx, which would render a
+  // broken-image icon in the comment). Don't cache bad requests.
+  if (!owner || !repo || !job || !isValidSha(sha)) {
+    sendSvg(res, renderBadgeSvg(PENDING_BADGE), "no-store");
+    return;
+  }
+
+  const repoFull = `${owner}/${repo}`;
+  const signalKey = drciSignalKeyForJob(job);
+
+  try {
+    // Finalized verdict wins. Hits the verdict table's ORDER BY prefix
+    // (repo, suspect_commit, signal_key) -> indexed point lookup.
+    const verdictRows = (await queryClickhouseSaved("advisor_verdict_for_job", {
+      repo: repoFull,
+      sha,
+      signalKey,
+    })) as { verdict: string; confidence: number }[];
+
+    if (verdictRows.length > 0) {
+      const row = verdictRows[0];
+      const badge = verdictBadge(row.verdict, Number(row.confidence));
+      sendSvg(res, renderBadgeSvg(badge), LONG_CACHE);
+      return;
+    }
+
+    // No verdict yet: show "analyzing" if a dispatch is in flight, else pending.
+    const states = await readDispatchStates(owner, repo, sha, [signalKey]);
+    const st = states.get(signalKey);
+    const inProgress =
+      st && (st.state === "dispatching" || st.state === "dispatched");
+    sendSvg(
+      res,
+      renderBadgeSvg(inProgress ? ANALYZING_BADGE : PENDING_BADGE),
+      SHORT_CACHE
+    );
+  } catch (e) {
+    // Fail soft: a pending pill, uncached so the next view retries. Never 500
+    // (a broken image is worse than a transient "pending").
+    console.error("advisorBadge: lookup failed", e);
+    sendSvg(res, renderBadgeSvg(PENDING_BADGE), "no-store");
+  }
+}

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -871,6 +871,10 @@ export function constructResultsComment(
     );
   }
 
+  // advisorLines is threaded only into the NEW FAILURES and UNCLASSIFIED
+  // sections below -- those are the only failures the advisor dispatches on.
+  // Broken-trunk / flaky / unstable / awaiting-approval jobs are already
+  // explained by their own section, so they intentionally get no verdict line.
   if (newFailedJobs.length) {
     output += constructResultsJobsSections(
       hudBaseUrl,

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -1,6 +1,7 @@
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import { buildAdvisorVerdictLines } from "lib/advisor/advisorComment";
 import { autoDispatchAdvisorForNewFailures } from "lib/advisor/advisorDispatch";
 import { fetchJSON, isTime0 } from "lib/bot/utils";
 import { queryClickhouse, queryClickhouseSaved } from "lib/clickhouse";
@@ -262,6 +263,27 @@ export async function updateDrciComments(
         );
       }
 
+      // Look up AI advisor verdicts / in-progress dispatches for this PR's new
+      // and unclassified failures, rendered as an inline "AI verdict:" line per
+      // job. Wrapped so an advisor / ClickHouse error can never break the comment.
+      let advisorLines: Map<number, string> = new Map();
+      try {
+        advisorLines = await buildAdvisorVerdictLines(
+          HUD_URL,
+          owner,
+          repo,
+          pr_info.pr_number,
+          pr_info.head_sha,
+          [...failedJobs, ...unknownJobs]
+        );
+      } catch (e) {
+        console.error(
+          "advisor verdict-line build threw for PR",
+          pr_info.pr_number,
+          e
+        );
+      }
+
       const failureInfo = constructResultsComment(
         pending,
         failedJobs,
@@ -279,7 +301,8 @@ export async function updateDrciComments(
         HUD_URL,
         owner,
         repo,
-        pr_info.pr_number
+        pr_info.pr_number,
+        advisorLines
       );
 
       const comment = formDrciComment(
@@ -615,7 +638,9 @@ function constructResultsJobsSections(
   collapsed: boolean = false,
   relatedJobs: Map<number, RecentWorkflowsData> = new Map(),
   relatedIssues: Map<number, IssueData[]> = new Map(),
-  relatedInfo: Map<number, string> = new Map()
+  relatedInfo: Map<number, string> = new Map(),
+  // job.id -> pre-rendered "AI verdict:" line, appended under each bullet.
+  advisorLines: Map<number, string> = new Map()
 ): string {
   if (jobs.length === 0) {
     return "";
@@ -677,6 +702,12 @@ function constructResultsJobsSections(
     if (job.failure_captures && job.failure_captures.length > 0) {
       output += `    \`${job.failure_captures[0]}\`\n`;
     }
+
+    // AI advisor verdict line (badge + optional reasoning expand), if any.
+    const advisorLine = advisorLines.get(job.id);
+    if (advisorLine) {
+      output += advisorLine;
+    }
   }
   output += "</p></details>";
   return output;
@@ -711,7 +742,9 @@ export function constructResultsComment(
   hudBaseUrl: string,
   owner: string,
   repo: string,
-  prNumber: number
+  prNumber: number,
+  // job.id -> pre-rendered "AI verdict:" line (empty unless advisor-enabled).
+  advisorLines: Map<number, string> = new Map()
 ): string {
   let output = `\n`;
   // Filter out unstable pending jobs
@@ -853,7 +886,8 @@ export function constructResultsComment(
       false,
       relatedJobs,
       relatedIssues,
-      relatedInfo
+      relatedInfo,
+      advisorLines
     );
   }
 
@@ -879,7 +913,8 @@ export function constructResultsComment(
       false,
       relatedJobs,
       relatedIssues,
-      relatedInfo
+      relatedInfo,
+      advisorLines
     );
   }
 

--- a/torchci/test/advisorBadge.test.ts
+++ b/torchci/test/advisorBadge.test.ts
@@ -1,0 +1,170 @@
+import {
+  advisorBadgeUrl,
+  ANALYZING_BADGE,
+  confidenceBucket,
+  drciSignalKeyForJob,
+  renderBadgeSvg,
+  renderInProgressLine,
+  renderVerdictLine,
+  selectAdvisorLines,
+  verdictBadge,
+} from "lib/advisor/advisorBadge";
+
+const HUD = "https://hud.pytorch.org";
+
+describe("confidenceBucket", () => {
+  it("buckets high/med/low at the 0.89 and 0.70 boundaries", () => {
+    expect(confidenceBucket(0.9)).toBe("high");
+    expect(confidenceBucket(0.89)).toBe("high");
+    expect(confidenceBucket(0.88)).toBe("med");
+    expect(confidenceBucket(0.71)).toBe("med");
+    expect(confidenceBucket(0.7)).toBe("low");
+    expect(confidenceBucket(0.5)).toBe("low");
+  });
+});
+
+describe("verdictBadge", () => {
+  it("encodes confidence in the not-related labels + gradient", () => {
+    expect(verdictBadge("not_related", 0.95)).toMatchObject({
+      label: "not related",
+      color: "#2da44e",
+    });
+    expect(verdictBadge("not_related", 0.8).label).toBe("probably not related");
+    expect(verdictBadge("not_related", 0.5).label).toBe(
+      "not related (uncertain)"
+    );
+  });
+
+  it("encodes confidence in the related labels + gradient", () => {
+    expect(verdictBadge("related", 0.95)).toMatchObject({
+      label: "related",
+      color: "#d1242f",
+    });
+    expect(verdictBadge("related", 0.8).label).toBe("probably related");
+    expect(verdictBadge("related", 0.5).label).toBe("related (uncertain)");
+  });
+
+  it("treats legacy 'revert' as the related pole", () => {
+    expect(verdictBadge("revert", 0.95).label).toBe("related");
+  });
+
+  it("handles garbage / unsure / unknown without confidence wording", () => {
+    expect(verdictBadge("garbage", 0.9).label).toBe("garbage");
+    expect(verdictBadge("unsure", 0.9).label).toBe("inconclusive");
+    expect(verdictBadge("something_new", 0.9).label).toBe("inconclusive");
+  });
+
+  it("does NOT prefix the badge with 'AI:' (the line carries that)", () => {
+    expect(verdictBadge("related", 0.95).label).not.toMatch(/AI/i);
+  });
+});
+
+describe("renderBadgeSvg", () => {
+  it("renders a valid single-segment SVG with the label and color", () => {
+    const svg = renderBadgeSvg(verdictBadge("not_related", 0.95));
+    expect(svg).toContain("<svg");
+    expect(svg).toContain("</svg>");
+    expect(svg).toContain("not related");
+    expect(svg).toContain("#2da44e");
+  });
+
+  it("uses dark text for light (uncertain) fills and escapes the label", () => {
+    const svg = renderBadgeSvg(verdictBadge("related", 0.5));
+    expect(svg).toContain("#33333a"); // dark text
+    expect(svg).toContain("related (uncertain)");
+  });
+
+  it("renders the analyzing badge", () => {
+    const svg = renderBadgeSvg(ANALYZING_BADGE);
+    expect(svg).toContain("analyzing");
+    expect(svg).toContain("#9f9f9f");
+  });
+});
+
+describe("advisorBadgeUrl", () => {
+  it("builds an absolute, URL-encoded badge URL", () => {
+    const url = advisorBadgeUrl(
+      HUD,
+      "pytorch",
+      "pytorch",
+      "abc123",
+      "trunk / linux-jammy / test (default, 1, 2)"
+    );
+    expect(url).toContain("https://hud.pytorch.org/api/drci/advisorBadge?");
+    expect(url).toContain("owner=pytorch");
+    expect(url).toContain("sha=abc123");
+    // job is encoded (spaces/slashes/parens)
+    expect(url).toContain("job=trunk+%2F+linux-jammy+%2F+test");
+    expect(url).not.toContain("job=trunk / linux");
+  });
+});
+
+describe("renderInProgressLine / renderVerdictLine", () => {
+  it("in-progress: badge only, no expand", () => {
+    const line = renderInProgressLine(
+      HUD,
+      "pytorch",
+      "pytorch",
+      123,
+      "abc",
+      "trunk / x / test",
+      42
+    );
+    expect(line).toContain("AI verdict:");
+    expect(line).toContain("/api/drci/advisorBadge?");
+    expect(line).not.toContain("<details>");
+    expect(line).toContain("/pr/pytorch/pytorch/123#42");
+  });
+
+  it("concluded: AI verdict text toggles a details expand with reasoning", () => {
+    const line = renderVerdictLine(
+      HUD,
+      "pytorch",
+      "pytorch",
+      123,
+      "abc",
+      "trunk / x / test",
+      42,
+      "Line one.\n  Line two."
+    );
+    expect(line).toContain("<details><summary>AI verdict:");
+    expect(line).toContain("</details>");
+    expect(line).toContain("Full reasoning on HUD");
+    // multi-line summary collapsed to one line inside the blockquote
+    expect(line).toContain("Line one. Line two.");
+    expect(line).not.toContain("Line one.\n");
+  });
+});
+
+describe("selectAdvisorLines", () => {
+  const jobs = [
+    { id: 1, name: "trunk / a / test" },
+    { id: 2, name: "trunk / b / test" },
+    { id: 3, name: "trunk / c / test" },
+    { id: 4, name: "" }, // skipped (no name)
+  ];
+
+  it("prefers a finalized verdict, else in-progress, else nothing", () => {
+    const verdictByKey = new Map([
+      [drciSignalKeyForJob("trunk / a / test"), { summary: "done" }],
+    ]);
+    const inProgress = new Set([drciSignalKeyForJob("trunk / b / test")]);
+
+    const out = selectAdvisorLines(
+      HUD,
+      "pytorch",
+      "pytorch",
+      1,
+      "sha",
+      jobs,
+      verdictByKey,
+      inProgress
+    );
+
+    expect(out.get(1)).toContain("<details>"); // verdict
+    expect(out.get(2)).toContain("AI verdict:"); // in-progress
+    expect(out.get(2)).not.toContain("<details>");
+    expect(out.has(3)).toBe(false); // no advisor activity
+    expect(out.has(4)).toBe(false); // no name
+  });
+});

--- a/torchci/test/advisorBadge.test.ts
+++ b/torchci/test/advisorBadge.test.ts
@@ -134,6 +134,23 @@ describe("renderInProgressLine / renderVerdictLine", () => {
     expect(line).toContain("Line one. Line two.");
     expect(line).not.toContain("Line one.\n");
   });
+
+  it("escapes HTML in the summary so it can't break out of the expand", () => {
+    const line = renderVerdictLine(
+      HUD,
+      "pytorch",
+      "pytorch",
+      123,
+      "abc",
+      "trunk / x / test",
+      42,
+      "</blockquote></details><img src=x onerror=alert(1)>"
+    );
+    expect(line).not.toContain("</blockquote></details><img");
+    expect(line).toContain("&lt;/blockquote&gt;&lt;/details&gt;");
+    // exactly one real closing pair (the structural one we emit)
+    expect(line.match(/<\/details>/g)?.length).toBe(1);
+  });
 });
 
 describe("selectAdvisorLines", () => {


### PR DESCRIPTION
Surfaces the AI CI Advisor verdict directly in the Dr.CI PR comment (task #132 part 3). Under each **NEW FAILURE** / **UNCLASSIFIED FAILURE**, an `AI verdict:` line shows a colored status pill; once the verdict is finalized, the pill becomes a collapsible expand with the reasoning.

### What it looks like
`AI verdict:` (plain text — toggles the expand) followed by a pill linking to HUD:

- **In-progress** (dispatched, no verdict yet): just the pill (`analyzing`), no expand.
- **Concluded**: the `AI verdict:` text toggles a `<details>` whose summary is the pill and whose body is the advisor's reasoning + a HUD link.

Confidence is encoded **in the wording** (never a number) and the pill color rides a green → yellow → red gradient, with low confidence pulling toward yellow:

| confidence | not-related pole | related pole |
|---|---|---|
| high (≥0.89) | `not related` (green) | `related` (red) |
| med (0.70–0.89) | `probably not related` | `probably related` |
| low (≤0.70) | `not related (uncertain)` (yellow) | `related (uncertain)` (yellow) |

`garbage` → gray; `unsure`/unknown → `inconclusive`. Rendering mock: https://github.com/pytorch/ciforge/issues/517 (final = the "Option C" comment).

### How it works
- **New SVG endpoint** `pages/api/drci/advisorBadge.ts`, keyed on `(owner, repo, sha, job)`. The comment's `<img>` points here, so the pill can flip *analyzing → verdict* server-side **without rewriting the comment** (which only happens on the ~15-min Dr.CI cron). **State-dependent caching**: short TTL (`max-age=60`) while in-progress so the proxy (GitHub camo) re-fetches and the badge updates soon after the verdict lands; **immutable** long TTL once final (a verdict never changes for a fixed `sha`+`job`) → near-zero load afterward.
- `lib/advisor/advisorBadge.ts` (pure): verdict+confidence → label/color, flat SVG render, badge-URL + line-HTML builders, and the per-job line selector. Fully unit-tested.
- `lib/advisor/advisorComment.ts`: reads finalized verdicts (`advisor_verdicts_for_pr`) + in-progress dispatch state (`advisor_dispatch_states`) and builds the per-job lines. Verdicts match jobs by **exact signal-key equality** (`dr_ci_${jobName}`, the same key auto-dispatch wrote) — no fuzzy matching.
- `drci.ts`: minimal additive hook — build the map (wrapped in try/catch so an advisor/ClickHouse error can never break the comment), thread it into the NEW FAILURE / UNCLASSIFIED sections.
- New saved query `advisor_verdict_for_job` (indexed point lookup on the verdict table's ORDER BY prefix).

### Rollout
Gated behind a **new `DRCI_ADVISOR_COMMENT_ENABLED` flag (default off)** so it ships dark — flip it in Vercel prod to enable. **Display-only**: never edits merge behavior. (Note: GitHub's comment sanitizer strips `target=_blank`, so the pill link opens in the same tab — unavoidable without JS.)

### Test plan
- `tsc --noEmit` clean; `prettier`/`sqlfluff` clean.
- New `test/advisorBadge.test.ts` (jest, node ≥18 — runs in CI) covers the confidence buckets, gradient mapping, SVG render, badge-URL encoding, in-progress vs concluded line rendering, and the verdict/in-progress/none line selection.
- Manual: enable the flag on a deployment and confirm the line renders on a real pytorch/pytorch PR with a known verdict.