### PR TITLE
Add ClickHouse query for nightly binary pipeline failure alert

### DIFF
--- a/clickhouse_db_schema/grafana_alerts/nightly_pipeline_failures.sql
+++ b/clickhouse_db_schema/grafana_alerts/nightly_pipeline_failures.sql
@@ -1,0 +1,17 @@
+-- Alert when the nightly binary build pipeline has failures.
+--
+-- The nightly binary builds (manywheel / libtorch / conda, across
+-- linux / linux-aarch64 / windows / macos / s390x) run on the `nightly` branch,
+-- e.g. workflow `linux-aarch64-binary-manywheel`, job `manywheel-cpu-aarch64-build`.
+-- This counts jobs from those workflows that completed with a failure in the
+-- evaluation window; the Grafana alert fires when the count is > 0.
+--
+-- Used by Grafana alert: <add URL after creating the rule in pytorchci.grafana.net>
+SELECT count() AS failed_nightly_jobs
+FROM default.workflow_job
+WHERE
+    head_branch = 'nightly'
+    AND workflow_name LIKE '%-binary-%'
+    AND status = 'completed'
+    AND conclusion = 'failure'
+    AND completed_at >= now() - INTERVAL 24 HOUR


### PR DESCRIPTION
## Summary

Adds the ClickHouse query that backs a new Grafana alert for **nightly binary build pipeline failures** (e.g. the `linux-aarch64-binary-manywheel` / `manywheel-cpu-aarch64-build` failures on the `nightly` branch).

Stored under `clickhouse_db_schema/grafana_alerts/` to match the existing convention (queries in source control; the Grafana rule itself is created in the UI).

## Query

Counts nightly-branch binary-build jobs that completed with `conclusion = 'failure'` in the last 24h; the Grafana rule fires when count > 0.

## Tunables (call out for review)
- `workflow_name LIKE '%-binary-%'` scopes to the binary pipeline; drop it to alert on *any* `nightly`-branch failure.
- 24h window matches the daily nightly cadence.
- Threshold (`> 0`) / team / priority live in the Grafana rule annotations, not the SQL.

## Next step (manual, not in this repo)
Create the rule in `pytorchci.grafana.net/alerting/` using this query, with `Teams` + `Priority` annotations and advanced notification routing -> flows to alerting-infra -> GitHub issue. Then backfill the rule URL into the SQL comment.
