### PR TITLE
[setup-nvidia] disable nvidia-container-cli CUDA require check to unblock new CUDA minor versions

### DIFF
--- a/.github/actions/setup-nvidia/action.yml
+++ b/.github/actions/setup-nvidia/action.yml
@@ -66,7 +66,15 @@ runs:
       run: |
         if [ "${HAS_NVIDIA}" = "true" ]; then
           echo "HAS_NVIDIA_GPU=true" >> "${GITHUB_ENV}"
-          echo "GPU_FLAG=--gpus all -e NVIDIA_DRIVER_CAPABILITIES=all" >> "${GITHUB_ENV}"
+          # NVIDIA_DISABLE_REQUIRE=1 disables the nvidia-container-cli prestart
+          # check that strict-compares a CUDA image's NVIDIA_REQUIRE_CUDA
+          # (e.g. "cuda>=13.2") against the host driver's advertised max CUDA.
+          # That check is overly conservative during a new-CUDA-minor rollout:
+          # CUDA minor-version compatibility lets a container built with a newer
+          # minor toolkit run on an older driver within the same major version
+          # (e.g. cuda13.2 image on the R580 / cuda13.0 driver). Without this,
+          # such jobs fail at container init (exit 125) before any work runs.
+          echo "GPU_FLAG=--gpus all -e NVIDIA_DRIVER_CAPABILITIES=all -e NVIDIA_DISABLE_REQUIRE=1" >> "${GITHUB_ENV}"
         else
           echo "HAS_NVIDIA_GPU=false" >> "${GITHUB_ENV}"
         fi


### PR DESCRIPTION
## What
Append `-e NVIDIA_DISABLE_REQUIRE=1` to `GPU_FLAG` in the `setup-nvidia` action.

## Why
GPU jobs that pull a container for a newer CUDA *minor* version fail at container init with `exit 125` before any work runs:

```
docker: Error response from daemon: failed to create task for container: ...
nvidia-container-cli: requirement error: unsatisfied condition: cuda>=13.2,
please update your driver to a newer version, or use an earlier cuda container
```

The `nvidia-container-cli` prestart hook strict-compares the image's `NVIDIA_REQUIRE_CUDA` (e.g. `cuda>=13.2`) against the host driver's advertised max CUDA. The fleet driver pinned in this action is `580.65.06` (R580 / CUDA 13.0), so any `cuda13.1`/`cuda13.2` image is rejected.

This is a false negative: **CUDA minor-version compatibility** guarantees that a container built with a newer minor toolkit runs on an older driver of the *same major version* (e.g. a `cuda13.2` image on an R580/CUDA-13.0 driver). pytorch/pytorch already relies on exactly this — it runs CUDA 13.2 GPU tests on the `580.82.07` (CUDA 13.0) driver — it just doesn't hit this gate because its CI images don't carry the strict `NVIDIA_REQUIRE_CUDA` label that the `almalinux-builder` images do.

## Scope / blast radius
`GPU_FLAG` is only set for NVIDIA GPU jobs, so this affects GPU CI only. Trade-off: a genuine *major*-version mismatch (e.g. a `cuda14` image on a CUDA-13 driver) will no longer fail fast at init — it'll surface later as a runtime error instead.

Alternative considered: bump the pinned driver to one that advertises ≥13.2. Rejected for now because the current R580 line (incl. `580.82.07`) still advertises CUDA 13.0, so a bump wouldn't clear the `cuda>=13.2` gate, and it's a fleet-wide change.

## Motivation / repro
pytorch/executorch adding `13.2` to its `cuda.yml` build matrix, which consumes `linux_job_v2.yml` (and thus this action's default driver + `--gpus all`).
