### PR TITLE
[macOS CI] Skip conda pin on macOS base env to fix osx-arm64 nightly builds

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -129,7 +129,16 @@ runs:
           set -euxo pipefail
           CONDA_ENV="${RUNNER_TEMP}/conda_environment_${GITHUB_RUN_ID}"
           export CONDA_EXTRA_PARAM=""
-          conda install -y conda=25.3.0
+          # Only pin conda on the Linux/Windows build containers. Their base env
+          # ships an older conda and relies on the implicit `defaults` channel
+          # that conda>=26 removed (upgrading them yields NoChannelsConfiguredError
+          # on the conda create below). The macOS runners' base env is on Python
+          # 3.14 -- which conda=25.3.0 has no build for (py314 starts at 26.1.0) --
+          # and already ships a newer conda with channels configured, so leave it
+          # untouched.
+          if [[ "${RUNNER_OS}" != "macOS" ]]; then
+            conda install -y conda=25.3.0
+          fi
 
           # shellcheck disable=SC2153
           case $PYTHON_VERSION in


### PR DESCRIPTION
## Summary

macOS (osx-arm64) nightly wheel builds for the domains (torchvision/torchaudio) have failed every night since **2026-07-09** in the `setup-binary-builds` action. Linux, aarch64-Linux, and Windows are unaffected.

The macOS binary-build runners' **base** miniconda env moved to `python=3.14` (pinned). `conda install -y conda=25.3.0` is unsatisfiable there because `conda=25.3.0` has no Python 3.14 build (defaults-channel py314 builds start at **26.1.0**):

```
LibMambaUnsatisfiableError: Encountered problems while solving:
  - package conda-25.3.0-py310hca03da5_0 requires python >=3.10,<3.11.0a0, but none of the providers can be installed
...
Pins seem to be involved in the conflict. Currently pinned specs:
 - python=3.14
```

This step runs in the `base` env *before* the target env is created, which is why **all** Python versions failed identically and only osx-arm64 was affected.

## Fix

Make the conda pin conditional:

```bash
if [[ "${RUNNER_OS}" != "macOS" ]]; then
  conda install -y conda=25.3.0
fi
```

- **Linux/Windows build containers** keep the exact, known-good `conda=25.3.0`. They ship an older base env that relies on the implicit `defaults` channel that **conda >=26 removed** — upgrading them to a newer conda breaks the subsequent `conda create` with `NoChannelsConfiguredError`.
- **macOS** skips the pin. Its base env is Python 3.14 (which `conda=25.3.0` can't install into) and already ships a newer conda with channels configured, so no pin is needed.

## Test plan

- macOS: `Test Build M1 Wheels` — was already confirmed green when the macOS base env uses its bundled conda 26.x.
- Linux/Windows: unchanged behavior (still pinned to `conda=25.3.0`), so their currently-green builds stay green.
