### PR TITLE
[CRCR] Fix duplicate-release race in lambda release workflow

### DIFF
--- a/.github/workflows/_lambda-do-release-runners.yml
+++ b/.github/workflows/_lambda-do-release-runners.yml
@@ -8,15 +8,25 @@ on:
 
 name: Upload Release for lambdas
 
+# Build every lambda zip in parallel and stage it as a workflow artifact, then
+# publish the release from a single job with one release-action call.
+#
+# Previously each build job uploaded directly to the release with
+# `ncipollo/release-action` (allowUpdates + draft). When the release did not yet
+# exist, the parallel jobs each hit "look up by tag -> not found -> create" and
+# GitHub allowed multiple draft releases to share the same tag name. The
+# artifacts then scattered across those duplicate drafts and `finish-release`
+# published only one of them, so a tag could end up missing assets (e.g.
+# cross-repo-ci-callback.zip stranded on an unpublished draft). Funnelling all
+# uploads through one release-action call removes the concurrent-create race.
+
 jobs:
-  release-lambdas:
-    name: Upload Release for runners lambdas
+  build-runner-lambdas:
+    name: Build runners lambdas
     runs-on: ubuntu-latest
     container: node:20
     permissions:
-      contents: write
-    env:
-      REF: ${{ inputs.tag }}
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -71,16 +81,18 @@ jobs:
         with:
           args: zip webhook.zip index.js
 
-      - uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
+      - name: Stage runner lambda zips
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          artifacts: "runner-binaries-syncer.zip,runners.zip,webhook.zip"
-          allowUpdates: true
-          draft: true
-          name: ${{ inputs.tag }}
-          tag: ${{ inputs.tag }}
-          updateOnlyUnreleased: true
+          name: lambda-runner-bundle
+          path: |
+            runner-binaries-syncer.zip
+            runners.zip
+            webhook.zip
+          if-no-files-found: error
+          retention-days: 1
 
-  release-python-lambdas:
+  build-python-lambdas:
     strategy:
       fail-fast: false
       matrix:
@@ -96,12 +108,10 @@ jobs:
           { dir-name: 'cross_repo_ci_relay/callback', zip-name: 'cross-repo-ci-callback' },
           { dir-name: 'cross_repo_ci_relay/webhook', zip-name: 'cross-repo-ci-webhook' },
         ]
-    name: Upload Release for ${{ matrix.dir-name }} lambda
+    name: Build ${{ matrix.dir-name }} lambda
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-    env:
-      REF: ${{ inputs.tag }}
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -119,31 +129,52 @@ jobs:
       - name: Copy deployment.zip to root
         run: cp aws/lambda/${{ matrix.dir-name }}/deployment.zip ${{ matrix.zip-name }}.zip
 
-      - uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
+      - name: Stage ${{ matrix.zip-name }} zip
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          artifacts: "${{ matrix.zip-name }}.zip"
+          name: lambda-${{ matrix.zip-name }}
+          path: ${{ matrix.zip-name }}.zip
+          if-no-files-found: error
+          retention-days: 1
+
+  release:
+    name: Publish release
+    needs:
+      - build-runner-lambdas
+      - build-python-lambdas
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Download all staged lambda zips
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: release-dist
+          merge-multiple: true
+
+      - name: List release artifacts
+        run: ls -l release-dist
+
+      # Single release-action invocation: create/update the draft with every
+      # artifact, then publish. One call -> no concurrent create -> no duplicate
+      # releases and no scattered assets.
+      - name: Upload artifacts to draft release
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
+        with:
+          artifacts: "release-dist/*.zip"
           allowUpdates: true
           draft: true
           name: ${{ inputs.tag }}
           tag: ${{ inputs.tag }}
           updateOnlyUnreleased: true
 
-  finish-release:
-    needs:
-      - release-lambdas
-      - release-python-lambdas
-    name: Mark the release as final and publish it
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    env:
-      REF: ${{ inputs.tag }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ inputs.tag }}
-      - uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
+      - name: Mark the release as final and publish it
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
         with:
           allowUpdates: true
           draft: false

--- a/.github/workflows/_lambda-do-release-runners.yml
+++ b/.github/workflows/_lambda-do-release-runners.yml
@@ -8,18 +8,6 @@ on:
 
 name: Upload Release for lambdas
 
-# Build every lambda zip in parallel and stage it as a workflow artifact, then
-# publish the release from a single job with one release-action call.
-#
-# Previously each build job uploaded directly to the release with
-# `ncipollo/release-action` (allowUpdates + draft). When the release did not yet
-# exist, the parallel jobs each hit "look up by tag -> not found -> create" and
-# GitHub allowed multiple draft releases to share the same tag name. The
-# artifacts then scattered across those duplicate drafts and `finish-release`
-# published only one of them, so a tag could end up missing assets (e.g.
-# cross-repo-ci-callback.zip stranded on an unpublished draft). Funnelling all
-# uploads through one release-action call removes the concurrent-create race.
-
 jobs:
   build-runner-lambdas:
     name: Build runners lambdas


### PR DESCRIPTION
## Summary

The lambda release workflow (`_lambda-do-release-runners.yml`) fanned out **~11 parallel `ncipollo/release-action` calls** against the same tag — one in `release-lambdas` plus one per `release-python-lambdas` matrix leg — each with `allowUpdates: true`, `draft: true`, `updateOnlyUnreleased: true`. `finish-release` then published the release.

When the release doesn't exist yet, the concurrent jobs each do *"look up release by tag → not found → create"*, and GitHub allows **multiple draft releases to share the same tag name**. The artifacts then scatter across those duplicate drafts, and `finish-release` publishes only **one** of them. So a tag can be published **missing assets**.

This is observable in production: for several recent tags the public asset URL is inconsistent, e.g.
```
releases/download/v20260619-144824/cross-repo-ci-callback.zip  -> 404   (stranded on an unpublished draft)
releases/download/v20260615-215239/cross-repo-ci-callback.zip  -> 404
releases/download/v20260615-212756/cross-repo-ci-callback.zip  -> 200
releases/download/v20260604-153951/cross-repo-ci-callback.zip  -> 200   (currently pinned by ci-infra CRCR deploy)
```
A 404 here breaks the CRCR Terraform deploy (`crcr/Terrafile` → `terrafile_lambdas.py` downloads `releases/download/{tag}/cross-repo-ci-callback.zip`).

## Fix

Keep builds parallel, but **serialize publishing through a single `release-action` call**:

- `build-runner-lambdas` / `build-python-lambdas` now only build their zips and stage them with `actions/upload-artifact` (`if-no-files-found: error`).
- A new `release` job `actions/download-artifact` (`merge-multiple: true`) all staged zips and makes **one** `release-action` call to upload every artifact, then publishes.

One create/upload path ⇒ no concurrent create ⇒ no duplicate releases and no scattered assets. `if-no-files-found: error` plus `needs` on both build jobs also prevents publishing an **incomplete** release (a build failure now fails the release instead of silently dropping an asset).

## Notes / test plan

- YAML validated; the caller `lambda-release-tag-runners.yml` only passes `tag`, so the internal job rename is not a breaking change.
- Action pins reused from existing repo conventions (`upload-artifact@…v4.6.2`, `download-artifact@…v4.3.0`).
- Full validation is the release workflow itself on merge to `main`; please confirm the next release tag publishes a single release containing **all** lambda zips (incl. `cross-repo-ci-callback.zip` / `cross-repo-ci-webhook.zip`).
- AI assistance (Claude) was used to prepare this change.
