### PR TITLE
Don't crash update_commit_hashes when the old pin is orphaned upstream

### DIFF
--- a/.github/scripts/test_update_commit_hashes.py
+++ b/.github/scripts/test_update_commit_hashes.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import unittest
+from unittest import mock
+
+import update_commit_hashes as uch
+
+
+class TestGetCommitDate(unittest.TestCase):
+    def test_parses_timestamp_when_reachable(self):
+        with mock.patch.object(uch, "_git_show_timestamp", return_value="1700000000"):
+            self.assertEqual(uch._get_commit_date("repo", "abc"), 1700000000)
+
+    def test_fetches_then_retries_when_missing_from_clone(self):
+        # First `git show` comes up empty (hash not in the clone); after an
+        # explicit fetch the retry succeeds.
+        with mock.patch.object(
+            uch, "_git_show_timestamp", side_effect=["", "1700000000"]
+        ) as show, mock.patch.object(uch.subprocess, "run") as run:
+            self.assertEqual(uch._get_commit_date("repo", "abc"), 1700000000)
+            run.assert_called_once()
+            self.assertEqual(show.call_count, 2)
+
+    def test_returns_none_when_unresolvable(self):
+        # Hash is orphaned upstream: neither the initial show nor the post-fetch
+        # retry can read it.
+        with mock.patch.object(
+            uch, "_git_show_timestamp", side_effect=["", ""]
+        ), mock.patch.object(uch.subprocess, "run"):
+            self.assertIsNone(uch._get_commit_date("repo", "abc"))
+
+
+class TestIsNewerHash(unittest.TestCase):
+    def _patch_dates(self, new_date, old_date):
+        # is_newer_hash queries the new hash first, then the old hash.
+        return mock.patch.object(
+            uch, "_get_commit_date", side_effect=[new_date, old_date]
+        )
+
+    def test_new_hash_is_newer(self):
+        with self._patch_dates(200, 100):
+            self.assertTrue(uch.is_newer_hash("new", "old", "repo"))
+
+    def test_new_hash_is_not_newer(self):
+        with self._patch_dates(100, 200):
+            self.assertFalse(uch.is_newer_hash("new", "old", "repo"))
+
+    def test_orphaned_old_hash_moves_pin_forward(self):
+        # The old pin is unreachable (orphaned upstream) -> treat as an update
+        # so the pin still advances instead of crashing.
+        with self._patch_dates(200, None):
+            self.assertTrue(uch.is_newer_hash("new", "old", "repo"))
+
+    def test_unresolvable_new_hash_does_not_update(self):
+        with self._patch_dates(None, 100):
+            self.assertFalse(uch.is_newer_hash("new", "old", "repo"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/update_commit_hashes.py
+++ b/.github/scripts/update_commit_hashes.py
@@ -2,7 +2,7 @@ import json
 import os
 import subprocess
 from argparse import ArgumentParser
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import requests
 
@@ -92,19 +92,41 @@ def close_pr(source_repo: str, pr_number: str) -> None:
 
 
 def is_newer_hash(new_hash: str, old_hash: str, repo_name: str) -> bool:
-    def _get_date(hash: str) -> int:
+    def _get_date(hash: str) -> Optional[int]:
         # this git command prints the unix timestamp of the hash
-        return int(
+        def _show() -> str:
+            return (
+                subprocess.run(
+                    f"git show --no-patch --no-notes --pretty=%ct {hash}".split(),
+                    capture_output=True,
+                    cwd=f"{repo_name}",
+                )
+                .stdout.decode("utf-8")
+                .strip()
+            )
+
+        timestamp = _show()
+        if not timestamp:
+            # The hash may be unreachable from the cloned branch, e.g. the old
+            # pinned commit was orphaned by a force-push/rebase upstream. Fetch
+            # it explicitly before giving up.
             subprocess.run(
-                f"git show --no-patch --no-notes --pretty=%ct {hash}".split(),
+                f"git fetch --quiet origin {hash}".split(),
                 capture_output=True,
                 cwd=f"{repo_name}",
             )
-            .stdout.decode("utf-8")
-            .strip()
-        )
+            timestamp = _show()
+        return int(timestamp) if timestamp else None
 
-    return _get_date(new_hash) > _get_date(old_hash)
+    new_date = _get_date(new_hash)
+    old_date = _get_date(old_hash)
+    # If the old pinned commit can no longer be found (orphaned upstream), treat
+    # the branch tip as newer so the pin moves forward instead of crashing.
+    if old_date is None:
+        return True
+    if new_date is None:
+        return False
+    return new_date > old_date
 
 
 def main() -> None:

--- a/.github/scripts/update_commit_hashes.py
+++ b/.github/scripts/update_commit_hashes.py
@@ -7,13 +7,11 @@ from typing import Any, Dict, Optional
 import requests
 
 
-UPDATEBOT_TOKEN = os.environ["UPDATEBOT_TOKEN"]
-PYTORCHBOT_TOKEN = os.environ["PYTORCHBOT_TOKEN"]
-
-
 def git_api(
-    url: str, params: Dict[str, str], type: str = "get", token: str = UPDATEBOT_TOKEN
+    url: str, params: Dict[str, str], type: str = "get", token: Optional[str] = None
 ) -> Any:
+    if token is None:
+        token = os.environ["UPDATEBOT_TOKEN"]
     headers = {
         "Accept": "application/vnd.github.v3+json",
         "Authorization": f"token {token}",
@@ -67,7 +65,7 @@ def approve_pr(source_repo: str, pr_number: str) -> None:
         f"/repos/{source_repo}/pulls/{pr_number}/reviews",
         params,
         type="post",
-        token=PYTORCHBOT_TOKEN,
+        token=os.environ["PYTORCHBOT_TOKEN"],
     )
 
 
@@ -78,7 +76,7 @@ def make_comment(source_repo: str, pr_number: str, msg: str) -> None:
         f"/repos/{source_repo}/issues/{pr_number}/comments",
         params,
         type="post",
-        token=PYTORCHBOT_TOKEN,
+        token=os.environ["PYTORCHBOT_TOKEN"],
     )
 
 
@@ -91,35 +89,37 @@ def close_pr(source_repo: str, pr_number: str) -> None:
     )
 
 
+def _git_show_timestamp(repo_name: str, hash: str) -> str:
+    # Print the unix commit timestamp of the hash, or "" if it can't be read.
+    return (
+        subprocess.run(
+            f"git show --no-patch --no-notes --pretty=%ct {hash}".split(),
+            capture_output=True,
+            cwd=repo_name,
+        )
+        .stdout.decode("utf-8")
+        .strip()
+    )
+
+
+def _get_commit_date(repo_name: str, hash: str) -> Optional[int]:
+    timestamp = _git_show_timestamp(repo_name, hash)
+    if not timestamp:
+        # The hash may be unreachable from the cloned branch, e.g. the old
+        # pinned commit was orphaned by a force-push/rebase upstream. Fetch it
+        # explicitly before giving up.
+        subprocess.run(
+            f"git fetch --quiet origin {hash}".split(),
+            capture_output=True,
+            cwd=repo_name,
+        )
+        timestamp = _git_show_timestamp(repo_name, hash)
+    return int(timestamp) if timestamp else None
+
+
 def is_newer_hash(new_hash: str, old_hash: str, repo_name: str) -> bool:
-    def _get_date(hash: str) -> Optional[int]:
-        # this git command prints the unix timestamp of the hash
-        def _show() -> str:
-            return (
-                subprocess.run(
-                    f"git show --no-patch --no-notes --pretty=%ct {hash}".split(),
-                    capture_output=True,
-                    cwd=f"{repo_name}",
-                )
-                .stdout.decode("utf-8")
-                .strip()
-            )
-
-        timestamp = _show()
-        if not timestamp:
-            # The hash may be unreachable from the cloned branch, e.g. the old
-            # pinned commit was orphaned by a force-push/rebase upstream. Fetch
-            # it explicitly before giving up.
-            subprocess.run(
-                f"git fetch --quiet origin {hash}".split(),
-                capture_output=True,
-                cwd=f"{repo_name}",
-            )
-            timestamp = _show()
-        return int(timestamp) if timestamp else None
-
-    new_date = _get_date(new_hash)
-    old_date = _get_date(old_hash)
+    new_date = _get_commit_date(repo_name, new_hash)
+    old_date = _get_commit_date(repo_name, old_hash)
     # If the old pinned commit can no longer be found (orphaned upstream), treat
     # the branch tip as newer so the pin moves forward instead of crashing.
     if old_date is None:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,11 +26,14 @@ jobs:
         echo ::group::setup Python environment
         python -m venv .venv/
         source .venv/bin/activate
-        pip install pip==23.0.1 pytest==7.2.0 jsonschema==4.17.3 clickhouse-connect==0.8.14
+        pip install pip==23.0.1 pytest==7.2.0 jsonschema==4.17.3 clickhouse-connect==0.8.14 requests==2.32.2
         echo ::endgroup::
 
         # Test tools
         python3 -m unittest discover -vs tools/tests -p 'test_*.py'
+
+        # Test .github/scripts
+        (cd .github/scripts && python3 -m unittest -v test_update_commit_hashes)
 
   test-aws-lambda:
     name: Test aws lambda


### PR DESCRIPTION
## Summary

The nightly `update-commit-hash` action clones a tracked repo's branch and compares commit dates between the new branch tip and the currently-pinned hash via `git show --no-patch --pretty=%ct <hash>`. When the upstream branch history is rewritten (force-push / rebase / squash), the currently-pinned commit can become **unreachable** from the branch and is therefore absent from the clone. `git show` then prints nothing and `int("")` raised `ValueError`, crashing the job.

This is currently breaking pytorch/pytorch's nightly `torchcomms` hash update ([failed job](https://github.com/pytorch/pytorch/actions/runs/28067407540/job/83094641246)) — the pinned commit was orphaned by an upstream history rewrite, so every run crashes:

```
fatal: unable to read tree (567c9737f1fbc81ba3fd52b891b5d99bbfafa5ec)
...
  File ".../update_commit_hashes.py", line 97, in _get_date
    return int(...)
ValueError: invalid literal for int() with base 10: ''
```

## Fix

`_get_date` is now resilient:
- On an empty `git show`, it does a best-effort `git fetch origin <hash>` and retries. This rescues commits that are reachable but simply missing from a partial clone.
- It returns `Optional[int]`. When the old pin truly can't be resolved (orphaned and unfetchable), `is_newer_hash` returns `True`, so the pin moves forward to the branch tip instead of crashing.

This PR was authored with the assistance of an AI coding assistant.