### PR TITLE
Guard "Build clean" step to setup-py builds only

### DIFF
--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -176,6 +176,9 @@ jobs:
           repository: ${{ inputs.repository  }}
           script: ${{ inputs.pre-script }}
       - name: Build clean
+        # Only relevant for setup-py builds; python-build-package projects may
+        # not have a setup.py (e.g. scikit-build-core based builds).
+        if: ${{ inputs.build-platform == 'setup-py' }}
         working-directory: ${{ inputs.repository }}
         run: |
           set -euxo pipefail

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -248,7 +248,9 @@ jobs:
           echo SSL_CERT_FILE=%CERT_PATH% >> %GITHUB_ENV%
           echo REQUESTS_CA_BUNDLE=%CERT_PATH% >> %GITHUB_ENV%
       - name: Build clean
-        if: inputs.architecture == 'x64'
+        # Only relevant for setup-py builds; python-build-package projects may
+        # not have a setup.py (e.g. scikit-build-core based builds).
+        if: inputs.build-platform == 'setup-py' && inputs.architecture == 'x64'
         working-directory: ${{ inputs.repository }}
         env:
           ENV_SCRIPT: ${{ inputs.env-script }}


### PR DESCRIPTION
The macOS and Windows  `wheel-build` workflows run `setup.py clean` in a dedicated unconditionally, even when `build-platform` is 'python-build-package'.

This is a problem because we are trying to rely on `scikit-build-core` in TorchCodec where we have removed the `setup.py` file: https://github.com/meta-pytorch/torchcodec/pull/1436. Since those scripts are relying on `setup.py` unconditionally, the TorchCodec build fails.

Note that the linux jobs are already properly gating this.