### PR TITLE
[CRCR] Add metrics page with success-rate graphs

### DIFF
--- a/torchci/clickhouse_queries/crcr_success_rate/params.json
+++ b/torchci/clickhouse_queries/crcr_success_rate/params.json
@@ -1,0 +1,10 @@
+{
+  "params": {
+    "days": "UInt64"
+  },
+  "tests": [
+    {
+      "days": "30"
+    }
+  ]
+}

--- a/torchci/clickhouse_queries/crcr_success_rate/query.sql
+++ b/torchci/clickhouse_queries/crcr_success_rate/query.sql
@@ -1,0 +1,17 @@
+SELECT
+    toDate(started_at) AS day,
+    downstream_repo AS repo,
+    countIf(conclusion = 'success') AS successes,
+    countIf(conclusion = 'failure') AS failures,
+    countIf(conclusion = 'timed_out') AS timed_out,
+    count() AS total,
+    if(total > 0, successes / total, 0) AS pass_rate
+FROM
+    default.crcr_workflow_job FINAL
+WHERE
+    started_at > now() - INTERVAL {days: UInt64} DAY
+    AND status = 'completed'
+GROUP BY
+    day, repo
+ORDER BY
+    day ASC, repo ASC

--- a/torchci/components/layout/NavBar.tsx
+++ b/torchci/components/layout/NavBar.tsx
@@ -125,6 +125,10 @@ function NavBar() {
       name: "Claude Billing",
       href: "/claude_billing",
     },
+    {
+      name: "CRCR Metrics",
+      href: "/crcr/metrics",
+    },
   ].map((item) => ({
     label: item.name,
     route: item.href,
@@ -163,11 +167,6 @@ function NavBar() {
           <li>
             <Link prefetch={false} href="/crcr">
               CRCR
-            </Link>
-          </li>
-          <li>
-            <Link prefetch={false} href="/crcr/metrics">
-              CRCR Metrics
             </Link>
           </li>
         </ul>

--- a/torchci/components/layout/NavBar.tsx
+++ b/torchci/components/layout/NavBar.tsx
@@ -165,6 +165,11 @@ function NavBar() {
               CRCR
             </Link>
           </li>
+          <li>
+            <Link prefetch={false} href="/crcr/metrics">
+              CRCR Metrics
+            </Link>
+          </li>
         </ul>
       </div>
       <div

--- a/torchci/pages/crcr/index.tsx
+++ b/torchci/pages/crcr/index.tsx
@@ -491,7 +491,11 @@ export default function CrcrSummaryPage() {
             rel="noreferrer"
           >
             HUD dashboard
-          </Link>
+          </Link>{" "}
+          or view{" "}
+          <NextLink href="/crcr/metrics" passHref legacyBehavior>
+            <Link underline="hover">success-rate trends</Link>
+          </NextLink>
           .
         </Typography>
 

--- a/torchci/pages/crcr/metrics.tsx
+++ b/torchci/pages/crcr/metrics.tsx
@@ -1,0 +1,260 @@
+import {
+  Box,
+  FormControl,
+  InputLabel,
+  Link,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Skeleton,
+  Stack,
+  Typography,
+} from "@mui/material";
+import {
+  seriesWithInterpolatedTimes,
+  TimeSeriesPanelWithData,
+} from "components/metrics/panels/TimeSeriesPanel";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import { fetcher } from "lib/GeneralUtils";
+import Head from "next/head";
+import NextLink from "next/link";
+import { useMemo, useState } from "react";
+import useSWR from "swr";
+dayjs.extend(utc);
+
+interface SuccessRateRow {
+  day: string;
+  repo: string;
+  successes: number;
+  failures: number;
+  timed_out: number;
+  total: number;
+  pass_rate: number;
+}
+
+function PassRateChart({
+  data,
+  days,
+}: {
+  data: SuccessRateRow[];
+  days: number;
+}) {
+  const startTime = dayjs.utc().subtract(days, "day").startOf("day");
+  const stopTime = dayjs.utc().endOf("day");
+
+  const series = seriesWithInterpolatedTimes(
+    data,
+    startTime,
+    stopTime,
+    "day",
+    "repo",
+    "day",
+    "pass_rate",
+    true,
+    true,
+    "name",
+    "line"
+  );
+
+  return (
+    <Box sx={{ height: 420 }}>
+      <TimeSeriesPanelWithData
+        data={data}
+        series={series}
+        title="Pass Rate Over Time"
+        groupByFieldName="repo"
+        yAxisRenderer={(v: number) => `${(v * 100).toFixed(0)}%`}
+        yAxisLabel="Pass Rate"
+        additionalOptions={{
+          yAxis: { min: 0, max: 1 },
+        }}
+        useUTC
+      />
+    </Box>
+  );
+}
+
+function FailuresChart({
+  data,
+  days,
+}: {
+  data: SuccessRateRow[];
+  days: number;
+}) {
+  const startTime = dayjs.utc().subtract(days, "day").startOf("day");
+  const stopTime = dayjs.utc().endOf("day");
+
+  const series = seriesWithInterpolatedTimes(
+    data,
+    startTime,
+    stopTime,
+    "day",
+    "repo",
+    "day",
+    "failures",
+    true,
+    false,
+    "name",
+    "stacked_bar"
+  );
+
+  return (
+    <Box sx={{ height: 420 }}>
+      <TimeSeriesPanelWithData
+        data={data}
+        series={series}
+        title="Failures Over Time"
+        groupByFieldName="repo"
+        yAxisRenderer={(v: number) => String(Math.round(v))}
+        yAxisLabel="Failures"
+        useUTC
+      />
+    </Box>
+  );
+}
+
+function TotalRunsChart({
+  data,
+  days,
+}: {
+  data: SuccessRateRow[];
+  days: number;
+}) {
+  const startTime = dayjs.utc().subtract(days, "day").startOf("day");
+  const stopTime = dayjs.utc().endOf("day");
+
+  const series = seriesWithInterpolatedTimes(
+    data,
+    startTime,
+    stopTime,
+    "day",
+    "repo",
+    "day",
+    "total",
+    true,
+    false,
+    "name",
+    "stacked_bar"
+  );
+
+  return (
+    <Box sx={{ height: 420 }}>
+      <TimeSeriesPanelWithData
+        data={data}
+        series={series}
+        title="Total Runs Over Time"
+        groupByFieldName="repo"
+        yAxisRenderer={(v: number) => String(Math.round(v))}
+        yAxisLabel="Total Runs"
+        useUTC
+      />
+    </Box>
+  );
+}
+
+export default function CrcrMetricsPage() {
+  const [days, setDays] = useState(30);
+
+  const url = `/api/clickhouse/crcr_success_rate?parameters=${encodeURIComponent(
+    JSON.stringify({ days: String(days) })
+  )}`;
+  const { data, error } = useSWR<SuccessRateRow[]>(url, fetcher, {
+    refreshInterval: 5 * 60_000,
+  });
+
+  const repos = useMemo(() => {
+    if (!data) return [];
+    return [...new Set(data.map((r) => r.repo))].sort();
+  }, [data]);
+
+  const isLoading = !data && !error;
+
+  return (
+    <>
+      <Head>
+        <title>CRCR Metrics | PyTorch HUD</title>
+      </Head>
+      <Stack spacing={3} sx={{ p: 3, maxWidth: 1400, mx: "auto" }}>
+        <Box display="flex" justifyContent="space-between" alignItems="center">
+          <Typography variant="h4">CRCR Metrics</Typography>
+          <FormControl size="small" sx={{ minWidth: 140 }}>
+            <InputLabel>Time Range</InputLabel>
+            <Select
+              value={days}
+              label="Time Range"
+              onChange={(e: SelectChangeEvent<number>) =>
+                setDays(Number(e.target.value))
+              }
+            >
+              <MenuItem value={7}>Last 7 days</MenuItem>
+              <MenuItem value={14}>Last 14 days</MenuItem>
+              <MenuItem value={30}>Last 30 days</MenuItem>
+              <MenuItem value={90}>Last 90 days</MenuItem>
+            </Select>
+          </FormControl>
+        </Box>
+
+        <Typography variant="body2" color="text.secondary">
+          Success rate and failure trends for all CRCR-registered downstream
+          repos.{" "}
+          <NextLink href="/crcr" passHref legacyBehavior>
+            <Link underline="hover">Back to CRCR Summary</Link>
+          </NextLink>
+        </Typography>
+
+        {error && (
+          <Typography color="error">
+            {error.message || "Failed to load metrics data"}
+          </Typography>
+        )}
+
+        {isLoading && (
+          <Stack spacing={2}>
+            <Skeleton variant="rectangular" height={420} />
+            <Skeleton variant="rectangular" height={420} />
+          </Stack>
+        )}
+
+        {data && (
+          <Stack spacing={3}>
+            <PassRateChart data={data} days={days} />
+            <FailuresChart data={data} days={days} />
+            <TotalRunsChart data={data} days={days} />
+          </Stack>
+        )}
+
+        {data && repos.length > 0 && (
+          <Box>
+            <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+              Repos in view ({repos.length}):
+            </Typography>
+            <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+              {repos.map((repo) => (
+                <NextLink
+                  key={repo}
+                  href={`/crcr/${repo}`}
+                  passHref
+                  legacyBehavior
+                >
+                  <Link
+                    underline="hover"
+                    sx={{
+                      fontSize: "0.85rem",
+                      px: 1,
+                      py: 0.25,
+                      bgcolor: "action.hover",
+                      borderRadius: 1,
+                    }}
+                  >
+                    {repo}
+                  </Link>
+                </NextLink>
+              ))}
+            </Box>
+          </Box>
+        )}
+      </Stack>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a new CRCR Metrics page at `hud.pytorch.org/crcr/metrics` with time-series charts showing:

- **Pass Rate Over Time** — daily success rate per downstream repo (line chart)
- **Failures Over Time** — daily failure count per repo (stacked bar chart)
- **Total Runs Over Time** — daily run volume per repo (stacked bar chart)

Uses the existing `TimeSeriesPanel` (echarts) component with a new `crcr_success_rate` ClickHouse query that aggregates daily success/failure/timed_out counts from `crcr_workflow_job`.

### Changes
- **New ClickHouse query**: `crcr_success_rate` — daily pass_rate, failures, total by repo
- **New page**: `pages/crcr/metrics.tsx` — metrics page with 3 charts and time range selector
- **NavBar**: Added "CRCR Metrics" link
- **CRCR Summary**: Added link to metrics page in description text

Resolves https://github.com/pytorch/test-infra/issues/8308

## Test plan
- [ ] Verify ClickHouse query returns expected results
- [ ] Check charts render correctly with time range selector (7d, 14d, 30d, 90d)
- [ ] Verify "CRCR Metrics" link appears in navbar
- [ ] Verify "success-rate trends" link on CRCR summary page navigates correctly
- [ ] Verify dark mode works (echarts theme)