### PR TITLE
Add "pull workflow duration per trunk commit" KPI to HUD

### DIFF
--- a/torchci/clickhouse_queries/pull_workflow_duration_per_commit/params.json
+++ b/torchci/clickhouse_queries/pull_workflow_duration_per_commit/params.json
@@ -1,0 +1,7 @@
+{
+  "params": {
+    "startTime": "DateTime64(3)",
+    "stopTime": "DateTime64(3)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/pull_workflow_duration_per_commit/query.sql
+++ b/torchci/clickhouse_queries/pull_workflow_duration_per_commit/query.sql
@@ -1,49 +1,72 @@
-WITH
-pull_workflow_durations AS (
-  SELECT
-    MAX(
-      DATE_DIFF(
-        'second',
-        w.created_at,
-        w.updated_at
-      )
-    ) / 60.0 AS duration_mins,
-    w.head_sha,
-    MIN(w.created_at) AS created_at
-  FROM
-    default.workflow_run w final
-  WHERE
-    lower(w.name) = 'pull'
-    AND w.head_branch = 'main'
-    AND w.created_at >= {startTime: DateTime64(3)}
-    AND w.created_at < {stopTime: DateTime64(3)}
-    AND w.head_repository.full_name = 'pytorch/pytorch'
-    AND w.id IN (
-      SELECT id
-      FROM materialized_views.workflow_run_by_created_at
-      WHERE created_at >= {startTime: DateTime64(3)}
-        AND created_at < {stopTime: DateTime64(3)}
-    )
-  GROUP BY
-    w.head_sha
+-- Powers the "pull workflow duration per trunk commit" KPI on https://hud.pytorch.org/kpis
+-- Per trunk (main) commit of pytorch/pytorch, three duration treatments of the `pull`
+-- workflow, each reported as weekly p50/p90 percentiles in HOURS:
+--   wall-clock : workflow_run updated_at - created_at            (queue + run time)
+--   longest_job: max(job completed_at - started_at)              (queue excluded)
+--   build_test : max(build-job run) + max(test-job run)          (queue excluded)
+WITH pull_runs AS (
+    SELECT
+        w.id AS run_id,
+        w.created_at AS created_at,
+        DATE_DIFF('second', w.created_at, w.updated_at) AS wallclock_sec
+    FROM
+        default.workflow_run w final
+    WHERE
+        lower(w.name) = 'pull'
+        AND w.head_branch = 'main'
+        AND w.head_repository.full_name = 'pytorch/pytorch'
+        AND w.run_attempt = 1
+        AND w.created_at >= {startTime: DateTime64(3)}
+        AND w.created_at < {stopTime: DateTime64(3)}
+        AND w.id IN (
+            SELECT id
+            FROM materialized_views.workflow_run_by_created_at
+            WHERE created_at >= {startTime: DateTime64(3)}
+                AND created_at < {stopTime: DateTime64(3)}
+        )
 ),
-percentiles AS (
-  SELECT
-    toStartOfWeek(d.created_at, 0) AS bucket,
-    quantileExact(0.5)(d.duration_mins) AS p50,
-    quantileExact(0.9)(d.duration_mins) AS p90
-  FROM
-    pull_workflow_durations d
-  GROUP BY
-    bucket
+per_run AS (
+    SELECT
+        any(r.created_at) AS created_at,
+        any(r.wallclock_sec) / 3600.0 AS wallclock_hours,
+        MAX(DATE_DIFF('second', j.started_at, j.completed_at)) / 3600.0 AS longest_job_hours,
+        (
+            MAX(IF(j.name LIKE '% / build%', DATE_DIFF('second', j.started_at, j.completed_at), 0))
+            + MAX(IF(j.name LIKE '% / test%', DATE_DIFF('second', j.started_at, j.completed_at), 0))
+        ) / 3600.0 AS build_test_hours
+    FROM
+        pull_runs r
+        INNER JOIN default.workflow_job j final ON j.run_id = r.run_id
+    WHERE
+        toUnixTimestamp(j.completed_at) != 0
+    GROUP BY
+        r.run_id
+),
+weekly AS (
+    SELECT
+        toStartOfWeek(created_at, 0) AS bucket,
+        quantileExact(0.5)(wallclock_hours) AS wallclock_p50,
+        quantileExact(0.9)(wallclock_hours) AS wallclock_p90,
+        quantileExact(0.5)(longest_job_hours) AS longest_job_p50,
+        quantileExact(0.9)(longest_job_hours) AS longest_job_p90,
+        quantileExact(0.5)(build_test_hours) AS build_test_p50,
+        quantileExact(0.9)(build_test_hours) AS build_test_p90
+    FROM
+        per_run
+    GROUP BY
+        bucket
 )
 SELECT
-  formatDateTime(p.bucket, '%Y-%m-%d') AS bucket,
-  p.p50,
-  p.p90
+    formatDateTime(bucket, '%Y-%m-%d') AS bucket,
+    wallclock_p50,
+    wallclock_p90,
+    longest_job_p50,
+    longest_job_p90,
+    build_test_p50,
+    build_test_p90
 FROM
-  percentiles p
+    weekly
 WHERE
-  p.bucket < CURRENT_TIMESTAMP() - INTERVAL 1 WEEK
+    bucket < CURRENT_TIMESTAMP() - INTERVAL 1 WEEK
 ORDER BY
-  bucket DESC
+    bucket DESC

--- a/torchci/clickhouse_queries/pull_workflow_duration_per_commit/query.sql
+++ b/torchci/clickhouse_queries/pull_workflow_duration_per_commit/query.sql
@@ -1,87 +1,59 @@
 -- Powers the "pull workflow duration per trunk commit" KPI on https://hud.pytorch.org/kpis
 -- Per trunk (main) commit of pytorch/pytorch, three duration treatments of the `pull`
 -- workflow, each reported as weekly p50/p90 percentiles in HOURS:
---   wall-clock : workflow_run updated_at - created_at                       (queue + run time)
---   longest_job: max(job completed_at - started_at)                         (queue excluded)
---   build_test : per-config critical path = build run + that config's       (queue excluded)
---                longest test run, maxed across configs. Build and its
---                tests are chained by the job-name prefix before ' / '.
-WITH pull_runs AS (
-    SELECT
-        w.id AS run_id,
-        w.created_at AS created_at,
-        DATE_DIFF('second', w.created_at, w.updated_at) AS wallclock_sec
-    FROM
-        default.workflow_run w final
-    WHERE
-        lower(w.name) = 'pull'
-        AND w.head_branch = 'main'
-        AND w.head_repository.full_name = 'pytorch/pytorch'
-        AND w.run_attempt = 1
-        AND w.created_at >= {startTime: DateTime64(3)}
-        AND w.created_at < {stopTime: DateTime64(3)}
-        AND w.id IN (
-            SELECT id
-            FROM materialized_views.workflow_run_by_created_at
-            WHERE created_at >= {startTime: DateTime64(3)}
-                AND created_at < {stopTime: DateTime64(3)}
-        )
-),
-per_run AS (
-    SELECT
-        r.run_id AS run_id,
-        any(r.created_at) AS created_at,
-        any(r.wallclock_sec) / 3600.0 AS wallclock_hours,
-        MAX(DATE_DIFF('second', j.started_at, j.completed_at)) / 3600.0 AS longest_job_hours
-    FROM
-        pull_runs r
-        INNER JOIN default.workflow_job j final ON j.run_id = r.run_id
-    WHERE
-        toUnixTimestamp(j.completed_at) != 0
-    GROUP BY
-        r.run_id
-),
-per_config AS (
+--   wall-clock : first job start -> last job completion (~ workflow_run created->updated; queue + run)
+--   longest_job: max(job completed_at - started_at)                                     (queue excluded)
+--   build_test : per-config critical path = build run + that config's longest test run, (queue excluded)
+--                maxed across configs. Build and its tests are chained by the job-name
+--                prefix before ' / '.
+--
+-- Reads default.workflow_job directly via its embedded workflow_name/head_branch/
+-- repository_full_name/workflow_created_at columns (no join to workflow_run), and avoids
+-- FINAL: every per-run aggregate is min/max/maxIf, which is duplicate-safe, and the
+-- completed_at != 0 filter drops in-progress duplicate rows. ~2x faster than the join+FINAL form.
+WITH per_config AS (
     -- Chain build -> its tests by the job-name prefix before ' / '.
     -- maxIf returns 0 when a config has no build (or no test), so build-only
     -- and test-only configs degrade gracefully to whichever side exists.
     SELECT
-        r.run_id AS run_id,
+        j.run_id AS run_id,
+        j.workflow_created_at AS wf_created,
         splitByString(' / ', j.name)[1] AS config,
         maxIf(DATE_DIFF('second', j.started_at, j.completed_at), j.name LIKE '% / build%')
-        + maxIf(DATE_DIFF('second', j.started_at, j.completed_at), j.name LIKE '% / test%') AS chain_sec
+        + maxIf(DATE_DIFF('second', j.started_at, j.completed_at), j.name LIKE '% / test%') AS chain_sec,
+        MAX(DATE_DIFF('second', j.started_at, j.completed_at)) AS max_job_sec,
+        MIN(j.started_at) AS min_started,
+        MAX(j.completed_at) AS max_completed
     FROM
-        pull_runs r
-        INNER JOIN default.workflow_job j final ON j.run_id = r.run_id
+        default.workflow_job j
     WHERE
-        toUnixTimestamp(j.completed_at) != 0
-        AND (j.name LIKE '% / build%' OR j.name LIKE '% / test%')
+        j.workflow_name = 'pull'
+        AND j.head_branch = 'main'
+        AND j.repository_full_name = 'pytorch/pytorch'
+        AND j.run_attempt = 1
+        AND j.workflow_created_at >= {startTime: DateTime64(3)}
+        AND j.workflow_created_at < {stopTime: DateTime64(3)}
+        AND toUnixTimestamp(j.completed_at) != 0
     GROUP BY
-        r.run_id,
+        j.run_id,
+        wf_created,
         config
 ),
-critical_path AS (
+per_run AS (
     SELECT
         run_id,
+        any(wf_created) AS wf_created,
+        DATE_DIFF('second', MIN(min_started), MAX(max_completed)) / 3600.0 AS wallclock_hours,
+        MAX(max_job_sec) / 3600.0 AS longest_job_hours,
         MAX(chain_sec) / 3600.0 AS build_test_hours
     FROM
         per_config
     GROUP BY
         run_id
 ),
-combined AS (
-    SELECT
-        pr.created_at AS created_at,
-        pr.wallclock_hours AS wallclock_hours,
-        pr.longest_job_hours AS longest_job_hours,
-        cp.build_test_hours AS build_test_hours
-    FROM
-        per_run pr
-        LEFT JOIN critical_path cp ON pr.run_id = cp.run_id
-),
 weekly AS (
     SELECT
-        toStartOfWeek(created_at, 0) AS bucket,
+        toStartOfWeek(wf_created, 0) AS bucket,
         quantileExact(0.5)(wallclock_hours) AS wallclock_p50,
         quantileExact(0.9)(wallclock_hours) AS wallclock_p90,
         quantileExact(0.5)(longest_job_hours) AS longest_job_p50,
@@ -89,7 +61,7 @@ weekly AS (
         quantileExact(0.5)(build_test_hours) AS build_test_p50,
         quantileExact(0.9)(build_test_hours) AS build_test_p90
     FROM
-        combined
+        per_run
     GROUP BY
         bucket
 )

--- a/torchci/clickhouse_queries/pull_workflow_duration_per_commit/query.sql
+++ b/torchci/clickhouse_queries/pull_workflow_duration_per_commit/query.sql
@@ -1,9 +1,11 @@
 -- Powers the "pull workflow duration per trunk commit" KPI on https://hud.pytorch.org/kpis
 -- Per trunk (main) commit of pytorch/pytorch, three duration treatments of the `pull`
 -- workflow, each reported as weekly p50/p90 percentiles in HOURS:
---   wall-clock : workflow_run updated_at - created_at            (queue + run time)
---   longest_job: max(job completed_at - started_at)              (queue excluded)
---   build_test : max(build-job run) + max(test-job run)          (queue excluded)
+--   wall-clock : workflow_run updated_at - created_at                       (queue + run time)
+--   longest_job: max(job completed_at - started_at)                         (queue excluded)
+--   build_test : per-config critical path = build run + that config's       (queue excluded)
+--                longest test run, maxed across configs. Build and its
+--                tests are chained by the job-name prefix before ' / '.
 WITH pull_runs AS (
     SELECT
         w.id AS run_id,
@@ -27,13 +29,10 @@ WITH pull_runs AS (
 ),
 per_run AS (
     SELECT
+        r.run_id AS run_id,
         any(r.created_at) AS created_at,
         any(r.wallclock_sec) / 3600.0 AS wallclock_hours,
-        MAX(DATE_DIFF('second', j.started_at, j.completed_at)) / 3600.0 AS longest_job_hours,
-        (
-            MAX(IF(j.name LIKE '% / build%', DATE_DIFF('second', j.started_at, j.completed_at), 0))
-            + MAX(IF(j.name LIKE '% / test%', DATE_DIFF('second', j.started_at, j.completed_at), 0))
-        ) / 3600.0 AS build_test_hours
+        MAX(DATE_DIFF('second', j.started_at, j.completed_at)) / 3600.0 AS longest_job_hours
     FROM
         pull_runs r
         INNER JOIN default.workflow_job j final ON j.run_id = r.run_id
@@ -41,6 +40,44 @@ per_run AS (
         toUnixTimestamp(j.completed_at) != 0
     GROUP BY
         r.run_id
+),
+per_config AS (
+    -- Chain build -> its tests by the job-name prefix before ' / '.
+    -- maxIf returns 0 when a config has no build (or no test), so build-only
+    -- and test-only configs degrade gracefully to whichever side exists.
+    SELECT
+        r.run_id AS run_id,
+        splitByString(' / ', j.name)[1] AS config,
+        maxIf(DATE_DIFF('second', j.started_at, j.completed_at), j.name LIKE '% / build%')
+        + maxIf(DATE_DIFF('second', j.started_at, j.completed_at), j.name LIKE '% / test%') AS chain_sec
+    FROM
+        pull_runs r
+        INNER JOIN default.workflow_job j final ON j.run_id = r.run_id
+    WHERE
+        toUnixTimestamp(j.completed_at) != 0
+        AND (j.name LIKE '% / build%' OR j.name LIKE '% / test%')
+    GROUP BY
+        r.run_id,
+        config
+),
+critical_path AS (
+    SELECT
+        run_id,
+        MAX(chain_sec) / 3600.0 AS build_test_hours
+    FROM
+        per_config
+    GROUP BY
+        run_id
+),
+combined AS (
+    SELECT
+        pr.created_at AS created_at,
+        pr.wallclock_hours AS wallclock_hours,
+        pr.longest_job_hours AS longest_job_hours,
+        cp.build_test_hours AS build_test_hours
+    FROM
+        per_run pr
+        LEFT JOIN critical_path cp ON pr.run_id = cp.run_id
 ),
 weekly AS (
     SELECT
@@ -52,7 +89,7 @@ weekly AS (
         quantileExact(0.5)(build_test_hours) AS build_test_p50,
         quantileExact(0.9)(build_test_hours) AS build_test_p90
     FROM
-        per_run
+        combined
     GROUP BY
         bucket
 )

--- a/torchci/clickhouse_queries/pull_workflow_duration_per_commit/query.sql
+++ b/torchci/clickhouse_queries/pull_workflow_duration_per_commit/query.sql
@@ -1,0 +1,49 @@
+WITH
+pull_workflow_durations AS (
+  SELECT
+    MAX(
+      DATE_DIFF(
+        'second',
+        w.created_at,
+        w.updated_at
+      )
+    ) / 60.0 AS duration_mins,
+    w.head_sha,
+    MIN(w.created_at) AS created_at
+  FROM
+    default.workflow_run w final
+  WHERE
+    lower(w.name) = 'pull'
+    AND w.head_branch = 'main'
+    AND w.created_at >= {startTime: DateTime64(3)}
+    AND w.created_at < {stopTime: DateTime64(3)}
+    AND w.head_repository.full_name = 'pytorch/pytorch'
+    AND w.id IN (
+      SELECT id
+      FROM materialized_views.workflow_run_by_created_at
+      WHERE created_at >= {startTime: DateTime64(3)}
+        AND created_at < {stopTime: DateTime64(3)}
+    )
+  GROUP BY
+    w.head_sha
+),
+percentiles AS (
+  SELECT
+    toStartOfWeek(d.created_at, 0) AS bucket,
+    quantileExact(0.5)(d.duration_mins) AS p50,
+    quantileExact(0.9)(d.duration_mins) AS p90
+  FROM
+    pull_workflow_durations d
+  GROUP BY
+    bucket
+)
+SELECT
+  formatDateTime(p.bucket, '%Y-%m-%d') AS bucket,
+  p.p50,
+  p.p90
+FROM
+  percentiles p
+WHERE
+  p.bucket < CURRENT_TIMESTAMP() - INTERVAL 1 WEEK
+ORDER BY
+  bucket DESC

--- a/torchci/clickhouse_queries/pull_workflow_duration_per_commit/query.sql
+++ b/torchci/clickhouse_queries/pull_workflow_duration_per_commit/query.sql
@@ -64,6 +64,11 @@ weekly AS (
         per_run
     GROUP BY
         bucket
+    -- Drop the latest partial week. Filter here (on the Date `bucket`) rather than
+    -- in the outer query, where `bucket` is re-aliased to a formatDateTime String and
+    -- `String < DateTime` throws NO_COMMON_TYPE (Code 386).
+    HAVING
+        bucket < CURRENT_TIMESTAMP() - INTERVAL 1 WEEK
 )
 SELECT
     formatDateTime(bucket, '%Y-%m-%d') AS bucket,
@@ -75,7 +80,5 @@ SELECT
     build_test_p90
 FROM
     weekly
-WHERE
-    bucket < CURRENT_TIMESTAMP() - INTERVAL 1 WEEK
 ORDER BY
     bucket DESC

--- a/torchci/clickhouse_queries/pull_workflow_duration_per_commit/query.sql
+++ b/torchci/clickhouse_queries/pull_workflow_duration_per_commit/query.sql
@@ -34,6 +34,9 @@ WITH per_config AS (
         AND j.workflow_created_at >= {startTime: DateTime64(3)}
         AND j.workflow_created_at < {stopTime: DateTime64(3)}
         AND toUnixTimestamp(j.completed_at) != 0
+        -- Drop data-quality artifacts: GitHub marks stuck jobs "completed" up to
+        -- 30 days later (~720h), which otherwise dominates the max/span aggregates.
+        AND DATE_DIFF('second', j.started_at, j.completed_at) < 86400
     GROUP BY
         j.run_id,
         wf_created,

--- a/torchci/clickhouse_queries/pull_workflow_duration_per_commit_detail/params.json
+++ b/torchci/clickhouse_queries/pull_workflow_duration_per_commit_detail/params.json
@@ -1,0 +1,7 @@
+{
+  "params": {
+    "startTime": "DateTime64(3)",
+    "stopTime": "DateTime64(3)"
+  },
+  "tests": []
+}

--- a/torchci/clickhouse_queries/pull_workflow_duration_per_commit_detail/query.sql
+++ b/torchci/clickhouse_queries/pull_workflow_duration_per_commit_detail/query.sql
@@ -87,7 +87,7 @@ scored AS (
         quantileExact(0.9)(build_test_hours) OVER w AS baseline_p90,
         -- How many commits are in the trailing window; used to suppress flags on
         -- the first rows of the range where the baseline is not yet meaningful.
-        count() OVER w AS baseline_n
+        count(build_test_hours) OVER w AS baseline_n
     FROM
         per_run
     WINDOW

--- a/torchci/clickhouse_queries/pull_workflow_duration_per_commit_detail/query.sql
+++ b/torchci/clickhouse_queries/pull_workflow_duration_per_commit_detail/query.sql
@@ -74,13 +74,20 @@ scored AS (
         longest_job_hours,
         build_test_hours,
         -- Worst conclusion among the critical config's longest build/test jobs.
+        -- Failure-equivalents (failure/timed_out/startup_failure) collapse to 'failure';
+        -- everything not explicitly cancelled/failed (incl. success and the empty
+        -- conclusion of a config missing a build or test side) is 'success'.
         multiIf(
-            crit_build_concl = 'failure' OR crit_test_concl = 'failure', 'failure',
+            crit_build_concl IN ('failure', 'timed_out', 'startup_failure')
+            OR crit_test_concl IN ('failure', 'timed_out', 'startup_failure'), 'failure',
             crit_build_concl = 'cancelled' OR crit_test_concl = 'cancelled', 'cancelled',
             'success'
         ) AS crit_conclusion,
         quantileExact(0.5)(build_test_hours) OVER w AS baseline_median,
-        quantileExact(0.9)(build_test_hours) OVER w AS baseline_p90
+        quantileExact(0.9)(build_test_hours) OVER w AS baseline_p90,
+        -- How many commits are in the trailing window; used to suppress flags on
+        -- the first rows of the range where the baseline is not yet meaningful.
+        count() OVER w AS baseline_n
     FROM
         per_run
     WINDOW
@@ -95,7 +102,8 @@ SELECT
     round(baseline_median, 3) AS baseline_median,
     crit_conclusion,
     (
-        baseline_median > 0
+        baseline_n >= 50
+        AND baseline_median > 0
         AND build_test_hours > 1.10 * baseline_median
         AND build_test_hours > baseline_p90
     ) AS flagged

--- a/torchci/clickhouse_queries/pull_workflow_duration_per_commit_detail/query.sql
+++ b/torchci/clickhouse_queries/pull_workflow_duration_per_commit_detail/query.sql
@@ -1,0 +1,79 @@
+-- Powers the per-commit drill-down on the "pull workflow duration per trunk commit"
+-- KPI at https://hud.pytorch.org/kpis. One row per trunk (main) commit's `pull`
+-- workflow run, with the three duration treatments (hours) and an anomaly flag.
+--   flagged = the build+test critical path is BOTH >10% over the trailing
+--             rolling-median baseline AND above the trailing p90 (a spread gate,
+--             so single-commit noise near the median is not flagged).
+-- Reads default.workflow_job directly (embedded workflow_* columns), no join to
+-- workflow_run and no FINAL: every per-run aggregate is min/max/maxIf (duplicate-safe)
+-- and completed_at != 0 drops in-progress duplicate rows. Duration definitions match
+-- the weekly pull_workflow_duration_per_commit query.
+WITH per_config AS (
+    SELECT
+        j.run_id AS run_id,
+        any(j.head_sha) AS head_sha,
+        j.workflow_created_at AS wf_created,
+        splitByString(' / ', j.name)[1] AS config,
+        maxIf(DATE_DIFF('second', j.started_at, j.completed_at), j.name LIKE '% / build%')
+        + maxIf(DATE_DIFF('second', j.started_at, j.completed_at), j.name LIKE '% / test%') AS chain_sec,
+        MAX(DATE_DIFF('second', j.started_at, j.completed_at)) AS max_job_sec,
+        MIN(j.started_at) AS min_started,
+        MAX(j.completed_at) AS max_completed
+    FROM
+        default.workflow_job j
+    WHERE
+        j.workflow_name = 'pull'
+        AND j.head_branch = 'main'
+        AND j.repository_full_name = 'pytorch/pytorch'
+        AND j.run_attempt = 1
+        AND j.workflow_created_at >= {startTime: DateTime64(3)}
+        AND j.workflow_created_at < {stopTime: DateTime64(3)}
+        AND toUnixTimestamp(j.completed_at) != 0
+    GROUP BY
+        j.run_id,
+        wf_created,
+        config
+),
+per_run AS (
+    SELECT
+        any(head_sha) AS sha,
+        any(wf_created) AS ts,
+        DATE_DIFF('second', MIN(min_started), MAX(max_completed)) / 3600.0 AS wallclock_hours,
+        MAX(max_job_sec) / 3600.0 AS longest_job_hours,
+        MAX(chain_sec) / 3600.0 AS build_test_hours
+    FROM
+        per_config
+    GROUP BY
+        run_id
+),
+scored AS (
+    -- Trailing rolling baseline over the previous 200 commits (excludes the current row).
+    SELECT
+        ts,
+        sha,
+        wallclock_hours,
+        longest_job_hours,
+        build_test_hours,
+        quantileExact(0.5)(build_test_hours) OVER w AS baseline_median,
+        quantileExact(0.9)(build_test_hours) OVER w AS baseline_p90
+    FROM
+        per_run
+    WINDOW
+        w AS (ORDER BY ts ASC ROWS BETWEEN 200 PRECEDING AND 1 PRECEDING)
+)
+SELECT
+    formatDateTime(ts, '%Y-%m-%dT%H:%i:%S') AS ts,
+    sha,
+    round(wallclock_hours, 3) AS wallclock_hours,
+    round(longest_job_hours, 3) AS longest_job_hours,
+    round(build_test_hours, 3) AS build_test_hours,
+    round(baseline_median, 3) AS baseline_median,
+    (
+        baseline_median > 0
+        AND build_test_hours > 1.10 * baseline_median
+        AND build_test_hours > baseline_p90
+    ) AS flagged
+FROM
+    scored
+ORDER BY
+    ts ASC

--- a/torchci/clickhouse_queries/pull_workflow_duration_per_commit_detail/query.sql
+++ b/torchci/clickhouse_queries/pull_workflow_duration_per_commit_detail/query.sql
@@ -92,22 +92,46 @@ scored AS (
         per_run
     WINDOW
         w AS (ORDER BY ts ASC ROWS BETWEEN 200 PRECEDING AND 1 PRECEDING)
+),
+-- Commit title + trunk land time from default.push (bloom-filter indexed on
+-- head_commit.'id'), for cross-referencing flagged commits against what landed.
+commit_meta AS (
+    SELECT
+        p.head_commit.'id' AS sha,
+        splitByChar('\n', p.head_commit.'message')[1] AS commit_title,
+        p.head_commit.'timestamp' AS land_time
+    FROM default.push p
+    WHERE
+        p.repository.'full_name' = 'pytorch/pytorch'
+        AND p.ref IN ('refs/heads/main', 'refs/heads/master')
+        AND p.head_commit.'timestamp' >= {startTime: DateTime64(3)}
+        AND p.head_commit.'timestamp' < {stopTime: DateTime64(3)}
+    -- default.push is a ReplacingMergeTree read without FINAL, so a sha can have
+    -- un-merged duplicate rows; keep one per sha so the join can't fan out points.
+    LIMIT 1 BY sha
 )
 SELECT
-    formatDateTime(ts, '%Y-%m-%dT%H:%i:%S') AS ts,
-    sha,
-    round(wallclock_hours, 3) AS wallclock_hours,
-    round(longest_job_hours, 3) AS longest_job_hours,
-    round(build_test_hours, 3) AS build_test_hours,
-    round(baseline_median, 3) AS baseline_median,
-    crit_conclusion,
+    formatDateTime(s.ts, '%Y-%m-%dT%H:%i:%S') AS ts,
+    s.sha AS sha,
+    round(s.wallclock_hours, 3) AS wallclock_hours,
+    round(s.longest_job_hours, 3) AS longest_job_hours,
+    round(s.build_test_hours, 3) AS build_test_hours,
+    round(s.baseline_median, 3) AS baseline_median,
+    s.crit_conclusion AS crit_conclusion,
     (
-        baseline_n >= 50
-        AND baseline_median > 0
-        AND build_test_hours > 1.10 * baseline_median
-        AND build_test_hours > baseline_p90
-    ) AS flagged
+        s.baseline_n >= 50
+        AND s.baseline_median > 0
+        AND s.build_test_hours > 1.10 * s.baseline_median
+        AND s.build_test_hours > s.baseline_p90
+    ) AS flagged,
+    coalesce(m.commit_title, '') AS commit_title,
+    if(
+        toUnixTimestamp(m.land_time) = 0,
+        '',
+        formatDateTime(m.land_time, '%Y-%m-%dT%H:%i:%S')
+    ) AS land_time
 FROM
-    scored
+    scored s
+LEFT JOIN commit_meta m ON m.sha = s.sha
 ORDER BY
-    ts ASC
+    s.ts ASC

--- a/torchci/clickhouse_queries/pull_workflow_duration_per_commit_detail/query.sql
+++ b/torchci/clickhouse_queries/pull_workflow_duration_per_commit_detail/query.sql
@@ -29,6 +29,9 @@ WITH per_config AS (
         AND j.workflow_created_at >= {startTime: DateTime64(3)}
         AND j.workflow_created_at < {stopTime: DateTime64(3)}
         AND toUnixTimestamp(j.completed_at) != 0
+        -- Drop data-quality artifacts: GitHub marks stuck jobs "completed" up to
+        -- 30 days later (~720h), which otherwise dominates the max/span aggregates.
+        AND DATE_DIFF('second', j.started_at, j.completed_at) < 86400
     GROUP BY
         j.run_id,
         wf_created,

--- a/torchci/clickhouse_queries/pull_workflow_duration_per_commit_detail/query.sql
+++ b/torchci/clickhouse_queries/pull_workflow_duration_per_commit_detail/query.sql
@@ -18,7 +18,20 @@ WITH per_config AS (
         + maxIf(DATE_DIFF('second', j.started_at, j.completed_at), j.name LIKE '% / test%') AS chain_sec,
         MAX(DATE_DIFF('second', j.started_at, j.completed_at)) AS max_job_sec,
         MIN(j.started_at) AS min_started,
-        MAX(j.completed_at) AS max_completed
+        MAX(j.completed_at) AS max_completed,
+        -- Conclusion of the longest build job and longest test job in this config,
+        -- so we can surface whether a high build+test point was driven by a
+        -- cancelled/failed job rather than a clean-but-slow run.
+        argMaxIf(
+            j.conclusion,
+            DATE_DIFF('second', j.started_at, j.completed_at),
+            j.name LIKE '% / build%'
+        ) AS build_concl,
+        argMaxIf(
+            j.conclusion,
+            DATE_DIFF('second', j.started_at, j.completed_at),
+            j.name LIKE '% / test%'
+        ) AS test_concl
     FROM
         default.workflow_job j
     WHERE
@@ -43,7 +56,10 @@ per_run AS (
         any(wf_created) AS ts,
         DATE_DIFF('second', MIN(min_started), MAX(max_completed)) / 3600.0 AS wallclock_hours,
         MAX(max_job_sec) / 3600.0 AS longest_job_hours,
-        MAX(chain_sec) / 3600.0 AS build_test_hours
+        MAX(chain_sec) / 3600.0 AS build_test_hours,
+        -- Conclusions of the config on the critical path (the one setting build_test_hours).
+        argMax(build_concl, chain_sec) AS crit_build_concl,
+        argMax(test_concl, chain_sec) AS crit_test_concl
     FROM
         per_config
     GROUP BY
@@ -57,6 +73,12 @@ scored AS (
         wallclock_hours,
         longest_job_hours,
         build_test_hours,
+        -- Worst conclusion among the critical config's longest build/test jobs.
+        multiIf(
+            crit_build_concl = 'failure' OR crit_test_concl = 'failure', 'failure',
+            crit_build_concl = 'cancelled' OR crit_test_concl = 'cancelled', 'cancelled',
+            'success'
+        ) AS crit_conclusion,
         quantileExact(0.5)(build_test_hours) OVER w AS baseline_median,
         quantileExact(0.9)(build_test_hours) OVER w AS baseline_p90
     FROM
@@ -71,6 +93,7 @@ SELECT
     round(longest_job_hours, 3) AS longest_job_hours,
     round(build_test_hours, 3) AS build_test_hours,
     round(baseline_median, 3) AS baseline_median,
+    crit_conclusion,
     (
         baseline_median > 0
         AND build_test_hours > 1.10 * baseline_median

--- a/torchci/clickhouse_queries/pull_workflow_duration_per_commit_detail/query.sql
+++ b/torchci/clickhouse_queries/pull_workflow_duration_per_commit_detail/query.sql
@@ -1,9 +1,8 @@
 -- Powers the per-commit drill-down on the "pull workflow duration per trunk commit"
 -- KPI at https://hud.pytorch.org/kpis. One row per trunk (main) commit's `pull`
--- workflow run, with the three duration treatments (hours) and an anomaly flag.
---   flagged = the build+test critical path is BOTH >10% over the trailing
---             rolling-median baseline AND above the trailing p90 (a spread gate,
---             so single-commit noise near the median is not flagged).
+-- workflow run, with the three duration treatments (hours). The rolling-median
+-- baseline and anomaly flag are computed client-side (the panel) with a
+-- user-selectable window, so this query returns raw per-commit durations only.
 -- Reads default.workflow_job directly (embedded workflow_* columns), no join to
 -- workflow_run and no FINAL: every per-run aggregate is min/max/maxIf (duplicate-safe)
 -- and completed_at != 0 drops in-progress duplicate rows. Duration definitions match
@@ -14,8 +13,14 @@ WITH per_config AS (
         any(j.head_sha) AS head_sha,
         j.workflow_created_at AS wf_created,
         splitByString(' / ', j.name)[1] AS config,
-        maxIf(DATE_DIFF('second', j.started_at, j.completed_at), j.name LIKE '% / build%')
-        + maxIf(DATE_DIFF('second', j.started_at, j.completed_at), j.name LIKE '% / test%') AS chain_sec,
+        maxIf(
+            DATE_DIFF('second', j.started_at, j.completed_at),
+            j.name LIKE '% / build%'
+        )
+        + maxIf(
+            DATE_DIFF('second', j.started_at, j.completed_at),
+            j.name LIKE '% / test%'
+        ) AS chain_sec,
         MAX(DATE_DIFF('second', j.started_at, j.completed_at)) AS max_job_sec,
         MIN(j.started_at) AS min_started,
         MAX(j.completed_at) AS max_completed,
@@ -50,11 +55,13 @@ WITH per_config AS (
         wf_created,
         config
 ),
+
 per_run AS (
     SELECT
         any(head_sha) AS sha,
         any(wf_created) AS ts,
-        DATE_DIFF('second', MIN(min_started), MAX(max_completed)) / 3600.0 AS wallclock_hours,
+        DATE_DIFF('second', MIN(min_started), MAX(max_completed))
+        / 3600.0 AS wallclock_hours,
         MAX(max_job_sec) / 3600.0 AS longest_job_hours,
         MAX(chain_sec) / 3600.0 AS build_test_hours,
         -- Conclusions of the config on the critical path (the one setting build_test_hours).
@@ -65,8 +72,8 @@ per_run AS (
     GROUP BY
         run_id
 ),
+
 scored AS (
-    -- Trailing rolling baseline over the previous 200 commits (excludes the current row).
     SELECT
         ts,
         sha,
@@ -79,20 +86,16 @@ scored AS (
         -- conclusion of a config missing a build or test side) is 'success'.
         multiIf(
             crit_build_concl IN ('failure', 'timed_out', 'startup_failure')
-            OR crit_test_concl IN ('failure', 'timed_out', 'startup_failure'), 'failure',
-            crit_build_concl = 'cancelled' OR crit_test_concl = 'cancelled', 'cancelled',
+            OR crit_test_concl IN ('failure', 'timed_out', 'startup_failure'),
+            'failure',
+            crit_build_concl = 'cancelled' OR crit_test_concl = 'cancelled',
+            'cancelled',
             'success'
-        ) AS crit_conclusion,
-        quantileExact(0.5)(build_test_hours) OVER w AS baseline_median,
-        quantileExact(0.9)(build_test_hours) OVER w AS baseline_p90,
-        -- How many commits are in the trailing window; used to suppress flags on
-        -- the first rows of the range where the baseline is not yet meaningful.
-        count(build_test_hours) OVER w AS baseline_n
+        ) AS crit_conclusion
     FROM
         per_run
-    WINDOW
-        w AS (ORDER BY ts ASC ROWS BETWEEN 200 PRECEDING AND 1 PRECEDING)
 ),
+
 -- Commit title + trunk land time from default.push (bloom-filter indexed on
 -- head_commit.'id'), for cross-referencing flagged commits against what landed.
 commit_meta AS (
@@ -110,20 +113,14 @@ commit_meta AS (
     -- un-merged duplicate rows; keep one per sha so the join can't fan out points.
     LIMIT 1 BY sha
 )
+
 SELECT
     formatDateTime(s.ts, '%Y-%m-%dT%H:%i:%S') AS ts,
     s.sha AS sha,
     round(s.wallclock_hours, 3) AS wallclock_hours,
     round(s.longest_job_hours, 3) AS longest_job_hours,
     round(s.build_test_hours, 3) AS build_test_hours,
-    round(s.baseline_median, 3) AS baseline_median,
     s.crit_conclusion AS crit_conclusion,
-    (
-        s.baseline_n >= 50
-        AND s.baseline_median > 0
-        AND s.build_test_hours > 1.10 * s.baseline_median
-        AND s.build_test_hours > s.baseline_p90
-    ) AS flagged,
     coalesce(m.commit_title, '') AS commit_title,
     if(
         toUnixTimestamp(m.land_time) = 0,

--- a/torchci/components/metrics/panels/PullWorkflowCommitScatterPanel.tsx
+++ b/torchci/components/metrics/panels/PullWorkflowCommitScatterPanel.tsx
@@ -11,7 +11,7 @@ import {
 import ReactECharts from "echarts-for-react";
 import { useDarkMode } from "lib/DarkModeContext";
 import { useClickHouseAPIImmutable } from "lib/GeneralUtils";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 type CommitRow = {
   ts: string;
@@ -56,24 +56,116 @@ export default function PullWorkflowCommitScatterPanel({
       : null
   );
 
+  const flaggedRows = useMemo(
+    () => (data ? data.filter((r) => Number(r.flagged) === 1) : []),
+    [data]
+  );
+
+  // Bounds of the full dataset, used to convert dataZoom percentages -> time.
+  const [tMin, tMax] = useMemo(() => {
+    const rows = data ?? [];
+    return rows.length
+      ? [Date.parse(rows[0].ts), Date.parse(rows[rows.length - 1].ts)]
+      : [0, 0];
+  }, [data]);
+
+  // Keep the option reference stable across zoom-driven re-renders
+  // (visibleRange is deliberately NOT a dependency) so the chart stays
+  // uncontrolled after mount and user zoom is preserved.
+  const option = useMemo(() => {
+    const rows = data ?? [];
+
+    const toPoint = (r: CommitRow) => ({
+      value: [r.ts, r.build_test_hours],
+      sha: r.sha,
+      wallclock_hours: r.wallclock_hours,
+      longest_job_hours: r.longest_job_hours,
+      build_test_hours: r.build_test_hours,
+      baseline_median: r.baseline_median,
+    });
+
+    return {
+      title: { text: "pull workflow build+test per trunk commit" },
+      grid: { top: 72, right: 8, bottom: 72, left: 48 },
+      legend: {
+        top: 28,
+        data: [
+          "build+test (per commit)",
+          "flagged (>10% over baseline & > p90)",
+          "build+test baseline (rolling median)",
+        ],
+      },
+      xAxis: { type: "time" },
+      yAxis: { type: "value", name: "Hours" },
+      dataZoom: [
+        {
+          type: "inside",
+          ...(focusStart && focusStop
+            ? { startValue: focusStart, endValue: focusStop }
+            : {}),
+        },
+        {
+          type: "slider",
+          ...(focusStart && focusStop
+            ? { startValue: focusStart, endValue: focusStop }
+            : {}),
+        },
+      ],
+      tooltip: {
+        trigger: "item",
+        formatter: (params: any) => {
+          const d = params?.data;
+          if (d === undefined || d.sha === undefined) {
+            return "";
+          }
+          return (
+            `<b>${d.sha.substring(0, 7)}</b><br/>` +
+            `build+test: ${Number(d.build_test_hours).toFixed(2)} h<br/>` +
+            `longest job: ${Number(d.longest_job_hours).toFixed(2)} h<br/>` +
+            `wall-clock: ${Number(d.wallclock_hours).toFixed(2)} h<br/>` +
+            `baseline: ${Number(d.baseline_median).toFixed(2)} h<br/>` +
+            `<span style="color:${LINK_COLOR};font-weight:bold;">▸ click to open this commit on HUD</span>`
+          );
+        },
+      },
+      series: [
+        {
+          name: "build+test (per commit)",
+          type: "scatter",
+          large: true,
+          largeThreshold: 2000,
+          progressive: 4000,
+          symbolSize: 4,
+          itemStyle: { color: "#8891a0", opacity: 0.35 },
+          cursor: "pointer",
+          z: 2,
+          data: rows.map(toPoint),
+        },
+        {
+          name: "build+test baseline (rolling median)",
+          type: "line",
+          showSymbol: false,
+          lineStyle: { width: 1, opacity: 0.6 },
+          z: 3,
+          data: rows.map((r) => [r.ts, r.baseline_median]),
+        },
+        {
+          name: "flagged (>10% over baseline & > p90)",
+          type: "scatter",
+          symbol: "triangle",
+          symbolSize: 10,
+          itemStyle: { color: "#e4572e" },
+          cursor: "pointer",
+          z: 5,
+          data: flaggedRows.map(toPoint),
+        },
+      ],
+    };
+  }, [data, flaggedRows, darkMode, focusStart, focusStop]);
+
   if (data === undefined) {
     return <Skeleton variant="rectangular" height={chartHeight} />;
   }
-
-  const toPoint = (r: CommitRow) => ({
-    value: [r.ts, r.build_test_hours],
-    sha: r.sha,
-    wallclock_hours: r.wallclock_hours,
-    longest_job_hours: r.longest_job_hours,
-    build_test_hours: r.build_test_hours,
-    baseline_median: r.baseline_median,
-  });
-
-  const flaggedRows = data.filter((r) => Number(r.flagged) === 1);
-
-  // Bounds of the full dataset, used to convert dataZoom percentages -> time.
-  const tMin = data.length ? Date.parse(data[0].ts) : 0;
-  const tMax = data.length ? Date.parse(data[data.length - 1].ts) : 0;
 
   const onDataZoom = (evt: any) => {
     const z = evt?.batch?.[0] ?? evt;
@@ -97,84 +189,6 @@ export default function PullWorkflowCommitScatterPanel({
     return t >= visibleRange[0] && t <= visibleRange[1];
   };
 
-  const option = {
-    title: { text: "pull workflow build+test per trunk commit" },
-    grid: { top: 72, right: 8, bottom: 72, left: 48 },
-    legend: {
-      top: 28,
-      data: [
-        "build+test (per commit)",
-        "flagged (>10% over baseline & > p90)",
-        "build+test baseline (rolling median)",
-      ],
-    },
-    xAxis: { type: "time" },
-    yAxis: { type: "value", name: "Hours" },
-    dataZoom: [
-      {
-        type: "inside",
-        ...(focusStart && focusStop
-          ? { startValue: focusStart, endValue: focusStop }
-          : {}),
-      },
-      {
-        type: "slider",
-        ...(focusStart && focusStop
-          ? { startValue: focusStart, endValue: focusStop }
-          : {}),
-      },
-    ],
-    tooltip: {
-      trigger: "item",
-      formatter: (params: any) => {
-        const d = params?.data;
-        if (d === undefined || d.sha === undefined) {
-          return "";
-        }
-        return (
-          `<b>${d.sha.substring(0, 7)}</b><br/>` +
-          `build+test: ${Number(d.build_test_hours).toFixed(2)} h<br/>` +
-          `longest job: ${Number(d.longest_job_hours).toFixed(2)} h<br/>` +
-          `wall-clock: ${Number(d.wallclock_hours).toFixed(2)} h<br/>` +
-          `baseline: ${Number(d.baseline_median).toFixed(2)} h<br/>` +
-          `<span style="color:${LINK_COLOR};font-weight:bold;">▸ click to open this commit on HUD</span>`
-        );
-      },
-    },
-    series: [
-      {
-        name: "build+test (per commit)",
-        type: "scatter",
-        large: true,
-        largeThreshold: 2000,
-        progressive: 4000,
-        symbolSize: 4,
-        itemStyle: { color: "#8891a0", opacity: 0.35 },
-        cursor: "pointer",
-        z: 2,
-        data: data.map(toPoint),
-      },
-      {
-        name: "build+test baseline (rolling median)",
-        type: "line",
-        showSymbol: false,
-        lineStyle: { width: 1, opacity: 0.6 },
-        z: 3,
-        data: data.map((r) => [r.ts, r.baseline_median]),
-      },
-      {
-        name: "flagged (>10% over baseline & > p90)",
-        type: "scatter",
-        symbol: "triangle",
-        symbolSize: 10,
-        itemStyle: { color: "#e4572e" },
-        cursor: "pointer",
-        z: 5,
-        data: flaggedRows.map(toPoint),
-      },
-    ],
-  };
-
   // Table follows the zoomed section (newest first).
   const visibleFlagged = flaggedRows.filter(inVisibleRange);
   const flaggedNewestFirst = [...visibleFlagged].reverse();
@@ -188,6 +202,7 @@ export default function PullWorkflowCommitScatterPanel({
         option={option}
         style={{ height: chartHeight, width: "100%" }}
         notMerge={false}
+        shouldSetOption={(prev: any, cur: any) => prev.option !== cur.option}
         onEvents={{
           click: (p: any) => {
             const sha = p?.data?.sha;

--- a/torchci/components/metrics/panels/PullWorkflowCommitScatterPanel.tsx
+++ b/torchci/components/metrics/panels/PullWorkflowCommitScatterPanel.tsx
@@ -11,7 +11,7 @@ import {
 import ReactECharts from "echarts-for-react";
 import { useDarkMode } from "lib/DarkModeContext";
 import { useClickHouseAPIImmutable } from "lib/GeneralUtils";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 type CommitRow = {
   ts: string;
@@ -63,6 +63,15 @@ export default function PullWorkflowCommitScatterPanel({
       ? [Date.parse(focusStart), Date.parse(focusStop)]
       : null
   );
+  // router.query.focus is undefined until Next hydrates, so the useState seed
+  // above can miss it; re-sync the table window when the focus props arrive or
+  // change. Fires only on focus-prop changes, not on user zoom (which updates
+  // visibleRange directly), so it doesn't fight manual zooming.
+  useEffect(() => {
+    if (focusStart && focusStop) {
+      setVisibleRange([Date.parse(focusStart), Date.parse(focusStop)]);
+    }
+  }, [focusStart, focusStop]);
 
   const flaggedRows = useMemo(
     () => (data ? data.filter((r) => Number(r.flagged) === 1) : []),
@@ -273,7 +282,7 @@ export default function PullWorkflowCommitScatterPanel({
             </TableHead>
             <TableBody>
               {shownFlagged.map((r) => (
-                <TableRow key={r.sha}>
+                <TableRow key={`${r.sha}-${r.ts}`}>
                   <TableCell>{r.ts.substring(0, 10)}</TableCell>
                   <TableCell>
                     <a

--- a/torchci/components/metrics/panels/PullWorkflowCommitScatterPanel.tsx
+++ b/torchci/components/metrics/panels/PullWorkflowCommitScatterPanel.tsx
@@ -1,5 +1,9 @@
 import {
+  FormControl,
+  InputLabel,
+  MenuItem,
   Paper,
+  Select,
   Skeleton,
   Table,
   TableBody,
@@ -19,14 +23,17 @@ type CommitRow = {
   wallclock_hours: number;
   longest_job_hours: number;
   build_test_hours: number;
-  baseline_median: number;
-  flagged: number;
   crit_conclusion: "success" | "failure" | "cancelled";
   commit_title: string;
   land_time: string;
 };
 
+// Rolling baseline + anomaly flag, computed client-side over a user-selectable
+// trailing window (the query returns raw per-commit durations only).
+type EnrichedRow = CommitRow & { baseline_median: number; flagged: boolean };
+
 const MAX_FLAGGED_TABLE_ROWS = 50;
+const MEDIAN_WINDOW_OPTIONS = [10, 25, 50, 100, 200];
 const LINK_COLOR = "#4493f8";
 // A cancelled/failed metric-driving job inflates the build+test height, so
 // color those points differently from genuinely-slow successful commits.
@@ -55,6 +62,18 @@ function truncateTitle(title: string, maxLen: number = 80): string {
   return title.length > maxLen ? `${title.substring(0, maxLen)}…` : title;
 }
 
+// Exact quantile of an ascending-sorted array: the median (q=0.5) averages the
+// two middle elements on even counts; other q interpolate between neighbors.
+function quantileSorted(sorted: number[], q: number): number {
+  if (sorted.length === 0) {
+    return 0;
+  }
+  const pos = (sorted.length - 1) * q;
+  const lo = Math.floor(pos);
+  const hi = Math.ceil(pos);
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (pos - lo);
+}
+
 export default function PullWorkflowCommitScatterPanel({
   startTime,
   stopTime,
@@ -73,6 +92,9 @@ export default function PullWorkflowCommitScatterPanel({
     "pull_workflow_duration_per_commit_detail",
     { startTime, stopTime }
   );
+  // Trailing-window size (commits) for the rolling-median baseline; also drives
+  // which commits get flagged as anomalies.
+  const [medianWindow, setMedianWindow] = useState(200);
   // Time window currently visible on the x-axis (ms epoch). null = full range.
   // Seed it from the pre-zoom focus so the table matches the initial view.
   const [visibleRange, setVisibleRange] = useState<[number, number] | null>(
@@ -90,26 +112,59 @@ export default function PullWorkflowCommitScatterPanel({
     }
   }, [focusStart, focusStop]);
 
+  // Sole source of the baseline + anomaly flag (moved off ClickHouse so the
+  // window is configurable without a re-query). For each commit, the baseline
+  // is the exact median of the trailing `medianWindow` commits (excluding the
+  // commit itself); a commit is flagged when it is BOTH >10% over that median
+  // AND above the trailing p90 (a spread gate, so single-commit noise near the
+  // median is not flagged). The warm-up gate suppresses flags until the
+  // trailing window is meaningful: min(medianWindow, 50) commits, matching the
+  // old fixed gate of 50 at the 200 default. Naive O(n·window·log window) is
+  // fine at this data size, and the result is memoized.
+  const enriched: EnrichedRow[] = useMemo(() => {
+    const rows = data ?? [];
+    return rows.map((r, i) => {
+      const trailing = rows
+        .slice(Math.max(0, i - medianWindow), i)
+        .map((p) => p.build_test_hours)
+        .sort((a, b) => a - b);
+      const baseline_median = quantileSorted(trailing, 0.5);
+      const baseline_p90 = quantileSorted(trailing, 0.9);
+      const flagged =
+        trailing.length >= Math.min(medianWindow, 50) &&
+        baseline_median > 0 &&
+        r.build_test_hours > 1.1 * baseline_median &&
+        r.build_test_hours > baseline_p90;
+      return { ...r, baseline_median, flagged };
+    });
+  }, [data, medianWindow]);
+
   const flaggedRows = useMemo(
-    () => (data ? data.filter((r) => Number(r.flagged) === 1) : []),
-    [data]
+    () => enriched.filter((r) => r.flagged),
+    [enriched]
   );
 
   // Bounds of the full dataset, used to convert dataZoom percentages -> time.
   const [tMin, tMax] = useMemo(() => {
-    const rows = data ?? [];
-    return rows.length
-      ? [Date.parse(rows[0].ts), Date.parse(rows[rows.length - 1].ts)]
+    return enriched.length
+      ? [
+          Date.parse(enriched[0].ts),
+          Date.parse(enriched[enriched.length - 1].ts),
+        ]
       : [0, 0];
-  }, [data]);
+  }, [enriched]);
 
   // Keep the option reference stable across zoom-driven re-renders
   // (visibleRange is deliberately NOT a dependency) so the chart stays
   // uncontrolled after mount and user zoom is preserved.
   const option = useMemo(() => {
-    const rows = data ?? [];
+    const rows = enriched;
+    // Series name and legend entry must stay byte-identical or the legend toggle
+    // breaks. Keep it static (the active window shows in the dropdown) so
+    // changing the window doesn't reset the user's legend show/hide state.
+    const baselineName = "build+test baseline (rolling median)";
 
-    const toPoint = (r: CommitRow) => ({
+    const toPoint = (r: EnrichedRow) => ({
       value: [r.ts, r.build_test_hours],
       sha: r.sha,
       wallclock_hours: r.wallclock_hours,
@@ -131,7 +186,7 @@ export default function PullWorkflowCommitScatterPanel({
           "failure",
           "cancelled",
           "flagged (anomaly)",
-          "build+test baseline (rolling median)",
+          baselineName,
         ],
       },
       xAxis: { type: "time" },
@@ -201,13 +256,11 @@ export default function PullWorkflowCommitScatterPanel({
           cursor: "pointer",
           z: 2,
           data: rows
-            .filter(
-              (r) => Number(r.flagged) !== 1 && r.crit_conclusion === name
-            )
+            .filter((r) => !r.flagged && r.crit_conclusion === name)
             .map(toPoint),
         })),
         {
-          name: "build+test baseline (rolling median)",
+          name: baselineName,
           type: "line",
           showSymbol: false,
           lineStyle: { width: 1, opacity: 0.6 },
@@ -233,7 +286,7 @@ export default function PullWorkflowCommitScatterPanel({
         },
       ],
     };
-  }, [data, flaggedRows, darkMode, focusStart, focusStop]);
+  }, [enriched, medianWindow, flaggedRows, darkMode, focusStart, focusStop]);
 
   // Stable onEvents identity: echarts-for-react disposes + reinits the chart when
   // the onEvents prop changes by reference, so an inline object (fresh each render)
@@ -284,6 +337,23 @@ export default function PullWorkflowCommitScatterPanel({
 
   return (
     <Paper sx={{ p: 2 }} elevation={3}>
+      <FormControl size="small" sx={{ mb: 1, minWidth: 220 }}>
+        <InputLabel id="median-window-label">
+          Rolling median window (commits)
+        </InputLabel>
+        <Select
+          labelId="median-window-label"
+          value={medianWindow}
+          label="Rolling median window (commits)"
+          onChange={(e) => setMedianWindow(Number(e.target.value))}
+        >
+          {MEDIAN_WINDOW_OPTIONS.map((w) => (
+            <MenuItem key={w} value={w}>
+              {w}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
       <ReactECharts
         theme={darkMode ? "dark-hud" : undefined}
         option={option}

--- a/torchci/components/metrics/panels/PullWorkflowCommitScatterPanel.tsx
+++ b/torchci/components/metrics/panels/PullWorkflowCommitScatterPanel.tsx
@@ -11,6 +11,7 @@ import {
 import ReactECharts from "echarts-for-react";
 import { useDarkMode } from "lib/DarkModeContext";
 import { useClickHouseAPIImmutable } from "lib/GeneralUtils";
+import { useState } from "react";
 
 type CommitRow = {
   ts: string;
@@ -23,6 +24,7 @@ type CommitRow = {
 };
 
 const MAX_FLAGGED_TABLE_ROWS = 50;
+const LINK_COLOR = "#4493f8";
 
 function commitUrl(sha: string): string {
   return `https://hud.pytorch.org/pytorch/pytorch/commit/${sha}`;
@@ -33,20 +35,29 @@ export default function PullWorkflowCommitScatterPanel({
   stopTime,
   focusStart,
   focusStop,
+  chartHeight = 320,
 }: {
   startTime: string;
   stopTime: string;
   focusStart?: string;
   focusStop?: string;
+  chartHeight?: number;
 }) {
   const { darkMode } = useDarkMode();
   const { data } = useClickHouseAPIImmutable<CommitRow>(
     "pull_workflow_duration_per_commit_detail",
     { startTime, stopTime }
   );
+  // Time window currently visible on the x-axis (ms epoch). null = full range.
+  // Seed it from the pre-zoom focus so the table matches the initial view.
+  const [visibleRange, setVisibleRange] = useState<[number, number] | null>(
+    focusStart && focusStop
+      ? [Date.parse(focusStart), Date.parse(focusStop)]
+      : null
+  );
 
   if (data === undefined) {
-    return <Skeleton variant="rectangular" height="100%" />;
+    return <Skeleton variant="rectangular" height={chartHeight} />;
   }
 
   const toPoint = (r: CommitRow) => ({
@@ -59,6 +70,32 @@ export default function PullWorkflowCommitScatterPanel({
   });
 
   const flaggedRows = data.filter((r) => Number(r.flagged) === 1);
+
+  // Bounds of the full dataset, used to convert dataZoom percentages -> time.
+  const tMin = data.length ? Date.parse(data[0].ts) : 0;
+  const tMax = data.length ? Date.parse(data[data.length - 1].ts) : 0;
+
+  const onDataZoom = (evt: any) => {
+    const z = evt?.batch?.[0] ?? evt;
+    let s = z?.startValue;
+    let e = z?.endValue;
+    if (s === undefined || e === undefined) {
+      // Slider/inside zoom reports percentages; map them onto the data range.
+      const startPct = z?.start ?? 0;
+      const endPct = z?.end ?? 100;
+      s = tMin + ((tMax - tMin) * startPct) / 100;
+      e = tMin + ((tMax - tMin) * endPct) / 100;
+    }
+    setVisibleRange([Number(new Date(s)), Number(new Date(e))]);
+  };
+
+  const inVisibleRange = (r: CommitRow) => {
+    if (visibleRange === null) {
+      return true;
+    }
+    const t = Date.parse(r.ts);
+    return t >= visibleRange[0] && t <= visibleRange[1];
+  };
 
   const option = {
     title: { text: "pull workflow build+test per trunk commit" },
@@ -100,7 +137,7 @@ export default function PullWorkflowCommitScatterPanel({
           `longest job: ${Number(d.longest_job_hours).toFixed(2)} h<br/>` +
           `wall-clock: ${Number(d.wallclock_hours).toFixed(2)} h<br/>` +
           `baseline: ${Number(d.baseline_median).toFixed(2)} h<br/>` +
-          `<span style="font-size:11px;opacity:0.8;">click to open commit</span>`
+          `<span style="color:${LINK_COLOR};font-weight:bold;">▸ click to open this commit on HUD</span>`
         );
       },
     },
@@ -138,16 +175,19 @@ export default function PullWorkflowCommitScatterPanel({
     ],
   };
 
-  const flaggedNewestFirst = [...flaggedRows].reverse();
+  // Table follows the zoomed section (newest first).
+  const visibleFlagged = flaggedRows.filter(inVisibleRange);
+  const flaggedNewestFirst = [...visibleFlagged].reverse();
   const shownFlagged = flaggedNewestFirst.slice(0, MAX_FLAGGED_TABLE_ROWS);
   const hiddenFlaggedCount = flaggedNewestFirst.length - shownFlagged.length;
 
   return (
-    <Paper sx={{ p: 2, height: "100%" }} elevation={3}>
+    <Paper sx={{ p: 2 }} elevation={3}>
       <ReactECharts
         theme={darkMode ? "dark-hud" : undefined}
         option={option}
-        style={{ height: 320, width: "100%" }}
+        style={{ height: chartHeight, width: "100%" }}
+        notMerge={false}
         onEvents={{
           click: (p: any) => {
             const sha = p?.data?.sha;
@@ -155,11 +195,16 @@ export default function PullWorkflowCommitScatterPanel({
               window.open(commitUrl(sha), "_blank");
             }
           },
+          datazoom: onDataZoom,
         }}
       />
+      <Typography variant="subtitle2" sx={{ mt: 2 }}>
+        Flagged commits{visibleRange !== null ? " (current zoom window)" : ""}:{" "}
+        {flaggedNewestFirst.length}
+      </Typography>
       {flaggedNewestFirst.length === 0 ? (
         <Typography variant="body2" sx={{ mt: 1 }}>
-          No flagged commits in range.
+          No flagged commits in this range.
         </Typography>
       ) : (
         <>
@@ -178,7 +223,12 @@ export default function PullWorkflowCommitScatterPanel({
                 <TableRow key={r.sha}>
                   <TableCell>{r.ts.substring(0, 10)}</TableCell>
                   <TableCell>
-                    <a href={commitUrl(r.sha)} target="_blank" rel="noreferrer">
+                    <a
+                      href={commitUrl(r.sha)}
+                      target="_blank"
+                      rel="noreferrer"
+                      style={{ color: LINK_COLOR }}
+                    >
                       {r.sha.substring(0, 7)}
                     </a>
                   </TableCell>

--- a/torchci/components/metrics/panels/PullWorkflowCommitScatterPanel.tsx
+++ b/torchci/components/metrics/panels/PullWorkflowCommitScatterPanel.tsx
@@ -22,6 +22,8 @@ type CommitRow = {
   baseline_median: number;
   flagged: number;
   crit_conclusion: "success" | "failure" | "cancelled";
+  commit_title: string;
+  land_time: string;
 };
 
 const MAX_FLAGGED_TABLE_ROWS = 50;
@@ -36,6 +38,21 @@ const CONCLUSION_COLOR: Record<string, string> = {
 
 function commitUrl(sha: string): string {
   return `https://hud.pytorch.org/pytorch/pytorch/commit/${sha}`;
+}
+
+// Commit titles go into tooltip HTML verbatim and routinely contain <, >, & and
+// quotes (e.g. template args in C++ op names), so they must be escaped.
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function truncateTitle(title: string, maxLen: number = 80): string {
+  return title.length > maxLen ? `${title.substring(0, maxLen)}…` : title;
 }
 
 export default function PullWorkflowCommitScatterPanel({
@@ -100,6 +117,8 @@ export default function PullWorkflowCommitScatterPanel({
       build_test_hours: r.build_test_hours,
       baseline_median: r.baseline_median,
       crit_conclusion: r.crit_conclusion,
+      commit_title: r.commit_title,
+      land_time: r.land_time,
     });
 
     return {
@@ -145,13 +164,19 @@ export default function PullWorkflowCommitScatterPanel({
               : `<span style="color:${
                   CONCLUSION_COLOR[conclusion] ?? "#8891a0"
                 };font-weight:bold;">${conclusion}</span>`;
+          const titleHtml = d.commit_title
+            ? `${escapeHtml(truncateTitle(d.commit_title))}<br/>`
+            : "";
+          const landedHtml = d.land_time ? `landed: ${d.land_time}<br/>` : "";
           return (
             `<b>${d.sha.substring(0, 7)}</b><br/>` +
+            titleHtml +
             `build+test: ${Number(d.build_test_hours).toFixed(2)} h<br/>` +
             `longest job: ${Number(d.longest_job_hours).toFixed(2)} h<br/>` +
             `wall-clock: ${Number(d.wallclock_hours).toFixed(2)} h<br/>` +
             `baseline: ${Number(d.baseline_median).toFixed(2)} h<br/>` +
             `conclusion: ${conclusionHtml}<br/>` +
+            landedHtml +
             `<span style="color:${LINK_COLOR};font-weight:bold;">▸ click to open this commit on HUD</span>`
           );
         },
@@ -282,6 +307,7 @@ export default function PullWorkflowCommitScatterPanel({
               <TableRow>
                 <TableCell>Date</TableCell>
                 <TableCell>Commit</TableCell>
+                <TableCell>Title</TableCell>
                 <TableCell align="right">build+test (h)</TableCell>
                 <TableCell align="right">baseline (h)</TableCell>
                 <TableCell align="right">Δ% over baseline</TableCell>
@@ -300,6 +326,17 @@ export default function PullWorkflowCommitScatterPanel({
                     >
                       {r.sha.substring(0, 7)}
                     </a>
+                  </TableCell>
+                  <TableCell
+                    sx={{
+                      maxWidth: 360,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                    title={r.commit_title}
+                  >
+                    {r.commit_title}
                   </TableCell>
                   <TableCell align="right">
                     {Number(r.build_test_hours).toFixed(2)}

--- a/torchci/components/metrics/panels/PullWorkflowCommitScatterPanel.tsx
+++ b/torchci/components/metrics/panels/PullWorkflowCommitScatterPanel.tsx
@@ -210,23 +210,38 @@ export default function PullWorkflowCommitScatterPanel({
     };
   }, [data, flaggedRows, darkMode, focusStart, focusStop]);
 
+  // Stable onEvents identity: echarts-for-react disposes + reinits the chart when
+  // the onEvents prop changes by reference, so an inline object (fresh each render)
+  // would tear the chart down — and drop the zoom. Memoize it; only tMin/tMax are
+  // captured (setVisibleRange is stable).
+  const onEvents = useMemo(
+    () => ({
+      click: (p: any) => {
+        const sha = p?.data?.sha;
+        if (sha) {
+          window.open(commitUrl(sha), "_blank");
+        }
+      },
+      datazoom: (evt: any) => {
+        const z = evt?.batch?.[0] ?? evt;
+        let s = z?.startValue;
+        let e = z?.endValue;
+        if (s === undefined || e === undefined) {
+          // Slider/inside zoom reports percentages; map them onto the data range.
+          const startPct = z?.start ?? 0;
+          const endPct = z?.end ?? 100;
+          s = tMin + ((tMax - tMin) * startPct) / 100;
+          e = tMin + ((tMax - tMin) * endPct) / 100;
+        }
+        setVisibleRange([Number(new Date(s)), Number(new Date(e))]);
+      },
+    }),
+    [tMin, tMax]
+  );
+
   if (data === undefined) {
     return <Skeleton variant="rectangular" height={chartHeight} />;
   }
-
-  const onDataZoom = (evt: any) => {
-    const z = evt?.batch?.[0] ?? evt;
-    let s = z?.startValue;
-    let e = z?.endValue;
-    if (s === undefined || e === undefined) {
-      // Slider/inside zoom reports percentages; map them onto the data range.
-      const startPct = z?.start ?? 0;
-      const endPct = z?.end ?? 100;
-      s = tMin + ((tMax - tMin) * startPct) / 100;
-      e = tMin + ((tMax - tMin) * endPct) / 100;
-    }
-    setVisibleRange([Number(new Date(s)), Number(new Date(e))]);
-  };
 
   const inVisibleRange = (r: CommitRow) => {
     if (visibleRange === null) {
@@ -250,15 +265,7 @@ export default function PullWorkflowCommitScatterPanel({
         style={{ height: chartHeight, width: "100%" }}
         notMerge={false}
         shouldSetOption={(prev: any, cur: any) => prev.option !== cur.option}
-        onEvents={{
-          click: (p: any) => {
-            const sha = p?.data?.sha;
-            if (sha) {
-              window.open(commitUrl(sha), "_blank");
-            }
-          },
-          datazoom: onDataZoom,
-        }}
+        onEvents={onEvents}
       />
       <Typography variant="subtitle2" sx={{ mt: 2 }}>
         Flagged commits{visibleRange !== null ? " (current zoom window)" : ""}:{" "}

--- a/torchci/components/metrics/panels/PullWorkflowCommitScatterPanel.tsx
+++ b/torchci/components/metrics/panels/PullWorkflowCommitScatterPanel.tsx
@@ -1,0 +1,194 @@
+import {
+  Paper,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import ReactECharts from "echarts-for-react";
+import { useDarkMode } from "lib/DarkModeContext";
+import { useClickHouseAPIImmutable } from "lib/GeneralUtils";
+
+type CommitRow = {
+  ts: string;
+  sha: string;
+  wallclock_hours: number;
+  longest_job_hours: number;
+  build_test_hours: number;
+  baseline_median: number;
+  flagged: number;
+};
+
+const MAX_FLAGGED_TABLE_ROWS = 50;
+
+function commitUrl(sha: string): string {
+  return `https://hud.pytorch.org/pytorch/pytorch/commit/${sha}`;
+}
+
+export default function PullWorkflowCommitScatterPanel({
+  startTime,
+  stopTime,
+}: {
+  startTime: string;
+  stopTime: string;
+}) {
+  const { darkMode } = useDarkMode();
+  const { data } = useClickHouseAPIImmutable<CommitRow>(
+    "pull_workflow_duration_per_commit_detail",
+    { startTime, stopTime }
+  );
+
+  if (data === undefined) {
+    return <Skeleton variant="rectangular" height="100%" />;
+  }
+
+  const toPoint = (r: CommitRow) => ({
+    value: [r.ts, r.build_test_hours],
+    sha: r.sha,
+    wallclock_hours: r.wallclock_hours,
+    longest_job_hours: r.longest_job_hours,
+    build_test_hours: r.build_test_hours,
+    baseline_median: r.baseline_median,
+  });
+
+  const flaggedRows = data.filter((r) => Number(r.flagged) === 1);
+
+  const option = {
+    title: { text: "pull workflow build+test per trunk commit" },
+    grid: { top: 72, right: 8, bottom: 72, left: 48 },
+    legend: {
+      top: 28,
+      data: [
+        "build+test (per commit)",
+        "flagged (>10% over baseline & > p90)",
+        "build+test baseline (rolling median)",
+      ],
+    },
+    xAxis: { type: "time" },
+    yAxis: { type: "value", name: "Hours" },
+    dataZoom: [{ type: "inside" }, { type: "slider" }],
+    tooltip: {
+      trigger: "item",
+      formatter: (params: any) => {
+        const d = params?.data;
+        if (d === undefined || d.sha === undefined) {
+          return "";
+        }
+        return (
+          `<b>${d.sha.substring(0, 7)}</b><br/>` +
+          `build+test: ${Number(d.build_test_hours).toFixed(2)} h<br/>` +
+          `longest job: ${Number(d.longest_job_hours).toFixed(2)} h<br/>` +
+          `wall-clock: ${Number(d.wallclock_hours).toFixed(2)} h<br/>` +
+          `baseline: ${Number(d.baseline_median).toFixed(2)} h<br/>` +
+          `<span style="font-size:11px;opacity:0.8;">click to open commit</span>`
+        );
+      },
+    },
+    series: [
+      {
+        name: "build+test (per commit)",
+        type: "scatter",
+        large: true,
+        largeThreshold: 2000,
+        progressive: 4000,
+        symbolSize: 4,
+        itemStyle: { color: "#8891a0", opacity: 0.35 },
+        cursor: "pointer",
+        z: 2,
+        data: data.map(toPoint),
+      },
+      {
+        name: "build+test baseline (rolling median)",
+        type: "line",
+        showSymbol: false,
+        lineStyle: { width: 1, opacity: 0.6 },
+        z: 3,
+        data: data.map((r) => [r.ts, r.baseline_median]),
+      },
+      {
+        name: "flagged (>10% over baseline & > p90)",
+        type: "scatter",
+        symbol: "triangle",
+        symbolSize: 10,
+        itemStyle: { color: "#e4572e" },
+        cursor: "pointer",
+        z: 5,
+        data: flaggedRows.map(toPoint),
+      },
+    ],
+  };
+
+  const flaggedNewestFirst = [...flaggedRows].reverse();
+  const shownFlagged = flaggedNewestFirst.slice(0, MAX_FLAGGED_TABLE_ROWS);
+  const hiddenFlaggedCount = flaggedNewestFirst.length - shownFlagged.length;
+
+  return (
+    <Paper sx={{ p: 2, height: "100%" }} elevation={3}>
+      <ReactECharts
+        theme={darkMode ? "dark-hud" : undefined}
+        option={option}
+        style={{ height: 320, width: "100%" }}
+        onEvents={{
+          click: (p: any) => {
+            const sha = p?.data?.sha;
+            if (sha) {
+              window.open(commitUrl(sha), "_blank");
+            }
+          },
+        }}
+      />
+      {flaggedNewestFirst.length === 0 ? (
+        <Typography variant="body2" sx={{ mt: 1 }}>
+          No flagged commits in range.
+        </Typography>
+      ) : (
+        <>
+          <Table size="small" sx={{ mt: 1 }}>
+            <TableHead>
+              <TableRow>
+                <TableCell>Date</TableCell>
+                <TableCell>Commit</TableCell>
+                <TableCell align="right">build+test (h)</TableCell>
+                <TableCell align="right">baseline (h)</TableCell>
+                <TableCell align="right">Δ% over baseline</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {shownFlagged.map((r) => (
+                <TableRow key={r.sha}>
+                  <TableCell>{r.ts.substring(0, 10)}</TableCell>
+                  <TableCell>
+                    <a href={commitUrl(r.sha)} target="_blank" rel="noreferrer">
+                      {r.sha.substring(0, 7)}
+                    </a>
+                  </TableCell>
+                  <TableCell align="right">
+                    {Number(r.build_test_hours).toFixed(2)}
+                  </TableCell>
+                  <TableCell align="right">
+                    {Number(r.baseline_median).toFixed(2)}
+                  </TableCell>
+                  <TableCell align="right">
+                    {(
+                      (r.build_test_hours / r.baseline_median - 1) *
+                      100
+                    ).toFixed(0)}
+                    %
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+          {hiddenFlaggedCount > 0 && (
+            <Typography variant="body2" sx={{ mt: 1 }}>
+              +{hiddenFlaggedCount} more
+            </Typography>
+          )}
+        </>
+      )}
+    </Paper>
+  );
+}

--- a/torchci/components/metrics/panels/PullWorkflowCommitScatterPanel.tsx
+++ b/torchci/components/metrics/panels/PullWorkflowCommitScatterPanel.tsx
@@ -21,10 +21,18 @@ type CommitRow = {
   build_test_hours: number;
   baseline_median: number;
   flagged: number;
+  crit_conclusion: "success" | "failure" | "cancelled";
 };
 
 const MAX_FLAGGED_TABLE_ROWS = 50;
 const LINK_COLOR = "#4493f8";
+// A cancelled/failed metric-driving job inflates the build+test height, so
+// color those points differently from genuinely-slow successful commits.
+const CONCLUSION_COLOR: Record<string, string> = {
+  success: "#8891a0",
+  failure: "#d32f2f",
+  cancelled: "#f5a623",
+};
 
 function commitUrl(sha: string): string {
   return `https://hud.pytorch.org/pytorch/pytorch/commit/${sha}`;
@@ -82,6 +90,7 @@ export default function PullWorkflowCommitScatterPanel({
       longest_job_hours: r.longest_job_hours,
       build_test_hours: r.build_test_hours,
       baseline_median: r.baseline_median,
+      crit_conclusion: r.crit_conclusion,
     });
 
     return {
@@ -90,8 +99,10 @@ export default function PullWorkflowCommitScatterPanel({
       legend: {
         top: 28,
         data: [
-          "build+test (per commit)",
-          "flagged (>10% over baseline & > p90)",
+          "success",
+          "failure",
+          "cancelled",
+          "flagged (anomaly)",
           "build+test baseline (rolling median)",
         ],
       },
@@ -118,29 +129,49 @@ export default function PullWorkflowCommitScatterPanel({
           if (d === undefined || d.sha === undefined) {
             return "";
           }
+          const conclusion = d.crit_conclusion;
+          const conclusionHtml =
+            conclusion === "success"
+              ? `<span style="opacity:0.7;">${conclusion}</span>`
+              : `<span style="color:${
+                  CONCLUSION_COLOR[conclusion] ?? "#8891a0"
+                };font-weight:bold;">${conclusion}</span>`;
           return (
             `<b>${d.sha.substring(0, 7)}</b><br/>` +
             `build+test: ${Number(d.build_test_hours).toFixed(2)} h<br/>` +
             `longest job: ${Number(d.longest_job_hours).toFixed(2)} h<br/>` +
             `wall-clock: ${Number(d.wallclock_hours).toFixed(2)} h<br/>` +
             `baseline: ${Number(d.baseline_median).toFixed(2)} h<br/>` +
+            `conclusion: ${conclusionHtml}<br/>` +
             `<span style="color:${LINK_COLOR};font-weight:bold;">▸ click to open this commit on HUD</span>`
           );
         },
       },
       series: [
-        {
-          name: "build+test (per commit)",
+        // One large-mode series per conclusion for the non-flagged points:
+        // large mode ignores per-point colors, so color must be series-level.
+        ...(
+          [
+            { name: "success", opacity: 0.35 },
+            { name: "failure", opacity: 0.55 },
+            { name: "cancelled", opacity: 0.75 },
+          ] as const
+        ).map(({ name, opacity }) => ({
+          name,
           type: "scatter",
           large: true,
           largeThreshold: 2000,
           progressive: 4000,
           symbolSize: 4,
-          itemStyle: { color: "#8891a0", opacity: 0.35 },
+          itemStyle: { color: CONCLUSION_COLOR[name], opacity },
           cursor: "pointer",
           z: 2,
-          data: rows.map(toPoint),
-        },
+          data: rows
+            .filter(
+              (r) => Number(r.flagged) !== 1 && r.crit_conclusion === name
+            )
+            .map(toPoint),
+        })),
         {
           name: "build+test baseline (rolling median)",
           type: "line",
@@ -150,14 +181,21 @@ export default function PullWorkflowCommitScatterPanel({
           data: rows.map((r) => [r.ts, r.baseline_median]),
         },
         {
-          name: "flagged (>10% over baseline & > p90)",
+          // Small series, so per-point itemStyle works; no large mode here.
+          name: "flagged (anomaly)",
           type: "scatter",
           symbol: "triangle",
-          symbolSize: 10,
-          itemStyle: { color: "#e4572e" },
+          symbolSize: 11,
           cursor: "pointer",
           z: 5,
-          data: flaggedRows.map(toPoint),
+          data: flaggedRows.map((r) => ({
+            ...toPoint(r),
+            itemStyle: {
+              color: CONCLUSION_COLOR[r.crit_conclusion] ?? "#8891a0",
+              borderColor: darkMode ? "#eee" : "#333",
+              borderWidth: 1,
+            },
+          })),
         },
       ],
     };

--- a/torchci/components/metrics/panels/PullWorkflowCommitScatterPanel.tsx
+++ b/torchci/components/metrics/panels/PullWorkflowCommitScatterPanel.tsx
@@ -31,9 +31,13 @@ function commitUrl(sha: string): string {
 export default function PullWorkflowCommitScatterPanel({
   startTime,
   stopTime,
+  focusStart,
+  focusStop,
 }: {
   startTime: string;
   stopTime: string;
+  focusStart?: string;
+  focusStop?: string;
 }) {
   const { darkMode } = useDarkMode();
   const { data } = useClickHouseAPIImmutable<CommitRow>(
@@ -69,7 +73,20 @@ export default function PullWorkflowCommitScatterPanel({
     },
     xAxis: { type: "time" },
     yAxis: { type: "value", name: "Hours" },
-    dataZoom: [{ type: "inside" }, { type: "slider" }],
+    dataZoom: [
+      {
+        type: "inside",
+        ...(focusStart && focusStop
+          ? { startValue: focusStart, endValue: focusStop }
+          : {}),
+      },
+      {
+        type: "slider",
+        ...(focusStart && focusStop
+          ? { startValue: focusStart, endValue: focusStop }
+          : {}),
+      },
+    ],
     tooltip: {
       trigger: "item",
       formatter: (params: any) => {

--- a/torchci/components/metrics/panels/TimeSeriesPanel.tsx
+++ b/torchci/components/metrics/panels/TimeSeriesPanel.tsx
@@ -321,6 +321,7 @@ export default function TimeSeriesPanel({
   useUTC = false,
   // Whether to fill in missing data points with 0s
   fillMissingData = true,
+  onEvents,
 }: {
   title: string;
   queryName: string;
@@ -344,6 +345,7 @@ export default function TimeSeriesPanel({
   dataReader?: (_data: { [k: string]: any }[]) => { [k: string]: any }[];
   useUTC?: boolean;
   fillMissingData?: boolean;
+  onEvents?: { [key: string]: any };
 }) {
   // - Granularity
   // - Group by
@@ -447,6 +449,7 @@ export default function TimeSeriesPanel({
       additionalOptions={additionalOptions}
       legendPadding={legendPadding}
       useUTC={useUTC}
+      onEvents={onEvents}
     />
   );
 }

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -118,7 +118,19 @@ export default function Kpis() {
               .flat();
           }}
           additionalOptions={{
-            title: { link: "/kpis/pull_workflow_commits", target: "self" },
+            // Render the drill-down link as a distinct, link-styled subtitle
+            // (a plain linked title doesn't read as clickable).
+            title: {
+              subtext: "▸ open detailed per-commit chart",
+              sublink: "/kpis/pull_workflow_commits",
+              subtarget: "self",
+              subtextStyle: {
+                color: "#4493f8",
+                fontSize: 13,
+                fontWeight: "bold",
+              },
+            },
+            grid: { top: 82 },
             tooltip: {
               trigger: "item",
               formatter: (params: any) => {
@@ -139,7 +151,8 @@ export default function Kpis() {
                   `${hrs} h<br/>` +
                   `<span style="font-size:11px;opacity:0.8;">${
                     DESCRIPTIONS[metric] ?? ""
-                  }</span>`
+                  }</span>` +
+                  `<br/><span style="color:#4493f8;font-weight:bold;">▸ click to drill into this week's commits</span>`
                 );
               },
             },

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -85,30 +85,61 @@ export default function Kpis() {
 
       <Grid size={{ xs: 12, lg: 6 }} height={ROW_HEIGHT}>
         <TimeSeriesPanel
-          title={"pull workflow duration per trunk commit (Weekly, p50/p90)"}
+          title={"pull workflow duration per trunk commit (Weekly, hrs)"}
           queryName={"pull_workflow_duration_per_commit"}
           queryParams={{
             ...timeParams,
           }}
           granularity={"week"}
           timeFieldName={"bucket"}
-          yAxisFieldName={"duration_mins"}
-          yAxisRenderer={(duration) => duration}
-          groupByFieldName="percentile"
-          yAxisLabel={"Minutes"}
+          yAxisFieldName={"value_hours"}
+          yAxisLabel={"Hours"}
+          yAxisRenderer={(value) => Number(value).toFixed(2)}
+          groupByFieldName="series"
           dataReader={(data) => {
-            const percentiles = ["p50", "p90"];
+            const series = [
+              { key: "wallclock_p50", name: "wall-clock p50" },
+              { key: "wallclock_p90", name: "wall-clock p90" },
+              { key: "longest_job_p50", name: "longest job p50" },
+              { key: "longest_job_p90", name: "longest job p90" },
+              { key: "build_test_p50", name: "build+test p50" },
+              { key: "build_test_p90", name: "build+test p90" },
+            ];
             return data
               .map((d) =>
-                percentiles.map((p) => {
-                  return {
-                    ...d,
-                    percentile: p,
-                    duration_mins: d[p],
-                  };
-                })
+                series.map((s) => ({
+                  bucket: d.bucket,
+                  series: s.name,
+                  value_hours: d[s.key],
+                }))
               )
               .flat();
+          }}
+          additionalOptions={{
+            tooltip: {
+              trigger: "item",
+              formatter: (params: any) => {
+                const DESCRIPTIONS: { [key: string]: string } = {
+                  "wall-clock":
+                    "Total workflow wall-clock (workflow_run updated_at − created_at). Includes per-job queue/runner-wait time.",
+                  "longest job":
+                    "Longest single job's run time: max(completed_at − started_at). Queue excluded.",
+                  "build+test":
+                    "max(build-job run) + max(test-job run) across the run. Queue excluded; the two maxes may come from different configs, so this can exceed wall-clock.",
+                };
+                const name: string = params.seriesName ?? "";
+                const metric = name.replace(/ p(?:50|90)$/, "");
+                const hrs = Number(params.value[1]).toFixed(2);
+                return (
+                  `<b>${name}</b><br/>` +
+                  `${params.value[0]}<br/>` +
+                  `${hrs} h<br/>` +
+                  `<span style="font-size:11px;opacity:0.8;">${
+                    DESCRIPTIONS[metric] ?? ""
+                  }</span>`
+                );
+              },
+            },
           }}
         />
       </Grid>

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -121,7 +121,7 @@ export default function Kpis() {
               formatter: (params: any) => {
                 const DESCRIPTIONS: { [key: string]: string } = {
                   "wall-clock":
-                    "Total workflow wall-clock (workflow_run updated_at − created_at). Includes per-job queue/runner-wait time.",
+                    "Total workflow wall-clock: first job start → last job completion (≈ workflow_run created→updated). Includes per-job queue/runner-wait time.",
                   "longest job":
                     "Longest single job's run time: max(completed_at − started_at). Queue excluded.",
                   "build+test":

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -1,4 +1,5 @@
 import { Grid } from "@mui/material";
+import PullWorkflowCommitScatterPanel from "components/metrics/panels/PullWorkflowCommitScatterPanel";
 import TimeSeriesPanel from "components/metrics/panels/TimeSeriesPanel";
 import dayjs from "dayjs";
 import { useState } from "react";
@@ -141,6 +142,13 @@ export default function Kpis() {
               },
             },
           }}
+        />
+      </Grid>
+
+      <Grid size={{ xs: 12 }} height={520}>
+        <PullWorkflowCommitScatterPanel
+          startTime={timeParams.startTime}
+          stopTime={timeParams.stopTime}
         />
       </Grid>
 

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -1,12 +1,13 @@
 import { Grid } from "@mui/material";
-import PullWorkflowCommitScatterPanel from "components/metrics/panels/PullWorkflowCommitScatterPanel";
 import TimeSeriesPanel from "components/metrics/panels/TimeSeriesPanel";
 import dayjs from "dayjs";
+import { useRouter } from "next/router";
 import { useState } from "react";
 
 const ROW_HEIGHT = 240;
 
 export default function Kpis() {
+  const router = useRouter();
   // Looking at data from the past six months
   const [startTime, _setStartTime] = useState(dayjs().subtract(6, "month"));
   const [stopTime, _setStopTime] = useState(dayjs());
@@ -117,6 +118,7 @@ export default function Kpis() {
               .flat();
           }}
           additionalOptions={{
+            title: { link: "/kpis/pull_workflow_commits", target: "self" },
             tooltip: {
               trigger: "item",
               formatter: (params: any) => {
@@ -142,13 +144,18 @@ export default function Kpis() {
               },
             },
           }}
-        />
-      </Grid>
-
-      <Grid size={{ xs: 12 }} height={520}>
-        <PullWorkflowCommitScatterPanel
-          startTime={timeParams.startTime}
-          stopTime={timeParams.stopTime}
+          onEvents={{
+            click: (params: any) => {
+              const ts = params?.value?.[0];
+              if (ts) {
+                router.push(
+                  `/kpis/pull_workflow_commits?focus=${encodeURIComponent(
+                    String(ts)
+                  )}`
+                );
+              }
+            },
+          }}
         />
       </Grid>
 

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -85,6 +85,36 @@ export default function Kpis() {
 
       <Grid size={{ xs: 12, lg: 6 }} height={ROW_HEIGHT}>
         <TimeSeriesPanel
+          title={"pull workflow duration per trunk commit (Weekly, p50/p90)"}
+          queryName={"pull_workflow_duration_per_commit"}
+          queryParams={{
+            ...timeParams,
+          }}
+          granularity={"week"}
+          timeFieldName={"bucket"}
+          yAxisFieldName={"duration_mins"}
+          yAxisRenderer={(duration) => duration}
+          groupByFieldName="percentile"
+          yAxisLabel={"Minutes"}
+          dataReader={(data) => {
+            const percentiles = ["p50", "p90"];
+            return data
+              .map((d) =>
+                percentiles.map((p) => {
+                  return {
+                    ...d,
+                    percentile: p,
+                    duration_mins: d[p],
+                  };
+                })
+              )
+              .flat();
+          }}
+        />
+      </Grid>
+
+      <Grid size={{ xs: 12, lg: 6 }} height={ROW_HEIGHT}>
+        <TimeSeriesPanel
           title={"% of force merges (Weekly, 2 week rolling avg)"}
           queryName={"weekly_force_merge_stats"}
           queryParams={{

--- a/torchci/pages/kpis.tsx
+++ b/torchci/pages/kpis.tsx
@@ -125,7 +125,7 @@ export default function Kpis() {
                   "longest job":
                     "Longest single job's run time: max(completed_at − started_at). Queue excluded.",
                   "build+test":
-                    "max(build-job run) + max(test-job run) across the run. Queue excluded; the two maxes may come from different configs, so this can exceed wall-clock.",
+                    "Per-config critical path: for each build-config, build run + that config's longest test run, then max across configs (build→test chained by job-name prefix). Queue excluded.",
                 };
                 const name: string = params.seriesName ?? "";
                 const metric = name.replace(/ p(?:50|90)$/, "");

--- a/torchci/pages/kpis/pull_workflow_commits.tsx
+++ b/torchci/pages/kpis/pull_workflow_commits.tsx
@@ -31,12 +31,13 @@ export default function PullWorkflowCommitsPage() {
           <MuiLink>← back to KPIs</MuiLink>
         </NextLink>
       </Grid>
-      <Grid size={{ xs: 12 }} height={680}>
+      <Grid size={{ xs: 12 }}>
         <PullWorkflowCommitScatterPanel
           startTime={startTime}
           stopTime={stopTime}
           focusStart={focusStart}
           focusStop={focusStop}
+          chartHeight={640}
         />
       </Grid>
     </Grid>

--- a/torchci/pages/kpis/pull_workflow_commits.tsx
+++ b/torchci/pages/kpis/pull_workflow_commits.tsx
@@ -1,0 +1,44 @@
+import { Grid, Link as MuiLink, Typography } from "@mui/material";
+import PullWorkflowCommitScatterPanel from "components/metrics/panels/PullWorkflowCommitScatterPanel";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import NextLink from "next/link";
+import { useRouter } from "next/router";
+dayjs.extend(utc);
+
+const FMT = "YYYY-MM-DDTHH:mm:ss.SSS";
+
+export default function PullWorkflowCommitsPage() {
+  const router = useRouter();
+  const startTime = dayjs().subtract(6, "month").utc().format(FMT);
+  const stopTime = dayjs().utc().format(FMT);
+
+  // Optional pre-zoom: ?focus=<ISO ts> -> window of focus +/- 5 days.
+  const focus =
+    typeof router.query.focus === "string" ? router.query.focus : undefined;
+  const focusStart = focus
+    ? dayjs(focus).subtract(5, "day").format(FMT)
+    : undefined;
+  const focusStop = focus ? dayjs(focus).add(5, "day").format(FMT) : undefined;
+
+  return (
+    <Grid container spacing={2} sx={{ p: 2 }}>
+      <Grid size={{ xs: 12 }}>
+        <Typography variant="h5">
+          pull workflow duration — per trunk commit
+        </Typography>
+        <NextLink href="/kpis" passHref legacyBehavior>
+          <MuiLink>← back to KPIs</MuiLink>
+        </NextLink>
+      </Grid>
+      <Grid size={{ xs: 12 }} height={680}>
+        <PullWorkflowCommitScatterPanel
+          startTime={startTime}
+          stopTime={stopTime}
+          focusStart={focusStart}
+          focusStop={focusStop}
+        />
+      </Grid>
+    </Grid>
+  );
+}

--- a/torchci/pages/kpis/pull_workflow_commits.tsx
+++ b/torchci/pages/kpis/pull_workflow_commits.tsx
@@ -13,13 +13,14 @@ export default function PullWorkflowCommitsPage() {
   const startTime = dayjs().subtract(6, "month").utc().format(FMT);
   const stopTime = dayjs().utc().format(FMT);
 
-  // Optional pre-zoom: ?focus=<ISO ts> -> window of focus +/- 5 days.
+  // Optional pre-zoom: ?focus=<ISO ts>. The focus is a weekly bucket START, so
+  // frame that week (7 days) plus a day of context on each side.
   const focus =
     typeof router.query.focus === "string" ? router.query.focus : undefined;
   const focusStart = focus
-    ? dayjs(focus).subtract(5, "day").format(FMT)
+    ? dayjs(focus).subtract(1, "day").format(FMT)
     : undefined;
-  const focusStop = focus ? dayjs(focus).add(5, "day").format(FMT) : undefined;
+  const focusStop = focus ? dayjs(focus).add(8, "day").format(FMT) : undefined;
 
   return (
     <Grid container spacing={2} sx={{ p: 2 }}>


### PR DESCRIPTION
Closes #8347.

Adds pull-workflow-duration tracking per **trunk** (`main`) commit on `pytorch/pytorch` to https://hud.pytorch.org/kpis.

### 1. Weekly trend panel (on /kpis)
Time series, weekly **p50/p90** in **hours**, three treatments to separate queue from compute:

| Series | Per-commit metric | Queue? |
|---|---|---|
| **wall-clock** | first job start → last job completion (≈ `workflow_run` created→updated) | queue + run |
| **longest job** | `max(job.completed_at − started_at)` | run only |
| **build+test** | per-config critical path: build run + that config's longest test run, maxed across configs | run only |

Build→test chained by job-name prefix before ` / ` (validated on prod: 99.2% coverage, 1 build/config, tests always start after their build → orders correctly). Per-line tooltips. The panel **title links** to the per-commit page, and **clicking a data point** opens that page pre-zoomed to ±5 days around the point.

### 2. Per-commit drill-down (its own page, `/kpis/pull_workflow_commits`)
- Scatter of per-commit build+test + rolling-median baseline line + **flagged** commits as red triangles.
- `dataZoom`, per-point tooltip (sha + 3 durations + baseline), click-through to the HUD commit page, and a **flagged-commits table** (date, sha, build+test, baseline, Δ%).
- **Anomaly flag** = build+test >10% over the trailing 200-commit rolling median **AND** above the trailing p90 (spread gate; ~10.5% flagged over 6 months).

### 3. Data-quality guard
GitHub marks stuck jobs "completed" up to exactly 30 days later (~720h), which otherwise dominates the aggregates and wrecks the per-commit y-axis. Both queries drop job rows with `started→completed ≥ 24h` (~77 artifact jobs / 6 months; legit tail ≤13.6h). Max build+test drops 720h → ~11h.

### Implementation notes
- Queries read `default.workflow_job` directly (embedded `workflow_*` columns), no `workflow_run` join and no `FINAL` — per-run aggregates are min/max/maxIf (duplicate-safe) + `completed_at != 0`. ~2× faster than a join+FINAL form. All validated against prod ClickHouse.
- Files: `clickhouse_queries/pull_workflow_duration_per_commit{,_detail}/`, `components/metrics/panels/{TimeSeriesPanel,PullWorkflowCommitScatterPanel}.tsx`, `pages/kpis.tsx`, `pages/kpis/pull_workflow_commits.tsx`. Passes `tsc`, Prettier, ESLint, `lintrunner` (incl. SQLFluff).

---
_Authored with OpenAI Codex (weekly query/panel) and Claude Fable 5 (per-commit panel + page split) at the request of and reviewed by @izaitsevfb, who validated all queries against production ClickHouse. Disclosing per PyTorch's AI policy._