### PR TITLE
[CRCR] Fix wrong parsing value in action.yml

### DIFF
--- a/.github/actions/cross-repo-ci-relay-callback/action.yml
+++ b/.github/actions/cross-repo-ci-relay-callback/action.yml
@@ -19,7 +19,7 @@ inputs:
   conclusion:
     description: >
       Conclusion of the workflow run, passed through to the check run as-is
-      (typically "${{ job.status }}").  Required when status is "completed" and
+      (typically "job.status").  Required when status is "completed" and
       must be a value GitHub accepts (e.g. success, failure, cancelled).  Ignored
       when status is "in_progress".
     required: false


### PR DESCRIPTION
When GitHub parses action templates, it evaluates the `${{}}` expressions within the string, even the input description. However, the `inputs:` scope doesn't have a job context (`job.status` only exists in `runs.steps`). Therefore, it will raise an error when using this action.

- https://github.com/pytorch/test-infra/pull/8173

cc @atalman @subinz1 