### PR TITLE
[release/2.13] Add CUDA 12.9 builds for Linux (x86 + aarch64) in the test channel

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -49,6 +49,7 @@ ROCM_ARCHES_DICT = {
 CUDA_CUDNN_VERSIONS = {
     "12.6": {"cuda": "12.6.3", "cudnn": "9"},
     "12.8": {"cuda": "12.8.0", "cudnn": "9"},
+    "12.9": {"cuda": "12.9.1", "cudnn": "9"},
     "13.0": {"cuda": "13.0.0", "cudnn": "9"},
     "13.2": {"cuda": "13.2.0", "cudnn": "9"},
 }
@@ -59,7 +60,11 @@ STABLE_CUDA_VERSIONS = {
     "release": "13.0",
 }
 
-CUDA_AARCH64_ARCHES = ["12.6-aarch64", "13.0-aarch64", "13.2-aarch64"]
+CUDA_AARCH64_ARCHES_DICT = {
+    "nightly": ["12.6-aarch64", "13.0-aarch64", "13.2-aarch64"],
+    "test": ["12.6-aarch64", "12.9-aarch64", "13.0-aarch64", "13.2-aarch64"],
+    "release": ["12.6-aarch64", "13.0-aarch64", "13.2-aarch64"],
+}
 
 PACKAGE_TYPES = ["wheel", "libtorch"]
 CXX11_ABI = "cxx11-abi"
@@ -91,6 +96,7 @@ CURRENT_VERSION = CURRENT_STABLE_VERSION
 
 # By default use Nightly for CUDA arches
 CUDA_ARCHES = CUDA_ARCHES_DICT[NIGHTLY]
+CUDA_AARCH64_ARCHES = CUDA_AARCH64_ARCHES_DICT[NIGHTLY]
 ROCM_ARCHES = ROCM_ARCHES_DICT[NIGHTLY]
 PYTHON_ARCHES = PYTHON_ARCHES_DICT[NIGHTLY]
 
@@ -167,6 +173,13 @@ def initialize_globals(
         CURRENT_VERSION = CURRENT_STABLE_VERSION
 
     CUDA_ARCHES = CUDA_ARCHES_DICT[channel]
+    CUDA_AARCH64_ARCHES = CUDA_AARCH64_ARCHES_DICT[channel]
+    # CUDA 12.9 is built for Linux only (x86 and aarch64) in the test channel.
+    # Windows and macOS do not build 12.9. aarch64 is handled via the per-channel
+    # CUDA_AARCH64_ARCHES_DICT above; here we add the x86 arch for Linux only so
+    # that Windows (which shares CUDA_ARCHES_DICT) does not pick it up.
+    if channel == TEST and os == LINUX:
+        CUDA_ARCHES = CUDA_ARCHES + ["12.9"]
     ROCM_ARCHES = ROCM_ARCHES_DICT[channel]
     if build_python_only:
         # Only select the oldest version of python if building a python only package


### PR DESCRIPTION
## Summary

Port of #8164 to **release/2.13**. Adds CUDA 12.9 wheel/libtorch builds to the **test** channel, scoped to **Linux only (x86 + aarch64)**. Windows and macOS do **not** build 12.9.

Changes in `tools/scripts/generate_binary_build_matrix.py`:
- **Linux x86**: 12.9 is added in `initialize_globals` only when `channel == test and os == linux`. It is intentionally **not** placed in `CUDA_ARCHES_DICT["test"]`, because Windows reads that same list and must not pick up 12.9.
- **Linux aarch64**: introduced a per-channel `CUDA_AARCH64_ARCHES_DICT` (mirroring `CUDA_ARCHES_DICT`) with `12.9-aarch64` in the `test` channel only. `linux-aarch64` is the only consumer of that list.
- `CUDA_CUDNN_VERSIONS`: added `"12.9": {"cuda": "12.9.1", "cudnn": "9"}`.
- Container images (`manylinux2_28-builder:cuda12.9`, `manylinuxaarch64-builder:cuda12.9`) are derived automatically.

## Verification

Generated matrices per OS for `--channel test`:

| OS | CUDA arches |
|----|----|
| linux | `12.6, 12.9, 13.0, 13.2` |
| linux-aarch64 | `12.6-aarch64, 12.9-aarch64, 13.0-aarch64, 13.2-aarch64` |
| windows | `12.6, 13.0, 13.2` (no 12.9) |
| macos | none (no CUDA) |

Other channels unaffected: `nightly`/`release` linux do not include 12.9. Sample 12.9 entry: `build_name=manywheel-py3_10-cuda12_9`, `desired_cuda=cu129`, `container_image=pytorch/manylinux2_28-builder:cuda12.9`.

## Test assets

Unlike #8164 on release/2.12, the reference assets on release/2.13 are **not** stale -- all 7 matrix tests pass on the pristine branch and after this change. The assets are generated for the **nightly** channel, which is unchanged, so no regeneration is needed.
