### PR TITLE
Fix R2 promotion: preserve subfolders and make R2_ONLY mirror prod

### DIFF
--- a/release/promote/common_utils.sh
+++ b/release/promote/common_utils.sh
@@ -155,7 +155,10 @@ r2_promote() {
 
     # List matching files from S3 first (using current OIDC credentials)
     echo "+ Listing matching files from S3..."
-    local s3_from_path="${PYTORCH_S3_FROM/\/$//}"
+    local s3_from_path="${PYTORCH_S3_FROM%/}"
+    # Bucket-relative source prefix (e.g. "libtorch/test"), used to preserve the
+    # per-arch subfolder layout (cpu/, cu126/, ...) when mapping keys onto R2.
+    local s3_from_prefix="${s3_from_path#"${PYTORCH_S3_BUCKET}"/}"
     local file_list="${tmp_dir}/file_list.txt"
     ${AWS} s3 ls "${s3_from_path}/" --recursive \
         | grep -E "${match_pattern}" \
@@ -202,6 +205,12 @@ r2_promote() {
         filename=$(basename "${s3_key}")
         local local_file="${tmp_dir}/${filename}"
 
+        # Preserve the source subfolder layout relative to the promotion
+        # channel so per-arch directories (cpu/, cu126/, ...) are kept on R2
+        # instead of being flattened to the destination root.
+        local rel_path="${s3_key#"${s3_from_prefix}"/}"
+        local r2_target="${r2_dest%/}/${rel_path}"
+
         # Download single file from S3 (using S3 credentials)
         _restore_s3_creds
         (
@@ -217,7 +226,7 @@ r2_promote() {
         _set_r2_creds
         (
             set -x
-            ${AWS} s3 cp "${local_file}" "${r2_dest/\/$//}/${filename}" \
+            ${AWS} s3 cp "${local_file}" "${r2_target}" \
                 --metadata "checksum-sha256=${sha256}" \
                 --endpoint-url "${R2_ENDPOINT_URL}"
         )

--- a/release/promote/s3_to_s3.sh
+++ b/release/promote/s3_to_s3.sh
@@ -16,13 +16,17 @@ PYTORCH_S3_FROM=${PYTORCH_S3_FROM:-${PYTORCH_S3_BUCKET}/${PACKAGE_TYPE}/${FROM}}
 TO=${TO:-}
 PYTORCH_S3_TO=${PYTORCH_S3_TO:-${PYTORCH_S3_BUCKET}/${PACKAGE_TYPE}/${TO}}
 
-# R2_ONLY: set to "true" to skip S3-to-S3 copy and only promote to R2
+# R2_ONLY: set to "true" to skip the S3-to-S3 copy and only promote to R2.
+# In that mode the S3 prod promotion has already happened, so mirror from the
+# prod (destination) location instead of the test channel, keeping R2 in sync
+# with what is actually live on S3.
 R2_ONLY=${R2_ONLY:-false}
 
 if [[ "${R2_ONLY}" != "true" ]]; then
     aws_promote "${PACKAGE_NAME}"
 else
-    echo "+ R2_ONLY=true, skipping S3-to-S3 promotion"
+    echo "+ R2_ONLY=true, skipping S3-to-S3 promotion; mirroring ${PYTORCH_S3_TO} to R2"
+    PYTORCH_S3_FROM="${PYTORCH_S3_TO}"
 fi
 
 # Promote to R2 (Cloudflare) before the slow SHA256 recomputation step so R2


### PR DESCRIPTION
## Problem

During release promotion, libtorch (and wheel) binaries were not appearing on R2 at their expected paths.

**Root cause 1 - subfolder flattening.** `r2_promote` built each R2 destination key from `basename(s3_key)` appended to `r2_dest`, dropping the per-arch directory (`cpu/`, `cu126/`, ...) in the source key, so every artifact collapsed onto the destination root. The trailing-slash strip `${r2_dest/\/$//}` is also a no-op (it matches a literal `/$`, not a trailing slash), so keys became `libtorch//<file>`. Net result: a file at `libtorch/test/cpu/...zip` was uploaded to `s3://pytorch-downloads/libtorch//<file>` instead of `.../libtorch/cpu/<file>`. The S3->S3 prod copy was unaffected (it uses `aws s3 cp --recursive`, which preserves layout) -- only the R2 mirror was wrong. Wheels with per-arch subfolders had the same bug.

**Root cause 2 - R2_ONLY sourced from test.** When `R2_ONLY=true` skipped the S3->S3 copy, `r2_promote` still read from the test channel, so R2 prod could be populated from test content (or find nothing if test was cleaned).

## Fix

1. Map each key onto R2 preserving the path relative to the promotion channel prefix (mirroring what the recursive S3 copy does), and strip the trailing slash with `${r2_dest%/}`.
2. When `R2_ONLY=true`, source from `PYTORCH_S3_TO` (prod) so R2 stays in sync with what's live on S3. `R2_ONLY` continues to make no S3 writes.

## Test Plan

Sourced the real functions with a stubbed `aws` CLI (`DRY_RUN=disabled`):

```
libtorch/test/cpu/...+cpu.zip     -> s3://pytorch-downloads/libtorch/cpu/...+cpu.zip
libtorch/test/cu126/...+cu126.zip -> s3://pytorch-downloads/libtorch/cu126/...+cu126.zip
```

`R2_ONLY=true`: verified it lists/downloads from `s3://pytorch/libtorch/` (prod), issues no S3-prod writes, and uploads only to `s3://pytorch-downloads/<arch>/...` via the R2 endpoint.

`bash -n` and `shellcheck` (no new warnings) pass on both scripts.

This change was authored with the assistance of an AI coding assistant (Claude Code).