### PR TITLE
[torchci] Capture test-osdc configs in test-times

### DIFF
--- a/tools/torchci/tests/test_update_test_times.py
+++ b/tools/torchci/tests/test_update_test_times.py
@@ -1,7 +1,29 @@
+import re
 import unittest
 from unittest.mock import patch
 
 from torchci.update_test_times import gen_test_class_times, gen_test_file_times
+from torchci.utils import REPO_ROOT
+
+
+# The (base_name, test_config) keys are extracted by these RE2 patterns in the
+# saved ClickHouse test_times queries. Mirrored here so we can exercise their
+# behavior; the test_queries_embed_expected_patterns guard fails if a query
+# stops using them, so the two can't silently drift.
+QUERY_DIRS = [
+    "per_file",
+    "per_file_periodic_jobs",
+    "per_class",
+    "per_class_periodic_jobs",
+]
+BASE_NAME_RE = r"^(.*) /"
+TEST_CONFIG_RE = r"/ test(?:-osdc)? \(([\w-]*),"
+
+
+def _query_path(name: str):
+    return (
+        REPO_ROOT / "torchci" / "clickhouse_queries" / "test_times" / name / "query.sql"
+    )
 
 
 @patch("torchci.update_test_times.clean_up_test_times", lambda x: x)
@@ -246,6 +268,62 @@ class TestCleanUpOldBuildEnvs(unittest.TestCase):
                 },
             }
             self.assertDictEqual(res, expected)
+
+
+class TestJobNameExtractionSql(unittest.TestCase):
+    # (job name, expected base_name, expected test_config)
+    CASES = [
+        (
+            "linux-jammy-py3.10-clang18 / test (dynamo_wrapped, 1, 3, lf-l-x86)",
+            "linux-jammy-py3.10-clang18",
+            "dynamo_wrapped",
+        ),
+        (
+            "linux-jammy-py3.14t-clang18 / test-osdc (dynamo_wrapped, 1, 3, mt-l-x86)",
+            "linux-jammy-py3.14t-clang18",
+            "dynamo_wrapped",
+        ),
+        (
+            "cross-compile-linux-test-cuda13 / test-osdc (aoti, 1, 1, r, win)",
+            "cross-compile-linux-test-cuda13",
+            "aoti",
+        ),
+        # Multi-segment prefix is kept.
+        (
+            "unit-test / inductor-test / test-osdc (inductor, 2, 2, mt-l-x86)",
+            "unit-test / inductor-test",
+            "inductor",
+        ),
+        # Non-test/test-osdc targets yield no config (must match "test-osdc" exactly,
+        # not as a prefix); an empty config field also renders as "".
+        ("env / test-foo (default, 1, 1, r)", "env", ""),
+        ("env / testbar (default, 1, 1, r)", "env", ""),
+        ("env / test-osdcfoo (default, 1, 1, r)", "env", ""),
+        ("env / inductor-cpu-core-test (3.11)", "env", ""),
+        ("env / build", "env", ""),
+        ("env / test (, 1, 2, r)", "env", ""),
+    ]
+
+    # Patterns run in ClickHouse (RE2); this mirrors them with Python re. Keep them
+    # RE2-safe -- verify any pattern change against ClickHouse directly.
+    def _apply(self, pattern: str, job_name: str) -> str:
+        m = re.search(pattern, job_name)
+        return m.group(1) if m else ""
+
+    def test_queries_embed_expected_patterns(self) -> None:
+        # Each pattern is a single-quoted SQL string literal, so this substring
+        # check is robust to query reformatting (line wraps happen outside it).
+        for name in QUERY_DIRS:
+            sql = _query_path(name).read_text()
+            with self.subTest(query=name):
+                self.assertIn(BASE_NAME_RE, sql)
+                self.assertIn(TEST_CONFIG_RE, sql)
+
+    def test_patterns_extract_consistently(self) -> None:
+        for job_name, want_base, want_cfg in self.CASES:
+            with self.subTest(job=job_name):
+                self.assertEqual(self._apply(BASE_NAME_RE, job_name), want_base)
+                self.assertEqual(self._apply(TEST_CONFIG_RE, job_name), want_cfg)
 
 
 if __name__ == "__main__":

--- a/torchci/clickhouse_queries/test_times/per_class/query.sql
+++ b/torchci/clickhouse_queries/test_times/per_class/query.sql
@@ -30,7 +30,8 @@ class_duration_per_job AS (
         test_run.classname AS classname,
         SUM(time) AS time,
         REGEXP_EXTRACT(job.name, '^(.*) /', 1) AS base_name,
-        REGEXP_EXTRACT(job.name, '/ test \(([\w-]*),', 1) AS test_config
+        REGEXP_EXTRACT(job.name, '/ test(?:-osdc)? \(([\w-]*),', 1)
+            AS test_config
     FROM
         default.test_run_summary test_run
     INNER JOIN job ON test_run.job_id = job.id

--- a/torchci/clickhouse_queries/test_times/per_class_periodic_jobs/query.sql
+++ b/torchci/clickhouse_queries/test_times/per_class_periodic_jobs/query.sql
@@ -35,7 +35,7 @@ class_duration_per_job AS (
         test_run.classname AS classname,
         SUM(time) AS time,
         REGEXP_EXTRACT(job.name, '^(.*) /', 1) AS base_name,
-        REGEXP_EXTRACT(job.name, '/ test \(([\w-]*),', 1) AS test_config
+        REGEXP_EXTRACT(job.name, '/ test(?:-osdc)? \(([\w-]*),', 1) AS test_config
     FROM
         default.test_run_summary test_run
     INNER JOIN job ON test_run.job_id = job.id

--- a/torchci/clickhouse_queries/test_times/per_file/query.sql
+++ b/torchci/clickhouse_queries/test_times/per_file/query.sql
@@ -29,7 +29,8 @@ file_duration_per_job AS (
         test_run.invoking_file AS file,
         SUM(time) AS time,
         REGEXP_EXTRACT(job.name, '^(.*) /', 1) AS base_name,
-        REGEXP_EXTRACT(job.name, '/ test \(([\w-]*),', 1) AS test_config
+        REGEXP_EXTRACT(job.name, '/ test(?:-osdc)? \(([\w-]*),', 1)
+            AS test_config
     FROM
         default.test_run_summary test_run
     INNER JOIN job ON test_run.job_id = job.id

--- a/torchci/clickhouse_queries/test_times/per_file_periodic_jobs/query.sql
+++ b/torchci/clickhouse_queries/test_times/per_file_periodic_jobs/query.sql
@@ -35,7 +35,7 @@ file_duration_per_job AS (
         test_run.invoking_file AS file,
         SUM(time) AS time,
         REGEXP_EXTRACT(job.name, '^(.*) /', 1) AS base_name,
-        REGEXP_EXTRACT(job.name, '/ test \(([\w-]*),', 1) AS test_config
+        REGEXP_EXTRACT(job.name, '/ test(?:-osdc)? \(([\w-]*),', 1) AS test_config
     FROM
         default.test_run_summary test_run
     INNER JOIN job ON test_run.job_id = job.id


### PR DESCRIPTION
The test_config regex in the test_times queries only matched "/ test (", so every test-osdc job's config was recorded as "" and merged into one bucket. Widen it to also match "/ test-osdc (".

This should help balance out test times by allowing us to properly capture the `test-osdc` historical times rather than as a default config, since we're seeing some skewed shard runtimes. It might be good to just keep this consistent.

<img width="953" height="50" alt="Screenshot 2026-06-29 at 3 07 54 PM" src="https://github.com/user-attachments/assets/ca5c05c4-2742-443c-a3c0-efc39a5011f1" />



Test Plan:
```
  python -m pytest tools/torchci/tests/test_update_test_times.py -k JobNameExtractionSql
```

*update-test-times.yml* should write *test-times.json* and *test-class-times.json* to be accessible by sharding: https://github.com/pytorch/test-infra/actions/workflows/update-test-times.yml

Authored with assistance from Claude.