### PR TITLE
[release/2.13] Drop Windows libtorch debug validations

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -382,7 +382,9 @@ def generate_libtorch_matrix(
 
     if abi_versions is None or len(abi_versions) == 0:
         if os == WINDOWS:
-            abi_versions = [RELEASE, DEBUG]
+            # Windows libtorch debug builds are no longer produced; only ship
+            # release builds for nightly and release channels.
+            abi_versions = [RELEASE]
         elif os == LINUX:
             abi_versions = [CXX11_ABI]
         elif os in [MACOS_ARM64]:


### PR DESCRIPTION
## What
Backport the Windows libtorch **debug** build removal from #8194 to the
`release/2.13` branch. `generate_binary_build_matrix.py` sets the Windows
libtorch `abi_versions` to release-only:

```diff
 if os == WINDOWS:
-    abi_versions = [RELEASE, DEBUG]
+    abi_versions = [RELEASE]
```

## Why
pytorch/pytorch no longer builds/publishes Windows libtorch **debug**
binaries (deprecated), so validating them on release/2.13 fails / is dead
weight.

## Effect
Windows libtorch matrix goes from 8 entries (4 release + 4 debug) to 4
(release only):
```
BEFORE: total 8  Counter({'release': 4, 'debug': 4})
AFTER:  total 4  Counter({'release': 4})
```
Verified via `generate_binary_build_matrix.py --package-type libtorch
--operating-system windows --channel release` (4 rows, all release).

## Tests
libtorch matrices are **not** covered by the JSON asset tests, so this
change needs no fixture updates.

Note: `python3 -m tools.tests.test_generate_binary_build_matrix` currently
reports 7 failures **on release/2.13 already, independent of this change**
— the wheel asset fixtures still embed `stable_version: 2.12.0` while the
script is at `2.13.0` (fixtures weren't regenerated when stable was bumped
on the branch). That is separate pre-existing drift; happy to fix it in a
follow-up (regenerate wheel fixtures for 2.13.0).

AI assistance (Claude) was used for this change.
