### PR TITLE
[release/2.13] Validate Python 3.15 via download.pytorch.org only (not PyPI)

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -329,6 +329,9 @@ def get_wheel_install_command(
     if (
         channel == RELEASE
         and (not use_only_dl_pytorch_org)
+        # Preview Python versions (e.g. 3.15 / 3.15t) have no PyPI wheels yet,
+        # so they must always install from download.pytorch.org, never PyPI.
+        and (python_version not in TORCH_ONLY_PYTHON_ARCHES)
         and (
             (gpu_arch_version == STABLE_CUDA_VERSIONS[channel] and os == LINUX)
             or (gpu_arch_type == CPU and os in [WINDOWS, MACOS_ARM64])


### PR DESCRIPTION
## What
Force Python **3.15 / 3.15t** binary validation to install from
`download.pytorch.org` only, never PyPI.

```diff
     if (
         channel == RELEASE
         and (not use_only_dl_pytorch_org)
+        and (python_version not in TORCH_ONLY_PYTHON_ARCHES)
         and (
             (gpu_arch_version == STABLE_CUDA_VERSIONS[channel] and os == LINUX)
             ...
```

## Why
On the release channel, `get_wheel_install_command` returns a bare
`pip3 install torch` (i.e. **from PyPI**) for the stable-CUDA linux arch.
Python 3.15 / 3.15t are pre-release and have **no PyPI wheels** — those
wheels only exist on download.pytorch.org — so the 3.15 `cu130` entry was
generating a PyPI install that pulls the wrong torch (or fails).

Before / after (release channel, linux):
```
BEFORE  3.15 cuda cu130 | pip3 install torch                                             <-- PyPI
AFTER   3.15 cuda cu130 | pip3 install torch --index-url https://download.pytorch.org/whl/cu130
```
Every other 3.15 arch (cpu/cu126/cu132/rocm/xpu) already used
`--index-url download.pytorch.org`; only the stable-CUDA entry was wrong.

## Scope / safety
- **Released** Python versions are unchanged — e.g. `3.10 cu130` still
  resolves to the bare `pip3 install torch torchvision` (PyPI) path.
- No test-fixture changes: preview Python rows are not part of the default
  build-matrix asset fixtures.

## Tests
`python3 -m tools.tests.test_generate_binary_build_matrix` reports 7
failures **pre-existing on release/2.13, unrelated to this change** — the
wheel fixtures still embed `stable_version: 2.12.0` while the script is at
`2.13.0` (same drift noted in the Windows-libtorch-debug PR). This change
produces no diff in the default (non-preview) matrix, so it adds no new
failures.

AI assistance (Claude) was used for this change.
