### PR TITLE
[CI] Stop docker container after test and add XPU teardown step

### DIFF
--- a/.github/scripts/run_with_env_secrets.py
+++ b/.github/scripts/run_with_env_secrets.py
@@ -95,7 +95,10 @@ def main():
             .replace("\n", "")
             .strip()
         )
-        run_cmd_or_die(f"docker exec -t {container_name} /exec")
+        try:
+            run_cmd_or_die(f"docker exec -t {container_name} /exec")
+        finally:
+            subprocess.run(["docker", "stop", container_name], check=False)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -382,8 +382,12 @@ jobs:
           overwrite: true
 
       - name: Teardown Linux
-        if: always() && steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false'
+        if: always() && steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' && inputs.gpu-arch-type != 'xpu'
         uses: ./test-infra/.github/actions/teardown-linux
+
+      - name: Teardown XPU
+        uses: pytorch/pytorch/.github/actions/teardown-xpu@main
+        if: ${{ always() && inputs.gpu-arch-type == 'xpu' }}
 
       - name: Clean workspace after tear down
         if: always() && steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false'


### PR DESCRIPTION
Recently, we have enabled xpu ci test for pytorch/kineto with PR https://github.com/pytorch/kineto/pull/1302 by using `.github/workflow/linux_job_v2.yml`, but the tear-linux action in the workflow will stop and delete all containers on the runner.
Refer kineto xpu test https://github.com/pytorch/kineto/actions/runs/28540159218/job/84611618708#step:25:87 stopped and deleted pytorch xpu CI test containers https://github.com/pytorch/pytorch/actions/runs/28535668052/job/84601071341#step:15:1

## Changes Summary
- Stop the detached docker container after test execution completes in `run_with_env_secrets.py`, using `try/finally` with `subprocess.run(check=False)` to ensure cleanup without masking test failures.
- Add a dedicated Teardown XPU step in `linux_job_v2.yml`, mirroring the existing Setup Linux / Setup XPU pattern: skip `Teardown Linux` for XPU jobs and use `pytorch/pytorch/.github/actions/teardown-xpu@main` instead. Depends on PR https://github.com/pytorch/pytorch/pull/188769