### PR TITLE
Enable Python 3.15 / 3.15t for macOS wheel builds

### DIFF
--- a/.github/actions/setup-binary-builds/action.yml
+++ b/.github/actions/setup-binary-builds/action.yml
@@ -138,6 +138,13 @@ runs:
           # untouched.
           if [[ "${RUNNER_OS}" != "macOS" ]]; then
             conda install -y conda=25.3.0
+          elif [[ "${PYTHON_VERSION}" == 3.15* ]]; then
+            # Newer macOS base conda 400s on the 3.15 label download; pin an older one.
+            conda install -y python=3.11
+            if [[ -n "$(conda list | grep conda-anaconda-telemetry)" ]]; then
+              conda uninstall -y conda-anaconda-telemetry conda-anaconda-tos
+            fi
+            conda install -y conda=24.7.1 conda-libmamba-solver=24.1.0
           fi
 
           # Pin openssl=3.5.6 by default: openssl 3.5.7 regressed ASN.1 parsing

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -448,15 +448,21 @@ def generate_wheels_matrix(
 ) -> List[Dict[str, str]]:
     package_type = "wheel"
 
+    explicitly_requested_versions = bool(python_versions)
+
     if not python_versions:
         # Define default python version
         python_versions = list(PYTHON_ARCHES)
 
         # Opt-in preview versions (e.g. 3.15/3.15t) are torch-only and validated
-        # on Linux x86 and aarch64 only. Append them to the default list so the
-        # shared default (used by domain libraries, Windows and macOS) is
+        # on Linux x86/aarch64 and macOS arm64. Append them to the default list
+        # so the shared default (used by domain libraries and Windows) is
         # unaffected.
-        if include_preview_python_versions and os in (LINUX, LINUX_AARCH64):
+        if include_preview_python_versions and os in (
+            LINUX,
+            LINUX_AARCH64,
+            MACOS_ARM64,
+        ):
             python_versions += PREVIEW_PYTHON_ARCHES_DICT.get(channel, [])
 
     if os == WINDOWS_ARM64:

--- a/tools/tests/test_generate_binary_build_matrix.py
+++ b/tools/tests/test_generate_binary_build_matrix.py
@@ -149,11 +149,11 @@ class GenerateBuildMatrixTest(TestCase):
         )
         return {entry["python_version"] for entry in out["include"]}
 
-    def test_preview_python_versions_opt_in_on_linux(self):
-        # 3.15 / 3.15t are validated on Linux x86 and aarch64 for the nightly and
-        # test channels when explicitly opted in.
+    def test_preview_python_versions_opt_in(self):
+        # 3.15 / 3.15t are validated on Linux x86/aarch64 and macOS arm64 for the
+        # nightly and test channels when explicitly opted in.
         for channel in ("nightly", "test"):
-            for operating_system in ("linux", "linux-aarch64"):
+            for operating_system in ("linux", "linux-aarch64", "macos-arm64"):
                 versions = self._test_channel_python_versions(
                     operating_system, include_preview="enable", channel=channel
                 )
@@ -167,14 +167,13 @@ class GenerateBuildMatrixTest(TestCase):
             self.assertNotIn("3.15", versions)
             self.assertNotIn("3.15t", versions)
 
-    def test_preview_python_versions_excluded_on_non_linux(self):
-        # Windows and macOS must not pick up the preview versions even when opted in.
-        for operating_system in ("windows", "macos"):
-            versions = self._test_channel_python_versions(
-                operating_system, include_preview="enable"
-            )
-            self.assertNotIn("3.15", versions)
-            self.assertNotIn("3.15t", versions)
+    def test_preview_python_versions_excluded_on_windows(self):
+        # Windows must not pick up the preview versions even when opted in.
+        versions = self._test_channel_python_versions(
+            "windows", include_preview="enable"
+        )
+        self.assertNotIn("3.15", versions)
+        self.assertNotIn("3.15t", versions)
 
     def test_preview_python_versions_excluded_on_release_channel(self):
         # Preview versions are defined for the nightly and test channels only,


### PR DESCRIPTION
Enables opt-in Python 3.15 / 3.15t for **macOS arm64** wheel builds, mirroring the Linux enablement in #8148.

- Extends the `INCLUDE_PREVIEW_PYTHON_VERSIONS` per-OS gate in `generate_binary_build_matrix.py` to include macOS arm64. 3.15/3.15t are intentionally left out of `MACOS_PYTHON_POINT_VERSIONS` so they flow to the shared conda case as `3.15`/`3.15t` and resolve to the pinned conda-forge beta.
- Skips the macOS smoke test for 3.15/3.15t (runtime deps lack cp315 wheels).
- Updates the matrix unit tests (macOS arm64 now opts in).
- Includes a temporary `[DO NOT MERGE]` commit forcing PR builds to 3.15/3.15t on macOS for CI validation; drop before merging.

**Depends on #8148** (the shared conda-forge 3.15 interpreter setup in `setup-binary-builds`); stacked on it, will shrink once #8148 lands.

Follow-up: wire `include-preview-python-versions: enable` into the macOS validate workflow for full nightly coverage.

Authored with assistance from Claude Code (AI assistant).