### PR TITLE
[CRCR][HUD] Add downstream repo summary page with stats

### DIFF
--- a/torchci/clickhouse_queries/crcr_backend_summary/params.json
+++ b/torchci/clickhouse_queries/crcr_backend_summary/params.json
@@ -1,0 +1,12 @@
+{
+  "params": {
+    "repo": "String",
+    "days": "UInt64"
+  },
+  "tests": [
+    {
+      "repo": "<company>/<repo>",
+      "days": "7"
+    }
+  ]
+}

--- a/torchci/clickhouse_queries/crcr_backend_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_backend_summary/query.sql
@@ -1,0 +1,32 @@
+SELECT
+    countIf(conclusion = 'success') AS successes,
+    countIf(conclusion = 'failure') AS failures,
+    countIf(conclusion = 'timed_out') AS timed_out,
+    count() AS total_jobs,
+    if(total_jobs > 0, successes / total_jobs, 0) AS pass_rate,
+    uniqExact(pr_number) AS total_prs,
+    avg(queue_time) AS avg_queue_time_s,
+    avg(execution_time) AS avg_exec_time_s,
+    -- Flaky: jobs where the same job_name has both success and failure
+    -- across different run_attempts for the same PR
+    uniqExactIf(
+        job_name,
+        job_name IN (
+            SELECT job_name
+            FROM default.crcr_workflow_job FINAL
+            WHERE
+                downstream_repo = {repo: String}
+                AND started_at > now() - INTERVAL {days: UInt64} DAY
+                AND status = 'completed'
+            GROUP BY pr_number, job_name
+            HAVING
+                countIf(conclusion = 'success') > 0
+                AND countIf(conclusion = 'failure') > 0
+        )
+    ) AS flaky_jobs
+FROM
+    default.crcr_workflow_job FINAL
+WHERE
+    downstream_repo = {repo: String}
+    AND started_at > now() - INTERVAL {days: UInt64} DAY
+    AND status = 'completed'

--- a/torchci/pages/api/crcr/commit-info.ts
+++ b/torchci/pages/api/crcr/commit-info.ts
@@ -1,0 +1,70 @@
+import { getOctokit } from "lib/github";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+interface CommitInfo {
+  sha: string;
+  title: string;
+  author: string;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { repo, shas } = req.query;
+  if (!repo || !shas) {
+    return res
+      .status(400)
+      .json({ error: "Missing required params: repo, shas" });
+  }
+
+  const repoStr = Array.isArray(repo) ? repo[0] : repo;
+  const shaList = (Array.isArray(shas) ? shas[0] : shas)
+    .split(",")
+    .filter(Boolean)
+    .slice(0, 50);
+
+  if (shaList.length === 0) {
+    return res.status(200).json([]);
+  }
+
+  const [owner, name] = repoStr.split("/");
+  if (!owner || !name) {
+    return res.status(400).json({ error: "repo must be owner/name format" });
+  }
+
+  try {
+    const octokit = await getOctokit(owner, name);
+    const results: CommitInfo[] = [];
+
+    // Fetch commits in parallel (bounded to 50 max)
+    const promises = shaList.map(async (sha) => {
+      try {
+        const { data } = await octokit.rest.repos.getCommit({
+          owner,
+          repo: name,
+          ref: sha,
+        });
+        const message = data.commit.message.split("\n")[0];
+        return {
+          sha,
+          title: message,
+          author: data.author?.login ?? data.commit.author?.name ?? "unknown",
+        };
+      } catch {
+        return { sha, title: "", author: "" };
+      }
+    });
+
+    const settled = await Promise.all(promises);
+    results.push(...settled);
+
+    // Commits are immutable — cache aggressively
+    res
+      .setHeader("Cache-Control", "s-maxage=86400, stale-while-revalidate=3600")
+      .status(200)
+      .json(results);
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+}

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Checkbox,
-  Chip,
   FormControl,
   FormControlLabel,
   InputLabel,
@@ -24,7 +23,7 @@ import {
 import { durationDisplay } from "components/common/TimeUtils";
 import { JobStatus } from "components/job/GroupJobConclusion";
 import { getFailureEl } from "components/job/JobConclusion";
-import { fetcher } from "lib/GeneralUtils";
+import { getConclusionChar } from "lib/JobClassifierUtil";
 import { JobData } from "lib/types";
 import Head from "next/head";
 import NextLink from "next/link";
@@ -32,7 +31,7 @@ import { useRouter } from "next/router";
 import { createContext, useContext, useMemo, useState } from "react";
 import useSWR from "swr";
 
-import { conclusionColor, conclusionLabel } from "lib/crcr/crcrUtils";
+import { fetcher } from "lib/GeneralUtils";
 
 // Local monsterization context for this page
 const CrcrMonsterContext = createContext<boolean>(false);
@@ -173,15 +172,27 @@ function SummaryCards({ stats }: { stats: SummaryStats }) {
   );
 }
 
-// ---- Job Chip (with monsterization) ----
+// ---- Job Cell (colored character, matching main HUD style) ----
 
-function JobChip({ job }: { job: CrcrJobRow }) {
+const conclusionCssColor: Record<string, string> = {
+  success: "var(--color-success, #3fb950)",
+  failure: "var(--color-failure, #f85149)",
+  cancelled: "var(--color-failure, #f85149)",
+  timed_out: "var(--color-failure, #f85149)",
+  pending: "var(--color-pending, #d29922)",
+  skipped: "var(--color-grey, #8b949e)",
+  neutral: "var(--color-grey, #8b949e)",
+};
+
+function JobCell({ job }: { job: CrcrJobRow }) {
   const monsterFailures = useContext(CrcrMonsterContext);
-  const color = conclusionColor(job.status, job.conclusion);
-  const label = conclusionLabel(job.status, job.conclusion);
+  const conclusion = job.status === "completed" ? job.conclusion : job.status;
+  const char = getConclusionChar(conclusion);
+  const color = conclusionCssColor[conclusion] ?? "var(--color-grey, #8b949e)";
 
   const tooltipContent = [
     `Job: ${job.job_name}`,
+    `Status: ${conclusion}`,
     job.run_attempt > 1 ? `Attempt: ${job.run_attempt}` : null,
     `Duration: ${
       job.duration_seconds
@@ -197,11 +208,7 @@ function JobChip({ job }: { job: CrcrJobRow }) {
     .join("\n");
 
   // Monsterization: show monster sprite for failures
-  if (
-    monsterFailures &&
-    job.status === "completed" &&
-    job.conclusion === "failure"
-  ) {
+  if (monsterFailures && conclusion === "failure") {
     const syntheticJobData: JobData = {
       failureLines: [job.job_name + (job.conclusion || "")],
     } as JobData;
@@ -217,7 +224,7 @@ function JobChip({ job }: { job: CrcrJobRow }) {
             href={job.workflow_run_url}
             target="_blank"
             rel="noopener noreferrer"
-            style={{ display: "inline-block", margin: "0 2px" }}
+            style={{ display: "inline-block" }}
           >
             {monsterEl}
           </a>
@@ -230,17 +237,23 @@ function JobChip({ job }: { job: CrcrJobRow }) {
     <Tooltip
       title={<span style={{ whiteSpace: "pre-line" }}>{tooltipContent}</span>}
     >
-      <Chip
-        label={label}
-        color={color}
-        size="small"
-        component="a"
+      <a
         href={job.workflow_run_url}
         target="_blank"
-        rel="noopener"
-        clickable
-        sx={{ mx: 0.25 }}
-      />
+        rel="noopener noreferrer"
+        style={{
+          fontFamily: "monospace",
+          fontWeight: "bold",
+          fontSize: "1rem",
+          display: "inline-block",
+          width: "14px",
+          textAlign: "center",
+          color,
+          textDecoration: "none",
+        }}
+      >
+        {char}
+      </a>
     </Tooltip>
   );
 }
@@ -479,7 +492,7 @@ function CrcrMatrix({
                   const job = row.jobs.get(name);
                   return (
                     <TableCell key={name} align="center">
-                      {job ? <JobChip job={job} /> : "–"}
+                      {job ? <JobCell job={job} /> : "–"}
                     </TableCell>
                   );
                 })}

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -505,9 +505,20 @@ export default function CrcrBackendPage() {
   const page = parseInt(router.query.page as string) || 1;
   const days = parseInt(router.query.days as string) || 7;
 
-  if (!org || !repo) return null;
+  const repoFullName =
+    org && repo ? `${org}/${repo}` : "";
 
-  const repoFullName = `${org}/${repo}`;
+  const summaryUrl = repoFullName
+    ? `/api/clickhouse/crcr_backend_summary?parameters=${encodeURIComponent(
+        JSON.stringify({ repo: repoFullName, days: String(days) })
+      )}`
+    : null;
+  const { data: summaryData } = useSWR<SummaryStats[]>(summaryUrl, fetcher, {
+    refreshInterval: 60_000,
+  });
+  const stats = summaryData?.[0] ?? null;
+
+  if (!org || !repo) return null;
 
   function updateQuery(updates: Record<string, string | number>) {
     router.push(
@@ -516,14 +527,6 @@ export default function CrcrBackendPage() {
       { shallow: true }
     );
   }
-
-  const summaryUrl = `/api/clickhouse/crcr_backend_summary?parameters=${encodeURIComponent(
-    JSON.stringify({ repo: repoFullName, days: String(days) })
-  )}`;
-  const { data: summaryData } = useSWR<SummaryStats[]>(summaryUrl, fetcher, {
-    refreshInterval: 60_000,
-  });
-  const stats = summaryData?.[0] ?? null;
 
   return (
     <CrcrMonsterContext.Provider value={monsterFailures}>

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -1,7 +1,9 @@
 import {
   Box,
+  Checkbox,
   Chip,
   FormControl,
+  FormControlLabel,
   InputLabel,
   Link,
   MenuItem,
@@ -20,13 +22,22 @@ import {
   Typography,
 } from "@mui/material";
 import { durationDisplay } from "components/common/TimeUtils";
+import { getFailureEl } from "components/job/JobConclusion";
+import { JobStatus } from "components/job/GroupJobConclusion";
 import { fetcher } from "lib/GeneralUtils";
-import { conclusionColor, conclusionLabel } from "lib/crcr/crcrUtils";
+import { JobData } from "lib/types";
 import Head from "next/head";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
-import { useMemo } from "react";
+import { createContext, useContext, useMemo, useState } from "react";
 import useSWR from "swr";
+
+import { conclusionColor, conclusionLabel } from "lib/crcr/crcrUtils";
+
+// Local monsterization context for this page
+const CrcrMonsterContext = createContext<boolean>(false);
+
+// ---- Types ----
 
 interface CrcrJobRow {
   upstream_repo: string;
@@ -52,9 +63,123 @@ interface CrcrJobRow {
   execution_time: number | null;
 }
 
+interface SummaryStats {
+  successes: number;
+  failures: number;
+  timed_out: number;
+  total_jobs: number;
+  pass_rate: number;
+  total_prs: number;
+  avg_queue_time_s: number | null;
+  avg_exec_time_s: number | null;
+  flaky_jobs: number;
+}
+
+// ---- Summary Stat Cards ----
+
+function StatCard({
+  label,
+  value,
+  sub,
+  color,
+}: {
+  label: string;
+  value: string | number;
+  sub?: string;
+  color?: string;
+}) {
+  return (
+    <Paper
+      elevation={1}
+      sx={{
+        p: 2,
+        minWidth: 140,
+        flex: 1,
+        textAlign: "center",
+        borderTop: color ? `3px solid ${color}` : undefined,
+      }}
+    >
+      <Typography variant="caption" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="h5" sx={{ fontWeight: 600, color: color }}>
+        {value}
+      </Typography>
+      {sub && (
+        <Typography variant="caption" color="text.secondary">
+          {sub}
+        </Typography>
+      )}
+    </Paper>
+  );
+}
+
+function SummaryCards({ stats }: { stats: SummaryStats }) {
+  const passColor =
+    stats.pass_rate >= 0.95
+      ? "#2e7d32"
+      : stats.pass_rate >= 0.8
+        ? "#ed6c02"
+        : "#d32f2f";
+
+  return (
+    <Stack spacing={2}>
+      <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+        <StatCard
+          label="Pass Rate"
+          value={`${(stats.pass_rate * 100).toFixed(1)}%`}
+          sub={`${stats.successes}/${stats.total_jobs} jobs`}
+          color={passColor}
+        />
+        <StatCard
+          label="Total PRs"
+          value={stats.total_prs}
+          sub="unique PRs tested"
+        />
+        <StatCard
+          label="Failures"
+          value={stats.failures}
+          sub={stats.timed_out > 0 ? `+ ${stats.timed_out} timed out` : ""}
+          color={stats.failures > 0 ? "#d32f2f" : undefined}
+        />
+      </Box>
+      <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+        <StatCard
+          label="Avg Queue Time"
+          value={
+            stats.avg_queue_time_s != null
+              ? durationDisplay(Math.round(stats.avg_queue_time_s))
+              : "–"
+          }
+          sub="dispatch to start"
+        />
+        <StatCard
+          label="Avg Execution Time"
+          value={
+            stats.avg_exec_time_s != null
+              ? durationDisplay(Math.round(stats.avg_exec_time_s))
+              : "–"
+          }
+          sub="start to completion"
+        />
+        <StatCard
+          label="Flaky Jobs"
+          value={stats.flaky_jobs}
+          sub="same job: pass + fail across attempts"
+          color={stats.flaky_jobs > 0 ? "#ed6c02" : undefined}
+        />
+      </Box>
+    </Stack>
+  );
+}
+
+// ---- Job Chip (with monsterization) ----
+
 function JobChip({ job }: { job: CrcrJobRow }) {
+  const monsterFailures = useContext(CrcrMonsterContext);
   const color = conclusionColor(job.status, job.conclusion);
   const label = conclusionLabel(job.status, job.conclusion);
+
   const tooltipContent = [
     `Job: ${job.job_name}`,
     job.run_attempt > 1 ? `Attempt: ${job.run_attempt}` : null,
@@ -70,6 +195,32 @@ function JobChip({ job }: { job: CrcrJobRow }) {
   ]
     .filter(Boolean)
     .join("\n");
+
+  // Monsterization: show monster sprite for failures
+  if (monsterFailures && job.status === "completed" && job.conclusion === "failure") {
+    const syntheticJobData: JobData = {
+      failureLines: [job.job_name + (job.conclusion || "")],
+    } as JobData;
+    const monsterEl = getFailureEl(JobStatus.Failure, syntheticJobData);
+    if (monsterEl) {
+      return (
+        <Tooltip
+          title={
+            <span style={{ whiteSpace: "pre-line" }}>{tooltipContent}</span>
+          }
+        >
+          <a
+            href={job.workflow_run_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ display: "inline-block", margin: "0 2px" }}
+          >
+            {monsterEl}
+          </a>
+        </Tooltip>
+      );
+    }
+  }
 
   return (
     <Tooltip
@@ -90,10 +241,13 @@ function JobChip({ job }: { job: CrcrJobRow }) {
   );
 }
 
+// ---- Matrix Builder ----
+
 interface MatrixRow {
   prNumber: number;
   sha: string;
   upstreamRepo: string;
+  latestTime: string;
   jobs: Map<string, CrcrJobRow>;
 }
 
@@ -112,11 +266,16 @@ function buildMatrix(data: CrcrJobRow[]): {
         prNumber: job.pr_number,
         sha: job.pytorch_head_sha,
         upstreamRepo: job.upstream_repo ?? "pytorch/pytorch",
+        latestTime: job.started_at,
         jobs: new Map(),
       };
       prMap.set(job.pr_number, row);
     }
-    // Keep the latest attempt per job_name (highest run_attempt wins)
+    // Track latest started_at for this PR
+    if (job.started_at > row.latestTime) {
+      row.latestTime = job.started_at;
+    }
+    // Keep the latest attempt per job_name
     const existing = row.jobs.get(job.job_name);
     if (!existing || job.run_attempt > existing.run_attempt) {
       row.jobs.set(job.job_name, job);
@@ -130,24 +289,25 @@ function buildMatrix(data: CrcrJobRow[]): {
   return { jobNames, rows };
 }
 
-function HealthSummary({ data }: { data: CrcrJobRow[] }) {
-  const completed = data.filter((j) => j.status === "completed");
-  const total = completed.length;
-  const success = completed.filter((j) => j.conclusion === "success").length;
-  const rate = total > 0 ? success / total : 0;
+// ---- Time display ----
 
-  return (
-    <Stack direction="row" spacing={2} alignItems="center">
-      <Chip
-        label={`Pass rate: ${(rate * 100).toFixed(1)}%`}
-        color={rate >= 0.95 ? "success" : rate >= 0.8 ? "warning" : "error"}
-      />
-      <Typography variant="body2" color="text.secondary">
-        {success}/{total} jobs passed (this page)
-      </Typography>
-    </Stack>
-  );
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
 }
+
+function formatShortDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+// ---- Pagination ----
 
 const PER_PAGE = 50;
 
@@ -189,6 +349,8 @@ function CrcrPagination({
     </div>
   );
 }
+
+// ---- PR Matrix Table ----
 
 function CrcrMatrix({
   repoFullName,
@@ -256,16 +418,18 @@ function CrcrMatrix({
 
   return (
     <>
-      <HealthSummary data={data} />
-      <TableContainer component={Paper} elevation={2} sx={{ mt: 2 }}>
+      <TableContainer component={Paper} elevation={2}>
         <Table size="small">
           <TableHead>
             <TableRow>
               <TableCell>
-                <strong>PR</strong>
+                <strong>Time</strong>
               </TableCell>
               <TableCell>
                 <strong>SHA</strong>
+              </TableCell>
+              <TableCell>
+                <strong>PR</strong>
               </TableCell>
               {matrix.jobNames.map((name) => (
                 <TableCell key={name} align="center">
@@ -277,23 +441,35 @@ function CrcrMatrix({
           <TableBody>
             {matrix.rows.map((row) => (
               <TableRow key={row.prNumber} hover>
-                <TableCell>
-                  <NextLink
-                    href={`https://github.com/${
-                      row.upstreamRepo ?? "pytorch/pytorch"
-                    }/pull/${row.prNumber}`}
-                    passHref
-                    legacyBehavior
-                  >
-                    <Link target="_blank" rel="noopener" underline="hover">
-                      #{row.prNumber}
-                    </Link>
-                  </NextLink>
+                <TableCell sx={{ whiteSpace: "nowrap" }}>
+                  <Tooltip title={new Date(row.latestTime).toLocaleString()}>
+                    <Typography variant="body2" color="text.secondary">
+                      {formatShortDate(row.latestTime)}
+                      <br />
+                      <small>{timeAgo(row.latestTime)}</small>
+                    </Typography>
+                  </Tooltip>
                 </TableCell>
                 <TableCell>
-                  <Typography variant="body2" fontFamily="monospace">
+                  <Link
+                    href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
+                    target="_blank"
+                    rel="noopener"
+                    underline="hover"
+                    sx={{ fontFamily: "monospace", fontSize: "0.85rem" }}
+                  >
                     {row.sha.slice(0, 7)}
-                  </Typography>
+                  </Link>
+                </TableCell>
+                <TableCell>
+                  <Link
+                    href={`https://github.com/${row.upstreamRepo}/pull/${row.prNumber}`}
+                    target="_blank"
+                    rel="noopener"
+                    underline="hover"
+                  >
+                    #{row.prNumber}
+                  </Link>
                 </TableCell>
                 {matrix.jobNames.map((name) => {
                   const job = row.jobs.get(name);
@@ -319,9 +495,12 @@ function CrcrMatrix({
   );
 }
 
+// ---- Main Page ----
+
 export default function CrcrBackendPage() {
   const router = useRouter();
   const { org, repo } = router.query;
+  const [monsterFailures, setMonsterFailures] = useState(false);
 
   const page = parseInt(router.query.page as string) || 1;
   const days = parseInt(router.query.days as string) || 7;
@@ -338,8 +517,16 @@ export default function CrcrBackendPage() {
     );
   }
 
+  const summaryUrl = `/api/clickhouse/crcr_backend_summary?parameters=${encodeURIComponent(
+    JSON.stringify({ repo: repoFullName, days: String(days) })
+  )}`;
+  const { data: summaryData } = useSWR<SummaryStats[]>(summaryUrl, fetcher, {
+    refreshInterval: 60_000,
+  });
+  const stats = summaryData?.[0] ?? null;
+
   return (
-    <>
+    <CrcrMonsterContext.Provider value={monsterFailures}>
       <Head>
         <title>{repoFullName} — CRCR CI | PyTorch HUD</title>
       </Head>
@@ -347,27 +534,58 @@ export default function CrcrBackendPage() {
         <Box display="flex" justifyContent="space-between" alignItems="center">
           <Stack spacing={0.5}>
             <Typography variant="h4">{repoFullName}</Typography>
-            <NextLink href="/crcr" passHref legacyBehavior>
-              <Link variant="body2" underline="hover">
-                ← Back to CRCR Summary
+            <Stack direction="row" spacing={2} alignItems="center">
+              <NextLink href="/crcr" passHref legacyBehavior>
+                <Link variant="body2" underline="hover">
+                  ← Back to CRCR Summary
+                </Link>
+              </NextLink>
+              <Link
+                href={`https://github.com/${repoFullName}`}
+                target="_blank"
+                rel="noopener"
+                variant="body2"
+                underline="hover"
+              >
+                GitHub ↗
               </Link>
-            </NextLink>
+            </Stack>
           </Stack>
-          <FormControl size="small" sx={{ minWidth: 140 }}>
-            <InputLabel>Time Range</InputLabel>
-            <Select
-              value={days}
-              label="Time Range"
-              onChange={(e: SelectChangeEvent<number>) =>
-                updateQuery({ days: Number(e.target.value), page: 1 })
+          <Stack direction="row" spacing={2} alignItems="center">
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={monsterFailures}
+                  onChange={(e) => setMonsterFailures(e.target.checked)}
+                  size="small"
+                />
               }
-            >
-              <MenuItem value={1}>Last 24h</MenuItem>
-              <MenuItem value={7}>Last 7 days</MenuItem>
-              <MenuItem value={30}>Last 30 days</MenuItem>
-            </Select>
-          </FormControl>
+              label={
+                <Typography variant="body2">Monsterize failures</Typography>
+              }
+            />
+            <FormControl size="small" sx={{ minWidth: 140 }}>
+              <InputLabel>Time Range</InputLabel>
+              <Select
+                value={days}
+                label="Time Range"
+                onChange={(e: SelectChangeEvent<number>) =>
+                  updateQuery({ days: Number(e.target.value), page: 1 })
+                }
+              >
+                <MenuItem value={1}>Last 24h</MenuItem>
+                <MenuItem value={7}>Last 7 days</MenuItem>
+                <MenuItem value={30}>Last 30 days</MenuItem>
+              </Select>
+            </FormControl>
+          </Stack>
         </Box>
+
+        {stats ? (
+          <SummaryCards stats={stats} />
+        ) : (
+          <Skeleton variant="rectangular" height={140} />
+        )}
 
         <Typography variant="body2" color="text.secondary">
           Rows = PyTorch PRs (50 per page), columns = downstream CI jobs. Click
@@ -381,6 +599,6 @@ export default function CrcrBackendPage() {
           onPageChange={(p) => updateQuery({ page: p })}
         />
       </Stack>
-    </>
+    </CrcrMonsterContext.Provider>
   );
 }

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -22,8 +22,8 @@ import {
   Typography,
 } from "@mui/material";
 import { durationDisplay } from "components/common/TimeUtils";
-import { getFailureEl } from "components/job/JobConclusion";
 import { JobStatus } from "components/job/GroupJobConclusion";
+import { getFailureEl } from "components/job/JobConclusion";
 import { fetcher } from "lib/GeneralUtils";
 import { JobData } from "lib/types";
 import Head from "next/head";

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -119,8 +119,8 @@ function SummaryCards({ stats }: { stats: SummaryStats }) {
     stats.pass_rate >= 0.95
       ? "#2e7d32"
       : stats.pass_rate >= 0.8
-        ? "#ed6c02"
-        : "#d32f2f";
+      ? "#ed6c02"
+      : "#d32f2f";
 
   return (
     <Stack spacing={2}>
@@ -197,7 +197,11 @@ function JobChip({ job }: { job: CrcrJobRow }) {
     .join("\n");
 
   // Monsterization: show monster sprite for failures
-  if (monsterFailures && job.status === "completed" && job.conclusion === "failure") {
+  if (
+    monsterFailures &&
+    job.status === "completed" &&
+    job.conclusion === "failure"
+  ) {
     const syntheticJobData: JobData = {
       failureLines: [job.job_name + (job.conclusion || "")],
     } as JobData;
@@ -505,8 +509,7 @@ export default function CrcrBackendPage() {
   const page = parseInt(router.query.page as string) || 1;
   const days = parseInt(router.query.days as string) || 7;
 
-  const repoFullName =
-    org && repo ? `${org}/${repo}` : "";
+  const repoFullName = org && repo ? `${org}/${repo}` : "";
 
   const summaryUrl = repoFullName
     ? `/api/clickhouse/crcr_backend_summary?parameters=${encodeURIComponent(

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -1,8 +1,6 @@
 import {
   Box,
-  Checkbox,
   FormControl,
-  FormControlLabel,
   InputLabel,
   Link,
   MenuItem,
@@ -21,20 +19,14 @@ import {
   Typography,
 } from "@mui/material";
 import { durationDisplay } from "components/common/TimeUtils";
-import { JobStatus } from "components/job/GroupJobConclusion";
-import { getFailureEl } from "components/job/JobConclusion";
 import { getConclusionChar } from "lib/JobClassifierUtil";
-import { JobData } from "lib/types";
 import Head from "next/head";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
-import { createContext, useContext, useMemo, useState } from "react";
+import { useMemo } from "react";
 import useSWR from "swr";
 
 import { fetcher } from "lib/GeneralUtils";
-
-// Local monsterization context for this page
-const CrcrMonsterContext = createContext<boolean>(false);
 
 // ---- Types ----
 
@@ -185,7 +177,6 @@ const conclusionCssColor: Record<string, string> = {
 };
 
 function JobCell({ job }: { job: CrcrJobRow }) {
-  const monsterFailures = useContext(CrcrMonsterContext);
   const conclusion = job.status === "completed" ? job.conclusion : job.status;
   const char = getConclusionChar(conclusion);
   const color = conclusionCssColor[conclusion] ?? "var(--color-grey, #8b949e)";
@@ -206,32 +197,6 @@ function JobCell({ job }: { job: CrcrJobRow }) {
   ]
     .filter(Boolean)
     .join("\n");
-
-  // Monsterization: show monster sprite for failures
-  if (monsterFailures && conclusion === "failure") {
-    const syntheticJobData: JobData = {
-      failureLines: [job.job_name + (job.conclusion || "")],
-    } as JobData;
-    const monsterEl = getFailureEl(JobStatus.Failure, syntheticJobData);
-    if (monsterEl) {
-      return (
-        <Tooltip
-          title={
-            <span style={{ whiteSpace: "pre-line" }}>{tooltipContent}</span>
-          }
-        >
-          <a
-            href={job.workflow_run_url}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ display: "inline-block" }}
-          >
-            {monsterEl}
-          </a>
-        </Tooltip>
-      );
-    }
-  }
 
   return (
     <Tooltip
@@ -589,7 +554,6 @@ function CrcrMatrix({
 export default function CrcrBackendPage() {
   const router = useRouter();
   const { org, repo } = router.query;
-  const [monsterFailures, setMonsterFailures] = useState(false);
 
   const page = parseInt(router.query.page as string) || 1;
   const days = parseInt(router.query.days as string) || 7;
@@ -617,7 +581,7 @@ export default function CrcrBackendPage() {
   }
 
   return (
-    <CrcrMonsterContext.Provider value={monsterFailures}>
+    <>
       <Head>
         <title>{repoFullName} — CRCR CI | PyTorch HUD</title>
       </Head>
@@ -643,18 +607,6 @@ export default function CrcrBackendPage() {
             </Stack>
           </Stack>
           <Stack direction="row" spacing={2} alignItems="center">
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={monsterFailures}
-                  onChange={(e) => setMonsterFailures(e.target.checked)}
-                  size="small"
-                />
-              }
-              label={
-                <Typography variant="body2">Monsterize failures</Typography>
-              }
-            />
             <FormControl size="small" sx={{ minWidth: 140 }}>
               <InputLabel>Time Range</InputLabel>
               <Select
@@ -680,7 +632,7 @@ export default function CrcrBackendPage() {
 
         <Typography variant="body2" color="text.secondary">
           Rows = PyTorch PRs (50 per page), columns = downstream CI jobs. Click
-          a chip to open the workflow run.
+          a cell to open the workflow run.
         </Typography>
 
         <CrcrMatrix
@@ -690,6 +642,6 @@ export default function CrcrBackendPage() {
           onPageChange={(p) => updateQuery({ page: p })}
         />
       </Stack>
-    </CrcrMonsterContext.Provider>
+    </>
   );
 }

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -385,7 +385,9 @@ function useCommitInfo(
   );
   const url =
     upstreamRepo && dedupedShas.length > 0
-      ? `/api/crcr/commit-info?repo=${encodeURIComponent(upstreamRepo)}&shas=${encodeURIComponent(dedupedShas.join(","))}`
+      ? `/api/crcr/commit-info?repo=${encodeURIComponent(
+          upstreamRepo
+        )}&shas=${encodeURIComponent(dedupedShas.join(","))}`
       : null;
   const { data } = useSWR<CommitInfo[]>(url, fetcher, {
     revalidateOnFocus: false,
@@ -442,10 +444,7 @@ function CrcrMatrix({
   }, [data]);
 
   const upstreamRepo = matrix?.rows[0]?.upstreamRepo ?? "pytorch/pytorch";
-  const shas = useMemo(
-    () => (matrix?.rows ?? []).map((r) => r.sha),
-    [matrix]
-  );
+  const shas = useMemo(() => (matrix?.rows ?? []).map((r) => r.sha), [matrix]);
   const commitInfoMap = useCommitInfo(upstreamRepo, shas);
 
   if (error) {

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -367,6 +367,41 @@ function CrcrPagination({
   );
 }
 
+// ---- Commit Info Hook ----
+
+interface CommitInfo {
+  sha: string;
+  title: string;
+  author: string;
+}
+
+function useCommitInfo(
+  upstreamRepo: string,
+  shas: string[]
+): Map<string, CommitInfo> {
+  const dedupedShas = useMemo(
+    () => Array.from(new Set(shas)).slice(0, 50),
+    [shas]
+  );
+  const url =
+    upstreamRepo && dedupedShas.length > 0
+      ? `/api/crcr/commit-info?repo=${encodeURIComponent(upstreamRepo)}&shas=${encodeURIComponent(dedupedShas.join(","))}`
+      : null;
+  const { data } = useSWR<CommitInfo[]>(url, fetcher, {
+    revalidateOnFocus: false,
+  });
+
+  return useMemo(() => {
+    const map = new Map<string, CommitInfo>();
+    if (data) {
+      for (const ci of data) {
+        map.set(ci.sha, ci);
+      }
+    }
+    return map;
+  }, [data]);
+}
+
 // ---- PR Matrix Table ----
 
 function CrcrMatrix({
@@ -406,6 +441,13 @@ function CrcrMatrix({
     };
   }, [data]);
 
+  const upstreamRepo = matrix?.rows[0]?.upstreamRepo ?? "pytorch/pytorch";
+  const shas = useMemo(
+    () => (matrix?.rows ?? []).map((r) => r.sha),
+    [matrix]
+  );
+  const commitInfoMap = useCommitInfo(upstreamRepo, shas);
+
   if (error) {
     return (
       <Typography color="error">
@@ -443,7 +485,10 @@ function CrcrMatrix({
                 <strong>Time</strong>
               </TableCell>
               <TableCell>
-                <strong>SHA</strong>
+                <strong>Commit</strong>
+              </TableCell>
+              <TableCell>
+                <strong>Author</strong>
               </TableCell>
               <TableCell>
                 <strong>PR</strong>
@@ -456,48 +501,76 @@ function CrcrMatrix({
             </TableRow>
           </TableHead>
           <TableBody>
-            {matrix.rows.map((row) => (
-              <TableRow key={row.prNumber} hover>
-                <TableCell sx={{ whiteSpace: "nowrap" }}>
-                  <Tooltip title={new Date(row.latestTime).toLocaleString()}>
-                    <Typography variant="body2" color="text.secondary">
-                      {formatShortDate(row.latestTime)}
-                      <br />
-                      <small>{timeAgo(row.latestTime)}</small>
-                    </Typography>
-                  </Tooltip>
-                </TableCell>
-                <TableCell>
-                  <Link
-                    href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
-                    target="_blank"
-                    rel="noopener"
-                    underline="hover"
-                    sx={{ fontFamily: "monospace", fontSize: "0.85rem" }}
-                  >
-                    {row.sha.slice(0, 7)}
-                  </Link>
-                </TableCell>
-                <TableCell>
-                  <Link
-                    href={`https://github.com/${row.upstreamRepo}/pull/${row.prNumber}`}
-                    target="_blank"
-                    rel="noopener"
-                    underline="hover"
-                  >
-                    #{row.prNumber}
-                  </Link>
-                </TableCell>
-                {matrix.jobNames.map((name) => {
-                  const job = row.jobs.get(name);
-                  return (
-                    <TableCell key={name} align="center">
-                      {job ? <JobCell job={job} /> : "–"}
-                    </TableCell>
-                  );
-                })}
-              </TableRow>
-            ))}
+            {matrix.rows.map((row) => {
+              const ci = commitInfoMap.get(row.sha);
+              return (
+                <TableRow key={row.prNumber} hover>
+                  <TableCell sx={{ whiteSpace: "nowrap" }}>
+                    <Tooltip title={new Date(row.latestTime).toLocaleString()}>
+                      <Typography variant="body2" color="text.secondary">
+                        {formatShortDate(row.latestTime)}
+                        <br />
+                        <small>{timeAgo(row.latestTime)}</small>
+                      </Typography>
+                    </Tooltip>
+                  </TableCell>
+                  <TableCell sx={{ maxWidth: 300 }}>
+                    <Link
+                      href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
+                      target="_blank"
+                      rel="noopener"
+                      underline="hover"
+                      sx={{ fontSize: "0.85rem" }}
+                    >
+                      {ci?.title
+                        ? ci.title.length > 60
+                          ? ci.title.slice(0, 57) + "..."
+                          : ci.title
+                        : row.sha.slice(0, 7)}
+                    </Link>
+                  </TableCell>
+                  <TableCell>
+                    {ci?.author ? (
+                      <Link
+                        href={`https://github.com/${ci.author}`}
+                        target="_blank"
+                        rel="noopener"
+                        underline="hover"
+                        sx={{ fontSize: "0.85rem" }}
+                      >
+                        {ci.author}
+                      </Link>
+                    ) : (
+                      <Typography
+                        variant="body2"
+                        color="text.secondary"
+                        sx={{ fontSize: "0.85rem" }}
+                      >
+                        –
+                      </Typography>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Link
+                      href={`https://github.com/${row.upstreamRepo}/pull/${row.prNumber}`}
+                      target="_blank"
+                      rel="noopener"
+                      underline="hover"
+                    >
+                      #{row.prNumber}
+                    </Link>
+                  </TableCell>
+                  {matrix.jobNames.map((name) => {
+                    const job = row.jobs.get(name);
+                    return (
+                      <TableCell key={name} align="center">
+                        {job ? <JobCell job={job} /> : "–"}
+                      </TableCell>
+                    );
+                  })}
+                </TableRow>
+              );
+            })}
           </TableBody>
         </Table>
       </TableContainer>


### PR DESCRIPTION
## Summary

Enhances the per-downstream-repo CRCR dashboard page (`/crcr/<org>/<repo>`) with three features from #8254:

**Mockup**: [oot-hud-mockup-crcr-backend.html](https://subinz1.github.io/rfcs/RFC-0054-assets/oot-hud-mockup-crcr-backend.html)

### Feature 001 — Summary Stat Cards
Added stat cards at the top showing:
- **Pass Rate** (color-coded: green ≥95%, orange ≥80%, red <80%)
- **Total PRs** tested
- **Failures** (+ timed out count)
- **Avg Queue Time** (dispatch → start)
- **Avg Execution Time** (start → completion)
- **Flaky Jobs** (same job_name with both pass and fail across attempts)

Powered by a new `crcr_backend_summary` ClickHouse query.

### Feature 002 — Enhanced PR Table
Added columns:
- **Time** — relative timestamp ("2h ago") with full date tooltip
- **SHA** — clickable link to the commit on GitHub
- **PR** — direct link to the GitHub PR page

### Feature 003 — Monsterization
- Added "Monsterize failures" checkbox toggle
- Failed jobs render as pixel-art monster sprites (matching the main HUD behavior)
- Uses `getFailureEl` hash function with synthetic failure lines derived from job_name + conclusion

### Changes
- **New ClickHouse query**: `crcr_backend_summary` — aggregated stats per repo (pass rate, avg queue/exec time, total PRs, flaky jobs)
- **Updated page**: `pages/crcr/[org]/[repo].tsx` — stat cards, time column, SHA/PR links, monsterization

Closes #8254

## Test plan
- [ ] Verify summary stat cards display correctly with all metrics
- [ ] Verify Time column shows relative timestamps with tooltip
- [ ] Verify SHA links to correct GitHub commit
- [ ] Verify PR links to correct GitHub PR
- [ ] Verify "Monsterize failures" toggle renders monster sprites for failed jobs
- [ ] Verify flaky job detection (same job with pass + fail across attempts)
- [ ] Verify pagination still works correctly
- [ ] Verify time range selector updates both stats and table