### PR TITLE
[release/2.13] Validate torch only (not torchvision) for Python 3.15

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -230,6 +230,12 @@ cleanup_conda_env() {
 
 handle_aarch64_cuda_override
 
+# torchvision wheels are not published for Python 3.15 / 3.15t yet, so validate
+# torch only: skip the torchvision install and its smoke-test module check.
+if [[ ${MATRIX_PYTHON_VERSION} == "3.15" || ${MATRIX_PYTHON_VERSION} == "3.15t" ]]; then
+    export TORCH_ONLY=true
+fi
+
 if [[ ${MATRIX_PACKAGE_TYPE} == "libtorch" ]]; then
     curl -L "${MATRIX_INSTALLATION}" -o libtorch.zip
     unzip libtorch.zip


### PR DESCRIPTION
## Summary

Validate **torch only** (not torchvision) for Python **3.15 / 3.15t** binary validation on `release/2.13`.

## Problem

3.15 validation failed at the smoke test ([run](https://github.com/pytorch/test-infra/actions/runs/28382058038/job/84087062491)):

```
RuntimeError: Module torchvision FAIL: 1 ...
  python3 ./vision/test/smoke_test.py ... returned non-zero exit status 1
```

torchvision does not publish `cp315`/`cp315t` wheels yet. The 3.15 matrix install is already torch-only (`pip3 install torch --index-url ...`), but `get_test_suffix` still returned `--package torch_torchvision`, so `smoke_test.py` ran the torchvision module check against a torchvision that was never installed.

## Fix

In `validate_binaries.sh`, set `TORCH_ONLY=true` for `3.15` / `3.15t`. That makes both helpers consistent:
- `build_installation_command` strips torchvision (the 3.15 install was already torch-only, so this is a safe no-op there)
- `get_test_suffix` returns `--package torchonly`, so the smoke test validates torch only

Other Python versions are unaffected.

## Test plan

- Re-run the 3.15 / 3.15t linux validation: install is `torch` only and the smoke test runs `--package torchonly` (no torchvision module check).
