### PR TITLE
[CRCR] Add SHA validator for nightly/periodic callbacks (Phase 1.2)

### DIFF
--- a/aws/lambda/cross_repo_ci_relay/tests/test_sha_validator.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_sha_validator.py
@@ -3,12 +3,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import github
-from utils.sha_validator import (
-    _CacheEntry,
-    _REPO_CACHE,
-    _SHA_CACHE,
-    validate_sha,
-)
+from utils.sha_validator import _CacheEntry, _REPO_CACHE, _SHA_CACHE, validate_sha
 
 
 class TestShaValidator(unittest.TestCase):

--- a/aws/lambda/cross_repo_ci_relay/tests/test_sha_validator.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_sha_validator.py
@@ -1,16 +1,24 @@
+import time
 import unittest
 from unittest.mock import MagicMock, patch
 
 import github
-from utils.sha_validator import _SHA_CACHE, validate_sha
+from utils.sha_validator import (
+    _CacheEntry,
+    _REPO_CACHE,
+    _SHA_CACHE,
+    validate_sha,
+)
 
 
 class TestShaValidator(unittest.TestCase):
     def setUp(self):
         _SHA_CACHE.clear()
+        _REPO_CACHE.clear()
 
     def tearDown(self):
         _SHA_CACHE.clear()
+        _REPO_CACHE.clear()
 
     def test_valid_sha_returns_true(self):
         mock_gh = MagicMock()
@@ -39,21 +47,26 @@ class TestShaValidator(unittest.TestCase):
         self.assertEqual(mock_gh.get_repo.call_count, 1)
 
         validate_sha("pytorch/pytorch", "abc123", gh_client=mock_gh)
+        # repo handle is cached, so get_repo is only called once
         self.assertEqual(mock_gh.get_repo.call_count, 1)
 
     def test_different_sha_not_cached(self):
         mock_gh = MagicMock()
-        mock_gh.get_repo.return_value.get_commit.return_value = MagicMock()
+        mock_repo = MagicMock()
+        mock_gh.get_repo.return_value = mock_repo
 
         validate_sha("pytorch/pytorch", "sha1", gh_client=mock_gh)
         validate_sha("pytorch/pytorch", "sha2", gh_client=mock_gh)
 
-        self.assertEqual(mock_gh.get_repo.call_count, 2)
+        # repo handle cached, but get_commit called twice (different SHAs)
+        self.assertEqual(mock_repo.get_commit.call_count, 2)
 
     @patch("utils.sha_validator.time")
     def test_expired_cache_entry_evicted(self, mock_time):
         mock_time.monotonic.return_value = 1000.0
-        _SHA_CACHE["pytorch/pytorch:old_sha"] = 1000.0
+        _SHA_CACHE["pytorch/pytorch:old_sha"] = _CacheEntry(
+            exists=True, timestamp=1000.0
+        )
 
         mock_time.monotonic.return_value = 1000.0 + 3601
         mock_gh = MagicMock()
@@ -63,24 +76,88 @@ class TestShaValidator(unittest.TestCase):
 
         self.assertNotIn("pytorch/pytorch:old_sha", _SHA_CACHE)
 
-    def test_non_404_error_propagates(self):
+    def test_transient_error_fails_open(self):
         mock_gh = MagicMock()
         mock_gh.get_repo.return_value.get_commit.side_effect = github.GithubException(
             500, {"message": "Server Error"}, None
         )
 
-        with self.assertRaises(github.GithubException):
-            validate_sha("pytorch/pytorch", "abc123", gh_client=mock_gh)
+        result = validate_sha("pytorch/pytorch", "abc123", gh_client=mock_gh)
 
-    def test_invalid_sha_not_cached(self):
+        self.assertTrue(result)
+
+    def test_rate_limit_403_fails_open(self):
+        mock_gh = MagicMock()
+        mock_gh.get_repo.return_value.get_commit.side_effect = github.GithubException(
+            403, {"message": "rate limit exceeded"}, None
+        )
+
+        result = validate_sha("pytorch/pytorch", "abc123", gh_client=mock_gh)
+
+        self.assertTrue(result)
+
+    def test_negative_cache_hit_returns_false(self):
         mock_gh = MagicMock()
         mock_gh.get_repo.return_value.get_commit.side_effect = github.GithubException(
             404, {"message": "Not Found"}, None
         )
 
         validate_sha("pytorch/pytorch", "bad_sha", gh_client=mock_gh)
+        self.assertIn("pytorch/pytorch:bad_sha", _SHA_CACHE)
+        self.assertFalse(_SHA_CACHE["pytorch/pytorch:bad_sha"].exists)
 
-        self.assertNotIn("pytorch/pytorch:bad_sha", _SHA_CACHE)
+        # Second call hits the negative cache — no additional API call
+        mock_gh.get_repo.return_value.get_commit.reset_mock()
+        result = validate_sha("pytorch/pytorch", "bad_sha", gh_client=mock_gh)
+        self.assertFalse(result)
+        mock_gh.get_repo.return_value.get_commit.assert_not_called()
+
+    @patch("utils.sha_validator.time")
+    def test_negative_cache_expires_sooner(self, mock_time):
+        mock_time.monotonic.return_value = 1000.0
+        _SHA_CACHE["pytorch/pytorch:bad_sha"] = _CacheEntry(
+            exists=False, timestamp=1000.0
+        )
+
+        # After 301 seconds (> 300s negative TTL), entry should be evicted
+        mock_time.monotonic.return_value = 1000.0 + 301
+        mock_gh = MagicMock()
+        mock_gh.get_repo.return_value.get_commit.side_effect = github.GithubException(
+            404, {"message": "Not Found"}, None
+        )
+
+        result = validate_sha("pytorch/pytorch", "bad_sha", gh_client=mock_gh)
+        self.assertFalse(result)
+        # API was called again because cache was evicted
+        mock_gh.get_repo.return_value.get_commit.assert_called_once()
+
+    def test_cached_valid_sha_short_circuits_even_if_api_would_404(self):
+        """A previously cached valid SHA returns True without hitting the API,
+        even if the API would now return 404."""
+        _SHA_CACHE["pytorch/pytorch:abc123"] = _CacheEntry(
+            exists=True, timestamp=time.monotonic()
+        )
+
+        mock_gh = MagicMock()
+        mock_gh.get_repo.return_value.get_commit.side_effect = github.GithubException(
+            404, {"message": "Not Found"}, None
+        )
+
+        result = validate_sha("pytorch/pytorch", "abc123", gh_client=mock_gh)
+
+        self.assertTrue(result)
+        mock_gh.get_repo.return_value.get_commit.assert_not_called()
+
+    def test_repo_handle_cached(self):
+        mock_gh = MagicMock()
+        mock_repo = MagicMock()
+        mock_gh.get_repo.return_value = mock_repo
+
+        validate_sha("pytorch/pytorch", "sha1", gh_client=mock_gh)
+        validate_sha("pytorch/pytorch", "sha2", gh_client=mock_gh)
+
+        # get_repo only called once due to repo handle caching
+        mock_gh.get_repo.assert_called_once_with("pytorch/pytorch")
 
 
 if __name__ == "__main__":

--- a/aws/lambda/cross_repo_ci_relay/tests/test_sha_validator.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_sha_validator.py
@@ -1,0 +1,87 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import github
+from utils.sha_validator import _SHA_CACHE, validate_sha
+
+
+class TestShaValidator(unittest.TestCase):
+    def setUp(self):
+        _SHA_CACHE.clear()
+
+    def tearDown(self):
+        _SHA_CACHE.clear()
+
+    def test_valid_sha_returns_true(self):
+        mock_gh = MagicMock()
+        mock_gh.get_repo.return_value.get_commit.return_value = MagicMock()
+
+        result = validate_sha("pytorch/pytorch", "abc123", gh_client=mock_gh)
+
+        self.assertTrue(result)
+        mock_gh.get_repo.assert_called_once_with("pytorch/pytorch")
+
+    def test_invalid_sha_returns_false(self):
+        mock_gh = MagicMock()
+        mock_gh.get_repo.return_value.get_commit.side_effect = github.GithubException(
+            404, {"message": "Not Found"}, None
+        )
+
+        result = validate_sha("pytorch/pytorch", "bad_sha", gh_client=mock_gh)
+
+        self.assertFalse(result)
+
+    def test_cache_hit_skips_api_call(self):
+        mock_gh = MagicMock()
+        mock_gh.get_repo.return_value.get_commit.return_value = MagicMock()
+
+        validate_sha("pytorch/pytorch", "abc123", gh_client=mock_gh)
+        self.assertEqual(mock_gh.get_repo.call_count, 1)
+
+        validate_sha("pytorch/pytorch", "abc123", gh_client=mock_gh)
+        self.assertEqual(mock_gh.get_repo.call_count, 1)
+
+    def test_different_sha_not_cached(self):
+        mock_gh = MagicMock()
+        mock_gh.get_repo.return_value.get_commit.return_value = MagicMock()
+
+        validate_sha("pytorch/pytorch", "sha1", gh_client=mock_gh)
+        validate_sha("pytorch/pytorch", "sha2", gh_client=mock_gh)
+
+        self.assertEqual(mock_gh.get_repo.call_count, 2)
+
+    @patch("utils.sha_validator.time")
+    def test_expired_cache_entry_evicted(self, mock_time):
+        mock_time.monotonic.return_value = 1000.0
+        _SHA_CACHE["pytorch/pytorch:old_sha"] = 1000.0
+
+        mock_time.monotonic.return_value = 1000.0 + 3601
+        mock_gh = MagicMock()
+        mock_gh.get_repo.return_value.get_commit.return_value = MagicMock()
+
+        validate_sha("pytorch/pytorch", "new_sha", gh_client=mock_gh)
+
+        self.assertNotIn("pytorch/pytorch:old_sha", _SHA_CACHE)
+
+    def test_non_404_error_propagates(self):
+        mock_gh = MagicMock()
+        mock_gh.get_repo.return_value.get_commit.side_effect = github.GithubException(
+            500, {"message": "Server Error"}, None
+        )
+
+        with self.assertRaises(github.GithubException):
+            validate_sha("pytorch/pytorch", "abc123", gh_client=mock_gh)
+
+    def test_invalid_sha_not_cached(self):
+        mock_gh = MagicMock()
+        mock_gh.get_repo.return_value.get_commit.side_effect = github.GithubException(
+            404, {"message": "Not Found"}, None
+        )
+
+        validate_sha("pytorch/pytorch", "bad_sha", gh_client=mock_gh)
+
+        self.assertNotIn("pytorch/pytorch:bad_sha", _SHA_CACHE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/aws/lambda/cross_repo_ci_relay/utils/sha_validator.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/sha_validator.py
@@ -10,53 +10,82 @@ from __future__ import annotations
 
 import logging
 import time
+from dataclasses import dataclass
 
 import github
 
 
 logger = logging.getLogger(__name__)
 
-_SHA_CACHE: dict[str, float] = {}
 _CACHE_TTL_SECONDS = 3600  # 1 hour
+_NEGATIVE_CACHE_TTL_SECONDS = 300  # 5 minutes for 404s
+
+
+@dataclass
+class _CacheEntry:
+    exists: bool
+    timestamp: float
+
+
+_SHA_CACHE: dict[str, _CacheEntry] = {}
+_REPO_CACHE: dict[str, object] = {}
 
 
 def _evict_expired() -> None:
     now = time.monotonic()
-    expired = [k for k, v in _SHA_CACHE.items() if now - v > _CACHE_TTL_SECONDS]
+    expired = []
+    for k, entry in _SHA_CACHE.items():
+        ttl = _CACHE_TTL_SECONDS if entry.exists else _NEGATIVE_CACHE_TTL_SECONDS
+        if now - entry.timestamp > ttl:
+            expired.append(k)
     for k in expired:
         del _SHA_CACHE[k]
+
+
+def _get_repo(gh_client: github.Github, upstream_repo: str):
+    """Return a cached repo handle to avoid redundant API calls."""
+    if upstream_repo not in _REPO_CACHE:
+        _REPO_CACHE[upstream_repo] = gh_client.get_repo(upstream_repo)
+    return _REPO_CACHE[upstream_repo]
 
 
 def validate_sha(
     upstream_repo: str,
     sha: str,
-    gh_client: github.Github | None = None,
+    gh_client: github.Github,
 ) -> bool:
     """Return True if ``sha`` exists on ``upstream_repo``, False otherwise.
 
-    Results are cached for ``_CACHE_TTL_SECONDS`` to avoid repeated API calls
-    when multiple downstream repos report against the same nightly SHA.
+    Results are cached: valid SHAs for 1 hour, invalid (404) SHAs for 5 minutes.
+    The repo handle is also cached to halve API calls per cache miss.
+
+    Transient API errors (500, 403 rate-limit) fail open — since nightly results
+    are informational, a GitHub outage should not reject valid callbacks.
     """
     _evict_expired()
 
     cache_key = f"{upstream_repo}:{sha}"
     if cache_key in _SHA_CACHE:
-        return True
-
-    if gh_client is None:
-        gh_client = github.Github(timeout=10)
+        return _SHA_CACHE[cache_key].exists
 
     try:
-        gh_client.get_repo(upstream_repo).get_commit(sha)
-        _SHA_CACHE[cache_key] = time.monotonic()
+        repo = _get_repo(gh_client, upstream_repo)
+        repo.get_commit(sha)
+        _SHA_CACHE[cache_key] = _CacheEntry(exists=True, timestamp=time.monotonic())
         return True
     except github.GithubException as exc:
         if exc.status == 404:
             logger.warning("SHA %s does not exist on %s", sha, upstream_repo)
+            _SHA_CACHE[cache_key] = _CacheEntry(
+                exists=False, timestamp=time.monotonic()
+            )
             return False
-        logger.exception(
-            "GitHub API error validating SHA %s on %s",
+        # Transient errors (500, 403 rate-limit, etc.) — fail open since
+        # nightly is informational and should not be blocked by GitHub outages.
+        logger.warning(
+            "GitHub API error (%d) validating SHA %s on %s, failing open",
+            exc.status,
             sha,
             upstream_repo,
         )
-        raise
+        return True

--- a/aws/lambda/cross_repo_ci_relay/utils/sha_validator.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/sha_validator.py
@@ -1,0 +1,62 @@
+"""Validate that a commit SHA exists on pytorch/pytorch via GitHub API.
+
+Used by the nightly/periodic callback path to verify that the self-reported
+dispatch_id (commit SHA) is real before accepting the result.  A TTL cache
+avoids redundant API calls when multiple downstream repos report against the
+same SHA.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import github
+
+
+logger = logging.getLogger(__name__)
+
+_SHA_CACHE: dict[str, float] = {}
+_CACHE_TTL_SECONDS = 3600  # 1 hour
+
+
+def _evict_expired() -> None:
+    now = time.monotonic()
+    expired = [k for k, v in _SHA_CACHE.items() if now - v > _CACHE_TTL_SECONDS]
+    for k in expired:
+        del _SHA_CACHE[k]
+
+
+def validate_sha(
+    upstream_repo: str,
+    sha: str,
+    gh_client: github.Github | None = None,
+) -> bool:
+    """Return True if ``sha`` exists on ``upstream_repo``, False otherwise.
+
+    Results are cached for ``_CACHE_TTL_SECONDS`` to avoid repeated API calls
+    when multiple downstream repos report against the same nightly SHA.
+    """
+    _evict_expired()
+
+    cache_key = f"{upstream_repo}:{sha}"
+    if cache_key in _SHA_CACHE:
+        return True
+
+    if gh_client is None:
+        gh_client = github.Github(timeout=10)
+
+    try:
+        gh_client.get_repo(upstream_repo).get_commit(sha)
+        _SHA_CACHE[cache_key] = time.monotonic()
+        return True
+    except github.GithubException as exc:
+        if exc.status == 404:
+            logger.warning("SHA %s does not exist on %s", sha, upstream_repo)
+            return False
+        logger.exception(
+            "GitHub API error validating SHA %s on %s",
+            sha,
+            upstream_repo,
+        )
+        raise


### PR DESCRIPTION
## Summary

Phase 1.2 of the CRCR nightly/periodic self-report implementation ([RFC 98](https://github.com/pytorch/rfcs/pull/98)).

Adds `utils/sha_validator.py` — validates that a self-reported commit SHA exists on `pytorch/pytorch` via the GitHub API before accepting nightly/periodic callback results.

**Key features:**
- `validate_sha(upstream_repo, sha)` → `True` if SHA exists, `False` on 404, raises on other errors
- Module-level TTL cache (1 hour) avoids redundant API calls when multiple downstream repos report against the same nightly SHA
- Expired entries are evicted lazily on each call

**Depends on:** Phase 1 (#8302) — will be called from `_handle_nightly_callback()`

**Changes:**
| File | Change |
|------|--------|
| `utils/sha_validator.py` | New module: SHA validation with TTL cache |
| `tests/test_sha_validator.py` | 7 tests: valid/invalid SHA, cache hit/miss, TTL expiry, error propagation |

## Test plan
- [x] 7 unit tests covering all paths
- [ ] CI passes