### PR TITLE
Add test_build_wheels_linux_v2.yml: build torchvision via uv-based v2

### DIFF
--- a/.github/workflows/test_build_wheels_linux_v2.yml
+++ b/.github/workflows/test_build_wheels_linux_v2.yml
@@ -1,0 +1,55 @@
+name: Test Build Linux Wheels V2 (uv) - torchvision
+
+# Exercises build_wheels_linux_v2.yml (uv-based, no conda) by building
+# torchvision (pytorch/vision) — a compiled C++/CUDA extension, so it stress-
+# tests the uv-provisioned interpreter, the cmake/ninja toolchain, the torch
+# dependency install, wheel repair, and the smoke test end-to-end.
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/build_wheels_linux_v2.yml
+      - .github/workflows/test_build_wheels_linux_v2.yml
+      - .github/workflows/generate_binary_build_matrix.yml
+      - .github/workflows/_binary_upload.yml
+      - tools/scripts/generate_binary_build_matrix.py
+      - tools/pkg-helpers/pytorch_pkg_helpers/version.py
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  generate-matrix:
+    uses: ./.github/workflows/generate_binary_build_matrix.yml
+    with:
+      package-type: wheel
+      os: linux
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      with-xpu: enable
+  test:
+    needs: generate-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repository: pytorch/vision
+            pre-script: packaging/pre_build_script.sh
+            post-script: packaging/post_build_script.sh
+            smoke-test-script: test/smoke_test.py
+            package-name: torchvision
+    uses: ./.github/workflows/build_wheels_linux_v2.yml
+    name: ${{ matrix.repository }}
+    with:
+      repository: ${{ matrix.repository }}
+      ref: nightly
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      pre-script: ${{ matrix.pre-script }}
+      post-script: ${{ matrix.post-script }}
+      smoke-test-script: ${{ matrix.smoke-test-script }}
+      package-name: ${{ matrix.package-name }}
+      trigger-event: "${{ github.event_name }}"


### PR DESCRIPTION
## Summary

Adds `test_build_wheels_linux_v2.yml` — a CI test that builds **torchvision** (`pytorch/vision`) through the uv-based `build_wheels_linux_v2.yml` introduced in #8336.

## ⚠️ Depends on #8336
This test's `uses: ./.github/workflows/build_wheels_linux_v2.yml` won't resolve until #8336 (the v2 workflow) is on `main`, so **CI here is expected to be red until #8336 merges**. Kept as a clean, test-only diff intentionally — **merge #8336 first**, then this turns green.

## Why torchvision
torchvision is a compiled C++/CUDA extension (setup-py + `packaging/pre_build_script.sh`/`post_build_script.sh` + `test/smoke_test.py`), so it exercises the full uv path end-to-end: uv-provisioned interpreter, `cmake`/`ninja` toolchain, torch-dep install, manylinux repair, and smoke test. A pure-python package wouldn't.

## Notes
- Mirrors the existing `test_build_wheels_linux_with_cuda.yml` vision matrix (CUDA + ROCm + XPU + CPU) but builds vision only, targeting v2.
- If the manylinux builder images don't ship openssl/libpng/libwebp/pkg-config (previously conda-supplied), the vision build will surface it here — torchvision's `pre_build_script.sh` already installs several of its own system deps, so it's a good canary.
- Triggers on `workflow_dispatch` and PRs touching the v2 workflow / matrix / pkg-helpers.
