### PR TITLE
Fix LF rollover metric to count both `lf.` and `lf-` runner labels

### DIFF
--- a/torchci/clickhouse_queries/lf_rollover_percentage/query.sql
+++ b/torchci/clickhouse_queries/lf_rollover_percentage/query.sql
@@ -1,9 +1,8 @@
 WITH
     normalized_jobs AS (
         SELECT
-            l AS label,
             extract(j.name, '[^,]*') AS job_name, -- Remove shard number and label from job names
-            j.workflow_name,
+            match(l, '^lf[.-]') AS is_lf,
             DATE_TRUNC({granularity: String}, j.created_at) AS bucket
         FROM
             -- Deliberatly not adding FINAL to this workflow_job.
@@ -26,67 +25,32 @@ WITH
             AND l NOT LIKE 'lf.c.%'
             AND l NOT LIKE '%.canary'
             AND l NOT LIKE 'c.%'
+            AND l NOT LIKE 'c-%'
     ),
     lf_jobs AS (
         SELECT
-            DISTINCT j.job_name
+            DISTINCT job_name
         FROM
-            normalized_jobs AS j
+            normalized_jobs
         WHERE
-            j.label LIKE 'lf.%'
+            is_lf
     ),
     comparable_jobs AS (
         SELECT
             j.bucket,
-            j.label,
-            j.job_name,
-            j.workflow_name
+            j.is_lf
         FROM
             normalized_jobs AS j
         INNER JOIN
             lf_jobs AS lfj ON j.job_name = lfj.job_name
     ),
-    success_stats AS (
-        SELECT
-            count(*) AS group_size,
-            bucket,
-            replaceOne(label, 'lf.', '') AS label_ref,
-            if(substring(label, 1, 3) = 'lf.', True, False) AS lf_fleet
-        FROM
-            comparable_jobs
-        GROUP BY
-            bucket, label_ref, lf_fleet
-    ),
-    lf_success_stats AS (
-        SELECT
-            *
-        FROM
-            success_stats
-        WHERE
-            lf_fleet = True
-    ),
-    meta_success_stats AS (
-        SELECT
-            *
-        FROM
-            success_stats
-        WHERE
-            lf_fleet = False
-    ),
     comparison_stats AS (
         SELECT
-            -- *
-            greatest(lf.bucket, m.bucket) AS bucket,
-            CAST(SUM(lf.group_size) AS Float32) / SUM(lf.group_size + m.group_size) * 100 AS percentage,
-            -- IF(lf.lf_fleet, 'Linux Foundation', 'Meta') AS fleet
-            'Linux Fundation' AS fleet
+            bucket,
+            CAST(countIf(is_lf) AS Float32) / count(*) * 100 AS percentage,
+            'Linux Foundation' AS fleet
         FROM
-            lf_success_stats AS lf
-        FULL OUTER JOIN
-            meta_success_stats AS m
-        ON
-            lf.label_ref = m.label_ref
-            AND lf.bucket = m.bucket
+            comparable_jobs
         GROUP BY
             bucket
     )


### PR DESCRIPTION
**Impact:** HUD `/metrics` "Percentage of jobs rolled over to Linux Foundation" panel only
**Risk:** low

## What
Updates the `lf_rollover_percentage` ClickHouse query to classify Linux Foundation jobs by both the `lf.` (dot) and `lf-` (dash) label prefixes, excludes the new `c-` dash canary form, and fixes the `Linux Fundation` → `Linux Foundation` typo on the series label.

## Why
LF runners started migrating from `lf.` to `lf-` labels around June 7, 2026. The classifier only matched the dot prefix, so roughly 79% of LF jobs (the `lf-…` ones) were silently counted as Meta. From mid-June the panel showed LF rollout collapsing to ~1–2% when it had actually grown — it was just renamed. With the fix the metric reads ~18–29% in the dash era.

# Notes
- The output contract (`bucket`, `fleet`, `percentage` + the three params) is unchanged, so the panel, query loader, and CI are unaffected.
- The LF-vs-Meta `FULL OUTER JOIN` was removed and replaced with a direct per-bucket conditional ratio. Verified to produce numerically identical output (diff = 0 across every bucket) while dropping a silent dependency on the server's `join_use_nulls` setting; the LF-prefix rule is now consolidated into a single `is_lf` column.
- Kept single-series (LF% only) intentionally — Meta% = 100 − LF%, so one line encodes both. This matches the earlier deliberate removal of the two-series variant in commit e2efc3869.
- Known limitation (not changed here): the "Meta" side of the denominator is mostly un-prefixed EC2, not strictly `mt-`, so the metric is "LF share of all comparable runs" rather than a strict `lf-` vs `mt-` head-to-head. A true fleet-vs-fleet comparison would be a separate product change.