### PR TITLE
Add rocm_test_stats HUD page

### DIFF
--- a/torchci/components/layout/NavBar.tsx
+++ b/torchci/components/layout/NavBar.tsx
@@ -75,6 +75,10 @@ function NavBar() {
       name: "MacOS test stats",
       href: "/mac_test_stats",
     },
+    {
+      name: "ROCm test stats",
+      href: "/rocm_test_stats",
+    },
   ].map((item) => ({
     label: item.name,
     route: item.href,

--- a/torchci/pages/rocm_test_stats.tsx
+++ b/torchci/pages/rocm_test_stats.tsx
@@ -1,0 +1,10 @@
+import { TestStatsPage } from "components/testStats/TestStatsPage";
+
+export default function Page() {
+  return (
+    <TestStatsPage
+      title="ROCm Test Stats"
+      jobFilter="(?i)jammy.*rocm|rocm.*jammy"
+    />
+  );
+}


### PR DESCRIPTION
Add a new **ROCm Test Stats** HUD page under Dev Infra (`/rocm_test_stats`), mirroring the existing `/cuda_test_stats` and `/mac_test_stats` pages added in #8127.

This is a wrapper around the shared `TestStatsPage` component and reuses the existing `test_stats_per_commit` ClickHouse query (no query or shared-component changes). It shows per-commit total/skip/flaky/fail counts for `pytorch/pytorch` trunk ROCm jobs.

- Restricted to the `trunk` workflow (runs on every push to `main`) and jobs matching `(?i)jammy.*rocm|rocm.*jammy` — i.e. the `linux-jammy-rocm-py3.10-mi355` build/test jobs defined in `trunk.yml`.
- Adds a NavBar entry `ROCm test stats`.

## Test plan
- Navigate to `/rocm_test_stats` and confirm per-commit ROCm counts render, with `?count=N` and `?sha=<hex>` working.