### PR TITLE
Set BUILD_VERSION for Windows Arm64 RC wheel builds (+cpu, match x64)

### DIFF
--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -190,13 +190,14 @@ jobs:
       - name: Set BUILD_VERSION for Arm64 RC build
         # Arm64 does not run setup-binary-builds (x64-only), so pytorch_pkg_helpers
         # never sets BUILD_VERSION. Without it setup.py appends the git sha
-        # (e.g. torchvision-0.28.0+5a5dd12). For RC (test channel) the wheel must
-        # carry the clean release version, so set BUILD_VERSION from version.txt.
+        # (e.g. torchvision-0.28.0+5a5dd12). For RC (test channel) set BUILD_VERSION
+        # to "<version.txt>+<arch>" to match what pytorch_pkg_helpers produces for
+        # x64 (e.g. torchvision-0.28.0+cpu) and torch's own win_arm64 wheels.
         if: ${{ inputs.architecture == 'arm64' && env.CHANNEL == 'test' }}
         working-directory: ${{ inputs.repository }}
         run: |
           if [[ -f version.txt ]]; then
-            echo "BUILD_VERSION=$(cat version.txt)" >> "${GITHUB_ENV}"
+            echo "BUILD_VERSION=$(cat version.txt)+${CU_VERSION}" >> "${GITHUB_ENV}"
           fi
       - name: Install torch dependency
         if: inputs.architecture == 'x64'

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -187,6 +187,17 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
           architecture: arm64
+      - name: Set BUILD_VERSION for Arm64 RC build
+        # Arm64 does not run setup-binary-builds (x64-only), so pytorch_pkg_helpers
+        # never sets BUILD_VERSION. Without it setup.py appends the git sha
+        # (e.g. torchvision-0.28.0+5a5dd12). For RC (test channel) the wheel must
+        # carry the clean release version, so set BUILD_VERSION from version.txt.
+        if: ${{ inputs.architecture == 'arm64' && env.CHANNEL == 'test' }}
+        working-directory: ${{ inputs.repository }}
+        run: |
+          if [[ -f version.txt ]]; then
+            echo "BUILD_VERSION=$(cat version.txt)" >> "${GITHUB_ENV}"
+          fi
       - name: Install torch dependency
         if: inputs.architecture == 'x64'
         run: |


### PR DESCRIPTION
## Summary

Windows Arm64 RC wheels were built with an unintended git-sha local version:

```
torchvision-0.28.0+5a5dd12-cp311-cp311-win_arm64.whl   # before
torchvision-0.28.0+cpu-cp311-cp311-win_arm64.whl        # after
```

## Root cause

`build_wheels_windows.yml` runs the `setup-binary-builds` action only for x64 (`if: inputs.architecture == 'x64'`). That action runs `pytorch_pkg_helpers`, which writes `BUILD_ENV_FILE` exporting `BUILD_VERSION`. The x64 build then does `${ENV_SCRIPT} python setup.py bdist_wheel` with `BUILD_VERSION` set.

The **Arm64** path never runs `setup-binary-builds`, so `BUILD_VERSION` is unset and `setup.py` hits the fallback in `get_version()`:

```python
if os.getenv("BUILD_VERSION"):
    version = os.getenv("BUILD_VERSION")
elif sha != "Unknown":
    version += "+" + sha[:7]      # -> 0.28.0+5a5dd12
```

The existing RC step only sets `PYTORCH_VERSION` (the torch dependency), not `BUILD_VERSION`.

## Fix

After the Arm64 checkout, for the **test** channel set `BUILD_VERSION` to `<version.txt>+<CU_VERSION>`, mirroring what `pytorch_pkg_helpers` produces on x64:

```yaml
- name: Set BUILD_VERSION for Arm64 RC build
  if: ${{ inputs.architecture == 'arm64' && env.CHANNEL == 'test' }}
  working-directory: ${{ inputs.repository }}
  run: |
    if [[ -f version.txt ]]; then
      echo "BUILD_VERSION=$(cat version.txt)+${CU_VERSION}" >> "${GITHUB_ENV}"
    fi
```

`pytorch_pkg_helpers` (version.py) computes the test-channel version as `get_base_version()` (`version.txt`) + post-build suffix `+{gpu_arch_version}`. For CPU that is `+cpu`. This keeps win_arm64 consistent with:
- x64 torchvision: `torchvision-0.28.0+cpu-...win_amd64.whl`
- torch's own win_arm64: `torch-2.9.1+cpu-...win_arm64.whl`

x64, nightly, and release channels are unchanged.

## Test plan

- Re-run vision v0.28.0-rc1 Windows Arm64 build; wheels should be `torchvision-0.28.0+cpu-cp3XX-cp3XX-win_arm64.whl` (no git sha).
- Verified `version.txt` = `0.28.0`, `CU_VERSION` = `cpu` for these jobs, and `setup.py get_version()` honors `BUILD_VERSION`.

## Note
Surfaced by the vision RC ([run](https://github.com/pytorch/vision/actions/runs/27388647918/job/80941202347)), which consumes `build_wheels_windows.yml@release/2.13`. This PR targets `main`; it must be cherry-picked to `release/2.13` to take effect for the in-flight RC. (The same bug also affected 0.27.1: `torchvision-0.27.1+df56172-...win_arm64.whl`.)
