### PR TITLE
manage_v2: cache prod index pages for 10 min (revalidate), skip nightly/test/preview

### DIFF
--- a/s3_management/manage_v2.py
+++ b/s3_management/manage_v2.py
@@ -600,6 +600,16 @@ def index_has_external_links(html: str) -> bool:
     return "files.pythonhosted.org" in html or "pypi.nvidia.com" in html
 
 
+# Cache-Control headers for uploaded index pages.
+#
+# Release/prod channels (e.g. whl, libtorch) publish immutable artifacts, so
+# their index pages may be cached for 10 minutes and then must be revalidated.
+# Nightly, test, and preview channels change constantly, so their indexes must
+# never be cached -- newly published packages have to appear immediately.
+PROD_INDEX_CACHE_CONTROL = "max-age=600, public, must-revalidate"
+NO_CACHE_INDEX_CACHE_CONTROL = "no-cache,no-store,must-revalidate"
+
+
 class S3Index:
     def __init__(self, objects: List[S3Object], prefix: str) -> None:
         self.objects = objects
@@ -615,6 +625,18 @@ class S3Index:
         self._parent_packages_cache: Dict[str, Set[str]] = {}
         # Cache for S3 bucket object listings to avoid repeated API calls
         self._bucket_listing_cache: Dict[str, List] = {}
+
+    def _index_cache_control(self, subdir: str) -> str:
+        """Return the ``Cache-Control`` header for an index page under ``subdir``.
+
+        Nightly, test, and preview channels change constantly and must never be
+        cached; release/prod channels may be cached for 10 minutes and then
+        revalidated.
+        """
+        parts = subdir.split("/")
+        if "nightly" in parts or "test" in parts or "preview" in parts:
+            return NO_CACHE_INDEX_CACHE_CONTROL
+        return PROD_INDEX_CACHE_CONTROL
 
     def packages_by_allow_list(self) -> List[S3Object]:
         """Filter packages to only include those in PACKAGE_ALLOW_LIST
@@ -946,7 +968,7 @@ class S3Index:
             )
             BUCKET.Object(key=f"{subdir}/{self.html_name}").put(
                 ACL="public-read",
-                CacheControl="no-cache,no-store,must-revalidate",
+                CacheControl=self._index_cache_control(subdir),
                 ContentType="text/html",
                 Body=index_html,
             )
@@ -958,7 +980,7 @@ class S3Index:
                 )
                 R2_BUCKET.Object(key=f"{subdir}/{self.html_name}").put(
                     ACL="public-read",
-                    CacheControl="no-cache,no-store,must-revalidate",
+                    CacheControl=self._index_cache_control(subdir),
                     ContentType="text/html",
                     Body=index_html,
                 )
@@ -974,7 +996,7 @@ class S3Index:
         )
         BUCKET.Object(key=f"{self.prefix}/{self.html_name}").put(
             ACL="public-read",
-            CacheControl="no-cache,no-store,must-revalidate",
+            CacheControl=self._index_cache_control(self.prefix),
             ContentType="text/html",
             Body=index_html,
         )
@@ -986,7 +1008,7 @@ class S3Index:
             )
             R2_BUCKET.Object(key=f"{self.prefix}/{self.html_name}").put(
                 ACL="public-read",
-                CacheControl="no-cache,no-store,must-revalidate",
+                CacheControl=self._index_cache_control(self.prefix),
                 ContentType="text/html",
                 Body=index_html,
             )
@@ -1007,7 +1029,7 @@ class S3Index:
             print(f"INFO Uploading {subdir}/index.html to S3 bucket {BUCKET.name}")
             BUCKET.Object(key=f"{subdir}/index.html").put(
                 ACL="public-read",
-                CacheControl="no-cache,no-store,must-revalidate",
+                CacheControl=self._index_cache_control(subdir),
                 ContentType="text/html",
                 Body=index_html,
             )
@@ -1019,7 +1041,7 @@ class S3Index:
                 )
                 R2_BUCKET.Object(key=f"{subdir}/index.html").put(
                     ACL="public-read",
-                    CacheControl="no-cache,no-store,must-revalidate",
+                    CacheControl=self._index_cache_control(subdir),
                     ContentType="text/html",
                     Body=index_html,
                 )
@@ -1100,7 +1122,7 @@ class S3Index:
                         # Upload to subdirectory in S3
                         BUCKET.Object(key=f"{subdir}/{compat_pkg_name}/index.html").put(
                             ACL="public-read",
-                            CacheControl="no-cache,no-store,must-revalidate",
+                            CacheControl=self._index_cache_control(subdir),
                             ContentType="text/html",
                             Body=root_index_html,
                         )
@@ -1111,7 +1133,7 @@ class S3Index:
                                 key=f"{subdir}/{compat_pkg_name}/index.html"
                             ).put(
                                 ACL="public-read",
-                                CacheControl="no-cache,no-store,must-revalidate",
+                                CacheControl=self._index_cache_control(subdir),
                                 ContentType="text/html",
                                 Body=root_index_html,
                             )
@@ -1131,7 +1153,7 @@ class S3Index:
                 )
                 BUCKET.Object(key=f"{subdir}/{compat_pkg_name}/index.html").put(
                     ACL="public-read",
-                    CacheControl="no-cache,no-store,must-revalidate",
+                    CacheControl=self._index_cache_control(subdir),
                     ContentType="text/html",
                     Body=s3_index_html,
                 )
@@ -1148,7 +1170,7 @@ class S3Index:
                     )
                     R2_BUCKET.Object(key=f"{subdir}/{compat_pkg_name}/index.html").put(
                         ACL="public-read",
-                        CacheControl="no-cache,no-store,must-revalidate",
+                        CacheControl=self._index_cache_control(subdir),
                         ContentType="text/html",
                         Body=r2_index_html,
                     )


### PR DESCRIPTION
## What

Fixes: https://github.com/pytorch/pytorch/issues/130571

Adjusts the `Cache-Control` header for index pages uploaded by the v2 uploader (`s3_management/manage_v2.py`), mirroring the intent of #6188 (which does this in `manage.py`) but **scoped to prod/release channels only**.

- **Prod/release channels** (`whl`, `libtorch`, `whl/variant`, `source_code`, and their cuda/cpu subdirs): index pages now upload with
  `Cache-Control: max-age=600, public, must-revalidate`
  so they may be cached for **10 minutes** and then **must be revalidated** with the origin before serving (no stale copies).
- **Nightly, test, and preview channels** (`whl/nightly`, `whl/test`, `whl/preview/*`, `libtorch/nightly`, `source_code/test`, ...): keep the existing `no-cache,no-store,must-revalidate` so newly published packages appear immediately.
- The flash-attn-3 copies into `whl/nightly` (`upload_flash_attn_3_to_nightly`) also stay `no-cache`.

## How
A small helper `S3Index._index_cache_control(subdir)` classifies the channel from the upload subdir/prefix (treats `nightly`/`test`/`preview` path segments as no-cache, everything else as prod). All S3 **and** R2 index uploads route through it: `upload_libtorch_html`, `upload_source_code_html`, `upload_pep503_htmls` package lists, and the per-package indexes (both the copy-from-parent and freshly-generated paths). 10 upload sites changed; the 2 flash-attn nightly-copy sites intentionally left as-is.

## Why
Prod/release artifacts are immutable, so their index pages can safely be cached briefly to cut origin/CDN load, while `must-revalidate` guarantees a stale index is never served past the 10-minute window (revalidation is a cheap conditional GET against S3's ETag/Last-Modified, returning `304` when unchanged). Nightly/test/preview must stay uncached because they change constantly.

## Notes
- Chose `max-age=600, public, must-revalidate` (vs #6188's `max-age=600, public`) to add the revalidation guarantee. `public` is largely redundant for these already-public S3 objects but matches #6188 / PyPI.
- `flake8` gains 4 `B023` "function does not bind loop variable" warnings on the new `subdir` references inside the existing `upload_package_index` closure. These are the same false-positive class already present ~15x in that closure (the key f-strings) and are not gated in CI (`main` ships 18 such B023/E501 in this file); the closure is consumed synchronously within the same loop iteration via `executor.map`, so the value is correct at call time. `black` is clean.