### PR TITLE
Group inductor-rocm jobs under ROCm instead of Inductor

### DIFF
--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -118,6 +118,10 @@ export const groups = [
     name: GROUP_LINT,
   },
   {
+    regex: /inductor-rocm/,
+    name: GROUP_ROCM,
+  },
+  {
     regex: /inductor/,
     name: GROUP_INDUCTOR,
   },


### PR DESCRIPTION
**Impact:** HUD job grouping UI only
**Risk:** low

## What
Adds a job classifier rule so jobs matching `inductor-rocm` are grouped under the ROCm group, placed ahead of the generic `inductor` rule.

## Why
The `groups` list matches jobs against the first regex that hits. Since `/inductor/` came before `/rocm/`, `inductor-rocm` jobs were being bucketed into the Inductor group rather than ROCm. The new rule short-circuits those jobs into ROCm where they belong.