### PR TITLE
[CRCR] Exclude crcr-test from main HUD grid alongside L3/L4 filter

### DIFF
--- a/torchci/clickhouse_queries/crcr_hud_results/query.sql
+++ b/torchci/clickhouse_queries/crcr_hud_results/query.sql
@@ -19,5 +19,6 @@ WHERE
     pr_number IN {prNums: Array(Int64)}
     AND pr_number > 0
     AND downstream_repo_level IN ('L3', 'L4')
+    AND downstream_repo != 'pytorch/crcr-test'
 ORDER BY
     pr_number, downstream_repo, job_name


### PR DESCRIPTION
## Summary

Combines the two prior CRCR HUD-grid filters into the `crcr_hud_results` ClickHouse query so **both** apply:

- **Only L3/L4 repos** (`downstream_repo_level IN ('L3', 'L4')`) — from #8343
- **Exclude `pytorch/crcr-test`** (`downstream_repo != 'pytorch/crcr-test'`) — from #8340

#8343 (L3/L4-only) landed on the same line as #8340 (crcr-test exclusion) and effectively replaced it, so `crcr-test` is currently only excluded implicitly (because it is L2). This re-adds the explicit `downstream_repo != 'pytorch/crcr-test'` filter on top of the L3/L4 filter, so `pytorch/crcr-test` stays off the main HUD grid even if it is ever promoted to L3/L4 (it is a synthetic CRCR health-check repo, not real downstream CI).

crcr-test results remain visible on the dedicated CRCR pages (`/crcr`, `/crcr/pytorch/crcr-test`).

## Test plan

- [ ] `pytorch/crcr-test` columns do not appear on `hud.pytorch.org/hud/pytorch/pytorch/main`
- [ ] L3/L4 downstream repos (e.g. `TorchedHat/pytorch-redhat-ci`) still appear
- [ ] L1/L2 repos remain excluded from the main grid
- [ ] crcr-test data still shows on `/crcr` and `/crcr/pytorch/crcr-test`

Refs #8343, #8340.