### PR TITLE
[CRCR] Add event_type column to ClickHouse schema for nightly/periodic

### DIFF
--- a/clickhouse_db_schema/default.crcr_workflow_job/schema.sql
+++ b/clickhouse_db_schema/default.crcr_workflow_job/schema.sql
@@ -26,6 +26,7 @@ CREATE TABLE default.crcr_workflow_job
     `artifact_url` String DEFAULT '' COMMENT 'URL to downstream-hosted artifacts (logs, reports)',
     `environment` String DEFAULT '' COMMENT 'JSON: {"sdk": "<version>", "device": "<hardware>", ...}',
     `downstream_repo_level` String DEFAULT '' COMMENT 'Relay level at dispatch time: L2, L3, L4',
+    `event_type` String DEFAULT 'pull_request' COMMENT 'Dispatch event type: pull_request, nightly, periodic',
     `_inserted_at` DateTime MATERIALIZED now(),
     `repository_full_name` String ALIAS downstream_repo COMMENT 'Alias for consistency with workflow_job queries',
     `duration_seconds` Float64 ALIAS if(completed_at = toDateTime64(0, 9), 0, dateDiff(second, started_at, completed_at)),

--- a/torchci/clickhouse_queries/crcr_backend_dashboard/query.sql
+++ b/torchci/clickhouse_queries/crcr_backend_dashboard/query.sql
@@ -25,12 +25,14 @@ FROM
 WHERE
     downstream_repo = {repo: String}
     AND started_at > now() - INTERVAL {days: UInt64} DAY
+    AND pr_number > 0
     AND pr_number IN (
         SELECT pr_number
         FROM default.crcr_workflow_job FINAL
         WHERE
             downstream_repo = {repo: String}
             AND started_at > now() - INTERVAL {days: UInt64} DAY
+            AND pr_number > 0
         GROUP BY pr_number
         ORDER BY max(started_at) DESC
         LIMIT

--- a/torchci/clickhouse_queries/crcr_backend_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_backend_summary/query.sql
@@ -18,6 +18,7 @@ SELECT
                 downstream_repo = {repo: String}
                 AND started_at > now() - INTERVAL {days: UInt64} DAY
                 AND status = 'completed'
+                AND pr_number > 0
             GROUP BY pr_number, job_name
             HAVING
                 countIf(conclusion = 'success') > 0
@@ -30,3 +31,4 @@ WHERE
     downstream_repo = {repo: String}
     AND started_at > now() - INTERVAL {days: UInt64} DAY
     AND status = 'completed'
+    AND pr_number > 0

--- a/torchci/clickhouse_queries/crcr_pr_results/query.sql
+++ b/torchci/clickhouse_queries/crcr_pr_results/query.sql
@@ -17,6 +17,7 @@ FROM
     default.crcr_workflow_job FINAL
 WHERE
     pr_number = {pr: UInt64}
+    AND pr_number > 0
 ORDER BY
     downstream_repo, started_at DESC
 LIMIT 100

--- a/torchci/clickhouse_queries/crcr_success_rate/query.sql
+++ b/torchci/clickhouse_queries/crcr_success_rate/query.sql
@@ -11,6 +11,7 @@ FROM
 WHERE
     started_at > now() - INTERVAL {days: UInt64} DAY
     AND status = 'completed'
+    AND pr_number > 0
 GROUP BY
     day, repo
 ORDER BY

--- a/torchci/clickhouse_queries/crcr_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_summary/query.sql
@@ -13,6 +13,7 @@ FROM
 WHERE
     started_at > now() - INTERVAL {days: UInt64} DAY
     AND status = 'completed'
+    AND pr_number > 0
 GROUP BY
     repo
 ORDER BY

--- a/torchci/lib/crcr/crcrUtils.ts
+++ b/torchci/lib/crcr/crcrUtils.ts
@@ -79,6 +79,7 @@ export interface CrcrWorkflowJobRecord {
   failed_tests?: number;
   skipped_tests?: number;
   downstream_repo_level?: string;
+  event_type?: string;
   artifact_url?: string;
   environment?: string;
 }
@@ -131,6 +132,10 @@ export function extractDynamoRecord(
 
   if (trusted.downstream_repo_level) {
     record.downstream_repo_level = trusted.downstream_repo_level;
+  }
+
+  if (cb.event_type) {
+    record.event_type = cb.event_type;
   }
 
   // Only set timing metrics when the relay provides a non-null value.

--- a/torchci/test/crcrUtils.test.ts
+++ b/torchci/test/crcrUtils.test.ts
@@ -82,6 +82,32 @@ describe("extractDynamoRecord", () => {
     expect(record.downstream_repo_level).toBeUndefined();
   });
 
+  test("sets event_type from callback payload", () => {
+    const record = extractDynamoRecord(makePayload());
+    expect(record.event_type).toBe("workflow_job");
+  });
+
+  test("sets event_type for nightly callback", () => {
+    const record = extractDynamoRecord(
+      makePayload({ callback: { event_type: "nightly" } })
+    );
+    expect(record.event_type).toBe("nightly");
+  });
+
+  test("sets event_type for periodic callback", () => {
+    const record = extractDynamoRecord(
+      makePayload({ callback: { event_type: "periodic" } })
+    );
+    expect(record.event_type).toBe("periodic");
+  });
+
+  test("omits event_type when empty", () => {
+    const record = extractDynamoRecord(
+      makePayload({ callback: { event_type: "" } })
+    );
+    expect(record.event_type).toBeUndefined();
+  });
+
   test("sets queue_time from ci_metrics when non-null", () => {
     const record = extractDynamoRecord(makePayload());
     expect(record.queue_time).toBe(12.5);


### PR DESCRIPTION
## Summary

Prepares the data layer for nightly and periodic CI support ([RFC 98](https://github.com/pytorch/rfcs/pull/98)).

The `crcr_workflow_job` ClickHouse table currently has no way to distinguish between PR-triggered, nightly, and periodic CI runs. This PR:

1. **Schema**: Adds `event_type String DEFAULT 'pull_request'` column to `crcr_workflow_job` — existing rows automatically get `'pull_request'` via the DEFAULT
2. **Write path**: Extracts `event_type` from the callback payload in `crcrUtils.ts` and persists it through DynamoDB to ClickHouse
3. **Queries**: Adds `pr_number > 0` filter to all PR-related queries (`crcr_summary`, `crcr_success_rate`, `crcr_backend_dashboard`, `crcr_backend_summary`, `crcr_pr_results`) to prevent nightly/periodic rows from polluting PR dashboards
4. **Tests**: Adds tests for `event_type` extraction (PR, nightly, periodic, empty)

### Deployment note

Run the following ALTER TABLE on ClickHouse before or after merge:

```sql
ALTER TABLE default.crcr_workflow_job
  ADD COLUMN IF NOT EXISTS event_type String
  DEFAULT 'pull_request'
  COMMENT 'Dispatch event type: pull_request, nightly, periodic'
  AFTER downstream_repo_level
```

### Data flow

```
Downstream CI → Relay Lambda → POST /api/crcr/results → DynamoDB → Replicator → ClickHouse
                                    ↑ event_type extracted here
```

### Nightly HUD design

The nightly results will be displayed on the CRCR summary page using a **Page-Level Tabs** design (PR | Nightly tabs at the top).

**Mockup**: https://subinz1.github.io/CRCR/mockups/crcr-summary-nightly-design.html

Fixes https://github.com/pytorch/crcr-test/issues/17

## Related PRs
- RFC 98: https://github.com/pytorch/rfcs/pull/98
- Nightly handler: https://github.com/pytorch/test-infra/pull/8302
- Callback action: https://github.com/pytorch/test-infra/pull/8303
- SHA validator: https://github.com/pytorch/test-infra/pull/8304

cc @atalman @jewelkm89