### PR TITLE
[autorevert] Add infra_issue AI advisor verdict (treated like not_related)

### DIFF
--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/hud_renderer.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/hud_renderer.py
@@ -57,6 +57,7 @@ HUD_CSS = """
     .advisor-cell.adv-revert { color: #a40000; }
     .advisor-cell.adv-not_related { color: #1a73e8; }
     .advisor-cell.adv-garbage { color: #7a5a00; }
+    .advisor-cell.adv-infra_issue { color: #57606a; }
     .advisor-cell.adv-unsure { color: #555; }
     .advisor-dispatch { font-size: 10px; display: block; margin-top: 2px;
         color: #1a73e8; font-style: italic; }

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -17,6 +17,15 @@ class AdvisorVerdict(Enum):
 
     `revert` is retained indefinitely for backward compatibility with
     historical CH rows produced before the rename.
+
+    `infra_issue` means the CI environment failed before producing a real
+    code-level outcome (runner/container/GPU/network/checkout failure). Like
+    `not_related`, it is not the suspect's fault, so the lambda treats it the
+    same as `not_related`: block this signal from autorevert (no revert). It is
+    kept as a distinct verdict so the reason is recorded faithfully.
+
+    `garbage` means the recorded signal itself is invalid/corrupt as data; it
+    suppresses the signal for a 2h window, then falls through to re-confirm.
     """
 
     REVERT = "revert"
@@ -24,6 +33,7 @@ class AdvisorVerdict(Enum):
     NOT_RELATED = "not_related"
     GARBAGE = "garbage"
     RELATED = "related"
+    INFRA_ISSUE = "infra_issue"
 
 
 @dataclass(frozen=True)
@@ -118,6 +128,7 @@ class IneligibleReason(Enum):
     PENDING_GAP = "pending_gap"  # unknown/pending commits present
     ADVISOR_NOT_RELATED = "advisor_not_related"  # AI advisor says not related
     ADVISOR_GARBAGE = "advisor_garbage"  # AI advisor says signal is garbage
+    ADVISOR_INFRA_ISSUE = "advisor_infra_issue"  # AI advisor says infra failure
 
 
 @dataclass
@@ -601,7 +612,7 @@ class Signal:
 
         Returns:
             - AutorevertPattern if advisor says "revert" or "related" with sufficient confidence
-            - Ineligible if advisor says "not_related" or "garbage" (within 2h window)
+            - Ineligible if advisor says "not_related"/"infra_issue", or "garbage" (within 2h window)
             - None if no verdict, verdict is "unsure", or confidence below threshold
         """
         suspected = partition.failed[-1]
@@ -620,14 +631,24 @@ class Signal:
         if result.verdict in (AdvisorVerdict.REVERT, AdvisorVerdict.RELATED):
             return self._build_autorevert_pattern(partition, advisor_result=result)
 
-        if result.verdict == AdvisorVerdict.NOT_RELATED:
+        # `infra_issue` (CI environment failed before producing a real
+        # code-level outcome) is not the suspect's fault, so it is handled
+        # exactly like `not_related`: block this signal from autorevert. Kept as
+        # a distinct IneligibleReason so the cause is recorded.
+        if result.verdict in (AdvisorVerdict.NOT_RELATED, AdvisorVerdict.INFRA_ISSUE):
+            if result.verdict == AdvisorVerdict.INFRA_ISSUE:
+                reason, label = IneligibleReason.ADVISOR_INFRA_ISSUE, "infra issue"
+            else:
+                reason, label = IneligibleReason.ADVISOR_NOT_RELATED, "not related"
             return Ineligible(
-                IneligibleReason.ADVISOR_NOT_RELATED,
-                f"AI advisor says not related (confidence={result.confidence:.2f})",
+                reason,
+                f"AI advisor says {label} (confidence={result.confidence:.2f})",
             )
 
         if result.verdict == AdvisorVerdict.GARBAGE:
-            # Garbage verdict blocks the signal for 2 hours since the verdict timestamp
+            # Garbage (invalid/corrupt signal) blocks the signal for 2 hours
+            # since the verdict timestamp, then falls through so a fresh run can
+            # re-confirm.
             from datetime import timezone
 
             now = datetime.now(timezone.utc)
@@ -639,7 +660,7 @@ class Signal:
                     f"(confidence={result.confidence:.2f}, "
                     f"age={int(verdict_age.total_seconds() / 60)}min)",
                 )
-            # Garbage verdict expired — fall through to normal processing
+            # Garbage window expired — fall through to normal processing
 
         # "unsure" or expired garbage → continue normally
         return None
@@ -655,7 +676,7 @@ class Signal:
         suspect commit is likely the one that introduced the test. Defer to the
         AI advisor:
         - If a prior advisor verdict exists on the suspect, act on it
-          (revert/related → `AutorevertPattern`; not_related/garbage → blocked).
+          (revert/related → `AutorevertPattern`; not_related/infra_issue/garbage → blocked).
         - Otherwise, dispatch a fresh advisor request alongside the `Ineligible`
           response. Next tick can act on the verdict.
 

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
@@ -973,6 +973,56 @@ class TestAdvisorVerdictIntegration(unittest.TestCase):
         # Garbage expired — should proceed to AutorevertPattern
         self.assertIsInstance(res, AutorevertPattern)
 
+    def test_advisor_infra_issue_produces_ineligible(self):
+        """infra_issue is treated like not_related: block the signal, no revert."""
+        s = self._make_signal_with_advisor(AdvisorVerdict.INFRA_ISSUE)
+        res = s.process_valid_autorevert_pattern()
+        self.assertIsInstance(res, Ineligible)
+        self.assertEqual(res.reason, IneligibleReason.ADVISOR_INFRA_ISSUE)
+
+    def test_advisor_infra_issue_does_not_expire(self):
+        """Unlike garbage, infra_issue has no 2h window — an old verdict still blocks."""
+        old_timestamp = datetime.now(tz=timezone.utc) - timedelta(hours=3)
+        advisor_result = AIAdvisorResult(
+            verdict=AdvisorVerdict.INFRA_ISSUE,
+            confidence=0.95,
+            timestamp=old_timestamp,
+            signal_key="job",
+        )
+        c_newest = SignalCommit(
+            head_sha="sha_newest",
+            timestamp=ts(self.t0, 0),
+            events=[self._ev("job", SignalStatus.FAILURE, 7)],
+        )
+        c_newer = SignalCommit(
+            head_sha="sha_newer",
+            timestamp=ts(self.t0, 0),
+            events=[self._ev("job", SignalStatus.FAILURE, 5)],
+        )
+        c_suspected = SignalCommit(
+            head_sha="sha_mid",
+            timestamp=ts(self.t0, 0),
+            events=[self._ev("job", SignalStatus.FAILURE, 4)],
+            advisor_result=advisor_result,
+        )
+        c_base = SignalCommit(
+            head_sha="sha_old",
+            timestamp=ts(self.t0, 0),
+            events=[
+                self._ev("job", SignalStatus.SUCCESS, 3),
+                self._ev("job", SignalStatus.SUCCESS, 6),
+            ],
+        )
+        s = Signal(
+            key="job",
+            workflow_name="wf",
+            commits=[c_newest, c_newer, c_suspected, c_base],
+        )
+        res = s.process_valid_autorevert_pattern()
+        # infra_issue has no expiry window — still blocked as not-the-suspect's-fault
+        self.assertIsInstance(res, Ineligible)
+        self.assertEqual(res.reason, IneligibleReason.ADVISOR_INFRA_ISSUE)
+
     def test_advisor_unsure_continues_normal_processing(self):
         """When advisor says 'unsure', continue with normal autorevert logic."""
         s = self._make_signal_with_advisor(AdvisorVerdict.UNSURE)

--- a/clickhouse_db_schema/misc.autorevert_advisor_verdicts/schema.sql
+++ b/clickhouse_db_schema/misc.autorevert_advisor_verdicts/schema.sql
@@ -9,7 +9,7 @@ CREATE TABLE misc.autorevert_advisor_verdicts
     `signal_key` String,
     `signal_source` LowCardinality(String),
     `workflow_name` String,
-    `verdict` Enum8('revert' = 1, 'unsure' = 2, 'not_related' = 3, 'garbage' = 4, 'related' = 5),
+    `verdict` Enum8('revert' = 1, 'unsure' = 2, 'not_related' = 3, 'garbage' = 4, 'related' = 5, 'infra_issue' = 6),
     `confidence` Float32,
     `summary` String,
     `causal_reasoning` String,

--- a/torchci/components/autorevert/AutorevertCell.tsx
+++ b/torchci/components/autorevert/AutorevertCell.tsx
@@ -1,6 +1,6 @@
 import { Tooltip } from "@mui/material";
 import AdvisorSection from "components/job/AdvisorSection";
-import { AdvisorVerdict } from "lib/advisorVerdictUtils";
+import { AdvisorVerdict, AdvisorVerdictType } from "lib/advisorVerdictUtils";
 import styles from "./autorevert.module.css";
 import {
   CellEvent,
@@ -33,17 +33,19 @@ const ADV_VERDICT_CLS: Record<string, string> = {
   revert: styles.advRevert,
   related: styles.advRevert,
   not_related: styles.advNotRelated,
+  infra_issue: styles.advInfra,
   garbage: styles.advGarbage,
   unsure: styles.advUnsure,
-};
+} satisfies Record<AdvisorVerdictType, string>;
 
 const ADV_VERDICT_SHORT: Record<string, string> = {
   revert: "REV",
   related: "REV",
   not_related: "OK",
+  infra_issue: "INF",
   garbage: "JNK",
   unsure: "?",
-};
+} satisfies Record<AdvisorVerdictType, string>;
 
 interface AutorevertCellProps {
   events: CellEvent[];

--- a/torchci/components/autorevert/AutorevertGrid.tsx
+++ b/torchci/components/autorevert/AutorevertGrid.tsx
@@ -44,8 +44,10 @@ const INELIGIBLE_REASONS: Record<string, string> = {
     "Some commits between the failure and baseline have pending CI — waiting for results.",
   advisor_not_related:
     "AI advisor determined this failure is not related to the suspect commit.",
+  advisor_infra_issue:
+    "AI advisor determined this failure is an infrastructure issue, not caused by the suspect commit.",
   advisor_garbage:
-    "AI advisor flagged this signal as unreliable (infrastructure flake).",
+    "AI advisor flagged this signal as invalid — it does not reflect a real CI outcome.",
 };
 
 function outcomeTooltip(

--- a/torchci/components/autorevert/autorevert.module.css
+++ b/torchci/components/autorevert/autorevert.module.css
@@ -358,6 +358,11 @@
   color: #8d6e63;
 }
 
+.advInfra {
+  background: rgba(87, 96, 106, 0.2);
+  color: #57606a;
+}
+
 .advUnsure {
   background: rgba(117, 117, 117, 0.2);
   color: #757575;

--- a/torchci/components/autorevert/types.ts
+++ b/torchci/components/autorevert/types.ts
@@ -5,6 +5,8 @@
  * The API merges multiple workflow-set rows into a unified response.
  */
 
+import { AdvisorVerdictType } from "lib/advisorVerdictUtils";
+
 // --- API Response ---
 
 export interface AutorevertStateResponse {
@@ -43,7 +45,7 @@ export interface CellEvent {
 }
 
 export interface ColumnAdvisorResult {
-  verdict: "revert" | "not_related" | "garbage" | "unsure";
+  verdict: AdvisorVerdictType;
   confidence: number;
   signal_key: string;
 }

--- a/torchci/components/job/AdvisorSection.tsx
+++ b/torchci/components/job/AdvisorSection.tsx
@@ -1,13 +1,18 @@
-import { AdvisorVerdict, advisorRunUrl } from "lib/advisorVerdictUtils";
+import {
+  AdvisorVerdict,
+  AdvisorVerdictType,
+  advisorRunUrl,
+} from "lib/advisorVerdictUtils";
 import { useState } from "react";
 
 const VERDICT_COLORS: Record<string, { border: string; badge: string }> = {
   revert: { border: "#d32f2f", badge: "#d32f2f" },
   related: { border: "#d32f2f", badge: "#d32f2f" },
   not_related: { border: "#388e3c", badge: "#2e7d32" },
+  infra_issue: { border: "#57606a", badge: "#57606a" },
   garbage: { border: "#8d6e63", badge: "#6d4c41" },
   unsure: { border: "#757575", badge: "#616161" },
-};
+} satisfies Record<AdvisorVerdictType, { border: string; badge: string }>;
 
 export default function AdvisorSection({
   verdict,

--- a/torchci/components/job/AiAdvisorIndicator.tsx
+++ b/torchci/components/job/AiAdvisorIndicator.tsx
@@ -68,22 +68,27 @@ function isDispatched(
 
 const VERDICT_CHIP_COLORS: Record<
   string,
-  "error" | "warning" | "success" | "default"
+  "error" | "warning" | "success" | "default" | "info"
 > = {
   revert: "error",
   related: "error",
   unsure: "warning",
   not_related: "success",
+  infra_issue: "info",
   garbage: "default",
-};
+} satisfies Record<
+  AdvisorVerdictType,
+  "error" | "warning" | "success" | "default" | "info"
+>;
 
 const VERDICT_LABELS: Record<string, string> = {
   revert: "Revert",
   related: "Related",
   unsure: "Unsure",
   not_related: "Not Related",
+  infra_issue: "Infra Issue",
   garbage: "Garbage Signal",
-};
+} satisfies Record<AdvisorVerdictType, string>;
 
 export default function AiAdvisorIndicator({
   jobName,

--- a/torchci/lib/advisor/advisorBadge.ts
+++ b/torchci/lib/advisor/advisorBadge.ts
@@ -88,6 +88,12 @@ export function verdictBadge(
   if (v === "garbage") {
     return { label: "garbage", color: "#6e7781", darkText: false };
   }
+  if (v === "infra_issue") {
+    // Same "suppressed, not the code's fault" family as garbage, but a
+    // distinct blue-grey so reviewers can tell CI-infra failures apart from
+    // genuinely corrupt signals.
+    return { label: "infra issue", color: "#57606a", darkText: false };
+  }
   if (v === "unsure") {
     return { label: "inconclusive", color: "#8b949e", darkText: false };
   }

--- a/torchci/lib/advisorVerdictUtils.ts
+++ b/torchci/lib/advisorVerdictUtils.ts
@@ -18,7 +18,8 @@ export type AdvisorVerdictType =
   | "related"
   | "unsure"
   | "not_related"
-  | "garbage";
+  | "garbage"
+  | "infra_issue";
 
 export interface AdvisorVerdict {
   sha: string;

--- a/torchci/test/advisorBadge.test.ts
+++ b/torchci/test/advisorBadge.test.ts
@@ -49,10 +49,17 @@ describe("verdictBadge", () => {
     expect(verdictBadge("revert", 0.95).label).toBe("related");
   });
 
-  it("handles garbage / unsure / unknown without confidence wording", () => {
+  it("handles garbage / infra_issue / unsure / unknown without confidence wording", () => {
     expect(verdictBadge("garbage", 0.9).label).toBe("garbage");
+    expect(verdictBadge("infra_issue", 0.9).label).toBe("infra issue");
     expect(verdictBadge("unsure", 0.9).label).toBe("inconclusive");
     expect(verdictBadge("something_new", 0.9).label).toBe("inconclusive");
+  });
+
+  it("gives infra_issue its own color, distinct from garbage", () => {
+    expect(verdictBadge("infra_issue", 0.9).color).not.toBe(
+      verdictBadge("garbage", 0.9).color
+    );
   });
 
   it("does NOT prefix the badge with 'AI:' (the line carries that)", () => {


### PR DESCRIPTION
Adds a new AI advisor verdict **`infra_issue`** alongside `garbage`, wired through every consumer here (ClickHouse schema, autorevert lambda, HUD). Companion prompt change: pytorch/pytorch#188042.

**Why:** a 7-day sample of `misc.autorevert_advisor_verdicts` showed nearly all `garbage` verdicts were actually CI infrastructure failures, and ~13 infra failures were mislabeled `not_related`. `infra_issue` gives them one consistent home ("the environment failed, no valid code-level signal"); `garbage` is narrowed to genuinely corrupt/invalid signals.

**Handling:** `infra_issue` is treated like `not_related` — it blocks the signal from autorevert (no revert), since it isn't the suspect's fault. `garbage` keeps its 2h suppress-then-recheck window.

**Changes:** CH schema `verdict` Enum8 gains `'infra_issue' = 6`; lambda `AdvisorVerdict.INFRA_ISSUE` + `ADVISOR_INFRA_ISSUE`, handled like `not_related` in `_check_advisor_verdict` (+2 tests); HUD `AdvisorVerdictType`, badge pill ("infra issue"), and `hud_renderer` CSS.

**⚠️ Rollout order:** the live table must be ALTERed **before** the workflow emits `infra_issue`, or ingestion drops those rows:
```sql
ALTER TABLE misc.autorevert_advisor_verdicts
  MODIFY COLUMN verdict Enum8('revert'=1,'unsure'=2,'not_related'=3,'garbage'=4,'related'=5,'infra_issue'=6);
```
Order: (1) ALTER → (2) merge this PR → (3) merge pytorch/pytorch#188042. Reads are crash-safe throughout (unknown verdict → `unsure`).