### PR TITLE
Grant meta-codesync GitHub App write-equivalent bot permissions

### DIFF
--- a/torchci/lib/bot/utils.ts
+++ b/torchci/lib/bot/utils.ts
@@ -258,7 +258,10 @@ export async function hasWritePermissions(
 ): Promise<boolean> {
   // GitHub Apps authenticate via installations, not as repo collaborators,
   // so the collaborator permission check doesn't apply to them.
-  if (username === "facebook-github-tools[bot]") {
+  if (
+    username === "facebook-github-tools[bot]" ||
+    username === "meta-codesync[bot]"
+  ) {
     return true;
   }
   const permissions = await getUserPermissions(ctx, username);


### PR DESCRIPTION
## Summary

`meta-codesync[bot]` authenticates via a GitHub App installation, not as a repo collaborator, so `getCollaboratorPermissionLevel` returns `none` for it and `hasWritePermissions` denies it. This blocked the bot from using the `@pytorchbot merge -i` flag, which requires write permissions.

Example: on pytorch/pytorch#187360 the bot commented `@pytorchbot merge -i` and was rejected with *"`-i` flag is only allowed for users with write permissions."*

This allowlists `meta-codesync[bot]` in `hasWritePermissions`, the same way `facebook-github-tools[bot]` is already handled. Since `hasRebasePermissions` and `hasWorkflowRunningPermissions` delegate to `hasWritePermissions`, this also covers those checks.

## Context

The `meta-codesync` app installation already has read/write scopes on the repo, but GitHub does not surface App installation scopes through the collaborator-permission API (or `authorAssociation`), so the collaborator check can never pass for an app. An explicit username allowlist is the established pattern here.

## Companion change

The revert path is gated separately in `pytorch/pytorch` (`validate_revert` in `.github/scripts/trymerge.py`), which keys off the app **URL** rather than the username. That companion PR: pytorch/pytorch#187873.

---
This PR was authored with the assistance of an AI coding assistant.