### PR TITLE
Fix Python 3.15 smoke tests on Windows and Linux

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -301,12 +301,7 @@ jobs:
           repository: ${{ inputs.repository  }}
           script: ${{ inputs.post-script }}
       - name: Smoke Test
-        # Skip the smoke test for Python 3.15 / 3.15t: the wheel builds fine, but
-        # the smoke test installs the wheel which pulls required runtime deps
-        # (e.g. pillow, a hard torchvision dependency) that have no cp315 wheels
-        # yet and fail to build from sdist. Re-enable once the ecosystem ships
-        # cp315 wheels.
-        if: ${{ inputs.run-smoke-test && ! startsWith(matrix.python_version, '3.15') }}
+        if: ${{ inputs.run-smoke-test }}
         shell: bash -l {0}
         env:
           PACKAGE_NAME: ${{ inputs.package-name }}
@@ -317,7 +312,15 @@ jobs:
           WHEEL_NAME=$(ls "${{ inputs.repository }}/dist/")
           echo "$WHEEL_NAME"
 
-          ${CONDA_RUN} pip install "${{ inputs.repository }}/dist/$WHEEL_NAME"
+          # numpy does not publish cp315 wheels on PyPI yet; they are available on
+          # download.pytorch.org as a pre-release. For 3.15 / 3.15t resolve runtime
+          # deps from there and allow pre-releases. Other versions use PyPI as before.
+          if [[ "${{ startsWith(matrix.python_version, '3.15') }}" == "true" ]]; then
+            ${CONDA_RUN} pip install --pre "${{ inputs.repository }}/dist/$WHEEL_NAME" \
+              --index-url "https://download.pytorch.org/whl/${CHANNEL}/${CU_VERSION}"
+          else
+            ${CONDA_RUN} pip install "${{ inputs.repository }}/dist/$WHEEL_NAME"
+          fi
           # Checking that we have a pinned version of torch in our dependency tree
           (
             pushd "${RUNNER_TEMP}"

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -362,7 +362,15 @@ jobs:
           source "${BUILD_ENV_FILE}"
           WHEEL_NAME=$(ls "${{ inputs.repository }}/dist/")
           echo "$WHEEL_NAME"
-          ${CONDA_RUN} pip install "${{ inputs.repository }}/dist/$WHEEL_NAME"
+          # numpy does not publish cp315 wheels on PyPI yet; they are available on
+          # download.pytorch.org as a pre-release. For 3.15 / 3.15t resolve runtime
+          # deps from there and allow pre-releases. Other versions use PyPI as before.
+          if [[ "${{ startsWith(matrix.python_version, '3.15') }}" == "true" ]]; then
+            ${CONDA_RUN} pip install --pre "${{ inputs.repository }}/dist/$WHEEL_NAME" \
+              --index-url "https://download.pytorch.org/whl/${CHANNEL}/${CU_VERSION}"
+          else
+            ${CONDA_RUN} pip install "${{ inputs.repository }}/dist/$WHEEL_NAME"
+          fi
           if [[ ! -f "${{ inputs.repository }}"/${SMOKE_TEST_SCRIPT} ]]; then
             echo "${{ inputs.repository }}/${SMOKE_TEST_SCRIPT} not found"
             ${CONDA_RUN} "${{ inputs.repository }}/${ENV_SCRIPT}" python -c "import ${PACKAGE_NAME}; print('package version is ', ${PACKAGE_NAME}.__version__)"
@@ -380,7 +388,14 @@ jobs:
           cd $SRC_DIR
           source .venv/Scripts/activate
           whl=$(find dist -name "${{env.PACKAGE_NAME}}-*.whl" | head -n 1)
-          pip install $whl
+          # See the X64 smoke test above: for 3.15 / 3.15t numpy ships only on
+          # download.pytorch.org, as a pre-release.
+          if [[ "${{ startsWith(matrix.python_version, '3.15') }}" == "true" ]]; then
+            pip install --pre "$whl" \
+              --index-url "https://download.pytorch.org/whl/${CHANNEL}/${CU_VERSION}"
+          else
+            pip install "$whl"
+          fi
 
           if [[ ! -f ${SMOKE_TEST_SCRIPT} ]]; then
             echo "${SMOKE_TEST_SCRIPT} not found"


### PR DESCRIPTION
`numpy` publishes no cp315 wheels on PyPI, so installing a freshly built wheel under 3.15 / 3.15t falls back to the numpy sdist and tries to build it from source. On Windows that build fails outright in the conda env:

```
..\meson.build:1:0: ERROR: Cython requires python3 dependency for link testing, but it could not be found
error: metadata-generation-failed
```

so `pip install <wheel>` aborts, the wheel is never installed, and the smoke test reports `ModuleNotFoundError: No module named 'torchvision'` — a symptom two steps removed from the cause.

cp315 wheels for **both numpy and pillow** are published on `download.pytorch.org` across `cpu / cu126 / cu128 / cu129 / cu130 / xpu`, so for 3.15 / 3.15t this resolves runtime deps from there with `--pre` (numpy is currently `2.6.0.dev0`). All other Python versions install from PyPI exactly as before.

### Changes

- **Windows** (`build_wheels_windows.yml`) — both the X64 and ARM64 smoke tests.
- **Linux** (`build_wheels_linux.yml`) — re-enables the 3.15 smoke test, which was skipped for exactly this reason, **and** applies the same dependency resolution. Re-enabling it without that would just relocate the failure, since numpy still has no cp315 wheels on PyPI.

`--index-url` (rather than `--extra-index-url`) replaces PyPI for that install, so every torchvision runtime dependency has to be present on the pytorch index. Verified for `torch`, `numpy` and `pillow` with cp315 `win_amd64`, `win_arm64` and `manylinux` builds across all of the indices listed above.

### Dropped from the earlier revision

The `generate_binary_build_matrix.py` and matrix-test changes are gone. #8427 has since enabled 3.15 / 3.15t by default for every OS and removed the opt-in `include_preview_python_versions` mechanism those hunks extended, so they are obsolete. The `[DO NOT MERGE]` PR-build override is also dropped.

### Follow-up

This fixes CI only. A user running `pip install torchvision` on Python 3.15 still cannot satisfy the numpy dependency from PyPI, so 3.15 remains effectively nightly-only until upstream numpy ships cp315 wheels.
