### PR TITLE
Validate ROCm on the regular almalinux image (like CUDA)

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -286,6 +286,15 @@ if [[ ${TARGET_OS} == 'macos-arm64' ]]; then
     export PATH="${CONDA_PREFIX}/bin:${PATH}"
 fi
 
+# Nightly ROCm validation runs on the lean pytorch/almalinux-builder:cpu-main
+# image, which does not ship libatomic.so.1. torch's _C extension links it, so
+# `import torch` fails with "libatomic.so.1: cannot open shared object file".
+# conda envs mask this by pulling libatomic in via libgcc, but the uv-based
+# 3.15 env does not, so install it explicitly. Scoped to ROCm on Linux.
+if [[ ${MATRIX_GPU_ARCH_TYPE:-} == 'rocm' && ${TARGET_OS} == 'linux' ]]; then
+    (dnf install -y libatomic || yum install -y libatomic) || true
+fi
+
 # Remove previous installation if wheel package
 if [[ ${MATRIX_PACKAGE_TYPE} == 'wheel' ]]; then
     pip3 uninstall -y torch torchaudio torchvision || true

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -123,7 +123,9 @@ jobs:
       repository: "pytorch/pytorch"
       ref: main
       job-name: ${{ matrix.build_name }}
-      docker-image: ${{ ((matrix.gpu_arch_type == 'xpu' || matrix.gpu_arch_type == 'rocm') && matrix.container_image) || 'pytorch/almalinux-builder:cpu-main' }}
+      # ROCm validates on the regular almalinux image (like CUDA) to confirm
+      # the wheels are self-contained. Only XPU still needs its own container.
+      docker-image: ${{ (matrix.gpu_arch_type == 'xpu' && matrix.container_image) || 'pytorch/almalinux-builder:cpu-main' }}
       binary-matrix: ${{ toJSON(matrix) }}
       docker-build-dir: "skip-docker-build"
       timeout: 180


### PR DESCRIPTION
## What
Validate ROCm wheels on the regular `pytorch/almalinux-builder:cpu-main` image
instead of the dedicated `pytorch/manylinux2_28-builder:rocm{ver}` builder image
— the same image CUDA already uses.

```diff
-docker-image: ${{ ((matrix.gpu_arch_type == 'xpu' || matrix.gpu_arch_type == 'rocm') && matrix.container_image) || 'pytorch/almalinux-builder:cpu-main' }}
+docker-image: ${{ (matrix.gpu_arch_type == 'xpu' && matrix.container_image) || 'pytorch/almalinux-builder:cpu-main' }}
```

- `xpu` → its container image
- `rocm` / `cuda` / `cpu` → `pytorch/almalinux-builder:cpu-main`

## Why
CUDA validation already runs on `almalinux-builder:cpu-main` (its wheels carry
their runtime as PyPI deps). This makes ROCm behave the same, confirming the
ROCm wheels are self-contained on a lean image. Mirrors release-branch PR #8258.

## libatomic
Also installs `libatomic` for ROCm-on-Linux in `validate_binaries.sh`. The lean
image doesn't ship `libatomic.so.1` (torch's `_C` links it); conda envs mask this
via `libgcc`, but the uv-provisioned Python 3.15 env does not, so `import torch`
would fail with `libatomic.so.1: cannot open shared object file`. Best-effort,
idempotent, guarded to ROCm+Linux. Mirrors the release/2.13 fix (#8264).

## Test plan
Run the "Validate binaries" workflow on this branch; ROCm jobs (incl. Python
3.15/3.15t) should pass on `almalinux-builder:cpu-main`. `bash -n` + YAML parse
pass locally.

AI assistance (Claude) was used for this change.