### PR TITLE
[release/2.13] Install libatomic for ROCm validation on lean image

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -288,6 +288,15 @@ if [[ ${TARGET_OS} == 'macos-arm64' ]]; then
     export PATH="${CONDA_PREFIX}/bin:${PATH}"
 fi
 
+# ROCm validation runs on the lean pytorch/almalinux-builder:cpu-main image,
+# which does not ship libatomic.so.1. torch's _C extension links it, so
+# `import torch` fails with "libatomic.so.1: cannot open shared object file".
+# conda envs mask this by pulling libatomic in via libgcc, but the uv-based
+# 3.15 env does not, so install it explicitly. Scoped to ROCm on Linux.
+if [[ ${MATRIX_GPU_ARCH_TYPE:-} == 'rocm' && ${TARGET_OS} == 'linux' ]]; then
+    (dnf install -y libatomic || yum install -y libatomic) || true
+fi
+
 # Remove previous installation if wheel package
 if [[ ${MATRIX_PACKAGE_TYPE} == 'wheel' ]]; then
     pip3 uninstall -y torch torchaudio torchvision || true


### PR DESCRIPTION
## What
Install `libatomic` before ROCm binary validation, scoped to ROCm on Linux.

```bash
if [[ ${MATRIX_GPU_ARCH_TYPE:-} == 'rocm' && ${TARGET_OS} == 'linux' ]]; then
    (dnf install -y libatomic || yum install -y libatomic) || true
fi
```

## Why
ROCm validation now runs on the lean `pytorch/almalinux-builder:cpu-main`
image, which does **not** ship `libatomic.so.1`. torch's `_C` extension
links it, so `import torch` fails:

```
ImportError: libatomic.so.1: cannot open shared object file
```

Only **Python 3.15 / 3.15t** hit this: those envs are provisioned via
`uv` + python-build-standalone, which does not provide `libatomic.so.1`.
The conda-based envs (3.10–3.14) accidentally mask the missing system lib
because conda pulls `libatomic.so.1` in via `libgcc` into
`$CONDA_PREFIX/lib` (which `validate_binaries.sh` puts on
`LD_LIBRARY_PATH`). `ldd` on the failing run confirms `libatomic.so.1 =>
not found` (it is not in the image, the wheel's `torch/lib/`, or the
gcc-toolset-13 lib dirs).

## Scope
Guarded to `MATRIX_GPU_ARCH_TYPE == rocm && TARGET_OS == linux`, so CUDA /
XPU / CPU / macOS / Windows validation is unchanged. The install is
best-effort (`|| true`) and idempotent, so it is harmless for the conda
Pythons that already have libatomic.

## Test plan
Re-run ROCm 3.15 / 3.15t validation on `release/2.13`; `import torch` should
succeed (previously failed on libatomic). Other ROCm Pythons remain green.

AI assistance (Claude) was used for this change.
