### PR TITLE
Remove TorchAudio from HUD top menu

### DIFF
--- a/torchci/components/layout/NavBar.tsx
+++ b/torchci/components/layout/NavBar.tsx
@@ -156,11 +156,6 @@ function NavBar() {
             </Link>
           </li>
           <li>
-            <Link prefetch={false} href="/hud/pytorch/audio/main">
-              TorchAudio
-            </Link>
-          </li>
-          <li>
             <Link prefetch={false} href="/hud/pytorch/helion/main">
               Helion
             </Link>


### PR DESCRIPTION
## Summary

torchaudio is currently in maintenance phase, so this removes its entry (`/hud/pytorch/audio/main`) from the HUD top navigation bar.

## Change

- Drop the `TorchAudio` `<li>` link from `torchci/components/layout/NavBar.tsx`.

No other references to the audio HUD in the nav are affected.