### PR TITLE
[CRCR] Rename OOT → CRCR in relay Lambda (Redis keys, config, tests)

### DIFF
--- a/aws/lambda/cross_repo_ci_relay/README.md
+++ b/aws/lambda/cross_repo_ci_relay/README.md
@@ -47,7 +47,7 @@ The callback endpoint validates incoming callbacks and forwards them to HUD for 
 - **State machine**: Relay maintains a **unified state machine** in Redis to validate callback lifecycles, compute timing metrics, and support per-workflow tracking:
   - **Unified structure**: Single enum `CallbackState` with states `DISPATCHED` (webhook side, keyed by sentinel `run_id=0, run_attempt=0`), `IN_PROGRESS`, and `COMPLETED` (callback side, per-workflow). State records stored as JSON: `{"state": "...", "timestamp": 1234.56}`.
   - **Dispatch validation**: `DISPATCHED` state proves valid webhook origin. Callbacks without this state are rejected (no prior dispatch).
-  - **Workflow-level tracking**: Each workflow has independent state and timestamps keyed by `{run_id}:{run_attempt}` (`oot:state:{delivery_id}:{repo}:{run_id}:{run_attempt}`). Supports multiple workflows per webhook.
+  - **Workflow-level tracking**: Each workflow has independent state and timestamps keyed by `{run_id}:{run_attempt}` (`crcr:state:{delivery_id}:{repo}:{run_id}:{run_attempt}`). Supports multiple workflows per webhook.
   - **Timing metrics**: `queue_time = dispatch_timestamp → in_progress_timestamp`, `execution_time = in_progress_timestamp → completed_timestamp`. Timestamps extracted from state records.
   - **State transitions**: Rejects invalid flows (`COMPLETED` without prior `IN_PROGRESS`, duplicate `IN_PROGRESS` for the same `{run_id}:{run_attempt}`, duplicate `COMPLETED`, callbacks without a prior `DISPATCHED` record).
     Note that the direction graph below is for a single check run, reruns have different `run_attempt` and are treated as separate workflows, so they won't violate the state machine since they won't have a prior `IN_PROGRESS` or `COMPLETED` record.
@@ -253,7 +253,7 @@ make clean
 - A running Redis instance:
   ```bash
   # Using the built-in "default" user with a password:
-  docker run -d --name oot-redis \
+  docker run -d --name crcr-redis \
     -p 6379:6379 \
     redis:7-alpine \
     redis-server --requirepass <your-password>

--- a/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
@@ -10,11 +10,11 @@ from utils.redis_helper import CallbackStateRecord
 
 def _cfg():
     cfg = MagicMock()
-    cfg.hud_api_url = "http://hud/api/oot-ci-events"
+    cfg.hud_api_url = "http://hud/api/crcr-ci-events"
     cfg.hud_bot_key = "bot-key-123"
     cfg.redis_endpoint = "host:6379"
     cfg.redis_login = ""
-    cfg.oot_status_ttl = 259200
+    cfg.crcr_status_ttl = 259200
     cfg.rate_limit_per_min = 20
     return cfg
 

--- a/aws/lambda/cross_repo_ci_relay/tests/test_cleanup_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_cleanup_handler.py
@@ -11,7 +11,7 @@ from utils.redis_helper import CallbackStateRecord
 
 def _cfg():
     cfg = MagicMock()
-    cfg.hud_api_url = "http://hud/api/oot/results"
+    cfg.hud_api_url = "http://hud/api/crcr/results"
     cfg.hud_bot_key = "bot-key-123"
     cfg.zombie_timeout_seconds = 86400
     cfg.max_cleanup_workers = 4

--- a/aws/lambda/cross_repo_ci_relay/tests/test_hud.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_hud.py
@@ -8,7 +8,7 @@ from utils.misc import HTTPException
 
 
 def _cfg(
-    url="http://hud/api/oot-ci-events",
+    url="http://hud/api/crcr-ci-events",
     key="bot-key",
     max_retries=3,
     rate_limit_per_min=60,

--- a/aws/lambda/cross_repo_ci_relay/tests/test_redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_redis_helper.py
@@ -22,7 +22,7 @@ def _cfg():
     cfg.redis_endpoint = "host:6379"
     cfg.redis_login = ""
     cfg.allowlist_ttl_seconds = 600
-    cfg.oot_status_ttl = 3600
+    cfg.crcr_status_ttl = 3600
     cfg.rate_limit_per_min = 20
     return cfg
 

--- a/aws/lambda/cross_repo_ci_relay/tests/test_redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_redis_helper.py
@@ -311,9 +311,9 @@ class TestInProgressTracker(unittest.TestCase):
         expected_member = "del-123:org/repo:99999:1"
         expected_score = now + 86400
         client.zadd.assert_called_once_with(
-            "oot:in_progress", {expected_member: expected_score}
+            "crcr:in_progress", {expected_member: expected_score}
         )
-        client.expire.assert_called_once_with("oot:in_progress", 172800)
+        client.expire.assert_called_once_with("crcr:in_progress", 172800)
 
     def test_add_in_progress_tracker_redis_error_is_silent(self):
         """Redis errors are logged but not raised — tracker is best-effort."""
@@ -335,7 +335,7 @@ class TestInProgressTracker(unittest.TestCase):
         remove_in_progress_tracker(cfg, "del-123", "org/repo", 99999, 1, client=client)
 
         client.zrem.assert_called_once_with(
-            "oot:in_progress", "del-123:org/repo:99999:1"
+            "crcr:in_progress", "del-123:org/repo:99999:1"
         )
 
     def test_remove_in_progress_tracker_redis_error_is_silent(self):
@@ -385,7 +385,7 @@ class TestInProgressTracker(unittest.TestCase):
         self.assertEqual(results[0]["state_record"].state, CallbackState.IN_PROGRESS)
 
         # Second entry (COMPLETED) had its tracker cleaned up
-        client.zrem.assert_any_call("oot:in_progress", "del-2:org/repo:20:1")
+        client.zrem.assert_any_call("crcr:in_progress", "del-2:org/repo:20:1")
 
     def test_scan_expired_skips_missing_state_records(self):
         """Members whose state record is gone are cleaned from the ZSET."""
@@ -403,7 +403,7 @@ class TestInProgressTracker(unittest.TestCase):
 
         self.assertEqual(results, [])
         client.zrem.assert_called_once_with(
-            "oot:in_progress", "del-missing:org/repo:5:1"
+            "crcr:in_progress", "del-missing:org/repo:5:1"
         )
 
     def test_scan_expired_handles_malformed_member(self):
@@ -420,7 +420,7 @@ class TestInProgressTracker(unittest.TestCase):
             results = scan_expired_in_progress(cfg, client=client)
 
         self.assertEqual(results, [])
-        client.zrem.assert_called_once_with("oot:in_progress", "bad-member")
+        client.zrem.assert_called_once_with("crcr:in_progress", "bad-member")
 
     def test_set_callback_state_with_payload(self):
         """Payload is stored alongside state and timestamp under a "payload" key."""

--- a/aws/lambda/cross_repo_ci_relay/utils/config.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/config.py
@@ -61,7 +61,7 @@ class RelayConfig:
     max_dispatch_workers: int
     hud_api_url: str
     hud_bot_key: str
-    oot_status_ttl: int
+    crcr_status_ttl: int
     hud_max_retries: int
     rate_limit_per_min: int
 
@@ -123,12 +123,12 @@ class RelayConfig:
         allowlist_ttl_seconds = max(allowlist_ttl_seconds, 900)
 
         # GitHub can keep a workflow in `pending` state for up to 3 days before
-        # auto-cancelling it, so OOT-status records must live at least that long.
+        # auto-cancelling it, so CRCR-status records must live at least that long.
         # Default to 3 days (259200 s).
         try:
-            oot_status_ttl = int(os.getenv("OOT_STATUS_TTL", "259200"))
+            crcr_status_ttl = int(os.getenv("CRCR_STATUS_TTL", "259200"))
         except ValueError:
-            raise RuntimeError("OOT_STATUS_TTL must be a valid integer")
+            raise RuntimeError("CRCR_STATUS_TTL must be a valid integer")
 
         # Maximum number of retry attempts for HUD API calls.
         # Default to 3 retries with exponential backoff.
@@ -151,9 +151,9 @@ class RelayConfig:
             raise RuntimeError(
                 "HUD_API_URL must use https:// to protect the bot key in transit"
             )
-        # Add hud_api_url ends with /oot/results for flexibility of adding features later
+        # Add hud_api_url ends with /crcr/results for flexibility of adding features later
         if hud_api_url:
-            hud_api_url = hud_api_url.rstrip("/") + "/oot/results"
+            hud_api_url = hud_api_url.rstrip("/") + "/crcr/results"
 
         return cls(
             github_app_id=_require("GITHUB_APP_ID"),
@@ -167,7 +167,7 @@ class RelayConfig:
             max_dispatch_workers=int(os.getenv("MAX_DISPATCH_WORKERS", "32")),
             hud_api_url=hud_api_url,
             hud_bot_key=hud_bot_key,
-            oot_status_ttl=oot_status_ttl,
+            crcr_status_ttl=crcr_status_ttl,
             hud_max_retries=hud_max_retries,
             rate_limit_per_min=rate_limit_per_min,
         )

--- a/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
@@ -14,9 +14,9 @@ from .misc import CallbackState, CallbackStateRecord, DISPATCH_RUN_ID, HTTPExcep
 
 logger = logging.getLogger(__name__)
 
-_ALLOWLIST_CACHE_KEY = "oot:allowlist_yaml"
-_STATE_PREFIX = "oot:state:"
-_RATE_LIMIT_PREFIX = "oot:rate:"
+_ALLOWLIST_CACHE_KEY = "crcr:allowlist_yaml"
+_STATE_PREFIX = "crcr:state:"
+_RATE_LIMIT_PREFIX = "crcr:rate:"
 _cached_client: redis_lib.Redis | None = None
 _cached_client_url: str | None = None
 
@@ -310,7 +310,7 @@ def set_callback_state(
             "state": state.value,
             "timestamp": timestamp,
         }
-        client.setex(key, config.oot_status_ttl, json.dumps(data))
+        client.setex(key, config.crcr_status_ttl, json.dumps(data))
         logger.info(
             "callback state set key=%s state=%s timestamp=%s",
             key,


### PR DESCRIPTION
## Summary

Part 1 of the OOT → CRCR rename series. Renames all `oot` references to `crcr` in the `cross_repo_ci_relay` Lambda code to align with the official "Cross-Repository CI Relay" (CRCR) terminology.

**Changes (6 files):**

- **`utils/config.py`** — `oot_status_ttl` → `crcr_status_ttl`, `OOT_STATUS_TTL` → `CRCR_STATUS_TTL` env var, `/oot/results` → `/crcr/results` HUD API path
- **`utils/redis_helper.py`** — Redis key prefixes: `oot:state:` → `crcr:state:`, `oot:rate:` → `crcr:rate:`, `oot:allowlist_yaml` → `crcr:allowlist_yaml`, `config.oot_status_ttl` → `config.crcr_status_ttl`
- **`README.md`** — Updated key format example and Docker container name
- **`tests/test_redis_helper.py`** — Updated mock config field
- **`tests/test_callback_handler.py`** — Updated mock config field and URL
- **`tests/test_hud.py`** — Updated mock URL

**Deployment note:** Existing Redis keys with the `oot:*` prefix will expire naturally via TTL — no migration needed. The `CRCR_STATUS_TTL` env var replaces `OOT_STATUS_TTL` on the Lambda.

**Depends on:** HUD-side `/api/crcr/results` endpoint (PR 3 in this series) must be deployed before or alongside this change so the Lambda can forward to the new path.

## Rename series

| PR | Scope | Status |
|----|-------|--------|
| **PR 1 (this)** | Lambda — Redis keys, config, tests | This PR |
| PR 2 | ClickHouse — schema + replicator | Upcoming |
| PR 3 | Frontend — lib, API, components, queries, tests | Upcoming |

## Test plan

- [ ] Verify all existing Lambda unit tests pass with renamed fields
- [ ] Confirm `CRCR_STATUS_TTL` env var is read correctly
- [ ] Confirm HUD API URL is constructed as `/crcr/results`