### PR TITLE
Make HUD settings URL-shareable with tri-state toggles

### DIFF
--- a/torchci/components/common/OptionRow.tsx
+++ b/torchci/components/common/OptionRow.tsx
@@ -1,0 +1,164 @@
+import CheckIcon from "@mui/icons-material/Check";
+import CloseIcon from "@mui/icons-material/Close";
+import RemoveIcon from "@mui/icons-material/Remove";
+import {
+  Switch,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  useTheme,
+} from "@mui/material";
+import { TriState } from "lib/types";
+
+// Shared column widths so the header lines up with each row.
+const TOGGLE_COL_WIDTH = 116;
+const PERSIST_COL_WIDTH = 48;
+
+/**
+ * Header row for the "Options" panel, labeling the three columns: the tri-state
+ * toggle (the value used for the current page), the option name, and the persist
+ * switch (the saved default). Column widths match OptionRow so they align.
+ */
+export function OptionRowHeader() {
+  const theme = useTheme();
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "flex-end",
+        gap: "0.5rem",
+        fontSize: "0.7rem",
+        fontWeight: 600,
+        textTransform: "uppercase",
+        letterSpacing: "0.03em",
+        color: theme.palette.text.secondary,
+        borderBottom: `1px solid ${theme.palette.divider}`,
+        paddingBottom: "0.25rem",
+        marginBottom: "0.25rem",
+      }}
+    >
+      <span style={{ width: TOGGLE_COL_WIDTH, textAlign: "center" }}>
+        This page
+      </span>
+      <span style={{ flex: 1 }}>Option</span>
+      <span style={{ width: PERSIST_COL_WIDTH, textAlign: "center" }}>
+        Default
+      </span>
+    </div>
+  );
+}
+
+/**
+ * A single row in the HUD "Options" panel. It combines:
+ *  - a tri-state toggle (Off / Default / On) whose value lives in the URL
+ *    ("default" means "not in the URL", so it falls back to the persisted value)
+ *  - a "persist" switch that writes the localStorage default used whenever the
+ *    toggle is in the "default" state.
+ *
+ * Uses off-the-shelf MUI ToggleButtonGroup + Switch so it inherits theming.
+ */
+export default function OptionRow({
+  label,
+  urlState,
+  setUrlState,
+  persist,
+  setPersist,
+  disabled = false,
+  title,
+}: {
+  label: string;
+  urlState: TriState;
+  setUrlState: (_value: TriState) => void;
+  persist: boolean;
+  setPersist: (_value: boolean) => void;
+  disabled?: boolean;
+  title?: string;
+}) {
+  const theme = useTheme();
+  const success = theme.palette.success.main;
+  const error = theme.palette.error.main;
+
+  const row = (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "0.5rem",
+        opacity: disabled ? 0.5 : 1,
+        cursor: disabled ? "not-allowed" : "default",
+      }}
+    >
+      <ToggleButtonGroup
+        exclusive
+        size="small"
+        value={urlState}
+        disabled={disabled}
+        onChange={(_e, value) => {
+          // MUI passes null when the already-selected button is clicked again;
+          // ignore that so a button can't be deselected into an invalid state.
+          if (value !== null) {
+            setUrlState(value as TriState);
+          }
+        }}
+        aria-label={label}
+        sx={{ width: TOGGLE_COL_WIDTH }}
+      >
+        <ToggleButton
+          value="off"
+          aria-label="off"
+          sx={{
+            flex: 1,
+            padding: "2px",
+            "&.Mui-selected": { color: error },
+          }}
+        >
+          <CloseIcon fontSize="small" />
+        </ToggleButton>
+        <ToggleButton
+          value="default"
+          aria-label="default"
+          sx={{ flex: 1, padding: "2px" }}
+        >
+          <RemoveIcon fontSize="small" />
+        </ToggleButton>
+        <ToggleButton
+          value="on"
+          aria-label="on"
+          sx={{
+            flex: 1,
+            padding: "2px",
+            "&.Mui-selected": { color: success },
+          }}
+        >
+          <CheckIcon fontSize="small" />
+        </ToggleButton>
+      </ToggleButtonGroup>
+      <span style={{ flex: 1, whiteSpace: "nowrap" }}>{label}</span>
+      <Tooltip title="Persist as your default (used when the toggle is in the middle/default state)">
+        <span
+          style={{
+            width: PERSIST_COL_WIDTH,
+            display: "flex",
+            justifyContent: "center",
+          }}
+        >
+          <Switch
+            size="small"
+            checked={persist}
+            disabled={disabled}
+            onChange={(e) => setPersist(e.target.checked)}
+            inputProps={{ "aria-label": `persist ${label}` }}
+          />
+        </span>
+      </Tooltip>
+    </div>
+  );
+
+  return title ? (
+    <Tooltip title={title}>
+      <span>{row}</span>
+    </Tooltip>
+  ) : (
+    row
+  );
+}

--- a/torchci/components/job/GroupJobConclusion.tsx
+++ b/torchci/components/job/GroupJobConclusion.tsx
@@ -14,7 +14,7 @@ import {
   isUnstableJob,
 } from "lib/jobUtils";
 import { IssueData, JobData, RowData } from "lib/types";
-import { useHideNonViableStrictPreference } from "lib/useGroupingPreference";
+import { useHudOption } from "lib/useGroupingPreference";
 import {
   MonsterFailuresContext,
   PinnedTooltipContext,
@@ -160,7 +160,9 @@ export default function HudGroupedCell({
 }) {
   const [pinnedId, setPinnedId] = useContext(PinnedTooltipContext);
   const [monsterFailures] = useContext(MonsterFailuresContext);
-  const [hideNonViableStrict] = useHideNonViableStrictPreference();
+  const { effective: hideNonViableStrict } = useHudOption(
+    "hideNonViableStrict"
+  );
 
   // When hiding non-viable-strict, restrict the group's status calculation
   // (and tooltip contents) to viable/strict-blocking jobs only — otherwise a

--- a/torchci/lib/fetchHud.ts
+++ b/torchci/lib/fetchHud.ts
@@ -125,10 +125,10 @@ export default async function fetchHud(
       jobsBySha[job.sha!] = {};
     }
     let key = job.name!;
-    if (params.mergeEphemeralLF) {
+    if (params.mergeEphemeralLF === "on") {
       key = getNameWithoutLF(key);
     }
-    if (params.mergeOSDC) {
+    if (params.mergeOSDC === "on") {
       key = getNameWithoutOSDC(key);
     }
 

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -121,6 +121,59 @@ export interface IssueData {
   labels: string[];
 }
 
+// A HUD option is tri-state: "on"/"off" come from the URL and override
+// everything; "default" means the URL says nothing, so the value falls back to
+// localStorage (the user's persisted default) and finally the server default.
+// "default" is NEVER serialized into a URL.
+export type TriState = "on" | "off" | "default";
+
+export function parseTriState(value: any): TriState {
+  if (value === "true" || value === true) {
+    return "on";
+  }
+  if (value === "false" || value === false) {
+    return "off";
+  }
+  return "default";
+}
+
+export function resolveTriState(
+  state: TriState,
+  stored: boolean | undefined,
+  serverDefault: boolean
+): boolean {
+  if (state === "on") {
+    return true;
+  }
+  if (state === "off") {
+    return false;
+  }
+  return stored ?? serverDefault;
+}
+
+// Maps each tri-state HudParams field to its URL query key.
+export const HUD_OPTION_URL_KEYS = {
+  useGrouping: "grouped",
+  monsterFailures: "monster",
+  hideUnstable: "hide_unstable",
+  hideGreenColumns: "hide_green",
+  hideNonViableStrict: "hide_non_viable_strict",
+  hideAlwaysSkipped: "hide_always_skipped",
+  mergeEphemeralLF: "mergeEphemeralLF",
+  mergeOSDC: "mergeOSDC",
+} as const;
+
+export type HudOptionKey = keyof typeof HUD_OPTION_URL_KEYS;
+
+// Options whose value changes the server-side data fetch (job-name merging).
+// These are serialized into both the fetch URL and the shareable route URL; all
+// other options are client-only and only serialized into the route URL (so they
+// don't needlessly bust the data-fetch cache key).
+export const FETCH_RELEVANT_OPTIONS: HudOptionKey[] = [
+  "mergeEphemeralLF",
+  "mergeOSDC",
+];
+
 export interface HudParams {
   repoOwner: string;
   repoName: string;
@@ -130,9 +183,16 @@ export interface HudParams {
   nameFilter?: string;
   filter_reruns: boolean;
   filter_unstable: boolean;
-  mergeEphemeralLF?: boolean;
-  mergeOSDC?: boolean;
   useRegexFilter?: boolean;
+  // Tri-state options (see TriState above).
+  useGrouping: TriState;
+  monsterFailures: TriState;
+  hideUnstable: TriState;
+  hideGreenColumns: TriState;
+  hideNonViableStrict: TriState;
+  hideAlwaysSkipped: TriState;
+  mergeEphemeralLF: TriState;
+  mergeOSDC: TriState;
 }
 
 export function isPyTorchPyTorchRepo(params: HudParams): boolean {
@@ -295,9 +355,23 @@ export function packHudParams(input: any) {
     nameFilter: input.name_filter as string | undefined,
     filter_reruns: input.filter_reruns ?? (false as boolean),
     filter_unstable: input.filter_unstable ?? (false as boolean),
-    mergeEphemeralLF: input.mergeEphemeralLF as boolean,
-    mergeOSDC: input.mergeOSDC as boolean,
     useRegexFilter: input.useRegexFilter === "true",
+    useGrouping: parseTriState(input[HUD_OPTION_URL_KEYS.useGrouping]),
+    monsterFailures: parseTriState(input[HUD_OPTION_URL_KEYS.monsterFailures]),
+    hideUnstable: parseTriState(input[HUD_OPTION_URL_KEYS.hideUnstable]),
+    hideGreenColumns: parseTriState(
+      input[HUD_OPTION_URL_KEYS.hideGreenColumns]
+    ),
+    hideNonViableStrict: parseTriState(
+      input[HUD_OPTION_URL_KEYS.hideNonViableStrict]
+    ),
+    hideAlwaysSkipped: parseTriState(
+      input[HUD_OPTION_URL_KEYS.hideAlwaysSkipped]
+    ),
+    mergeEphemeralLF: parseTriState(
+      input[HUD_OPTION_URL_KEYS.mergeEphemeralLF]
+    ),
+    mergeOSDC: parseTriState(input[HUD_OPTION_URL_KEYS.mergeOSDC]),
   };
 }
 
@@ -334,20 +408,26 @@ function formatHudURL(
     base += `&filter_unstable=true`;
   }
 
+  // Serialize tri-state options. "default" is never written to a URL; only
+  // explicit "on"/"off" appear (as true/false). The shareable route URL carries
+  // every option, while the data-fetch URL only carries options that change what
+  // the server returns (so client-only toggles don't bust the fetch cache key).
+  (Object.keys(HUD_OPTION_URL_KEYS) as HudOptionKey[]).forEach((key) => {
+    if (!keepFilter && !FETCH_RELEVANT_OPTIONS.includes(key)) {
+      return;
+    }
+    const state = params[key];
+    if (state === "on" || state === "off") {
+      base += `&${HUD_OPTION_URL_KEYS[key]}=${state === "on"}`;
+    }
+  });
+
   if (params.nameFilter != null && keepFilter) {
     base += `&name_filter=${encodeURIComponent(params.nameFilter)}`;
   }
 
   if (params.useRegexFilter && keepFilter) {
     base += `&useRegexFilter=true`;
-  }
-
-  if (params.mergeEphemeralLF) {
-    base += `&mergeEphemeralLF=true`;
-  }
-
-  if (params.mergeOSDC) {
-    base += `&mergeOSDC=true`;
   }
 
   // Preserve autorevert view params so router.push doesn't strip them.

--- a/torchci/lib/useGroupingPreference.tsx
+++ b/torchci/lib/useGroupingPreference.tsx
@@ -1,4 +1,12 @@
+import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import {
+  HUD_OPTION_URL_KEYS,
+  HudOptionKey,
+  parseTriState,
+  resolveTriState,
+  TriState,
+} from "./types";
 
 /**
  * A hook to manage a boolean preference in local storage.
@@ -32,72 +40,99 @@ export function usePreference(
   return [state, setStatePersist, setState];
 }
 
-export function useGroupingPreference(
-  nameFilter: string | undefined | null
-): [boolean, (_grouping: boolean) => void] {
-  const hasNameFilter =
-    nameFilter !== "" && nameFilter !== null && nameFilter !== undefined;
-  const override = hasNameFilter ? false : undefined;
-  const [state, setState, setStateTemp] = usePreference(
-    "useGrouping",
-    override
-  );
-  useEffect(() => {
-    if (hasNameFilter) {
-      // Manually set grouping to be false if there is a name filter on first
-      // load.  Without this setState, if you enter a filter, check use
-      // grouping, then enter another filter, it will still be grouped
-      setStateTemp(false);
-    }
-  }, [nameFilter]);
-
-  return [state, setState];
+/**
+ * Configuration for each tri-state HUD option. `localStorageKey` is where the
+ * persisted default lives (used when the URL doesn't pin the option on/off), and
+ * `serverDefault` is the hardcoded fallback used on a brand-new browser with no
+ * saved preference. `pytorchOnly` options are no-ops outside pytorch/pytorch.
+ */
+export interface HudOptionConfig {
+  key: HudOptionKey;
+  localStorageKey: string;
+  serverDefault: boolean;
+  label: string;
+  pytorchOnly?: boolean;
 }
 
-export function useMonsterFailuresPreference(): [
-  boolean,
-  (_useMonsterFailuresValue: boolean) => void
-] {
-  const [state, setState] = usePreference(
-    "useMonsterFailures",
-    /*override*/ undefined,
-    /*default*/ false
-  );
-  return [state, setState];
-}
+// Display order of the rows in the "Options" settings panel.
+export const HUD_OPTIONS: HudOptionConfig[] = [
+  {
+    key: "hideUnstable",
+    localStorageKey: "hideUnstable",
+    serverDefault: true,
+    label: "Hide unstable jobs",
+  },
+  {
+    key: "hideGreenColumns",
+    localStorageKey: "hideGreenColumns",
+    serverDefault: false,
+    label: "Hide green columns",
+  },
+  {
+    key: "hideNonViableStrict",
+    localStorageKey: "hideNonViableStrict",
+    serverDefault: true,
+    label: "Hide non-viable-strict jobs",
+    pytorchOnly: true,
+  },
+  {
+    key: "hideAlwaysSkipped",
+    localStorageKey: "hideAlwaysSkipped",
+    serverDefault: true,
+    label: "Hide always-skipped jobs",
+  },
+  {
+    key: "useGrouping",
+    localStorageKey: "useGrouping",
+    serverDefault: true,
+    label: "Use grouped view",
+  },
+  {
+    key: "monsterFailures",
+    localStorageKey: "useMonsterFailures",
+    serverDefault: false,
+    label: "Monsterize failures",
+  },
+  {
+    key: "mergeEphemeralLF",
+    localStorageKey: "mergeLF",
+    serverDefault: false,
+    label: "Condense LF, ephemeral jobs",
+  },
+  {
+    key: "mergeOSDC",
+    localStorageKey: "mergeOSDC",
+    serverDefault: false,
+    label: "Condense OSDC, non-OSDC jobs",
+  },
+];
 
-export function useHideGreenColumnsPreference(): [
-  boolean,
-  (_hideGreenColumnsValue: boolean) => void
-] {
-  const [state, setState] = usePreference(
-    "hideGreenColumns",
-    /*override*/ undefined,
-    /*default*/ false
-  );
-  return [state, setState];
-}
+export const HUD_OPTIONS_BY_KEY: Record<HudOptionKey, HudOptionConfig> =
+  Object.fromEntries(HUD_OPTIONS.map((o) => [o.key, o])) as Record<
+    HudOptionKey,
+    HudOptionConfig
+  >;
 
-export function useHideNonViableStrictPreference(): [
-  boolean,
-  (_hideNonViableStrictValue: boolean) => void
-] {
-  const [state, setState] = usePreference(
-    "hideNonViableStrict",
+/**
+ * Resolves a single tri-state option: the URL (on/off) overrides the persisted
+ * localStorage default, which overrides the hardcoded server default. Also
+ * exposes the raw URL state (for rendering the tri-state toggle) and the
+ * persisted default (for rendering the "persist" switch).
+ */
+export function useHudOption(key: HudOptionKey): {
+  effective: boolean;
+  urlState: TriState;
+  persist: boolean;
+  setPersist: (_value: boolean) => void;
+} {
+  const router = useRouter();
+  const config = HUD_OPTIONS_BY_KEY[key];
+  const urlState = parseTriState(router.query[HUD_OPTION_URL_KEYS[key]]);
+  const [persist, setPersist] = usePreference(
+    config.localStorageKey,
     /*override*/ undefined,
-    /*default*/ true
+    config.serverDefault
   );
-  return [state, setState];
-}
-
-export function useHideAlwaysSkippedPreference(): [
-  boolean,
-  (_hideAlwaysSkippedValue: boolean) => void
-] {
-  const [state, setState] = usePreference(
-    "hideAlwaysSkipped",
-    /*override*/ undefined,
-    /*default*/ true
-  );
-  return [state, setState];
+  const effective = resolveTriState(urlState, persist, config.serverDefault);
+  return { effective, urlState, persist, setPersist };
 }

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -2,9 +2,9 @@ import AutorevertToggle, {
   isAutorevertActive,
 } from "components/autorevert/AutorevertToggle";
 import AutorevertView from "components/autorevert/AutorevertView";
-import CheckBoxSelector from "components/common/CheckBoxSelector";
 import CopyLink from "components/common/CopyLink";
 import LoadingPage from "components/common/LoadingPage";
+import OptionRow, { OptionRowHeader } from "components/common/OptionRow";
 import PageSelector from "components/common/PageSelector";
 import { LocalTimeHuman } from "components/common/TimeUtils";
 import TooltipTarget from "components/common/tooltipTarget/TooltipTarget";
@@ -50,14 +50,12 @@ import {
   JobData,
   packHudParams,
   RowData,
+  TriState,
 } from "lib/types";
 import {
-  useGroupingPreference,
-  useHideAlwaysSkippedPreference,
-  useHideGreenColumnsPreference,
-  useHideNonViableStrictPreference,
-  useMonsterFailuresPreference,
-  usePreference,
+  HUD_OPTIONS,
+  HUD_OPTIONS_BY_KEY,
+  useHudOption,
 } from "lib/useGroupingPreference";
 import useHudData from "lib/useHudData";
 import useTableFilter from "lib/useTableFilter";
@@ -379,24 +377,51 @@ function HudTableBody({
   );
 }
 
+// Renders one option row wired to the URL (tri-state toggle) and localStorage
+// (persist switch). Toggling on/off writes the option's key into the URL;
+// toggling back to "default" removes it. Uses a shallow route push so the grid
+// re-renders without a full navigation.
+function HudOptionRow({
+  optionKey,
+  disabled,
+  title,
+}: {
+  optionKey: typeof HUD_OPTIONS[number]["key"];
+  disabled?: boolean;
+  title?: string;
+}) {
+  const router = useRouter();
+  const params = packHudParams(router.query);
+  const config = HUD_OPTIONS_BY_KEY[optionKey];
+  const { urlState, persist, setPersist } = useHudOption(optionKey);
+
+  const setUrlState = (value: TriState) => {
+    router.push(
+      formatHudUrlForRoute("hud", { ...params, [optionKey]: value }),
+      undefined,
+      { shallow: true }
+    );
+  };
+
+  return (
+    <OptionRow
+      label={config.label}
+      urlState={urlState}
+      setUrlState={setUrlState}
+      persist={persist}
+      setPersist={setPersist}
+      disabled={disabled}
+      title={title}
+    />
+  );
+}
+
 function FiltersAndSettings({}: {}) {
   const router = useRouter();
   const params = packHudParams(router.query);
   const { jobFilter, handleSubmit } = useTableFilter(params);
-  const [mergeEphemeralLF, setMergeEphemeralLF] = useContext(MergeLFContext);
-  const [mergeOSDC, setMergeOSDC] = useContext(MergeOSDCContext);
   const [autorevertView, setAutorevertView] = useContext(AutorevertViewContext);
   const [settingsPanelOpen, setSettingsPanelOpen] = useState(false);
-  const [hideUnstable, setHideUnstable] = usePreference("hideUnstable");
-  const [hideGreenColumns, setHideGreenColumns] =
-    useHideGreenColumnsPreference();
-  const [hideNonViableStrict, setHideNonViableStrict] =
-    useHideNonViableStrictPreference();
-  const [hideAlwaysSkipped, setHideAlwaysSkipped] =
-    useHideAlwaysSkippedPreference();
-  const [useGrouping, setUseGrouping] = useGroupingPreference(
-    params.nameFilter
-  );
 
   // Only show autorevert toggle for pytorch/pytorch main
   const isPyTorchMain =
@@ -416,71 +441,24 @@ function FiltersAndSettings({}: {}) {
           />
           <SettingsPanel
             settingGroups={{
-              // You need to specify both checkBoxName and key for each setting.
-              // `checkbox name` is used by CheckBoxSelector while `key` is
-              // used to uniquely identify the component in the settings panel.
-              // As far as I can CheckBoxSelector cannot read or write `key` but
-              // React requires us to set key since it's a list element, so we
-              // end up with some unfortunate duplication.
-              "View Options": [
-                <CheckBoxSelector
-                  value={useGrouping}
-                  setValue={(value) => setUseGrouping(value)}
-                  checkBoxName="groupView"
-                  key="groupView"
-                  labelText={"Use grouped view"}
-                />,
-                <MonsterFailuresCheckbox key="monsterFailures" />,
-              ],
-              "Filter Options": [
-                <CheckBoxSelector
-                  value={hideUnstable}
-                  setValue={(value) => setHideUnstable(value)}
-                  checkBoxName="hideUnstable"
-                  key="hideUnstable"
-                  labelText={"Hide unstable jobs"}
-                />,
-                <CheckBoxSelector
-                  value={hideGreenColumns}
-                  setValue={(value) => setHideGreenColumns(value)}
-                  checkBoxName="hideGreenColumns"
-                  key="hideGreenColumns"
-                  labelText={"Hide green columns"}
-                />,
-                <CheckBoxSelector
-                  value={hideNonViableStrict}
-                  setValue={(value) => setHideNonViableStrict(value)}
-                  checkBoxName="hideNonViableStrict"
-                  key="hideNonViableStrict"
-                  labelText={"Hide non-viable-strict jobs"}
-                  disabled={!isPyTorchRepo}
-                  title={
-                    isPyTorchRepo
-                      ? undefined
-                      : "Only applies to the pytorch/pytorch repo"
-                  }
-                />,
-                <CheckBoxSelector
-                  value={hideAlwaysSkipped}
-                  setValue={(value) => setHideAlwaysSkipped(value)}
-                  checkBoxName="hideAlwaysSkipped"
-                  key="hideAlwaysSkipped"
-                  labelText={"Hide always-skipped jobs"}
-                />,
-                <CheckBoxSelector
-                  value={mergeEphemeralLF}
-                  setValue={setMergeEphemeralLF}
-                  checkBoxName="mergeEphemeralLF"
-                  key="mergeEphemeralLF"
-                  labelText={"Condense LF, ephemeral jobs"}
-                />,
-                <CheckBoxSelector
-                  value={mergeOSDC}
-                  setValue={setMergeOSDC}
-                  checkBoxName="mergeOSDC"
-                  key="mergeOSDC"
-                  labelText={"Condense OSDC, non-OSDC jobs"}
-                />,
+              Options: [
+                <OptionRowHeader key="__header" />,
+                ...HUD_OPTIONS.map((option) => {
+                  const pytorchOnlyDisabled =
+                    option.pytorchOnly && !isPyTorchRepo;
+                  return (
+                    <HudOptionRow
+                      key={option.key}
+                      optionKey={option.key}
+                      disabled={pytorchOnlyDisabled}
+                      title={
+                        pytorchOnlyDisabled
+                          ? "Only applies to the pytorch/pytorch repo"
+                          : undefined
+                      }
+                    />
+                  );
+                }),
               ],
             }}
             isOpen={settingsPanelOpen}
@@ -527,27 +505,14 @@ export function MonsterFailuresProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const [monsterFailures, setMonsterFailures] = useMonsterFailuresPreference();
+  // Read-only effective value (URL override -> persisted default -> server
+  // default). Deep grid cells consume this via context to decide whether to
+  // render the monster sprite; the toggle itself lives in the Options panel.
+  const { effective: monsterFailures } = useHudOption("monsterFailures");
   return (
-    <MonsterFailuresContext.Provider
-      value={[monsterFailures, setMonsterFailures]}
-    >
+    <MonsterFailuresContext.Provider value={[monsterFailures, undefined]}>
       {children}
     </MonsterFailuresContext.Provider>
-  );
-}
-
-export function MonsterFailuresCheckbox() {
-  const [monsterFailures, setMonsterFailures] = useContext(
-    MonsterFailuresContext
-  );
-  return (
-    <CheckBoxSelector
-      value={monsterFailures}
-      setValue={(value) => setMonsterFailures && setMonsterFailures(value)}
-      checkBoxName="monsterFailures"
-      labelText={"Monsterize failures"}
-    />
   );
 }
 
@@ -581,27 +546,12 @@ export const PinnedTooltipContext = createContext<[Highlight, any]>([
   null,
 ]);
 
-export const MergeLFContext = createContext<[boolean, (val: boolean) => void]>([
-  false,
-  (_) => {},
-]);
-
-export const MergeOSDCContext = createContext<
-  [boolean, (val: boolean) => void]
->([false, (_) => {}]);
-
 export const AutorevertViewContext = createContext<
   [boolean, (val: boolean) => void]
 >([false, (_) => {}]);
 
 export default function Hud() {
   const router = useRouter();
-  const [mergeEphemeralLF, setMergeEphemeralLF] = usePreference("mergeLF");
-  const [mergeOSDC, setMergeOSDC] = usePreference(
-    "mergeOSDC",
-    /*override*/ undefined,
-    /*default*/ false
-  );
   const [autorevertView, setAutorevertView] = useState(() =>
     isAutorevertActive(router.query)
   );
@@ -609,11 +559,7 @@ export default function Hud() {
   useEffect(() => {
     setAutorevertView(isAutorevertActive(router.query));
   }, [router.query]);
-  const params = packHudParams({
-    ...router.query,
-    mergeEphemeralLF: mergeEphemeralLF,
-    mergeOSDC: mergeOSDC,
-  });
+  const params = packHudParams(router.query);
 
   // Logic to handle tooltip pinning. The behavior we want is:
   // - If the user clicks on a tooltip, it should be pinned.
@@ -657,45 +603,39 @@ export default function Hud() {
       </Head>
       <PinnedTooltipContext.Provider value={[pinnedTooltip, setPinnedTooltip]}>
         <MonsterFailuresProvider>
-          <MergeLFContext.Provider
-            value={[mergeEphemeralLF, setMergeEphemeralLF]}
+          <AutorevertViewContext.Provider
+            value={[autorevertView, setAutorevertView]}
           >
-            <MergeOSDCContext.Provider value={[mergeOSDC, setMergeOSDC]}>
-              <AutorevertViewContext.Provider
-                value={[autorevertView, setAutorevertView]}
-              >
-                {params.branch !== undefined && (
-                  <div onClick={handleClick}>
-                    <div style={{ display: "flex", alignItems: "flex-end" }}>
-                      <HudHeader params={params} />
-                      <CopyPermanentLink
-                        params={params}
-                        style={{ marginLeft: "10px" }}
-                        autorevertView={autorevertView}
-                      />
+            {params.branch !== undefined && (
+              <div onClick={handleClick}>
+                <div style={{ display: "flex", alignItems: "flex-end" }}>
+                  <HudHeader params={params} />
+                  <CopyPermanentLink
+                    params={params}
+                    style={{ marginLeft: "10px" }}
+                    autorevertView={autorevertView}
+                  />
+                </div>
+                <div style={{ position: "relative", clear: "both" }}>
+                  <FiltersAndSettings />
+                  {autorevertView ? (
+                    <AutorevertView />
+                  ) : (
+                    <GroupedHudTable params={params} />
+                  )}
+                </div>
+                {!autorevertView && (
+                  <>
+                    <PageSelector params={params} baseUrl="hud" />
+                    <br />
+                    <div>
+                      <em>This page automatically updates.</em>
                     </div>
-                    <div style={{ position: "relative", clear: "both" }}>
-                      <FiltersAndSettings />
-                      {autorevertView ? (
-                        <AutorevertView />
-                      ) : (
-                        <GroupedHudTable params={params} />
-                      )}
-                    </div>
-                    {!autorevertView && (
-                      <>
-                        <PageSelector params={params} baseUrl="hud" />
-                        <br />
-                        <div>
-                          <em>This page automatically updates.</em>
-                        </div>
-                      </>
-                    )}
-                  </div>
+                  </>
                 )}
-              </AutorevertViewContext.Provider>
-            </MergeOSDCContext.Provider>
-          </MergeLFContext.Provider>
+              </div>
+            )}
+          </AutorevertViewContext.Provider>
         </MonsterFailuresProvider>
       </PinnedTooltipContext.Provider>
     </>
@@ -778,11 +718,20 @@ function GroupedHudTable({ params }: { params: HudParams }) {
     return buildVerdictsBySha(deduplicateVerdicts(advisorRows));
   }, [advisorRows]);
 
-  const [hideUnstable] = usePreference("hideUnstable");
-  const [hideGreenColumns] = useHideGreenColumnsPreference();
-  const [hideNonViableStrict] = useHideNonViableStrictPreference();
-  const [hideAlwaysSkipped] = useHideAlwaysSkippedPreference();
-  const [useGrouping] = useGroupingPreference(params.nameFilter);
+  const { effective: hideUnstable } = useHudOption("hideUnstable");
+  const { effective: hideGreenColumns } = useHudOption("hideGreenColumns");
+  const { effective: hideNonViableStrict } = useHudOption(
+    "hideNonViableStrict"
+  );
+  const { effective: hideAlwaysSkipped } = useHudOption("hideAlwaysSkipped");
+  const { effective: groupingPref } = useHudOption("useGrouping");
+  // A name filter forces the ungrouped view so individual matching jobs are
+  // visible, regardless of the grouping preference/toggle.
+  const hasNameFilter =
+    params.nameFilter !== "" &&
+    params.nameFilter !== null &&
+    params.nameFilter !== undefined;
+  const useGrouping = hasNameFilter ? false : groupingPref;
 
   const {
     shaGrid,

--- a/torchci/test/hudParams.test.ts
+++ b/torchci/test/hudParams.test.ts
@@ -1,0 +1,179 @@
+import {
+  formatHudUrlForFetch,
+  formatHudUrlForRoute,
+  HudParams,
+  packHudParams,
+  parseTriState,
+  resolveTriState,
+} from "../lib/types";
+
+describe("parseTriState", () => {
+  test.each([
+    ["true", "on"],
+    [true, "on"],
+    ["false", "off"],
+    [false, "off"],
+    [undefined, "default"],
+    [null, "default"],
+    ["", "default"],
+    ["garbage", "default"],
+  ])("parseTriState(%p) === %p", (input, expected) => {
+    expect(parseTriState(input)).toBe(expected);
+  });
+});
+
+describe("resolveTriState", () => {
+  test("on/off from the URL override stored and server defaults", () => {
+    expect(resolveTriState("on", false, false)).toBe(true);
+    expect(resolveTriState("off", true, true)).toBe(false);
+  });
+
+  test("default falls back to the stored value when present", () => {
+    expect(resolveTriState("default", true, false)).toBe(true);
+    expect(resolveTriState("default", false, true)).toBe(false);
+  });
+
+  test("default falls back to the server default when nothing is stored", () => {
+    expect(resolveTriState("default", undefined, true)).toBe(true);
+    expect(resolveTriState("default", undefined, false)).toBe(false);
+  });
+});
+
+const BASE_QUERY = {
+  repoOwner: "pytorch",
+  repoName: "pytorch",
+  branch: "main",
+  page: "1",
+  per_page: "50",
+};
+
+describe("packHudParams tri-state options", () => {
+  test("absent option keys resolve to default", () => {
+    const params = packHudParams(BASE_QUERY);
+    expect(params.hideUnstable).toBe("default");
+    expect(params.hideGreenColumns).toBe("default");
+    expect(params.hideNonViableStrict).toBe("default");
+    expect(params.hideAlwaysSkipped).toBe("default");
+    expect(params.useGrouping).toBe("default");
+    expect(params.monsterFailures).toBe("default");
+    expect(params.mergeEphemeralLF).toBe("default");
+    expect(params.mergeOSDC).toBe("default");
+  });
+
+  test("true/false query values become on/off", () => {
+    const params = packHudParams({
+      ...BASE_QUERY,
+      hide_unstable: "true",
+      hide_green: "false",
+      hide_non_viable_strict: "true",
+      grouped: "false",
+    });
+    expect(params.hideUnstable).toBe("on");
+    expect(params.hideGreenColumns).toBe("off");
+    expect(params.hideNonViableStrict).toBe("on");
+    expect(params.useGrouping).toBe("off");
+  });
+
+  test("malformed query values fall back to default", () => {
+    const params = packHudParams({ ...BASE_QUERY, hide_unstable: "yes" });
+    expect(params.hideUnstable).toBe("default");
+  });
+});
+
+function makeParams(overrides: Partial<HudParams> = {}): HudParams {
+  return {
+    repoOwner: "pytorch",
+    repoName: "pytorch",
+    branch: "main",
+    page: 1,
+    per_page: 50,
+    filter_reruns: false,
+    filter_unstable: false,
+    useGrouping: "default",
+    monsterFailures: "default",
+    hideUnstable: "default",
+    hideGreenColumns: "default",
+    hideNonViableStrict: "default",
+    hideAlwaysSkipped: "default",
+    mergeEphemeralLF: "default",
+    mergeOSDC: "default",
+    ...overrides,
+  };
+}
+
+describe("formatHudUrlForRoute serialization", () => {
+  test("default options are omitted from the URL", () => {
+    const url = formatHudUrlForRoute("hud", makeParams());
+    expect(url).toBe("/hud/pytorch/pytorch/main/1?per_page=50");
+  });
+
+  test("the literal string 'default' never appears in a URL", () => {
+    const url = formatHudUrlForRoute(
+      "hud",
+      makeParams({
+        hideUnstable: "on",
+        hideGreenColumns: "off",
+        useGrouping: "default",
+      })
+    );
+    expect(url).not.toContain("default");
+  });
+
+  test("on serializes to =true and off serializes to =false", () => {
+    const url = formatHudUrlForRoute(
+      "hud",
+      makeParams({ hideUnstable: "on", hideGreenColumns: "off" })
+    );
+    expect(url).toContain("hide_unstable=true");
+    expect(url).toContain("hide_green=false");
+  });
+
+  test("round trips pack(format(...)) for on/off, dropping default", () => {
+    const params = makeParams({
+      hideUnstable: "on",
+      hideNonViableStrict: "off",
+      mergeOSDC: "on",
+      hideAlwaysSkipped: "default",
+    });
+    const url = formatHudUrlForRoute("hud", params);
+    // Reparse the query portion the way Next.js would hand it to packHudParams.
+    const query = Object.fromEntries(
+      new URLSearchParams(url.split("?")[1]).entries()
+    );
+    const reparsed = packHudParams({
+      repoOwner: "pytorch",
+      repoName: "pytorch",
+      branch: "main",
+      ...query,
+    });
+    expect(reparsed.hideUnstable).toBe("on");
+    expect(reparsed.hideNonViableStrict).toBe("off");
+    expect(reparsed.mergeOSDC).toBe("on");
+    expect(reparsed.hideAlwaysSkipped).toBe("default");
+  });
+});
+
+describe("formatHudUrlForFetch serialization", () => {
+  test("only fetch-relevant (merge) options are serialized", () => {
+    const url = formatHudUrlForFetch(
+      "api/hud",
+      makeParams({
+        hideUnstable: "on", // client-only, should NOT appear
+        mergeEphemeralLF: "on", // fetch-relevant, should appear
+        mergeOSDC: "off",
+      })
+    );
+    expect(url).toContain("mergeEphemeralLF=true");
+    expect(url).toContain("mergeOSDC=false");
+    expect(url).not.toContain("hide_unstable");
+  });
+
+  test("client-only toggles don't change the fetch URL", () => {
+    const withToggle = formatHudUrlForFetch(
+      "api/hud",
+      makeParams({ hideUnstable: "on", hideGreenColumns: "off" })
+    );
+    const without = formatHudUrlForFetch("api/hud", makeParams());
+    expect(withToggle).toBe(without);
+  });
+});


### PR DESCRIPTION
## Author Notes

Suggested changes to the settings system so we can both control with url and have persistence. New tab is in picture below.

<img width="1984" height="1366" alt="image" src="https://github.com/user-attachments/assets/4a1e402b-7883-4fa2-94e1-c0d209e30f47" />


<!-- Drag-and-drop the screenshot of the new Options tab here -->

## Agent Notes

Reworks the HUD **Options** settings panel so every option is both URL-driven and persistable.

**Behavior**
- Each option is now a **tri-state toggle** (Off / Default / On):
  - **On** → `?key=true` in the URL
  - **Off** → `?key=false` in the URL
  - **Default** (middle, greyed) → key **absent** from the URL; value falls back to the persisted default, then a hardcoded server default
- A per-option **Persist** switch writes the localStorage default used whenever the toggle is in the Default state.
- Resolution order: **URL (on/off) ?? localStorage (persist) ?? server default**.
- The string `"default"` is never serialized into a URL.
- Shareable route URLs carry all options; the **data-fetch URL only carries the merge options** (`mergeEphemeralLF`/`mergeOSDC`) that change server output, so client-only toggles don't bust the fetch cache key.
- Added a column header (**This page / Option / Default**) to the panel so the columns are self-explanatory.

**Implementation**
- `lib/types.ts`: added `TriState`, `parseTriState`, `resolveTriState`, `HUD_OPTION_URL_KEYS`, `FETCH_RELEVANT_OPTIONS`; `HudParams` now carries the 8 tri-state options; `packHudParams`/`formatHudURL` handle them.
- `lib/useGroupingPreference.tsx`: added `HUD_OPTIONS` config + `useHudOption()` resolver hook; removed the bespoke per-option preference hooks (kept `usePreference`, still used by `failure.tsx`).
- `components/common/OptionRow.tsx` (new): MUI `ToggleButtonGroup` + `Switch`, themed via `useTheme()` for light/dark; exports `OptionRowHeader`.
- HUD page: single **Options** group of rows; toggles do a shallow `router.push`; grid + `GroupJobConclusion` read effective values from the resolver. Removed `MergeLFContext`/`MergeOSDCContext` and the monster checkbox.
- `lib/fetchHud.ts`: merge checks compare `=== "on"`.

**Tests**
- `test/hudParams.test.ts` (new): parsing, resolution precedence, URL serialization, the fetch-vs-route split, round-trip, and the no-`"default"`-in-URL guarantee. Full suite (42 suites) passes; `tsc` and `next lint` clean.

This PR was written by Claude (claude-opus-4) on behalf of @albanD.