### PR TITLE
[release/2.13] Validate ROCm wheels on regular almalinux image

### DIFF
--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -124,7 +124,10 @@ jobs:
       repository: "pytorch/pytorch"
       ref: release/2.13
       job-name: ${{ matrix.build_name }}
-      docker-image: ${{ ((matrix.gpu_arch_type == 'xpu' || matrix.gpu_arch_type == 'rocm') && matrix.container_image) || 'pytorch/almalinux-builder:cpu-main' }}
+      # ROCm now validates on the regular almalinux image (like CUDA) to
+      # confirm the wheels are self-contained and no longer need the fat
+      # manylinux-rocm builder image. Only XPU still needs its own container.
+      docker-image: ${{ (matrix.gpu_arch_type == 'xpu' && matrix.container_image) || 'pytorch/almalinux-builder:cpu-main' }}
       binary-matrix: ${{ toJSON(matrix) }}
       docker-build-dir: "skip-docker-build"
       timeout: 180


### PR DESCRIPTION
## What
Validate ROCm wheels on the regular `pytorch/almalinux-builder:cpu-main`
image instead of the dedicated `pytorch/manylinux2_28-builder:rocm{ver}`
builder image, matching how CUDA wheels are already validated.

```diff
-docker-image: ${{ ((matrix.gpu_arch_type == 'xpu' || matrix.gpu_arch_type == 'rocm') && matrix.container_image) || 'pytorch/almalinux-builder:cpu-main' }}
+docker-image: ${{ (matrix.gpu_arch_type == 'xpu' && matrix.container_image) || 'pytorch/almalinux-builder:cpu-main' }}
```

## Why
This confirms the release/2.13 ROCm wheels are self-contained (bundle their
own runtime libs) and no longer depend on the fat ROCm builder image at
import/smoke-test time. `validate_binaries.sh` installs no system ROCm
libraries, so if the wheel were not self-contained, `import torch` on the
regular image would fail — which is exactly what this exercises.

Line 127 in `validate-linux-binaries.yml` is the only ROCm docker-image
conditional; aarch64 has no ROCm builds and other validate workflows do not
branch on ROCm. ROCm validation already runs on `LINUX_CPU_RUNNER`, so this
remains a wheel-loads/smoke-test check with no GPU dependency.

## Not a duplicate
No existing open PR changes the ROCm validation image on the
`release-213-rocm` branch.

## Test plan
This is a CI-config change; correctness is demonstrated by the ROCm binary
validation jobs in the "Validate binaries" workflow passing on the regular
image for this branch.

AI assistance (Claude) was used for this change.