### PR TITLE
[CRCR] Add CRCR results to main HUD grid with monsterization

### DIFF
--- a/torchci/clickhouse_queries/crcr_hud_results/params.json
+++ b/torchci/clickhouse_queries/crcr_hud_results/params.json
@@ -1,10 +1,10 @@
 {
   "params": {
-    "shas": "Array(String)"
+    "prNums": "Array(Int64)"
   },
   "tests": [
     {
-      "shas": "[\"abc123\"]"
+      "prNums": "[12345]"
     }
   ]
 }

--- a/torchci/clickhouse_queries/crcr_hud_results/params.json
+++ b/torchci/clickhouse_queries/crcr_hud_results/params.json
@@ -1,0 +1,10 @@
+{
+  "params": {
+    "shas": "Array(String)"
+  },
+  "tests": [
+    {
+      "shas": "[\"abc123\"]"
+    }
+  ]
+}

--- a/torchci/clickhouse_queries/crcr_hud_results/query.sql
+++ b/torchci/clickhouse_queries/crcr_hud_results/query.sql
@@ -1,0 +1,20 @@
+SELECT
+    pytorch_head_sha,
+    downstream_repo,
+    downstream_repo_level,
+    workflow_name,
+    job_name,
+    check_run_id,
+    run_id,
+    run_attempt,
+    status,
+    conclusion,
+    workflow_run_url,
+    duration_seconds,
+    failed_tests_json
+FROM
+    default.crcr_workflow_job FINAL
+WHERE
+    pytorch_head_sha IN {shas: Array(String)}
+ORDER BY
+    pytorch_head_sha, downstream_repo, job_name

--- a/torchci/clickhouse_queries/crcr_hud_results/query.sql
+++ b/torchci/clickhouse_queries/crcr_hud_results/query.sql
@@ -1,4 +1,5 @@
 SELECT
+    pr_number,
     pytorch_head_sha,
     downstream_repo,
     downstream_repo_level,
@@ -15,6 +16,7 @@ SELECT
 FROM
     default.crcr_workflow_job FINAL
 WHERE
-    pytorch_head_sha IN {shas: Array(String)}
+    pr_number IN {prNums: Array(Int64)}
+    AND pr_number > 0
 ORDER BY
-    pytorch_head_sha, downstream_repo, job_name
+    pr_number, downstream_repo, job_name

--- a/torchci/lib/JobClassifierUtil.ts
+++ b/torchci/lib/JobClassifierUtil.ts
@@ -15,6 +15,7 @@ export const VIABLE_STRICT_BLOCKING_JOBS: RepoViableStrictBlockingJobsMap = {
     /lint/i,
     /linux-aarch64/i,
     /docs-build/i,
+    /\(L4\)/,
   ],
 };
 
@@ -73,10 +74,15 @@ const GROUP_LIBTORCH = "Libtorch";
 const GROUP_OTHER_VIABLE_STRICT_BLOCKING = "Other viable/strict blocking";
 const GROUP_XPU = "XPU";
 const GROUP_VLLM = "vLLM";
+const GROUP_CRCR = "CRCR";
 const GROUP_OTHER = "other";
 
 // Jobs will be grouped with the first regex they match in this list
 export const groups = [
+  {
+    regex: /^CRCR /,
+    name: GROUP_CRCR,
+  },
   {
     regex: /vllm/i,
     name: GROUP_VLLM,
@@ -235,6 +241,7 @@ const HUD_GROUP_SORTING = [
   GROUP_BINARY_WINDOWS,
   GROUP_MEMORY_LEAK_CHECK,
   GROUP_RERUN_DISABLED_TESTS,
+  GROUP_CRCR,
   // These two groups should always be at the end
   GROUP_OTHER,
   GROUP_UNSTABLE,

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -839,7 +839,10 @@ function GroupedHudTable({ params }: { params: HudParams }) {
   // Lazy-load CRCR results for commits on screen (pytorch/pytorch only)
   const isPyTorch = isPyTorchPyTorchRepo(params);
   const prNums = useMemo(
-    () => data?.map((row) => row.prNum).filter((n): n is number => n != null && n > 0) ?? [],
+    () =>
+      data
+        ?.map((row) => row.prNum)
+        .filter((n): n is number => n != null && n > 0) ?? [],
     [data]
   );
   const { data: crcrRows } = useClickHouseAPIImmutable<CrcrHudRow>(

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -748,6 +748,66 @@ function CopyPermanentLink({
   return <CopyLink textToCopy={url} compressed={false} style={style} />;
 }
 
+interface CrcrHudRow {
+  pytorch_head_sha: string;
+  downstream_repo: string;
+  downstream_repo_level: string;
+  workflow_name: string;
+  job_name: string;
+  check_run_id: string;
+  run_id: string;
+  run_attempt: number;
+  status: string;
+  conclusion: string;
+  workflow_run_url: string;
+  duration_seconds: number;
+  failed_tests_json: string;
+}
+
+function crcrToJobData(row: CrcrHudRow): JobData {
+  let conclusion: string | undefined;
+  if (row.status === "completed") {
+    conclusion = row.conclusion || "failure";
+  } else if (row.status === "in_progress") {
+    conclusion = "pending";
+  } else {
+    conclusion = undefined;
+  }
+
+  const failureLines: string[] = [];
+  if (conclusion === "failure") {
+    if (row.failed_tests_json) {
+      try {
+        const tests = JSON.parse(row.failed_tests_json);
+        if (Array.isArray(tests) && tests.length > 0) {
+          failureLines.push(
+            tests.map((t: any) => t.name || t.classname || "").join("; ")
+          );
+        }
+      } catch {
+        // fall through to synthetic failure line
+      }
+    }
+    if (failureLines.length === 0) {
+      failureLines.push(`${row.downstream_repo}/${row.job_name}`);
+    }
+  }
+
+  const level = row.downstream_repo_level || "L2";
+  return {
+    name: `CRCR ${row.downstream_repo} / ${row.job_name} (${level})`,
+    conclusion,
+    htmlUrl: row.workflow_run_url,
+    durationS: row.duration_seconds || undefined,
+    failureLines: failureLines.length > 0 ? failureLines : undefined,
+    id: row.check_run_id,
+    sha: row.pytorch_head_sha,
+    workflowName: `CRCR ${row.downstream_repo}`,
+    jobName: `${row.job_name} (${level})`,
+    runAttempt: row.run_attempt,
+  };
+}
+
 function GroupedHudTable({ params }: { params: HudParams }) {
   const router = useRouter();
   const { data, isLoading, error } = useHudData(params);
@@ -758,9 +818,6 @@ function GroupedHudTable({ params }: { params: HudParams }) {
       dedupingInterval: 300 * 1000,
       refreshInterval: 300 * 1000, // refresh every 5 minutes
     }
-  );
-  const jobNames = new Set(
-    data?.flatMap((row) => Array.from(row.nameToJobs.keys()))
   );
 
   // Lazy-load AI advisor verdicts for commits on screen
@@ -778,6 +835,51 @@ function GroupedHudTable({ params }: { params: HudParams }) {
     return buildVerdictsBySha(deduplicateVerdicts(advisorRows));
   }, [advisorRows]);
 
+  // Lazy-load CRCR results for commits on screen (pytorch/pytorch only)
+  const isPyTorch = isPyTorchPyTorchRepo(params);
+  const { data: crcrRows } = useClickHouseAPIImmutable<CrcrHudRow>(
+    "crcr_hud_results",
+    { shas },
+    isPyTorch && shas.length > 0
+  );
+
+  // Merge CRCR results into each row's nameToJobs so they appear as
+  // regular grid columns (with grouping, filtering, monsterization).
+  const dataWithCrcr = useMemo(() => {
+    if (!data) return data;
+    if (!crcrRows || crcrRows.length === 0) return data;
+
+    const crcrBySha = new Map<string, CrcrHudRow[]>();
+    for (const row of crcrRows) {
+      const list = crcrBySha.get(row.pytorch_head_sha) ?? [];
+      list.push(row);
+      crcrBySha.set(row.pytorch_head_sha, list);
+    }
+
+    return data.map((row) => {
+      const crcrForSha = crcrBySha.get(row.sha);
+      if (!crcrForSha) return row;
+
+      const merged = new Map(row.nameToJobs);
+      for (const cr of crcrForSha) {
+        const jobData = crcrToJobData(cr);
+        const existing = merged.get(jobData.name!);
+        if (
+          !existing ||
+          !existing.id ||
+          cr.run_attempt > (existing.runAttempt ?? 0)
+        ) {
+          merged.set(jobData.name!, jobData);
+        }
+      }
+      return { ...row, nameToJobs: merged };
+    });
+  }, [data, crcrRows]);
+
+  const jobNames = new Set(
+    dataWithCrcr?.flatMap((row) => Array.from(row.nameToJobs.keys()))
+  );
+
   const [hideUnstable] = usePreference("hideUnstable");
   const [hideGreenColumns] = useHideGreenColumnsPreference();
   const [hideNonViableStrict] = useHideNonViableStrictPreference();
@@ -794,7 +896,7 @@ function GroupedHudTable({ params }: { params: HudParams }) {
     jobsViableStrictBlocking,
     groupsViableStrictBlocking,
   } = getGroupingData(
-    data ?? [],
+    dataWithCrcr ?? [],
     jobNames,
     (!useGrouping && hideUnstable) || (useGrouping && !hideUnstable),
     unstableIssuesData ?? [],

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -749,6 +749,7 @@ function CopyPermanentLink({
 }
 
 interface CrcrHudRow {
+  pr_number: number;
   pytorch_head_sha: string;
   downstream_repo: string;
   downstream_repo_level: string;
@@ -837,10 +838,14 @@ function GroupedHudTable({ params }: { params: HudParams }) {
 
   // Lazy-load CRCR results for commits on screen (pytorch/pytorch only)
   const isPyTorch = isPyTorchPyTorchRepo(params);
+  const prNums = useMemo(
+    () => data?.map((row) => row.prNum).filter((n): n is number => n != null && n > 0) ?? [],
+    [data]
+  );
   const { data: crcrRows } = useClickHouseAPIImmutable<CrcrHudRow>(
     "crcr_hud_results",
-    { shas },
-    isPyTorch && shas.length > 0
+    { prNums },
+    isPyTorch && prNums.length > 0
   );
 
   // Merge CRCR results into each row's nameToJobs so they appear as
@@ -849,19 +854,20 @@ function GroupedHudTable({ params }: { params: HudParams }) {
     if (!data) return data;
     if (!crcrRows || crcrRows.length === 0) return data;
 
-    const crcrBySha = new Map<string, CrcrHudRow[]>();
+    const crcrByPr = new Map<number, CrcrHudRow[]>();
     for (const row of crcrRows) {
-      const list = crcrBySha.get(row.pytorch_head_sha) ?? [];
+      const list = crcrByPr.get(row.pr_number) ?? [];
       list.push(row);
-      crcrBySha.set(row.pytorch_head_sha, list);
+      crcrByPr.set(row.pr_number, list);
     }
 
     return data.map((row) => {
-      const crcrForSha = crcrBySha.get(row.sha);
-      if (!crcrForSha) return row;
+      if (!row.prNum) return row;
+      const crcrForPr = crcrByPr.get(row.prNum);
+      if (!crcrForPr) return row;
 
       const merged = new Map(row.nameToJobs);
-      for (const cr of crcrForSha) {
+      for (const cr of crcrForPr) {
         const jobData = crcrToJobData(cr);
         const existing = merged.get(jobData.name!);
         if (


### PR DESCRIPTION
## Summary

Integrates CRCR downstream CI results into the main HUD commit grid (`hud.pytorch.org`) as native columns with full monsterization support.

- CRCR jobs appear under a **"CRCR"** group alongside existing groups (Linux, Windows, ROCm, etc.)
- All existing HUD features work automatically: grouped view, hide-green, hide-always-skipped, job filter, tooltips, and **monsterization**
- Only fetches for `pytorch/pytorch` — no impact on other repos
- **L4 (merge-gating)** CRCR jobs are treated as viable/strict blocking; **L3 (non-blocking)** jobs are hidden when "Hide non-viable-strict jobs" is checked

### Mockup

**[Main HUD grid mockup with CRCR columns](https://subinz1.github.io/rfcs/RFC-0054-assets/oot-hud-mockup.html)**

### Approach

Mirrors the AI advisor verdicts pattern:
1. **New ClickHouse query** (`crcr_hud_results`) fetches CRCR results by commit SHA
2. **Parallel client-side fetch** via `useClickHouseAPIImmutable` (no changes to `fetchHud`)
3. **Maps CRCR results → `JobData`** and merges into each row's `nameToJobs` before grouping
4. **Zero new UI components** — existing `JobCell`, `HudGroupedCell`, and `JobConclusion` handle everything

### Level-based filtering

Column names include the CRCR level — e.g. `CRCR pytorch/crcr-test / l1-critical (L3)`. This integrates with the existing "Hide non-viable-strict jobs" filter:

| Filter state | L3 (non-blocking) | L4 (merge-gating) |
|---|---|---|
| **Unchecked** | Visible | Visible |
| **Checked** | Hidden | Visible |

L4 CRCR jobs are registered as viable/strict blocking via the `(L4)` pattern in `VIABLE_STRICT_BLOCKING_JOBS`.

### Monsterization

Failed CRCR jobs produce monster sprites by hashing:
- `failed_tests_json` content (when available from downstream test reports)
- Synthetic string `downstream_repo/job_name` (fallback — gives each unique CRCR failure type its own monster)

### Files changed

| File | Change |
|------|--------|
| `clickhouse_queries/crcr_hud_results/` | **New** — SHA-keyed query for CRCR results |
| `lib/JobClassifierUtil.ts` | Add "CRCR" group + regex + sort order; register `(L4)` as viable/strict blocking |
| `pages/hud/.../[[...page]].tsx` | CRCR data fetch, mapping, and merge logic |

## Test plan

- [ ] Verify CRCR columns appear on `hud.pytorch.org/hud/pytorch/pytorch/main`
- [ ] Verify CRCR group is collapsible in grouped view
- [ ] Verify monsterization works on failed CRCR jobs
- [ ] Verify hide-green filters out all-green CRCR columns
- [ ] Verify "Hide non-viable-strict jobs" hides L3 but keeps L4 CRCR columns
- [ ] Verify no CRCR columns on non-pytorch repos