### PR TITLE
[release/2.13] Skip torch.compile smoke test for Python 3.15

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -196,13 +196,20 @@ run_smoke_tests() {
         source "${SCRIPT_DIR}/validate_test_ops.sh"
     fi
 
+    # torch.compile is not supported on Python 3.15+ (torch.compile() raises
+    # RuntimeError at call time), so disable the compile smoke test there.
+    local compile_check=""
+    if [[ ${MATRIX_PYTHON_VERSION} == "3.15" || ${MATRIX_PYTHON_VERSION} == "3.15t" ]]; then
+        compile_check="--torch-compile-check disabled"
+    fi
+
     # Regular smoke test
-    ${PYTHON_RUN} ./smoke_test/smoke_test.py ${test_suffix}
+    ${PYTHON_RUN} ./smoke_test/smoke_test.py ${test_suffix} ${compile_check}
 
     # For pip install also test with latest numpy
     if [[ ${MATRIX_PACKAGE_TYPE} == 'wheel' ]]; then
         pip3 install numpy --upgrade --force-reinstall
-        ${PYTHON_RUN} ./smoke_test/smoke_test.py ${test_suffix}
+        ${PYTHON_RUN} ./smoke_test/smoke_test.py ${test_suffix} ${compile_check}
     fi
 
     popd


### PR DESCRIPTION
## Summary

The `manywheel-py3_15-cuda13_0` validation job on `release/2.13` fails in the smoke test because `torch.compile` is not supported on Python 3.15+:

```
  File ".ci/pytorch/smoke_test/smoke_test.py", line 502, in smoke_test_compile
    x_pt2 = torch.compile(foo)(x)
  File ".../torch/__init__.py", line 2745, in compile
    raise RuntimeError("torch.compile is not supported on Python 3.15+")
RuntimeError: torch.compile is not supported on Python 3.15+
```

The `smoke_test.py` compile gate on `release/2.13` has no Python-version guard, so the compile test runs and crashes under 3.15.

## Fix

Pass `--torch-compile-check disabled` (already supported by `smoke_test.py`) to the smoke test invocation for `3.15` / `3.15t`, so validation skips the compile test. This matches the existing 3.15 special-casing already in `validate_binaries.sh` (torch-only validation, uv-provisioned 3.15.0b1 interpreter).

## Test plan

```
bash -n .github/scripts/validate_binaries.sh   # syntax check passes
```

Failing job: https://github.com/pytorch/test-infra/actions/runs/28384488349/job/84095559046

Authored with assistance from Claude.