### PR TITLE
[release/2.13] Fix libtorch validation: guard MATRIX_PYTHON_VERSION unbound variable

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -239,7 +239,9 @@ handle_aarch64_cuda_override
 
 # torchvision wheels are not published for Python 3.15 / 3.15t yet, so validate
 # torch only: skip the torchvision install and its smoke-test module check.
-if [[ ${MATRIX_PYTHON_VERSION} == "3.15" || ${MATRIX_PYTHON_VERSION} == "3.15t" ]]; then
+# Guard with :- since libtorch builds run this before the libtorch exit below
+# and do not set MATRIX_PYTHON_VERSION (set -u would abort otherwise).
+if [[ ${MATRIX_PYTHON_VERSION:-} == "3.15" || ${MATRIX_PYTHON_VERSION:-} == "3.15t" ]]; then
     export TORCH_ONLY=true
 fi
 


### PR DESCRIPTION
## Problem
libtorch validations on `release/2.13` fail in the "Run script" step:

```
validate_binaries.sh: line 242: MATRIX_PYTHON_VERSION: unbound variable
```

(e.g. `mac-arm64 / libtorch-cpu-shared-with-deps-cxx11-abi`, run 28529093692).

The Python 3.15 `TORCH_ONLY` block added in #8227 runs **before** the libtorch early-exit, but libtorch builds do not set `MATRIX_PYTHON_VERSION`. Under `set -u` the unquoted reference aborts the script.

## Fix
Guard the checks with `${MATRIX_PYTHON_VERSION:-}` so an unset value expands to empty (condition false) instead of aborting. No behavior change for wheel/conda builds where the variable is always set.