### PR TITLE
[CRCR] Exclude crcr-test from main HUD grid

### DIFF
--- a/torchci/clickhouse_queries/crcr_hud_results/query.sql
+++ b/torchci/clickhouse_queries/crcr_hud_results/query.sql
@@ -18,5 +18,6 @@ FROM
 WHERE
     pr_number IN {prNums: Array(Int64)}
     AND pr_number > 0
+    AND downstream_repo != 'pytorch/crcr-test'
 ORDER BY
     pr_number, downstream_repo, job_name


### PR DESCRIPTION
## Summary

`pytorch/crcr-test` is a health-check repo used to monitor CRCR infrastructure itself — it runs synthetic probe jobs, not real downstream CI. Its results should not appear on the main HUD grid alongside actual downstream repos like `TorchedHat/pytorch-redhat-ci`.

This PR adds a `downstream_repo != 'pytorch/crcr-test'` filter to the `crcr_hud_results` ClickHouse query so crcr-test jobs are excluded from the main HUD page.

crcr-test results remain visible on:
- The CRCR Summary page (`/crcr`)
- The per-repo dashboard (`/crcr/pytorch/crcr-test`)

## Test plan

- [ ] Verify `pytorch/crcr-test` columns no longer appear on `hud.pytorch.org/hud/pytorch/pytorch/main`
- [ ] Verify real downstream repos (e.g. `TorchedHat/pytorch-redhat-ci`) still appear
- [ ] Verify crcr-test data still shows on `/crcr` and `/crcr/pytorch/crcr-test`