### PR TITLE
Disable R2, use download.pytorch.org everywhere (R2 outage toggle)

### DIFF
--- a/s3_management/manage_v2.py
+++ b/s3_management/manage_v2.py
@@ -443,36 +443,22 @@ PT_FOUNDATION_PACKAGES = {
 # Packages that should use R2 (download-r2.pytorch.org) for nightly builds
 # These packages will have their URLs point to R2 instead of S3/CloudFront
 # when the path is whl/nightly
-PT_R2_PACKAGES = {
-    "torch",
-    "torchvision",
-    "torchaudio",
-    "fbgemm_gpu",
-    "fbgemm_gpu_genai",
-    "triton",
-    "triton_rocm",
-    "triton_xpu",
-    "pytorch_triton",
-    "pytorch_triton_rocm",
-    "pytorch_triton_xpu",
-}
+# R2 DISABLED - original packages commented out during R2 outage;
+# foundation packages fall back to download.pytorch.org (relative/S3 URLs):
+#     "torch", "torchvision", "torchaudio", "fbgemm_gpu", "fbgemm_gpu_genai",
+#     "triton", "triton_rocm", "triton_xpu",
+#     "pytorch_triton", "pytorch_triton_rocm", "pytorch_triton_xpu"
+PT_R2_PACKAGES: set[str] = set()
 
 # Packages that should use R2 (download-r2.pytorch.org) for prod/stable builds
 # These packages will have their URLs point to R2 instead of S3/CloudFront
 # when the path is NOT whl/test and NOT whl/nightly (i.e., prod)
-PT_R2_PACKAGES_PROD = {
-    "torch",
-    "torchaudio",
-    "torchvision",
-    "fbgemm_gpu",
-    "fbgemm_gpu_genai",
-    "triton",
-    "triton_rocm",
-    "triton_xpu",
-    "pytorch_triton",
-    "pytorch_triton_rocm",
-    "pytorch_triton_xpu",
-}
+# R2 DISABLED - original packages commented out during R2 outage;
+# foundation packages fall back to download.pytorch.org (relative/S3 URLs):
+#     "torch", "torchaudio", "torchvision", "fbgemm_gpu", "fbgemm_gpu_genai",
+#     "triton", "triton_rocm", "triton_xpu",
+#     "pytorch_triton", "pytorch_triton_rocm", "pytorch_triton_xpu"
+PT_R2_PACKAGES_PROD: set[str] = set()
 
 # Packages that should have their root index.html copied to subdirectories
 # instead of processing wheels in subdirectories


### PR DESCRIPTION
## Summary

Disables Cloudflare R2 (`download-r2.pytorch.org`) URL generation for the
PyTorch foundation packages so that **all** download index URLs point at
`download.pytorch.org` (S3/CloudFront) instead of R2. Intended as the
"R2 outage toggle" fallback during an R2/Cloudflare outage.

This empties both routing sets in `s3_management/manage_v2.py`:

- `PT_R2_PACKAGES` — controls R2 URLs for **nightly** builds (`whl/nightly`)
- `PT_R2_PACKAGES_PROD` — controls R2 URLs for **prod/stable** builds

With both sets empty, foundation packages (`torch`, `torchvision`,
`torchaudio`, `fbgemm_gpu`, `fbgemm_gpu_genai`, `triton`, `triton_rocm`,
`triton_xpu`, `pytorch_triton`, `pytorch_triton_rocm`, `pytorch_triton_xpu`)
fall through the routing logic in `to_simple_package_html` to
`base_url = ""` (relative URLs served from `download.pytorch.org`).

The original set contents are preserved as comments so R2 can be
re-enabled easily once the outage is resolved.

## Notes

- Only URL routing is changed. The `to_simple_package_html` routing logic
  is untouched — it handles empty sets naturally.
- R2 index *mirroring* (upload, gated on `R2_BUCKET` credentials) is left
  as-is; only the URLs written into the indexes change.

## Deployment

This change only modifies the source file. To take effect:
1. Land this change.
2. Re-run index generation: `python s3_management/manage_v2.py all`
   (or target `whl/nightly` / `whl` prefixes as needed).

The regenerated index HTML will use `download.pytorch.org` (relative/S3)
URLs for foundation packages instead of `download-r2.pytorch.org`.
