### PR TITLE
[torchci] Fix yarn format broken on main (unparseable `satisfies`)

### DIFF
--- a/torchci/components/autorevert/AutorevertCell.tsx
+++ b/torchci/components/autorevert/AutorevertCell.tsx
@@ -29,23 +29,23 @@ const HIGHLIGHT_LABELS: Record<string, string> = {
   restart: "Targeted for CI restart",
 };
 
-const ADV_VERDICT_CLS: Record<string, string> = {
+const ADV_VERDICT_CLS: Record<AdvisorVerdictType, string> = {
   revert: styles.advRevert,
   related: styles.advRevert,
   not_related: styles.advNotRelated,
   infra_issue: styles.advInfra,
   garbage: styles.advGarbage,
   unsure: styles.advUnsure,
-} satisfies Record<AdvisorVerdictType, string>;
+};
 
-const ADV_VERDICT_SHORT: Record<string, string> = {
+const ADV_VERDICT_SHORT: Record<AdvisorVerdictType, string> = {
   revert: "REV",
   related: "REV",
   not_related: "OK",
   infra_issue: "INF",
   garbage: "JNK",
   unsure: "?",
-} satisfies Record<AdvisorVerdictType, string>;
+};
 
 interface AutorevertCellProps {
   events: CellEvent[];

--- a/torchci/components/job/AdvisorSection.tsx
+++ b/torchci/components/job/AdvisorSection.tsx
@@ -5,14 +5,17 @@ import {
 } from "lib/advisorVerdictUtils";
 import { useState } from "react";
 
-const VERDICT_COLORS: Record<string, { border: string; badge: string }> = {
+const VERDICT_COLORS: Record<
+  AdvisorVerdictType,
+  { border: string; badge: string }
+> = {
   revert: { border: "#d32f2f", badge: "#d32f2f" },
   related: { border: "#d32f2f", badge: "#d32f2f" },
   not_related: { border: "#388e3c", badge: "#2e7d32" },
   infra_issue: { border: "#57606a", badge: "#57606a" },
   garbage: { border: "#8d6e63", badge: "#6d4c41" },
   unsure: { border: "#757575", badge: "#616161" },
-} satisfies Record<AdvisorVerdictType, { border: string; badge: string }>;
+};
 
 export default function AdvisorSection({
   verdict,

--- a/torchci/components/job/AiAdvisorIndicator.tsx
+++ b/torchci/components/job/AiAdvisorIndicator.tsx
@@ -67,7 +67,7 @@ function isDispatched(
 }
 
 const VERDICT_CHIP_COLORS: Record<
-  string,
+  AdvisorVerdictType,
   "error" | "warning" | "success" | "default" | "info"
 > = {
   revert: "error",
@@ -76,19 +76,16 @@ const VERDICT_CHIP_COLORS: Record<
   not_related: "success",
   infra_issue: "info",
   garbage: "default",
-} satisfies Record<
-  AdvisorVerdictType,
-  "error" | "warning" | "success" | "default" | "info"
->;
+};
 
-const VERDICT_LABELS: Record<string, string> = {
+const VERDICT_LABELS: Record<AdvisorVerdictType, string> = {
   revert: "Revert",
   related: "Related",
   unsure: "Unsure",
   not_related: "Not Related",
   infra_issue: "Infra Issue",
   garbage: "Garbage Signal",
-} satisfies Record<AdvisorVerdictType, string>;
+};
 
 export default function AiAdvisorIndicator({
   jobName,


### PR DESCRIPTION
`yarn format` is failing on `main` after #8213. The advisor verdict maps used the TS `satisfies` operator, which the repo's prettier version can't parse — prettier throws `SyntaxError: ',' expected` on `} satisfies Record<...>` and `yarn format` exits non-zero (e.g. [this run](https://github.com/pytorch/test-infra/actions/runs/28980734998/job/85998682132)).  It turns out that I use node 26 locally while CI use node 24.

**Fix:** replace `{...} satisfies Record<AdvisorVerdictType, …>` with a direct `Record<AdvisorVerdictType, …>` type annotation on the three verdict maps (`AutorevertCell`, `AiAdvisorIndicator`, `AdvisorSection`). This keeps the same compile-time exhaustiveness — `tsc` still errors if a future verdict is added without updating a map — but uses syntax prettier understands.

No behavior change. `prettier --check` and `tsc --noEmit` both pass locally.