### PR TITLE
[CRCR] Fix multi-job state key collision by adding job_name to Redis key

### DIFF
--- a/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
@@ -60,10 +60,11 @@ def _verify_access(
     return allowlist, repo_level
 
 
-def _parse_callback_body(body: dict) -> tuple[str, str, int, int, str]:
-    """Return (delivery_id, status, run_id, run_attempt, workflow_name) from ``body``.
+def _parse_callback_body(body: dict) -> tuple[str, str, int, int, str, str | None]:
+    """Return (delivery_id, status, run_id, run_attempt, workflow_name, job_name).
 
-    run_id and run_attempt uniquely identify a workflow run execution.
+    run_id and run_attempt identify a workflow run execution.
+    job_name (``github.job``) disambiguates multiple jobs within the same run.
     run_attempt defaults to 1 when not present in the callback body.
 
     Raises HTTPException(400) on any missing or mis-typed field.
@@ -72,17 +73,16 @@ def _parse_callback_body(body: dict) -> tuple[str, str, int, int, str]:
         delivery_id = body["delivery_id"]
         workflow_dict = body["workflow"]
         status = workflow_dict["status"]
-        run_id = int(workflow_dict["run_id"])  # Required for HUD grouping
-        run_attempt = int(
-            workflow_dict.get("run_attempt", 1)
-        )  # Default to 1 if not present
-        workflow_name = workflow_dict["name"]  # Required for HUD grouping
+        run_id = int(workflow_dict["run_id"])
+        run_attempt = int(workflow_dict.get("run_attempt", 1))
+        workflow_name = workflow_dict["name"]
+        job_name = workflow_dict.get("job_name")
     except (KeyError, TypeError) as exc:
         logger.warning(f"missing required field in callback body: {exc}")
         raise HTTPException(
             400, f"callback body missing required field: {exc}"
         ) from exc
-    return delivery_id, status, run_id, run_attempt, workflow_name
+    return delivery_id, status, run_id, run_attempt, workflow_name, job_name
 
 
 def _update_state_and_compute_metrics(
@@ -96,6 +96,7 @@ def _update_state_and_compute_metrics(
     dispatch_record: CallbackStateRecord,
     workflow_record: CallbackStateRecord | None,
     payload: dict | None = None,
+    job_name: str | None = None,
 ) -> dict:
     """Persist the new workflow state to Redis and return CI timing metrics.
 
@@ -129,6 +130,7 @@ def _update_state_and_compute_metrics(
             current_timestamp,
             workflow_name,
             payload=payload,
+            job_name=job_name,
         )
     except RedisError:
         raise HTTPException(
@@ -144,7 +146,7 @@ def _update_state_and_compute_metrics(
         raise
 
     updated_workflow_record = redis_helper.get_callback_state(
-        config, delivery_id, verified_repo, run_id, run_attempt
+        config, delivery_id, verified_repo, run_id, run_attempt, job_name=job_name
     )
     if updated_workflow_record is None:
         return ci_metrics
@@ -188,7 +190,9 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
         return {"ok": True, "status": "ignored"}
     _, repo_level = result
 
-    delivery_id, status, run_id, run_attempt, workflow_name = _parse_callback_body(body)
+    delivery_id, status, run_id, run_attempt, workflow_name, job_name = (
+        _parse_callback_body(body)
+    )
 
     dispatch_record = redis_helper.get_callback_state(
         config, delivery_id, verified_repo, DISPATCH_RUN_ID, DISPATCH_RUN_ATTEMPT
@@ -202,7 +206,7 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
         raise HTTPException(400, "callback rejected: no matching dispatch record")
 
     workflow_record = redis_helper.get_callback_state(
-        config, delivery_id, verified_repo, run_id, run_attempt
+        config, delivery_id, verified_repo, run_id, run_attempt, job_name=job_name
     )
 
     payload = None
@@ -230,16 +234,16 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
         dispatch_record,
         workflow_record,
         payload=payload,
+        job_name=job_name,
     )
 
-    # Track in-progress jobs for zombie detection.
     if status == "in_progress":
         redis_helper.add_in_progress_tracker(
-            config, delivery_id, verified_repo, run_id, run_attempt
+            config, delivery_id, verified_repo, run_id, run_attempt, job_name=job_name
         )
     elif status == "completed":
         redis_helper.remove_in_progress_tracker(
-            config, delivery_id, verified_repo, run_id, run_attempt
+            config, delivery_id, verified_repo, run_id, run_attempt, job_name=job_name
         )
 
     trusted = {

--- a/aws/lambda/cross_repo_ci_relay/callback/cleanup_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/cleanup_handler.py
@@ -68,29 +68,30 @@ def _cleanup_one(
     repo = zombie["downstream_repo"]
     run_id = zombie["run_id"]
     run_attempt = zombie["run_attempt"]
+    job_name = zombie.get("job_name")
     hud_ok = True
 
-    # 1. Build and forward timeout payload to HUD
     try:
         trusted, untrusted = _build_timeout_payload(zombie, completed_at)
         forward_to_hud(config, trusted, untrusted)
         logger.info(
-            "zombie HUD forward succeeded repo=%s run_id=%s run_attempt=%s",
+            "zombie HUD forward succeeded repo=%s run_id=%s run_attempt=%s job_name=%s",
             repo,
             run_id,
             run_attempt,
+            job_name,
         )
     except Exception:
         logger.exception(
-            "zombie HUD forward failed repo=%s run_id=%s run_attempt=%s",
+            "zombie HUD forward failed repo=%s run_id=%s run_attempt=%s job_name=%s",
             repo,
             run_id,
             run_attempt,
+            job_name,
         )
         hud_ok = False
 
     if hud_ok:
-        # 2. Mark state as COMPLETED in Redis (best-effort)
         try:
             redis_helper.set_callback_state(
                 config,
@@ -100,22 +101,20 @@ def _cleanup_one(
                 run_attempt,
                 CallbackState.COMPLETED,
                 time.time(),
+                job_name=job_name,
             )
         except (AssertionError, RedisError):
-            # Race: another process already resolved this record, or Redis
-            # was unavailable.
             logger.warning(
                 "zombie state transition failed (may already be resolved) "
-                "delivery_id=%s repo=%s run_id=%s run_attempt=%s",
+                "delivery_id=%s repo=%s run_id=%s run_attempt=%s job_name=%s",
                 delivery_id,
                 repo,
                 run_id,
                 run_attempt,
+                job_name,
             )
-        # Erase the records from Redis only when HUD was successfully
-        # updated, keeping the two systems in sync.
         redis_helper.remove_in_progress_tracker(
-            config, delivery_id, repo, run_id, run_attempt
+            config, delivery_id, repo, run_id, run_attempt, job_name=job_name
         )
 
     return {"ok": hud_ok}

--- a/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
@@ -19,7 +19,24 @@ def _cfg():
     return cfg
 
 
-def _body(status="completed", workflow_name="default", run_id=99999, run_attempt=1):
+def _body(
+    status="completed",
+    workflow_name="default",
+    run_id=99999,
+    run_attempt=1,
+    job_name=None,
+):
+    wf = {
+        "status": status,
+        "conclusion": "success" if status == "completed" else None,
+        "name": "CI",
+        "url": "http://ci.example.com/run/1",
+        "workflow_name": workflow_name,
+        "run_id": run_id,
+        "run_attempt": run_attempt,
+    }
+    if job_name is not None:
+        wf["job_name"] = job_name
     return {
         "event_type": "pull_request",
         "delivery_id": "del-123",
@@ -27,15 +44,7 @@ def _body(status="completed", workflow_name="default", run_id=99999, run_attempt
             "pull_request": {"number": 42, "head": {"sha": "abc123"}},
             "repository": {"full_name": "pytorch/pytorch"},
         },
-        "workflow": {
-            "status": status,
-            "conclusion": "success" if status == "completed" else None,
-            "name": "CI",
-            "url": "http://ci.example.com/run/1",
-            "workflow_name": workflow_name,
-            "run_id": run_id,
-            "run_attempt": run_attempt,
-        },
+        "workflow": wf,
     }
 
 
@@ -54,7 +63,13 @@ class TestCallbackHandler(unittest.TestCase):
 
         # Setup default: dispatch exists, workflow state is None (in_progress not yet reported)
         def default_get_state(
-            cfg, delivery_id, repo, run_id_arg, run_attempt_arg, client=None
+            cfg,
+            delivery_id,
+            repo,
+            run_id_arg,
+            run_attempt_arg,
+            client=None,
+            job_name=None,
         ):
             if run_id_arg == DISPATCH_RUN_ID:
                 return CallbackStateRecord(
@@ -233,6 +248,30 @@ class TestCallbackHandler(unittest.TestCase):
 
         _, trusted_arg, _ = self.mock_hud.call_args[0]
         self.assertIsNone(trusted_arg["ci_metrics"]["execution_time"])
+
+    def test_job_name_passed_to_redis_state_calls(self):
+        """job_name from callback body is forwarded to all Redis state calls."""
+        dispatch_record = CallbackStateRecord(CallbackState.DISPATCHED, 1000.0, {})
+        in_progress_record = CallbackStateRecord(CallbackState.IN_PROGRESS, 1030.0, {})
+        self.mock_redis.get_callback_state.side_effect = [
+            dispatch_record,
+            None,
+            in_progress_record,
+        ]
+
+        handle(
+            _cfg(),
+            _body(status="in_progress", job_name="build"),
+            verified_repo="org/repo",
+        )
+
+        # set_callback_state should have been called with job_name="build"
+        call_kwargs = self.mock_redis.set_callback_state.call_args
+        self.assertEqual(call_kwargs.kwargs.get("job_name"), "build")
+
+        # add_in_progress_tracker should have been called with job_name="build"
+        tracker_kwargs = self.mock_redis.add_in_progress_tracker.call_args
+        self.assertEqual(tracker_kwargs.kwargs.get("job_name"), "build")
 
 
 if __name__ == "__main__":

--- a/aws/lambda/cross_repo_ci_relay/tests/test_cleanup_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_cleanup_handler.py
@@ -54,6 +54,7 @@ def _zombie_entry(
     repo="org/repo",
     run_id=99999,
     run_attempt=1,
+    job_name="my-job",
     in_progress_ts=None,
     body_overrides=None,
 ):
@@ -79,6 +80,7 @@ def _zombie_entry(
         "downstream_repo": repo,
         "run_id": run_id,
         "run_attempt": run_attempt,
+        "job_name": job_name,
         "state_record": CallbackStateRecord(
             CallbackState.IN_PROGRESS, in_progress_ts, stored_payload
         ),
@@ -186,7 +188,7 @@ class TestCleanupHandler(unittest.TestCase):
             untrusted["callback_payload"]["workflow"]["conclusion"], "timed_out"
         )
 
-        # Redis state was updated to COMPLETED
+        # Redis state was updated to COMPLETED with job_name
         self.mock_redis.set_callback_state.assert_called_once()
         call_args = self.mock_redis.set_callback_state.call_args[0]
         self.assertEqual(call_args[1], "del-123")
@@ -194,14 +196,13 @@ class TestCleanupHandler(unittest.TestCase):
         self.assertEqual(call_args[3], 99999)
         self.assertEqual(call_args[4], 1)
         self.assertEqual(call_args[5], CallbackState.COMPLETED)
+        call_kwargs = self.mock_redis.set_callback_state.call_args[1]
+        self.assertEqual(call_kwargs.get("job_name"), "my-job")
 
-        # ZSET entry was removed
+        # ZSET entry was removed with job_name
         self.mock_redis.remove_in_progress_tracker.assert_called_once()
-        rm_args = self.mock_redis.remove_in_progress_tracker.call_args[0]
-        self.assertEqual(rm_args[1], "del-123")
-        self.assertEqual(rm_args[2], "org/repo")
-        self.assertEqual(rm_args[3], 99999)
-        self.assertEqual(rm_args[4], 1)
+        rm_kwargs = self.mock_redis.remove_in_progress_tracker.call_args[1]
+        self.assertEqual(rm_kwargs.get("job_name"), "my-job")
 
     def test_cleans_multiple_zombies(self):
         """Multiple zombies are all cleaned independently."""

--- a/aws/lambda/cross_repo_ci_relay/tests/test_redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_redis_helper.py
@@ -181,7 +181,13 @@ class TestCallbackStateMachine(unittest.TestCase):
         """None → IN_PROGRESS is accepted when dispatch record exists."""
 
         def get_side_effect(
-            cfg, delivery_id, repo, run_id_arg, run_attempt_arg, client=None
+            cfg,
+            delivery_id,
+            repo,
+            run_id_arg,
+            run_attempt_arg,
+            client=None,
+            job_name=None,
         ):
             if run_id_arg == DISPATCH_RUN_ID:
                 return CallbackStateRecord(CallbackState.DISPATCHED, 1000.0, {})
@@ -228,7 +234,13 @@ class TestCallbackStateMachine(unittest.TestCase):
         """Redis write failure is re-raised as RedisError."""
 
         def get_side_effect(
-            cfg, delivery_id, repo, run_id_arg, run_attempt_arg, client=None
+            cfg,
+            delivery_id,
+            repo,
+            run_id_arg,
+            run_attempt_arg,
+            client=None,
+            job_name=None,
         ):
             if run_id_arg == DISPATCH_RUN_ID:
                 return CallbackStateRecord(CallbackState.DISPATCHED, 1000.0, {})
@@ -315,6 +327,26 @@ class TestInProgressTracker(unittest.TestCase):
         )
         client.expire.assert_called_once_with("crcr:in_progress", 172800)
 
+    def test_add_in_progress_tracker_with_job_name(self):
+        """ZADD member includes job_name when provided."""
+        from utils.redis_helper import add_in_progress_tracker
+
+        client = MagicMock()
+        cfg = self._cfg_with_zombie_timeout()
+        now = 1700000000.0
+
+        with unittest.mock.patch("utils.redis_helper.time") as mock_time:
+            mock_time.time.return_value = now
+            add_in_progress_tracker(
+                cfg, "del-123", "org/repo", 99999, 1, client=client, job_name="build"
+            )
+
+        expected_member = "del-123:org/repo:99999:1:build"
+        expected_score = now + 86400
+        client.zadd.assert_called_once_with(
+            "crcr:in_progress", {expected_member: expected_score}
+        )
+
     def test_add_in_progress_tracker_redis_error_is_silent(self):
         """Redis errors are logged but not raised — tracker is best-effort."""
         from utils.redis_helper import add_in_progress_tracker
@@ -336,6 +368,20 @@ class TestInProgressTracker(unittest.TestCase):
 
         client.zrem.assert_called_once_with(
             "crcr:in_progress", "del-123:org/repo:99999:1"
+        )
+
+    def test_remove_in_progress_tracker_with_job_name(self):
+        """ZREM member includes job_name when provided."""
+        from utils.redis_helper import remove_in_progress_tracker
+
+        client = MagicMock()
+        cfg = _cfg()
+        remove_in_progress_tracker(
+            cfg, "del-123", "org/repo", 99999, 1, client=client, job_name="build"
+        )
+
+        client.zrem.assert_called_once_with(
+            "crcr:in_progress", "del-123:org/repo:99999:1:build"
         )
 
     def test_remove_in_progress_tracker_redis_error_is_silent(self):
@@ -362,7 +408,6 @@ class TestInProgressTracker(unittest.TestCase):
             "del-2:org/repo:20:1",
         ]
 
-        # First entry is IN_PROGRESS (zombie), second is already COMPLETED
         get_returns = [
             json.dumps({"state": "IN_PROGRESS", "timestamp": now - 90000}),
             json.dumps({"state": "COMPLETED", "timestamp": now - 100}),
@@ -382,10 +427,32 @@ class TestInProgressTracker(unittest.TestCase):
         self.assertEqual(results[0]["downstream_repo"], "org/repo")
         self.assertEqual(results[0]["run_id"], 10)
         self.assertEqual(results[0]["run_attempt"], 1)
+        self.assertIsNone(results[0]["job_name"])
         self.assertEqual(results[0]["state_record"].state, CallbackState.IN_PROGRESS)
 
-        # Second entry (COMPLETED) had its tracker cleaned up
         client.zrem.assert_any_call("crcr:in_progress", "del-2:org/repo:20:1")
+
+    def test_scan_expired_parses_job_name_from_member(self):
+        """scan_expired_in_progress correctly parses job_name from member strings."""
+        from utils.redis_helper import scan_expired_in_progress
+
+        cfg = self._cfg_with_zombie_timeout()
+        client = MagicMock()
+        client.zcard.return_value = 0
+        now = 1700000000.0
+        client.zrangebyscore.return_value = [
+            "del-1:org/repo:10:1:build-job",
+        ]
+        client.get.return_value = json.dumps(
+            {"state": "IN_PROGRESS", "timestamp": now - 90000}
+        )
+
+        with unittest.mock.patch("utils.redis_helper.time") as mock_time:
+            mock_time.time.return_value = now
+            results = scan_expired_in_progress(cfg, client=client)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["job_name"], "build-job")
 
     def test_scan_expired_skips_missing_state_records(self):
         """Members whose state record is gone are cleaned from the ZSET."""
@@ -421,6 +488,24 @@ class TestInProgressTracker(unittest.TestCase):
 
         self.assertEqual(results, [])
         client.zrem.assert_called_once_with("crcr:in_progress", "bad-member")
+
+    def test_state_key_unique_per_job_name(self):
+        """Two jobs in the same run get distinct state keys via job_name."""
+        from utils.redis_helper import _state_key
+
+        key_a = _state_key("del-1", "org/repo", 100, 1, "job-a")
+        key_b = _state_key("del-1", "org/repo", 100, 1, "job-b")
+        self.assertNotEqual(key_a, key_b)
+        self.assertIn("job-a", key_a)
+        self.assertIn("job-b", key_b)
+
+    def test_state_key_without_job_name_backward_compat(self):
+        """State key without job_name matches the old format."""
+        from utils.redis_helper import _state_key
+
+        key = _state_key("del-1", "org/repo", 100, 1)
+        self.assertFalse(key.endswith(":None"))
+        self.assertEqual(key, "crcr:state:del-1:org/repo:100:1")
 
     def test_set_callback_state_with_payload(self):
         """Payload is stored alongside state and timestamp under a "payload" key."""

--- a/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
@@ -170,14 +170,23 @@ def check_rate_limit(
 
 
 def _state_key(
-    delivery_id: str, downstream_repo: str, run_id: int, run_attempt: int
+    delivery_id: str,
+    downstream_repo: str,
+    run_id: int,
+    run_attempt: int,
+    job_name: str | None = None,
 ) -> str:
     """Redis key for callback state machine.
 
-    Keyed by delivery_id + repo + run_id + run_attempt to support per-execution state tracking.
-    run_id + run_attempt uniquely identify a workflow run execution.
+    Keyed by delivery_id + repo + run_id + run_attempt + job_name.
+    job_name disambiguates multiple jobs within the same workflow run
+    (they share run_id + run_attempt but have distinct job names).
+    Omitted for DISPATCHED records which are per-repo, not per-job.
     """
-    return f"{_STATE_PREFIX}{delivery_id}:{downstream_repo}:{run_id}:{run_attempt}"
+    key = f"{_STATE_PREFIX}{delivery_id}:{downstream_repo}:{run_id}:{run_attempt}"
+    if job_name:
+        return f"{key}:{job_name}"
+    return key
 
 
 def get_callback_state(
@@ -187,6 +196,7 @@ def get_callback_state(
     run_id: int,
     run_attempt: int,
     client: redis_lib.Redis | None = None,
+    job_name: str | None = None,
 ) -> CallbackStateRecord | None:
     """Get callback state record from Redis, or None if no record exists.
 
@@ -195,7 +205,7 @@ def get_callback_state(
     try:
         if client is None:
             client = create_client(config)
-        key = _state_key(delivery_id, downstream_repo, run_id, run_attempt)
+        key = _state_key(delivery_id, downstream_repo, run_id, run_attempt, job_name)
         value = client.get(key)
         if value is None:
             return None
@@ -223,6 +233,7 @@ def set_callback_state(
     workflow_name: str | None = None,
     client: redis_lib.Redis | None = None,
     payload: dict | None = None,
+    job_name: str | None = None,
 ) -> None:
     """Set callback state with timestamp in Redis.
 
@@ -233,8 +244,8 @@ def set_callback_state(
     - DISPATCHED -> DISPATCHED: reject (duplicate webhook)
 
     IN_PROGRESS state (callback-side):
-    - None -> IN_PROGRESS: accept (first callback for this run_id + run_attempt)
-    - IN_PROGRESS -> IN_PROGRESS: reject (replay attack for same run_id + run_attempt)
+    - None -> IN_PROGRESS: accept (first callback for this job)
+    - IN_PROGRESS -> IN_PROGRESS: reject (replay attack for same job)
 
     COMPLETED state (callback-side):
     - None -> COMPLETED: reject (no prior in_progress)
@@ -255,10 +266,10 @@ def set_callback_state(
                 )
             )
 
-        key = _state_key(delivery_id, downstream_repo, run_id, run_attempt)
+        key = _state_key(delivery_id, downstream_repo, run_id, run_attempt, job_name)
 
         current_record = get_callback_state(
-            config, delivery_id, downstream_repo, run_id, run_attempt, client
+            config, delivery_id, downstream_repo, run_id, run_attempt, client, job_name
         )
 
         if state == CallbackState.DISPATCHED:
@@ -268,24 +279,22 @@ def set_callback_state(
             if current_record is not None:
                 error_msg = (
                     "rejecting replay attack IN_PROGRESS for same "
-                    "run_id=%s, run_attempt=%s, downstream_repo=%s, workflow_name=%s"
-                    % (
-                        run_id,
-                        run_attempt,
-                        downstream_repo,
-                        workflow_name,
-                    )
+                    "run_id=%s, run_attempt=%s, downstream_repo=%s, "
+                    "workflow_name=%s, job_name=%s"
+                    % (run_id, run_attempt, downstream_repo, workflow_name, job_name)
                 )
 
         elif state == CallbackState.COMPLETED:
             if current_record is None:
                 error_msg = (
                     "rejecting COMPLETED without prior IN_PROGRESS "
-                    "key=%s, downstream_repo=%s, workflow_name=%s, run_id=%s, run_attempt=%s"
+                    "key=%s, downstream_repo=%s, workflow_name=%s, "
+                    "job_name=%s, run_id=%s, run_attempt=%s"
                     % (
                         key,
                         downstream_repo,
                         workflow_name,
+                        job_name,
                         run_id,
                         run_attempt,
                     )
@@ -295,12 +304,14 @@ def set_callback_state(
             elif current_record.state != CallbackState.IN_PROGRESS:
                 error_msg = (
                     "rejecting abnormal state transition %s -> COMPLETED "
-                    "key=%s, downstream_repo=%s, workflow_name=%s, run_id=%s, run_attempt=%s"
+                    "key=%s, downstream_repo=%s, workflow_name=%s, "
+                    "job_name=%s, run_id=%s, run_attempt=%s"
                     % (
                         current_record.state.value,
                         key,
                         downstream_repo,
                         workflow_name,
+                        job_name,
                         run_id,
                         run_attempt,
                     )
@@ -333,27 +344,43 @@ def set_callback_state(
 
 
 def _in_progress_member(
-    delivery_id: str, downstream_repo: str, run_id: int, run_attempt: int
+    delivery_id: str,
+    downstream_repo: str,
+    run_id: int,
+    run_attempt: int,
+    job_name: str | None = None,
 ) -> str:
     """Build a ZSET member string from the state-key components."""
-    return f"{delivery_id}:{downstream_repo}:{run_id}:{run_attempt}"
+    base = f"{delivery_id}:{downstream_repo}:{run_id}:{run_attempt}"
+    if job_name:
+        return f"{base}:{job_name}"
+    return base
 
 
-def _parse_in_progress_member(member: str) -> tuple[str, str, int, int]:
+def _parse_in_progress_member(
+    member: str,
+) -> tuple[str, str, int, int, str | None]:
     """Parse a ZSET member string back into its components.
 
-    The repo part may contain '/' (e.g. 'org/repo'), so we split from the right
-    for the integer fields and from the left for delivery_id.
+    Supports both old format (without job_name) and new format (with job_name).
+    run_attempt is always an integer; if the last token is non-numeric it is
+    the job_name appended by the new format.
     """
     parts = member.split(":")
     if len(parts) < 4:
         raise ValueError(f"invalid in-progress member: {member!r}")
-    # delivery_id is the first token, then repo is everything up to the last two tokens
     delivery_id = parts[0]
+    # Check if last part is non-numeric (job_name)
+    job_name = None
+    try:
+        int(parts[-1])
+    except ValueError:
+        job_name = parts[-1]
+        parts = parts[:-1]
     run_attempt = int(parts[-1])
     run_id = int(parts[-2])
     downstream_repo = ":".join(parts[1:-2])
-    return delivery_id, downstream_repo, run_id, run_attempt
+    return delivery_id, downstream_repo, run_id, run_attempt, job_name
 
 
 def add_in_progress_tracker(
@@ -363,6 +390,7 @@ def add_in_progress_tracker(
     run_id: int,
     run_attempt: int,
     client: redis_lib.Redis | None = None,
+    job_name: str | None = None,
 ) -> None:
     """Add a job to the in-progress ZSET for zombie detection.
 
@@ -373,7 +401,9 @@ def add_in_progress_tracker(
     try:
         if client is None:
             client = create_client(config)
-        member = _in_progress_member(delivery_id, downstream_repo, run_id, run_attempt)
+        member = _in_progress_member(
+            delivery_id, downstream_repo, run_id, run_attempt, job_name
+        )
         timeout_ts = time.time() + config.zombie_timeout_seconds
         client.zadd(_IN_PROGRESS_ZSET, {member: timeout_ts})
         # Auto-expire the ZSET key so it doesn't accumulate stale members forever.
@@ -392,6 +422,7 @@ def remove_in_progress_tracker(
     run_id: int,
     run_attempt: int,
     client: redis_lib.Redis | None = None,
+    job_name: str | None = None,
 ) -> None:
     """Remove a job from the in-progress ZSET after normal completion.
 
@@ -400,7 +431,9 @@ def remove_in_progress_tracker(
     try:
         if client is None:
             client = create_client(config)
-        member = _in_progress_member(delivery_id, downstream_repo, run_id, run_attempt)
+        member = _in_progress_member(
+            delivery_id, downstream_repo, run_id, run_attempt, job_name
+        )
         client.zrem(_IN_PROGRESS_ZSET, member)
         logger.info("in_progress tracker removed member=%s", member)
     except RedisError:
@@ -418,7 +451,7 @@ def scan_expired_in_progress(
     have already resolved it).
 
     Returns a list of dicts with keys:
-      delivery_id, downstream_repo, run_id, run_attempt, state_record
+      delivery_id, downstream_repo, run_id, run_attempt, job_name, state_record
     The state_record includes the stored payload via ``state_record.payload``.
     """
     results: list[dict] = []
@@ -446,7 +479,7 @@ def scan_expired_in_progress(
         logger.info("found %d expired in_progress members", len(expired_members))
         for member in expired_members:
             try:
-                delivery_id, downstream_repo, run_id, run_attempt = (
+                delivery_id, downstream_repo, run_id, run_attempt, job_name = (
                     _parse_in_progress_member(member)
                 )
             except ValueError:
@@ -455,10 +488,15 @@ def scan_expired_in_progress(
                 continue
 
             state_record = get_callback_state(
-                config, delivery_id, downstream_repo, run_id, run_attempt, client
+                config,
+                delivery_id,
+                downstream_repo,
+                run_id,
+                run_attempt,
+                client,
+                job_name,
             )
             if state_record is None:
-                # State record already expired/removed — clean up the stale ZSET entry.
                 logger.info(
                     "state record missing for expired member=%s, removing tracker",
                     member,
@@ -467,7 +505,6 @@ def scan_expired_in_progress(
                 continue
 
             if state_record.state != CallbackState.IN_PROGRESS:
-                # Already resolved (race with normal completion) — just clean up.
                 logger.info(
                     "state already %s for member=%s, removing tracker",
                     state_record.state.value,
@@ -482,6 +519,7 @@ def scan_expired_in_progress(
                     "downstream_repo": downstream_repo,
                     "run_id": run_id,
                     "run_attempt": run_attempt,
+                    "job_name": job_name,
                     "state_record": state_record,
                 }
             )


### PR DESCRIPTION
## Summary

- PR #8170 changed the Redis state key from `check_run_id` (unique per job) to `run_id:run_attempt` (unique per workflow run), causing state machine collisions when multiple jobs in the same workflow run sent callbacks concurrently
- This fix preserves PR #8170's re-run correlation intent while adding per-job uniqueness via `job_name` (`github.job`, already present in callback payloads)
- The state key is now `crcr:state:{delivery_id}:{repo}:{run_id}:{run_attempt}:{job_name}`, with `job_name` omitted for DISPATCHED records (backward-compatible)

## Test plan

- [ ] All 78 unit tests pass locally (verified)
- [ ] Trigger 3 successful runs on `TorchedHat/pytorch-redhat-ci` L2 edge case workflow (multi-job `ec05-a`/`ec05-b` jobs no longer collide)
- [ ] Verify single-job workflows still work (no regression from optional `job_name`)