### PR TITLE
[CRCR] Only show L3/L4 repos on main HUD grid

### DIFF
--- a/torchci/clickhouse_queries/crcr_hud_results/query.sql
+++ b/torchci/clickhouse_queries/crcr_hud_results/query.sql
@@ -18,6 +18,6 @@ FROM
 WHERE
     pr_number IN {prNums: Array(Int64)}
     AND pr_number > 0
-    AND downstream_repo != 'pytorch/crcr-test'
+    AND downstream_repo_level IN ('L3', 'L4')
 ORDER BY
     pr_number, downstream_repo, job_name


### PR DESCRIPTION
## Summary

The main HUD grid currently displays all CRCR repos regardless of their trust level. This means L2 repos like `pytorch/crcr-test` (a health-check-only repo) show up on the main page, which is not useful for PR authors.

This PR filters the `crcr_hud_results` ClickHouse query to only return L3 and L4 repos:

- **L4** (merge-gating) — always visible, survives "Hide non-viable-strict jobs" filter via existing `/\(L4\)/` regex
- **L3** (non-blocking check runs) — visible when "Hide non-viable-strict jobs" is unchecked, hidden when checked

L2 (observation) and L1 (webhook-only) repos remain accessible on the dedicated CRCR pages (`/crcr`, `/crcr/[org]/[repo]`).

## Test plan

- [ ] Verify L2 repos no longer appear as columns on `hud.pytorch.org/hud/pytorch/pytorch/main`
- [ ] Verify L3/L4 repos appear when data exists
- [ ] Verify "Hide non-viable-strict jobs" hides L3 but keeps L4
- [ ] Verify L2 repos still show on `/crcr` and `/crcr/[org]/[repo]`