### PR TITLE
Allowlist torchmonarch wheels

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -339,6 +339,7 @@ PACKAGE_ALLOW_LIST = {
         "Markdown",
         "MarkupSafe",
         "monarch",
+        "torchmonarch",
         "opentelemetry_api",
         "pillow",
         "pip",

--- a/s3_management/manage_v2.py
+++ b/s3_management/manage_v2.py
@@ -394,6 +394,7 @@ PACKAGE_ALLOW_LIST = {
         "Markdown",
         "MarkupSafe",
         "monarch",
+        "torchmonarch",
         "opentelemetry_api",
         "pip",
         "platformdirs",


### PR DESCRIPTION
## Summary
- add `torchmonarch` to the S3 package index allow list in `manage.py`
- add `torchmonarch` to the v2 S3 package index allow list in `manage_v2.py`

This lets the generated download.pytorch.org simple indexes include Monarch wheel uploads whose package name is `torchmonarch`.

## Test Plan
- `python3 -m py_compile s3_management/manage.py s3_management/manage_v2.py`
- `git diff --check -- s3_management/manage.py s3_management/manage_v2.py`
