### PR TITLE
torchci: auto-dispatch AI advisor on Unclassified Dr.CI failures too

### DIFF
--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -242,10 +242,17 @@ export async function updateDrciComments(
         AWAITING_APPROVAL: awaitingApprovalJobs,
       };
 
-      // Auto-dispatch the AI CI Advisor on NEW failures. No-op unless the
-      // feature flag + production env + per-repo config are all set; dispatch
-      // only (no comment/merge changes), with its own ClickHouse dedup +
-      // outage guard. Wrapped so an advisor error can never break the comment.
+      // Auto-dispatch the AI CI Advisor on NEW + UNCLASSIFIED failures. Both are
+      // PR failures the advisor can usefully analyze: unknownJobs (Unclassified)
+      // are failures whose job did not run on the merge base, so Dr.CI has no
+      // same-job baseline -- but the advisor builds its own recent-trunk baseline
+      // by job-name pattern, so it still has signal. They're passed as one list
+      // so the maxNewFailures outage guard bounds the combined per-PR fan-out
+      // (Unclassified were historically part of the new-failure bucket; splitting
+      // them in the Dr.CI comment was only to reduce comment noise). No-op unless
+      // the feature flag + production env + per-repo config are all set; dispatch
+      // only (no comment/merge changes), with its own ClickHouse dedup + outage
+      // guard. Wrapped so an advisor error can never break the comment.
       try {
         await autoDispatchAdvisorForNewFailures({
           owner,
@@ -253,7 +260,7 @@ export async function updateDrciComments(
           prNumber: pr_info.pr_number,
           headSha: pr_info.head_sha,
           mergeBaseSha: pr_info.merge_base,
-          newFailures: failedJobs,
+          newFailures: [...failedJobs, ...unknownJobs],
         });
       } catch (e) {
         console.error(


### PR DESCRIPTION
## What

Extend the Dr.CI AI-advisor auto-dispatch to also run on **Unclassified** failures, not just **New** failures.

Dr.CI buckets a PR failure as *Unclassified* (`unknownJobs`) when the failing job's name did not run on the merge-base commit, so Dr.CI has no same-job baseline to diff against. Today those failures get no advisor verdict, even though they're real failures and the advisor can usefully classify them.

## Why these are worth analyzing

A job is "not on the merge base" mostly for benign, timing-related reasons — **not** because the failure is unimportant:

- **Schedule/label-gated workflows** (`xpu`, `periodic`, `inductor-rocm-mi200`): whether the merge-base commit happens to carry a matching scheduled run is luck of timing. Same job + different merge base ⇒ opposite classification. Real example: `xpu / linux-noble-xpu-n-py3.10 / test` is *Unclassified* on [#187993](https://github.com/pytorch/pytorch/pull/187993) (merge base had only the `pull`-workflow build) but a *New Failure* on [#184892](https://github.com/pytorch/pytorch/pull/184892) (its merge base happened to land on a commit with the scheduled xpu run).
- **Nightly/binary-only workflows** (`linux-binary-manywheel`, `*-binary-wheel`) that never run on `main` pushes.

Crucially, the advisor does **not** depend on the merge base — `dispatchAdvisorWorkflow` pulls a recent-trunk baseline by job-name LIKE pattern. So for the common schedule-gated case (xpu/periodic, which *do* run on trunk on a schedule) the advisor has a real PR-head-vs-trunk comparison — exactly the signal Dr.CI's binary base-name check throws away. For jobs with no trunk presence at all (binary builds), the advisor still sees the PR-head failure but with weaker comparative signal.

## Design

- `drci.ts` passes `unknownJobs` as a new `unclassifiedFailures` arg alongside `failedJobs`.
- The cancelled-filter + signal_key dedup + outage guard are refactored into a `prepareBucket()` helper, applied to each bucket **independently**. This matters: a ciflow/all PR can produce dozens of unclassified failures (e.g. [#180247](https://github.com/pytorch/pytorch/pull/180247) has 48). A naive union would trip the `maxNewFailures` outage guard and **starve the legitimate new-failure dispatch**. Per-bucket guard ⇒ new failures always dispatch; an unclassified flood just skips the unclassified batch.
- Dedup/retry state stays shared by `signal_key` (a job is only ever in one bucket; if that ever changed, the merge keeps the first entry and de-dups by key, so behavior stays conservative — no duplicate dispatches).
- The new-failures-only path is **behavior-preserving**, including bailing before the ClickHouse dedup read on an outage flood.

## Test plan

`yarn jest test/advisorDispatch.test.ts test/drci.test.ts` — PASS.

Adds tests for: dispatching unclassified failures; dispatching both buckets; cross-bucket dedup (one dispatch); and per-bucket outage isolation (a flood in one bucket doesn't starve the other).

## Notes

Dispatch-only — no change to the Dr.CI comment or merge behavior. The resulting verdicts surface via the existing `dr_ci_<job>` signal on the HUD PR view; rendering them inline in the comment's *Unclassified* section, and optionally skipping unclassified jobs that have no trunk baseline, are possible follow-ups.