### PR TITLE
[BE] Update Windows SDK version to 22621

### DIFF
--- a/aws/ami/windows/scripts/Installers/Install-VS.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-VS.ps1
@@ -27,7 +27,7 @@ $VS_INSTALL_ARGS = @("--nocache","--quiet","--wait", "--add Microsoft.VisualStud
                                                      "--add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset")
 
 if (${env:INSTALL_WINDOWS_SDK} -eq "1") {
-    $VS_INSTALL_ARGS += "--add Microsoft.VisualStudio.Component.Windows10SDK.19041"
+    $VS_INSTALL_ARGS += "--add Microsoft.VisualStudio.Component.Windows10SDK.22621"
 }
 
 if (Test-Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe") {


### PR DESCRIPTION
Works for https://github.com/pytorch/pytorch/issues/184352 to support PyTorch Windows build with python 3.15.

In PR https://github.com/pytorch/pytorch/pull/186033, we plan to enable python 3.15 PyTorch build, but missing numpy pre-built packages, so we need source code build numpy before the PyTorch build. But numpy build on Windows requires Windows SDK version > 22000 to include the missing header file `stdalign.h`. Refer https://github.com/pytorch/pytorch/actions/runs/29386139923/job/87259785893?pr=186033#step:11:2463