### PR TITLE
PyPI staging: exclude pre-release 3.15 wheels and strip the 3.15 classifier

### DIFF
--- a/release/pypi/prep_binary_for_pypi.py
+++ b/release/pypi/prep_binary_for_pypi.py
@@ -17,6 +17,40 @@ import tempfile
 from pathlib import Path
 
 
+# PyPI validates trove classifiers against a fixed list and rejects unknown
+# ones. Python 3.15 is still pre-release and not yet a recognized classifier, so
+# wheels built with 3.15 support fail to upload with an "invalid classifier"
+# error. Strip these classifier values from the METADATA of every staged wheel.
+CLASSIFIERS_TO_REMOVE = frozenset(
+    {
+        "Programming Language :: Python :: 3.15",
+    }
+)
+
+
+def remove_disallowed_classifiers(metadata_file):
+    """Drop Classifier lines PyPI would reject (e.g. pre-release Python 3.15)."""
+    with open(metadata_file, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    kept = []
+    removed = []
+    for line in lines:
+        # METADATA classifier entries are formatted as "Classifier: <value>".
+        if line.startswith("Classifier:"):
+            value = line.split(":", 1)[1].strip()
+            if value in CLASSIFIERS_TO_REMOVE:
+                removed.append(value)
+                continue
+        kept.append(line)
+
+    if removed:
+        with open(metadata_file, "w", encoding="utf-8") as f:
+            f.writelines(kept)
+        for value in removed:
+            print(f"Removed disallowed classifier: {value}")
+
+
 def process_wheel(whl_file, output_dir=None):
     # Check if auditwheel is installed
     try:
@@ -105,6 +139,11 @@ def process_wheel(whl_file, output_dir=None):
                     except UnicodeDecodeError:
                         # Skip binary files
                         pass
+
+            # Strip classifiers PyPI will not accept (e.g. pre-release 3.15)
+            # before upload. Done while metadata_file still points at the
+            # current (pre-rename) dist-info directory.
+            remove_disallowed_classifiers(metadata_file)
 
             # Rename the dist-info directory
             new_dist_info_dir = dist_info_dir.replace(

--- a/release/pypi/upload_pypi_to_staging.sh
+++ b/release/pypi/upload_pypi_to_staging.sh
@@ -24,14 +24,15 @@ ARCH=${ARCH:-cpu}
 # This extract links to packages from the index.html
 # We strip all extra characters including final sha256 char
 echo "Retrieving packages for promotion for ${PACKAGE_NAME} ${PACKAGE_VERSION}"
-# Python 3.15 is still pre-release, so do not stage its wheels to PyPI. Both the
-# regular (cp315) and free-threaded (cp315t) 3.15 wheels carry the "-cp315"
-# interpreter tag in their filenames, so a single exclusion drops them all.
+# Python 3.15 is still pre-release, so do not stage its wheels to PyPI. Exclude
+# both the regular (cp315-cp315) and free-threaded (cp315-cp315t) 3.15 wheels:
+# the "-cp315-" clause drops both by interpreter tag, and the explicit "-cp315t-"
+# clause also drops any wheel tagged free-threaded by ABI.
 pkgs_to_promote=$(\
     curl -fsSL "https://download-s3.pytorch.org/whl/test/${ARCH}/${PACKAGE_NAME}/index.html" \
         | grep "${PACKAGE_NAME}-${PACKAGE_VERSION}${VERSION_SUFFIX}-" \
         | grep "${PLATFORM}" \
-        | grep -v -- "-cp315" \
+        | grep -Ev -- "-cp315-|-cp315t-" \
         | cut -d '"' -f2 \
         | cut -d "#" -f1
 )

--- a/release/pypi/upload_pypi_to_staging.sh
+++ b/release/pypi/upload_pypi_to_staging.sh
@@ -24,10 +24,14 @@ ARCH=${ARCH:-cpu}
 # This extract links to packages from the index.html
 # We strip all extra characters including final sha256 char
 echo "Retrieving packages for promotion for ${PACKAGE_NAME} ${PACKAGE_VERSION}"
+# Python 3.15 is still pre-release, so do not stage its wheels to PyPI. Both the
+# regular (cp315) and free-threaded (cp315t) 3.15 wheels carry the "-cp315"
+# interpreter tag in their filenames, so a single exclusion drops them all.
 pkgs_to_promote=$(\
     curl -fsSL "https://download-s3.pytorch.org/whl/test/${ARCH}/${PACKAGE_NAME}/index.html" \
         | grep "${PACKAGE_NAME}-${PACKAGE_VERSION}${VERSION_SUFFIX}-" \
         | grep "${PLATFORM}" \
+        | grep -v -- "-cp315" \
         | cut -d '"' -f2 \
         | cut -d "#" -f1
 )


### PR DESCRIPTION
## What
Two related changes to the PyPI staging path so pre-release Python 3.15 does not break / leak into PyPI uploads:

1. **Exclude cp315 / cp315t wheels from staging** (`release/pypi/upload_pypi_to_staging.sh`) -- 3.15 is pre-release, so its wheel files should not be promoted to PyPI at all.
2. **Strip the `Programming Language :: Python :: 3.15` classifier** from every staged wheel's METADATA (`release/pypi/prep_binary_for_pypi.py`) -- non-3.15 wheels can still *declare* the 3.15 classifier, which PyPI rejects.

## Why
- PyPI validates trove classifiers against a fixed list and **rejects unknown ones**; `Programming Language :: Python :: 3.15` is not recognized yet (pre-release), so any wheel declaring it fails to upload with an "invalid classifier" error.
- Independently, the actual 3.15 wheel binaries shouldn't be published to PyPI while the version is pre-release.

Both are easy to revert once 3.15 ships (drop the classifier from `CLASSIFIERS_TO_REMOVE` and remove the `-cp315` exclusion).

## How
**`upload_pypi_to_staging.sh`** -- add `grep -v -- "-cp315"` to the package-selection pipeline. Both regular (`cp315`) and free-threaded (`cp315t`) 3.15 wheels carry the `-cp315` interpreter tag, so one exclusion drops both; `cp310`..`cp314` (incl. `cp314t`) are untouched.

**`prep_binary_for_pypi.py`** -- new `remove_disallowed_classifiers(metadata_file)` + `CLASSIFIERS_TO_REMOVE` set. Called from `process_wheel` after the version-suffix rewrite and **before** the `.dist-info` rename (while `metadata_file` still resolves); auditwheel regenerates `RECORD` on context exit. Matches the **full** classifier value, so `:: 3`, `:: 3.1`, `:: 3.13`, `:: 3.14` and non-Python classifiers are left intact.

## Test plan
- `bash -n upload_pypi_to_staging.sh`, `python3 -m py_compile` + `black --check` on the prep script -- all clean.
- Filter check: a wheel list of `cp310 / cp314 / cp314t / cp315 / cp315t` passes through the exclusion leaving `cp310, cp314, cp314t` and dropping both `cp315` lines.
- Classifier check on a sample METADATA: only `:: 3.15` is dropped; `:: 3`, `:: 3.1`, `:: 3.13`, `:: 3.14` and other (`License ::`) classifiers preserved.

## Note
Both changes affect the staging path that repackages suffixed wheels (`VERSION_SUFFIX` set). Wheels moved through without repackaging (no version suffix) are not touched, matching existing behavior.