### PR TITLE
[torchci] Bump prettier 2.6.2 -> 2.8.8 to support satisfies (fixes yarn format CI)

### DIFF
--- a/torchci/components/benchmark_v3/configs/config_book_types.ts
+++ b/torchci/components/benchmark_v3/configs/config_book_types.ts
@@ -24,7 +24,7 @@ export const BenchmarkPageType = {
 
 // Infer the type automatically
 export type BenchmarkPageType =
-  typeof BenchmarkPageType[keyof typeof BenchmarkPageType];
+  (typeof BenchmarkPageType)[keyof typeof BenchmarkPageType];
 
 export type BenchmarkUIConfig = {
   apiId: string;

--- a/torchci/components/testStats/TestStatsPage.tsx
+++ b/torchci/components/testStats/TestStatsPage.tsx
@@ -39,7 +39,7 @@ type Row = {
 };
 
 const COUNT_KEYS = ["total", "skipped", "flaky", "failure"] as const;
-type CountKey = typeof COUNT_KEYS[number];
+type CountKey = (typeof COUNT_KEYS)[number];
 
 const COUNT_LABELS: Record<CountKey, string> = {
   total: "Total",

--- a/torchci/package.json
+++ b/torchci/package.json
@@ -95,7 +95,7 @@
     "jest": "^29.7.0",
     "monaco-editor": "^0.33.0",
     "nock": "^13.2.6",
-    "prettier": "2.6.2",
+    "prettier": "2.8.8",
     "prettier-plugin-organize-imports": "^3.2.4",
     "ts-jest": "^29.2.5",
     "typescript": "^5.7.2"

--- a/torchci/yarn.lock
+++ b/torchci/yarn.lock
@@ -7857,10 +7857,10 @@ prettier-plugin-organize-imports@^3.2.4:
   resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.4.tgz#77967f69d335e9c8e6e5d224074609309c62845e"
   integrity sha512-6m8WBhIp0dfwu0SkgfOxJqh+HpdyfqSSLfKKRZSFbDuEQXDDndb8fTpRWkUrX/uBenkex3MgnVk0J3b3Y5byog==
 
-prettier@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz"
-  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
+prettier@2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-format@^29.0.0, pretty-format@^29.7.0:
   version "29.7.0"


### PR DESCRIPTION
## Problem
The `Run yarn format` CI step (`yarn prettier --write .`) fails on **every**
torchci PR — including [#8220](https://github.com/pytorch/test-infra/pull/8220),
which doesn't touch the affected files:

```
[error] components/job/AdvisorSection.tsx: SyntaxError: ',' expected. (15:3)
        } satisfies Record<AdvisorVerdictType, { border: string; badge: string }>;
[error] components/job/AiAdvisorIndicator.tsx: SyntaxError: ',' expected. (79:3)
error Command failed with exit code 2.
```

`torchci` pins **`prettier@2.6.2`**, which predates TypeScript **`satisfies`**
support (added in prettier **2.8.0**). Three files on `main` use `satisfies`
(`components/job/AdvisorSection.tsx`, `components/job/AiAdvisorIndicator.tsx`,
`components/autorevert/AutorevertCell.tsx`), so `prettier --write .` can't parse
them and exits non-zero — failing the format step under `set -e` before the
diff check. This is pre-existing `main` breakage, not caused by the PRs that hit it.

## Fix
Bump `prettier` `2.6.2 → 2.8.8` (last 2.x — adds `satisfies` support with a
minimal formatting delta vs a 3.x major).

## Impact
- `prettier --check .` now passes ("All matched files use Prettier code style!").
- Formatting churn is just **2 pre-existing files**, 1 line each, where 2.8
  parenthesizes indexed-access-on-`typeof` (`typeof X[K]` → `(typeof X)[K]`).
- `yarn.lock` change is limited to the `prettier` entry (no mass re-resolution).

## Test plan
- `yarn prettier --write .` → exit 0, no `satisfies` parse errors.
- `yarn prettier --check .` → clean.

AI assistance (Claude) was used for this change.
