### PR TITLE
Add opt-in Python 3.15 / 3.15t torch-only validation (Linux x86 + aarch64)

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -27,6 +27,17 @@ get_python_config() {
             PYTHON_V=3.14.0rc1
             CONDA_EXTRA_PARAM=" -c conda-forge/label/python_rc -c conda-forge"
             ;;
+        3.15t)
+            # 3.15 is pre-release: conda-forge ships the interpreter under the
+            # python_dev label (alphas), but the build depends on the _python_rc
+            # marker that lives on the python_rc label, so both are required.
+            PYTHON_V=3.15.0a8
+            CONDA_EXTRA_PARAM=" python-freethreading -c conda-forge/label/python_dev -c conda-forge/label/python_rc -c conda-forge"
+            ;;
+        3.15)
+            PYTHON_V=3.15.0a8
+            CONDA_EXTRA_PARAM=" -c conda-forge/label/python_dev -c conda-forge/label/python_rc -c conda-forge"
+            ;;
         *)
             PYTHON_V=${MATRIX_PYTHON_VERSION}
             CONDA_EXTRA_PARAM=""
@@ -185,13 +196,20 @@ run_smoke_tests() {
         source "${SCRIPT_DIR}/validate_test_ops.sh"
     fi
 
+    # torch.compile is not supported on Python 3.15+ (torch.compile() raises
+    # RuntimeError at call time), so disable the compile smoke test there.
+    local compile_check=""
+    if [[ ${MATRIX_PYTHON_VERSION} == "3.15" || ${MATRIX_PYTHON_VERSION} == "3.15t" ]]; then
+        compile_check="--torch-compile-check disabled"
+    fi
+
     # Regular smoke test
-    ${PYTHON_RUN} ./smoke_test/smoke_test.py ${test_suffix}
+    ${PYTHON_RUN} ./smoke_test/smoke_test.py ${test_suffix} ${compile_check}
 
     # For pip install also test with latest numpy
     if [[ ${MATRIX_PACKAGE_TYPE} == 'wheel' ]]; then
         pip3 install numpy --upgrade --force-reinstall
-        ${PYTHON_RUN} ./smoke_test/smoke_test.py ${test_suffix}
+        ${PYTHON_RUN} ./smoke_test/smoke_test.py ${test_suffix} ${compile_check}
     fi
 
     popd
@@ -219,6 +237,14 @@ cleanup_conda_env() {
 
 handle_aarch64_cuda_override
 
+# torchvision wheels are not published for Python 3.15 / 3.15t yet, so validate
+# torch only: skip the torchvision install and its smoke-test module check.
+# Guard with :- since libtorch builds run this before the libtorch exit below
+# and do not set MATRIX_PYTHON_VERSION (set -u would abort otherwise).
+if [[ ${MATRIX_PYTHON_VERSION:-} == "3.15" || ${MATRIX_PYTHON_VERSION:-} == "3.15t" ]]; then
+    export TORCH_ONLY=true
+fi
+
 if [[ ${MATRIX_PACKAGE_TYPE} == "libtorch" ]]; then
     LIBTORCH_PYTHON="python3"
     if [[ ${TARGET_OS} == 'windows' ]]; then
@@ -237,11 +263,30 @@ if [[ ${TARGET_OS} == 'windows' ]]; then
     export PYTHON_RUN="python"
 fi
 
-# Setup conda environment
-update_conda
-get_python_config
-conda create -y -n "${ENV_NAME}" python="${PYTHON_V}" pip ${CONDA_EXTRA_PARAM}
-conda activate "${ENV_NAME}"
+# Setup the Python environment.
+#
+# Python 3.15 is still pre-release. The cp315/cp315t wheels are built against
+# CPython 3.15.0b1 (see pytorch .ci/docker/common/install_cpython.sh), but
+# conda-forge only ships 3.15.0a8 -- the pre-release ABI differs, so installing
+# the wheel under the conda interpreter segfaults on "import torch". Provision
+# the matching 3.15.0b1 interpreter with uv (from python-build-standalone)
+# instead of conda. A --seed venv provides pip so the rest of the flow (pip3
+# install, smoke tests) is unchanged.
+if [[ ${MATRIX_PYTHON_VERSION} == "3.15" || ${MATRIX_PYTHON_VERSION} == "3.15t" ]]; then
+    UV_PYTHON="3.15.0b1"
+    if [[ ${MATRIX_PYTHON_VERSION} == "3.15t" ]]; then
+        UV_PYTHON="3.15.0b1+freethreaded"
+    fi
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    source "${HOME}/.local/bin/env"
+    uv venv --seed --python "${UV_PYTHON}" "${ENV_NAME}"
+    source "${ENV_NAME}/bin/activate"
+else
+    update_conda
+    get_python_config
+    conda create -y -n "${ENV_NAME}" python="${PYTHON_V}" pip ${CONDA_EXTRA_PARAM}
+    conda activate "${ENV_NAME}"
+fi
 
 # Save original PATH for macos-arm64 workaround
 export OLD_PATH=${PATH}

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -27,17 +27,9 @@ get_python_config() {
             PYTHON_V=3.14.0rc1
             CONDA_EXTRA_PARAM=" -c conda-forge/label/python_rc -c conda-forge"
             ;;
-        3.15t)
-            # 3.15 is pre-release: conda-forge ships the interpreter under the
-            # python_dev label (alphas), but the build depends on the _python_rc
-            # marker that lives on the python_rc label, so both are required.
-            PYTHON_V=3.15.0a8
-            CONDA_EXTRA_PARAM=" python-freethreading -c conda-forge/label/python_dev -c conda-forge/label/python_rc -c conda-forge"
-            ;;
-        3.15)
-            PYTHON_V=3.15.0a8
-            CONDA_EXTRA_PARAM=" -c conda-forge/label/python_dev -c conda-forge/label/python_rc -c conda-forge"
-            ;;
+        # Note: 3.15 / 3.15t are intentionally absent here. They are provisioned
+        # via uv (CPython 3.15.0b1) in the interpreter-setup branch below and
+        # never reach the conda create path that reads CONDA_EXTRA_PARAM.
         *)
             PYTHON_V=${MATRIX_PYTHON_VERSION}
             CONDA_EXTRA_PARAM=""

--- a/.github/workflows/generate_binary_build_matrix.yml
+++ b/.github/workflows/generate_binary_build_matrix.yml
@@ -52,6 +52,11 @@ on:
         description: "A JSON-encoded list of python versions to build. An empty list means building all supported versions"
         default: "[]"
         type: string
+      include-preview-python-versions:
+        description: "Include opt-in preview python versions (torch-only, Linux x86 and aarch64), e.g. 3.15/3.15t"
+        default: "disable"
+        required: false
+        type: string
       getting-started:
         description: "Release matrix for getting started page"
         required: false
@@ -97,6 +102,7 @@ jobs:
           BUILD_PYTHON_ONLY: ${{ inputs.build-python-only }}
           GETTING_STARTED: ${{ inputs.getting-started }}
           PYTHON_VERSIONS: ${{ inputs.python-versions }}
+          INCLUDE_PREVIEW_PYTHON_VERSIONS: ${{ inputs.include-preview-python-versions }}
         run: |
           set -eou pipefail
           MATRIX_BLOB="$(python3 tools/scripts/generate_binary_build_matrix.py)"

--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -99,6 +99,8 @@ jobs:
       with-cuda: enable
       with-cpu: enable
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
+      # Validate torch-only preview python versions (3.15/3.15t) on the test channel.
+      include-preview-python-versions: enable
 
   linux-aarch64:
     needs: generate-aarch64-linux-matrix

--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -99,7 +99,7 @@ jobs:
       with-cuda: enable
       with-cpu: enable
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
-      # Validate torch-only preview python versions (3.15/3.15t) on the test channel.
+      # Validate torch-only preview python versions (3.15/3.15t) on the nightly and test channels.
       include-preview-python-versions: enable
 
   linux-aarch64:

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -108,7 +108,7 @@ jobs:
       channel: ${{ inputs.channel }}
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
       with-xpu: enable
-      # Validate torch-only preview python versions (3.15/3.15t) on the test channel.
+      # Validate torch-only preview python versions (3.15/3.15t) on the nightly and test channels.
       include-preview-python-versions: enable
 
   linux:

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -108,6 +108,8 @@ jobs:
       channel: ${{ inputs.channel }}
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
       with-xpu: enable
+      # Validate torch-only preview python versions (3.15/3.15t) on the test channel.
+      include-preview-python-versions: enable
 
   linux:
     needs: generate-linux-matrix

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -32,7 +32,7 @@ PYTHON_ARCHES_DICT = {
 # generator default is unchanged for domain libraries (torchvision, torchaudio)
 # and for Windows/macOS, which do not have wheels for these versions yet.
 PREVIEW_PYTHON_ARCHES_DICT = {
-    "nightly": [],
+    "nightly": ["3.15", "3.15t"],
     "test": ["3.15", "3.15t"],
     "release": [],
 }

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -27,6 +27,21 @@ PYTHON_ARCHES_DICT = {
     "release": ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"],
 }
 
+# Preview Python versions validated for torch only, on Linux x86 and aarch64.
+# These are opt-in via INCLUDE_PREVIEW_PYTHON_VERSIONS so that the shared
+# generator default is unchanged for domain libraries (torchvision, torchaudio)
+# and for Windows/macOS, which do not have wheels for these versions yet.
+PREVIEW_PYTHON_ARCHES_DICT = {
+    "nightly": [],
+    "test": ["3.15", "3.15t"],
+    "release": [],
+}
+
+# Python versions for which only torch is validated (no torchvision). torchvision
+# wheels are not published for these versions yet, so the install command must
+# request torch alone.
+TORCH_ONLY_PYTHON_ARCHES = ["3.15", "3.15t"]
+
 MACOS_PYTHON_POINT_VERSIONS = {
     "3.10": "3.10.19",
     "3.11": "3.11.14",
@@ -293,6 +308,11 @@ def get_wheel_install_command(
         else PACKAGES_TO_INSTALL_WHL
     )
 
+    # Validate torch only (no torchvision) for versions without published
+    # torchvision wheels, e.g. 3.15 / 3.15t.
+    if python_version in TORCH_ONLY_PYTHON_ARCHES:
+        PACKAGES_TO_INSTALL = "torch"
+
     if (
         channel == RELEASE
         and (not use_only_dl_pytorch_org)
@@ -330,7 +350,9 @@ def generate_libtorch_matrix(
     abi_versions: Optional[List[str]] = None,
     arches: Optional[List[str]] = None,
     libtorch_variants: Optional[List[str]] = None,
+    include_preview_python_versions: bool = False,
 ) -> List[Dict[str, str]]:
+    # libtorch is python-agnostic; the preview python versions do not apply.
     ret: List[Dict[str, str]] = []
 
     if arches is None:
@@ -422,12 +444,20 @@ def generate_wheels_matrix(
     getting_started: bool = False,
     python_versions: Optional[List[str]] = None,
     arches: Optional[List[str]] = None,
+    include_preview_python_versions: bool = False,
 ) -> List[Dict[str, str]]:
     package_type = "wheel"
 
     if not python_versions:
         # Define default python version
         python_versions = list(PYTHON_ARCHES)
+
+        # Opt-in preview versions (e.g. 3.15/3.15t) are torch-only and validated
+        # on Linux x86 and aarch64 only. Append them to the default list so the
+        # shared default (used by domain libraries, Windows and macOS) is
+        # unaffected.
+        if include_preview_python_versions and os in (LINUX, LINUX_AARCH64):
+            python_versions += PREVIEW_PYTHON_ARCHES_DICT.get(channel, [])
 
     if os == WINDOWS_ARM64:
         python_versions = ["3.11", "3.12", "3.13"]  # only versions for now
@@ -528,6 +558,7 @@ def generate_build_matrix(
     build_python_only: str,
     getting_started: str = "false",
     python_versions: Optional[List[str]] = None,
+    include_preview_python_versions: str = "disable",
 ) -> Dict[str, List[Dict[str, str]]]:
     includes = []
 
@@ -557,6 +588,8 @@ def generate_build_matrix(
                     use_only_dl_pytorch_org == "true",
                     getting_started == "true",
                     python_versions,
+                    include_preview_python_versions=include_preview_python_versions
+                    == ENABLE,
                 )
             )
 
@@ -658,6 +691,15 @@ def main(args: List[str]) -> None:
         default=os.getenv("PYTHON_VERSIONS", "[]"),
     )
 
+    parser.add_argument(
+        "--include-preview-python-versions",
+        help="Include opt-in preview python versions (torch-only, Linux x86 and "
+        "aarch64) in the matrix",
+        type=str,
+        choices=[ENABLE, DISABLE],
+        default=os.getenv("INCLUDE_PREVIEW_PYTHON_VERSIONS", DISABLE),
+    )
+
     options = parser.parse_args(args)
     try:
         python_versions = json.loads(options.python_versions)
@@ -681,6 +723,7 @@ def main(args: List[str]) -> None:
         options.build_python_only,
         options.getting_started,
         python_versions,
+        options.include_preview_python_versions,
     )
 
     print(json.dumps(build_matrix))

--- a/tools/tests/test_generate_binary_build_matrix.py
+++ b/tools/tests/test_generate_binary_build_matrix.py
@@ -126,6 +126,85 @@ class GenerateBuildMatrixTest(TestCase):
             reference_output_file="build_matrix_linux_wheel_xpu.json",
         )
 
+    def _test_channel_python_versions(
+        self,
+        operating_system: str,
+        include_preview: str = "disable",
+        channel: str = "test",
+    ) -> set:
+        out = generate_build_matrix(
+            "wheel",
+            operating_system,
+            channel,
+            "enable",
+            "enable" if operating_system in ("linux",) else "disable",
+            "enable",
+            "enable" if operating_system in ("linux", "windows") else "disable",
+            "false",
+            "false",
+            "disable",
+            "false",
+            None,
+            include_preview,
+        )
+        return {entry["python_version"] for entry in out["include"]}
+
+    def test_preview_python_versions_opt_in_on_linux(self):
+        # 3.15 / 3.15t are validated on Linux x86 and aarch64 for the test channel
+        # only when explicitly opted in.
+        for operating_system in ("linux", "linux-aarch64"):
+            versions = self._test_channel_python_versions(
+                operating_system, include_preview="enable"
+            )
+            self.assertIn("3.15", versions)
+            self.assertIn("3.15t", versions)
+
+    def test_preview_python_versions_off_by_default(self):
+        # Without opt-in the shared default is unchanged (e.g. torchvision builds).
+        for operating_system in ("linux", "linux-aarch64"):
+            versions = self._test_channel_python_versions(operating_system)
+            self.assertNotIn("3.15", versions)
+            self.assertNotIn("3.15t", versions)
+
+    def test_preview_python_versions_excluded_on_non_linux(self):
+        # Windows and macOS must not pick up the preview versions even when opted in.
+        for operating_system in ("windows", "macos"):
+            versions = self._test_channel_python_versions(
+                operating_system, include_preview="enable"
+            )
+            self.assertNotIn("3.15", versions)
+            self.assertNotIn("3.15t", versions)
+
+    def test_preview_python_versions_only_test_channel(self):
+        # Preview versions are defined for the test channel only.
+        versions = self._test_channel_python_versions(
+            "linux", include_preview="enable", channel="nightly"
+        )
+        self.assertNotIn("3.15", versions)
+        self.assertNotIn("3.15t", versions)
+
+    def test_torch_only_install_command_for_preview_arches(self):
+        out = generate_build_matrix(
+            "wheel",
+            "linux",
+            "test",
+            "enable",
+            "enable",
+            "enable",
+            "enable",
+            "false",
+            "false",
+            "disable",
+            "false",
+            None,
+            "enable",
+        )
+        for entry in out["include"]:
+            if entry["python_version"] in ("3.15", "3.15t"):
+                # torchvision is not published for these versions yet.
+                self.assertNotIn("torchvision", entry["installation"])
+                self.assertIn("torch", entry["installation"])
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Test generate build matrix")

--- a/tools/tests/test_generate_binary_build_matrix.py
+++ b/tools/tests/test_generate_binary_build_matrix.py
@@ -150,14 +150,15 @@ class GenerateBuildMatrixTest(TestCase):
         return {entry["python_version"] for entry in out["include"]}
 
     def test_preview_python_versions_opt_in_on_linux(self):
-        # 3.15 / 3.15t are validated on Linux x86 and aarch64 for the test channel
-        # only when explicitly opted in.
-        for operating_system in ("linux", "linux-aarch64"):
-            versions = self._test_channel_python_versions(
-                operating_system, include_preview="enable"
-            )
-            self.assertIn("3.15", versions)
-            self.assertIn("3.15t", versions)
+        # 3.15 / 3.15t are validated on Linux x86 and aarch64 for the nightly and
+        # test channels when explicitly opted in.
+        for channel in ("nightly", "test"):
+            for operating_system in ("linux", "linux-aarch64"):
+                versions = self._test_channel_python_versions(
+                    operating_system, include_preview="enable", channel=channel
+                )
+                self.assertIn("3.15", versions)
+                self.assertIn("3.15t", versions)
 
     def test_preview_python_versions_off_by_default(self):
         # Without opt-in the shared default is unchanged (e.g. torchvision builds).
@@ -175,10 +176,11 @@ class GenerateBuildMatrixTest(TestCase):
             self.assertNotIn("3.15", versions)
             self.assertNotIn("3.15t", versions)
 
-    def test_preview_python_versions_only_test_channel(self):
-        # Preview versions are defined for the test channel only.
+    def test_preview_python_versions_excluded_on_release_channel(self):
+        # Preview versions are defined for the nightly and test channels only,
+        # never for the release channel.
         versions = self._test_channel_python_versions(
-            "linux", include_preview="enable", channel="nightly"
+            "linux", include_preview="enable", channel="release"
         )
         self.assertNotIn("3.15", versions)
         self.assertNotIn("3.15t", versions)


### PR DESCRIPTION
## What
Forward-ports the **Python 3.15 / 3.15t** binary-validation enablement developed on `release/2.13` to `main`, so `main` also validates 3.15. Scoped as:
- **torch only** (no torchvision -- no 3.15 torchvision wheels yet),
- **Linux x86 + aarch64** only,
- the **nightly and test** channels,
- **opt-in**, so the shared generator default is unchanged for everyone else.

Extracted from release/2.13 commits #8214, #8216, #8222, #8227, #8230, #8239 -- **excluding the release-only bits**: the `pytorch/pytorch` checkout stays `ref: main` here (release/2.13 pinned it to `ref: release/2.13` for the cuDNN-version smoke check; that fix is not applicable to main).

## Changes
**`tools/scripts/generate_binary_build_matrix.py`**
- New `PREVIEW_PYTHON_ARCHES_DICT` (`3.15`/`3.15t` on the **nightly and test** channels; release excluded) and `TORCH_ONLY_PYTHON_ARCHES`. `PYTHON_ARCHES_DICT` default is **unchanged**, so torchvision/torchaudio, Windows and macOS matrices are byte-for-byte identical.
- `generate_wheels_matrix` appends preview versions only when `include_preview_python_versions` is enabled **and** `os in (linux, linux-aarch64)`.
- `get_wheel_install_command` emits `pip3 install torch ...` (no torchvision) for the preview versions.
- New `--include-preview-python-versions` flag / `INCLUDE_PREVIEW_PYTHON_VERSIONS` env.

**`.github/workflows/generate_binary_build_matrix.yml`** -- new `include-preview-python-versions` input (default `disable`).

**`validate-linux-binaries.yml` / `validate-aarch64-linux-binaries.yml`** -- set `include-preview-python-versions: enable` (the only change; `ref: main` untouched).

**`.github/scripts/validate_binaries.sh`**
- `get_python_config`: 3.15/3.15t conda-forge cases (`python_dev` + `python_rc` labels).
- Provision **CPython 3.15.0b1** (`3.15.0b1+freethreaded` for 3.15t) via **uv** instead of conda for 3.15/3.15t: the cp315 wheels are built against 3.15.0b1 while conda-forge only ships 3.15.0a8, whose pre-release ABI differs and segfaults on `import torch`.
- Force `TORCH_ONLY` for 3.15/3.15t (guarded with `:-` for the libtorch path).
- Skip the `torch.compile` smoke check on 3.15+ (unsupported there).

## Blast radius
- torchvision / torchaudio, Windows / macOS torch validation, release channel: **unaffected** (default unchanged; preview versions stripped off-channel / off-OS; release excluded).
- Only torch **Linux x86 + aarch64** validation on the **nightly and test** channels gains 3.15/3.15t.

## Test plan
- `python3 -m unittest tools.tests.test_generate_binary_build_matrix` -- **12 tests pass** (7 existing + 5 preview: opt-in adds 3.15/3.15t on linux & linux-aarch64 for nightly **and** test; off by default; excluded on windows/macos even when opted in; excluded on the release channel; torch-only install).
- `bash -n .github/scripts/validate_binaries.sh` passes.
- Verified generation delta: `--channel nightly`/`--channel test` `--operating-system linux` gains exactly `3.15`/`3.15t` only with `--include-preview-python-versions enable`; `--channel release` never does.

## Note
`black 25.11.0` locally wants to collapse one pre-existing wrapped line (`whl_install_command` for winarm64) that this PR does not touch; left as-is to match `main`'s current (lint-passing) formatting -- it's a black-version skew, not a change here.