### PR TITLE
[release/2.13] Add 3.15/3.15t torch-only validation for Linux x86 + aarch64 (opt-in, test channel)

### DIFF
--- a/.github/workflows/generate_binary_build_matrix.yml
+++ b/.github/workflows/generate_binary_build_matrix.yml
@@ -52,6 +52,11 @@ on:
         description: "A JSON-encoded list of python versions to build. An empty list means building all supported versions"
         default: "[]"
         type: string
+      include-preview-python-versions:
+        description: "Include opt-in preview python versions (torch-only, Linux x86 and aarch64), e.g. 3.15/3.15t"
+        default: "disable"
+        required: false
+        type: string
       getting-started:
         description: "Release matrix for getting started page"
         required: false
@@ -97,6 +102,7 @@ jobs:
           BUILD_PYTHON_ONLY: ${{ inputs.build-python-only }}
           GETTING_STARTED: ${{ inputs.getting-started }}
           PYTHON_VERSIONS: ${{ inputs.python-versions }}
+          INCLUDE_PREVIEW_PYTHON_VERSIONS: ${{ inputs.include-preview-python-versions }}
         run: |
           set -eou pipefail
           MATRIX_BLOB="$(python3 tools/scripts/generate_binary_build_matrix.py)"

--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -100,6 +100,8 @@ jobs:
       with-cuda: enable
       with-cpu: enable
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
+      # Validate torch-only preview python versions (3.15/3.15t) on the test channel.
+      include-preview-python-versions: enable
 
   linux-aarch64:
     needs: generate-aarch64-linux-matrix

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -109,6 +109,8 @@ jobs:
       test-infra-ref: release/2.13
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
       with-xpu: enable
+      # Validate torch-only preview python versions (3.15/3.15t) on the test channel.
+      include-preview-python-versions: enable
 
   linux:
     needs: generate-linux-matrix

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -23,9 +23,19 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 PYTHON_ARCHES_DICT = {
     "nightly": ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"],
-    "test": ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"],
+    "test": ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"],
     "release": ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"],
 }
+
+# Python versions validated on Linux (x86 and aarch64) only for now. They are
+# stripped from Windows and macOS matrices since torch wheels for these versions
+# are not built/validated there yet.
+LINUX_ONLY_PYTHON_ARCHES = ["3.15", "3.15t"]
+
+# Python versions for which only torch is validated (no torchvision). torchvision
+# wheels are not published for these versions yet, so the install command must
+# request torch alone.
+TORCH_ONLY_PYTHON_ARCHES = ["3.15", "3.15t"]
 
 MACOS_PYTHON_POINT_VERSIONS = {
     "3.10": "3.10.19",
@@ -293,6 +303,11 @@ def get_wheel_install_command(
         else PACKAGES_TO_INSTALL_WHL
     )
 
+    # Validate torch only (no torchvision) for versions without published
+    # torchvision wheels, e.g. 3.15 / 3.15t.
+    if python_version in TORCH_ONLY_PYTHON_ARCHES:
+        PACKAGES_TO_INSTALL = "torch"
+
     if (
         channel == RELEASE
         and (not use_only_dl_pytorch_org)
@@ -429,6 +444,13 @@ def generate_wheels_matrix(
 
     if os == WINDOWS_ARM64:
         python_versions = ["3.11", "3.12", "3.13"]  # only versions for now
+
+    # Restrict Linux-only Python versions (e.g. 3.15/3.15t) to the Linux x86 and
+    # aarch64 matrices so Windows/macOS validation is unaffected.
+    if os not in (LINUX, LINUX_AARCH64):
+        python_versions = [
+            pv for pv in python_versions if pv not in LINUX_ONLY_PYTHON_ARCHES
+        ]
 
     if os == LINUX:
         # NOTE: We only build manywheel packages for linux

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -23,14 +23,19 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 PYTHON_ARCHES_DICT = {
     "nightly": ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"],
-    "test": ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"],
+    "test": ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"],
     "release": ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"],
 }
 
-# Python versions validated on Linux (x86 and aarch64) only for now. They are
-# stripped from Windows and macOS matrices since torch wheels for these versions
-# are not built/validated there yet.
-LINUX_ONLY_PYTHON_ARCHES = ["3.15", "3.15t"]
+# Preview Python versions validated for torch only, on Linux x86 and aarch64.
+# These are opt-in via INCLUDE_PREVIEW_PYTHON_VERSIONS so that the shared
+# generator default is unchanged for domain libraries (torchvision, torchaudio)
+# and for Windows/macOS, which do not have wheels for these versions yet.
+PREVIEW_PYTHON_ARCHES_DICT = {
+    "nightly": [],
+    "test": ["3.15", "3.15t"],
+    "release": [],
+}
 
 # Python versions for which only torch is validated (no torchvision). torchvision
 # wheels are not published for these versions yet, so the install command must
@@ -345,7 +350,9 @@ def generate_libtorch_matrix(
     abi_versions: Optional[List[str]] = None,
     arches: Optional[List[str]] = None,
     libtorch_variants: Optional[List[str]] = None,
+    include_preview_python_versions: bool = False,
 ) -> List[Dict[str, str]]:
+    # libtorch is python-agnostic; the preview python versions do not apply.
     ret: List[Dict[str, str]] = []
 
     if arches is None:
@@ -435,6 +442,7 @@ def generate_wheels_matrix(
     getting_started: bool = False,
     python_versions: Optional[List[str]] = None,
     arches: Optional[List[str]] = None,
+    include_preview_python_versions: bool = False,
 ) -> List[Dict[str, str]]:
     package_type = "wheel"
 
@@ -442,15 +450,15 @@ def generate_wheels_matrix(
         # Define default python version
         python_versions = list(PYTHON_ARCHES)
 
+        # Opt-in preview versions (e.g. 3.15/3.15t) are torch-only and validated
+        # on Linux x86 and aarch64 only. Append them to the default list so the
+        # shared default (used by domain libraries, Windows and macOS) is
+        # unaffected.
+        if include_preview_python_versions and os in (LINUX, LINUX_AARCH64):
+            python_versions += PREVIEW_PYTHON_ARCHES_DICT.get(channel, [])
+
     if os == WINDOWS_ARM64:
         python_versions = ["3.11", "3.12", "3.13"]  # only versions for now
-
-    # Restrict Linux-only Python versions (e.g. 3.15/3.15t) to the Linux x86 and
-    # aarch64 matrices so Windows/macOS validation is unaffected.
-    if os not in (LINUX, LINUX_AARCH64):
-        python_versions = [
-            pv for pv in python_versions if pv not in LINUX_ONLY_PYTHON_ARCHES
-        ]
 
     if os == LINUX:
         # NOTE: We only build manywheel packages for linux
@@ -548,6 +556,7 @@ def generate_build_matrix(
     build_python_only: str,
     getting_started: str = "false",
     python_versions: Optional[List[str]] = None,
+    include_preview_python_versions: str = "disable",
 ) -> Dict[str, List[Dict[str, str]]]:
     includes = []
 
@@ -577,6 +586,8 @@ def generate_build_matrix(
                     use_only_dl_pytorch_org == "true",
                     getting_started == "true",
                     python_versions,
+                    include_preview_python_versions=include_preview_python_versions
+                    == ENABLE,
                 )
             )
 
@@ -678,6 +689,15 @@ def main(args: List[str]) -> None:
         default=os.getenv("PYTHON_VERSIONS", "[]"),
     )
 
+    parser.add_argument(
+        "--include-preview-python-versions",
+        help="Include opt-in preview python versions (torch-only, Linux x86 and "
+        "aarch64) in the matrix",
+        type=str,
+        choices=[ENABLE, DISABLE],
+        default=os.getenv("INCLUDE_PREVIEW_PYTHON_VERSIONS", DISABLE),
+    )
+
     options = parser.parse_args(args)
     try:
         python_versions = json.loads(options.python_versions)
@@ -701,6 +721,7 @@ def main(args: List[str]) -> None:
         options.build_python_only,
         options.getting_started,
         python_versions,
+        options.include_preview_python_versions,
     )
 
     print(json.dumps(build_matrix))

--- a/tools/tests/test_generate_binary_build_matrix.py
+++ b/tools/tests/test_generate_binary_build_matrix.py
@@ -126,11 +126,16 @@ class GenerateBuildMatrixTest(TestCase):
             reference_output_file="build_matrix_linux_wheel_xpu.json",
         )
 
-    def _test_channel_python_versions(self, operating_system: str) -> set:
+    def _test_channel_python_versions(
+        self,
+        operating_system: str,
+        include_preview: str = "disable",
+        channel: str = "test",
+    ) -> set:
         out = generate_build_matrix(
             "wheel",
             operating_system,
-            "test",
+            channel,
             "enable",
             "enable" if operating_system in ("linux",) else "disable",
             "enable",
@@ -138,24 +143,47 @@ class GenerateBuildMatrixTest(TestCase):
             "false",
             "false",
             "disable",
+            "false",
+            None,
+            include_preview,
         )
         return {entry["python_version"] for entry in out["include"]}
 
-    def test_linux_only_python_arches_on_linux(self):
-        # 3.15 / 3.15t are validated on Linux x86 and aarch64 for the test channel.
+    def test_preview_python_versions_opt_in_on_linux(self):
+        # 3.15 / 3.15t are validated on Linux x86 and aarch64 for the test channel
+        # only when explicitly opted in.
         for operating_system in ("linux", "linux-aarch64"):
-            versions = self._test_channel_python_versions(operating_system)
+            versions = self._test_channel_python_versions(
+                operating_system, include_preview="enable"
+            )
             self.assertIn("3.15", versions)
             self.assertIn("3.15t", versions)
 
-    def test_linux_only_python_arches_excluded_elsewhere(self):
-        # Windows and macOS must not pick up the Linux-only versions.
-        for operating_system in ("windows", "macos"):
+    def test_preview_python_versions_off_by_default(self):
+        # Without opt-in the shared default is unchanged (e.g. torchvision builds).
+        for operating_system in ("linux", "linux-aarch64"):
             versions = self._test_channel_python_versions(operating_system)
             self.assertNotIn("3.15", versions)
             self.assertNotIn("3.15t", versions)
 
-    def test_torch_only_install_command_for_linux_only_arches(self):
+    def test_preview_python_versions_excluded_on_non_linux(self):
+        # Windows and macOS must not pick up the preview versions even when opted in.
+        for operating_system in ("windows", "macos"):
+            versions = self._test_channel_python_versions(
+                operating_system, include_preview="enable"
+            )
+            self.assertNotIn("3.15", versions)
+            self.assertNotIn("3.15t", versions)
+
+    def test_preview_python_versions_only_test_channel(self):
+        # Preview versions are defined for the test channel only.
+        versions = self._test_channel_python_versions(
+            "linux", include_preview="enable", channel="nightly"
+        )
+        self.assertNotIn("3.15", versions)
+        self.assertNotIn("3.15t", versions)
+
+    def test_torch_only_install_command_for_preview_arches(self):
         out = generate_build_matrix(
             "wheel",
             "linux",
@@ -167,6 +195,9 @@ class GenerateBuildMatrixTest(TestCase):
             "false",
             "false",
             "disable",
+            "false",
+            None,
+            "enable",
         )
         for entry in out["include"]:
             if entry["python_version"] in ("3.15", "3.15t"):

--- a/tools/tests/test_generate_binary_build_matrix.py
+++ b/tools/tests/test_generate_binary_build_matrix.py
@@ -126,6 +126,54 @@ class GenerateBuildMatrixTest(TestCase):
             reference_output_file="build_matrix_linux_wheel_xpu.json",
         )
 
+    def _test_channel_python_versions(self, operating_system: str) -> set:
+        out = generate_build_matrix(
+            "wheel",
+            operating_system,
+            "test",
+            "enable",
+            "enable" if operating_system in ("linux",) else "disable",
+            "enable",
+            "enable" if operating_system in ("linux", "windows") else "disable",
+            "false",
+            "false",
+            "disable",
+        )
+        return {entry["python_version"] for entry in out["include"]}
+
+    def test_linux_only_python_arches_on_linux(self):
+        # 3.15 / 3.15t are validated on Linux x86 and aarch64 for the test channel.
+        for operating_system in ("linux", "linux-aarch64"):
+            versions = self._test_channel_python_versions(operating_system)
+            self.assertIn("3.15", versions)
+            self.assertIn("3.15t", versions)
+
+    def test_linux_only_python_arches_excluded_elsewhere(self):
+        # Windows and macOS must not pick up the Linux-only versions.
+        for operating_system in ("windows", "macos"):
+            versions = self._test_channel_python_versions(operating_system)
+            self.assertNotIn("3.15", versions)
+            self.assertNotIn("3.15t", versions)
+
+    def test_torch_only_install_command_for_linux_only_arches(self):
+        out = generate_build_matrix(
+            "wheel",
+            "linux",
+            "test",
+            "enable",
+            "enable",
+            "enable",
+            "enable",
+            "false",
+            "false",
+            "disable",
+        )
+        for entry in out["include"]:
+            if entry["python_version"] in ("3.15", "3.15t"):
+                # torchvision is not published for these versions yet.
+                self.assertNotIn("torchvision", entry["installation"])
+                self.assertIn("torch", entry["installation"])
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Test generate build matrix")


### PR DESCRIPTION
## What

Add Python **3.15** and **3.15t** to the binary **validation** matrix, scoped to:
- **torch only** (no torchvision in the install command),
- **Linux x86 and aarch64** only,
- the **test** channel only,
- and **opt-in**, so the shared generator default is unchanged for everyone else.

## Why opt-in (updated)

`tools/scripts/generate_binary_build_matrix.py` is shared by torch validation **and** by the domain libraries (torchvision, torchaudio) -- both their wheel builds and `validate-domain-library.yml`. Putting 3.15/3.15t directly into the `test` channel default leaked the versions into **torchvision release/0.28** validation, which has no 3.15 wheels. So instead of changing the shared default, the preview versions are opt-in.

## Details

- `PYTHON_ARCHES_DICT` default is **unchanged** (no 3.15) -- vision/audio, Windows and macOS matrices are byte-for-byte identical to before.
- New `PREVIEW_PYTHON_ARCHES_DICT` holds `3.15` / `3.15t` for the **test** channel only.
- `generate_wheels_matrix` appends the preview versions only when `include_preview_python_versions` is enabled **and** `os in (linux, linux-aarch64)`.
- New `include-preview-python-versions` input on the reusable `generate_binary_build_matrix.yml` (default `disable`), wired to the `INCLUDE_PREVIEW_PYTHON_VERSIONS` env var.
- Enabled (`enable`) **only** in the torch validation workflows `validate-linux-binaries.yml` and `validate-aarch64-linux-binaries.yml`.
- `get_wheel_install_command` emits `pip3 install torch ...` (no torchvision) for `TORCH_ONLY_PYTHON_ARCHES = [3.15, 3.15t]`.
- Full accelerator coverage on Linux matching 3.14: CPU + CUDA 12.6/13.0/13.2 + ROCm + XPU (x86); CPU + CUDA 12.6/13.0/13.2 (aarch64).

## Blast radius

- torchvision / torchaudio: **unaffected** (default unchanged, they do not set the opt-in).
- Windows / macOS torch validation: **unaffected** (preview versions stripped even if opted in).
- nightly / release channels: **unaffected** (`PREVIEW_PYTHON_ARCHES_DICT` only populates `test`).
- Only torch Linux x86 + aarch64 **test**-channel validation gains 3.15/3.15t.

## Test plan

- `python -m unittest tools.tests.test_generate_binary_build_matrix` -- 12 tests pass (7 existing + 5 new).
- New tests assert: opt-in adds 3.15/3.15t on linux & linux-aarch64; off-by-default; excluded on windows/macos even when opted in; only on the test channel; install command is torch-only.
- Manual generation verified:
  - default `--channel test --operating-system linux` -> no 3.15 (vision path).
  - `--include-preview-python-versions enable` linux / linux-aarch64 -> 3.15/3.15t, torch-only install.
  - opt-in windows/macos and opt-in nightly -> no 3.15.
- Golden assets (generated on the nightly channel, default) are unchanged.
