### PR TITLE
[CRCR] Display CRCR results as workflow boxes in the PR page

### DIFF
--- a/torchci/components/commit/CommitStatus.tsx
+++ b/torchci/components/commit/CommitStatus.tsx
@@ -1,4 +1,5 @@
 import styles from "components/commit/commit.module.css";
+import CrcrPrSection from "components/crcr/CrcrPrSection";
 import {
   isFailedJob,
   isRerunDisabledTestsJob,
@@ -184,6 +185,10 @@ export default function CommitStatus({
         unstableIssues={unstableIssues}
         repoFullName={`${repoOwner}/${repoName}`}
       />
+      {isCommitPage &&
+        commit.prNum != null &&
+        repoOwner === "pytorch" &&
+        repoName === "pytorch" && <CrcrPrSection prNumber={commit.prNum} />}
       {isCommitPage && (
         <WorkflowDispatcher
           repoOwner={repoOwner}

--- a/torchci/components/commit/commit.module.css
+++ b/torchci/components/commit/commit.module.css
@@ -33,6 +33,31 @@
   background-color: var(--workflow-box-pending-bg);
 }
 
+.crcrSection {
+  grid-column: 1 / -1;
+  border: 2px solid var(--color-crcr-border, #0288d1);
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.crcrBackendsGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 10px;
+}
+
+.crcrLevelBadge {
+  display: inline-block;
+  font-size: 0.6rem;
+  padding: 1px 5px;
+  border-radius: 8px;
+  border: 1px solid var(--color-crcr-border, #0288d1);
+  color: var(--color-crcr-border, #0288d1);
+  font-weight: 600;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
 .buttonBorder {
   border: 1px solid;
 }

--- a/torchci/components/crcr/CrcrPrSection.tsx
+++ b/torchci/components/crcr/CrcrPrSection.tsx
@@ -1,26 +1,15 @@
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Chip,
-  Link,
-  Stack,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Typography,
-} from "@mui/material";
+import { Stack, styled, Tooltip, Typography } from "@mui/material";
+import styles from "components/commit/commit.module.css";
 import { durationDisplay } from "components/common/TimeUtils";
+import JobConclusion from "components/job/JobConclusion";
 import { fetcher } from "lib/GeneralUtils";
-import { conclusionColor, conclusionLabel } from "lib/crcr/crcrUtils";
+import _ from "lodash";
+
 import useSWR from "swr";
 
 interface CrcrPrResult {
   downstream_repo: string;
+  downstream_repo_level: string;
   workflow_name: string;
   job_name: string;
   check_run_id: string;
@@ -36,6 +25,141 @@ interface CrcrPrResult {
   execution_time: number | null;
 }
 
+function crcrToConclusion(status: string, conclusion: string): string {
+  if (status === "in_progress") return "pending";
+  return conclusion || "pending";
+}
+
+function isFailedResult(r: CrcrPrResult): boolean {
+  return (
+    r.status === "completed" &&
+    r.conclusion !== "success" &&
+    r.conclusion !== "skipped"
+  );
+}
+
+const LinkButton = styled("a")({
+  fontSize: "8px",
+  padding: "0 2px",
+  color: "green",
+  margin: "2px",
+  border: "1px solid rgba(0,128,0,0.5)",
+  borderRadius: "3px",
+  textDecoration: "none",
+});
+
+function CrcrJobLine({ result }: { result: CrcrPrResult }) {
+  const conclusion = crcrToConclusion(result.status, result.conclusion);
+
+  const subInfo = [];
+  if (result.queue_time != null) {
+    subInfo.push(`Queued: ${durationDisplay(Math.max(result.queue_time, 0))}`);
+  }
+  if (result.status === "in_progress") {
+    subInfo.push("Running");
+  } else if (result.execution_time != null) {
+    subInfo.push(
+      `Duration: ${durationDisplay(Math.round(result.execution_time))}`
+    );
+  } else if (result.duration_seconds) {
+    subInfo.push(
+      `Duration: ${durationDisplay(Math.round(result.duration_seconds))}`
+    );
+  }
+
+  return (
+    <div>
+      <JobConclusion conclusion={conclusion} />
+      {result.workflow_run_url ? (
+        <a href={result.workflow_run_url} target="_blank" rel="noreferrer">
+          {" "}
+          {result.job_name}{" "}
+        </a>
+      ) : (
+        <span> {result.job_name} </span>
+      )}
+      <br />
+      <small>
+        &nbsp;&nbsp;&nbsp;&nbsp;
+        {subInfo.join(" ")}
+        {result.workflow_run_url && (
+          <>
+            {" "}
+            <LinkButton
+              href={result.workflow_run_url}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Run
+            </LinkButton>
+          </>
+        )}
+        {result.artifact_url && (
+          <LinkButton
+            href={result.artifact_url}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Artifacts
+          </LinkButton>
+        )}
+      </small>
+    </div>
+  );
+}
+
+function CrcrBackendBox({
+  repoName,
+  level,
+  results,
+}: {
+  repoName: string;
+  level: string;
+  results: CrcrPrResult[];
+}) {
+  const hasFailed = results.some(isFailedResult);
+  const hasPending = results.some((r) => r.status === "in_progress");
+
+  const boxClass = hasFailed
+    ? styles.workflowBoxFail
+    : hasPending
+    ? styles.workflowBoxPending
+    : styles.workflowBoxSuccess;
+
+  const sorted = _.orderBy(
+    results,
+    [
+      (r) => {
+        if (isFailedResult(r)) return 0;
+        if (r.status === "in_progress") return 1;
+        return 2;
+      },
+      (r) => r.job_name,
+    ],
+    ["asc", "asc"]
+  );
+
+  return (
+    <div className={boxClass}>
+      <Typography variant="h6" fontWeight="bold" paddingTop={2}>
+        <a
+          href={`/crcr/${repoName.replace("/", "/")}`}
+          style={{ color: "inherit", textDecoration: "none" }}
+        >
+          {repoName}
+        </a>
+        <span className={styles.crcrLevelBadge}>{level}</span>
+      </Typography>
+      <Typography fontWeight="bold" paddingBottom={2}>
+        Job Status
+      </Typography>
+      {sorted.map((r, i) => (
+        <CrcrJobLine key={`${r.check_run_id}-${i}`} result={r} />
+      ))}
+    </div>
+  );
+}
+
 export default function CrcrPrSection({ prNumber }: { prNumber: number }) {
   const url = `/api/clickhouse/crcr_pr_results?parameters=${encodeURIComponent(
     JSON.stringify({ pr: String(prNumber) })
@@ -46,100 +170,50 @@ export default function CrcrPrSection({ prNumber }: { prNumber: number }) {
 
   if (error || !data || data.length === 0) return null;
 
-  const successCount = data.filter(
-    (r) => r.status === "completed" && r.conclusion === "success"
-  ).length;
-  const totalCompleted = data.filter((r) => r.status === "completed").length;
-  const inProgress = data.filter((r) => r.status === "in_progress").length;
+  const byRepo = _.groupBy(data, "downstream_repo");
+  const repoNames = Object.keys(byRepo).sort();
 
-  const summaryText = [
-    totalCompleted > 0 ? `${successCount}/${totalCompleted} passed` : null,
-    inProgress > 0 ? `${inProgress} running` : null,
-  ]
-    .filter(Boolean)
-    .join(", ");
+  const totalBackends = repoNames.length;
 
   return (
-    <Accordion defaultExpanded={false} sx={{ mt: 2 }}>
-      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-        <Stack direction="row" spacing={1} alignItems="center">
-          <Typography variant="subtitle1">
-            <strong>Cross-Repo CI Backends</strong>
+    <div className={styles.crcrSection}>
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
+        <Typography variant="h6" fontWeight="bold">
+          Cross-Repo CI Backends
+        </Typography>
+        <Tooltip title="Results from downstream CI backends via the Cross-Repository CI Relay (CRCR)">
+          <Typography
+            sx={{
+              fontSize: "0.7rem",
+              px: 1,
+              py: 0.25,
+              borderRadius: "10px",
+              bgcolor: "#0288d1",
+              color: "#fff",
+              fontWeight: 600,
+            }}
+          >
+            CRCR
           </Typography>
-          <Typography variant="body2" color="text.secondary">
-            ({summaryText})
-          </Typography>
-        </Stack>
-      </AccordionSummary>
-      <AccordionDetails>
-        <TableContainer>
-          <Table size="small">
-            <TableHead>
-              <TableRow>
-                <TableCell>
-                  <strong>Backend</strong>
-                </TableCell>
-                <TableCell>
-                  <strong>Job</strong>
-                </TableCell>
-                <TableCell align="center">
-                  <strong>Status</strong>
-                </TableCell>
-                <TableCell align="right">
-                  <strong>Duration</strong>
-                </TableCell>
-                <TableCell>
-                  <strong>Links</strong>
-                </TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {data.map((row, i) => (
-                <TableRow key={i} hover>
-                  <TableCell>{row.downstream_repo}</TableCell>
-                  <TableCell>{row.job_name}</TableCell>
-                  <TableCell align="center">
-                    <Chip
-                      label={conclusionLabel(row.status, row.conclusion)}
-                      color={conclusionColor(row.status, row.conclusion)}
-                      size="small"
-                    />
-                  </TableCell>
-                  <TableCell align="right">
-                    {row.duration_seconds
-                      ? durationDisplay(Math.round(row.duration_seconds))
-                      : "–"}
-                  </TableCell>
-                  <TableCell>
-                    <Stack direction="row" spacing={1}>
-                      {row.workflow_run_url && (
-                        <Link
-                          href={row.workflow_run_url}
-                          target="_blank"
-                          rel="noopener"
-                          variant="body2"
-                        >
-                          Run
-                        </Link>
-                      )}
-                      {row.artifact_url && (
-                        <Link
-                          href={row.artifact_url}
-                          target="_blank"
-                          rel="noopener"
-                          variant="body2"
-                        >
-                          Artifacts
-                        </Link>
-                      )}
-                    </Stack>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      </AccordionDetails>
-    </Accordion>
+        </Tooltip>
+        <Typography variant="body2" color="text.secondary">
+          ({totalBackends} backend{totalBackends !== 1 ? "s" : ""} dispatched)
+        </Typography>
+      </Stack>
+      <div className={styles.crcrBackendsGrid}>
+        {repoNames.map((repo) => {
+          const results = byRepo[repo];
+          const level = results[0]?.downstream_repo_level || "L2";
+          return (
+            <CrcrBackendBox
+              key={repo}
+              repoName={repo}
+              level={level}
+              results={results}
+            />
+          );
+        })}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- Replaces the collapsed accordion+table rendering of Cross-Repo CI results with native workflow boxes inside the Workflows grid on the PR page
- Each downstream CRCR backend gets its own workflow box (with level badge, conclusion chars, timing info, and action links), grouped under a full-width "Cross-Repo CI Backends" section
- Passes `prNumber` through the component chain (`[prNumber].tsx` → `CommitInfo` → `CommitStatus` → `WorkflowsContainer`) so CRCR data can be fetched and rendered inline

### Files changed

| File | Change |
|------|--------|
| `torchci/components/crcr/CrcrPrSection.tsx` | Rewritten from MUI Accordion+Table to workflow-box style rendering with `JobConclusion` chars, grouped by `downstream_repo` |
| `torchci/components/commit/CommitStatus.tsx` | Added `prNumber` prop, renders `CrcrPrSection` inside the workflow grid for `pytorch/pytorch` |
| `torchci/components/commit/CommitInfo.tsx` | Passes `prNumber` through to `CommitStatus` |
| `torchci/pages/[repoOwner]/[repoName]/pull/[prNumber].tsx` | Passes `prNumber` to `CommitInfo` |
| `torchci/components/commit/commit.module.css` | Added `.crcrSection`, `.crcrBackendsGrid`, `.crcrLevelBadge` CSS classes |

### Mockup

[PR Workflows Mockup](https://subinz1.github.io/rfcs/RFC-0054-assets/oot-hud-mockup-pr-workflows.html)

## Test plan

- [ ] Verify CRCR section renders inside the Workflows grid on a pytorch/pytorch PR page (e.g., `/pr/188793`)
- [ ] Verify each downstream backend appears as a separate workflow box with correct conclusion chars
- [ ] Verify the CRCR section spans both grid columns with the blue border
- [ ] Verify non-pytorch/pytorch PRs do not show the CRCR section
- [ ] Verify commit pages (not PR pages) do not show the CRCR section
- [ ] Verify the existing workflow boxes (pull, trunk, Lint, etc.) are unaffected