### PR TITLE
[CRCR] Ignore ciflow/crcr/* labels in CIFlow trigger

### DIFF
--- a/torchci/lib/bot/ciflowPushTrigger.ts
+++ b/torchci/lib/bot/ciflowPushTrigger.ts
@@ -11,7 +11,11 @@ import {
 const CIFLOW_PENDING_MARKER = "<!-- ciflow-pending -->";
 
 function isCIFlowLabel(label: string): boolean {
-  return label.startsWith("ciflow/");
+  // `ciflow/crcr/*` are Cross-Repo CI Relay gating labels: the relay reacts to
+  // the `pull_request.labeled` webhook directly, they do not push a git tag to
+  // trigger CI. So they must not go through this push-tag machinery (which would
+  // wrongly flag them as an "Unknown label" and create a spurious ciflow tag).
+  return label.startsWith("ciflow/") && !label.startsWith("ciflow/crcr/");
 }
 
 /**

--- a/torchci/test/ciflow-push-trigger.test.ts
+++ b/torchci/test/ciflow-push-trigger.test.ts
@@ -499,6 +499,21 @@ describe("Push trigger integration tests", () => {
     await probot.receive({ name: "pull_request", id: "123", payload });
   });
 
+  test("ciflow/crcr/* labels are ignored (handled by the relay, not push-tags)", async () => {
+    // Deep-clone to avoid mutating the cached require() result.
+    const payload = JSON.parse(
+      JSON.stringify(require("./fixtures/push-trigger/pull_request.labeled"))
+    );
+    payload.pull_request.state = "open";
+    payload.label.name = "ciflow/crcr/crcr-test";
+
+    // No nock interceptors are set up: a crcr label must make no GitHub API
+    // calls (no "Unknown label" comment, no tag creation). With
+    // nock.disableNetConnect(), any request would throw, and the afterEach
+    // nock.isDone() assertion confirms nothing was called.
+    await probot.receive({ name: "pull_request", id: "123", payload });
+  });
+
   test("CIFlow label without approval keeps label and posts pending comment", async () => {
     // Deep-clone fixture to avoid mutating the cached require() result
     const payload = JSON.parse(


### PR DESCRIPTION
The `ciflow-push-trigger` bot treats every `ciflow/*` label as a CI push-tag label: it validates the label against `ciflow_push_tags` in `.github/pytorch-probot.yml` and pushes a `ciflow/<name>/<pr>` git tag to trigger workflows. Because `ciflow/crcr/*` labels are not in that list, the bot posts a misleading "Unknown label" warning on the PR (example: pytorch/pytorch#189246) and would create a stray git tag nothing consumes.

However, `ciflow/crcr/*` are CRCR gating labels. The relay reacts to the `pull_request.labeled` webhook directly to decide whether to create an upstream check run for an L3 downstream repo — it does not rely on a git-tag push. So these labels should not go through the push-tag machinery at all.

cc @atalman 