### PR TITLE
[CRCR] Rename OOT → CRCR in ClickHouse schema and replicator mapping

### DIFF
--- a/aws/lambda/clickhouse-replicator-dynamo/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-dynamo/lambda_function.py
@@ -33,7 +33,7 @@ SUPPORTED_TABLES = {
     "vllm-buildkite-agent-events": "vllm.vllm_buildkite_agents",
     "vllm-buildkite-build-events": "vllm.vllm_buildkite_builds",
     "vllm-buildkite-job-events": "vllm.vllm_buildkite_jobs",
-    "torchci-oot-workflow-job": "default.oot_workflow_job",
+    "torchci-oot-workflow-job": "default.crcr_workflow_job",
 }
 
 

--- a/clickhouse_db_schema/default.crcr_workflow_job/schema.sql
+++ b/clickhouse_db_schema/default.crcr_workflow_job/schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE default.oot_workflow_job
+CREATE TABLE default.crcr_workflow_job
 (
     `dynamoKey` String,
     `status` String,


### PR DESCRIPTION
## Summary

Part 2 of the OOT → CRCR rename series. Renames the ClickHouse table schema and updates the DynamoDB-to-ClickHouse replicator mapping.

**Changes (2 files):**

- **`clickhouse_db_schema/default.oot_workflow_job/`** → **`default.crcr_workflow_job/`** — directory rename + `CREATE TABLE` statement updated
- **`aws/lambda/clickhouse-replicator-dynamo/lambda_function.py`** — replicator mapping target: `default.oot_workflow_job` → `default.crcr_workflow_job`

**Note:** The DynamoDB source key (`torchci-oot-workflow-job`) is kept as-is here since that's an AWS resource renamed separately (infra change).

**Deployment note:** Run `RENAME TABLE default.oot_workflow_job TO default.crcr_workflow_job` on the live ClickHouse instance alongside this deploy.

## Rename series

| PR | Scope | Status |
|----|-------|--------|
| PR 1 | Lambda — Redis keys, config, tests | [#8217](https://github.com/pytorch/test-infra/pull/8217) |
| **PR 2 (this)** | ClickHouse — schema + replicator | This PR |
| PR 3 | Frontend — lib, API, components, queries, tests | Upcoming |

## Test plan

- [ ] Verify ClickHouse schema file has correct table name
- [ ] Verify replicator mapping targets the new table
- [ ] Coordinate `RENAME TABLE` on ClickHouse during deployment