### PR TITLE
[CRCR] Move CRCR link to top-level navbar

### DIFF
--- a/torchci/components/layout/NavBar.tsx
+++ b/torchci/components/layout/NavBar.tsx
@@ -79,10 +79,6 @@ function NavBar() {
       name: "ROCm test stats",
       href: "/rocm_test_stats",
     },
-    {
-      name: "CRCR CI Summary",
-      href: "/crcr",
-    },
   ].map((item) => ({
     label: item.name,
     route: item.href,
@@ -162,6 +158,11 @@ function NavBar() {
           <li>
             <Link prefetch={false} href="/hud/pytorch/helion/main">
               Helion
+            </Link>
+          </li>
+          <li>
+            <Link prefetch={false} href="/crcr">
+              CRCR
             </Link>
           </li>
         </ul>


### PR DESCRIPTION
## Summary

- Moves the CRCR CI Summary link from the Dev Infra dropdown to the top-level navigation bar, next to Helion
- CRCR is a cross-project system (not a Dev Infra internal tool), so it deserves the same visibility as PyTorch, ExecuTorch, TorchVision, TorchAudio, and Helion

## Changes

| File | Change |
|------|--------|
| `components/layout/NavBar.tsx` | Remove CRCR entry from `devInfraDropdown`, add as top-level `<li>` after Helion |

## Test plan

- Verify CRCR appears in the top-level navbar between Helion and Help
- Verify CRCR is no longer in the Dev Infra dropdown
- Verify clicking CRCR navigates to `/crcr`