### PR TITLE
[CRCR] Add pagination to backend dashboard page

### DIFF
--- a/torchci/clickhouse_queries/crcr_backend_dashboard/params.json
+++ b/torchci/clickhouse_queries/crcr_backend_dashboard/params.json
@@ -1,12 +1,16 @@
 {
   "params": {
     "repo": "String",
-    "days": "UInt64"
+    "days": "UInt64",
+    "per_page": "UInt64",
+    "offset": "UInt64"
   },
   "tests": [
     {
       "repo": "<company>/<repo>",
-      "days": "7"
+      "days": "7",
+      "per_page": "50",
+      "offset": "0"
     }
   ]
 }

--- a/torchci/clickhouse_queries/crcr_backend_dashboard/query.sql
+++ b/torchci/clickhouse_queries/crcr_backend_dashboard/query.sql
@@ -25,6 +25,17 @@ FROM
 WHERE
     downstream_repo = {repo: String}
     AND started_at > now() - INTERVAL {days: UInt64} DAY
+    AND pr_number IN (
+        SELECT pr_number
+        FROM default.crcr_workflow_job FINAL
+        WHERE
+            downstream_repo = {repo: String}
+            AND started_at > now() - INTERVAL {days: UInt64} DAY
+        GROUP BY pr_number
+        ORDER BY max(started_at) DESC
+        LIMIT
+            {per_page: UInt64}
+            OFFSET {offset: UInt64}
+    )
 ORDER BY
     started_at DESC
-LIMIT 500

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -25,7 +25,7 @@ import { conclusionColor, conclusionLabel } from "lib/crcr/crcrUtils";
 import Head from "next/head";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import useSWR from "swr";
 
 interface CrcrJobRow {
@@ -143,27 +143,89 @@ function HealthSummary({ data }: { data: CrcrJobRow[] }) {
         color={rate >= 0.95 ? "success" : rate >= 0.8 ? "warning" : "error"}
       />
       <Typography variant="body2" color="text.secondary">
-        {success}/{total} jobs passed
+        {success}/{total} jobs passed (this page)
       </Typography>
     </Stack>
+  );
+}
+
+const PER_PAGE = 50;
+
+function CrcrPagination({
+  page,
+  hasNextPage,
+  onPageChange,
+}: {
+  page: number;
+  hasNextPage: boolean;
+  onPageChange: (page: number) => void;
+}) {
+  return (
+    <div>
+      Page {page}:{" "}
+      {page > 1 ? (
+        <Link
+          component="button"
+          underline="hover"
+          onClick={() => onPageChange(page - 1)}
+        >
+          Prev
+        </Link>
+      ) : (
+        <span>Prev</span>
+      )}{" "}
+      |{" "}
+      {hasNextPage ? (
+        <Link
+          component="button"
+          underline="hover"
+          onClick={() => onPageChange(page + 1)}
+        >
+          Next
+        </Link>
+      ) : (
+        <span>Next</span>
+      )}
+    </div>
   );
 }
 
 function CrcrMatrix({
   repoFullName,
   days,
+  page,
+  onPageChange,
 }: {
   repoFullName: string;
   days: number;
+  page: number;
+  onPageChange: (page: number) => void;
 }) {
+  const offset = (page - 1) * PER_PAGE;
   const url = `/api/clickhouse/crcr_backend_dashboard?parameters=${encodeURIComponent(
-    JSON.stringify({ repo: repoFullName, days: String(days) })
+    JSON.stringify({
+      repo: repoFullName,
+      days: String(days),
+      per_page: String(PER_PAGE + 1),
+      offset: String(offset),
+    })
   )}`;
   const { data, error } = useSWR<CrcrJobRow[]>(url, fetcher, {
     refreshInterval: 60_000,
   });
 
-  const matrix = useMemo(() => (data ? buildMatrix(data) : null), [data]);
+  const { matrix, hasNextPage } = useMemo(() => {
+    if (!data) return { matrix: null, hasNextPage: false };
+    const full = buildMatrix(data);
+    const hasMore = full.rows.length > PER_PAGE;
+    return {
+      matrix: {
+        jobNames: full.jobNames,
+        rows: full.rows.slice(0, PER_PAGE),
+      },
+      hasNextPage: hasMore,
+    };
+  }, [data]);
 
   if (error) {
     return (
@@ -177,9 +239,18 @@ function CrcrMatrix({
   }
   if (data.length === 0) {
     return (
-      <Typography color="text.secondary" sx={{ py: 4, textAlign: "center" }}>
-        No results for {repoFullName} in the last {days} days.
-      </Typography>
+      <>
+        <Typography color="text.secondary" sx={{ py: 4, textAlign: "center" }}>
+          No results for {repoFullName} in the last {days} days.
+        </Typography>
+        {page > 1 && (
+          <CrcrPagination
+            page={page}
+            hasNextPage={false}
+            onPageChange={onPageChange}
+          />
+        )}
+      </>
     );
   }
 
@@ -237,6 +308,13 @@ function CrcrMatrix({
           </TableBody>
         </Table>
       </TableContainer>
+      <Box sx={{ mt: 2 }}>
+        <CrcrPagination
+          page={page}
+          hasNextPage={hasNextPage}
+          onPageChange={onPageChange}
+        />
+      </Box>
     </>
   );
 }
@@ -244,11 +322,21 @@ function CrcrMatrix({
 export default function CrcrBackendPage() {
   const router = useRouter();
   const { org, repo } = router.query;
-  const [days, setDays] = useState(7);
+
+  const page = parseInt(router.query.page as string) || 1;
+  const days = parseInt(router.query.days as string) || 7;
 
   if (!org || !repo) return null;
 
   const repoFullName = `${org}/${repo}`;
+
+  function updateQuery(updates: Record<string, string | number>) {
+    router.push(
+      { pathname: router.pathname, query: { ...router.query, ...updates } },
+      undefined,
+      { shallow: true }
+    );
+  }
 
   return (
     <>
@@ -271,7 +359,7 @@ export default function CrcrBackendPage() {
               value={days}
               label="Time Range"
               onChange={(e: SelectChangeEvent<number>) =>
-                setDays(Number(e.target.value))
+                updateQuery({ days: Number(e.target.value), page: 1 })
               }
             >
               <MenuItem value={1}>Last 24h</MenuItem>
@@ -282,11 +370,16 @@ export default function CrcrBackendPage() {
         </Box>
 
         <Typography variant="body2" color="text.secondary">
-          Rows = PyTorch PRs, columns = downstream CI jobs. Click a chip to open
-          the workflow run.
+          Rows = PyTorch PRs (50 per page), columns = downstream CI jobs. Click
+          a chip to open the workflow run.
         </Typography>
 
-        <CrcrMatrix repoFullName={repoFullName} days={days} />
+        <CrcrMatrix
+          repoFullName={repoFullName}
+          days={days}
+          page={page}
+          onPageChange={(p) => updateQuery({ page: p })}
+        />
       </Stack>
     </>
   );


### PR DESCRIPTION
## Summary

- Adds PR-level pagination (50 PRs per page) to the CRCR backend dashboard at `/crcr/{org}/{repo}`
- Replaces the previous hardcoded `LIMIT 500` with ClickHouse `OFFSET/LIMIT` on distinct `pr_number` values
- Adds `Page N: Prev | Next` pagination below the table, matching the HUD home page style
- Page and time range are persisted in URL query params (`?page=N&days=N`) for shareable links

## Problem

The CRCR backend dashboard loaded up to 500 raw job rows with no pagination. With ~20 jobs per dispatch (TorchedHat test repo), this only showed ~25 PRs mixed with stale zombie records from months ago. No way to navigate to older results.

## Changes

| File | Change |
|------|--------|
| `clickhouse_queries/crcr_backend_dashboard/query.sql` | Paginate by distinct `pr_number` via subquery with `GROUP BY` + `LIMIT/OFFSET`, ordered by `max(started_at) DESC` (most recent CI activity, not PR number). Fetches `per_page + 1` rows to detect whether a next page exists. |
| `clickhouse_queries/crcr_backend_dashboard/params.json` | Added `per_page` (UInt64) and `offset` (UInt64) params with test defaults of 50 and 0. |
| `pages/crcr/[org]/[repo].tsx` | Added `page`/`days` URL query params, `CrcrPagination` component below the table (`Page N: Prev \| Next`), reset to page 1 on time range change. Next is disabled when fewer than 51 PRs are returned (no dead link on last page). HealthSummary labeled as page-scoped. |

## Test plan

- [ ] Verify page 1 shows the 50 most recent PRs (by latest CI activity)
- [ ] Verify Next loads the next 50 PRs
- [ ] Verify Prev is disabled on page 1, Next is disabled on the last page
- [ ] Verify changing time range resets to page 1
- [ ] Verify URL params are shareable (`?page=2&days=7`)
- [ ] Verify pass rate label says "(this page)"