### PR TITLE
Fix "Claude append system prompt" envvar

### DIFF
--- a/.github/workflows/_claude-code.yml
+++ b/.github/workflows/_claude-code.yml
@@ -186,7 +186,7 @@ jobs:
           claude_args: "--model ${{ inputs.model }} ${{ inputs.additional_claude_args }} ${{ steps.ghstack-check.outputs.extra_claude_args }}"
           settings: ${{ inputs.settings }}
         env:
-          INPUT_APPEND_SYSTEM_PROMPT: |
+          APPEND_SYSTEM_PROMPT: |
               ${{ steps.ghstack-check.outputs.ghstack_notice }}
               ${{ inputs.append_system_prompt }}
 


### PR DESCRIPTION
The envvar for this is actually APPEND_SYSTEM_PROMPT, not INPUT_APPEND_SYSTEM_PROMPT.

Evidence:
- https://github.com/anthropics/claude-code-action/blob/593d7a5c4e0073569f74772c2b7b64c30ec14707/src/entrypoints/run.ts#L283-L286

Context:
- getting https://github.com/pytorch/pytorch/pull/188418 to work

Authored with assistance from an AI assistant.