### PR TITLE
[CRCR] Add allowlist-driven summary page with L4→L1 sections

### DIFF
--- a/torchci/clickhouse_queries/crcr_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_summary/query.sql
@@ -3,6 +3,7 @@ SELECT
     anyLast(downstream_repo_level) AS downstream_repo_level,
     countIf(conclusion = 'success') AS successes,
     countIf(conclusion = 'failure') AS failures,
+    countIf(conclusion = 'timed_out') AS timed_out,
     count() AS total,
     if(total > 0, successes / total, 0) AS pass_rate,
     avg(duration_seconds) AS avg_duration_s,

--- a/torchci/pages/api/crcr/allowlist.ts
+++ b/torchci/pages/api/crcr/allowlist.ts
@@ -1,0 +1,95 @@
+import yaml from "js-yaml";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const ALLOWLIST_RAW_URL =
+  "https://raw.githubusercontent.com/pytorch/pytorch/main/.github/allowlist.yml";
+
+const CACHE_TTL_MS = 15 * 60 * 1000;
+
+export interface AllowlistEntry {
+  repo: string;
+  oncalls: string[];
+}
+
+export interface AllowlistResponse {
+  L1: AllowlistEntry[];
+  L2: AllowlistEntry[];
+  L3: AllowlistEntry[];
+  L4: AllowlistEntry[];
+}
+
+let cached: { data: AllowlistResponse; expiry: number } | null = null;
+
+function parseEntry(raw: unknown): AllowlistEntry | null {
+  if (typeof raw === "string") {
+    const repo = raw.trim().replace(/^\/|\/$/g, "");
+    return repo.includes("/") ? { repo, oncalls: [] } : null;
+  }
+  if (typeof raw === "object" && raw !== null) {
+    const [key, val] = Object.entries(raw)[0] ?? [];
+    const repo = String(key ?? "")
+      .trim()
+      .replace(/^\/|\/$/g, "");
+    if (!repo.includes("/")) return null;
+    const oncalls = val
+      ? String(val)
+          .split(",")
+          .map((s: string) => s.trim())
+          .filter(Boolean)
+      : [];
+    return { repo, oncalls };
+  }
+  return null;
+}
+
+function parseAllowlist(rawYaml: Record<string, unknown>): AllowlistResponse {
+  const result: AllowlistResponse = { L1: [], L2: [], L3: [], L4: [] };
+  for (const level of ["L1", "L2", "L3", "L4"] as const) {
+    const entries = rawYaml[level];
+    if (!Array.isArray(entries)) continue;
+    for (const raw of entries) {
+      const entry = parseEntry(raw);
+      if (entry) result[level].push(entry);
+    }
+  }
+  return result;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const now = Date.now();
+  if (cached && now < cached.expiry) {
+    res.setHeader("X-Cache", "HIT");
+    return res.status(200).json(cached.data);
+  }
+
+  try {
+    const response = await fetch(ALLOWLIST_RAW_URL);
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch allowlist from GitHub: ${response.status}`
+      );
+    }
+    const text = await response.text();
+    const parsed = (yaml.load(text) as Record<string, unknown>) || {};
+    const data = parseAllowlist(parsed);
+
+    cached = { data, expiry: now + CACHE_TTL_MS };
+    res.setHeader("X-Cache", "MISS");
+    return res.status(200).json(data);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    console.error("CRCR allowlist fetch error:", message);
+    if (cached) {
+      res.setHeader("X-Cache", "STALE");
+      return res.status(200).json(cached.data);
+    }
+    return res.status(502).json({ error: message });
+  }
+}

--- a/torchci/pages/crcr/index.tsx
+++ b/torchci/pages/crcr/index.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Chip,
+  Divider,
   FormControl,
   InputLabel,
   Link,
@@ -22,19 +23,56 @@ import { durationDisplay } from "components/common/TimeUtils";
 import { fetcher } from "lib/GeneralUtils";
 import Head from "next/head";
 import NextLink from "next/link";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import useSWR from "swr";
 
-interface CrcrSummaryRow {
+import type { AllowlistEntry, AllowlistResponse } from "../api/crcr/allowlist";
+
+interface CiMetricsRow {
   repo: string;
   downstream_repo_level: string;
   successes: number;
   failures: number;
+  timed_out: number;
   total: number;
   pass_rate: number;
   avg_duration_s: number;
   last_run: string;
 }
+
+type Level = "L1" | "L2" | "L3" | "L4";
+
+const LEVEL_META: Record<
+  Level,
+  { label: string; description: string; color: string }
+> = {
+  L4: {
+    label: "L4 Backends (merge-gating)",
+    description:
+      "Blocking check run on every PR; reserved for critical accelerators.",
+    color: "#7b1fa2",
+  },
+  L3: {
+    label: "L3 Backends (check runs on PR)",
+    description:
+      "Non-blocking check run on PRs when ciflow/crcr/<name> label is applied.",
+    color: "#ed6c02",
+  },
+  L2: {
+    label: "L2 Backends (callback-only)",
+    description: "CI results displayed on the HUD page, but not on PRs.",
+    color: "#0288d1",
+  },
+  L1: {
+    label: "L1 Integrations (webhook-only)",
+    description:
+      "Repos receive webhook notifications on new commits. No CI results reported back.",
+    color: "#9e9e9e",
+  },
+};
+
+const LEVELS_ORDERED: Level[] = ["L4", "L3", "L2", "L1"];
+const CRCR_HEALTH_REPO = "pytorch/crcr-test";
 
 function PassRateChip({ rate }: { rate: number }) {
   const pct = (rate * 100).toFixed(1) + "%";
@@ -43,37 +81,44 @@ function PassRateChip({ rate }: { rate: number }) {
   return <Chip label={pct} color="error" size="small" />;
 }
 
-function CrcrSummaryTable({ days }: { days: number }) {
-  const url = `/api/clickhouse/crcr_summary?parameters=${encodeURIComponent(
-    JSON.stringify({ days: String(days) })
-  )}`;
-  const { data, error } = useSWR<CrcrSummaryRow[]>(url, fetcher, {
-    refreshInterval: 60_000,
-  });
-
-  if (error) {
-    return (
-      <Typography color="error">
-        Failed to load CRCR summary: {error.message}
-      </Typography>
-    );
-  }
-  if (!data) {
-    return <Skeleton variant="rectangular" height={300} />;
-  }
-  if (data.length === 0) {
-    return (
-      <Typography color="text.secondary" sx={{ py: 4, textAlign: "center" }}>
-        No CRCR CI results in the last {days} days.
-      </Typography>
-    );
-  }
-
+function LevelChip({ level }: { level: Level }) {
+  const meta = LEVEL_META[level];
   return (
-    <TableContainer component={Paper} elevation={2}>
+    <Chip
+      label={level}
+      size="small"
+      variant="outlined"
+      sx={{ borderColor: meta.color, color: meta.color }}
+    />
+  );
+}
+
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function CiHealthTable({
+  level,
+  repos,
+  metricsMap,
+}: {
+  level: Level;
+  repos: AllowlistEntry[];
+  metricsMap: Map<string, CiMetricsRow>;
+}) {
+  return (
+    <TableContainer component={Paper} elevation={1}>
       <Table size="small">
         <TableHead>
           <TableRow>
+            <TableCell sx={{ width: 28 }} />
             <TableCell>
               <strong>Backend Repository</strong>
             </TableCell>
@@ -101,39 +146,93 @@ function CrcrSummaryTable({ days }: { days: number }) {
           </TableRow>
         </TableHead>
         <TableBody>
-          {data.map((row) => {
-            const parts = row.repo?.split("/") ?? [];
+          {repos.map((entry) => {
+            const metrics = metricsMap.get(entry.repo);
+            const parts = entry.repo.split("/");
             if (parts.length !== 2) return null;
             const [org, repo] = parts;
+            const hasData = !!metrics;
             return (
-              <TableRow key={row.repo} hover>
-                <TableCell>
-                  <NextLink
-                    href={`/crcr/${org}/${repo}`}
-                    passHref
-                    legacyBehavior
-                  >
-                    <Link underline="hover">{row.repo}</Link>
-                  </NextLink>
-                </TableCell>
+              <TableRow
+                key={entry.repo}
+                hover
+                sx={{ cursor: hasData ? "pointer" : "default" }}
+              >
                 <TableCell align="center">
-                  <Chip
-                    label={row.downstream_repo_level || "–"}
-                    size="small"
-                    variant="outlined"
+                  <Box
+                    sx={{
+                      width: 8,
+                      height: 8,
+                      borderRadius: "50%",
+                      bgcolor: hasData ? "success.main" : "grey.400",
+                      display: "inline-block",
+                    }}
+                    title={hasData ? "Active" : "No data"}
                   />
                 </TableCell>
-                <TableCell align="right">
-                  <PassRateChip rate={row.pass_rate} />
+                <TableCell>
+                  {hasData ? (
+                    <NextLink
+                      href={`/crcr/${org}/${repo}`}
+                      passHref
+                      legacyBehavior
+                    >
+                      <Link underline="hover">{entry.repo}</Link>
+                    </NextLink>
+                  ) : (
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      component="span"
+                    >
+                      {entry.repo}
+                    </Typography>
+                  )}
                 </TableCell>
-                <TableCell align="right">{row.successes}</TableCell>
-                <TableCell align="right">{row.failures}</TableCell>
-                <TableCell align="right">{row.total}</TableCell>
-                <TableCell align="right">
-                  {durationDisplay(Math.round(row.avg_duration_s))}
+                <TableCell align="center">
+                  <LevelChip level={level} />
                 </TableCell>
                 <TableCell align="right">
-                  {new Date(row.last_run).toLocaleString()}
+                  {metrics ? (
+                    <PassRateChip rate={metrics.pass_rate} />
+                  ) : (
+                    <Typography variant="body2" color="text.disabled">
+                      –
+                    </Typography>
+                  )}
+                </TableCell>
+                <TableCell align="right">{metrics?.successes ?? "–"}</TableCell>
+                <TableCell align="right">
+                  {metrics ? (
+                    <Typography
+                      variant="body2"
+                      component="span"
+                      sx={{
+                        color:
+                          metrics.failures > 0 ? "error.main" : "text.primary",
+                        fontWeight: metrics.failures > 0 ? 500 : 400,
+                      }}
+                    >
+                      {metrics.failures}
+                    </Typography>
+                  ) : (
+                    "–"
+                  )}
+                </TableCell>
+                <TableCell align="right">{metrics?.total ?? "–"}</TableCell>
+                <TableCell align="right">
+                  {metrics
+                    ? durationDisplay(Math.round(metrics.avg_duration_s))
+                    : "–"}
+                </TableCell>
+                <TableCell align="right">
+                  {metrics ? (
+                    <Typography variant="body2" color="text.secondary">
+                      {timeAgo(metrics.last_run)}
+                    </Typography>
+                  ) : (
+                    "–"
+                  )}
                 </TableCell>
               </TableRow>
             );
@@ -144,8 +243,213 @@ function CrcrSummaryTable({ days }: { days: number }) {
   );
 }
 
+function L1Section({ repos }: { repos: AllowlistEntry[] }) {
+  if (repos.length === 0) return null;
+  return (
+    <Paper elevation={1} sx={{ p: 2 }}>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+        {LEVEL_META.L1.description}
+      </Typography>
+      <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+        {repos.map((entry) => (
+          <Link
+            key={entry.repo}
+            href={`https://github.com/${entry.repo}`}
+            target="_blank"
+            rel="noopener"
+            underline="hover"
+            sx={{
+              fontSize: "0.85rem",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 0.5,
+            }}
+          >
+            <LevelChip level="L1" />
+            {entry.repo}
+          </Link>
+        ))}
+      </Box>
+    </Paper>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string | number;
+  sub?: string;
+}) {
+  return (
+    <Paper
+      elevation={1}
+      sx={{ p: 2, minWidth: 160, flex: 1, textAlign: "center" }}
+    >
+      <Typography variant="caption" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="h5" sx={{ fontWeight: 600 }}>
+        {value}
+      </Typography>
+      {sub && (
+        <Typography variant="caption" color="text.secondary">
+          {sub}
+        </Typography>
+      )}
+    </Paper>
+  );
+}
+
+function CrcrTestHealthCard({
+  metrics,
+}: {
+  metrics: CiMetricsRow | undefined;
+}) {
+  if (!metrics) return null;
+  const rate = (metrics.pass_rate * 100).toFixed(1) + "%";
+  const isHealthy = metrics.pass_rate >= 0.95;
+  const borderColor = isHealthy ? "#2e7d32" : "#d32f2f";
+  return (
+    <NextLink href="/crcr/pytorch/crcr-test" passHref legacyBehavior>
+      <Paper
+        component="a"
+        elevation={2}
+        sx={{
+          p: 2,
+          flex: 1,
+          minWidth: 160,
+          textAlign: "center",
+          borderLeft: `4px solid ${borderColor}`,
+          textDecoration: "none",
+          color: "inherit",
+          cursor: "pointer",
+          "&:hover": { bgcolor: "action.hover" },
+        }}
+      >
+        <Typography variant="caption" color="text.secondary">
+          CRCR-test Pass Rate
+        </Typography>
+        <Typography variant="h5" sx={{ fontWeight: 600, color: borderColor }}>
+          {rate}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {metrics.successes}/{metrics.total} jobs passed &middot;
+          pytorch/crcr-test
+        </Typography>
+      </Paper>
+    </NextLink>
+  );
+}
+
 export default function CrcrSummaryPage() {
   const [days, setDays] = useState(7);
+
+  const ciUrl = `/api/clickhouse/crcr_summary?parameters=${encodeURIComponent(
+    JSON.stringify({ days: String(days) })
+  )}`;
+  const { data: ciData, error: ciError } = useSWR<CiMetricsRow[]>(
+    ciUrl,
+    fetcher,
+    { refreshInterval: 60_000 }
+  );
+  const { data: allowlist, error: alError } = useSWR<AllowlistResponse>(
+    "/api/crcr/allowlist",
+    fetcher,
+    { refreshInterval: 5 * 60_000 }
+  );
+
+  const metricsMap = useMemo(() => {
+    const map = new Map<string, CiMetricsRow>();
+    if (!ciData) return map;
+    for (const row of ciData) {
+      map.set(row.repo, row);
+    }
+    return map;
+  }, [ciData]);
+
+  // Merge: for L2-L4, combine allowlist repos with any ClickHouse-only repos
+  // (repos that report data but aren't yet in the allowlist)
+  const reposByLevel = useMemo(() => {
+    const result: Record<Level, AllowlistEntry[]> = {
+      L1: [],
+      L2: [],
+      L3: [],
+      L4: [],
+    };
+    if (!allowlist) return result;
+
+    const seen = new Set<string>();
+    for (const level of LEVELS_ORDERED) {
+      for (const entry of allowlist[level]) {
+        if (entry.repo === CRCR_HEALTH_REPO) continue;
+        result[level].push(entry);
+        seen.add(entry.repo);
+      }
+    }
+
+    // Add ClickHouse-only repos (not in allowlist) under their reported level
+    if (ciData) {
+      for (const row of ciData) {
+        if (seen.has(row.repo) || row.repo === CRCR_HEALTH_REPO) continue;
+        const level = (row.downstream_repo_level || "L2") as Level;
+        if (level in result) {
+          result[level].push({ repo: row.repo, oncalls: [] });
+          seen.add(row.repo);
+        }
+      }
+    }
+
+    // Sort each level by pass rate (worst first); repos with no metrics sort last
+    for (const level of LEVELS_ORDERED) {
+      result[level].sort(
+        (a, b) =>
+          (metricsMap.get(a.repo)?.pass_rate ?? 1) -
+          (metricsMap.get(b.repo)?.pass_rate ?? 1)
+      );
+    }
+
+    return result;
+  }, [allowlist, ciData, metricsMap]);
+
+  const stats = useMemo(() => {
+    if (!ciData || ciData.length === 0) return null;
+    const ct = metricsMap.get(CRCR_HEALTH_REPO);
+
+    const totalRepos = allowlist
+      ? Object.values(allowlist).reduce(
+          (s, arr) =>
+            s +
+            arr.filter((e: AllowlistEntry) => e.repo !== CRCR_HEALTH_REPO)
+              .length,
+          0
+        )
+      : ciData.filter((r) => r.repo !== CRCR_HEALTH_REPO).length;
+    const levelBreakdown = (["L4", "L3", "L2", "L1"] as Level[])
+      .map((l) => {
+        const count =
+          allowlist?.[l]?.filter(
+            (e: AllowlistEntry) => e.repo !== CRCR_HEALTH_REPO
+          ).length ?? 0;
+        return count > 0 ? `${count} ${l}` : null;
+      })
+      .filter(Boolean)
+      .join(" \u00b7 ");
+
+    return {
+      totalRuns: ct?.total ?? 0,
+      runsSub: `last ${days} days \u00b7 pytorch/crcr-test`,
+      failures: ct?.failures ?? 0,
+      timedOut: ct?.timed_out ?? 0,
+      totalRepos,
+      reposSub: levelBreakdown || undefined,
+    };
+  }, [ciData, metricsMap, allowlist, days]);
+
+  const isLoading = !ciData && !ciError && !allowlist && !alError;
+  const hasError = ciError || alError;
 
   return (
     <>
@@ -172,11 +476,107 @@ export default function CrcrSummaryPage() {
         </Box>
 
         <Typography variant="body2" color="text.secondary">
-          Cross-repo CI health overview. Repos sorted by pass rate (worst
-          first). Click a row to see the per-backend dashboard.
+          Relay health metrics from{" "}
+          <Link
+            href="https://github.com/pytorch/crcr-test"
+            target="_blank"
+            rel="noreferrer"
+          >
+            pytorch/crcr-test
+          </Link>{" "}
+          probes. To know more, check the{" "}
+          <Link
+            href="https://hud.pytorch.org/crcr/pytorch/crcr-test"
+            target="_blank"
+            rel="noreferrer"
+          >
+            HUD dashboard
+          </Link>
+          .
         </Typography>
 
-        <CrcrSummaryTable days={days} />
+        {hasError && (
+          <Typography color="error">
+            {ciError?.message || alError?.message || "Failed to load data"}
+          </Typography>
+        )}
+
+        {isLoading && <Skeleton variant="rectangular" height={120} />}
+
+        {stats && (
+          <Stack spacing={2}>
+            <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+              <CrcrTestHealthCard metrics={metricsMap.get(CRCR_HEALTH_REPO)} />
+              <StatCard
+                label="Total Probe Runs"
+                value={stats.totalRuns}
+                sub={stats.runsSub}
+              />
+              <StatCard
+                label="Probe Failures"
+                value={stats.failures}
+                sub="pytorch/crcr-test failures"
+              />
+            </Box>
+            <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+              <StatCard
+                label="Registered Backends"
+                value={stats.totalRepos}
+                sub={stats.reposSub}
+              />
+              <StatCard
+                label="Timed Out"
+                value={stats.timedOut}
+                sub="probes that failed to report completion"
+              />
+            </Box>
+          </Stack>
+        )}
+
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+          Registered downstream repos sorted by pass rate (worst first). Click a
+          row to see the per-downstream repo dashboard.
+        </Typography>
+
+        {LEVELS_ORDERED.map((level) => {
+          const repos = reposByLevel[level];
+          if (repos.length === 0) return null;
+          const meta = LEVEL_META[level];
+
+          return (
+            <Box key={level}>
+              <Divider sx={{ mb: 2 }}>
+                <Typography variant="h6">{meta.label}</Typography>
+              </Divider>
+              {level === "L1" ? (
+                <L1Section repos={repos} />
+              ) : (
+                <CiHealthTable
+                  level={level}
+                  repos={repos}
+                  metricsMap={metricsMap}
+                />
+              )}
+            </Box>
+          );
+        })}
+
+        {!isLoading &&
+          LEVELS_ORDERED.every((l) => reposByLevel[l].length === 0) && (
+            <Typography
+              color="text.secondary"
+              sx={{ py: 4, textAlign: "center" }}
+            >
+              No CRCR backends registered. Add repos to{" "}
+              <Link
+                href="https://github.com/pytorch/pytorch/blob/main/.github/allowlist.yml"
+                target="_blank"
+              >
+                pytorch/pytorch/.github/allowlist.yml
+              </Link>{" "}
+              to get started.
+            </Typography>
+          )}
       </Stack>
     </>
   );


### PR DESCRIPTION
## Summary

Rewrites the CRCR summary page (`/crcr`) to dynamically fetch the allowlist from `pytorch/pytorch/.github/allowlist.yml` and merge it with ClickHouse CI metrics. This replaces the existing flat table with a sectioned layout matching the [CRCR summary mockup](https://subinz1.github.io/rfcs/RFC-0054-assets/oot-hud-mockup-crcr-summary.html).

### Changes

- **New file: `torchci/pages/api/crcr/allowlist.ts`** — GET endpoint that fetches the allowlist YAML from `pytorch/pytorch`, parses it (mirroring the Lambda's parsing logic), and returns structured JSON. Includes 15-min in-memory cache to avoid GitHub rate limits. Auto-refreshes — no manual sync needed when repos are added/removed.

- **Modified: `torchci/pages/crcr/index.tsx`** — Rewritten to:
  - Fetch both allowlist (repo→level mapping) and ClickHouse data (CI metrics)
  - Display summary stat cards (registered repos, overall pass rate, total CI runs, avg duration)
  - Show L4 → L3 → L2 sections as health tables with pass rate, success/failure counts, duration, and last run
  - Show L1 section as simple repo links (webhook-only, no CI data)
  - Handle repos in ClickHouse that aren't yet in the allowlist (shown under their reported level)
  - Link to `pytorch/pytorch/.github/allowlist.yml` when no backends are registered

### Data flow

```
pytorch/pytorch/.github/allowlist.yml  →  /api/crcr/allowlist (cached 15min)  →  Frontend
ClickHouse crcr_workflow_job table     →  /api/clickhouse/oot_summary         →  Frontend
                                                                                    ↓
                                                                          Merge + render by level
```

## Test plan

- [ ] Verify `/api/crcr/allowlist` returns correct JSON structure when allowlist has repos
- [ ] Verify summary page renders L4→L3→L2→L1 sections correctly
- [ ] Verify repos from ClickHouse that aren't in allowlist appear under their reported level
- [ ] Verify empty state shows link to allowlist.yml
- [ ] Verify cache behavior (subsequent requests within 15min return cached data)